### PR TITLE
feat(ch12): phase 1 — type-system foundation (events, sources, schema, env)

### DIFF
--- a/src/hooks/config_manager.py
+++ b/src/hooks/config_manager.py
@@ -42,7 +42,7 @@ def _get_settings_path() -> Path:
     return Path.home() / ".claude" / "settings.json"
 
 
-def _parse_hook_config(raw: dict[str, Any]) -> HookConfig:
+def _parse_hook_config(raw: dict[str, Any], source: HookSource | None = None) -> HookConfig:
     hook_type = raw.get("type", "command")
     return HookConfig(
         type=hook_type,
@@ -52,7 +52,14 @@ def _parse_hook_config(raw: dict[str, Any]) -> HookConfig:
         url=raw.get("url"),
         prompt_text=raw.get("promptText") or raw.get("prompt_text"),
         agent_instructions=raw.get("agentInstructions") or raw.get("agent_instructions"),
-        source=HookSource.SETTINGS,
+        # Phase-1 / WI-1.3 — new fields. Settings.json is permissive on key
+        # casing: accept both ``if_condition`` (snake_case, Python-native) and
+        # ``if`` (TS-native, matches schemas/hooks.ts). ``once`` stays as a
+        # bool. ``skill_root`` is NOT parsed from settings — only set at
+        # skill-hook registration time (Phase 3).
+        if_condition=raw.get("if_condition") or raw.get("if"),
+        once=bool(raw.get("once", False)),
+        source=source if source is not None else HookSource.USER_SETTINGS,
     )
 
 
@@ -71,6 +78,29 @@ def validate_hook_configs(
                 severity="warning",
             ))
             continue
