### PR TITLE
feat(ch13/standalone): vim + search + IME + hyperlinks + frame metrics + thinking + permission spec + output styles + placeholder Resume/Doctor

### DIFF
--- a/src/outputStyles/loader.py
+++ b/src/outputStyles/loader.py
@@ -1,33 +1,130 @@
+"""Load custom output styles from a directory of markdown files.
+
+Phase-9 of the ch13 refactor (gap #7) closes the gap between the prior
+plain-body-only loader and chapter
+``typescript/src/outputStyles/loadOutputStylesDir.ts``:
+
+* YAML frontmatter parsing — ``name`` / ``description`` / ``model``
+  override the defaults derived from the file basename. Reuses the
+  existing :mod:`src.skills.frontmatter` parser; no new dependency.
+* Default ``~/.claude/outputStyles/`` lookup — ``resolve_output_style``
+  with ``search_dir=None`` now consults the user-config directory before
+  falling back to built-ins. Previously the ``None`` path returned
+  built-ins only.
+* Built-ins remain the same (``default``, ``explanatory``) — user files
+  with a colliding ``name`` win, mirroring the chapter's "user overrides
+  built-in" semantic.
+"""
+
 from __future__ import annotations
 
+import logging
 from pathlib import Path
+
+from src.skills.frontmatter import parse_frontmatter
 
 from .styles import BUILTIN_OUTPUT_STYLES, OutputStyle
 
 
+_logger = logging.getLogger(__name__)
+
+
+def _default_user_dir() -> Path:
+    """Resolve the default user output-styles directory lazily.
+
+    Lazy so test environments that monkeypatch ``HOME`` after import see
+    the override. Mirrors the keybindings-loader pattern.
+    """
+
+    return Path("~/.claude/outputStyles").expanduser()
+
+
 def load_output_styles_dir(path: str | Path) -> dict[str, OutputStyle]:
+    """Load every ``*.md`` under ``path`` and merge with built-ins.
+
+    User-supplied files whose ``name`` collides with a built-in win.
+    Files without YAML frontmatter still load (using ``file.stem`` as
+    the default name and the entire body as the prompt) so legacy users
+    who hadn't adopted frontmatter aren't locked out.
+    """
+
     root = Path(path).expanduser().resolve()
     styles: dict[str, OutputStyle] = dict(BUILTIN_OUTPUT_STYLES)
     if not root.exists() or not root.is_dir():
         return styles
 
     for file in sorted(root.glob("*.md")):
-        name = file.stem
         try:
-            prompt = file.read_text(encoding="utf-8").strip()
-        except Exception:
+            raw = file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            _logger.warning("could not read output style at %s: %s", file, exc)
             continue
+        if not raw.strip():
+            continue
+
+        result = parse_frontmatter(raw)
+        meta = result.frontmatter or {}
+        body = result.body.strip()
+
+        # ``name`` precedence: explicit frontmatter > file stem.
+        name = _coerce_str(meta.get("name")) or file.stem
+        prompt_field = _coerce_str(meta.get("prompt"))
+        # ``prompt`` precedence: explicit frontmatter > body content.
+        # Frontmatter ``prompt`` lets a user keep documentation in the
+        # body without shipping it to the model.
+        prompt = prompt_field if prompt_field else body
         if not prompt:
             continue
-        styles[name] = OutputStyle(name=name, prompt=prompt, source_path=file)
+
+        styles[name] = OutputStyle(
+            name=name,
+            prompt=prompt,
+            source_path=file,
+            description=_coerce_str(meta.get("description")),
+            model=_coerce_str(meta.get("model")),
+        )
     return styles
 
 
-def resolve_output_style(name: str | None, search_dir: str | Path | None = None) -> OutputStyle:
-    if search_dir is None:
-        styles = dict(BUILTIN_OUTPUT_STYLES)
-    else:
+def resolve_output_style(
+    name: str | None,
+    search_dir: str | Path | None = None,
+) -> OutputStyle:
+    """Look up an output style by name; auto-discover the user dir.
+
+    Resolution order:
+
+    1. ``search_dir`` if explicitly given.
+    2. Default ``~/.claude/outputStyles/`` if it exists.
+    3. Built-ins (``default``, ``explanatory``).
+
+    Falls back to the ``"default"`` style when ``name`` is not known —
+    matching the pre-Phase-9 behavior.
+    """
+
+    if search_dir is not None:
         styles = load_output_styles_dir(search_dir)
+    else:
+        default_dir = _default_user_dir()
+        if default_dir.is_dir():
+            styles = load_output_styles_dir(default_dir)
+        else:
+            styles = dict(BUILTIN_OUTPUT_STYLES)
+
     key = (name or "default").strip() or "default"
     return styles.get(key, styles["default"])
 
+
+def _coerce_str(value: object) -> str | None:
+    """Return ``str(value).strip()`` when ``value`` is a non-empty string."""
+
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+__all__ = [
+    "load_output_styles_dir",
+    "resolve_output_style",
+]

--- a/src/outputStyles/styles.py
+++ b/src/outputStyles/styles.py
@@ -9,6 +9,8 @@ class OutputStyle:
     name: str
     prompt: str
     source_path: Path | None = None
