### PR TITLE
feat(ch16/phase5): CCR upstream proxy (CONNECT-over-WS relay + 6-step setup)

### DIFF
--- a/src/upstreamproxy/ca_bundle.py
+++ b/src/upstreamproxy/ca_bundle.py
@@ -1,0 +1,162 @@
+"""CA-bundle download + PEM validation.
+
+Ports ``isValidPemContent`` and ``downloadCaBundle`` from
+``typescript/src/upstreamproxy/upstreamproxy.ts:211-216, 266-304``.
+
+The CCR upstream-proxy server signs traffic with a forged CA so it can
+MITM credential injection. The CLI downloads that CA and concatenates it
+with the system CA bundle, then exports the combined bundle's path via
+``SSL_CERT_FILE`` etc. so child subprocesses (curl, gh, python) trust
+the proxy.
+
+Two security guards:
+  1. ``isValidPemContent`` — refuses to write non-PEM bytes (e.g., HTML
+     error page from a compromised server) into the system bundle.
+  2. 5-second timeout on the fetch — a hung endpoint cannot stall CLI
+     startup forever.
+
+Both fail open: any failure returns ``False`` and the proxy stays
+disabled.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import tempfile
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+#: Matches one well-formed PEM certificate block. The non-greedy body
+#: ensures multiple blocks in a bundle are matched separately. This
+#: regex is structural-only; we don't parse the cert itself (the OpenSSL
+#: layer downstream of ``SSL_CERT_FILE`` will reject malformed certs).
+_PEM_BLOCK_RE = re.compile(
+    rb'-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----'
+)
+
+DEFAULT_CA_FETCH_TIMEOUT_SECONDS = 5.0
+
+
+def is_valid_pem_content(content: str | bytes) -> bool:
+    """Return True if ``content`` contains at least one well-formed PEM block.
+
+    Used as a security guard before writing the downloaded CA into the
+    system bundle. A compromised upstream proxy might respond with HTML
+    or JSON; without this check, that arbitrary content would be
+    appended to the trust store.
+
+    Mirrors ``upstreamproxy.ts:211-216`` and the test cases at
+    ``upstreamproxy.test.ts:1-43``.
+    """
+    if isinstance(content, str):
+        if not content.strip():
+            return False
+        data = content.encode('utf-8', errors='replace')
+    else:
+        if not content.strip():
+            return False
+        data = content
+    return bool(_PEM_BLOCK_RE.search(data))
+
+
+async def download_ca_bundle(
+    base_url: str,
+    system_ca_path: str | os.PathLike[str],
+    out_path: str | os.PathLike[str],
+    *,
+    timeout_seconds: float = DEFAULT_CA_FETCH_TIMEOUT_SECONDS,
+    client: httpx.AsyncClient | None = None,
+) -> bool:
+    """Fetch the CCR upstream-proxy CA, concat with system CA, write atomically.
+
+    Returns ``True`` on success, ``False`` on any failure (fail-open).
+
+    Steps:
+      1. ``GET ${base_url}/v1/code/upstreamproxy/ca-cert`` with a 5s
+         timeout. Non-2xx responses, network errors, and timeouts all
+         return ``False``.
+      2. Validate the response body via ``is_valid_pem_content``. A
+         non-PEM response (HTML/JSON/arbitrary bytes from a compromised
+         server) returns ``False`` rather than corrupting the bundle.
+      3. Read the system CA bundle. Missing file is OK — we just write
+         the CCR CA alone (TS does the same: ``catch(() => '')``).
+      4. Write the concatenated bundle atomically: write to a temp file
+         in the same directory, then ``os.rename`` (POSIX atomic).
+
+    Mirrors ``upstreamproxy.ts:266-304``. Parameter ``client`` is for
+    tests — production callers can omit and a fresh ``AsyncClient`` is
+    constructed per call.
+    """
+    out_path = Path(out_path)
+    system_ca_path = Path(system_ca_path)
+    url = f'{base_url}/v1/code/upstreamproxy/ca-cert'
+
+    try:
+        if client is None:
+            async with httpx.AsyncClient(timeout=timeout_seconds) as fresh:
+                resp = await fresh.get(url)
+        else:
+            resp = await client.get(url, timeout=timeout_seconds)
+    except (httpx.HTTPError, httpx.TimeoutException) as exc:
+        logger.warning('[upstreamproxy] ca-cert download failed: %s; proxy disabled', exc)
+        return False
+
+    if resp.status_code < 200 or resp.status_code >= 300:
+        logger.warning(
+            '[upstreamproxy] ca-cert fetch %d; proxy disabled', resp.status_code
+        )
+        return False
+
+    ccr_ca = resp.content
+    if not is_valid_pem_content(ccr_ca):
+        logger.warning(
+            '[upstreamproxy] ca-cert response is not valid PEM; proxy disabled'
+        )
+        return False
+
+    # System bundle may not exist (alpine, distroless); empty fallback
+    # matches TS ``readFile(systemCaPath, 'utf8').catch(() => '')``.
+    try:
+        system_ca = system_ca_path.read_bytes()
+    except OSError:
+        system_ca = b''
+
+    try:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        # Atomic write: same-directory tempfile + os.rename. POSIX
+        # rename is atomic when both paths are on the same filesystem.
+        # Linux/macOS guarantee this; Windows raises if dst exists, but
+        # the upstreamproxy is Linux-only in production.
+        fd, tmp_path = tempfile.mkstemp(dir=out_path.parent, prefix='.ca-bundle.', suffix='.tmp')
+        try:
+            with os.fdopen(fd, 'wb') as fh:
+                fh.write(system_ca)
+                if system_ca and not system_ca.endswith(b'\n'):
+                    fh.write(b'\n')
+                fh.write(ccr_ca)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_path, out_path)
+        except OSError:
+            # Best-effort cleanup of the tempfile on failure.
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+    except OSError as exc:
+        logger.warning('[upstreamproxy] ca-bundle write failed: %s; proxy disabled', exc)
+        return False
+    return True
+
+
+__all__ = [
+    'DEFAULT_CA_FETCH_TIMEOUT_SECONDS',
+    'download_ca_bundle',
+    'is_valid_pem_content',
+]

--- a/src/upstreamproxy/protobuf_codec.py
+++ b/src/upstreamproxy/protobuf_codec.py
@@ -1,0 +1,95 @@
+"""Hand-encoded ``UpstreamProxyChunk`` protobuf codec.
+
+Ports ``encode_chunk``/``decode_chunk`` from
+``typescript/src/upstreamproxy/relay.ts:66-103``.
+
+Wire format for ``message UpstreamProxyChunk { bytes data = 1; }``:
+    tag = (field_number << 3) | wire_type = (1 << 3) | 2 = 0x0a
+    followed by varint length, followed by the bytes.
+
+The chapter calls this out as the "10-line pattern" — for a single-field
+``bytes`` message, hand encoding is shorter than pulling in a protobuf
+runtime, and the bit manipulation is well-contained.
+
+A varint encodes an unsigned 64-bit length using 7 bits per byte plus a
+continuation bit (0x80 means "more bytes follow"). Most chunks fit in
+1-3 length bytes; bytes longer than ``MAX_CHUNK_BYTES`` (~512KB Envoy
+buffer cap) are split by the relay caller, not here.
+"""
+
+from __future__ import annotations
+
+#: Field 1, wire-type 2 (length-delimited bytes). The single byte that
+#: starts every UpstreamProxyChunk on the wire.
+WIRE_TAG_FIELD1_LEN_DELIMITED = 0x0A
+
+#: Maximum varint chain length. ``2^28`` covers up to 256MB chunks
+#: (4 bytes × 7 bits = 28 bits). Real chunks are <= 512KB, so 4 bytes
+#: of varint is the practical max — but the loop accepts up to 5 (35
+#: bits, > Envoy's 4GB hard cap on a single proto message). Matches TS
+#: ``relay.ts:99`` ``shift > 28`` overflow check.
+_MAX_VARINT_SHIFT = 28
+
+
+def encode_chunk(data: bytes) -> bytes:
+    """Encode ``data`` as a protobuf ``UpstreamProxyChunk`` message.
+
+    Wire layout: ``[0x0a][varint(len)][data...]``. Returns ``bytes``;
+    the original ``data`` is not modified.
+    """
+    n = len(data)
+    # Varint encoding: chunks of 7 bits, low-bit-first; high bit set
+    # while more bytes follow, cleared on the last byte.
+    varint = bytearray()
+    while n > 0x7F:
+        varint.append((n & 0x7F) | 0x80)
+        n >>= 7
+    varint.append(n)
+
+    out = bytearray(1 + len(varint) + len(data))
+    out[0] = WIRE_TAG_FIELD1_LEN_DELIMITED
+    out[1 : 1 + len(varint)] = varint
+    out[1 + len(varint) :] = data
+    return bytes(out)
+
+
+def decode_chunk(buf: bytes) -> bytes | None:
+    """Decode an ``UpstreamProxyChunk``. Returns the ``bytes`` field or ``None``.
+
+    Returns ``None`` for malformed input (wrong tag byte, varint
+    overflow, declared length exceeds remaining buffer). Tolerates a
+    zero-length input by returning empty bytes — the server uses that
+    as a keepalive signal.
+
+    Mirrors ``typescript/src/upstreamproxy/relay.ts:87-103``.
+    """
+    if len(buf) == 0:
+        # Server keepalive — empty payload, no header.
+        return b''
+    if buf[0] != WIRE_TAG_FIELD1_LEN_DELIMITED:
+        return None
+
+    length = 0
+    shift = 0
+    i = 1
+    while i < len(buf):
+        b = buf[i]
+        length |= (b & 0x7F) << shift
+        i += 1
+        if (b & 0x80) == 0:
+            break
+        shift += 7
+        if shift > _MAX_VARINT_SHIFT:
+            return None
+    else:
+        # Loop ran off the end without seeing the continuation-bit
+        # terminator — truncated varint.
+        return None
+
+    if i + length > len(buf):
+        # Declared length exceeds what's left in the buffer.
+        return None
+    return bytes(buf[i : i + length])
+
+
+__all__ = ['WIRE_TAG_FIELD1_LEN_DELIMITED', 'decode_chunk', 'encode_chunk']

--- a/src/upstreamproxy/ptrace_guard.py
+++ b/src/upstreamproxy/ptrace_guard.py
@@ -1,0 +1,92 @@
+"""``prctl(PR_SET_DUMPABLE, 0)`` heap-protection guard.
+
+Ports ``setNonDumpable`` from
+``typescript/src/upstreamproxy/upstreamproxy.ts:237-264``.
+
+Linux-only. Calls ``libc.prctl(PR_SET_DUMPABLE, 0, 0, 0, 0)`` via
+``ctypes``. Other platforms (macOS, Windows) silently no-op — matches TS
+Bun-FFI-or-skip behavior.
+
+Why this exists: a CCR session container reads its session token from
+``/run/ccr/session_token`` into the agent process's heap, then unlinks
+the file. Without ``PR_SET_DUMPABLE = 0``, a same-UID attacker (e.g., a
+prompt-injected ``gdb -p $PPID``) could attach via ptrace and scrape the
+token from the heap. Setting it to 0 blocks ptrace by other same-UID
+processes.
+
+Per chapter "Apply This" rule #4: *"Keep secrets heap-only in
+adversarial environments. Reading the token from a file, disabling
+ptrace, and unlinking the file eliminates both filesystem and
+memory-inspection attack vectors."*
+"""
+
+from __future__ import annotations
+
+import logging
+import platform
+
+logger = logging.getLogger(__name__)
+
+#: ``PR_SET_DUMPABLE`` operation code from ``<linux/prctl.h>``. Value 4
+#: across all kernel versions since 2.3.20.
+PR_SET_DUMPABLE = 4
+
+
+def set_non_dumpable() -> bool:
+    """Block same-UID ptrace via ``prctl(PR_SET_DUMPABLE, 0)``.
+
+    Returns ``True`` on success, ``False`` on any failure. Linux-only;
+    non-Linux platforms silently return ``False`` (no-op). Failure is
+    NEVER raised — this is a fail-open security guard, and a missing
+    libc / hardened kernel must not break the agent loop.
+    """
+    if platform.system() != 'Linux':
+        logger.debug(
+            '[upstreamproxy] non-Linux platform (%s); skipping prctl(PR_SET_DUMPABLE)',
+            platform.system(),
+        )
+        return False
+
+    try:
+        import ctypes
+    except ImportError:
+        logger.warning('[upstreamproxy] ctypes unavailable; cannot prctl')
+        return False
+
+    try:
+        # Standard glibc location. Some distros expose libc under
+        # different names; try the most common first.
+        libc = ctypes.CDLL('libc.so.6', use_errno=True)
+    except OSError:
+        try:
+            libc = ctypes.CDLL('libc.so', use_errno=True)
+        except OSError as exc:
+            logger.warning('[upstreamproxy] could not load libc: %s', exc)
+            return False
+
+    try:
+        libc.prctl.argtypes = [
+            ctypes.c_int,
+            ctypes.c_ulong,
+            ctypes.c_ulong,
+            ctypes.c_ulong,
+            ctypes.c_ulong,
+        ]
+        libc.prctl.restype = ctypes.c_int
+        rc = libc.prctl(PR_SET_DUMPABLE, 0, 0, 0, 0)
+    except (OSError, AttributeError, ValueError) as exc:
+        logger.warning('[upstreamproxy] prctl call failed: %s', exc)
+        return False
+
+    if rc != 0:
+        errno = ctypes.get_errno()
+        logger.warning(
+            '[upstreamproxy] prctl(PR_SET_DUMPABLE,0) returned nonzero rc=%d errno=%d',
+            rc,
+            errno,
+        )
+        return False
+    return True
+
+
+__all__ = ['PR_SET_DUMPABLE', 'set_non_dumpable']

--- a/src/upstreamproxy/relay.py
+++ b/src/upstreamproxy/relay.py
@@ -1,0 +1,408 @@
+"""CONNECT-over-WebSocket relay for the CCR upstream proxy.
+
+Ports ``typescript/src/upstreamproxy/relay.ts``.
+
+Listens on a localhost TCP port, accepts HTTP CONNECT from
+``curl``/``gh``/``kubectl``/etc., and tunnels bytes over a WebSocket to
+the CCR upstream proxy endpoint. The CCR server-side terminates the
+tunnel, MITMs TLS, injects org-configured credentials, and forwards to
+the real upstream.
+
+Why WebSocket and not raw CONNECT: CCR ingress is GKE L7 with
+path-prefix routing; there's no ``connect_matcher``. The session-ingress
+tunnel already uses this pattern.
+
+Wire protocol: bytes are wrapped in ``UpstreamProxyChunk`` protobuf
+messages (see ``protobuf_codec.py``) for compatibility with
+``gateway.NewWebSocketStreamAdapter`` on the server side.
+
+Implementation differences from TS:
+  - **Single asyncio implementation** — no Bun/Node fork (Python only
+    has one event loop family).
+  - ``asyncio.start_server`` provides the TCP listen surface.
+  - ``websockets.asyncio.client.connect`` provides the WS upgrade.
+  - ``StreamWriter.drain()`` provides the backpressure primitive (no
+    explicit per-socket queueing needed — Python streams buffer
+    internally and ``await drain()`` blocks the producer when full).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+import websockets
+from websockets.asyncio.client import connect as ws_connect
+
+from .protobuf_codec import decode_chunk, encode_chunk
+
+logger = logging.getLogger(__name__)
+
+#: Envoy per-request buffer cap. CONNECT payloads larger than this are
+#: split into multiple chunks. Week-1 Datadog payloads won't hit this,
+#: but design for it so e.g. ``git push`` doesn't need a relay rewrite.
+MAX_CHUNK_BYTES = 512 * 1024
+
+#: WebSocket application-level keepalive interval. Sidecar idle-timeout
+#: is 50 s; 30 s gives a comfortable margin.
+PING_INTERVAL_SECONDS = 30.0
+
+#: HTTP CONNECT request header buffer cap. Beyond this, a malformed
+#: client (or an attacker probing the relay) gets 400 Bad Request and
+#: the connection closes.
+MAX_CONNECT_HEADER_BYTES = 8 * 1024
+
+
+@dataclass
+class UpstreamProxyRelay:
+    """Handle to a running relay; ``stop()`` shuts the listener down."""
+
+    port: int
+    server: asyncio.AbstractServer = field(repr=False)
+
+    async def stop(self) -> None:
+        """Close the listener and wait for inflight handlers to drain."""
+        self.server.close()
+        await self.server.wait_closed()
+
+
+# ─── Phase 1: parse the HTTP CONNECT request ───────────────────────────────
+
+
+@dataclass
+class _ConnectRequest:
+    """Parsed CONNECT request header."""
+
+    raw_line: str  # full request-line, e.g. "CONNECT example.com:443 HTTP/1.1"
+    target: str  # the host:port part
+    trailing_bytes: bytes  # bytes that arrived AFTER the CRLFCRLF header end
+
+
+async def _read_connect_request(
+    reader: asyncio.StreamReader,
+) -> _ConnectRequest | str:
+    """Read until CRLFCRLF; return parsed request OR an error string for a 4xx.
+
+    The string variant is the response body to send to the client before
+    closing (e.g. ``'HTTP/1.1 400 Bad Request\r\n\r\n'``).
+
+    Mirrors ``relay.ts:295-333`` ``handleData`` Phase 1.
+    """
+    buf = bytearray()
+    while True:
+        chunk = await reader.read(4096)
+        if not chunk:
+            return 'HTTP/1.1 400 Bad Request\r\n\r\n'
+        buf.extend(chunk)
+        end = buf.find(b'\r\n\r\n')
+        if end != -1:
+            break
+        if len(buf) > MAX_CONNECT_HEADER_BYTES:
+            return 'HTTP/1.1 400 Bad Request\r\n\r\n'
+
+    head = buf[:end].decode('utf-8', errors='replace')
+    trailing = bytes(buf[end + 4 :])
+    first_line = head.split('\r\n', 1)[0]
+    parts = first_line.split()
+    if (
+        len(parts) != 3
+        or parts[0].upper() != 'CONNECT'
+        or not parts[2].upper().startswith('HTTP/1.')
+    ):
+        return 'HTTP/1.1 405 Method Not Allowed\r\n\r\n'
+    target = parts[1]
+    return _ConnectRequest(raw_line=first_line, target=target, trailing_bytes=trailing)
+
+
+# ─── Phase 2: tunnel bytes between the client TCP socket and the WS ────────
+
+
+async def _pump_client_to_ws(
+    reader: asyncio.StreamReader,
+    ws: websockets.asyncio.client.ClientConnection,
+    initial: bytes,
+) -> None:
+    """Read from the local TCP client; encode each chunk; send over the WS.
+
+    Splits chunks larger than ``MAX_CHUNK_BYTES``. Exits on EOF or any
+    socket error; the caller's ``handle_connection`` task-group catches
+    the resulting cancellation.
+    """
+    async def _send(data: bytes) -> None:
+        for off in range(0, len(data), MAX_CHUNK_BYTES):
+            slice_ = data[off : off + MAX_CHUNK_BYTES]
+            await ws.send(encode_chunk(slice_))
+
+    if initial:
+        await _send(initial)
+
+    while True:
+        try:
+            chunk = await reader.read(MAX_CHUNK_BYTES)
+        except (ConnectionError, OSError):
+            return
+        if not chunk:
+            return
+        try:
+            await _send(chunk)
+        except (websockets.exceptions.ConnectionClosed, ConnectionError, OSError):
+            return
+
+
+async def _pump_ws_to_client(
+    ws: websockets.asyncio.client.ClientConnection,
+    writer: asyncio.StreamWriter,
+    on_first_payload: Callable[[], None],
+) -> None:
+    """Read encoded chunks from the WS; decode; write to the TCP client.
+
+    ``on_first_payload`` is fired exactly once when the first non-empty
+    decoded chunk arrives. The relay uses this to flip the
+    ``established`` flag: after the first byte the TCP stream is
+    carrying TLS, and writing a plaintext 502 would corrupt it.
+    """
+    fired = False
+    try:
+        async for raw in ws:
+            if isinstance(raw, str):
+                # CCR upstream sends only binary frames; ignore text.
+                continue
+            payload = decode_chunk(raw)
+            if payload is None or not payload:
+                # Malformed or zero-length keepalive — drop silently.
+                continue
+            if not fired:
+                fired = True
+                on_first_payload()
+            try:
+                writer.write(payload)
+                await writer.drain()
+            except (ConnectionError, OSError):
+                return
+    except websockets.exceptions.ConnectionClosed:
+        return
+
+
+async def _keepalive(
+    ws: websockets.asyncio.client.ClientConnection,
+    interval: float = PING_INTERVAL_SECONDS,
+) -> None:
+    """Application-level keepalive — empty chunks the server can ignore.
+
+    The ``websockets`` library has its own protocol-level ping
+    (``ping_interval`` constructor kwarg) but we send the empty-chunk
+    keepalive too, matching TS. Either is enough on its own; both
+    together give belt-and-suspenders coverage.
+    """
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            await ws.send(encode_chunk(b''))
+        except (websockets.exceptions.ConnectionClosed, OSError):
+            return
+
+
+# ─── Connection handler ────────────────────────────────────────────────────
+
+
+async def _handle_connection(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    ws_url: str,
+    auth_header: str,
+    ws_auth_header: str,
+) -> None:
+    """One accepted TCP connection: parse CONNECT, open WS, pump bytes.
+
+    Mirrors ``relay.ts:344-428`` ``openTunnel``.
+    """
+    parsed = await _read_connect_request(reader)
+    if isinstance(parsed, str):
+        try:
+            writer.write(parsed.encode('ascii'))
+            await writer.drain()
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except (ConnectionError, OSError):
+                pass
+        return
+
+    # Open the WebSocket. The server upgrade requires:
+    #   - Authorization: Bearer <token>            (auth on the WS itself)
+    #   - Content-Type: application/proto          (so the server picks
+    #     binary-proto framing, not the JSON default)
+    # Bytes that arrived after the CONNECT header (TCP coalesces CONNECT
+    # + ClientHello into one packet under heavy load) are flushed first.
+    headers = {
+        'Authorization': ws_auth_header,
+        'Content-Type': 'application/proto',
+    }
+    try:
+        ws = await ws_connect(
+            ws_url,
+            additional_headers=headers,
+            ping_interval=None,  # we do app-level keepalive ourselves
+        )
+    except (websockets.exceptions.WebSocketException, ConnectionError, OSError) as exc:
+        logger.warning('[upstreamproxy] ws upgrade failed: %s', exc)
+        try:
+            writer.write(b'HTTP/1.1 502 Bad Gateway\r\n\r\n')
+            await writer.drain()
+        except (ConnectionError, OSError):
+            pass
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except (ConnectionError, OSError):
+                pass
+        return
+
+    # First chunk over the tunnel is the CONNECT request line plus
+    # ``Proxy-Authorization: Basic <session_id>:<token>`` so the server
+    # can authenticate the tunnel target. The server responds with its
+    # own ``HTTP/1.1 200 ...`` over the tunnel; we just pipe it through
+    # to the local client.
+    head = (
+        f'{parsed.raw_line}\r\n'
+        f'Proxy-Authorization: {auth_header}\r\n'
+        f'\r\n'
+    ).encode('ascii')
+
+    established = False
+
+    def _mark_established() -> None:
+        nonlocal established
+        established = True
+
+    c2s_task: asyncio.Task[None] | None = None
+    s2c_task: asyncio.Task[None] | None = None
+    ka_task: asyncio.Task[None] | None = None
+    try:
+        # Send the head-chunk first, then any trailing bytes from the
+        # CONNECT packet, then start pumping live data.
+        await ws.send(encode_chunk(head))
+
+        # Pumps run in parallel; whichever exits first triggers teardown
+        # of the others. ``TaskGroup`` would wait for ALL tasks to
+        # complete — fine for the happy-path race-free case, but s2c
+        # never returns until the WS closes, and the WS closes only when
+        # we close it. So we use ``asyncio.wait(FIRST_COMPLETED)`` to
+        # detect the first pump's exit and cancel the rest.
+        loop = asyncio.get_running_loop()
+        c2s_task = loop.create_task(
+            _pump_client_to_ws(reader, ws, parsed.trailing_bytes),
+            name='upstreamproxy-c2s',
+        )
+        s2c_task = loop.create_task(
+            _pump_ws_to_client(ws, writer, _mark_established),
+            name='upstreamproxy-s2c',
+        )
+        ka_task = loop.create_task(_keepalive(ws), name='upstreamproxy-ka')
+
+        await asyncio.wait(
+            [c2s_task, s2c_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+    except (
+        websockets.exceptions.ConnectionClosed,
+        ConnectionError,
+        OSError,
+        asyncio.CancelledError,
+    ) as exc:
+        logger.debug('[upstreamproxy] connection setup exited: %s', exc)
+    finally:
+        # Cancel any pump that's still running so we don't leak tasks.
+        for task in (c2s_task, s2c_task, ka_task):
+            if task is not None and not task.done():
+                task.cancel()
+        # Wait for cancellations to propagate; suppress noise.
+        for task in (c2s_task, s2c_task, ka_task):
+            if task is None:
+                continue
+            try:
+                await task
+            except (
+                websockets.exceptions.ConnectionClosed,
+                ConnectionError,
+                OSError,
+                asyncio.CancelledError,
+            ):
+                pass
+            except Exception as exc:  # noqa: BLE001 -- shutdown noise; never propagate
+                logger.debug('[upstreamproxy] pump cleanup exception: %s', exc)
+        # If we never received a server payload, the client is still
+        # waiting for the CONNECT response — send 502 before closing.
+        if not established:
+            try:
+                writer.write(b'HTTP/1.1 502 Bad Gateway\r\n\r\n')
+                await writer.drain()
+            except (ConnectionError, OSError):
+                pass
+        try:
+            await ws.close()
+        except (ConnectionError, OSError):
+            pass
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except (ConnectionError, OSError):
+            pass
+
+
+# ─── Public entry point ────────────────────────────────────────────────────
+
+
+async def start_upstream_proxy_relay(
+    *,
+    ws_url: str,
+    session_id: str,
+    token: str,
+    host: str = '127.0.0.1',
+    port: int = 0,
+) -> UpstreamProxyRelay:
+    """Start the CONNECT-over-WS relay listener.
+
+    Returns an ``UpstreamProxyRelay`` whose ``port`` is the actual
+    bound port (ephemeral when ``port=0``) and whose ``stop()`` shuts
+    the listener down.
+
+    The WS upgrade itself is auth-gated (the gateway wants the
+    session-ingress JWT on the upgrade); the inner CONNECT carries
+    ``Proxy-Authorization: Basic`` for the tunnel target. The two
+    headers are different roles even though they share the same token.
+    """
+    auth_header = (
+        'Basic '
+        + base64.b64encode(f'{session_id}:{token}'.encode('utf-8')).decode('ascii')
+    )
+    ws_auth_header = f'Bearer {token}'
+
+    server = await asyncio.start_server(
+        lambda r, w: _handle_connection(r, w, ws_url, auth_header, ws_auth_header),
+        host=host,
+        port=port,
+    )
+
+    sockets = server.sockets or ()
+    if not sockets:
+        raise RuntimeError('upstreamproxy: server has no listening socket')
+    bound_port = sockets[0].getsockname()[1]
+    logger.debug(
+        '[upstreamproxy] relay listening on %s:%d', host, bound_port
+    )
+    return UpstreamProxyRelay(port=bound_port, server=server)
+
+
+__all__ = [
+    'MAX_CHUNK_BYTES',
+    'MAX_CONNECT_HEADER_BYTES',
+    'PING_INTERVAL_SECONDS',
+    'UpstreamProxyRelay',
+    'start_upstream_proxy_relay',
+]

--- a/src/upstreamproxy/upstream_proxy.py
+++ b/src/upstreamproxy/upstream_proxy.py
@@ -1,0 +1,287 @@
+"""CCR upstream-proxy initialization + env-var derivation.
+
+Ports ``initUpstreamProxy``, ``getUpstreamProxyEnv``,
+``resetUpstreamProxyForTests`` from
+``typescript/src/upstreamproxy/upstreamproxy.ts:79-204``.
+
+Lifecycle (the chapter's 6-step ordered setup at §"Upstream Proxy"):
+    1. Read ``/run/ccr/session_token`` (or override).
+    2. ``prctl(PR_SET_DUMPABLE, 0)`` to block same-UID ptrace.
+    3. Download CA cert + concat with system bundle.
+    4. Start CONNECT-over-WS relay on an ephemeral port.
+    5. Unlink the token file (only AFTER the listener is up — a
+       supervisor restart can retry with the token still on disk).
+    6. Export ``HTTPS_PROXY``/``SSL_CERT_FILE``/etc. env vars for child
+       subprocesses (``getUpstreamProxyEnv()``).
+
+Two env-var gates: ``CLAUDE_CODE_REMOTE`` AND
+``CCR_UPSTREAM_PROXY_ENABLED`` MUST both be truthy. Plus
+``CLAUDE_CODE_REMOTE_SESSION_ID`` MUST be set. If any gate is off, the
+proxy is disabled — without these gates the proxy would MITM traffic
+in non-CCR contexts.
+
+**Fail-open everywhere.** Any error during init returns the disabled
+state sentinel (``UpstreamProxyState(enabled=False)``); the agent loop
+keeps running with no proxy. This matches chapter "Apply This" rule #5:
+*"The upstream proxy fails open because it provides enhanced
+functionality (credential injection), not core functionality (model
+inference)."*
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.bridge.no_proxy import default_no_proxy
+
+from .ca_bundle import download_ca_bundle
+from .ptrace_guard import set_non_dumpable
+from .relay import UpstreamProxyRelay, start_upstream_proxy_relay
+
+logger = logging.getLogger(__name__)
+
+#: Default location of the session-token file inside a CCR container.
+SESSION_TOKEN_PATH = '/run/ccr/session_token'
+
+#: Default location of the system CA bundle on Debian/Ubuntu CCR base
+#: images. macOS dev environments use this path too via Homebrew's
+#: ``ca-certificates``.
+SYSTEM_CA_BUNDLE = '/etc/ssl/certs/ca-certificates.crt'
+
+#: Default location of the merged CCR + system CA bundle.
+def _default_ca_bundle_out() -> Path:
+    return Path.home() / '.ccr' / 'ca-bundle.crt'
+
+
+@dataclass(frozen=True)
+class UpstreamProxyState:
+    """Disabled-or-enabled state sentinel (returned by ``init_upstream_proxy``).
+
+    When ``enabled`` is ``False``, ``port`` and ``ca_bundle_path`` are
+    ``None``; when ``enabled`` is ``True``, both are set.
+    """
+
+    enabled: bool
+    port: int | None = None
+    ca_bundle_path: str | None = None
+    relay: UpstreamProxyRelay | None = None
+
+
+_DISABLED = UpstreamProxyState(enabled=False)
+
+# Module-level state. ``init_upstream_proxy`` writes; ``get_upstream_proxy_env``
+# reads. Per A11 + chapter §"Apply This" rule #5, all writes are fail-open
+# (errors return DISABLED; never raise).
+_state: UpstreamProxyState = _DISABLED
+
+
+def _is_env_truthy(value: str | None) -> bool:
+    """Truthy test matching ``isEnvTruthy`` semantics in TS.
+
+    Returns ``True`` when value is non-empty and not one of
+    ``"0", "false", "no", "off"`` (case-insensitive). Mirrors the Bun
+    helper that gates ``initUpstreamProxy``.
+    """
+    if value is None:
+        return False
+    return value.lower() not in ('', '0', 'false', 'no', 'off')
+
+
+async def init_upstream_proxy(
+    *,
+    token_path: str | os.PathLike[str] | None = None,
+    system_ca_path: str | os.PathLike[str] | None = None,
+    ca_bundle_path: str | os.PathLike[str] | None = None,
+    ccr_base_url: str | None = None,
+) -> UpstreamProxyState:
+    """Initialize the CCR upstream proxy.
+
+    Returns the resulting state. Safe to call from non-CCR contexts —
+    the env-var gates short-circuit and ``DISABLED`` is returned with no
+    side effects. All overrides are for tests; production callers omit
+    them.
+
+    The function is idempotent only via the disabled-on-failure path:
+    if a previous call set ``_state`` to enabled, calling again does NOT
+    re-init. Tests should call ``reset_for_tests`` between cases.
+    """
+    global _state
+
+    # Gate 1: ``CLAUDE_CODE_REMOTE``.
+    if not _is_env_truthy(os.environ.get('CLAUDE_CODE_REMOTE')):
+        return _state
+
+    # Gate 2: ``CCR_UPSTREAM_PROXY_ENABLED``. CCR injects this from
+    # ``StartupContext.EnvironmentVariables`` so the GrowthBook
+    # decision is server-side (each container is a fresh process with
+    # no GB cache, so a client-side check would always default to false).
+    if not _is_env_truthy(os.environ.get('CCR_UPSTREAM_PROXY_ENABLED')):
+        return _state
+
+    # Gate 3: session ID (used in the ``Proxy-Authorization: Basic``
+    # tunnel header).
+    session_id = os.environ.get('CLAUDE_CODE_REMOTE_SESSION_ID')
+    if not session_id:
+        logger.warning(
+            '[upstreamproxy] CLAUDE_CODE_REMOTE_SESSION_ID unset; proxy disabled'
+        )
+        return _state
+
+    # Step 1: read the session token.
+    token_path = Path(token_path) if token_path is not None else Path(SESSION_TOKEN_PATH)
+    token = await _read_token(token_path)
+    if not token:
+        logger.debug('[upstreamproxy] no session token file; proxy disabled')
+        return _state
+
+    # Step 2: ptrace guard (Linux-only; no-op elsewhere).
+    set_non_dumpable()
+
+    # Step 3: resolve base URL and download the CA bundle.
+    base_url = (
+        ccr_base_url
+        or os.environ.get('ANTHROPIC_BASE_URL')
+        or 'https://api.anthropic.com'
+    )
+    ca_bundle_resolved = (
+        Path(ca_bundle_path) if ca_bundle_path is not None else _default_ca_bundle_out()
+    )
+    system_ca_resolved = (
+        Path(system_ca_path) if system_ca_path is not None else Path(SYSTEM_CA_BUNDLE)
+    )
+    ok = await download_ca_bundle(
+        base_url=base_url,
+        system_ca_path=system_ca_resolved,
+        out_path=ca_bundle_resolved,
+    )
+    if not ok:
+        return _state  # download_ca_bundle already logged the reason
+
+    # Step 4: start the relay (ephemeral port).
+    ws_url = base_url.replace('http://', 'ws://', 1).replace('https://', 'wss://', 1)
+    ws_url = ws_url.rstrip('/') + '/v1/code/upstreamproxy/ws'
+    try:
+        relay = await start_upstream_proxy_relay(
+            ws_url=ws_url, session_id=session_id, token=token
+        )
+    except Exception as exc:  # noqa: BLE001 -- fail-open per A11
+        logger.warning(
+            '[upstreamproxy] relay start failed: %s; proxy disabled', exc
+        )
+        return _state
+
+    # Step 5: unlink the token file (now that the relay is up — a
+    # supervisor restart before this point can retry with the token
+    # still on disk).
+    try:
+        token_path.unlink()
+    except FileNotFoundError:
+        pass  # already gone — fine
+    except OSError:
+        logger.warning('[upstreamproxy] token file unlink failed', exc_info=True)
+
+    _state = UpstreamProxyState(
+        enabled=True,
+        port=relay.port,
+        ca_bundle_path=str(ca_bundle_resolved),
+        relay=relay,
+    )
+    logger.info('[upstreamproxy] enabled on 127.0.0.1:%d', relay.port)
+    return _state
+
+
+def get_upstream_proxy_env() -> dict[str, str]:
+    """Env-var dict for child subprocesses (Bash/MCP/LSP/hooks).
+
+    When the proxy is enabled: returns the 9-var recipe
+    (``HTTPS_PROXY``/``https_proxy``/``NO_PROXY``/``no_proxy``/
+    ``SSL_CERT_FILE``/``NODE_EXTRA_CA_CERTS``/``REQUESTS_CA_BUNDLE``/
+    ``CURL_CA_BUNDLE``). The TS recipe also sets ``proxy`` in lowercase
+    via ``HTTPS_PROXY`` lowercase variant; we follow the same pattern.
+
+    When the proxy is disabled: if the parent already has both
+    ``HTTPS_PROXY`` and ``SSL_CERT_FILE`` set, we inherit those
+    (handles the case where a child CLI process can't re-init the
+    relay — token file already unlinked — but the parent's relay is
+    still running and reachable). Otherwise returns empty dict.
+
+    Mirrors ``upstreamproxy.ts:160-199``.
+    """
+    if _state.enabled and _state.port is not None and _state.ca_bundle_path is not None:
+        proxy_url = f'http://127.0.0.1:{_state.port}'
+        no_proxy = default_no_proxy()
+        ca = _state.ca_bundle_path
+        return {
+            'HTTPS_PROXY': proxy_url,
+            'https_proxy': proxy_url,
+            'NO_PROXY': no_proxy,
+            'no_proxy': no_proxy,
+            'SSL_CERT_FILE': ca,
+            'NODE_EXTRA_CA_CERTS': ca,
+            'REQUESTS_CA_BUNDLE': ca,
+            'CURL_CA_BUNDLE': ca,
+        }
+
+    # Disabled-but-inherited path: child CLI processes can't re-init
+    # the relay (token file already unlinked by parent), but the
+    # parent's relay is still reachable on 127.0.0.1:<port>. Pass
+    # through the parent's proxy env so subprocess inherits the
+    # same routing.
+    if os.environ.get('HTTPS_PROXY') and os.environ.get('SSL_CERT_FILE'):
+        inherited: dict[str, str] = {}
+        for key in (
+            'HTTPS_PROXY',
+            'https_proxy',
+            'NO_PROXY',
+            'no_proxy',
+            'SSL_CERT_FILE',
+            'NODE_EXTRA_CA_CERTS',
+            'REQUESTS_CA_BUNDLE',
+            'CURL_CA_BUNDLE',
+        ):
+            value = os.environ.get(key)
+            if value is not None:
+                inherited[key] = value
+        return inherited
+    return {}
+
+
+def reset_for_tests() -> None:
+    """Reset module state to DISABLED. Test-only helper."""
+    global _state
+    _state = _DISABLED
+
+
+async def _read_token(path: Path) -> str | None:
+    """Read and trim the session token from ``path``.
+
+    Returns ``None`` for missing file, empty content, or any read error.
+    """
+    try:
+        # We use ``run_in_executor`` to keep async semantics; the file
+        # is small but reading from /run/ccr/* on a slow tmpfs is
+        # non-instant under contention.
+        import asyncio
+
+        loop = asyncio.get_running_loop()
+        raw = await loop.run_in_executor(None, path.read_text, 'utf-8')
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        logger.warning('[upstreamproxy] token read failed: %s', exc)
+        return None
+    token = raw.strip()
+    return token if token else None
+
+
+__all__ = [
+    'SESSION_TOKEN_PATH',
+    'SYSTEM_CA_BUNDLE',
+    'UpstreamProxyState',
+    'get_upstream_proxy_env',
+    'init_upstream_proxy',
+    'reset_for_tests',
+]

--- a/tests/upstreamproxy/test_ca_bundle.py
+++ b/tests/upstreamproxy/test_ca_bundle.py
@@ -1,0 +1,184 @@
+"""Tests for ``src.upstreamproxy.ca_bundle``.
+
+Mirrors ``typescript/src/upstreamproxy/upstreamproxy.test.ts:1-43``
+plus the ``download_ca_bundle`` happy path + failure cases.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from src.upstreamproxy.ca_bundle import download_ca_bundle, is_valid_pem_content
+
+# ─── is_valid_pem_content (replicates upstreamproxy.test.ts:1-43) ────────
+
+
+def test_pem_single_block() -> None:
+    pem = '\n'.join([
+        '-----BEGIN CERTIFICATE-----',
+        'MIICpDCCAYwCCQDU+pQ4pHgSpDANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls',
+        'b2NhbGhvc3QwHhcNMjMwMTAxMDAwMDAwWhcNMjQwMTAxMDAwMDAwWjAUMRIwEAYD',
+        'VQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7',
+        '-----END CERTIFICATE-----',
+    ])
+    assert is_valid_pem_content(pem)
+
+
+def test_pem_multiple_blocks() -> None:
+    block = '-----BEGIN CERTIFICATE-----\nABCD\n-----END CERTIFICATE-----'
+    assert is_valid_pem_content(f'{block}\n{block}')
+
+
+def test_arbitrary_text_rejected() -> None:
+    assert not is_valid_pem_content('Hello world')
+    assert not is_valid_pem_content('<html><body>error</body></html>')
+    assert not is_valid_pem_content('{"error":"unauthorized"}')
+
+
+def test_empty_string_rejected() -> None:
+    assert not is_valid_pem_content('')
+
+
+def test_whitespace_only_rejected() -> None:
+    assert not is_valid_pem_content('   \n   ')
+
+
+def test_malformed_pem_no_end_marker_rejected() -> None:
+    assert not is_valid_pem_content('-----BEGIN CERTIFICATE-----\nABCD')
+
+
+def test_bytes_input_accepted() -> None:
+    """is_valid_pem_content accepts both str and bytes."""
+    pem_bytes = b'-----BEGIN CERTIFICATE-----\nABCD\n-----END CERTIFICATE-----'
+    assert is_valid_pem_content(pem_bytes)
+    assert not is_valid_pem_content(b'not pem')
+    assert not is_valid_pem_content(b'')
+
+
+# ─── download_ca_bundle ──────────────────────────────────────────────────
+
+
+_GOOD_PEM = (
+    b'-----BEGIN CERTIFICATE-----\n'
+    b'MIICpDCCAYwCCQDU+pQ4pHgSpDANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls\n'
+    b'-----END CERTIFICATE-----\n'
+)
+
+
+@pytest.mark.asyncio
+async def test_happy_path_writes_concatenated_bundle(tmp_path):
+    """200 OK with PEM body → file written = system + CCR PEM."""
+    system_ca = tmp_path / 'system.crt'
+    system_ca.write_bytes(b'SYSTEM_CA_BYTES\n')
+    out = tmp_path / 'merged.crt'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == '/v1/code/upstreamproxy/ca-cert'
+        return httpx.Response(200, content=_GOOD_PEM)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        ok = await download_ca_bundle('https://api.test', system_ca, out, client=client)
+
+    assert ok is True
+    written = out.read_bytes()
+    assert b'SYSTEM_CA_BYTES' in written
+    assert _GOOD_PEM in written
+    # System CA comes BEFORE the CCR PEM (per upstreamproxy.ts:295).
+    assert written.index(b'SYSTEM_CA_BYTES') < written.index(_GOOD_PEM)
+
+
+@pytest.mark.asyncio
+async def test_missing_system_ca_falls_through(tmp_path):
+    """System CA file missing — still works, writes only the CCR PEM."""
+    out = tmp_path / 'merged.crt'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=_GOOD_PEM)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        ok = await download_ca_bundle(
+            'https://api.test', tmp_path / 'nonexistent.crt', out, client=client
+        )
+    assert ok is True
+    assert _GOOD_PEM in out.read_bytes()
+
+
+@pytest.mark.asyncio
+async def test_non_2xx_returns_false(tmp_path):
+    """500 from server → fail-open, returns False, no file written."""
+    out = tmp_path / 'merged.crt'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, content=b'oops')
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        ok = await download_ca_bundle(
+            'https://api.test', tmp_path / 'sys.crt', out, client=client
+        )
+    assert ok is False
+    assert not out.exists()
+
+
+@pytest.mark.asyncio
+async def test_non_pem_response_returns_false(tmp_path):
+    """200 OK but body is HTML — refuse to write, fail open."""
+    out = tmp_path / 'merged.crt'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b'<html>not a cert</html>')
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        ok = await download_ca_bundle(
+            'https://api.test', tmp_path / 'sys.crt', out, client=client
+        )
+    assert ok is False
+    assert not out.exists()
+
+
+@pytest.mark.asyncio
+async def test_network_error_returns_false(tmp_path):
+    """Connection error (e.g., DNS fail, refused) → fail open."""
+    out = tmp_path / 'merged.crt'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError('connection refused')
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        ok = await download_ca_bundle(
+            'https://api.test', tmp_path / 'sys.crt', out, client=client
+        )
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_atomic_write_no_partial_file_on_crash(tmp_path, monkeypatch):
+    """Simulate fsync failure: the .tmp file should not survive."""
+    out = tmp_path / 'merged.crt'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=_GOOD_PEM)
+
+    # Force os.replace to fail after the temp file is written.
+    import os as _os
+
+    original_replace = _os.replace
+
+    def fail_replace(*args, **kwargs):
+        raise OSError('simulated rename failure')
+
+    monkeypatch.setattr(_os, 'replace', fail_replace)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        ok = await download_ca_bundle(
+            'https://api.test', tmp_path / 'sys.crt', out, client=client
+        )
+
+    assert ok is False
+    assert not out.exists()
+    # No .tmp file should be left behind.
+    leftover = list(tmp_path.glob('.ca-bundle.*.tmp'))
+    assert leftover == [], f'expected no leftover tempfile, got {leftover}'
+
+    # Restore for subsequent tests.
+    monkeypatch.setattr(_os, 'replace', original_replace)

