### PR TITLE
feat(ch05/A): typed Terminal + state-field parity foundation

### DIFF
--- a/src/query/query.py
+++ b/src/query/query.py
@@ -25,7 +25,13 @@ from ..utils.abort_controller import AbortController
 from ..providers.base import BaseProvider, ChatResponse
 
 from .config import QueryConfig, build_query_config
-from .transitions import QueryState, Terminal, Transition
+from .transitions import (
+    QueryState,
+    Terminal,
+    TerminalHolder,
+    Transition,
+    set_terminal,
+)
 from ..services.compact.pipeline import (
     CompressionPipeline,
     PipelineConfig,
@@ -576,15 +582,38 @@ def _run_tools_sync(
     return results
 
 
-async def query(params: QueryParams) -> AsyncGenerator[Message | StreamEvent, None]:
+async def query(
+    params: QueryParams,
+    *,
+    terminal_holder: TerminalHolder | None = None,
+) -> AsyncGenerator[Message | StreamEvent, None]:
+    """Canonical agent loop (chapter 5, Phase A foundation).
+
+    The async generator yields messages and stream events to the consumer.
+    The final ``Terminal`` is written to ``terminal_holder.value`` just
+    before the generator returns (Python async generators cannot return
+    values: PEP 525). Callers who care about the terminal pass their own
+    ``TerminalHolder`` and read its ``.value`` after iteration.
+
+    See :func:`run_query` for a convenience helper that consumes the
+    generator and returns ``(messages, terminal)``.
+
+    This PR (Phase A) introduces the typed Terminal infrastructure;
+    recovery integration, stop hooks, token budget, model fallback,
+    and continuation nudge land in subsequent PRs.
+    """
     _diag = os.environ.get("CLAWCODEX_DEBUG", "").lower() in ("1", "true", "yes")
+    holder = terminal_holder or TerminalHolder()
+    # Inner-only flag for the future outer two-layer wrapper (Phase G).
+    # Until that lands, the flag is local; set_terminal still writes it
+    # so every exit site uses the canonical helper.
+    natural_termination: list[bool] = [False]
     state = QueryState(
         messages=list(params.messages),
         tool_use_context=params.tool_use_context,
         max_output_tokens_override=params.max_output_tokens_override,
     )
     config = build_query_config()
-    terminal: Terminal | None = None
 
     while True:
         messages = state.messages
@@ -666,6 +695,7 @@ async def query(params: QueryParams) -> AsyncGenerator[Message | StreamEvent, No
                 yield err_msg
 
             yield _create_assistant_api_error_message(content=error_message)
+            set_terminal(holder, natural_termination, Terminal(reason="model_error", error=e))
             return
 
         if params.abort_controller.signal.aborted:
@@ -676,6 +706,7 @@ async def query(params: QueryParams) -> AsyncGenerator[Message | StreamEvent, No
 
             if params.abort_controller.signal.reason != "interrupt":
                 yield _create_user_interruption_message(tool_use=False)
+            set_terminal(holder, natural_termination, Terminal(reason="aborted_streaming"))
             return
 
         if not needs_follow_up:
@@ -724,8 +755,10 @@ async def query(params: QueryParams) -> AsyncGenerator[Message | StreamEvent, No
                 yield last_message  # type: ignore[arg-type]
 
             if last_message and getattr(last_message, "isApiErrorMessage", False):
+                set_terminal(holder, natural_termination, Terminal(reason="completed"))
                 return
 
+            set_terminal(holder, natural_termination, Terminal(reason="completed"))
             return
 
         for block in tool_use_blocks:
@@ -771,12 +804,18 @@ async def query(params: QueryParams) -> AsyncGenerator[Message | StreamEvent, No
         if params.abort_controller.signal.aborted:
             if params.abort_controller.signal.reason != "interrupt":
                 yield _create_user_interruption_message(tool_use=True)
+            set_terminal(holder, natural_termination, Terminal(reason="aborted_tools"))
             return
 
         next_turn_count = turn_count + 1
 
         if params.max_turns and next_turn_count > params.max_turns:
             yield _create_max_turns_attachment(params.max_turns, next_turn_count)
+            set_terminal(
+                holder,
+                natural_termination,
+                Terminal(reason="max_turns", turn_count=next_turn_count),
+            )
             return
 
         # Chapter-10 / Chunk D / WI-3.3 — pending-messages drain at the
@@ -799,5 +838,38 @@ async def query(params: QueryParams) -> AsyncGenerator[Message | StreamEvent, No
             has_attempted_reactive_compact=False,
             max_output_tokens_override=None,
             stop_hook_active=state.stop_hook_active,
+            # Phase A: reset per-turn counter; carry pending summary forward.
+            continuation_nudge_count=0,
+            pending_tool_use_summary=state.pending_tool_use_summary,
             transition=Transition(reason="next_turn"),
         )
+
+
+async def run_query(
+    params: QueryParams,
+) -> tuple[list[Message | StreamEvent], Terminal]:
+    """Ch5/A.4: Convenience helper for callers that want both the
+    yielded messages and the Terminal in one call.
+
+    Drives the canonical :func:`query` async generator, collects all
+    yielded messages into a list, and returns ``(messages, terminal)``.
+    The terminal's reason discriminates why the loop stopped (10
+    distinct reasons per chapter §"Terminal States").
+
+    Tests and convenience entry points should use this helper.
+    Streaming consumers (REPL, TUI) should keep using ``async for``
+    with their own ``TerminalHolder``.
+    """
+    holder = TerminalHolder()
+    messages: list[Message | StreamEvent] = []
+    async for msg in query(params, terminal_holder=holder):
+        messages.append(msg)
+    if holder.value is None:
+        # Contract violation — the loop returned without setting
+        # the terminal. Fall back to a model_error so callers don't
+        # see ``None`` and crash.
+        holder.value = Terminal(
+            reason="model_error",
+            error=RuntimeError("query() returned without setting Terminal"),
+        )
+    return messages, holder.value

--- a/src/query/transitions.py
+++ b/src/query/transitions.py
@@ -15,6 +15,21 @@ ContinueReason = Literal[
     "collapse_drain_retry",
     "stop_hook_blocking",
     "token_budget_continuation",
+    "continuation_nudge",
+]
+
+
+TerminalReason = Literal[
+    "blocking_limit",
+    "image_error",
+    "model_error",
+    "aborted_streaming",
+    "prompt_too_long",
+    "completed",
+    "stop_hook_prevented",
+    "aborted_tools",
+    "hook_stopped",
+    "max_turns",
 ]
 
 
@@ -27,9 +42,48 @@ class Transition:
 
 @dataclass(frozen=True)
 class Terminal:
-    reason: str
+    reason: TerminalReason
     error: Exception | None = None
     turn_count: int | None = None
+
+
+class TerminalHolder:
+    """Mutable container an async generator appends its Terminal to
+    just before its bare ``return``. Callers read ``.value`` after
+    consuming the generator.
+
+    Required because Python's async generator protocol does not
+    expose the return value of a ``return`` statement, and Python
+    forbids ``return value`` inside ``async def`` generators
+    (SyntaxError on 3.10-3.14; PEP 828 still Draft).
+    """
+
+    __slots__ = ("value",)
+
+    def __init__(self) -> None:
+        self.value: Terminal | None = None
+
+
+def set_terminal(
+    holder: TerminalHolder,
+    flag: list[bool],
+    terminal: Terminal,
+) -> None:
+    """Set holder.value and mark the exit as natural.
+
+    Use at every ``return`` site inside the query loop's inner
+    generator. Call as the last action before ``return``.
+
+    The ``flag`` argument is a single-element list[bool] used as a
+    mutable container that the outer wrapper can inspect after
+    iteration to distinguish natural termination from
+    ``.aclose()`` / exception unwinds. Phase A introduces the helper
+    and the parameter; a future phase wires the outer wrapper that
+    reads the flag — until then ``flag`` is write-only and the
+    parameter is preserved for forward compatibility.
+    """
+    holder.value = terminal
+    flag[0] = True
 
 
 ToolUseContext = ToolContext
@@ -45,4 +99,14 @@ class QueryState:
     max_output_tokens_override: int | None = None
     stop_hook_active: bool | None = None
     turn_count: int = 1
+    # Promise from previous turn's Haiku summary, resolved during current streaming.
+    # Mirrors TS State.pendingToolUseSummary at query.ts:212. Currently unused in
+    # Python (tool-use summary is out-of-scope for ch5) but reserved so callers
+    # can plumb a future Haiku promise through state without a struct change.
+    pending_tool_use_summary: Any | None = None
+    # Count of consecutive continuation nudges within the current turn.
+    # Capped at MAX_CONTINUATION_NUDGES to prevent infinite nudge loops
+    # when the model keeps matching continuation signals without tool calls.
+    # Mirrors TS State.continuationNudgeCount at query.ts:218.
+    continuation_nudge_count: int = 0
     transition: Transition | None = None

--- a/src/reference_data/ts_query_transitions.json
+++ b/src/reference_data/ts_query_transitions.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Query state transitions from TS query.ts",
+  "_comment": "Query state transitions from TS query.ts (chapter 5)",
   "transition_reasons": [
     "next_turn",
     "max_output_tokens_recovery",
@@ -7,7 +7,20 @@
     "reactive_compact_retry",
     "collapse_drain_retry",
     "stop_hook_blocking",
-    "token_budget_continuation"
+    "token_budget_continuation",
+    "continuation_nudge"
+  ],
+  "terminal_reasons": [
+    "blocking_limit",
+    "image_error",
+    "model_error",
+    "aborted_streaming",
+    "prompt_too_long",
+    "completed",
+    "stop_hook_prevented",
+    "aborted_tools",
+    "hook_stopped",
+    "max_turns"
   ],
   "query_state_fields": [
     "messages",
@@ -18,11 +31,14 @@
     "max_output_tokens_override",
     "stop_hook_active",
     "turn_count",
+    "pending_tool_use_summary",
+    "continuation_nudge_count",
     "transition"
   ],
   "recovery_constants": {
     "ESCALATED_MAX_TOKENS": 64000,
-    "MAX_OUTPUT_TOKENS_RECOVERY_LIMIT": 3
+    "MAX_OUTPUT_TOKENS_RECOVERY_LIMIT": 3,
+    "MAX_CONTINUATION_NUDGES": 3
   },
   "query_config_fields": [
     "session_id",

--- a/tests/parity/test_query_state_parity.py
+++ b/tests/parity/test_query_state_parity.py
@@ -16,6 +16,7 @@ from src.query.transitions import (
     ContinueReason,
     QueryState,
     Terminal,
+    TerminalReason,
     Transition,
 )
 from src.query.config import QueryConfig, build_query_config
@@ -94,8 +95,20 @@ class TestTransitionReasonsParity(unittest.TestCase):
             t.reason = "max_output_tokens_recovery"  # type: ignore
 
     def test_terminal_has_reason_field(self) -> None:
-        term = Terminal(reason="end_turn")
-        self.assertEqual(term.reason, "end_turn")
+        term = Terminal(reason="completed")
+        self.assertEqual(term.reason, "completed")
+
+    def test_all_terminal_reasons_match_ts(self) -> None:
+        """The 10 chapter §'Terminal States' reasons must round-trip."""
+        ts_reasons = set(self.snapshot["terminal_reasons"])
+        import typing as _typing
+        py_reasons = set(_typing.get_args(TerminalReason))
+        self.assertEqual(ts_reasons, py_reasons)
+
+    def test_terminal_can_be_created_for_each_reason(self) -> None:
+        for reason in self.snapshot["terminal_reasons"]:
+            t = Terminal(reason=reason)
+            self.assertEqual(t.reason, reason)
 
 
 class TestRecoveryConstantsParity(unittest.TestCase):

--- a/tests/test_query_terminal.py
+++ b/tests/test_query_terminal.py
@@ -1,0 +1,257 @@
+"""Phase A acceptance tests: typed Terminal return values via the
+``run_query()`` helper and the ``TerminalHolder`` protocol.
+
+Verifies the Phase A foundation — the 4 terminal reasons reachable
+on the un-extended loop body:
+
+  * completed (normal completion)
+  * max_turns (max_turns limit hit)
+  * aborted_streaming (abort during model call)
+  * aborted_tools (abort during tool execution)
+  * model_error (unrecoverable exception in the model call)
+
+The remaining 5 reasons (prompt_too_long, image_error,
+blocking_limit, stop_hook_prevented, hook_stopped) are reachable
+only after later phases land their recovery / hook / guard
+infrastructure.
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.providers.base import ChatResponse
+from src.query.query import (
+    QueryParams,
+    StreamEvent,
+    run_query,
+)
+from src.query.transitions import Terminal, TerminalHolder
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.types.messages import AssistantMessage, SystemMessage, UserMessage
+from src.utils.abort_controller import AbortController
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_params(
+    *,
+    workspace: Path,
+    provider: MagicMock,
+    abort: AbortController | None = None,
+    max_turns: int = 10,
+) -> QueryParams:
+    registry = build_default_registry()
+    context = ToolContext(workspace_root=workspace)
+    return QueryParams(
+        messages=[UserMessage(content="Hi")],
+        system_prompt="You are helpful.",
+        tools=registry.list_tools(),
+        tool_registry=registry,
+        tool_use_context=context,
+        provider=provider,
+        abort_controller=abort or AbortController(),
+        max_turns=max_turns,
+    )
+
+
+class TestTerminalCompleted(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_single_turn_returns_completed(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="Hello, world!",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 5},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        params = _make_params(workspace=self.workspace, provider=provider)
+        messages, terminal = _run(run_query(params))
+        self.assertIsInstance(terminal, Terminal)
+        self.assertEqual(terminal.reason, "completed")
+
+
+class TestTerminalMaxTurns(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_max_turns_returns_max_turns_terminal(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="Working...",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 20},
+            finish_reason="tool_use",
+            tool_uses=[{
+                "id": "toolu_001",
+                "name": "Write",
+                "input": {
+                    "file_path": str(self.workspace / "x.txt"),
+                    "content": "hi",
+                },
+            }],
+        )
+
+        params = _make_params(workspace=self.workspace, provider=provider, max_turns=2)
+        messages, terminal = _run(run_query(params))
+        self.assertEqual(terminal.reason, "max_turns")
+        self.assertEqual(terminal.turn_count, 3)
+
+
+class TestTerminalAbortedStreaming(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_abort_before_response_returns_aborted_streaming(self):
+        abort = AbortController()
+        abort.abort("test_abort")
+
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="Should not see this",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 5},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        params = _make_params(workspace=self.workspace, provider=provider, abort=abort)
+        _, terminal = _run(run_query(params))
+        self.assertEqual(terminal.reason, "aborted_streaming")
+
+
+class TestTerminalAbortedTools(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_abort_during_tools_returns_aborted_tools(self):
+        # Abort needs to fire AFTER the model call's abort check
+        # but BEFORE the post-tool abort check. The model call itself
+        # must return normally; the abort is raised from within tool
+        # execution. We patch `_run_tools_partitioned` to set the
+        # abort signal as a side-effect during execution.
+        abort = AbortController()
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="I'll write the file.",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 20},
+            finish_reason="tool_use",
+            tool_uses=[{
+                "id": "toolu_001",
+                "name": "Write",
+                "input": {
+                    "file_path": str(self.workspace / "x.txt"),
+                    "content": "hi",
+                },
+            }],
+        )
+
+        params = _make_params(workspace=self.workspace, provider=provider, abort=abort)
+
+        async def aborting_runner(*args, **kwargs):
+            from src.types.content_blocks import ToolResultBlock
+            abort.abort("user_abort")
+            return [
+                UserMessage(content=[
+                    ToolResultBlock(
+                        tool_use_id="toolu_001",
+                        content="aborted",
+                        is_error=True,
+                    ),
+                ]),
+            ]
+
+        with patch(
+            "src.query.query._run_tools_partitioned",
+            side_effect=aborting_runner,
+        ):
+            _, terminal = _run(run_query(params))
+        self.assertEqual(terminal.reason, "aborted_tools")
+
+
+class TestTerminalModelError(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_unrecoverable_model_error_returns_model_error(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = RuntimeError("network exploded")
+
+        params = _make_params(workspace=self.workspace, provider=provider)
+        _, terminal = _run(run_query(params))
+        self.assertEqual(terminal.reason, "model_error")
+        self.assertIsNotNone(terminal.error)
+
+
+class TestTerminalHolderDirectUsage(unittest.TestCase):
+    """Streaming consumers can pass their own TerminalHolder."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_holder_value_set_after_async_for_loop(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="Hi back.",
+            model="test",
+            usage={"input_tokens": 5, "output_tokens": 3},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        params = _make_params(workspace=self.workspace, provider=provider)
+        holder = TerminalHolder()
+
+        async def consume():
+            from src.query.query import query as query_gen
+            async for _ in query_gen(params, terminal_holder=holder):
+                pass
+
+        _run(consume())
+        self.assertIsNotNone(holder.value)
+        self.assertEqual(holder.value.reason, "completed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR **1 of 5** for chapter 5 (the agent loop). Lays the foundation that the rest of the stack depends on.

- Adds typed `TerminalReason` (10 chapter-§"Terminal States" reasons) and the `TerminalHolder` shared-container helper. Python async generators cannot `return value` (PEP 525), so the loop sets `holder.value = Terminal(...)` right before a bare `return`; callers read it after iteration.
- Adds `set_terminal(holder, flag, terminal)` paired-write helper. The `flag` (a 1-element `list[bool]`) is write-only in this PR; the outer two-layer wrapper that reads it for command-lifecycle gating lands in PR 4.
- Extends `QueryState` with `pending_tool_use_summary` and `continuation_nudge_count` (chapter §"State Object" — 11 fields total). Both are reserved here; populated by later PRs.
- Extends `ContinueReason` with `continuation_nudge`.
- Updates `query()` to accept an optional `terminal_holder` kwarg and call `set_terminal` at every existing exit site (model_error, aborted_streaming, completed ×2, aborted_tools, max_turns).
- Adds `run_query(params) -> (messages, terminal)` convenience helper.
- Updates `src/reference_data/ts_query_transitions.json` and extends the parity test (`tests/parity/test_query_state_parity.py`).

## What this is NOT

Pure foundation — no recovery integration, no stop hooks, no token budget, no model fallback, no continuation nudge. Each of those lands in a follow-up PR (2–5) on this stack.

## Test plan

- [x] `tests/test_query_loop.py` — 5 existing tests still pass
- [x] `tests/test_query_terminal.py` — 6 new tests cover the 5 reachable Terminal reasons on the un-extended loop (completed, max_turns, aborted_streaming, aborted_tools, model_error) plus direct `TerminalHolder` usage
- [x] `tests/test_query_error_recovery.py` — 3 existing tests still pass
- [x] `tests/test_query_engine.py` — 9 existing tests still pass
- [x] `tests/parity/test_query_state_parity.py` — 18 tests including new `test_all_terminal_reasons_match_ts` + `test_terminal_can_be_created_for_each_reason`
- [x] `tests/integration/test_query_integration.py` — 5 existing tests still pass

**46 tests pass total. No behavior change for existing consumers.**

## Stack

This PR is part of a 5-PR stack for chapter 5 (agent loop):

1. **This PR** — Phase A foundation
2. Phases B + B.3 + B.5 + D — recovery (PTL, blocking-limit, autocompact circuit-breaker, token budget)
3. Phases C + E — stop hooks, model fallback, continuation nudge
4. Phases G + F.1 — QueryDeps + lifecycle + adapter module
5. Phases F.2/F.3 + cleanup — migrate headless+TUI, remove legacy `run_agent_loop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)