### PR TITLE
feat(ch12): phase 5 — forked skill execution + async migration + D3/D4 fixes

### DIFF
--- a/src/agent/subagent_context.py
+++ b/src/agent/subagent_context.py
@@ -183,6 +183,19 @@ def create_subagent_context(
         agent_id=agent_id,
         agent_type=agent_type,
         user_modified=parent_context.user_modified,
+        # Phase-5 follow-up D3 — sub-agents inherit the parent's
+        # forked-skill runner so a skill with ``context: 'fork'``
+        # invoked from a sub-agent context still spawns correctly.
+        forked_skill_runner=parent_context.forked_skill_runner,
+        # Inherit the chapter-12 hook plumbing too — sub-agents share
+        # the parent's snapshot manager + session-hook registry +
+        # workspace_trusted gate. Otherwise a sub-agent would see
+        # ``hook_config_manager=None`` and trip the deprecation warning
+        # via the legacy options.hooks fallback.
+        hook_config_manager=parent_context.hook_config_manager,
+        workspace_trusted=parent_context.workspace_trusted,
+        session_hook_registry=parent_context.session_hook_registry,
+        session_id=parent_context.session_id,
     )
 
 

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -178,6 +178,14 @@ def run_headless(options: HeadlessOptions) -> int:
     # AskUserQuestion has no terminal to read from in headless mode.
     tool_context.ask_user = _noop_ask_user
 
+    # Phase-5 follow-up D3 — wire production forked-skill runner.
+    from src.tool_system.tools.skill_fork import wire_forked_skill_runner
+    wire_forked_skill_runner(
+        tool_context=tool_context,
+        provider=provider,
+        tool_registry=tool_registry,
+    )
+
     # Build the input iterator.
     if options.input_format == "stream-json":
         inputs: Iterable[UserInputMessage] = StreamJsonReader(stdin)

--- a/src/entrypoints/tui.py
+++ b/src/entrypoints/tui.py
@@ -124,6 +124,17 @@ def run_tui(options: TUIOptions) -> int:
         tool_context.allow_docs = True
     tool_context.options.is_non_interactive_session = False
 
+    # Phase-5 follow-up D3 — wire the production forked-skill runner so
+    # skills with ``context: 'fork'`` actually run a sub-agent (rather
+    # than hitting the "configure forked_skill_runner" error). Idempotent;
+    # test fixtures that pre-inject a stub runner are preserved.
+    from src.tool_system.tools.skill_fork import wire_forked_skill_runner
+    wire_forked_skill_runner(
+        tool_context=tool_context,
+        provider=provider,
+        tool_registry=tool_registry,
+    )
+
     # Build and run app ---------------------------------------------------
     from src.tui.app import ClawCodexTUI
 

--- a/src/hooks/register_frontmatter_hooks.py
+++ b/src/hooks/register_frontmatter_hooks.py
@@ -39,20 +39,28 @@ async def register_frontmatter_hooks(
     source_name: str,
     is_agent: bool = False,
     skill_root: str | None = None,
-) -> int:
+) -> list[tuple[HookEvent, HookConfig]]:
     """Register frontmatter hooks; convert ``Stop → SubagentStop`` if
     ``is_agent`` is True.
 
-    Returns the count registered.
+    Returns a list of ``(event, hook_config)`` tuples for the hooks that
+    were registered. Callers can use the list to roll back registration
+    on a subsequent error (e.g., ``execute_forked_skill`` rolls back when
+    its runner errors after registration). Empty list means nothing
+    registered.
+
+    Pre-Phase-5-followup return type was ``int`` (count). Changed to a
+    list so D4's rollback contract is implementable. Callers that just
+    want the count use ``len(...)``.
 
     ``source_name`` is informational (e.g., ``"agent foo"`` /
     ``"skill /commit"``); used in debug logs to trace registrations back to
     their declarer.
     """
+    registered_entries: list[tuple[HookEvent, HookConfig]] = []
     if not frontmatter_hooks:
-        return 0
+        return registered_entries
 
-    registered = 0
     for event_name, matcher_groups in frontmatter_hooks.items():
         if not isinstance(matcher_groups, list):
             continue
@@ -108,14 +116,14 @@ async def register_frontmatter_hooks(
                     on_success=on_success,
                     skill_root=skill_root,
                 )
-                registered += 1
+                registered_entries.append((target_event, config))
 
-    if registered > 0:
+    if registered_entries:
         logger.debug(
             "Registered %d frontmatter hook(s) from %s (session=%s, is_agent=%s)",
-            registered, source_name, session_id, is_agent,
+            len(registered_entries), source_name, session_id, is_agent,
         )
-    return registered
+    return registered_entries
 
 
 def _make_once_remover(

--- a/src/permissions/rules.py
+++ b/src/permissions/rules.py
@@ -111,7 +111,7 @@ def get_deny_rule_for_tool(
     tool: ToolLike,
 ) -> PermissionRule | None:
     for rule in get_deny_rules(context):
-        if _tool_matches_rule(tool, rule):
+        if tool_matches_rule(tool, rule):
             return rule
     return None
 
@@ -121,7 +121,7 @@ def get_ask_rule_for_tool(
     tool: ToolLike,
 ) -> PermissionRule | None:
     for rule in get_ask_rules(context):
-        if _tool_matches_rule(tool, rule):
+        if tool_matches_rule(tool, rule):
             return rule
     return None
 
@@ -131,7 +131,7 @@ def tool_always_allowed_rule(
     tool: ToolLike,
 ) -> PermissionRule | None:
     for rule in get_allow_rules(context):
-        if _tool_matches_rule(tool, rule):
+        if tool_matches_rule(tool, rule):
             return rule
     return None
 

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -325,6 +325,14 @@ class ClawcodexREPL:
             ),
         )
         self.tool_context.ask_user = self._ask_user_questions
+
+        # Phase-5 follow-up D3 — wire production forked-skill runner.
+        from src.tool_system.tools.skill_fork import wire_forked_skill_runner
+        wire_forked_skill_runner(
+            tool_context=self.tool_context,
+            provider=self.provider,
+            tool_registry=self.tool_registry,
+        )
         # Permission handler with status control for proper input handling
         self._current_status = None
         if self._permission_mode == "bypassPermissions":

--- a/src/tool_system/context.py
+++ b/src/tool_system/context.py
@@ -165,6 +165,23 @@ class ToolContext:
     # snapshot's config-driven hooks at fire time. ``Any`` typing avoids a
     # circular import with ``src.hooks.session_hooks``.
     session_hook_registry: Any | None = None
+    # Chapter-12 / Phase 5 / WI-5.1 — forked-skill runner injection point.
+    # When a skill declares ``context: 'fork'`` in frontmatter,
+    # ``execute_forked_skill`` calls this runner with the rendered prompt
+    # and the skill's allowed_tools / model / effort, awaiting the
+    # sub-agent's final result text.
+    #
+    # ``None`` (default) means no runner is wired — the fork branch
+    # returns an ``is_error=True`` ToolResult explaining the missing
+    # configuration. Bootstrap is responsible for installing a real
+    # runner (e.g., one that drives ``run_agent`` with the skill's
+    # parameters); tests inject stubs to exercise the fork code path
+    # without a real LLM provider.
+    #
+    # Signature: ``async (prompt: str, *, allowed_tools, model, effort,
+    # parent_context) -> str``. ``Any`` typing avoids a circular import
+    # with the agent-tool layer.
+    forked_skill_runner: Any | None = None
 
     def __post_init__(self) -> None:
         self.workspace_root = Path(self.workspace_root).resolve()

--- a/src/tool_system/tools/skill.py
+++ b/src/tool_system/tools/skill.py
@@ -159,21 +159,32 @@ def _skill_map_result_to_api(output: Any, tool_use_id: str) -> dict[str, Any]:
 # Call implementation
 # ---------------------------------------------------------------------------
 
-def _skill_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
+async def _skill_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
+    """Phase-5 / WI-5.1 / I3 — full async migration.
+
+    The Phase-3 fire-and-forget bridge (``_schedule_skill_hook_registration``)
+    is gone. Skill-hook registration awaits ``register_skill_hooks``
+    directly; forked execution awaits the sub-agent runner. The dispatcher
+    (``registry.py:_invoke_tool_call``) handles both sync and async ``call``
+    callables transparently.
+    """
     skill_name = tool_input.get("skill")
     if isinstance(skill_name, str) and skill_name.strip():
         # Normalize: strip leading slash
         normalized = skill_name.strip().lstrip("/")
-        return _run_markdown_skill(normalized, tool_input.get("args", ""), context)
+        return await _run_markdown_skill(normalized, tool_input.get("args", ""), context)
 
     legacy_name = tool_input.get("name")
     if isinstance(legacy_name, str) and legacy_name.strip():
+        # Legacy .py skills don't have a fork path and don't use the
+        # async session-hook registry; the existing sync path is
+        # preserved.
         return _run_legacy_python_skill(legacy_name.strip(), tool_input.get("input", {}), context)
 
     raise ToolInputError("either 'skill' (for SKILL.md) or 'name' (for legacy .py) is required")
 
 
-def _run_markdown_skill(skill_name: str, args: str, context: ToolContext) -> ToolResult:
+async def _run_markdown_skill(skill_name: str, args: str, context: ToolContext) -> ToolResult:
     from src.skills.loader import get_all_skills, get_registered_skill
     from src.skills.runtime_substitution import render_skill_prompt
 
@@ -188,6 +199,23 @@ def _run_markdown_skill(skill_name: str, args: str, context: ToolContext) -> Too
             name="Skill",
             output={"error": f"skill not found: {skill_name}"},
             is_error=True,
+        )
+
+    # Phase-5 / WI-5.1 — forked execution. When skill frontmatter declares
+    # ``context: 'fork'``, run the skill in a sub-agent with its own
+    # context window. The previously-dead ``status == "forked"`` branch in
+    # ``_skill_map_result_to_api`` becomes live code via this branch.
+    # Skill prompt rendering + hook registration both happen inside
+    # ``execute_forked_skill`` (the forked-skill path uses
+    # ``register_frontmatter_hooks(is_agent=True)`` for the
+    # Stop→SubagentStop conversion, NOT ``register_skill_hooks``).
+    if getattr(skill, "context", None) == "fork":
+        from .skill_fork import execute_forked_skill
+        return await execute_forked_skill(
+            skill=skill,
+            args=args,
+            context=context,
+            tool_use_id=context.tool_use_id or "",
         )
 
     # Bundled skills supply a callable prompt builder and define their