+
+        # Per-hook field validation for the WI-1.3 additions:
+        # ``if`` / ``if_condition`` must be a string when present;
+        # ``once`` must be a bool.
+        if isinstance(hook_list, list):
+            for i, hook_raw in enumerate(hook_list):
+                if not isinstance(hook_raw, dict):
+                    continue
+                if_value = hook_raw.get("if_condition", hook_raw.get("if"))
+                if if_value is not None and not isinstance(if_value, str):
+                    errors.append(HookValidationError(
+                        event=event_name,
+                        index=i,
+                        field="if",
+                        message="`if` must be a string (permission-rule grammar)",
+                    ))
+                if "once" in hook_raw and not isinstance(hook_raw["once"], bool):
+                    errors.append(HookValidationError(
+                        event=event_name,
+                        index=i,
+                        field="once",
+                        message="`once` must be a boolean",
+                    ))
 
         if not isinstance(hook_list, list):
             errors.append(HookValidationError(
@@ -149,6 +179,54 @@ def validate_hook_configs(
     return errors
 
 
+# ---------------------------------------------------------------------------
+# Phase-1 / WI-1.1 — legacy back-compat reader for lifecycle events.
+# ---------------------------------------------------------------------------
+
+# Pre-Phase-1, ``SessionStart`` / ``SessionEnd`` / compaction events were
+# routed through the ``Notification`` event with a magic matcher string.
+# Phase 1 promotes them to first-class events; this map preserves the legacy
+# form for one CHANGELOG cycle. The matcher can be either ``onSessionStart``
+# (legacy code path in ``session_hooks.py`` pre-Phase-1) or the bare event
+# name (used in the regression test). Both translate to the same first-class
+# event with a DeprecationWarning.
+_LEGACY_NOTIFICATION_MATCHER_TO_EVENT: dict[str, HookEvent] = {
+    "onSessionStart": "SessionStart",
+    "onSessionEnd": "SessionEnd",
+    "onCompact": "PreCompact",
+    "SessionStart": "SessionStart",
+    "SessionEnd": "SessionEnd",
+    "PreCompact": "PreCompact",
+    "PostCompact": "PostCompact",
+}
+
+
+def _translate_legacy_notification_entry(
+    hook_raw: dict[str, Any],
+) -> HookEvent | None:
+    """If ``hook_raw`` carries a legacy lifecycle matcher under
+    ``Notification``, return the canonical first-class event name; else None.
+
+    Emits a DeprecationWarning at translation time so settings authors see
+    one warning per offending entry.
+    """
+    matcher = hook_raw.get("matcher")
+    if not isinstance(matcher, str):
+        return None
+    target = _LEGACY_NOTIFICATION_MATCHER_TO_EVENT.get(matcher)
+    if target is None:
+        return None
+    import warnings as _warnings
+    _warnings.warn(
+        f"Hook registered under 'Notification' with matcher={matcher!r} is "
+        f"deprecated; use the first-class event {target!r} directly. "
+        "Will be removed two CHANGELOG entries after the rename.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    return target
+
+
 def load_hooks_from_settings(
     settings_path: str | Path | None = None,
 ) -> HookConfigSnapshot:
@@ -171,12 +249,17 @@ def load_hooks_from_settings(
     for event_name, hook_list in hooks_raw.items():
         if not isinstance(hook_list, list):
             continue
-        configs: list[HookConfig] = []
         for hook_raw in hook_list:
-            if isinstance(hook_raw, dict):
-                configs.append(_parse_hook_config(hook_raw))
-        if configs:
-            hooks[event_name] = configs
+            if not isinstance(hook_raw, dict):
+                continue
+            # Phase-1 / WI-1.1 — legacy ``Notification + matcher`` form
+            # translates to first-class lifecycle events.
+            target_event: str = event_name
+            if event_name == "Notification":
+                translated = _translate_legacy_notification_entry(hook_raw)
+                if translated is not None:
+                    target_event = translated
+            hooks.setdefault(target_event, []).append(_parse_hook_config(hook_raw))
 
     return HookConfigSnapshot(
         hooks=hooks,
@@ -204,7 +287,7 @@ class HookConfigManager:
         snapshot = load_hooks_from_settings(self._settings_path)
         self._snapshot = snapshot
 
-        await self._registry.clear_source(HookSource.SETTINGS)
+        await self._registry.clear_source(HookSource.USER_SETTINGS)
 
         for event_name, hook_configs in snapshot.hooks.items():
             for config in hook_configs:
@@ -212,7 +295,7 @@ class HookConfigManager:
                     await self._registry.register(
                         event_name,  # type: ignore[arg-type]
                         config,
-                        HookSource.SETTINGS,
+                        HookSource.USER_SETTINGS,
                     )
 
         try:

--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -136,11 +136,75 @@ def _matches_tool(matcher: str | None, tool_name: str) -> bool:
     return matcher == tool_name
 
 
+def _build_hook_env(
+    hook: HookConfig,
+    stdin_data: dict[str, Any],
+    tool_use_context: Any | None,
+) -> dict[str, str]:
+    """Compute the env-var dict passed to a command-hook subprocess.
+
+    Phase-1 / WI-1.5 — adds three vars on top of inherited ``os.environ``:
+
+      * ``CLAUDE_HOOK_EVENT`` — the canonical event name (existing).
+      * ``CLAUDE_PROJECT_DIR`` — workspace root from the active context.
+        Empty string if the context doesn't carry a workspace_root.
+      * ``CLAUDE_PLUGIN_ROOT`` — set from ``hook.skill_root`` (populated only
+        for skill-declared hooks; empty for everything else).
+      * ``CLAUDE_ENV_FILE`` — per-fire ephemeral env file path. Set ONLY for
+        the three lifecycle events that benefit from env propagation
+        (``SessionStart``, ``Setup``, ``CwdChanged``). For other events:
+        empty string. Per N4: this WI sets the path; the
+        sourcing-and-applying loop (read the file back and apply exports to
+        subsequent shells in the session) is a separate follow-up ticket.
+        TODO(ch12-followup): ticket #<TBD> covers the env-file source/apply
+        cycle.
+    """
+    event_name = stdin_data.get("hook_event", "")
+    workspace_root = ""
+    if tool_use_context is not None:
+        wr = getattr(tool_use_context, "workspace_root", None)
+        if wr is not None:
+            workspace_root = str(wr)
+
+    env_file = _env_file_for_event(event_name)
+
+    return {
+        **os.environ,
+        "CLAUDE_HOOK_EVENT": event_name,
+        "CLAUDE_PROJECT_DIR": workspace_root,
+        "CLAUDE_PLUGIN_ROOT": hook.skill_root or "",
+        "CLAUDE_ENV_FILE": env_file,
+    }
+
+
+def _env_file_for_event(event_name: str) -> str:
+    """Return a writable path for the hook to write env exports to.
+
+    Only set for events whose hooks may legitimately propagate env to
+    subsequent shells in the session (TS pattern). For other events, return
+    empty string — the hook MAY still observe ``CLAUDE_ENV_FILE`` and treat
+    "empty" as "no env propagation requested."
+
+    The file is per-fire ephemeral: a unique path under
+    ``~/.clawcodex/hook-env/<event>.<pid>.<nanos>``. This WI does NOT
+    create the file or read it back; it only computes the path. Sourcing is
+    a follow-up.
+    """
+    if event_name not in ("SessionStart", "Setup", "CwdChanged"):
+        return ""
+    home = os.path.expanduser("~")
+    return os.path.join(
+        home, ".clawcodex", "hook-env",
+        f"{event_name}.{os.getpid()}.{time.time_ns()}",
+    )
+
+
 async def _execute_command_hook(
     hook: HookConfig,
     stdin_data: dict[str, Any],
     abort_signal: Any | None = None,
     timeout_ms: int = TOOL_HOOK_EXECUTION_TIMEOUT_MS,
+    tool_use_context: Any | None = None,
 ) -> HookResult:
     command = hook.command
     if not command:
@@ -157,7 +221,7 @@ async def _execute_command_hook(
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            env={**os.environ, "CLAUDE_HOOK_EVENT": stdin_data.get("hook_event", "")},
+            env=_build_hook_env(hook, stdin_data, tool_use_context),
         )
 
         try:
@@ -218,25 +282,33 @@ async def _execute_command_hook(
             command=command,
         )
 
+        # Phase-1 / WI-1.4 — schema-validated output parsing. Replaces the
+        # prior ad-hoc ``dict.get`` block: malformed output (capital-D
+        # ``Deny``, unknown fields, non-string ``reason``, etc.) used to no-op
+        # silently; now it logs a WARNING and the decision payload is
+        # dropped (exit code is still honored).
         if stdout:
-            try:
-                parsed = json.loads(stdout)
-                if isinstance(parsed, dict):
-                    decision = parsed.get("decision")
-                    if decision in ("allow", "deny", "ask"):
-                        result.permission_behavior = decision
-                        result.hook_permission_decision_reason = parsed.get("reason")
-                    if parsed.get("updatedInput"):
-                        result.updated_input = parsed["updatedInput"]
-                    if parsed.get("preventContinuation"):
-                        result.prevent_continuation = True
-                        result.stop_reason = parsed.get("stopReason")
-                    if parsed.get("additionalContexts"):
-                        result.additional_contexts = parsed["additionalContexts"]
-                    if parsed.get("updatedMCPToolOutput"):
-                        result.updated_mcp_tool_output = parsed["updatedMCPToolOutput"]
-            except json.JSONDecodeError:
-                pass
+            from src.hooks.output_schema import parse_hook_output  # local import: pydantic
+            parsed, err = parse_hook_output(stdout)
+            if err is not None:
+                logger.warning(
+                    "Hook %r emitted output that failed schema validation; "
+                    "dropping decision payload. error=%s stdout=%r",
+                    command, err, stdout[:200],
+                )
+            elif parsed is not None:
+                if parsed.decision is not None:
+                    result.permission_behavior = parsed.decision
+                    result.hook_permission_decision_reason = parsed.reason
+                if parsed.updatedInput:
+                    result.updated_input = parsed.updatedInput
+                if parsed.preventContinuation:
+                    result.prevent_continuation = True
+                    result.stop_reason = parsed.stopReason
+                if parsed.additionalContexts:
+                    result.additional_contexts = parsed.additionalContexts
+                if parsed.updatedMCPToolOutput is not None:
+                    result.updated_mcp_tool_output = parsed.updatedMCPToolOutput
 
         return result
 
@@ -271,11 +343,12 @@ async def _run_hooks_for_event(
 
     if trust_skip:
         # Drop everything that isn't a policy-source hook. ``HookConfig.source``
-        # is a ``HookSource`` enum; any non-POLICY value is gated. Imported
+        # is a ``HookSource`` enum; any non-policy value is gated. Imported
         # locally to avoid pulling the enum into module-init paths that don't
-        # need it.
-        from src.hooks.hook_types import HookSource
-        event_hooks = [h for h in event_hooks if h.source == HookSource.POLICY]
+        # need it. Phase-1 / WI-1.2 renamed ``POLICY`` → ``POLICY_SETTINGS``;
+        # the ``is_policy`` predicate is the canonical way to ask the
+        # question and shields callers from future renames.
+        event_hooks = [h for h in event_hooks if h.source.is_policy]
 
     tool_use_id = stdin_data.get("tool_use_id", str(uuid4()))
     parent_tool_use_id = ""
@@ -297,6 +370,7 @@ async def _run_hooks_for_event(
             {**stdin_data, "hook_event": event},
             abort_signal=abort_signal,
             timeout_ms=timeout_ms,
+            tool_use_context=tool_use_context,
         )
 
         if result.blocking_error:

--- a/src/hooks/hook_types.py
+++ b/src/hooks/hook_types.py
@@ -1,54 +1,221 @@
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import Enum, EnumMeta
 from typing import Any, Literal
 
+# ---------------------------------------------------------------------------
+# Hook events — Chapter-12 / Phase-1 / WI-1.1
+# ---------------------------------------------------------------------------
+#
+# 25-event taxonomy promoted from the legacy 10-event Literal. Mirrors
+# typescript/src/utils/hooks/hooksConfigManager.ts:26-267 plus the chapter's
+# reference table (``ch12-extensibility.md`` §"Five Most Important Lifecycle
+# Events" + §"Reference table — remaining events").
+#
+# Per assumption A1 (resolved-by-critic in §19 of the plan):
+# ``SessionStart``, ``SessionEnd``, ``PreCompact``, ``PostCompact`` are
+# **first-class** events — no longer routed through ``Notification`` with a
+# magic matcher string. The legacy form is supported by a back-compat
+# translator in ``config_manager.load_hooks_from_settings`` for one CHANGELOG
+# cycle (with DeprecationWarning).
 HookEvent = Literal[
+    # --- Tool lifecycle ---
     "PreToolUse",
     "PostToolUse",
     "PostToolUseFailure",
-    "Stop",
+    # --- Permission ---
+    "PermissionDenied",
+    "PermissionRequest",
+    # --- Session ---
+    "SessionStart",
+    "SessionEnd",
+    "Setup",
+    # --- Subagent ---
+    "SubagentStart",
     "SubagentStop",
+    # --- Stop / continuation ---
+    "Stop",
+    "StopFailure",
+    # --- Compaction ---
+    "PreCompact",
+    "PostCompact",
+    # --- Notification (general-purpose; no longer a routing target for
+    # SessionStart etc. after Phase 1) ---
+    "Notification",
+    # --- User input ---
+    "UserPromptSubmit",
+    # --- Sampling lifecycle ---
+    "PostSampling",
+    # --- Configuration ---
+    "ConfigChange",
+    "InstructionsLoaded",
+    "CwdChanged",
+    "FileChanged",
+    # --- Workspace ---
+    "WorktreeCreate",
+    "WorktreeRemove",
+    # --- Task lifecycle ---
+    "TaskCreated",
     "TaskCompleted",
     "TeammateIdle",
-    "Notification",
-    "UserPromptSubmit",
-    "PostSampling",
+    # --- Elicitation (MCP-related) ---
+    "Elicitation",
+    "ElicitationResult",
 ]
 
 ALL_HOOK_EVENTS: list[HookEvent] = [
+    # Tool lifecycle
     "PreToolUse",
     "PostToolUse",
     "PostToolUseFailure",
-    "Stop",
+    # Permission
+    "PermissionDenied",
+    "PermissionRequest",
+    # Session
+    "SessionStart",
+    "SessionEnd",
+    "Setup",
+    # Subagent
+    "SubagentStart",
     "SubagentStop",
+    # Stop
+    "Stop",
+    "StopFailure",
+    # Compaction
+    "PreCompact",
+    "PostCompact",
+    # Notification
+    "Notification",
+    # User input
+    "UserPromptSubmit",
+    # Sampling
+    "PostSampling",
+    # Configuration
+    "ConfigChange",
+    "InstructionsLoaded",
+    "CwdChanged",
+    "FileChanged",
+    # Workspace
+    "WorktreeCreate",
+    "WorktreeRemove",
+    # Task lifecycle
+    "TaskCreated",
     "TaskCompleted",
     "TeammateIdle",
-    "Notification",
-    "UserPromptSubmit",
-    "PostSampling",
+    # Elicitation
+    "Elicitation",
+    "ElicitationResult",
 ]
 
+
+# Hook *type* — the kind of executor that runs the hook. Phase-1 keeps the
+# four config-driven types; ``callback`` lands in Phase 9 (gap #12).
 HookType = Literal["command", "agent", "http", "prompt"]
 
 
-class HookSource(str, Enum):
-    POLICY = "policy"
-    SETTINGS = "settings"
-    FRONTMATTER = "frontmatter"
-    SKILLS = "skills"
-    PLUGINS = "plugins"
+# ---------------------------------------------------------------------------
+# Hook source — Chapter-12 / Phase-1 / WI-1.2
+# ---------------------------------------------------------------------------
+#
+# Six-source priority scheme matching TS ``hooksSettings.ts:103-107``. Priority
+# is an integer attribute (not the enum's ordinal) so PLUGIN_HOOK can carry the
+# 999 sentinel meaning "always last," consistent with the chapter table.
+#
+# **Renamed from Phase 0:**
+#   - ``SETTINGS`` → ``USER_SETTINGS`` (split from ``PROJECT_SETTINGS`` +
+#     ``LOCAL_SETTINGS``).
+#   - ``POLICY`` → ``POLICY_SETTINGS``.
+#   - ``PLUGINS`` → ``PLUGIN_HOOK``.
+#
+# **Removed:** ``FRONTMATTER`` and ``SKILLS`` had no producer in Phase 0
+# (gap analysis §5). Removed outright.
+#
+# **Deprecation aliases:** the ``EnumMeta``-level ``__getattr__`` on the
+# metaclass below intercepts the old names, emits a ``DeprecationWarning``,
+# and returns the new value. Callers see continuity for one CHANGELOG cycle.
+
+
+class _HookSourceMeta(EnumMeta):
+    """Intercept legacy enum-name access (``HookSource.SETTINGS`` etc.) at the
+    metaclass level so the back-compat alias path can emit ``DeprecationWarning``.
+
+    Module-level ``__getattr__`` (PEP 562) does not apply here: ``HookSource.X``
+    is a class-attribute access on the enum, resolved via the metaclass.
+    """
+
+    _DEPRECATED_ALIASES: dict[str, str] = {
+        "SETTINGS": "USER_SETTINGS",
+        "POLICY": "POLICY_SETTINGS",
+        "PLUGINS": "PLUGIN_HOOK",
+    }
+
+    def __getattr__(cls, name: str):
+        # Dunder names: defer to default lookup (raises AttributeError as
+        # EnumMeta does); avoids spurious DeprecationWarning paths and lets
+        # ``hasattr(HookSource, "__name__")`` etc. work normally.
+        if name.startswith("_"):
+            return EnumMeta.__getattr__(cls, name)
+
+        if name in cls._DEPRECATED_ALIASES:
+            new_name = cls._DEPRECATED_ALIASES[name]
+            warnings.warn(
+                f"HookSource.{name} is deprecated; use HookSource.{new_name}. "
+                "Will be removed two CHANGELOG entries after the rename.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            # Resolve the canonical member via the enum's member map. We index
+            # into ``_member_map_`` rather than recurse through ``__getattr__``
+            # to keep the warning fire site exact (one warning per alias use,
+            # not two).
+            return cls._member_map_[new_name]
+
+        return EnumMeta.__getattr__(cls, name)
+
+
+class HookSource(str, Enum, metaclass=_HookSourceMeta):
+    USER_SETTINGS = "userSettings"
+    PROJECT_SETTINGS = "projectSettings"
+    LOCAL_SETTINGS = "localSettings"
+    POLICY_SETTINGS = "policySettings"
+    SESSION_HOOK = "sessionHook"
+    PLUGIN_HOOK = "pluginHook"
 
     @property
     def priority(self) -> int:
+        """Sort key for snapshot ordering. Lower = sorts first.
+
+        The 999 sentinel for ``PLUGIN_HOOK`` matches TS' pattern ("always
+        last") so insertions of new tiers between the canonical ones don't
+        disturb plugin ordering. Note: priority is an *ordering* attribute
+        only — the chapter's "policy cannot be overridden" semantic is
+        enforced by ``apply_policy_cascade`` (Phase 2 / WI-2.3), not by
+        priority. Don't confuse the two.
+        """
         return {
-            HookSource.POLICY: 0,
-            HookSource.SETTINGS: 1,
-            HookSource.FRONTMATTER: 2,
-            HookSource.SKILLS: 3,
-            HookSource.PLUGINS: 4,
+            HookSource.USER_SETTINGS: 0,
+            HookSource.PROJECT_SETTINGS: 1,
+            HookSource.LOCAL_SETTINGS: 2,
+            HookSource.POLICY_SETTINGS: 3,
+            HookSource.SESSION_HOOK: 4,
+            HookSource.PLUGIN_HOOK: 999,
         }[self]
+
+    @property
+    def is_policy(self) -> bool:
+        """True iff this source is the enterprise-managed policy tier.
+
+        Used by the trust gate (WI-0.2) and the policy cascade (Phase 2 /
+        WI-2.3) to identify hooks that bypass user-side controls.
+        """
+        return self == HookSource.POLICY_SETTINGS
+
+
+# ---------------------------------------------------------------------------
+# HookConfig — Chapter-12 / Phase-1 / WI-1.3
+# ---------------------------------------------------------------------------
 
 
 @dataclass
@@ -60,7 +227,34 @@ class HookConfig:
     url: str | None = None
     prompt_text: str | None = None
     agent_instructions: str | None = None
-    source: HookSource = HookSource.SETTINGS
+    source: HookSource = HookSource.USER_SETTINGS
+
+    # Phase-1 / WI-1.3 — schema additions:
+    #
+    # ``if_condition`` — permission-rule grammar string (e.g.,
+    # ``"Bash(git commit*)"``). Evaluated by ``matches_hook_condition``
+    # (Phase 4 / WI-4.2) against the active tool call. ``None`` means "no
+    # extra filter beyond ``matcher``." Mirrors TS ``schemas/hooks.ts:19-27``
+    # ``if`` field.
+    if_condition: str | None = None
+
+    # ``once`` — if True, the hook is removed from the session registry after
+    # its first successful execution. Honored by Phase-3 ``session_hooks``
+    # registration only (config-driven hooks are not session-scoped, so the
+    # field is parsed-and-ignored for them). Mirrors TS ``HookSettings.once``.
+    once: bool = False
+
+    # ``skill_root`` — for skill-declared hooks, the absolute path of the
+    # skill directory. Becomes ``CLAUDE_PLUGIN_ROOT`` in subprocess env at
+    # hook-fire time (WI-1.5). ``None`` for non-skill hooks. Carries through
+    # registration → execution; not parsed from settings.json (only set at
+    # skill-hook registration time in Phase 3).
+    skill_root: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# HookResult / HookProgress / per-event input dataclasses
+# ---------------------------------------------------------------------------
 
 
 @dataclass

--- a/src/hooks/output_schema.py
+++ b/src/hooks/output_schema.py
@@ -1,0 +1,77 @@
+"""Hook output JSON schema validation.
+
+Phase-1 / WI-1.4. Mirrors TS ``schemas/hooks.ts:hookJSONOutputSchema`` (lines
+169-176). Replaces the ad-hoc ``dict.get`` block at the old ``hook_executor.py``
+``_execute_command_hook`` lines 170-188 — that path silently no-op'd on
+malformed output (e.g., ``{"decision": "Deny"}`` with capital D would not match
+the literal ``Literal["allow","deny","ask"]`` and the executor never fired the
+behavior).
+
+The new path uses Pydantic 2 (already a transitive dependency via the
+Anthropic SDK) to validate against a strict schema:
+
+    * Unknown fields are forbidden (``extra = "forbid"``).
+    * ``decision`` must be one of ``"allow" | "deny" | "ask"``.
+    * Other fields type-check via Pydantic.
+
+Validation failures don't raise — they return ``(None, error_msg)`` so the
+executor can log a WARNING and continue. The hook's exit code is still
+honored; only the *decision payload* is dropped on bad JSON.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+class HookOutput(BaseModel):
+    """Schema for the JSON object hooks emit on stdout (exit code 0).
+
+    Mirrors TS ``schemas/hooks.ts:hookJSONOutputSchema``. Field naming follows
+    the wire format (camelCase) since hooks are language-agnostic and the wire
+    format is what users actually write in their settings.json.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    decision: Literal["allow", "deny", "ask"] | None = None
+    reason: str | None = None
+    updatedInput: dict[str, Any] | None = None
+    additionalContexts: list[str] | None = None
+    preventContinuation: bool | None = None
+    stopReason: str | None = None
+    updatedMCPToolOutput: Any | None = None
+
+
+def parse_hook_output(stdout: str) -> tuple[HookOutput | None, str | None]:
+    """Parse a hook's stdout into a typed ``HookOutput`` (or an error message).
+
+    Returns ``(output, None)`` on success, ``(None, error_msg)`` on failure.
+
+    Empty / whitespace-only stdout is **not** an error: it's treated as "the
+    hook chose not to emit a decision" and returns ``(None, None)``. This
+    matches TS' behavior where hooks may exit 0 without writing anything.
+
+    Failure cases that return ``(None, error_msg)``:
+      * stdout is non-empty but not valid JSON.
+      * stdout is JSON but doesn't satisfy the schema (unknown field, bad
+        type, ``decision`` not in the allowed literal, etc.).
+    """
+    if not stdout or not stdout.strip():
+        return (None, None)
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        return (None, f"Hook output is not valid JSON: {exc}")
+    if not isinstance(data, dict):
+        return (None, f"Hook output must be a JSON object, got {type(data).__name__}")
+    try:
+        return (HookOutput.model_validate(data), None)
+    except ValidationError as exc:
+        return (None, f"Hook output failed schema validation: {exc}")

--- a/src/hooks/session_hooks.py
+++ b/src/hooks/session_hooks.py
@@ -1,3 +1,20 @@
+"""Lifecycle-event routers (Phase-1 / WI-1.1 wiring).
+
+Pre-Phase-1 these helpers filtered on ``Notification + matcher: "onXxx"``.
+Phase 1 promotes ``SessionStart``, ``SessionEnd``, ``PreCompact`` to first-class
+``HookEvent`` values; this module now routes via those names.
+
+Per assumption A9, this file will be renamed to ``lifecycle_routers.py`` in
+Phase 2 (when a new ``session_hooks.py`` introduces the registration API in
+Phase 3 / WI-3.1). Public function names are preserved across that rename so
+callers don't churn — only the import path moves.
+
+Legacy settings.json with ``Notification + matcher: "onSessionStart"`` is
+translated to first-class events at config load time
+(``config_manager.load_hooks_from_settings``), so by the time these routers
+read from the registry/snapshot, the events have been canonicalized.
+"""
+
 from __future__ import annotations
 
 import logging
@@ -8,9 +25,13 @@ from .registry import AsyncHookRegistry, get_global_hook_registry
 
 logger = logging.getLogger(__name__)
 
-SESSION_START_EVENT: HookEvent = "Notification"
-SESSION_END_EVENT: HookEvent = "Notification"
-COMPACT_EVENT: HookEvent = "Notification"
+# Phase-1 / WI-1.1 — first-class lifecycle event constants. The legacy values
+# (all three pointing at "Notification") have been removed; the back-compat
+# reader at config-load time translates legacy settings.json into these
+# first-class names.
+SESSION_START_EVENT: HookEvent = "SessionStart"
+SESSION_END_EVENT: HookEvent = "SessionEnd"
+COMPACT_EVENT: HookEvent = "PreCompact"
 
 
 async def run_session_start_hooks(
@@ -20,16 +41,12 @@ async def run_session_start_hooks(
     cwd: str | None = None,
 ) -> list[dict[str, Any]]:
     reg = registry or get_global_hook_registry()
-    hooks = await reg.get_hooks_for_event("Notification")
+    hooks = await reg.get_hooks_for_event(SESSION_START_EVENT)
 
     results: list[dict[str, Any]] = []
     for hook in hooks:
-        if hook.config.matcher and hook.config.matcher != "onSessionStart":
-            continue
-
         stdin_data = {
-            "hook_event": "Notification",
-            "notification_type": "onSessionStart",
+            "hook_event": SESSION_START_EVENT,
             "session_id": session_id,
             "cwd": cwd,
         }
@@ -63,16 +80,12 @@ async def run_session_end_hooks(
     total_turns: int | None = None,
 ) -> list[dict[str, Any]]:
     reg = registry or get_global_hook_registry()
-    hooks = await reg.get_hooks_for_event("Notification")
+    hooks = await reg.get_hooks_for_event(SESSION_END_EVENT)
 
     results: list[dict[str, Any]] = []
     for hook in hooks:
-        if hook.config.matcher and hook.config.matcher != "onSessionEnd":
-            continue
-
         stdin_data = {
-            "hook_event": "Notification",
-            "notification_type": "onSessionEnd",
+            "hook_event": SESSION_END_EVENT,
             "session_id": session_id,
             "total_cost": total_cost,
             "total_turns": total_turns,
@@ -105,16 +118,12 @@ async def run_compact_hooks(
     trigger: str = "manual",
 ) -> list[dict[str, Any]]:
     reg = registry or get_global_hook_registry()
-    hooks = await reg.get_hooks_for_event("Notification")
+    hooks = await reg.get_hooks_for_event(COMPACT_EVENT)
 
     results: list[dict[str, Any]] = []
     for hook in hooks:
-        if hook.config.matcher and hook.config.matcher != "onCompact":
-            continue
-
         stdin_data = {
-            "hook_event": "Notification",
-            "notification_type": "onCompact",
+            "hook_event": COMPACT_EVENT,
             "session_id": session_id,
             "tokens_before": tokens_before,
             "tokens_after": tokens_after,

--- a/src/tool_system/context.py
+++ b/src/tool_system/context.py
@@ -156,7 +156,7 @@ class ToolContext:
     hook_config_manager: Any | None = None
     # Chapter-12 / Phase 0 / WI-0.2 — workspace-trust gate. Bootstrap flips
     # this to ``True`` after the user accepts the trust dialog. Hooks (other
-    # than ``HookSource.POLICY``) are skipped while the workspace is
+    # than ``HookSource.POLICY_SETTINGS``) are skipped while the workspace is
     # untrusted, mirroring TS' ``shouldSkipHookDueToTrust`` gate.
     workspace_trusted: bool = False
 

--- a/tests/integration/test_phase_c_hooks.py
+++ b/tests/integration/test_phase_c_hooks.py
@@ -15,7 +15,7 @@ class TestHooksIntegration:
     def test_register_and_retrieve(self, registry):
         async def _run():
             config = HookConfig(command="echo test")
-            hook = await registry.register("PreToolUse", config, HookSource.SETTINGS)
+            hook = await registry.register("PreToolUse", config, HookSource.USER_SETTINGS)
             assert hook is not None
             hooks = await registry.get_hooks_for_event("PreToolUse")
             assert len(hooks) == 1
@@ -23,27 +23,34 @@ class TestHooksIntegration:
 
         assert asyncio.run(_run())
 
-    def test_priority_ordering(self, registry):
+    def test_iteration_order_matches_chapter_table(self, registry):
+        # Phase-1 / WI-1.2 — priority scheme is now ascending integer order:
+        # USER_SETTINGS=0, POLICY_SETTINGS=3, PLUGIN_HOOK=999 (sentinel last).
+        # Pre-Phase-1 this test asserted POLICY first; the rename + integer
+        # priorities reordered the iteration to match the chapter's "Six
+        # Hook Sources" table where userSettings is highest priority.
+        # The "policy cannot be overridden" semantic is enforced separately
+        # by ``apply_policy_cascade`` (Phase 2 / WI-2.3), not by priority.
         async def _run():
             await registry.register(
                 "PreToolUse",
                 HookConfig(command="plugin-hook"),
-                HookSource.PLUGINS,
+                HookSource.PLUGIN_HOOK,
             )
             await registry.register(
                 "PreToolUse",
                 HookConfig(command="policy-hook"),
-                HookSource.POLICY,
+                HookSource.POLICY_SETTINGS,
             )
             await registry.register(
                 "PreToolUse",
                 HookConfig(command="settings-hook"),
-                HookSource.SETTINGS,
+                HookSource.USER_SETTINGS,
             )
             hooks = await registry.get_hooks_for_event("PreToolUse")
-            assert hooks[0].source == HookSource.POLICY
-            assert hooks[1].source == HookSource.SETTINGS
-            assert hooks[2].source == HookSource.PLUGINS
+            assert hooks[0].source == HookSource.USER_SETTINGS
+            assert hooks[1].source == HookSource.POLICY_SETTINGS
+            assert hooks[2].source == HookSource.PLUGIN_HOOK
 
         asyncio.run(_run())
 
@@ -60,17 +67,17 @@ class TestHooksIntegration:
             await registry.register(
                 "PreToolUse",
                 HookConfig(command="a"),
-                HookSource.PLUGINS,
+                HookSource.PLUGIN_HOOK,
             )
             await registry.register(
                 "PreToolUse",
                 HookConfig(command="b"),
-                HookSource.SETTINGS,
+                HookSource.USER_SETTINGS,
             )
-            cleared = await registry.clear_source(HookSource.PLUGINS)
+            cleared = await registry.clear_source(HookSource.PLUGIN_HOOK)
             assert cleared == 1
             hooks = await registry.get_hooks_for_event("PreToolUse")
             assert len(hooks) == 1
-            assert hooks[0].source == HookSource.SETTINGS
+            assert hooks[0].source == HookSource.USER_SETTINGS
 
         asyncio.run(_run())

--- a/tests/parity/test_structural_parity_r2.py
+++ b/tests/parity/test_structural_parity_r2.py
@@ -770,7 +770,7 @@ class TestHookRegistryLifecycle(unittest.TestCase):
             config = HookConfig(type="command", command="echo test")
             event = "PreToolUse"
 
-            hook = await reg.register(event, config, HookSource.SETTINGS)
+            hook = await reg.register(event, config, HookSource.USER_SETTINGS)
             self.assertIsNotNone(hook)
             self.assertEqual(reg.hook_count, 1)
 

--- a/tests/test_hook_config_schema.py
+++ b/tests/test_hook_config_schema.py
@@ -1,0 +1,115 @@
+"""Phase-1 / WI-1.3 — ``HookConfig`` schema additions.
+
+New fields:
+  * ``if_condition: str | None`` — permission-rule grammar string. Parsed
+    from ``if_condition`` or ``if`` (TS-native) keys in settings.json.
+  * ``once: bool`` — remove after first successful execution. Honored by
+    Phase-3 session-hook registration only.
+  * ``skill_root: str | None`` — set at skill-hook registration time
+    (Phase 3); not parsed from settings.json.
+
+Also covers the validator updates in ``validate_hook_configs``: new fields
+type-check (``if`` must be string, ``once`` must be bool).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.hooks.config_manager import (
+    _parse_hook_config,
+    load_hooks_from_settings,
+    validate_hook_configs,
+)
+from src.hooks.hook_types import HookConfig, HookSource
+
+
+class TestHookConfigFields:
+    def test_default_values(self):
+        c = HookConfig()
+        assert c.if_condition is None
+        assert c.once is False
+        assert c.skill_root is None
+
+    def test_parse_if_condition_snake_case(self):
+        c = _parse_hook_config({
+            "type": "command", "command": "echo x",
+            "if_condition": "Bash(git commit*)",
+        })
+        assert c.if_condition == "Bash(git commit*)"
+
+    def test_parse_if_condition_ts_native_alias(self):
+        # TS-native key: ``if``. Same field, alternate name.
+        c = _parse_hook_config({
+            "type": "command", "command": "echo x",
+            "if": "Bash(git commit*)",
+        })
+        assert c.if_condition == "Bash(git commit*)"
+
+    def test_parse_once_true(self):
+        c = _parse_hook_config({
+            "type": "command", "command": "echo x", "once": True,
+        })
+        assert c.once is True
+
+    def test_parse_once_default_false(self):
+        c = _parse_hook_config({"type": "command", "command": "echo x"})
+        assert c.once is False
+
+    def test_skill_root_not_parsed_from_settings(self):
+        # ``skill_root`` is set at registration time (Phase 3), not at parse
+        # time. A settings.json entry that includes ``skill_root`` is
+        # ignored — the field stays None.
+        c = _parse_hook_config({
+            "type": "command", "command": "echo x",
+            "skill_root": "/some/skill/dir",
+        })
+        assert c.skill_root is None
+
+
+class TestSchemaValidation:
+    def test_if_must_be_string(self):
+        cfg = {"PreToolUse": [{"type": "command", "command": "x", "if": 42}]}
+        errors = validate_hook_configs(cfg)
+        if_errors = [e for e in errors if e.field == "if"]
+        assert len(if_errors) == 1
+        assert "string" in if_errors[0].message.lower()
+
+    def test_once_must_be_bool(self):
+        cfg = {"PreToolUse": [{"type": "command", "command": "x", "once": "yes"}]}
+        errors = validate_hook_configs(cfg)
+        once_errors = [e for e in errors if e.field == "once"]
+        assert len(once_errors) == 1
+        assert "boolean" in once_errors[0].message.lower()
+
+    def test_valid_config_no_errors(self):
+        cfg = {"PreToolUse": [{
+            "type": "command", "command": "x",
+            "if": "Bash(git*)", "once": True, "matcher": "Bash",
+        }]}
+        errors = validate_hook_configs(cfg)
+        # No new-field errors. Other validation (existing) may flag things
+        # but our new fields should not.
+        new_field_errors = [e for e in errors if e.field in ("if", "once")]
+        assert new_field_errors == []
+
+
+class TestRoundTripFromSettingsJson:
+    @pytest.mark.asyncio
+    async def test_load_with_if_and_once_round_trip(self, tmp_path):
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps({
+            "hooks": {"PreToolUse": [{
+                "type": "command", "command": "guard.sh",
+                "if": "Bash(git commit*)",
+                "once": True,
+                "matcher": "Bash",
+            }]}
+        }))
+        snapshot = load_hooks_from_settings(path)
+        hook = snapshot.hooks["PreToolUse"][0]
+        assert hook.if_condition == "Bash(git commit*)"
+        assert hook.once is True
+        assert hook.matcher == "Bash"

--- a/tests/test_hook_env_injection.py
+++ b/tests/test_hook_env_injection.py
@@ -1,0 +1,145 @@
+"""Phase-1 / WI-1.5 — env-var injection at hook fire time.
+
+Three new env vars on top of inherited ``os.environ``:
+  * ``CLAUDE_PROJECT_DIR`` — workspace root from active context.
+  * ``CLAUDE_PLUGIN_ROOT`` — set from ``hook.skill_root`` (skill-declared
+    hooks only).
+  * ``CLAUDE_ENV_FILE`` — per-fire ephemeral path. Set ONLY for
+    ``SessionStart``, ``Setup``, ``CwdChanged``. Per N4: this WI sets the
+    path; sourcing-and-applying loop is a separate follow-up ticket.
+
+These tests cover ``_build_hook_env`` directly (unit-level) plus a
+subprocess round-trip that verifies the env var is actually visible to the
+hook command.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+import pytest
+
+from src.hooks.hook_executor import _build_hook_env, _execute_command_hook
+from src.hooks.hook_types import HookConfig
+
+
+@dataclass
+class _MockCtx:
+    workspace_root: str = "/some/workspace"
+
+
+class TestBuildHookEnv:
+    def test_claude_project_dir_set_from_workspace_root(self):
+        ctx = _MockCtx(workspace_root="/work/dir")
+        hook = HookConfig(type="command", command="x")
+        env = _build_hook_env(hook, {"hook_event": "PreToolUse"}, ctx)
+        assert env["CLAUDE_PROJECT_DIR"] == "/work/dir"
+
+    def test_claude_project_dir_empty_when_no_context(self):
+        hook = HookConfig(type="command", command="x")
+        env = _build_hook_env(hook, {"hook_event": "PreToolUse"}, None)
+        assert env["CLAUDE_PROJECT_DIR"] == ""
+
+    def test_claude_plugin_root_from_skill_root(self):
+        ctx = _MockCtx()
+        hook = HookConfig(type="command", command="x", skill_root="/skills/my-skill")
+        env = _build_hook_env(hook, {"hook_event": "PreToolUse"}, ctx)
+        assert env["CLAUDE_PLUGIN_ROOT"] == "/skills/my-skill"
+
+    def test_claude_plugin_root_empty_for_non_skill_hooks(self):
+        ctx = _MockCtx()
+        hook = HookConfig(type="command", command="x")  # skill_root=None
+        env = _build_hook_env(hook, {"hook_event": "PreToolUse"}, ctx)
+        assert env["CLAUDE_PLUGIN_ROOT"] == ""
+
+    def test_claude_env_file_set_for_session_start(self):
+        ctx = _MockCtx()
+        hook = HookConfig(type="command", command="x")
+        env = _build_hook_env(hook, {"hook_event": "SessionStart"}, ctx)
+        assert env["CLAUDE_ENV_FILE"] != ""
+        # Path is under ~/.clawcodex/hook-env/ — fail-loud if the layout
+        # changes silently.
+        assert "hook-env" in env["CLAUDE_ENV_FILE"]
+        assert "SessionStart" in env["CLAUDE_ENV_FILE"]
+
+    def test_claude_env_file_set_for_setup(self):
+        ctx = _MockCtx()
+        hook = HookConfig(type="command", command="x")
+        env = _build_hook_env(hook, {"hook_event": "Setup"}, ctx)
+        assert env["CLAUDE_ENV_FILE"] != ""
+
+    def test_claude_env_file_set_for_cwd_changed(self):
+        ctx = _MockCtx()
+        hook = HookConfig(type="command", command="x")
+        env = _build_hook_env(hook, {"hook_event": "CwdChanged"}, ctx)
+        assert env["CLAUDE_ENV_FILE"] != ""
+
+    def test_claude_env_file_empty_for_pre_tool_use(self):
+        # PreToolUse is a tool-lifecycle event, not a lifecycle env-propagation
+        # event.
+        ctx = _MockCtx()
+        hook = HookConfig(type="command", command="x")
+        env = _build_hook_env(hook, {"hook_event": "PreToolUse"}, ctx)
+        assert env["CLAUDE_ENV_FILE"] == ""
+
+    def test_claude_hook_event_preserved(self):
+        # Pre-existing var stays.
+        ctx = _MockCtx()
+        hook = HookConfig(type="command", command="x")
+        env = _build_hook_env(hook, {"hook_event": "PostToolUse"}, ctx)
+        assert env["CLAUDE_HOOK_EVENT"] == "PostToolUse"
+
+    def test_inherited_environment_preserved(self):
+        # The new vars don't clobber inherited environment.
+        os.environ["CLAW_TEST_PRESERVED"] = "yes"
+        try:
+            ctx = _MockCtx()
+            hook = HookConfig(type="command", command="x")
+            env = _build_hook_env(hook, {"hook_event": "PreToolUse"}, ctx)
+            assert env.get("CLAW_TEST_PRESERVED") == "yes"
+        finally:
+            del os.environ["CLAW_TEST_PRESERVED"]
+
+
+class TestEnvVisibleToSubprocess:
+    @pytest.mark.asyncio
+    async def test_command_sees_claude_project_dir(self):
+        ctx = _MockCtx(workspace_root="/expected/path")
+        hook = HookConfig(
+            type="command",
+            command='printf "DIR=%s" "$CLAUDE_PROJECT_DIR"',
+        )
+        result = await _execute_command_hook(
+            hook, {"hook_event": "PreToolUse"}, tool_use_context=ctx,
+        )
+        assert result.exit_code == 0
+        assert "DIR=/expected/path" in (result.stdout or "")
+
+    @pytest.mark.asyncio
+    async def test_command_sees_claude_plugin_root(self):
+        ctx = _MockCtx()
+        hook = HookConfig(
+            type="command",
+            command='printf "ROOT=%s" "$CLAUDE_PLUGIN_ROOT"',
+            skill_root="/path/to/skill",
+        )
+        result = await _execute_command_hook(
+            hook, {"hook_event": "PreToolUse"}, tool_use_context=ctx,
+        )
+        assert result.exit_code == 0
+        assert "ROOT=/path/to/skill" in (result.stdout or "")
+
+    @pytest.mark.asyncio
+    async def test_command_sees_claude_env_file_for_session_start(self):
+        ctx = _MockCtx()
+        hook = HookConfig(
+            type="command",
+            command='printf "FILE=%s" "$CLAUDE_ENV_FILE"',
+        )
+        result = await _execute_command_hook(
+            hook, {"hook_event": "SessionStart"}, tool_use_context=ctx,
+        )
+        assert result.exit_code == 0
+        assert "hook-env" in (result.stdout or "")
+        assert "SessionStart" in (result.stdout or "")

--- a/tests/test_hook_event_taxonomy.py
+++ b/tests/test_hook_event_taxonomy.py
@@ -1,0 +1,116 @@
+"""Phase-1 / WI-1.1 — 25-event taxonomy regression tests.
+
+Verifies that:
+  * The ``HookEvent`` literal and ``ALL_HOOK_EVENTS`` list contain all 25
+    chapter-specified events.
+  * First-class lifecycle events (``SessionStart``, ``SessionEnd``,
+    ``PreCompact``, ``PostCompact``) are present and routable.
+  * ``validate_hook_configs`` accepts new event names without warnings.
+  * Settings.json with first-class names loads correctly into the snapshot.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.hooks.config_manager import (
+    HookConfigManager,
+    load_hooks_from_settings,
+    validate_hook_configs,
+)
+from src.hooks.hook_types import (
+    ALL_HOOK_EVENTS,
+    HookConfig,
+    HookEvent,
+    HookSource,
+)
+from src.hooks.registry import AsyncHookRegistry
+
+
+CHAPTER_BIG_FIVE = (
+    "PreToolUse", "PostToolUse", "Stop", "SessionStart", "UserPromptSubmit",
+)
+
+# Chapter §"Reference table — remaining events" plus the four lifecycle
+# events promoted to first-class in Phase 1.
+CHAPTER_OTHER_EVENTS = (
+    "PostToolUseFailure", "PermissionDenied", "PermissionRequest",
+    "SessionEnd", "Setup",
+    "SubagentStart", "SubagentStop",
+    "PreCompact", "PostCompact",
+    "Notification", "Elicitation", "ElicitationResult",
+    "ConfigChange", "InstructionsLoaded", "CwdChanged", "FileChanged",
+    "TaskCreated", "TaskCompleted", "TeammateIdle",
+    "WorktreeCreate", "WorktreeRemove",
+    "StopFailure", "PostSampling",
+)
+
+
+class TestEventTaxonomy:
+    def test_all_25_events_in_list(self):
+        # Big Five + the rest = 28 total entries because Stop counts in both;
+        # wait — Stop is in big five. Let me recount: Big Five = 5; Other = 23.
+        # That's 28. But the chapter table says ~25. The difference is just
+        # how I'm slicing the lists in this test (Big Five vs reference table).
+        # The actual ALL_HOOK_EVENTS list has 27 entries — we accept anywhere
+        # in [25, 30] as a valid count and verify membership instead.
+        assert 25 <= len(ALL_HOOK_EVENTS) <= 30
+        for ev in CHAPTER_BIG_FIVE:
+            assert ev in ALL_HOOK_EVENTS, f"missing event: {ev}"
+        for ev in CHAPTER_OTHER_EVENTS:
+            assert ev in ALL_HOOK_EVENTS, f"missing event: {ev}"
+
+    def test_first_class_lifecycle_events_present(self):
+        # The four events promoted from ``Notification + matcher`` form to
+        # first-class names in WI-1.1.
+        for ev in ("SessionStart", "SessionEnd", "PreCompact", "PostCompact"):
+            assert ev in ALL_HOOK_EVENTS
+
+    def test_validate_accepts_new_events_no_warning(self):
+        # Settings.json with first-class names: validation produces no
+        # event-name warnings.
+        cfg = {
+            "SessionStart": [{"type": "command", "command": "echo a"}],
+            "PreCompact": [{"type": "command", "command": "echo b"}],
+            "FileChanged": [{"type": "command", "command": "echo c"}],
+            "PermissionRequest": [{"type": "command", "command": "echo d"}],
+        }
+        errors = validate_hook_configs(cfg)
+        # Only "Unknown hook event" errors would fire here; everything else
+        # is well-formed.
+        unknown_event_errors = [e for e in errors if e.field == "event"]
+        assert unknown_event_errors == []
+
+    def test_validate_rejects_genuinely_unknown_event(self):
+        cfg = {"NotAnEvent": [{"type": "command", "command": "echo x"}]}
+        errors = validate_hook_configs(cfg)
+        unknown = [e for e in errors if e.field == "event"]
+        assert len(unknown) == 1
+        assert "NotAnEvent" in unknown[0].message
+
+    @pytest.mark.asyncio
+    async def test_first_class_settings_json_loads_to_snapshot(self, tmp_path):
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text(json.dumps({
+            "hooks": {
+                "SessionStart": [{"type": "command", "command": "echo start"}],
+                "FileChanged": [{"type": "command", "command": "echo fc"}],
+            }
+        }))
+        snapshot = load_hooks_from_settings(settings_path)
+        assert "SessionStart" in snapshot.hooks
+        assert "FileChanged" in snapshot.hooks
+        # Settings load assigns USER_SETTINGS source by default (post-WI-1.2).
+        assert snapshot.hooks["SessionStart"][0].source == HookSource.USER_SETTINGS
+
+    @pytest.mark.asyncio
+    async def test_async_hook_registry_has_buckets_for_all_events(self):
+        # The registry's ``get_all_hooks`` returns one bucket per event in
+        # ALL_HOOK_EVENTS; verify the new events all have buckets.
+        reg = AsyncHookRegistry()
+        all_buckets = reg.get_all_hooks()
+        for ev in ("SessionStart", "FileChanged", "PreCompact", "Setup"):
+            assert ev in all_buckets, f"registry missing bucket for {ev}"

--- a/tests/test_hook_event_taxonomy.py
+++ b/tests/test_hook_event_taxonomy.py
@@ -50,13 +50,15 @@ CHAPTER_OTHER_EVENTS = (
 
 
 class TestEventTaxonomy:
-    def test_all_25_events_in_list(self):
-        # Big Five + the rest = 28 total entries because Stop counts in both;
-        # wait — Stop is in big five. Let me recount: Big Five = 5; Other = 23.
-        # That's 28. But the chapter table says ~25. The difference is just
-        # how I'm slicing the lists in this test (Big Five vs reference table).
-        # The actual ALL_HOOK_EVENTS list has 27 entries — we accept anywhere
-        # in [25, 30] as a valid count and verify membership instead.
+    def test_all_chapter_events_present(self):
+        # Chapter (``ch12-extensibility.md``) says "over two dozen distinct
+        # points" and enumerates 22 explicitly across Big Five + the
+        # reference table. WI-1.1 also adds 4 events from the gap analysis
+        # §1 row #2 list (StopFailure, WorktreeCreate/Remove) plus the
+        # pre-existing PostSampling — total 28 in ALL_HOOK_EVENTS.
+        # Membership check is the contract; total count is allowed in
+        # [25, 30] so adding/removing a peripheral event doesn't churn
+        # this assertion.
         assert 25 <= len(ALL_HOOK_EVENTS) <= 30
         for ev in CHAPTER_BIG_FIVE:
             assert ev in ALL_HOOK_EVENTS, f"missing event: {ev}"

--- a/tests/test_hook_executor.py
+++ b/tests/test_hook_executor.py
@@ -35,7 +35,18 @@ class TestMatchesTool:
 
 
 class TestHasHookForEvent:
+    """Legacy ``options.hooks`` tests.
+
+    These exercise the deprecation back-compat path introduced by Phase-0
+    WI-0.1: a ToolContext without a ``hook_config_manager`` falls back to
+    reading ``options.hooks`` and emits a ``DeprecationWarning``. The tests
+    are wrapped in ``pytest.warns`` (Phase-1 / N3 nit cleanup) so the
+    warning is *asserted* rather than printed as test-output noise.
+    """
+
     def test_no_hooks(self):
+        # Empty options.hooks does NOT emit a warning (the shim only fires
+        # when the legacy path actually has data).
         class MockCtx:
             options = type("Options", (), {"hooks": None})()
         assert not has_hook_for_event("PreToolUse", MockCtx())
@@ -45,14 +56,16 @@ class TestHasHookForEvent:
             options = type("Options", (), {
                 "hooks": {"PreToolUse": [{"type": "command", "command": "echo test"}]}
             })()
-        assert has_hook_for_event("PreToolUse", MockCtx())
+        with pytest.warns(DeprecationWarning, match="options.hooks"):
+            assert has_hook_for_event("PreToolUse", MockCtx())
 
     def test_wrong_event(self):
         class MockCtx:
             options = type("Options", (), {
                 "hooks": {"PreToolUse": [{"type": "command", "command": "echo test"}]}
             })()
-        assert not has_hook_for_event("PostToolUse", MockCtx())
+        with pytest.warns(DeprecationWarning, match="options.hooks"):
+            assert not has_hook_for_event("PostToolUse", MockCtx())
 
 
 class TestExecuteCommandHook:

--- a/tests/test_hook_output_schema.py
+++ b/tests/test_hook_output_schema.py
@@ -1,0 +1,141 @@
+"""Phase-1 / WI-1.4 — hook output JSON schema validation.
+
+Replaces the pre-Phase-1 ad-hoc ``dict.get`` parsing block in
+``_execute_command_hook``. Failure mode the schema closes: capital-D
+``"Deny"`` (instead of ``"deny"``) used to silently no-op; now it logs a
+WARNING and the executor drops the decision payload (exit code is still
+honored).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+import pytest
+
+from src.hooks.hook_types import HookConfig
+from src.hooks.hook_executor import _execute_command_hook
+from src.hooks.output_schema import HookOutput, parse_hook_output
+
+
+class TestParseHookOutput:
+    def test_empty_stdout_returns_no_output_no_error(self):
+        out, err = parse_hook_output("")
+        assert out is None
+        assert err is None
+
+    def test_whitespace_only_returns_no_output_no_error(self):
+        out, err = parse_hook_output("   \n  ")
+        assert out is None
+        assert err is None
+
+    def test_valid_decision_allow(self):
+        out, err = parse_hook_output(json.dumps({"decision": "allow", "reason": "test"}))
+        assert err is None
+        assert out is not None
+        assert out.decision == "allow"
+        assert out.reason == "test"
+
+    def test_valid_decision_deny(self):
+        out, err = parse_hook_output(json.dumps({"decision": "deny"}))
+        assert err is None
+        assert out is not None
+        assert out.decision == "deny"
+
+    def test_valid_decision_ask(self):
+        out, err = parse_hook_output(json.dumps({"decision": "ask"}))
+        assert err is None
+        assert out is not None
+        assert out.decision == "ask"
+
+    def test_capital_d_deny_rejected(self):
+        # The headline failure mode the schema closes: capital-D used to
+        # silently no-op; now it's a validation error and the decision is
+        # dropped.
+        out, err = parse_hook_output(json.dumps({"decision": "Deny"}))
+        assert out is None
+        assert err is not None
+        assert "schema validation" in err.lower()
+
+    def test_unknown_field_rejected(self):
+        out, err = parse_hook_output(json.dumps({
+            "decision": "allow", "stowaway": 1,
+        }))
+        assert out is None
+        assert err is not None
+        assert "schema validation" in err.lower()
+
+    def test_malformed_json_rejected(self):
+        out, err = parse_hook_output("not json at all {")
+        assert out is None
+        assert err is not None
+        assert "json" in err.lower()
+
+    def test_non_object_json_rejected(self):
+        # Top-level array/string/etc. is invalid even if it parses as JSON.
+        out, err = parse_hook_output(json.dumps([1, 2, 3]))
+        assert out is None
+        assert err is not None
+
+    def test_updated_input_round_trip(self):
+        out, err = parse_hook_output(json.dumps({
+            "updatedInput": {"command": "safer_cmd"},
+        }))
+        assert err is None
+        assert out is not None
+        assert out.updatedInput == {"command": "safer_cmd"}
+
+    def test_prevent_continuation_with_reason(self):
+        out, err = parse_hook_output(json.dumps({
+            "preventContinuation": True,
+            "stopReason": "verification failed",
+        }))
+        assert err is None
+        assert out is not None
+        assert out.preventContinuation is True
+        assert out.stopReason == "verification failed"
+
+
+class TestExecutorWiresSchema:
+    @pytest.mark.asyncio
+    async def test_capital_d_deny_logged_not_silently_ignored(self, caplog):
+        # Run a command hook whose stdout is malformed by the new schema.
+        # Pre-Phase-1: silently dropped. Post-Phase-1: logged at WARNING.
+        hook = HookConfig(
+            type="command",
+            command='echo \'{"decision": "Deny"}\'',  # capital D — invalid
+        )
+        with caplog.at_level(logging.WARNING, logger="src.hooks.hook_executor"):
+            result = await _execute_command_hook(hook, {"hook_event": "PreToolUse"})
+
+        # Decision payload was dropped (didn't make it through schema).
+        assert result.permission_behavior is None
+        # WARNING was logged about the failed validation.
+        assert any(
+            "schema validation" in rec.message.lower() or
+            "failed schema" in rec.message.lower()
+            for rec in caplog.records
+        ), f"Expected schema-validation WARNING; saw: {[r.message for r in caplog.records]}"
+
+    @pytest.mark.asyncio
+    async def test_valid_lowercase_decision_round_trips_through_executor(self):
+        hook = HookConfig(
+            type="command",
+            command='echo \'{"decision": "deny", "reason": "blocked"}\'',
+        )
+        result = await _execute_command_hook(hook, {"hook_event": "PreToolUse"})
+        assert result.permission_behavior == "deny"
+        assert result.hook_permission_decision_reason == "blocked"
+
+    @pytest.mark.asyncio
+    async def test_unknown_field_at_executor_level_logged(self, caplog):
+        hook = HookConfig(
+            type="command",
+            command='echo \'{"decision": "allow", "stowaway": 1}\'',
+        )
+        with caplog.at_level(logging.WARNING, logger="src.hooks.hook_executor"):
+            result = await _execute_command_hook(hook, {"hook_event": "PreToolUse"})
+        assert result.permission_behavior is None  # decision dropped
+        assert any("schema validation" in rec.message.lower() for rec in caplog.records)

--- a/tests/test_hook_registry.py
+++ b/tests/test_hook_registry.py
@@ -110,19 +110,28 @@ class TestAsyncHookRegistry:
 
     @pytest.mark.asyncio
     async def test_priority_ordering(self, registry):
-        config_plugin = HookConfig(type="command", command="echo plugin", source=HookSource.PLUGINS)
-        config_settings = HookConfig(type="command", command="echo settings", source=HookSource.SETTINGS)
-        config_policy = HookConfig(type="command", command="echo policy", source=HookSource.POLICY)
+        # Phase-1 / WI-1.2 — priority scheme reshuffled to match the chapter
+        # table (``ch12-extensibility.md`` §"Six Hook Sources"):
+        #   USER_SETTINGS  = 0   (highest priority — sorts first)
+        #   POLICY_SETTINGS = 3
+        #   PLUGIN_HOOK    = 999 (sentinel: always last)
+        # Note: priority is *display ordering* only. The chapter's "policy
+        # cannot be overridden" semantic is enforced by ``apply_policy_cascade``
+        # (Phase 2 / WI-2.3), not by priority. The sort order below reflects
+        # priority, not security precedence.
+        config_plugin = HookConfig(type="command", command="echo plugin", source=HookSource.PLUGIN_HOOK)
+        config_settings = HookConfig(type="command", command="echo settings", source=HookSource.USER_SETTINGS)
+        config_policy = HookConfig(type="command", command="echo policy", source=HookSource.POLICY_SETTINGS)
 
-        await registry.register("PreToolUse", config_plugin, HookSource.PLUGINS)
-        await registry.register("PreToolUse", config_settings, HookSource.SETTINGS)
-        await registry.register("PreToolUse", config_policy, HookSource.POLICY)
+        await registry.register("PreToolUse", config_plugin, HookSource.PLUGIN_HOOK)
+        await registry.register("PreToolUse", config_settings, HookSource.USER_SETTINGS)
+        await registry.register("PreToolUse", config_policy, HookSource.POLICY_SETTINGS)
 
         hooks = await registry.get_hooks_for_event("PreToolUse")
         assert len(hooks) == 3
-        assert hooks[0].source == HookSource.POLICY
-        assert hooks[1].source == HookSource.SETTINGS
-        assert hooks[2].source == HookSource.PLUGINS
+        assert hooks[0].source == HookSource.USER_SETTINGS
+        assert hooks[1].source == HookSource.POLICY_SETTINGS
+        assert hooks[2].source == HookSource.PLUGIN_HOOK
 
     @pytest.mark.asyncio
     async def test_has_hooks_for_event(self, registry):
@@ -144,10 +153,10 @@ class TestAsyncHookRegistry:
     async def test_clear_source(self, registry):
         config_settings = HookConfig(type="command", command="echo settings")
         config_plugins = HookConfig(type="command", command="echo plugins")
-        await registry.register("PreToolUse", config_settings, HookSource.SETTINGS)
-        await registry.register("PreToolUse", config_plugins, HookSource.PLUGINS)
+        await registry.register("PreToolUse", config_settings, HookSource.USER_SETTINGS)
+        await registry.register("PreToolUse", config_plugins, HookSource.PLUGIN_HOOK)
         assert registry.hook_count == 2
-        removed = await registry.clear_source(HookSource.PLUGINS)
+        removed = await registry.clear_source(HookSource.PLUGIN_HOOK)
         assert removed == 1
         assert registry.hook_count == 1
 
@@ -187,15 +196,41 @@ class TestGlobalRegistry:
 
 
 class TestHookSource:
+    """Phase-1 / WI-1.2 — six-source priority scheme.
+
+    Old enum values ``POLICY`` / ``SETTINGS`` / ``PLUGINS`` are preserved as
+    deprecated aliases (``EnumMeta``-level ``__getattr__``); ``FRONTMATTER``
+    and ``SKILLS`` had no producer in Phase 0 (gap analysis §5) and are
+    removed outright.
+    """
+
     def test_priority_ordering(self):
-        assert HookSource.POLICY.priority < HookSource.SETTINGS.priority
-        assert HookSource.SETTINGS.priority < HookSource.FRONTMATTER.priority
-        assert HookSource.FRONTMATTER.priority < HookSource.SKILLS.priority
-        assert HookSource.SKILLS.priority < HookSource.PLUGINS.priority
+        # Phase-1 priority scheme: USER_SETTINGS=0, PROJECT=1, LOCAL=2,
+        # POLICY_SETTINGS=3, SESSION_HOOK=4, PLUGIN_HOOK=999 (sentinel).
+        assert HookSource.USER_SETTINGS.priority < HookSource.PROJECT_SETTINGS.priority
+        assert HookSource.PROJECT_SETTINGS.priority < HookSource.LOCAL_SETTINGS.priority
+        assert HookSource.LOCAL_SETTINGS.priority < HookSource.POLICY_SETTINGS.priority
+        assert HookSource.POLICY_SETTINGS.priority < HookSource.SESSION_HOOK.priority
+        assert HookSource.SESSION_HOOK.priority < HookSource.PLUGIN_HOOK.priority
+
+    def test_plugin_hook_priority_is_999(self):
+        # Sentinel value: any tier added later (e.g., a future "managed-cloud"
+        # source) inserts between LOCAL and PLUGIN without disturbing plugin
+        # ordering.
+        assert HookSource.PLUGIN_HOOK.priority == 999
 
     def test_source_values(self):
-        assert HookSource.POLICY.value == "policy"
-        assert HookSource.SETTINGS.value == "settings"
-        assert HookSource.FRONTMATTER.value == "frontmatter"
-        assert HookSource.SKILLS.value == "skills"
-        assert HookSource.PLUGINS.value == "plugins"
+        # camelCase wire format matches TS' source string identifiers.
+        assert HookSource.USER_SETTINGS.value == "userSettings"
+        assert HookSource.PROJECT_SETTINGS.value == "projectSettings"
+        assert HookSource.LOCAL_SETTINGS.value == "localSettings"
+        assert HookSource.POLICY_SETTINGS.value == "policySettings"
+        assert HookSource.SESSION_HOOK.value == "sessionHook"
+        assert HookSource.PLUGIN_HOOK.value == "pluginHook"
+
+    def test_is_policy_predicate(self):
+        # The trust gate (WI-0.2) and policy cascade (WI-2.3) ask
+        # "is this source the enterprise tier?" via ``is_policy``.
+        assert HookSource.POLICY_SETTINGS.is_policy is True
+        assert HookSource.USER_SETTINGS.is_policy is False
+        assert HookSource.PLUGIN_HOOK.is_policy is False

--- a/tests/test_hook_source_deprecation.py
+++ b/tests/test_hook_source_deprecation.py
@@ -1,0 +1,79 @@
+"""Phase-1 / WI-1.2 — ``HookSource`` deprecation alias regression tests.
+
+Verifies the ``EnumMeta``-level ``__getattr__`` mechanism (N3 critic-resolved):
+  * Legacy aliases ``SETTINGS`` / ``POLICY`` / ``PLUGINS`` resolve to the
+    canonical values ``USER_SETTINGS`` / ``POLICY_SETTINGS`` / ``PLUGIN_HOOK``.
+  * Each alias access emits a single ``DeprecationWarning``.
+  * Identity comparison works (``HookSource.SETTINGS is HookSource.USER_SETTINGS``)
+    so existing call sites that compare via ``is`` keep working through the
+    deprecation cycle.
+  * Truly unknown names raise ``AttributeError``.
+  * Dunder access (``HookSource.__name__`` etc.) does NOT emit warnings.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from src.hooks.hook_types import HookSource
+
+
+class TestDeprecationAlias:
+    def test_settings_alias_resolves_to_user_settings(self):
+        with pytest.warns(DeprecationWarning, match="HookSource.SETTINGS is deprecated"):
+            value = HookSource.SETTINGS
+        assert value is HookSource.USER_SETTINGS
+
+    def test_policy_alias_resolves_to_policy_settings(self):
+        with pytest.warns(DeprecationWarning, match="HookSource.POLICY is deprecated"):
+            value = HookSource.POLICY
+        assert value is HookSource.POLICY_SETTINGS
+
+    def test_plugins_alias_resolves_to_plugin_hook(self):
+        with pytest.warns(DeprecationWarning, match="HookSource.PLUGINS is deprecated"):
+            value = HookSource.PLUGINS
+        assert value is HookSource.PLUGIN_HOOK
+
+    def test_alias_emits_one_warning_per_access(self):
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            _ = HookSource.SETTINGS
+        deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecations) == 1
+
+    def test_alias_value_is_canonical(self):
+        # Round-trip: alias .value == canonical .value because ``is`` returns
+        # the same enum member.
+        with pytest.warns(DeprecationWarning):
+            settings_via_alias = HookSource.SETTINGS
+        assert settings_via_alias.value == "userSettings"
+
+    def test_unknown_attribute_raises(self):
+        with pytest.raises(AttributeError):
+            _ = HookSource.NONEXISTENT
+
+    def test_dunder_access_does_not_warn(self):
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            # Class-level dunder access goes through metaclass __getattr__;
+            # our override delegates to ``EnumMeta.__getattr__`` for dunders
+            # so no warning fires.
+            _ = HookSource.__name__
+            _ = HookSource.__members__
+        assert all(
+            not issubclass(w.category, DeprecationWarning) for w in captured
+        )
+
+    def test_canonical_names_no_warning(self):
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            _ = HookSource.USER_SETTINGS
+            _ = HookSource.POLICY_SETTINGS
+            _ = HookSource.PLUGIN_HOOK
+            _ = HookSource.PROJECT_SETTINGS
+            _ = HookSource.LOCAL_SETTINGS
+            _ = HookSource.SESSION_HOOK
+        deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning)]
+        assert deprecations == []

--- a/tests/test_legacy_notification_backcompat.py
+++ b/tests/test_legacy_notification_backcompat.py
@@ -1,0 +1,156 @@
+"""Phase-1 / WI-1.1 — legacy ``Notification + matcher`` back-compat reader.
+
+Per assumption A1 + critic confirm: ``SessionStart`` / ``SessionEnd`` /
+``PreCompact`` / ``PostCompact`` are first-class events post-Phase-1, but
+existing settings.json files using the legacy form
+(``Notification + matcher: "onSessionStart"``) must keep working for one
+CHANGELOG cycle.
+
+The team-lead specifically requested:
+  > Back-compat reader test: a settings.json with `Notification + matcher:
+  > SessionStart` still routes to SessionStart handler.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+
+import pytest
+
+from src.hooks.config_manager import load_hooks_from_settings
+
+
+class TestLegacyMatcherTranslation:
+    def test_on_session_start_matcher_translates_to_first_class(self, tmp_path):
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps({
+            "hooks": {"Notification": [{
+                "type": "command", "command": "echo start",
+                "matcher": "onSessionStart",
+            }]}
+        }))
+        with pytest.warns(DeprecationWarning, match="onSessionStart"):
+            snapshot = load_hooks_from_settings(path)
+        # The hook is now under SessionStart, NOT under Notification.
+        assert "SessionStart" in snapshot.hooks
+        assert snapshot.hooks["SessionStart"][0].command == "echo start"
+        # And it's NOT under Notification anymore (translated, not duplicated).
+        assert "Notification" not in snapshot.hooks or not snapshot.hooks.get("Notification")
+
+    def test_on_session_end_matcher_translates(self, tmp_path):
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps({
+            "hooks": {"Notification": [{
+                "type": "command", "command": "echo end",
+                "matcher": "onSessionEnd",
+            }]}
+        }))
+        with pytest.warns(DeprecationWarning, match="onSessionEnd"):
+            snapshot = load_hooks_from_settings(path)
+        assert "SessionEnd" in snapshot.hooks
+        assert snapshot.hooks["SessionEnd"][0].command == "echo end"
+
+    def test_on_compact_matcher_translates_to_pre_compact(self, tmp_path):
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps({
+            "hooks": {"Notification": [{
+                "type": "command", "command": "echo c",
+                "matcher": "onCompact",
+            }]}
+        }))
+        with pytest.warns(DeprecationWarning, match="onCompact"):
+            snapshot = load_hooks_from_settings(path)
+        # Convention: legacy ``onCompact`` → ``PreCompact`` (about-to-happen).
+        assert "PreCompact" in snapshot.hooks
+
+    def test_bare_event_name_as_matcher_also_translates(self, tmp_path):
+        # Team-lead's literal example: ``matcher: "SessionStart"`` (without
+        # the ``on`` prefix). Both forms translate to the same first-class
+        # event.
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps({
+            "hooks": {"Notification": [{
+                "type": "command", "command": "echo s",
+                "matcher": "SessionStart",
+            }]}
+        }))
+        with pytest.warns(DeprecationWarning, match="SessionStart"):
+            snapshot = load_hooks_from_settings(path)
+        assert "SessionStart" in snapshot.hooks
+        assert snapshot.hooks["SessionStart"][0].command == "echo s"
+
+    def test_notification_without_matching_matcher_stays_under_notification(self, tmp_path):
+        # A genuine ``Notification`` hook with a non-lifecycle matcher (e.g.,
+        # ``onPermissionRequest`` — not in the legacy lifecycle map) is NOT
+        # translated; it stays under Notification.
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps({
+            "hooks": {"Notification": [{
+                "type": "command", "command": "echo n",
+                "matcher": "onPermissionRequest",
+            }]}
+        }))
+        # No deprecation warning expected.
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            snapshot = load_hooks_from_settings(path)
+        deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning)]
+        assert deprecations == []
+        assert "Notification" in snapshot.hooks
+        assert snapshot.hooks["Notification"][0].matcher == "onPermissionRequest"
+
+    def test_first_class_event_no_warning(self, tmp_path):
+        # Settings.json using first-class names directly: no deprecation
+        # warning fires (the warning is only for the legacy form).
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps({
+            "hooks": {"SessionStart": [{
+                "type": "command", "command": "echo modern",
+            }]}
+        }))
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            snapshot = load_hooks_from_settings(path)
+        deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning)]
+        assert deprecations == []
+        assert "SessionStart" in snapshot.hooks
+
+    def test_multiple_legacy_entries_each_warn(self, tmp_path):
+        # Two legacy entries → two warnings.
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps({
+            "hooks": {"Notification": [
+                {"type": "command", "command": "echo a", "matcher": "onSessionStart"},
+                {"type": "command", "command": "echo b", "matcher": "onSessionEnd"},
+            ]}
+        }))
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            snapshot = load_hooks_from_settings(path)
+        deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecations) == 2
+        assert "SessionStart" in snapshot.hooks
+        assert "SessionEnd" in snapshot.hooks
+
+
+class TestLifecycleRoutersReadFirstClass:
+    """The lifecycle routers (``run_session_start_hooks`` etc.) now read
+    from first-class events, not from ``Notification + matcher``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_session_start_router_reads_first_class_event(self):
+        from src.hooks.session_hooks import SESSION_START_EVENT
+        # The constant is now ``SessionStart`` (first-class), not ``Notification``.
+        assert SESSION_START_EVENT == "SessionStart"
+
+    @pytest.mark.asyncio
+    async def test_session_end_router_reads_first_class_event(self):
+        from src.hooks.session_hooks import SESSION_END_EVENT
+        assert SESSION_END_EVENT == "SessionEnd"
+
+    @pytest.mark.asyncio
+    async def test_compact_router_reads_pre_compact(self):
+        from src.hooks.session_hooks import COMPACT_EVENT
+        assert COMPACT_EVENT == "PreCompact"

--- a/tests/test_snapshot_freezing.py
+++ b/tests/test_snapshot_freezing.py
@@ -80,7 +80,7 @@ def _build_manager_with_snapshot(hooks: dict[str, list[HookConfig]]) -> HookConf
 
 class TestExecutorReadsFromSnapshot:
     def test_get_hooks_from_snapshot_when_manager_present(self):
-        real_hook = HookConfig(type="command", command="echo real", source=HookSource.SETTINGS)
+        real_hook = HookConfig(type="command", command="echo real", source=HookSource.USER_SETTINGS)
         manager = _build_manager_with_snapshot({"PreToolUse": [real_hook]})
 
         ctx = _MockContext(
@@ -98,7 +98,7 @@ class TestExecutorReadsFromSnapshot:
         assert all("BOGUS" not in (h.command or "") for h in result["PreToolUse"])
 
     def test_has_hook_for_event_consults_snapshot(self):
-        real_hook = HookConfig(type="command", command="echo x", source=HookSource.SETTINGS)
+        real_hook = HookConfig(type="command", command="echo x", source=HookSource.USER_SETTINGS)
         manager = _build_manager_with_snapshot({"PreToolUse": [real_hook]})
 
         ctx = _MockContext(hook_config_manager=manager)
@@ -134,7 +134,7 @@ class TestRunHooksForEventReadsSnapshot:
         real_hook = HookConfig(
             type="command",
             command=f"echo 'real' > {marker}",
-            source=HookSource.SETTINGS,
+            source=HookSource.USER_SETTINGS,
         )
         manager = _build_manager_with_snapshot({"PreToolUse": [real_hook]})
 

--- a/tests/test_trust_gate.py
+++ b/tests/test_trust_gate.py
@@ -82,7 +82,7 @@ class TestExecutorRespectsGate:
         user_hook = HookConfig(
             type="command",
             command=f"echo 'user' > {marker}",
-            source=HookSource.SETTINGS,
+            source=HookSource.USER_SETTINGS,
         )
         ctx = _MockContext(
             workspace_trusted=False,
@@ -103,7 +103,7 @@ class TestExecutorRespectsGate:
         policy_hook = HookConfig(
             type="command",
             command=f"echo 'policy' > {marker}",
-            source=HookSource.POLICY,  # current Python enum value pre-WI-1.2
+            source=HookSource.POLICY_SETTINGS,
         )
         ctx = _MockContext(
             workspace_trusted=False,
@@ -127,12 +127,12 @@ class TestExecutorRespectsGate:
         user_hook = HookConfig(
             type="command",
             command=f"echo 'u' > {user_marker}",
-            source=HookSource.SETTINGS,
+            source=HookSource.USER_SETTINGS,
         )
         policy_hook = HookConfig(
             type="command",
             command=f"echo 'p' > {policy_marker}",
-            source=HookSource.POLICY,
+            source=HookSource.POLICY_SETTINGS,
         )
         ctx = _MockContext(
             workspace_trusted=True,
@@ -152,7 +152,7 @@ class TestExecutorRespectsGate:
     async def test_untrusted_workspace_with_only_user_hooks_yields_nothing(self):
         """When the gate strips everything, the executor yields no items."""
         user_hook = HookConfig(
-            type="command", command="echo x", source=HookSource.SETTINGS,
+            type="command", command="echo x", source=HookSource.USER_SETTINGS,
         )
         ctx = _MockContext(
             workspace_trusted=False,


### PR DESCRIPTION
## Summary
Phase 1 of ch12 — type-system foundation. Expands the event taxonomy from 10 to 28 first-class events, replaces the 5-value `HookSource` enum with the chapter's 6-source priority model, adds Pydantic output validation, and injects three documented env vars at hook fire time.

## What's new in this phase (vs Phase 0)
- **Events**: `HookEvent` literal expanded 10 → 28; `SessionStart`/`SessionEnd`/`PreCompact`/`PostCompact` promoted to first-class. Back-compat reader translates legacy `Notification + matcher: onSessionStart` form with `DeprecationWarning`.
- **Sources**: `HookSource` → 6 values (`USER_SETTINGS` / `PROJECT_SETTINGS` / `LOCAL_SETTINGS` / `POLICY_SETTINGS` / `SESSION_HOOK` / `PLUGIN_HOOK`). Deprecation aliases (`SETTINGS`/`POLICY`/`PLUGINS`) via `EnumMeta.__getattr__`.
- **Hook config**: `if_condition`, `once`, `skill_root` added (optional).
- **Output schema**: Pydantic `HookOutput` with `extra=\"forbid\"` replaces ad-hoc `dict.get`; malformed output → WARNING + drop decision payload.
- **Env vars**: `CLAUDE_PROJECT_DIR`, `CLAUDE_PLUGIN_ROOT`, `CLAUDE_ENV_FILE` injected at hook fire (CLAUDE_ENV_FILE narrowed to SessionStart/Setup/CwdChanged).
- **Cleanup commit**: B1 priority test renamed/fixed; N1 stale test name fixed; N2 deprecated-alias test wrapped.
- 60 new tests across 6 files.

## Test plan
- [ ] Phase 1 focused suite → 60/60
- [ ] All hook tests → 166/166
- [ ] Full sweep: same 27 pre-existing env failures, no new

🤖 Generated with [Claude Code](https://claude.com/claude-code)