### PR TITLE
ch03 state #2: bootstrap state core expansion

### DIFF
--- a/src/bootstrap/state.py
+++ b/src/bootstrap/state.py
@@ -1,26 +1,252 @@
-"""Process-wide session state mirroring ``typescript/src/bootstrap/state.ts``.
+"""Process-wide session state. Mirrors ``typescript/src/bootstrap/state.ts``.
 
-Only the small slice of state needed to gate tool availability is modeled for
-now: whether the current process is running an interactive REPL/TUI session or
-a headless/SDK-style invocation. The default is ``isInteractive = False`` which
-matches the TypeScript default and is flipped to ``True`` by ``start_repl`` and
-``run_tui`` when they boot an interactive UI.
+DO NOT ADD MORE STATE HERE — BE JUDICIOUS WITH GLOBAL STATE.
+
+This module is a DAG leaf — it must not import from any feature subsystem
+package (``src/tui``, ``src/repl``, ``src/agent``, ``src/services``,
+``src/query``, ``src/context_system``, ``src/permissions``,
+``src/command_system``, ``src/tool_system``, ``src/coordinator``). The
+``import-linter`` contract (see ``pyproject.toml``) enforces this when the
+linter is installed; until then, treat the rule as review discipline.
+
+Phase 1 of the ch03 state refactor covers the ~30 fields below.
+Subsequent phases will grow the field list as their respective subsystems
+land (telemetry/OTel handles, plugin/channel state, hooks registry, etc.).
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
+import os
+import time
+import unicodedata
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, NewType
+
+from src.utils.signal import Signal, create_signal
+
+
+# ---------------------------------------------------------------------------
+# Type aliases / value types
+# ---------------------------------------------------------------------------
+
+# Branded session ID (mirrors TS ``type SessionId = string & {__brand: ...}``).
+# Python's NewType is purely a static-analysis hint — it does not enforce
+# the brand at runtime — but it prevents accidental crossover with other
+# string-typed identifiers in type-checked code.
+SessionId = NewType("SessionId", str)
+
+
+@dataclass
+class ModelUsage:
+    """Per-model usage accumulator. Mirrors the TS ``ModelUsage`` type used
+    by ``addToTotalCostState`` and ``setCostStateForRestore``.
+
+    Phase 1 keeps this minimal; richer fields (webSearchRequests, tool-call
+    counts, etc.) land in Phase 2 alongside the cost-tracker consolidation.
+    """
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cost_usd: float = 0.0
+    web_search_requests: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Path resolution helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_real_cwd() -> str:
+    """Resolve ``os.getcwd()`` through ``os.path.realpath`` and NFC-normalize.
+
+    Mirrors TS ``realpathSync(cwd()).normalize('NFC')`` at module init.
+    Captures the cwd at process start — this matches the chapter's note:
+    "The ``originalCwd`` is resolved through ``realpathSync`` and
+    NFC-normalized at process start. It never changes."
+
+    On filesystems where ``realpath`` raises (CloudStorage EPERM on macOS),
+    falls back to the raw cwd, still NFC-normalized.
+    """
+    raw = os.getcwd()
+    try:
+        return unicodedata.normalize("NFC", os.path.realpath(raw))
+    except OSError:
+        return unicodedata.normalize("NFC", raw)
+
+
+def _new_session_id() -> SessionId:
+    return SessionId(str(uuid.uuid4()))
+
+
+# ---------------------------------------------------------------------------
+# State dataclass
+# ---------------------------------------------------------------------------
 
 
 @dataclass
 class _BootstrapState:
+    """The Phase 1 field subset.
+
+    Fields are grouped by domain matching ``bootstrap/state.ts``. New
+    fields land here as their consuming subsystem is ported. **Do not**
+    split this into multiple dataclasses — the single-file discipline is
+    what enforces the DAG-leaf property (one file to lint, one file to
+    reason about).
+    """
+
+    # --- Identity & paths (TS: lines 46-50, 100-103, 219) -------------------
+    original_cwd: str = field(default_factory=_resolve_real_cwd)
+    project_root: str = field(default_factory=_resolve_real_cwd)
+    cwd: str = field(default_factory=_resolve_real_cwd)
+    session_id: SessionId = field(default_factory=_new_session_id)
+    parent_session_id: SessionId | None = None
+    session_project_dir: str | None = None
+
+    # --- Session flags (TS: lines 71-79, 153-157, etc.) ---------------------
     is_interactive: bool = False
+    # Pre-existing default is "claude-code"; TS source uses "cli"
+    # (``bootstrap/state.ts:305``). Keep "claude-code" until existing
+    # call sites are migrated; tracking as a follow-up.
     client_type: str = "claude-code"