@@ -224,23 +252,31 @@ def _run_markdown_skill(skill_name: str, args: str, context: ToolContext) -> Too
     # ``register_frontmatter_hooks(is_agent=True)``); ``register_skill_hooks``
     # forwards events verbatim.
     #
-    # ``_run_markdown_skill`` stays sync (existing call-site contract;
-    # 30+ tests bypass the dispatcher and call ``SkillTool.call`` directly).
-    # I3's original concern was ``asyncio.run`` blocking inside a running
-    # loop; we sidestep it via fire-and-forget: ``loop.create_task`` schedules
-    # the async registration on the current loop without blocking, and the
-    # task completes before the model's next tool call (microseconds vs.
-    # seconds). When invoked outside a running loop (rare; mostly tests),
-    # we fall back to ``asyncio.run`` since there's no nesting risk.
+    # Phase-5 / WI-5.1 / I3 — full async migration: now that
+    # ``_run_markdown_skill`` is ``async def``, we await
+    # ``register_skill_hooks`` directly. The Phase-3 fire-and-forget
+    # bridge (``_schedule_skill_hook_registration``) is gone.
     skill_hooks = getattr(skill, "hooks", None)
     if skill_hooks and context.session_hook_registry is not None and context.session_id:
-        _schedule_skill_hook_registration(
-            registry=context.session_hook_registry,
-            session_id=context.session_id,
-            skill_hooks=skill_hooks,
-            skill_name=skill_name,
-            skill_root=skill.skill_root,
-        )
+        from src.hooks.register_skill_hooks import register_skill_hooks
+        try:
+            count = await register_skill_hooks(
+                registry=context.session_hook_registry,
+                session_id=context.session_id,
+                skill_hooks=skill_hooks,
+                skill_name=skill_name,
+                skill_root=skill.skill_root,
+            )
+            if count:
+                logger.debug(
+                    "Skill %r registered %d session hooks", skill_name, count,
+                )
+        except Exception:
+            # Hook registration failure should not break skill invocation;
+            # log and continue. (The skill itself is still useful; the
+            # author's auxiliary hooks not firing is a degraded but
+            # recoverable state.)
+            logger.exception("register_skill_hooks failed for skill %r", skill_name)
 
     # Build context modifier if skill specifies allowed_tools, model, or effort
     context_modifier = _build_context_modifier(skill)
@@ -258,57 +294,6 @@ def _run_markdown_skill(skill_name: str, args: str, context: ToolContext) -> Too
         },
         context_modifier=context_modifier,
     )
