### PR TITLE
feat(ch12): phase 9 — callback hook type + lazy JSON + /skills + /hooks

### DIFF
--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -186,42 +186,214 @@ def help_command_call(args: str, context: CommandContext) -> LocalCommandResult:
     )
 
 
-def skills_command_call(args: str, context: CommandContext) -> LocalCommandResult:
+def _build_skills_menu_items(skills: list) -> list[dict[str, Any]]:
+    """Build the structured menu-item list for ``/skills``.
+
+    Phase-9 / WI-9.3 — interactive variant data shape. Each item is a
+    dict with the fields a TUI menu component (or SDK consumer) needs:
+
+      * ``name``: skill identifier (e.g., ``"commit"`` or ``"git:commit"``)
+      * ``description``: one-line description from frontmatter
+      * ``when_to_use``: optional usage guidance from frontmatter
+      * ``source``: the chapter's "loaded_from" tier (``user`` /
+        ``project`` / ``bundled`` / ``mcp``)
+      * ``status``: ``"installed"`` (always — current implementation
+        only surfaces installed skills; ``"available"`` is reserved for
+        a future skill-marketplace integration)
+      * ``has_hooks``: True if the skill declares frontmatter hooks
+        (helpful indicator for users debugging hook firings)
+      * ``context``: ``"inline"`` or ``"fork"`` (forked skills run in
+        their own context window — relevant signal for the menu)
+
+    The structured shape is what TUI components consume; the textual
+    fallback (the existing ``/skills`` rendering) is built on top of
+    the same items so the two views never drift.
     """
-    Handle /skills command - list available skills.
+    items: list[dict[str, Any]] = []
+    for skill in skills:
+        items.append({
+            "name": skill.name,
+            "description": skill.description or "",
+            "when_to_use": skill.when_to_use,
+            "source": getattr(skill, "loaded_from", None) or "unknown",
+            "status": "installed",
+            "has_hooks": bool(getattr(skill, "hooks", None)),
+            "context": getattr(skill, "context", "inline") or "inline",
+        })
+    return items
 
-    Args:
-        args: Command arguments
-        context: Command context
 
-    Returns:
-        LocalCommandResult
+def _format_skills_menu_text(items: list[dict[str, Any]]) -> str:
+    """Textual fallback rendering when no interactive UI is available.
+
+    Mirrors the pre-Phase-9 flat listing but adds the source/context/
+    has_hooks columns for parity with the interactive menu.
+    """
+    if not items:
+        return (
+            "No skills available. Add skills to ~/.clawcodex/skills/ or "
+            "./.clawcodex/skills/."
+        )
+
+    lines = ["Available skills:", ""]
+    for item in items:
+        # Inline indicators for non-default options:
+        #   [F] = forked execution (context: 'fork')
+        #   [H] = declares frontmatter hooks
+        flags = []
+        if item["context"] == "fork":
+            flags.append("F")
+        if item["has_hooks"]:
+            flags.append("H")
+        flag_str = f" [{','.join(flags)}]" if flags else ""
+
+        lines.append(f"  {item['name']}{flag_str}  ({item['source']})")
+        if item["description"]:
+            lines.append(f"      {item['description']}")
+        if item["when_to_use"]:
+            lines.append(f"      When to use: {item['when_to_use']}")
+        lines.append("")
+
+    lines.append("Flags: F=forked-execution, H=declares-frontmatter-hooks")
+    return "\n".join(lines)
+
+
+def skills_command_call(args: str, context: CommandContext) -> LocalCommandResult:
+    """Handle ``/skills`` command.
+
+    Phase-9 / WI-9.3: builds a structured menu-item list (consumable by
+    interactive TUI components) and formats a text fallback for the
+    REPL / non-interactive paths. Both views share the same data
+    so they never drift.
+
+    The structured items are exposed on the result via the
+    ``menu_items`` attribute (when supported by ``LocalCommandResult``)
+    so an interactive caller can render the menu directly. Callers
+    that don't need the structure get the formatted text.
     """
     try:
         from ..skills.loader import get_all_skills
-        # Pass project_root to find skills in project directories
         skills = get_all_skills(project_root=context.cwd or context.workspace_root)
     except Exception:
         skills = []
 
-    if not skills:
+    items = _build_skills_menu_items(skills)
+    text = _format_skills_menu_text(items)
+
+    result = LocalCommandResult(type="text", value=text)
+    # Attach structured data for interactive UI consumers. Setattr is
+    # used because ``LocalCommandResult`` is a fixed dataclass; this
+    # keeps the back-compat text shape while adding optional
+    # structured access.
+    try:
+        setattr(result, "menu_items", items)
+    except (AttributeError, TypeError):
+        # Frozen dataclass — fall back to text only.
+        pass
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Phase-9 / WI-9.4 — /hooks slash command
+# ---------------------------------------------------------------------------
+
+
+def hooks_command_call(args: str, context: CommandContext) -> LocalCommandResult:
+    """Handle ``/hooks`` command — list configured hooks.
+
+    Phase-9 / WI-9.4. Lists hooks from the active session's snapshot,
+    grouped by event then sorted by source priority (the chapter's
+    "userSettings → policySettings → pluginHook" order). Useful for
+    debugging "what's about to fire when I run X."
+
+    Respects the workspace-trust gate: if the workspace isn't trusted,
+    only policy-source hooks are listed (matching the executor's
+    runtime gate behavior).
+    """
+    # The snapshot lives on ToolContext.hook_config_manager; the
+    # CommandContext doesn't carry that directly. Look it up via the
+    # context's tool_context attribute if present, falling back to
+    # an "unconfigured" message.
+    tool_ctx = getattr(context, "tool_context", None)
+    if tool_ctx is None:
         return LocalCommandResult(
             type="text",
-            value="No skills available. Add skills to ~/.clawcodex/skills/ or ./.clawcodex/skills/.",
+            value=(
+                "Hook listing unavailable: no ToolContext attached to the "
+                "command context. (This is a configuration issue in the "
+                "session bootstrap, not a user error.)"
+            ),
         )
 