+    session_trust_accepted: bool = False
+    session_persistence_disabled: bool = False
+    is_remote_mode: bool = False
+    has_exited_plan_mode: bool = False
+
+    # --- Cost & timing (TS: lines 51-66) -----------------------------------
+    total_cost_usd: float = 0.0
+    total_api_duration: int = 0
+    total_api_duration_without_retries: int = 0
+    total_tool_duration: int = 0
+    start_time: float = field(default_factory=time.time)
+    last_interaction_time: float = field(default_factory=time.time)
+    total_lines_added: int = 0
+    total_lines_removed: int = 0
+    has_unknown_model_cost: bool = False
+    model_usage: dict[str, ModelUsage] = field(default_factory=dict)
+
+    # --- Cache optimization (TS: lines 122-123, 202-205, 207, 256) ---------
+    cached_claude_md_content: str | None = None
+    system_prompt_section_cache: dict[str, str | None] = field(default_factory=dict)
+    pending_post_compaction: bool = False
+    additional_directories_for_claude_md: list[str] = field(default_factory=list)
+
+    # --- Model (TS: lines 68-70) -------------------------------------------
+    main_loop_model_override: str | None = None
+    initial_main_loop_model: str | None = None
+
+    # --- API correlation (TS: lines 244-252, 205) --------------------------
+    prompt_id: str | None = None
+    last_main_request_id: str | None = None
+    last_api_completion_timestamp: float | None = None
+    last_emitted_date: str | None = None
+
+    # --- Backwards-compat extras (pre-existing Python field) ---------------
     extra: dict[str, Any] | None = None
 
 
-_STATE = _BootstrapState()
+# ---------------------------------------------------------------------------
+# Module-scope singleton
+# ---------------------------------------------------------------------------
+
+
+_STATE: _BootstrapState = _BootstrapState()
+
+# ---------------------------------------------------------------------------
+# Signals
+# ---------------------------------------------------------------------------
+
+# Fires whenever ``switch_session`` mutates ``session_id``. Listeners
+# receive the new session id as the single positional argument. Bootstrap
+# cannot import the listener modules (DAG-leaf rule), so consumers register
+# via ``on_session_switch(cb)`` and are responsible for unsubscribing.
+_session_switched: Signal = create_signal()
+on_session_switch = _session_switched.subscribe
+
+
+# ===========================================================================
+# Accessors — Identity & paths
+# ===========================================================================
+
+
+def get_session_id() -> SessionId:
+    """Current session ID. Mirrors TS ``getSessionId()``."""
+    return _STATE.session_id
+
+
+def regenerate_session_id(*, set_current_as_parent: bool = False) -> SessionId:
+    """Generate a fresh UUID session ID and install it.
+
+    If ``set_current_as_parent`` is True, the outgoing session ID becomes
+    the new ``parent_session_id``. Mirrors TS ``regenerateSessionId``.
+    Does NOT emit ``session_switched`` — that is reserved for
+    ``switch_session`` (which is the resume/teleport path). This is the
+    /clear or new-session-within-same-process path.
+    """
+    current = _STATE.session_id
+    if set_current_as_parent:
+        _STATE.parent_session_id = current
+    new_id = _new_session_id()
+    _STATE.session_id = new_id
+    _STATE.session_project_dir = None
+    return new_id
+
+
+def switch_session(session_id: SessionId, project_dir: str | None = None) -> None:
+    """Atomically switch the active session.
+
+    ``session_id`` and ``session_project_dir`` always change together; this
+    is the **only** mutator for either. Mirrors TS ``switchSession``
+    (``bootstrap/state.ts:522``) and the CC-34 single-setter discipline.
+    Fires the ``session_switched`` signal after the mutation.
+    """
+    _STATE.session_id = session_id
+    _STATE.session_project_dir = project_dir
+    _session_switched.emit(session_id)
+
+
+def get_parent_session_id() -> SessionId | None:
+    return _STATE.parent_session_id
+
+
+def get_session_project_dir() -> str | None:
+    return _STATE.session_project_dir
+
+
+def get_original_cwd() -> str:
+    return _STATE.original_cwd
+
+
+def set_original_cwd(path: str) -> None:
+    _STATE.original_cwd = unicodedata.normalize("NFC", path)
+
+
+def get_project_root() -> str:
+    """Stable project root. Set once at startup (and by ``--worktree``);
+    NOT updated by mid-session ``EnterWorktreeTool``. Mirrors TS
+    ``getProjectRoot``."""
+    return _STATE.project_root
+
+
+def set_project_root(path: str) -> None:
+    """Only for ``--worktree`` startup flag. Mirrors TS ``setProjectRoot``."""
+    _STATE.project_root = unicodedata.normalize("NFC", path)
+
+
+def get_cwd_state() -> str:
+    return _STATE.cwd
+
+
+def set_cwd_state(path: str) -> None:
+    _STATE.cwd = unicodedata.normalize("NFC", path)
+
+
+# ===========================================================================
+# Accessors — Session flags
+# ===========================================================================
 
 
 def get_is_interactive() -> bool:
@@ -43,10 +269,359 @@ def set_client_type(value: str) -> None:
     _STATE.client_type = str(value)
 
 
+def get_session_trust_accepted() -> bool:
+    return _STATE.session_trust_accepted
+
+
+def set_session_trust_accepted(value: bool) -> None:
+    _STATE.session_trust_accepted = bool(value)
+
+
+def is_session_persistence_disabled() -> bool:
+    return _STATE.session_persistence_disabled
+
+
+def set_session_persistence_disabled(value: bool) -> None:
+    _STATE.session_persistence_disabled = bool(value)
+
+
+def get_is_remote_mode() -> bool:
+    return _STATE.is_remote_mode
+
+
+def set_is_remote_mode(value: bool) -> None:
+    _STATE.is_remote_mode = bool(value)
+
+
+def has_exited_plan_mode_in_session() -> bool:
+    return _STATE.has_exited_plan_mode
+
+
+def set_has_exited_plan_mode(value: bool) -> None:
+    _STATE.has_exited_plan_mode = bool(value)
+
+
+# ===========================================================================
+# Accessors — Cost & timing
+# ===========================================================================
+
+
+def get_total_cost_usd() -> float:
+    return _STATE.total_cost_usd
+
+
+def add_to_total_cost_state(
+    cost: float,
+    model_usage: ModelUsage,
+    model: str,
+) -> None:
+    """Record a cost event. Mirrors TS ``addToTotalCostState``."""
+    _STATE.model_usage[model] = model_usage
+    _STATE.total_cost_usd += cost
+
+
+def get_total_api_duration() -> int:
+    return _STATE.total_api_duration
+
+
+def get_total_api_duration_without_retries() -> int:
+    return _STATE.total_api_duration_without_retries
+
+
+def add_to_total_duration_state(duration: int, duration_without_retries: int) -> None:
+    _STATE.total_api_duration += duration
+    _STATE.total_api_duration_without_retries += duration_without_retries
+
+
+def get_total_tool_duration() -> int:
+    return _STATE.total_tool_duration
+
+
+def add_to_tool_duration(duration: int) -> None:
+    _STATE.total_tool_duration += duration
+
+
+def get_total_lines_added() -> int:
+    return _STATE.total_lines_added
+
+
+def get_total_lines_removed() -> int:
+    return _STATE.total_lines_removed
+
+
+def add_to_total_lines_changed(added: int, removed: int) -> None:
+    _STATE.total_lines_added += added
+    _STATE.total_lines_removed += removed
+
+
+def has_unknown_model_cost() -> bool:
+    return _STATE.has_unknown_model_cost
+
+
+def set_has_unknown_model_cost() -> None:
+    _STATE.has_unknown_model_cost = True
+
+
+def get_model_usage() -> dict[str, ModelUsage]:
+    """Return the per-model usage map. Callers may read but should not
+    mutate; use ``add_to_total_cost_state`` to record."""
+    return _STATE.model_usage
+
+
+def get_start_time() -> float:
+    return _STATE.start_time
+
+
+def get_last_interaction_time() -> float:
+    return _STATE.last_interaction_time
+
+
+def update_last_interaction_time() -> None:
+    _STATE.last_interaction_time = time.time()
+
+
+def reset_cost_state() -> None:
+    """Reset accumulators for a fresh session. Mirrors TS ``resetCostState``."""
+    _STATE.total_cost_usd = 0.0
+    _STATE.total_api_duration = 0
+    _STATE.total_api_duration_without_retries = 0
+    _STATE.total_tool_duration = 0
+    _STATE.start_time = time.time()
+    _STATE.total_lines_added = 0
+    _STATE.total_lines_removed = 0
+    _STATE.has_unknown_model_cost = False
+    _STATE.model_usage = {}
+    _STATE.prompt_id = None
+
+
+def set_cost_state_for_restore(
+    *,
+    total_cost_usd: float,
+    total_api_duration: int,
+    total_api_duration_without_retries: int,
+    total_tool_duration: int,
+    total_lines_added: int,
+    total_lines_removed: int,
+    last_duration: float | None = None,
+    model_usage: dict[str, ModelUsage] | None = None,
+) -> None:
+    """Restore accumulators from a persisted session snapshot.
+
+    Called by the (deferred Phase 2) ``restore_cost_state_for_session``
+    orchestrator. Mirrors TS ``setCostStateForRestore``
+    (``bootstrap/state.ts:955``).
+    """
+    _STATE.total_cost_usd = total_cost_usd
+    _STATE.total_api_duration = total_api_duration
+    _STATE.total_api_duration_without_retries = total_api_duration_without_retries
+    _STATE.total_tool_duration = total_tool_duration
+    _STATE.total_lines_added = total_lines_added
+    _STATE.total_lines_removed = total_lines_removed
+    if model_usage is not None:
+        _STATE.model_usage = dict(model_usage)
+    if last_duration is not None:
+        _STATE.start_time = time.time() - last_duration
+
+
+# ===========================================================================
+# Accessors — Cache optimization
+# ===========================================================================
+
+
+def get_cached_claude_md_content() -> str | None:
+    return _STATE.cached_claude_md_content
+
+
+def set_cached_claude_md_content(content: str | None) -> None:
+    _STATE.cached_claude_md_content = content
+
+
+def get_system_prompt_section_cache() -> dict[str, str | None]:
+    return _STATE.system_prompt_section_cache
+
+
+def set_system_prompt_section_cache_entry(name: str, value: str | None) -> None:
+    _STATE.system_prompt_section_cache[name] = value
+
+
+def clear_system_prompt_section_state() -> None:
+    _STATE.system_prompt_section_cache.clear()
+
+
+def mark_post_compaction() -> None:
+    """Mark that a compaction just occurred. Consumed once by the next API
+    success event, then auto-resets. Mirrors TS ``markPostCompaction``."""
+    _STATE.pending_post_compaction = True
+
+
+def consume_post_compaction() -> bool:
+    """Returns True once after compaction, then False on subsequent calls.
+    Mirrors TS ``consumePostCompaction``."""
+    was = _STATE.pending_post_compaction
+    _STATE.pending_post_compaction = False
+    return was
+
+
+def get_additional_directories_for_claude_md() -> list[str]:
+    return _STATE.additional_directories_for_claude_md
+
+
+def set_additional_directories_for_claude_md(directories: list[str]) -> None:
+    _STATE.additional_directories_for_claude_md = list(directories)
+
+
+# ===========================================================================
+# Accessors — Model
+# ===========================================================================
+
+
+def get_main_loop_model_override() -> str | None:
+    return _STATE.main_loop_model_override
+
+
+def set_main_loop_model_override(model: str | None) -> None:
+    _STATE.main_loop_model_override = model
+
+
+def get_initial_main_loop_model() -> str | None:
+    return _STATE.initial_main_loop_model
+
+
+def set_initial_main_loop_model(model: str | None) -> None:
+    _STATE.initial_main_loop_model = model
+
+
+# ===========================================================================
+# Accessors — API correlation
+# ===========================================================================
+
+
+def get_prompt_id() -> str | None:
+    return _STATE.prompt_id
+
+
+def set_prompt_id(prompt_id: str | None) -> None:
+    _STATE.prompt_id = prompt_id
+
+
+def get_last_main_request_id() -> str | None:
+    return _STATE.last_main_request_id
+
+
+def set_last_main_request_id(request_id: str) -> None:
+    _STATE.last_main_request_id = request_id
+
+
+def get_last_api_completion_timestamp() -> float | None:
+    return _STATE.last_api_completion_timestamp
+
+
+def set_last_api_completion_timestamp(ts: float) -> None:
+    _STATE.last_api_completion_timestamp = ts
+
+
+def get_last_emitted_date() -> str | None:
+    return _STATE.last_emitted_date
+
+
+def set_last_emitted_date(date: str | None) -> None:
+    _STATE.last_emitted_date = date
+
+
+# ===========================================================================
+# Test reset
+# ===========================================================================
+
+
+def reset_state_for_tests() -> None:
+    """Wipe state to defaults. Test-only escape hatch.
+
+    Gated by the ``PYTEST_CURRENT_TEST`` environment variable, which pytest
+    sets during test execution. Production calls raise ``RuntimeError``.
+    Mirrors TS ``resetStateForTests`` (``bootstrap/state.ts:993``).
+    """
+    if os.environ.get("PYTEST_CURRENT_TEST") is None:
+        raise RuntimeError("reset_state_for_tests can only be called in tests")
+    global _STATE
+    _STATE = _BootstrapState()
+    _session_switched.clear()
+
+
 __all__ = [
+    # Types
+    "SessionId",
+    "ModelUsage",
+    # Signal
+    "on_session_switch",
+    # Identity & paths
+    "get_session_id",
+    "regenerate_session_id",
+    "switch_session",
+    "get_parent_session_id",
+    "get_session_project_dir",
+    "get_original_cwd",
+    "set_original_cwd",
+    "get_project_root",
+    "set_project_root",
+    "get_cwd_state",
+    "set_cwd_state",
+    # Session flags
     "get_is_interactive",
     "set_is_interactive",
     "get_is_non_interactive_session",
     "get_client_type",
     "set_client_type",
+    "get_session_trust_accepted",
+    "set_session_trust_accepted",
+    "is_session_persistence_disabled",
+    "set_session_persistence_disabled",
+    "get_is_remote_mode",
+    "set_is_remote_mode",
+    "has_exited_plan_mode_in_session",
+    "set_has_exited_plan_mode",
+    # Cost & timing
+    "get_total_cost_usd",
+    "add_to_total_cost_state",
+    "get_total_api_duration",
+    "get_total_api_duration_without_retries",
+    "add_to_total_duration_state",
+    "get_total_tool_duration",
+    "add_to_tool_duration",
+    "get_total_lines_added",
+    "get_total_lines_removed",
+    "add_to_total_lines_changed",
+    "has_unknown_model_cost",
+    "set_has_unknown_model_cost",
+    "get_model_usage",
+    "get_start_time",
+    "get_last_interaction_time",
+    "update_last_interaction_time",
+    "reset_cost_state",
+    "set_cost_state_for_restore",
+    # Cache optimization
+    "get_cached_claude_md_content",
+    "set_cached_claude_md_content",
+    "get_system_prompt_section_cache",
+    "set_system_prompt_section_cache_entry",
+    "clear_system_prompt_section_state",
+    "mark_post_compaction",
+    "consume_post_compaction",
+    "get_additional_directories_for_claude_md",
+    "set_additional_directories_for_claude_md",
+    # Model
+    "get_main_loop_model_override",
+    "set_main_loop_model_override",
+    "get_initial_main_loop_model",
+    "set_initial_main_loop_model",
+    # API correlation
+    "get_prompt_id",
+    "set_prompt_id",
+    "get_last_main_request_id",
+    "set_last_main_request_id",
+    "get_last_api_completion_timestamp",
+    "set_last_api_completion_timestamp",
+    "get_last_emitted_date",
+    "set_last_emitted_date",
+    # Test reset
+    "reset_state_for_tests",
 ]

