### PR TITLE
fix(agent): align subagent async lifecycle with TS parity

### DIFF
--- a/src/agent/run_agent.py
+++ b/src/agent/run_agent.py
@@ -18,7 +18,7 @@ from ..tool_system.context import ToolContext
 from ..tool_system.registry import ToolRegistry
 from ..types.content_blocks import ToolUseBlock
 from ..types.messages import AssistantMessage, Message, UserMessage
-from ..utils.abort_controller import AbortController, create_child_abort_controller
+from ..utils.abort_controller import AbortController
 
 from .agent_definitions import AgentDefinition, is_built_in_agent
 from .agent_tool_utils import resolve_agent_tools, count_tool_uses
@@ -119,34 +119,57 @@ def _build_permission_context(
 
 
 def filter_incomplete_tool_calls(messages: list[Message]) -> list[Message]:
-    """Remove trailing assistant messages that have incomplete tool_use blocks.
+    """Remove assistant messages that contain incomplete tool_use blocks.
 
     Mirrors filterIncompleteToolCalls() from typescript/src/tools/AgentTool/runAgent.ts.
 
-    When an agent is interrupted, the last assistant message may contain tool_use
-    blocks without corresponding tool_result messages. Sending these would cause
-    an API error. This function removes such trailing messages.
+    Assistant messages with tool_use blocks are only valid if each tool_use has a
+    corresponding tool_result block in a user message. This function removes any
+    assistant message containing unresolved tool_use IDs.
     """
-    if not messages:
-        return messages
+    tool_use_ids_with_results: set[str] = set()
 
-    result = list(messages)
-    while result:
-        last = result[-1]
-        if not isinstance(last, AssistantMessage):
-            break
-        content = last.content
+    for message in messages:
+        if not isinstance(message, UserMessage):
+            continue
+        content = message.content
         if not isinstance(content, list):
-            break
-        has_tool_use = any(
-            isinstance(block, ToolUseBlock) for block in content
-        )
-        if not has_tool_use:
-            break
-        # Check if there's a following user message with tool_result
-        result.pop()
+            continue
+        for block in content:
+            block_type = block.get("type") if isinstance(block, dict) else getattr(block, "type", None)
+            if block_type != "tool_result":
+                continue
+            tool_use_id = (
+                block.get("tool_use_id")
+                if isinstance(block, dict)
+                else getattr(block, "tool_use_id", None)
+            )
+            if isinstance(tool_use_id, str) and tool_use_id:
+                tool_use_ids_with_results.add(tool_use_id)
 
-    return result
+    filtered: list[Message] = []
+    for message in messages:
+        if isinstance(message, AssistantMessage):
+            content = message.content
+            if isinstance(content, list):
+                has_incomplete_tool_call = False
+                for block in content:
+                    block_type = block.get("type") if isinstance(block, dict) else getattr(block, "type", None)
+                    if block_type != "tool_use":
+                        continue
+                    tool_use_id = (
+                        block.get("id")
+                        if isinstance(block, dict)
+                        else getattr(block, "id", None)
+                    )
+                    if isinstance(tool_use_id, str) and tool_use_id not in tool_use_ids_with_results:
+                        has_incomplete_tool_call = True
+                        break
+                if has_incomplete_tool_call:
+                    continue
+        filtered.append(message)
+
+    return filtered
 
 
 async def run_agent(params: RunAgentParams) -> AsyncGenerator[Message, None]:
@@ -200,11 +223,10 @@ async def run_agent(params: RunAgentParams) -> AsyncGenerator[Message, None]:
     # Determine abort controller
     if params.abort_controller is not None:
         abort_controller = params.abort_controller
-    elif params.is_async and params.parent_context.abort_controller is not None:
-        # Async agents get an independent abort controller (child linked to parent)
-        abort_controller = create_child_abort_controller(
-            params.parent_context.abort_controller
-        )
+    elif params.is_async:
+        # Async agents run independently in the background and should survive
+        # parent cancellation events.
+        abort_controller = AbortController()
     elif params.parent_context.abort_controller is not None:
         # Sync agents share abort with parent
         abort_controller = params.parent_context.abort_controller
@@ -226,7 +248,8 @@ async def run_agent(params: RunAgentParams) -> AsyncGenerator[Message, None]:
         abort_controller=abort_controller,
         permission_context=perm_context,
         share_abort_controller=not params.is_async,
-        share_set_response_length=not params.is_async,
+        # Both sync and async subagents should contribute to response-length metrics.
+        share_set_response_length=True,
         share_permission_handler=not params.is_async,
     )
 

--- a/src/tool_system/tools/agent.py
+++ b/src/tool_system/tools/agent.py
@@ -11,7 +11,6 @@ Supports three modes:
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import sys
 import time
@@ -30,7 +29,6 @@ from src.agent.agent_definitions import (
     get_built_in_agents,
 )
 from src.agent.agent_tool_utils import (
-    count_tool_uses,
     extract_partial_result,
     finalize_agent_tool,
 )
@@ -176,8 +174,10 @@ def make_agent_tool(
         if is_async:
             return _launch_async_agent(
                 run_params=run_params,
+                context=context,
                 agent_id=agent_id,
                 description=description,
+                prompt=prompt,
                 agent_type=agent_def.agent_type,
             )
         else:
@@ -185,6 +185,7 @@ def make_agent_tool(
                 run_params=run_params,
                 agent_id=agent_id,
                 start_time=start_time,
+                prompt=prompt,
                 agent_type=agent_def.agent_type,
             )
 
@@ -193,6 +194,7 @@ def make_agent_tool(
         run_params: RunAgentParams,
         agent_id: str,
         start_time: float,
+        prompt: str,
         agent_type: str,
     ) -> ToolResult:
         """Run an agent synchronously and return the result."""
@@ -230,6 +232,7 @@ def make_agent_tool(
             name=AGENT_TOOL_NAME,
             output={
                 "status": "completed",
+                "prompt": prompt,
                 "agent_id": result.agent_id,
                 "agent_type": result.agent_type,
                 "content": result.content,
@@ -242,34 +245,67 @@ def make_agent_tool(
     def _launch_async_agent(
         *,
         run_params: RunAgentParams,
+        context: ToolContext,
         agent_id: str,
         description: str,
+        prompt: str,
         agent_type: str,
     ) -> ToolResult:
         """Launch an agent in the background and return immediately."""
-        try:
-            loop = asyncio.get_event_loop()
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
+        context.tasks[agent_id] = {
+            "id": agent_id,
+            "subject": description,
+            "description": prompt,
+            "status": "in_progress",
+            "owner": agent_type,
+            "blocks": [],
+            "blockedBy": [],
+            "metadata": {"_internal": True, "task_type": "agent"},
+            "output": "",
+        }
 
         async def _background_lifecycle() -> None:
             try:
                 messages = await _collect_agent_messages(run_params)
+                metadata = {
+                    "start_time": time.time(),
+                    "agent_type": agent_type,
+                }
+                result = finalize_agent_tool(messages, agent_id, metadata)
+                result_text = "\n".join(
+                    block.get("text", "")
+                    for block in result.content
+                    if isinstance(block, dict) and block.get("type") == "text"
+                ).strip()
+                if not result_text:
+                    result_text = "(Subagent completed with no textual output.)"
+                context.tasks[agent_id]["status"] = "completed"
+                context.tasks[agent_id]["output"] = result_text
                 logger.info(
                     "Async agent %s (%s) finished: %d messages",
                     agent_id, agent_type, len(messages),
                 )
-            except Exception:
+            except Exception as exc:
+                partial = extract_partial_result(locals().get("messages", []))
+                context.tasks[agent_id]["status"] = "failed"
+                context.tasks[agent_id]["output"] = partial or str(exc)
                 logger.exception(
                     "Async agent %s (%s) failed",
                     agent_id, agent_type,
                 )
 
-        if loop.is_running():
-            asyncio.ensure_future(_background_lifecycle())
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+
+        if running_loop is not None:
+            running_loop.create_task(_background_lifecycle())
         else:
-            loop.create_task(_background_lifecycle())
+            def _runner(_stop_event: Any) -> None:
+                asyncio.run(_background_lifecycle())
+
+            context.task_manager.start(name=f"agent:{agent_type}", target=_runner)
 
         return ToolResult(
             name=AGENT_TOOL_NAME,
@@ -278,6 +314,8 @@ def make_agent_tool(
                 "agent_id": agent_id,
                 "agent_type": agent_type,
                 "description": description,
+                "prompt": prompt,
+                "task_output_key": agent_id,
             },
         )
 
@@ -296,6 +334,33 @@ def make_agent_tool(
                 "tool_use_id": tool_use_id,
                 "content": result.get("error", content),
                 "is_error": True,
+            }
+        if result.get("status") == "async_launched":
+            return {
+                "type": "tool_result",
+                "tool_use_id": tool_use_id,
+                "content": (
+                    "Async agent launched successfully.\n"
+                    f"agent_id: {result.get('agent_id', '')}\n"
+                    f"task_output_key: {result.get('task_output_key', '')}\n"
+                    "Use TaskOutput with task_id equal to task_output_key to check completion."
+                ),
+            }
+        if result.get("status") == "completed":
+            text_parts: list[str] = []
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        text = block.get("text")
+                        if isinstance(text, str) and text.strip():
+                            text_parts.append(text.strip())
+            elif isinstance(content, str) and content.strip():
+                text_parts.append(content.strip())
+            rendered = "\n\n".join(text_parts).strip() or "(Subagent completed with no textual output.)"
+            return {
+                "type": "tool_result",
+                "tool_use_id": tool_use_id,
+                "content": rendered,
             }
         return {"type": "tool_result", "tool_use_id": tool_use_id, "content": content}
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -349,6 +349,39 @@ class TestFilterIncompleteToolCalls(unittest.TestCase):
         result = filter_incomplete_tool_calls(msgs)
         assert len(result) == 1
 
+    def test_matched_tool_use_is_kept(self):
+        from src.agent.run_agent import filter_incomplete_tool_calls
+        from src.types.messages import AssistantMessage, UserMessage
+        from src.types.content_blocks import ToolUseBlock, ToolResultBlock
+
+        msgs = [
+            AssistantMessage(content=[
+                ToolUseBlock(id="t1", name="Read", input={"path": "/tmp/a"}),
+            ]),
+            UserMessage(content=[
+                ToolResultBlock(tool_use_id="t1", content="ok"),
+            ]),
+        ]
+        result = filter_incomplete_tool_calls(msgs)
+        assert len(result) == 2
+
+    def test_unmatched_tool_use_removed_even_if_not_trailing(self):
+        from src.agent.run_agent import filter_incomplete_tool_calls
+        from src.types.messages import AssistantMessage, UserMessage
+        from src.types.content_blocks import ToolUseBlock, TextBlock
+
+        msgs = [
+            AssistantMessage(content=[
+                ToolUseBlock(id="t1", name="Read", input={"path": "/tmp/a"}),
+            ]),
+            UserMessage(content="no tool results here"),
+            AssistantMessage(content=[TextBlock(text="final summary")]),
+        ]
+        result = filter_incomplete_tool_calls(msgs)
+        assert len(result) == 2
+        assert isinstance(result[0], UserMessage)
+        assert isinstance(result[1], AssistantMessage)
+
 
 class TestAgentDefinitions(unittest.TestCase):
     """Test agent definition module."""

--- a/tests/test_agent_tool_async.py
+++ b/tests/test_agent_tool_async.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.tool_system.protocol import ToolCall
+from src.types.content_blocks import TextBlock
+from src.types.messages import AssistantMessage
+
+
+def _wait_for_task_status(context: ToolContext, task_id: str, timeout_s: float = 2.0) -> str:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        status = str(context.tasks.get(task_id, {}).get("status", ""))
+        if status and status != "in_progress":
+            return status
+        time.sleep(0.05)
+    return str(context.tasks.get(task_id, {}).get("status", ""))
+
+
+def test_async_agent_launch_persists_completed_output(tmp_path: Path) -> None:
+    registry = build_default_registry(provider=object())
+    context = ToolContext(workspace_root=tmp_path)
+
+    async def _fake_run_agent(_params):
+        yield AssistantMessage(content=[TextBlock(text="async done")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _fake_run_agent):
+        result = registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={
+                    "description": "background test",
+                    "prompt": "do background work",
+                    "run_in_background": True,
+                },
+            ),
+            context,
+        )
+
+        assert result.is_error is False
+        assert isinstance(result.output, dict)
+        assert result.output.get("status") == "async_launched"
+
+        task_id = str(result.output["agent_id"])
+        assert result.output.get("task_output_key") == task_id
+        assert task_id in context.tasks
+
+        final_status = _wait_for_task_status(context, task_id)
+        assert final_status == "completed"
+        assert "async done" in str(context.tasks[task_id].get("output", ""))
+
+
+def test_async_agent_launch_marks_failed_output(tmp_path: Path) -> None:
+    registry = build_default_registry(provider=object())
+    context = ToolContext(workspace_root=tmp_path)
+
+    async def _failing_run_agent(_params):
+        if False:
+            yield AssistantMessage(content=[TextBlock(text="unused")])
+        raise RuntimeError("boom")
+
+    with patch("src.tool_system.tools.agent.run_agent", _failing_run_agent):
+        result = registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={
+                    "description": "background failure",
+                    "prompt": "fail",
+                    "run_in_background": True,
+                },
+            ),
+            context,
+        )
+
+        task_id = str(result.output["agent_id"])
+        final_status = _wait_for_task_status(context, task_id)
+        assert final_status == "failed"
+        assert "boom" in str(context.tasks[task_id].get("output", ""))


### PR DESCRIPTION
## Summary
- align subagent async abort behavior with TS semantics by using independent abort controllers for background agents
- port incomplete tool-call filtering to tool_use/tool_result pairing, and strengthen tests around that behavior
- improve Agent async lifecycle reliability/observability by persisting background task status/output and exposing async launch guidance

## Test plan
- [x] `uv run pytest tests/test_agent_loop.py tests/test_agent_permission_inheritance.py tests/test_subagent_context.py tests/test_agent_tool_async.py`
- [x] verify no lints for changed files via `ReadLints`


Made with [Cursor](https://cursor.com)