-    lines = ["Available skills:", ""]
-    for skill in skills:
-        lines.append(f"  {skill.name}")
-        lines.append(f"      {skill.description}")
-        if skill.when_to_use:
-            lines.append(f"      When to use: {skill.when_to_use}")
+    manager = getattr(tool_ctx, "hook_config_manager", None)
+    snapshot = getattr(manager, "snapshot", None) if manager is not None else None
+    if snapshot is None or not snapshot.hooks:
+        return LocalCommandResult(
+            type="text",
+            value=(
+                "No hooks configured. Add hooks to ~/.claude/settings.json, "
+                "your project's .claude/settings.json, or a plugin's "
+                "hooks.json."
+            ),
+        )
+
+    # Trust gate — same logic as the executor's runtime gate.
+    workspace_trusted = getattr(tool_ctx, "workspace_trusted", False)
+
+    lines = ["Configured hooks:"]
+    if not workspace_trusted:
+        lines.append(
+            "  (Workspace untrusted — only policy-source hooks shown; "
+            "trust the workspace to see all hooks.)"
+        )
+    lines.append("")
+
+    for event_name in sorted(snapshot.hooks.keys()):
+        event_hooks = snapshot.hooks[event_name]
+        if not workspace_trusted:
+            event_hooks = [h for h in event_hooks if h.source.is_policy]
+        if not event_hooks:
+            continue
+
+        # Sort by source priority (lower = higher precedence per the
+        # chapter's "Six Hook Sources" table).
+        sorted_hooks = sorted(event_hooks, key=lambda h: h.source.priority)
+
+        lines.append(f"  {event_name}:")
+        for hook in sorted_hooks:
+            descriptor = _describe_hook(hook)
+            lines.append(f"    [{hook.source.value}] {descriptor}")
         lines.append("")
 
-    return LocalCommandResult(
-        type="text",
-        value="\n".join(lines),
-    )
+    return LocalCommandResult(type="text", value="\n".join(lines).rstrip())
+
+
+def _describe_hook(hook: Any) -> str:
+    """Format a HookConfig as a one-line descriptor for the listing."""
+    parts = [f"type={hook.type}"]
+    if hook.matcher:
+        parts.append(f"matcher={hook.matcher!r}")
+    if hook.if_condition:
+        parts.append(f"if={hook.if_condition!r}")
+    if hook.once:
+        parts.append("once")
+    if hook.type == "command" and hook.command:
+        # Truncate long commands so the listing stays readable.
+        cmd = hook.command if len(hook.command) <= 60 else hook.command[:57] + "..."
+        parts.append(f"command={cmd!r}")
+    elif hook.type == "http" and hook.url:
+        parts.append(f"url={hook.url}")
+    elif hook.type == "agent" and hook.agent_instructions:
+        instr = hook.agent_instructions
+        instr = instr if len(instr) <= 50 else instr[:47] + "..."
+        parts.append(f"agent_instructions={instr!r}")
+    elif hook.type == "prompt" and hook.prompt_text:
+        prompt = hook.prompt_text
+        prompt = prompt if len(prompt) <= 50 else prompt[:47] + "..."
+        parts.append(f"prompt_text={prompt!r}")
+    elif hook.type == "callback":
+        parts.append("callback=<programmatic>")
+    return " ".join(parts)
 
 
 def exit_command_call(args: str, context: CommandContext) -> LocalCommandResult:
@@ -589,6 +761,13 @@ SKILLS_COMMAND = LocalCommand(
     supports_non_interactive=True,
 )
 
