### PR TITLE
feat(ch07/M5): block git push/commit/reset from concurrent batches

### DIFF
--- a/src/tool_system/tools/bash/read_only_validation.py
+++ b/src/tool_system/tools/bash/read_only_validation.py
@@ -3,6 +3,11 @@
 Splits on pipes and checks each sub-command's leading token against
 a known allowlist.  Rejects shell meta-characters that could bypass
 the simple token check (back-ticks, $(), etc.).
+
+For ``git``, also validates the subcommand against a read-only allowlist.
+Without this, ``git push`` / ``git commit`` / ``git reset`` would
+classify as concurrency-safe and could race on ``.git/index.lock``
+when emitted in the same model turn.
 """
 
 from __future__ import annotations
@@ -29,6 +34,19 @@ READONLY_COMMANDS: frozenset[str] = frozenset([
     "hostname", "tput",
 ])
 
+# Subcommands of ``git`` that don't mutate the working tree, index, or
+# refs. Anything not on this allowlist is treated as not read-only,
+# including stash/worktree (their ``list`` form is read but
+# sub-subcommand parsing isn't worth the complexity here — the
+# conservative classification is a parallelism loss, not a correctness
+# loss).
+GIT_READ_SUBCOMMANDS: frozenset[str] = frozenset([
+    "status", "diff", "log", "show", "blame", "branch", "tag",
+    "describe", "rev-parse", "rev-list", "ls-files", "ls-tree",
+    "cat-file", "config", "remote", "shortlog", "name-rev", "reflog",
+    "whatchanged",
+])
+
 _SHELL_METACHARS = re.compile(r"[;&|`$(){}><]")
 
 
@@ -53,4 +71,11 @@ def is_command_read_only(command: str) -> bool:
         base = tokens[0].split("/")[-1]
         if base not in READONLY_COMMANDS:
             return False
+        if base == "git":
+            # `git` alone is help/usage — treat as not safe (ambiguous).
+            if len(tokens) < 2:
+                return False
+            git_subcmd = tokens[1].lower()
+            if git_subcmd not in GIT_READ_SUBCOMMANDS:
+                return False
     return True

--- a/tests/test_bash_read_only_classifier.py
+++ b/tests/test_bash_read_only_classifier.py
@@ -1,0 +1,86 @@
+"""ch07 / M5: read-only Bash classifier — git subcommand discipline.
+
+Locks the classification of git subcommands. `git push` / `git commit`
+/ `git reset` are NOT read-only and must not be batched concurrently
+(would race on .git/index.lock). `git status` / `git log` / etc. are
+read-only and safe to parallelize.
+
+Also locks the conservative classification of `git stash *` and
+`git worktree *` — their `list` forms are technically read-only, but
+the plan classifies them as NOT read-only to avoid parsing
+sub-subcommands. A contributor who later "fixes" this needs to update
+the test deliberately.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.tool_system.tools.bash.read_only_validation import is_command_read_only
+
+
+@pytest.mark.parametrize("cmd", [
+    "git push",
+    "git push --force origin main",
+    "git commit -m hi",
+    "git commit --amend",
+    "git reset --hard",
+    "git rebase main",
+    "git clean -fd",
+    "git merge feature",
+    "git cherry-pick HEAD~1",
+    "git stash",
+    "git stash push",
+    "git stash list",        # conservatively NOT marked safe
+    "git worktree list",     # conservatively NOT marked safe
+    "git worktree add ../x", # actually mutating
+    "git",                   # bare git → ambiguous → not safe
+])
+def test_git_write_subcommands_are_not_read_only(cmd: str) -> None:
+    assert is_command_read_only(cmd) is False, f"{cmd!r} must not be read-only"
+
+
+@pytest.mark.parametrize("cmd", [
+    "git status",
+    "git diff",
+    "git diff --stat HEAD~1",
+    "git log --oneline -5",
+    "git show HEAD",
+    "git blame foo.py",
+    "git branch",
+    "git tag",
+    "git describe",
+    "git rev-parse HEAD",
+    "git ls-files",
+    "git ls-tree HEAD",
+    "git config user.name",
+    "git remote -v",
+    "git shortlog",
+    "git reflog",
+    "git whatchanged",
+])
+def test_git_read_subcommands_are_read_only(cmd: str) -> None:
+    assert is_command_read_only(cmd) is True, f"{cmd!r} must be read-only"
+
+
+@pytest.mark.parametrize("cmd", [
+    "ls -la",
+    "cat README.md",
+    "grep foo bar.txt",
+    "find . -name '*.py'",
+    "cat README.md | grep foo",
+    "ls | head",
+])
+def test_existing_read_only_commands_unaffected(cmd: str) -> None:
+    """The git-subcommand change must not regress any non-git case."""
+    assert is_command_read_only(cmd) is True
+
+
+@pytest.mark.parametrize("cmd", [
+    "rm -rf /",
+    "mkdir build",
+    "ls && cat foo",           # compound — still rejected by metachar guard
+    "echo $(whoami)",          # subshell — still rejected by metachar guard
+    "cat foo; rm bar",         # semicolon — still rejected
+])
+def test_existing_non_read_only_commands_unaffected(cmd: str) -> None:
+    assert is_command_read_only(cmd) is False


### PR DESCRIPTION
## Summary

- Add a git-subcommand allowlist to ``is_command_read_only`` so only read-only git invocations (``status``, ``diff``, ``log``, ``show``, ``blame``, ``branch``, ``tag``, ``describe``, ``rev-parse``, ``rev-list``, ``ls-files``, ``ls-tree``, ``cat-file``, ``config``, ``remote``, ``shortlog``, ``name-rev``, ``reflog``, ``whatchanged``) classify as concurrency-safe.
- ``git push``, ``git commit``, ``git reset``, ``git rebase``, ``git stash``, ``git worktree add``, etc. now classify as NOT safe to parallelize.
- Closes gap **M5** (correctness, not parallelism). Two concurrent git writes in the same turn would race on ``.git/index.lock``; the existing classifier missed this because it only checked the base binary, not the subcommand.

## Why

The Python port had ``git`` on the read-only allowlist as a top-level command, so ``git push`` and ``git commit`` were considered concurrency-safe. The TS reference uses ``commandHasAnyGit`` + subcommand-aware allowlisting in ``checkReadOnlyConstraints``. This PR ports that subcommand discipline.

## Test plan

- [x] ``tests/test_bash_read_only_classifier.py`` — ~30 parametrized cases:
  - All write/mutating git subcommands → NOT read-only
  - All read git subcommands → read-only
  - ``git stash list`` and ``git worktree list`` conservatively demoted (test locks the choice)
  - Existing non-git read-only commands (``ls -la``, ``cat README.md``, ``cat foo \| grep bar``) unaffected
  - Existing non-read-only commands (``rm -rf``, ``ls && cat``, ``echo \$(whoami)``) unaffected
- [x] 156 bash-related tests pass (parser, permissions, security, read-only classifier).

## Conservative classification note

``git stash list`` and ``git worktree list`` ARE read-only in reality, but the plan classifies them as NOT safe to parallelize rather than parsing sub-subcommands. The test pins this conservative choice with a docstring so a future contributor "fixing" it knows it's intentional.

## Stacked PR sequence

**PR 2 of 3** — Base: ``feat/ch07-concurrency-1-env-var`` (PR #62).

- 1️⃣ #62 — env var rename
- 2️⃣ **#this** — git subcommand classifier
- 3️⃣ next — Epic E1: orchestrator cutover (C2 + C3 + M6 + M7 + 2a.5 + 2b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)