### PR TITLE
feat(ch16/phase3): Bridge v2 transport (SSE reads + CCRClient writes)

### DIFF
--- a/src/bridge/code_session_api.py
+++ b/src/bridge/code_session_api.py
@@ -1,0 +1,265 @@
+"""HTTP wrappers for the CCR v2 code-session API + worker registration.
+
+Ports ``typescript/src/bridge/codeSessionApi.ts:26-168`` and the
+``register_worker`` half of ``workSecret.ts:97-127``.
+
+Three calls:
+
+  * ``create_code_session(base_url, access_token, title, ...)`` — POST
+    ``/v1/code/sessions`` and return the new session ID (``cse_*``).
+  * ``fetch_remote_credentials(session_id, base_url, access_token, ...)``
+    — POST ``/v1/code/sessions/{id}/bridge`` and return the
+    ``RemoteCredentials`` (``worker_jwt``/``api_base_url``/
+    ``expires_in``/``worker_epoch``). Each call to ``/bridge`` IS the
+    registration; the server bumps ``worker_epoch`` on every call.
+  * ``register_worker(session_url, access_token)`` — POST
+    ``/worker/register`` (legacy v2 path used when ``/bridge`` did not
+    return an epoch). Returns the ``worker_epoch`` integer.
+
+All return ``None`` on best-effort failure (network, non-2xx, malformed
+response) — matches TS ``return null`` rather than raising. Callers log
+and continue.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from .protojson import coerce_int64
+
+logger = logging.getLogger(__name__)
+
+ANTHROPIC_VERSION = '2023-06-01'
+
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+
+def _oauth_headers(access_token: str) -> dict[str, str]:
+    return {
+        'Authorization': f'Bearer {access_token}',
+        'Content-Type': 'application/json',
+        'anthropic-version': ANTHROPIC_VERSION,
+    }
+
+
+@dataclass(frozen=True)
+class RemoteCredentials:
+    """Output of ``fetch_remote_credentials`` (POST /bridge).
+
+    Mirrors TS ``RemoteCredentials`` at ``codeSessionApi.ts:84-91``.
+    The JWT is opaque — callers should not decode it (use
+    ``schedule_from_expires_in`` for the refresh timer, not
+    ``decode_jwt_expiry``).
+    """
+
+    worker_jwt: str
+    api_base_url: str
+    expires_in: int
+    worker_epoch: int
+
+
+# ─── POST /v1/code/sessions ────────────────────────────────────────────────
+
+
+async def create_code_session(
+    base_url: str,
+    access_token: str,
+    title: str,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    tags: list[str] | None = None,
+    client: httpx.AsyncClient | None = None,
+) -> str | None:
+    """POST ``/v1/code/sessions`` and return the new session ID.
+
+    Body: ``{title, bridge: {}, tags?}`` — the ``bridge: {}`` is the
+    positive signal for the oneof runner; omitting it 400s.
+
+    Returns ``None`` on any failure (network, non-2xx, missing or
+    malformed ``session.id``); the caller logs and falls through.
+
+    Mirrors ``codeSessionApi.ts:26-80``.
+    """
+    url = f'{base_url.rstrip("/")}/v1/code/sessions'
+    body: dict[str, Any] = {'title': title, 'bridge': {}}
+    if tags:
+        body['tags'] = tags
+
+    try:
+        if client is None:
+            async with httpx.AsyncClient(timeout=timeout_seconds) as fresh:
+                resp = await fresh.post(url, json=body, headers=_oauth_headers(access_token))
+        else:
+            resp = await client.post(
+                url, json=body, headers=_oauth_headers(access_token), timeout=timeout_seconds,
+            )
+    except (httpx.HTTPError, httpx.TimeoutException) as exc:
+        logger.debug('[code-session] Session create request failed: %s', exc)
+        return None
+
+    if resp.status_code not in (200, 201):
+        logger.debug(
+            '[code-session] Session create failed %d', resp.status_code
+        )
+        return None
+
+    try:
+        data = resp.json()
+    except ValueError:
+        return None
+
+    session_obj = data.get('session') if isinstance(data, dict) else None
+    if not isinstance(session_obj, dict):
+        return None
+    sid = session_obj.get('id')
+    if not isinstance(sid, str) or not sid.startswith('cse_'):
+        logger.debug('[code-session] No session.id (cse_*) in response')
+        return None
+    return sid
+
+
+# ─── POST /v1/code/sessions/{id}/bridge ────────────────────────────────────
+
+
+async def fetch_remote_credentials(
+    session_id: str,
+    base_url: str,
+    access_token: str,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    trusted_device_token: str | None = None,
+    client: httpx.AsyncClient | None = None,
+) -> RemoteCredentials | None:
+    """POST ``/v1/code/sessions/{id}/bridge`` and return credentials.
+
+    Mirrors ``codeSessionApi.ts:93-168``. ``trusted_device_token`` is
+    passed as ``X-Trusted-Device-Token`` if set; otherwise omitted.
+
+    Returns ``None`` on failure. ``worker_epoch`` is coerced via
+    ``coerce_int64`` (handles protojson string-OR-number).
+    """
+    url = f'{base_url.rstrip("/")}/v1/code/sessions/{session_id}/bridge'
+    headers = _oauth_headers(access_token)
+    if trusted_device_token:
+        headers['X-Trusted-Device-Token'] = trusted_device_token
+
+    try:
+        if client is None:
+            async with httpx.AsyncClient(timeout=timeout_seconds) as fresh:
+                resp = await fresh.post(url, json={}, headers=headers)
+        else:
+            resp = await client.post(
+                url, json={}, headers=headers, timeout=timeout_seconds,
+            )
+    except (httpx.HTTPError, httpx.TimeoutException) as exc:
+        logger.debug('[code-session] /bridge request failed: %s', exc)
+        return None
+
+    if resp.status_code != 200:
+        logger.debug('[code-session] /bridge failed %d', resp.status_code)
+        return None
+
+    try:
+        data = resp.json()
+    except ValueError:
+        return None
+
+    if not isinstance(data, dict):
+        return None
+    worker_jwt = data.get('worker_jwt')
+    api_base = data.get('api_base_url')
+    expires_in = data.get('expires_in')
+    raw_epoch = data.get('worker_epoch')
+
+    if not isinstance(worker_jwt, str) or not worker_jwt:
+        logger.debug('[code-session] /bridge missing worker_jwt')
+        return None
+    if not isinstance(api_base, str) or not api_base:
+        logger.debug('[code-session] /bridge missing api_base_url')
+        return None
+    if not isinstance(expires_in, int):
+        logger.debug('[code-session] /bridge missing or invalid expires_in')
+        return None
+    if raw_epoch is None:
+        logger.debug('[code-session] /bridge missing worker_epoch')
+        return None
+    try:
+        epoch = coerce_int64(raw_epoch)
+    except ValueError as exc:
+        logger.debug('[code-session] /bridge worker_epoch invalid: %s', exc)
+        return None
+    return RemoteCredentials(
+        worker_jwt=worker_jwt,
+        api_base_url=api_base,
+        expires_in=expires_in,
+        worker_epoch=epoch,
+    )
+
+
+# ─── POST /worker/register (legacy path) ───────────────────────────────────
+
+
+async def register_worker(
+    session_url: str,
+    access_token: str,
+    *,
+    timeout_seconds: float = 10.0,
+    client: httpx.AsyncClient | None = None,
+) -> int:
+    """POST ``${session_url}/worker/register`` and return the ``worker_epoch``.
+
+    Used by the v1 CCR-v2 path (``replBridge`` poll loop) when ``/bridge``
+    didn't return an epoch directly. Raises ``RuntimeError`` on
+    network/HTTP failure or malformed response — callers wrap in their
+    own retry budget.
+
+    Mirrors ``workSecret.ts:97-127``.
+    """
+    url = f'{session_url.rstrip("/")}/worker/register'
+    headers = _oauth_headers(access_token)
+    try:
+        if client is None:
+            async with httpx.AsyncClient(timeout=timeout_seconds) as fresh:
+                resp = await fresh.post(url, json={}, headers=headers)
+        else:
+            resp = await client.post(
+                url, json={}, headers=headers, timeout=timeout_seconds,
+            )
+    except (httpx.HTTPError, httpx.TimeoutException) as exc:
+        raise RuntimeError(f'register_worker failed: {exc}') from exc
+
+    if resp.status_code not in (200, 201):
+        raise RuntimeError(
+            f'register_worker: unexpected status {resp.status_code}'
+        )
+
+    try:
+        data = resp.json()
+    except ValueError as exc:
+        raise RuntimeError(f'register_worker: invalid JSON response: {exc}') from exc
+
+    if not isinstance(data, dict):
+        raise RuntimeError('register_worker: response is not an object')
+    raw = data.get('worker_epoch')
+    if raw is None:
+        raise RuntimeError('register_worker: response missing worker_epoch')
+    try:
+        return coerce_int64(raw)
+    except ValueError as exc:
+        raise RuntimeError(
+            f'register_worker: invalid worker_epoch: {exc}'
+        ) from exc
+
+
+__all__ = [
+    'ANTHROPIC_VERSION',
+    'DEFAULT_TIMEOUT_SECONDS',
+    'RemoteCredentials',
+    'create_code_session',
+    'fetch_remote_credentials',
+    'register_worker',
+]

--- a/src/bridge/repl_bridge_transport.py
+++ b/src/bridge/repl_bridge_transport.py
@@ -1,0 +1,329 @@
+"""``ReplBridgeTransport`` — unified v1/v2 transport interface.
+
+Ports the consumer-facing surface of
+``typescript/src/bridge/replBridgeTransport.ts:23-369``.
+
+Two halves:
+
+  * ``ReplBridgeTransport`` Protocol — the 14-method contract that
+    ``replBridge`` writes against. v1 and v2 implementations conform.
+  * ``create_v2_repl_transport`` — the v2 factory: SSE reads +
+    ``CCRClient`` writes, with the epoch-mismatch handler that closes
+    both transports + raises ``EpochSupersededError`` to unwind callers.
+
+The v1 factory is **not yet implemented** (out of Phase 6 scope).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from src.bridge.close_codes import (
+    WS_CLOSE_EPOCH_MISMATCH,
+    WS_CLOSE_INIT_FAILURE,
+)
+from src.bridge.exceptions import EpochSupersededError
+from src.transports.ccr_client import CCRClient, CCRClientOptions
+from src.transports.sse_transport import SSEEvent, SSETransport
+
+logger = logging.getLogger(__name__)
+
+
+# ─── Protocol ──────────────────────────────────────────────────────────────
+
+
+class ReplBridgeTransport(Protocol):
+    """The 14-method contract ``replBridge`` writes against.
+
+    Mirrors TS ``replBridgeTransport.ts:23-70``. ``write`` and
+    ``write_batch`` return awaitables (``async def`` in
+    implementations); the rest are sync — flag-checks, callback
+    registrations, etc.
+    """
+
+    async def write(self, message: dict[str, Any]) -> None: ...
+    async def write_batch(self, messages: list[dict[str, Any]]) -> None: ...
+    def close(self) -> None: ...
+    def is_connected_status(self) -> bool: ...
+    def get_state_label(self) -> str: ...
+    def set_on_data(self, cb: Callable[[str], None]) -> None: ...
+    def set_on_close(self, cb: Callable[[int | None], None]) -> None: ...
+    def set_on_connect(self, cb: Callable[[], None]) -> None: ...
+    def connect(self) -> None: ...
+    def get_last_sequence_num(self) -> int: ...
+
+    @property
+    def dropped_batch_count(self) -> int: ...
+
+    def report_state(self, state: dict[str, Any]) -> None: ...
+    def report_metadata(self, metadata: dict[str, Any]) -> None: ...
+    def report_delivery(self, event_id: str, status: str) -> None: ...
+    async def flush(self) -> None: ...
+
+
+# ─── v2 implementation ────────────────────────────────────────────────────
+
+
+@dataclass
+class V2TransportOptions:
+    """Construction-time knobs for ``create_v2_repl_transport``."""
+
+    session_url: str
+    ingress_token: str
+    session_id: str
+    epoch: int
+    initial_sequence_num: int = 0
+    heartbeat_interval_seconds: float | None = None
+    heartbeat_jitter_fraction: float | None = None
+    outbound_only: bool = False
+    get_auth_token: Callable[[], str | None] | None = None
+
+
+class _V2ReplTransport:
+    """Concrete v2 transport (SSE reads + CCRClient writes).
+
+    Mirrors ``replBridgeTransport.ts:119-369``. Constructed via
+    ``create_v2_repl_transport``; satisfies the ``ReplBridgeTransport``
+    Protocol structurally.
+    """
+
+    def __init__(
+        self,
+        sse: SSETransport,
+        ccr: CCRClient,
+        *,
+        epoch: int,
+        outbound_only: bool,
+    ) -> None:
+        self._sse = sse
+        self._ccr = ccr
+        self._epoch = epoch
+        self._outbound_only = outbound_only
+        self._closed = False
+
+        self._on_connect_cb: Callable[[], None] | None = None
+        self._on_close_cb: Callable[[int | None], None] | None = None
+        self._ccr_initialized = False
+
+    # ─── State ──────────────────────────────────────────────────────────
+
+    def is_connected_status(self) -> bool:
+        """Write-readiness, not read-readiness — replBridge checks this
+        before calling ``write_batch``. SSE open state is orthogonal."""
+        return self._ccr_initialized and not self._closed
+
+    def get_state_label(self) -> str:
+        if self._sse.is_closed_status():
+            return 'closed'
+        if self._sse.is_connected_status():
+            return 'connected' if self._ccr_initialized else 'init'
+        return 'connecting'
+
+    def get_last_sequence_num(self) -> int:
+        if self._outbound_only:
+            return 0  # no SSE read stream → no cursor to report
+        return self._sse.get_last_sequence_num()
+
+    @property
+    def dropped_batch_count(self) -> int:
+        return self._ccr.dropped_batch_count
+
+    # ─── Callback wiring ───────────────────────────────────────────────
+
+    def set_on_data(self, cb: Callable[[str], None]) -> None:
+        if self._outbound_only:
+            return  # no inbound stream — set_on_data is a no-op
+        self._sse.set_on_data(cb)
+
+    def set_on_close(self, cb: Callable[[int | None], None]) -> None:
+        self._on_close_cb = cb
+        # When the SSE reconnect-budget is exhausted, fire onClose so
+        # replBridge can reconnect via the poll loop.
+        self._sse.set_on_close(lambda code: cb(code))
+
+    def set_on_connect(self, cb: Callable[[], None]) -> None:
+        self._on_connect_cb = cb
+
+    # ─── Lifecycle ─────────────────────────────────────────────────────
+
+    def connect(self) -> None:
+        """Open SSE + initialize CCRClient. Returns immediately."""
+        loop = asyncio.get_running_loop()
+        loop.create_task(self._do_connect(), name='v2-transport-connect')
+
+    async def _do_connect(self) -> None:
+        if not self._outbound_only:
+            await self._sse.connect()
+        try:
+            await self._ccr.initialize(self._epoch)
+        except EpochSupersededError:
+            self._fire_close(WS_CLOSE_EPOCH_MISMATCH)
+            return
+        except Exception as exc:  # noqa: BLE001
+            logger.warning('[v2-transport] CCR init failed: %s', exc)
+            self._fire_close(WS_CLOSE_INIT_FAILURE)
+            return
+        self._ccr_initialized = True
+        if self._on_connect_cb is not None:
+            try:
+                self._on_connect_cb()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning('[v2-transport] on_connect_cb raised: %s', exc)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._sse.close()
+        self._ccr.close()
+
+    async def aclose(self) -> None:
+        self.close()
+        await asyncio.gather(
+            self._sse.aclose(),
+            self._ccr.aclose(),
+            return_exceptions=True,
+        )
+
+    # ─── Write API ─────────────────────────────────────────────────────
+
+    async def write(self, message: dict[str, Any]) -> None:
+        await self._ccr.write_event(message)
+
+    async def write_batch(self, messages: list[dict[str, Any]]) -> None:
+        for m in messages:
+            if self._closed:
+                return
+            await self._ccr.write_event(m)
+
+    async def flush(self) -> None:
+        await self._ccr.flush()
+
+    # ─── State / metadata / delivery passthrough ──────────────────────
+
+    def report_state(self, state: dict[str, Any]) -> None:
+        self._ccr.report_state(state)
+
+    def report_metadata(self, metadata: dict[str, Any]) -> None:
+        self._ccr.report_metadata(metadata)
+
+    def report_delivery(self, event_id: str, status: str) -> None:
+        self._ccr.report_delivery(event_id, status)
+
+    # ─── Internal helpers ─────────────────────────────────────────────
+
+    def _fire_close(self, code: int) -> None:
+        cb = self._on_close_cb
+        if cb is None:
+            return
+        try:
+            cb(code)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning('[v2-transport] on_close_cb raised: %s', exc)
+
+
+# ─── Public factory ───────────────────────────────────────────────────────
+
+
+async def create_v2_repl_transport(opts: V2TransportOptions) -> _V2ReplTransport:
+    """Build a v2 transport (SSE reads + CCRClient writes).
+
+    Mirrors ``replBridgeTransport.ts:119-369``. The
+    ``on_epoch_mismatch`` handler closes both transports, fires
+    ``on_close_cb(4090)``, and raises ``EpochSupersededError`` to
+    unwind callers (matches TS ``throw 'epoch superseded'``).
+
+    The auth-header closure is per-instance so multiple concurrent
+    sessions don't clobber each other (mirrors the TS multi-session
+    safety fix).
+    """
+    # Per-instance auth header closure (multi-session safety).
+    def _auth_headers() -> dict[str, str]:
+        token: str | None
+        if opts.get_auth_token is not None:
+            token = opts.get_auth_token()
+        else:
+            token = opts.ingress_token
+        if not token:
+            return {}
+        return {'Authorization': f'Bearer {token}'}
+
+    # Derive SSE stream URL: append /worker/events/stream to the session URL.
+    sse_url = opts.session_url.rstrip('/') + '/worker/events/stream'
+    sse = SSETransport(
+        url=sse_url,
+        headers={},
+        session_id=opts.session_id,
+        get_auth_headers=_auth_headers,
+        initial_sequence_num=opts.initial_sequence_num,
+    )
+
+    transport_ref: dict[str, _V2ReplTransport | None] = {'t': None}
+
+    def _on_epoch_mismatch() -> None:
+        """Called by CCRClient on 409. Closes both, fires onClose(4090),
+        raises EpochSupersededError to unwind the caller."""
+        t = transport_ref['t']
+        if t is not None:
+            try:
+                t._sse.close()
+                t._ccr.close()
+                t._fire_close(WS_CLOSE_EPOCH_MISMATCH)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning('[v2-transport] epoch-mismatch cleanup: %s', exc)
+
+    # Heartbeat options: pass through if explicitly set.
+    ccr_opts_kwargs: dict[str, Any] = {
+        'get_auth_headers': _auth_headers,
+        'on_epoch_mismatch': _on_epoch_mismatch,
+    }
+    if opts.heartbeat_interval_seconds is not None:
+        ccr_opts_kwargs['heartbeat_interval_seconds'] = opts.heartbeat_interval_seconds
+    if opts.heartbeat_jitter_fraction is not None:
+        ccr_opts_kwargs['heartbeat_jitter_fraction'] = opts.heartbeat_jitter_fraction
+    ccr = CCRClient(
+        base_url=opts.session_url,
+        options=CCRClientOptions(**ccr_opts_kwargs),
+    )
+
+    # Wire SSE → CCRClient delivery ACKs (TS replBridgeTransport.ts:249-252).
+    # ACK both 'received' AND 'processed' immediately so daemon-path
+    # reconnects don't re-queue events forever.
+    def _ack(event: SSEEvent) -> None:
+        if not event.event_id:
+            return
+        try:
+            ccr.report_delivery(event.event_id, 'received')
+            ccr.report_delivery(event.event_id, 'processed')
+        except Exception as exc:  # noqa: BLE001
+            logger.debug('[v2-transport] delivery ACK failed: %s', exc)
+
+    sse.set_on_event(_ack)
+
+    transport = _V2ReplTransport(
+        sse=sse,
+        ccr=ccr,
+        epoch=opts.epoch,
+        outbound_only=opts.outbound_only,
+    )
+    transport_ref['t'] = transport
+    return transport
+
+
+def create_v1_repl_transport(*args: Any, **kwargs: Any) -> ReplBridgeTransport:
+    """Stub. v1 is deferred to Phase 6 per the refactoring plan."""
+    raise NotImplementedError(
+        'v1 ReplBridgeTransport is deferred to Phase 6 — see ch16 refactoring plan'
+    )
+
+
+__all__ = [
+    'ReplBridgeTransport',
+    'V2TransportOptions',
+    'create_v1_repl_transport',
+    'create_v2_repl_transport',
+]

