### PR TITLE
feat(ch04/api-2): output-token cap + x-client-request-id injection

### DIFF
--- a/src/services/api/__init__.py
+++ b/src/services/api/__init__.py
@@ -1,4 +1,15 @@
-from .claude import StreamEvent, call_model, tool_to_api_schema
+from .claude import (
+    CAPPED_DEFAULT_MAX_TOKENS,
+    CLIENT_REQUEST_ID_HEADER,
+    CallModelOptions,
+    MAX_NON_STREAMING_TOKENS,
+    StreamEvent,
+    adjust_params_for_non_streaming,
+    call_model,
+    get_max_output_tokens_for_model,
+    make_client_request_id,
+    tool_to_api_schema,
+)
 from .errors import (
     FallbackTriggeredError,
     MaxOutputTokensError,
@@ -13,8 +24,12 @@ from .retry import CannotRetryError, RetryContext, with_retry
 from .tool_normalization import normalize_tool_arguments
 
 __all__ = [
+    "CAPPED_DEFAULT_MAX_TOKENS",
+    "CLIENT_REQUEST_ID_HEADER",
+    "CallModelOptions",
     "CannotRetryError",
     "FallbackTriggeredError",
+    "MAX_NON_STREAMING_TOKENS",
     "MaxOutputTokensError",
     "NonNullableUsage",
     "OverloadedError",
@@ -24,8 +39,11 @@ __all__ = [
     "RetryContext",
     "StreamEvent",
     "accumulate_usage",
+    "adjust_params_for_non_streaming",
     "call_model",
     "categorize_retryable_api_error",
+    "get_max_output_tokens_for_model",
+    "make_client_request_id",
     "normalize_tool_arguments",
     "resolve_agent_provider",
     "tool_to_api_schema",

--- a/src/services/api/claude.py
+++ b/src/services/api/claude.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -16,6 +17,112 @@ from .logging import APICallLog, NonNullableUsage, log_api_call, update_usage
 logger = logging.getLogger(__name__)
 
 CLI_SYSPROMPT_PREFIX = "[S]"
+
+# Per chapter §"Output Token Cap": production p99 output is ~4.9K tokens, so
+# the typical 32K/64K defaults over-reserve slot capacity by 8-16×. Default
+# cap is 8K; requests that hit it retry once at 64K (non-streaming fallback
+# — lands in a later PR).
+CAPPED_DEFAULT_MAX_TOKENS = 8_000
+MAX_NON_STREAMING_TOKENS = 64_000
+
+# Per-model "native" upper limits. Used to floor the default at the model's
+# own default when it is below the cap (e.g. Haiku is already 8K). Mirrors
+# TS ``getModelMaxOutputTokens()``.
+_MODEL_DEFAULT_MAX_TOKENS: dict[str, int] = {
+    "claude-opus-4-7": 64_000,
+    "claude-opus-4-6": 64_000,
+    "claude-opus-4-5": 64_000,
+    "claude-opus-4-1": 32_000,
+    "claude-opus-4-0": 32_000,
+    "claude-sonnet-4-6": 64_000,
+    "claude-sonnet-4-5": 64_000,
+    "claude-sonnet-4-0": 32_000,
+    "claude-haiku-4-5": 8_000,
+    "claude-3-5-sonnet-20241022": 8_000,
+    "claude-3-5-haiku-20241022": 8_000,
+    "claude-3-opus-20240229": 4_000,
+}
+
+CLIENT_REQUEST_ID_HEADER = "x-client-request-id"
+
+
+def get_max_output_tokens_for_model(model: str) -> int:
+    """Return the effective output-token cap for ``model``.
+
+    Mirrors TS ``getMaxOutputTokensForModel`` (claude.ts:3443-3463).
+    The default is ``min(per_model_native_default, 8_000)``; the env var
+    ``CLAUDE_CODE_MAX_OUTPUT_TOKENS`` overrides bounded by the per-model
+    upper limit. Returns at least 1 (a zero-token request would 400).
+
+    The 8K cap exists for slot-reservation economics — see chapter for the
+    p99 distribution. Requests that hit the cap retry once at
+    ``MAX_NON_STREAMING_TOKENS`` (64K) via the non-streaming fallback path
+    (wired in a later PR).
+    """
+    native_default = _MODEL_DEFAULT_MAX_TOKENS.get(model, CAPPED_DEFAULT_MAX_TOKENS)
+    default = min(native_default, CAPPED_DEFAULT_MAX_TOKENS)
+    upper_limit = max(native_default, CAPPED_DEFAULT_MAX_TOKENS)
+
+    env_override = os.environ.get("CLAUDE_CODE_MAX_OUTPUT_TOKENS", "").strip()
+    if env_override:
+        try:
+            override_val = int(env_override)
+            if override_val > 0:
+                return max(1, min(override_val, upper_limit))
+        except ValueError:
+            pass
+
+    return max(1, default)
+
+
+def adjust_params_for_non_streaming(
+    max_tokens: int,
+    thinking_budget: int | None,
+    *,
+    cap: int = MAX_NON_STREAMING_TOKENS,
+) -> tuple[int, int | None]:
+    """Cap ``max_tokens`` and (if needed) ``thinking.budget_tokens``.
+
+    Mirrors TS ``adjustParamsForNonStreaming`` (claude.ts:3408-3436). The
+    API requires ``max_tokens > thinking.budget_tokens`` so the budget
+    shrinks to ``capped_max - 1`` when both are at the ceiling.
+
+    Returns (capped_max_tokens, adjusted_thinking_budget).
+    """
+    capped = min(max_tokens, cap)
+    if thinking_budget is not None and thinking_budget >= capped:
+        thinking_budget = max(1, capped - 1)
+    return capped, thinking_budget
+
+
+def make_client_request_id() -> str:
+    """Generate a fresh UUID for x-client-request-id correlation.
+
+    Mirrors TS ``randomUUID()`` usage at the client construction site
+    (services/api/client.ts:540-542). The header lets the API team
+    correlate timeouts (where the server never returns a request ID) with
+    server-side logs.
+    """
+    return uuid.uuid4().hex
+
+
+def _is_first_party_endpoint(client: Any) -> bool:
+    """True iff ``client`` targets the first-party Anthropic endpoint.
+
+    Mirrors TS ``isFirstPartyAnthropicBaseUrl()`` (utils/model/providers.ts).
+    Third-party providers (Bedrock, Vertex, Foundry, OpenAI-shim) reject
+    unknown headers, so ``x-client-request-id`` is only emitted on the
+    first-party path.
+
+    The Anthropic Python SDK stores its base URL on ``client.base_url`` after
+    construction. When the caller leaves it default, the SDK's internal URL
+    is the first-party endpoint, so an empty / missing attribute also
+    qualifies as first-party.
+    """
+    base_url = getattr(client, "base_url", "") or ""
+    if not base_url:
+        return True
+    return "anthropic.com" in str(base_url).lower()
 
 
 @dataclass
@@ -133,8 +240,15 @@ def _build_tool_schemas(tools: list[Any]) -> list[dict[str, Any]]:
 
 @dataclass
 class CallModelOptions:
+    """Per-call configuration for ``call_model``.
+
+    ``max_tokens=None`` defers to ``get_max_output_tokens_for_model()`` so
+    the slot-reservation cap (8K default) applies. Pass an explicit int
+    only when the caller needs a specific ceiling.
+    """
+
     model: str = "claude-sonnet-4-6"
-    max_tokens: int = 16384
+    max_tokens: int | None = None
     system_prompt: str = ""
     tools: list[Any] = field(default_factory=list)
     thinking_enabled: bool = False
@@ -145,6 +259,18 @@ class CallModelOptions:
     structured_output: dict[str, Any] | None = None
     extra_headers: dict[str, str] | None = None
     extra_body: dict[str, Any] | None = None
+
+    def resolved_max_tokens(self) -> int:
+        """Return ``max_tokens`` with the per-model cap applied.
+
+        ``None`` (default) routes through the helper for the slot-
+        reservation cap. Explicit positive ints are honoured but bounded at
+        ``MAX_NON_STREAMING_TOKENS`` so callers cannot configure a request
+        the API will reject.
+        """
+        if self.max_tokens is None:
+            return get_max_output_tokens_for_model(self.model)
+        return max(1, min(self.max_tokens, MAX_NON_STREAMING_TOKENS))
 
 
 async def call_model(
@@ -171,7 +297,7 @@ async def call_model(
 
         create_kwargs: dict[str, Any] = {
             "model": opts.model,
-            "max_tokens": opts.max_tokens,
+            "max_tokens": opts.resolved_max_tokens(),
             "messages": messages,
         }
 
@@ -193,7 +319,17 @@ async def call_model(
                 "budget_tokens": opts.thinking_budget,
             }
 
+        # Build the per-request header dict so we can inject
+        # ``x-client-request-id`` without mutating the caller's options.
+        # Explicit caller headers win — if the caller pre-set the request
+        # ID (e.g. to thread one across a streaming + non-streaming-fallback
+        # pair, landing in a later PR) we honour that.
         extra_headers = dict(opts.extra_headers or {})
+        if (
+            _is_first_party_endpoint(client)
+            and CLIENT_REQUEST_ID_HEADER not in extra_headers
+        ):
+            extra_headers[CLIENT_REQUEST_ID_HEADER] = make_client_request_id()
         if extra_headers:
             create_kwargs["extra_headers"] = extra_headers
 

--- a/tests/test_client_request_id.py
+++ b/tests/test_client_request_id.py
@@ -1,0 +1,166 @@
+"""Tests for x-client-request-id injection (Phase C)."""
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+from src.services.api.claude import (
+    CLIENT_REQUEST_ID_HEADER,
+    CallModelOptions,
+    _is_first_party_endpoint,
+    call_model,
+    make_client_request_id,
+)
+
+
+class _FakeStream:
+    """Async iterator that produces a minimal sequence of SDK-shaped events.
+
+    Used to drive ``call_model`` without an Anthropic SDK install. Each
+    event is a SimpleNamespace-like object with the attributes ``call_model``
+    reads via ``getattr``.
+    """
+
+    def __init__(self) -> None:
+        self._events: list[object] = [
+            type("E", (), {
+                "type": "message_start",
+                "message": type("M", (), {
+                    "usage": type("U", (), {
+                        "input_tokens": 1, "output_tokens": 0,
+                        "cache_creation_input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                    })(),
+                    "model": "claude-haiku-4-5",
+                })(),
+            })(),
+            type("E", (), {
+                "type": "message_delta",
+                "delta": type("D", (), {"stop_reason": "end_turn"})(),
+                "usage": type("U", (), {"output_tokens": 5})(),
+            })(),
+            type("E", (), {"type": "message_stop"})(),
+        ]
+        self._i = 0
+
+    def __aiter__(self) -> "_FakeStream":
+        return self
+
+    async def __anext__(self) -> object:
+        if self._i >= len(self._events):
+            raise StopAsyncIteration
+        ev = self._events[self._i]
+        self._i += 1
+        return ev
+
+
+class _RecordingMessages:
+    def __init__(self) -> None:
+        self.last_kwargs: dict | None = None
+
+    async def create(self, **kwargs):
+        self.last_kwargs = kwargs
+        return _FakeStream()
+
+
+class _FakeClient:
+    def __init__(self, base_url: str = "") -> None:
+        self.base_url = base_url
+        self.messages = _RecordingMessages()
+
+
+class TestIsFirstPartyEndpoint(unittest.TestCase):
+    def test_default_base_url(self) -> None:
+        client = _FakeClient(base_url="")
+        self.assertTrue(_is_first_party_endpoint(client))
+
+    def test_anthropic_base_url(self) -> None:
+        client = _FakeClient(base_url="https://api.anthropic.com")
+        self.assertTrue(_is_first_party_endpoint(client))
+
+    def test_bedrock_base_url(self) -> None:
+        client = _FakeClient(base_url="https://bedrock-runtime.us-east-1.amazonaws.com")
+        self.assertFalse(_is_first_party_endpoint(client))
+
+    def test_vertex_base_url(self) -> None:
+        client = _FakeClient(base_url="https://us-east5-aiplatform.googleapis.com")
+        self.assertFalse(_is_first_party_endpoint(client))
+
+    def test_attribute_missing(self) -> None:
+        class _NoBaseUrl:
+            pass
+        # No base_url attribute at all → conservatively first-party.
+        self.assertTrue(_is_first_party_endpoint(_NoBaseUrl()))
+
+
+class TestMakeClientRequestId(unittest.TestCase):
+    def test_returns_unique_hex(self) -> None:
+        a = make_client_request_id()
+        b = make_client_request_id()
+        self.assertNotEqual(a, b)
+        # uuid4().hex is 32 chars
+        self.assertEqual(len(a), 32)
+
+
+class TestCallModelHeaders(unittest.TestCase):
+    def test_first_party_client_gets_request_id(self) -> None:
+        client = _FakeClient(base_url="")
+        opts = CallModelOptions(model="claude-haiku-4-5")
+
+        async def _drain() -> None:
+            async for _ in call_model([], opts, client=client):
+                pass
+
+        asyncio.run(_drain())
+
+        headers = (client.messages.last_kwargs or {}).get("extra_headers", {})
+        self.assertIn(CLIENT_REQUEST_ID_HEADER, headers)
+        self.assertEqual(len(headers[CLIENT_REQUEST_ID_HEADER]), 32)
+
+    def test_third_party_client_no_request_id(self) -> None:
+        client = _FakeClient(base_url="https://bedrock-runtime.us-east-1.amazonaws.com")
+        opts = CallModelOptions(model="claude-haiku-4-5")
+
+        async def _drain() -> None:
+            async for _ in call_model([], opts, client=client):
+                pass
+
+        asyncio.run(_drain())
+
+        headers = (client.messages.last_kwargs or {}).get("extra_headers", {})
+        self.assertNotIn(CLIENT_REQUEST_ID_HEADER, headers)
+
+    def test_caller_supplied_request_id_preserved(self) -> None:
+        """A caller pre-setting the header (e.g. to thread one across a
+        streaming + non-streaming-fallback pair) must override the auto-mint."""
+        client = _FakeClient(base_url="")
+        custom_id = "caller-provided-id"
+        opts = CallModelOptions(
+            model="claude-haiku-4-5",
+            extra_headers={CLIENT_REQUEST_ID_HEADER: custom_id},
+        )
+
+        async def _drain() -> None:
+            async for _ in call_model([], opts, client=client):
+                pass
+
+        asyncio.run(_drain())
+
+        headers = (client.messages.last_kwargs or {}).get("extra_headers", {})
+        self.assertEqual(headers[CLIENT_REQUEST_ID_HEADER], custom_id)
+
+    def test_resolved_max_tokens_applied_in_request(self) -> None:
+        client = _FakeClient(base_url="")
+        opts = CallModelOptions(model="claude-opus-4-7")  # default cap = 8K
+
+        async def _drain() -> None:
+            async for _ in call_model([], opts, client=client):
+                pass
+
+        asyncio.run(_drain())
+
+        self.assertEqual((client.messages.last_kwargs or {}).get("max_tokens"), 8_000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_max_output_tokens.py
+++ b/tests/test_max_output_tokens.py
@@ -1,0 +1,145 @@
+"""Tests for the output-token cap helpers (Phase B)."""
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from src.services.api.claude import (
+    CAPPED_DEFAULT_MAX_TOKENS,
+    CallModelOptions,
+    MAX_NON_STREAMING_TOKENS,
+    adjust_params_for_non_streaming,
+    get_max_output_tokens_for_model,
+)
+
+
+class TestGetMaxOutputTokensForModel(unittest.TestCase):
+    def setUp(self) -> None:
+        # Strip the env var so each test starts clean.
+        self._saved_env = os.environ.pop("CLAUDE_CODE_MAX_OUTPUT_TOKENS", None)
+
+    def tearDown(self) -> None:
+        os.environ.pop("CLAUDE_CODE_MAX_OUTPUT_TOKENS", None)
+        if self._saved_env is not None:
+            os.environ["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] = self._saved_env
+
+    def test_opus_default_capped_at_8k(self) -> None:
+        # Native default is 64K but the slot-reservation cap clamps to 8K
+        # so production p99 (~5K) requests don't reserve 8-16× slot capacity.
+        self.assertEqual(
+            get_max_output_tokens_for_model("claude-opus-4-7"),
+            CAPPED_DEFAULT_MAX_TOKENS,
+        )
+
+    def test_haiku_default_at_native(self) -> None:
+        # Haiku's native default is already 8K (matches the cap), so the
+        # cap is a no-op rather than a downgrade.
+        self.assertEqual(
+            get_max_output_tokens_for_model("claude-haiku-4-5"),
+            CAPPED_DEFAULT_MAX_TOKENS,
+        )
+
+    def test_unknown_model_falls_back_to_default(self) -> None:
+        self.assertEqual(
+            get_max_output_tokens_for_model("imaginary-model"),
+            CAPPED_DEFAULT_MAX_TOKENS,
+        )
+
+    def test_env_override_below_upper_limit(self) -> None:
+        os.environ["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] = "12000"
+        self.assertEqual(
+            get_max_output_tokens_for_model("claude-opus-4-7"),
+            12000,
+        )
+
+    def test_env_override_above_upper_limit_bounded(self) -> None:
+        # Opus's native upper-limit is 64K; an env value of 100K must be
+        # bounded to 64K.
+        os.environ["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] = "100000"
+        self.assertEqual(
+            get_max_output_tokens_for_model("claude-opus-4-7"),
+            64_000,
+        )
+
+    def test_env_override_invalid_falls_back_to_default(self) -> None:
+        os.environ["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] = "not-a-number"
+        self.assertEqual(
+            get_max_output_tokens_for_model("claude-opus-4-7"),
+            CAPPED_DEFAULT_MAX_TOKENS,
+        )
+
+    def test_env_override_zero_falls_back_to_default(self) -> None:
+        # A zero env override is meaningless (would 400); fall back.
+        os.environ["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] = "0"
+        self.assertEqual(
+            get_max_output_tokens_for_model("claude-opus-4-7"),
+            CAPPED_DEFAULT_MAX_TOKENS,
+        )
+
+
+class TestAdjustParamsForNonStreaming(unittest.TestCase):
+    def test_caps_max_tokens(self) -> None:
+        capped, thinking = adjust_params_for_non_streaming(
+            128_000, thinking_budget=None,
+        )
+        self.assertEqual(capped, MAX_NON_STREAMING_TOKENS)
+        self.assertIsNone(thinking)
+
+    def test_below_cap_unchanged(self) -> None:
+        capped, thinking = adjust_params_for_non_streaming(
+            8_000, thinking_budget=4_000,
+        )
+        self.assertEqual(capped, 8_000)
+        self.assertEqual(thinking, 4_000)
+
+    def test_thinking_budget_shrinks_when_at_or_above_max(self) -> None:
+        # API requires max_tokens > thinking.budget_tokens. When both are at
+        # the ceiling, thinking shrinks to max - 1.
+        capped, thinking = adjust_params_for_non_streaming(
+            MAX_NON_STREAMING_TOKENS, thinking_budget=MAX_NON_STREAMING_TOKENS,
+        )
+        self.assertEqual(capped, MAX_NON_STREAMING_TOKENS)
+        self.assertEqual(thinking, MAX_NON_STREAMING_TOKENS - 1)
+
+    def test_thinking_budget_equal_to_max_still_shrinks(self) -> None:
+        capped, thinking = adjust_params_for_non_streaming(
+            5_000, thinking_budget=5_000,
+        )
+        self.assertEqual(capped, 5_000)
+        self.assertEqual(thinking, 4_999)
+
+    def test_thinking_budget_floor_is_one(self) -> None:
+        # When the capped max collapses to a single token, the budget
+        # cannot be negative; it floors at 1.
+        capped, thinking = adjust_params_for_non_streaming(
+            1, thinking_budget=5,
+        )
+        self.assertEqual(capped, 1)
+        self.assertEqual(thinking, 1)
+
+
+class TestCallModelOptionsResolvedMaxTokens(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved_env = os.environ.pop("CLAUDE_CODE_MAX_OUTPUT_TOKENS", None)
+
+    def tearDown(self) -> None:
+        os.environ.pop("CLAUDE_CODE_MAX_OUTPUT_TOKENS", None)
+        if self._saved_env is not None:
+            os.environ["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] = self._saved_env
+
+    def test_default_resolves_to_8k(self) -> None:
+        opts = CallModelOptions(model="claude-opus-4-7")
+        self.assertEqual(opts.resolved_max_tokens(), CAPPED_DEFAULT_MAX_TOKENS)
+
+    def test_explicit_max_tokens_honoured(self) -> None:
+        opts = CallModelOptions(model="claude-opus-4-7", max_tokens=24_000)
+        self.assertEqual(opts.resolved_max_tokens(), 24_000)
+
+    def test_explicit_max_tokens_bounded(self) -> None:
+        opts = CallModelOptions(model="claude-opus-4-7", max_tokens=200_000)
+        self.assertEqual(opts.resolved_max_tokens(), MAX_NON_STREAMING_TOKENS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR 2 of 4 in the Chapter 4 (API Layer) refactor. **Stacked on top of #72** — merge that first.

### Output-token cap (chapter §"Output Token Cap")
- `get_max_output_tokens_for_model(model)` returns `min(per-model native, 8K)` by default. Production p99 output is ~4.9K tokens — the typical 32K/64K defaults over-reserve slot capacity by 8-16×.
- `CLAUDE_CODE_MAX_OUTPUT_TOKENS` env var overrides, bounded by per-model upper limit.
- `adjust_params_for_non_streaming(max_tokens, thinking_budget)` caps both and shrinks thinking budget to satisfy `max_tokens > thinking.budget_tokens`. Used by the non-streaming fallback (lands in PR4).
- `CallModelOptions.max_tokens: int | None = None` — sentinel routes through the helper; explicit `int` overrides remain bounded.
- Mirrors TS `getMaxOutputTokensForModel` (claude.ts:3443-3463).

### `x-client-request-id` injection (chapter §"buildFetch Wrapper")
- `CLIENT_REQUEST_ID_HEADER = "x-client-request-id"` constant.
- `make_client_request_id()` mints a per-request UUID.
- `_is_first_party_endpoint(client)` gates the injection — third-party providers (Bedrock/Vertex/Foundry/openai-shim) reject unknown headers.
- `call_model` now injects a fresh UUID on the first-party path; caller-supplied headers win.
- Mirrors TS `buildFetch` at `services/api/client.ts:522-555`.

Both changes are additive — existing callers that pass an explicit `max_tokens` or pre-set `extra_headers[CLIENT_REQUEST_ID_HEADER]` keep working unchanged.

## Test plan

- [x] `tests/test_max_output_tokens.py` — 15 cases: per-model defaults capped at 8K, env override above/below the upper limit, invalid env values, `adjust_params_for_non_streaming` shrinks thinking budget correctly.
- [x] `tests/test_client_request_id.py` — 10 cases: first-party clients (empty / `api.anthropic.com`) get the header; Bedrock/Vertex don't; caller-supplied header preserved; resolved_max_tokens applied to the request.
- [x] Pre-existing tests pass unchanged (test_api_retry, test_api_errors, test_api_logging, test_streaming_query_loop, etc.)

## Sequencing

1. ~~#72~~ — section factories + DANGEROUS naming (merge first)
2. **#this** — output-token cap + x-client-request-id
3. `feat/ch04-api-3-cache-and-haiku` — add_cache_breakpoints + query_haiku
4. `feat/ch04-api-4-recovery-pipeline` — watchdog + non-streaming fallback + with_retry_stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)