### PR TITLE
chore(gitignore): ignore /claude-code-from-source/ reference book

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ out/
 /assets/
 /my-docs/
 /screenshots_work/
+/claude-code-from-source/
 
 # Logs
 npm-debug.log*


### PR DESCRIPTION
## Summary

Add `/claude-code-from-source/` to `.gitignore`. The directory holds the reference book used during the chapter-by-chapter porting work — local-only material that should not show up as untracked or be staged accidentally.

This is the one-line salvage from the closed #17.

## Test plan

- [x] `git status` is clean after the change with the directory present on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)