--- a/src/transports/__init__.py
+++ b/src/transports/__init__.py
@@ -1,0 +1,9 @@
+"""CCR Bridge v2 read/write transports.
+
+Two halves:
+
+  * ``sse_transport.SSETransport`` — read side (SSE long-poll).
+  * ``ccr_client.CCRClient`` — write side (HTTP POST batching + heartbeat).
+
+Both consumed by ``src.bridge.repl_bridge_transport.create_v2_repl_transport``.
+"""

--- a/src/transports/ccr_client.py
+++ b/src/transports/ccr_client.py
@@ -1,0 +1,384 @@
+"""CCR Bridge v2 write transport (HTTP POST batching + heartbeat).
+
+Ports the consumer-facing surface of
+``typescript/src/transports/ccrClient.ts (998 lines)``.
+
+Three responsibilities:
+
+1. **`SerialBatchEventUploader`** — `asyncio.Queue(maxsize=N)` of
+   pending events; a single uploader task drains the queue in batches
+   of up to `max_batch_size` and POSTs to ``/worker/events``. Per
+   Risk #23: queue blocks on the producer side (back-pressure to
+   `write_event`); a configurable timeout triggers `dropped_batch_count`
+   if the producer is starved (the queue is full and stays full).
+
+2. **Heartbeat** — `asyncio.Task` that POSTs `/worker/heartbeat` every
+   `heartbeat_interval_seconds` (default 20s with optional jitter).
+   Cancelled on close.
+
+3. **State / metadata / delivery** — `report_state`, `report_metadata`,
+   `report_delivery` are best-effort POSTs.
+
+**Epoch mismatch (409)** — when the server returns 409, the configured
+`on_epoch_mismatch` callback is fired. The TS callback throws
+`'epoch superseded'` to unwind the caller; in Python we raise
+`EpochSupersededError` (defined in `src.bridge.exceptions`).
+
+This implementation is the **functional surface** the
+`ReplBridgeTransport` needs; rare error branches (multipart timeout,
+specific 5xx retry budgets) are simplified.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from src.bridge.exceptions import EpochSupersededError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 20.0
+DEFAULT_MAX_BATCH_SIZE = 100
+DEFAULT_QUEUE_MAX_SIZE = 100
+DEFAULT_PRODUCER_TIMEOUT_SECONDS = 30.0
+#: Number of additional retries after the first attempt fails before
+#: the batch is dropped. Total attempts = 1 (initial) + this many.
+#: Renamed from "max_consecutive_failures" for clarity — the option
+#: name describes the retry count, not the failure count.
+DEFAULT_MAX_RETRIES_PER_BATCH = 3
+DEFAULT_RETRY_BACKOFF_SECONDS = 2.0
+
+
+GetAuthHeaders = Callable[[], dict[str, str]]
+OnEpochMismatch = Callable[[], None]
+
+
+@dataclass
+class CCRClientOptions:
+    """Construction-time knobs for ``CCRClient``."""
+
+    get_auth_headers: GetAuthHeaders | None = None
+    heartbeat_interval_seconds: float = DEFAULT_HEARTBEAT_INTERVAL_SECONDS
+    heartbeat_jitter_fraction: float = 0.0
+    max_batch_size: int = DEFAULT_MAX_BATCH_SIZE
+    queue_max_size: int = DEFAULT_QUEUE_MAX_SIZE
+    producer_timeout_seconds: float = DEFAULT_PRODUCER_TIMEOUT_SECONDS
+    max_retries_per_batch: int = DEFAULT_MAX_RETRIES_PER_BATCH
+    retry_backoff_seconds: float = DEFAULT_RETRY_BACKOFF_SECONDS
+    on_epoch_mismatch: OnEpochMismatch | None = None
+
+
+class CCRClient:
+    """Write-side transport for Bridge v2.
+
+    Lifecycle:
+        client = CCRClient(base_url, options, http_client=...)
+        await client.initialize(epoch)
+        await client.write_event(msg)            # -> queue
+        client.report_state({'status': '...'})    # fire-and-forget
+        client.report_delivery(eid, 'received')   # fire-and-forget
+        await client.flush()                      # drain the queue
+        client.close()
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        options: CCRClientOptions | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip('/')
+        self._options = options or CCRClientOptions()
+        self._http = http_client
+        self._owned_http = http_client is None
+
+        self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(
+            maxsize=self._options.queue_max_size
+        )
+        self._epoch: int | None = None
+        self._initialized = False
+        self._closed = False
+
+        self._uploader_task: asyncio.Task[None] | None = None
+        self._heartbeat_task: asyncio.Task[None] | None = None
+
+        #: Monotonic count of batches the uploader silently dropped due
+        #: to repeated POST failures. Producers can snapshot this around
+        #: ``write_event`` to detect drops (the future resolves normally
+        #: even when the batch was lost).
+        self._dropped_batch_count = 0
+
+    # ─── Public properties ────────────────────────────────────────────
+
+    @property
+    def dropped_batch_count(self) -> int:
+        return self._dropped_batch_count
+
+    @property
+    def is_initialized(self) -> bool:
+        return self._initialized
+
+    @property
+    def is_closed(self) -> bool:
+        return self._closed
+
+    # ─── Lifecycle ────────────────────────────────────────────────────
+
+    async def initialize(self, epoch: int) -> None:
+        """Set the worker epoch and spawn the uploader + heartbeat tasks."""
+        if self._initialized:
+            return
+        if self._http is None:
+            self._http = httpx.AsyncClient(timeout=30.0)
+        self._epoch = epoch
+        self._initialized = True
+        loop = asyncio.get_running_loop()
+        self._uploader_task = loop.create_task(self._uploader_loop(), name='ccr-uploader')
+        if self._options.heartbeat_interval_seconds > 0:
+            self._heartbeat_task = loop.create_task(self._heartbeat_loop(), name='ccr-heartbeat')
+
+    def close(self) -> None:
+        """Cancel uploader + heartbeat, drop pending writes."""
+        if self._closed:
+            return
+        self._closed = True
+        for task in (self._uploader_task, self._heartbeat_task):
+            if task is not None and not task.done():
+                task.cancel()
+
+    async def aclose(self) -> None:
+        """Cancel everything and clean up the owned HTTP client."""
+        self.close()
+        for task in (self._uploader_task, self._heartbeat_task):
+            if task is None:
+                continue
+            try:
+                await task
+            except (asyncio.CancelledError, httpx.HTTPError):
+                pass
+        if self._owned_http and self._http is not None:
+            await self._http.aclose()
+            self._http = None
+
+    async def flush(self) -> None:
+        """Wait for the queue to drain.
+
+        Note: only flushes events currently queued; events written after
+        the call returns are not guaranteed to land before subsequent
+        calls. Callers serialize their writes before flushing if they
+        need a hard barrier.
+        """
+        await self._queue.join()
+
+    # ─── Write API ────────────────────────────────────────────────────
+
+    async def write_event(self, message: dict[str, Any]) -> None:
+        """Enqueue ``message`` for batched POST to ``/worker/events``.
+
+        Blocks if the queue is full (back-pressure to caller). Times out
+        after ``producer_timeout_seconds``; on timeout, increments
+        ``dropped_batch_count`` and returns (the message is lost).
+        """
+        if self._closed or not self._initialized:
+            self._dropped_batch_count += 1
+            return
+        try:
+            await asyncio.wait_for(
+                self._queue.put(message),
+                timeout=self._options.producer_timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            self._dropped_batch_count += 1
+
+    # ─── State / metadata / delivery (fire-and-forget POSTs) ──────────
+
+    def report_state(self, state: dict[str, Any]) -> None:
+        """PUT ``/worker`` state (e.g. ``{requires_action: True}``)."""
+        if self._closed:
+            return
+        asyncio.get_running_loop().create_task(
+            self._safe_put('/worker', json={'state': state}),
+            name='ccr-report-state',
+        )
+
+    def report_metadata(self, metadata: dict[str, Any]) -> None:
+        if self._closed:
+            return
+        asyncio.get_running_loop().create_task(
+            self._safe_put('/worker', json={'external_metadata': metadata}),
+            name='ccr-report-metadata',
+        )
+
+    def report_delivery(self, event_id: str, status: str) -> None:
+        """POST ``/worker/events/{event_id}/delivery``."""
+        if self._closed:
+            return
+        path = f'/worker/events/{event_id}/delivery'
+        asyncio.get_running_loop().create_task(
+            self._safe_post(path, json={'status': status}),
+            name='ccr-report-delivery',
+        )
+
+    # ─── Internal: HTTP helpers ───────────────────────────────────────
+
+    def _headers(self) -> dict[str, str]:
+        h: dict[str, str] = {'Content-Type': 'application/json'}
+        if self._options.get_auth_headers is not None:
+            h.update(self._options.get_auth_headers())
+        if self._epoch is not None:
+            h['X-Worker-Epoch'] = str(self._epoch)
+        return h
+
+    async def _safe_post(self, path: str, json: dict[str, Any]) -> None:
+        if self._http is None:
+            return
+        url = f'{self._base_url}{path}'
+        try:
+            resp = await self._http.post(url, json=json, headers=self._headers())
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            logger.debug('[ccr] POST %s failed: %s', path, exc)
+            return
+        await self._handle_response(resp)
+
+    async def _safe_put(self, path: str, json: dict[str, Any]) -> None:
+        if self._http is None:
+            return
+        url = f'{self._base_url}{path}'
+        try:
+            resp = await self._http.put(url, json=json, headers=self._headers())
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            logger.debug('[ccr] PUT %s failed: %s', path, exc)
+            return
+        await self._handle_response(resp)
+
+    async def _handle_response(self, resp: httpx.Response) -> None:
+        if resp.status_code == 409:
+            logger.debug('[ccr] 409 epoch superseded')
+            cb = self._options.on_epoch_mismatch
+            if cb is not None:
+                try:
+                    cb()
+                except EpochSupersededError:
+                    raise
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug('[ccr] on_epoch_mismatch callback raised: %s', exc)
+            raise EpochSupersededError(
+                'CCR worker epoch superseded (409)'
+            )
+        if resp.status_code >= 500:
+            logger.debug('[ccr] server error %d', resp.status_code)
+
+    # ─── Internal: uploader + heartbeat loops ─────────────────────────
+
+    async def _uploader_loop(self) -> None:
+        """Drain the queue in batches; POST each batch to /worker/events.
+
+        On failure, re-attempt the same batch up to
+        ``max_retries_per_batch`` times before dropping (matches TS
+        ``maxConsecutiveFailures`` semantics — failures count for one
+        batch, not lifetime). Drops increment ``dropped_batch_count``.
+        """
+        while not self._closed:
+            try:
+                first = await self._queue.get()
+            except asyncio.CancelledError:
+                return
+            batch: list[dict[str, Any]] = [first]
+            for _ in range(self._options.max_batch_size - 1):
+                try:
+                    batch.append(self._queue.get_nowait())
+                except asyncio.QueueEmpty:
+                    break
+            # Mark queue items as done immediately — we own the batch
+            # now; retries don't go back through the queue.
+            for _ in batch:
+                self._queue.task_done()
+
+            failures = 0
+            while not self._closed:
+                try:
+                    success = await self._post_batch(batch)
+                except EpochSupersededError:
+                    # Don't keep retrying through epoch mismatches —
+                    # the parent transport will close us.
+                    return
+                if success:
+                    break
+                failures += 1
+                if failures > self._options.max_retries_per_batch:
+                    # Total attempts = 1 (initial) + max_retries_per_batch.
+                    # Now exhausted; drop the batch and proceed.
+                    self._dropped_batch_count += 1
+                    break
+                try:
+                    await asyncio.sleep(self._options.retry_backoff_seconds)
+                except asyncio.CancelledError:
+                    return
+
+    async def _post_batch(self, batch: list[dict[str, Any]]) -> bool:
+        """POST one batch. Returns True on success, False on transient failure.
+
+        Raises ``EpochSupersededError`` on 409 — caller must let it
+        propagate so the parent transport can recreate.
+        """
+        if self._http is None:
+            return False
+        url = f'{self._base_url}/worker/events'
+        try:
+            resp = await self._http.post(
+                url,
+                json={'events': batch},
+                headers=self._headers(),
+            )
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            logger.debug('[ccr] batch POST failed: %s', exc)
+            return False
+        if resp.status_code == 409:
+            logger.debug('[ccr] batch POST: 409 epoch superseded')
+            cb = self._options.on_epoch_mismatch
+            if cb is not None:
+                try:
+                    cb()
+                except EpochSupersededError:
+                    raise
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug('[ccr] on_epoch_mismatch callback raised: %s', exc)
+            raise EpochSupersededError('CCR worker epoch superseded (409)')
+        if resp.status_code >= 500:
+            logger.debug('[ccr] batch POST 5xx: %d', resp.status_code)
+            return False
+        return True
+
+    async def _heartbeat_loop(self) -> None:
+        """Periodic POST ``/worker/heartbeat`` with optional jitter."""
+        interval = self._options.heartbeat_interval_seconds
+        jitter = self._options.heartbeat_jitter_fraction
+        while not self._closed:
+            try:
+                # ±jitter fraction of the interval.
+                delta = random.uniform(-jitter, jitter) * interval if jitter > 0 else 0.0
+                await asyncio.sleep(max(0.1, interval + delta))
+            except asyncio.CancelledError:
+                return
+            await self._safe_post('/worker/heartbeat', json={})
+
+
+__all__ = [
+    'CCRClient',
+    'CCRClientOptions',
+    'DEFAULT_HEARTBEAT_INTERVAL_SECONDS',
+    'DEFAULT_MAX_BATCH_SIZE',
+    'DEFAULT_MAX_RETRIES_PER_BATCH',
+    'DEFAULT_PRODUCER_TIMEOUT_SECONDS',
+    'DEFAULT_QUEUE_MAX_SIZE',
+    'DEFAULT_RETRY_BACKOFF_SECONDS',
+    'GetAuthHeaders',
+    'OnEpochMismatch',
+]

--- a/src/transports/sse_transport.py
+++ b/src/transports/sse_transport.py
@@ -1,0 +1,244 @@
+"""SSE read transport for the CCR Bridge v2 stream.
+
+Ports the read-side surface of
+``typescript/src/transports/SSETransport.ts (711 lines)``. We port
+the **functional surface** (connect, parse SSE frames, dispatch
+events, reconnect with Last-Event-ID resume), not every TS line.
+
+Key design decisions:
+
+  - **`httpx-sse` does NOT auto-resume `Last-Event-ID`** on reconnect
+    (Risk #21 in the refactoring plan). We track ``_last_event_id``
+    ourselves and pass it as a header on every reconnect.
+  - **Reconnect budget** matches TS: max 5 attempts with constant
+    ``RECONNECT_DELAY_SECONDS = 2.0``. Exhaustion fires
+    ``on_close(WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED)``.
+  - **Backpressure**: ``on_data`` is called synchronously per event;
+    the pump task awaits the next byte so a slow consumer naturally
+    backpressures the read.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+import httpx
+from httpx_sse import aconnect_sse
+
+from src.bridge.close_codes import WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RECONNECT_DELAY_SECONDS = 2.0
+DEFAULT_RECONNECT_BUDGET = 5
+
+GetAuthHeaders = Callable[[], dict[str, str]]
+OnData = Callable[[str], None]
+OnClose = Callable[[int | None], None]
+OnEvent = Callable[['SSEEvent'], None]
+
+
+@dataclass
+class SSEEvent:
+    """One parsed SSE frame.
+
+    ``event_id``: the SSE ``id:`` field value, used by the consumer to
+    update the Last-Event-ID cursor that drives history-resume on
+    reconnect.
+    """
+
+    event_id: str | None
+    event: str | None
+    data: str
+
+
+class SSETransport:
+    """Async SSE long-poll client with Last-Event-ID resume.
+
+    Public API mirrors the surface ``ReplBridgeTransport`` consumes:
+
+        connect()                   — open the stream (returns when first
+                                       frame arrives or stream errors)
+        set_on_data(cb)             — receive raw ``data:`` payloads
+        set_on_event(cb)            — receive parsed SSEEvent objects
+        set_on_close(cb)            — receive close-codes
+        get_last_sequence_num()     — current Last-Event-ID cursor
+        is_connected_status()       — True while a stream is open
+        is_closed_status()          — True after permanent close
+        close()                     — terminate the stream + reconnect loop
+    """
+
+    def __init__(
+        self,
+        url: str,
+        headers: dict[str, str] | None = None,
+        session_id: str | None = None,
+        get_auth_headers: GetAuthHeaders | None = None,
+        initial_sequence_num: int = 0,
+        reconnect_delay_seconds: float = DEFAULT_RECONNECT_DELAY_SECONDS,
+        reconnect_budget: int = DEFAULT_RECONNECT_BUDGET,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._url = url
+        self._headers = dict(headers or {})
+        self._session_id = session_id
+        self._get_auth_headers = get_auth_headers
+        self._last_event_id: str = str(initial_sequence_num) if initial_sequence_num else ''
+        self._reconnect_delay = reconnect_delay_seconds
+        self._reconnect_budget = reconnect_budget
+        self._reconnect_attempts = 0
+
+        self._client = client
+        self._owned_client = client is None
+        self._on_data: OnData | None = None
+        self._on_close: OnClose | None = None
+        self._on_event: OnEvent | None = None
+
+        self._connected = False
+        self._closed = False
+        self._read_task: asyncio.Task[None] | None = None
+
+    # ─── Public callback wiring ────────────────────────────────────────
+
+    def set_on_data(self, cb: OnData) -> None:
+        self._on_data = cb
+
+    def set_on_close(self, cb: OnClose) -> None:
+        self._on_close = cb
+
+    def set_on_event(self, cb: OnEvent) -> None:
+        self._on_event = cb
+
+    # ─── Public state queries ─────────────────────────────────────────
+
+    def is_connected_status(self) -> bool:
+        return self._connected and not self._closed
+
+    def is_closed_status(self) -> bool:
+        return self._closed
+
+    def get_last_sequence_num(self) -> int:
+        """Current Last-Event-ID as int (0 if missing or non-numeric)."""
+        try:
+            return int(self._last_event_id) if self._last_event_id else 0
+        except ValueError:
+            return 0
+
+    # ─── Lifecycle ────────────────────────────────────────────────────
+
+    async def connect(self) -> None:
+        """Spawn the read loop. Returns immediately; the caller awaits
+        the first event via ``set_on_data`` / ``set_on_event``."""
+        if self._read_task is not None and not self._read_task.done():
+            return
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=None)
+        loop = asyncio.get_running_loop()
+        self._read_task = loop.create_task(self._read_loop(), name='sse-read-loop')
+
+    def close(self) -> None:
+        """Terminate the read loop. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._read_task is not None and not self._read_task.done():
+            self._read_task.cancel()
+
+    async def aclose(self) -> None:
+        """Cancel the loop AND await the underlying client cleanup."""
+        self.close()
+        if self._read_task is not None:
+            try:
+                await self._read_task
+            except (asyncio.CancelledError, httpx.HTTPError):
+                pass
+        if self._owned_client and self._client is not None:
+            await self._client.aclose()
+
+    # ─── Read loop ────────────────────────────────────────────────────
+
+    async def _read_loop(self) -> None:
+        """Open the SSE stream, parse frames, fire callbacks; reconnect on drop."""
+        assert self._client is not None
+        while not self._closed:
+            headers = dict(self._headers)
+            if self._get_auth_headers is not None:
+                headers.update(self._get_auth_headers())
+            if self._last_event_id:
+                # Per Risk #21: httpx-sse does NOT auto-resume
+                # Last-Event-ID. Pass it explicitly on each (re)connect
+                # so the server resumes from the right cursor.
+                headers['Last-Event-ID'] = self._last_event_id
+
+            try:
+                async with aconnect_sse(
+                    self._client,
+                    'GET',
+                    self._url,
+                    headers=headers,
+                ) as event_source:
+                    self._connected = True
+                    self._reconnect_attempts = 0
+                    async for sse in event_source.aiter_sse():
+                        if self._closed:
+                            return
+                        if sse.id:
+                            self._last_event_id = sse.id
+                        event = SSEEvent(
+                            event_id=sse.id or None,
+                            event=sse.event or None,
+                            data=sse.data,
+                        )
+                        if self._on_event is not None:
+                            try:
+                                self._on_event(event)
+                            except Exception as exc:  # noqa: BLE001
+                                logger.warning('[sse] on_event callback raised: %s', exc)
+                        if self._on_data is not None:
+                            try:
+                                self._on_data(sse.data)
+                            except Exception as exc:  # noqa: BLE001
+                                logger.warning('[sse] on_data callback raised: %s', exc)
+            except asyncio.CancelledError:
+                # close() cancellation — exit cleanly without a reconnect.
+                self._connected = False
+                return
+            except (httpx.HTTPError, httpx.TimeoutException, OSError) as exc:
+                logger.debug('[sse] stream error: %s', exc)
+                self._connected = False
+            except Exception as exc:  # noqa: BLE001 -- unknown errors from httpx-sse
+                logger.warning('[sse] unexpected error: %s', exc)
+                self._connected = False
+
+            # Reconnect with budget.
+            self._reconnect_attempts += 1
+            if self._reconnect_attempts > self._reconnect_budget or self._closed:
+                self._closed = True
+                self._connected = False
+                if self._on_close is not None:
+                    try:
+                        self._on_close(WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning('[sse] on_close callback raised: %s', exc)
+                return
+
+            try:
+                await asyncio.sleep(self._reconnect_delay)
+            except asyncio.CancelledError:
+                self._connected = False
+                return
+
+
+__all__ = [
+    'DEFAULT_RECONNECT_BUDGET',
+    'DEFAULT_RECONNECT_DELAY_SECONDS',
+    'GetAuthHeaders',
+    'OnClose',
+    'OnData',
+    'OnEvent',
+    'SSEEvent',
+    'SSETransport',
+]

--- a/tests/bridge/test_code_session_api.py
+++ b/tests/bridge/test_code_session_api.py
@@ -1,0 +1,253 @@
+"""Tests for ``src.bridge.code_session_api``."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from src.bridge.code_session_api import (
+    create_code_session,
+    fetch_remote_credentials,
+    register_worker,
+)
+
+
+# ─── create_code_session ────────────────────────────────────────────────
+
+
+class TestCreateCodeSession:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_session_id(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            assert req.method == 'POST'
+            assert req.url.path == '/v1/code/sessions'
+            body = json.loads(req.content)
+            assert body['title'] == 'My Session'
+            assert body['bridge'] == {}
+            return httpx.Response(201, json={'session': {'id': 'cse_abc'}})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            sid = await create_code_session(
+                'https://api.test', 'tok', 'My Session', client=client,
+            )
+        assert sid == 'cse_abc'
+
+    @pytest.mark.asyncio
+    async def test_passes_tags_when_provided(self):
+        captured: list[dict] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured.append(json.loads(req.content))
+            return httpx.Response(201, json={'session': {'id': 'cse_xyz'}})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            await create_code_session(
+                'https://api.test', 'tok', 'Title', tags=['a', 'b'], client=client,
+            )
+        assert captured[0]['tags'] == ['a', 'b']
+
+    @pytest.mark.asyncio
+    async def test_omits_tags_when_empty(self):
+        captured: list[dict] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured.append(json.loads(req.content))
+            return httpx.Response(201, json={'session': {'id': 'cse_xyz'}})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            await create_code_session(
+                'https://api.test', 'tok', 'Title', tags=[], client=client,
+            )
+        assert 'tags' not in captured[0]
+
+    @pytest.mark.asyncio
+    async def test_non_2xx_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, content=b'unavailable')
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            sid = await create_code_session('https://api.test', 'tok', 't', client=client)
+        assert sid is None
+
+    @pytest.mark.asyncio
+    async def test_network_error_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError('refused')
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            sid = await create_code_session('https://api.test', 'tok', 't', client=client)
+        assert sid is None
+
+    @pytest.mark.asyncio
+    async def test_missing_session_id_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(201, json={'session': {}})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            sid = await create_code_session('https://api.test', 'tok', 't', client=client)
+        assert sid is None
+
+    @pytest.mark.asyncio
+    async def test_non_cse_prefix_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(201, json={'session': {'id': 'wrong_prefix'}})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            sid = await create_code_session('https://api.test', 'tok', 't', client=client)
+        assert sid is None
+
+
+# ─── fetch_remote_credentials ───────────────────────────────────────────
+
+
+class TestFetchRemoteCredentials:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_credentials(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            assert req.url.path == '/v1/code/sessions/cse_abc/bridge'
+            return httpx.Response(200, json={
+                'worker_jwt': 'jwt-tok',
+                'api_base_url': 'https://api.test',
+                'expires_in': 3600,
+                'worker_epoch': 5,
+            })
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            creds = await fetch_remote_credentials(
+                'cse_abc', 'https://api.test', 'tok', client=client,
+            )
+        assert creds is not None
+        assert creds.worker_jwt == 'jwt-tok'
+        assert creds.expires_in == 3600
+        assert creds.worker_epoch == 5
+
+    @pytest.mark.asyncio
+    async def test_handles_string_encoded_int64_epoch(self):
+        """Per A12 + critic: protojson sometimes serializes int64 as string."""
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={
+                'worker_jwt': 'jwt',
+                'api_base_url': 'https://api.test',
+                'expires_in': 60,
+                'worker_epoch': '42',
+            })
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            creds = await fetch_remote_credentials(
+                'cse', 'https://api.test', 'tok', client=client,
+            )
+        assert creds is not None
+        assert creds.worker_epoch == 42
+
+    @pytest.mark.asyncio
+    async def test_passes_trusted_device_token_header(self):
+        captured: list[dict] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured.append(dict(req.headers))
+            return httpx.Response(200, json={
+                'worker_jwt': 'j', 'api_base_url': 'u',
+                'expires_in': 1, 'worker_epoch': 0,
+            })
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            await fetch_remote_credentials(
+                'cse', 'https://api.test', 'tok',
+                trusted_device_token='td-tok', client=client,
+            )
+        assert captured[0]['x-trusted-device-token'] == 'td-tok'
+
+    @pytest.mark.asyncio
+    async def test_missing_worker_jwt_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={
+                'api_base_url': 'u', 'expires_in': 1, 'worker_epoch': 0,
+            })
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            creds = await fetch_remote_credentials(
+                'cse', 'https://api.test', 'tok', client=client,
+            )
+        assert creds is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_epoch_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={
+                'worker_jwt': 'j', 'api_base_url': 'u',
+                'expires_in': 1, 'worker_epoch': 'not a number',
+            })
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            creds = await fetch_remote_credentials(
+                'cse', 'https://api.test', 'tok', client=client,
+            )
+        assert creds is None
+
+    @pytest.mark.asyncio
+    async def test_non_200_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(401, content=b'unauthorized')
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            creds = await fetch_remote_credentials(
+                'cse', 'https://api.test', 'tok', client=client,
+            )
+        assert creds is None
+
+
+# ─── register_worker ───────────────────────────────────────────────────
+
+
+class TestRegisterWorker:
+    @pytest.mark.asyncio
+    async def test_returns_int_epoch(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            assert req.url.path.endswith('/worker/register')
+            return httpx.Response(200, json={'worker_epoch': 7})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            epoch = await register_worker(
+                'https://api.test/v1/code/sessions/cse_abc', 'tok', client=client,
+            )
+        assert epoch == 7
+
+    @pytest.mark.asyncio
+    async def test_string_encoded_epoch_coerced(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={'worker_epoch': '99'})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            epoch = await register_worker(
+                'https://api.test/v1/code/sessions/cse', 'tok', client=client,
+            )
+        assert epoch == 99
+
+    @pytest.mark.asyncio
+    async def test_missing_epoch_raises(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            with pytest.raises(RuntimeError, match='missing worker_epoch'):
+                await register_worker('https://x', 'tok', client=client)
+
+    @pytest.mark.asyncio
+    async def test_non_2xx_raises(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(403)
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            with pytest.raises(RuntimeError, match='unexpected status'):
+                await register_worker('https://x', 'tok', client=client)
+
+    @pytest.mark.asyncio
+    async def test_network_error_raises(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError('refused')
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            with pytest.raises(RuntimeError, match='register_worker failed'):
+                await register_worker('https://x', 'tok', client=client)

--- a/tests/bridge/test_repl_bridge_transport.py
+++ b/tests/bridge/test_repl_bridge_transport.py
@@ -1,0 +1,216 @@
+"""Tests for ``src.bridge.repl_bridge_transport`` (v2 transport).
+
+End-to-end-ish: builds a v2 transport against an in-process httpx
+mock that serves both the SSE stream and the CCR write endpoints.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from src.bridge.close_codes import WS_CLOSE_EPOCH_MISMATCH
+from src.bridge.repl_bridge_transport import (
+    V2TransportOptions,
+    create_v1_repl_transport,
+    create_v2_repl_transport,
+)
+
+
+def _sse_body(events: list[tuple[str, str]]) -> bytes:
+    out: list[str] = []
+    for eid, data in events:
+        out.append(f'id: {eid}')
+        out.append(f'data: {data}')
+        out.append('')
+    return ('\n'.join(out) + '\n').encode('utf-8')
+
+
+@pytest.mark.asyncio
+async def test_v1_factory_raises_not_implemented():
+    with pytest.raises(NotImplementedError):
+        create_v1_repl_transport()
+
+
+@pytest.mark.asyncio
+async def test_v2_transport_reads_sse_and_writes_to_ccr():
+    received_writes: list[dict] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path.endswith('/worker/events/stream'):
+            return httpx.Response(
+                200,
+                headers={'content-type': 'text/event-stream'},
+                content=_sse_body([('1', '{"type":"user","uuid":"u1"}')]),
+            )
+        if req.url.path.endswith('/worker/events'):
+            import json
+            body = json.loads(req.content)
+            received_writes.extend(body.get('events', []))
+            return httpx.Response(200, json={})
+        # Heartbeat / state / delivery — all 200 OK.
+        return httpx.Response(200, json={})
+
+    received_data: list[str] = []
+    connected = asyncio.Event()
+
+    # Create transport with mocked HTTP. We have to inject the client
+    # into BOTH the SSE and CCR layers, so we patch them after
+    # construction.
+    transport = await create_v2_repl_transport(V2TransportOptions(
+        session_url='https://api.test/v1/code/sessions/cse_abc',
+        ingress_token='tok',
+        session_id='cse_abc',
+        epoch=1,
+        heartbeat_interval_seconds=0,
+    ))
+    transport._sse._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    transport._sse._owned_client = True
+    transport._ccr._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    transport._ccr._owned_http = True
+
+    transport.set_on_data(received_data.append)
+    transport.set_on_connect(connected.set)
+    try:
+        transport.connect()
+        await asyncio.wait_for(connected.wait(), timeout=2.0)
+        # Write something via the v2 transport.
+        await transport.write({'type': 'assistant', 'uuid': 'a1'})
+        await transport.flush()
+        # Wait for the SSE stream to deliver the user message.
+        for _ in range(100):
+            if received_data:
+                break
+            await asyncio.sleep(0.02)
+        assert any('"type":"user"' in d for d in received_data)
+        assert any(e.get('uuid') == 'a1' for e in received_writes)
+    finally:
+        await transport.aclose()
+
+
+@pytest.mark.asyncio
+async def test_v2_transport_409_fires_on_close_with_4090():
+    """When CCR returns 409 epoch-mismatch, on_close fires with 4090."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path.endswith('/worker/events/stream'):
+            return httpx.Response(
+                200,
+                headers={'content-type': 'text/event-stream'},
+                content=_sse_body([]),
+            )
+        if req.url.path.endswith('/worker/events'):
+            return httpx.Response(409, json={'error': 'epoch superseded'})
+        return httpx.Response(200, json={})
+
+    close_codes: list[int | None] = []
+    connected = asyncio.Event()
+
+    transport = await create_v2_repl_transport(V2TransportOptions(
+        session_url='https://api.test/v1/code/sessions/cse',
+        ingress_token='tok',
+        session_id='cse',
+        epoch=1,
+        heartbeat_interval_seconds=0,
+    ))
+    transport._sse._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    transport._sse._owned_client = True
+    transport._ccr._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    transport._ccr._owned_http = True
+
+    transport.set_on_close(close_codes.append)
+    transport.set_on_connect(connected.set)
+    try:
+        transport.connect()
+        await asyncio.wait_for(connected.wait(), timeout=2.0)
+        await transport.write({'type': 'user', 'uuid': 'u1'})
+        # Wait for the uploader to hit 409 and fire the epoch-mismatch handler.
+        for _ in range(200):
+            if WS_CLOSE_EPOCH_MISMATCH in close_codes:
+                break
+            await asyncio.sleep(0.02)
+    finally:
+        await transport.aclose()
+
+    assert WS_CLOSE_EPOCH_MISMATCH in close_codes
+
+
+@pytest.mark.asyncio
+async def test_v2_transport_outbound_only_skips_sse():
+    """outbound_only=True: set_on_data is no-op; get_last_sequence_num returns 0."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path.endswith('/worker/events/stream'):
+            # Should NOT be hit when outbound_only=True.
+            raise AssertionError('SSE stream opened in outbound_only mode')
+        return httpx.Response(200, json={})
+
+    connected = asyncio.Event()
+
+    transport = await create_v2_repl_transport(V2TransportOptions(
+        session_url='https://api.test/v1/code/sessions/cse',
+        ingress_token='tok',
+        session_id='cse',
+        epoch=1,
+        outbound_only=True,
+        heartbeat_interval_seconds=0,
+    ))
+    transport._ccr._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    transport._ccr._owned_http = True
+
+    transport.set_on_connect(connected.set)
+    transport.set_on_data(lambda _: None)  # should be no-op
+    try:
+        transport.connect()
+        await asyncio.wait_for(connected.wait(), timeout=2.0)
+        assert transport.get_last_sequence_num() == 0
+        assert transport.is_connected_status()
+    finally:
+        await transport.aclose()
+
+
+@pytest.mark.asyncio
+async def test_v2_transport_dropped_batch_count_passthrough():
+    """Transport's dropped_batch_count delegates to CCRClient."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path.endswith('/worker/events/stream'):
+            return httpx.Response(
+                200,
+                headers={'content-type': 'text/event-stream'},
+                content=_sse_body([]),
+            )
+        # All writes return 503 → drops accumulate.
+        if req.url.path.endswith('/worker/events'):
+            return httpx.Response(503)
+        return httpx.Response(200, json={})
+
+    connected = asyncio.Event()
+
+    transport = await create_v2_repl_transport(V2TransportOptions(
+        session_url='https://api.test/v1/code/sessions/cse',
+        ingress_token='tok',
+        session_id='cse',
+        epoch=1,
+        heartbeat_interval_seconds=0,
+    ))
+    transport._sse._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    transport._sse._owned_client = True
+    transport._ccr._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    transport._ccr._owned_http = True
+    transport._ccr._options.max_retries_per_batch = 1
+    transport._ccr._options.retry_backoff_seconds = 0.01
+    transport.set_on_connect(connected.set)
+    try:
+        transport.connect()
+        await asyncio.wait_for(connected.wait(), timeout=2.0)
+        await transport.write({'type': 'user', 'uuid': 'u1'})
+        for _ in range(200):
+            if transport.dropped_batch_count > 0:
+                break
+            await asyncio.sleep(0.02)
+        assert transport.dropped_batch_count > 0
+    finally:
+        await transport.aclose()

--- a/tests/transports/test_ccr_client.py
+++ b/tests/transports/test_ccr_client.py
@@ -1,0 +1,190 @@
+"""Tests for ``src.transports.ccr_client.CCRClient``."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from src.bridge.exceptions import EpochSupersededError
+from src.transports.ccr_client import CCRClient, CCRClientOptions
+
+
+@pytest.mark.asyncio
+async def test_initialize_spawns_loops_and_uploads_event():
+    received: list[dict] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path == '/worker/events':
+            body = json.loads(req.content)
+            received.extend(body.get('events', []))
+            return httpx.Response(200, json={})
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = CCRClient(
+            base_url='https://api.test',
+            options=CCRClientOptions(heartbeat_interval_seconds=0),
+            http_client=http,
+        )
+        await client.initialize(epoch=1)
+        try:
+            await client.write_event({'type': 'user', 'uuid': 'u1'})
+            await client.flush()
+            assert received == [{'type': 'user', 'uuid': 'u1'}]
+        finally:
+            await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_write_batch_groups_multiple_events():
+    received_batches: list[list[dict]] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path == '/worker/events':
+            body = json.loads(req.content)
+            received_batches.append(body['events'])
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = CCRClient(
+            base_url='https://api.test',
+            options=CCRClientOptions(
+                heartbeat_interval_seconds=0,
+                max_batch_size=10,
+            ),
+            http_client=http,
+        )
+        await client.initialize(epoch=1)
+        try:
+            # Drop several events into the queue rapidly; the uploader
+            # should batch them in a single POST after the first read.
+            for i in range(5):
+                await client.write_event({'type': 'user', 'uuid': f'u{i}'})
+            await client.flush()
+        finally:
+            await client.aclose()
+
+    # All 5 should have been delivered. Batching is opportunistic — the
+    # first event triggers the post; subsequent events arriving before
+    # the post completes get batched.
+    flat = [e for batch in received_batches for e in batch]
+    assert len(flat) == 5
+    assert {e['uuid'] for e in flat} == {f'u{i}' for i in range(5)}
+
+
+@pytest.mark.asyncio
+async def test_409_raises_epoch_superseded_error():
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(409, json={'error': 'epoch superseded'})
+
+    callback_fired = asyncio.Event()
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = CCRClient(
+            base_url='https://api.test',
+            options=CCRClientOptions(
+                heartbeat_interval_seconds=0,
+                on_epoch_mismatch=callback_fired.set,
+            ),
+            http_client=http,
+        )
+        await client.initialize(epoch=1)
+        try:
+            await client.write_event({'type': 'user', 'uuid': 'u1'})
+            # Wait for the uploader to attempt the POST and hit 409.
+            for _ in range(100):
+                if callback_fired.is_set():
+                    break
+                await asyncio.sleep(0.02)
+        finally:
+            await client.aclose()
+
+    assert callback_fired.is_set()
+
+
+@pytest.mark.asyncio
+async def test_dropped_batch_count_tracks_5xx_failures():
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, content=b'unavailable')
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = CCRClient(
+            base_url='https://api.test',
+            options=CCRClientOptions(
+                heartbeat_interval_seconds=0,
+                max_retries_per_batch=2,
+                retry_backoff_seconds=0.01,
+            ),
+            http_client=http,
+        )
+        await client.initialize(epoch=1)
+        try:
+            for i in range(5):
+                await client.write_event({'type': 'user', 'uuid': f'u{i}'})
+            # Wait for the uploader to exhaust retries.
+            for _ in range(200):
+                if client.dropped_batch_count > 0:
+                    break
+                await asyncio.sleep(0.02)
+        finally:
+            await client.aclose()
+
+    assert client.dropped_batch_count > 0
+
+
+@pytest.mark.asyncio
+async def test_report_state_metadata_delivery_fire_and_forget():
+    """report_state/metadata/delivery POST without raising."""
+    seen_paths: list[str] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen_paths.append(req.url.path)
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = CCRClient(
+            base_url='https://api.test',
+            options=CCRClientOptions(heartbeat_interval_seconds=0),
+            http_client=http,
+        )
+        await client.initialize(epoch=1)
+        try:
+            client.report_state({'requires_action': True})
+            client.report_metadata({'custom': 'value'})
+            client.report_delivery('event-1', 'received')
+            await asyncio.sleep(0.1)
+        finally:
+            await client.aclose()
+
+    # All three paths should have been hit.
+    assert any('/worker' == p for p in seen_paths)  # state + metadata both hit /worker (PUT)
+    assert any('/worker/events/event-1/delivery' == p for p in seen_paths)
+
+
+@pytest.mark.asyncio
+async def test_write_after_close_increments_dropped():
+    async with httpx.AsyncClient() as http:
+        client = CCRClient(
+            base_url='https://api.test',
+            options=CCRClientOptions(heartbeat_interval_seconds=0),
+            http_client=http,
+        )
+        await client.initialize(epoch=1)
+        await client.aclose()
+        await client.write_event({'type': 'user', 'uuid': 'u1'})
+    assert client.dropped_batch_count == 1
+
+
+@pytest.mark.asyncio
+async def test_write_before_initialize_increments_dropped():
+    async with httpx.AsyncClient() as http:
+        client = CCRClient(
+            base_url='https://api.test',
+            options=CCRClientOptions(heartbeat_interval_seconds=0),
+            http_client=http,
+        )
+        await client.write_event({'type': 'user', 'uuid': 'u1'})
+    assert client.dropped_batch_count == 1

--- a/tests/transports/test_sse_transport.py
+++ b/tests/transports/test_sse_transport.py
@@ -1,0 +1,213 @@
+"""Tests for ``src.transports.sse_transport.SSETransport``.
+
+Uses ``httpx.MockTransport`` to inject SSE-formatted responses and
+asserts the parsed event flow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from src.bridge.close_codes import WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED
+from src.transports.sse_transport import SSEEvent, SSETransport
+
+
+def _sse_response(events: list[tuple[str | None, str]]) -> bytes:
+    """Build a fake SSE response body. Each event is ``(id, data)``."""
+    out: list[str] = []
+    for eid, data in events:
+        if eid is not None:
+            out.append(f'id: {eid}')
+        out.append(f'data: {data}')
+        out.append('')  # blank line terminates the event
+    return ('\n'.join(out) + '\n').encode('utf-8')
+
+
+@pytest.mark.asyncio
+async def test_basic_event_dispatch():
+    body = _sse_response([
+        ('1', 'first'),
+        ('2', 'second'),
+    ])
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={'content-type': 'text/event-stream'},
+            content=body,
+        )
+
+    received_data: list[str] = []
+    received_events: list[SSEEvent] = []
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sse = SSETransport(
+            url='https://api.test/stream',
+            client=client,
+        )
+        sse.set_on_data(received_data.append)
+        sse.set_on_event(received_events.append)
+        await sse.connect()
+        # Allow the read-loop to drain the (already-buffered) response.
+        for _ in range(50):
+            if len(received_data) >= 2:
+                break
+            await asyncio.sleep(0.02)
+        await sse.aclose()
+
+    assert received_data == ['first', 'second']
+    assert [e.event_id for e in received_events] == ['1', '2']
+
+
+@pytest.mark.asyncio
+async def test_get_last_sequence_num_tracks_event_id():
+    body = _sse_response([('100', 'a'), ('200', 'b'), ('300', 'c')])
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={'content-type': 'text/event-stream'},
+            content=body,
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sse = SSETransport(url='https://api.test/stream', client=client)
+        sse.set_on_data(lambda _: None)
+        await sse.connect()
+        for _ in range(50):
+            if sse.get_last_sequence_num() >= 300:
+                break
+            await asyncio.sleep(0.02)
+        await sse.aclose()
+
+    assert sse.get_last_sequence_num() == 300
+
+
+@pytest.mark.asyncio
+async def test_last_event_id_passed_on_reconnect():
+    """Per Risk #21: SSETransport must pass Last-Event-ID on reconnect."""
+    request_headers: list[dict] = []
+    body = _sse_response([('5', 'x')])
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        request_headers.append({k.lower(): v for k, v in req.headers.items()})
+        return httpx.Response(
+            200,
+            headers={'content-type': 'text/event-stream'},
+            content=body,
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sse = SSETransport(
+            url='https://api.test/stream',
+            client=client,
+            reconnect_delay_seconds=0.01,
+            reconnect_budget=2,
+        )
+        sse.set_on_data(lambda _: None)
+        await sse.connect()
+        # Wait long enough for two reconnect attempts.
+        for _ in range(100):
+            if len(request_headers) >= 2:
+                break
+            await asyncio.sleep(0.02)
+        await sse.aclose()
+
+    # First request: no Last-Event-ID. Second: has '5'.
+    assert len(request_headers) >= 2
+    assert request_headers[0].get('last-event-id') is None
+    assert request_headers[1].get('last-event-id') == '5'
+
+
+@pytest.mark.asyncio
+async def test_reconnect_budget_exhausted_fires_close():
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError('refused')
+
+    received_close: list[int | None] = []
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sse = SSETransport(
+            url='https://api.test/stream',
+            client=client,
+            reconnect_delay_seconds=0.01,
+            reconnect_budget=2,
+        )
+        sse.set_on_close(received_close.append)
+        await sse.connect()
+        # Wait for the budget to be exhausted.
+        for _ in range(100):
+            if received_close:
+                break
+            await asyncio.sleep(0.02)
+        await sse.aclose()
+
+    assert received_close == [WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED]
+
+
+@pytest.mark.asyncio
+async def test_get_auth_headers_called_on_each_connect():
+    call_count = 0
+
+    def auth_headers() -> dict[str, str]:
+        nonlocal call_count
+        call_count += 1
+        return {'Authorization': f'Bearer tok-{call_count}'}
+
+    captured_auth: list[str] = []
+    body = _sse_response([('1', 'x')])
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured_auth.append(req.headers.get('authorization', ''))
+        return httpx.Response(
+            200,
+            headers={'content-type': 'text/event-stream'},
+            content=body,
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sse = SSETransport(
+            url='https://api.test/stream',
+            client=client,
+            get_auth_headers=auth_headers,
+            reconnect_delay_seconds=0.01,
+            reconnect_budget=2,
+        )
+        sse.set_on_data(lambda _: None)
+        await sse.connect()
+        for _ in range(100):
+            if len(captured_auth) >= 2:
+                break
+            await asyncio.sleep(0.02)
+        await sse.aclose()
+
+    # Each connect attempt re-evaluates get_auth_headers (token refresh).
+    assert len(captured_auth) >= 2
+    assert captured_auth[0] != captured_auth[1]
+
+
+@pytest.mark.asyncio
+async def test_close_terminates_loop():
+    body = _sse_response([('1', 'x')])
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={'content-type': 'text/event-stream'},
+            content=body,
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sse = SSETransport(
+            url='https://api.test/stream',
+            client=client,
+            reconnect_delay_seconds=10,  # would block reconnect for ages
+        )
+        sse.set_on_data(lambda _: None)
+        await sse.connect()
+        await asyncio.sleep(0.05)
+        await sse.aclose()  # should not hang
+        assert sse.is_closed_status()


### PR DESCRIPTION
## Summary

**PR 5 of 6** in the Ch16 stack. Stacked on #41 (Phase 2). Rebase to `main` once #40 + #41 land. PR 6 (Phase 4 Remote Session viewer) depends on this PR.

Phase 3 — what claude.ai actually uses for new sessions. The strategic centerpiece of the chapter.

## Modules added

### `src/transports/`

| Module | Purpose |
|---|---|
| `sse_transport.py` | `SSETransport` wraps `httpx_sse.aconnect_sse`. **Per Risk #21**: explicitly tracks `_last_event_id` and passes it as `Last-Event-ID` header on every (re)connect — `httpx-sse` does NOT auto-resume the cursor. Per-attempt `get_auth_headers()` re-evaluation so token refresh works. Reconnect budget (default 5) → `WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED` (4092). |
| `ccr_client.py` | `CCRClient` with `asyncio.Queue(maxsize=100)` producer-blocking back-pressure (**Risk #23**), `producer_timeout_seconds` → `dropped_batch_count` increment if starved. **Uploader retries the SAME batch** up to `max_retries_per_batch` times before dropping (matches TS retry-counts-per-batch semantics). Heartbeat task with optional jitter. 409 → fires `on_epoch_mismatch` + raises `EpochSupersededError` to unwind callers. |

### `src/bridge/`

| Module | Purpose |
|---|---|
| `code_session_api.py` | `create_code_session`, `fetch_remote_credentials` (`worker_epoch` coerced via Phase 2's `coerce_int64`; handles protojson string-OR-number int64), `register_worker`. Best-effort failure semantics for create/fetch (return `None` on network/HTTP error); `register_worker` raises so caller can wrap in retry budget. |
| `repl_bridge_transport.py` | `_V2ReplTransport` satisfies the 14-method `ReplBridgeTransport` Protocol structurally. `create_v2_repl_transport` factory wires SSE + CCRClient + epoch-mismatch handler that closes both transports + raises `EpochSupersededError`. **`outbound_only` mode** skips SSE; `set_on_data` no-op; `get_last_sequence_num` returns 0. **Delivery ACK** both `'received'` AND `'processed'` immediately per the daemon-path fix in `replBridgeTransport.ts:249-252`. `create_v1_repl_transport` is a `NotImplementedError` stub (Phase 6 deferred). |

## Notable correctness invariants

- **SSE Last-Event-ID resume** — `httpx-sse` doesn't auto-resume; we explicitly pass the cursor on each reconnect (Risk #21).
- **`websockets` no auto-reconnect** — explicit reconnect loops in WS clients (Risk #22).
- **Asyncio backpressure** — `asyncio.Queue(maxsize=100)` blocks producer; configurable timeout triggers `dropped_batch_count` if starved (Risk #23).
- **`max_retries_per_batch` semantics** — total attempts = 1 (initial) + `max_retries_per_batch`. Renamed from `max_consecutive_failures` to remove off-by-one ambiguity.
- **Daemon-path delivery ACK fix** — `report_delivery('received')` AND `report_delivery('processed')` immediately, otherwise daemon reconnects re-queue events forever (TS comment at `replBridgeTransport.ts:234-247`).

## Test plan

- [x] `pytest tests/transports/ tests/bridge/test_code_session_api.py tests/bridge/test_repl_bridge_transport.py` — 36 pass
- [x] All HTTP exercised via `httpx.MockTransport`
- [x] Async write contract test (`tests/bridge/test_messaging_handlers.py::TestAsyncWriteContract` from Phase 2) catches the silent-loss bug class
- [x] 80% module coverage; uncovered branches are rare WS-during-handshake errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)