### PR TITLE
feat(ch04/api-1): section factories + DANGEROUS naming + latch reset

### DIFF
--- a/src/context_system/system_prompt_cache.py
+++ b/src/context_system/system_prompt_cache.py
@@ -40,6 +40,67 @@ class SystemPromptSection:
     content: str
     cache_scope: CacheScope = CacheScope.SESSION
     order: int = 0  # Lower = earlier in prompt
+    cache_break: bool = False
+    reason: str | None = None
+
+
+def system_prompt_section(
+    name: str,
+    *,
+    content: str,
+    cache_scope: CacheScope = CacheScope.SESSION,
+    order: int = 0,
+) -> SystemPromptSection:
+    """Build a cacheable prompt section.
+
+    Mirrors TS ``systemPromptSection`` from
+    ``constants/systemPromptSections.ts``. Sections built through this
+    factory have ``cache_break = False``; their content is memoized until
+    ``clear_system_prompt_sections()`` is called (on /clear or /compact).
+    """
+    return SystemPromptSection(
+        id=name,
+        content=content,
+        cache_scope=cache_scope,
+        order=order,
+        cache_break=False,
+    )
+
+
+def DANGEROUS_uncachedSystemPromptSection(
+    name: str,
+    *,
+    content: str,
+    reason: str,
+    cache_scope: CacheScope = CacheScope.REQUEST,
+    order: int = 0,
+) -> SystemPromptSection:
+    """Build a cache-breaking prompt section that recomputes every turn.
+
+    Mirrors TS ``DANGEROUS_uncachedSystemPromptSection`` from
+    ``constants/systemPromptSections.ts``. The loud name is deliberate (per
+    chapter §"The DANGEROUS Naming Convention"): cache-breaking sections
+    must surface in code review because each one risks invalidating ~50-70K
+    tokens of cached prefix.
+
+    ``reason`` is required — a blank reason raises ``ValueError``. The
+    parameter is unused at runtime, but enforcing non-empty content turns
+    code review from "remember to ask why" into a constructor-time invariant.
+    """
+    if not reason or not reason.strip():
+        raise ValueError(
+            "DANGEROUS_uncachedSystemPromptSection requires a non-empty "
+            "reason — explain why this section cannot be cached so future "
+            "readers can evaluate whether the trade-off is still warranted."
+        )
+    return SystemPromptSection(
+        id=name,
+        content=content,
+        cache_scope=cache_scope,
+        order=order,
+        cache_break=True,
+        reason=reason.strip(),
+    )
 
 
 class SystemPromptCache:
@@ -102,3 +163,34 @@ class SystemPromptCache:
             k for k, v in self._cache.items()
             if not v.is_expired
         ]
+
+
+def clear_system_prompt_sections() -> None:
+    """Clear the section cache and reset sticky beta-header latches.
+
+    Mirrors TS ``clearSystemPromptSections()`` (constants/systemPromptSections.ts).
+    Called on ``/clear`` and ``/compact`` so a fresh conversation gets fresh
+    evaluation of AFK / fast-mode / cache-editing / thinking-clear / 1h-cache
+    eligibility *and* fresh content for memoized sections.
+
+    Importing ``cache_state`` lazily avoids a circular dependency: cache_state
+    does not import from this module, but a future change might, and the lazy
+    import keeps that risk contained.
+    """
+    # Lazy import to keep this file free of state dependencies at import time.
+    from src.state.cache_state import clear_beta_header_latches
+
+    # Clear the module-level prompt cache used by prompt_assembly.py.
+    # The cache lives on a singleton created in prompt_assembly; import
+    # lazily to avoid the prompt_assembly → system_prompt_cache circular
+    # dependency that the file's "from .system_prompt_cache import ..."
+    # block already comments on.
+    try:
+        from src.context_system.prompt_assembly import get_system_prompt_cache
+        get_system_prompt_cache().invalidate_all()
+    except ImportError:
+        # prompt_assembly isn't always importable in minimal test contexts;
+        # latch clearing still proceeds.
+        pass
+
+    clear_beta_header_latches()

