### PR TITLE
fix: Show elapsed time and token count in REPL spinner row

### DIFF
--- a/src/providers/openai_compatible.py
+++ b/src/providers/openai_compatible.py
@@ -336,12 +336,24 @@ class OpenAICompatibleProvider(BaseProvider):
             converted = [_convert_to_openai_tool_schema(t) for t in tools]
             extra_kwargs["tools"] = [t for t in converted if t is not None]
 
+        # ``stream_options.include_usage`` opts the OpenAI streaming API
+        # into emitting a final ``usage`` chunk; without it, ``chunk.usage``
+        # is always ``None`` and the rebuilt ChatResponse has empty token
+        # counts. The spinner row + ``/stats`` rely on this — see
+        # ``_build_usage_dict`` below and the consumer in
+        # ``src/query/query.py``.
+        stream_kwargs = {k: v for k, v in kwargs.items() if k not in ["model", "tools"]}
+        existing_stream_options = stream_kwargs.pop("stream_options", None) or {}
+        stream_kwargs["stream_options"] = {
+            **existing_stream_options,
+            "include_usage": True,
+        }
         stream = self.client.chat.completions.create(
             model=model,
             messages=provider_messages,
             stream=True,
             **extra_kwargs,
-            **{k: v for k, v in kwargs.items() if k not in ["model", "tools"]},
+            **stream_kwargs,
         )
 
         content_parts: list[str] = []

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -269,6 +269,7 @@ async def _call_model_sync(
     assistant_msg = AssistantMessage(
         content=assistant_blocks if assistant_blocks else "",
         stop_reason=stop_reason,
+        usage=response.usage,
     )
     if response.reasoning_content:
         # Preserve provider thinking metadata for follow-up turns.

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -2289,6 +2289,11 @@ class ClawcodexREPL:
                 last_text_was_printed = False
                 api_call_count = 0
                 tool_use_map: dict[str, tuple[str, dict]] = {}
+                # Per-turn token totals — surfaced to the spinner suffix
+                # via ``status.set_tokens(...)``. Local to the closure so
+                # they reset every turn; ``self._stats_*`` remain the
+                # session-cumulative counters for ``/stats``.
+                turn_tokens = 0
                 # Track whether a Task*/TodoWrite round is "in flight" so we
                 # can coalesce a run of task-management calls into a single
                 # TaskListV2-style snapshot instead of dumping one ``●`` bullet
@@ -2331,12 +2336,13 @@ class ClawcodexREPL:
                         self.session.conversation.add_assistant_message(msg.content)
                         usage = getattr(msg, "usage", None)
                         if isinstance(usage, dict):
-                            self._stats_input_tokens += int(
-                                usage.get("input_tokens", 0) or 0
-                            )
-                            self._stats_output_tokens += int(
-                                usage.get("output_tokens", 0) or 0
-                            )
+                            in_toks = int(usage.get("input_tokens", 0) or 0)
+                            out_toks = int(usage.get("output_tokens", 0) or 0)
+                            self._stats_input_tokens += in_toks
+                            self._stats_output_tokens += out_toks
+                            turn_tokens += in_toks + out_toks
+                            if _engine_status_ref:
+                                _engine_status_ref[0].set_tokens(turn_tokens)
                         content = msg.content
                         if isinstance(content, str):
                             if content:

--- a/src/repl/live_status.py
+++ b/src/repl/live_status.py
@@ -33,8 +33,11 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import time
 from contextlib import contextmanager
 from typing import Callable, Iterator
+
+from src.utils.format import format_duration, format_number
 
 try:
     from prompt_toolkit.application import Application
@@ -68,6 +71,9 @@ _SPINNER_FRAMES: tuple[str, ...] = (
     "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏",
 )
 _FRAME_INTERVAL = 0.08
+# Mirrors ``SHOW_TOKENS_AFTER_MS`` in
+# ``typescript/src/components/Spinner/SpinnerAnimationRow.tsx``.
+_SHOW_TIMER_AFTER_MS = 30_000
 
 
 class LiveStatus:
@@ -103,6 +109,7 @@ class LiveStatus:
         on_submit: Callable[[str], None] | None = None,
         on_expand: Callable[[], None] | None = None,
         completer=None,
+        verbose: bool = False,
     ) -> None:
         if not _HAS_PROMPT_TOOLKIT:
             raise RuntimeError(
@@ -125,6 +132,18 @@ class LiveStatus:
         self._ready = threading.Event()
         self._lock = threading.Lock()
         self._input_buffer: Buffer | None = None
+        # Tracks the wall-clock origin for the spinner's elapsed-time
+        # readout (mirrors ``loadingStartTimeRef`` in the TS spinner).
+        # Set in ``__enter__`` / ``paused.__exit__`` and cleared in
+        # ``_stop`` so a paused-and-resumed cycle restarts the timer.
+        self._started_at: float | None = None
+        # Latest token total surfaced via :meth:`set_tokens`. Mirrors
+        # ``responseLengthRef.current / 4`` + teammate sum from
+        # ``SpinnerAnimationRow.tsx``.
+        self._tokens: int = 0
+        # Force-show the elapsed/token suffix before the 30s threshold.
+        # Maps to the TS ``verbose`` prop in ``SpinnerWithVerb``.
+        self._verbose = verbose
 
     # ---- public API ----
     def update(self, message: str) -> None:
@@ -134,7 +153,24 @@ class LiveStatus:
             self._message = message
         self._invalidate()
 
+    def set_tokens(self, n: int) -> None:
+        """Update the token count shown in the spinner suffix.
+
+        Safe to call from any thread. Pass the running per-turn total
+        (input + output tokens) — the spinner re-renders on the next
+        frame tick. Mirrors how the TS spinner reads
+        ``responseLengthRef.current / 4`` each frame.
+        """
+
+        with self._lock:
+            if n == self._tokens:
+                return
+            self._tokens = max(0, int(n))
+        self._invalidate()
+
     def __enter__(self) -> "LiveStatus":
+        self._started_at = time.monotonic()
+        self._tokens = 0
         self._thread = threading.Thread(
             target=self._run_thread,
             name="clawcodex-live-status",
@@ -168,6 +204,11 @@ class LiveStatus:
         on_submit = self._on_submit
         on_expand = self._on_expand
         completer = self._completer
+        # Preserve the timer / token counter across the pause so the
+        # spinner picks up where it left off after the foreground prompt
+        # finishes. ``_stop`` clears ``_started_at``; capture first.
+        started_at = self._started_at
+        tokens = self._tokens
         self._stop()
         try:
             yield
@@ -178,6 +219,8 @@ class LiveStatus:
             self._on_expand = on_expand
             self._completer = completer
             self._frame_index = 0
+            self._started_at = started_at
+            self._tokens = tokens
             self._ready = threading.Event()
             self._thread = threading.Thread(
                 target=self._run_thread,
@@ -369,14 +412,31 @@ class LiveStatus:
     def _render_spinner_text(self) -> "FormattedText":
         with self._lock:
             message = self._message
+            started_at = self._started_at
+            tokens = self._tokens
+            verbose = self._verbose
         frame = _SPINNER_FRAMES[self._frame_index % len(_SPINNER_FRAMES)]
         self._frame_index += 1
+
+        # Match ``SpinnerAnimationRow.tsx``'s suffix:
+        # ``(esc to interrupt · 12s · ↓ 1.2k tokens)``.
+        # Timer + token suffix gated by 30s elapsed (or ``verbose``),
+        # tokens additionally require a non-zero count.
+        elapsed_ms = (time.monotonic() - started_at) * 1000 if started_at else 0.0
+        wants_timer = verbose or elapsed_ms > _SHOW_TIMER_AFTER_MS
+        suffix = "  (esc to interrupt"
+        if wants_timer:
+            suffix += f" · {format_duration(elapsed_ms)}"
+            if tokens > 0:
+                suffix += f" · ↓ {format_number(tokens)} tokens"
+        suffix += ")"
+
         return FormattedText(
             [
                 ("class:spinner", frame),
                 ("", " "),
                 ("class:status", message),
-                ("class:hint", "  (esc to cancel · enter to queue)"),
+                ("class:hint", suffix),
             ]
         )
 
@@ -403,3 +463,8 @@ class LiveStatus:
         self._loop = None
         self._thread = None
         self._input_buffer = None
+        # Cleared so a fresh ``__enter__`` after a full teardown starts
+        # the elapsed timer from zero. ``paused()`` snapshots and
+        # restores this so its pause/resume cycle preserves the timer.
+        self._started_at = None
+        self._tokens = 0

--- a/src/utils/format.py
+++ b/src/utils/format.py
@@ -1,0 +1,102 @@
+"""Pure display formatters — Python port of ``typescript/src/utils/format.ts``.
+
+Used by the REPL spinner (and any future caller) to render durations and
+token counts in the same compact form as the TypeScript Ink reference UI:
+``12s`` / ``1m 30s`` for time, ``900`` / ``1.2k`` / ``1.0m`` for counts.
+
+Behaviour matches the TS reference closely enough that the two
+implementations produce byte-identical output for the spinner row.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def format_duration(
+    ms: float,
+    *,
+    hide_trailing_zeros: bool = False,
+    most_significant_only: bool = False,
+) -> str:
+    """Render a millisecond duration the same way ``formatDuration`` in
+    ``typescript/src/utils/format.ts`` does."""
+
+    if ms < 60_000:
+        if ms == 0:
+            return "0s"
+        if ms < 1:
+            return f"{ms / 1000:.1f}s"
+        return f"{int(math.floor(ms / 1000))}s"
+
+    days = int(math.floor(ms / 86_400_000))
+    hours = int(math.floor((ms % 86_400_000) / 3_600_000))
+    minutes = int(math.floor((ms % 3_600_000) / 60_000))
+    # Match JS ``Math.round`` (round-half-up) rather than Python's
+    # banker's rounding so 0.5s ticks land identically across the two
+    # implementations.
+    seconds = int(math.floor((ms % 60_000) / 1000 + 0.5))
+
+    # Carry rounded seconds (e.g. 59.5s → 60s → 1m).
+    if seconds == 60:
+        seconds = 0
+        minutes += 1
+    if minutes == 60:
+        minutes = 0
+        hours += 1
+    if hours == 24:
+        hours = 0
+        days += 1
+
+    if most_significant_only:
+        if days > 0:
+            return f"{days}d"
+        if hours > 0:
+            return f"{hours}h"
+        if minutes > 0:
+            return f"{minutes}m"
+        return f"{seconds}s"
+
+    hide = hide_trailing_zeros
+
+    if days > 0:
+        if hide and hours == 0 and minutes == 0:
+            return f"{days}d"
+        if hide and minutes == 0:
+            return f"{days}d {hours}h"
+        return f"{days}d {hours}h {minutes}m"
+    if hours > 0:
+        if hide and minutes == 0 and seconds == 0:
+            return f"{hours}h"
+        if hide and seconds == 0:
+            return f"{hours}h {minutes}m"
+        return f"{hours}h {minutes}m {seconds}s"
+    if minutes > 0:
+        if hide and seconds == 0:
+            return f"{minutes}m"
+        return f"{minutes}m {seconds}s"
+    return f"{seconds}s"
+
+
+def format_number(n: float) -> str:
+    """Compact-notation number formatter matching ``formatNumber``.
+
+    Examples: ``900`` → ``"900"``, ``1321`` → ``"1.3k"``, ``1_000`` →
+    ``"1.0k"``, ``1_500_000`` → ``"1.5m"``.
+    """
+
+    if n < 1000:
+        # TS path: Intl.NumberFormat compact with no minimum fraction
+        # digits collapses < 1000 values to bare integers.
+        return str(int(n))
+    if n < 1_000_000:
+        return f"{n / 1000:.1f}k"
+    if n < 1_000_000_000:
+        return f"{n / 1_000_000:.1f}m"
+    return f"{n / 1_000_000_000:.1f}b"
+
+
+def format_tokens(count: int) -> str:
+    """Mirror ``formatTokens`` in TS: drop the ``.0`` when present."""
+
+    return format_number(count).replace(".0", "")

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,0 +1,79 @@
+"""Parity tests for ``src.utils.format``.
+
+These mirror the behaviour of ``typescript/src/utils/format.ts`` so the
+REPL spinner row produces byte-identical output across implementations.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.utils.format import format_duration, format_number, format_tokens
+
+
+@pytest.mark.parametrize(
+    "ms,expected",
+    [
+        (0, "0s"),
+        (500, "0s"),
+        (999, "0s"),
+        (1_000, "1s"),
+        (12_345, "12s"),
+        (59_999, "59s"),
+        (60_000, "1m 0s"),
+        (90_000, "1m 30s"),
+        (3_599_000, "59m 59s"),
+        (3_600_000, "1h 0m 0s"),
+        (3_660_500, "1h 1m 1s"),
+        (86_400_000, "1d 0h 0m"),
+        (90_061_000, "1d 1h 1m"),
+    ],
+)
+def test_format_duration(ms: int, expected: str) -> None:
+    assert format_duration(ms) == expected
+
+
+@pytest.mark.parametrize(
+    "ms,expected",
+    [
+        (90_000, "1m"),
+        (3_600_000, "1h"),
+        (86_400_000, "1d"),
+        (45_000, "45s"),
+    ],
+)
+def test_format_duration_most_significant_only(ms: int, expected: str) -> None:
+    assert format_duration(ms, most_significant_only=True) == expected
+
+
+def test_format_duration_hide_trailing_zeros() -> None:
+    assert format_duration(3_600_000, hide_trailing_zeros=True) == "1h"
+    assert format_duration(3_660_000, hide_trailing_zeros=True) == "1h 1m"
+    assert format_duration(86_400_000, hide_trailing_zeros=True) == "1d"
+    assert format_duration(90_000_000, hide_trailing_zeros=True) == "1d 1h"
+
+
+@pytest.mark.parametrize(
+    "n,expected",
+    [
+        (0, "0"),
+        (1, "1"),
+        (900, "900"),
+        (999, "999"),
+        (1_000, "1.0k"),
+        (1_321, "1.3k"),
+        (12_500, "12.5k"),
+        (999_999, "1000.0k"),
+        (1_000_000, "1.0m"),
+        (1_500_000, "1.5m"),
+        (2_000_000_000, "2.0b"),
+    ],
+)
+def test_format_number(n: int, expected: str) -> None:
+    assert format_number(n) == expected
+
+
+def test_format_tokens_drops_trailing_zero() -> None:
+    assert format_tokens(1_000) == "1k"
+    assert format_tokens(1_321) == "1.3k"
+    assert format_tokens(900) == "900"


### PR DESCRIPTION
## Summary
- Default Python REPL spinner now renders `(esc to interrupt · 12s · ↓ 1.2k tokens)` to match `typescript/src/components/Spinner/SpinnerAnimationRow.tsx` (timer + tokens gated by the same 30s threshold as TS).
- Two upstream bugs were dropping per-turn token usage on the floor — both fixed so `/stats` is also accurate now:
  - `src/query/query.py:269` — `AssistantMessage` was constructed without `usage=response.usage`.
  - `src/providers/openai_compatible.py` — streaming requests didn't pass `stream_options={"include_usage": True}`, so OpenAI's SDK never emitted a usage chunk.
- New `src/utils/format.py` ports `formatDuration` / `formatNumber` from `typescript/src/utils/format.ts`, including JS-style round-half-up so the Python output matches byte-for-byte.

## Files changed
- `src/utils/format.py` *(new)* — duration / number formatters.
- `src/repl/live_status.py` — `LiveStatus` tracks elapsed time + exposes `set_tokens(n)`; `paused()` preserves the timer.
- `src/repl/core.py` — `chat()` accumulates per-turn tokens from `AssistantMessage.usage` and pushes them to the spinner.
- `src/query/query.py` — pass `usage` through to `AssistantMessage`.
- `src/providers/openai_compatible.py` — opt streaming calls into `include_usage`.
- `tests/test_format.py` *(new)* — 30 parity tests for the new formatters.

## Test plan
- [x] `pytest tests/test_format.py` (30 passed)
- [x] Manual: `python -m src.cli --dangerously-skip-permissions`, send a long prompt; after ~30s the bottom row shows `⠋ Thinking…  (esc to interrupt · 42s · ↓ 1.2k tokens)` and ticks live.
- [x] Confirmed token portion populates against an OpenAI streaming model (was stuck at 0 without the `include_usage` opt-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)