### PR TITLE
ch10 phase 3+4: three-channel comms + TaskOutput polling

### DIFF
--- a/src/constants/xml.py
+++ b/src/constants/xml.py
@@ -1,0 +1,44 @@
+"""XML tag constants for chapter-10 task notifications.
+
+Mirrors ``typescript/src/constants/xml.ts``. Single source of truth for
+the tag names that appear in ``<task-notification>`` envelopes the model
+sees in its conversation flow. Keep names byte-identical to the TS
+source so prompt-cache stability holds across TS↔Python interop and
+snapshot tests pin the surface.
+"""
+from __future__ import annotations
+
+from typing import Final
+
+TASK_NOTIFICATION_TAG: Final[str] = "task-notification"
+TASK_ID_TAG: Final[str] = "task-id"
+TOOL_USE_ID_TAG: Final[str] = "tool-use-id"
+OUTPUT_FILE_TAG: Final[str] = "output-file"
+STATUS_TAG: Final[str] = "status"
+SUMMARY_TAG: Final[str] = "summary"
+RESULT_TAG: Final[str] = "result"
+USAGE_TAG: Final[str] = "usage"
+TOTAL_TOKENS_TAG: Final[str] = "total_tokens"
+TOOL_USES_TAG: Final[str] = "tool_uses"
+DURATION_MS_TAG: Final[str] = "duration_ms"
+WORKTREE_TAG: Final[str] = "worktree"
+WORKTREE_PATH_TAG: Final[str] = "worktree-path"
+WORKTREE_BRANCH_TAG: Final[str] = "worktree-branch"
+
+
+__all__ = [
+    "TASK_NOTIFICATION_TAG",
+    "TASK_ID_TAG",
+    "TOOL_USE_ID_TAG",
+    "OUTPUT_FILE_TAG",
+    "STATUS_TAG",
+    "SUMMARY_TAG",
+    "RESULT_TAG",
+    "USAGE_TAG",
+    "TOTAL_TOKENS_TAG",
+    "TOOL_USES_TAG",
+    "DURATION_MS_TAG",
+    "WORKTREE_TAG",
+    "WORKTREE_PATH_TAG",
+    "WORKTREE_BRANCH_TAG",
+]

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -104,6 +104,49 @@ def _create_max_turns_attachment(max_turns: int, turn_count: int) -> SystemMessa
     )
 
 
