### PR TITLE
docs(readme): add Quick Install section and refresh header screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@
 
 ***
 
+## ⚡ Quick Install
+
+```bash
+git clone https://github.com/agentforce314/clawcodex.git
+cd clawcodex
+python3 -m venv .venv && source .venv/bin/activate   # Python 3.10+
+pip install -r requirements.txt
+python -m src.cli login
+python -m src.cli
+```
+
+***
+
 ## 🎯 Why ClawCodex?
 
 **ClawCodex** is a **production-oriented Python rebuild of Claude Code**, ported from the **real TypeScript architecture** and shipped as a **working CLI agent**, not just a source dump.


### PR DESCRIPTION
## Summary
- Adds a copy-paste **Quick Install** block right under the header screenshot (clone → venv → install → login → run) so first-time visitors can get to a running REPL without scrolling past the feature tour.
- Refreshes the header screenshot (`assets/clawcodex-screenshot-1.png`) with a higher-resolution running-session capture.

## Test plan
- [ ] Render README on GitHub and confirm the Quick Install block appears directly under the screenshot.
- [ ] Copy the 5 commands into a fresh shell on Python 3.10+ and confirm the REPL launches.
- [ ] Confirm the new screenshot loads cleanly at desktop and mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)