### PR TITLE
feat(ch16/phase1): Direct Connect end-to-end (cc:// + cc+unix://)

### DIFF
--- a/src/server/direct_connect_manager.py
+++ b/src/server/direct_connect_manager.py
@@ -1,0 +1,348 @@
+"""WebSocket client for Direct Connect sessions.
+
+Ports ``typescript/src/server/directConnectManager.ts:40-213``.
+
+Connects to the WS URL returned by ``create_direct_connect_session``,
+reads NDJSON messages, branches by ``type``:
+
+  - ``control_request`` with subtype ``can_use_tool`` → permission
+    request callback (the only request the local server sends).
+  - ``control_request`` with any other subtype → error response so the
+    server doesn't hang.
+  - Other SDK messages (assistant, result, system) → on_message callback.
+  - ``control_response``, ``keep_alive``, ``control_cancel_request``,
+    ``streamlined_*``, ``system{subtype:'post_turn_summary'}`` → drop.
+
+Send side: ``send_message`` (user prompt), ``respond_to_permission_request``
+(allow/deny + updated_input/message), ``send_interrupt`` (cancel).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid as _uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+import websockets
+from websockets.asyncio.client import connect as ws_connect
+
+from src.bridge.messaging import RemotePermissionResponse
+from src.bridge.sdk_types import SDKControlPermissionRequest, SDKMessage
+
+from .direct_connect_session import DirectConnectConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DirectConnectCallbacks:
+    """Per-session event callbacks.
+
+    Mirrors TS ``DirectConnectCallbacks`` at
+    ``directConnectManager.ts:20-29``.
+    """
+
+    on_message: Callable[[SDKMessage], None | Awaitable[None]]
+    on_permission_request: Callable[[SDKControlPermissionRequest, str], None | Awaitable[None]]
+    on_connected: Callable[[], None | Awaitable[None]] | None = None
+    on_disconnected: Callable[[], None | Awaitable[None]] | None = None
+    on_error: Callable[[Exception], None | Awaitable[None]] | None = None
+
+
+def _is_stdout_message(value: object) -> bool:
+    """True for ``{type: str}`` payloads — pre-narrowing guard."""
+    return (
+        isinstance(value, dict)
+        and 'type' in value
+        and isinstance(value.get('type'), str)
+    )
+
+
+# Message types that the manager filters out (server-internal noise that
+# the local CLI does not need to surface). Mirrors the inverted check at
+# ``directConnectManager.ts:104-110``.
+_FILTERED_TYPES = frozenset({
+    'control_response',
+    'keep_alive',
+    'control_cancel_request',
+    'streamlined_text',
+    'streamlined_tool_use_summary',
+})
+
+
+class DirectConnectSessionManager:
+    """One Direct Connect WS session.
+
+    Lifecycle:
+        connect()      → opens WS, spawns reader task, fires on_connected
+        send_message() → POST a user prompt over the WS
+        respond_to_permission_request() → reply to a can_use_tool prompt
+        send_interrupt() → cancel the in-flight tool call
+        disconnect()   → close WS + cancel reader task
+    """
+
+    def __init__(
+        self,
+        config: DirectConnectConfig,
+        callbacks: DirectConnectCallbacks,
+    ) -> None:
+        self._config = config
+        self._callbacks = callbacks
+        self._ws: websockets.asyncio.client.ClientConnection | None = None
+        self._reader_task: asyncio.Task[None] | None = None
+        self._closed = False
+        # Set once on_disconnected has fired, to prevent double-fire when
+        # both the reader's finally AND disconnect() try to invoke it.
+        self._disconnected_fired = False
+
+    # ─── Public API ────────────────────────────────────────────────────
+
+    async def connect(self) -> None:
+        """Open the WS and start the reader. Resolves once the WS is open.
+
+        Raises ``websockets.exceptions.WebSocketException`` (and OSError
+        subclasses) on connect failure; does NOT swallow — caller can
+        retry or surface the error.
+        """
+        headers: dict[str, str] = {}
+        if self._config.auth_token:
+            headers['authorization'] = f'Bearer {self._config.auth_token}'
+
+        ws = await ws_connect(
+            self._config.ws_url,
+            additional_headers=headers,
+        )
+        self._ws = ws
+        self._reader_task = asyncio.get_running_loop().create_task(
+            self._read_loop(),
+            name='direct-connect-reader',
+        )
+        await self._invoke(self._callbacks.on_connected)
+
+    def is_connected(self) -> bool:
+        return self._ws is not None and not self._closed
+
+    async def send_message(self, content: object) -> bool:
+        """Send a user prompt over the WS.
+
+        Mirrors ``directConnectManager.ts:125-142``. The wire shape
+        matches what the agent's stream-json input format expects.
+        Returns False if the WS is not open.
+        """
+        if self._ws is None or self._closed:
+            return False
+        envelope = {
+            'type': 'user',
+            'message': {'role': 'user', 'content': content},
+            'parent_tool_use_id': None,
+            'session_id': '',
+        }
+        try:
+            await self._ws.send(json.dumps(envelope))
+        except (websockets.exceptions.ConnectionClosed, OSError):
+            return False
+        return True
+
+    async def respond_to_permission_request(
+        self,
+        request_id: str,
+        result: RemotePermissionResponse,
+    ) -> None:
+        """Reply to a ``can_use_tool`` control_request.
+
+        Mirrors ``directConnectManager.ts:144-167``. The wire shape is a
+        ``control_response`` with ``subtype: 'success'`` carrying the
+        allow/deny payload.
+        """
+        if self._ws is None or self._closed:
+            return
+        if result.behavior == 'allow':
+            response: dict[str, object] = {
+                'behavior': 'allow',
+                'updatedInput': getattr(result, 'updated_input', {}),
+            }
+        else:
+            response = {
+                'behavior': 'deny',
+                'message': getattr(result, 'message', ''),
+            }
+        envelope = {
+            'type': 'control_response',
+            'response': {
+                'subtype': 'success',
+                'request_id': request_id,
+                'response': response,
+            },
+        }
+        try:
+            await self._ws.send(json.dumps(envelope))
+        except (websockets.exceptions.ConnectionClosed, OSError):
+            pass
+
+    async def send_interrupt(self) -> None:
+        """Send a control_request with subtype ``interrupt``.
+
+        Mirrors ``directConnectManager.ts:172-186``. The local server
+        cancels the in-flight tool call and returns the agent loop to
+        an awaiting-user-input state.
+        """
+        if self._ws is None or self._closed:
+            return
+        envelope = {
+            'type': 'control_request',
+            'request_id': str(_uuid.uuid4()),
+            'request': {'subtype': 'interrupt'},
+        }
+        try:
+            await self._ws.send(json.dumps(envelope))
+        except (websockets.exceptions.ConnectionClosed, OSError):
+            pass
+
+    async def disconnect(self) -> None:
+        """Close the WS and cancel the reader task.
+
+        Fires ``on_disconnected`` exactly once — before cancelling the
+        reader, since the reader's ``finally``-block fire would itself
+        get cancelled mid-await and never reach the callback.
+        """
+        self._closed = True
+        ws, self._ws = self._ws, None
+        # Fire on_disconnected first (sync-or-coroutine), so cancellation
+        # of the reader can't pre-empt it. The flag prevents double-fire
+        # when the reader's natural finally also tries to invoke it.
+        await self._fire_disconnected_once()
+        if self._reader_task is not None:
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except (asyncio.CancelledError, websockets.exceptions.ConnectionClosed):
+                pass
+        if ws is not None:
+            try:
+                await ws.close()
+            except (websockets.exceptions.ConnectionClosed, OSError):
+                pass
+
+    async def _fire_disconnected_once(self) -> None:
+        if self._disconnected_fired:
+            return
+        self._disconnected_fired = True
+        await self._invoke(self._callbacks.on_disconnected)
+
+    # ─── Internal: message routing ─────────────────────────────────────
+
+    async def _read_loop(self) -> None:
+        """Pump WS messages until disconnect or error.
+
+        Mirrors ``directConnectManager.ts:64-122``. Handles NDJSON-on-WS
+        (each WS frame may contain multiple `\\n`-delimited messages, or
+        a single message; both shapes work).
+        """
+        ws = self._ws
+        assert ws is not None
+        try:
+            async for raw in ws:
+                if isinstance(raw, bytes):
+                    text = raw.decode('utf-8', errors='replace')
+                else:
+                    text = raw
+                # Split on newlines so a single WS frame containing
+                # multiple NDJSON lines is handled correctly. Empty
+                # lines are skipped.
+                for line in text.split('\n'):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        parsed = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not _is_stdout_message(parsed):
+                        continue
+                    await self._dispatch(parsed)
+        except websockets.exceptions.ConnectionClosed:
+            pass
+        except Exception as exc:  # noqa: BLE001 -- callback decides how to surface
+            await self._invoke(self._callbacks.on_error, exc)
+        finally:
+            await self._fire_disconnected_once()
+
+    async def _dispatch(self, msg: dict[str, object]) -> None:
+        """Branch one parsed message to the right callback."""
+        msg_type = msg.get('type')
+
+        if msg_type == 'control_request':
+            await self._handle_control_request(msg)
+            return
+
+        if msg_type == 'system' and msg.get('subtype') == 'post_turn_summary':
+            return  # filtered
+
+        if msg_type in _FILTERED_TYPES:
+            return  # filtered
+
+        await self._invoke(self._callbacks.on_message, msg)  # type: ignore[arg-type]
+
+    async def _handle_control_request(self, msg: dict[str, object]) -> None:
+        """Route a server → client control_request.
+
+        Only ``can_use_tool`` is recognized. Other subtypes get an error
+        response so the server doesn't hang waiting for a reply that
+        never comes (chapter explicit pattern).
+        """
+        request_id = msg.get('request_id')
+        inner = msg.get('request')
+        if not isinstance(request_id, str) or not isinstance(inner, dict):
+            return
+        subtype = inner.get('subtype')
+        if subtype == 'can_use_tool':
+            await self._invoke(
+                self._callbacks.on_permission_request,
+                inner,  # type: ignore[arg-type]
+                request_id,
+            )
+            return
+        # Unknown — send error response so the server doesn't hang.
+        logger.debug(
+            '[DirectConnect] Unsupported control request subtype: %s', subtype
+        )
+        await self._send_error_response(
+            request_id, f'Unsupported control request subtype: {subtype}'
+        )
+
+    async def _send_error_response(self, request_id: str, error: str) -> None:
+        """Send a ``control_response`` with ``subtype: 'error'``."""
+        if self._ws is None or self._closed:
+            return
+        envelope = {
+            'type': 'control_response',
+            'response': {
+                'subtype': 'error',
+                'request_id': request_id,
+                'error': error,
+            },
+        }
+        try:
+            await self._ws.send(json.dumps(envelope))
+        except (websockets.exceptions.ConnectionClosed, OSError):
+            pass
+
+    # ─── Internal: callback invocation helper ─────────────────────────
+
+    @staticmethod
+    async def _invoke(callback: Callable[..., object] | None, /, *args: object) -> None:
+        """Call a callback; await if it returns a coroutine."""
+        if callback is None:
+            return
+        result = callback(*args)
+        if asyncio.iscoroutine(result):
+            await result
+
+
+__all__ = [
+    'DirectConnectCallbacks',
+    'DirectConnectSessionManager',
+]

--- a/src/server/direct_connect_session.py
+++ b/src/server/direct_connect_session.py
@@ -1,0 +1,121 @@
+"""Direct Connect session creation (client side of POST /sessions).
+
+Ports ``typescript/src/server/createDirectConnectSession.ts:11-88``.
+
+Posts to ``${server_url}/sessions``, validates the response via
+``validate_connect_response``, returns a ``DirectConnectConfig`` ready
+for use by ``DirectConnectSessionManager``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from .types import validate_connect_response
+
+
+class DirectConnectError(Exception):
+    """Network, HTTP, or response-parsing failure during connect."""
+
+
+@dataclass(frozen=True)
+class DirectConnectConfig:
+    """Immutable config returned by ``create_direct_connect_session``.
+
+    Mirrors TS ``DirectConnectConfig`` at
+    ``server/directConnectManager.ts:13-18``. The ``auth_token`` is the
+    same token the server granted at session create; the WS upgrade
+    sends it as ``Authorization: Bearer ...``.
+    """
+
+    server_url: str
+    session_id: str
+    ws_url: str
+    auth_token: str | None = None
+
+
+async def create_direct_connect_session(
+    *,
+    server_url: str,
+    cwd: str,
+    auth_token: str | None = None,
+    dangerously_skip_permissions: bool = False,
+    client: httpx.AsyncClient | None = None,
+    timeout_seconds: float = 30.0,
+) -> tuple[DirectConnectConfig, str | None]:
+    """POST ``/sessions`` to ``server_url`` and return ``(config, work_dir)``.
+
+    Mirrors ``createDirectConnectSession.ts:26-88``.
+
+    Raises ``DirectConnectError`` on:
+      - network failure (DNS, connection refused, timeout)
+      - non-2xx HTTP response
+      - invalid response payload (missing ``session_id`` or ``ws_url``)
+
+    The ``client`` parameter is for tests; production callers omit it
+    and a fresh ``AsyncClient`` is constructed per call.
+    """
+    headers: dict[str, str] = {'content-type': 'application/json'}
+    if auth_token:
+        headers['authorization'] = f'Bearer {auth_token}'
+
+    body: dict[str, Any] = {'cwd': cwd}
+    if dangerously_skip_permissions:
+        body['dangerously_skip_permissions'] = True
+
+    url = f'{server_url.rstrip("/")}/sessions'
+
+    async def _do_post(c: httpx.AsyncClient) -> httpx.Response:
+        return await c.post(url, json=body, headers=headers, timeout=timeout_seconds)
+
+    try:
+        if client is None:
+            async with httpx.AsyncClient() as fresh:
+                resp = await _do_post(fresh)
+        else:
+            resp = await _do_post(client)
+    except (httpx.HTTPError, httpx.TimeoutException) as exc:
+        raise DirectConnectError(
+            f'Failed to connect to server at {server_url}: {exc}'
+        ) from exc
+
+    if resp.status_code < 200 or resp.status_code >= 300:
+        raise DirectConnectError(
+            f'Failed to create session: {resp.status_code} {resp.reason_phrase}'
+        )
+
+    try:
+        payload = resp.json()
+    except ValueError as exc:
+        raise DirectConnectError(f'Invalid session response: not valid JSON: {exc}') from exc
+
+    try:
+        validated = validate_connect_response(payload)
+    except ValueError as exc:
+        raise DirectConnectError(f'Invalid session response: {exc}') from exc
+
+    # Prefer the server-issued per-session token over the caller-supplied
+    # bootstrap token: the server's POST /sessions response includes a
+    # short-lived token in ``auth_token`` for the WS upgrade. Falling back
+    # to the bootstrap token preserves compatibility with servers that
+    # don't issue per-session tokens.
+    issued_token = payload.get('auth_token') if isinstance(payload, dict) else None
+    effective_token = issued_token if isinstance(issued_token, str) and issued_token else auth_token
+    config = DirectConnectConfig(
+        server_url=server_url,
+        session_id=validated['session_id'],
+        ws_url=validated['ws_url'],
+        auth_token=effective_token,
+    )
+    work_dir = validated.get('work_dir')
+    return config, work_dir
+
+
+__all__ = [
+    'DirectConnectConfig',
+    'DirectConnectError',
+    'create_direct_connect_session',
+]

--- a/src/server/lockfile.py
+++ b/src/server/lockfile.py
@@ -1,0 +1,110 @@
+"""Single-server-instance lockfile (POSIX flock; no-op on Windows).
+
+Reverse-engineered from ``main.tsx:3982`` which imports
+``./server/lockfile.js``. The TS source isn't in this snapshot; the
+contract from context is: prevent two ``claude server`` invocations
+from competing for the same ``--port`` (or default port).
+
+POSIX ``fcntl.flock(LOCK_EX | LOCK_NB)`` is automatically released by
+the kernel when the holding process exits, so stale-lock-after-crash
+is automatic.
+
+Direct Connect server is not supported on Windows in production, so
+the no-op there is acceptable; a Windows port would need
+``msvcrt.locking`` or a sentinel-PID file.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class LockfileBusyError(RuntimeError):
+    """Another process holds the server lockfile."""
+
+
+class ServerLockfile:
+    """Acquire/release context for ``~/.claude/server.lock``.
+
+    Usage:
+        async with ServerLockfile(path).hold():
+            await server.serve_forever()
+
+    Or imperatively:
+        lock = ServerLockfile(path)
+        lock.acquire()  # raises LockfileBusyError if held
+        try:
+            ...
+        finally:
+            lock.release()
+    """
+
+    def __init__(self, path: str | os.PathLike[str]) -> None:
+        self._path = Path(path)
+        self._fd: int | None = None
+
+    def acquire(self) -> None:
+        """Acquire the lock (LOCK_EX | LOCK_NB).
+
+        Raises ``LockfileBusyError`` if another process holds it.
+        ``OSError`` on filesystem failures (no permissions, missing
+        parent directory after the mkdir attempt, etc.) — those
+        propagate so the caller can decide how to surface.
+        """
+        try:
+            import fcntl
+        except ImportError:
+            # Windows: no-op. We still create the file so subsequent
+            # ``release`` is symmetric.
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._fd = os.open(self._path, os.O_RDWR | os.O_CREAT, 0o600)
+            return
+
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(self._path, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            os.close(fd)
+            raise LockfileBusyError(
+                f'Another claude server instance holds {self._path}'
+            ) from exc
+        self._fd = fd
+
+    def release(self) -> None:
+        """Release the lock and close the FD. Idempotent."""
+        if self._fd is None:
+            return
+        try:
+            import fcntl
+
+            try:
+                fcntl.flock(self._fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+        except ImportError:
+            pass
+        try:
+            os.close(self._fd)
+        except OSError:
+            pass
+        self._fd = None
+        # Best-effort unlink so the file doesn't accumulate over restarts.
+        try:
+            self._path.unlink()
+        except OSError:
+            pass
+
+    def __enter__(self) -> ServerLockfile:
+        self.acquire()
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.release()
+
+
+__all__ = ['LockfileBusyError', 'ServerLockfile']

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1,0 +1,479 @@
+"""Direct Connect local server (cc:// + cc+unix:// URL schemes).
+
+Reverse-engineered from ``main.tsx:3965`` which imports
+``./server/server.js``. The TS source isn't in this snapshot; the
+contract is deduced from the client side
+(``createDirectConnectSession.ts`` and ``directConnectManager.ts``):
+
+  - ``POST /sessions`` accepts ``{cwd, dangerously_skip_permissions?}``
+    and returns ``{session_id, ws_url, work_dir?, auth_token}``.
+  - WS endpoint accepts NDJSON-over-WS, with ``Authorization: Bearer``
+    on the upgrade request OR ``?token=<token>`` query param.
+  - 5-state ``SessionState`` lifecycle persisted to
+    ``~/.claude/server-sessions.json`` (via ``SessionManager``).
+
+**Architecture** — for robustness, the server uses **two separate
+listeners**: one HTTP (``asyncio.start_server`` + minimal HTTP/1.1
+parser) for ``POST /sessions``, and one WS (``websockets.asyncio.server``)
+for ``/ws/<session_id>``. The ``ws_url`` returned by ``POST /sessions``
+points at the WS port. This avoids depending on websockets internal
+``Protocol`` APIs to wrap an HTTP-upgraded socket.
+
+WI-1.9 (RESERVED) refines the spec once integration tests reveal gaps
+in the reverse-engineered protocol.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import secrets
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass, field
+from urllib.parse import parse_qs
+
+import websockets
+from websockets.asyncio.server import ServerConnection, serve as ws_serve
+
+from .session_manager import SessionManager
+from .types import ServerConfig, SessionState
+
+logger = logging.getLogger(__name__)
+
+
+#: Type for the callback that spawns an agent subprocess for a session.
+#: The implementation is out of scope for this minimal cut — tests
+#: provide a fake that returns an in-process pipe; the real CLI wiring
+#: lands in a follow-up.
+SpawnAgent = Callable[
+    [str, str, str | None],  # session_id, cwd, permission_mode
+    Awaitable['AgentHandle'],
+]
+
+
+@dataclass
+class AgentHandle:
+    """Handle to a spawned agent subprocess (or test double).
+
+    ``send_to_agent``: write a JSON-encoded SDK message into the agent's
+    stdin (caller adds a trailing newline if needed).
+    ``messages_from_agent``: async iterator yielding SDK message dicts
+    parsed from the agent's stdout.
+    ``shutdown``: terminate the agent and clean up.
+    """
+
+    send_to_agent: Callable[[dict], Awaitable[None]]
+    messages_from_agent: Callable[[], AsyncIterator[dict]]
+    shutdown: Callable[[], Awaitable[None]]
+
+
+# ─── HTTP/1.1 minimal parser for POST /sessions ────────────────────────────
+
+
+@dataclass
+class _ParsedRequest:
+    method: str
+    path: str
+    headers: dict[str, str]
+    body: bytes
+
+
+async def _read_http_request(
+    reader: asyncio.StreamReader,
+    *,
+    max_header_bytes: int = 64 * 1024,
+    max_body_bytes: int = 1 * 1024 * 1024,
+) -> _ParsedRequest | None:
+    """Read one HTTP/1.1 request from ``reader``. Returns None on malformed input."""
+    head_buf = bytearray()
+    while True:
+        chunk = await reader.read(4096)
+        if not chunk:
+            return None
+        head_buf.extend(chunk)
+        end = head_buf.find(b'\r\n\r\n')
+        if end != -1:
+            break
+        if len(head_buf) > max_header_bytes:
+            return None
+    head_text = head_buf[:end].decode('utf-8', errors='replace')
+    leftover = bytes(head_buf[end + 4 :])
+    lines = head_text.split('\r\n')
+    if not lines:
+        return None
+    request_line = lines[0].split()
+    if len(request_line) != 3:
+        return None
+    method, path, version = request_line
+    if not version.upper().startswith('HTTP/1.'):
+        return None
+
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        if ':' not in line:
+            continue
+        key, _, value = line.partition(':')
+        headers[key.strip().lower()] = value.strip()
+
+    content_length_str = headers.get('content-length', '0') or '0'
+    try:
+        content_length = int(content_length_str)
+    except ValueError:
+        return None
+    if content_length < 0 or content_length > max_body_bytes:
+        return None
+    body = bytearray(leftover[:content_length])
+    while len(body) < content_length:
+        chunk = await reader.read(content_length - len(body))
+        if not chunk:
+            return None
+        body.extend(chunk)
+
+    return _ParsedRequest(
+        method=method.upper(),
+        path=path,
+        headers=headers,
+        body=bytes(body),
+    )
+
+
+def _build_http_response(
+    *,
+    status: int,
+    reason: str,
+    body: bytes = b'',
+    content_type: str = 'application/json',
+) -> bytes:
+    return (
+        f'HTTP/1.1 {status} {reason}\r\n'
+        f'Content-Type: {content_type}\r\n'
+        f'Content-Length: {len(body)}\r\n'
+        f'Connection: close\r\n'
+        f'\r\n'
+    ).encode('ascii') + body
+
+
+# ─── Server ────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class DirectConnectServer:
+    """Direct Connect server — HTTP ``/sessions`` + WS ``/ws/<sid>``.
+
+    Lifecycle:
+        srv = DirectConnectServer(config, manager, spawn_agent)
+        await srv.start()
+        await srv.serve_forever()  # or use srv.stop() to shut down
+        await srv.stop()
+
+    Two listeners: HTTP on ``config.port`` (or ephemeral) and WS on a
+    separate ephemeral port. ``ws_url`` in the create-session response
+    points at the WS port. Auth is per-session: ``POST /sessions``
+    returns ``auth_token``; the WS upgrade requires it via
+    ``Authorization: Bearer <token>`` or ``?token=<token>``.
+    """
+
+    config: ServerConfig
+    manager: SessionManager
+    spawn_agent: SpawnAgent
+    _http_server: asyncio.AbstractServer | None = None
+    _ws_server: asyncio.Server | None = None
+    _session_tokens: dict[str, str] = field(default_factory=dict)
+    _ws_port: int | None = None
+
+    # ─── Public lifecycle ────────────────────────────────────────────
+
+    async def start(self) -> None:
+        """Bind both listeners; ``serve_forever`` to actually run."""
+        # WS listener first so we know its port for the ``ws_url`` we
+        # hand out from the HTTP route.
+        self._ws_server = await ws_serve(
+            self._handle_ws_connection,
+            host=self.config.host or '127.0.0.1',
+            port=0,  # ephemeral
+        )
+        ws_sockets = list(self._ws_server.sockets or [])
+        if not ws_sockets:
+            raise RuntimeError('DirectConnectServer: WS listener has no socket')
+        self._ws_port = ws_sockets[0].getsockname()[1]
+
+        # HTTP listener.
+        if self.config.unix:
+            self._http_server = await asyncio.start_unix_server(
+                self._handle_http_connection,
+                path=self.config.unix,
+            )
+        else:
+            self._http_server = await asyncio.start_server(
+                self._handle_http_connection,
+                host=self.config.host or '127.0.0.1',
+                port=self.config.port,
+            )
+
+    async def serve_forever(self) -> None:
+        if self._http_server is None or self._ws_server is None:
+            raise RuntimeError('start() must be called before serve_forever()')
+        # Both servers run concurrently; cancellation of either tears
+        # down both atomically via the gather.
+        await asyncio.gather(
+            self._http_server.serve_forever(),
+            self._ws_server.serve_forever(),
+            return_exceptions=True,
+        )
+
+    async def stop(self) -> None:
+        if self._http_server is not None:
+            self._http_server.close()
+            await self._http_server.wait_closed()
+            self._http_server = None
+        if self._ws_server is not None:
+            self._ws_server.close()
+            await self._ws_server.wait_closed()
+            self._ws_server = None
+        for sid in list(self.manager.active_session_ids()):
+            await self.manager.stop_session(sid)
+
+    @property
+    def bound_http_port(self) -> int | None:
+        """Bound HTTP port (None if not started or Unix-only)."""
+        if self._http_server is None:
+            return None
+        sockets = self._http_server.sockets
+        if not sockets:
+            return None
+        sock = sockets[0]
+        if sock.family.name == 'AF_UNIX':
+            return None
+        return sock.getsockname()[1]
+
+    @property
+    def bound_ws_port(self) -> int | None:
+        return self._ws_port
+
+    # ─── HTTP listener handler ───────────────────────────────────────
+
+    async def _handle_http_connection(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """One accepted HTTP connection: parse request, dispatch route."""
+        try:
+            request = await _read_http_request(reader)
+            if request is None:
+                writer.write(_build_http_response(
+                    status=400, reason='Bad Request', body=b'malformed request',
+                ))
+                await writer.drain()
+                return
+
+            if request.method == 'POST' and request.path == '/sessions':
+                await self._handle_post_sessions(request, writer)
+            else:
+                writer.write(_build_http_response(
+                    status=404, reason='Not Found', body=b'no such route',
+                ))
+                await writer.drain()
+        except (ConnectionError, OSError) as exc:
+            logger.debug('[server] HTTP connection error: %s', exc)
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except (ConnectionError, OSError):
+                pass
+
+    async def _handle_post_sessions(
+        self,
+        request: _ParsedRequest,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """Create a new session and return ``{session_id, ws_url, work_dir, auth_token}``."""
+        if self.config.auth_token:
+            authz = request.headers.get('authorization', '')
+            expected = f'Bearer {self.config.auth_token}'
+            if authz != expected:
+                writer.write(_build_http_response(
+                    status=401, reason='Unauthorized',
+                    body=b'{"error":"invalid auth token"}',
+                ))
+                await writer.drain()
+                return
+
+        try:
+            payload = json.loads(request.body)
+        except json.JSONDecodeError:
+            writer.write(_build_http_response(
+                status=400, reason='Bad Request',
+                body=b'{"error":"invalid JSON body"}',
+            ))
+            await writer.drain()
+            return
+
+        if not isinstance(payload, dict):
+            writer.write(_build_http_response(
+                status=400, reason='Bad Request',
+                body=b'{"error":"body must be a JSON object"}',
+            ))
+            await writer.drain()
+            return
+
+        cwd = payload.get('cwd')
+        if not isinstance(cwd, str) or not cwd:
+            writer.write(_build_http_response(
+                status=400, reason='Bad Request',
+                body=b'{"error":"cwd is required (non-empty string)"}',
+            ))
+            await writer.drain()
+            return
+
+        try:
+            info = self.manager.create_session(cwd=cwd)
+        except RuntimeError as exc:
+            writer.write(_build_http_response(
+                status=503, reason='Service Unavailable',
+                body=json.dumps({'error': str(exc)}).encode('utf-8'),
+            ))
+            await writer.drain()
+            return
+
+        token = secrets.token_urlsafe(32)
+        self._session_tokens[info.id] = token
+
+        host = self.config.host or '127.0.0.1'
+        ws_port = self._ws_port
+        ws_url = f'ws://{host}:{ws_port}/ws/{info.id}?token={token}'
+
+        body = json.dumps({
+            'session_id': info.id,
+            'ws_url': ws_url,
+            'work_dir': info.work_dir,
+            'auth_token': token,
+        }).encode('utf-8')
+        writer.write(_build_http_response(
+            status=201, reason='Created', body=body,
+        ))
+        await writer.drain()
+
+    # ─── WS listener handler ─────────────────────────────────────────
+
+    async def _handle_ws_connection(self, ws: ServerConnection) -> None:
+        """One accepted WS connection: validate session/token, then pump."""
+        # The ``websockets`` library exposes the request path on
+        # ``ws.request``. URL: ``/ws/<session_id>[?token=<token>]``.
+        request = ws.request
+        if request is None:
+            await ws.close(code=1008, reason='no request')
+            return
+        path = request.path
+        prefix = '/ws/'
+        if not path.startswith(prefix):
+            await ws.close(code=1008, reason='no such route')
+            return
+        sid_and_query = path[len(prefix):]
+        sid, _, query_str = sid_and_query.partition('?')
+        if not sid:
+            await ws.close(code=1008, reason='missing session id')
+            return
+
+        expected_token = self._session_tokens.get(sid)
+        if expected_token is None:
+            await ws.close(code=1008, reason='no such session')
+            return
+
+        # Token from header OR query param.
+        provided = ''
+        authz = request.headers.get('authorization', '') if request.headers else ''
+        if authz.startswith('Bearer '):
+            provided = authz[len('Bearer '):]
+        else:
+            params = parse_qs(query_str)
+            provided = (params.get('token') or [''])[0]
+        if not secrets.compare_digest(provided, expected_token):
+            await ws.close(code=1008, reason='invalid token')
+            return
+
+        info = self.manager.get(sid)
+        if info is None:
+            await ws.close(code=1008, reason='session not found')
+            return
+
+        try:
+            agent = await self.spawn_agent(sid, info.work_dir, None)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning('[server] agent spawn failed for %s: %s', sid, exc)
+            await ws.close(code=1011, reason='agent spawn failed')
+            return
+        self.manager.mark_running(sid)
+
+        try:
+            await self._run_ws_session(ws, sid, agent)
+        finally:
+            # Drop the per-session token so it can't be reused after
+            # this WS connection ends.
+            self._session_tokens.pop(sid, None)
+            await agent.shutdown()
+            await self.manager.stop_session(sid)
+
+    async def _run_ws_session(
+        self,
+        ws: ServerConnection,
+        session_id: str,
+        agent: AgentHandle,
+    ) -> None:
+        """Pump frames between the WS and the agent subprocess."""
+
+        async def outbound() -> None:
+            try:
+                async for msg in agent.messages_from_agent():
+                    await ws.send(json.dumps(msg))
+            except (
+                websockets.exceptions.ConnectionClosed,
+                ConnectionError,
+                OSError,
+            ):
+                return
+
+        async def inbound() -> None:
+            try:
+                async for raw in ws:
+                    text = raw if isinstance(raw, str) else raw.decode('utf-8', errors='replace')
+                    for line in text.split('\n'):
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            parsed = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        if isinstance(parsed, dict):
+                            try:
+                                await agent.send_to_agent(parsed)
+                            except (ConnectionError, OSError):
+                                return
+            except websockets.exceptions.ConnectionClosed:
+                return
+
+        out_task = asyncio.get_running_loop().create_task(outbound())
+        in_task = asyncio.get_running_loop().create_task(inbound())
+        try:
+            await asyncio.wait(
+                [out_task, in_task], return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            for task in (out_task, in_task):
+                if not task.done():
+                    task.cancel()
+                try:
+                    await task
+                except (
+                    asyncio.CancelledError,
+                    websockets.exceptions.ConnectionClosed,
+                    ConnectionError,
+                    OSError,
+                ):
+                    pass
+
+
+__all__ = ['AgentHandle', 'DirectConnectServer', 'SpawnAgent']

--- a/src/server/session_index.py
+++ b/src/server/session_index.py
@@ -1,0 +1,223 @@
+"""``~/.claude/server-sessions.json`` persistence for Direct Connect sessions.
+
+Mirrors the persistence helpers implied by ``server/types.ts:46-57``:
+the server reads the index at startup to resume sessions across server
+restarts; reads/writes the index when sessions start/stop/become
+detached.
+
+Concurrency: server process and resuming-client process can both touch
+the file. We use ``fcntl.flock(LOCK_EX)`` on POSIX (no-op on Windows
+since Direct Connect is Linux/macOS-only in production). Atomic writes
+via ``tempfile.mkstemp`` + ``os.replace``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import tempfile
+from contextlib import contextmanager
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Iterator
+
+from .types import SessionIndexEntry
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_INDEX_PATH = Path.home() / '.claude' / 'server-sessions.json'
+
+#: ``SessionIndex`` is keyed by ``session_id`` (TS uses ``string`` keys
+#: but the value type matches ``SessionIndexEntry``).
+SessionIndex = dict[str, SessionIndexEntry]
+
+
+# ─── File-lock context manager ─────────────────────────────────────────────
+
+
+@contextmanager
+def _flock(path: Path) -> Iterator[None]:
+    """Exclusive lock on ``path`` for the duration of the ``with`` block.
+
+    POSIX-only via ``fcntl.flock``; Windows is a no-op (Direct Connect
+    server is not supported on Windows in production). Lock is auto-
+    released by kernel when the FD closes (process exit included), so
+    stale-lock-after-crash is automatic.
+    """
+    try:
+        import fcntl
+    except ImportError:
+        # Windows: no-op. Direct Connect server isn't supported there.
+        yield
+        return
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+# ─── Read/write ────────────────────────────────────────────────────────────
+
+
+def _entry_to_dict(entry: SessionIndexEntry) -> dict[str, Any]:
+    return asdict(entry)
+
+
+def _dict_to_entry(payload: dict[str, Any]) -> SessionIndexEntry:
+    """Strict ``dict → SessionIndexEntry`` parser; raises on unknown keys."""
+    required = {'session_id', 'transcript_session_id', 'cwd', 'created_at', 'last_active_at'}
+    missing = required - payload.keys()
+    if missing:
+        raise ValueError(f'session index entry missing fields: {sorted(missing)}')
+    return SessionIndexEntry(
+        session_id=str(payload['session_id']),
+        transcript_session_id=str(payload['transcript_session_id']),
+        cwd=str(payload['cwd']),
+        created_at=float(payload['created_at']),
+        last_active_at=float(payload['last_active_at']),
+        permission_mode=(
+            str(payload['permission_mode'])
+            if payload.get('permission_mode') is not None
+            else None
+        ),
+    )
+
+
+def load_index(path: Path = DEFAULT_INDEX_PATH) -> SessionIndex:
+    """Read the index file. Missing/empty/corrupted file → empty dict.
+
+    Best-effort: a corrupted file (invalid JSON, missing fields) is
+    treated as empty rather than raising — the server can still start
+    fresh.
+    """
+    try:
+        raw = path.read_text(encoding='utf-8')
+    except FileNotFoundError:
+        return {}
+    except OSError as exc:
+        logger.warning('[session_index] read failed: %s; returning empty index', exc)
+        return {}
+    if not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning('[session_index] invalid JSON: %s; returning empty index', exc)
+        return {}
+    if not isinstance(parsed, dict):
+        logger.warning('[session_index] root is not an object; returning empty index')
+        return {}
+    out: SessionIndex = {}
+    for key, value in parsed.items():
+        if not isinstance(value, dict):
+            continue
+        try:
+            out[str(key)] = _dict_to_entry(value)
+        except (ValueError, TypeError) as exc:
+            logger.warning(
+                '[session_index] skipping malformed entry %r: %s', key, exc
+            )
+            continue
+    return out
+
+
+def save_index(index: SessionIndex, path: Path = DEFAULT_INDEX_PATH) -> None:
+    """Atomically replace the index file with ``index`` contents.
+
+    Uses ``tempfile.mkstemp`` in the same directory + ``os.replace``
+    (POSIX atomic). The file mode is 0o600 to keep session IDs +
+    cwds out of other users' view.
+    """
+    payload: dict[str, dict[str, Any]] = {
+        sid: _entry_to_dict(entry) for sid, entry in index.items()
+    }
+    serialized = json.dumps(payload, sort_keys=True, indent=2).encode('utf-8')
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent), prefix='.server-sessions.', suffix='.tmp'
+    )
+    try:
+        with os.fdopen(fd, 'wb') as fh:
+            fh.write(serialized)
+            fh.flush()
+            os.fsync(fh.fileno())
+        # Mode 0o600 — owner only.
+        try:
+            os.chmod(tmp_path, 0o600)
+        except OSError:
+            pass
+        os.replace(tmp_path, path)
+    except OSError:
+        # Best-effort cleanup of the tempfile on failure.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ─── Mutators ──────────────────────────────────────────────────────────────
+
+
+def add_entry(entry: SessionIndexEntry, path: Path = DEFAULT_INDEX_PATH) -> None:
+    """Add or replace ``entry`` in the index. Locked; atomic."""
+    with _flock(path):
+        index = load_index(path)
+        index[entry.session_id] = entry
+        save_index(index, path)
+
+
+def remove_entry(session_id: str, path: Path = DEFAULT_INDEX_PATH) -> None:
+    """Remove ``session_id`` from the index. Locked; atomic. No-op if absent."""
+    with _flock(path):
+        index = load_index(path)
+        if session_id in index:
+            del index[session_id]
+            save_index(index, path)
+
+
+def update_last_active(
+    session_id: str,
+    timestamp: float,
+    path: Path = DEFAULT_INDEX_PATH,
+) -> None:
+    """Bump ``last_active_at`` for ``session_id``. Locked; atomic.
+
+    No-op if the session isn't in the index (the server may be ahead of
+    the index for a freshly-started session not yet persisted).
+    """
+    with _flock(path):
+        index = load_index(path)
+        existing = index.get(session_id)
+        if existing is None:
+            return
+        # Frozen dataclass — replace by constructing a new instance.
+        index[session_id] = SessionIndexEntry(
+            session_id=existing.session_id,
+            transcript_session_id=existing.transcript_session_id,
+            cwd=existing.cwd,
+            created_at=existing.created_at,
+            last_active_at=timestamp,
+            permission_mode=existing.permission_mode,
+        )
+        save_index(index, path)
+
+
+__all__ = [
+    'DEFAULT_INDEX_PATH',
+    'SessionIndex',
+    'add_entry',
+    'load_index',
+    'remove_entry',
+    'save_index',
+    'update_last_active',
+]

--- a/src/server/session_manager.py
+++ b/src/server/session_manager.py
@@ -1,0 +1,203 @@
+"""Session lifecycle manager for the Direct Connect server.
+
+Reverse-engineered from ``main.tsx:3968`` which imports
+``./server/sessionManager.js``. The TS source isn't in this snapshot;
+the contract from the client side (``directConnectManager.ts``) plus
+``main.tsx`` flag handling implies:
+
+  - Map ``session_id`` → spawned agent subprocess.
+  - Track ``SessionState`` (5-state lifecycle from ``types.py``).
+  - Persist to ``SessionIndex`` so a server restart can resume.
+  - Enforce ``--max-sessions`` cap.
+  - Idle-timeout for ``DETACHED`` sessions (the user navigated away
+    but didn't kill the session).
+
+This implementation is intentionally minimal — the core fan-out
+(WS-frame → subprocess-stdin and subprocess-stdout → WS-frame) is
+implemented; advanced features (worktree, mid-session permission-mode
+change) are deferred to WI-1.9.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid as _uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .session_index import (
+    DEFAULT_INDEX_PATH,
+    add_entry,
+    remove_entry,
+    update_last_active,
+)
+from .types import SessionIndexEntry, SessionInfo, SessionState
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SessionManager:
+    """In-memory + on-disk Direct Connect session registry.
+
+    The manager owns the map of live sessions; the server-loop module
+    drives them via ``create_session``, ``mark_running``,
+    ``mark_detached``, ``mark_stopped``, and ``stop_session``.
+    """
+
+    workspace: str
+    max_sessions: int | None = None
+    idle_timeout_ms: int = 0
+    index_path: Path = DEFAULT_INDEX_PATH
+    _sessions: dict[str, SessionInfo] = field(default_factory=dict)
+
+    # ─── Mutators ──────────────────────────────────────────────────────
+
+    def create_session(
+        self,
+        *,
+        cwd: str | None = None,
+        permission_mode: str | None = None,
+    ) -> SessionInfo:
+        """Allocate a new session ID and record it in STARTING state.
+
+        Raises ``RuntimeError`` if ``max_sessions`` would be exceeded.
+        Caller is responsible for actually spawning the agent
+        subprocess and then calling ``attach_process`` + ``mark_running``.
+        """
+        if self.max_sessions is not None and self._active_count() >= self.max_sessions:
+            raise RuntimeError(
+                f'Direct Connect server: max_sessions ({self.max_sessions}) reached'
+            )
+        sid = f'ds_{_uuid.uuid4().hex}'
+        now = time.time()
+        info = SessionInfo(
+            id=sid,
+            status=SessionState.STARTING,
+            created_at=now,
+            work_dir=cwd or self.workspace,
+            last_active_at=now,
+        )
+        self._sessions[sid] = info
+        # Persist so a server restart can resume — even before the
+        # subprocess actually starts. The transcript_session_id
+        # initially equals the session_id; if the subprocess uses a
+        # different transcript ID, the server can update via
+        # ``update_transcript_id`` (out of scope for this minimal cut).
+        add_entry(
+            SessionIndexEntry(
+                session_id=sid,
+                transcript_session_id=sid,
+                cwd=info.work_dir,
+                created_at=info.created_at,
+                last_active_at=info.created_at,
+                permission_mode=permission_mode,
+            ),
+            path=self.index_path,
+        )
+        return info
+
+    def attach_process(
+        self,
+        session_id: str,
+        process: asyncio.subprocess.Process,
+    ) -> None:
+        info = self._sessions.get(session_id)
+        if info is None:
+            raise KeyError(f'unknown session: {session_id}')
+        info.process = process
+
+    def mark_running(self, session_id: str) -> None:
+        info = self._sessions.get(session_id)
+        if info is None:
+            return
+        now = time.time()
+        info.status = SessionState.RUNNING
+        info.last_active_at = now
+        update_last_active(session_id, now, path=self.index_path)
+
+    def mark_detached(self, session_id: str) -> None:
+        info = self._sessions.get(session_id)
+        if info is None:
+            return
+        now = time.time()
+        info.status = SessionState.DETACHED
+        info.last_active_at = now
+        update_last_active(session_id, now, path=self.index_path)
+
+    def touch(self, session_id: str) -> None:
+        """Bump ``last_active_at`` (e.g., on each message exchange).
+
+        Use from server hot paths to keep the idle reaper accurate.
+        """
+        info = self._sessions.get(session_id)
+        if info is None:
+            return
+        info.last_active_at = time.time()
+
+    async def stop_session(self, session_id: str) -> None:
+        """Transition through STOPPING → STOPPED, killing the subprocess."""
+        info = self._sessions.get(session_id)
+        if info is None:
+            return
+        info.status = SessionState.STOPPING
+        proc = info.process
+        if proc is not None and proc.returncode is None:
+            try:
+                proc.terminate()
+                # Give the agent a chance to flush; SIGKILL after 5s.
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=5.0)
+                except asyncio.TimeoutError:
+                    proc.kill()
+                    await proc.wait()
+            except (ProcessLookupError, OSError):
+                pass
+        info.status = SessionState.STOPPED
+        info.process = None
+        remove_entry(session_id, path=self.index_path)
+        self._sessions.pop(session_id, None)
+
+    # ─── Read-side helpers ────────────────────────────────────────────
+
+    def get(self, session_id: str) -> SessionInfo | None:
+        return self._sessions.get(session_id)
+
+    def active_session_ids(self) -> list[str]:
+        return [
+            sid
+            for sid, info in self._sessions.items()
+            if info.status in (SessionState.STARTING, SessionState.RUNNING, SessionState.DETACHED)
+        ]
+
+    def _active_count(self) -> int:
+        return len(self.active_session_ids())
+
+    # ─── Idle-timeout sweeper ─────────────────────────────────────────
+
+    async def reap_idle_detached(self, now: float | None = None) -> list[str]:
+        """Stop any DETACHED session whose ``last_active_at`` is past idle_timeout.
+
+        ``idle_timeout_ms == 0`` disables the sweep (per ``ServerConfig``).
+        Returns the list of session IDs that were stopped. Compares
+        against ``last_active_at`` (NOT ``created_at``) so a long-lived
+        active-then-detached session isn't reaped purely because it was
+        created hours ago.
+        """
+        if self.idle_timeout_ms <= 0:
+            return []
+        now_t = now if now is not None else time.time()
+        cutoff = now_t - (self.idle_timeout_ms / 1000.0)
+        stopped: list[str] = []
+        for sid, info in list(self._sessions.items()):
+            if info.status != SessionState.DETACHED:
+                continue
+            if info.last_active_at < cutoff:
+                await self.stop_session(sid)
+                stopped.append(sid)
+        return stopped
+
+
+__all__ = ['SessionManager']

--- a/src/server/types.py
+++ b/src/server/types.py
@@ -1,0 +1,138 @@
+"""Direct Connect type definitions.
+
+Ports ``typescript/src/server/types.ts``: ``ServerConfig``,
+``SessionState`` (5-state lifecycle), ``SessionInfo``,
+``SessionIndexEntry``, and the response-validation helper for
+``POST /sessions``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, TypedDict
+
+
+class SessionState(str, Enum):
+    """5-state Direct Connect session lifecycle.
+
+    Mirrors ``server/types.ts:26-31``. Values are strings so they
+    serialize cleanly through ``~/.claude/server-sessions.json``.
+    """
+
+    STARTING = 'starting'
+    RUNNING = 'running'
+    DETACHED = 'detached'
+    STOPPING = 'stopping'
+    STOPPED = 'stopped'
+
+
+@dataclass(frozen=True)
+class ServerConfig:
+    """Direct Connect server configuration.
+
+    Mirrors ``server/types.ts:13-24``. The ``unix`` field selects the
+    Unix-domain-socket variant (``--unix /path/to/sock``); when set,
+    ``host``/``port`` are ignored. ``idle_timeout_ms = 0`` means
+    "never expire detached sessions."
+    """
+
+    port: int = 0
+    host: str = '127.0.0.1'
+    auth_token: str = ''
+    unix: str | None = None
+    idle_timeout_ms: int = 0
+    max_sessions: int | None = None
+    workspace: str | None = None
+
+
+@dataclass
+class SessionInfo:
+    """In-memory record of a server-side session.
+
+    Mirrors ``server/types.ts:33-41``. ``process`` is a Popen-equivalent
+    handle (``asyncio.subprocess.Process``); ``None`` when the session
+    is being torn down.
+
+    ``last_active_at`` is bumped on state transitions and per-message
+    activity; the idle-timeout reaper compares against this field, NOT
+    against ``created_at`` — otherwise a long-lived active-then-detached
+    session would be reaped purely because it was created hours ago.
+    """
+
+    id: str
+    status: SessionState
+    created_at: float
+    work_dir: str
+    process: asyncio.subprocess.Process | None = None
+    session_key: str | None = None
+    last_active_at: float = 0.0  # initialized to created_at by SessionManager.create_session
+
+
+@dataclass(frozen=True)
+class SessionIndexEntry:
+    """On-disk record persisted to ``~/.claude/server-sessions.json``.
+
+    Mirrors ``server/types.ts:46-55``. Used to resume sessions across
+    server restarts: the new server reads this file at startup and can
+    restart the agent subprocess with ``--resume {transcriptSessionId}``.
+    """
+
+    session_id: str
+    transcript_session_id: str
+    cwd: str
+    created_at: float
+    last_active_at: float
+    permission_mode: str | None = None
+
+
+# ─── Wire schema for POST /sessions response ──────────────────────────────
+
+
+class ConnectResponse(TypedDict, total=False):
+    """``POST /sessions`` response shape.
+
+    Mirrors zod ``connectResponseSchema`` at ``server/types.ts:5-11``.
+    """
+
+    session_id: str
+    ws_url: str
+    work_dir: str  # optional
+
+
+def validate_connect_response(payload: object) -> ConnectResponse:
+    """Validate a ``POST /sessions`` response payload.
+
+    Raises ``ValueError`` on missing required fields or wrong types.
+    Returns the payload typed as ``ConnectResponse`` (caller still
+    treats it as a dict; the TypedDict is documentation).
+    """
+    if not isinstance(payload, dict):
+        raise ValueError(
+            f'connect response must be an object, got {type(payload).__name__}'
+        )
+    sid = payload.get('session_id')
+    if not isinstance(sid, str) or not sid:
+        raise ValueError('connect response missing session_id (non-empty string)')
+    ws_url = payload.get('ws_url')
+    if not isinstance(ws_url, str) or not ws_url:
+        raise ValueError('connect response missing ws_url (non-empty string)')
+    # work_dir is optional
+    work_dir = payload.get('work_dir')
+    if work_dir is not None and not isinstance(work_dir, str):
+        raise ValueError('connect response work_dir must be a string when present')
+    out: ConnectResponse = {'session_id': sid, 'ws_url': ws_url}
+    if isinstance(work_dir, str):
+        out['work_dir'] = work_dir
+    return out
+
+
+__all__ = [
+    'ConnectResponse',
+    'ServerConfig',
+    'SessionIndexEntry',
+    'SessionInfo',
+    'SessionState',
+    'validate_connect_response',
+]

--- a/src/server/url_scheme.py
+++ b/src/server/url_scheme.py
@@ -1,0 +1,123 @@
+"""``cc://`` and ``cc+unix://`` URL scheme parser for Direct Connect.
+
+Mirrors the parser logic implied by ``main.tsx:613, 618, 635, 3872``
+which accept both schemes. There is no canonical TS file for the
+parser — the URL is split by the surrounding code — but the contract
+is clear:
+
+    cc://host:port/session_id?key=value
+    cc+unix:///path/to/socket/session_id?key=value
+
+For Unix sockets, the socket path can itself contain ``/``; we treat
+**everything after the LAST ``/``** as the session ID.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+from urllib.parse import parse_qs
+
+
+CCScheme = Literal['cc', 'cc+unix']
+
+
+@dataclass(frozen=True)
+class CCAddress:
+    """Parsed ``cc://`` or ``cc+unix://`` address."""
+
+    scheme: CCScheme
+    #: For ``cc://``: the hostname (e.g. ``127.0.0.1``).
+    #: For ``cc+unix://``: the absolute Unix-socket path.
+    host_or_socket: str
+    port: int | None
+    session_id: str
+    query: dict[str, str] = field(default_factory=dict)
+
+
+def parse_cc_url(raw: str) -> CCAddress:
+    """Parse a ``cc://`` or ``cc+unix://`` URL.
+
+    Raises ``ValueError`` for any malformed input. ``urllib.parse`` is
+    NOT used directly because it doesn't handle our two custom schemes
+    consistently across Python versions; we parse by hand.
+    """
+    if raw.startswith('cc+unix://'):
+        return _parse_cc_unix(raw[len('cc+unix://'):])
+    if raw.startswith('cc://'):
+        return _parse_cc_tcp(raw[len('cc://'):])
+    raise ValueError(f'unsupported scheme: {raw!r}')
+
+
+def _split_query(rest: str) -> tuple[str, dict[str, str]]:
+    """Split ``path?query`` into (path, parsed_query)."""
+    if '?' not in rest:
+        return rest, {}
+    path, _, query_str = rest.partition('?')
+    parsed = parse_qs(query_str, keep_blank_values=True)
+    # parse_qs returns list[str] per key; flatten to first value (last write wins).
+    flat: dict[str, str] = {k: v[-1] for k, v in parsed.items()}
+    return path, flat
+
+
+def _parse_cc_tcp(remainder: str) -> CCAddress:
+    """Parse the body of ``cc://`` (host[:port]/session_id[?query])."""
+    body, query = _split_query(remainder)
+    if '/' not in body:
+        raise ValueError('cc:// URL missing session ID component')
+    authority, _, session_id = body.rpartition('/')
+    if not session_id:
+        raise ValueError('cc:// URL has empty session ID')
+    if not authority:
+        raise ValueError('cc:// URL missing host')
+    if ':' in authority:
+        host, port_str = authority.rsplit(':', 1)
+        try:
+            port = int(port_str, 10)
+        except ValueError as exc:
+            raise ValueError(f'cc:// URL invalid port: {port_str!r}') from exc
+        if not (1 <= port <= 65535):
+            raise ValueError(f'cc:// URL port out of range: {port}')
+    else:
+        host = authority
+        port = None
+    if not host:
+        raise ValueError('cc:// URL has empty host')
+    return CCAddress(
+        scheme='cc',
+        host_or_socket=host,
+        port=port,
+        session_id=session_id,
+        query=query,
+    )
+
+
+def _parse_cc_unix(remainder: str) -> CCAddress:
+    """Parse the body of ``cc+unix://`` (/path/to/socket/session_id[?query]).
+
+    The Unix socket path can contain ``/``; the session ID is the last
+    path component.
+    """
+    body, query = _split_query(remainder)
+    # cc+unix:// requires an absolute path — leading slash is consumed
+    # by the scheme prefix split, so ``body`` must START with another
+    # ``/`` in absolute form. Reject empty too.
+    if not body or '/' not in body:
+        raise ValueError('cc+unix:// URL missing path or session ID')
+    socket_path, _, session_id = body.rpartition('/')
+    if not session_id:
+        raise ValueError('cc+unix:// URL has empty session ID')
+    # Add the leading slash back: ``cc+unix:///foo/bar/sid`` →
+    # remainder ``/foo/bar/sid`` → split → socket_path = '/foo/bar'.
+    if not socket_path:
+        raise ValueError('cc+unix:// URL has empty socket path')
+    return CCAddress(
+        scheme='cc+unix',
+        host_or_socket=socket_path,
+        port=None,
+        session_id=session_id,
+        query=query,
+    )
+
+
+__all__ = ['CCAddress', 'CCScheme', 'parse_cc_url']

--- a/tests/server/test_direct_connect_manager.py
+++ b/tests/server/test_direct_connect_manager.py
@@ -1,0 +1,284 @@
+"""Tests for ``src.server.direct_connect_manager.DirectConnectSessionManager``.
+
+Uses an in-process WS echo server so tests run without external
+infrastructure. Exercises message routing, permission round-trip,
+interrupt, control-request unknown-subtype error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+
+import pytest
+import websockets
+from websockets.asyncio.server import serve as ws_serve
+
+from src.bridge.messaging import AllowResponse, DenyResponse
+from src.server.direct_connect_manager import (
+    DirectConnectCallbacks,
+    DirectConnectSessionManager,
+)
+from src.server.direct_connect_session import DirectConnectConfig
+
+
+pytestmark = pytest.mark.integration  # spins up real WS listeners
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('127.0.0.1', 0))
+        return s.getsockname()[1]
+
+
+class _TestEnv:
+    """Helper: WS server + manager wired for one test case."""
+
+    def __init__(self) -> None:
+        self.received_from_client: list[str] = []
+        self.client_messages_received: list[dict] = []
+        self.client_permission_requests: list[tuple[dict, str]] = []
+        self.client_disconnected = asyncio.Event()
+        self.server_send_queue: asyncio.Queue[str] = asyncio.Queue()
+
+    async def server_handler(self, ws):
+        async def out():
+            try:
+                while True:
+                    line = await self.server_send_queue.get()
+                    await ws.send(line)
+            except websockets.exceptions.ConnectionClosed:
+                return
+
+        async def inn():
+            try:
+                async for raw in ws:
+                    text = raw if isinstance(raw, str) else raw.decode()
+                    self.received_from_client.append(text)
+            except websockets.exceptions.ConnectionClosed:
+                return
+
+        out_task = asyncio.get_running_loop().create_task(out())
+        in_task = asyncio.get_running_loop().create_task(inn())
+        try:
+            await asyncio.wait(
+                [out_task, in_task], return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            for t in (out_task, in_task):
+                if not t.done():
+                    t.cancel()
+                try:
+                    await t
+                except (asyncio.CancelledError, websockets.exceptions.ConnectionClosed):
+                    pass
+
+    def make_callbacks(self) -> DirectConnectCallbacks:
+        return DirectConnectCallbacks(
+            on_message=lambda m: self.client_messages_received.append(m),
+            on_permission_request=lambda req, rid: self.client_permission_requests.append(
+                (req, rid)
+            ),
+            on_disconnected=lambda: self.client_disconnected.set(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_assistant_message_forwarded_to_on_message():
+    env = _TestEnv()
+    port = _free_port()
+    server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = DirectConnectConfig(
+            server_url=f'http://127.0.0.1:{port}',
+            session_id='s1',
+            ws_url=f'ws://127.0.0.1:{port}/',
+        )
+        mgr = DirectConnectSessionManager(config, env.make_callbacks())
+        await mgr.connect()
+        try:
+            await env.server_send_queue.put(json.dumps({
+                'type': 'assistant', 'uuid': 'u1', 'message': {'content': 'hi'}
+            }))
+            # Give the reader a turn.
+            await asyncio.sleep(0.05)
+            assert len(env.client_messages_received) == 1
+            assert env.client_messages_received[0]['type'] == 'assistant'
+        finally:
+            await mgr.disconnect()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_permission_request_routed_correctly():
+    env = _TestEnv()
+    port = _free_port()
+    server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = DirectConnectConfig(
+            server_url=f'http://127.0.0.1:{port}',
+            session_id='s1',
+            ws_url=f'ws://127.0.0.1:{port}/',
+        )
+        mgr = DirectConnectSessionManager(config, env.make_callbacks())
+        await mgr.connect()
+        try:
+            await env.server_send_queue.put(json.dumps({
+                'type': 'control_request',
+                'request_id': 'req-1',
+                'request': {
+                    'subtype': 'can_use_tool',
+                    'tool_name': 'Bash',
+                    'input': {'command': 'ls'},
+                    'tool_use_id': 'tu-1',
+                },
+            }))
+            await asyncio.sleep(0.05)
+            assert len(env.client_permission_requests) == 1
+            req, rid = env.client_permission_requests[0]
+            assert rid == 'req-1'
+            assert req['tool_name'] == 'Bash'
+
+            # Respond allow.
+            await mgr.respond_to_permission_request(
+                'req-1', AllowResponse(updated_input={'command': 'ls -la'})
+            )
+            await asyncio.sleep(0.05)
+            # Server should have received the response.
+            assert any('control_response' in line for line in env.received_from_client)
+            sent = json.loads(env.received_from_client[-1])
+            assert sent['response']['response']['behavior'] == 'allow'
+            assert sent['response']['response']['updatedInput'] == {'command': 'ls -la'}
+        finally:
+            await mgr.disconnect()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_unknown_control_request_subtype_returns_error():
+    env = _TestEnv()
+    port = _free_port()
+    server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = DirectConnectConfig(
+            server_url=f'http://127.0.0.1:{port}',
+            session_id='s1',
+            ws_url=f'ws://127.0.0.1:{port}/',
+        )
+        mgr = DirectConnectSessionManager(config, env.make_callbacks())
+        await mgr.connect()
+        try:
+            await env.server_send_queue.put(json.dumps({
+                'type': 'control_request',
+                'request_id': 'req-2',
+                'request': {'subtype': 'set_quantum_flux'},
+            }))
+            await asyncio.sleep(0.05)
+            # Permission callback was NOT fired.
+            assert env.client_permission_requests == []
+            # An error response was sent back.
+            assert any(
+                'control_response' in line and 'error' in line
+                for line in env.received_from_client
+            )
+        finally:
+            await mgr.disconnect()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_send_message_round_trip():
+    env = _TestEnv()
+    port = _free_port()
+    server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = DirectConnectConfig(
+            server_url=f'http://127.0.0.1:{port}',
+            session_id='s1',
+            ws_url=f'ws://127.0.0.1:{port}/',
+        )
+        mgr = DirectConnectSessionManager(config, env.make_callbacks())
+        await mgr.connect()
+        try:
+            ok = await mgr.send_message('hello')
+            assert ok is True
+            await asyncio.sleep(0.05)
+            assert len(env.received_from_client) == 1
+            sent = json.loads(env.received_from_client[0])
+            assert sent['type'] == 'user'
+            assert sent['message']['role'] == 'user'
+            assert sent['message']['content'] == 'hello'
+        finally:
+            await mgr.disconnect()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_send_interrupt_emits_control_request():
+    env = _TestEnv()
+    port = _free_port()
+    server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = DirectConnectConfig(
+            server_url=f'http://127.0.0.1:{port}',
+            session_id='s1',
+            ws_url=f'ws://127.0.0.1:{port}/',
+        )
+        mgr = DirectConnectSessionManager(config, env.make_callbacks())
+        await mgr.connect()
+        try:
+            await mgr.send_interrupt()
+            await asyncio.sleep(0.05)
+            assert len(env.received_from_client) == 1
+            sent = json.loads(env.received_from_client[0])
+            assert sent['type'] == 'control_request'
+            assert sent['request']['subtype'] == 'interrupt'
+        finally:
+            await mgr.disconnect()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_fires_on_disconnected():
+    env = _TestEnv()
+    port = _free_port()
+    server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = DirectConnectConfig(
+            server_url=f'http://127.0.0.1:{port}',
+            session_id='s1',
+            ws_url=f'ws://127.0.0.1:{port}/',
+        )
+        mgr = DirectConnectSessionManager(config, env.make_callbacks())
+        await mgr.connect()
+        await mgr.disconnect()
+        # ``on_disconnected`` may fire from the reader's finally block.
+        await asyncio.wait_for(env.client_disconnected.wait(), timeout=2.0)
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_send_message_returns_false_when_disconnected():
+    env = _TestEnv()
+    config = DirectConnectConfig(
+        server_url='http://x',
+        session_id='s1',
+        ws_url='ws://127.0.0.1:1/',
+    )
+    mgr = DirectConnectSessionManager(config, env.make_callbacks())
+    # Did NOT call connect — should return False without raising.
+    ok = await mgr.send_message('hi')
+    assert ok is False

--- a/tests/server/test_direct_connect_session.py
+++ b/tests/server/test_direct_connect_session.py
@@ -1,0 +1,109 @@
+"""Tests for ``src.server.direct_connect_session``."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from src.server.direct_connect_session import (
+    DirectConnectError,
+    create_direct_connect_session,
+)
+
+
+@pytest.mark.asyncio
+async def test_happy_path():
+    def handler(req: httpx.Request) -> httpx.Response:
+        assert req.method == 'POST'
+        assert req.url.path == '/sessions'
+        body = json.loads(req.content)
+        assert body['cwd'] == '/tmp/work'
+        return httpx.Response(
+            201,
+            json={
+                'session_id': 'cse_abc',
+                'ws_url': 'ws://127.0.0.1:1234/ws/cse_abc?token=tk',
+                'work_dir': '/tmp/work',
+                'auth_token': 'tk',
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        config, work_dir = await create_direct_connect_session(
+            server_url='http://srv', cwd='/tmp/work', client=client,
+        )
+    assert config.session_id == 'cse_abc'
+    assert config.ws_url == 'ws://127.0.0.1:1234/ws/cse_abc?token=tk'
+    assert work_dir == '/tmp/work'
+
+
+@pytest.mark.asyncio
+async def test_passes_auth_token_when_set():
+    def handler(req: httpx.Request) -> httpx.Response:
+        assert req.headers.get('authorization') == 'Bearer my-token'
+        return httpx.Response(
+            201, json={'session_id': 's', 'ws_url': 'ws://x/ws/s'},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await create_direct_connect_session(
+            server_url='http://srv', cwd='/tmp', auth_token='my-token', client=client,
+        )
+
+
+@pytest.mark.asyncio
+async def test_dangerously_skip_permissions_in_body():
+    captured_body: list[dict] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured_body.append(json.loads(req.content))
+        return httpx.Response(
+            201, json={'session_id': 's', 'ws_url': 'ws://x/ws/s'},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await create_direct_connect_session(
+            server_url='http://srv',
+            cwd='/tmp',
+            dangerously_skip_permissions=True,
+            client=client,
+        )
+    assert captured_body[0]['dangerously_skip_permissions'] is True
+
+
+@pytest.mark.asyncio
+async def test_network_error_raises_direct_connect_error():
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError('refused')
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(DirectConnectError, match='Failed to connect'):
+            await create_direct_connect_session(
+                server_url='http://srv', cwd='/tmp', client=client,
+            )
+
+
+@pytest.mark.asyncio
+async def test_non_2xx_raises():
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, content=b'unavailable')
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(DirectConnectError, match='Failed to create session'):
+            await create_direct_connect_session(
+                server_url='http://srv', cwd='/tmp', client=client,
+            )
+
+
+@pytest.mark.asyncio
+async def test_invalid_response_payload_raises():
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(201, json={'session_id': 's'})  # missing ws_url
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(DirectConnectError, match='Invalid session response'):
+            await create_direct_connect_session(
+                server_url='http://srv', cwd='/tmp', client=client,
+            )

--- a/tests/server/test_lockfile.py
+++ b/tests/server/test_lockfile.py
@@ -1,0 +1,54 @@
+"""Tests for ``src.server.lockfile.ServerLockfile``."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.server.lockfile import LockfileBusyError, ServerLockfile
+
+
+def test_acquire_release(tmp_path):
+    p = tmp_path / 'server.lock'
+    lock = ServerLockfile(p)
+    lock.acquire()
+    lock.release()
+    # Idempotent release.
+    lock.release()
+
+
+def test_double_acquire_raises_busy(tmp_path):
+    """Two ServerLockfile instances on the same path can't both hold it."""
+    p = tmp_path / 'server.lock'
+    lock1 = ServerLockfile(p)
+    lock2 = ServerLockfile(p)
+
+    lock1.acquire()
+    try:
+        with pytest.raises(LockfileBusyError):
+            lock2.acquire()
+    finally:
+        lock1.release()
+
+
+def test_lock_releasable_for_subsequent_acquire(tmp_path):
+    p = tmp_path / 'server.lock'
+    lock1 = ServerLockfile(p)
+    lock1.acquire()
+    lock1.release()
+
+    lock2 = ServerLockfile(p)
+    lock2.acquire()  # should succeed
+    lock2.release()
+
+
+def test_context_manager(tmp_path):
+    p = tmp_path / 'server.lock'
+    with ServerLockfile(p):
+        # Inside the context, another lockfile is busy.
+        other = ServerLockfile(p)
+        with pytest.raises(LockfileBusyError):
+            other.acquire()
+    # After exit, lock is released.
+    third = ServerLockfile(p)
+    third.acquire()
+    third.release()

--- a/tests/server/test_server_e2e.py
+++ b/tests/server/test_server_e2e.py
@@ -1,0 +1,237 @@
+"""End-to-end test: DirectConnectServer + DirectConnectSessionManager.
+
+Spins up the real server, connects via the client, exchanges a user
+prompt + assistant response, verifies the session lifecycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+
+from src.server.direct_connect_manager import (
+    DirectConnectCallbacks,
+    DirectConnectSessionManager,
+)
+from src.server.direct_connect_session import (
+    DirectConnectConfig,
+    create_direct_connect_session,
+)
+from src.server.server import AgentHandle, DirectConnectServer
+from src.server.session_index import load_index
+from src.server.session_manager import SessionManager
+from src.server.types import ServerConfig
+
+
+pytestmark = pytest.mark.integration
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('127.0.0.1', 0))
+        return s.getsockname()[1]
+
+
+def _make_fake_agent_factory(scripted_responses: list[dict]):
+    """Returns a SpawnAgent callable; the spawned agent emits ``scripted_responses``
+    when the client sends its first message."""
+
+    async def spawn(session_id: str, cwd: str, perm_mode: str | None) -> AgentHandle:
+        send_queue: asyncio.Queue[dict] = asyncio.Queue()
+        out_queue: asyncio.Queue[dict | None] = asyncio.Queue()
+        first_received = asyncio.Event()
+
+        async def consumer() -> None:
+            await send_queue.get()
+            first_received.set()
+            for resp in scripted_responses:
+                await out_queue.put(resp)
+            await out_queue.put(None)  # sentinel: shutdown
+
+        consumer_task = asyncio.get_running_loop().create_task(consumer())
+
+        async def send_to_agent(msg: dict) -> None:
+            await send_queue.put(msg)
+
+        async def messages_from_agent() -> AsyncIterator[dict]:
+            while True:
+                item = await out_queue.get()
+                if item is None:
+                    return
+                yield item
+
+        async def shutdown() -> None:
+            consumer_task.cancel()
+            try:
+                await consumer_task
+            except asyncio.CancelledError:
+                pass
+
+        return AgentHandle(
+            send_to_agent=send_to_agent,
+            messages_from_agent=messages_from_agent,
+            shutdown=shutdown,
+        )
+
+    return spawn
+
+
+@pytest.mark.asyncio
+async def test_e2e_create_session_and_exchange_message(tmp_path):
+    config = ServerConfig(
+        host='127.0.0.1',
+        port=_free_port(),
+        workspace=str(tmp_path),
+    )
+    manager = SessionManager(workspace=str(tmp_path), index_path=tmp_path / 'idx.json')
+    spawn = _make_fake_agent_factory([
+        {'type': 'assistant', 'uuid': 'a1', 'message': {'content': 'hi back'}},
+    ])
+    server = DirectConnectServer(config=config, manager=manager, spawn_agent=spawn)
+    await server.start()
+
+    serve_task = asyncio.get_running_loop().create_task(server.serve_forever())
+
+    try:
+        # Step 1: POST /sessions via the client helper.
+        cfg, work_dir = await create_direct_connect_session(
+            server_url=f'http://127.0.0.1:{config.port}',
+            cwd=str(tmp_path),
+        )
+        assert cfg.session_id.startswith('ds_')
+        assert work_dir == str(tmp_path)
+
+        # Session should be in the index.
+        idx = load_index(tmp_path / 'idx.json')
+        assert cfg.session_id in idx
+
+        # Step 2: open the WS via DirectConnectSessionManager.
+        received_messages: list[dict] = []
+        disc = asyncio.Event()
+        callbacks = DirectConnectCallbacks(
+            on_message=lambda m: received_messages.append(m),
+            on_permission_request=lambda req, rid: None,
+            on_disconnected=lambda: disc.set(),
+        )
+        client = DirectConnectSessionManager(cfg, callbacks)
+        await client.connect()
+        try:
+            # Step 3: send a user prompt; expect the scripted assistant
+            # response to land via on_message.
+            await client.send_message('hello')
+
+            # Wait for the assistant message (with timeout).
+            for _ in range(50):
+                if received_messages:
+                    break
+                await asyncio.sleep(0.05)
+            assert received_messages, 'expected at least one assistant message'
+            assert received_messages[0]['type'] == 'assistant'
+            assert received_messages[0]['message']['content'] == 'hi back'
+        finally:
+            await client.disconnect()
+
+    finally:
+        await server.stop()
+        serve_task.cancel()
+        try:
+            await serve_task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_e2e_session_persists_across_index_reads(tmp_path):
+    """After session create, the index has the entry; after stop, it's gone."""
+    config = ServerConfig(
+        host='127.0.0.1', port=_free_port(), workspace=str(tmp_path),
+    )
+    manager = SessionManager(workspace=str(tmp_path), index_path=tmp_path / 'idx.json')
+    server = DirectConnectServer(
+        config=config,
+        manager=manager,
+        spawn_agent=_make_fake_agent_factory([]),
+    )
+    await server.start()
+    serve_task = asyncio.get_running_loop().create_task(server.serve_forever())
+
+    try:
+        cfg, _ = await create_direct_connect_session(
+            server_url=f'http://127.0.0.1:{config.port}',
+            cwd=str(tmp_path),
+        )
+        # Session is in the index.
+        assert cfg.session_id in load_index(tmp_path / 'idx.json')
+
+        # Stop it via the manager.
+        await manager.stop_session(cfg.session_id)
+        assert cfg.session_id not in load_index(tmp_path / 'idx.json')
+    finally:
+        await server.stop()
+        serve_task.cancel()
+        try:
+            await serve_task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_e2e_unauthorized_session_create_returns_401(tmp_path):
+    config = ServerConfig(
+        host='127.0.0.1',
+        port=_free_port(),
+        auth_token='secret',
+        workspace=str(tmp_path),
+    )
+    manager = SessionManager(workspace=str(tmp_path), index_path=tmp_path / 'idx.json')
+    server = DirectConnectServer(
+        config=config, manager=manager,
+        spawn_agent=_make_fake_agent_factory([]),
+    )
+    await server.start()
+    serve_task = asyncio.get_running_loop().create_task(server.serve_forever())
+
+    try:
+        # No auth_token passed; server requires one → 401.
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f'http://127.0.0.1:{config.port}/sessions',
+                json={'cwd': str(tmp_path)},
+            )
+        assert resp.status_code == 401
+    finally:
+        await server.stop()
+        serve_task.cancel()
+        try:
+            await serve_task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_e2e_unknown_route_returns_404(tmp_path):
+    config = ServerConfig(host='127.0.0.1', port=_free_port(), workspace=str(tmp_path))
+    manager = SessionManager(workspace=str(tmp_path), index_path=tmp_path / 'idx.json')
+    server = DirectConnectServer(
+        config=config, manager=manager,
+        spawn_agent=_make_fake_agent_factory([]),
+    )
+    await server.start()
+    serve_task = asyncio.get_running_loop().create_task(server.serve_forever())
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f'http://127.0.0.1:{config.port}/nope')
+        assert resp.status_code == 404
+    finally:
+        await server.stop()
+        serve_task.cancel()
+        try:
+            await serve_task
+        except asyncio.CancelledError:
+            pass

--- a/tests/server/test_session_index.py
+++ b/tests/server/test_session_index.py
@@ -1,0 +1,137 @@
+"""Tests for ``src.server.session_index``."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from src.server.session_index import (
+    add_entry,
+    load_index,
+    remove_entry,
+    save_index,
+    update_last_active,
+)
+from src.server.types import SessionIndexEntry
+
+
+def _entry(sid: str = 's1', t: float = 1000.0) -> SessionIndexEntry:
+    return SessionIndexEntry(
+        session_id=sid,
+        transcript_session_id=f'tx_{sid}',
+        cwd='/tmp/work',
+        created_at=t,
+        last_active_at=t,
+    )
+
+
+def test_load_missing_file_returns_empty(tmp_path):
+    assert load_index(tmp_path / 'nope.json') == {}
+
+
+def test_load_invalid_json_returns_empty(tmp_path):
+    p = tmp_path / 'idx.json'
+    p.write_text('not json {{{')
+    assert load_index(p) == {}
+
+
+def test_load_non_object_root_returns_empty(tmp_path):
+    p = tmp_path / 'idx.json'
+    p.write_text('[1, 2, 3]')
+    assert load_index(p) == {}
+
+
+def test_load_skips_malformed_entries(tmp_path):
+    p = tmp_path / 'idx.json'
+    p.write_text(json.dumps({
+        'good': {
+            'session_id': 'good',
+            'transcript_session_id': 'tx',
+            'cwd': '/tmp',
+            'created_at': 1.0,
+            'last_active_at': 2.0,
+        },
+        'bad': {'session_id': 'bad'},  # missing fields
+        'wrong_type': 'not a dict',
+    }))
+    idx = load_index(p)
+    assert 'good' in idx
+    assert 'bad' not in idx
+    assert 'wrong_type' not in idx
+
+
+def test_save_and_load_round_trip(tmp_path):
+    p = tmp_path / 'idx.json'
+    save_index({'s1': _entry('s1')}, p)
+    loaded = load_index(p)
+    assert loaded['s1'].cwd == '/tmp/work'
+    assert loaded['s1'].transcript_session_id == 'tx_s1'
+
+
+def test_add_entry_creates_file(tmp_path):
+    p = tmp_path / 'idx.json'
+    add_entry(_entry('s1'), p)
+    assert load_index(p)['s1'].session_id == 's1'
+
+
+def test_add_entry_replaces_existing(tmp_path):
+    p = tmp_path / 'idx.json'
+    add_entry(_entry('s1', t=100), p)
+    add_entry(_entry('s1', t=200), p)
+    idx = load_index(p)
+    assert idx['s1'].created_at == 200
+
+
+def test_remove_entry(tmp_path):
+    p = tmp_path / 'idx.json'
+    add_entry(_entry('s1'), p)
+    add_entry(_entry('s2'), p)
+    remove_entry('s1', p)
+    idx = load_index(p)
+    assert 's1' not in idx
+    assert 's2' in idx
+
+
+def test_remove_entry_missing_is_noop(tmp_path):
+    p = tmp_path / 'idx.json'
+    add_entry(_entry('s1'), p)
+    remove_entry('nope', p)  # should not raise
+    assert 's1' in load_index(p)
+
+
+def test_update_last_active(tmp_path):
+    p = tmp_path / 'idx.json'
+    add_entry(_entry('s1', t=100), p)
+    update_last_active('s1', 5000.0, p)
+    idx = load_index(p)
+    assert idx['s1'].last_active_at == 5000.0
+    # created_at preserved.
+    assert idx['s1'].created_at == 100.0
+
+
+def test_update_last_active_missing_session_is_noop(tmp_path):
+    p = tmp_path / 'idx.json'
+    add_entry(_entry('s1'), p)
+    update_last_active('nope', 9999.0, p)  # no-op
+    assert load_index(p)['s1'].last_active_at == 1000.0
+
+
+def test_atomic_write_no_leftover_tempfile_on_failure(tmp_path, monkeypatch):
+    """If os.replace fails mid-write, the .tmp file should not survive."""
+    import os
+
+    p = tmp_path / 'idx.json'
+    add_entry(_entry('s1'), p)
+
+    def fail_replace(*args, **kwargs):
+        raise OSError('simulated rename failure')
+
+    monkeypatch.setattr(os, 'replace', fail_replace)
+
+    with pytest.raises(OSError):
+        save_index({'s1': _entry('s1', t=999.0)}, p)
+
+    leftover = list(tmp_path.glob('.server-sessions.*.tmp'))
+    assert leftover == [], f'expected no leftover tempfile, got {leftover}'

--- a/tests/server/test_session_manager.py
+++ b/tests/server/test_session_manager.py
@@ -1,0 +1,146 @@
+"""Tests for ``src.server.session_manager.SessionManager``."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from src.server.session_manager import SessionManager
+from src.server.types import SessionState
+
+
+def _make_manager(tmp_path, **overrides):
+    return SessionManager(
+        workspace=str(tmp_path),
+        index_path=tmp_path / 'idx.json',
+        **overrides,
+    )
+
+
+def test_create_session_assigns_id_and_records_starting(tmp_path):
+    mgr = _make_manager(tmp_path)
+    info = mgr.create_session(cwd='/tmp/work')
+    assert info.id.startswith('ds_')
+    assert info.status == SessionState.STARTING
+    assert info.work_dir == '/tmp/work'
+    # Persisted to the index.
+    from src.server.session_index import load_index
+    idx = load_index(tmp_path / 'idx.json')
+    assert info.id in idx
+
+
+def test_create_session_default_cwd(tmp_path):
+    mgr = _make_manager(tmp_path)
+    info = mgr.create_session()
+    assert info.work_dir == str(tmp_path)
+
+
+def test_max_sessions_enforced(tmp_path):
+    mgr = _make_manager(tmp_path, max_sessions=2)
+    mgr.create_session()
+    mgr.create_session()
+    with pytest.raises(RuntimeError, match='max_sessions'):
+        mgr.create_session()
+
+
+def test_mark_running_updates_state(tmp_path):
+    mgr = _make_manager(tmp_path)
+    info = mgr.create_session()
+    mgr.mark_running(info.id)
+    assert mgr.get(info.id).status == SessionState.RUNNING
+
+
+def test_mark_detached_updates_state(tmp_path):
+    mgr = _make_manager(tmp_path)
+    info = mgr.create_session()
+    mgr.mark_detached(info.id)
+    assert mgr.get(info.id).status == SessionState.DETACHED
+
+
+@pytest.mark.asyncio
+async def test_stop_session_removes_from_index(tmp_path):
+    mgr = _make_manager(tmp_path)
+    info = mgr.create_session()
+    await mgr.stop_session(info.id)
+    assert mgr.get(info.id) is None
+    from src.server.session_index import load_index
+    assert info.id not in load_index(tmp_path / 'idx.json')
+
+
+@pytest.mark.asyncio
+async def test_stop_unknown_session_is_noop(tmp_path):
+    mgr = _make_manager(tmp_path)
+    await mgr.stop_session('does-not-exist')
+
+
+def test_active_session_ids_filters_stopped(tmp_path):
+    mgr = _make_manager(tmp_path)
+    a = mgr.create_session()
+    b = mgr.create_session()
+    mgr.mark_running(a.id)
+    assert set(mgr.active_session_ids()) == {a.id, b.id}
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_detached_zero_timeout_no_op(tmp_path):
+    mgr = _make_manager(tmp_path, idle_timeout_ms=0)
+    info = mgr.create_session()
+    mgr.mark_detached(info.id)
+    stopped = await mgr.reap_idle_detached()
+    assert stopped == []
+    assert mgr.get(info.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_detached_stops_old_detached(tmp_path):
+    """Reaper uses last_active_at, not created_at — push it into the past."""
+    mgr = _make_manager(tmp_path, idle_timeout_ms=500)
+    info = mgr.create_session()
+    mgr.mark_detached(info.id)
+    mgr.get(info.id).last_active_at = time.time() - 10
+    stopped = await mgr.reap_idle_detached()
+    assert stopped == [info.id]
+    assert mgr.get(info.id) is None
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_detached_skips_running(tmp_path):
+    """RUNNING sessions are NOT reaped — only DETACHED."""
+    mgr = _make_manager(tmp_path, idle_timeout_ms=500)
+    info = mgr.create_session()
+    mgr.mark_running(info.id)
+    mgr.get(info.id).last_active_at = time.time() - 10
+    stopped = await mgr.reap_idle_detached()
+    assert stopped == []
+    assert mgr.get(info.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_detached_uses_last_active_not_created_at(tmp_path):
+    """Long-lived session that was active recently must NOT be reaped."""
+    mgr = _make_manager(tmp_path, idle_timeout_ms=500)
+    info = mgr.create_session()
+    mgr.mark_detached(info.id)
+    # Created hours ago (would be reaped under the old buggy logic) but
+    # active just now — must NOT be reaped.
+    mgr.get(info.id).created_at = time.time() - 3600
+    mgr.get(info.id).last_active_at = time.time()
+    stopped = await mgr.reap_idle_detached()
+    assert stopped == []
+    assert mgr.get(info.id) is not None
+
+
+def test_touch_bumps_last_active_at(tmp_path):
+    """SessionManager.touch updates last_active_at to now."""
+    mgr = _make_manager(tmp_path)
+    info = mgr.create_session()
+    info.last_active_at = time.time() - 1000
+    mgr.touch(info.id)
+    assert mgr.get(info.id).last_active_at > time.time() - 1
+
+
+def test_touch_unknown_session_is_noop(tmp_path):
+    mgr = _make_manager(tmp_path)
+    mgr.touch('not-a-session')  # should not raise

--- a/tests/server/test_types.py
+++ b/tests/server/test_types.py
@@ -1,0 +1,58 @@
+"""Tests for ``src.server.types``."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.server.types import (
+    SessionState,
+    validate_connect_response,
+)
+
+
+class TestSessionState:
+    def test_five_state_lifecycle(self) -> None:
+        """Mirror TS server/types.ts:26-31."""
+        assert {s.value for s in SessionState} == {
+            'starting', 'running', 'detached', 'stopping', 'stopped'
+        }
+
+    def test_serializes_as_string(self) -> None:
+        assert SessionState.RUNNING.value == 'running'
+        assert str(SessionState.RUNNING.value) == 'running'
+
+
+class TestValidateConnectResponse:
+    def test_minimal_valid_payload(self) -> None:
+        out = validate_connect_response({'session_id': 'cse_abc', 'ws_url': 'ws://x:1/ws/y'})
+        assert out['session_id'] == 'cse_abc'
+        assert out['ws_url'] == 'ws://x:1/ws/y'
+        assert 'work_dir' not in out
+
+    def test_with_optional_work_dir(self) -> None:
+        out = validate_connect_response({
+            'session_id': 's', 'ws_url': 'ws://x:1/ws/s', 'work_dir': '/tmp',
+        })
+        assert out['work_dir'] == '/tmp'
+
+    def test_rejects_non_dict(self) -> None:
+        with pytest.raises(ValueError, match='must be an object'):
+            validate_connect_response([])
+
+    def test_rejects_missing_session_id(self) -> None:
+        with pytest.raises(ValueError, match='session_id'):
+            validate_connect_response({'ws_url': 'ws://x'})
+
+    def test_rejects_empty_session_id(self) -> None:
+        with pytest.raises(ValueError, match='session_id'):
+            validate_connect_response({'session_id': '', 'ws_url': 'ws://x'})
+
+    def test_rejects_missing_ws_url(self) -> None:
+        with pytest.raises(ValueError, match='ws_url'):
+            validate_connect_response({'session_id': 's'})
+
+    def test_rejects_non_string_work_dir(self) -> None:
+        with pytest.raises(ValueError, match='work_dir'):
+            validate_connect_response({
+                'session_id': 's', 'ws_url': 'ws://x', 'work_dir': 42,
+            })

--- a/tests/server/test_url_scheme.py
+++ b/tests/server/test_url_scheme.py
@@ -1,0 +1,72 @@
+"""Tests for ``src.server.url_scheme``."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.server.url_scheme import parse_cc_url
+
+
+class TestCcTcp:
+    def test_basic(self) -> None:
+        addr = parse_cc_url('cc://127.0.0.1:8765/sess_abc')
+        assert addr.scheme == 'cc'
+        assert addr.host_or_socket == '127.0.0.1'
+        assert addr.port == 8765
+        assert addr.session_id == 'sess_abc'
+        assert addr.query == {}
+
+    def test_no_port(self) -> None:
+        addr = parse_cc_url('cc://localhost/sess_abc')
+        assert addr.host_or_socket == 'localhost'
+        assert addr.port is None
+
+    def test_with_query(self) -> None:
+        addr = parse_cc_url('cc://h:1/sid?token=tk&foo=bar')
+        assert addr.query == {'token': 'tk', 'foo': 'bar'}
+
+    def test_invalid_port(self) -> None:
+        with pytest.raises(ValueError, match='invalid port'):
+            parse_cc_url('cc://h:abc/sid')
+
+    def test_port_out_of_range(self) -> None:
+        with pytest.raises(ValueError, match='port out of range'):
+            parse_cc_url('cc://h:99999/sid')
+
+    def test_missing_session(self) -> None:
+        with pytest.raises(ValueError, match='session ID'):
+            parse_cc_url('cc://h:1/')
+
+    def test_missing_authority(self) -> None:
+        with pytest.raises(ValueError):
+            parse_cc_url('cc:///sid')
+
+
+class TestCcUnix:
+    def test_basic(self) -> None:
+        addr = parse_cc_url('cc+unix:///var/run/claude/sock/sess_abc')
+        assert addr.scheme == 'cc+unix'
+        assert addr.host_or_socket == '/var/run/claude/sock'
+        assert addr.port is None
+        assert addr.session_id == 'sess_abc'
+
+    def test_socket_path_with_query(self) -> None:
+        addr = parse_cc_url('cc+unix:///tmp/x.sock/sid?token=tk')
+        assert addr.host_or_socket == '/tmp/x.sock'
+        assert addr.session_id == 'sid'
+        assert addr.query == {'token': 'tk'}
+
+    def test_deep_socket_path(self) -> None:
+        addr = parse_cc_url('cc+unix:///a/b/c/d/e/sid')
+        assert addr.host_or_socket == '/a/b/c/d/e'
+        assert addr.session_id == 'sid'
+
+
+class TestSchemeDispatch:
+    def test_unsupported_scheme(self) -> None:
+        with pytest.raises(ValueError, match='unsupported scheme'):
+            parse_cc_url('http://example.com/foo')
+
+    def test_empty_string(self) -> None:
+        with pytest.raises(ValueError):
+            parse_cc_url('')


### PR DESCRIPTION
## Summary

**PR 4 of 6** in the Ch16 stack. Stacked on #41 (Phase 2). Rebase to `main` once #40 + #41 land. Can land in parallel with PR 3 (#42 — Upstream Proxy) and PR 5 (Bridge v2 transport).

Phase 1 — local server topology with `cc://` and `cc+unix://` URL schemes. Smallest end-to-end Ch16 slice; depends on Phase 2's `BoundedUUIDSet` + `RemotePermissionResponse` + `sdk_types`.

## Modules added (`src/server/`)

| Module | Purpose |
|---|---|
| `types.py` | `SessionState` 5-state lifecycle, `ServerConfig`, `SessionInfo` (with `last_active_at` for idle reaper), `SessionIndexEntry`, `validate_connect_response`. |
| `direct_connect_session.py` | `create_direct_connect_session` POST /sessions handshake. Reads server-issued `auth_token` from response (per-session token preferred; falls back to bootstrap). |
| `direct_connect_manager.py` | `DirectConnectSessionManager` WS client with NDJSON routing, control_request unknown-subtype → error response, `_fire_disconnected_once` flag (prevents the cancellation/race where the reader's `finally` `on_disconnected` await would itself be cancelled). |
| `url_scheme.py` | `parse_cc_url` for `cc://` and `cc+unix://`. Unix-socket paths can contain `/`; session ID is the last component. |
| `session_index.py` | `~/.claude/server-sessions.json` persistence: atomic write + `fcntl.flock`, malformed entries logged + skipped. |
| `lockfile.py` | `ServerLockfile` with `fcntl.flock(LOCK_EX|LOCK_NB)`; kernel auto-releases on process exit. |
| `session_manager.py` | `SessionManager` 5-state tracker with idle-timeout reaper that compares against **`last_active_at`** (NOT `created_at` — long-lived active sessions must NOT be reaped because they were created hours ago); `max_sessions` enforcement; `touch()` for hot path. |
| `server.py` | `DirectConnectServer` with **two listeners** (HTTP + WS on separate ports). Per-session token via `secrets.token_urlsafe(32)` + `secrets.compare_digest`. `_session_tokens` cleaned up in WS connection's `finally`. `asyncio.gather(both serve_forever)` so cancellation tears down both atomically. |

## Reverse-engineered surface

WI-1.6/1.7/1.8 (`server.py`, `session_manager.py`, `lockfile.py`) are reverse-engineered from the **client side** plus `main.tsx:3963-3982` import shapes — the corresponding TS source isn't in this snapshot. WI-1.9 reserved for spec refinement after first integration test (already exercised via `test_server_e2e.py`). Documented in module docstrings.

## Notable correctness invariants

- **Idle reaper uses `last_active_at`** — not `created_at`. Long-lived active-then-detached sessions aren't reaped purely because they were created hours ago.
- **Per-session token cleanup** in WS connection's `finally` — `_session_tokens` dict doesn't grow unboundedly under churn.
- **Server-issued token preferred** over bootstrap token — `direct_connect_session.py:105-111` reads `payload.get('auth_token')` and uses it for the WS upgrade Authorization header. Falls back to bootstrap for older server implementations.
- **Two-listener architecture** — splits HTTP `POST /sessions` and WS `/ws/<sid>` onto separate ports because the `websockets` library doesn't cleanly wrap an existing HTTP-upgraded socket.

## Test plan

- [x] `pytest tests/server/` — 65 pass
- [x] `tests/server/test_server_e2e.py` (4 tests, marked `integration`) — real server + client + session lifecycle + session-index persistence across stop, auth-token rejection (401), unknown route (404)
- [x] `tests/server/test_session_manager.py::test_reap_idle_detached_uses_last_active_not_created_at` explicitly verifies the bug fix
- [x] 82% module coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)