### PR TITLE
ch03 state #1: Signal + Store primitives

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,9 @@ Documentation = "https://github.com/agentforce314/clawcodex#readme"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+# Prepend the project root so pytest imports the worktree's ``src/`` rather
+# than the parent repo's editable-install mapping.
+pythonpath = ["."]
 markers = [
     "integration: marks tests as integration (deselect with '-m \"not integration\"')",
     "linux_only: marks tests that require Linux (auto-skipped on macOS/Windows)",
@@ -91,3 +94,50 @@ filterwarnings = [
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["src*"]
+
+# ---------------------------------------------------------------------------
+# import-linter — DAG-leaf enforcement for src/bootstrap/state.py
+# ---------------------------------------------------------------------------
+# Mirrors the TS ``bootstrap-isolation`` ESLint rule (typescript/src/.eslintrc).
+# Bootstrap state is a DAG leaf — it cannot import from feature subsystems
+# (``src/tui``, ``src/repl``, ``src/agent``, ``src/services``, ``src/query``,
+# ``src/context_system``, ``src/permissions``, ``src/command_system``,
+# ``src/tool_system``, ``src/coordinator``). The contract below enforces
+# this on every commit when ``lint-imports`` runs in CI.
+#
+# To run locally: ``pip install import-linter && lint-imports``.
+# (Not in ``dev`` extras yet — install ad-hoc until CI wires it in.)
+[tool.importlinter]
+root_package = "src"
+
+[[tool.importlinter.contracts]]
+name = "bootstrap/state.py cannot import from feature subsystems (DAG-leaf rule)"
+type = "forbidden"
+source_modules = ["src.bootstrap.state"]
+forbidden_modules = [
+    "src.tui",
+    "src.repl",
+    "src.agent",
+    "src.services",
+    "src.query",
+    "src.context_system",
+    "src.permissions",
+    "src.command_system",
+    "src.tool_system",
+    "src.coordinator",
+    "src.providers",
+    "src.tasks",
+    "src.bridge",
+    "src.remote",
+    "src.commands",
+    "src.skills",
+]
+
+# TODO: add a positive-allowlist (kept) contract restricting bootstrap to
+# import only from ``src.utils.signal`` and a small set of leaf utilities.
+# The forbidden contract above misses the case where someone adds
+# ``from src.utils.tui_helpers import foo`` to bootstrap — ``src.utils`` is
+# not in the blocklist. ``import-linter`` doesn't have a perfect positive-
+# allowlist primitive; the closest is the ``independence`` contract or a
+# custom contract. Plan §P1.0 acknowledged the ~30 min research cost.
+# Tracking as a Phase-2 follow-up.

--- a/src/utils/signal.py
+++ b/src/utils/signal.py
@@ -1,0 +1,94 @@
+"""Tiny pub/sub primitive for pure event signals (no stored state).
+
+Mirrors ``typescript/src/utils/signal.ts`` (43 LOC). Distinct from a Store —
+there is no ``get_state``, no snapshot. Use this when subscribers only need
+to know "something happened" (optionally with event args), not "what is the
+current value".
+
+Typical pattern in bootstrap state::
+
+    _session_switched: Signal = create_signal()
+    on_session_switch = _session_switched.subscribe
+
+    def switch_session(sid: SessionId, ...) -> None:
+        ...
+        _session_switched.emit(sid)
+
+Listener call order is **insertion-order** — backed by a ``dict[Callable, None]``
+which is an ordered set in CPython 3.7+. Callers should not depend on order
+as a contract; this is documented behavior for ease of debugging, not part
+of the API.
+
+**Exception handling.** A listener that raises propagates the exception
+through ``emit`` to the caller — matches TS ``signal.ts`` which does not
+catch. Any caller wanting fan-out-with-suppression must build it on top
+(typically a try/except wrapper around the listener registration).
+
+**Subscriber-mutation safety.** ``emit`` snapshots the listener set before
+iterating, so a listener that calls ``subscribe`` or its own
+``unsubscribe`` during the callback does not corrupt the iteration. A
+newly-subscribed listener will **not** receive the in-flight emit; it
+fires on the next ``emit``.
+
+**Deliberate divergence from TS.** TS ``signal.ts`` iterates the live
+``Set``, so a listener that subscribes a new listener during emit
+**would** fire the new listener on the same emit (per JS Set iterator
+semantics). The Python port uses snapshot iteration as a defensive
+choice — same-emit fan-out from a freshly-subscribed listener is rarely
+intentional and is harder to reason about. Tests at
+``tests/test_signal.py:84-101`` lock the snapshot behavior so a future
+refactor doesn't silently re-match TS at the cost of breaking callers
+that depend on the current semantics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+
+@dataclass
+class Signal:
+    """Listener-set primitive with ``subscribe``/``emit``/``clear``.
+
+    ``emit`` arguments are untyped (``*args: Any``) — the TS reference uses
+    ``ParamSpec`` for typed event args, but Python's ``Protocol[ParamSpec]``
+    has historically been flaky on mypy. The plan defers typed-emit to a
+    follow-up WI; see ``my-docs/ch03-state-refactoring-plan.md`` §Risks.
+    """
+
+    # Ordered set: dict-with-None-values preserves insertion order on
+    # CPython 3.7+. Hash+equality-based deduplication, same as ``set``.
+    _listeners: dict[Callable[..., None], None] = field(default_factory=dict)
+
+    def subscribe(self, listener: Callable[..., None]) -> Callable[[], None]:
+        """Register ``listener``. Returns an idempotent unsubscribe function."""
+        self._listeners[listener] = None
+
+        def unsubscribe() -> None:
+            self._listeners.pop(listener, None)
+
+        return unsubscribe
+
+    def emit(self, *args: Any, **kwargs: Any) -> None:
+        """Call every subscribed listener with the given args.
+
+        Iterates a snapshot taken at emit-entry; mid-iteration
+        subscribe/unsubscribe does not affect the current emit. Exceptions
+        raised by listeners propagate to the caller.
+        """
+        for listener in list(self._listeners):
+            listener(*args, **kwargs)
+
+    def clear(self) -> None:
+        """Remove all listeners. Useful in dispose/reset paths."""
+        self._listeners.clear()
+
+
+def create_signal() -> Signal:
+    """Factory matching the TS ``createSignal<Args>()`` name. Returns a
+    fresh ``Signal`` with no listeners."""
+    return Signal()
+
+
+__all__ = ["Signal", "create_signal"]

--- a/src/utils/store.py
+++ b/src/utils/store.py
@@ -1,0 +1,107 @@
+"""Tiny reactive store: get, set (via updater), subscribe + onChange.
+
+Mirrors ``typescript/src/state/store.ts`` (34 LOC). Designed to back a
+single AppState instance per process. The defining properties:
+
+* **Updater function pattern.** Callers pass ``(prev) -> next`` rather than
+  a raw new value. This eliminates stale-state bugs from captured-stale
+  closures in async paths — every mutation sees the freshest state.
+
+* **Identity skip.** If ``updater(prev) is prev``, the mutation is a no-op
+  and no listeners or onChange callbacks fire. Python's ``is`` matches TS
+  ``Object.is`` semantics for the use case (no ``NaN``, no ``+0``/``-0``
+  involved — state is a dataclass instance).
+
+  **Caller contract:** if the updater wants the no-op skip, it must return
+  the *same reference* it received. Returning a freshly-constructed but
+  structurally-identical dataclass fires onChange and all listeners. This
+  is intentional and matches TS — structural equality would be O(n) per
+  mutation and would silently swallow "I built a new object on purpose"
+  intent.
+
+* **onChange fires synchronously before listeners.** The bridge to bootstrap
+  state and other side effects hook here so they run *before* any
+  subscriber re-renders. Listeners see the post-onChange state via
+  ``get_state``.
+
+The TS module is `state/store.ts`; here it lives under ``src/utils/`` to
+parallel ``src/utils/signal.py`` and avoid `src/state/__init__.py`'s
+import-time file I/O. Architectural cost of deviation: zero — the store is
+single-purpose and location-agnostic.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Generic, TypeVar
+
+T = TypeVar("T")
+
+Listener = Callable[[], None]
+OnChange = Callable[[T, T], None]  # (old_state, new_state) -> None
+
+
+class Store(Generic[T]):
+    """Reactive store backed by a single state reference.
+
+    Use ``create_store(initial, on_change=...)`` to construct. The store
+    is *not* thread-safe; if multiple threads need to mutate, wrap the
+    setter in a lock at the call site.
+    """
+
+    def __init__(self, initial_state: T, on_change: OnChange | None = None) -> None:
+        self._state: T = initial_state
+        # Ordered (insertion-stable) set of listeners; matches Signal.
+        self._listeners: dict[Listener, None] = {}
+        self._on_change: OnChange | None = on_change
+
+    def get_state(self) -> T:
+        """Return the current state reference. Callers must treat the
+        return value as immutable — mutating it in place breaks the store's
+        identity-skip contract."""
+        return self._state
+
+    def set_state(self, updater: Callable[[T], T]) -> None:
+        """Apply ``updater(prev)`` to produce the next state.
+
+        If ``updater(prev) is prev`` (identity check, not structural
+        equality), the call is a no-op. Otherwise:
+
+        1. The new state is committed to ``self._state``.
+        2. ``on_change(old, new)`` fires synchronously (if set).
+        3. All subscribed listeners fire in insertion order.
+
+        Listener and onChange exceptions propagate to the caller; the
+        state has already been committed at that point.
+        """
+        prev = self._state
+        nxt = updater(prev)
+        if nxt is prev:
+            return
+        # Commit state BEFORE side effects so an onChange or listener that
+        # reads back via get_state() sees the new value (matches TS).
+        self._state = nxt
+        if self._on_change is not None:
+            self._on_change(prev, nxt)
+        # Snapshot before iterating: listeners may unsubscribe themselves
+        # or trigger another set_state during the callback.
+        for listener in list(self._listeners):
+            listener()
+
+    def subscribe(self, listener: Listener) -> Callable[[], None]:
+        """Register ``listener``. Returns an idempotent unsubscribe."""
+        self._listeners[listener] = None
+
+        def unsubscribe() -> None:
+            self._listeners.pop(listener, None)
+
+        return unsubscribe
+
+
+def create_store(initial_state: T, on_change: OnChange | None = None) -> Store[T]:
+    """Construct a ``Store`` with the given initial state and optional
+    ``on_change`` callback. Factory function matches the TS ``createStore``
+    name."""
+    return Store(initial_state, on_change)
+
+
+__all__ = ["Store", "Listener", "OnChange", "create_store"]

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,0 +1,165 @@
+"""Tests for ``src/utils/signal.py``.
+
+Mirrors the TS test discipline for ``utils/signal.ts``: subscribe-then-emit,
+unsubscribe, clear, plus the listener-mutates-subscribers and
+listener-raises edge cases. Lockfile for the dict-as-ordered-set
+insertion-order behavior.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.utils.signal import Signal, create_signal
+
+
+class TestSubscribeThenEmit(unittest.TestCase):
+    def test_subscribe_then_emit_calls_listener(self) -> None:
+        sig = create_signal()
+        calls: list[tuple] = []
+
+        sig.subscribe(lambda *args: calls.append(args))
+        sig.emit("hello")
+
+        self.assertEqual(calls, [("hello",)])
+
+    def test_subscribe_returns_an_unsubscribe_function(self) -> None:
+        sig = create_signal()
+        unsubscribe = sig.subscribe(lambda: None)
+        self.assertTrue(callable(unsubscribe))
+
+    def test_emit_with_no_listeners_is_a_noop(self) -> None:
+        sig = create_signal()
+        sig.emit("ignored")  # should not raise
+
+
+class TestInsertionOrder(unittest.TestCase):
+    def test_emit_calls_listeners_in_insertion_order(self) -> None:
+        """The dict-as-ordered-set lockfile. CPython 3.7+ guarantees this."""
+        sig = create_signal()
+        order: list[str] = []
+
+        sig.subscribe(lambda: order.append("first"))
+        sig.subscribe(lambda: order.append("second"))
+        sig.subscribe(lambda: order.append("third"))
+
+        sig.emit()
+
+        self.assertEqual(order, ["first", "second", "third"])
+
+
+class TestUnsubscribe(unittest.TestCase):
+    def test_unsubscribe_removes_listener(self) -> None:
+        sig = create_signal()
+        calls: list[int] = []
+
+        unsubscribe = sig.subscribe(lambda: calls.append(1))
+        sig.emit()
+        unsubscribe()
+        sig.emit()
+
+        self.assertEqual(calls, [1])  # listener fired once before unsubscribe
+
+    def test_unsubscribe_is_idempotent(self) -> None:
+        sig = create_signal()
+        unsubscribe = sig.subscribe(lambda: None)
+        unsubscribe()
+        unsubscribe()  # second call: should not raise
+
+
+class TestClear(unittest.TestCase):
+    def test_clear_removes_all_listeners(self) -> None:
+        sig = create_signal()
+        calls: list[int] = []
+
+        sig.subscribe(lambda: calls.append(1))
+        sig.subscribe(lambda: calls.append(2))
+        sig.clear()
+        sig.emit()
+
+        self.assertEqual(calls, [])
+
+
+class TestSubscriberMutationDuringEmit(unittest.TestCase):
+    def test_listener_that_subscribes_another_listener_is_safe(self) -> None:
+        """Subscribing a fresh listener inside an emit callback must not
+        corrupt the iteration. The new listener does NOT receive the
+        in-flight emit; it fires on subsequent emits."""
+        sig = create_signal()
+        calls: list[str] = []
+
+        def first_listener() -> None:
+            calls.append("first")
+            sig.subscribe(lambda: calls.append("late"))
+
+        sig.subscribe(first_listener)
+        sig.emit()
+
+        self.assertEqual(calls, ["first"])  # late listener NOT called this emit
+
+        sig.emit()
+        self.assertIn("late", calls)  # late listener fires on the next emit
+
+    def test_listener_that_unsubscribes_itself_is_safe(self) -> None:
+        """A listener that removes itself during the callback must complete
+        the current emit without raising, and must not fire on subsequent
+        emits."""
+        sig = create_signal()
+        calls: list[int] = []
+        unsubscribe_holder: list = []
+
+        def self_removing() -> None:
+            calls.append(1)
+            unsubscribe_holder[0]()
+
+        unsubscribe = sig.subscribe(self_removing)
+        unsubscribe_holder.append(unsubscribe)
+
+        sig.emit()
+        sig.emit()
+
+        self.assertEqual(calls, [1])  # only the first emit triggers
+
+
+class TestExceptionPropagation(unittest.TestCase):
+    def test_emit_with_listener_that_raises_propagates(self) -> None:
+        """Matches TS behavior: ``signal.ts`` does not catch listener
+        exceptions. They propagate to the caller of emit."""
+        sig = create_signal()
+
+        def raiser() -> None:
+            raise RuntimeError("boom")
+
+        sig.subscribe(raiser)
+
+        with self.assertRaises(RuntimeError):
+            sig.emit()
+
+
+class TestEmitArgs(unittest.TestCase):
+    def test_emit_with_positional_and_kwargs(self) -> None:
+        sig = create_signal()
+        received: list[tuple] = []
+
+        sig.subscribe(lambda *args, **kwargs: received.append((args, kwargs)))
+        sig.emit("a", "b", x=1, y=2)
+
+        self.assertEqual(received, [(("a", "b"), {"x": 1, "y": 2})])
+
+
+class TestType(unittest.TestCase):
+    def test_create_signal_returns_a_signal(self) -> None:
+        sig = create_signal()
+        self.assertIsInstance(sig, Signal)
+
+    def test_each_create_signal_call_returns_a_fresh_instance(self) -> None:
+        a = create_signal()
+        b = create_signal()
+        self.assertIsNot(a, b)
+        a.subscribe(lambda: None)
+        self.assertEqual(len(a._listeners), 1)
+        self.assertEqual(len(b._listeners), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,254 @@
+"""Tests for ``src/utils/store.py``.
+
+Mirrors the TS test discipline for ``state/store.ts``: updater-with-prev,
+identity-skip on same reference, on_change-before-listeners ordering, and
+the caller-contract lock that structural-equality-but-different-reference
+DOES fire (proves we're using ``is``, not ``==``).
+"""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass
+
+from src.utils.store import Store, create_store
+
+
+@dataclass
+class _S:
+    """Test fixture state — a small dataclass for identity testing."""
+    x: int
+    label: str = ""
+
+
+class TestGetState(unittest.TestCase):
+    def test_get_state_returns_initial(self) -> None:
+        store = create_store(_S(x=1))
+        self.assertEqual(store.get_state(), _S(x=1))
+
+    def test_get_state_returns_same_reference(self) -> None:
+        initial = _S(x=1)
+        store = create_store(initial)
+        self.assertIs(store.get_state(), initial)
+
+
+class TestSetState(unittest.TestCase):
+    def test_set_state_with_updater_replaces_state(self) -> None:
+        store = create_store(_S(x=1))
+        store.set_state(lambda prev: _S(x=2, label="bumped"))
+        self.assertEqual(store.get_state(), _S(x=2, label="bumped"))
+
+    def test_set_state_passes_prev_to_updater(self) -> None:
+        store = create_store(_S(x=5))
+        received: list[_S] = []
+        store.set_state(lambda prev: (received.append(prev), prev)[1])
+        self.assertEqual(received, [_S(x=5)])
+
+    def test_set_state_identity_skip_returns_same_ref_does_not_notify(self) -> None:
+        """Identity check: same reference returned → no notification."""
+        store = create_store(_S(x=1))
+        calls: list[int] = []
+        store.subscribe(lambda: calls.append(1))
+
+        # Return the exact same object reference
+        store.set_state(lambda prev: prev)
+
+        self.assertEqual(calls, [])
+
+    def test_set_state_fresh_but_equal_object_DOES_notify(self) -> None:
+        """Caller-contract lock: returning a freshly-constructed but
+        structurally-identical dataclass fires onChange and listeners.
+
+        This proves we're using ``is`` (identity), not ``==`` (equality).
+        Without this test, a future refactor could "optimize" the store
+        to use ``==`` and silently change behavior."""
+        on_change_calls: list[tuple] = []
+        store_with_oc = create_store(
+            _S(x=1),
+            on_change=lambda old, new: on_change_calls.append((old, new)),
+        )
+        listener_calls: list[int] = []
+        store_with_oc.subscribe(lambda: listener_calls.append(1))
+
+        # Construct a freshly-equal but distinct dataclass
+        store_with_oc.set_state(lambda prev: _S(x=1))
+
+        # Both onChange and listener fire because the reference changed
+        self.assertEqual(len(on_change_calls), 1)
+        self.assertEqual(listener_calls, [1])
+        # And the equality check confirms they're structurally equal
+        old, new = on_change_calls[0]
+        self.assertEqual(old, new)
+        self.assertIsNot(old, new)  # but distinct references
+
+
+class TestSubscribe(unittest.TestCase):
+    def test_subscribe_notifies_on_state_change(self) -> None:
+        store = create_store(_S(x=1))
+        calls: list[int] = []
+        store.subscribe(lambda: calls.append(1))
+
+        store.set_state(lambda prev: _S(x=2))
+
+        self.assertEqual(calls, [1])
+
+    def test_subscribe_does_not_notify_on_identity_skip(self) -> None:
+        store = create_store(_S(x=1))
+        calls: list[int] = []
+        store.subscribe(lambda: calls.append(1))
+
+        store.set_state(lambda prev: prev)
+
+        self.assertEqual(calls, [])
+
+    def test_unsubscribe_stops_notifications(self) -> None:
+        store = create_store(_S(x=1))
+        calls: list[int] = []
+        unsubscribe = store.subscribe(lambda: calls.append(1))
+
+        store.set_state(lambda prev: _S(x=2))
+        unsubscribe()
+        store.set_state(lambda prev: _S(x=3))
+
+        self.assertEqual(calls, [1])
+
+    def test_subscribe_multiple_listeners_all_fire_in_insertion_order(self) -> None:
+        store = create_store(_S(x=1))
+        order: list[str] = []
+
+        store.subscribe(lambda: order.append("first"))
+        store.subscribe(lambda: order.append("second"))
+        store.subscribe(lambda: order.append("third"))
+
+        store.set_state(lambda prev: _S(x=2))
+
+        self.assertEqual(order, ["first", "second", "third"])
+
+
+class TestOnChange(unittest.TestCase):
+    def test_on_change_fires_before_listeners(self) -> None:
+        """The core architectural property: side effects run before
+        subscribers, so bootstrap-state mirrors and credential-cache
+        clearing complete before the UI re-renders."""
+        order: list[str] = []
+        store = create_store(
+            _S(x=1),
+            on_change=lambda old, new: order.append("on_change"),
+        )
+        store.subscribe(lambda: order.append("listener"))
+
+        store.set_state(lambda prev: _S(x=2))
+
+        self.assertEqual(order, ["on_change", "listener"])
+
+    def test_on_change_receives_old_and_new_state(self) -> None:
+        received: list[tuple] = []
+        store = create_store(
+            _S(x=1),
+            on_change=lambda old, new: received.append((old, new)),
+        )
+
+        store.set_state(lambda prev: _S(x=2))
+
+        self.assertEqual(len(received), 1)
+        old, new = received[0]
+        self.assertEqual(old, _S(x=1))
+        self.assertEqual(new, _S(x=2))
+
+    def test_on_change_sees_committed_state(self) -> None:
+        """When onChange fires, ``store.get_state()`` already returns the
+        new state — onChange sees committed state, not in-flight."""
+        seen_via_getter: list[_S] = []
+
+        def on_change(old: _S, new: _S) -> None:
+            seen_via_getter.append(store.get_state())
+
+        store = create_store(_S(x=1), on_change=on_change)
+        store.set_state(lambda prev: _S(x=42))
+
+        self.assertEqual(seen_via_getter, [_S(x=42)])
+
+    def test_on_change_not_called_when_no_state_change(self) -> None:
+        calls: list[int] = []
+        store = create_store(_S(x=1), on_change=lambda old, new: calls.append(1))
+
+        store.set_state(lambda prev: prev)
+
+        self.assertEqual(calls, [])
+
+
+class TestReentry(unittest.TestCase):
+    def test_listener_can_call_set_state_no_infinite_recursion(self) -> None:
+        """A listener that triggers another set_state must not deadlock or
+        recurse unbounded. The second set_state runs as a normal sequential
+        call; its listeners fire once for it."""
+        store = create_store(_S(x=0))
+        order: list[int] = []
+        recursion_guard: list[int] = [0]
+
+        def listener() -> None:
+            order.append(store.get_state().x)
+            # Trigger one more set_state but only the first time
+            if recursion_guard[0] == 0:
+                recursion_guard[0] = 1
+                store.set_state(lambda prev: _S(x=prev.x + 1))
+
+        store.subscribe(listener)
+        store.set_state(lambda prev: _S(x=1))
+
+        # First mutation set x=1 → listener fires (sees 1) → triggers x=2
+        # → listener fires again (sees 2). Two total notifications.
+        self.assertEqual(order, [1, 2])
+
+
+class TestUpdaterErrors(unittest.TestCase):
+    def test_set_state_updater_raises_state_unchanged(self) -> None:
+        """If the updater raises, state must remain at prev and no
+        notifications fire."""
+        on_change_calls: list[int] = []
+        store = create_store(
+            _S(x=1),
+            on_change=lambda old, new: on_change_calls.append(1),
+        )
+        calls: list[int] = []
+        store.subscribe(lambda: calls.append(1))
+
+        def raising_updater(prev: _S) -> _S:
+            raise RuntimeError("nope")
+
+        with self.assertRaises(RuntimeError):
+            store.set_state(raising_updater)
+
+        self.assertEqual(store.get_state(), _S(x=1))  # unchanged
+        self.assertEqual(calls, [])
+        self.assertEqual(on_change_calls, [])
+
+    def test_on_change_raises_state_already_committed(self) -> None:
+        """If onChange raises, the state has already been committed at
+        that point (lock the documented contract from store.py:73-74).
+        Subscribers also fire only if the listener-loop reaches them — onChange
+        raising blocks the loop, so subscribers should NOT fire."""
+        def bad_on_change(old: _S, new: _S) -> None:
+            raise RuntimeError("on_change_boom")
+
+        store = create_store(_S(x=1), on_change=bad_on_change)
+        listener_calls: list[int] = []
+        store.subscribe(lambda: listener_calls.append(1))
+
+        with self.assertRaises(RuntimeError):
+            store.set_state(lambda prev: _S(x=2))
+
+        # State committed BEFORE on_change raised
+        self.assertEqual(store.get_state(), _S(x=2))
+        # Listener loop never reached
+        self.assertEqual(listener_calls, [])
+
+
+class TestStoreType(unittest.TestCase):
+    def test_create_store_returns_a_store(self) -> None:
+        store = create_store(_S(x=1))
+        self.assertIsInstance(store, Store)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

First of 6 stacked PRs implementing Chapter 3's two-tier state architecture. This PR is the **foundation** that subsequent PRs build on — no behavior changes to existing code.

- **`src/utils/signal.py`** (94 LOC): mirrors `typescript/src/utils/signal.ts`. Tiny `subscribe`/`emit`/`clear` pub-sub primitive with no stored state. Uses `dict[Callable, None]` for insertion-stable iteration order.
- **`src/utils/store.py`** (107 LOC): mirrors `typescript/src/state/store.ts`. The 34-line `createStore` template ported with the chapter's three load-bearing properties: updater-function pattern (no stale-state bugs), `is`-based identity skip (no spurious notifications), synchronous `onChange`-before-listeners (deterministic side-effect ordering). Lives under `src/utils/` rather than `src/state/` because `src/state/__init__.py` performs file I/O at import time.
- **`pyproject.toml`**: pytest `pythonpath = ["."]` so the worktree's `src/` overrides the editable-install mapping; new `[tool.importlinter]` contract enforcing `src/bootstrap/state.py` as a DAG leaf (analogue of TS's custom `bootstrap-isolation` ESLint rule).

## Test plan
- [x] `pytest tests/test_signal.py tests/test_store.py` — 31 passing
- [x] Covers: insertion-order, subscribe-during-emit, unsubscribe-self, fresh-but-equal-object DOES fire, identity-skip does NOT fire, onChange-before-listeners ordering, reentry safety, updater-raises-leaves-state-unchanged.
- [x] No regressions in the full suite (verified locally; 8 pre-existing failures unrelated to this PR).

## Stacked PR plan
1. **#this** — Signal + Store primitives
2. `feat/ch03-state-2-bootstrap` — Bootstrap state core expansion (~30 fields, accessors, session signal)
3. `feat/ch03-state-3-contextvars` — SdkContext + run_with_sdk_context + Session migration
4. `feat/ch03-state-4-appstate` — AppState dataclass + on_change_app_state router
5. `feat/ch03-state-5-cost-tracker` — Pricing extraction + CostTracker facade + restore orchestrator
6. `feat/ch03-state-6-session-start` — 1h cache eligibility wiring

Each subsequent PR is branched off the previous one. Merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)