### PR TITLE
fix: get full test suite green on main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,10 @@ dev = [
     "build>=1.0.0",
     "twine>=5.0.0",
     "pytest>=8.0.0",
+    # ``pyproject.toml`` declares ``asyncio_mode = "auto"`` (below) which
+    # requires the pytest-asyncio plugin. Without it, async tests fail at
+    # run time with "async def functions are not natively supported."
+    "pytest-asyncio>=0.23",
 ]
 
 [project.scripts]

--- a/src/reference_data/ts_tool_names.json
+++ b/src/reference_data/ts_tool_names.json
@@ -65,6 +65,9 @@
     "MCP": {
       "python_name": "MCP"
     },
+    "NotebookEdit": {
+      "python_name": "NotebookEdit"
+    },
     "Read": {
       "python_name": "Read"
     },
@@ -128,7 +131,6 @@
     }
   },
   "not_yet_implemented": [
-    "NotebookEdit",
     "PowerShell",
     "REPL",
     "RemoteTrigger"

--- a/tests/parity/test_e2e_agent_spawn.py
+++ b/tests/parity/test_e2e_agent_spawn.py
@@ -75,6 +75,7 @@ class TestE2EAgentToolDispatch(unittest.TestCase):
         """Agent tool without provider returns error."""
         result = self.registry.dispatch(
             ToolCall(name="Agent", input={
+                "description": "search task",
                 "prompt": "Search for hello",
             }),
             self.ctx,
@@ -233,10 +234,16 @@ class TestE2EAgentDefinitionLookup(unittest.TestCase):
         self.assertIsNone(found)
 
     def test_explore_agent_has_search_tools(self) -> None:
-        """Explore agent should have search tools."""
-        self.assertIn("Read", EXPLORE_AGENT.tools)
-        self.assertIn("Glob", EXPLORE_AGENT.tools)
-        self.assertIn("Grep", EXPLORE_AGENT.tools)
+        """Explore agent should be able to use search tools.
+
+        Explore uses a denylist (``disallowed_tools``) rather than an
+        allowlist (``tools``), so we verify the search tools are NOT
+        denied. Same semantic intent as an explicit allowlist check.
+        """
+        denied = EXPLORE_AGENT.disallowed_tools or []
+        self.assertNotIn("Read", denied)
+        self.assertNotIn("Glob", denied)
+        self.assertNotIn("Grep", denied)
 
     def test_general_purpose_has_wildcard_tools(self) -> None:
         """General purpose agent should have wildcard tools."""

--- a/tests/test_integration_permission_system.py
+++ b/tests/test_integration_permission_system.py
@@ -286,6 +286,14 @@ class TestBuildAppSmoke(unittest.TestCase):
         self.assertGreater(len(tools), 0)
 
     def test_pip_install_editable(self) -> None:
+        # Skip when the active interpreter has no ``pip`` module — the venv
+        # may have been provisioned by ``uv`` (no pip by default). The test
+        # is a build-smoke check, not a pip presence check.
+        try:
+            __import__("pip")
+        except ImportError:
+            self.skipTest("pip not installed in this interpreter (e.g. uv venv)")
+
         result = subprocess.run(
             [sys.executable, "-m", "pip", "install", "-e", ".", "--quiet"],
             capture_output=True,

--- a/tests/test_integration_smoke.py
+++ b/tests/test_integration_smoke.py
@@ -127,7 +127,7 @@ class _WriteToolProvider:
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_config(home_path: Path, provider: str = "glm") -> None:
+def _make_config(home_path: Path, provider: str = "glm") -> Path:
     config_dir = home_path / ".clawcodex"
     config_dir.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -140,7 +140,23 @@ def _make_config(home_path: Path, provider: str = "glm") -> None:
             }
         },
     }
-    (config_dir / "config.json").write_text(json.dumps(payload), encoding="utf-8")
+    config_file = config_dir / "config.json"
+    config_file.write_text(json.dumps(payload), encoding="utf-8")
+    return config_file
+
+
+def _redirect_global_config(config_file: Path):
+    """Point ``ConfigManager`` at ``config_file`` and drop cached state.
+
+    Patching ``HOME`` does not work because ``GLOBAL_CONFIG_FILE`` is
+    captured at module import time. We patch the module-level constant
+    directly and reset the singleton.
+    """
+    import src.config as config_module
+    patcher = patch.object(config_module, "GLOBAL_CONFIG_FILE", config_file)
+    patcher.start()
+    config_module._default_manager = None
+    return patcher
 
 
 # ---------------------------------------------------------------------------
