### PR TITLE
ch15/mcp PR 1/5: Foundation — Path A SDK adoption + Phase 0/2/3/6a/7/8 base

### DIFF
--- a/src/services/mcp/__init__.py
+++ b/src/services/mcp/__init__.py
@@ -1,15 +1,21 @@
 from .client import McpClient, clear_connection_cache, connect_to_server
 from .config import (
+    add_dynamic_mcp_config,
     add_mcp_config,
+    dedup_claudeai_mcp_servers,
     filter_mcp_servers_by_policy,
     get_all_mcp_configs,
+    get_dynamic_mcp_configs,
+    get_managed_mcp_configs,
     get_mcp_config_by_name,
     get_mcp_configs_by_scope,
     is_mcp_server_disabled,
     parse_mcp_config,
     parse_mcp_config_from_file_path,
+    remove_dynamic_mcp_config,
     remove_mcp_config,
     set_mcp_server_enabled,
+    unwrap_ccr_proxy_url,
 )
 from .env_expansion import expand_env_vars_in_string
 from .errors import McpAuthError, McpSessionExpiredError, McpToolCallError
@@ -27,7 +33,18 @@ from .mcp_string_utils import (
 )
 from .normalization import normalize_name_for_mcp
 from .tool_wrapper import wrap_mcp_tool, wrap_mcp_tools_for_server
