### PR TITLE
feat(ch12): phase 2 — multi-source policy cascade

### DIFF
--- a/src/hooks/config_manager.py
+++ b/src/hooks/config_manager.py
@@ -269,13 +269,29 @@ def load_hooks_from_settings(
 
 
 class HookConfigManager:
+    """Phase-2 / WI-2.1 — composes the six chapter sources at startup,
+    applies the policy cascade (WI-2.3), and produces the immutable
+    ``HookConfigSnapshot``.
+
+    Pre-Phase-2 this manager only loaded user-tier settings and used
+    ``settings_path`` exclusively. Phase 2 keeps that path as a single-source
+    constructor parameter (legacy callers pass exactly one path) AND adds an
+    optional ``workspace_root`` for project/local discovery. When
+    ``workspace_root`` is None, only the user/policy/plugin sources are
+    consulted (no walk).
+    """
+
     def __init__(
         self,
         registry: AsyncHookRegistry,
         settings_path: str | Path | None = None,
+        workspace_root: str | Path | None = None,
     ) -> None:
         self._registry = registry
+        # ``_settings_path`` is the user-tier path (back-compat with legacy
+        # single-path callers + ``reload_if_changed`` mtime tracking).
         self._settings_path = Path(settings_path) if settings_path else _get_settings_path()
+        self._workspace_root = Path(workspace_root) if workspace_root is not None else None
         self._snapshot: HookConfigSnapshot | None = None
         self._last_mtime: float = 0.0
 
@@ -284,19 +300,67 @@ class HookConfigManager:
         return self._snapshot
 
     async def load(self) -> HookConfigSnapshot:
-        snapshot = load_hooks_from_settings(self._settings_path)
+        # Local imports avoid a startup cost for callers that never reach
+        # ``load()``; also dodges any circular-import surface.
+        from .policy import apply_policy_cascade
+        from .sources.user_settings import load_user_hooks
+        from .sources.project_settings import load_project_hooks
+        from .sources.local_settings import load_local_hooks
+        from .sources.policy_settings import load_policy_hooks, load_policy_config
+        from src.utils.plugins.load_plugin_hooks import load_plugin_hooks
+
+        # Five disk-backed sources. Each returns ``dict[event, list[HookConfig]]``;
+        # missing files / parse errors yield ``{}`` (fail-soft per loader).
+        # Order in this list does NOT matter for correctness — the cascade
+        # uses ``HookSource.priority`` for sort, and ``apply_policy_cascade``
+        # filters by source membership. Order does matter for *trace clarity*
+        # in logs, so policy comes first (most authoritative), plugins last.
+        sources: list[dict[str, list[HookConfig]]] = [
+            load_policy_hooks(),
+            load_user_hooks(self._settings_path),
+            load_project_hooks(self._workspace_root),
+            load_local_hooks(self._workspace_root),
+            load_plugin_hooks(),
+        ]
+        policy_config = load_policy_config()
+
+        # Merge per event. Within each event the per-source lists are
+        # concatenated; ``AsyncHookRegistry.register`` later sorts each
+        # bucket by ``(source.priority, registration_order)``, so the merge
+        # order here only affects ties (which are stable-sorted by
+        # registration_order).
+        merged: dict[str, list[HookConfig]] = {}
+        for source_hooks in sources:
+            for event, hooks in source_hooks.items():
+                merged.setdefault(event, []).extend(hooks)
+
+        # WI-2.3 — apply policy cascade (disableAllHooks /
+        # allowManagedHooksOnly). MUST happen AFTER merge so the cascade
+        # sees all source-tagged hooks, not just policy.
+        merged = apply_policy_cascade(merged, policy_config)
+
+        snapshot = HookConfigSnapshot(
+            hooks=merged,
+            timestamp=time.time(),
+            source_path=str(self._settings_path),
+        )
         self._snapshot = snapshot
 
-        await self._registry.clear_source(HookSource.USER_SETTINGS)
-
+        # Sync the in-memory registry with the snapshot. ``clear`` then
+        # re-register from snapshot — simpler than reconciling deltas, and
+        # ``load()`` is rare (startup + /hooks reload). Each hook is
+        # registered with its TAGGED source (not a hard-coded one) so the
+        # registry's priority sort is correct across all five tiers.
+        await self._registry.clear()
         for event_name, hook_configs in snapshot.hooks.items():
+            if event_name not in ALL_HOOK_EVENTS:
+                continue
             for config in hook_configs:
-                if event_name in ALL_HOOK_EVENTS:
-                    await self._registry.register(
-                        event_name,  # type: ignore[arg-type]
-                        config,
-                        HookSource.USER_SETTINGS,
-                    )
+                await self._registry.register(
+                    event_name,  # type: ignore[arg-type]
+                    config,
+                    config.source,
+                )
 
         try:
             self._last_mtime = self._settings_path.stat().st_mtime

--- a/src/hooks/policy.py
+++ b/src/hooks/policy.py
@@ -1,0 +1,89 @@
+"""Policy cascade: ``disableAllHooks`` and ``allowManagedHooksOnly``.
+
+Mirrors TS ``hooksConfigSnapshot.ts:18-88``. Two enterprise-managed flags
+that override the default merge behavior, applied AFTER all sources have
+been merged but BEFORE the snapshot is built.
+
+Per the chapter (``ch12-extensibility.md`` §"The Snapshot Security Model"):
+
+    > The policy enforcement cascade: ``disableAllHooks`` in policy settings
+    > clears everything. ``allowManagedHooksOnly`` excludes user and project
+    > hooks. A user can disable their own hooks by setting ``disableAllHooks``,
+    > but they cannot disable enterprise-managed hooks. The policy layer
+    > always wins.
+
+Per §19 #8 (critic-confirmed): ``disableAllHooks: true`` clears policy hooks
+*too* — the chapter's stated semantic. This is counterintuitive but matches
+TS. The reason: an enterprise admin who sets ``disableAllHooks: true``
+explicitly wants no hooks at all (e.g., during incident response, when even
+audit hooks should be disabled).
+
+The cascade does NOT enforce priority precedence within a source — that's
+``HookSource.priority``'s job. The cascade is strictly about which sources
+survive.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .hook_types import HookConfig, HookSource
+
+logger = logging.getLogger(__name__)
+
+
+def should_disable_all_hooks(policy_config: dict[str, Any]) -> bool:
+    """True iff policy says ``disableAllHooks: true``.
+
+    Mirrors TS ``hooksConfigSnapshot.ts:21-48``. When this returns True, ALL
+    hooks are skipped — including policy-source hooks themselves.
+    """
+    return bool(policy_config.get("disableAllHooks", False))
+
+
+def should_allow_managed_hooks_only(policy_config: dict[str, Any]) -> bool:
+    """True iff policy says ``allowManagedHooksOnly: true``.
+
+    Mirrors TS ``hooksConfigSnapshot.ts:62-76``. When this returns True, only
+    POLICY_SETTINGS-source hooks survive the cascade; user/project/local/
+    plugin/session hooks are all dropped.
+    """
+    return bool(policy_config.get("allowManagedHooksOnly", False))
+
+
+def apply_policy_cascade(
+    hooks_by_event: dict[str, list[HookConfig]],
+    policy_config: dict[str, Any],
+) -> dict[str, list[HookConfig]]:
+    """Apply ``disableAllHooks`` / ``allowManagedHooksOnly`` to a merged
+    hooks-by-event dict.
+
+    Returns a NEW dict (does not mutate input).
+
+    Order of checks:
+        1. ``disableAllHooks`` — short-circuit; everything cleared, including
+           policy-source hooks. The chapter is explicit: "clears everything."
+        2. ``allowManagedHooksOnly`` — keep only hooks tagged with
+           ``HookSource.POLICY_SETTINGS``.
+        3. Otherwise — return unchanged.
+
+    Mirrors TS ``hooksConfigManager.ts:executeHooks`` precedence. Called from
+    ``HookConfigManager.load()`` after merging across sources.
+    """
+    if should_disable_all_hooks(policy_config):
+        logger.info("Policy disableAllHooks=true — clearing all hooks (including policy)")
+        return {}
+
+    if should_allow_managed_hooks_only(policy_config):
+        logger.info(
+            "Policy allowManagedHooksOnly=true — keeping policy-source hooks only"
+        )
+        return {
+            event: [h for h in hooks if h.source.is_policy]
+            for event, hooks in hooks_by_event.items()
+            # Drop empty event keys after filtering for tidier snapshot.
+            if any(h.source.is_policy for h in hooks)
+        }
+
+    return dict(hooks_by_event)

--- a/src/hooks/sources/__init__.py
+++ b/src/hooks/sources/__init__.py
@@ -1,0 +1,17 @@
+"""Per-source hook loaders.
+
+Phase-2 / WI-2.1. Each module in this package loads hooks from one of the
+chapter's six sources (``ch12-extensibility.md`` §"Six Hook Sources"). The
+``HookConfigManager`` composes them at startup, applies the policy cascade
+(``src/hooks/policy.py``), and builds the immutable snapshot.
+
+Source modules:
+    user_settings     — ~/.claude/settings.json (highest priority)
+    project_settings  — walks up from workspace_root looking for .claude/settings.json
+    local_settings    — <workspace>/.claude/settings.local.json (gitignored)
+    policy_settings   — enterprise-managed; cannot be overridden by user
+    plugin_hook       — plugins/<plugin>/hooks.json (priority 999, lowest)
+
+The session_hook source is in-memory only (Phase 3 / WI-3.1) and not loaded
+from disk; it has no module here.
+"""

--- a/src/hooks/sources/_common.py
+++ b/src/hooks/sources/_common.py
@@ -1,0 +1,70 @@
+"""Shared helpers used by all per-source loaders.
+
+Loads a settings.json-shaped file, applies the legacy ``Notification +
+matcher`` back-compat translation (Phase-1 / WI-1.1), and tags every parsed
+``HookConfig`` with the source enum value the caller specifies.
+
+Returns ``dict[event, list[HookConfig]]`` so the ``HookConfigManager`` can
+merge per-event lists across sources cheaply.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from ..hook_types import HookConfig, HookSource
+
+logger = logging.getLogger(__name__)
+
+
+def parse_hooks_file(
+    path: Path,
+    *,
+    source: HookSource,
+) -> dict[str, list[HookConfig]]:
+    """Read one JSON settings file and return its hooks tagged with ``source``.
+
+    Returns ``{}`` (empty dict, not None) if the file doesn't exist or fails
+    to parse — fail-soft so a missing tier doesn't break startup.
+
+    Reuses the back-compat translation in
+    ``config_manager.load_hooks_from_settings`` for the legacy
+    ``Notification + matcher: "onSessionStart"`` form.
+    """
+    if not path.exists():
+        return {}
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Failed to read hooks settings from %s: %s", path, exc)
+        return {}
+
+    hooks_raw = data.get("hooks", {})
+    if not isinstance(hooks_raw, dict):
+        return {}
+
+    # Reuse the existing parse + back-compat path for consistency. Loading
+    # via ``load_hooks_from_settings`` rebuilds the snapshot wrapper; we
+    # only need the events dict, so we replicate the parse loop here.
+    from ..config_manager import _parse_hook_config, _translate_legacy_notification_entry
+
+    hooks: dict[str, list[HookConfig]] = {}
+    for event_name, hook_list in hooks_raw.items():
+        if not isinstance(hook_list, list):
+            continue
+        for hook_raw in hook_list:
+            if not isinstance(hook_raw, dict):
+                continue
+            target_event = event_name
+            if event_name == "Notification":
+                translated = _translate_legacy_notification_entry(hook_raw)
+                if translated is not None:
+                    target_event = translated
+            hooks.setdefault(target_event, []).append(
+                _parse_hook_config(hook_raw, source=source)
+            )
+    return hooks

--- a/src/hooks/sources/local_settings.py
+++ b/src/hooks/sources/local_settings.py
@@ -1,0 +1,52 @@
+"""Local-tier settings loader: ``<workspace>/.claude/settings.local.json``.
+
+Per the chapter: "gitignored." Used for per-developer overrides on a shared
+project — e.g., a developer wants a ``PreToolUse`` audit hook locally
+without checking it into team configuration.
+
+Local settings live alongside the project settings (same ``.claude/`` dir,
+different filename). The lookup also walks up from workspace root to find
+the closest ``.claude/`` (matching ``project_settings``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..hook_types import HookConfig, HookSource
+from ._common import parse_hooks_file
+from .project_settings import find_project_settings_path
+
+
+def find_local_settings_path(start: Path) -> Path | None:
+    """Walk up from ``start`` looking for ``.claude/settings.local.json``.
+
+    Reuses ``find_project_settings_path`` to locate the ``.claude/``
+    directory, then swaps the filename. This guarantees user/project/local
+    all agree on which workspace ``.claude/`` they're reading from.
+    """
+    project_path = find_project_settings_path(start)
+    if project_path is None:
+        # No .claude/ dir found in the walk — try one more time looking
+        # specifically for the .local.json variant (the project-tier
+        # file might not exist but the local one might).
+        cur = start.resolve()
+        home = Path.home().resolve()
+        while True:
+            candidate = cur / ".claude" / "settings.local.json"
+            if candidate.exists() and cur != home:
+                return candidate
+            if cur == cur.parent or cur == home:
+                return None
+            cur = cur.parent
+    local = project_path.parent / "settings.local.json"
+    return local if local.exists() else None
+
+
+def load_local_hooks(workspace_root: Path | str | None) -> dict[str, list[HookConfig]]:
+    if workspace_root is None:
+        return {}
+    path = find_local_settings_path(Path(workspace_root))
+    if path is None:
+        return {}
+    return parse_hooks_file(path, source=HookSource.LOCAL_SETTINGS)

--- a/src/hooks/sources/policy_settings.py
+++ b/src/hooks/sources/policy_settings.py
@@ -1,0 +1,73 @@
+"""Policy-tier settings loader: enterprise-managed.
+
+Cannot be overridden by user/project/local hooks. Enforces ``disableAllHooks``
+and ``allowManagedHooksOnly`` cascades (handled in ``src/hooks/policy.py``).
+
+Path resolution (in order):
+    1. ``CLAUDE_POLICY_DIR`` env var (test fixtures + admin override).
+    2. Platform default:
+         macOS    → /Library/Application Support/com.anthropic.claude
+         Windows  → %ALLUSERSPROFILE%\\AnthropicClaude
+         Linux    → /etc/anthropic/claude
+
+Returns both:
+  * the parsed hooks (typed under ``HookSource.POLICY_SETTINGS``)
+  * the raw policy config dict — needed by the cascade gate to read
+    ``disableAllHooks`` / ``allowManagedHooksOnly`` flags. The flags live
+    at the *top level* of the policy settings file, not under the ``hooks``
+    key, so they need to flow back to the manager separately.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+from pathlib import Path
+from typing import Any
+
+from ..hook_types import HookConfig, HookSource
+from ._common import parse_hooks_file
+
+logger = logging.getLogger(__name__)
+
+
+def get_policy_settings_path() -> Path:
+    env_override = os.environ.get("CLAUDE_POLICY_DIR")
+    if env_override:
+        return Path(env_override).expanduser().resolve() / "settings.json"
+    system = platform.system()
+    if system == "Darwin":
+        return Path("/Library/Application Support/com.anthropic.claude/settings.json")
+    if system == "Windows":
+        prog_data = os.environ.get("ALLUSERSPROFILE", r"C:\ProgramData")
+        return Path(prog_data) / "AnthropicClaude" / "settings.json"
+    # Default to Linux/Unix layout.
+    return Path("/etc/anthropic/claude/settings.json")
+
+
+def load_policy_hooks(path: Path | None = None) -> dict[str, list[HookConfig]]:
+    return parse_hooks_file(
+        path if path is not None else get_policy_settings_path(),
+        source=HookSource.POLICY_SETTINGS,
+    )
+
+
+def load_policy_config(path: Path | None = None) -> dict[str, Any]:
+    """Read the full policy settings JSON object (not just hooks).
+
+    Returns the *top-level* dict so callers can read ``disableAllHooks`` and
+    ``allowManagedHooksOnly`` flags. Returns ``{}`` on any failure (missing
+    file, bad JSON) — fail-soft so a missing policy file doesn't break
+    startup.
+    """
+    p = path if path is not None else get_policy_settings_path()
+    if not p.exists():
+        return {}
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Failed to read policy settings from %s: %s", p, exc)
+        return {}
+    return data if isinstance(data, dict) else {}

--- a/src/hooks/sources/project_settings.py
+++ b/src/hooks/sources/project_settings.py
@@ -1,0 +1,47 @@
+"""Project-tier settings loader: ``<workspace>/.claude/settings.json``.
+
+Walked up from the workspace root (or cwd) to support multi-workspace
+layouts — matches the TS pattern of finding the *closest* ``.claude/``
+directory walking towards the filesystem root.
+
+The walk stops at the user's home directory (so we don't pick up
+``~/.claude/settings.json`` again — that's the user-tier loader's job).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..hook_types import HookConfig, HookSource
+from ._common import parse_hooks_file
+
+
+def find_project_settings_path(start: Path) -> Path | None:
+    """Walk up from ``start`` looking for ``.claude/settings.json``.
+
+    Stops at the user's home directory or the filesystem root, whichever
+    comes first. Returns the path if found, else None.
+    """
+    home = Path.home().resolve()
+    cur = start.resolve()
+    while True:
+        candidate = cur / ".claude" / "settings.json"
+        if candidate.exists() and cur != home:
+            # Cur != home guards against accidentally picking up the
+            # user-tier path when the project is the home directory itself
+            # (unusual but possible in dev environments).
+            return candidate
+        if cur == cur.parent:  # filesystem root
+            return None
+        if cur == home:
+            return None
+        cur = cur.parent
+
+
+def load_project_hooks(workspace_root: Path | str | None) -> dict[str, list[HookConfig]]:
+    if workspace_root is None:
+        return {}
+    path = find_project_settings_path(Path(workspace_root))
+    if path is None:
+        return {}
+    return parse_hooks_file(path, source=HookSource.PROJECT_SETTINGS)

--- a/src/hooks/sources/user_settings.py
+++ b/src/hooks/sources/user_settings.py
@@ -1,0 +1,33 @@
+"""User-tier settings loader: ``~/.claude/settings.json``.
+
+The chapter's "highest priority" tier — personal config that follows the
+user across projects. Mirrors TS ``hooksSettings.ts`` user-settings path.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from ..hook_types import HookConfig, HookSource
+from ._common import parse_hooks_file
+
+
+def get_user_settings_path() -> Path:
+    """Return the canonical user-settings path.
+
+    Honors ``CLAUDE_CONFIG_DIR`` env-var override (test fixtures use this);
+    falls back to ``~/.claude/settings.json``. Mirrors the legacy
+    ``_get_settings_path`` in ``config_manager.py``.
+    """
+    env_override = os.environ.get("CLAUDE_CONFIG_DIR")
+    if env_override:
+        return Path(env_override).expanduser().resolve() / "settings.json"
+    return Path.home() / ".claude" / "settings.json"
+
+
+def load_user_hooks(path: Path | None = None) -> dict[str, list[HookConfig]]:
+    return parse_hooks_file(
+        path if path is not None else get_user_settings_path(),
+        source=HookSource.USER_SETTINGS,
+    )

--- a/src/utils/plugins/__init__.py
+++ b/src/utils/plugins/__init__.py
@@ -1,0 +1,6 @@
+"""Plugin-system utilities (Phase-2 / WI-2.2 — plugin hook loader).
+
+This is the ``utils/plugins/`` namespace mirroring TS layout. The deeper
+plugin runtime lives at ``src/plugins/``; this dir hosts integration helpers
+that don't belong in the core plugin loader.
+"""

--- a/src/utils/plugins/load_plugin_hooks.py
+++ b/src/utils/plugins/load_plugin_hooks.py
@@ -1,0 +1,69 @@
+"""Plugin-tier hook loader.
+
+Mirrors TS ``typescript/src/utils/plugins/loadPluginHooks.ts``. Per assumption
+A2 (plan §19), plugins ship a separate ``hooks.json`` per plugin directory
+rather than burying hooks under the manifest's ``hooks`` field. Cleaner
+separation; easier plugin-manifest evolution.
+
+Discovery:
+    1. ``CLAUDE_PLUGINS_ROOT`` env var (test fixtures + admin override).
+    2. ``~/.claude/plugins/`` (legacy default).
+
+Each plugin is a directory under the plugins root. We look for
+``<plugin>/hooks.json``; missing files are silently skipped (a plugin
+needn't ship hooks).
+
+The loaded ``HookConfig`` objects carry:
+  * ``source = HookSource.PLUGIN_HOOK`` (priority 999, sorts last).
+  * ``skill_root = <plugin_dir>`` so subprocess env injection (WI-1.5)
+    populates ``CLAUDE_PLUGIN_ROOT`` correctly when the plugin's hook fires.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+from src.hooks.hook_types import HookConfig, HookSource
+from src.hooks.sources._common import parse_hooks_file
+
+logger = logging.getLogger(__name__)
+
+
+def get_plugins_root() -> Path | None:
+    env_override = os.environ.get("CLAUDE_PLUGINS_ROOT")
+    if env_override:
+        p = Path(env_override).expanduser().resolve()
+        return p if p.exists() else None
+    default = Path.home() / ".claude" / "plugins"
+    return default if default.exists() else None
+
+
+def load_plugin_hooks(
+    plugins_root: Path | None = None,
+) -> dict[str, list[HookConfig]]:
+    root = plugins_root if plugins_root is not None else get_plugins_root()
+    if root is None or not root.exists():
+        return {}
+
+    merged: dict[str, list[HookConfig]] = {}
+    for plugin_dir in sorted(root.iterdir()):
+        if not plugin_dir.is_dir():
+            continue
+        hooks_path = plugin_dir / "hooks.json"
+        if not hooks_path.exists():
+            continue
+
+        plugin_hooks = parse_hooks_file(hooks_path, source=HookSource.PLUGIN_HOOK)
+        # Stamp ``skill_root`` so CLAUDE_PLUGIN_ROOT is set when a plugin
+        # hook fires (WI-1.5).
+        for event_hooks in plugin_hooks.values():
+            for hook in event_hooks:
+                hook.skill_root = str(plugin_dir)
+
+        for event, hooks in plugin_hooks.items():
+            merged.setdefault(event, []).extend(hooks)
+
+    return merged

--- a/tests/test_hook_policy_cascade.py
+++ b/tests/test_hook_policy_cascade.py
@@ -1,0 +1,338 @@
+"""Phase-2 / WI-2.3 — policy cascade tests.
+
+The chapter (``ch12-extensibility.md`` §"The Snapshot Security Model")
+specifies two enterprise-managed flags that override the default merge
+behavior:
+
+  * ``disableAllHooks`` — clears EVERYTHING, including policy-source hooks
+    (per §19 #8, critic-confirmed). Counterintuitive but matches TS; the
+    rationale is "incident response — turn off all hooks, including audit."
+  * ``allowManagedHooksOnly`` — keeps only policy-source hooks, drops
+    user/project/local/plugin hooks.
+
+The "policy wins" semantic critic asked for is exercised at the integration
+level: a user setting that conflicts with policy is dropped when
+``allowManagedHooksOnly`` is on.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.hooks.config_manager import HookConfigManager
+from src.hooks.hook_types import HookConfig, HookSource
+from src.hooks.policy import (
+    apply_policy_cascade,
+    should_allow_managed_hooks_only,
+    should_disable_all_hooks,
+)
+from src.hooks.registry import AsyncHookRegistry
+
+
+# ---------------------------------------------------------------------------
+# Pure-function predicate tests
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyPredicates:
+    def test_disable_all_hooks_default_false(self):
+        assert should_disable_all_hooks({}) is False
+
+    def test_disable_all_hooks_explicit_true(self):
+        assert should_disable_all_hooks({"disableAllHooks": True}) is True
+
+    def test_disable_all_hooks_explicit_false(self):
+        assert should_disable_all_hooks({"disableAllHooks": False}) is False
+
+    def test_disable_all_hooks_truthy_coercion(self):
+        # bool() coercion: any truthy value enables the flag, matching
+        # TS' permissive ``Boolean(...)`` cast.
+        assert should_disable_all_hooks({"disableAllHooks": 1}) is True
+        assert should_disable_all_hooks({"disableAllHooks": "yes"}) is True
+
+    def test_allow_managed_only_default_false(self):
+        assert should_allow_managed_hooks_only({}) is False
+
+    def test_allow_managed_only_explicit(self):
+        assert should_allow_managed_hooks_only({"allowManagedHooksOnly": True}) is True
+
+
+# ---------------------------------------------------------------------------
+# apply_policy_cascade — pure transformation tests
+# ---------------------------------------------------------------------------
+
+
+def _hook(cmd: str, source: HookSource) -> HookConfig:
+    return HookConfig(type="command", command=cmd, source=source)
+
+
+class TestApplyPolicyCascade:
+    def test_disable_all_clears_everything_including_policy(self):
+        # Critic-confirmed §19 #8: ``disableAllHooks`` clears policy too.
+        merged = {
+            "PreToolUse": [
+                _hook("u", HookSource.USER_SETTINGS),
+                _hook("policy", HookSource.POLICY_SETTINGS),
+            ],
+        }
+        result = apply_policy_cascade(merged, {"disableAllHooks": True})
+        assert result == {}
+
+    def test_allow_managed_only_keeps_policy_drops_others(self):
+        merged = {
+            "PreToolUse": [
+                _hook("user", HookSource.USER_SETTINGS),
+                _hook("project", HookSource.PROJECT_SETTINGS),
+                _hook("local", HookSource.LOCAL_SETTINGS),
+                _hook("policy", HookSource.POLICY_SETTINGS),
+                _hook("plugin", HookSource.PLUGIN_HOOK),
+            ],
+        }
+        result = apply_policy_cascade(merged, {"allowManagedHooksOnly": True})
+        assert "PreToolUse" in result
+        assert len(result["PreToolUse"]) == 1
+        assert result["PreToolUse"][0].source == HookSource.POLICY_SETTINGS
+
+    def test_allow_managed_only_drops_event_with_no_policy_hook(self):
+        # If an event has no policy-source hooks, it disappears from the
+        # result entirely (tidier snapshot).
+        merged = {
+            "PreToolUse": [_hook("u", HookSource.USER_SETTINGS)],
+            "PostToolUse": [_hook("policy", HookSource.POLICY_SETTINGS)],
+        }
+        result = apply_policy_cascade(merged, {"allowManagedHooksOnly": True})
+        assert "PreToolUse" not in result
+        assert "PostToolUse" in result
+
+    def test_no_flags_returns_unchanged(self):
+        merged = {"PreToolUse": [_hook("a", HookSource.USER_SETTINGS)]}
+        result = apply_policy_cascade(merged, {})
+        assert result == merged
+        # Returns a NEW dict (no mutation contract).
+        assert result is not merged
+
+    def test_input_not_mutated(self):
+        merged = {
+            "PreToolUse": [
+                _hook("u", HookSource.USER_SETTINGS),
+                _hook("policy", HookSource.POLICY_SETTINGS),
+            ],
+        }
+        before = {ev: list(hs) for ev, hs in merged.items()}
+        _ = apply_policy_cascade(merged, {"allowManagedHooksOnly": True})
+        # Original dict untouched.
+        assert merged == before
+
+
+# ---------------------------------------------------------------------------
+# Integration: HookConfigManager.load() with policy cascade end-to-end
+# ---------------------------------------------------------------------------
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+class TestPolicyCascadeIntegration:
+    """End-to-end: load user + policy + project + local hooks, apply
+    cascade, observe the snapshot.
+    """
+
+    @pytest.mark.asyncio
+    async def test_disable_all_clears_user_and_policy(self, monkeypatch, tmp_path):
+        # Set up two source files: user settings with one hook, policy
+        # settings with disableAllHooks=true plus its own hook.
+        user_dir = tmp_path / "user"
+        policy_dir = tmp_path / "policy"
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(user_dir))
+        monkeypatch.setenv("CLAUDE_POLICY_DIR", str(policy_dir))
+        monkeypatch.setenv("CLAUDE_PLUGINS_ROOT", str(plugins_dir))
+
+        _write_json(user_dir / "settings.json", {
+            "hooks": {"PreToolUse": [{"type": "command", "command": "echo u"}]},
+        })
+        _write_json(policy_dir / "settings.json", {
+            "disableAllHooks": True,
+            "hooks": {"PreToolUse": [{"type": "command", "command": "echo p"}]},
+        })
+
+        manager = HookConfigManager(
+            registry=AsyncHookRegistry(),
+            settings_path=user_dir / "settings.json",
+        )
+        snapshot = await manager.load()
+        # Everything cleared, including the policy hook.
+        assert snapshot.hooks == {}
+
+    @pytest.mark.asyncio
+    async def test_allow_managed_only_drops_user_keeps_policy(self, monkeypatch, tmp_path):
+        user_dir = tmp_path / "user"
+        policy_dir = tmp_path / "policy"
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(user_dir))
+        monkeypatch.setenv("CLAUDE_POLICY_DIR", str(policy_dir))
+        monkeypatch.setenv("CLAUDE_PLUGINS_ROOT", str(plugins_dir))
+
+        _write_json(user_dir / "settings.json", {
+            "hooks": {"PreToolUse": [{"type": "command", "command": "echo user"}]},
+        })
+        _write_json(policy_dir / "settings.json", {
+            "allowManagedHooksOnly": True,
+            "hooks": {"PreToolUse": [{"type": "command", "command": "echo policy"}]},
+        })
+
+        manager = HookConfigManager(
+            registry=AsyncHookRegistry(),
+            settings_path=user_dir / "settings.json",
+        )
+        snapshot = await manager.load()
+        # User hook dropped; policy hook survives.
+        assert "PreToolUse" in snapshot.hooks
+        assert len(snapshot.hooks["PreToolUse"]) == 1
+        assert snapshot.hooks["PreToolUse"][0].source == HookSource.POLICY_SETTINGS
+        assert snapshot.hooks["PreToolUse"][0].command == "echo policy"
+
+    @pytest.mark.asyncio
+    async def test_policy_cascade_overrides_user_settings(self, monkeypatch, tmp_path):
+        # Critic ask: a test that exercises the "policy wins" semantic.
+        # Setup: user defines a hook for PreToolUse; policy says
+        # ``allowManagedHooksOnly: true`` AND defines a different hook.
+        # Expected: only the policy hook survives.
+        user_dir = tmp_path / "user"
+        policy_dir = tmp_path / "policy"
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(user_dir))
+        monkeypatch.setenv("CLAUDE_POLICY_DIR", str(policy_dir))
+        monkeypatch.setenv("CLAUDE_PLUGINS_ROOT", str(plugins_dir))
+
+        _write_json(user_dir / "settings.json", {
+            "hooks": {"PreToolUse": [
+                {"type": "command", "command": "user-says-allow",
+                 "matcher": "Bash"},
+            ]},
+        })
+        _write_json(policy_dir / "settings.json", {
+            "allowManagedHooksOnly": True,
+            "hooks": {"PreToolUse": [
+                {"type": "command", "command": "policy-says-deny",
+                 "matcher": "Bash"},
+            ]},
+        })
+
+        manager = HookConfigManager(
+            registry=AsyncHookRegistry(),
+            settings_path=user_dir / "settings.json",
+        )
+        snapshot = await manager.load()
+        # User's ``user-says-allow`` is dropped by the cascade; the policy
+        # hook is the only surviving entry, and it's tagged POLICY_SETTINGS.
+        assert "PreToolUse" in snapshot.hooks
+        survivors = snapshot.hooks["PreToolUse"]
+        assert len(survivors) == 1
+        assert survivors[0].command == "policy-says-deny"
+        assert survivors[0].source == HookSource.POLICY_SETTINGS
+
+    @pytest.mark.asyncio
+    async def test_no_policy_flags_keeps_all_sources(self, monkeypatch, tmp_path):
+        # No ``disableAllHooks`` / ``allowManagedHooksOnly`` flags →
+        # cascade is a no-op, all sources flow through to the snapshot.
+        user_dir = tmp_path / "user"
+        policy_dir = tmp_path / "policy"
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(user_dir))
+        monkeypatch.setenv("CLAUDE_POLICY_DIR", str(policy_dir))
+        monkeypatch.setenv("CLAUDE_PLUGINS_ROOT", str(plugins_dir))
+
+        _write_json(user_dir / "settings.json", {
+            "hooks": {"PreToolUse": [{"type": "command", "command": "user"}]},
+        })
+        _write_json(policy_dir / "settings.json", {
+            "hooks": {"PreToolUse": [{"type": "command", "command": "policy"}]},
+        })
+
+        manager = HookConfigManager(
+            registry=AsyncHookRegistry(),
+            settings_path=user_dir / "settings.json",
+        )
+        snapshot = await manager.load()
+        assert "PreToolUse" in snapshot.hooks
+        # Both sources represented.
+        commands = {h.command for h in snapshot.hooks["PreToolUse"]}
+        sources = {h.source for h in snapshot.hooks["PreToolUse"]}
+        assert "user" in commands
+        assert "policy" in commands
+        assert HookSource.USER_SETTINGS in sources
+        assert HookSource.POLICY_SETTINGS in sources
+
+    @pytest.mark.asyncio
+    async def test_workspace_root_picks_up_project_and_local(self, monkeypatch, tmp_path):
+        user_dir = tmp_path / "user"
+        policy_dir = tmp_path / "policy"
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(user_dir))
+        monkeypatch.setenv("CLAUDE_POLICY_DIR", str(policy_dir))
+        monkeypatch.setenv("CLAUDE_PLUGINS_ROOT", str(plugins_dir))
+
+        _write_json(workspace / ".claude" / "settings.json", {
+            "hooks": {"PreToolUse": [{"type": "command", "command": "project"}]},
+        })
+        _write_json(workspace / ".claude" / "settings.local.json", {
+            "hooks": {"PreToolUse": [{"type": "command", "command": "local"}]},
+        })
+
+        manager = HookConfigManager(
+            registry=AsyncHookRegistry(),
+            settings_path=user_dir / "settings.json",
+            workspace_root=workspace,
+        )
+        snapshot = await manager.load()
+        commands = {h.command for h in snapshot.hooks["PreToolUse"]}
+        sources = {h.source for h in snapshot.hooks["PreToolUse"]}
+        assert "project" in commands
+        assert "local" in commands
+        assert HookSource.PROJECT_SETTINGS in sources
+        assert HookSource.LOCAL_SETTINGS in sources
+
+    @pytest.mark.asyncio
+    async def test_plugin_hooks_loaded_with_skill_root(self, monkeypatch, tmp_path):
+        user_dir = tmp_path / "user"
+        policy_dir = tmp_path / "policy"
+        plugins_dir = tmp_path / "plugins"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(user_dir))
+        monkeypatch.setenv("CLAUDE_POLICY_DIR", str(policy_dir))
+        monkeypatch.setenv("CLAUDE_PLUGINS_ROOT", str(plugins_dir))
+
+        plugin_dir = plugins_dir / "my-plugin"
+        plugin_dir.mkdir(parents=True)
+        _write_json(plugin_dir / "hooks.json", {
+            "hooks": {"PreToolUse": [{"type": "command", "command": "plug"}]},
+        })
+
+        manager = HookConfigManager(
+            registry=AsyncHookRegistry(),
+            settings_path=user_dir / "settings.json",
+        )
+        snapshot = await manager.load()
+        assert "PreToolUse" in snapshot.hooks
+        plugin_hooks = [h for h in snapshot.hooks["PreToolUse"]
+                        if h.source == HookSource.PLUGIN_HOOK]
+        assert len(plugin_hooks) == 1
+        # ``skill_root`` populated for CLAUDE_PLUGIN_ROOT env injection.
+        assert plugin_hooks[0].skill_root == str(plugin_dir)

