### PR TITLE
feat(skills): port Python skills subsystem to parity with TypeScript

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,14 @@ dependencies = [
     "prompt-toolkit",
     "tiktoken>=0.7.0",
     "textual>=0.79",
+    # YAML frontmatter parser (SKILL.md, agent files, output styles).
+    # Required for nested structures like ``hooks:`` and ``shell:`` to
+    # round-trip through ``src.skills.frontmatter.parse_frontmatter``.
+    "PyYAML>=6.0",
+    # gitwildmatch path matching for conditional-skill ``paths:`` rules.
+    # The TS port uses the `ignore` library; ``pathspec`` is the Python
+    # equivalent (full ``**`` recursion + anchoring + negation).
+    "pathspec>=0.11",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ python-dotenv>=1.0.0
 rich>=13.0.0
 prompt-toolkit>=3.0.0
 textual>=0.79
+PyYAML>=6.0
+pathspec>=0.11
 
 # Development Dependencies
 build>=1.0.0

--- a/scripts/run_skill_smoke.py
+++ b/scripts/run_skill_smoke.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Manual smoke-test runner for the QA-2 example skills.
+
+Loads every skill under ``tests/fixtures/skills/`` (plus the bundled
+catalogue from DEV-5), prints a listing that mirrors what the model
+would see in its system-reminder, and then invokes each in turn so you
+can eyeball the rendered prompt.
+
+Useful as:
+
+  - A manual artifact for the user / team-lead ("here's what skills
+    look like once they hit the model").
+  - A quick smoke-check that the disk → registry → SkillTool pipeline
+    is wired correctly without spinning up a real REPL.
+
+Run from the repo root:
+
+    python scripts/run_skill_smoke.py
+
+No arguments. Output goes to stdout.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+
+# Make the repo root importable when the script is launched from a
+# subdirectory.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+from src.skills.bundled import init_bundled_skills  # noqa: E402
+from src.skills.bundled_skills import clear_bundled_skills  # noqa: E402
+from src.skills.loader import (  # noqa: E402
+    activate_conditional_skills_for_paths,
+    clear_dynamic_skills,
+    clear_skill_caches,
+    clear_skill_registry,
+    get_all_skills,
+)
+from src.tool_system.context import ToolContext  # noqa: E402
+from src.tool_system.tools import SkillTool  # noqa: E402
+
+
+FIXTURES_ROOT = REPO_ROOT / "tests" / "fixtures" / "skills"
+FIXTURE_NAMES = ("commit-helper", "frontend", "lint-py")
+PREVIEW_CHARS = 200
+
+
+def _build_workspace(tmp: Path) -> Path:
+    """Construct a workspace whose ``.claude/skills/`` mirrors the
+    fixture catalogue. Returns the workspace root."""
+    project = tmp / "proj"
+    skills_root = project / ".claude" / "skills"
+    skills_root.mkdir(parents=True)
+    for name in FIXTURE_NAMES:
+        shutil.copytree(FIXTURES_ROOT / name, skills_root / name)
+    return project
+
+
+def _isolate_env(tmp: Path) -> None:
+    """Strip every env knob that would inject non-fixture skill dirs."""
+    fake_home = tmp / "home"
+    fake_home.mkdir()
+    os.environ["HOME"] = str(fake_home)
+    os.environ["CLAUDE_MANAGED_CONFIG_DIR"] = str(tmp / "managed")
+    for var in (
+        "CLAUDE_CONFIG_DIR",
+        "CLAWCODEX_SKILLS_DIR",
+        "CLAUDE_SKILLS_DIR",
+        "CLAWCODEX_MANAGED_SKILLS_DIR",
+        "CLAUDE_CODE_BARE_MODE",
+        "CLAUDE_CODE_DISABLE_POLICY_SKILLS",
+        "CLAUDE_CODE_ADDITIONAL_DIRECTORIES",
+    ):
+        os.environ.pop(var, None)
+
+
+def _print_section(title: str) -> None:
+    bar = "=" * 72
+    print(f"\n{bar}\n{title}\n{bar}")
+
+
+def _print_listing(project: Path) -> None:
+    skills = get_all_skills(project_root=project)
+    _print_section(f"Available skills ({len(skills)}, unconditional only)")
+    print(f"{'name':<30}  {'source':<10}  description")
+    print("-" * 72)
+    for s in sorted(skills, key=lambda x: x.name):
+        desc = s.description or ""
+        if len(desc) > 60:
+            desc = desc[:57] + "..."
+        print(f"{s.name:<30}  {s.loaded_from:<10}  {desc}")
+
+
+def _print_invocation(
+    skill_name: str, args: str, ctx: ToolContext
+) -> None:
+    result = SkillTool.call({"skill": skill_name, "args": args}, ctx)
+    out = result.output
+    head = f"--- /{skill_name}"
+    if args:
+        head += f' "{args}"'
+    head += " ---"
+    print(f"\n{head}")
+    if not out.get("success"):
+        print(f"  ERROR: {out}")
+        return
+    prompt = out["prompt"]
+    preview = prompt if len(prompt) <= PREVIEW_CHARS else (
+        prompt[:PREVIEW_CHARS] + f"\n... [truncated, total {len(prompt)} chars]"
+    )
+    for line in preview.splitlines():
+        print(f"  {line}")
+    if out.get("loadedFrom"):
+        print(f"  [loadedFrom={out['loadedFrom']}, allowedTools={out.get('allowedTools')}]")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        _isolate_env(tmp)
+
+        # Reset every cache + register the bundled catalogue.
+        clear_skill_caches()
+        clear_dynamic_skills()
+        clear_skill_registry()
+        clear_bundled_skills()
+        init_bundled_skills()
+
+        project = _build_workspace(tmp)
+        ctx = ToolContext(workspace_root=project)
+        ctx.session_id = "S-smoke-001"
+
+        _print_listing(project)
+
+        _print_section("Invocations (first 200 chars of each rendered prompt)")
+        # commit-helper — substitutions + args
+        _print_invocation("commit-helper", "feat", ctx)
+
+        # frontend:add-component — namespaced + named arg
+        _print_invocation("frontend:add-component", "Button", ctx)
+
+        # simplify — bundled skill (no base-dir header)
+        _print_invocation("simplify", "focus on caching", ctx)
+
+        # lint-py — conditional skill: activate it by touching a
+        # matching path, then invoke. As of bug fix #14, activated
+        # conditional skills flow through `get_all_skills` →
+        # `_skill_registry` automatically, so SkillTool resolves them
+        # naturally on the next call (no manual registry promotion).
+        _print_section("Activating conditional `lint-py` for src/foo.py")
+        py_path = project / "src" / "foo.py"
+        py_path.parent.mkdir(parents=True, exist_ok=True)
+        py_path.write_text("# placeholder")
+        activated = activate_conditional_skills_for_paths(
+            [str(py_path)], str(project)
+        )
+        print(f"  activated: {activated}")
+        _print_invocation("lint-py", "", ctx)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/skills/__init__.py
+++ b/src/skills/__init__.py
@@ -1,4 +1,5 @@
 from .argument_substitution import parse_arguments, substitute_arguments
+from .bundled import init_bundled_skills
 from .bundled_skills import (
     BundledSkillDefinition,
     SkillValidationError,
@@ -17,17 +18,31 @@ from .loader import (
     add_skill_directories,
     clear_dynamic_skills,
     clear_skill_caches,
+    clear_skill_registry,
     create_skill_command,
     discover_skill_dirs_for_paths,
+    get_all_skills,
     get_conditional_skill_count,
     get_dynamic_skills,
+    get_registered_skill,
     get_skill_dir_commands,
     get_skills_path,
+    load_skills_from_dir,
     load_skills_from_skills_dir,
     parse_skill_frontmatter_fields,
 )
 from .mcp_skill_builders import get_mcp_skill_builders, register_mcp_skill_builders
 from .model import PromptSkill, Skill
+from .runtime_substitution import (
+    find_shell_blocks,
+    format_shell_error,
+    format_shell_output,
+    has_shell_blocks,
+    prepend_base_dir_header,
+    render_skill_prompt,
+    substitute_session_id,
+    substitute_skill_dir,
+)
 
 __all__ = [
     "Skill",
@@ -50,6 +65,7 @@ __all__ = [
     "get_skill_dir_commands",
     "get_skills_path",
     "load_skills_from_skills_dir",
+    "load_skills_from_dir",
     "discover_skill_dirs_for_paths",
     "add_skill_directories",
     "activate_conditional_skills_for_paths",
@@ -57,6 +73,18 @@ __all__ = [
     "get_conditional_skill_count",
     "clear_skill_caches",
     "clear_dynamic_skills",
+    "clear_skill_registry",
+    "get_all_skills",
+    "get_registered_skill",
     "register_mcp_skill_builders",
     "get_mcp_skill_builders",
+    "render_skill_prompt",
+    "prepend_base_dir_header",
+    "substitute_skill_dir",
+    "substitute_session_id",
+    "find_shell_blocks",
+    "has_shell_blocks",
+    "format_shell_output",
+    "format_shell_error",
+    "init_bundled_skills",
 ]

--- a/src/skills/bundled/__init__.py
+++ b/src/skills/bundled/__init__.py
@@ -1,0 +1,73 @@
+"""Bundled-skill catalogue + init orchestrator.
+
+Mirrors the TS pattern in ``typescript/src/skills/bundled/index.ts``:
+each individual skill module exposes a ``register_*_skill()`` function
+that calls ``register_bundled_skill(BundledSkillDefinition(...))``;
+``init_bundled_skills()`` calls them in order at startup.
+
+``init_bundled_skills`` is idempotent — calling it twice does not
+re-register skills (the second call is a no-op). The bundled-skill
+registry consults a sentinel set so a fresh ``clear_bundled_skills()``
+forces re-init on the next call.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from .debug import register_debug_skill
+from .loop import register_loop_skill
+from .simplify import register_simplify_skill
+from .stuck import register_stuck_skill
+from .verify_content import register_verify_content_skill
+
+logger = logging.getLogger(__name__)
+
+
+# Tracks whether ``init_bundled_skills`` has already populated the
+# registry. Reset by ``clear_bundled_skills`` (via the hook below) so
+# tests that wipe state can re-init cleanly.
+_INITIALIZED: bool = False
+
+
+def init_bundled_skills() -> None:
+    """Register every always-on bundled skill exactly once.
+
+    Calls each ``register_*_skill()`` function in a fixed order. Skills
+    with feature gates check ``is_enabled`` lazily at lookup time
+    (matches TS) — they're registered unconditionally so they show up
+    in the catalogue when the gate flips.
+
+    Idempotent: subsequent calls are no-ops. Use the
+    ``clear_bundled_skills()`` hook in ``src.skills.bundled_skills`` to
+    reset state in tests.
+    """
+    global _INITIALIZED
+    if _INITIALIZED:
+        return
+    register_simplify_skill()
+    register_debug_skill()
+    register_loop_skill()
+    register_stuck_skill()
+    register_verify_content_skill()
+    _INITIALIZED = True
+    logger.debug("bundled skills initialized")
+
+
+def reset_bundled_skills_init_flag() -> None:
+    """Drop the idempotency flag so the next ``init_bundled_skills``
+    call re-runs. Wired to ``clear_bundled_skills`` so test fixtures
+    that reset the registry also reset the flag."""
+    global _INITIALIZED
+    _INITIALIZED = False
+
+
+__all__ = [
+    "init_bundled_skills",
+    "reset_bundled_skills_init_flag",
+    "register_simplify_skill",
+    "register_debug_skill",
+    "register_loop_skill",
+    "register_stuck_skill",
+    "register_verify_content_skill",
+]

--- a/src/skills/bundled/debug.py
+++ b/src/skills/bundled/debug.py
@@ -1,0 +1,187 @@
+"""Bundled ``/debug`` skill — minimal port of ``bundled/debug.ts``.
+
+Reads the tail of a session debug log (last ~64 KB / 20 lines), surfaces
+the log path, settings paths, and the user's issue description so the
+model can diagnose. Scoped to ``Read``/``Grep``/``Glob`` tools.
+
+The full TS skill calls ``enableDebugLogging()`` to opt-in to logging
+mid-session. Python has no equivalent helper today, so the "just
+enabled" call is a no-op (TODO when the Python runtime grows one). The
+prompt still surfaces the resolved log path so the user can tail it
+out-of-band.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from ..bundled_skills import BundledSkillDefinition, register_bundled_skill
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_DEBUG_LINES_READ = 20
+_TAIL_READ_BYTES = 64 * 1024
+
+
+def _get_debug_log_path() -> str:
+    """Resolve the conventional session debug log path.
+
+    Honors ``CLAUDE_CODE_DEBUG_LOG_PATH`` if set; otherwise falls back to
+    ``$CLAUDE_CONFIG_DIR/debug.log`` (or ``~/.claude/debug.log``). The
+    file may not exist — callers handle that case.
+    """
+    env = os.environ.get("CLAUDE_CODE_DEBUG_LOG_PATH")
+    if env:
+        return str(Path(env).expanduser())
+    config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+    base = Path(config_dir).expanduser() if config_dir else Path.home() / ".claude"
+    return str(base / "debug.log")
+
+
+def _enable_debug_logging() -> bool:
+    """Stub for TS ``enableDebugLogging``.
+
+    Returns True if logging was already on, False otherwise. The Python
+    runtime has no mid-session logging toggle yet — the function is a
+    no-op that always reports "was already on" (so the prompt skips the
+    "just enabled" hint). TODO: wire to a real logging toggle when one
+    lands.
+    """
+    return True
+
+
+def _format_file_size(num_bytes: int) -> str:
+    units = ["B", "KB", "MB", "GB"]
+    n = float(num_bytes)
+    for unit in units:
+        if n < 1024 or unit == units[-1]:
+            return f"{n:.1f} {unit}" if unit != "B" else f"{int(n)} B"
+        n /= 1024
+    return f"{num_bytes} B"
+
+
+def _read_log_tail(log_path: str) -> str:
+    """Return a markdown-rendered tail block, or a graceful "no log" hint.
+
+    Mirrors TS: stat → seek to ``size - TAIL_READ_BYTES`` → read → keep
+    last ``DEFAULT_DEBUG_LINES_READ`` lines. Returns a short hint when
+    the file is missing or unreadable.
+    """
+    try:
+        p = Path(log_path)
+        size = p.stat().st_size
+        read_size = min(size, _TAIL_READ_BYTES)
+        start_offset = max(0, size - read_size)
+        with p.open("rb") as fh:
+            fh.seek(start_offset)
+            data = fh.read(read_size)
+        text = data.decode("utf-8", errors="replace")
+        tail_lines = text.split("\n")[-_DEFAULT_DEBUG_LINES_READ:]
+        tail = "\n".join(tail_lines)
+        return (
+            f"Log size: {_format_file_size(size)}\n\n"
+            f"### Last {_DEFAULT_DEBUG_LINES_READ} lines\n\n"
+            f"```\n{tail}\n```"
+        )
+    except FileNotFoundError:
+        return "No debug log exists yet — logging was just enabled."
+    except OSError as exc:
+        return (
+            f"Failed to read last {_DEFAULT_DEBUG_LINES_READ} lines of "
+            f"debug log: {exc}"
+        )
+
+
+def _settings_path_hint(scope: str) -> str:
+    """Return a stable hint for the settings file at ``scope``.
+
+    The Python codebase doesn't yet expose a unified
+    ``getSettingsFilePathForSource`` equivalent; we render conventional
+    paths so the user can locate them. Mirrors TS' three scopes.
+    """
+    if scope == "userSettings":
+        config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+        base = Path(config_dir).expanduser() if config_dir else Path.home() / ".claude"
+        return str(base / "settings.json")
+    if scope == "projectSettings":
+        return ".claude/settings.json"
+    if scope == "localSettings":
+        return ".claude/settings.local.json"
+    return "(unknown scope)"
+
+
+def _build_debug_prompt(args: str) -> str:
+    was_already_logging = _enable_debug_logging()
+    debug_log_path = _get_debug_log_path()
+    log_info = _read_log_tail(debug_log_path)
+
+    just_enabled_section = (
+        ""
+        if was_already_logging
+        else (
+            "\n## Debug Logging Just Enabled\n\n"
+            "Debug logging was OFF for this session until now. Nothing prior to this /debug invocation was captured.\n\n"
+            f"Tell the user that debug logging is now active at `{debug_log_path}`, ask them to reproduce the issue, then re-read the log. If they can't reproduce, they can also restart with `claude --debug` to capture logs from startup.\n"
+        )
+    )
+
+    issue_description = args or (
+        "The user did not describe a specific issue. Read the debug log and "
+        "summarize any errors, warnings, or notable issues."
+    )
+
+    return (
+        "# Debug Skill\n"
+        "\n"
+        "Help the user debug an issue they're encountering in this current Claude Code session.\n"
+        f"{just_enabled_section}\n"
+        "## Session Debug Log\n"
+        "\n"
+        f"The debug log for the current session is at: `{debug_log_path}`\n"
+        "\n"
+        f"{log_info}\n"
+        "\n"
+        "For additional context, grep for [ERROR] and [WARN] lines across the full file.\n"
+        "\n"
+        "## Issue Description\n"
+        "\n"
+        f"{issue_description}\n"
+        "\n"
+        "## Settings\n"
+        "\n"
+        f"Remember that settings are in:\n"
+        f"* user - {_settings_path_hint('userSettings')}\n"
+        f"* project - {_settings_path_hint('projectSettings')}\n"
+        f"* local - {_settings_path_hint('localSettings')}\n"
+        "\n"
+        "## Instructions\n"
+        "\n"
+        "1. Review the user's issue description\n"
+        f"2. The last {_DEFAULT_DEBUG_LINES_READ} lines show the debug file format. Look for [ERROR] and [WARN] entries, stack traces, and failure patterns across the file\n"
+        "3. Consider launching the claude-code-guide subagent to understand the relevant Claude Code features\n"
+        "4. Explain what you found in plain language\n"
+        "5. Suggest concrete fixes or next steps\n"
+    )
+
+
+def register_debug_skill() -> None:
+    register_bundled_skill(
+        BundledSkillDefinition(
+            name="debug",
+            description=(
+                "Enable debug logging for this session and help diagnose issues"
+            ),
+            allowed_tools=["Read", "Grep", "Glob"],
+            argument_hint="[issue description]",
+            # disable_model_invocation: matches TS — user must opt in
+            # via `/debug`; otherwise the description doesn't burn
+            # context budget on every model turn.
+            disable_model_invocation=True,
+            user_invocable=True,
+            get_prompt_for_command=_build_debug_prompt,
+        )
+    )

--- a/src/skills/bundled/loop.py
+++ b/src/skills/bundled/loop.py
@@ -1,0 +1,272 @@
+"""Bundled ``/loop`` skill — port of ``bundled/loop.ts``.
+
+Pure argument-parsing logic + two prompt builders. Three modes:
+``fixed-prompt``, ``fixed-maintenance``, ``dynamic-prompt``,
+``dynamic-maintenance``. Routes to ``buildFixedPrompt`` or
+``buildDynamicPrompt`` based on whether the user supplied an interval.
+
+The TS feature gate (``isKairosCronEnabled``) has no Python equivalent
+yet; the ``is_enabled`` callback returns True so the skill is always
+visible. TODO: wire to a real Python feature gate when one lands.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from ..bundled_skills import BundledSkillDefinition, register_bundled_skill
+
+
+# Cron-tool name constants. The Python tool registry exposes
+# ``CronCreate`` / ``CronDelete`` (see ``src.tool_system.tools.cron``)
+# which is the same naming the prompt body references.
+_CRON_CREATE_TOOL_NAME = "CronCreate"
+_CRON_DELETE_TOOL_NAME = "CronDelete"
+
+# Recurring-job auto-expiration window (mirrors TS DEFAULT_MAX_AGE_DAYS).
+_DEFAULT_MAX_AGE_DAYS = 7
+
+_DYNAMIC_MIN_DELAY = "1 minute"
+_DYNAMIC_MAX_DELAY = "1 hour"
+
+
+_MAINTENANCE_PROMPT = """Scheduled maintenance loop iteration.
+
+If .claude/loop.md exists, read it and follow it.
+Otherwise, if ~/.claude/loop.md exists, read it and follow it.
+Otherwise:
+- continue any unfinished work from the conversation
+- tend to the current branch's pull request: review comments, failed CI runs, merge conflicts
+- run cleanup passes such as bug hunts or simplification when nothing else is pending
+
+Do not start new initiatives outside that scope.
+Irreversible actions such as pushing or deleting only proceed when they continue something the transcript already authorized."""
+
+
+@dataclass(frozen=True)
+class ParsedLoopArgs:
+    mode: str  # "dynamic-prompt" | "dynamic-maintenance" | "fixed-prompt" | "fixed-maintenance"
+    interval: Optional[str] = None
+    prompt: Optional[str] = None
+
+
+# ----------------------------------------------------------------------
+# Argument parser (verbatim port of TS parseLoopArgs et al.)
+# ----------------------------------------------------------------------
+
+
+def _normalize_interval_unit(raw_unit: str) -> str | None:
+    unit = raw_unit.lower()
+    if unit in {"s", "sec", "secs", "second", "seconds"}:
+        return "s"
+    if unit in {"m", "min", "mins", "minute", "minutes"}:
+        return "m"
+    if unit in {"h", "hr", "hrs", "hour", "hours"}:
+        return "h"
+    if unit in {"d", "day", "days"}:
+        return "d"
+    return None
+
+
+def _parse_interval_token(token: str) -> str | None:
+    """Match ``<int><unit>`` (e.g. ``5m``, ``2hours``); return canonical form."""
+    m = re.match(r"^(\d+)\s*([a-zA-Z]+)$", token.strip())
+    if not m:
+        return None
+    try:
+        value = int(m.group(1), 10)
+    except ValueError:
+        return None
+    if value < 1:
+        return None
+    unit = _normalize_interval_unit(m.group(2))
+    if unit is None:
+        return None
+    return f"{value}{unit}"
+
+
+def _parse_trailing_every_clause(text: str) -> tuple[str, str] | None:
+    """Match ``... every <int> <unit>`` and return ``(prompt, interval)``."""
+    m = re.match(r"^(.*?)(?:\s+every\s+)(\d+)\s*([a-zA-Z]+)\s*$", text, re.IGNORECASE)
+    if not m:
+        return None
+    interval = _parse_interval_token(f"{m.group(2)}{m.group(3)}")
+    if not interval:
+        return None
+    return m.group(1).strip(), interval
+
+
+def parse_loop_args(args: str) -> ParsedLoopArgs:
+    """Port of TS ``parseLoopArgs``.
+
+    Routing:
+    - empty args                   → ``dynamic-maintenance``
+    - bare interval (``5m``)       → ``fixed-maintenance``
+    - ``<interval> <prompt>``      → ``fixed-prompt``
+    - ``<prompt> every <interval>`` → ``fixed-prompt``
+    - anything else                → ``dynamic-prompt``
+    """
+    trimmed = args.strip()
+    if not trimmed:
+        return ParsedLoopArgs(mode="dynamic-maintenance")
+
+    bare = _parse_interval_token(trimmed)
+    if bare:
+        return ParsedLoopArgs(mode="fixed-maintenance", interval=bare)
+
+    tokens = trimmed.split()
+    first_token, rest_tokens = tokens[0], tokens[1:]
+    leading = _parse_interval_token(first_token)
+    if leading:
+        prompt = " ".join(rest_tokens).strip()
+        if not prompt:
+            return ParsedLoopArgs(mode="fixed-maintenance", interval=leading)
+        return ParsedLoopArgs(mode="fixed-prompt", interval=leading, prompt=prompt)
+
+    trailing = _parse_trailing_every_clause(trimmed)
+    if trailing:
+        prompt, interval = trailing
+        if not prompt:
+            return ParsedLoopArgs(mode="fixed-maintenance", interval=interval)
+        return ParsedLoopArgs(mode="fixed-prompt", interval=interval, prompt=prompt)
+
+    return ParsedLoopArgs(mode="dynamic-prompt", prompt=trimmed)
+
+
+# ----------------------------------------------------------------------
+# Prompt builders (verbatim ports of buildFixedPrompt / buildDynamicPrompt)
+# ----------------------------------------------------------------------
+
+
+def _build_fixed_prompt(parsed: ParsedLoopArgs) -> str:
+    if parsed.prompt:
+        target_instructions = (
+            "Use this prompt verbatim for both the immediate run and the recurring scheduled task:\n"
+            "\n--- BEGIN PROMPT ---\n"
+            f"{parsed.prompt}\n"
+            "--- END PROMPT ---\n"
+        )
+    else:
+        target_instructions = (
+            "This is a maintenance loop with no explicit prompt.\n"
+            "\nFor the recurring scheduled task, use this exact maintenance prompt body:\n"
+            "\n--- BEGIN MAINTENANCE PROMPT ---\n"
+            f"{_MAINTENANCE_PROMPT}\n"
+            "--- END MAINTENANCE PROMPT ---\n"
+        )
+
+    return (
+        "# /loop — fixed recurring interval\n"
+        "\n"
+        "The user invoked /loop with a fixed interval.\n"
+        "\n"
+        f"Requested interval: {parsed.interval}\n"
+        "\n"
+        f"{target_instructions}\n"
+        "## Instructions\n"
+        "\n"
+        "1. Convert the requested interval to a recurring cron expression.\n"
+        "   - Supported suffixes: s, m, h, d.\n"
+        "   - Seconds must be rounded up to the nearest minute because cron has minute granularity.\n"
+        "   - If the requested interval does not map cleanly to cron cadence, choose the nearest clean recurring interval and tell the user what you picked.\n"
+        f"2. Call {_CRON_CREATE_TOOL_NAME} with:\n"
+        "   - the recurring cron expression\n"
+        "   - the effective prompt body above\n"
+        "   - recurring: true\n"
+        "   - durable: false\n"
+        f"3. Briefly confirm what was scheduled, the cron expression, the human cadence, that recurring tasks auto-expire after {_DEFAULT_MAX_AGE_DAYS} days, and that the user can cancel sooner with {_CRON_DELETE_TOOL_NAME} using the returned job ID.\n"
+        "4. Immediately execute the effective prompt now — do not wait for the first cron fire.\n"
+        "   - If the effective prompt starts with a slash command, invoke it via the Skill tool.\n"
+        "   - Otherwise, act on it directly.\n"
+    )
+
+
+def _build_dynamic_prompt(parsed: ParsedLoopArgs) -> str:
+    if parsed.prompt:
+        effective_instructions = (
+            "Use this prompt verbatim as the effective prompt for this iteration:\n"
+            "\n--- BEGIN PROMPT ---\n"
+            f"{parsed.prompt}\n"
+            "--- END PROMPT ---\n"
+        )
+    else:
+        effective_instructions = (
+            "This is a maintenance loop with no explicit prompt.\n"
+            "\nDetermine the effective prompt in this order:\n"
+            "1. If .claude/loop.md exists, read it and use it.\n"
+            "2. Otherwise, if ~/.claude/loop.md exists, read it and use it.\n"
+            "3. Otherwise, use this built-in maintenance prompt:\n"
+            "\n--- BEGIN MAINTENANCE PROMPT ---\n"
+            f"{_MAINTENANCE_PROMPT}\n"
+            "--- END MAINTENANCE PROMPT ---\n"
+        )
+
+    reschedule_prompt = f"/loop {parsed.prompt}" if parsed.prompt else "/loop"
+
+    return (
+        "# /loop — dynamic rescheduling\n"
+        "\n"
+        "The user invoked /loop without a fixed interval.\n"
+        "\n"
+        f"{effective_instructions}\n"
+        "## Instructions\n"
+        "\n"
+        "1. Execute the effective prompt now.\n"
+        "   - If it starts with a slash command, invoke it via the Skill tool.\n"
+        "   - Otherwise, act on it directly.\n"
+        f"2. After the work finishes, choose the next delay dynamically between {_DYNAMIC_MIN_DELAY} and {_DYNAMIC_MAX_DELAY}.\n"
+        "   - Use shorter delays while active work is progressing or likely to change soon.\n"
+        "   - Use longer delays when the situation is quiet or stable.\n"
+        "3. Briefly tell the user the chosen delay and the reason.\n"
+        f"4. Schedule exactly one session-only follow-up run with {_CRON_CREATE_TOOL_NAME}.\n"
+        "   - Use recurring: false.\n"
+        "   - Use durable: false.\n"
+        "   - Pin the cron expression to a specific future local-time minute that matches the chosen delay.\n"
+        "   - Set the scheduled prompt to this exact text so the next iteration stays in dynamic mode:\n"
+        "\n--- BEGIN SCHEDULED PROMPT ---\n"
+        f"{reschedule_prompt}\n"
+        "--- END SCHEDULED PROMPT ---\n"
+        "\n"
+        "5. Confirm the next run time and the returned job ID.\n"
+        "6. Do not create a recurring cron for this mode.\n"
+    )
+
+
+def _build_loop_prompt(args: str) -> str:
+    parsed = parse_loop_args(args)
+    if parsed.mode in ("fixed-prompt", "fixed-maintenance"):
+        return _build_fixed_prompt(parsed)
+    return _build_dynamic_prompt(parsed)
+
+
+def _is_loop_enabled() -> bool:
+    """Stub for TS' ``isKairosCronEnabled``.
+
+    Returns True so /loop is always discoverable in the catalogue.
+    TODO: wire to a real Python feature gate (e.g., a settings flag or
+    env-var driven check) when the runtime gains one.
+    """
+    return True
+
+
+def register_loop_skill() -> None:
+    register_bundled_skill(
+        BundledSkillDefinition(
+            name="loop",
+            description=(
+                "Run a prompt on a fixed interval or dynamically reschedule "
+                "it, including bare maintenance-mode loops."
+            ),
+            when_to_use=(
+                "When the user wants to poll for status, babysit a workflow, "
+                "run recurring maintenance, or keep re-running a prompt "
+                "within the current session."
+            ),
+            argument_hint="[interval] [prompt]",
+            user_invocable=True,
+            is_enabled=_is_loop_enabled,
+            get_prompt_for_command=_build_loop_prompt,
+        )
+    )

--- a/src/skills/bundled/simplify.py
+++ b/src/skills/bundled/simplify.py
@@ -1,0 +1,88 @@
+"""Bundled ``/simplify`` skill — verbatim port of ``bundled/simplify.ts``.
+
+Three-agent code review (reuse / quality / efficiency) over recently
+changed files, then fix-and-summarize.
+"""
+
+from __future__ import annotations
+
+from ..bundled_skills import BundledSkillDefinition, register_bundled_skill
+
+
+# AGENT_TOOL_NAME in TS is "Agent". The Python tool registry uses the
+# same name (see ``src.tool_system.tools.agent``) so the literal here
+# matches what the model invokes.
+_AGENT_TOOL_NAME = "Agent"
+
+
+SIMPLIFY_PROMPT = f"""# Simplify: Code Review and Cleanup
+
+Review all changed files for reuse, quality, and efficiency. Fix any issues found.
+
+## Phase 1: Identify Changes
+
+Run `git diff` (or `git diff HEAD` if there are staged changes) to see what changed. If there are no git changes, review the most recently modified files that the user mentioned or that you edited earlier in this conversation.
+
+## Phase 2: Launch Three Review Agents in Parallel
+
+Use the {_AGENT_TOOL_NAME} tool to launch all three agents concurrently in a single message. Pass each agent the full diff so it has the complete context.
+
+### Agent 1: Code Reuse Review
+
+For each change:
+
+1. **Search for existing utilities and helpers** that could replace newly written code. Look for similar patterns elsewhere in the codebase — common locations are utility directories, shared modules, and files adjacent to the changed ones.
+2. **Flag any new function that duplicates existing functionality.** Suggest the existing function to use instead.
+3. **Flag any inline logic that could use an existing utility** — hand-rolled string manipulation, manual path handling, custom environment checks, ad-hoc type guards, and similar patterns are common candidates.
+
+### Agent 2: Code Quality Review
+
+Review the same changes for hacky patterns:
+
+1. **Redundant state**: state that duplicates existing state, cached values that could be derived, observers/effects that could be direct calls
+2. **Parameter sprawl**: adding new parameters to a function instead of generalizing or restructuring existing ones
+3. **Copy-paste with slight variation**: near-duplicate code blocks that should be unified with a shared abstraction
+4. **Leaky abstractions**: exposing internal details that should be encapsulated, or breaking existing abstraction boundaries
+5. **Stringly-typed code**: using raw strings where constants, enums (string unions), or branded types already exist in the codebase
+6. **Unnecessary JSX nesting**: wrapper Boxes/elements that add no layout value — check if inner component props (flexShrink, alignItems, etc.) already provide the needed behavior
+7. **Unnecessary comments**: comments explaining WHAT the code does (well-named identifiers already do that), narrating the change, or referencing the task/caller — delete; keep only non-obvious WHY (hidden constraints, subtle invariants, workarounds)
+
+### Agent 3: Efficiency Review
+
+Review the same changes for efficiency:
+
+1. **Unnecessary work**: redundant computations, repeated file reads, duplicate network/API calls, N+1 patterns
+2. **Missed concurrency**: independent operations run sequentially when they could run in parallel
+3. **Hot-path bloat**: new blocking work added to startup or per-request/per-render hot paths
+4. **Recurring no-op updates**: state/store updates inside polling loops, intervals, or event handlers that fire unconditionally — add a change-detection guard so downstream consumers aren't notified when nothing changed. Also: if a wrapper function takes an updater/reducer callback, verify it honors same-reference returns (or whatever the "no change" signal is) — otherwise callers' early-return no-ops are silently defeated
+5. **Unnecessary existence checks**: pre-checking file/resource existence before operating (TOCTOU anti-pattern) — operate directly and handle the error
+6. **Memory**: unbounded data structures, missing cleanup, event listener leaks
+7. **Overly broad operations**: reading entire files when only a portion is needed, loading all items when filtering for one
+
+## Phase 3: Fix Issues
+
+Wait for all three agents to complete. Aggregate their findings and fix each issue directly. If a finding is a false positive or not worth addressing, note it and move on — do not argue with the finding, just skip it.
+
+When done, briefly summarize what was fixed (or confirm the code was already clean).
+"""
+
+
+def _build_simplify_prompt(args: str) -> str:
+    prompt = SIMPLIFY_PROMPT
+    if args:
+        prompt += f"\n\n## Additional Focus\n\n{args}"
+    return prompt
+
+
+def register_simplify_skill() -> None:
+    register_bundled_skill(
+        BundledSkillDefinition(
+            name="simplify",
+            description=(
+                "Review changed code for reuse, quality, and efficiency, "
+                "then fix any issues found."
+            ),
+            user_invocable=True,
+            get_prompt_for_command=_build_simplify_prompt,
+        )
+    )

--- a/src/skills/bundled/stuck.py
+++ b/src/skills/bundled/stuck.py
@@ -1,0 +1,49 @@
+"""Bundled ``/stuck`` skill — minimal "you're stuck, change tactics" prompt.
+
+The TS module (``bundled/stuck.ts``) is currently a no-op stub. The
+Python port keeps a small but useful prompt so the skill is discoverable
+in the catalogue and gives the user something actionable when invoked.
+"""
+
+from __future__ import annotations
+
+from ..bundled_skills import BundledSkillDefinition, register_bundled_skill
+
+
+_STUCK_PROMPT = """# /stuck — Reset and Re-Approach
+
+You appear to be stuck. Pause the current line of work and reassess.
+
+## Step 1: Diagnose
+- Summarize what you were trying to do, what you tried, and what failed.
+- Identify the *first* assumption that turned out to be wrong.
+
+## Step 2: Pivot
+- Pick a different approach. Examples: read files you haven't read, run a different diagnostic command, ask the user a clarifying question, or search for prior art in the codebase.
+- Avoid retrying the same thing with minor variations.
+
+## Step 3: Report
+- Tell the user concisely: what was failing, what new approach you're taking, and why.
+
+If the user supplied additional context with /stuck, treat it as guidance for the pivot.
+"""
+
+
+def _build_stuck_prompt(args: str) -> str:
+    if not args:
+        return _STUCK_PROMPT
+    return f"{_STUCK_PROMPT}\n\n## User Context\n\n{args}\n"
+
+
+def register_stuck_skill() -> None:
+    register_bundled_skill(
+        BundledSkillDefinition(
+            name="stuck",
+            description=(
+                "Reset when stuck: diagnose what failed, pivot to a different "
+                "approach, and report back."
+            ),
+            user_invocable=True,
+            get_prompt_for_command=_build_stuck_prompt,
+        )
+    )

--- a/src/skills/bundled/verify_content.py
+++ b/src/skills/bundled/verify_content.py
@@ -1,0 +1,57 @@
+"""Bundled ``/verify-content`` skill — sanity-check the user's intent
+against the most recent edits.
+
+The TS module (``bundled/verifyContent.ts``) is build-time inlined .md
+content; the Python port keeps a concise actionable prompt here so the
+skill is discoverable in the catalogue without requiring extra .md
+asset shipping.
+"""
+
+from __future__ import annotations
+
+from ..bundled_skills import BundledSkillDefinition, register_bundled_skill
+
+
+_VERIFY_PROMPT = """# /verify-content — Verify Recent Edits Match Intent
+
+Review the most recent changes (or the files the user names) and verify
+they match what was actually requested.
+
+## Step 1: Recall the request
+- State, in your own words, what the user asked for.
+- If multiple iterations occurred, focus on the latest stated goal.
+
+## Step 2: Read the changes
+- Read each touched file fresh. Do not rely on what you remember writing.
+- For each diff hunk, ask: does this implement (or move toward) the goal?
+
+## Step 3: Surface mismatches
+- Note any change that doesn't serve the stated goal — accidental edits, half-completed transformations, leftover debug code, comments that no longer match the code.
+- Note any part of the request that is *not* yet implemented.
+
+## Step 4: Report
+- Lead with a one-line verdict: matches / partial / mismatch.
+- Then list the specific file/line locations of any mismatches and what should be done about each.
+
+If the user supplied additional context with /verify-content, treat it as the authoritative description of intent.
+"""
+
+
+def _build_verify_prompt(args: str) -> str:
+    if not args:
+        return _VERIFY_PROMPT
+    return f"{_VERIFY_PROMPT}\n\n## User-Supplied Intent\n\n{args}\n"
+
+
+def register_verify_content_skill() -> None:
+    register_bundled_skill(
+        BundledSkillDefinition(
+            name="verify-content",
+            description=(
+                "Verify the most recent edits actually match the user's "
+                "stated intent; surface mismatches and gaps."
+            ),
+            user_invocable=True,
+            get_prompt_for_command=_build_verify_prompt,
+        )
+    )

--- a/src/skills/bundled_skills.py
+++ b/src/skills/bundled_skills.py
@@ -41,6 +41,35 @@ class BundledSkillDefinition:
 
 _bundled_skills: list[Skill] = []
 
+# Lazy-init guard — populated on first read so callers don't need to
+# explicitly invoke ``init_bundled_skills`` at runtime startup. Tests
+# that wipe state via ``clear_bundled_skills`` also reset this flag,
+# leaving them in full control.
+_LAZY_INITIALIZED: bool = False
+
+
+def _lazy_init() -> None:
+    """Run ``init_bundled_skills`` once on first registry consumer.
+
+    Imported lazily to break the import cycle (``bundled.*`` modules
+    import from this file). The first call seeds the registry; later
+    calls are no-ops until ``clear_bundled_skills`` resets the flag.
+    """
+    global _LAZY_INITIALIZED
+    if _LAZY_INITIALIZED:
+        return
+    # Set BEFORE the import to avoid recursion if a register_*_skill
+    # callable somehow calls back into ``get_bundled_skills`` mid-init.
+    _LAZY_INITIALIZED = True
+    try:
+        from .bundled import init_bundled_skills
+        init_bundled_skills()
+    except Exception:
+        # Fail open: if a bundled-skill module is malformed at import
+        # time, surface the failure as "no bundled skills" rather than
+        # crashing every SkillTool.call.
+        logger.exception("failed to initialize bundled skills")
+
 
 def validate_skill_definition(
     definition: BundledSkillDefinition,
@@ -129,6 +158,14 @@ def skill_from_mcp_tool(
 
 
 def register_bundled_skill(definition: BundledSkillDefinition) -> None:
+    """Append a bundled-skill definition to the in-process registry.
+
+    Suppresses the lazy-init seeding for the rest of this fixture
+    cycle: if a caller (test or app) is explicitly registering, they
+    own the catalogue contents. ``clear_bundled_skills`` re-arms the
+    lazy-init flag so the next caller-driven cycle starts fresh.
+    """
+    global _LAZY_INITIALIZED
     skill = Skill(
         name=definition.name,
         description=definition.description,
@@ -148,13 +185,16 @@ def register_bundled_skill(definition: BundledSkillDefinition) -> None:
         is_hidden=not definition.user_invocable,
     )
     _bundled_skills.append(skill)
+    _LAZY_INITIALIZED = True
 
 
 def get_bundled_skills() -> list[Skill]:
+    _lazy_init()
     return list(_bundled_skills)
 
 
 def get_bundled_skill_by_name(name: str) -> Skill | None:
+    _lazy_init()
     for skill in _bundled_skills:
         if skill.name == name:
             return skill
@@ -164,4 +204,22 @@ def get_bundled_skill_by_name(name: str) -> Skill | None:
 
 
 def clear_bundled_skills() -> None:
+    """Wipe the registry and reset the lazy-init flag.
+
+    Resetting the flag ensures the next ``get_bundled_skills`` /
+    ``register_bundled_skill`` cycle re-seeds the catalogue, which is
+    what test fixtures want — otherwise a clear-then-read would return
+    an empty list and silently mask "did init_bundled_skills get
+    called?" bugs.
+    """
+    global _LAZY_INITIALIZED
     _bundled_skills.clear()
+    _LAZY_INITIALIZED = False
+    try:
+        from .bundled import reset_bundled_skills_init_flag
+        reset_bundled_skills_init_flag()
+    except Exception:
+        # If the bundled package can't import, the lazy-init flag in
+        # this module is enough; the bundled-side flag is just a
+        # belt-and-braces idempotency check.
+        pass

--- a/src/skills/frontmatter.py
+++ b/src/skills/frontmatter.py
@@ -1,7 +1,48 @@
+"""YAML frontmatter parser for SKILL.md / agent / output-style files.
+
+Replaces the prior homegrown YAML-subset parser (top-level scalars + list
+forms only) with ``yaml.safe_load`` so nested structures used by the TS
+port — most importantly ``hooks:`` and ``shell:`` blocks — round-trip
+intact. The public ``parse_frontmatter`` API is preserved.
+
+Structure of an accepted file::
+
+    ---
+    description: Some skill
+    allowed-tools:
+      - Bash(git status:*)
+      - Read
+    hooks:
+      PostToolUse:
+        - matcher: Write
+          hooks:
+            - type: command
+              command: ./scripts/format.sh
+    ---
+    <markdown body>
+
+Behavior:
+- A missing or malformed frontmatter block returns ``frontmatter={}``
+  with the original markdown intact as ``body``. We never raise; a bad
+  ``---`` fence should not block-load other skills.
+- Empty frontmatter (``---\\n---``) returns ``{}`` and the body that
+  follows.
+- ``yaml.safe_load`` is used (not ``load``) so arbitrary Python tag
+  resolution is disabled.
+"""
+
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict
+
+try:
+    import yaml  # type: ignore[import-untyped]
+except ImportError:  # pragma: no cover — yaml is a hard runtime dep
+    yaml = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -11,25 +52,19 @@ class FrontmatterParseResult:
 
 
 def parse_frontmatter(markdown: str) -> FrontmatterParseResult:
+    """Split ``---``-fenced frontmatter from a markdown document.
+
+    Returns a ``FrontmatterParseResult`` with the parsed frontmatter
+    dict and the remaining body. Files without a leading ``---`` fence
+    return an empty dict and the original markdown as the body.
     """
-    Minimal frontmatter parser supporting a safe subset of YAML-like syntax:
-    - Top-level key: value pairs
-    - Booleans: true/false (case-insensitive)
-    - Numbers: integers
-    - Lists via inline bracket form:
-        key: [item1, item2]
-    - Lists via hyphen form:
-        key:
-          - item1
-          - item2
-    - Lists via comma-separated shorthand:
-        key: a, b, c
-    Any unsupported structure falls back to a string.
-    """
+    if not markdown:
+        return FrontmatterParseResult(frontmatter={}, body=markdown or "")
+
     lines = markdown.splitlines()
     if len(lines) < 3 or lines[0].strip() != "---":
         return FrontmatterParseResult(frontmatter={}, body=markdown)
-    # Find closing ---
+
     end_idx = None
     for i in range(1, len(lines)):
         if lines[i].strip() == "---":
@@ -38,70 +73,36 @@ def parse_frontmatter(markdown: str) -> FrontmatterParseResult:
     if end_idx is None:
         return FrontmatterParseResult(frontmatter={}, body=markdown)
 
-    fm_lines = lines[1:end_idx]
+    fm_raw = "\n".join(lines[1:end_idx])
     body = "\n".join(lines[end_idx + 1 :])
-    fm: Dict[str, Any] = {}
-    i = 0
-    while i < len(fm_lines):
-        line = fm_lines[i]
-        if not line.strip():
-            i += 1
-            continue
-        if ":" not in line:
-            i += 1
-            continue
-        key, value = _split_key_value(line)
-        # List (hyphen form)
-        if value == "" and i + 1 < len(fm_lines) and fm_lines[i + 1].lstrip().startswith("- "):
-            items: List[str] = []
-            i += 1
-            while i < len(fm_lines):
-                item_line = fm_lines[i]
-                if item_line.lstrip().startswith("- "):
-                    items.append(item_line.lstrip()[2:].strip())
-                    i += 1
-                else:
-                    break
-            fm[key] = [_coerce_scalar(x) for x in items]
-            continue
-        inline_list = _parse_inline_list(value)
-        if inline_list is not None:
-            fm[key] = inline_list
-            i += 1
-            continue
-        # Comma-separated list
-        if "," in value:
-            fm[key] = [_coerce_scalar(v.strip()) for v in value.split(",") if v.strip()]
-        else:
-            fm[key] = _coerce_scalar(value.strip())
-        i += 1
-    return FrontmatterParseResult(frontmatter=fm, body=body)
 
+    if not fm_raw.strip():
+        return FrontmatterParseResult(frontmatter={}, body=body)
 
-def _split_key_value(line: str) -> Tuple[str, str]:
-    idx = line.find(":")
-    key = line[:idx].strip()
-    value = line[idx + 1 :].strip()
-    return key, value
+    if yaml is None:
+        # Defensive — ``pyproject.toml`` declares PyYAML as a hard
+        # dependency, so this branch only runs in degraded installs.
+        logger.warning(
+            "PyYAML not available; frontmatter parser cannot read nested "
+            "structures (hooks / shell will be silently dropped). "
+            "Install PyYAML to enable full parsing."
+        )
+        return FrontmatterParseResult(frontmatter={}, body=body)
 
+    try:
+        parsed = yaml.safe_load(fm_raw)
+    except yaml.YAMLError as exc:
+        logger.debug("frontmatter YAML parse failed: %s", exc)
+        return FrontmatterParseResult(frontmatter={}, body=body)
 
-def _coerce_scalar(value: str) -> Any:
-    low = value.lower()
-    if low in ("true", "false"):
-        return low == "true"
-    if value.isdigit():
-        try:
-            return int(value)
-        except Exception:
-            pass
-    return value
+    if parsed is None:
+        return FrontmatterParseResult(frontmatter={}, body=body)
+    if not isinstance(parsed, dict):
+        # Top-level scalar / list — not a frontmatter shape we recognize.
+        logger.debug(
+            "frontmatter parsed as %s, expected dict; ignoring",
+            type(parsed).__name__,
+        )
+        return FrontmatterParseResult(frontmatter={}, body=body)
 
-
-def _parse_inline_list(value: str) -> List[Any] | None:
-    stripped = value.strip()
-    if len(stripped) < 2 or not stripped.startswith("[") or not stripped.endswith("]"):
-        return None
-    inner = stripped[1:-1].strip()
-    if not inner:
-        return []
-    return [_coerce_scalar(part.strip()) for part in inner.split(",") if part.strip()]
+    return FrontmatterParseResult(frontmatter=parsed, body=body)

--- a/src/skills/loader.py
+++ b/src/skills/loader.py
@@ -63,38 +63,276 @@ def _get_skill_command_name(file_path: str, base_dir: str) -> str:
     return f"{namespace}:{command_base_name}" if namespace else command_base_name
 
 
+# ----------------------------------------------------------------------
+# Field validators (mirrored from TS)
+#
+# These ride alongside ``parse_skill_frontmatter_fields`` and degrade
+# gracefully — a bad value logs a debug warning and either drops the
+# field (``None``) or keeps a permissive coerced value, mirroring TS
+# behavior of "fall back to default; never block-load the skill".
+# ----------------------------------------------------------------------
+
+# Mirrors TS ``EFFORT_LEVELS`` (utils/effort.ts).
+EFFORT_LEVELS: frozenset[str] = frozenset({"low", "medium", "high", "max"})
+
+# Mirrors TS ``FRONTMATTER_SHELLS`` (utils/frontmatterParser.ts).
+FRONTMATTER_SHELLS: frozenset[str] = frozenset({"bash", "powershell"})
+
+
+def _extract_description_from_markdown(content: str, default: str) -> str:
+    """Port of TS ``extractDescriptionFromMarkdown``.
+
+    Pulls the first non-empty line, strips a leading ``#`` heading
+    prefix, and clamps to 100 chars (the TS limit) with a trailing
+    ``...`` ellipsis when truncated. Falls back to ``default`` if no
+    content line is found.
+    """
+    for line in (content or "").splitlines():
+        trimmed = line.strip()
+        if not trimmed:
+            continue
+        # Strip ``#``/``##``/etc. heading prefix
+        m = re.match(r"^#+\s+(.+)$", trimmed)
+        text = m.group(1) if m else trimmed
+        if len(text) > 100:
+            return text[:97] + "..."
+        return text
+    return default
+
+
+def _coerce_description(
+    raw: Any, markdown_content: str, resolved_name: str
+) -> tuple[str, bool]:
+    """Return ``(description, has_user_specified_description)``.
+
+    Precedence: explicit frontmatter ``description`` > first-line of
+    markdown body > generated ``Skill: <name>`` placeholder.
+    """
+    if raw is None or raw == "":
+        body_desc = _extract_description_from_markdown(
+            markdown_content, default=f"Skill: {resolved_name}"
+        )
+        return body_desc, False
+
+    if isinstance(raw, list):
+        return " ".join(str(x) for x in raw), True
+    return str(raw), True
+
+
+def _coerce_bool(value: Any, *, default: bool) -> bool:
+    """Coerce a YAML scalar to bool; falls back to ``default`` for
+    non-recognized values."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.lower() in ("true", "yes", "1")
+    return default
+
+
+def _coerce_allowed_tools(value: Any) -> list[str]:
+    """Parse the ``allowed-tools`` field.
+
+    Accepts a string (comma-separated) or a list. Each entry can be a
+    bare tool name (``Read``) or a tool with a parenthesized arg pattern
+    (``Bash(git status:*)``). Both forms are preserved verbatim so the
+    permission layer can apply its own matching semantics.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [t.strip() for t in value.split(",") if t.strip()]
+    if isinstance(value, list):
+        return [str(t).strip() for t in value if str(t).strip()]
+    return []
+
+
+def _coerce_model(value: Any) -> str | None:
+    """Validate the ``model`` field.
+
+    ``inherit`` / falsy → ``None`` (use caller default). Otherwise
+    return as a string. Logs a debug warning when the value isn't in
+    ``MODEL_ALIASES`` AND doesn't look like a canonical provider model
+    (``claude-``, ``gpt-``, ``o1-``, etc.) — but always keeps the value
+    so the user can pin a brand-new model that the alias table hasn't
+    learned about yet.
+    """
+    if value is None or value == "" or value == "inherit":
+        return None
+    s = str(value).strip()
+    if not s:
+        return None
+
+    try:
+        from src.models.aliases import MODEL_ALIASES
+        known_aliases = set(MODEL_ALIASES.keys())
+    except Exception:
+        known_aliases = set()
+
+    lower = s.lower()
+    looks_canonical = any(
+        lower.startswith(prefix)
+        for prefix in (
+            "claude-", "gpt-", "o1-", "o3-", "o4-",
+            "grok-", "gemini-", "deepseek-", "glm-", "qwen-",
+        )
+    )
+    if lower not in known_aliases and not looks_canonical:
+        logger.warning(
+            "skill frontmatter model %r is not a recognized alias or "
+            "canonical model name; keeping as-is",
+            s,
+        )
+    return s
+
+
+def _coerce_effort(value: Any) -> str | None:
+    """Port of TS ``parseEffortValue``.
+
+    Accepts:
+      - One of ``EFFORT_LEVELS`` (case-insensitive) → returned lowercased.
+      - An integer (or numeric string) → returned as a string.
+    Anything else logs a warning and returns ``None`` (mirrors TS
+    "drop on invalid").
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        # bool is a subclass of int in Python — exclude explicitly
+        logger.warning("skill frontmatter effort=%r is not a valid level", value)
+        return None
+    if isinstance(value, int):
+        return str(value)
+    s = str(value).strip().lower()
+    if not s:
+        return None
+    if s in EFFORT_LEVELS:
+        return s
+    try:
+        n = int(s, 10)
+        return str(n)
+    except (TypeError, ValueError):
+        pass
+    logger.warning(
+        "skill frontmatter effort=%r is not a valid level "
+        "(expected one of %s or an integer); dropping",
+        value,
+        sorted(EFFORT_LEVELS),
+    )
+    return None
+
+
+def _coerce_shell(value: Any) -> str | None:
+    """Port of TS ``parseShellFrontmatter`` — accepts ``bash`` /
+    ``powershell``; logs and drops anything else."""
+    if value is None or value == "":
+        return None
+    s = str(value).strip().lower()
+    if not s:
+        return None
+    if s in FRONTMATTER_SHELLS:
+        return s
+    logger.warning(
+        "skill frontmatter shell=%r is not recognized "
+        "(valid: %s); falling back to default",
+        value,
+        sorted(FRONTMATTER_SHELLS),
+    )
+    return None
+
+
+def _coerce_hooks(value: Any, *, skill_name: str) -> dict | None:
+    """Validate the ``hooks:`` frontmatter dict against the rough TS
+    schema (``Partial<Record<HookEvent, HookMatcher[]>>``).
+
+    Schema (loose check, no Zod equivalent):
+      hooks:
+        <HookEvent>:               # one of ALL_HOOK_EVENTS
+          - matcher: <str>         # optional
+            hooks:                 # required, list
+              - type: <str>        # required ("command" / "agent" / ...)
+                ...                # other shape-specific fields
+                                   #   (passed through verbatim)
+
+    Returns the parsed dict on shape-match. Returns ``None`` (and logs
+    a debug message) on any structural mismatch — the SkillTool can
+    keep loading the skill, just without the hooks.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        logger.debug(
+            "skill %r hooks: expected dict, got %s; dropping",
+            skill_name,
+            type(value).__name__,
+        )
+        return None
+
+    try:
+        from src.hooks.hook_types import ALL_HOOK_EVENTS
+        valid_events = set(ALL_HOOK_EVENTS)
+    except Exception:
+        valid_events = set()
+
+    for event_name, matchers in value.items():
+        if valid_events and event_name not in valid_events:
+            logger.debug(
+                "skill %r hooks: unknown event %r; dropping all hooks",
+                skill_name,
+                event_name,
+            )
+            return None
+        if not isinstance(matchers, list):
+            logger.debug(
+                "skill %r hooks.%s: expected list of matchers, got %s",
+                skill_name,
+                event_name,
+                type(matchers).__name__,
+            )
+            return None
+        for matcher in matchers:
+            if not isinstance(matcher, dict):
+                logger.debug(
+                    "skill %r hooks.%s: matcher must be a dict",
+                    skill_name,
+                    event_name,
+                )
+                return None
+            inner = matcher.get("hooks")
+            if not isinstance(inner, list):
+                logger.debug(
+                    "skill %r hooks.%s.hooks: required list missing or wrong type",
+                    skill_name,
+                    event_name,
+                )
+                return None
+            for cmd in inner:
+                if not isinstance(cmd, dict) or "type" not in cmd:
+                    logger.debug(
+                        "skill %r hooks.%s.hooks[]: each entry needs a `type` field",
+                        skill_name,
+                        event_name,
+                    )
+                    return None
+
+    return value
+
+
 def parse_skill_frontmatter_fields(
     frontmatter: dict[str, Any],
     markdown_content: str,
     resolved_name: str,
 ) -> dict[str, Any]:
-    raw_desc = frontmatter.get("description", "")
-    if isinstance(raw_desc, list):
-        description = " ".join(str(x) for x in raw_desc)
-    elif raw_desc:
-        description = str(raw_desc)
-    else:
-        description = f"Skill: {resolved_name}"
+    raw_desc = frontmatter.get("description")
+    description, has_user_specified_description = _coerce_description(
+        raw_desc, markdown_content, resolved_name
+    )
 
-    user_invocable = frontmatter.get("user-invocable", True)
-    if isinstance(user_invocable, str):
-        user_invocable = user_invocable.lower() in ("true", "yes", "1")
-    elif not isinstance(user_invocable, bool):
-        user_invocable = True
+    user_invocable = _coerce_bool(frontmatter.get("user-invocable", True), default=True)
+    disable_model = _coerce_bool(
+        frontmatter.get("disable-model-invocation", False), default=False
+    )
 
-    disable_model = frontmatter.get("disable-model-invocation", False)
-    if isinstance(disable_model, str):
-        disable_model = disable_model.lower() in ("true", "yes", "1")
-    elif not isinstance(disable_model, bool):
-        disable_model = False
-
-    allowed_tools_raw = frontmatter.get("allowed-tools", [])
-    if isinstance(allowed_tools_raw, str):
-        allowed_tools = [t.strip() for t in allowed_tools_raw.split(",") if t.strip()]
-    elif isinstance(allowed_tools_raw, list):
-        allowed_tools = [str(t) for t in allowed_tools_raw]
-    else:
-        allowed_tools = []
+    allowed_tools = _coerce_allowed_tools(frontmatter.get("allowed-tools"))
 
     argument_names = parse_argument_names(frontmatter.get("arguments"))
 
@@ -106,10 +344,7 @@ def parse_skill_frontmatter_fields(
     if version is not None:
         version = str(version)
 
-    model_raw = frontmatter.get("model")
-    model = None
-    if model_raw and model_raw != "inherit":
-        model = str(model_raw)
+    model = _coerce_model(frontmatter.get("model"))
 
     context = frontmatter.get("context", "inline")
     execution_context = "fork" if context == "fork" else None
@@ -118,9 +353,11 @@ def parse_skill_frontmatter_fields(
     if agent is not None:
         agent = str(agent)
 
-    effort = frontmatter.get("effort")
-    if effort is not None:
-        effort = str(effort)
+    effort = _coerce_effort(frontmatter.get("effort"))
+
+    shell = _coerce_shell(frontmatter.get("shell"))
+
+    hooks = _coerce_hooks(frontmatter.get("hooks"), skill_name=resolved_name)
 
     argument_hint_raw = frontmatter.get("argument-hint")
     argument_hint = str(argument_hint_raw) if argument_hint_raw is not None else None
@@ -147,7 +384,7 @@ def parse_skill_frontmatter_fields(
     return {
         "display_name": display_name,
         "description": description,
-        "has_user_specified_description": bool(raw_desc),
+        "has_user_specified_description": has_user_specified_description,
         "allowed_tools": allowed_tools,
         "argument_hint": argument_hint,
         "argument_names": argument_names,
@@ -160,6 +397,8 @@ def parse_skill_frontmatter_fields(
         "agent": agent,
         "effort": effort,
         "paths": paths,
+        "hooks": hooks,
+        "shell": shell,
     }
 
 
@@ -185,6 +424,8 @@ def create_skill_command(
     agent: str | None = None,
     paths: list[str] | None = None,
     effort: str | None = None,
+    hooks: dict | None = None,
+    shell: str | None = None,
 ) -> Skill:
     return Skill(
         name=skill_name,
@@ -212,6 +453,8 @@ def create_skill_command(
         has_user_specified_description=has_user_specified_description,
         base_dir=base_dir,
         markdown_content=markdown_content,
+        hooks=hooks,
+        shell=shell,
     )
 
 
@@ -277,10 +520,33 @@ def _find_skill_markdown_files(base_path: str) -> list[str]:
     return skill_files
 
 
+_SOURCE_TO_LOADED_FROM: dict[str, str] = {
+    "policySettings": "managed",
+    "userSettings": "user",
+    "projectSettings": "project",
+    "plugin": "plugin",
+}
+
+
 def load_skills_from_skills_dir(
     base_path: str,
     source: str,
+    *,
+    loaded_from: str | None = None,
 ) -> list[Skill]:
+    """Load every ``SKILL.md`` under ``base_path`` recursively.
+
+    ``loaded_from`` defaults to a friendly label derived from ``source``
+    (``policySettings`` -> ``managed``, ``userSettings`` -> ``user``,
+    ``projectSettings`` -> ``project``). Callers can pass an explicit
+    string to override (used by the legacy registry path).
+    """
+    resolved_loaded_from = (
+        loaded_from
+        if loaded_from is not None
+        else _SOURCE_TO_LOADED_FROM.get(source, "skills")
+    )
+
     skill_files = _find_skill_markdown_files(base_path)
     skills: list[Skill] = []
 
@@ -318,11 +584,13 @@ def load_skills_from_skills_dir(
             user_invocable=parsed["user_invocable"],
             source=source,
             base_dir=str(Path(skill_file_path).parent),
-            loaded_from="skills",
+            loaded_from=resolved_loaded_from,
             execution_context=parsed["execution_context"],
             agent=parsed["agent"],
             paths=parsed["paths"],
             effort=parsed["effort"],
+            hooks=parsed.get("hooks"),
+            shell=parsed.get("shell"),
         )
         skills.append(skill)
 
@@ -347,39 +615,208 @@ def _get_project_skills_dirs(cwd: str) -> list[str]:
 _skill_dir_cache: dict[str, list[Skill]] = {}
 
 
+# ----------------------------------------------------------------------
+# Bare mode + policy plumbing
+#
+# Mirrors TS' `isBareMode()` / `CLAUDE_CODE_DISABLE_POLICY_SKILLS` /
+# `isRestrictedToPluginOnly('skills')` gates so the Python loader honors
+# the same env-driven safety flags. We reuse the existing
+# `_is_bare_mode` / `_get_additional_directories` semantics already
+# established by `src/context_system/claude_md.py` rather than inventing
+# parallel ones.
+# ----------------------------------------------------------------------
+
+
+def _is_bare_mode() -> bool:
+    """True when ``CLAUDE_CODE_BARE_MODE`` is set (matches CLAUDE.md path).
+
+    Bare mode skips autodiscovery entirely; only ``--add-dir`` paths
+    contribute disk skills. Bundled/MCP skills are unaffected (they go
+    through `get_all_skills`'s separate merge path).
+    """
+    return os.environ.get("CLAUDE_CODE_BARE_MODE", "").lower() in ("1", "true", "yes")
+
+
+def _is_skills_policy_disabled() -> bool:
+    """True when ``CLAUDE_CODE_DISABLE_POLICY_SKILLS`` is set.
+
+    Mirrors the TS check at `loadSkillsDir.ts:771`. When set, the
+    managed/policy skills directory (`/etc/claude/.claude/skills`) is
+    skipped — useful for opting out of admin-distributed skills on
+    multi-tenant machines.
+    """
+    return os.environ.get("CLAUDE_CODE_DISABLE_POLICY_SKILLS", "").lower() in (
+        "1", "true", "yes",
+    )
+
+
+def _is_restricted_to_plugin_only(scope: str) -> bool:
+    """Stub for the TS `isRestrictedToPluginOnly(scope)` policy gate.
+
+    The TS implementation is policy-driven (managed settings can lock
+    skills/agents/etc. to plugin-supplied entries only). The Python port
+    has no policy plumbing yet, so this returns False — equivalent to
+    "policy unset; allow normal discovery". Plugin-policy support can
+    flip this in a future task without touching call sites.
+    """
+    _ = scope  # documented hook for future plugin policy
+    return False
+
+
+def _get_additional_skill_dirs() -> list[str]:
+    """Read ``--add-dir`` paths from ``CLAUDE_CODE_ADDITIONAL_DIRECTORIES``.
+
+    Each entry maps to ``<dir>/.claude/skills`` for skill loading
+    (matches TS `additionalSkillsNested` block).
+    """
+    val = os.environ.get("CLAUDE_CODE_ADDITIONAL_DIRECTORIES", "")
+    if not val:
+        return []
+    return [d.strip() for d in val.split(os.pathsep) if d.strip()]
+
+
+def _get_file_identity(path: str) -> str | None:
+    """Return a stable identity for ``path`` (resolved via realpath).
+
+    Mirrors TS `getFileIdentity` (`loadSkillsDir.ts:118`). Uses
+    realpath so symlinked-and-overlapping mounts collapse to the same
+    identity. Returns ``None`` on broken-symlink / OSError so the caller
+    can fail open (i.e., keep the skill rather than drop it on a stat
+    failure).
+    """
+    try:
+        return os.path.realpath(path)
+    except (OSError, ValueError):
+        return None
+
+
 def get_skill_dir_commands(cwd: str) -> list[Skill]:
+    """Return the union of disk-loaded skills, deduped by realpath identity.
+
+    Behavior matches TS `loadSkillsFromSkillsDir` (line 720+):
+      - Bare mode: load only ``--add-dir`` paths; skip everything else.
+      - Policy disabled: skip the managed/`/etc/claude` dir.
+      - Plugin-only restriction: collapses user + project loads to empty
+        (the gate currently always returns False; future hook).
+      - Order: managed → user → project → additional. Realpath dedup is
+        first-wins so the same SKILL.md file accessed via overlapping
+        sources (symlinks, bind mounts) collapses to one entry.
+
+    The cwd-keyed cache is preserved; cache invalidation goes through
+    ``clear_skill_caches``.
+    """
     if cwd in _skill_dir_cache:
         return list(_skill_dir_cache[cwd])
 
-    user_skills_dir = str(_get_global_config_dir() / "skills")
+    additional_dirs = _get_additional_skill_dirs()
+    plugin_only = _is_restricted_to_plugin_only("skills")
+
+    # --- Bare mode short-circuit --------------------------------------
+    if _is_bare_mode():
+        if not additional_dirs or plugin_only:
+            logger.debug(
+                "[skills] bare mode active; skipping discovery "
+                "(additional_dirs=%d plugin_only=%s)",
+                len(additional_dirs),
+                plugin_only,
+            )
+            _skill_dir_cache[cwd] = []
+            return []
+        bare_skills: list[Skill] = []
+        for d in additional_dirs:
+            skills_dir = str(Path(d) / ".claude" / "skills")
+            bare_skills.extend(
+                load_skills_from_skills_dir(skills_dir, "projectSettings")
+            )
+        unconditional = _split_conditional(bare_skills)
+        _skill_dir_cache[cwd] = unconditional
+        return list(unconditional)
+
+    # --- Standard discovery -------------------------------------------
     managed_skills_dir = str(_get_managed_file_path() / ".claude" / "skills")
+    user_skills_dir = str(_get_global_config_dir() / "skills")
     project_skills_dirs = _get_project_skills_dirs(cwd)
 
-    managed_skills = load_skills_from_skills_dir(managed_skills_dir, "policySettings")
-    user_skills = load_skills_from_skills_dir(user_skills_dir, "userSettings")
+    managed_skills: list[Skill] = []
+    if not _is_skills_policy_disabled():
+        managed_skills = load_skills_from_skills_dir(
+            managed_skills_dir, "policySettings"
+        )
 
+    user_skills: list[Skill] = []
     project_skills: list[Skill] = []
-    for d in project_skills_dirs:
-        project_skills.extend(load_skills_from_skills_dir(d, "projectSettings"))
+    if not plugin_only:
+        user_skills = load_skills_from_skills_dir(user_skills_dir, "userSettings")
+        for d in project_skills_dirs:
+            project_skills.extend(
+                load_skills_from_skills_dir(d, "projectSettings")
+            )
 
-    all_skills = managed_skills + user_skills + project_skills
+    additional_skills: list[Skill] = []
+    if not plugin_only:
+        for d in additional_dirs:
+            skills_dir = str(Path(d) / ".claude" / "skills")
+            additional_skills.extend(
+                load_skills_from_skills_dir(skills_dir, "projectSettings")
+            )
 
-    seen_names: set[str] = set()
-    deduped: list[Skill] = []
-    for skill in all_skills:
-        if skill.name not in seen_names:
-            seen_names.add(skill.name)
-            deduped.append(skill)
+    all_skills = managed_skills + user_skills + project_skills + additional_skills
 
+    deduped = _dedup_by_realpath(all_skills)
+    unconditional = _split_conditional(deduped)
+
+    _skill_dir_cache[cwd] = unconditional
+    return list(unconditional)
+
+
+def _dedup_by_realpath(skills: list[Skill]) -> list[Skill]:
+    """First-wins dedup keyed on each skill's resolved SKILL.md path.
+
+    Matches TS `loadSkillsDir.ts:813-848`. Skills whose `base_dir` can't
+    be resolved (broken symlink, OSError) fall through unchanged — fail
+    open, mirroring TS' `null` identity branch.
+    """
+    seen: dict[str, Skill] = {}
+    out: list[Skill] = []
+    for skill in skills:
+        skill_md = (
+            str(Path(skill.base_dir) / "SKILL.md")
+            if skill.base_dir
+            else None
+        )
+        identity = _get_file_identity(skill_md) if skill_md else None
+        if identity is None:
+            out.append(skill)
+            continue
+        existing = seen.get(identity)
+        if existing is not None:
+            logger.debug(
+                "[skills] dropping duplicate %r from %s "
+                "(same SKILL.md already loaded from %s)",
+                skill.name,
+                skill.source,
+                existing.source,
+            )
+            continue
+        seen[identity] = skill
+        out.append(skill)
+    return out
+
+
+def _split_conditional(skills: list[Skill]) -> list[Skill]:
+    """Move conditional (paths-gated) skills to ``_conditional_skills``.
+
+    Returns the list of unconditional skills. Conditional ones become
+    visible only after `activate_conditional_skills_for_paths` matches
+    a touched file against their `paths:` patterns.
+    """
     unconditional: list[Skill] = []
-    for skill in deduped:
+    for skill in skills:
         if not skill.is_conditional:
             unconditional.append(skill)
         else:
             _conditional_skills[skill.name] = skill
-
-    _skill_dir_cache[cwd] = unconditional
-    return list(unconditional)
+    return unconditional
 
 
 _conditional_skills: dict[str, Skill] = {}
@@ -392,10 +829,41 @@ def get_dynamic_skills() -> list[Skill]:
     return list(_dynamic_skills.values())
 
 
+def _is_path_gitignored(path: str, cwd: str) -> bool:
+    """Return True iff git considers ``path`` ignored.
+
+    Mirrors TS `isPathGitignored` (`utils/git/gitignore.ts`) — shells out
+    to ``git check-ignore <path>`` and treats exit 0 as ignored, exit 1
+    as not-ignored, anything else (e.g. exit 128 outside a git repo) as
+    not-ignored. Fails open on subprocess errors so non-git workspaces
+    keep working.
+    """
+    import subprocess
+    try:
+        result = subprocess.run(
+            ["git", "check-ignore", path],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, OSError):
+        return False
+    return result.returncode == 0
+
+
 def discover_skill_dirs_for_paths(
     file_paths: list[str],
     cwd: str,
 ) -> list[str]:
+    """Walk parent dirs of each touched file looking for `.claude/skills`.
+
+    Mirrors TS `discoverSkillDirsForPaths` (`loadSkillsDir.ts:951+`).
+    Each newly-found skills dir whose containing folder is gitignored is
+    skipped (e.g. `node_modules/pkg/.claude/skills` won't load silently);
+    `git check-ignore` handles nested `.gitignore` and global rules with
+    correct precedence. Fails open outside a git repo.
+    """
     resolved_cwd = cwd.rstrip(os.sep)
     new_dirs: list[str] = []
 
@@ -407,7 +875,13 @@ def discover_skill_dirs_for_paths(
             if skill_dir not in _dynamic_skill_dirs:
                 _dynamic_skill_dirs.add(skill_dir)
                 if Path(skill_dir).is_dir():
-                    new_dirs.append(skill_dir)
+                    if _is_path_gitignored(current_dir, resolved_cwd):
+                        logger.debug(
+                            "[skills] Skipped gitignored skills dir: %s",
+                            skill_dir,
+                        )
+                    else:
+                        new_dirs.append(skill_dir)
 
             parent = str(Path(current_dir).parent)
             if parent == current_dir:
@@ -430,33 +904,93 @@ def activate_conditional_skills_for_paths(
     file_paths: list[str],
     cwd: str,
 ) -> list[str]:
+    """Promote conditional skills whose ``paths:`` patterns match.
+
+    Path matching uses gitignore semantics via ``pathspec`` (TS uses the
+    `ignore` library) — supports ``**`` recursion, anchoring, negation,
+    etc. Each skill's full ``paths:`` list compiles into a single
+    `PathSpec` that the touched files match against; skills where any
+    pattern matches any file get moved out of `_conditional_skills`
+    into `_dynamic_skills`.
+
+    Path-validity guards from TS:
+      - Skip empty rel-paths.
+      - Skip ``..``-prefixed paths (file escaped the workspace).
+      - Skip absolute paths (Windows cross-drive).
+    """
     if not _conditional_skills:
+        return []
+
+    # Pre-resolve relative paths once per file_path so we don't repeat
+    # the work for each conditional skill. Filter invalid entries here.
+    rel_paths: list[str] = []
+    for file_path in file_paths:
+        rel_path = os.path.relpath(file_path, cwd)
+        if not rel_path or rel_path.startswith("..") or os.path.isabs(rel_path):
+            continue
+        rel_paths.append(rel_path)
+
+    if not rel_paths:
         return []
 
     activated: list[str] = []
     for name, skill in list(_conditional_skills.items()):
         if not skill.paths:
             continue
-        for file_path in file_paths:
-            rel_path = os.path.relpath(file_path, cwd)
-            if rel_path.startswith("..") or os.path.isabs(rel_path):
-                continue
-            for pattern in skill.paths:
-                if _path_matches_pattern(rel_path, pattern):
-                    _dynamic_skills[name] = skill
-                    del _conditional_skills[name]
-                    _activated_conditional_names.add(name)
-                    activated.append(name)
-                    break
-            if name in activated:
+        spec = _compile_path_spec(skill.paths)
+        if spec is None:
+            continue
+        for rel_path in rel_paths:
+            if spec.match_file(rel_path):
+                _dynamic_skills[name] = skill
+                del _conditional_skills[name]
+                _activated_conditional_names.add(name)
+                activated.append(name)
                 break
 
     return activated
 
 
+def _compile_path_spec(patterns: list[str]):
+    """Compile a list of gitwildmatch patterns into a ``PathSpec``.
+
+    Returns ``None`` (and logs at debug) if pathspec isn't installed or
+    the patterns can't compile. The unconditional-skill path treats this
+    as a no-match — better than crashing the activation loop.
+    """
+    try:
+        import pathspec
+    except ImportError:  # pragma: no cover — pathspec is a hard dep
+        logger.debug(
+            "pathspec not installed; conditional `paths:` matching disabled"
+        )
+        return None
+    # Prefer the modern ``gitignore`` pattern factory (pathspec >= 1.0)
+    # which subsumes the legacy ``gitwildmatch`` and emits no deprecation
+    # warning. Fall back to ``gitwildmatch`` for older pathspec versions.
+    for factory in ("gitignore", "gitwildmatch"):
+        try:
+            return pathspec.PathSpec.from_lines(factory, patterns)
+        except (LookupError, KeyError):
+            continue
+        except Exception as exc:
+            logger.debug("failed to compile path spec %r: %s", patterns, exc)
+            return None
+    return None
+
+
 def _path_matches_pattern(path: str, pattern: str) -> bool:
-    import fnmatch
-    return fnmatch.fnmatch(path, pattern) or fnmatch.fnmatch(path, pattern + "/**")
+    """Legacy single-pattern matcher kept for backward compat.
+
+    Uses pathspec under the hood now (so ``src/**/*.py`` works correctly
+    against ``src/foo/bar.py``); the prior `fnmatch`-based impl missed
+    those cases. New code should prefer building a `PathSpec` once and
+    calling `.match_file(...)` directly.
+    """
+    spec = _compile_path_spec([pattern])
+    if spec is None:
+        return False
+    return spec.match_file(path)
 
 
 def clear_skill_caches() -> None:
@@ -476,122 +1010,88 @@ def get_conditional_skill_count() -> int:
     return len(_conditional_skills)
 
 
-from .model import PromptSkill  # noqa: E402
+# ----------------------------------------------------------------------
+# Unified skill registry
+#
+# Historically this module had two parallel disk-loading paths: the
+# TS-port branch (above) that produced rich `Skill` objects with nested
+# namespace support, and a second branch that produced `PromptSkill`
+# objects via `load_skills_from_dir` and populated `_skill_registry`.
+# Only the second registry was wired into `SkillTool`, so everything
+# loaded by the TS-port path was invisible to the model.
+#
+# `Skill` and `PromptSkill` are now the same class (see model.py).
+# `get_all_skills` delegates to `get_skill_dir_commands` for the
+# managed/user/project disk layout, then merges in bundled skills, MCP
+# skills, and any legacy clawcodex-specific directories. The unified
+# result is cached in `_skill_registry` so `get_registered_skill`
+# (used by `SkillTool`) continues to work and now sees every skill.
+# ----------------------------------------------------------------------
 
-_skill_registry: dict[str, PromptSkill] = {}
+from .model import PromptSkill  # noqa: E402  (re-exported for back-compat)
+from .bundled_skills import get_bundled_skills, get_bundled_skill_by_name  # noqa: E402
+
+_skill_registry: dict[str, Skill] = {}
 
 
 def clear_skill_registry() -> None:
     _skill_registry.clear()
 
 
-def _candidate_user_skills_dirs() -> list[Path]:
+def _legacy_user_skill_dirs(
+    user_skills_dir: str | Path | None,
+) -> list[Path]:
+    """Resolve the legacy clawcodex user-skill locations.
+
+    The TS-port loader walks `~/.claude/skills` (handled inside
+    `get_skill_dir_commands`). This function returns the additional
+    clawcodex-specific dirs plus any env overrides so existing setups
+    that drop skills under `CLAWCODEX_SKILLS_DIR` or `~/.clawcodex/skills`
+    continue to work.
+    """
+    dirs: list[Path] = []
+
+    if user_skills_dir is not None:
+        dirs.append(Path(user_skills_dir).expanduser().resolve())
+        return dirs
+
     env_primary = os.environ.get("CLAWCODEX_SKILLS_DIR")
     env_ts = os.environ.get("CLAUDE_SKILLS_DIR")
-    dirs: list[Path] = []
     if env_primary:
         dirs.append(Path(env_primary).expanduser().resolve())
     if env_ts:
         p = Path(env_ts).expanduser().resolve()
         if p not in dirs:
             dirs.append(p)
-    for d in (Path.home() / ".clawcodex" / "skills", Path.home() / ".claude" / "skills"):
-        p = d.expanduser().resolve()
-        if p not in dirs:
-            dirs.append(p)
+
+    clawcodex_dir = (Path.home() / ".clawcodex" / "skills").expanduser().resolve()
+    if clawcodex_dir not in dirs:
+        dirs.append(clawcodex_dir)
+
     return dirs
 
 
-def _as_str_list(val: Any) -> list[str]:
-    if val is None:
-        return []
-    if isinstance(val, list):
-        return [str(x) for x in val if str(x)]
-    if isinstance(val, str):
-        s = val.strip()
-        if not s:
-            return []
-        if "," in s:
-            return [x.strip() for x in s.split(",") if x.strip()]
-        return [s]
-    return [str(val)]
+def _legacy_project_skill_dirs(project_root: str | Path) -> list[Path]:
+    """Resolve clawcodex-specific project skill dirs.
+
+    `.claude/skills` is already handled by `get_skill_dir_commands`; here
+    we add `.clawcodex/skills` as a sibling so the legacy layout still
+    works.
+    """
+    pr = Path(project_root).expanduser().resolve()
+    return [pr / ".clawcodex" / "skills"]
 
 
-def _extract_description(body: str) -> str | None:
-    for line in body.splitlines():
-        stripped = line.strip()
-        if not stripped:
-            continue
-        if stripped.startswith("#"):
-            continue
-        return stripped[:200]
-    return None
-
-
-def load_skills_from_dir(
-    base_dir: str | Path, *, loaded_from: str = "skills"
-) -> list[PromptSkill]:
-    base = Path(base_dir).expanduser().resolve()
-    if not base.exists() or not base.is_dir():
-        return []
-
-    skills: list[PromptSkill] = []
-    for entry in sorted(base.iterdir()):
-        if not entry.is_dir():
-            continue
-        skill_name = entry.name
-        md_path = entry / "SKILL.md"
-        if not md_path.exists():
-            continue
-        content = md_path.read_text(encoding="utf-8")
-        parsed_fm = parse_frontmatter(content)
-        fm = parsed_fm.frontmatter
-        body = parsed_fm.body
-
-        description = str(
-            fm.get("description") or _extract_description(body) or f"Skill: {skill_name}"
+def _load_dirs_as(
+    dirs: Sequence[Path | str],
+    source: str,
+    loaded_from: str,
+) -> list[Skill]:
+    skills: list[Skill] = []
+    for d in dirs:
+        skills.extend(
+            load_skills_from_skills_dir(str(d), source, loaded_from=loaded_from)
         )
-        user_invocable = bool(fm.get("user-invocable", True))
-        disable_model_invocation = bool(fm.get("disable-model-invocation", False))
-        when_to_use = fm.get("when_to_use")
-        when_to_use = str(when_to_use) if when_to_use is not None else None
-        version = fm.get("version")
-        version = str(version) if version is not None else None
-        model = fm.get("model")
-        model = str(model) if model is not None else None
-
-        allowed_tools = _as_str_list(fm.get("allowed-tools"))
-        arg_names = parse_argument_names(fm.get("arguments"))
-        context = "fork" if str(fm.get("context", "")).lower() == "fork" else "inline"
-        agent_val = fm.get("agent")
-        agent_val = str(agent_val) if agent_val is not None else None
-        effort_val = fm.get("effort")
-        effort_val = str(effort_val) if effort_val is not None else None
-        paths_val = _as_str_list(fm.get("paths"))
-        if paths_val == []:
-            paths_val = None
-
-        skill = PromptSkill(
-            name=skill_name,
-            description=description,
-            loaded_from=loaded_from,
-            user_invocable=user_invocable,
-            disable_model_invocation=disable_model_invocation,
-            content_length=len(body),
-            is_hidden=not user_invocable,
-            skill_root=str(entry),
-            when_to_use=when_to_use,
-            version=version,
-            model=model,
-            allowed_tools=allowed_tools,
-            arg_names=arg_names,
-            context=context,
-            agent=agent_val,
-            effort=effort_val,
-            paths=paths_val,
-            markdown_content=body,
-        )
-        skills.append(skill)
     return skills
 
 
@@ -599,36 +1099,140 @@ def get_all_skills(
     *,
     project_root: str | Path | None = None,
     user_skills_dir: str | Path | None = None,
-) -> Sequence[PromptSkill]:
-    clear_skill_registry()
-    if user_skills_dir is not None:
-        user_dirs = [Path(user_skills_dir).expanduser().resolve()]
-    else:
-        user_dirs = _candidate_user_skills_dirs()
-    for user_dir in user_dirs:
-        for s in load_skills_from_dir(user_dir, loaded_from="user"):
-            _skill_registry[s.name] = s
+) -> Sequence[Skill]:
+    """Return the unified set of skills available to the model.
 
+    Sources, in priority order (first occurrence of a name wins):
+
+    1. Managed/policy skills (``/etc/claude/.claude/skills`` by default)
+    2. User skills (``~/.claude/skills`` plus any clawcodex/env-specified
+       user-skill dirs)
+    3. Project skills (walking up from ``project_root`` to ``$HOME`` for
+       ``.claude/skills`` plus ``<project_root>/.clawcodex/skills``)
+    4. Managed override via ``CLAWCODEX_MANAGED_SKILLS_DIR``
+    5. Bundled skills registered via ``register_bundled_skill``
+    6. MCP-loaded skills returned by registered MCP skill builders
+
+    Disk skills support nested namespacing (``category/skill/SKILL.md``
+    becomes ``category:skill``) via ``get_skill_dir_commands``.
+
+    The returned set is also stored in ``_skill_registry`` so legacy
+    callers of ``get_registered_skill`` see every source.
+    """
+    clear_skill_registry()
+
+    cwd = (
+        str(Path(project_root).expanduser().resolve())
+        if project_root is not None
+        else os.getcwd()
+    )
+
+    # 1-3: Managed + user + project disk skills via the unified TS-port loader
+    disk_skills: list[Skill] = list(get_skill_dir_commands(cwd))
+
+    # 2b: Additional user-skill dirs (clawcodex-specific + env overrides)
+    extra_user_skills = _load_dirs_as(
+        _legacy_user_skill_dirs(user_skills_dir),
+        source="userSettings",
+        loaded_from="user",
+    )
+
+    # 3b: Additional project-skill dir for the clawcodex layout
+    extra_project_skills: list[Skill] = []
+    if project_root is not None:
+        extra_project_skills = _load_dirs_as(
+            _legacy_project_skill_dirs(project_root),
+            source="projectSettings",
+            loaded_from="project",
+        )
+
+    # 4: Managed override env (separate from /etc/claude policy dir)
+    extra_managed_skills: list[Skill] = []
     managed_env = os.environ.get("CLAWCODEX_MANAGED_SKILLS_DIR")
     if managed_env:
-        managed_dir = Path(managed_env).expanduser().resolve()
-        for s in load_skills_from_dir(managed_dir, loaded_from="managed"):
-            _skill_registry[s.name] = s
+        extra_managed_skills = _load_dirs_as(
+            [managed_env],
+            source="policySettings",
+            loaded_from="managed",
+        )
 
-    if project_root is not None:
-        pr = Path(project_root).expanduser().resolve()
-        proj_dirs = []
-        main_path = pr / ".clawcodex" / "skills"
-        compat_path = pr / ".claude" / "skills"
-        proj_dirs.append(main_path)
-        if compat_path != main_path:
-            proj_dirs.append(compat_path)
-        for pr_dir in proj_dirs:
-            for s in load_skills_from_dir(pr_dir, loaded_from="project"):
-                _skill_registry[s.name] = s
+    # 5: Bundled skills (always present)
+    bundled = get_bundled_skills()
 
-    return list(_skill_registry.values())
+    # 6: MCP skills (if a builder is registered)
+    mcp_skills: list[Skill] = []
+    builders = None
+    try:
+        from .mcp_skill_builders import get_mcp_skill_builders
+        builders = get_mcp_skill_builders()
+    except Exception:
+        builders = None
+    if builders:
+        for builder in builders.values():
+            try:
+                produced = builder()
+            except Exception:
+                continue
+            if produced:
+                mcp_skills.extend(produced)
+
+    # Activated conditional skills + skills introduced by
+    # ``add_skill_directories`` live in ``_dynamic_skills``. They must be
+    # merged last so explicit user/project skills with the same name win
+    # — a conditional skill is by definition the "lowest-priority"
+    # entry. Without this, ``activate_conditional_skills_for_paths``
+    # would silently move a skill into ``_dynamic_skills`` while the
+    # canonical ``SkillTool`` lookup (which goes through
+    # ``get_registered_skill`` → ``_skill_registry``) still returns
+    # "Unknown skill". (QA bug #14.)
+    dynamic_skills = get_dynamic_skills()
+
+    # Merge with first-source-wins precedence. The order below mirrors
+    # the priority list above: managed env override first (so admins can
+    # force a version), then policy/user/project from the unified loader,
+    # then clawcodex extras, then bundled and MCP as fallbacks, with
+    # dynamic (activated conditional / runtime-added) entries last.
+    merge_order: list[Skill] = (
+        list(extra_managed_skills)
+        + list(disk_skills)
+        + list(extra_user_skills)
+        + list(extra_project_skills)
+        + list(bundled)
+        + list(mcp_skills)
+        + list(dynamic_skills)
+    )
+
+    deduped: dict[str, Skill] = {}
+    for skill in merge_order:
+        if skill.name not in deduped:
+            deduped[skill.name] = skill
+
+    _skill_registry.update(deduped)
+    return list(deduped.values())
 
 
-def get_registered_skill(name: str) -> PromptSkill | None:
-    return _skill_registry.get(name)
+def get_registered_skill(name: str) -> Skill | None:
+    """Look up a skill in the unified registry.
+
+    Falls back to ``get_bundled_skill_by_name`` so callers that rely on
+    bundled-skill aliases keep working even before ``get_all_skills`` is
+    populated for the current cwd.
+    """
+    found = _skill_registry.get(name)
+    if found is not None:
+        return found
+    return get_bundled_skill_by_name(name)
+
+
+# Back-compat shim for the old PromptSkill-producing loader. Some callers
+# (and downstream tests) imported `load_skills_from_dir` directly. Keep
+# the surface the same but route through the unified
+# `load_skills_from_skills_dir` so behaviour matches the registry.
+def load_skills_from_dir(
+    base_dir: str | Path, *, loaded_from: str = "skills"
+) -> list[Skill]:
+    return load_skills_from_skills_dir(
+        str(Path(base_dir).expanduser().resolve()),
+        source="userSettings",
+        loaded_from=loaded_from,
+    )

--- a/src/skills/model.py
+++ b/src/skills/model.py
@@ -33,6 +33,20 @@ class Skill:
     base_dir: Optional[str] = None
     markdown_content: str = ""
     progress_message: str = "running"
+    # ------------------------------------------------------------------
+    # Frontmatter fields supported by the TS port that the prior Python
+    # parser silently dropped:
+    #   - ``hooks``: nested dict shaped as
+    #     ``{HookEvent: [{"matcher"?: str, "hooks": [HookCommand]}]}``.
+    #     Validated by ``parse_skill_frontmatter_fields`` against
+    #     ``ALL_HOOK_EVENTS``; invalid shapes are logged and dropped
+    #     (set to ``None``) without raising.
+    #   - ``shell``: ``"bash"`` | ``"powershell"``. Used by the runtime
+    #     shell-execution-in-prompt path to pick which shell tool
+    #     evaluates ``!`...``` blocks. ``None`` -> caller default (bash).
+    # ------------------------------------------------------------------
+    hooks: Optional[dict] = None
+    shell: Optional[str] = None
 
     get_prompt_for_command: Optional[Callable[[str], str]] = None
     is_enabled_fn: Optional[Callable[[], bool]] = None
@@ -69,7 +83,30 @@ class Skill:
             return self.is_enabled_fn()
         return True
 
+    # ------------------------------------------------------------------
+    # Backward-compat alias
+    #
+    # Historically a separate `PromptSkill` subclass exposed an `arg_names`
+    # field while the TS-port `Skill` used `argument_names`. Now that the
+    # two have collapsed to a single canonical `Skill`, expose `arg_names`
+    # as a property that proxies to `argument_names` so older call sites
+    # (e.g., command_system/skills_integration.py, tools/skill.py) keep
+    # working without modification.
+    # ------------------------------------------------------------------
 
-@dataclass
-class PromptSkill(Skill):
-    arg_names: list[str] = field(default_factory=list)
+    @property
+    def arg_names(self) -> list[str]:
+        return self.argument_names
+
+    @arg_names.setter
+    def arg_names(self, value: list[str] | None) -> None:
+        self.argument_names = list(value) if value else []
+
+
+# ----------------------------------------------------------------------
+# `PromptSkill` is preserved as an alias for backward compatibility.
+# All disk-loaded skills are now plain `Skill` instances; the prior
+# parallel hierarchy has been folded into one canonical type.
+# ----------------------------------------------------------------------
+
+PromptSkill = Skill

--- a/src/skills/runtime_substitution.py
+++ b/src/skills/runtime_substitution.py
@@ -1,0 +1,260 @@
+"""Per-invocation transforms applied to a skill's markdown body.
+
+These mirror the four transforms TS performs inside
+``createSkillCommand.getPromptForCommand`` (loadSkillsDir.ts:344-399):
+
+    1. Prepend ``Base directory for this skill: <root>\\n\\n`` if the
+       skill carries a ``skill_root``/``base_dir``.
+    2. Apply ``substitute_arguments`` (named placeholders, ``$N``,
+       ``$ARGUMENTS`` shorthand, optional append-on-no-placeholder).
+    3. Replace ``${CLAUDE_SKILL_DIR}`` with the resolved skill directory.
+       Backslashes get normalized to forward slashes (Windows compat with
+       embedded shell injections).
+    4. Replace ``${CLAUDE_SESSION_ID}`` with the active session id.
+    5. Execute embedded ``!`...`` and `````! ... ````` shell blocks
+       via the supplied ``shell_executor``. Skipped entirely for skills
+       loaded from MCP (security boundary mirroring TS' ``loadedFrom !==
+       'mcp'`` guard).
+
+The transforms live in this file as pure functions (one per step) plus a
+single orchestrator, ``render_skill_prompt``, that wires them together.
+The orchestrator takes a pluggable ``shell_executor`` callable so the
+SkillTool can pass a BashTool-backed implementation while unit tests can
+inject a fake (or pass ``None`` to skip shell execution).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Callable, Optional, Sequence
+
+from .argument_substitution import substitute_arguments
+
+logger = logging.getLogger(__name__)
+
+
+# ----------------------------------------------------------------------
+# Shell-block patterns (mirroring promptShellExecution.ts)
+# ----------------------------------------------------------------------
+
+# `````!\\n<command>\\n````` — multi-line fenced form. Capture is the inner
+# command with surrounding whitespace stripped at use-site.
+_BLOCK_PATTERN = re.compile(r"```!\s*\n?([\s\S]*?)\n?```")
+
+# ``!`<command>``` — inline form. Requires whitespace or start-of-line
+# before the ``!`` to avoid false positives inside other inline-code spans
+# (e.g. ```foo`!`bar```) and shell variable references like ``$!``.
+_INLINE_PATTERN = re.compile(r"(?:^|(?<=\s))!`([^`]+)`", re.MULTILINE)
+
+
+# ----------------------------------------------------------------------
+# Pure transforms (each independently testable)
+# ----------------------------------------------------------------------
+
+
+def prepend_base_dir_header(content: str, base_dir: Optional[str]) -> str:
+    """Prepend the canonical ``Base directory ...`` header.
+
+    No-op when ``base_dir`` is empty/None — matches TS behavior where
+    bundled skills without a shipped ``files`` directory get no header.
+    """
+    if not base_dir:
+        return content
+    return f"Base directory for this skill: {base_dir}\n\n{content}"
+
+
+def substitute_skill_dir(content: str, base_dir: Optional[str]) -> str:
+    """Replace every ``${CLAUDE_SKILL_DIR}`` with the skill root.
+
+    Backslashes are flipped to forward slashes so embedded shell commands
+    (``!`cat ${CLAUDE_SKILL_DIR}/script.sh```) don't treat them as escape
+    sequences on Windows. Mirrors the TS ``process.platform === 'win32'``
+    branch but applies unconditionally — flipping ``\\`` to ``/`` is safe
+    on POSIX paths since absolute POSIX paths never contain ``\\``.
+    """
+    if not base_dir:
+        return content
+    skill_dir = base_dir.replace("\\", "/") if "\\" in base_dir else base_dir
+    return content.replace("${CLAUDE_SKILL_DIR}", skill_dir)
+
+
+def substitute_session_id(content: str, session_id: Optional[str]) -> str:
+    """Replace ``${CLAUDE_SESSION_ID}`` with the active session id.
+
+    Unknown / unset session id → empty string substitution (matches TS
+    behavior when ``getSessionId()`` returns falsy).
+    """
+    return content.replace("${CLAUDE_SESSION_ID}", session_id or "")
+
+
+# ----------------------------------------------------------------------
+# Shell-block detection + execution helpers
+# ----------------------------------------------------------------------
+
+
+def find_shell_blocks(content: str) -> list[tuple[str, str, bool]]:
+    """Return ``[(full_match, command, inline)]`` for both block forms.
+
+    ``inline`` is ``True`` for ``!`...```, ``False`` for fenced `````! ... `````.
+    Fenced blocks are scanned unconditionally; the inline scan is gated on
+    the cheap ``"!`" in content`` check (mirrors the TS micro-opt: 93% of
+    skills have no inline form, and the inline regex with lookbehind is
+    significantly slower than the fenced one).
+    """
+    out: list[tuple[str, str, bool]] = []
+    for m in _BLOCK_PATTERN.finditer(content):
+        cmd = (m.group(1) or "").strip()
+        if cmd:
+            out.append((m.group(0), cmd, False))
+    if "!`" in content:
+        for m in _INLINE_PATTERN.finditer(content):
+            cmd = (m.group(1) or "").strip()
+            if cmd:
+                out.append((m.group(0), cmd, True))
+    return out
+
+
+def has_shell_blocks(content: str) -> bool:
+    """Cheap check for whether ``content`` contains any shell-exec form."""
+    if "```!" in content:
+        return True
+    if "!`" in content and _INLINE_PATTERN.search(content) is not None:
+        return True
+    return False
+
+
+def format_shell_output(stdout: str, stderr: str, *, inline: bool) -> str:
+    """Format BashTool output the way TS' ``formatBashOutput`` does."""
+    parts: list[str] = []
+    if stdout and stdout.strip():
+        parts.append(stdout.strip())
+    if stderr and stderr.strip():
+        if inline:
+            parts.append(f"[stderr: {stderr.strip()}]")
+        else:
+            parts.append(f"[stderr]\n{stderr.strip()}")
+    return (" " if inline else "\n").join(parts)
+
+
+def format_shell_error(
+    error: BaseException | str,
+    pattern: str,
+    *,
+    inline: bool,
+) -> str:
+    """Format an exception/timeout the way TS' ``formatBashError`` does.
+
+    Unlike TS (which raises ``MalformedCommandError`` and lets the caller
+    re-throw), the Python port embeds the formatted error text inline in
+    the rendered prompt. This satisfies the DEV-2 requirement that shell
+    failures "surface as visible errors in the rendered prompt, not
+    silent drops" without crashing the SkillTool call.
+    """
+    msg = str(error) if not isinstance(error, str) else error
+    if inline:
+        return f"[Error: {msg}]"
+    return f"[Error]\n{msg}"
+
+
+# ----------------------------------------------------------------------
+# Orchestrator
+# ----------------------------------------------------------------------
+
+
+# Signature: (command:str, inline:bool) -> rendered text to splice in.
+# Returning a string lets the executor format errors uniformly without
+# the renderer needing to know about the underlying tool.
+ShellExecutor = Callable[[str, bool], str]
+
+
+def render_skill_prompt(
+    *,
+    body: str,
+    args: str | None,
+    base_dir: Optional[str],
+    argument_names: Sequence[str] = (),
+    session_id: Optional[str] = None,
+    loaded_from: Optional[str] = None,
+    slash_command_name: str = "",
+    shell_executor: ShellExecutor | None = None,
+) -> str:
+    """Apply every per-invocation transform in TS order.
+
+    Order is fixed (and matches TS):
+        1. base-dir prepend
+        2. argument substitution
+        3. ``${CLAUDE_SKILL_DIR}``
+        4. ``${CLAUDE_SESSION_ID}``
+        5. embedded shell execution (skipped for ``loaded_from == 'mcp'``)
+
+    ``shell_executor`` is the only side-effecting hook. When ``None`` (or
+    when the skill is MCP-loaded), step 5 is a no-op and any embedded
+    shell blocks survive verbatim in the output. The SkillTool wires a
+    BashTool-backed executor; tests can inject fakes.
+    """
+    content = body or ""
+
+    # 1. Base-dir header
+    content = prepend_base_dir_header(content, base_dir)
+
+    # 2. Arguments. ``append_if_no_placeholder=True`` matches TS and the
+    # existing Python behavior — non-placeholder skills still receive the
+    # raw args appended as ``ARGUMENTS: <args>``.
+    content = substitute_arguments(
+        content,
+        args,
+        append_if_no_placeholder=True,
+        argument_names=list(argument_names),
+    )
+
+    # 3. ${CLAUDE_SKILL_DIR}
+    content = substitute_skill_dir(content, base_dir)
+
+    # 4. ${CLAUDE_SESSION_ID}
+    content = substitute_session_id(content, session_id)
+
+    # 5. Shell exec — guarded on MCP source (security boundary). MCP
+    # skills come from remote untrusted servers; their markdown bodies
+    # must never trigger local shell execution.
+    if loaded_from == "mcp":
+        if has_shell_blocks(content):
+            logger.debug(
+                "skill %r is MCP-loaded; skipping inline shell execution "
+                "for %d blocks",
+                slash_command_name,
+                len(find_shell_blocks(content)),
+            )
+        return content
+
+    if shell_executor is None:
+        if has_shell_blocks(content):
+            logger.debug(
+                "skill %r contains inline shell blocks but no executor "
+                "was provided; leaving them as-is",
+                slash_command_name,
+            )
+        return content
+
+    blocks = find_shell_blocks(content)
+    if not blocks:
+        return content
+
+    for full_match, command, inline in blocks:
+        try:
+            replacement = shell_executor(command, inline)
+        except Exception as exc:  # noqa: BLE001 — we want to surface anything
+            logger.exception(
+                "shell executor crashed for skill %r command %r",
+                slash_command_name,
+                command,
+            )
+            replacement = format_shell_error(exc, full_match, inline=inline)
+        # Use a lambda for the replacement to bypass re-style $-expansion
+        # in str.replace? Python's ``str.replace`` doesn't interpret
+        # backreferences, so a plain string is safe — but we limit to one
+        # replacement per call so multiple identical blocks can each get
+        # their own (potentially different) executor result.
+        content = content.replace(full_match, replacement, 1)
+
+    return content

--- a/src/tool_system/context.py
+++ b/src/tool_system/context.py
@@ -103,6 +103,12 @@ class ToolContext:
     agent_type: str | None = None
     tool_use_id: str | None = None
     user_modified: bool = False
+    # Identifier of the active query/session. Surfaced to skills (SKILL.md
+    # bodies may reference ``${CLAUDE_SESSION_ID}``) and any other tool
+    # that needs to correlate with persisted session state. ``None`` is
+    # interpreted as "unknown" by callers; substitutions yield an empty
+    # string in that case.
+    session_id: str | None = None
 
     def __post_init__(self) -> None:
         self.workspace_root = Path(self.workspace_root).resolve()

--- a/src/tool_system/tools/skill.py
+++ b/src/tool_system/tools/skill.py
@@ -76,7 +76,11 @@ def _validate_skill_input(tool_input: dict[str, Any], context: ToolContext) -> V
     # Remove leading slash if present (for compatibility)
     command_name = trimmed.lstrip("/")
 
-    # Look up in the skill registry
+    # Populate the unified registry for the current cwd, then look up.
+    # The registry now includes managed/user/project disk skills (with
+    # nested namespacing like "git:commit"), bundled skills, and any
+    # MCP-provided skills. `get_registered_skill` falls back to bundled
+    # alias matching for back-compat.
     from src.skills.loader import get_all_skills, get_registered_skill
 
     get_all_skills(project_root=context.workspace_root)
@@ -168,15 +172,46 @@ def _skill_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
 
 def _run_markdown_skill(skill_name: str, args: str, context: ToolContext) -> ToolResult:
     from src.skills.loader import get_all_skills, get_registered_skill
-    from src.skills.argument_substitution import substitute_arguments
+    from src.skills.runtime_substitution import render_skill_prompt
 
+    # Populate / refresh the unified registry for the active cwd. This
+    # pulls in managed / user / project disk skills (with nested
+    # `category:skill` namespacing), bundled skills, and any registered
+    # MCP skills.
     get_all_skills(project_root=context.workspace_root)
     skill = get_registered_skill(skill_name)
     if skill is None:
-        return ToolResult(name="Skill", output={"error": f"skill not found: {skill_name}"}, is_error=True)
+        return ToolResult(
+            name="Skill",
+            output={"error": f"skill not found: {skill_name}"},
+            is_error=True,
+        )
 
-    body = skill.markdown_content or ""
-    prompt = substitute_arguments(body, args, argument_names=skill.arg_names or [])
+    # Bundled skills supply a callable prompt builder and define their
+    # own substitution semantics; we pass args through and trust the
+    # callable. Disk-loaded skills go through the canonical renderer
+    # which mirrors TS' getPromptForCommand transform pipeline:
+    #   1. base-dir header → 2. arg substitute → 3. ${CLAUDE_SKILL_DIR}
+    #   → 4. ${CLAUDE_SESSION_ID} → 5. embedded shell exec (gated on
+    #   non-MCP sources, scoped through skill.allowed_tools).
+    if getattr(skill, "get_prompt_for_command", None) is not None:
+        prompt = skill.get_prompt_for_command(args or "")
+    else:
+        body = skill.markdown_content or skill.content or ""
+        base_dir = skill.base_dir or skill.skill_root
+        executor = _make_shell_executor(
+            context, skill.allowed_tools, slash_command_name=f"/{skill_name}"
+        )
+        prompt = render_skill_prompt(
+            body=body,
+            args=args,
+            base_dir=base_dir,
+            argument_names=skill.argument_names,
+            session_id=context.session_id,
+            loaded_from=skill.loaded_from,
+            slash_command_name=f"/{skill_name}",
+            shell_executor=executor,
+        )
 
     # Build context modifier if skill specifies allowed_tools, model, or effort
     context_modifier = _build_context_modifier(skill)
@@ -194,6 +229,69 @@ def _run_markdown_skill(skill_name: str, args: str, context: ToolContext) -> Too
         },
         context_modifier=context_modifier,
     )
+
+
+def _make_shell_executor(
+    context: ToolContext,
+    allowed_tools: list[str] | None,
+    *,
+    slash_command_name: str,
+):
+    """Return a callable that runs a shell command via BashTool.
+
+    The returned executor matches the
+    ``runtime_substitution.ShellExecutor`` signature: ``(command, inline)
+    -> rendered text``. Errors and non-zero exits are formatted via
+    ``format_shell_error`` / ``format_shell_output`` so the renderer can
+    splice the result back into the prompt without raising.
+
+    The skill's ``allowed_tools`` list is documented for parity with TS
+    (which injects them as ``alwaysAllowRules.command`` for the duration
+    of the call), but the Python BashTool's ``call()`` path bypasses the
+    registry-level permission gate and runs the command directly under
+    the active ``ToolContext`` permission mode. Wiring the
+    ``alwaysAllowRules.command`` injection precisely is tracked as a
+    follow-up; in bypass-permissions sessions (the default for the
+    in-process SkillTool path) commands run unprompted.
+    """
+    from .bash import BashTool
+    from src.skills.runtime_substitution import (
+        format_shell_error,
+        format_shell_output,
+    )
+
+    _ = allowed_tools  # acknowledged; precise injection deferred (see docstring)
+
+    def _exec(command: str, inline: bool) -> str:
+        try:
+            tr = BashTool.call({"command": command}, context)
+        except Exception as exc:  # noqa: BLE001 — surface every failure
+            return format_shell_error(exc, command, inline=inline)
+
+        output = tr.output if isinstance(tr.output, dict) else {}
+        stdout = str(output.get("stdout", ""))
+        stderr = str(output.get("stderr", ""))
+        exit_code = output.get("exit_code")
+
+        # Treat non-zero exit codes the same way TS' ShellError surfaces
+        # — embed the failure text inline so the model sees what went
+        # wrong, but keep going so the rest of the prompt still renders.
+        if isinstance(exit_code, int) and exit_code != 0:
+            err_text = format_shell_output(stdout, stderr, inline=inline)
+            err_text = err_text or f"command failed (exit {exit_code})"
+            return format_shell_error(err_text, command, inline=inline)
+
+        if tr.is_error:
+            err_text = (
+                format_shell_output(stdout, stderr, inline=inline)
+                or output.get("error")
+                or "command failed"
+            )
+            return format_shell_error(str(err_text), command, inline=inline)
+
+        return format_shell_output(stdout, stderr, inline=inline)
+
+    return _exec
 
 
 def _build_context_modifier(skill: Any) -> Any:

--- a/tests/fixtures/skills/commit-helper/SKILL.md
+++ b/tests/fixtures/skills/commit-helper/SKILL.md
@@ -1,0 +1,11 @@
+---
+description: Generate a conventional-commit message from staged changes.
+allowed-tools: [Bash, Read]
+arguments: [scope]
+argument-hint: <scope>
+---
+# Commit Helper
+
+Run `git diff --cached` and produce a conventional-commit message in `$scope` scope.
+Skill base: ${CLAUDE_SKILL_DIR}
+Session: ${CLAUDE_SESSION_ID}

--- a/tests/fixtures/skills/frontend/add-component/SKILL.md
+++ b/tests/fixtures/skills/frontend/add-component/SKILL.md
@@ -1,0 +1,8 @@
+---
+description: Scaffold a new React component.
+arguments: [name]
+when_to_use: When the user asks to add a new React component.
+---
+# Add Component
+
+Create `src/components/$name.tsx` and a matching test.

--- a/tests/fixtures/skills/lint-py/SKILL.md
+++ b/tests/fixtures/skills/lint-py/SKILL.md
@@ -1,0 +1,13 @@
+---
+description: Run lints on Python files.
+paths:
+  - "**/*.py"
+allowed-tools: [Bash]
+---
+# Lint Python
+
+Lint the Python files in this checkout and report findings.
+
+Working directory: !`pwd`
+
+Run ruff and report findings.

--- a/tests/test_skills_bundled.py
+++ b/tests/test_skills_bundled.py
@@ -44,6 +44,14 @@ class TestBundledSkills:
         assert len(get_bundled_skills()) == 3
 
     def test_clear(self) -> None:
+        # Test the in-process behavior of `clear_bundled_skills`:
+        # registering a one-off, then clearing, must wipe that one-off
+        # from the registry. We don't assert "len == 0" after clear
+        # because clearing also re-arms the lazy-init flag, so the next
+        # `get_bundled_skills()` call seeds the always-on bundled
+        # catalogue (simplify, debug, loop, stuck, verify-content).
+        # Instead we assert the temporary skill is gone.
+        from src.skills.bundled_skills import _bundled_skills
         register_bundled_skill(
             BundledSkillDefinition(
                 name="temp",
@@ -51,9 +59,15 @@ class TestBundledSkills:
                 get_prompt_for_command=lambda a: a,
             )
         )
-        assert len(get_bundled_skills()) == 1
+        assert len(get_bundled_skills()) == 1  # lazy-init suppressed by register
         clear_bundled_skills()
-        assert len(get_bundled_skills()) == 0
+        # After clear, the in-memory list is empty until the next
+        # consumer triggers lazy-init.
+        assert _bundled_skills == []
+        seeded = get_bundled_skills()
+        names = {s.name for s in seeded}
+        assert "temp" not in names  # one-off was wiped
+        assert "simplify" in names  # bundled catalogue re-seeded
 
     def test_get_returns_copy(self) -> None:
         register_bundled_skill(

--- a/tests/test_skills_bundled_catalogue.py
+++ b/tests/test_skills_bundled_catalogue.py
@@ -1,0 +1,272 @@
+"""Tests for DEV-5: bundled-skill catalogue + init orchestrator.
+
+Acceptance criteria:
+1. After init, get_bundled_skills returns ≥ 5 named skills.
+2. SkillTool /simplify returns prompt containing "Phase 1: Identify Changes".
+3. SkillTool /loop "5m hello" → fixed-prompt branch with 5m + hello body.
+4. SkillTool /loop "" → dynamic-rescheduling branch.
+5. SkillTool /debug returns a prompt that contains the debug log path
+   and does not throw on a missing log file.
+6. init_bundled_skills is idempotent (no double-registration).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.skills.bundled import (
+    init_bundled_skills,
+    register_debug_skill,
+    register_loop_skill,
+    register_simplify_skill,
+    register_stuck_skill,
+    register_verify_content_skill,
+    reset_bundled_skills_init_flag,
+)
+from src.skills.bundled.loop import (
+    ParsedLoopArgs,
+    parse_loop_args,
+)
+from src.skills.bundled_skills import (
+    clear_bundled_skills,
+    get_bundled_skills,
+)
+from src.skills.loader import (
+    clear_dynamic_skills,
+    clear_skill_caches,
+    clear_skill_registry,
+)
+from src.tool_system.context import ToolContext
+from src.tool_system.tools import SkillTool
+
+
+def _reset_all() -> None:
+    clear_bundled_skills()
+    reset_bundled_skills_init_flag()
+    clear_skill_caches()
+    clear_dynamic_skills()
+    clear_skill_registry()
+
+
+class TestInitOrchestrator(unittest.TestCase):
+    def setUp(self) -> None:
+        _reset_all()
+
+    def tearDown(self) -> None:
+        _reset_all()
+
+    def test_init_seeds_at_least_five(self) -> None:
+        # AC#1
+        init_bundled_skills()
+        names = {s.name for s in get_bundled_skills()}
+        self.assertGreaterEqual(len(names), 5)
+        for required in ("simplify", "debug", "loop", "stuck", "verify-content"):
+            self.assertIn(required, names)
+
+    def test_init_idempotent(self) -> None:
+        # AC#6
+        init_bundled_skills()
+        first = len(get_bundled_skills())
+        init_bundled_skills()
+        init_bundled_skills()
+        self.assertEqual(len(get_bundled_skills()), first)
+
+
+class TestSimplifySkill(unittest.TestCase):
+    def setUp(self) -> None:
+        _reset_all()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name).resolve()
+
+    def tearDown(self) -> None:
+        _reset_all()
+        self._tmp.cleanup()
+
+    def test_simplify_returns_phase1_marker(self) -> None:
+        # AC#2
+        ctx = ToolContext(workspace_root=self.root)
+        out = SkillTool.call({"skill": "simplify"}, ctx).output
+        self.assertTrue(out["success"])
+        self.assertIn("Phase 1: Identify Changes", out["prompt"])
+
+    def test_simplify_appends_args(self) -> None:
+        ctx = ToolContext(workspace_root=self.root)
+        out = SkillTool.call({"skill": "simplify", "args": "look at /auth"}, ctx).output
+        self.assertIn("Additional Focus", out["prompt"])
+        self.assertIn("look at /auth", out["prompt"])
+
+
+class TestLoopSkillParser(unittest.TestCase):
+    def test_empty_args_dynamic_maintenance(self) -> None:
+        self.assertEqual(parse_loop_args(""), ParsedLoopArgs(mode="dynamic-maintenance"))
+
+    def test_bare_interval_fixed_maintenance(self) -> None:
+        out = parse_loop_args("5m")
+        self.assertEqual(out.mode, "fixed-maintenance")
+        self.assertEqual(out.interval, "5m")
+
+    def test_leading_interval_with_prompt(self) -> None:
+        out = parse_loop_args("5m hello world")
+        self.assertEqual(out.mode, "fixed-prompt")
+        self.assertEqual(out.interval, "5m")
+        self.assertEqual(out.prompt, "hello world")
+
+    def test_trailing_every_clause(self) -> None:
+        out = parse_loop_args("ping the build every 10 minutes")
+        self.assertEqual(out.mode, "fixed-prompt")
+        self.assertEqual(out.interval, "10m")
+        self.assertEqual(out.prompt, "ping the build")
+
+    def test_unit_aliases(self) -> None:
+        # Variants accepted by normalize_interval_unit.
+        for token, expect in (
+            ("3secs", "3s"),
+            ("2 hours", "2h"),
+            ("1day", "1d"),
+            ("10 minute", "10m"),
+        ):
+            out = parse_loop_args(token)
+            self.assertEqual(
+                out, ParsedLoopArgs(mode="fixed-maintenance", interval=expect),
+                f"failed for token={token!r}",
+            )
+
+    def test_invalid_interval_returns_dynamic_prompt(self) -> None:
+        out = parse_loop_args("just some prose with no interval")
+        self.assertEqual(out.mode, "dynamic-prompt")
+        self.assertEqual(out.prompt, "just some prose with no interval")
+
+
+class TestLoopSkillEndToEnd(unittest.TestCase):
+    def setUp(self) -> None:
+        _reset_all()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name).resolve()
+
+    def tearDown(self) -> None:
+        _reset_all()
+        self._tmp.cleanup()
+
+    def test_loop_5m_hello_fixed_prompt_branch(self) -> None:
+        # AC#3
+        ctx = ToolContext(workspace_root=self.root)
+        out = SkillTool.call({"skill": "loop", "args": "5m hello"}, ctx).output
+        self.assertTrue(out["success"])
+        prompt = out["prompt"]
+        self.assertIn("fixed recurring interval", prompt)
+        self.assertIn("Requested interval: 5m", prompt)
+        self.assertIn("hello", prompt)
+        self.assertIn("--- BEGIN PROMPT ---", prompt)
+        self.assertIn("CronCreate", prompt)
+
+    def test_loop_empty_args_dynamic_branch(self) -> None:
+        # AC#4
+        ctx = ToolContext(workspace_root=self.root)
+        out = SkillTool.call({"skill": "loop"}, ctx).output
+        self.assertTrue(out["success"])
+        prompt = out["prompt"]
+        self.assertIn("dynamic rescheduling", prompt)
+        self.assertIn("--- BEGIN MAINTENANCE PROMPT ---", prompt)
+
+
+class TestDebugSkill(unittest.TestCase):
+    def setUp(self) -> None:
+        _reset_all()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name).resolve()
+
+    def tearDown(self) -> None:
+        _reset_all()
+        self._tmp.cleanup()
+
+    def test_debug_prompt_includes_log_path_no_log_file(self) -> None:
+        # AC#5: surfaces log path; no exception on missing file.
+        nonexistent = self.root / "no-such-debug.log"
+        with patch.dict(
+            os.environ,
+            {"CLAUDE_CODE_DEBUG_LOG_PATH": str(nonexistent)},
+        ):
+            ctx = ToolContext(workspace_root=self.root)
+            out = SkillTool.call({"skill": "debug"}, ctx).output
+        self.assertTrue(out["success"])
+        self.assertIn(str(nonexistent), out["prompt"])
+        # The "no debug log exists yet" hint must be in the body.
+        self.assertIn("No debug log exists yet", out["prompt"])
+
+    def test_debug_prompt_with_existing_log(self) -> None:
+        log = self.root / "debug.log"
+        log.write_text("[INFO] hi\n[ERROR] crash\n")
+        with patch.dict(os.environ, {"CLAUDE_CODE_DEBUG_LOG_PATH": str(log)}):
+            ctx = ToolContext(workspace_root=self.root)
+            out = SkillTool.call({"skill": "debug"}, ctx).output
+        self.assertTrue(out["success"])
+        self.assertIn(str(log), out["prompt"])
+        self.assertIn("[ERROR] crash", out["prompt"])
+
+    def test_debug_prompt_includes_user_issue(self) -> None:
+        ctx = ToolContext(workspace_root=self.root)
+        out = SkillTool.call(
+            {"skill": "debug", "args": "auth keeps failing"}, ctx
+        ).output
+        self.assertIn("auth keeps failing", out["prompt"])
+
+
+class TestStuckAndVerifySkills(unittest.TestCase):
+    def setUp(self) -> None:
+        _reset_all()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name).resolve()
+
+    def tearDown(self) -> None:
+        _reset_all()
+        self._tmp.cleanup()
+
+    def test_stuck_renders(self) -> None:
+        ctx = ToolContext(workspace_root=self.root)
+        out = SkillTool.call({"skill": "stuck"}, ctx).output
+        self.assertTrue(out["success"])
+        self.assertIn("Reset and Re-Approach", out["prompt"])
+
+    def test_stuck_with_args_appends_user_context(self) -> None:
+        ctx = ToolContext(workspace_root=self.root)
+        out = SkillTool.call({"skill": "stuck", "args": "tests fail"}, ctx).output
+        self.assertIn("tests fail", out["prompt"])
+        self.assertIn("User Context", out["prompt"])
+
+    def test_verify_content_renders(self) -> None:
+        ctx = ToolContext(workspace_root=self.root)
+        out = SkillTool.call({"skill": "verify-content"}, ctx).output
+        self.assertTrue(out["success"])
+        self.assertIn("Verify Recent Edits Match Intent", out["prompt"])
+
+
+class TestRegisterFunctionsIdempotent(unittest.TestCase):
+    """Each register_*_skill is allowed to be called explicitly; doing
+    so should not double-register if init has already run."""
+
+    def setUp(self) -> None:
+        _reset_all()
+
+    def tearDown(self) -> None:
+        _reset_all()
+
+    def test_individual_register_does_not_double(self) -> None:
+        # Register-by-hand path (used by tests + the init orchestrator).
+        # The bundled_skills.register_bundled_skill IS additive — calling
+        # the same register function twice WILL register twice. The
+        # orchestrator's idempotency comes from the _INITIALIZED flag in
+        # bundled/__init__.py.
+        register_simplify_skill()
+        first_count = len(get_bundled_skills())
+        register_simplify_skill()
+        # NOTE: register_bundled_skill is additive by design. The init
+        # orchestrator (init_bundled_skills) is the idempotent layer.
+        self.assertEqual(len(get_bundled_skills()), first_count + 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skills_dedup_and_paths.py
+++ b/tests/test_skills_dedup_and_paths.py
@@ -1,0 +1,502 @@
+"""Tests for DEV-4: realpath dedup, bare/policy gates, conditional paths.
+
+Acceptance criteria:
+1. Two same-file skills accessed via different sources collapse to one.
+2. Symlink → SKILL.md does not produce a duplicate (same realpath).
+3. ``CLAUDE_CODE_DISABLE_POLICY_SKILLS`` skips the managed dir.
+4. ``CLAUDE_CODE_BARE_MODE`` skips autodiscovery; only ``--add-dir``.
+5. Conditional ``paths: ["src/**/*.py"]`` activates for `src/foo/bar.py`.
+6. ``discover_skill_dirs_for_paths`` skips a `.claude/skills` dir whose
+   parent is gitignored.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.skills.bundled_skills import clear_bundled_skills
+from src.skills.create import create_skill
+from src.skills.loader import (
+    _compile_path_spec,
+    _dedup_by_realpath,
+    _get_additional_skill_dirs,
+    _get_file_identity,
+    _is_bare_mode,
+    _is_path_gitignored,
+    _is_restricted_to_plugin_only,
+    _is_skills_policy_disabled,
+    _path_matches_pattern,
+    activate_conditional_skills_for_paths,
+    clear_dynamic_skills,
+    clear_skill_caches,
+    clear_skill_registry,
+    discover_skill_dirs_for_paths,
+    get_skill_dir_commands,
+    load_skills_from_skills_dir,
+)
+from src.skills.model import Skill
+
+
+class _IsolatedHomeMixin:
+    """Provide an isolated $HOME / managed-dir per test so user/managed
+    skill discovery doesn't leak in real disk content."""
+
+    def _isolate_env(self) -> None:
+        self._env_patch = patch.dict(
+            os.environ,
+            {
+                "HOME": str(self._home),
+                "CLAUDE_CONFIG_DIR": str(self._home / ".claude"),
+                "CLAUDE_MANAGED_CONFIG_DIR": str(self._managed),
+            },
+            clear=False,
+        )
+        self._env_patch.start()
+        # Drop any contaminating envs:
+        for k in (
+            "CLAWCODEX_SKILLS_DIR",
+            "CLAUDE_SKILLS_DIR",
+            "CLAWCODEX_MANAGED_SKILLS_DIR",
+            "CLAUDE_CODE_BARE_MODE",
+            "CLAUDE_CODE_ADDITIONAL_DIRECTORIES",
+            "CLAUDE_CODE_DISABLE_POLICY_SKILLS",
+        ):
+            os.environ.pop(k, None)
+
+
+class TestFileIdentity(unittest.TestCase):
+    def test_returns_realpath(self) -> None:
+        with tempfile.TemporaryDirectory() as t:
+            p = Path(t) / "f.txt"
+            p.write_text("x")
+            link = Path(t) / "link.txt"
+            link.symlink_to(p)
+            self.assertEqual(_get_file_identity(str(link)), str(p.resolve()))
+
+    def test_broken_symlink_returns_path_or_none(self) -> None:
+        # `os.path.realpath` on a broken symlink returns the target path
+        # without resolving it; either result is acceptable as long as
+        # we never raise.
+        with tempfile.TemporaryDirectory() as t:
+            broken = Path(t) / "broken"
+            broken.symlink_to(Path(t) / "missing")
+            out = _get_file_identity(str(broken))
+            # Should not raise; may return the unresolved path string.
+            self.assertIsInstance(out, str)
+
+
+class TestDedupByRealpath(unittest.TestCase):
+    def test_same_realpath_drops_later_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as t:
+            sk = Path(t) / "s"
+            sk.mkdir()
+            (sk / "SKILL.md").write_text("---\ndescription: x\n---\nbody")
+            link = Path(t) / "link"
+            link.symlink_to(sk)
+
+            a = Skill(
+                name="x", description="x", source="userSettings",
+                base_dir=str(sk),
+            )
+            b = Skill(
+                name="x", description="x", source="projectSettings",
+                base_dir=str(link),
+            )
+            out = _dedup_by_realpath([a, b])
+            self.assertEqual(len(out), 1)
+            self.assertEqual(out[0].source, "userSettings")  # first wins
+
+    def test_different_files_both_kept(self) -> None:
+        with tempfile.TemporaryDirectory() as t:
+            d1, d2 = Path(t) / "a", Path(t) / "b"
+            d1.mkdir(); d2.mkdir()
+            (d1 / "SKILL.md").write_text("body1")
+            (d2 / "SKILL.md").write_text("body2")
+            a = Skill(name="x", description="x", base_dir=str(d1))
+            b = Skill(name="x", description="x", base_dir=str(d2))
+            out = _dedup_by_realpath([a, b])
+            self.assertEqual(len(out), 2)
+
+    def test_no_base_dir_fails_open(self) -> None:
+        a = Skill(name="x", description="x", base_dir=None)
+        b = Skill(name="y", description="y", base_dir=None)
+        out = _dedup_by_realpath([a, b])
+        self.assertEqual(len(out), 2)
+
+
+class TestPolicyAndBareGates(unittest.TestCase):
+    def test_bare_mode_env_signal(self) -> None:
+        with patch.dict(os.environ, {"CLAUDE_CODE_BARE_MODE": "1"}):
+            self.assertTrue(_is_bare_mode())
+        with patch.dict(os.environ, {"CLAUDE_CODE_BARE_MODE": "0"}):
+            self.assertFalse(_is_bare_mode())
+        os.environ.pop("CLAUDE_CODE_BARE_MODE", None)
+        self.assertFalse(_is_bare_mode())
+
+    def test_policy_disabled_env_signal(self) -> None:
+        with patch.dict(os.environ, {"CLAUDE_CODE_DISABLE_POLICY_SKILLS": "true"}):
+            self.assertTrue(_is_skills_policy_disabled())
+        os.environ.pop("CLAUDE_CODE_DISABLE_POLICY_SKILLS", None)
+        self.assertFalse(_is_skills_policy_disabled())
+
+    def test_plugin_only_stub_returns_false(self) -> None:
+        self.assertFalse(_is_restricted_to_plugin_only("skills"))
+
+    def test_additional_dirs_pathsep_split(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"CLAUDE_CODE_ADDITIONAL_DIRECTORIES": f"/a{os.pathsep}/b{os.pathsep}"},
+        ):
+            self.assertEqual(_get_additional_skill_dirs(), ["/a", "/b"])
+        os.environ.pop("CLAUDE_CODE_ADDITIONAL_DIRECTORIES", None)
+        self.assertEqual(_get_additional_skill_dirs(), [])
+
+
+class TestGetSkillDirCommandsBareAndPolicy(_IsolatedHomeMixin, unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._root = Path(self._tmp.name).resolve()
+        self._home = self._root / "_home"; self._home.mkdir()
+        self._managed = self._root / "_etc"; self._managed.mkdir()
+        self._project = self._root / "proj"; self._project.mkdir()
+        self._isolate_env()
+        clear_skill_caches(); clear_dynamic_skills(); clear_skill_registry()
+
+    def tearDown(self) -> None:
+        self._env_patch.stop()
+        self._tmp.cleanup()
+        clear_skill_caches(); clear_dynamic_skills(); clear_skill_registry()
+
+    def _make_skill(self, parent: Path, name: str, body: str = "body") -> Path:
+        skill_dir = parent / "skills" / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(f"---\ndescription: {name}\n---\n{body}")
+        return skill_dir
+
+    def test_policy_disabled_skips_managed_dir(self) -> None:
+        # AC#3
+        self._make_skill(self._managed / ".claude", "managed-only")
+        with patch.dict(os.environ, {"CLAUDE_CODE_DISABLE_POLICY_SKILLS": "1"}):
+            clear_skill_caches()
+            skills = get_skill_dir_commands(str(self._project))
+        names = {s.name for s in skills}
+        self.assertNotIn("managed-only", names)
+
+    def test_managed_loaded_when_policy_enabled(self) -> None:
+        self._make_skill(self._managed / ".claude", "managed-only")
+        clear_skill_caches()
+        skills = get_skill_dir_commands(str(self._project))
+        names = {s.name for s in skills}
+        self.assertIn("managed-only", names)
+
+    def test_bare_mode_skips_managed_user_project(self) -> None:
+        # AC#4
+        self._make_skill(self._managed / ".claude", "m1")
+        self._make_skill(self._home / ".claude", "u1")
+        self._make_skill(self._project / ".claude", "p1")
+        with patch.dict(os.environ, {"CLAUDE_CODE_BARE_MODE": "1"}):
+            clear_skill_caches()
+            skills = get_skill_dir_commands(str(self._project))
+        # No additional dirs → bare mode returns empty.
+        self.assertEqual(skills, [])
+
+    def test_bare_mode_with_add_dir_loads_additional_only(self) -> None:
+        # AC#4 — bare + --add-dir loads only the explicit dir.
+        self._make_skill(self._managed / ".claude", "m1")
+        self._make_skill(self._home / ".claude", "u1")
+        self._make_skill(self._project / ".claude", "p1")
+        extra = self._root / "extra"
+        self._make_skill(extra / ".claude", "e1")
+        with patch.dict(
+            os.environ,
+            {
+                "CLAUDE_CODE_BARE_MODE": "1",
+                "CLAUDE_CODE_ADDITIONAL_DIRECTORIES": str(extra),
+            },
+        ):
+            clear_skill_caches()
+            skills = get_skill_dir_commands(str(self._project))
+        names = {s.name for s in skills}
+        self.assertEqual(names, {"e1"})
+
+
+class TestSymlinkDedup(_IsolatedHomeMixin, unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._root = Path(self._tmp.name).resolve()
+        self._home = self._root / "_home"; self._home.mkdir()
+        self._managed = self._root / "_etc"; self._managed.mkdir()
+        self._project = self._root / "proj"; self._project.mkdir()
+        self._isolate_env()
+        clear_skill_caches(); clear_dynamic_skills(); clear_skill_registry()
+
+    def tearDown(self) -> None:
+        self._env_patch.stop()
+        self._tmp.cleanup()
+        clear_skill_caches(); clear_dynamic_skills(); clear_skill_registry()
+
+    def test_symlink_to_project_skill_collapses_to_one(self) -> None:
+        # AC#2: ~/.claude/skills/foo → <proj>/.claude/skills/foo
+        proj_skill = self._project / ".claude" / "skills" / "foo"
+        proj_skill.mkdir(parents=True)
+        (proj_skill / "SKILL.md").write_text("---\ndescription: foo\n---\nbody")
+
+        user_skills_dir = self._home / ".claude" / "skills"
+        user_skills_dir.mkdir(parents=True)
+        (user_skills_dir / "foo").symlink_to(proj_skill)
+
+        skills = get_skill_dir_commands(str(self._project))
+        names = [s.name for s in skills]
+        self.assertEqual(names.count("foo"), 1, f"got {names}")
+
+
+class TestConditionalPathsGitignoreSemantics(unittest.TestCase):
+    def setUp(self) -> None:
+        clear_skill_caches(); clear_dynamic_skills()
+
+    def tearDown(self) -> None:
+        clear_skill_caches(); clear_dynamic_skills()
+
+    def test_compile_pathspec_handles_doublestar(self) -> None:
+        spec = _compile_path_spec(["src/**/*.py"])
+        self.assertIsNotNone(spec)
+        self.assertTrue(spec.match_file("src/foo/bar.py"))
+        self.assertTrue(spec.match_file("src/x.py"))
+        self.assertFalse(spec.match_file("docs/x.md"))
+
+    def test_path_matches_pattern_recursive(self) -> None:
+        # Regression for the prior fnmatch-based matcher that missed nested files.
+        self.assertTrue(_path_matches_pattern("src/foo/bar.py", "src/**/*.py"))
+        self.assertFalse(_path_matches_pattern("docs/x.md", "src/**/*.py"))
+
+    def test_activate_conditional_via_pathspec(self) -> None:
+        # AC#5: paths: ["src/**/*.py"] activates for src/foo/bar.py
+        with tempfile.TemporaryDirectory() as t:
+            base = Path(t)
+            sk = base / "skills" / "py-helper"
+            sk.mkdir(parents=True)
+            (sk / "SKILL.md").write_text(
+                "---\n"
+                "description: py helper\n"
+                "paths:\n"
+                "  - src/**/*.py\n"
+                "---\n"
+                "body\n"
+            )
+            # Loading puts the skill into _conditional_skills (because
+            # paths is set), not into the returned list — that's the
+            # contract callers rely on.
+            loaded = load_skills_from_skills_dir(
+                str(sk.parent), "projectSettings"
+            )
+            from src.skills.loader import _conditional_skills, _dynamic_skills
+            # Manually move into conditional pool (simulates the
+            # get_skill_dir_commands path):
+            for s in loaded:
+                _conditional_skills[s.name] = s
+
+            cwd = str(base)
+            (base / "src" / "foo").mkdir(parents=True)
+            (base / "src" / "foo" / "bar.py").write_text("x = 1")
+
+            activated = activate_conditional_skills_for_paths(
+                [str(base / "src" / "foo" / "bar.py")], cwd
+            )
+            self.assertIn("py-helper", activated)
+            self.assertIn("py-helper", _dynamic_skills)
+
+            # Same skill should NOT activate for unrelated docs/x.md:
+            _dynamic_skills.clear()
+            _conditional_skills["py-helper"] = loaded[0]
+            (base / "docs").mkdir()
+            (base / "docs" / "x.md").write_text("doc")
+            activated = activate_conditional_skills_for_paths(
+                [str(base / "docs" / "x.md")], cwd
+            )
+            self.assertNotIn("py-helper", activated)
+
+
+class TestActivatedConditionalIsInvokableViaSkillTool(unittest.TestCase):
+    """Regression for QA bug #14.
+
+    Before the fix, ``get_all_skills`` did not merge ``_dynamic_skills``
+    into ``_skill_registry``, so a conditional skill that
+    ``activate_conditional_skills_for_paths`` had just promoted was
+    invisible to ``SkillTool`` (`Unknown skill: ...`, error_code=2).
+    """
+
+    def setUp(self) -> None:
+        clear_skill_caches(); clear_dynamic_skills(); clear_skill_registry()
+        self._tmp = tempfile.TemporaryDirectory()
+        self._project = Path(self._tmp.name).resolve()
+        # Isolate $HOME and managed-dir so user/managed discovery doesn't
+        # contaminate the project under test.
+        self._home = self._project / "_home"; self._home.mkdir()
+        self._managed = self._project / "_etc"; self._managed.mkdir()
+        self._env_patch = patch.dict(
+            os.environ,
+            {
+                "HOME": str(self._home),
+                "CLAUDE_CONFIG_DIR": str(self._home / ".claude"),
+                "CLAUDE_MANAGED_CONFIG_DIR": str(self._managed),
+            },
+            clear=False,
+        )
+        self._env_patch.start()
+        for k in (
+            "CLAWCODEX_SKILLS_DIR",
+            "CLAUDE_SKILLS_DIR",
+            "CLAWCODEX_MANAGED_SKILLS_DIR",
+            "CLAUDE_CODE_BARE_MODE",
+            "CLAUDE_CODE_ADDITIONAL_DIRECTORIES",
+            "CLAUDE_CODE_DISABLE_POLICY_SKILLS",
+        ):
+            os.environ.pop(k, None)
+
+    def tearDown(self) -> None:
+        self._env_patch.stop()
+        self._tmp.cleanup()
+        clear_skill_caches(); clear_dynamic_skills(); clear_skill_registry()
+
+    def test_skilltool_can_invoke_activated_conditional(self) -> None:
+        from src.skills.loader import get_all_skills, get_registered_skill
+        from src.tool_system.context import ToolContext
+        from src.tool_system.tools import SkillTool
+
+        # Place a paths-gated SKILL.md under .claude/skills/lint-py/
+        skill_dir = self._project / ".claude" / "skills" / "lint-py"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "description: Lint Python files\n"
+            "paths:\n"
+            '  - "**/*.py"\n'
+            "---\n"
+            "Lint that file.\n"
+        )
+
+        # Pre-activation: the skill is held back (conditional).
+        names = {s.name for s in get_all_skills(project_root=self._project)}
+        self.assertNotIn("lint-py", names)
+        self.assertIsNone(get_registered_skill("lint-py"))
+
+        # Touching a .py file activates it.
+        (self._project / "src").mkdir()
+        target = self._project / "src" / "foo.py"
+        target.write_text("x = 1")
+        activated = activate_conditional_skills_for_paths(
+            [str(target)], str(self._project)
+        )
+        self.assertIn("lint-py", activated)
+
+        # The SkillTool path must now succeed for /lint-py — that is,
+        # `get_all_skills` must splice `_dynamic_skills` into the
+        # registry so the lookup hits.
+        ctx = ToolContext(workspace_root=self._project)
+        result = SkillTool.call({"skill": "lint-py"}, ctx)
+        self.assertFalse(
+            result.is_error,
+            f"SkillTool returned error after activation: {result.output}",
+        )
+        self.assertTrue(result.output["success"])
+        self.assertIn("Lint that file.", result.output["prompt"])
+
+
+class TestDiscoverSkillDirsGitignore(unittest.TestCase):
+    def setUp(self) -> None:
+        clear_skill_caches(); clear_dynamic_skills()
+        self._tmp = tempfile.TemporaryDirectory()
+        self._cwd = Path(self._tmp.name).resolve()
+        # Initialize a real git repo so `git check-ignore` works.
+        try:
+            subprocess.run(
+                ["git", "init", "-q"], cwd=self._cwd, check=True, timeout=10,
+            )
+            subprocess.run(
+                ["git", "config", "user.email", "t@t.test"],
+                cwd=self._cwd, check=True, timeout=5,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "t"],
+                cwd=self._cwd, check=True, timeout=5,
+            )
+            self._git_ok = True
+        except (FileNotFoundError, subprocess.SubprocessError):
+            self._git_ok = False
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+        clear_skill_caches(); clear_dynamic_skills()
+
+    def test_skips_gitignored_skills_dir(self) -> None:
+        if not self._git_ok:
+            self.skipTest("git unavailable")
+        # AC#6: node_modules-style gitignored dir's .claude/skills isn't loaded.
+        (self._cwd / ".gitignore").write_text("node_modules/\n")
+        ignored_pkg = self._cwd / "node_modules" / "pkg"
+        ignored_pkg.mkdir(parents=True)
+        skills_dir = ignored_pkg / ".claude" / "skills"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "evil").mkdir()
+        (skills_dir / "evil" / "SKILL.md").write_text(
+            "---\ndescription: evil\n---\n"
+        )
+        (ignored_pkg / "x.js").write_text("nop")
+
+        new_dirs = discover_skill_dirs_for_paths(
+            [str(ignored_pkg / "x.js")], str(self._cwd)
+        )
+        self.assertNotIn(str(skills_dir), new_dirs)
+
+    def test_loads_non_gitignored_skills_dir(self) -> None:
+        if not self._git_ok:
+            self.skipTest("git unavailable")
+        # Sanity: a non-ignored .claude/skills dir IS picked up.
+        nested = self._cwd / "feature"
+        nested.mkdir()
+        skills_dir = nested / ".claude" / "skills"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "good").mkdir()
+        (skills_dir / "good" / "SKILL.md").write_text(
+            "---\ndescription: good\n---\n"
+        )
+        (nested / "f.txt").write_text("x")
+        new_dirs = discover_skill_dirs_for_paths(
+            [str(nested / "f.txt")], str(self._cwd)
+        )
+        self.assertIn(str(skills_dir), new_dirs)
+
+
+class TestGitignoreCheckHelper(unittest.TestCase):
+    def test_returns_false_outside_git_repo(self) -> None:
+        with tempfile.TemporaryDirectory() as t:
+            p = Path(t) / "f.txt"
+            p.write_text("x")
+            # No git init → fail open.
+            self.assertFalse(_is_path_gitignored(str(p), t))
+
+    def test_returns_true_for_ignored_path(self) -> None:
+        if shutil.which("git") is None:
+            self.skipTest("git unavailable")
+        with tempfile.TemporaryDirectory() as t:
+            try:
+                subprocess.run(
+                    ["git", "init", "-q"], cwd=t, check=True, timeout=10,
+                )
+            except subprocess.SubprocessError:
+                self.skipTest("git init failed")
+            (Path(t) / ".gitignore").write_text("ignored_file\n")
+            (Path(t) / "ignored_file").write_text("x")
+            self.assertTrue(_is_path_gitignored("ignored_file", t))
+            (Path(t) / "kept").write_text("x")
+            self.assertFalse(_is_path_gitignored("kept", t))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skills_dedup_paths.py
+++ b/tests/test_skills_dedup_paths.py
@@ -1,0 +1,368 @@
+"""Groups D & E — Symlink dedup, bare/policy modes, conditional paths,
+and gitignore-aware dynamic discovery (covers DEV-4).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest.mock as mock
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from src.skills.bundled_skills import clear_bundled_skills
+from src.skills.loader import (
+    activate_conditional_skills_for_paths,
+    clear_dynamic_skills,
+    clear_skill_caches,
+    clear_skill_registry,
+    discover_skill_dirs_for_paths,
+    get_all_skills,
+    get_conditional_skill_count,
+    get_dynamic_skills,
+    get_skill_dir_commands,
+)
+
+
+@pytest.fixture
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    for var in (
+        "CLAUDE_CONFIG_DIR",
+        "CLAUDE_MANAGED_CONFIG_DIR",
+        "CLAWCODEX_SKILLS_DIR",
+        "CLAUDE_SKILLS_DIR",
+        "CLAWCODEX_MANAGED_SKILLS_DIR",
+        "CLAUDE_CODE_BARE_MODE",
+        "CLAUDE_CODE_DISABLE_POLICY_SKILLS",
+        "CLAUDE_CODE_ADDITIONAL_DIRECTORIES",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("CLAUDE_MANAGED_CONFIG_DIR", str(tmp_path / "managed"))
+    yield home
+
+
+@pytest.fixture(autouse=True)
+def _clean_skill_state() -> Iterator[None]:
+    clear_skill_caches()
+    clear_dynamic_skills()
+    clear_skill_registry()
+    clear_bundled_skills()
+    yield
+    clear_skill_caches()
+    clear_dynamic_skills()
+    clear_skill_registry()
+    clear_bundled_skills()
+
+
+def _write_skill(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+# ======================================================================
+# D — Dedup + bare/policy modes
+# ======================================================================
+
+
+def test_symlinked_skill_collapses_to_single_entry(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    """Two paths pointing at the same SKILL.md (via symlink) must
+    collapse to one entry after realpath dedup."""
+    project = tmp_path / "proj"
+    real_dir = project / ".claude" / "skills" / "real"
+    _write_skill(real_dir / "SKILL.md", "---\ndescription: real\n---\nbody")
+
+    # Create a sibling symlinked dir that points at the same
+    # SKILL.md-containing folder. After realpath dedup they should
+    # collapse to one entry.
+    link_dir = project / ".claude" / "skills" / "linked"
+    link_dir.symlink_to(real_dir, target_is_directory=True)
+
+    skills = get_skill_dir_commands(str(project))
+    # Both names land in the walker, but the realpath dedup keeps the
+    # first-wins entry only. Total count of unique skills must be 1.
+    seen_files = {
+        os.path.realpath(str(Path(s.base_dir) / "SKILL.md"))
+        for s in skills
+        if s.base_dir
+    }
+    assert len(seen_files) == 1, (
+        f"realpath dedup should collapse symlinked skills, got: "
+        f"{[s.name for s in skills]}"
+    )
+
+
+def test_disable_policy_skills_excludes_managed_dir(
+    tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Plant a "policy" skill in the managed dir we set via the fixture.
+    managed_root = Path(os.environ["CLAUDE_MANAGED_CONFIG_DIR"])
+    _write_skill(
+        managed_root / ".claude" / "skills" / "policyskill" / "SKILL.md",
+        "---\ndescription: policy\n---\nbody",
+    )
+
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    # Without the disable, the policy skill should appear.
+    skills = get_skill_dir_commands(str(project))
+    assert any(s.name == "policyskill" for s in skills), (
+        f"managed/policy skill should load by default; got: "
+        f"{[s.name for s in skills]}"
+    )
+
+    # With CLAUDE_CODE_DISABLE_POLICY_SKILLS=1, it must NOT.
+    clear_skill_caches()
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_POLICY_SKILLS", "1")
+    skills2 = get_skill_dir_commands(str(project))
+    assert all(s.name != "policyskill" for s in skills2), (
+        f"CLAUDE_CODE_DISABLE_POLICY_SKILLS=1 must skip the managed "
+        f"dir; got: {[s.name for s in skills2]}"
+    )
+
+
+def test_bare_mode_skips_autodiscovery(
+    tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = tmp_path / "proj"
+    _write_skill(
+        project / ".claude" / "skills" / "projskill" / "SKILL.md",
+        "---\ndescription: proj\n---\nbody",
+    )
+
+    # Sanity: without bare mode the project skill loads.
+    assert any(s.name == "projskill" for s in get_skill_dir_commands(str(project)))
+
+    # With bare mode and no --add-dir paths, discovery returns empty.
+    clear_skill_caches()
+    monkeypatch.setenv("CLAUDE_CODE_BARE_MODE", "1")
+    assert get_skill_dir_commands(str(project)) == []
+
+
+def test_bare_mode_with_add_dir_only_loads_those(
+    tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = tmp_path / "proj"
+    # Plant a project skill that should be IGNORED in bare mode.
+    _write_skill(
+        project / ".claude" / "skills" / "projskill" / "SKILL.md",
+        "---\ndescription: proj\n---\nbody",
+    )
+
+    # Plant an additional-dir skill that SHOULD load.
+    extra_dir = tmp_path / "extra"
+    _write_skill(
+        extra_dir / ".claude" / "skills" / "extraskill" / "SKILL.md",
+        "---\ndescription: extra\n---\nbody",
+    )
+
+    monkeypatch.setenv("CLAUDE_CODE_BARE_MODE", "1")
+    monkeypatch.setenv("CLAUDE_CODE_ADDITIONAL_DIRECTORIES", str(extra_dir))
+
+    skills = get_skill_dir_commands(str(project))
+    names = {s.name for s in skills}
+    assert "extraskill" in names, (
+        f"bare mode should still load --add-dir skills; got: {names}"
+    )
+    assert "projskill" not in names, (
+        f"bare mode must skip auto-discovery; got: {names}"
+    )
+
+
+def test_managed_user_project_precedence(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    """When the same skill name appears in managed + user + project
+    dirs, the unified ``get_all_skills`` merge keeps the highest-
+    priority occurrence (TS order: managed → user → project → bundled).
+    """
+    managed_root = Path(os.environ["CLAUDE_MANAGED_CONFIG_DIR"])
+    user_root = isolated_home
+
+    _write_skill(
+        managed_root / ".claude" / "skills" / "shared" / "SKILL.md",
+        "---\ndescription: from-managed\n---\nM",
+    )
+    _write_skill(
+        user_root / ".claude" / "skills" / "shared" / "SKILL.md",
+        "---\ndescription: from-user\n---\nU",
+    )
+    project = tmp_path / "proj"
+    _write_skill(
+        project / ".claude" / "skills" / "shared" / "SKILL.md",
+        "---\ndescription: from-project\n---\nP",
+    )
+
+    skills = get_all_skills(project_root=project)
+    by_name = {s.name: s for s in skills}
+    # Managed wins per `get_skill_dir_commands` ordering (managed loads
+    # first, dedup is first-wins).
+    assert by_name["shared"].description == "from-managed", (
+        f"precedence regression — expected managed to win, got: "
+        f"{by_name['shared'].description!r}"
+    )
+
+
+# ======================================================================
+# E — Conditional paths + dynamic discovery
+# ======================================================================
+
+
+def test_conditional_skill_held_until_path_matches(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    project = tmp_path / "proj"
+    _write_skill(
+        project / ".claude" / "skills" / "lintpy" / "SKILL.md",
+        "---\n"
+        "description: lint python\n"
+        "paths:\n"
+        '  - "src/**/*.py"\n'
+        "---\n"
+        "Run ruff",
+    )
+
+    # Initial load: the conditional skill is held back.
+    skills = get_skill_dir_commands(str(project))
+    assert all(s.name != "lintpy" for s in skills), (
+        "conditional skill must NOT appear in unconditional results"
+    )
+    assert get_conditional_skill_count() >= 1
+
+    # A non-matching activation must not flip it on.
+    activated = activate_conditional_skills_for_paths(
+        [str(project / "docs" / "x.md")], str(project)
+    )
+    assert activated == []
+    assert "lintpy" not in {s.name for s in get_dynamic_skills()}
+
+    # A matching activation flips it on.
+    activated = activate_conditional_skills_for_paths(
+        [str(project / "src" / "foo" / "bar.py")], str(project)
+    )
+    assert activated == ["lintpy"]
+    assert "lintpy" in {s.name for s in get_dynamic_skills()}
+
+
+def test_paths_double_glob_treated_as_unconditional(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    project = tmp_path / "proj"
+    _write_skill(
+        project / ".claude" / "skills" / "always" / "SKILL.md",
+        "---\ndescription: always\npaths:\n  - \"**\"\n---\nbody",
+    )
+    skills = get_skill_dir_commands(str(project))
+    names = {s.name for s in skills}
+    assert "always" in names, (
+        "`paths: ['**']` cleans to no-filter (None) and must appear "
+        "in the unconditional list, not the conditional bucket"
+    )
+
+
+def test_path_validity_guards_reject_dotdot_and_absolute(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    project = tmp_path / "proj"
+    _write_skill(
+        project / ".claude" / "skills" / "guarded" / "SKILL.md",
+        "---\n"
+        "description: guarded\n"
+        "paths:\n"
+        '  - "src/**/*.py"\n'
+        "---\n"
+        "body",
+    )
+
+    # Prime the conditional bucket.
+    get_skill_dir_commands(str(project))
+    assert get_conditional_skill_count() >= 1
+
+    # `..`-escaping path: should be filtered out by the validity guard.
+    above = tmp_path.parent / "outside.py"
+    activated = activate_conditional_skills_for_paths(
+        [str(above)], str(project)
+    )
+    assert activated == [], (
+        "files outside the cwd (relpath starts with '..') must be "
+        "ignored by the activation guard"
+    )
+
+    # Absolute path that ISN'T under cwd similarly drops.
+    activated2 = activate_conditional_skills_for_paths(
+        ["/etc/passwd"], str(project)
+    )
+    assert activated2 == []
+
+    # The skill stays in the conditional bucket.
+    assert "guarded" not in {s.name for s in get_dynamic_skills()}
+
+
+def test_dynamic_discovery_skips_gitignored_dirs(
+    tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`discover_skill_dirs_for_paths` consults `git check-ignore` to
+    avoid loading skills out of gitignored trees (e.g. node_modules).
+    """
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    # Plant a `.claude/skills` dir under a gitignored path.
+    ignored_skills_dir = project / "node_modules" / "pkg" / ".claude" / "skills"
+    ignored_skills_dir.mkdir(parents=True)
+    (ignored_skills_dir / "noisy" / "SKILL.md").parent.mkdir(parents=True)
+    (ignored_skills_dir / "noisy" / "SKILL.md").write_text(
+        "---\ndescription: noisy\n---\nbody"
+    )
+
+    # Mock `git check-ignore` to say "yes, this is ignored". We mock
+    # at the `subprocess.run` boundary used by `_is_path_gitignored`.
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        # cmd looks like ["git", "check-ignore", "<path>"]
+        # Anything under node_modules/ is ignored.
+        path = cmd[-1] if cmd else ""
+        rc = 0 if "node_modules" in path else 1
+        return subprocess.CompletedProcess(cmd, rc, "", "")
+
+    file_under_ignored = ignored_skills_dir.parent / "lib.js"
+    file_under_ignored.write_text("//")
+
+    # Walk from a touched file inside the ignored dir.
+    with mock.patch("subprocess.run", side_effect=fake_run):
+        new_dirs = discover_skill_dirs_for_paths(
+            [str(file_under_ignored)], str(project)
+        )
+
+    # The gitignored skills dir must NOT be returned.
+    assert all(
+        "node_modules" not in d for d in new_dirs
+    ), f"gitignored skills dir leaked into discovery: {new_dirs}"
+
+
+def test_dynamic_discovery_includes_non_ignored_dirs(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    """Sanity counterpart: a non-ignored `.claude/skills` dir is
+    returned by the discovery walk."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    nested_skills_dir = project / "pkg" / ".claude" / "skills"
+    nested_skills_dir.mkdir(parents=True)
+    file_path = project / "pkg" / "lib.js"
+    file_path.write_text("//")
+
+    # `git check-ignore` outside a git repo returns 128 — treated as
+    # not-ignored by `_is_path_gitignored`'s fail-open branch.
+    new_dirs = discover_skill_dirs_for_paths([str(file_path)], str(project))
+    # The nested skills dir is included.
+    assert any(str(nested_skills_dir) == d for d in new_dirs), (
+        f"non-ignored nested .claude/skills dir should appear in "
+        f"discovery; got: {new_dirs}"
+    )

--- a/tests/test_skills_e2e.py
+++ b/tests/test_skills_e2e.py
@@ -1,0 +1,368 @@
+"""QA-2 — End-to-end real-skill tests.
+
+Drops three example SKILL.md files (under ``tests/fixtures/skills/``)
+into a workspace's ``.claude/skills/`` tree (via tmp-path symlink) and
+exercises them through the full ``SkillTool`` pipeline:
+
+    fixture SKILL.md  ──►  load via get_all_skills  ──►  invoke via
+    SkillTool.call    ──►  rendered prompt with all transforms applied
+
+The fixtures (live on disk under ``tests/fixtures/skills/``):
+
+  - ``commit-helper``     simple skill with args, ``${CLAUDE_SKILL_DIR}``,
+                          ``${CLAUDE_SESSION_ID}``, allowed-tools.
+  - ``frontend/add-component``
+                          nested-namespace skill (resolves as
+                          ``frontend:add-component``); has ``when_to_use``
+                          and a named arg.
+  - ``lint-py``           conditional skill (paths-gated) that ALSO has a
+                          ``!`pwd``` shell block — exercises both the
+                          conditional-activation gate and the shell-exec-
+                          in-prompt path end-to-end.
+
+Plus one bundled-skill invocation (``simplify`` from DEV-5) to cover
+the bundled-path wiring through SkillTool.
+
+Acceptance criteria covered:
+  1. ``pytest tests/test_skills_e2e.py -v`` passes.
+  2. ``commit-helper`` test asserts arg, ``${CLAUDE_SKILL_DIR}``,
+     ``${CLAUDE_SESSION_ID}``, base-dir header all present.
+  3. ``frontend:add-component`` invocation by namespaced name succeeds.
+  4. ``lint-py`` not invokable until
+     ``activate_conditional_skills_for_paths`` matches.
+  5. ``simplify`` bundled skill exercised end-to-end through SkillTool.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from src.skills.bundled import init_bundled_skills
+from src.skills.bundled_skills import clear_bundled_skills
+from src.skills.loader import (
+    activate_conditional_skills_for_paths,
+    clear_dynamic_skills,
+    clear_skill_caches,
+    clear_skill_registry,
+    get_all_skills,
+    get_conditional_skill_count,
+    get_registered_skill,
+)
+from src.tool_system.context import ToolContext
+from src.tool_system.tools import SkillTool
+
+
+FIXTURES_ROOT = Path(__file__).parent / "fixtures" / "skills"
+FIXTURE_NAMES = ("commit-helper", "frontend", "lint-py")
+
+
+@pytest.fixture
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Isolate every env knob that would inject a non-fixture skill dir."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    for var in (
+        "CLAUDE_CONFIG_DIR",
+        "CLAWCODEX_SKILLS_DIR",
+        "CLAUDE_SKILLS_DIR",
+        "CLAWCODEX_MANAGED_SKILLS_DIR",
+        "CLAUDE_CODE_BARE_MODE",
+        "CLAUDE_CODE_DISABLE_POLICY_SKILLS",
+        "CLAUDE_CODE_ADDITIONAL_DIRECTORIES",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("CLAUDE_MANAGED_CONFIG_DIR", str(tmp_path / "managed"))
+    yield home
+
+
+@pytest.fixture(autouse=True)
+def _clean_skill_state() -> Iterator[None]:
+    clear_skill_caches()
+    clear_dynamic_skills()
+    clear_skill_registry()
+    clear_bundled_skills()
+    yield
+    clear_skill_caches()
+    clear_dynamic_skills()
+    clear_skill_registry()
+    clear_bundled_skills()
+
+
+@pytest.fixture
+def project_with_fixtures(tmp_path: Path, isolated_home: Path) -> Path:
+    """Construct a workspace whose ``.claude/skills/`` mirrors the
+    fixture catalogue.
+
+    Each fixture under ``tests/fixtures/skills/<name>/`` is copied to
+    ``<workspace>/.claude/skills/<name>/`` so the unified loader picks
+    them up via the project-skills walk. We copy (rather than symlink)
+    so the dedup-by-realpath logic doesn't collapse them with the
+    fixtures dir itself.
+    """
+    project = tmp_path / "proj"
+    skills_root = project / ".claude" / "skills"
+    skills_root.mkdir(parents=True)
+
+    for name in FIXTURE_NAMES:
+        src = FIXTURES_ROOT / name
+        dst = skills_root / name
+        shutil.copytree(src, dst)
+
+    return project
+
+
+# ======================================================================
+# 1. ``commit-helper`` — args + ${CLAUDE_SKILL_DIR} + ${CLAUDE_SESSION_ID}
+#    + allowed-tools metadata + base-dir header.
+# ======================================================================
+
+
+def test_commit_helper_renders_all_substitutions(
+    project_with_fixtures: Path,
+) -> None:
+    ctx = ToolContext(workspace_root=project_with_fixtures)
+    ctx.session_id = "S-e2e-001"
+
+    result = SkillTool.call(
+        {"skill": "commit-helper", "args": "feat"},
+        ctx,
+    )
+    out = result.output
+    assert out["success"] is True, f"unexpected failure: {out}"
+    prompt = out["prompt"]
+
+    skill_dir = project_with_fixtures / ".claude" / "skills" / "commit-helper"
+    expected_dir_str = str(skill_dir.resolve())
+
+    # (a) base-dir header — exact format pinned by render_skill_prompt.
+    expected_header = f"Base directory for this skill: {expected_dir_str}\n\n"
+    assert prompt.startswith(expected_header), (
+        f"missing/mangled base-dir header.\n"
+        f"  expected start: {expected_header!r}\n"
+        f"  actual start:   {prompt[:200]!r}"
+    )
+
+    # (b) $scope arg substitution — `feat` lands in the body.
+    assert "in `feat` scope" in prompt
+
+    # (c) ${CLAUDE_SKILL_DIR} resolved to the skill's actual abs path.
+    assert f"Skill base: {expected_dir_str}" in prompt
+    assert "${CLAUDE_SKILL_DIR}" not in prompt
+
+    # (d) ${CLAUDE_SESSION_ID} resolved.
+    assert "Session: S-e2e-001" in prompt
+    assert "${CLAUDE_SESSION_ID}" not in prompt
+
+    # (e) allowed-tools metadata propagated to the tool result.
+    assert out["allowedTools"] == ["Bash", "Read"], (
+        f"allowed-tools metadata didn't ride through: {out!r}"
+    )
+    assert out["loadedFrom"] == "project"
+
+
+# ======================================================================
+# 2. ``frontend:add-component`` — nested namespace + when_to_use +
+#    named arg substitution.
+# ======================================================================
+
+
+def test_frontend_add_component_namespaced_invocation(
+    project_with_fixtures: Path,
+) -> None:
+    # Listing first — confirms the namespace-construction logic.
+    skills = get_all_skills(project_root=project_with_fixtures)
+    by_name = {s.name: s for s in skills}
+    assert "frontend:add-component" in by_name, (
+        f"expected nested namespace 'frontend:add-component' in {sorted(by_name)}"
+    )
+
+    # `when_to_use` field rides onto the loaded Skill.
+    assert by_name["frontend:add-component"].when_to_use == (
+        "When the user asks to add a new React component."
+    )
+
+    # Invoke through SkillTool by the namespaced name.
+    ctx = ToolContext(workspace_root=project_with_fixtures)
+    result = SkillTool.call(
+        {"skill": "frontend:add-component", "args": "Button"},
+        ctx,
+    )
+    out = result.output
+    assert out["success"] is True
+    assert out["commandName"] == "frontend:add-component"
+    # Named-arg substitution: `$name` → `Button`.
+    assert "src/components/Button.tsx" in out["prompt"]
+
+
+# ======================================================================
+# 3. ``lint-py`` — conditional skill: NOT invokable until
+#    ``activate_conditional_skills_for_paths`` matches.
+#    Bonus: once activated, the embedded ``!`pwd`` shell block runs
+#    end-to-end through BashTool, demonstrating shell-exec coverage.
+# ======================================================================
+
+
+def test_lint_py_not_invokable_until_activated(
+    project_with_fixtures: Path,
+) -> None:
+    # Initial registry walk: ``lint-py`` is conditional, so it should
+    # be held back from the unconditional list.
+    skills = get_all_skills(project_root=project_with_fixtures)
+    names = {s.name for s in skills}
+    assert "lint-py" not in names, (
+        f"conditional skill must NOT appear before path activation; "
+        f"got: {sorted(names)}"
+    )
+    assert get_conditional_skill_count() >= 1, (
+        "conditional bucket should hold lint-py"
+    )
+
+    # Activation with a non-matching path keeps it dormant.
+    activated = activate_conditional_skills_for_paths(
+        [str(project_with_fixtures / "docs" / "x.md")],
+        str(project_with_fixtures),
+    )
+    assert "lint-py" not in activated
+
+    # Activation with a matching path flips it on.
+    py_path = project_with_fixtures / "src" / "foo.py"
+    py_path.parent.mkdir(parents=True, exist_ok=True)
+    py_path.write_text("# placeholder")
+    activated = activate_conditional_skills_for_paths(
+        [str(py_path)], str(project_with_fixtures)
+    )
+    assert "lint-py" in activated, (
+        "conditional skill should activate on matching path; "
+        f"activated={activated}"
+    )
+
+    # After activation, `get_all_skills` must return lint-py — the
+    # unified loader splices `_dynamic_skills` (where activated
+    # conditionals live) into `_skill_registry` so the canonical
+    # SkillTool lookup path sees them.
+    skills_after = get_all_skills(project_root=project_with_fixtures)
+    names_after = {s.name for s in skills_after}
+    assert "lint-py" in names_after, (
+        f"after activation, lint-py should be reachable via "
+        f"get_all_skills; got: {sorted(names_after)}"
+    )
+
+
+def test_lint_py_after_activation_runs_shell_block_through_skilltool(
+    project_with_fixtures: Path,
+) -> None:
+    """Once activated, lint-py's `!`pwd`` shell block must execute
+    end-to-end via BashTool when invoked through SkillTool.
+
+    The fix for QA bug #14 makes `get_all_skills` splice
+    `_dynamic_skills` into `_skill_registry`, so the canonical SkillTool
+    lookup path resolves activated conditional skills without any
+    test-side promotion.
+    """
+    # Prime the registry + activate.
+    get_all_skills(project_root=project_with_fixtures)
+    py_path = project_with_fixtures / "src" / "foo.py"
+    py_path.parent.mkdir(parents=True, exist_ok=True)
+    py_path.write_text("# placeholder")
+    activate_conditional_skills_for_paths(
+        [str(py_path)], str(project_with_fixtures)
+    )
+
+    ctx = ToolContext(workspace_root=project_with_fixtures)
+    result = SkillTool.call({"skill": "lint-py"}, ctx)
+
+    out = result.output
+    assert out["success"] is True, f"lint-py invocation failed: {out}"
+    prompt = out["prompt"]
+
+    # Shell block ran: `!`pwd`` is replaced by the actual cwd path.
+    assert "Working directory: " in prompt
+    # The literal block is gone (substituted).
+    assert "!`pwd`" not in prompt
+    # The substituted output looks like a real path (starts with `/`).
+    # We don't pin the exact path because the test runs in whatever
+    # cwd pytest invoked from; what matters is that *something* path-
+    # shaped landed there.
+    after_marker = prompt.split("Working directory: ", 1)[1].split("\n", 1)[0]
+    assert after_marker.startswith("/"), (
+        f"shell exec should have produced a path; got: {after_marker!r}"
+    )
+
+
+# ======================================================================
+# 4. Bundled skill — exercises DEV-5's init orchestrator wiring through
+#    SkillTool. Picks ``simplify`` per the spec example.
+# ======================================================================
+
+
+def test_simplify_bundled_skill_invokable_through_skilltool(
+    project_with_fixtures: Path,
+) -> None:
+    # DEV-5: init orchestrator registers the bundled-skill catalogue.
+    init_bundled_skills()
+
+    # Sanity: simplify is in the registry after init.
+    skills = get_all_skills(project_root=project_with_fixtures)
+    by_name = {s.name: s for s in skills}
+    assert "simplify" in by_name, (
+        f"bundled `simplify` missing after init; got: {sorted(by_name)}"
+    )
+    assert by_name["simplify"].loaded_from == "bundled"
+
+    # Invoke through SkillTool — exercises the bundled `get_prompt_for_command`
+    # branch in `_run_markdown_skill`.
+    ctx = ToolContext(workspace_root=project_with_fixtures)
+    result = SkillTool.call(
+        {"skill": "simplify", "args": "focus on caching"},
+        ctx,
+    )
+    out = result.output
+    assert out["success"] is True, f"bundled simplify failed: {out}"
+    prompt = out["prompt"]
+
+    # Pin the bundled prompt's contract (matches DEV-5 simplify.py):
+    assert "Phase 1: Identify Changes" in prompt
+    assert "Phase 2: Launch Three Review Agents in Parallel" in prompt
+    # User-supplied args land in the "Additional Focus" block.
+    assert "focus on caching" in prompt
+    # Bundled skills don't get a base-dir header (they have no skill_root).
+    assert "Base directory for this skill" not in prompt
+    assert out["loadedFrom"] == "bundled"
+
+
+# ======================================================================
+# 5. Catalogue listing — what the model sees in its system reminder.
+#    All three disk fixtures + at least one bundled skill, all reachable
+#    from the unified registry.
+# ======================================================================
+
+
+def test_catalogue_lists_disk_and_bundled_skills_together(
+    project_with_fixtures: Path,
+) -> None:
+    init_bundled_skills()
+    skills = get_all_skills(project_root=project_with_fixtures)
+    names = {s.name for s in skills}
+
+    # Disk fixtures (lint-py is conditional, so excluded from the
+    # unconditional listing — that's by design).
+    assert "commit-helper" in names
+    assert "frontend:add-component" in names
+    assert "lint-py" not in names, (
+        "lint-py is conditional and must not appear until activated"
+    )
+
+    # Bundled (DEV-5).
+    assert "simplify" in names
+
+    # Source labels: disk skills report `project`, bundled report `bundled`.
+    by_name = {s.name: s for s in skills}
+    assert by_name["commit-helper"].loaded_from == "project"
+    assert by_name["frontend:add-component"].loaded_from == "project"
+    assert by_name["simplify"].loaded_from == "bundled"

--- a/tests/test_skills_frontmatter_validators.py
+++ b/tests/test_skills_frontmatter_validators.py
@@ -1,0 +1,387 @@
+"""Tests for the YAML frontmatter parser + field validators.
+
+Covers DEV-3 acceptance criteria:
+1. Nested ``hooks:`` parses to a dict on Skill.
+2. Multi-line ``description: |`` joins.
+3. ``model: inherit`` -> None; valid → kept; bogus → warning logged.
+4. ``effort:`` accepts ``low/medium/high/max`` and integers; rejects garbage.
+5. ``allowed-tools: [Bash(git diff:*), Read]`` preserves arg-pattern intact.
+6. Invalid hook shape → ``Skill.hooks is None`` (no exception).
+7. Existing tests in test_skills_loader_ws8.py / test_skills_system.py
+   keep passing (covered separately).
+"""
+
+from __future__ import annotations
+
+import logging
+import unittest
+from pathlib import Path
+
+from src.skills.frontmatter import parse_frontmatter
+from src.skills.loader import (
+    EFFORT_LEVELS,
+    FRONTMATTER_SHELLS,
+    _coerce_allowed_tools,
+    _coerce_description,
+    _coerce_effort,
+    _coerce_hooks,
+    _coerce_model,
+    _coerce_shell,
+    _extract_description_from_markdown,
+    load_skills_from_skills_dir,
+    parse_skill_frontmatter_fields,
+)
+
+
+# ----------------------------------------------------------------------
+# Frontmatter parser (PyYAML-backed)
+# ----------------------------------------------------------------------
+
+
+class TestParseFrontmatterYaml(unittest.TestCase):
+    def test_no_frontmatter_returns_body(self) -> None:
+        out = parse_frontmatter("just a markdown body\nwith lines")
+        self.assertEqual(out.frontmatter, {})
+        self.assertEqual(out.body, "just a markdown body\nwith lines")
+
+    def test_basic_scalars(self) -> None:
+        out = parse_frontmatter("---\ndescription: hi\nversion: 1\n---\nbody")
+        self.assertEqual(out.frontmatter["description"], "hi")
+        # PyYAML coerces numeric-looking values to int
+        self.assertEqual(out.frontmatter["version"], 1)
+        self.assertEqual(out.body, "body")
+
+    def test_inline_list(self) -> None:
+        out = parse_frontmatter(
+            "---\nallowed-tools: [Bash, Read]\n---\nbody"
+        )
+        self.assertEqual(out.frontmatter["allowed-tools"], ["Bash", "Read"])
+
+    def test_hyphen_list(self) -> None:
+        out = parse_frontmatter(
+            "---\nallowed-tools:\n  - Bash\n  - Read\n---\nbody"
+        )
+        self.assertEqual(out.frontmatter["allowed-tools"], ["Bash", "Read"])
+
+    def test_nested_dict_hooks(self) -> None:
+        text = (
+            "---\n"
+            "hooks:\n"
+            "  PostToolUse:\n"
+            "    - matcher: Write\n"
+            "      hooks:\n"
+            "        - type: command\n"
+            "          command: ./fmt.sh\n"
+            "---\n"
+            "body\n"
+        )
+        out = parse_frontmatter(text)
+        self.assertIn("hooks", out.frontmatter)
+        self.assertIsInstance(out.frontmatter["hooks"], dict)
+        post = out.frontmatter["hooks"]["PostToolUse"]
+        self.assertEqual(post[0]["matcher"], "Write")
+        self.assertEqual(post[0]["hooks"][0]["type"], "command")
+
+    def test_multiline_string_block(self) -> None:
+        text = (
+            "---\n"
+            "description: |\n"
+            "  multi\n"
+            "  line\n"
+            "---\n"
+            "body"
+        )
+        out = parse_frontmatter(text)
+        # YAML's ``|`` keeps interior newlines; the trailing newline is
+        # stripped because ``parse_frontmatter`` joins with ``\n`` and the
+        # frontmatter ends right at ``---``.
+        self.assertEqual(out.frontmatter["description"], "multi\nline")
+
+    def test_quoted_string(self) -> None:
+        out = parse_frontmatter(
+            '---\ndescription: "value with: colon"\n---\nbody'
+        )
+        self.assertEqual(out.frontmatter["description"], "value with: colon")
+
+    def test_empty_frontmatter(self) -> None:
+        out = parse_frontmatter("---\n---\nbody")
+        self.assertEqual(out.frontmatter, {})
+        self.assertEqual(out.body, "body")
+
+    def test_unclosed_frontmatter_keeps_body(self) -> None:
+        out = parse_frontmatter("---\ndescription: hi\nbody-line")
+        # No closing ``---`` → treat as no frontmatter, return raw text.
+        self.assertEqual(out.frontmatter, {})
+
+    def test_malformed_yaml_does_not_crash(self) -> None:
+        # Should not raise; should return empty frontmatter.
+        out = parse_frontmatter("---\nfoo: : bad\n---\nbody")
+        self.assertEqual(out.frontmatter, {})
+        self.assertEqual(out.body, "body")
+
+
+# ----------------------------------------------------------------------
+# Description extractor + coercer
+# ----------------------------------------------------------------------
+
+
+class TestDescriptionFallbacks(unittest.TestCase):
+    def test_first_non_empty_line_used(self) -> None:
+        out = _extract_description_from_markdown(
+            "\n\nFirst line text\nSecond\n", "default"
+        )
+        self.assertEqual(out, "First line text")
+
+    def test_heading_stripped(self) -> None:
+        out = _extract_description_from_markdown("# A Heading\nbody", "default")
+        self.assertEqual(out, "A Heading")
+
+    def test_truncates_long(self) -> None:
+        long = "x" * 200
+        out = _extract_description_from_markdown(long, "default")
+        self.assertEqual(len(out), 100)
+        self.assertTrue(out.endswith("..."))
+
+    def test_default_when_blank(self) -> None:
+        self.assertEqual(_extract_description_from_markdown("", "fallback"), "fallback")
+        self.assertEqual(
+            _extract_description_from_markdown("\n\n  \n", "fallback"), "fallback"
+        )
+
+    def test_coerce_description_uses_frontmatter(self) -> None:
+        desc, has = _coerce_description("explicit", "ignored", "name")
+        self.assertEqual(desc, "explicit")
+        self.assertTrue(has)
+
+    def test_coerce_description_falls_back(self) -> None:
+        desc, has = _coerce_description(None, "First body line\nrest", "skill-x")
+        self.assertEqual(desc, "First body line")
+        self.assertFalse(has)
+
+    def test_coerce_description_default_fallback(self) -> None:
+        desc, has = _coerce_description(None, "", "skill-x")
+        self.assertEqual(desc, "Skill: skill-x")
+        self.assertFalse(has)
+
+
+# ----------------------------------------------------------------------
+# Field validators
+# ----------------------------------------------------------------------
+
+
+class TestModelCoercion(unittest.TestCase):
+    def test_inherit_returns_none(self) -> None:
+        self.assertIsNone(_coerce_model("inherit"))
+
+    def test_alias_kept(self) -> None:
+        self.assertEqual(_coerce_model("sonnet"), "sonnet")
+
+    def test_canonical_name_kept_silently(self) -> None:
+        with self.assertLogs("src.skills.loader", level="WARNING") as cm:
+            # Have to log _something_ for the assertLogs context to pass; emit
+            # a sentinel so an unrelated absence of warnings doesn't fail.
+            logging.getLogger("src.skills.loader").warning("sentinel")
+            self.assertEqual(_coerce_model("claude-opus-4-5"), "claude-opus-4-5")
+        # only the sentinel; the valid-canonical model should not warn.
+        warnings = [r for r in cm.records if "sentinel" not in r.message]
+        self.assertEqual(warnings, [])
+
+    def test_unknown_model_warns(self) -> None:
+        with self.assertLogs("src.skills.loader", level="WARNING") as cm:
+            out = _coerce_model("totally-bogus")
+        self.assertEqual(out, "totally-bogus")  # kept; user might know best
+        self.assertTrue(any("not a recognized" in r.message for r in cm.records))
+
+    def test_empty_returns_none(self) -> None:
+        self.assertIsNone(_coerce_model(""))
+        self.assertIsNone(_coerce_model(None))
+
+
+class TestEffortCoercion(unittest.TestCase):
+    def test_levels_lowercased(self) -> None:
+        for v in EFFORT_LEVELS:
+            self.assertEqual(_coerce_effort(v.upper()), v)
+
+    def test_integer_kept_as_string(self) -> None:
+        self.assertEqual(_coerce_effort(5), "5")
+        self.assertEqual(_coerce_effort("7"), "7")
+
+    def test_invalid_warns_and_drops(self) -> None:
+        with self.assertLogs("src.skills.loader", level="WARNING") as cm:
+            out = _coerce_effort("insane")
+        self.assertIsNone(out)
+        self.assertTrue(any("not a valid level" in r.message for r in cm.records))
+
+    def test_empty_returns_none(self) -> None:
+        self.assertIsNone(_coerce_effort(None))
+        self.assertIsNone(_coerce_effort(""))
+
+
+class TestShellCoercion(unittest.TestCase):
+    def test_bash_accepted(self) -> None:
+        self.assertEqual(_coerce_shell("bash"), "bash")
+        self.assertEqual(_coerce_shell("BASH"), "bash")
+
+    def test_powershell_accepted(self) -> None:
+        self.assertEqual(_coerce_shell("powershell"), "powershell")
+
+    def test_invalid_warns_and_returns_none(self) -> None:
+        with self.assertLogs("src.skills.loader", level="WARNING") as cm:
+            out = _coerce_shell("zsh")
+        self.assertIsNone(out)
+        self.assertTrue(any("not recognized" in r.message for r in cm.records))
+
+    def test_empty_returns_none(self) -> None:
+        self.assertIsNone(_coerce_shell(None))
+        self.assertIsNone(_coerce_shell(""))
+
+
+class TestAllowedToolsCoercion(unittest.TestCase):
+    def test_arg_patterns_preserved(self) -> None:
+        out = _coerce_allowed_tools(["Bash(git diff:*)", "Read"])
+        self.assertEqual(out, ["Bash(git diff:*)", "Read"])
+
+    def test_string_form(self) -> None:
+        out = _coerce_allowed_tools("Bash, Read, Grep")
+        self.assertEqual(out, ["Bash", "Read", "Grep"])
+
+    def test_empty_inputs(self) -> None:
+        self.assertEqual(_coerce_allowed_tools(None), [])
+        self.assertEqual(_coerce_allowed_tools(""), [])
+        self.assertEqual(_coerce_allowed_tools([]), [])
+
+
+class TestHooksCoercion(unittest.TestCase):
+    def test_valid_shape(self) -> None:
+        hooks = {
+            "PostToolUse": [
+                {
+                    "matcher": "Write",
+                    "hooks": [{"type": "command", "command": "./fmt.sh"}],
+                }
+            ]
+        }
+        out = _coerce_hooks(hooks, skill_name="x")
+        self.assertEqual(out, hooks)
+
+    def test_unknown_event_drops(self) -> None:
+        hooks = {"NotAnEvent": [{"hooks": [{"type": "command"}]}]}
+        out = _coerce_hooks(hooks, skill_name="x")
+        self.assertIsNone(out)
+
+    def test_missing_inner_hooks_list(self) -> None:
+        hooks = {"PostToolUse": [{"matcher": "Write"}]}  # no `hooks` key
+        out = _coerce_hooks(hooks, skill_name="x")
+        self.assertIsNone(out)
+
+    def test_inner_hook_missing_type(self) -> None:
+        hooks = {
+            "PostToolUse": [{"hooks": [{"command": "./x.sh"}]}]  # no `type`
+        }
+        out = _coerce_hooks(hooks, skill_name="x")
+        self.assertIsNone(out)
+
+    def test_non_dict_input(self) -> None:
+        self.assertIsNone(_coerce_hooks("not a dict", skill_name="x"))
+        self.assertIsNone(_coerce_hooks([], skill_name="x"))
+
+    def test_none_input(self) -> None:
+        self.assertIsNone(_coerce_hooks(None, skill_name="x"))
+
+
+# ----------------------------------------------------------------------
+# Integration: parse_skill_frontmatter_fields dispatches to validators
+# ----------------------------------------------------------------------
+
+
+class TestParseSkillFrontmatterFields(unittest.TestCase):
+    def test_hooks_round_trip(self) -> None:
+        fm = {
+            "description": "hi",
+            "hooks": {
+                "PostToolUse": [
+                    {"hooks": [{"type": "command", "command": "./x.sh"}]}
+                ]
+            },
+        }
+        parsed = parse_skill_frontmatter_fields(fm, "body", "x")
+        self.assertIsNotNone(parsed["hooks"])
+        self.assertIn("PostToolUse", parsed["hooks"])
+
+    def test_invalid_hooks_dropped_silently(self) -> None:
+        # AC#6: invalid shape → hooks is None, no exception
+        fm = {"description": "hi", "hooks": {"PostToolUse": [{"matcher": "X"}]}}
+        parsed = parse_skill_frontmatter_fields(fm, "body", "x")
+        self.assertIsNone(parsed["hooks"])
+
+    def test_shell_passes_through(self) -> None:
+        fm = {"description": "hi", "shell": "powershell"}
+        parsed = parse_skill_frontmatter_fields(fm, "body", "x")
+        self.assertEqual(parsed["shell"], "powershell")
+
+    def test_model_inherit_to_none(self) -> None:
+        fm = {"description": "hi", "model": "inherit"}
+        parsed = parse_skill_frontmatter_fields(fm, "body", "x")
+        self.assertIsNone(parsed["model"])
+
+    def test_effort_int_preserved(self) -> None:
+        fm = {"description": "hi", "effort": 5}
+        parsed = parse_skill_frontmatter_fields(fm, "body", "x")
+        self.assertEqual(parsed["effort"], "5")
+
+    def test_effort_invalid_dropped(self) -> None:
+        fm = {"description": "hi", "effort": "insane"}
+        parsed = parse_skill_frontmatter_fields(fm, "body", "x")
+        self.assertIsNone(parsed["effort"])
+
+    def test_description_falls_back_to_first_line(self) -> None:
+        fm = {}  # no description
+        body = "First line of the body\nsecond"
+        parsed = parse_skill_frontmatter_fields(fm, body, "x")
+        self.assertEqual(parsed["description"], "First line of the body")
+        self.assertFalse(parsed["has_user_specified_description"])
+
+    def test_allowed_tools_with_arg_pattern(self) -> None:
+        fm = {"allowed-tools": ["Bash(git diff:*)", "Read"]}
+        parsed = parse_skill_frontmatter_fields(fm, "", "x")
+        self.assertEqual(parsed["allowed_tools"], ["Bash(git diff:*)", "Read"])
+
+
+# ----------------------------------------------------------------------
+# End-to-end via load_skills_from_skills_dir — disk SKILL.md path
+# ----------------------------------------------------------------------
+
+
+class TestLoadSkillsWithFrontmatter(unittest.TestCase):
+    def test_skill_carries_hooks_and_shell(self, *, tmp_path=None) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as t:
+            base = Path(t)
+            sk = base / "demo"
+            sk.mkdir()
+            (sk / "SKILL.md").write_text(
+                "---\n"
+                "description: demo\n"
+                "shell: powershell\n"
+                "hooks:\n"
+                "  PostToolUse:\n"
+                "    - matcher: Write\n"
+                "      hooks:\n"
+                "        - type: command\n"
+                "          command: ./fmt.sh\n"
+                "---\n"
+                "body\n"
+            )
+            skills = load_skills_from_skills_dir(str(base), "projectSettings")
+            self.assertEqual(len(skills), 1)
+            s = skills[0]
+            self.assertEqual(s.shell, "powershell")
+            self.assertIsNotNone(s.hooks)
+            self.assertIn("PostToolUse", s.hooks)
+            self.assertEqual(
+                s.hooks["PostToolUse"][0]["hooks"][0]["command"], "./fmt.sh"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skills_frontmatter_yaml.py
+++ b/tests/test_skills_frontmatter_yaml.py
@@ -1,0 +1,315 @@
+"""Group C — Frontmatter parser & field validators (covers DEV-3).
+
+DEV-3 swapped the homegrown frontmatter parser for ``yaml.safe_load`` so
+nested structures (`hooks:`, `shell:`) round-trip, and added per-field
+validators in ``loader.parse_skill_frontmatter_fields`` that drop bad
+values rather than raising. These tests pin the parser/validator
+contracts so a regression that silently crashes-on-bad-input or starts
+swallowing valid input fails loudly.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from src.skills.bundled_skills import clear_bundled_skills
+from src.skills.frontmatter import parse_frontmatter
+from src.skills.loader import (
+    clear_dynamic_skills,
+    clear_skill_caches,
+    clear_skill_registry,
+    load_skills_from_skills_dir,
+    parse_skill_frontmatter_fields,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_skill_state() -> Iterator[None]:
+    clear_skill_caches()
+    clear_dynamic_skills()
+    clear_skill_registry()
+    clear_bundled_skills()
+    yield
+    clear_skill_caches()
+    clear_dynamic_skills()
+    clear_skill_registry()
+    clear_bundled_skills()
+
+
+def _write_skill(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+# ======================================================================
+# Frontmatter parser (the YAML layer that produces the raw dict)
+# ======================================================================
+
+
+class TestFrontmatterParser:
+    def test_nested_hooks_round_trip(self) -> None:
+        md = (
+            "---\n"
+            "description: H\n"
+            "hooks:\n"
+            "  PostToolUse:\n"
+            "    - matcher: Write\n"
+            "      hooks:\n"
+            "        - type: command\n"
+            "          command: ./scripts/format.sh\n"
+            "---\n"
+            "body\n"
+        )
+        result = parse_frontmatter(md)
+        hooks = result.frontmatter["hooks"]
+        # Round-trips into a real nested dict, not a stringified blob.
+        assert isinstance(hooks, dict)
+        assert "PostToolUse" in hooks
+        post = hooks["PostToolUse"]
+        assert isinstance(post, list)
+        assert post[0]["matcher"] == "Write"
+        assert post[0]["hooks"][0]["type"] == "command"
+        assert post[0]["hooks"][0]["command"] == "./scripts/format.sh"
+
+    def test_multiline_pipe_description_joins(self) -> None:
+        md = (
+            "---\n"
+            "description: |\n"
+            "  Line one\n"
+            "  Line two\n"
+            "---\n"
+            "body\n"
+        )
+        result = parse_frontmatter(md)
+        # YAML `|` preserves newlines as a single string.
+        desc = result.frontmatter["description"]
+        assert isinstance(desc, str)
+        assert "Line one" in desc
+        assert "Line two" in desc
+
+    def test_allowed_tools_preserves_paren_arg_pattern(self) -> None:
+        # The TS `allowed-tools` syntax allows `Tool(arg-pattern)`. The
+        # YAML parser must keep these as single list entries, not split
+        # them on the `:` inside the parens.
+        md = (
+            "---\n"
+            'allowed-tools: ["Bash(git diff:*)", "Read"]\n'
+            "---\n"
+            "body\n"
+        )
+        result = parse_frontmatter(md)
+        tools = result.frontmatter["allowed-tools"]
+        assert tools == ["Bash(git diff:*)", "Read"], (
+            f"paren-arg pattern was split or mangled: {tools!r}"
+        )
+
+    def test_malformed_yaml_does_not_raise(self, caplog: pytest.LogCaptureFixture) -> None:
+        # A bad YAML body must not crash the loader — it should return
+        # an empty frontmatter and the body intact. This is the
+        # "never block-load other skills" contract.
+        md = (
+            "---\n"
+            "description: ok\n"
+            "  bad: indent: here\n"  # malformed
+            "---\n"
+            "body content\n"
+        )
+        with caplog.at_level(logging.DEBUG, logger="src.skills.frontmatter"):
+            result = parse_frontmatter(md)
+        # Must not raise; frontmatter is empty, body is preserved.
+        assert result.frontmatter == {}
+        assert "body content" in result.body
+
+    def test_no_frontmatter_returns_empty_dict_and_full_body(self) -> None:
+        md = "no fence here\nstill no fence\n"
+        result = parse_frontmatter(md)
+        assert result.frontmatter == {}
+        assert result.body == md
+
+
+# ======================================================================
+# parse_skill_frontmatter_fields — coercions / validators
+# ======================================================================
+
+
+class TestFieldValidators:
+    def test_model_inherit_returns_none(self) -> None:
+        result = parse_skill_frontmatter_fields(
+            {"model": "inherit"}, "", "s"
+        )
+        assert result["model"] is None, (
+            "`model: inherit` must yield None so callers fall back to "
+            "the active session model (TS parity)."
+        )
+
+    def test_model_unset_returns_none(self) -> None:
+        assert parse_skill_frontmatter_fields({}, "", "s")["model"] is None
+
+    def test_model_known_value_kept(self) -> None:
+        # A canonical-looking model name is preserved as-is.
+        result = parse_skill_frontmatter_fields(
+            {"model": "claude-sonnet-4-5"}, "", "s"
+        )
+        assert result["model"] == "claude-sonnet-4-5"
+
+    def test_effort_low_kept(self) -> None:
+        result = parse_skill_frontmatter_fields({"effort": "low"}, "", "s")
+        assert result["effort"] == "low"
+
+    def test_effort_medium_high_max_kept(self) -> None:
+        for level in ("medium", "high", "max"):
+            result = parse_skill_frontmatter_fields({"effort": level}, "", "s")
+            assert result["effort"] == level
+
+    def test_effort_invalid_drops_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING, logger="src.skills.loader"):
+            result = parse_skill_frontmatter_fields(
+                {"effort": "garbage"}, "", "s"
+            )
+        assert result["effort"] is None, (
+            "invalid effort levels must be dropped (None), not preserved"
+        )
+        # Confirm we logged the rejection — the spec asks us to capture
+        # the warning explicitly with caplog.
+        assert any(
+            "effort" in rec.getMessage().lower() for rec in caplog.records
+        ), "expected a warning log for invalid effort"
+
+    def test_effort_integer_kept_as_string(self) -> None:
+        # TS' parseEffortValue accepts numeric strings too.
+        result = parse_skill_frontmatter_fields({"effort": 3}, "", "s")
+        assert result["effort"] == "3"
+
+    def test_allowed_tools_preserves_paren_arg_pattern(self) -> None:
+        result = parse_skill_frontmatter_fields(
+            {"allowed-tools": ["Bash(git diff:*)"]}, "", "s"
+        )
+        assert result["allowed_tools"] == ["Bash(git diff:*)"], (
+            "paren-arg pattern must be preserved as one entry; "
+            "splitting on `:` would break Bash command rules"
+        )
+
+    def test_allowed_tools_string_form_split_on_comma(self) -> None:
+        result = parse_skill_frontmatter_fields(
+            {"allowed-tools": "Bash, Read"}, "", "s"
+        )
+        # String form is split on commas.
+        assert result["allowed_tools"] == ["Bash", "Read"]
+
+    def test_hooks_valid_event_round_trips_to_dict(self) -> None:
+        hooks_in = {
+            "PostToolUse": [
+                {"matcher": "Write", "hooks": [{"type": "command", "command": "x"}]}
+            ]
+        }
+        result = parse_skill_frontmatter_fields({"hooks": hooks_in}, "", "s")
+        assert result["hooks"] == hooks_in
+
+    def test_hooks_unknown_event_drops_silently(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.DEBUG, logger="src.skills.loader"):
+            result = parse_skill_frontmatter_fields(
+                {"hooks": {"BogusEvent": [{"hooks": [{"type": "command"}]}]}},
+                "",
+                "s",
+            )
+        assert result["hooks"] is None
+
+    def test_hooks_malformed_inner_drops(self) -> None:
+        # Inner hooks list missing `type` must drop the whole hooks dict.
+        result = parse_skill_frontmatter_fields(
+            {
+                "hooks": {
+                    "PostToolUse": [{"hooks": [{"command": "no-type-field"}]}]
+                }
+            },
+            "",
+            "s",
+        )
+        assert result["hooks"] is None
+
+    def test_shell_bash_kept(self) -> None:
+        result = parse_skill_frontmatter_fields({"shell": "bash"}, "", "s")
+        assert result["shell"] == "bash"
+
+    def test_shell_powershell_kept(self) -> None:
+        result = parse_skill_frontmatter_fields({"shell": "powershell"}, "", "s")
+        assert result["shell"] == "powershell"
+
+    def test_shell_invalid_drops_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING, logger="src.skills.loader"):
+            result = parse_skill_frontmatter_fields(
+                {"shell": "fish"}, "", "s"
+            )
+        assert result["shell"] is None
+
+
+# ======================================================================
+# Round-trip via load_skills_from_skills_dir — confirms the new fields
+# (hooks, shell) ride all the way onto the Skill dataclass when a real
+# SKILL.md is loaded from disk.
+# ======================================================================
+
+
+class TestSkillRoundTrip:
+    def test_hooks_field_lands_on_skill(self, tmp_path: Path) -> None:
+        skills_dir = tmp_path / "skills"
+        body = (
+            "---\n"
+            "description: H\n"
+            "hooks:\n"
+            "  PostToolUse:\n"
+            "    - matcher: Write\n"
+            "      hooks:\n"
+            "        - type: command\n"
+            "          command: ./fmt.sh\n"
+            "---\n"
+            "body\n"
+        )
+        _write_skill(skills_dir / "withhooks" / "SKILL.md", body)
+
+        skills = load_skills_from_skills_dir(str(skills_dir), "projectSettings")
+        assert len(skills) == 1
+        skill = skills[0]
+        assert skill.hooks is not None
+        assert "PostToolUse" in skill.hooks
+        assert skill.hooks["PostToolUse"][0]["matcher"] == "Write"
+
+    def test_shell_field_lands_on_skill(self, tmp_path: Path) -> None:
+        skills_dir = tmp_path / "skills"
+        _write_skill(
+            skills_dir / "shsk" / "SKILL.md",
+            "---\ndescription: S\nshell: bash\n---\nbody\n",
+        )
+        skills = load_skills_from_skills_dir(str(skills_dir), "projectSettings")
+        assert skills[0].shell == "bash"
+
+    def test_invalid_yaml_skill_is_skipped_quietly_others_still_load(
+        self, tmp_path: Path
+    ) -> None:
+        skills_dir = tmp_path / "skills"
+        # Bad skill.
+        _write_skill(
+            skills_dir / "broken" / "SKILL.md",
+            "---\ndescription: ok\n  bad: yaml\n---\nbody",
+        )
+        # Good skill alongside it.
+        _write_skill(
+            skills_dir / "good" / "SKILL.md",
+            "---\ndescription: ok\n---\nbody",
+        )
+        skills = load_skills_from_skills_dir(str(skills_dir), "projectSettings")
+        names = {s.name for s in skills}
+        # The "good" skill must still load. The broken one falls back
+        # to an empty frontmatter dict but still loads; what matters
+        # is that one bad skill doesn't kill the whole batch.
+        assert "good" in names

--- a/tests/test_skills_runtime_substitution.py
+++ b/tests/test_skills_runtime_substitution.py
@@ -1,0 +1,450 @@
+"""Tests for the per-invocation skill prompt-rendering pipeline.
+
+Covers DEV-2: each transform in isolation, the orchestrator combining
+them in TS order, the MCP shell-exec security guard, and shell-error
+formatting (failures embed inline rather than crash the SkillTool).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.skills.bundled_skills import (
+    BundledSkillDefinition,
+    clear_bundled_skills,
+    register_bundled_skill,
+)
+from src.skills.create import create_skill
+from src.skills.loader import (
+    clear_dynamic_skills,
+    clear_skill_caches,
+    clear_skill_registry,
+)
+from src.skills.runtime_substitution import (
+    find_shell_blocks,
+    format_shell_error,
+    format_shell_output,
+    has_shell_blocks,
+    prepend_base_dir_header,
+    render_skill_prompt,
+    substitute_session_id,
+    substitute_skill_dir,
+)
+from src.tool_system.context import ToolContext
+from src.tool_system.tools import SkillTool
+
+
+# ----------------------------------------------------------------------
+# Pure transforms in isolation
+# ----------------------------------------------------------------------
+
+
+class TestPrependBaseDirHeader(unittest.TestCase):
+    def test_prepends_when_base_dir_set(self) -> None:
+        out = prepend_base_dir_header("body", "/skills/foo")
+        self.assertEqual(out, "Base directory for this skill: /skills/foo\n\nbody")
+
+    def test_no_op_when_base_dir_none(self) -> None:
+        self.assertEqual(prepend_base_dir_header("body", None), "body")
+
+    def test_no_op_when_base_dir_empty(self) -> None:
+        self.assertEqual(prepend_base_dir_header("body", ""), "body")
+
+
+class TestSubstituteSkillDir(unittest.TestCase):
+    def test_replaces_placeholder(self) -> None:
+        out = substitute_skill_dir(
+            "cd ${CLAUDE_SKILL_DIR}/scripts", "/abs/skill"
+        )
+        self.assertEqual(out, "cd /abs/skill/scripts")
+
+    def test_replaces_multiple(self) -> None:
+        out = substitute_skill_dir(
+            "${CLAUDE_SKILL_DIR}/a ${CLAUDE_SKILL_DIR}/b", "/x"
+        )
+        self.assertEqual(out, "/x/a /x/b")
+
+    def test_normalizes_backslashes(self) -> None:
+        out = substitute_skill_dir(
+            "${CLAUDE_SKILL_DIR}/script.ps1", r"C:\users\me\skill"
+        )
+        self.assertEqual(out, "C:/users/me/skill/script.ps1")
+
+    def test_no_op_when_base_dir_missing(self) -> None:
+        self.assertEqual(
+            substitute_skill_dir("${CLAUDE_SKILL_DIR}", None),
+            "${CLAUDE_SKILL_DIR}",
+        )
+
+
+class TestSubstituteSessionId(unittest.TestCase):
+    def test_replaces_placeholder(self) -> None:
+        out = substitute_session_id("session=${CLAUDE_SESSION_ID}", "abc-123")
+        self.assertEqual(out, "session=abc-123")
+
+    def test_unset_id_substitutes_empty(self) -> None:
+        # Matches TS' getSessionId() -> '' fallback.
+        out = substitute_session_id("session=${CLAUDE_SESSION_ID}!", None)
+        self.assertEqual(out, "session=!")
+
+
+class TestFindShellBlocks(unittest.TestCase):
+    def test_finds_fenced_block(self) -> None:
+        text = "before\n```!\nls -la\n```\nafter"
+        blocks = find_shell_blocks(text)
+        self.assertEqual(len(blocks), 1)
+        full, cmd, inline = blocks[0]
+        self.assertIn("```!", full)
+        self.assertEqual(cmd, "ls -la")
+        self.assertFalse(inline)
+
+    def test_finds_inline_block(self) -> None:
+        blocks = find_shell_blocks("status: !`git status -sb`")
+        self.assertEqual(len(blocks), 1)
+        _, cmd, inline = blocks[0]
+        self.assertEqual(cmd, "git status -sb")
+        self.assertTrue(inline)
+
+    def test_inline_requires_whitespace_before_bang(self) -> None:
+        # TS' lookbehind blocks `foo!`bar` where ! has no preceding ws.
+        # We replicate by anchoring the inline pattern at start-or-ws.
+        blocks = find_shell_blocks("foo!`nope`")
+        self.assertEqual(blocks, [])
+
+    def test_inline_at_line_start(self) -> None:
+        blocks = find_shell_blocks("!`pwd`")
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0][1], "pwd")
+
+    def test_no_blocks(self) -> None:
+        self.assertEqual(find_shell_blocks("plain text"), [])
+
+    def test_has_shell_blocks_cheap_check(self) -> None:
+        self.assertTrue(has_shell_blocks("```!\nls\n```"))
+        self.assertTrue(has_shell_blocks(" !`ls`"))
+        self.assertFalse(has_shell_blocks("nothing here"))
+        self.assertFalse(has_shell_blocks("foo!`bar`"))
+
+
+class TestFormatShellOutput(unittest.TestCase):
+    def test_stdout_only(self) -> None:
+        self.assertEqual(format_shell_output("hello\n", "", inline=False), "hello")
+
+    def test_stderr_block_form(self) -> None:
+        out = format_shell_output("ok", "warn!", inline=False)
+        self.assertEqual(out, "ok\n[stderr]\nwarn!")
+
+    def test_stderr_inline_form(self) -> None:
+        out = format_shell_output("ok", "warn!", inline=True)
+        self.assertEqual(out, "ok [stderr: warn!]")
+
+    def test_empty(self) -> None:
+        self.assertEqual(format_shell_output("", "", inline=False), "")
+
+
+class TestFormatShellError(unittest.TestCase):
+    def test_block_form(self) -> None:
+        self.assertEqual(
+            format_shell_error("oops", "```!cmd```", inline=False),
+            "[Error]\noops",
+        )
+
+    def test_inline_form(self) -> None:
+        self.assertEqual(
+            format_shell_error("oops", "!`cmd`", inline=True),
+            "[Error: oops]",
+        )
+
+    def test_accepts_exception(self) -> None:
+        out = format_shell_error(RuntimeError("boom"), "x", inline=True)
+        self.assertEqual(out, "[Error: boom]")
+
+
+# ----------------------------------------------------------------------
+# Renderer orchestration
+# ----------------------------------------------------------------------
+
+
+class TestRenderSkillPrompt(unittest.TestCase):
+    def test_combined_substitutions(self) -> None:
+        out = render_skill_prompt(
+            body="Base: ${CLAUDE_SKILL_DIR}\nSession: ${CLAUDE_SESSION_ID}",
+            args="",
+            base_dir="/skills/demo",
+            argument_names=[],
+            session_id="sess-xyz",
+            loaded_from="user",
+        )
+        # Header prepended
+        self.assertTrue(out.startswith("Base directory for this skill: /skills/demo"))
+        # ${CLAUDE_SKILL_DIR} substituted
+        self.assertIn("Base: /skills/demo", out)
+        # ${CLAUDE_SESSION_ID} substituted
+        self.assertIn("Session: sess-xyz", out)
+
+    def test_argument_substitution_runs_after_header(self) -> None:
+        out = render_skill_prompt(
+            body="Hello $name from $1",
+            args="alice somewhere",
+            base_dir="/s/d",
+            argument_names=["name"],
+            session_id=None,
+            loaded_from="user",
+        )
+        self.assertIn("Hello alice from somewhere", out)
+        # Header is still first
+        self.assertTrue(out.startswith("Base directory for this skill: /s/d"))
+
+    def test_arguments_appended_when_no_placeholder(self) -> None:
+        out = render_skill_prompt(
+            body="Static body",
+            args="extra",
+            base_dir=None,
+            argument_names=[],
+            session_id=None,
+            loaded_from="user",
+        )
+        self.assertIn("Static body", out)
+        self.assertIn("ARGUMENTS: extra", out)
+
+    def test_no_base_dir_no_header(self) -> None:
+        out = render_skill_prompt(
+            body="bare body",
+            args="",
+            base_dir=None,
+            argument_names=[],
+            session_id=None,
+            loaded_from="bundled",
+        )
+        self.assertNotIn("Base directory for this skill", out)
+        self.assertEqual(out, "bare body")
+
+    def test_session_id_unset_substitutes_empty(self) -> None:
+        out = render_skill_prompt(
+            body="ID=${CLAUDE_SESSION_ID}",
+            args="",
+            base_dir=None,
+            argument_names=[],
+            session_id=None,
+            loaded_from="user",
+        )
+        self.assertEqual(out, "ID=")
+
+
+class TestRenderSkillPromptShellExecution(unittest.TestCase):
+    def test_shell_executor_called_for_inline(self) -> None:
+        seen: list[tuple[str, bool]] = []
+
+        def fake_exec(cmd: str, inline: bool) -> str:
+            seen.append((cmd, inline))
+            return "fake-output"
+
+        out = render_skill_prompt(
+            body="status: !`git status`",
+            args="",
+            base_dir=None,
+            argument_names=[],
+            session_id=None,
+            loaded_from="user",
+            shell_executor=fake_exec,
+        )
+        self.assertEqual(seen, [("git status", True)])
+        self.assertIn("fake-output", out)
+        self.assertNotIn("!`git status`", out)
+
+    def test_shell_executor_called_for_block(self) -> None:
+        seen: list[tuple[str, bool]] = []
+
+        def fake_exec(cmd: str, inline: bool) -> str:
+            seen.append((cmd, inline))
+            return f"<<{cmd}>>"
+
+        out = render_skill_prompt(
+            body="```!\nls -la\n```",
+            args="",
+            base_dir=None,
+            argument_names=[],
+            session_id=None,
+            loaded_from="user",
+            shell_executor=fake_exec,
+        )
+        self.assertEqual(seen, [("ls -la", False)])
+        self.assertIn("<<ls -la>>", out)
+
+    def test_mcp_skill_skips_shell_execution(self) -> None:
+        # Security boundary — MCP skills come from remote untrusted servers
+        # and must never trigger local shell execution.
+        called: list[str] = []
+
+        def fake_exec(cmd: str, inline: bool) -> str:
+            called.append(cmd)
+            return "WOULD-RUN"
+
+        out = render_skill_prompt(
+            body="hi !`evil` bye",
+            args="",
+            base_dir=None,
+            argument_names=[],
+            session_id=None,
+            loaded_from="mcp",
+            shell_executor=fake_exec,
+        )
+        self.assertEqual(called, [])
+        self.assertIn("!`evil`", out)  # left intact
+
+    def test_no_executor_leaves_blocks_intact(self) -> None:
+        out = render_skill_prompt(
+            body="run !`whoami` here",
+            args="",
+            base_dir=None,
+            argument_names=[],
+            session_id=None,
+            loaded_from="user",
+            shell_executor=None,
+        )
+        self.assertIn("!`whoami`", out)
+
+    def test_executor_exception_renders_inline_error(self) -> None:
+        def boom(cmd: str, inline: bool) -> str:
+            raise RuntimeError("oops")
+
+        out = render_skill_prompt(
+            body="x !`bad` y",
+            args="",
+            base_dir=None,
+            argument_names=[],
+            session_id=None,
+            loaded_from="user",
+            shell_executor=boom,
+        )
+        # Failures must SURFACE in the rendered prompt, not be silently
+        # dropped. They should also not crash the renderer.
+        self.assertIn("[Error: oops]", out)
+        self.assertNotIn("!`bad`", out)
+
+    def test_transforms_run_in_correct_order(self) -> None:
+        # Shell command should see the post-substitution dir, since ${CLAUDE_SKILL_DIR}
+        # is replaced before shell exec.
+        captured: list[str] = []
+
+        def fake_exec(cmd: str, inline: bool) -> str:
+            captured.append(cmd)
+            return "ran"
+
+        render_skill_prompt(
+            body="check !`stat ${CLAUDE_SKILL_DIR}/x`",
+            args="",
+            base_dir="/abs/skill",
+            argument_names=[],
+            session_id=None,
+            loaded_from="user",
+            shell_executor=fake_exec,
+        )
+        self.assertEqual(captured, ["stat /abs/skill/x"])
+
+
+# ----------------------------------------------------------------------
+# Acceptance criteria — end-to-end via SkillTool
+# ----------------------------------------------------------------------
+
+
+class TestSkillToolRuntimeIntegration(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name).resolve()
+
+    def tearDown(self) -> None:
+        clear_skill_caches()
+        clear_dynamic_skills()
+        clear_skill_registry()
+        clear_bundled_skills()
+        self.tmp.cleanup()
+
+    def test_disk_skill_gets_base_dir_header(self) -> None:
+        """AC#2: disk-loaded skill prepends the canonical header."""
+        skills_dir = self.root / ".claude" / "skills"
+        create_skill(
+            directory=skills_dir, name="hello", description="say hi", body="Hi!",
+        )
+        ctx = ToolContext(workspace_root=self.root)
+        out = SkillTool.call({"skill": "hello"}, ctx).output
+        self.assertTrue(out["success"])
+        self.assertTrue(
+            out["prompt"].startswith("Base directory for this skill:"),
+            f"prompt does not start with header: {out['prompt']!r}",
+        )
+        self.assertIn(str(skills_dir / "hello"), out["prompt"])
+        self.assertIn("Hi!", out["prompt"])
+
+    def test_skill_dir_and_session_substitution(self) -> None:
+        """AC#1: ${CLAUDE_SKILL_DIR} and ${CLAUDE_SESSION_ID} both
+        substitute in a real disk-loaded skill via SkillTool."""
+        skills_dir = self.root / ".claude" / "skills"
+        create_skill(
+            directory=skills_dir, name="echo",
+            description="echo placeholders",
+            body="DIR=${CLAUDE_SKILL_DIR}\nSID=${CLAUDE_SESSION_ID}",
+        )
+        ctx = ToolContext(workspace_root=self.root, session_id="my-session-42")
+        out = SkillTool.call({"skill": "echo"}, ctx).output
+        self.assertTrue(out["success"])
+        self.assertIn(f"DIR={skills_dir / 'echo'}", out["prompt"])
+        self.assertIn("SID=my-session-42", out["prompt"])
+
+    def test_bundled_skill_no_header(self) -> None:
+        """AC#3: bundled skill without skill_root should NOT get header."""
+        register_bundled_skill(
+            BundledSkillDefinition(
+                name="b1",
+                description="bundled",
+                get_prompt_for_command=lambda a: f"BUNDLED-PROMPT:{a}",
+            )
+        )
+        ctx = ToolContext(workspace_root=self.root)
+        out = SkillTool.call({"skill": "b1", "args": "x"}, ctx).output
+        self.assertTrue(out["success"])
+        self.assertNotIn("Base directory for this skill", out["prompt"])
+        self.assertIn("BUNDLED-PROMPT:x", out["prompt"])
+
+    def test_argument_substitution_with_header(self) -> None:
+        """AC#4: arg substitution still works after header prepend."""
+        skills_dir = self.root / ".claude" / "skills"
+        create_skill(
+            directory=skills_dir, name="greet", description="greet",
+            arguments=["name"], body="Hello $name from $1",
+        )
+        ctx = ToolContext(workspace_root=self.root)
+        out = SkillTool.call({"skill": "greet", "args": "alice town"}, ctx).output
+        self.assertTrue(out["success"])
+        self.assertTrue(out["prompt"].startswith("Base directory for this skill"))
+        self.assertIn("Hello alice from town", out["prompt"])
+
+    def test_shell_executor_logs_when_no_executor_for_mcp(self) -> None:
+        """AC#5: MCP-loaded skills never trigger inline shell execution."""
+        # Simulate by directly calling the renderer with loaded_from="mcp"
+        # and a tracker executor. The MCP guard runs before any executor
+        # call.
+        called: list[str] = []
+        def trk(cmd: str, inline: bool) -> str:
+            called.append(cmd)
+            return "x"
+
+        out = render_skill_prompt(
+            body="!`whoami`",
+            args="",
+            base_dir=None,
+            argument_names=[],
+            session_id=None,
+            loaded_from="mcp",
+            shell_executor=trk,
+        )
+        self.assertEqual(called, [])
+        self.assertIn("!`whoami`", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skills_shell_exec.py
+++ b/tests/test_skills_shell_exec.py
@@ -1,0 +1,426 @@
+"""Group B' — Shell-execution-in-prompt (covers DEV-2).
+
+Required cases (per QA-1 acceptance criteria #5 and #6):
+
+  - Success (inline ``!`...``` and fenced `````! ... ````` forms).
+  - Failure (non-zero exit) — visible error marker, prompt still renders.
+  - Timeout — visible timeout marker, doesn't block the test.
+  - **MCP-skip** — security boundary. A skill loaded from MCP whose
+    body contains shell blocks must NOT spawn a subprocess. We assert
+    via mock that the executor entrypoint was never called.
+  - Combined transform-order — single body exercising every transform
+    (header + arg sub + var sub + shell exec) and verifying that ``$1``
+    inside `` !`echo $1` `` sees the substituted arg, not the literal
+    ``$1`` (validates DEV-2's transform order matches TS).
+
+Strategy: most cases test ``render_skill_prompt`` directly with a fake
+``shell_executor`` callable — pure, fast, no subprocess. The MCP-skip
+case is double-layered: a unit assertion against the renderer's
+executor mock, and an integration assertion against ``BashTool.call``
+(through ``SkillTool``) so a regression at either layer fails loudly.
+"""
+
+from __future__ import annotations
+
+import unittest.mock as mock
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from src.skills.bundled_skills import clear_bundled_skills
+from src.skills.loader import (
+    clear_dynamic_skills,
+    clear_skill_caches,
+    clear_skill_registry,
+)
+from src.skills.runtime_substitution import (
+    find_shell_blocks,
+    has_shell_blocks,
+    render_skill_prompt,
+)
+from src.tool_system.context import ToolContext
+from src.tool_system.tools import SkillTool
+
+
+@pytest.fixture
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    for var in (
+        "CLAUDE_CONFIG_DIR",
+        "CLAUDE_MANAGED_CONFIG_DIR",
+        "CLAWCODEX_SKILLS_DIR",
+        "CLAUDE_SKILLS_DIR",
+        "CLAWCODEX_MANAGED_SKILLS_DIR",
+        "CLAUDE_CODE_BARE_MODE",
+        "CLAUDE_CODE_DISABLE_POLICY_SKILLS",
+        "CLAUDE_CODE_ADDITIONAL_DIRECTORIES",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("CLAUDE_MANAGED_CONFIG_DIR", str(tmp_path / "managed"))
+    yield home
+
+
+@pytest.fixture(autouse=True)
+def _clean_skill_state() -> Iterator[None]:
+    clear_skill_caches()
+    clear_dynamic_skills()
+    clear_skill_registry()
+    clear_bundled_skills()
+    yield
+    clear_skill_caches()
+    clear_dynamic_skills()
+    clear_skill_registry()
+    clear_bundled_skills()
+
+
+def _write_skill(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+# ======================================================================
+# Block-detection sanity checks (cheap; protect the regex from drift).
+# ======================================================================
+
+
+class TestBlockDetection:
+    def test_inline_block_detected(self) -> None:
+        body = "echo: !`echo hello`"
+        assert has_shell_blocks(body) is True
+        blocks = find_shell_blocks(body)
+        assert len(blocks) == 1
+        full, cmd, inline = blocks[0]
+        assert cmd == "echo hello"
+        assert inline is True
+
+    def test_fenced_block_detected(self) -> None:
+        body = "```!\necho world\n```"
+        assert has_shell_blocks(body) is True
+        blocks = find_shell_blocks(body)
+        assert len(blocks) == 1
+        full, cmd, inline = blocks[0]
+        assert cmd == "echo world"
+        assert inline is False
+
+    def test_inline_requires_leading_whitespace(self) -> None:
+        # The lookbehind protects against false positives like
+        # ``foo!`bar``` — the ``!`` must be at start-of-line or
+        # preceded by whitespace.
+        body = "abc!`echo nope`"
+        # `has_shell_blocks` does a cheap "!`" check then runs the regex
+        # again; for a clean negative we look at the canonical scan:
+        assert find_shell_blocks(body) == []
+
+
+# ======================================================================
+# B'-1. Success — both inline and fenced forms run and substitute.
+# ======================================================================
+
+
+def test_inline_shell_block_success_substitutes_stdout() -> None:
+    calls: list[tuple[str, bool]] = []
+
+    def fake_exec(command: str, inline: bool) -> str:
+        calls.append((command, inline))
+        # Mirror what the real executor returns via format_shell_output:
+        # plain stdout for a clean success.
+        return "hello"
+
+    out = render_skill_prompt(
+        body="echo: !`echo hello`",
+        args=None,
+        base_dir=None,
+        loaded_from="project",
+        shell_executor=fake_exec,
+    )
+    assert calls == [("echo hello", True)]
+    assert out == "echo: hello"
+    # Original literal block is gone.
+    assert "!`echo hello`" not in out
+
+
+def test_fenced_shell_block_success_substitutes_stdout() -> None:
+    calls: list[tuple[str, bool]] = []
+
+    def fake_exec(command: str, inline: bool) -> str:
+        calls.append((command, inline))
+        return "world"
+
+    body = "before\n```!\necho world\n```\nafter"
+    out = render_skill_prompt(
+        body=body,
+        args=None,
+        base_dir=None,
+        loaded_from="project",
+        shell_executor=fake_exec,
+    )
+    assert calls == [("echo world", False)]
+    assert "before" in out and "after" in out
+    assert "world" in out
+    assert "```!" not in out
+
+
+def test_multiple_blocks_each_executed_once() -> None:
+    counter = {"n": 0}
+
+    def fake_exec(command: str, inline: bool) -> str:
+        counter["n"] += 1
+        return f"[{counter['n']}]"
+
+    # The inline regex requires whitespace (or start-of-line) BEFORE
+    # the `!` to avoid matching inside other inline-code spans. So
+    # each block needs leading whitespace; we use a leading space.
+    out = render_skill_prompt(
+        body="A= !`a` B= !`b` C= !`c`",
+        args=None,
+        base_dir=None,
+        loaded_from="project",
+        shell_executor=fake_exec,
+    )
+    # Each unique block replaced separately (replace called with count=1).
+    assert counter["n"] == 3, f"expected 3 exec calls, got {counter['n']} (out={out!r})"
+    # Distinct outputs land in order.
+    assert "A= [1]" in out
+    assert "B= [2]" in out
+    assert "C= [3]" in out
+
+
+# ======================================================================
+# B'-2. Failure (non-zero exit / executor exception) — visible marker.
+# ======================================================================
+
+
+def test_failure_executor_exception_renders_visible_marker() -> None:
+    def crashing_exec(command: str, inline: bool) -> str:
+        raise RuntimeError("simulated non-zero exit (exit 7)")
+
+    body = "before !`exit 7` after"
+    out = render_skill_prompt(
+        body=body,
+        args=None,
+        base_dir=None,
+        loaded_from="project",
+        shell_executor=crashing_exec,
+    )
+    # `format_shell_error(...)` is the marker DEV-2 picked: inline form
+    # produces `[Error: <msg>]`. Capturing the format here pins it so a
+    # silent change to the marker shape will fail this test.
+    assert "[Error:" in out, f"expected visible error marker in: {out!r}"
+    assert "exit 7" in out
+    # Rest of the prompt still renders.
+    assert "before" in out
+    assert "after" in out
+
+
+def test_failure_executor_returns_formatted_error_string() -> None:
+    # The executor (e.g. _make_shell_executor in skill.py) is allowed
+    # to format errors itself and return them as the substitution.
+    # render_skill_prompt should pass that string through unmodified.
+    def errfmt_exec(command: str, inline: bool) -> str:
+        return "[Error: command failed (exit 7)]"
+
+    # `!` requires whitespace (or BOL) in front per _INLINE_PATTERN.
+    body = "x= !`exit 7`"
+    out = render_skill_prompt(
+        body=body,
+        args=None,
+        base_dir=None,
+        loaded_from="project",
+        shell_executor=errfmt_exec,
+    )
+    assert out == "x= [Error: command failed (exit 7)]"
+
+
+# ======================================================================
+# B'-3. Timeout — visible marker, doesn't block.
+# DEV-2 doesn't expose a timeout-override hook on render_skill_prompt;
+# instead the executor itself is responsible for raising on timeout.
+# We simulate by having the fake executor raise TimeoutError, which
+# render_skill_prompt's broad `except Exception` catches and formats.
+# ======================================================================
+
+
+def test_timeout_renders_visible_marker_and_continues() -> None:
+    def timeout_exec(command: str, inline: bool) -> str:
+        raise TimeoutError("command timed out after 1s")
+
+    body = "result: !`sleep 30`"
+    out = render_skill_prompt(
+        body=body,
+        args=None,
+        base_dir=None,
+        loaded_from="project",
+        shell_executor=timeout_exec,
+    )
+    assert "[Error:" in out, f"expected error marker in: {out!r}"
+    assert "timed out" in out
+    # Doesn't block; the surrounding text still renders.
+    assert "result:" in out
+
+
+# ======================================================================
+# B'-4. MCP-skip — the security boundary. DOUBLE-LAYERED:
+#   (a) render_skill_prompt with loaded_from="mcp" must NOT call the
+#       executor mock, and the literal block must survive.
+#   (b) SkillTool.call against an MCP-loaded skill must NOT invoke
+#       BashTool.call. Asserted via patch on the BashTool.call entry.
+# A regression at either layer should fail loudly — this is exactly
+# the "fail loudly on regression" requirement from the QA-1 spec.
+# ======================================================================
+
+
+def test_mcp_skill_renderer_does_not_call_shell_executor() -> None:
+    executor = mock.Mock(return_value="should-not-appear")
+    body = "danger: !`whoami`"
+
+    out = render_skill_prompt(
+        body=body,
+        args=None,
+        base_dir=None,
+        loaded_from="mcp",  # the security gate
+        shell_executor=executor,
+    )
+
+    # Hard security assertion: zero subprocess invocations.
+    assert executor.call_count == 0, (
+        "SECURITY REGRESSION: render_skill_prompt invoked the shell "
+        "executor for an MCP-loaded skill. The TS port and DEV-2 spec "
+        "require MCP skills to skip shell execution entirely."
+    )
+    # Literal block survives unchanged in the rendered prompt.
+    assert "!`whoami`" in out
+
+
+def test_mcp_skill_through_skilltool_never_calls_bash(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    """End-to-end version of the MCP-skip security boundary.
+
+    Registers an MCP-loaded skill containing a shell block, invokes
+    through SkillTool, and asserts BashTool.call was never invoked.
+    """
+    from src.skills.bundled_skills import skill_from_mcp_tool
+    from src.skills.loader import _skill_registry
+
+    # MCP-loaded skills go through `get_prompt_for_command` callable
+    # rather than the markdown renderer, so for the security-boundary
+    # test we construct a synthetic disk-style MCP skill directly. We
+    # bypass `register_bundled_skill` because that hard-codes
+    # `loaded_from="bundled"`. This mirrors how a real MCP skill would
+    # arrive in the registry via `get_all_skills` step 6.
+    from src.skills.model import Skill
+    mcp_skill = Skill(
+        name="evil-mcp",
+        description="MCP skill with a shell block",
+        markdown_content="user is !`whoami`",
+        source="mcp:evil",
+        loaded_from="mcp",
+    )
+    _skill_registry["evil-mcp"] = mcp_skill
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    ctx = ToolContext(workspace_root=project)
+
+    # NOTE: SkillTool re-populates the registry on each call via
+    # `get_all_skills`, which would clobber our manual registration.
+    # We patch the source (`src.skills.loader.get_all_skills`) since
+    # it's imported inside the function rather than at module scope.
+    with mock.patch(
+        "src.skills.loader.get_all_skills", lambda **_: None
+    ), mock.patch("src.tool_system.tools.bash.BashTool.call") as bash_call:
+        result = SkillTool.call({"skill": "evil-mcp"}, ctx)
+
+    assert bash_call.call_count == 0, (
+        "SECURITY REGRESSION: SkillTool invoked BashTool for an "
+        "MCP-loaded skill. MCP-sourced skills must never trigger "
+        "local shell execution (TS-port `loadedFrom !== 'mcp'` guard)."
+    )
+    out = result.output
+    assert out["success"] is True
+    # The literal block survives.
+    assert "!`whoami`" in out["prompt"]
+    assert out["loadedFrom"] == "mcp"
+
+
+# ======================================================================
+# B'-5. Combined transform order — every transform in one body.
+# Validates DEV-2's order matches TS:
+#   header → arg sub → ${CLAUDE_SKILL_DIR} → ${CLAUDE_SESSION_ID}
+#   → shell exec
+# Critical assertion: `$1` inside `!`echo $1`` must be substituted to
+# `world` BEFORE the shell block runs, so the executor receives
+# `echo world` (not the literal `echo $1`).
+# ======================================================================
+
+
+def test_combined_transform_order_arg_sub_runs_before_shell_exec() -> None:
+    received: list[str] = []
+
+    def fake_exec(command: str, inline: bool) -> str:
+        received.append(command)
+        # Echo back the command's last token, simulating real `echo`
+        # behavior closely enough to confirm the substitution worked.
+        return command.split()[-1]
+
+    # `$0` is the 0-indexed shorthand for the first parsed arg (this
+    # impl is 0-indexed: see argument_substitution._repl_shorthand).
+    # Note: `!` needs whitespace before it for the inline regex.
+    body = (
+        "Base: ${CLAUDE_SKILL_DIR} | "
+        "Session: ${CLAUDE_SESSION_ID} | "
+        "Out: !`echo $0`"
+    )
+    out = render_skill_prompt(
+        body=body,
+        args="world",
+        base_dir="/abs/skill",
+        argument_names=[],
+        session_id="sess-42",
+        loaded_from="project",
+        shell_executor=fake_exec,
+    )
+
+    # 1. base-dir header is FIRST
+    assert out.startswith("Base directory for this skill: /abs/skill\n\n")
+
+    # 2. argument substitution applied — the executor must have been
+    #    called with `echo world`, not `echo $0`. This is the critical
+    #    transform-order assertion (DEV-2 docstring step order:
+    #    base-dir prepend → arg sub → ${CLAUDE_SKILL_DIR} →
+    #    ${CLAUDE_SESSION_ID} → shell exec).
+    assert received == ["echo world"], (
+        f"transform order regression — shell exec saw {received!r}; "
+        "DEV-2's order is supposed to substitute $0 BEFORE running "
+        "embedded shell blocks (matches TS getPromptForCommand)."
+    )
+
+    # 3 + 4. var subs applied
+    assert "Base: /abs/skill" in out
+    assert "Session: sess-42" in out
+
+    # 5. shell exec output spliced in
+    assert "Out: world" in out
+
+    # No literal placeholders survived.
+    assert "${CLAUDE_SKILL_DIR}" not in out
+    assert "${CLAUDE_SESSION_ID}" not in out
+    assert "!`echo" not in out
+
+
+def test_render_no_executor_leaves_blocks_in_place() -> None:
+    # If no shell_executor is supplied (e.g. a test setup or a
+    # SkillTool wired without bash), shell blocks survive verbatim
+    # rather than crashing the render.
+    body = "before !`echo hi` after"
+    out = render_skill_prompt(
+        body=body,
+        args=None,
+        base_dir=None,
+        loaded_from="project",
+        shell_executor=None,
+    )
+    assert out == body

--- a/tests/test_skills_substitutions.py
+++ b/tests/test_skills_substitutions.py
@@ -1,0 +1,293 @@
+"""Group B — Runtime substitutions (covers DEV-2, var-sub portion).
+
+Tests every transform in ``runtime_substitution.render_skill_prompt`` in
+isolation:
+
+  - base-dir header is prepended for disk skills, omitted for bundled
+  - ``${CLAUDE_SKILL_DIR}`` resolves to the skill's base dir
+  - ``${CLAUDE_SESSION_ID}`` resolves to the active session id (and to
+    the empty string when unknown)
+  - argument substitution still composes correctly with the prepended
+    header (i.e., the order ``header → arg sub`` doesn't break either)
+
+Shell-execution-in-prompt is a separate file (test_skills_shell_exec.py).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from src.skills.bundled_skills import (
+    BundledSkillDefinition,
+    clear_bundled_skills,
+    register_bundled_skill,
+)
+from src.skills.loader import (
+    clear_dynamic_skills,
+    clear_skill_caches,
+    clear_skill_registry,
+)
+from src.skills.runtime_substitution import (
+    prepend_base_dir_header,
+    render_skill_prompt,
+    substitute_session_id,
+    substitute_skill_dir,
+)
+from src.tool_system.context import ToolContext
+from src.tool_system.tools import SkillTool
+
+
+@pytest.fixture
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    for var in (
+        "CLAUDE_CONFIG_DIR",
+        "CLAUDE_MANAGED_CONFIG_DIR",
+        "CLAWCODEX_SKILLS_DIR",
+        "CLAUDE_SKILLS_DIR",
+        "CLAWCODEX_MANAGED_SKILLS_DIR",
+        "CLAUDE_CODE_BARE_MODE",
+        "CLAUDE_CODE_DISABLE_POLICY_SKILLS",
+        "CLAUDE_CODE_ADDITIONAL_DIRECTORIES",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("CLAUDE_MANAGED_CONFIG_DIR", str(tmp_path / "managed"))
+    yield home
+
+
+@pytest.fixture(autouse=True)
+def _clean_skill_state() -> Iterator[None]:
+    clear_skill_caches()
+    clear_dynamic_skills()
+    clear_skill_registry()
+    clear_bundled_skills()
+    yield
+    clear_skill_caches()
+    clear_dynamic_skills()
+    clear_skill_registry()
+    clear_bundled_skills()
+
+
+def _write_skill(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+# ======================================================================
+# Pure-function tests (each transform in isolation)
+# ======================================================================
+
+
+class TestPrependBaseDirHeader:
+    def test_with_base_dir_prepends_header(self) -> None:
+        result = prepend_base_dir_header("body", "/path/to/skill")
+        assert result == "Base directory for this skill: /path/to/skill\n\nbody"
+
+    def test_without_base_dir_is_noop(self) -> None:
+        assert prepend_base_dir_header("body", None) == "body"
+        assert prepend_base_dir_header("body", "") == "body"
+
+
+class TestSubstituteSkillDir:
+    def test_replaces_placeholder(self) -> None:
+        result = substitute_skill_dir(
+            "Path: ${CLAUDE_SKILL_DIR}/script.sh", "/abs/skill"
+        )
+        assert result == "Path: /abs/skill/script.sh"
+
+    def test_replaces_all_occurrences(self) -> None:
+        result = substitute_skill_dir(
+            "${CLAUDE_SKILL_DIR} | ${CLAUDE_SKILL_DIR}", "/x"
+        )
+        assert result == "/x | /x"
+
+    def test_no_base_dir_leaves_placeholder(self) -> None:
+        # Bundled skills (no base_dir) keep the literal placeholder
+        # rather than emitting a stray empty-string substitution.
+        assert (
+            substitute_skill_dir("Path: ${CLAUDE_SKILL_DIR}", None)
+            == "Path: ${CLAUDE_SKILL_DIR}"
+        )
+
+    def test_normalizes_backslashes(self) -> None:
+        # Windows compat: backslashes get flipped so embedded shell
+        # commands don't see them as escape sequences.
+        result = substitute_skill_dir("X=${CLAUDE_SKILL_DIR}", r"C:\Users\me\skill")
+        assert "\\" not in result
+        assert "C:/Users/me/skill" in result
+
+
+class TestSubstituteSessionId:
+    def test_replaces_placeholder(self) -> None:
+        assert (
+            substitute_session_id("S=${CLAUDE_SESSION_ID}", "abc-123")
+            == "S=abc-123"
+        )
+
+    def test_unknown_session_substitutes_empty(self) -> None:
+        # Matches TS' falsy-getSessionId() behavior.
+        assert substitute_session_id("S=${CLAUDE_SESSION_ID}", None) == "S="
+        assert substitute_session_id("S=${CLAUDE_SESSION_ID}", "") == "S="
+
+
+# ======================================================================
+# Combined renderer tests (disk skill — full transform chain)
+# ======================================================================
+
+
+def test_render_disk_skill_prepends_base_dir_header() -> None:
+    out = render_skill_prompt(
+        body="hello",
+        args=None,
+        base_dir="/abs/skill",
+        argument_names=[],
+        session_id="sess-1",
+        loaded_from="project",
+    )
+    assert out.startswith("Base directory for this skill: /abs/skill\n\n")
+    assert out.endswith("hello")
+
+
+def test_render_bundled_skill_skips_base_dir_header() -> None:
+    # Bundled skills don't ship a `base_dir` — the header must NOT
+    # appear, mirroring the TS behavior that gates the prepend on the
+    # presence of a `files` directory.
+    out = render_skill_prompt(
+        body="bundled body",
+        args=None,
+        base_dir=None,
+        argument_names=[],
+        session_id="sess-1",
+        loaded_from="bundled",
+    )
+    assert "Base directory for this skill" not in out
+    assert out == "bundled body"
+
+
+def test_render_substitutes_skill_dir_and_session_id_together() -> None:
+    out = render_skill_prompt(
+        body="dir=${CLAUDE_SKILL_DIR} sess=${CLAUDE_SESSION_ID}",
+        args=None,
+        base_dir="/abs/skill",
+        argument_names=[],
+        session_id="sess-xyz",
+        loaded_from="project",
+    )
+    # Header + body with both placeholders resolved.
+    assert "dir=/abs/skill" in out
+    assert "sess=sess-xyz" in out
+    assert out.startswith("Base directory for this skill: /abs/skill")
+
+
+def test_render_argument_substitution_works_after_prepend() -> None:
+    # Body has `$0` (0-indexed shorthand for the first parsed arg);
+    # args provided. After base-dir prepend the body should still see
+    # argument substitution apply correctly.
+    out = render_skill_prompt(
+        body="Hello $0",
+        args="world",
+        base_dir="/abs/skill",
+        argument_names=[],
+        session_id=None,
+        loaded_from="project",
+    )
+    assert "Hello world" in out
+    assert out.startswith("Base directory for this skill:")
+
+
+def test_render_named_argument_substitution_works_after_prepend() -> None:
+    out = render_skill_prompt(
+        body="Hello $name",
+        args="alice",
+        base_dir="/abs/skill",
+        argument_names=["name"],
+        session_id=None,
+        loaded_from="project",
+    )
+    assert "Hello alice" in out
+
+
+# ======================================================================
+# End-to-end through SkillTool — verifies the wiring (not just the
+# helper functions) substitutes everything correctly when invoked the
+# way the model would.
+# ======================================================================
+
+
+def test_skilltool_invocation_substitutes_all_placeholders(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    project = tmp_path / "proj"
+    skill_dir = project / ".claude" / "skills" / "showctx"
+    _write_skill(
+        skill_dir / "SKILL.md",
+        "---\n"
+        "description: Show context placeholders\n"
+        "arguments: [name]\n"
+        "---\n"
+        "Hi $name from ${CLAUDE_SKILL_DIR} (session ${CLAUDE_SESSION_ID})",
+    )
+
+    ctx = ToolContext(workspace_root=project)
+    ctx.session_id = "S-12345"
+
+    result = SkillTool.call({"skill": "showctx", "args": "ada"}, ctx)
+    out = result.output
+    assert out["success"] is True
+    prompt = out["prompt"]
+
+    # All four expected substitutions:
+    assert prompt.startswith(
+        "Base directory for this skill:"
+    ), f"missing base-dir header in: {prompt!r}"
+    assert str(skill_dir.resolve()) in prompt or str(skill_dir) in prompt
+    assert "Hi ada from" in prompt
+    assert "(session S-12345)" in prompt
+    # Placeholders fully resolved (no literal ${...} survivors).
+    assert "${CLAUDE_SKILL_DIR}" not in prompt
+    assert "${CLAUDE_SESSION_ID}" not in prompt
+
+
+def test_skilltool_unknown_session_id_renders_empty(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    project = tmp_path / "proj"
+    _write_skill(
+        project / ".claude" / "skills" / "sess" / "SKILL.md",
+        "---\ndescription: shows session\n---\nsession=[${CLAUDE_SESSION_ID}]",
+    )
+
+    ctx = ToolContext(workspace_root=project)
+    # Default ToolContext.session_id is None.
+    assert ctx.session_id is None
+
+    result = SkillTool.call({"skill": "sess"}, ctx)
+    prompt = result.output["prompt"]
+    assert "session=[]" in prompt
+
+
+def test_bundled_skill_invocation_does_not_get_base_dir_header(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    register_bundled_skill(
+        BundledSkillDefinition(
+            name="bcheck",
+            description="bundled prompt-builder",
+            get_prompt_for_command=lambda args: f"bundled body :: args={args}",
+        )
+    )
+    project = tmp_path / "proj"
+    project.mkdir()
+    ctx = ToolContext(workspace_root=project)
+    result = SkillTool.call({"skill": "bcheck", "args": "x"}, ctx)
+    prompt = result.output["prompt"]
+    # Bundled skills route through their own get_prompt_for_command
+    # callable; the header (which is render_skill_prompt's job) must
+    # not appear.
+    assert "Base directory for this skill" not in prompt
+    assert "bundled body :: args=x" in prompt

--- a/tests/test_skills_unified.py
+++ b/tests/test_skills_unified.py
@@ -1,0 +1,256 @@
+"""Group A — Unified registry (covers DEV-1).
+
+Verifies that disk-loaded skills (including nested-namespace skills) and
+bundled skills are reachable through the single ``get_all_skills`` /
+``SkillTool`` entry point. Before DEV-1 the SkillTool only saw the
+narrower ``PromptSkill`` registry; these tests pin the unified path so a
+regression on the wiring fails loudly.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from src.skills.bundled_skills import (
+    BundledSkillDefinition,
+    clear_bundled_skills,
+    register_bundled_skill,
+)
+from src.skills.loader import (
+    clear_dynamic_skills,
+    clear_skill_caches,
+    clear_skill_registry,
+    get_all_skills,
+    get_registered_skill,
+)
+from src.tool_system.context import ToolContext
+from src.tool_system.tools import SkillTool
+
+
+# ----------------------------------------------------------------------
+# Test isolation: every test gets a clean ``HOME`` (so ``~/.claude`` /
+# ``~/.clawcodex`` lookups don't leak from the developer's machine) and
+# every skill cache is cleared before AND after each test.
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    # Strip every env knob that would inject extra skill dirs.
+    for var in (
+        "CLAUDE_CONFIG_DIR",
+        "CLAUDE_MANAGED_CONFIG_DIR",
+        "CLAWCODEX_SKILLS_DIR",
+        "CLAUDE_SKILLS_DIR",
+        "CLAWCODEX_MANAGED_SKILLS_DIR",
+        "CLAUDE_CODE_BARE_MODE",
+        "CLAUDE_CODE_DISABLE_POLICY_SKILLS",
+        "CLAUDE_CODE_ADDITIONAL_DIRECTORIES",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    # Send the managed-policy lookup to an empty tmp dir so /etc/claude
+    # never affects results.
+    monkeypatch.setenv("CLAUDE_MANAGED_CONFIG_DIR", str(tmp_path / "managed"))
+    yield home
+
+
+@pytest.fixture(autouse=True)
+def _clean_skill_state() -> Iterator[None]:
+    clear_skill_caches()
+    clear_dynamic_skills()
+    clear_skill_registry()
+    clear_bundled_skills()
+    yield
+    clear_skill_caches()
+    clear_dynamic_skills()
+    clear_skill_registry()
+    clear_bundled_skills()
+
+
+def _write_skill(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+# ======================================================================
+# A1. Flat project skill at ``.claude/skills/foo/SKILL.md`` is
+# invokable through SkillTool with skill="foo".
+# ======================================================================
+
+
+def test_flat_project_skill_invokable_via_skilltool(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    project = tmp_path / "proj"
+    _write_skill(
+        project / ".claude" / "skills" / "foo" / "SKILL.md",
+        "---\ndescription: foo skill\n---\nfoo body",
+    )
+
+    ctx = ToolContext(workspace_root=project)
+    result = SkillTool.call({"skill": "foo"}, ctx)
+    out = result.output
+    assert out["success"] is True, f"expected success, got: {out}"
+    assert out["commandName"] == "foo"
+    assert "foo body" in out["prompt"]
+
+
+# ======================================================================
+# A2. Nested namespace lookup — the previously-broken case from DEV-1.
+# ``.claude/skills/git/commit/SKILL.md`` must be invokable as
+# ``skill: "git:commit"`` through SkillTool.
+# ======================================================================
+
+
+def test_nested_namespace_skill_invokable_as_colon_form(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    project = tmp_path / "proj"
+    _write_skill(
+        project / ".claude" / "skills" / "git" / "commit" / "SKILL.md",
+        "---\ndescription: git commit skill\n---\nWrite a commit message",
+    )
+
+    ctx = ToolContext(workspace_root=project)
+    result = SkillTool.call({"skill": "git:commit"}, ctx)
+    out = result.output
+    assert out["success"] is True, (
+        "nested-namespace lookup is the previously-broken case from "
+        f"DEV-1; SkillTool must resolve 'git:commit' through the "
+        f"unified registry. Got: {out}"
+    )
+    assert out["commandName"] == "git:commit"
+    assert "Write a commit message" in out["prompt"]
+
+
+def test_nested_namespace_appears_in_get_all_skills(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    project = tmp_path / "proj"
+    _write_skill(
+        project / ".claude" / "skills" / "deep" / "nested" / "thing" / "SKILL.md",
+        "---\ndescription: deep skill\n---\nbody",
+    )
+
+    skills = get_all_skills(project_root=project)
+    by_name = {s.name: s for s in skills}
+    # `_get_skill_command_name` joins ALL relative-path segments with
+    # `:` (every dir between the skills root and the skill folder
+    # becomes a namespace component).
+    assert "deep:nested:thing" in by_name, (
+        f"expected nested namespace 'deep:nested:thing' in {sorted(by_name)}"
+    )
+
+
+# ======================================================================
+# A3. Bundled skills registered via ``register_bundled_skill`` are
+# discoverable through SkillTool.
+# ======================================================================
+
+
+def test_bundled_skill_discoverable_through_skilltool(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    register_bundled_skill(
+        BundledSkillDefinition(
+            name="bundled-thing",
+            description="A bundled skill",
+            get_prompt_for_command=lambda args: f"bundled prompt: {args}",
+        )
+    )
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    ctx = ToolContext(workspace_root=project)
+    result = SkillTool.call({"skill": "bundled-thing", "args": "hello"}, ctx)
+    out = result.output
+    assert out["success"] is True
+    assert out["commandName"] == "bundled-thing"
+    assert "bundled prompt: hello" in out["prompt"]
+    assert out["loadedFrom"] == "bundled"
+
+
+# ======================================================================
+# A4. Listing via ``get_all_skills(project_root=tmp)`` returns the union
+# of bundled + disk-loaded skills.
+# ======================================================================
+
+
+def test_get_all_skills_returns_union_of_bundled_and_disk(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    project = tmp_path / "proj"
+    _write_skill(
+        project / ".claude" / "skills" / "diskskill" / "SKILL.md",
+        "---\ndescription: disk skill\n---\nbody",
+    )
+    register_bundled_skill(
+        BundledSkillDefinition(
+            name="bundledskill",
+            description="bundled",
+            get_prompt_for_command=lambda a: a,
+        )
+    )
+
+    skills = get_all_skills(project_root=project)
+    names = {s.name for s in skills}
+    assert "diskskill" in names, f"missing disk skill in {names}"
+    assert "bundledskill" in names, f"missing bundled skill in {names}"
+
+
+# ======================================================================
+# A5. ``CLAWCODEX_SKILLS_DIR`` + the user-skills bucket are merged into
+# the unified registry — env-var dirs are reachable via SkillTool.
+# ======================================================================
+
+
+def test_env_var_user_skill_dir_is_reachable_via_skilltool(
+    tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    user_skills = tmp_path / "extra_user_skills"
+    _write_skill(
+        user_skills / "envskill" / "SKILL.md",
+        "---\ndescription: env skill\n---\nbody-from-env",
+    )
+    monkeypatch.setenv("CLAWCODEX_SKILLS_DIR", str(user_skills))
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    ctx = ToolContext(workspace_root=project)
+    result = SkillTool.call({"skill": "envskill"}, ctx)
+    out = result.output
+    assert out["success"] is True
+    assert "body-from-env" in out["prompt"]
+    assert out["loadedFrom"] == "user"
+
+
+# ======================================================================
+# A6. ``get_registered_skill`` is the public lookup used by SkillTool's
+# validate path. Calling ``get_all_skills`` first must populate it.
+# ======================================================================
+
+
+def test_get_registered_skill_populated_after_get_all_skills(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    project = tmp_path / "proj"
+    _write_skill(
+        project / ".claude" / "skills" / "lookup-me" / "SKILL.md",
+        "---\ndescription: lookup\n---\nbody",
+    )
+
+    # Before populating, the registry should not have it.
+    assert get_registered_skill("lookup-me") is None
+
+    get_all_skills(project_root=project)
+    found = get_registered_skill("lookup-me")
+    assert found is not None
+    assert found.name == "lookup-me"
+    assert found.markdown_content == "body"

--- a/uv.lock
+++ b/uv.lock
@@ -240,8 +240,10 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },
+    { name = "pathspec" },
     { name = "prompt-toolkit" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "rich" },
     { name = "textual" },
     { name = "tiktoken" },
@@ -260,9 +262,11 @@ requires-dist = [
     { name = "anthropic" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "openai" },
+    { name = "pathspec", specifier = ">=0.11" },
     { name = "prompt-toolkit" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "python-dotenv" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich" },
     { name = "textual", specifier = ">=0.79" },
     { name = "tiktoken", specifier = ">=0.7.0" },
@@ -723,6 +727,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.6"
 source = { registry = "https://pypi.org/simple" }
@@ -955,6 +968,70 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Closes the gap between the Python skills subsystem and the TypeScript reference implementation: unified registry visible to `SkillTool`, full TS-order render pipeline including the `!\`...\`` shell-execution-in-prompt feature, PyYAML-backed frontmatter with hardened validators, realpath-based dedup with bare/policy modes and gitignore-semantics for conditional paths, and a bundled-skills package with five ported skills (`simplify`, `loop`, `debug`, `stuck`, `verify-content`).
- 251 skill-suite tests passing (49 baseline + 117 dev coverage + 85 QA coverage); 79–88% line coverage on core modules; **0 regressions** in the broader skill+command suite. Pre-existing 109 failures elsewhere in the repo (REPL/TUI/hooks, missing `pytest-asyncio`) are unrelated and pre-date this branch.
- Tier-B bundled skills (`update-config`, `keybindings-help`, `batch`, `claude-api`, `claude-in-chrome`, `schedule-remote-agents`) are deferred — each requires Python-side runtime infrastructure that doesn't exist yet (settings-store mutation, keybindings registry, GrowthBook gates, etc.).

## What changed

| Area | Files | Notes |
|---|---|---|
| Unified registry | `src/skills/loader.py`, `src/skills/model.py`, `src/skills/__init__.py`, `src/tool_system/tools/skill.py` | `get_all_skills(...)` is the canonical entry point; nested `category:skill` namespaces resolve through `SkillTool`; activated conditional skills now flow through the unified path (fixes a bug surfaced by QA where `paths:`-gated skills were unreachable). |
| Runtime render pipeline | `src/skills/runtime_substitution.py` (new), `src/tool_system/tools/skill.py`, `src/tool_system/context.py` | TS-order: base-dir header → arg sub → `${CLAUDE_SKILL_DIR}` → `${CLAUDE_SESSION_ID}` → embedded shell exec. Both fenced (` ```!\n…\n``` `) and inline (`` !\`…\` ``) patterns. MCP skills skip exec (security boundary, double-asserted in tests). Failures render visibly inline as `[Error: …]` / `[stderr: …]` rather than silently dropped. |
| Frontmatter | `src/skills/frontmatter.py`, `src/skills/loader.py` | Replaced homegrown YAML-subset parser with PyYAML; `Skill` gained `hooks` and `shell` fields; ported field validators for `description`, `model`, `effort`, `shell`, `allowed-tools` (preserves arg patterns like `Bash(git diff:*)`), and `hooks` (shape-validated against `ALL_HOOK_EVENTS`, debug-logs and drops on mismatch — never raises). |
| Dedup & path semantics | `src/skills/loader.py` | Realpath-based dedup (collapses symlinked same-file, keeps same-name different-files); bare mode; `CLAUDE_CODE_DISABLE_POLICY_SKILLS`; `pathspec`-based gitignore semantics for `paths:`; `git check-ignore` skips dynamic discovery under gitignored dirs (e.g., `node_modules/pkg/.claude/skills`). |
| Bundled skills | `src/skills/bundled/` (new package), `src/skills/bundled_skills.py` | Idempotent `init_bundled_skills()` orchestrator + lazy-init seeding via `get_bundled_skills`. Five skills ported: `simplify`, `loop` (full `parseLoopArgs` with unit aliases and trailing-`every` clause), `debug` (env-driven log path resolution), `stuck`, `verify-content`. |
| Deps | `pyproject.toml`, `requirements.txt`, `uv.lock` | Adds `PyYAML>=6.0` (frontmatter) and `pathspec>=0.11` (gitignore semantics). |

## Test plan
- [ ] `uv run pytest tests/test_skills_*.py -q` — expect **251 passed, 0 failed**.
- [ ] `python scripts/run_skill_smoke.py` — manual catalogue + rendered-prompt preview; `lint-py` activates after `activate_conditional_skills_for_paths(["src/foo.py"], cwd)` and is invokable through `SkillTool` with no patches.
- [ ] Manual repro of the original conditional-skills bug:
  1. `get_all_skills(project_root=p)` — `lint-py` not present (correct).
  2. `activate_conditional_skills_for_paths([p/"src"/"foo.py"], p)` — returns `["lint-py"]`.
  3. `SkillTool.call({"skill": "lint-py"}, ctx)` — returns rendered prompt with base-dir header, no `Unknown skill` error.
- [ ] Spot-check a bundled skill: `SkillTool.call({"skill": "simplify"}, ctx)` returns prompt containing `"Phase 1: Identify Changes"`.
- [ ] Spot-check the shell-exec security boundary: an MCP-sourced skill body containing `` !\`whoami\` `` is returned unevaluated.

## Follow-ups (parked)
Six tasks tracked separately for the Tier-B bundled skills, each blocked on prerequisite Python-side runtime infra:
- `update-config` — needs settings-store mutation API
- `keybindings-help` — needs keybindings registry
- `batch` — needs parallel-tool orchestration
- `claude-api` — needs GrowthBook gating + Anthropic SDK content
- `claude-in-chrome` — needs browser-extension integration
- `schedule-remote-agents` — needs persistent remote-trigger plumbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)