### PR TITLE
feat(ch17/phase5): token + streaming hardening

### DIFF
--- a/src/models/context.py
+++ b/src/models/context.py
@@ -8,9 +8,39 @@ from .configs import get_model_config
 DEFAULT_CONTEXT_WINDOW = 200_000
 DEFAULT_MAX_OUTPUT_TOKENS = 8_192
 
+# WI-5.3: 1M context window via ``[1m]`` model-id suffix. Mirrors TS
+# ``utils/context.ts:54-55,98-100,129-134``. The suffix is a user-facing
+# opt-in (e.g., ``claude-opus-4-7[1m]``) on models that support 1M tokens.
+# At resolution time the suffix is stripped before the id reaches the API.
+ONE_MILLION_CONTEXT_TOKENS = 1_000_000
+ONE_MILLION_SUFFIX = "[1m]"
+
+
+def has_1m_context_suffix(model_id: str) -> bool:
+    """True if ``model_id`` ends with the opt-in ``[1m]`` suffix."""
+    return isinstance(model_id, str) and model_id.endswith(ONE_MILLION_SUFFIX)
+
+
+def strip_1m_context_suffix(model_id: str) -> str:
+    """Strip the ``[1m]`` suffix if present. Use before sending to the API.
+
+    The Anthropic API doesn't accept ``[1m]`` in the model field — it's a
+    Python-side opt-in marker. Strip before forwarding.
+    """
+    if has_1m_context_suffix(model_id):
+        return model_id[: -len(ONE_MILLION_SUFFIX)]
+    return model_id
+
 
 def get_context_window_for_model(model_id: str) -> int:
-    """Get the context window size for a model."""
+    """Get the context window size for a model.
+
+    Recognizes the ``[1m]`` opt-in suffix (WI-5.3) and returns 1_000_000
+    for any model with the suffix. Otherwise falls back to the per-model
+    config or the default 200K.
+    """
+    if has_1m_context_suffix(model_id):
+        return ONE_MILLION_CONTEXT_TOKENS
     config = get_model_config(model_id)
     if config:
         return config.context_window
@@ -18,8 +48,14 @@ def get_context_window_for_model(model_id: str) -> int:
 
 
 def get_model_max_output_tokens(model_id: str) -> int:
-    """Get the maximum output tokens for a model."""
-    config = get_model_config(model_id)
+    """Get the maximum output tokens for a model.
+
+    The ``[1m]`` suffix doesn't change max_output_tokens (only the input
+    context window). Strip the suffix and look up the underlying model's
+    output cap.
+    """
+    base_id = strip_1m_context_suffix(model_id)
+    config = get_model_config(base_id)
     if config:
         return config.max_output_tokens
     return DEFAULT_MAX_OUTPUT_TOKENS

--- a/src/providers/anthropic_provider.py
+++ b/src/providers/anthropic_provider.py
@@ -250,7 +250,16 @@ class AnthropicProvider(BaseProvider):
         on_text_chunk: TextChunkCallback | None = None,
         **kwargs
     ) -> ChatResponse:
-        """Stream Anthropic text chunks and return the final structured response."""
+        """Stream Anthropic text chunks and return the final structured response.
+
+        WI-5.2: wraps the stream with a ``StreamWatchdog`` that closes the
+        underlying HTTP response if no chunks arrive within
+        ``CLAUDE_STREAM_IDLE_TIMEOUT_MS`` (default 90 s). On timeout the
+        iterator raises; we catch it and fall back to the non-streaming
+        ``chat()`` path so the user gets an answer rather than a hung session.
+        """
+        from src.utils.stream_watchdog import StreamWatchdog
+
         model = self._get_model(**kwargs)
         max_tokens = kwargs.get("max_tokens", 4096)
         system = kwargs.pop("system", None)
@@ -261,25 +270,86 @@ class AnthropicProvider(BaseProvider):
         if tools:
             extra_kwargs["tools"] = tools
 
+        def _fallback_to_chat() -> ChatResponse:
+            """Re-issue the request without streaming (WI-5.2 recovery path).
+
+            Mirrors TS ``streamLatencyWatchdog.ts:resumeViaChatCompletion``.
+            Strips kwargs that ``chat`` already accepts as named args so we
+            don't double-pass them.
+            """
+            forwarded = {
+                k: v
+                for k, v in kwargs.items()
+                if k not in ["model", "max_tokens", "tools"]
+            }
+            return self.chat(
+                messages,
+                tools=tools,
+                **({"system": system} if system else {}),
+                **forwarded,
+                model=model,
+                max_tokens=max_tokens,
+            )
+
         streamed_text = ""
-        with client.messages.stream(
-            model=model,
-            max_tokens=max_tokens,
-            messages=anthropic_messages,
-            **({"system": system} if system else {}),
-            **extra_kwargs,
-            **{k: v for k, v in kwargs.items() if k not in ["model", "max_tokens", "tools"]},
-        ) as stream:
-            for text in stream.text_stream:
-                if not text:
-                    continue
-                streamed_text += text
-                if on_text_chunk is not None:
-                    on_text_chunk(text)
-            try:
-                final_message = stream.get_final_message()
-            except Exception:
-                final_message = None
+        watchdog_fired = False
+        final_message = None
+        try:
+            with client.messages.stream(
+                model=model,
+                max_tokens=max_tokens,
+                messages=anthropic_messages,
+                **({"system": system} if system else {}),
+                **extra_kwargs,
+                **{k: v for k, v in kwargs.items() if k not in ["model", "max_tokens", "tools"]},
+            ) as stream:
+                watchdog = StreamWatchdog(stream)
+                watchdog.arm()
+                try:
+                    for text in stream.text_stream:
+                        # Each chunk pushes the deadline forward.
+                        watchdog.reset()
+                        if not text:
+                            continue
+                        streamed_text += text
+                        if on_text_chunk is not None:
+                            on_text_chunk(text)
+                    try:
+                        final_message = stream.get_final_message()
+                    except Exception:
+                        final_message = None
+                finally:
+                    # Snapshot watchdog state INSIDE the finally so it
+                    # survives an exception propagating through the
+                    # iterator (close() raises mid-stream). Critic B1
+                    # caught this — otherwise the assignment was on a
+                    # line never reached during the exception path and
+                    # the fallback branch below ran with watchdog_fired
+                    # still False.
+                    watchdog_fired = watchdog.fired
+                    watchdog.disarm()
+        except Exception as streaming_exc:
+            # WI-5.2 fallback path: stream interrupted. If our watchdog
+            # triggered the interruption, fall back to non-streaming so
+            # the user still gets an answer. If the failure is something
+            # else (network/auth/etc.), re-raise the original.
+            if watchdog_fired:
+                try:
+                    return _fallback_to_chat()
+                except Exception as fallback_exc:
+                    # Recovery itself failed — surface BOTH causes so
+                    # observers see the original streaming error AND the
+                    # fallback failure that prevented recovery. Critic
+                    # M3 — bare ``except: pass`` swallowed the fallback
+                    # error and re-raised only the streaming one.
+                    raise fallback_exc from streaming_exc
+            raise
+
+        if watchdog_fired:
+            # Stream got interrupted but no exception escaped the
+            # with-block (close-side raced the iterator's normal exit).
+            # Fall back to non-streaming for the full answer.
+            return _fallback_to_chat()
 
         if final_message is not None:
             return self._build_chat_response(final_message)

