### PR TITLE
feat(agent): port chapter 9 fork subagent path

### DIFF
--- a/src/agent/constants.py
+++ b/src/agent/constants.py
@@ -70,4 +70,4 @@ DEFAULT_AGENT_PROMPT = (
 # Fork-specific constants
 FORK_SUBAGENT_TYPE = "fork"
 FORK_BOILERPLATE_TAG = "fork-boilerplate"
-FORK_DIRECTIVE_PREFIX = "DIRECTIVE: "
+FORK_DIRECTIVE_PREFIX = "Your directive: "

--- a/src/agent/fork_subagent.py
+++ b/src/agent/fork_subagent.py
@@ -1,0 +1,289 @@
+"""Fork subagent helpers.
+
+Mirrors ``typescript/src/tools/AgentTool/forkSubagent.ts``.
+
+Fork is an implicit-spawn path where the child inherits the parent's full
+conversation context and tool array, so the API request prefix is
+byte-identical across all parallel children. Anthropic's prompt cache then
+discounts every child after the first by ~90% on the shared prefix.
+
+This module supplies:
+
+- ``is_fork_subagent_enabled`` — feature gate (env-flag plus interactivity
+  check). Coordinator-mode gating is a no-op until coordinator mode is
+  ported to Python.
+- ``FORK_AGENT`` (re-exported from agent_definitions) — synthetic agent
+  definition used when the gate is on and ``subagent_type`` is omitted.
+- ``build_forked_messages`` / ``build_child_message`` — produce the trailing
+  message pair that wraps every child's directive in the
+  ``<fork-boilerplate>`` envelope while leaving the prefix byte-identical
+  across all children.
+- ``is_in_fork_child`` — fallback recursion guard scanning user messages for
+  the boilerplate tag.
+- ``build_worktree_notice`` — translation hint when fork combines with
+  worktree isolation.
+"""
+from __future__ import annotations
+
+import copy
+import os
+from typing import Any
+from uuid import uuid4
+
+from ..bootstrap.state import get_is_non_interactive_session
+from ..tool_system.context import ToolContext
+from ..types.content_blocks import TextBlock, ToolResultBlock, ToolUseBlock
+from ..types.messages import (
+    AssistantMessage,
+    Message,
+    UserMessage,
+    create_user_message,
+)
+
+from .agent_definitions import FORK_AGENT
+from .constants import (
+    FORK_BOILERPLATE_TAG,
+    FORK_DIRECTIVE_PREFIX,
+    FORK_SUBAGENT_TYPE,
+)
+
+
+# Placeholder tool_result text reused across every fork child so the
+# pre-directive prefix is byte-identical. Mirrors
+# ``forkSubagent.ts:93``.
+FORK_PLACEHOLDER_RESULT = "Fork started — processing in background"
+
+
+# Truthy values accepted by the env-flag gate. Mirrors common Python
+# convention; matches the spirit of the GrowthBook flag in TS.
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _is_env_truthy(name: str) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return False
+    return raw.strip().lower() in _TRUTHY
+
+
+def is_fork_subagent_enabled(context: ToolContext | None = None) -> bool:
+    """Check whether the fork-subagent path is enabled.
+
+    Mirrors ``isForkSubagentEnabled()`` from ``forkSubagent.ts:32``. The
+    gate is on when:
+
+    - ``CLAUDE_FORK_SUBAGENT`` env var is set to a truthy value
+      (Python equivalent of the GrowthBook ``feature('FORK_SUBAGENT')``).
+    - The current session is interactive (no SDK / ``--print`` mode).
+    - (Coordinator mode is not yet ported; the check is a no-op.)
+    """
+    if not _is_env_truthy("CLAUDE_FORK_SUBAGENT"):
+        return False
+
+    if context is not None:
+        opts = getattr(context, "options", None)
+        if opts is not None and getattr(opts, "is_non_interactive_session", False):
+            return False
+    elif get_is_non_interactive_session():
+        return False
+
+    return True
+
+
+def is_in_fork_child(messages: list[Any] | None) -> bool:
+    """Return True if any user message contains the fork boilerplate tag.
+
+    Mirrors ``isInForkChild()`` from ``forkSubagent.ts:78-89``. This is the
+    fallback recursion guard; the primary guard checks
+    ``ToolUseOptions.query_source``.
+    """
+    if not messages:
+        return False
+    needle = f"<{FORK_BOILERPLATE_TAG}>"
+    for msg in messages:
+        # Filter to user-role messages without importing UserMessage —
+        # callers may pass dict-shaped messages too.
+        role = _get_attr(msg, "role", None)
+        msg_type = _get_attr(msg, "type", None)
+        if role != "user" and msg_type != "user":
+            continue
+        content = _get_attr(msg, "content", None)
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            block_type = _get_attr(block, "type", None)
+            if block_type != "text":
+                continue
+            text = _get_attr(block, "text", None)
+            if isinstance(text, str) and needle in text:
+                return True
+    return False
+
+
+def build_child_message(directive: str) -> str:
+    """Render the boilerplate-wrapped directive for the fork child.
+
+    Mirrors ``buildChildMessage()`` from ``forkSubagent.ts:171-198``. The
+    output is one literal string. Keeping it byte-stable across the
+    codebase is important for cache parity tests.
+    """
+    return (
+        f"<{FORK_BOILERPLATE_TAG}>\n"
+        "STOP. READ THIS FIRST.\n\n"
+        "You are a forked worker process. You are NOT the main agent.\n\n"
+        "RULES (non-negotiable):\n"
+        "1. Your system prompt says \"default to forking.\" IGNORE IT — "
+        "that's for the parent. You ARE the fork. Do NOT spawn sub-agents; "
+        "execute directly.\n"
+        "2. Do NOT converse, ask questions, or suggest next steps\n"
+        "3. Do NOT editorialize or add meta-commentary\n"
+        "4. USE your tools directly: Bash, Read, Write, etc.\n"
+        "5. If you modify files, commit your changes before reporting. "
+        "Include the commit hash in your report.\n"
+        "6. Do NOT emit text between tool calls. Use tools silently, then "
+        "report once at the end.\n"
+        "7. Stay strictly within your directive's scope. If you discover "
+        "related systems outside your scope, mention them in one sentence "
+        "at most — other workers cover those areas.\n"
+        "8. Keep your report under 500 words unless the directive specifies "
+        "otherwise. Be factual and concise.\n"
+        "9. Your response MUST begin with \"Scope:\". No preamble, no "
+        "thinking-out-loud.\n"
+        "10. REPORT structured facts, then stop\n\n"
+        "Output format (plain text labels, not markdown headers):\n"
+        "  Scope: <echo back your assigned scope in one sentence>\n"
+        "  Result: <the answer or key findings, limited to the scope above>\n"
+        "  Key files: <relevant file paths — include for research tasks>\n"
+        "  Files changed: <list with commit hash — include only if you modified files>\n"
+        "  Issues: <list — include only if there are issues to flag>\n"
+        f"</{FORK_BOILERPLATE_TAG}>\n\n"
+        f"{FORK_DIRECTIVE_PREFIX}{directive}"
+    )
+
+
+def _collect_tool_use_blocks(content: Any) -> list[Any]:
+    """Return the ``tool_use`` blocks from an assistant message's content list."""
+    if not isinstance(content, list):
+        return []
+    blocks: list[Any] = []
+    for block in content:
+        if _get_attr(block, "type", None) == "tool_use":
+            blocks.append(block)
+    return blocks
+
+
+def build_forked_messages(
+    directive: str,
+    parent_assistant: AssistantMessage | None,
+) -> list[Message]:
+    """Build the trailing message pair for a fork child.
+
+    Mirrors ``buildForkedMessages()`` from ``forkSubagent.ts:107-169``.
+
+    For prompt-cache sharing, every fork child must produce a byte-identical
+    API request prefix. This function:
+
+    1. Clones the parent assistant message (preserving every ``tool_use``
+       block and its ID).
+    2. For each ``tool_use`` block, emits a ``tool_result`` with the
+       constant ``FORK_PLACEHOLDER_RESULT`` text.
+    3. Appends a single user message containing all those placeholder
+       ``tool_result`` blocks followed by the boilerplate-wrapped
+       directive.
+
+    Result: ``[cloned_assistant, user_message]``. Only the final text block
+    differs per child, maximizing cache hits.
+
+    If the parent assistant has no ``tool_use`` blocks (or no parent at
+    all), we fall back to a single user message carrying the directive.
+    """
+    if parent_assistant is None:
+        return [
+            create_user_message(content=[TextBlock(text=build_child_message(directive))])
+        ]
+
+    tool_use_blocks = _collect_tool_use_blocks(parent_assistant.content)
+
+    if not tool_use_blocks:
+        return [
+            create_user_message(content=[TextBlock(text=build_child_message(directive))])
+        ]
+
+    # Clone the assistant message — new uuid, deep-copied content list — so
+    # we never mutate the parent's message in place.
+    cloned_content: list[Any] = []
+    for block in parent_assistant.content if isinstance(parent_assistant.content, list) else []:
+        cloned_content.append(copy.deepcopy(block))
+    cloned_assistant = AssistantMessage(
+        content=cloned_content,
+        uuid=str(uuid4()),
+        timestamp=parent_assistant.timestamp,
+        stop_reason=parent_assistant.stop_reason,
+        model=parent_assistant.model,
+        usage=parent_assistant.usage,
+        requestId=parent_assistant.requestId,
+    )
+
+    # Build placeholder tool_result blocks for every parent tool_use block.
+    tool_result_blocks: list[ToolResultBlock] = []
+    for block in tool_use_blocks:
+        tool_use_id = _get_attr(block, "id", "") or ""
+        tool_result_blocks.append(
+            ToolResultBlock(
+                tool_use_id=str(tool_use_id),
+                content=FORK_PLACEHOLDER_RESULT,
+            )
+        )
+
+    # Single user message: all placeholder tool_results + the per-child
+    # directive wrapped in <fork-boilerplate>. The directive is appended
+    # as a TextBlock sibling so the cache boundary lands right before it.
+    user_msg = create_user_message(
+        content=[*tool_result_blocks, TextBlock(text=build_child_message(directive))]
+    )
+
+    return [cloned_assistant, user_msg]
+
+
+def build_worktree_notice(parent_cwd: str, worktree_cwd: str) -> str:
+    """Build the worktree-isolation notice for a fork child.
+
+    Mirrors ``buildWorktreeNotice()`` from ``forkSubagent.ts:205-210``. The
+    notice tells the child to translate inherited paths to the worktree
+    root, re-read potentially stale files, and that its changes stay
+    isolated.
+    """
+    return (
+        f"You've inherited the conversation context above from a parent agent "
+        f"working in {parent_cwd}. You are operating in an isolated git worktree at "
+        f"{worktree_cwd} — same repository, same relative file structure, separate "
+        f"working copy. Paths in the inherited context refer to the parent's working "
+        f"directory; translate them to your worktree root. Re-read files before editing "
+        f"if the parent may have modified them since they appear in the context. Your "
+        f"changes stay in this worktree and will not affect the parent's files."
+    )
+
+
+def _get_attr(obj: Any, name: str, default: Any) -> Any:
+    """Read an attribute or mapping key from a heterogeneous object.
+
+    Forked messages can arrive as dataclass instances, plain dicts, or
+    Pydantic-style objects. This helper unifies the reads.
+    """
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+__all__ = [
+    "FORK_AGENT",
+    "FORK_PLACEHOLDER_RESULT",
+    "FORK_SUBAGENT_TYPE",
+    "build_child_message",
+    "build_forked_messages",
+    "build_worktree_notice",
+    "is_fork_subagent_enabled",
+    "is_in_fork_child",
+]

--- a/src/agent/run_agent.py
+++ b/src/agent/run_agent.py
@@ -57,6 +57,13 @@ class RunAgentParams:
     context_messages: list[Message] | None = None
     abort_controller: AbortController | None = None
     on_message: Any = None
+    # When True, use ``available_tools`` directly without filtering through
+    # ``resolve_agent_tools()``. Mirrors the ``useExactTools`` flag from
+    # typescript/src/tools/AgentTool/runAgent.ts (the fork path).
+    use_exact_tools: bool = False
+    # Identifier threaded into ``ToolUseOptions.query_source`` for the
+    # primary recursive-fork guard. Mirrors the TS ``querySource`` argument.
+    query_source: str | None = None
 
 
 @dataclass
@@ -199,20 +206,26 @@ async def run_agent(params: RunAgentParams) -> AsyncGenerator[Message, None]:
         is_async=params.is_async,
     )
 
