### PR TITLE
feat(ch04/api-4): watchdog + non-streaming fallback + with_retry_stream

### DIFF
--- a/src/query/config.py
+++ b/src/query/config.py
@@ -32,6 +32,11 @@ class QueryConfig:
     fallback_model: str | None = None
     query_source: str = "repl_main_thread"
     session_id: str = ""
+    # Default ON for first-party Anthropic — the chapter's three-tier cache
+    # policy is the largest single cost lever, and getting a marker on the
+    # tail of the message array is what unlocks it. Third-party providers
+    # that reject cache_control should turn this off explicitly.
+    enable_prompt_caching: bool = True
 
 
 @dataclass(frozen=True)
@@ -57,6 +62,7 @@ class FrozenQueryConfig:
     fallback_model: str | None = None
     query_source: str = "repl_main_thread"
     session_id: str = ""
+    enable_prompt_caching: bool = True
 
 
 def build_query_config(

--- a/src/query/streaming.py
+++ b/src/query/streaming.py
@@ -11,9 +11,11 @@ from ..services.api.claude import (
     CallModelOptions,
     ContentBlockStop,
     ErrorEvent,
+    FallbackEvent,
     MessageDelta,
     MessageStart,
     MessageStop,
+    RetryEvent,
     TextDelta,
     ThinkingDelta,
     ToolUseDelta,
@@ -206,6 +208,9 @@ async def _run_model_turn(
         structured_output=state.config.structured_output,
         extra_headers=state.config.extra_headers,
         extra_body=state.config.extra_body,
+        enable_prompt_caching=getattr(
+            state.config, "enable_prompt_caching", True,
+        ),
     )
 
     current_tool_use: dict[str, Any] | None = None
@@ -263,3 +268,31 @@ async def _run_model_turn(
 
         elif isinstance(event, MessageStop):
             pass
+
+        elif isinstance(event, FallbackEvent):
+            # call_model is about to replay the non-streamed response as a
+            # complete event sequence. Anything we accumulated from the
+            # aborted partial stream must be discarded — the synthetic
+            # events represent the FULL response, not a continuation.
+            # Mirrors TS ``onStreamingFallback`` callback (claude.ts:2553)
+            # which resets the accumulator state for exactly this reason.
+            turn.text_content = ""
+            turn.thinking_content = ""
+            turn.tool_uses = []
+            turn.usage = NonNullableUsage()
+            current_tool_use = None
+            tool_use_json_parts = []
+            yield QueryEvent(type="fallback", data={"cause": event.cause})
+
+        elif isinstance(event, RetryEvent):
+            # Surface retry progress so the UI can render a "retrying in 5s..."
+            # status inline with the rest of the stream. Mirrors TS
+            # ``SystemAPIErrorMessage`` yielding pattern in withRetry.
+            yield QueryEvent(type="retry", data={
+                "attempt": event.attempt,
+                "delay_ms": event.delay_ms,
+                "error_type": event.error_type,
+                "status": event.status,
+                "message": event.message,
+                "model": event.model,
+            })

--- a/src/services/api/__init__.py
+++ b/src/services/api/__init__.py
@@ -2,7 +2,9 @@ from .claude import (
     CAPPED_DEFAULT_MAX_TOKENS,
     CLIENT_REQUEST_ID_HEADER,
     CallModelOptions,
+    FallbackEvent,
     MAX_NON_STREAMING_TOKENS,
+    RetryEvent,
     SMALL_FAST_MODEL,
     StreamEvent,
     add_cache_breakpoints,
@@ -23,7 +25,13 @@ from .errors import (
 )
 from .logging import NonNullableUsage, accumulate_usage, update_usage
 from .provider_config import ProviderOverride, resolve_agent_provider
-from .retry import CannotRetryError, RetryContext, with_retry
+from .retry import (
+    CannotRetryError,
+    RetryContext,
+    RetryStatusMessage,
+    with_retry,
+    with_retry_stream,
+)
 from .tool_normalization import normalize_tool_arguments
 
 __all__ = [
@@ -31,6 +39,7 @@ __all__ = [
     "CLIENT_REQUEST_ID_HEADER",
     "CallModelOptions",
     "CannotRetryError",
+    "FallbackEvent",
     "FallbackTriggeredError",
     "MAX_NON_STREAMING_TOKENS",
     "MaxOutputTokensError",
@@ -40,6 +49,8 @@ __all__ = [
     "ProviderOverride",
     "RateLimitError",
     "RetryContext",
+    "RetryEvent",
+    "RetryStatusMessage",
     "SMALL_FAST_MODEL",
     "StreamEvent",
     "accumulate_usage",
@@ -55,4 +66,5 @@ __all__ = [
     "tool_to_api_schema",
     "update_usage",
     "with_retry",
+    "with_retry_stream",
 ]

--- a/src/services/api/claude.py
+++ b/src/services/api/claude.py
@@ -20,8 +20,7 @@ CLI_SYSPROMPT_PREFIX = "[S]"
 
 # Per chapter §"Output Token Cap": production p99 output is ~4.9K tokens, so
 # the typical 32K/64K defaults over-reserve slot capacity by 8-16×. Default
-# cap is 8K; requests that hit it retry once at 64K (non-streaming fallback
-# — lands in a later PR).
+# cap is 8K; requests that hit it retry once at 64K (non-streaming fallback).
 CAPPED_DEFAULT_MAX_TOKENS = 8_000
 MAX_NON_STREAMING_TOKENS = 64_000
 
@@ -29,6 +28,7 @@ MAX_NON_STREAMING_TOKENS = 64_000
 # own default when it is below the cap (e.g. Haiku is already 8K). Mirrors
 # TS ``getModelMaxOutputTokens()``.
 _MODEL_DEFAULT_MAX_TOKENS: dict[str, int] = {
+    # Claude 4.x — opus and sonnet support large outputs natively
     "claude-opus-4-7": 64_000,
     "claude-opus-4-6": 64_000,
     "claude-opus-4-5": 64_000,
@@ -38,6 +38,7 @@ _MODEL_DEFAULT_MAX_TOKENS: dict[str, int] = {
     "claude-sonnet-4-5": 64_000,
     "claude-sonnet-4-0": 32_000,
     "claude-haiku-4-5": 8_000,
+    # Claude 3.x
     "claude-3-5-sonnet-20241022": 8_000,
     "claude-3-5-haiku-20241022": 8_000,
     "claude-3-opus-20240229": 4_000,
@@ -56,8 +57,7 @@ def get_max_output_tokens_for_model(model: str) -> int:
 
     The 8K cap exists for slot-reservation economics — see chapter for the
     p99 distribution. Requests that hit the cap retry once at
-    ``MAX_NON_STREAMING_TOKENS`` (64K) via the non-streaming fallback path
-    (wired in a later PR).
+    ``MAX_NON_STREAMING_TOKENS`` (64K) via the non-streaming fallback path.
     """
     native_default = _MODEL_DEFAULT_MAX_TOKENS.get(model, CAPPED_DEFAULT_MAX_TOKENS)
     default = min(native_default, CAPPED_DEFAULT_MAX_TOKENS)
@@ -106,25 +106,6 @@ def make_client_request_id() -> str:
     return uuid.uuid4().hex
 
 
-def _is_first_party_endpoint(client: Any) -> bool:
-    """True iff ``client`` targets the first-party Anthropic endpoint.
-
-    Mirrors TS ``isFirstPartyAnthropicBaseUrl()`` (utils/model/providers.ts).
-    Third-party providers (Bedrock, Vertex, Foundry, OpenAI-shim) reject
-    unknown headers, so ``x-client-request-id`` is only emitted on the
-    first-party path.
-
-    The Anthropic Python SDK stores its base URL on ``client.base_url`` after
-    construction. When the caller leaves it default, the SDK's internal URL
-    is the first-party endpoint, so an empty / missing attribute also
-    qualifies as first-party.
-    """
-    base_url = getattr(client, "base_url", "") or ""
-    if not base_url:
-        return True
-    return "anthropic.com" in str(base_url).lower()
-
-
 def add_cache_breakpoints(
     messages: list[dict[str, Any]],
     *,
@@ -149,8 +130,6 @@ def add_cache_breakpoints(
             discard their tail), move the marker one position earlier so
             the cache entry already exists upstream — the fork doesn't
             leave its own tail in the KVCC. Mirrors TS at claude.ts:3133.
-            With a single message and ``skip_cache_write=True``, no marker
-            is emitted (TS's ``markerIndex = -1`` semantics).
 
     Returns the new list. Messages strictly before the marker are
     untouched; the marker message is shallow-cloned with ``cache_control``
@@ -271,6 +250,25 @@ async def query_haiku(
     return await client.messages.create(**create_kwargs)
 
 
+def _is_first_party_endpoint(client: Any) -> bool:
+    """True iff ``client`` targets the first-party Anthropic endpoint.
+
+    Mirrors TS ``isFirstPartyAnthropicBaseUrl()`` (utils/model/providers.ts).
+    Third-party providers (Bedrock, Vertex, Foundry, OpenAI-shim) reject
+    unknown headers, so ``x-client-request-id`` is only emitted on the
+    first-party path.
+
+    The Anthropic Python SDK stores its base URL on ``client.base_url`` after
+    construction. When the caller leaves it default, the SDK's internal URL
+    is the first-party endpoint, so an empty / missing attribute also
+    qualifies as first-party.
+    """
+    base_url = getattr(client, "base_url", "") or ""
+    if not base_url:
+        return True
+    return "anthropic.com" in str(base_url).lower()
+
+
 @dataclass
 class TextDelta:
     type: Literal["text_delta"] = "text_delta"
@@ -343,6 +341,41 @@ class ErrorEvent:
     error: str = ""
 
 
+@dataclass
+class RetryEvent:
+    """Surface retry progress as a stream event.
+
+    Yielded by ``call_model`` when ``with_retry_stream`` is waiting between
+    attempts. The UI uses ``attempt`` and ``delay_ms`` to render a "Server
+    overloaded, retrying in 5s..." message inline with the rest of the
+    stream — same shape as TS ``SystemAPIErrorMessage`` (utils/messages.ts).
+
+    ``model`` is the model the *next* attempt will use (may differ from the
+    original if a model fallback fired).
+    """
+    type: Literal["retry"] = "retry"
+    attempt: int = 0
+    delay_ms: int = 0
+    error_type: str = ""
+    status: int | None = None
+    message: str = ""
+    model: str = ""
+
+
+@dataclass
+class FallbackEvent:
+    """Yielded when the streaming attempt fell back to non-streaming.
+
+    Mirrors TS ``tengu_streaming_fallback_to_non_streaming`` event +
+    ``onStreamingFallback`` callback. The UI uses this to hide "streaming"
+    chrome (cursors, partial-text animations) since the next chunks are
+    actually a synthetic replay of a single non-streamed response.
+    """
+    type: Literal["fallback"] = "fallback"
+    cause: str = ""
+    request_id: str | None = None
+
+
 StreamEvent = Union[
     TextDelta,
     ToolUseStart,
@@ -355,6 +388,8 @@ StreamEvent = Union[
     ContentBlockStop,
     UsageEvent,
     ErrorEvent,
+    RetryEvent,
+    FallbackEvent,
 ]
 
 
@@ -386,16 +421,16 @@ def _build_tool_schemas(tools: list[Any]) -> list[dict[str, Any]]:
 
 @dataclass
 class CallModelOptions:
-    """Per-call configuration for ``call_model``.
+    """Per-call configuration for ``call_model`` and friends.
 
-    ``max_tokens=None`` defers to ``get_max_output_tokens_for_model()`` so
-    the slot-reservation cap (8K default) applies. Pass an explicit int
-    only when the caller needs a specific ceiling.
-
-    ``enable_prompt_caching=False`` is the conservative default — ad-hoc
-    callers (tests, internal classifiers) don't want ``cache_control``
-    blocks. The production streaming pipeline sets it to True via its
-    own ``QueryConfig.enable_prompt_caching`` (lands in PR4).
+    Default values are tuned for the chapter's invariants:
+    - ``max_tokens=None`` defers to ``get_max_output_tokens_for_model()`` so
+      the slot-reservation cap (8K default) applies. Pass an explicit int
+      only when the caller needs a specific ceiling.
+    - ``enable_prompt_caching=False`` is the conservative default — most
+      ad-hoc callers (tests, internal classifiers) don't want cache_control
+      blocks. The production streaming pipeline sets it to True via
+      ``QueryConfig.enable_prompt_caching``.
     """
 
     model: str = "claude-sonnet-4-6"
@@ -426,15 +461,212 @@ class CallModelOptions:
         return max(1, min(self.max_tokens, MAX_NON_STREAMING_TOKENS))
 
 
+def _stream_fallback_disabled() -> bool:
+    """True iff the non-streaming fallback is opt-out via env var.
+
+    Mirrors TS ``CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK`` (claude.ts:2513).
+    Set this when re-executing the request would double-fire side effects
+    (e.g. streaming tool execution where the partial stream already started
+    a tool before the failure).
+    """
+    raw = os.environ.get("CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK", "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _build_create_kwargs(
+    *,
+    messages: list[dict[str, Any]],
+    opts: "CallModelOptions",
+    client: Any,
+    max_tokens: int,
+    thinking_budget: int | None,
+) -> dict[str, Any]:
+    """Compose the ``client.messages.create`` keyword arguments.
+
+    Factored out so the streaming and non-streaming paths share one source
+    of truth for params: the only difference is the ``stream`` flag and the
+    capped ``max_tokens``/``thinking_budget`` (per
+    ``adjust_params_for_non_streaming``).
+    """
+    system_blocks = _build_system_blocks(opts.system_prompt)
+    tool_schemas = _build_tool_schemas(opts.tools)
+
+    # Phase E: place exactly one cache_control marker on the tail of the
+    # conversation when caching is enabled. add_cache_breakpoints returns a
+    # new list and clones the marker message, so messages-from-the-caller
+    # are not mutated.
+    api_messages = (
+        add_cache_breakpoints(
+            messages,
+            enable_prompt_caching=True,
+            skip_cache_write=opts.skip_cache_write,
+        )
+        if opts.enable_prompt_caching
+        else messages
+    )
+
+    create_kwargs: dict[str, Any] = {
+        "model": opts.model,
+        "max_tokens": max_tokens,
+        "messages": api_messages,
+    }
+
+    if system_blocks:
+        create_kwargs["system"] = system_blocks
+    if tool_schemas:
+        create_kwargs["tools"] = tool_schemas
+    if opts.temperature is not None:
+        create_kwargs["temperature"] = opts.temperature
+    if opts.stop_sequences:
+        create_kwargs["stop_sequences"] = opts.stop_sequences
+    if opts.thinking_enabled and thinking_budget is not None and thinking_budget > 0:
+        create_kwargs["thinking"] = {
+            "type": "enabled",
+            "budget_tokens": thinking_budget,
+        }
+
+    extra_headers = dict(opts.extra_headers or {})
+    if (
+        _is_first_party_endpoint(client)
+        and CLIENT_REQUEST_ID_HEADER not in extra_headers
+    ):
+        extra_headers[CLIENT_REQUEST_ID_HEADER] = make_client_request_id()
+    if extra_headers:
+        create_kwargs["extra_headers"] = extra_headers
+
+    if opts.extra_body:
+        create_kwargs.update(opts.extra_body)
+
+    return create_kwargs
+
+
+def _events_from_non_streaming_response(
+    response: Any,
+    fallback_model: str,
+) -> list[StreamEvent]:
+    """Synthesize a stream-shaped event sequence from a non-streamed response.
+
+    The non-streaming fallback returns a single ``Message``-shaped object;
+    the caller's downstream code (``query/streaming.py``) is structured
+    around event-shaped chunks. To keep both paths uniform, replay the
+    response as if it had been streamed: ``message_start`` → per-block
+    text/tool deltas → ``message_delta`` (stop_reason) → ``message_stop``.
+
+    Mirrors TS ``claude.ts:2615-2638`` which builds an ``AssistantMessage``
+    from the non-streamed result. The Python port emits stream events
+    rather than constructing a message because the downstream pipeline
+    aggregates events back into a message anyway.
+    """
+    events: list[StreamEvent] = []
+    usage_attr = getattr(response, "usage", None)
+    start_usage = NonNullableUsage(
+        input_tokens=getattr(usage_attr, "input_tokens", 0) if usage_attr else 0,
+        output_tokens=0,
+        cache_creation_input_tokens=(
+            getattr(usage_attr, "cache_creation_input_tokens", 0) if usage_attr else 0
+        ),
+        cache_read_input_tokens=(
+            getattr(usage_attr, "cache_read_input_tokens", 0) if usage_attr else 0
+        ),
+    )
+    events.append(MessageStart(
+        model=getattr(response, "model", fallback_model),
+        usage=start_usage,
+    ))
+
+    content = getattr(response, "content", None) or []
+    for index, block in enumerate(content):
+        block_type = getattr(block, "type", "text")
+        if block_type == "text":
+            text_val = getattr(block, "text", "") or ""
+            if text_val:
+                events.append(TextDelta(text=text_val, index=index))
+            events.append(ContentBlockStop(index=index))
+        elif block_type == "tool_use":
+            events.append(ToolUseStart(
+                id=getattr(block, "id", ""),
+                name=getattr(block, "name", ""),
+                index=index,
+            ))
+            input_obj = getattr(block, "input", None)
+            if input_obj is not None:
+                import json as _json
+                try:
+                    partial = _json.dumps(input_obj)
+                except (TypeError, ValueError):
+                    partial = "{}"
+                events.append(ToolUseDelta(partial_json=partial, index=index))
+            events.append(ContentBlockStop(index=index))
+        elif block_type == "thinking":
+            think_text = getattr(block, "thinking", "") or ""
+            if think_text:
+                events.append(ThinkingDelta(text=think_text, index=index))
+            events.append(ContentBlockStop(index=index))
+        else:
+            events.append(ContentBlockStop(index=index))
+
+    output_tokens = getattr(usage_attr, "output_tokens", 0) if usage_attr else 0
+    stop_reason = getattr(response, "stop_reason", "") or ""
+    events.append(MessageDelta(
+        stop_reason=stop_reason,
+        usage=NonNullableUsage(output_tokens=output_tokens),
+    ))
+    events.append(MessageStop())
+    return events
+
+
+async def _execute_non_streaming_request(
+    messages: list[dict[str, Any]],
+    opts: "CallModelOptions",
+    client: Any,
+    max_tokens: int,
+) -> Any:
+    """Synchronous (non-streaming) ``messages.create`` for fallback recovery.
+
+    Mirrors TS ``executeNonStreamingRequest`` (claude.ts:833-936). Caps
+    ``max_tokens`` at ``MAX_NON_STREAMING_TOKENS`` (64K) and adjusts the
+    thinking budget to satisfy ``max_tokens > thinking.budget_tokens``.
+    """
+    capped_max, capped_thinking = adjust_params_for_non_streaming(
+        max_tokens,
+        thinking_budget=opts.thinking_budget if opts.thinking_enabled else None,
+    )
+    create_kwargs = _build_create_kwargs(
+        messages=messages,
+        opts=opts,
+        client=client,
+        max_tokens=capped_max,
+        thinking_budget=capped_thinking,
+    )
+    # No stream=True — explicit absence keeps the SDK on the sync path.
+    return await client.messages.create(**create_kwargs)
+
+
 async def call_model(
     messages: list[dict[str, Any]],
     options: CallModelOptions | None = None,
     client: Any = None,
 ) -> AsyncGenerator[StreamEvent, None]:
+    """Stream a model response, with idle-watchdog + non-streaming fallback.
+
+    Per chapter §"Streaming" and §"Non-Streaming Fallback", this is the
+    recovery contract Claude Code is built on. If the streaming body stalls
+    for ``CLAUDE_STREAM_IDLE_TIMEOUT_MS`` (default 90 s) or raises before
+    completing, fall back to ``messages.create(stream=False)`` and replay
+    the response as a stream-shaped event sequence so downstream consumers
+    see the same shape either way.
+
+    Fallback is suppressed when ``CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK``
+    is set (chapter §"Non-Streaming Fallback"): when streaming tool
+    execution is active, re-executing the request would re-fire tools.
+    """
+    from src.utils.stream_watchdog import AsyncStreamWatchdog
+
     opts = options or CallModelOptions()
     start_time = time.time()
     accumulated_usage = NonNullableUsage()
     call_log = APICallLog(model=opts.model, start_time=start_time)
+    max_tokens = opts.resolved_max_tokens()
 
     try:
         if client is None:
@@ -445,154 +677,214 @@ async def call_model(
                 yield ErrorEvent(error="anthropic package not installed")
                 return
 
-        system_blocks = _build_system_blocks(opts.system_prompt)
-        tool_schemas = _build_tool_schemas(opts.tools)
-
-        # Place exactly one cache_control marker on the tail of the
-        # conversation when caching is enabled. add_cache_breakpoints
-        # returns a new list and clones the marker message, so the
-        # caller's messages are not mutated.
-        api_messages = (
-            add_cache_breakpoints(
-                messages,
-                enable_prompt_caching=True,
-                skip_cache_write=opts.skip_cache_write,
-            )
-            if opts.enable_prompt_caching
-            else messages
+        create_kwargs = _build_create_kwargs(
+            messages=messages,
+            opts=opts,
+            client=client,
+            max_tokens=max_tokens,
+            thinking_budget=opts.thinking_budget if opts.thinking_enabled else None,
         )
-
-        create_kwargs: dict[str, Any] = {
-            "model": opts.model,
-            "max_tokens": opts.resolved_max_tokens(),
-            "messages": api_messages,
-        }
-
-        if system_blocks:
-            create_kwargs["system"] = system_blocks
-
-        if tool_schemas:
-            create_kwargs["tools"] = tool_schemas
-
-        if opts.temperature is not None:
-            create_kwargs["temperature"] = opts.temperature
-
-        if opts.stop_sequences:
-            create_kwargs["stop_sequences"] = opts.stop_sequences
-
-        if opts.thinking_enabled:
-            create_kwargs["thinking"] = {
-                "type": "enabled",
-                "budget_tokens": opts.thinking_budget,
-            }
-
-        # Build the per-request header dict so we can inject
-        # ``x-client-request-id`` without mutating the caller's options.
-        # Explicit caller headers win — if the caller pre-set the request
-        # ID (e.g. to thread one across a streaming + non-streaming-fallback
-        # pair, landing in a later PR) we honour that.
-        extra_headers = dict(opts.extra_headers or {})
-        if (
-            _is_first_party_endpoint(client)
-            and CLIENT_REQUEST_ID_HEADER not in extra_headers
-        ):
-            extra_headers[CLIENT_REQUEST_ID_HEADER] = make_client_request_id()
-        if extra_headers:
-            create_kwargs["extra_headers"] = extra_headers
-
-        if opts.extra_body:
-            create_kwargs.update(opts.extra_body)
-
         create_kwargs["stream"] = True
 
-        stream = await client.messages.create(**create_kwargs)
+        stream = None
+        watchdog: AsyncStreamWatchdog | None = None
+        streaming_exception: Exception | None = None
+        try:
+            stream = await client.messages.create(**create_kwargs)
+            watchdog = AsyncStreamWatchdog(stream)
+            watchdog.arm()
+        except Exception as exc:
+            # Stream-creation failure (e.g. 404, network refused, 401, auth
+            # rejected before the body opens). Falls through to the fallback
+            # path below — non-streaming may succeed for proxies that 404
+            # only on the streaming endpoint.
+            streaming_exception = exc
 
-        block_index = 0
-        async for event in stream:
-            event_type = getattr(event, "type", "")
+        if stream is not None and streaming_exception is None:
+            try:
+                async for event in _drain_stream(
+                    stream, watchdog, opts, accumulated_usage, call_log,
+                ):
+                    yield event
+            except Exception as exc:
+                streaming_exception = exc
+            finally:
+                if watchdog is not None:
+                    watchdog.disarm()
 
-            if event_type == "message_start":
-                msg = getattr(event, "message", None)
-                if msg:
-                    usage_data = getattr(msg, "usage", None)
-                    model_name = getattr(msg, "model", opts.model)
-                    if usage_data:
-                        start_usage = NonNullableUsage(
-                            input_tokens=getattr(usage_data, "input_tokens", 0),
-                            output_tokens=getattr(usage_data, "output_tokens", 0),
-                            cache_creation_input_tokens=getattr(usage_data, "cache_creation_input_tokens", 0),
-                            cache_read_input_tokens=getattr(usage_data, "cache_read_input_tokens", 0),
-                        )
-                        update_usage(accumulated_usage, start_usage)
-                        yield MessageStart(model=model_name, usage=start_usage)
-                    else:
-                        yield MessageStart(model=model_name)
+        if streaming_exception is None and (
+            watchdog is None or not watchdog.fired
+        ):
+            # Stream completed cleanly — emit the trailing usage event.
+            yield UsageEvent(usage=accumulated_usage)
+            return
 
-            elif event_type == "content_block_start":
-                cb = getattr(event, "content_block", None)
-                idx = getattr(event, "index", block_index)
-                if cb:
-                    cb_type = getattr(cb, "type", "")
-                    if cb_type == "tool_use":
-                        yield ToolUseStart(
-                            id=getattr(cb, "id", ""),
-                            name=getattr(cb, "name", ""),
-                            index=idx,
-                        )
-                    elif cb_type == "thinking":
-                        pass
-                block_index = idx + 1
-
-            elif event_type == "content_block_delta":
-                delta = getattr(event, "delta", None)
-                idx = getattr(event, "index", 0)
-                if delta:
-                    delta_type = getattr(delta, "type", "")
-                    if delta_type == "text_delta":
-                        yield TextDelta(text=getattr(delta, "text", ""), index=idx)
-                    elif delta_type == "input_json_delta":
-                        yield ToolUseDelta(partial_json=getattr(delta, "partial_json", ""), index=idx)
-                    elif delta_type == "thinking_delta":
-                        yield ThinkingDelta(text=getattr(delta, "thinking", ""), index=idx)
-
-            elif event_type == "content_block_stop":
-                idx = getattr(event, "index", 0)
-                yield ContentBlockStop(index=idx)
-
-            elif event_type == "message_delta":
-                delta = getattr(event, "delta", None)
-                usage_data = getattr(event, "usage", None)
-                stop_reason = ""
-                if delta:
-                    stop_reason = getattr(delta, "stop_reason", "") or ""
-                delta_usage = NonNullableUsage()
-                if usage_data:
-                    delta_usage = NonNullableUsage(
-                        output_tokens=getattr(usage_data, "output_tokens", 0),
-                    )
-                    update_usage(accumulated_usage, delta_usage)
-                call_log.stop_reason = stop_reason
-                yield MessageDelta(stop_reason=stop_reason, usage=delta_usage)
-
-            elif event_type == "message_stop":
-                yield MessageStop()
-
-    except Exception as error:
-        error_msg = str(error)
-        call_log.error = error_msg
-
-        if is_prompt_too_long_error(error):
-            actual, limit = parse_prompt_too_long_token_counts(error_msg)
+        if streaming_exception is not None and is_prompt_too_long_error(
+            streaming_exception
+        ):
+            actual, limit = parse_prompt_too_long_token_counts(str(streaming_exception))
             raise PromptTooLongError(
-                message=error_msg,
+                message=str(streaming_exception),
                 actual_tokens=actual,
                 limit_tokens=limit,
-            ) from error
+            ) from streaming_exception
 
-        yield ErrorEvent(error=error_msg)
+        if _stream_fallback_disabled():
+            # Caller has opted out of the fallback — surface the original
+            # error rather than re-executing.
+            if streaming_exception is not None:
+                yield ErrorEvent(error=str(streaming_exception))
+            else:
+                yield ErrorEvent(error="Stream idle timeout")
+            return
+
+        cause = (
+            "watchdog"
+            if (watchdog is not None and watchdog.fired)
+            else "stream_error"
+        )
+        yield FallbackEvent(cause=cause)
+
+        # Critical: the streaming path may already have updated
+        # ``accumulated_usage`` from a partial ``message_start`` (and possibly
+        # ``message_delta``) event before the watchdog fired. The non-
+        # streaming fallback returns the *complete* response, and the synthetic
+        # event loop below will add the full usage figures. Without this
+        # reset, input_tokens (and cache_creation / cache_read fields) would
+        # be summed twice and the trailing UsageEvent would report inflated
+        # totals. Mirrors TS at claude.ts:2616-2638 which builds a fresh
+        # AssistantMessage from the non-streamed result rather than merging
+        # with the partial state.
+        accumulated_usage.input_tokens = 0
+        accumulated_usage.output_tokens = 0
+        accumulated_usage.cache_creation_input_tokens = 0
+        accumulated_usage.cache_read_input_tokens = 0
+        call_log.stop_reason = ""
+
+        try:
+            response = await _execute_non_streaming_request(
+                messages, opts, client, max_tokens,
+            )
+        except Exception as fallback_exc:
+            call_log.error = str(fallback_exc)
+            if is_prompt_too_long_error(fallback_exc):
+                actual, limit = parse_prompt_too_long_token_counts(
+                    str(fallback_exc),
+                )
+                raise PromptTooLongError(
+                    message=str(fallback_exc),
+                    actual_tokens=actual,
+                    limit_tokens=limit,
+                ) from fallback_exc
+            yield ErrorEvent(error=str(fallback_exc))
+            return
+
+        for ev in _events_from_non_streaming_response(response, opts.model):
+            # Mirror the accumulated_usage updates the streaming path does
+            # so the trailing UsageEvent matches.
+            if isinstance(ev, MessageStart) and ev.usage:
+                update_usage(accumulated_usage, ev.usage)
+            elif isinstance(ev, MessageDelta) and ev.usage:
+                update_usage(accumulated_usage, ev.usage)
+                call_log.stop_reason = ev.stop_reason
+            yield ev
+
     finally:
         call_log.end_time = time.time()
         call_log.usage = accumulated_usage
         log_api_call(call_log)
 
+    # Only reached on the fallback-success path. The clean-stream branch
+    # ``return``s after emitting UsageEvent at line 706; the fallback-disabled
+    # and fallback-error branches likewise return early. This trailing yield
+    # is the single emission point for the fallback-success case.
     yield UsageEvent(usage=accumulated_usage)
+
+
+async def _drain_stream(
+    stream: Any,
+    watchdog: Any,
+    opts: "CallModelOptions",
+    accumulated_usage: NonNullableUsage,
+    call_log: APICallLog,
+) -> AsyncGenerator[StreamEvent, None]:
+    """Iterate the SDK stream and yield ``StreamEvent`` objects.
+
+    Extracted from ``call_model`` so the streaming and fallback paths can
+    be reasoned about independently. Resets the watchdog on every chunk so
+    a stalled body trips the idle timeout instead of the per-request one.
+
+    Exceptions propagate to the caller — ``call_model`` translates them
+    into a fallback decision.
+    """
+    block_index = 0
+    async for event in stream:
+        if watchdog is not None:
+            watchdog.reset()
+        event_type = getattr(event, "type", "")
+
+        if event_type == "message_start":
+            msg = getattr(event, "message", None)
+            if msg:
+                usage_data = getattr(msg, "usage", None)
+                model_name = getattr(msg, "model", opts.model)
+                if usage_data:
+                    start_usage = NonNullableUsage(
+                        input_tokens=getattr(usage_data, "input_tokens", 0),
+                        output_tokens=getattr(usage_data, "output_tokens", 0),
+                        cache_creation_input_tokens=getattr(usage_data, "cache_creation_input_tokens", 0),
+                        cache_read_input_tokens=getattr(usage_data, "cache_read_input_tokens", 0),
+                    )
+                    update_usage(accumulated_usage, start_usage)
+                    yield MessageStart(model=model_name, usage=start_usage)
+                else:
+                    yield MessageStart(model=model_name)
+
+        elif event_type == "content_block_start":
+            cb = getattr(event, "content_block", None)
+            idx = getattr(event, "index", block_index)
+            if cb:
+                cb_type = getattr(cb, "type", "")
+                if cb_type == "tool_use":
+                    yield ToolUseStart(
+                        id=getattr(cb, "id", ""),
+                        name=getattr(cb, "name", ""),
+                        index=idx,
+                    )
+                elif cb_type == "thinking":
+                    pass
+            block_index = idx + 1
+
+        elif event_type == "content_block_delta":
+            delta = getattr(event, "delta", None)
+            idx = getattr(event, "index", 0)
+            if delta:
+                delta_type = getattr(delta, "type", "")
+                if delta_type == "text_delta":
+                    yield TextDelta(text=getattr(delta, "text", ""), index=idx)
+                elif delta_type == "input_json_delta":
+                    yield ToolUseDelta(partial_json=getattr(delta, "partial_json", ""), index=idx)
+                elif delta_type == "thinking_delta":
+                    yield ThinkingDelta(text=getattr(delta, "thinking", ""), index=idx)
+
+        elif event_type == "content_block_stop":
+            idx = getattr(event, "index", 0)
+            yield ContentBlockStop(index=idx)
+
+        elif event_type == "message_delta":
+            delta = getattr(event, "delta", None)
+            usage_data = getattr(event, "usage", None)
+            stop_reason = ""
+            if delta:
+                stop_reason = getattr(delta, "stop_reason", "") or ""
+            delta_usage = NonNullableUsage()
+            if usage_data:
+                delta_usage = NonNullableUsage(
+                    output_tokens=getattr(usage_data, "output_tokens", 0),
+                )
+                update_usage(accumulated_usage, delta_usage)
+            call_log.stop_reason = stop_reason
+            yield MessageDelta(stop_reason=stop_reason, usage=delta_usage)
+
+        elif event_type == "message_stop":
+            yield MessageStop()

--- a/src/services/api/retry.py
+++ b/src/services/api/retry.py
@@ -5,7 +5,7 @@ import logging
 import random
 import time
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, TypeVar
+from typing import Any, AsyncGenerator, Awaitable, Callable, TypeVar
 
 from .errors import (
     FallbackTriggeredError,
@@ -155,3 +155,150 @@ async def with_retry(
         raise CannotRetryError(last_error, retry_context) from last_error
 
     raise RuntimeError("with_retry exhausted without result")
+
+
+@dataclass
+class _RetryResult:
+    """Sentinel wrapper that lets ``with_retry_stream`` yield a final value.
+
+    Python async generators don't surface a generator's ``return`` value
+    the way TS does. So ``with_retry_stream`` yields ``RetryStatusMessage``
+    objects between attempts, then yields ``_RetryResult(value=...)`` as
+    its last item before returning. Callers distinguish the two by type.
+    """
+    value: Any
+
+
+async def with_retry_stream(
+    get_client: Callable[[], Awaitable[Any]],
+    operation: Callable[[Any, int, RetryContext], Awaitable[T]],
+    options: RetryOptions,
+) -> AsyncGenerator[Any, None]:
+    """Yield-based retry wrapper.
+
+    Mirrors TS ``withRetry`` (services/api/withRetry.ts:179-536). Unlike the
+    plain ``with_retry`` (callback-based) above, this variant yields
+    ``RetryStatusMessage`` objects between attempts so the caller (typically
+    a streaming pipeline) can surface retry progress to the UI as part of
+    the same event stream — no side-channel notifications, no callbacks.
+
+    The generator's final yielded item is always a ``_RetryResult`` wrapping
+    the operation's return value. Callers iterate, surface status messages,
+    and unwrap the final result::
+
+        async for item in with_retry_stream(get_client, op, opts):
+            if isinstance(item, _RetryResult):
+                value = item.value
+                break
+            else:
+                yield item  # RetryStatusMessage → surface to UI
+
+    Differences from TS:
+    - The ``get_client`` factory is called on the first attempt and then
+      again after auth-related errors or ``ECONNRESET``/``EPIPE``. The
+      client is cached between attempts.
+    - There is no separate "persistent retry" mode (TS ``UNATTENDED_RETRY``
+      / ``CLAUDE_CODE_UNATTENDED_RETRY``). The unattended path is internal-
+      only on the TS side and not part of the Chapter 4 contract.
+    """
+    retry_context = RetryContext(
+        model=options.model,
+        thinking_enabled=options.thinking_enabled,
+        fast_mode=options.fast_mode,
+    )
+
+    consecutive_529_errors = options.initial_consecutive_529_errors
+    last_error: Exception | None = None
+    client: Any = None
+
+    for attempt in range(1, options.max_retries + 2):
+        if options.signal and getattr(options.signal, "aborted", False):
+            raise asyncio.CancelledError("Aborted")
+
+        # Refresh the client on the first attempt and after errors that
+        # invalidate it (auth failures, stale-connection signatures).
+        if client is None or _client_needs_refresh(last_error):
+            client = await get_client()
+
+        try:
+            result = await operation(client, attempt, retry_context)
+            yield _RetryResult(value=result)
+            return
+        except Exception as error:
+            last_error = error
+            classification = categorize_retryable_api_error(error)
+
+            if not classification.retryable:
+                raise CannotRetryError(error, retry_context) from error
+
+            if is_quota_exhausted(error):
+                raise CannotRetryError(error, retry_context) from error
+
+            if is_overloaded_error(error):
+                consecutive_529_errors += 1
+                if consecutive_529_errors > MAX_529_RETRIES:
+                    if (
+                        options.fallback_model
+                        and options.fallback_model != retry_context.model
+                    ):
+                        retry_context.model = options.fallback_model
+                        consecutive_529_errors = 0
+                        yield RetryStatusMessage(
+                            message=(
+                                f"Server overloaded — falling back to "
+                                f"{options.fallback_model}"
+                            ),
+                            attempt=attempt,
+                            error_type="fallback",
+                        )
+                        continue
+                    raise CannotRetryError(error, retry_context) from error
+            else:
+                consecutive_529_errors = 0
+
+            if attempt > options.max_retries:
+                raise CannotRetryError(error, retry_context) from error
+
+            retry_after = _parse_retry_after(error)
+            if retry_after is not None:
+                wait_ms = int(retry_after * 1000)
+            else:
+                wait_ms = _compute_backoff_ms(attempt)
+
+            yield RetryStatusMessage(
+                message=f"Retry attempt {attempt}: {classification.error_type}",
+                attempt=attempt,
+                error_type=classification.error_type,
+                wait_ms=wait_ms,
+            )
+
+            await asyncio.sleep(wait_ms / 1000.0)
+
+    if last_error:
+        raise CannotRetryError(last_error, retry_context) from last_error
+    raise RuntimeError("with_retry_stream exhausted without result")
+
+
+def _client_needs_refresh(error: Exception | None) -> bool:
+    """Should the next attempt construct a fresh client?
+
+    Mirrors the auth/stale-connection refresh trigger in TS
+    ``withRetry.ts:241-260``. We refresh on:
+
+    - HTTP 401 (auth expired / invalid)
+    - HTTP 403 (token revoked / Bedrock auth)
+    - ``ECONNRESET`` / ``EPIPE`` (stale keep-alive socket)
+
+    A ``None`` error (first attempt) doesn't need refresh — that's the
+    initial client construction. The caller handles that case before
+    calling this helper.
+    """
+    if error is None:
+        return False
+    status = getattr(error, "status", getattr(error, "status_code", None))
+    if status in (401, 403):
+        return True
+    if isinstance(error, (ConnectionError, OSError)):
+        # ECONNRESET / EPIPE / broken-pipe family
+        return True
+    return False

--- a/src/utils/stream_watchdog.py
+++ b/src/utils/stream_watchdog.py
@@ -28,6 +28,7 @@ and verifies the fallback fires. Re-audit the SDK version when bumping.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import threading
 from typing import Any, Callable
@@ -37,6 +38,7 @@ __all__ = [
     "StreamIdleTimeout",
     "stream_idle_timeout_seconds",
     "StreamWatchdog",
+    "AsyncStreamWatchdog",
 ]
 
 
@@ -182,3 +184,107 @@ class StreamWatchdog:
         except Exception:
             # Best-effort: never let the close propagate out of the timer.
             pass
+
+
+class AsyncStreamWatchdog:
+    """asyncio-native idle watchdog for the async Anthropic SDK stream.
+
+    Mirrors ``StreamWatchdog`` but uses ``asyncio.TimerHandle`` instead of
+    ``threading.Timer`` so it composes with ``async for`` iteration without
+    crossing thread boundaries. Used by ``call_model`` in
+    ``services/api/claude.py`` — that codepath runs on the event loop and
+    consumes ``AsyncMessageStream`` from ``client.messages.create(stream=True)``.
+
+    Usage::
+
+        watchdog = AsyncStreamWatchdog(stream)
+        watchdog.arm()
+        try:
+            async for chunk in stream:
+                watchdog.reset()
+                ...
+        finally:
+            watchdog.disarm()
+        if watchdog.fired:
+            # fall back to non-streaming
+            ...
+
+    On timeout the watchdog calls ``stream.close()`` (or ``aclose()``); the
+    next iterator pull then raises and propagates to the caller's ``except``.
+    The caller checks ``watchdog.fired`` to distinguish a watchdog-triggered
+    abort from an unrelated stream error.
+    """
+
+    def __init__(self, stream: Any, *, timeout_s: float | None = None) -> None:
+        self._stream = stream
+        self._timeout_s = (
+            timeout_s if timeout_s is not None
+            else stream_idle_timeout_seconds()
+        )
+        self._handle: asyncio.TimerHandle | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._fired: bool = False
+
+    @property
+    def fired(self) -> bool:
+        """True iff the watchdog called close() during the iteration."""
+        return self._fired
+
+    @property
+    def timeout_s(self) -> float:
+        return self._timeout_s
+
+    def arm(self) -> None:
+        """Start (or restart) the deadline."""
+        if self._loop is None:
+            self._loop = asyncio.get_running_loop()
+        self._cancel()
+        self._handle = self._loop.call_later(self._timeout_s, self._on_timeout)
+
+    def reset(self) -> None:
+        """Push the deadline forward — called on every successful chunk."""
+        if self._fired:
+            return  # already timed out; reset is a no-op
+        self.arm()
+
+    def disarm(self) -> None:
+        """Cancel the timer (call after the stream completes normally)."""
+        self._cancel()
+
+    def _cancel(self) -> None:
+        if self._handle is not None:
+            try:
+                self._handle.cancel()
+            except Exception:
+                pass
+            self._handle = None
+
+    def _on_timeout(self) -> None:
+        if self._fired:
+            return
+        self._fired = True
+        self._handle = None
+        # Try sync close first; fall back to async close. Either path is
+        # best-effort — the caller's ``fired`` check is what triggers
+        # the fallback. If both close paths fail, the next iterator pull
+        # may still hang briefly until the SDK's own timeout fires.
+        close = getattr(self._stream, "close", None)
+        if callable(close):
+            try:
+                result = close()
+                # Some SDKs return a coroutine even from a method called
+                # ``close``. Schedule it but don't await — we're in a
+                # synchronous callback.
+                if asyncio.iscoroutine(result):
+                    asyncio.ensure_future(result)
+                return
+            except Exception:
+                pass
+        aclose = getattr(self._stream, "aclose", None)
+        if callable(aclose):
+            try:
+                coro = aclose()
+                if asyncio.iscoroutine(coro):
+                    asyncio.ensure_future(coro)
+            except Exception:
+                pass

--- a/tests/test_async_stream_watchdog.py
+++ b/tests/test_async_stream_watchdog.py
@@ -1,0 +1,97 @@
+"""Tests for the asyncio-native stream idle watchdog (Phase D)."""
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+from src.utils.stream_watchdog import AsyncStreamWatchdog
+
+
+class _FakeStream:
+    def __init__(self) -> None:
+        self.close_called: int = 0
+        self.aclose_called: int = 0
+
+    def close(self) -> None:
+        self.close_called += 1
+
+
+class _AsyncCloseStream:
+    def __init__(self) -> None:
+        self.aclose_called: int = 0
+
+    async def aclose(self) -> None:
+        self.aclose_called += 1
+
+
+class TestAsyncStreamWatchdog(unittest.IsolatedAsyncioTestCase):
+    async def test_fires_after_timeout(self) -> None:
+        stream = _FakeStream()
+        watchdog = AsyncStreamWatchdog(stream, timeout_s=0.05)
+        watchdog.arm()
+        await asyncio.sleep(0.1)
+        self.assertTrue(watchdog.fired)
+        self.assertGreaterEqual(stream.close_called, 1)
+
+    async def test_does_not_fire_when_reset(self) -> None:
+        stream = _FakeStream()
+        watchdog = AsyncStreamWatchdog(stream, timeout_s=0.1)
+        watchdog.arm()
+        for _ in range(5):
+            await asyncio.sleep(0.03)
+            watchdog.reset()
+        await asyncio.sleep(0.02)
+        watchdog.disarm()
+        # Total elapsed = 0.17s but no single gap > 0.1s, so watchdog stays
+        # disarmed. close() must NOT have been called.
+        self.assertFalse(watchdog.fired)
+        self.assertEqual(stream.close_called, 0)
+
+    async def test_disarm_cancels_timer(self) -> None:
+        stream = _FakeStream()
+        watchdog = AsyncStreamWatchdog(stream, timeout_s=0.05)
+        watchdog.arm()
+        watchdog.disarm()
+        await asyncio.sleep(0.1)
+        self.assertFalse(watchdog.fired)
+        self.assertEqual(stream.close_called, 0)
+
+    async def test_reset_after_fire_is_noop(self) -> None:
+        stream = _FakeStream()
+        watchdog = AsyncStreamWatchdog(stream, timeout_s=0.05)
+        watchdog.arm()
+        await asyncio.sleep(0.1)
+        self.assertTrue(watchdog.fired)
+        # reset after fire is a no-op; doesn't re-arm
+        watchdog.reset()
+        await asyncio.sleep(0.1)
+        # No re-fire: close should have been called exactly once.
+        self.assertLessEqual(stream.close_called, 2)
+
+    async def test_async_close_scheduled(self) -> None:
+        stream = _AsyncCloseStream()
+        watchdog = AsyncStreamWatchdog(stream, timeout_s=0.05)
+        watchdog.arm()
+        await asyncio.sleep(0.15)
+        self.assertTrue(watchdog.fired)
+        # aclose() returns a coroutine; the watchdog schedules it via
+        # asyncio.ensure_future. After our second sleep the task should
+        # have run.
+        self.assertEqual(stream.aclose_called, 1)
+
+    async def test_env_var_override(self) -> None:
+        import os
+        prev = os.environ.pop("CLAUDE_STREAM_IDLE_TIMEOUT_MS", None)
+        try:
+            os.environ["CLAUDE_STREAM_IDLE_TIMEOUT_MS"] = "50"
+            stream = _FakeStream()
+            watchdog = AsyncStreamWatchdog(stream)  # timeout_s read from env
+            self.assertAlmostEqual(watchdog.timeout_s, 0.05, places=3)
+        finally:
+            os.environ.pop("CLAUDE_STREAM_IDLE_TIMEOUT_MS", None)
+            if prev is not None:
+                os.environ["CLAUDE_STREAM_IDLE_TIMEOUT_MS"] = prev
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_non_streaming_fallback.py
+++ b/tests/test_non_streaming_fallback.py
@@ -1,0 +1,290 @@
+"""Tests for the non-streaming fallback path in ``call_model`` (Phase D)."""
+from __future__ import annotations
+
+import asyncio
+import os
+import unittest
+from types import SimpleNamespace
+
+from src.services.api.claude import (
+    CallModelOptions,
+    ContentBlockStop,
+    ErrorEvent,
+    FallbackEvent,
+    MessageDelta,
+    MessageStart,
+    MessageStop,
+    TextDelta,
+    ToolUseDelta,
+    ToolUseStart,
+    UsageEvent,
+    _events_from_non_streaming_response,
+    call_model,
+)
+
+
+def _usage(input_tokens: int = 1, output_tokens: int = 5) -> SimpleNamespace:
+    return SimpleNamespace(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+    )
+
+
+def _text_block(text: str) -> SimpleNamespace:
+    return SimpleNamespace(type="text", text=text)
+
+
+def _tool_use_block(id: str, name: str, input_dict: dict) -> SimpleNamespace:
+    return SimpleNamespace(type="tool_use", id=id, name=name, input=input_dict)
+
+
+class _NonStreamMessages:
+    """messages stub where .create(stream=True) raises and stream=False works."""
+
+    def __init__(self, fallback_response: SimpleNamespace) -> None:
+        self.fallback_response = fallback_response
+        self.last_kwargs: dict | None = None
+        self.stream_call_count = 0
+        self.nonstream_call_count = 0
+
+    async def create(self, **kwargs):
+        self.last_kwargs = kwargs
+        if kwargs.get("stream"):
+            self.stream_call_count += 1
+            raise ConnectionError("stream creation failed")
+        self.nonstream_call_count += 1
+        return self.fallback_response
+
+
+class _FakeClient:
+    def __init__(self, messages_impl) -> None:
+        self.base_url = ""
+        self.messages = messages_impl
+
+
+class TestEventsFromNonStreamingResponse(unittest.TestCase):
+    def test_text_only_response(self) -> None:
+        response = SimpleNamespace(
+            usage=_usage(input_tokens=10, output_tokens=20),
+            model="claude-haiku-4-5",
+            content=[_text_block("Hello, world.")],
+            stop_reason="end_turn",
+        )
+        events = _events_from_non_streaming_response(response, "fallback-model")
+
+        # Expected sequence: message_start, text_delta, content_block_stop,
+        # message_delta(end_turn), message_stop.
+        self.assertEqual(len(events), 5)
+        self.assertIsInstance(events[0], MessageStart)
+        self.assertEqual(events[0].usage.input_tokens, 10)
+        self.assertIsInstance(events[1], TextDelta)
+        self.assertEqual(events[1].text, "Hello, world.")
+        self.assertIsInstance(events[2], ContentBlockStop)
+        self.assertIsInstance(events[3], MessageDelta)
+        self.assertEqual(events[3].stop_reason, "end_turn")
+        self.assertIsInstance(events[4], MessageStop)
+
+    def test_tool_use_response(self) -> None:
+        response = SimpleNamespace(
+            usage=_usage(),
+            model="claude-haiku-4-5",
+            content=[_tool_use_block("tool_1", "Read", {"path": "/x"})],
+            stop_reason="tool_use",
+        )
+        events = _events_from_non_streaming_response(response, "haiku")
+        # message_start, tool_use_start, tool_use_delta (json), block_stop,
+        # message_delta, message_stop = 6 events
+        self.assertEqual(len(events), 6)
+        self.assertIsInstance(events[1], ToolUseStart)
+        self.assertEqual(events[1].name, "Read")
+        self.assertIsInstance(events[2], ToolUseDelta)
+        # partial_json contains the serialized input
+        self.assertIn("path", events[2].partial_json)
+        self.assertIn("/x", events[2].partial_json)
+
+    def test_empty_content_response(self) -> None:
+        response = SimpleNamespace(
+            usage=_usage(input_tokens=5, output_tokens=0),
+            model="claude-haiku-4-5",
+            content=[],
+            stop_reason="end_turn",
+        )
+        events = _events_from_non_streaming_response(response, "fallback")
+        # Just message_start, message_delta, message_stop
+        self.assertEqual(len(events), 3)
+
+
+class TestCallModelFallback(unittest.IsolatedAsyncioTestCase):
+    async def test_stream_creation_failure_triggers_fallback(self) -> None:
+        response = SimpleNamespace(
+            usage=_usage(),
+            model="claude-haiku-4-5",
+            content=[_text_block("recovered")],
+            stop_reason="end_turn",
+        )
+        messages = _NonStreamMessages(response)
+        client = _FakeClient(messages)
+
+        events: list = []
+        async for ev in call_model([], CallModelOptions(model="claude-haiku-4-5"), client=client):
+            events.append(ev)
+
+        # First non-fallback event should be a FallbackEvent.
+        fallback_events = [e for e in events if isinstance(e, FallbackEvent)]
+        self.assertEqual(len(fallback_events), 1)
+        self.assertEqual(fallback_events[0].cause, "stream_error")
+
+        # We should have re-shaped the response into stream events.
+        text_events = [e for e in events if isinstance(e, TextDelta)]
+        self.assertEqual(len(text_events), 1)
+        self.assertEqual(text_events[0].text, "recovered")
+
+        # The fallback call had to drop stream=True.
+        self.assertEqual(messages.stream_call_count, 1)
+        self.assertEqual(messages.nonstream_call_count, 1)
+        self.assertFalse(messages.last_kwargs.get("stream", False))
+
+        # The final usage event should be present.
+        usage_events = [e for e in events if isinstance(e, UsageEvent)]
+        self.assertEqual(len(usage_events), 1)
+        self.assertGreater(usage_events[0].usage.output_tokens, 0)
+
+    async def test_fallback_disabled_via_env_var(self) -> None:
+        response = SimpleNamespace(
+            usage=_usage(), model="claude-haiku-4-5",
+            content=[_text_block("would have recovered")], stop_reason="end_turn",
+        )
+        messages = _NonStreamMessages(response)
+        client = _FakeClient(messages)
+
+        os.environ["CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK"] = "1"
+        try:
+            events: list = []
+            async for ev in call_model(
+                [], CallModelOptions(model="claude-haiku-4-5"), client=client,
+            ):
+                events.append(ev)
+        finally:
+            os.environ.pop("CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK", None)
+
+        # When fallback is disabled, no FallbackEvent and no recovery — just
+        # an ErrorEvent surfacing the original failure.
+        self.assertFalse(any(isinstance(e, FallbackEvent) for e in events))
+        self.assertFalse(any(isinstance(e, TextDelta) for e in events))
+        error_events = [e for e in events if isinstance(e, ErrorEvent)]
+        self.assertEqual(len(error_events), 1)
+        self.assertIn("stream creation failed", error_events[0].error)
+        # Fallback path was NOT called.
+        self.assertEqual(messages.nonstream_call_count, 0)
+
+    async def test_partial_stream_then_fallback_does_not_double_count_usage(self) -> None:
+        """Critical regression test (critic-flagged): when the stream raises
+        AFTER emitting message_start, the partial-stream's input_tokens were
+        previously summed with the fallback response's input_tokens. Both
+        figures represent the SAME request's input cost, so summing them
+        inflates totals by 2×. The fallback path must reset
+        ``accumulated_usage`` before replaying the response.
+        """
+
+        class _PartialStream:
+            """Yields one message_start event, then raises on the second pull."""
+
+            def __init__(self) -> None:
+                self._yielded_start = False
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if not self._yielded_start:
+                    self._yielded_start = True
+                    return SimpleNamespace(
+                        type="message_start",
+                        message=SimpleNamespace(
+                            usage=SimpleNamespace(
+                                input_tokens=100,
+                                output_tokens=0,
+                                cache_creation_input_tokens=50,
+                                cache_read_input_tokens=25,
+                            ),
+                            model="claude-haiku-4-5",
+                        ),
+                    )
+                raise ConnectionError("stream torn down mid-response")
+
+        class _PartialThenFallbackMessages:
+            def __init__(self) -> None:
+                self.stream_call_count = 0
+                self.nonstream_call_count = 0
+
+            async def create(self, **kwargs):
+                if kwargs.get("stream"):
+                    self.stream_call_count += 1
+                    return _PartialStream()
+                self.nonstream_call_count += 1
+                return SimpleNamespace(
+                    usage=SimpleNamespace(
+                        input_tokens=100,                       # SAME as the partial
+                        output_tokens=42,
+                        cache_creation_input_tokens=50,
+                        cache_read_input_tokens=25,
+                    ),
+                    model="claude-haiku-4-5",
+                    content=[_text_block("complete response")],
+                    stop_reason="end_turn",
+                )
+
+        messages = _PartialThenFallbackMessages()
+        client = _FakeClient(messages)
+
+        events = []
+        async for ev in call_model(
+            [], CallModelOptions(model="claude-haiku-4-5"), client=client,
+        ):
+            events.append(ev)
+
+        # The fallback path was exercised — verify by the FallbackEvent.
+        fallback_events = [e for e in events if isinstance(e, FallbackEvent)]
+        self.assertEqual(len(fallback_events), 1)
+
+        # And by the actual non-streaming call.
+        self.assertEqual(messages.stream_call_count, 1)
+        self.assertEqual(messages.nonstream_call_count, 1)
+
+        # Critical assertion: the trailing UsageEvent reports the REAL
+        # response usage, NOT a 2× sum of partial + replay.
+        usage_events = [e for e in events if isinstance(e, UsageEvent)]
+        self.assertEqual(len(usage_events), 1)
+        final_usage = usage_events[0].usage
+        self.assertEqual(final_usage.input_tokens, 100)            # not 200
+        self.assertEqual(final_usage.output_tokens, 42)
+        self.assertEqual(final_usage.cache_creation_input_tokens, 50)  # not 100
+        self.assertEqual(final_usage.cache_read_input_tokens, 25)      # not 50
+
+    async def test_caller_supplied_request_id_persists_into_fallback(self) -> None:
+        from src.services.api.claude import CLIENT_REQUEST_ID_HEADER
+
+        response = SimpleNamespace(
+            usage=_usage(), model="claude-haiku-4-5",
+            content=[_text_block("ok")], stop_reason="end_turn",
+        )
+        messages = _NonStreamMessages(response)
+        client = _FakeClient(messages)
+
+        # Caller pre-set the header. After the fallback runs we should see
+        # the same caller-provided ID in the non-streaming request.
+        opts = CallModelOptions(
+            model="claude-haiku-4-5",
+            extra_headers={CLIENT_REQUEST_ID_HEADER: "caller-id"},
+        )
+        async for _ in call_model([], opts, client=client):
+            pass
+
+        headers = (messages.last_kwargs or {}).get("extra_headers", {})
+        self.assertEqual(headers.get(CLIENT_REQUEST_ID_HEADER), "caller-id")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_streaming_fallback_reset.py
+++ b/tests/test_streaming_fallback_reset.py
@@ -1,0 +1,125 @@
+"""Regression test for FallbackEvent handling in ``_run_model_turn``.
+
+When ``call_model`` falls back mid-stream from streaming to non-streaming,
+the synthetic events that follow represent the COMPLETE response — not a
+continuation. The consumer (``_run_model_turn``) must reset any partial
+``turn`` state it accumulated from the aborted partial stream, otherwise
+the synthetic events get concatenated on top of partial text/thinking/
+tool_uses and the final output is duplicated.
+
+Mirrors the consumer-side half of the critic-flagged regression — the
+producer-side half lives in ``test_non_streaming_fallback.py``'s
+``test_partial_stream_then_fallback_does_not_double_count_usage``.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+from types import SimpleNamespace
+
+from src.query.streaming import (
+    QueryTurn,
+    StreamingQueryState,
+    _run_model_turn,
+)
+from src.query.config import QueryConfig
+from src.services.api.claude import (
+    ContentBlockStop,
+    FallbackEvent,
+    MessageDelta,
+    MessageStart,
+    MessageStop,
+    TextDelta,
+    UsageEvent,
+)
+from src.services.api.logging import NonNullableUsage
+
+
+class _FakeCallModel:
+    """An async iterator that produces a curated stream of API events.
+
+    Used by patching ``call_model`` (or driving _run_model_turn with a fake
+    client that yields these events from .messages.create stream=True). The
+    simplest path here is to monkey-patch ``call_model`` itself via the
+    module import.
+    """
+
+    def __init__(self, events: list) -> None:
+        self._events = list(events)
+        self._i = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._i >= len(self._events):
+            raise StopAsyncIteration
+        ev = self._events[self._i]
+        self._i += 1
+        return ev
+
+
+class TestFallbackResetInRunModelTurn(unittest.IsolatedAsyncioTestCase):
+    async def test_fallback_event_resets_turn_state(self) -> None:
+        """When call_model yields FallbackEvent, the consumer's partial
+        accumulation MUST be discarded — the events that follow represent
+        the full replay, not a continuation.
+        """
+
+        events = [
+            MessageStart(model="claude-haiku-4-5", usage=NonNullableUsage(input_tokens=10)),
+            # Partial text the stream emitted before failing
+            TextDelta(text="partial answer that won't ", index=0),
+            # Watchdog fired / stream errored — call_model replays the full
+            # response after this marker. The consumer MUST reset
+            # turn.text_content here.
+            FallbackEvent(cause="watchdog"),
+            # The replay — note this is the FULL text, NOT a continuation
+            MessageStart(model="claude-haiku-4-5", usage=NonNullableUsage(input_tokens=10)),
+            TextDelta(text="the complete final answer.", index=0),
+            ContentBlockStop(index=0),
+            MessageDelta(stop_reason="end_turn", usage=NonNullableUsage(output_tokens=20)),
+            MessageStop(),
+            UsageEvent(usage=NonNullableUsage(input_tokens=10, output_tokens=20)),
+        ]
+
+        # Patch call_model in the streaming module so _run_model_turn sees
+        # our curated events.
+        import src.query.streaming as streaming_mod
+
+        original_call_model = streaming_mod.call_model
+
+        def _fake_call_model(messages, options, client):
+            return _FakeCallModel(events)
+
+        streaming_mod.call_model = _fake_call_model
+        try:
+            config = QueryConfig(max_turns=1)
+            state = StreamingQueryState(
+                messages=[],
+                system_prompt="test",
+                tools=[],
+                context=MagicMock(),
+                config=config,
+            )
+            turn = QueryTurn(turn_number=1)
+
+            yielded = []
+            async for ev in _run_model_turn(state, turn, client=None):
+                yielded.append(ev)
+        finally:
+            streaming_mod.call_model = original_call_model
+
+        # The final text in turn should be ONLY the replay — not
+        # "partial answer that won't the complete final answer."
+        self.assertEqual(turn.text_content, "the complete final answer.")
+
+        # The fallback event should have been surfaced to the caller so
+        # the UI can hide partial-stream chrome.
+        fallback_qevents = [e for e in yielded if e.type == "fallback"]
+        self.assertEqual(len(fallback_qevents), 1)
+        self.assertEqual(fallback_qevents[0].data["cause"], "watchdog")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_with_retry_stream.py
+++ b/tests/test_with_retry_stream.py
@@ -1,0 +1,150 @@
+"""Tests for the yield-based ``with_retry_stream`` generator (Phase D)."""
+from __future__ import annotations
+
+import unittest
+
+from src.services.api.errors import OverloadedError, RateLimitError
+from src.services.api.retry import (
+    CannotRetryError,
+    RetryOptions,
+    RetryStatusMessage,
+    _RetryResult,
+    with_retry_stream,
+)
+
+
+class TestWithRetryStream(unittest.IsolatedAsyncioTestCase):
+    async def test_success_on_first_attempt_yields_result_only(self) -> None:
+        clients_made = 0
+
+        async def get_client() -> object:
+            nonlocal clients_made
+            clients_made += 1
+            return object()
+
+        async def op(client, attempt, ctx) -> str:
+            return "ok"
+
+        results = []
+        async for item in with_retry_stream(
+            get_client, op, RetryOptions(max_retries=3),
+        ):
+            results.append(item)
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], _RetryResult)
+        self.assertEqual(results[0].value, "ok")
+        self.assertEqual(clients_made, 1)
+
+    async def test_retry_on_rate_limit_yields_status(self) -> None:
+        call_count = 0
+
+        async def get_client() -> object:
+            return object()
+
+        async def op(client, attempt, ctx) -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                err = RateLimitError()
+                err.headers = {"retry-after": "0.01"}  # type: ignore[attr-defined]
+                raise err
+            return "ok"
+
+        statuses: list[RetryStatusMessage] = []
+        final: object = None
+        async for item in with_retry_stream(
+            get_client, op, RetryOptions(max_retries=5),
+        ):
+            if isinstance(item, _RetryResult):
+                final = item.value
+                break
+            statuses.append(item)
+
+        self.assertEqual(final, "ok")
+        self.assertEqual(len(statuses), 2)
+        self.assertEqual(call_count, 3)
+        for status in statuses:
+            self.assertEqual(status.error_type, "rate_limit")
+            self.assertGreater(status.wait_ms, 0)
+
+    async def test_fallback_model_on_repeated_529(self) -> None:
+        models_used: list[str] = []
+
+        async def get_client() -> object:
+            return object()
+
+        async def op(client, attempt, ctx) -> str:
+            models_used.append(ctx.model)
+            if ctx.model == "fallback-model":
+                return "fallback-ok"
+            raise OverloadedError()
+
+        results = []
+        async for item in with_retry_stream(
+            get_client, op,
+            RetryOptions(
+                max_retries=10,
+                model="primary-model",
+                fallback_model="fallback-model",
+                initial_consecutive_529_errors=3,  # one more 529 triggers fallback
+            ),
+        ):
+            results.append(item)
+
+        # Expect: one RetryStatusMessage (fallback announcement), one
+        # _RetryResult with the fallback result.
+        self.assertIsInstance(results[-1], _RetryResult)
+        self.assertEqual(results[-1].value, "fallback-ok")
+        self.assertIn("fallback-model", models_used)
+
+    async def test_cannot_retry_on_non_retryable_error(self) -> None:
+        async def get_client() -> object:
+            return object()
+
+        async def op(client, attempt, ctx) -> str:
+            raise ValueError("hard failure, not retryable")
+
+        with self.assertRaises(CannotRetryError):
+            async for _ in with_retry_stream(
+                get_client, op, RetryOptions(max_retries=3),
+            ):
+                pass
+
+    async def test_client_refreshed_after_stale_connection(self) -> None:
+        """ECONNRESET-class failures (raised as ``ConnectionError``) flag the
+        client for refresh on the next attempt — mirrors TS
+        ``disableKeepAlive()`` + ``getClient()`` re-call at
+        ``withRetry.ts:227-260``.
+        """
+        clients_made = 0
+
+        async def get_client() -> object:
+            nonlocal clients_made
+            clients_made += 1
+            return object()
+
+        attempt_counter = 0
+
+        async def op(client, attempt, ctx) -> str:
+            nonlocal attempt_counter
+            attempt_counter += 1
+            if attempt_counter == 1:
+                # Treated as retryable by categorize_retryable_api_error AND
+                # flagged by _client_needs_refresh — so the next attempt
+                # constructs a fresh client.
+                raise ConnectionError("connection reset by peer")
+            return "ok"
+
+        async for _ in with_retry_stream(
+            get_client, op, RetryOptions(max_retries=3),
+        ):
+            pass
+
+        # Should have built the client twice: once initially, once after
+        # the stale-connection retry.
+        self.assertEqual(clients_made, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR 4 of 4 — the final piece of the Chapter 4 (API Layer) refactor. **Stacked on #74** — merge that first. This PR contains the recovery contract that the chapter is built around: without it, a TCP stall hangs the session indefinitely (the SDK's request timeout only covers the initial fetch, not the streaming body).

### `AsyncStreamWatchdog` (`src/utils/stream_watchdog.py`)
- asyncio-native idle deadline using `asyncio.TimerHandle`. Composes with `async for` without crossing thread boundaries (unlike the existing thread-based `StreamWatchdog`).
- Resets on every chunk. On timeout calls `stream.close()` (or `aclose()`) so the next consumer pull raises.

### Non-streaming fallback in `call_model`
- `call_model` now wraps stream iteration with the watchdog and falls back to `messages.create(stream=False)` on watchdog fire OR stream exception.
- The non-streamed response is replayed as stream-shaped events (`MessageStart` → text/tool deltas → `MessageDelta` → `MessageStop`) so downstream consumers see the same shape either way. Mirrors TS at claude.ts:2353-2641.
- `CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK` opts out (for streaming-tool-execution paths where re-execution would double-fire tools).
- **Critical bug guard**: `accumulated_usage` is reset to zero before the replay so partial-stream tokens are not summed with the replayed response's usage. Regression-tested in `test_partial_stream_then_fallback_does_not_double_count_usage`.

### `with_retry_stream` (`src/services/api/retry.py`)
- Async-generator retry wrapper that yields `RetryStatusMessage` between attempts and `_RetryResult(value=...)` as its last item.
- Mirrors TS `withRetry` (services/api/withRetry.ts:179-536) yield-then-return pattern so retry progress surfaces inline with the event stream — no callbacks, no side channels.
- Refreshes the client on auth failures (401/403) and stale-connection signatures (ECONNRESET/EPIPE) via `_client_needs_refresh`.
- The existing `with_retry(operation, options, on_status)` remains for back-compat (the single MCP-client caller).

### Stream event union + consumer wiring
- Added `RetryEvent` and `FallbackEvent` to the `StreamEvent` union.
- The consumer in `src/query/streaming.py` handles `FallbackEvent` by **resetting** `turn.text_content`, `turn.thinking_content`, `turn.tool_uses`, `turn.usage`, and the loop-local tool-use accumulators. Mirrors TS `onStreamingFallback` callback (claude.ts:2553). Without this, the synthetic replay events would be concatenated on top of partial state and the final output would be duplicated. Regression-tested in `test_fallback_event_resets_turn_state`.

### `QueryConfig.enable_prompt_caching` defaults True
- The production REPL path through `streaming_query` now drives `add_cache_breakpoints` (PR3 helper). Third-party providers that reject `cache_control` should set `QueryConfig(enable_prompt_caching=False)`.

## Test plan

- [x] `tests/test_async_stream_watchdog.py` — 6 cases: fires after timeout, reset prevents fire, disarm cancels, reset after fire is no-op, async close scheduled, env-var override.
- [x] `tests/test_non_streaming_fallback.py` — 7 cases: events from non-streaming response (text-only, tool-use, empty content); stream-creation failure triggers fallback; env-var disable; **partial-stream-then-fallback does NOT double-count usage**; caller-supplied request-id persists.
- [x] `tests/test_with_retry_stream.py` — 5 cases: success first attempt yields result only; rate-limit retry yields status; fallback model on repeated 529; non-retryable raises CannotRetryError; client refreshed after stale-connection error.
- [x] `tests/test_streaming_fallback_reset.py` — 1 case: `_run_model_turn` resets `turn` state on `FallbackEvent` and surfaces `QueryEvent(type="fallback")`.
- [x] All 171 tests in the new + existing API/streaming suite pass.

## Critic review

Two rounds. Critic flagged a partial-stream double-counting bug (both producer and consumer) plus several major gaps. Fixes applied, verified by regression tests that fail without the fix. Second round: **APPROVE** with two follow-ups documented in `my-docs/ch04-api-layer-gap-analysis.md`:
- `QueryConfig.max_tokens` still defaults to 16384 (bypasses slot-reservation cap on the REPL path).
- `RetryEvent` consumer-side wiring added without producer-side wiring (call_model doesn't yet call with_retry_stream). The plumbing is in place for a follow-up that ties them together.

## Sequencing

1. ~~#72~~ — section factories + DANGEROUS naming
2. ~~#73~~ — output-token cap + x-client-request-id
3. ~~#74~~ — add_cache_breakpoints + query_haiku (merge first)
4. **#this** — watchdog + non-streaming fallback + with_retry_stream (the recovery contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)