### PR TITLE
fix(repl): restore enter-to-queue hint + ANSI diff backgrounds

### DIFF
--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -1022,14 +1022,20 @@ class ClawcodexREPL:
                 # on newlines and produce blank rows between every entry.
                 stripped = raw.rstrip("\n").rstrip("\r")
                 if stripped.startswith("+"):
-                    diff.append(f"     {new_lineno:>4}  ", style="green")
-                    diff.append("+ ", style="bold green")
-                    diff.append(stripped[1:] + "\n", style="green on #0f2314")
+                    # Match Claude Code's TUI: default terminal foreground
+                    # on an ANSI ``green`` / ``red`` background, so added
+                    # and removed lines read as solid bars regardless of
+                    # the user's terminal theme. Mirrors
+                    # ``typescript/src/utils/theme.ts``'s ANSI themes —
+                    # ``diffAdded: 'ansi:green'``, ``diffRemoved: 'ansi:red'``.
+                    diff.append(f"     {new_lineno:>4}  ", style="on green")
+                    diff.append("+ ", style="bold on green")
+                    diff.append(stripped[1:] + "\n", style="on green")
                     new_lineno += 1
                 elif stripped.startswith("-"):
-                    diff.append(f"     {old_lineno:>4}  ", style="red")
-                    diff.append("- ", style="bold red")
-                    diff.append(stripped[1:] + "\n", style="red on #2a1414")
+                    diff.append(f"     {old_lineno:>4}  ", style="on red")
+                    diff.append("- ", style="bold on red")
+                    diff.append(stripped[1:] + "\n", style="on red")
                     old_lineno += 1
                 else:
                     body = stripped[1:] if stripped.startswith(" ") else stripped

--- a/src/repl/live_status.py
+++ b/src/repl/live_status.py
@@ -418,13 +418,17 @@ class LiveStatus:
         frame = _SPINNER_FRAMES[self._frame_index % len(_SPINNER_FRAMES)]
         self._frame_index += 1
 
-        # Match ``SpinnerAnimationRow.tsx``'s suffix:
-        # ``(esc to interrupt · 12s · ↓ 1.2k tokens)``.
-        # Timer + token suffix gated by 30s elapsed (or ``verbose``),
-        # tokens additionally require a non-zero count.
+        # Spinner suffix layout:
+        # ``(esc to interrupt · enter to queue · 12s · ↓ 1.2k tokens)``.
+        # ``esc to interrupt · enter to queue`` is always shown — it tells
+        # the user how to cancel the run and that typing-while-thinking
+        # queues the next prompt (a Python-only affordance not present in
+        # the TS reference's ``SpinnerAnimationRow.tsx``). Timer + token
+        # parts mirror the TS suffix and stay gated by 30s elapsed (or
+        # ``verbose``); tokens additionally require a non-zero count.
         elapsed_ms = (time.monotonic() - started_at) * 1000 if started_at else 0.0
         wants_timer = verbose or elapsed_ms > _SHOW_TIMER_AFTER_MS
-        suffix = "  (esc to interrupt"
+        suffix = "  (esc to interrupt · enter to queue"
         if wants_timer:
             suffix += f" · {format_duration(elapsed_ms)}"
             if tokens > 0:

--- a/src/tui/widgets/structured_diff.py
+++ b/src/tui/widgets/structured_diff.py
@@ -191,16 +191,20 @@ def render_diff(lines: Iterable[DiffLine], *, width_hint: int = 100) -> Text:
             out.append("\n")
             continue
         if line.kind == "add":
+            # Match Claude Code's TUI: default terminal foreground on an
+            # ANSI ``green`` background so the entire row reads as a solid
+            # bar. Mirrors ``typescript/src/utils/theme.ts``'s ANSI themes
+            # (``diffAdded: 'ansi:green'``).
             prefix = _fmt_line_no(None, line.new_lineno)
-            out.append(prefix, style="green")
-            out.append("+ ", style="bold green")
-            out.append(line.text, style="green on #0f2314")
+            out.append(prefix, style="on green")
+            out.append("+ ", style="bold on green")
+            out.append(line.text, style="on green")
             out.append("\n")
         elif line.kind == "remove":
             prefix = _fmt_line_no(line.old_lineno, None)
-            out.append(prefix, style="red")
-            out.append("- ", style="bold red")
-            out.append(line.text, style="red on #2a1414")
+            out.append(prefix, style="on red")
+            out.append("- ", style="bold on red")
+            out.append(line.text, style="on red")
             out.append("\n")
         else:  # context
             prefix = _fmt_line_no(line.old_lineno, line.new_lineno)


### PR DESCRIPTION
## Summary

Two small REPL/TUI polish fixes the spinner refactor (#?, commit 6f29564) lost. The Textual TUI refactor was supposed to improve `/tui` mode only — the default Rich REPL accidentally lost a hint and renders diffs with poor contrast.

### Spinner suffix (`src/repl/live_status.py`)

`6f29564` ported the TS reference's `SpinnerAnimationRow.tsx` suffix (`(esc to interrupt · 12s · ↓ 1.2k tokens)`) but dropped the Python-only `enter to queue` hint. Bring it back; the timer/token parts (gated at 30s, matching TS) stay as-is.

Before:
```
(esc to interrupt)                                               # < 30s
(esc to interrupt · 35s · ↓ 1.2k tokens)                         # ≥ 30s
```

After:
```
(esc to interrupt · enter to queue)                              # < 30s
(esc to interrupt · enter to queue · 35s · ↓ 1.2k tokens)        # ≥ 30s
```

### Edit-diff line colors (`src/repl/core.py`, `src/tui/widgets/structured_diff.py`)

Both diff renderers used `green on #0f2314` / `red on #2a1414` — green/red text on a near-black-green/red background, near-zero contrast and the content is barely legible.

Switch to the ANSI theme variant Claude Code's TUI uses ([`typescript/src/utils/theme.ts:223-228`](typescript/src/utils/theme.ts#L223-L228) — `diffAdded: 'ansi:green'`, `diffRemoved: 'ansi:red'`): paint the gutter, sigil, and content with an ANSI `green` / `red` background and leave the foreground to the terminal default. Each row reads as a single solid bar across both light and dark themes.

## Test plan

- [x] `pytest tests/test_repl.py tests/test_live_status.py` — 33 passed
- [x] `pytest tests/tui/test_phase3_dialogs.py` — 24 passed
- [ ] Eyeball the spinner suffix in an interactive `clawcodex` session
- [ ] Eyeball an Edit/MultiEdit tool result in both the default REPL and `clawcodex --tui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)