### PR TITLE
fix: Fixed DeepSeek thinking-mode replay failures and noisy prompts

### DIFF
--- a/src/providers/openai_compatible.py
+++ b/src/providers/openai_compatible.py
@@ -67,6 +67,11 @@ def _convert_anthropic_messages_to_openai(
                     "role": "assistant",
                     "tool_calls": tool_calls,
                 }
+                # DeepSeek thinking mode requires reasoning_content to be
+                # replayed together with assistant tool call messages.
+                reasoning_content = msg.get("reasoning_content")
+                if isinstance(reasoning_content, str) and reasoning_content:
+                    assistant_msg["reasoning_content"] = reasoning_content
                 text_content = "\n".join(text_parts) if text_parts else None
                 if text_content:
                     assistant_msg["content"] = text_content

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -270,6 +270,9 @@ async def _call_model_sync(
         content=assistant_blocks if assistant_blocks else "",
         stop_reason=stop_reason,
     )
+    if response.reasoning_content:
+        # Preserve provider thinking metadata for follow-up turns.
+        assistant_msg.reasoning_content = response.reasoning_content  # type: ignore[attr-defined]
 
     if stop_reason == "max_tokens":
         assistant_msg._api_error = "max_output_tokens"  # type: ignore[attr-defined]

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -354,6 +354,13 @@ class ClawcodexREPL:
         # reference's "type while it's still thinking" affordance.
         self._queued_prompts: list[str] = []
         self._queued_prompts_lock = threading.Lock()
+        # Permission dialogs can be requested from different worker paths
+        # (e.g. subagents/tools). Serialize interactive prompts so we never
+        # mount competing prompt_toolkit applications at once.
+        self._permission_prompt_lock = threading.Lock()
+        # Session-level cache for permission decisions (tool_name -> allow/deny)
+        # so identical prompts in loops don't repeatedly interrupt the user.
+        self._permission_decision_cache: dict[str, bool] = {}
 
         # The currently mounted ``LiveStatus`` (if any). ``_safe_input``
         # pauses it before reading a synchronous answer (e.g. permission