--- a/src/providers/base.py
+++ b/src/providers/base.py
@@ -120,9 +120,16 @@ class BaseProvider(ABC):
             **kwargs: Keyword arguments that may contain 'model'
 
         Returns:
-            Model name to use
+            Model name to use. The optional ``[1m]`` opt-in suffix
+            (WI-5.3) is stripped here so the API receives a clean
+            model id; the suffix's only effect is driving
+            ``get_context_window_for_model`` to return 1M tokens.
         """
-        return kwargs.get("model", self.model)
+        # Late import to avoid a top-level dependency from base.py
+        # into the models package.
+        from src.models.context import strip_1m_context_suffix
+        raw = kwargs.get("model", self.model)
+        return strip_1m_context_suffix(raw) if raw else raw
 
     def _prepare_messages(self, messages: list[MessageInput]) -> list[dict[str, Any]]:
         """Convert provider messages to API dictionary format."""

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -411,8 +411,12 @@ def _dispatch_single_tool(
 ) -> UserMessage:
     """Dispatch a single tool and return the UserMessage result.
 
-    Uses tool.map_result_to_api() (mirrors TS mapToolResultToAPIMessage)
-    to convert structured output (e.g. file_unchanged) to API-ready text.
+    Routes through ``process_tool_result_block`` (mirrors TS Step 11 of
+    the execution pipeline at ``processToolResultBlock``) so the per-tool
+    persistence threshold AND the WI-5.1 per-message aggregate budget
+    both engage on the production path. The running aggregate is held on
+    ``tool_use_context.tool_result_chars_so_far`` (reset at the top of
+    each per-turn loop in :func:`query`).
     """
     try:
         call = ToolCall(
@@ -423,8 +427,47 @@ def _dispatch_single_tool(
         result = tool_registry.dispatch(call, tool_use_context)
 
         tool = find_tool_by_name(tools, block.name) if tools else None
+        metadata: dict[str, Any] = {}
+        if isinstance(result.output, dict):
+            metadata["tool_output"] = result.output
+
         if tool is not None:
-            api_block = tool.map_result_to_api(result.output, block.id)
+            # WI-5.1: route through ``process_tool_result_block`` so the
+            # 200K per-message aggregate cap is enforced. Without this
+            # call the production REPL ran ``map_result_to_api`` directly
+            # and never engaged the gate (critic B2).
+            #
+            # The read-decide-write on ``tool_result_chars_so_far`` is
+            # serialized via ``_aggregate_lock`` because ``_run_tools_partitioned``
+            # dispatches concurrency-safe tools (Read/Grep/Glob) via
+            # ``asyncio.to_thread`` (critic B6). The decision MUST be
+            # made on a fresh snapshot of the counter — otherwise N
+            # threads racing the read all see 0, all decide "under cap"
+            # and the cap is silently bypassed. ``process_tool_result_block``
+            # is called inside the critical section: for small blocks
+            # under threshold it just returns the block (no I/O); the
+            # rare persist-to-disk path runs while serialized but those
+            # are at most O(1) per turn (typically <5%).
+            from ..services.tool_execution.tool_result_persistence import (
+                compute_block_chars,
+                process_tool_result_block,
+                resolve_tool_results_dir,
+            )
+            tool_results_dir = resolve_tool_results_dir(tool_use_context)
+            with tool_use_context._aggregate_lock:
+                aggregate_so_far = tool_use_context.tool_result_chars_so_far
+                api_block = process_tool_result_block(
+                    tool,
+                    result.output,
+                    block.id,
+                    tool_results_dir=tool_results_dir,
+                    aggregate_chars_so_far=aggregate_so_far,
+                )
+                # Update the running aggregate AFTER the block is
+                # finalized (post-persistence, so the wrapper message
+                # size is what counts toward the budget — not the
+                # original 200K output).
+                tool_use_context.tool_result_chars_so_far += compute_block_chars(api_block)
             content_str = api_block.get("content", "")
             if not isinstance(content_str, str):
                 content_str = json.dumps(content_str, ensure_ascii=False)
@@ -435,12 +478,6 @@ def _dispatch_single_tool(
         else:
             content_str = str(result.output)
 
-        # Preserve the original tool output as in-process metadata so the
-        # REPL/TUI can render rich previews (Edit's structuredPatch is the
-        # current consumer). map_result_to_api strips it for the wire.
-        metadata: dict[str, Any] = {}
-        if isinstance(result.output, dict):
-            metadata["tool_output"] = result.output
         return UserMessage(
             content=[
                 ToolResultBlock(
@@ -539,6 +576,14 @@ async def query(params: QueryParams) -> AsyncGenerator[Message | StreamEvent, No
                 state.transition.reason if state.transition else "initial",
             )
         tool_use_context = state.tool_use_context
+        # WI-5.1: reset the per-message aggregate counter at each turn
+        # boundary. The 200K cap is PER USER MESSAGE (the next batch of
+        # tool_result blocks the model will see), not per session. Without
+        # this reset the counter grows monotonically and every tool result
+        # eventually gets persisted regardless of size. Mirrors TS
+        # ``toolResultStorage.ts:collectCandidatesByMessage`` which
+        # partitions evaluation by message.
+        tool_use_context.tool_result_chars_so_far = 0
         max_output_tokens_recovery_count = state.max_output_tokens_recovery_count
         has_attempted_reactive_compact = state.has_attempted_reactive_compact
         max_output_tokens_override = state.max_output_tokens_override

--- a/src/services/tool_execution/tool_execution.py
+++ b/src/services/tool_execution/tool_execution.py
@@ -308,8 +308,23 @@ async def _check_permissions_and_call_tool(
         )
 
         tool_results_dir = resolve_tool_results_dir(tool_use_context)
+        # WI-5.1: thread the per-message aggregate counter through. The
+        # function consults it to decide whether to force-persist a
+        # block that would push the running total past the cap. We then
+        # update the counter with the post-decision block size via
+        # ``compute_block_chars``.
+        from src.services.tool_execution.tool_result_persistence import (
+            compute_block_chars,
+        )
         tool_result_block = process_tool_result_block(
-            tool, result.data, tool_use_id, tool_results_dir=tool_results_dir,
+            tool,
+            result.data,
+            tool_use_id,
+            tool_results_dir=tool_results_dir,
+            aggregate_chars_so_far=tool_use_context.tool_result_chars_so_far,
+        )
+        tool_use_context.tool_result_chars_so_far += compute_block_chars(
+            tool_result_block,
         )
 
         resulting_messages.append(MessageUpdateLazy(

--- a/src/services/tool_execution/tool_result_persistence.py
+++ b/src/services/tool_execution/tool_result_persistence.py
@@ -35,6 +35,15 @@ log = logging.getLogger(__name__)
 # Mirrors typescript/src/constants/toolLimits.ts.
 DEFAULT_MAX_RESULT_SIZE_CHARS: int = 50_000
 
+# WI-5.1: per-message tool-result aggregate budget. TS constant at
+# ``typescript/src/constants/toolLimits.ts:49``. Prevents the
+# ``[Read, Read, Read, Read, Read]`` parallel-tool fan-out from blowing
+# the context budget in a single turn — five 40K results each fit under
+# the per-tool 50K threshold but sum to 200K, which is the per-message
+# aggregate cap. The Nth result that would push the running aggregate
+# past this cap is persisted to disk regardless of its individual size.
+MAX_TOOL_RESULTS_PER_MESSAGE_CHARS: int = 200_000
+
 # Preview size for the wrapper message — TS toolResultStorage.ts:109.
 PREVIEW_SIZE_BYTES: int = 2_000
 
@@ -316,20 +325,33 @@ def maybe_persist_large_tool_result(
     *,
     threshold: float,
     tool_results_dir: Path,
+    aggregate_chars_so_far: int = 0,
+    aggregate_cap: int = MAX_TOOL_RESULTS_PER_MESSAGE_CHARS,
 ) -> dict[str, Any]:
     """Apply per-tool persistence to a tool_result block.
 
     Mirrors ``maybePersistLargeToolResult`` in
     ``typescript/src/utils/toolResultStorage.ts:272-334``.
 
