### PR TITLE
feat(ch17/phase0): startup profiler + cache-credit forwarding

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -13,6 +13,13 @@ from rich.table import Table
 
 def main():
     """CLI main entry point."""
+    # WI-0.1 (ch17 Phase 0): instrument cold-start phases. Env-gated by
+    # ``CLAUDE_CODE_PROFILE_STARTUP``; a no-op import + no-op call when
+    # disabled (~ns overhead). On exit the profiler writes a Markdown
+    # report to ``$CLAUDE_CONFIG_DIR/startup-perf/{session_id}.txt``.
+    from src.utils.startup_profiler import profile_checkpoint
+    profile_checkpoint("cli_main_entry")
+
     import os
     if os.environ.get("CLAWCODEX_DEBUG", "").lower() in ("1", "true", "yes"):
         import logging
@@ -44,6 +51,7 @@ def main():
 
     parser = _build_parser()
     args = parser.parse_args(argv)
+    profile_checkpoint("argparse_done")
 
     if args.version:
         from src import __version__
@@ -57,8 +65,10 @@ def main():
     # ``--dangerously-skip-permissions`` consistently. Mirrors
     # ``typescript/src/main.tsx:1383-1389``.
     _resolve_permission_state(args)
+    profile_checkpoint("permissions_resolved")
 
     if args.print:
+        profile_checkpoint("mode_dispatch_print")
         return _run_print_mode(args)
 
     # Interactive path: decide between the Textual TUI (new default) and the
@@ -72,8 +82,10 @@ def main():
     from src.entrypoints.tui import should_use_tui
 
     if should_use_tui(explicit_tui):
+        profile_checkpoint("mode_dispatch_tui")
         return _run_tui_mode(args)
 
