### PR TITLE
feat(ch12): phase 6 — hook event emission stream

### DIFF
--- a/src/hooks/events.py
+++ b/src/hooks/events.py
@@ -1,0 +1,226 @@
+"""Hook event emission stream.
+
+Phase-6 / WI-6.1. Mirrors TS ``typescript/src/utils/hooks/hookEvents.ts``.
+
+Subscribers (UI / SDK / telemetry) register handlers that receive
+notifications when hooks fire. The chapter §"Hook Event Emission" calls
+this out as the integration surface for "hook running" spinners,
+permission-decision attribution UIs, and structured telemetry pipes.
+
+Emission seams (post-Phase 4):
+
+  * ``emit_hook_started`` — fired before each hook executes (sub-process
+    spawn, HTTP POST, LLM call). Lets subscribers show a per-hook
+    spinner with the command/source.
+  * ``emit_hook_response`` — fired after each hook returns. Carries the
+    hook's exit code, duration, and ``blocking_error`` if any. Pairs
+    with ``emit_hook_started`` for matched start/stop bracketing.
+  * ``emit_hook_aggregated`` — fired ONCE per ``_run_hooks_for_event``
+    invocation, after Phase-4 aggregation. Carries the
+    ``AggregatedHookResult`` so subscribers see the final decision +
+    full ``contributing_reasons`` attribution without re-deriving from
+    individual responses. New in Phase 6.
+
+**Error isolation contract (chapter requirement).** A subscriber that
+raises must NOT break the executor or other subscribers. Each handler is
+called inside a try/except; failures are logged at WARNING and dispatch
+continues to the next subscriber.
+
+**Concurrency.** Subscriber state is module-level. Adds and removes are
+brief sync mutations under a ``threading.Lock`` (the executor is async
+but emits are synchronous-from-the-emitter's-perspective; subscribers
+wishing to do async work create their own task internally). The lock
+is short-held — only the list copy / append / remove. Dispatch iterates
+a snapshot of the handler list, so a handler can deregister itself
+safely.
+
+**Idempotent unregister.** ``register_hook_event_handler`` returns a
+deregister function. Calling it twice is a no-op; the second call
+returns without error. Tests pin this property because subscribers
+typically wrap registration in context managers and want exception-safe
+cleanup.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Callable, Literal
+
+from .hook_types import HookEvent, HookSource, HookType
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Subscriber API
+# ---------------------------------------------------------------------------
+
+# Handlers receive a dict-shaped payload. Using a dict (rather than typed
+# event objects) keeps the surface flexible for SDK consumers that may
+# want to forward payloads as-is over a wire protocol. The ``type`` key
+# is the discriminator: ``hook_started`` / ``hook_response`` /
+# ``hook_aggregated``.
+HookEventHandler = Callable[[dict[str, Any]], None]
+
+
+_handlers_lock = threading.Lock()
+_handlers: list[HookEventHandler] = []
+_enabled: bool = True
+
+
+def register_hook_event_handler(handler: HookEventHandler) -> Callable[[], None]:
+    """Register a subscriber. Returns an idempotent deregister function.
+
+    The returned function is safe to call multiple times; a second call
+    is a no-op. This matches the "context-manager-cleanup" pattern most
+    subscribers use.
+    """
+    with _handlers_lock:
+        _handlers.append(handler)
+
+    deregistered = {"done": False}
+
+    def _deregister() -> None:
+        if deregistered["done"]:
+            return
+        deregistered["done"] = True
+        with _handlers_lock:
+            try:
+                _handlers.remove(handler)
+            except ValueError:
+                # Already removed (e.g., via clear_hook_event_state).
+                pass
+
+    return _deregister
+
+
+def set_all_hook_events_enabled(enabled: bool) -> None:
+    """Globally enable/disable emission. Useful for tests that want to
+    silence the stream without unregistering individual subscribers,
+    and for runtime configuration (e.g., disabling for performance-
+    sensitive code paths).
+    """
+    global _enabled
+    _enabled = enabled
+
+
+def clear_hook_event_state() -> None:
+    """Remove all subscribers + reset the enabled flag. Test fixtures
+    use this between cases to guarantee isolation.
+    """
+    global _enabled
+    with _handlers_lock:
+        _handlers.clear()
+    _enabled = True
+
+
+def _dispatch(event: dict[str, Any]) -> None:
+    """Fan out one event to all current subscribers.
+
+    Iterates a snapshot of the handler list so a subscriber can
+    deregister itself or others mid-iteration safely. Each handler is
+    called inside a try/except; failures are logged at WARNING and
+    don't break the dispatch loop.
+    """
+    if not _enabled:
+        return
+    # Snapshot under the lock so concurrent register/unregister doesn't
+    # race the iteration. Lock release is fast — we copy the small list,
+    # then iterate without holding it (so subscribers can safely call
+    # register/deregister recursively).
+    with _handlers_lock:
+        snapshot = list(_handlers)
+    for h in snapshot:
+        try:
+            h(event)
+        except Exception:
+            # Subscriber crashes do NOT break the executor or other
+            # subscribers. Logged at WARNING (not exception, to avoid
+            # massive tracebacks for buggy subscribers).
+            logger.warning(
+                "hook event handler raised; continuing", exc_info=True,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Emission API — called from src/hooks/hook_executor.py
+# ---------------------------------------------------------------------------
+
+
+def emit_hook_started(
+    *,
+    hook_id: str,
+    event: HookEvent | str,
+    hook_type: HookType | str = "command",
+    command: str | None = None,
+    source: HookSource | str | None = None,
+    tool_use_id: str = "",
+) -> None:
+    """Fire a ``hook_started`` event before a hook executes.
+
+    Pairs with ``emit_hook_response`` to bracket the hook's run. The
+    ``hook_id`` ties the start to the matching response — typically a
+    composition of (event, command-hash, sequence) so concurrent hooks
+    don't collide.
+    """
+    _dispatch({
+        "type": "hook_started",
+        "hook_id": hook_id,
+        "event": str(event),
+        "hook_type": str(hook_type),
+        "command": command,
+        "source": str(source) if source is not None else None,
+        "tool_use_id": tool_use_id,
+    })
+
+
+def emit_hook_response(
+    *,
+    hook_id: str,
+    event: HookEvent | str,
+    exit_code: int | None,
+    duration_ms: int | None,
+    blocking_error: str | None = None,
+    permission_behavior: str | None = None,
+    command: str | None = None,
+) -> None:
+    """Fire a ``hook_response`` event after a hook returns.
+
+    The ``permission_behavior`` field is per-hook (the hook's own
+    decision), NOT the aggregated decision. Subscribers that want the
+    aggregated decision listen for ``hook_aggregated`` instead.
+    """
+    _dispatch({
+        "type": "hook_response",
+        "hook_id": hook_id,
+        "event": str(event),
+        "exit_code": exit_code,
+        "duration_ms": duration_ms,
+        "blocking_error": blocking_error,
+        "permission_behavior": permission_behavior,
+        "command": command,
+    })
+
+
+def emit_hook_aggregated(
+    *,
+    event: HookEvent | str,
+    aggregated: Any,
+) -> None:
+    """Fire a ``hook_aggregated`` event after Phase-4 aggregation.
+
+    ``aggregated`` is the ``AggregatedHookResult`` from
+    ``src.hooks.aggregation``. Subscribers can read
+    ``contributing_reasons`` for full per-hook attribution without
+    needing to track ``hook_response`` events themselves.
+
+    Fires once per ``_run_hooks_for_event`` invocation that produced at
+    least one result. Skipped when the executor's collected results list
+    is empty (no hooks fired → no aggregation → no event).
+    """
+    _dispatch({
+        "type": "hook_aggregated",
+        "event": str(event),
+        "aggregated": aggregated,
+    })

--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -425,8 +425,30 @@ async def _run_hooks_for_event(
     # for UI feedback, not decision-routing).
     collected_results: list[HookResult] = []
 
-    for entry in entries:
+    # Phase-6 / WI-6.1 — emission stream subscribers see one
+    # ``hook_started`` per hook before execution, one ``hook_response``
+    # after, and one ``hook_aggregated`` at the end. Local import
+    # because ``src.hooks.events`` shouldn't be a hard dep of executors
+    # that don't have subscribers (zero-subscriber path is one
+    # ``_dispatch`` short-circuit on the global enable flag).
+    from src.hooks.events import emit_hook_started, emit_hook_response
+
+    for hook_index, entry in enumerate(entries):
         hook = entry.config
+        # Hook id ties ``hook_started`` to the matching ``hook_response``.
+        # Composition (event, sequence, tool_use_id) ensures uniqueness
+        # across concurrent _run_hooks_for_event calls (each with its own
+        # tool_use_id).
+        hook_event_id = f"{event}:{hook_index}:{tool_use_id}"
+
+        emit_hook_started(
+            hook_id=hook_event_id,
+            event=event,
+            hook_type=hook.type,
+            command=hook.command,
+            source=hook.source,
+            tool_use_id=tool_use_id,
+        )
 
         yield {
             "message": create_progress_message(
@@ -445,6 +467,16 @@ async def _run_hooks_for_event(
         )
 
         collected_results.append(result)
+
+        emit_hook_response(
+            hook_id=hook_event_id,
+            event=event,
+            exit_code=result.exit_code,
+            duration_ms=result.duration_ms,
+            blocking_error=result.blocking_error,
+            permission_behavior=result.permission_behavior,
+            command=hook.command,
+        )
 
         # WI-3.1 — ``once: true`` removal. Fire the entry's on_success
         # callback after a *successful* firing (exit 0, no blocking_error,
@@ -498,7 +530,14 @@ async def _run_hooks_for_event(
     # AggregatedHookResult for telemetry/UI.
     if collected_results:
         from .aggregation import aggregate_hook_results
+        from src.hooks.events import emit_hook_aggregated
         agg = aggregate_hook_results(collected_results)
+
+        # Phase-6 / WI-6.1 — fire the final ``hook_aggregated`` event so
+        # subscribers see the post-aggregation decision + full
+        # ``contributing_reasons`` attribution without re-deriving from
+        # individual ``hook_response`` events.
+        emit_hook_aggregated(event=event, aggregated=agg)
 
         if agg.blocking_error:
             yield {

--- a/tests/test_hook_event_emission.py
+++ b/tests/test_hook_event_emission.py
@@ -1,0 +1,340 @@
+"""Phase-6 / WI-6.1 — hook event emission stream regression tests.
+
+Subscribers (UI / SDK / telemetry) register handlers that receive
+notifications when hooks fire. The chapter §"Hook Event Emission" specifies
+three event types:
+
+  * ``hook_started``    — before each hook executes
+  * ``hook_response``   — after each hook returns (per-hook decision)
+  * ``hook_aggregated`` — once per executor invocation, post-aggregation
+                          (the final decision + contributing_reasons)
+
+Test coverage:
+  * Subscriber registration / deregistration.
+  * Idempotent unregister (calling the deregister fn twice is safe).
+  * Subscriber exception isolation (one handler raising must NOT break
+    the executor or other subscribers).
+  * Ordering: ``hook_started`` precedes the matching ``hook_response``;
+    ``hook_aggregated`` fires AFTER all per-hook responses.
+  * Global enable flag suppresses all events.
+  * ``clear_hook_event_state`` resets between tests.
+  * End-to-end: drive ``_run_hooks_for_event`` with a configured snapshot
+    and observe the full event stream.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.hooks.aggregation import AggregatedHookResult
+from src.hooks.config_manager import HookConfigManager, HookConfigSnapshot
+from src.hooks.events import (
+    clear_hook_event_state,
+    emit_hook_aggregated,
+    emit_hook_response,
+    emit_hook_started,
+    register_hook_event_handler,
+    set_all_hook_events_enabled,
+)
+from src.hooks.hook_executor import _run_hooks_for_event
+from src.hooks.hook_types import HookConfig, HookSource
+from src.hooks.registry import AsyncHookRegistry
+
+
+@dataclass
+class _MockOptions:
+    hooks: dict[str, Any] | None = None
+    tools: list[Any] = field(default_factory=list)
+
+
+@dataclass
+class _MockContext:
+    options: _MockOptions = field(default_factory=_MockOptions)
+    hook_config_manager: Any | None = None
+    workspace_trusted: bool = True
+    abort_controller: Any | None = None
+    session_hook_registry: Any | None = None
+    session_id: str | None = None
+    workspace_root: Path | None = None
+    tool_use_id: str | None = None
+
+
+def _manager_with(hooks: dict[str, list[HookConfig]]) -> HookConfigManager:
+    m = HookConfigManager(registry=AsyncHookRegistry(), settings_path="/dev/null")
+    m._snapshot = HookConfigSnapshot(hooks=hooks, timestamp=0.0, source_path=None)
+    return m
+
+
+@pytest.fixture(autouse=True)
+def _isolate_event_stream():
+    """Reset the module-level subscriber list between tests so one
+    test's leftover handlers don't leak into the next.
+    """
+    clear_hook_event_state()
+    yield
+    clear_hook_event_state()
+
+
+# ---------------------------------------------------------------------------
+# Subscriber registration / deregistration
+# ---------------------------------------------------------------------------
+
+
+class TestSubscription:
+    def test_subscriber_receives_started_event(self):
+        events: list[dict] = []
+        register_hook_event_handler(events.append)
+        emit_hook_started(hook_id="h1", event="PreToolUse", command="x")
+        assert len(events) == 1
+        assert events[0]["type"] == "hook_started"
+        assert events[0]["hook_id"] == "h1"
+
+    def test_subscriber_receives_response_event(self):
+        events: list[dict] = []
+        register_hook_event_handler(events.append)
+        emit_hook_response(
+            hook_id="h1", event="PreToolUse",
+            exit_code=0, duration_ms=42,
+        )
+        assert len(events) == 1
+        assert events[0]["type"] == "hook_response"
+        assert events[0]["exit_code"] == 0
+
+    def test_subscriber_receives_aggregated_event(self):
+        events: list[dict] = []
+        register_hook_event_handler(events.append)
+        agg = AggregatedHookResult(permission_behavior="allow")
+        emit_hook_aggregated(event="PreToolUse", aggregated=agg)
+        assert len(events) == 1
+        assert events[0]["type"] == "hook_aggregated"
+        assert events[0]["aggregated"] is agg
+
+    def test_deregister_stops_delivery(self):
+        events: list[dict] = []
+        deregister = register_hook_event_handler(events.append)
+        emit_hook_started(hook_id="h1", event="PreToolUse")
+        deregister()
+        emit_hook_started(hook_id="h2", event="PreToolUse")
+        # Only h1 was delivered.
+        assert len(events) == 1
+        assert events[0]["hook_id"] == "h1"
+
+    def test_idempotent_deregister(self):
+        events: list[dict] = []
+        deregister = register_hook_event_handler(events.append)
+        deregister()
+        # Second call must NOT raise.
+        deregister()
+        emit_hook_started(hook_id="x", event="PreToolUse")
+        assert events == []
+
+
+# ---------------------------------------------------------------------------
+# Subscriber exception isolation
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionIsolation:
+    def test_handler_exception_does_not_break_dispatch(self):
+        # First handler raises; second handler must STILL be called.
+        events: list[dict] = []
+
+        def crashing_handler(_event):
+            raise RuntimeError("subscriber crash")
+
+        register_hook_event_handler(crashing_handler)
+        register_hook_event_handler(events.append)
+
+        # Dispatch must NOT raise.
+        emit_hook_started(hook_id="h", event="PreToolUse")
+
+        # Second subscriber received the event.
+        assert len(events) == 1
+
+    def test_handler_exception_isolated_per_event(self):
+        # Each event dispatch starts fresh — a crashing handler doesn't
+        # taint the next emit call.
+        crashes = {"count": 0}
+
+        def crashing_handler(_event):
+            crashes["count"] += 1
+            raise ValueError(f"crash #{crashes['count']}")
+
+        register_hook_event_handler(crashing_handler)
+
+        emit_hook_started(hook_id="a", event="PreToolUse")
+        emit_hook_started(hook_id="b", event="PreToolUse")
+        emit_hook_started(hook_id="c", event="PreToolUse")
+
+        # All three emit calls completed (didn't propagate the
+        # ValueError out); the handler was called 3 times.
+        assert crashes["count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Global enable flag
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalEnableFlag:
+    def test_set_enabled_false_suppresses_all(self):
+        events: list[dict] = []
+        register_hook_event_handler(events.append)
+        set_all_hook_events_enabled(False)
+        emit_hook_started(hook_id="x", event="PreToolUse")
+        emit_hook_response(
+            hook_id="x", event="PreToolUse", exit_code=0, duration_ms=1,
+        )
+        assert events == []
+
+    def test_re_enable_resumes_delivery(self):
+        events: list[dict] = []
+        register_hook_event_handler(events.append)
+        set_all_hook_events_enabled(False)
+        emit_hook_started(hook_id="x", event="PreToolUse")
+        set_all_hook_events_enabled(True)
+        emit_hook_started(hook_id="y", event="PreToolUse")
+        assert len(events) == 1
+        assert events[0]["hook_id"] == "y"
+
+
+# ---------------------------------------------------------------------------
+# clear_hook_event_state
+# ---------------------------------------------------------------------------
+
+
+class TestClearState:
+    def test_clear_removes_all_subscribers(self):
+        events: list[dict] = []
+        register_hook_event_handler(events.append)
+        clear_hook_event_state()
+        emit_hook_started(hook_id="x", event="PreToolUse")
+        assert events == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: emission via _run_hooks_for_event
+# ---------------------------------------------------------------------------
+
+
+class TestExecutorEmission:
+    @pytest.mark.asyncio
+    async def test_run_hooks_for_event_emits_started_response_aggregated(
+        self, tmp_path,
+    ):
+        # Driving a real executor invocation produces the full event
+        # sequence: started → response → aggregated.
+        hook = HookConfig(
+            type="command",
+            command="echo emission-test",
+            source=HookSource.USER_SETTINGS,
+        )
+        manager = _manager_with({"PreToolUse": [hook]})
+        ctx = _MockContext(hook_config_manager=manager)
+
+        events: list[dict] = []
+        register_hook_event_handler(events.append)
+
+        async for _ in _run_hooks_for_event(
+            "PreToolUse", "Bash",
+            {"tool_name": "Bash", "tool_use_id": "u1"},
+            ctx,
+        ):
+            pass
+
+        # Filter to the three event types we care about.
+        types = [e["type"] for e in events]
+        assert "hook_started" in types
+        assert "hook_response" in types
+        assert "hook_aggregated" in types
+
+        # Ordering: started precedes the matching response, response
+        # precedes the aggregated. We have ONE hook so the ordering is
+        # easy to assert.
+        started_idx = types.index("hook_started")
+        response_idx = types.index("hook_response")
+        aggregated_idx = types.index("hook_aggregated")
+        assert started_idx < response_idx < aggregated_idx
+
+    @pytest.mark.asyncio
+    async def test_aggregated_event_carries_aggregation_payload(
+        self, tmp_path,
+    ):
+        # The ``hook_aggregated`` payload carries the
+        # AggregatedHookResult so subscribers don't need to track
+        # individual responses to derive the final decision.
+        hook = HookConfig(
+            type="command",
+            command='echo \'{"decision": "allow", "reason": "ok"}\'',
+            source=HookSource.USER_SETTINGS,
+        )
+        manager = _manager_with({"PreToolUse": [hook]})
+        ctx = _MockContext(hook_config_manager=manager)
+
+        events: list[dict] = []
+        register_hook_event_handler(events.append)
+
+        async for _ in _run_hooks_for_event(
+            "PreToolUse", "Bash",
+            {"tool_name": "Bash", "tool_use_id": "u1"},
+            ctx,
+        ):
+            pass
+
+        agg_events = [e for e in events if e["type"] == "hook_aggregated"]
+        assert len(agg_events) == 1
+        agg = agg_events[0]["aggregated"]
+        assert isinstance(agg, AggregatedHookResult)
+        assert agg.permission_behavior == "allow"
+        assert agg.hook_permission_decision_reason == "ok"
+
+    @pytest.mark.asyncio
+    async def test_no_aggregated_event_when_no_hooks_fire(self):
+        # If the snapshot has no hooks for the event, no events fire at
+        # all — no started, no response, no aggregated.
+        manager = _manager_with({})  # empty
+        ctx = _MockContext(hook_config_manager=manager)
+
+        events: list[dict] = []
+        register_hook_event_handler(events.append)
+
+        async for _ in _run_hooks_for_event(
+            "PreToolUse", "Bash",
+            {"tool_name": "Bash"},
+            ctx,
+        ):
+            pass
+
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_subscriber_crash_does_not_break_executor(self):
+        # End-to-end version of TestExceptionIsolation: a handler that
+        # raises must NOT propagate up through the executor.
+        hook = HookConfig(
+            type="command", command="echo x",
+            source=HookSource.USER_SETTINGS,
+        )
+        manager = _manager_with({"PreToolUse": [hook]})
+        ctx = _MockContext(hook_config_manager=manager)
+
+        def crashing(_event):
+            raise RuntimeError("subscriber boom")
+
+        register_hook_event_handler(crashing)
+
+        # Executor must complete without raising.
+        results = []
+        async for item in _run_hooks_for_event(
+            "PreToolUse", "Bash",
+            {"tool_name": "Bash", "tool_use_id": "u1"},
+            ctx,
+        ):
+            results.append(item)
+        # Hook still ran (we got progress + attachment messages).
+        assert len(results) > 0


### PR DESCRIPTION
## Summary
Phase 6 of ch12 — hook event emission stream for SDK / TUI / telemetry consumers. Three event types, idempotent subscriber API, exception-isolated dispatch.

## What's new in this phase (vs Phase 5)
- New `src/hooks/events.py` with three event types:
  - `hook_started` — pre-execution, per-hook
  - `hook_response` — post-execution, per-hook (carries hook's own decision, NOT aggregated)
  - `hook_aggregated` — once per `_run_hooks_for_event` invocation, carries `AggregatedHookResult` with `contributing_reasons`
- Subscriber API: `register_hook_event_handler(handler)` returns idempotent deregister closure. `set_all_hook_events_enabled(False)` short-circuit for sessions without listeners.
- Error isolation: subscriber raising does NOT break executor or other subscribers. Logged at WARNING. Tested at three levels (cross-subscriber, cross-event, end-to-end via executor).
- Concurrency: `threading.Lock` guards subscriber list; dispatch iterates a snapshot so handlers can deregister mid-iteration safely.
- Emission seams wired into `_run_hooks_for_event`:
  - `emit_hook_started` before each `_execute_command_hook`
  - `emit_hook_response` after (per-hook decision)
  - `emit_hook_aggregated` once at the end with `AggregatedHookResult`
- 14 new tests covering subscriber lifecycle, error isolation, ordering, and idempotent unregister.

## Test plan
- [ ] Phase 6 focused suite → 14/14
- [ ] Cross-subscriber + cross-event + end-to-end isolation tests pass
- [ ] Chapter examples #1 and #2 stay E2E green

🤖 Generated with [Claude Code](https://claude.com/claude-code)