-    # Resolve tools for the agent
-    resolved = resolve_agent_tools(
-        agent_def,
-        params.available_tools,
-        is_async=params.is_async,
-    )
-    agent_tools = resolved.resolved_tools
-
-    if resolved.invalid_tools:
-        logger.warning(
-            "Agent %s has invalid tools: %s",
-            agent_def.agent_type,
-            resolved.invalid_tools,
+    # Resolve tools for the agent.
+    # When ``use_exact_tools`` is set (fork path), bypass ``resolve_agent_tools``
+    # so the child receives the parent's exact tool array. Mirrors the
+    # ``useExactTools`` branch in typescript/src/tools/AgentTool/runAgent.ts:513.
+    if params.use_exact_tools:
+        agent_tools = list(params.available_tools)
+    else:
+        resolved = resolve_agent_tools(
+            agent_def,
+            params.available_tools,
+            is_async=params.is_async,
         )
+        agent_tools = resolved.resolved_tools
+
+        if resolved.invalid_tools:
+            logger.warning(
+                "Agent %s has invalid tools: %s",
+                agent_def.agent_type,
+                resolved.invalid_tools,
+            )
 
     # Build system prompt
     system_prompt = (
@@ -240,17 +253,37 @@ async def run_agent(params: RunAgentParams) -> AsyncGenerator[Message, None]:
         params.is_async,
     )
 
+    # Strip orphaned tool_use blocks before threading parent context into the
+    # child. Mirrors typescript/src/tools/AgentTool/runAgent.ts:381-385 — the
+    # API rejects assistant messages whose tool_use IDs lack matching
+    # tool_result IDs.
+    if params.context_messages:
+        sanitized_context_messages = filter_incomplete_tool_calls(params.context_messages)
+    else:
+        sanitized_context_messages = []
+
+    # When the fork path threads its own ``query_source`` (e.g.
+    # ``"agent:builtin:fork"``), surface it on the child's options so the
+    # primary recursive-fork guard at the Agent tool's call site can read it.
+    options_override = None
+    if params.query_source is not None:
+        # Shallow-copy the parent options so we don't mutate them in place.
+        from copy import copy as _shallow_copy
+        options_override = _shallow_copy(params.parent_context.options)
+        options_override.query_source = params.query_source
+
     # Build overrides
     overrides = SubagentContextOverrides(
         agent_id=agent_id,
         agent_type=agent_def.agent_type,
-        messages=params.context_messages or [],
+        messages=sanitized_context_messages,
         abort_controller=abort_controller,
         permission_context=perm_context,
         share_abort_controller=not params.is_async,
         # Both sync and async subagents should contribute to response-length metrics.
         share_set_response_length=True,
         share_permission_handler=not params.is_async,
+        options=options_override,
     )
 
     # Create isolated context
@@ -259,9 +292,16 @@ async def run_agent(params: RunAgentParams) -> AsyncGenerator[Message, None]:
         overrides,
     )
 