+    profile_checkpoint("mode_dispatch_repl")
     return start_repl(
         stream=args.stream,
         permission_mode=args._resolved_permission_mode,

--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -4,6 +4,13 @@ Command system for Claw Codex.
 A complete reimplementation of Claude Code's command system.
 """
 
+# WI-0.1 (ch17 Phase 0): mark the moment the command-system package starts
+# import work. Placed before the heavy re-exports so the checkpoint's
+# delta-from-previous reflects the package's cost.
+from src.utils.startup_profiler import profile_checkpoint
+
+profile_checkpoint("command_system_imported")
+
 from .argument_substitution import parse_argument_names, substitute_arguments
 from .builtins import (
     CLEAR_COMMAND,

--- a/src/providers/anthropic_provider.py
+++ b/src/providers/anthropic_provider.py
@@ -19,6 +19,54 @@ except ModuleNotFoundError:  # pragma: no cover
 from .base import BaseProvider, ChatResponse, MessageInput, TextChunkCallback
 
 
+def _extract_usage_dict(usage: Any) -> dict[str, Any]:
+    """Build the ChatResponse.usage dict from an Anthropic SDK ``Usage`` object.
+
+    WI-0.2 (ch17 Phase 0): forwards prompt-cache credits and the
+    ``cache_creation`` 5m/1h breakdown so downstream consumers stop reading
+    0 from the dict. Mirrors TS ``services/api/claude.ts``'s usage handling
+    (chapter line 61: "Token counting is anchored on the API's actual
+    ``usage`` field ... accounting for prompt caching credits").
+
+    The chapter calls out four observability fields on the API response:
+      * ``cache_creation_input_tokens`` — top-level int.
+      * ``cache_read_input_tokens`` — top-level int.
+      * ``cache_creation.ephemeral_5m_input_tokens`` — sub-object.
+      * ``cache_creation.ephemeral_1h_input_tokens`` — sub-object.
+
+    Note on thinking tokens: the Anthropic Python SDK 0.88.0 ``Usage`` type
+    does NOT expose a thinking-token attribute (verified via
+    ``Usage.__annotations__``). Extended-thinking tokens live in content
+    blocks, not ``usage``, so they are not forwarded here. Extend this
+    helper if a future SDK adds the attribute.
+    """
+    if usage is None:
+        return {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        }
+
+    result: dict[str, Any] = {
+        "input_tokens": getattr(usage, "input_tokens", 0) or 0,
+        "output_tokens": getattr(usage, "output_tokens", 0) or 0,
+        "cache_creation_input_tokens": getattr(usage, "cache_creation_input_tokens", 0) or 0,
+        "cache_read_input_tokens": getattr(usage, "cache_read_input_tokens", 0) or 0,
+    }
+
+    # cache_creation breakdown — sub-object with ephemeral_5m / ephemeral_1h.
+    # Forwarded as a nested dict so consumers can attribute cache writes by TTL.
+    cache_creation = getattr(usage, "cache_creation", None)
+    if cache_creation is not None:
+        result["cache_creation"] = {
+            "ephemeral_5m_input_tokens": getattr(cache_creation, "ephemeral_5m_input_tokens", 0) or 0,
+            "ephemeral_1h_input_tokens": getattr(cache_creation, "ephemeral_1h_input_tokens", 0) or 0,
+        }
+
+    return result
+
+
 class AnthropicProvider(BaseProvider):
     """Anthropic Claude provider."""
 
@@ -67,10 +115,7 @@ class AnthropicProvider(BaseProvider):
         return ChatResponse(
             content=content_text,
             model=getattr(response, "model", self.model or ""),
-            usage={
-                "input_tokens": getattr(usage, "input_tokens", 0),
-                "output_tokens": getattr(usage, "output_tokens", 0),
-            },
+            usage=_extract_usage_dict(usage),
             finish_reason=str(getattr(response, "stop_reason", "stop")),
             tool_uses=tool_uses if tool_uses else None,
         )

--- a/src/tool_system/__init__.py
+++ b/src/tool_system/__init__.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# WI-0.1 (ch17 Phase 0): mark the moment the tool-system package starts
+# import work. Placed before the heavy re-exports so the checkpoint's
+# delta-from-previous reflects the package's cost.
+from src.utils.startup_profiler import profile_checkpoint
+
+profile_checkpoint("tool_system_imported")
+
 from .build_tool import (
     McpInfo,
     SearchOrReadResult,

--- a/src/utils/startup_profiler.py
+++ b/src/utils/startup_profiler.py
@@ -1,0 +1,178 @@
+"""Startup profiling instrumentation — gap #6 from ch17.
+
+Records named checkpoints with monotonic timestamps so cold-start latency
+sources can be attributed to specific phases. Mirrors TS
+``utils/startupProfiler.ts:65,123`` (``profileCheckpoint`` /
+``profileReport``) but emits to disk + stderr instead of Statsig (sampling
+is a follow-on).
+
+Usage::
+
+    from src.utils.startup_profiler import profile_checkpoint
+    profile_checkpoint("cli_main_entry")
+
+The function is a near-zero-cost no-op when ``CLAUDE_CODE_PROFILE_STARTUP``
+is unset; that gate is what makes call sites safe to scatter through the
+critical path. When the env var is truthy at process start, an ``atexit``
+handler writes the report to ``.claude/startup-perf/{session_id}.txt`` and
+emits a one-line stderr summary.
+
+The chapter's thesis (line 205): *"Measurement first, optimization second,
+always."* This module is what makes the rest of the ch17 plan data-driven.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+
+__all__ = [
+    "is_profiling_enabled",
+    "profile_checkpoint",
+    "profile_report",
+    "get_internal_phase_log",
+    "reset_profiler_for_test_only",
+]
+
+
+# Storage. List-of-tuples (name, perf_counter) keyed by call order; cheap.
+# Module-level so it survives across imports without a class instance.
+_phase_log: list[tuple[str, float]] = []
+
+# Gate state. Captured ONCE at module import so toggles mid-run don't
+# create asymmetric reports (some checkpoints recorded, others skipped).
+_PROFILING_ENABLED: bool = False
+
+# Session identifier for the output file. Uuid keeps concurrent runs
+# from clobbering each other.
+_SESSION_ID: str = uuid.uuid4().hex[:12]
+
+# Output directory. Lazy-created on first write; never read at import time.
+# Honors ``CLAUDE_CONFIG_DIR`` (matches the codebase's existing config-dir
+# resolution at ``src/memdir/paths.py:108`` ``get_claude_config_home_dir``).
+def _resolve_output_dir() -> Path:
+    override = os.environ.get("CLAUDE_CONFIG_DIR")
+    if override:
+        return Path(override).expanduser() / "startup-perf"
+    return Path.home() / ".claude" / "startup-perf"
+
+
+_OUTPUT_DIR = _resolve_output_dir()
+
+
+def _read_env_gate() -> bool:
+    """Truthy values: 1, true, yes (case-insensitive). Anything else: false."""
+    raw = os.environ.get("CLAUDE_CODE_PROFILE_STARTUP", "")
+    return raw.strip().lower() in {"1", "true", "yes"}
+
+
+_PROFILING_ENABLED = _read_env_gate()
+
+
+def is_profiling_enabled() -> bool:
+    """Whether ``CLAUDE_CODE_PROFILE_STARTUP`` was truthy at module import.
+
+    Latched at import time so a mid-run env-var change does not produce a
+    half-recorded report.
+    """
+    return _PROFILING_ENABLED
+
+
+def profile_checkpoint(name: str) -> None:
+    """Record a named checkpoint. No-op when profiling is disabled.
+
+    Cost when disabled: a single ``if`` and a function-call return — the
+    branch predictor will skip the recording path entirely on every call
+    after the first. Safe to scatter through hot paths without measurement
+    cost in the common (disabled) case.
+    """
+    if not _PROFILING_ENABLED:
+        return
+    _phase_log.append((name, time.perf_counter()))
+
+
+def profile_report() -> str:
+    """Build a Markdown-shaped report of recorded phases.
+
+    Each row: ``- {name}: {abs_ms:>7.2f}ms (+{delta_ms:>6.2f}ms since prior)``.
+    Returns an empty report if no checkpoints were recorded (typical when
+    ``CLAUDE_CODE_PROFILE_STARTUP`` is unset).
+    """
+    if not _phase_log:
+        return "# Startup Profile\n\n(no checkpoints recorded)\n"
+
+    base = _phase_log[0][1]
+    lines = ["# Startup Profile", ""]
+    lines.append(f"Session: `{_SESSION_ID}`  Phases: {len(_phase_log)}")
+    lines.append("")
+    lines.append("| Phase | Absolute (ms) | Delta (ms) |")
+    lines.append("|---|---:|---:|")
+    prev = base
+    for name, ts in _phase_log:
+        abs_ms = (ts - base) * 1000.0
+        delta_ms = (ts - prev) * 1000.0
+        lines.append(f"| {name} | {abs_ms:.2f} | {delta_ms:.2f} |")
+        prev = ts
+
+    total_ms = (_phase_log[-1][1] - base) * 1000.0
+    # Slowest phase by delta (excluding the first, which is always 0ms delta).
+    slowest = max(
+        (
+            (name, (ts - prev_ts) * 1000.0)
+            for prev_ts, (name, ts) in zip(
+                (entry[1] for entry in _phase_log),
+                _phase_log[1:],
+            )
+        ),
+        default=("none", 0.0),
+        key=lambda item: item[1],
+    )
+    lines.append("")
+    lines.append(f"Total: {total_ms:.2f}ms; slowest delta: {slowest[0]} ({slowest[1]:.2f}ms)")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def get_internal_phase_log() -> list[tuple[str, float]]:
+    """Return a copy of the recorded log. Used by tests and the report writer."""
+    return list(_phase_log)
+
+
+def reset_profiler_for_test_only() -> None:
+    """Wipe the phase log. Test-only escape hatch.
+
+    The production code path never calls this — the log accumulates for the
+    process lifetime and is written once on exit. Tests need to reset between
+    cases to avoid cross-test pollution.
+    """
+    _phase_log.clear()
+
+
+def _flush_on_exit() -> None:
+    """atexit handler: write the report to disk and emit a stderr summary.
+
+    Best-effort: any exception is swallowed — we never want profiling
+    instrumentation to break a process exit path.
+    """
+    if not _PROFILING_ENABLED or not _phase_log:
+        return
+    try:
+        _OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+        out_path = _OUTPUT_DIR / f"{_SESSION_ID}.txt"
+        out_path.write_text(profile_report(), encoding="utf-8")
+        base = _phase_log[0][1]
+        total_ms = (_phase_log[-1][1] - base) * 1000.0
+        sys.stderr.write(
+            f"startup: {len(_phase_log)} phases, total {total_ms:.0f}ms; "
+            f"report → {out_path}\n"
+        )
+    except Exception:
+        # Never let profiler I/O block process exit.
+        pass
+
+
+atexit.register(_flush_on_exit)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -170,6 +170,118 @@ class TestAnthropicProvider(unittest.TestCase):
         self.assertEqual(response.tool_uses[0]["name"], "Read")
 
 
+class TestAnthropicUsageForwarding(unittest.TestCase):
+    """WI-0.2 (ch17 Phase 0) — provider forwards prompt-cache credits + breakdown.
+
+    Without this, downstream consumers (``src/tasks/progress.py``,
+    ``src/agent/agent_tool_utils.py``, ``src/context_system/context_analyzer.py``)
+    that read ``usage["cache_creation_input_tokens"]`` / etc. always
+    observe 0 even when server-side prompt caching is engaged. The
+    chapter line 61 anchor — "Token counting is anchored on the API's
+    actual usage field ... accounting for prompt caching credits".
+    """
+
+    @staticmethod
+    def _make_response(usage):
+        response = MagicMock()
+        text_block = MagicMock()
+        text_block.type = "text"
+        text_block.text = "ok"
+        response.content = [text_block]
+        response.model = "claude-sonnet-4-20250514"
+        response.usage = usage
+        response.stop_reason = "end_turn"
+        return response
+
+    def test_cache_creation_input_tokens_forwarded(self):
+        provider = AnthropicProvider(api_key="test")
+        usage = MagicMock(
+            input_tokens=10, output_tokens=5,
+            cache_creation_input_tokens=1234, cache_read_input_tokens=0,
+            cache_creation=None,
+        )
+        cr = provider._build_chat_response(self._make_response(usage))
+        self.assertEqual(cr.usage["cache_creation_input_tokens"], 1234)
+
+    def test_cache_read_input_tokens_forwarded(self):
+        provider = AnthropicProvider(api_key="test")
+        usage = MagicMock(
+            input_tokens=10, output_tokens=5,
+            cache_creation_input_tokens=0, cache_read_input_tokens=9876,
+            cache_creation=None,
+        )
+        cr = provider._build_chat_response(self._make_response(usage))
+        self.assertEqual(cr.usage["cache_read_input_tokens"], 9876)
+
+    def test_missing_cache_fields_default_to_zero(self):
+        """Older SDK responses without cache fields → graceful 0."""
+        class OldUsage:
+            def __init__(self):
+                self.input_tokens = 10
+                self.output_tokens = 5
+        provider = AnthropicProvider(api_key="test")
+        cr = provider._build_chat_response(self._make_response(OldUsage()))
+        self.assertEqual(cr.usage["cache_creation_input_tokens"], 0)
+        self.assertEqual(cr.usage["cache_read_input_tokens"], 0)
+        self.assertNotIn("cache_creation", cr.usage)
+
+    def test_none_value_fields_default_to_zero(self):
+        """SDK ``int | None`` → forward 0 instead of None."""
+        provider = AnthropicProvider(api_key="test")
+        usage = MagicMock(
+            input_tokens=10, output_tokens=5,
+            cache_creation_input_tokens=None, cache_read_input_tokens=None,
+            cache_creation=None,
+        )
+        cr = provider._build_chat_response(self._make_response(usage))
+        self.assertEqual(cr.usage["cache_creation_input_tokens"], 0)
+        self.assertEqual(cr.usage["cache_read_input_tokens"], 0)
+
+    def test_cache_creation_breakdown_forwarded(self):
+        """``cache_creation`` sub-object's 5m/1h breakdown → nested dict."""
+        provider = AnthropicProvider(api_key="test")
+        cache_creation = MagicMock(
+            ephemeral_5m_input_tokens=100, ephemeral_1h_input_tokens=200,
+        )
+        usage = MagicMock(
+            input_tokens=10, output_tokens=5,
+            cache_creation_input_tokens=300, cache_read_input_tokens=0,
+            cache_creation=cache_creation,
+        )
+        cr = provider._build_chat_response(self._make_response(usage))
+        self.assertEqual(
+            cr.usage["cache_creation"],
+            {"ephemeral_5m_input_tokens": 100, "ephemeral_1h_input_tokens": 200},
+        )
+
+    def test_existing_input_output_tokens_regression(self):
+        provider = AnthropicProvider(api_key="test")
+        usage = MagicMock(
+            input_tokens=42, output_tokens=17,
+            cache_creation_input_tokens=0, cache_read_input_tokens=0,
+            cache_creation=None,
+        )
+        cr = provider._build_chat_response(self._make_response(usage))
+        self.assertEqual(cr.usage["input_tokens"], 42)
+        self.assertEqual(cr.usage["output_tokens"], 17)
+
+    def test_missing_usage_object_safe_default(self):
+        provider = AnthropicProvider(api_key="test")
+        response = MagicMock()
+        text_block = MagicMock()
+        text_block.type = "text"
+        text_block.text = "ok"
+        response.content = [text_block]
+        response.model = "claude-sonnet-4-20250514"
+        response.usage = None
+        response.stop_reason = "end_turn"
+        cr = provider._build_chat_response(response)
+        self.assertEqual(cr.usage["input_tokens"], 0)
+        self.assertEqual(cr.usage["output_tokens"], 0)
+        self.assertEqual(cr.usage["cache_creation_input_tokens"], 0)
+        self.assertEqual(cr.usage["cache_read_input_tokens"], 0)
+
+
 class TestOpenAIProvider(unittest.TestCase):
     """Test OpenAI provider."""
 

--- a/tests/test_startup_profiler.py
+++ b/tests/test_startup_profiler.py
@@ -1,0 +1,199 @@
+"""Tests for ``src/utils/startup_profiler.py`` — gap #6 (WI-0.1).
+
+The profiler is normally a process-level singleton with state captured at
+import. Tests reload the module per-case via ``importlib.reload`` so each
+test exercises a clean env-gate and a fresh phase log without leaking
+into other tests.
+
+Critic note (M10): the no-op-when-disabled assertion is structural
+(``get_internal_phase_log() == []``), not timing-based — Python function
+overhead jitters above the chapter's wall-clock thresholds on shared CI.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _fresh_profiler(env: dict[str, str] | None = None):
+    """Reload the profiler module under a clean environment.
+
+    Patches ``os.environ`` BEFORE the module reloads so the env-gate is
+    re-read against the patched dict. Returns the freshly-loaded module.
+    """
+    real_env = env if env is not None else {}
+    # Drop any cached copy so the import-time gate evaluation runs again.
+    sys.modules.pop("src.utils.startup_profiler", None)
+    with patch.dict("os.environ", real_env, clear=True):
+        return importlib.import_module("src.utils.startup_profiler")
+
+
+class TestStartupProfiler(unittest.TestCase):
+    """WI-0.1 acceptance tests."""
+
+    def tearDown(self):
+        """Disarm the module-level atexit handler for the next test/process.
+
+        The profiler registers ``_flush_on_exit`` at import time so it can
+        emit a report when the user's process exits. In tests, the LAST
+        test's state is what atexit sees when pytest exits — without this
+        cleanup, a test that left ``_PROFILING_ENABLED=True`` plus some
+        checkpoints would cause a real ``~/.claude/startup-perf/`` write
+        on every test-suite run. Resetting the module state in tearDown
+        keeps the test side-effect-free for the user's filesystem.
+        """
+        mod = sys.modules.get("src.utils.startup_profiler")
+        if mod is not None:
+            mod._PROFILING_ENABLED = False  # type: ignore[attr-defined]
+            mod.reset_profiler_for_test_only()
+
+    def test_records_two_entries_with_monotonic_timestamps(self):
+        mod = _fresh_profiler({"CLAUDE_CODE_PROFILE_STARTUP": "1"})
+        mod.reset_profiler_for_test_only()
+        mod.profile_checkpoint("a")
+        mod.profile_checkpoint("b")
+        log = mod.get_internal_phase_log()
+        self.assertEqual([name for name, _ in log], ["a", "b"])
+        self.assertLessEqual(log[0][1], log[1][1])
+
+    def test_report_returns_markdown_with_phase_deltas(self):
+        mod = _fresh_profiler({"CLAUDE_CODE_PROFILE_STARTUP": "1"})
+        mod.reset_profiler_for_test_only()
+        mod.profile_checkpoint("first")
+        mod.profile_checkpoint("second")
+        report = mod.profile_report()
+        self.assertIn("# Startup Profile", report)
+        self.assertIn("first", report)
+        self.assertIn("second", report)
+        # Delta column is present.
+        self.assertIn("Delta", report)
+
+    def test_is_profiling_enabled_reads_env_truthy_values(self):
+        for truthy in ("1", "true", "TRUE", "yes", "Yes"):
+            with self.subTest(value=truthy):
+                mod = _fresh_profiler({"CLAUDE_CODE_PROFILE_STARTUP": truthy})
+                self.assertTrue(
+                    mod.is_profiling_enabled(),
+                    f"{truthy!r} should be truthy",
+                )
+
+    def test_is_profiling_enabled_reads_env_falsy_values(self):
+        for falsy in ("0", "false", "no", "", "garbage"):
+            with self.subTest(value=falsy):
+                mod = _fresh_profiler({"CLAUDE_CODE_PROFILE_STARTUP": falsy})
+                self.assertFalse(
+                    mod.is_profiling_enabled(),
+                    f"{falsy!r} should be falsy",
+                )
+
+    def test_is_profiling_enabled_unset_env_is_falsy(self):
+        # No CLAUDE_CODE_PROFILE_STARTUP key in env at all.
+        mod = _fresh_profiler({})
+        self.assertFalse(mod.is_profiling_enabled())
+
+    def test_no_op_when_disabled_structural_assertion(self):
+        """Critic-resolved M10: zero-tolerance structural test, not timing.
+
+        When the env-gate is false, profile_checkpoint MUST NOT record any
+        entries — verified by inspecting the internal log directly. Avoids
+        the flake-prone ``<1µs per call`` wall-clock assertion the original
+        plan attempted.
+        """
+        mod = _fresh_profiler({})  # env unset, gate is false
+        mod.reset_profiler_for_test_only()
+        mod.profile_checkpoint("ignored_a")
+        mod.profile_checkpoint("ignored_b")
+        mod.profile_checkpoint("ignored_c")
+        self.assertEqual(mod.get_internal_phase_log(), [])
+
+    def test_atexit_handler_writes_to_disk_when_enabled(self):
+        mod = _fresh_profiler({"CLAUDE_CODE_PROFILE_STARTUP": "1"})
+        mod.reset_profiler_for_test_only()
+        mod.profile_checkpoint("setup")
+        mod.profile_checkpoint("done")
+
+        # Patch the output directory to a tmp path so we don't pollute
+        # the real ~/.claude. tmp_path-style isolation via tmpdir.
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_root = Path(tmpdir) / "startup-perf"
+            with patch.object(mod, "_OUTPUT_DIR", tmp_root):
+                mod._flush_on_exit()  # type: ignore[attr-defined]
+            files = list(tmp_root.glob("*.txt"))
+            self.assertEqual(len(files), 1, f"expected one report file, got {files!r}")
+            content = files[0].read_text(encoding="utf-8")
+            self.assertIn("setup", content)
+            self.assertIn("done", content)
+
+    def test_atexit_handler_no_write_when_disabled(self):
+        mod = _fresh_profiler({})  # gate false
+        mod.reset_profiler_for_test_only()
+        mod.profile_checkpoint("ignored")
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_root = Path(tmpdir) / "startup-perf"
+            with patch.object(mod, "_OUTPUT_DIR", tmp_root):
+                mod._flush_on_exit()  # type: ignore[attr-defined]
+            # Directory should not have been created at all.
+            self.assertFalse(
+                tmp_root.exists(),
+                "Disabled profiler must not touch the output directory",
+            )
+
+    def test_report_with_no_checkpoints_is_empty_skeleton(self):
+        mod = _fresh_profiler({"CLAUDE_CODE_PROFILE_STARTUP": "1"})
+        mod.reset_profiler_for_test_only()
+        report = mod.profile_report()
+        self.assertIn("no checkpoints recorded", report)
+
+    def test_atexit_handler_swallows_io_errors(self):
+        """Critic m1: atexit must NEVER raise — process exit must complete.
+
+        Patches ``Path.mkdir`` on the output directory to raise PermissionError
+        (a real-world failure mode when ``~/.claude`` is on a read-only mount
+        or owned by root). The handler must swallow the exception cleanly.
+        """
+        mod = _fresh_profiler({"CLAUDE_CODE_PROFILE_STARTUP": "1"})
+        mod.reset_profiler_for_test_only()
+        mod.profile_checkpoint("setup")
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_root = Path(tmpdir) / "startup-perf"
+            with patch.object(mod, "_OUTPUT_DIR", tmp_root):
+                with patch.object(
+                    type(tmp_root), "mkdir", side_effect=PermissionError("read-only")
+                ):
+                    # Must not raise — atexit must always complete.
+                    try:
+                        mod._flush_on_exit()  # type: ignore[attr-defined]
+                    except Exception as exc:
+                        self.fail(f"_flush_on_exit must swallow exceptions, got {exc!r}")
+            # No file written because mkdir failed.
+            self.assertFalse(tmp_root.exists())
+
+    def test_output_dir_honors_claude_config_dir_env(self):
+        """Critic m6: ``CLAUDE_CONFIG_DIR`` should redirect the report path."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mod = _fresh_profiler({
+                "CLAUDE_CODE_PROFILE_STARTUP": "1",
+                "CLAUDE_CONFIG_DIR": tmpdir,
+            })
+            self.assertEqual(
+                mod._OUTPUT_DIR,  # type: ignore[attr-defined]
+                Path(tmpdir) / "startup-perf",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Phase 0 of the ch17 performance refactor — instrumentation foundation that the remaining phases build on.

- **WI-0.1 startup profiler** (\`src/utils/startup_profiler.py\`): env-gated checkpoints (\`CLAUDE_CODE_PROFILE_STARTUP\`) with atexit Markdown report at \`\$CLAUDE_CONFIG_DIR/startup-perf/{session_id}.txt\`. Call sites in \`src/cli.py\`, \`src/tool_system/__init__.py\`, \`src/command_system/__init__.py\`.
- **WI-0.2 cache-credit forwarding** (\`src/providers/anthropic_provider.py\`): \`_extract_usage_dict\` helper forwards \`cache_creation_input_tokens\`, \`cache_read_input_tokens\`, and the \`cache_creation\` 5m/1h breakdown so downstream consumers stop reading 0 when server-side prompt caching is engaged.

## Test plan
- [x] \`tests/test_startup_profiler.py\` — 11 tests (env-gate truth table, structural no-op assertion, atexit handler, \`CLAUDE_CONFIG_DIR\` honor, IO error swallow).
- [x] \`tests/test_providers.py::TestAnthropicUsageForwarding\` — 7 tests (populated fields, missing fields default to 0, None values default to 0, breakdown forwarded, regression on existing input/output, missing usage object).
- [x] All 18 pass; no regressions to existing 33 provider tests.

## Series
This is PR 1 of 4. Sequential merge order:
1. **(this) phase0** — instrumentation foundation
2. phase1+2 — cache plumbing (cache_control markers + sticky latches)
3. phase4 — cold-start (deferred imports + fast-path dispatch + prefetch + preconnect)
4. phase5 — token + streaming (1M context + per-message budget + watchdog)

Subsequent PRs will rebase on top of this one after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)