### PR TITLE
feat(ch16): land remaining 5 phases on main (1, 2, 3, 4, 5)

### DIFF
--- a/src/bridge/bounded_uuid_set.py
+++ b/src/bridge/bounded_uuid_set.py
@@ -1,0 +1,75 @@
+"""Fixed-capacity UUID dedup set with FIFO eviction.
+
+Mirrors ``BoundedUUIDSet`` from ``typescript/src/bridge/bridgeMessaging.ts:429-461``.
+
+The CCR bridge has an echo problem: a message a client posts may be
+re-delivered on the read stream, and a transport swap can cause the
+server to replay history. Two parallel sets at capacity 2000 act as the
+dedup buffer (one for posted UUIDs, one for inbound UUIDs).
+
+O(1) ``add``/``has``/``len``; O(capacity) memory. The TS code uses a
+manual ``writeIdx`` modulo because JS lacks a deque; Python's
+``collections.deque(maxlen=capacity)`` provides FIFO eviction natively.
+
+Concurrency: single-coroutine use only. Concurrent ``add``/``has``/``clear``
+calls from different asyncio tasks are undefined behavior. The TS source
+is single-threaded JS by definition; Python needs this said explicitly
+because asyncio + threads is a footgun.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+DEFAULT_CAPACITY = 2000
+
+
+class BoundedUUIDSet:
+    """FIFO-bounded set; oldest entry evicted when capacity is reached."""
+
+    __slots__ = ('_capacity', '_ring', '_set')
+
+    def __init__(self, capacity: int = DEFAULT_CAPACITY) -> None:
+        if capacity <= 0:
+            raise ValueError('BoundedUUIDSet capacity must be > 0')
+        self._capacity: int = capacity
+        # ``deque(maxlen=N)`` automatically discards the leftmost element
+        # when ``append`` would exceed ``N``. We mirror that eviction in
+        # ``_set`` so membership stays consistent.
+        self._ring: deque[str] = deque(maxlen=capacity)
+        self._set: set[str] = set()
+
+    @property
+    def capacity(self) -> int:
+        return self._capacity
+
+    def __len__(self) -> int:
+        return len(self._set)
+
+    def add(self, uuid: str) -> None:
+        """Add ``uuid``; idempotent (does NOT bump LRU position).
+
+        Matches TS ``:441`` early-return-when-already-present semantics.
+        """
+        if uuid in self._set:
+            return
+        if len(self._ring) == self._capacity:
+            # deque.append will evict leftmost; remove it from the set
+            # FIRST so we don't leak it.
+            evicted = self._ring[0]
+            self._set.discard(evicted)
+        self._ring.append(uuid)
+        self._set.add(uuid)
+
+    def has(self, uuid: str) -> bool:
+        return uuid in self._set
+
+    def __contains__(self, uuid: object) -> bool:
+        return isinstance(uuid, str) and uuid in self._set
+
+    def clear(self) -> None:
+        self._ring.clear()
+        self._set.clear()
+
+
+__all__ = ['DEFAULT_CAPACITY', 'BoundedUUIDSet']

--- a/src/bridge/close_codes.py
+++ b/src/bridge/close_codes.py
@@ -1,0 +1,52 @@
+"""WebSocket close codes used by the CCR bridge layer.
+
+Ports the close-code constants synthesized in
+``typescript/src/bridge/replBridgeTransport.ts:209-365`` and
+``typescript/src/remote/SessionsWebSocket.ts:34-37``.
+
+Single source of truth so consumers (Phase 3 `replBridgeTransport`,
+Phase 4 `SessionsWebSocket`, Phase 1 `directConnectManager`) do not
+re-define these magic numbers.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# ─── Server-initiated close codes the bridge transport synthesizes ─────
+
+#: Worker epoch superseded — closes both transports; replBridge's poll
+#: loop reconnects with a fresh epoch.
+#: ``replBridgeTransport.ts:220``.
+WS_CLOSE_EPOCH_MISMATCH: Final = 4090
+
+#: CCRClient.initialize failed — closes both; poll loop will retry on
+#: the next work dispatch.
+#: ``replBridgeTransport.ts:365``.
+WS_CLOSE_INIT_FAILURE: Final = 4091
+
+#: SSE reconnect-budget exhausted — distinguishable from HTTP-status
+#: closes so ws_closed telemetry can branch on it.
+#: ``replBridgeTransport.ts:313``.
+WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED: Final = 4092
+
+# ─── claude.ai → CCR session close codes (Phase 4 SessionsWebSocket) ───
+
+#: Server says "you are not authorized for this session" — stop
+#: reconnecting permanently.
+#: ``SessionsWebSocket.ts:35``.
+WS_CLOSE_PERMANENT_UNAUTHORIZED: Final = 4003
+
+#: Server says "session not found" — could be transient during
+#: compaction; retry with limited linear backoff (max 3 attempts).
+#: ``SessionsWebSocket.ts:26``.
+WS_CLOSE_SESSION_NOT_FOUND: Final = 4001
+
+
+__all__ = [
+    'WS_CLOSE_EPOCH_MISMATCH',
+    'WS_CLOSE_INIT_FAILURE',
+    'WS_CLOSE_PERMANENT_UNAUTHORIZED',
+    'WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED',
+    'WS_CLOSE_SESSION_NOT_FOUND',
+]

--- a/src/bridge/code_session_api.py
+++ b/src/bridge/code_session_api.py
@@ -1,0 +1,265 @@
+"""HTTP wrappers for the CCR v2 code-session API + worker registration.
+
+Ports ``typescript/src/bridge/codeSessionApi.ts:26-168`` and the
+``register_worker`` half of ``workSecret.ts:97-127``.
+
+Three calls:
+
+  * ``create_code_session(base_url, access_token, title, ...)`` — POST
+    ``/v1/code/sessions`` and return the new session ID (``cse_*``).
+  * ``fetch_remote_credentials(session_id, base_url, access_token, ...)``
+    — POST ``/v1/code/sessions/{id}/bridge`` and return the
+    ``RemoteCredentials`` (``worker_jwt``/``api_base_url``/
+    ``expires_in``/``worker_epoch``). Each call to ``/bridge`` IS the
+    registration; the server bumps ``worker_epoch`` on every call.
+  * ``register_worker(session_url, access_token)`` — POST
+    ``/worker/register`` (legacy v2 path used when ``/bridge`` did not
+    return an epoch). Returns the ``worker_epoch`` integer.
+
+All return ``None`` on best-effort failure (network, non-2xx, malformed
+response) — matches TS ``return null`` rather than raising. Callers log
+and continue.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from .protojson import coerce_int64
+
+logger = logging.getLogger(__name__)
+
+ANTHROPIC_VERSION = '2023-06-01'
+
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+
+def _oauth_headers(access_token: str) -> dict[str, str]:
+    return {
+        'Authorization': f'Bearer {access_token}',
+        'Content-Type': 'application/json',
+        'anthropic-version': ANTHROPIC_VERSION,
+    }
+
+
+@dataclass(frozen=True)
+class RemoteCredentials:
+    """Output of ``fetch_remote_credentials`` (POST /bridge).
+
+    Mirrors TS ``RemoteCredentials`` at ``codeSessionApi.ts:84-91``.
+    The JWT is opaque — callers should not decode it (use
+    ``schedule_from_expires_in`` for the refresh timer, not
+    ``decode_jwt_expiry``).
+    """
+
+    worker_jwt: str
+    api_base_url: str
+    expires_in: int
+    worker_epoch: int
+
+
+# ─── POST /v1/code/sessions ────────────────────────────────────────────────
+
+
+async def create_code_session(
+    base_url: str,
+    access_token: str,
+    title: str,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    tags: list[str] | None = None,
+    client: httpx.AsyncClient | None = None,
+) -> str | None:
+    """POST ``/v1/code/sessions`` and return the new session ID.
+
+    Body: ``{title, bridge: {}, tags?}`` — the ``bridge: {}`` is the
+    positive signal for the oneof runner; omitting it 400s.
+
+    Returns ``None`` on any failure (network, non-2xx, missing or
+    malformed ``session.id``); the caller logs and falls through.
+
+    Mirrors ``codeSessionApi.ts:26-80``.
+    """
+    url = f'{base_url.rstrip("/")}/v1/code/sessions'
+    body: dict[str, Any] = {'title': title, 'bridge': {}}
+    if tags:
+        body['tags'] = tags
+
+    try:
+        if client is None:
+            async with httpx.AsyncClient(timeout=timeout_seconds) as fresh:
+                resp = await fresh.post(url, json=body, headers=_oauth_headers(access_token))
+        else:
+            resp = await client.post(
+                url, json=body, headers=_oauth_headers(access_token), timeout=timeout_seconds,
+            )
+    except (httpx.HTTPError, httpx.TimeoutException) as exc:
+        logger.debug('[code-session] Session create request failed: %s', exc)
+        return None
+
+    if resp.status_code not in (200, 201):
+        logger.debug(
+            '[code-session] Session create failed %d', resp.status_code
+        )
+        return None
+
+    try:
+        data = resp.json()
+    except ValueError:
+        return None
+
+    session_obj = data.get('session') if isinstance(data, dict) else None
+    if not isinstance(session_obj, dict):
+        return None
+    sid = session_obj.get('id')
+    if not isinstance(sid, str) or not sid.startswith('cse_'):
+        logger.debug('[code-session] No session.id (cse_*) in response')
+        return None
+    return sid
+
+
+# ─── POST /v1/code/sessions/{id}/bridge ────────────────────────────────────
+
+
+async def fetch_remote_credentials(
+    session_id: str,
+    base_url: str,
+    access_token: str,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    trusted_device_token: str | None = None,
+    client: httpx.AsyncClient | None = None,
+) -> RemoteCredentials | None:
+    """POST ``/v1/code/sessions/{id}/bridge`` and return credentials.
+
+    Mirrors ``codeSessionApi.ts:93-168``. ``trusted_device_token`` is
+    passed as ``X-Trusted-Device-Token`` if set; otherwise omitted.
+
+    Returns ``None`` on failure. ``worker_epoch`` is coerced via
+    ``coerce_int64`` (handles protojson string-OR-number).
+    """
+    url = f'{base_url.rstrip("/")}/v1/code/sessions/{session_id}/bridge'
+    headers = _oauth_headers(access_token)
+    if trusted_device_token:
+        headers['X-Trusted-Device-Token'] = trusted_device_token
+
+    try:
+        if client is None:
+            async with httpx.AsyncClient(timeout=timeout_seconds) as fresh:
+                resp = await fresh.post(url, json={}, headers=headers)
+        else:
+            resp = await client.post(
+                url, json={}, headers=headers, timeout=timeout_seconds,
+            )
+    except (httpx.HTTPError, httpx.TimeoutException) as exc:
+        logger.debug('[code-session] /bridge request failed: %s', exc)
+        return None
+
+    if resp.status_code != 200:
+        logger.debug('[code-session] /bridge failed %d', resp.status_code)
+        return None
+
+    try:
+        data = resp.json()
+    except ValueError:
+        return None
+
+    if not isinstance(data, dict):
+        return None
+    worker_jwt = data.get('worker_jwt')
+    api_base = data.get('api_base_url')
+    expires_in = data.get('expires_in')
+    raw_epoch = data.get('worker_epoch')
+
+    if not isinstance(worker_jwt, str) or not worker_jwt:
+        logger.debug('[code-session] /bridge missing worker_jwt')
+        return None
+    if not isinstance(api_base, str) or not api_base:
+        logger.debug('[code-session] /bridge missing api_base_url')
+        return None
+    if not isinstance(expires_in, int):
+        logger.debug('[code-session] /bridge missing or invalid expires_in')
+        return None
+    if raw_epoch is None:
+        logger.debug('[code-session] /bridge missing worker_epoch')
+        return None
+    try:
+        epoch = coerce_int64(raw_epoch)
+    except ValueError as exc:
+        logger.debug('[code-session] /bridge worker_epoch invalid: %s', exc)
+        return None
+    return RemoteCredentials(
+        worker_jwt=worker_jwt,
+        api_base_url=api_base,
+        expires_in=expires_in,
+        worker_epoch=epoch,
+    )
+
+
+# ─── POST /worker/register (legacy path) ───────────────────────────────────
+
+
+async def register_worker(
+    session_url: str,
+    access_token: str,
+    *,
+    timeout_seconds: float = 10.0,
+    client: httpx.AsyncClient | None = None,
+) -> int:
+    """POST ``${session_url}/worker/register`` and return the ``worker_epoch``.
+
+    Used by the v1 CCR-v2 path (``replBridge`` poll loop) when ``/bridge``
+    didn't return an epoch directly. Raises ``RuntimeError`` on
+    network/HTTP failure or malformed response — callers wrap in their
+    own retry budget.
+
+    Mirrors ``workSecret.ts:97-127``.
+    """
+    url = f'{session_url.rstrip("/")}/worker/register'
+    headers = _oauth_headers(access_token)
+    try:
+        if client is None:
+            async with httpx.AsyncClient(timeout=timeout_seconds) as fresh:
+                resp = await fresh.post(url, json={}, headers=headers)
+        else:
+            resp = await client.post(
+                url, json={}, headers=headers, timeout=timeout_seconds,
+            )
+    except (httpx.HTTPError, httpx.TimeoutException) as exc:
+        raise RuntimeError(f'register_worker failed: {exc}') from exc
+
+    if resp.status_code not in (200, 201):
+        raise RuntimeError(
+            f'register_worker: unexpected status {resp.status_code}'
+        )
+
+    try:
+        data = resp.json()
+    except ValueError as exc:
+        raise RuntimeError(f'register_worker: invalid JSON response: {exc}') from exc
+
+    if not isinstance(data, dict):
+        raise RuntimeError('register_worker: response is not an object')
+    raw = data.get('worker_epoch')
+    if raw is None:
+        raise RuntimeError('register_worker: response missing worker_epoch')
+    try:
+        return coerce_int64(raw)
+    except ValueError as exc:
+        raise RuntimeError(
+            f'register_worker: invalid worker_epoch: {exc}'
+        ) from exc
+
+
+__all__ = [
+    'ANTHROPIC_VERSION',
+    'DEFAULT_TIMEOUT_SECONDS',
+    'RemoteCredentials',
+    'create_code_session',
+    'fetch_remote_credentials',
+    'register_worker',
+]

--- a/src/bridge/exceptions.py
+++ b/src/bridge/exceptions.py
@@ -1,0 +1,29 @@
+"""Project-wide exceptions for the CCR bridge layer.
+
+Phase-local exceptions (e.g., ``DirectConnectError``) live with their
+respective modules; only cross-phase exceptions live here.
+"""
+
+from __future__ import annotations
+
+
+class EpochSupersededError(Exception):
+    """Raised by Phase 3's V2 transport when the server returns 409
+    (worker_epoch superseded).
+
+    Mirrors TS ``replBridgeTransport.ts:230`` which throws ``new Error(
+    'epoch superseded')`` to unwind in-flight callers (``request()``).
+    Catching this is how callers learn the epoch was bumped — they should
+    drop the current transport and recreate it with a fresh epoch.
+    """
+
+
+class BridgeAuthError(Exception):
+    """Raised when JWT cannot be decoded or refresh fails permanently.
+
+    The ``TokenRefreshScheduler`` (WI-2.4) has a 3-failure cap; past that,
+    the scheduler stops retrying and surfaces this exception to the caller.
+    """
+
+
+__all__ = ['BridgeAuthError', 'EpochSupersededError']

--- a/src/bridge/flush_gate.py
+++ b/src/bridge/flush_gate.py
@@ -1,0 +1,92 @@
+"""State machine for gating message writes during an initial flush.
+
+Ports ``typescript/src/bridge/flushGate.ts``.
+
+When a bridge session starts, historical messages are flushed to the
+server via a single HTTP POST. During that flush, new messages must
+be queued to prevent them from arriving at the server interleaved with
+the historical ones.
+
+Lifecycle:
+    start()      → enqueue() returns True; items are queued
+    end()        → returns queued items for draining; enqueue() returns False
+    drop()       → discards queued items (permanent transport close)
+    deactivate() → clears active flag without dropping queued items
+                    (transport replacement — the new transport will drain
+                    the pending items)
+
+Concurrency: single-coroutine use only — concurrent ``enqueue``/``end``
+calls from different asyncio tasks are undefined behavior. Asyncio +
+threads is a footgun; the TS source assumes a single-threaded event loop.
+"""
+
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+T = TypeVar('T')
+
+
+class FlushGate(Generic[T]):
+    """Queue-with-lifecycle that gates writes during a one-shot flush."""
+
+    __slots__ = ('_active', '_pending')
+
+    def __init__(self) -> None:
+        self._active: bool = False
+        self._pending: list[T] = []
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._pending)
+
+    def start(self) -> None:
+        """Mark flush as in-progress. ``enqueue`` will start queuing items."""
+        self._active = True
+
+    def end(self) -> list[T]:
+        """End the flush and return queued items for draining.
+
+        The caller is responsible for sending the returned items.
+        Subsequent ``enqueue`` calls return False until ``start`` is called
+        again.
+        """
+        self._active = False
+        items = self._pending
+        self._pending = []
+        return items
+
+    def enqueue(self, *items: T) -> bool:
+        """If flush is active, queue ``items`` and return True.
+
+        If flush is not active, return False (caller should send directly).
+        """
+        if not self._active:
+            return False
+        self._pending.extend(items)
+        return True
+
+    def drop(self) -> int:
+        """Discard all queued items (permanent transport close).
+
+        Returns the number of items dropped.
+        """
+        self._active = False
+        count = len(self._pending)
+        self._pending = []
+        return count
+
+    def deactivate(self) -> None:
+        """Clear the active flag without dropping queued items.
+
+        Used when the transport is replaced (``onWorkReceived``) — the new
+        transport's flush will drain the pending items.
+        """
+        self._active = False
+
+
+__all__ = ['FlushGate']

--- a/src/bridge/jwt_utils.py
+++ b/src/bridge/jwt_utils.py
@@ -1,0 +1,348 @@
+"""JWT payload decoder + proactive token refresh scheduler.
+
+Ports ``typescript/src/bridge/jwtUtils.ts``. **Does NOT verify
+signatures** — the TS source doesn't either; this is a payload reader,
+not a JWT validator.
+
+Two surfaces:
+
+1. ``decode_jwt_payload`` / ``decode_jwt_expiry`` — pure functions for
+   reading the payload + ``exp`` claim from a base64url-encoded JWT.
+   Strips the ``sk-ant-si-`` session-ingress prefix if present.
+
+2. ``TokenRefreshScheduler`` — per-session timer that proactively
+   refreshes tokens 5 minutes before expiry, with a generation counter
+   to invalidate cancelled-then-rescheduled refreshes, fallback
+   ``schedule_from_expires_in`` for opaque JWTs (30 s floor clamp), and
+   a 30-min follow-up so long-running sessions stay authenticated.
+   Constants match TS exactly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any, Mapping, Union
+
+logger = logging.getLogger(__name__)
+
+# ─── JWT payload reading ───────────────────────────────────────────────────
+
+
+def decode_jwt_payload(token: str) -> Mapping[str, Any] | None:
+    """Decode a JWT's payload segment without verifying the signature.
+
+    Strips the ``sk-ant-si-`` session-ingress prefix if present. Returns
+    the parsed JSON payload as ``Mapping`` (project convention uses
+    ``Any`` not ``object``; see ``src/types/messages.py:115``), or
+    ``None`` if the token is malformed or the payload is not valid JSON.
+
+    Mirrors ``typescript/src/bridge/jwtUtils.ts:21-32``.
+    """
+    jwt = token[len('sk-ant-si-'):] if token.startswith('sk-ant-si-') else token
+    parts = jwt.split('.')
+    if len(parts) != 3 or not parts[1]:
+        return None
+    try:
+        # base64url payload may omit padding.
+        body = parts[1]
+        body += '=' * ((-len(body)) % 4)
+        decoded = base64.urlsafe_b64decode(body).decode('utf-8')
+        parsed: Any = json.loads(decoded)
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
+
+
+def decode_jwt_expiry(token: str) -> int | None:
+    """Return the ``exp`` claim (Unix seconds) or None if unparseable.
+
+    Mirrors ``typescript/src/bridge/jwtUtils.ts:38-49``.
+    """
+    payload = decode_jwt_payload(token)
+    if payload is None:
+        return None
+    exp = payload.get('exp')
+    if isinstance(exp, int):
+        return exp
+    return None
+
+
+# ─── Token refresh scheduler ───────────────────────────────────────────────
+
+# Constants — keep identical to TS so behavior matches.
+TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000
+"""Refresh buffer: request a new token this many ms before expiry."""
+
+FALLBACK_REFRESH_INTERVAL_MS = 30 * 60 * 1000
+"""Fallback refresh interval when the new token's expiry is unknown."""
+
+MAX_REFRESH_FAILURES = 3
+"""Cap on consecutive failures before giving up on the refresh chain."""
+
+REFRESH_RETRY_DELAY_MS = 60_000
+"""Retry delay when ``get_access_token`` returns None."""
+
+SCHEDULE_FROM_EXPIRES_IN_FLOOR_MS = 30_000
+"""30 s floor for ``schedule_from_expires_in`` to avoid tight-loop refresh."""
+
+
+GetAccessToken = Callable[[], Union[str, None, Awaitable[Union[str, None]]]]
+OnRefresh = Callable[[str, str], None]
+
+
+def _format_duration_ms(ms: float) -> str:
+    """Format a millisecond duration as a human-readable string."""
+    if ms < 60_000:
+        return f'{round(ms / 1000)}s'
+    minutes = int(ms // 60_000)
+    seconds = round((ms % 60_000) / 1000)
+    return f'{minutes}m {seconds}s' if seconds > 0 else f'{minutes}m'
+
+
+class TokenRefreshScheduler:
+    """Per-session refresh-timer manager.
+
+    Mirrors ``typescript/src/bridge/jwtUtils.ts:72-256`` (``createTokenRefreshScheduler``).
+
+    Public API:
+        schedule(session_id, token)               — refresh based on JWT.exp
+        schedule_from_expires_in(sid, sec)        — refresh based on TTL
+        cancel(session_id)                        — cancel one session
+        cancel_all()                              — cancel all sessions
+
+    Concurrency: all methods assume single-event-loop use AND must be
+    called from inside a running asyncio loop (we use
+    ``asyncio.get_running_loop()`` rather than the deprecated
+    ``get_event_loop()`` to avoid the implicit-loop-creation hazard on
+    Python 3.12+). Cancellation via ``loop.call_later(...).cancel()`` is
+    synchronous — returns immediately; the callback is just unscheduled.
+    """
+
+    def __init__(
+        self,
+        get_access_token: GetAccessToken,
+        on_refresh: OnRefresh,
+        label: str,
+        refresh_buffer_ms: int = TOKEN_REFRESH_BUFFER_MS,
+    ) -> None:
+        self._get_access_token = get_access_token
+        self._on_refresh = on_refresh
+        self._label = label
+        self._refresh_buffer_ms = refresh_buffer_ms
+        self._timers: dict[str, asyncio.TimerHandle] = {}
+        self._failure_counts: dict[str, int] = {}
+        # Generation counter per session — bumped by schedule() and
+        # cancel() so in-flight async _do_refresh calls can detect when
+        # they've been superseded and bail out.
+        self._generations: dict[str, int] = {}
+
+    # ─── Public API ────────────────────────────────────────────────────────
+
+    def schedule(self, session_id: str, token: str) -> None:
+        """Schedule refresh based on the token's ``exp`` claim."""
+        expiry_seconds = decode_jwt_expiry(token)
+        if expiry_seconds is None:
+            # Token is not a decodable JWT (e.g., an OAuth token from the
+            # REPL bridge WS open handler). Preserve any existing timer
+            # (such as the follow-up refresh set by _do_refresh) so the
+            # refresh chain isn't broken.
+            logger.debug(
+                '[%s:token] Could not decode JWT expiry for sessionId=%s, token prefix=%s..., keeping existing timer',
+                self._label,
+                session_id,
+                token[:15],
+            )
+            return
+
+        # Cancel any existing timer — we have a concrete expiry to replace it.
+        existing = self._timers.pop(session_id, None)
+        if existing is not None:
+            existing.cancel()
+
+        gen = self._next_generation(session_id)
+        delay_ms = expiry_seconds * 1000 - int(time.time() * 1000) - self._refresh_buffer_ms
+        if delay_ms <= 0:
+            logger.debug(
+                '[%s:token] Token for sessionId=%s already past refresh buffer; refreshing immediately',
+                self._label,
+                session_id,
+            )
+            asyncio.get_running_loop().create_task(self._do_refresh(session_id, gen))
+            return
+
+        logger.debug(
+            '[%s:token] Scheduled token refresh for sessionId=%s in %s (buffer=%ss)',
+            self._label,
+            session_id,
+            _format_duration_ms(delay_ms),
+            self._refresh_buffer_ms / 1000,
+        )
+        loop = asyncio.get_running_loop()
+        handle = loop.call_later(delay_ms / 1000, self._fire_refresh, session_id, gen)
+        self._timers[session_id] = handle
+
+    def schedule_from_expires_in(self, session_id: str, expires_in_seconds: int) -> None:
+        """Schedule refresh from an explicit TTL (for opaque JWTs).
+
+        Used by callers whose JWT is opaque (e.g., POST /v1/code/sessions/
+        {id}/bridge returns ``expires_in`` directly).
+
+        Clamped to ``SCHEDULE_FROM_EXPIRES_IN_FLOOR_MS`` (30 s) to avoid a
+        tight-loop refresh if the buffer exceeds the server's TTL.
+        """
+        existing = self._timers.pop(session_id, None)
+        if existing is not None:
+            existing.cancel()
+        gen = self._next_generation(session_id)
+        delay_ms = max(
+            expires_in_seconds * 1000 - self._refresh_buffer_ms,
+            SCHEDULE_FROM_EXPIRES_IN_FLOOR_MS,
+        )
+        logger.debug(
+            '[%s:token] Scheduled token refresh for sessionId=%s in %s (expires_in=%ss, buffer=%ss)',
+            self._label,
+            session_id,
+            _format_duration_ms(delay_ms),
+            expires_in_seconds,
+            self._refresh_buffer_ms / 1000,
+        )
+        loop = asyncio.get_running_loop()
+        handle = loop.call_later(delay_ms / 1000, self._fire_refresh, session_id, gen)
+        self._timers[session_id] = handle
+
+    def cancel(self, session_id: str) -> None:
+        """Cancel the timer for one session and bump its generation."""
+        # Bump generation to invalidate any in-flight async _do_refresh.
+        self._next_generation(session_id)
+        timer = self._timers.pop(session_id, None)
+        if timer is not None:
+            timer.cancel()
+        self._failure_counts.pop(session_id, None)
+
+    def cancel_all(self) -> None:
+        """Cancel all timers and bump all generations."""
+        for sid in list(self._generations.keys()):
+            self._next_generation(sid)
+        for handle in self._timers.values():
+            handle.cancel()
+        self._timers.clear()
+        self._failure_counts.clear()
+
+    # ─── Internal ──────────────────────────────────────────────────────────
+
+    def _next_generation(self, session_id: str) -> int:
+        gen = self._generations.get(session_id, 0) + 1
+        self._generations[session_id] = gen
+        return gen
+
+    def _fire_refresh(self, session_id: str, gen: int) -> None:
+        """Timer callback — schedules the async refresh as a task."""
+        asyncio.get_running_loop().create_task(self._do_refresh(session_id, gen))
+
+    async def _do_refresh(self, session_id: str, gen: int) -> None:
+        """Run one refresh cycle.
+
+        If ``get_access_token`` returns None, increments failure count
+        and reschedules until ``MAX_REFRESH_FAILURES`` is reached.
+        On success: fires ``on_refresh(session_id, token)`` and schedules
+        the follow-up at ``FALLBACK_REFRESH_INTERVAL_MS``.
+        """
+        oauth_token: str | None = None
+        try:
+            result = self._get_access_token()
+            if asyncio.iscoroutine(result) or isinstance(result, Awaitable):
+                oauth_token = await result  # type: ignore[assignment]
+            else:
+                oauth_token = result  # type: ignore[assignment]
+        except Exception as exc:  # noqa: BLE001 -- log + continue, like TS
+            logger.error(
+                '[%s:token] get_access_token threw for sessionId=%s: %s',
+                self._label,
+                session_id,
+                exc,
+            )
+
+        # If the session was cancelled or rescheduled while we were
+        # awaiting, the generation will have changed — bail out to avoid
+        # orphaning timers.
+        if self._generations.get(session_id) != gen:
+            logger.debug(
+                '[%s:token] _do_refresh for sessionId=%s stale (gen %s vs %s), skipping',
+                self._label,
+                session_id,
+                gen,
+                self._generations.get(session_id),
+            )
+            return
+
+        if not oauth_token:
+            failures = self._failure_counts.get(session_id, 0) + 1
+            self._failure_counts[session_id] = failures
+            logger.error(
+                '[%s:token] No OAuth token available for refresh sessionId=%s (failure %d/%d)',
+                self._label,
+                session_id,
+                failures,
+                MAX_REFRESH_FAILURES,
+            )
+            if failures < MAX_REFRESH_FAILURES:
+                loop = asyncio.get_running_loop()
+                handle = loop.call_later(
+                    REFRESH_RETRY_DELAY_MS / 1000,
+                    self._fire_refresh,
+                    session_id,
+                    gen,
+                )
+                self._timers[session_id] = handle
+            return
+
+        # Success: reset failure counter; fire the refresh callback;
+        # schedule the follow-up.
+        self._failure_counts.pop(session_id, None)
+        logger.debug(
+            '[%s:token] Refreshing token for sessionId=%s: new prefix=%s...',
+            self._label,
+            session_id,
+            oauth_token[:15],
+        )
+        try:
+            self._on_refresh(session_id, oauth_token)
+        except Exception as exc:  # noqa: BLE001 -- never let on_refresh throw kill the chain
+            logger.error('[%s:token] on_refresh raised for sessionId=%s: %s', self._label, session_id, exc)
+
+        # Schedule a follow-up so long-running sessions stay authenticated.
+        loop = asyncio.get_running_loop()
+        handle = loop.call_later(
+            FALLBACK_REFRESH_INTERVAL_MS / 1000,
+            self._fire_refresh,
+            session_id,
+            gen,
+        )
+        self._timers[session_id] = handle
+        logger.debug(
+            '[%s:token] Scheduled follow-up refresh for sessionId=%s in %s',
+            self._label,
+            session_id,
+            _format_duration_ms(FALLBACK_REFRESH_INTERVAL_MS),
+        )
+
+
+__all__ = [
+    'FALLBACK_REFRESH_INTERVAL_MS',
+    'GetAccessToken',
+    'MAX_REFRESH_FAILURES',
+    'OnRefresh',
+    'REFRESH_RETRY_DELAY_MS',
+    'SCHEDULE_FROM_EXPIRES_IN_FLOOR_MS',
+    'TOKEN_REFRESH_BUFFER_MS',
+    'TokenRefreshScheduler',
+    'decode_jwt_expiry',
+    'decode_jwt_payload',
+]

--- a/src/bridge/messaging.py
+++ b/src/bridge/messaging.py
@@ -1,0 +1,402 @@
+"""CCR bridge ingress router + message filters/adapters.
+
+Ports the **router** half (``handle_ingress_message``, type guards,
+``normalize_control_message_keys``) and the **filter/adapter** half
+(``is_eligible_bridge_message``, ``extract_title_text``,
+``make_result_message``, ``RemotePermissionResponse``) of
+``typescript/src/bridge/bridgeMessaging.ts``.
+
+The **server-control-request handler** (``handle_server_control_request``
+plus the per-subtype handler dispatch) lives in
+``src/bridge/messaging_handlers.py`` so the router stays small and stable
+while the handler set evolves.
+
+Concurrency: ingress messages flow on a single asyncio task; the
+``BoundedUUIDSet`` instances passed in must not be shared across tasks
+without external locking.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import logging
+import re
+import uuid as _uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any, Union
+
+from .bounded_uuid_set import BoundedUUIDSet
+from .sdk_types import (
+    SDKControlRequest,
+    SDKControlResponse,
+    SDKMessage,
+    SDKResultSuccess,
+)
+
+logger = logging.getLogger(__name__)
+
+# ─── Type guards ───────────────────────────────────────────────────────────
+
+
+def is_sdk_message(value: object) -> bool:
+    """True if ``value`` looks like an SDKMessage (has a string ``type``).
+
+    Mirrors ``bridgeMessaging.ts:36-43``. Permissive on purpose — callers
+    narrow further by branching on ``type``.
+    """
+    return (
+        isinstance(value, dict)
+        and 'type' in value
+        and isinstance(value.get('type'), str)
+    )
+
+
+def is_sdk_control_response(value: object) -> bool:
+    """True for ``{type:'control_response', response}``-shaped dicts."""
+    return (
+        isinstance(value, dict)
+        and value.get('type') == 'control_response'
+        and 'response' in value
+    )
+
+
+def is_sdk_control_request(value: object) -> bool:
+    """True for ``{type:'control_request', request_id, request}``-shaped dicts."""
+    return (
+        isinstance(value, dict)
+        and value.get('type') == 'control_request'
+        and 'request_id' in value
+        and 'request' in value
+    )
+
+
+# ─── camelCase ↔ snake_case normalization for control envelopes ────────────
+
+# Hand-ported known-key set from ``typescript/src/utils/controlMessageCompat.ts``
+# (referenced by ``bridgeMessaging.ts:141``). Unknown keys pass through
+# unchanged with a debug log entry.
+_KNOWN_CAMEL_TO_SNAKE: dict[str, str] = {
+    'requestId': 'request_id',
+    'toolUseId': 'tool_use_id',
+    'parentToolUseId': 'parent_tool_use_id',
+    'controlRequest': 'control_request',
+    'controlResponse': 'control_response',
+    'controlCancelRequest': 'control_cancel_request',
+    'sessionId': 'session_id',
+    'workerEpoch': 'worker_epoch',
+    'workerJwt': 'worker_jwt',
+    'apiBaseUrl': 'api_base_url',
+    'expiresIn': 'expires_in',
+    'updatedInput': 'updated_input',
+    'maxThinkingTokens': 'max_thinking_tokens',
+    'permissionMode': 'permission_mode',
+    'toolName': 'tool_name',
+}
+
+
+def normalize_control_message_keys(value: object) -> object:
+    """Walk the wire payload and normalize known camelCase keys to snake_case.
+
+    Recurses into nested dicts and lists. Unknown camelCase keys are
+    passed through unchanged with a one-line debug log so the messaging
+    layer surfaces wire-format drift without silently dropping anything.
+
+    Mirrors ``typescript/src/utils/controlMessageCompat.ts``.
+    """
+    if isinstance(value, list):
+        return [normalize_control_message_keys(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+    out: dict[str, Any] = {}
+    for key, val in value.items():
+        normalized_key = _KNOWN_CAMEL_TO_SNAKE.get(key, key)
+        if normalized_key == key and _looks_camel_case(key):
+            logger.debug(
+                '[bridge:messaging] Unknown camelCase key passed through unchanged: %s',
+                key,
+            )
+        out[normalized_key] = normalize_control_message_keys(val)
+    return out
+
+
+def _looks_camel_case(key: str) -> bool:
+    """Heuristic: contains an internal uppercase letter and starts lowercase."""
+    return bool(key) and key[0].islower() and any(c.isupper() for c in key[1:])
+
+
+# ─── Ingress router ────────────────────────────────────────────────────────
+
+
+def handle_ingress_message(
+    data: str,
+    recent_posted_uuids: BoundedUUIDSet,
+    recent_inbound_uuids: BoundedUUIDSet,
+    on_inbound_message: Callable[[dict[str, Any]], Union[None, Awaitable[None]]] | None = None,
+    on_permission_response: Callable[[dict[str, Any]], None] | None = None,
+    on_control_request: Callable[[dict[str, Any]], None] | None = None,
+) -> None:
+    """Parse an ingress WebSocket message and route it to the right handler.
+
+    Mirrors ``bridgeMessaging.ts:132-208``.
+
+    Routing rules:
+      1. Parse JSON (silently drop on parse error — log only).
+      2. Normalize control-message keys.
+      3. ``control_response`` → ``on_permission_response``.
+      4. ``control_request`` → ``on_control_request``.
+      5. UUID dedup: drop if in ``recent_posted_uuids`` (echo of our own
+         write) or ``recent_inbound_uuids`` (re-delivery from history
+         replay).
+      6. ``user`` SDKMessage → ``on_inbound_message`` (and add UUID to
+         ``recent_inbound_uuids``).
+      7. Other SDK message types → log + drop (server only wants user
+         turns on the read side; we filter in
+         ``is_eligible_bridge_message`` for the write side).
+    """
+    try:
+        raw = json.loads(data)
+    except json.JSONDecodeError as exc:
+        logger.debug('[bridge:messaging] Failed to parse ingress message: %s', exc)
+        return
+
+    parsed = normalize_control_message_keys(raw)
+
+    if is_sdk_control_response(parsed):
+        logger.debug('[bridge:messaging] Ingress message type=control_response')
+        if on_permission_response is not None:
+            on_permission_response(parsed)  # type: ignore[arg-type]
+        return
+
+    if is_sdk_control_request(parsed):
+        subtype = parsed.get('request', {}).get('subtype', '<unknown>')  # type: ignore[union-attr]
+        logger.debug('[bridge:messaging] Inbound control_request subtype=%s', subtype)
+        if on_control_request is not None:
+            on_control_request(parsed)  # type: ignore[arg-type]
+        return
+
+    if not is_sdk_message(parsed):
+        return
+
+    msg = parsed  # narrowed to dict by is_sdk_message
+    msg_uuid = msg.get('uuid') if isinstance(msg.get('uuid'), str) else None  # type: ignore[union-attr]
+
+    if msg_uuid is not None and recent_posted_uuids.has(msg_uuid):
+        logger.debug(
+            '[bridge:messaging] Ignoring echo: type=%s uuid=%s',
+            msg.get('type'),  # type: ignore[union-attr]
+            msg_uuid,
+        )
+        return
+
+    if msg_uuid is not None and recent_inbound_uuids.has(msg_uuid):
+        logger.debug(
+            '[bridge:messaging] Ignoring re-delivered inbound: type=%s uuid=%s',
+            msg.get('type'),  # type: ignore[union-attr]
+            msg_uuid,
+        )
+        return
+
+    msg_type = msg.get('type')  # type: ignore[union-attr]
+    logger.debug(
+        '[bridge:messaging] Ingress message type=%s%s',
+        msg_type,
+        f' uuid={msg_uuid}' if msg_uuid else '',
+    )
+
+    if msg_type == 'user':
+        if msg_uuid is not None:
+            recent_inbound_uuids.add(msg_uuid)
+        if on_inbound_message is not None:
+            result = on_inbound_message(msg)  # type: ignore[arg-type]
+            # If the handler is async, fire-and-forget on the running loop.
+            # Matches TS ``void onInboundMessage?.(parsed)`` discard.
+            # Caller MUST invoke ``handle_ingress_message`` from inside a
+            # running asyncio loop when ``on_inbound_message`` is async;
+            # use ``get_running_loop`` (raises RuntimeError if no loop)
+            # rather than the deprecated ``get_event_loop``.
+            if inspect.isawaitable(result):
+                asyncio.get_running_loop().create_task(result)  # type: ignore[arg-type]
+    else:
+        logger.debug(
+            '[bridge:messaging] Ignoring non-user inbound message: type=%s',
+            msg_type,
+        )
+
+
+# ─── Forward-filter for outbound bridge messages ───────────────────────────
+
+
+def is_eligible_bridge_message(message: dict[str, Any]) -> bool:
+    """True if ``message`` should be forwarded to the bridge transport.
+
+    Mirrors ``bridgeMessaging.ts:77-88``: filters out virtual REPL
+    inner-call messages, tool_results, progress, non-human origins, etc.
+    Forwards user/assistant turns and ``system`` messages of subtype
+    ``local_command``.
+    """
+    msg_type = message.get('type')
+    if msg_type in ('user', 'assistant'):
+        if message.get('isVirtual'):
+            return False
+        return True
+    if msg_type == 'system':
+        return message.get('subtype') == 'local_command'
+    return False
+
+
+# Mirror of TS ``utils/displayTags.ts:14`` ``XML_TAG_BLOCK_PATTERN`` —
+# lowercase-only opening (so user prose like "<Button>" passes through),
+# backreference for the closing tag (so adjacent blocks don't merge and
+# mismatched ``<foo>x</bar>`` is left alone), optional attributes,
+# multi-line content (``[\s\S]`` is the JS equivalent of ``re.DOTALL``).
+# Trailing ``\n?`` strips the newline that wraps system-injected blocks.
+_DISPLAY_TAG_RE = re.compile(r'<([a-z][\w-]*)(?:\s[^>]*)?>[\s\S]*?</\1>\n?')
+
+
+def _strip_display_tags(text: str) -> str:
+    """Strip XML-like display tags from ``text``.
+
+    Equivalent to TS ``stripDisplayTagsAllowEmpty`` (``displayTags.ts:37``)
+    — returns empty string when all content is tags. Used by
+    ``extract_title_text`` to skip pure-XML messages during bridge title
+    derivation.
+    """
+    return _DISPLAY_TAG_RE.sub('', text).strip()
+
+
+def extract_title_text(message: dict[str, Any]) -> str | None:
+    """Extract title-worthy text from a Message for ``onUserMessage``.
+
+    Returns None for messages that shouldn't title the session: non-user,
+    meta (nudges), tool results, compact summaries, non-human origins
+    (task notifications, channel messages), or pure display-tag content.
+
+    Mirrors ``bridgeMessaging.ts:103-122``.
+    """
+    if message.get('type') != 'user':
+        return None
+    # Match JS truthy semantics: ``isMeta``/``isCompactSummary`` are
+    # bool flags (False/None means "not meta"), but ``toolUseResult`` is
+    # a dict where even ``{}`` should disqualify (in JS ``{}`` is truthy;
+    # in Python ``{}`` is falsy, so we check for *presence*, not truthiness).
+    if message.get('isMeta'):
+        return None
+    if 'toolUseResult' in message and message.get('toolUseResult') is not None:
+        return None
+    if message.get('isCompactSummary'):
+        return None
+    origin = message.get('origin')
+    if isinstance(origin, dict) and origin.get('kind') != 'human':
+        return None
+
+    inner = message.get('message') or {}
+    content = inner.get('content') if isinstance(inner, dict) else None
+    raw: str | None
+    if isinstance(content, str):
+        raw = content
+    elif isinstance(content, list):
+        raw = None
+        for block in content:
+            if isinstance(block, dict) and block.get('type') == 'text':
+                raw = block.get('text')
+                if isinstance(raw, str):
+                    break
+                raw = None
+    else:
+        raw = None
+
+    if not raw:
+        return None
+    cleaned = _strip_display_tags(raw)
+    return cleaned or None
+
+
+# ─── Result message (for session archival on teardown) ─────────────────────
+
+
+def make_result_message(session_id: str) -> SDKResultSuccess:
+    """Build a minimal ``SDKResultSuccess`` for session archival.
+
+    The server needs this event before a WS close to trigger archival.
+    Mirrors ``bridgeMessaging.ts:399-416``.
+    """
+    return {
+        'type': 'result',
+        'subtype': 'success',
+        'duration_ms': 0,
+        'duration_api_ms': 0,
+        'is_error': False,
+        'num_turns': 0,
+        'result': '',
+        'stop_reason': None,
+        'total_cost_usd': 0.0,
+        'usage': {},
+        'modelUsage': {},
+        'permission_denials': [],
+        'session_id': session_id,
+        'uuid': str(_uuid.uuid4()),
+    }
+
+
+# ─── Remote permission response (Phase 4 + Direct Connect consumer) ────────
+
+
+@dataclass(frozen=True)
+class AllowResponse:
+    """Permission allow with possibly-rewritten input."""
+
+    updated_input: dict[str, Any] = field(default_factory=dict)
+    behavior: str = 'allow'
+
+
+@dataclass(frozen=True)
+class DenyResponse:
+    """Permission deny with a user-visible message."""
+
+    message: str
+    behavior: str = 'deny'
+
+
+# Discriminated union — callers branch on ``isinstance(...)``.
+RemotePermissionResponse = Union[AllowResponse, DenyResponse]
+
+
+def remote_permission_response_from_dict(payload: dict[str, Any]) -> RemotePermissionResponse:
+    """Wire-format → ``RemotePermissionResponse``.
+
+    Mirrors ``RemotePermissionResponse`` discriminated union from
+    ``remote/RemoteSessionManager.ts:40-48``.
+    """
+    behavior = payload.get('behavior')
+    if behavior == 'allow':
+        updated = payload.get('updated_input') or payload.get('updatedInput') or {}
+        if not isinstance(updated, dict):
+            raise ValueError(
+                f'allow response: updated_input must be dict, got {type(updated).__name__}'
+            )
+        return AllowResponse(updated_input=updated)
+    if behavior == 'deny':
+        msg = payload.get('message')
+        if not isinstance(msg, str):
+            raise ValueError('deny response: message must be a string')
+        return DenyResponse(message=msg)
+    raise ValueError(f'unknown permission behavior: {behavior!r}')
+
+
+__all__ = [
+    'AllowResponse',
+    'DenyResponse',
+    'RemotePermissionResponse',
+    'extract_title_text',
+    'handle_ingress_message',
+    'is_eligible_bridge_message',
+    'is_sdk_control_request',
+    'is_sdk_control_response',
+    'is_sdk_message',
+    'make_result_message',
+    'normalize_control_message_keys',
+    'remote_permission_response_from_dict',
+]

--- a/src/bridge/messaging_handlers.py
+++ b/src/bridge/messaging_handlers.py
@@ -1,0 +1,261 @@
+"""Server-initiated control_request handler.
+
+Ports ``handle_server_control_request`` from
+``typescript/src/bridge/bridgeMessaging.ts:243-391`` plus the per-subtype
+dispatch (``initialize``, ``set_model``, ``set_max_thinking_tokens``,
+``set_permission_mode``, ``interrupt``) AND the **unknown-subtype error
+response default** + outbound-only error response.
+
+Lives in a separate file from ``messaging.py`` so the router stays small
+and stable while the handler set evolves.
+
+Dispatch flow:
+    server WS → handle_ingress_message (router)
+              → on_control_request callback
+              → handle_server_control_request (this module)
+              → per-subtype handler (callbacks supplied by ``handlers``)
+              → transport.write(control_response)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Protocol, Union
+
+logger = logging.getLogger(__name__)
+
+OUTBOUND_ONLY_ERROR = (
+    'This session is outbound-only. Enable Remote Control locally to allow '
+    'inbound control.'
+)
+
+
+# ─── Verdict type for set_permission_mode (WI-3.7a wiring point) ───────────
+
+
+@dataclass(frozen=True)
+class Ok:
+    """Verdict: policy permitted the mode change."""
+
+
+@dataclass(frozen=True)
+class Err:
+    """Verdict: policy rejected the mode change with a user-visible reason."""
+
+    error: str
+
+
+Verdict = Union[Ok, Err]
+
+
+# ─── Transport surface this module needs ───────────────────────────────────
+
+
+class _TransportLike(Protocol):
+    """Minimal write-side surface used by ``handle_server_control_request``.
+
+    Real implementations (``ReplBridgeTransport``,
+    ``DirectConnectSessionManager``) provide more; this Protocol pins
+    what we depend on.
+
+    **Sync OR async write is supported.** TS ``ReplBridgeTransport.write``
+    is async (returns ``Promise<void>`` per
+    ``replBridgeTransport.ts:24``); TS consumers fire-and-forget with
+    ``void transport.write(event)``. The Python equivalent: if ``write``
+    returns an awaitable, ``_send`` schedules it on the running loop via
+    ``asyncio.create_task``. If it returns ``None`` (sync), nothing extra
+    happens. Callers MUST invoke ``handle_server_control_request`` from
+    inside a running loop when the transport's ``write`` is async.
+    """
+
+    def write(  # pragma: no cover -- structural
+        self, message: dict[str, Any]
+    ) -> Any:
+        ...
+
+
+# ─── Handlers struct ───────────────────────────────────────────────────────
+
+
+@dataclass
+class ServerControlRequestHandlers:
+    """Per-callsite wiring for the 5 control_request subtypes.
+
+    Mirrors the TS ``ServerControlRequestHandlers`` type at
+    ``bridgeMessaging.ts:212-229``.
+
+    Required fields:
+      transport — the write surface the response is sent through.
+      session_id — included in every emitted control_response.
+
+    Optional callbacks (None means "subtype not supported here"):
+      on_interrupt — called for ``interrupt``; success response is sent.
+      on_set_model — called for ``set_model(model)``; success response.
+      on_set_max_thinking_tokens — called for that subtype; success.
+      on_set_permission_mode — called for ``set_permission_mode(mode)``;
+            **must return** ``Ok()`` or ``Err(error=...)``. If None, the
+            handler returns ``Err`` with a "not supported in this context"
+            message — the chapter-prescribed unknown-handler pattern at
+            ``bridgeMessaging.ts:336-340``. WI-3.7b will replace the default
+            with real policy gates once those land.
+
+    outbound_only — when True, all mutable subtypes (everything except
+    ``initialize``) reply with an error so claude.ai sees a proper error
+    instead of false-success. ``initialize`` still succeeds — the server
+    kills the connection within 10-14 s otherwise.
+    """
+
+    transport: _TransportLike
+    session_id: str
+    outbound_only: bool = False
+    on_interrupt: Callable[[], None] | None = None
+    on_set_model: Callable[[str | None], None] | None = None
+    on_set_max_thinking_tokens: Callable[[int | None], None] | None = None
+    on_set_permission_mode: Callable[[str], Verdict] | None = None
+
+
+# ─── Main dispatch ─────────────────────────────────────────────────────────
+
+
+def handle_server_control_request(
+    request: dict[str, Any],
+    handlers: ServerControlRequestHandlers,
+) -> None:
+    """Dispatch a server-initiated ``control_request`` message.
+
+    Mirrors ``bridgeMessaging.ts:243-391``. Sends exactly one
+    ``control_response`` via ``handlers.transport.write`` per call. Never
+    silent — unknown subtypes get an error response so the server doesn't
+    hang waiting (~10-14 s timeout before WS kill).
+    """
+    inner = request.get('request') or {}
+    if not isinstance(inner, dict):
+        logger.debug('[bridge:messaging] control_request.request is not a dict; ignoring')
+        return
+    request_id = request.get('request_id', '')
+    subtype = inner.get('subtype')
+
+    response_inner: dict[str, Any]
+
+    # Outbound-only: reply error for mutable requests so claude.ai doesn't
+    # show false success. ``initialize`` must still succeed (server kills
+    # the connection if it doesn't).
+    if handlers.outbound_only and subtype != 'initialize':
+        response_inner = {
+            'subtype': 'error',
+            'request_id': request_id,
+            'error': OUTBOUND_ONLY_ERROR,
+        }
+        _send(handlers, response_inner, subtype, kind='outbound-only')
+        return
+
+    if subtype == 'initialize':
+        # Minimal capabilities — the REPL handles commands/models/account
+        # info itself.
+        response_inner = {
+            'subtype': 'success',
+            'request_id': request_id,
+            'response': {
+                'commands': [],
+                'output_style': 'normal',
+                'available_output_styles': ['normal'],
+                'models': [],
+                'account': {},
+                'pid': os.getpid(),
+            },
+        }
+    elif subtype == 'set_model':
+        if handlers.on_set_model is not None:
+            handlers.on_set_model(inner.get('model'))
+        response_inner = {'subtype': 'success', 'request_id': request_id}
+    elif subtype == 'set_max_thinking_tokens':
+        if handlers.on_set_max_thinking_tokens is not None:
+            handlers.on_set_max_thinking_tokens(inner.get('max_thinking_tokens'))
+        response_inner = {'subtype': 'success', 'request_id': request_id}
+    elif subtype == 'set_permission_mode':
+        # The callback returns a Verdict so we can send an error
+        # control_response without importing policy gates here.
+        # If no callback is registered (daemon context, which doesn't
+        # wire this), return an error verdict rather than silent
+        # false-success — the chapter-prescribed pattern at
+        # bridgeMessaging.ts:336-340 (WI-3.7b).
+        mode = inner.get('mode', '')
+        if handlers.on_set_permission_mode is None:
+            verdict: Verdict = Err(
+                error=(
+                    'set_permission_mode is not supported in this context '
+                    '(on_set_permission_mode callback not registered)'
+                )
+            )
+        else:
+            verdict = handlers.on_set_permission_mode(mode)
+        if isinstance(verdict, Ok):
+            response_inner = {'subtype': 'success', 'request_id': request_id}
+        else:
+            response_inner = {
+                'subtype': 'error',
+                'request_id': request_id,
+                'error': verdict.error,
+            }
+    elif subtype == 'interrupt':
+        if handlers.on_interrupt is not None:
+            handlers.on_interrupt()
+        response_inner = {'subtype': 'success', 'request_id': request_id}
+    else:
+        # Unknown subtype — respond with error so the server doesn't
+        # hang waiting for a reply that never comes. Chapter explicit
+        # pattern at bridgeMessaging.ts:373-384.
+        response_inner = {
+            'subtype': 'error',
+            'request_id': request_id,
+            'error': f'REPL bridge does not handle control_request subtype: {subtype}',
+        }
+
+    _send(handlers, response_inner, subtype, kind='dispatch')
+
+
+def _send(
+    handlers: ServerControlRequestHandlers,
+    response_inner: dict[str, Any],
+    subtype: object,
+    *,
+    kind: str,
+) -> None:
+    """Build the ``control_response`` envelope and write it.
+
+    Supports both sync and async ``transport.write``. If ``write``
+    returns an awaitable (the TS-equivalent path), schedule it on the
+    running loop via ``create_task`` — matches TS's
+    ``void transport.write(event)`` fire-and-forget at
+    ``bridgeMessaging.ts:278, 387``.
+    """
+    envelope: dict[str, Any] = {
+        'type': 'control_response',
+        'response': response_inner,
+        'session_id': handlers.session_id,
+    }
+    result = handlers.transport.write(envelope)
+    if inspect.isawaitable(result):
+        asyncio.get_running_loop().create_task(result)
+    logger.debug(
+        '[bridge:messaging] Sent control_response (%s) for %s request_id=%s result=%s',
+        kind,
+        subtype,
+        response_inner.get('request_id'),
+        response_inner.get('subtype'),
+    )
+
+
+__all__ = [
+    'Err',
+    'OUTBOUND_ONLY_ERROR',
+    'Ok',
+    'ServerControlRequestHandlers',
+    'Verdict',
+    'handle_server_control_request',
+]

--- a/src/bridge/no_proxy.py
+++ b/src/bridge/no_proxy.py
@@ -1,0 +1,50 @@
+"""NO_PROXY allowlist for the CCR upstream proxy (Phase 5).
+
+Mirrors ``typescript/src/upstreamproxy/upstreamproxy.ts:37-63`` — the
+exact ordering of the three Anthropic forms matters:
+``'anthropic.com'`` (apex/Python urllib suffix), then
+``'.anthropic.com'`` (Python urllib also strips leading dot), then
+``'*.anthropic.com'`` (Bun, curl, Go glob match).
+
+If any of the three forms is missing, runtimes that parse NO_PROXY
+strictly will MITM the model API itself, breaking inference. Hence
+the explicit triple form rather than relying on glob matching.
+"""
+
+from __future__ import annotations
+
+# Order matters — see module docstring for the rationale on the three
+# Anthropic forms specifically.
+NO_PROXY_LIST: tuple[str, ...] = (
+    'localhost',
+    '127.0.0.1',
+    '::1',
+    '169.254.0.0/16',  # IMDS
+    '10.0.0.0/8',
+    '172.16.0.0/12',
+    '192.168.0.0/16',
+    # Anthropic API: no upstream route will ever match, and the MITM
+    # breaks non-Bun runtimes (Python httpx/certifi doesn't trust the
+    # forged CA). Three forms because NO_PROXY parsing differs across
+    # runtimes — see module docstring.
+    'anthropic.com',
+    '.anthropic.com',
+    '*.anthropic.com',
+    'github.com',
+    'api.github.com',
+    '*.github.com',
+    '*.githubusercontent.com',
+    'registry.npmjs.org',
+    'pypi.org',
+    'files.pythonhosted.org',
+    'index.crates.io',
+    'proxy.golang.org',
+)
+
+
+def default_no_proxy() -> str:
+    """Comma-joined ``NO_PROXY`` string for the upstream proxy env."""
+    return ','.join(NO_PROXY_LIST)
+
+
+__all__ = ['NO_PROXY_LIST', 'default_no_proxy']

--- a/src/bridge/protojson.py
+++ b/src/bridge/protojson.py
@@ -1,0 +1,63 @@
+"""Protojson-encoding helpers for CCR v2 wire-format quirks.
+
+Per gap analysis §1 #21 universal rule: every CCR v2 endpoint that
+returns an int64 may arrive as **string** OR **number** depending on the
+encoder settings. ``protojson`` (Go) serializes int64 as string by
+default to avoid JS precision loss; some endpoints serialize as number.
+
+This helper normalizes both shapes into Python ``int``. Used by
+``register_worker`` (WI-3.4) and ``fetch_remote_credentials`` (WI-3.3).
+
+**Bounds:** matches TS ``Number.isSafeInteger`` (``±(2^53 - 1)``), NOT
+the int64 range Python could otherwise represent. Wire-format symmetry
+with the JS encoder is more important than Python's larger-int capacity:
+the field is constrained at the JS-side encoder anyway, so accepting
+larger values in Python would create a Python↔TS interop divergence the
+server-side schema does not guarantee.
+"""
+
+from __future__ import annotations
+
+# Per JS Number.isSafeInteger:
+#   Number.MAX_SAFE_INTEGER = 2^53 - 1
+#   Number.MIN_SAFE_INTEGER = -(2^53 - 1)
+SAFE_INTEGER_MIN = -((2**53) - 1)
+SAFE_INTEGER_MAX = (2**53) - 1
+
+# Aliases kept for callers that prefer the int64 naming. Same values as
+# the safe-integer pair so the wire-format symmetry holds. If a future
+# server endpoint truly needs the full int64 range, add a separate
+# ``coerce_full_int64`` helper rather than widening these.
+INT64_MIN = SAFE_INTEGER_MIN
+INT64_MAX = SAFE_INTEGER_MAX
+
+
+def coerce_int64(value: object) -> int:
+    """Return ``value`` as a Python ``int``, accepting string or int input.
+
+    Raises ``ValueError`` if the value is neither, or if the parsed result
+    overflows ``Number.isSafeInteger`` bounds (``±(2^53 - 1)``). Matches
+    TS ``Number.isSafeInteger`` semantics for wire-format symmetry; see
+    module docstring for the rationale.
+    """
+    if isinstance(value, bool):
+        # bool is a subclass of int in Python; reject explicitly to avoid
+        # accepting True/False as 1/0 from a wire payload.
+        raise ValueError(f'coerce_int64: refusing bool: {value!r}')
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = int(value, 10)
+        except ValueError as exc:
+            raise ValueError(f'coerce_int64: not a base-10 integer string: {value!r}') from exc
+    else:
+        raise ValueError(f'coerce_int64: unsupported type {type(value).__name__}: {value!r}')
+    if not (SAFE_INTEGER_MIN <= parsed <= SAFE_INTEGER_MAX):
+        raise ValueError(
+            f'coerce_int64: out of safe-integer range (TS Number.isSafeInteger): {parsed}'
+        )
+    return parsed
+
+
+__all__ = ['INT64_MAX', 'INT64_MIN', 'SAFE_INTEGER_MAX', 'SAFE_INTEGER_MIN', 'coerce_int64']

--- a/src/bridge/repl_bridge_transport.py
+++ b/src/bridge/repl_bridge_transport.py
@@ -1,0 +1,329 @@
+"""``ReplBridgeTransport`` — unified v1/v2 transport interface.
+
+Ports the consumer-facing surface of
+``typescript/src/bridge/replBridgeTransport.ts:23-369``.
+
+Two halves:
+
+  * ``ReplBridgeTransport`` Protocol — the 14-method contract that
+    ``replBridge`` writes against. v1 and v2 implementations conform.
+  * ``create_v2_repl_transport`` — the v2 factory: SSE reads +
+    ``CCRClient`` writes, with the epoch-mismatch handler that closes
+    both transports + raises ``EpochSupersededError`` to unwind callers.
+
+The v1 factory is **not yet implemented** (out of Phase 6 scope).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from src.bridge.close_codes import (
+    WS_CLOSE_EPOCH_MISMATCH,
+    WS_CLOSE_INIT_FAILURE,
+)
+from src.bridge.exceptions import EpochSupersededError
+from src.transports.ccr_client import CCRClient, CCRClientOptions
+from src.transports.sse_transport import SSEEvent, SSETransport
+
+logger = logging.getLogger(__name__)
+
+
+# ─── Protocol ──────────────────────────────────────────────────────────────
+
+
+class ReplBridgeTransport(Protocol):
+    """The 14-method contract ``replBridge`` writes against.
+
+    Mirrors TS ``replBridgeTransport.ts:23-70``. ``write`` and
+    ``write_batch`` return awaitables (``async def`` in
+    implementations); the rest are sync — flag-checks, callback
+    registrations, etc.
+    """
+
+    async def write(self, message: dict[str, Any]) -> None: ...
+    async def write_batch(self, messages: list[dict[str, Any]]) -> None: ...
+    def close(self) -> None: ...
+    def is_connected_status(self) -> bool: ...
+    def get_state_label(self) -> str: ...
+    def set_on_data(self, cb: Callable[[str], None]) -> None: ...
+    def set_on_close(self, cb: Callable[[int | None], None]) -> None: ...
+    def set_on_connect(self, cb: Callable[[], None]) -> None: ...
+    def connect(self) -> None: ...
+    def get_last_sequence_num(self) -> int: ...
+
+    @property
+    def dropped_batch_count(self) -> int: ...
+
+    def report_state(self, state: dict[str, Any]) -> None: ...
+    def report_metadata(self, metadata: dict[str, Any]) -> None: ...
+    def report_delivery(self, event_id: str, status: str) -> None: ...
+    async def flush(self) -> None: ...
+
+
+# ─── v2 implementation ────────────────────────────────────────────────────
+
+
+@dataclass
+class V2TransportOptions:
+    """Construction-time knobs for ``create_v2_repl_transport``."""
+
+    session_url: str
+    ingress_token: str
+    session_id: str
+    epoch: int
+    initial_sequence_num: int = 0
+    heartbeat_interval_seconds: float | None = None
+    heartbeat_jitter_fraction: float | None = None
+    outbound_only: bool = False
+    get_auth_token: Callable[[], str | None] | None = None
+
+
+class _V2ReplTransport:
+    """Concrete v2 transport (SSE reads + CCRClient writes).
+
+    Mirrors ``replBridgeTransport.ts:119-369``. Constructed via
+    ``create_v2_repl_transport``; satisfies the ``ReplBridgeTransport``
+    Protocol structurally.
+    """
+
+    def __init__(
+        self,
+        sse: SSETransport,
+        ccr: CCRClient,
+        *,
+        epoch: int,
+        outbound_only: bool,
+    ) -> None:
+        self._sse = sse
+        self._ccr = ccr
+        self._epoch = epoch
+        self._outbound_only = outbound_only
+        self._closed = False
+
+        self._on_connect_cb: Callable[[], None] | None = None
+        self._on_close_cb: Callable[[int | None], None] | None = None
+        self._ccr_initialized = False
+
+    # ─── State ──────────────────────────────────────────────────────────
+
+    def is_connected_status(self) -> bool:
+        """Write-readiness, not read-readiness — replBridge checks this
+        before calling ``write_batch``. SSE open state is orthogonal."""
+        return self._ccr_initialized and not self._closed
+
+    def get_state_label(self) -> str:
+        if self._sse.is_closed_status():
+            return 'closed'
+        if self._sse.is_connected_status():
+            return 'connected' if self._ccr_initialized else 'init'
+        return 'connecting'
+
+    def get_last_sequence_num(self) -> int:
+        if self._outbound_only:
+            return 0  # no SSE read stream → no cursor to report
+        return self._sse.get_last_sequence_num()
+
+    @property
+    def dropped_batch_count(self) -> int:
+        return self._ccr.dropped_batch_count
+
+    # ─── Callback wiring ───────────────────────────────────────────────
+
+    def set_on_data(self, cb: Callable[[str], None]) -> None:
+        if self._outbound_only:
+            return  # no inbound stream — set_on_data is a no-op
+        self._sse.set_on_data(cb)
+
+    def set_on_close(self, cb: Callable[[int | None], None]) -> None:
+        self._on_close_cb = cb
+        # When the SSE reconnect-budget is exhausted, fire onClose so
+        # replBridge can reconnect via the poll loop.
+        self._sse.set_on_close(lambda code: cb(code))
+
+    def set_on_connect(self, cb: Callable[[], None]) -> None:
+        self._on_connect_cb = cb
+
+    # ─── Lifecycle ─────────────────────────────────────────────────────
+
+    def connect(self) -> None:
+        """Open SSE + initialize CCRClient. Returns immediately."""
+        loop = asyncio.get_running_loop()
+        loop.create_task(self._do_connect(), name='v2-transport-connect')
+
+    async def _do_connect(self) -> None:
+        if not self._outbound_only:
+            await self._sse.connect()
+        try:
+            await self._ccr.initialize(self._epoch)
+        except EpochSupersededError:
+            self._fire_close(WS_CLOSE_EPOCH_MISMATCH)
+            return
+        except Exception as exc:  # noqa: BLE001
+            logger.warning('[v2-transport] CCR init failed: %s', exc)
+            self._fire_close(WS_CLOSE_INIT_FAILURE)
+            return
+        self._ccr_initialized = True
+        if self._on_connect_cb is not None:
+            try:
+                self._on_connect_cb()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning('[v2-transport] on_connect_cb raised: %s', exc)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._sse.close()
+        self._ccr.close()
+
+    async def aclose(self) -> None:
+        self.close()
+        await asyncio.gather(
+            self._sse.aclose(),
+            self._ccr.aclose(),
+            return_exceptions=True,
+        )
+
+    # ─── Write API ─────────────────────────────────────────────────────
+
+    async def write(self, message: dict[str, Any]) -> None:
+        await self._ccr.write_event(message)
+
+    async def write_batch(self, messages: list[dict[str, Any]]) -> None:
+        for m in messages:
+            if self._closed:
+                return
+            await self._ccr.write_event(m)
+
+    async def flush(self) -> None:
+        await self._ccr.flush()
+
+    # ─── State / metadata / delivery passthrough ──────────────────────
+
+    def report_state(self, state: dict[str, Any]) -> None:
+        self._ccr.report_state(state)
+
+    def report_metadata(self, metadata: dict[str, Any]) -> None:
+        self._ccr.report_metadata(metadata)
+
+    def report_delivery(self, event_id: str, status: str) -> None:
+        self._ccr.report_delivery(event_id, status)
+
+    # ─── Internal helpers ─────────────────────────────────────────────
+
+    def _fire_close(self, code: int) -> None:
+        cb = self._on_close_cb
+        if cb is None:
+            return
+        try:
+            cb(code)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning('[v2-transport] on_close_cb raised: %s', exc)
+
+
+# ─── Public factory ───────────────────────────────────────────────────────
+
+
+async def create_v2_repl_transport(opts: V2TransportOptions) -> _V2ReplTransport:
+    """Build a v2 transport (SSE reads + CCRClient writes).
+
+    Mirrors ``replBridgeTransport.ts:119-369``. The
+    ``on_epoch_mismatch`` handler closes both transports, fires
+    ``on_close_cb(4090)``, and raises ``EpochSupersededError`` to
+    unwind callers (matches TS ``throw 'epoch superseded'``).
+
+    The auth-header closure is per-instance so multiple concurrent
+    sessions don't clobber each other (mirrors the TS multi-session
+    safety fix).
+    """
+    # Per-instance auth header closure (multi-session safety).
+    def _auth_headers() -> dict[str, str]:
+        token: str | None
+        if opts.get_auth_token is not None:
+            token = opts.get_auth_token()
+        else:
+            token = opts.ingress_token
+        if not token:
+            return {}
+        return {'Authorization': f'Bearer {token}'}
+
+    # Derive SSE stream URL: append /worker/events/stream to the session URL.
+    sse_url = opts.session_url.rstrip('/') + '/worker/events/stream'
+    sse = SSETransport(
+        url=sse_url,
+        headers={},
+        session_id=opts.session_id,
+        get_auth_headers=_auth_headers,
+        initial_sequence_num=opts.initial_sequence_num,
+    )
+
+    transport_ref: dict[str, _V2ReplTransport | None] = {'t': None}
+
+    def _on_epoch_mismatch() -> None:
+        """Called by CCRClient on 409. Closes both, fires onClose(4090),
+        raises EpochSupersededError to unwind the caller."""
+        t = transport_ref['t']
+        if t is not None:
+            try:
+                t._sse.close()
+                t._ccr.close()
+                t._fire_close(WS_CLOSE_EPOCH_MISMATCH)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning('[v2-transport] epoch-mismatch cleanup: %s', exc)
+
+    # Heartbeat options: pass through if explicitly set.
+    ccr_opts_kwargs: dict[str, Any] = {
+        'get_auth_headers': _auth_headers,
+        'on_epoch_mismatch': _on_epoch_mismatch,
+    }
+    if opts.heartbeat_interval_seconds is not None:
+        ccr_opts_kwargs['heartbeat_interval_seconds'] = opts.heartbeat_interval_seconds
+    if opts.heartbeat_jitter_fraction is not None:
+        ccr_opts_kwargs['heartbeat_jitter_fraction'] = opts.heartbeat_jitter_fraction
+    ccr = CCRClient(
+        base_url=opts.session_url,
+        options=CCRClientOptions(**ccr_opts_kwargs),
+    )
+
+    # Wire SSE → CCRClient delivery ACKs (TS replBridgeTransport.ts:249-252).
+    # ACK both 'received' AND 'processed' immediately so daemon-path
+    # reconnects don't re-queue events forever.
+    def _ack(event: SSEEvent) -> None:
+        if not event.event_id:
+            return
+        try:
+            ccr.report_delivery(event.event_id, 'received')
+            ccr.report_delivery(event.event_id, 'processed')
+        except Exception as exc:  # noqa: BLE001
+            logger.debug('[v2-transport] delivery ACK failed: %s', exc)
+
+    sse.set_on_event(_ack)
+
+    transport = _V2ReplTransport(
+        sse=sse,
+        ccr=ccr,
+        epoch=opts.epoch,
+        outbound_only=opts.outbound_only,
+    )
+    transport_ref['t'] = transport
+    return transport
+
+
+def create_v1_repl_transport(*args: Any, **kwargs: Any) -> ReplBridgeTransport:
+    """Stub. v1 is deferred to Phase 6 per the refactoring plan."""
+    raise NotImplementedError(
+        'v1 ReplBridgeTransport is deferred to Phase 6 — see ch16 refactoring plan'
+    )
+
+
+__all__ = [
+    'ReplBridgeTransport',
+    'V2TransportOptions',
+    'create_v1_repl_transport',
+    'create_v2_repl_transport',
+]

--- a/src/bridge/sdk_types.py
+++ b/src/bridge/sdk_types.py
@@ -1,0 +1,275 @@
+"""CCR wire-format types — discriminated unions used by the bridge layer.
+
+Ports a curated subset of the TS SDK schemas at
+``typescript/src/entrypoints/sdk/{coreTypes.generated.ts, shared.ts,
+controlSchemas.ts}`` (~3,393 lines combined). Only the variants this
+plan's WIs touch are defined here (~250-300 LOC). For full schema, see
+the TS sources.
+
+We use ``TypedDict(total=False)`` per variant + a top-level ``Union``
+alias so the discriminating field (``type`` / ``subtype``) tells callers
+which variant they are looking at. This matches Python's `pyright` /
+`mypy` discriminated-union pattern; consumers narrow via ``isinstance``
+or ``match`` on the discriminator field.
+
+NOTE on field naming: every wire-level field uses **snake_case** because
+that is what the CCR servers send. ``src/types/messages.py`` has a
+parallel ``Message`` hierarchy with ``camelCase`` fields for the local
+REPL; the two never alias and live in separate files.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict, Union
+
+# ─── Core SDK message variants (the `type` discriminator) ──────────────────
+
+# Each variant is a TypedDict with ``total=False`` so optional fields can
+# be omitted. The discriminating ``type`` field is required by the
+# discriminated-union convention.
+
+
+class UserMessage(TypedDict, total=False):
+    """User turn from the model API.
+
+    Source: ``coreTypes.generated.ts`` UserMessage variant.
+    """
+
+    type: Literal['user']
+    uuid: str
+    session_id: str
+    parent_tool_use_id: str | None
+    message: dict[str, Any]
+
+
+class AssistantMessage(TypedDict, total=False):
+    """Assistant turn (text + tool calls) from the model API."""
+
+    type: Literal['assistant']
+    uuid: str
+    session_id: str
+    parent_tool_use_id: str | None
+    message: dict[str, Any]
+
+
+class SystemMessage(TypedDict, total=False):
+    """System message: init, post_turn_summary, local_command, etc."""
+
+    type: Literal['system']
+    subtype: str
+    uuid: str
+    session_id: str
+    data: dict[str, Any]
+
+
+class SDKResultSuccess(TypedDict, total=False):
+    """Result message — emitted on session teardown for archival.
+
+    Used by ``make_result_message`` (WI-2.6c) to tell the server the
+    session ended cleanly. See ``bridgeMessaging.ts:399-416``.
+    """
+
+    type: Literal['result']
+    subtype: Literal['success']
+    duration_ms: int
+    duration_api_ms: int
+    is_error: bool
+    num_turns: int
+    result: str
+    stop_reason: str | None
+    total_cost_usd: float
+    usage: dict[str, Any]
+    modelUsage: dict[str, Any]
+    permission_denials: list[dict[str, Any]]
+    session_id: str
+    uuid: str
+
+
+class ToolResultMessage(TypedDict, total=False):
+    """Tool execution result, emitted by the local REPL after a tool call."""
+
+    type: Literal['tool_result']
+    uuid: str
+    session_id: str
+    tool_use_id: str
+    content: Any
+    is_error: bool
+
+
+class KeepAliveMessage(TypedDict, total=False):
+    """Empty heartbeat from the server. Filtered by the ingress router."""
+
+    type: Literal['keep_alive']
+
+
+class StreamlinedTextMessage(TypedDict, total=False):
+    """Streamlined text payload (compact wire form). Filtered by Direct Connect."""
+
+    type: Literal['streamlined_text']
+    text: str
+
+
+class StreamlinedToolUseSummaryMessage(TypedDict, total=False):
+    """Streamlined tool-use summary. Filtered by Direct Connect."""
+
+    type: Literal['streamlined_tool_use_summary']
+    tool_name: str
+    summary: str
+
+
+# ─── control_request inner subtypes (the `subtype` discriminator) ──────────
+
+# control_request.request is itself a discriminated union on ``subtype``.
+# We declare each subtype as a TypedDict and union them.
+
+
+class InitializeRequest(TypedDict, total=False):
+    subtype: Literal['initialize']
+
+
+class SetModelRequest(TypedDict, total=False):
+    subtype: Literal['set_model']
+    model: str | None
+
+
+class SetMaxThinkingTokensRequest(TypedDict, total=False):
+    subtype: Literal['set_max_thinking_tokens']
+    max_thinking_tokens: int | None
+
+
+class SetPermissionModeRequest(TypedDict, total=False):
+    subtype: Literal['set_permission_mode']
+    mode: str  # PermissionMode in src/permissions/types.py — kept str on the wire.
+
+
+class InterruptRequest(TypedDict, total=False):
+    subtype: Literal['interrupt']
+
+
+class SDKControlPermissionRequest(TypedDict, total=False):
+    """``can_use_tool`` payload — the only request the server sends to ask
+    a permission decision from the client.
+    """
+
+    subtype: Literal['can_use_tool']
+    tool_name: str
+    input: dict[str, Any]
+    tool_use_id: str | None
+
+
+SDKControlRequestInner = Union[
+    InitializeRequest,
+    SetModelRequest,
+    SetMaxThinkingTokensRequest,
+    SetPermissionModeRequest,
+    InterruptRequest,
+    SDKControlPermissionRequest,
+]
+
+
+class SDKControlRequest(TypedDict, total=False):
+    """``{type:'control_request', request_id, request}`` envelope."""
+
+    type: Literal['control_request']
+    request_id: str
+    request: SDKControlRequestInner
+
+
+# ─── control_response variants ─────────────────────────────────────────────
+
+
+class ControlResponseSuccess(TypedDict, total=False):
+    subtype: Literal['success']
+    request_id: str
+    response: dict[str, Any] | None
+
+
+class ControlResponseError(TypedDict, total=False):
+    subtype: Literal['error']
+    request_id: str
+    error: str
+
+
+ControlResponseInner = Union[ControlResponseSuccess, ControlResponseError]
+
+
+class SDKControlResponse(TypedDict, total=False):
+    """``{type:'control_response', response}`` envelope."""
+
+    type: Literal['control_response']
+    response: ControlResponseInner
+
+
+# ─── Cancellation envelope ─────────────────────────────────────────────────
+
+
+class SDKControlCancelRequest(TypedDict, total=False):
+    """Server → client: cancel a pending permission prompt by ``request_id``."""
+
+    type: Literal['control_cancel_request']
+    request_id: str
+    tool_use_id: str | None
+
+
+# ─── Top-level union and aliases ───────────────────────────────────────────
+
+# The full SDKMessage union — anything the read-side router can encounter
+# on the bridge stream. Note this includes both data messages (user,
+# assistant, etc.) and control messages (control_request, control_response,
+# control_cancel_request); the router branches on ``type`` first.
+
+SDKMessage = Union[
+    UserMessage,
+    AssistantMessage,
+    SystemMessage,
+    SDKResultSuccess,
+    ToolResultMessage,
+    KeepAliveMessage,
+    StreamlinedTextMessage,
+    StreamlinedToolUseSummaryMessage,
+    SDKControlRequest,
+    SDKControlResponse,
+    SDKControlCancelRequest,
+]
+
+# Write-side alias — what the client sends to the server. control_request
+# is excluded because the local CLI never originates a control_request
+# (the server initiates those); control_response is what the client uses
+# to reply. Matches ``StdoutMessage`` in TS.
+
+StdoutMessage = Union[
+    UserMessage,
+    AssistantMessage,
+    SystemMessage,
+    SDKResultSuccess,
+    ToolResultMessage,
+    SDKControlResponse,
+    SDKControlRequest,  # for client-originated interrupt
+]
+
+
+__all__ = [
+    'AssistantMessage',
+    'ControlResponseError',
+    'ControlResponseInner',
+    'ControlResponseSuccess',
+    'InitializeRequest',
+    'InterruptRequest',
+    'KeepAliveMessage',
+    'SDKControlCancelRequest',
+    'SDKControlPermissionRequest',
+    'SDKControlRequest',
+    'SDKControlRequestInner',
+    'SDKControlResponse',
+    'SDKMessage',
+    'SDKResultSuccess',
+    'SetMaxThinkingTokensRequest',
+    'SetModelRequest',
+    'SetPermissionModeRequest',
+    'StdoutMessage',
+    'StreamlinedTextMessage',
+    'StreamlinedToolUseSummaryMessage',
+    'SystemMessage',
+    'ToolResultMessage',
+    'UserMessage',
+]

--- a/src/bridge/work_secret.py
+++ b/src/bridge/work_secret.py
@@ -1,0 +1,156 @@
+"""WorkSecret decoder + URL builders + tagged-session-ID compat helpers.
+
+Ports ``typescript/src/bridge/workSecret.ts`` (the wire-format primitive
+half — ``decode_work_secret``, ``build_sdk_url``, ``same_session_id``,
+``build_ccr_v2_sdk_url``). The ``register_worker`` HTTP call lives in
+``src/bridge/code_session_api.py`` (Phase 3 WI-3.4) — different concern
+(HTTP), grouped with other CCR v2 API calls.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlparse
+
+
+@dataclass(frozen=True)
+class WorkSecret:
+    """Parsed work-secret payload (Bridge v1).
+
+    Schema mirrors ``typescript/src/bridge/types.ts:33-51``. The ``version``
+    field MUST be 1; ``decode_work_secret`` raises if not.
+    """
+
+    version: int
+    session_ingress_token: str
+    api_base_url: str
+    sources: tuple[dict[str, Any], ...] = ()
+    auth: tuple[dict[str, Any], ...] = ()
+    claude_code_args: dict[str, str] | None = None
+    mcp_config: object | None = None
+    environment_variables: dict[str, str] | None = None
+    use_code_sessions: bool | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+def decode_work_secret(secret: str) -> WorkSecret:
+    """Decode a base64url-encoded work secret JSON.
+
+    Raises ``ValueError`` on:
+      - Non-base64url payload.
+      - Non-object JSON.
+      - Missing or non-1 ``version`` field.
+      - Missing/empty ``session_ingress_token``.
+      - Missing/non-string ``api_base_url``.
+
+    Mirrors ``typescript/src/bridge/workSecret.ts:6-32``.
+    """
+    try:
+        # Pad to a multiple of 4 — base64url omits padding by convention.
+        padding_needed = (-len(secret)) % 4
+        decoded_bytes = base64.urlsafe_b64decode(secret + '=' * padding_needed)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f'work secret is not valid base64url: {exc}') from exc
+
+    try:
+        parsed: Any = json.loads(decoded_bytes.decode('utf-8'))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f'work secret payload is not valid JSON: {exc}') from exc
+
+    if not isinstance(parsed, dict):
+        raise ValueError(f'work secret must be a JSON object, got {type(parsed).__name__}')
+
+    version = parsed.get('version')
+    if version != 1:
+        raise ValueError(f'Unsupported work secret version: {version!r}')
+
+    token = parsed.get('session_ingress_token')
+    if not isinstance(token, str) or not token:
+        raise ValueError('Invalid work secret: missing or empty session_ingress_token')
+
+    base_url = parsed.get('api_base_url')
+    if not isinstance(base_url, str):
+        raise ValueError('Invalid work secret: missing api_base_url')
+
+    sources_raw = parsed.get('sources', [])
+    auth_raw = parsed.get('auth', [])
+
+    return WorkSecret(
+        version=version,
+        session_ingress_token=token,
+        api_base_url=base_url,
+        sources=tuple(sources_raw) if isinstance(sources_raw, list) else (),
+        auth=tuple(auth_raw) if isinstance(auth_raw, list) else (),
+        claude_code_args=parsed.get('claude_code_args'),
+        mcp_config=parsed.get('mcp_config'),
+        environment_variables=parsed.get('environment_variables'),
+        use_code_sessions=parsed.get('use_code_sessions'),
+        raw=parsed,
+    )
+
+
+def build_sdk_url(api_base_url: str, session_id: str) -> str:
+    """Build a session-ingress WS URL from an HTTP base + session ID.
+
+    Mirrors ``workSecret.ts:41-48``: localhost gets ``ws://`` + ``/v2/``
+    (direct to session-ingress, no Envoy rewrite); production gets
+    ``wss://`` + ``/v1/`` (Envoy rewrites ``/v1/`` → ``/v2/``).
+    """
+    parsed = urlparse(api_base_url)
+    hostname = parsed.hostname or ''
+    is_localhost = hostname in ('localhost', '127.0.0.1')
+    protocol = 'ws' if is_localhost else 'wss'
+    version = 'v2' if is_localhost else 'v1'
+    # Strip protocol + trailing slashes from the original host part.
+    host = api_base_url
+    for prefix in ('https://', 'http://'):
+        if host.startswith(prefix):
+            host = host[len(prefix):]
+            break
+    host = host.rstrip('/')
+    return f'{protocol}://{host}/{version}/session_ingress/ws/{session_id}'
+
+
+def build_ccr_v2_sdk_url(api_base_url: str, session_id: str) -> str:
+    """Build a CCR v2 session URL (HTTP base for /v1/code/sessions/{id}).
+
+    Mirrors ``workSecret.ts:81-87``. The child CC derives the SSE stream
+    path and worker endpoints from this URL.
+    """
+    base = api_base_url.rstrip('/')
+    return f'{base}/v1/code/sessions/{session_id}'
+
+
+def same_session_id(a: str, b: str) -> bool:
+    """Compare two session IDs regardless of the tagged-ID prefix family.
+
+    Tagged IDs have the shape ``{tag}_{body}`` or ``{tag}_staging_{body}``,
+    where the body encodes a UUID. CCR v2's compat layer returns
+    ``session_*`` to v1 API clients but the infra layer uses ``cse_*``;
+    both have the same underlying UUID. Without this, ``replBridge``
+    rejects its own session as "foreign" at the work-received check when
+    the ``ccr_v2_compat_enabled`` gate is on.
+
+    Mirrors ``workSecret.ts:62-73``.
+    """
+    if a == b:
+        return True
+    a_body = a[a.rfind('_') + 1:]
+    b_body = b[b.rfind('_') + 1:]
+    # Guard against IDs with no underscore (bare UUIDs): rfind returns -1,
+    # slice starts at 0, returns the whole string. We already handled
+    # ``a == b`` above; require min length 4 to avoid false matches on
+    # short suffixes (e.g., single-char tag remnants).
+    return len(a_body) >= 4 and a_body == b_body
+
+
+__all__ = [
+    'WorkSecret',
+    'build_ccr_v2_sdk_url',
+    'build_sdk_url',
+    'decode_work_secret',
+    'same_session_id',
+]

--- a/src/remote/remote_session_manager.py
+++ b/src/remote/remote_session_manager.py
@@ -1,0 +1,293 @@
+"""High-level CCR session manager (claude.ai → CCR viewer/control).
+
+Ports ``typescript/src/remote/RemoteSessionManager.ts:95-324``.
+
+Wraps ``SessionsWebSocket`` + adds:
+
+  - Per-``request_id`` tracking of pending permission requests
+    (so ``control_cancel_request`` can find the right tool_use_id).
+  - Permission round-trip: ``respond_to_permission_request`` builds
+    the ``control_response`` envelope (allow→updated_input,
+    deny→message).
+  - ``cancel_session`` sends a ``control_request`` with subtype
+    ``interrupt`` (skipped in viewer-only mode).
+  - ``viewer_only`` flag — accepts the flag; ``cancel_session`` is a
+    no-op when set. Other viewer-only behaviors (no 60 s response-stuck
+    timeout, no title updates) live in the front-end consumer per A16.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+from src.bridge.messaging import RemotePermissionResponse
+from src.bridge.sdk_types import SDKControlPermissionRequest
+
+from .sessions_websocket import (
+    SessionsWebSocket,
+    SessionsWebSocketCallbacks,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RemoteSessionConfig:
+    """Construction-time config. Mirrors TS at lines 50-62."""
+
+    session_id: str
+    get_access_token: Callable[[], str]
+    org_uuid: str
+    has_initial_prompt: bool = False
+    #: Viewer-only mode (``claude assistant``): cancel_session is a no-op.
+    viewer_only: bool = False
+
+
+@dataclass
+class RemoteSessionCallbacks:
+    """Public callbacks. Mirrors TS at lines 64-85."""
+
+    on_message: Callable[[dict], None | Awaitable[None]]
+    on_permission_request: Callable[
+        [SDKControlPermissionRequest, str], None | Awaitable[None]
+    ]
+    on_permission_cancelled: (
+        Callable[[str, str | None], None | Awaitable[None]] | None
+    ) = None
+    on_connected: Callable[[], None | Awaitable[None]] | None = None
+    on_disconnected: Callable[[], None | Awaitable[None]] | None = None
+    on_reconnecting: Callable[[], None | Awaitable[None]] | None = None
+    on_error: Callable[[Exception], None | Awaitable[None]] | None = None
+
+
+class RemoteSessionManager:
+    """High-level façade over ``SessionsWebSocket`` for one CCR session."""
+
+    def __init__(
+        self,
+        config: RemoteSessionConfig,
+        callbacks: RemoteSessionCallbacks,
+        *,
+        base_url: str = 'wss://api.anthropic.com',
+    ) -> None:
+        self._config = config
+        self._callbacks = callbacks
+        self._base_url = base_url
+        self._websocket: SessionsWebSocket | None = None
+        self._pending_permission_requests: dict[str, SDKControlPermissionRequest] = {}
+
+    # ─── Public API ────────────────────────────────────────────────────
+
+    def connect(self) -> None:
+        """Open the WS to ``/v1/sessions/ws/{id}/subscribe``.
+
+        Mirrors ``RemoteSessionManager.ts:108-141``. Construction +
+        connect are split so callers can wire callbacks first.
+        """
+        ws_callbacks = SessionsWebSocketCallbacks(
+            on_message=self._handle_message,
+            on_connected=self._callbacks.on_connected,
+            on_close=self._callbacks.on_disconnected,
+            on_reconnecting=self._callbacks.on_reconnecting,
+            on_error=self._callbacks.on_error,
+        )
+        self._websocket = SessionsWebSocket(
+            self._config.session_id,
+            self._config.org_uuid,
+            self._config.get_access_token,
+            ws_callbacks,
+            base_url=self._base_url,
+        )
+        # Schedule the connect; SessionsWebSocket.connect is async.
+        loop = asyncio.get_running_loop()
+        loop.create_task(self._websocket.connect(), name='remote-session-connect')
+
+    def is_connected(self) -> bool:
+        return self._websocket is not None and self._websocket.is_connected()
+
+    async def send_message(self, content: object, *, uuid: str | None = None) -> bool:
+        """Send a user prompt to the remote session.
+
+        TS (``RemoteSessionManager.ts:219-242``) routes via HTTP POST to
+        ``sendEventToRemoteSession`` (a teleport API). For Phase 4 we
+        send via the WS itself for protocol simplicity; the wire shape
+        matches what the agent expects on its stdin (``stream-json``).
+        Returns False if the WS is not connected.
+        """
+        if self._websocket is None or not self._websocket.is_connected():
+            return False
+        envelope = {
+            'type': 'user',
+            'message': {'role': 'user', 'content': content},
+            'parent_tool_use_id': None,
+            'session_id': self._config.session_id,
+        }
+        if uuid is not None:
+            envelope['uuid'] = uuid
+        # Re-use the WS' send-control-response method to push raw JSON;
+        # the WS doesn't distinguish between control envelopes and SDK
+        # messages on send.
+        await self._websocket.send_control_response(envelope)
+        return True
+
+    async def respond_to_permission_request(
+        self,
+        request_id: str,
+        result: RemotePermissionResponse,
+    ) -> None:
+        """Reply to a ``can_use_tool`` request.
+
+        Mirrors ``RemoteSessionManager.ts:247-282``. Builds the
+        ``control_response`` envelope with the allow/deny payload.
+        """
+        if request_id not in self._pending_permission_requests:
+            logger.warning(
+                '[RemoteSessionManager] no pending permission request: %s',
+                request_id,
+            )
+            return
+        del self._pending_permission_requests[request_id]
+
+        if result.behavior == 'allow':
+            response_payload: dict[str, object] = {
+                'behavior': 'allow',
+                'updatedInput': getattr(result, 'updated_input', {}),
+            }
+        else:
+            response_payload = {
+                'behavior': 'deny',
+                'message': getattr(result, 'message', ''),
+            }
+        envelope = {
+            'type': 'control_response',
+            'response': {
+                'subtype': 'success',
+                'request_id': request_id,
+                'response': response_payload,
+            },
+        }
+        if self._websocket is not None:
+            await self._websocket.send_control_response(envelope)
+
+    async def cancel_session(self) -> None:
+        """Send an interrupt to the remote agent. No-op in viewer-only mode.
+
+        Mirrors ``RemoteSessionManager.ts:294-297``. Viewer-only
+        gating per A16: viewer_only callers must NOT send interrupts.
+        """
+        if self._config.viewer_only:
+            logger.debug(
+                '[RemoteSessionManager] viewer_only: cancel_session is a no-op'
+            )
+            return
+        if self._websocket is None:
+            return
+        await self._websocket.send_control_request({'subtype': 'interrupt'})
+
+    async def disconnect(self) -> None:
+        """Close the WS and clear pending permission requests."""
+        if self._websocket is not None:
+            await self._websocket.disconnect()
+            self._websocket = None
+        self._pending_permission_requests.clear()
+
+    async def reconnect(self) -> None:
+        """Force-reconnect the WS (e.g., after stale subscription)."""
+        if self._websocket is not None:
+            await self._websocket.reconnect()
+
+    def get_session_id(self) -> str:
+        return self._config.session_id
+
+    # ─── Internal: WS message routing ────────────────────────────────
+
+    async def _handle_message(self, message: dict) -> None:
+        """Route messages from the WS to the right consumer callback."""
+        msg_type = message.get('type')
+
+        if msg_type == 'control_request':
+            await self._handle_control_request(message)
+            return
+        if msg_type == 'control_cancel_request':
+            await self._handle_control_cancel(message)
+            return
+        if msg_type == 'control_response':
+            logger.debug('[RemoteSessionManager] received control_response')
+            return
+        # All other SDK message types → on_message.
+        await self._invoke(self._callbacks.on_message, message)
+
+    async def _handle_control_request(self, message: dict) -> None:
+        request_id = message.get('request_id')
+        inner = message.get('request')
+        if not isinstance(request_id, str) or not isinstance(inner, dict):
+            return
+        subtype = inner.get('subtype')
+        if subtype == 'can_use_tool':
+            self._pending_permission_requests[request_id] = inner  # type: ignore[assignment]
+            await self._invoke(
+                self._callbacks.on_permission_request,
+                inner,  # type: ignore[arg-type]
+                request_id,
+            )
+            return
+        # Unknown subtype — send error so the server doesn't hang.
+        logger.debug(
+            '[RemoteSessionManager] unsupported control request subtype: %s', subtype
+        )
+        if self._websocket is not None:
+            await self._websocket.send_control_response({
+                'type': 'control_response',
+                'response': {
+                    'subtype': 'error',
+                    'request_id': request_id,
+                    'error': f'Unsupported control request subtype: {subtype}',
+                },
+            })
+
+    async def _handle_control_cancel(self, message: dict) -> None:
+        request_id = message.get('request_id')
+        if not isinstance(request_id, str):
+            return
+        pending = self._pending_permission_requests.pop(request_id, None)
+        tool_use_id = pending.get('tool_use_id') if pending else None
+        await self._invoke(
+            self._callbacks.on_permission_cancelled, request_id, tool_use_id
+        )
+
+    @staticmethod
+    async def _invoke(callback: Callable[..., object] | None, /, *args: object) -> None:
+        if callback is None:
+            return
+        result = callback(*args)
+        if asyncio.iscoroutine(result):
+            await result
+
+
+def create_remote_session_config(
+    session_id: str,
+    get_access_token: Callable[[], str],
+    org_uuid: str,
+    *,
+    has_initial_prompt: bool = False,
+    viewer_only: bool = False,
+) -> RemoteSessionConfig:
+    """Convenience helper mirroring ``createRemoteSessionConfig`` in TS."""
+    return RemoteSessionConfig(
+        session_id=session_id,
+        get_access_token=get_access_token,
+        org_uuid=org_uuid,
+        has_initial_prompt=has_initial_prompt,
+        viewer_only=viewer_only,
+    )
+
+
+__all__ = [
+    'RemoteSessionCallbacks',
+    'RemoteSessionConfig',
+    'RemoteSessionManager',
+    'create_remote_session_config',
+]

--- a/src/remote/sdk_message_adapter.py
+++ b/src/remote/sdk_message_adapter.py
@@ -1,0 +1,112 @@
+"""SDK-message format adapter for the remote-session bridge.
+
+Ports the **functional surface** of
+``typescript/src/remote/sdkMessageAdapter.ts (302 lines)``: translate
+between the SDK message format used in the local REPL and the bridge
+wire format. The TS source is large because it handles many edge cases
+(streamlined messages, partial assistant chunks, tool-result back-refs,
+etc.); we port the **canonical translation paths** the chapter calls
+out, not the long tail of edge cases.
+
+Two directions:
+
+  - **Wire → SDK**: incoming messages from the WS are normalized into
+    the SDK shape (bridge wire format may use camelCase from older
+    server versions; we use ``normalize_control_message_keys`` to fix).
+  - **SDK → Wire**: outgoing user messages are wrapped in the
+    ``stream-json`` envelope shape the agent expects.
+
+Tests pin the canonical shapes; new edge cases land here as they're
+discovered.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from src.bridge.messaging import normalize_control_message_keys
+
+logger = logging.getLogger(__name__)
+
+
+def adapt_wire_to_sdk(wire: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a wire payload to SDK-canonical shape.
+
+    Only known camelCase keys are converted to snake_case; unknown keys
+    pass through (matches ``normalize_control_message_keys``).
+    """
+    result = normalize_control_message_keys(wire)
+    if not isinstance(result, dict):
+        return wire
+    return result
+
+
+def adapt_sdk_to_wire_user_message(
+    content: object,
+    session_id: str,
+    *,
+    parent_tool_use_id: str | None = None,
+    uuid: str | None = None,
+) -> dict[str, Any]:
+    """Build the stream-json envelope for a user prompt.
+
+    Wire shape:
+        {
+          'type': 'user',
+          'message': {'role': 'user', 'content': content},
+          'parent_tool_use_id': parent_tool_use_id,
+          'session_id': session_id,
+          'uuid': uuid,                # optional
+        }
+    """
+    envelope: dict[str, Any] = {
+        'type': 'user',
+        'message': {'role': 'user', 'content': content},
+        'parent_tool_use_id': parent_tool_use_id,
+        'session_id': session_id,
+    }
+    if uuid is not None:
+        envelope['uuid'] = uuid
+    return envelope
+
+
+def adapt_permission_response(
+    request_id: str,
+    behavior: str,
+    *,
+    updated_input: dict | None = None,
+    message: str | None = None,
+) -> dict[str, Any]:
+    """Build the control_response envelope for a permission decision.
+
+    Mirrors ``RemoteSessionManager.respondToPermissionRequest`` payload
+    construction.
+    """
+    if behavior == 'allow':
+        inner_response: dict[str, Any] = {
+            'behavior': 'allow',
+            'updatedInput': updated_input or {},
+        }
+    elif behavior == 'deny':
+        inner_response = {
+            'behavior': 'deny',
+            'message': message or '',
+        }
+    else:
+        raise ValueError(f'unknown permission behavior: {behavior!r}')
+    return {
+        'type': 'control_response',
+        'response': {
+            'subtype': 'success',
+            'request_id': request_id,
+            'response': inner_response,
+        },
+    }
+
+
+__all__ = [
+    'adapt_permission_response',
+    'adapt_sdk_to_wire_user_message',
+    'adapt_wire_to_sdk',
+]

--- a/src/remote/sessions_websocket.py
+++ b/src/remote/sessions_websocket.py
@@ -1,0 +1,345 @@
+"""WebSocket client for ``/v1/sessions/ws/{id}/subscribe`` (claude.ai → CCR).
+
+Ports ``typescript/src/remote/SessionsWebSocket.ts:82-404``.
+
+Reconnection strategy is **discriminated by close code** (per chapter
+§"Remote Session Management"):
+
+  - **4003 (unauthorized)**: stop immediately. Permanent rejection.
+  - **4001 (session not found)**: max 3 retries with linear backoff
+    (transient during compaction).
+  - **other transient**: max 5 attempts with constant-delay retry
+    (``RECONNECT_DELAY_SECONDS = 2.0``). [chapter, unverified: chapter
+    says "exponential backoff", but the actual TS code uses a constant
+    2 s delay; we match the code.]
+
+Per Risk #22 in the refactoring plan: the ``websockets`` library does
+NOT auto-reconnect (unlike JS WebSocket event handlers). We implement
+an explicit reconnect loop with the discriminated retry strategy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid as _uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+import websockets
+from websockets.asyncio.client import connect as ws_connect
+
+from src.bridge.close_codes import (
+    WS_CLOSE_PERMANENT_UNAUTHORIZED,
+    WS_CLOSE_SESSION_NOT_FOUND,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Constant retry delay matching ``SessionsWebSocket.ts:17``.
+RECONNECT_DELAY_SECONDS = 2.0
+
+#: Max retries for the generic-transient path
+#: (``SessionsWebSocket.ts:18`` ``MAX_RECONNECT_ATTEMPTS``).
+MAX_RECONNECT_ATTEMPTS = 5
+
+#: Max retries for the 4001 session-not-found path
+#: (``SessionsWebSocket.ts:26`` ``MAX_SESSION_NOT_FOUND_RETRIES``).
+MAX_SESSION_NOT_FOUND_RETRIES = 3
+
+#: Application-level ping interval (websockets library handles
+#: protocol-level pings; this constant matches TS for parity).
+PING_INTERVAL_SECONDS = 30.0
+
+
+GetAccessToken = Callable[[], str]
+
+
+@dataclass
+class SessionsWebSocketCallbacks:
+    """Per-session event callbacks. Mirrors TS at lines 57-65.
+
+    All callbacks may be sync or async; sync is just called, async is
+    awaited via ``asyncio.iscoroutine`` check.
+    """
+
+    on_message: Callable[[dict], None | Awaitable[None]]
+    on_close: Callable[[], None | Awaitable[None]] | None = None
+    on_error: Callable[[Exception], None | Awaitable[None]] | None = None
+    on_connected: Callable[[], None | Awaitable[None]] | None = None
+    on_reconnecting: Callable[[], None | Awaitable[None]] | None = None
+
+
+def _is_sessions_message(value: object) -> bool:
+    """Permissive type guard: any dict with a string ``type`` field.
+
+    Mirrors ``SessionsWebSocket.ts:46-55``. Deliberately permissive so
+    new server-side message types don't get silently dropped before the
+    Python client is updated.
+    """
+    return isinstance(value, dict) and isinstance(value.get('type'), str)
+
+
+class SessionsWebSocket:
+    """WS client for the claude.ai → CCR session-subscribe stream.
+
+    Lifecycle:
+        ws = SessionsWebSocket(session_id, org_uuid, get_token, callbacks)
+        await ws.connect()           — opens the WS, spawns reader task
+        await ws.send_control_response(resp)
+        await ws.send_control_request(inner)
+        ws.is_connected()
+        await ws.disconnect()        — stop reconnecting, close the WS
+        await ws.reconnect()         — force-close + immediately retry
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        org_uuid: str,
+        get_access_token: GetAccessToken,
+        callbacks: SessionsWebSocketCallbacks,
+        *,
+        base_url: str = 'wss://api.anthropic.com',
+        anthropic_version: str = '2023-06-01',
+    ) -> None:
+        self._session_id = session_id
+        self._org_uuid = org_uuid
+        self._get_access_token = get_access_token
+        self._callbacks = callbacks
+        self._base_url = base_url.rstrip('/')
+        self._anthropic_version = anthropic_version
+
+        self._ws: websockets.asyncio.client.ClientConnection | None = None
+        self._reader_task: asyncio.Task[None] | None = None
+        self._reconnect_task: asyncio.Task[None] | None = None
+        self._closed = False
+        self._reconnect_attempts = 0
+        self._not_found_retries = 0
+
+    # ─── State queries ────────────────────────────────────────────────
+
+    def is_connected(self) -> bool:
+        return self._ws is not None and not self._closed
+
+    # ─── Lifecycle ────────────────────────────────────────────────────
+
+    async def connect(self) -> None:
+        """Open the WS and start the reader. Returns once open OR raises."""
+        if self._closed:
+            return
+        url = (
+            f'{self._base_url}/v1/sessions/ws/{self._session_id}/subscribe'
+            f'?organization_uuid={self._org_uuid}'
+        )
+        headers = {
+            'Authorization': f'Bearer {self._get_access_token()}',
+            'anthropic-version': self._anthropic_version,
+        }
+        try:
+            ws = await ws_connect(
+                url,
+                additional_headers=headers,
+                ping_interval=PING_INTERVAL_SECONDS,
+            )
+        except (websockets.exceptions.WebSocketException, OSError) as exc:
+            await self._invoke(self._callbacks.on_error, exc)
+            self._schedule_reconnect_or_close()
+            return
+
+        self._ws = ws
+        self._reconnect_attempts = 0
+        self._not_found_retries = 0
+        await self._invoke(self._callbacks.on_connected)
+        self._reader_task = asyncio.get_running_loop().create_task(
+            self._read_loop(), name='sessions-ws-reader',
+        )
+
+    async def disconnect(self) -> None:
+        """Permanent close — no reconnects, fire on_close."""
+        self._closed = True
+        if self._reconnect_task is not None and not self._reconnect_task.done():
+            self._reconnect_task.cancel()
+        ws, self._ws = self._ws, None
+        if self._reader_task is not None and not self._reader_task.done():
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except (asyncio.CancelledError, websockets.exceptions.ConnectionClosed):
+                pass
+        if ws is not None:
+            try:
+                await ws.close()
+            except (websockets.exceptions.ConnectionClosed, OSError):
+                pass
+
+    async def reconnect(self) -> None:
+        """Force close + immediate reconnect (resets retry counters).
+
+        Used when the subscription is known stale (e.g., after the
+        worker container shutdown the server detected on its side).
+        """
+        self._reconnect_attempts = 0
+        self._not_found_retries = 0
+        ws, self._ws = self._ws, None
+        if ws is not None:
+            try:
+                await ws.close()
+            except (websockets.exceptions.ConnectionClosed, OSError):
+                pass
+        if self._reader_task is not None and not self._reader_task.done():
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except (asyncio.CancelledError, websockets.exceptions.ConnectionClosed):
+                pass
+        # 500 ms grace before reconnecting (matches TS).
+        await asyncio.sleep(0.5)
+        await self.connect()
+
+    # ─── Send API ─────────────────────────────────────────────────────
+
+    async def send_control_response(self, response: dict) -> None:
+        """Send a ``control_response`` (e.g., permission decision)."""
+        if self._ws is None or self._closed:
+            logger.warning('[SessionsWebSocket] cannot send: not connected')
+            return
+        try:
+            await self._ws.send(json.dumps(response))
+        except (websockets.exceptions.ConnectionClosed, OSError) as exc:
+            logger.warning('[SessionsWebSocket] send failed: %s', exc)
+
+    async def send_control_request(self, inner: dict) -> None:
+        """Wrap ``inner`` in a ``control_request`` envelope and send."""
+        if self._ws is None or self._closed:
+            logger.warning('[SessionsWebSocket] cannot send: not connected')
+            return
+        envelope = {
+            'type': 'control_request',
+            'request_id': str(_uuid.uuid4()),
+            'request': inner,
+        }
+        try:
+            await self._ws.send(json.dumps(envelope))
+        except (websockets.exceptions.ConnectionClosed, OSError) as exc:
+            logger.warning('[SessionsWebSocket] send failed: %s', exc)
+
+    # ─── Read loop ────────────────────────────────────────────────────
+
+    async def _read_loop(self) -> None:
+        ws = self._ws
+        assert ws is not None
+        try:
+            async for raw in ws:
+                text = raw if isinstance(raw, str) else raw.decode('utf-8', errors='replace')
+                try:
+                    parsed = json.loads(text)
+                except json.JSONDecodeError as exc:
+                    logger.debug('[SessionsWebSocket] parse error: %s', exc)
+                    continue
+                if not _is_sessions_message(parsed):
+                    logger.debug('[SessionsWebSocket] ignoring non-message: %s', parsed)
+                    continue
+                await self._invoke(self._callbacks.on_message, parsed)
+        except websockets.exceptions.ConnectionClosed as exc:
+            close_code = exc.rcvd.code if exc.rcvd else None
+            self._on_ws_close(close_code)
+        except Exception as exc:  # noqa: BLE001
+            await self._invoke(self._callbacks.on_error, exc)
+            self._on_ws_close(None)
+
+    def _on_ws_close(self, close_code: int | None) -> None:
+        """Discriminated reconnect strategy.
+
+        4003 → permanent stop, fire on_close.
+        4001 → max 3 retries with linear backoff.
+        other → max 5 attempts with constant delay.
+        """
+        if self._closed:
+            return
+        self._ws = None
+
+        if close_code == WS_CLOSE_PERMANENT_UNAUTHORIZED:
+            logger.debug(
+                '[SessionsWebSocket] permanent close 4003; not reconnecting'
+            )
+            self._closed = True
+            asyncio.get_running_loop().create_task(
+                self._invoke(self._callbacks.on_close)
+            )
+            return
+
+        if close_code == WS_CLOSE_SESSION_NOT_FOUND:
+            self._not_found_retries += 1
+            if self._not_found_retries > MAX_SESSION_NOT_FOUND_RETRIES:
+                logger.debug(
+                    '[SessionsWebSocket] 4001 retry budget exhausted; not reconnecting'
+                )
+                self._closed = True
+                asyncio.get_running_loop().create_task(
+                    self._invoke(self._callbacks.on_close)
+                )
+                return
+            delay = RECONNECT_DELAY_SECONDS * self._not_found_retries
+            self._schedule_reconnect_with_delay(delay)
+            return
+
+        # Generic transient.
+        self._reconnect_attempts += 1
+        if self._reconnect_attempts > MAX_RECONNECT_ATTEMPTS:
+            logger.debug('[SessionsWebSocket] not reconnecting (budget exhausted)')
+            self._closed = True
+            asyncio.get_running_loop().create_task(
+                self._invoke(self._callbacks.on_close)
+            )
+            return
+        self._schedule_reconnect_with_delay(RECONNECT_DELAY_SECONDS)
+
+    def _schedule_reconnect_or_close(self) -> None:
+        """Initial-connect failure path: same retry strategy as transient close."""
+        if self._closed:
+            return
+        self._reconnect_attempts += 1
+        if self._reconnect_attempts > MAX_RECONNECT_ATTEMPTS:
+            self._closed = True
+            asyncio.get_running_loop().create_task(
+                self._invoke(self._callbacks.on_close)
+            )
+            return
+        self._schedule_reconnect_with_delay(RECONNECT_DELAY_SECONDS)
+
+    def _schedule_reconnect_with_delay(self, delay_seconds: float) -> None:
+        async def _do_reconnect() -> None:
+            await self._invoke(self._callbacks.on_reconnecting)
+            try:
+                await asyncio.sleep(delay_seconds)
+            except asyncio.CancelledError:
+                return
+            if self._closed:
+                return
+            await self.connect()
+
+        loop = asyncio.get_running_loop()
+        self._reconnect_task = loop.create_task(_do_reconnect(), name='sessions-ws-reconnect')
+
+    # ─── Internal: callback helper ───────────────────────────────────
+
+    @staticmethod
+    async def _invoke(callback: Callable[..., object] | None, /, *args: object) -> None:
+        if callback is None:
+            return
+        result = callback(*args)
+        if asyncio.iscoroutine(result):
+            await result
+
+
+__all__ = [
+    'GetAccessToken',
+    'MAX_RECONNECT_ATTEMPTS',
+    'MAX_SESSION_NOT_FOUND_RETRIES',
+    'PING_INTERVAL_SECONDS',
+    'RECONNECT_DELAY_SECONDS',
+    'SessionsWebSocket',
+    'SessionsWebSocketCallbacks',
+]

--- a/src/server/direct_connect_manager.py
+++ b/src/server/direct_connect_manager.py
@@ -1,0 +1,348 @@
+"""WebSocket client for Direct Connect sessions.
+
+Ports ``typescript/src/server/directConnectManager.ts:40-213``.
+
+Connects to the WS URL returned by ``create_direct_connect_session``,
+reads NDJSON messages, branches by ``type``:
+
+  - ``control_request`` with subtype ``can_use_tool`` → permission
+    request callback (the only request the local server sends).
+  - ``control_request`` with any other subtype → error response so the
+    server doesn't hang.
+  - Other SDK messages (assistant, result, system) → on_message callback.
+  - ``control_response``, ``keep_alive``, ``control_cancel_request``,
+    ``streamlined_*``, ``system{subtype:'post_turn_summary'}`` → drop.
+
+Send side: ``send_message`` (user prompt), ``respond_to_permission_request``
+(allow/deny + updated_input/message), ``send_interrupt`` (cancel).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid as _uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+import websockets
+from websockets.asyncio.client import connect as ws_connect
+
+from src.bridge.messaging import RemotePermissionResponse
+from src.bridge.sdk_types import SDKControlPermissionRequest, SDKMessage
+
+from .direct_connect_session import DirectConnectConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DirectConnectCallbacks:
+    """Per-session event callbacks.
+
+    Mirrors TS ``DirectConnectCallbacks`` at
+    ``directConnectManager.ts:20-29``.
+    """
+
+    on_message: Callable[[SDKMessage], None | Awaitable[None]]
+    on_permission_request: Callable[[SDKControlPermissionRequest, str], None | Awaitable[None]]
+    on_connected: Callable[[], None | Awaitable[None]] | None = None
+    on_disconnected: Callable[[], None | Awaitable[None]] | None = None
+    on_error: Callable[[Exception], None | Awaitable[None]] | None = None
+
+
+def _is_stdout_message(value: object) -> bool:
+    """True for ``{type: str}`` payloads — pre-narrowing guard."""
+    return (
+        isinstance(value, dict)
+        and 'type' in value
+        and isinstance(value.get('type'), str)
+    )
+
+
+# Message types that the manager filters out (server-internal noise that
+# the local CLI does not need to surface). Mirrors the inverted check at
+# ``directConnectManager.ts:104-110``.
+_FILTERED_TYPES = frozenset({
+    'control_response',
+    'keep_alive',
+    'control_cancel_request',
+    'streamlined_text',
+    'streamlined_tool_use_summary',
+})
+
+
+class DirectConnectSessionManager:
+    """One Direct Connect WS session.
+
+    Lifecycle:
+        connect()      → opens WS, spawns reader task, fires on_connected
+        send_message() → POST a user prompt over the WS
+        respond_to_permission_request() → reply to a can_use_tool prompt
+        send_interrupt() → cancel the in-flight tool call
+        disconnect()   → close WS + cancel reader task
+    """
+
+    def __init__(
+        self,
+        config: DirectConnectConfig,
+        callbacks: DirectConnectCallbacks,
+    ) -> None:
+        self._config = config
+        self._callbacks = callbacks
+        self._ws: websockets.asyncio.client.ClientConnection | None = None
+        self._reader_task: asyncio.Task[None] | None = None
+        self._closed = False
+        # Set once on_disconnected has fired, to prevent double-fire when
+        # both the reader's finally AND disconnect() try to invoke it.
+        self._disconnected_fired = False
+
+    # ─── Public API ────────────────────────────────────────────────────
+
+    async def connect(self) -> None:
+        """Open the WS and start the reader. Resolves once the WS is open.
+
+        Raises ``websockets.exceptions.WebSocketException`` (and OSError
+        subclasses) on connect failure; does NOT swallow — caller can
+        retry or surface the error.
+        """
+        headers: dict[str, str] = {}
+        if self._config.auth_token:
+            headers['authorization'] = f'Bearer {self._config.auth_token}'
+
+        ws = await ws_connect(
+            self._config.ws_url,
+            additional_headers=headers,
+        )
+        self._ws = ws
+        self._reader_task = asyncio.get_running_loop().create_task(
+            self._read_loop(),
+            name='direct-connect-reader',
+        )
+        await self._invoke(self._callbacks.on_connected)
+
+    def is_connected(self) -> bool:
+        return self._ws is not None and not self._closed
+
+    async def send_message(self, content: object) -> bool:
+        """Send a user prompt over the WS.
+
+        Mirrors ``directConnectManager.ts:125-142``. The wire shape
+        matches what the agent's stream-json input format expects.
+        Returns False if the WS is not open.
+        """
+        if self._ws is None or self._closed:
+            return False
+        envelope = {
+            'type': 'user',
+            'message': {'role': 'user', 'content': content},
+            'parent_tool_use_id': None,
+            'session_id': '',
+        }
+        try:
+            await self._ws.send(json.dumps(envelope))
+        except (websockets.exceptions.ConnectionClosed, OSError):
+            return False
+        return True
+
+    async def respond_to_permission_request(
+        self,
+        request_id: str,
+        result: RemotePermissionResponse,
+    ) -> None:
+        """Reply to a ``can_use_tool`` control_request.
+
+        Mirrors ``directConnectManager.ts:144-167``. The wire shape is a
+        ``control_response`` with ``subtype: 'success'`` carrying the
+        allow/deny payload.
+        """
+        if self._ws is None or self._closed:
+            return
+        if result.behavior == 'allow':
+            response: dict[str, object] = {
+                'behavior': 'allow',
+                'updatedInput': getattr(result, 'updated_input', {}),
+            }
+        else:
+            response = {
+                'behavior': 'deny',
+                'message': getattr(result, 'message', ''),
+            }
+        envelope = {
+            'type': 'control_response',
+            'response': {
+                'subtype': 'success',
+                'request_id': request_id,
+                'response': response,
+            },
+        }
+        try:
+            await self._ws.send(json.dumps(envelope))
+        except (websockets.exceptions.ConnectionClosed, OSError):
+            pass
+
+    async def send_interrupt(self) -> None:
+        """Send a control_request with subtype ``interrupt``.
+
+        Mirrors ``directConnectManager.ts:172-186``. The local server
+        cancels the in-flight tool call and returns the agent loop to
+        an awaiting-user-input state.
+        """
+        if self._ws is None or self._closed:
+            return
+        envelope = {
+            'type': 'control_request',
+            'request_id': str(_uuid.uuid4()),
+            'request': {'subtype': 'interrupt'},
+        }
+        try:
+            await self._ws.send(json.dumps(envelope))
+        except (websockets.exceptions.ConnectionClosed, OSError):
+            pass
+
+    async def disconnect(self) -> None:
+        """Close the WS and cancel the reader task.
+
+        Fires ``on_disconnected`` exactly once — before cancelling the
+        reader, since the reader's ``finally``-block fire would itself
+        get cancelled mid-await and never reach the callback.
+        """
+        self._closed = True
+        ws, self._ws = self._ws, None
+        # Fire on_disconnected first (sync-or-coroutine), so cancellation
+        # of the reader can't pre-empt it. The flag prevents double-fire
+        # when the reader's natural finally also tries to invoke it.
+        await self._fire_disconnected_once()
+        if self._reader_task is not None:
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except (asyncio.CancelledError, websockets.exceptions.ConnectionClosed):
+                pass
+        if ws is not None:
+            try:
+                await ws.close()
+            except (websockets.exceptions.ConnectionClosed, OSError):
+                pass
+
+    async def _fire_disconnected_once(self) -> None:
+        if self._disconnected_fired:
+            return
+        self._disconnected_fired = True
+        await self._invoke(self._callbacks.on_disconnected)
+
+    # ─── Internal: message routing ─────────────────────────────────────
+
+    async def _read_loop(self) -> None:
+        """Pump WS messages until disconnect or error.
+
+        Mirrors ``directConnectManager.ts:64-122``. Handles NDJSON-on-WS
+        (each WS frame may contain multiple `\\n`-delimited messages, or
+        a single message; both shapes work).
+        """
+        ws = self._ws
+        assert ws is not None
+        try:
+            async for raw in ws:
+                if isinstance(raw, bytes):
+                    text = raw.decode('utf-8', errors='replace')
+                else:
+                    text = raw
+                # Split on newlines so a single WS frame containing
+                # multiple NDJSON lines is handled correctly. Empty
+                # lines are skipped.
+                for line in text.split('\n'):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        parsed = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not _is_stdout_message(parsed):
+                        continue
+                    await self._dispatch(parsed)
+        except websockets.exceptions.ConnectionClosed:
+            pass
+        except Exception as exc:  # noqa: BLE001 -- callback decides how to surface
+            await self._invoke(self._callbacks.on_error, exc)
+        finally:
+            await self._fire_disconnected_once()
+
+    async def _dispatch(self, msg: dict[str, object]) -> None:
+        """Branch one parsed message to the right callback."""
+        msg_type = msg.get('type')
+
+        if msg_type == 'control_request':
+            await self._handle_control_request(msg)
+            return
+
+        if msg_type == 'system' and msg.get('subtype') == 'post_turn_summary':
+            return  # filtered
+
+        if msg_type in _FILTERED_TYPES:
+            return  # filtered
+
+        await self._invoke(self._callbacks.on_message, msg)  # type: ignore[arg-type]
+
+    async def _handle_control_request(self, msg: dict[str, object]) -> None:
+        """Route a server → client control_request.
+
+        Only ``can_use_tool`` is recognized. Other subtypes get an error
+        response so the server doesn't hang waiting for a reply that
+        never comes (chapter explicit pattern).
+        """
+        request_id = msg.get('request_id')
+        inner = msg.get('request')
+        if not isinstance(request_id, str) or not isinstance(inner, dict):
+            return
+        subtype = inner.get('subtype')
+        if subtype == 'can_use_tool':
+            await self._invoke(
+                self._callbacks.on_permission_request,
+                inner,  # type: ignore[arg-type]
+                request_id,
+            )
+            return
+        # Unknown — send error response so the server doesn't hang.
+        logger.debug(
+            '[DirectConnect] Unsupported control request subtype: %s', subtype
+        )
+        await self._send_error_response(
+            request_id, f'Unsupported control request subtype: {subtype}'
+        )
+
+    async def _send_error_response(self, request_id: str, error: str) -> None:
+        """Send a ``control_response`` with ``subtype: 'error'``."""
+        if self._ws is None or self._closed:
+            return
+        envelope = {
+            'type': 'control_response',
+            'response': {
+                'subtype': 'error',
+                'request_id': request_id,
+                'error': error,
+            },
+        }
+        try:
+            await self._ws.send(json.dumps(envelope))
+        except (websockets.exceptions.ConnectionClosed, OSError):
+            pass
+
+    # ─── Internal: callback invocation helper ─────────────────────────
+
+    @staticmethod
+    async def _invoke(callback: Callable[..., object] | None, /, *args: object) -> None:
+        """Call a callback; await if it returns a coroutine."""
+        if callback is None:
+            return
+        result = callback(*args)
+        if asyncio.iscoroutine(result):
+            await result
+
+
+__all__ = [
+    'DirectConnectCallbacks',
+    'DirectConnectSessionManager',
+]

--- a/src/server/direct_connect_session.py
+++ b/src/server/direct_connect_session.py
@@ -1,0 +1,121 @@
+"""Direct Connect session creation (client side of POST /sessions).
+
+Ports ``typescript/src/server/createDirectConnectSession.ts:11-88``.
+
+Posts to ``${server_url}/sessions``, validates the response via
+``validate_connect_response``, returns a ``DirectConnectConfig`` ready
+for use by ``DirectConnectSessionManager``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from .types import validate_connect_response
+
+
+class DirectConnectError(Exception):
+    """Network, HTTP, or response-parsing failure during connect."""
+
+
+@dataclass(frozen=True)
+class DirectConnectConfig:
+    """Immutable config returned by ``create_direct_connect_session``.
+
+    Mirrors TS ``DirectConnectConfig`` at
+    ``server/directConnectManager.ts:13-18``. The ``auth_token`` is the
+    same token the server granted at session create; the WS upgrade
+    sends it as ``Authorization: Bearer ...``.
+    """
+
+    server_url: str
+    session_id: str
+    ws_url: str
+    auth_token: str | None = None
+
+
+async def create_direct_connect_session(
+    *,
+    server_url: str,
+    cwd: str,
+    auth_token: str | None = None,
+    dangerously_skip_permissions: bool = False,
+    client: httpx.AsyncClient | None = None,
+    timeout_seconds: float = 30.0,
+) -> tuple[DirectConnectConfig, str | None]:
+    """POST ``/sessions`` to ``server_url`` and return ``(config, work_dir)``.
+
+    Mirrors ``createDirectConnectSession.ts:26-88``.
+
+    Raises ``DirectConnectError`` on:
+      - network failure (DNS, connection refused, timeout)
+      - non-2xx HTTP response
+      - invalid response payload (missing ``session_id`` or ``ws_url``)
+
+    The ``client`` parameter is for tests; production callers omit it
+    and a fresh ``AsyncClient`` is constructed per call.
+    """
+    headers: dict[str, str] = {'content-type': 'application/json'}
+    if auth_token:
+        headers['authorization'] = f'Bearer {auth_token}'
+
+    body: dict[str, Any] = {'cwd': cwd}
+    if dangerously_skip_permissions:
+        body['dangerously_skip_permissions'] = True
+
+    url = f'{server_url.rstrip("/")}/sessions'
+
+    async def _do_post(c: httpx.AsyncClient) -> httpx.Response:
+        return await c.post(url, json=body, headers=headers, timeout=timeout_seconds)
+
+    try:
+        if client is None:
+            async with httpx.AsyncClient() as fresh:
+                resp = await _do_post(fresh)
+        else:
+            resp = await _do_post(client)
+    except (httpx.HTTPError, httpx.TimeoutException) as exc:
+        raise DirectConnectError(
+            f'Failed to connect to server at {server_url}: {exc}'
+        ) from exc
+
+    if resp.status_code < 200 or resp.status_code >= 300:
+        raise DirectConnectError(
+            f'Failed to create session: {resp.status_code} {resp.reason_phrase}'
+        )
+
+    try:
+        payload = resp.json()
+    except ValueError as exc:
+        raise DirectConnectError(f'Invalid session response: not valid JSON: {exc}') from exc
+
+    try:
+        validated = validate_connect_response(payload)
+    except ValueError as exc:
+        raise DirectConnectError(f'Invalid session response: {exc}') from exc
+
+    # Prefer the server-issued per-session token over the caller-supplied
+    # bootstrap token: the server's POST /sessions response includes a
+    # short-lived token in ``auth_token`` for the WS upgrade. Falling back
+    # to the bootstrap token preserves compatibility with servers that
+    # don't issue per-session tokens.
+    issued_token = payload.get('auth_token') if isinstance(payload, dict) else None
+    effective_token = issued_token if isinstance(issued_token, str) and issued_token else auth_token
+    config = DirectConnectConfig(
+        server_url=server_url,
+        session_id=validated['session_id'],
+        ws_url=validated['ws_url'],
+        auth_token=effective_token,
+    )
+    work_dir = validated.get('work_dir')
+    return config, work_dir
+
+
+__all__ = [
+    'DirectConnectConfig',
+    'DirectConnectError',
+    'create_direct_connect_session',
+]

--- a/src/server/lockfile.py
+++ b/src/server/lockfile.py
@@ -1,0 +1,110 @@
+"""Single-server-instance lockfile (POSIX flock; no-op on Windows).
+
+Reverse-engineered from ``main.tsx:3982`` which imports
+``./server/lockfile.js``. The TS source isn't in this snapshot; the
+contract from context is: prevent two ``claude server`` invocations
+from competing for the same ``--port`` (or default port).
+
+POSIX ``fcntl.flock(LOCK_EX | LOCK_NB)`` is automatically released by
+the kernel when the holding process exits, so stale-lock-after-crash
+is automatic.
+
+Direct Connect server is not supported on Windows in production, so
+the no-op there is acceptable; a Windows port would need
+``msvcrt.locking`` or a sentinel-PID file.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class LockfileBusyError(RuntimeError):
+    """Another process holds the server lockfile."""
+
+
+class ServerLockfile:
+    """Acquire/release context for ``~/.claude/server.lock``.
+
+    Usage:
+        async with ServerLockfile(path).hold():
+            await server.serve_forever()
+
+    Or imperatively:
+        lock = ServerLockfile(path)
+        lock.acquire()  # raises LockfileBusyError if held
+        try:
+            ...
+        finally:
+            lock.release()
+    """
+
+    def __init__(self, path: str | os.PathLike[str]) -> None:
+        self._path = Path(path)
+        self._fd: int | None = None
+
+    def acquire(self) -> None:
+        """Acquire the lock (LOCK_EX | LOCK_NB).
+
+        Raises ``LockfileBusyError`` if another process holds it.
+        ``OSError`` on filesystem failures (no permissions, missing
+        parent directory after the mkdir attempt, etc.) — those
+        propagate so the caller can decide how to surface.
+        """
+        try:
+            import fcntl
+        except ImportError:
+            # Windows: no-op. We still create the file so subsequent
+            # ``release`` is symmetric.
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._fd = os.open(self._path, os.O_RDWR | os.O_CREAT, 0o600)
+            return
+
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(self._path, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            os.close(fd)
+            raise LockfileBusyError(
+                f'Another claude server instance holds {self._path}'
+            ) from exc
+        self._fd = fd
+
+    def release(self) -> None:
+        """Release the lock and close the FD. Idempotent."""
+        if self._fd is None:
+            return
+        try:
+            import fcntl
+
+            try:
+                fcntl.flock(self._fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+        except ImportError:
+            pass
+        try:
+            os.close(self._fd)
+        except OSError:
+            pass
+        self._fd = None
+        # Best-effort unlink so the file doesn't accumulate over restarts.
+        try:
+            self._path.unlink()
+        except OSError:
+            pass
+
+    def __enter__(self) -> ServerLockfile:
+        self.acquire()
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.release()
+
+
+__all__ = ['LockfileBusyError', 'ServerLockfile']

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1,0 +1,479 @@
+"""Direct Connect local server (cc:// + cc+unix:// URL schemes).
+
+Reverse-engineered from ``main.tsx:3965`` which imports
+``./server/server.js``. The TS source isn't in this snapshot; the
+contract is deduced from the client side
+(``createDirectConnectSession.ts`` and ``directConnectManager.ts``):
+
+  - ``POST /sessions`` accepts ``{cwd, dangerously_skip_permissions?}``
+    and returns ``{session_id, ws_url, work_dir?, auth_token}``.
+  - WS endpoint accepts NDJSON-over-WS, with ``Authorization: Bearer``
+    on the upgrade request OR ``?token=<token>`` query param.
+  - 5-state ``SessionState`` lifecycle persisted to
+    ``~/.claude/server-sessions.json`` (via ``SessionManager``).
+
+**Architecture** — for robustness, the server uses **two separate
+listeners**: one HTTP (``asyncio.start_server`` + minimal HTTP/1.1
+parser) for ``POST /sessions``, and one WS (``websockets.asyncio.server``)
+for ``/ws/<session_id>``. The ``ws_url`` returned by ``POST /sessions``
+points at the WS port. This avoids depending on websockets internal
+``Protocol`` APIs to wrap an HTTP-upgraded socket.
+
+WI-1.9 (RESERVED) refines the spec once integration tests reveal gaps
+in the reverse-engineered protocol.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import secrets
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass, field
+from urllib.parse import parse_qs
+
+import websockets
+from websockets.asyncio.server import ServerConnection, serve as ws_serve
+
+from .session_manager import SessionManager
+from .types import ServerConfig, SessionState
+
+logger = logging.getLogger(__name__)
+
+
+#: Type for the callback that spawns an agent subprocess for a session.
+#: The implementation is out of scope for this minimal cut — tests
+#: provide a fake that returns an in-process pipe; the real CLI wiring
+#: lands in a follow-up.
+SpawnAgent = Callable[
+    [str, str, str | None],  # session_id, cwd, permission_mode
+    Awaitable['AgentHandle'],
+]
+
+
+@dataclass
+class AgentHandle:
+    """Handle to a spawned agent subprocess (or test double).
+
+    ``send_to_agent``: write a JSON-encoded SDK message into the agent's
+    stdin (caller adds a trailing newline if needed).
+    ``messages_from_agent``: async iterator yielding SDK message dicts
+    parsed from the agent's stdout.
+    ``shutdown``: terminate the agent and clean up.
+    """
+
+    send_to_agent: Callable[[dict], Awaitable[None]]
+    messages_from_agent: Callable[[], AsyncIterator[dict]]
+    shutdown: Callable[[], Awaitable[None]]
+
+
+# ─── HTTP/1.1 minimal parser for POST /sessions ────────────────────────────
+
+
+@dataclass
+class _ParsedRequest:
+    method: str
+    path: str
+    headers: dict[str, str]
+    body: bytes
+
+
+async def _read_http_request(
+    reader: asyncio.StreamReader,
+    *,
+    max_header_bytes: int = 64 * 1024,
+    max_body_bytes: int = 1 * 1024 * 1024,
+) -> _ParsedRequest | None:
+    """Read one HTTP/1.1 request from ``reader``. Returns None on malformed input."""
+    head_buf = bytearray()
+    while True:
+        chunk = await reader.read(4096)
+        if not chunk:
+            return None
+        head_buf.extend(chunk)
+        end = head_buf.find(b'\r\n\r\n')
+        if end != -1:
+            break
+        if len(head_buf) > max_header_bytes:
+            return None
+    head_text = head_buf[:end].decode('utf-8', errors='replace')
+    leftover = bytes(head_buf[end + 4 :])
+    lines = head_text.split('\r\n')
+    if not lines:
+        return None
+    request_line = lines[0].split()
+    if len(request_line) != 3:
+        return None
+    method, path, version = request_line
+    if not version.upper().startswith('HTTP/1.'):
+        return None
+
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        if ':' not in line:
+            continue
+        key, _, value = line.partition(':')
+        headers[key.strip().lower()] = value.strip()
+
+    content_length_str = headers.get('content-length', '0') or '0'
+    try:
+        content_length = int(content_length_str)
+    except ValueError:
+        return None
+    if content_length < 0 or content_length > max_body_bytes:
+        return None
+    body = bytearray(leftover[:content_length])
+    while len(body) < content_length:
+        chunk = await reader.read(content_length - len(body))
+        if not chunk:
+            return None
+        body.extend(chunk)
+
+    return _ParsedRequest(
+        method=method.upper(),
+        path=path,
+        headers=headers,
+        body=bytes(body),
+    )
+
+
+def _build_http_response(
+    *,
+    status: int,
+    reason: str,
+    body: bytes = b'',
+    content_type: str = 'application/json',
+) -> bytes:
+    return (
+        f'HTTP/1.1 {status} {reason}\r\n'
+        f'Content-Type: {content_type}\r\n'
+        f'Content-Length: {len(body)}\r\n'
+        f'Connection: close\r\n'
+        f'\r\n'
+    ).encode('ascii') + body
+
+
+# ─── Server ────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class DirectConnectServer:
+    """Direct Connect server — HTTP ``/sessions`` + WS ``/ws/<sid>``.
+
+    Lifecycle:
+        srv = DirectConnectServer(config, manager, spawn_agent)
+        await srv.start()
+        await srv.serve_forever()  # or use srv.stop() to shut down
+        await srv.stop()
+
+    Two listeners: HTTP on ``config.port`` (or ephemeral) and WS on a
+    separate ephemeral port. ``ws_url`` in the create-session response
+    points at the WS port. Auth is per-session: ``POST /sessions``
+    returns ``auth_token``; the WS upgrade requires it via
+    ``Authorization: Bearer <token>`` or ``?token=<token>``.
+    """
+
+    config: ServerConfig
+    manager: SessionManager
+    spawn_agent: SpawnAgent
+    _http_server: asyncio.AbstractServer | None = None
+    _ws_server: asyncio.Server | None = None
+    _session_tokens: dict[str, str] = field(default_factory=dict)
+    _ws_port: int | None = None
+
+    # ─── Public lifecycle ────────────────────────────────────────────
+
+    async def start(self) -> None:
+        """Bind both listeners; ``serve_forever`` to actually run."""
+        # WS listener first so we know its port for the ``ws_url`` we
+        # hand out from the HTTP route.
+        self._ws_server = await ws_serve(
+            self._handle_ws_connection,
+            host=self.config.host or '127.0.0.1',
+            port=0,  # ephemeral
+        )
+        ws_sockets = list(self._ws_server.sockets or [])
+        if not ws_sockets:
+            raise RuntimeError('DirectConnectServer: WS listener has no socket')
+        self._ws_port = ws_sockets[0].getsockname()[1]
+
+        # HTTP listener.
+        if self.config.unix:
+            self._http_server = await asyncio.start_unix_server(
+                self._handle_http_connection,
+                path=self.config.unix,
+            )
+        else:
+            self._http_server = await asyncio.start_server(
+                self._handle_http_connection,
+                host=self.config.host or '127.0.0.1',
+                port=self.config.port,
+            )
+
+    async def serve_forever(self) -> None:
+        if self._http_server is None or self._ws_server is None:
+            raise RuntimeError('start() must be called before serve_forever()')
+        # Both servers run concurrently; cancellation of either tears
+        # down both atomically via the gather.
+        await asyncio.gather(
+            self._http_server.serve_forever(),
+            self._ws_server.serve_forever(),
+            return_exceptions=True,
+        )
+
+    async def stop(self) -> None:
+        if self._http_server is not None:
+            self._http_server.close()
+            await self._http_server.wait_closed()
+            self._http_server = None
+        if self._ws_server is not None:
+            self._ws_server.close()
+            await self._ws_server.wait_closed()
+            self._ws_server = None
+        for sid in list(self.manager.active_session_ids()):
+            await self.manager.stop_session(sid)
+
+    @property
+    def bound_http_port(self) -> int | None:
+        """Bound HTTP port (None if not started or Unix-only)."""
+        if self._http_server is None:
+            return None
+        sockets = self._http_server.sockets
+        if not sockets:
+            return None
+        sock = sockets[0]
+        if sock.family.name == 'AF_UNIX':
+            return None
+        return sock.getsockname()[1]
+
+    @property
+    def bound_ws_port(self) -> int | None:
+        return self._ws_port
+
+    # ─── HTTP listener handler ───────────────────────────────────────
+
+    async def _handle_http_connection(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """One accepted HTTP connection: parse request, dispatch route."""
+        try:
+            request = await _read_http_request(reader)
+            if request is None:
+                writer.write(_build_http_response(
+                    status=400, reason='Bad Request', body=b'malformed request',
+                ))
+                await writer.drain()
+                return
+
+            if request.method == 'POST' and request.path == '/sessions':
+                await self._handle_post_sessions(request, writer)
+            else:
+                writer.write(_build_http_response(
+                    status=404, reason='Not Found', body=b'no such route',
+                ))
+                await writer.drain()
+        except (ConnectionError, OSError) as exc:
+            logger.debug('[server] HTTP connection error: %s', exc)
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except (ConnectionError, OSError):
+                pass
+
+    async def _handle_post_sessions(
+        self,
+        request: _ParsedRequest,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """Create a new session and return ``{session_id, ws_url, work_dir, auth_token}``."""
+        if self.config.auth_token:
+            authz = request.headers.get('authorization', '')
+            expected = f'Bearer {self.config.auth_token}'
+            if authz != expected:
+                writer.write(_build_http_response(
+                    status=401, reason='Unauthorized',
+                    body=b'{"error":"invalid auth token"}',
+                ))
+                await writer.drain()
+                return
+
+        try:
+            payload = json.loads(request.body)
+        except json.JSONDecodeError:
+            writer.write(_build_http_response(
+                status=400, reason='Bad Request',
+                body=b'{"error":"invalid JSON body"}',
+            ))
+            await writer.drain()
+            return
+
+        if not isinstance(payload, dict):
+            writer.write(_build_http_response(
+                status=400, reason='Bad Request',
+                body=b'{"error":"body must be a JSON object"}',
+            ))
+            await writer.drain()
+            return
+
+        cwd = payload.get('cwd')
+        if not isinstance(cwd, str) or not cwd:
+            writer.write(_build_http_response(
+                status=400, reason='Bad Request',
+                body=b'{"error":"cwd is required (non-empty string)"}',
+            ))
+            await writer.drain()
+            return
+
+        try:
+            info = self.manager.create_session(cwd=cwd)
+        except RuntimeError as exc:
+            writer.write(_build_http_response(
+                status=503, reason='Service Unavailable',
+                body=json.dumps({'error': str(exc)}).encode('utf-8'),
+            ))
+            await writer.drain()
+            return
+
+        token = secrets.token_urlsafe(32)
+        self._session_tokens[info.id] = token
+
+        host = self.config.host or '127.0.0.1'
+        ws_port = self._ws_port
+        ws_url = f'ws://{host}:{ws_port}/ws/{info.id}?token={token}'
+
+        body = json.dumps({
+            'session_id': info.id,
+            'ws_url': ws_url,
+            'work_dir': info.work_dir,
+            'auth_token': token,
+        }).encode('utf-8')
+        writer.write(_build_http_response(
+            status=201, reason='Created', body=body,
+        ))
+        await writer.drain()
+
+    # ─── WS listener handler ─────────────────────────────────────────
+
+    async def _handle_ws_connection(self, ws: ServerConnection) -> None:
+        """One accepted WS connection: validate session/token, then pump."""
+        # The ``websockets`` library exposes the request path on
+        # ``ws.request``. URL: ``/ws/<session_id>[?token=<token>]``.
+        request = ws.request
+        if request is None:
+            await ws.close(code=1008, reason='no request')
+            return
+        path = request.path
+        prefix = '/ws/'
+        if not path.startswith(prefix):
+            await ws.close(code=1008, reason='no such route')
+            return
+        sid_and_query = path[len(prefix):]
+        sid, _, query_str = sid_and_query.partition('?')
+        if not sid:
+            await ws.close(code=1008, reason='missing session id')
+            return
+
+        expected_token = self._session_tokens.get(sid)
+        if expected_token is None:
+            await ws.close(code=1008, reason='no such session')
+            return
+
+        # Token from header OR query param.
+        provided = ''
+        authz = request.headers.get('authorization', '') if request.headers else ''
+        if authz.startswith('Bearer '):
+            provided = authz[len('Bearer '):]
+        else:
+            params = parse_qs(query_str)
+            provided = (params.get('token') or [''])[0]
+        if not secrets.compare_digest(provided, expected_token):
+            await ws.close(code=1008, reason='invalid token')
+            return
+
+        info = self.manager.get(sid)
+        if info is None:
+            await ws.close(code=1008, reason='session not found')
+            return
+
+        try:
+            agent = await self.spawn_agent(sid, info.work_dir, None)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning('[server] agent spawn failed for %s: %s', sid, exc)
+            await ws.close(code=1011, reason='agent spawn failed')
+            return
+        self.manager.mark_running(sid)
+
+        try:
+            await self._run_ws_session(ws, sid, agent)
+        finally:
+            # Drop the per-session token so it can't be reused after
+            # this WS connection ends.
+            self._session_tokens.pop(sid, None)
+            await agent.shutdown()
+            await self.manager.stop_session(sid)
+
+    async def _run_ws_session(
+        self,
+        ws: ServerConnection,
+        session_id: str,
+        agent: AgentHandle,
+    ) -> None:
+        """Pump frames between the WS and the agent subprocess."""
+
+        async def outbound() -> None:
+            try:
+                async for msg in agent.messages_from_agent():
+                    await ws.send(json.dumps(msg))
+            except (
+                websockets.exceptions.ConnectionClosed,
+                ConnectionError,
+                OSError,
+            ):
+                return
+
+        async def inbound() -> None:
+            try:
+                async for raw in ws:
+                    text = raw if isinstance(raw, str) else raw.decode('utf-8', errors='replace')
+                    for line in text.split('\n'):
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            parsed = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        if isinstance(parsed, dict):
+                            try:
+                                await agent.send_to_agent(parsed)
+                            except (ConnectionError, OSError):
+                                return
+            except websockets.exceptions.ConnectionClosed:
+                return
+
+        out_task = asyncio.get_running_loop().create_task(outbound())
+        in_task = asyncio.get_running_loop().create_task(inbound())
+        try:
+            await asyncio.wait(
+                [out_task, in_task], return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            for task in (out_task, in_task):
+                if not task.done():
+                    task.cancel()
+                try:
+                    await task
+                except (
+                    asyncio.CancelledError,
+                    websockets.exceptions.ConnectionClosed,
+                    ConnectionError,
+                    OSError,
+                ):
+                    pass
+
+
+__all__ = ['AgentHandle', 'DirectConnectServer', 'SpawnAgent']

--- a/src/server/session_index.py
+++ b/src/server/session_index.py
@@ -1,0 +1,223 @@
+"""``~/.claude/server-sessions.json`` persistence for Direct Connect sessions.
+
+Mirrors the persistence helpers implied by ``server/types.ts:46-57``:
+the server reads the index at startup to resume sessions across server
+restarts; reads/writes the index when sessions start/stop/become
+detached.
+
+Concurrency: server process and resuming-client process can both touch
+the file. We use ``fcntl.flock(LOCK_EX)`` on POSIX (no-op on Windows
+since Direct Connect is Linux/macOS-only in production). Atomic writes
+via ``tempfile.mkstemp`` + ``os.replace``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import tempfile
+from contextlib import contextmanager
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Iterator
+
+from .types import SessionIndexEntry
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_INDEX_PATH = Path.home() / '.claude' / 'server-sessions.json'
+
+#: ``SessionIndex`` is keyed by ``session_id`` (TS uses ``string`` keys
+#: but the value type matches ``SessionIndexEntry``).
+SessionIndex = dict[str, SessionIndexEntry]
+
+
+# ─── File-lock context manager ─────────────────────────────────────────────
+
+
+@contextmanager
+def _flock(path: Path) -> Iterator[None]:
+    """Exclusive lock on ``path`` for the duration of the ``with`` block.
+
+    POSIX-only via ``fcntl.flock``; Windows is a no-op (Direct Connect
+    server is not supported on Windows in production). Lock is auto-
+    released by kernel when the FD closes (process exit included), so
+    stale-lock-after-crash is automatic.
+    """
+    try:
+        import fcntl
+    except ImportError:
+        # Windows: no-op. Direct Connect server isn't supported there.
+        yield
+        return
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+# ─── Read/write ────────────────────────────────────────────────────────────
+
+
+def _entry_to_dict(entry: SessionIndexEntry) -> dict[str, Any]:
+    return asdict(entry)
+
+
+def _dict_to_entry(payload: dict[str, Any]) -> SessionIndexEntry:
+    """Strict ``dict → SessionIndexEntry`` parser; raises on unknown keys."""
+    required = {'session_id', 'transcript_session_id', 'cwd', 'created_at', 'last_active_at'}
+    missing = required - payload.keys()
+    if missing:
+        raise ValueError(f'session index entry missing fields: {sorted(missing)}')
+    return SessionIndexEntry(
+        session_id=str(payload['session_id']),
+        transcript_session_id=str(payload['transcript_session_id']),
+        cwd=str(payload['cwd']),
+        created_at=float(payload['created_at']),
+        last_active_at=float(payload['last_active_at']),
+        permission_mode=(
+            str(payload['permission_mode'])
+            if payload.get('permission_mode') is not None
+            else None
+        ),
+    )
+
+
+def load_index(path: Path = DEFAULT_INDEX_PATH) -> SessionIndex:
+    """Read the index file. Missing/empty/corrupted file → empty dict.
+
+    Best-effort: a corrupted file (invalid JSON, missing fields) is
+    treated as empty rather than raising — the server can still start
+    fresh.
+    """
+    try:
+        raw = path.read_text(encoding='utf-8')
+    except FileNotFoundError:
+        return {}
+    except OSError as exc:
+        logger.warning('[session_index] read failed: %s; returning empty index', exc)
+        return {}
+    if not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning('[session_index] invalid JSON: %s; returning empty index', exc)
+        return {}
+    if not isinstance(parsed, dict):
+        logger.warning('[session_index] root is not an object; returning empty index')
+        return {}
+    out: SessionIndex = {}
+    for key, value in parsed.items():
+        if not isinstance(value, dict):
+            continue
+        try:
+            out[str(key)] = _dict_to_entry(value)
+        except (ValueError, TypeError) as exc:
+            logger.warning(
+                '[session_index] skipping malformed entry %r: %s', key, exc
+            )
+            continue
+    return out
+
+
+def save_index(index: SessionIndex, path: Path = DEFAULT_INDEX_PATH) -> None:
+    """Atomically replace the index file with ``index`` contents.
+
+    Uses ``tempfile.mkstemp`` in the same directory + ``os.replace``
+    (POSIX atomic). The file mode is 0o600 to keep session IDs +
+    cwds out of other users' view.
+    """
+    payload: dict[str, dict[str, Any]] = {
+        sid: _entry_to_dict(entry) for sid, entry in index.items()
+    }
+    serialized = json.dumps(payload, sort_keys=True, indent=2).encode('utf-8')
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent), prefix='.server-sessions.', suffix='.tmp'
+    )
+    try:
+        with os.fdopen(fd, 'wb') as fh:
+            fh.write(serialized)
+            fh.flush()
+            os.fsync(fh.fileno())
+        # Mode 0o600 — owner only.
+        try:
+            os.chmod(tmp_path, 0o600)
+        except OSError:
+            pass
+        os.replace(tmp_path, path)
+    except OSError:
+        # Best-effort cleanup of the tempfile on failure.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ─── Mutators ──────────────────────────────────────────────────────────────
+
+
+def add_entry(entry: SessionIndexEntry, path: Path = DEFAULT_INDEX_PATH) -> None:
+    """Add or replace ``entry`` in the index. Locked; atomic."""
+    with _flock(path):
+        index = load_index(path)
+        index[entry.session_id] = entry
+        save_index(index, path)
+
+
+def remove_entry(session_id: str, path: Path = DEFAULT_INDEX_PATH) -> None:
+    """Remove ``session_id`` from the index. Locked; atomic. No-op if absent."""
+    with _flock(path):
+        index = load_index(path)
+        if session_id in index:
+            del index[session_id]
+            save_index(index, path)
+
+
+def update_last_active(
+    session_id: str,
+    timestamp: float,
+    path: Path = DEFAULT_INDEX_PATH,
+) -> None:
+    """Bump ``last_active_at`` for ``session_id``. Locked; atomic.
+
+    No-op if the session isn't in the index (the server may be ahead of
+    the index for a freshly-started session not yet persisted).
+    """
+    with _flock(path):
+        index = load_index(path)
+        existing = index.get(session_id)
+        if existing is None:
+            return
+        # Frozen dataclass — replace by constructing a new instance.
+        index[session_id] = SessionIndexEntry(
+            session_id=existing.session_id,
+            transcript_session_id=existing.transcript_session_id,
+            cwd=existing.cwd,
+            created_at=existing.created_at,
+            last_active_at=timestamp,
+            permission_mode=existing.permission_mode,
+        )
+        save_index(index, path)
+
+
+__all__ = [
+    'DEFAULT_INDEX_PATH',
+    'SessionIndex',
+    'add_entry',
+    'load_index',
+    'remove_entry',
+    'save_index',
+    'update_last_active',
+]

--- a/src/server/session_manager.py
+++ b/src/server/session_manager.py
@@ -1,0 +1,203 @@
+"""Session lifecycle manager for the Direct Connect server.
+
+Reverse-engineered from ``main.tsx:3968`` which imports
+``./server/sessionManager.js``. The TS source isn't in this snapshot;
+the contract from the client side (``directConnectManager.ts``) plus
+``main.tsx`` flag handling implies:
+
+  - Map ``session_id`` → spawned agent subprocess.
+  - Track ``SessionState`` (5-state lifecycle from ``types.py``).
+  - Persist to ``SessionIndex`` so a server restart can resume.
+  - Enforce ``--max-sessions`` cap.
+  - Idle-timeout for ``DETACHED`` sessions (the user navigated away
+    but didn't kill the session).
+
+This implementation is intentionally minimal — the core fan-out
+(WS-frame → subprocess-stdin and subprocess-stdout → WS-frame) is
+implemented; advanced features (worktree, mid-session permission-mode
+change) are deferred to WI-1.9.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid as _uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .session_index import (
+    DEFAULT_INDEX_PATH,
+    add_entry,
+    remove_entry,
+    update_last_active,
+)
+from .types import SessionIndexEntry, SessionInfo, SessionState
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SessionManager:
+    """In-memory + on-disk Direct Connect session registry.
+
+    The manager owns the map of live sessions; the server-loop module
+    drives them via ``create_session``, ``mark_running``,
+    ``mark_detached``, ``mark_stopped``, and ``stop_session``.
+    """
+
+    workspace: str
+    max_sessions: int | None = None
+    idle_timeout_ms: int = 0
+    index_path: Path = DEFAULT_INDEX_PATH
+    _sessions: dict[str, SessionInfo] = field(default_factory=dict)
+
+    # ─── Mutators ──────────────────────────────────────────────────────
+
+    def create_session(
+        self,
+        *,
+        cwd: str | None = None,
+        permission_mode: str | None = None,
+    ) -> SessionInfo:
+        """Allocate a new session ID and record it in STARTING state.
+
+        Raises ``RuntimeError`` if ``max_sessions`` would be exceeded.
+        Caller is responsible for actually spawning the agent
+        subprocess and then calling ``attach_process`` + ``mark_running``.
+        """
+        if self.max_sessions is not None and self._active_count() >= self.max_sessions:
+            raise RuntimeError(
+                f'Direct Connect server: max_sessions ({self.max_sessions}) reached'
+            )
+        sid = f'ds_{_uuid.uuid4().hex}'
+        now = time.time()
+        info = SessionInfo(
+            id=sid,
+            status=SessionState.STARTING,
+            created_at=now,
+            work_dir=cwd or self.workspace,
+            last_active_at=now,
+        )
+        self._sessions[sid] = info
+        # Persist so a server restart can resume — even before the
+        # subprocess actually starts. The transcript_session_id
+        # initially equals the session_id; if the subprocess uses a
+        # different transcript ID, the server can update via
+        # ``update_transcript_id`` (out of scope for this minimal cut).
+        add_entry(
+            SessionIndexEntry(
+                session_id=sid,
+                transcript_session_id=sid,
+                cwd=info.work_dir,
+                created_at=info.created_at,
+                last_active_at=info.created_at,
+                permission_mode=permission_mode,
+            ),
+            path=self.index_path,
+        )
+        return info
+
+    def attach_process(
+        self,
+        session_id: str,
+        process: asyncio.subprocess.Process,
+    ) -> None:
+        info = self._sessions.get(session_id)
+        if info is None:
+            raise KeyError(f'unknown session: {session_id}')
+        info.process = process
+
+    def mark_running(self, session_id: str) -> None:
+        info = self._sessions.get(session_id)
+        if info is None:
+            return
+        now = time.time()
+        info.status = SessionState.RUNNING
+        info.last_active_at = now
+        update_last_active(session_id, now, path=self.index_path)
+
+    def mark_detached(self, session_id: str) -> None:
+        info = self._sessions.get(session_id)
+        if info is None:
+            return
+        now = time.time()
+        info.status = SessionState.DETACHED
+        info.last_active_at = now
+        update_last_active(session_id, now, path=self.index_path)
+
+    def touch(self, session_id: str) -> None:
+        """Bump ``last_active_at`` (e.g., on each message exchange).
+
+        Use from server hot paths to keep the idle reaper accurate.
+        """
+        info = self._sessions.get(session_id)
+        if info is None:
+            return
+        info.last_active_at = time.time()
+
+    async def stop_session(self, session_id: str) -> None:
+        """Transition through STOPPING → STOPPED, killing the subprocess."""
+        info = self._sessions.get(session_id)
+        if info is None:
+            return
+        info.status = SessionState.STOPPING
+        proc = info.process
+        if proc is not None and proc.returncode is None:
+            try:
+                proc.terminate()
+                # Give the agent a chance to flush; SIGKILL after 5s.
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=5.0)
+                except asyncio.TimeoutError:
+                    proc.kill()
+                    await proc.wait()
+            except (ProcessLookupError, OSError):
+                pass
+        info.status = SessionState.STOPPED
+        info.process = None
+        remove_entry(session_id, path=self.index_path)
+        self._sessions.pop(session_id, None)
+
+    # ─── Read-side helpers ────────────────────────────────────────────
+
+    def get(self, session_id: str) -> SessionInfo | None:
+        return self._sessions.get(session_id)
+
+    def active_session_ids(self) -> list[str]:
+        return [
+            sid
+            for sid, info in self._sessions.items()
+            if info.status in (SessionState.STARTING, SessionState.RUNNING, SessionState.DETACHED)
+        ]
+
+    def _active_count(self) -> int:
+        return len(self.active_session_ids())
+
+    # ─── Idle-timeout sweeper ─────────────────────────────────────────
+
+    async def reap_idle_detached(self, now: float | None = None) -> list[str]:
+        """Stop any DETACHED session whose ``last_active_at`` is past idle_timeout.
+
+        ``idle_timeout_ms == 0`` disables the sweep (per ``ServerConfig``).
+        Returns the list of session IDs that were stopped. Compares
+        against ``last_active_at`` (NOT ``created_at``) so a long-lived
+        active-then-detached session isn't reaped purely because it was
+        created hours ago.
+        """
+        if self.idle_timeout_ms <= 0:
+            return []
+        now_t = now if now is not None else time.time()
+        cutoff = now_t - (self.idle_timeout_ms / 1000.0)
+        stopped: list[str] = []
+        for sid, info in list(self._sessions.items()):
+            if info.status != SessionState.DETACHED:
+                continue
+            if info.last_active_at < cutoff:
+                await self.stop_session(sid)
+                stopped.append(sid)
+        return stopped
+
+
+__all__ = ['SessionManager']

--- a/src/server/types.py
+++ b/src/server/types.py
@@ -1,0 +1,138 @@
+"""Direct Connect type definitions.
+
+Ports ``typescript/src/server/types.ts``: ``ServerConfig``,
+``SessionState`` (5-state lifecycle), ``SessionInfo``,
+``SessionIndexEntry``, and the response-validation helper for
+``POST /sessions``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, TypedDict
+
+
+class SessionState(str, Enum):
+    """5-state Direct Connect session lifecycle.
+
+    Mirrors ``server/types.ts:26-31``. Values are strings so they
+    serialize cleanly through ``~/.claude/server-sessions.json``.
+    """
+
+    STARTING = 'starting'
+    RUNNING = 'running'
+    DETACHED = 'detached'
+    STOPPING = 'stopping'
+    STOPPED = 'stopped'
+
+
+@dataclass(frozen=True)
+class ServerConfig:
+    """Direct Connect server configuration.
+
+    Mirrors ``server/types.ts:13-24``. The ``unix`` field selects the
+    Unix-domain-socket variant (``--unix /path/to/sock``); when set,
+    ``host``/``port`` are ignored. ``idle_timeout_ms = 0`` means
+    "never expire detached sessions."
+    """
+
+    port: int = 0
+    host: str = '127.0.0.1'
+    auth_token: str = ''
+    unix: str | None = None
+    idle_timeout_ms: int = 0
+    max_sessions: int | None = None
+    workspace: str | None = None
+
+
+@dataclass
+class SessionInfo:
+    """In-memory record of a server-side session.
+
+    Mirrors ``server/types.ts:33-41``. ``process`` is a Popen-equivalent
+    handle (``asyncio.subprocess.Process``); ``None`` when the session
+    is being torn down.
+
+    ``last_active_at`` is bumped on state transitions and per-message
+    activity; the idle-timeout reaper compares against this field, NOT
+    against ``created_at`` — otherwise a long-lived active-then-detached
+    session would be reaped purely because it was created hours ago.
+    """
+
+    id: str
+    status: SessionState
+    created_at: float
+    work_dir: str
+    process: asyncio.subprocess.Process | None = None
+    session_key: str | None = None
+    last_active_at: float = 0.0  # initialized to created_at by SessionManager.create_session
+
+
+@dataclass(frozen=True)
+class SessionIndexEntry:
+    """On-disk record persisted to ``~/.claude/server-sessions.json``.
+
+    Mirrors ``server/types.ts:46-55``. Used to resume sessions across
+    server restarts: the new server reads this file at startup and can
+    restart the agent subprocess with ``--resume {transcriptSessionId}``.
+    """
+
+    session_id: str
+    transcript_session_id: str
+    cwd: str
+    created_at: float
+    last_active_at: float
+    permission_mode: str | None = None
+
+
+# ─── Wire schema for POST /sessions response ──────────────────────────────
+
+
+class ConnectResponse(TypedDict, total=False):
+    """``POST /sessions`` response shape.
+
+    Mirrors zod ``connectResponseSchema`` at ``server/types.ts:5-11``.
+    """
+
+    session_id: str
+    ws_url: str
+    work_dir: str  # optional
+
+
+def validate_connect_response(payload: object) -> ConnectResponse:
+    """Validate a ``POST /sessions`` response payload.
+
+    Raises ``ValueError`` on missing required fields or wrong types.
+    Returns the payload typed as ``ConnectResponse`` (caller still
+    treats it as a dict; the TypedDict is documentation).
+    """
+    if not isinstance(payload, dict):
+        raise ValueError(
+            f'connect response must be an object, got {type(payload).__name__}'
+        )
+    sid = payload.get('session_id')
+    if not isinstance(sid, str) or not sid:
+        raise ValueError('connect response missing session_id (non-empty string)')
+    ws_url = payload.get('ws_url')
+    if not isinstance(ws_url, str) or not ws_url:
+        raise ValueError('connect response missing ws_url (non-empty string)')
+    # work_dir is optional
+    work_dir = payload.get('work_dir')
+    if work_dir is not None and not isinstance(work_dir, str):
+        raise ValueError('connect response work_dir must be a string when present')
+    out: ConnectResponse = {'session_id': sid, 'ws_url': ws_url}
+    if isinstance(work_dir, str):
+        out['work_dir'] = work_dir
+    return out
+
+
+__all__ = [
+    'ConnectResponse',
+    'ServerConfig',
+    'SessionIndexEntry',
+    'SessionInfo',
+    'SessionState',
+    'validate_connect_response',
+]

--- a/src/server/url_scheme.py
+++ b/src/server/url_scheme.py
@@ -1,0 +1,123 @@
+"""``cc://`` and ``cc+unix://`` URL scheme parser for Direct Connect.
+
+Mirrors the parser logic implied by ``main.tsx:613, 618, 635, 3872``
+which accept both schemes. There is no canonical TS file for the
+parser — the URL is split by the surrounding code — but the contract
+is clear:
+
+    cc://host:port/session_id?key=value
+    cc+unix:///path/to/socket/session_id?key=value
+
+For Unix sockets, the socket path can itself contain ``/``; we treat
+**everything after the LAST ``/``** as the session ID.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+from urllib.parse import parse_qs
+
+
+CCScheme = Literal['cc', 'cc+unix']
+
+
+@dataclass(frozen=True)
+class CCAddress:
+    """Parsed ``cc://`` or ``cc+unix://`` address."""
+
+    scheme: CCScheme
+    #: For ``cc://``: the hostname (e.g. ``127.0.0.1``).
+    #: For ``cc+unix://``: the absolute Unix-socket path.
+    host_or_socket: str
+    port: int | None
+    session_id: str
+    query: dict[str, str] = field(default_factory=dict)
+
+
+def parse_cc_url(raw: str) -> CCAddress:
+    """Parse a ``cc://`` or ``cc+unix://`` URL.
+
+    Raises ``ValueError`` for any malformed input. ``urllib.parse`` is
+    NOT used directly because it doesn't handle our two custom schemes
+    consistently across Python versions; we parse by hand.
+    """
+    if raw.startswith('cc+unix://'):
+        return _parse_cc_unix(raw[len('cc+unix://'):])
+    if raw.startswith('cc://'):
+        return _parse_cc_tcp(raw[len('cc://'):])
+    raise ValueError(f'unsupported scheme: {raw!r}')
+
+
+def _split_query(rest: str) -> tuple[str, dict[str, str]]:
+    """Split ``path?query`` into (path, parsed_query)."""
+    if '?' not in rest:
+        return rest, {}
+    path, _, query_str = rest.partition('?')
+    parsed = parse_qs(query_str, keep_blank_values=True)
+    # parse_qs returns list[str] per key; flatten to first value (last write wins).
+    flat: dict[str, str] = {k: v[-1] for k, v in parsed.items()}
+    return path, flat
+
+
+def _parse_cc_tcp(remainder: str) -> CCAddress:
+    """Parse the body of ``cc://`` (host[:port]/session_id[?query])."""
+    body, query = _split_query(remainder)
+    if '/' not in body:
+        raise ValueError('cc:// URL missing session ID component')
+    authority, _, session_id = body.rpartition('/')
+    if not session_id:
+        raise ValueError('cc:// URL has empty session ID')
+    if not authority:
+        raise ValueError('cc:// URL missing host')
+    if ':' in authority:
+        host, port_str = authority.rsplit(':', 1)
+        try:
+            port = int(port_str, 10)
+        except ValueError as exc:
+            raise ValueError(f'cc:// URL invalid port: {port_str!r}') from exc
+        if not (1 <= port <= 65535):
+            raise ValueError(f'cc:// URL port out of range: {port}')
+    else:
+        host = authority
+        port = None
+    if not host:
+        raise ValueError('cc:// URL has empty host')
+    return CCAddress(
+        scheme='cc',
+        host_or_socket=host,
+        port=port,
+        session_id=session_id,
+        query=query,
+    )
+
+
+def _parse_cc_unix(remainder: str) -> CCAddress:
+    """Parse the body of ``cc+unix://`` (/path/to/socket/session_id[?query]).
+
+    The Unix socket path can contain ``/``; the session ID is the last
+    path component.
+    """
+    body, query = _split_query(remainder)
+    # cc+unix:// requires an absolute path — leading slash is consumed
+    # by the scheme prefix split, so ``body`` must START with another
+    # ``/`` in absolute form. Reject empty too.
+    if not body or '/' not in body:
+        raise ValueError('cc+unix:// URL missing path or session ID')
+    socket_path, _, session_id = body.rpartition('/')
+    if not session_id:
+        raise ValueError('cc+unix:// URL has empty session ID')
+    # Add the leading slash back: ``cc+unix:///foo/bar/sid`` →
+    # remainder ``/foo/bar/sid`` → split → socket_path = '/foo/bar'.
+    if not socket_path:
+        raise ValueError('cc+unix:// URL has empty socket path')
+    return CCAddress(
+        scheme='cc+unix',
+        host_or_socket=socket_path,
+        port=None,
+        session_id=session_id,
+        query=query,
+    )
+
+
+__all__ = ['CCAddress', 'CCScheme', 'parse_cc_url']

--- a/src/transports/__init__.py
+++ b/src/transports/__init__.py
@@ -1,0 +1,9 @@
+"""CCR Bridge v2 read/write transports.
+
+Two halves:
+
+  * ``sse_transport.SSETransport`` — read side (SSE long-poll).
+  * ``ccr_client.CCRClient`` — write side (HTTP POST batching + heartbeat).
+
+Both consumed by ``src.bridge.repl_bridge_transport.create_v2_repl_transport``.
+"""

--- a/src/transports/ccr_client.py
+++ b/src/transports/ccr_client.py
@@ -1,0 +1,384 @@
+"""CCR Bridge v2 write transport (HTTP POST batching + heartbeat).
+
+Ports the consumer-facing surface of
+``typescript/src/transports/ccrClient.ts (998 lines)``.
+
+Three responsibilities:
+
+1. **`SerialBatchEventUploader`** — `asyncio.Queue(maxsize=N)` of
+   pending events; a single uploader task drains the queue in batches
+   of up to `max_batch_size` and POSTs to ``/worker/events``. Per
+   Risk #23: queue blocks on the producer side (back-pressure to
+   `write_event`); a configurable timeout triggers `dropped_batch_count`
+   if the producer is starved (the queue is full and stays full).
+
+2. **Heartbeat** — `asyncio.Task` that POSTs `/worker/heartbeat` every
+   `heartbeat_interval_seconds` (default 20s with optional jitter).
+   Cancelled on close.
+
+3. **State / metadata / delivery** — `report_state`, `report_metadata`,
+   `report_delivery` are best-effort POSTs.
+
+**Epoch mismatch (409)** — when the server returns 409, the configured
+`on_epoch_mismatch` callback is fired. The TS callback throws
+`'epoch superseded'` to unwind the caller; in Python we raise
+`EpochSupersededError` (defined in `src.bridge.exceptions`).
+
+This implementation is the **functional surface** the
+`ReplBridgeTransport` needs; rare error branches (multipart timeout,
+specific 5xx retry budgets) are simplified.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from src.bridge.exceptions import EpochSupersededError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 20.0
+DEFAULT_MAX_BATCH_SIZE = 100
+DEFAULT_QUEUE_MAX_SIZE = 100
+DEFAULT_PRODUCER_TIMEOUT_SECONDS = 30.0
+#: Number of additional retries after the first attempt fails before
+#: the batch is dropped. Total attempts = 1 (initial) + this many.
+#: Renamed from "max_consecutive_failures" for clarity — the option
+#: name describes the retry count, not the failure count.
+DEFAULT_MAX_RETRIES_PER_BATCH = 3
+DEFAULT_RETRY_BACKOFF_SECONDS = 2.0
+
+
+GetAuthHeaders = Callable[[], dict[str, str]]
+OnEpochMismatch = Callable[[], None]
+
+
+@dataclass
+class CCRClientOptions:
+    """Construction-time knobs for ``CCRClient``."""
+
+    get_auth_headers: GetAuthHeaders | None = None
+    heartbeat_interval_seconds: float = DEFAULT_HEARTBEAT_INTERVAL_SECONDS
+    heartbeat_jitter_fraction: float = 0.0
+    max_batch_size: int = DEFAULT_MAX_BATCH_SIZE
+    queue_max_size: int = DEFAULT_QUEUE_MAX_SIZE
+    producer_timeout_seconds: float = DEFAULT_PRODUCER_TIMEOUT_SECONDS
+    max_retries_per_batch: int = DEFAULT_MAX_RETRIES_PER_BATCH
+    retry_backoff_seconds: float = DEFAULT_RETRY_BACKOFF_SECONDS
+    on_epoch_mismatch: OnEpochMismatch | None = None
+
+
+class CCRClient:
+    """Write-side transport for Bridge v2.
+
+    Lifecycle:
+        client = CCRClient(base_url, options, http_client=...)
+        await client.initialize(epoch)
+        await client.write_event(msg)            # -> queue
+        client.report_state({'status': '...'})    # fire-and-forget
+        client.report_delivery(eid, 'received')   # fire-and-forget
+        await client.flush()                      # drain the queue
+        client.close()
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        options: CCRClientOptions | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip('/')
+        self._options = options or CCRClientOptions()
+        self._http = http_client
+        self._owned_http = http_client is None
+
+        self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(
+            maxsize=self._options.queue_max_size
+        )
+        self._epoch: int | None = None
+        self._initialized = False
+        self._closed = False
+
+        self._uploader_task: asyncio.Task[None] | None = None
+        self._heartbeat_task: asyncio.Task[None] | None = None
+
+        #: Monotonic count of batches the uploader silently dropped due
+        #: to repeated POST failures. Producers can snapshot this around
+        #: ``write_event`` to detect drops (the future resolves normally
+        #: even when the batch was lost).
+        self._dropped_batch_count = 0
+
+    # ─── Public properties ────────────────────────────────────────────
+
+    @property
+    def dropped_batch_count(self) -> int:
+        return self._dropped_batch_count
+
+    @property
+    def is_initialized(self) -> bool:
+        return self._initialized
+
+    @property
+    def is_closed(self) -> bool:
+        return self._closed
+
+    # ─── Lifecycle ────────────────────────────────────────────────────
+
+    async def initialize(self, epoch: int) -> None:
+        """Set the worker epoch and spawn the uploader + heartbeat tasks."""
+        if self._initialized:
+            return
+        if self._http is None:
+            self._http = httpx.AsyncClient(timeout=30.0)
+        self._epoch = epoch
+        self._initialized = True
+        loop = asyncio.get_running_loop()
+        self._uploader_task = loop.create_task(self._uploader_loop(), name='ccr-uploader')
+        if self._options.heartbeat_interval_seconds > 0:
+            self._heartbeat_task = loop.create_task(self._heartbeat_loop(), name='ccr-heartbeat')
+
+    def close(self) -> None:
+        """Cancel uploader + heartbeat, drop pending writes."""
+        if self._closed:
+            return
+        self._closed = True
+        for task in (self._uploader_task, self._heartbeat_task):
+            if task is not None and not task.done():
+                task.cancel()
+
+    async def aclose(self) -> None:
+        """Cancel everything and clean up the owned HTTP client."""
+        self.close()
+        for task in (self._uploader_task, self._heartbeat_task):
+            if task is None:
+                continue
+            try:
+                await task
+            except (asyncio.CancelledError, httpx.HTTPError):
+                pass
+        if self._owned_http and self._http is not None:
+            await self._http.aclose()
+            self._http = None
+
+    async def flush(self) -> None:
+        """Wait for the queue to drain.
+
+        Note: only flushes events currently queued; events written after
+        the call returns are not guaranteed to land before subsequent
+        calls. Callers serialize their writes before flushing if they
+        need a hard barrier.
+        """
+        await self._queue.join()
+
+    # ─── Write API ────────────────────────────────────────────────────
+
+    async def write_event(self, message: dict[str, Any]) -> None:
+        """Enqueue ``message`` for batched POST to ``/worker/events``.
+
+        Blocks if the queue is full (back-pressure to caller). Times out
+        after ``producer_timeout_seconds``; on timeout, increments
+        ``dropped_batch_count`` and returns (the message is lost).
+        """
+        if self._closed or not self._initialized:
+            self._dropped_batch_count += 1
+            return
+        try:
+            await asyncio.wait_for(
+                self._queue.put(message),
+                timeout=self._options.producer_timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            self._dropped_batch_count += 1
+
+    # ─── State / metadata / delivery (fire-and-forget POSTs) ──────────
+
+    def report_state(self, state: dict[str, Any]) -> None:
+        """PUT ``/worker`` state (e.g. ``{requires_action: True}``)."""
+        if self._closed:
+            return
+        asyncio.get_running_loop().create_task(
+            self._safe_put('/worker', json={'state': state}),
+            name='ccr-report-state',
+        )
+
+    def report_metadata(self, metadata: dict[str, Any]) -> None:
+        if self._closed:
+            return
+        asyncio.get_running_loop().create_task(
+            self._safe_put('/worker', json={'external_metadata': metadata}),
+            name='ccr-report-metadata',
+        )
+
+    def report_delivery(self, event_id: str, status: str) -> None:
+        """POST ``/worker/events/{event_id}/delivery``."""
+        if self._closed:
+            return
+        path = f'/worker/events/{event_id}/delivery'
+        asyncio.get_running_loop().create_task(
+            self._safe_post(path, json={'status': status}),
+            name='ccr-report-delivery',
+        )
+
+    # ─── Internal: HTTP helpers ───────────────────────────────────────
+
+    def _headers(self) -> dict[str, str]:
+        h: dict[str, str] = {'Content-Type': 'application/json'}
+        if self._options.get_auth_headers is not None:
+            h.update(self._options.get_auth_headers())
+        if self._epoch is not None:
+            h['X-Worker-Epoch'] = str(self._epoch)
+        return h
+
+    async def _safe_post(self, path: str, json: dict[str, Any]) -> None:
+        if self._http is None:
+            return
+        url = f'{self._base_url}{path}'
+        try:
+            resp = await self._http.post(url, json=json, headers=self._headers())
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            logger.debug('[ccr] POST %s failed: %s', path, exc)
+            return
+        await self._handle_response(resp)
+
+    async def _safe_put(self, path: str, json: dict[str, Any]) -> None:
+        if self._http is None:
+            return
+        url = f'{self._base_url}{path}'
+        try:
+            resp = await self._http.put(url, json=json, headers=self._headers())
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            logger.debug('[ccr] PUT %s failed: %s', path, exc)
+            return
+        await self._handle_response(resp)
+
+    async def _handle_response(self, resp: httpx.Response) -> None:
+        if resp.status_code == 409:
+            logger.debug('[ccr] 409 epoch superseded')
+            cb = self._options.on_epoch_mismatch
+            if cb is not None:
+                try:
+                    cb()
+                except EpochSupersededError:
+                    raise
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug('[ccr] on_epoch_mismatch callback raised: %s', exc)
+            raise EpochSupersededError(
+                'CCR worker epoch superseded (409)'
+            )
+        if resp.status_code >= 500:
+            logger.debug('[ccr] server error %d', resp.status_code)
+
+    # ─── Internal: uploader + heartbeat loops ─────────────────────────
+
+    async def _uploader_loop(self) -> None:
+        """Drain the queue in batches; POST each batch to /worker/events.
+
+        On failure, re-attempt the same batch up to
+        ``max_retries_per_batch`` times before dropping (matches TS
+        ``maxConsecutiveFailures`` semantics — failures count for one
+        batch, not lifetime). Drops increment ``dropped_batch_count``.
+        """
+        while not self._closed:
+            try:
+                first = await self._queue.get()
+            except asyncio.CancelledError:
+                return
+            batch: list[dict[str, Any]] = [first]
+            for _ in range(self._options.max_batch_size - 1):
+                try:
+                    batch.append(self._queue.get_nowait())
+                except asyncio.QueueEmpty:
+                    break
+            # Mark queue items as done immediately — we own the batch
+            # now; retries don't go back through the queue.
+            for _ in batch:
+                self._queue.task_done()
+
+            failures = 0
+            while not self._closed:
+                try:
+                    success = await self._post_batch(batch)
+                except EpochSupersededError:
+                    # Don't keep retrying through epoch mismatches —
+                    # the parent transport will close us.
+                    return
+                if success:
+                    break
+                failures += 1
+                if failures > self._options.max_retries_per_batch:
+                    # Total attempts = 1 (initial) + max_retries_per_batch.
+                    # Now exhausted; drop the batch and proceed.
+                    self._dropped_batch_count += 1
+                    break
+                try:
+                    await asyncio.sleep(self._options.retry_backoff_seconds)
+                except asyncio.CancelledError:
+                    return
+
+    async def _post_batch(self, batch: list[dict[str, Any]]) -> bool:
+        """POST one batch. Returns True on success, False on transient failure.
+
+        Raises ``EpochSupersededError`` on 409 — caller must let it
+        propagate so the parent transport can recreate.
+        """
+        if self._http is None:
+            return False
+        url = f'{self._base_url}/worker/events'
+        try:
+            resp = await self._http.post(
+                url,
+                json={'events': batch},
+                headers=self._headers(),
+            )
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            logger.debug('[ccr] batch POST failed: %s', exc)
+            return False
+        if resp.status_code == 409:
+            logger.debug('[ccr] batch POST: 409 epoch superseded')
+            cb = self._options.on_epoch_mismatch
+            if cb is not None:
+                try:
+                    cb()
+                except EpochSupersededError:
+                    raise
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug('[ccr] on_epoch_mismatch callback raised: %s', exc)
+            raise EpochSupersededError('CCR worker epoch superseded (409)')
+        if resp.status_code >= 500:
+            logger.debug('[ccr] batch POST 5xx: %d', resp.status_code)
+            return False
+        return True
+
+    async def _heartbeat_loop(self) -> None:
+        """Periodic POST ``/worker/heartbeat`` with optional jitter."""
+        interval = self._options.heartbeat_interval_seconds
+        jitter = self._options.heartbeat_jitter_fraction
+        while not self._closed:
+            try:
+                # ±jitter fraction of the interval.
+                delta = random.uniform(-jitter, jitter) * interval if jitter > 0 else 0.0
+                await asyncio.sleep(max(0.1, interval + delta))
+            except asyncio.CancelledError:
+                return
+            await self._safe_post('/worker/heartbeat', json={})
+
+
+__all__ = [
+    'CCRClient',
+    'CCRClientOptions',
+    'DEFAULT_HEARTBEAT_INTERVAL_SECONDS',
+    'DEFAULT_MAX_BATCH_SIZE',
+    'DEFAULT_MAX_RETRIES_PER_BATCH',
+    'DEFAULT_PRODUCER_TIMEOUT_SECONDS',
+    'DEFAULT_QUEUE_MAX_SIZE',
+    'DEFAULT_RETRY_BACKOFF_SECONDS',
+    'GetAuthHeaders',
+    'OnEpochMismatch',
+]

--- a/src/transports/sse_transport.py
+++ b/src/transports/sse_transport.py
@@ -1,0 +1,244 @@
+"""SSE read transport for the CCR Bridge v2 stream.
+
+Ports the read-side surface of
+``typescript/src/transports/SSETransport.ts (711 lines)``. We port
+the **functional surface** (connect, parse SSE frames, dispatch
+events, reconnect with Last-Event-ID resume), not every TS line.
+
+Key design decisions:
+
+  - **`httpx-sse` does NOT auto-resume `Last-Event-ID`** on reconnect
+    (Risk #21 in the refactoring plan). We track ``_last_event_id``
+    ourselves and pass it as a header on every reconnect.
+  - **Reconnect budget** matches TS: max 5 attempts with constant
+    ``RECONNECT_DELAY_SECONDS = 2.0``. Exhaustion fires
+    ``on_close(WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED)``.
+  - **Backpressure**: ``on_data`` is called synchronously per event;
+    the pump task awaits the next byte so a slow consumer naturally
+    backpressures the read.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+import httpx
+from httpx_sse import aconnect_sse
+
+from src.bridge.close_codes import WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RECONNECT_DELAY_SECONDS = 2.0
+DEFAULT_RECONNECT_BUDGET = 5
+
+GetAuthHeaders = Callable[[], dict[str, str]]
+OnData = Callable[[str], None]
+OnClose = Callable[[int | None], None]
+OnEvent = Callable[['SSEEvent'], None]
+
+
+@dataclass
+class SSEEvent:
+    """One parsed SSE frame.
+
+    ``event_id``: the SSE ``id:`` field value, used by the consumer to
+    update the Last-Event-ID cursor that drives history-resume on
+    reconnect.
+    """
+
+    event_id: str | None
+    event: str | None
+    data: str
+
+
+class SSETransport:
+    """Async SSE long-poll client with Last-Event-ID resume.
+
+    Public API mirrors the surface ``ReplBridgeTransport`` consumes:
+
+        connect()                   — open the stream (returns when first
+                                       frame arrives or stream errors)
+        set_on_data(cb)             — receive raw ``data:`` payloads
+        set_on_event(cb)            — receive parsed SSEEvent objects
+        set_on_close(cb)            — receive close-codes
+        get_last_sequence_num()     — current Last-Event-ID cursor
+        is_connected_status()       — True while a stream is open
+        is_closed_status()          — True after permanent close
+        close()                     — terminate the stream + reconnect loop
+    """
+
+    def __init__(
+        self,
+        url: str,
+        headers: dict[str, str] | None = None,
+        session_id: str | None = None,
+        get_auth_headers: GetAuthHeaders | None = None,
+        initial_sequence_num: int = 0,
+        reconnect_delay_seconds: float = DEFAULT_RECONNECT_DELAY_SECONDS,
+        reconnect_budget: int = DEFAULT_RECONNECT_BUDGET,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._url = url
+        self._headers = dict(headers or {})
+        self._session_id = session_id
+        self._get_auth_headers = get_auth_headers
+        self._last_event_id: str = str(initial_sequence_num) if initial_sequence_num else ''
+        self._reconnect_delay = reconnect_delay_seconds
+        self._reconnect_budget = reconnect_budget
+        self._reconnect_attempts = 0
+
+        self._client = client
+        self._owned_client = client is None
+        self._on_data: OnData | None = None
+        self._on_close: OnClose | None = None
+        self._on_event: OnEvent | None = None
+
+        self._connected = False
+        self._closed = False
+        self._read_task: asyncio.Task[None] | None = None
+
+    # ─── Public callback wiring ────────────────────────────────────────
+
+    def set_on_data(self, cb: OnData) -> None:
+        self._on_data = cb
+
+    def set_on_close(self, cb: OnClose) -> None:
+        self._on_close = cb
+
+    def set_on_event(self, cb: OnEvent) -> None:
+        self._on_event = cb
+
+    # ─── Public state queries ─────────────────────────────────────────
+
+    def is_connected_status(self) -> bool:
+        return self._connected and not self._closed
+
+    def is_closed_status(self) -> bool:
+        return self._closed
+
+    def get_last_sequence_num(self) -> int:
+        """Current Last-Event-ID as int (0 if missing or non-numeric)."""
+        try:
+            return int(self._last_event_id) if self._last_event_id else 0
+        except ValueError:
+            return 0
+
+    # ─── Lifecycle ────────────────────────────────────────────────────
+
+    async def connect(self) -> None:
+        """Spawn the read loop. Returns immediately; the caller awaits
+        the first event via ``set_on_data`` / ``set_on_event``."""
+        if self._read_task is not None and not self._read_task.done():
+            return
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=None)
+        loop = asyncio.get_running_loop()
+        self._read_task = loop.create_task(self._read_loop(), name='sse-read-loop')
+
+    def close(self) -> None:
+        """Terminate the read loop. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._read_task is not None and not self._read_task.done():
+            self._read_task.cancel()
+
+    async def aclose(self) -> None:
+        """Cancel the loop AND await the underlying client cleanup."""
+        self.close()
+        if self._read_task is not None:
+            try:
+                await self._read_task
+            except (asyncio.CancelledError, httpx.HTTPError):
+                pass
+        if self._owned_client and self._client is not None:
+            await self._client.aclose()
+
+    # ─── Read loop ────────────────────────────────────────────────────
+
+    async def _read_loop(self) -> None:
+        """Open the SSE stream, parse frames, fire callbacks; reconnect on drop."""
+        assert self._client is not None
+        while not self._closed:
+            headers = dict(self._headers)
+            if self._get_auth_headers is not None:
+                headers.update(self._get_auth_headers())
+            if self._last_event_id:
+                # Per Risk #21: httpx-sse does NOT auto-resume
+                # Last-Event-ID. Pass it explicitly on each (re)connect
+                # so the server resumes from the right cursor.
+                headers['Last-Event-ID'] = self._last_event_id
+
+            try:
+                async with aconnect_sse(
+                    self._client,
+                    'GET',
+                    self._url,
+                    headers=headers,
+                ) as event_source:
+                    self._connected = True
+                    self._reconnect_attempts = 0
+                    async for sse in event_source.aiter_sse():
+                        if self._closed:
+                            return
+                        if sse.id:
+                            self._last_event_id = sse.id
+                        event = SSEEvent(
+                            event_id=sse.id or None,
+                            event=sse.event or None,
+                            data=sse.data,
+                        )
+                        if self._on_event is not None:
+                            try:
+                                self._on_event(event)
+                            except Exception as exc:  # noqa: BLE001
+                                logger.warning('[sse] on_event callback raised: %s', exc)
+                        if self._on_data is not None:
+                            try:
+                                self._on_data(sse.data)
+                            except Exception as exc:  # noqa: BLE001
+                                logger.warning('[sse] on_data callback raised: %s', exc)
+            except asyncio.CancelledError:
+                # close() cancellation — exit cleanly without a reconnect.
+                self._connected = False
+                return
+            except (httpx.HTTPError, httpx.TimeoutException, OSError) as exc:
+                logger.debug('[sse] stream error: %s', exc)
+                self._connected = False
+            except Exception as exc:  # noqa: BLE001 -- unknown errors from httpx-sse
+                logger.warning('[sse] unexpected error: %s', exc)
+                self._connected = False
+
+            # Reconnect with budget.
+            self._reconnect_attempts += 1
+            if self._reconnect_attempts > self._reconnect_budget or self._closed:
+                self._closed = True
+                self._connected = False
+                if self._on_close is not None:
+                    try:
+                        self._on_close(WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning('[sse] on_close callback raised: %s', exc)
+                return
+
+            try:
+                await asyncio.sleep(self._reconnect_delay)
+            except asyncio.CancelledError:
+                self._connected = False
+                return
+
+
+__all__ = [
+    'DEFAULT_RECONNECT_BUDGET',
+    'DEFAULT_RECONNECT_DELAY_SECONDS',
+    'GetAuthHeaders',
+    'OnClose',
+    'OnData',
+    'OnEvent',
+    'SSEEvent',
+    'SSETransport',
+]

--- a/src/upstreamproxy/ca_bundle.py
+++ b/src/upstreamproxy/ca_bundle.py
@@ -1,0 +1,162 @@
+"""CA-bundle download + PEM validation.
+
+Ports ``isValidPemContent`` and ``downloadCaBundle`` from
+``typescript/src/upstreamproxy/upstreamproxy.ts:211-216, 266-304``.
+
+The CCR upstream-proxy server signs traffic with a forged CA so it can
+MITM credential injection. The CLI downloads that CA and concatenates it
+with the system CA bundle, then exports the combined bundle's path via
+``SSL_CERT_FILE`` etc. so child subprocesses (curl, gh, python) trust
+the proxy.
+
+Two security guards:
+  1. ``isValidPemContent`` — refuses to write non-PEM bytes (e.g., HTML
+     error page from a compromised server) into the system bundle.
+  2. 5-second timeout on the fetch — a hung endpoint cannot stall CLI
+     startup forever.
+
+Both fail open: any failure returns ``False`` and the proxy stays
+disabled.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import tempfile
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+#: Matches one well-formed PEM certificate block. The non-greedy body
+#: ensures multiple blocks in a bundle are matched separately. This
+#: regex is structural-only; we don't parse the cert itself (the OpenSSL
+#: layer downstream of ``SSL_CERT_FILE`` will reject malformed certs).
+_PEM_BLOCK_RE = re.compile(
+    rb'-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----'
+)
+
+DEFAULT_CA_FETCH_TIMEOUT_SECONDS = 5.0
+
+
+def is_valid_pem_content(content: str | bytes) -> bool:
+    """Return True if ``content`` contains at least one well-formed PEM block.
+
+    Used as a security guard before writing the downloaded CA into the
+    system bundle. A compromised upstream proxy might respond with HTML
+    or JSON; without this check, that arbitrary content would be
+    appended to the trust store.
+
+    Mirrors ``upstreamproxy.ts:211-216`` and the test cases at
+    ``upstreamproxy.test.ts:1-43``.
+    """
+    if isinstance(content, str):
+        if not content.strip():
+            return False
+        data = content.encode('utf-8', errors='replace')
+    else:
+        if not content.strip():
+            return False
+        data = content
+    return bool(_PEM_BLOCK_RE.search(data))
+
+
+async def download_ca_bundle(
+    base_url: str,
+    system_ca_path: str | os.PathLike[str],
+    out_path: str | os.PathLike[str],
+    *,
+    timeout_seconds: float = DEFAULT_CA_FETCH_TIMEOUT_SECONDS,
+    client: httpx.AsyncClient | None = None,
+) -> bool:
+    """Fetch the CCR upstream-proxy CA, concat with system CA, write atomically.
+
+    Returns ``True`` on success, ``False`` on any failure (fail-open).
+
+    Steps:
+      1. ``GET ${base_url}/v1/code/upstreamproxy/ca-cert`` with a 5s
+         timeout. Non-2xx responses, network errors, and timeouts all
+         return ``False``.
+      2. Validate the response body via ``is_valid_pem_content``. A
+         non-PEM response (HTML/JSON/arbitrary bytes from a compromised
+         server) returns ``False`` rather than corrupting the bundle.
+      3. Read the system CA bundle. Missing file is OK — we just write
+         the CCR CA alone (TS does the same: ``catch(() => '')``).
+      4. Write the concatenated bundle atomically: write to a temp file
+         in the same directory, then ``os.rename`` (POSIX atomic).
+
+    Mirrors ``upstreamproxy.ts:266-304``. Parameter ``client`` is for
+    tests — production callers can omit and a fresh ``AsyncClient`` is
+    constructed per call.
+    """
+    out_path = Path(out_path)
+    system_ca_path = Path(system_ca_path)
+    url = f'{base_url}/v1/code/upstreamproxy/ca-cert'
+
+    try:
+        if client is None:
+            async with httpx.AsyncClient(timeout=timeout_seconds) as fresh:
+                resp = await fresh.get(url)
+        else:
+            resp = await client.get(url, timeout=timeout_seconds)
+    except (httpx.HTTPError, httpx.TimeoutException) as exc:
+        logger.warning('[upstreamproxy] ca-cert download failed: %s; proxy disabled', exc)
+        return False
+
+    if resp.status_code < 200 or resp.status_code >= 300:
+        logger.warning(
+            '[upstreamproxy] ca-cert fetch %d; proxy disabled', resp.status_code
+        )
+        return False
+
+    ccr_ca = resp.content
+    if not is_valid_pem_content(ccr_ca):
+        logger.warning(
+            '[upstreamproxy] ca-cert response is not valid PEM; proxy disabled'
+        )
+        return False
+
+    # System bundle may not exist (alpine, distroless); empty fallback
+    # matches TS ``readFile(systemCaPath, 'utf8').catch(() => '')``.
+    try:
+        system_ca = system_ca_path.read_bytes()
+    except OSError:
+        system_ca = b''
+
+    try:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        # Atomic write: same-directory tempfile + os.rename. POSIX
+        # rename is atomic when both paths are on the same filesystem.
+        # Linux/macOS guarantee this; Windows raises if dst exists, but
+        # the upstreamproxy is Linux-only in production.
+        fd, tmp_path = tempfile.mkstemp(dir=out_path.parent, prefix='.ca-bundle.', suffix='.tmp')
+        try:
+            with os.fdopen(fd, 'wb') as fh:
+                fh.write(system_ca)
+                if system_ca and not system_ca.endswith(b'\n'):
+                    fh.write(b'\n')
+                fh.write(ccr_ca)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_path, out_path)
+        except OSError:
+            # Best-effort cleanup of the tempfile on failure.
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+    except OSError as exc:
+        logger.warning('[upstreamproxy] ca-bundle write failed: %s; proxy disabled', exc)
+        return False
+    return True
+
+
+__all__ = [
+    'DEFAULT_CA_FETCH_TIMEOUT_SECONDS',
+    'download_ca_bundle',
+    'is_valid_pem_content',
+]

--- a/src/upstreamproxy/protobuf_codec.py
+++ b/src/upstreamproxy/protobuf_codec.py
@@ -1,0 +1,95 @@
+"""Hand-encoded ``UpstreamProxyChunk`` protobuf codec.
+
+Ports ``encode_chunk``/``decode_chunk`` from
+``typescript/src/upstreamproxy/relay.ts:66-103``.
+
+Wire format for ``message UpstreamProxyChunk { bytes data = 1; }``:
+    tag = (field_number << 3) | wire_type = (1 << 3) | 2 = 0x0a
+    followed by varint length, followed by the bytes.
+
+The chapter calls this out as the "10-line pattern" — for a single-field
+``bytes`` message, hand encoding is shorter than pulling in a protobuf
+runtime, and the bit manipulation is well-contained.
+
+A varint encodes an unsigned 64-bit length using 7 bits per byte plus a
+continuation bit (0x80 means "more bytes follow"). Most chunks fit in
+1-3 length bytes; bytes longer than ``MAX_CHUNK_BYTES`` (~512KB Envoy
+buffer cap) are split by the relay caller, not here.
+"""
+
+from __future__ import annotations
+
+#: Field 1, wire-type 2 (length-delimited bytes). The single byte that
+#: starts every UpstreamProxyChunk on the wire.
+WIRE_TAG_FIELD1_LEN_DELIMITED = 0x0A
+
+#: Maximum varint chain length. ``2^28`` covers up to 256MB chunks
+#: (4 bytes × 7 bits = 28 bits). Real chunks are <= 512KB, so 4 bytes
+#: of varint is the practical max — but the loop accepts up to 5 (35
+#: bits, > Envoy's 4GB hard cap on a single proto message). Matches TS
+#: ``relay.ts:99`` ``shift > 28`` overflow check.
+_MAX_VARINT_SHIFT = 28
+
+
+def encode_chunk(data: bytes) -> bytes:
+    """Encode ``data`` as a protobuf ``UpstreamProxyChunk`` message.
+
+    Wire layout: ``[0x0a][varint(len)][data...]``. Returns ``bytes``;
+    the original ``data`` is not modified.
+    """
+    n = len(data)
+    # Varint encoding: chunks of 7 bits, low-bit-first; high bit set
+    # while more bytes follow, cleared on the last byte.
+    varint = bytearray()
+    while n > 0x7F:
+        varint.append((n & 0x7F) | 0x80)
+        n >>= 7
+    varint.append(n)
+
+    out = bytearray(1 + len(varint) + len(data))
+    out[0] = WIRE_TAG_FIELD1_LEN_DELIMITED
+    out[1 : 1 + len(varint)] = varint
+    out[1 + len(varint) :] = data
+    return bytes(out)
+
+
+def decode_chunk(buf: bytes) -> bytes | None:
+    """Decode an ``UpstreamProxyChunk``. Returns the ``bytes`` field or ``None``.
+
+    Returns ``None`` for malformed input (wrong tag byte, varint
+    overflow, declared length exceeds remaining buffer). Tolerates a
+    zero-length input by returning empty bytes — the server uses that
+    as a keepalive signal.
+
+    Mirrors ``typescript/src/upstreamproxy/relay.ts:87-103``.
+    """
+    if len(buf) == 0:
+        # Server keepalive — empty payload, no header.
+        return b''
+    if buf[0] != WIRE_TAG_FIELD1_LEN_DELIMITED:
+        return None
+
+    length = 0
+    shift = 0
+    i = 1
+    while i < len(buf):
+        b = buf[i]
+        length |= (b & 0x7F) << shift
+        i += 1
+        if (b & 0x80) == 0:
+            break
+        shift += 7
+        if shift > _MAX_VARINT_SHIFT:
+            return None
+    else:
+        # Loop ran off the end without seeing the continuation-bit
+        # terminator — truncated varint.
+        return None
+
+    if i + length > len(buf):
+        # Declared length exceeds what's left in the buffer.
+        return None
+    return bytes(buf[i : i + length])
+
+
+__all__ = ['WIRE_TAG_FIELD1_LEN_DELIMITED', 'decode_chunk', 'encode_chunk']

--- a/src/upstreamproxy/ptrace_guard.py
+++ b/src/upstreamproxy/ptrace_guard.py
@@ -1,0 +1,92 @@
+"""``prctl(PR_SET_DUMPABLE, 0)`` heap-protection guard.
+
+Ports ``setNonDumpable`` from
+``typescript/src/upstreamproxy/upstreamproxy.ts:237-264``.
+
+Linux-only. Calls ``libc.prctl(PR_SET_DUMPABLE, 0, 0, 0, 0)`` via
+``ctypes``. Other platforms (macOS, Windows) silently no-op — matches TS
+Bun-FFI-or-skip behavior.
+
+Why this exists: a CCR session container reads its session token from
+``/run/ccr/session_token`` into the agent process's heap, then unlinks
+the file. Without ``PR_SET_DUMPABLE = 0``, a same-UID attacker (e.g., a
+prompt-injected ``gdb -p $PPID``) could attach via ptrace and scrape the
+token from the heap. Setting it to 0 blocks ptrace by other same-UID
+processes.
+
+Per chapter "Apply This" rule #4: *"Keep secrets heap-only in
+adversarial environments. Reading the token from a file, disabling
+ptrace, and unlinking the file eliminates both filesystem and
+memory-inspection attack vectors."*
+"""
+
+from __future__ import annotations
+
+import logging
+import platform
+
+logger = logging.getLogger(__name__)
+
+#: ``PR_SET_DUMPABLE`` operation code from ``<linux/prctl.h>``. Value 4
+#: across all kernel versions since 2.3.20.
+PR_SET_DUMPABLE = 4
+
+
+def set_non_dumpable() -> bool:
+    """Block same-UID ptrace via ``prctl(PR_SET_DUMPABLE, 0)``.
+
+    Returns ``True`` on success, ``False`` on any failure. Linux-only;
+    non-Linux platforms silently return ``False`` (no-op). Failure is
+    NEVER raised — this is a fail-open security guard, and a missing
+    libc / hardened kernel must not break the agent loop.
+    """
+    if platform.system() != 'Linux':
+        logger.debug(
+            '[upstreamproxy] non-Linux platform (%s); skipping prctl(PR_SET_DUMPABLE)',
+            platform.system(),
+        )
+        return False
+
+    try:
+        import ctypes
+    except ImportError:
+        logger.warning('[upstreamproxy] ctypes unavailable; cannot prctl')
+        return False
+
+    try:
+        # Standard glibc location. Some distros expose libc under
+        # different names; try the most common first.
+        libc = ctypes.CDLL('libc.so.6', use_errno=True)
+    except OSError:
+        try:
+            libc = ctypes.CDLL('libc.so', use_errno=True)
+        except OSError as exc:
+            logger.warning('[upstreamproxy] could not load libc: %s', exc)
+            return False
+
+    try:
+        libc.prctl.argtypes = [
+            ctypes.c_int,
+            ctypes.c_ulong,
+            ctypes.c_ulong,
+            ctypes.c_ulong,
+            ctypes.c_ulong,
+        ]
+        libc.prctl.restype = ctypes.c_int
+        rc = libc.prctl(PR_SET_DUMPABLE, 0, 0, 0, 0)
+    except (OSError, AttributeError, ValueError) as exc:
+        logger.warning('[upstreamproxy] prctl call failed: %s', exc)
+        return False
+
+    if rc != 0:
+        errno = ctypes.get_errno()
+        logger.warning(
+            '[upstreamproxy] prctl(PR_SET_DUMPABLE,0) returned nonzero rc=%d errno=%d',
+            rc,
+            errno,
+        )
+        return False
+    return True
+
+
+__all__ = ['PR_SET_DUMPABLE', 'set_non_dumpable']

--- a/src/upstreamproxy/relay.py
+++ b/src/upstreamproxy/relay.py
@@ -1,0 +1,408 @@
+"""CONNECT-over-WebSocket relay for the CCR upstream proxy.
+
+Ports ``typescript/src/upstreamproxy/relay.ts``.
+
+Listens on a localhost TCP port, accepts HTTP CONNECT from
+``curl``/``gh``/``kubectl``/etc., and tunnels bytes over a WebSocket to
+the CCR upstream proxy endpoint. The CCR server-side terminates the
+tunnel, MITMs TLS, injects org-configured credentials, and forwards to
+the real upstream.
+
+Why WebSocket and not raw CONNECT: CCR ingress is GKE L7 with
+path-prefix routing; there's no ``connect_matcher``. The session-ingress
+tunnel already uses this pattern.
+
+Wire protocol: bytes are wrapped in ``UpstreamProxyChunk`` protobuf
+messages (see ``protobuf_codec.py``) for compatibility with
+``gateway.NewWebSocketStreamAdapter`` on the server side.
+
+Implementation differences from TS:
+  - **Single asyncio implementation** — no Bun/Node fork (Python only
+    has one event loop family).
+  - ``asyncio.start_server`` provides the TCP listen surface.
+  - ``websockets.asyncio.client.connect`` provides the WS upgrade.
+  - ``StreamWriter.drain()`` provides the backpressure primitive (no
+    explicit per-socket queueing needed — Python streams buffer
+    internally and ``await drain()`` blocks the producer when full).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+import websockets
+from websockets.asyncio.client import connect as ws_connect
+
+from .protobuf_codec import decode_chunk, encode_chunk
+
+logger = logging.getLogger(__name__)
+
+#: Envoy per-request buffer cap. CONNECT payloads larger than this are
+#: split into multiple chunks. Week-1 Datadog payloads won't hit this,
+#: but design for it so e.g. ``git push`` doesn't need a relay rewrite.
+MAX_CHUNK_BYTES = 512 * 1024
+
+#: WebSocket application-level keepalive interval. Sidecar idle-timeout
+#: is 50 s; 30 s gives a comfortable margin.
+PING_INTERVAL_SECONDS = 30.0
+
+#: HTTP CONNECT request header buffer cap. Beyond this, a malformed
+#: client (or an attacker probing the relay) gets 400 Bad Request and
+#: the connection closes.
+MAX_CONNECT_HEADER_BYTES = 8 * 1024
+
+
+@dataclass
+class UpstreamProxyRelay:
+    """Handle to a running relay; ``stop()`` shuts the listener down."""
+
+    port: int
+    server: asyncio.AbstractServer = field(repr=False)
+
+    async def stop(self) -> None:
+        """Close the listener and wait for inflight handlers to drain."""
+        self.server.close()
+        await self.server.wait_closed()
+
+
+# ─── Phase 1: parse the HTTP CONNECT request ───────────────────────────────
+
+
+@dataclass
+class _ConnectRequest:
+    """Parsed CONNECT request header."""
+
+    raw_line: str  # full request-line, e.g. "CONNECT example.com:443 HTTP/1.1"
+    target: str  # the host:port part
+    trailing_bytes: bytes  # bytes that arrived AFTER the CRLFCRLF header end
+
+
+async def _read_connect_request(
+    reader: asyncio.StreamReader,
+) -> _ConnectRequest | str:
+    """Read until CRLFCRLF; return parsed request OR an error string for a 4xx.
+
+    The string variant is the response body to send to the client before
+    closing (e.g. ``'HTTP/1.1 400 Bad Request\r\n\r\n'``).
+
+    Mirrors ``relay.ts:295-333`` ``handleData`` Phase 1.
+    """
+    buf = bytearray()
+    while True:
+        chunk = await reader.read(4096)
+        if not chunk:
+            return 'HTTP/1.1 400 Bad Request\r\n\r\n'
+        buf.extend(chunk)
+        end = buf.find(b'\r\n\r\n')
+        if end != -1:
+            break
+        if len(buf) > MAX_CONNECT_HEADER_BYTES:
+            return 'HTTP/1.1 400 Bad Request\r\n\r\n'
+
+    head = buf[:end].decode('utf-8', errors='replace')
+    trailing = bytes(buf[end + 4 :])
+    first_line = head.split('\r\n', 1)[0]
+    parts = first_line.split()
+    if (
+        len(parts) != 3
+        or parts[0].upper() != 'CONNECT'
+        or not parts[2].upper().startswith('HTTP/1.')
+    ):
+        return 'HTTP/1.1 405 Method Not Allowed\r\n\r\n'
+    target = parts[1]
+    return _ConnectRequest(raw_line=first_line, target=target, trailing_bytes=trailing)
+
+
+# ─── Phase 2: tunnel bytes between the client TCP socket and the WS ────────
+
+
+async def _pump_client_to_ws(
+    reader: asyncio.StreamReader,
+    ws: websockets.asyncio.client.ClientConnection,
+    initial: bytes,
+) -> None:
+    """Read from the local TCP client; encode each chunk; send over the WS.
+
+    Splits chunks larger than ``MAX_CHUNK_BYTES``. Exits on EOF or any
+    socket error; the caller's ``handle_connection`` task-group catches
+    the resulting cancellation.
+    """
+    async def _send(data: bytes) -> None:
+        for off in range(0, len(data), MAX_CHUNK_BYTES):
+            slice_ = data[off : off + MAX_CHUNK_BYTES]
+            await ws.send(encode_chunk(slice_))
+
+    if initial:
+        await _send(initial)
+
+    while True:
+        try:
+            chunk = await reader.read(MAX_CHUNK_BYTES)
+        except (ConnectionError, OSError):
+            return
+        if not chunk:
+            return
+        try:
+            await _send(chunk)
+        except (websockets.exceptions.ConnectionClosed, ConnectionError, OSError):
+            return
+
+
+async def _pump_ws_to_client(
+    ws: websockets.asyncio.client.ClientConnection,
+    writer: asyncio.StreamWriter,
+    on_first_payload: Callable[[], None],
+) -> None:
+    """Read encoded chunks from the WS; decode; write to the TCP client.
+
+    ``on_first_payload`` is fired exactly once when the first non-empty
+    decoded chunk arrives. The relay uses this to flip the
+    ``established`` flag: after the first byte the TCP stream is
+    carrying TLS, and writing a plaintext 502 would corrupt it.
+    """
+    fired = False
+    try:
+        async for raw in ws:
+            if isinstance(raw, str):
+                # CCR upstream sends only binary frames; ignore text.
+                continue
+            payload = decode_chunk(raw)
+            if payload is None or not payload:
+                # Malformed or zero-length keepalive — drop silently.
+                continue
+            if not fired:
+                fired = True
+                on_first_payload()
+            try:
+                writer.write(payload)
+                await writer.drain()
+            except (ConnectionError, OSError):
+                return
+    except websockets.exceptions.ConnectionClosed:
+        return
+
+
+async def _keepalive(
+    ws: websockets.asyncio.client.ClientConnection,
+    interval: float = PING_INTERVAL_SECONDS,
+) -> None:
+    """Application-level keepalive — empty chunks the server can ignore.
+
+    The ``websockets`` library has its own protocol-level ping
+    (``ping_interval`` constructor kwarg) but we send the empty-chunk
+    keepalive too, matching TS. Either is enough on its own; both
+    together give belt-and-suspenders coverage.
+    """
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            await ws.send(encode_chunk(b''))
+        except (websockets.exceptions.ConnectionClosed, OSError):
+            return
+
+
+# ─── Connection handler ────────────────────────────────────────────────────
+
+
+async def _handle_connection(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    ws_url: str,
+    auth_header: str,
+    ws_auth_header: str,
+) -> None:
+    """One accepted TCP connection: parse CONNECT, open WS, pump bytes.
+
+    Mirrors ``relay.ts:344-428`` ``openTunnel``.
+    """
+    parsed = await _read_connect_request(reader)
+    if isinstance(parsed, str):
+        try:
+            writer.write(parsed.encode('ascii'))
+            await writer.drain()
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except (ConnectionError, OSError):
+                pass
+        return
+
+    # Open the WebSocket. The server upgrade requires:
+    #   - Authorization: Bearer <token>            (auth on the WS itself)
+    #   - Content-Type: application/proto          (so the server picks
+    #     binary-proto framing, not the JSON default)
+    # Bytes that arrived after the CONNECT header (TCP coalesces CONNECT
+    # + ClientHello into one packet under heavy load) are flushed first.
+    headers = {
+        'Authorization': ws_auth_header,
+        'Content-Type': 'application/proto',
+    }
+    try:
+        ws = await ws_connect(
+            ws_url,
+            additional_headers=headers,
+            ping_interval=None,  # we do app-level keepalive ourselves
+        )
+    except (websockets.exceptions.WebSocketException, ConnectionError, OSError) as exc:
+        logger.warning('[upstreamproxy] ws upgrade failed: %s', exc)
+        try:
+            writer.write(b'HTTP/1.1 502 Bad Gateway\r\n\r\n')
+            await writer.drain()
+        except (ConnectionError, OSError):
+            pass
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except (ConnectionError, OSError):
+                pass
+        return
+
+    # First chunk over the tunnel is the CONNECT request line plus
+    # ``Proxy-Authorization: Basic <session_id>:<token>`` so the server
+    # can authenticate the tunnel target. The server responds with its
+    # own ``HTTP/1.1 200 ...`` over the tunnel; we just pipe it through
+    # to the local client.
+    head = (
+        f'{parsed.raw_line}\r\n'
+        f'Proxy-Authorization: {auth_header}\r\n'
+        f'\r\n'
+    ).encode('ascii')
+
+    established = False
+
+    def _mark_established() -> None:
+        nonlocal established
+        established = True
+
+    c2s_task: asyncio.Task[None] | None = None
+    s2c_task: asyncio.Task[None] | None = None
+    ka_task: asyncio.Task[None] | None = None
+    try:
+        # Send the head-chunk first, then any trailing bytes from the
+        # CONNECT packet, then start pumping live data.
+        await ws.send(encode_chunk(head))
+
+        # Pumps run in parallel; whichever exits first triggers teardown
+        # of the others. ``TaskGroup`` would wait for ALL tasks to
+        # complete — fine for the happy-path race-free case, but s2c
+        # never returns until the WS closes, and the WS closes only when
+        # we close it. So we use ``asyncio.wait(FIRST_COMPLETED)`` to
+        # detect the first pump's exit and cancel the rest.
+        loop = asyncio.get_running_loop()
+        c2s_task = loop.create_task(
+            _pump_client_to_ws(reader, ws, parsed.trailing_bytes),
+            name='upstreamproxy-c2s',
+        )
+        s2c_task = loop.create_task(
+            _pump_ws_to_client(ws, writer, _mark_established),
+            name='upstreamproxy-s2c',
+        )
+        ka_task = loop.create_task(_keepalive(ws), name='upstreamproxy-ka')
+
+        await asyncio.wait(
+            [c2s_task, s2c_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+    except (
+        websockets.exceptions.ConnectionClosed,
+        ConnectionError,
+        OSError,
+        asyncio.CancelledError,
+    ) as exc:
+        logger.debug('[upstreamproxy] connection setup exited: %s', exc)
+    finally:
+        # Cancel any pump that's still running so we don't leak tasks.
+        for task in (c2s_task, s2c_task, ka_task):
+            if task is not None and not task.done():
+                task.cancel()
+        # Wait for cancellations to propagate; suppress noise.
+        for task in (c2s_task, s2c_task, ka_task):
+            if task is None:
+                continue
+            try:
+                await task
+            except (
+                websockets.exceptions.ConnectionClosed,
+                ConnectionError,
+                OSError,
+                asyncio.CancelledError,
+            ):
+                pass
+            except Exception as exc:  # noqa: BLE001 -- shutdown noise; never propagate
+                logger.debug('[upstreamproxy] pump cleanup exception: %s', exc)
+        # If we never received a server payload, the client is still
+        # waiting for the CONNECT response — send 502 before closing.
+        if not established:
+            try:
+                writer.write(b'HTTP/1.1 502 Bad Gateway\r\n\r\n')
+                await writer.drain()
+            except (ConnectionError, OSError):
+                pass
+        try:
+            await ws.close()
+        except (ConnectionError, OSError):
+            pass
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except (ConnectionError, OSError):
+            pass
+
+
+# ─── Public entry point ────────────────────────────────────────────────────
+
+
+async def start_upstream_proxy_relay(
+    *,
+    ws_url: str,
+    session_id: str,
+    token: str,
+    host: str = '127.0.0.1',
+    port: int = 0,
+) -> UpstreamProxyRelay:
+    """Start the CONNECT-over-WS relay listener.
+
+    Returns an ``UpstreamProxyRelay`` whose ``port`` is the actual
+    bound port (ephemeral when ``port=0``) and whose ``stop()`` shuts
+    the listener down.
+
+    The WS upgrade itself is auth-gated (the gateway wants the
+    session-ingress JWT on the upgrade); the inner CONNECT carries
+    ``Proxy-Authorization: Basic`` for the tunnel target. The two
+    headers are different roles even though they share the same token.
+    """
+    auth_header = (
+        'Basic '
+        + base64.b64encode(f'{session_id}:{token}'.encode('utf-8')).decode('ascii')
+    )
+    ws_auth_header = f'Bearer {token}'
+
+    server = await asyncio.start_server(
+        lambda r, w: _handle_connection(r, w, ws_url, auth_header, ws_auth_header),
+        host=host,
+        port=port,
+    )
+
+    sockets = server.sockets or ()
+    if not sockets:
+        raise RuntimeError('upstreamproxy: server has no listening socket')
+    bound_port = sockets[0].getsockname()[1]
+    logger.debug(
+        '[upstreamproxy] relay listening on %s:%d', host, bound_port
+    )
+    return UpstreamProxyRelay(port=bound_port, server=server)
+
+
+__all__ = [
+    'MAX_CHUNK_BYTES',
+    'MAX_CONNECT_HEADER_BYTES',
+    'PING_INTERVAL_SECONDS',
+    'UpstreamProxyRelay',
+    'start_upstream_proxy_relay',
+]

--- a/src/upstreamproxy/upstream_proxy.py
+++ b/src/upstreamproxy/upstream_proxy.py
@@ -1,0 +1,287 @@
+"""CCR upstream-proxy initialization + env-var derivation.
+
+Ports ``initUpstreamProxy``, ``getUpstreamProxyEnv``,
+``resetUpstreamProxyForTests`` from
+``typescript/src/upstreamproxy/upstreamproxy.ts:79-204``.
+
+Lifecycle (the chapter's 6-step ordered setup at §"Upstream Proxy"):
+    1. Read ``/run/ccr/session_token`` (or override).
+    2. ``prctl(PR_SET_DUMPABLE, 0)`` to block same-UID ptrace.
+    3. Download CA cert + concat with system bundle.
+    4. Start CONNECT-over-WS relay on an ephemeral port.
+    5. Unlink the token file (only AFTER the listener is up — a
+       supervisor restart can retry with the token still on disk).
+    6. Export ``HTTPS_PROXY``/``SSL_CERT_FILE``/etc. env vars for child
+       subprocesses (``getUpstreamProxyEnv()``).
+
+Two env-var gates: ``CLAUDE_CODE_REMOTE`` AND
+``CCR_UPSTREAM_PROXY_ENABLED`` MUST both be truthy. Plus
+``CLAUDE_CODE_REMOTE_SESSION_ID`` MUST be set. If any gate is off, the
+proxy is disabled — without these gates the proxy would MITM traffic
+in non-CCR contexts.
+
+**Fail-open everywhere.** Any error during init returns the disabled
+state sentinel (``UpstreamProxyState(enabled=False)``); the agent loop
+keeps running with no proxy. This matches chapter "Apply This" rule #5:
+*"The upstream proxy fails open because it provides enhanced
+functionality (credential injection), not core functionality (model
+inference)."*
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.bridge.no_proxy import default_no_proxy
+
+from .ca_bundle import download_ca_bundle
+from .ptrace_guard import set_non_dumpable
+from .relay import UpstreamProxyRelay, start_upstream_proxy_relay
+
+logger = logging.getLogger(__name__)
+
+#: Default location of the session-token file inside a CCR container.
+SESSION_TOKEN_PATH = '/run/ccr/session_token'
+
+#: Default location of the system CA bundle on Debian/Ubuntu CCR base
+#: images. macOS dev environments use this path too via Homebrew's
+#: ``ca-certificates``.
+SYSTEM_CA_BUNDLE = '/etc/ssl/certs/ca-certificates.crt'
+
+#: Default location of the merged CCR + system CA bundle.
+def _default_ca_bundle_out() -> Path:
+    return Path.home() / '.ccr' / 'ca-bundle.crt'
+
+
+@dataclass(frozen=True)
+class UpstreamProxyState:
+    """Disabled-or-enabled state sentinel (returned by ``init_upstream_proxy``).
+
+    When ``enabled`` is ``False``, ``port`` and ``ca_bundle_path`` are
+    ``None``; when ``enabled`` is ``True``, both are set.
+    """
+
+    enabled: bool
+    port: int | None = None
+    ca_bundle_path: str | None = None
+    relay: UpstreamProxyRelay | None = None
+
+
+_DISABLED = UpstreamProxyState(enabled=False)
+
+# Module-level state. ``init_upstream_proxy`` writes; ``get_upstream_proxy_env``
+# reads. Per A11 + chapter §"Apply This" rule #5, all writes are fail-open
+# (errors return DISABLED; never raise).
+_state: UpstreamProxyState = _DISABLED
+
+
+def _is_env_truthy(value: str | None) -> bool:
+    """Truthy test matching ``isEnvTruthy`` semantics in TS.
+
+    Returns ``True`` when value is non-empty and not one of
+    ``"0", "false", "no", "off"`` (case-insensitive). Mirrors the Bun
+    helper that gates ``initUpstreamProxy``.
+    """
+    if value is None:
+        return False
+    return value.lower() not in ('', '0', 'false', 'no', 'off')
+
+
+async def init_upstream_proxy(
+    *,
+    token_path: str | os.PathLike[str] | None = None,
+    system_ca_path: str | os.PathLike[str] | None = None,
+    ca_bundle_path: str | os.PathLike[str] | None = None,
+    ccr_base_url: str | None = None,
+) -> UpstreamProxyState:
+    """Initialize the CCR upstream proxy.
+
+    Returns the resulting state. Safe to call from non-CCR contexts —
+    the env-var gates short-circuit and ``DISABLED`` is returned with no
+    side effects. All overrides are for tests; production callers omit
+    them.
+
+    The function is idempotent only via the disabled-on-failure path:
+    if a previous call set ``_state`` to enabled, calling again does NOT
+    re-init. Tests should call ``reset_for_tests`` between cases.
+    """
+    global _state
+
+    # Gate 1: ``CLAUDE_CODE_REMOTE``.
+    if not _is_env_truthy(os.environ.get('CLAUDE_CODE_REMOTE')):
+        return _state
+
+    # Gate 2: ``CCR_UPSTREAM_PROXY_ENABLED``. CCR injects this from
+    # ``StartupContext.EnvironmentVariables`` so the GrowthBook
+    # decision is server-side (each container is a fresh process with
+    # no GB cache, so a client-side check would always default to false).
+    if not _is_env_truthy(os.environ.get('CCR_UPSTREAM_PROXY_ENABLED')):
+        return _state
+
+    # Gate 3: session ID (used in the ``Proxy-Authorization: Basic``
+    # tunnel header).
+    session_id = os.environ.get('CLAUDE_CODE_REMOTE_SESSION_ID')
+    if not session_id:
+        logger.warning(
+            '[upstreamproxy] CLAUDE_CODE_REMOTE_SESSION_ID unset; proxy disabled'
+        )
+        return _state
+
+    # Step 1: read the session token.
+    token_path = Path(token_path) if token_path is not None else Path(SESSION_TOKEN_PATH)
+    token = await _read_token(token_path)
+    if not token:
+        logger.debug('[upstreamproxy] no session token file; proxy disabled')
+        return _state
+
+    # Step 2: ptrace guard (Linux-only; no-op elsewhere).
+    set_non_dumpable()
+
+    # Step 3: resolve base URL and download the CA bundle.
+    base_url = (
+        ccr_base_url
+        or os.environ.get('ANTHROPIC_BASE_URL')
+        or 'https://api.anthropic.com'
+    )
+    ca_bundle_resolved = (
+        Path(ca_bundle_path) if ca_bundle_path is not None else _default_ca_bundle_out()
+    )
+    system_ca_resolved = (
+        Path(system_ca_path) if system_ca_path is not None else Path(SYSTEM_CA_BUNDLE)
+    )
+    ok = await download_ca_bundle(
+        base_url=base_url,
+        system_ca_path=system_ca_resolved,
+        out_path=ca_bundle_resolved,
+    )
+    if not ok:
+        return _state  # download_ca_bundle already logged the reason
+
+    # Step 4: start the relay (ephemeral port).
+    ws_url = base_url.replace('http://', 'ws://', 1).replace('https://', 'wss://', 1)
+    ws_url = ws_url.rstrip('/') + '/v1/code/upstreamproxy/ws'
+    try:
+        relay = await start_upstream_proxy_relay(
+            ws_url=ws_url, session_id=session_id, token=token
+        )
+    except Exception as exc:  # noqa: BLE001 -- fail-open per A11
+        logger.warning(
+            '[upstreamproxy] relay start failed: %s; proxy disabled', exc
+        )
+        return _state
+
+    # Step 5: unlink the token file (now that the relay is up — a
+    # supervisor restart before this point can retry with the token
+    # still on disk).
+    try:
+        token_path.unlink()
+    except FileNotFoundError:
+        pass  # already gone — fine
+    except OSError:
+        logger.warning('[upstreamproxy] token file unlink failed', exc_info=True)
+
+    _state = UpstreamProxyState(
+        enabled=True,
+        port=relay.port,
+        ca_bundle_path=str(ca_bundle_resolved),
+        relay=relay,
+    )
+    logger.info('[upstreamproxy] enabled on 127.0.0.1:%d', relay.port)
+    return _state
+
+
+def get_upstream_proxy_env() -> dict[str, str]:
+    """Env-var dict for child subprocesses (Bash/MCP/LSP/hooks).
+
+    When the proxy is enabled: returns the 9-var recipe
+    (``HTTPS_PROXY``/``https_proxy``/``NO_PROXY``/``no_proxy``/
+    ``SSL_CERT_FILE``/``NODE_EXTRA_CA_CERTS``/``REQUESTS_CA_BUNDLE``/
+    ``CURL_CA_BUNDLE``). The TS recipe also sets ``proxy`` in lowercase
+    via ``HTTPS_PROXY`` lowercase variant; we follow the same pattern.
+
+    When the proxy is disabled: if the parent already has both
+    ``HTTPS_PROXY`` and ``SSL_CERT_FILE`` set, we inherit those
+    (handles the case where a child CLI process can't re-init the
+    relay — token file already unlinked — but the parent's relay is
+    still running and reachable). Otherwise returns empty dict.
+
+    Mirrors ``upstreamproxy.ts:160-199``.
+    """
+    if _state.enabled and _state.port is not None and _state.ca_bundle_path is not None:
+        proxy_url = f'http://127.0.0.1:{_state.port}'
+        no_proxy = default_no_proxy()
+        ca = _state.ca_bundle_path
+        return {
+            'HTTPS_PROXY': proxy_url,
+            'https_proxy': proxy_url,
+            'NO_PROXY': no_proxy,
+            'no_proxy': no_proxy,
+            'SSL_CERT_FILE': ca,
+            'NODE_EXTRA_CA_CERTS': ca,
+            'REQUESTS_CA_BUNDLE': ca,
+            'CURL_CA_BUNDLE': ca,
+        }
+
+    # Disabled-but-inherited path: child CLI processes can't re-init
+    # the relay (token file already unlinked by parent), but the
+    # parent's relay is still reachable on 127.0.0.1:<port>. Pass
+    # through the parent's proxy env so subprocess inherits the
+    # same routing.
+    if os.environ.get('HTTPS_PROXY') and os.environ.get('SSL_CERT_FILE'):
+        inherited: dict[str, str] = {}
+        for key in (
+            'HTTPS_PROXY',
+            'https_proxy',
+            'NO_PROXY',
+            'no_proxy',
+            'SSL_CERT_FILE',
+            'NODE_EXTRA_CA_CERTS',
+            'REQUESTS_CA_BUNDLE',
+            'CURL_CA_BUNDLE',
+        ):
+            value = os.environ.get(key)
+            if value is not None:
+                inherited[key] = value
+        return inherited
+    return {}
+
+
+def reset_for_tests() -> None:
+    """Reset module state to DISABLED. Test-only helper."""
+    global _state
+    _state = _DISABLED
+
+
+async def _read_token(path: Path) -> str | None:
+    """Read and trim the session token from ``path``.
+
+    Returns ``None`` for missing file, empty content, or any read error.
+    """
+    try:
+        # We use ``run_in_executor`` to keep async semantics; the file
+        # is small but reading from /run/ccr/* on a slow tmpfs is
+        # non-instant under contention.
+        import asyncio
+
+        loop = asyncio.get_running_loop()
+        raw = await loop.run_in_executor(None, path.read_text, 'utf-8')
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        logger.warning('[upstreamproxy] token read failed: %s', exc)
+        return None
+    token = raw.strip()
+    return token if token else None
+
+
+__all__ = [
+    'SESSION_TOKEN_PATH',
+    'SYSTEM_CA_BUNDLE',
+    'UpstreamProxyState',
+    'get_upstream_proxy_env',
+    'init_upstream_proxy',
+    'reset_for_tests',
+]

--- a/tests/bridge/conftest.py
+++ b/tests/bridge/conftest.py
@@ -1,0 +1,22 @@
+"""Shared test helpers for ``tests/bridge/``."""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+
+def make_jwt(payload: dict[str, Any]) -> str:
+    """Build a synthetic JWT for tests.
+
+    Used by ``test_jwt_utils`` and ``test_token_refresh_scheduler``. No
+    signature verification is performed by the production code, so a
+    fake signature segment is fine.
+    """
+    header = base64.urlsafe_b64encode(b'{"alg":"none","typ":"JWT"}').rstrip(b'=').decode('ascii')
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode('utf-8')).rstrip(b'=').decode('ascii')
+    return f'{header}.{body}.signature'
+
+
+__all__ = ['make_jwt']

--- a/tests/bridge/test_bounded_uuid_set.py
+++ b/tests/bridge/test_bounded_uuid_set.py
@@ -1,0 +1,111 @@
+"""Tests for ``src.bridge.bounded_uuid_set.BoundedUUIDSet``."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.bridge.bounded_uuid_set import DEFAULT_CAPACITY, BoundedUUIDSet
+
+
+def test_default_capacity_is_2000() -> None:
+    s = BoundedUUIDSet()
+    assert s.capacity == 2000
+    assert s.capacity == DEFAULT_CAPACITY
+
+
+def test_zero_or_negative_capacity_rejected() -> None:
+    with pytest.raises(ValueError):
+        BoundedUUIDSet(0)
+    with pytest.raises(ValueError):
+        BoundedUUIDSet(-1)
+
+
+def test_add_then_has_returns_true() -> None:
+    s = BoundedUUIDSet(10)
+    s.add('abc')
+    assert s.has('abc')
+    assert 'abc' in s
+
+
+def test_has_returns_false_for_unknown() -> None:
+    s = BoundedUUIDSet(10)
+    assert not s.has('xyz')
+
+
+def test_capacity_one_evicts_immediately() -> None:
+    s = BoundedUUIDSet(1)
+    s.add('a')
+    assert s.has('a')
+    s.add('b')
+    assert s.has('b')
+    assert not s.has('a'), 'capacity-1 set should evict the only old entry'
+    assert len(s) == 1
+
+
+def test_fifo_eviction_order() -> None:
+    s = BoundedUUIDSet(3)
+    s.add('a')
+    s.add('b')
+    s.add('c')
+    assert len(s) == 3
+    s.add('d')  # evicts 'a'
+    assert not s.has('a')
+    for u in ('b', 'c', 'd'):
+        assert s.has(u)
+    s.add('e')  # evicts 'b'
+    assert not s.has('b')
+    assert s.has('c')
+    assert s.has('d')
+    assert s.has('e')
+
+
+def test_add_idempotent_no_lru_bump() -> None:
+    """Re-adding an existing UUID must NOT bump its LRU position.
+
+    Mirrors TS ``:441`` early-return-when-already-present.
+    """
+    s = BoundedUUIDSet(3)
+    s.add('a')
+    s.add('b')
+    s.add('c')
+    s.add('a')  # no-op — does NOT make 'a' the youngest entry
+    s.add('d')  # evicts 'a' (the original oldest)
+    assert not s.has('a')
+    assert s.has('b')
+    assert s.has('c')
+    assert s.has('d')
+
+
+def test_clear_resets_to_empty() -> None:
+    s = BoundedUUIDSet(3)
+    s.add('a')
+    s.add('b')
+    assert len(s) == 2
+    s.clear()
+    assert len(s) == 0
+    assert not s.has('a')
+    s.add('c')
+    assert s.has('c')
+
+
+def test_large_capacity_stress() -> None:
+    """Add 5*N items into a capacity-N set; only the last N are present."""
+    n = 100
+    s = BoundedUUIDSet(n)
+    for i in range(5 * n):
+        s.add(f'uuid-{i}')
+    assert len(s) == n
+    # The last N (i = 4n .. 5n-1) should remain.
+    for i in range(4 * n, 5 * n):
+        assert s.has(f'uuid-{i}')
+    # The first 4*N should be evicted.
+    for i in range(4 * n):
+        assert not s.has(f'uuid-{i}')
+
+
+def test_contains_rejects_non_string() -> None:
+    s = BoundedUUIDSet(3)
+    s.add('a')
+    assert 'a' in s
+    assert 123 not in s  # non-string should not raise
+    assert None not in s

--- a/tests/bridge/test_close_codes.py
+++ b/tests/bridge/test_close_codes.py
@@ -1,0 +1,26 @@
+"""Tests for ``src.bridge.close_codes`` constants."""
+
+from __future__ import annotations
+
+from src.bridge import close_codes
+
+
+def test_constants_match_typescript_source() -> None:
+    """These literal values are wire-protocol surface and must not drift."""
+    assert close_codes.WS_CLOSE_EPOCH_MISMATCH == 4090
+    assert close_codes.WS_CLOSE_INIT_FAILURE == 4091
+    assert close_codes.WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED == 4092
+    assert close_codes.WS_CLOSE_PERMANENT_UNAUTHORIZED == 4003
+    assert close_codes.WS_CLOSE_SESSION_NOT_FOUND == 4001
+
+
+def test_codes_are_distinct() -> None:
+    """Each close-code has a distinct meaning; collision would be a bug."""
+    codes = {
+        close_codes.WS_CLOSE_EPOCH_MISMATCH,
+        close_codes.WS_CLOSE_INIT_FAILURE,
+        close_codes.WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED,
+        close_codes.WS_CLOSE_PERMANENT_UNAUTHORIZED,
+        close_codes.WS_CLOSE_SESSION_NOT_FOUND,
+    }
+    assert len(codes) == 5

--- a/tests/bridge/test_code_session_api.py
+++ b/tests/bridge/test_code_session_api.py
@@ -1,0 +1,253 @@
+"""Tests for ``src.bridge.code_session_api``."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from src.bridge.code_session_api import (
+    create_code_session,
+    fetch_remote_credentials,
+    register_worker,
+)
+
+
+# ─── create_code_session ────────────────────────────────────────────────
+
+
+class TestCreateCodeSession:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_session_id(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            assert req.method == 'POST'
+            assert req.url.path == '/v1/code/sessions'
+            body = json.loads(req.content)
+            assert body['title'] == 'My Session'
+            assert body['bridge'] == {}
+            return httpx.Response(201, json={'session': {'id': 'cse_abc'}})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            sid = await create_code_session(
+                'https://api.test', 'tok', 'My Session', client=client,
+            )
+        assert sid == 'cse_abc'
+
+    @pytest.mark.asyncio
+    async def test_passes_tags_when_provided(self):
+        captured: list[dict] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured.append(json.loads(req.content))
+            return httpx.Response(201, json={'session': {'id': 'cse_xyz'}})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            await create_code_session(
+                'https://api.test', 'tok', 'Title', tags=['a', 'b'], client=client,
+            )
+        assert captured[0]['tags'] == ['a', 'b']
+
+    @pytest.mark.asyncio
+    async def test_omits_tags_when_empty(self):
+        captured: list[dict] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured.append(json.loads(req.content))
+            return httpx.Response(201, json={'session': {'id': 'cse_xyz'}})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            await create_code_session(
+                'https://api.test', 'tok', 'Title', tags=[], client=client,
+            )
+        assert 'tags' not in captured[0]
+
+    @pytest.mark.asyncio
+    async def test_non_2xx_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, content=b'unavailable')
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            sid = await create_code_session('https://api.test', 'tok', 't', client=client)
+        assert sid is None
+
+    @pytest.mark.asyncio
+    async def test_network_error_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError('refused')
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            sid = await create_code_session('https://api.test', 'tok', 't', client=client)
+        assert sid is None
+
+    @pytest.mark.asyncio
+    async def test_missing_session_id_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(201, json={'session': {}})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            sid = await create_code_session('https://api.test', 'tok', 't', client=client)
+        assert sid is None
+
+    @pytest.mark.asyncio
+    async def test_non_cse_prefix_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(201, json={'session': {'id': 'wrong_prefix'}})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            sid = await create_code_session('https://api.test', 'tok', 't', client=client)
+        assert sid is None
+
+
+# ─── fetch_remote_credentials ───────────────────────────────────────────
+
+
+class TestFetchRemoteCredentials:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_credentials(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            assert req.url.path == '/v1/code/sessions/cse_abc/bridge'
+            return httpx.Response(200, json={
+                'worker_jwt': 'jwt-tok',
+                'api_base_url': 'https://api.test',
+                'expires_in': 3600,
+                'worker_epoch': 5,
+            })
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            creds = await fetch_remote_credentials(
+                'cse_abc', 'https://api.test', 'tok', client=client,
+            )
+        assert creds is not None
+        assert creds.worker_jwt == 'jwt-tok'
+        assert creds.expires_in == 3600
+        assert creds.worker_epoch == 5
+
+    @pytest.mark.asyncio
+    async def test_handles_string_encoded_int64_epoch(self):
+        """Per A12 + critic: protojson sometimes serializes int64 as string."""
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={
+                'worker_jwt': 'jwt',
+                'api_base_url': 'https://api.test',
+                'expires_in': 60,
+                'worker_epoch': '42',
+            })
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            creds = await fetch_remote_credentials(
+                'cse', 'https://api.test', 'tok', client=client,
+            )
+        assert creds is not None
+        assert creds.worker_epoch == 42
+
+    @pytest.mark.asyncio
+    async def test_passes_trusted_device_token_header(self):
+        captured: list[dict] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured.append(dict(req.headers))
+            return httpx.Response(200, json={
+                'worker_jwt': 'j', 'api_base_url': 'u',
+                'expires_in': 1, 'worker_epoch': 0,
+            })
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            await fetch_remote_credentials(
+                'cse', 'https://api.test', 'tok',
+                trusted_device_token='td-tok', client=client,
+            )
+        assert captured[0]['x-trusted-device-token'] == 'td-tok'
+
+    @pytest.mark.asyncio
+    async def test_missing_worker_jwt_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={
+                'api_base_url': 'u', 'expires_in': 1, 'worker_epoch': 0,
+            })
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            creds = await fetch_remote_credentials(
+                'cse', 'https://api.test', 'tok', client=client,
+            )
+        assert creds is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_epoch_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={
+                'worker_jwt': 'j', 'api_base_url': 'u',
+                'expires_in': 1, 'worker_epoch': 'not a number',
+            })
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            creds = await fetch_remote_credentials(
+                'cse', 'https://api.test', 'tok', client=client,
+            )
+        assert creds is None
+
+    @pytest.mark.asyncio
+    async def test_non_200_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(401, content=b'unauthorized')
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            creds = await fetch_remote_credentials(
+                'cse', 'https://api.test', 'tok', client=client,
+            )
+        assert creds is None
+
+
+# ─── register_worker ───────────────────────────────────────────────────
+
+
+class TestRegisterWorker:
+    @pytest.mark.asyncio
+    async def test_returns_int_epoch(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            assert req.url.path.endswith('/worker/register')
+            return httpx.Response(200, json={'worker_epoch': 7})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            epoch = await register_worker(
+                'https://api.test/v1/code/sessions/cse_abc', 'tok', client=client,
+            )
+        assert epoch == 7
+
+    @pytest.mark.asyncio
+    async def test_string_encoded_epoch_coerced(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={'worker_epoch': '99'})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            epoch = await register_worker(
+                'https://api.test/v1/code/sessions/cse', 'tok', client=client,
+            )
+        assert epoch == 99
+
+    @pytest.mark.asyncio
+    async def test_missing_epoch_raises(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            with pytest.raises(RuntimeError, match='missing worker_epoch'):
+                await register_worker('https://x', 'tok', client=client)
+
+    @pytest.mark.asyncio
+    async def test_non_2xx_raises(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(403)
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            with pytest.raises(RuntimeError, match='unexpected status'):
+                await register_worker('https://x', 'tok', client=client)
+
+    @pytest.mark.asyncio
+    async def test_network_error_raises(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError('refused')
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            with pytest.raises(RuntimeError, match='register_worker failed'):
+                await register_worker('https://x', 'tok', client=client)

--- a/tests/bridge/test_flush_gate.py
+++ b/tests/bridge/test_flush_gate.py
@@ -1,0 +1,81 @@
+"""Tests for ``src.bridge.flush_gate.FlushGate``."""
+
+from __future__ import annotations
+
+from src.bridge.flush_gate import FlushGate
+
+
+def test_initial_state_inactive() -> None:
+    g: FlushGate[int] = FlushGate()
+    assert g.active is False
+    assert g.pending_count == 0
+
+
+def test_enqueue_when_inactive_returns_false() -> None:
+    g: FlushGate[int] = FlushGate()
+    assert g.enqueue(1) is False
+    assert g.pending_count == 0
+
+
+def test_enqueue_when_active_returns_true_and_queues() -> None:
+    g: FlushGate[int] = FlushGate()
+    g.start()
+    assert g.active
+    assert g.enqueue(1) is True
+    assert g.enqueue(2, 3) is True
+    assert g.pending_count == 3
+
+
+def test_end_drains_in_arrival_order_and_clears_active() -> None:
+    g: FlushGate[str] = FlushGate()
+    g.start()
+    g.enqueue('a')
+    g.enqueue('b', 'c')
+    drained = g.end()
+    assert drained == ['a', 'b', 'c']
+    assert g.active is False
+    assert g.pending_count == 0
+    # After end, enqueue is no longer active.
+    assert g.enqueue('d') is False
+
+
+def test_drop_returns_count_and_clears_pending() -> None:
+    g: FlushGate[int] = FlushGate()
+    g.start()
+    g.enqueue(1, 2, 3)
+    assert g.drop() == 3
+    assert g.active is False
+    assert g.pending_count == 0
+
+
+def test_deactivate_clears_active_but_keeps_pending() -> None:
+    """Used when transport is replaced — new transport's flush will drain."""
+    g: FlushGate[int] = FlushGate()
+    g.start()
+    g.enqueue(1, 2)
+    g.deactivate()
+    assert g.active is False
+    # pending items are NOT dropped — they survive the deactivate.
+    assert g.pending_count == 2
+    drained = g.end()
+    assert drained == [1, 2]
+
+
+def test_multiple_start_end_cycles() -> None:
+    g: FlushGate[int] = FlushGate()
+    for cycle in range(3):
+        g.start()
+        g.enqueue(cycle)
+        assert g.end() == [cycle]
+        assert g.active is False
+
+
+def test_generic_type_preserved() -> None:
+    """FlushGate is generic — items round-trip through with their type."""
+    g: FlushGate[dict[str, int]] = FlushGate()
+    g.start()
+    item = {'a': 1, 'b': 2}
+    g.enqueue(item)
+    drained = g.end()
+    assert drained == [item]
+    assert drained[0] is item, 'items should not be copied'

--- a/tests/bridge/test_jwt_utils.py
+++ b/tests/bridge/test_jwt_utils.py
@@ -1,0 +1,62 @@
+"""Tests for the JWT decoder half of ``src.bridge.jwt_utils``."""
+
+from __future__ import annotations
+
+import base64
+import time
+
+from src.bridge.jwt_utils import decode_jwt_expiry, decode_jwt_payload
+
+from .conftest import make_jwt
+
+
+def test_decode_payload_valid_jwt() -> None:
+    expiry = int(time.time()) + 3600
+    token = make_jwt({'exp': expiry, 'sub': 'me'})
+    payload = decode_jwt_payload(token)
+    assert payload is not None
+    assert payload['exp'] == expiry
+    assert payload['sub'] == 'me'
+
+
+def test_decode_expiry_returns_exp_seconds() -> None:
+    expiry = int(time.time()) + 100
+    token = make_jwt({'exp': expiry})
+    assert decode_jwt_expiry(token) == expiry
+
+
+def test_decode_payload_strips_session_ingress_prefix() -> None:
+    expiry = int(time.time()) + 1
+    token = 'sk-ant-si-' + make_jwt({'exp': expiry})
+    assert decode_jwt_expiry(token) == expiry
+
+
+def test_decode_payload_returns_none_for_malformed_token() -> None:
+    # Not 3 parts.
+    assert decode_jwt_payload('a.b') is None
+    assert decode_jwt_payload('') is None
+    # Empty payload segment.
+    assert decode_jwt_payload('header..sig') is None
+    # Non-base64url payload.
+    assert decode_jwt_payload('header.!!!.sig') is None
+
+
+def test_decode_payload_returns_none_for_non_json_payload() -> None:
+    body = base64.urlsafe_b64encode(b'not json').rstrip(b'=').decode('ascii')
+    assert decode_jwt_payload(f'header.{body}.sig') is None
+
+
+def test_decode_payload_returns_none_for_non_object_payload() -> None:
+    """JWT spec allows only objects; arrays should be rejected."""
+    body = base64.urlsafe_b64encode(b'[1,2,3]').rstrip(b'=').decode('ascii')
+    assert decode_jwt_payload(f'header.{body}.sig') is None
+
+
+def test_decode_expiry_returns_none_when_exp_missing() -> None:
+    token = make_jwt({'sub': 'me'})  # no ``exp``
+    assert decode_jwt_expiry(token) is None
+
+
+def test_decode_expiry_returns_none_when_exp_not_int() -> None:
+    token = make_jwt({'exp': '3600'})  # string, not int — must reject
+    assert decode_jwt_expiry(token) is None

--- a/tests/bridge/test_messaging_handlers.py
+++ b/tests/bridge/test_messaging_handlers.py
@@ -1,0 +1,264 @@
+"""Tests for ``src.bridge.messaging_handlers.handle_server_control_request``."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from src.bridge.messaging_handlers import (
+    OUTBOUND_ONLY_ERROR,
+    Err,
+    Ok,
+    ServerControlRequestHandlers,
+    handle_server_control_request,
+)
+
+
+class _FakeTransport:
+    def __init__(self) -> None:
+        self.writes: list[dict] = []
+
+    def write(self, message: dict) -> None:
+        self.writes.append(message)
+
+
+def _make_handlers(**kw) -> tuple[_FakeTransport, ServerControlRequestHandlers]:
+    transport = _FakeTransport()
+    handlers = ServerControlRequestHandlers(
+        transport=transport,
+        session_id='cse_test',
+        **kw,
+    )
+    return transport, handlers
+
+
+class TestSubtypeDispatch:
+    def test_initialize_returns_minimal_capabilities(self) -> None:
+        transport, handlers = _make_handlers()
+        handle_server_control_request(
+            {'type': 'control_request', 'request_id': 'r1', 'request': {'subtype': 'initialize'}},
+            handlers,
+        )
+        assert len(transport.writes) == 1
+        env = transport.writes[0]
+        assert env['type'] == 'control_response'
+        assert env['session_id'] == 'cse_test'
+        resp = env['response']
+        assert resp['subtype'] == 'success'
+        assert resp['request_id'] == 'r1'
+        inner = resp['response']
+        assert inner['commands'] == []
+        assert inner['output_style'] == 'normal'
+        assert inner['available_output_styles'] == ['normal']
+        assert inner['models'] == []
+        assert inner['account'] == {}
+        assert inner['pid'] == os.getpid()
+
+    def test_set_model_invokes_callback_and_returns_success(self) -> None:
+        captured: list[str | None] = []
+        transport, handlers = _make_handlers(on_set_model=captured.append)
+        handle_server_control_request(
+            {
+                'type': 'control_request',
+                'request_id': 'r2',
+                'request': {'subtype': 'set_model', 'model': 'opus'},
+            },
+            handlers,
+        )
+        assert captured == ['opus']
+        assert transport.writes[0]['response']['subtype'] == 'success'
+
+    def test_set_model_without_callback_still_succeeds(self) -> None:
+        transport, handlers = _make_handlers()
+        handle_server_control_request(
+            {'type': 'control_request', 'request_id': 'r2', 'request': {'subtype': 'set_model', 'model': 'opus'}},
+            handlers,
+        )
+        assert transport.writes[0]['response']['subtype'] == 'success'
+
+    def test_set_max_thinking_tokens_dispatches(self) -> None:
+        captured: list[int | None] = []
+        transport, handlers = _make_handlers(on_set_max_thinking_tokens=captured.append)
+        handle_server_control_request(
+            {
+                'type': 'control_request',
+                'request_id': 'r3',
+                'request': {'subtype': 'set_max_thinking_tokens', 'max_thinking_tokens': 1000},
+            },
+            handlers,
+        )
+        assert captured == [1000]
+        assert transport.writes[0]['response']['subtype'] == 'success'
+
+    def test_interrupt_dispatches(self) -> None:
+        called = []
+        transport, handlers = _make_handlers(on_interrupt=lambda: called.append(True))
+        handle_server_control_request(
+            {'type': 'control_request', 'request_id': 'r4', 'request': {'subtype': 'interrupt'}},
+            handlers,
+        )
+        assert called == [True]
+        assert transport.writes[0]['response']['subtype'] == 'success'
+
+
+class TestSetPermissionMode:
+    def test_no_callback_returns_error_not_silent_success(self) -> None:
+        """WI-3.7b chapter pattern: missing handler returns Err, NOT silent success."""
+        transport, handlers = _make_handlers()
+        handle_server_control_request(
+            {
+                'type': 'control_request',
+                'request_id': 'r5',
+                'request': {'subtype': 'set_permission_mode', 'mode': 'auto'},
+            },
+            handlers,
+        )
+        env = transport.writes[0]
+        assert env['response']['subtype'] == 'error'
+        assert 'on_set_permission_mode callback not registered' in env['response']['error']
+
+    def test_callback_returning_ok_yields_success(self) -> None:
+        transport, handlers = _make_handlers(
+            on_set_permission_mode=lambda mode: Ok(),
+        )
+        handle_server_control_request(
+            {
+                'type': 'control_request',
+                'request_id': 'r5',
+                'request': {'subtype': 'set_permission_mode', 'mode': 'auto'},
+            },
+            handlers,
+        )
+        assert transport.writes[0]['response']['subtype'] == 'success'
+
+    def test_callback_returning_err_yields_error_with_reason(self) -> None:
+        transport, handlers = _make_handlers(
+            on_set_permission_mode=lambda mode: Err(error='gate disabled'),
+        )
+        handle_server_control_request(
+            {
+                'type': 'control_request',
+                'request_id': 'r5',
+                'request': {'subtype': 'set_permission_mode', 'mode': 'bypass'},
+            },
+            handlers,
+        )
+        env = transport.writes[0]
+        assert env['response']['subtype'] == 'error'
+        assert env['response']['error'] == 'gate disabled'
+
+
+class TestUnknownSubtype:
+    def test_unknown_subtype_returns_error_response_not_silence(self) -> None:
+        """Chapter explicit pattern: unknown subtypes get an error response,
+        not silence — server kills WS in 10-14s otherwise.
+        """
+        transport, handlers = _make_handlers()
+        handle_server_control_request(
+            {
+                'type': 'control_request',
+                'request_id': 'r99',
+                'request': {'subtype': 'set_quantum_flux'},
+            },
+            handlers,
+        )
+        env = transport.writes[0]
+        assert env['response']['subtype'] == 'error'
+        assert 'set_quantum_flux' in env['response']['error']
+        assert env['response']['request_id'] == 'r99'
+
+
+class TestOutboundOnly:
+    def test_initialize_succeeds_in_outbound_only(self) -> None:
+        """initialize MUST succeed even in outbound-only — server kills WS otherwise."""
+        transport, handlers = _make_handlers(outbound_only=True)
+        handle_server_control_request(
+            {'type': 'control_request', 'request_id': 'r1', 'request': {'subtype': 'initialize'}},
+            handlers,
+        )
+        assert transport.writes[0]['response']['subtype'] == 'success'
+
+    def test_mutable_subtype_returns_outbound_only_error(self) -> None:
+        transport, handlers = _make_handlers(outbound_only=True)
+        for subtype in ('set_model', 'set_max_thinking_tokens', 'set_permission_mode', 'interrupt'):
+            transport.writes.clear()
+            handle_server_control_request(
+                {'type': 'control_request', 'request_id': 'r1', 'request': {'subtype': subtype}},
+                handlers,
+            )
+            env = transport.writes[0]
+            assert env['response']['subtype'] == 'error', f'subtype {subtype}'
+            assert env['response']['error'] == OUTBOUND_ONLY_ERROR
+
+
+class TestSessionIdAttachment:
+    def test_session_id_in_every_response(self) -> None:
+        transport, handlers = _make_handlers()
+        handle_server_control_request(
+            {'type': 'control_request', 'request_id': 'r1', 'request': {'subtype': 'initialize'}},
+            handlers,
+        )
+        assert transport.writes[0]['session_id'] == 'cse_test'
+
+
+class TestMalformedRequest:
+    def test_request_inner_not_a_dict_logged_and_dropped(self) -> None:
+        transport, handlers = _make_handlers()
+        handle_server_control_request(
+            {'type': 'control_request', 'request_id': 'r1', 'request': 'not a dict'},
+            handlers,
+        )
+        assert transport.writes == []
+
+
+class _AsyncWriteTransport:
+    """Test double for the Phase 3 ``ReplBridgeTransport.write`` async surface.
+
+    Returns a coroutine from ``write`` (matching the TS
+    ``Promise<void>`` contract). ``handle_server_control_request`` must
+    schedule that coroutine on the running loop or the response is never
+    sent and the server kills the WS in 10-14 s.
+    """
+
+    def __init__(self) -> None:
+        self.writes: list[dict] = []
+        self.write_completed = asyncio.Event()
+
+    def write(self, message: dict) -> object:
+        async def _do_write() -> None:
+            # Simulate any async work (e.g., HTTP POST).
+            await asyncio.sleep(0)
+            self.writes.append(message)
+            self.write_completed.set()
+
+        return _do_write()
+
+
+class TestAsyncWriteContract:
+    """Per critic #2: handle_server_control_request must support async write
+    transports without losing the response.
+    """
+
+    @pytest.mark.asyncio
+    async def test_async_write_is_scheduled_and_completes(self) -> None:
+        transport = _AsyncWriteTransport()
+        handlers = ServerControlRequestHandlers(
+            transport=transport,
+            session_id='cse_async',
+        )
+        handle_server_control_request(
+            {'type': 'control_request', 'request_id': 'r1', 'request': {'subtype': 'initialize'}},
+            handlers,
+        )
+        # Before yielding, the write hasn't run yet — the coroutine is
+        # scheduled but not awaited.
+        assert transport.writes == []
+        # Yield once to let the scheduled task run.
+        await transport.write_completed.wait()
+        assert len(transport.writes) == 1
+        env = transport.writes[0]
+        assert env['type'] == 'control_response'
+        assert env['session_id'] == 'cse_async'
+        assert env['response']['subtype'] == 'success'

--- a/tests/bridge/test_messaging_router.py
+++ b/tests/bridge/test_messaging_router.py
@@ -1,0 +1,398 @@
+"""Tests for the router half of ``src.bridge.messaging``.
+
+Covers ``handle_ingress_message`` routing, the type guards, the
+forward-filter (``is_eligible_bridge_message``), ``extract_title_text``,
+``normalize_control_message_keys``, ``make_result_message``, and the
+``RemotePermissionResponse`` parser.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.bridge.bounded_uuid_set import BoundedUUIDSet
+from src.bridge.messaging import (
+    AllowResponse,
+    DenyResponse,
+    extract_title_text,
+    handle_ingress_message,
+    is_eligible_bridge_message,
+    is_sdk_control_request,
+    is_sdk_control_response,
+    is_sdk_message,
+    make_result_message,
+    normalize_control_message_keys,
+    remote_permission_response_from_dict,
+)
+
+
+# ─── Type guards ─────────────────────────────────────────────────────────
+
+
+class TestTypeGuards:
+    def test_is_sdk_message_accepts_string_type(self) -> None:
+        assert is_sdk_message({'type': 'user'})
+        assert is_sdk_message({'type': 'assistant', 'extra': 'fields'})
+
+    def test_is_sdk_message_rejects_missing_or_non_string_type(self) -> None:
+        assert not is_sdk_message({})
+        assert not is_sdk_message({'type': 123})
+        assert not is_sdk_message('not a dict')
+        assert not is_sdk_message(None)
+
+    def test_is_sdk_control_response_requires_type_and_response(self) -> None:
+        assert is_sdk_control_response({'type': 'control_response', 'response': {}})
+        assert not is_sdk_control_response({'type': 'control_response'})  # no response
+        assert not is_sdk_control_response({'type': 'control_request', 'response': {}})
+
+    def test_is_sdk_control_request_requires_all_three_fields(self) -> None:
+        assert is_sdk_control_request({
+            'type': 'control_request', 'request_id': 'r1', 'request': {}
+        })
+        assert not is_sdk_control_request({'type': 'control_request', 'request_id': 'r1'})
+        assert not is_sdk_control_request({'type': 'control_response', 'request_id': 'r1', 'request': {}})
+
+
+# ─── normalize_control_message_keys ──────────────────────────────────────
+
+
+class TestNormalizeControlMessageKeys:
+    def test_known_camel_case_keys_get_snake_cased(self) -> None:
+        out = normalize_control_message_keys({
+            'requestId': 'r1', 'toolUseId': 'tu', 'workerEpoch': 5
+        })
+        assert out == {'request_id': 'r1', 'tool_use_id': 'tu', 'worker_epoch': 5}
+
+    def test_snake_case_keys_pass_through(self) -> None:
+        inp = {'request_id': 'r1', 'tool_use_id': 'tu'}
+        assert normalize_control_message_keys(inp) == inp
+
+    def test_unknown_camel_case_passes_through_with_debug_log(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Per gap analysis #24 + critic #20: unknown camelCase keys must
+        NOT be silently dropped or guessed; pass through with debug log.
+        """
+        with caplog.at_level('DEBUG', logger='src.bridge.messaging'):
+            out = normalize_control_message_keys({'futureField': 'val'})
+        assert out == {'futureField': 'val'}
+        assert any('Unknown camelCase key' in rec.message for rec in caplog.records)
+
+    def test_recurses_into_nested_dicts(self) -> None:
+        inp = {
+            'controlRequest': {
+                'requestId': 'r1',
+                'request': {'subtype': 'set_model', 'model': 'opus'},
+            }
+        }
+        out = normalize_control_message_keys(inp)
+        assert out == {
+            'control_request': {
+                'request_id': 'r1',
+                'request': {'subtype': 'set_model', 'model': 'opus'},
+            }
+        }
+
+    def test_recurses_into_lists(self) -> None:
+        inp = [{'requestId': 'r1'}, {'toolUseId': 'tu'}]
+        out = normalize_control_message_keys(inp)
+        assert out == [{'request_id': 'r1'}, {'tool_use_id': 'tu'}]
+
+    def test_non_dict_non_list_passes_through(self) -> None:
+        assert normalize_control_message_keys(42) == 42
+        assert normalize_control_message_keys('hello') == 'hello'
+        assert normalize_control_message_keys(None) is None
+
+
+# ─── handle_ingress_message ──────────────────────────────────────────────
+
+
+class TestHandleIngressMessage:
+    def setup_method(self) -> None:
+        self.posted = BoundedUUIDSet(100)
+        self.inbound = BoundedUUIDSet(100)
+        self.user_messages: list[dict] = []
+        self.permission_responses: list[dict] = []
+        self.control_requests: list[dict] = []
+
+    def _route(self, payload: dict) -> None:
+        handle_ingress_message(
+            json.dumps(payload),
+            self.posted,
+            self.inbound,
+            on_inbound_message=self.user_messages.append,
+            on_permission_response=self.permission_responses.append,
+            on_control_request=self.control_requests.append,
+        )
+
+    def test_user_message_forwarded_and_uuid_added_to_inbound_set(self) -> None:
+        self._route({'type': 'user', 'uuid': 'u1', 'message': {'content': 'hi'}})
+        assert len(self.user_messages) == 1
+        assert self.inbound.has('u1')
+
+    def test_assistant_message_dropped_on_read_side(self) -> None:
+        """Only ``user`` messages are forwarded on the read side; others log+drop."""
+        self._route({'type': 'assistant', 'uuid': 'a1'})
+        assert self.user_messages == []
+
+    def test_echo_dedup_ignores_own_posted_uuid(self) -> None:
+        self.posted.add('u1')
+        self._route({'type': 'user', 'uuid': 'u1', 'message': {}})
+        assert self.user_messages == []
+
+    def test_redelivery_dedup_ignores_inbound_uuid(self) -> None:
+        self.inbound.add('u1')
+        self._route({'type': 'user', 'uuid': 'u1', 'message': {}})
+        assert self.user_messages == []
+
+    def test_user_without_uuid_still_forwards(self) -> None:
+        self._route({'type': 'user', 'message': {}})
+        assert len(self.user_messages) == 1
+
+    def test_control_response_routes_to_permission_handler(self) -> None:
+        self._route({'type': 'control_response', 'response': {'subtype': 'success', 'request_id': 'r1'}})
+        assert len(self.permission_responses) == 1
+        assert self.user_messages == []
+
+    def test_control_request_routes_to_request_handler(self) -> None:
+        self._route({
+            'type': 'control_request',
+            'request_id': 'r1',
+            'request': {'subtype': 'initialize'},
+        })
+        assert len(self.control_requests) == 1
+        assert self.user_messages == []
+
+    def test_camel_case_request_id_normalized_before_routing(self) -> None:
+        """Server may send camelCase; router should snake-case before dispatch."""
+        self._route({
+            'type': 'control_request',
+            'requestId': 'r1',
+            'request': {'subtype': 'initialize'},
+        })
+        assert len(self.control_requests) == 1
+        # The dispatched payload has the normalized key.
+        assert self.control_requests[0].get('request_id') == 'r1'
+
+    def test_invalid_json_silently_dropped(self) -> None:
+        handle_ingress_message(
+            'not json {{{',
+            self.posted,
+            self.inbound,
+            on_inbound_message=self.user_messages.append,
+        )
+        assert self.user_messages == []
+
+    def test_non_object_json_silently_dropped(self) -> None:
+        handle_ingress_message(
+            '[1, 2, 3]',
+            self.posted,
+            self.inbound,
+            on_inbound_message=self.user_messages.append,
+        )
+        assert self.user_messages == []
+
+    def test_optional_callbacks_default_to_none(self) -> None:
+        """Without callbacks, the router must not raise."""
+        handle_ingress_message(
+            json.dumps({'type': 'user', 'uuid': 'u1', 'message': {}}),
+            self.posted,
+            self.inbound,
+        )  # no callbacks; should silently route + dedup
+
+
+# ─── is_eligible_bridge_message ──────────────────────────────────────────
+
+
+class TestIsEligibleBridgeMessage:
+    def test_user_messages_forward(self) -> None:
+        assert is_eligible_bridge_message({'type': 'user'})
+
+    def test_assistant_messages_forward(self) -> None:
+        assert is_eligible_bridge_message({'type': 'assistant'})
+
+    def test_virtual_messages_filtered(self) -> None:
+        assert not is_eligible_bridge_message({'type': 'user', 'isVirtual': True})
+        assert not is_eligible_bridge_message({'type': 'assistant', 'isVirtual': True})
+
+    def test_system_local_command_forwards(self) -> None:
+        assert is_eligible_bridge_message({'type': 'system', 'subtype': 'local_command'})
+
+    def test_system_other_subtype_filtered(self) -> None:
+        assert not is_eligible_bridge_message({'type': 'system', 'subtype': 'init'})
+        assert not is_eligible_bridge_message({'type': 'system', 'subtype': 'post_turn_summary'})
+
+    def test_tool_result_filtered(self) -> None:
+        assert not is_eligible_bridge_message({'type': 'tool_result'})
+
+    def test_keep_alive_filtered(self) -> None:
+        assert not is_eligible_bridge_message({'type': 'keep_alive'})
+
+
+# ─── extract_title_text ──────────────────────────────────────────────────
+
+
+class TestExtractTitleText:
+    def test_user_text_string_content(self) -> None:
+        msg = {'type': 'user', 'message': {'content': 'fix the bug'}}
+        assert extract_title_text(msg) == 'fix the bug'
+
+    def test_user_text_list_content_first_text_block(self) -> None:
+        msg = {
+            'type': 'user',
+            'message': {'content': [{'type': 'text', 'text': 'first'}, {'type': 'text', 'text': 'second'}]},
+        }
+        assert extract_title_text(msg) == 'first'
+
+    def test_non_user_returns_none(self) -> None:
+        assert extract_title_text({'type': 'assistant', 'message': {'content': 'hi'}}) is None
+
+    def test_meta_returns_none(self) -> None:
+        assert extract_title_text({'type': 'user', 'isMeta': True, 'message': {'content': 'x'}}) is None
+
+    def test_tool_use_result_returns_none(self) -> None:
+        assert extract_title_text(
+            {'type': 'user', 'toolUseResult': {}, 'message': {'content': 'x'}}
+        ) is None
+
+    def test_compact_summary_returns_none(self) -> None:
+        assert extract_title_text(
+            {'type': 'user', 'isCompactSummary': True, 'message': {'content': 'x'}}
+        ) is None
+
+    def test_non_human_origin_returns_none(self) -> None:
+        msg = {
+            'type': 'user',
+            'origin': {'kind': 'task_notification'},
+            'message': {'content': 'x'},
+        }
+        assert extract_title_text(msg) is None
+
+    def test_pure_display_tag_returns_none(self) -> None:
+        msg = {
+            'type': 'user',
+            'message': {'content': '<ide_opened_file>foo.py</ide_opened_file>'},
+        }
+        assert extract_title_text(msg) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert extract_title_text({'type': 'user', 'message': {'content': ''}}) is None
+
+    def test_jsx_uppercase_component_passes_through(self) -> None:
+        """Per critic #1: TS regex is lowercase-only — `<Button>` is user prose."""
+        msg = {
+            'type': 'user',
+            'message': {'content': 'fix the <Button> layout'},
+        }
+        assert extract_title_text(msg) == 'fix the <Button> layout'
+
+    def test_doctype_html_passes_through(self) -> None:
+        """`<!DOCTYPE html>` starts with `!`, not a letter — never stripped."""
+        msg = {'type': 'user', 'message': {'content': 'remove <!DOCTYPE html>'}}
+        assert extract_title_text(msg) == 'remove <!DOCTYPE html>'
+
+    def test_mismatched_tags_pass_through(self) -> None:
+        """`<foo>x</bar>` — no backreference match means TS leaves it alone."""
+        msg = {'type': 'user', 'message': {'content': 'check <foo>x</bar>'}}
+        assert extract_title_text(msg) == 'check <foo>x</bar>'
+
+    def test_trailing_newline_stripped_after_tag(self) -> None:
+        """The TS regex includes `\\n?` after the closing tag."""
+        msg = {
+            'type': 'user',
+            'message': {'content': '<ide_opened_file>foo.py</ide_opened_file>\nactual prompt'},
+        }
+        assert extract_title_text(msg) == 'actual prompt'
+
+    def test_multiline_tag_block_stripped(self) -> None:
+        """`[\\s\\S]` in regex is JS equivalent of Python's re.DOTALL."""
+        msg = {
+            'type': 'user',
+            'message': {
+                'content': '<ide_selection>\nlines\nof\ncontent\n</ide_selection>real',
+            },
+        }
+        assert extract_title_text(msg) == 'real'
+
+    def test_unpaired_angle_brackets_pass_through(self) -> None:
+        """User prose like 'when x < y' must not be eaten."""
+        msg = {'type': 'user', 'message': {'content': 'verify when x < y'}}
+        assert extract_title_text(msg) == 'verify when x < y'
+
+    def test_tool_use_result_dict_disqualifies(self) -> None:
+        """Per critic #20 + the `toolUseResult: {}` truthy fix."""
+        msg = {'type': 'user', 'toolUseResult': {}, 'message': {'content': 'x'}}
+        assert extract_title_text(msg) is None
+        msg = {'type': 'user', 'toolUseResult': {'output': 'ok'}, 'message': {'content': 'x'}}
+        assert extract_title_text(msg) is None
+
+    def test_tool_use_result_none_does_not_disqualify(self) -> None:
+        """`toolUseResult: None` (i.e., explicit null) means "no tool result"."""
+        msg = {'type': 'user', 'toolUseResult': None, 'message': {'content': 'x'}}
+        assert extract_title_text(msg) == 'x'
+
+
+# ─── make_result_message ─────────────────────────────────────────────────
+
+
+def test_make_result_message_has_required_fields_and_unique_uuid() -> None:
+    r1 = make_result_message('cse_xyz')
+    r2 = make_result_message('cse_xyz')
+    assert r1['type'] == 'result'
+    assert r1['subtype'] == 'success'
+    assert r1['session_id'] == 'cse_xyz'
+    assert r1['is_error'] is False
+    assert r1['stop_reason'] is None
+    assert r1['uuid'] != r2['uuid']  # generated fresh per call
+
+
+# ─── RemotePermissionResponse parser ─────────────────────────────────────
+
+
+class TestRemotePermissionResponse:
+    def test_allow_with_snake_case(self) -> None:
+        resp = remote_permission_response_from_dict({
+            'behavior': 'allow',
+            'updated_input': {'a': 1},
+        })
+        assert isinstance(resp, AllowResponse)
+        assert resp.updated_input == {'a': 1}
+
+    def test_allow_with_camel_case_compat(self) -> None:
+        """The wire normalizer happens upstream, but if parser is called
+        directly (Direct Connect) it should also accept ``updatedInput``.
+        """
+        resp = remote_permission_response_from_dict({
+            'behavior': 'allow',
+            'updatedInput': {'a': 1},
+        })
+        assert isinstance(resp, AllowResponse)
+        assert resp.updated_input == {'a': 1}
+
+    def test_allow_default_empty_input(self) -> None:
+        resp = remote_permission_response_from_dict({'behavior': 'allow'})
+        assert isinstance(resp, AllowResponse)
+        assert resp.updated_input == {}
+
+    def test_deny(self) -> None:
+        resp = remote_permission_response_from_dict({
+            'behavior': 'deny', 'message': 'too risky',
+        })
+        assert isinstance(resp, DenyResponse)
+        assert resp.message == 'too risky'
+
+    def test_unknown_behavior_raises(self) -> None:
+        with pytest.raises(ValueError, match='unknown permission behavior'):
+            remote_permission_response_from_dict({'behavior': 'maybe'})
+
+    def test_allow_rejects_non_dict_updated_input(self) -> None:
+        with pytest.raises(ValueError, match='updated_input must be dict'):
+            remote_permission_response_from_dict({
+                'behavior': 'allow', 'updated_input': 'not a dict',
+            })
+
+    def test_deny_rejects_non_string_message(self) -> None:
+        with pytest.raises(ValueError, match='message must be a string'):
+            remote_permission_response_from_dict({'behavior': 'deny', 'message': 42})

--- a/tests/bridge/test_no_proxy.py
+++ b/tests/bridge/test_no_proxy.py
@@ -1,0 +1,62 @@
+"""Tests for ``src.bridge.no_proxy``."""
+
+from __future__ import annotations
+
+from src.bridge.no_proxy import NO_PROXY_LIST, default_no_proxy
+
+
+def test_three_anthropic_forms_in_correct_order() -> None:
+    """Per gap analysis #38: order MUST be apex / Python-suffix / glob.
+
+    Loopback/RFC1918 entries come before the Anthropic forms.
+    """
+    apex_idx = NO_PROXY_LIST.index('anthropic.com')
+    suffix_idx = NO_PROXY_LIST.index('.anthropic.com')
+    glob_idx = NO_PROXY_LIST.index('*.anthropic.com')
+    assert apex_idx < suffix_idx < glob_idx, (
+        f'expected apex<suffix<glob, got apex={apex_idx} suffix={suffix_idx} glob={glob_idx}'
+    )
+
+
+def test_default_no_proxy_is_comma_joined() -> None:
+    s = default_no_proxy()
+    assert isinstance(s, str)
+    parts = s.split(',')
+    assert parts[0] == 'localhost'
+    assert 'anthropic.com' in parts
+    assert '.anthropic.com' in parts
+    assert '*.anthropic.com' in parts
+
+
+def test_required_loopback_and_rfc1918_present() -> None:
+    """The CCR container must not proxy itself or RFC1918 networks."""
+    required = {
+        'localhost',
+        '127.0.0.1',
+        '::1',
+        '169.254.0.0/16',  # IMDS
+        '10.0.0.0/8',
+        '172.16.0.0/12',
+        '192.168.0.0/16',
+    }
+    assert required.issubset(set(NO_PROXY_LIST))
+
+
+def test_github_pypi_npm_excluded_to_prevent_mitm() -> None:
+    """Package registries must bypass the upstream proxy (TLS pinning)."""
+    expected = {
+        'github.com',
+        'api.github.com',
+        '*.github.com',
+        '*.githubusercontent.com',
+        'registry.npmjs.org',
+        'pypi.org',
+        'files.pythonhosted.org',
+        'index.crates.io',
+        'proxy.golang.org',
+    }
+    assert expected.issubset(set(NO_PROXY_LIST))
+
+
+def test_no_duplicates() -> None:
+    assert len(NO_PROXY_LIST) == len(set(NO_PROXY_LIST))

--- a/tests/bridge/test_protojson.py
+++ b/tests/bridge/test_protojson.py
@@ -1,0 +1,93 @@
+"""Tests for ``src.bridge.protojson.coerce_int64``.
+
+Bounds match TS ``Number.isSafeInteger`` (``±(2^53 - 1)``); see module
+docstring. ``INT64_*`` aliases point at the same values for wire-format
+symmetry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.bridge.protojson import (
+    INT64_MAX,
+    INT64_MIN,
+    SAFE_INTEGER_MAX,
+    SAFE_INTEGER_MIN,
+    coerce_int64,
+)
+
+
+def test_int_passthrough() -> None:
+    assert coerce_int64(0) == 0
+    assert coerce_int64(42) == 42
+    assert coerce_int64(-1) == -1
+
+
+def test_string_parsed_as_base10() -> None:
+    assert coerce_int64('0') == 0
+    assert coerce_int64('42') == 42
+    assert coerce_int64('-1') == -1
+    # Whitespace is permitted by Python int(); explicitly test.
+    assert coerce_int64(' 7 ') == 7
+
+
+def test_int64_aliases_match_safe_integer() -> None:
+    """INT64_MIN/MAX alias the safe-integer pair (Number.isSafeInteger)."""
+    assert INT64_MAX == SAFE_INTEGER_MAX == (2**53) - 1
+    assert INT64_MIN == SAFE_INTEGER_MIN == -((2**53) - 1)
+
+
+def test_safe_integer_bounds_accepted() -> None:
+    assert coerce_int64(SAFE_INTEGER_MAX) == SAFE_INTEGER_MAX
+    assert coerce_int64(SAFE_INTEGER_MIN) == SAFE_INTEGER_MIN
+    assert coerce_int64(str(SAFE_INTEGER_MAX)) == SAFE_INTEGER_MAX
+    assert coerce_int64(str(SAFE_INTEGER_MIN)) == SAFE_INTEGER_MIN
+
+
+def test_safe_integer_overflow_rejected() -> None:
+    with pytest.raises(ValueError, match='out of safe-integer range'):
+        coerce_int64(SAFE_INTEGER_MAX + 1)
+    with pytest.raises(ValueError, match='out of safe-integer range'):
+        coerce_int64(SAFE_INTEGER_MIN - 1)
+    with pytest.raises(ValueError, match='out of safe-integer range'):
+        coerce_int64(str(SAFE_INTEGER_MAX + 1))
+
+
+def test_2_pow_53_to_2_pow_63_now_rejected() -> None:
+    """Values in (2^53-1, 2^63) used to be accepted under int64 bounds.
+
+    Per critic #4 + the round-4 plan revision: matching TS
+    ``Number.isSafeInteger`` for wire-format symmetry. Any port-author
+    expecting the old ±2^63 envelope must now coerce explicitly.
+    """
+    with pytest.raises(ValueError, match='out of safe-integer range'):
+        coerce_int64(2**60)
+    with pytest.raises(ValueError, match='out of safe-integer range'):
+        coerce_int64(str(2**60))
+
+
+def test_invalid_string_rejected() -> None:
+    with pytest.raises(ValueError, match='not a base-10 integer string'):
+        coerce_int64('hello')
+    with pytest.raises(ValueError, match='not a base-10 integer string'):
+        coerce_int64('1.5')
+    with pytest.raises(ValueError, match='not a base-10 integer string'):
+        coerce_int64('0x10')
+
+
+def test_unsupported_type_rejected() -> None:
+    with pytest.raises(ValueError, match='unsupported type'):
+        coerce_int64(1.5)
+    with pytest.raises(ValueError, match='unsupported type'):
+        coerce_int64(None)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match='unsupported type'):
+        coerce_int64([1])  # type: ignore[arg-type]
+
+
+def test_bool_explicitly_rejected() -> None:
+    """``bool`` is a subclass of int in Python; must be rejected explicitly."""
+    with pytest.raises(ValueError, match='refusing bool'):
+        coerce_int64(True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match='refusing bool'):
+        coerce_int64(False)  # type: ignore[arg-type]

--- a/tests/bridge/test_repl_bridge_transport.py
+++ b/tests/bridge/test_repl_bridge_transport.py
@@ -1,0 +1,216 @@
+"""Tests for ``src.bridge.repl_bridge_transport`` (v2 transport).
+
+End-to-end-ish: builds a v2 transport against an in-process httpx
+mock that serves both the SSE stream and the CCR write endpoints.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from src.bridge.close_codes import WS_CLOSE_EPOCH_MISMATCH
+from src.bridge.repl_bridge_transport import (
+    V2TransportOptions,
+    create_v1_repl_transport,
+    create_v2_repl_transport,
+)
+
+
+def _sse_body(events: list[tuple[str, str]]) -> bytes:
+    out: list[str] = []
+    for eid, data in events:
+        out.append(f'id: {eid}')
+        out.append(f'data: {data}')
+        out.append('')
+    return ('\n'.join(out) + '\n').encode('utf-8')
+
+
+@pytest.mark.asyncio
+async def test_v1_factory_raises_not_implemented():
+    with pytest.raises(NotImplementedError):
+        create_v1_repl_transport()
+
+
+@pytest.mark.asyncio
+async def test_v2_transport_reads_sse_and_writes_to_ccr():
+    received_writes: list[dict] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path.endswith('/worker/events/stream'):
+            return httpx.Response(
+                200,
+                headers={'content-type': 'text/event-stream'},
+                content=_sse_body([('1', '{"type":"user","uuid":"u1"}')]),
+            )
+        if req.url.path.endswith('/worker/events'):
+            import json
+            body = json.loads(req.content)
+            received_writes.extend(body.get('events', []))
+            return httpx.Response(200, json={})
+        # Heartbeat / state / delivery — all 200 OK.
+        return httpx.Response(200, json={})
+
+    received_data: list[str] = []
+    connected = asyncio.Event()
+
+    # Create transport with mocked HTTP. We have to inject the client
+    # into BOTH the SSE and CCR layers, so we patch them after
+    # construction.
+    transport = await create_v2_repl_transport(V2TransportOptions(
+        session_url='https://api.test/v1/code/sessions/cse_abc',
+        ingress_token='tok',
+        session_id='cse_abc',
+        epoch=1,
+        heartbeat_interval_seconds=0,
+    ))
+    transport._sse._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    transport._sse._owned_client = True
+    transport._ccr._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    transport._ccr._owned_http = True
+
+    transport.set_on_data(received_data.append)
+    transport.set_on_connect(connected.set)
+    try:
+        transport.connect()
+        await asyncio.wait_for(connected.wait(), timeout=2.0)
+        # Write something via the v2 transport.
+        await transport.write({'type': 'assistant', 'uuid': 'a1'})
+        await transport.flush()
+        # Wait for the SSE stream to deliver the user message.
+        for _ in range(100):
+            if received_data:
+                break
+            await asyncio.sleep(0.02)
+        assert any('"type":"user"' in d for d in received_data)
+        assert any(e.get('uuid') == 'a1' for e in received_writes)
+    finally:
+        await transport.aclose()
+
+
+@pytest.mark.asyncio
+async def test_v2_transport_409_fires_on_close_with_4090():
+    """When CCR returns 409 epoch-mismatch, on_close fires with 4090."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path.endswith('/worker/events/stream'):
+            return httpx.Response(
+                200,
+                headers={'content-type': 'text/event-stream'},
+                content=_sse_body([]),
+            )
+        if req.url.path.endswith('/worker/events'):
+            return httpx.Response(409, json={'error': 'epoch superseded'})
+        return httpx.Response(200, json={})
+
+    close_codes: list[int | None] = []
+    connected = asyncio.Event()
+
+    transport = await create_v2_repl_transport(V2TransportOptions(
+        session_url='https://api.test/v1/code/sessions/cse',
+        ingress_token='tok',
+        session_id='cse',
+        epoch=1,
+        heartbeat_interval_seconds=0,
+    ))
+    transport._sse._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    transport._sse._owned_client = True
+    transport._ccr._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    transport._ccr._owned_http = True
+
+    transport.set_on_close(close_codes.append)
+    transport.set_on_connect(connected.set)
+    try:
+        transport.connect()
+        await asyncio.wait_for(connected.wait(), timeout=2.0)
+        await transport.write({'type': 'user', 'uuid': 'u1'})
+        # Wait for the uploader to hit 409 and fire the epoch-mismatch handler.
+        for _ in range(200):
+            if WS_CLOSE_EPOCH_MISMATCH in close_codes:
+                break
+            await asyncio.sleep(0.02)
+    finally:
+        await transport.aclose()
+
+    assert WS_CLOSE_EPOCH_MISMATCH in close_codes
+
+
+@pytest.mark.asyncio
+async def test_v2_transport_outbound_only_skips_sse():
+    """outbound_only=True: set_on_data is no-op; get_last_sequence_num returns 0."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path.endswith('/worker/events/stream'):
+            # Should NOT be hit when outbound_only=True.
+            raise AssertionError('SSE stream opened in outbound_only mode')
+        return httpx.Response(200, json={})
+
+    connected = asyncio.Event()
+
+    transport = await create_v2_repl_transport(V2TransportOptions(
+        session_url='https://api.test/v1/code/sessions/cse',
+        ingress_token='tok',
+        session_id='cse',
+        epoch=1,
+        outbound_only=True,
+        heartbeat_interval_seconds=0,
+    ))
+    transport._ccr._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    transport._ccr._owned_http = True
+
+    transport.set_on_connect(connected.set)
+    transport.set_on_data(lambda _: None)  # should be no-op
+    try:
+        transport.connect()
+        await asyncio.wait_for(connected.wait(), timeout=2.0)
+        assert transport.get_last_sequence_num() == 0
+        assert transport.is_connected_status()
+    finally:
+        await transport.aclose()
+
+
+@pytest.mark.asyncio
+async def test_v2_transport_dropped_batch_count_passthrough():
+    """Transport's dropped_batch_count delegates to CCRClient."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path.endswith('/worker/events/stream'):
+            return httpx.Response(
+                200,
+                headers={'content-type': 'text/event-stream'},
+                content=_sse_body([]),
+            )
+        # All writes return 503 → drops accumulate.
+        if req.url.path.endswith('/worker/events'):
+            return httpx.Response(503)
+        return httpx.Response(200, json={})
+
+    connected = asyncio.Event()
+
+    transport = await create_v2_repl_transport(V2TransportOptions(
+        session_url='https://api.test/v1/code/sessions/cse',
+        ingress_token='tok',
+        session_id='cse',
+        epoch=1,
+        heartbeat_interval_seconds=0,
+    ))
+    transport._sse._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    transport._sse._owned_client = True
+    transport._ccr._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    transport._ccr._owned_http = True
+    transport._ccr._options.max_retries_per_batch = 1
+    transport._ccr._options.retry_backoff_seconds = 0.01
+    transport.set_on_connect(connected.set)
+    try:
+        transport.connect()
+        await asyncio.wait_for(connected.wait(), timeout=2.0)
+        await transport.write({'type': 'user', 'uuid': 'u1'})
+        for _ in range(200):
+            if transport.dropped_batch_count > 0:
+                break
+            await asyncio.sleep(0.02)
+        assert transport.dropped_batch_count > 0
+    finally:
+        await transport.aclose()

--- a/tests/bridge/test_sdk_types.py
+++ b/tests/bridge/test_sdk_types.py
@@ -1,0 +1,131 @@
+"""Tests for ``src.bridge.sdk_types``.
+
+TypedDicts are erased at runtime; we only assert that representative
+fixtures fit the expected shape via Python's structural duck-typing.
+This catches the common port-author mistake of fields being renamed
+silently, while keeping the tests pragmatic.
+"""
+
+from __future__ import annotations
+
+from src.bridge.sdk_types import (
+    SDKControlCancelRequest,
+    SDKControlPermissionRequest,
+    SDKControlRequest,
+    SDKControlResponse,
+    SDKResultSuccess,
+)
+
+
+def test_user_message_shape() -> None:
+    msg: dict = {
+        'type': 'user',
+        'uuid': 'u1',
+        'session_id': 'cse_x',
+        'parent_tool_use_id': None,
+        'message': {'role': 'user', 'content': 'hi'},
+    }
+    assert msg['type'] == 'user'
+
+
+def test_control_request_initialize_shape() -> None:
+    req: SDKControlRequest = {
+        'type': 'control_request',
+        'request_id': 'r1',
+        'request': {'subtype': 'initialize'},
+    }
+    assert req['type'] == 'control_request'
+    assert req['request']['subtype'] == 'initialize'
+
+
+def test_control_request_set_model_shape() -> None:
+    req: SDKControlRequest = {
+        'type': 'control_request',
+        'request_id': 'r2',
+        'request': {'subtype': 'set_model', 'model': 'claude-opus-4-7'},
+    }
+    assert req['request']['model'] == 'claude-opus-4-7'
+
+
+def test_control_request_set_permission_mode_shape() -> None:
+    req: SDKControlRequest = {
+        'type': 'control_request',
+        'request_id': 'r3',
+        'request': {'subtype': 'set_permission_mode', 'mode': 'auto'},
+    }
+    assert req['request']['mode'] == 'auto'
+
+
+def test_control_request_can_use_tool_shape() -> None:
+    inner: SDKControlPermissionRequest = {
+        'subtype': 'can_use_tool',
+        'tool_name': 'Bash',
+        'input': {'command': 'ls'},
+        'tool_use_id': 'tu_1',
+    }
+    req: SDKControlRequest = {
+        'type': 'control_request',
+        'request_id': 'r4',
+        'request': inner,
+    }
+    assert req['request']['subtype'] == 'can_use_tool'
+    assert req['request']['tool_name'] == 'Bash'
+
+
+def test_control_response_success_shape() -> None:
+    resp: SDKControlResponse = {
+        'type': 'control_response',
+        'response': {
+            'subtype': 'success',
+            'request_id': 'r1',
+            'response': {'pid': 1234},
+        },
+    }
+    assert resp['response']['subtype'] == 'success'
+
+
+def test_control_response_error_shape() -> None:
+    resp: SDKControlResponse = {
+        'type': 'control_response',
+        'response': {
+            'subtype': 'error',
+            'request_id': 'r1',
+            'error': 'unsupported subtype',
+        },
+    }
+    assert resp['response']['error'] == 'unsupported subtype'
+
+
+def test_control_cancel_request_shape() -> None:
+    cancel: SDKControlCancelRequest = {
+        'type': 'control_cancel_request',
+        'request_id': 'r1',
+        'tool_use_id': 'tu_99',
+    }
+    assert cancel['request_id'] == 'r1'
+    assert cancel['tool_use_id'] == 'tu_99'
+
+
+def test_result_success_has_required_fields() -> None:
+    """``make_result_message`` (WI-2.6c) builds this shape; verify the
+    required fields per ``bridgeMessaging.ts:399-416``.
+    """
+    result: SDKResultSuccess = {
+        'type': 'result',
+        'subtype': 'success',
+        'duration_ms': 0,
+        'duration_api_ms': 0,
+        'is_error': False,
+        'num_turns': 0,
+        'result': '',
+        'stop_reason': None,
+        'total_cost_usd': 0.0,
+        'usage': {},
+        'modelUsage': {},
+        'permission_denials': [],
+        'session_id': 's1',
+        'uuid': 'u1',
+    }
+    assert result['type'] == 'result'
+    assert result['subtype'] == 'success'
+    assert result['is_error'] is False

--- a/tests/bridge/test_token_refresh_scheduler.py
+++ b/tests/bridge/test_token_refresh_scheduler.py
@@ -1,0 +1,153 @@
+"""Tests for ``src.bridge.jwt_utils.TokenRefreshScheduler``.
+
+We use the running asyncio event loop's ``call_later`` directly (no
+``asyncio.sleep`` inside the scheduler). To keep tests fast, callers
+schedule short delays and ``await asyncio.sleep`` in the test body to
+let the loop fire pending timers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import time
+
+import pytest
+
+from src.bridge.jwt_utils import (
+    MAX_REFRESH_FAILURES,
+    SCHEDULE_FROM_EXPIRES_IN_FLOOR_MS,
+    TokenRefreshScheduler,
+)
+
+
+def make_jwt(payload: dict[str, object]) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none","typ":"JWT"}').rstrip(b'=').decode('ascii')
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode('utf-8')).rstrip(b'=').decode('ascii')
+    return f'{header}.{body}.signature'
+
+
+@pytest.mark.asyncio
+async def test_immediate_refresh_when_token_already_past_buffer() -> None:
+    """Token expires in 1 s, buffer is 5 min — fire immediately."""
+    refreshed: list[tuple[str, str]] = []
+
+    sched = TokenRefreshScheduler(
+        get_access_token=lambda: 'fresh-token',
+        on_refresh=lambda sid, tok: refreshed.append((sid, tok)),
+        label='test',
+    )
+    token = make_jwt({'exp': int(time.time()) + 1})
+    sched.schedule('s1', token)
+
+    # Let the immediate fire run.
+    await asyncio.sleep(0.05)
+    assert refreshed == [('s1', 'fresh-token')]
+    sched.cancel_all()
+
+
+@pytest.mark.asyncio
+async def test_schedule_from_expires_in_clamps_to_30s_floor() -> None:
+    """When expires_in is small (e.g., shorter than the buffer), clamp to
+    ``SCHEDULE_FROM_EXPIRES_IN_FLOOR_MS`` (30 s) — no tight loop.
+    """
+    sched = TokenRefreshScheduler(
+        get_access_token=lambda: 'tok',
+        on_refresh=lambda sid, tok: None,
+        label='test',
+    )
+    # expires_in shorter than the 5-min buffer → would be negative without clamp.
+    sched.schedule_from_expires_in('s1', 60)
+    # Internal: a timer should be scheduled with delay >= 30 s.
+    handle = sched._timers.get('s1')  # noqa: SLF001 -- test-only introspection
+    assert handle is not None
+    # call_later returns a TimerHandle; ``when()`` is monotonic time of fire.
+    when = handle.when()
+    now = asyncio.get_event_loop().time()
+    delay = when - now
+    assert delay >= (SCHEDULE_FROM_EXPIRES_IN_FLOOR_MS / 1000) - 0.5  # tolerance
+    sched.cancel_all()
+
+
+@pytest.mark.asyncio
+async def test_failure_chain_caps_at_max_refresh_failures() -> None:
+    """If get_access_token returns None each time, retries cap at MAX."""
+    call_count = 0
+
+    def fake_get_access_token() -> str | None:
+        nonlocal call_count
+        call_count += 1
+        return None
+
+    # Patch the retry interval BEFORE scheduling so we don't wait 60 s
+    # between retries. The scheduler reads the constant at the call site
+    # inside _do_refresh.
+    import src.bridge.jwt_utils as jwt_utils
+
+    original_retry = jwt_utils.REFRESH_RETRY_DELAY_MS
+    jwt_utils.REFRESH_RETRY_DELAY_MS = 10
+
+    sched = TokenRefreshScheduler(
+        get_access_token=fake_get_access_token,
+        on_refresh=lambda sid, tok: None,
+        label='test',
+        refresh_buffer_ms=1,
+    )
+    # Token already past — triggers the immediate-fire branch.
+    token = make_jwt({'exp': int(time.time()) - 10})
+    try:
+        sched.schedule('s1', token)
+        # Wait long enough for the immediate fire + (MAX-1) retries at 10ms each.
+        await asyncio.sleep(0.2)
+    finally:
+        jwt_utils.REFRESH_RETRY_DELAY_MS = original_retry
+        sched.cancel_all()
+
+    # MAX_REFRESH_FAILURES retries should have fired and stopped.
+    assert call_count == MAX_REFRESH_FAILURES, (
+        f'expected {MAX_REFRESH_FAILURES} attempts, got {call_count}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_invalidates_in_flight_refresh() -> None:
+    """If we cancel mid-flight, the in-flight ``_do_refresh`` bails out
+    on the generation check before invoking ``on_refresh``.
+    """
+    refreshed: list[str] = []
+
+    async def slow_get_token() -> str:
+        await asyncio.sleep(0.05)
+        return 'tok-1'
+
+    sched = TokenRefreshScheduler(
+        get_access_token=slow_get_token,
+        on_refresh=lambda sid, tok: refreshed.append(sid),
+        label='test',
+    )
+    token = make_jwt({'exp': int(time.time()) + 1})
+    sched.schedule('s1', token)
+
+    # Let the refresh fire and start awaiting; then cancel before it
+    # resolves.
+    await asyncio.sleep(0.01)
+    sched.cancel('s1')
+    await asyncio.sleep(0.10)
+
+    assert refreshed == [], 'cancelled refresh should not invoke on_refresh'
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_clears_timers_and_failures() -> None:
+    sched = TokenRefreshScheduler(
+        get_access_token=lambda: 'tok',
+        on_refresh=lambda sid, tok: None,
+        label='test',
+    )
+    sched.schedule_from_expires_in('s1', 600)
+    sched.schedule_from_expires_in('s2', 600)
+    assert len(sched._timers) == 2  # noqa: SLF001
+    sched.cancel_all()
+    assert len(sched._timers) == 0
+    assert len(sched._failure_counts) == 0  # noqa: SLF001

--- a/tests/bridge/test_work_secret.py
+++ b/tests/bridge/test_work_secret.py
@@ -1,0 +1,154 @@
+"""Tests for ``src.bridge.work_secret``."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from src.bridge.work_secret import (
+    build_ccr_v2_sdk_url,
+    build_sdk_url,
+    decode_work_secret,
+    same_session_id,
+)
+
+
+def _encode_secret(payload: dict[str, object]) -> str:
+    return base64.urlsafe_b64encode(json.dumps(payload).encode('utf-8')).rstrip(b'=').decode('ascii')
+
+
+def test_decode_minimal_v1_secret() -> None:
+    secret = _encode_secret({
+        'version': 1,
+        'session_ingress_token': 'tok-123',
+        'api_base_url': 'https://api.anthropic.com',
+    })
+    parsed = decode_work_secret(secret)
+    assert parsed.version == 1
+    assert parsed.session_ingress_token == 'tok-123'
+    assert parsed.api_base_url == 'https://api.anthropic.com'
+    assert parsed.sources == ()
+    assert parsed.environment_variables is None
+
+
+def test_decode_secret_with_all_optional_fields() -> None:
+    secret = _encode_secret({
+        'version': 1,
+        'session_ingress_token': 'tok',
+        'api_base_url': 'http://localhost:8000',
+        'sources': [{'type': 'git_repository'}],
+        'auth': [{'type': 'oauth', 'token': 'oauth-tok'}],
+        'claude_code_args': {'flag': 'value'},
+        'mcp_config': {'mcpServers': {}},
+        'environment_variables': {'KEY': 'val'},
+        'use_code_sessions': True,
+    })
+    parsed = decode_work_secret(secret)
+    assert parsed.sources == ({'type': 'git_repository'},)
+    assert parsed.use_code_sessions is True
+    assert parsed.environment_variables == {'KEY': 'val'}
+
+
+def test_decode_rejects_non_v1_version() -> None:
+    secret = _encode_secret({
+        'version': 2,
+        'session_ingress_token': 'tok',
+        'api_base_url': 'https://x',
+    })
+    with pytest.raises(ValueError, match='Unsupported work secret version'):
+        decode_work_secret(secret)
+
+
+def test_decode_rejects_missing_token() -> None:
+    secret = _encode_secret({
+        'version': 1,
+        'api_base_url': 'https://x',
+    })
+    with pytest.raises(ValueError, match='session_ingress_token'):
+        decode_work_secret(secret)
+
+
+def test_decode_rejects_empty_token() -> None:
+    secret = _encode_secret({
+        'version': 1,
+        'session_ingress_token': '',
+        'api_base_url': 'https://x',
+    })
+    with pytest.raises(ValueError, match='session_ingress_token'):
+        decode_work_secret(secret)
+
+
+def test_decode_rejects_missing_base_url() -> None:
+    secret = _encode_secret({
+        'version': 1,
+        'session_ingress_token': 'tok',
+    })
+    with pytest.raises(ValueError, match='api_base_url'):
+        decode_work_secret(secret)
+
+
+def test_decode_rejects_invalid_base64() -> None:
+    with pytest.raises(ValueError, match='base64url'):
+        decode_work_secret('!!! not base64 !!!')
+
+
+def test_decode_rejects_non_object_json() -> None:
+    secret = base64.urlsafe_b64encode(b'[1,2,3]').rstrip(b'=').decode('ascii')
+    with pytest.raises(ValueError, match='must be a JSON object'):
+        decode_work_secret(secret)
+
+
+def test_build_sdk_url_localhost_uses_v2_ws() -> None:
+    url = build_sdk_url('http://localhost:8000', 'cse_abc')
+    assert url == 'ws://localhost:8000/v2/session_ingress/ws/cse_abc'
+
+
+def test_build_sdk_url_127_0_0_1_uses_v2_ws() -> None:
+    url = build_sdk_url('http://127.0.0.1:8000', 'cse_abc')
+    assert url == 'ws://127.0.0.1:8000/v2/session_ingress/ws/cse_abc'
+
+
+def test_build_sdk_url_production_uses_v1_wss() -> None:
+    url = build_sdk_url('https://api.anthropic.com', 'cse_abc')
+    assert url == 'wss://api.anthropic.com/v1/session_ingress/ws/cse_abc'
+
+
+def test_build_sdk_url_strips_trailing_slash() -> None:
+    url = build_sdk_url('https://api.anthropic.com/', 'cse_abc')
+    assert url == 'wss://api.anthropic.com/v1/session_ingress/ws/cse_abc'
+
+
+def test_build_ccr_v2_sdk_url_strips_trailing_slash() -> None:
+    assert build_ccr_v2_sdk_url('https://api.anthropic.com', 'cse_xyz') == (
+        'https://api.anthropic.com/v1/code/sessions/cse_xyz'
+    )
+    assert build_ccr_v2_sdk_url('https://api.anthropic.com/', 'cse_xyz') == (
+        'https://api.anthropic.com/v1/code/sessions/cse_xyz'
+    )
+
+
+def test_same_session_id_identical_strings() -> None:
+    assert same_session_id('cse_abc1234', 'cse_abc1234')
+
+
+def test_same_session_id_cse_vs_session_prefix() -> None:
+    """``cse_*`` (infra) and ``session_*`` (compat) share the same UUID body."""
+    assert same_session_id('cse_abc1234', 'session_abc1234')
+    assert same_session_id('session_abc1234', 'cse_abc1234')
+
+
+def test_same_session_id_session_staging_prefix() -> None:
+    """``session_staging_*`` is the staging-environment compat form."""
+    assert same_session_id('cse_abc1234', 'session_staging_abc1234')
+
+
+def test_same_session_id_different_uuids_returns_false() -> None:
+    assert not same_session_id('cse_abc1234', 'cse_xyz5678')
+    assert not same_session_id('cse_abc1234', 'session_xyz5678')
+
+
+def test_same_session_id_short_body_returns_false() -> None:
+    """Body shorter than 4 chars must not false-match."""
+    assert not same_session_id('a_b', 'c_b')  # body 'b' is too short

--- a/tests/remote/test_remote_session_manager.py
+++ b/tests/remote/test_remote_session_manager.py
@@ -1,0 +1,292 @@
+"""Tests for ``src.remote.remote_session_manager.RemoteSessionManager``."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+
+import pytest
+import websockets
+from websockets.asyncio.server import serve as ws_serve
+
+from src.bridge.messaging import AllowResponse, DenyResponse
+from src.remote.remote_session_manager import (
+    RemoteSessionCallbacks,
+    RemoteSessionConfig,
+    RemoteSessionManager,
+    create_remote_session_config,
+)
+
+
+pytestmark = pytest.mark.integration
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('127.0.0.1', 0))
+        return s.getsockname()[1]
+
+
+class _TestEnv:
+    def __init__(self):
+        self.received_messages: list[dict] = []
+        self.permission_requests: list[tuple[dict, str]] = []
+        self.permission_cancellations: list[tuple[str, str | None]] = []
+        self.connected = asyncio.Event()
+        self.disconnected = asyncio.Event()
+        self.from_client: list[str] = []
+        self.to_client_queue: asyncio.Queue[str] = asyncio.Queue()
+
+    async def server_handler(self, ws):
+        async def out():
+            try:
+                while True:
+                    line = await self.to_client_queue.get()
+                    await ws.send(line)
+            except websockets.exceptions.ConnectionClosed:
+                return
+
+        async def inn():
+            try:
+                async for raw in ws:
+                    self.from_client.append(raw if isinstance(raw, str) else raw.decode())
+            except websockets.exceptions.ConnectionClosed:
+                return
+
+        out_t = asyncio.get_running_loop().create_task(out())
+        in_t = asyncio.get_running_loop().create_task(inn())
+        try:
+            await asyncio.wait([out_t, in_t], return_when=asyncio.FIRST_COMPLETED)
+        finally:
+            for t in (out_t, in_t):
+                if not t.done():
+                    t.cancel()
+                try:
+                    await t
+                except (asyncio.CancelledError, websockets.exceptions.ConnectionClosed):
+                    pass
+
+    def make_callbacks(self) -> RemoteSessionCallbacks:
+        return RemoteSessionCallbacks(
+            on_message=lambda m: self.received_messages.append(m),
+            on_permission_request=lambda req, rid: self.permission_requests.append((req, rid)),
+            on_permission_cancelled=lambda rid, tuid: self.permission_cancellations.append((rid, tuid)),
+            on_connected=lambda: self.connected.set(),
+            on_disconnected=lambda: self.disconnected.set(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_assistant_message_forwarded():
+    env = _TestEnv()
+    port = _free_port()
+    ws_server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = RemoteSessionConfig(
+            session_id='cse_x', get_access_token=lambda: 'tok', org_uuid='org',
+        )
+        mgr = RemoteSessionManager(config, env.make_callbacks(), base_url=f'ws://127.0.0.1:{port}')
+        mgr.connect()
+        await asyncio.wait_for(env.connected.wait(), timeout=2.0)
+        await env.to_client_queue.put(json.dumps({
+            'type': 'assistant', 'message': {'content': 'hello'},
+        }))
+        for _ in range(50):
+            if env.received_messages:
+                break
+            await asyncio.sleep(0.02)
+        assert env.received_messages[0]['type'] == 'assistant'
+        await mgr.disconnect()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_permission_request_routed_and_response_sent():
+    env = _TestEnv()
+    port = _free_port()
+    ws_server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = RemoteSessionConfig(
+            session_id='cse_x', get_access_token=lambda: 'tok', org_uuid='org',
+        )
+        mgr = RemoteSessionManager(config, env.make_callbacks(), base_url=f'ws://127.0.0.1:{port}')
+        mgr.connect()
+        await asyncio.wait_for(env.connected.wait(), timeout=2.0)
+
+        # Send a can_use_tool request from the server.
+        await env.to_client_queue.put(json.dumps({
+            'type': 'control_request',
+            'request_id': 'r1',
+            'request': {
+                'subtype': 'can_use_tool',
+                'tool_name': 'Bash',
+                'input': {'command': 'ls'},
+                'tool_use_id': 'tu1',
+            },
+        }))
+        for _ in range(50):
+            if env.permission_requests:
+                break
+            await asyncio.sleep(0.02)
+        assert len(env.permission_requests) == 1
+        req, rid = env.permission_requests[0]
+        assert req['tool_name'] == 'Bash'
+        assert rid == 'r1'
+
+        # Respond allow.
+        await mgr.respond_to_permission_request('r1', AllowResponse(updated_input={'command': 'ls -la'}))
+        await asyncio.sleep(0.1)
+        sent = json.loads(env.from_client[-1])
+        assert sent['type'] == 'control_response'
+        assert sent['response']['response']['behavior'] == 'allow'
+        assert sent['response']['response']['updatedInput'] == {'command': 'ls -la'}
+        await mgr.disconnect()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_permission_cancel_routed_with_tool_use_id():
+    env = _TestEnv()
+    port = _free_port()
+    ws_server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = RemoteSessionConfig(
+            session_id='cse_x', get_access_token=lambda: 'tok', org_uuid='org',
+        )
+        mgr = RemoteSessionManager(config, env.make_callbacks(), base_url=f'ws://127.0.0.1:{port}')
+        mgr.connect()
+        await asyncio.wait_for(env.connected.wait(), timeout=2.0)
+
+        # Send the permission request first so the manager has a pending entry.
+        await env.to_client_queue.put(json.dumps({
+            'type': 'control_request',
+            'request_id': 'r1',
+            'request': {
+                'subtype': 'can_use_tool',
+                'tool_name': 'Bash',
+                'input': {},
+                'tool_use_id': 'tu_99',
+            },
+        }))
+        for _ in range(50):
+            if env.permission_requests:
+                break
+            await asyncio.sleep(0.02)
+
+        # Now send a control_cancel_request; manager should fire on_permission_cancelled.
+        await env.to_client_queue.put(json.dumps({
+            'type': 'control_cancel_request',
+            'request_id': 'r1',
+        }))
+        for _ in range(50):
+            if env.permission_cancellations:
+                break
+            await asyncio.sleep(0.02)
+        assert env.permission_cancellations == [('r1', 'tu_99')]
+        await mgr.disconnect()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_unknown_subtype_returns_error_response():
+    env = _TestEnv()
+    port = _free_port()
+    ws_server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = RemoteSessionConfig(
+            session_id='cse_x', get_access_token=lambda: 'tok', org_uuid='org',
+        )
+        mgr = RemoteSessionManager(config, env.make_callbacks(), base_url=f'ws://127.0.0.1:{port}')
+        mgr.connect()
+        await asyncio.wait_for(env.connected.wait(), timeout=2.0)
+        await env.to_client_queue.put(json.dumps({
+            'type': 'control_request',
+            'request_id': 'r2',
+            'request': {'subtype': 'set_quantum_flux'},
+        }))
+        await asyncio.sleep(0.1)
+        # Manager should have sent an error response back.
+        assert any('error' in line for line in env.from_client)
+        await mgr.disconnect()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_cancel_session_no_op_in_viewer_only():
+    env = _TestEnv()
+    port = _free_port()
+    ws_server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = RemoteSessionConfig(
+            session_id='cse_x',
+            get_access_token=lambda: 'tok',
+            org_uuid='org',
+            viewer_only=True,
+        )
+        mgr = RemoteSessionManager(config, env.make_callbacks(), base_url=f'ws://127.0.0.1:{port}')
+        mgr.connect()
+        await asyncio.wait_for(env.connected.wait(), timeout=2.0)
+        await mgr.cancel_session()  # no-op
+        await asyncio.sleep(0.1)
+        # Server received nothing — viewer-only suppressed the interrupt.
+        assert env.from_client == []
+        await mgr.disconnect()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_cancel_session_sends_interrupt_when_not_viewer():
+    env = _TestEnv()
+    port = _free_port()
+    ws_server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = RemoteSessionConfig(
+            session_id='cse_x',
+            get_access_token=lambda: 'tok',
+            org_uuid='org',
+            viewer_only=False,
+        )
+        mgr = RemoteSessionManager(config, env.make_callbacks(), base_url=f'ws://127.0.0.1:{port}')
+        mgr.connect()
+        await asyncio.wait_for(env.connected.wait(), timeout=2.0)
+        await mgr.cancel_session()
+        await asyncio.sleep(0.1)
+        assert any('interrupt' in line for line in env.from_client)
+        await mgr.disconnect()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_send_message_returns_false_when_not_connected():
+    config = RemoteSessionConfig(
+        session_id='cse_x', get_access_token=lambda: 'tok', org_uuid='org',
+    )
+    callbacks = RemoteSessionCallbacks(
+        on_message=lambda m: None,
+        on_permission_request=lambda req, rid: None,
+    )
+    mgr = RemoteSessionManager(config, callbacks)
+    ok = await mgr.send_message('hi')
+    assert ok is False
+
+
+def test_create_remote_session_config_helper():
+    cfg = create_remote_session_config(
+        'cse_x', lambda: 'tok', 'org', viewer_only=True,
+    )
+    assert cfg.session_id == 'cse_x'
+    assert cfg.viewer_only is True
+    assert cfg.org_uuid == 'org'

--- a/tests/remote/test_sdk_message_adapter.py
+++ b/tests/remote/test_sdk_message_adapter.py
@@ -1,0 +1,84 @@
+"""Tests for ``src.remote.sdk_message_adapter``."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.remote.sdk_message_adapter import (
+    adapt_permission_response,
+    adapt_sdk_to_wire_user_message,
+    adapt_wire_to_sdk,
+)
+
+
+class TestAdaptWireToSdk:
+    def test_normalizes_camel_case_keys(self) -> None:
+        out = adapt_wire_to_sdk({
+            'type': 'control_request',
+            'requestId': 'r1',
+            'request': {'subtype': 'set_model', 'model': 'opus'},
+        })
+        assert out == {
+            'type': 'control_request',
+            'request_id': 'r1',
+            'request': {'subtype': 'set_model', 'model': 'opus'},
+        }
+
+    def test_passes_through_snake_case(self) -> None:
+        inp = {'type': 'user', 'message': {'content': 'hi'}}
+        assert adapt_wire_to_sdk(inp) == inp
+
+
+class TestAdaptSdkToWireUserMessage:
+    def test_minimal(self) -> None:
+        env = adapt_sdk_to_wire_user_message('hello', session_id='cse_x')
+        assert env == {
+            'type': 'user',
+            'message': {'role': 'user', 'content': 'hello'},
+            'parent_tool_use_id': None,
+            'session_id': 'cse_x',
+        }
+
+    def test_with_uuid(self) -> None:
+        env = adapt_sdk_to_wire_user_message('hi', session_id='s', uuid='u1')
+        assert env['uuid'] == 'u1'
+
+    def test_with_parent_tool_use_id(self) -> None:
+        env = adapt_sdk_to_wire_user_message(
+            'sub-prompt', session_id='s', parent_tool_use_id='tu1',
+        )
+        assert env['parent_tool_use_id'] == 'tu1'
+
+    def test_list_content_passed_through(self) -> None:
+        content = [{'type': 'text', 'text': 'hi'}]
+        env = adapt_sdk_to_wire_user_message(content, session_id='s')
+        assert env['message']['content'] == content
+
+
+class TestAdaptPermissionResponse:
+    def test_allow_with_updated_input(self) -> None:
+        env = adapt_permission_response(
+            'r1', 'allow', updated_input={'command': 'ls -la'},
+        )
+        assert env['type'] == 'control_response'
+        assert env['response']['subtype'] == 'success'
+        assert env['response']['request_id'] == 'r1'
+        assert env['response']['response']['behavior'] == 'allow'
+        assert env['response']['response']['updatedInput'] == {'command': 'ls -la'}
+
+    def test_allow_default_empty_input(self) -> None:
+        env = adapt_permission_response('r1', 'allow')
+        assert env['response']['response']['updatedInput'] == {}
+
+    def test_deny_with_message(self) -> None:
+        env = adapt_permission_response('r1', 'deny', message='too risky')
+        assert env['response']['response']['behavior'] == 'deny'
+        assert env['response']['response']['message'] == 'too risky'
+
+    def test_deny_default_empty_message(self) -> None:
+        env = adapt_permission_response('r1', 'deny')
+        assert env['response']['response']['message'] == ''
+
+    def test_unknown_behavior_raises(self) -> None:
+        with pytest.raises(ValueError, match='unknown permission behavior'):
+            adapt_permission_response('r1', 'maybe')

--- a/tests/remote/test_sessions_websocket.py
+++ b/tests/remote/test_sessions_websocket.py
@@ -1,0 +1,305 @@
+"""Tests for ``src.remote.sessions_websocket.SessionsWebSocket``.
+
+Uses an in-process WS echo/script server with controllable close codes
+to exercise the discriminated reconnection strategy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+
+import pytest
+import websockets
+from websockets.asyncio.server import serve as ws_serve
+
+from src.remote.sessions_websocket import (
+    MAX_RECONNECT_ATTEMPTS,
+    MAX_SESSION_NOT_FOUND_RETRIES,
+    SessionsWebSocket,
+    SessionsWebSocketCallbacks,
+)
+
+
+pytestmark = pytest.mark.integration
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('127.0.0.1', 0))
+        return s.getsockname()[1]
+
+
+class _ScriptedServer:
+    """In-process WS server with per-connection close-code control.
+
+    On each connection, immediately closes with the next ``close_codes``
+    code. We do NOT wait for client messages — the test purpose is to
+    exercise the client's reconnection logic, not message exchange.
+    """
+
+    def __init__(self, close_codes: list[int]) -> None:
+        self.close_codes = list(close_codes)
+        self.connection_count = 0
+        self.received_messages: list[str] = []
+
+    async def handler(self, ws):
+        self.connection_count += 1
+        # Close immediately with the next code — don't wait for messages.
+        if self.close_codes:
+            code = self.close_codes.pop(0)
+            try:
+                await ws.close(code=code, reason='scripted close')
+            except (websockets.exceptions.ConnectionClosed, OSError):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_4003_is_permanent_no_reconnect():
+    server = _ScriptedServer(close_codes=[4003])
+    port = _free_port()
+    ws_server = await ws_serve(server.handler, '127.0.0.1', port)
+    try:
+        on_close_fired = asyncio.Event()
+        callbacks = SessionsWebSocketCallbacks(
+            on_message=lambda m: None,
+            on_close=lambda: on_close_fired.set(),
+        )
+        ws = SessionsWebSocket(
+            'sid', 'org', lambda: 'tok', callbacks,
+            base_url=f'ws://127.0.0.1:{port}',
+        )
+        await ws.connect()
+        # Server immediately closes with 4003.
+        await asyncio.wait_for(on_close_fired.wait(), timeout=2.0)
+        # Only one connection attempt — 4003 is permanent.
+        assert server.connection_count == 1
+        await ws.disconnect()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_4001_triggers_reconnect_with_on_reconnecting():
+    """A single 4001 close fires on_reconnecting then attempts to reconnect.
+
+    NOTE: matches TS — both ``sessionNotFoundRetries`` and
+    ``reconnectAttempts`` are reset on every successful WS open, so a
+    server that keeps sending 4001 forever loops indefinitely. The
+    realistic test is "verify the 4001 path triggers a reconnect at all"
+    rather than budget exhaustion.
+    """
+    server = _ScriptedServer(close_codes=[4001, 4001])
+    port = _free_port()
+    ws_server = await ws_serve(server.handler, '127.0.0.1', port)
+    try:
+        reconnecting_fired = asyncio.Event()
+        callbacks = SessionsWebSocketCallbacks(
+            on_message=lambda m: None,
+            on_reconnecting=lambda: reconnecting_fired.set(),
+        )
+        from src.remote import sessions_websocket as ws_mod
+        original_delay = ws_mod.RECONNECT_DELAY_SECONDS
+        ws_mod.RECONNECT_DELAY_SECONDS = 0.02
+        try:
+            ws = SessionsWebSocket(
+                'sid', 'org', lambda: 'tok', callbacks,
+                base_url=f'ws://127.0.0.1:{port}',
+            )
+            await ws.connect()
+            await asyncio.wait_for(reconnecting_fired.wait(), timeout=5.0)
+            # Wait for the second connect to happen.
+            for _ in range(100):
+                if server.connection_count >= 2:
+                    break
+                await asyncio.sleep(0.02)
+            assert server.connection_count >= 2
+        finally:
+            ws_mod.RECONNECT_DELAY_SECONDS = original_delay
+        await ws.disconnect()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_initial_connect_failure_exhausts_budget():
+    """When the server is unreachable from the start, the initial-connect
+    retry budget exhausts at MAX_RECONNECT_ATTEMPTS. This is the realistic
+    "budget exhaustion" path because no successful connect resets the
+    counter.
+    """
+    # Use a bound-then-released port so connect() fails with refused.
+    port = _free_port()  # binds + releases — port is now likely refused
+
+    on_close_fired = asyncio.Event()
+    error_count = 0
+
+    def on_error(_exc):
+        nonlocal error_count
+        error_count += 1
+
+    callbacks = SessionsWebSocketCallbacks(
+        on_message=lambda m: None,
+        on_close=lambda: on_close_fired.set(),
+        on_error=on_error,
+    )
+    from src.remote import sessions_websocket as ws_mod
+    original_delay = ws_mod.RECONNECT_DELAY_SECONDS
+    ws_mod.RECONNECT_DELAY_SECONDS = 0.02
+    try:
+        ws = SessionsWebSocket(
+            'sid', 'org', lambda: 'tok', callbacks,
+            base_url=f'ws://127.0.0.1:{port}',
+        )
+        await ws.connect()
+        await asyncio.wait_for(on_close_fired.wait(), timeout=10.0)
+    finally:
+        ws_mod.RECONNECT_DELAY_SECONDS = original_delay
+
+    # Each failed initial connect goes through _schedule_reconnect_or_close
+    # which increments _reconnect_attempts; budget exhausts at MAX+1.
+    assert error_count >= MAX_RECONNECT_ATTEMPTS
+    await ws.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_message_dispatch_to_on_message():
+    received: list[dict] = []
+
+    class _MsgServer:
+        def __init__(self):
+            self.connection_count = 0
+
+        async def handler(self, ws):
+            self.connection_count += 1
+            await ws.send(json.dumps({'type': 'assistant', 'message': {'content': 'hi'}}))
+            await asyncio.sleep(0.1)  # keep connection open briefly
+
+    server = _MsgServer()
+    port = _free_port()
+    ws_server = await ws_serve(server.handler, '127.0.0.1', port)
+    try:
+        callbacks = SessionsWebSocketCallbacks(
+            on_message=lambda m: received.append(m),
+        )
+        ws = SessionsWebSocket(
+            'sid', 'org', lambda: 'tok', callbacks,
+            base_url=f'ws://127.0.0.1:{port}',
+        )
+        await ws.connect()
+        for _ in range(50):
+            if received:
+                break
+            await asyncio.sleep(0.02)
+        assert any(m.get('type') == 'assistant' for m in received)
+        await ws.disconnect()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_is_silently_dropped():
+    """Server sends garbage; reader logs + drops, doesn't fire on_message."""
+    received: list[dict] = []
+
+    class _GarbageServer:
+        async def handler(self, ws):
+            await ws.send('not json {{{')
+            await ws.send(json.dumps({'type': 'good'}))
+            await asyncio.sleep(0.1)
+
+    server = _GarbageServer()
+    port = _free_port()
+    ws_server = await ws_serve(server.handler, '127.0.0.1', port)
+    try:
+        callbacks = SessionsWebSocketCallbacks(
+            on_message=lambda m: received.append(m),
+        )
+        ws = SessionsWebSocket(
+            'sid', 'org', lambda: 'tok', callbacks,
+            base_url=f'ws://127.0.0.1:{port}',
+        )
+        await ws.connect()
+        for _ in range(50):
+            if received:
+                break
+            await asyncio.sleep(0.02)
+        # Only the good message should make it through.
+        assert received == [{'type': 'good'}]
+        await ws.disconnect()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_send_control_response_round_trip():
+    server_received: list[str] = []
+
+    class _EchoServer:
+        async def handler(self, ws):
+            try:
+                async for raw in ws:
+                    server_received.append(raw if isinstance(raw, str) else raw.decode())
+            except websockets.exceptions.ConnectionClosed:
+                pass
+
+    server = _EchoServer()
+    port = _free_port()
+    ws_server = await ws_serve(server.handler, '127.0.0.1', port)
+    try:
+        callbacks = SessionsWebSocketCallbacks(on_message=lambda m: None)
+        ws = SessionsWebSocket(
+            'sid', 'org', lambda: 'tok', callbacks,
+            base_url=f'ws://127.0.0.1:{port}',
+        )
+        await ws.connect()
+        await ws.send_control_response({
+            'type': 'control_response',
+            'response': {'subtype': 'success', 'request_id': 'r1'},
+        })
+        await asyncio.sleep(0.1)
+        assert any('control_response' in line for line in server_received)
+        await ws.disconnect()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_send_control_request_wraps_in_envelope():
+    server_received: list[str] = []
+
+    class _EchoServer:
+        async def handler(self, ws):
+            try:
+                async for raw in ws:
+                    server_received.append(raw if isinstance(raw, str) else raw.decode())
+            except websockets.exceptions.ConnectionClosed:
+                pass
+
+    server = _EchoServer()
+    port = _free_port()
+    ws_server = await ws_serve(server.handler, '127.0.0.1', port)
+    try:
+        callbacks = SessionsWebSocketCallbacks(on_message=lambda m: None)
+        ws = SessionsWebSocket(
+            'sid', 'org', lambda: 'tok', callbacks,
+            base_url=f'ws://127.0.0.1:{port}',
+        )
+        await ws.connect()
+        await ws.send_control_request({'subtype': 'interrupt'})
+        await asyncio.sleep(0.1)
+        assert len(server_received) == 1
+        envelope = json.loads(server_received[0])
+        assert envelope['type'] == 'control_request'
+        assert envelope['request']['subtype'] == 'interrupt'
+        assert 'request_id' in envelope
+        await ws.disconnect()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()

--- a/tests/server/test_direct_connect_manager.py
+++ b/tests/server/test_direct_connect_manager.py
@@ -1,0 +1,284 @@
+"""Tests for ``src.server.direct_connect_manager.DirectConnectSessionManager``.
+
+Uses an in-process WS echo server so tests run without external
+infrastructure. Exercises message routing, permission round-trip,
+interrupt, control-request unknown-subtype error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+
+import pytest
+import websockets
+from websockets.asyncio.server import serve as ws_serve
+
+from src.bridge.messaging import AllowResponse, DenyResponse
+from src.server.direct_connect_manager import (
+    DirectConnectCallbacks,
+    DirectConnectSessionManager,
+)
+from src.server.direct_connect_session import DirectConnectConfig
+
+
+pytestmark = pytest.mark.integration  # spins up real WS listeners
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('127.0.0.1', 0))
+        return s.getsockname()[1]
+
+
+class _TestEnv:
+    """Helper: WS server + manager wired for one test case."""
+
+    def __init__(self) -> None:
+        self.received_from_client: list[str] = []
+        self.client_messages_received: list[dict] = []
+        self.client_permission_requests: list[tuple[dict, str]] = []
+        self.client_disconnected = asyncio.Event()
+        self.server_send_queue: asyncio.Queue[str] = asyncio.Queue()
+
+    async def server_handler(self, ws):
+        async def out():
+            try:
+                while True:
+                    line = await self.server_send_queue.get()
+                    await ws.send(line)
+            except websockets.exceptions.ConnectionClosed:
+                return
+
+        async def inn():
+            try:
+                async for raw in ws:
+                    text = raw if isinstance(raw, str) else raw.decode()
+                    self.received_from_client.append(text)
+            except websockets.exceptions.ConnectionClosed:
+                return
+
+        out_task = asyncio.get_running_loop().create_task(out())
+        in_task = asyncio.get_running_loop().create_task(inn())
+        try:
+            await asyncio.wait(
+                [out_task, in_task], return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            for t in (out_task, in_task):
+                if not t.done():
+                    t.cancel()
+                try:
+                    await t
+                except (asyncio.CancelledError, websockets.exceptions.ConnectionClosed):
+                    pass
+
+    def make_callbacks(self) -> DirectConnectCallbacks:
+        return DirectConnectCallbacks(
+            on_message=lambda m: self.client_messages_received.append(m),
+            on_permission_request=lambda req, rid: self.client_permission_requests.append(
+                (req, rid)
+            ),
+            on_disconnected=lambda: self.client_disconnected.set(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_assistant_message_forwarded_to_on_message():
+    env = _TestEnv()
+    port = _free_port()
+    server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = DirectConnectConfig(
+            server_url=f'http://127.0.0.1:{port}',
+            session_id='s1',
+            ws_url=f'ws://127.0.0.1:{port}/',
+        )
+        mgr = DirectConnectSessionManager(config, env.make_callbacks())
+        await mgr.connect()
+        try:
+            await env.server_send_queue.put(json.dumps({
+                'type': 'assistant', 'uuid': 'u1', 'message': {'content': 'hi'}
+            }))
+            # Give the reader a turn.
+            await asyncio.sleep(0.05)
+            assert len(env.client_messages_received) == 1
+            assert env.client_messages_received[0]['type'] == 'assistant'
+        finally:
+            await mgr.disconnect()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_permission_request_routed_correctly():
+    env = _TestEnv()
+    port = _free_port()
+    server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = DirectConnectConfig(
+            server_url=f'http://127.0.0.1:{port}',
+            session_id='s1',
+            ws_url=f'ws://127.0.0.1:{port}/',
+        )
+        mgr = DirectConnectSessionManager(config, env.make_callbacks())
+        await mgr.connect()
+        try:
+            await env.server_send_queue.put(json.dumps({
+                'type': 'control_request',
+                'request_id': 'req-1',
+                'request': {
+                    'subtype': 'can_use_tool',
+                    'tool_name': 'Bash',
+                    'input': {'command': 'ls'},
+                    'tool_use_id': 'tu-1',
+                },
+            }))
+            await asyncio.sleep(0.05)
+            assert len(env.client_permission_requests) == 1
+            req, rid = env.client_permission_requests[0]
+            assert rid == 'req-1'
+            assert req['tool_name'] == 'Bash'
+
+            # Respond allow.
+            await mgr.respond_to_permission_request(
+                'req-1', AllowResponse(updated_input={'command': 'ls -la'})
+            )
+            await asyncio.sleep(0.05)
+            # Server should have received the response.
+            assert any('control_response' in line for line in env.received_from_client)
+            sent = json.loads(env.received_from_client[-1])
+            assert sent['response']['response']['behavior'] == 'allow'
+            assert sent['response']['response']['updatedInput'] == {'command': 'ls -la'}
+        finally:
+            await mgr.disconnect()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_unknown_control_request_subtype_returns_error():
+    env = _TestEnv()
+    port = _free_port()
+    server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = DirectConnectConfig(
+            server_url=f'http://127.0.0.1:{port}',
+            session_id='s1',
+            ws_url=f'ws://127.0.0.1:{port}/',
+        )
+        mgr = DirectConnectSessionManager(config, env.make_callbacks())
+        await mgr.connect()
+        try:
+            await env.server_send_queue.put(json.dumps({
+                'type': 'control_request',
+                'request_id': 'req-2',
+                'request': {'subtype': 'set_quantum_flux'},
+            }))
+            await asyncio.sleep(0.05)
+            # Permission callback was NOT fired.
+            assert env.client_permission_requests == []
+            # An error response was sent back.
+            assert any(
+                'control_response' in line and 'error' in line
+                for line in env.received_from_client
+            )
+        finally:
+            await mgr.disconnect()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_send_message_round_trip():
+    env = _TestEnv()
+    port = _free_port()
+    server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = DirectConnectConfig(
+            server_url=f'http://127.0.0.1:{port}',
+            session_id='s1',
+            ws_url=f'ws://127.0.0.1:{port}/',
+        )
+        mgr = DirectConnectSessionManager(config, env.make_callbacks())
+        await mgr.connect()
+        try:
+            ok = await mgr.send_message('hello')
+            assert ok is True
+            await asyncio.sleep(0.05)
+            assert len(env.received_from_client) == 1
+            sent = json.loads(env.received_from_client[0])
+            assert sent['type'] == 'user'
+            assert sent['message']['role'] == 'user'
+            assert sent['message']['content'] == 'hello'
+        finally:
+            await mgr.disconnect()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_send_interrupt_emits_control_request():
+    env = _TestEnv()
+    port = _free_port()
+    server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = DirectConnectConfig(
+            server_url=f'http://127.0.0.1:{port}',
+            session_id='s1',
+            ws_url=f'ws://127.0.0.1:{port}/',
+        )
+        mgr = DirectConnectSessionManager(config, env.make_callbacks())
+        await mgr.connect()
+        try:
+            await mgr.send_interrupt()
+            await asyncio.sleep(0.05)
+            assert len(env.received_from_client) == 1
+            sent = json.loads(env.received_from_client[0])
+            assert sent['type'] == 'control_request'
+            assert sent['request']['subtype'] == 'interrupt'
+        finally:
+            await mgr.disconnect()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_fires_on_disconnected():
+    env = _TestEnv()
+    port = _free_port()
+    server = await ws_serve(env.server_handler, '127.0.0.1', port)
+    try:
+        config = DirectConnectConfig(
+            server_url=f'http://127.0.0.1:{port}',
+            session_id='s1',
+            ws_url=f'ws://127.0.0.1:{port}/',
+        )
+        mgr = DirectConnectSessionManager(config, env.make_callbacks())
+        await mgr.connect()
+        await mgr.disconnect()
+        # ``on_disconnected`` may fire from the reader's finally block.
+        await asyncio.wait_for(env.client_disconnected.wait(), timeout=2.0)
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_send_message_returns_false_when_disconnected():
+    env = _TestEnv()
+    config = DirectConnectConfig(
+        server_url='http://x',
+        session_id='s1',
+        ws_url='ws://127.0.0.1:1/',
+    )
+    mgr = DirectConnectSessionManager(config, env.make_callbacks())
+    # Did NOT call connect — should return False without raising.
+    ok = await mgr.send_message('hi')
+    assert ok is False

--- a/tests/server/test_direct_connect_session.py
+++ b/tests/server/test_direct_connect_session.py
@@ -1,0 +1,109 @@
+"""Tests for ``src.server.direct_connect_session``."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from src.server.direct_connect_session import (
+    DirectConnectError,
+    create_direct_connect_session,
+)
+
+
+@pytest.mark.asyncio
+async def test_happy_path():
+    def handler(req: httpx.Request) -> httpx.Response:
+        assert req.method == 'POST'
+        assert req.url.path == '/sessions'
+        body = json.loads(req.content)
+        assert body['cwd'] == '/tmp/work'
+        return httpx.Response(
+            201,
+            json={
+                'session_id': 'cse_abc',
+                'ws_url': 'ws://127.0.0.1:1234/ws/cse_abc?token=tk',
+                'work_dir': '/tmp/work',
+                'auth_token': 'tk',
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        config, work_dir = await create_direct_connect_session(
+            server_url='http://srv', cwd='/tmp/work', client=client,
+        )
+    assert config.session_id == 'cse_abc'
+    assert config.ws_url == 'ws://127.0.0.1:1234/ws/cse_abc?token=tk'
+    assert work_dir == '/tmp/work'
+
+
+@pytest.mark.asyncio
+async def test_passes_auth_token_when_set():
+    def handler(req: httpx.Request) -> httpx.Response:
+        assert req.headers.get('authorization') == 'Bearer my-token'
+        return httpx.Response(
+            201, json={'session_id': 's', 'ws_url': 'ws://x/ws/s'},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await create_direct_connect_session(
+            server_url='http://srv', cwd='/tmp', auth_token='my-token', client=client,
+        )
+
+
+@pytest.mark.asyncio
+async def test_dangerously_skip_permissions_in_body():
+    captured_body: list[dict] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured_body.append(json.loads(req.content))
+        return httpx.Response(
+            201, json={'session_id': 's', 'ws_url': 'ws://x/ws/s'},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await create_direct_connect_session(
+            server_url='http://srv',
+            cwd='/tmp',
+            dangerously_skip_permissions=True,
+            client=client,
+        )
+    assert captured_body[0]['dangerously_skip_permissions'] is True
+
+
+@pytest.mark.asyncio
+async def test_network_error_raises_direct_connect_error():
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError('refused')
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(DirectConnectError, match='Failed to connect'):
+            await create_direct_connect_session(
+                server_url='http://srv', cwd='/tmp', client=client,
+            )
+
+
+@pytest.mark.asyncio
+async def test_non_2xx_raises():
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, content=b'unavailable')
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(DirectConnectError, match='Failed to create session'):
+            await create_direct_connect_session(
+                server_url='http://srv', cwd='/tmp', client=client,
+            )
+
+
+@pytest.mark.asyncio
+async def test_invalid_response_payload_raises():
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(201, json={'session_id': 's'})  # missing ws_url
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(DirectConnectError, match='Invalid session response'):
+            await create_direct_connect_session(
+                server_url='http://srv', cwd='/tmp', client=client,
+            )

--- a/tests/server/test_lockfile.py
+++ b/tests/server/test_lockfile.py
@@ -1,0 +1,54 @@
+"""Tests for ``src.server.lockfile.ServerLockfile``."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.server.lockfile import LockfileBusyError, ServerLockfile
+
+
+def test_acquire_release(tmp_path):
+    p = tmp_path / 'server.lock'
+    lock = ServerLockfile(p)
+    lock.acquire()
+    lock.release()
+    # Idempotent release.
+    lock.release()
+
+
+def test_double_acquire_raises_busy(tmp_path):
+    """Two ServerLockfile instances on the same path can't both hold it."""
+    p = tmp_path / 'server.lock'
+    lock1 = ServerLockfile(p)
+    lock2 = ServerLockfile(p)
+
+    lock1.acquire()
+    try:
+        with pytest.raises(LockfileBusyError):
+            lock2.acquire()
+    finally:
+        lock1.release()
+
+
+def test_lock_releasable_for_subsequent_acquire(tmp_path):
+    p = tmp_path / 'server.lock'
+    lock1 = ServerLockfile(p)
+    lock1.acquire()
+    lock1.release()
+
+    lock2 = ServerLockfile(p)
+    lock2.acquire()  # should succeed
+    lock2.release()
+
+
+def test_context_manager(tmp_path):
+    p = tmp_path / 'server.lock'
+    with ServerLockfile(p):
+        # Inside the context, another lockfile is busy.
+        other = ServerLockfile(p)
+        with pytest.raises(LockfileBusyError):
+            other.acquire()
+    # After exit, lock is released.
+    third = ServerLockfile(p)
+    third.acquire()
+    third.release()

--- a/tests/server/test_server_e2e.py
+++ b/tests/server/test_server_e2e.py
@@ -1,0 +1,237 @@
+"""End-to-end test: DirectConnectServer + DirectConnectSessionManager.
+
+Spins up the real server, connects via the client, exchanges a user
+prompt + assistant response, verifies the session lifecycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+
+from src.server.direct_connect_manager import (
+    DirectConnectCallbacks,
+    DirectConnectSessionManager,
+)
+from src.server.direct_connect_session import (
+    DirectConnectConfig,
+    create_direct_connect_session,
+)
+from src.server.server import AgentHandle, DirectConnectServer
+from src.server.session_index import load_index
+from src.server.session_manager import SessionManager
+from src.server.types import ServerConfig
+
+
+pytestmark = pytest.mark.integration
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('127.0.0.1', 0))
+        return s.getsockname()[1]
+
+
+def _make_fake_agent_factory(scripted_responses: list[dict]):
+    """Returns a SpawnAgent callable; the spawned agent emits ``scripted_responses``
+    when the client sends its first message."""
+
+    async def spawn(session_id: str, cwd: str, perm_mode: str | None) -> AgentHandle:
+        send_queue: asyncio.Queue[dict] = asyncio.Queue()
+        out_queue: asyncio.Queue[dict | None] = asyncio.Queue()
+        first_received = asyncio.Event()
+
+        async def consumer() -> None:
+            await send_queue.get()
+            first_received.set()
+            for resp in scripted_responses:
+                await out_queue.put(resp)
+            await out_queue.put(None)  # sentinel: shutdown
+
+        consumer_task = asyncio.get_running_loop().create_task(consumer())
+
+        async def send_to_agent(msg: dict) -> None:
+            await send_queue.put(msg)
+
+        async def messages_from_agent() -> AsyncIterator[dict]:
+            while True:
+                item = await out_queue.get()
+                if item is None:
+                    return
+                yield item
+
+        async def shutdown() -> None:
+            consumer_task.cancel()
+            try:
+                await consumer_task
+            except asyncio.CancelledError:
+                pass
+
+        return AgentHandle(
+            send_to_agent=send_to_agent,
+            messages_from_agent=messages_from_agent,
+            shutdown=shutdown,
+        )
+
+    return spawn
+
+
+@pytest.mark.asyncio
+async def test_e2e_create_session_and_exchange_message(tmp_path):
+    config = ServerConfig(
+        host='127.0.0.1',
+        port=_free_port(),
+        workspace=str(tmp_path),
+    )
+    manager = SessionManager(workspace=str(tmp_path), index_path=tmp_path / 'idx.json')
+    spawn = _make_fake_agent_factory([
+        {'type': 'assistant', 'uuid': 'a1', 'message': {'content': 'hi back'}},
+    ])
+    server = DirectConnectServer(config=config, manager=manager, spawn_agent=spawn)
+    await server.start()
+
+    serve_task = asyncio.get_running_loop().create_task(server.serve_forever())
+
+    try:
+        # Step 1: POST /sessions via the client helper.
+        cfg, work_dir = await create_direct_connect_session(
+            server_url=f'http://127.0.0.1:{config.port}',
+            cwd=str(tmp_path),
+        )
+        assert cfg.session_id.startswith('ds_')
+        assert work_dir == str(tmp_path)
+
+        # Session should be in the index.
+        idx = load_index(tmp_path / 'idx.json')
+        assert cfg.session_id in idx
+
+        # Step 2: open the WS via DirectConnectSessionManager.
+        received_messages: list[dict] = []
+        disc = asyncio.Event()
+        callbacks = DirectConnectCallbacks(
+            on_message=lambda m: received_messages.append(m),
+            on_permission_request=lambda req, rid: None,
+            on_disconnected=lambda: disc.set(),
+        )
+        client = DirectConnectSessionManager(cfg, callbacks)
+        await client.connect()
+        try:
+            # Step 3: send a user prompt; expect the scripted assistant
+            # response to land via on_message.
+            await client.send_message('hello')
+
+            # Wait for the assistant message (with timeout).
+            for _ in range(50):
+                if received_messages:
+                    break
+                await asyncio.sleep(0.05)
+            assert received_messages, 'expected at least one assistant message'
+            assert received_messages[0]['type'] == 'assistant'
+            assert received_messages[0]['message']['content'] == 'hi back'
+        finally:
+            await client.disconnect()
+
+    finally:
+        await server.stop()
+        serve_task.cancel()
+        try:
+            await serve_task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_e2e_session_persists_across_index_reads(tmp_path):
+    """After session create, the index has the entry; after stop, it's gone."""
+    config = ServerConfig(
+        host='127.0.0.1', port=_free_port(), workspace=str(tmp_path),
+    )
+    manager = SessionManager(workspace=str(tmp_path), index_path=tmp_path / 'idx.json')
+    server = DirectConnectServer(
+        config=config,
+        manager=manager,
+        spawn_agent=_make_fake_agent_factory([]),
+    )
+    await server.start()
+    serve_task = asyncio.get_running_loop().create_task(server.serve_forever())
+
+    try:
+        cfg, _ = await create_direct_connect_session(
+            server_url=f'http://127.0.0.1:{config.port}',
+            cwd=str(tmp_path),
+        )
+        # Session is in the index.
+        assert cfg.session_id in load_index(tmp_path / 'idx.json')
+
+        # Stop it via the manager.
+        await manager.stop_session(cfg.session_id)
+        assert cfg.session_id not in load_index(tmp_path / 'idx.json')
+    finally:
+        await server.stop()
+        serve_task.cancel()
+        try:
+            await serve_task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_e2e_unauthorized_session_create_returns_401(tmp_path):
+    config = ServerConfig(
+        host='127.0.0.1',
+        port=_free_port(),
+        auth_token='secret',
+        workspace=str(tmp_path),
+    )
+    manager = SessionManager(workspace=str(tmp_path), index_path=tmp_path / 'idx.json')
+    server = DirectConnectServer(
+        config=config, manager=manager,
+        spawn_agent=_make_fake_agent_factory([]),
+    )
+    await server.start()
+    serve_task = asyncio.get_running_loop().create_task(server.serve_forever())
+
+    try:
+        # No auth_token passed; server requires one → 401.
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f'http://127.0.0.1:{config.port}/sessions',
+                json={'cwd': str(tmp_path)},
+            )
+        assert resp.status_code == 401
+    finally:
+        await server.stop()
+        serve_task.cancel()
+        try:
+            await serve_task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_e2e_unknown_route_returns_404(tmp_path):
+    config = ServerConfig(host='127.0.0.1', port=_free_port(), workspace=str(tmp_path))
+    manager = SessionManager(workspace=str(tmp_path), index_path=tmp_path / 'idx.json')
+    server = DirectConnectServer(
+        config=config, manager=manager,
+        spawn_agent=_make_fake_agent_factory([]),
+    )
+    await server.start()
+    serve_task = asyncio.get_running_loop().create_task(server.serve_forever())
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f'http://127.0.0.1:{config.port}/nope')
+        assert resp.status_code == 404
+    finally:
+        await server.stop()
+        serve_task.cancel()
+        try:
+            await serve_task
+        except asyncio.CancelledError:
+            pass

--- a/tests/server/test_session_index.py
+++ b/tests/server/test_session_index.py
@@ -1,0 +1,137 @@
+"""Tests for ``src.server.session_index``."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from src.server.session_index import (
+    add_entry,
+    load_index,
+    remove_entry,
+    save_index,
+    update_last_active,
+)
+from src.server.types import SessionIndexEntry
+
+
+def _entry(sid: str = 's1', t: float = 1000.0) -> SessionIndexEntry:
+    return SessionIndexEntry(
+        session_id=sid,
+        transcript_session_id=f'tx_{sid}',
+        cwd='/tmp/work',
+        created_at=t,
+        last_active_at=t,
+    )
+
+
+def test_load_missing_file_returns_empty(tmp_path):
+    assert load_index(tmp_path / 'nope.json') == {}
+
+
+def test_load_invalid_json_returns_empty(tmp_path):
+    p = tmp_path / 'idx.json'
+    p.write_text('not json {{{')
+    assert load_index(p) == {}
+
+
+def test_load_non_object_root_returns_empty(tmp_path):
+    p = tmp_path / 'idx.json'
+    p.write_text('[1, 2, 3]')
+    assert load_index(p) == {}
+
+
+def test_load_skips_malformed_entries(tmp_path):
+    p = tmp_path / 'idx.json'
+    p.write_text(json.dumps({
+        'good': {
+            'session_id': 'good',
+            'transcript_session_id': 'tx',
+            'cwd': '/tmp',
+            'created_at': 1.0,
+            'last_active_at': 2.0,
+        },
+        'bad': {'session_id': 'bad'},  # missing fields
+        'wrong_type': 'not a dict',
+    }))
+    idx = load_index(p)
+    assert 'good' in idx
+    assert 'bad' not in idx
+    assert 'wrong_type' not in idx
+
+
+def test_save_and_load_round_trip(tmp_path):
+    p = tmp_path / 'idx.json'
+    save_index({'s1': _entry('s1')}, p)
+    loaded = load_index(p)
+    assert loaded['s1'].cwd == '/tmp/work'
+    assert loaded['s1'].transcript_session_id == 'tx_s1'
+
+
+def test_add_entry_creates_file(tmp_path):
+    p = tmp_path / 'idx.json'
+    add_entry(_entry('s1'), p)
+    assert load_index(p)['s1'].session_id == 's1'
+
+
+def test_add_entry_replaces_existing(tmp_path):
+    p = tmp_path / 'idx.json'
+    add_entry(_entry('s1', t=100), p)
+    add_entry(_entry('s1', t=200), p)
+    idx = load_index(p)
+    assert idx['s1'].created_at == 200
+
+
+def test_remove_entry(tmp_path):
+    p = tmp_path / 'idx.json'
+    add_entry(_entry('s1'), p)
+    add_entry(_entry('s2'), p)
+    remove_entry('s1', p)
+    idx = load_index(p)
+    assert 's1' not in idx
+    assert 's2' in idx
+
+
+def test_remove_entry_missing_is_noop(tmp_path):
+    p = tmp_path / 'idx.json'
+    add_entry(_entry('s1'), p)
+    remove_entry('nope', p)  # should not raise
+    assert 's1' in load_index(p)
+
+
+def test_update_last_active(tmp_path):
+    p = tmp_path / 'idx.json'
+    add_entry(_entry('s1', t=100), p)
+    update_last_active('s1', 5000.0, p)
+    idx = load_index(p)
+    assert idx['s1'].last_active_at == 5000.0
+    # created_at preserved.
+    assert idx['s1'].created_at == 100.0
+
+
+def test_update_last_active_missing_session_is_noop(tmp_path):
+    p = tmp_path / 'idx.json'
+    add_entry(_entry('s1'), p)
+    update_last_active('nope', 9999.0, p)  # no-op
+    assert load_index(p)['s1'].last_active_at == 1000.0
+
+
+def test_atomic_write_no_leftover_tempfile_on_failure(tmp_path, monkeypatch):
+    """If os.replace fails mid-write, the .tmp file should not survive."""
+    import os
+
+    p = tmp_path / 'idx.json'
+    add_entry(_entry('s1'), p)
+
+    def fail_replace(*args, **kwargs):
+        raise OSError('simulated rename failure')
+
+    monkeypatch.setattr(os, 'replace', fail_replace)
+
+    with pytest.raises(OSError):
+        save_index({'s1': _entry('s1', t=999.0)}, p)
+
+    leftover = list(tmp_path.glob('.server-sessions.*.tmp'))
+    assert leftover == [], f'expected no leftover tempfile, got {leftover}'

--- a/tests/server/test_session_manager.py
+++ b/tests/server/test_session_manager.py
@@ -1,0 +1,146 @@
+"""Tests for ``src.server.session_manager.SessionManager``."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from src.server.session_manager import SessionManager
+from src.server.types import SessionState
+
+
+def _make_manager(tmp_path, **overrides):
+    return SessionManager(
+        workspace=str(tmp_path),
+        index_path=tmp_path / 'idx.json',
+        **overrides,
+    )
+
+
+def test_create_session_assigns_id_and_records_starting(tmp_path):
+    mgr = _make_manager(tmp_path)
+    info = mgr.create_session(cwd='/tmp/work')
+    assert info.id.startswith('ds_')
+    assert info.status == SessionState.STARTING
+    assert info.work_dir == '/tmp/work'
+    # Persisted to the index.
+    from src.server.session_index import load_index
+    idx = load_index(tmp_path / 'idx.json')
+    assert info.id in idx
+
+
+def test_create_session_default_cwd(tmp_path):
+    mgr = _make_manager(tmp_path)
+    info = mgr.create_session()
+    assert info.work_dir == str(tmp_path)
+
+
+def test_max_sessions_enforced(tmp_path):
+    mgr = _make_manager(tmp_path, max_sessions=2)
+    mgr.create_session()
+    mgr.create_session()
+    with pytest.raises(RuntimeError, match='max_sessions'):
+        mgr.create_session()
+
+
+def test_mark_running_updates_state(tmp_path):
+    mgr = _make_manager(tmp_path)
+    info = mgr.create_session()
+    mgr.mark_running(info.id)
+    assert mgr.get(info.id).status == SessionState.RUNNING
+
+
+def test_mark_detached_updates_state(tmp_path):
+    mgr = _make_manager(tmp_path)
+    info = mgr.create_session()
+    mgr.mark_detached(info.id)
+    assert mgr.get(info.id).status == SessionState.DETACHED
+
+
+@pytest.mark.asyncio
+async def test_stop_session_removes_from_index(tmp_path):
+    mgr = _make_manager(tmp_path)
+    info = mgr.create_session()
+    await mgr.stop_session(info.id)
+    assert mgr.get(info.id) is None
+    from src.server.session_index import load_index
+    assert info.id not in load_index(tmp_path / 'idx.json')
+
+
+@pytest.mark.asyncio
+async def test_stop_unknown_session_is_noop(tmp_path):
+    mgr = _make_manager(tmp_path)
+    await mgr.stop_session('does-not-exist')
+
+
+def test_active_session_ids_filters_stopped(tmp_path):
+    mgr = _make_manager(tmp_path)
+    a = mgr.create_session()
+    b = mgr.create_session()
+    mgr.mark_running(a.id)
+    assert set(mgr.active_session_ids()) == {a.id, b.id}
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_detached_zero_timeout_no_op(tmp_path):
+    mgr = _make_manager(tmp_path, idle_timeout_ms=0)
+    info = mgr.create_session()
+    mgr.mark_detached(info.id)
+    stopped = await mgr.reap_idle_detached()
+    assert stopped == []
+    assert mgr.get(info.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_detached_stops_old_detached(tmp_path):
+    """Reaper uses last_active_at, not created_at — push it into the past."""
+    mgr = _make_manager(tmp_path, idle_timeout_ms=500)
+    info = mgr.create_session()
+    mgr.mark_detached(info.id)
+    mgr.get(info.id).last_active_at = time.time() - 10
+    stopped = await mgr.reap_idle_detached()
+    assert stopped == [info.id]
+    assert mgr.get(info.id) is None
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_detached_skips_running(tmp_path):
+    """RUNNING sessions are NOT reaped — only DETACHED."""
+    mgr = _make_manager(tmp_path, idle_timeout_ms=500)
+    info = mgr.create_session()
+    mgr.mark_running(info.id)
+    mgr.get(info.id).last_active_at = time.time() - 10
+    stopped = await mgr.reap_idle_detached()
+    assert stopped == []
+    assert mgr.get(info.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_detached_uses_last_active_not_created_at(tmp_path):
+    """Long-lived session that was active recently must NOT be reaped."""
+    mgr = _make_manager(tmp_path, idle_timeout_ms=500)
+    info = mgr.create_session()
+    mgr.mark_detached(info.id)
+    # Created hours ago (would be reaped under the old buggy logic) but
+    # active just now — must NOT be reaped.
+    mgr.get(info.id).created_at = time.time() - 3600
+    mgr.get(info.id).last_active_at = time.time()
+    stopped = await mgr.reap_idle_detached()
+    assert stopped == []
+    assert mgr.get(info.id) is not None
+
+
+def test_touch_bumps_last_active_at(tmp_path):
+    """SessionManager.touch updates last_active_at to now."""
+    mgr = _make_manager(tmp_path)
+    info = mgr.create_session()
+    info.last_active_at = time.time() - 1000
+    mgr.touch(info.id)
+    assert mgr.get(info.id).last_active_at > time.time() - 1
+
+
+def test_touch_unknown_session_is_noop(tmp_path):
+    mgr = _make_manager(tmp_path)
+    mgr.touch('not-a-session')  # should not raise

--- a/tests/server/test_types.py
+++ b/tests/server/test_types.py
@@ -1,0 +1,58 @@
+"""Tests for ``src.server.types``."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.server.types import (
+    SessionState,
+    validate_connect_response,
+)
+
+
+class TestSessionState:
+    def test_five_state_lifecycle(self) -> None:
+        """Mirror TS server/types.ts:26-31."""
+        assert {s.value for s in SessionState} == {
+            'starting', 'running', 'detached', 'stopping', 'stopped'
+        }
+
+    def test_serializes_as_string(self) -> None:
+        assert SessionState.RUNNING.value == 'running'
+        assert str(SessionState.RUNNING.value) == 'running'
+
+
+class TestValidateConnectResponse:
+    def test_minimal_valid_payload(self) -> None:
+        out = validate_connect_response({'session_id': 'cse_abc', 'ws_url': 'ws://x:1/ws/y'})
+        assert out['session_id'] == 'cse_abc'
+        assert out['ws_url'] == 'ws://x:1/ws/y'
+        assert 'work_dir' not in out
+
+    def test_with_optional_work_dir(self) -> None:
+        out = validate_connect_response({
+            'session_id': 's', 'ws_url': 'ws://x:1/ws/s', 'work_dir': '/tmp',
+        })
+        assert out['work_dir'] == '/tmp'
+
+    def test_rejects_non_dict(self) -> None:
+        with pytest.raises(ValueError, match='must be an object'):
+            validate_connect_response([])
+
+    def test_rejects_missing_session_id(self) -> None:
+        with pytest.raises(ValueError, match='session_id'):
+            validate_connect_response({'ws_url': 'ws://x'})
+
+    def test_rejects_empty_session_id(self) -> None:
+        with pytest.raises(ValueError, match='session_id'):
+            validate_connect_response({'session_id': '', 'ws_url': 'ws://x'})
+
+    def test_rejects_missing_ws_url(self) -> None:
+        with pytest.raises(ValueError, match='ws_url'):
+            validate_connect_response({'session_id': 's'})
+
+    def test_rejects_non_string_work_dir(self) -> None:
+        with pytest.raises(ValueError, match='work_dir'):
+            validate_connect_response({
+                'session_id': 's', 'ws_url': 'ws://x', 'work_dir': 42,
+            })

--- a/tests/server/test_url_scheme.py
+++ b/tests/server/test_url_scheme.py
@@ -1,0 +1,72 @@
+"""Tests for ``src.server.url_scheme``."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.server.url_scheme import parse_cc_url
+
+
+class TestCcTcp:
+    def test_basic(self) -> None:
+        addr = parse_cc_url('cc://127.0.0.1:8765/sess_abc')
+        assert addr.scheme == 'cc'
+        assert addr.host_or_socket == '127.0.0.1'
+        assert addr.port == 8765
+        assert addr.session_id == 'sess_abc'
+        assert addr.query == {}
+
+    def test_no_port(self) -> None:
+        addr = parse_cc_url('cc://localhost/sess_abc')
+        assert addr.host_or_socket == 'localhost'
+        assert addr.port is None
+
+    def test_with_query(self) -> None:
+        addr = parse_cc_url('cc://h:1/sid?token=tk&foo=bar')
+        assert addr.query == {'token': 'tk', 'foo': 'bar'}
+
+    def test_invalid_port(self) -> None:
+        with pytest.raises(ValueError, match='invalid port'):
+            parse_cc_url('cc://h:abc/sid')
+
+    def test_port_out_of_range(self) -> None:
+        with pytest.raises(ValueError, match='port out of range'):
+            parse_cc_url('cc://h:99999/sid')
+
+    def test_missing_session(self) -> None:
+        with pytest.raises(ValueError, match='session ID'):
+            parse_cc_url('cc://h:1/')
+
+    def test_missing_authority(self) -> None:
+        with pytest.raises(ValueError):
+            parse_cc_url('cc:///sid')
+
+
+class TestCcUnix:
+    def test_basic(self) -> None:
+        addr = parse_cc_url('cc+unix:///var/run/claude/sock/sess_abc')
+        assert addr.scheme == 'cc+unix'
+        assert addr.host_or_socket == '/var/run/claude/sock'
+        assert addr.port is None
+        assert addr.session_id == 'sess_abc'
+
+    def test_socket_path_with_query(self) -> None:
+        addr = parse_cc_url('cc+unix:///tmp/x.sock/sid?token=tk')
+        assert addr.host_or_socket == '/tmp/x.sock'
+        assert addr.session_id == 'sid'
+        assert addr.query == {'token': 'tk'}
+
+    def test_deep_socket_path(self) -> None:
+        addr = parse_cc_url('cc+unix:///a/b/c/d/e/sid')
+        assert addr.host_or_socket == '/a/b/c/d/e'
+        assert addr.session_id == 'sid'
+
+
+class TestSchemeDispatch:
+    def test_unsupported_scheme(self) -> None:
+        with pytest.raises(ValueError, match='unsupported scheme'):
+            parse_cc_url('http://example.com/foo')
+
+    def test_empty_string(self) -> None:
+        with pytest.raises(ValueError):
+            parse_cc_url('')

--- a/tests/transports/test_ccr_client.py
+++ b/tests/transports/test_ccr_client.py
@@ -1,0 +1,190 @@
+"""Tests for ``src.transports.ccr_client.CCRClient``."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from src.bridge.exceptions import EpochSupersededError
+from src.transports.ccr_client import CCRClient, CCRClientOptions
+
+
+@pytest.mark.asyncio
+async def test_initialize_spawns_loops_and_uploads_event():
+    received: list[dict] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path == '/worker/events':
+            body = json.loads(req.content)
+            received.extend(body.get('events', []))
+            return httpx.Response(200, json={})
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = CCRClient(
+            base_url='https://api.test',
+            options=CCRClientOptions(heartbeat_interval_seconds=0),
+            http_client=http,
+        )
+        await client.initialize(epoch=1)
+        try:
+            await client.write_event({'type': 'user', 'uuid': 'u1'})
+            await client.flush()
+            assert received == [{'type': 'user', 'uuid': 'u1'}]
+        finally:
+            await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_write_batch_groups_multiple_events():
+    received_batches: list[list[dict]] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path == '/worker/events':
+            body = json.loads(req.content)
+            received_batches.append(body['events'])
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = CCRClient(
+            base_url='https://api.test',
+            options=CCRClientOptions(
+                heartbeat_interval_seconds=0,
+                max_batch_size=10,
+            ),
+            http_client=http,
+        )
+        await client.initialize(epoch=1)
+        try:
+            # Drop several events into the queue rapidly; the uploader
+            # should batch them in a single POST after the first read.
+            for i in range(5):
+                await client.write_event({'type': 'user', 'uuid': f'u{i}'})
+            await client.flush()
+        finally:
+            await client.aclose()
+
+    # All 5 should have been delivered. Batching is opportunistic — the
+    # first event triggers the post; subsequent events arriving before
+    # the post completes get batched.
+    flat = [e for batch in received_batches for e in batch]
+    assert len(flat) == 5
+    assert {e['uuid'] for e in flat} == {f'u{i}' for i in range(5)}
+
+
+@pytest.mark.asyncio
+async def test_409_raises_epoch_superseded_error():
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(409, json={'error': 'epoch superseded'})
+
+    callback_fired = asyncio.Event()
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = CCRClient(
+            base_url='https://api.test',
+            options=CCRClientOptions(
+                heartbeat_interval_seconds=0,
+                on_epoch_mismatch=callback_fired.set,
+            ),
+            http_client=http,
+        )
+        await client.initialize(epoch=1)
+        try:
+            await client.write_event({'type': 'user', 'uuid': 'u1'})
+            # Wait for the uploader to attempt the POST and hit 409.
+            for _ in range(100):
+                if callback_fired.is_set():
+                    break
+                await asyncio.sleep(0.02)
+        finally:
+            await client.aclose()
+
+    assert callback_fired.is_set()
+
+
+@pytest.mark.asyncio
+async def test_dropped_batch_count_tracks_5xx_failures():
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, content=b'unavailable')
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = CCRClient(
+            base_url='https://api.test',
+            options=CCRClientOptions(
+                heartbeat_interval_seconds=0,
+                max_retries_per_batch=2,
+                retry_backoff_seconds=0.01,
+            ),
+            http_client=http,
+        )
+        await client.initialize(epoch=1)
+        try:
+            for i in range(5):
+                await client.write_event({'type': 'user', 'uuid': f'u{i}'})
+            # Wait for the uploader to exhaust retries.
+            for _ in range(200):
+                if client.dropped_batch_count > 0:
+                    break
+                await asyncio.sleep(0.02)
+        finally:
+            await client.aclose()
+
+    assert client.dropped_batch_count > 0
+
+
+@pytest.mark.asyncio
+async def test_report_state_metadata_delivery_fire_and_forget():
+    """report_state/metadata/delivery POST without raising."""
+    seen_paths: list[str] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen_paths.append(req.url.path)
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = CCRClient(
+            base_url='https://api.test',
+            options=CCRClientOptions(heartbeat_interval_seconds=0),
+            http_client=http,
+        )
+        await client.initialize(epoch=1)
+        try:
+            client.report_state({'requires_action': True})
+            client.report_metadata({'custom': 'value'})
+            client.report_delivery('event-1', 'received')
+            await asyncio.sleep(0.1)
+        finally:
+            await client.aclose()
+
+    # All three paths should have been hit.
+    assert any('/worker' == p for p in seen_paths)  # state + metadata both hit /worker (PUT)
+    assert any('/worker/events/event-1/delivery' == p for p in seen_paths)
+
+
+@pytest.mark.asyncio
+async def test_write_after_close_increments_dropped():
+    async with httpx.AsyncClient() as http:
+        client = CCRClient(
+            base_url='https://api.test',
+            options=CCRClientOptions(heartbeat_interval_seconds=0),
+            http_client=http,
+        )
+        await client.initialize(epoch=1)
+        await client.aclose()
+        await client.write_event({'type': 'user', 'uuid': 'u1'})
+    assert client.dropped_batch_count == 1
+
+
+@pytest.mark.asyncio
+async def test_write_before_initialize_increments_dropped():
+    async with httpx.AsyncClient() as http:
+        client = CCRClient(
+            base_url='https://api.test',
+            options=CCRClientOptions(heartbeat_interval_seconds=0),
+            http_client=http,
+        )
+        await client.write_event({'type': 'user', 'uuid': 'u1'})
+    assert client.dropped_batch_count == 1

--- a/tests/transports/test_sse_transport.py
+++ b/tests/transports/test_sse_transport.py
@@ -1,0 +1,213 @@
+"""Tests for ``src.transports.sse_transport.SSETransport``.
+
+Uses ``httpx.MockTransport`` to inject SSE-formatted responses and
+asserts the parsed event flow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from src.bridge.close_codes import WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED
+from src.transports.sse_transport import SSEEvent, SSETransport
+
+
+def _sse_response(events: list[tuple[str | None, str]]) -> bytes:
+    """Build a fake SSE response body. Each event is ``(id, data)``."""
+    out: list[str] = []
+    for eid, data in events:
+        if eid is not None:
+            out.append(f'id: {eid}')
+        out.append(f'data: {data}')
+        out.append('')  # blank line terminates the event
+    return ('\n'.join(out) + '\n').encode('utf-8')
+
+
+@pytest.mark.asyncio
+async def test_basic_event_dispatch():
+    body = _sse_response([
+        ('1', 'first'),
+        ('2', 'second'),
+    ])
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={'content-type': 'text/event-stream'},
+            content=body,
+        )
+
+    received_data: list[str] = []
+    received_events: list[SSEEvent] = []
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sse = SSETransport(
+            url='https://api.test/stream',
+            client=client,
+        )
+        sse.set_on_data(received_data.append)
+        sse.set_on_event(received_events.append)
+        await sse.connect()
+        # Allow the read-loop to drain the (already-buffered) response.
+        for _ in range(50):
+            if len(received_data) >= 2:
+                break
+            await asyncio.sleep(0.02)
+        await sse.aclose()
+
+    assert received_data == ['first', 'second']
+    assert [e.event_id for e in received_events] == ['1', '2']
+
+
+@pytest.mark.asyncio
+async def test_get_last_sequence_num_tracks_event_id():
+    body = _sse_response([('100', 'a'), ('200', 'b'), ('300', 'c')])
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={'content-type': 'text/event-stream'},
+            content=body,
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sse = SSETransport(url='https://api.test/stream', client=client)
+        sse.set_on_data(lambda _: None)
+        await sse.connect()
+        for _ in range(50):
+            if sse.get_last_sequence_num() >= 300:
+                break
+            await asyncio.sleep(0.02)
+        await sse.aclose()
+
+    assert sse.get_last_sequence_num() == 300
+
+
+@pytest.mark.asyncio
+async def test_last_event_id_passed_on_reconnect():
+    """Per Risk #21: SSETransport must pass Last-Event-ID on reconnect."""
+    request_headers: list[dict] = []
+    body = _sse_response([('5', 'x')])
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        request_headers.append({k.lower(): v for k, v in req.headers.items()})
+        return httpx.Response(
+            200,
+            headers={'content-type': 'text/event-stream'},
+            content=body,
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sse = SSETransport(
+            url='https://api.test/stream',
+            client=client,
+            reconnect_delay_seconds=0.01,
+            reconnect_budget=2,
+        )
+        sse.set_on_data(lambda _: None)
+        await sse.connect()
+        # Wait long enough for two reconnect attempts.
+        for _ in range(100):
+            if len(request_headers) >= 2:
+                break
+            await asyncio.sleep(0.02)
+        await sse.aclose()
+
+    # First request: no Last-Event-ID. Second: has '5'.
+    assert len(request_headers) >= 2
+    assert request_headers[0].get('last-event-id') is None
+    assert request_headers[1].get('last-event-id') == '5'
+
+
+@pytest.mark.asyncio
+async def test_reconnect_budget_exhausted_fires_close():
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError('refused')
+
+    received_close: list[int | None] = []
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sse = SSETransport(
+            url='https://api.test/stream',
+            client=client,
+            reconnect_delay_seconds=0.01,
+            reconnect_budget=2,
+        )
+        sse.set_on_close(received_close.append)
+        await sse.connect()
+        # Wait for the budget to be exhausted.
+        for _ in range(100):
+            if received_close:
+                break
+            await asyncio.sleep(0.02)
+        await sse.aclose()
+
+    assert received_close == [WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED]
+
+
+@pytest.mark.asyncio
+async def test_get_auth_headers_called_on_each_connect():
+    call_count = 0
+
+    def auth_headers() -> dict[str, str]:
+        nonlocal call_count
+        call_count += 1
+        return {'Authorization': f'Bearer tok-{call_count}'}
+
+    captured_auth: list[str] = []
+    body = _sse_response([('1', 'x')])
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured_auth.append(req.headers.get('authorization', ''))
+        return httpx.Response(
+            200,
+            headers={'content-type': 'text/event-stream'},
+            content=body,
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sse = SSETransport(
+            url='https://api.test/stream',
+            client=client,
+            get_auth_headers=auth_headers,
+            reconnect_delay_seconds=0.01,
+            reconnect_budget=2,
+        )
+        sse.set_on_data(lambda _: None)
+        await sse.connect()
+        for _ in range(100):
+            if len(captured_auth) >= 2:
+                break
+            await asyncio.sleep(0.02)
+        await sse.aclose()
+
+    # Each connect attempt re-evaluates get_auth_headers (token refresh).
+    assert len(captured_auth) >= 2
+    assert captured_auth[0] != captured_auth[1]
+
+
+@pytest.mark.asyncio
+async def test_close_terminates_loop():
+    body = _sse_response([('1', 'x')])
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={'content-type': 'text/event-stream'},
+            content=body,
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sse = SSETransport(
+            url='https://api.test/stream',
+            client=client,
+            reconnect_delay_seconds=10,  # would block reconnect for ages
+        )
+        sse.set_on_data(lambda _: None)
+        await sse.connect()
+        await asyncio.sleep(0.05)
+        await sse.aclose()  # should not hang
+        assert sse.is_closed_status()

--- a/tests/upstreamproxy/test_ca_bundle.py
+++ b/tests/upstreamproxy/test_ca_bundle.py
@@ -1,0 +1,184 @@
+"""Tests for ``src.upstreamproxy.ca_bundle``.
+
+Mirrors ``typescript/src/upstreamproxy/upstreamproxy.test.ts:1-43``
+plus the ``download_ca_bundle`` happy path + failure cases.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from src.upstreamproxy.ca_bundle import download_ca_bundle, is_valid_pem_content
+
+# ─── is_valid_pem_content (replicates upstreamproxy.test.ts:1-43) ────────
+
+
+def test_pem_single_block() -> None:
+    pem = '\n'.join([
+        '-----BEGIN CERTIFICATE-----',
+        'MIICpDCCAYwCCQDU+pQ4pHgSpDANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls',
+        'b2NhbGhvc3QwHhcNMjMwMTAxMDAwMDAwWhcNMjQwMTAxMDAwMDAwWjAUMRIwEAYD',
+        'VQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7',
+        '-----END CERTIFICATE-----',
+    ])
+    assert is_valid_pem_content(pem)
+
+
+def test_pem_multiple_blocks() -> None:
+    block = '-----BEGIN CERTIFICATE-----\nABCD\n-----END CERTIFICATE-----'
+    assert is_valid_pem_content(f'{block}\n{block}')
+
+
+def test_arbitrary_text_rejected() -> None:
+    assert not is_valid_pem_content('Hello world')
+    assert not is_valid_pem_content('<html><body>error</body></html>')
+    assert not is_valid_pem_content('{"error":"unauthorized"}')
+
+
+def test_empty_string_rejected() -> None:
+    assert not is_valid_pem_content('')
+
+
+def test_whitespace_only_rejected() -> None:
+    assert not is_valid_pem_content('   \n   ')
+
+
+def test_malformed_pem_no_end_marker_rejected() -> None:
+    assert not is_valid_pem_content('-----BEGIN CERTIFICATE-----\nABCD')
+
+
+def test_bytes_input_accepted() -> None:
+    """is_valid_pem_content accepts both str and bytes."""
+    pem_bytes = b'-----BEGIN CERTIFICATE-----\nABCD\n-----END CERTIFICATE-----'
+    assert is_valid_pem_content(pem_bytes)
+    assert not is_valid_pem_content(b'not pem')
+    assert not is_valid_pem_content(b'')
+
+
+# ─── download_ca_bundle ──────────────────────────────────────────────────
+
+
+_GOOD_PEM = (
+    b'-----BEGIN CERTIFICATE-----\n'
+    b'MIICpDCCAYwCCQDU+pQ4pHgSpDANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls\n'
+    b'-----END CERTIFICATE-----\n'
+)
+
+
+@pytest.mark.asyncio
+async def test_happy_path_writes_concatenated_bundle(tmp_path):
+    """200 OK with PEM body → file written = system + CCR PEM."""
+    system_ca = tmp_path / 'system.crt'
+    system_ca.write_bytes(b'SYSTEM_CA_BYTES\n')
+    out = tmp_path / 'merged.crt'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == '/v1/code/upstreamproxy/ca-cert'
+        return httpx.Response(200, content=_GOOD_PEM)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        ok = await download_ca_bundle('https://api.test', system_ca, out, client=client)
+
+    assert ok is True
+    written = out.read_bytes()
+    assert b'SYSTEM_CA_BYTES' in written
+    assert _GOOD_PEM in written
+    # System CA comes BEFORE the CCR PEM (per upstreamproxy.ts:295).
+    assert written.index(b'SYSTEM_CA_BYTES') < written.index(_GOOD_PEM)
+
+
+@pytest.mark.asyncio
+async def test_missing_system_ca_falls_through(tmp_path):
+    """System CA file missing — still works, writes only the CCR PEM."""
+    out = tmp_path / 'merged.crt'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=_GOOD_PEM)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        ok = await download_ca_bundle(
+            'https://api.test', tmp_path / 'nonexistent.crt', out, client=client
+        )
+    assert ok is True
+    assert _GOOD_PEM in out.read_bytes()
+
+
+@pytest.mark.asyncio
+async def test_non_2xx_returns_false(tmp_path):
+    """500 from server → fail-open, returns False, no file written."""
+    out = tmp_path / 'merged.crt'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, content=b'oops')
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        ok = await download_ca_bundle(
+            'https://api.test', tmp_path / 'sys.crt', out, client=client
+        )
+    assert ok is False
+    assert not out.exists()
+
+
+@pytest.mark.asyncio
+async def test_non_pem_response_returns_false(tmp_path):
+    """200 OK but body is HTML — refuse to write, fail open."""
+    out = tmp_path / 'merged.crt'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b'<html>not a cert</html>')
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        ok = await download_ca_bundle(
+            'https://api.test', tmp_path / 'sys.crt', out, client=client
+        )
+    assert ok is False
+    assert not out.exists()
+
+
+@pytest.mark.asyncio
+async def test_network_error_returns_false(tmp_path):
+    """Connection error (e.g., DNS fail, refused) → fail open."""
+    out = tmp_path / 'merged.crt'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError('connection refused')
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        ok = await download_ca_bundle(
+            'https://api.test', tmp_path / 'sys.crt', out, client=client
+        )
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_atomic_write_no_partial_file_on_crash(tmp_path, monkeypatch):
+    """Simulate fsync failure: the .tmp file should not survive."""
+    out = tmp_path / 'merged.crt'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=_GOOD_PEM)
+
+    # Force os.replace to fail after the temp file is written.
+    import os as _os
+
+    original_replace = _os.replace
+
+    def fail_replace(*args, **kwargs):
+        raise OSError('simulated rename failure')
+
+    monkeypatch.setattr(_os, 'replace', fail_replace)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        ok = await download_ca_bundle(
+            'https://api.test', tmp_path / 'sys.crt', out, client=client
+        )
+
+    assert ok is False
+    assert not out.exists()
+    # No .tmp file should be left behind.
+    leftover = list(tmp_path.glob('.ca-bundle.*.tmp'))
+    assert leftover == [], f'expected no leftover tempfile, got {leftover}'
+
+    # Restore for subsequent tests.
+    monkeypatch.setattr(_os, 'replace', original_replace)

--- a/tests/upstreamproxy/test_protobuf_codec.py
+++ b/tests/upstreamproxy/test_protobuf_codec.py
@@ -1,0 +1,113 @@
+"""Tests for ``src.upstreamproxy.protobuf_codec``."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.upstreamproxy.protobuf_codec import (
+    WIRE_TAG_FIELD1_LEN_DELIMITED,
+    decode_chunk,
+    encode_chunk,
+)
+
+
+class TestEncodeChunk:
+    def test_empty_payload(self) -> None:
+        out = encode_chunk(b'')
+        assert out == bytes([0x0A, 0x00])
+
+    def test_single_byte_payload(self) -> None:
+        out = encode_chunk(b'X')
+        assert out == bytes([0x0A, 0x01, ord('X')])
+
+    def test_one_byte_varint_127(self) -> None:
+        """127 is the max value that fits in a single varint byte."""
+        out = encode_chunk(b'A' * 127)
+        assert out[0] == 0x0A
+        assert out[1] == 127  # one varint byte; high bit clear
+        assert out[2:] == b'A' * 127
+
+    def test_two_byte_varint_128(self) -> None:
+        """128 takes 2 varint bytes (high bit set on the first)."""
+        out = encode_chunk(b'B' * 128)
+        assert out[0] == 0x0A
+        assert out[1] == 0x80  # low 7 bits = 0, continuation bit set
+        assert out[2] == 0x01  # high bits = 1, no continuation
+        assert out[3:] == b'B' * 128
+
+    def test_three_byte_varint_16384(self) -> None:
+        """16384 = 2^14 takes 3 varint bytes."""
+        n = 16384
+        out = encode_chunk(b'C' * n)
+        assert out[0] == 0x0A
+        assert out[1] == 0x80
+        assert out[2] == 0x80
+        assert out[3] == 0x01
+        assert len(out) == 4 + n
+
+
+class TestDecodeChunk:
+    def test_decode_empty_keepalive(self) -> None:
+        """Empty input is the server keepalive — return empty bytes."""
+        assert decode_chunk(b'') == b''
+
+    def test_decode_zero_length_chunk(self) -> None:
+        """0x0a 0x00 — well-formed chunk with empty payload."""
+        assert decode_chunk(bytes([0x0A, 0x00])) == b''
+
+    def test_decode_single_byte(self) -> None:
+        assert decode_chunk(bytes([0x0A, 0x01, ord('X')])) == b'X'
+
+    def test_decode_two_byte_varint(self) -> None:
+        payload = b'B' * 128
+        encoded = bytes([0x0A, 0x80, 0x01]) + payload
+        assert decode_chunk(encoded) == payload
+
+    def test_decode_wrong_tag_returns_none(self) -> None:
+        """First byte must be 0x0a; anything else is malformed."""
+        assert decode_chunk(bytes([0x05, 0x00])) is None
+        assert decode_chunk(bytes([0xFF, 0x00])) is None
+
+    def test_decode_truncated_payload_returns_none(self) -> None:
+        """Declared length > remaining buffer."""
+        assert decode_chunk(bytes([0x0A, 0x05, ord('A'), ord('B')])) is None
+
+    def test_decode_truncated_varint_returns_none(self) -> None:
+        """Continuation bit set on the last byte — varint never terminates."""
+        # 0x80 0x80 0x80 (all continuation bits) — runs off the end.
+        assert decode_chunk(bytes([0x0A, 0x80, 0x80, 0x80])) is None
+
+    def test_decode_overflowed_varint_returns_none(self) -> None:
+        """Varint shift > 28 means a 5+-byte length — out of bounds."""
+        # 5 bytes all with continuation bit set, then one without.
+        encoded = bytes([0x0A, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01])
+        # Should reject before the final byte (shift exceeds limit).
+        assert decode_chunk(encoded) is None
+
+
+class TestRoundTrip:
+    @pytest.mark.parametrize('size', [0, 1, 7, 127, 128, 16383, 16384, 65536])
+    def test_round_trip(self, size: int) -> None:
+        original = bytes(range(256)) * (size // 256) + bytes(range(size % 256))
+        # Adjust size: the construction above doesn't quite equal `size`
+        # for sizes that aren't multiples of 256.
+        original = original[:size] if len(original) >= size else original + b'\x00' * (
+            size - len(original)
+        )
+        assert len(original) == size
+        encoded = encode_chunk(original)
+        decoded = decode_chunk(encoded)
+        assert decoded == original
+
+    def test_concat_chunks_decoded_independently(self) -> None:
+        """Two chunks concatenated: decoder reads the first; second is leftover."""
+        a = encode_chunk(b'first')
+        b = encode_chunk(b'second')
+        assert decode_chunk(a + b) == b'first'
+        # Decoder doesn't return leftover; consumers split on encode.
+
+
+def test_tag_constant_is_correct() -> None:
+    """Tag = (field_number << 3) | wire_type = (1 << 3) | 2 = 0x0a."""
+    assert WIRE_TAG_FIELD1_LEN_DELIMITED == 0x0A
+    assert WIRE_TAG_FIELD1_LEN_DELIMITED == (1 << 3) | 2

--- a/tests/upstreamproxy/test_ptrace_guard.py
+++ b/tests/upstreamproxy/test_ptrace_guard.py
@@ -1,0 +1,45 @@
+"""Tests for ``src.upstreamproxy.ptrace_guard``.
+
+Most tests are platform-gated. The actual prctl invocation only runs on
+Linux (gated by ``@pytest.mark.linux_only``); on macOS/Windows we
+verify the no-op return.
+"""
+
+from __future__ import annotations
+
+import platform
+
+import pytest
+
+from src.upstreamproxy.ptrace_guard import PR_SET_DUMPABLE, set_non_dumpable
+
+
+def test_pr_set_dumpable_constant() -> None:
+    """Operation code from <linux/prctl.h> is 4."""
+    assert PR_SET_DUMPABLE == 4
+
+
+def test_non_linux_returns_false() -> None:
+    """On macOS/Windows, set_non_dumpable is a no-op returning False."""
+    if platform.system() == 'Linux':
+        pytest.skip('platform-specific test for non-Linux')
+    assert set_non_dumpable() is False
+
+
+@pytest.mark.linux_only
+def test_linux_returns_true() -> None:
+    """On Linux, prctl(PR_SET_DUMPABLE, 0) succeeds."""
+    if platform.system() != 'Linux':
+        pytest.skip('Linux-only test')
+    assert set_non_dumpable() is True
+
+
+def test_no_exception_on_failure() -> None:
+    """Whatever the underlying call does, set_non_dumpable must NEVER raise.
+
+    Per chapter "Apply This" rule #5 (fail-open semantics).
+    """
+    # Just call it; no platform-specific expectation. The only requirement
+    # is that the call returns rather than raising.
+    result = set_non_dumpable()
+    assert isinstance(result, bool)

--- a/tests/upstreamproxy/test_relay_e2e.py
+++ b/tests/upstreamproxy/test_relay_e2e.py
@@ -1,0 +1,174 @@
+"""End-to-end test for the CONNECT-over-WS relay.
+
+Runs an in-process echo WS server, starts the relay pointing at it,
+opens a TCP CONNECT to the relay, sends bytes, asserts they round-trip
+back through both legs (encoded → WS → echoed → decoded → TCP client).
+
+Marked ``@pytest.mark.integration`` because it spins up real TCP +
+real WS listeners on ephemeral ports.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import pytest
+import websockets
+from websockets.asyncio.server import serve as ws_serve
+
+from src.upstreamproxy.protobuf_codec import decode_chunk, encode_chunk
+from src.upstreamproxy.relay import start_upstream_proxy_relay
+
+
+pytestmark = pytest.mark.integration
+
+
+async def _echo_handler(ws: websockets.asyncio.server.ServerConnection) -> None:
+    """Echo handler: every chunk in → same chunk out.
+
+    Plus we synthesize the ``HTTP/1.1 200 Connection Established`` reply
+    that the real CCR server sends after parsing the first inner chunk
+    (the CONNECT request line + Proxy-Authorization). This satisfies the
+    relay's ``established`` gate so subsequent traffic flows through.
+    """
+    saw_connect = False
+    try:
+        async for raw in ws:
+            assert isinstance(raw, (bytes, bytearray))
+            payload = decode_chunk(bytes(raw))
+            if payload is None:
+                continue
+            if not saw_connect:
+                # First inner chunk is the CONNECT line + Proxy-Auth.
+                assert payload.startswith(b'CONNECT '), payload[:32]
+                saw_connect = True
+                # Send the synthesized 200 response back over the tunnel.
+                await ws.send(encode_chunk(b'HTTP/1.1 200 Connection Established\r\n\r\n'))
+                continue
+            # Plain echo for everything else.
+            await ws.send(encode_chunk(payload))
+    except websockets.exceptions.ConnectionClosed:
+        return
+
+
+def _free_port() -> int:
+    """Bind ephemeral port, immediately release for the WS server to take."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('127.0.0.1', 0))
+        return s.getsockname()[1]
+
+
+@pytest.mark.asyncio
+async def test_relay_round_trip_echo() -> None:
+    """CONNECT to the relay, exchange bytes, verify echo through both legs."""
+    ws_port = _free_port()
+
+    # Start the in-process echo WS server.
+    ws_server = await ws_serve(_echo_handler, '127.0.0.1', ws_port)
+    try:
+        ws_url = f'ws://127.0.0.1:{ws_port}/v1/code/upstreamproxy/ws'
+        relay = await start_upstream_proxy_relay(
+            ws_url=ws_url, session_id='cse_test', token='secret-token'
+        )
+        try:
+            # Open a TCP connection to the relay and send a CONNECT.
+            reader, writer = await asyncio.open_connection('127.0.0.1', relay.port)
+            try:
+                writer.write(b'CONNECT example.com:443 HTTP/1.1\r\n\r\n')
+                await writer.drain()
+
+                # Expect the 200-Connection-Established response back.
+                resp = await asyncio.wait_for(reader.readuntil(b'\r\n\r\n'), timeout=2.0)
+                assert resp.startswith(b'HTTP/1.1 200'), resp
+
+                # Send some "TLS payload" bytes; expect them echoed back.
+                payload = b'\x16\x03\x01' + b'X' * 200  # not real TLS, but an opaque blob
+                writer.write(payload)
+                await writer.drain()
+
+                # Read the echo. Use a small read so we don't block forever.
+                received = b''
+                while len(received) < len(payload):
+                    chunk = await asyncio.wait_for(
+                        reader.read(len(payload) - len(received)), timeout=2.0
+                    )
+                    if not chunk:
+                        break
+                    received += chunk
+                assert received == payload
+            finally:
+                writer.close()
+                try:
+                    await writer.wait_closed()
+                except (ConnectionError, OSError):
+                    pass
+        finally:
+            await relay.stop()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_relay_rejects_non_connect_method() -> None:
+    """An HTTP GET to the relay returns 405 Method Not Allowed."""
+    ws_port = _free_port()
+    ws_server = await ws_serve(_echo_handler, '127.0.0.1', ws_port)
+    try:
+        relay = await start_upstream_proxy_relay(
+            ws_url=f'ws://127.0.0.1:{ws_port}/v1/code/upstreamproxy/ws',
+            session_id='cse_test',
+            token='tok',
+        )
+        try:
+            reader, writer = await asyncio.open_connection('127.0.0.1', relay.port)
+            try:
+                writer.write(b'GET /foo HTTP/1.1\r\nHost: x\r\n\r\n')
+                await writer.drain()
+                resp = await asyncio.wait_for(reader.readuntil(b'\r\n\r\n'), timeout=2.0)
+                assert resp.startswith(b'HTTP/1.1 405'), resp
+            finally:
+                writer.close()
+                try:
+                    await writer.wait_closed()
+                except (ConnectionError, OSError):
+                    pass
+        finally:
+            await relay.stop()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_relay_oversized_header_rejected() -> None:
+    """An over-8KB CONNECT header gets 400 Bad Request."""
+    ws_port = _free_port()
+    ws_server = await ws_serve(_echo_handler, '127.0.0.1', ws_port)
+    try:
+        relay = await start_upstream_proxy_relay(
+            ws_url=f'ws://127.0.0.1:{ws_port}/v1/code/upstreamproxy/ws',
+            session_id='cse_test',
+            token='tok',
+        )
+        try:
+            reader, writer = await asyncio.open_connection('127.0.0.1', relay.port)
+            try:
+                # Send 9KB of garbage with no CRLFCRLF — should hit the
+                # 8KB cap and return 400.
+                writer.write(b'X' * (9 * 1024))
+                await writer.drain()
+                resp = await asyncio.wait_for(reader.readuntil(b'\r\n\r\n'), timeout=2.0)
+                assert resp.startswith(b'HTTP/1.1 400'), resp
+            finally:
+                writer.close()
+                try:
+                    await writer.wait_closed()
+                except (ConnectionError, OSError):
+                    pass
+        finally:
+            await relay.stop()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()

--- a/tests/upstreamproxy/test_upstream_proxy.py
+++ b/tests/upstreamproxy/test_upstream_proxy.py
@@ -1,0 +1,286 @@
+"""Tests for ``src.upstreamproxy.upstream_proxy``.
+
+Covers the env-var gate logic, fail-open semantics, and
+``get_upstream_proxy_env`` (both enabled and inherited paths).
+The full init_upstream_proxy lifecycle is exercised via mocked HTTP +
+mocked relay (we don't spin up a real WS server here — that's
+``test_relay_e2e``).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from src.upstreamproxy import upstream_proxy as up
+from src.upstreamproxy.upstream_proxy import (
+    UpstreamProxyState,
+    _is_env_truthy,
+    get_upstream_proxy_env,
+    init_upstream_proxy,
+    reset_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    """Reset module-level state between tests; clear inherited env vars."""
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+@pytest.fixture
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear every relevant env var so test cases set them explicitly."""
+    for var in (
+        'CLAUDE_CODE_REMOTE',
+        'CCR_UPSTREAM_PROXY_ENABLED',
+        'CLAUDE_CODE_REMOTE_SESSION_ID',
+        'ANTHROPIC_BASE_URL',
+        'HTTPS_PROXY',
+        'https_proxy',
+        'NO_PROXY',
+        'no_proxy',
+        'SSL_CERT_FILE',
+        'NODE_EXTRA_CA_CERTS',
+        'REQUESTS_CA_BUNDLE',
+        'CURL_CA_BUNDLE',
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ─── _is_env_truthy ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize('val', ['1', 'true', 'TRUE', 'yes', 'on', 'anything-else'])
+def test_truthy_values(val: str) -> None:
+    assert _is_env_truthy(val)
+
+
+@pytest.mark.parametrize('val', ['', '0', 'false', 'FALSE', 'no', 'off', None])
+def test_falsy_values(val: str | None) -> None:
+    assert not _is_env_truthy(val)
+
+
+# ─── init_upstream_proxy gate logic ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_env_vars_returns_disabled(_clean_env) -> None:
+    state = await init_upstream_proxy()
+    assert state.enabled is False
+    assert state.port is None
+
+
+@pytest.mark.asyncio
+async def test_only_first_env_set_returns_disabled(
+    _clean_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``CLAUDE_CODE_REMOTE`` alone is insufficient; need both gates."""
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE', '1')
+    state = await init_upstream_proxy()
+    assert state.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_only_second_env_set_returns_disabled(
+    _clean_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``CCR_UPSTREAM_PROXY_ENABLED`` alone is insufficient."""
+    monkeypatch.setenv('CCR_UPSTREAM_PROXY_ENABLED', '1')
+    state = await init_upstream_proxy()
+    assert state.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_both_env_set_but_no_session_id_returns_disabled(
+    _clean_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both gates AND a session ID are needed."""
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE', '1')
+    monkeypatch.setenv('CCR_UPSTREAM_PROXY_ENABLED', '1')
+    state = await init_upstream_proxy()
+    assert state.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_missing_token_file_returns_disabled(
+    _clean_env, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """All env vars set but no token file — fail-open, return disabled."""
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE', '1')
+    monkeypatch.setenv('CCR_UPSTREAM_PROXY_ENABLED', '1')
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE_SESSION_ID', 'cse_test')
+    state = await init_upstream_proxy(token_path=tmp_path / 'no-such-file')
+    assert state.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_empty_token_file_returns_disabled(
+    _clean_env, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Token file exists but contains only whitespace — fail-open."""
+    token_path = tmp_path / 'token'
+    token_path.write_text('   \n   ')
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE', '1')
+    monkeypatch.setenv('CCR_UPSTREAM_PROXY_ENABLED', '1')
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE_SESSION_ID', 'cse_test')
+    state = await init_upstream_proxy(token_path=token_path)
+    assert state.enabled is False
+
+
+# ─── get_upstream_proxy_env ──────────────────────────────────────────────
+
+
+def test_disabled_returns_empty_dict(_clean_env) -> None:
+    """No state, no inherited proxy env → empty."""
+    assert get_upstream_proxy_env() == {}
+
+
+def test_disabled_inherits_parent_proxy_env(
+    _clean_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Child CLI: parent had HTTPS_PROXY + SSL_CERT_FILE → inherit."""
+    monkeypatch.setenv('HTTPS_PROXY', 'http://127.0.0.1:9999')
+    monkeypatch.setenv('https_proxy', 'http://127.0.0.1:9999')
+    monkeypatch.setenv('SSL_CERT_FILE', '/tmp/parent-ca.crt')
+    monkeypatch.setenv('NO_PROXY', 'localhost,*.anthropic.com')
+    env = get_upstream_proxy_env()
+    assert env['HTTPS_PROXY'] == 'http://127.0.0.1:9999'
+    assert env['SSL_CERT_FILE'] == '/tmp/parent-ca.crt'
+    assert env['NO_PROXY'] == 'localhost,*.anthropic.com'
+
+
+def test_disabled_partial_parent_env_returns_empty(
+    _clean_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Parent has HTTPS_PROXY but no SSL_CERT_FILE — refuse to inherit."""
+    monkeypatch.setenv('HTTPS_PROXY', 'http://127.0.0.1:9999')
+    assert get_upstream_proxy_env() == {}
+
+
+def test_enabled_returns_full_env_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When state.enabled, return the 9-var recipe with right NO_PROXY order."""
+    # Prime module state directly (bypass init for this unit test).
+    up._state = UpstreamProxyState(
+        enabled=True, port=12345, ca_bundle_path='/tmp/ca.crt'
+    )
+    env = get_upstream_proxy_env()
+    assert env['HTTPS_PROXY'] == 'http://127.0.0.1:12345'
+    assert env['https_proxy'] == 'http://127.0.0.1:12345'
+    assert env['SSL_CERT_FILE'] == '/tmp/ca.crt'
+    assert env['NODE_EXTRA_CA_CERTS'] == '/tmp/ca.crt'
+    assert env['REQUESTS_CA_BUNDLE'] == '/tmp/ca.crt'
+    assert env['CURL_CA_BUNDLE'] == '/tmp/ca.crt'
+    # NO_PROXY: anthropic.com forms must appear in the right order.
+    no_proxy = env['NO_PROXY']
+    apex = no_proxy.index('anthropic.com')
+    suffix = no_proxy.index('.anthropic.com')
+    glob = no_proxy.index('*.anthropic.com')
+    assert apex < suffix < glob
+
+
+# ─── End-to-end happy path with mocked HTTP + mocked relay ──────────────
+
+
+@pytest.mark.asyncio
+async def test_init_happy_path_with_mocked_components(
+    _clean_env, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """All gates pass + token file exists + CA download succeeds + relay starts."""
+    token_path = tmp_path / 'token'
+    token_path.write_text('secret-token-123')
+    sys_ca = tmp_path / 'system.crt'
+    sys_ca.write_bytes(b'SYS\n')
+    out_ca = tmp_path / 'merged.crt'
+
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE', '1')
+    monkeypatch.setenv('CCR_UPSTREAM_PROXY_ENABLED', '1')
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE_SESSION_ID', 'cse_test')
+    monkeypatch.setenv('ANTHROPIC_BASE_URL', 'https://api.test')
+
+    # Patch download_ca_bundle to write a fake bundle and return True.
+    async def fake_download_ca_bundle(
+        *, base_url, system_ca_path, out_path, **kwargs
+    ) -> bool:
+        out_path.write_bytes(b'-----BEGIN CERTIFICATE-----\nABC\n-----END CERTIFICATE-----\n')
+        return True
+
+    monkeypatch.setattr(up, 'download_ca_bundle', fake_download_ca_bundle)
+
+    # Patch start_upstream_proxy_relay to skip the real WS upgrade.
+    class _FakeRelay:
+        port = 54321
+
+        async def stop(self) -> None:
+            pass
+
+    async def fake_start_relay(*, ws_url, session_id, token):
+        assert ws_url == 'wss://api.test/v1/code/upstreamproxy/ws'
+        assert session_id == 'cse_test'
+        assert token == 'secret-token-123'
+        return _FakeRelay()
+
+    monkeypatch.setattr(up, 'start_upstream_proxy_relay', fake_start_relay)
+
+    state = await init_upstream_proxy(
+        token_path=token_path, system_ca_path=sys_ca, ca_bundle_path=out_ca
+    )
+
+    assert state.enabled is True
+    assert state.port == 54321
+    assert state.ca_bundle_path == str(out_ca)
+    # Token file unlinked AFTER relay startup (per WI-5.5 step 5).
+    assert not token_path.exists()
+    # Env dict reflects the new state.
+    env = get_upstream_proxy_env()
+    assert env['HTTPS_PROXY'] == 'http://127.0.0.1:54321'
+
+
+@pytest.mark.asyncio
+async def test_init_relay_failure_is_fail_open(
+    _clean_env, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Relay startup raises → return DISABLED, do NOT propagate."""
+    token_path = tmp_path / 'token'
+    token_path.write_text('tok')
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE', '1')
+    monkeypatch.setenv('CCR_UPSTREAM_PROXY_ENABLED', '1')
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE_SESSION_ID', 'cse_test')
+
+    async def good_download(**kwargs) -> bool:
+        return True
+
+    async def bad_relay(**kwargs):
+        raise OSError('cannot bind port')
+
+    monkeypatch.setattr(up, 'download_ca_bundle', good_download)
+    monkeypatch.setattr(up, 'start_upstream_proxy_relay', bad_relay)
+
+    state = await init_upstream_proxy(token_path=token_path)
+    assert state.enabled is False
+    # Token file should still be present — relay didn't start, so the
+    # unlink step is skipped (a supervisor restart can retry).
+    assert token_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_init_ca_download_failure_is_fail_open(
+    _clean_env, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """CA download returns False → return DISABLED."""
+    token_path = tmp_path / 'token'
+    token_path.write_text('tok')
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE', '1')
+    monkeypatch.setenv('CCR_UPSTREAM_PROXY_ENABLED', '1')
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE_SESSION_ID', 'cse_test')
+
+    async def fail_download(**kwargs) -> bool:
+        return False
+
+    monkeypatch.setattr(up, 'download_ca_bundle', fail_download)
+
+    state = await init_upstream_proxy(token_path=token_path)
+    assert state.enabled is False
+    assert token_path.exists(), 'token file must NOT be unlinked when CA download fails'


### PR DESCRIPTION
## Summary

Consolidation PR. PRs #41–#45 were already reviewed + merged into their stacked bases (the Ch16 PR-1-of-6 → PR-6-of-6 stack), but only PR #40 (Phase 0) reached `main` directly. This PR brings the remaining 5 phases onto `main` in one shot.

The merge commits in this PR are the ones already created when each stacked PR was merged — no new code, just bringing the existing merge graph onto `main`.

## What's included

| Phase | Original PR | Surface |
|---|---|---|
| Phase 1 — Direct Connect (cc:// + cc+unix://) | #43 | `src/server/` (8 modules, 8 tests) |
| Phase 2 — Shared primitives | #41 | `src/bridge/` (11 modules, 12 tests) |
| Phase 3 — Bridge v2 transport (SSE + CCRClient) | #44 | `src/transports/` + `src/bridge/{code_session_api,repl_bridge_transport}` |
| Phase 4 — Remote Session viewer | #45 | `src/remote/` (3 modules, 3 tests) |
| Phase 5 — Upstream Proxy | #42 | `src/upstreamproxy/` (5 modules, 5 tests) |

## Test results on this branch

- **346 Ch16 tests pass + 1 Linux-only skipped** (`prctl`-specific) on `tests/{bridge, transports, server, remote, upstreamproxy}/`
- **84% combined coverage** on `src/{bridge, transports, server, remote, upstreamproxy}` (~2,786 LOC)
- **Zero regressions** in the broader project (4114 pass, 2 skipped, 2 pre-existing MCP-config failures requiring `python` in PATH — unrelated to Ch16)
- **Consumer-impacted tests pass**: `test_repl.py`, `test_dangerous_skip_permissions.py`, `test_porting_workspace.py`, `test_bridge.py`, `test_integration_smoke.py` (96 pass)

## Why a separate consolidation PR

The 6 PRs were originally stacked: PR N+1 based on PR N. When the user reviewed and merged each in sequence, each PR went into its parent's branch (not directly to `main`). This is the standard stacked-PR pattern but it leaves the descendants un-merged to `main` until a follow-up.

This PR is that follow-up — pure plumbing, no new code review needed.

## Files

64 files changed, +11,582 lines (test code + production code; no deletions). All files are net-new modules in:

- `src/bridge/` (Phase 2 primitives + Phase 3's `code_session_api.py` + `repl_bridge_transport.py`)
- `src/server/` (Phase 1 Direct Connect)
- `src/transports/` (Phase 3 SSE + CCRClient)
- `src/remote/` (Phase 4 Remote Session)
- `src/upstreamproxy/` (Phase 5 Upstream Proxy)
- `tests/{bridge, server, transports, remote, upstreamproxy}/` (matching test packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)