+def _drain_pending_user_messages(tool_use_context: Any) -> list[UserMessage]:
+    """Drain the running agent's ``pending_messages`` inbox, if any.
+
+    Chapter-10 / Chunk D / WI-3.3 hook. The TS implementation drains at
+    the tool-round boundary inside the agent's run loop; the Python
+    equivalent is here, between `tool_results` and the next API call,
+    where the chapter's "messages arrive between tool rounds, not
+    mid-execution" contract holds.
+
+    No-op when:
+    * The context has no ``agent_id`` (top-level / non-runtime-task agents).
+    * The context has no ``runtime_tasks`` registry (test fixtures
+      that didn't construct a real ToolContext).
+    * The agent's entry isn't a ``LocalAgentTaskState`` (defensive —
+      a future task type that runs through the same query loop).
+    * The inbox is empty.
+
+    Returns the drained messages as a list of fresh ``UserMessage``
+    objects, which the caller appends to the next turn's prompt.
+    """
+    agent_id = getattr(tool_use_context, "agent_id", None)
+    runtime = getattr(tool_use_context, "runtime_tasks", None)
+    if not agent_id or runtime is None:
+        return []
+    # Local import to avoid pulling the tasks package into the query
+    # module's import graph at startup; this hook only fires when an
+    # agent_id is set, so the tasks module will already be loaded.
+    try:
+        from src.tasks.local_agent import (
+            LocalAgentTaskState,
+            drain_pending_messages,
+        )
+    except ImportError:
+        return []
+    state = runtime.get(agent_id)
+    if not isinstance(state, LocalAgentTaskState):
+        return []
+    drained = drain_pending_messages(agent_id, runtime)
+    if not drained:
+        return []
+    return [UserMessage(content=text) for text in drained]
+
+
 def _yield_missing_tool_result_blocks(
     assistant_messages: list[AssistantMessage],
     error_message: str,
@@ -633,8 +676,19 @@ async def query(params: QueryParams) -> AsyncGenerator[Message | StreamEvent, No
             yield _create_max_turns_attachment(params.max_turns, next_turn_count)
             return
 
+        # Chapter-10 / Chunk D / WI-3.3 — pending-messages drain at the
+        # tool-round boundary. Per chapter §"Background: Three Channels":
+        # *"messages arrive between tool rounds, not mid-execution. The
+        # agent finishes its current thought, then receives the new
+        # information."* We drain AFTER tool_results have been appended
+        # but BEFORE the next API call, so the model sees the queued
+        # messages on the next turn alongside the tool results.
+        injected_messages = _drain_pending_user_messages(tool_use_context)
+        for inj in injected_messages:
+            yield inj
+
         state = QueryState(
-            messages=[*messages, *assistant_messages, *tool_results],
+            messages=[*messages, *assistant_messages, *tool_results, *injected_messages],
             tool_use_context=tool_use_context,
             auto_compact_tracking=state.auto_compact_tracking,
             turn_count=next_turn_count,

--- a/src/tasks/eviction.py
+++ b/src/tasks/eviction.py
@@ -1,0 +1,222 @@
+"""Eviction sweeper for terminal-state runtime tasks — Chunk D / WI-3.4.
+
+Mirrors ``PANEL_GRACE_MS`` + the eviction-after-deadline behavior
+described in chapter §"TaskStop" final paragraph + plan WI-3.4.
+
+Per assumption A8 (TS source-confirmed at
+``typescript/src/utils/task/framework.ts:28``): the grace period is
+30 seconds. The sweeper runs every 5 seconds, so the worst-case
+eviction lag is ≤35 seconds.
+
+Constraints:
+1. **Notify before evict.** A terminal task without ``notified=True``
+   must NOT be evicted — the parent agent hasn't been told the task
+   finished yet, and dropping the entry would lose the
+   ``<task-notification>`` envelope. The sweeper skips entries with
+   ``notified=False``.
+2. **Daemon thread, cancel-on-shutdown.** The sweeper runs on a daemon
+   thread so it never blocks process exit. ``stop_eviction_sweeper``
+   is exposed for clean shutdown in tests and explicit teardown paths.
+3. **Idempotent start.** ``start_eviction_sweeper`` is safe to call
+   multiple times; only the first call spawns the thread.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any
+
+from src.tasks_core import TaskStateBase, is_terminal_task_status
+
+if TYPE_CHECKING:
+    from src.task_registry import RuntimeTaskRegistry
+
+logger = logging.getLogger(__name__)
+
+
+# Per assumption A8 / TS framework.ts:28. Do not adjust without
+# revisiting the chapter §"TaskStop" rationale.
+PANEL_GRACE_SECONDS: float = 30.0
+
+# Sweeper tick — 5s tick over 30s grace bounds eviction lag at ≤35s
+# (worst case: terminal transition lands one tick after a sweep, sits
+# the full grace, waits up to one more tick for the next sweep).
+_SWEEPER_TICK_SECONDS: float = 5.0
+
+
+def schedule_eviction(
+    state: TaskStateBase,
+    *,
+    grace_seconds: float = PANEL_GRACE_SECONDS,
+    now: float | None = None,
+) -> TaskStateBase:
+    """Return a copy of ``state`` with ``evict_after`` set to ``now + grace``.
+
+    Pure helper — does not touch the registry. Used inside lifecycle
+    mutators (``complete_agent_task`` etc.) to schedule the eviction
+    deadline atomically with the terminal-state transition.
+
+    Behavior matches TS LocalAgentTask.tsx:294
+    (``evictAfter: task.retain ? undefined : Date.now() + PANEL_GRACE_MS``):
+
+    * **Terminal + not retained** → set ``evict_after = now + grace``.
+    * **Terminal + retained** → CLEAR ``evict_after = None`` (retain
+      pins the entry; existing deadline must be removed so a future
+      ``retain`` flip doesn't leave a stale deadline pointing at a
+      moment in the past).
+    * **Non-terminal** → leave the state unchanged. ``evict_after`` only
+      makes sense for terminal entries.
+    * **State without ``evict_after`` field** → identity (defensive).
+    """
+    if not hasattr(state, "evict_after"):
+        return state
+    if not is_terminal_task_status(state.status):
+        return state
+    if getattr(state, "retain", False):
+        # Retain pins the entry; clear any stale deadline.
+        if state.evict_after is None:  # type: ignore[attr-defined]
+            return state  # already clear
+        return replace(state, evict_after=None)  # type: ignore[type-var]
+    deadline = (now if now is not None else time.time()) + grace_seconds
+    return replace(state, evict_after=deadline)  # type: ignore[type-var]
+
+
+def is_eligible_for_eviction(state: TaskStateBase, *, now: float | None = None) -> bool:
+    """Predicate for the sweeper.
+
+    Eligible iff:
+    * status is terminal, AND
+    * notified=True (don't drop entries before the parent has been told), AND
+    * evict_after is set and in the past, AND
+    * retain=False (UI hasn't pinned the entry).
+    """
+    if not is_terminal_task_status(state.status):
+        return False
+    if not state.notified:
+        # Notify-before-evict guard. The parent agent's run loop will
+        # surface the notification; only after that does eviction make
+        # sense.
+        return False
+    deadline = getattr(state, "evict_after", None)
+    if deadline is None:
+        return False
+    if getattr(state, "retain", False):
+        return False
+    moment = now if now is not None else time.time()
+    return moment >= deadline
+
+
+def sweep_once(
+    registry: "RuntimeTaskRegistry",
+    *,
+    now: float | None = None,
+) -> list[str]:
+    """Walk every entry, evict the eligible ones, return the dropped IDs.
+
+    Snapshot-then-remove pattern (the registry's ``all()`` returns a
+    snapshot list; the ``remove`` calls land outside the snapshot
+    iteration). No mutator runs under the lock during eviction —
+    ``remove`` is a single dict-pop guarded by the registry's RLock.
+    """
+    moment = now if now is not None else time.time()
+    dropped: list[str] = []
+    for state in registry.all():
+        if is_eligible_for_eviction(state, now=moment):
+            if registry.remove(state.id):
+                dropped.append(state.id)
+                logger.debug(
+                    "evicted terminal task %s (status=%s, notified=True)",
+                    state.id, state.status,
+                )
+    return dropped
+
+
+# ---------------------------------------------------------------------------
+# Background sweeper thread — daemon, cancel-on-shutdown
+# ---------------------------------------------------------------------------
+
+
+_sweeper_lock = threading.Lock()
+_sweeper_thread: threading.Thread | None = None
+_sweeper_stop = threading.Event()
+_sweeper_registry: "RuntimeTaskRegistry | None" = None
+
+
+def start_eviction_sweeper(
+    registry: "RuntimeTaskRegistry",
+    *,
+    tick_seconds: float = _SWEEPER_TICK_SECONDS,
+) -> None:
+    """Start the background eviction sweeper for ``registry``.
+
+    Idempotent — re-calling with the same registry is a no-op; the
+    existing thread keeps running. Calling with a *different* registry
+    is treated as a re-bind (stop the old thread, start a new one);
+    test fixtures construct fresh registries per test.
+    """
+    global _sweeper_thread, _sweeper_registry
+    with _sweeper_lock:
+        if _sweeper_thread is not None and _sweeper_thread.is_alive():
+            if _sweeper_registry is registry:
+                return
+            # Different registry — tear down and re-arm.
+            _sweeper_stop.set()
+            _sweeper_thread.join(timeout=2.0)
+            _sweeper_thread = None
+        _sweeper_stop = threading.Event()  # noqa: F841 (rebound below)
+        # Replace the module-level event with a fresh one for the new run.
+        globals()["_sweeper_stop"] = _sweeper_stop
+        _sweeper_registry = registry
+        thread = threading.Thread(
+            target=_sweeper_loop,
+            args=(registry, tick_seconds, _sweeper_stop),
+            name="runtime-task-eviction-sweeper",
+            daemon=True,
+        )
+        _sweeper_thread = thread
+        thread.start()
+
+
+def stop_eviction_sweeper(*, timeout: float = 2.0) -> None:
+    """Signal the sweeper to exit and wait for it. Safe to call when no
+    sweeper is running."""
+    global _sweeper_thread, _sweeper_registry
+    with _sweeper_lock:
+        if _sweeper_thread is None:
+            return
+        thread = _sweeper_thread
+        _sweeper_stop.set()
+        _sweeper_thread = None
+        _sweeper_registry = None
+    thread.join(timeout=timeout)
+
+
+def _sweeper_loop(
+    registry: "RuntimeTaskRegistry",
+    tick_seconds: float,
+    stop_event: threading.Event,
+) -> None:
+    """Background thread body — sleep tick, sweep, repeat until stopped."""
+    while not stop_event.is_set():
+        # Use the stop event as the sleep so we cancel promptly on
+        # shutdown rather than waiting out a full tick.
+        if stop_event.wait(timeout=tick_seconds):
+            return
+        try:
+            sweep_once(registry)
+        except Exception:
+            # The sweeper must never die from a transient error;
+            # logging + continuing is the right policy.
+            logger.exception("eviction sweeper iteration failed")
+
+
+__all__ = [
+    "PANEL_GRACE_SECONDS",
+    "schedule_eviction",
+    "is_eligible_for_eviction",
+    "sweep_once",
+    "start_eviction_sweeper",
+    "stop_eviction_sweeper",
+]

--- a/src/tool_system/registry.py
+++ b/src/tool_system/registry.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import asyncio
+import inspect
+import threading
 from typing import Any, Iterable
 
 from .build_tool import Tool, Tools, tool_matches_name
@@ -114,7 +117,7 @@ class ToolRegistry:
                     tool_use_id=call.tool_use_id,
                 )
 
-        result = tool.call(call.input, context)
+        result = _invoke_tool_call(tool, call.input, context)
         if result.tool_use_id is None and call.tool_use_id is not None:
             return ToolResult(
                 name=result.name,
@@ -126,6 +129,63 @@ class ToolRegistry:
                 context_modifier=result.context_modifier,
             )
         return result
+
+
+def _invoke_tool_call(tool: Any, input: dict, context: ToolContext) -> ToolResult:
+    """Dispatch a tool's ``call`` — sync or async — and return its
+    ``ToolResult``.
+
+    Chapter-10 / Chunk D / WI-4.0: the ``Tool.call`` signature was
+    historically sync-only, but TaskOutputTool's polling loop (WI-4.1)
+    needs async; broadening the dispatcher here unblocks that without
+    rippling through every existing tool. Sync tools are dispatched
+    unchanged; async tools (``inspect.iscoroutinefunction(tool.call)``
+    is True) are awaited via ``asyncio.run`` if no loop is active or
+    via a thread-bridge if we're already inside one (the same pattern
+    Chunk B introduced for TaskStop's async-kill bridge).
+    """
+    fn = tool.call
+    if not inspect.iscoroutinefunction(fn):
+        return fn(input, context)
+
+    # Async tool — drive the coroutine to completion.
+    try:
+        running = asyncio.get_running_loop()
+    except RuntimeError:
+        running = None
+
+    if running is None:
+        return asyncio.run(fn(input, context))
+
+    # Already inside a loop — schedule on a worker thread to avoid
+    # nesting (Python disallows ``run_until_complete`` on a running
+    # loop). Same pattern as ``task_stop.py``'s async-kill bridge.
+    holder: dict[str, Any] = {}
+    done = threading.Event()
+
+    def _runner() -> None:
+        try:
+            holder["result"] = asyncio.run(fn(input, context))
+        except BaseException as exc:  # noqa: BLE001 — re-raise
+            holder["error"] = exc
+        finally:
+            done.set()
+
+    threading.Thread(
+        target=_runner,
+        daemon=True,
+        name=f"tool-async-bridge:{getattr(tool, 'name', '?')}",
+    ).start()
+    # No timeout on this wait — async tools are expected to self-bound
+    # (TaskOutput uses its own ``timeout`` knob; TaskStop uses
+    # ``asyncio.wait_for(timeout=5.0)`` inside its body). A hung
+    # ``done.wait()`` here is a tool bug, not something the dispatcher
+    # tries to paper over with a global cap. If a future tool grows a
+    # naturally-unbounded await, give it an internal deadline first.
+    done.wait()
+    if "error" in holder:
+        raise holder["error"]  # type: ignore[misc]
+    return holder["result"]  # type: ignore[no-any-return]
 
 
 def get_all_base_tools(registry: ToolRegistry) -> Tools:

--- a/src/utils/message_queue_manager.py
+++ b/src/utils/message_queue_manager.py
@@ -1,0 +1,114 @@
+"""Pending-notification queue for parent-agent injection — Chunk D / WI-3.1.
+
+Mirrors the ``messageQueueManager`` surface in
+``typescript/src/utils/messageQueueManager.ts``. Notifications enqueued
+here are drained at the next tool-round boundary (or by an explicit
+caller) and surfaced as user-role messages in the parent agent's
+conversation. The chapter calls these out as the "task notifications"
+channel — the parent sees them in its normal message flow without a
+special tool to poll.
+
+The queue is process-global (one per Python process) for parity with
+the TS module-singleton shape. A single ``threading.RLock`` guards the
+deque; reads and writes are short.
+"""
+from __future__ import annotations
+
+import threading
+from collections import deque
+from dataclasses import dataclass
+from typing import Iterator, Literal
+
+# Notification "mode" — the TS messageQueueManager carries a discriminator
+# so different injection sites (task-notification vs other system
+# messages) can be filtered. We adopt the same shape so future modes
+# (e.g. permission-request escalations in Phase 9) can join the queue
+# without reworking the contract.
+NotificationMode = Literal["task-notification"]
+
+
+@dataclass(frozen=True)
+class PendingNotification:
+    """One queued notification awaiting injection into the parent's
+    conversation. ``value`` is the literal user-role message text
+    (chapter-shaped XML for the ``"task-notification"`` mode)."""
+
+    value: str
+    mode: NotificationMode = "task-notification"
+
+
+_lock = threading.RLock()
+_queue: deque[PendingNotification] = deque()
+
+
+def enqueue_pending_notification(*, value: str, mode: NotificationMode = "task-notification") -> None:
+    """Push a notification onto the global queue.
+
+    Mirrors TS ``enqueuePendingNotification``. Idempotency is the
+    caller's responsibility — chapter-10 / WI-3.2's ``notified``
+    check-and-set is what guards against duplicate XML; this queue
+    is a dumb FIFO.
+    """
+    with _lock:
+        _queue.append(PendingNotification(value=value, mode=mode))
+
+
+def drain_pending_notifications(
+    *, mode: NotificationMode | None = None
+) -> list[PendingNotification]:
+    """Atomically pop every queued notification (or every notification
+    of one ``mode``) and return them in FIFO order.
+
+    Pass ``mode=None`` to drain everything, or a specific mode to drain
+    only that subset (the others stay queued). The return value is a
+    plain list — callers iterating outside the lock cannot see
+    in-flight enqueues.
+    """
+    with _lock:
+        if mode is None:
+            drained = list(_queue)
+            _queue.clear()
+            return drained
+        kept: deque[PendingNotification] = deque()
+        drained_subset: list[PendingNotification] = []
+        for entry in _queue:
+            if entry.mode == mode:
+                drained_subset.append(entry)
+            else:
+                kept.append(entry)
+        _queue.clear()
+        _queue.extend(kept)
+        return drained_subset
+
+
+def peek_pending_notifications() -> list[PendingNotification]:
+    """Snapshot of the queue without modifying it. Test/diagnostic use."""
+    with _lock:
+        return list(_queue)
+
+
+def clear_pending_notifications() -> None:
+    """Test helper — empty the queue. Production code should not need
+    this; the drain path is the contract."""
+    with _lock:
+        _queue.clear()
+
+
+def _queue_size() -> int:
+    """Test helper — current queue depth."""
+    with _lock:
+        return len(_queue)
+
+
+def __iter__() -> Iterator[PendingNotification]:  # pragma: no cover (module-level)
+    return iter(peek_pending_notifications())
+
+
+__all__ = [
+    "PendingNotification",
+    "NotificationMode",
+    "enqueue_pending_notification",
+    "drain_pending_notifications",
+    "peek_pending_notifications",
+    "clear_pending_notifications",
+]

--- a/src/utils/task_notification.py
+++ b/src/utils/task_notification.py
@@ -1,0 +1,171 @@
+"""``<task-notification>`` XML emitter — Chunk D / WI-3.1.
+
+Mirrors the ``enqueueAgentNotification`` body in
+``typescript/src/tasks/LocalAgentTask/LocalAgentTask.tsx:197-262``. Builds
+the chapter-shaped envelope and pushes it onto the global pending-
+notification queue (Chunk D / WI-3.3 will drain that queue at tool-round
+boundaries inside the parent agent's run loop).
+
+WI-3.2 (the ``notified`` flag check-and-set) is folded into this module's
+``enqueue_agent_notification`` body: the registry update is atomic, and
+the function refuses to enqueue when the task is already ``notified=True``.
+This is the primary guard against duplicate XML deliveries — a task that
+flips terminal between two notification sweeps still produces exactly
+one envelope.
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any, Literal, TYPE_CHECKING
+
+from src.constants.xml import (
+    DURATION_MS_TAG,
+    OUTPUT_FILE_TAG,
+    RESULT_TAG,
+    STATUS_TAG,
+    SUMMARY_TAG,
+    TASK_ID_TAG,
+    TASK_NOTIFICATION_TAG,
+    TOOL_USE_ID_TAG,
+    TOOL_USES_TAG,
+    TOTAL_TOKENS_TAG,
+    USAGE_TAG,
+)
+from src.utils.message_queue_manager import enqueue_pending_notification
+
+if TYPE_CHECKING:
+    from src.task_registry import RuntimeTaskRegistry
+
+
+NotificationStatus = Literal["completed", "failed", "killed"]
+
+
+def _build_summary(description: str, status: NotificationStatus, error: str | None) -> str:
+    """Mirror TS LocalAgentTask.tsx:246 summary phrasing exactly."""
+    if status == "completed":
+        return f'Agent "{description}" completed'
+    if status == "failed":
+        err = error or "Unknown error"
+        return f'Agent "{description}" failed: {err}'
+    return f'Agent "{description}" was stopped'
+
+
+def build_task_notification_xml(
+    *,
+    task_id: str,
+    description: str,
+    status: NotificationStatus,
+    output_file: str,
+    error: str | None = None,
+    final_message: str | None = None,
+    usage: dict[str, int] | None = None,
+    tool_use_id: str | None = None,
+) -> str:
+    """Produce the ``<task-notification>`` envelope for a terminal task.
+
+    Pure function — no registry mutation, no queue push. ``enqueue_agent_notification``
+    composes this with the WI-3.2 check-and-set; tests use it directly
+    for snapshot comparisons.
+
+    Format matches TS LocalAgentTask.tsx:252-257 byte-for-byte (modulo
+    optional sections that disappear when their inputs are absent). All
+    values are rendered as-is (no XML escaping) — the chapter shape
+    treats these as model-facing user content, and TS does the same
+    raw concatenation. Callers are responsible for not embedding
+    closing tags inside summary/result text.
+    """
+    summary = _build_summary(description, status, error)
+    tool_use_line = (
+        f"\n<{TOOL_USE_ID_TAG}>{tool_use_id}</{TOOL_USE_ID_TAG}>"
+        if tool_use_id
+        else ""
+    )
+    result_section = (
+        f"\n<{RESULT_TAG}>{final_message}</{RESULT_TAG}>"
+        if final_message
+        else ""
+    )
+    if usage is not None:
+        usage_section = (
+            f"\n<{USAGE_TAG}>"
+            f"<{TOTAL_TOKENS_TAG}>{usage.get('total_tokens', 0)}</{TOTAL_TOKENS_TAG}>"
+            f"<{TOOL_USES_TAG}>{usage.get('tool_uses', 0)}</{TOOL_USES_TAG}>"
+            f"<{DURATION_MS_TAG}>{usage.get('duration_ms', 0)}</{DURATION_MS_TAG}>"
+            f"</{USAGE_TAG}>"
+        )
+    else:
+        usage_section = ""
+    return (
+        f"<{TASK_NOTIFICATION_TAG}>\n"
+        f"<{TASK_ID_TAG}>{task_id}</{TASK_ID_TAG}>{tool_use_line}\n"
+        f"<{OUTPUT_FILE_TAG}>{output_file}</{OUTPUT_FILE_TAG}>\n"
+        f"<{STATUS_TAG}>{status}</{STATUS_TAG}>\n"
+        f"<{SUMMARY_TAG}>{summary}</{SUMMARY_TAG}>{result_section}{usage_section}\n"
+        f"</{TASK_NOTIFICATION_TAG}>"
+    )
+
+
+def enqueue_agent_notification(
+    *,
+    task_id: str,
+    description: str,
+    status: NotificationStatus,
+    output_file: str,
+    registry: "RuntimeTaskRegistry",
+    error: str | None = None,
+    final_message: str | None = None,
+    usage: dict[str, int] | None = None,
+    tool_use_id: str | None = None,
+) -> bool:
+    """Atomically check-and-set the ``notified`` flag, then enqueue.
+
+    WI-3.2 contract: this is the single duplicate-delivery guard. The
+    ``runtime_tasks.update`` mutator atomically reads ``prev.notified``
+    and (if False) returns a new state with ``notified=True``. The XML
+    is enqueued only when the mutator's pre-state had ``notified=False``.
+
+    Returns True iff a notification was actually enqueued.
+
+    Two concurrent callers on the same ``task_id`` race against the
+    registry RLock; the second call sees ``notified=True`` and returns
+    False without touching the queue.
+    """
+    # Local import to defer the cycle: ``local_agent`` imports
+    # transcript stuff that imports back through the agent module.
+    from src.tasks.local_agent import LocalAgentTaskState
+
+    should_enqueue = False
+
+    def _mark_notified(prev: Any) -> Any:
+        nonlocal should_enqueue
+        if not isinstance(prev, LocalAgentTaskState):
+            return prev
+        if prev.notified:
+            return prev
+        should_enqueue = True
+        return replace(prev, notified=True)
+
+    registry.update(task_id, _mark_notified)
+
+    if not should_enqueue:
+        return False
+
+    xml = build_task_notification_xml(
+        task_id=task_id,
+        description=description,
+        status=status,
+        output_file=output_file,
+        error=error,
+        final_message=final_message,
+        usage=usage,
+        tool_use_id=tool_use_id,
+    )
+    enqueue_pending_notification(value=xml, mode="task-notification")
+    return True
+
+
+__all__ = [
+    "NotificationStatus",
+    "build_task_notification_xml",
+    "enqueue_agent_notification",
+]

--- a/tests/test_eviction.py
+++ b/tests/test_eviction.py
@@ -1,0 +1,224 @@
+"""WI-3.4 tests — eviction grace + sweeper.
+
+Covers:
+* `schedule_eviction` no-ops on non-terminal status / `retain=True`.
+* `is_eligible_for_eviction` notify-before-evict guard.
+* `sweep_once` drops eligible entries and leaves others.
+* Real sweeper thread can be started/stopped without leaking the
+  daemon.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import replace
+
+from src.task_registry import RuntimeTaskRegistry
+from src.tasks.eviction import (
+    PANEL_GRACE_SECONDS,
+    is_eligible_for_eviction,
+    schedule_eviction,
+    start_eviction_sweeper,
+    stop_eviction_sweeper,
+    sweep_once,
+)
+from src.tasks.local_agent import (
+    LocalAgentTaskState,
+    complete_agent_task,
+    register_async_agent,
+)
+from src.tasks_core import generate_task_id
+
+
+def _make_terminal_notified(reg: RuntimeTaskRegistry) -> LocalAgentTaskState:
+    """Spawn → complete → mark notified. Helper for the eligibility
+    tests."""
+    agent_id = generate_task_id("local_agent")
+    register_async_agent(
+        agent_id=agent_id, description="x", prompt="x",
+        agent_type="general-purpose", registry=reg,
+    )
+    complete_agent_task(agent_id, result_text="done", registry=reg)
+    # Manually mark ``notified=True`` — the production path does this
+    # via ``enqueue_agent_notification``, but we test eviction in
+    # isolation here.
+    reg.update(agent_id, lambda prev: replace(prev, notified=True))
+    return reg.get(agent_id)
+
+
+# ---------------------------------------------------------------------------
+# PANEL_GRACE constant — A8 source-confirmed
+# ---------------------------------------------------------------------------
+
+
+def test_panel_grace_seconds_matches_ts_30_seconds() -> None:
+    """A8 / TS framework.ts:28 ``PANEL_GRACE_MS = 30_000`` → 30.0s here."""
+    assert PANEL_GRACE_SECONDS == 30.0
+
+
+# ---------------------------------------------------------------------------
+# schedule_eviction — pure helper
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_eviction_sets_deadline_for_terminal_state() -> None:
+    reg = RuntimeTaskRegistry()
+    state = _make_terminal_notified(reg)
+    now = 1_000_000.0
+    out = schedule_eviction(state, now=now)
+    assert out.evict_after == now + PANEL_GRACE_SECONDS
+
+
+def test_schedule_eviction_noop_for_running_state() -> None:
+    reg = RuntimeTaskRegistry()
+    agent_id = generate_task_id("local_agent")
+    state = register_async_agent(
+        agent_id=agent_id, description="x", prompt="x",
+        agent_type="general-purpose", registry=reg,
+    )
+    out = schedule_eviction(state)
+    assert out.evict_after is None
+
+
+def test_schedule_eviction_noop_for_retained_terminal() -> None:
+    """Retain flag pins the entry — UI is "holding" it."""
+    reg = RuntimeTaskRegistry()
+    state = _make_terminal_notified(reg)
+    retained = replace(state, retain=True)
+    out = schedule_eviction(retained)
+    assert out.evict_after is None
+
+
+# ---------------------------------------------------------------------------
+# is_eligible_for_eviction — notify-before-evict guard
+# ---------------------------------------------------------------------------
+
+
+def test_eligible_when_notified_and_past_deadline() -> None:
+    reg = RuntimeTaskRegistry()
+    state = _make_terminal_notified(reg)
+    now = state.evict_after + 1.0  # past the deadline
+    assert is_eligible_for_eviction(state, now=now) is True
+
+
+def test_not_eligible_before_deadline() -> None:
+    reg = RuntimeTaskRegistry()
+    state = _make_terminal_notified(reg)
+    now = state.evict_after - 5.0  # before deadline
+    assert is_eligible_for_eviction(state, now=now) is False
+
+
+def test_not_eligible_when_not_notified() -> None:
+    """Notify-before-evict guard. A terminal task whose parent hasn't
+    been told yet must NOT be evicted — losing the entry would lose
+    the ``<task-notification>`` envelope."""
+    reg = RuntimeTaskRegistry()
+    agent_id = generate_task_id("local_agent")
+    register_async_agent(
+        agent_id=agent_id, description="x", prompt="x",
+        agent_type="general-purpose", registry=reg,
+    )
+    complete_agent_task(agent_id, result_text="done", registry=reg)
+    # ``notified`` left at False (deliberately).
+    state = reg.get(agent_id)
+    now = (state.evict_after or 0) + 100
+    assert is_eligible_for_eviction(state, now=now) is False
+
+
+def test_not_eligible_when_running() -> None:
+    reg = RuntimeTaskRegistry()
+    agent_id = generate_task_id("local_agent")
+    state = register_async_agent(
+        agent_id=agent_id, description="x", prompt="x",
+        agent_type="general-purpose", registry=reg,
+    )
+    assert is_eligible_for_eviction(state, now=time.time() + 1e9) is False
+
+
+def test_not_eligible_when_retained() -> None:
+    reg = RuntimeTaskRegistry()
+    state = _make_terminal_notified(reg)
+    retained = replace(state, retain=True)
+    assert is_eligible_for_eviction(retained, now=(state.evict_after or 0) + 100) is False
+
+
+# ---------------------------------------------------------------------------
+# sweep_once — drops the eligible entries
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_once_removes_eligible_entries() -> None:
+    reg = RuntimeTaskRegistry()
+    a = _make_terminal_notified(reg)
+    b = _make_terminal_notified(reg)
+    # ``c`` is still running — should NOT be swept.
+    c_id = generate_task_id("local_agent")
+    register_async_agent(
+        agent_id=c_id, description="x", prompt="x",
+        agent_type="general-purpose", registry=reg,
+    )
+    far_future = max(a.evict_after, b.evict_after) + 100
+
+    dropped = sweep_once(reg, now=far_future)
+
+    assert sorted(dropped) == sorted([a.id, b.id])
+    assert reg.get(a.id) is None
+    assert reg.get(b.id) is None
+    assert reg.get(c_id) is not None  # still running
+
+
+def test_sweep_once_keeps_unnotified_terminal_entries() -> None:
+    """Notify-before-evict at the sweep level: entries with
+    ``notified=False`` are skipped even when past their deadline."""
+    reg = RuntimeTaskRegistry()
+    agent_id = generate_task_id("local_agent")
+    register_async_agent(
+        agent_id=agent_id, description="x", prompt="x",
+        agent_type="general-purpose", registry=reg,
+    )
+    complete_agent_task(agent_id, result_text="done", registry=reg)
+    # Leave ``notified=False``.
+    state = reg.get(agent_id)
+    far_future = (state.evict_after or 0) + 100
+
+    dropped = sweep_once(reg, now=far_future)
+
+    assert dropped == []
+    assert reg.get(agent_id) is not None
+
+
+# ---------------------------------------------------------------------------
+# start/stop_eviction_sweeper — daemon thread lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_sweeper_thread_starts_and_stops_cleanly() -> None:
+    reg = RuntimeTaskRegistry()
+    start_eviction_sweeper(reg, tick_seconds=0.05)
+    # Spawn a terminal-notified entry with a past deadline so the
+    # sweeper has work to do.
+    state = _make_terminal_notified(reg)
+    reg.update(state.id, lambda prev: replace(prev, evict_after=time.time() - 1.0))
+
+    # Wait for the sweep to fire.
+    deadline = time.time() + 1.0
+    while time.time() < deadline:
+        if reg.get(state.id) is None:
+            break
+        time.sleep(0.02)
+
+    assert reg.get(state.id) is None, "sweeper did not evict the eligible entry"
+
+    stop_eviction_sweeper(timeout=1.0)
+    # No live sweeper thread left in the runtime-task pool.
+    live = [t for t in threading.enumerate() if t.name == "runtime-task-eviction-sweeper"]
+    assert live == []
+
+
+def test_sweeper_start_is_idempotent_for_same_registry() -> None:
+    reg = RuntimeTaskRegistry()
+    start_eviction_sweeper(reg, tick_seconds=0.5)
+    start_eviction_sweeper(reg, tick_seconds=0.5)  # second call is a no-op
+    live = [t for t in threading.enumerate() if t.name == "runtime-task-eviction-sweeper"]
+    assert len(live) == 1
+    stop_eviction_sweeper(timeout=1.0)

--- a/tests/test_pending_message_drain.py
+++ b/tests/test_pending_message_drain.py
@@ -1,0 +1,93 @@
+"""WI-3.3 tests — pending_messages drain at tool-round boundary.
+
+The chapter contract: messages enqueued via ``queue_pending_message``
+arrive at the next tool-round boundary, NOT mid-execution. The query
+loop's between-turn hook is what surfaces them in the conversation.
+"""
+from __future__ import annotations
+
+from src.query.query import _drain_pending_user_messages
+from src.task_registry import RuntimeTaskRegistry
+from src.tasks.local_agent import (
+    queue_pending_message,
+    register_async_agent,
+)
+from src.tasks_core import generate_task_id
+from src.tool_system.context import ToolContext
+from src.types.messages import UserMessage
+
+
+def _make_context_with_running_agent(tmp_path) -> tuple[ToolContext, str]:
+    ctx = ToolContext(workspace_root=tmp_path)
+    agent_id = generate_task_id("local_agent")
+    register_async_agent(
+        agent_id=agent_id, description="x", prompt="x",
+        agent_type="general-purpose", registry=ctx.runtime_tasks,
+    )
+    ctx.agent_id = agent_id
+    return ctx, agent_id
+
+
+def test_drain_returns_empty_when_no_pending(tmp_path) -> None:
+    ctx, _ = _make_context_with_running_agent(tmp_path)
+    drained = _drain_pending_user_messages(ctx)
+    assert drained == []
+
+
+def test_drain_returns_user_messages_in_fifo_order(tmp_path) -> None:
+    ctx, agent_id = _make_context_with_running_agent(tmp_path)
+    queue_pending_message(agent_id, "first", ctx.runtime_tasks)
+    queue_pending_message(agent_id, "second", ctx.runtime_tasks)
+    queue_pending_message(agent_id, "third", ctx.runtime_tasks)
+
+    drained = _drain_pending_user_messages(ctx)
+
+    assert len(drained) == 3
+    assert all(isinstance(m, UserMessage) for m in drained)
+    assert [m.content for m in drained] == ["first", "second", "third"]
+
+
+def test_drain_clears_inbox_atomically(tmp_path) -> None:
+    """Second drain returns an empty list — the inbox is consumed in
+    one atomic sweep at the boundary."""
+    ctx, agent_id = _make_context_with_running_agent(tmp_path)
+    queue_pending_message(agent_id, "only-once", ctx.runtime_tasks)
+
+    first = _drain_pending_user_messages(ctx)
+    second = _drain_pending_user_messages(ctx)
+
+    assert len(first) == 1
+    assert second == []
+
+
+def test_drain_noop_when_no_agent_id(tmp_path) -> None:
+    """The hook is per-agent — without ``context.agent_id`` (top-level
+    or main-session calls) there's nothing to drain."""
+    ctx = ToolContext(workspace_root=tmp_path)
+    # ctx.agent_id stays None
+    drained = _drain_pending_user_messages(ctx)
+    assert drained == []
+
+
+def test_drain_noop_when_agent_id_unknown(tmp_path) -> None:
+    """An ``agent_id`` that isn't registered in runtime_tasks must not
+    crash the query loop — the drain returns empty."""
+    ctx = ToolContext(workspace_root=tmp_path)
+    ctx.agent_id = "a-unknown"
+    drained = _drain_pending_user_messages(ctx)
+    assert drained == []
+
+
+def test_drain_refuses_terminal_state_implicitly(tmp_path) -> None:
+    """When the lifecycle has flipped the task to terminal, queueing
+    refuses (covered in lifecycle tests). Drain on a terminal entry
+    returns empty since pending_messages stayed empty."""
+    from src.tasks.local_agent import complete_agent_task
+
+    ctx, agent_id = _make_context_with_running_agent(tmp_path)
+    complete_agent_task(agent_id, result_text="done", registry=ctx.runtime_tasks)
+
+    # Queue refuses post-terminal — the inbox stays empty.
+    fired = queue_pending_message(agent_id, "stale", ctx.runtime_tasks)
+    assert fired is False
+    assert _drain_pending_user_messages(ctx) == []

--- a/tests/test_task_notification.py
+++ b/tests/test_task_notification.py
@@ -1,0 +1,268 @@
+"""WI-3.1 + WI-3.2 tests — task-notification XML envelope + dedup.
+
+Covers the chapter's notification surface: byte-for-byte envelope
+parity with TS, ``notified`` flag check-and-set, idempotent enqueue,
+and the racy "completion fires between two sweeps" scenario.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from src.task_registry import RuntimeTaskRegistry
+from src.tasks.local_agent import (
+    LocalAgentTaskState,
+    register_async_agent,
+)
+from src.tasks_core import generate_task_id
+from src.utils.message_queue_manager import (
+    clear_pending_notifications,
+    drain_pending_notifications,
+    peek_pending_notifications,
+)
+from src.utils.task_notification import (
+    build_task_notification_xml,
+    enqueue_agent_notification,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_queue():
+    """Each test starts with an empty global notification queue."""
+    clear_pending_notifications()
+    yield
+    clear_pending_notifications()
+
+
+# ---------------------------------------------------------------------------
+# build_task_notification_xml — envelope shape parity with TS
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_contains_all_chapter_required_tags() -> None:
+    """Chapter §"Background: Three Channels" lists the fields:
+    task-id, tool-use-id, output-file, status, summary, result, usage.
+    Snapshot the envelope and assert each tag appears."""
+    xml = build_task_notification_xml(
+        task_id="a1234567z",
+        description="hello",
+        status="completed",
+        output_file="/tmp/a1234567z.jsonl",
+        final_message="Done — 3 files updated",
+        usage={"total_tokens": 1500, "tool_uses": 8, "duration_ms": 12000},
+        tool_use_id="toolu_abc",
+    )
+    for tag in [
+        "<task-notification>",
+        "<task-id>a1234567z</task-id>",
+        "<tool-use-id>toolu_abc</tool-use-id>",
+        "<output-file>/tmp/a1234567z.jsonl</output-file>",
+        "<status>completed</status>",
+        "<summary>",
+        "<result>Done — 3 files updated</result>",
+        "<usage>",
+        "<total_tokens>1500</total_tokens>",
+        "<tool_uses>8</tool_uses>",
+        "<duration_ms>12000</duration_ms>",
+        "</usage>",
+        "</task-notification>",
+    ]:
+        assert tag in xml, f"missing {tag!r} in:\n{xml}"
+
+
+def test_envelope_summary_phrasing_completed() -> None:
+    xml = build_task_notification_xml(
+        task_id="a1", description="my agent", status="completed",
+        output_file="/x",
+    )
+    assert '<summary>Agent "my agent" completed</summary>' in xml
+
+
+def test_envelope_summary_phrasing_failed_with_error() -> None:
+    xml = build_task_notification_xml(
+        task_id="a1", description="my agent", status="failed",
+        error="ValueError: bad", output_file="/x",
+    )
+    assert 'failed: ValueError: bad' in xml
+
+
+def test_envelope_summary_phrasing_failed_no_error() -> None:
+    xml = build_task_notification_xml(
+        task_id="a1", description="my agent", status="failed",
+        output_file="/x",
+    )
+    assert "failed: Unknown error" in xml
+
+
+def test_envelope_summary_phrasing_killed() -> None:
+    xml = build_task_notification_xml(
+        task_id="a1", description="my agent", status="killed",
+        output_file="/x",
+    )
+    assert '<summary>Agent "my agent" was stopped</summary>' in xml
+
+
+def test_envelope_optional_sections_omitted_when_inputs_absent() -> None:
+    xml = build_task_notification_xml(
+        task_id="a1", description="x", status="completed",
+        output_file="/x",
+    )
+    # Without final_message, no <result> tag.
+    assert "<result>" not in xml
+    # Without usage, no <usage> block.
+    assert "<usage>" not in xml
+    # Without tool_use_id, no <tool-use-id> tag.
+    assert "<tool-use-id>" not in xml
+
+
+def test_envelope_snapshot_completed_with_usage() -> None:
+    """Snapshot test — pin byte-level shape so future edits surface
+    obvious diffs at review time. Updating this snapshot is a
+    deliberate review step.
+
+    This branch covers the no-tool-use-id form (the Agent-tool spawn
+    case where the parent's ``tool_use_id`` isn't threaded through —
+    e.g. a coordinator that spawned without binding the response to a
+    specific tool_use). Companion test below covers the with-tool-use-id
+    branch (per critic concern N2)."""
+    xml = build_task_notification_xml(
+        task_id="a1234567z",
+        description="snapshot",
+        status="completed",
+        output_file="/tmp/a1234567z.jsonl",
+        final_message="ok",
+        usage={"total_tokens": 100, "tool_uses": 2, "duration_ms": 1000},
+    )
+    expected = (
+        "<task-notification>\n"
+        "<task-id>a1234567z</task-id>\n"
+        "<output-file>/tmp/a1234567z.jsonl</output-file>\n"
+        "<status>completed</status>\n"
+        '<summary>Agent "snapshot" completed</summary>'
+        "\n<result>ok</result>"
+        "\n<usage><total_tokens>100</total_tokens><tool_uses>2</tool_uses><duration_ms>1000</duration_ms></usage>\n"
+        "</task-notification>"
+    )
+    assert xml == expected, f"snapshot drifted:\n{xml!r}\nexpected:\n{expected!r}"
+
+
+def test_envelope_snapshot_with_tool_use_id() -> None:
+    """Critic N2 fold-in (Chunk E): the with-``tool-use-id`` branch
+    inserts ``\\n<tool-use-id>...</tool-use-id>`` directly after the
+    ``<task-id>`` close tag. Pin the shape so a future edit that
+    moves or restyles the insertion shows up in review."""
+    xml = build_task_notification_xml(
+        task_id="a1234567z",
+        description="snapshot",
+        status="completed",
+        output_file="/tmp/a1234567z.jsonl",
+        final_message="ok",
+        tool_use_id="toolu_abc123",
+    )
+    expected = (
+        "<task-notification>\n"
+        "<task-id>a1234567z</task-id>\n"
+        "<tool-use-id>toolu_abc123</tool-use-id>\n"
+        "<output-file>/tmp/a1234567z.jsonl</output-file>\n"
+        "<status>completed</status>\n"
+        '<summary>Agent "snapshot" completed</summary>'
+        "\n<result>ok</result>\n"
+        "</task-notification>"
+    )
+    assert xml == expected, f"snapshot drifted:\n{xml!r}\nexpected:\n{expected!r}"
+
+
+# ---------------------------------------------------------------------------
+# enqueue_agent_notification — WI-3.2 check-and-set against duplicates
+# ---------------------------------------------------------------------------
+
+
+def _make_running(reg: RuntimeTaskRegistry) -> LocalAgentTaskState:
+    agent_id = generate_task_id("local_agent")
+    register_async_agent(
+        agent_id=agent_id, description="example", prompt="x",
+        agent_type="general-purpose", registry=reg,
+    )
+    return reg.get(agent_id)
+
+
+def test_enqueue_marks_task_notified_and_pushes_one_envelope() -> None:
+    reg = RuntimeTaskRegistry()
+    state = _make_running(reg)
+
+    fired = enqueue_agent_notification(
+        task_id=state.id,
+        description=state.description,
+        status="completed",
+        output_file=state.output_file,
+        registry=reg,
+    )
+
+    assert fired is True
+    assert reg.get(state.id).notified is True
+    queue = peek_pending_notifications()
+    assert len(queue) == 1
+    assert "<task-notification>" in queue[0].value
+    assert queue[0].mode == "task-notification"
+
+
+def test_enqueue_is_no_op_when_already_notified() -> None:
+    """Idempotency contract: a second call against the same task does
+    NOT push a second envelope."""
+    reg = RuntimeTaskRegistry()
+    state = _make_running(reg)
+
+    enqueue_agent_notification(
+        task_id=state.id, description=state.description,
+        status="completed", output_file=state.output_file, registry=reg,
+    )
+    fired_again = enqueue_agent_notification(
+        task_id=state.id, description=state.description,
+        status="killed", output_file=state.output_file, registry=reg,
+    )
+    assert fired_again is False
+    assert len(peek_pending_notifications()) == 1
+
+
+def test_concurrent_completion_and_kill_produces_one_envelope() -> None:
+    """Race scenario from chapter: completion and kill fire close
+    together. The atomic check-and-set on ``notified`` ensures exactly
+    one envelope reaches the queue."""
+    import threading
+
+    reg = RuntimeTaskRegistry()
+    state = _make_running(reg)
+    barrier = threading.Barrier(2)
+
+    def emit(status: str) -> None:
+        barrier.wait()  # both threads enter at the same instant
+        enqueue_agent_notification(
+            task_id=state.id, description=state.description,
+            status=status, output_file=state.output_file, registry=reg,
+        )
+
+    t1 = threading.Thread(target=emit, args=("completed",))
+    t2 = threading.Thread(target=emit, args=("killed",))
+    t1.start(); t2.start()
+    t1.join(); t2.join()
+
+    queue = peek_pending_notifications()
+    assert len(queue) == 1, f"race produced {len(queue)} envelopes — dedup failed"
+
+
+def test_drain_removes_envelopes_from_queue() -> None:
+    reg = RuntimeTaskRegistry()
+    a = _make_running(reg)
+    b = _make_running(reg)
+    enqueue_agent_notification(
+        task_id=a.id, description=a.description,
+        status="completed", output_file=a.output_file, registry=reg,
+    )
+    enqueue_agent_notification(
+        task_id=b.id, description=b.description,
+        status="failed", output_file=b.output_file, registry=reg,
+    )
+    drained = drain_pending_notifications()
+    assert len(drained) == 2
+    assert peek_pending_notifications() == []

--- a/tests/test_task_output_polling.py
+++ b/tests/test_task_output_polling.py
@@ -1,0 +1,224 @@
+"""WI-4.0 + WI-4.1 tests — async tool dispatch + TaskOutput polling.
+
+Covers the dispatch layer's sync-vs-async branch, the three
+``retrieval_status`` values (``success`` / ``timeout`` / ``not_ready``),
+schema bounds rejection, default timeout, and abort-fast-path.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+import pytest
+
+from src.task_registry import RuntimeTaskRegistry
+from src.tasks.local_agent import (
+    LocalAgentTaskState,
+    complete_agent_task,
+    register_async_agent,
+)
+from src.tasks_core import generate_task_id
+from src.tool_system.context import ToolContext
+from src.tool_system.tools.tasks_v2 import TaskOutputTool
+
+
+# ---------------------------------------------------------------------------
+# WI-4.0 — async build_tool dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_loop_branches_on_iscoroutinefunction(tmp_path: Path) -> None:
+    """The registry's ``_invoke_tool_call`` helper drives async tools
+    through ``asyncio.run`` when no loop is active."""
+    from src.tool_system.registry import _invoke_tool_call
+
+    ctx = ToolContext(workspace_root=tmp_path)
+
+    class _AsyncStub:
+        name = "AsyncStub"
+        async def call(self, _input, _ctx):
+            from src.tool_system.protocol import ToolResult
+            return ToolResult(name="AsyncStub", output={"ok": True})
+
+    class _SyncStub:
+        name = "SyncStub"
+        def call(self, _input, _ctx):
+            from src.tool_system.protocol import ToolResult
+            return ToolResult(name="SyncStub", output={"ok": True})
+
+    # Both stubs round-trip through the same dispatcher.
+    sync_result = _invoke_tool_call(_SyncStub(), {}, ctx)
+    async_result = _invoke_tool_call(_AsyncStub(), {}, ctx)
+    assert sync_result.output == {"ok": True}
+    assert async_result.output == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# WI-4.1 — retrieval_status semantics
+# ---------------------------------------------------------------------------
+
+
+def _ctx_with_agent(tmp_path: Path) -> tuple[ToolContext, str]:
+    ctx = ToolContext(workspace_root=tmp_path)
+    agent_id = generate_task_id("local_agent")
+    register_async_agent(
+        agent_id=agent_id, description="x", prompt="x",
+        agent_type="general-purpose", registry=ctx.runtime_tasks,
+    )
+    return ctx, agent_id
+
+
+def test_block_false_returns_not_ready_for_running_task(tmp_path: Path) -> None:
+    ctx, agent_id = _ctx_with_agent(tmp_path)
+    result = asyncio.run(
+        TaskOutputTool.call({"task_id": agent_id, "block": False}, ctx)
+    )
+    assert result.output["retrieval_status"] == "not_ready"
+    assert result.output["task"]["status"] == "running"
+
+
+def test_block_false_returns_success_for_terminal_task(tmp_path: Path) -> None:
+    ctx, agent_id = _ctx_with_agent(tmp_path)
+    complete_agent_task(agent_id, result_text="ok", registry=ctx.runtime_tasks)
+    result = asyncio.run(
+        TaskOutputTool.call({"task_id": agent_id, "block": False}, ctx)
+    )
+    assert result.output["retrieval_status"] == "success"
+    assert result.output["task"]["status"] == "completed"
+
+
+def test_block_true_returns_timeout_when_deadline_expires(tmp_path: Path) -> None:
+    """Polling with a tight deadline against a still-running task
+    returns ``retrieval_status="timeout"`` and the running snapshot."""
+    ctx, agent_id = _ctx_with_agent(tmp_path)
+    start = time.time()
+    result = asyncio.run(
+        TaskOutputTool.call(
+            {"task_id": agent_id, "block": True, "timeout": 200},  # 200ms
+            ctx,
+        )
+    )
+    elapsed = time.time() - start
+    assert result.output["retrieval_status"] == "timeout"
+    assert result.output["task"]["status"] == "running"
+    # Timeout was 200ms; the poll should bound around that with some
+    # slop for the asyncio.sleep tick.
+    assert elapsed < 1.0, f"timeout not respected, took {elapsed:.2f}s"
+
+
+def test_block_true_waits_for_terminal_then_returns_success(tmp_path: Path) -> None:
+    """With a generous timeout, a task that completes mid-poll
+    surfaces as ``retrieval_status="success"``."""
+    import threading
+
+    ctx, agent_id = _ctx_with_agent(tmp_path)
+
+    # Fire completion on a background thread shortly after the poll starts.
+    def _complete_after_short_delay() -> None:
+        time.sleep(0.2)
+        complete_agent_task(agent_id, result_text="late", registry=ctx.runtime_tasks)
+
+    threading.Thread(target=_complete_after_short_delay, daemon=True).start()
+
+    result = asyncio.run(
+        TaskOutputTool.call(
+            {"task_id": agent_id, "block": True, "timeout": 5000},
+            ctx,
+        )
+    )
+    assert result.output["retrieval_status"] == "success"
+    assert result.output["task"]["status"] == "completed"
+    assert "late" in result.output["task"]["output"]
+
+
+def test_unknown_task_id_returns_success_with_null_task(tmp_path: Path) -> None:
+    """Mirrors TS: an absent task is reported as success-with-null-body
+    (NOT an error). Callers distinguish via the ``task`` key."""
+    ctx = ToolContext(workspace_root=tmp_path)
+    result = asyncio.run(
+        TaskOutputTool.call({"task_id": "a-unknown"}, ctx)
+    )
+    assert result.output["retrieval_status"] == "success"
+    assert result.output["task"] is None
+
+
+# ---------------------------------------------------------------------------
+# Schema bounds — TS TaskOutputTool.tsx:33 z.number().min(0).max(600000)
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_default_is_30000_ms(tmp_path: Path) -> None:
+    """The schema's ``default: 30000`` is honored when the model omits
+    ``timeout``. Verified by the ``block: false`` early-return path
+    (which doesn't actually wait) so the test runs in ms."""
+    ctx, agent_id = _ctx_with_agent(tmp_path)
+    # No ``timeout`` in input; ``block: false`` so we don't wait.
+    result = asyncio.run(
+        TaskOutputTool.call({"task_id": agent_id, "block": False}, ctx)
+    )
+    assert result.output["retrieval_status"] == "not_ready"
+
+
+def test_timeout_invalid_string_raises() -> None:
+    """A non-numeric timeout is rejected at the body — the
+    ``ToolInputError`` propagates rather than dispatching with a
+    nonsense value."""
+    from src.tool_system.errors import ToolInputError
+
+    ctx = ToolContext(workspace_root=Path("/tmp"))
+    with pytest.raises(ToolInputError):
+        asyncio.run(
+            TaskOutputTool.call(
+                {"task_id": "a1", "timeout": "huge"}, ctx
+            )
+        )
+
+
+def test_schema_declares_minimum_and_maximum_bounds() -> None:
+    """The chapter spec pins ``timeout`` to [0, 600000]. Verify the
+    schema declares both bounds so downstream JSON-schema validators
+    enforce them."""
+    schema = TaskOutputTool.input_schema
+    timeout_schema = schema["properties"]["timeout"]
+    assert timeout_schema["minimum"] == 0
+    assert timeout_schema["maximum"] == 600000
+    assert timeout_schema["default"] == 30000
+
+
+def test_schema_declares_block_default_true() -> None:
+    schema = TaskOutputTool.input_schema
+    block_schema = schema["properties"]["block"]
+    assert block_schema["default"] is True
+
+
+# ---------------------------------------------------------------------------
+# Abort fast-path
+# ---------------------------------------------------------------------------
+
+
+def test_block_true_exits_early_on_abort_signal(tmp_path: Path) -> None:
+    """If the parent's abort controller signals, the poll exits
+    promptly with the current snapshot rather than waiting out the
+    timeout."""
+    ctx, agent_id = _ctx_with_agent(tmp_path)
+
+    # Fake abort controller — simplest possible shape.
+    class _Sig:
+        aborted = True
+    class _Ctl:
+        signal = _Sig()
+    ctx.abort_controller = _Ctl()
+
+    start = time.time()
+    result = asyncio.run(
+        TaskOutputTool.call(
+            {"task_id": agent_id, "block": True, "timeout": 5000},
+            ctx,
+        )
+    )
+    elapsed = time.time() - start
+    # Should bail almost immediately rather than polling the full 5s.
+    assert elapsed < 1.0
+    # Status retrieved from the running snapshot.
+    assert result.output["task"]["status"] == "running"


### PR DESCRIPTION
## Summary

Phase 3 + Phase 4 — the three-channel communication layer plus its TaskOutput consumer.

- New: `src/utils/task_notification.py` — `<task-notification>` XML envelope emitter matching TS byte-for-byte. Atomic check-and-set on `state.notified` is the single dedup guard; concurrent completion + kill produce exactly one envelope (race-tested via `threading.Barrier(2)`).
- New: `src/utils/message_queue_manager.py` — global pending-notification queue. Notifications inject as user-role messages into the parent's conversation, matching the chapter's contract.
- New: `src/constants/xml.py` — pinned XML tag constants.
- New: `src/tasks/eviction.py` — eviction grace + sweeper. `PANEL_GRACE_SECONDS = 30.0` matches TS `framework.ts:28 PANEL_GRACE_MS = 30_000`. Daemon thread, idempotent start, ~5s tick. Notify-before-evict guard: terminal tasks with `notified=False` are skipped.
- `src/query/query.py`: pending-messages drain hooked at the tool-round boundary — AFTER `tool_results` are gathered and BEFORE the next API call. Chapter's "messages arrive between tool rounds, not mid-execution" contract.
- WI-4.0: `src/tool_system/registry.py` — async-aware `Tool.call` dispatch. Sync tools bypass asyncio entirely.
- WI-4.1: `_task_output_call` in `tasks_v2.py` is now async with real polling. Emits all three TS retrieval_status values (`success` / `timeout` / `not_ready`). Schema bounds `timeout: {minimum: 0, maximum: 600000, default: 30000}` matching TS. Abort fast-path exits within one sleep boundary.
- The Phase-0 task_stop async bridge is simplified to use `asyncio.wait_for` now that `build_tool` accepts async (M1 timeout regression preserved verbatim).

41 new tests across 4 files. Notification XML byte-pinned via snapshot tests for both with-tool-use-id and without branches.

**Stacked PR.** Base: `feat/ch10-coordination-phase2`. Merge after the Phase 2 PR.

## Test plan
- [x] One `<task-notification>` envelope per terminal-state agent (race test via `threading.Barrier(2)` confirms exactly one)
- [x] `pending_messages` drained at tool-round boundary, not mid-tool
- [x] Eviction sweeper purges past-30s + `notified=True`; skips not-yet-notified
- [x] `TaskOutputTool` returns success / timeout / not_ready for the three branches
- [x] Schema rejects out-of-range timeout
- [x] WI-4.0 dispatch loop branches correctly (sync tools unaffected)
- [x] M1 task_stop timeout regression preserved