-    # Build initial messages
-    prompt_message = UserMessage(content=params.prompt)
-    initial_messages: list[Message] = list(subagent_context.messages) + [prompt_message]
+    # Build initial messages.
+    # When ``params.prompt`` is empty (e.g. fork path, where the directive is
+    # already embedded inside ``context_messages`` via build_forked_messages),
+    # do not append an empty user turn — it would shift the cache boundary
+    # and confuse the model with a blank input.
+    if params.prompt:
+        prompt_message = UserMessage(content=params.prompt)
+        initial_messages: list[Message] = list(subagent_context.messages) + [prompt_message]
+    else:
+        initial_messages = list(subagent_context.messages)
 
     # Determine max turns — mirrors TS: maxTurns ?? agentDefinition.maxTurns
     # TS has no built-in fallback, but we keep a safety net to prevent runaway agents.
@@ -271,6 +311,7 @@ async def run_agent(params: RunAgentParams) -> AsyncGenerator[Message, None]:
     # TS microcompact is a no-op for subagents (only fires for
     # repl_main_thread). Don't pass pipeline_config so we don't
     # aggressively clear tool results the model just read.
+    effective_query_source = params.query_source or f"agent_{agent_def.agent_type}"
     query_params = QueryParams(
         messages=initial_messages,
         system_prompt=system_prompt,
@@ -279,7 +320,7 @@ async def run_agent(params: RunAgentParams) -> AsyncGenerator[Message, None]:
         tool_use_context=subagent_context,
         provider=params.provider,
         abort_controller=abort_controller,
-        query_source=f"agent_{agent_def.agent_type}",
+        query_source=effective_query_source,
         max_turns=max_turns,
     )
 

--- a/src/tool_system/tools/agent.py
+++ b/src/tool_system/tools/agent.py
@@ -25,6 +25,7 @@ from ..registry import ToolRegistry
 
 from src.agent.agent_definitions import (
     AgentDefinition,
+    FORK_AGENT,
     find_agent_by_type,
     get_built_in_agents,
 )
@@ -34,10 +35,16 @@ from src.agent.agent_tool_utils import (
 )
 from src.agent.constants import (
     AGENT_TOOL_NAME,
+    FORK_SUBAGENT_TYPE,
     LEGACY_AGENT_TOOL_NAME,
     ONE_SHOT_BUILTIN_AGENT_TYPES,
 )
-from src.agent.prompt import get_agent_prompt
+from src.agent.fork_subagent import (
+    build_forked_messages,
+    is_fork_subagent_enabled,
+    is_in_fork_child,
+)
+from src.agent.prompt import get_agent_prompt, get_agent_system_prompt
 from src.agent.run_agent import RunAgentParams, run_agent
 
 logger = logging.getLogger(__name__)
