### PR TITLE
feat(ch12): phase 3 — session-hook registration API + skill registrars

### DIFF
--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -322,6 +322,73 @@ async def _execute_command_hook(
         )
 
 
+async def _collect_hooks_for_event(
+    event: str,
+    tool_name: str | None,
+    tool_use_context: Any,
+) -> list[Any]:
+    """Phase-3 / WI-3.1 (I2 contract split — Phase 3 owns "collect"):
+    merge snapshot hooks with session-registered hooks for ``event``,
+    apply the trust gate and matcher filter, return the ordered list of
+    ``SessionHookEntry``-shaped items to fire.
+
+    Each returned item carries:
+      * ``config`` — the ``HookConfig`` to execute
+      * ``event``  — the event name (post-Stop→SubagentStop conversion)
+      * ``matcher`` — copied from ``config.matcher`` (or empty string)
+      * ``on_success`` — optional callback fired by the executor after a
+                          successful firing; populated for ``once: true``
+                          session-scoped hooks.
+
+    Snapshot hooks always have ``on_success=None``: ``once: true`` is a
+    session-hook-only contract per the chapter. (A snapshot ``once: true``
+    would be ambiguous — what would "once" mean for a config-driven hook
+    that's reloaded fresh on every startup?)
+
+    Phase 4 (aggregation) consumes the per-hook results yielded by the
+    executor; this collect step does NOT consume results — it just lines
+    up which hooks are eligible to fire.
+    """
+    from .session_hooks import SessionHookEntry
+
+    trust_skip = should_skip_hook_due_to_trust(tool_use_context)
+
+    snapshot_hooks = _get_hooks_from_snapshot(tool_use_context).get(event, [])
+    if trust_skip:
+        snapshot_hooks = [h for h in snapshot_hooks if h.source.is_policy]
+
+    snapshot_entries: list[SessionHookEntry] = [
+        SessionHookEntry(
+            config=h,
+            event=event,  # type: ignore[arg-type]
+            matcher=h.matcher or "",
+            on_success=None,
+        )
+        for h in snapshot_hooks
+    ]
+
+    session_entries: list[SessionHookEntry] = []
+    registry = getattr(tool_use_context, "session_hook_registry", None)
+    session_id = getattr(tool_use_context, "session_id", None)
+    if registry is not None and session_id is not None:
+        raw_session_entries = await registry.get_for_event(session_id, event)
+        if trust_skip:
+            # Session-source hooks are NEVER policy-tier (only POLICY_SETTINGS
+            # is); under trust gate, all session-scoped hooks are dropped.
+            raw_session_entries = []
+        session_entries = list(raw_session_entries)
+
+    merged = snapshot_entries + session_entries
+
+    if tool_name is not None:
+        merged = [
+            entry for entry in merged
+            if _matches_tool(entry.config.matcher, tool_name)
+        ]
+
+    return merged
+
+
 async def _run_hooks_for_event(
     event: str,
     tool_name: str | None,
@@ -330,32 +397,17 @@ async def _run_hooks_for_event(
     abort_signal: Any | None = None,
     timeout_ms: int = TOOL_HOOK_EXECUTION_TIMEOUT_MS,
 ) -> AsyncGenerator[dict[str, Any], None]:
-    # WI-0.2 — workspace-trust gate. Skip non-policy hooks while the workspace
-    # is untrusted. The per-hook policy check happens below since policy-source
-    # identification is per-HookConfig.
-    trust_skip = should_skip_hook_due_to_trust(tool_use_context)
-
-    # WI-0.1 — read from the frozen snapshot, not from options.hooks. The
-    # snapshot is built once at startup by HookConfigManager.load() and is
-    # immune to settings.json mutation between trust acceptance and tool calls.
-    hooks = _get_hooks_from_snapshot(tool_use_context)
-    event_hooks = hooks.get(event, [])
-
-    if trust_skip:
-        # Drop everything that isn't a policy-source hook. ``HookConfig.source``
-        # is a ``HookSource`` enum; any non-policy value is gated. Imported
-        # locally to avoid pulling the enum into module-init paths that don't
-        # need it. Phase-1 / WI-1.2 renamed ``POLICY`` → ``POLICY_SETTINGS``;
-        # the ``is_policy`` predicate is the canonical way to ask the
-        # question and shields callers from future renames.
-        event_hooks = [h for h in event_hooks if h.source.is_policy]
+    # WI-3.1 — Phase 3 owns "collect": merge snapshot + session-registry
+    # hooks into a single ordered list of entries to fire. Trust gate and
+    # matcher filtering happen inside the helper. Phase 4 will own the
+    # "aggregate" step (deny>ask>allow precedence across results).
+    entries = await _collect_hooks_for_event(event, tool_name, tool_use_context)
 
     tool_use_id = stdin_data.get("tool_use_id", str(uuid4()))
     parent_tool_use_id = ""
 
-    for hook in event_hooks:
-        if tool_name and not _matches_tool(hook.matcher, tool_name):
-            continue
+    for entry in entries:
+        hook = entry.config
 
         yield {
             "message": create_progress_message(
@@ -372,6 +424,22 @@ async def _run_hooks_for_event(
             timeout_ms=timeout_ms,
             tool_use_context=tool_use_context,
         )
+
+        # WI-3.1 — ``once: true`` removal. Fire the entry's on_success
+        # callback after a *successful* firing (exit 0, no blocking_error,
+        # no permission deny). The callback fire-and-forgets removal via
+        # ``asyncio.create_task`` so the executor doesn't await the lock
+        # acquisition.
+        if (
+            entry.on_success is not None
+            and result.exit_code == 0
+            and result.blocking_error is None
+            and result.permission_behavior != "deny"
+        ):
+            try:
+                entry.on_success()
+            except Exception:
+                logger.exception("once: true on_success callback raised")
 
         if result.blocking_error:
             yield {"blocking_error": {"blocking_error": result.blocking_error, "command": result.command}}

--- a/src/hooks/lifecycle_routers.py
+++ b/src/hooks/lifecycle_routers.py
@@ -1,0 +1,148 @@
+"""Lifecycle-event routers (Phase-1 / WI-1.1 wiring).
+
+Pre-Phase-1 these helpers filtered on ``Notification + matcher: "onXxx"``.
+Phase 1 promotes ``SessionStart``, ``SessionEnd``, ``PreCompact`` to first-class
+``HookEvent`` values; this module now routes via those names.
+
+Per assumption A9, this file will be renamed to ``lifecycle_routers.py`` in
+Phase 2 (when a new ``session_hooks.py`` introduces the registration API in
+Phase 3 / WI-3.1). Public function names are preserved across that rename so
+callers don't churn — only the import path moves.
+
+Legacy settings.json with ``Notification + matcher: "onSessionStart"`` is
+translated to first-class events at config load time
+(``config_manager.load_hooks_from_settings``), so by the time these routers
+read from the registry/snapshot, the events have been canonicalized.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, AsyncGenerator
+
+from .hook_types import HookConfig, HookEvent
+from .registry import AsyncHookRegistry, get_global_hook_registry
+
+logger = logging.getLogger(__name__)
+
+# Phase-1 / WI-1.1 — first-class lifecycle event constants. The legacy values
+# (all three pointing at "Notification") have been removed; the back-compat
+# reader at config-load time translates legacy settings.json into these
+# first-class names.
+SESSION_START_EVENT: HookEvent = "SessionStart"
+SESSION_END_EVENT: HookEvent = "SessionEnd"
+COMPACT_EVENT: HookEvent = "PreCompact"
+
+
+async def run_session_start_hooks(
+    registry: AsyncHookRegistry | None = None,
+    *,
+    session_id: str | None = None,
+    cwd: str | None = None,
+) -> list[dict[str, Any]]:
+    reg = registry or get_global_hook_registry()
+    hooks = await reg.get_hooks_for_event(SESSION_START_EVENT)
+
+    results: list[dict[str, Any]] = []
+    for hook in hooks:
+        stdin_data = {
+            "hook_event": SESSION_START_EVENT,
+            "session_id": session_id,
+            "cwd": cwd,
+        }
+
+        from .hook_executor import _execute_command_hook
+        from .exec_http_hook import execute_http_hook
+        from .exec_prompt_hook import execute_prompt_hook
+
+        if hook.config.type == "command":
+            result = await _execute_command_hook(hook.config, stdin_data)
+        elif hook.config.type == "http":
+            result = await execute_http_hook(hook.config, stdin_data)
+        elif hook.config.type == "prompt":
+            result = await execute_prompt_hook(hook.config, stdin_data)
+        else:
+            continue
+
+        results.append({
+            "hook": hook.config,
+            "result": result,
+        })
+
+    return results
+
+
+async def run_session_end_hooks(
+    registry: AsyncHookRegistry | None = None,
+    *,
+    session_id: str | None = None,
+    total_cost: float | None = None,
+    total_turns: int | None = None,
+) -> list[dict[str, Any]]:
+    reg = registry or get_global_hook_registry()
+    hooks = await reg.get_hooks_for_event(SESSION_END_EVENT)
+
+    results: list[dict[str, Any]] = []
+    for hook in hooks:
+        stdin_data = {
+            "hook_event": SESSION_END_EVENT,
+            "session_id": session_id,
+            "total_cost": total_cost,
+            "total_turns": total_turns,
+        }
+
+        from .hook_executor import _execute_command_hook
+        from .exec_http_hook import execute_http_hook
+
+        if hook.config.type == "command":
+            result = await _execute_command_hook(hook.config, stdin_data)
+        elif hook.config.type == "http":
+            result = await execute_http_hook(hook.config, stdin_data)
+        else:
+            continue
+
+        results.append({
+            "hook": hook.config,
+            "result": result,
+        })
+
+    return results
+
+
+async def run_compact_hooks(
+    registry: AsyncHookRegistry | None = None,
+    *,
+    session_id: str | None = None,
+    tokens_before: int | None = None,
+    tokens_after: int | None = None,
+    trigger: str = "manual",
+) -> list[dict[str, Any]]:
+    reg = registry or get_global_hook_registry()
+    hooks = await reg.get_hooks_for_event(COMPACT_EVENT)
+
+    results: list[dict[str, Any]] = []
+    for hook in hooks:
+        stdin_data = {
+            "hook_event": COMPACT_EVENT,
+            "session_id": session_id,
+            "tokens_before": tokens_before,
+            "tokens_after": tokens_after,
+            "trigger": trigger,
+        }
+
+        from .hook_executor import _execute_command_hook
+        from .exec_http_hook import execute_http_hook
+
+        if hook.config.type == "command":
+            result = await _execute_command_hook(hook.config, stdin_data)
+        elif hook.config.type == "http":
+            result = await execute_http_hook(hook.config, stdin_data)
+        else:
+            continue
+
+        results.append({
+            "hook": hook.config,
+            "result": result,
+        })
+
+    return results

--- a/src/hooks/register_frontmatter_hooks.py
+++ b/src/hooks/register_frontmatter_hooks.py
@@ -1,0 +1,152 @@
+"""Register agent/skill frontmatter hooks as session-scoped.
+
+Phase-3 / WI-3.3. Mirrors TS
+``typescript/src/utils/hooks/registerFrontmatterHooks.ts:18-67``.
+
+The general frontmatter-hook registration entry point. Used by anything
+that loads frontmatter ``hooks:`` blocks (skills, agents, etc.). Critically:
+**this is the home of the ``Stop → SubagentStop`` conversion**, gated on
+``is_agent: bool`` per the gap-analysis B1 correction.
+
+The conversion exists because subagents trigger ``SubagentStop`` (not the
+top-level ``Stop`` event) when they finish. A ``Stop`` hook declared in an
+agent's frontmatter would never fire without the rewrite — the gap analysis
+gap #11 and the chapter §"Sub-agents" both call this out.
+
+``register_skill_hooks.py`` does NOT call into this module — skills don't
+get the conversion. The split is intentional: skills run in the parent
+session, so their ``Stop`` hooks should fire on top-level ``Stop``; agent
+frontmatter hooks run in a sub-session, so their ``Stop`` hooks need
+``SubagentStop`` to actually fire.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .hook_types import HookConfig, HookEvent, HookSource
+from .session_hooks import SessionHookRegistry, add_session_hook, remove_session_hook
+
+logger = logging.getLogger(__name__)
+
+
+async def register_frontmatter_hooks(
+    *,
+    registry: SessionHookRegistry,
+    session_id: str,
+    frontmatter_hooks: dict[str, list[dict[str, Any]]] | None,
+    source_name: str,
+    is_agent: bool = False,
+    skill_root: str | None = None,
+) -> int:
+    """Register frontmatter hooks; convert ``Stop → SubagentStop`` if
+    ``is_agent`` is True.
+
+    Returns the count registered.
+
+    ``source_name`` is informational (e.g., ``"agent foo"`` /
+    ``"skill /commit"``); used in debug logs to trace registrations back to
+    their declarer.
+    """
+    if not frontmatter_hooks:
+        return 0
+
+    registered = 0
+    for event_name, matcher_groups in frontmatter_hooks.items():
+        if not isinstance(matcher_groups, list):
+            continue
+
+        # ``Stop → SubagentStop`` conversion (B1: lives here, not in
+        # register_skill_hooks). Mirrors registerFrontmatterHooks.ts:37-45.
+        target_event: HookEvent = event_name  # type: ignore[assignment]
+        if is_agent and event_name == "Stop":
+            target_event = "SubagentStop"
+            logger.debug(
+                "register_frontmatter_hooks: Stop → SubagentStop for %s "
+                "(is_agent=True)",
+                source_name,
+            )
+
+        for matcher_group in matcher_groups:
+            if not isinstance(matcher_group, dict):
+                continue
+            matcher = matcher_group.get("matcher", "") or ""
+            inner_hooks = matcher_group.get("hooks", [])
+            if not isinstance(inner_hooks, list):
+                continue
+            for raw in inner_hooks:
+                if not isinstance(raw, dict):
+                    continue
+                config = HookConfig(
+                    type=raw.get("type", "command"),
+                    command=raw.get("command", ""),
+                    timeout=raw.get("timeout"),
+                    matcher=matcher or raw.get("matcher"),
+                    url=raw.get("url"),
+                    prompt_text=raw.get("promptText") or raw.get("prompt_text"),
+                    agent_instructions=raw.get("agentInstructions") or raw.get("agent_instructions"),
+                    if_condition=raw.get("if_condition") or raw.get("if"),
+                    once=bool(raw.get("once", False)),
+                    skill_root=skill_root,
+                    source=HookSource.SESSION_HOOK,
+                )
+
+                on_success = _make_once_remover(
+                    registry=registry,
+                    session_id=session_id,
+                    event=target_event,
+                    hook_config=config,
+                ) if config.once else None
+
+                await add_session_hook(
+                    registry=registry,
+                    session_id=session_id,
+                    event=target_event,
+                    matcher=matcher,
+                    hook=config,
+                    on_success=on_success,
+                    skill_root=skill_root,
+                )
+                registered += 1
+
+    if registered > 0:
+        logger.debug(
+            "Registered %d frontmatter hook(s) from %s (session=%s, is_agent=%s)",
+            registered, source_name, session_id, is_agent,
+        )
+    return registered
+
+
+def _make_once_remover(
+    *,
+    registry: SessionHookRegistry,
+    session_id: str,
+    event: HookEvent,
+    hook_config: HookConfig,
+):
+    """See register_skill_hooks._make_once_remover — same shape, separate
+    instance so each registrar's logging is distinct.
+    """
+    import asyncio as _asyncio
+
+    def _on_success() -> None:
+        try:
+            loop = _asyncio.get_running_loop()
+        except RuntimeError:
+            logger.warning(
+                "once: true removal skipped — no running loop "
+                "(session=%s, event=%s, command=%r)",
+                session_id, event, hook_config.command,
+            )
+            return
+        loop.create_task(
+            remove_session_hook(
+                registry=registry,
+                session_id=session_id,
+                event=event,
+                hook=hook_config,
+            )
+        )
+
+    return _on_success

--- a/src/hooks/register_skill_hooks.py
+++ b/src/hooks/register_skill_hooks.py
@@ -1,0 +1,166 @@
+"""Register skill-frontmatter hooks as session-scoped.
+
+Phase-3 / WI-3.2. Mirrors TS ``typescript/src/utils/hooks/registerSkillHooks.ts``.
+
+When a skill with frontmatter ``hooks:`` is invoked, each declared hook
+becomes a session-scoped entry that fires for the lifetime of the session.
+Hooks with ``once: true`` are auto-removed after their first successful
+firing.
+
+**Critical: this module does NOT do the ``Stop → SubagentStop`` conversion.**
+That conversion lives in ``register_frontmatter_hooks.py`` (Phase-3 / WI-3.3),
+gated on ``is_agent: bool``. ``registerSkillHooks.ts:20-64`` forwards each
+event verbatim to ``addSessionHook``; the conversion is exclusively a
+``registerFrontmatterHooks`` concern (registerFrontmatterHooks.ts:37-45).
+
+This split was a critic correction during the gap analysis (B1) — earlier
+plan revisions had attributed the conversion to ``registerSkillHooks``,
+which was wrong.
+
+Skill frontmatter shape (from ``skills/loader.py``):
+    hooks:
+      PreToolUse:
+        - matcher: "Bash"
+          hooks:
+            - type: command
+              command: ".claude/scripts/audit.sh"
+              once: true
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .hook_types import HookConfig, HookEvent, HookSource
+from .session_hooks import SessionHookRegistry, add_session_hook, remove_session_hook
+
+logger = logging.getLogger(__name__)
+
+
+async def register_skill_hooks(
+    *,
+    registry: SessionHookRegistry,
+    session_id: str,
+    skill_hooks: dict[str, list[dict[str, Any]]] | None,
+    skill_name: str,
+    skill_root: str | None = None,
+) -> int:
+    """Register a skill's frontmatter hooks as session-scoped entries.
+
+    Returns the number of hooks registered.
+
+    ``skill_hooks`` is the parsed frontmatter ``hooks:`` field, shaped like:
+        { event: [ { matcher, hooks: [HookConfig-shaped dicts] } ] }
+
+    Hooks tagged with ``HookSource.SESSION_HOOK`` so the registry's priority
+    sort places them after policy/user/project/local but before plugin hooks
+    (PLUGIN_HOOK has the 999 sentinel, sorts last). Skill-declared
+    ``skill_root`` propagates to ``HookConfig.skill_root`` so WI-1.5's
+    ``CLAUDE_PLUGIN_ROOT`` injection populates correctly when the hook fires.
+
+    Each ``once: true`` hook is wired with an ``on_success`` callback that
+    schedules removal via ``asyncio.create_task`` — fire-and-forget, so the
+    executor's main loop doesn't await the lock acquisition (per N2 +
+    A10's sync-mutator contract).
+    """
+    if not skill_hooks:
+        return 0
+
+    registered = 0
+    for event_name, matcher_groups in skill_hooks.items():
+        if not isinstance(matcher_groups, list):
+            continue
+        event: HookEvent = event_name  # type: ignore[assignment]
+        for matcher_group in matcher_groups:
+            if not isinstance(matcher_group, dict):
+                continue
+            matcher = matcher_group.get("matcher", "") or ""
+            inner_hooks = matcher_group.get("hooks", [])
+            if not isinstance(inner_hooks, list):
+                continue
+            for raw in inner_hooks:
+                if not isinstance(raw, dict):
+                    continue
+                config = HookConfig(
+                    type=raw.get("type", "command"),
+                    command=raw.get("command", ""),
+                    timeout=raw.get("timeout"),
+                    matcher=matcher or raw.get("matcher"),
+                    url=raw.get("url"),
+                    prompt_text=raw.get("promptText") or raw.get("prompt_text"),
+                    agent_instructions=raw.get("agentInstructions") or raw.get("agent_instructions"),
+                    if_condition=raw.get("if_condition") or raw.get("if"),
+                    once=bool(raw.get("once", False)),
+                    skill_root=skill_root,
+                    source=HookSource.SESSION_HOOK,
+                )
+
+                on_success = _make_once_remover(
+                    registry=registry,
+                    session_id=session_id,
+                    event=event,
+                    hook_config=config,
+                ) if config.once else None
+
+                await add_session_hook(
+                    registry=registry,
+                    session_id=session_id,
+                    event=event,  # NO Stop→SubagentStop conversion (B1).
+                    matcher=matcher,
+                    hook=config,
+                    on_success=on_success,
+                    skill_root=skill_root,
+                )
+                registered += 1
+
+    if registered > 0:
+        logger.debug(
+            "Registered %d session hook(s) from skill %r (session=%s)",
+            registered, skill_name, session_id,
+        )
+    return registered
+
+
+def _make_once_remover(
+    *,
+    registry: SessionHookRegistry,
+    session_id: str,
+    event: HookEvent,
+    hook_config: HookConfig,
+):
+    """Build an on-success callback that fire-and-forgets removal of a
+    ``once: true`` hook after it executes successfully.
+
+    The callback is sync (the executor calls it synchronously after a hook
+    fires) but it schedules an async removal task — preserves A10's
+    sync-mutator-on-the-callsite contract while letting the actual lock
+    acquisition happen on the loop.
+    """
+    import asyncio as _asyncio
+
+    def _on_success() -> None:
+        try:
+            loop = _asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop — caller isn't on asyncio. Removal can't be
+            # scheduled; log and let the next iteration of the loop
+            # handle cleanup. In practice this branch is unreachable
+            # (the executor is always inside ``_run_hooks_for_event``,
+            # which is async).
+            logger.warning(
+                "once: true removal skipped — no running loop "
+                "(session=%s, event=%s, command=%r)",
+                session_id, event, hook_config.command,
+            )
+            return
+        loop.create_task(
+            remove_session_hook(
+                registry=registry,
+                session_id=session_id,
+                event=event,
+                hook=hook_config,
+            )
+        )
+
+    return _on_success

--- a/src/hooks/session_hooks.py
+++ b/src/hooks/session_hooks.py
@@ -1,148 +1,194 @@
-"""Lifecycle-event routers (Phase-1 / WI-1.1 wiring).
+"""Session-scoped hook registration API.
 
-Pre-Phase-1 these helpers filtered on ``Notification + matcher: "onXxx"``.
-Phase 1 promotes ``SessionStart``, ``SessionEnd``, ``PreCompact`` to first-class
-``HookEvent`` values; this module now routes via those names.
+Phase-3 / WI-3.1 (A9 rename: this is the *new* ``session_hooks.py``; the
+pre-Phase-3 file with the same name has been moved to
+``lifecycle_routers.py``).
 
-Per assumption A9, this file will be renamed to ``lifecycle_routers.py`` in
-Phase 2 (when a new ``session_hooks.py`` introduces the registration API in
-Phase 3 / WI-3.1). Public function names are preserved across that rename so
-callers don't churn — only the import path moves.
+Mirrors TS ``typescript/src/utils/hooks/sessionHooks.ts``. Session-scoped
+hooks live in memory only — they're registered programmatically (e.g., by
+``register_skill_hooks`` when a skill with frontmatter ``hooks:`` is
+invoked) and disappear when the session ends. The chapter's
+``HookSource.SESSION_HOOK`` source.
 
-Legacy settings.json with ``Notification + matcher: "onSessionStart"`` is
-translated to first-class events at config load time
-(``config_manager.load_hooks_from_settings``), so by the time these routers
-read from the registry/snapshot, the events have been canonicalized.
+**Concurrency contract (assumption A10).**
+The registry mutator is *synchronous* — never ``await`` inside it. The lock
+itself is ``asyncio.Lock`` (per critic N2) because all callers run on the
+asyncio loop; ``threading.RLock`` would block the event loop on contention.
+Mutators that violate the sync contract get an ``asyncio`` deadlock between
+the lock-holder and the bash-worker bridge in ``registry.py:_invoke_tool_call``.
+
+**``once: true`` removal.**
+A hook with ``once=True`` is removed after its first successful firing
+(exit code 0, no blocking_error, no permission deny). The executor schedules
+the removal via ``asyncio.create_task(remove_session_hook(...))`` — fire-and-
+forget, so the executor's main loop doesn't await the lock acquisition.
+Removal under concurrent firing is race-free because the registry's lock
+guards the lookup-and-remove sequence.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Any, AsyncGenerator
+from dataclasses import dataclass, field
+from typing import Callable
 
 from .hook_types import HookConfig, HookEvent
-from .registry import AsyncHookRegistry, get_global_hook_registry
 
 logger = logging.getLogger(__name__)
 
-# Phase-1 / WI-1.1 — first-class lifecycle event constants. The legacy values
-# (all three pointing at "Notification") have been removed; the back-compat
-# reader at config-load time translates legacy settings.json into these
-# first-class names.
-SESSION_START_EVENT: HookEvent = "SessionStart"
-SESSION_END_EVENT: HookEvent = "SessionEnd"
-COMPACT_EVENT: HookEvent = "PreCompact"
+
+@dataclass
+class SessionHookEntry:
+    """A single session-scoped hook.
+
+    The matcher is duplicated from ``config.matcher`` for fast
+    lookup; the on-success callback is opaque to the registry (only the
+    executor invokes it after a hook fires successfully).
+
+    ``source_session_id`` is informational — useful for logs/diagnostics
+    when a leaked hook needs to be traced back to the session that
+    registered it.
+    """
+    config: HookConfig
+    event: HookEvent
+    matcher: str = ""
+    on_success: Callable[[], None] | None = None
+    source_session_id: str = ""
 
 
-async def run_session_start_hooks(
-    registry: AsyncHookRegistry | None = None,
+class SessionHookRegistry:
+    """In-memory registry of session-scoped hooks, keyed by session_id.
+
+    Per A10's contract: the lock is ``asyncio.Lock`` (not ``threading.RLock``)
+    because every caller is on the asyncio loop. Mutator bodies must be
+    synchronous — the registry's ``add``/``remove``/``clear`` await *only*
+    on the lock acquisition itself; the body is plain dict mutation.
+    """
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._hooks: dict[str, list[SessionHookEntry]] = {}
+
+    async def add(self, session_id: str, entry: SessionHookEntry) -> None:
+        async with self._lock:
+            self._hooks.setdefault(session_id, []).append(entry)
+
+    async def remove(
+        self,
+        session_id: str,
+        event: HookEvent,
+        hook_config: HookConfig,
+    ) -> bool:
+        """Remove the *first* entry matching ``(session_id, event, config)``.
+
+        Returns True if an entry was removed. Identity is by (event, command,
+        matcher) tuple — sufficient for ``once: true`` since each registered
+        hook has a distinct combination in practice (the same skill can't
+        register two byte-identical hooks for the same event).
+
+        Race-free under concurrent firing: the lock guards the find-and-
+        remove sequence, so two firings of the same ``once: true`` hook
+        either find it (one wins) or don't (the other lost the race).
+        """
+        async with self._lock:
+            entries = self._hooks.get(session_id, [])
+            for i, entry in enumerate(entries):
+                if (
+                    entry.event == event
+                    and entry.config.command == hook_config.command
+                    and entry.config.matcher == hook_config.matcher
+                    and entry.config.type == hook_config.type
+                ):
+                    del entries[i]
+                    return True
+            return False
+
+    async def get_for_event(
+        self,
+        session_id: str,
+        event: HookEvent,
+    ) -> list[SessionHookEntry]:
+        """Return a snapshot of entries for ``(session_id, event)``.
+
+        Returns a fresh list — callers may iterate safely while other tasks
+        mutate the registry.
+        """
+        async with self._lock:
+            return [
+                entry for entry in self._hooks.get(session_id, [])
+                if entry.event == event
+            ]
+
+    async def clear(self, session_id: str) -> int:
+        """Remove all hooks for ``session_id``. Returns count removed."""
+        async with self._lock:
+            entries = self._hooks.pop(session_id, [])
+            return len(entries)
+
+    async def count(self, session_id: str) -> int:
+        async with self._lock:
+            return len(self._hooks.get(session_id, []))
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers — mirror TS ``sessionHooks.ts`` exports.
+# ---------------------------------------------------------------------------
+
+
+async def add_session_hook(
     *,
-    session_id: str | None = None,
-    cwd: str | None = None,
-) -> list[dict[str, Any]]:
-    reg = registry or get_global_hook_registry()
-    hooks = await reg.get_hooks_for_event(SESSION_START_EVENT)
+    registry: SessionHookRegistry,
+    session_id: str,
+    event: HookEvent,
+    matcher: str,
+    hook: HookConfig,
+    on_success: Callable[[], None] | None = None,
+    skill_root: str | None = None,
+) -> None:
+    """Register a session-scoped hook.
 
-    results: list[dict[str, Any]] = []
-    for hook in hooks:
-        stdin_data = {
-            "hook_event": SESSION_START_EVENT,
-            "session_id": session_id,
-            "cwd": cwd,
-        }
-
-        from .hook_executor import _execute_command_hook
-        from .exec_http_hook import execute_http_hook
-        from .exec_prompt_hook import execute_prompt_hook
-
-        if hook.config.type == "command":
-            result = await _execute_command_hook(hook.config, stdin_data)
-        elif hook.config.type == "http":
-            result = await execute_http_hook(hook.config, stdin_data)
-        elif hook.config.type == "prompt":
-            result = await execute_prompt_hook(hook.config, stdin_data)
-        else:
-            continue
-
-        results.append({
-            "hook": hook.config,
-            "result": result,
-        })
-
-    return results
+    ``skill_root`` is optional metadata: when set, the hook's
+    ``CLAUDE_PLUGIN_ROOT`` env var (WI-1.5) is populated to this path. We
+    write through to ``HookConfig.skill_root`` rather than carry a separate
+    field on ``SessionHookEntry`` so the executor's existing
+    ``_build_hook_env`` (which reads ``hook.skill_root``) needs no special
+    case for session-scoped hooks.
+    """
+    if skill_root is not None and not hook.skill_root:
+        hook.skill_root = skill_root
+    entry = SessionHookEntry(
+        config=hook,
+        event=event,
+        matcher=matcher,
+        on_success=on_success,
+        source_session_id=session_id,
+    )
+    await registry.add(session_id, entry)
 
 
-async def run_session_end_hooks(
-    registry: AsyncHookRegistry | None = None,
+async def remove_session_hook(
     *,
-    session_id: str | None = None,
-    total_cost: float | None = None,
-    total_turns: int | None = None,
-) -> list[dict[str, Any]]:
-    reg = registry or get_global_hook_registry()
-    hooks = await reg.get_hooks_for_event(SESSION_END_EVENT)
-
-    results: list[dict[str, Any]] = []
-    for hook in hooks:
-        stdin_data = {
-            "hook_event": SESSION_END_EVENT,
-            "session_id": session_id,
-            "total_cost": total_cost,
-            "total_turns": total_turns,
-        }
-
-        from .hook_executor import _execute_command_hook
-        from .exec_http_hook import execute_http_hook
-
-        if hook.config.type == "command":
-            result = await _execute_command_hook(hook.config, stdin_data)
-        elif hook.config.type == "http":
-            result = await execute_http_hook(hook.config, stdin_data)
-        else:
-            continue
-
-        results.append({
-            "hook": hook.config,
-            "result": result,
-        })
-
-    return results
+    registry: SessionHookRegistry,
+    session_id: str,
+    event: HookEvent,
+    hook: HookConfig,
+) -> bool:
+    return await registry.remove(session_id, event, hook)
 
 
-async def run_compact_hooks(
-    registry: AsyncHookRegistry | None = None,
+async def get_session_hooks(
     *,
-    session_id: str | None = None,
-    tokens_before: int | None = None,
-    tokens_after: int | None = None,
-    trigger: str = "manual",
-) -> list[dict[str, Any]]:
-    reg = registry or get_global_hook_registry()
-    hooks = await reg.get_hooks_for_event(COMPACT_EVENT)
+    registry: SessionHookRegistry,
+    session_id: str,
+    event: HookEvent,
+) -> list[SessionHookEntry]:
+    return await registry.get_for_event(session_id, event)
 
-    results: list[dict[str, Any]] = []
-    for hook in hooks:
-        stdin_data = {
-            "hook_event": COMPACT_EVENT,
-            "session_id": session_id,
-            "tokens_before": tokens_before,
-            "tokens_after": tokens_after,
-            "trigger": trigger,
-        }
 
-        from .hook_executor import _execute_command_hook
-        from .exec_http_hook import execute_http_hook
-
-        if hook.config.type == "command":
-            result = await _execute_command_hook(hook.config, stdin_data)
-        elif hook.config.type == "http":
-            result = await execute_http_hook(hook.config, stdin_data)
-        else:
-            continue
-
-        results.append({
-            "hook": hook.config,
-            "result": result,
-        })
-
-    return results
+async def clear_session_hooks(
+    *,
+    registry: SessionHookRegistry,
+    session_id: str,
+) -> int:
+    return await registry.clear(session_id)

--- a/src/tool_system/context.py
+++ b/src/tool_system/context.py
@@ -159,6 +159,12 @@ class ToolContext:
     # than ``HookSource.POLICY_SETTINGS``) are skipped while the workspace is
     # untrusted, mirroring TS' ``shouldSkipHookDueToTrust`` gate.
     workspace_trusted: bool = False
+    # Chapter-12 / Phase 3 / WI-3.1 — session-scoped hook registry.
+    # Programmatically-registered hooks (e.g., from skill frontmatter via
+    # ``register_skill_hooks``) live here; the executor merges them with the
+    # snapshot's config-driven hooks at fire time. ``Any`` typing avoids a
+    # circular import with ``src.hooks.session_hooks``.
+    session_hook_registry: Any | None = None
 
     def __post_init__(self) -> None:
         self.workspace_root = Path(self.workspace_root).resolve()

--- a/src/tool_system/tools/skill.py
+++ b/src/tool_system/tools/skill.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import importlib
 import json
+import logging
 import os
 import sys
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 from ..build_tool import Tool, ValidationResult, build_tool
 from ..context import ToolContext
@@ -213,6 +216,32 @@ def _run_markdown_skill(skill_name: str, args: str, context: ToolContext) -> Too
             shell_executor=executor,
         )
 
+    # Phase-3 / WI-3.2 — register the skill's frontmatter hooks as
+    # session-scoped. Skipped when no registry is mounted on the context
+    # (test fixtures and some integration paths don't wire one); skipped
+    # when the skill declares no hooks. Per B1: skill hooks do NOT get the
+    # ``Stop → SubagentStop`` conversion (that's exclusive to
+    # ``register_frontmatter_hooks(is_agent=True)``); ``register_skill_hooks``
+    # forwards events verbatim.
+    #
+    # ``_run_markdown_skill`` stays sync (existing call-site contract;
+    # 30+ tests bypass the dispatcher and call ``SkillTool.call`` directly).
+    # I3's original concern was ``asyncio.run`` blocking inside a running
+    # loop; we sidestep it via fire-and-forget: ``loop.create_task`` schedules
+    # the async registration on the current loop without blocking, and the
+    # task completes before the model's next tool call (microseconds vs.
+    # seconds). When invoked outside a running loop (rare; mostly tests),
+    # we fall back to ``asyncio.run`` since there's no nesting risk.
+    skill_hooks = getattr(skill, "hooks", None)
+    if skill_hooks and context.session_hook_registry is not None and context.session_id:
+        _schedule_skill_hook_registration(
+            registry=context.session_hook_registry,
+            session_id=context.session_id,
+            skill_hooks=skill_hooks,
+            skill_name=skill_name,
+            skill_root=skill.skill_root,
+        )
+
     # Build context modifier if skill specifies allowed_tools, model, or effort
     context_modifier = _build_context_modifier(skill)
 
@@ -229,6 +258,57 @@ def _run_markdown_skill(skill_name: str, args: str, context: ToolContext) -> Too
         },
         context_modifier=context_modifier,
     )
+
+
+def _schedule_skill_hook_registration(
+    *,
+    registry: Any,
+    session_id: str,
+    skill_hooks: Any,
+    skill_name: str,
+    skill_root: str | None,
+) -> None:
+    """Schedule async ``register_skill_hooks`` from a sync caller.
+
+    Two paths:
+      * If a running asyncio loop is available, schedule the registration
+        coroutine via ``loop.create_task`` (fire-and-forget). The task
+        completes asynchronously; the calling tool returns immediately.
+      * If no loop is running (rare; mostly test fixtures that invoke
+        ``SkillTool.call`` from sync test code), fall back to ``asyncio.run``
+        — safe because there's no nesting.
+
+    Failures are logged at ERROR; we never raise (hook registration must
+    not break skill invocation).
+    """
+    import asyncio
+    from src.hooks.register_skill_hooks import register_skill_hooks
+
+    async def _do_register() -> None:
+        try:
+            count = await register_skill_hooks(
+                registry=registry,
+                session_id=session_id,
+                skill_hooks=skill_hooks,
+                skill_name=skill_name,
+                skill_root=skill_root,
+            )
+            if count:
+                logger.debug(
+                    "Skill %r registered %d session hooks", skill_name, count,
+                )
+        except Exception:
+            logger.exception("register_skill_hooks failed for skill %r", skill_name)
+
+    try:
+        loop = asyncio.get_running_loop()
+        loop.create_task(_do_register())
+    except RuntimeError:
+        # No running loop — sync caller (e.g., test). Run directly.
+        try:
+            asyncio.run(_do_register())
+        except Exception:
+            logger.exception("register_skill_hooks failed for skill %r", skill_name)
 
 
 def _make_shell_executor(

--- a/tests/integration/test_phase_c_build.py
+++ b/tests/integration/test_phase_c_build.py
@@ -25,7 +25,10 @@ class TestPhaseCImports:
         assert hasattr(mod, "execute_prompt_hook")
 
     def test_hooks_session(self):
-        mod = importlib.import_module("src.hooks.session_hooks")
+        # A9 rename: lifecycle helpers (``run_session_start_hooks`` etc.)
+        # moved to ``lifecycle_routers``; ``session_hooks`` is now the
+        # session-scoped registration API (Phase 3 / WI-3.1).
+        mod = importlib.import_module("src.hooks.lifecycle_routers")
         assert hasattr(mod, "run_session_start_hooks")
 
     def test_hooks_post_sampling(self):

--- a/tests/test_hook_executors.py
+++ b/tests/test_hook_executors.py
@@ -8,7 +8,7 @@ from src.hooks.exec_agent_hook import execute_agent_hook
 from src.hooks.exec_http_hook import execute_http_hook
 from src.hooks.exec_prompt_hook import execute_prompt_hook
 from src.hooks.post_sampling_hooks import run_post_sampling_hooks
-from src.hooks.session_hooks import (
+from src.hooks.lifecycle_routers import (
     run_session_start_hooks,
     run_session_end_hooks,
     run_compact_hooks,

--- a/tests/test_legacy_notification_backcompat.py
+++ b/tests/test_legacy_notification_backcompat.py
@@ -141,16 +141,16 @@ class TestLifecycleRoutersReadFirstClass:
 
     @pytest.mark.asyncio
     async def test_session_start_router_reads_first_class_event(self):
-        from src.hooks.session_hooks import SESSION_START_EVENT
+        from src.hooks.lifecycle_routers import SESSION_START_EVENT
         # The constant is now ``SessionStart`` (first-class), not ``Notification``.
         assert SESSION_START_EVENT == "SessionStart"
 
     @pytest.mark.asyncio
     async def test_session_end_router_reads_first_class_event(self):
-        from src.hooks.session_hooks import SESSION_END_EVENT
+        from src.hooks.lifecycle_routers import SESSION_END_EVENT
         assert SESSION_END_EVENT == "SessionEnd"
 
     @pytest.mark.asyncio
     async def test_compact_router_reads_pre_compact(self):
-        from src.hooks.session_hooks import COMPACT_EVENT
+        from src.hooks.lifecycle_routers import COMPACT_EVENT
         assert COMPACT_EVENT == "PreCompact"

--- a/tests/test_register_frontmatter_hooks.py
+++ b/tests/test_register_frontmatter_hooks.py
@@ -1,0 +1,136 @@
+"""Phase-3 / WI-3.3 — register_frontmatter_hooks tests.
+
+The general frontmatter-hook entry point. Critically: **this is the home of
+the ``Stop → SubagentStop`` conversion** (gap-analysis B1 correction).
+``register_skill_hooks`` does NOT do the conversion.
+
+Tests cover both modes:
+  * ``is_agent=False`` (default; for skills) — Stop stays Stop.
+  * ``is_agent=True`` (for sub-agent frontmatter) — Stop becomes SubagentStop.
+
+Plus the basics already covered for ``register_skill_hooks``: registration
+count, source tag, ``once: true`` wiring.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.hooks.hook_types import HookSource
+from src.hooks.register_frontmatter_hooks import register_frontmatter_hooks
+from src.hooks.session_hooks import SessionHookRegistry, get_session_hooks
+
+
+AGENT_FRONTMATTER = {
+    "Stop": [
+        {"matcher": "", "hooks": [{"type": "command", "command": "echo cleanup"}]},
+    ],
+    "PreToolUse": [
+        {"matcher": "Bash", "hooks": [
+            {"type": "command", "command": "echo pre"},
+        ]},
+    ],
+}
+
+
+class TestStopToSubagentStopConversion:
+    @pytest.mark.asyncio
+    async def test_is_agent_true_converts_stop_to_subagentstop(self):
+        # B1: this is the conversion's only home.
+        reg = SessionHookRegistry()
+        await register_frontmatter_hooks(
+            registry=reg, session_id="s1",
+            frontmatter_hooks=AGENT_FRONTMATTER,
+            source_name="agent foo", is_agent=True,
+        )
+        # Stop hook is now under SubagentStop, NOT under Stop.
+        stop_hooks = await get_session_hooks(
+            registry=reg, session_id="s1", event="Stop",
+        )
+        assert stop_hooks == []
+        sub_hooks = await get_session_hooks(
+            registry=reg, session_id="s1", event="SubagentStop",
+        )
+        assert len(sub_hooks) == 1
+        assert sub_hooks[0].config.command == "echo cleanup"
+
+    @pytest.mark.asyncio
+    async def test_is_agent_false_keeps_stop(self):
+        reg = SessionHookRegistry()
+        await register_frontmatter_hooks(
+            registry=reg, session_id="s1",
+            frontmatter_hooks=AGENT_FRONTMATTER,
+            source_name="non-agent caller", is_agent=False,
+        )
+        stop_hooks = await get_session_hooks(
+            registry=reg, session_id="s1", event="Stop",
+        )
+        assert len(stop_hooks) == 1
+        sub_hooks = await get_session_hooks(
+            registry=reg, session_id="s1", event="SubagentStop",
+        )
+        assert sub_hooks == []
+
+    @pytest.mark.asyncio
+    async def test_subagentstop_unchanged_regardless_of_is_agent(self):
+        # If the frontmatter explicitly declares SubagentStop, both modes
+        # leave it under SubagentStop. The conversion only touches Stop.
+        fm = {
+            "SubagentStop": [{"matcher": "", "hooks": [
+                {"type": "command", "command": "echo s"}
+            ]}],
+        }
+        for is_agent in (True, False):
+            reg = SessionHookRegistry()
+            await register_frontmatter_hooks(
+                registry=reg, session_id="s1",
+                frontmatter_hooks=fm,
+                source_name="src", is_agent=is_agent,
+            )
+            sub_hooks = await get_session_hooks(
+                registry=reg, session_id="s1", event="SubagentStop",
+            )
+            assert len(sub_hooks) == 1
+            stop_hooks = await get_session_hooks(
+                registry=reg, session_id="s1", event="Stop",
+            )
+            assert stop_hooks == []
+
+    @pytest.mark.asyncio
+    async def test_non_stop_events_unchanged_under_is_agent(self):
+        # PreToolUse stays PreToolUse even with is_agent=True.
+        reg = SessionHookRegistry()
+        await register_frontmatter_hooks(
+            registry=reg, session_id="s1",
+            frontmatter_hooks=AGENT_FRONTMATTER,
+            source_name="agent foo", is_agent=True,
+        )
+        pre = await get_session_hooks(
+            registry=reg, session_id="s1", event="PreToolUse",
+        )
+        assert len(pre) == 1
+        assert pre[0].config.command == "echo pre"
+
+
+class TestBasicRegistration:
+    @pytest.mark.asyncio
+    async def test_returns_zero_for_empty(self):
+        reg = SessionHookRegistry()
+        n = await register_frontmatter_hooks(
+            registry=reg, session_id="s1",
+            frontmatter_hooks=None, source_name="x",
+        )
+        assert n == 0
+
+    @pytest.mark.asyncio
+    async def test_session_hook_source_tag(self):
+        reg = SessionHookRegistry()
+        await register_frontmatter_hooks(
+            registry=reg, session_id="s1",
+            frontmatter_hooks=AGENT_FRONTMATTER,
+            source_name="x", is_agent=True,
+        )
+        sub = await get_session_hooks(
+            registry=reg, session_id="s1", event="SubagentStop",
+        )
+        assert sub[0].config.source == HookSource.SESSION_HOOK

--- a/tests/test_register_skill_hooks.py
+++ b/tests/test_register_skill_hooks.py
@@ -1,0 +1,136 @@
+"""Phase-3 / WI-3.2 — register_skill_hooks tests.
+
+Verifies:
+  * Frontmatter ``hooks`` blocks register as session-scoped entries.
+  * Hooks tagged with ``HookSource.SESSION_HOOK``.
+  * ``skill_root`` propagates through to ``HookConfig.skill_root``.
+  * **Skill hooks do NOT get the ``Stop → SubagentStop`` conversion** (B1
+    correction — that's exclusive to ``register_frontmatter_hooks``).
+  * ``once: true`` registers an ``on_success`` callback.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.hooks.hook_types import HookSource
+from src.hooks.register_skill_hooks import register_skill_hooks
+from src.hooks.session_hooks import SessionHookRegistry, get_session_hooks
+
+
+SKILL_FRONTMATTER_HOOKS = {
+    "PreToolUse": [
+        {
+            "matcher": "Bash",
+            "hooks": [
+                {"type": "command", "command": "echo audit", "once": True},
+                {"type": "command", "command": "echo log"},
+            ],
+        }
+    ],
+    # Skill declares a Stop hook — registration must NOT rewrite this to
+    # SubagentStop (skills run in the parent session, not a sub-agent).
+    "Stop": [
+        {
+            "matcher": "",
+            "hooks": [{"type": "command", "command": "echo cleanup"}],
+        }
+    ],
+}
+
+
+class TestRegisterSkillHooks:
+    @pytest.mark.asyncio
+    async def test_returns_zero_for_empty_hooks(self):
+        reg = SessionHookRegistry()
+        n = await register_skill_hooks(
+            registry=reg, session_id="s1",
+            skill_hooks=None, skill_name="empty",
+        )
+        assert n == 0
+
+    @pytest.mark.asyncio
+    async def test_registers_each_hook(self):
+        reg = SessionHookRegistry()
+        n = await register_skill_hooks(
+            registry=reg, session_id="s1",
+            skill_hooks=SKILL_FRONTMATTER_HOOKS, skill_name="audit-skill",
+        )
+        # 2 PreToolUse hooks + 1 Stop hook = 3 registrations.
+        assert n == 3
+
+    @pytest.mark.asyncio
+    async def test_pretooluse_hooks_routed_correctly(self):
+        reg = SessionHookRegistry()
+        await register_skill_hooks(
+            registry=reg, session_id="s1",
+            skill_hooks=SKILL_FRONTMATTER_HOOKS, skill_name="x",
+        )
+        pre = await get_session_hooks(
+            registry=reg, session_id="s1", event="PreToolUse",
+        )
+        assert len(pre) == 2
+        commands = {e.config.command for e in pre}
+        assert commands == {"echo audit", "echo log"}
+
+    @pytest.mark.asyncio
+    async def test_stop_hook_NOT_converted_to_subagentstop(self):
+        # B1: skill hooks forward verbatim — the Stop event stays Stop.
+        reg = SessionHookRegistry()
+        await register_skill_hooks(
+            registry=reg, session_id="s1",
+            skill_hooks=SKILL_FRONTMATTER_HOOKS, skill_name="x",
+        )
+        stop_hooks = await get_session_hooks(
+            registry=reg, session_id="s1", event="Stop",
+        )
+        assert len(stop_hooks) == 1
+        assert stop_hooks[0].config.command == "echo cleanup"
+        # Definitively NOT under SubagentStop.
+        sub = await get_session_hooks(
+            registry=reg, session_id="s1", event="SubagentStop",
+        )
+        assert sub == []
+
+    @pytest.mark.asyncio
+    async def test_session_hook_source_tag(self):
+        reg = SessionHookRegistry()
+        await register_skill_hooks(
+            registry=reg, session_id="s1",
+            skill_hooks=SKILL_FRONTMATTER_HOOKS, skill_name="x",
+        )
+        pre = await get_session_hooks(
+            registry=reg, session_id="s1", event="PreToolUse",
+        )
+        for entry in pre:
+            assert entry.config.source == HookSource.SESSION_HOOK
+
+    @pytest.mark.asyncio
+    async def test_skill_root_propagated(self):
+        reg = SessionHookRegistry()
+        await register_skill_hooks(
+            registry=reg, session_id="s1",
+            skill_hooks=SKILL_FRONTMATTER_HOOKS, skill_name="x",
+            skill_root="/skills/audit",
+        )
+        pre = await get_session_hooks(
+            registry=reg, session_id="s1", event="PreToolUse",
+        )
+        for entry in pre:
+            assert entry.config.skill_root == "/skills/audit"
+
+    @pytest.mark.asyncio
+    async def test_once_true_wires_on_success(self):
+        reg = SessionHookRegistry()
+        await register_skill_hooks(
+            registry=reg, session_id="s1",
+            skill_hooks=SKILL_FRONTMATTER_HOOKS, skill_name="x",
+        )
+        pre = await get_session_hooks(
+            registry=reg, session_id="s1", event="PreToolUse",
+        )
+        # The audit hook (once=True) has on_success; the log hook does not.
+        audit = next(e for e in pre if e.config.command == "echo audit")
+        log = next(e for e in pre if e.config.command == "echo log")
+        assert audit.on_success is not None
+        assert log.on_success is None

--- a/tests/test_session_hook_registry.py
+++ b/tests/test_session_hook_registry.py
@@ -1,0 +1,170 @@
+"""Phase-3 / WI-3.1 — SessionHookRegistry tests.
+
+Covers the in-memory registration API: add/remove/get/clear, concurrent
+safety under ``asyncio.Lock`` (per N2), and the session-scoped indexing
+that lets multiple sessions coexist without cross-pollution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.hooks.hook_types import HookConfig, HookSource
+from src.hooks.session_hooks import (
+    SessionHookEntry,
+    SessionHookRegistry,
+    add_session_hook,
+    clear_session_hooks,
+    get_session_hooks,
+    remove_session_hook,
+)
+
+
+def _hook(cmd: str, *, matcher: str | None = None, once: bool = False) -> HookConfig:
+    return HookConfig(
+        type="command", command=cmd, matcher=matcher, once=once,
+        source=HookSource.SESSION_HOOK,
+    )
+
+
+class TestAddRemove:
+    @pytest.mark.asyncio
+    async def test_add_then_get(self):
+        reg = SessionHookRegistry()
+        await add_session_hook(
+            registry=reg, session_id="s1", event="PreToolUse",
+            matcher="Bash", hook=_hook("echo a"),
+        )
+        entries = await get_session_hooks(
+            registry=reg, session_id="s1", event="PreToolUse",
+        )
+        assert len(entries) == 1
+        assert entries[0].config.command == "echo a"
+
+    @pytest.mark.asyncio
+    async def test_remove_returns_true(self):
+        reg = SessionHookRegistry()
+        h = _hook("echo a", matcher="Bash")
+        await add_session_hook(
+            registry=reg, session_id="s1", event="PreToolUse",
+            matcher="Bash", hook=h,
+        )
+        removed = await remove_session_hook(
+            registry=reg, session_id="s1", event="PreToolUse", hook=h,
+        )
+        assert removed is True
+        entries = await get_session_hooks(
+            registry=reg, session_id="s1", event="PreToolUse",
+        )
+        assert entries == []
+
+    @pytest.mark.asyncio
+    async def test_remove_nonexistent_returns_false(self):
+        reg = SessionHookRegistry()
+        h = _hook("echo nope")
+        removed = await remove_session_hook(
+            registry=reg, session_id="s1", event="PreToolUse", hook=h,
+        )
+        assert removed is False
+
+    @pytest.mark.asyncio
+    async def test_get_returns_empty_for_unknown_session(self):
+        reg = SessionHookRegistry()
+        entries = await get_session_hooks(
+            registry=reg, session_id="never-added", event="PreToolUse",
+        )
+        assert entries == []
+
+    @pytest.mark.asyncio
+    async def test_session_isolation(self):
+        # Hooks registered under session A don't leak into session B.
+        reg = SessionHookRegistry()
+        await add_session_hook(
+            registry=reg, session_id="A", event="PreToolUse",
+            matcher="Bash", hook=_hook("a"),
+        )
+        await add_session_hook(
+            registry=reg, session_id="B", event="PreToolUse",
+            matcher="Bash", hook=_hook("b"),
+        )
+        a_hooks = await get_session_hooks(
+            registry=reg, session_id="A", event="PreToolUse",
+        )
+        b_hooks = await get_session_hooks(
+            registry=reg, session_id="B", event="PreToolUse",
+        )
+        assert len(a_hooks) == 1
+        assert len(b_hooks) == 1
+        assert a_hooks[0].config.command == "a"
+        assert b_hooks[0].config.command == "b"
+
+    @pytest.mark.asyncio
+    async def test_clear_removes_all_for_session(self):
+        reg = SessionHookRegistry()
+        for cmd in ("a", "b", "c"):
+            await add_session_hook(
+                registry=reg, session_id="s1", event="PreToolUse",
+                matcher="Bash", hook=_hook(cmd),
+            )
+        cleared = await clear_session_hooks(registry=reg, session_id="s1")
+        assert cleared == 3
+        entries = await get_session_hooks(
+            registry=reg, session_id="s1", event="PreToolUse",
+        )
+        assert entries == []
+
+    @pytest.mark.asyncio
+    async def test_skill_root_propagates_to_hookconfig(self):
+        # The chapter wires CLAUDE_PLUGIN_ROOT (WI-1.5) from
+        # ``hook.skill_root`` — registration must propagate the path.
+        reg = SessionHookRegistry()
+        await add_session_hook(
+            registry=reg, session_id="s1", event="PreToolUse",
+            matcher="Bash", hook=_hook("x"),
+            skill_root="/path/to/skill",
+        )
+        entries = await get_session_hooks(
+            registry=reg, session_id="s1", event="PreToolUse",
+        )
+        assert entries[0].config.skill_root == "/path/to/skill"
+
+
+class TestConcurrentSafety:
+    @pytest.mark.asyncio
+    async def test_concurrent_adds_all_round_trip(self):
+        # 50 concurrent adds across 5 coroutines → all 50 land. asyncio.Lock
+        # serializes the inner mutation; outer concurrency is the test.
+        reg = SessionHookRegistry()
+
+        async def adder(start: int) -> None:
+            for i in range(10):
+                await add_session_hook(
+                    registry=reg, session_id="s1", event="PreToolUse",
+                    matcher="Bash", hook=_hook(f"cmd-{start}-{i}"),
+                )
+
+        await asyncio.gather(*(adder(s * 10) for s in range(5)))
+        entries = await get_session_hooks(
+            registry=reg, session_id="s1", event="PreToolUse",
+        )
+        assert len(entries) == 50
+
+    @pytest.mark.asyncio
+    async def test_concurrent_remove_idempotent(self):
+        # Two coroutines try to remove the same hook concurrently. Lock
+        # ensures exactly one wins.
+        reg = SessionHookRegistry()
+        h = _hook("once-cmd", matcher="Bash")
+        await add_session_hook(
+            registry=reg, session_id="s1", event="PreToolUse",
+            matcher="Bash", hook=h,
+        )
+        results = await asyncio.gather(
+            remove_session_hook(registry=reg, session_id="s1", event="PreToolUse", hook=h),
+            remove_session_hook(registry=reg, session_id="s1", event="PreToolUse", hook=h),
+        )
+        # Exactly one remove succeeded.
+        assert results.count(True) == 1
+        assert results.count(False) == 1

--- a/tests/test_skill_hook_registration_production_path.py
+++ b/tests/test_skill_hook_registration_production_path.py
@@ -1,0 +1,218 @@
+"""Phase-3 D1 cleanup — production-path test for skill hook scheduling.
+
+Critic D1 flagged that ``test_skill_once_true_e2e`` calls
+``register_skill_hooks`` directly via ``await``, bypassing the sync→async
+bridge in ``_schedule_skill_hook_registration`` that the production
+``_run_markdown_skill`` actually uses. This test drives the production path
+end-to-end via the real ``SkillTool.call`` entry, proving:
+
+  * The sync caller (``SkillTool.call``) returns immediately.
+  * The fire-and-forget registration completes via ``loop.create_task``
+    before the next ``await`` boundary.
+  * The newly-registered hook is visible to ``_run_hooks_for_event`` on
+    the very next executor invocation — i.e., "registration completes
+    before next executor invocation" (the critical timing property D1
+    asks us to pin).
+
+This option-A test is preferred over a unit test of
+``_schedule_skill_hook_registration`` itself because it covers the actual
+production wiring (including the fire-and-forget timing assumption) rather
+than the helper in isolation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.hooks.config_manager import HookConfigManager, HookConfigSnapshot
+from src.hooks.hook_executor import _run_hooks_for_event
+from src.hooks.registry import AsyncHookRegistry
+from src.hooks.session_hooks import SessionHookRegistry, get_session_hooks
+from src.tool_system.tools.skill import SkillTool
+
+
+@dataclass
+class _MockOptions:
+    hooks: dict[str, Any] | None = None
+    tools: list[Any] = field(default_factory=list)
+
+
+@dataclass
+class _MockContext:
+    options: _MockOptions = field(default_factory=_MockOptions)
+    hook_config_manager: Any | None = None
+    workspace_trusted: bool = True
+    abort_controller: Any | None = None
+    session_hook_registry: Any | None = None
+    session_id: str | None = None
+    workspace_root: Path | None = None
+
+
+def _empty_config_manager() -> HookConfigManager:
+    m = HookConfigManager(registry=AsyncHookRegistry(), settings_path="/dev/null")
+    m._snapshot = HookConfigSnapshot(hooks={}, timestamp=0.0, source_path=None)
+    return m
+
+
+def _write_skill_with_hooks(skills_dir: Path, *, name: str, hook_command: str) -> Path:
+    """Write a SKILL.md file with frontmatter ``hooks:`` declaring a single
+    once=true PreToolUse Bash hook.
+
+    Mirrors the chapter's worked example #2 layout. We hand-roll the
+    frontmatter (rather than calling ``create_skill``) because
+    ``create_skill`` doesn't accept a ``hooks:`` argument — that's chapter-
+    12 territory not yet wired into the skill-creation helper.
+    """
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        "---\n"
+        f"name: {name}\n"
+        f"description: production-path test skill\n"
+        "hooks:\n"
+        "  PreToolUse:\n"
+        "    - matcher: Bash\n"
+        "      hooks:\n"
+        f"        - type: command\n"
+        f"          command: {hook_command}\n"
+        f"          once: true\n"
+        "---\n\n"
+        f"# {name}\n\nProduction-path test skill body.\n"
+    )
+    return skill_md
+
+
+class TestSkillHookRegistrationProductionPath:
+    """The bridge contract: sync ``SkillTool.call`` schedules an async
+    registration that lands before the next executor invocation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_skilltool_call_registers_hooks_visible_to_next_executor_run(
+        self, tmp_path,
+    ):
+        # 1. Build the skill on disk with frontmatter hooks.
+        skills_dir = tmp_path / "skills"
+        _write_skill_with_hooks(
+            skills_dir, name="audit-skill", hook_command="echo audit",
+        )
+
+        # 2. Build the production-shaped context: a SessionHookRegistry,
+        #    a session_id, an empty snapshot manager.
+        registry = SessionHookRegistry()
+        session_id = "session-prod-path"
+        ctx = _MockContext(
+            hook_config_manager=_empty_config_manager(),
+            session_hook_registry=registry,
+            session_id=session_id,
+        )
+
+        # 3. Sanity: registry is empty before invocation.
+        before = await get_session_hooks(
+            registry=registry, session_id=session_id, event="PreToolUse",
+        )
+        assert before == []
+
+        # 4. Drive the production entry point: SkillTool.call. Note this
+        #    is a SYNC call returning a ToolResult immediately. The hook
+        #    registration is fire-and-forget via loop.create_task.
+        with patch.dict(os.environ, {"CLAWCODEX_SKILLS_DIR": str(skills_dir)}):
+            result = SkillTool.call({"skill": "audit-skill"}, ctx)
+
+        # The sync return: ToolResult shape (skill rendered successfully).
+        assert result.is_error is False
+        assert result.output["commandName"] == "audit-skill"
+
+        # 5. Yield once to let the loop.create_task'd registration land.
+        #    This is the timing pin: ONE await boundary between SkillTool.call
+        #    return and the registration being visible. If the bridge is
+        #    broken (e.g., asyncio.run inside a running loop, or registration
+        #    silently dropped), this test fails.
+        await asyncio.sleep(0)
+
+        # 6. Registration is now visible.
+        after = await get_session_hooks(
+            registry=registry, session_id=session_id, event="PreToolUse",
+        )
+        assert len(after) == 1, (
+            f"Production-path bridge failed: registration didn't land "
+            f"after one await boundary; registry={[e.config.command for e in after]!r}"
+        )
+        assert after[0].config.command == "echo audit"
+        assert after[0].config.once is True
+
+        # 7. Drive the executor — the hook must fire on a matching
+        #    PreToolUse + Bash combination (proving the I2 collect step
+        #    sees session-scoped hooks registered via the production path).
+        fired_commands: list[str] = []
+        async for item in _run_hooks_for_event(
+            "PreToolUse", "Bash",
+            {"tool_name": "Bash", "tool_use_id": "u1"},
+            ctx,
+        ):
+            msg = item.get("message")
+            if msg is not None:
+                # Progress messages contain the command in the data dict.
+                data = getattr(msg, "data", None) or {}
+                if isinstance(data, dict) and data.get("command"):
+                    fired_commands.append(str(data["command"]))
+
+        assert any("echo audit" in c for c in fired_commands), (
+            f"hook did not fire after production-path registration; "
+            f"fired_commands={fired_commands!r}"
+        )
+
+        # 8. ``once: true`` removal landed via the executor's on_success
+        #    callback → the second invocation finds the registry empty.
+        for _ in range(3):
+            await asyncio.sleep(0)
+        final = await get_session_hooks(
+            registry=registry, session_id=session_id, event="PreToolUse",
+        )
+        assert final == [], (
+            f"once:true removal failed via production path; still: "
+            f"{[e.config.command for e in final]!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_skilltool_call_with_no_hooks_does_not_schedule(
+        self, tmp_path,
+    ):
+        # Sanity: a skill WITHOUT frontmatter ``hooks:`` does not schedule
+        # any registration (no spurious async tasks, no registry entries).
+        skills_dir = tmp_path / "skills"
+        skill_dir = skills_dir / "plain-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: plain-skill\ndescription: no hooks\n---\n\nplain body.\n"
+        )
+
+        registry = SessionHookRegistry()
+        ctx = _MockContext(
+            hook_config_manager=_empty_config_manager(),
+            session_hook_registry=registry,
+            session_id="s",
+        )
+
+        with patch.dict(os.environ, {"CLAWCODEX_SKILLS_DIR": str(skills_dir)}):
+            result = SkillTool.call({"skill": "plain-skill"}, ctx)
+        assert result.is_error is False
+
+        await asyncio.sleep(0)
+        # Registry stays empty across all events.
+        for ev in ("PreToolUse", "PostToolUse", "Stop"):
+            entries = await get_session_hooks(
+                registry=registry, session_id="s", event=ev,
+            )
+            assert entries == [], (
+                f"plain skill spuriously registered hooks under {ev!r}: "
+                f"{[e.config.command for e in entries]!r}"
+            )

--- a/tests/test_skill_once_true_e2e.py
+++ b/tests/test_skill_once_true_e2e.py
@@ -1,0 +1,262 @@
+"""Phase-3 acceptance gate — chapter example #2 end-to-end.
+
+The chapter (``ch12-extensibility.md``) describes:
+
+    A skill with frontmatter ``hooks: [PreToolUse, once: true]`` registers
+    a PreToolUse hook on invocation; it fires the next time a Bash tool
+    call happens; it is automatically removed after that first firing; it
+    does not fire on subsequent Bash calls.
+
+Pre-Phase-3 this was inert in the Python port (gap analysis #4 + #11).
+This test exercises the full chain end-to-end:
+
+  1. ``_run_markdown_skill`` (Phase 0 / I3 — now async) is invoked.
+  2. The skill's frontmatter ``hooks`` field is registered via
+     ``register_skill_hooks`` (Phase 3 / WI-3.2).
+  3. ``_run_hooks_for_event`` collects the session-scoped hook in its
+     ``_collect_hooks_for_event`` step (Phase 3 / WI-3.1, the I2 contract's
+     Collect step).
+  4. The hook fires on the first PreToolUse with a matching tool name.
+  5. The on_success callback (registered for ``once=True``) schedules
+     removal via ``asyncio.create_task``; the second firing finds nothing.
+
+Failure mode this protects against: any of the chain's links breaking →
+chapter example #2 silently no-ops or fires twice.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.hooks.config_manager import HookConfigManager, HookConfigSnapshot
+from src.hooks.hook_executor import _run_hooks_for_event
+from src.hooks.hook_types import HookConfig
+from src.hooks.register_skill_hooks import register_skill_hooks
+from src.hooks.registry import AsyncHookRegistry
+from src.hooks.session_hooks import SessionHookRegistry, get_session_hooks
+
+
+@dataclass
+class _MockOptions:
+    hooks: dict[str, Any] | None = None
+    tools: list[Any] = field(default_factory=list)
+
+
+@dataclass
+class _MockContext:
+    """Minimal stand-in for ToolContext for the E2E run."""
+    options: _MockOptions = field(default_factory=_MockOptions)
+    hook_config_manager: Any | None = None
+    workspace_trusted: bool = True
+    abort_controller: Any | None = None
+    session_hook_registry: Any | None = None
+    session_id: str | None = None
+    workspace_root: Path | None = None
+
+
+def _empty_config_manager() -> HookConfigManager:
+    """Manager with an empty snapshot — needed because the executor reads
+    the snapshot for non-session hooks. We don't want any snapshot-tier
+    hooks for this test; the goal is to exercise *only* the session-scoped
+    path.
+    """
+    m = HookConfigManager(registry=AsyncHookRegistry(), settings_path="/dev/null")
+    m._snapshot = HookConfigSnapshot(hooks={}, timestamp=0.0, source_path=None)
+    return m
+
+
+# Skill frontmatter: a single PreToolUse hook with ``once: true``.
+# Matcher ``"Bash"`` so it only fires for Bash tool calls.
+SKILL_HOOKS_ONCE_PRETOOLUSE = {
+    "PreToolUse": [
+        {
+            "matcher": "Bash",
+            "hooks": [
+                {"type": "command", "command": "echo audit", "once": True},
+            ],
+        }
+    ],
+}
+
+
+class TestSkillOnceTruePreToolUseEndToEnd:
+    @pytest.mark.asyncio
+    async def test_skill_once_true_pretooluse_e2e(self, tmp_path):
+        """Headline acceptance test for Phase 3.
+
+        Setup: a SessionHookRegistry, an empty HookConfigManager snapshot,
+        and a ToolContext wired to both. We register the skill's frontmatter
+        hooks directly via ``register_skill_hooks`` (the call ``_run_markdown_skill``
+        would make end-to-end; we don't spin up a full skill loader here to
+        keep the test focused on the hook-pipeline contract).
+
+        Then we drive ``_run_hooks_for_event`` twice for ``PreToolUse + Bash``
+        and assert the hook fired exactly once.
+        """
+        reg = SessionHookRegistry()
+        ctx = _MockContext(
+            hook_config_manager=_empty_config_manager(),
+            session_hook_registry=reg,
+            session_id="session-abc",
+        )
+
+        # Step 1 — register the skill's frontmatter hooks (mirroring what
+        # _run_markdown_skill does at the registration call site).
+        n = await register_skill_hooks(
+            registry=reg,
+            session_id="session-abc",
+            skill_hooks=SKILL_HOOKS_ONCE_PRETOOLUSE,
+            skill_name="audit-skill",
+        )
+        assert n == 1
+
+        # Sanity: registry has exactly the one hook before any firing.
+        before = await get_session_hooks(
+            registry=reg, session_id="session-abc", event="PreToolUse",
+        )
+        assert len(before) == 1
+
+        # Step 2 — first PreToolUse firing for Bash. Hook should fire.
+        # Drive the generator to completion (we don't care about progress
+        # messages here, only that the hook actually executed).
+        first_run_yields = []
+        async for item in _run_hooks_for_event(
+            "PreToolUse", "Bash",
+            {"tool_name": "Bash", "tool_use_id": "u1"},
+            ctx,
+        ):
+            first_run_yields.append(item)
+
+        # The progress yield includes a message with the hook's command.
+        # That's the proof-of-fire signal we use here (the actual subprocess
+        # output is captured by the `result` mechanism but isn't yielded
+        # back as a separate item unless there's a non-zero exit etc.).
+        assert any(
+            "echo audit" in str(item.get("message", "") or {})
+            for item in first_run_yields
+        ), f"hook did not fire on first PreToolUse; yields={first_run_yields!r}"
+
+        # Step 3 — give the asyncio.create_task removal a tick to land.
+        # The on_success callback fires synchronously after the hook
+        # finishes, but the removal it schedules runs on the next loop
+        # iteration. ``asyncio.sleep(0)`` yields control to let the
+        # scheduled remove_session_hook task run.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)  # one more tick for safety
+
+        after_first = await get_session_hooks(
+            registry=reg, session_id="session-abc", event="PreToolUse",
+        )
+        assert len(after_first) == 0, (
+            f"hook should have been removed after first firing (once=True); "
+            f"still present: {[e.config.command for e in after_first]}"
+        )
+
+        # Step 4 — second PreToolUse firing. Hook is gone; nothing fires.
+        second_run_yields = []
+        async for item in _run_hooks_for_event(
+            "PreToolUse", "Bash",
+            {"tool_name": "Bash", "tool_use_id": "u2"},
+            ctx,
+        ):
+            second_run_yields.append(item)
+
+        # No progress messages because no hooks matched.
+        assert not any(
+            "echo audit" in str(item.get("message", "") or {})
+            for item in second_run_yields
+        ), f"hook fired twice — once removal failed; yields={second_run_yields!r}"
+
+    @pytest.mark.asyncio
+    async def test_once_true_does_not_remove_on_blocking_error(self):
+        """A ``once: true`` hook that BLOCKS (exit 2) is NOT removed —
+        the on_success callback only fires for successful runs (exit 0).
+
+        Otherwise an audit hook that detected a violation and blocked the
+        tool call would silently uninstall itself, defeating the audit
+        purpose.
+        """
+        reg = SessionHookRegistry()
+        ctx = _MockContext(
+            hook_config_manager=_empty_config_manager(),
+            session_hook_registry=reg,
+            session_id="s",
+        )
+        # Hook exits 2 → blocking error.
+        await register_skill_hooks(
+            registry=reg, session_id="s",
+            skill_hooks={"PreToolUse": [{"matcher": "Bash", "hooks": [
+                {"type": "command", "command": "echo blocked >&2; exit 2", "once": True},
+            ]}]},
+            skill_name="blocker",
+        )
+
+        # Fire it once.
+        async for _ in _run_hooks_for_event(
+            "PreToolUse", "Bash", {"tool_name": "Bash"}, ctx,
+        ):
+            pass
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        # Hook still registered — blocking-error firing didn't trigger removal.
+        after = await get_session_hooks(
+            registry=reg, session_id="s", event="PreToolUse",
+        )
+        assert len(after) == 1
+
+
+class TestOnceTrueRaceRegression:
+    @pytest.mark.asyncio
+    async def test_concurrent_firings_of_once_true_only_remove_once(self):
+        """Race regression: two concurrent firings of the same once=True hook.
+
+        Both firings see the hook in the registry's collect step; both
+        execute (we accept this — TS does too); both schedule removal via
+        ``asyncio.create_task``. The first removal succeeds; the second
+        finds nothing and returns False. The end state is "hook removed
+        exactly once, registry is clean."
+
+        We're testing the *removal* race, not the firing race — the chapter's
+        ``once: true`` contract is "removed after first successful firing,"
+        not "fires at most once under contention." The latter would require
+        a check-and-set inside the executor, which neither TS nor Phase 3
+        implements.
+        """
+        reg = SessionHookRegistry()
+        ctx = _MockContext(
+            hook_config_manager=_empty_config_manager(),
+            session_hook_registry=reg,
+            session_id="s",
+        )
+        await register_skill_hooks(
+            registry=reg, session_id="s",
+            skill_hooks={"PreToolUse": [{"matcher": "Bash", "hooks": [
+                {"type": "command", "command": "echo once", "once": True},
+            ]}]},
+            skill_name="x",
+        )
+
+        async def fire():
+            async for _ in _run_hooks_for_event(
+                "PreToolUse", "Bash", {"tool_name": "Bash"}, ctx,
+            ):
+                pass
+
+        # Two concurrent firings.
+        await asyncio.gather(fire(), fire())
+        # Let both removal tasks settle.
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        # Registry is empty — exactly-once removal happened (the second
+        # remove found nothing and returned False).
+        after = await get_session_hooks(
+            registry=reg, session_id="s", event="PreToolUse",
+        )
+        assert after == []


### PR DESCRIPTION
## Summary
Phase 3 of ch12 — session-hook registration API plus skill/frontmatter registrars. **Chapter worked example #2 (skill `once: true` PreToolUse) is now end-to-end live in Python for the first time.**

## What's new in this phase (vs Phase 2)
- A9 rename: `src/hooks/session_hooks.py` → `lifecycle_routers.py`. New `session_hooks.py` houses the registration API.
- New `SessionHookRegistry` with `asyncio.Lock` (per N2); `add_session_hook` / `remove_session_hook` (sync contract per A10); `once: true` atomic removal via `asyncio.create_task(registry.remove(...))`. Mounted on `ToolContext.session_hook_registry`.
- New `register_skill_hooks.py` — forwards events verbatim (no Stop→SubagentStop conversion).
- New `register_frontmatter_hooks.py` — Stop→SubagentStop conversion gated on `is_agent: bool` (B1 correction; mirrors `registerFrontmatterHooks.ts:37-45`).
- `_run_markdown_skill` calls `register_skill_hooks` when frontmatter hooks present.
- I2 contract split: new `_collect_hooks_for_event` in executor merges snapshot + session registry. Phase 4 will own aggregation.
- **Acceptance gate test:** `test_skill_once_true_pretooluse_e2e` — chapter example #2 E2E.
- D1 production-path test: drives sync→async bridge through `SkillTool.call`.
- 25 new tests across 4 files; production-path test added.

## Test plan
- [ ] Phase 3 focused suite → 25/25
- [ ] All hook tests → 261/261
- [ ] Chapter example #2 E2E green

🤖 Generated with [Claude Code](https://claude.com/claude-code)