+HOOKS_COMMAND = LocalCommand(
+    name="hooks",
+    description="List configured hooks (Phase-9 / WI-9.4)",
+    argument_hint="",
+    supports_non_interactive=True,
+)
+
 COST_COMMAND = LocalCommand(
     name="cost",
     description="Show session cost and usage",
@@ -648,6 +827,8 @@ def execute_command_sync(cmd_name: str, args: str, context: CommandContext) -> t
             result = exit_command_call(args, context)
         elif cmd is SKILLS_COMMAND:
             result = skills_command_call(args, context)
+        elif cmd is HOOKS_COMMAND:
+            result = hooks_command_call(args, context)
         elif cmd is COST_COMMAND:
             result = cost_command_call(args, context)
         elif cmd is CONTEXT_COMMAND:
@@ -667,6 +848,7 @@ HELP_COMMAND.set_call(help_command_call)
 CLEAR_COMMAND.set_call(clear_command_call)
 EXIT_COMMAND.set_call(exit_command_call)
 SKILLS_COMMAND.set_call(skills_command_call)
+HOOKS_COMMAND.set_call(hooks_command_call)
 COST_COMMAND.set_call(cost_command_call)
 CONTEXT_COMMAND.set_call(context_command_call)
 COMPACT_COMMAND.set_call(compact_command_call)
@@ -679,6 +861,7 @@ def get_builtin_commands() -> list[Command]:
         CLEAR_COMMAND,
         EXIT_COMMAND,
         SKILLS_COMMAND,
+        HOOKS_COMMAND,
         COST_COMMAND,
         CONTEXT_COMMAND,
         COMPACT_COMMAND,

--- a/src/hooks/events.py
+++ b/src/hooks/events.py
@@ -43,6 +43,7 @@ cleanup.
 
 from __future__ import annotations
 
+import json
 import logging
 import threading
 from typing import Any, Callable, Literal
@@ -115,6 +116,60 @@ def clear_hook_event_state() -> None:
     _enabled = True
 
 
+class LazyJsonPayload(dict):
+    """Phase-9 / WI-9.2 — dict subclass with a memoized ``json``
+    property for subscribers that need a wire-format serialization.
+
+    Two performance properties this wrapper preserves:
+
+      1. **Zero serialization cost when no subscriber wants JSON.**
+         If subscribers all consume the dict directly (the common case
+         for in-process consumers — TUI / SDK callbacks), ``json`` is
+         never called and ``json.dumps`` never runs.
+      2. **Single serialization shared across all subscribers that
+         want JSON.** If three subscribers (telemetry pipe + audit log
+         + remote forwarder) each access ``payload.json``, the
+         serialization happens exactly once — the result is cached on
+         first access.
+
+    Inheriting from ``dict`` keeps full back-compat with subscribers
+    that read fields directly via ``payload["type"]`` /
+    ``payload.get("event")``. The lazy property is opt-in.
+
+    Memoization is thread-safe via ``threading.Lock`` — multiple
+    subscribers accessing ``payload.json`` concurrently will see one
+    serialization pass, not N races. The lock is per-instance (each
+    event has its own); contention is bounded by the number of
+    subscribers requesting JSON for a single event.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Cached JSON; ``None`` is the not-yet-computed sentinel. Empty
+        # string would be a valid payload (empty dict serializes to
+        # ``"{}"`` not ``""``), so ``None`` is unambiguous.
+        self._json_cache: str | None = None
+        self._json_lock = threading.Lock()
+
+    @property
+    def json(self) -> str:
+        """Return the JSON-serialized payload, computing on first
+        access and caching for subsequent calls.
+
+        Subscribers that don't need JSON pay zero serialization cost.
+        Subscribers that DO need JSON pay it exactly once across all
+        consumers of this event.
+        """
+        if self._json_cache is not None:
+            return self._json_cache
+        with self._json_lock:
+            # Double-check after lock acquisition (another thread may
+            # have populated the cache while we waited).
+            if self._json_cache is None:
+                self._json_cache = json.dumps(dict(self), default=str)
+            return self._json_cache
+
+
 def _dispatch(event: dict[str, Any]) -> None:
     """Fan out one event to all current subscribers.
 
@@ -122,9 +177,18 @@ def _dispatch(event: dict[str, Any]) -> None:
     deregister itself or others mid-iteration safely. Each handler is
     called inside a try/except; failures are logged at WARNING and
     don't break the dispatch loop.
+
+    The event is wrapped in a ``LazyJsonPayload`` (Phase-9 / WI-9.2):
+    subscribers can either read fields directly via dict access (zero
+    serialization cost) or request a memoized JSON serialization via
+    ``event.json``. The wrapper is transparent to existing subscribers
+    that treat the event as a plain dict.
     """
     if not _enabled:
         return
+    # Wrap with lazy-JSON memoization. ``LazyJsonPayload`` IS a dict,
+    # so all existing subscribers continue to work unchanged.
+    payload = LazyJsonPayload(event)
     # Snapshot under the lock so concurrent register/unregister doesn't
     # race the iteration. Lock release is fast — we copy the small list,
     # then iterate without holding it (so subscribers can safely call
@@ -133,7 +197,7 @@ def _dispatch(event: dict[str, Any]) -> None:
         snapshot = list(_handlers)
     for h in snapshot:
         try:
-            h(event)
+            h(payload)
         except Exception:
             # Subscriber crashes do NOT break the executor or other
             # subscribers. Logged at WARNING (not exception, to avoid

--- a/src/hooks/exec_callback_hook.py
+++ b/src/hooks/exec_callback_hook.py
@@ -1,0 +1,137 @@
+"""Callback hook executor — synchronous in-process callable.
+
+Phase-9 / WI-9.1. Closes gap analysis #12.
+
+Callback hooks invoke a Python callable directly — no subprocess, no
+LLM call, no HTTP. The chapter's "fast path": SDK consumers and TUI
+subscribers that want to react to hook events without the cost or
+configuration overhead of the other types. The TS chapter cites a
+≈70% latency reduction vs command hooks; the Python equivalent is
+even bigger because we skip the subprocess + JSON serialization /
+deserialization round-trip that command hooks pay.
+
+**Registration.** Callback hooks are programmatic — they're never
+loaded from settings.json (a JSON config can't carry a Python
+callable). The expected registration path is:
+
+  await add_session_hook(
+      registry=registry,
+      session_id=session_id,
+      event="PreToolUse",
+      matcher="Bash",
+      hook=HookConfig(
+          type="callback",
+          callback_ref=lambda event_data: HookResult(
+              additional_contexts=["audit log entry"],
+          ),
+      ),
+  )
+
+**Sync vs. async callables.** Both are accepted. The executor checks
+``inspect.iscoroutinefunction``; async callables are awaited. Sync
+callables run in-line on the event loop — the chapter assumes
+callbacks are *fast*, so blocking the loop briefly is acceptable.
+Slow callbacks should use ``asyncio.to_thread`` internally.
+
+**Return value contract.** The callable may return either:
+  * A ``HookResult`` instance — used directly (decision routing,
+    additional_contexts, etc. all flow through aggregation).
+  * ``None`` — treated as "exit_code=0, no decision" (the no-op
+    success case).
+
+**Exception isolation.** Callbacks that raise are caught at the
+executor boundary; the exception becomes ``blocking_error`` on the
+HookResult. The aggregator treats this like any blocking_error from
+other hook types — first-non-None-wins precedence — and the rest of
+the executor pipeline is unaffected.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import time
+from typing import Any
+
+from .hook_types import HookConfig, HookResult
+
+logger = logging.getLogger(__name__)
+
+
+async def execute_callback_hook(
+    hook: HookConfig,
+    stdin_data: dict[str, Any],
+) -> HookResult:
+    """Run a callback hook by invoking its registered Python callable.
+
+    Returns a ``HookResult`` matching the dispatch contract used by
+    other hook executors (command / http / prompt / agent). The
+    callable may return ``HookResult`` or ``None``; ``None`` becomes a
+    no-op-success result. Callable exceptions are converted to
+    ``blocking_error`` so the executor pipeline stays robust.
+    """
+    callback = hook.callback_ref
+    if callback is None:
+        return HookResult(
+            blocking_error=(
+                "Callback hook has no callback_ref configured. "
+                "Programmatic registration only (not loadable from "
+                "settings.json); see add_session_hook."
+            ),
+            exit_code=-1,
+        )
+
+    if not callable(callback):
+        return HookResult(
+            blocking_error=(
+                f"Callback hook's callback_ref is not callable "
+                f"(got {type(callback).__name__})"
+            ),
+            exit_code=-1,
+        )
+
+    start_time = time.monotonic()
+    try:
+        if inspect.iscoroutinefunction(callback):
+            outcome = await callback(stdin_data)
+        else:
+            outcome = callback(stdin_data)
+    except Exception as exc:
+        # Exception isolation per chapter §"Hook Event Emission" /
+        # §"Subscriber Error Isolation": one bad callback must not
+        # break the executor pipeline. Convert to blocking_error so
+        # the aggregator can route the failure normally.
+        duration_ms = int((time.monotonic() - start_time) * 1000)
+        logger.warning(
+            "callback hook raised; converting to blocking_error", exc_info=True,
+        )
+        return HookResult(
+            blocking_error=f"Callback hook raised: {exc}",
+            exit_code=-1,
+            duration_ms=duration_ms,
+        )
+
+    duration_ms = int((time.monotonic() - start_time) * 1000)
+
+    if outcome is None:
+        # No-op success — callback chose to do nothing actionable.
+        return HookResult(exit_code=0, duration_ms=duration_ms)
+
+    if isinstance(outcome, HookResult):
+        # Annotate the duration if the callback didn't set it (most
+        # callbacks won't bother — they shouldn't have to).
+        if outcome.duration_ms is None:
+            outcome.duration_ms = duration_ms
+        return outcome
+
+    # Anything else — treat as a programmer error in the callback. We
+    # don't try to coerce arbitrary values into HookResult shapes;
+    # surface the mistake.
+    return HookResult(
+        blocking_error=(
+            f"Callback hook returned an unsupported type "
+            f"{type(outcome).__name__}; expected HookResult | None"
+        ),
+        exit_code=-1,
+        duration_ms=duration_ms,
+    )

--- a/src/hooks/file_changed_watcher.py
+++ b/src/hooks/file_changed_watcher.py
@@ -155,8 +155,11 @@ class FileChangedWatcher:
         debounce_s: float = DEFAULT_DEBOUNCE_S,
     ) -> None:
         self._watch_root = Path(watch_root)