@@ -671,65 +678,76 @@ class ClawcodexREPL:
             Tuple of (allowed: bool, continue_without_caching: bool).
             continue_without_caching is always False since we don't cache in REPL.
         """
-        # Stop the Rich status spinner if running, so we can get clean input
-        if self._current_status is not None:
-            try:
-                self._current_status.stop()
-            except Exception:
-                pass
+        with self._permission_prompt_lock:
+            cache_key = tool_name.strip().lower()
+            cached = self._permission_decision_cache.get(cache_key)
+            if cached is not None:
+                return cached, False
 
-        self.console.print("")
-        self.console.print("[bold yellow]⚠ Permission Required[/bold yellow]")
-        self.console.print(f"  {message}")
-        self.console.print("")
+            # Stop the Rich status spinner if running, so we can get clean input
+            if self._current_status is not None:
+                try:
+                    self._current_status.stop()
+                except Exception:
+                    pass
 
-        # Determine if this is a setting that can be enabled
-        can_enable_setting = False
-        setting_to_enable: str | None = None
+            self.console.print("")
+            self.console.print("[bold yellow]⚠ Permission Required[/bold yellow]")
+            self.console.print(f"  {message}")
+            self.console.print("")
 
-        msg_lower = message.lower()
-        if "allow_docs" in msg_lower or "documentation files" in msg_lower:
-            if not self.tool_context.allow_docs:
-                can_enable_setting = True
-                setting_to_enable = "allow_docs"
+            # Determine if this is a setting that can be enabled
+            can_enable_setting = False
+            setting_to_enable: str | None = None
 
-        # Build options
-        options: list[tuple[str, str]] = [
-            ("y", "Yes, allow this action"),
-            ("n", "No, deny this action"),
-        ]
-        if can_enable_setting:
-            options.insert(0, ("e", f"Enable {setting_to_enable} and allow"))
+            msg_lower = message.lower()
+            if "allow_docs" in msg_lower or "documentation files" in msg_lower:
+                if not self.tool_context.allow_docs:
+                    can_enable_setting = True
+                    setting_to_enable = "allow_docs"
 
-        self.console.print("[bold]Options:[/bold]")
-        for i, (key, desc) in enumerate(options, start=1):
-            self.console.print(f"  {i}. [{key}] {desc}")
-        self.console.print("")
+            # Build options
+            options: list[tuple[str, str]] = [
+                ("y", "Yes, allow this action"),
+                ("n", "No, deny this action"),
+            ]
+            if can_enable_setting:
+                options.insert(0, ("e", f"Enable {setting_to_enable} and allow"))
 
-        # Get input via prompt_toolkit so it cooperates with patch_stdout()
-        # and the LiveStatus bottom region.
-        choice = self._safe_input("Select option> ").strip().lower()
+            self.console.print("[bold]Options:[/bold]")
+            for i, (key, desc) in enumerate(options, start=1):
+                self.console.print(f"  {i}. [{key}] {desc}")
+            self.console.print("")
 
-        # Parse choice based on the actual displayed options
-        if can_enable_setting:
-            # Menu: 1=Enable, 2=Yes, 3=No
-            if choice in ("1", "e", "enable"):
-                self._enable_permission_setting(setting_to_enable)
-                return True, False
-            elif choice in ("2", "y", "yes", ""):
-                return True, False
-            elif choice in ("3", "n", "no"):
-                return False, False
-        else:
-            # Menu: 1=Yes, 2=No
-            if choice in ("1", "y", "yes", ""):
-                return True, False
-            elif choice in ("2", "n", "no"):
-                return False, False
+            # Get input via prompt_toolkit so it cooperates with patch_stdout()
+            # and the LiveStatus bottom region.
+            choice = self._safe_input("Select option> ").strip().lower()
 
-        # Default to deny for invalid input
-        self.console.print("[dim]Invalid choice, defaulting to deny.[/dim]")
-        return False, False
+            # Parse choice based on the actual displayed options
+            if can_enable_setting:
+                # Menu: 1=Enable, 2=Yes, 3=No
+                if choice in ("1", "e", "enable"):
+                    self._enable_permission_setting(setting_to_enable)
+                    self._permission_decision_cache[cache_key] = True
+                    return True, False
+                elif choice in ("2", "y", "yes", ""):
+                    self._permission_decision_cache[cache_key] = True
+                    return True, False
+                elif choice in ("3", "n", "no"):
+                    self._permission_decision_cache[cache_key] = False
+                    return False, False
+            else:
+                # Menu: 1=Yes, 2=No
+                if choice in ("1", "y", "yes", ""):
+                    self._permission_decision_cache[cache_key] = True
+                    return True, False
+                elif choice in ("2", "n", "no"):
+                    self._permission_decision_cache[cache_key] = False
+                    return False, False
+
+            # Default to deny for invalid input
+            self.console.print("[dim]Invalid choice, defaulting to deny.[/dim]")
+            return False, False
 
     def _enable_permission_setting(self, setting_name: str | None) -> None:
         """Enable a permission setting in the tool context."""

--- a/src/tool_system/agent_loop.py
+++ b/src/tool_system/agent_loop.py
@@ -363,6 +363,10 @@ def run_agent_loop(
             conversation.add_assistant_message(final_assistant_content)
             # Add assistant message to OpenAI messages (text only)
             openai_assistant_msg: dict[str, Any] = {"role": "assistant", "content": final_assistant_content}
+            # DeepSeek/GLM thinking modes require reasoning_content to be replayed
+            # on subsequent turns when the assistant response included it.
+            if response.reasoning_content:
+                openai_assistant_msg["reasoning_content"] = response.reasoning_content
             # If there are tool_uses, add them in OpenAI format
             if response.tool_uses:
                 # Build OpenAI tool_calls

--- a/src/types/messages.py
+++ b/src/types/messages.py
@@ -344,7 +344,14 @@ def normalize_message_for_api(message: MessageLike) -> dict[str, Any] | None:
     else:
         normalized_content = str(content)
 
-    return {"role": api_role, "content": normalized_content}
+    result: dict[str, Any] = {"role": api_role, "content": normalized_content}
+    # DeepSeek/GLM thinking modes may require replaying assistant
+    # reasoning_content on follow-up turns.
+    if api_role == "assistant":
+        reasoning_content = _get_field(message, "reasoning_content", None)
+        if isinstance(reasoning_content, str) and reasoning_content:
+            result["reasoning_content"] = reasoning_content
+    return result
 
 
 def ensure_tool_result_pairing(
@@ -407,6 +414,9 @@ def ensure_tool_result_pairing(
             final_content = [{"type": "text", "text": "[Tool use interrupted]"}]
 
         assistant_msg = {"role": "assistant", "content": final_content}
+        reasoning_content = msg.get("reasoning_content")
+        if isinstance(reasoning_content, str) and reasoning_content:
+            assistant_msg["reasoning_content"] = reasoning_content
         result.append(assistant_msg)
 
         tool_use_ids = list(seen_tool_use_ids)

--- a/tests/test_claude_code_tool_parity.py
+++ b/tests/test_claude_code_tool_parity.py
@@ -132,6 +132,49 @@ class TestClaudeCodeToolParity(unittest.TestCase):
         )
         self.assertEqual(self.ctx.todos, [])
 
+    def test_openai_messages_preserve_reasoning_content_across_tool_turns(self) -> None:
+        conversation = Conversation()
+        conversation.add_user_message("hi")
+
+        mock_provider = MagicMock()
+        mock_provider.__class__.__name__ = "DeepSeekProvider"
+        first = ChatResponse(
+            content="Let me check",
+            model="deepseek-v4-pro",
+            usage={"input_tokens": 1, "output_tokens": 1},
+            finish_reason="tool_calls",
+            reasoning_content="hidden chain of thought token stream",
+            tool_uses=[{"id": "toolu_1", "name": "SendUserMessage", "input": {"message": "working"}}],
+        )
+        second = ChatResponse(
+            content="done",
+            model="deepseek-v4-pro",
+            usage={"input_tokens": 1, "output_tokens": 1},
+            finish_reason="stop",
+            tool_uses=None,
+        )
+        mock_provider.chat.side_effect = [first, second]
+
+        out = run_agent_loop(
+            conversation=conversation,
+            provider=mock_provider,
+            tool_registry=self.registry,
+            tool_context=self.ctx,
+            verbose=False,
+        )
+        self.assertEqual(out.response_text, "done")
+        self.assertEqual(mock_provider.chat.call_count, 2)
+        second_call_messages = mock_provider.chat.call_args_list[1].args[0]
+        assistant_with_tool_call = next(
+            msg
+            for msg in second_call_messages
+            if msg.get("role") == "assistant" and msg.get("tool_calls")
+        )
+        self.assertEqual(
+            assistant_with_tool_call.get("reasoning_content"),
+            "hidden chain of thought token stream",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_message_normalization.py
+++ b/tests/test_message_normalization.py
@@ -94,6 +94,15 @@ class TestMessageNormalization(unittest.TestCase):
         self.assertEqual(normalized[0]["content"][0]["text"], "legacy")
         self.assertEqual(normalized[0]["content"][1]["name"], "Grep")
 
+    def test_preserves_assistant_reasoning_content(self):
+        assistant = AssistantMessage(content=[TextBlock(text="working")])
+        assistant.reasoning_content = "internal reasoning trace"  # type: ignore[attr-defined]
+
+        normalized = normalize_messages_for_api([assistant])
+
+        self.assertEqual(normalized[0]["role"], "assistant")
+        self.assertEqual(normalized[0]["reasoning_content"], "internal reasoning trace")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from src.providers import get_provider_class
 from src.providers.anthropic_provider import AnthropicProvider
 from src.providers.glm_provider import GLMProvider
+from src.providers.openai_compatible import _convert_anthropic_messages_to_openai
 from src.providers.openai_provider import OpenAIProvider
 from src.providers.base import ChatMessage, ChatResponse
 
@@ -188,6 +189,28 @@ class TestOpenAIProvider(unittest.TestCase):
         models = provider.get_available_models()
         self.assertIn("gpt-4", models)
         self.assertIn("gpt-4o", models)
+
+    def test_converter_preserves_reasoning_with_tool_calls(self):
+        messages = [
+            {
+                "role": "assistant",
+                "reasoning_content": "keep-me",
+                "content": [
+                    {"type": "text", "text": "Thinking..."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "TaskCreate",
+                        "input": {"title": "todo"},
+                    },
+                ],
+            }
+        ]
+        converted = _convert_anthropic_messages_to_openai(messages)
+        self.assertEqual(len(converted), 1)
+        self.assertEqual(converted[0]["role"], "assistant")
+        self.assertEqual(converted[0]["reasoning_content"], "keep-me")
+        self.assertTrue(converted[0]["tool_calls"])
 
     @patch("src.providers.openai_provider.OpenAI")
     def test_chat(self, mock_openai):

--- a/tests/test_query_loop.py
+++ b/tests/test_query_loop.py
@@ -129,6 +129,62 @@ class TestQueryLoopSingleTurn(unittest.TestCase):
         ]
         self.assertGreaterEqual(len(tool_results), 1)
 
+    def test_multi_turn_replays_reasoning_content_for_followup(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+
+        first = ChatResponse(
+            content="I'll handle this",
+            model="deepseek-v4-pro",
+            usage={"input_tokens": 10, "output_tokens": 20},
+            finish_reason="tool_use",
+            reasoning_content="thinking trace from provider",
+            tool_uses=[{
+                "id": "toolu_001",
+                "name": "Write",
+                "input": {
+                    "file_path": str(self.workspace / "reasoning.txt"),
+                    "content": "hello",
+                },
+            }],
+        )
+        second = ChatResponse(
+            content="Done",
+            model="deepseek-v4-pro",
+            usage={"input_tokens": 30, "output_tokens": 10},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+        provider.chat.side_effect = [first, second]
+
+        params = QueryParams(
+            messages=[UserMessage(content="Create file")],
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=10,
+        )
+
+        async def run():
+            async for _msg in query(params):
+                pass
+
+        _run(run())
+
+        self.assertEqual(provider.chat.call_count, 2)
+        second_call_messages = provider.chat.call_args_list[1].args[0]
+        assistant_with_tool_use = next(
+            msg for msg in second_call_messages
+            if msg.get("role") == "assistant" and isinstance(msg.get("content"), list)
+        )
+        self.assertEqual(
+            assistant_with_tool_use.get("reasoning_content"),
+            "thinking trace from provider",
+        )
+
     def test_max_turns_limit(self):
         provider = MagicMock()
         provider.chat_stream_response.side_effect = NotImplementedError()

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -7,6 +7,8 @@ from unittest.mock import Mock, patch, MagicMock
 from pathlib import Path
 import tempfile
 import json
+import threading
+import time
 from rich.markdown import Markdown
 
 from src.repl import ClawcodexREPL
@@ -428,6 +430,94 @@ class TestREPL(unittest.TestCase):
 
                         # Session should not change
                         self.assertEqual(repl.session, original_session)
+
+    def test_permission_prompt_is_serialized(self):
+        """Concurrent permission checks should not open overlapping prompts."""
+        with patch('src.repl.core.get_provider_config', return_value={
+            "api_key": "test_api_key_12345678",
+            "base_url": "https://open.bigmodel.cn/api/paas/v4",
+            "default_model": "glm-4.5",
+        }), patch('src.repl.core.PromptSession') as mock_prompt_session:
+            mock_prompt_session.return_value = Mock(prompt=Mock(return_value=""))
+            with patch('src.repl.core.Session.create'):
+                with patch('src.repl.core.get_provider_class') as mock_provider_class:
+                    mock_provider = Mock()
+                    mock_provider.model = "glm-4.5"
+                    mock_provider_class.return_value = mock_provider
+                    repl = ClawcodexREPL(provider_name="glm")
+                    repl.console.print = Mock()
+
+                    in_prompt = 0
+                    max_in_prompt = 0
+                    counter_lock = threading.Lock()
+
+                    def fake_input(_prompt: str) -> str:
+                        nonlocal in_prompt, max_in_prompt
+                        with counter_lock:
+                            in_prompt += 1
+                            if in_prompt > max_in_prompt:
+                                max_in_prompt = in_prompt
+                        time.sleep(0.03)
+                        with counter_lock:
+                            in_prompt -= 1
+                        return "1"
+
+                    repl._safe_input = fake_input  # type: ignore[assignment]
+
+                    t1 = threading.Thread(
+                        target=repl._handle_permission_request,
+                        args=("Grep", "Claude wants to use Grep. Allow?", None),
+                    )
+                    t2 = threading.Thread(
+                        target=repl._handle_permission_request,
+                        args=("Read", "Claude wants to use Read. Allow?", None),
+                    )
+                    t1.start()
+                    t2.start()
+                    t1.join()
+                    t2.join()
+
+                    self.assertEqual(max_in_prompt, 1)
+
+    def test_permission_prompt_cached_per_tool(self):
+        """After first decision, same tool should not prompt again."""
+        with patch('src.repl.core.get_provider_config', return_value={
+            "api_key": "test_api_key_12345678",
+            "base_url": "https://open.bigmodel.cn/api/paas/v4",
+            "default_model": "glm-4.5",
+        }), patch('src.repl.core.PromptSession') as mock_prompt_session:
+            mock_prompt_session.return_value = Mock(prompt=Mock(return_value=""))
+            with patch('src.repl.core.Session.create'):
+                with patch('src.repl.core.get_provider_class') as mock_provider_class:
+                    mock_provider = Mock()
+                    mock_provider.model = "glm-4.5"
+                    mock_provider_class.return_value = mock_provider
+                    repl = ClawcodexREPL(provider_name="glm")
+                    repl.console.print = Mock()
+
+                    prompt_calls = 0
+
+                    def fake_input(_prompt: str) -> str:
+                        nonlocal prompt_calls
+                        prompt_calls += 1
+                        return "1"
+
+                    repl._safe_input = fake_input  # type: ignore[assignment]
+
+                    first = repl._handle_permission_request(
+                        "Grep",
+                        "Claude wants to use Grep. Allow?",
+                        None,
+                    )
+                    second = repl._handle_permission_request(
+                        "Grep",
+                        "Claude wants to use Grep. Allow?",
+                        None,
+                    )
+
+                    self.assertEqual(first, (True, False))
+                    self.assertEqual(second, (True, False))
+                    self.assertEqual(prompt_calls, 1)
 
 
 class TestConversation(unittest.TestCase):


### PR DESCRIPTION
Fixed DeepSeek thinking-mode replay failures and noisy permission prompts. reasoning_content is now preserved across both agent-loop and QueryEngine/tool-call paths, including OpenAI-compatible message conversion, preventing DeepSeek 400 errors after tool use. REPL permission prompts are now serialized to avoid prompt_toolkit races and cached per tool for the session, so repeated Grep/Glob calls only ask once. Added focused regression coverage for reasoning replay, message normalization, provider conversion, and REPL permission prompt behavior.