### PR TITLE
ch10 phase 6+7: swarm primitives + SendMessage routing + auto-resume

### DIFF
--- a/src/agent/resume_agent.py
+++ b/src/agent/resume_agent.py
@@ -1,0 +1,246 @@
+"""Auto-resume for terminal local_agent tasks — Chunk F / WI-7.4.
+
+Mirrors ``typescript/src/tools/AgentTool/resumeAgent.ts``. When
+SendMessage targets a terminal-state agent (completed / failed /
+killed), instead of returning an error this module re-spawns the
+agent with the prior conversation reconstructed from its sidechain
+JSONL transcript (Chunk C / WI-2.2 — gate-zero).
+
+DIP claim (concern C6 from refactoring-plan review): this module
+depends on ``TranscriptReader`` (the interface, not the writer's IO
+layer) — the reader is the canonical consumer for ``state.output_file``.
+
+Race guard
+----------
+
+Two concurrent SendMessage calls to the same dead agent_id should
+NOT both spawn replacement runs. The atomic claim:
+
+1. Read the registry entry.
+2. If state is terminal AND ``not state.is_resuming``, set
+   ``is_resuming=True`` and return "this caller wins."
+3. Else return "another caller is resuming; queue the message via
+   ``queue_pending_message`` instead."
+
+The check + flip are one ``runtime_tasks.update`` mutator call —
+atomic under the registry's RLock. Two concurrent callers see
+exactly one winner.
+
+Pending-message handoff
+-----------------------
+
+The caller that wins the resume race carries the SendMessage payload
+into the resumed run by passing it as the new ``prompt``. Losers
+queue their messages onto the new running state via
+``queue_pending_message`` (which by then sees the running entry the
+winner just registered).
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, replace
+from typing import Any, TYPE_CHECKING
+
+from src.agent.transcript import TranscriptReader
+from src.tasks.local_agent import (
+    LocalAgentTaskState,
+    register_async_agent,
+)
+from src.tasks_core import is_terminal_task_status
+
+if TYPE_CHECKING:
+    from src.task_registry import RuntimeTaskRegistry
+    from src.tool_system.context import ToolContext
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ResumeResult:
+    """Outcome of a resume attempt.
+
+    * ``resumed``: True iff this caller won the race and re-spawned
+      the agent. False means another caller got there first or the
+      target agent isn't actually terminal.
+    * ``agent_id``: the resumed agent's id (same as the original).
+    * ``output_file``: transcript path on disk.
+    * ``replayed_message_count``: number of messages reconstructed
+      from the transcript.
+    * ``reason``: human-readable status (only populated on the loser
+      / no-op paths).
+    """
+
+    resumed: bool
+    agent_id: str
+    output_file: str = ""
+    replayed_message_count: int = 0
+    reason: str = ""
+
+
+def _claim_resume(
+    agent_id: str,
+    runtime_tasks: "RuntimeTaskRegistry",
+) -> tuple[bool, LocalAgentTaskState | None]:
+    """Atomic check-and-claim — race-safe resume gate.
+
+    Returns ``(won, prev_state)``:
+    * ``(True, terminal_state)`` — caller is the resume winner; the
+      registry entry now has ``is_resuming=True`` so concurrent
+      callers see the terminal flag and back off.
+    * ``(False, None)`` — caller lost (or task isn't resumable).
+
+    The ``is_resuming`` bookkeeping lives on
+    ``LocalAgentTaskState.is_resuming`` (Chunk-F field; the dataclass
+    grew the flag for this WI).
+
+    **Load-bearing invariant (critic Chunk-F C1):** the path from this
+    helper to ``register_async_agent`` (in
+    ``resume_agent_background``) MUST stay synchronous. Loser callers
+    rely on observing the winner's *running* fresh state — they fall
+    back to ``queue_pending_message``, which refuses terminal states.
+    If a future refactor makes ``_reconstruct_messages_from_transcript``
+    async (e.g., streaming reads of large transcripts), the winner
+    yields control mid-path; the loser then observes
+    ``is_resuming=True`` on a still-terminal state and the
+    ``queue_pending_message`` no-ops, silently dropping the loser's
+    message. If async is needed later, the fix is to gate the
+    loser's ``queue_pending_message`` with a state-refresh-loop that
+    waits for the winner to land the running state.
+    """
+    won = False
+    captured: LocalAgentTaskState | None = None
+
+    def _maybe_claim(prev: Any) -> Any:
+        nonlocal won, captured
+        if not isinstance(prev, LocalAgentTaskState):
+            return prev
+        if not is_terminal_task_status(prev.status):
+            return prev  # not terminal — nothing to resume
+        if getattr(prev, "is_resuming", False):
+            return prev  # someone else is already resuming
+        won = True
+        captured = prev
+        return replace(prev, is_resuming=True)
+
+    runtime_tasks.update(agent_id, _maybe_claim)
+    return won, captured
+
+
+def _reconstruct_messages_from_transcript(transcript_path: str) -> list[Any]:
+    """Read the JSONL transcript and return parseable message objects.
+
+    Tolerant of trailing partial lines (writer-crashed-mid-write —
+    the same case the chapter-correct ``TranscriptReader`` already
+    handles). Returns the raw dict / Message objects that the reader
+    yields; the caller decides how to hydrate them into typed
+    ``Message`` subclasses.
+    """
+    return TranscriptReader(transcript_path).read_all()
+
+
+async def resume_agent_background(
+    *,
+    agent_id: str,
+    prompt: str,
+    context: "ToolContext",
+) -> ResumeResult:
+    """Re-spawn a stopped agent's background lifecycle with ``prompt``
+    as the resume message.
+
+    Returns a ``ResumeResult`` describing the outcome:
+
+    * Winner of the race → ``resumed=True``; the registry holds a
+      fresh ``LocalAgentTaskState`` for ``agent_id`` with status
+      ``"running"``. The transcript is read from disk and counted in
+      ``replayed_message_count`` for the caller's diagnostics.
+    * Loser → ``resumed=False``, ``reason`` describes the situation.
+      Caller should typically follow up with ``queue_pending_message``
+      to deliver the prompt to the now-running agent.
+    * Target not terminal / not present → ``resumed=False`` with a
+      reason like ``"task not terminal"`` or ``"task not found"``.
+
+    **The resume run does NOT actually drive a model call in this
+    chunk.** Wiring the resumed lifecycle into ``run_agent`` requires
+    threading the reconstructed messages and the resume prompt through
+    ``RunAgentParams`` — that's a subsequent integration step. This
+    chunk lands the structural primitive (race-safe re-registration +
+    transcript replay scaffolding) so SendMessage's auto-resume
+    branch has something to call. The resumed entry's ``status`` is
+    ``"running"`` so other callers see it and queue rather than
+    re-resume.
+    """
+    runtime = context.runtime_tasks
+    state = runtime.get(agent_id)
+
+    if state is None:
+        return ResumeResult(
+            resumed=False, agent_id=agent_id,
+            reason="task not found in runtime_tasks",
+        )
+
+    if not isinstance(state, LocalAgentTaskState):
+        return ResumeResult(
+            resumed=False, agent_id=agent_id,
+            reason=f"task type {state.type!r} is not local_agent",
+        )
+
+    if not is_terminal_task_status(state.status):
+        return ResumeResult(
+            resumed=False, agent_id=agent_id,
+            reason=f"task is {state.status!r}, not terminal",
+        )
+
+    won, prev = _claim_resume(agent_id, runtime)
+    if not won or prev is None:
+        # Another caller won the race; the registry entry is now
+        # ``is_resuming=True`` (and likely already replaced by the
+        # winner with a fresh running state). Return a no-op so the
+        # SendMessage caller knows to fall back to queueing.
+        return ResumeResult(
+            resumed=False, agent_id=agent_id,
+            reason="another caller is resuming; queue your message instead",
+        )
+
+    # Reconstruct the prior conversation. Errors here are non-fatal —
+    # the resumed run still gets the new prompt; it just lacks the
+    # historical context.
+    transcript_path = prev.output_file
+    replayed: list[Any] = []
+    try:
+        replayed = _reconstruct_messages_from_transcript(transcript_path)
+    except Exception:
+        logger.exception(
+            "transcript reconstruction failed for %s; resuming without history",
+            agent_id,
+        )
+
+    # Re-register the agent with a fresh running state. ``register_async_agent``
+    # ``upsert``s, replacing the terminal entry. The new state has
+    # ``is_resuming=False`` (default) so a future resume can fire if
+    # this run also completes. Carry the resume ``prompt`` into
+    # pending_messages so the resumed run picks it up at its first
+    # tool-round drain (chapter-correct behavior — Chunk D / WI-3.3).
+    fresh_state = register_async_agent(
+        agent_id=agent_id,
+        description=prev.description,
+        prompt=prompt,  # the SendMessage payload is the resume prompt
+        agent_type=prev.agent_type,
+        selected_agent=prev.selected_agent,
+        model=prev.model,
+        tool_use_id=prev.tool_use_id,
+        registry=runtime,
+    )
+
+    return ResumeResult(
+        resumed=True,
+        agent_id=agent_id,
+        output_file=fresh_state.output_file,
+        replayed_message_count=len(replayed),
+        reason="",
+    )
+
+
+__all__ = [
+    "ResumeResult",
+    "resume_agent_background",
+]

--- a/src/reference_data/ts_tool_names.json
+++ b/src/reference_data/ts_tool_names.json
@@ -1,52 +1,136 @@
 {
   "_comment": "Canonical TS tool names from tools.ts getAllBaseTools, mapped to Python equivalents",
   "core_tools": {
-    "Agent": {"python_name": "Agent", "factory": true, "aliases": ["Task"]},
-    "AskUserQuestion": {"python_name": "AskUserQuestion"},
-    "Bash": {"python_name": "Bash"},
-    "Brief": {"python_name": "Brief"},
-    "ClipboardRead": {"python_name": "ClipboardRead"},
-    "ClipboardWrite": {"python_name": "ClipboardWrite"},
-    "Config": {"python_name": "Config"},
-    "CronCreate": {"python_name": "CronCreate"},
-    "CronDelete": {"python_name": "CronDelete"},
-    "CronList": {"python_name": "CronList"},
-    "Edit": {"python_name": "Edit"},
-    "EnterPlanMode": {"python_name": "EnterPlanMode"},
-    "EnterWorktree": {"python_name": "EnterWorktree"},
-    "ExitPlanMode": {"python_name": "ExitPlanMode"},
-    "ExitWorktree": {"python_name": "ExitWorktree"},
-    "Glob": {"python_name": "Glob"},
-    "Grep": {"python_name": "Grep"},
-    "LSP": {"python_name": "LSP"},
-    "ListMcpResourcesTool": {"python_name": "ListMcpResourcesTool"},
-    "MCP": {"python_name": "MCP"},
-    "Read": {"python_name": "Read"},
-    "ReadMcpResourceTool": {"python_name": "ReadMcpResourceTool"},
-    "SendUserMessage": {"python_name": "SendUserMessage"},
-    "Skill": {"python_name": "Skill"},
-    "Sleep": {"python_name": "Sleep"},
-    "Status": {"python_name": "Status"},
-    "StructuredOutput": {"python_name": "StructuredOutput"},
-    "TaskCreate": {"python_name": "TaskCreate"},
-    "TaskGet": {"python_name": "TaskGet"},
-    "TaskList": {"python_name": "TaskList"},
-    "TaskOutput": {"python_name": "TaskOutput"},
-    "TaskStop": {"python_name": "TaskStop"},
-    "TaskUpdate": {"python_name": "TaskUpdate"},
-    "TeamCreate": {"python_name": "TeamCreate"},
-    "TeamDelete": {"python_name": "TeamDelete"},
-    "TodoWrite": {"python_name": "TodoWrite"},
-    "ToolSearch": {"python_name": "ToolSearch", "factory": true},
-    "WebFetch": {"python_name": "WebFetch"},
-    "WebSearch": {"python_name": "WebSearch"},
-    "Write": {"python_name": "Write"}
+    "Agent": {
+      "python_name": "Agent",
+      "factory": true,
+      "aliases": [
+        "Task"
+      ]
+    },
+    "AskUserQuestion": {
+      "python_name": "AskUserQuestion"
+    },
+    "Bash": {
+      "python_name": "Bash"
+    },
+    "Brief": {
+      "python_name": "Brief"
+    },
+    "ClipboardRead": {
+      "python_name": "ClipboardRead"
+    },
+    "ClipboardWrite": {
+      "python_name": "ClipboardWrite"
+    },
+    "Config": {
+      "python_name": "Config"
+    },
+    "CronCreate": {
+      "python_name": "CronCreate"
+    },
+    "CronDelete": {
+      "python_name": "CronDelete"
+    },
+    "CronList": {
+      "python_name": "CronList"
+    },
+    "Edit": {
+      "python_name": "Edit"
+    },
+    "EnterPlanMode": {
+      "python_name": "EnterPlanMode"
+    },
+    "EnterWorktree": {
+      "python_name": "EnterWorktree"
+    },
+    "ExitPlanMode": {
+      "python_name": "ExitPlanMode"
+    },
+    "ExitWorktree": {
+      "python_name": "ExitWorktree"
+    },
+    "Glob": {
+      "python_name": "Glob"
+    },
+    "Grep": {
+      "python_name": "Grep"
+    },
+    "LSP": {
+      "python_name": "LSP"
+    },
+    "ListMcpResourcesTool": {
+      "python_name": "ListMcpResourcesTool"
+    },
+    "MCP": {
+      "python_name": "MCP"
+    },
+    "Read": {
+      "python_name": "Read"
+    },
+    "ReadMcpResourceTool": {
+      "python_name": "ReadMcpResourceTool"
+    },
+    "SendUserMessage": {
+      "python_name": "SendUserMessage"
+    },
+    "Skill": {
+      "python_name": "Skill"
+    },
+    "Sleep": {
+      "python_name": "Sleep"
+    },
+    "Status": {
+      "python_name": "Status"
+    },
+    "StructuredOutput": {
+      "python_name": "StructuredOutput"
+    },
+    "TaskCreate": {
+      "python_name": "TaskCreate"
+    },
+    "TaskGet": {
+      "python_name": "TaskGet"
+    },
+    "TaskList": {
+      "python_name": "TaskList"
+    },
+    "TaskOutput": {
+      "python_name": "TaskOutput"
+    },
+    "TaskStop": {
+      "python_name": "TaskStop"
+    },
+    "TaskUpdate": {
+      "python_name": "TaskUpdate"
+    },
+    "TeamCreate": {
+      "python_name": "TeamCreate"
+    },
+    "TeamDelete": {
+      "python_name": "TeamDelete"
+    },
+    "TodoWrite": {
+      "python_name": "TodoWrite"
+    },
+    "ToolSearch": {
+      "python_name": "ToolSearch",
+      "factory": true
+    },
+    "WebFetch": {
+      "python_name": "WebFetch"
+    },
+    "WebSearch": {
+      "python_name": "WebSearch"
+    },
+    "Write": {
+      "python_name": "Write"
+    }
   },
   "not_yet_implemented": [
     "NotebookEdit",
     "PowerShell",
     "REPL",
-    "RemoteTrigger",
-    "SendMessage"
+    "RemoteTrigger"
   ]
 }

--- a/src/services/swarm/agent_name_registry.py
+++ b/src/services/swarm/agent_name_registry.py
@@ -1,0 +1,137 @@
+"""Agent name registry — Chunk F / WI-6.1 + Chunk-F-Phase-6 critic C1.
+
+Critic C1 carried into Phase 7: the original Phase-6 implementation
+used a bare ``dict[str, str]`` on ``ToolContext`` and did the
+collision check + write across two unprotected statements in
+``_launch_async_agent``. With Phase 7 introducing concurrent-spawn
+patterns (coordinator mode launches workers in parallel), that
+TOCTOU window lets a second spawn-with-same-name silently succeed
+and steal the binding.
+
+Fix shape (option (b) per the brief — SRP-clean): wrap the dict in a
+small class with a single ``claim_or_raise`` method that does
+check-and-claim under its own ``threading.RLock``. The registry is
+the source of truth; ``_launch_async_agent`` no longer touches the
+dict directly.
+
+The class also exposes ``get`` / ``release`` / ``items`` /
+``__contains__`` so existing readers (SendMessage routing, tests)
+keep working with familiar shapes.
+"""
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Iterator
+
+from src.tasks_core import is_terminal_task_status
+
+if TYPE_CHECKING:
+    from src.task_registry import RuntimeTaskRegistry
+
+
+class AgentNameAlreadyClaimedError(Exception):
+    """Raised by ``claim_or_raise`` when the requested name is already
+    bound to a running task. Callers should treat this as "model picked
+    a colliding name; tell them via SendMessage to continue the
+    existing one or pick a different name."
+
+    Subclassed from plain ``Exception`` (NOT ``ToolInputError``) so the
+    registry stays decoupled from the tool layer; the agent tool's
+    ``_launch_async_agent`` translates this into ``ToolInputError`` at
+    the boundary.
+    """
+
+    def __init__(self, name: str, existing_agent_id: str) -> None:
+        super().__init__(
+            f"Agent name {name!r} is already registered to running task "
+            f"{existing_agent_id}. Use SendMessage with to={name!r} to "
+            f"continue, or pick a different name."
+        )
+        self.name = name
+        self.existing_agent_id = existing_agent_id
+
+
+class AgentNameRegistry:
+    """Thread-safe map of human-readable agent names → agent ids.
+
+    The single ``claim_or_raise`` method is the atomic primitive: it
+    holds the registry's RLock across the read of the existing
+    binding, the look-up of the existing task's terminal status, AND
+    the write of the new binding. No TOCTOU window between the three.
+
+    Other methods (``get``, ``__contains__``, ``items``, ``release``)
+    are simple read/write operations that take the lock briefly.
+
+    Per A6/C5 contract: callers must NOT hold the registry's RLock
+    across an ``await``. ``claim_or_raise`` runs synchronously
+    (``runtime_tasks.get`` and the Python attribute reads are all
+    sync), so this isn't a problem in practice.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._mapping: dict[str, str] = {}
+
+    def claim_or_raise(
+        self,
+        name: str,
+        agent_id: str,
+        runtime_tasks: "RuntimeTaskRegistry",
+    ) -> None:
+        """Atomically claim ``name`` for ``agent_id``.
+
+        Behavior:
+        * Name unbound → bind to ``agent_id``.
+        * Name bound to ``agent_id`` already → no-op (idempotent).
+        * Name bound to a different agent_id whose task is **running** →
+          ``AgentNameAlreadyClaimedError``.
+        * Name bound to a different agent_id whose task is **terminal**
+          (or evicted from the registry) → overwrite. Old terminal
+          holders remain reachable via raw task_id + auto-resume
+          (Chunk F / WI-7.4).
+
+        The check + claim are atomic under the registry's RLock; two
+        concurrent ``claim_or_raise`` calls with the same name will
+        not both succeed.
+        """
+        with self._lock:
+            existing = self._mapping.get(name)
+            if existing == agent_id:
+                return
+            if existing is not None:
+                existing_state = runtime_tasks.get(existing)
+                if existing_state is not None and not is_terminal_task_status(
+                    existing_state.status
+                ):
+                    raise AgentNameAlreadyClaimedError(name, existing)
+            self._mapping[name] = agent_id
+
+    def get(self, name: str) -> str | None:
+        with self._lock:
+            return self._mapping.get(name)
+
+    def release(self, name: str) -> bool:
+        """Drop the binding for ``name``. Returns True if a binding
+        was removed."""
+        with self._lock:
+            return self._mapping.pop(name, None) is not None
+
+    def items(self) -> list[tuple[str, str]]:
+        """Snapshot of every (name, agent_id) pair. Returns a list, not
+        a live view — concurrent writers can't corrupt iteration."""
+        with self._lock:
+            return list(self._mapping.items())
+
+    def __contains__(self, name: str) -> bool:
+        with self._lock:
+            return name in self._mapping
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._mapping)
+
+
+__all__ = [
+    "AgentNameAlreadyClaimedError",
+    "AgentNameRegistry",
+]

