### PR TITLE
ch03 state #5: cost tracker consolidation

### DIFF
--- a/src/cost_tracker.py
+++ b/src/cost_tracker.py
@@ -1,13 +1,95 @@
+"""Cost tracker — facade over ``src.bootstrap.state``.
+
+Phase 2.3 of the ch03 state refactor: the class shape is preserved for
+backward compatibility with existing callers (``costHook.py``,
+``repl/core.py``, ``tui/app.py``, ``command_system/builtins.py``), but
+all state now lives in the bootstrap singleton. Every ``CostTracker``
+instance is a view into the same state — there is no "two trackers
+disagreeing about cost" problem.
+
+Legacy ``record(label, units)`` API is retained for the existing
+``costHook.apply_cost_hook`` callers (which feed the /cost slash
+command's event log). The richer ``record_usage(model, usage)`` API
+records to the bootstrap singleton's per-model accumulators and
+also computes USD cost via ``src.services.pricing``.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
+
+from src.bootstrap.state import (
+    ModelUsage,
+    add_to_total_cost_state,
+    get_model_usage,
+    get_total_cost_usd,
+)
+from src.services.pricing import compute_cost
 
 
 @dataclass
 class CostTracker:
+    """Facade over the bootstrap singleton.
+
+    Two distinct event streams co-exist for back-compat:
+
+    * ``events`` and ``total_units``: legacy free-form units that the
+      ``/cost`` slash command displays. These live on the instance (NOT
+      bootstrap) because they're informational — not part of cost
+      accounting. Multiple instances accumulate independently.
+
+    * ``record_usage(model, usage)``: routes through the bootstrap
+      singleton, so cost USD and per-model breakdown agree across
+      every consumer in the process.
+    """
+
     total_units: int = 0
     events: list[str] = field(default_factory=list)
+    last_usage: dict[str, Any] | None = None
 
     def record(self, label: str, units: int) -> None:
+        """Legacy event recorder. Used by ``costHook.apply_cost_hook``."""
         self.total_units += units
-        self.events.append(f'{label}:{units}')
+        self.events.append(f"{label}:{units}")
+
+    def record_usage(self, model: str, usage: dict[str, Any]) -> float:
+        """Record a real API usage event into the bootstrap singleton.
+
+        Computes USD cost from per-model pricing, updates the
+        process-wide ``total_cost_usd`` accumulator, and stores a
+        ``last_usage`` snapshot for downstream consumers (e.g. the
+        ``/cost`` command's last-call summary).
+        """
+        cost = compute_cost(model, usage)
+        bootstrap_usage = ModelUsage(
+            input_tokens=int(usage.get("input_tokens", 0)),
+            output_tokens=int(usage.get("output_tokens", 0)),
+            cache_creation_input_tokens=int(usage.get("cache_creation_input_tokens", 0)),
+            cache_read_input_tokens=int(usage.get("cache_read_input_tokens", 0)),
+            cost_usd=cost,
+        )
+        # Merge with any existing per-model accumulator
+        existing = get_model_usage().get(model)
+        if existing is not None:
+            bootstrap_usage = ModelUsage(
+                input_tokens=existing.input_tokens + bootstrap_usage.input_tokens,
+                output_tokens=existing.output_tokens + bootstrap_usage.output_tokens,
+                cache_creation_input_tokens=(
+                    existing.cache_creation_input_tokens
+                    + bootstrap_usage.cache_creation_input_tokens
+                ),
+                cache_read_input_tokens=(
+                    existing.cache_read_input_tokens + bootstrap_usage.cache_read_input_tokens
+                ),
+                cost_usd=existing.cost_usd + cost,
+            )
+        add_to_total_cost_state(cost, bootstrap_usage, model)
+        self.last_usage = dict(usage)
+        return cost
+
+    @property
+    def total_cost_usd(self) -> float:
+        """Read-through to the bootstrap singleton — every tracker
+        instance sees the same total."""
+        return get_total_cost_usd()

--- a/src/services/cost_restore.py
+++ b/src/services/cost_restore.py
@@ -1,0 +1,107 @@
+"""Cost-state restore orchestrator.
+
+Mirrors TS ``cost-tracker.ts:149`` (``restoreCostStateForSession``). Reads
+the persisted cost snapshot for a given session ID and dispatches
+``set_cost_state_for_restore`` into the bootstrap singleton so the
+``/resume`` path picks up where the last session left off, rather than
+silently starting from zero.
+
+The TS file ``cost-tracker.ts`` does two things: defines the
+``CostTracker`` class (which Python's port has consolidated onto the
+bootstrap singleton) and the restore orchestrator. The orchestrator is
+the only piece that needs its own file in Python — pricing is at
+``src/services/pricing.py`` and accounting is at
+``src/bootstrap/state.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from src.bootstrap.state import (
+    ModelUsage,
+    SessionId,
+    set_cost_state_for_restore,
+)
+
+
+def _sessions_dir() -> Path:
+    """Persistence directory — extracted so tests can monkeypatch."""
+    return Path.home() / ".clawcodex" / "sessions"
+
+
+def restore_cost_state_for_session(session_id: SessionId | str) -> bool:
+    """Restore cost accumulators from the persisted snapshot for
+    ``session_id``.
+
+    Returns True if the snapshot was found and applied, False otherwise.
+
+    Mirrors TS ``restoreCostStateForSession`` semantics: the gate is the
+    **persisted file's session_id**, not the bootstrap singleton's
+    runtime session_id. This means the function works regardless of
+    whether ``switch_session(sid)`` was called first — the resume path
+    can call restore-then-switch or switch-then-restore.
+
+    The on-disk location is ``~/.clawcodex/sessions/<sid>.json`` —
+    the same place ``Session.save`` writes. Today the Python
+    ``Session.save`` does NOT persist a ``cost`` block — this function
+    reads whatever cost fields are present and tolerates missing ones,
+    so it works correctly once persistence catches up (Phase-2.4
+    follow-up).
+    """
+    target = str(session_id)
+    session_file = _sessions_dir() / f"{target}.json"
+    if not session_file.exists():
+        return False
+
+    try:
+        data = json.loads(session_file.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+
+    if not isinstance(data, dict):
+        return False
+
+    # Gate on the *persisted* session_id matching the target — mirrors
+    # the TS pattern. Refuses to restore from a file whose session_id
+    # header doesn't agree with the filename (defends against a renamed
+    # or hand-edited file).
+    persisted_sid = data.get("session_id")
+    if persisted_sid != target:
+        return False
+
+    # Extract cost fields with defaults — tolerate snapshots that
+    # don't yet persist them.
+    cost_block: dict[str, Any] = data.get("cost", {}) if isinstance(data, dict) else {}
+
+    model_usage_raw: dict[str, Any] = cost_block.get("model_usage", {}) or {}
+    model_usage: dict[str, ModelUsage] = {}
+    for model, entry in model_usage_raw.items():
+        if not isinstance(entry, dict):
+            continue
+        model_usage[model] = ModelUsage(
+            input_tokens=int(entry.get("input_tokens", 0)),
+            output_tokens=int(entry.get("output_tokens", 0)),
+            cache_creation_input_tokens=int(entry.get("cache_creation_input_tokens", 0)),
+            cache_read_input_tokens=int(entry.get("cache_read_input_tokens", 0)),
+            cost_usd=float(entry.get("cost_usd", 0.0)),
+        )
+
+    set_cost_state_for_restore(
+        total_cost_usd=float(cost_block.get("total_cost_usd", 0.0)),
+        total_api_duration=int(cost_block.get("total_api_duration", 0)),
+        total_api_duration_without_retries=int(
+            cost_block.get("total_api_duration_without_retries", 0)
+        ),
+        total_tool_duration=int(cost_block.get("total_tool_duration", 0)),
+        total_lines_added=int(cost_block.get("total_lines_added", 0)),
+        total_lines_removed=int(cost_block.get("total_lines_removed", 0)),
+        last_duration=cost_block.get("last_duration"),
+        model_usage=model_usage if model_usage else None,
+    )
+    return True
+
+
+__all__ = ["restore_cost_state_for_session"]

--- a/src/services/cost_tracker.py
+++ b/src/services/cost_tracker.py
@@ -1,6 +1,18 @@
 """Cost tracker — per-model pricing, per-turn + cumulative cost, cache hit savings.
 
-Mirrors the TypeScript cost tracking behavior for API usage metering.
+**DEPRECATED**: This module's ``CostTracker`` class is test-only and
+predates the Phase 2.3 consolidation onto the bootstrap singleton. New
+production code should use:
+
+* ``src.cost_tracker.CostTracker`` — facade over the bootstrap singleton.
+* ``src.bootstrap.state.add_to_total_cost_state(...)`` — direct accessor.
+* ``src.services.pricing`` — pricing table + ``compute_cost`` pure function.
+* ``src.services.cost_restore.restore_cost_state_for_session(...)`` — resume orchestrator.
+
+The class below is retained ONLY because ~23 unit/parity tests still
+import it directly. The pricing tables are now re-exported from
+``src.services.pricing`` to eliminate the duplication that previously
+risked pricing drift between this file and the bootstrap-singleton path.
 """
 
 from __future__ import annotations
@@ -9,67 +21,15 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
-
-PRICING: dict[str, dict[str, float]] = {
-    "claude-opus-4-20250514": {
-        "input": 15.0 / 1_000_000,
-        "output": 75.0 / 1_000_000,
-        "cache_creation": 18.75 / 1_000_000,
-        "cache_read": 1.50 / 1_000_000,
-    },
-    "claude-sonnet-4-20250514": {
-        "input": 3.0 / 1_000_000,
-        "output": 15.0 / 1_000_000,
-        "cache_creation": 3.75 / 1_000_000,
-        "cache_read": 0.30 / 1_000_000,
-    },
-    "claude-3-7-sonnet-20250219": {
-        "input": 3.0 / 1_000_000,
-        "output": 15.0 / 1_000_000,
-        "cache_creation": 3.75 / 1_000_000,
-        "cache_read": 0.30 / 1_000_000,
-    },
-    "claude-3-5-sonnet-20241022": {
-        "input": 3.0 / 1_000_000,
-        "output": 15.0 / 1_000_000,
-        "cache_creation": 3.75 / 1_000_000,
-        "cache_read": 0.30 / 1_000_000,
-    },
-    "claude-3-5-sonnet-20240620": {
-        "input": 3.0 / 1_000_000,
-        "output": 15.0 / 1_000_000,
-        "cache_creation": 3.75 / 1_000_000,
-        "cache_read": 0.30 / 1_000_000,
-    },
-    "claude-3-haiku-20240307": {
-        "input": 0.25 / 1_000_000,
-        "output": 1.25 / 1_000_000,
-        "cache_creation": 0.30 / 1_000_000,
-        "cache_read": 0.03 / 1_000_000,
-    },
-    "claude-3-5-haiku-20241022": {
-        "input": 1.0 / 1_000_000,
-        "output": 5.0 / 1_000_000,
-        "cache_creation": 1.25 / 1_000_000,
-        "cache_read": 0.10 / 1_000_000,
-    },
-}
-
-DEFAULT_PRICING: dict[str, float] = {
-    "input": 3.0 / 1_000_000,
-    "output": 15.0 / 1_000_000,
-    "cache_creation": 3.75 / 1_000_000,
-    "cache_read": 0.30 / 1_000_000,
-}
-
-
-def _get_pricing(model: str) -> dict[str, float]:
-    if model in PRICING:
-        return PRICING[model]
-    for prefix, pricing in PRICING.items():
-        if model.startswith(prefix.rsplit("-", 1)[0]):
-            return pricing
-    return DEFAULT_PRICING
+# Re-export pricing constants/functions from the canonical source.
+# Phase 2.3: this is the single source of truth — both the bootstrap-
+# backed facade and this legacy class use these tables.
+from src.services.pricing import (
+    DEFAULT_PRICING,
+    PRICING,
+    compute_cost as _compute_cost,
+    get_pricing as _get_pricing,
+)
 
 
 @dataclass

--- a/src/services/pricing.py
+++ b/src/services/pricing.py
@@ -1,0 +1,96 @@
+"""Per-model pricing for cost calculation.
+
+Pure functions and constants — no state, no class. The actual accumulation
+of cost state lives in ``src.bootstrap.state`` (via
+``add_to_total_cost_state`` and friends); this module just computes the
+dollar cost of a usage record.
+
+Extracted from the (deprecated) ``src/services/cost_tracker.py`` as part
+of Phase 2.3 of the ch03 state refactor.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+PRICING: dict[str, dict[str, float]] = {
+    "claude-opus-4-20250514": {
+        "input": 15.0 / 1_000_000,
+        "output": 75.0 / 1_000_000,
+        "cache_creation": 18.75 / 1_000_000,
+        "cache_read": 1.50 / 1_000_000,
+    },
+    "claude-sonnet-4-20250514": {
+        "input": 3.0 / 1_000_000,
+        "output": 15.0 / 1_000_000,
+        "cache_creation": 3.75 / 1_000_000,
+        "cache_read": 0.30 / 1_000_000,
+    },
+    "claude-3-7-sonnet-20250219": {
+        "input": 3.0 / 1_000_000,
+        "output": 15.0 / 1_000_000,
+        "cache_creation": 3.75 / 1_000_000,
+        "cache_read": 0.30 / 1_000_000,
+    },
+    "claude-3-5-sonnet-20241022": {
+        "input": 3.0 / 1_000_000,
+        "output": 15.0 / 1_000_000,
+        "cache_creation": 3.75 / 1_000_000,
+        "cache_read": 0.30 / 1_000_000,
+    },
+    "claude-3-5-sonnet-20240620": {
+        "input": 3.0 / 1_000_000,
+        "output": 15.0 / 1_000_000,
+        "cache_creation": 3.75 / 1_000_000,
+        "cache_read": 0.30 / 1_000_000,
+    },
+    "claude-3-haiku-20240307": {
+        "input": 0.25 / 1_000_000,
+        "output": 1.25 / 1_000_000,
+        "cache_creation": 0.30 / 1_000_000,
+        "cache_read": 0.03 / 1_000_000,
+    },
+    "claude-3-5-haiku-20241022": {
+        "input": 1.0 / 1_000_000,
+        "output": 5.0 / 1_000_000,
+        "cache_creation": 1.25 / 1_000_000,
+        "cache_read": 0.10 / 1_000_000,
+    },
+}
+
+DEFAULT_PRICING: dict[str, float] = {
+    "input": 3.0 / 1_000_000,
+    "output": 15.0 / 1_000_000,
+    "cache_creation": 3.75 / 1_000_000,
+    "cache_read": 0.30 / 1_000_000,
+}
+
+
+def get_pricing(model: str) -> dict[str, float]:
+    """Return per-token prices for ``model``. Falls back to the closest
+    prefix match, then to ``DEFAULT_PRICING``."""
+    if model in PRICING:
+        return PRICING[model]
+    for prefix, pricing in PRICING.items():
+        if model.startswith(prefix.rsplit("-", 1)[0]):
+            return pricing
+    return DEFAULT_PRICING
+
+
+def compute_cost(model: str, usage: dict[str, Any]) -> float:
+    """Compute USD cost for a usage record. Pure function."""
+    pricing = get_pricing(model)
+    input_tokens = int(usage.get("input_tokens", 0))
+    output_tokens = int(usage.get("output_tokens", 0))
+    cache_creation = int(usage.get("cache_creation_input_tokens", 0))
+    cache_read = int(usage.get("cache_read_input_tokens", 0))
+    return (
+        input_tokens * pricing["input"]
+        + output_tokens * pricing["output"]
+        + cache_creation * pricing["cache_creation"]
+        + cache_read * pricing["cache_read"]
+    )
+
+
+__all__ = ["PRICING", "DEFAULT_PRICING", "get_pricing", "compute_cost"]

--- a/tests/test_cost_tracker_facade.py
+++ b/tests/test_cost_tracker_facade.py
@@ -1,0 +1,246 @@
+"""Tests for the Phase 2.3 cost-tracker consolidation.
+
+Verifies:
+* ``CostTracker.record(label, units)`` still works (legacy back-compat).
+* ``CostTracker.record_usage(model, usage)`` routes to bootstrap; two
+  instances see the same ``total_cost_usd``.
+* ``compute_cost`` returns expected values from pricing tables.
+* ``restore_cost_state_for_session`` round-trips a persisted snapshot.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from src.bootstrap.state import (
+    SessionId,
+    get_model_usage,
+    get_total_cost_usd,
+    reset_state_for_tests,
+    switch_session,
+)
+from src.cost_tracker import CostTracker
+from src.services import cost_restore as cost_restore_mod
+from src.services.cost_restore import restore_cost_state_for_session
+from src.services.pricing import (
+    DEFAULT_PRICING,
+    PRICING,
+    compute_cost,
+    get_pricing,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_bootstrap():
+    reset_state_for_tests()
+    yield
+    reset_state_for_tests()
+
+
+class TestLegacyRecordApi(unittest.TestCase):
+    """The ``record(label, units)`` API stays untouched for back-compat."""
+
+    def test_record_accumulates_total_units(self) -> None:
+        t = CostTracker()
+        t.record("a", 10)
+        t.record("b", 5)
+        self.assertEqual(t.total_units, 15)
+        self.assertEqual(t.events, ["a:10", "b:5"])
+
+    def test_record_does_not_touch_bootstrap_cost(self) -> None:
+        """Legacy units are NOT a USD measurement; they don't flow to
+        bootstrap ``total_cost_usd``."""
+        t = CostTracker()
+        t.record("a", 100)
+        self.assertEqual(get_total_cost_usd(), 0.0)
+
+
+class TestRecordUsage(unittest.TestCase):
+    def test_record_usage_returns_cost(self) -> None:
+        t = CostTracker()
+        cost = t.record_usage(
+            "claude-sonnet-4-20250514",
+            {"input_tokens": 1_000_000, "output_tokens": 0},
+        )
+        # Sonnet input is $3/M
+        self.assertAlmostEqual(cost, 3.0, places=4)
+
+    def test_record_usage_updates_bootstrap_total(self) -> None:
+        t = CostTracker()
+        t.record_usage(
+            "claude-sonnet-4-20250514",
+            {"input_tokens": 1_000_000},
+        )
+        self.assertAlmostEqual(get_total_cost_usd(), 3.0, places=4)
+
+    def test_two_trackers_share_bootstrap_total(self) -> None:
+        """Architectural invariant: every tracker instance reads the
+        same total. No more 'two trackers disagree' bug."""
+        a = CostTracker()
+        b = CostTracker()
+        a.record_usage(
+            "claude-sonnet-4-20250514",
+            {"input_tokens": 500_000},
+        )
+        b.record_usage(
+            "claude-sonnet-4-20250514",
+            {"input_tokens": 500_000},
+        )
+        # Both trackers see the same total: $1.50 + $1.50 = $3.00
+        self.assertAlmostEqual(a.total_cost_usd, 3.0, places=4)
+        self.assertAlmostEqual(b.total_cost_usd, 3.0, places=4)
+        self.assertEqual(a.total_cost_usd, b.total_cost_usd)
+
+    def test_record_usage_accumulates_per_model(self) -> None:
+        t = CostTracker()
+        t.record_usage(
+            "claude-sonnet-4-20250514",
+            {"input_tokens": 1_000_000},
+        )
+        t.record_usage(
+            "claude-sonnet-4-20250514",
+            {"input_tokens": 500_000},
+        )
+        usage = get_model_usage()["claude-sonnet-4-20250514"]
+        self.assertEqual(usage.input_tokens, 1_500_000)
+        self.assertAlmostEqual(usage.cost_usd, 4.5, places=4)
+
+    def test_record_usage_sets_last_usage(self) -> None:
+        t = CostTracker()
+        t.record_usage(
+            "claude-sonnet-4-20250514",
+            {"input_tokens": 100, "output_tokens": 50},
+        )
+        self.assertEqual(t.last_usage, {"input_tokens": 100, "output_tokens": 50})
+
+
+class TestPricing(unittest.TestCase):
+    def test_get_pricing_known_model(self) -> None:
+        p = get_pricing("claude-opus-4-20250514")
+        self.assertAlmostEqual(p["input"], 15.0 / 1_000_000)
+        self.assertAlmostEqual(p["output"], 75.0 / 1_000_000)
+
+    def test_get_pricing_falls_back_to_default(self) -> None:
+        p = get_pricing("some-future-model-not-in-table")
+        self.assertEqual(p, DEFAULT_PRICING)
+
+    def test_compute_cost_basic(self) -> None:
+        cost = compute_cost(
+            "claude-sonnet-4-20250514",
+            {
+                "input_tokens": 1_000_000,
+                "output_tokens": 1_000_000,
+            },
+        )
+        # $3 input + $15 output = $18
+        self.assertAlmostEqual(cost, 18.0, places=4)
+
+    def test_compute_cost_with_cache(self) -> None:
+        cost = compute_cost(
+            "claude-sonnet-4-20250514",
+            {
+                "cache_creation_input_tokens": 1_000_000,
+                "cache_read_input_tokens": 1_000_000,
+            },
+        )
+        # $3.75 cache_creation + $0.30 cache_read = $4.05
+        self.assertAlmostEqual(cost, 4.05, places=4)
+
+    def test_compute_cost_pure(self) -> None:
+        """Computing cost must not mutate bootstrap state."""
+        before = get_total_cost_usd()
+        compute_cost(
+            "claude-sonnet-4-20250514",
+            {"input_tokens": 100_000_000},
+        )
+        self.assertEqual(get_total_cost_usd(), before)
+
+
+class TestRestoreCostStateForSession:
+    """Pytest-style class so we can use ``tmp_path`` to avoid polluting
+    the real ``~/.clawcodex/sessions/`` directory."""
+
+    test_sid = SessionId("99999999-9999-9999-9999-999999999999")
+
+    @pytest.fixture(autouse=True)
+    def _redirect_sessions_dir(self, tmp_path, monkeypatch):
+        """Point ``cost_restore._sessions_dir`` at the test tmp dir."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(cost_restore_mod, "_sessions_dir", lambda: sessions_dir)
+        self._sessions_dir = sessions_dir
+        self._test_file = sessions_dir / f"{self.test_sid}.json"
+        yield
+
+    def test_restore_returns_false_when_file_missing(self) -> None:
+        result = restore_cost_state_for_session(self.test_sid)
+        assert result is False
+
+    def test_restore_returns_false_on_malformed_json(self) -> None:
+        self._test_file.write_text("not-json{")
+        result = restore_cost_state_for_session(self.test_sid)
+        assert result is False
+
+    def test_restore_returns_false_when_persisted_sid_does_not_match(self) -> None:
+        """Gate: the persisted file's session_id field must match the
+        target. Defends against a renamed/hand-edited file."""
+        wrong_snapshot = {
+            "session_id": "different-session-id",
+            "cost": {"total_cost_usd": 1.0},
+        }
+        self._test_file.write_text(json.dumps(wrong_snapshot))
+        result = restore_cost_state_for_session(self.test_sid)
+        assert result is False
+
+    def test_restore_works_without_calling_switch_session_first(self) -> None:
+        """Critical TS-parity property: restore should NOT require the
+        bootstrap session_id to match the target. The gate is the
+        persisted file's session_id, not the runtime one."""
+        # Note: we deliberately do NOT call switch_session(test_sid) here
+        snapshot = {
+            "session_id": str(self.test_sid),
+            "cost": {"total_cost_usd": 2.50},
+        }
+        self._test_file.write_text(json.dumps(snapshot))
+
+        result = restore_cost_state_for_session(self.test_sid)
+        assert result is True
+        assert abs(get_total_cost_usd() - 2.50) < 1e-6
+
+    def test_restore_applies_persisted_snapshot(self) -> None:
+        snapshot = {
+            "session_id": str(self.test_sid),
+            "cost": {
+                "total_cost_usd": 4.20,
+                "total_api_duration": 1234,
+                "total_api_duration_without_retries": 1100,
+                "total_tool_duration": 567,
+                "total_lines_added": 100,
+                "total_lines_removed": 50,
+                "model_usage": {
+                    "claude-opus-4-20250514": {
+                        "input_tokens": 500_000,
+                        "output_tokens": 250_000,
+                        "cost_usd": 4.20,
+                    },
+                },
+            },
+        }
+        self._test_file.write_text(json.dumps(snapshot))
+
+        result = restore_cost_state_for_session(self.test_sid)
+
+        assert result is True
+        assert abs(get_total_cost_usd() - 4.20) < 1e-6
+        usage = get_model_usage()["claude-opus-4-20250514"]
+        assert usage.input_tokens == 500_000
+        assert abs(usage.cost_usd - 4.20) < 1e-6
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR 5/6 in the ch03 state stack. Stacked on top of #68 (AppState + on_change_app_state).

Consolidates Python's two `CostTracker` classes onto the bootstrap-singleton-backed accounting added in #66.

### New files

- **`src/services/pricing.py`** — single source of truth for per-model pricing. Pure functions and constants: `PRICING`, `DEFAULT_PRICING`, `get_pricing(model)`, `compute_cost(model, usage)`. No state, no class.
- **`src/services/cost_restore.py`** — restore orchestrator analogue of TS `cost-tracker.ts:149`. `restore_cost_state_for_session(sid)` reads the persisted snapshot at `~/.clawcodex/sessions/<sid>.json` and dispatches `set_cost_state_for_restore` into the bootstrap singleton. **The gate is the persisted file's `session_id` field** (matches TS exactly): works whether the caller called `switch_session(sid)` first or not, and defends against renamed/hand-edited files. `_sessions_dir()` is exposed as a function so tests can monkeypatch with `tmp_path`.

### Modified files

- **`src/cost_tracker.py`** — refactored from 13-LOC stub to a facade over the bootstrap singleton. `record(label, units)` preserved for back-compat with `costHook.apply_cost_hook`. New `record_usage(model, usage)` routes through `compute_cost` + `add_to_total_cost_state`. `total_cost_usd` is a property that reads through to bootstrap, so **two CostTracker instances share state** — the "two trackers disagree" problem the gap analysis flagged is gone.
- **`src/services/cost_tracker.py`** — annotated DEPRECATED in the docstring. Pricing tables/functions removed; now re-exports `PRICING`, `DEFAULT_PRICING`, `compute_cost`, `get_pricing` from `src/services/pricing.py`. The 283-LOC `CostTracker` class is preserved because 23 unit tests depend on it; production code should use the new facade or the bootstrap accessors directly.

## Test plan
- [x] `pytest tests/test_cost_tracker_facade.py tests/test_cost_tracker.py tests/test_cost_tracker_full.py` — 40 passing (17 new + 23 preserved legacy)
- [x] Restore tests use `tmp_path` + `monkeypatch` (no real-home pollution)
- [x] `test_restore_works_without_calling_switch_session_first` locks the TS-parity property
- [x] `test_two_trackers_share_bootstrap_total` locks the architectural invariant
- [x] No regressions in the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)