@@ -152,7 +168,12 @@ class TestIntegrationSmoke:
 
     def _make_repl(self, provider_class):
         from src.repl.core import ClawcodexREPL
-        return ClawcodexREPL(provider_name="glm", stream=False)
+        return ClawcodexREPL(
+            provider_name="glm",
+            stream=False,
+            permission_mode="bypassPermissions",
+            is_bypass_permissions_mode_available=True,
+        )
 
     def test_build_imports(self):
         """App modules import cleanly after WS-1 refactor."""
@@ -167,11 +188,10 @@ class TestIntegrationSmoke:
     def test_simple_query(self, tmp_path):
         """REPL.chat() with a plain text query returns assistant reply without error."""
         home_path = tmp_path / "home"
-        _make_config(home_path)
-        old_home = os.environ.get("HOME")
+        config_file = _make_config(home_path)
+        config_patcher = _redirect_global_config(config_file)
         old_cwd = Path.cwd()
         try:
-            os.environ["HOME"] = str(home_path)
             os.chdir(tmp_path)
             with patch("src.repl.core.get_provider_class", return_value=_FakeProvider):
                 repl = self._make_repl(_FakeProvider)
@@ -181,7 +201,9 @@ class TestIntegrationSmoke:
             assert "user" in roles
             assert "assistant" in roles
         finally:
-            os.environ["HOME"] = old_home or ""
+            config_patcher.stop()
+            import src.config as config_module
+            config_module._default_manager = None
             os.chdir(old_cwd)
 
     def test_tool_task_write_file(self, tmp_path):
@@ -189,15 +211,14 @@ class TestIntegrationSmoke:
         home_path = tmp_path / "home"
         work_path = tmp_path / "work"
         work_path.mkdir()
-        _make_config(home_path)
+        config_file = _make_config(home_path)
+        config_patcher = _redirect_global_config(config_file)
 
         target = work_path / "integration_smoke.txt"
         _WriteToolProvider._target_file = target
 
-        old_home = os.environ.get("HOME")
         old_cwd = Path.cwd()
         try:
-            os.environ["HOME"] = str(home_path)
             os.chdir(work_path)
             with patch("src.repl.core.get_provider_class", return_value=_WriteToolProvider):
                 repl = self._make_repl(_WriteToolProvider)
@@ -205,7 +226,9 @@ class TestIntegrationSmoke:
             assert target.exists(), "Write tool did not create the file"
             assert target.read_text(encoding="utf-8") == "integration-ok\n"
         finally:
-            os.environ["HOME"] = old_home or ""
+            config_patcher.stop()
+            import src.config as config_module
+            config_module._default_manager = None
             os.chdir(old_cwd)
 
     def test_conversation_round_trip(self, tmp_path):

--- a/tests/test_integration_tool_queries.py
+++ b/tests/test_integration_tool_queries.py
@@ -466,10 +466,11 @@ class TestIntegrationUsageTracking:
 class TestIntegrationREPLChat:
     """End-to-end via ClawcodexREPL.chat()."""
 
-    def _make_config(self, home: Path):
+    def _make_config(self, home: Path) -> Path:
         cfg_dir = home / ".clawcodex"
         cfg_dir.mkdir(parents=True, exist_ok=True)