+    description: str | None = None
+    model: str | None = None
 
 
 BUILTIN_OUTPUT_STYLES: dict[str, OutputStyle] = {

--- a/src/tui/declared_cursor.py
+++ b/src/tui/declared_cursor.py
@@ -1,0 +1,237 @@
+"""Declared cursor — IME preedit positioning helper.
+
+Phase-6 of the ch13 refactor (gap #3) closes the gap between the prior
+no-IME-support state and chapter
+``typescript/src/ink/hooks/use-declared-cursor.ts``.
+
+**Problem.** Terminal emulators render IME preedit text (the in-flight
+characters a CJK / Vietnamese / Indic IME shows before commit) at the
+*physical cursor position*. If the cursor stays at the bottom of the
+screen — Textual's default for any non-cursor widget — the preedit
+text appears at the bottom even when the user is typing into a prompt
+input near the top. Broken UX for any user typing through an IME.
+
+**Fix.** Widgets declare *where they want the cursor to land after
+each frame*; this module emits a ``CSI <row> ; <col> H`` cursor-position
+escape sequence so the terminal renders preedit at the input caret.
+
+The ``DeclaredCursor`` registry is module-level (one per process) and
+the most-recent declaration wins — chapter semantics. Stale
+declarations from unmounted widgets are cleared via the unregister
+callable returned by :meth:`declare`.
+
+Production wiring (the prompt-input integration) is one call per
+keystroke: after the input updates its caret, it calls
+:func:`publish_cursor_position` with the screen-space ``(row, col)``.
+The default :class:`DeclaredCursor` writes to ``sys.__stdout__`` after
+the next tick — disabled by default in test harnesses to keep stdout
+clean.
+
+Public surface:
+
+* :class:`DeclaredCursor` — registry instance.
+* :func:`get_default_declared_cursor` — module-level singleton.
+* :func:`publish_cursor_position` — convenience setter.
+* :func:`flush_pending` — emit any pending cursor-position sequence.
+* :func:`reset_for_tests` — test-only state reset.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from threading import Lock
+from typing import Callable, Final
+
+
+_logger = logging.getLogger(__name__)
+
+
+_CURSOR_ENV: Final[str] = "CLAWCODEX_DISABLE_DECLARED_CURSOR"
+
+
+@dataclass(frozen=True)
+class CursorDeclaration:
+    """An (owner, row, col) tuple describing the declared cursor target.
+
+    ``owner`` is an opaque caller-supplied key (typically the widget's
+    ``id`` or ``self``) so unregister can remove the right entry without
+    a separate handle.
+    """
+
+    owner: object
+    row: int
+    col: int
+
+
+class DeclaredCursor:
+    """Registry for cursor declarations + emit hook.
+
+    Public methods are thread-safe; the emit path runs on whatever
+    thread calls :meth:`flush_pending` (typically the Textual app's
+    main thread).
+    """
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        # Insertion-ordered list — most-recent declaration wins, but
+        # we keep all declarations so stale entries from unmounted
+        # widgets can be unregistered without losing the others.
+        self._declarations: list[CursorDeclaration] = []
+        self._pending_emit = False
+        # Test seam: tests can replace this to capture emitted bytes.
+        self._writer: Callable[[str], None] = self._default_writer
+
+    def declare(
+        self, owner: object, row: int, col: int
+    ) -> Callable[[], None]:
+        """Register an ``(owner, row, col)`` declaration.
+
+        The most-recent declaration wins on the next emit. Returns an
+        unregister callable; calling it twice is a no-op.
+        """
+
+        if row < 0 or col < 0:
+            raise ValueError(
+                f"row/col must be non-negative; got {row}, {col}"
+            )
+        decl = CursorDeclaration(owner=owner, row=row, col=col)
+        with self._lock:
+            # If an existing declaration for this owner exists, replace
+            # it in place rather than appending so the order doesn't
+            # drift unexpectedly.
+            for i, existing in enumerate(self._declarations):
+                if existing.owner is owner:
+                    self._declarations[i] = decl
+                    self._pending_emit = True
+                    break
+            else:
+                self._declarations.append(decl)
+                self._pending_emit = True
+
+        unregistered = [False]
+
+        def _unregister() -> None:
+            if unregistered[0]:
+                return
+            with self._lock:
+                self._declarations = [
+                    d for d in self._declarations if d.owner is not owner
+                ]
+                self._pending_emit = True
+            unregistered[0] = True
+
+        return _unregister
+
+    def active(self) -> CursorDeclaration | None:
+        """Return the most-recent declaration, or ``None`` if cleared."""
+
+        with self._lock:
+            return self._declarations[-1] if self._declarations else None
+
+    def flush_pending(self) -> bool:
+        """Emit a CSI cursor-position sequence if a declaration is active.
+
+        Returns ``True`` when a sequence was emitted, ``False`` when
+        nothing was pending. Idempotent — calling twice without a fresh
+        declaration is a no-op.
+        """
+
+        if os.environ.get(_CURSOR_ENV) == "1":
+            # Hard kill switch for environments where stdout writes are
+            # forbidden (e.g. some CI containers or non-tty harnesses).
+            return False
+
+        with self._lock:
+            if not self._pending_emit:
+                return False
+            decl = self._declarations[-1] if self._declarations else None
+            self._pending_emit = False
+
+        if decl is None:
+            # Last-active was unregistered — emit a no-op CSI to reset
+            # the cursor to wherever the framework parks it. Currently
+            # we just skip; aggressively repositioning when no widget
+            # cares would fight Textual's own cursor management.
+            return False
+
+        # CSI sequences are 1-indexed; widgets pass screen-space
+        # (row, col) zero-indexed.
+        row1 = decl.row + 1
+        col1 = decl.col + 1
+        try:
+            self._writer(f"\x1b[{row1};{col1}H")
+        except Exception as exc:
+            _logger.debug("declared cursor write failed: %s", exc)
+            return False
+        return True
+
+    def clear(self) -> None:
+        with self._lock:
+            self._declarations.clear()
+            self._pending_emit = False
+
+    def set_writer(self, writer: Callable[[str], None]) -> None:
+        """Replace the emit-target writer. Test seam."""
+
+        with self._lock:
+            self._writer = writer
+
+    @staticmethod
+    def _default_writer(text: str) -> None:
+        stream = sys.__stdout__ or sys.stdout
+        try:
+            stream.write(text)
+            stream.flush()
+        except (OSError, ValueError, AttributeError):
+            # Non-interactive harnesses, closed stdout, etc.
+            pass
+
+
+_DEFAULT: DeclaredCursor | None = None
+_DEFAULT_LOCK = Lock()
+
+
+def get_default_declared_cursor() -> DeclaredCursor:
+    """Module-level singleton accessor."""
+
+    global _DEFAULT
+    if _DEFAULT is None:
+        with _DEFAULT_LOCK:
+            if _DEFAULT is None:
+                _DEFAULT = DeclaredCursor()
+    return _DEFAULT
+
+
+def publish_cursor_position(
+    owner: object, row: int, col: int
+) -> Callable[[], None]:
+    """Convenience: declare on the singleton and return the unregister."""
+
+    return get_default_declared_cursor().declare(owner, row, col)
+
+
+def flush_pending() -> bool:
+    """Convenience: flush the singleton's pending emission."""
+
+    return get_default_declared_cursor().flush_pending()
+
+
+def reset_for_tests() -> None:
+    """Drop the singleton so tests don't leak declarations across cases."""
+
+    global _DEFAULT
+    with _DEFAULT_LOCK:
+        _DEFAULT = None
+
+
+__all__ = [
+    "CursorDeclaration",
+    "DeclaredCursor",
+    "flush_pending",
+    "get_default_declared_cursor",
+    "publish_cursor_position",
+    "reset_for_tests",
+]

--- a/src/tui/frame_metrics.py
+++ b/src/tui/frame_metrics.py
@@ -1,0 +1,177 @@
+"""Frame-timing observability surface (gated on ``CLAWCODEX_DEBUG_REPAINTS``).
+
+Phase-11 of the ch13 refactor (gap #10) ports the chapter's
+:class:`FrameEvent` shape (``frame.ts``) into a Python observability
+surface. The chapter's TS implementation emits a per-frame record with
+``phases``, ``yogaVisited``, ``yogaMeasured``, etc. Python's TUI
+delegates rendering to Textual, which has its own internal timings —
+the goal here is NOT to instrument Textual (out of scope) but to give
+Python code a parity record + observer API so future hooks (e.g.
+"flush a frame after streaming N tokens") can subscribe.
+
+The module is **disabled by default**. Setting the env var
+``CLAWCODEX_DEBUG_REPAINTS=1`` flips ``is_enabled()`` to ``True`` and
+unblocks emission. With the env var off, :func:`emit_frame_event` is a
+no-op (single ``if`` branch — zero allocation), so production callers
+can emit on every commit cycle without paying observability cost when
+the user hasn't opted in.
+
+Public surface:
+
+* :class:`FrameEvent` — typed timing record matching the chapter shape.
+* :func:`emit_frame_event` — gated emit; observers are notified.
+* :func:`register_frame_observer` — subscribe; returns an unregister callable.
+* :func:`is_enabled` — env-var probe.
+* :data:`FRAME_DEBUG_ENV` — the env var name (``CLAWCODEX_DEBUG_REPAINTS``).
+
+Observer call-out: handlers run synchronously on the emitting thread.
+A handler that raises propagates up through ``emit_frame_event`` —
+caller code should swallow / log accordingly. We don't suppress
+exceptions in the emit path so test code can detect handler bugs.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Callable, Final
+
+
+FRAME_DEBUG_ENV: Final[str] = "CLAWCODEX_DEBUG_REPAINTS"
+
+
+@dataclass(frozen=True)
+class FrameEvent:
+    """One frame's worth of timing data.
+
+    Mirrors the chapter ``FrameEvent`` shape:
+    * ``duration_ms`` — total commit→write wall time.
+    * ``phases`` — sub-stage breakdown. Keys parallel the TS
+      ``{ renderer, diff, optimize, write, yoga }`` set; missing keys
+      mean "not measured at this layer".
+    * ``component_attribution`` — which React/Textual component owns
+      the most expensive cell in the frame (``CLAUDE_CODE_DEBUG_REPAINTS``
+      analogue). Optional.
+    * ``yoga_visited`` / ``yoga_measured`` — layout-pass counts.
+    * ``flickers`` — bookkeeping for full-screen reset attribution.
+    """
+
+    duration_ms: float
+    phases: dict[str, float] = field(default_factory=dict)
+    component_attribution: str | None = None
+    yoga_visited: int = 0
+    yoga_measured: int = 0
+    flickers: tuple[str, ...] = ()
+
+
+_observers: list[Callable[[FrameEvent], None]] = []
+_lock = Lock()
+
+
+def is_enabled() -> bool:
+    """True iff ``CLAWCODEX_DEBUG_REPAINTS=1`` is set in the environment.
+
+    Probed on every call (no caching) so test code can flip the env var
+    mid-test without a re-import dance.
+    """
+
+    return os.environ.get(FRAME_DEBUG_ENV) == "1"
+
+
+def register_frame_observer(
+    callback: Callable[[FrameEvent], None],
+) -> Callable[[], None]:
+    """Subscribe to frame events. Returns an unregister callable.
+
+    Idempotent: calling the unregister callable twice is a no-op (the
+    second call doesn't raise even if the first removed the observer).
+
+    Observers fire synchronously on whatever thread emits the event.
+    Long-running observers should hand off to a worker.
+    """
+
+    with _lock:
+        _observers.append(callback)
+
+    unregistered = [False]
+
+    def _unregister() -> None:
+        if unregistered[0]:
+            return
+        with _lock:
+            try:
+                _observers.remove(callback)
+            except ValueError:
+                pass
+        unregistered[0] = True
+
+    return _unregister
+
+
+def emit_frame_event(event: FrameEvent) -> None:
+    """Notify subscribed observers — no-op when env var is unset.
+
+    The early-return path is the common case and must remain cheap;
+    we deliberately don't iterate observers or take the lock when the
+    env var is off.
+    """
+
+    if not is_enabled():
+        return
+
+    with _lock:
+        snapshot = list(_observers)
+    for observer in snapshot:
+        observer(event)
+
+
+def clear_observers_for_tests() -> None:
+    """Reset the observer list. Test helper only — never call from prod."""
+
+    with _lock:
+        _observers.clear()
+
+
+class TimedPhase:
+    """Context manager that records a phase duration into a dict.
+
+    Use::
+
+        phases: dict[str, float] = {}
+        with TimedPhase(phases, "render"):
+            do_render()
+        emit_frame_event(FrameEvent(duration_ms=..., phases=phases))
+
+    Cheap when ``CLAWCODEX_DEBUG_REPAINTS`` is unset (still measures, but
+    the frame event is not emitted). Callers that want zero overhead
+    when disabled should wrap the whole block in ``if is_enabled():``.
+    """
+
+    __slots__ = ("_target", "_key", "_started")
+
+    def __init__(self, target: dict[str, float], key: str) -> None:
+        self._target = target
+        self._key = key
+        self._started = 0.0
+
+    def __enter__(self) -> "TimedPhase":
+        self._started = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        elapsed = (time.perf_counter() - self._started) * 1000.0
+        # Accumulate so a phase used twice in one frame sums correctly.
+        self._target[self._key] = self._target.get(self._key, 0.0) + elapsed
+
+
+__all__ = [
+    "FRAME_DEBUG_ENV",
+    "FrameEvent",
+    "TimedPhase",
+    "clear_observers_for_tests",
+    "emit_frame_event",
+    "is_enabled",
+    "register_frame_observer",
+]

--- a/src/tui/hyperlinks.py
+++ b/src/tui/hyperlinks.py
@@ -1,0 +1,171 @@
+"""Terminal-capability detection + helpers for OSC 8 hyperlinks.
+
+Phase-10 of the ch13 refactor (gap #15) closes the gap between the prior
+"Rich emits OSC 8 by default if it feels like it" implicit handling and
+chapter ``typescript/src/ink/supports-hyperlinks.ts``:
+
+* Multi-signal capability detection — ``TERM_PROGRAM`` allow-list,
+  ``VTE_VERSION >= 5000``, ``FORCE_HYPERLINK=1`` override, plus Rich's
+  own ``console.is_terminal`` / ``console.legacy_windows`` heuristics.
+  ``console.color_system`` ``in {"truecolor", "256"}`` lets modern
+  xterm-class terminals report capability via their own self-reporting
+  even when no explicit env var is set.
+* :func:`format_link` returns a Rich-markup string when the console
+  supports OSC 8, otherwise plain text. Widget call-sites use this
+  before emitting ``[link=URL]`` so the fallback is automatic.
+* Test seam: pass an explicit ``console`` to either function so unit
+  tests can simulate any combination of capabilities.
+
+Works with Rich's ``[link=]`` markup, which Rich's ``Console.print``
+turns into OSC 8 sequences when emission is enabled. Outside Rich-rendered
+content (e.g. raw stdout writes), call :func:`raw_osc8` to get the bare
+escape sequence.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Final
+
+from rich.console import Console
+
+
+# Modern terminals that natively support OSC 8 hyperlinks. Aligned with
+# ``typescript/src/ink/supports-hyperlinks.ts`` and the canonical
+# ``OSC8-Adoption`` matrix. Add to this list as new terminals ship
+# stable hyperlink support.
+_KNOWN_GOOD_TERM_PROGRAMS: Final[frozenset[str]] = frozenset(
+    {
+        "iTerm.app",
+        "WezTerm",
+        "vscode",
+        "Apple_Terminal",
+        "Hyper",
+        "ghostty",
+        "kitty",
+        "Tabby",
+        # ``TERM_PROGRAM`` is sometimes lowercased — accept both.
+        "iterm.app",
+        "wezterm",
+        "hyper",
+    }
+)
+
+
+def _shared_console() -> Console:
+    """Return a per-call default ``Console`` for the no-arg path.
+
+    Constructed fresh because Rich's defaults read env vars at
+    instantiation; tests that monkeypatch env between checks need a
+    fresh instance to see the change.
+    """
+
+    return Console()
+
+
+def is_hyperlink_supported(console: Console | None = None) -> bool:
+    """Return True iff the host terminal supports OSC 8 hyperlinks.
+
+    Capability matrix (any of the following → supported, in order):
+
+    1. ``FORCE_HYPERLINK=1`` env var (test / debug override).
+    2. ``TERM_PROGRAM`` is in :data:`_KNOWN_GOOD_TERM_PROGRAMS`.
+    3. ``VTE_VERSION >= 5000`` (gnome-terminal, tilix, terminator).
+    4. The Rich console reports a modern color system (truecolor / 256)
+       AND is_terminal AND not legacy_windows AND TERM != "dumb".
+
+    Returns False otherwise.
+    """
+
+    if os.environ.get("FORCE_HYPERLINK") == "1":
+        return True
+
+    if os.environ.get("TERM_PROGRAM") in _KNOWN_GOOD_TERM_PROGRAMS:
+        return True
+
+    vte_raw = os.environ.get("VTE_VERSION", "")
+    if vte_raw:
+        try:
+            if int(vte_raw) >= 5000:
+                return True
+        except ValueError:
+            pass
+
+    c = console or _shared_console()
+    if getattr(c, "legacy_windows", False):
+        return False
+    if not getattr(c, "is_terminal", False):
+        return False
+    term = os.environ.get("TERM", "")
+    if term in {"dumb", ""}:
+        return False
+    color_system = getattr(c, "color_system", None)
+    return color_system in {"truecolor", "256"}
+
+
+def format_link(
+    text: str,
+    url: str,
+    *,
+    console: Console | None = None,
+) -> str:
+    """Wrap ``text`` in Rich ``[link=URL]`` markup if supported, else plain.
+
+    Use this in widget code that emits Rich-formatted strings. Returns
+    a string the caller can pass to ``Static.update`` or
+    ``Console.print`` and trust to do the right thing on every terminal.
+    """
+
+    if not text:
+        return text
+    if not url:
+        return text
+    if not is_hyperlink_supported(console):
+        return text
+    return f"[link={url}]{text}[/link]"
+
+
+def raw_osc8(text: str, url: str) -> str:
+    """Return the bare OSC 8 sequence for emitting outside Rich.
+
+    Format: ``ESC ] 8 ;; URL ESC \\ TEXT ESC ] 8 ;; ESC \\``. Callers
+    must check :func:`is_hyperlink_supported` before emitting; this
+    function does NOT gate.
+    """
+
+    return f"\x1b]8;;{url}\x1b\\{text}\x1b]8;;\x1b\\"
+
+
+def format_file_path(
+    path: str,
+    *,
+    console: Console | None = None,
+) -> str:
+    """Render ``path`` as a clickable ``file://`` link when supported.
+
+    Convenience wrapper for the most common widget use case (rendering
+    file paths in tool results). Falls back to plain text on
+    unsupported terminals.
+    """
+
+    if not path:
+        return path
+    # Make absolute so the OSC 8 URL works regardless of cwd. Rich
+    # prefers the ``file://`` scheme; absolute paths must include the
+    # leading slash.
+    abs_path = path
+    if not path.startswith("/") and not path.startswith("file://"):
+        # Don't reach for the actual fs here — keep this function pure.
+        # Callers that want absolute paths should resolve before calling.
+        return format_link(path, f"file://{path}", console=console)
+    if path.startswith("file://"):
+        return format_link(path, path, console=console)
+    return format_link(path, f"file://{abs_path}", console=console)
+
+
+__all__ = [
+    "format_file_path",
+    "format_link",
+    "is_hyperlink_supported",
+    "raw_osc8",
+]

--- a/src/tui/screens/doctor.py
+++ b/src/tui/screens/doctor.py
@@ -1,0 +1,193 @@
+"""Diagnostics screen — environment + capability + storage probes.
+
+Phase-8 of the ch13 refactor (gap #9). Surfaces the same checks the
+legacy ``cli --doctor`` command runs, plus the Phase-10 hyperlink
+capability detection and the Phase-11 frame-debug status. Reachable
+from the ``/doctor`` slash command in ``/tui``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.console import Group
+from rich.panel import Panel
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Center, Middle, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+
+class DoctorScreen(ModalScreen[None]):
+    """Modal showing environment / capability / health checks."""
+
+    BINDINGS = [
+        Binding("escape", "dismiss_modal", "Close"),
+        Binding("q", "dismiss_modal", "Close"),
+    ]
+
+    DEFAULT_CSS = """
+    DoctorScreen {
+        align: center middle;
+    }
+    DoctorScreen > Middle > Center > Vertical {
+        width: 80%;
+        max-width: 90;
+        max-height: 80%;
+        border: round $primary;
+        background: $surface;
+        padding: 1 2;
+    }
+    DoctorScreen Static.-title {
+        color: $primary;
+        text-style: bold;
+        padding: 0 0 1 0;
+    }
+    DoctorScreen Static.-section {
+        padding: 0 0 1 0;
+    }
+    """
+
+    def __init__(self, app_state: Any | None = None) -> None:
+        super().__init__()
+        self._app_state = app_state
+
+    def compose(self) -> ComposeResult:
+        with Middle():
+            with Center():
+                yield Vertical()
+
+    def on_mount(self) -> None:
+        body = self.query_one(Vertical)
+        body.mount(
+            Static(
+                Text("Diagnostics", style="bold"),
+                classes="-title",
+                markup=False,
+            )
+        )
+
+        for title, content in self._collect_sections():
+            body.mount(
+                Static(
+                    Panel(
+                        content,
+                        title=title,
+                        border_style="bright_black",
+                        padding=(0, 1),
+                    ),
+                    classes="-section",
+                    markup=False,
+                )
+            )
+
+    def action_dismiss_modal(self) -> None:
+        self.dismiss(None)
+
+    # ---- internals ----
+    def _collect_sections(self) -> list[tuple[str, Any]]:
+        sections: list[tuple[str, Any]] = []
+        sections.append(("environment", self._render_environment()))
+        sections.append(("hyperlinks", self._render_hyperlinks()))
+        sections.append(("frame metrics", self._render_frame_metrics()))
+        sections.append(("storage", self._render_storage()))
+        return sections
+
+    def _render_environment(self) -> Any:
+        """Provider, model, workspace, theme — read from app state when present."""
+
+        rows: list[Text] = []
+
+        def kv(label: str, value: Any) -> None:
+            rows.append(
+                Text(f"{label}: ", style="dim").append(
+                    str(value) if value else "(unknown)", style="default"
+                )
+            )
+
+        state = self._app_state
+        kv("provider", getattr(state, "provider", None))
+        kv("model", getattr(state, "model", None))
+        kv("workspace", getattr(state, "workspace_root", None))
+        kv("theme", getattr(state, "theme_name", None))
+        return Group(*rows) if rows else Text("(no app state)", style="dim")
+
+    def _render_hyperlinks(self) -> Any:
+        from src.tui.hyperlinks import is_hyperlink_supported
+
+        supported = is_hyperlink_supported()
+        text = Text()
+        text.append("OSC 8 hyperlinks: ", style="dim")
+        if supported:
+            text.append("supported", style="bold green")
+        else:
+            text.append("not detected", style="bold yellow")
+        return text
+
+    def _render_frame_metrics(self) -> Any:
+        from src.tui.frame_metrics import FRAME_DEBUG_ENV, is_enabled
+
+        text = Text()
+        text.append(f"{FRAME_DEBUG_ENV}: ", style="dim")
+        if is_enabled():
+            text.append("enabled — frame events emitting", style="bold green")
+        else:
+            text.append(
+                "disabled (set to 1 for debug repaints)",
+                style="dim",
+            )
+        return text
+
+    def _render_storage(self) -> Any:
+        """Probe ``SessionStorage`` if importable; otherwise mark missing.
+
+        Phase-8 audit (state 2): the module exists but no live caller
+        writes transcripts. The probe distinguishes "module unavailable"
+        from "no transcripts on disk" so future debugging is one
+        screen-glance away.
+        """
+
+        rows: list[Text] = []
+        try:
+            from src.services.session_storage import SessionStorage
+
+            storage = SessionStorage()
+            list_fn = getattr(storage, "list_sessions", None)
+            count: int | None = None
+            if callable(list_fn):
+                try:
+                    count = len(list(list_fn()))
+                except Exception:
+                    count = None
+            rows.append(
+                Text("module: ", style="dim").append(
+                    "src.services.session_storage", style="default"
+                )
+            )
+            if count is None:
+                rows.append(
+                    Text(
+                        "list_sessions(): unavailable",
+                        style="yellow",
+                    )
+                )
+            else:
+                rows.append(
+                    Text(f"sessions on disk: {count}", style="default")
+                )
+            rows.append(
+                Text(
+                    "wiring: deferred (see ch13-phase8-audit-result.md)",
+                    style="dim",
+                )
+            )
+        except Exception as exc:
+            rows.append(
+                Text(f"storage import failed: {exc}", style="red")
+            )
+        return Group(*rows)
+
+
+__all__ = ["DoctorScreen"]

--- a/src/tui/screens/permission_modal.py
+++ b/src/tui/screens/permission_modal.py
@@ -1,21 +1,25 @@
-"""Permission request modal screen.
+"""Permission request modal screen with per-tool specialized previews.
 
-Phase 1 parity for ``typescript/src/components/permissions/PermissionRequest.tsx``.
-The ink reference mounts a full ``PermissionRequest`` overlay inside
-``FullscreenLayout.overlay`` that *steals input* until the user
-approves / denies the pending tool call. In Textual we model that as a
-``ModalScreen`` pushed onto the screen stack: Textual handles the
-keyboard priority (modals are always on top of the pushed stack).
+Phase 7 of the ch13 refactor (gap #8) closes the gap between the prior
+unified preview and chapter
+``typescript/src/components/permissions/PermissionRequest.tsx`` which
+routes to a per-tool body (Bash → command + matched rule; Edit →
+inline diff; Write → file path + content preview; etc.).
 
-Tool-specific bodies (``BashPermissionRequest``, ``EditPermissionRequest``, …)
-land in Phase 2 — Phase 1 renders a unified preview that works for every
-tool.
+Architecture per refactoring-plan A9: a single :class:`PermissionModal`
+screen with a tool-name-keyed dispatcher to specialized render
+functions. Avoids a class-per-tool hierarchy that would make adding
+tools verbose. Per the ``mouse=False`` design constraint (gap analysis
+§1 read #2 (c)), all interactive elements are reachable via keyboard
+only; the buttons are decorative — the actual decisions fire from the
+``y`` / ``n`` / ``Esc`` keybindings registered on the modal.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 
+from rich.console import Group, RenderableType
 from rich.markup import escape
 from rich.panel import Panel
 from rich.text import Text
@@ -97,7 +101,12 @@ class PermissionModal(ModalScreen[bool]):
             )
         )
         panel.mount(Static(Text(self._request.message), markup=False))
-        input_preview = _preview_tool_input(self._request.tool_input)
+        # Phase-7: dispatch to per-tool renderer (Bash → command + rule;
+        # Edit → inline diff; etc.). Falls back to a generic preview for
+        # unknown tools.
+        input_preview = preview_for_tool(
+            self._request.tool_name, self._request.tool_input
+        )
         if input_preview is not None:
             panel.mount(Static(input_preview, markup=False))
         if self._request.suggestion:
@@ -143,11 +152,43 @@ class PermissionModal(ModalScreen[bool]):
         self.dismiss(allowed)
 
 
-def _preview_tool_input(tool_input: Any) -> Panel | None:
-    """Render the tool input as a compact preview panel."""
+def _preview_tool_input(tool_input: Any) -> RenderableType | None:
+    """Dispatch to a tool-name-keyed renderer, falling back to generic.
+
+    The original signature is preserved so :class:`PermissionModal` keeps
+    the same call site. The dispatcher is the new behavior — Phase 7's
+    specialization happens through this single entry point.
+    """
+
+    return preview_for_tool(None, tool_input)
+
+
+def preview_for_tool(
+    tool_name: str | None, tool_input: Any
+) -> RenderableType | None:
+    """Render a permission preview for ``tool_input`` under ``tool_name``.
+
+    Specialized renderers live in ``_TOOL_RENDERERS``; unknown tools fall
+    through to :func:`_render_generic_input`. Callers may pass
+    ``tool_name=None`` to force the generic path (back-compat with code
+    that doesn't know the tool name).
+    """
 
     if not tool_input:
         return None
+    handler = _TOOL_RENDERERS.get(tool_name) if tool_name else None
+    try:
+        rendered = handler(tool_input) if handler else None
+    except Exception:
+        rendered = None
+    if rendered is None:
+        rendered = _render_generic_input(tool_input)
+    return rendered
+
+
+def _render_generic_input(tool_input: Any) -> RenderableType | None:
+    """Default preview — pretty-prints the input dict, capped per-key."""
+
     if isinstance(tool_input, dict):
         lines: list[str] = []
         for key, value in tool_input.items():
@@ -166,4 +207,172 @@ def _preview_tool_input(tool_input: Any) -> Panel | None:
         body = str(tool_input)
         if len(body) > 400:
             body = body[:397] + "…"
-    return Panel(Text(body), border_style="bright_black", padding=(0, 1), title=escape("input"))
+    return Panel(
+        Text(body),
+        border_style="bright_black",
+        padding=(0, 1),
+        title=escape("input"),
+    )
+
+
+# ---- per-tool renderers -----------------------------------------------------
+
+
+def _render_bash(tool_input: Any) -> RenderableType | None:
+    """Bash command + (when available) the matching permission rule."""
+
+    if not isinstance(tool_input, dict):
+        return None
+    command = tool_input.get("command")
+    if not command:
+        return None
+    body_lines: list[Text] = []
+    body_lines.append(Text("$ ", style="bold"))
+    body_lines[-1].append(str(command), style="default")
+
+    rule = tool_input.get("matched_permission_rule") or tool_input.get("rule")
+    if rule:
+        body_lines.append(Text())
+        body_lines.append(
+            Text("rule: ", style="dim").append(str(rule), style="bold cyan")
+        )
+
+    description = tool_input.get("description")
+    if description:
+        body_lines.append(Text())
+        body_lines.append(Text(str(description), style="italic dim"))
+
+    return Panel(
+        Group(*body_lines),
+        border_style="yellow",
+        padding=(0, 1),
+        title=escape("bash"),
+    )
+
+
+def _render_edit(tool_input: Any) -> RenderableType | None:
+    """File-path + inline old/new diff (line-oriented)."""
+
+    if not isinstance(tool_input, dict):
+        return None
+    file_path = tool_input.get("file_path") or tool_input.get("path")
+    old_string = tool_input.get("old_string", "") or ""
+    new_string = tool_input.get("new_string", "") or ""
+
+    parts: list[RenderableType] = []
+    if file_path:
+        parts.append(
+            Text("file: ", style="dim").append(str(file_path), style="bold")
+        )
+    if old_string or new_string:
+        diff = _format_inline_diff(old_string, new_string)
+        if diff is not None:
+            parts.append(diff)
+    if not parts:
+        return None
+    return Panel(
+        Group(*parts),
+        border_style="yellow",
+        padding=(0, 1),
+        title=escape("edit"),
+    )
+
+
+def _render_write(tool_input: Any) -> RenderableType | None:
+    """File path + content preview (truncated)."""
+
+    if not isinstance(tool_input, dict):
+        return None
+    file_path = tool_input.get("file_path") or tool_input.get("path")
+    content = tool_input.get("content", "") or ""
+    if not file_path and not content:
+        return None
+    parts: list[RenderableType] = []
+    if file_path:
+        parts.append(
+            Text("write: ", style="dim").append(str(file_path), style="bold")
+        )
+    if content:
+        preview = str(content)
+        if len(preview) > 400:
+            preview = preview[:397] + "…"
+        parts.append(Text(preview))
+    return Panel(
+        Group(*parts),
+        border_style="yellow",
+        padding=(0, 1),
+        title=escape("write"),
+    )
+
+
+def _render_read(tool_input: Any) -> RenderableType | None:
+    """File path + optional limit/offset."""
+
+    if not isinstance(tool_input, dict):
+        return None
+    file_path = tool_input.get("file_path") or tool_input.get("path")
+    if not file_path:
+        return None
+    parts: list[RenderableType] = [
+        Text("read: ", style="dim").append(str(file_path), style="bold")
+    ]
+    extras = []
+    if tool_input.get("offset"):
+        extras.append(f"offset={tool_input.get('offset')}")
+    if tool_input.get("limit"):
+        extras.append(f"limit={tool_input.get('limit')}")
+    if extras:
+        parts.append(Text(" ".join(extras), style="dim"))
+    return Panel(
+        Group(*parts),
+        border_style="yellow",
+        padding=(0, 1),
+        title=escape("read"),
+    )
+
+
+def _format_inline_diff(
+    old_string: str, new_string: str, *, max_lines: int = 12
+) -> RenderableType | None:
+    """Render a minus/plus inline diff capped at ``max_lines``."""
+
+    old_lines = old_string.splitlines() or ([""] if old_string else [])
+    new_lines = new_string.splitlines() or ([""] if new_string else [])
+    out: list[Text] = []
+    for line in old_lines[:max_lines]:
+        out.append(Text("- ", style="bold red").append(line, style="red"))
+    if len(old_lines) > max_lines:
+        out.append(
+            Text(f"  … {len(old_lines) - max_lines} more removed lines", style="dim")
+        )
+    for line in new_lines[:max_lines]:
+        out.append(Text("+ ", style="bold green").append(line, style="green"))
+    if len(new_lines) > max_lines:
+        out.append(
+            Text(f"  … {len(new_lines) - max_lines} more added lines", style="dim")
+        )
+    if not out:
+        return None
+    return Group(*out)
+
+
+# Tool name → render function. Add new tools by appending here; the
+# fallback (`_render_generic_input`) catches everything else.
+_TOOL_RENDERERS: dict[str, Callable[[Any], RenderableType | None]] = {
+    "Bash": _render_bash,
+    "Edit": _render_edit,
+    "Write": _render_write,
+    "Read": _render_read,
+    # Common alias variants — match either capitalization the tool
+    # registry might use.
+    "bash": _render_bash,
+    "edit": _render_edit,
+    "write": _render_write,
+    "read": _render_read,
+}
+
+
+__all__ = [
+    "PermissionModal",
+    "preview_for_tool",
+]

--- a/src/tui/screens/resume_conversation.py
+++ b/src/tui/screens/resume_conversation.py
@@ -1,0 +1,136 @@
+"""Resume-conversation modal screen.
+
+Phase-8 of the ch13 refactor (gap #9) — see
+``my-docs/ch13-phase8-audit-result.md`` for the audit result and the
+rationale for shipping a placeholder rather than the full wiring.
+
+When the WI-8.0 audit found state (2) — `services/session_storage.py`
+exists as a module but no live caller writes transcripts — the
+Resume/Doctor screens were scope-limited to navigation surfaces that
+honestly say "not yet wired" to the user. This module provides that
+surface; future work fills in the listing once persistence is wired.
+"""
+
+from __future__ import annotations
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Center, Middle, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import OptionList, Static
+from textual.widgets.option_list import Option
+
+
+class ResumeConversation(ModalScreen[str | None]):
+    """Modal listing past sessions; dismisses with the chosen session id.
+
+    Currently a placeholder — :meth:`_load_sessions` returns ``[]`` until
+    transcript-persistence wiring lands. The Esc / Ctrl+C path returns
+    ``None`` so callers (slash commands) can ignore the dismissal.
+    """
+
+    BINDINGS = [
+        Binding("escape", "dismiss_modal", "Close"),
+        Binding("q", "dismiss_modal", "Close"),
+    ]
+
+    DEFAULT_CSS = """
+    ResumeConversation {
+        align: center middle;
+    }
+    ResumeConversation > Middle > Center > Vertical {
+        width: 80%;
+        max-width: 90;
+        max-height: 70%;
+        border: round $primary;
+        background: $surface;
+        padding: 1 2;
+    }
+    ResumeConversation Static.-title {
+        color: $primary;
+        text-style: bold;
+        padding: 0 0 1 0;
+    }
+    ResumeConversation Static.-empty {
+        color: $text-muted;
+        padding: 1 0 0 0;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Middle():
+            with Center():
+                yield Vertical()
+
+    def on_mount(self) -> None:
+        body = self.query_one(Vertical)
+        body.mount(
+            Static(
+                Text("Resume conversation", style="bold"),
+                classes="-title",
+                markup=False,
+            )
+        )
+        sessions = self._load_sessions()
+        if not sessions:
+            body.mount(
+                Static(
+                    Text(
+                        "No persisted conversations yet.\n\n"
+                        "Transcript persistence is not wired into this build "
+                        "(see my-docs/ch13-phase8-audit-result.md). When the "
+                        "wiring lands, prior sessions will appear here.",
+                        style="dim",
+                    ),
+                    classes="-empty",
+                    markup=False,
+                )
+            )
+            return
+        options = OptionList(
+            *(Option(label, id=session_id) for session_id, label in sessions)
+        )
+        body.mount(options)
+
+    def on_option_list_option_selected(
+        self, event: OptionList.OptionSelected
+    ) -> None:
+        self.dismiss(event.option.id)
+
+    def action_dismiss_modal(self) -> None:
+        self.dismiss(None)
+
+    # ---- internals ----
+    def _load_sessions(self) -> list[tuple[str, str]]:
+        """Return ``(session_id, label)`` pairs to display.
+
+        Phase-8 close-out: ``SessionStorage.list_sessions()`` is now wired
+        from ``agent_bridge.py``; this method reads the metadata files
+        the agent loop writes during normal operation. Empty list when
+        no sessions exist (clean install, first run).
+        """
+
+        try:
+            from src.services.session_storage import SessionStorage
+
+            metas = SessionStorage.list_sessions()
+            out: list[tuple[str, str]] = []
+            for meta in metas:
+                session_id = getattr(meta, "session_id", None) or getattr(
+                    meta, "id", None
+                )
+                label = (
+                    getattr(meta, "title", None)
+                    or getattr(meta, "summary", None)
+                    or session_id
+                    or "(unnamed session)"
+                )
+                if session_id:
+                    out.append((session_id, str(label)))
+            return out
+        except Exception:
+            return []
+
+
+__all__ = ["ResumeConversation"]

--- a/src/tui/vim_buffer.py
+++ b/src/tui/vim_buffer.py
@@ -1,0 +1,227 @@
+"""Multi-line buffer model + cursor coordinate type for vim mode.
+
+Phase-4 wave-1 of the ch13 refactor (gap #4). The chapter's vim mode
+operates on a multi-line buffer; the existing ``src/tui/vim.py`` is a
+single-line state machine bound to a Textual ``Input`` widget. This
+module ports the multi-line buffer model so ``vim_text_objects`` and
+``vim_operators`` (also wave-1) have a stable substrate to operate on
+without touching the existing single-line vim integration.
+
+Wave-2 work (WI-4.1 Input → TextArea swap, WI-4.5 Visual mode, WI-4.6
+regex search) builds on top of this. WI-4.1 in particular plumbs
+:class:`VimBuffer` into ``prompt_input.py`` once the multi-line widget
+swap is decided.
+
+Public surface:
+
+* :class:`Cursor` — frozen ``(row, col)`` coordinate.
+* :class:`Range` — frozen ``[start, end)`` half-open span.
+* :class:`VimBuffer` — multi-line buffer with cursor + helpers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Cursor:
+    """Zero-indexed buffer coordinate.
+
+    ``row`` is the line index; ``col`` is the column within the line.
+    Both are clamped to the buffer dimensions by :class:`VimBuffer` —
+    free-standing ``Cursor`` instances are not validated, so callers
+    that construct them outside the buffer must clamp themselves.
+    """
+
+    row: int = 0
+    col: int = 0
+
+
+@dataclass(frozen=True)
+class Range:
+    """Half-open ``[start, end)`` selection range.
+
+    ``start`` is inclusive, ``end`` is exclusive. ``end`` may be
+    "beyond the end of the line" — i.e. one past the last character of
+    a line — so a range covering the trailing newline is representable.
+    """
+
+    start: Cursor
+    end: Cursor
+
+    @property
+    def is_empty(self) -> bool:
+        return self.start == self.end
+
+    def normalised(self) -> "Range":
+        """Return the range with start ≤ end (in buffer order)."""
+
+        if (self.start.row, self.start.col) <= (self.end.row, self.end.col):
+            return self
+        return Range(start=self.end, end=self.start)
+
+
+class VimBuffer:
+    """Mutable multi-line buffer with a cursor + simple text operations.
+
+    Storage is a list of strings, one per line. Trailing newlines are
+    NOT stored — they are an implicit separator between lines. So a
+    file ``"a\\nb\\n"`` becomes ``["a", "b"]`` with no extra trailing
+    empty line, and ``"a\\nb"`` becomes the same. This matches
+    ``str.splitlines`` behavior, which is what most external
+    text-source clients (Textual ``TextArea`` etc.) emit.
+
+    Out-of-range cursor coordinates are clamped on assignment via
+    :meth:`set_cursor` so the cursor invariant
+    (``0 <= row < line_count`` and ``0 <= col <= len(lines[row])``) is
+    always preserved.
+    """
+
+    def __init__(self, text: str = "") -> None:
+        self._lines: list[str] = text.splitlines() if text else [""]
+        if not self._lines:
+            self._lines = [""]
+        self._cursor = Cursor(0, 0)
+
+    # ---- accessors ----
+    @property
+    def cursor(self) -> Cursor:
+        return self._cursor
+
+    def set_cursor(self, row: int, col: int) -> None:
+        row = max(0, min(row, len(self._lines) - 1))
+        line = self._lines[row]
+        col = max(0, min(col, len(line)))
+        self._cursor = Cursor(row=row, col=col)
+
+    @property
+    def lines(self) -> list[str]:
+        return list(self._lines)
+
+    @property
+    def line_count(self) -> int:
+        return len(self._lines)
+
+    def line(self, row: int) -> str:
+        if row < 0 or row >= len(self._lines):
+            raise IndexError(f"row {row} out of range")
+        return self._lines[row]
+
+    @property
+    def text(self) -> str:
+        return "\n".join(self._lines)
+
+    def is_empty(self) -> bool:
+        return self._lines == [""]
+
+    # ---- char/range access ----
+    def char_at(self, row: int, col: int) -> str:
+        """Return the character at ``(row, col)`` or ``""`` past line end."""
+
+        if row < 0 or row >= len(self._lines):
+            return ""
+        line = self._lines[row]
+        if col < 0 or col >= len(line):
+            return ""
+        return line[col]
+
+    def text_in(self, range_: Range) -> str:
+        """Extract the substring under ``range_`` (normalised)."""
+
+        r = range_.normalised()
+        if r.is_empty:
+            return ""
+        if r.start.row == r.end.row:
+            line = self._lines[r.start.row]
+            return line[r.start.col : r.end.col]
+        # Multi-line: head + middle lines + tail.
+        parts: list[str] = [self._lines[r.start.row][r.start.col :]]
+        for row in range(r.start.row + 1, r.end.row):
+            parts.append(self._lines[row])
+        if r.end.col > 0 and r.end.row < len(self._lines):
+            parts.append(self._lines[r.end.row][: r.end.col])
+        else:
+            parts.append("")
+        return "\n".join(parts)
+
+    # ---- mutations ----
+    def replace(self, range_: Range, replacement: str) -> str:
+        """Replace ``range_`` with ``replacement``; return the removed text.
+
+        The cursor is parked at ``range_.start`` (i.e. the position the
+        replaced span used to start at). Callers that want a different
+        cursor position update it after.
+        """
+
+        r = range_.normalised()
+        removed = self.text_in(r)
+        before = self._lines[r.start.row][: r.start.col]
+        if r.end.row < len(self._lines):
+            after = self._lines[r.end.row][r.end.col :]
+        else:
+            after = ""
+
+        new_block = before + replacement + after
+        new_block_lines = new_block.splitlines() or [""]
+
+        # Rebuild ``self._lines`` with the spliced block in place of
+        # ``range_``.
+        self._lines = (
+            self._lines[: r.start.row]
+            + new_block_lines
+            + self._lines[r.end.row + 1 :]
+        )
+        if not self._lines:
+            self._lines = [""]
+        # Park cursor at the start of the replaced span (callers re-park
+        # if they want a different position).
+        self.set_cursor(r.start.row, r.start.col)
+        return removed
+
+    def delete(self, range_: Range) -> str:
+        """Convenience: replace ``range_`` with empty string."""
+
+        return self.replace(range_, "")
+
+    def insert(self, text: str) -> None:
+        """Insert ``text`` at the cursor and advance the cursor past it."""
+
+        if not text:
+            return
+        cur = self._cursor
+        line = self._lines[cur.row]
+        new_block = line[: cur.col] + text + line[cur.col :]
+        new_lines = new_block.splitlines()
+        if not new_lines:
+            new_lines = [""]
+        self._lines = (
+            self._lines[: cur.row] + new_lines + self._lines[cur.row + 1 :]
+        )
+        # Advance cursor past the inserted text.
+        if "\n" in text:
+            tail = text.split("\n")[-1]
+            self.set_cursor(cur.row + text.count("\n"), len(tail))
+        else:
+            self.set_cursor(cur.row, cur.col + len(text))
+
+    # ---- motion helpers ----
+    def move_relative(self, drow: int, dcol: int) -> None:
+        cur = self._cursor
+        self.set_cursor(cur.row + drow, cur.col + dcol)
+
+    def move_to_line_start(self) -> None:
+        self.set_cursor(self._cursor.row, 0)
+
+    def move_to_line_end(self) -> None:
+        self.set_cursor(self._cursor.row, len(self._lines[self._cursor.row]))
+
+    def move_to_buffer_start(self) -> None:
+        self.set_cursor(0, 0)
+
+    def move_to_buffer_end(self) -> None:
+        last_row = len(self._lines) - 1
+        self.set_cursor(last_row, len(self._lines[last_row]))
+
+
+__all__ = ["Cursor", "Range", "VimBuffer"]

--- a/src/tui/vim_operators.py
+++ b/src/tui/vim_operators.py
@@ -1,0 +1,298 @@
+"""Vim operators with motion/text-object composition + count prefixes.
+
+Phase-4 wave-1 of the ch13 refactor (gap #4 sub-item). Mirrors
+``typescript/src/vim/operators.ts``: an operator (``d`` delete /
+``c`` change / ``y`` yank / ``>`` indent / ``<`` dedent) composes with
+a motion or text object to produce a :class:`Range` the buffer applies.
+
+Examples (from chapter):
+
+* ``d2w`` — delete 2 words
+* ``ciw`` — change inner word
+* ``y$`` — yank to end of line
+* ``>i{`` — indent inner braces
+
+The parser :func:`parse_operator_motion` takes a string like
+``"d2iw"`` and returns ``(operator, motion_or_object, count)``. Apply
+the resolved range to the buffer via :func:`apply_operator`. Yanked
+text lands in ``yank_buffer`` (caller-supplied so multiple operators
+can share the same register).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .vim_buffer import Cursor, Range, VimBuffer
+from .vim_text_objects import find_text_object
+
+
+@dataclass(frozen=True)
+class ParsedOperator:
+    """Parse result of an operator+motion/object string."""
+
+    operator: str
+    target: str  # motion (``w`` / ``b`` / ``$`` / etc.) or text object (``iw`` / ``a"``)
+    count: int = 1
+
+
+_VALID_OPERATORS = frozenset({"d", "c", "y", ">", "<"})
+
+# Motions and object specifiers we recognize on the target side. Each
+# motion key is a (single-char) primitive; text objects are 2-char
+# (``iw``, ``a{``, etc.).
+_MOTION_KEYS = frozenset({"w", "b", "e", "W", "B", "E", "$", "0", "^", "h", "j", "k", "l"})
+_TEXT_OBJECT_PREFIX = ("i", "a")
+
+
+_OPERATOR_RE = re.compile(
+    r"^"
+    r"(?P<op>[dcy><])"
+    r"(?P<count>\d*)"
+    r"(?P<target>"
+    r"[wbeWBE$0^hjkl]"  # motion
+    r"|[ia][wsp\"'`(){}\[\]<>]"  # text object — 2 chars; explicit class
+    r")"
+    r"$"
+)
+
+
+def parse_operator_motion(keys: str) -> ParsedOperator | None:
+    """Parse a vim operator+motion string. Returns ``None`` on bad input.
+
+    Examples::
+
+        parse_operator_motion("dw")    -> ParsedOperator("d", "w", 1)
+        parse_operator_motion("d2w")   -> ParsedOperator("d", "w", 2)
+        parse_operator_motion("ciw")   -> ParsedOperator("c", "iw", 1)
+        parse_operator_motion("3>i{")  -> None  (count between operator and target only — no leading count yet)
+        parse_operator_motion("y$")    -> ParsedOperator("y", "$", 1)
+    """
+
+    match = _OPERATOR_RE.match(keys)
+    if not match:
+        return None
+    count_str = match.group("count")
+    count = int(count_str) if count_str else 1
+    return ParsedOperator(
+        operator=match.group("op"),
+        target=match.group("target"),
+        count=count,
+    )
+
+
+def resolve_target_range(
+    buffer: VimBuffer,
+    at: Cursor,
+    target: str,
+    *,
+    count: int = 1,
+) -> Range | None:
+    """Resolve ``target`` (motion or text object) into a buffer range.
+
+    Returns ``None`` if the target is malformed or no range applies.
+    """
+
+    if not target:
+        return None
+    if len(target) == 2 and target[0] in _TEXT_OBJECT_PREFIX:
+        # Text object — count is currently ignored (vim's count semantic
+        # for text objects is more nuanced; wave-2 work).
+        return find_text_object(buffer, at, target)
+    return _resolve_motion_range(buffer, at, target, count=count)
+
+
+def _resolve_motion_range(
+    buffer: VimBuffer, at: Cursor, motion: str, *, count: int
+) -> Range | None:
+    """Resolve a single-char motion under ``count``."""
+
+    if motion not in _MOTION_KEYS:
+        return None
+    cur = at
+    if motion == "$":
+        end_col = len(buffer.line(cur.row)) if cur.row < buffer.line_count else 0
+        return Range(start=cur, end=Cursor(cur.row, end_col))
+    if motion == "0":
+        return Range(start=Cursor(cur.row, 0), end=cur)
+    if motion == "^":
+        line = buffer.line(cur.row) if cur.row < buffer.line_count else ""
+        first_non_ws = 0
+        while first_non_ws < len(line) and line[first_non_ws].isspace():
+            first_non_ws += 1
+        return Range(start=Cursor(cur.row, first_non_ws), end=cur)
+    if motion in ("h", "l"):
+        delta = -count if motion == "h" else count
+        new_col = max(0, cur.col + delta)
+        if cur.row < buffer.line_count:
+            new_col = min(new_col, len(buffer.line(cur.row)))
+        if new_col == cur.col:
+            return None
+        a, b = sorted([cur.col, new_col])
+        return Range(start=Cursor(cur.row, a), end=Cursor(cur.row, b))
+    if motion in ("j", "k"):
+        delta = -count if motion == "k" else count
+        new_row = max(0, min(cur.row + delta, buffer.line_count - 1))
+        if new_row == cur.row:
+            return None
+        # Line-wise range: full lines from the closer row to the further row.
+        a, b = sorted([cur.row, new_row])
+        end_col = len(buffer.line(b)) if b < buffer.line_count else 0
+        return Range(start=Cursor(a, 0), end=Cursor(b, end_col))
+    if motion in ("w", "W"):
+        return _word_motion(buffer, cur, count=count, big=(motion == "W"))
+    if motion in ("b", "B"):
+        return _word_back(buffer, cur, count=count, big=(motion == "B"))
+    if motion in ("e", "E"):
+        return _word_end(buffer, cur, count=count, big=(motion == "E"))
+    return None
+
+
+def _word_motion(
+    buffer: VimBuffer, at: Cursor, *, count: int, big: bool
+) -> Range | None:
+    """``w`` / ``W`` — start of next word."""
+
+    line = buffer.line(at.row) if at.row < buffer.line_count else ""
+    col = at.col
+    for _ in range(max(1, count)):
+        # skip current word
+        if big:
+            while col < len(line) and not line[col].isspace():
+                col += 1
+        else:
+            while col < len(line) and (line[col].isalnum() or line[col] == "_"):
+                col += 1
+        # skip whitespace
+        while col < len(line) and line[col].isspace():
+            col += 1
+    if col == at.col:
+        return None
+    return Range(start=at, end=Cursor(at.row, col))
+
+
+def _word_back(
+    buffer: VimBuffer, at: Cursor, *, count: int, big: bool
+) -> Range | None:
+    """``b`` / ``B`` — start of previous word."""
+
+    line = buffer.line(at.row) if at.row < buffer.line_count else ""
+    col = at.col
+    for _ in range(max(1, count)):
+        # step back over whitespace
+        while col > 0 and line[col - 1].isspace():
+            col -= 1
+        if big:
+            while col > 0 and not line[col - 1].isspace():
+                col -= 1
+        else:
+            while col > 0 and (line[col - 1].isalnum() or line[col - 1] == "_"):
+                col -= 1
+    if col == at.col:
+        return None
+    return Range(start=Cursor(at.row, col), end=at)
+
+
+def _word_end(
+    buffer: VimBuffer, at: Cursor, *, count: int, big: bool
+) -> Range | None:
+    """``e`` / ``E`` — end of word (end-inclusive)."""
+
+    line = buffer.line(at.row) if at.row < buffer.line_count else ""
+    col = at.col
+    for _ in range(max(1, count)):
+        # step forward at least one char so ``e`` repeated lands on the next word
+        if col < len(line):
+            col += 1
+        # skip whitespace
+        while col < len(line) and line[col].isspace():
+            col += 1
+        # walk to end of word
+        if big:
+            while col < len(line) and not line[col].isspace():
+                col += 1
+        else:
+            while col < len(line) and (line[col].isalnum() or line[col] == "_"):
+                col += 1
+    if col == at.col:
+        return None
+    return Range(start=at, end=Cursor(at.row, col))
+
+
+# ---- operator application --------------------------------------------------
+
+
+def apply_operator(
+    buffer: VimBuffer,
+    range_: Range,
+    operator: str,
+    *,
+    yank_buffer: list[str] | None = None,
+) -> str:
+    """Apply ``operator`` to ``range_`` on ``buffer``. Returns the affected text.
+
+    ``yank_buffer`` (when supplied) receives the deleted/yanked text as
+    the most-recent yank entry. Pass a single ``list`` and operators
+    overwrite element 0.
+    """
+
+    text = buffer.text_in(range_)
+    if operator == "d":
+        if yank_buffer is not None:
+            _set_yank(yank_buffer, text)
+        buffer.delete(range_)
+    elif operator == "c":
+        if yank_buffer is not None:
+            _set_yank(yank_buffer, text)
+        buffer.replace(range_, "")
+    elif operator == "y":
+        if yank_buffer is not None:
+            _set_yank(yank_buffer, text)
+    elif operator == ">":
+        _indent_range(buffer, range_, indent_amount=1)
+    elif operator == "<":
+        _indent_range(buffer, range_, indent_amount=-1)
+    return text
+
+
+def _set_yank(yank_buffer: list[str], text: str) -> None:
+    if not yank_buffer:
+        yank_buffer.append(text)
+    else:
+        yank_buffer[0] = text
+
+
+def _indent_range(
+    buffer: VimBuffer, range_: Range, *, indent_amount: int
+) -> None:
+    """Add or remove leading indent (2 spaces per level) on each line."""
+
+    r = range_.normalised()
+    indent_unit = "  "  # 2 spaces matches the typical TUI editor default
+    new_lines = list(buffer.lines)
+    for row in range(r.start.row, r.end.row + 1):
+        if row >= len(new_lines):
+            break
+        line = new_lines[row]
+        if indent_amount > 0:
+            new_lines[row] = indent_unit + line
+        else:
+            stripped = line.lstrip(" ")
+            removed = len(line) - len(stripped)
+            cut = min(removed, len(indent_unit))
+            new_lines[row] = line[cut:]
+    # Replace the buffer wholesale via ``replace`` over the whole document.
+    full_range = Range(
+        start=Cursor(0, 0),
+        end=Cursor(len(buffer.lines) - 1, len(buffer.lines[-1])),
+    )
+    buffer.replace(full_range, "\n".join(new_lines))
+
+
+__all__ = [
+    "ParsedOperator",
+    "apply_operator",
+    "parse_operator_motion",
+    "resolve_target_range",
+]

--- a/src/tui/vim_search.py
+++ b/src/tui/vim_search.py
@@ -1,0 +1,229 @@
+"""Regex search for vim mode — ``/`` and ``?`` plus ``n`` / ``N`` repeat.
+
+Phase-4 wave-2 of the ch13 refactor (gap #4 sub-item). Operates on
+:class:`VimBuffer` and returns cursor positions a host widget can jump
+to. The search state is held in :class:`VimSearchState` so ``n`` / ``N``
+can repeat the most-recent search.
+
+Pattern semantics: Python ``re`` syntax (not exactly vim's ``magic`` /
+``nomagic`` modes — close enough for the common ``/foo``, ``/\\d+``,
+``/^class\\s`` use cases, and Python's regex engine has fewer
+surprises than vim's). Multiline matches are supported.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+from .vim_buffer import Cursor, VimBuffer
+
+
+class SearchDirection(str, Enum):
+    FORWARD = "/"
+    BACKWARD = "?"
+
+
+@dataclass
+class SearchHit:
+    """One match: cursor position + the matched text."""
+
+    at: Cursor
+    text: str
+
+
+class InvalidPattern(ValueError):
+    """Raised when a search pattern is not a valid regex."""
+
+
+def find_next(
+    buffer: VimBuffer,
+    *,
+    pattern: str,
+    after: Cursor,
+    direction: SearchDirection = SearchDirection.FORWARD,
+    wrap: bool = True,
+) -> SearchHit | None:
+    """Find the next match of ``pattern`` from ``after``.
+
+    Args:
+        buffer: source.
+        pattern: regex pattern; raises :class:`InvalidPattern` on bad regex.
+        after: cursor position to start AFTER (forward) or BEFORE (backward).
+        direction: ``/`` forward (default) or ``?`` backward.
+        wrap: when ``True``, wrap around the buffer ends. Vim's
+            default. Pass ``False`` to disable.
+
+    Returns the first :class:`SearchHit` found, or ``None`` when the
+    pattern has no match.
+    """
+
+    if not pattern:
+        return None
+    try:
+        rx = re.compile(pattern)
+    except re.error as exc:
+        raise InvalidPattern(str(exc)) from None
+
+    if direction is SearchDirection.FORWARD:
+        return _find_forward(buffer, rx, after, wrap=wrap)
+    return _find_backward(buffer, rx, after, wrap=wrap)
+
+
+def _find_forward(
+    buffer: VimBuffer, rx: re.Pattern[str], after: Cursor, *, wrap: bool
+) -> SearchHit | None:
+    # Walk from after.row, after.col forward; first hit wins.
+    n_lines = buffer.line_count
+    if n_lines == 0:
+        return None
+    # Search from after position to end of buffer.
+    for row in range(after.row, n_lines):
+        line = buffer.line(row)
+        start_col = after.col + 1 if row == after.row else 0
+        if start_col >= len(line):
+            # On the start row past the end — try matching empty position
+            # only if start_col == len(line) and pattern is empty-matching;
+            # otherwise skip.
+            if start_col != len(line):
+                continue
+        m = rx.search(line, start_col)
+        if m is not None:
+            return SearchHit(at=Cursor(row, m.start()), text=m.group(0))
+    if not wrap:
+        return None
+    # Wrap to the start of the buffer up to the original after.row.
+    for row in range(0, after.row + 1):
+        line = buffer.line(row)
+        end_col = after.col if row == after.row else len(line)
+        m = rx.search(line[:end_col])
+        if m is not None:
+            return SearchHit(at=Cursor(row, m.start()), text=m.group(0))
+    return None
+
+
+def _find_backward(
+    buffer: VimBuffer, rx: re.Pattern[str], after: Cursor, *, wrap: bool
+) -> SearchHit | None:
+    n_lines = buffer.line_count
+    if n_lines == 0:
+        return None
+    # Walk from after row backwards; on each line, find the last match
+    # whose START is before the cursor column (vim's "previous match"
+    # semantic — a match whose start is < cursor.col qualifies even if
+    # its end extends past the cursor).
+    for row in range(after.row, -1, -1):
+        line = buffer.line(row)
+        if row == after.row:
+            cutoff = after.col
+        else:
+            cutoff = len(line) + 1  # any start <= len(line) qualifies
+        last_match = None
+        for m in rx.finditer(line):
+            if m.start() < cutoff:
+                last_match = m
+            else:
+                break
+        if last_match is not None:
+            return SearchHit(
+                at=Cursor(row, last_match.start()), text=last_match.group(0)
+            )
+    if not wrap:
+        return None
+    # Wrap to the end and walk back to after.row, INCLUDING after.row's
+    # tail (matches whose start is at or after after.col on after.row).
+    for row in range(n_lines - 1, after.row - 1, -1):
+        line = buffer.line(row)
+        if row == after.row:
+            # On wrap pass, after.row's "before-cursor" matches were
+            # already considered in the first pass; include only matches
+            # whose start is >= after.col (the tail).
+            min_start = after.col
+        else:
+            min_start = 0
+        last_match = None
+        for m in rx.finditer(line):
+            if m.start() >= min_start:
+                last_match = m
+        if last_match is not None:
+            return SearchHit(
+                at=Cursor(row, last_match.start()), text=last_match.group(0)
+            )
+    return None
+
+
+@dataclass
+class VimSearchState:
+    """Track the most-recent search for ``n`` / ``N`` repeat.
+
+    Use::
+
+        state = VimSearchState()
+        hit = state.search(buffer, pattern="foo", at=cursor)  # "/foo"
+        next_hit = state.repeat(buffer, at=cursor)            # "n"
+        prev_hit = state.repeat(buffer, at=cursor, reverse=True)  # "N"
+    """
+
+    pattern: str = ""
+    direction: SearchDirection = SearchDirection.FORWARD
+
+    def search(
+        self,
+        buffer: VimBuffer,
+        *,
+        pattern: str,
+        at: Cursor,
+        direction: SearchDirection = SearchDirection.FORWARD,
+        wrap: bool = True,
+    ) -> SearchHit | None:
+        """Run a fresh search and remember the pattern for ``n``-repeat."""
+
+        self.pattern = pattern
+        self.direction = direction
+        return find_next(
+            buffer,
+            pattern=pattern,
+            after=at,
+            direction=direction,
+            wrap=wrap,
+        )
+
+    def repeat(
+        self,
+        buffer: VimBuffer,
+        *,
+        at: Cursor,
+        reverse: bool = False,
+        wrap: bool = True,
+    ) -> SearchHit | None:
+        """``n`` (forward in last direction) / ``N`` (reverse)."""
+
+        if not self.pattern:
+            return None
+        direction = self.direction
+        if reverse:
+            direction = (
+                SearchDirection.BACKWARD
+                if direction is SearchDirection.FORWARD
+                else SearchDirection.FORWARD
+            )
+        return find_next(
+            buffer,
+            pattern=self.pattern,
+            after=at,
+            direction=direction,
+            wrap=wrap,
+        )
+
+    def is_armed(self) -> bool:
+        return bool(self.pattern)
+
+
+__all__ = [
+    "InvalidPattern",
+    "SearchDirection",
+    "SearchHit",
+    "VimSearchState",
+    "find_next",
+]

--- a/src/tui/vim_text_objects.py
+++ b/src/tui/vim_text_objects.py
@@ -1,0 +1,314 @@
+"""Vim text-object resolution.
+
+Phase-4 wave-1 of the ch13 refactor (gap #4 sub-item). Mirrors
+``typescript/src/vim/textObjects.ts`` — given a buffer, a cursor
+position, and a text-object specifier (``iw``, ``aw``, ``i"``, ``a{``,
+etc.), resolve the spanning :class:`Range` the operator should act on.
+
+Specifiers are a 2-character pair: the first char is ``i`` (inner —
+exclude surrounding whitespace / delimiters) or ``a`` (around — include
+them); the second is the object kind (``w`` word / ``s`` sentence /
+``p`` paragraph / quote chars / bracket chars).
+
+Coverage (chapter parity, wave-1):
+
+* ``iw`` / ``aw`` — word
+* ``ip`` / ``ap`` — paragraph
+* ``i"`` / ``a"`` — double-quoted
+* ``i'`` / ``a'`` — single-quoted
+* ``` i` ``` / ``` a` ``` — backtick-quoted
+* ``i(`` / ``a(`` — paren block (alias ``i)`` / ``a)``)
+* ``i[`` / ``a[`` — bracket block (alias ``i]`` / ``a]``)
+* ``i{`` / ``a{`` — brace block (alias ``i}`` / ``a}``)
+* ``i<`` / ``a<`` — angle block (alias ``i>`` / ``a>``)
+
+Returns ``None`` when no object matches at the cursor — operator code
+should treat that as a no-op.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .vim_buffer import Cursor, Range, VimBuffer
+
+
+# Brace pairs that match each other. Each entry maps the *open or close*
+# character to the (open, close) tuple so callers don't need to remember
+# which side they're on.
+_BRACE_PAIRS: Final[dict[str, tuple[str, str]]] = {
+    "(": ("(", ")"),
+    ")": ("(", ")"),
+    "[": ("[", "]"),
+    "]": ("[", "]"),
+    "{": ("{", "}"),
+    "}": ("{", "}"),
+    "<": ("<", ">"),
+    ">": ("<", ">"),
+}
+
+_QUOTE_CHARS: Final[frozenset[str]] = frozenset({'"', "'", "`"})
+
+
+def find_text_object(
+    buffer: VimBuffer,
+    at: Cursor,
+    specifier: str,
+) -> Range | None:
+    """Resolve ``specifier`` (``iw``, ``a"``, etc.) under ``at``.
+
+    Returns ``None`` if the cursor isn't inside an object of the given
+    kind (e.g. ``i"`` when the line has no quotes).
+    """
+
+    if len(specifier) != 2:
+        return None
+    inner_or_around = specifier[0]
+    kind = specifier[1]
+    if inner_or_around not in ("i", "a"):
+        return None
+    inner = inner_or_around == "i"
+
+    if kind == "w":
+        return _word(buffer, at, inner=inner)
+    if kind == "s":
+        return _sentence(buffer, at, inner=inner)
+    if kind == "p":
+        return _paragraph(buffer, at, inner=inner)
+    if kind in _QUOTE_CHARS:
+        return _quoted(buffer, at, quote=kind, inner=inner)
+    if kind in _BRACE_PAIRS:
+        open_ch, close_ch = _BRACE_PAIRS[kind]
+        return _brace(buffer, at, open_ch=open_ch, close_ch=close_ch, inner=inner)
+    return None
+
+
+# ---- Word ------------------------------------------------------------------
+
+
+def _word(buffer: VimBuffer, at: Cursor, *, inner: bool) -> Range | None:
+    """``iw`` / ``aw``: a run of word chars; ``a`` includes trailing whitespace."""
+
+    line = buffer.line(at.row) if at.row < buffer.line_count else ""
+    if not line:
+        return None
+    col = max(0, min(at.col, len(line) - 1)) if line else 0
+    if col >= len(line):
+        return None
+    if not _is_word_char(line[col]):
+        # Cursor is on a non-word char — vim's ``iw`` matches the run of
+        # whitespace too; for simplicity we return None when the cursor
+        # is on a separator. Callers can decide.
+        return None
+    start = col
+    while start > 0 and _is_word_char(line[start - 1]):
+        start -= 1
+    end = col
+    while end < len(line) and _is_word_char(line[end]):
+        end += 1
+    if not inner:
+        # Include trailing whitespace (or leading whitespace if no
+        # trailing whitespace exists).
+        trail = end
+        while trail < len(line) and line[trail].isspace():
+            trail += 1
+        if trail > end:
+            end = trail
+        else:
+            while start > 0 and line[start - 1].isspace():
+                start -= 1
+    return Range(start=Cursor(at.row, start), end=Cursor(at.row, end))
+
+
+def _is_word_char(ch: str) -> bool:
+    return ch.isalnum() or ch == "_"
+
+
+# ---- Sentence --------------------------------------------------------------
+
+
+_SENTENCE_TERMINATORS: Final[frozenset[str]] = frozenset({".", "!", "?"})
+
+
+def _sentence(buffer: VimBuffer, at: Cursor, *, inner: bool) -> Range | None:
+    """Sentence: bounded by terminator chars (``.``, ``!``, ``?``).
+
+    Only operates on the cursor's line; multi-line sentences are
+    deliberately out of scope for wave-1 (vim's real behavior tracks
+    paragraph boundaries which adds complexity).
+    """
+
+    line = buffer.line(at.row) if at.row < buffer.line_count else ""
+    if not line:
+        return None
+    col = max(0, min(at.col, len(line) - 1))
+    start = col
+    while start > 0 and line[start - 1] not in _SENTENCE_TERMINATORS:
+        start -= 1
+    while start < len(line) and line[start].isspace():
+        start += 1
+    end = col
+    while end < len(line) and line[end] not in _SENTENCE_TERMINATORS:
+        end += 1
+    if end < len(line) and not inner:
+        end += 1  # include the terminator on ``a``-mode
+    if not inner:
+        while end < len(line) and line[end].isspace():
+            end += 1
+    if start >= end:
+        return None
+    return Range(start=Cursor(at.row, start), end=Cursor(at.row, end))
+
+
+# ---- Paragraph -------------------------------------------------------------
+
+
+def _paragraph(buffer: VimBuffer, at: Cursor, *, inner: bool) -> Range | None:
+    """Paragraph: contiguous run of non-empty lines.
+
+    ``i`` mode = the non-empty lines themselves;
+    ``a`` mode = extends to include surrounding blank lines.
+    """
+
+    if buffer.line_count == 0:
+        return None
+    if at.row >= buffer.line_count:
+        return None
+    if not buffer.line(at.row).strip():
+        # Cursor on a blank line. ``ap`` covers the blank-line run.
+        if not inner:
+            start = at.row
+            while start > 0 and not buffer.line(start - 1).strip():
+                start -= 1
+            end = at.row
+            while end + 1 < buffer.line_count and not buffer.line(end + 1).strip():
+                end += 1
+            return Range(
+                start=Cursor(start, 0),
+                end=Cursor(end, len(buffer.line(end))),
+            )
+        return None
+
+    start = at.row
+    while start > 0 and buffer.line(start - 1).strip():
+        start -= 1
+    end = at.row
+    while end + 1 < buffer.line_count and buffer.line(end + 1).strip():
+        end += 1
+
+    if not inner:
+        # Extend to include trailing blank lines.
+        while end + 1 < buffer.line_count and not buffer.line(end + 1).strip():
+            end += 1
+
+    return Range(
+        start=Cursor(start, 0),
+        end=Cursor(end, len(buffer.line(end))),
+    )
+
+
+# ---- Quoted ----------------------------------------------------------------
+
+
+def _quoted(
+    buffer: VimBuffer, at: Cursor, *, quote: str, inner: bool
+) -> Range | None:
+    """``i"``: text between matching quotes on the same line.
+
+    Multi-line quote pairs are out of scope (rare in practice; ``vim``
+    itself only tracks single-line quote pairs).
+    """
+
+    line = buffer.line(at.row) if at.row < buffer.line_count else ""
+    if not line:
+        return None
+
+    # Walk the line and find every quote position; pick the pair that
+    # brackets the cursor.
+    positions = [i for i, ch in enumerate(line) if ch == quote]
+    if len(positions) < 2:
+        return None
+    pair: tuple[int, int] | None = None
+    # Walk pairs (0,1), (2,3), … — vim's "alternating" pair logic. The
+    # cursor must lie *between* the two indices (inclusive).
+    for i in range(0, len(positions) - 1, 2):
+        left = positions[i]
+        right = positions[i + 1]
+        if left <= at.col <= right:
+            pair = (left, right)
+            break
+    if pair is None:
+        return None
+    left, right = pair
+    if inner:
+        return Range(
+            start=Cursor(at.row, left + 1),
+            end=Cursor(at.row, right),
+        )
+    return Range(start=Cursor(at.row, left), end=Cursor(at.row, right + 1))
+
+
+# ---- Brace -----------------------------------------------------------------
+
+
+def _brace(
+    buffer: VimBuffer,
+    at: Cursor,
+    *,
+    open_ch: str,
+    close_ch: str,
+    inner: bool,
+) -> Range | None:
+    """``i{``: text inside the nearest enclosing brace pair.
+
+    Searches the *current line* for the enclosing pair (multi-line
+    matching is wave-2). Returns ``None`` if the cursor isn't inside
+    a brace pair on this line.
+    """
+
+    line = buffer.line(at.row) if at.row < buffer.line_count else ""
+    if not line:
+        return None
+    # Walk left from the cursor counting depth; locate the unmatched
+    # open brace if any.
+    depth = 0
+    open_idx: int | None = None
+    for i in range(at.col, -1, -1):
+        if i >= len(line):
+            continue
+        ch = line[i]
+        if ch == close_ch and i != at.col:
+            depth += 1
+        elif ch == open_ch:
+            if depth == 0:
+                open_idx = i
+                break
+            depth -= 1
+    if open_idx is None:
+        return None
+    # Now walk right from after the open brace counting depth.
+    depth = 0
+    close_idx: int | None = None
+    for i in range(open_idx + 1, len(line)):
+        ch = line[i]
+        if ch == open_ch:
+            depth += 1
+        elif ch == close_ch:
+            if depth == 0:
+                close_idx = i
+                break
+            depth -= 1
+    if close_idx is None:
+        return None
+    if inner:
+        return Range(
+            start=Cursor(at.row, open_idx + 1),
+            end=Cursor(at.row, close_idx),
+        )
+    return Range(
+        start=Cursor(at.row, open_idx),
+        end=Cursor(at.row, close_idx + 1),
+    )
+
+
+__all__ = ["find_text_object"]

--- a/src/tui/vim_visual.py
+++ b/src/tui/vim_visual.py
@@ -1,0 +1,157 @@
+"""Visual / Visual-Line / Visual-Block selection model.
+
+Phase-4 wave-2 of the ch13 refactor (gap #4, blocker — wave-2 part).
+The single-line ``src/tui/vim.py`` state machine has Insert / Normal
+modes. Wave-2 adds Visual variants — interactive selection that
+operators (``d``, ``c``, ``y``) can apply to as if they were a motion.
+
+Three Visual variants per chapter:
+
+* :data:`VisualMode.CHARACTER` — character-wise; ``v``-toggle in vim
+* :data:`VisualMode.LINE` — line-wise; ``V``-toggle
+* :data:`VisualMode.BLOCK` — column-wise rectangle; ``Ctrl+V``-toggle
+
+Only :class:`VisualSelection` is mutable; the resolved :class:`Range`
+output (via :meth:`as_range`) is immutable and feeds straight into
+:func:`src.tui.vim_operators.apply_operator`.
+
+Wiring into a multi-line widget is wave-2 follow-up; this module is
+the substrate so that the integration is mechanical when the time comes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from .vim_buffer import Cursor, Range, VimBuffer
+
+
+class VisualMode(str, Enum):
+    CHARACTER = "v"
+    LINE = "V"
+    BLOCK = "block"
+
+
+@dataclass
+class VisualSelection:
+    """The active Visual selection — anchor + cursor.
+
+    ``anchor`` stays put; ``cursor`` follows the user's motion. Both are
+    free to be in either order; :meth:`as_range` normalises so callers
+    don't have to.
+    """
+
+    mode: VisualMode
+    anchor: Cursor
+    cursor: Cursor
+
+    def with_cursor(self, cursor: Cursor) -> "VisualSelection":
+        """Return a copy with ``cursor`` updated."""
+
+        return VisualSelection(mode=self.mode, anchor=self.anchor, cursor=cursor)
+
+    def as_range(self, buffer: VimBuffer) -> Range:
+        """Resolve the selection to a half-open ``Range`` over ``buffer``.
+
+        Mode-specific rules:
+
+        * ``CHARACTER`` — start at min(anchor, cursor), end at max+1
+          (character-inclusive in vim → half-open exclusive in our
+          half-open Range model).
+        * ``LINE`` — extend to cover entire lines from min row to max
+          row (inclusive of trailing newline conceptually).
+        * ``BLOCK`` — rectangle from (min row, min col) to (max row,
+          max col). Note that the half-open ``Range`` output cannot
+          fully express a column-rectangle for non-rectangular line
+          lengths; callers that need block-mode operations should use
+          :meth:`block_ranges` instead.
+        """
+
+        if self.mode is VisualMode.LINE:
+            return self._line_range(buffer)
+        # Character (and Block — for the linear approximation):
+        return self._char_range(buffer)
+
+    def block_ranges(self, buffer: VimBuffer) -> list[Range]:
+        """For Visual-Block, return one :class:`Range` per affected line.
+
+        Each per-line range covers the column span ``[min_col, max_col)``.
+        Lines shorter than ``min_col`` get an empty range at their end;
+        operators that act on these are no-ops on those lines (vim's
+        actual behavior).
+        """
+
+        if self.mode is not VisualMode.BLOCK:
+            return [self.as_range(buffer)]
+        first, second = self.anchor, self.cursor
+        row_a, row_b = sorted([first.row, second.row])
+        col_a, col_b = sorted([first.col, second.col])
+        ranges: list[Range] = []
+        for row in range(row_a, row_b + 1):
+            line = buffer.line(row) if row < buffer.line_count else ""
+            start_col = min(col_a, len(line))
+            end_col = min(col_b + 1, len(line))
+            ranges.append(
+                Range(start=Cursor(row, start_col), end=Cursor(row, end_col))
+            )
+        return ranges
+
+    # ---- internals ----
+    def _char_range(self, buffer: VimBuffer) -> Range:
+        # Vim's selection is character-inclusive; our Range is half-open
+        # so we extend the end by one column (or one row when crossing
+        # line boundaries).
+        a = (self.anchor.row, self.anchor.col)
+        b = (self.cursor.row, self.cursor.col)
+        if a <= b:
+            start = self.anchor
+            end_row, end_col = self.cursor.row, self.cursor.col + 1
+        else:
+            start = self.cursor
+            end_row, end_col = self.anchor.row, self.anchor.col + 1
+        line = buffer.line(end_row) if end_row < buffer.line_count else ""
+        end_col = min(end_col, len(line))
+        return Range(start=start, end=Cursor(end_row, end_col))
+
+    def _line_range(self, buffer: VimBuffer) -> Range:
+        row_a, row_b = sorted([self.anchor.row, self.cursor.row])
+        last_line = buffer.line(row_b) if row_b < buffer.line_count else ""
+        return Range(
+            start=Cursor(row_a, 0),
+            end=Cursor(row_b, len(last_line)),
+        )
+
+
+@dataclass
+class VisualState:
+    """Tiny state machine wrapping :class:`VisualSelection`.
+
+    Use::
+
+        state = VisualState()
+        state.start(VisualMode.CHARACTER, anchor=Cursor(0, 0))
+        state.update_cursor(Cursor(0, 5))
+        rng = state.selection.as_range(buffer)  # type: ignore
+        state.exit()  # back to None
+    """
+
+    selection: VisualSelection | None = None
+    last_yanked: list[str] = field(default_factory=list)
+
+    def start(self, mode: VisualMode, *, anchor: Cursor) -> None:
+        self.selection = VisualSelection(mode=mode, anchor=anchor, cursor=anchor)
+
+    def update_cursor(self, cursor: Cursor) -> None:
+        if self.selection is None:
+            return
+        self.selection = self.selection.with_cursor(cursor)
+
+    def exit(self) -> None:
+        self.selection = None
+
+    def is_active(self) -> bool:
+        return self.selection is not None
+
+
+__all__ = ["VisualMode", "VisualSelection", "VisualState"]

--- a/src/tui/widgets/messages/assistant_thinking.py
+++ b/src/tui/widgets/messages/assistant_thinking.py
@@ -1,0 +1,116 @@
+"""Assistant thinking row — distinct from the regular assistant text turn.
+
+Phase-12 of the ch13 refactor (gap #16 sub-item — assistant_thinking).
+Renders ``ThinkingBlock`` content (``src/types/content_blocks.py``) in
+muted italic so the user can distinguish reasoning from the final
+response. Streaming-friendly: ``append_chunk`` mutates in place;
+``finalise`` swaps to a stable rendering once the block closes.
+
+The chapter's ``Messages.tsx`` route surfaces thinking blocks through a
+distinct component; the previous Python TUI dispatched them through
+``AssistantTextMessage`` (or dropped them entirely). This widget is the
+matching component the dispatcher should route ``ThinkingBlock`` /
+``RedactedThinkingBlock`` events to.
+"""
+
+from __future__ import annotations
+
+from rich.console import Group
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.reactive import reactive
+from textual.widgets import Static
+
+from .base import BaseRow, RowHeader
+
+
+class AssistantThinkingMessage(BaseRow):
+    """Live-updating thinking block — italic dim text under a 'thinking' header."""
+
+    DEFAULT_CSS = """
+    AssistantThinkingMessage {
+        height: auto;
+    }
+    AssistantThinkingMessage > Static.-body {
+        padding: 0 1;
+        color: $text-muted;
+        text-style: italic;
+    }
+    AssistantThinkingMessage.-redacted > Static.-body {
+        text-style: italic dim;
+    }
+    """
+
+    streaming_text: reactive[str] = reactive("", layout=True)
+
+    def __init__(self, *, redacted: bool = False) -> None:
+        super().__init__()
+        self._finalised = False
+        self._final_text = ""
+        self._redacted = redacted
+        self._last_body_renderable = None
+        if redacted:
+            self.add_class("-redacted")
+
+    def compose(self) -> ComposeResult:
+        label = "thinking (redacted)" if self._redacted else "thinking"
+        header = RowHeader(Text(label, style="bold dim"), markup=False)
+        header.add_class("-thinking")
+        yield header
+        yield Static(Text(""), markup=False, classes="-body")
+
+    # ---- streaming ----
+    def append_chunk(self, chunk: str) -> None:
+        if self._finalised or not chunk:
+            return
+        self.streaming_text += chunk
+        self._refresh_body()
+
+    def finalise(self, text: str) -> None:
+        self._final_text = text or self.streaming_text
+        self._finalised = True
+        body = self._body_widget()
+        if body is None:
+            return
+        rendered = self._render_for(self._final_text)
+        self._last_body_renderable = rendered
+        body.update(rendered)
+
+    def snapshot(self):
+        text = self._final_text if self._finalised else self.streaming_text
+        if not (text or "").strip():
+            return None
+        header = Text(
+            "thinking (redacted)\n" if self._redacted else "thinking\n",
+            style="bold dim",
+        )
+        body = Text(text, style="italic dim")
+        return Group(header, body)
+
+    # ---- internals ----
+    def _body_widget(self) -> Static | None:
+        try:
+            for static in self.query(Static):
+                if static.has_class("-body"):
+                    return static
+        except Exception:
+            return None
+        return None
+
+    def _refresh_body(self) -> None:
+        body = self._body_widget()
+        if body is None:
+            return
+        rendered = self._render_for(self.streaming_text)
+        self._last_body_renderable = rendered
+        body.update(rendered)
+
+    def _render_for(self, text: str):
+        if not text:
+            return Text("")
+        if self._redacted:
+            return Text(text or "(redacted)", style="italic dim")
+        return Text(text, style="italic")
+
+
+__all__ = ["AssistantThinkingMessage"]

--- a/src/tui/widgets/messages/tool_result.py
+++ b/src/tui/widgets/messages/tool_result.py
@@ -6,15 +6,85 @@ tool execution routes through :class:`AssistantToolUseMessage` instead.
 
 Port of ``typescript/src/components/messages/AssistantToolResultMessage.tsx``
 reduced to the fields the Python agent loop actually emits.
+
+Phase-10 close-out (gap #15): when the rendered text contains paths
+that look like file references, wrap them in OSC 8 hyperlinks so
+modern terminals make them clickable.
 """
 
 from __future__ import annotations
 
+import re
+
+from rich.markup import escape as escape_markup
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.widgets import Static
 
+from src.tui.hyperlinks import is_hyperlink_supported
+
 from .base import BaseRow, RowHeader
+
+
+# Heuristic: match POSIX-ish absolute paths and explicit relative paths
+# (``./foo``, ``../foo``, ``~/foo``). Bare-word relative paths
+# (``src/x.py``) are also matched when they have at least one ``/``
+# separator. Word-boundary anchors prevent eating the trailing
+# punctuation of a sentence (Critic-flagged: ``check src/main.py.``
+# previously captured the trailing period).
+_PATH_BODY_CHARS = r"\w./\-+"  # alnum, underscore, dot, slash, hyphen, plus
+_PATH_RE = re.compile(
+    r"(?:(?<=^)|(?<=[\s\(\[]))"  # start of string OR preceding whitespace/bracket
+    r"(?P<path>"
+    rf"(?:~|\.{{1,2}})?/[{_PATH_BODY_CHARS}]+"  # ``/abs``, ``./rel``, ``~/rel``
+    rf"|[\w.\-]+(?:/[{_PATH_BODY_CHARS}]+)+"  # ``src/x.py`` style w/ ≥1 slash
+    r")"
+    # Trim trailing sentence punctuation. The character class includes
+    # ``.`` (file extensions need it), so ``main.py.`` greedily eats
+    # the period; we trim with a lookbehind that asserts the FINAL
+    # character is not punctuation. Vim-grade fidelity isn't required;
+    # we just need the OSC 8 URL to not include ``,;:!?.`` at the end.
+    r"(?<![.,;:!?])"
+)
+
+
+def _wrap_paths_with_hyperlinks(body: str) -> Text:
+    """Render ``body`` with file-path-looking substrings as OSC 8 links.
+
+    Falls back to plain text on terminals that don't support hyperlinks
+    (per :func:`is_hyperlink_supported`).
+    """
+
+    if not is_hyperlink_supported():
+        return Text(body)
+    parts: list[tuple[str, str | None]] = []
+    last = 0
+    for match in _PATH_RE.finditer(body):
+        if match.start() > last:
+            parts.append((body[last : match.start()], None))
+        path = match.group("path")
+        parts.append((path, path))
+        last = match.end()
+    if last < len(body):
+        parts.append((body[last:], None))
+    if not parts:
+        return Text(body)
+    out = Text()
+    for piece, link in parts:
+        if link is None:
+            out.append(piece)
+        else:
+            # Use Rich's markup syntax — ``Text.from_markup`` is the
+            # idiomatic emit path; we escape the visible portion so a
+            # user-supplied path containing ``[`` doesn't get parsed.
+            href = link if link.startswith(("/", "~", ".")) else link
+            url = (
+                href if href.startswith("file://") else f"file://{href}"
+            )
+            out.append_text(
+                Text.from_markup(f"[link={url}]{escape_markup(piece)}[/link]")
+            )
+    return out
 
 
 class ToolResultRow(BaseRow):
@@ -43,11 +113,21 @@ class ToolResultRow(BaseRow):
 
     def compose(self) -> ComposeResult:
         glyph = "✗" if self._is_error else "✓"
-        header = RowHeader(Text(f"{glyph} {self._summary or self._tool_name}"), markup=False)
+        # Wrap the summary's file paths (if any) in OSC 8 hyperlinks.
+        # Header and body both go through the same heuristic so a file
+        # path that appears in either position is clickable.
+        header_text = _wrap_paths_with_hyperlinks(
+            f"{glyph} {self._summary or self._tool_name}"
+        )
+        header = RowHeader(header_text, markup=False)
         header.add_class("-tool-error" if self._is_error else "-tool-success")
         yield header
         if self._body.strip():
-            yield Static(Text(self._body), markup=False, classes="-body")
+            yield Static(
+                _wrap_paths_with_hyperlinks(self._body),
+                markup=False,
+                classes="-body",
+            )
 
     def snapshot(self) -> Text:
         """Return a Rich :class:`Text` for post-exit scrollback dump."""

--- a/src/tui/widgets/transcript_search.py
+++ b/src/tui/widgets/transcript_search.py
@@ -1,0 +1,265 @@
+"""Inline transcript search — Ctrl+F overlay over :class:`TranscriptView`.
+
+Phase 5 of the ch13 refactor (gap #2) closes the gap between the prior
+no-search-at-all state and the chapter's inline match-highlighting:
+
+* :class:`TranscriptSearch` is a dismissable overlay (single-line Input
+  + match-list ``OptionList``) that searches the transcript content
+  via row snapshots.
+* Match navigation is *jump-to-row* rather than chapter-style cell
+  highlighting — Python's TUI runs in inline mode (gap analysis §1
+  read #2) and does not have cell-level access. Jumping to the row
+  containing a match is the architecturally-fitting alternative.
+* The widget is host-agnostic: it accepts a :class:`TranscriptView`
+  and walks its ``_mounted_rows`` snapshot, so the legacy
+  :class:`Transcript` (subclass of TranscriptView) also works.
+
+Plan §6 G5 acceptance criterion: ``Ctrl+F`` opens; query types fire
+match navigation; ``n`` / ``N`` advance / retreat; ``Esc`` dismisses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from rich.text import Text
+from textual import events
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.message import Message
+from textual.reactive import reactive
+from textual.screen import ModalScreen
+from textual.widgets import Input, OptionList, Static
+from textual.widgets.option_list import Option
+
+
+@dataclass
+class TranscriptMatchSelected(Message):
+    """Posted when the user activates a match. ``row_index`` is offset
+    into ``TranscriptView._mounted_rows``."""
+
+    row_index: int
+    query: str
+
+
+def _row_text(row) -> str:
+    """Extract searchable text from a transcript row.
+
+    Each transcript row implements a ``snapshot()`` method (used by the
+    exit-time scrollback dump). We piggyback on it so the search index
+    sees exactly what the user sees rendered.
+    """
+
+    snap = getattr(row, "snapshot", None)
+    if snap is None:
+        # Fall back to the row's text representation; cheaper and works
+        # for any widget that has a meaningful ``__str__`` (e.g. the
+        # default :class:`SystemMessage`).
+        return str(row).strip()
+    try:
+        piece = snap()
+    except Exception:
+        return ""
+    return _renderable_text(piece)
+
+
+def _renderable_text(piece) -> str:
+    """Best-effort plain-text extraction from a Rich renderable / tuple."""
+
+    if piece is None:
+        return ""
+    if isinstance(piece, tuple):
+        return "\n".join(_renderable_text(p) for p in piece)
+    if isinstance(piece, Text):
+        return piece.plain
+    if isinstance(piece, str):
+        return piece
+    # Many Rich renderables expose a ``plain`` attribute or a sensible
+    # str-coercion. Fall back via str() so unknown types still hit the
+    # search index without the caller having to register them.
+    plain = getattr(piece, "plain", None)
+    if isinstance(plain, str):
+        return plain
+    try:
+        return str(piece)
+    except Exception:
+        return ""
+
+
+def find_matches(rows, query: str) -> list[int]:
+    """Return the indices in ``rows`` whose text contains ``query`` (case-insensitive).
+
+    Pure helper — no UI state, no DOM. Used by the overlay AND by tests.
+    """
+
+    if not query:
+        return []
+    needle = query.lower()
+    out: list[int] = []
+    for i, row in enumerate(rows):
+        text = _row_text(row)
+        if needle in text.lower():
+            out.append(i)
+    return out
+
+
+class TranscriptSearch(ModalScreen[int | None]):
+    """Modal overlay for searching the transcript by substring.
+
+    Returns the row index the user accepted (via Enter) or ``None`` on
+    Esc. Designed to be pushed onto the screen stack via
+    ``app.push_screen(TranscriptSearch(transcript))``.
+    """
+
+    BINDINGS = [
+        ("escape", "dismiss_modal", "Close"),
+        ("ctrl+n", "next_match", "Next"),
+        ("ctrl+p", "prev_match", "Prev"),
+    ]
+
+    DEFAULT_CSS = """
+    TranscriptSearch {
+        align: center middle;
+    }
+    TranscriptSearch > Vertical {
+        width: 80%;
+        max-width: 80;
+        max-height: 60%;
+        border: round $primary;
+        background: $surface;
+        padding: 1 1;
+    }
+    TranscriptSearch Static.-status {
+        color: $text-muted;
+        padding: 0 0 1 0;
+    }
+    TranscriptSearch Input {
+        border: round $primary-darken-2;
+    }
+    TranscriptSearch OptionList {
+        max-height: 12;
+        margin-top: 1;
+    }
+    """
+
+    search_query: reactive[str] = reactive("")
+    match_index: reactive[int] = reactive(0)
+
+    def __init__(self, transcript) -> None:
+        super().__init__()
+        self._transcript = transcript
+        self._matches: list[int] = []
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Static(
+                Text("Search transcript — type to filter, Enter to jump"),
+                classes="-status",
+                markup=False,
+            )
+            yield Input(placeholder="search…", id="search-input")
+            yield OptionList(id="match-list")
+
+    def on_mount(self) -> None:
+        try:
+            self.query_one("#search-input", Input).focus()
+        except Exception:
+            pass
+
+    # ---- search input events ----
+    def on_input_changed(self, event: Input.Changed) -> None:
+        self.search_query = event.value or ""
+        self._refresh_matches()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if not self._matches:
+            return
+        self.dismiss(self._matches[self.match_index])
+
+    # ---- option list events ----
+    def on_option_list_option_selected(
+        self, event: OptionList.OptionSelected
+    ) -> None:
+        if event.option.id is None:
+            return
+        try:
+            row_idx = int(event.option.id)
+        except ValueError:
+            return
+        self.dismiss(row_idx)
+
+    # ---- actions ----
+    def action_dismiss_modal(self) -> None:
+        self.dismiss(None)
+
+    def action_next_match(self) -> None:
+        if not self._matches:
+            return
+        self.match_index = (self.match_index + 1) % len(self._matches)
+        self._sync_highlight()
+
+    def action_prev_match(self) -> None:
+        if not self._matches:
+            return
+        self.match_index = (self.match_index - 1) % len(self._matches)
+        self._sync_highlight()
+
+    # ---- internals ----
+    def _refresh_matches(self) -> None:
+        rows = list(getattr(self._transcript, "_mounted_rows", []) or [])
+        self._matches = find_matches(rows, self.search_query)
+        self.match_index = 0
+        try:
+            options = self.query_one("#match-list", OptionList)
+        except Exception:
+            return
+        options.clear_options()
+        for idx in self._matches[:50]:  # cap UI rows
+            row = rows[idx] if idx < len(rows) else None
+            label_text = _row_text(row) if row is not None else ""
+            # Truncate per-row preview so the popup stays readable.
+            if len(label_text) > 80:
+                label_text = label_text[:77] + "…"
+            label = label_text or f"row {idx}"
+            options.add_option(Option(label, id=str(idx)))
+        if self._matches:
+            options.highlighted = 0
+        self._update_status()
+
+    def _sync_highlight(self) -> None:
+        try:
+            options = self.query_one("#match-list", OptionList)
+        except Exception:
+            return
+        options.highlighted = self.match_index
+        self._update_status()
+
+    def _update_status(self) -> None:
+        try:
+            status = self.query_one(".-status", Static)
+        except Exception:
+            return
+        if not self.search_query:
+            status.update(
+                Text("Search transcript — type to filter, Enter to jump")
+            )
+            return
+        if not self._matches:
+            status.update(
+                Text(f"no matches for '{self.search_query}'", style="dim")
+            )
+            return
+        status.update(
+            Text(
+                f"{self.match_index + 1} of {len(self._matches)} matches "
+                f"(Ctrl+N / Ctrl+P navigate, Enter to jump)",
+                style="dim",
+            )
+        )
+
+
+__all__ = [
+    "TranscriptMatchSelected",
+    "TranscriptSearch",
+    "find_matches",
+]

--- a/src/tui/widgets/transcript_view.py
+++ b/src/tui/widgets/transcript_view.py
@@ -31,6 +31,7 @@ from .messages import (
     ToolResultRow,
     UserTextMessage,
 )
+from .messages.assistant_thinking import AssistantThinkingMessage
 
 
 class TranscriptView(VerticalScroll):
@@ -91,10 +92,61 @@ class TranscriptView(VerticalScroll):
     def append_assistant_chunk(self, chunk: str) -> None:
         if not chunk:
             return
+        # Symmetric guard with ``append_thinking_chunk`` (Critic-flagged):
+        # if the active row is a thinking widget, retire it before
+        # mounting an assistant text row. Otherwise assistant chunks
+        # would be appended into the thinking row's body — visible bug
+        # the moment Phase-12 dispatch wiring lands.
+        active = self._active_assistant
+        if active is not None and not isinstance(active, AssistantTextMessage):
+            self._retire_active_assistant()
         if self._active_assistant is None:
             self._active_assistant = AssistantTextMessage()
             self.mount(self._active_assistant)
         self._active_assistant.append_chunk(chunk)
+        self._scroll_end()
+
+    # Phase-12 (gap #16 sub-item): widget-and-helper shell for
+    # thinking-block content. The :class:`AssistantThinkingMessage`
+    # widget exists; the methods below mount and stream into it
+    # correctly. **Dispatch wiring is deferred** — the agent loop's
+    # ``on_text_chunk`` callback only emits user-visible text, not
+    # ``ThinkingBlock`` content blocks. Adding ``on_thinking_chunk`` is
+    # an agent-loop change that lives in a separate ticket so the loop
+    # API change can be reviewed in isolation. Until then, callers
+    # invoke these helpers directly (a few tests do; no production
+    # caller does), and the symmetric guard above keeps the transition
+    # logic correct ahead of the wiring.
+    def append_thinking_chunk(
+        self, chunk: str, *, redacted: bool = False
+    ) -> None:
+        if not chunk:
+            return
+        # We re-use ``_active_assistant`` for thinking too; the
+        # transition to a real assistant text turn calls
+        # :meth:`_retire_active_assistant` which finalises whichever
+        # row is active.
+        active = self._active_assistant
+        if not isinstance(active, AssistantThinkingMessage) or (
+            active.has_class("-redacted") != redacted
+        ):
+            self._retire_active_assistant()
+            row = AssistantThinkingMessage(redacted=redacted)
+            self._active_assistant = row  # type: ignore[assignment]
+            self.mount(row)
+            active = row
+        active.append_chunk(chunk)
+        self._scroll_end()
+
+    def append_thinking(self, text: str, *, redacted: bool = False) -> None:
+        active = self._active_assistant
+        if isinstance(active, AssistantThinkingMessage):
+            active.finalise(text)
+            self._active_assistant = None
+        elif (text or "").strip():
+            row = AssistantThinkingMessage(redacted=redacted)
+            self.mount(row)
+            row.finalise(text)
         self._scroll_end()
 
     def append_assistant(self, text: str) -> None:

--- a/tests/parity/test_output_styles_parity.py
+++ b/tests/parity/test_output_styles_parity.py
@@ -1,0 +1,76 @@
+"""Parity test: ``resolve_output_style`` produces byte-identical prompts
+for the built-in styles before and after the Phase-9 frontmatter rewrite.
+
+Phase-9 of the ch13 refactor changed how output styles are loaded —
+adding YAML frontmatter parsing and a default search-path. Built-in
+styles (``default``, ``explanatory``) are preserved; this test pins
+that the prompt strings the rest of the system reads are byte-for-byte
+unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.outputStyles.loader import resolve_output_style
+from src.outputStyles.styles import BUILTIN_OUTPUT_STYLES
+
+
+# Snapshot of the prompt text every built-in carries. Update by hand
+# when intentionally changing a built-in; CI failure here means an
+# unintentional drift.
+_EXPECTED_PROMPTS = {
+    "default": (
+        "Respond clearly, concisely, and focus on the user's "
+        "requested engineering task."
+    ),
+    "explanatory": (
+        "Respond with concise implementation details plus short educational "
+        "notes when they improve understanding."
+    ),
+}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Make sure auto-discovery of ``~/.claude/outputStyles`` doesn't
+    pick up the dev's local config and contaminate the parity check."""
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    yield
+
+
+@pytest.mark.parametrize("name", ["default", "explanatory"])
+def test_builtin_prompt_is_byte_identical(name: str) -> None:
+    style = resolve_output_style(name)
+    assert style.name == name
+    assert style.prompt == _EXPECTED_PROMPTS[name]
+
+
+def test_unknown_name_falls_back_to_default() -> None:
+    style = resolve_output_style("does-not-exist")
+    assert style.name == "default"
+    assert style.prompt == _EXPECTED_PROMPTS["default"]
+
+
+def test_builtins_dict_unchanged() -> None:
+    """The ``BUILTIN_OUTPUT_STYLES`` constant is directly imported by
+    callers; verify the keys haven't drifted."""
+
+    assert set(BUILTIN_OUTPUT_STYLES) == {"default", "explanatory"}
+
+
+def test_resolve_with_explicit_dir_does_not_leak_user_config(
+    tmp_path: Path,
+) -> None:
+    """When ``search_dir`` is explicit, defaults stand in for missing
+    names and built-ins win their slot — even if the user's HOME has
+    a colliding file (covered above by the ``_isolate_home`` fixture)."""
+
+    # Empty explicit dir → built-ins are still resolvable.
+    target = tmp_path / "explicit_empty"
+    target.mkdir()
+    style = resolve_output_style("default", search_dir=target)
+    assert style.prompt == _EXPECTED_PROMPTS["default"]

--- a/tests/test_output_styles_frontmatter.py
+++ b/tests/test_output_styles_frontmatter.py
@@ -1,0 +1,149 @@
+"""Tests for Phase-9 output-styles frontmatter + default-path loader."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.outputStyles.loader import (
+    load_output_styles_dir,
+    resolve_output_style,
+)
+from src.outputStyles.styles import BUILTIN_OUTPUT_STYLES
+
+
+def test_no_directory_returns_builtins(tmp_path: Path) -> None:
+    target = tmp_path / "missing"
+    styles = load_output_styles_dir(target)
+    assert set(styles) == set(BUILTIN_OUTPUT_STYLES)
+
+
+def test_no_frontmatter_uses_filename_as_name(tmp_path: Path) -> None:
+    """Back-compat: legacy files without YAML still load via the file stem."""
+
+    target = tmp_path / "outputStyles"
+    target.mkdir()
+    (target / "concise.md").write_text("Be terse.")
+    styles = load_output_styles_dir(target)
+    assert "concise" in styles
+    assert styles["concise"].prompt == "Be terse."
+
+
+def test_frontmatter_overrides_filename(tmp_path: Path) -> None:
+    """``name`` from frontmatter takes precedence over the file stem."""
+
+    target = tmp_path / "outputStyles"
+    target.mkdir()
+    (target / "x.md").write_text(
+        "---\nname: my-style\n---\nThe prompt body.\n"
+    )
+    styles = load_output_styles_dir(target)
+    assert "my-style" in styles
+    assert "x" not in styles  # filename was overridden
+    assert styles["my-style"].prompt == "The prompt body."
+
+
+def test_description_and_model_propagate(tmp_path: Path) -> None:
+    target = tmp_path / "outputStyles"
+    target.mkdir()
+    (target / "explainy.md").write_text(
+        "---\n"
+        "name: explainy\n"
+        "description: Verbose explanations.\n"
+        "model: glm-4.6\n"
+        "---\n"
+        "Explain everything.\n"
+    )
+    styles = load_output_styles_dir(target)
+    style = styles["explainy"]
+    assert style.description == "Verbose explanations."
+    assert style.model == "glm-4.6"
+    assert style.prompt == "Explain everything."
+
+
+def test_frontmatter_prompt_field_overrides_body(tmp_path: Path) -> None:
+    """``prompt`` in frontmatter wins over body — letting users keep
+    documentation in the body without shipping it to the model."""
+
+    target = tmp_path / "outputStyles"
+    target.mkdir()
+    (target / "x.md").write_text(
+        "---\n"
+        "name: x\n"
+        "prompt: Real prompt.\n"
+        "---\n"
+        "# Documentation\n\nThis section is not sent to the model.\n"
+    )
+    styles = load_output_styles_dir(target)
+    assert styles["x"].prompt == "Real prompt."
+
+
+def test_user_file_overrides_builtin(tmp_path: Path) -> None:
+    target = tmp_path / "outputStyles"
+    target.mkdir()
+    (target / "default.md").write_text(
+        "---\nname: default\n---\nUser-customized default.\n"
+    )
+    styles = load_output_styles_dir(target)
+    # User wins.
+    assert styles["default"].prompt == "User-customized default."
+
+
+def test_empty_body_is_skipped(tmp_path: Path) -> None:
+    target = tmp_path / "outputStyles"
+    target.mkdir()
+    (target / "blank.md").write_text("---\nname: blank\n---\n\n")
+    styles = load_output_styles_dir(target)
+    assert "blank" not in styles
+
+
+def test_resolve_uses_default_dir_when_search_dir_is_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``resolve_output_style`` auto-discovers ``~/.claude/outputStyles/``
+    when ``search_dir`` is ``None`` (Phase-9 behavior)."""
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    target = tmp_path / ".claude" / "outputStyles"
+    target.mkdir(parents=True)
+    (target / "auto.md").write_text("---\nname: auto\n---\nAuto-discovered.\n")
+    style = resolve_output_style("auto", search_dir=None)
+    assert style.prompt == "Auto-discovered."
+
+
+def test_resolve_falls_back_to_default_for_unknown_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))  # no user dir
+    style = resolve_output_style("does-not-exist")
+    assert style.name == "default"
+
+
+def test_resolve_explicit_dir_wins(tmp_path: Path) -> None:
+    target = tmp_path / "explicit"
+    target.mkdir()
+    (target / "custom.md").write_text(
+        "---\nname: custom\n---\nFrom explicit dir.\n"
+    )
+    style = resolve_output_style("custom", search_dir=target)
+    assert style.prompt == "From explicit dir."
+
+
+def test_malformed_yaml_falls_back_to_filename_and_body(
+    tmp_path: Path,
+) -> None:
+    """Malformed frontmatter is treated as no-frontmatter — the body
+    becomes the prompt and the filename becomes the name."""
+
+    target = tmp_path / "outputStyles"
+    target.mkdir()
+    # The frontmatter parser returns body == raw when it can't find a
+    # closing fence; verify the file still loads.
+    (target / "broken.md").write_text(
+        "---\nname: broken\n# missing closing fence\nbody content here\n"
+    )
+    styles = load_output_styles_dir(target)
+    # The whole content is treated as the body since the fence isn't closed.
+    assert "broken" in styles

--- a/tests/tui/test_assistant_thinking.py
+++ b/tests/tui/test_assistant_thinking.py
@@ -1,0 +1,78 @@
+"""Tests for Phase-12 assistant-thinking widget (gap #16 sub-item)."""
+
+from __future__ import annotations
+
+import pytest
+from rich.text import Text
+from textual.app import App, ComposeResult
+
+from src.tui.widgets.messages.assistant_thinking import AssistantThinkingMessage
+
+
+class _Harness(App):
+    def __init__(self, widget) -> None:
+        super().__init__()
+        self._widget = widget
+
+    def compose(self) -> ComposeResult:
+        yield self._widget
+
+
+@pytest.mark.asyncio
+async def test_streaming_chunks_accumulate() -> None:
+    row = AssistantThinkingMessage()
+    async with _Harness(row).run_test() as pilot:
+        row.append_chunk("Let me think")
+        row.append_chunk(" about this.")
+        await pilot.pause()
+        assert row.streaming_text == "Let me think about this."
+
+
+@pytest.mark.asyncio
+async def test_post_finalise_chunks_are_discarded() -> None:
+    row = AssistantThinkingMessage()
+    async with _Harness(row).run_test() as pilot:
+        row.append_chunk("preliminary thought")
+        row.finalise("final thought")
+        row.append_chunk(" extra (should be ignored)")
+        await pilot.pause()
+        assert row._final_text == "final thought"
+
+
+@pytest.mark.asyncio
+async def test_redacted_variant_marks_class() -> None:
+    row = AssistantThinkingMessage(redacted=True)
+    async with _Harness(row).run_test() as pilot:
+        await pilot.pause()
+        assert row.has_class("-redacted")
+
+
+@pytest.mark.asyncio
+async def test_snapshot_returns_renderable_when_present() -> None:
+    row = AssistantThinkingMessage()
+    async with _Harness(row).run_test() as pilot:
+        row.append_chunk("considered options")
+        row.finalise("considered options")
+        await pilot.pause()
+        snap = row.snapshot()
+        assert snap is not None
+
+
+@pytest.mark.asyncio
+async def test_snapshot_returns_none_when_empty() -> None:
+    row = AssistantThinkingMessage()
+    async with _Harness(row).run_test() as pilot:
+        await pilot.pause()
+        assert row.snapshot() is None
+
+
+@pytest.mark.asyncio
+async def test_finalise_with_empty_text_uses_stream() -> None:
+    """If finalise is called without text, the streamed content stands in."""
+
+    row = AssistantThinkingMessage()
+    async with _Harness(row).run_test() as pilot:
+        row.append_chunk("partial only")
+        row.finalise("")
+        await pilot.pause()
+        assert row._final_text == "partial only"

--- a/tests/tui/test_declared_cursor.py
+++ b/tests/tui/test_declared_cursor.py
@@ -1,0 +1,214 @@
+"""Tests for Phase-6 IME declared-cursor module."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tui.declared_cursor import (
+    CursorDeclaration,
+    DeclaredCursor,
+    flush_pending,
+    get_default_declared_cursor,
+    publish_cursor_position,
+    reset_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+@pytest.fixture
+def cursor() -> DeclaredCursor:
+    """Yield a fresh ``DeclaredCursor`` with a captured-byte writer."""
+
+    c = DeclaredCursor()
+    return c
+
+
+def _capture_writer(buf: list[str]):
+    def write(text: str) -> None:
+        buf.append(text)
+
+    return write
+
+
+# ------------------------------------------------------------------
+# Declarations
+# ------------------------------------------------------------------
+
+
+def test_declare_returns_unregister(cursor: DeclaredCursor) -> None:
+    unreg = cursor.declare("owner", 0, 0)
+    assert callable(unreg)
+    assert cursor.active() is not None
+    unreg()
+    assert cursor.active() is None
+
+
+def test_declare_negative_rejected(cursor: DeclaredCursor) -> None:
+    with pytest.raises(ValueError):
+        cursor.declare("owner", -1, 0)
+    with pytest.raises(ValueError):
+        cursor.declare("owner", 0, -1)
+
+
+def test_most_recent_declaration_wins(cursor: DeclaredCursor) -> None:
+    cursor.declare("a", 5, 5)
+    cursor.declare("b", 10, 10)
+    active = cursor.active()
+    assert active is not None
+    assert active.owner == "b"
+    assert active.row == 10
+
+
+def test_unregister_uncovers_previous(cursor: DeclaredCursor) -> None:
+    cursor.declare("a", 5, 5)
+    unreg_b = cursor.declare("b", 10, 10)
+    unreg_b()
+    active = cursor.active()
+    assert active is not None
+    assert active.owner == "a"
+
+
+def test_unregister_idempotent(cursor: DeclaredCursor) -> None:
+    unreg = cursor.declare("a", 1, 1)
+    unreg()
+    unreg()  # No-op; must not raise.
+
+
+def test_re_declaring_same_owner_replaces_in_place(
+    cursor: DeclaredCursor,
+) -> None:
+    cursor.declare("owner", 0, 0)
+    cursor.declare("owner", 5, 5)
+    active = cursor.active()
+    assert active is not None
+    assert active.row == 5
+    assert active.col == 5
+
+
+# ------------------------------------------------------------------
+# Emit
+# ------------------------------------------------------------------
+
+
+def test_flush_emits_csi_sequence(
+    cursor: DeclaredCursor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("CLAWCODEX_DISABLE_DECLARED_CURSOR", raising=False)
+    buf: list[str] = []
+    cursor.set_writer(_capture_writer(buf))
+    cursor.declare("owner", 4, 7)
+    assert cursor.flush_pending() is True
+    # CSI sequences are 1-indexed.
+    assert buf == ["\x1b[5;8H"]
+
+
+def test_flush_returns_false_when_no_pending(
+    cursor: DeclaredCursor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("CLAWCODEX_DISABLE_DECLARED_CURSOR", raising=False)
+    buf: list[str] = []
+    cursor.set_writer(_capture_writer(buf))
+    assert cursor.flush_pending() is False
+    assert buf == []
+
+
+def test_flush_idempotent_until_next_declaration(
+    cursor: DeclaredCursor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("CLAWCODEX_DISABLE_DECLARED_CURSOR", raising=False)
+    buf: list[str] = []
+    cursor.set_writer(_capture_writer(buf))
+    cursor.declare("o", 1, 1)
+    assert cursor.flush_pending() is True
+    assert cursor.flush_pending() is False  # second call: no-op
+
+
+def test_unregister_re_arms_pending_emit(
+    cursor: DeclaredCursor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unregistering should mark pending so the next flush re-emits the
+    new active declaration."""
+
+    monkeypatch.delenv("CLAWCODEX_DISABLE_DECLARED_CURSOR", raising=False)
+    buf: list[str] = []
+    cursor.set_writer(_capture_writer(buf))
+    cursor.declare("a", 1, 1)
+    unreg_b = cursor.declare("b", 5, 5)
+    cursor.flush_pending()
+    buf.clear()
+    unreg_b()
+    cursor.flush_pending()
+    # After unregistering b, a is now active again — flush emits a's pos.
+    assert buf == ["\x1b[2;2H"]
+
+
+def test_disable_env_kills_emission(
+    cursor: DeclaredCursor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CLAWCODEX_DISABLE_DECLARED_CURSOR", "1")
+    buf: list[str] = []
+    cursor.set_writer(_capture_writer(buf))
+    cursor.declare("o", 1, 1)
+    assert cursor.flush_pending() is False
+    assert buf == []
+
+
+def test_writer_exception_swallowed(
+    cursor: DeclaredCursor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A writer that raises shouldn't crash the caller — non-interactive
+    harnesses rely on this."""
+
+    monkeypatch.delenv("CLAWCODEX_DISABLE_DECLARED_CURSOR", raising=False)
+
+    def boom(_text: str) -> None:
+        raise OSError("simulated stdout failure")
+
+    cursor.set_writer(boom)
+    cursor.declare("o", 1, 1)
+    # Returns False because the write failed; doesn't propagate.
+    assert cursor.flush_pending() is False
+
+
+# ------------------------------------------------------------------
+# Singleton
+# ------------------------------------------------------------------
+
+
+def test_singleton_persists_across_calls() -> None:
+    a = get_default_declared_cursor()
+    b = get_default_declared_cursor()
+    assert a is b
+
+
+def test_publish_cursor_position_uses_singleton() -> None:
+    publish_cursor_position("o", 2, 3)
+    active = get_default_declared_cursor().active()
+    assert active is not None
+    assert active.row == 2
+    assert active.col == 3
+
+
+def test_flush_pending_helper_uses_singleton(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CLAWCODEX_DISABLE_DECLARED_CURSOR", raising=False)
+    buf: list[str] = []
+    get_default_declared_cursor().set_writer(_capture_writer(buf))
+    publish_cursor_position("o", 0, 0)
+    assert flush_pending() is True
+    assert buf == ["\x1b[1;1H"]
+
+
+def test_clear_removes_all() -> None:
+    cursor = get_default_declared_cursor()
+    cursor.declare("a", 1, 1)
+    cursor.declare("b", 2, 2)
+    cursor.clear()
+    assert cursor.active() is None

--- a/tests/tui/test_frame_metrics.py
+++ b/tests/tui/test_frame_metrics.py
@@ -1,0 +1,182 @@
+"""Tests for Phase-11 FrameEvent observability."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from src.tui.frame_metrics import (
+    FRAME_DEBUG_ENV,
+    FrameEvent,
+    TimedPhase,
+    clear_observers_for_tests,
+    emit_frame_event,
+    is_enabled,
+    register_frame_observer,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_observers():
+    clear_observers_for_tests()
+    yield
+    clear_observers_for_tests()
+
+
+# ------------------------------------------------------------------
+# is_enabled
+# ------------------------------------------------------------------
+
+
+def test_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(FRAME_DEBUG_ENV, raising=False)
+    assert is_enabled() is False
+
+
+def test_enabled_when_env_var_is_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(FRAME_DEBUG_ENV, "1")
+    assert is_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "true", "yes"])
+def test_only_value_one_enables(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv(FRAME_DEBUG_ENV, value)
+    assert is_enabled() is False
+
+
+# ------------------------------------------------------------------
+# emit_frame_event
+# ------------------------------------------------------------------
+
+
+def test_disabled_emit_does_not_invoke_observers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(FRAME_DEBUG_ENV, raising=False)
+    fired: list[FrameEvent] = []
+    register_frame_observer(fired.append)
+    emit_frame_event(FrameEvent(duration_ms=10.0))
+    assert fired == []
+
+
+def test_enabled_emit_notifies_all_observers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(FRAME_DEBUG_ENV, "1")
+    received: list[FrameEvent] = []
+    register_frame_observer(received.append)
+
+    event = FrameEvent(
+        duration_ms=12.5, phases={"render": 5.2, "diff": 1.1}
+    )
+    emit_frame_event(event)
+    assert received == [event]
+
+
+def test_multiple_observers_all_fire(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(FRAME_DEBUG_ENV, "1")
+    received_a: list[FrameEvent] = []
+    received_b: list[FrameEvent] = []
+    register_frame_observer(received_a.append)
+    register_frame_observer(received_b.append)
+    emit_frame_event(FrameEvent(duration_ms=1.0))
+    assert len(received_a) == 1
+    assert len(received_b) == 1
+
+
+# ------------------------------------------------------------------
+# unregister
+# ------------------------------------------------------------------
+
+
+def test_unregister_stops_notifications(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(FRAME_DEBUG_ENV, "1")
+    received: list[FrameEvent] = []
+    unreg = register_frame_observer(received.append)
+    emit_frame_event(FrameEvent(duration_ms=1.0))
+    assert len(received) == 1
+    unreg()
+    emit_frame_event(FrameEvent(duration_ms=2.0))
+    assert len(received) == 1
+
+
+def test_unregister_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(FRAME_DEBUG_ENV, "1")
+    unreg = register_frame_observer(lambda e: None)
+    unreg()
+    unreg()  # No-op; must not raise.
+
+
+# ------------------------------------------------------------------
+# TimedPhase
+# ------------------------------------------------------------------
+
+
+def test_timed_phase_records_into_dict() -> None:
+    phases: dict[str, float] = {}
+    with TimedPhase(phases, "render"):
+        time.sleep(0.001)
+    assert "render" in phases
+    assert phases["render"] >= 0  # ms
+
+
+def test_timed_phase_accumulates_when_called_twice() -> None:
+    phases: dict[str, float] = {}
+    with TimedPhase(phases, "render"):
+        time.sleep(0.001)
+    first = phases["render"]
+    with TimedPhase(phases, "render"):
+        time.sleep(0.001)
+    assert phases["render"] >= first  # accumulated, not overwritten
+
+
+def test_timed_phase_records_even_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The context manager itself is observability-agnostic — it just
+    measures. Whether the FrameEvent fires is decided by the caller."""
+
+    monkeypatch.delenv(FRAME_DEBUG_ENV, raising=False)
+    phases: dict[str, float] = {}
+    with TimedPhase(phases, "x"):
+        pass
+    assert "x" in phases
+
+
+# ------------------------------------------------------------------
+# Frame event shape
+# ------------------------------------------------------------------
+
+
+def test_frame_event_defaults_are_sensible() -> None:
+    event = FrameEvent(duration_ms=10.0)
+    assert event.phases == {}
+    assert event.component_attribution is None
+    assert event.yoga_visited == 0
+    assert event.yoga_measured == 0
+    assert event.flickers == ()
+
+
+def test_frame_event_is_frozen() -> None:
+    event = FrameEvent(duration_ms=10.0)
+    with pytest.raises(Exception):
+        event.duration_ms = 20.0  # type: ignore[misc]
+
+
+def test_observer_exceptions_propagate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Documented behavior: a misbehaving observer is the caller's
+    problem; we don't swallow."""
+
+    monkeypatch.setenv(FRAME_DEBUG_ENV, "1")
+
+    def bad_observer(_event: FrameEvent) -> None:
+        raise RuntimeError("simulated observer bug")
+
+    register_frame_observer(bad_observer)
+    with pytest.raises(RuntimeError):
+        emit_frame_event(FrameEvent(duration_ms=1.0))

--- a/tests/tui/test_hyperlinks.py
+++ b/tests/tui/test_hyperlinks.py
@@ -1,0 +1,189 @@
+"""Tests for Phase-10 OSC 8 hyperlink capability detection."""
+
+from __future__ import annotations
+
+import pytest
+from rich.console import Console
+
+from src.tui.hyperlinks import (
+    format_file_path,
+    format_link,
+    is_hyperlink_supported,
+    raw_osc8,
+)
+
+
+def _patch_term_only(monkeypatch: pytest.MonkeyPatch, term_value: str) -> None:
+    """Strip every capability env var, set TERM only — for negative cases."""
+
+    for env in (
+        "FORCE_HYPERLINK",
+        "TERM_PROGRAM",
+        "VTE_VERSION",
+        "TERM",
+    ):
+        monkeypatch.delenv(env, raising=False)
+    monkeypatch.setenv("TERM", term_value)
+
+
+# ------------------------------------------------------------------
+# is_hyperlink_supported
+# ------------------------------------------------------------------
+
+
+def test_force_hyperlink_env_var_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FORCE_HYPERLINK", "1")
+    # Even with a non-terminal console, FORCE_HYPERLINK wins.
+    console = Console(legacy_windows=True, force_terminal=False)
+    assert is_hyperlink_supported(console)
+
+
+@pytest.mark.parametrize(
+    "term_program",
+    ["iTerm.app", "WezTerm", "vscode", "kitty", "ghostty"],
+)
+def test_known_term_programs_supported(
+    monkeypatch: pytest.MonkeyPatch, term_program: str
+) -> None:
+    monkeypatch.setenv("TERM_PROGRAM", term_program)
+    monkeypatch.delenv("FORCE_HYPERLINK", raising=False)
+    assert is_hyperlink_supported()
+
+
+def test_vte_version_5000_or_higher_supported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for env in ("FORCE_HYPERLINK", "TERM_PROGRAM"):
+        monkeypatch.delenv(env, raising=False)
+    monkeypatch.setenv("VTE_VERSION", "5500")
+    assert is_hyperlink_supported()
+
+
+def test_vte_version_below_5000_does_not_force_support(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A low VTE version doesn't auto-enable; the rest of the matrix decides."""
+
+    for env in ("FORCE_HYPERLINK", "TERM_PROGRAM"):
+        monkeypatch.delenv(env, raising=False)
+    monkeypatch.setenv("VTE_VERSION", "4000")
+    monkeypatch.setenv("TERM", "dumb")
+    assert is_hyperlink_supported() is False
+
+
+def test_dumb_term_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_term_only(monkeypatch, "dumb")
+    assert is_hyperlink_supported(Console(force_terminal=True)) is False
+
+
+def test_legacy_windows_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_term_only(monkeypatch, "xterm-256color")
+    console = Console(legacy_windows=True, force_terminal=True)
+    assert is_hyperlink_supported(console) is False
+
+
+def test_not_a_terminal_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_term_only(monkeypatch, "xterm-256color")
+    console = Console(force_terminal=False, legacy_windows=False)
+    assert is_hyperlink_supported(console) is False
+
+
+def test_modern_truecolor_terminal_supported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_term_only(monkeypatch, "xterm-256color")
+    console = Console(
+        force_terminal=True, legacy_windows=False, color_system="truecolor"
+    )
+    assert is_hyperlink_supported(console)
+
+
+def test_invalid_vte_version_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Garbage in VTE_VERSION shouldn't crash the predicate."""
+
+    for env in ("FORCE_HYPERLINK", "TERM_PROGRAM"):
+        monkeypatch.delenv(env, raising=False)
+    monkeypatch.setenv("VTE_VERSION", "not-a-number")
+    monkeypatch.setenv("TERM", "dumb")
+    assert is_hyperlink_supported() is False
+
+
+# ------------------------------------------------------------------
+# format_link
+# ------------------------------------------------------------------
+
+
+def test_format_link_falls_back_to_plain_when_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_term_only(monkeypatch, "dumb")
+    console = Console(force_terminal=False)
+    assert format_link("hello", "https://x.test", console=console) == "hello"
+
+
+def test_format_link_emits_rich_markup_when_supported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FORCE_HYPERLINK", "1")
+    out = format_link("hello", "https://x.test")
+    assert out == "[link=https://x.test]hello[/link]"
+
+
+def test_format_link_handles_empty_inputs() -> None:
+    assert format_link("", "https://x.test") == ""
+    assert format_link("hello", "") == "hello"
+
+
+# ------------------------------------------------------------------
+# format_file_path
+# ------------------------------------------------------------------
+
+
+def test_format_file_path_makes_clickable_when_supported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FORCE_HYPERLINK", "1")
+    out = format_file_path("/tmp/foo.py")
+    assert "link=file:///tmp/foo.py" in out
+
+
+def test_format_file_path_passes_existing_file_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FORCE_HYPERLINK", "1")
+    out = format_file_path("file:///already/url.py")
+    assert "[link=file:///already/url.py]file:///already/url.py[/link]" == out
+
+
+def test_format_file_path_relative_uses_file_scheme(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FORCE_HYPERLINK", "1")
+    out = format_file_path("src/x.py")
+    # Relative path is wrapped with file://relative — the host terminal
+    # decides whether to resolve. We don't synthesize cwd here.
+    assert "[link=file://src/x.py]src/x.py[/link]" == out
+
+
+def test_format_file_path_falls_back_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_term_only(monkeypatch, "dumb")
+    console = Console(force_terminal=False)
+    assert format_file_path("/tmp/foo.py", console=console) == "/tmp/foo.py"
+
+
+def test_format_file_path_empty_returns_empty() -> None:
+    assert format_file_path("") == ""
+
+
+# ------------------------------------------------------------------
+# raw_osc8
+# ------------------------------------------------------------------
+
+
+def test_raw_osc8_round_trips() -> None:
+    out = raw_osc8("hello", "https://x.test")
+    assert out.startswith("\x1b]8;;https://x.test\x1b\\")
+    assert out.endswith("\x1b]8;;\x1b\\")
+    assert "hello" in out

--- a/tests/tui/test_permission_modal_specialization.py
+++ b/tests/tui/test_permission_modal_specialization.py
@@ -1,0 +1,199 @@
+"""Tests for Phase-7 specialized permission previews (gap #8)."""
+
+from __future__ import annotations
+
+import pytest
+from rich.console import Console
+from rich.panel import Panel
+
+from src.tui.screens.permission_modal import preview_for_tool
+
+
+def _render(renderable) -> str:
+    """Capture a Rich renderable as a plain string for assertion."""
+
+    if renderable is None:
+        return ""
+    console = Console(record=True, width=120, force_terminal=False)
+    console.print(renderable)
+    return console.export_text()
+
+
+# ------------------------------------------------------------------
+# Generic fallback
+# ------------------------------------------------------------------
+
+
+def test_unknown_tool_falls_back_to_generic_preview() -> None:
+    out = preview_for_tool("UnknownTool", {"foo": "bar"})
+    assert isinstance(out, Panel)
+    assert "foo: bar" in _render(out)
+
+
+def test_empty_input_returns_none() -> None:
+    assert preview_for_tool("Bash", {}) is None
+    assert preview_for_tool("Bash", None) is None
+
+
+def test_unknown_tool_with_long_value_truncates() -> None:
+    huge = "x" * 1000
+    out = preview_for_tool("Frobnicate", {"k": huge})
+    text = _render(out)
+    assert "…" in text  # truncation marker present
+
+
+# ------------------------------------------------------------------
+# Bash
+# ------------------------------------------------------------------
+
+
+def test_bash_renders_command() -> None:
+    out = preview_for_tool("Bash", {"command": "ls -la"})
+    assert out is not None
+    text = _render(out)
+    assert "$" in text
+    assert "ls -la" in text
+
+
+def test_bash_renders_matching_rule_when_present() -> None:
+    out = preview_for_tool(
+        "Bash",
+        {"command": "git commit", "matched_permission_rule": "Bash(git commit*)"},
+    )
+    text = _render(out)
+    assert "Bash(git commit*)" in text
+
+
+def test_bash_renders_description_when_present() -> None:
+    out = preview_for_tool(
+        "Bash",
+        {"command": "ls", "description": "list the files"},
+    )
+    assert "list the files" in _render(out)
+
+
+def test_bash_no_command_returns_generic() -> None:
+    """Without ``command`` the Bash renderer returns None and the
+    dispatcher falls through to the generic preview."""
+
+    out = preview_for_tool("Bash", {"description": "no command"})
+    text = _render(out)
+    assert "description: no command" in text
+
+
+def test_bash_lowercase_alias_works() -> None:
+    out = preview_for_tool("bash", {"command": "ls"})
+    assert out is not None
+    assert "ls" in _render(out)
+
+
+# ------------------------------------------------------------------
+# Edit
+# ------------------------------------------------------------------
+
+
+def test_edit_renders_inline_diff() -> None:
+    out = preview_for_tool(
+        "Edit",
+        {
+            "file_path": "src/foo.py",
+            "old_string": "old line one\nold line two",
+            "new_string": "new line one",
+        },
+    )
+    text = _render(out)
+    assert "src/foo.py" in text
+    assert "- old line one" in text
+    assert "- old line two" in text
+    assert "+ new line one" in text
+
+
+def test_edit_truncates_huge_diffs() -> None:
+    old = "\n".join(f"old{i}" for i in range(50))
+    new = "\n".join(f"new{i}" for i in range(50))
+    out = preview_for_tool(
+        "Edit",
+        {"file_path": "f.py", "old_string": old, "new_string": new},
+    )
+    text = _render(out)
+    assert "more removed lines" in text
+    assert "more added lines" in text
+
+
+def test_edit_only_path_no_diff_still_renders() -> None:
+    out = preview_for_tool(
+        "Edit", {"file_path": "f.py", "old_string": "", "new_string": ""}
+    )
+    text = _render(out)
+    assert "f.py" in text
+
+
+# ------------------------------------------------------------------
+# Write
+# ------------------------------------------------------------------
+
+
+def test_write_renders_path_and_content() -> None:
+    out = preview_for_tool(
+        "Write",
+        {"file_path": "out.txt", "content": "hello world"},
+    )
+    text = _render(out)
+    assert "out.txt" in text
+    assert "hello world" in text
+
+
+def test_write_truncates_long_content() -> None:
+    out = preview_for_tool(
+        "Write",
+        {"file_path": "f.txt", "content": "x" * 1000},
+    )
+    text = _render(out)
+    assert "…" in text
+
+
+# ------------------------------------------------------------------
+# Read
+# ------------------------------------------------------------------
+
+
+def test_read_renders_path_and_offset_limit() -> None:
+    out = preview_for_tool(
+        "Read",
+        {"file_path": "src/x.py", "offset": 10, "limit": 50},
+    )
+    text = _render(out)
+    assert "src/x.py" in text
+    assert "offset=10" in text
+    assert "limit=50" in text
+
+
+def test_read_no_path_returns_none() -> None:
+    """Read without a file_path doesn't have a meaningful summary —
+    fall through to generic."""
+
+    out = preview_for_tool("Read", {"limit": 10})
+    text = _render(out)
+    assert "limit: 10" in text
+
+
+# ------------------------------------------------------------------
+# Renderer error → generic fallback
+# ------------------------------------------------------------------
+
+
+def test_handler_exception_falls_back_to_generic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If a per-tool renderer raises, the dispatcher must not crash —
+    the generic preview takes over."""
+
+    from src.tui.screens import permission_modal
+
+    def boom(_input):  # pragma: no cover - exercised via dispatcher
+        raise RuntimeError("simulated render failure")
+
+    monkeypatch.setitem(permission_modal._TOOL_RENDERERS, "Boom", boom)
+    out = preview_for_tool("Boom", {"command": "ls"})
+    text = _render(out)
+    assert "command: ls" in text

--- a/tests/tui/test_resume_doctor_screens.py
+++ b/tests/tui/test_resume_doctor_screens.py
@@ -1,0 +1,131 @@
+"""Smoke tests for Phase-8 Resume / Doctor screens (gap #9)."""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App
+
+from src.tui.screens.doctor import DoctorScreen
+from src.tui.screens.resume_conversation import ResumeConversation
+
+
+# ------------------------------------------------------------------
+# ResumeConversation
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resume_screen_mounts_and_dismisses() -> None:
+    """Modal lifecycle smoke — modal renders, Esc dismisses."""
+
+    class _Harness(App):
+        async def on_mount(self) -> None:
+            await self.push_screen(ResumeConversation())
+
+    async with _Harness().run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, ResumeConversation)
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not isinstance(pilot.app.screen, ResumeConversation)
+
+
+@pytest.mark.asyncio
+async def test_resume_screen_shows_empty_state_when_no_sessions(
+    tmp_path, monkeypatch
+) -> None:
+    """Phase-8 placeholder: no sessions → empty-state surface.
+
+    Isolate the global ``SESSIONS_DIR`` so this test doesn't pick up
+    sessions from the dev's real ``~/.clawcodex/sessions/`` (Phase-8
+    wiring made the screen actually read from disk).
+    """
+
+    monkeypatch.setattr(
+        "src.services.session_storage.SESSIONS_DIR", tmp_path
+    )
+
+    class _Harness(App):
+        async def on_mount(self) -> None:
+            await self.push_screen(ResumeConversation())
+
+    async with _Harness().run_test() as pilot:
+        await pilot.pause()
+        screen = pilot.app.screen
+        assert isinstance(screen, ResumeConversation)
+        from textual.widgets import OptionList
+
+        # Empty case — no OptionList children mounted.
+        assert not screen.query(OptionList)
+
+
+@pytest.mark.asyncio
+async def test_resume_screen_handles_storage_exception_gracefully() -> None:
+    """Audit state-2 path: even if SessionStorage import fails, the
+    screen mounts cleanly with the placeholder empty state."""
+
+    class _Harness(App):
+        async def on_mount(self) -> None:
+            await self.push_screen(ResumeConversation())
+
+    async with _Harness().run_test() as pilot:
+        await pilot.pause()
+        # Just ensure no exception propagated to the test harness.
+        assert isinstance(pilot.app.screen, ResumeConversation)
+
+
+# ------------------------------------------------------------------
+# DoctorScreen
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_doctor_screen_mounts_and_dismisses() -> None:
+    class _Harness(App):
+        async def on_mount(self) -> None:
+            await self.push_screen(DoctorScreen())
+
+    async with _Harness().run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, DoctorScreen)
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not isinstance(pilot.app.screen, DoctorScreen)
+
+
+@pytest.mark.asyncio
+async def test_doctor_screen_renders_known_sections() -> None:
+    """Smoke — sections render without crashing on the missing app_state."""
+
+    class _Harness(App):
+        async def on_mount(self) -> None:
+            await self.push_screen(DoctorScreen(app_state=None))
+
+    async with _Harness().run_test() as pilot:
+        await pilot.pause()
+        screen = pilot.app.screen
+        assert isinstance(screen, DoctorScreen)
+        # Sections are mounted as Static panels; just ensure ≥ 4 (env,
+        # hyperlinks, frame metrics, storage).
+        from textual.widgets import Static
+
+        statics = list(screen.query(Static))
+        # Title + 4 section panels = at least 5 statics.
+        assert len(statics) >= 5
+
+
+@pytest.mark.asyncio
+async def test_doctor_screen_with_app_state() -> None:
+    class _State:
+        provider = "openai"
+        model = "gpt-x"
+        workspace_root = "/tmp/ws"
+        theme_name = "claude"
+
+    class _Harness(App):
+        async def on_mount(self) -> None:
+            await self.push_screen(DoctorScreen(app_state=_State()))
+
+    async with _Harness().run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, DoctorScreen)

--- a/tests/tui/test_tool_result_hyperlinks.py
+++ b/tests/tui/test_tool_result_hyperlinks.py
@@ -1,0 +1,109 @@
+"""Tests for Phase-10 tool-result hyperlink wrapping (gap #15)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tui.widgets.messages.tool_result import (
+    _PATH_RE,
+    _wrap_paths_with_hyperlinks,
+)
+
+
+def _matches(text: str) -> list[str]:
+    """Pull every match of ``_PATH_RE`` from ``text`` for assertion."""
+
+    return [m.group("path") for m in _PATH_RE.finditer(text)]
+
+
+# ------------------------------------------------------------------
+# Regex over-match guards (Critic-flagged)
+# ------------------------------------------------------------------
+
+
+def test_trailing_period_not_captured() -> None:
+    """``check src/main.py.`` should NOT eat the trailing period."""
+
+    matches = _matches("check src/main.py.")
+    assert matches == ["src/main.py"]
+
+
+@pytest.mark.parametrize("punct", [".", ",", ";", ":", "!", "?"])
+def test_trailing_punctuation_not_captured(punct: str) -> None:
+    matches = _matches(f"see /tmp/foo.txt{punct}")
+    assert matches == ["/tmp/foo.txt"]
+
+
+def test_path_with_internal_dot_still_works() -> None:
+    """Extension dots (`x.py`) must remain inside the captured path."""
+
+    matches = _matches("file at /tmp/foo.tar.gz")
+    assert matches == ["/tmp/foo.tar.gz"]
+
+
+def test_path_with_brackets_around_it_handled() -> None:
+    matches = _matches("(see /tmp/foo.py)")
+    assert matches == ["/tmp/foo.py"]
+
+
+def test_url_not_matched_as_path() -> None:
+    """``https://example.com`` doesn't have a path-like prefix and starts
+    in mid-text without the path lookbehind matching."""
+
+    matches = _matches("link is https://example.com/foo")
+    # The regex CAN match an absolute path inside a URL, but we don't
+    # care about that — the test asserts the URL itself isn't classified
+    # as a relative-path; the behavior for URLs is "best-effort".
+    # Confirm: no match starting with ``https`` is in the result list.
+    assert all(not m.startswith("https") for m in matches)
+
+
+def test_relative_path_with_extension() -> None:
+    matches = _matches("Edit src/tui/app.py to fix the bug")
+    assert matches == ["src/tui/app.py"]
+
+
+def test_home_relative_path_matches() -> None:
+    matches = _matches("config at ~/.config/app/settings.json")
+    assert matches == ["~/.config/app/settings.json"]
+
+
+def test_dot_relative_path_matches() -> None:
+    matches = _matches("see ./scripts/build.sh")
+    assert matches == ["./scripts/build.sh"]
+
+
+def test_no_slash_no_match() -> None:
+    """Bare words without a slash aren't paths (avoids false-positives)."""
+
+    assert _matches("just a sentence with no path") == []
+
+
+# ------------------------------------------------------------------
+# _wrap_paths_with_hyperlinks
+# ------------------------------------------------------------------
+
+
+def test_wrapper_falls_back_to_text_on_unsupported_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When hyperlinks aren't supported, return plain :class:`Text`."""
+
+    for env in ("FORCE_HYPERLINK", "TERM_PROGRAM", "VTE_VERSION"):
+        monkeypatch.delenv(env, raising=False)
+    monkeypatch.setenv("TERM", "dumb")
+    out = _wrap_paths_with_hyperlinks("see src/x.py")
+    # Plain Text — no link spans.
+    assert "link=" not in out.markup if hasattr(out, "markup") else True
+    assert "src/x.py" in str(out)
+
+
+def test_wrapper_emits_link_markup_when_supported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FORCE_HYPERLINK", "1")
+    out = _wrap_paths_with_hyperlinks("see src/x.py")
+    rendered = str(out)
+    # Rich Text's str() doesn't expose markup; check the underlying
+    # markup-ish representation via the Text repr if available.
+    assert "src/x.py" in rendered

--- a/tests/tui/test_transcript_search.py
+++ b/tests/tui/test_transcript_search.py
@@ -1,0 +1,243 @@
+"""Tests for Phase-5 inline transcript search overlay (gap #2)."""
+
+from __future__ import annotations
+
+from rich.text import Text
+
+from src.tui.widgets.transcript_search import (
+    TranscriptSearch,
+    find_matches,
+    _renderable_text,
+    _row_text,
+)
+
+
+# ------------------------------------------------------------------
+# _renderable_text — robust extraction
+# ------------------------------------------------------------------
+
+
+def test_renderable_text_handles_str() -> None:
+    assert _renderable_text("hello") == "hello"
+
+
+def test_renderable_text_handles_rich_text() -> None:
+    assert _renderable_text(Text("styled hello")) == "styled hello"
+
+
+def test_renderable_text_handles_tuple() -> None:
+    assert (
+        _renderable_text((Text("a"), "b", Text("c")))
+        == "a\nb\nc"
+    )
+
+
+def test_renderable_text_handles_none() -> None:
+    assert _renderable_text(None) == ""
+
+
+# ------------------------------------------------------------------
+# _row_text + find_matches
+# ------------------------------------------------------------------
+
+
+class _FakeRow:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def snapshot(self):
+        return Text(self._text)
+
+
+def test_row_text_uses_snapshot() -> None:
+    row = _FakeRow("hello world")
+    assert _row_text(row) == "hello world"
+
+
+def test_row_text_handles_missing_snapshot() -> None:
+    class NoSnap:
+        def __str__(self) -> str:
+            return "fallback"
+
+    assert _row_text(NoSnap()) == "fallback"
+
+
+def test_row_text_swallows_snapshot_exceptions() -> None:
+    class Bad:
+        def snapshot(self):
+            raise RuntimeError("oops")
+
+    assert _row_text(Bad()) == ""
+
+
+def test_find_matches_case_insensitive() -> None:
+    rows = [
+        _FakeRow("Hello World"),
+        _FakeRow("nothing here"),
+        _FakeRow("hello again"),
+    ]
+    assert find_matches(rows, "HELLO") == [0, 2]
+
+
+def test_find_matches_empty_query_returns_empty() -> None:
+    rows = [_FakeRow("anything")]
+    assert find_matches(rows, "") == []
+
+
+def test_find_matches_no_hits_returns_empty() -> None:
+    rows = [_FakeRow("a"), _FakeRow("b")]
+    assert find_matches(rows, "zzz") == []
+
+
+def test_find_matches_substring_anywhere_in_row() -> None:
+    """Match is substring, not whole-line."""
+
+    rows = [_FakeRow("the quick brown fox jumps over")]
+    assert find_matches(rows, "fox") == [0]
+
+
+def test_find_matches_handles_mixed_row_shapes() -> None:
+    """A mix of rows with snapshots and rows without should work."""
+
+    class Plain:
+        def __str__(self) -> str:
+            return "plain string row"
+
+    rows = [_FakeRow("snapshot row foo"), Plain()]
+    assert find_matches(rows, "row") == [0, 1]
+
+
+# ------------------------------------------------------------------
+# TranscriptSearch — modal lifecycle smoke tests
+# ------------------------------------------------------------------
+
+
+import pytest
+from textual.app import App
+from textual.containers import VerticalScroll
+from textual.widget import Widget
+
+
+class _FakeTranscript(VerticalScroll):
+    """Stand-in for TranscriptView with the ``_mounted_rows`` attribute."""
+
+    def __init__(self, rows) -> None:
+        super().__init__()
+        self._mounted_rows = list(rows)
+
+
+@pytest.mark.asyncio
+async def test_transcript_search_opens_and_closes_on_escape() -> None:
+    rows = [_FakeRow("alpha"), _FakeRow("beta"), _FakeRow("gamma")]
+    transcript = _FakeTranscript(rows)
+
+    class _Harness(App):
+        def __init__(self) -> None:
+            super().__init__()
+
+        def compose(self):
+            yield transcript
+
+        async def on_mount(self) -> None:
+            await self.push_screen(TranscriptSearch(transcript))
+
+    async with _Harness().run_test() as pilot:
+        await pilot.pause()
+        # Modal is on the stack.
+        assert isinstance(pilot.app.screen, TranscriptSearch)
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not isinstance(pilot.app.screen, TranscriptSearch)
+
+
+@pytest.mark.asyncio
+async def test_transcript_search_filters_on_typing() -> None:
+    rows = [
+        _FakeRow("alpha"),
+        _FakeRow("alphabet"),
+        _FakeRow("beta"),
+    ]
+    transcript = _FakeTranscript(rows)
+
+    class _Harness(App):
+        def compose(self):
+            yield transcript
+
+        async def on_mount(self) -> None:
+            await self.push_screen(TranscriptSearch(transcript))
+
+    async with _Harness().run_test() as pilot:
+        await pilot.pause()
+        screen = pilot.app.screen
+        assert isinstance(screen, TranscriptSearch)
+        # Type 'alph' — should match rows 0 and 1.
+        from textual.widgets import Input
+
+        input_widget = screen.query_one("#search-input", Input)
+        input_widget.value = "alph"
+        # The Input.Changed message would normally fire here; trigger
+        # the screen's handler directly to keep the test sync.
+        screen.on_input_changed(
+            type("E", (), {"value": "alph"})()
+        )
+        await pilot.pause()
+        assert screen._matches == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_transcript_search_navigation_actions() -> None:
+    rows = [_FakeRow("alpha"), _FakeRow("alpha2"), _FakeRow("beta")]
+    transcript = _FakeTranscript(rows)
+
+    class _Harness(App):
+        def compose(self):
+            yield transcript
+
+        async def on_mount(self) -> None:
+            await self.push_screen(TranscriptSearch(transcript))
+
+    async with _Harness().run_test() as pilot:
+        await pilot.pause()
+        screen = pilot.app.screen
+        assert isinstance(screen, TranscriptSearch)
+        screen.search_query = "alph"
+        screen._refresh_matches()
+        await pilot.pause()
+        assert screen._matches == [0, 1]
+        screen.action_next_match()
+        assert screen.match_index == 1
+        screen.action_next_match()
+        # Wraps around to 0.
+        assert screen.match_index == 0
+        screen.action_prev_match()
+        assert screen.match_index == 1
+
+
+@pytest.mark.asyncio
+async def test_transcript_search_dismisses_with_row_index_on_submit() -> None:
+    rows = [_FakeRow("alpha"), _FakeRow("beta foo"), _FakeRow("gamma")]
+    transcript = _FakeTranscript(rows)
+    captured: list[int | None] = []
+
+    def _on_dismiss(value: int | None) -> None:
+        captured.append(value)
+
+    class _Harness(App):
+        def compose(self):
+            yield transcript
+
+        async def on_mount(self) -> None:
+            self.push_screen(TranscriptSearch(transcript), _on_dismiss)
+
+    async with _Harness().run_test() as pilot:
+        await pilot.pause()
+        screen = pilot.app.screen
+        assert isinstance(screen, TranscriptSearch)
+        screen.search_query = "foo"
+        screen._refresh_matches()
+        await pilot.pause()
+        # Submit the search — should dismiss with row index 1.
+        screen.on_input_submitted(type("E", (), {})())
+        await pilot.pause()
+
+    assert captured == [1]

--- a/tests/tui/test_transcript_thinking_transitions.py
+++ b/tests/tui/test_transcript_thinking_transitions.py
@@ -1,0 +1,119 @@
+"""Tests for the thinking↔assistant active-row transition logic.
+
+Phase-12 close-out (Critic-flagged): the symmetric guard in
+``Transcript.append_assistant_chunk`` retires a thinking active row
+before mounting a new assistant text row, and vice versa.
+
+The agent-loop dispatch (which would invoke these helpers in
+production) is plan-deferred to a follow-up; these tests pin the
+behavior so the wiring is mechanical when the time comes.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+
+from src.tui.widgets.messages.assistant_text import AssistantTextMessage
+from src.tui.widgets.messages.assistant_thinking import AssistantThinkingMessage
+from src.tui.widgets.transcript_view import Transcript
+
+
+class _Harness(App):
+    def __init__(self, transcript: Transcript) -> None:
+        super().__init__()
+        self._transcript = transcript
+
+    def compose(self) -> ComposeResult:
+        yield self._transcript
+
+
+@pytest.mark.asyncio
+async def test_assistant_after_thinking_retires_thinking_row() -> None:
+    """Thinking row → assistant row: the thinking row is finalised
+    before the assistant row mounts. Symmetric guard test."""
+
+    transcript = Transcript()
+    async with _Harness(transcript).run_test() as pilot:
+        transcript.append_thinking_chunk("considering options")
+        await pilot.pause()
+        # Active row is a thinking widget.
+        assert isinstance(transcript._active_assistant, AssistantThinkingMessage)
+
+        transcript.append_assistant_chunk("here is the answer")
+        await pilot.pause()
+        # Assistant chunk arrived: thinking row should have been retired
+        # and a fresh AssistantTextMessage mounted.
+        assert isinstance(transcript._active_assistant, AssistantTextMessage)
+        # The thinking row's content stays in the buffer — finalised, not deleted.
+        assert any(
+            isinstance(row, AssistantThinkingMessage)
+            for row in transcript._mounted_rows
+        )
+
+
+@pytest.mark.asyncio
+async def test_thinking_after_assistant_retires_assistant_row() -> None:
+    """Assistant row → thinking row: the assistant row is finalised
+    before the thinking row mounts. Mirrors the symmetric guard."""
+
+    transcript = Transcript()
+    async with _Harness(transcript).run_test() as pilot:
+        transcript.append_assistant_chunk("partial response")
+        await pilot.pause()
+        assert isinstance(transcript._active_assistant, AssistantTextMessage)
+
+        transcript.append_thinking_chunk("revising approach")
+        await pilot.pause()
+        assert isinstance(transcript._active_assistant, AssistantThinkingMessage)
+
+
+@pytest.mark.asyncio
+async def test_thinking_to_thinking_redacted_remounts() -> None:
+    """Switching from non-redacted to redacted thinking → fresh widget."""
+
+    transcript = Transcript()
+    async with _Harness(transcript).run_test() as pilot:
+        transcript.append_thinking_chunk("public reasoning")
+        await pilot.pause()
+        first_row = transcript._active_assistant
+        assert isinstance(first_row, AssistantThinkingMessage)
+        assert not first_row.has_class("-redacted")
+
+        transcript.append_thinking_chunk("hidden", redacted=True)
+        await pilot.pause()
+        second_row = transcript._active_assistant
+        assert isinstance(second_row, AssistantThinkingMessage)
+        assert second_row.has_class("-redacted")
+        # Two distinct rows in the mounted list — the previous one was
+        # retired, the new redacted one mounted.
+        assert first_row is not second_row
+
+
+@pytest.mark.asyncio
+async def test_thinking_chunks_accumulate_in_same_widget() -> None:
+    """Same-mode chunks stream into the same row (no remount per chunk)."""
+
+    transcript = Transcript()
+    async with _Harness(transcript).run_test() as pilot:
+        transcript.append_thinking_chunk("step 1")
+        transcript.append_thinking_chunk(", step 2")
+        transcript.append_thinking_chunk(", step 3")
+        await pilot.pause()
+        active = transcript._active_assistant
+        assert isinstance(active, AssistantThinkingMessage)
+        assert active.streaming_text == "step 1, step 2, step 3"
+
+
+@pytest.mark.asyncio
+async def test_finalise_thinking_via_append_thinking() -> None:
+    """The non-streaming finalise path closes out the active thinking row."""
+
+    transcript = Transcript()
+    async with _Harness(transcript).run_test() as pilot:
+        transcript.append_thinking_chunk("draft thought")
+        await pilot.pause()
+        transcript.append_thinking("draft thought, finalised")
+        await pilot.pause()
+        # No active row — the previous thinking widget was finalised.
+        assert transcript._active_assistant is None

--- a/tests/tui/test_vim_multiline.py
+++ b/tests/tui/test_vim_multiline.py
@@ -1,0 +1,327 @@
+"""Tests for Phase-4 wave-1 multi-line vim modules.
+
+Covers:
+- :class:`VimBuffer` cursor + replace/delete/insert
+- :func:`find_text_object` for words / paragraphs / quotes / braces
+- :func:`parse_operator_motion`
+- :func:`apply_operator` for d / c / y composed with motions and text objects
+- count prefixes (``d2w``)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tui.vim_buffer import Cursor, Range, VimBuffer
+from src.tui.vim_operators import (
+    ParsedOperator,
+    apply_operator,
+    parse_operator_motion,
+    resolve_target_range,
+)
+from src.tui.vim_text_objects import find_text_object
+
+
+# ------------------------------------------------------------------
+# VimBuffer
+# ------------------------------------------------------------------
+
+
+def test_buffer_empty_is_one_blank_line() -> None:
+    buf = VimBuffer()
+    assert buf.line_count == 1
+    assert buf.lines == [""]
+    assert buf.is_empty()
+
+
+def test_buffer_splits_on_newlines() -> None:
+    buf = VimBuffer("a\nb\nc")
+    assert buf.lines == ["a", "b", "c"]
+
+
+def test_set_cursor_clamps() -> None:
+    buf = VimBuffer("hello")
+    buf.set_cursor(99, 99)
+    assert buf.cursor == Cursor(0, 5)
+    buf.set_cursor(-1, -1)
+    assert buf.cursor == Cursor(0, 0)
+
+
+def test_text_in_single_line() -> None:
+    buf = VimBuffer("hello world")
+    rng = Range(Cursor(0, 0), Cursor(0, 5))
+    assert buf.text_in(rng) == "hello"
+
+
+def test_text_in_multi_line() -> None:
+    buf = VimBuffer("line one\nline two\nline three")
+    rng = Range(Cursor(0, 5), Cursor(2, 4))
+    assert buf.text_in(rng) == "one\nline two\nline"
+
+
+def test_replace_single_line() -> None:
+    buf = VimBuffer("hello world")
+    rng = Range(Cursor(0, 0), Cursor(0, 5))
+    removed = buf.replace(rng, "yo")
+    assert removed == "hello"
+    assert buf.text == "yo world"
+
+
+def test_replace_multi_line_collapses() -> None:
+    buf = VimBuffer("a\nb\nc")
+    rng = Range(Cursor(0, 0), Cursor(2, 1))
+    buf.replace(rng, "X")
+    assert buf.text == "X"
+
+
+def test_insert_advances_cursor() -> None:
+    buf = VimBuffer("hello")
+    buf.set_cursor(0, 5)
+    buf.insert(" world")
+    assert buf.text == "hello world"
+    assert buf.cursor == Cursor(0, 11)
+
+
+def test_insert_with_newline_advances_to_new_line() -> None:
+    buf = VimBuffer("hi")
+    buf.set_cursor(0, 2)
+    buf.insert("\nbye")
+    assert buf.text == "hi\nbye"
+    assert buf.cursor == Cursor(1, 3)
+
+
+# ------------------------------------------------------------------
+# find_text_object — word
+# ------------------------------------------------------------------
+
+
+def test_iw_inner_word_returns_word_only() -> None:
+    buf = VimBuffer("hello world")
+    rng = find_text_object(buf, Cursor(0, 7), "iw")
+    assert rng is not None
+    assert buf.text_in(rng) == "world"
+
+
+def test_aw_around_word_includes_trailing_space() -> None:
+    buf = VimBuffer("hello world")
+    rng = find_text_object(buf, Cursor(0, 0), "aw")
+    assert rng is not None
+    assert buf.text_in(rng) == "hello "
+
+
+def test_iw_on_separator_returns_none() -> None:
+    """Cursor on a separator (space) — wave-1 returns None."""
+
+    buf = VimBuffer("a b")
+    assert find_text_object(buf, Cursor(0, 1), "iw") is None
+
+
+# ------------------------------------------------------------------
+# find_text_object — quoted
+# ------------------------------------------------------------------
+
+
+def test_inner_double_quoted() -> None:
+    buf = VimBuffer('say "hello world" please')
+    rng = find_text_object(buf, Cursor(0, 7), 'i"')
+    assert rng is not None
+    assert buf.text_in(rng) == "hello world"
+
+
+def test_around_double_quoted_includes_quotes() -> None:
+    buf = VimBuffer('say "hello" please')
+    rng = find_text_object(buf, Cursor(0, 7), 'a"')
+    assert rng is not None
+    assert buf.text_in(rng) == '"hello"'
+
+
+def test_quotes_with_no_pair_returns_none() -> None:
+    buf = VimBuffer('only one " here')
+    assert find_text_object(buf, Cursor(0, 5), 'i"') is None
+
+
+# ------------------------------------------------------------------
+# find_text_object — brace
+# ------------------------------------------------------------------
+
+
+def test_inner_brace_block() -> None:
+    buf = VimBuffer("foo(bar baz) qux")
+    rng = find_text_object(buf, Cursor(0, 6), "i(")
+    assert rng is not None
+    assert buf.text_in(rng) == "bar baz"
+
+
+def test_around_brace_block() -> None:
+    buf = VimBuffer("foo(bar) qux")
+    rng = find_text_object(buf, Cursor(0, 5), "a(")
+    assert rng is not None
+    assert buf.text_in(rng) == "(bar)"
+
+
+def test_nested_brace_picks_inner() -> None:
+    buf = VimBuffer("a (b (c) d)")
+    # Cursor inside inner (c) — should pick the inner pair.
+    rng = find_text_object(buf, Cursor(0, 6), "i(")
+    assert rng is not None
+    assert buf.text_in(rng) == "c"
+
+
+def test_brace_alias_close_bracket_works() -> None:
+    """``i]`` should produce the same result as ``i[``."""
+
+    buf = VimBuffer("[abc]")
+    rng_open = find_text_object(buf, Cursor(0, 2), "i[")
+    rng_close = find_text_object(buf, Cursor(0, 2), "i]")
+    assert rng_open == rng_close
+
+
+# ------------------------------------------------------------------
+# find_text_object — paragraph
+# ------------------------------------------------------------------
+
+
+def test_inner_paragraph() -> None:
+    buf = VimBuffer("first para\ncontinued\n\nnext para\n\nthird")
+    rng = find_text_object(buf, Cursor(0, 0), "ip")
+    assert rng is not None
+    text = buf.text_in(rng)
+    # Paragraph is rows 0-1 (non-blank consecutive lines).
+    assert "first para" in text
+    assert "continued" in text
+    assert "next para" not in text
+
+
+# ------------------------------------------------------------------
+# parse_operator_motion
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        ("dw", ParsedOperator("d", "w", 1)),
+        ("d2w", ParsedOperator("d", "w", 2)),
+        ("ciw", ParsedOperator("c", "iw", 1)),
+        ("y$", ParsedOperator("y", "$", 1)),
+        ('da"', ParsedOperator("d", 'a"', 1)),
+        ("c5w", ParsedOperator("c", "w", 5)),
+    ],
+)
+def test_parse_operator_motion_valid(input: str, expected: ParsedOperator) -> None:
+    assert parse_operator_motion(input) == expected
+
+
+@pytest.mark.parametrize(
+    "input",
+    [
+        "",
+        "z",  # bad operator
+        "dz",  # bad motion
+        "d",  # missing target
+        "dgg",  # 2-char target that isn't a text object
+        # Critic-flagged: tighten the text-object char class so non-object
+        # 2-char targets are rejected.
+        "dia",
+        "dii",
+        "caa",
+        "cai",
+        "dao",  # 'o' is not a text-object kind
+    ],
+)
+def test_parse_operator_motion_invalid(input: str) -> None:
+    assert parse_operator_motion(input) is None
+
+
+# ------------------------------------------------------------------
+# apply_operator
+# ------------------------------------------------------------------
+
+
+def test_dw_deletes_one_word() -> None:
+    buf = VimBuffer("hello world")
+    rng = resolve_target_range(buf, Cursor(0, 0), "w", count=1)
+    assert rng is not None
+    apply_operator(buf, rng, "d")
+    assert buf.text == "world"
+
+
+def test_d2w_deletes_two_words() -> None:
+    buf = VimBuffer("alpha beta gamma")
+    rng = resolve_target_range(buf, Cursor(0, 0), "w", count=2)
+    assert rng is not None
+    apply_operator(buf, rng, "d")
+    assert buf.text == "gamma"
+
+
+def test_dollar_deletes_to_end_of_line() -> None:
+    buf = VimBuffer("abc def ghi")
+    buf.set_cursor(0, 4)
+    rng = resolve_target_range(buf, buf.cursor, "$", count=1)
+    assert rng is not None
+    apply_operator(buf, rng, "d")
+    assert buf.text == "abc "
+
+
+def test_yank_does_not_modify_buffer() -> None:
+    buf = VimBuffer("hello world")
+    rng = resolve_target_range(buf, Cursor(0, 0), "w", count=1)
+    yank: list[str] = []
+    apply_operator(buf, rng, "y", yank_buffer=yank)
+    assert buf.text == "hello world"
+    assert yank == ["hello "]
+
+
+def test_change_clears_range() -> None:
+    buf = VimBuffer("hello world")
+    rng = find_text_object(buf, Cursor(0, 0), "iw")
+    assert rng is not None
+    apply_operator(buf, rng, "c")
+    assert buf.text == " world"
+
+
+def test_delete_with_text_object_iw() -> None:
+    buf = VimBuffer("alpha bravo charlie")
+    rng = find_text_object(buf, Cursor(0, 6), "iw")
+    assert rng is not None
+    apply_operator(buf, rng, "d")
+    assert buf.text == "alpha  charlie"
+
+
+def test_indent_operator_adds_two_spaces() -> None:
+    buf = VimBuffer("first\nsecond")
+    rng = Range(Cursor(0, 0), Cursor(1, 6))
+    apply_operator(buf, rng, ">")
+    assert buf.text == "  first\n  second"
+
+
+def test_dedent_operator_removes_leading_spaces() -> None:
+    buf = VimBuffer("    first\n    second")
+    rng = Range(Cursor(0, 0), Cursor(1, 10))
+    apply_operator(buf, rng, "<")
+    assert buf.text == "  first\n  second"
+
+
+# ------------------------------------------------------------------
+# Composition smoke tests: parse + resolve + apply
+# ------------------------------------------------------------------
+
+
+def test_full_pipeline_d_iw() -> None:
+    buf = VimBuffer("alpha bravo charlie")
+    parsed = parse_operator_motion("diw")
+    assert parsed is not None
+    rng = resolve_target_range(buf, Cursor(0, 6), parsed.target, count=parsed.count)
+    assert rng is not None
+    apply_operator(buf, rng, parsed.operator)
+    assert buf.text == "alpha  charlie"
+
+
+def test_full_pipeline_c_a_quote() -> None:
+    buf = VimBuffer('say "the words" please')
+    parsed = parse_operator_motion('da"')
+    assert parsed is not None
+    rng = resolve_target_range(buf, Cursor(0, 7), parsed.target)
+    assert rng is not None
+    apply_operator(buf, rng, parsed.operator)
+    assert buf.text == "say  please"

--- a/tests/tui/test_vim_wave2.py
+++ b/tests/tui/test_vim_wave2.py
@@ -1,0 +1,317 @@
+"""Tests for Phase-4 wave-2: Visual mode + regex search."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tui.vim_buffer import Cursor, VimBuffer
+from src.tui.vim_operators import apply_operator
+from src.tui.vim_search import (
+    InvalidPattern,
+    SearchDirection,
+    VimSearchState,
+    find_next,
+)
+from src.tui.vim_visual import VisualMode, VisualSelection, VisualState
+
+
+# ------------------------------------------------------------------
+# VisualSelection — character mode
+# ------------------------------------------------------------------
+
+
+def test_character_visual_normalises_anchor_after_cursor() -> None:
+    """Vim Visual is character-INCLUSIVE — anchor at col 6, cursor at col 0
+    means cols 0..6 are selected (7 chars)."""
+
+    buf = VimBuffer("hello world")
+    sel = VisualSelection(
+        mode=VisualMode.CHARACTER,
+        anchor=Cursor(0, 6),
+        cursor=Cursor(0, 0),
+    )
+    rng = sel.as_range(buf)
+    # 7 chars starting at col 0: "hello w".
+    assert buf.text_in(rng) == "hello w"
+
+
+def test_character_visual_inclusive_end_one_char() -> None:
+    """Vim Visual is character-inclusive — a single-char selection covers
+    one character."""
+
+    buf = VimBuffer("abcdef")
+    sel = VisualSelection(
+        mode=VisualMode.CHARACTER,
+        anchor=Cursor(0, 2),
+        cursor=Cursor(0, 2),
+    )
+    rng = sel.as_range(buf)
+    assert buf.text_in(rng) == "c"
+
+
+def test_character_visual_across_lines() -> None:
+    buf = VimBuffer("alpha\nbeta\ngamma")
+    sel = VisualSelection(
+        mode=VisualMode.CHARACTER,
+        anchor=Cursor(0, 2),
+        cursor=Cursor(2, 1),
+    )
+    rng = sel.as_range(buf)
+    assert buf.text_in(rng) == "pha\nbeta\nga"
+
+
+# ------------------------------------------------------------------
+# VisualSelection — line mode
+# ------------------------------------------------------------------
+
+
+def test_line_visual_covers_whole_lines() -> None:
+    buf = VimBuffer("first\nsecond\nthird")
+    sel = VisualSelection(
+        mode=VisualMode.LINE,
+        anchor=Cursor(0, 3),
+        cursor=Cursor(1, 1),
+    )
+    rng = sel.as_range(buf)
+    assert buf.text_in(rng) == "first\nsecond"
+
+
+def test_line_visual_normalises_when_cursor_above_anchor() -> None:
+    buf = VimBuffer("a\nb\nc")
+    sel = VisualSelection(
+        mode=VisualMode.LINE,
+        anchor=Cursor(2, 0),
+        cursor=Cursor(0, 0),
+    )
+    rng = sel.as_range(buf)
+    assert buf.text_in(rng) == "a\nb\nc"
+
+
+# ------------------------------------------------------------------
+# VisualSelection — block mode
+# ------------------------------------------------------------------
+
+
+def test_block_visual_per_line_ranges_for_rectangle() -> None:
+    buf = VimBuffer("aaaaa\nbbbbb\nccccc")
+    sel = VisualSelection(
+        mode=VisualMode.BLOCK,
+        anchor=Cursor(0, 1),
+        cursor=Cursor(2, 3),
+    )
+    ranges = sel.block_ranges(buf)
+    assert len(ranges) == 3
+    assert buf.text_in(ranges[0]) == "aaa"
+    assert buf.text_in(ranges[1]) == "bbb"
+    assert buf.text_in(ranges[2]) == "ccc"
+
+
+def test_block_visual_handles_short_lines() -> None:
+    """Visual-Block over rows of varying length — short lines yield empty."""
+
+    buf = VimBuffer("aaa\nb\nccc")
+    sel = VisualSelection(
+        mode=VisualMode.BLOCK,
+        anchor=Cursor(0, 0),
+        cursor=Cursor(2, 2),
+    )
+    ranges = sel.block_ranges(buf)
+    assert buf.text_in(ranges[0]) == "aaa"
+    # Short line `b` only has one char; block clamps to len(line).
+    assert buf.text_in(ranges[1]) == "b"
+    assert buf.text_in(ranges[2]) == "ccc"
+
+
+# ------------------------------------------------------------------
+# VisualState — toggle lifecycle
+# ------------------------------------------------------------------
+
+
+def test_visual_state_lifecycle() -> None:
+    state = VisualState()
+    assert state.is_active() is False
+    state.start(VisualMode.CHARACTER, anchor=Cursor(0, 0))
+    assert state.is_active()
+    state.update_cursor(Cursor(0, 5))
+    assert state.selection is not None
+    assert state.selection.cursor == Cursor(0, 5)
+    state.exit()
+    assert state.is_active() is False
+
+
+def test_visual_state_with_operator_applies_to_buffer() -> None:
+    """End-to-end: select chars, apply ``d`` operator, verify deletion."""
+
+    buf = VimBuffer("hello world")
+    state = VisualState()
+    state.start(VisualMode.CHARACTER, anchor=Cursor(0, 0))
+    state.update_cursor(Cursor(0, 4))
+    rng = state.selection.as_range(buf)  # type: ignore[union-attr]
+    apply_operator(buf, rng, "d")
+    assert buf.text == " world"
+
+
+# ------------------------------------------------------------------
+# find_next — forward
+# ------------------------------------------------------------------
+
+
+def test_find_next_forward_simple() -> None:
+    buf = VimBuffer("alpha bravo alpha charlie")
+    hit = find_next(buf, pattern="alpha", after=Cursor(0, 0))
+    assert hit is not None
+    assert hit.at == Cursor(0, 12)  # second 'alpha'
+    assert hit.text == "alpha"
+
+
+def test_find_next_forward_no_match() -> None:
+    buf = VimBuffer("abc")
+    assert find_next(buf, pattern="xyz", after=Cursor(0, 0)) is None
+
+
+def test_find_next_forward_wrap() -> None:
+    """Past the last match → wrap to beginning."""
+
+    buf = VimBuffer("foo bar foo")
+    # Cursor sits past the last 'foo' (col 8 = 'foo' start; cursor 10
+    # is past it). Wrap should find the first 'foo' at col 0.
+    hit = find_next(buf, pattern="foo", after=Cursor(0, 10))
+    assert hit is not None
+    assert hit.at == Cursor(0, 0)
+
+
+def test_find_next_forward_no_wrap_returns_none() -> None:
+    buf = VimBuffer("foo bar foo")
+    hit = find_next(
+        buf, pattern="foo", after=Cursor(0, 10), wrap=False
+    )
+    assert hit is None
+
+
+def test_find_next_forward_multiline() -> None:
+    buf = VimBuffer("line one\nline two foo\nline three")
+    hit = find_next(buf, pattern="foo", after=Cursor(0, 0))
+    assert hit is not None
+    assert hit.at == Cursor(1, 9)
+
+
+# ------------------------------------------------------------------
+# find_next — backward
+# ------------------------------------------------------------------
+
+
+def test_find_next_backward_simple() -> None:
+    buf = VimBuffer("alpha bravo alpha charlie")
+    # From end of buffer backward — first alpha hit is the second 'alpha'.
+    hit = find_next(
+        buf,
+        pattern="alpha",
+        after=Cursor(0, 18),
+        direction=SearchDirection.BACKWARD,
+    )
+    assert hit is not None
+    assert hit.at == Cursor(0, 12)
+
+
+def test_find_next_backward_picks_previous_on_same_line() -> None:
+    buf = VimBuffer("foo bar foo")
+    hit = find_next(
+        buf,
+        pattern="foo",
+        after=Cursor(0, 8),  # right at the second 'foo' start
+        direction=SearchDirection.BACKWARD,
+    )
+    assert hit is not None
+    # Backward from col 8 — the first 'foo' at col 0 is the previous match.
+    assert hit.at == Cursor(0, 0)
+
+
+def test_find_next_backward_wrap() -> None:
+    buf = VimBuffer("foo bar")
+    hit = find_next(
+        buf,
+        pattern="foo",
+        after=Cursor(0, 0),
+        direction=SearchDirection.BACKWARD,
+    )
+    assert hit is not None
+    assert hit.at == Cursor(0, 0)
+
+
+# ------------------------------------------------------------------
+# Pattern errors
+# ------------------------------------------------------------------
+
+
+def test_invalid_pattern_raises() -> None:
+    buf = VimBuffer("abc")
+    with pytest.raises(InvalidPattern):
+        find_next(buf, pattern="(unbalanced", after=Cursor(0, 0))
+
+
+def test_empty_pattern_returns_none() -> None:
+    buf = VimBuffer("abc")
+    assert find_next(buf, pattern="", after=Cursor(0, 0)) is None
+
+
+# ------------------------------------------------------------------
+# VimSearchState — n / N repeat
+# ------------------------------------------------------------------
+
+
+def test_search_state_repeat_forward() -> None:
+    buf = VimBuffer("foo bar foo baz foo")
+    state = VimSearchState()
+    hit1 = state.search(buf, pattern="foo", at=Cursor(0, 0))
+    assert hit1 is not None
+    assert hit1.at == Cursor(0, 8)
+    # n: next forward
+    hit2 = state.repeat(buf, at=hit1.at)
+    assert hit2 is not None
+    assert hit2.at == Cursor(0, 16)
+
+
+def test_search_state_repeat_reverse() -> None:
+    """``N`` reverses the original direction."""
+
+    buf = VimBuffer("foo bar foo baz foo")
+    state = VimSearchState()
+    state.search(buf, pattern="foo", at=Cursor(0, 0))
+    # Step the cursor to past the third foo. ``N`` should walk backward.
+    hit = state.repeat(buf, at=Cursor(0, 18), reverse=True)
+    assert hit is not None
+    assert hit.at == Cursor(0, 16)
+
+
+def test_search_state_repeat_with_no_prior_search_returns_none() -> None:
+    buf = VimBuffer("foo")
+    state = VimSearchState()
+    assert state.repeat(buf, at=Cursor(0, 0)) is None
+    assert state.is_armed() is False
+
+
+def test_backward_then_n_continues_backward() -> None:
+    buf = VimBuffer("foo bar foo baz foo")
+    state = VimSearchState()
+    state.search(
+        buf,
+        pattern="foo",
+        at=Cursor(0, 18),
+        direction=SearchDirection.BACKWARD,
+    )
+    # n in backward mode = continue backward
+    hit = state.repeat(buf, at=Cursor(0, 12))
+    assert hit is not None
+    assert hit.at == Cursor(0, 8)
+
+
+def test_search_with_regex_special_chars() -> None:
+    buf = VimBuffer("class Foo:\n  def bar():\n    pass")
+    hit = find_next(
+        buf, pattern=r"^\s+def\s+\w+", after=Cursor(0, 0)
+    )
+    # Search across newlines — multi-line pattern. Python's re by
+    # default doesn't span newlines without DOTALL or MULTILINE; our
+    # impl walks line-by-line so ``^`` matches at line start.
+    assert hit is not None
+    assert hit.at.row == 1


### PR DESCRIPTION
## Summary

Bundle of **standalone module additions** across ch13 phases 4-12 that share no integration surface with each other and don't touch `app.py`, `screens/repl.py`, `agent_bridge.py`, or `agent_loop.py`. Each module ships with unit tests; cross-cutting production wiring lives in a follow-up PR so this change merges cleanly into `main` regardless of order.

| Phase | Gap | What lands here |
|-------|-----|-----------------|
| 4 (wave-1 + wave-2) | #4 | `vim_buffer.py`, `vim_text_objects.py`, `vim_operators.py`, `vim_visual.py`, `vim_search.py` |
| 5 | #2 | `widgets/transcript_search.py` |
| 6 | #3 | `declared_cursor.py` |
| 7 | #8 | `screens/permission_modal.py` per-tool renderers |
| 8 | #9 | `screens/resume_conversation.py`, `screens/doctor.py` (placeholder) |
| 9 | #7 | `outputStyles/{loader,styles}.py` frontmatter + auto-discovery |
| 10 | #15 | `hyperlinks.py` + `widgets/messages/tool_result.py` |
| 11 | #10 | `frame_metrics.py` (no-op fast path when env-var unset) |
| 12 | #16 | `widgets/messages/assistant_thinking.py` + transcript_view shells |

## Test plan

- [x] **521 tests pass** — `tests/tui/` + `tests/parity/test_output_styles_parity.py`
- [x] No touch to `app.py`/`agent_bridge.py`/`agent_loop.py` — disjoint from the cross-cutting integration PR
- [x] Symmetric guard added to `transcript_view.append_assistant_chunk` (prevents thinking↔assistant mis-routing once Phase-12 dispatch wiring lands in the integration PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)