-
-
-def _schedule_skill_hook_registration(
-    *,
-    registry: Any,
-    session_id: str,
-    skill_hooks: Any,
-    skill_name: str,
-    skill_root: str | None,
-) -> None:
-    """Schedule async ``register_skill_hooks`` from a sync caller.
-
-    Two paths:
-      * If a running asyncio loop is available, schedule the registration
-        coroutine via ``loop.create_task`` (fire-and-forget). The task
-        completes asynchronously; the calling tool returns immediately.
-      * If no loop is running (rare; mostly test fixtures that invoke
-        ``SkillTool.call`` from sync test code), fall back to ``asyncio.run``
-        — safe because there's no nesting.
-
-    Failures are logged at ERROR; we never raise (hook registration must
-    not break skill invocation).
-    """
-    import asyncio
-    from src.hooks.register_skill_hooks import register_skill_hooks
-
-    async def _do_register() -> None:
-        try:
-            count = await register_skill_hooks(
-                registry=registry,
-                session_id=session_id,
-                skill_hooks=skill_hooks,
-                skill_name=skill_name,
-                skill_root=skill_root,
-            )
-            if count:
-                logger.debug(
-                    "Skill %r registered %d session hooks", skill_name, count,
-                )
-        except Exception:
-            logger.exception("register_skill_hooks failed for skill %r", skill_name)
-
-    try:
-        loop = asyncio.get_running_loop()
-        loop.create_task(_do_register())
-    except RuntimeError:
-        # No running loop — sync caller (e.g., test). Run directly.
-        try:
-            asyncio.run(_do_register())
-        except Exception:
-            logger.exception("register_skill_hooks failed for skill %r", skill_name)
 
 
 def _make_shell_executor(

--- a/src/tool_system/tools/skill_fork.py
+++ b/src/tool_system/tools/skill_fork.py
@@ -1,0 +1,184 @@
+"""Forked skill execution.
+
+Phase-5 / WI-5.1. Mirrors TS
+``typescript/src/tools/SkillTool/SkillTool.ts:122-289`` (``executeForkedSkill``).
+
+Closes gap #8: the previously-dead ``status == "forked"`` branch in
+``_skill_map_result_to_api`` (skill.py:124-141 in the pre-Phase-5 layout)
+becomes live code. Skills declaring ``context: 'fork'`` in frontmatter
+now run with a separate context window — sub-agent token budget is
+isolated from the parent's, per the chapter's "Forked Skills" semantic.
+
+**Runner indirection (Phase 5 design choice).** ``execute_forked_skill``
+does NOT spawn the sub-agent directly. Instead it calls a runner
+callback wired onto ``ToolContext.forked_skill_runner``. Two reasons:
+
+  1. **Provider injection.** The agent-tool's ``run_agent`` machinery
+     is module-scoped over a ``BaseProvider`` instance, captured at
+     ``build_agent_tool(provider, registry)``. SkillTool has no provider
+     handle today; threading one through would require either a circular
+     import or duplicating the spawn-and-collect loop. The runner
+     callback resolves that without either tradeoff.
+  2. **Testability.** Forked execution by definition makes an LLM call.
+     Tests inject a stub runner that returns a fixed string; production
+     bootstrap wires a real runner that drives ``run_agent`` with the
+     skill's parameters. The fork code path is exercised in CI without
+     spinning up a real provider.
+
+When ``forked_skill_runner`` is None on the context, the fork branch
+returns an ``is_error=True`` ToolResult. Skill authors get a clear
+"forked execution unavailable" signal rather than a silent
+degradation-to-inline.
+
+Hook registration (skill frontmatter ``hooks:``) for forked skills
+flows through ``register_frontmatter_hooks(is_agent=True)`` per the
+B1-corrected gap analysis: forked skills are sub-agents, so their
+``Stop`` hooks need converting to ``SubagentStop`` (the conversion
+``register_skill_hooks`` does NOT do). The session_id is the
+parent's (the sub-agent inherits the parent's session for hook scope);
+this matches TS' executeForkedSkill behavior at SkillTool.ts:226-247.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ..context import ToolContext
+from ..protocol import ToolResult
+
+logger = logging.getLogger(__name__)
+
+
+async def execute_forked_skill(
+    *,
+    skill: Any,
+    args: str,
+    context: ToolContext,
+    tool_use_id: str,
+) -> ToolResult:
+    """Run a skill in a forked sub-agent context. Returns the sub-agent's
+    final result text packed into a ToolResult with ``status="forked"``.
+
+    Caller responsibilities:
+      * Skill prompt rendering — done by the caller (``_run_markdown_skill``).
+      * Hook registration with ``is_agent=True`` — done here, after the
+        runner returns, so hooks scoped to the forked execution don't
+        outlive a runner that errored out.
+
+    The runner indirection means this function is *almost entirely*
+    bookkeeping; the actual sub-agent spawn lives in
+    ``ToolContext.forked_skill_runner``.
+    """
+    from src.skills.runtime_substitution import render_skill_prompt
+    from src.tool_system.tools.skill import _make_shell_executor
+
+    runner = getattr(context, "forked_skill_runner", None)
+    if runner is None:
+        return ToolResult(
+            name="Skill",
+            output={
+                "status": "forked",
+                "commandName": skill.name,
+                "error": (
+                    "Forked skill execution requires a forked_skill_runner "
+                    "on the ToolContext. Bootstrap wires this in production; "
+                    "tests inject a stub. See "
+                    "src/tool_system/tools/skill_fork.py for the contract."
+                ),
+            },
+            is_error=True,
+        )
+
+    # Render the skill prompt the same way inline skills do (skill.py:_run_markdown_skill).
+    # The forked sub-agent receives this rendered string as its initial
+    # user prompt. Shell-block execution is gated on non-MCP sources;
+    # MCP-loaded skills' shell blocks are left as text in the rendered
+    # prompt for the sub-agent to interpret literally (per the chapter's
+    # MCP security boundary).
+    if getattr(skill, "get_prompt_for_command", None) is not None:
+        prompt = skill.get_prompt_for_command(args or "")
+    else:
+        body = skill.markdown_content or skill.content or ""
+        base_dir = skill.base_dir or skill.skill_root
+        executor = _make_shell_executor(
+            context, skill.allowed_tools, slash_command_name=f"/{skill.name}",
+        )
+        prompt = render_skill_prompt(
+            body=body,
+            args=args,
+            base_dir=base_dir,
+            argument_names=skill.argument_names,
+            session_id=context.session_id,
+            loaded_from=skill.loaded_from,
+            slash_command_name=f"/{skill.name}",
+            shell_executor=executor,
+        )
+
+    # Drive the sub-agent via the injected runner. Errors from the
+    # runner surface as is_error=True ToolResults; the user sees the
+    # underlying error message, not a generic "forked failed."
+    try:
+        result_text = await runner(
+            prompt=prompt,
+            allowed_tools=getattr(skill, "allowed_tools", None),
+            model=getattr(skill, "model", None),
+            effort=getattr(skill, "effort", None),
+            parent_context=context,
+        )
+    except Exception as exc:
+        logger.exception(
+            "forked_skill_runner raised for skill %r", skill.name,
+        )
+        return ToolResult(
+            name="Skill",
+            output={
+                "status": "forked",
+                "commandName": skill.name,
+                "error": f"Forked skill execution failed: {exc}",
+            },
+            is_error=True,
+        )
+
+    # Register skill-frontmatter hooks scoped to the parent session
+    # but with ``is_agent=True`` so the Stop→SubagentStop conversion
+    # fires (the forked skill IS a sub-agent for hook-routing purposes).
+    # B1 correction: this conversion lives in register_frontmatter_hooks,
+    # NOT register_skill_hooks. The forked-skill case is one of the few
+    # places skill code calls register_frontmatter_hooks directly.
+    skill_hooks = getattr(skill, "hooks", None)
+    if skill_hooks and context.session_hook_registry is not None and context.session_id:
+        from src.hooks.register_frontmatter_hooks import register_frontmatter_hooks
+        try:
+            count = await register_frontmatter_hooks(
+                registry=context.session_hook_registry,
+                session_id=context.session_id,
+                frontmatter_hooks=skill_hooks,
+                source_name=f"forked-skill {skill.name!r}",
+                is_agent=True,
+                skill_root=skill.skill_root,
+            )
+            if count:
+                logger.debug(
+                    "Forked skill %r registered %d session hooks (Stop→SubagentStop)",
+                    skill.name, count,
+                )
+        except Exception:
+            logger.exception(
+                "register_frontmatter_hooks failed for forked skill %r",
+                skill.name,
+            )
+
+    return ToolResult(
+        name="Skill",
+        output={
+            "success": True,
+            "status": "forked",
+            "commandName": skill.name,
+            "result": result_text,
+            "loadedFrom": skill.loaded_from,
+            "skillRoot": skill.skill_root,
+            "allowedTools": skill.allowed_tools if skill.allowed_tools else None,
+            "model": skill.model,
+        },
+    )

--- a/src/tool_system/tools/skill_fork.py
+++ b/src/tool_system/tools/skill_fork.py
@@ -1,6 +1,6 @@
 """Forked skill execution.
 
-Phase-5 / WI-5.1. Mirrors TS
+Phase-5 / WI-5.1 + Phase-5 follow-ups (D3, D4). Mirrors TS
 ``typescript/src/tools/SkillTool/SkillTool.ts:122-289`` (``executeForkedSkill``).
 
 Closes gap #8: the previously-dead ``status == "forked"`` branch in
@@ -115,6 +115,45 @@ async def execute_forked_skill(
             shell_executor=executor,
         )
 
+    # D4 fix — register skill-frontmatter hooks BEFORE the runner so the
+    # hooks fire on THIS forked skill's SubagentStop, not future
+    # sub-agents'. ``is_agent=True`` triggers the B1 Stop→SubagentStop
+    # conversion (the forked skill IS a sub-agent for hook-routing
+    # purposes). Pre-D4 ordering registered AFTER the runner returned —
+    # by which point the sub-agent's SubagentStop had already fired.
+    # Chapter intent ("an agent's stop-verification hook fires when this
+    # agent stops") was therefore unrealized despite the conversion being
+    # plumbed correctly.
+    #
+    # Rollback contract: if the runner raises, the registered entries are
+    # removed from the registry (try/finally with explicit remove). Avoids
+    # a "the runner errored but its hooks are now active for the rest of
+    # the session" leak.
+    registered_entries: list[tuple[Any, Any]] = []
+    skill_hooks = getattr(skill, "hooks", None)
+    if skill_hooks and context.session_hook_registry is not None and context.session_id:
+        from src.hooks.register_frontmatter_hooks import register_frontmatter_hooks
+        try:
+            registered_entries = await register_frontmatter_hooks(
+                registry=context.session_hook_registry,
+                session_id=context.session_id,
+                frontmatter_hooks=skill_hooks,
+                source_name=f"forked-skill {skill.name!r}",
+                is_agent=True,
+                skill_root=skill.skill_root,
+            )
+            if registered_entries:
+                logger.debug(
+                    "Forked skill %r registered %d session hooks (Stop→SubagentStop)",
+                    skill.name, len(registered_entries),
+                )
+        except Exception:
+            logger.exception(
+                "register_frontmatter_hooks failed for forked skill %r",
+                skill.name,
+            )
+            registered_entries = []
+
     # Drive the sub-agent via the injected runner. Errors from the
     # runner surface as is_error=True ToolResults; the user sees the
     # underlying error message, not a generic "forked failed."
@@ -130,6 +169,24 @@ async def execute_forked_skill(
         logger.exception(
             "forked_skill_runner raised for skill %r", skill.name,
         )
+        # D4 rollback — remove the hooks we registered before the runner
+        # ran. Keeps the session's hook surface clean of artifacts from a
+        # forked skill that never actually ran.
+        if registered_entries and context.session_hook_registry and context.session_id:
+            from src.hooks.session_hooks import remove_session_hook
+            for event, hook_config in registered_entries:
+                try:
+                    await remove_session_hook(
+                        registry=context.session_hook_registry,
+                        session_id=context.session_id,
+                        event=event,
+                        hook=hook_config,
+                    )
+                except Exception:
+                    logger.exception(
+                        "rollback of forked-skill hook registration failed "
+                        "(skill=%r, event=%r)", skill.name, event,
+                    )
         return ToolResult(
             name="Skill",
             output={
@@ -139,35 +196,6 @@ async def execute_forked_skill(
             },
             is_error=True,
         )
-
-    # Register skill-frontmatter hooks scoped to the parent session
-    # but with ``is_agent=True`` so the Stop→SubagentStop conversion
-    # fires (the forked skill IS a sub-agent for hook-routing purposes).
-    # B1 correction: this conversion lives in register_frontmatter_hooks,
-    # NOT register_skill_hooks. The forked-skill case is one of the few
-    # places skill code calls register_frontmatter_hooks directly.
-    skill_hooks = getattr(skill, "hooks", None)
-    if skill_hooks and context.session_hook_registry is not None and context.session_id:
-        from src.hooks.register_frontmatter_hooks import register_frontmatter_hooks
-        try:
-            count = await register_frontmatter_hooks(
-                registry=context.session_hook_registry,
-                session_id=context.session_id,
-                frontmatter_hooks=skill_hooks,
-                source_name=f"forked-skill {skill.name!r}",
-                is_agent=True,
-                skill_root=skill.skill_root,
-            )
-            if count:
-                logger.debug(
-                    "Forked skill %r registered %d session hooks (Stop→SubagentStop)",
-                    skill.name, count,
-                )
-        except Exception:
-            logger.exception(
-                "register_frontmatter_hooks failed for forked skill %r",
-                skill.name,
-            )
 
     return ToolResult(
         name="Skill",
@@ -181,4 +209,131 @@ async def execute_forked_skill(
             "allowedTools": skill.allowed_tools if skill.allowed_tools else None,
             "model": skill.model,
         },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase-5 follow-up D3 — production runner factory.
+# ---------------------------------------------------------------------------
+
+
+def make_forked_skill_runner(
+    *,
+    provider: Any,
+    tool_registry: Any,
+):
+    """Build a forked-skill runner closure over ``provider`` + ``tool_registry``.
+
+    Phase-5 follow-up D3 (critic-flagged). Pre-D3, the prior commit's
+    summary claimed "Production bootstrap wires this in production" but
+    ``bootstrap_graph.py`` / ``bootstrap/state.py`` had zero references.
+    Production sessions hit the "configure forked_skill_runner" error.
+
+    This factory closes the gap: bootstrap calls
+    ``make_forked_skill_runner(provider=provider, tool_registry=registry)``
+    and mounts the result on ``ToolContext.forked_skill_runner``. The
+    closure has the exact ``execute_forked_skill`` signature
+    ``(prompt, allowed_tools, model, effort, parent_context) -> str``.
+
+    The runner drives ``run_agent`` with the skill's parameters and
+    returns the sub-agent's final assistant text. When ``allowed_tools``
+    is set, the available-tool list is filtered to that allowlist.
+
+    Falls back to ``general-purpose`` agent definition (the chapter's
+    "default agent" — it has no agent-type-specific tools, so the skill's
+    ``allowed_tools`` is the only filter that matters).
+
+    Local imports below: avoids dragging the agent-tool / run_agent
+    machinery into module-init paths that don't need it (e.g., test
+    fixtures that only hit ``execute_forked_skill`` with a stub runner).
+    """
+
+    async def _runner(
+        *,
+        prompt: str,
+        allowed_tools: list[str] | None,
+        model: str | None,
+        effort: str | None,
+        parent_context: ToolContext,
+    ) -> str:
+        from src.agent.agent_definitions import find_agent_by_type, get_built_in_agents
+        from src.agent.run_agent import RunAgentParams
+        from src.tasks_core import generate_task_id
+        from src.tool_system.tools.agent import (
+            _collect_agent_messages,
+            finalize_agent_tool,
+        )
+        import time as _time
+
+        agent_def = find_agent_by_type(get_built_in_agents(), "general-purpose")
+        if agent_def is None:
+            raise RuntimeError(
+                "No general-purpose agent definition available for forked skill"
+            )
+
+        # Filter the registry's tool list to ``allowed_tools`` when the
+        # skill specifies one. Skills can scope their forked sub-agent's
+        # capabilities — e.g., a research skill may only need Read and
+        # Glob. ``None``/empty means "use parent's full tool list."
+        available_tools = list(tool_registry.list_tools())
+        if allowed_tools:
+            allowed_set = set(allowed_tools)
+            available_tools = [
+                t for t in available_tools
+                if getattr(t, "name", "") in allowed_set
+            ]
+
+        agent_id = generate_task_id("local_agent")
+        start_time = _time.time()
+
+        run_params = RunAgentParams(
+            parent_context=parent_context,
+            agent_definition=agent_def,
+            prompt=prompt,
+            available_tools=available_tools,
+            tool_registry=tool_registry,
+            provider=provider,
+            model=model,
+            agent_id=agent_id,
+            is_async=False,
+            max_turns=agent_def.max_turns,
+        )
+
+        messages = await _collect_agent_messages(run_params)
+        result = finalize_agent_tool(
+            messages,
+            agent_id,
+            {
+                "start_time": start_time,
+                "agent_type": agent_def.agent_type,
+            },
+        )
+        # Return the sub-agent's final assistant text. ``content`` is the
+        # canonical field per ``finalize_agent_tool``'s return shape.
+        return result.content
+
+    return _runner
+
+
+def wire_forked_skill_runner(
+    *,
+    tool_context: ToolContext,
+    provider: Any,
+    tool_registry: Any,
+) -> None:
+    """Mount a production forked-skill runner on ``tool_context``.
+
+    Convenience wrapper around ``make_forked_skill_runner`` so each
+    bootstrap entry point (tui, repl, headless, subagent_context) has
+    a one-liner instead of repeating the factory + assignment.
+
+    Idempotent: a context that already has a runner is left unchanged
+    (test fixtures that inject stubs aren't clobbered if they happen to
+    flow through a bootstrap path).
+    """
+    if getattr(tool_context, "forked_skill_runner", None) is not None:
+        return
+    tool_context.forked_skill_runner = make_forked_skill_runner(
+        provider=provider,
+        tool_registry=tool_registry,
     )

--- a/tests/test_phase5_followups.py
+++ b/tests/test_phase5_followups.py
@@ -1,0 +1,300 @@
+"""Phase-5 follow-ups (D3 + D4) regression tests.
+
+D3 — production wiring of ``forked_skill_runner``. Pre-D3, the prior
+Phase-5 commit summary claimed bootstrap wired the runner but in fact
+``bootstrap_graph.py`` / ``bootstrap/state.py`` had zero references.
+D3 adds ``make_forked_skill_runner(provider, tool_registry)`` and
+``wire_forked_skill_runner(...)`` plus the bootstrap-side wiring
+(tui, repl, headless, subagent_context).
+
+D4 — hook registration ordering for forked skills. Pre-D4,
+``execute_forked_skill`` registered hooks AFTER the runner returned.
+The forked sub-agent's SubagentStop had already fired by then, so the
+hook would only fire on FUTURE sub-agents' stops, not THIS skill's
+own stop. The B1 conversion was plumbed but its outcome was unrealized.
+D4 moves registration BEFORE the runner with rollback on error.
+
+Tests:
+  * D3 — factory shape + signature + bootstrap-side smoke.
+  * D4 — registration-order regression (entries visible BEFORE runner
+    sees its first call); firing-semantic test (driving
+    ``_run_hooks_for_event("SubagentStop", ...)`` AFTER forked execution
+    fires the registered hook); rollback-on-runner-error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.hooks.config_manager import HookConfigManager, HookConfigSnapshot
+from src.hooks.hook_executor import _run_hooks_for_event
+from src.hooks.registry import AsyncHookRegistry
+from src.hooks.session_hooks import SessionHookRegistry, get_session_hooks
+from src.tool_system.tools.skill import SkillTool
+from src.tool_system.tools.skill_fork import (
+    make_forked_skill_runner,
+    wire_forked_skill_runner,
+)
+
+
+@dataclass
+class _MockOptions:
+    hooks: dict[str, Any] | None = None
+    tools: list[Any] = field(default_factory=list)
+
+
+@dataclass
+class _MockContext:
+    options: _MockOptions = field(default_factory=_MockOptions)
+    hook_config_manager: Any | None = None
+    workspace_trusted: bool = True
+    abort_controller: Any | None = None
+    session_hook_registry: Any | None = None
+    session_id: str | None = None
+    workspace_root: Path | None = None
+    forked_skill_runner: Any | None = None
+    tool_use_id: str | None = None
+
+
+def _empty_config_manager() -> HookConfigManager:
+    m = HookConfigManager(registry=AsyncHookRegistry(), settings_path="/dev/null")
+    m._snapshot = HookConfigSnapshot(hooks={}, timestamp=0.0, source_path=None)
+    return m
+
+
+def _write_skill_with_stop_hook(skills_dir: Path, *, name: str) -> Path:
+    """Write a SKILL.md with frontmatter ``context: fork`` AND a Stop hook
+    so the D4 path (Stop→SubagentStop conversion + firing semantic)
+    becomes exercisable.
+    """
+    d = skills_dir / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: D4 firing-semantic test skill\n"
+        "context: fork\n"
+        "hooks:\n"
+        "  Stop:\n"
+        "    - matcher: \"\"\n"
+        "      hooks:\n"
+        "        - type: command\n"
+        "          command: echo cleanup-on-stop\n"
+        "---\n\nbody\n"
+    )
+    return d / "SKILL.md"
+
+
+# ---------------------------------------------------------------------------
+# D3 — production runner factory
+# ---------------------------------------------------------------------------
+
+
+class TestD3ProductionRunnerFactory:
+    def test_factory_returns_async_callable(self):
+        # Factory has the right shape: returns a coroutine function with
+        # the kwargs the execute_forked_skill caller uses.
+        runner = make_forked_skill_runner(
+            provider=object(),       # placeholder; we don't invoke
+            tool_registry=object(),
+        )
+        import inspect
+        assert inspect.iscoroutinefunction(runner)
+        sig = inspect.signature(runner)
+        params = sig.parameters
+        for name in ("prompt", "allowed_tools", "model", "effort", "parent_context"):
+            assert name in params, f"runner missing param: {name}"
+
+    def test_wire_forked_skill_runner_sets_field(self):
+        # Bootstrap-side wiring: a fresh context with no runner gets one
+        # mounted by ``wire_forked_skill_runner``.
+        ctx = _MockContext()
+        assert ctx.forked_skill_runner is None
+        wire_forked_skill_runner(
+            tool_context=ctx,
+            provider=object(),
+            tool_registry=object(),
+        )
+        assert ctx.forked_skill_runner is not None
+
+    def test_wire_is_idempotent_does_not_clobber_test_stub(self):
+        # Test fixtures inject stub runners; bootstrap-style wiring must
+        # NOT overwrite them. Idempotency check.
+        async def stub(**kwargs):
+            return ""
+        ctx = _MockContext(forked_skill_runner=stub)
+        wire_forked_skill_runner(
+            tool_context=ctx,
+            provider=object(),
+            tool_registry=object(),
+        )
+        assert ctx.forked_skill_runner is stub  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# D4 — hook registration ordering
+# ---------------------------------------------------------------------------
+
+
+class TestD4RegistrationOrdering:
+    @pytest.mark.asyncio
+    async def test_hooks_registered_before_runner_runs(self, tmp_path):
+        # Pre-D4 ordering: register AFTER runner. Test inverts that:
+        # capture the registry state at the moment the runner is called;
+        # if the hook is already there, registration happened before.
+        skills_dir = tmp_path / "skills"
+        _write_skill_with_stop_hook(skills_dir, name="d4skill")
+
+        registry = SessionHookRegistry()
+        captured_hooks_at_runner_call: list = []
+
+        async def stub_runner(**kwargs):
+            # At this point, hooks must already be registered.
+            captured_hooks_at_runner_call.extend(
+                await get_session_hooks(
+                    registry=registry, session_id="s-d4", event="SubagentStop",
+                )
+            )
+            return "result"
+
+        ctx = _MockContext(
+            hook_config_manager=_empty_config_manager(),
+            session_hook_registry=registry,
+            session_id="s-d4",
+            forked_skill_runner=stub_runner,
+        )
+
+        with patch.dict(os.environ, {"CLAWCODEX_SKILLS_DIR": str(skills_dir)}):
+            result = await SkillTool.call({"skill": "d4skill"}, ctx)
+
+        assert result.is_error is False
+        # Hook was already registered when the runner was called.
+        # Pre-D4 this list would have been empty — the bug.
+        assert len(captured_hooks_at_runner_call) == 1
+        assert captured_hooks_at_runner_call[0].config.command == "echo cleanup-on-stop"
+
+    @pytest.mark.asyncio
+    async def test_subagentstop_hook_fires_after_forked_execution(self, tmp_path):
+        # The chapter intent ("an agent's stop-verification hook fires
+        # when this agent stops") realized end-to-end:
+        #   1. Forked skill registers a Stop hook (converted to SubagentStop).
+        #   2. After forked execution completes, the parent fires
+        #      SubagentStop for the sub-agent.
+        #   3. The registered hook fires.
+        skills_dir = tmp_path / "skills"
+        _write_skill_with_stop_hook(skills_dir, name="d4fire")
+
+        registry = SessionHookRegistry()
+
+        async def stub_runner(**kwargs):
+            return "sub-agent done"
+
+        ctx = _MockContext(
+            hook_config_manager=_empty_config_manager(),
+            session_hook_registry=registry,
+            session_id="s-fire",
+            forked_skill_runner=stub_runner,
+        )
+
+        with patch.dict(os.environ, {"CLAWCODEX_SKILLS_DIR": str(skills_dir)}):
+            result = await SkillTool.call({"skill": "d4fire"}, ctx)
+
+        assert result.is_error is False
+
+        # After forked execution: drive SubagentStop and verify the
+        # registered hook fires. This is the firing-semantic test the
+        # team-lead asked for.
+        fired_commands: list[str] = []
+        async for item in _run_hooks_for_event(
+            "SubagentStop", None,
+            {"hook_event": "SubagentStop", "subagent_id": "sub-1"},
+            ctx,
+        ):
+            msg = item.get("message")
+            data = getattr(msg, "data", None) or {}
+            if isinstance(data, dict) and data.get("command"):
+                fired_commands.append(str(data["command"]))
+
+        assert any("cleanup-on-stop" in c for c in fired_commands), (
+            f"forked-skill SubagentStop hook did not fire after the "
+            f"sub-agent's stop. Pre-D4 this was the bug: registration "
+            f"happened AFTER runner return so SubagentStop had already "
+            f"fired. fired_commands={fired_commands!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# D4 — rollback on runner error
+# ---------------------------------------------------------------------------
+
+
+class TestD4RollbackOnRunnerError:
+    @pytest.mark.asyncio
+    async def test_runner_exception_rolls_back_hook_registration(self, tmp_path):
+        # When the runner raises, the hooks that were registered before
+        # the runner ran are rolled back. The session is left as if the
+        # forked-skill invocation had never happened.
+        skills_dir = tmp_path / "skills"
+        _write_skill_with_stop_hook(skills_dir, name="d4rollback")
+
+        registry = SessionHookRegistry()
+
+        async def failing_runner(**kwargs):
+            raise RuntimeError("simulated forked-skill failure")
+
+        ctx = _MockContext(
+            hook_config_manager=_empty_config_manager(),
+            session_hook_registry=registry,
+            session_id="s-rollback",
+            forked_skill_runner=failing_runner,
+        )
+
+        with patch.dict(os.environ, {"CLAWCODEX_SKILLS_DIR": str(skills_dir)}):
+            result = await SkillTool.call({"skill": "d4rollback"}, ctx)
+
+        # Runner errored → ToolResult is_error=True.
+        assert result.is_error is True
+        assert "simulated forked-skill failure" in result.output["error"]
+
+        # Hooks rolled back: registry empty under SubagentStop.
+        sub_hooks = await get_session_hooks(
+            registry=registry, session_id="s-rollback", event="SubagentStop",
+        )
+        assert sub_hooks == [], (
+            f"D4 rollback failed: hooks remained after runner error. "
+            f"left over: {[e.config.command for e in sub_hooks]!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_runner_success_keeps_hook_registration(self, tmp_path):
+        # Counterpart: when the runner succeeds, hooks stay registered
+        # (so the firing-semantic test above remains green).
+        skills_dir = tmp_path / "skills"
+        _write_skill_with_stop_hook(skills_dir, name="d4keep")
+
+        registry = SessionHookRegistry()
+
+        async def stub_runner(**kwargs):
+            return "ok"
+
+        ctx = _MockContext(
+            hook_config_manager=_empty_config_manager(),
+            session_hook_registry=registry,
+            session_id="s-keep",
+            forked_skill_runner=stub_runner,
+        )
+
+        with patch.dict(os.environ, {"CLAWCODEX_SKILLS_DIR": str(skills_dir)}):
+            await SkillTool.call({"skill": "d4keep"}, ctx)
+
+        sub_hooks = await get_session_hooks(
+            registry=registry, session_id="s-keep", event="SubagentStop",
+        )
+        assert len(sub_hooks) == 1

--- a/tests/test_register_frontmatter_hooks.py
+++ b/tests/test_register_frontmatter_hooks.py
@@ -116,11 +116,14 @@ class TestBasicRegistration:
     @pytest.mark.asyncio
     async def test_returns_zero_for_empty(self):
         reg = SessionHookRegistry()
-        n = await register_frontmatter_hooks(
+        entries = await register_frontmatter_hooks(
             registry=reg, session_id="s1",
             frontmatter_hooks=None, source_name="x",
         )
-        assert n == 0
+        # Phase-5-followup D4: register_frontmatter_hooks returns the
+        # registered (event, config) entries (not just a count) so
+        # callers can roll back on subsequent error.
+        assert entries == []
 
     @pytest.mark.asyncio
     async def test_session_hook_source_tag(self):

--- a/tests/test_skill_context_fork.py
+++ b/tests/test_skill_context_fork.py
@@ -1,0 +1,329 @@
+"""Phase-5 / WI-5.1 — forked skill execution tests.
+
+Closes gap #8: skills with frontmatter ``context: 'fork'`` now run in a
+separate context window via ``execute_forked_skill``. The previously-dead
+``status == "forked"`` branch in ``_skill_map_result_to_api`` is now
+reachable.
+
+Production wiring of the forked-skill runner happens at bootstrap time
+(it drives ``run_agent`` with the skill's parameters). For these tests
+we inject a stub runner via ``ToolContext.forked_skill_runner`` so the
+forked code path is exercised without requiring a real LLM provider.
+
+Coverage:
+  * ``context: 'fork'`` triggers the forked path; ``context: 'inline'``
+    (default) does not.
+  * The runner receives the rendered prompt + skill parameters
+    (allowed_tools, model, effort).
+  * The runner's return value lands in ``output["result"]`` and the
+    output carries ``status="forked"``.
+  * ``_skill_map_result_to_api`` correctly formats the forked result
+    (chapter-12's "Skill X completed (forked execution).\\n\\nResult: ..."
+    shape).
+  * Missing runner → ``is_error=True`` ToolResult with a clear message.
+  * Runner exceptions → ``is_error=True``, error preserved in output.
+  * Hook registration goes through ``register_frontmatter_hooks(is_agent=True)``
+    (the Stop→SubagentStop conversion path) — NOT through
+    ``register_skill_hooks``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.hooks.config_manager import HookConfigManager, HookConfigSnapshot
+from src.hooks.registry import AsyncHookRegistry
+from src.hooks.session_hooks import SessionHookRegistry, get_session_hooks
+from src.tool_system.tools.skill import SkillTool, _skill_map_result_to_api
+
+
+@dataclass
+class _MockOptions:
+    hooks: dict[str, Any] | None = None
+    tools: list[Any] = field(default_factory=list)
+
+
+@dataclass
+class _MockContext:
+    options: _MockOptions = field(default_factory=_MockOptions)
+    hook_config_manager: Any | None = None
+    workspace_trusted: bool = True
+    abort_controller: Any | None = None
+    session_hook_registry: Any | None = None
+    session_id: str | None = None
+    workspace_root: Path | None = None
+    forked_skill_runner: Any | None = None
+    tool_use_id: str | None = None
+
+
+def _empty_config_manager() -> HookConfigManager:
+    m = HookConfigManager(registry=AsyncHookRegistry(), settings_path="/dev/null")
+    m._snapshot = HookConfigSnapshot(hooks={}, timestamp=0.0, source_path=None)
+    return m
+
+
+def _write_skill(
+    skills_dir: Path,
+    *,
+    name: str,
+    fork: bool,
+    body: str = "Forked skill body",
+    extra_frontmatter: str = "",
+) -> Path:
+    """Write a SKILL.md file with optional ``context: 'fork'`` frontmatter."""
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_md = skill_dir / "SKILL.md"
+    fm = [
+        f"name: {name}",
+        f"description: Phase-5 fork test skill",
+    ]
+    if fork:
+        fm.append("context: fork")
+    if extra_frontmatter:
+        fm.append(extra_frontmatter)
+    skill_md.write_text(
+        "---\n" + "\n".join(fm) + "\n---\n\n" + body + "\n"
+    )
+    return skill_md
+
+
+# ---------------------------------------------------------------------------
+# Fork-vs-inline branching
+# ---------------------------------------------------------------------------
+
+
+class TestForkBranching:
+    @pytest.mark.asyncio
+    async def test_context_fork_triggers_forked_path(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        _write_skill(skills_dir, name="forky", fork=True, body="Do the thing")
+
+        captured: dict[str, Any] = {}
+
+        async def stub_runner(*, prompt, allowed_tools, model, effort, parent_context):
+            captured["prompt"] = prompt
+            captured["allowed_tools"] = allowed_tools
+            captured["model"] = model
+            captured["effort"] = effort
+            return "forked-result-text"
+
+        ctx = _MockContext(
+            hook_config_manager=_empty_config_manager(),
+            forked_skill_runner=stub_runner,
+        )
+
+        with patch.dict(os.environ, {"CLAWCODEX_SKILLS_DIR": str(skills_dir)}):
+            result = await SkillTool.call({"skill": "forky"}, ctx)
+
+        # Runner was called.
+        assert "prompt" in captured
+        # Rendered skill body reached the runner.
+        assert "Do the thing" in captured["prompt"]
+
+        # Result shape matches the forked branch.
+        assert result.is_error is False
+        assert result.output["status"] == "forked"
+        assert result.output["commandName"] == "forky"
+        assert result.output["result"] == "forked-result-text"
+
+    @pytest.mark.asyncio
+    async def test_no_context_fork_runs_inline(self, tmp_path):
+        # Default: inline execution. Runner must NOT be called.
+        skills_dir = tmp_path / "skills"
+        _write_skill(skills_dir, name="inliny", fork=False, body="inline body")
+
+        called = {"count": 0}
+
+        async def stub_runner(**kwargs):
+            called["count"] += 1
+            return "should-not-be-called"
+
+        ctx = _MockContext(
+            hook_config_manager=_empty_config_manager(),
+            forked_skill_runner=stub_runner,
+        )
+
+        with patch.dict(os.environ, {"CLAWCODEX_SKILLS_DIR": str(skills_dir)}):
+            result = await SkillTool.call({"skill": "inliny"}, ctx)
+
+        # Runner was NOT called — inline path returns rendered prompt.
+        assert called["count"] == 0
+        assert result.output.get("status") != "forked"
+        assert "inline body" in result.output.get("prompt", "")
+
+
+# ---------------------------------------------------------------------------
+# Dead branch in _skill_map_result_to_api becomes reachable
+# ---------------------------------------------------------------------------
+
+
+class TestSkillMapResultToApiForkedBranch:
+    """The pre-Phase-5 ``status == "forked"`` branch in
+    ``_skill_map_result_to_api`` was dead code (no caller produced
+    ``status="forked"``). Phase 5 makes the branch reachable.
+    """
+
+    def test_forked_branch_returns_completed_envelope(self):
+        # Direct unit-test of the formatter — no SkillTool needed.
+        output = {
+            "status": "forked",
+            "commandName": "my-skill",
+            "result": "the sub-agent's final text",
+        }
+        api_result = _skill_map_result_to_api(output, tool_use_id="t1")
+        assert api_result["type"] == "tool_result"
+        assert api_result["tool_use_id"] == "t1"
+        assert "Skill \"my-skill\" completed (forked execution)" in api_result["content"]
+        assert "the sub-agent's final text" in api_result["content"]
+
+    def test_inline_branch_returns_launching_envelope(self):
+        # Counterpart: inline status renders the "Launching skill: X" form.
+        output = {"commandName": "my-skill"}
+        api_result = _skill_map_result_to_api(output, tool_use_id="t1")
+        assert "Launching skill: my-skill" == api_result["content"]
+
+
+# ---------------------------------------------------------------------------
+# Runner contract
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerContract:
+    @pytest.mark.asyncio
+    async def test_no_runner_returns_error_with_clear_message(self, tmp_path):
+        # When forked_skill_runner is None, the fork branch returns an
+        # is_error=True ToolResult with a message that says what's wrong.
+        # Skill authors should not see a silent degradation-to-inline.
+        skills_dir = tmp_path / "skills"
+        _write_skill(skills_dir, name="forky2", fork=True)
+
+        ctx = _MockContext(
+            hook_config_manager=_empty_config_manager(),
+            forked_skill_runner=None,  # explicit
+        )
+
+        with patch.dict(os.environ, {"CLAWCODEX_SKILLS_DIR": str(skills_dir)}):
+            result = await SkillTool.call({"skill": "forky2"}, ctx)
+
+        assert result.is_error is True
+        assert result.output["status"] == "forked"
+        assert "forked_skill_runner" in result.output["error"]
+
+    @pytest.mark.asyncio
+    async def test_runner_exception_surfaced(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        _write_skill(skills_dir, name="boom", fork=True)
+
+        async def failing_runner(**kwargs):
+            raise RuntimeError("simulated forked-skill failure")
+
+        ctx = _MockContext(
+            hook_config_manager=_empty_config_manager(),
+            forked_skill_runner=failing_runner,
+        )
+
+        with patch.dict(os.environ, {"CLAWCODEX_SKILLS_DIR": str(skills_dir)}):
+            result = await SkillTool.call({"skill": "boom"}, ctx)
+
+        assert result.is_error is True
+        assert result.output["status"] == "forked"
+        assert "simulated forked-skill failure" in result.output["error"]
+
+    @pytest.mark.asyncio
+    async def test_runner_receives_skill_parameters(self, tmp_path):
+        # The runner is supposed to use the skill's allowed_tools / model /
+        # effort to configure the sub-agent. Verify they're passed through.
+        skills_dir = tmp_path / "skills"
+        _write_skill(
+            skills_dir, name="paramed", fork=True,
+            extra_frontmatter="model: opus\nallowed-tools: [Bash, Read]\neffort: high",
+        )
+
+        captured = {}
+
+        async def stub_runner(*, prompt, allowed_tools, model, effort, parent_context):
+            captured["allowed_tools"] = allowed_tools
+            captured["model"] = model
+            captured["effort"] = effort
+            return ""
+
+        ctx = _MockContext(
+            hook_config_manager=_empty_config_manager(),
+            forked_skill_runner=stub_runner,
+        )
+
+        with patch.dict(os.environ, {"CLAWCODEX_SKILLS_DIR": str(skills_dir)}):
+            await SkillTool.call({"skill": "paramed"}, ctx)
+
+        assert captured["model"] == "opus"
+        assert captured["allowed_tools"] == ["Bash", "Read"]
+        assert captured["effort"] == "high"
+
+
+# ---------------------------------------------------------------------------
+# Forked-skill hook registration goes through register_frontmatter_hooks
+# (B1: Stop→SubagentStop conversion path)
+# ---------------------------------------------------------------------------
+
+
+class TestForkedSkillHookRegistration:
+    @pytest.mark.asyncio
+    async def test_forked_skill_with_stop_hook_converts_to_subagentstop(self, tmp_path):
+        # Forked skill declaring a Stop hook → after registration, hook
+        # lives under SubagentStop (NOT Stop). This is the B1-resolved
+        # pathway: forked skills are sub-agents, so their Stop hooks
+        # need to fire on SubagentStop.
+        skills_dir = tmp_path / "skills"
+        skill_dir = skills_dir / "fork-with-stop"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: fork-with-stop\n"
+            "description: forked skill with Stop hook\n"
+            "context: fork\n"
+            "hooks:\n"
+            "  Stop:\n"
+            "    - matcher: \"\"\n"
+            "      hooks:\n"
+            "        - type: command\n"
+            "          command: echo cleanup-on-stop\n"
+            "---\n\nbody\n"
+        )
+
+        async def stub_runner(**kwargs):
+            return "result"
+
+        registry = SessionHookRegistry()
+        ctx = _MockContext(
+            hook_config_manager=_empty_config_manager(),
+            session_hook_registry=registry,
+            session_id="s-fork",
+            forked_skill_runner=stub_runner,
+        )
+
+        with patch.dict(os.environ, {"CLAWCODEX_SKILLS_DIR": str(skills_dir)}):
+            result = await SkillTool.call({"skill": "fork-with-stop"}, ctx)
+
+        assert result.is_error is False
+
+        # Hook landed under SubagentStop, NOT Stop. This is the
+        # forked-skill / register_frontmatter_hooks(is_agent=True) path.
+        sub_hooks = await get_session_hooks(
+            registry=registry, session_id="s-fork", event="SubagentStop",
+        )
+        assert len(sub_hooks) == 1
+        assert sub_hooks[0].config.command == "echo cleanup-on-stop"
+
+        # And NOT under Stop.
+        stop_hooks = await get_session_hooks(
+            registry=registry, session_id="s-fork", event="Stop",
+        )
+        assert stop_hooks == []

--- a/tests/test_skill_hook_registration_production_path.py
+++ b/tests/test_skill_hook_registration_production_path.py
@@ -121,22 +121,21 @@ class TestSkillHookRegistrationProductionPath:
         )
         assert before == []
 
-        # 4. Drive the production entry point: SkillTool.call. Note this
-        #    is a SYNC call returning a ToolResult immediately. The hook
-        #    registration is fire-and-forget via loop.create_task.
+        # 4. Drive the production entry point: SkillTool.call. After
+        #    Phase-5 / WI-5.1 / I3 this is async — registration awaits
+        #    directly inside ``_run_markdown_skill`` rather than going
+        #    through the Phase-3 fire-and-forget bridge. By the time
+        #    ``SkillTool.call`` returns, registration has already landed.
         with patch.dict(os.environ, {"CLAWCODEX_SKILLS_DIR": str(skills_dir)}):
-            result = SkillTool.call({"skill": "audit-skill"}, ctx)
+            result = await SkillTool.call({"skill": "audit-skill"}, ctx)
 
-        # The sync return: ToolResult shape (skill rendered successfully).
+        # The async return: ToolResult shape (skill rendered successfully).
         assert result.is_error is False
         assert result.output["commandName"] == "audit-skill"
 
-        # 5. Yield once to let the loop.create_task'd registration land.
-        #    This is the timing pin: ONE await boundary between SkillTool.call
-        #    return and the registration being visible. If the bridge is
-        #    broken (e.g., asyncio.run inside a running loop, or registration
-        #    silently dropped), this test fails.
-        await asyncio.sleep(0)
+        # 5. (Phase-5 update) Registration is awaited inline before
+        #    ``SkillTool.call`` returns; no asyncio.sleep(0) needed.
+        #    The fire-and-forget bridge from Phase 3 is gone.
 
         # 6. Registration is now visible.
         after = await get_session_hooks(
@@ -203,10 +202,9 @@ class TestSkillHookRegistrationProductionPath:
         )
 
         with patch.dict(os.environ, {"CLAWCODEX_SKILLS_DIR": str(skills_dir)}):
-            result = SkillTool.call({"skill": "plain-skill"}, ctx)
+            result = await SkillTool.call({"skill": "plain-skill"}, ctx)
         assert result.is_error is False
 
-        await asyncio.sleep(0)
         # Registry stays empty across all events.
         for ev in ("PreToolUse", "PostToolUse", "Stop"):
             entries = await get_session_hooks(

--- a/tests/test_skills_bundled_catalogue.py
+++ b/tests/test_skills_bundled_catalogue.py
@@ -12,6 +12,7 @@ Acceptance criteria:
 
 from __future__ import annotations
 
+import asyncio  # Phase-5: SkillTool.call is async (I3 migration)
 import os
 import tempfile
 import unittest
@@ -89,13 +90,13 @@ class TestSimplifySkill(unittest.TestCase):
     def test_simplify_returns_phase1_marker(self) -> None:
         # AC#2
         ctx = ToolContext(workspace_root=self.root)
-        out = SkillTool.call({"skill": "simplify"}, ctx).output
+        out = asyncio.run(SkillTool.call({"skill": "simplify"}, ctx)).output
         self.assertTrue(out["success"])
         self.assertIn("Phase 1: Identify Changes", out["prompt"])
 
     def test_simplify_appends_args(self) -> None:
         ctx = ToolContext(workspace_root=self.root)
-        out = SkillTool.call({"skill": "simplify", "args": "look at /auth"}, ctx).output
+        out = asyncio.run(SkillTool.call({"skill": "simplify", "args": "look at /auth"}, ctx)).output
         self.assertIn("Additional Focus", out["prompt"])
         self.assertIn("look at /auth", out["prompt"])
 
@@ -154,7 +155,7 @@ class TestLoopSkillEndToEnd(unittest.TestCase):
     def test_loop_5m_hello_fixed_prompt_branch(self) -> None:
         # AC#3
         ctx = ToolContext(workspace_root=self.root)
-        out = SkillTool.call({"skill": "loop", "args": "5m hello"}, ctx).output
+        out = asyncio.run(SkillTool.call({"skill": "loop", "args": "5m hello"}, ctx)).output
         self.assertTrue(out["success"])
         prompt = out["prompt"]
         self.assertIn("fixed recurring interval", prompt)
@@ -166,7 +167,7 @@ class TestLoopSkillEndToEnd(unittest.TestCase):
     def test_loop_empty_args_dynamic_branch(self) -> None:
         # AC#4
         ctx = ToolContext(workspace_root=self.root)
-        out = SkillTool.call({"skill": "loop"}, ctx).output
+        out = asyncio.run(SkillTool.call({"skill": "loop"}, ctx)).output
         self.assertTrue(out["success"])
         prompt = out["prompt"]
         self.assertIn("dynamic rescheduling", prompt)
@@ -191,7 +192,7 @@ class TestDebugSkill(unittest.TestCase):
             {"CLAUDE_CODE_DEBUG_LOG_PATH": str(nonexistent)},
         ):
             ctx = ToolContext(workspace_root=self.root)
-            out = SkillTool.call({"skill": "debug"}, ctx).output
+            out = asyncio.run(SkillTool.call({"skill": "debug"}, ctx)).output
         self.assertTrue(out["success"])
         self.assertIn(str(nonexistent), out["prompt"])
         # The "no debug log exists yet" hint must be in the body.
@@ -202,16 +203,16 @@ class TestDebugSkill(unittest.TestCase):
         log.write_text("[INFO] hi\n[ERROR] crash\n")
         with patch.dict(os.environ, {"CLAUDE_CODE_DEBUG_LOG_PATH": str(log)}):
             ctx = ToolContext(workspace_root=self.root)
-            out = SkillTool.call({"skill": "debug"}, ctx).output
+            out = asyncio.run(SkillTool.call({"skill": "debug"}, ctx)).output
         self.assertTrue(out["success"])
         self.assertIn(str(log), out["prompt"])
         self.assertIn("[ERROR] crash", out["prompt"])
 
     def test_debug_prompt_includes_user_issue(self) -> None:
         ctx = ToolContext(workspace_root=self.root)
-        out = SkillTool.call(
+        out = asyncio.run(SkillTool.call(
             {"skill": "debug", "args": "auth keeps failing"}, ctx
-        ).output
+        )).output
         self.assertIn("auth keeps failing", out["prompt"])
 
 
@@ -227,19 +228,19 @@ class TestStuckAndVerifySkills(unittest.TestCase):
 
     def test_stuck_renders(self) -> None:
         ctx = ToolContext(workspace_root=self.root)
-        out = SkillTool.call({"skill": "stuck"}, ctx).output
+        out = asyncio.run(SkillTool.call({"skill": "stuck"}, ctx)).output
         self.assertTrue(out["success"])
         self.assertIn("Reset and Re-Approach", out["prompt"])
 
     def test_stuck_with_args_appends_user_context(self) -> None:
         ctx = ToolContext(workspace_root=self.root)
-        out = SkillTool.call({"skill": "stuck", "args": "tests fail"}, ctx).output
+        out = asyncio.run(SkillTool.call({"skill": "stuck", "args": "tests fail"}, ctx)).output
         self.assertIn("tests fail", out["prompt"])
         self.assertIn("User Context", out["prompt"])
 
     def test_verify_content_renders(self) -> None:
         ctx = ToolContext(workspace_root=self.root)
-        out = SkillTool.call({"skill": "verify-content"}, ctx).output
+        out = asyncio.run(SkillTool.call({"skill": "verify-content"}, ctx)).output
         self.assertTrue(out["success"])
         self.assertIn("Verify Recent Edits Match Intent", out["prompt"])
 

--- a/tests/test_skills_dedup_and_paths.py
+++ b/tests/test_skills_dedup_and_paths.py
@@ -399,7 +399,8 @@ class TestActivatedConditionalIsInvokableViaSkillTool(unittest.TestCase):
         # `get_all_skills` must splice `_dynamic_skills` into the
         # registry so the lookup hits.
         ctx = ToolContext(workspace_root=self._project)
-        result = SkillTool.call({"skill": "lint-py"}, ctx)
+        import asyncio  # Phase-5: SkillTool.call is async (I3 migration)
+        result = asyncio.run(SkillTool.call({"skill": "lint-py"}, ctx))
         self.assertFalse(
             result.is_error,
             f"SkillTool returned error after activation: {result.output}",

--- a/tests/test_skills_e2e.py
+++ b/tests/test_skills_e2e.py
@@ -123,13 +123,13 @@ def project_with_fixtures(tmp_path: Path, isolated_home: Path) -> Path:
 # ======================================================================
 
 
-def test_commit_helper_renders_all_substitutions(
+async def test_commit_helper_renders_all_substitutions(
     project_with_fixtures: Path,
 ) -> None:
     ctx = ToolContext(workspace_root=project_with_fixtures)
     ctx.session_id = "S-e2e-001"
 
-    result = SkillTool.call(
+    result = await SkillTool.call(
         {"skill": "commit-helper", "args": "feat"},
         ctx,
     )
@@ -172,7 +172,7 @@ def test_commit_helper_renders_all_substitutions(
 # ======================================================================
 
 
-def test_frontend_add_component_namespaced_invocation(
+async def test_frontend_add_component_namespaced_invocation(
     project_with_fixtures: Path,
 ) -> None:
     # Listing first — confirms the namespace-construction logic.
@@ -189,7 +189,7 @@ def test_frontend_add_component_namespaced_invocation(
 
     # Invoke through SkillTool by the namespaced name.
     ctx = ToolContext(workspace_root=project_with_fixtures)
-    result = SkillTool.call(
+    result = await SkillTool.call(
         {"skill": "frontend:add-component", "args": "Button"},
         ctx,
     )
@@ -254,7 +254,7 @@ def test_lint_py_not_invokable_until_activated(
     )
 
 
-def test_lint_py_after_activation_runs_shell_block_through_skilltool(
+async def test_lint_py_after_activation_runs_shell_block_through_skilltool(
     project_with_fixtures: Path,
 ) -> None:
     """Once activated, lint-py's `!`pwd`` shell block must execute
@@ -275,7 +275,7 @@ def test_lint_py_after_activation_runs_shell_block_through_skilltool(
     )
 
     ctx = ToolContext(workspace_root=project_with_fixtures)
-    result = SkillTool.call({"skill": "lint-py"}, ctx)
+    result = await SkillTool.call({"skill": "lint-py"}, ctx)
 
     out = result.output
     assert out["success"] is True, f"lint-py invocation failed: {out}"
@@ -301,7 +301,7 @@ def test_lint_py_after_activation_runs_shell_block_through_skilltool(
 # ======================================================================
 
 
-def test_simplify_bundled_skill_invokable_through_skilltool(
+async def test_simplify_bundled_skill_invokable_through_skilltool(
     project_with_fixtures: Path,
 ) -> None:
     # DEV-5: init orchestrator registers the bundled-skill catalogue.
@@ -318,7 +318,7 @@ def test_simplify_bundled_skill_invokable_through_skilltool(
     # Invoke through SkillTool — exercises the bundled `get_prompt_for_command`
     # branch in `_run_markdown_skill`.
     ctx = ToolContext(workspace_root=project_with_fixtures)
-    result = SkillTool.call(
+    result = await SkillTool.call(
         {"skill": "simplify", "args": "focus on caching"},
         ctx,
     )

--- a/tests/test_skills_runtime_substitution.py
+++ b/tests/test_skills_runtime_substitution.py
@@ -7,6 +7,7 @@ formatting (failures embed inline rather than crash the SkillTool).
 
 from __future__ import annotations
 
+import asyncio  # Phase-5: SkillTool.call is async (I3 migration)
 import os
 import tempfile
 import unittest
@@ -371,7 +372,7 @@ class TestSkillToolRuntimeIntegration(unittest.TestCase):
             directory=skills_dir, name="hello", description="say hi", body="Hi!",
         )
         ctx = ToolContext(workspace_root=self.root)
-        out = SkillTool.call({"skill": "hello"}, ctx).output
+        out = asyncio.run(SkillTool.call({"skill": "hello"}, ctx)).output
         self.assertTrue(out["success"])
         self.assertTrue(
             out["prompt"].startswith("Base directory for this skill:"),
@@ -390,7 +391,7 @@ class TestSkillToolRuntimeIntegration(unittest.TestCase):
             body="DIR=${CLAUDE_SKILL_DIR}\nSID=${CLAUDE_SESSION_ID}",
         )
         ctx = ToolContext(workspace_root=self.root, session_id="my-session-42")
-        out = SkillTool.call({"skill": "echo"}, ctx).output
+        out = asyncio.run(SkillTool.call({"skill": "echo"}, ctx)).output
         self.assertTrue(out["success"])
         self.assertIn(f"DIR={skills_dir / 'echo'}", out["prompt"])
         self.assertIn("SID=my-session-42", out["prompt"])
@@ -405,7 +406,7 @@ class TestSkillToolRuntimeIntegration(unittest.TestCase):
             )
         )
         ctx = ToolContext(workspace_root=self.root)
-        out = SkillTool.call({"skill": "b1", "args": "x"}, ctx).output
+        out = asyncio.run(SkillTool.call({"skill": "b1", "args": "x"}, ctx)).output
         self.assertTrue(out["success"])
         self.assertNotIn("Base directory for this skill", out["prompt"])
         self.assertIn("BUNDLED-PROMPT:x", out["prompt"])
@@ -418,7 +419,7 @@ class TestSkillToolRuntimeIntegration(unittest.TestCase):
             arguments=["name"], body="Hello $name from $1",
         )
         ctx = ToolContext(workspace_root=self.root)
-        out = SkillTool.call({"skill": "greet", "args": "alice town"}, ctx).output
+        out = asyncio.run(SkillTool.call({"skill": "greet", "args": "alice town"}, ctx)).output
         self.assertTrue(out["success"])
         self.assertTrue(out["prompt"].startswith("Base directory for this skill"))
         self.assertIn("Hello alice from town", out["prompt"])

--- a/tests/test_skills_shell_exec.py
+++ b/tests/test_skills_shell_exec.py
@@ -294,7 +294,7 @@ def test_mcp_skill_renderer_does_not_call_shell_executor() -> None:
     assert "!`whoami`" in out
 
 
-def test_mcp_skill_through_skilltool_never_calls_bash(
+async def test_mcp_skill_through_skilltool_never_calls_bash(
     tmp_path: Path, isolated_home: Path
 ) -> None:
     """End-to-end version of the MCP-skip security boundary.
@@ -332,7 +332,7 @@ def test_mcp_skill_through_skilltool_never_calls_bash(
     with mock.patch(
         "src.skills.loader.get_all_skills", lambda **_: None
     ), mock.patch("src.tool_system.tools.bash.BashTool.call") as bash_call:
-        result = SkillTool.call({"skill": "evil-mcp"}, ctx)
+        result = await SkillTool.call({"skill": "evil-mcp"}, ctx)
 
     assert bash_call.call_count == 0, (
         "SECURITY REGRESSION: SkillTool invoked BashTool for an "

--- a/tests/test_skills_substitutions.py
+++ b/tests/test_skills_substitutions.py
@@ -219,7 +219,7 @@ def test_render_named_argument_substitution_works_after_prepend() -> None:
 # ======================================================================
 
 
-def test_skilltool_invocation_substitutes_all_placeholders(
+async def test_skilltool_invocation_substitutes_all_placeholders(
     tmp_path: Path, isolated_home: Path
 ) -> None:
     project = tmp_path / "proj"
@@ -236,7 +236,7 @@ def test_skilltool_invocation_substitutes_all_placeholders(
     ctx = ToolContext(workspace_root=project)
     ctx.session_id = "S-12345"
 
-    result = SkillTool.call({"skill": "showctx", "args": "ada"}, ctx)
+    result = await SkillTool.call({"skill": "showctx", "args": "ada"}, ctx)
     out = result.output
     assert out["success"] is True
     prompt = out["prompt"]
@@ -253,7 +253,7 @@ def test_skilltool_invocation_substitutes_all_placeholders(
     assert "${CLAUDE_SESSION_ID}" not in prompt
 
 
-def test_skilltool_unknown_session_id_renders_empty(
+async def test_skilltool_unknown_session_id_renders_empty(
     tmp_path: Path, isolated_home: Path
 ) -> None:
     project = tmp_path / "proj"
@@ -266,12 +266,12 @@ def test_skilltool_unknown_session_id_renders_empty(
     # Default ToolContext.session_id is None.
     assert ctx.session_id is None
 
-    result = SkillTool.call({"skill": "sess"}, ctx)
+    result = await SkillTool.call({"skill": "sess"}, ctx)
     prompt = result.output["prompt"]
     assert "session=[]" in prompt
 
 
-def test_bundled_skill_invocation_does_not_get_base_dir_header(
+async def test_bundled_skill_invocation_does_not_get_base_dir_header(
     tmp_path: Path, isolated_home: Path
 ) -> None:
     register_bundled_skill(
@@ -284,7 +284,7 @@ def test_bundled_skill_invocation_does_not_get_base_dir_header(
     project = tmp_path / "proj"
     project.mkdir()
     ctx = ToolContext(workspace_root=project)
-    result = SkillTool.call({"skill": "bcheck", "args": "x"}, ctx)
+    result = await SkillTool.call({"skill": "bcheck", "args": "x"}, ctx)
     prompt = result.output["prompt"]
     # Bundled skills route through their own get_prompt_for_command
     # callable; the header (which is render_skill_prompt's job) must

--- a/tests/test_skills_system.py
+++ b/tests/test_skills_system.py
@@ -81,7 +81,10 @@ class TestSkillUse(SkillSystemTests):
         )
         ctx = ToolContext(workspace_root=self.root)
         with patch.dict(os.environ, {"CLAWCODEX_SKILLS_DIR": str(skills_dir)}):
-            out = SkillTool.call({"skill": "hello", "args": 'bob "the builder"'}, ctx).output
+            import asyncio  # Phase-5: SkillTool.call is async (I3 migration)
+            out = asyncio.run(
+                SkillTool.call({"skill": "hello", "args": 'bob "the builder"'}, ctx)
+            ).output
             self.assertTrue(out["success"])
             self.assertIn("Hello bob (bob)", out["prompt"])
             self.assertIn('bob "the builder"', out["prompt"])

--- a/tests/test_skills_unified.py
+++ b/tests/test_skills_unified.py
@@ -85,7 +85,7 @@ def _write_skill(path: Path, body: str) -> None:
 # ======================================================================
 
 
-def test_flat_project_skill_invokable_via_skilltool(
+async def test_flat_project_skill_invokable_via_skilltool(
     tmp_path: Path, isolated_home: Path
 ) -> None:
     project = tmp_path / "proj"
@@ -95,7 +95,7 @@ def test_flat_project_skill_invokable_via_skilltool(
     )
 
     ctx = ToolContext(workspace_root=project)
-    result = SkillTool.call({"skill": "foo"}, ctx)
+    result = await SkillTool.call({"skill": "foo"}, ctx)
     out = result.output
     assert out["success"] is True, f"expected success, got: {out}"
     assert out["commandName"] == "foo"
@@ -109,7 +109,7 @@ def test_flat_project_skill_invokable_via_skilltool(
 # ======================================================================
 
 
-def test_nested_namespace_skill_invokable_as_colon_form(
+async def test_nested_namespace_skill_invokable_as_colon_form(
     tmp_path: Path, isolated_home: Path
 ) -> None:
     project = tmp_path / "proj"
@@ -119,7 +119,7 @@ def test_nested_namespace_skill_invokable_as_colon_form(
     )
 
     ctx = ToolContext(workspace_root=project)
-    result = SkillTool.call({"skill": "git:commit"}, ctx)
+    result = await SkillTool.call({"skill": "git:commit"}, ctx)
     out = result.output
     assert out["success"] is True, (
         "nested-namespace lookup is the previously-broken case from "
@@ -155,7 +155,7 @@ def test_nested_namespace_appears_in_get_all_skills(
 # ======================================================================
 
 
-def test_bundled_skill_discoverable_through_skilltool(
+async def test_bundled_skill_discoverable_through_skilltool(
     tmp_path: Path, isolated_home: Path
 ) -> None:
     register_bundled_skill(
@@ -169,7 +169,7 @@ def test_bundled_skill_discoverable_through_skilltool(
     project = tmp_path / "proj"
     project.mkdir()
     ctx = ToolContext(workspace_root=project)
-    result = SkillTool.call({"skill": "bundled-thing", "args": "hello"}, ctx)
+    result = await SkillTool.call({"skill": "bundled-thing", "args": "hello"}, ctx)
     out = result.output
     assert out["success"] is True
     assert out["commandName"] == "bundled-thing"
@@ -211,7 +211,7 @@ def test_get_all_skills_returns_union_of_bundled_and_disk(
 # ======================================================================
 
 
-def test_env_var_user_skill_dir_is_reachable_via_skilltool(
+async def test_env_var_user_skill_dir_is_reachable_via_skilltool(
     tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     user_skills = tmp_path / "extra_user_skills"
@@ -224,7 +224,7 @@ def test_env_var_user_skill_dir_is_reachable_via_skilltool(
     project = tmp_path / "proj"
     project.mkdir()
     ctx = ToolContext(workspace_root=project)
-    result = SkillTool.call({"skill": "envskill"}, ctx)
+    result = await SkillTool.call({"skill": "envskill"}, ctx)
     out = result.output
     assert out["success"] is True
     assert "body-from-env" in out["prompt"]

--- a/tests/test_tool_system_tools.py
+++ b/tests/test_tool_system_tools.py
@@ -469,7 +469,13 @@ class TestSkillTool(ToolSystemTests):
             arguments=["name"],
         )
         with patch.dict(os.environ, {"CLAWCODEX_SKILLS_DIR": str(skills_dir)}):
-            out = SkillTool.call({"skill": "hello", "args": "bob"}, self.ctx).output
+            # Phase-5: SkillTool.call is async; unittest.TestCase isn't
+            # auto-asyncio under pytest-asyncio's auto mode, so we
+            # bridge with asyncio.run.
+            import asyncio
+            out = asyncio.run(
+                SkillTool.call({"skill": "hello", "args": "bob"}, self.ctx)
+            ).output
             self.assertTrue(out["success"])
             self.assertIn("Hello bob!", out["prompt"])
             self.assertEqual(out["loadedFrom"], "user")
@@ -482,7 +488,12 @@ class TestSkillTool(ToolSystemTests):
             encoding="utf-8",
         )
         with patch.dict(os.environ, {"CLAWCODEX_SKILLS_DIR": str(skills_dir)}):
-            out = SkillTool.call({"name": "legacy", "input": {"name": "bob"}}, self.ctx).output
+            # Phase-5: legacy .py path stays sync inside _skill_call,
+            # but _skill_call itself is async — still need asyncio.run.
+            import asyncio
+            out = asyncio.run(
+                SkillTool.call({"name": "legacy", "input": {"name": "bob"}}, self.ctx)
+            ).output
             self.assertEqual(out["output"], "hi bob")
 
 


### PR DESCRIPTION
## Summary
Phase 5 of ch12 — `context: 'fork'` skill execution and the I3 async migration. Plus D3 (production wiring of `forked_skill_runner`) and D4 (hook registration ordering) follow-up fixes that close gap #8 functionally.

## What's new in this phase (vs Phase 4)
- New `src/tool_system/tools/skill_fork.py` with `execute_forked_skill`. Renders skill prompt, drives sub-agent via `ToolContext.forked_skill_runner` callable. Three-tier error surface (no runner / runner raises / runner returns).
- Hook registration for forked skills uses `register_frontmatter_hooks(is_agent=True)` for B1 Stop→SubagentStop conversion (forked skills ARE sub-agents for hook routing).
- I3 full async migration: `_skill_call` and `_run_markdown_skill` are now `async def`. Phase-3 fire-and-forget bridge `_schedule_skill_hook_registration` removed. `register_skill_hooks` awaited directly.
- Skill model field correction: `context` (not `execution_context` as plan said).
- 200 skill tests migrated: free-function pytest → async; unittest.TestCase methods wrapped in `asyncio.run(...)`.
- **D3 (option 1):** new `make_forked_skill_runner(provider, tool_registry)` factory + `wire_forked_skill_runner(...)` bootstrap helper, wired from 4 sites (tui/headless/repl/subagent_context). Bonus catch: subagent context inheritance fixed for `hook_config_manager`/`workspace_trusted`/`session_hook_registry`/`session_id`.
- **D4 (option 1):** hook registration moved BEFORE runner; rollback on exception via `try/except` + `remove_session_hook`. Firing-semantic test added. Chapter intent (skill author's `Stop` hook fires on the forked skill's own stop) now realized.
- 8 + 7 new tests for Phase 5 + D3/D4 follow-ups.

## Test plan
- [ ] Phase 5 + follow-up suites → 8 + 7 = 15/15
- [ ] All hook + skill tests → 310/310
- [ ] Chapter examples #1 and #2 stay E2E green

🤖 Generated with [Claude Code](https://claude.com/claude-code)