@@ -120,9 +127,30 @@ def make_agent_tool(
         model = tool_input.get("model")
         run_in_background = bool(tool_input.get("run_in_background", False))
 
-        # Resolve agent definition
+        # Resolve agent definition.
+        #
+        # Routing rules mirror typescript/src/tools/AgentTool/AgentTool.tsx:318-356:
+        # - subagent_type provided → use it (explicit wins).
+        # - subagent_type omitted, fork gate on → implicit fork via FORK_AGENT.
+        # - subagent_type omitted, fork gate off → default to general-purpose.
         agent_definitions = _get_agent_definitions(context)
-        if subagent_type:
+        is_fork_path = (
+            subagent_type is None and is_fork_subagent_enabled(context)
+        )
+
+        if is_fork_path:
+            # Recursive-fork guard. Primary check: querySource on the parent's
+            # options. Secondary check: scan parent messages for the fork
+            # boilerplate tag. Either one trips means we are already inside a
+            # fork child, so refuse to spawn another.
+            parent_query_source = getattr(context.options, "query_source", None)
+            if parent_query_source == f"agent:builtin:{FORK_SUBAGENT_TYPE}" or is_in_fork_child(context.messages):
+                raise ToolInputError(
+                    "Fork is not available inside a forked worker. "
+                    "Complete your task directly using your tools."
+                )
+            agent_def = FORK_AGENT
+        elif subagent_type:
             agent_def = find_agent_by_type(agent_definitions, subagent_type)
             if agent_def is None:
                 available = [a.agent_type for a in agent_definitions]
@@ -158,10 +186,61 @@ def make_agent_tool(
                 is_error=True,
             )
 
+        # Fork-specific run-agent inputs.
+        #
+        # On the fork path:
+        #   * The child inherits the parent's full conversation as
+        #     ``context_messages`` so the API-request prefix matches the
+        #     parent's most recent turn.
+        #   * ``build_forked_messages()`` produces the trailing pair: a
+        #     cloned parent assistant message plus a single user message
+        #     carrying placeholder tool_results and the boilerplate-wrapped
+        #     directive. This pair is passed as a single concatenated
+        #     ``prompt`` (run_agent appends a UserMessage built from
+        #     ``params.prompt``); to preserve the cloned-assistant block we
+        #     instead route the messages via ``context_messages`` and pass
+        #     the directive bytes alone as ``params.prompt``.
+        #   * ``use_exact_tools`` skips ``resolve_agent_tools()`` so the
+        #     child's tool array is byte-identical to the parent's.
+        #   * ``query_source`` is threaded onto the child's options for the
+        #     primary recursive-fork guard at the next call site.
+        #   * ``parent_system_prompt`` carries the parent's resolved prompt
+        #     so the fork agent's empty get_system_prompt is filled in via
+        #     ``get_agent_system_prompt()``.
+        fork_context_messages: list[Any] | None = None
+        fork_query_source: str | None = None
+        fork_use_exact_tools = False
+        fork_parent_system_prompt: str | None = None
+        fork_prompt = prompt
+
+        if is_fork_path:
+            from src.types.messages import AssistantMessage
+
+            parent_assistant: AssistantMessage | None = None
+            for msg in reversed(context.messages):
+                if isinstance(msg, AssistantMessage):
+                    parent_assistant = msg
+                    break
+
+            forked_pair = build_forked_messages(prompt, parent_assistant)
+            fork_context_messages = list(context.messages) + forked_pair
+            fork_use_exact_tools = True
+            fork_query_source = f"agent:builtin:{FORK_SUBAGENT_TYPE}"
+            # Best-effort parent system prompt: derived from the active
+            # agent definition or falling back to None. Threading the
+            # exact rendered bytes from the main loop is a follow-up.
+            fork_parent_system_prompt = _resolve_parent_system_prompt(context, agent_definitions)
+            # ``run_agent`` will append a UserMessage built from ``prompt``
+            # to whatever ``context_messages`` it receives. We have already
+            # placed the directive inside ``forked_pair`` via
+            # ``build_forked_messages``; pass an empty prompt so we don't
+            # duplicate it.
+            fork_prompt = ""
+
         run_params = RunAgentParams(
             parent_context=context,
             agent_definition=agent_def,
-            prompt=prompt,
+            prompt=fork_prompt,
             available_tools=available_tools,
             tool_registry=registry,
             provider=provider,
@@ -169,6 +248,10 @@ def make_agent_tool(
             agent_id=agent_id,
             is_async=is_async,
             max_turns=agent_def.max_turns,
+            context_messages=fork_context_messages,
+            use_exact_tools=fork_use_exact_tools,
+            query_source=fork_query_source,
+            parent_system_prompt=fork_parent_system_prompt,
         )
 
         if is_async:
@@ -378,6 +461,40 @@ def make_agent_tool(
         to_auto_classifier_input=lambda input_data: (input_data or {}).get("prompt", "")[:200],
         get_activity_description=lambda input_data: (input_data or {}).get("description", "Running agent") if input_data else None,
     )
+
+
+def _resolve_parent_system_prompt(
+    context: ToolContext,
+    agent_definitions: list[AgentDefinition],
+) -> str | None:
+    """Best-effort parent-system-prompt resolution for fork children.
+
+    The TS implementation threads the parent's already-rendered
+    ``renderedSystemPrompt`` so the bytes are identical to the parent's
+    last API call. We do not yet propagate the rendered bytes from the
+    main loop, so this helper falls back to:
+
+    1. ``context.options.custom_system_prompt`` if provided.
+    2. The active agent definition's ``get_system_prompt()`` output.
+    3. ``None`` (let the FORK_AGENT empty prompt fall through to the
+       default).
+
+    Returns ``None`` when no candidate is available.
+    """
+    custom = getattr(context.options, "custom_system_prompt", None)
+    if isinstance(custom, str) and custom.strip():
+        return custom
+
+    active_type = getattr(context, "agent_type", None)
+    if active_type:
+        active_def = find_agent_by_type(agent_definitions, active_type)
+        if active_def is not None:
+            try:
+                return active_def.get_system_prompt()
+            except Exception:
+                return None
+
+    return None
 
 
 def _sync_collect_agent_messages(params: RunAgentParams) -> list[Any]:

--- a/tests/test_agent_tool_fork.py
+++ b/tests/test_agent_tool_fork.py
@@ -1,0 +1,243 @@
+"""Tests for Agent tool fork routing.
+
+Covers ``src/tool_system/tools/agent.py`` integration with the fork helpers:
+
+- Disabled by default → no fork routing.
+- Enabled via env var → routes to ``FORK_AGENT`` when ``subagent_type``
+  is omitted.
+- Recursive-fork guard rejects nested fork attempts.
+- ``filter_incomplete_tool_calls`` runs on parent context messages.
+- ``use_exact_tools`` bypasses ``resolve_agent_tools()``.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.agent.fork_subagent import FORK_AGENT
+from src.tool_system.context import ToolContext, ToolUseOptions
+from src.tool_system.defaults import build_default_registry
+from src.tool_system.errors import ToolInputError
+from src.tool_system.protocol import ToolCall
+from src.types.content_blocks import (
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+)
+from src.types.messages import (
+    AssistantMessage,
+    UserMessage,
+    create_user_message,
+)
+
+
+def _set_fork_env(monkeypatch: pytest.MonkeyPatch, *, enabled: bool) -> None:
+    if enabled:
+        monkeypatch.setenv("CLAUDE_FORK_SUBAGENT", "1")
+    else:
+        monkeypatch.delenv("CLAUDE_FORK_SUBAGENT", raising=False)
+
+
+def _make_interactive_context(tmp_path: Path) -> ToolContext:
+    ctx = ToolContext(workspace_root=tmp_path)
+    ctx.options = ToolUseOptions(is_non_interactive_session=False)
+    return ctx
+
+
+def test_fork_routing_disabled_by_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_fork_env(monkeypatch, enabled=False)
+    registry = build_default_registry(provider=object())
+    context = _make_interactive_context(tmp_path)
+
+    captured: dict[str, object] = {}
+
+    async def _fake_run_agent(params):
+        captured["agent_type"] = params.agent_definition.agent_type
+        captured["use_exact_tools"] = params.use_exact_tools
+        captured["query_source"] = params.query_source
+        yield AssistantMessage(content=[TextBlock(text="ok")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _fake_run_agent):
+        result = registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={"description": "test", "prompt": "go"},
+            ),
+            context,
+        )
+
+    assert result.is_error is False
+    # Without the env flag, fork is disabled — defaults to general-purpose.
+    assert captured["agent_type"] == "general-purpose"
+    assert captured["use_exact_tools"] is False
+    assert captured["query_source"] is None
+
+
+def test_fork_routing_enabled_via_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_fork_env(monkeypatch, enabled=True)
+    registry = build_default_registry(provider=object())
+    context = _make_interactive_context(tmp_path)
+
+    captured: dict[str, object] = {}
+
+    async def _fake_run_agent(params):
+        captured["agent_type"] = params.agent_definition.agent_type
+        captured["use_exact_tools"] = params.use_exact_tools
+        captured["query_source"] = params.query_source
+        captured["context_messages"] = list(params.context_messages or [])
+        yield AssistantMessage(content=[TextBlock(text="forked done")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _fake_run_agent):
+        result = registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={"description": "fork test", "prompt": "build feature foo"},
+            ),
+            context,
+        )
+
+    assert result.is_error is False
+    # With the env flag and no subagent_type, the fork path is selected.
+    assert captured["agent_type"] == FORK_AGENT.agent_type
+    assert captured["use_exact_tools"] is True
+    assert captured["query_source"] == "agent:builtin:fork"
+
+    # The forked-message pair should have been appended to the context.
+    msgs = captured["context_messages"]
+    assert isinstance(msgs, list)
+    assert len(msgs) >= 1
+    # Last message must contain the boilerplate-wrapped directive.
+    last = msgs[-1]
+    assert isinstance(last, UserMessage)
+    text_blocks = [b for b in last.content if isinstance(b, TextBlock)]
+    assert any("<fork-boilerplate>" in b.text for b in text_blocks)
+    assert any("Your directive: build feature foo" in b.text for b in text_blocks)
+
+
+def test_fork_recursive_guard_via_query_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_fork_env(monkeypatch, enabled=True)
+    registry = build_default_registry(provider=object())
+    context = _make_interactive_context(tmp_path)
+    # Simulate that this context is already a fork child.
+    context.options.query_source = "agent:builtin:fork"
+
+    with pytest.raises(ToolInputError) as excinfo:
+        registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={"description": "x", "prompt": "spawn another"},
+            ),
+            context,
+        )
+    assert "fork" in str(excinfo.value).lower()
+
+
+def test_fork_recursive_guard_via_message_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_fork_env(monkeypatch, enabled=True)
+    registry = build_default_registry(provider=object())
+    context = _make_interactive_context(tmp_path)
+    # Simulate the parent conversation already containing a fork tag.
+    context.messages = [
+        create_user_message(content=[TextBlock(text="<fork-boilerplate>...</fork-boilerplate>")]),
+    ]
+
+    with pytest.raises(ToolInputError) as excinfo:
+        registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={"description": "x", "prompt": "spawn another"},
+            ),
+            context,
+        )
+    assert "fork" in str(excinfo.value).lower()
+
+
+def test_fork_routing_includes_parent_assistant_clone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_fork_env(monkeypatch, enabled=True)
+    registry = build_default_registry(provider=object())
+    context = _make_interactive_context(tmp_path)
+
+    parent_assistant = AssistantMessage(
+        content=[
+            ToolUseBlock(id="tu_1", name="Read", input={"path": "/a"}),
+            ToolUseBlock(id="tu_2", name="Read", input={"path": "/b"}),
+        ]
+    )
+    context.messages = [
+        create_user_message(content=[TextBlock(text="planning step")]),
+        parent_assistant,
+    ]
+
+    captured: dict[str, object] = {}
+
+    async def _fake_run_agent(params):
+        captured["context_messages"] = list(params.context_messages or [])
+        yield AssistantMessage(content=[TextBlock(text="done")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _fake_run_agent):
+        registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={"description": "test", "prompt": "rewrite a"},
+            ),
+            context,
+        )
+
+    msgs = captured["context_messages"]
+    assert isinstance(msgs, list)
+    # context_messages should be: [original parent messages..., cloned_assistant, user_with_directive]
+    assert len(msgs) >= 4
+    cloned_assistant_candidate = msgs[-2]
+    assert isinstance(cloned_assistant_candidate, AssistantMessage)
+    # Cloned assistant must preserve all tool_use block IDs.
+    block_ids = [
+        b.id for b in cloned_assistant_candidate.content if isinstance(b, ToolUseBlock)
+    ]
+    assert block_ids == ["tu_1", "tu_2"]
+    # The cloned assistant should not be the same Python object as the parent's.
+    assert cloned_assistant_candidate is not parent_assistant
+
+    user_msg = msgs[-1]
+    assert isinstance(user_msg, UserMessage)
+    result_block_ids = {
+        b.tool_use_id for b in user_msg.content if isinstance(b, ToolResultBlock)
+    }
+    assert result_block_ids == {"tu_1", "tu_2"}
+
+
+def test_fork_disabled_in_non_interactive_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_fork_env(monkeypatch, enabled=True)
+    registry = build_default_registry(provider=object())
+    context = _make_interactive_context(tmp_path)
+    context.options.is_non_interactive_session = True
+
+    captured: dict[str, object] = {}
+
+    async def _fake_run_agent(params):
+        captured["agent_type"] = params.agent_definition.agent_type
+        captured["use_exact_tools"] = params.use_exact_tools
+        yield AssistantMessage(content=[TextBlock(text="ok")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _fake_run_agent):
+        registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={"description": "test", "prompt": "go"},
+            ),
+            context,
+        )
+
+    # Even with the env flag, non-interactive sessions skip the fork path.
+    assert captured["agent_type"] == "general-purpose"
+    assert captured["use_exact_tools"] is False

--- a/tests/test_fork_subagent.py
+++ b/tests/test_fork_subagent.py
@@ -1,0 +1,258 @@
+"""Tests for the fork-subagent helper module.
+
+Mirrors typescript/src/tools/AgentTool/forkSubagent.ts behavior.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.agent.constants import (
+    FORK_BOILERPLATE_TAG,
+    FORK_DIRECTIVE_PREFIX,
+    FORK_SUBAGENT_TYPE,
+)
+from src.agent.fork_subagent import (
+    FORK_AGENT,
+    FORK_PLACEHOLDER_RESULT,
+    build_child_message,
+    build_forked_messages,
+    build_worktree_notice,
+    is_fork_subagent_enabled,
+    is_in_fork_child,
+)
+from src.tool_system.context import ToolContext, ToolUseOptions
+from src.types.content_blocks import (
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+)
+from src.types.messages import (
+    AssistantMessage,
+    UserMessage,
+    create_user_message,
+)
+
+
+class TestForkConstants(unittest.TestCase):
+    """Constants match the TypeScript reference."""
+
+    def test_fork_subagent_type(self) -> None:
+        self.assertEqual(FORK_SUBAGENT_TYPE, "fork")
+
+    def test_fork_boilerplate_tag(self) -> None:
+        self.assertEqual(FORK_BOILERPLATE_TAG, "fork-boilerplate")
+
+    def test_fork_directive_prefix_matches_ts(self) -> None:
+        # TS: typescript/src/constants/xml.ts:66
+        self.assertEqual(FORK_DIRECTIVE_PREFIX, "Your directive: ")
+
+    def test_fork_placeholder_result(self) -> None:
+        # TS: forkSubagent.ts:93
+        self.assertEqual(
+            FORK_PLACEHOLDER_RESULT, "Fork started — processing in background"
+        )
+
+    def test_fork_agent_type(self) -> None:
+        self.assertEqual(FORK_AGENT.agent_type, "fork")
+
+    def test_fork_agent_uses_inherit_model(self) -> None:
+        self.assertEqual(FORK_AGENT.model, "inherit")
+
+
+class TestBuildChildMessage(unittest.TestCase):
+    """Boilerplate-wrapped directive matches TS structure."""
+
+    def test_contains_open_and_close_tags(self) -> None:
+        out = build_child_message("do thing")
+        self.assertIn(f"<{FORK_BOILERPLATE_TAG}>", out)
+        self.assertIn(f"</{FORK_BOILERPLATE_TAG}>", out)
+
+    def test_uses_your_directive_prefix(self) -> None:
+        out = build_child_message("refactor login flow")
+        self.assertIn("Your directive: refactor login flow", out)
+        self.assertNotIn("DIRECTIVE: refactor", out)
+
+    def test_contains_rule_about_default_to_forking(self) -> None:
+        out = build_child_message("x")
+        # The boilerplate calls out the parent's "default to forking"
+        # instruction so the child knows to ignore it. Match the substring
+        # rather than the surrounding quote/period punctuation, which is
+        # part of an English sentence and may be reformatted in the future.
+        self.assertIn("default to forking", out)
+
+    def test_contains_scope_format_marker(self) -> None:
+        out = build_child_message("x")
+        # The TS template requires the response to begin with "Scope:".
+        self.assertIn("Scope:", out)
+        self.assertIn("Result:", out)
+        self.assertIn("Key files:", out)
+        self.assertIn("Files changed:", out)
+        self.assertIn("Issues:", out)
+
+
+class TestBuildForkedMessages(unittest.TestCase):
+    """Forked message pair construction matches TS algorithm."""
+
+    def test_no_parent_returns_single_user_message(self) -> None:
+        out = build_forked_messages("do thing", None)
+        self.assertEqual(len(out), 1)
+        self.assertIsInstance(out[0], UserMessage)
+
+    def test_parent_with_no_tool_use_returns_single_user_message(self) -> None:
+        parent = AssistantMessage(content=[TextBlock(text="hello")])
+        out = build_forked_messages("do thing", parent)
+        self.assertEqual(len(out), 1)
+        self.assertIsInstance(out[0], UserMessage)
+
+    def test_parent_with_tool_use_clones_assistant_and_emits_placeholders(self) -> None:
+        parent = AssistantMessage(
+            content=[
+                TextBlock(text="planning"),
+                ToolUseBlock(id="tu_1", name="Read", input={"path": "/a"}),
+                ToolUseBlock(id="tu_2", name="Write", input={"path": "/b", "content": "x"}),
+            ]
+        )
+        out = build_forked_messages("update foo", parent)
+        self.assertEqual(len(out), 2)
+
+        # The first message is a cloned assistant — distinct uuid, same blocks.
+        cloned = out[0]
+        self.assertIsInstance(cloned, AssistantMessage)
+        self.assertNotEqual(cloned.uuid, parent.uuid)
+        # All original blocks must survive.
+        self.assertEqual(len(cloned.content), 3)
+        self.assertEqual(cloned.content[1].id, "tu_1")
+        self.assertEqual(cloned.content[2].id, "tu_2")
+
+        # Second message: tool_results for every tool_use + the directive text.
+        user_msg = out[1]
+        self.assertIsInstance(user_msg, UserMessage)
+        blocks = list(user_msg.content)
+        # 2 placeholders + 1 directive text
+        self.assertEqual(len(blocks), 3)
+
+        result_blocks = [b for b in blocks if isinstance(b, ToolResultBlock)]
+        self.assertEqual({b.tool_use_id for b in result_blocks}, {"tu_1", "tu_2"})
+        for b in result_blocks:
+            self.assertEqual(b.content, FORK_PLACEHOLDER_RESULT)
+
+        text_blocks = [b for b in blocks if isinstance(b, TextBlock)]
+        self.assertEqual(len(text_blocks), 1)
+        self.assertIn(f"<{FORK_BOILERPLATE_TAG}>", text_blocks[0].text)
+        self.assertIn("Your directive: update foo", text_blocks[0].text)
+
+    def test_clone_does_not_mutate_parent(self) -> None:
+        original_blocks = [
+            TextBlock(text="planning"),
+            ToolUseBlock(id="tu_1", name="Read", input={"path": "/a"}),
+        ]
+        parent = AssistantMessage(content=original_blocks)
+        original_count = len(parent.content)
+        original_uuid = parent.uuid
+        _ = build_forked_messages("x", parent)
+        self.assertEqual(len(parent.content), original_count)
+        self.assertEqual(parent.uuid, original_uuid)
+
+
+class TestIsInForkChild(unittest.TestCase):
+    """Recursion-guard fallback scans message history for the boilerplate tag."""
+
+    def test_empty_messages_returns_false(self) -> None:
+        self.assertFalse(is_in_fork_child([]))
+        self.assertFalse(is_in_fork_child(None))
+
+    def test_user_message_with_tag_returns_true(self) -> None:
+        msg = create_user_message(
+            content=[TextBlock(text=f"<{FORK_BOILERPLATE_TAG}> rules ...")]
+        )
+        self.assertTrue(is_in_fork_child([msg]))
+
+    def test_assistant_message_with_tag_returns_false(self) -> None:
+        # Only user messages are scanned, mirroring TS guard.
+        msg = AssistantMessage(
+            content=[TextBlock(text=f"<{FORK_BOILERPLATE_TAG}>")]
+        )
+        self.assertFalse(is_in_fork_child([msg]))
+
+    def test_user_message_text_block_without_tag(self) -> None:
+        msg = create_user_message(content=[TextBlock(text="just a directive")])
+        self.assertFalse(is_in_fork_child([msg]))
+
+    def test_dict_shaped_messages_supported(self) -> None:
+        msg = {
+            "role": "user",
+            "type": "user",
+            "content": [{"type": "text", "text": f"...<{FORK_BOILERPLATE_TAG}>..."}],
+        }
+        self.assertTrue(is_in_fork_child([msg]))
+
+
+class TestIsForkSubagentEnabled(unittest.TestCase):
+    """Feature gate honors env flag and interactivity."""
+
+    def setUp(self) -> None:
+        self._original_env = os.environ.get("CLAUDE_FORK_SUBAGENT")
+        os.environ.pop("CLAUDE_FORK_SUBAGENT", None)
+
+    def tearDown(self) -> None:
+        if self._original_env is None:
+            os.environ.pop("CLAUDE_FORK_SUBAGENT", None)
+        else:
+            os.environ["CLAUDE_FORK_SUBAGENT"] = self._original_env
+
+    def _make_context(self, *, non_interactive: bool) -> ToolContext:
+        ctx = ToolContext(workspace_root=Path("/tmp"))
+        ctx.options = ToolUseOptions(is_non_interactive_session=non_interactive)
+        return ctx
+
+    def test_disabled_when_env_unset(self) -> None:
+        ctx = self._make_context(non_interactive=False)
+        self.assertFalse(is_fork_subagent_enabled(ctx))
+
+    def test_disabled_when_env_falsey(self) -> None:
+        os.environ["CLAUDE_FORK_SUBAGENT"] = "0"
+        ctx = self._make_context(non_interactive=False)
+        self.assertFalse(is_fork_subagent_enabled(ctx))
+
+    def test_enabled_when_env_truthy_and_interactive(self) -> None:
+        os.environ["CLAUDE_FORK_SUBAGENT"] = "1"
+        ctx = self._make_context(non_interactive=False)
+        self.assertTrue(is_fork_subagent_enabled(ctx))
+
+    def test_disabled_in_non_interactive_session(self) -> None:
+        os.environ["CLAUDE_FORK_SUBAGENT"] = "1"
+        ctx = self._make_context(non_interactive=True)
+        self.assertFalse(is_fork_subagent_enabled(ctx))
+
+    def test_uses_global_state_when_no_context(self) -> None:
+        os.environ["CLAUDE_FORK_SUBAGENT"] = "1"
+        with patch(
+            "src.agent.fork_subagent.get_is_non_interactive_session",
+            return_value=False,
+        ):
+            self.assertTrue(is_fork_subagent_enabled())
+        with patch(
+            "src.agent.fork_subagent.get_is_non_interactive_session",
+            return_value=True,
+        ):
+            self.assertFalse(is_fork_subagent_enabled())
+
+
+class TestBuildWorktreeNotice(unittest.TestCase):
+    """Worktree notice mentions both paths and isolation."""
+
+    def test_mentions_both_paths(self) -> None:
+        out = build_worktree_notice("/repo", "/tmp/wt-1234")
+        self.assertIn("/repo", out)
+        self.assertIn("/tmp/wt-1234", out)
+
+    def test_mentions_isolation(self) -> None:
+        out = build_worktree_notice("/repo", "/tmp/wt-1234")
+        self.assertIn("isolated", out.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Ports the fork-subagent mechanism from `typescript/src/tools/AgentTool/forkSubagent.ts` so the implicit-fork path (omit `subagent_type` to clone parent context) is finally reachable in Python.
- Wires `useExactTools` parity into `run_agent()` and the Agent tool so a fork child reuses the parent's tool array verbatim and threads `querySource` for the recursive-fork guard.
- Closes 11 gaps catalogued in `my-docs/ch09-fork-agents-gap-analysis.md` (G1-G11), per the slice plan in `my-docs/ch09-fork-agents-refactor-plan.md`.

## What changed

**New module** — `src/agent/fork_subagent.py`:
- `is_fork_subagent_enabled(context)` — env-flag gate (`CLAUDE_FORK_SUBAGENT`) + interactivity check. Coordinator-mode check is a no-op until coordinator mode is ported.
- `is_in_fork_child(messages)` — fallback recursion guard scanning user messages for the `<fork-boilerplate>` tag.
- `build_child_message(directive)` — renders the 10-rule boilerplate envelope used to instruct the fork child (override "default to forking", silent execution, `Scope:/Result:/Key files:/Files changed:/Issues:` output template).
- `build_forked_messages(directive, parent_assistant)` — clones the parent assistant message (preserving every `tool_use` block + ID) and emits a single user message containing one `tool_result(FORK_PLACEHOLDER_RESULT)` per parent `tool_use` plus the boilerplate-wrapped directive. This is the byte-identical-prefix construction described in chapter 9.
- `build_worktree_notice(parent_cwd, worktree_cwd)` — translation hint for fork+worktree workflows.

**Agent tool routing** — `src/tool_system/tools/agent.py`:
- When `subagent_type` is omitted and the gate is on in an interactive session, routes to `FORK_AGENT`, raises if a recursive-fork guard trips (`options.query_source == 'agent:builtin:fork'` or boilerplate tag in messages), threads parent messages + cloned-assistant + directive through `context_messages`, sets `use_exact_tools=True`, and threads `query_source="agent:builtin:fork"`.
- Adds `_resolve_parent_system_prompt()` for best-effort parent prompt threading. Full byte-cache parity with the parent's prior API call requires threading `rendered_system_prompt` from the main loop and is left as a follow-up.

**`run_agent` plumbing** — `src/agent/run_agent.py`:
- Adds `use_exact_tools` and `query_source` to `RunAgentParams`.
- When `use_exact_tools=True`, bypasses `resolve_agent_tools()` so `agent_tools = list(available_tools)` — matches `runAgent.ts:513`.
- Threads `params.query_source` onto the child's `ToolUseOptions.query_source` for the primary recursive-fork guard.
- Sanitizes `context_messages` through `filter_incomplete_tool_calls()` before threading them into the subagent context (the API rejects orphaned `tool_use` IDs).
- Skips the empty-prompt user-message append on the fork path (the directive is already inside `context_messages`).

**Constant fix** — `src/agent/constants.py`:
- `FORK_DIRECTIVE_PREFIX` corrected from `"DIRECTIVE: "` to `"Your directive: "` to match `typescript/src/constants/xml.ts:66`.

## Tests

32 new tests, all passing:

- `tests/test_fork_subagent.py` (26): constants parity (directive prefix, placeholder, tag, type), `build_child_message` boilerplate structure, `build_forked_messages` clone semantics + placeholder emission, `is_in_fork_child` tag scan (incl. dict-shaped messages), `is_fork_subagent_enabled` matrix (env on/off × interactive/non-interactive), `build_worktree_notice` content.
- `tests/test_agent_tool_fork.py` (6): routing disabled by default, routing enabled via env, recursion guard via `query_source`, recursion guard via message scan, parent-assistant clone shape (tool_use IDs preserved, placeholder `tool_result` IDs match), non-interactive disable.

Existing agent-related suites still green (`test_agent_loop`, `test_agent_permission_inheritance`, `test_agent_tool_async`, `test_agent_toolkit_filtering`, `tests/parity/test_agent_isolation`). No new regressions in the broader suite — the pre-existing TUI/REPL/hook failures on `main` are unrelated.

## Out of scope (follow-ups)

- **Byte-identical prompt-cache parity with the parent's prior API call** — requires threading `renderedSystemPrompt` from the main loop instead of re-resolving via `_resolve_parent_system_prompt()`.
- **Force-async-on-fork** (`forceAsync = isForkSubagentEnabled()` in TS) — fork spawns currently still honor `run_in_background`.
- **Schema omission of `run_in_background`** when the fork gate is on.
- **Coordinator-mode gating** — depends on coordinator mode landing in Python first.

## Test plan

- [x] `pytest tests/test_fork_subagent.py -v` (26 pass)
- [x] `pytest tests/test_agent_tool_fork.py -v` (6 pass)
- [x] `pytest tests/test_agent_loop.py tests/test_agent_permission_inheritance.py tests/test_agent_tool_async.py tests/test_agent_toolkit_filtering.py tests/parity/test_agent_isolation.py -v` (99 pass)
- [x] Broader regression sweep (`pytest tests/ --ignore=tests/integration --ignore=tests/tui`) — no new failures introduced
- [ ] Manual sanity: `CLAUDE_FORK_SUBAGENT=1` in an interactive session, omit `subagent_type` from an Agent tool call, observe the fork path firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)