--- a/tests/test_bootstrap_state.py
+++ b/tests/test_bootstrap_state.py
@@ -1,0 +1,361 @@
+"""Tests for ``src/bootstrap/state.py`` (Phase 1 expansion).
+
+Verifies the chapter's two-tier architecture invariants on the
+bootstrap-singleton side:
+
+* Identity defaults are NFC-normalized at module load.
+* ``session_id`` is a UUID (not strftime).
+* ``switch_session`` is the only setter that mutates session_id + project_dir
+  together (the CC-34 single-setter discipline).
+* ``regenerate_session_id`` lineages parent correctly.
+* ``mark_post_compaction`` / ``consume_post_compaction`` are one-shot.
+* NFC normalization applies to every path setter.
+* ``reset_state_for_tests`` is gated and resets cleanly.
+* Existing accessors (``get_is_interactive`` etc.) still work.
+"""
+
+from __future__ import annotations
+
+import os
+import unicodedata
+import unittest
+
+import pytest
+
+from src.bootstrap.state import (
+    ModelUsage,
+    SessionId,
+    add_to_total_cost_state,
+    add_to_total_duration_state,
+    add_to_total_lines_changed,
+    consume_post_compaction,
+    get_cached_claude_md_content,
+    get_client_type,
+    get_is_interactive,
+    get_is_non_interactive_session,
+    get_main_loop_model_override,
+    get_model_usage,
+    get_original_cwd,
+    get_parent_session_id,
+    get_project_root,
+    get_session_id,
+    get_session_project_dir,
+    get_total_api_duration,
+    get_total_cost_usd,
+    get_total_lines_added,
+    has_unknown_model_cost,
+    mark_post_compaction,
+    on_session_switch,
+    regenerate_session_id,
+    reset_cost_state,
+    reset_state_for_tests,
+    set_cached_claude_md_content,
+    set_client_type,
+    set_cost_state_for_restore,
+    set_has_unknown_model_cost,
+    set_is_interactive,
+    set_main_loop_model_override,
+    set_original_cwd,
+    set_project_root,
+    switch_session,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_bootstrap_state():
+    """Reset the bootstrap singleton before each test in this file.
+
+    Without this, the global ``_STATE`` would leak between tests and a
+    test that calls ``switch_session(...)`` would corrupt every following
+    test. Autouse limits the reset to this module."""
+    reset_state_for_tests()
+    yield
+    reset_state_for_tests()
+
+
+class TestDefaults(unittest.TestCase):
+    def test_session_id_is_uuid(self) -> None:
+        sid = get_session_id()
+        # UUID v4 string is 36 chars with hyphens at fixed positions
+        self.assertIsInstance(sid, str)
+        self.assertEqual(len(sid), 36)
+        self.assertEqual(sid[8], "-")
+        self.assertEqual(sid[13], "-")
+        self.assertEqual(sid[18], "-")
+        self.assertEqual(sid[23], "-")
+
+    def test_parent_session_id_is_none_initially(self) -> None:
+        self.assertIsNone(get_parent_session_id())
+
+    def test_session_project_dir_is_none_initially(self) -> None:
+        self.assertIsNone(get_session_project_dir())
+
+    def test_paths_are_nfc_normalized(self) -> None:
+        cwd = get_original_cwd()
+        self.assertEqual(cwd, unicodedata.normalize("NFC", cwd))
+
+    def test_project_root_equals_original_cwd_initially(self) -> None:
+        self.assertEqual(get_original_cwd(), get_project_root())
+
+    def test_cost_accumulators_start_at_zero(self) -> None:
+        self.assertEqual(get_total_cost_usd(), 0.0)
+        self.assertEqual(get_total_api_duration(), 0)
+        self.assertEqual(get_total_lines_added(), 0)
+        self.assertFalse(has_unknown_model_cost())
+        self.assertEqual(get_model_usage(), {})
+
+    def test_pending_post_compaction_starts_false(self) -> None:
+        # Consume once: should be False because we never set it
+        self.assertFalse(consume_post_compaction())
+
+    def test_main_loop_model_override_is_none_initially(self) -> None:
+        self.assertIsNone(get_main_loop_model_override())
+
+
+class TestExistingAccessorsStillWork(unittest.TestCase):
+    """The migration contract: get/set_is_interactive and get/set_client_type
+    must continue to behave identically to the pre-expansion shape."""
+
+    def test_is_interactive_default_false(self) -> None:
+        self.assertFalse(get_is_interactive())
+        self.assertTrue(get_is_non_interactive_session())
+
+    def test_set_is_interactive_roundtrips(self) -> None:
+        set_is_interactive(True)
+        self.assertTrue(get_is_interactive())
+        self.assertFalse(get_is_non_interactive_session())
+
+    def test_client_type_default_and_setter(self) -> None:
+        # Pre-existing default. TS uses 'cli'; we preserve the pre-expansion
+        # value to keep migration backward compatible.
+        self.assertEqual(get_client_type(), "claude-code")
+        set_client_type("ide")
+        self.assertEqual(get_client_type(), "ide")
+
+
+class TestNfcNormalization(unittest.TestCase):
+    """Every path setter must NFC-normalize input."""
+
+    def test_set_original_cwd_normalizes_nfd_to_nfc(self) -> None:
+        # NFD form of "é" is two code points: 'e' + combining acute
+        nfd = "/path/café"  # "café" in NFD
+        set_original_cwd(nfd)
+        stored = get_original_cwd()
+        self.assertEqual(stored, "/path/café")  # composed é
+        self.assertEqual(stored, unicodedata.normalize("NFC", stored))
+
+    def test_set_project_root_normalizes(self) -> None:
+        nfd = "/proj/café"  # already NFC
+        set_project_root(nfd)
+        self.assertEqual(get_project_root(), nfd)
+        # NFD input
+        nfd2 = "/proj/café"
+        set_project_root(nfd2)
+        self.assertEqual(get_project_root(), "/proj/café")
+
+
+class TestSwitchSession(unittest.TestCase):
+    def test_switch_session_updates_id_and_project_dir(self) -> None:
+        new_id = SessionId("11111111-1111-1111-1111-111111111111")
+        switch_session(new_id, "/some/dir")
+        self.assertEqual(get_session_id(), new_id)
+        self.assertEqual(get_session_project_dir(), "/some/dir")
+
+    def test_switch_session_with_none_project_dir(self) -> None:
+        new_id = SessionId("22222222-2222-2222-2222-222222222222")
+        switch_session(new_id)
+        self.assertEqual(get_session_id(), new_id)
+        self.assertIsNone(get_session_project_dir())
+
+    def test_switch_session_emits_signal(self) -> None:
+        received: list[SessionId] = []
+        unsubscribe = on_session_switch(lambda sid: received.append(sid))
+        try:
+            new_id = SessionId("33333333-3333-3333-3333-333333333333")
+            switch_session(new_id, "/x")
+            self.assertEqual(received, [new_id])
+        finally:
+            unsubscribe()
+
+    def test_switch_session_signal_fires_after_state_update(self) -> None:
+        """The signal listener must see the new state via get_session_id()."""
+        seen_ids: list[SessionId] = []
+
+        unsubscribe = on_session_switch(lambda sid: seen_ids.append(get_session_id()))
+        try:
+            new_id = SessionId("44444444-4444-4444-4444-444444444444")
+            switch_session(new_id)
+            self.assertEqual(seen_ids, [new_id])
+        finally:
+            unsubscribe()
+
+
+class TestRegenerateSessionId(unittest.TestCase):
+    def test_regenerate_returns_new_uuid(self) -> None:
+        old = get_session_id()
+        new = regenerate_session_id()
+        self.assertNotEqual(old, new)
+        self.assertEqual(get_session_id(), new)
+
+    def test_regenerate_with_parent_flag(self) -> None:
+        old = get_session_id()
+        regenerate_session_id(set_current_as_parent=True)
+        self.assertEqual(get_parent_session_id(), old)
+
+    def test_regenerate_without_parent_flag_leaves_parent_none(self) -> None:
+        regenerate_session_id()
+        self.assertIsNone(get_parent_session_id())
+
+    def test_regenerate_clears_session_project_dir(self) -> None:
+        # Set a project dir, then regenerate — should clear
+        switch_session(SessionId("55555555-5555-5555-5555-555555555555"), "/old")
+        self.assertEqual(get_session_project_dir(), "/old")
+        regenerate_session_id()
+        self.assertIsNone(get_session_project_dir())
+
+    def test_regenerate_does_NOT_emit_signal(self) -> None:
+        """regenerate is the /clear path; switch_session is the resume path.
+        Only switch_session fires the signal — concurrentSessions/PID-file
+        sync only cares about cross-process boundary changes."""
+        received: list = []
+        unsubscribe = on_session_switch(lambda sid: received.append(sid))
+        try:
+            regenerate_session_id()
+            self.assertEqual(received, [])
+        finally:
+            unsubscribe()
+
+
+class TestPostCompaction(unittest.TestCase):
+    def test_pending_post_compaction_one_shot(self) -> None:
+        mark_post_compaction()
+        self.assertIs(consume_post_compaction(), True)
+        self.assertIs(consume_post_compaction(), False)
+        self.assertIs(consume_post_compaction(), False)
+
+    def test_mark_is_idempotent(self) -> None:
+        mark_post_compaction()
+        mark_post_compaction()
+        # Still only one consumption flips it
+        self.assertIs(consume_post_compaction(), True)
+        self.assertIs(consume_post_compaction(), False)
+
+
+class TestCostState(unittest.TestCase):
+    def test_add_to_total_cost_state_accumulates(self) -> None:
+        usage1 = ModelUsage(input_tokens=100, output_tokens=50, cost_usd=0.5)
+        usage2 = ModelUsage(input_tokens=200, output_tokens=100, cost_usd=1.0)
+
+        add_to_total_cost_state(0.5, usage1, "claude-sonnet-4")
+        add_to_total_cost_state(1.0, usage2, "claude-opus-4")
+
+        self.assertEqual(get_total_cost_usd(), 1.5)
+        self.assertEqual(get_model_usage()["claude-sonnet-4"].cost_usd, 0.5)
+        self.assertEqual(get_model_usage()["claude-opus-4"].cost_usd, 1.0)
+
+    def test_add_to_total_duration_state_accumulates(self) -> None:
+        add_to_total_duration_state(100, 80)
+        add_to_total_duration_state(200, 150)
+        self.assertEqual(get_total_api_duration(), 300)
+
+    def test_add_to_total_lines_changed_accumulates(self) -> None:
+        add_to_total_lines_changed(10, 5)
+        add_to_total_lines_changed(20, 15)
+        self.assertEqual(get_total_lines_added(), 30)
+
+    def test_has_unknown_model_cost_setter(self) -> None:
+        self.assertFalse(has_unknown_model_cost())
+        set_has_unknown_model_cost()
+        self.assertTrue(has_unknown_model_cost())
+
+    def test_reset_cost_state_wipes_accumulators(self) -> None:
+        add_to_total_cost_state(2.5, ModelUsage(cost_usd=2.5), "claude-opus-4")
+        add_to_total_lines_changed(50, 25)
+        set_has_unknown_model_cost()
+
+        reset_cost_state()
+
+        self.assertEqual(get_total_cost_usd(), 0.0)
+        self.assertEqual(get_total_lines_added(), 0)
+        self.assertFalse(has_unknown_model_cost())
+        self.assertEqual(get_model_usage(), {})
+
+    def test_set_cost_state_for_restore(self) -> None:
+        set_cost_state_for_restore(
+            total_cost_usd=3.14,
+            total_api_duration=1000,
+            total_api_duration_without_retries=900,
+            total_tool_duration=500,
+            total_lines_added=42,
+            total_lines_removed=21,
+            model_usage={"claude-opus-4": ModelUsage(cost_usd=3.14)},
+        )
+        self.assertEqual(get_total_cost_usd(), 3.14)
+        self.assertEqual(get_total_api_duration(), 1000)
+        self.assertEqual(get_total_lines_added(), 42)
+        self.assertEqual(get_model_usage()["claude-opus-4"].cost_usd, 3.14)
+
+
+class TestModelOverride(unittest.TestCase):
+    def test_set_main_loop_model_override(self) -> None:
+        set_main_loop_model_override("claude-sonnet-4-6")
+        self.assertEqual(get_main_loop_model_override(), "claude-sonnet-4-6")
+
+    def test_clear_main_loop_model_override(self) -> None:
+        set_main_loop_model_override("claude-sonnet-4-6")
+        set_main_loop_model_override(None)
+        self.assertIsNone(get_main_loop_model_override())
+
+
+class TestCachedClaudeMd(unittest.TestCase):
+    def test_cached_claude_md_starts_none(self) -> None:
+        self.assertIsNone(get_cached_claude_md_content())
+
+    def test_set_get_cached_claude_md(self) -> None:
+        set_cached_claude_md_content("# Project Notes\nfoo")
+        self.assertEqual(get_cached_claude_md_content(), "# Project Notes\nfoo")
+
+    def test_clear_cached_claude_md(self) -> None:
+        set_cached_claude_md_content("foo")
+        set_cached_claude_md_content(None)
+        self.assertIsNone(get_cached_claude_md_content())
+
+
+class TestResetStateForTests(unittest.TestCase):
+    def test_reset_outside_pytest_raises(self) -> None:
+        """The gate prevents production code from accidentally wiping
+        bootstrap state. Within pytest the autouse fixture above relies
+        on PYTEST_CURRENT_TEST being set."""
+        # Temporarily remove PYTEST_CURRENT_TEST to simulate production
+        env = os.environ.pop("PYTEST_CURRENT_TEST", None)
+        try:
+            with self.assertRaises(RuntimeError):
+                reset_state_for_tests()
+        finally:
+            if env is not None:
+                os.environ["PYTEST_CURRENT_TEST"] = env
+
+    def test_reset_clears_signal_subscribers(self) -> None:
+        """Critical for test isolation: a subscriber from a previous test
+        must not still be active in the next test."""
+        from src.bootstrap.state import _session_switched
+
+        on_session_switch(lambda sid: None)
+        self.assertGreater(len(_session_switched._listeners), 0)
+
+        reset_state_for_tests()
+
+        self.assertEqual(len(_session_switched._listeners), 0)
+
+    def test_reset_resets_cost_accumulators(self) -> None:
+        add_to_total_cost_state(5.0, ModelUsage(cost_usd=5.0), "claude-opus")
+        self.assertGreater(get_total_cost_usd(), 0)
+
+        reset_state_for_tests()
+
+        self.assertEqual(get_total_cost_usd(), 0.0)
+        self.assertEqual(get_model_usage(), {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR 2/6 in the ch03 state stack. Stacked on top of #65 (Signal + Store primitives).

Grows `src/bootstrap/state.py` from 52 LOC / 2 fields → ~33 fields with ~50 accessors. Mirrors the field groupings in `typescript/src/bootstrap/state.ts`:

- **Identity & paths**: `original_cwd`, `project_root`, `cwd`, `session_id` (UUID, branded `SessionId` NewType), `parent_session_id`, `session_project_dir`. Every path setter NFC-normalizes (matches macOS HFS+/APFS expectations).
- **Session flags**: `session_trust_accepted`, `session_persistence_disabled`, `is_remote_mode`, `has_exited_plan_mode`, plus pre-existing `is_interactive` / `client_type`.
- **Cost & timing**: `total_cost_usd`, `total_api_duration{,_without_retries}`, `total_tool_duration`, `total_lines_added/removed`, `has_unknown_model_cost`, `model_usage`, `start_time`, `last_interaction_time`.
- **Cache optimization**: `cached_claude_md_content`, `system_prompt_section_cache`, `pending_post_compaction` (with `mark`/`consume` one-shot helpers from chapter §3.6), `additional_directories_for_claude_md`.
- **Model**: `main_loop_model_override`, `initial_main_loop_model`.
- **API correlation**: `prompt_id`, `last_main_request_id`, `last_api_completion_timestamp`, `last_emitted_date`.

### Architectural choices preserved from chapter

- **`switch_session` is the only mutator for `session_id` + `session_project_dir`** (CC-34 single-setter discipline) and emits the `_session_switched` signal. `regenerate_session_id` is the `/clear` path and deliberately does NOT emit.
- **`SessionId = NewType("SessionId", str)`** for static type discipline (TS analogue of the branded type).
- **`reset_state_for_tests()`** gated by `PYTEST_CURRENT_TEST` so production code cannot accidentally wipe state. Also clears signal subscribers between tests.
- **All pre-existing accessors preserved exactly** — `get_is_interactive`, `set_is_interactive`, `get_is_non_interactive_session`, `get/set_client_type` continue to work; verified by `TestExistingAccessorsStillWork`.

### Out of scope (next PR in stack)

- `SdkContext` + `run_with_sdk_context` / contextvars per-query isolation.
- `Session.create()` migration to use `get_session_id()`.

Both land in `feat/ch03-state-3-contextvars` (next).

## Test plan
- [x] `pytest tests/test_bootstrap_state.py` — 38 passing
- [x] Defaults, NFC round-trip with actual NFD input, switch_session/regenerate semantics, post-compaction one-shot, cost accumulator math, model override clear/set, test-reset gating + signal-subscriber cleanup.
- [x] No regressions in the full suite (verified locally; 8 pre-existing failures unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)