--- a/src/state/cache_state.py
+++ b/src/state/cache_state.py
@@ -240,3 +240,20 @@ def reset_for_test_only() -> None:
     """
     global _LATCHES
     _LATCHES = BetaHeaderLatches()
+
+
+def clear_beta_header_latches() -> None:
+    """Reset the sticky beta-header latches.
+
+    Mirrors TS ``clearBetaHeaderLatches()`` from
+    ``bootstrap/state.ts``. Called on ``/clear`` and ``/compact`` so a fresh
+    conversation re-evaluates AFK / fast-mode / cache-editing / thinking-
+    clear / 1h-eligibility from scratch (per chapter §"Sticky Latch
+    Fields").
+
+    The 1h-eligibility latch is included because the conversation rewind
+    invalidates the request-source history that informed the original
+    evaluation.
+    """
+    global _LATCHES
+    _LATCHES = BetaHeaderLatches()

--- a/tests/test_clear_system_prompt_sections.py
+++ b/tests/test_clear_system_prompt_sections.py
@@ -1,0 +1,70 @@
+"""Test the cache+latch reset that fires on /clear and /compact (Phase A)."""
+from __future__ import annotations
+
+import unittest
+
+from src.context_system.system_prompt_cache import (
+    CacheScope,
+    clear_system_prompt_sections,
+)
+from src.state import cache_state as cs
+
+
+class TestClearSystemPromptSections(unittest.TestCase):
+    def setUp(self) -> None:
+        cs.reset_for_test_only()
+
+    def tearDown(self) -> None:
+        cs.reset_for_test_only()
+
+    def test_clear_resets_all_toggle_latches(self) -> None:
+        latches = cs.get_beta_header_latches()
+        latches.fast_mode_header_latched = True
+        latches.afk_mode_header_latched = True
+        latches.cache_editing_header_latched = True
+        latches.thinking_clear_latched = True
+        latches.prompt_cache_1h_eligible = True
+
+        clear_system_prompt_sections()
+
+        fresh = cs.get_beta_header_latches()
+        self.assertFalse(fresh.fast_mode_header_latched)
+        self.assertFalse(fresh.afk_mode_header_latched)
+        self.assertFalse(fresh.cache_editing_header_latched)
+        self.assertFalse(fresh.thinking_clear_latched)
+        self.assertIsNone(fresh.prompt_cache_1h_eligible)
+
+    def test_clear_invalidates_prompt_cache(self) -> None:
+        from src.context_system.prompt_assembly import get_system_prompt_cache
+
+        cache = get_system_prompt_cache()
+        # Populate the cache with three sections at distinct scopes so we
+        # can distinguish a partial clear from a full clear.
+        from src.context_system.system_prompt_cache import CacheScope
+        cache.set("intro", "intro content", scope=CacheScope.GLOBAL)
+        cache.set("env", "env content", scope=CacheScope.SESSION)
+        cache.set("mcp", "mcp content", scope=CacheScope.REQUEST)
+        self.assertEqual(cache.size, 3)
+
+        clear_system_prompt_sections()
+
+        # All entries gone — invalidate_all, not just one scope.
+        self.assertEqual(cache.size, 0)
+        self.assertIsNone(cache.get("intro"))
+        self.assertIsNone(cache.get("env"))
+        self.assertIsNone(cache.get("mcp"))
+
+    def test_clear_is_safe_when_prompt_assembly_unavailable(self) -> None:
+        """The function must not raise even when ``prompt_assembly`` cannot
+        be imported (minimal test envs without context_system fully wired).
+        /clear and /compact run unconditionally — they cannot afford to
+        crash because an optional submodule is missing.
+        """
+        # We can't easily simulate the ImportError here, but the
+        # implementation guards with ``except ImportError: pass`` so this
+        # is at minimum a smoke test that no other exception classes leak.
+        clear_system_prompt_sections()  # should not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_system_prompt_section_factory.py
+++ b/tests/test_system_prompt_section_factory.py
@@ -1,0 +1,87 @@
+"""Tests for the section factories from ch04-api-layer refactor (Phase A).
+
+Mirrors the TS contract in ``constants/systemPromptSections.ts``: cacheable
+sections route through ``system_prompt_section``; cache-breaking sections
+must route through ``DANGEROUS_uncachedSystemPromptSection`` with a
+non-empty reason. The factory is the *only* surface that should be used
+when authoring new prompt sections — direct ``SystemPromptSection(...)``
+construction bypasses the convention.
+"""
+from __future__ import annotations
+
+import unittest
+
+from src.context_system.system_prompt_cache import (
+    CacheScope,
+    DANGEROUS_uncachedSystemPromptSection,
+    SystemPromptSection,
+    system_prompt_section,
+)
+
+
+class TestSystemPromptSectionFactory(unittest.TestCase):
+    def test_safe_factory_defaults(self) -> None:
+        section = system_prompt_section("intro", content="hello world")
+        self.assertIsInstance(section, SystemPromptSection)
+        self.assertEqual(section.id, "intro")
+        self.assertEqual(section.content, "hello world")
+        self.assertEqual(section.cache_scope, CacheScope.SESSION)
+        self.assertFalse(section.cache_break)
+        self.assertIsNone(section.reason)
+
+    def test_safe_factory_explicit_scope_and_order(self) -> None:
+        section = system_prompt_section(
+            "memory",
+            content="mem",
+            cache_scope=CacheScope.GLOBAL,
+            order=10,
+        )
+        self.assertEqual(section.cache_scope, CacheScope.GLOBAL)
+        self.assertEqual(section.order, 10)
+        self.assertFalse(section.cache_break)
+
+
+class TestDangerousFactory(unittest.TestCase):
+    def test_dangerous_factory_sets_cache_break_and_reason(self) -> None:
+        section = DANGEROUS_uncachedSystemPromptSection(
+            "mcp",
+            content="mcp instructions",
+            reason="MCP servers connect/disconnect between turns",
+        )
+        self.assertTrue(section.cache_break)
+        self.assertEqual(section.reason, "MCP servers connect/disconnect between turns")
+        self.assertEqual(section.cache_scope, CacheScope.REQUEST)
+
+    def test_dangerous_factory_strips_reason_whitespace(self) -> None:
+        section = DANGEROUS_uncachedSystemPromptSection(
+            "x",
+            content="x",
+            reason="   the cache changes per turn   ",
+        )
+        self.assertEqual(section.reason, "the cache changes per turn")
+
+    def test_dangerous_factory_rejects_empty_reason(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            DANGEROUS_uncachedSystemPromptSection(
+                "x", content="x", reason="",
+            )
+        self.assertIn("reason", str(ctx.exception).lower())
+
+    def test_dangerous_factory_rejects_whitespace_reason(self) -> None:
+        with self.assertRaises(ValueError):
+            DANGEROUS_uncachedSystemPromptSection(
+                "x", content="x", reason="   \t \n  ",
+            )
+
+    def test_dangerous_factory_default_scope_is_request(self) -> None:
+        """REQUEST scope is the default because cache-breaking sections
+        cannot share the SESSION-scope cache slot — they recompute per turn.
+        """
+        section = DANGEROUS_uncachedSystemPromptSection(
+            "x", content="x", reason="varies turn-to-turn",
+        )
+        self.assertEqual(section.cache_scope, CacheScope.REQUEST)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR 1 of 4 in the Chapter 4 (API Layer) refactor. Closes the section-factory + cache-discipline gap from `ch04-api-layer-gap-analysis.md`.

- Adds `system_prompt_section(name, content, ...)` for cacheable, memoized sections.
- Adds `DANGEROUS_uncachedSystemPromptSection(name, content, reason, ...)` for cache-breaking sections. The required `reason` parameter is enforced at construction time — empty/whitespace strings raise `ValueError`. Mirrors TS `constants/systemPromptSections.ts` (chapter §"The DANGEROUS Naming Convention").
- Adds `clear_system_prompt_sections()` that clears the section cache *and* resets the sticky beta-header latches in `state/cache_state`. Mirrors TS `clearSystemPromptSections()` — used on `/clear` and `/compact` so a fresh conversation re-evaluates AFK / fast-mode / cache-editing / thinking-clear / 1h-eligibility from scratch.
- Exposes `clear_beta_header_latches()` as the production-API counterpart to the existing test-only `reset_for_test_only`.

No call-site changes — this is pure new surface area. PR2 will start using `_is_first_party_endpoint` from the next phase.

## Test plan

- [x] `tests/test_system_prompt_section_factory.py` — 7 cases covering both factories, default scopes, and the empty-reason ValueError.
- [x] `tests/test_clear_system_prompt_sections.py` — populates the cache + sets all five latches, calls `clear_system_prompt_sections()`, asserts cache is empty and all latches reset. Plus a smoke test for the "prompt_assembly not importable" graceful-degrade path.
- [x] No regressions on the 8 pre-existing API/streaming test files (test_api_retry, test_api_errors, test_api_logging, test_streaming_query_loop, test_streaming_executor, test_streaming_executor_race, test_agent_loop, test_compact).

## Sequencing

This PR is the first of four; merge first, then I'll open the next stacked PR.

1. **#this** — section factories + DANGEROUS naming
2. `feat/ch04-api-2-request-helpers` — output-token cap + x-client-request-id
3. `feat/ch04-api-3-cache-and-haiku` — add_cache_breakpoints + query_haiku
4. `feat/ch04-api-4-recovery-pipeline` — watchdog + non-streaming fallback + with_retry_stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)