--- a/src/services/swarm/helpers.py
+++ b/src/services/swarm/helpers.py
@@ -24,7 +24,7 @@ def format_team_summary(manager: TeammateManager) -> str:
             TeammateStatus.RUNNING: "🔄",
             TeammateStatus.COMPLETED: "✅",
             TeammateStatus.FAILED: "❌",
-            TeammateStatus.CANCELLED: "⛔",
+            TeammateStatus.KILLED: "⛔",
             TeammateStatus.PENDING: "⏳",
         }.get(t.status, "?")
         prompt_preview = t.config.prompt[:40] + ("..." if len(t.config.prompt) > 40 else "")

--- a/src/services/swarm/mailbox.py
+++ b/src/services/swarm/mailbox.py
@@ -1,0 +1,335 @@
+"""File-based JSONL mailbox — Chunk F / WI-6.3.
+
+Mirrors the ``writeToMailbox`` / envelope-helper surface in
+``typescript/src/utils/teammateMailbox.ts``. Per assumption A4
+(JSONL with atomic-append-without-locking) and critic concern C1
+(path-traversal sanitization on model-controlled names).
+
+Format
+------
+
+JSONL — one JSON object per line, UTF-8, terminated with ``\\n``.
+Reader is tolerant of trailing partial writes (writer-crashed-mid-
+write); see ``read_unread_messages``.
+
+Storage
+-------
+
+* Per-team directory: ``<workspace_root>/.clawcodex/mailboxes/<team>/``
+* Per-recipient file: ``<recipient>.jsonl``
+* Both names sanitized against ``[A-Za-z0-9_-]{1,64}`` whitelist
+  BEFORE any filesystem call. ``ValueError`` on rejection — no
+  silent escape, no fallback.
+
+Concurrency
+-----------
+
+Writes go through ``os.write`` on an ``O_APPEND`` file descriptor.
+POSIX guarantees atomic appends for sub-PIPE_BUF (≥4 KiB) writes;
+mailbox messages are well under that. Multi-writer interleaving at
+sub-PIPE_BUF granularity is not possible. Lines >4 KiB *can*
+interleave under heavy concurrency; the reader's tolerant parser
+absorbs the resulting partial line.
+
+Out of scope (per critic concern C4 / Phase 11)
+-----------------------------------------------
+
+GC / rotation / age-based eviction. Mailbox files grow unbounded
+under this WI; a separate ticket lands the cleanup policy.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterator, Literal
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Path sanitization (critic concern C1)
+# ---------------------------------------------------------------------------
+
+# Whitelist allowing alphanumerics, underscore, and dash. ``..`` and
+# ``/`` are rejected — both would let a malicious or buggy ``to:``
+# field write outside the mailboxes dir.
+_VALID_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+def _sanitize_name(name: str, *, kind: str) -> str:
+    """Reject any name that could escape the mailboxes directory.
+
+    Whitelist rather than blocklist — explicit safer than clever. Names
+    failing the check raise ``ValueError`` BEFORE any filesystem
+    operation runs (no path resolved, no file opened).
+
+    Per critic concern C1: ``recipient_name`` and ``team_name`` reach
+    this function from model-controlled inputs (SendMessage's ``to:``
+    field, TeamCreate's ``team_name``). The whitelist closes the
+    traversal vector.
+    """
+    if not isinstance(name, str) or not _VALID_NAME_RE.match(name):
+        raise ValueError(
+            f"Invalid {kind}: {name!r} "
+            "(allowed chars: A-Z, a-z, 0-9, _, -; max 64; min 1)."
+        )
+    return name
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+def get_mailboxes_root(workspace_root: Path, team_name: str) -> Path:
+    """Return ``<workspace_root>/.clawcodex/mailboxes/<team>/`` (created
+    if absent). ``team_name`` is sanitized before path composition."""
+    safe_team = _sanitize_name(team_name, kind="team_name")
+    root = workspace_root / ".clawcodex" / "mailboxes" / safe_team
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def get_inbox_path(
+    recipient_name: str, team_name: str, workspace_root: Path
+) -> Path:
+    """Return absolute path to ``<recipient>.jsonl`` for the given team.
+
+    Both names are sanitized via ``_sanitize_name``; either failing
+    the whitelist raises ``ValueError`` BEFORE any filesystem call.
+    """
+    safe_recipient = _sanitize_name(recipient_name, kind="recipient_name")
+    return get_mailboxes_root(workspace_root, team_name) / f"{safe_recipient}.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Envelope dataclass — chapter-canonical message shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TeammateMessage:
+    """One mailbox entry. Mirrors TS ``teammateMailbox.ts:TeammateMessage``."""
+
+    from_: str
+    text: str
+    timestamp: str  # ISO 8601
+    summary: str | None = None
+    color: str | None = None
+
+    def to_jsonable(self) -> dict[str, Any]:
+        """Serialize for disk. ``from_`` → ``from`` to match TS shape."""
+        out: dict[str, Any] = {
+            "from": self.from_,
+            "text": self.text,
+            "timestamp": self.timestamp,
+        }
+        if self.summary is not None:
+            out["summary"] = self.summary
+        if self.color is not None:
+            out["color"] = self.color
+        return out
+
+    @classmethod
+    def from_jsonable(cls, raw: dict[str, Any]) -> "TeammateMessage":
+        return cls(
+            from_=str(raw.get("from", "")),
+            text=str(raw.get("text", "")),
+            timestamp=str(raw.get("timestamp", "")),
+            summary=raw.get("summary"),
+            color=raw.get("color"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Write — atomic O_APPEND
+# ---------------------------------------------------------------------------
+
+
+def write_to_mailbox(
+    recipient_name: str,
+    message: TeammateMessage,
+    *,
+    team_name: str,
+    workspace_root: Path,
+) -> None:
+    """Append ``message`` to ``<recipient>.jsonl`` as one UTF-8 JSON line.
+
+    Atomic at line granularity (single ``os.write`` of the encoded
+    line on an ``O_APPEND`` fd). Synchronous — callers must NOT hold
+    the runtime_tasks RLock across this call (A6/C5 contract).
+    """
+    path = get_inbox_path(recipient_name, team_name, workspace_root)
+    line = json.dumps(message.to_jsonable(), ensure_ascii=False, separators=(",", ":")) + "\n"
+    encoded = line.encode("utf-8")
+
+    # ``O_APPEND`` makes every write atomic at the file-position level.
+    # ``O_CLOEXEC`` keeps the fd from leaking to bash subprocesses.
+    # ``0o600`` because mailboxes can carry sensitive plan content —
+    # readable by the user only.
+    fd = os.open(
+        str(path),
+        os.O_WRONLY | os.O_APPEND | os.O_CREAT | os.O_CLOEXEC,
+        0o600,
+    )
+    try:
+        view = memoryview(encoded)
+        while view:
+            written = os.write(fd, view)
+            if written <= 0:
+                raise OSError(f"mailbox write returned {written} for {path}")
+            view = view[written:]
+    finally:
+        os.close(fd)
+
+
+# ---------------------------------------------------------------------------
+# Read — tolerant of partial trailing lines
+# ---------------------------------------------------------------------------
+
+
+def read_mailbox(
+    recipient_name: str,
+    *,
+    team_name: str,
+    workspace_root: Path,
+) -> list[TeammateMessage]:
+    """Read every parseable message; skip blank/unparseable lines.
+
+    Returns an empty list if the file doesn't exist (a recipient with
+    no inbox file). Logs a single warning if any unparseable line is
+    encountered (writer-crashed-mid-write tolerance, mirroring the
+    transcript reader's behavior).
+
+    The ``log-once`` guard prevents a corrupt file from spamming the
+    log on every read.
+    """
+    path = get_inbox_path(recipient_name, team_name, workspace_root)
+    if not path.exists():
+        return []
+
+    messages: list[TeammateMessage] = []
+    logged_partial = False
+    try:
+        handle = open(path, "rb")
+    except OSError:
+        logger.exception("mailbox open failed for %s", path)
+        return []
+    try:
+        for raw_line in handle:
+            line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+            if not line:
+                continue
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                if not logged_partial:
+                    logger.warning(
+                        "skipping unparseable mailbox line in %s "
+                        "(file may have a trailing partial-write)",
+                        path,
+                    )
+                    logged_partial = True
+                continue
+            if not isinstance(parsed, dict):
+                continue
+            messages.append(TeammateMessage.from_jsonable(parsed))
+    finally:
+        handle.close()
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Envelope helpers — structured-protocol payloads
+# ---------------------------------------------------------------------------
+
+
+def make_iso_timestamp() -> str:
+    """Produce an ISO-8601 timestamp suitable for ``TeammateMessage.timestamp``."""
+    # ``time.time`` → ISO-8601 UTC with microsecond precision and a
+    # ``Z`` suffix. Avoids the timezone-aware datetime overhead.
+    import datetime as _dt
+    return _dt.datetime.fromtimestamp(time.time(), tz=_dt.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%S.%fZ"
+    )
+
+
+def create_shutdown_request_message(
+    *, request_id: str, from_: str, reason: str | None = None
+) -> dict[str, Any]:
+    """Mirror ``createShutdownRequestMessage`` from teammateMailbox.ts."""
+    out: dict[str, Any] = {
+        "type": "shutdown_request",
+        "request_id": request_id,
+        "from": from_,
+        "timestamp": make_iso_timestamp(),
+    }
+    if reason is not None:
+        out["reason"] = reason
+    return out
+
+
+def create_shutdown_approved_message(
+    *, request_id: str, from_: str
+) -> dict[str, Any]:
+    return {
+        "type": "shutdown_response",
+        "request_id": request_id,
+        "from": from_,
+        "approved": True,
+        "timestamp": make_iso_timestamp(),
+    }
+
+
+def create_shutdown_rejected_message(
+    *, request_id: str, from_: str, reason: str
+) -> dict[str, Any]:
+    return {
+        "type": "shutdown_response",
+        "request_id": request_id,
+        "from": from_,
+        "approved": False,
+        "reason": reason,
+        "timestamp": make_iso_timestamp(),
+    }
+
+
+def create_plan_approval_response_message(
+    *,
+    request_id: str,
+    approved: bool,
+    permission_mode: str,
+    from_: str,
+    feedback: str | None = None,
+) -> dict[str, Any]:
+    """Plan-approval response envelope (chapter §"Plan-mode lifecycle")."""
+    out: dict[str, Any] = {
+        "type": "plan_approval_response",
+        "request_id": request_id,
+        "approved": approved,
+        "permission_mode": permission_mode,
+        "from": from_,
+        "timestamp": make_iso_timestamp(),
+    }
+    if feedback is not None:
+        out["feedback"] = feedback
+    return out
+
+
+__all__ = [
+    "TeammateMessage",
+    "get_mailboxes_root",
+    "get_inbox_path",
+    "write_to_mailbox",
+    "read_mailbox",
+    "make_iso_timestamp",
+    "create_shutdown_request_message",
+    "create_shutdown_approved_message",
+    "create_shutdown_rejected_message",
+    "create_plan_approval_response_message",
+]

--- a/src/services/swarm/team_file.py
+++ b/src/services/swarm/team_file.py
@@ -1,0 +1,168 @@
+"""Team file schema + read/write/mutator helpers — Chunk F / WI-6.4.
+
+Mirrors the surface of ``typescript/src/utils/swarm/teamHelpers.ts``.
+Provides the typed `TeamFile` and `TeamMember` dataclasses plus the
+JSON read/write helpers that ``TeamCreate``, ``TeamDelete``, the
+mailbox poller, and ``is_team_lead`` all depend on.
+
+Schema (matches plan §11 WI-6.4):
+
+```json
+{
+  "team_name": "...",
+  "description": "...",
+  "lead_agent_id": "...",
+  "members": [
+    {"agent_id": "...", "name": "researcher", "color": "blue",
+     "tmux_pane_id": null, "backend_type": "in-process"}
+  ]
+}
+```
+
+The team file lives at ``<workspace_root>/.clawcodex/team.json`` (the
+existing path; pre-Chunk-F TeamCreate already wrote there). Reader is
+tolerant of missing ``members`` field (legacy teams pre-Chunk-F).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Literal
+
+BackendType = Literal["in-process", "tmux", "iterm2"]
+
+
+@dataclass(frozen=True)
+class TeamMember:
+    """One team-roster entry. Mirrors TS ``teamHelpers.ts:TeamMember``."""
+
+    agent_id: str
+    name: str
+    color: str | None = None
+    tmux_pane_id: str | None = None
+    backend_type: BackendType = "in-process"
+
+
+@dataclass(frozen=True)
+class TeamFile:
+    """Typed view of ``.clawcodex/team.json``.
+
+    Frozen because mutations always go through the explicit
+    ``add_member`` / ``remove_member`` helpers — they return a new
+    ``TeamFile`` instance which the caller writes back to disk via
+    ``write_team_file``.
+    """
+
+    team_name: str
+    lead_agent_id: str
+    description: str | None = None
+    members: tuple[TeamMember, ...] = field(default_factory=tuple)
+
+
+def get_team_file_path(workspace_root: Path) -> Path:
+    """Stable path for a workspace's team file."""
+    return workspace_root / ".clawcodex" / "team.json"
+
+
+def read_team_file(workspace_root: Path) -> TeamFile | None:
+    """Read and parse the team file. Returns ``None`` if absent.
+
+    Tolerant of legacy schemas that pre-date the ``members`` field
+    (Chunk-F migration); missing/empty ``members`` is treated as an
+    empty roster, not an error. Other parse failures (malformed
+    JSON) propagate so the caller can surface them rather than
+    silently treating them as "no team."
+    """
+    path = get_team_file_path(workspace_root)
+    if not path.exists():
+        return None
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        return None
+    members_raw = raw.get("members") or []
+    members: list[TeamMember] = []
+    if isinstance(members_raw, list):
+        for entry in members_raw:
+            if not isinstance(entry, dict):
+                continue
+            members.append(
+                TeamMember(
+                    agent_id=str(entry.get("agent_id", "")),
+                    name=str(entry.get("name", "")),
+                    color=entry.get("color"),
+                    tmux_pane_id=entry.get("tmux_pane_id"),
+                    backend_type=entry.get("backend_type", "in-process"),
+                )
+            )
+    return TeamFile(
+        team_name=str(raw.get("team_name", "")),
+        lead_agent_id=str(raw.get("lead_agent_id", "")),
+        description=raw.get("description"),
+        members=tuple(members),
+    )
+
+
+def write_team_file(team: TeamFile, workspace_root: Path) -> None:
+    """Serialize ``team`` to ``.clawcodex/team.json``. Creates parent
+    directory if needed; overwrites in place.
+
+    Synchronous — the file is small and the write is short. Per the
+    A6/C5 contract, callers should NOT hold the registry lock across
+    this call (it's filesystem IO).
+    """
+    path = get_team_file_path(workspace_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "team_name": team.team_name,
+        "description": team.description,
+        "lead_agent_id": team.lead_agent_id,
+        "members": [
+            {
+                "agent_id": m.agent_id,
+                "name": m.name,
+                "color": m.color,
+                "tmux_pane_id": m.tmux_pane_id,
+                "backend_type": m.backend_type,
+            }
+            for m in team.members
+        ],
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def add_member(team: TeamFile, member: TeamMember) -> TeamFile:
+    """Return a new TeamFile with ``member`` appended.
+
+    Idempotent on ``agent_id`` — a second add of the same agent_id
+    replaces the existing entry rather than duplicating it. Useful
+    for teammate re-registration (e.g. backend type changes).
+    """
+    filtered = tuple(m for m in team.members if m.agent_id != member.agent_id)
+    return replace(team, members=filtered + (member,))
+
+
+def remove_member(team: TeamFile, agent_id: str) -> TeamFile:
+    return replace(team, members=tuple(m for m in team.members if m.agent_id != agent_id))
+
+
+def find_member_by_name(team: TeamFile, name: str) -> TeamMember | None:
+    """Case-insensitive lookup; returns the first match or None."""
+    target = name.lower()
+    for m in team.members:
+        if m.name.lower() == target:
+            return m
+    return None
+
+
+__all__ = [
+    "BackendType",
+    "TeamMember",
+    "TeamFile",
+    "get_team_file_path",
+    "read_team_file",
+    "write_team_file",
+    "add_member",
+    "remove_member",
+    "find_member_by_name",
+]

--- a/src/services/swarm/team_membership.py
+++ b/src/services/swarm/team_membership.py
@@ -1,0 +1,46 @@
+"""Team-membership predicates — Chunk F / WI-6.4.
+
+Single source of truth for "is the active agent the team lead?" Used
+by SendMessage's plan-approval gate (sender side, Chunk F / WI-7.3),
+the mailbox poller's envelope verification (receiver side, per critic
+concern C3), and Phase 9's permission-forwarding bridge.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.tool_system.context import ToolContext
+
+
+def is_team_lead(context: "ToolContext") -> bool:
+    """True iff the active agent is the team lead.
+
+    Mirrors the gate at ``typescript/src/tools/SendMessageTool/SendMessageTool.ts:442``
+    and ``:487``. Compares ``context.agent_id`` against
+    ``context.team["lead_agent_id"]``. Returns False (does not raise)
+    when:
+
+    * No team is active on the context.
+    * No ``agent_id`` is set on the context.
+    * The team file lacks a ``lead_agent_id``.
+
+    **Callers MUST treat False as "not authorized," not "team
+    unavailable"** — the predicate intentionally collapses both into
+    False so authorization checks are straightforward (a not-team-lead
+    branch handles both safely; granting permission would be
+    catastrophic in either).
+    """
+    team = getattr(context, "team", None)
+    agent_id = getattr(context, "agent_id", None)
+    if team is None or not agent_id:
+        return False
+    if not isinstance(team, dict):
+        return False
+    lead_agent_id = team.get("lead_agent_id")
+    return bool(lead_agent_id) and agent_id == lead_agent_id
+
+
+__all__ = [
+    "is_team_lead",
+]

--- a/src/services/swarm/teammate.py
+++ b/src/services/swarm/teammate.py
@@ -16,11 +16,23 @@ logger = logging.getLogger(__name__)
 
 
 class TeammateStatus(str, Enum):
+    """Lifecycle states for a teammate.
+
+    Chapter-10 / Chunk F / WI-6.2 + assumption A3 (gap analysis
+    ambiguity #3): renamed ``CANCELLED → KILLED`` to match the
+    chapter's canonical 5-status vocabulary (``pending`` / ``running``
+    / ``completed`` / ``failed`` / ``killed``). Aliases the old name
+    so legacy callers don't break — the alias goes away in a follow-
+    up sweep.
+    """
     PENDING = "pending"
     RUNNING = "running"
     COMPLETED = "completed"
     FAILED = "failed"
-    CANCELLED = "cancelled"
+    KILLED = "killed"
+    # Back-compat alias — equal to KILLED. Removed when no callers
+    # reference TeammateStatus.KILLED. Don't add new uses.
+    CANCELLED = "killed"
 
 
 @dataclass
@@ -102,7 +114,7 @@ class TeammateManager:
         """Cancel a running teammate."""
         teammate = self._teammates.get(teammate_id)
         if teammate and teammate.is_active:
-            teammate.status = TeammateStatus.CANCELLED
+            teammate.status = TeammateStatus.KILLED
             teammate.completed_at = time.time()
 
     def get(self, teammate_id: str) -> Teammate | None:
@@ -116,7 +128,7 @@ class TeammateManager:
         count = 0
         for t in self._teammates.values():
             if t.is_active:
-                t.status = TeammateStatus.CANCELLED
+                t.status = TeammateStatus.KILLED
                 t.completed_at = time.time()
                 count += 1
         return count

--- a/src/tasks/in_process_teammate.py
+++ b/src/tasks/in_process_teammate.py
@@ -1,0 +1,377 @@
+"""``in_process_teammate`` task type — Chunk F / WI-6.2 + sub-WI-6.2.a.
+
+Mirrors ``typescript/src/tasks/InProcessTeammateTask/types.ts:22-77``.
+Implements the chapter's full state shape for in-process teammates
+(swarm peers running in the same Python process under
+``AsyncLocalStorage``-equivalent isolation) plus the two-level abort
+hook semantics.
+
+Per-gap-analysis-§5 reframe: this module is "rename-and-rewrite, not
+extend" relative to the existing ``services/swarm/teammate.py``. Only
+the status enum (post ``CANCELLED → KILLED`` rename) and the
+``TeammateConfig`` field shape carry forward; everything else is
+green-field. The legacy ``Teammate``/``TeammateManager`` are NOT
+deleted from this module — that's a separate teardown ticket — but
+all chapter-10 callers should reach for the typed state in this
+module instead.
+
+**Sub-WI-6.2.a — two-level abort hook semantics:**
+
+Two ``asyncio.Event`` fields on the state, with two distinct
+exception classes raised when each fires:
+
+* ``current_work_abort_event`` set → ``CurrentWorkAbortedError`` →
+  outer lifecycle CATCHES, clears the event, loops to next pending
+  message (the "redirect" pattern).
+* ``abort_event`` set → ``TeammateAbortedError`` → outer lifecycle
+  does NOT catch; the teammate exits ("kill" pattern).
+
+Both subclass ``asyncio.CancelledError`` so existing cancellation
+paths (e.g. ``asyncio.Task.cancel()`` semantics) keep working without
+special-casing.
+
+**Note — Python 3.11+ ExceptionGroup interaction (flag F2):** the
+catch clauses use specific subclass names (``except CurrentWorkAbortedError:``)
+which is correct for the current flat-await shape. If the run loop
+is later wrapped in ``asyncio.TaskGroup``, the catches need
+``except* CurrentWorkAbortedError`` (PEP 654 syntax). Today's run
+loop is a flat await; flagged here so a future TaskGroup refactor
+remembers to update.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field, replace
+from typing import Any, Awaitable, Callable, Literal, TYPE_CHECKING, TypeVar
+
+from src.tasks_core import TaskStateBase, is_terminal_task_status
+
+if TYPE_CHECKING:
+    from src.task_registry import RuntimeTaskRegistry
+
+# ---------------------------------------------------------------------------
+# Two-level abort exception hierarchy (sub-WI-6.2.a)
+# ---------------------------------------------------------------------------
+
+
+class TeammateAbortedError(asyncio.CancelledError):
+    """Raised when ``abort_event`` fires.
+
+    The outer teammate lifecycle does NOT catch this — it propagates
+    up and unwinds the lifecycle. The teammate exits.
+
+    Subclassing ``asyncio.CancelledError`` means standard cancellation
+    paths (``asyncio.Task.cancel()`` semantics, ``await asyncio.shield``)
+    treat it correctly without special handling.
+    """
+
+
+class CurrentWorkAbortedError(asyncio.CancelledError):
+    """Raised when ``current_work_abort_event`` fires.
+
+    The outer teammate lifecycle CATCHES this, clears the event, and
+    loops to pick up the next pending message — the "redirect" pattern.
+    The teammate continues running.
+    """
+
+
+# ---------------------------------------------------------------------------
+# TeammateIdentity — chapter-10 identity record
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TeammateIdentity:
+    """Stable identity for an in-process teammate.
+
+    Mirrors TS ``InProcessTeammateTask/types.ts:13-20``. Values are
+    plain data (no live handles) so the identity can be serialized to
+    AppState and survive process restarts. Permission-mode and
+    plan-mode-required policy live here because they're set at spawn
+    time and don't change over the teammate's lifetime.
+    """
+
+    agent_id: str  # e.g. "researcher@my-team"
+    agent_name: str  # e.g. "researcher"
+    team_name: str
+    parent_session_id: str = ""
+    color: str | None = None
+    plan_mode_required: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Message-cap helper (chapter §"In-Process Teammates" — whale-session OOM guard)
+# ---------------------------------------------------------------------------
+
+# Per chapter §"In-Process Teammates": cap the UI-facing
+# ``messages`` snapshot at 50 entries. The actual conversation
+# continues with full history on disk; this cap only bounds the
+# AppState mirror that the zoomed-transcript view reads. BQ analysis
+# (round 9, 2026-03-20) showed ~20MB RSS per agent at 500+ turns;
+# whale session 9a990de8 reached 36.8GB across 292 agents in 2 minutes.
+TEAMMATE_MESSAGES_UI_CAP: int = 50
+
+T = TypeVar("T")
+
+
+def append_capped_message(prev: list[T] | None, item: T) -> list[T]:
+    """Append ``item`` to ``prev``, capping the result at
+    ``TEAMMATE_MESSAGES_UI_CAP`` entries by dropping the oldest.
+
+    Always returns a new list — callers passing a frozen / shared
+    list don't have to worry about mutation.
+    """
+    if prev is None or len(prev) == 0:
+        return [item]
+    if len(prev) >= TEAMMATE_MESSAGES_UI_CAP:
+        return list(prev[-(TEAMMATE_MESSAGES_UI_CAP - 1):]) + [item]
+    return list(prev) + [item]
+
+
+# ---------------------------------------------------------------------------
+# InProcessTeammateTaskState — chapter's full field set
+# ---------------------------------------------------------------------------
+
+
+@dataclass(kw_only=True)
+class InProcessTeammateTaskState(TaskStateBase):
+    """Runtime state for a single in-process swarm teammate.
+
+    Mirrors ``typescript/src/tasks/InProcessTeammateTask/types.ts:22-77``.
+    Field accounting matches the chapter:
+
+    * ``identity`` — the stable ``TeammateIdentity`` record.
+    * ``prompt`` / ``model`` / ``selected_agent`` — spawn inputs.
+    * ``abort_event`` / ``current_work_abort_event`` — two-level abort
+      (sub-WI-6.2.a). See exception classes above.
+    * ``awaiting_plan_approval`` — flag flipped True when the
+      teammate submits a plan via ExitPlanMode; the leader's
+      ``plan_approval_response`` clears it.
+    * ``permission_mode`` — per-teammate permission mode (cycled
+      independently of the leader).
+    * ``messages`` — UI-facing conversation snapshot, capped at
+      ``TEAMMATE_MESSAGES_UI_CAP`` via ``append_capped_message``.
+    * ``in_progress_tool_use_ids`` — tool_use_ids currently being
+      executed (used for animation in transcript view).
+    * ``pending_user_messages`` — inbox for user-typed messages
+      delivered when viewing the teammate's transcript.
+    * ``is_idle`` — work-stealing flag; an idle teammate consumes no
+      tokens and is waiting for the next message.
+    * ``shutdown_requested`` — cooperative-termination flag set by
+      the leader's ``shutdown_request``; the teammate winds down at
+      a natural stopping point.
+    * ``on_idle_callbacks`` — runtime-only hooks for orchestration
+      patterns (e.g. "wait for all teammates to idle").
+    * ``progress`` / ``last_reported_*`` — same shape as
+      LocalAgentTaskState's progress fields.
+    """
+
+    type: Literal["in_process_teammate"] = "in_process_teammate"  # type: ignore[assignment]
+    identity: TeammateIdentity = field(
+        default_factory=lambda: TeammateIdentity(
+            agent_id="", agent_name="", team_name="",
+        )
+    )
+    prompt: str = ""
+    model: str | None = None
+    selected_agent: Any = None  # AgentDefinition; loose to avoid cycles
+    abort_event: asyncio.Event | None = field(default=None, repr=False, compare=False)
+    current_work_abort_event: asyncio.Event | None = field(
+        default=None, repr=False, compare=False
+    )
+    awaiting_plan_approval: bool = False
+    # TODO (Phase 9): tighten to ``permissions.types.PermissionMode``
+    # Literal once the permission-forwarding bridge lands. Loose-typed
+    # for now so the chapter-10 task layer doesn't pull in the
+    # permissions module's typing — flagged per critic Phase-6 N2.
+    permission_mode: str = "default"
+    error: str | None = None
+    result: Any = None
+    progress: Any = None  # AgentProgress; loose to avoid cycles
+    messages: list[Any] = field(default_factory=list)
+    in_progress_tool_use_ids: set[str] = field(default_factory=set)
+    pending_user_messages: list[str] = field(default_factory=list)
+    is_idle: bool = False
+    shutdown_requested: bool = False
+    on_idle_callbacks: list[Callable[[], None]] = field(
+        default_factory=list, repr=False, compare=False
+    )
+    last_reported_tool_count: int = 0
+    last_reported_token_count: int = 0
+
+
+def is_in_process_teammate_task(state: Any) -> bool:
+    return isinstance(state, InProcessTeammateTaskState)
+
+
+# ---------------------------------------------------------------------------
+# Two-level abort hook (sub-WI-6.2.a)
+# ---------------------------------------------------------------------------
+
+
+def check_abort_events(state: InProcessTeammateTaskState) -> None:
+    """Raise the appropriate exception if either abort event is set.
+
+    Called by the teammate's run loop between yield points. The
+    chapter-correct ordering: ``abort_event`` (kill, stronger intent)
+    is checked FIRST so a "both events fired in the same yield"
+    scenario surfaces ``TeammateAbortedError`` rather than
+    ``CurrentWorkAbortedError``. The kill wins.
+
+    No-op when neither event is set (or when the event fields are
+    None — defensive for state objects constructed without them).
+    """
+    abort = state.abort_event
+    if abort is not None and abort.is_set():
+        raise TeammateAbortedError(
+            f"teammate {state.identity.agent_id!r} kill event fired"
+        )
+    current_work = state.current_work_abort_event
+    if current_work is not None and current_work.is_set():
+        raise CurrentWorkAbortedError(
+            f"teammate {state.identity.agent_id!r} current-work redirect"
+        )
+
+
+async def run_with_two_level_abort(
+    coro_factory: Callable[[], Awaitable[T]],
+    *,
+    state_provider: Callable[[], InProcessTeammateTaskState | None],
+) -> T:
+    """Wrap a coroutine with the two-level abort policy.
+
+    Polls the registry-provided state via ``state_provider`` between
+    awaits — the ``current_work_abort_event`` and ``abort_event``
+    references can change as the teammate is reset / re-spawned, so
+    we resolve them fresh on each tick rather than capturing them.
+
+    Returns the wrapped coroutine's result on normal completion.
+    Raises:
+    * ``TeammateAbortedError`` if ``abort_event`` fires (caller MUST
+      NOT catch — this is the kill signal).
+    * ``CurrentWorkAbortedError`` if ``current_work_abort_event``
+      fires (caller's outer loop is expected to catch and continue).
+
+    This is a thin helper for unit-testable two-level-abort behavior.
+    Production integration (the actual run_agent loop wiring) lands
+    when the in-process teammate spawn path goes live in Phase 7.
+    """
+    task = asyncio.ensure_future(coro_factory())
+    try:
+        while not task.done():
+            state = state_provider()
+            if state is not None:
+                # ``check_abort_events`` raises before we wait again —
+                # callers see the right exception class on the next
+                # ``await`` boundary.
+                try:
+                    check_abort_events(state)
+                except (TeammateAbortedError, CurrentWorkAbortedError):
+                    task.cancel()
+                    # Drain the cancellation; ignore the resulting
+                    # CancelledError — we'll re-raise our typed
+                    # variant below.
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
+                    raise
+            # Tick interval — small enough to feel responsive,
+            # large enough not to burn CPU.
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=0.05)
+            except asyncio.TimeoutError:
+                continue  # task not done yet; re-check abort events
+        return task.result()
+    finally:
+        if not task.done():
+            task.cancel()
+
+
+def outer_lifecycle_should_catch(exc: BaseException) -> bool:
+    """Helper for the outer-loop catch policy.
+
+    Returns True for ``CurrentWorkAbortedError`` (the teammate should
+    redirect to the next pending message) and False for
+    ``TeammateAbortedError`` (the teammate should exit). Plain
+    ``asyncio.CancelledError`` returns False — the kill path; the
+    teammate should respect the cancel.
+
+    Lets the outer loop in the eventual run_agent integration look
+    like:
+
+    ```python
+    while not state.shutdown_requested:
+        try:
+            await _run_one_turn(...)
+        except (TeammateAbortedError, CurrentWorkAbortedError) as exc:
+            if outer_lifecycle_should_catch(exc):
+                # Clear the event and loop again.
+                state.current_work_abort_event.clear()
+                continue
+            raise
+    ```
+    """
+    return isinstance(exc, CurrentWorkAbortedError)
+
+
+# ---------------------------------------------------------------------------
+# Task adapter — kill via the two-level signal
+# ---------------------------------------------------------------------------
+
+
+class InProcessTeammateTask:
+    """``Task`` adapter for ``in_process_teammate`` entries.
+
+    Polymorphic dispatch target for ``stop_task`` (Phase 5). Setting
+    ``abort_event`` propagates the kill signal; the teammate's run
+    loop sees ``TeammateAbortedError`` at its next yield and
+    unwinds the lifecycle.
+    """
+
+    name: str = "InProcessTeammateTask"
+    type: Literal["in_process_teammate"] = "in_process_teammate"
+
+    async def kill(
+        self, task_id: str, registry: "RuntimeTaskRegistry"
+    ) -> None:
+        aborted_event: asyncio.Event | None = None
+
+        def _kill(prev: TaskStateBase) -> TaskStateBase:
+            nonlocal aborted_event
+            if not isinstance(prev, InProcessTeammateTaskState):
+                return prev
+            if is_terminal_task_status(prev.status):
+                return prev
+            aborted_event = prev.abort_event
+            return replace(prev, status="killed")
+
+        registry.update(task_id, _kill)
+        # Set the event OUTSIDE the registry lock — same defense-in-depth
+        # pattern as kill_async_agent. asyncio.Event is thread-safe for
+        # ``set()`` (it dispatches via the loop's call_soon_threadsafe
+        # internally), but we don't want a misbehaving subclass to
+        # deadlock the registry.
+        if aborted_event is not None:
+            try:
+                aborted_event.set()
+            except Exception:
+                import logging
+                logging.getLogger(__name__).exception(
+                    "failed to set abort event for killed teammate %s", task_id
+                )
+
+
+__all__ = [
+    "TeammateAbortedError",
+    "CurrentWorkAbortedError",
+    "TeammateIdentity",
+    "TEAMMATE_MESSAGES_UI_CAP",
+    "append_capped_message",
+    "InProcessTeammateTaskState",
+    "InProcessTeammateTask",
+    "is_in_process_teammate_task",
+    "check_abort_events",
+    "run_with_two_level_abort",
+    "outer_lifecycle_should_catch",
+]

--- a/src/tool_system/tools/__init__.py
+++ b/src/tool_system/tools/__init__.py
@@ -18,6 +18,7 @@ from .mcp_resources import ListMcpResourcesTool, ReadMcpResourceTool
 from .misc import ClipboardReadTool, ClipboardWriteTool, StatusTool
 from .plan_mode import EnterPlanModeTool, ExitPlanModeTool
 from .read import ReadTool
+from .send_message import SendMessageTool
 from .send_user_message import SendUserMessageTool
 from .skill import SkillTool
 from .sleep import SleepTool
@@ -61,6 +62,7 @@ ALL_STATIC_TOOLS: list[Tool] = [
     NotebookEditTool,
     ReadMcpResourceTool,
     ReadTool,
+    SendMessageTool,
     SendUserMessageTool,
     SkillTool,
     SleepTool,
@@ -104,6 +106,7 @@ __all__ = [
     "NotebookEditTool",
     "ReadMcpResourceTool",
     "ReadTool",
+    "SendMessageTool",
     "SendUserMessageTool",
     "SkillTool",
     "SleepTool",

--- a/src/tool_system/tools/send_message.py
+++ b/src/tool_system/tools/send_message.py
@@ -1,0 +1,545 @@
+"""SendMessage tool — Chunk F / WI-7.1 + WI-7.2 + WI-7.3.
+
+Mirrors ``typescript/src/tools/SendMessageTool/SendMessageTool.ts``.
+The universal communication primitive for inter-agent messaging:
+plain text from leader → teammate, structured protocol envelopes
+(shutdown, plan-approval), and broadcasts.
+
+Routing dispatch chain (matches TS dispatch order — preserved as
+real branches even for the out-of-scope schemes so a future addition
+is a localized body change, not a re-ordering):
+
+1. ``bridge:<session-id>`` — cross-machine via Anthropic's Remote
+   Control relay. **NotImplementedError stub** (out of scope per
+   ambiguity #5).
+2. ``uds:<socket-path>`` — local IPC via Unix-domain socket.
+   **NotImplementedError stub** (out of scope).
+3. **In-process** — registry first, raw agent_id fallback. If the
+   target is a running ``local_agent``, queue the message via
+   ``queue_pending_message``; if terminal, attempt
+   ``resume_agent_background`` (race-guarded).
+4. **Team mailbox** — when team context is active and the recipient
+   isn't an in-process agent, write a JSONL line to
+   ``<team>/<recipient>.jsonl``. ``"*"`` → broadcast to every team
+   member except the sender.
+5. **Error** — recipient not found in any branch.
+
+Structured protocols
+--------------------
+
+The ``message`` field is a union: plain text (``str``) or one of
+``shutdown_request`` / ``shutdown_response`` /
+``plan_approval_response``. The latter carries sender-side
+authorization (``is_team_lead``) for plan approvals; receiver-side
+verification (envelope ``from`` matches ``lead_agent_id``) is the
+mailbox poller's job — see ``src/services/swarm/mailbox_poller.py``.
+
+Defense-in-depth note: the sender-side ``is_team_lead`` gate refuses
+``plan_approval_response`` from non-leader callers. The receiver-side
+``from`` check (in the poller) refuses envelopes that claim to be
+from the leader but were written through some other path — covers
+the case where a future malicious / buggy code path bypasses the
+SendMessage gate entirely.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from src.services.swarm.mailbox import (
+    TeammateMessage,
+    create_plan_approval_response_message,
+    create_shutdown_approved_message,
+    create_shutdown_rejected_message,
+    create_shutdown_request_message,
+    make_iso_timestamp,
+    write_to_mailbox,
+)
+from src.services.swarm.team_file import TeamFile, find_member_by_name, read_team_file
+from src.services.swarm.team_membership import is_team_lead
+from src.utils.peer_address import parse_address
+
+from ..build_tool import Tool, build_tool
+from ..context import ToolContext
+from ..errors import ToolInputError
+from ..protocol import ToolResult
+
+logger = logging.getLogger(__name__)
+
+
+SEND_MESSAGE_TOOL_NAME = "SendMessage"
+
+
+SEND_MESSAGE_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["to", "message"],
+    "properties": {
+        "to": {
+            "type": "string",
+            "description": (
+                "Recipient: a teammate name, '*' for broadcast, "
+                "'bridge:<session-id>' for a Remote Control peer (out of "
+                "scope in this build), or 'uds:<socket-path>' for a "
+                "local UDS peer (out of scope in this build)."
+            ),
+        },
+        "summary": {
+            "type": "string",
+            "description": (
+                "5-10 word UI preview shown in chat. Required for plain "
+                "string messages; ignored for structured protocols."
+            ),
+        },
+        "message": {
+            "description": (
+                "Plain text or one of the structured protocols: "
+                "shutdown_request / shutdown_response / "
+                "plan_approval_response. Structured protocols use a "
+                "discriminated union via the 'type' field."
+            ),
+            # JSON-schema oneOf: a string, OR an object with a 'type'
+            # discriminator. We don't enforce the union shape strictly
+            # at the schema level (Python's json-schema validator
+            # would complain about other fields); validation happens
+            # in ``_send_message_call`` against the runtime shape.
+            "oneOf": [
+                {"type": "string"},
+                {"type": "object", "required": ["type"]},
+            ],
+        },
+    },
+}
+
+
+# Structured-protocol type discriminators we accept.
+_VALID_STRUCTURED_TYPES = {
+    "shutdown_request",
+    "shutdown_response",
+    "plan_approval_response",
+}
+
+
+def _ok(message: str, **extra: Any) -> ToolResult:
+    out: dict[str, Any] = {"success": True, "message": message}
+    out.update(extra)
+    return ToolResult(name=SEND_MESSAGE_TOOL_NAME, output=out)
+
+
+def _err(message: str, **extra: Any) -> ToolResult:
+    out: dict[str, Any] = {"success": False, "message": message}
+    out.update(extra)
+    return ToolResult(name=SEND_MESSAGE_TOOL_NAME, output=out, is_error=True)
+
+
+def _resolve_in_process(
+    name_or_id: str, context: ToolContext
+) -> tuple[str, Any] | None:
+    """Resolve ``to:`` against the in-process registries.
+
+    Returns ``(agent_id, state_or_None)`` if a candidate is found
+    (registry hit OR raw agent_id matches a runtime_tasks entry),
+    None if neither registry knows the target. The caller decides
+    whether to queue (running) or resume (terminal).
+    """
+    # Step 1 — agent name registry first.
+    by_name = context.agent_name_registry.get(name_or_id)
+    if by_name is not None:
+        return by_name, context.runtime_tasks.get(by_name)
+    # Step 2 — raw agent_id fallback (model may pass the id directly).
+    by_id = context.runtime_tasks.get(name_or_id)
+    if by_id is not None:
+        return name_or_id, by_id
+    return None
+
+
+async def _route_in_process(
+    *, to: str, message_text: str, context: ToolContext
+) -> ToolResult | None:
+    """Try to route as an in-process agent. Returns None if the target
+    isn't an in-process agent (caller falls through to mailbox)."""
+    from src.tasks.local_agent import (
+        LocalAgentTaskState,
+        queue_pending_message,
+    )
+    from src.tasks_core import is_terminal_task_status
+
+    resolved = _resolve_in_process(to, context)
+    if resolved is None:
+        return None
+    agent_id, state = resolved
+
+    if state is None:
+        # Name was bound but the runtime entry was evicted. Treat as
+        # not-an-in-process-agent so the mailbox branch can handle
+        # it (or the error branch if no team is active).
+        return None
+
+    if not isinstance(state, LocalAgentTaskState):
+        # Some other task type — let mailbox/error handle it.
+        return None
+
+    if not is_terminal_task_status(state.status):
+        # Running — queue and return.
+        if not queue_pending_message(agent_id, message_text, context.runtime_tasks):
+            return _err(
+                f"Failed to queue message for {to!r} (task may have "
+                f"transitioned to terminal)."
+            )
+        return _ok(
+            f"Message queued for delivery to {to!r} at its next tool round.",
+            agent_id=agent_id,
+        )
+
+    # Terminal — attempt auto-resume. Race-guarded by
+    # ``resume_agent_background``: only one concurrent caller wins.
+    from src.agent.resume_agent import resume_agent_background
+
+    result = await resume_agent_background(
+        agent_id=agent_id, prompt=message_text, context=context,
+    )
+    if result.resumed:
+        return _ok(
+            f"Agent {to!r} was {state.status!r}; resumed it in the "
+            f"background with your message.",
+            agent_id=agent_id,
+            output_file=result.output_file,
+            replayed_messages=result.replayed_message_count,
+        )
+    # Lost the race or unable to resume — queue onto whatever the
+    # winner registered (or report an error if the agent state moved
+    # in an unexpected way).
+    queued = queue_pending_message(agent_id, message_text, context.runtime_tasks)
+    if queued:
+        return _ok(
+            f"Agent {to!r} is being resumed by another caller; your "
+            f"message was queued for delivery at its next tool round.",
+            agent_id=agent_id,
+        )
+    return _err(
+        f"Agent {to!r} could not be resumed: {result.reason}",
+        agent_id=agent_id,
+    )
+
+
+async def _route_team_mailbox(
+    *, to: str, message_text: str, summary: str | None, context: ToolContext
+) -> ToolResult | None:
+    """Mailbox routing — write a JSONL line to the recipient's inbox.
+
+    Returns None if no team context is active (caller falls through
+    to the error branch). Also handles the ``"*"`` broadcast.
+    """
+    if context.team is None:
+        return None
+    team_file = read_team_file(context.workspace_root)
+    if team_file is None:
+        return None
+    team_name = team_file.team_name
+    sender_name = context.team.get("sender_name") or "team-lead"
+
+    if to == "*":
+        return _broadcast(
+            team_file=team_file, sender_name=sender_name,
+            message_text=message_text, summary=summary, context=context,
+        )
+
+    # Sanity: confirm the recipient is on the team roster (defense-in-
+    # depth — the model could pass an arbitrary string). If the team
+    # file has no members yet (Chunk-F TeamCreate writes []),
+    # fall through to the path-sanitized write — the recipient's
+    # inbox file is created on demand.
+    if team_file.members and find_member_by_name(team_file, to) is None:
+        return _err(
+            f"Recipient {to!r} is not on team {team_name!r}.",
+            recipient=to,
+        )
+
+    msg = TeammateMessage(
+        from_=sender_name, text=message_text, timestamp=make_iso_timestamp(),
+        summary=summary,
+    )
+    try:
+        write_to_mailbox(
+            to, msg, team_name=team_name, workspace_root=context.workspace_root,
+        )
+    except ValueError as exc:
+        return _err(f"Invalid recipient: {exc}")
+    return _ok(
+        f"Message delivered to mailbox of {to!r}.",
+        recipient=to,
+    )
+
+
+def _broadcast(
+    *,
+    team_file: TeamFile,
+    sender_name: str,
+    message_text: str,
+    summary: str | None,
+    context: ToolContext,
+) -> ToolResult:
+    """``to: "*"`` — fan out to every team member except the sender.
+
+    Per chapter §"The Mailbox": no fan-out optimization, each
+    recipient gets a separate ``write_to_mailbox`` call. At swarm
+    scale (3-8 members) this is trivially cheap.
+    """
+    delivered: list[str] = []
+    for member in team_file.members:
+        if member.name.lower() == sender_name.lower():
+            continue  # don't echo to self
+        msg = TeammateMessage(
+            from_=sender_name, text=message_text,
+            timestamp=make_iso_timestamp(), summary=summary,
+        )
+        try:
+            write_to_mailbox(
+                member.name, msg,
+                team_name=team_file.team_name,
+                workspace_root=context.workspace_root,
+            )
+            delivered.append(member.name)
+        except ValueError:
+            # Skip malformed names — shouldn't happen with TeamCreate-
+            # written rosters but defensive.
+            continue
+    return _ok(
+        f"Broadcast delivered to {len(delivered)} teammate(s).",
+        recipients=delivered,
+    )
+
+
+def _structured_message_to_envelope(
+    *,
+    message_obj: dict[str, Any],
+    sender_name: str,
+    context: ToolContext,
+) -> tuple[dict[str, Any], str]:
+    """Build a structured-protocol envelope and identify the recipient
+    (which may differ from ``to`` for shutdown_response — those
+    always go to the team lead by name).
+
+    Returns ``(envelope_dict, recipient_name)``. Raises
+    ``ToolInputError`` for invalid / unauthorized payloads.
+    """
+    msg_type = message_obj.get("type")
+    request_id = str(message_obj.get("request_id") or "")
+    if msg_type == "shutdown_request":
+        return (
+            create_shutdown_request_message(
+                request_id=request_id, from_=sender_name,
+                reason=message_obj.get("reason"),
+            ),
+            "",  # caller passes the original ``to``
+        )
+    if msg_type == "shutdown_response":
+        approve = bool(message_obj.get("approve"))
+        if approve:
+            return (
+                create_shutdown_approved_message(
+                    request_id=request_id, from_=sender_name,
+                ),
+                "",  # caller passes the original ``to`` (typically team-lead)
+            )
+        reason = message_obj.get("reason")
+        if not isinstance(reason, str) or not reason.strip():
+            raise ToolInputError(
+                "shutdown_response with approve=False requires a reason."
+            )
+        return (
+            create_shutdown_rejected_message(
+                request_id=request_id, from_=sender_name, reason=reason,
+            ),
+            "",
+        )
+    if msg_type == "plan_approval_response":
+        # Sender-side authorization gate — only team-lead may issue
+        # plan approvals (chapter §"Plan-mode lifecycle"; refactoring-
+        # plan critic concern C3 sender-side check).
+        if not is_team_lead(context):
+            raise ToolInputError(
+                "plan_approval_response can only be sent by the team lead."
+            )
+        approve = bool(message_obj.get("approve"))
+        permission_mode = str(
+            message_obj.get("permission_mode") or "default"
+        )
+        feedback = message_obj.get("feedback")
+        if feedback is not None and not isinstance(feedback, str):
+            raise ToolInputError("plan_approval_response.feedback must be a string.")
+        return (
+            create_plan_approval_response_message(
+                request_id=request_id, approved=approve,
+                permission_mode=permission_mode, from_=sender_name,
+                feedback=feedback,
+            ),
+            "",
+        )
+    raise ToolInputError(
+        f"Unknown structured-protocol type: {msg_type!r}. "
+        f"Expected one of: {sorted(_VALID_STRUCTURED_TYPES)}."
+    )
+
+
+async def _send_message_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
+    """SendMessage entrypoint — input parse, then dispatch.
+
+    Dispatch order (preserved across all branches even when some are
+    out-of-scope stubs — the parity guarantee is that adding a future
+    body to bridge:/uds: is a body change, not a re-ordering):
+
+    1. ``bridge:<session-id>`` → ``NotImplementedError`` stub.
+    2. ``uds:<socket-path>`` → ``NotImplementedError`` stub.
+    3. In-process (name registry + runtime_tasks fallback).
+    4. Team mailbox (named recipient or ``"*"`` broadcast).
+    5. Error: recipient not found.
+    """
+    to = tool_input.get("to")
+    if not isinstance(to, str) or not to.strip():
+        raise ToolInputError("'to' is required and must be a non-empty string.")
+    to = to.strip()
+
+    raw_message = tool_input.get("message")
+    if raw_message is None:
+        raise ToolInputError("'message' is required.")
+
+    summary = tool_input.get("summary")
+    if summary is not None and not isinstance(summary, str):
+        raise ToolInputError("'summary' must be a string when provided.")
+
+    # ``to`` validation: TS rejects '@' (the chapter has one team per
+    # session, no fully-qualified addressing).
+    if "@" in to and not to.startswith(("bridge:", "uds:")):
+        raise ToolInputError(
+            "'to' must be a bare teammate name or '*' — no '@' addressing."
+        )
+
+    addr = parse_address(to)
+
+    # Branch 1 — bridge: stub.
+    if addr.scheme == "bridge":
+        raise NotImplementedError(
+            f"bridge: addressing is not supported in this build "
+            f"(feature('UDS_INBOX') is off-by-default upstream; "
+            f"target was {addr.target!r})."
+        )
+
+    # Branch 2 — uds: stub.
+    if addr.scheme == "uds":
+        raise NotImplementedError(
+            f"uds: addressing is not supported in this build "
+            f"(feature('UDS_INBOX') is off-by-default upstream; "
+            f"target was {addr.target!r})."
+        )
+
+    # Determine sender name — the team config's ``sender_name`` if
+    # set, else the agent's id. Plain leader uses 'team-lead'.
+    sender_name = "team-lead"
+    if context.team is not None:
+        sender_name = context.team.get("sender_name") or sender_name
+
+    # Resolve plain-text vs structured payload.
+    if isinstance(raw_message, str):
+        # Plain text path — Branches 3, 4, or 5.
+        message_text = raw_message
+        if not summary and to != "*":
+            # Summary is required for plain-text messages per TS
+            # validation; broadcast accepts no-summary because the UI
+            # surfaces a generic broadcast indicator.
+            raise ToolInputError(
+                "'summary' is required for plain-text messages."
+            )
+
+        # Branch 3 — in-process.
+        if to != "*":
+            in_process_result = await _route_in_process(
+                to=to, message_text=message_text, context=context,
+            )
+            if in_process_result is not None:
+                return in_process_result
+
+        # Branch 4 — team mailbox / broadcast.
+        mailbox_result = await _route_team_mailbox(
+            to=to, message_text=message_text, summary=summary,
+            context=context,
+        )
+        if mailbox_result is not None:
+            return mailbox_result
+
+        # Branch 5 — not found.
+        return _err(
+            f"Recipient {to!r} not found (no in-process agent with that "
+            f"name/id; no team context to mailbox into)."
+        )
+
+    if not isinstance(raw_message, dict):
+        raise ToolInputError(
+            "'message' must be a string or a structured-protocol object."
+        )
+
+    # Structured-protocol path — always routes via mailbox (no
+    # in-process queue for protocol messages; the mailbox poller
+    # translates them back into teammate state changes).
+    envelope, _ = _structured_message_to_envelope(
+        message_obj=raw_message, sender_name=sender_name, context=context,
+    )
+    if context.team is None:
+        raise ToolInputError(
+            "structured-protocol messages require an active team context."
+        )
+    team_file = read_team_file(context.workspace_root)
+    if team_file is None:
+        raise ToolInputError(
+            "structured-protocol messages require a team file; "
+            "TeamCreate hasn't run."
+        )
+
+    import json as _json
+    msg = TeammateMessage(
+        from_=sender_name,
+        text=_json.dumps(envelope, ensure_ascii=False),
+        timestamp=make_iso_timestamp(),
+    )
+    try:
+        write_to_mailbox(
+            to, msg, team_name=team_file.team_name,
+            workspace_root=context.workspace_root,
+        )
+    except ValueError as exc:
+        return _err(f"Invalid recipient: {exc}")
+    return _ok(
+        f"Structured {raw_message.get('type')!r} envelope delivered to "
+        f"mailbox of {to!r}.",
+        recipient=to, envelope_type=raw_message.get("type"),
+    )
+
+
+SendMessageTool: Tool = build_tool(
+    name=SEND_MESSAGE_TOOL_NAME,
+    input_schema=SEND_MESSAGE_INPUT_SCHEMA,
+    call=_send_message_call,
+    prompt=(
+        "Send a message to a teammate, a remote peer, or broadcast to "
+        "the team. The 'to' field accepts a teammate name, '*' for "
+        "broadcast, or a 'bridge:'/'uds:' prefix for cross-session peers. "
+        "The 'message' field is plain text or a structured protocol "
+        "(shutdown_request, shutdown_response, plan_approval_response)."
+    ),
+    description="Send a message to a teammate / peer / team.",
+    strict=False,  # ``message`` is a union, can't strict-validate via JSON Schema
+    max_result_size_chars=2000,
+    is_read_only=lambda _input: False,
+    # ``is_concurrency_safe`` deliberately NOT overridden — defaults to
+    # False to match the parity snapshot. SendMessage's registry +
+    # mailbox writes are thread-safe (per A6/C5), but TS doesn't
+    # declare the tool as concurrency-safe either; mirror that until
+    # there's a demonstrated need.
+)
+
+
+__all__ = [
+    "SEND_MESSAGE_TOOL_NAME",
+    "SEND_MESSAGE_INPUT_SCHEMA",
+    "SendMessageTool",
+]

--- a/src/tool_system/tools/team.py
+++ b/src/tool_system/tools/team.py
@@ -24,7 +24,18 @@ def _team_create_call(tool_input: dict[str, Any], context: ToolContext) -> ToolR
     lead_agent_id = uuid.uuid4().hex[:12]
     team_file = context.workspace_root / ".clawcodex" / "team.json"
     team_file.parent.mkdir(parents=True, exist_ok=True)
-    team = {"team_name": team_name, "description": description, "agent_type": agent_type, "lead_agent_id": lead_agent_id}
+    # Chapter-10 / Chunk F / WI-6.4: schema includes ``members: []`` from
+    # day one. TeammateInit (future Phase-7 work) appends entries when
+    # in-process teammates spawn. Keeping the empty list explicit makes
+    # the team-file parser's "missing members" tolerance defensive
+    # rather than load-bearing.
+    team = {
+        "team_name": team_name,
+        "description": description,
+        "agent_type": agent_type,
+        "lead_agent_id": lead_agent_id,
+        "members": [],
+    }
     team_file.write_text(json.dumps(team, ensure_ascii=False, indent=2), encoding="utf-8")
     context.team = team
     return ToolResult(

--- a/src/utils/peer_address.py
+++ b/src/utils/peer_address.py
@@ -1,0 +1,61 @@
+"""Peer address parser — Chunk F / WI-7.2.
+
+Mirrors the ``parseAddress`` helper in ``typescript/src/utils/peerAddress.ts``.
+SendMessage's ``to:`` field accepts four forms:
+
+* ``"<name>"`` or ``"<agent_id>"`` — in-process / mailbox routing
+  (the parser tags this as ``scheme="other"``).
+* ``"*"`` — broadcast (also ``scheme="other"``; SendMessage handles
+  the wildcard at routing-time, not parsing-time).
+* ``"bridge:<session-id>"`` — cross-machine via Anthropic's relay.
+* ``"uds:<socket-path>"`` — local Unix-domain-socket peer.
+
+The bridge: / uds: schemes are out of scope for this port (per
+ambiguity #5 — gated behind ``feature('UDS_INBOX')`` even in TS).
+SendMessage's dispatch chain still has explicit branches for them
+(``NotImplementedError`` stubs preserving TS dispatch order so a
+future implementation is a localized body change).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+AddressScheme = Literal["bridge", "uds", "other"]
+
+
+@dataclass(frozen=True)
+class ParsedAddress:
+    """Output of ``parse_address``.
+
+    * ``scheme`` — ``"bridge"`` / ``"uds"`` / ``"other"``.
+    * ``target`` — the part after the prefix (e.g.
+      ``"my-session-id"`` for ``"bridge:my-session-id"``). For
+      ``"other"`` it's the entire input.
+    """
+
+    scheme: AddressScheme
+    target: str
+
+
+def parse_address(to: str) -> ParsedAddress:
+    """Classify the ``to:`` field by prefix.
+
+    The ``"bridge:"`` and ``"uds:"`` checks are case-sensitive
+    (matching TS); a payload of ``"Bridge:..."`` falls through to
+    ``"other"``. Empty input is allowed and tagged ``"other"`` —
+    SendMessage's input-validation layer rejects empty strings before
+    they reach this helper.
+    """
+    if to.startswith("bridge:"):
+        return ParsedAddress(scheme="bridge", target=to[len("bridge:"):])
+    if to.startswith("uds:"):
+        return ParsedAddress(scheme="uds", target=to[len("uds:"):])
+    return ParsedAddress(scheme="other", target=to)
+
+
+__all__ = [
+    "AddressScheme",
+    "ParsedAddress",
+    "parse_address",
+]

--- a/tests/services/swarm/test_mailbox.py
+++ b/tests/services/swarm/test_mailbox.py
@@ -1,0 +1,250 @@
+"""WI-6.3 tests — JSONL mailbox + path-traversal sanitization.
+
+Covers:
+* Path sanitization (critic concern C1) — `..`, `/`, empty, oversize.
+* Atomic O_APPEND writes; concurrent writers don't interleave.
+* Read tolerance of partial trailing lines and blank lines.
+* Envelope helpers (shutdown_request/response, plan_approval_response).
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+from pathlib import Path
+
+import pytest
+
+from src.services.swarm.mailbox import (
+    TeammateMessage,
+    create_plan_approval_response_message,
+    create_shutdown_approved_message,
+    create_shutdown_rejected_message,
+    create_shutdown_request_message,
+    get_inbox_path,
+    get_mailboxes_root,
+    make_iso_timestamp,
+    read_mailbox,
+    write_to_mailbox,
+)
+
+
+# ---------------------------------------------------------------------------
+# Path sanitization — concern C1
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        # Path-traversal payloads.
+        "..", "../etc/passwd", "../../etc/passwd", "evil/path",
+        # Whitespace / control / null.
+        "with space", "name with\nbreaks", "\x00null-byte", "tab\there",
+        # Backslash (Windows-flavor traversal vector + just disallowed).
+        "name\\back", "back\\\\slash",
+        # Leading / trailing dots — disallowed even if no traversal,
+        # to keep the whitelist crisp (per N1 fold-in).
+        ".alice", "alice.", ".", "..",
+        # Empty / oversize.
+        "", "a" * 65, "a" * 100,
+        # Unicode is rejected by the ASCII-only whitelist.
+        "🙂unicode", "café",
+    ],
+)
+def test_recipient_traversal_rejected(tmp_path: Path, bad_name: str) -> None:
+    """Bad names raise ``ValueError`` BEFORE any filesystem operation."""
+    with pytest.raises(ValueError, match="Invalid recipient_name"):
+        get_inbox_path(bad_name, "team", tmp_path)
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    ["..", "../other-team", "team/with-slash", "", "a" * 65],
+)
+def test_team_traversal_rejected(tmp_path: Path, bad_name: str) -> None:
+    with pytest.raises(ValueError, match="Invalid team_name"):
+        get_inbox_path("recipient", bad_name, tmp_path)
+
+
+@pytest.mark.parametrize(
+    "good_name",
+    ["alice", "bob_42", "team-lead", "x", "X", "a-very-long-but-still-valid-team-name-of-44-len"],
+)
+def test_legal_names_accepted(tmp_path: Path, good_name: str) -> None:
+    """Whitelist accepts ``[A-Za-z0-9_-]{1,64}``."""
+    path = get_inbox_path(good_name, good_name, tmp_path)
+    assert path.suffix == ".jsonl"
+
+
+def test_inbox_path_isolated_per_team(tmp_path: Path) -> None:
+    p1 = get_inbox_path("alice", "team-a", tmp_path)
+    p2 = get_inbox_path("alice", "team-b", tmp_path)
+    assert p1 != p2
+    assert p1.parent != p2.parent
+
+
+# ---------------------------------------------------------------------------
+# Round-trip — write then read
+# ---------------------------------------------------------------------------
+
+
+def test_write_and_read_round_trip(tmp_path: Path) -> None:
+    msg = TeammateMessage(
+        from_="alice", text="hello bob", timestamp="2026-05-08T12:00:00Z",
+        summary="greeting",
+    )
+    write_to_mailbox("bob", msg, team_name="t", workspace_root=tmp_path)
+
+    messages = read_mailbox("bob", team_name="t", workspace_root=tmp_path)
+    assert len(messages) == 1
+    assert messages[0].from_ == "alice"
+    assert messages[0].text == "hello bob"
+    assert messages[0].summary == "greeting"
+
+
+def test_multiple_writes_preserve_order(tmp_path: Path) -> None:
+    for i in range(5):
+        msg = TeammateMessage(
+            from_="x", text=f"msg-{i}", timestamp="2026-05-08T12:00:00Z",
+        )
+        write_to_mailbox("inbox", msg, team_name="t", workspace_root=tmp_path)
+
+    messages = read_mailbox("inbox", team_name="t", workspace_root=tmp_path)
+    assert [m.text for m in messages] == [f"msg-{i}" for i in range(5)]
+
+
+def test_read_missing_inbox_returns_empty(tmp_path: Path) -> None:
+    messages = read_mailbox("never-wrote", team_name="t", workspace_root=tmp_path)
+    assert messages == []
+
+
+def test_inbox_file_has_user_only_permissions(tmp_path: Path) -> None:
+    """0o600 — mailboxes can carry sensitive plan content."""
+    msg = TeammateMessage(from_="x", text="x", timestamp="2026-05-08T12:00:00Z")
+    write_to_mailbox("alice", msg, team_name="t", workspace_root=tmp_path)
+    path = get_inbox_path("alice", "t", tmp_path)
+    mode = os.stat(path).st_mode & 0o777
+    assert mode & 0o077 == 0, f"mailbox leaks permissions: {oct(mode)}"
+
+
+# ---------------------------------------------------------------------------
+# Reader tolerance
+# ---------------------------------------------------------------------------
+
+
+def test_reader_tolerates_partial_trailing_line(tmp_path: Path) -> None:
+    path = get_inbox_path("alice", "t", tmp_path)
+    path.write_bytes(
+        b'{"from":"x","text":"good","timestamp":"t"}\n'
+        b'{"from":"y","text":"good","timestamp":"t"}\n'
+        b'{"from":"z","text":"part'  # truncated mid-write
+    )
+    messages = read_mailbox("alice", team_name="t", workspace_root=tmp_path)
+    assert len(messages) == 2
+    assert messages[0].text == "good"
+
+
+def test_reader_skips_blank_lines(tmp_path: Path) -> None:
+    path = get_inbox_path("alice", "t", tmp_path)
+    path.write_text(
+        '{"from":"a","text":"x","timestamp":"t"}\n'
+        '\n\n'
+        '{"from":"b","text":"y","timestamp":"t"}\n',
+        encoding="utf-8",
+    )
+    messages = read_mailbox("alice", team_name="t", workspace_root=tmp_path)
+    assert len(messages) == 2
+
+
+# ---------------------------------------------------------------------------
+# Concurrent writers — atomic O_APPEND at line granularity
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_writes_no_interleave(tmp_path: Path) -> None:
+    n_threads = 4
+    n_writes = 50
+
+    def worker(idx: int) -> None:
+        for j in range(n_writes):
+            msg = TeammateMessage(
+                from_=f"t{idx}", text=f"thread-{idx}-msg-{j}",
+                timestamp="2026-05-08T12:00:00Z",
+            )
+            write_to_mailbox("inbox", msg, team_name="t", workspace_root=tmp_path)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    messages = read_mailbox("inbox", team_name="t", workspace_root=tmp_path)
+    assert len(messages) == n_threads * n_writes
+    pairs = {(m.from_, m.text) for m in messages}
+    assert len(pairs) == n_threads * n_writes
+
+
+# ---------------------------------------------------------------------------
+# Envelope helpers
+# ---------------------------------------------------------------------------
+
+
+def test_shutdown_request_envelope_shape() -> None:
+    msg = create_shutdown_request_message(
+        request_id="req-1", from_="leader", reason="end of session"
+    )
+    assert msg["type"] == "shutdown_request"
+    assert msg["request_id"] == "req-1"
+    assert msg["from"] == "leader"
+    assert msg["reason"] == "end of session"
+    assert "timestamp" in msg
+
+
+def test_shutdown_request_envelope_omits_optional_reason() -> None:
+    msg = create_shutdown_request_message(request_id="req-1", from_="leader")
+    assert "reason" not in msg
+
+
+def test_shutdown_approved_envelope_shape() -> None:
+    msg = create_shutdown_approved_message(request_id="req-1", from_="bob")
+    assert msg["type"] == "shutdown_response"
+    assert msg["approved"] is True
+    assert "reason" not in msg
+
+
+def test_shutdown_rejected_envelope_shape() -> None:
+    msg = create_shutdown_rejected_message(
+        request_id="req-1", from_="bob", reason="finishing migration"
+    )
+    assert msg["approved"] is False
+    assert msg["reason"] == "finishing migration"
+
+
+def test_plan_approval_response_envelope_shape() -> None:
+    msg = create_plan_approval_response_message(
+        request_id="req-1", approved=True,
+        permission_mode="default", from_="team-lead",
+    )
+    assert msg["type"] == "plan_approval_response"
+    assert msg["approved"] is True
+    assert msg["permission_mode"] == "default"
+    assert msg["from"] == "team-lead"
+
+
+def test_plan_approval_rejection_carries_feedback() -> None:
+    msg = create_plan_approval_response_message(
+        request_id="req-1", approved=False,
+        permission_mode="default", from_="team-lead",
+        feedback="needs more research",
+    )
+    assert msg["approved"] is False
+    assert msg["feedback"] == "needs more research"
+
+
+def test_iso_timestamp_format() -> None:
+    ts = make_iso_timestamp()
+    # ISO-8601 UTC with Z suffix — basic shape check.
+    assert ts.endswith("Z")
+    assert "T" in ts

--- a/tests/services/swarm/test_team_file.py
+++ b/tests/services/swarm/test_team_file.py
@@ -1,0 +1,111 @@
+"""WI-6.4 tests — team file + members[] schema."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.services.swarm.team_file import (
+    TeamFile,
+    TeamMember,
+    add_member,
+    find_member_by_name,
+    get_team_file_path,
+    read_team_file,
+    remove_member,
+    write_team_file,
+)
+
+
+def test_read_missing_team_returns_none(tmp_path: Path) -> None:
+    assert read_team_file(tmp_path) is None
+
+
+def test_round_trip_write_read(tmp_path: Path) -> None:
+    team = TeamFile(
+        team_name="my-team",
+        lead_agent_id="abc12345",
+        description="testing",
+        members=(
+            TeamMember(agent_id="t1", name="alice", color="blue"),
+            TeamMember(agent_id="t2", name="bob"),
+        ),
+    )
+    write_team_file(team, tmp_path)
+    loaded = read_team_file(tmp_path)
+    assert loaded == team
+
+
+def test_legacy_team_file_no_members_treated_as_empty(tmp_path: Path) -> None:
+    """Pre-Chunk-F team files lacked ``members``; reader treats it
+    as empty rather than raising."""
+    path = get_team_file_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {"team_name": "old", "lead_agent_id": "abc", "description": "legacy"}
+        ),
+        encoding="utf-8",
+    )
+    loaded = read_team_file(tmp_path)
+    assert loaded is not None
+    assert loaded.members == ()
+
+
+def test_add_member_returns_new_team_file(tmp_path: Path) -> None:
+    """Frozen TeamFile — mutator returns new instance."""
+    team = TeamFile(team_name="t", lead_agent_id="abc")
+    member = TeamMember(agent_id="a1", name="alice")
+    new_team = add_member(team, member)
+
+    assert team.members == ()  # original unchanged
+    assert new_team.members == (member,)
+
+
+def test_add_member_replaces_existing_agent_id(tmp_path: Path) -> None:
+    """Idempotent on agent_id — re-add replaces, not duplicates."""
+    team = TeamFile(team_name="t", lead_agent_id="abc")
+    team = add_member(team, TeamMember(agent_id="a1", name="alice", color="blue"))
+    team = add_member(team, TeamMember(agent_id="a1", name="alice", color="red"))
+
+    assert len(team.members) == 1
+    assert team.members[0].color == "red"
+
+
+def test_remove_member_drops_only_target(tmp_path: Path) -> None:
+    team = TeamFile(
+        team_name="t", lead_agent_id="abc",
+        members=(
+            TeamMember(agent_id="a1", name="alice"),
+            TeamMember(agent_id="a2", name="bob"),
+        ),
+    )
+    new_team = remove_member(team, "a1")
+    assert {m.agent_id for m in new_team.members} == {"a2"}
+
+
+def test_find_member_by_name_case_insensitive() -> None:
+    team = TeamFile(
+        team_name="t", lead_agent_id="abc",
+        members=(TeamMember(agent_id="a1", name="Alice"),),
+    )
+    assert find_member_by_name(team, "alice") is not None
+    assert find_member_by_name(team, "ALICE") is not None
+    assert find_member_by_name(team, "bob") is None
+
+
+def test_team_create_writes_members_field(tmp_path: Path) -> None:
+    """``TeamCreate`` (Chunk-F edit) now writes ``members: []`` from
+    day one — verify the on-disk shape directly."""
+    from src.tool_system.context import ToolContext
+    from src.tool_system.tools.team import TeamCreateTool
+
+    ctx = ToolContext(workspace_root=tmp_path)
+    TeamCreateTool.call(
+        {"team_name": "my-team", "description": "x"}, ctx
+    )
+    raw = json.loads(get_team_file_path(tmp_path).read_text(encoding="utf-8"))
+    assert raw["members"] == []
+    assert raw["team_name"] == "my-team"
+    assert "lead_agent_id" in raw

--- a/tests/services/swarm/test_team_membership.py
+++ b/tests/services/swarm/test_team_membership.py
@@ -1,0 +1,60 @@
+"""WI-6.4 tests — ``is_team_lead`` predicate (4 truth cases)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.services.swarm.team_membership import is_team_lead
+from src.tool_system.context import ToolContext
+
+
+def test_is_team_lead_true_when_agent_id_matches(tmp_path: Path) -> None:
+    ctx = ToolContext(workspace_root=tmp_path)
+    ctx.team = {"team_name": "t", "lead_agent_id": "lead-123"}
+    ctx.agent_id = "lead-123"
+    assert is_team_lead(ctx) is True
+
+
+def test_is_team_lead_false_when_agent_id_is_member_not_lead(tmp_path: Path) -> None:
+    ctx = ToolContext(workspace_root=tmp_path)
+    ctx.team = {"team_name": "t", "lead_agent_id": "lead-123"}
+    ctx.agent_id = "member-456"
+    assert is_team_lead(ctx) is False
+
+
+def test_is_team_lead_false_when_no_team_active(tmp_path: Path) -> None:
+    ctx = ToolContext(workspace_root=tmp_path)
+    ctx.agent_id = "lead-123"
+    # ctx.team is None
+    assert is_team_lead(ctx) is False
+
+
+def test_is_team_lead_false_when_agent_id_unset(tmp_path: Path) -> None:
+    ctx = ToolContext(workspace_root=tmp_path)
+    ctx.team = {"team_name": "t", "lead_agent_id": "lead-123"}
+    # ctx.agent_id is None
+    assert is_team_lead(ctx) is False
+
+
+def test_is_team_lead_false_when_team_lacks_lead_agent_id(tmp_path: Path) -> None:
+    """Defensive — a malformed team dict missing ``lead_agent_id``
+    must NOT spuriously authorize anyone."""
+    ctx = ToolContext(workspace_root=tmp_path)
+    ctx.team = {"team_name": "t"}  # no lead_agent_id
+    ctx.agent_id = "lead-123"
+    assert is_team_lead(ctx) is False
+
+
+def test_is_team_lead_false_when_team_is_not_a_dict(tmp_path: Path) -> None:
+    """Defensive — a malformed team field must not authorize.
+
+    Per the docstring: the predicate collapses 'team unavailable' and
+    'not authorized' into the same False return so authorization
+    branches handle both safely. Granting permission to either would
+    be catastrophic.
+    """
+    ctx = ToolContext(workspace_root=tmp_path)
+    ctx.team = "not-a-dict"  # type: ignore[assignment]
+    ctx.agent_id = "lead-123"
+    assert is_team_lead(ctx) is False

--- a/tests/tasks/test_agent_name_registry.py
+++ b/tests/tasks/test_agent_name_registry.py
@@ -1,0 +1,252 @@
+"""WI-6.1 tests — agent name registry + collision policy."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.tool_system.protocol import ToolCall
+from src.types.content_blocks import TextBlock
+from src.types.messages import AssistantMessage
+
+
+# ---------------------------------------------------------------------------
+# Schema — name field declared
+# ---------------------------------------------------------------------------
+
+
+def test_agent_input_schema_declares_name_field() -> None:
+    from src.tool_system.tools.agent import AGENT_INPUT_SCHEMA
+
+    assert "name" in AGENT_INPUT_SCHEMA["properties"]
+    assert AGENT_INPUT_SCHEMA["properties"]["name"]["type"] == "string"
+    # Name is OPTIONAL — not in `required`.
+    assert "name" not in AGENT_INPUT_SCHEMA["required"]
+
+
+# ---------------------------------------------------------------------------
+# Registry round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_registry_field_default_empty(tmp_path: Path) -> None:
+    ctx = ToolContext(workspace_root=tmp_path)
+    assert len(ctx.agent_name_registry) == 0
+
+
+def test_named_async_agent_registers_name_to_id(tmp_path: Path) -> None:
+    """Spawn with ``name="researcher"`` populates
+    ``ctx.agent_name_registry["researcher"]``."""
+    registry = build_default_registry(provider=object())
+    ctx = ToolContext(workspace_root=tmp_path)
+
+    async def _fake(_params):
+        yield AssistantMessage(content=[TextBlock(text="ok")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _fake):
+        result = registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={
+                    "description": "named",
+                    "prompt": "x",
+                    "name": "researcher",
+                    "run_in_background": True,
+                },
+            ),
+            ctx,
+        )
+
+    task_id = str(result.output["agent_id"])
+    assert ctx.agent_name_registry.get("researcher") == task_id
+
+
+def test_unnamed_spawn_does_not_register(tmp_path: Path) -> None:
+    """No ``name`` → registry stays empty."""
+    registry = build_default_registry(provider=object())
+    ctx = ToolContext(workspace_root=tmp_path)
+
+    async def _fake(_params):
+        yield AssistantMessage(content=[TextBlock(text="ok")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _fake):
+        registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={
+                    "description": "unnamed",
+                    "prompt": "x",
+                    "run_in_background": True,
+                },
+            ),
+            ctx,
+        )
+
+    assert len(ctx.agent_name_registry) == 0
+
+
+# ---------------------------------------------------------------------------
+# Collision policy
+# ---------------------------------------------------------------------------
+
+
+def test_collision_with_running_agent_raises(tmp_path: Path) -> None:
+    """Spawning with a name already registered to a running task is
+    an error — the model can re-attach via SendMessage rather than
+    silently overwriting.
+
+    ``ToolInputError`` propagates as a raised exception (matches the
+    existing pattern for "missing prompt" / "unknown subagent_type"
+    errors in ``_agent_call``); the dispatcher does not wrap input
+    errors into is_error results."""
+    from src.tool_system.errors import ToolInputError
+
+    registry = build_default_registry(provider=object())
+    ctx = ToolContext(workspace_root=tmp_path)
+
+    # Pre-populate the registry as if a running agent was already
+    # registered.
+    from src.tasks.local_agent import register_async_agent
+    existing = register_async_agent(
+        agent_id="a-existing", description="x", prompt="x",
+        agent_type="general-purpose", registry=ctx.runtime_tasks,
+    )
+    ctx.agent_name_registry._mapping["researcher"] = existing.id
+
+    async def _fake(_params):
+        yield AssistantMessage(content=[TextBlock(text="ok")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _fake):
+        with pytest.raises(ToolInputError, match="already registered"):
+            registry.dispatch(
+                ToolCall(
+                    name="Agent",
+                    input={
+                        "description": "collision",
+                        "prompt": "x",
+                        "name": "researcher",
+                        "run_in_background": True,
+                    },
+                ),
+                ctx,
+            )
+
+    # Original agent still in the registry; name still maps to it.
+    assert ctx.agent_name_registry.get("researcher") == "a-existing"
+
+
+# ---------------------------------------------------------------------------
+# C1 — concurrent same-name spawn must NOT both succeed
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_same_name_spawn_only_one_wins(tmp_path: Path) -> None:
+    """Critic Chunk-F-Phase-6 concern C1: the original Phase-6
+    implementation had a TOCTOU window between the read of the
+    existing binding and the write of the new one. Phase-7 wraps
+    the registry as a typed ``AgentNameRegistry`` with an atomic
+    ``claim_or_raise``. This test forces a literal race via
+    ``threading.Barrier(2)`` and asserts only one of two concurrent
+    same-name spawns wins; the other gets ``AgentNameAlreadyClaimedError``
+    (translated to ``ToolInputError`` at the agent-tool boundary).
+
+    Pre-fix: a serial coordinator-mode test would mask this race, but
+    Phase-7's coordinator pattern explicitly spawns workers in
+    parallel — at which point the second-spawn-with-same-name would
+    silently steal the binding. This guard prevents the silent-steal
+    regression.
+    """
+    import threading
+
+    from src.services.swarm.agent_name_registry import (
+        AgentNameAlreadyClaimedError,
+        AgentNameRegistry,
+    )
+    from src.task_registry import RuntimeTaskRegistry
+    from src.tasks.local_agent import register_async_agent
+
+    runtime = RuntimeTaskRegistry()
+    name_registry = AgentNameRegistry()
+
+    # Pre-register two RUNNING agents with distinct ids; the test
+    # races their name claims.
+    register_async_agent(
+        agent_id="a-1", description="x", prompt="x",
+        agent_type="general-purpose", registry=runtime,
+    )
+    register_async_agent(
+        agent_id="a-2", description="x", prompt="x",
+        agent_type="general-purpose", registry=runtime,
+    )
+
+    barrier = threading.Barrier(2)
+    outcomes: dict[str, str | type] = {}
+
+    def claim_thread(label: str, agent_id: str) -> None:
+        barrier.wait()  # both threads enter at the same instant
+        try:
+            name_registry.claim_or_raise("researcher", agent_id, runtime)
+            outcomes[label] = "ok"
+        except AgentNameAlreadyClaimedError:
+            outcomes[label] = "raised"
+
+    t1 = threading.Thread(target=claim_thread, args=("first", "a-1"))
+    t2 = threading.Thread(target=claim_thread, args=("second", "a-2"))
+    t1.start(); t2.start()
+    t1.join(); t2.join()
+
+    # Exactly one thread wins; the other raises.
+    statuses = list(outcomes.values())
+    assert sorted(statuses) == ["ok", "raised"], (
+        f"expected one ok / one raised under literal race; got {outcomes}"
+    )
+    # The registry holds the winner's binding.
+    bound = name_registry.get("researcher")
+    assert bound in {"a-1", "a-2"}
+
+
+def test_collision_with_terminal_agent_overwrites(tmp_path: Path) -> None:
+    """If the existing entry is terminal (completed/failed/killed),
+    the new spawn overwrites the name → agent_id mapping. Older
+    terminal holders remain reachable via raw task_id."""
+    registry = build_default_registry(provider=object())
+    ctx = ToolContext(workspace_root=tmp_path)
+
+    from src.tasks.local_agent import (
+        complete_agent_task,
+        register_async_agent,
+    )
+    existing = register_async_agent(
+        agent_id="a-old", description="x", prompt="x",
+        agent_type="general-purpose", registry=ctx.runtime_tasks,
+    )
+    complete_agent_task("a-old", result_text="done", registry=ctx.runtime_tasks)
+    ctx.agent_name_registry._mapping["researcher"] = existing.id
+
+    async def _fake(_params):
+        yield AssistantMessage(content=[TextBlock(text="ok")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _fake):
+        result = registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={
+                    "description": "fresh",
+                    "prompt": "x",
+                    "name": "researcher",
+                    "run_in_background": True,
+                },
+            ),
+            ctx,
+        )
+
+    new_id = str(result.output["agent_id"])
+    assert result.is_error is False
+    # Name now points at the new spawn.
+    assert ctx.agent_name_registry.get("researcher") == new_id
+    assert new_id != "a-old"
+    # Old terminal entry still in the registry (reachable by raw ID).
+    assert ctx.runtime_tasks.get("a-old") is not None

--- a/tests/tasks/test_in_process_teammate.py
+++ b/tests/tasks/test_in_process_teammate.py
@@ -1,0 +1,269 @@
+"""WI-6.2 + sub-WI-6.2.a tests — InProcessTeammateTaskState + abort hooks."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+
+import pytest
+
+from src.task_registry import RuntimeTaskRegistry, get_task_by_type
+from src.tasks.in_process_teammate import (
+    CurrentWorkAbortedError,
+    InProcessTeammateTask,
+    InProcessTeammateTaskState,
+    TEAMMATE_MESSAGES_UI_CAP,
+    TeammateAbortedError,
+    TeammateIdentity,
+    append_capped_message,
+    check_abort_events,
+    is_in_process_teammate_task,
+    outer_lifecycle_should_catch,
+    run_with_two_level_abort,
+)
+from src.tasks_core import is_terminal_task_status
+
+
+def _make_running_state(task_id: str = "t1abc1234") -> InProcessTeammateTaskState:
+    return InProcessTeammateTaskState(
+        id=task_id,
+        type="in_process_teammate",
+        status="running",
+        description="x",
+        start_time=0.0,
+        output_file="/tmp/x",
+        identity=TeammateIdentity(
+            agent_id=task_id, agent_name="alice", team_name="my-team",
+        ),
+        prompt="x",
+        abort_event=asyncio.Event(),
+        current_work_abort_event=asyncio.Event(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# State construction + chapter field accounting
+# ---------------------------------------------------------------------------
+
+
+def test_chapter_required_fields_present() -> None:
+    state = _make_running_state()
+    assert state.identity.agent_id == "t1abc1234"
+    assert state.identity.agent_name == "alice"
+    assert state.identity.team_name == "my-team"
+    assert state.identity.plan_mode_required is False
+    # Two-level abort signals
+    assert isinstance(state.abort_event, asyncio.Event)
+    assert isinstance(state.current_work_abort_event, asyncio.Event)
+    # Lifecycle flags
+    assert state.is_idle is False
+    assert state.shutdown_requested is False
+    assert state.awaiting_plan_approval is False
+    assert state.permission_mode == "default"
+    # Inboxes
+    assert state.pending_user_messages == []
+    assert state.in_progress_tool_use_ids == set()
+    # Progress / message UI fields
+    assert state.last_reported_tool_count == 0
+    assert state.last_reported_token_count == 0
+    assert state.messages == []
+
+
+def test_is_in_process_teammate_task_predicate() -> None:
+    state = _make_running_state()
+    assert is_in_process_teammate_task(state) is True
+    assert is_in_process_teammate_task("not a state") is False
+    assert is_in_process_teammate_task(None) is False
+
+
+# ---------------------------------------------------------------------------
+# 50-message UI cap (whale-session OOM guard)
+# ---------------------------------------------------------------------------
+
+
+def test_messages_ui_cap_drops_oldest_on_overflow() -> None:
+    capped = list(range(TEAMMATE_MESSAGES_UI_CAP))
+    new = append_capped_message(capped, TEAMMATE_MESSAGES_UI_CAP)  # one over
+    assert len(new) == TEAMMATE_MESSAGES_UI_CAP
+    assert new[-1] == TEAMMATE_MESSAGES_UI_CAP
+    assert new[0] == 1  # 0 dropped
+
+
+def test_append_capped_to_empty() -> None:
+    assert append_capped_message(None, "x") == ["x"]
+    assert append_capped_message([], "x") == ["x"]
+
+
+def test_append_capped_below_cap_grows() -> None:
+    out = append_capped_message([1, 2, 3], 4)
+    assert out == [1, 2, 3, 4]
+
+
+# ---------------------------------------------------------------------------
+# Two-level abort — exception classes (sub-WI-6.2.a)
+# ---------------------------------------------------------------------------
+
+
+def test_two_level_exception_classes_subclass_cancelled_error() -> None:
+    """Both subclass ``asyncio.CancelledError`` so existing
+    cancellation paths keep working without special-casing."""
+    assert issubclass(TeammateAbortedError, asyncio.CancelledError)
+    assert issubclass(CurrentWorkAbortedError, asyncio.CancelledError)
+    # And they're distinct.
+    assert TeammateAbortedError is not CurrentWorkAbortedError
+
+
+def test_check_abort_events_no_op_when_neither_set() -> None:
+    state = _make_running_state()
+    # No exception raised.
+    check_abort_events(state)
+
+
+def test_check_abort_events_raises_current_work_when_set() -> None:
+    state = _make_running_state()
+    state.current_work_abort_event.set()
+    with pytest.raises(CurrentWorkAbortedError):
+        check_abort_events(state)
+
+
+def test_check_abort_events_raises_teammate_when_kill_set() -> None:
+    state = _make_running_state()
+    state.abort_event.set()
+    with pytest.raises(TeammateAbortedError):
+        check_abort_events(state)
+
+
+def test_check_abort_events_kill_wins_when_both_set() -> None:
+    """Both events fired → TeammateAbortedError takes precedence
+    (kill is the stronger intent)."""
+    state = _make_running_state()
+    state.abort_event.set()
+    state.current_work_abort_event.set()
+    with pytest.raises(TeammateAbortedError):
+        check_abort_events(state)
+
+
+# ---------------------------------------------------------------------------
+# Outer-lifecycle catch policy
+# ---------------------------------------------------------------------------
+
+
+def test_outer_lifecycle_catches_current_work() -> None:
+    """Redirect pattern — outer loop catches CurrentWorkAbortedError."""
+    assert outer_lifecycle_should_catch(CurrentWorkAbortedError("x")) is True
+
+
+def test_outer_lifecycle_does_not_catch_teammate_aborted() -> None:
+    """Kill pattern — outer loop does NOT catch."""
+    assert outer_lifecycle_should_catch(TeammateAbortedError("x")) is False
+
+
+def test_outer_lifecycle_does_not_catch_plain_cancelled() -> None:
+    """Plain CancelledError (e.g. asyncio.Task.cancel()) propagates;
+    the teammate respects the cancel."""
+    assert outer_lifecycle_should_catch(asyncio.CancelledError()) is False
+
+
+# ---------------------------------------------------------------------------
+# run_with_two_level_abort — integration helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_with_two_level_abort_completes_normally() -> None:
+    state = _make_running_state()
+    counter = {"n": 0}
+
+    async def work() -> str:
+        for _ in range(3):
+            await asyncio.sleep(0.01)
+            counter["n"] += 1
+        return "done"
+
+    result = await run_with_two_level_abort(work, state_provider=lambda: state)
+    assert result == "done"
+    assert counter["n"] == 3
+
+
+@pytest.mark.asyncio
+async def test_run_with_two_level_abort_redirect_raises_current_work() -> None:
+    state = _make_running_state()
+
+    async def work() -> str:
+        await asyncio.sleep(2.0)
+        return "should not reach"
+
+    async def trigger() -> None:
+        await asyncio.sleep(0.05)
+        state.current_work_abort_event.set()
+
+    with pytest.raises(CurrentWorkAbortedError):
+        await asyncio.gather(
+            run_with_two_level_abort(work, state_provider=lambda: state),
+            trigger(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_with_two_level_abort_kill_raises_teammate() -> None:
+    state = _make_running_state()
+
+    async def work() -> str:
+        await asyncio.sleep(2.0)
+        return "should not reach"
+
+    async def trigger() -> None:
+        await asyncio.sleep(0.05)
+        state.abort_event.set()
+
+    with pytest.raises(TeammateAbortedError):
+        await asyncio.gather(
+            run_with_two_level_abort(work, state_provider=lambda: state),
+            trigger(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task adapter — kill flips status and signals abort
+# ---------------------------------------------------------------------------
+
+
+def test_task_adapter_registered_for_in_process_teammate() -> None:
+    """Centralized ``register_task`` in ``tasks/__init__.py`` registers
+    InProcessTeammateTask alongside LocalShellTask and LocalAgentTask."""
+    impl = get_task_by_type("in_process_teammate")
+    assert impl is not None
+    assert impl.name == "InProcessTeammateTask"
+    assert impl.type == "in_process_teammate"
+
+
+@pytest.mark.asyncio
+async def test_kill_flips_status_and_signals_abort_event() -> None:
+    reg = RuntimeTaskRegistry()
+    state = _make_running_state()
+    reg.upsert(state)
+
+    await InProcessTeammateTask().kill(state.id, reg)
+
+    refreshed = reg.get(state.id)
+    assert isinstance(refreshed, InProcessTeammateTaskState)
+    assert refreshed.status == "killed"
+    assert is_terminal_task_status(refreshed.status)
+    # Abort event fired so the run loop sees TeammateAbortedError on
+    # its next yield.
+    assert refreshed.abort_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_kill_terminal_state_is_noop() -> None:
+    """Already-terminal teammate is unchanged by kill (idempotent)."""
+    reg = RuntimeTaskRegistry()
+    state = _make_running_state()
+    state = replace(state, status="completed")
+    reg.upsert(state)
+
+    await InProcessTeammateTask().kill(state.id, reg)
+
+    refreshed = reg.get(state.id)
+    assert refreshed.status == "completed"
+    # abort_event was NOT signalled (no kill needed).
+    assert not refreshed.abort_event.is_set()

--- a/tests/test_resume_agent.py
+++ b/tests/test_resume_agent.py
@@ -1,0 +1,257 @@
+"""WI-7.4 tests — ``resume_agent_background`` race guard + transcript replay.
+
+Covers:
+* Terminal task → resume succeeds, fresh state visible in registry.
+* Non-terminal task → resume returns no-op with reason.
+* Missing task → resume returns no-op with reason.
+* Concurrent resume callers → exactly one wins (atomic claim).
+* TranscriptReader is the consumer — replays count is reported.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from src.agent.resume_agent import resume_agent_background
+from src.agent.transcript import TranscriptWriter, get_agent_transcript_path
+from src.tasks.local_agent import (
+    LocalAgentTaskState,
+    complete_agent_task,
+    fail_agent_task,
+    register_async_agent,
+)
+from src.tasks_core import generate_task_id
+from src.tool_system.context import ToolContext
+
+
+def _make_terminal_agent(ctx: ToolContext, terminal_status: str = "completed") -> str:
+    """Spawn → terminal. Returns the agent_id."""
+    agent_id = generate_task_id("local_agent")
+    register_async_agent(
+        agent_id=agent_id, description="x", prompt="initial",
+        agent_type="general-purpose", registry=ctx.runtime_tasks,
+    )
+    if terminal_status == "completed":
+        complete_agent_task(agent_id, result_text="done", registry=ctx.runtime_tasks)
+    elif terminal_status == "failed":
+        fail_agent_task(agent_id, error="boom", registry=ctx.runtime_tasks)
+    return agent_id
+
+
+# ---------------------------------------------------------------------------
+# Happy path — terminal task → resumed
+# ---------------------------------------------------------------------------
+
+
+def test_resume_terminal_agent_returns_resumed_true(tmp_path: Path) -> None:
+    ctx = ToolContext(workspace_root=tmp_path)
+    agent_id = _make_terminal_agent(ctx)
+
+    result = asyncio.run(resume_agent_background(
+        agent_id=agent_id, prompt="wake up", context=ctx,
+    ))
+    assert result.resumed is True
+    assert result.agent_id == agent_id
+
+    refreshed = ctx.runtime_tasks.get(agent_id)
+    assert isinstance(refreshed, LocalAgentTaskState)
+    assert refreshed.status == "running"
+    assert refreshed.prompt == "wake up"
+
+
+def test_resume_carries_resume_prompt_into_fresh_state(tmp_path: Path) -> None:
+    ctx = ToolContext(workspace_root=tmp_path)
+    agent_id = _make_terminal_agent(ctx, terminal_status="failed")
+
+    asyncio.run(resume_agent_background(
+        agent_id=agent_id, prompt="retry the failed work", context=ctx,
+    ))
+    refreshed = ctx.runtime_tasks.get(agent_id)
+    assert refreshed.prompt == "retry the failed work"
+
+
+def test_resume_reads_transcript_via_transcript_reader(tmp_path: Path) -> None:
+    """DIP claim — ``resume_agent_background`` consumes the transcript
+    via ``TranscriptReader``. Verify by writing some entries to the
+    transcript pre-resume and asserting ``replayed_message_count``."""
+    ctx = ToolContext(workspace_root=tmp_path)
+    agent_id = _make_terminal_agent(ctx)
+
+    # Write 3 entries to the transcript (whatever shape — the reader
+    # just yields parseable JSON objects).
+    transcript_path = get_agent_transcript_path(agent_id)
+    with TranscriptWriter(transcript_path) as w:
+        w.append({"role": "user", "content": "hi"})
+        w.append({"role": "assistant", "content": "hello"})
+        w.append({"role": "user", "content": "follow-up"})
+
+    result = asyncio.run(resume_agent_background(
+        agent_id=agent_id, prompt="continue", context=ctx,
+    ))
+    assert result.resumed is True
+    assert result.replayed_message_count == 3
+
+
+def test_resume_handles_missing_transcript_gracefully(tmp_path: Path) -> None:
+    """Transcript file may not exist (e.g., the agent crashed before
+    the writer opened). Resume should still succeed; replay count is 0."""
+    ctx = ToolContext(workspace_root=tmp_path)
+    agent_id = _make_terminal_agent(ctx)
+
+    # Don't create the transcript file. ``register_async_agent``
+    # populated ``output_file`` with the path, but no writes have
+    # happened.
+    result = asyncio.run(resume_agent_background(
+        agent_id=agent_id, prompt="x", context=ctx,
+    ))
+    assert result.resumed is True
+    assert result.replayed_message_count == 0
+
+
+# ---------------------------------------------------------------------------
+# No-op paths — task missing / not terminal / not local_agent
+# ---------------------------------------------------------------------------
+
+
+def test_resume_returns_noop_for_missing_task(tmp_path: Path) -> None:
+    ctx = ToolContext(workspace_root=tmp_path)
+    result = asyncio.run(resume_agent_background(
+        agent_id="a-ghost", prompt="x", context=ctx,
+    ))
+    assert result.resumed is False
+    assert "not found" in result.reason.lower()
+
+
+def test_resume_returns_noop_for_running_task(tmp_path: Path) -> None:
+    """Auto-resume only fires for terminal tasks — running ones are
+    left alone."""
+    ctx = ToolContext(workspace_root=tmp_path)
+    agent_id = generate_task_id("local_agent")
+    register_async_agent(
+        agent_id=agent_id, description="x", prompt="x",
+        agent_type="general-purpose", registry=ctx.runtime_tasks,
+    )
+    result = asyncio.run(resume_agent_background(
+        agent_id=agent_id, prompt="x", context=ctx,
+    ))
+    assert result.resumed is False
+    assert "not terminal" in result.reason.lower()
+
+
+def test_resume_returns_noop_for_non_local_agent_task(tmp_path: Path) -> None:
+    """A bash task at the same id wouldn't be a local_agent — resume
+    rejects it cleanly."""
+    from src.tasks.local_shell import LocalShellTaskState
+    import time
+
+    ctx = ToolContext(workspace_root=tmp_path)
+    state = LocalShellTaskState(
+        id="b-shell",
+        type="local_bash",
+        status="completed",
+        description="x",
+        start_time=time.time(),
+        output_file="/tmp/x",
+        command="echo x",
+        cwd="/tmp",
+    )
+    ctx.runtime_tasks.upsert(state)
+
+    result = asyncio.run(resume_agent_background(
+        agent_id="b-shell", prompt="x", context=ctx,
+    ))
+    assert result.resumed is False
+    assert "not local_agent" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# Race guard — atomic claim
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_resume_callers_only_one_wins(tmp_path: Path) -> None:
+    """asyncio.gather() races two concurrent ``resume_agent_background``
+    calls against the same dead agent_id. Exactly one returns
+    ``resumed=True``; the other returns ``resumed=False`` with the
+    "another caller is resuming" reason.
+
+    The atomic ``runtime_tasks.update`` mutator that performs the
+    check + flip in one breath is what makes this race-safe — without
+    it, both callers would proceed past the terminal-state check,
+    and the second ``register_async_agent`` would silently overwrite
+    the first."""
+    ctx = ToolContext(workspace_root=tmp_path)
+    agent_id = _make_terminal_agent(ctx)
+
+    results = await asyncio.gather(
+        resume_agent_background(
+            agent_id=agent_id, prompt="A", context=ctx,
+        ),
+        resume_agent_background(
+            agent_id=agent_id, prompt="B", context=ctx,
+        ),
+    )
+
+    won = [r for r in results if r.resumed]
+    lost = [r for r in results if not r.resumed]
+    assert len(won) == 1, f"expected exactly 1 resumer; got {len(won)}"
+    assert len(lost) == 1
+    # Loser's reason is one of two valid outcomes:
+    # * "another caller is resuming" — winner was mid-resume when
+    #   loser hit the registry (won the claim race but hadn't
+    #   finished register_async_agent yet).
+    # * "task is 'running', not terminal" — winner had already
+    #   re-registered the fresh state before loser even read.
+    # Both prove the second resume correctly did NOT fire — that's
+    # what the race guard is for. Assert either is present.
+    loser_reason = lost[0].reason.lower()
+    assert (
+        "another caller is resuming" in loser_reason
+        or "not terminal" in loser_reason
+    ), f"unexpected loser reason: {loser_reason!r}"
+
+    # Final state has the winner's prompt.
+    #
+    # Critic Chunk-F N1 note: this race test calls ``resume_agent_background``
+    # directly, so loser callers return a no-op ``ResumeResult`` —
+    # they don't carry the loser's message into pending_messages
+    # (that's SendMessage's job, exercised at
+    # ``tests/tool_system/test_send_message.py::
+    # test_concurrent_resume_race_only_one_winner`` which asserts the
+    # loser's message lands in ``final.pending_messages``). Keeping
+    # the assertions narrow here so the test focuses on the resume
+    # primitive's race guard, not the SendMessage flow.
+    final = ctx.runtime_tasks.get(agent_id)
+    assert final.status == "running"
+    assert final.prompt in {"A", "B"}
+
+
+# ---------------------------------------------------------------------------
+# is_resuming bookkeeping
+# ---------------------------------------------------------------------------
+
+
+def test_resume_resets_is_resuming_on_fresh_state(tmp_path: Path) -> None:
+    """After a successful resume, the fresh state has
+    ``is_resuming=False`` so a future re-resume can fire if this run
+    also terminates."""
+    ctx = ToolContext(workspace_root=tmp_path)
+    agent_id = _make_terminal_agent(ctx)
+
+    asyncio.run(resume_agent_background(
+        agent_id=agent_id, prompt="first-resume", context=ctx,
+    ))
+    after_first = ctx.runtime_tasks.get(agent_id)
+    assert after_first.is_resuming is False
+
+    # Drive to terminal again, resume again — works because the
+    # is_resuming flag was reset.
+    complete_agent_task(agent_id, result_text="re-done", registry=ctx.runtime_tasks)
+    second = asyncio.run(resume_agent_background(
+        agent_id=agent_id, prompt="second-resume", context=ctx,
+    ))
+    assert second.resumed is True

--- a/tests/tool_system/test_send_message.py
+++ b/tests/tool_system/test_send_message.py
@@ -1,0 +1,552 @@
+"""WI-7.1 + WI-7.2 + WI-7.3 tests — SendMessage tool routing + protocols.
+
+Covers:
+* Tool registration + schema shape.
+* 4-branch routing dispatch order parity (WI-7.2).
+* In-process queue (running) + auto-resume (terminal) — WI-7.4
+  integration smoke.
+* Mailbox routing (named recipient + ``*`` broadcast).
+* Structured protocols + sender-side authorization.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.services.swarm.mailbox import get_inbox_path, read_mailbox
+from src.services.swarm.team_file import TeamFile, TeamMember, write_team_file
+from src.tool_system.context import ToolContext
+from src.tool_system.errors import ToolInputError
+from src.tool_system.tools.send_message import (
+    SEND_MESSAGE_INPUT_SCHEMA,
+    SEND_MESSAGE_TOOL_NAME,
+    SendMessageTool,
+)
+
+
+def _call_send_message(input: dict, ctx: ToolContext):
+    """Sync wrapper for the async tool — mirrors test_task_stop helper."""
+    return asyncio.run(SendMessageTool.call(input, ctx))
+
+
+# ---------------------------------------------------------------------------
+# WI-7.1 — Tool registration + schema
+# ---------------------------------------------------------------------------
+
+
+def test_tool_registered_with_canonical_name() -> None:
+    assert SendMessageTool.name == "SendMessage"
+    assert SEND_MESSAGE_TOOL_NAME == "SendMessage"
+
+
+def test_tool_in_default_static_tools() -> None:
+    from src.tool_system.tools import ALL_STATIC_TOOLS
+    assert SendMessageTool in ALL_STATIC_TOOLS
+
+
+def test_input_schema_required_fields() -> None:
+    assert "to" in SEND_MESSAGE_INPUT_SCHEMA["required"]
+    assert "message" in SEND_MESSAGE_INPUT_SCHEMA["required"]
+    # ``summary`` is optional (required for plain text via runtime
+    # check; not at the schema level).
+    assert "summary" not in SEND_MESSAGE_INPUT_SCHEMA["required"]
+
+
+def test_input_schema_message_is_union() -> None:
+    msg_schema = SEND_MESSAGE_INPUT_SCHEMA["properties"]["message"]
+    assert "oneOf" in msg_schema
+    type_options = {opt.get("type") for opt in msg_schema["oneOf"]}
+    assert type_options == {"string", "object"}
+
+
+# ---------------------------------------------------------------------------
+# WI-7.2 — 4-branch routing dispatch order parity (the critical guard)
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_order_parity_with_ts(tmp_path: Path) -> None:
+    """Pin the dispatch chain order so a future re-arrangement that
+    silently breaks UDS_INBOX integration shows up at review time.
+
+    TS dispatch order (mirrored): bridge → uds → in-process → mailbox
+    → error. Per critic Chunk-F N2 — verify by walking the AST and
+    matching ``If`` / ``Return`` nodes by line position rather than
+    string searching. A comment containing the search text would have
+    confused the substring approach; the AST walk is sturdier.
+    """
+    import ast
+
+    from src.tool_system.tools import send_message as sm
+
+    tree = ast.parse(inspect.getsource(sm._send_message_call))
+
+    bridge_line = None
+    uds_line = None
+    in_process_line = None
+    mailbox_line = None
+    error_line = None
+
+    for node in ast.walk(tree):
+        # Bridge / uds branches: ``if addr.scheme == "bridge":`` /
+        # ``"uds":``. We match an If whose test compares
+        # ``addr.scheme`` to a constant.
+        if isinstance(node, ast.If):
+            test = node.test
+            if (
+                isinstance(test, ast.Compare)
+                and isinstance(test.left, ast.Attribute)
+                and getattr(test.left.value, "id", None) == "addr"
+                and test.left.attr == "scheme"
+                and len(test.comparators) == 1
+                and isinstance(test.comparators[0], ast.Constant)
+            ):
+                scheme = test.comparators[0].value
+                if scheme == "bridge" and bridge_line is None:
+                    bridge_line = node.lineno
+                elif scheme == "uds" and uds_line is None:
+                    uds_line = node.lineno
+        # Calls to ``_route_in_process(...)`` / ``_route_team_mailbox(...)``
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            if node.func.id == "_route_in_process" and in_process_line is None:
+                in_process_line = node.lineno
+            elif node.func.id == "_route_team_mailbox" and mailbox_line is None:
+                mailbox_line = node.lineno
+        # The error-branch return — match the literal "Recipient" text
+        # but only on a Return node so a docstring / comment wouldn't
+        # match.
+        if isinstance(node, ast.Return) and node.value is not None:
+            for child in ast.walk(node.value):
+                if (
+                    isinstance(child, ast.Constant)
+                    and isinstance(child.value, str)
+                    and child.value.startswith("Recipient")
+                ):
+                    if error_line is None:
+                        error_line = node.lineno
+                    break
+
+    assert bridge_line is not None, "bridge branch not found in AST"
+    assert uds_line is not None, "uds branch not found in AST"
+    assert in_process_line is not None, "in-process call not found in AST"
+    assert mailbox_line is not None, "mailbox call not found in AST"
+    assert error_line is not None, "error branch not found in AST"
+    assert bridge_line < uds_line < in_process_line < mailbox_line < error_line, (
+        f"dispatch order regression: expected bridge < uds < in-process "
+        f"< mailbox < error; got bridge={bridge_line} uds={uds_line} "
+        f"in_process={in_process_line} mailbox={mailbox_line} error={error_line}"
+    )
+
+
+def test_bridge_addressing_raises_not_implemented(tmp_path: Path) -> None:
+    ctx = ToolContext(workspace_root=tmp_path)
+    with pytest.raises(NotImplementedError, match="bridge:"):
+        _call_send_message(
+            {"to": "bridge:my-session", "message": "hi", "summary": "x"},
+            ctx,
+        )
+
+
+def test_uds_addressing_raises_not_implemented(tmp_path: Path) -> None:
+    ctx = ToolContext(workspace_root=tmp_path)
+    with pytest.raises(NotImplementedError, match="uds:"):
+        _call_send_message(
+            {"to": "uds:/tmp/sock", "message": "hi", "summary": "x"},
+            ctx,
+        )
+
+
+def test_uds_error_message_names_feature_gate(tmp_path: Path) -> None:
+    """Error message names ``feature('UDS_INBOX')`` so the model and
+    a future implementer know exactly what's gating the path."""
+    ctx = ToolContext(workspace_root=tmp_path)
+    with pytest.raises(NotImplementedError) as excinfo:
+        _call_send_message(
+            {"to": "uds:/tmp/sock", "message": "hi", "summary": "x"}, ctx
+        )
+    assert "UDS_INBOX" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# In-process routing — running agent → queue
+# ---------------------------------------------------------------------------
+
+
+def test_message_to_running_agent_queued(tmp_path: Path) -> None:
+    """Running ``local_agent`` → message goes onto pending_messages."""
+    from src.tasks.local_agent import register_async_agent
+
+    ctx = ToolContext(workspace_root=tmp_path)
+    state = register_async_agent(
+        agent_id="a-running", description="x", prompt="x",
+        agent_type="general-purpose", registry=ctx.runtime_tasks,
+    )
+    ctx.agent_name_registry._mapping["researcher"] = state.id
+
+    result = _call_send_message(
+        {"to": "researcher", "message": "follow-up", "summary": "more"},
+        ctx,
+    )
+    assert result.is_error is False
+    assert "queued" in result.output["message"].lower()
+    refreshed = ctx.runtime_tasks.get(state.id)
+    assert "follow-up" in refreshed.pending_messages
+
+
+def test_message_to_running_agent_by_raw_id(tmp_path: Path) -> None:
+    """Raw agent_id fallback (model passes the id directly)."""
+    from src.tasks.local_agent import register_async_agent
+
+    ctx = ToolContext(workspace_root=tmp_path)
+    state = register_async_agent(
+        agent_id="a-raw", description="x", prompt="x",
+        agent_type="general-purpose", registry=ctx.runtime_tasks,
+    )
+
+    result = _call_send_message(
+        {"to": "a-raw", "message": "by-id", "summary": "x"},
+        ctx,
+    )
+    assert result.is_error is False
+    refreshed = ctx.runtime_tasks.get(state.id)
+    assert "by-id" in refreshed.pending_messages
+
+
+# ---------------------------------------------------------------------------
+# WI-7.4 — auto-resume race guard
+# ---------------------------------------------------------------------------
+
+
+def test_message_to_terminal_agent_triggers_resume(tmp_path: Path) -> None:
+    """Terminal agent + SendMessage → resume_agent_background fires.
+    The resumed entry shows status='running' and the resume prompt
+    is the new state's prompt."""
+    from src.tasks.local_agent import (
+        complete_agent_task,
+        register_async_agent,
+    )
+
+    ctx = ToolContext(workspace_root=tmp_path)
+    state = register_async_agent(
+        agent_id="a-dead", description="x", prompt="initial",
+        agent_type="general-purpose", registry=ctx.runtime_tasks,
+    )
+    complete_agent_task(state.id, result_text="done", registry=ctx.runtime_tasks)
+
+    result = _call_send_message(
+        {"to": "a-dead", "message": "wake up", "summary": "wakeup"},
+        ctx,
+    )
+    assert result.is_error is False
+    assert "resumed" in result.output["message"].lower()
+    refreshed = ctx.runtime_tasks.get(state.id)
+    assert refreshed.status == "running"
+    assert refreshed.prompt == "wake up"
+    assert refreshed.is_resuming is False  # reset on the fresh state
+
+
+@pytest.mark.asyncio
+async def test_concurrent_resume_race_only_one_winner(tmp_path: Path) -> None:
+    """Two concurrent SendMessage calls to the same dead agent_id;
+    only one resumes, the other queues."""
+    from src.tasks.local_agent import (
+        complete_agent_task,
+        register_async_agent,
+    )
+
+    ctx = ToolContext(workspace_root=tmp_path)
+    register_async_agent(
+        agent_id="a-race", description="x", prompt="x",
+        agent_type="general-purpose", registry=ctx.runtime_tasks,
+    )
+    complete_agent_task("a-race", result_text="done", registry=ctx.runtime_tasks)
+
+    # Race two calls via asyncio.gather. The atomic claim mutator
+    # ensures exactly one wins; the other should queue.
+    results = await asyncio.gather(
+        SendMessageTool.call(
+            {"to": "a-race", "message": "msg-A", "summary": "x"}, ctx,
+        ),
+        SendMessageTool.call(
+            {"to": "a-race", "message": "msg-B", "summary": "x"}, ctx,
+        ),
+    )
+
+    msgs = [r.output["message"].lower() for r in results]
+    resumed_count = sum(1 for m in msgs if "resumed" in m)
+    queued_count = sum(1 for m in msgs if "queued" in m)
+    assert resumed_count == 1, f"expected exactly 1 resume, got {resumed_count}: {msgs}"
+    assert queued_count == 1, f"expected exactly 1 queue, got {queued_count}: {msgs}"
+
+    # The fresh state has the resume prompt + the queued message in
+    # pending_messages.
+    final = ctx.runtime_tasks.get("a-race")
+    assert final.status == "running"
+    assert final.prompt in {"msg-A", "msg-B"}
+    other_msg = "msg-B" if final.prompt == "msg-A" else "msg-A"
+    assert other_msg in final.pending_messages
+
+
+# ---------------------------------------------------------------------------
+# Mailbox routing — named recipient + broadcast
+# ---------------------------------------------------------------------------
+
+
+def _seed_team(tmp_path: Path, members: list[TeamMember] | None = None) -> ToolContext:
+    """Helper: write a team file + populate ``ctx.team`` so mailbox
+    routing has something to work with."""
+    team = TeamFile(
+        team_name="t",
+        lead_agent_id="lead-1",
+        description="test",
+        members=tuple(members or []),
+    )
+    write_team_file(team, tmp_path)
+    ctx = ToolContext(workspace_root=tmp_path)
+    ctx.team = {
+        "team_name": "t", "lead_agent_id": "lead-1",
+        "sender_name": "team-lead",
+    }
+    return ctx
+
+
+def test_named_recipient_writes_to_mailbox(tmp_path: Path) -> None:
+    ctx = _seed_team(
+        tmp_path,
+        members=[TeamMember(agent_id="r1", name="researcher")],
+    )
+    result = _call_send_message(
+        {"to": "researcher", "message": "go investigate", "summary": "task"},
+        ctx,
+    )
+    assert result.is_error is False
+    msgs = read_mailbox(
+        "researcher", team_name="t", workspace_root=tmp_path,
+    )
+    assert len(msgs) == 1
+    assert msgs[0].text == "go investigate"
+    assert msgs[0].from_ == "team-lead"
+
+
+def test_broadcast_writes_to_every_member_except_sender(tmp_path: Path) -> None:
+    ctx = _seed_team(
+        tmp_path,
+        members=[
+            TeamMember(agent_id="r1", name="alice"),
+            TeamMember(agent_id="r2", name="bob"),
+            TeamMember(agent_id="r3", name="team-lead"),  # sender
+        ],
+    )
+    result = _call_send_message(
+        {"to": "*", "message": "all hands", "summary": "broadcast"},
+        ctx,
+    )
+    assert result.is_error is False
+    assert sorted(result.output["recipients"]) == ["alice", "bob"]
+
+    # Each recipient's mailbox got the message; team-lead did not.
+    assert len(read_mailbox("alice", team_name="t", workspace_root=tmp_path)) == 1
+    assert len(read_mailbox("bob", team_name="t", workspace_root=tmp_path)) == 1
+    assert read_mailbox(
+        "team-lead", team_name="t", workspace_root=tmp_path,
+    ) == []
+
+
+def test_unknown_recipient_returns_error(tmp_path: Path) -> None:
+    ctx = ToolContext(workspace_root=tmp_path)
+    # No team context, no in-process agent — branch 5 (error).
+    result = _call_send_message(
+        {"to": "ghost", "message": "knock knock", "summary": "x"},
+        ctx,
+    )
+    assert result.is_error is True
+    assert "not found" in result.output["message"].lower()
+
+
+def test_recipient_not_on_roster_rejected(tmp_path: Path) -> None:
+    """If the team has members but the recipient isn't on the roster,
+    reject (defense-in-depth — model could pass an arbitrary string)."""
+    ctx = _seed_team(
+        tmp_path,
+        members=[TeamMember(agent_id="r1", name="alice")],
+    )
+    result = _call_send_message(
+        {"to": "stranger", "message": "x", "summary": "x"}, ctx
+    )
+    assert result.is_error is True
+    assert "not on team" in result.output["message"]
+
+
+# ---------------------------------------------------------------------------
+# Validation — input shape rejection
+# ---------------------------------------------------------------------------
+
+
+def test_missing_to_raises(tmp_path: Path) -> None:
+    ctx = ToolContext(workspace_root=tmp_path)
+    with pytest.raises(ToolInputError):
+        _call_send_message({"message": "x", "summary": "x"}, ctx)
+
+
+def test_empty_to_raises(tmp_path: Path) -> None:
+    ctx = ToolContext(workspace_root=tmp_path)
+    with pytest.raises(ToolInputError):
+        _call_send_message({"to": "   ", "message": "x", "summary": "x"}, ctx)
+
+
+def test_at_in_to_raises(tmp_path: Path) -> None:
+    """TS rejects '@' in the ``to:`` field (one team per session)."""
+    ctx = ToolContext(workspace_root=tmp_path)
+    with pytest.raises(ToolInputError, match="@"):
+        _call_send_message(
+            {"to": "alice@team", "message": "x", "summary": "x"}, ctx
+        )
+
+
+def test_missing_message_raises(tmp_path: Path) -> None:
+    ctx = ToolContext(workspace_root=tmp_path)
+    with pytest.raises(ToolInputError):
+        _call_send_message({"to": "x", "summary": "x"}, ctx)
+
+
+def test_plain_text_message_requires_summary(tmp_path: Path) -> None:
+    """Per TS: plain-text messages need a summary for UI preview."""
+    ctx = _seed_team(tmp_path, members=[TeamMember(agent_id="r1", name="alice")])
+    with pytest.raises(ToolInputError, match="summary"):
+        _call_send_message({"to": "alice", "message": "no summary"}, ctx)
+
+
+# ---------------------------------------------------------------------------
+# WI-7.3 — Structured protocols
+# ---------------------------------------------------------------------------
+
+
+def test_shutdown_request_writes_envelope_to_mailbox(tmp_path: Path) -> None:
+    ctx = _seed_team(
+        tmp_path,
+        members=[TeamMember(agent_id="r1", name="researcher")],
+    )
+    result = _call_send_message(
+        {
+            "to": "researcher",
+            "message": {
+                "type": "shutdown_request",
+                "request_id": "req-1",
+                "reason": "end of session",
+            },
+        },
+        ctx,
+    )
+    assert result.is_error is False
+
+    msgs = read_mailbox(
+        "researcher", team_name="t", workspace_root=tmp_path,
+    )
+    assert len(msgs) == 1
+    envelope = json.loads(msgs[0].text)
+    assert envelope["type"] == "shutdown_request"
+    assert envelope["request_id"] == "req-1"
+    assert envelope["reason"] == "end of session"
+    assert envelope["from"] == "team-lead"
+
+
+def test_shutdown_response_approve(tmp_path: Path) -> None:
+    ctx = _seed_team(tmp_path, members=[TeamMember(agent_id="lead", name="team-lead")])
+    result = _call_send_message(
+        {
+            "to": "team-lead",
+            "message": {
+                "type": "shutdown_response",
+                "request_id": "req-1",
+                "approve": True,
+            },
+        },
+        ctx,
+    )
+    assert result.is_error is False
+    msgs = read_mailbox("team-lead", team_name="t", workspace_root=tmp_path)
+    envelope = json.loads(msgs[0].text)
+    assert envelope["type"] == "shutdown_response"
+    assert envelope["approved"] is True
+
+
+def test_shutdown_response_reject_requires_reason(tmp_path: Path) -> None:
+    ctx = _seed_team(tmp_path, members=[TeamMember(agent_id="lead", name="team-lead")])
+    with pytest.raises(ToolInputError, match="reason"):
+        _call_send_message(
+            {
+                "to": "team-lead",
+                "message": {
+                    "type": "shutdown_response",
+                    "request_id": "req-1",
+                    "approve": False,
+                },
+            },
+            ctx,
+        )
+
+
+def test_plan_approval_only_team_lead_can_send(tmp_path: Path) -> None:
+    """Sender-side authorization: ``is_team_lead`` gates plan approvals."""
+    ctx = _seed_team(
+        tmp_path, members=[TeamMember(agent_id="r1", name="researcher")],
+    )
+    # Active agent is NOT the team lead.
+    ctx.agent_id = "r1"
+    with pytest.raises(ToolInputError, match="team lead"):
+        _call_send_message(
+            {
+                "to": "researcher",
+                "message": {
+                    "type": "plan_approval_response",
+                    "request_id": "req-1",
+                    "approve": True,
+                    "permission_mode": "default",
+                },
+            },
+            ctx,
+        )
+
+
+def test_plan_approval_succeeds_when_sender_is_lead(tmp_path: Path) -> None:
+    ctx = _seed_team(
+        tmp_path, members=[TeamMember(agent_id="r1", name="researcher")],
+    )
+    # Lead identifies as the team lead.
+    ctx.agent_id = "lead-1"
+    result = _call_send_message(
+        {
+            "to": "researcher",
+            "message": {
+                "type": "plan_approval_response",
+                "request_id": "req-1",
+                "approve": True,
+                "permission_mode": "default",
+            },
+        },
+        ctx,
+    )
+    assert result.is_error is False
+    msgs = read_mailbox(
+        "researcher", team_name="t", workspace_root=tmp_path,
+    )
+    envelope = json.loads(msgs[0].text)
+    assert envelope["type"] == "plan_approval_response"
+    assert envelope["approved"] is True
+    assert envelope["from"] == "team-lead"
+
+
+def test_unknown_structured_type_raises(tmp_path: Path) -> None:
+    ctx = _seed_team(tmp_path, members=[TeamMember(agent_id="r1", name="alice")])
+    with pytest.raises(ToolInputError, match="Unknown structured-protocol"):
+        _call_send_message(
+            {
+                "to": "alice",
+                "message": {"type": "this_is_not_a_protocol"},
+            },
+            ctx,
+        )


### PR DESCRIPTION
## Summary

Phase 6 + Phase 7 — the largest single PR of the stack. Adds the swarm primitives (typed agent name registry, in-process teammate state with two-level abort, JSONL mailbox, team file + `is_team_lead` predicate) plus the `SendMessageTool` with 4-branch routing and race-guarded `resume_agent_background`.

**Phase 6 — swarm primitives:**
- `AgentNameRegistry` (`src/services/swarm/agent_name_registry.py`) — typed class with `claim_or_raise(name, agent_id, runtime_tasks)`. Atomic check-and-claim under `self._lock` so concurrent same-name spawns cannot both succeed. Closes a TOCTOU window that the bare-dict approach would have left open under coordinator-mode parallel spawns.
- `InProcessTeammateTaskState` (`src/tasks/in_process_teammate.py`) — chapter's full field set including `messages` cap at 50 (the chapter's 36GB-RSS guard). Two-level abort exception hierarchy (`TeammateAbortedError` and `CurrentWorkAbortedError` both subclass `asyncio.CancelledError`). `check_abort_events` reads `abort_event` FIRST so kill wins when both fire — deterministic ordering, not luck.
- `src/services/swarm/mailbox.py` — JSONL mailbox at `~/.clawcodex/mailboxes/<team>/<recipient>.jsonl`. `_sanitize_name` whitelist `[A-Za-z0-9_-]{1,64}` rejects path traversal vectors. Atomic O_APPEND, 0o600 file mode.
- `src/services/swarm/team_file.py` + `team_membership.py` — typed team file with `members[]` and `is_team_lead(context)` predicate (single source of truth for plan-approval gating).
- `TeammateStatus.CANCELLED → KILLED` rename (alias kept for one PR cycle).

**Phase 7 — SendMessage routing + auto-resume:**
- `src/tool_system/tools/send_message.py` — `SendMessageTool` with 4-branch routing in TS-parity order: `bridge:` (NotImplementedError stub) → `uds:` (NotImplementedError stub) → in-process → mailbox → error. Dispatch order is **AST-position-pinned** by a parity test using `ast.walk` + node-type filtering.
- Schema: `to`/`message` required, `summary` optional. `message` is `oneOf [string, structured-protocol]`.
- Structured protocols: `shutdown_request` / `shutdown_response` / `plan_approval_response`. **Sender-side `is_team_lead(context)` gate** on `plan_approval_response` raises `ToolInputError` for non-leader callers BEFORE any envelope is built.
- `src/agent/resume_agent.py` — `resume_agent_background()` with race-guarded atomic claim via `is_resuming` flag. Concurrent callers see exactly one winner; loser falls back to `queue_pending_message` against the winner's fresh state. Reads JSONL via `TranscriptReader` (Phase 2's DIP claim is now load-bearing).

111 new tests across 7 files. Includes:
- `threading.Barrier(2)` literal-race test for `AgentNameRegistry.claim_or_raise`
- 17 path-traversal rejection cases for the mailbox sanitizer
- AST-position-pinned dispatch order parity test
- `asyncio.gather`-based concurrent-resume race-guard test

**Stacked PR.** Base: `feat/ch10-coordination-phase5`. Merge after the Phase 5 PR.

## Test plan
- [x] `agent_name_registry` round-trips name ↔ agent_id with concurrent-spawn race test passing
- [x] Mailbox sanitization rejects 22 bad-name patterns including null byte, backslash, dots, unicode
- [x] `is_team_lead(ctx)` covers 6 truth cases (chapter's 4 + 2 defensive)
- [x] Two-level abort: redirect / kill / both-set-kill-wins / shutdown-cooperative all covered
- [x] SendMessage routing: 4 branches; AST-pinned dispatch order parity test passes
- [x] `resume_agent_background` reconstructs from JSONL; concurrent callers produce exactly one resumed agent
- [x] Plan-approval sender-side gate rejects non-leader before mailbox write
- [x] All Phase 0-5 tests still green