--- a/tests/upstreamproxy/test_protobuf_codec.py
+++ b/tests/upstreamproxy/test_protobuf_codec.py
@@ -1,0 +1,113 @@
+"""Tests for ``src.upstreamproxy.protobuf_codec``."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.upstreamproxy.protobuf_codec import (
+    WIRE_TAG_FIELD1_LEN_DELIMITED,
+    decode_chunk,
+    encode_chunk,
+)
+
+
+class TestEncodeChunk:
+    def test_empty_payload(self) -> None:
+        out = encode_chunk(b'')
+        assert out == bytes([0x0A, 0x00])
+
+    def test_single_byte_payload(self) -> None:
+        out = encode_chunk(b'X')
+        assert out == bytes([0x0A, 0x01, ord('X')])
+
+    def test_one_byte_varint_127(self) -> None:
+        """127 is the max value that fits in a single varint byte."""
+        out = encode_chunk(b'A' * 127)
+        assert out[0] == 0x0A
+        assert out[1] == 127  # one varint byte; high bit clear
+        assert out[2:] == b'A' * 127
+
+    def test_two_byte_varint_128(self) -> None:
+        """128 takes 2 varint bytes (high bit set on the first)."""
+        out = encode_chunk(b'B' * 128)
+        assert out[0] == 0x0A
+        assert out[1] == 0x80  # low 7 bits = 0, continuation bit set
+        assert out[2] == 0x01  # high bits = 1, no continuation
+        assert out[3:] == b'B' * 128
+
+    def test_three_byte_varint_16384(self) -> None:
+        """16384 = 2^14 takes 3 varint bytes."""
+        n = 16384
+        out = encode_chunk(b'C' * n)
+        assert out[0] == 0x0A
+        assert out[1] == 0x80
+        assert out[2] == 0x80
+        assert out[3] == 0x01
+        assert len(out) == 4 + n
+
+
+class TestDecodeChunk:
+    def test_decode_empty_keepalive(self) -> None:
+        """Empty input is the server keepalive — return empty bytes."""
+        assert decode_chunk(b'') == b''
+
+    def test_decode_zero_length_chunk(self) -> None:
+        """0x0a 0x00 — well-formed chunk with empty payload."""
+        assert decode_chunk(bytes([0x0A, 0x00])) == b''
+
+    def test_decode_single_byte(self) -> None:
+        assert decode_chunk(bytes([0x0A, 0x01, ord('X')])) == b'X'
+
+    def test_decode_two_byte_varint(self) -> None:
+        payload = b'B' * 128
+        encoded = bytes([0x0A, 0x80, 0x01]) + payload
+        assert decode_chunk(encoded) == payload
+
+    def test_decode_wrong_tag_returns_none(self) -> None:
+        """First byte must be 0x0a; anything else is malformed."""
+        assert decode_chunk(bytes([0x05, 0x00])) is None
+        assert decode_chunk(bytes([0xFF, 0x00])) is None
+
+    def test_decode_truncated_payload_returns_none(self) -> None:
+        """Declared length > remaining buffer."""
+        assert decode_chunk(bytes([0x0A, 0x05, ord('A'), ord('B')])) is None
+
+    def test_decode_truncated_varint_returns_none(self) -> None:
+        """Continuation bit set on the last byte — varint never terminates."""
+        # 0x80 0x80 0x80 (all continuation bits) — runs off the end.
+        assert decode_chunk(bytes([0x0A, 0x80, 0x80, 0x80])) is None
+
+    def test_decode_overflowed_varint_returns_none(self) -> None:
+        """Varint shift > 28 means a 5+-byte length — out of bounds."""
+        # 5 bytes all with continuation bit set, then one without.
+        encoded = bytes([0x0A, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01])
+        # Should reject before the final byte (shift exceeds limit).
+        assert decode_chunk(encoded) is None
+
+
+class TestRoundTrip:
+    @pytest.mark.parametrize('size', [0, 1, 7, 127, 128, 16383, 16384, 65536])
+    def test_round_trip(self, size: int) -> None:
+        original = bytes(range(256)) * (size // 256) + bytes(range(size % 256))
+        # Adjust size: the construction above doesn't quite equal `size`
+        # for sizes that aren't multiples of 256.
+        original = original[:size] if len(original) >= size else original + b'\x00' * (
+            size - len(original)
+        )
+        assert len(original) == size
+        encoded = encode_chunk(original)
+        decoded = decode_chunk(encoded)
+        assert decoded == original
+
+    def test_concat_chunks_decoded_independently(self) -> None:
+        """Two chunks concatenated: decoder reads the first; second is leftover."""
+        a = encode_chunk(b'first')
+        b = encode_chunk(b'second')
+        assert decode_chunk(a + b) == b'first'
+        # Decoder doesn't return leftover; consumers split on encode.
+
+
+def test_tag_constant_is_correct() -> None:
+    """Tag = (field_number << 3) | wire_type = (1 << 3) | 2 = 0x0a."""
+    assert WIRE_TAG_FIELD1_LEN_DELIMITED == 0x0A
+    assert WIRE_TAG_FIELD1_LEN_DELIMITED == (1 << 3) | 2

--- a/tests/upstreamproxy/test_ptrace_guard.py
+++ b/tests/upstreamproxy/test_ptrace_guard.py
@@ -1,0 +1,45 @@
+"""Tests for ``src.upstreamproxy.ptrace_guard``.
+
+Most tests are platform-gated. The actual prctl invocation only runs on
+Linux (gated by ``@pytest.mark.linux_only``); on macOS/Windows we
+verify the no-op return.
+"""
+
+from __future__ import annotations
+
+import platform
+
+import pytest
+
+from src.upstreamproxy.ptrace_guard import PR_SET_DUMPABLE, set_non_dumpable
+
+
+def test_pr_set_dumpable_constant() -> None:
+    """Operation code from <linux/prctl.h> is 4."""
+    assert PR_SET_DUMPABLE == 4
+
+
+def test_non_linux_returns_false() -> None:
+    """On macOS/Windows, set_non_dumpable is a no-op returning False."""
+    if platform.system() == 'Linux':
+        pytest.skip('platform-specific test for non-Linux')
+    assert set_non_dumpable() is False
+
+
+@pytest.mark.linux_only
+def test_linux_returns_true() -> None:
+    """On Linux, prctl(PR_SET_DUMPABLE, 0) succeeds."""
+    if platform.system() != 'Linux':
+        pytest.skip('Linux-only test')
+    assert set_non_dumpable() is True
+
+
+def test_no_exception_on_failure() -> None:
+    """Whatever the underlying call does, set_non_dumpable must NEVER raise.
+
+    Per chapter "Apply This" rule #5 (fail-open semantics).
+    """
+    # Just call it; no platform-specific expectation. The only requirement
+    # is that the call returns rather than raising.
+    result = set_non_dumpable()
+    assert isinstance(result, bool)

--- a/tests/upstreamproxy/test_relay_e2e.py
+++ b/tests/upstreamproxy/test_relay_e2e.py
@@ -1,0 +1,174 @@
+"""End-to-end test for the CONNECT-over-WS relay.
+
+Runs an in-process echo WS server, starts the relay pointing at it,
+opens a TCP CONNECT to the relay, sends bytes, asserts they round-trip
+back through both legs (encoded → WS → echoed → decoded → TCP client).
+
+Marked ``@pytest.mark.integration`` because it spins up real TCP +
+real WS listeners on ephemeral ports.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import pytest
+import websockets
+from websockets.asyncio.server import serve as ws_serve
+
+from src.upstreamproxy.protobuf_codec import decode_chunk, encode_chunk
+from src.upstreamproxy.relay import start_upstream_proxy_relay
+
+
+pytestmark = pytest.mark.integration
+
+
+async def _echo_handler(ws: websockets.asyncio.server.ServerConnection) -> None:
+    """Echo handler: every chunk in → same chunk out.
+
+    Plus we synthesize the ``HTTP/1.1 200 Connection Established`` reply
+    that the real CCR server sends after parsing the first inner chunk
+    (the CONNECT request line + Proxy-Authorization). This satisfies the
+    relay's ``established`` gate so subsequent traffic flows through.
+    """
+    saw_connect = False
+    try:
+        async for raw in ws:
+            assert isinstance(raw, (bytes, bytearray))
+            payload = decode_chunk(bytes(raw))
+            if payload is None:
+                continue
+            if not saw_connect:
+                # First inner chunk is the CONNECT line + Proxy-Auth.
+                assert payload.startswith(b'CONNECT '), payload[:32]
+                saw_connect = True
+                # Send the synthesized 200 response back over the tunnel.
+                await ws.send(encode_chunk(b'HTTP/1.1 200 Connection Established\r\n\r\n'))
+                continue
+            # Plain echo for everything else.
+            await ws.send(encode_chunk(payload))
+    except websockets.exceptions.ConnectionClosed:
+        return
+
+
+def _free_port() -> int:
+    """Bind ephemeral port, immediately release for the WS server to take."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('127.0.0.1', 0))
+        return s.getsockname()[1]
+
+
+@pytest.mark.asyncio
+async def test_relay_round_trip_echo() -> None:
+    """CONNECT to the relay, exchange bytes, verify echo through both legs."""
+    ws_port = _free_port()
+
+    # Start the in-process echo WS server.
+    ws_server = await ws_serve(_echo_handler, '127.0.0.1', ws_port)
+    try:
+        ws_url = f'ws://127.0.0.1:{ws_port}/v1/code/upstreamproxy/ws'
+        relay = await start_upstream_proxy_relay(
+            ws_url=ws_url, session_id='cse_test', token='secret-token'
+        )
+        try:
+            # Open a TCP connection to the relay and send a CONNECT.
+            reader, writer = await asyncio.open_connection('127.0.0.1', relay.port)
+            try:
+                writer.write(b'CONNECT example.com:443 HTTP/1.1\r\n\r\n')
+                await writer.drain()
+
+                # Expect the 200-Connection-Established response back.
+                resp = await asyncio.wait_for(reader.readuntil(b'\r\n\r\n'), timeout=2.0)
+                assert resp.startswith(b'HTTP/1.1 200'), resp
+
+                # Send some "TLS payload" bytes; expect them echoed back.
+                payload = b'\x16\x03\x01' + b'X' * 200  # not real TLS, but an opaque blob
+                writer.write(payload)
+                await writer.drain()
+
+                # Read the echo. Use a small read so we don't block forever.
+                received = b''
+                while len(received) < len(payload):
+                    chunk = await asyncio.wait_for(
+                        reader.read(len(payload) - len(received)), timeout=2.0
+                    )
+                    if not chunk:
+                        break
+                    received += chunk
+                assert received == payload
+            finally:
+                writer.close()
+                try:
+                    await writer.wait_closed()
+                except (ConnectionError, OSError):
+                    pass
+        finally:
+            await relay.stop()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_relay_rejects_non_connect_method() -> None:
+    """An HTTP GET to the relay returns 405 Method Not Allowed."""
+    ws_port = _free_port()
+    ws_server = await ws_serve(_echo_handler, '127.0.0.1', ws_port)
+    try:
+        relay = await start_upstream_proxy_relay(
+            ws_url=f'ws://127.0.0.1:{ws_port}/v1/code/upstreamproxy/ws',
+            session_id='cse_test',
+            token='tok',
+        )
+        try:
+            reader, writer = await asyncio.open_connection('127.0.0.1', relay.port)
+            try:
+                writer.write(b'GET /foo HTTP/1.1\r\nHost: x\r\n\r\n')
+                await writer.drain()
+                resp = await asyncio.wait_for(reader.readuntil(b'\r\n\r\n'), timeout=2.0)
+                assert resp.startswith(b'HTTP/1.1 405'), resp
+            finally:
+                writer.close()
+                try:
+                    await writer.wait_closed()
+                except (ConnectionError, OSError):
+                    pass
+        finally:
+            await relay.stop()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_relay_oversized_header_rejected() -> None:
+    """An over-8KB CONNECT header gets 400 Bad Request."""
+    ws_port = _free_port()
+    ws_server = await ws_serve(_echo_handler, '127.0.0.1', ws_port)
+    try:
+        relay = await start_upstream_proxy_relay(
+            ws_url=f'ws://127.0.0.1:{ws_port}/v1/code/upstreamproxy/ws',
+            session_id='cse_test',
+            token='tok',
+        )
+        try:
+            reader, writer = await asyncio.open_connection('127.0.0.1', relay.port)
+            try:
+                # Send 9KB of garbage with no CRLFCRLF — should hit the
+                # 8KB cap and return 400.
+                writer.write(b'X' * (9 * 1024))
+                await writer.drain()
+                resp = await asyncio.wait_for(reader.readuntil(b'\r\n\r\n'), timeout=2.0)
+                assert resp.startswith(b'HTTP/1.1 400'), resp
+            finally:
+                writer.close()
+                try:
+                    await writer.wait_closed()
+                except (ConnectionError, OSError):
+                    pass
+        finally:
+            await relay.stop()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()

--- a/tests/upstreamproxy/test_upstream_proxy.py
+++ b/tests/upstreamproxy/test_upstream_proxy.py
@@ -1,0 +1,286 @@
+"""Tests for ``src.upstreamproxy.upstream_proxy``.
+
+Covers the env-var gate logic, fail-open semantics, and
+``get_upstream_proxy_env`` (both enabled and inherited paths).
+The full init_upstream_proxy lifecycle is exercised via mocked HTTP +
+mocked relay (we don't spin up a real WS server here — that's
+``test_relay_e2e``).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from src.upstreamproxy import upstream_proxy as up
+from src.upstreamproxy.upstream_proxy import (
+    UpstreamProxyState,
+    _is_env_truthy,
+    get_upstream_proxy_env,
+    init_upstream_proxy,
+    reset_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    """Reset module-level state between tests; clear inherited env vars."""
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+@pytest.fixture
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear every relevant env var so test cases set them explicitly."""
+    for var in (
+        'CLAUDE_CODE_REMOTE',
+        'CCR_UPSTREAM_PROXY_ENABLED',
+        'CLAUDE_CODE_REMOTE_SESSION_ID',
+        'ANTHROPIC_BASE_URL',
+        'HTTPS_PROXY',
+        'https_proxy',
+        'NO_PROXY',
+        'no_proxy',
+        'SSL_CERT_FILE',
+        'NODE_EXTRA_CA_CERTS',
+        'REQUESTS_CA_BUNDLE',
+        'CURL_CA_BUNDLE',
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ─── _is_env_truthy ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize('val', ['1', 'true', 'TRUE', 'yes', 'on', 'anything-else'])
+def test_truthy_values(val: str) -> None:
+    assert _is_env_truthy(val)
+
+
+@pytest.mark.parametrize('val', ['', '0', 'false', 'FALSE', 'no', 'off', None])
+def test_falsy_values(val: str | None) -> None:
+    assert not _is_env_truthy(val)
+
+
+# ─── init_upstream_proxy gate logic ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_env_vars_returns_disabled(_clean_env) -> None:
+    state = await init_upstream_proxy()
+    assert state.enabled is False
+    assert state.port is None
+
+
+@pytest.mark.asyncio
+async def test_only_first_env_set_returns_disabled(
+    _clean_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``CLAUDE_CODE_REMOTE`` alone is insufficient; need both gates."""
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE', '1')
+    state = await init_upstream_proxy()
+    assert state.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_only_second_env_set_returns_disabled(
+    _clean_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``CCR_UPSTREAM_PROXY_ENABLED`` alone is insufficient."""
+    monkeypatch.setenv('CCR_UPSTREAM_PROXY_ENABLED', '1')
+    state = await init_upstream_proxy()
+    assert state.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_both_env_set_but_no_session_id_returns_disabled(
+    _clean_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both gates AND a session ID are needed."""
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE', '1')
+    monkeypatch.setenv('CCR_UPSTREAM_PROXY_ENABLED', '1')
+    state = await init_upstream_proxy()
+    assert state.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_missing_token_file_returns_disabled(
+    _clean_env, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """All env vars set but no token file — fail-open, return disabled."""
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE', '1')
+    monkeypatch.setenv('CCR_UPSTREAM_PROXY_ENABLED', '1')
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE_SESSION_ID', 'cse_test')
+    state = await init_upstream_proxy(token_path=tmp_path / 'no-such-file')
+    assert state.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_empty_token_file_returns_disabled(
+    _clean_env, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Token file exists but contains only whitespace — fail-open."""
+    token_path = tmp_path / 'token'
+    token_path.write_text('   \n   ')
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE', '1')
+    monkeypatch.setenv('CCR_UPSTREAM_PROXY_ENABLED', '1')
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE_SESSION_ID', 'cse_test')
+    state = await init_upstream_proxy(token_path=token_path)
+    assert state.enabled is False
+
+
+# ─── get_upstream_proxy_env ──────────────────────────────────────────────
+
+
+def test_disabled_returns_empty_dict(_clean_env) -> None:
+    """No state, no inherited proxy env → empty."""
+    assert get_upstream_proxy_env() == {}
+
+
+def test_disabled_inherits_parent_proxy_env(
+    _clean_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Child CLI: parent had HTTPS_PROXY + SSL_CERT_FILE → inherit."""
+    monkeypatch.setenv('HTTPS_PROXY', 'http://127.0.0.1:9999')
+    monkeypatch.setenv('https_proxy', 'http://127.0.0.1:9999')
+    monkeypatch.setenv('SSL_CERT_FILE', '/tmp/parent-ca.crt')
+    monkeypatch.setenv('NO_PROXY', 'localhost,*.anthropic.com')
+    env = get_upstream_proxy_env()
+    assert env['HTTPS_PROXY'] == 'http://127.0.0.1:9999'
+    assert env['SSL_CERT_FILE'] == '/tmp/parent-ca.crt'
+    assert env['NO_PROXY'] == 'localhost,*.anthropic.com'
+
+
+def test_disabled_partial_parent_env_returns_empty(
+    _clean_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Parent has HTTPS_PROXY but no SSL_CERT_FILE — refuse to inherit."""
+    monkeypatch.setenv('HTTPS_PROXY', 'http://127.0.0.1:9999')
+    assert get_upstream_proxy_env() == {}
+
+
+def test_enabled_returns_full_env_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When state.enabled, return the 9-var recipe with right NO_PROXY order."""
+    # Prime module state directly (bypass init for this unit test).
+    up._state = UpstreamProxyState(
+        enabled=True, port=12345, ca_bundle_path='/tmp/ca.crt'
+    )
+    env = get_upstream_proxy_env()
+    assert env['HTTPS_PROXY'] == 'http://127.0.0.1:12345'
+    assert env['https_proxy'] == 'http://127.0.0.1:12345'
+    assert env['SSL_CERT_FILE'] == '/tmp/ca.crt'
+    assert env['NODE_EXTRA_CA_CERTS'] == '/tmp/ca.crt'
+    assert env['REQUESTS_CA_BUNDLE'] == '/tmp/ca.crt'
+    assert env['CURL_CA_BUNDLE'] == '/tmp/ca.crt'
+    # NO_PROXY: anthropic.com forms must appear in the right order.
+    no_proxy = env['NO_PROXY']
+    apex = no_proxy.index('anthropic.com')
+    suffix = no_proxy.index('.anthropic.com')
+    glob = no_proxy.index('*.anthropic.com')
+    assert apex < suffix < glob
+
+
+# ─── End-to-end happy path with mocked HTTP + mocked relay ──────────────
+
+
+@pytest.mark.asyncio
+async def test_init_happy_path_with_mocked_components(
+    _clean_env, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """All gates pass + token file exists + CA download succeeds + relay starts."""
+    token_path = tmp_path / 'token'
+    token_path.write_text('secret-token-123')
+    sys_ca = tmp_path / 'system.crt'
+    sys_ca.write_bytes(b'SYS\n')
+    out_ca = tmp_path / 'merged.crt'
+
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE', '1')
+    monkeypatch.setenv('CCR_UPSTREAM_PROXY_ENABLED', '1')
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE_SESSION_ID', 'cse_test')
+    monkeypatch.setenv('ANTHROPIC_BASE_URL', 'https://api.test')
+
+    # Patch download_ca_bundle to write a fake bundle and return True.
+    async def fake_download_ca_bundle(
+        *, base_url, system_ca_path, out_path, **kwargs
+    ) -> bool:
+        out_path.write_bytes(b'-----BEGIN CERTIFICATE-----\nABC\n-----END CERTIFICATE-----\n')
+        return True
+
+    monkeypatch.setattr(up, 'download_ca_bundle', fake_download_ca_bundle)
+
+    # Patch start_upstream_proxy_relay to skip the real WS upgrade.
+    class _FakeRelay:
+        port = 54321
+
+        async def stop(self) -> None:
+            pass
+
+    async def fake_start_relay(*, ws_url, session_id, token):
+        assert ws_url == 'wss://api.test/v1/code/upstreamproxy/ws'
+        assert session_id == 'cse_test'
+        assert token == 'secret-token-123'
+        return _FakeRelay()
+
+    monkeypatch.setattr(up, 'start_upstream_proxy_relay', fake_start_relay)
+
+    state = await init_upstream_proxy(
+        token_path=token_path, system_ca_path=sys_ca, ca_bundle_path=out_ca
+    )
+
+    assert state.enabled is True
+    assert state.port == 54321
+    assert state.ca_bundle_path == str(out_ca)
+    # Token file unlinked AFTER relay startup (per WI-5.5 step 5).
+    assert not token_path.exists()
+    # Env dict reflects the new state.
+    env = get_upstream_proxy_env()
+    assert env['HTTPS_PROXY'] == 'http://127.0.0.1:54321'
+
+
+@pytest.mark.asyncio
+async def test_init_relay_failure_is_fail_open(
+    _clean_env, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Relay startup raises → return DISABLED, do NOT propagate."""
+    token_path = tmp_path / 'token'
+    token_path.write_text('tok')
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE', '1')
+    monkeypatch.setenv('CCR_UPSTREAM_PROXY_ENABLED', '1')
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE_SESSION_ID', 'cse_test')
+
+    async def good_download(**kwargs) -> bool:
+        return True
+
+    async def bad_relay(**kwargs):
+        raise OSError('cannot bind port')
+
+    monkeypatch.setattr(up, 'download_ca_bundle', good_download)
+    monkeypatch.setattr(up, 'start_upstream_proxy_relay', bad_relay)
+
+    state = await init_upstream_proxy(token_path=token_path)
+    assert state.enabled is False
+    # Token file should still be present — relay didn't start, so the
+    # unlink step is skipped (a supervisor restart can retry).
+    assert token_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_init_ca_download_failure_is_fail_open(
+    _clean_env, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """CA download returns False → return DISABLED."""
+    token_path = tmp_path / 'token'
+    token_path.write_text('tok')
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE', '1')
+    monkeypatch.setenv('CCR_UPSTREAM_PROXY_ENABLED', '1')
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE_SESSION_ID', 'cse_test')
+
+    async def fail_download(**kwargs) -> bool:
+        return False
+
+    monkeypatch.setattr(up, 'download_ca_bundle', fail_download)
+
+    state = await init_upstream_proxy(token_path=token_path)
+    assert state.enabled is False
+    assert token_path.exists(), 'token file must NOT be unlinked when CA download fails'


### PR DESCRIPTION
## Summary

**PR 3 of 6** in the Ch16 stack. Stacked on #41 (Phase 2). Rebase to `main` once #40 + #41 land.

Phase 5 — credential injection for CCR sessions running inside containers. Self-contained (depends only on Phase 2's `NO_PROXY` allowlist); can ship in parallel with Phase 1, 3, 4.

## Modules added (`src/upstreamproxy/`)

| Module | Purpose |
|---|---|
| `protobuf_codec.py` | Hand-encoded `UpstreamProxyChunk` codec (tag `0x0a` + varint + payload). 16 LOC of bit manipulation replaces a protobuf runtime dep. |
| `ptrace_guard.py` | `set_non_dumpable()` calls `libc.prctl(PR_SET_DUMPABLE, 0, ...)` via `ctypes` on Linux to block same-UID ptrace of the agent's heap (chapter §\"Apply This\" rule #4). No-op on macOS/Windows. Never raises. |
| `ca_bundle.py` | `is_valid_pem_content` (regex match for ≥1 well-formed PEM block — security guard against compromised server returning HTML/JSON) + `download_ca_bundle` (5 s timeout, PEM validation, atomic write via tempfile + `os.replace`). |
| `relay.py` | Single-asyncio CONNECT-over-WS relay (no Bun/Node fork). `asyncio.start_server` listens on 127.0.0.1:0; per-connection: parse CRLFCRLF (8 KB cap) → `websockets.connect` upgrade → bidirectional pump + 30 s app-level keepalive. **`asyncio.wait(FIRST_COMPLETED)`** instead of TaskGroup so one pump exiting tears down the others (caught a hang during dev). |
| `upstream_proxy.py` | `init_upstream_proxy` 6-step ordered setup: env-var gates (`CLAUDE_CODE_REMOTE` + `CCR_UPSTREAM_PROXY_ENABLED` + `CLAUDE_CODE_REMOTE_SESSION_ID`) → read `/run/ccr/session_token` → `set_non_dumpable` → download CA bundle → start relay → unlink token file (only AFTER relay up). `get_upstream_proxy_env` returns the 9-var dict for child subprocesses with parent-env-inheritance fallback. |

## Notable correctness invariants

- **Both env-var gates required** — without them the proxy would MITM traffic in non-CCR contexts.
- **Token file unlinked AFTER relay startup** — a supervisor restart before this point can retry with the token still on disk.
- **Three Anthropic NO_PROXY forms** in TS-exact order (`anthropic.com`, `.anthropic.com`, `*.anthropic.com`) — different runtimes parse NO_PROXY differently; missing any one would MITM the model API itself.
- **Atomic CA-bundle write** via `tempfile.mkstemp` + `os.replace`; test verifies no leftover `.tmp` on simulated rename failure.
- **Fail-open everywhere** — every error path returns the `_DISABLED` sentinel; never raises (chapter §\"Apply This\" rule #5).

## Test plan

- [x] `pytest tests/upstreamproxy/` — 64 pass + 1 skipped (Linux-only `prctl`)
- [x] `tests/upstreamproxy/test_relay_e2e.py` (3 tests, marked `integration`) — real WS round-trip against in-process echo server
- [x] `tests/upstreamproxy/test_ca_bundle.py::test_atomic_write_no_partial_file_on_crash` — simulates `os.replace` failure mid-write, asserts no leftover `.tmp`
- [x] `tests/upstreamproxy/test_upstream_proxy.py` — every gate combination returns disabled state; relay-failure-is-fail-open verifies token file is preserved when relay startup raises
- [x] 87% module coverage; uncovered branches are Linux-only `prctl` paths and rare WS-during-handshake errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)