### PR TITLE
docs(readme): note config path after login in Quick Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ git clone https://github.com/agentforce314/clawcodex.git
 cd clawcodex
 python3 -m venv .venv && source .venv/bin/activate   # Python 3.10+
 pip install -r requirements.txt
-python -m src.cli login
-python -m src.cli
+
+python -m src.cli login   # writes config to ~/.clawcodex/config.json
+
+python -m src.cli         # start the REPL
 ```
 
 ***


### PR DESCRIPTION
## Summary
- Annotates the `python -m src.cli login` line in the Quick Install block to call out that credentials land in `~/.clawcodex/config.json`.
- Adds a brief `# start the REPL` comment on the final command so the two steps read as distinct phases.

Follow-up to #10 (merged); pure README change, no code touched.

## Test plan
- [ ] Render README on GitHub and confirm the inline `# writes config to ~/.clawcodex/config.json` comment appears next to the `login` command.
- [ ] Confirm the trailing `python -m src.cli` line shows the `# start the REPL` hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)