+        # Phase-9 / Step A — pathspec ``gitwildmatch`` factory is
+        # deprecated in pathspec 0.12+. Use the canonical ``gitignore``
+        # name; semantics are identical (gitignore-style globs).
         self._spec = pathspec.PathSpec.from_lines(
-            "gitwildmatch", list(patterns),
+            "gitignore", list(patterns),
         )
         self._observer: Observer | None = None  # type: ignore[valid-type]
         self._handler = _FileChangedEventHandler(

--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -445,6 +445,12 @@ async def _dispatch_hook_by_type(
         return await execute_agent_hook(
             hook, stdin_data, provider=provider, model=model,
         )
+    if hook_type == "callback":
+        # Phase-9 / WI-9.1 — in-process callable; no subprocess / no
+        # LLM. Skips the command-hook overhead path entirely (the
+        # chapter's "fast path" for SDK / TUI subscribers).
+        from .exec_callback_hook import execute_callback_hook
+        return await execute_callback_hook(hook, stdin_data)
     # Unknown hook type → log and return a no-op result. The validator
     # at config-load time should have caught this; if it slipped
     # through, we don't crash the executor.

--- a/src/hooks/hook_types.py
+++ b/src/hooks/hook_types.py
@@ -110,9 +110,15 @@ ALL_HOOK_EVENTS: list[HookEvent] = [
 ]
 
 
-# Hook *type* — the kind of executor that runs the hook. Phase-1 keeps the
-# four config-driven types; ``callback`` lands in Phase 9 (gap #12).
-HookType = Literal["command", "agent", "http", "prompt"]
+# Hook *type* — the kind of executor that runs the hook. Phase-1 had the
+# four config-driven types; Phase-9 / WI-9.1 adds ``callback`` for
+# in-process subscribers (gap #12). Callback hooks bypass the
+# command-hook subprocess fork (-70% overhead) and the LLM dispatch of
+# agent/prompt — they're a synchronous Python callable invoked directly
+# by the executor. Useful for SDK consumers and TUI subscribers that
+# want to react to hook events without the cost / configuration of the
+# other types.
+HookType = Literal["command", "agent", "http", "prompt", "callback"]
 
 
 # ---------------------------------------------------------------------------
@@ -250,6 +256,15 @@ class HookConfig:
     # registration → execution; not parsed from settings.json (only set at
     # skill-hook registration time in Phase 3).
     skill_root: str | None = None
+
+    # Phase-9 / WI-9.1 — callable for ``type="callback"`` hooks. Direct
+    # Python callable invoked by ``execute_callback_hook``; mutually
+    # exclusive with ``command`` / ``url`` / ``prompt_text`` /
+    # ``agent_instructions``. Not parsed from settings.json (callbacks
+    # are programmatic — registered via ``add_session_hook`` from SDK /
+    # TUI consumers). Signature: ``(event_data: dict) -> HookResult |
+    # None``. Returning ``None`` is treated as "exit_code=0, no decision."
+    callback_ref: Any = None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_phase9_callback_hook.py
+++ b/tests/test_phase9_callback_hook.py
@@ -1,0 +1,285 @@
+"""Phase-9 / WI-9.1 — callback hook type tests.
+
+Closes gap analysis #12. Callback hooks are an in-process Python
+callable invoked synchronously by the executor — no subprocess fork
+(unlike command), no LLM call (unlike agent/prompt), no HTTP (unlike
+http). The chapter cites a ~70% latency reduction over command hooks;
+the Python equivalent skips the subprocess + JSON round-trip.
+
+Coverage:
+  * Sync callback fires in-process; HookResult flows through.
+  * Async callback awaited; HookResult flows through.
+  * Returning ``None`` is treated as no-op success.
+  * Returning unsupported type → blocking_error.
+  * Callback raising → blocking_error (exception isolation).
+  * No ``callback_ref`` → blocking_error.
+  * Decision routes through aggregation; emission stream fires.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.hooks.aggregation import AggregatedHookResult
+from src.hooks.config_manager import HookConfigManager, HookConfigSnapshot
+from src.hooks.events import (
+    clear_hook_event_state,
+    register_hook_event_handler,
+)
+from src.hooks.exec_callback_hook import execute_callback_hook
+from src.hooks.hook_executor import _dispatch_hook_by_type, _run_hooks_for_event
+from src.hooks.hook_types import HookConfig, HookSource
+from src.hooks.registry import AsyncHookRegistry
+
+
+@dataclass
+class _MockOptions:
+    hooks: dict[str, Any] | None = None
+    tools: list[Any] = field(default_factory=list)
+
+
+@dataclass
+class _MockContext:
+    options: _MockOptions = field(default_factory=_MockOptions)
+    hook_config_manager: Any | None = None
+    workspace_trusted: bool = True
+    abort_controller: Any | None = None
+    session_hook_registry: Any | None = None
+    session_id: str | None = None
+    workspace_root: Path | None = None
+    provider: Any | None = None
+    model: str | None = None
+
+
+def _manager_with(hooks: dict[str, list[HookConfig]]) -> HookConfigManager:
+    m = HookConfigManager(registry=AsyncHookRegistry(), settings_path="/dev/null")
+    m._snapshot = HookConfigSnapshot(hooks=hooks, timestamp=0.0, source_path=None)
+    return m
+
+
+@pytest.fixture(autouse=True)
+def _isolate_event_stream():
+    clear_hook_event_state()
+    yield
+    clear_hook_event_state()
+
+
+# ---------------------------------------------------------------------------
+# Direct execute_callback_hook tests
+# ---------------------------------------------------------------------------
+
+
+class TestCallbackHookDirect:
+    @pytest.mark.asyncio
+    async def test_sync_callback_returns_hookresult(self):
+        from src.hooks.hook_types import HookResult
+
+        captured: dict[str, Any] = {}
+
+        def my_cb(event_data):
+            captured["event"] = event_data.get("hook_event")
+            return HookResult(
+                exit_code=0,
+                additional_contexts=["audit log entry"],
+            )
+
+        hook = HookConfig(type="callback", callback_ref=my_cb)
+        result = await execute_callback_hook(
+            hook, {"hook_event": "PreToolUse", "tool_name": "Bash"},
+        )
+
+        assert captured["event"] == "PreToolUse"
+        assert result.exit_code == 0
+        assert result.additional_contexts == ["audit log entry"]
+
+    @pytest.mark.asyncio
+    async def test_async_callback_awaited(self):
+        from src.hooks.hook_types import HookResult
+
+        async def my_async_cb(event_data):
+            return HookResult(exit_code=0, additional_contexts=["from async"])
+
+        hook = HookConfig(type="callback", callback_ref=my_async_cb)
+        result = await execute_callback_hook(hook, {"hook_event": "PreToolUse"})
+        assert result.additional_contexts == ["from async"]
+
+    @pytest.mark.asyncio
+    async def test_returning_none_is_noop_success(self):
+        # Common pattern: a logging callback that doesn't have anything
+        # actionable to return.
+        def silent(event_data):
+            pass
+
+        hook = HookConfig(type="callback", callback_ref=silent)
+        result = await execute_callback_hook(hook, {})
+        assert result.exit_code == 0
+        assert result.blocking_error is None
+        assert result.additional_contexts is None
+
+    @pytest.mark.asyncio
+    async def test_callback_raising_becomes_blocking_error(self):
+        # Exception isolation: callback that raises doesn't propagate
+        # up through the executor; converted to blocking_error.
+        def crashing(event_data):
+            raise RuntimeError("callback boom")
+
+        hook = HookConfig(type="callback", callback_ref=crashing)
+        result = await execute_callback_hook(hook, {})
+        assert result.blocking_error is not None
+        assert "callback boom" in result.blocking_error
+        assert result.exit_code == -1
+
+    @pytest.mark.asyncio
+    async def test_no_callback_ref_blocks(self):
+        hook = HookConfig(type="callback", callback_ref=None)
+        result = await execute_callback_hook(hook, {})
+        assert result.blocking_error is not None
+        assert "callback_ref" in result.blocking_error.lower()
+
+    @pytest.mark.asyncio
+    async def test_non_callable_callback_ref_blocks(self):
+        hook = HookConfig(type="callback", callback_ref="not a callable")
+        result = await execute_callback_hook(hook, {})
+        assert result.blocking_error is not None
+        assert "not callable" in result.blocking_error.lower()
+
+    @pytest.mark.asyncio
+    async def test_unsupported_return_type_blocks(self):
+        # Programmer error: callback returns something that isn't
+        # HookResult or None.
+        def bad(event_data):
+            return {"decision": "allow"}  # raw dict, not HookResult
+
+        hook = HookConfig(type="callback", callback_ref=bad)
+        result = await execute_callback_hook(hook, {})
+        assert result.blocking_error is not None
+        assert "unsupported type" in result.blocking_error.lower()
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher routes callback type
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherRoutesCallback:
+    @pytest.mark.asyncio
+    async def test_dispatch_routes_callback_to_callback_executor(self):
+        from src.hooks.hook_types import HookResult
+
+        called = {"n": 0}
+
+        def my_cb(event_data):
+            called["n"] += 1
+            return HookResult(
+                exit_code=0,
+                permission_behavior="allow",
+                hook_permission_decision_reason="ok",
+            )
+
+        hook = HookConfig(type="callback", callback_ref=my_cb)
+        result = await _dispatch_hook_by_type(hook, {"hook_event": "PreToolUse"})
+
+        assert called["n"] == 1
+        assert result.permission_behavior == "allow"
+
+
+# ---------------------------------------------------------------------------
+# Aggregation + emission for callback hooks
+# ---------------------------------------------------------------------------
+
+
+class TestCallbackAggregationAndEmission:
+    @pytest.mark.asyncio
+    async def test_callback_decision_routes_through_aggregation(self):
+        # Snapshot has a callback hook that denies. The executor
+        # collects + aggregates, and the aggregated decision is "deny."
+        from src.hooks.hook_types import HookResult
+
+        def deny_cb(event_data):
+            return HookResult(
+                permission_behavior="deny",
+                hook_permission_decision_reason="callback says no",
+            )
+
+        callback_hook = HookConfig(
+            type="callback",
+            callback_ref=deny_cb,
+            source=HookSource.SESSION_HOOK,
+        )
+        manager = _manager_with({"PreToolUse": [callback_hook]})
+        ctx = _MockContext(hook_config_manager=manager)
+
+        yields = []
+        async for item in _run_hooks_for_event(
+            "PreToolUse", "Bash",
+            {"tool_name": "Bash", "tool_use_id": "u1"},
+            ctx,
+        ):
+            yields.append(item)
+
+        # Aggregated permission_behavior is deny.
+        permission_yields = [y for y in yields if "permission_behavior" in y]
+        assert len(permission_yields) == 1
+        assert permission_yields[0]["permission_behavior"] == "deny"
+        assert "callback says no" in str(permission_yields[0])
+
+    @pytest.mark.asyncio
+    async def test_emission_fires_for_callback_hooks(self):
+        # The hook event emission stream (Phase-6) fires for callback
+        # hooks the same way it fires for command/http/prompt/agent.
+        from src.hooks.hook_types import HookResult
+
+        def my_cb(event_data):
+            return HookResult(exit_code=0)
+
+        callback_hook = HookConfig(
+            type="callback",
+            callback_ref=my_cb,
+            source=HookSource.SESSION_HOOK,
+        )
+        manager = _manager_with({"PreToolUse": [callback_hook]})
+        ctx = _MockContext(hook_config_manager=manager)
+
+        events: list[dict] = []
+        register_hook_event_handler(events.append)
+
+        async for _ in _run_hooks_for_event(
+            "PreToolUse", "Bash", {"tool_name": "Bash"}, ctx,
+        ):
+            pass
+
+        types = [e["type"] for e in events]
+        assert "hook_started" in types
+        assert "hook_response" in types
+        assert "hook_aggregated" in types
+
+    @pytest.mark.asyncio
+    async def test_callback_raising_does_not_break_executor(self):
+        # End-to-end exception isolation: a callback that raises produces
+        # a blocking_error, and the executor pipeline completes.
+        def crashing(event_data):
+            raise RuntimeError("end-to-end boom")
+
+        callback_hook = HookConfig(
+            type="callback",
+            callback_ref=crashing,
+            source=HookSource.SESSION_HOOK,
+        )
+        manager = _manager_with({"PreToolUse": [callback_hook]})
+        ctx = _MockContext(hook_config_manager=manager)
+
+        yields = []
+        async for item in _run_hooks_for_event(
+            "PreToolUse", "Bash", {"tool_name": "Bash"}, ctx,
+        ):
+            yields.append(item)
+
+        # Executor completed (we got yields). Aggregated yield carries
+        # the blocking_error.
+        blocking = [y for y in yields if "blocking_error" in y]
+        assert len(blocking) == 1
+        assert "end-to-end boom" in str(blocking[0])

--- a/tests/test_phase9_lazy_json.py
+++ b/tests/test_phase9_lazy_json.py
@@ -1,0 +1,162 @@
+"""Phase-9 / WI-9.2 — lazy JSON serialization tests.
+
+The hook event emission stream wraps each event in a
+``LazyJsonPayload`` (subclass of dict) with a memoized ``json``
+property. Two performance properties:
+
+  1. Zero-subscriber and dict-only-consumer scenarios pay zero
+     serialization cost.
+  2. When N subscribers each access ``payload.json``, serialization
+     happens exactly once (memoized).
+
+Tests inspect the serialization side-channel by patching
+``json.dumps`` to count calls — concrete proof the contract holds.
+"""
+
+from __future__ import annotations
+
+import json as stdlib_json
+from unittest.mock import patch
+
+import pytest
+
+from src.hooks.events import (
+    LazyJsonPayload,
+    clear_hook_event_state,
+    emit_hook_started,
+    register_hook_event_handler,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_event_stream():
+    clear_hook_event_state()
+    yield
+    clear_hook_event_state()
+
+
+class TestLazyJsonPayloadDirect:
+    def test_acts_as_dict_for_field_access(self):
+        # Back-compat: subscribers that read fields directly continue
+        # to work — LazyJsonPayload IS a dict.
+        payload = LazyJsonPayload({"type": "hook_started", "event": "PreToolUse"})
+        assert payload["type"] == "hook_started"
+        assert payload.get("event") == "PreToolUse"
+        assert "type" in payload
+
+    def test_json_property_returns_serialized_string(self):
+        payload = LazyJsonPayload({"a": 1, "b": "two"})
+        result = payload.json
+        # Re-parse to ensure it's valid JSON with the same content.
+        assert stdlib_json.loads(result) == {"a": 1, "b": "two"}
+
+    def test_zero_serialization_when_json_never_accessed(self):
+        # The headline property: dict-only consumers pay zero cost.
+        payload = LazyJsonPayload({"type": "x"})
+        with patch("src.hooks.events.json.dumps") as mock_dumps:
+            # Read field directly (the dict path).
+            _ = payload["type"]
+            _ = payload.get("missing", "default")
+            for k in payload:
+                pass
+        # json.dumps was never called.
+        assert mock_dumps.call_count == 0
+
+    def test_json_property_memoizes_across_n_accesses(self):
+        # Multiple accesses → one serialization. (Ten accesses arbitrary
+        # — point is "many"; one serialization regardless.)
+        payload = LazyJsonPayload({"a": 1})
+        with patch(
+            "src.hooks.events.json.dumps", wraps=stdlib_json.dumps,
+        ) as mock_dumps:
+            for _ in range(10):
+                _ = payload.json
+        assert mock_dumps.call_count == 1
+
+    def test_concurrent_json_access_serializes_once(self):
+        # Thread-safety: two threads both reading payload.json see
+        # exactly one serialization between them.
+        import threading
+
+        payload = LazyJsonPayload({"a": 1})
+
+        results: list[str] = []
+        barrier = threading.Barrier(5)
+
+        def reader():
+            barrier.wait()  # all threads start together
+            results.append(payload.json)
+
+        with patch(
+            "src.hooks.events.json.dumps", wraps=stdlib_json.dumps,
+        ) as mock_dumps:
+            threads = [threading.Thread(target=reader) for _ in range(5)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        # Exactly one serialization across all 5 readers.
+        assert mock_dumps.call_count == 1
+        # All 5 got the same string.
+        assert len(set(results)) == 1
+
+
+class TestLazyJsonInDispatchedEvents:
+    def test_dispatched_event_is_lazy_payload(self):
+        # When emit_* fires, subscribers receive LazyJsonPayload (NOT
+        # a plain dict). Subscribers can opt into JSON via .json or
+        # treat it as a dict for free.
+        captured: list = []
+        register_hook_event_handler(captured.append)
+
+        emit_hook_started(hook_id="x", event="PreToolUse", command="echo")
+
+        assert len(captured) == 1
+        assert isinstance(captured[0], LazyJsonPayload)
+        # Field access works.
+        assert captured[0]["type"] == "hook_started"
+
+    def test_subscribers_share_one_serialization(self):
+        # 3 subscribers, all of which call payload.json. Total
+        # serialization count: 1.
+        sub_results: list[str] = []
+
+        def sub(payload):
+            sub_results.append(payload.json)
+
+        for _ in range(3):
+            register_hook_event_handler(sub)
+
+        with patch(
+            "src.hooks.events.json.dumps", wraps=stdlib_json.dumps,
+        ) as mock_dumps:
+            emit_hook_started(hook_id="x", event="PreToolUse")
+
+        # One emit → one event payload → one serialization.
+        assert mock_dumps.call_count == 1
+        # All 3 subscribers got the same string.
+        assert len(sub_results) == 3
+        assert len(set(sub_results)) == 1
+
+    def test_zero_subscribers_zero_serialization(self):
+        # No subscribers registered → emit fires (no-op) → no
+        # serialization, ever.
+        with patch("src.hooks.events.json.dumps") as mock_dumps:
+            emit_hook_started(hook_id="x", event="PreToolUse")
+        assert mock_dumps.call_count == 0
+
+    def test_dict_only_subscriber_zero_serialization(self):
+        # Subscriber that only reads dict fields (the common case)
+        # pays zero serialization cost even when registered.
+        captured: list = []
+
+        def dict_only_sub(payload):
+            # Only dict access; never .json.
+            captured.append(payload["type"])
+
+        register_hook_event_handler(dict_only_sub)
+        with patch("src.hooks.events.json.dumps") as mock_dumps:
+            emit_hook_started(hook_id="x", event="PreToolUse")
+        assert mock_dumps.call_count == 0
+        assert captured == ["hook_started"]

--- a/tests/test_phase9_skills_hooks_commands.py
+++ b/tests/test_phase9_skills_hooks_commands.py
@@ -1,0 +1,255 @@
+"""Phase-9 / WI-9.3 + WI-9.4 — /skills + /hooks command tests.
+
+WI-9.3: ``/skills`` builds a structured menu-item list (consumable by
+interactive TUI components) and a text fallback. The menu items
+include source / status / has_hooks / context fields beyond the
+pre-Phase-9 flat listing.
+
+WI-9.4: ``/hooks`` is a new command that lists configured hooks from
+the active snapshot, grouped by event and sorted by source priority.
+Respects the workspace-trust gate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.command_system.builtins import (
+    HOOKS_COMMAND,
+    SKILLS_COMMAND,
+    _build_skills_menu_items,
+    _format_skills_menu_text,
+    hooks_command_call,
+    skills_command_call,
+)
+from src.command_system.engine import CommandContext
+from src.hooks.config_manager import HookConfigManager, HookConfigSnapshot
+from src.hooks.hook_types import HookConfig, HookSource
+from src.hooks.registry import AsyncHookRegistry
+
+
+@dataclass
+class _MockToolContext:
+    hook_config_manager: Any | None = None
+    workspace_trusted: bool = True
+
+
+@dataclass
+class _MockCommandContext:
+    cwd: Path | None = None
+    workspace_root: Path | None = None
+    config: dict = field(default_factory=dict)
+    tool_context: Any | None = None
+
+
+def _manager_with(hooks: dict[str, list[HookConfig]]) -> HookConfigManager:
+    m = HookConfigManager(registry=AsyncHookRegistry(), settings_path="/dev/null")
+    m._snapshot = HookConfigSnapshot(hooks=hooks, timestamp=0.0, source_path=None)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# /skills — interactive menu data shape (WI-9.3)
+# ---------------------------------------------------------------------------
+
+
+class TestSkillsMenuItems:
+    def test_menu_items_include_chapter_fields(self):
+        # Each item must carry the fields the TUI component / SDK
+        # consumer needs.
+        skill = type("Skill", (), {
+            "name": "my-skill",
+            "description": "does a thing",
+            "when_to_use": "when needed",
+            "loaded_from": "user",
+            "hooks": None,
+            "context": "inline",
+        })()
+        items = _build_skills_menu_items([skill])
+        assert len(items) == 1
+        item = items[0]
+        assert item["name"] == "my-skill"
+        assert item["description"] == "does a thing"
+        assert item["when_to_use"] == "when needed"
+        assert item["source"] == "user"
+        assert item["status"] == "installed"
+        assert item["has_hooks"] is False
+        assert item["context"] == "inline"
+
+    def test_forked_skill_marked_in_context(self):
+        skill = type("Skill", (), {
+            "name": "forky",
+            "description": "forked",
+            "when_to_use": None,
+            "loaded_from": "project",
+            "hooks": None,
+            "context": "fork",
+        })()
+        items = _build_skills_menu_items([skill])
+        assert items[0]["context"] == "fork"
+
+    def test_skill_with_hooks_flagged(self):
+        skill = type("Skill", (), {
+            "name": "hooked",
+            "description": "has hooks",
+            "when_to_use": None,
+            "loaded_from": "user",
+            "hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": []}]},
+            "context": "inline",
+        })()
+        items = _build_skills_menu_items([skill])
+        assert items[0]["has_hooks"] is True
+
+
+class TestSkillsMenuTextFormat:
+    def test_empty_text(self):
+        text = _format_skills_menu_text([])
+        assert "No skills available" in text
+
+    def test_text_includes_flag_legend(self):
+        items = [{
+            "name": "x", "description": "d", "when_to_use": None,
+            "source": "user", "status": "installed",
+            "has_hooks": False, "context": "inline",
+        }]
+        text = _format_skills_menu_text(items)
+        assert "Flags:" in text
+
+    def test_forked_skill_gets_F_flag(self):
+        items = [{
+            "name": "forky", "description": "", "when_to_use": None,
+            "source": "user", "status": "installed",
+            "has_hooks": False, "context": "fork",
+        }]
+        text = _format_skills_menu_text(items)
+        assert "[F]" in text
+
+    def test_skill_with_hooks_gets_H_flag(self):
+        items = [{
+            "name": "hooked", "description": "", "when_to_use": None,
+            "source": "user", "status": "installed",
+            "has_hooks": True, "context": "inline",
+        }]
+        text = _format_skills_menu_text(items)
+        assert "[H]" in text
+
+
+# ---------------------------------------------------------------------------
+# /hooks command (WI-9.4)
+# ---------------------------------------------------------------------------
+
+
+class TestHooksCommand:
+    def test_no_tool_context_helpful_message(self):
+        ctx = _MockCommandContext(tool_context=None)
+        result = hooks_command_call("", ctx)
+        assert "no ToolContext" in result.value or "configuration issue" in result.value
+
+    def test_no_hooks_configured_message(self):
+        manager = _manager_with({})
+        tool_ctx = _MockToolContext(hook_config_manager=manager)
+        ctx = _MockCommandContext(tool_context=tool_ctx)
+        result = hooks_command_call("", ctx)
+        assert "No hooks configured" in result.value
+
+    def test_lists_command_hook(self):
+        hook = HookConfig(
+            type="command",
+            command="echo audit",
+            matcher="Bash",
+            source=HookSource.USER_SETTINGS,
+        )
+        manager = _manager_with({"PreToolUse": [hook]})
+        tool_ctx = _MockToolContext(hook_config_manager=manager)
+        ctx = _MockCommandContext(tool_context=tool_ctx)
+
+        result = hooks_command_call("", ctx)
+        assert "PreToolUse" in result.value
+        assert "type=command" in result.value
+        assert "echo audit" in result.value
+        assert "userSettings" in result.value
+
+    def test_groups_by_event_and_source_priority(self):
+        # Multiple events + multiple sources. Event names sort
+        # alphabetically; within an event, sources sort by priority
+        # (USER_SETTINGS=0 first, POLICY_SETTINGS=3 later, etc.).
+        hooks = {
+            "Stop": [
+                HookConfig(type="command", command="stop-cmd",
+                           source=HookSource.USER_SETTINGS),
+            ],
+            "PreToolUse": [
+                HookConfig(type="command", command="plugin-cmd",
+                           source=HookSource.PLUGIN_HOOK),
+                HookConfig(type="command", command="user-cmd",
+                           source=HookSource.USER_SETTINGS),
+                HookConfig(type="command", command="policy-cmd",
+                           source=HookSource.POLICY_SETTINGS),
+            ],
+        }
+        manager = _manager_with(hooks)
+        tool_ctx = _MockToolContext(hook_config_manager=manager)
+        ctx = _MockCommandContext(tool_context=tool_ctx)
+
+        result = hooks_command_call("", ctx)
+        # PreToolUse precedes Stop alphabetically.
+        assert result.value.index("PreToolUse") < result.value.index("Stop")
+        # Within PreToolUse: user (priority 0) < policy (3) < plugin (999).
+        pre_section = result.value.split("Stop")[0]
+        assert pre_section.index("user-cmd") < pre_section.index("policy-cmd")
+        assert pre_section.index("policy-cmd") < pre_section.index("plugin-cmd")
+
+    def test_workspace_untrusted_only_shows_policy(self):
+        # Trust gate: only POLICY_SETTINGS hooks shown when workspace
+        # is untrusted (matches executor's runtime gate).
+        hooks = {
+            "PreToolUse": [
+                HookConfig(type="command", command="user-cmd",
+                           source=HookSource.USER_SETTINGS),
+                HookConfig(type="command", command="policy-cmd",
+                           source=HookSource.POLICY_SETTINGS),
+            ],
+        }
+        manager = _manager_with(hooks)
+        tool_ctx = _MockToolContext(
+            hook_config_manager=manager, workspace_trusted=False,
+        )
+        ctx = _MockCommandContext(tool_context=tool_ctx)
+
+        result = hooks_command_call("", ctx)
+        assert "policy-cmd" in result.value
+        assert "user-cmd" not in result.value
+        # Diagnostic message mentions trust state.
+        assert "untrusted" in result.value.lower()
+
+    def test_lists_callback_hook_with_placeholder_descriptor(self):
+        # Callback hooks can't show their callable in a flat string;
+        # the descriptor uses ``<programmatic>``.
+        hook = HookConfig(
+            type="callback",
+            callback_ref=lambda evt: None,
+            source=HookSource.SESSION_HOOK,
+        )
+        manager = _manager_with({"PreToolUse": [hook]})
+        tool_ctx = _MockToolContext(hook_config_manager=manager)
+        ctx = _MockCommandContext(tool_context=tool_ctx)
+
+        result = hooks_command_call("", ctx)
+        assert "type=callback" in result.value
+        assert "<programmatic>" in result.value
+
+
+class TestCommandRegistration:
+    def test_hooks_command_registered_in_builtins(self):
+        from src.command_system.builtins import get_builtin_commands
+        names = [c.name for c in get_builtin_commands()]
+        assert "hooks" in names
+
+    def test_skills_command_still_registered(self):
+        from src.command_system.builtins import get_builtin_commands
+        names = [c.name for c in get_builtin_commands()]
+        assert "skills" in names


