### PR TITLE
feat(ch07/M3): rename CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY env var

### DIFF
--- a/src/query/query.py
+++ b/src/query/query.py
@@ -364,10 +364,29 @@ async def _call_model_sync(
     return [assistant_msg], tool_use_blocks
 
 
-# Max tools to run in parallel (TS default: 10, configurable via env var)
-MAX_TOOL_USE_CONCURRENCY = int(
-    os.environ.get("CLAWCODEX_MAX_TOOL_USE_CONCURRENCY", "10")
-)
+# Max tools to run in parallel (TS default: 10, configurable via env var).
+# Reads CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY (the name documented in
+# chapter 7 and used in the TS reference). Falls back to the legacy
+# CLAWCODEX_MAX_TOOL_USE_CONCURRENCY with a DeprecationWarning so
+# users learn to migrate.
+def _resolve_max_tool_use_concurrency() -> int:
+    canonical = os.environ.get("CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY")
+    if canonical is not None:
+        return int(canonical)
+    legacy = os.environ.get("CLAWCODEX_MAX_TOOL_USE_CONCURRENCY")
+    if legacy is not None:
+        import warnings
+        warnings.warn(
+            "CLAWCODEX_MAX_TOOL_USE_CONCURRENCY is deprecated; use "
+            "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return int(legacy)
+    return 10
+
+
+MAX_TOOL_USE_CONCURRENCY = _resolve_max_tool_use_concurrency()
 
 
 @dataclass

--- a/tests/test_tool_orchestration.py
+++ b/tests/test_tool_orchestration.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import importlib
+import os
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from src.services.tool_execution.orchestrator import (
     Batch,
@@ -88,3 +92,40 @@ class TestPartitionToolCalls:
         ctx = _make_context([])
         batches = partition_tool_calls([], ctx)
         assert len(batches) == 0
+
+
+class TestMaxToolUseConcurrencyEnvVar:
+    """ch07 / M3: production path reads CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY,
+    not CLAWCODEX_MAX_TOOL_USE_CONCURRENCY."""
+
+    def _reload_query(self):
+        # Use importlib.import_module so the module is keyed in
+        # sys.modules under its fully-qualified name, which
+        # importlib.reload requires.
+        query_mod = importlib.import_module("src.query.query")
+        return importlib.reload(query_mod)
+
+    def test_canonical_env_var_is_honoured(self, monkeypatch):
+        monkeypatch.delenv("CLAWCODEX_MAX_TOOL_USE_CONCURRENCY", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY", "3")
+        mod = self._reload_query()
+        assert mod.MAX_TOOL_USE_CONCURRENCY == 3
+
+    def test_legacy_env_var_still_works_with_deprecation(self, monkeypatch):
+        monkeypatch.delenv("CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY", raising=False)
+        monkeypatch.setenv("CLAWCODEX_MAX_TOOL_USE_CONCURRENCY", "7")
+        with pytest.warns(DeprecationWarning, match="CLAWCODEX_MAX_TOOL_USE_CONCURRENCY"):
+            mod = self._reload_query()
+        assert mod.MAX_TOOL_USE_CONCURRENCY == 7
+
+    def test_canonical_takes_precedence_over_legacy(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY", "5")
+        monkeypatch.setenv("CLAWCODEX_MAX_TOOL_USE_CONCURRENCY", "99")
+        mod = self._reload_query()
+        assert mod.MAX_TOOL_USE_CONCURRENCY == 5
+
+    def test_default_when_neither_set(self, monkeypatch):
+        monkeypatch.delenv("CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY", raising=False)
+        monkeypatch.delenv("CLAWCODEX_MAX_TOOL_USE_CONCURRENCY", raising=False)
+        mod = self._reload_query()
+        assert mod.MAX_TOOL_USE_CONCURRENCY == 10


### PR DESCRIPTION
## Summary

- Rename the production tool-concurrency env var from `CLAWCODEX_MAX_TOOL_USE_CONCURRENCY` to `CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY` to match the TS reference (`typescript/src/services/tools/toolOrchestration.ts:10`) and chapter-7 documentation.
- Preserve backwards compatibility: legacy name still works but emits a `DeprecationWarning` on use.
- Closes gap **M3** from `my-docs/ch07-concurrency-gap-analysis.md` — independent P0 quick win, unblocks Epic E1 but doesn't depend on it.

## Why

The Python port wired the concurrency cap to a clawcodex-prefixed env var; everywhere else (TS reference, chapter, orchestrator's own helper at `orchestrator.py:34`) the name is `CLAUDE_CODE_…`. Users following the chapter or the upstream docs couldn't actually override the production cap.

## Test plan

- [x] `tests/test_tool_orchestration.py::TestMaxToolUseConcurrencyEnvVar` — 4 cases:
  - canonical name honored
  - legacy name still works (with `DeprecationWarning`)
  - canonical takes precedence over legacy
  - default 10 when neither set
- [x] All existing `test_tool_orchestration.py` cases unchanged (9 pass).

## Stacked PR sequence

This is **PR 1 of 3** for the ch07 concurrency refactor. The chain:
1. **#this** — env var rename (independent P0)
2. **next** — git subcommand classification (independent P0)
3. **next** — Epic E1: production cutover to `run_tool_use` (PreToolUse/PostToolUse hooks now fire on the concurrent path, plus M6/M7/2a.5/2b)

Each merges cleanly off the previous; merging in order minimizes rebase churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)