+    Returns the (possibly modified) block. Callers tracking the per-
+    message aggregate budget (WI-5.1) should use
+    ``compute_block_chars`` on the returned block + their running
+    counter; ``maybe_persist_large_tool_result`` itself uses the
+    ``aggregate_chars_so_far`` argument only to DECIDE whether to
+    persist a block that would otherwise pass the per-tool threshold
+    but push the running total past ``aggregate_cap``.
+
     Returns the original block unchanged when:
     - content is non-empty AND below ``threshold``
+      AND the running aggregate WOULD NOT exceed ``aggregate_cap``
     - content contains image blocks (those reach the model intact)
     - persistence fails (we surface the original rather than lose data)
 
     Returns a modified block (new ``content``) when:
     - content is empty → ``"(<tool_name> completed with no output)"``
     - content is large → wrapper message with size + path + preview
+    - the running aggregate WOULD exceed ``aggregate_cap`` after adding
+      this block (WI-5.1: persist-to-disk to keep total within budget)
     """
     content = tool_result_block.get("content")
 
@@ -347,7 +369,14 @@ def maybe_persist_large_tool_result(
         return tool_result_block
 
     size = _content_size(content)
-    if size <= threshold:
+
+    # WI-5.1: per-message aggregate gate. Even when this block alone is
+    # under ``threshold``, if adding it would push the running total
+    # over ``aggregate_cap`` we persist it to disk to keep the message
+    # within budget. The TS reference checks the aggregate at the same
+    # point per ``toolLimits.ts:49`` semantics.
+    aggregate_would_exceed = (aggregate_chars_so_far + size) > aggregate_cap
+    if size <= threshold and not aggregate_would_exceed:
         return tool_result_block
 
     tool_use_id = tool_result_block.get("tool_use_id") or _hash_id(content)
@@ -372,18 +401,37 @@ def maybe_persist_large_tool_result(
     return new_block
 
 
+def compute_block_chars(tool_result_block: dict[str, Any]) -> int:
+    """Return the char-size of a tool_result block's content.
+
+    Helper for WI-5.1 aggregate tracking. Use after
+    ``process_tool_result_block`` / ``maybe_persist_large_tool_result``
+    to update the running per-message aggregate counter.
+    """
+    return _content_size(tool_result_block.get("content"))
+
+
 def process_tool_result_block(
     tool: "Tool",
     tool_use_result: Any,
     tool_use_id: str,
     *,
     tool_results_dir: Path,
+    aggregate_chars_so_far: int = 0,
 ) -> dict[str, Any]:
     """Map a tool result to its API form and apply per-tool persistence.
 
     Mirrors ``processToolResultBlock`` in
     ``typescript/src/utils/toolResultStorage.ts:205-226``. The single entry
     point used by the execution pipeline (Step 11).