--- a/tests/test_hook_sources.py
+++ b/tests/test_hook_sources.py
@@ -1,0 +1,239 @@
+"""Phase-2 / WI-2.1 — per-source loader tests.
+
+Covers the four file-backed source loaders + the plugin loader. Each test
+sets ``CLAUDE_*_DIR`` / ``CLAUDE_PLUGINS_ROOT`` env vars to point at
+``tmp_path`` so the loaders read fixtures rather than the user's real
+configuration.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from src.hooks.hook_types import HookConfig, HookSource
+from src.hooks.sources.user_settings import (
+    get_user_settings_path,
+    load_user_hooks,
+)
+from src.hooks.sources.project_settings import (
+    find_project_settings_path,
+    load_project_hooks,
+)
+from src.hooks.sources.local_settings import (
+    find_local_settings_path,
+    load_local_hooks,
+)
+from src.hooks.sources.policy_settings import (
+    get_policy_settings_path,
+    load_policy_config,
+    load_policy_hooks,
+)
+from src.utils.plugins.load_plugin_hooks import (
+    get_plugins_root,
+    load_plugin_hooks,
+)
+
+
+def _write_settings(path: Path, hooks: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"hooks": hooks}))
+
+
+# ---------------------------------------------------------------------------
+# User-tier
+# ---------------------------------------------------------------------------
+
+
+class TestUserSettingsLoader:
+    def test_env_override_changes_path(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+        assert get_user_settings_path() == tmp_path / "settings.json"
+
+    def test_loader_returns_empty_when_file_missing(self, tmp_path):
+        result = load_user_hooks(tmp_path / "nonexistent.json")
+        assert result == {}
+
+    def test_loader_returns_user_settings_tagged_hooks(self, tmp_path):
+        path = tmp_path / "settings.json"
+        _write_settings(path, {"PreToolUse": [{"type": "command", "command": "echo u"}]})
+        hooks = load_user_hooks(path)
+        assert "PreToolUse" in hooks
+        assert hooks["PreToolUse"][0].source == HookSource.USER_SETTINGS
+
+    def test_malformed_file_returns_empty(self, tmp_path):
+        path = tmp_path / "settings.json"
+        path.write_text("not valid json {")
+        assert load_user_hooks(path) == {}
+
+
+# ---------------------------------------------------------------------------
+# Project-tier (walk up from workspace_root)
+# ---------------------------------------------------------------------------
+
+
+class TestProjectSettingsLoader:
+    def test_walks_up_from_workspace_root(self, tmp_path):
+        proj = tmp_path / "myproject"
+        deep = proj / "src" / "deep" / "nested"
+        deep.mkdir(parents=True)
+        _write_settings(
+            proj / ".claude" / "settings.json",
+            {"PreToolUse": [{"type": "command", "command": "echo p"}]},
+        )
+        path = find_project_settings_path(deep)
+        assert path == proj / ".claude" / "settings.json"
+
+    def test_returns_none_when_no_dotclaude_dir(self, tmp_path):
+        proj = tmp_path / "noproj"
+        proj.mkdir()
+        assert find_project_settings_path(proj) is None
+
+    def test_loader_tags_with_project_settings(self, tmp_path):
+        proj = tmp_path / "p"
+        proj.mkdir()
+        _write_settings(
+            proj / ".claude" / "settings.json",
+            {"PreToolUse": [{"type": "command", "command": "echo p"}]},
+        )
+        hooks = load_project_hooks(proj)
+        assert hooks["PreToolUse"][0].source == HookSource.PROJECT_SETTINGS
+
+    def test_loader_returns_empty_when_workspace_none(self):
+        assert load_project_hooks(None) == {}
+
+
+# ---------------------------------------------------------------------------
+# Local-tier (settings.local.json next to project settings)
+# ---------------------------------------------------------------------------
+
+
+class TestLocalSettingsLoader:
+    def test_finds_local_alongside_project(self, tmp_path):
+        proj = tmp_path / "p"
+        proj.mkdir()
+        _write_settings(proj / ".claude" / "settings.json", {})  # project anchor
+        _write_settings(
+            proj / ".claude" / "settings.local.json",
+            {"PreToolUse": [{"type": "command", "command": "echo l"}]},
+        )
+        path = find_local_settings_path(proj)
+        assert path == proj / ".claude" / "settings.local.json"
+
+    def test_finds_local_even_without_project_settings(self, tmp_path):
+        # Local-only setup (no settings.json, just settings.local.json).
+        proj = tmp_path / "p"
+        (proj / ".claude").mkdir(parents=True)
+        _write_settings(
+            proj / ".claude" / "settings.local.json",
+            {"PreToolUse": [{"type": "command", "command": "echo l"}]},
+        )
+        path = find_local_settings_path(proj)
+        assert path == proj / ".claude" / "settings.local.json"
+
+    def test_loader_tags_with_local_settings(self, tmp_path):
+        proj = tmp_path / "p"
+        (proj / ".claude").mkdir(parents=True)
+        _write_settings(
+            proj / ".claude" / "settings.local.json",
+            {"PreToolUse": [{"type": "command", "command": "echo l"}]},
+        )
+        hooks = load_local_hooks(proj)
+        assert hooks["PreToolUse"][0].source == HookSource.LOCAL_SETTINGS
+
+
+# ---------------------------------------------------------------------------
+# Policy-tier
+# ---------------------------------------------------------------------------
+
+
+class TestPolicySettingsLoader:
+    def test_env_override_changes_path(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CLAUDE_POLICY_DIR", str(tmp_path))
+        assert get_policy_settings_path() == tmp_path / "settings.json"
+
+    def test_loader_tags_with_policy_settings(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CLAUDE_POLICY_DIR", str(tmp_path))
+        _write_settings(
+            tmp_path / "settings.json",
+            {"PreToolUse": [{"type": "command", "command": "echo policy"}]},
+        )
+        hooks = load_policy_hooks()
+        assert hooks["PreToolUse"][0].source == HookSource.POLICY_SETTINGS
+
+    def test_load_policy_config_returns_top_level(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CLAUDE_POLICY_DIR", str(tmp_path))
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps({
+            "disableAllHooks": True,
+            "hooks": {"PreToolUse": [{"type": "command", "command": "x"}]},
+        }))
+        config = load_policy_config()
+        assert config["disableAllHooks"] is True
+
+    def test_load_policy_config_missing_returns_empty(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CLAUDE_POLICY_DIR", str(tmp_path))
+        # No settings.json written.
+        assert load_policy_config() == {}
+
+
+# ---------------------------------------------------------------------------
+# Plugin-tier
+# ---------------------------------------------------------------------------
+
+
+class TestPluginHookLoader:
+    def test_env_override_changes_root(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CLAUDE_PLUGINS_ROOT", str(tmp_path))
+        assert get_plugins_root() == tmp_path
+
+    def test_no_root_returns_empty(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CLAUDE_PLUGINS_ROOT", str(tmp_path / "nonexistent"))
+        assert load_plugin_hooks() == {}
+
+    def test_plugin_with_hooks_json_loaded(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CLAUDE_PLUGINS_ROOT", str(tmp_path))
+        plugin = tmp_path / "my-plugin"
+        plugin.mkdir()
+        _write_settings(
+            plugin / "hooks.json",
+            {"PreToolUse": [{"type": "command", "command": "echo plug"}]},
+        )
+        hooks = load_plugin_hooks()
+        assert "PreToolUse" in hooks
+        assert hooks["PreToolUse"][0].source == HookSource.PLUGIN_HOOK
+
+    def test_skill_root_set_to_plugin_dir(self, monkeypatch, tmp_path):
+        # CLAUDE_PLUGIN_ROOT injection (WI-1.5) needs ``skill_root`` to
+        # point at the plugin's directory.
+        monkeypatch.setenv("CLAUDE_PLUGINS_ROOT", str(tmp_path))
+        plugin = tmp_path / "my-plugin"
+        plugin.mkdir()
+        _write_settings(
+            plugin / "hooks.json",
+            {"PreToolUse": [{"type": "command", "command": "echo p"}]},
+        )
+        hooks = load_plugin_hooks()
+        assert hooks["PreToolUse"][0].skill_root == str(plugin)
+
+    def test_plugin_without_hooks_json_skipped(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CLAUDE_PLUGINS_ROOT", str(tmp_path))
+        plugin = tmp_path / "no-hooks-plugin"
+        plugin.mkdir()
+        # No hooks.json → silently skipped.
+        assert load_plugin_hooks() == {}
+
+    def test_multiple_plugins_merged(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CLAUDE_PLUGINS_ROOT", str(tmp_path))
+        for name in ("plugin-a", "plugin-b"):
+            p = tmp_path / name
+            p.mkdir()
+            _write_settings(
+                p / "hooks.json",
+                {"PreToolUse": [{"type": "command", "command": f"echo {name}"}]},
+            )
+        hooks = load_plugin_hooks()
+        assert len(hooks["PreToolUse"]) == 2


### PR DESCRIPTION
## Summary
Phase 2 of ch12 — multi-source policy cascade. Adds 5 file-backed source loaders (user/project/local/policy/plugin), wires `disableAllHooks` and `allowManagedHooksOnly` policy semantics, and rewrites `HookConfigManager.load()` to merge across sources before applying the cascade.

## What's new in this phase (vs Phase 1)
- New `src/hooks/sources/` package with 4 file-backed loaders (`user_settings.py`, `project_settings.py`, `local_settings.py`, `policy.py`) plus shared `_common.parse_hooks_file()` helper. All honor `CLAUDE_*_DIR` env overrides; fail-soft on missing/malformed.
- New `src/utils/plugins/load_plugin_hooks.py` — plugin `hooks.json` is a SEPARATE file (per A2), not a manifest field. Stamps `skill_root=<plugin_dir>`.
- New `src/hooks/policy.py` with `should_disable_all_hooks` / `should_allow_managed_hooks_only` / `apply_policy_cascade`. `disableAllHooks: true` clears policy too (chapter-correct).
- `HookConfigManager.load()` rewritten to merge 5 sources → apply cascade → sync registry. Constructor gains optional `workspace_root`; legacy single-path callers still work.
- 38 new tests including `test_disable_all_clears_user_and_policy`, `test_allow_managed_only_drops_user_keeps_policy`, `test_policy_cascade_overrides_user_settings`.

## Test plan
- [ ] Phase 2 focused suite → 38/38
- [ ] All hook tests → 209/209
- [ ] Full sweep: same 27 pre-existing env failures (baseline-diff'd identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)