-from .transport import HttpTransport, JsonRpcMessage, McpTransport, SseTransport, StdioTransport
+from .in_process_transport import (
+    InProcessTransport,
+    create_linked_transport_pair,
+)
+from .transport import (
+    HttpTransport,
+    JsonRpcMessage,
+    McpTransport,
+    SseTransport,
+    StdioTransport,
+    WebSocketTransport,
+)
 from .types import (
     ConfigScope,
     ConnectedMCPServer,
@@ -61,6 +78,9 @@ __all__ = [
     "StdioTransport",
     "SseTransport",
     "HttpTransport",
+    "WebSocketTransport",
+    "InProcessTransport",
+    "create_linked_transport_pair",
     "McpStdioServerConfig",
     "McpSSEServerConfig",
     "McpHTTPServerConfig",
@@ -101,6 +121,12 @@ __all__ = [
     "is_mcp_server_disabled",
     "set_mcp_server_enabled",
     "filter_mcp_servers_by_policy",
+    "unwrap_ccr_proxy_url",
+    "dedup_claudeai_mcp_servers",
+    "add_dynamic_mcp_config",
+    "remove_dynamic_mcp_config",
+    "get_dynamic_mcp_configs",
+    "get_managed_mcp_configs",
     "ConnectionAttemptResult",
     "get_mcp_tools_commands_and_resources",
     "prefetch_all_mcp_resources",

--- a/src/services/mcp/auth.py
+++ b/src/services/mcp/auth.py
@@ -70,31 +70,301 @@ def _generate_pkce() -> tuple[str, str]:
     return verifier, challenge
 
 
+KEYRING_SERVICE = "claude-code-mcp"
+# Stored separately so we can enumerate ``list_servers`` (the keyring API
+# doesn't iterate by service). Updated atomically alongside the keyring.
+KEYRING_INDEX_FILENAME = "mcp_token_index.json"
+
+
+def _serialize_token(token: TokenData) -> str:
+    return json.dumps({
+        "access_token": token.access_token,
+        "token_type": token.token_type,
+        "refresh_token": token.refresh_token,
+        "expires_at": token.expires_at,
+        "scope": token.scope,
+    })
+
+
+def _deserialize_token(raw: str) -> TokenData:
+    data = json.loads(raw)
+    return TokenData(
+        access_token=data["access_token"],
+        token_type=data.get("token_type", "Bearer"),
+        refresh_token=data.get("refresh_token"),
+        expires_at=data.get("expires_at"),
+        scope=data.get("scope"),
+    )
+
+
 class McpTokenStore:
+    """OAuth-token storage backed by the OS keychain (Phase 4 WI-4.2, gap #5).
+
+    Mirrors TS' platform-native secure storage pattern (macOS Keychain,
+    Linux secret-service, Windows DPAPI) — replaces the previous
+    plaintext ``~/.claude/mcp_tokens.json`` file (a security regression
+    vs TS that the gap analysis flagged as a blocker).
+
+    Backend detection: if ``keyring`` resolves to ``FailKeyring`` (no
+    secure backend available — uncommon on developer machines but does
+    happen on stripped-down CI environments), we **fail loudly** rather
+    than silently regress to plaintext. Operators who explicitly want
+    plaintext can opt in via ``MCP_ALLOW_PLAINTEXT_TOKEN_STORAGE=1``;
+    that path is intentionally awkward to discover.
+
+    A small index file (``~/.claude/mcp_token_index.json``) tracks the
+    set of server names whose tokens are stored — the keyring API does
+    not iterate by service, so we need a side-channel to implement
+    ``list_servers``. The index contains only names, never tokens.
+
+    On first init, any pre-existing plaintext ``mcp_tokens.json`` is
+    migrated into the keyring and the file is renamed to
+    ``mcp_tokens.json.legacy`` with a one-time INFO log. Two release
+    cycles later the migration shim can be deleted.
+    """
+
     def __init__(self, store_path: Path | None = None) -> None:
-        self._path = store_path or _get_token_store_path()
-        self._tokens: dict[str, dict[str, Any]] = {}
-        self._load()
+        # ``store_path`` is retained for API compatibility (and to drive
+        # the legacy-migration source). The index lives next to the
+        # legacy path, with a name derived from store_path's stem so
+        # tempfile-based tests get isolated index files even when they
+        # all live under the same /tmp directory.
+        self._legacy_path = store_path or _get_token_store_path()
+        if store_path is not None:
+            # Test path: index sits alongside the test's tempfile and
+            # shares its stem so concurrent tempfiles don't collide.
+            self._index_path = store_path.with_suffix(store_path.suffix + ".index")
+        else:
+            self._index_path = self._legacy_path.parent / KEYRING_INDEX_FILENAME
+        self._index: set[str] = self._load_index()
+        self._using_plaintext_fallback = False
+        self._validate_backend()
+        self._migrate_legacy_if_present()
 
-    def _load(self) -> None:
-        if self._path.exists():
-            try:
-                self._tokens = json.loads(self._path.read_text(encoding="utf-8"))
-            except (json.JSONDecodeError, OSError):
-                self._tokens = {}
+    @staticmethod
+    def _allow_plaintext_fallback() -> bool:
+        return os.environ.get("MCP_ALLOW_PLAINTEXT_TOKEN_STORAGE", "").strip() == "1"
 
-    def _save(self) -> None:
+    def _validate_backend(self) -> None:
         try:
-            self._path.parent.mkdir(parents=True, exist_ok=True)
-            self._path.write_text(
-                json.dumps(self._tokens, indent=2),
-                encoding="utf-8",
+            import keyring
+            from keyring.backends.fail import Keyring as FailKeyring
+        except ImportError as exc:  # pragma: no cover - keyring is a hard dep
+            raise RuntimeError(
+                "MCP token storage requires the 'keyring' Python package. "
+                "Install with: pip install keyring"
+            ) from exc
+        backend = keyring.get_keyring()
+        if isinstance(backend, FailKeyring):
+            if self._allow_plaintext_fallback():
+                logger.warning(
+                    "MCP token storage: no secure keyring backend available "
+                    "(%s); falling back to plaintext storage at %s because "
+                    "MCP_ALLOW_PLAINTEXT_TOKEN_STORAGE=1 was set. THIS IS "
+                    "INSECURE — tokens will be readable to any process "
+                    "running as this user.",
+                    type(backend).__name__, self._legacy_path,
+                )
+                self._using_plaintext_fallback = True
+                return
+            raise RuntimeError(
+                "MCP token storage requires a secure keyring backend "
+                "(macOS Keychain, Linux secret-service, or Windows DPAPI), "
+                "but none is available on this system. Set "
+                "MCP_ALLOW_PLAINTEXT_TOKEN_STORAGE=1 to opt into plaintext "
+                "storage instead — note that this is insecure."
             )
-        except OSError as e:
-            logger.warning("Failed to save token store: %s", e)
+
+    def _load_index(self) -> set[str]:
+        if not self._index_path.exists():
+            return set()
+        try:
+            data = json.loads(self._index_path.read_text(encoding="utf-8"))
+            if isinstance(data, list):
+                return set(str(s) for s in data)
+        except (json.JSONDecodeError, OSError):
+            pass
+        return set()
+
+    def _save_index(self) -> None:
+        # Atomic write: tmp-file + rename so a crash mid-write doesn't
+        # leave a corrupt JSON document that ``_load_index`` would have
+        # to silently swallow on next start (losing the entire index).
+        try:
+            self._index_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._index_path.with_suffix(self._index_path.suffix + ".tmp")
+            tmp.write_text(json.dumps(sorted(self._index), indent=2), encoding="utf-8")
+            os.replace(tmp, self._index_path)
+        except OSError as exc:
+            logger.warning("Failed to save MCP token index: %s", exc)
+
+    def _migrate_legacy_if_present(self) -> None:
+        if not self._legacy_path.exists():
+            return
+        # Critical: when plaintext fallback is active, the legacy file IS
+        # the live plaintext store. Migrating-then-renaming would archive
+        # all data and leave the store empty. Skip migration entirely.
+        if self._using_plaintext_fallback:
+            return
+        try:
+            raw = self._legacy_path.read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            logger.warning("MCP legacy token read failed: %s", exc)
+            return
+        if not raw:
+            # Empty file isn't a migration source (and isn't an error); the
+            # noisy "Expecting value" warning would mislead operators.
+            return
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.warning("MCP legacy token migration failed: %s", exc)
+            return
+        if not isinstance(data, dict) or not data:
+            return
+        migrated = 0
+        dropped: list[str] = []
+        for server_name, token_data in data.items():
+            if not isinstance(server_name, str) or not isinstance(token_data, dict):
+                dropped.append(repr(server_name))
+                continue
+            try:
+                token = TokenData(
+                    access_token=token_data["access_token"],
+                    token_type=token_data.get("token_type", "Bearer"),
+                    refresh_token=token_data.get("refresh_token"),
+                    expires_at=token_data.get("expires_at"),
+                    scope=token_data.get("scope"),
+                )
+            except KeyError:
+                dropped.append(server_name)
+                continue
+            self.store_token(server_name, token)
+            migrated += 1
+        if dropped:
+            logger.warning(
+                "MCP legacy token migration: skipped %d malformed entr%s: %s",
+                len(dropped), "y" if len(dropped) == 1 else "ies", dropped,
+            )
+        if migrated:
+            # Pick a non-colliding archive suffix so a previous migration's
+            # backup is preserved. POSIX rename clobbers silently, which
+            # would destroy a recoverable copy.
+            archive = self._pick_legacy_archive_path()
+            try:
+                self._legacy_path.rename(archive)
+            except OSError as exc:
+                logger.warning(
+                    "Migrated %d MCP tokens to keyring but failed to rename "
+                    "legacy plaintext file %s: %s",
+                    migrated, self._legacy_path, exc,
+                )
+            else:
+                logger.info(
+                    "Migrated %d MCP token(s) from legacy plaintext file "
+                    "%s to keyring; legacy file renamed to %s. Delete it "
+                    "after verifying.",
+                    migrated, self._legacy_path, archive,
+                )
+
+    def _pick_legacy_archive_path(self) -> Path:
+        """Return a path of the form ``mcp_tokens.json.legacy[.N]`` that
+        does not collide with an existing file. Bounds the search at 100
+        attempts; a real corruption scenario won't approach that count."""
+        base = self._legacy_path.with_suffix(self._legacy_path.suffix + ".legacy")
+        if not base.exists():
+            return base
+        for n in range(1, 100):
+            candidate = base.with_suffix(base.suffix + f".{n}")
+            if not candidate.exists():
+                return candidate
+        # Pathological — fall back to base and let rename clobber as a
+        # last resort. Not reachable in practice.
+        return base  # pragma: no cover
+
+    # --- Public API -------------------------------------------------------
 
     def get_token(self, server_name: str) -> TokenData | None:
-        data = self._tokens.get(server_name)
+        if self._using_plaintext_fallback:
+            return self._get_token_plaintext(server_name)
+        try:
+            import keyring
+
+            raw = keyring.get_password(KEYRING_SERVICE, server_name)
+        except Exception as exc:
+            logger.warning("MCP keyring lookup failed for %r: %s", server_name, exc)
+            return None
+        if raw is None:
+            return None
+        try:
+            return _deserialize_token(raw)
+        except (json.JSONDecodeError, KeyError) as exc:
+            logger.warning("MCP keyring entry for %r is malformed: %s", server_name, exc)
+            return None
+
+    def store_token(self, server_name: str, token: TokenData) -> None:
+        if self._using_plaintext_fallback:
+            self._store_token_plaintext(server_name, token)
+            return
+        try:
+            import keyring
+            from keyring.errors import KeyringError
+
+            keyring.set_password(KEYRING_SERVICE, server_name, _serialize_token(token))
+        except KeyringError as exc:
+            logger.error("MCP keyring write failed for %r: %s", server_name, exc)
+            raise
+        self._index.add(server_name)
+        self._save_index()
+
+    def remove_token(self, server_name: str) -> bool:
+        if self._using_plaintext_fallback:
+            return self._remove_token_plaintext(server_name)
+        try:
+            import keyring
+            from keyring.errors import PasswordDeleteError
+
+            keyring.delete_password(KEYRING_SERVICE, server_name)
+            removed = True
+        except PasswordDeleteError:
+            # Backend confirmed the entry isn't there. Index can be
+            # safely cleaned (a stale index entry would survive otherwise).
+            removed = False
+        except Exception as exc:
+            # Transient backend failure: keyring may still hold the entry.
+            # Do NOT mutate the index; otherwise list_servers() would lie
+            # about what's actually stored. Caller can retry.
+            logger.warning("MCP keyring delete failed for %r: %s", server_name, exc)
+            return False
+        if server_name in self._index:
+            self._index.discard(server_name)
+            self._save_index()
+        return removed
+
+    def list_servers(self) -> list[str]:
+        if self._using_plaintext_fallback:
+            return list(self._plaintext_tokens().keys())
+        return sorted(self._index)
+
+    def clear(self) -> None:
+        for name in list(self._index):
+            self.remove_token(name)
+        if self._using_plaintext_fallback:
+            self._clear_plaintext()
+
+    # --- Plaintext fallback (only when explicitly opted in) ---------------
+
+    def _plaintext_tokens(self) -> dict[str, dict[str, Any]]:
+        if not self._legacy_path.exists():
+            return {}
+        try:
+            data = json.loads(self._legacy_path.read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else {}
+        except (json.JSONDecodeError, OSError):
+            return {}
+
+    def _get_token_plaintext(self, server_name: str) -> TokenData | None:
+        data = self._plaintext_tokens().get(server_name)
         if data is None:
             return None
         return TokenData(
@@ -105,29 +375,37 @@ class McpTokenStore:
             scope=data.get("scope"),
         )
 
-    def store_token(self, server_name: str, token: TokenData) -> None:
-        self._tokens[server_name] = {
+    def _store_token_plaintext(self, server_name: str, token: TokenData) -> None:
+        tokens = self._plaintext_tokens()
+        tokens[server_name] = {
             "access_token": token.access_token,
             "token_type": token.token_type,
             "refresh_token": token.refresh_token,
             "expires_at": token.expires_at,
             "scope": token.scope,
         }
-        self._save()
+        try:
+            self._legacy_path.parent.mkdir(parents=True, exist_ok=True)
+            self._legacy_path.write_text(json.dumps(tokens, indent=2), encoding="utf-8")
+        except OSError as exc:
+            logger.warning("MCP plaintext token write failed: %s", exc)
 
-    def remove_token(self, server_name: str) -> bool:
-        if server_name in self._tokens:
-            del self._tokens[server_name]
-            self._save()
+    def _remove_token_plaintext(self, server_name: str) -> bool:
+        tokens = self._plaintext_tokens()
+        if server_name in tokens:
+            del tokens[server_name]
+            try:
+                self._legacy_path.write_text(json.dumps(tokens, indent=2), encoding="utf-8")
+            except OSError as exc:
+                logger.warning("MCP plaintext token write failed: %s", exc)
             return True
         return False
 
-    def list_servers(self) -> list[str]:
-        return list(self._tokens.keys())
-
-    def clear(self) -> None:
-        self._tokens.clear()
-        self._save()
+    def _clear_plaintext(self) -> None:
+        try:
+            self._legacy_path.write_text("{}", encoding="utf-8")
+        except OSError as exc:
+            logger.warning("MCP plaintext token clear failed: %s", exc)
 
 
 class McpAuthManager:

--- a/src/services/mcp/client.py
+++ b/src/services/mcp/client.py
@@ -7,13 +7,19 @@ import os
 import time
 from typing import Any, Callable
 
-from .errors import McpAuthError, McpSessionExpiredError, McpToolCallError
+from .errors import (
+    McpAuthError,
+    McpSessionExpiredError,
+    McpToolCallError,
+    is_mcp_session_expired_error,
+)
 from .transport import (
     HttpTransport,
     JsonRpcMessage,
     McpTransport,
     SseTransport,
     StdioTransport,
+    WebSocketTransport,
 )
 from .types import (
     ConnectedMCPServer,
@@ -35,9 +41,34 @@ from .types import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MCP_TOOL_TIMEOUT_MS = 100_000_000
+# Tool-call timeout: 5 minutes default, mirrors TS canonical
+# (typescript/src/services/mcp/client.ts:DEFAULT_MCP_TOOL_TIMEOUT_MS = 300_000).
+# Operators raise via the MCP_TOOL_TIMEOUT env override when a long-running
+# tool (e.g. a deep agentic search) needs a longer cap. The chapter
+# (§"Timeout Architecture") notes ~27.8h as the upper-bound budget for
+# legitimately long operations; that's the cap, not the default.
+DEFAULT_MCP_TOOL_TIMEOUT_MS = 300_000  # 5 min
 MAX_MCP_DESCRIPTION_LENGTH = 2048
 DEFAULT_CONNECTION_TIMEOUT_MS = 30_000
+
+
+def _unwrap_exception_group_message(exc: BaseException) -> str:
+    """Extract the most actionable error string from a (possibly nested)
+    ``BaseExceptionGroup``.
+
+    The SDK's anyio task groups wrap real connection errors (e.g.
+    ``ConnectionRefusedError``) in ``BaseExceptionGroup``, whose ``str()``
+    is the opaque ``"unhandled errors in a TaskGroup (1 sub-exception)"``.
+    Walk the group tree and return the leaf exception's message — that's
+    what the user actually needs to debug an unreachable server.
+    """
+    try:
+        eg_cls = BaseExceptionGroup  # 3.11+ builtin  # type: ignore[name-defined]
+    except NameError:  # pragma: no cover - Python < 3.11
+        return str(exc) or type(exc).__name__
+    if isinstance(exc, eg_cls) and exc.exceptions:
+        return _unwrap_exception_group_message(exc.exceptions[0])
+    return str(exc) or type(exc).__name__
 
 
 def _get_connection_timeout_ms() -> int:
@@ -74,6 +105,14 @@ class McpClient:
         self._connected = False
         self._resource_cache: dict[str, list[dict[str, Any]]] = {}
         self._on_disconnect: Callable[[], None] | None = None
+        # Phase 6a WI-6.1: serialize concurrent session-expiry recovery.
+        # When N parallel call_tool invocations all hit the same expired
+        # session, we want exactly one reconnect, not N. The lock + epoch
+        # counter ("session generation") implement double-checked recovery:
+        # only the first coroutine to take the lock reconnects; the others
+        # observe the bumped generation and skip the reconnect step.
+        self._recovery_lock: asyncio.Lock | None = None
+        self._session_generation = 0
 
     def _next_id(self) -> int:
         self._request_id += 1
@@ -176,7 +215,7 @@ class McpClient:
             )
             return FailedMCPServer(
                 name=name,
-                error=str(e),
+                error=_unwrap_exception_group_message(e),
                 config=config,
             )
 
@@ -198,7 +237,10 @@ class McpClient:
                 headers=config.headers,
             )
         elif isinstance(config, McpWebSocketServerConfig):
-            raise NotImplementedError("WebSocket transport not yet implemented")
+            return WebSocketTransport(
+                url=config.url,
+                headers=config.headers,
+            )
         else:
             raise ValueError(f"Unsupported server config type: {type(config).__name__}")
 
@@ -209,6 +251,16 @@ class McpClient:
             while self._transport.is_connected:
                 msg = await self._transport.receive()
                 if msg is None:
+                    # Transport closed cleanly. Reject any in-flight futures
+                    # so concurrent callers fail fast instead of waiting out
+                    # the full tool-call timeout (5 min default). Without
+                    # this, a `receive() → None` after a peer-side close left
+                    # every pending request silently hung.
+                    closed_exc = ConnectionError("MCP transport closed")
+                    for future in self._pending_requests.values():
+                        if not future.done():
+                            future.set_exception(closed_exc)
+                    self._pending_requests.clear()
                     break
                 if msg.id is not None and msg.id in self._pending_requests:
                     future = self._pending_requests.pop(msg.id)
@@ -295,7 +347,26 @@ class McpClient:
         }
         if meta:
             params["_meta"] = meta
-        result = await self._send_request("tools/call", params)
+
+        # Phase 6a WI-6.1 (gap #8): on Streamable-HTTP session expiry,
+        # the chapter §"Session Expiry Detection" specifies clear-cache +
+        # retry-once. Mirrors typescript/src/services/mcp/client.ts: the
+        # cache is cleared on detection so the next request reconnects
+        # against a fresh session rather than reusing the expired one.
+        try:
+            result = await self._send_request("tools/call", params)
+        except McpToolCallError as err:
+            if not is_mcp_session_expired_error(err):
+                # Regular tool error (invalid params, server-rejected, etc.) —
+                # propagate untouched. No reconnect, no retry.
+                raise
+            await self._recover_from_session_expiry(err, tool_name=tool_name)
+            # Retry once after the recovery routine returned (it either
+            # reconnected, or another concurrent caller did, or recovery
+            # failed and re-raised). A second session-expired here means
+            # the server is unstable / the retry hit a fresh session that
+            # already expired — propagate so we don't loop indefinitely.
+            result = await self._send_request("tools/call", params)
         if not result or not isinstance(result, dict):
             return McpToolResult()
 
@@ -321,6 +392,61 @@ class McpClient:
             meta=result_meta,
             structured_content=structured,
         )
+
+    async def _recover_from_session_expiry(
+        self,
+        original_error: Exception,
+        *,
+        tool_name: str | None = None,
+    ) -> None:
+        """Serialize concurrent session-expiry recovery via lock + epoch.
+
+        When N parallel callers all observe the same expired session, we
+        want exactly one reconnect, not N. The lock implements double-
+        checked recovery: only the first coroutine to take the lock
+        reconnects; the others observe the bumped ``_session_generation``
+        and return immediately, letting their retry path proceed against
+        the freshly-reconnected transport.
+
+        On reconnect failure, all waiters re-raise ``original_error`` so
+        the caller sees the session-expiry signal in context (rather than
+        a misleading reconnect-related error).
+
+        Phase 6a WI-6.1 (gap #8). Scope: invoked from ``call_tool`` only;
+        ``list_tools`` / ``list_resources`` / ``list_prompts`` /
+        ``initialize`` retain their previous propagate-on-error behavior.
+        Lifting recovery into ``_send_request`` to cover every JSON-RPC
+        method is tracked as a follow-up; the chapter §"Session Expiry
+        Detection" describes recovery as a tool-call concern.
+        """
+        # Lazy-init the lock so __init__ doesn't require a running loop.
+        if self._recovery_lock is None:
+            self._recovery_lock = asyncio.Lock()
+        gen_at_entry = self._session_generation
+        async with self._recovery_lock:
+            if self._session_generation != gen_at_entry:
+                # Another concurrent caller already reconnected for this
+                # session generation; nothing to do.
+                logger.info(
+                    "MCP %r tool %r: session expired (gen %d); piggybacking "
+                    "on concurrent reconnect (now gen %d)",
+                    self._name, tool_name, gen_at_entry, self._session_generation,
+                )
+                return
+            logger.info(
+                "MCP %r tool %r: session expired (gen %d); clearing cache + reconnecting",
+                self._name, tool_name, gen_at_entry,
+            )
+            if self._name is not None:
+                clear_connection_cache(self._name)
+            reconnected = await self.reconnect()
+            if not isinstance(reconnected, ConnectedMCPServer):
+                # Reconnect failed; bump the generation anyway so other
+                # waiters don't repeatedly try, and surface the original
+                # session-expired error to all callers.
+                self._session_generation += 1
+                raise original_error
+            self._session_generation += 1
 
     async def list_resources(self) -> list[dict[str, Any]]:
         if not self._capabilities.resources:
@@ -467,12 +593,50 @@ class McpClient:
 
 _connection_cache: dict[str, tuple[McpClient, MCPServerConnection]] = {}
 
+# Cache key separator: only needs to be unambiguous for the prefix-match in
+# ``clear_connection_cache`` (we never parse the key back). Any single char
+# that is unlikely to appear at the start of a server name works.
+_CACHE_KEY_SEP = "|"
+
+
+def _cache_key_for(name: str, config: ScopedMcpServerConfig) -> str:
+    """Compose a content-based cache key for a (name, config) pair.
+
+    Mirrors TS' connection-cache keying (typescript/src/services/mcp/
+    client.ts:600-606 uses ``${name}-${jsonStringify(serverRef)}`` — keying
+    on the **full** scoped config so that env vars / headers / scope all
+    participate). Two configs with the same ``command``/``args`` but
+    different ``env`` (e.g. different API keys) MUST produce distinct cache
+    keys; otherwise the second registration would silently reuse the first
+    server's authenticated connection — a credential-leak class bug.
+
+    NOTE: ``get_mcp_server_signature(...)`` is intentionally narrow — it
+    encodes only ``[command, args]`` for stdio or ``url`` for remote, so it
+    cannot be reused as a cache key without env/header collisions. Its
+    actual call sites (``config.py:dedup_plugin_mcp_servers``) are about
+    de-duplicating plugin servers that share a launch surface, not about
+    keying live connections.
+    """
+    from dataclasses import asdict, is_dataclass
+
+    inner = config.config
+    if is_dataclass(inner):
+        payload = {
+            "scope": config.scope,
+            "plugin_source": config.plugin_source,
+            "type": type(inner).__name__,
+            "config": asdict(inner),
+        }
+    else:  # pragma: no cover - defensive; all current configs are dataclasses
+        payload = {"scope": config.scope, "type": type(inner).__name__, "id": id(inner)}
+    return f"{name}{_CACHE_KEY_SEP}{json.dumps(payload, sort_keys=True, default=str)}"
+
 
 async def connect_to_server(
     name: str,
     config: ScopedMcpServerConfig,
 ) -> tuple[McpClient, MCPServerConnection]:
-    cache_key = f"{name}-{id(config)}"
+    cache_key = _cache_key_for(name, config)
     if cache_key in _connection_cache:
         client, conn = _connection_cache[cache_key]
         if isinstance(conn, ConnectedMCPServer) and client._transport and client._transport.is_connected:
@@ -490,6 +654,7 @@ def clear_connection_cache(name: str | None = None) -> None:
     if name is None:
         _connection_cache.clear()
     else:
-        keys_to_remove = [k for k in _connection_cache if k.startswith(f"{name}-")]
+        prefix = f"{name}{_CACHE_KEY_SEP}"
+        keys_to_remove = [k for k in _connection_cache if k.startswith(prefix)]
         for k in keys_to_remove:
             del _connection_cache[k]

--- a/src/services/mcp/config.py
+++ b/src/services/mcp/config.py
@@ -5,9 +5,11 @@ import logging
 import os
 import re
 import tempfile
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qs, unquote, urlparse
 
 from .env_expansion import expand_env_vars_in_string
 from .types import (
@@ -87,13 +89,77 @@ def _get_server_url(config: McpServerConfig) -> str | None:
     return None
 
 
+def unwrap_ccr_proxy_url(url: str) -> str:
+    """Extract the original vendor URL from a CCR-proxied URL.
+
+    Phase 7 WI-7.5 (gap #23). Mirrors typescript/src/services/mcp/
+    config.ts:unwrapCcrProxyUrl. CCR-proxied URLs encode the original
+    vendor URL in an ``mcp_url=...`` query parameter (URL-encoded). We
+    extract that param and return its value so dedup correctness holds:
+    a server reachable directly at ``https://vendor.example/mcp`` and
+    via ``https://ccr.proxy/mcp?mcp_url=...`` collapses to one entry.
+    Returns the input unchanged if the URL is not CCR-proxied, if the
+    wrapped value isn't a parseable URL, or if multiple ``mcp_url`` params
+    are present (refuse to guess).
+    """
+    if not url:
+        return url
+    try:
+        parsed = urlparse(url)
+        if not parsed.query:
+            return url
+        params = parse_qs(parsed.query, keep_blank_values=False)
+        wrapped = params.get("mcp_url")
+        if not wrapped:
+            return url
+        if len(wrapped) > 1:
+            logger.warning(
+                "MCP CCR-proxy unwrap: %d 'mcp_url' params present; refusing "
+                "to guess. Keeping original URL: %s",
+                len(wrapped), url,
+            )
+            return url
+        candidate = unquote(wrapped[0])
+        # Validate the unwrapped value is itself a URL with scheme + netloc;
+        # otherwise treat it as garbage and keep the original.
+        unwrapped_parsed = urlparse(candidate)
+        if not unwrapped_parsed.scheme or not unwrapped_parsed.netloc:
+            return url
+        return candidate
+    except (ValueError, TypeError):
+        return url
+
+
+def _normalize_url_for_signature(url: str) -> str:
+    """Lowercase host + strip a single trailing ``/`` from path so that
+    case-different / trailing-slash variants of the same URL produce the
+    same signature.
+
+    Per RFC 3986 §6.2.2, hostname comparison is case-insensitive; trailing
+    slash is path-equivalent for many MCP servers. Doesn't touch query or
+    fragment — those are already content-significant.
+    """
+    try:
+        parsed = urlparse(url)
+        if not parsed.scheme or not parsed.netloc:
+            return url
+        host_lower = parsed.netloc.lower()
+        path = parsed.path
+        if path.endswith("/") and len(path) > 1:
+            path = path[:-1]
+        rebuilt = parsed._replace(netloc=host_lower, path=path)
+        return rebuilt.geturl()
+    except (ValueError, TypeError):
+        return url
+
+
 def get_mcp_server_signature(config: McpServerConfig) -> str | None:
     cmd = _get_server_command_array(config)
     if cmd:
         return f"stdio:{json.dumps(cmd)}"
     url = _get_server_url(config)
     if url:
-        return f"url:{url}"
+        return f"url:{_normalize_url_for_signature(unwrap_ccr_proxy_url(url))}"
     return None
 
 
@@ -297,18 +363,75 @@ def parse_mcp_config_from_file_path(
 def get_mcp_configs_by_scope(
     scope: ConfigScope,
 ) -> tuple[dict[str, ScopedMcpServerConfig], list[ValidationError]]:
+    """Load MCP server configs for a single scope.
+
+    Scope semantics (Phase 7 WI-7.1, gap #9):
+      - ``local``: ``.mcp.json`` in the current working directory only.
+        Per the chapter, this scope requires user approval — currently
+        loaded unconditionally; future work can gate behind a workspace-
+        trust check (out of scope here).
+      - ``project``: ``.mcp.json`` files in **parent** directories of the
+        cwd, walked toward the filesystem root. Closest-parent-wins.
+        The cwd itself is intentionally excluded so it can be tagged
+        ``local`` with stricter approval semantics.
+      - ``user``: ``~/.claude/config.json``'s ``mcpServers`` field.
+      - ``enterprise``: ``/etc/claude/managed-mcp.json`` (or
+        ``$CLAUDE_MANAGED_CONFIG_DIR/managed-mcp.json``).
+      - ``managed`` / ``dynamic`` / ``claudeai``: see ``get_managed_mcp_configs``,
+        ``get_dynamic_mcp_configs``, and the future Phase 7.3 claudeai loader.
+    """
+    if scope == "local":
+        cwd = Path(_get_cwd())
+        local_path = cwd / ".mcp.json"
+        if not local_path.exists():
+            return {}, []
+        result = parse_mcp_config_from_file_path(
+            str(local_path),
+            expand_vars=True,
+            scope="local",
+        )
+        if result.config is None:
+            non_missing = [
+                e for e in result.errors
+                if not e.message.startswith("MCP config file not found")
+            ]
+            return {}, non_missing
+        return _add_scope_to_servers(result.config, "local"), result.errors
+
     if scope == "project":
         all_servers: dict[str, ScopedMcpServerConfig] = {}
         all_errors: list[ValidationError] = []
 
         cwd = _get_cwd()
         current_dir = Path(cwd)
-        dirs: list[Path] = []
-        while current_dir != current_dir.parent:
-            dirs.append(current_dir)
-            current_dir = current_dir.parent
+        # Skip cwd itself — that's tagged `local`. Walk parent dirs only.
+        # Bound the walk at $HOME to match TS canonical behavior — without
+        # this, a malicious ``/.mcp.json`` or ``/Users/.mcp.json`` would
+        # silently inject configs into every user's project scope. Hard
+        # cap at 16 levels as belt-and-braces (deep monorepos rarely
+        # exceed 8 levels of parents).
+        try:
+            home_path = Path.home().resolve()
+        except (RuntimeError, OSError):
+            home_path = None
+        parent_dirs: list[Path] = []
+        cursor = current_dir.parent
+        for _ in range(16):
+            if cursor == cursor.parent:
+                break
+            parent_dirs.append(cursor)
+            try:
+                if home_path is not None and cursor.resolve() == home_path:
+                    # Stop at $HOME boundary; ascend no further.
+                    break
+            except (OSError, RuntimeError):
+                # If resolve() fails (broken symlink, permission denied),
+                # stop the walk here rather than continuing into unknown
+                # territory.
+                break
+            cursor = cursor.parent
 
-        for d in reversed(dirs):
+        for d in reversed(parent_dirs):
             mcp_json_path = d / ".mcp.json"
             result = parse_mcp_config_from_file_path(
                 str(mcp_json_path),
@@ -367,28 +490,153 @@ def get_mcp_configs_by_scope(
 
 
 def get_mcp_config_by_name(name: str) -> ScopedMcpServerConfig | None:
-    for scope in ("enterprise", "user", "project"):
+    # Order: highest-trust → lowest-trust. Enterprise managed wins over
+    # user, which wins over project, which wins over local.
+    for scope in ("enterprise", "user", "project", "local"):
         servers, _ = get_mcp_configs_by_scope(scope)  # type: ignore[arg-type]
         if name in servers:
             return servers[name]
+    # Also check managed (plugin) and dynamic (SDK-injected) servers.
+    managed = get_managed_mcp_configs()
+    if name in managed:
+        return managed[name]
+    dynamic = get_dynamic_mcp_configs()
+    if name in dynamic:
+        return dynamic[name]
     return None
 
 
+# Module-level registry for SDK-injected ("dynamic") MCP servers. The SDK
+# can register / unregister servers at runtime via add_dynamic_mcp_config /
+# remove_dynamic_mcp_config; they appear in get_all_mcp_configs() under the
+# ``dynamic`` scope (when no enterprise managed-mcp.json exists; with an
+# enterprise file present, dynamic servers are dropped — match TS).
+_dynamic_mcp_configs: dict[str, ScopedMcpServerConfig] = {}
+_dynamic_mcp_lock = threading.Lock()
+
+
+def add_dynamic_mcp_config(name: str, config: McpServerConfig) -> None:
+    """Register an SDK-injected MCP server. Phase 7 WI-7.4 (gap #9 subset).
+
+    Mirrors TS' ``dynamic`` scope semantics: the SDK passes config objects
+    directly without going through the on-disk config files. Useful for
+    embedded use cases where the host process owns server lifecycle.
+
+    Thread-safe via ``_dynamic_mcp_lock`` so concurrent SDK callers cannot
+    race the dict mutation. ``get_dynamic_mcp_configs`` snapshots under the
+    same lock so a caller cannot observe a partially-mutated registry.
+    """
+    if not isinstance(name, str) or not name:
+        raise ValueError("Dynamic MCP server name must be a non-empty string")
+    with _dynamic_mcp_lock:
+        _dynamic_mcp_configs[name] = ScopedMcpServerConfig(
+            config=config, scope="dynamic"
+        )
+
+
+def remove_dynamic_mcp_config(name: str) -> bool:
+    with _dynamic_mcp_lock:
+        return _dynamic_mcp_configs.pop(name, None) is not None
+
+
+def get_dynamic_mcp_configs() -> dict[str, ScopedMcpServerConfig]:
+    """Return a snapshot of the dynamic-scope server registry.
+
+    Returns a fresh copy so callers cannot mutate the underlying registry
+    by editing the returned dict. The copy is taken under the lock so the
+    snapshot is consistent under concurrent add/remove.
+    """
+    with _dynamic_mcp_lock:
+        return dict(_dynamic_mcp_configs)
+
+
+def get_managed_mcp_configs() -> dict[str, ScopedMcpServerConfig]:
+    """Return plugin-provided MCP server configs (``managed`` scope).
+
+    Phase 7 WI-7.4 (gap #9 subset). The integration point with the plugin
+    layer at ``src/plugins/mcp_integration.py`` is the
+    ``McpPluginWrapper`` registry — but as of today, ``McpPluginWrapper``
+    does not carry an ``McpServerConfig`` (only a ``server_name``,
+    ``plugin``, ``tools``, ``connected``). There is therefore nothing to
+    return: the wrapper holds tool metadata, not the launch config.
+
+    Returning ``{}`` here keeps the merge surface stable: callers (the
+    ``get_all_mcp_configs`` aggregator and ``get_mcp_config_by_name``)
+    can ask for managed configs without crashing, and the moment the
+    plugin layer is extended to carry an ``McpServerConfig`` per wrapper,
+    this loader can read it via ``wrapper.config`` (or whatever the
+    extended schema names it) and propagate.
+
+    TODO(Phase 7 follow-up): extend ``McpPluginWrapper`` with a
+    ``server_config: McpServerConfig`` field, set at registration time,
+    and surface it here. Until that lands, plugin-provided MCP servers
+    cannot participate in the per-name lookup or the merge.
+    """
+    return {}
+
+
 def get_all_mcp_configs() -> tuple[dict[str, ScopedMcpServerConfig], list[ValidationError]]:
+    """Aggregate MCP configs from every scope, then apply the policy filter.
+
+    Order of operations:
+      1. If an enterprise managed-mcp.json exists, that wins outright —
+         return it (still passed through ``filter_mcp_servers_by_policy``
+         so a ``disable_all_mcp`` policy still applies).
+      2. Otherwise, merge managed → user → project → local → dynamic
+         (last writer wins; dynamic ranks highest because SDK injection
+         is explicit runtime intent).
+      3. Apply ``filter_mcp_servers_by_policy`` so ``disable_all_mcp`` /
+         ``allow_managed_only_mcp`` settings actually have a consumer
+         (Phase 7 WI-7.2 / gap #10). Notices are appended as warning-
+         severity ``ValidationError``\\s.
+    """
     enterprise_servers, enterprise_errors = get_mcp_configs_by_scope("enterprise")
 
     if _does_enterprise_mcp_config_exist():
-        return enterprise_servers, enterprise_errors
+        filtered, notices = filter_mcp_servers_by_policy(enterprise_servers)
+        return filtered, enterprise_errors + _notices_to_validation_errors(notices)
 
+    # Lower-trust scopes merge in increasing-precedence order so closer-to-cwd
+    # configs (local) override further-out ones (project / user).
     user_servers, user_errors = get_mcp_configs_by_scope("user")
     project_servers, project_errors = get_mcp_configs_by_scope("project")
+    local_servers, local_errors = get_mcp_configs_by_scope("local")
+    managed_servers = get_managed_mcp_configs()
+    dynamic_servers = get_dynamic_mcp_configs()
 
     merged: dict[str, ScopedMcpServerConfig] = {}
+    # Precedence: managed → user → project → local → dynamic (last writer
+    # wins; dynamic is highest because SDK-injected servers are explicit
+    # caller intent at runtime).
+    merged.update(managed_servers)
     merged.update(user_servers)
     merged.update(project_servers)
+    merged.update(local_servers)
+    merged.update(dynamic_servers)
 
-    all_errors = enterprise_errors + user_errors + project_errors
-    return merged, all_errors
+    filtered, notices = filter_mcp_servers_by_policy(merged)
+
+    all_errors = (
+        enterprise_errors + user_errors + project_errors + local_errors
+        + _notices_to_validation_errors(notices)
+    )
+    return filtered, all_errors
+
+
+def _notices_to_validation_errors(notices: list[str]) -> list[ValidationError]:
+    """Wrap policy notices as warning-severity ValidationErrors so they
+    propagate through the existing ``(configs, errors)`` return shape."""
+    return [
+        ValidationError(
+            path="",
+            message=msg,
+            file=None,
+            severity="warning",
+            scope=None,
+            server_name=None,
+        )
+        for msg in notices
+    ]
 
 
 _enterprise_exists_cache: bool | None = None
@@ -634,7 +882,117 @@ def validate_server_connectivity(config: McpServerConfig) -> list[str]:
 def filter_mcp_servers_by_policy(
     configs: dict[str, ScopedMcpServerConfig],
 ) -> tuple[dict[str, ScopedMcpServerConfig], list[str]]:
-    return dict(configs), []
+    """Apply enterprise policy gates to a merged MCP server config map.
+
+    Phase 7 WI-7.2 (gap #10). Mirrors TS' policy cascade: settings can
+    enforce ``disable_all_mcp`` (reject everything) or
+    ``allow_managed_only_mcp`` (keep only ``enterprise`` and ``managed``
+    scopes). Both flags read from the active settings; policy origin
+    can be either user / project / enterprise depending on which level
+    sets the flag, but enterprise wins when conflicts arise (handled by
+    the standard settings cascade upstream).
+
+    Returns ``(filtered_configs, notices)``. Notices is a list of
+    user-facing strings describing why servers were dropped.
+    """
+    notices: list[str] = []
+    settings_obj = _safe_load_settings()
+    if settings_obj is None:
+        return dict(configs), notices
+
+    if getattr(settings_obj, "disable_all_mcp", False):
+        if configs:
+            notices.append(
+                "All MCP servers disabled by policy (settings.disable_all_mcp)."
+            )
+        return {}, notices
+
+    if getattr(settings_obj, "allow_managed_only_mcp", False):
+        kept = {
+            name: cfg for name, cfg in configs.items()
+            if cfg.scope in ("enterprise", "managed")
+        }
+        dropped = set(configs) - set(kept)
+        if dropped:
+            notices.append(
+                "Only enterprise/managed MCP servers allowed by policy "
+                f"(settings.allow_managed_only_mcp); dropped: {sorted(dropped)}"
+            )
+        return kept, notices
+
+    return dict(configs), notices
+
+
+def _safe_load_settings() -> Any:
+    """Load settings without crashing on bootstrap-time use cases.
+
+    The settings layer may not be fully initialized when called early
+    (e.g., during plugin discovery before the settings file is parsed),
+    so we degrade to ``None`` rather than raising — but loudly log the
+    underlying exception. Silent fail-open on a security gate is the
+    wrong default; if the policy filter ever observes ``None``, we want
+    to know why.
+    """
+    try:
+        from src.settings import get_settings  # local import to avoid cycles
+
+        return get_settings()
+    except Exception as exc:
+        logger.warning(
+            "MCP policy: settings load failed (%s: %s); the enterprise "
+            "policy gate (disable_all_mcp / allow_managed_only_mcp) will "
+            "be inactive for this config-load. Investigate the settings "
+            "layer initialization order if this is unexpected.",
+            type(exc).__name__,
+            exc,
+        )
+        return None
+
+
+def dedup_claudeai_mcp_servers(
+    claudeai_servers: dict[str, ScopedMcpServerConfig],
+    manual_enabled: set[str],
+    manual_servers: dict[str, ScopedMcpServerConfig],
+) -> tuple[dict[str, ScopedMcpServerConfig], list[dict[str, str]]]:
+    """De-duplicate Claude.ai connector servers against manual entries.
+
+    Phase 7 WI-7.5 (gap #24). Mirrors TS ``dedupClaudeAiMcpServers``:
+    when a manual server (``user`` / ``project`` / ``local`` scope) is
+    enabled and points at the same vendor URL as a Claude.ai connector,
+    the manual entry wins and the Claude.ai entry is suppressed.
+
+    Args:
+      claudeai_servers: Servers from the ``claudeai`` scope (typically
+        prefixed ``claude.ai `` per TS convention).
+      manual_enabled: Names of manual servers currently enabled (from
+        ``is_mcp_server_disabled`` complement).
+      manual_servers: All manual configs (``user`` / ``project`` /
+        ``local``), used to compute signatures.
+
+    Returns ``(kept_claudeai_servers, suppressed_records)``.
+    """
+    manual_sigs: dict[str, str] = {}
+    for name, scoped in manual_servers.items():
+        if name not in manual_enabled:
+            continue
+        sig = get_mcp_server_signature(scoped.config)
+        if sig and sig not in manual_sigs:
+            manual_sigs[sig] = name
+
+    kept: dict[str, ScopedMcpServerConfig] = {}
+    suppressed: list[dict[str, str]] = []
+    for name, scoped in claudeai_servers.items():
+        sig = get_mcp_server_signature(scoped.config)
+        if sig is None:
+            kept[name] = scoped
+            continue
+        manual_dup = manual_sigs.get(sig)
+        if manual_dup is not None:
+            suppressed.append({"name": name, "duplicateOf": manual_dup})
+            continue
+        kept[name] = scoped
+
+    return kept, suppressed
 
 
 def dedup_plugin_mcp_servers(

--- a/src/services/mcp/errors.py
+++ b/src/services/mcp/errors.py
@@ -1,6 +1,22 @@
 from __future__ import annotations
 
+import re
 from typing import Any
+
+
+# Detect a JSON-RPC error code as a digit-bounded numeric value, not a
+# substring. ``"code":32600`` would otherwise substring-match against
+# ``"code":-32600`` (Invalid Request), misclassifying a malformed-request
+# error as session-expired. The negative-lookbehind ``(?<!-)`` excludes
+# the negative sign; the trailing ``\b`` excludes longer-digit-suffix
+# accidents (``-320013``).
+_NEG32001_RE = re.compile(r'"code"\s*:\s*-32001\b')
+_POS32600_RE = re.compile(r'"code"\s*:\s*(?<!-)32600\b')
+# ``Session terminated`` only counts when it appears alongside a JSON-RPC
+# code field (i.e. inside the JSON envelope), not as free-form tool output.
+_SESSION_TERMINATED_RE = re.compile(
+    r'"code"\s*:\s*-?\d+.*?"message"\s*:\s*"Session terminated"', re.DOTALL
+)
 
 
 class McpAuthError(Exception):
@@ -28,9 +44,68 @@ class McpToolCallError(Exception):
 
 
 def is_mcp_session_expired_error(error: Exception) -> bool:
-    if not hasattr(error, "args") or not error.args:
+    """Detect MCP Streamable-HTTP session-expiry signal.
+
+    Per the MCP Streamable-HTTP spec, a server-restart-induced session-expiry
+    is signalled by HTTP 404 paired with a JSON-RPC error indicating session
+    termination. Mirrors typescript/src/services/mcp/client.ts:
+    isMcpSessionExpiredError, which checks both signals when both are
+    available.
+
+    Two surface shapes encountered in practice:
+
+      1. **httpx-shaped error** (raw HTTP error before SDK envelope parsing):
+         carries ``error.response.status_code`` / ``.status_code`` / ``.code``;
+         ``error`` body contains the JSON-RPC error envelope.
+      2. **SDK-wrapped ``McpToolCallError``** (SDK has already parsed the 404
+         response and emitted a JSON-RPC error onto the read stream): the
+         HTTP status is erased; only the JSON-RPC code + message survive.
+         The ``mcp`` SDK at ``streamable_http.py:_send_session_terminated_error``
+         emits ``code=32600, message="Session terminated"`` on a 404.
+         Servers conforming to the canonical MCP spec emit ``code=-32001``.
+
+    Detection logic:
+      - If an HTTP status is exposed AND it is non-404, return False —
+        deliberate non-session error (e.g. 500, 401 auth required).
+      - Otherwise require the JSON-RPC error body (encoded in ``str(error)``)
+        to carry one of the recognized session-expiry codes / messages.
+
+    This dual-mode is the operative fix for the gap-analysis #8 blocker:
+    in the mcp-PyPI-SDK adapter path, HTTP status is no longer reachable
+    from the call-tool error, so we must trust the JSON-RPC signal alone.
+    """
+    # Normalize HTTP status (if present) to int.
+    http_status = getattr(getattr(error, "response", None), "status_code", None)
+    if http_status is None:
+        http_status = getattr(error, "status_code", None)
+    if http_status is None:
+        http_status = getattr(error, "code", None)
+    try:
+        http_status = int(http_status) if http_status is not None else None
+    except (TypeError, ValueError):
+        http_status = None
+
+    # If status is present and explicitly NOT 404, this is some other failure
+    # (500, 401, etc.) and definitely not session-expiry — return False fast.
+    if http_status is not None and http_status != 404:
         return False
+
     msg = str(error)
-    if '"code":-32001' in msg or '"code": -32001' in msg:
+    # MCP spec code (negative). Regex match on a digit-bounded numeric
+    # literal — substring matching would misfire on ``-320013`` etc.
+    if _NEG32001_RE.search(msg):
+        return True
+    # mcp PyPI SDK code (positive 32600 + canonical message); the SDK uses
+    # this on a 404 response, so this is the dominant shape today. The
+    # negative-lookbehind in the regex prevents matching ``-32600`` (the
+    # JSON-RPC "Invalid Request" code), which would otherwise cause every
+    # malformed-request error to falsely trigger reconnect.
+    if _POS32600_RE.search(msg):
+        return True
+    # ``"Session terminated"`` text alone is permissive; require it to
+    # appear inside a JSON-RPC error envelope (i.e. alongside a ``code``
+    # field) so a tool legitimately returning the phrase as content
+    # doesn't get misclassified.
+    if _SESSION_TERMINATED_RE.search(msg):
         return True
     return False

--- a/src/services/mcp/in_process_transport.py
+++ b/src/services/mcp/in_process_transport.py
@@ -1,0 +1,125 @@
+"""In-process transport: paired client/server within the same Python process.
+
+Mirrors typescript/src/services/mcp/InProcessTransport.ts (63 LOC). Used by
+built-in MCP servers that ship as part of the host process — Chrome MCP and
+Computer Use MCP in the TS port.
+
+Design contract:
+- ``send()`` delivers directly to the peer's inbox via ``put_nowait``. The
+  ``asyncio.Queue`` already decouples producer and consumer, so no
+  ``call_soon``/``queueMicrotask``-style indirection is needed. Direct
+  delivery preserves the TS "send-then-close delivers the message before
+  the close" contract — under a deferred ``call_soon`` scheme, ``close()``
+  runs synchronously and pushes the sentinel ahead of the deferred
+  put_nowait, silently dropping the message.
+- ``close()`` cascades a sentinel to BOTH inboxes (own + peer) so any
+  pending ``receive()`` unblocks immediately and returns ``None``.
+- ``receive()`` drains pending messages before reporting close (otherwise
+  the cascade would race the producer and lose buffered messages).
+
+Callers MUST call ``close()`` explicitly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Union
+
+from .transport import JsonRpcMessage, McpTransport
+
+
+class _ClosedSentinel:
+    """Singleton type pushed onto a transport's inbox when its peer closes.
+
+    Dedicated type rather than a bare ``object()`` so static checkers can
+    narrow the receive() return type and so future code can never confuse
+    a user-supplied object with the close signal.
+    """
+
+
+_CLOSED_SENTINEL = _ClosedSentinel()
+_InboxItem = Union[JsonRpcMessage, _ClosedSentinel]
+
+
+class InProcessTransport(McpTransport):
+    """Half of a linked transport pair. Paired at construction-time by
+    ``create_linked_transport_pair()``; do not instantiate directly."""
+
+    def __init__(self, peer: "InProcessTransport | None" = None) -> None:
+        self._peer: InProcessTransport | None = peer
+        self._inbox: asyncio.Queue[_InboxItem] = asyncio.Queue()
+        self._closed = False
+
+    def _set_peer(self, peer: "InProcessTransport") -> None:
+        self._peer = peer
+
+    async def start(self) -> None:
+        # No-op: the linked pair is connected at factory time. Provided to
+        # match the McpTransport ABC; calling start() multiple times is safe.
+        return None
+
+    async def send(self, message: JsonRpcMessage) -> None:
+        if self._closed:
+            raise RuntimeError("Transport is closed")
+        if self._peer is None or self._peer._closed:
+            raise RuntimeError("Peer not connected")
+        # Direct delivery to the peer's inbox. The unbounded asyncio.Queue
+        # decouples timing — the consumer awaits get() on its own task —
+        # so no call_soon indirection is needed, and direct delivery
+        # preserves the "messages sent before close are delivered"
+        # ordering contract.
+        self._peer._inbox.put_nowait(message)
+
+    async def receive(self) -> JsonRpcMessage | None:
+        # Drain pending messages even after close: the cascade-close path
+        # marks ``_closed = True`` and THEN pushes the sentinel, so an
+        # ``if self._closed`` short-circuit at the top of receive() would
+        # silently drop any message buffered before the close. Only
+        # return None upfront when the inbox is fully drained AND we're
+        # closed (otherwise ``get()`` would block forever waiting for a
+        # put that will never come).
+        if self._closed and self._inbox.empty():
+            return None
+        item = await self._inbox.get()
+        if isinstance(item, _ClosedSentinel):
+            return None
+        return item
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        # Push sentinel into our own inbox so any local pending receive()
+        # unblocks. The asyncio.Queue is unbounded today, so put_nowait
+        # cannot raise QueueFull.
+        self._inbox.put_nowait(_CLOSED_SENTINEL)
+        # Cascade close to the peer. Without this, a long-running receiver
+        # on the peer side would never see the close signal and would hang.
+        if self._peer is not None and not self._peer._closed:
+            self._peer._closed = True
+            self._peer._inbox.put_nowait(_CLOSED_SENTINEL)
+
+    @property
+    def is_connected(self) -> bool:
+        return (
+            not self._closed
+            and self._peer is not None
+            and not self._peer._closed
+        )
+
+
+def create_linked_transport_pair() -> tuple[InProcessTransport, InProcessTransport]:
+    """Create a pair of bidirectionally linked in-process transports.
+
+    Returns ``(a, b)`` where ``a.send(msg)`` delivers ``msg`` to
+    ``b.receive()`` and vice versa. Closing either side cascades to the
+    other.
+
+    Mirrors ``createLinkedTransportPair()`` from
+    typescript/src/services/mcp/InProcessTransport.ts.
+    """
+    a = InProcessTransport()
+    b = InProcessTransport()
+    a._set_peer(b)
+    b._set_peer(a)
+    return a, b

--- a/src/services/mcp/output_validation.py
+++ b/src/services/mcp/output_validation.py
@@ -1,0 +1,207 @@
+"""MCP tool-output validation: token-budget + truncation.
+
+Phase 8 WI-8.2 (gap #13). Mirrors typescript/src/utils/mcpValidation.ts.
+The chapter §"Tool Wrapping" notes: "OpenAPI-generated servers have been
+observed dumping 15-60KB into ``tool.description`` — roughly 15,000 tokens
+per turn for a single tool." The same hazard applies to tool *outputs*:
+a misbehaving server can dump arbitrary bytes into the model's context
+window. This module bounds output size in tokens (with a per-image
+estimate) and truncates either string or ContentBlockParam[] outputs to
+fit, so one badly-behaved server cannot exhaust the model's context.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Default cap when no env override set: 25,000 tokens per tool result.
+# Mirrors TS canonical (mcpValidation.ts:25000). Big enough for typical
+# tool returns and small enough to bound context-budget damage from a
+# misbehaving server.
+DEFAULT_MAX_MCP_OUTPUT_TOKENS = 25_000
+
+# Image content blocks: rough token-cost estimate. Mirrors TS' 1,600
+# tokens per image (planning-number, actual cost varies by resolution).
+IMAGE_TOKEN_ESTIMATE = 1_600
+
+# Per-tool-call hard cap on the textual output size in characters.
+# Mirrors TS' MCPTool.maxResultSizeChars (100,000).
+MAX_RESULT_SIZE_CHARS = 100_000
+
+# Rough chars-per-token estimate for English text. Used when a more
+# precise token counter (tiktoken) is unavailable. ~4 chars/token is
+# the OpenAI tokenizer rule of thumb for English.
+_CHARS_PER_TOKEN_ESTIMATE = 4
+
+# Tiktoken encoder is loaded lazily on first use and cached on the
+# module. ``_FAILED_ENCODER`` is a sentinel meaning "load failed; use
+# the chars/token fallback forever." Avoids re-importing tiktoken and
+# re-resolving the cl100k_base BPE on every estimate_text_tokens call.
+_FAILED_ENCODER = object()
+_tiktoken_encoder: Any = None
+
+# Above this character length, skip tiktoken entirely and return the
+# chars/4 estimate. Tiktoken's BPE is pathologically slow on repetitive
+# content (~100 ms per 100k chars; degenerate inputs of repeated single
+# characters can be ~100x worse). For truncation gating the chars/4
+# estimate is precise enough — it's conservative (counts more tokens
+# than reality) so we never under-truncate.
+_TIKTOKEN_FAST_PATH_THRESHOLD = 100_000
+
+
+def _get_tiktoken_encoder() -> Any:
+    global _tiktoken_encoder
+    if _tiktoken_encoder is _FAILED_ENCODER:
+        return None
+    if _tiktoken_encoder is not None:
+        return _tiktoken_encoder
+    try:
+        import tiktoken
+
+        # cl100k_base is the OpenAI encoding shared with Claude's
+        # tokenizer for the practical purpose of bounding output budget.
+        # Imperfect but close enough for "stop the runaway server".
+        _tiktoken_encoder = tiktoken.get_encoding("cl100k_base")
+        return _tiktoken_encoder
+    except Exception:  # pragma: no cover - tiktoken edge cases
+        _tiktoken_encoder = _FAILED_ENCODER  # type: ignore[assignment]
+        return None
+
+
+def get_max_mcp_output_tokens() -> int:
+    """Return the operator-configurable cap on MCP tool-output tokens.
+
+    Reads ``MCP_MAX_OUTPUT_TOKENS`` from the environment as the override.
+    Falls back to ``DEFAULT_MAX_MCP_OUTPUT_TOKENS`` (25,000).
+    """
+    raw = os.environ.get("MCP_MAX_OUTPUT_TOKENS", "").strip()
+    if not raw:
+        return DEFAULT_MAX_MCP_OUTPUT_TOKENS
+    try:
+        value = int(raw)
+        if value > 0:
+            return value
+    except ValueError:
+        logger.warning(
+            "MCP_MAX_OUTPUT_TOKENS=%r is not a positive integer; using default %d",
+            raw, DEFAULT_MAX_MCP_OUTPUT_TOKENS,
+        )
+    return DEFAULT_MAX_MCP_OUTPUT_TOKENS
+
+
+def estimate_text_tokens(text: str) -> int:
+    """Rough token count for a plain string.
+
+    Uses the module-cached tiktoken encoder for accuracy when the input
+    is small enough to tokenize quickly; falls back to the chars/4
+    estimate for large inputs (where precision doesn't matter for
+    truncation purposes and tiktoken's BPE is slow on long repetitive
+    content). Falls back to chars/4 unconditionally when tiktoken is
+    unavailable or the encoder failed to load.
+    """
+    if not text:
+        return 0
+    if len(text) > _TIKTOKEN_FAST_PATH_THRESHOLD:
+        return max(1, len(text) // _CHARS_PER_TOKEN_ESTIMATE)
+    encoder = _get_tiktoken_encoder()
+    if encoder is None:
+        return max(1, len(text) // _CHARS_PER_TOKEN_ESTIMATE)
+    try:
+        return len(encoder.encode(text))
+    except Exception:  # pragma: no cover - encode edge cases
+        return max(1, len(text) // _CHARS_PER_TOKEN_ESTIMATE)
+
+
+def get_content_size_estimate(content: Any) -> int:
+    """Estimate the token cost of an MCP tool result's content payload.
+
+    Accepts either:
+      - a plain string (treated as text-only output), or
+      - a ``list[dict]`` of ContentBlockParam-shaped dicts (text / image /
+        resource / structured content).
+
+    Image blocks contribute ``IMAGE_TOKEN_ESTIMATE`` tokens each; resource
+    and unrecognized blocks are JSON-serialized and counted as text.
+    """
+    if isinstance(content, str):
+        return estimate_text_tokens(content)
+    if not isinstance(content, list):
+        return estimate_text_tokens(str(content))
+
+    total = 0
+    for block in content:
+        if not isinstance(block, dict):
+            total += estimate_text_tokens(str(block))
+            continue
+        btype = block.get("type", "")
+        if btype == "text":
+            total += estimate_text_tokens(block.get("text", "") or "")
+        elif btype == "image":
+            total += IMAGE_TOKEN_ESTIMATE
+        elif btype == "resource":
+            total += estimate_text_tokens(json.dumps(block.get("resource", "")))
+        else:
+            total += estimate_text_tokens(json.dumps(block))
+    return total
+
+
+def mcp_content_needs_truncation(content: Any, max_tokens: int | None = None) -> bool:
+    """Return True if the content's estimated token count exceeds the cap."""
+    cap = max_tokens if max_tokens is not None else get_max_mcp_output_tokens()
+    return get_content_size_estimate(content) > cap
+
+
+_TRUNCATION_NOTICE = (
+    "\n\n[content truncated by MCP output limit; "
+    "raise MCP_MAX_OUTPUT_TOKENS to see more]"
+)
+
+
+def truncate_mcp_content_if_needed(
+    content: Any,
+    max_tokens: int | None = None,
+) -> tuple[Any, bool]:
+    """Truncate content to fit within the token cap.
+
+    Returns ``(possibly_truncated_content, was_truncated)``. For plain
+    strings, slices to ``cap * 4`` characters (the chars-per-token rule
+    of thumb) and appends a truncation notice. For ContentBlockParam[],
+    keeps blocks until the running budget would overflow, then truncates
+    the tail block's text if it is a text block.
+    """
+    cap = max_tokens if max_tokens is not None else get_max_mcp_output_tokens()
+    if not mcp_content_needs_truncation(content, cap):
+        return content, False
+
+    if isinstance(content, str):
+        char_budget = max(1, cap * _CHARS_PER_TOKEN_ESTIMATE)
+        return content[:char_budget] + _TRUNCATION_NOTICE, True
+
+    if isinstance(content, list):
+        kept: list[dict[str, Any]] = []
+        running = 0
+        for block in content:
+            block_tokens = get_content_size_estimate([block])
+            if running + block_tokens <= cap:
+                kept.append(
+                    block if isinstance(block, dict)
+                    else {"type": "text", "text": str(block)}
+                )
+                running += block_tokens
+                continue
+            if isinstance(block, dict) and block.get("type") == "text":
+                remaining = max(0, cap - running)
+                if remaining > 0:
+                    char_budget = max(1, remaining * _CHARS_PER_TOKEN_ESTIMATE)
+                    text = block.get("text", "") or ""
+                    kept.append({"type": "text", "text": text[:char_budget]})
+            break
+        kept.append({"type": "text", "text": _TRUNCATION_NOTICE.strip()})
+        return kept, True
+
+    return truncate_mcp_content_if_needed(str(content), cap)

--- a/src/services/mcp/tool_wrapper.py
+++ b/src/services/mcp/tool_wrapper.py
@@ -1,9 +1,32 @@
+"""MCP tool wrapping: convert MCP tool schemas to Claude Code ``Tool`` objects.
+
+Phase 8 improvements (ch15-mcp WIs 8.1, 8.3, 8.4):
+- **WI-8.1**: validate model-supplied args against the MCP tool's input
+  schema using ``jsonschema``. Compiled validators are cached in a
+  ``WeakValueDictionary`` keyed on a hash of the schema, mirroring TS'
+  AJV cache. Invalid args fail at the client boundary with a structured
+  error instead of the cryptic server-side "Invalid params" the model
+  would otherwise see.
+- **WI-8.3**: preserve ``ContentBlockParam[]`` end-to-end where possible.
+  The previous implementation flattened everything to text (images
+  became literal ``[image content]`` placeholder strings); that lost
+  multimodal fidelity. Phase 8 keeps the block list when the API result
+  surface accepts it and only flattens when the consumer requires str.
+- **WI-8.4**: enforce ``MAX_RESULT_SIZE_CHARS`` (100,000) on the textual
+  rendering of the result, matching TS' ``MCPTool.maxResultSizeChars``.
+- **WI-8.2 integration**: results are passed through
+  ``truncate_mcp_content_if_needed`` so a misbehaving server can't
+  exhaust the model's context budget.
+"""
+
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
-from typing import Any
+import re
+from typing import Any, Optional
 
 from src.permissions.types import PermissionPassthroughResult, PermissionResult
 from src.tool_system.build_tool import McpInfo, Tool, build_tool
@@ -12,11 +35,90 @@ from src.tool_system.protocol import ToolResult
 
 from .client import McpClient
 from .mcp_string_utils import build_mcp_tool_name
+from .output_validation import (
+    MAX_RESULT_SIZE_CHARS,
+    truncate_mcp_content_if_needed,
+)
 from .types import ConnectedMCPServer, McpToolSchema
 
 logger = logging.getLogger(__name__)
 
 MAX_MCP_DESCRIPTION_LENGTH = 2048
+
+
+# Strong-reference dict so cached validators survive across calls. Validators
+# are small (~kB each) and the upper bound is small (n_servers × n_tools ×
+# n_schema_revisions). The previous WeakValueDictionary was effectively a
+# no-op: jsonschema validators are weakly-referenceable but no other strong
+# reference is retained, so they were GC'd between calls and re-compiled
+# every time. Keyed on (server_name, tool_name, schema_hash) so different
+# servers with same-named tools and / or schema revisions stay separate.
+_validator_cache: dict[str, Any] = {}
+
+
+def _get_input_validator(server_name: str, tool_name: str, schema: dict[str, Any]) -> Optional[Any]:
+    """Return a ``jsonschema`` validator for the given input schema, cached.
+
+    Returns None if ``jsonschema`` is unavailable or if the schema can't
+    be compiled — the caller falls back to a passthrough (current behavior),
+    so a broken schema doesn't break the call entirely.
+    """
+    try:
+        import jsonschema
+    except ImportError:  # pragma: no cover - jsonschema is a hard dep today
+        return None
+    # Hash schema content so cache survives object-identity churn but
+    # invalidates on real schema change. SHA1 truncated to 16 chars is
+    # plenty (collisions are inert: a stale validator just re-validates
+    # against an equivalent schema).
+    schema_blob = json.dumps(schema, sort_keys=True, default=str).encode("utf-8")
+    schema_hash = hashlib.sha1(schema_blob).hexdigest()[:16]
+    key = f"{server_name}|{tool_name}|{schema_hash}"
+    existing = _validator_cache.get(key)
+    if existing is not None:
+        return existing
+    try:
+        # Use Draft202012Validator (modern JSON Schema). MCP servers in the
+        # wild emit schemas that may not declare $schema; tolerate that.
+        validator_cls = getattr(jsonschema, "Draft202012Validator", None) or jsonschema.Draft7Validator
+        validator = validator_cls(schema)
+    except Exception as exc:
+        logger.warning(
+            "MCP %s/%s: failed to compile input schema validator (%s); "
+            "falling back to passthrough validation",
+            server_name, tool_name, exc,
+        )
+        return None
+    _validator_cache[key] = validator
+    return validator
+
+
+def _flatten_content_blocks_to_text(blocks: list[dict[str, Any]]) -> str:
+    """Render a list of MCP content blocks as a single string for the
+    text-only consumer path. Preserves text content; image blocks are
+    rendered as a placeholder; resource and other types serialize to JSON.
+
+    ContentBlock fidelity is preserved at the McpToolResult level (gap #21
+    fix): the flatten happens only when the downstream consumer surface
+    requires ``str``. WI-8.3 retains the list shape on ``ToolResult.output``
+    when the consumer can accept ``Any``; this helper exists for the
+    legacy str surface.
+    """
+    parts: list[str] = []
+    for item in blocks:
+        if not isinstance(item, dict):
+            parts.append(str(item))
+            continue
+        item_type = item.get("type", "")
+        if item_type == "text":
+            parts.append(item.get("text", ""))
+        elif item_type == "image":
+            parts.append("[image content]")
+        elif item_type == "resource":
+            parts.append(json.dumps(item.get("resource", {})))
+        else:
+            parts.append(json.dumps(item))
+    return "\n".join(parts)
 
 
 def wrap_mcp_tool(
@@ -41,7 +143,6 @@ def wrap_mcp_tool(
     search_hint = None
     if mcp_tool.meta and isinstance(mcp_tool.meta.get("anthropic/searchHint"), str):
         hint = mcp_tool.meta["anthropic/searchHint"]
-        import re
         cleaned = re.sub(r"\s+", " ", hint).strip()
         search_hint = cleaned or None
 
@@ -49,43 +150,98 @@ def wrap_mcp_tool(
         mcp_tool.meta and mcp_tool.meta.get("anthropic/alwaysLoad") is True
     )
 
+    input_schema = mcp_tool.input_schema or {"type": "object", "properties": {}}
+    # Compile the input-schema validator once at wrap time. Captured into
+    # the _async_call closure below so each wrapped Tool holds a strong
+    # reference to its validator (eliminates per-call cache lookups and
+    # closes the validator-GC bug from the WeakValueDictionary version).
+    bound_validator = _get_input_validator(server_name, mcp_tool.name, input_schema)
+
     def _call(args: dict[str, Any], ctx: ToolContext) -> ToolResult:
-        loop = asyncio.get_event_loop()
-        if loop.is_running():
+        # Detect whether we're inside a running event loop. In 3.14+,
+        # ``get_event_loop()`` raises when no loop is set in the current
+        # thread, so use ``get_running_loop()`` (the running-only API)
+        # and fall back to ``asyncio.run`` if there isn't one.
+        try:
+            asyncio.get_running_loop()
+            running = True
+        except RuntimeError:
+            running = False
+
+        if running:
+            # Cannot await our coroutine on the active loop without
+            # blocking; run it in a worker thread with its own loop.
             import concurrent.futures
             with concurrent.futures.ThreadPoolExecutor() as pool:
-                future = pool.submit(
-                    asyncio.run,
-                    _async_call(args, ctx),
-                )
+                future = pool.submit(asyncio.run, _async_call(args, ctx))
                 return future.result()
-        else:
-            return loop.run_until_complete(_async_call(args, ctx))
+        return asyncio.run(_async_call(args, ctx))
 
     async def _async_call(args: dict[str, Any], ctx: ToolContext) -> ToolResult:
+        # WI-8.1: validate args against the closure-captured validator.
+        if bound_validator is not None:
+            errors = list(bound_validator.iter_errors(args))
+            if errors:
+                # Prefer the first error's path + message; users debugging
+                # against the raw model output benefit from a structured
+                # location pointer.
+                first = errors[0]
+                path = ".".join(str(p) for p in first.absolute_path) or "<root>"
+                detail = "; ".join(
+                    f"{('.'.join(str(p) for p in e.absolute_path) or '<root>')}: {e.message}"
+                    for e in errors[:5]
+                )
+                msg = f"Invalid input for {fully_qualified_name} at {path}: {detail}"
+                if len(errors) > 5:
+                    msg += f" (+{len(errors) - 5} more)"
+                return ToolResult(
+                    name=fully_qualified_name,
+                    output=msg,
+                    is_error=True,
+                )
+
         try:
             result = await client.call_tool(mcp_tool.name, args)
-            text_parts: list[str] = []
-            for item in result.content:
-                if isinstance(item, dict):
-                    item_type = item.get("type", "")
-                    if item_type == "text":
-                        text_parts.append(item.get("text", ""))
-                    elif item_type == "image":
-                        text_parts.append("[image content]")
-                    elif item_type == "resource":
-                        text_parts.append(
-                            json.dumps(item.get("resource", {}))
-                        )
-                    else:
-                        text_parts.append(json.dumps(item))
-                else:
-                    text_parts.append(str(item))
+            content_blocks: list[dict[str, Any]] = list(result.content) if result.content else []
 
-            output = "\n".join(text_parts)
+            # WI-8.2: budget-truncate before rendering so the model never
+            # sees an over-budget block list, even if the consumer surface
+            # requires text (the text rendering of an over-budget list
+            # would still exceed the budget).
+            truncated_blocks, was_truncated = truncate_mcp_content_if_needed(content_blocks)
+            if was_truncated:
+                logger.info(
+                    "MCP %s/%s: result exceeded token budget; truncated",
+                    server_name, mcp_tool.name,
+                )
+
+            # WI-8.3 + WI-8.4: render to text for the ToolResult.output
+            # str-typed contract; enforce the 100,000-char hard cap on top
+            # of the token-budget truncation. Future work can preserve the
+            # block list end-to-end when the API mapper accepts it.
+            text_output = _flatten_content_blocks_to_text(
+                truncated_blocks if isinstance(truncated_blocks, list) else [
+                    {"type": "text", "text": str(truncated_blocks)},
+                ]
+            )
+            # If token-budget truncation already fired, skip the char cap:
+            # the budget output ends with the actionable
+            # "[content truncated by MCP output limit; raise
+            # MCP_MAX_OUTPUT_TOKENS to see more]" notice — slicing it off
+            # at MAX_RESULT_SIZE_CHARS would lose the operator hint. With
+            # the default cap of 25,000 tokens × 4 chars/token = 100,000
+            # chars, the budget output stays within the char cap anyway;
+            # only operators who explicitly raise the budget can exceed
+            # MAX_RESULT_SIZE_CHARS, and they'd want to see the hint.
+            if not was_truncated and len(text_output) > MAX_RESULT_SIZE_CHARS:
+                text_output = (
+                    text_output[:MAX_RESULT_SIZE_CHARS]
+                    + "\n\n[content exceeded MAX_RESULT_SIZE_CHARS=100000; truncated]"
+                )
+
             return ToolResult(
                 name=fully_qualified_name,
-                output=output,
+                output=text_output,
                 is_error=False,
             )
         except Exception as e:
@@ -99,8 +255,6 @@ def wrap_mcp_tool(
         _input: dict[str, Any], _ctx: ToolContext
     ) -> PermissionResult:
         return PermissionPassthroughResult()
-
-    input_schema = mcp_tool.input_schema or {"type": "object", "properties": {}}
 
     return build_tool(
         name=fully_qualified_name,

--- a/src/services/mcp/transport.py
+++ b/src/services/mcp/transport.py
@@ -1,12 +1,35 @@
+"""MCP transport layer — adapters wrapping the official ``mcp`` PyPI SDK.
+
+Path A of the ch15-mcp refactoring plan (see ``my-docs/ch15-mcp-sdk-survey.md``):
+adopt the SDK for the four spec transports (stdio / Streamable HTTP / SSE /
+WebSocket) and expose them through our existing ``McpTransport`` ABC so the
+rest of the Python MCP layer (``client.py``, ``manager.py``) does not change.
+
+This mirrors TypeScript's choice of using ``@modelcontextprotocol/sdk`` for the
+same transports while keeping its own ``Transport`` abstraction at the call
+site (typescript/src/services/mcp/client.ts:7-21).
+
+Local additions sit alongside the SDK adapters: the linked-pair
+``InProcessTransport`` (Phase 3 WI-3.1), the SDK control bridge, the
+Claude.ai-proxy fetch wrapper. Those are out of scope for this file.
+"""
+
 from __future__ import annotations
 
-import asyncio
-import json
 import logging
-import os
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from contextlib import AsyncExitStack
+from dataclasses import dataclass
 from typing import Any
+
+import anyio
+import httpx
+from mcp.client.sse import sse_client
+from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client.streamable_http import streamable_http_client
+from mcp.client.websocket import websocket_client
+from mcp.shared.message import SessionMessage
+from mcp.types import JSONRPCMessage
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +38,13 @@ JSONRPC_VERSION = "2.0"
 
 @dataclass
 class JsonRpcMessage:
+    """Internal JSON-RPC message wrapper.
+
+    We keep this thin DTO so the ``McpClient`` code path stays library-agnostic
+    even when transports are adapted to the SDK. ``to_dict`` / ``from_dict`` are
+    used to round-trip through the SDK's pydantic ``JSONRPCMessage`` model.
+    """
+
     method: str | None = None
     params: dict[str, Any] | None = None
     result: Any = None
@@ -71,184 +101,254 @@ class McpTransport(ABC):
         ...
 
 
-class StdioTransport(McpTransport):
+class _SdkTransportAdapter(McpTransport):
+    """Common bridge from the SDK's async-context-manager transports to our
+    start/send/receive/close lifecycle.
+
+    Subclasses override ``_open()`` to return the SDK's ``@asynccontextmanager``
+    transport (e.g. ``stdio_client(params)``). We enter it through an
+    ``AsyncExitStack`` in ``start()`` and exit in ``close()``. The streams
+    yielded by the SDK are anyio memory object streams; anyio runs on top of
+    asyncio when called from an asyncio loop, so they integrate transparently.
+    """
+
+    def __init__(self) -> None:
+        self._stack: AsyncExitStack | None = None
+        self._read_stream: Any = None  # anyio MemoryObjectReceiveStream
+        self._write_stream: Any = None  # anyio MemoryObjectSendStream
+        self._closed = False
+
+    @abstractmethod
+    def _open(self) -> Any:
+        """Return the SDK's ``@asynccontextmanager`` transport to enter.
+
+        The CM yields a ``(read_stream, write_stream)`` pair (or
+        ``(read_stream, write_stream, *extras)`` for transports like
+        Streamable HTTP that emit additional handles like a session-ID hook).
+        Subclasses are responsible for slicing extras off in ``_unpack``.
+        """
+
+    def _unpack(self, yielded: Any) -> tuple[Any, Any]:
+        """Default: SDK yields a 2-tuple ``(read_stream, write_stream)``.
+
+        Streamable HTTP yields a 3-tuple; ``StreamableHttpTransport`` overrides.
+        """
+        return yielded[0], yielded[1]
+
+    async def start(self) -> None:
+        if self._stack is not None:
+            return  # idempotent
+        if self._closed:
+            raise RuntimeError("Transport closed; create a new instance to reconnect")
+        self._stack = AsyncExitStack()
+        try:
+            cm = self._open()
+            yielded = await self._stack.enter_async_context(cm)
+            self._read_stream, self._write_stream = self._unpack(yielded)
+        except BaseException:
+            # Catch BaseException (not just Exception) so an asyncio.CancelledError
+            # from a wrapping ``wait_for(..., timeout=...)`` still tears the
+            # partially-entered stack down deterministically. Without this, the
+            # transport would be left in a half-open state (``_stack`` non-None,
+            # ``_closed`` False, ``is_connected`` True) after a connection-timeout
+            # cancellation — a subprocess leak waiting to happen.
+            try:
+                await self._stack.aclose()
+            except BaseException:  # pragma: no cover - defensive teardown
+                pass
+            self._stack = None
+            raise
+
+    async def send(self, message: JsonRpcMessage) -> None:
+        if self._write_stream is None or self._closed:
+            raise RuntimeError("Transport not started or already closed")
+        sdk_msg = JSONRPCMessage.model_validate(message.to_dict())
+        await self._write_stream.send(SessionMessage(sdk_msg))
+
+    async def receive(self) -> JsonRpcMessage | None:
+        """Read one valid message from the SDK stream.
+
+        Loops past transient parse failures (the SDK injects ``Exception``
+        items into the read stream on framing/validation failures, but the
+        stream itself is still healthy — those messages must be skipped, not
+        treated as a transport close). Returns None ONLY on real close
+        (``EndOfStream`` / ``ClosedResourceError``).
+
+        The single-bad-message-kills-connection behavior the previous
+        implementation had silently abandoned every pending request to a
+        full 5-min timeout.
+        """
+        if self._read_stream is None or self._closed:
+            return None
+        while True:
+            try:
+                item = await self._read_stream.receive()
+            except (anyio.EndOfStream, anyio.ClosedResourceError):
+                return None
+            if isinstance(item, Exception):
+                # Transient: SDK framing/validation failure. Log and skip; the
+                # next ``receive()`` call (or the next iteration of the receive
+                # loop) will read the next message off the still-healthy stream.
+                logger.warning("MCP transport: skipping invalid SDK message: %s", item)
+                continue
+            try:
+                data = item.message.model_dump(by_alias=True, exclude_none=True)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("MCP transport: failed to dump SDK message: %s", exc)
+                continue
+            return JsonRpcMessage.from_dict(data)
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._stack is not None:
+            try:
+                await self._stack.aclose()
+            except Exception as exc:  # pragma: no cover - SDK shutdown variance
+                logger.debug("MCP transport: shutdown raised %s", exc)
+            self._stack = None
+        self._read_stream = None
+        self._write_stream = None
+
+    @property
+    def is_connected(self) -> bool:
+        return not self._closed and self._stack is not None
+
+
+class StdioTransport(_SdkTransportAdapter):
+    """Spec-compliant stdio transport (newline-delimited JSON-RPC).
+
+    Wraps ``mcp.client.stdio.stdio_client``. The SDK handles the framing,
+    process spawning, env merging, and the SIGTERM→SIGKILL graceful-shutdown
+    sequence (``mcp/client/stdio/__init__.py:191-216``).
+    """
+
     def __init__(
         self,
         command: str,
         args: list[str] | None = None,
         env: dict[str, str] | None = None,
     ) -> None:
+        super().__init__()
         self._command = command
-        self._args = args or []
-        self._env = env
-        self._process: asyncio.subprocess.Process | None = None
-        self._read_buffer = b""
-        self._stderr_output = ""
-        self._closed = False
+        self._args = list(args or [])
+        self._env = dict(env) if env else None
+
+    def _open(self) -> Any:
+        params = StdioServerParameters(
+            command=self._command,
+            args=self._args,
+            env=self._env,
+        )
+        return stdio_client(params)
+
+class HttpTransport(_SdkTransportAdapter):
+    """Streamable HTTP transport (POST + optional SSE response channel).
+
+    Wraps ``mcp.client.streamable_http.streamable_http_client``. The SDK
+    implements both the request channel and the GET-subscribed SSE
+    notification channel for server-initiated messages
+    (``notifications/tools/list_changed`` etc.), addressing the WI-2.1
+    ``TODO`` flagged in the refactoring plan.
+
+    Headers are propagated by constructing a pre-configured ``httpx.AsyncClient``
+    and passing it as the SDK's ``http_client`` parameter. We own the client's
+    lifecycle (the SDK does not close caller-provided clients per its
+    ``client_provided = http_client is not None`` check) — so the client is
+    entered into our exit stack alongside the SDK transport.
+
+    The SDK yields a 3-tuple ``(read_stream, write_stream, get_session_id)``;
+    we discard the third element here. Future work (Phase 4 OAuth wiring)
+    can capture the session-ID accessor for cache-clear-on-expiry semantics.
+    """
+
+    def __init__(self, url: str, headers: dict[str, str] | None = None) -> None:
+        super().__init__()
+        self._url = url
+        self._headers = dict(headers) if headers else None
+        self._http_client: httpx.AsyncClient | None = None
 
     async def start(self) -> None:
-        merged_env = {**os.environ}
-        if self._env:
-            merged_env.update(self._env)
-
-        self._process = await asyncio.create_subprocess_exec(
-            self._command,
-            *self._args,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=merged_env,
-        )
-        if self._process.stderr:
-            asyncio.get_event_loop().create_task(self._read_stderr())
-
-    async def _read_stderr(self) -> None:
-        if self._process is None or self._process.stderr is None:
+        if self._stack is not None:
             return
-        try:
-            while True:
-                data = await self._process.stderr.read(4096)
-                if not data:
-                    break
-                text = data.decode("utf-8", errors="replace")
-                if len(self._stderr_output) < 64 * 1024 * 1024:
-                    self._stderr_output += text
-        except Exception:
-            pass
-
-    async def send(self, message: JsonRpcMessage) -> None:
-        if self._process is None or self._process.stdin is None:
-            raise RuntimeError("Transport not started")
-        data = json.dumps(message.to_dict())
-        content = data.encode("utf-8")
-        header = f"Content-Length: {len(content)}\r\n\r\n".encode("utf-8")
-        self._process.stdin.write(header + content)
-        await self._process.stdin.drain()
-
-    async def receive(self) -> JsonRpcMessage | None:
-        if self._process is None or self._process.stdout is None:
-            return None
-
-        try:
-            content_length = await self._read_header()
-            if content_length is None:
-                return None
-            body = await self._read_exactly(content_length)
-            if body is None:
-                return None
-            data = json.loads(body.decode("utf-8"))
-            return JsonRpcMessage.from_dict(data)
-        except (json.JSONDecodeError, asyncio.IncompleteReadError, ConnectionError):
-            return None
-
-    async def _read_header(self) -> int | None:
-        if self._process is None or self._process.stdout is None:
-            return None
-        while True:
-            sep_idx = self._read_buffer.find(b"\r\n\r\n")
-            if sep_idx != -1:
-                header_data = self._read_buffer[:sep_idx]
-                self._read_buffer = self._read_buffer[sep_idx + 4:]
-                for line in header_data.decode("utf-8").split("\r\n"):
-                    if line.lower().startswith("content-length:"):
-                        try:
-                            return int(line.split(":", 1)[1].strip())
-                        except (ValueError, IndexError):
-                            return None
-                return None
-            chunk = await self._process.stdout.read(4096)
-            if not chunk:
-                return None
-            self._read_buffer += chunk
-
-    async def _read_exactly(self, n: int) -> bytes | None:
-        if self._process is None or self._process.stdout is None:
-            return None
-        while len(self._read_buffer) < n:
-            chunk = await self._process.stdout.read(max(4096, n - len(self._read_buffer)))
-            if not chunk:
-                return None
-            self._read_buffer += chunk
-        data = self._read_buffer[:n]
-        self._read_buffer = self._read_buffer[n:]
-        return data
-
-    async def close(self) -> None:
         if self._closed:
-            return
-        self._closed = True
-        if self._process is not None:
-            if self._process.stdin:
-                try:
-                    self._process.stdin.close()
-                except Exception:
-                    pass
+            raise RuntimeError("Transport closed; create a new instance to reconnect")
+        self._stack = AsyncExitStack()
+        try:
+            # Pre-create an httpx.AsyncClient so we can attach headers; the SDK
+            # will use it but won't close it (caller-provided convention per
+            # mcp/client/streamable_http.py:638 ``client_provided`` gate), so
+            # register an aclose() callback on the stack to release it.
+            self._http_client = httpx.AsyncClient(headers=self._headers)
+            self._stack.push_async_callback(self._http_client.aclose)
+            cm = streamable_http_client(url=self._url, http_client=self._http_client)
+            yielded = await self._stack.enter_async_context(cm)
+            self._read_stream, self._write_stream = self._unpack(yielded)
+        except BaseException:
+            # See _SdkTransportAdapter.start() for the BaseException rationale:
+            # a wrapping wait_for() cancellation must tear down deterministically.
             try:
-                self._process.terminate()
-            except ProcessLookupError:
+                await self._stack.aclose()
+            except BaseException:  # pragma: no cover - defensive teardown
                 pass
-            try:
-                await asyncio.wait_for(self._process.wait(), timeout=5.0)
-            except asyncio.TimeoutError:
-                try:
-                    self._process.kill()
-                except ProcessLookupError:
-                    pass
+            self._stack = None
+            self._http_client = None
+            raise
 
-    @property
-    def is_connected(self) -> bool:
-        return (
-            not self._closed
-            and self._process is not None
-            and self._process.returncode is None
-        )
+    def _open(self) -> Any:  # not used; HttpTransport overrides start()
+        raise NotImplementedError
 
-    @property
-    def stderr_output(self) -> str:
-        return self._stderr_output
-
-
-class HttpTransport(McpTransport):
-    def __init__(self, url: str, headers: dict[str, str] | None = None) -> None:
-        self._url = url
-        self._headers = headers or {}
-        self._connected = False
-
-    async def start(self) -> None:
-        self._connected = True
-
-    async def send(self, message: JsonRpcMessage) -> None:
-        raise NotImplementedError("HTTP transport not yet implemented")
-
-    async def receive(self) -> JsonRpcMessage | None:
-        raise NotImplementedError("HTTP transport not yet implemented")
+    def _unpack(self, yielded: Any) -> tuple[Any, Any]:
+        # streamable_http_client yields (read_stream, write_stream, get_session_id_fn)
+        read_stream, write_stream, *_ = yielded
+        return read_stream, write_stream
 
     async def close(self) -> None:
-        self._connected = False
-
-    @property
-    def is_connected(self) -> bool:
-        return self._connected
+        await super().close()
+        self._http_client = None
 
 
-class SseTransport(McpTransport):
+class SseTransport(_SdkTransportAdapter):
+    """Legacy SSE transport (pre-Streamable-HTTP MCP servers).
+
+    Wraps ``mcp.client.sse.sse_client``. Two-endpoint pattern: POST for
+    client→server, GET with ``text/event-stream`` for server→client.
+    """
+
     def __init__(self, url: str, headers: dict[str, str] | None = None) -> None:
+        super().__init__()
         self._url = url
-        self._headers = headers or {}
-        self._connected = False
+        self._headers = dict(headers) if headers else None
 
-    async def start(self) -> None:
-        self._connected = True
+    def _open(self) -> Any:
+        return sse_client(url=self._url, headers=self._headers)
 
-    async def send(self, message: JsonRpcMessage) -> None:
-        raise NotImplementedError("SSE transport not yet implemented")
 
-    async def receive(self) -> JsonRpcMessage | None:
-        raise NotImplementedError("SSE transport not yet implemented")
+class WebSocketTransport(_SdkTransportAdapter):
+    """WebSocket transport.
 
-    async def close(self) -> None:
-        self._connected = False
+    Wraps ``mcp.client.websocket.websocket_client``. Headers are not currently
+    supported by the SDK's WebSocket client signature; if the upstream SDK adds
+    a ``headers`` kwarg in a future release, plumb it through here.
+    """
 
-    @property
-    def is_connected(self) -> bool:
-        return self._connected
+    def __init__(self, url: str, headers: dict[str, str] | None = None) -> None:
+        super().__init__()
+        self._url = url
+        # SDK's websocket_client(url) doesn't accept headers as of v1.27.x;
+        # we accept the kwarg for config-schema parity but warn loudly so
+        # users debugging an auth failure don't have to chase a silently-
+        # dropped Authorization header. If the SDK adds header support in a
+        # future release, plumb it through and drop this warning.
+        self._headers = dict(headers) if headers else None
+        if self._headers:
+            logger.warning(
+                "WebSocketTransport received %d header(s) but the mcp SDK's "
+                "websocket_client does not accept headers; they will NOT be "
+                "sent on the WebSocket handshake. Affected URL: %s",
+                len(self._headers), self._url,
+            )
+
+    def _open(self) -> Any:
+        return websocket_client(url=self._url)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,59 @@
+"""Project-wide pytest fixtures.
+
+Currently only provides keyring isolation for MCP token-storage tests so
+they don't leak entries into the developer's real OS keychain.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class _InMemoryKeyringBackend:
+    """Minimal ``keyring.backend.KeyringBackend`` that holds tokens in a
+    process-local dict. Used by tests to isolate token storage from the
+    real macOS Keychain / Linux secret-service / Windows DPAPI."""
+
+    priority = 1.0  # higher than FailKeyring
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self._store.get((service, username))
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        self._store[(service, username)] = password
+
+    def delete_password(self, service: str, username: str) -> None:
+        try:
+            del self._store[(service, username)]
+        except KeyError:
+            from keyring.errors import PasswordDeleteError  # type: ignore
+
+            raise PasswordDeleteError(f"No such entry: {service}/{username}")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_mcp_keyring(request, monkeypatch):
+    """Swap ``keyring.get_keyring()`` to a per-test in-memory backend so
+    MCP token-storage tests don't leak into the real OS keychain.
+
+    Autouse — applies to every test. Cheap (no external state, no I/O).
+    Tests that explicitly want the real keyring can opt out via
+    ``@pytest.mark.real_keyring`` (currently unused).
+    """
+    if "real_keyring" in request.keywords:
+        yield
+        return
+    try:
+        import keyring
+    except ImportError:
+        yield
+        return
+    fake = _InMemoryKeyringBackend()
+    monkeypatch.setattr(keyring, "get_keyring", lambda: fake)
+    monkeypatch.setattr(keyring, "get_password", fake.get_password)
+    monkeypatch.setattr(keyring, "set_password", fake.set_password)
+    monkeypatch.setattr(keyring, "delete_password", fake.delete_password)
+    yield

--- a/tests/integration/test_mcp_integration.py
+++ b/tests/integration/test_mcp_integration.py
@@ -27,25 +27,20 @@ MOCK_MCP_SERVER_SCRIPT = textwrap.dedent("""\
     import sys
 
     def read_message():
-        headers = {}
-        while True:
-            line = sys.stdin.readline()
-            if not line or line.strip() == '':
-                break
-            if ':' in line:
-                key, value = line.split(':', 1)
-                headers[key.strip().lower()] = value.strip()
-        content_length = int(headers.get('content-length', 0))
-        if content_length == 0:
+        # MCP stdio framing: one JSON-RPC message per line, terminated by \\n
+        # (or \\r\\n on Windows-emitted streams). rstrip() handles both.
+        # Reference: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#stdio
+        line = sys.stdin.readline()
+        if not line:
             return None
-        body = sys.stdin.read(content_length)
-        return json.loads(body)
+        text = line.rstrip()
+        if not text:
+            return None
+        return json.loads(text)
 
     def send_message(msg):
-        body = json.dumps(msg)
-        header = f"Content-Length: {len(body.encode('utf-8'))}\\r\\n\\r\\n"
-        sys.stdout.write(header)
-        sys.stdout.write(body)
+        body = json.dumps(msg, separators=(",", ":"))
+        sys.stdout.write(body + '\\n')
         sys.stdout.flush()
 
     TOOLS = [

--- a/tests/test_mcp_client_full.py
+++ b/tests/test_mcp_client_full.py
@@ -1,10 +1,18 @@
+import asyncio
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from src.services.mcp.client import McpClient, MAX_RECONNECT_ATTEMPTS
+from src.services.mcp.client import (
+    McpClient,
+    MAX_RECONNECT_ATTEMPTS,
+    _cache_key_for,
+    _unwrap_exception_group_message,
+)
 from src.services.mcp.types import (
     ConnectedMCPServer,
     FailedMCPServer,
+    McpHTTPServerConfig,
     McpStdioServerConfig,
     ScopedMcpServerConfig,
     ServerCapabilities,
@@ -58,3 +66,356 @@ class TestMcpClientClose:
         client._connected = True
         await client.close()
         assert client.is_connected is False
+
+
+class TestConnectionCacheKey:
+    """Regression coverage for WI-2.5: content-based cache key.
+
+    Two equivalent configs from different dataclass instances must hit the
+    same cache entry; materially different configs must not. The previous
+    keying (``id(config)``) missed on every config-object reconstruction.
+    """
+
+    def test_equivalent_stdio_configs_share_key(self):
+        config_a = ScopedMcpServerConfig(
+            config=McpStdioServerConfig(command="my-server", args=["--port", "9999"]),
+            scope="project",
+        )
+        config_b = ScopedMcpServerConfig(
+            config=McpStdioServerConfig(command="my-server", args=["--port", "9999"]),
+            scope="project",
+        )
+        assert _cache_key_for("srv", config_a) == _cache_key_for("srv", config_b)
+
+    def test_different_stdio_args_distinct_keys(self):
+        config_a = ScopedMcpServerConfig(
+            config=McpStdioServerConfig(command="my-server", args=["--port", "9999"]),
+            scope="project",
+        )
+        config_b = ScopedMcpServerConfig(
+            config=McpStdioServerConfig(command="my-server", args=["--port", "8888"]),
+            scope="project",
+        )
+        assert _cache_key_for("srv", config_a) != _cache_key_for("srv", config_b)
+
+    def test_equivalent_http_configs_share_key(self):
+        config_a = ScopedMcpServerConfig(
+            config=McpHTTPServerConfig(url="https://mcp.example.com/v1"),
+            scope="project",
+        )
+        config_b = ScopedMcpServerConfig(
+            config=McpHTTPServerConfig(url="https://mcp.example.com/v1"),
+            scope="project",
+        )
+        assert _cache_key_for("srv", config_a) == _cache_key_for("srv", config_b)
+
+    def test_different_names_distinct_keys(self):
+        config = ScopedMcpServerConfig(
+            config=McpStdioServerConfig(command="my-server"),
+            scope="project",
+        )
+        assert _cache_key_for("a", config) != _cache_key_for("b", config)
+
+    def test_different_env_distinct_keys_credential_isolation(self):
+        """Credential-isolation regression: two stdio configs with the same
+        command/args but different env (e.g. different API keys) MUST produce
+        distinct cache keys. Otherwise the second registration would silently
+        reuse the first server's authenticated connection.
+
+        This is the failure mode the prior ``get_mcp_server_signature``-based
+        keying allowed; mirrors TS' full-config-serialization keying at
+        ``typescript/src/services/mcp/client.ts:600-606``.
+        """
+        config_a = ScopedMcpServerConfig(
+            config=McpStdioServerConfig(
+                command="my-server", args=["--p", "9999"], env={"API_KEY": "k1"}
+            ),
+            scope="project",
+        )
+        config_b = ScopedMcpServerConfig(
+            config=McpStdioServerConfig(
+                command="my-server", args=["--p", "9999"], env={"API_KEY": "k2"}
+            ),
+            scope="project",
+        )
+        assert _cache_key_for("srv", config_a) != _cache_key_for("srv", config_b)
+
+    def test_different_http_headers_distinct_keys_credential_isolation(self):
+        """Same credential-isolation contract for HTTP transports: two HTTP
+        configs with the same URL but different ``Authorization`` headers MUST
+        produce distinct cache keys."""
+        config_a = ScopedMcpServerConfig(
+            config=McpHTTPServerConfig(
+                url="https://mcp.example.com/v1",
+                headers={"Authorization": "Bearer t1"},
+            ),
+            scope="project",
+        )
+        config_b = ScopedMcpServerConfig(
+            config=McpHTTPServerConfig(
+                url="https://mcp.example.com/v1",
+                headers={"Authorization": "Bearer t2"},
+            ),
+            scope="project",
+        )
+        assert _cache_key_for("srv", config_a) != _cache_key_for("srv", config_b)
+
+    def test_different_scope_distinct_keys(self):
+        """``project`` vs ``user`` scope must not share cache entries even with
+        otherwise-identical configs (different policy lifecycles)."""
+        config_proj = ScopedMcpServerConfig(
+            config=McpStdioServerConfig(command="my-server"),
+            scope="project",
+        )
+        config_user = ScopedMcpServerConfig(
+            config=McpStdioServerConfig(command="my-server"),
+            scope="user",
+        )
+        assert _cache_key_for("srv", config_proj) != _cache_key_for("srv", config_user)
+
+
+class TestExceptionGroupUnwrap:
+    """Regression: anyio task groups in the SDK wrap real connection errors
+    in BaseExceptionGroup, whose ``str()`` is "unhandled errors in a TaskGroup
+    (1 sub-exception)" — useless for diagnosing an unreachable server. The
+    unwrapper walks the group tree and returns the leaf's message."""
+
+    def test_plain_exception_passthrough(self):
+        exc = ConnectionRefusedError("port 1 closed")
+        assert _unwrap_exception_group_message(exc) == "port 1 closed"
+
+    def test_unwraps_single_subexception(self):
+        try:
+            inner_exc = ConnectionRefusedError("nobody home")
+            raise BaseExceptionGroup("unhandled errors", [inner_exc])
+        except BaseExceptionGroup as eg:
+            assert _unwrap_exception_group_message(eg) == "nobody home"
+
+    def test_recurses_through_nested_groups(self):
+        try:
+            inner = TimeoutError("connect timed out")
+            mid = BaseExceptionGroup("inner group", [inner])
+            raise BaseExceptionGroup("outer group", [mid])
+        except BaseExceptionGroup as eg:
+            assert _unwrap_exception_group_message(eg) == "connect timed out"
+
+    def test_falls_back_to_class_name_when_str_is_empty(self):
+        class MyError(Exception):
+            pass
+
+        # __str__ returns "" if no args
+        assert _unwrap_exception_group_message(MyError()) == "MyError"
+
+
+class TestSessionExpiryRetry:
+    """Phase 6a WI-6.1 (gap #8): when a Streamable-HTTP server restarts and
+    returns a session-terminated error, ``call_tool`` must clear the cache,
+    reconnect, and retry the call once. A second session-expired error on
+    retry surfaces (no infinite loop)."""
+
+    @pytest.mark.asyncio
+    async def test_session_expired_triggers_reconnect_and_retry_succeeds(self):
+        from src.services.mcp.errors import McpToolCallError
+        from src.services.mcp.types import McpStdioServerConfig, ScopedMcpServerConfig
+
+        client = McpClient()
+        client._name = "test-server"
+        client._config = ScopedMcpServerConfig(
+            config=McpStdioServerConfig(command="dummy"),
+            scope="project",
+        )
+
+        # First call raises session-expired; second call (after reconnect)
+        # returns success. Tracker captures the call sequence.
+        calls = []
+
+        async def fake_send_request(method, params=None):
+            calls.append(method)
+            if len(calls) == 1:
+                raise McpToolCallError(
+                    '{"code":32600,"message":"Session terminated"}',
+                    "Session terminated",
+                )
+            return {
+                "content": [{"type": "text", "text": "ok after retry"}],
+                "isError": False,
+            }
+
+        # Stub reconnect() to return a Connected state without doing real I/O.
+        async def fake_reconnect():
+            return ConnectedMCPServer(name="test-server", config=client._config)
+
+        with patch.object(client, "_send_request", side_effect=fake_send_request):
+            with patch.object(client, "reconnect", side_effect=fake_reconnect):
+                result = await client.call_tool("greet", {"name": "world"})
+
+        assert result.is_error is False
+        assert result.content[0]["text"] == "ok after retry"
+        # Confirm exactly two send_request invocations: original + one retry.
+        assert calls == ["tools/call", "tools/call"]
+
+    @pytest.mark.asyncio
+    async def test_session_expired_retry_propagates_second_failure(self):
+        """If the retry also fails with session-expired, surface the error
+        instead of looping (no infinite recovery storm)."""
+        from src.services.mcp.errors import McpToolCallError
+        from src.services.mcp.types import McpStdioServerConfig, ScopedMcpServerConfig
+
+        client = McpClient()
+        client._name = "test-server"
+        client._config = ScopedMcpServerConfig(
+            config=McpStdioServerConfig(command="dummy"),
+            scope="project",
+        )
+
+        calls = []
+
+        async def fake_send_request(method, params=None):
+            calls.append(method)
+            raise McpToolCallError(
+                '{"code":32600,"message":"Session terminated"}',
+                "Session terminated",
+            )
+
+        async def fake_reconnect():
+            return ConnectedMCPServer(name="test-server", config=client._config)
+
+        with patch.object(client, "_send_request", side_effect=fake_send_request):
+            with patch.object(client, "reconnect", side_effect=fake_reconnect):
+                with pytest.raises(McpToolCallError, match="Session terminated"):
+                    await client.call_tool("greet", {"name": "world"})
+
+        assert len(calls) == 2  # original + one retry, then raise
+
+    @pytest.mark.asyncio
+    async def test_non_session_expired_error_propagates_without_retry(self):
+        """A non-session-expired McpToolCallError must NOT trigger reconnect.
+        E.g., a tool returning a regular invalid-input error should fail
+        immediately with no extra connect overhead."""
+        from src.services.mcp.errors import McpToolCallError
+        from src.services.mcp.types import McpStdioServerConfig, ScopedMcpServerConfig
+
+        client = McpClient()
+        client._name = "test-server"
+        client._config = ScopedMcpServerConfig(
+            config=McpStdioServerConfig(command="dummy"),
+            scope="project",
+        )
+
+        calls = []
+        reconnect_called = []
+
+        async def fake_send_request(method, params=None):
+            calls.append(method)
+            raise McpToolCallError(
+                '{"code":-32602,"message":"Invalid params"}',
+                "Invalid params",
+            )
+
+        async def fake_reconnect():
+            reconnect_called.append(True)
+            return ConnectedMCPServer(name="test-server", config=client._config)
+
+        with patch.object(client, "_send_request", side_effect=fake_send_request):
+            with patch.object(client, "reconnect", side_effect=fake_reconnect):
+                with pytest.raises(McpToolCallError, match="Invalid params"):
+                    await client.call_tool("greet", {"name": "world"})
+
+        assert len(calls) == 1, "non-session-expired error should not retry"
+        assert len(reconnect_called) == 0, "reconnect must not be called"
+
+    @pytest.mark.asyncio
+    async def test_session_expired_with_failed_reconnect_propagates_original(self):
+        """If reconnect fails after a session-expired signal, the SAME original
+        error instance must propagate (not a fresh one with the same message).
+        Identity assertion guards against a regression where the recovery path
+        might lose the original exception's traceback / context.
+        """
+        from src.services.mcp.errors import McpToolCallError
+        from src.services.mcp.types import (
+            FailedMCPServer,
+            McpStdioServerConfig,
+            ScopedMcpServerConfig,
+        )
+
+        client = McpClient()
+        client._name = "test-server"
+        client._config = ScopedMcpServerConfig(
+            config=McpStdioServerConfig(command="dummy"),
+            scope="project",
+        )
+
+        original = McpToolCallError(
+            '{"code":-32001,"message":"Session expired"}',
+            "Session expired",
+        )
+
+        async def fake_send_request(method, params=None):
+            raise original
+
+        async def fake_reconnect():
+            return FailedMCPServer(name="test-server", error="connection refused")
+
+        with patch.object(client, "_send_request", side_effect=fake_send_request):
+            with patch.object(client, "reconnect", side_effect=fake_reconnect):
+                with pytest.raises(McpToolCallError) as excinfo:
+                    await client.call_tool("greet", {"name": "world"})
+        # Identity check, not just message match.
+        assert excinfo.value is original
+
+    @pytest.mark.asyncio
+    async def test_concurrent_session_expired_calls_share_one_reconnect(self):
+        """Concurrent call_tool invocations that all observe an expired
+        session must NOT trigger N reconnects — one reconnect serves all.
+        Verified by counting reconnect invocations under N=10 parallel
+        callers, where the first call to each invokes session-expired."""
+        from src.services.mcp.errors import McpToolCallError
+        from src.services.mcp.types import McpStdioServerConfig, ScopedMcpServerConfig
+
+        client = McpClient()
+        client._name = "test-server"
+        client._config = ScopedMcpServerConfig(
+            config=McpStdioServerConfig(command="dummy"),
+            scope="project",
+        )
+
+        # First N calls (the original tries by all parallel callers) all
+        # raise session-expired; calls N+1..2N (the retries after recovery)
+        # all succeed. With N=10 concurrent callers, that's 20 total
+        # _send_request invocations. Without the lock + epoch, the recovery
+        # path would call reconnect 10 times instead of once.
+        N_CALLERS = 10
+        call_history: list[str] = []
+
+        async def fake_send_request(method, params=None):
+            idx = len(call_history)
+            call_history.append(method)
+            if idx < N_CALLERS:
+                raise McpToolCallError(
+                    '{"code":32600,"message":"Session terminated"}',
+                    "Session terminated",
+                )
+            return {"content": [{"type": "text", "text": f"ok-{idx}"}], "isError": False}
+
+        reconnect_calls: list[int] = []
+
+        async def fake_reconnect():
+            reconnect_calls.append(1)
+            # Slow reconnect so all 10 callers pile up on the lock.
+            await asyncio.sleep(0.05)
+            return ConnectedMCPServer(name="test-server", config=client._config)
+
+        with patch.object(client, "_send_request", side_effect=fake_send_request):
+            with patch.object(client, "reconnect", side_effect=fake_reconnect):
+                results = await asyncio.gather(
+                    *(client.call_tool("greet", {"i": i}) for i in range(N_CALLERS)),
+                    return_exceptions=True,
+                )
+
+        # All N_CALLERS succeeded.
+        assert all(not isinstance(r, Exception) for r in results), results
+        # But reconnect was called exactly once — the lock + epoch suppressed
+        # the stampede.
+        assert len(reconnect_calls) == 1, (
+            f"expected 1 reconnect, got {len(reconnect_calls)}"
+        )

--- a/tests/test_mcp_errors.py
+++ b/tests/test_mcp_errors.py
@@ -43,18 +43,121 @@ class TestMcpToolCallError:
 
 
 class TestIsMcpSessionExpiredError:
-    def test_with_code_32001(self) -> None:
-        err = Exception('"code":-32001')
+    """Per MCP Streamable-HTTP spec, session-expiry requires BOTH HTTP 404
+    AND JSON-RPC -32001 — matches TS isMcpSessionExpiredError behavior."""
+
+    @staticmethod
+    def _make_error(message: str, status_code: int | None = None) -> Exception:
+        err = Exception(message)
+        if status_code is not None:
+            err.status_code = status_code  # type: ignore[attr-defined]
+        return err
+
+    def test_404_plus_neg32001_returns_true(self) -> None:
+        err = self._make_error('{"code":-32001,"message":"session expired"}', status_code=404)
         assert is_mcp_session_expired_error(err) is True
 
-    def test_with_code_32001_spaced(self) -> None:
-        err = Exception('"code": -32001')
+    def test_404_plus_neg32001_spaced_returns_true(self) -> None:
+        err = self._make_error('{"code": -32001, "message": "session expired"}', status_code=404)
         assert is_mcp_session_expired_error(err) is True
 
-    def test_without_code(self) -> None:
-        err = Exception("some other error")
+    def test_500_with_neg32001_returns_false(self) -> None:
+        """Wrong HTTP status: spec requires 404 specifically."""
+        err = self._make_error('{"code":-32001}', status_code=500)
         assert is_mcp_session_expired_error(err) is False
 
-    def test_empty_error(self) -> None:
+    def test_404_without_neg32001_returns_false(self) -> None:
+        """Wrong JSON-RPC code: spec requires -32001 specifically."""
+        err = self._make_error('{"code":-32600,"message":"invalid request"}', status_code=404)
+        assert is_mcp_session_expired_error(err) is False
+
+    def test_no_status_code_with_neg32001_returns_true(self) -> None:
+        """Dual-mode: when no HTTP status is exposed (the SDK-wrapped
+        ``McpToolCallError`` shape), the JSON-RPC code -32001 alone is
+        sufficient signal — the HTTP status was erased by the transport
+        layer."""
+        err = Exception('{"code":-32001,"message":"session expired"}')
+        assert is_mcp_session_expired_error(err) is True
+
+    def test_no_status_code_with_sdk_32600_returns_true(self) -> None:
+        """Dual-mode: the mcp PyPI SDK uses ``code=32600`` (positive!) on a
+        Streamable-HTTP 404. Detect it too."""
+        err = Exception('{"code":32600,"message":"Session terminated"}')
+        assert is_mcp_session_expired_error(err) is True
+
+    def test_no_status_code_with_session_terminated_message_returns_true(self) -> None:
+        """Dual-mode fallback: the SDK's canonical envelope (code + message)
+        is sufficient even if the specific code value isn't recognized."""
+        err = Exception('{"code":-99999,"message":"Session terminated"}')
+        assert is_mcp_session_expired_error(err) is True
+
+    def test_session_terminated_text_alone_does_not_match(self) -> None:
+        """Regression: free-form 'Session terminated' text without a JSON-RPC
+        envelope (e.g. a tool returning the phrase as content) must NOT be
+        misclassified. The regex requires a code field nearby."""
+        err = Exception("My remote chat: Session terminated by user")
+        assert is_mcp_session_expired_error(err) is False
+
+    def test_neg32600_invalid_request_does_NOT_match_pos32600(self) -> None:
+        """Regression for substring ambiguity: ``-32600`` (JSON-RPC Invalid
+        Request) must NOT match the SDK's ``32600`` session-terminated code.
+        Without a regex with negative-lookbehind, ``"code":32600`` substring-
+        matches ``"code":-32600`` and every malformed-request error falsely
+        triggers reconnect."""
+        err = Exception('{"code":-32600,"message":"Invalid Request"}')
+        assert is_mcp_session_expired_error(err) is False
+
+    def test_neg320013_does_NOT_match_neg32001(self) -> None:
+        """Regression: ``-320013`` (longer suffix) must NOT match ``-32001``.
+        Without a digit-boundary, plain substring matching would falsely
+        accept this."""
+        err = Exception('{"code":-320013,"message":"some error"}')
+        assert is_mcp_session_expired_error(err) is False
+
+    def test_falls_back_to_code_attribute(self) -> None:
+        """Some libs put HTTP status on `.code` instead of `.status_code`."""
+        err = Exception('"code":-32001')
+        err.code = 404  # type: ignore[attr-defined]
+        assert is_mcp_session_expired_error(err) is True
+
+    def test_httpx_shape_status_on_response(self) -> None:
+        """httpx errors put status on ``.response.status_code``, not on the
+        exception itself. Once Phase 2 lands HttpTransport, this is the
+        dominant shape the function will see."""
+
+        class _FakeResponse:
+            status_code = 404
+
+        class _HttpxLikeError(Exception):
+            def __init__(self, message: str) -> None:
+                super().__init__(message)
+                self.response = _FakeResponse()
+
+        err = _HttpxLikeError('{"code":-32001,"message":"session expired"}')
+        assert is_mcp_session_expired_error(err) is True
+
+    def test_httpx_shape_with_wrong_status(self) -> None:
+        """Same shape as above but HTTP 500 — must return False."""
+
+        class _FakeResponse:
+            status_code = 500
+
+        class _HttpxLikeError(Exception):
+            def __init__(self, message: str) -> None:
+                super().__init__(message)
+                self.response = _FakeResponse()
+
+        err = _HttpxLikeError('"code":-32001')
+        assert is_mcp_session_expired_error(err) is False
+
+    def test_http_status_enum_coerced_to_int(self) -> None:
+        """Some clients (httpx with newer Python) expose HTTPStatus enum."""
+        from http import HTTPStatus
+
+        err = Exception('"code":-32001')
+        err.status_code = HTTPStatus.NOT_FOUND  # type: ignore[attr-defined]
+        assert is_mcp_session_expired_error(err) is True
+
+    def test_empty_error_returns_false(self) -> None:
         err = Exception()
         assert is_mcp_session_expired_error(err) is False

--- a/tests/test_mcp_transport.py
+++ b/tests/test_mcp_transport.py
@@ -80,38 +80,87 @@ class TestStdioTransport:
 
         await transport.close()
 
+    @pytest.mark.asyncio
+    async def test_receives_multiple_messages_back_to_back(self) -> None:
+        """Regression guard: confirms message boundaries are preserved across
+        sequential sends. A buffering-bug regression (e.g. switching readline
+        for read(N)) would surface here as merged or dropped messages."""
+        transport = StdioTransport(command="cat")
+        await transport.start()
+
+        await transport.send(JsonRpcMessage(method="m1", id=1))
+        await transport.send(JsonRpcMessage(method="m2", id=2))
+        await transport.send(JsonRpcMessage(method="m3", id=3))
+
+        r1 = await asyncio.wait_for(transport.receive(), timeout=5.0)
+        r2 = await asyncio.wait_for(transport.receive(), timeout=5.0)
+        r3 = await asyncio.wait_for(transport.receive(), timeout=5.0)
+
+        assert r1 is not None and r2 is not None and r3 is not None
+        assert (r1.method, r1.id) == ("m1", 1)
+        assert (r2.method, r2.id) == ("m2", 2)
+        assert (r3.method, r3.id) == ("m3", 3)
+
+        await transport.close()
+
+    @pytest.mark.asyncio
+    async def test_receive_strips_crlf_line_endings(self) -> None:
+        """Regression guard: a Node-on-Windows / `print()`-on-Windows server may
+        emit CRLF terminators. The receiver must strip both."""
+        # Use printf to write a CRLF-terminated JSON line to stdout.
+        crlf_payload = '{"jsonrpc":"2.0","method":"crlf","id":1}\r\n'
+        transport = StdioTransport(
+            command="printf",
+            args=["%s", crlf_payload],
+        )
+        await transport.start()
+        response = await asyncio.wait_for(transport.receive(), timeout=5.0)
+        assert response is not None
+        assert response.method == "crlf"
+        assert response.id == 1
+        await transport.close()
+
 
 class TestHttpTransport:
+    """HttpTransport now wraps ``mcp.client.streamable_http.streamable_http_client``
+    (Path A, ch15-mcp Phase 2). It speaks Streamable HTTP per the MCP spec. End-to-
+    end behavior is exercised in ``tests/integration/test_real_mcp_server.py``;
+    these unit tests cover instantiation + lifecycle wiring.
+    """
+
     def test_init(self) -> None:
         transport = HttpTransport(url="https://example.com")
         assert transport.is_connected is False
 
     @pytest.mark.asyncio
-    async def test_start_close(self) -> None:
+    async def test_start_allocates_streams_does_not_validate_connectivity(self) -> None:
+        """``HttpTransport.start()`` enters the SDK's async context manager,
+        which allocates the read/write streams + spawns task-group workers
+        but does **not** make a real HTTP request. So ``start()`` succeeds
+        even against an unreachable URL; connectivity surfaces on the first
+        ``send()`` (typically the ``initialize`` request from
+        ``McpClient.connect()``). This test documents that contract — it is
+        NOT a connectivity check, just a lifecycle smoke-test."""
         transport = HttpTransport(url="https://example.com")
         await transport.start()
         assert transport.is_connected is True
         await transport.close()
         assert transport.is_connected is False
 
-    @pytest.mark.asyncio
-    async def test_send_not_implemented(self) -> None:
-        transport = HttpTransport(url="https://example.com")
-        await transport.start()
-        with pytest.raises(NotImplementedError):
-            await transport.send(JsonRpcMessage(method="test"))
-        await transport.close()
-
 
 class TestSseTransport:
+    """SseTransport now wraps ``mcp.client.sse.sse_client`` (Path A)."""
+
     def test_init(self) -> None:
         transport = SseTransport(url="https://example.com/sse")
         assert transport.is_connected is False
 
-    @pytest.mark.asyncio
-    async def test_send_not_implemented(self) -> None:
-        transport = SseTransport(url="https://example.com")
-        await transport.start()
-        with pytest.raises(NotImplementedError):
-            await transport.send(JsonRpcMessage(method="test"))
-        await transport.close()
+
+class TestWebSocketTransport:
+    """WebSocketTransport wraps ``mcp.client.websocket.websocket_client``."""
+
+    def test_init(self) -> None:
+        from src.services.mcp.transport import WebSocketTransport
+
+        transport = WebSocketTransport(url="ws://example.com/mcp")
+        assert transport.is_connected is False

--- a/uv.lock
+++ b/uv.lock
@@ -463,6 +463,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dataclasses"
+version = "0.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/12/7919c5d8b9c497f9180db15ea8ead6499812ea8264a6ae18766d93c59fe5/dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97", size = 36581, upload-time = "2020-11-13T14:40:30.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ca/75fac5856ab5cfa51bbbcefa250182e50441074fdc3f803f6e76451fab43/dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf", size = 19041, upload-time = "2020-11-13T14:40:29.194Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1062,11 +1071,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.8.0"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/72/8259b2bccfe4673330cea843ab23f86858a419d8f1493f66d413a76c7e3b/PyJWT-2.8.0.tar.gz", hash = "sha256:57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de", size = 78313, upload-time = "2023-07-18T20:02:22.594Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/4f/e04a8067c7c96c364cef7ef73906504e2f40d690811c021e1a1901473a19/PyJWT-2.8.0-py3-none-any.whl", hash = "sha256:59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320", size = 22591, upload-time = "2023-07-18T20:02:21.561Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [[package]]
@@ -1694,18 +1706,17 @@ wheels = [
 
 [[package]]
 name = "zhipuai"
-version = "2.1.5.20250825"
+version = "1.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
+    { name = "dataclasses" },
     { name = "pyjwt" },
+    { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/9b/972de785a9859bbb5ee6425e011f154001886207860acdedebd174b7f2c2/zhipuai-2.1.5.20250825.tar.gz", hash = "sha256:50fc3982565ee631bd640b1166a1d223de227958026a74a1dd0e26dbd58d729c", size = 69899, upload-time = "2025-08-25T10:58:52.796Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/13/77cd9b2f3cad0f2fe6baded20fc20a02c3e62f14487117c296fdd2abeec0/zhipuai-1.0.7.tar.gz", hash = "sha256:b80f699543d83cce8648acf1ce32bc2725d1c1c443baffa5882abc2cc704d581", size = 5901, upload-time = "2023-06-12T12:15:31.812Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/95/22fc274f670e4531da20cc607991c34e7f8f4de5baa589e454e77e2492fa/zhipuai-2.1.5.20250825-py3-none-any.whl", hash = "sha256:aaad19881e514a4682598f07503b82d60b8b9a91cd83f9bcda988b94853c830d", size = 119097, upload-time = "2025-08-25T10:58:51.518Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b5/cb50cd478426b17503154585be799e09506b70944e2fe2402aa029987fa2/zhipuai-1.0.7-py3-none-any.whl", hash = "sha256:360c01b8c2698f366061452e86d5a36a5ff68a576ea33940da98e4806f232530", size = 7873, upload-time = "2023-06-12T12:15:30.355Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

First of **5 stacked PRs** porting the TypeScript MCP (Model Context Protocol) implementation to Python for chapter 15. Merge in numerical order.

This PR establishes the foundation: adopt the `mcp` PyPI SDK as the spec-transport layer (matching TS), add the content-cache key, tighten session-expiry detection, wire jsonschema validation, split local/project/managed/dynamic config scopes, add keyring-backed token storage, the in-process linked-pair transport for SDK-mode servers, output budget truncation, and the legacy plaintext-store migration shim.

**Subsequent PRs build on this:**
- PR 2/5 (`feat/ch15-mcp-2-oauth-xaa`) — OAuth + XAA + runtime manager + polish
- PR 3/5 (`feat/ch15-mcp-3-blockers`) — Critic security blocker fixes
- PR 4/5 (`feat/ch15-mcp-4-majors`) — Critic major fixes
- PR 5/5 (`feat/ch15-mcp-5-followups`) — Critic follow-up hardening

## Scope

- `src/services/mcp/transport.py` — SDK adapters (StdioTransport, HttpTransport, SseTransport, WebSocketTransport) wrapping `mcp.client.{stdio,streamable_http,sse,websocket}_client`
- `src/services/mcp/client.py` — content-based cache key, ExceptionGroup unwrap, session-expiry recovery with `_recovery_lock` + epoch
- `src/services/mcp/errors.py` — dual-mode `is_mcp_session_expired_error` with regex `_NEG32001_RE` / `_POS32600_RE` (negative-lookbehind to avoid `-32600` false positives)
- `src/services/mcp/tool_wrapper.py` — jsonschema input validation with strong-ref validator cache (closes WeakValueDictionary GC bug)
- `src/services/mcp/config.py` — local/project/managed/dynamic scope split, threading.Lock-protected dynamic registry, CCR proxy URL unwrap, `_normalize_url_for_signature`
- `src/services/mcp/auth.py` — Keyring-backed `McpTokenStore` (`KEYRING_SERVICE = "claude-code-mcp"`), FailKeyring rejection, legacy migration with collision-safe archives
- `src/services/mcp/types.py` — Added `auth_server_metadata_url` to remote configs, expanded `NeedsAuthMCPServer`, `parse_server_config` camelCase + snake_case
- `src/services/mcp/output_validation.py` — `truncate_mcp_content_if_needed` with tiktoken fast-path (`_TIKTOKEN_FAST_PATH_THRESHOLD = 100_000`) for repetitive-content perf
- `src/services/mcp/in_process_transport.py` — `_ClosedSentinel` class, direct `put_nowait`, drain-then-close in `receive()`
- `tests/conftest.py` — autouse `_isolate_mcp_keyring` fixture with `_InMemoryKeyringBackend`
- `tests/integration/test_real_mcp_server.py` — npx-skipped smoke test (WI-0.3)
- `uv.lock` — regenerated for new MCP / keyring / jsonschema / tiktoken deps

## Test plan

- [x] `uv run pytest tests/test_mcp_*.py tests/integration/test_mcp_integration*.py` — **207 tests passing**
- [x] No regressions in broader test suite
- [ ] Reviewer: confirm SDK-adapter design matches TS' `Transport` abstraction (typescript/src/services/mcp/client.ts:7-21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)