+
+    Backward-compat: returns just the block (not a tuple). The caller
+    threads the running aggregate counter via ``aggregate_chars_so_far``
+    so this function can decide whether to force-persist a block that
+    would otherwise pass the per-tool threshold but push the running
+    total past ``MAX_TOOL_RESULTS_PER_MESSAGE_CHARS``. Updating the
+    counter post-call is the caller's responsibility — use
+    ``compute_block_chars(returned_block)`` to measure.
     """
     tool_result_block = tool.map_result_to_api(tool_use_result, tool_use_id)
     threshold = get_persistence_threshold(tool.name, tool.max_result_size_chars)
@@ -392,6 +440,7 @@ def process_tool_result_block(
         tool.name,
         threshold=threshold,
         tool_results_dir=tool_results_dir,
+        aggregate_chars_so_far=aggregate_chars_so_far,
     )
 
 

--- a/src/tool_system/context.py
+++ b/src/tool_system/context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -82,6 +83,26 @@ class ToolContext:
     # for the chapter-10 task state machine; ``tasks`` continues to host
     # ``tasks_v2``/todo entries for the unrelated TaskCreate system.
     runtime_tasks: RuntimeTaskRegistry = field(default_factory=RuntimeTaskRegistry)
+    # WI-5.1: per-message tool-result aggregate counter. The execution
+    # pipeline (Step 11) reads + increments this each time a tool result
+    # is mapped to its API form; when the running total exceeds
+    # ``MAX_TOOL_RESULTS_PER_MESSAGE_CHARS`` (default 200K) the next
+    # result is persisted to disk regardless of its individual size.
+    # Reset to 0 between messages by the turn-loop dispatcher.
+    #
+    # ``_aggregate_lock`` synchronizes the read-decide-write across
+    # concurrent tool dispatches (critic B6). ``_run_tools_partitioned``
+    # uses ``asyncio.to_thread`` to fan out concurrency-safe tools (Read,
+    # Grep, Glob) — without this lock, N threads would all read 0, all
+    # decide their block is under the cap, and the per-message budget
+    # would be silently bypassed. The full read+decide+write runs
+    # serialized so the persistence decision uses the LIVE counter and
+    # the cap is strictly enforced. Cost: the rare persist-to-disk path
+    # serializes against the lock, but persists are O(1) per turn in
+    # typical workloads (the common case under-threshold returns the
+    # block without I/O).
+    tool_result_chars_so_far: int = 0
+    _aggregate_lock: threading.Lock = field(default_factory=threading.Lock)
     # Chapter-10 / Chunk F / WI-6.1 — agent-name registry. Maps the
     # human-readable ``name`` (passed via Agent({name: "researcher"}))
     # to the random ``agent_id`` returned by the spawn. SendMessage

--- a/src/utils/stream_watchdog.py
+++ b/src/utils/stream_watchdog.py
@@ -1,0 +1,184 @@
+"""WI-5.2: streaming watchdog for the Anthropic SDK ``messages.stream``.
+
+Mirrors TS ``services/api/claude.ts:1922`` (``CLAUDE_STREAM_IDLE_TIMEOUT_MS``,
+default 90 s). When no chunks arrive for ``timeout_s`` seconds the watchdog
+closes the underlying HTTP response, which interrupts the sync iterator and
+lets the provider fall back to non-streaming ``messages.create``.
+
+**Why threading.Timer, not asyncio.** The Anthropic Python SDK's
+``messages.stream()`` is a SYNCHRONOUS context manager (``with``, not
+``async with``); ``stream.text_stream`` is a synchronous iterator.
+``asyncio.wait_for`` requires the inner code path be awaitable — it
+can't wrap a synchronous generator. Switching the whole provider chain
+to ``AsyncAnthropic`` would cascade async into every call site of
+``chat_stream_response`` (query.py, engine.py, the turn loop). The
+plan WI-5.2 explicitly rejected that approach.
+
+The threading.Timer pattern: schedule a deadline; reset on each chunk;
+on timeout call ``stream.response.close()`` which causes the next
+iterator pull to raise. The provider catches the raise and falls back.
+
+**Known fragility (per Phase 2 critic R5).** If a future Anthropic SDK
+version adds retry/reconnect logic between ``stream.response.close()``
+and the next iterator pull, the close may be invisible — the iterator
+would silently continue against a fresh connection. Mitigation: test
+coverage exercises the timeout path against a synthetic stalled stream
+and verifies the fallback fires. Re-audit the SDK version when bumping.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import Any, Callable
+
+__all__ = [
+    "DEFAULT_STREAM_IDLE_TIMEOUT_S",
+    "StreamIdleTimeout",
+    "stream_idle_timeout_seconds",
+    "StreamWatchdog",
+]
+
+
+DEFAULT_STREAM_IDLE_TIMEOUT_S = 90.0
+
+
+def stream_idle_timeout_seconds() -> float:
+    """Resolve the idle-timeout from ``CLAUDE_STREAM_IDLE_TIMEOUT_MS`` env var.
+
+    Falls back to ``DEFAULT_STREAM_IDLE_TIMEOUT_S`` (90s) when the env var
+    is unset or malformed. Mirrors TS ``claude.ts:1922``.
+    """
+    raw = os.environ.get("CLAUDE_STREAM_IDLE_TIMEOUT_MS", "").strip()
+    if not raw:
+        return DEFAULT_STREAM_IDLE_TIMEOUT_S
+    try:
+        ms = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_STREAM_IDLE_TIMEOUT_S
+    if ms <= 0:
+        return DEFAULT_STREAM_IDLE_TIMEOUT_S
+    return ms / 1000.0
+
+
+class StreamIdleTimeout(Exception):
+    """Raised on the consumer-thread when the watchdog fires.
+
+    The provider catches this and falls back to non-streaming.
+    """
+
+
+class StreamWatchdog:
+    """Manage a per-stream idle deadline.
+
+    Usage::
+
+        watchdog = StreamWatchdog(stream, timeout_s=90.0)
+        try:
+            watchdog.arm()
+            for chunk in stream.text_stream:
+                watchdog.reset()  # got a chunk, push deadline back
+                ...
+        finally:
+            watchdog.disarm()
+
+    On timeout the watchdog's timer thread calls ``stream.response.close()``;
+    the next ``stream.text_stream`` pull raises. The provider catches
+    the raise and decides whether to fall back.
+    """
+
+    def __init__(self, stream: Any, *, timeout_s: float | None = None) -> None:
+        self._stream = stream
+        self._timeout_s = (
+            timeout_s if timeout_s is not None else stream_idle_timeout_seconds()
+        )
+        self._timer: threading.Timer | None = None
+        # Event raised when the timer fires — consumer can check
+        # ``watchdog.fired`` to distinguish a timeout from an SDK-side
+        # error in the fallback decision.
+        self._fired = threading.Event()
+        self._lock = threading.Lock()
+
+    @property
+    def fired(self) -> bool:
+        """True if the timeout fired (i.e., we triggered the stream close)."""
+        return self._fired.is_set()
+
+    def arm(self) -> None:
+        """Start the deadline. Idempotent: re-arming cancels the prior timer."""
+        with self._lock:
+            self._cancel_locked()
+            self._timer = self._make_timer_locked()
+            self._timer.start()
+
+    def reset(self) -> None:
+        """Push the deadline forward — called on every successful chunk."""
+        if self._fired.is_set():
+            return  # already timed out; reset is a no-op
+        with self._lock:
+            self._cancel_locked()
+            self._timer = self._make_timer_locked()
+            self._timer.start()
+
+    def disarm(self) -> None:
+        """Cancel the timer (call after the stream completes normally)."""
+        with self._lock:
+            self._cancel_locked()
+
+    def _make_timer_locked(self) -> threading.Timer:
+        """Build a new Timer bound to this exact instance for stale-fire
+        detection.
+
+        Critic M2: ``Timer.cancel()`` is a no-op once the timer's worker
+        thread has entered the callback. If ``reset()`` lands AFTER
+        ``_on_timeout`` started but BEFORE it took the lock, the cancel
+        does nothing and the callback proceeds to fire. To detect that
+        race we capture the timer object in a closure and have the
+        callback short-circuit if it isn't ``self._timer`` anymore.
+        """
+        timer: threading.Timer | None = None
+
+        def _callback() -> None:
+            self._on_timeout(timer)
+
+        timer = threading.Timer(self._timeout_s, _callback)
+        timer.daemon = True
+        return timer
+
+    def _cancel_locked(self) -> None:
+        if self._timer is not None:
+            try:
+                self._timer.cancel()
+            except Exception:
+                pass
+            self._timer = None
+
+    def _on_timeout(self, expected_timer: threading.Timer | None) -> None:
+        """Timer callback: mark fired, then close the stream's response.
+
+        The close causes the next iterator pull in the consumer thread
+        to raise. We swallow all close-side exceptions — the consumer's
+        catch is what matters.
+
+        Critic M2: short-circuit if the firing timer isn't the active one
+        (the consumer raced ``reset()`` past our cancel point).
+        """
+        with self._lock:
+            if self._timer is not expected_timer:
+                return
+            if self._fired.is_set():
+                return
+            self._fired.set()
+            self._timer = None
+            stream = self._stream
+        # Close the response OUTSIDE the lock — close() may block on
+        # network I/O and we shouldn't hold the lock during that.
+        try:
+            response = getattr(stream, "response", None)
+            if response is not None:
+                close = getattr(response, "close", None)
+                if callable(close):
+                    close()
+        except Exception:
+            # Best-effort: never let the close propagate out of the timer.
+            pass

--- a/tests/test_model_system.py
+++ b/tests/test_model_system.py
@@ -208,3 +208,58 @@ class TestAgentRouting:
     def test_no_config(self):
         model = get_model_for_agent("explore", parent_model="my-model")
         assert model == "my-model"