### PR DESCRIPTION
## Summary
Phase 9 of ch12 — final implementation phase. Pure additive surface: in-process callback hook type, lazy JSON serialization for emission events, interactive `/skills` data shape, new `/hooks` listing command.

## What's new in this phase (vs Phase 8)
- **WI-9.1 — Callback hook type.** `HookType` extended with `\"callback\"`; `HookConfig.callback_ref: Any`. New `src/hooks/exec_callback_hook.py`. Sync OR async callable (via `inspect.iscoroutinefunction`). No subprocess / no LLM / no HTTP — chapter's "fast path" for SDK/TUI subscribers. `_dispatch_hook_by_type` callback branch is a one-line addition (Phase 7's dispatcher factoring paid off). Exception isolation via try/except → `blocking_error`. Defensive errors for missing/non-callable `callback_ref` and unsupported return types.
- **WI-9.2 — Lazy JSON.** New `LazyJsonPayload` (dict subclass) in `events.py`. Memoized `.json` property; `threading.Lock` for thread-safe one-shot serialization. Two perf properties pinned: zero-subscriber → 0 dumps; N-subscriber concurrent access → 1 dumps (verified with 5 concurrent threads).
- **WI-9.3 — `/skills` interactive.** `_build_skills_menu_items` produces structured items (name/description/source/status/has_hooks/context). Back-compat text fallback with `[F]`/`[H]` flag indicators. `LocalCommandResult` carries `menu_items` for interactive callers.
- **WI-9.4 — `/hooks` command.** New `HOOKS_COMMAND` in builtins. Reads from snapshot, groups by event (alphabetical) + sorts by source priority. **Workspace-trust gate matches the executor's runtime gate** — untrusted shows only `POLICY_SETTINGS` hooks with diagnostic line. Per-hook descriptors format type+matcher+if+once+payload (incl. `<programmatic>` for callback).
- **Cleanup:** pathspec `gitwildmatch` → `gitignore` (sweep DeprecationWarnings dropped 25 → 11).
- 35 new tests across 3 files (10 callback + 10 lazy-JSON + 15 skills/hooks commands).

## Test plan
- [ ] Phase 9 focused suite → 35/35
- [ ] Callback dispatch routes through aggregation + Phase 6 emission
- [ ] Lazy JSON: 5-concurrent-threads → exactly 1 `dumps` call
- [ ] Both chapter examples #1 and #2 stay E2E green
- [ ] Full sweep → 3962 passed, same 27 pre-existing env failures

---
Final PR in the ch12 phase series. Subsystem implementation complete; one outstanding follow-up tracked in plan §15 (HTTPS/TLS-SNI compatibility under `SsrfGuardedTransport`'s URL rewrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)