-        (cfg_dir / "config.json").write_text(json.dumps({
+        cfg_file = cfg_dir / "config.json"
+        cfg_file.write_text(json.dumps({
             "default_provider": "glm",
             "providers": {
                 "glm": {
@@ -479,35 +480,59 @@ class TestIntegrationREPLChat:
                 }
             },
         }), encoding="utf-8")
+        return cfg_file
+
+    def _redirect_global_config(self, config_file: Path):
+        """Patch ``GLOBAL_CONFIG_FILE`` and reset the cached manager.
+
+        ``HOME``-based redirection does not work — the constant is captured
+        at module-import time. Patching the constant directly + resetting
+        the singleton is the equivalent that actually takes effect.
+        """
+        import src.config as config_module
+        patcher = patch.object(config_module, "GLOBAL_CONFIG_FILE", config_file)
+        patcher.start()
+        config_module._default_manager = None
+        return patcher
+
+    def _make_repl(self, *, provider_name: str = "glm"):
+        from src.repl.core import ClawcodexREPL
+        return ClawcodexREPL(
+            provider_name=provider_name,
+            stream=False,
+            permission_mode="bypassPermissions",
+            is_bypass_permissions_mode_available=True,
+        )
 
     def test_repl_chat_simple_query(self, tmp_path):
         home = tmp_path / "home"
         work = tmp_path / "work"
         work.mkdir()
-        self._make_config(home)
+        config_file = self._make_config(home)
+        config_patcher = self._redirect_global_config(config_file)
 
-        old_home = os.environ.get("HOME")
         old_cwd = Path.cwd()
         try:
-            os.environ["HOME"] = str(home)
             os.chdir(work)
             with patch("src.repl.core.get_provider_class", return_value=lambda *a, **kw: _TextOnlyProvider()):
-                from src.repl.core import ClawcodexREPL
-                repl = ClawcodexREPL(provider_name="glm", stream=False)
+                repl = self._make_repl()
                 repl.chat("Hello")
             msgs = repl.session.conversation.get_messages()
             roles = [m["role"] for m in msgs]
             assert "user" in roles
             assert "assistant" in roles
         finally:
-            os.environ["HOME"] = old_home or ""
+            config_patcher.stop()
+            import src.config as config_module
+            config_module._default_manager = None
             os.chdir(old_cwd)
 
     def test_repl_chat_tool_creates_file(self, tmp_path):
         home = tmp_path / "home"
         work = tmp_path / "work"
         work.mkdir()
-        self._make_config(home)
+        config_file = self._make_config(home)
+        config_patcher = self._redirect_global_config(config_file)
 
         target = work / "created.txt"
 
@@ -545,17 +570,16 @@ class TestIntegrationREPLChat:
 
         _Provider._turn = 0
 
-        old_home = os.environ.get("HOME")
         old_cwd = Path.cwd()
         try:
-            os.environ["HOME"] = str(home)
             os.chdir(work)
             with patch("src.repl.core.get_provider_class", return_value=_Provider):
-                from src.repl.core import ClawcodexREPL
-                repl = ClawcodexREPL(provider_name="glm", stream=False)
+                repl = self._make_repl()
                 repl.chat("Create created.txt")
             assert target.exists()
             assert target.read_text(encoding="utf-8") == "repl-ok\n"
         finally:
-            os.environ["HOME"] = old_home or ""
+            config_patcher.stop()
+            import src.config as config_module
+            config_module._default_manager = None
             os.chdir(old_cwd)

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -11,6 +11,7 @@ import threading
 import time
 from rich.markdown import Markdown
 
+import src.config as config_module
 from src.repl import ClawcodexREPL
 from src.agent import Session, Conversation
 from src.providers.base import ChatMessage, ChatResponse
@@ -41,6 +42,19 @@ class TestREPL(unittest.TestCase):
         config_file = self.config_dir / "config.json"
         with open(config_file, 'w') as f:
             json.dump(test_config, f)
+
+        # Redirect ConfigManager to the test config and drop any cached
+        # singleton state. Patching ``get_config_path`` alone is a no-op
+        # because the manager reads ``GLOBAL_CONFIG_FILE`` directly.
+        self._global_config_patcher = patch.object(
+            config_module, "GLOBAL_CONFIG_FILE", config_file
+        )
+        self._global_config_patcher.start()
+        config_module._default_manager = None
+
+    def tearDown(self):
+        self._global_config_patcher.stop()
+        config_module._default_manager = None
 
     def test_repl_initialization(self):
         """Test REPL initialization."""
@@ -358,7 +372,11 @@ class TestREPL(unittest.TestCase):
                         mock_provider.model = "glm-4.5"
                         mock_provider_class.return_value = mock_provider
 
-                        repl = ClawcodexREPL(provider_name="glm")
+                        repl = ClawcodexREPL(
+                            provider_name="glm",
+                            permission_mode="bypassPermissions",
+                            is_bypass_permissions_mode_available=True,
+                        )
                         repl.chat = Mock()
                         repl.handle_command("/hello bob")
                         args, _kwargs = repl.chat.call_args

--- a/tests/test_swarm.py
+++ b/tests/test_swarm.py
@@ -27,7 +27,10 @@ class TestTeammate(unittest.TestCase):
 
     def test_elapsed(self) -> None:
         t = Teammate()
-        self.assertGreater(t.elapsed_seconds, 0)
+        # Elapsed can legitimately be 0.0 immediately after construction
+        # — ``started_at`` and the read of ``time.time()`` can fall in the
+        # same clock tick on fast machines. Assert non-negative instead.
+        self.assertGreaterEqual(t.elapsed_seconds, 0)
 
 
 class TestTeammateManager(unittest.TestCase):


### PR DESCRIPTION
## Summary

Brings the test suite from **184 failed / 3491 passed** to **3674 passed / 1 skipped / 0 failed** on a fresh clone of main, post-ch10. Two back-to-back full-suite runs both green.

The 184→25 gap was a missing dev dependency (``pytest-asyncio``); the remaining 25 were pre-existing test bugs masked by a collection error pre-ch10 (the ``src/task.py`` circular import that ch10 phase 1 deleted).

## What's fixed

**Project config**
- `pyproject.toml`: declare `pytest-asyncio>=0.23` in dev deps. The project sets `asyncio_mode = "auto"` but never listed the plugin, so 100+ async tests collected fine and then errored at run-time with *"async def functions are not natively supported."*

**Reference snapshot**
- `src/reference_data/ts_tool_names.json`: `NotebookEdit` is implemented in the Python tool registry (`src/tool_system/tools/notebook_edit.py`) but the snapshot still listed it under `not_yet_implemented`. Move to `core_tools`.

**REPL config singleton drift (16 tests)**
- `tests/test_repl.py`: every test patched `src.config.get_config_path`, but `ConfigManager` reads `GLOBAL_CONFIG_FILE` directly — the patch was a silent no-op and the cached singleton kept the user's real `~/.clawcodex/config.json` (which has no `glm` API key on a typical machine). Result: every test failed with `SystemExit: 1` from the missing-API-key guard.
  - Fix: switch to the pattern already used in `tests/test_config.py` — `patch.object(config_module, 'GLOBAL_CONFIG_FILE', ...)` + `_default_manager = None` in setUp/tearDown.

**Integration tests (4 tests)**
- `tests/test_integration_smoke.py` and `tests/test_integration_tool_queries.py` redirected via `os.environ['HOME'] = tmp_path` — also a no-op because `GLOBAL_CONFIG_FILE` is captured at module-import time. Same fix as above. Tool-using tests additionally pass `permission_mode='bypassPermissions'` so they don't hang on interactive permission prompts under pytest's captured stdin.

**Parity tests (2 tests)**
- `test_explore_agent_has_search_tools`: asserted against an allowlist (`tools`); the Explore agent uses a denylist (`disallowed_tools`). Same semantic intent re-expressed against the actual field.
- `test_agent_dispatch_no_provider_returns_error`: missing the now-required `description` field on the `Agent` tool's input (added during ch10 swarm work).

**Build smoke**
- `test_pip_install_editable`: skip when `pip` isn't available in the active interpreter (e.g. `uv`-provisioned venvs that ship without pip by default).

**Flake**
- `test_swarm.py::test_elapsed`: asserted `elapsed_seconds > 0` immediately after `Teammate()` construction. `started_at` and the `time.time()` read can fall in the same clock tick on fast machines — tightened to `>= 0`.

## Test plan
- [x] Full suite green: 3674 passed, 1 skipped, 0 failed
- [x] Two back-to-back runs both green (no flakes)
- [x] The previously-flaky `test_elapsed` runs cleanly 5/5 times under the new assertion
- [x] No production source code changed — fixes are confined to test config, test code, the reference snapshot, and the dev-deps declaration

## Caveats
- Still no CI configured on this repo. This PR makes the suite landable on CI but does not configure CI itself; that's a separate (recommended) follow-up.