+
+
+class TestOneMillionContextSuffix:
+    """WI-5.3: ``[1m]`` model-id suffix opts into the 1M context window.
+
+    Mirrors TS ``utils/context.ts:54-55,98-100,129-134``. The suffix is a
+    Python-side marker that drives ``get_context_window_for_model`` to
+    return 1_000_000; it's stripped before the model id reaches the API.
+    """
+
+    def test_has_suffix_detects_opt_in(self):
+        from src.models.context import has_1m_context_suffix
+        assert has_1m_context_suffix("claude-opus-4-7[1m]")
+        assert not has_1m_context_suffix("claude-opus-4-7")
+        assert not has_1m_context_suffix("")
+        # Sentinel: middle-of-name occurrence is NOT the opt-in.
+        assert not has_1m_context_suffix("[1m]claude-opus-4-7")
+
+    def test_strip_removes_suffix(self):
+        from src.models.context import strip_1m_context_suffix
+        assert strip_1m_context_suffix("claude-opus-4-7[1m]") == "claude-opus-4-7"
+        # No-op when suffix absent.
+        assert strip_1m_context_suffix("claude-opus-4-7") == "claude-opus-4-7"
+        # No-op on empty/None-ish (defensive).
+        assert strip_1m_context_suffix("") == ""
+
+    def test_context_window_returns_1m_for_suffixed_model(self):
+        from src.models.context import get_context_window_for_model
+        assert get_context_window_for_model("claude-opus-4-7[1m]") == 1_000_000
+        # Without suffix, falls back to the per-model config or default.
+        assert get_context_window_for_model("claude-opus-4-7") == 200_000
+
+    def test_context_window_1m_works_on_unknown_models(self):
+        """The suffix is a universal opt-in; doesn't require a config entry."""
+        from src.models.context import get_context_window_for_model
+        assert get_context_window_for_model("future-model[1m]") == 1_000_000
+
+    def test_max_output_tokens_strips_suffix_before_config_lookup(self):
+        """[1m] doesn't change max_output_tokens — only context window."""
+        from src.models.context import get_model_max_output_tokens
+        base = get_model_max_output_tokens("claude-sonnet-4-20250514")
+        with_suffix = get_model_max_output_tokens("claude-sonnet-4-20250514[1m]")
+        assert base == with_suffix
+        assert base == 16_384
+
+    def test_provider_get_model_strips_suffix(self):
+        """``BaseProvider._get_model`` strips ``[1m]`` so the API never sees it."""
+        from src.providers.anthropic_provider import AnthropicProvider
+        provider = AnthropicProvider(api_key="test", model="claude-opus-4-7[1m]")
+        # ``_get_model`` is the resolver every chat/stream path goes through.
+        resolved = provider._get_model()
+        assert resolved == "claude-opus-4-7"
+        # And with an explicit override kwarg.
+        resolved2 = provider._get_model(model="claude-opus-4-6[1m]")
+        assert resolved2 == "claude-opus-4-6"

--- a/tests/test_stream_watchdog.py
+++ b/tests/test_stream_watchdog.py
@@ -1,0 +1,179 @@
+"""WI-5.2 acceptance tests — streaming watchdog.
+
+The chapter's pattern (TS ``claude.ts:1922``): if no chunks arrive for
+``CLAUDE_STREAM_IDLE_TIMEOUT_MS`` (default 90 s), abort the stream and
+fall back to non-streaming. Python uses ``threading.Timer`` to schedule
+the deadline (per the plan's WI-5.2 decision; asyncio was rejected
+because the SDK is sync).
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from src.utils.stream_watchdog import (
+    DEFAULT_STREAM_IDLE_TIMEOUT_S,
+    StreamWatchdog,
+    stream_idle_timeout_seconds,
+)
+
+
+class TestStreamIdleTimeoutResolution(unittest.TestCase):
+    """Env-var resolution for ``CLAUDE_STREAM_IDLE_TIMEOUT_MS``."""
+
+    def tearDown(self):
+        os.environ.pop("CLAUDE_STREAM_IDLE_TIMEOUT_MS", None)
+
+    def test_default_when_unset(self):
+        os.environ.pop("CLAUDE_STREAM_IDLE_TIMEOUT_MS", None)
+        self.assertEqual(stream_idle_timeout_seconds(), DEFAULT_STREAM_IDLE_TIMEOUT_S)
+        self.assertEqual(DEFAULT_STREAM_IDLE_TIMEOUT_S, 90.0)
+
+    def test_env_var_in_milliseconds(self):
+        os.environ["CLAUDE_STREAM_IDLE_TIMEOUT_MS"] = "30000"
+        self.assertEqual(stream_idle_timeout_seconds(), 30.0)
+
+    def test_malformed_env_falls_back_to_default(self):
+        os.environ["CLAUDE_STREAM_IDLE_TIMEOUT_MS"] = "not-a-number"
+        self.assertEqual(stream_idle_timeout_seconds(), DEFAULT_STREAM_IDLE_TIMEOUT_S)
+
+    def test_zero_falls_back_to_default(self):
+        os.environ["CLAUDE_STREAM_IDLE_TIMEOUT_MS"] = "0"
+        self.assertEqual(stream_idle_timeout_seconds(), DEFAULT_STREAM_IDLE_TIMEOUT_S)
+
+    def test_negative_falls_back_to_default(self):
+        os.environ["CLAUDE_STREAM_IDLE_TIMEOUT_MS"] = "-1"
+        self.assertEqual(stream_idle_timeout_seconds(), DEFAULT_STREAM_IDLE_TIMEOUT_S)
+
+
+class TestStreamWatchdogFires(unittest.TestCase):
+    """The watchdog fires after the idle deadline and closes the stream."""
+
+    def test_timer_does_not_fire_when_disarmed_quickly(self):
+        """``arm`` then ``disarm`` within the timeout → ``fired`` stays False."""
+        stream = MagicMock()
+        watchdog = StreamWatchdog(stream, timeout_s=10.0)
+        watchdog.arm()
+        watchdog.disarm()
+        # Tiny sleep to ensure any racing timer would have fired.
+        time.sleep(0.05)
+        self.assertFalse(watchdog.fired)
+        stream.response.close.assert_not_called()
+
+    def test_timer_fires_after_short_timeout(self):
+        """Set a 50ms timeout, don't reset, wait 200ms → fired + close called."""
+        stream = MagicMock()
+        watchdog = StreamWatchdog(stream, timeout_s=0.05)
+        watchdog.arm()
+        time.sleep(0.2)  # wait past the deadline
+        self.assertTrue(watchdog.fired)
+        stream.response.close.assert_called_once()
+        watchdog.disarm()  # cleanup
+
+    def test_reset_pushes_deadline_forward(self):
+        """Periodic ``reset`` calls prevent the timer from firing."""
+        stream = MagicMock()
+        watchdog = StreamWatchdog(stream, timeout_s=0.1)
+        watchdog.arm()
+        # Reset every 30ms for 200ms total → never let the deadline lapse.
+        for _ in range(7):
+            time.sleep(0.03)
+            watchdog.reset()
+        watchdog.disarm()
+        self.assertFalse(watchdog.fired)
+        stream.response.close.assert_not_called()
+
+    def test_close_failure_does_not_propagate(self):
+        """If ``response.close`` raises, the timer thread swallows it."""
+        stream = MagicMock()
+        stream.response.close.side_effect = RuntimeError("simulated close failure")
+        watchdog = StreamWatchdog(stream, timeout_s=0.05)
+        watchdog.arm()
+        time.sleep(0.2)
+        # No exception escaped to this thread — the timer thread swallowed it.
+        self.assertTrue(watchdog.fired)
+        watchdog.disarm()
+
+    def test_disarm_after_fire_is_safe(self):
+        """``disarm`` can be called after the timer has already fired."""
+        stream = MagicMock()
+        watchdog = StreamWatchdog(stream, timeout_s=0.05)
+        watchdog.arm()
+        time.sleep(0.2)
+        watchdog.disarm()  # Must not raise.
+
+    def test_response_none_safe(self):
+        """If the stream has no ``.response`` attribute, the timer no-ops cleanly."""
+        stream = object()  # bare object, no response
+        watchdog = StreamWatchdog(stream, timeout_s=0.05)
+        watchdog.arm()
+        time.sleep(0.2)
+        self.assertTrue(watchdog.fired)
+        watchdog.disarm()
+
+
+class TestWatchdogIntegrationWithProvider(unittest.TestCase):
+    """End-to-end check that the watchdog fallback path engages — critic
+    B1 caught the prior layout where the exception escaped before
+    ``watchdog_fired`` was assigned, so the fallback ``chat()`` was
+    never invoked.
+    """
+
+    def test_chat_stream_response_falls_back_on_watchdog_fire(self):
+        from unittest.mock import patch as _patch
+        from src.providers.anthropic_provider import AnthropicProvider
+
+        # Build a fake stream whose ``text_stream`` yields nothing for
+        # long enough that the watchdog fires, then raises (mirrors
+        # ``close()`` interrupting the iterator).
+        fake_response = MagicMock()
+        fake_response.close = MagicMock()
+
+        def slow_text_stream():
+            time.sleep(0.3)
+            # After watchdog fires + closes response, iteration should raise.
+            raise RuntimeError("stream closed by watchdog")
+            yield  # unreachable; makes this a generator
+
+        fake_stream = MagicMock()
+        fake_stream.text_stream = slow_text_stream()
+        fake_stream.response = fake_response
+
+        # The context manager returns our fake stream.
+        stream_cm = MagicMock()
+        stream_cm.__enter__ = MagicMock(return_value=fake_stream)
+        stream_cm.__exit__ = MagicMock(return_value=False)
+
+        fake_client = MagicMock()
+        fake_client.messages.stream.return_value = stream_cm
+
+        # Build a non-streaming fallback response. The provider's
+        # ``chat()`` method should be called when the watchdog fires.
+        fallback_response = MagicMock()
+        fallback_response.content = "fallback answer"
+
+        provider = AnthropicProvider(api_key="test")
+        provider.client = fake_client
+        # 50 ms idle deadline so the watchdog fires before slow_text_stream
+        # finishes its 300 ms sleep. Env var is the wire that the watchdog
+        # actually reads at instantiation, so we drive it from there.
+        with _patch.dict(os.environ, {"CLAUDE_STREAM_IDLE_TIMEOUT_MS": "50"}), \
+             _patch.object(provider, "chat", return_value=fallback_response) as mock_chat:
+            result = provider.chat_stream_response(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=None,
+                on_text_chunk=None,
+            )
+
+        self.assertEqual(result, fallback_response)
+        mock_chat.assert_called_once()
+        # Verify the close() ran (i.e., the watchdog actually fired).
+        fake_response.close.assert_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tool_result_budget.py
+++ b/tests/test_tool_result_budget.py
@@ -157,5 +157,419 @@ class TestApplyToolResultBudget(unittest.TestCase):
         self.assertEqual(saved, 0)
 
 
