### PR TITLE
Fix AskUserQuestion schema for options array

### DIFF
--- a/src/tool_system/tools/ask_user_question.py
+++ b/src/tool_system/tools/ask_user_question.py
@@ -46,7 +46,19 @@ AskUserQuestionTool: Tool = build_tool(
                     "properties": {
                         "question": {"type": "string"},
                         "header": {"type": "string"},
-                        "options": {"type": "array"},
+                        "multiSelect": {"type": "boolean"},
+                        "options": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "label": {"type": "string"},
+                                    "description": {"type": "string"},
+                                    "preview": {"type": "string"},
+                                },
+                                "required": ["label"],
+                            },
+                        },
                     },
                     "required": ["question"],
                 },


### PR DESCRIPTION
## Summary
OpenAI (and compatible APIs) reject tool definitions when a JSON Schema array omits items. The AskUserQuestion tool declared options as `{ "type": "array" }` without items, which produced `400 invalid_function_parameters` with a message like "array schema missing items" under `tools[0].function.parameters`.

## Changes
- Define options as an array of objects with `label` (required) and `description` (optional), aligned with how the handler normalizes option objects.
- `options`: array of objects with `label` (required), `description` and optional `preview`
- `multiSelect`: optional boolean on each question (used by `src/repl/core.py` `_ask_user_questions`)

## Testing
- Run the Python CLI with tools enabled; the request should pass tool schema validation for `AskUserQuestion`.
- Original error message:
  - Assistant Query error: Error code: 400 - {'error': {'message': "Invalid schema for function 'AskUserQuestion': In context=('properties', 'questions', 'items', 'properties', 'options'), array schema missing items.", 'type': 'invalid_request_error', 'param': 'tools[0].function.parameters', 'code': 'invalid_function_parameters'}} Error code: 400 - {'error': {'message': "Invalid schema for function 'AskUserQuestion': In context=('properties', 'questions',   'items', 'properties', 'options'), array schema missing items.", 'type': 'invalid_request_error', 'param':                       'tools[0].function.parameters', 'code': 'invalid_function_parameters'}}

## Prompt to reproduce
The prompt used to reproduce the error was:

`Please generate a to-do app with the above requirements`

(Using the provided Task CLI requirements block.)