+class TestPerMessageAggregateBudget(unittest.TestCase):
+    """WI-5.1: per-message tool-result aggregate cap (200K chars).
+
+    Each block individually under the per-tool 50K threshold passes
+    through alone — but if FIVE such blocks (5×40K=200K) all reach the
+    message, the context budget is blown. This class verifies the
+    aggregate gate at ``maybe_persist_large_tool_result``.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.tool_results_dir = Path(self.tmpdir.name)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_under_budget_unchanged(self):
+        """Aggregate counter below cap → block passes through unchanged."""
+        from src.services.tool_execution.tool_result_persistence import (
+            maybe_persist_large_tool_result,
+        )
+        block = {"type": "tool_result", "tool_use_id": "1", "content": "x" * 30_000}
+        result = maybe_persist_large_tool_result(
+            block,
+            tool_name="Read",
+            threshold=50_000,
+            tool_results_dir=self.tool_results_dir,
+            aggregate_chars_so_far=10_000,
+        )
+        self.assertEqual(result["content"], "x" * 30_000)
+
+    def test_at_budget_threshold_persisted(self):
+        """Adding a block that pushes past 200K → persisted to disk."""
+        from src.services.tool_execution.tool_result_persistence import (
+            maybe_persist_large_tool_result,
+        )
+        block = {"type": "tool_result", "tool_use_id": "2", "content": "x" * 40_000}
+        result = maybe_persist_large_tool_result(
+            block,
+            tool_name="Read",
+            threshold=50_000,
+            tool_results_dir=self.tool_results_dir,
+            aggregate_chars_so_far=180_000,
+        )
+        self.assertIn("<persisted-output>", result["content"])
+        self.assertNotEqual(result["content"], "x" * 40_000)
+
+    def test_simulated_five_parallel_reads_at_40k(self):
+        """Five 40K reads sum to exactly 200K — at-cap, not over → all pass."""
+        from src.services.tool_execution.tool_result_persistence import (
+            compute_block_chars, maybe_persist_large_tool_result,
+        )
+        running = 0
+        results = []
+        for i in range(5):
+            block = {"type": "tool_result", "tool_use_id": str(i), "content": "x" * 40_000}
+            result = maybe_persist_large_tool_result(
+                block,
+                tool_name="Read",
+                threshold=50_000,
+                tool_results_dir=self.tool_results_dir,
+                aggregate_chars_so_far=running,
+            )
+            running += compute_block_chars(result)
+            results.append(result)
+        # All five pass through (cumulative 200K == cap, not > cap).
+        for r in results:
+            self.assertEqual(r["content"], "x" * 40_000)
+
+    def test_six_parallel_reads_triggers_persistence(self):
+        """Six × 40K = 240K > 200K → 6th block persisted."""
+        from src.services.tool_execution.tool_result_persistence import (
+            maybe_persist_large_tool_result,
+        )
+        block = {"type": "tool_result", "tool_use_id": "6", "content": "x" * 40_000}
+        result = maybe_persist_large_tool_result(
+            block,
+            tool_name="Read",
+            threshold=50_000,
+            tool_results_dir=self.tool_results_dir,
+            aggregate_chars_so_far=200_000,
+        )
+        self.assertIn("<persisted-output>", result["content"])
+
+    def test_max_constant_value(self):
+        from src.services.tool_execution.tool_result_persistence import (
+            MAX_TOOL_RESULTS_PER_MESSAGE_CHARS,
+        )
+        self.assertEqual(MAX_TOOL_RESULTS_PER_MESSAGE_CHARS, 200_000)
+
+    def test_compute_block_chars_returns_size(self):
+        from src.services.tool_execution.tool_result_persistence import (
+            compute_block_chars,
+        )
+        self.assertEqual(
+            compute_block_chars({"content": "hello"}),
+            5,
+        )
+
+    def test_tool_use_context_carries_aggregate_field(self):
+        """``ToolContext.tool_result_chars_so_far`` defaults to 0."""
+        from src.tool_system.context import ToolContext
+        ctx = ToolContext(workspace_root=Path("/tmp"))
+        self.assertEqual(ctx.tool_result_chars_so_far, 0)
+
+    def test_query_loop_resets_aggregate_each_turn(self):
+        """WI-5.1 (post-Phase 5 critic M1): the counter MUST reset at each
+        turn boundary, otherwise a session monotonically grows it and
+        every tool result eventually persists regardless of size.
+
+        Mirrors TS ``toolResultStorage.ts:collectCandidatesByMessage`` —
+        each user message is a fresh aggregate budget.
+
+        Structural AST test (post-Phase-5 critic M1, refined by M5):
+        walk the AST of ``query.py`` and assert the assignment
+        ``tool_use_context.tool_result_chars_so_far = 0`` has a
+        ``while True:`` ancestor. This catches the most realistic
+        refactor failure (hoisting the reset out of the loop body so it
+        runs at most once per ``query()`` call). It does NOT verify
+        reachability or relative ordering — the assignment could
+        theoretically sit after a return or in dead code and the test
+        would still pass. Manual placement at the top of the loop body
+        is the contract; this test guards the structural half.
+        """
+        import ast
+        from pathlib import Path
+        query_src = Path(__file__).parent.parent / "src" / "query" / "query.py"
+        tree = ast.parse(query_src.read_text())
+
+        # Find every ``tool_use_context.tool_result_chars_so_far = 0`` and
+        # check it is structurally inside a ``while True:`` loop body.
+        target_assignments: list[ast.Assign] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if len(node.targets) != 1:
+                continue
+            target = node.targets[0]
+            if not isinstance(target, ast.Attribute):
+                continue
+            if target.attr != "tool_result_chars_so_far":
+                continue
+            if not isinstance(target.value, ast.Name):
+                continue
+            if target.value.id != "tool_use_context":
+                continue
+            if not isinstance(node.value, ast.Constant) or node.value.value != 0:
+                continue
+            target_assignments.append(node)
+
+        self.assertGreater(
+            len(target_assignments), 0,
+            "WI-5.1 per-turn reset missing from query.py — "
+            "tool_use_context.tool_result_chars_so_far = 0 not found",
+        )
+
+        # Build a parent map and verify each reset has a ``while True:``
+        # ancestor before reaching the function body.
+        parent_of: dict[ast.AST, ast.AST] = {}
+        for parent in ast.walk(tree):
+            for child in ast.iter_child_nodes(parent):
+                parent_of[child] = parent
+
+        def _has_while_true_ancestor(node: ast.AST) -> bool:
+            cursor: ast.AST | None = parent_of.get(node)
+            while cursor is not None:
+                if isinstance(cursor, ast.While):
+                    cond = cursor.test
+                    is_while_true = (
+                        isinstance(cond, ast.Constant) and cond.value is True
+                    )
+                    if is_while_true:
+                        return True
+                cursor = parent_of.get(cursor)
+            return False
+
+        in_loop = [a for a in target_assignments if _has_while_true_ancestor(a)]
+        self.assertGreater(
+            len(in_loop), 0,
+            "Reset must be INSIDE a ``while True:`` loop body — "
+            "otherwise it runs at most once at function entry and the "
+            "counter grows across turns",
+        )
+
+
+class TestProductionPathBudgetEnforcement(unittest.TestCase):
+    """WI-5.1 critic B2: the production REPL routes tool execution through
+    ``query._dispatch_single_tool``. That function MUST go through
+    ``process_tool_result_block`` so the aggregate gate engages — the
+    prior layout called ``tool.map_result_to_api()`` directly, leaving
+    the 200K cap unenforced in production.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.tool_results_dir = Path(self.tmpdir.name)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_dispatch_single_tool_increments_aggregate_counter(self):
+        """A successful tool dispatch must bump
+        ``tool_use_context.tool_result_chars_so_far``.
+        """
+        from unittest.mock import MagicMock, patch as _patch
+        from src.query.query import _dispatch_single_tool
+        from src.tool_system.context import ToolContext
+        from src.types.content_blocks import ToolUseBlock
+
+        # Fake tool that returns a 30K-char string.
+        big_output = "x" * 30_000
+        fake_tool = MagicMock()
+        fake_tool.name = "Read"
+        fake_tool.max_result_size_chars = 50_000
+        fake_tool.map_result_to_api = MagicMock(
+            return_value={
+                "type": "tool_result",
+                "tool_use_id": "block-1",
+                "content": big_output,
+            }
+        )
+
+        fake_registry = MagicMock()
+        result_obj = MagicMock()
+        result_obj.output = big_output
+        result_obj.is_error = False
+        fake_registry.dispatch = MagicMock(return_value=result_obj)
+
+        ctx = ToolContext(workspace_root=self.tool_results_dir)
+        ctx.tool_result_chars_so_far = 0
+
+        block = ToolUseBlock(id="block-1", name="Read", input={})
+
+        with _patch(
+            "src.services.tool_execution.tool_result_persistence.resolve_tool_results_dir",
+            return_value=self.tool_results_dir,
+        ):
+            _dispatch_single_tool(block, fake_registry, ctx, tools=[fake_tool])
+
+        # Counter must reflect the block we just processed.
+        self.assertGreater(
+            ctx.tool_result_chars_so_far, 0,
+            "WI-5.1 critic B2: production path didn't increment the aggregate counter",
+        )
+
+    def test_dispatch_concurrent_does_not_bypass_cap(self):
+        """Critic B6: under parallel ``asyncio.to_thread`` dispatch (the
+        production path for concurrency-safe tools like Read/Grep/Glob),
+        N threads racing the counter read MUST NOT all see 0 and all
+        decide their block is under the cap. The ``_aggregate_lock`` on
+        ``ToolContext`` serializes the read-modify-write.
+
+        Test design:
+        - 6 dispatches run via ``asyncio.to_thread``.
+        - A ``threading.Barrier`` aligns all threads at the start of the
+          WI-5.1 read-modify-write region so they ALL hit the counter
+          at the same moment.
+        - ``compute_block_chars`` is patched to ``time.sleep`` BETWEEN
+          the lock'd read and the lock'd write, forcing GIL releases
+          and widening the race window deterministically across CPython
+          versions.
+        - With 6 × 40K-char blocks (240K total > 200K cap), the test
+          asserts (a) every write reflects in the final counter (no
+          lost updates), and (b) at least one block was persisted.
+        """
+        import asyncio
+        import threading
+        import time
+        from unittest.mock import MagicMock, patch as _patch
+        from src.query.query import _dispatch_single_tool
+        from src.tool_system.context import ToolContext
+        from src.types.content_blocks import ToolUseBlock
+
+        big_output = "x" * 40_000
+        barrier = threading.Barrier(6)
+
+        def synced_dispatch(call, ctx):
+            barrier.wait(timeout=5.0)
+            r = MagicMock()
+            r.output = big_output
+            r.is_error = False
+            return r
+
+        fake_registry = MagicMock()
+        fake_registry.dispatch.side_effect = synced_dispatch
+
+        fake_tool = MagicMock()
+        fake_tool.name = "Read"
+        fake_tool.max_result_size_chars = 50_000
+
+        def fake_map(output, block_id):
+            return {
+                "type": "tool_result",
+                "tool_use_id": block_id,
+                "content": output,
+            }
+        fake_tool.map_result_to_api.side_effect = fake_map
+
+        ctx = ToolContext(workspace_root=self.tool_results_dir)
+
+        blocks = [
+            ToolUseBlock(id=f"b{i}", name="Read", input={})
+            for i in range(6)
+        ]
+
+        # Patch ``compute_block_chars`` to sleep so the read-modify-write
+        # path releases the GIL and the race window opens
+        # deterministically. Importantly we patch the name as it's
+        # resolved in ``src.query.query`` (since that's how
+        # ``_dispatch_single_tool`` imports it).
+        from src.services.tool_execution import tool_result_persistence as _trp
+
+        original_compute = _trp.compute_block_chars
+
+        def slow_compute(block):
+            time.sleep(0.02)  # 20 ms — far exceeds any GIL switch interval
+            return original_compute(block)
+
+        async def run_parallel():
+            async def dispatch_one(b):
+                return await asyncio.to_thread(
+                    _dispatch_single_tool, b, fake_registry, ctx, [fake_tool]
+                )
+            return await asyncio.gather(*(dispatch_one(b) for b in blocks))
+
+        with _patch(
+            "src.services.tool_execution.tool_result_persistence.resolve_tool_results_dir",
+            return_value=self.tool_results_dir,
+        ), _patch(
+            "src.services.tool_execution.tool_result_persistence.compute_block_chars",
+            side_effect=slow_compute,
+        ):
+            results = asyncio.run(run_parallel())
+
+        # After 6 × 40K = 240K of inline content, the final counter
+        # should reflect ALL writes (no lost updates). With the lock,
+        # every write goes through ``+=`` under serialization — so the
+        # sum equals the actual block sizes. Without the lock, races
+        # lose writes (every thread reads 0 → counter = ONE block's
+        # worth, not six).
+        self.assertEqual(
+            ctx.tool_result_chars_so_far,
+            sum(len(r.content[0].content) for r in results),
+            "Concurrent writes lost updates — aggregate counter doesn't "
+            "reflect every block's contribution. Lock is missing or "
+            "broken.",
+        )
+        # And at least one block must be persisted: the 240K total
+        # exceeds the 200K cap by 40K.
+        persisted_count = sum(
+            1
+            for msg in results
+            if "<persisted-output>" in msg.content[0].content
+        )
+        self.assertGreater(
+            persisted_count, 0,
+            "Critic B6: concurrent dispatch bypassed the WI-5.1 cap — "
+            "240K of inline content reached the message instead of "
+            "persisting the over-budget tail to disk",
+        )
+
+    def test_dispatch_aggregate_triggers_persistence_when_over_cap(self):
+        """When the running aggregate would push past 200K, the next block
+        is persisted to disk instead of returned inline.
+        """
+        from unittest.mock import MagicMock, patch as _patch
+        from src.query.query import _dispatch_single_tool
+        from src.tool_system.context import ToolContext
+        from src.types.content_blocks import ToolUseBlock
+
+        # 30K output that alone fits under per-tool 50K threshold.
+        big_output = "x" * 30_000
+        fake_tool = MagicMock()
+        fake_tool.name = "Read"
+        fake_tool.max_result_size_chars = 50_000
+        fake_tool.map_result_to_api = MagicMock(
+            return_value={
+                "type": "tool_result",
+                "tool_use_id": "block-2",
+                "content": big_output,
+            }
+        )
+
+        fake_registry = MagicMock()
+        result_obj = MagicMock()
+        result_obj.output = big_output
+        result_obj.is_error = False
+        fake_registry.dispatch = MagicMock(return_value=result_obj)
+
+        ctx = ToolContext(workspace_root=self.tool_results_dir)
+        # Running aggregate already at 190K — the new 30K block must
+        # trigger persistence to keep the message within budget.
+        ctx.tool_result_chars_so_far = 190_000
+
+        block = ToolUseBlock(id="block-2", name="Read", input={})
+
+        with _patch(
+            "src.services.tool_execution.tool_result_persistence.resolve_tool_results_dir",
+            return_value=self.tool_results_dir,
+        ):
+            user_message = _dispatch_single_tool(
+                block, fake_registry, ctx, tools=[fake_tool]
+            )
+
+        # The returned UserMessage's tool_result content should be the
+        # ``<persisted-output>`` wrapper, NOT the raw 30K output.
+        content = user_message.content[0].content
+        self.assertIn(
+            "<persisted-output>", content,
+            "WI-5.1 critic B2: aggregate gate didn't fire on production path "
+            "— large block returned inline instead of persisted",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Implements ch17 Phase 5 work items WI-5.1, WI-5.2, WI-5.3. Final PR in the ch17 performance series.

### Work items

- **WI-5.1** — Per-message tool-result aggregate budget (200K chars cap). Engages on the production path (`query._dispatch_single_tool`) via `process_tool_result_block`. Full read+decide+write runs under `ToolContext._aggregate_lock` to handle concurrent `asyncio.to_thread` dispatch.
- **WI-5.2** — Streaming watchdog (`StreamWatchdog` using `threading.Timer`). On timeout, calls `stream.response.close()` and falls back to non-streaming `chat()`. Stale-fire detection prevents race with `reset()`.
- **WI-5.3** — 1M context window opt-in via `[1m]` model suffix. `get_context_window_for_model()` returns 1M for suffixed models; provider `_get_model()` strips the suffix before the API call.

### Critic review (3 rounds)

| Round | Findings | Resolution |
|-------|----------|------------|
| 1 | B1 (watchdog fallback never fires — `finally` swallowed the snapshot), B2 (WI-5.1 bypassed in production path), M1-M4 | Moved snapshot into `finally:`, routed `_dispatch_single_tool` through `process_tool_result_block`, AST-walk test for M1, stale-fire detection for M2, exception chaining for M3, integration test for M4 |
| 2 | B6 (new race: concurrent `asyncio.to_thread` dispatch all read 0 between writes) | Added `_aggregate_lock` to `ToolContext`, full critical section wraps the entire read+decide+write |
| 3 | N8 docstring inconsistency | Tightened doc to match strict-cap semantics |

Final verdict: **APPROVE**. Test verified: replacing the lock with the racy pattern reproduces `counter=40000 instead of 240000` — exactly matching the prior bug reproducer.

## Test plan

- [x] 79 Phase 5 tests pass (test_model_system, test_stream_watchdog, test_tool_result_budget)
- [x] Full suite: 4245 passed, 4 skipped
- [x] Concurrent regression test uses `threading.Barrier(6)` + patched `compute_block_chars` to widen the race window deterministically
- [x] AST-based reset placement test for WI-5.1 per-turn reset

## Sequence

Fifth and final PR in the ch17 series:
- #50 — Phase 0 instrumentation
- #51 — Phase 1+2 cache plumbing
- #52 — Phase 4 cold-start latency
- #53 — Phase 3 search speed
- **#this — Phase 5 token + streaming hardening**

🤖 Generated with [Claude Code](https://claude.com/claude-code)