### PR TITLE
feat(ch05/B+D): PTL/media recovery, blocking-limit guards, token budget

### DIFF
--- a/src/query/query.py
+++ b/src/query/query.py
@@ -70,6 +70,10 @@ class QueryParams:
     user_context: dict[str, str] | None = None
     system_context: dict[str, str] | None = None
     pipeline_config: PipelineConfig | None = None
+    # Ch5/D.1: Task-level token budget. When set, the loop checks
+    # `check_token_budget` after each completion and may continue
+    # with a nudge message until 90% of `total` is reached.
+    task_budget: dict[str, int] | None = None
 
 
 @dataclass
@@ -192,6 +196,36 @@ def _is_withheld_max_output_tokens(msg: Message | None) -> bool:
     return getattr(msg, "_api_error", None) == "max_output_tokens"
 
 
+def _is_withheld_prompt_too_long(msg: Message | None) -> bool:
+    """Ch5/B.1: PTL withholding detector. Mirrors TS isWithheldPromptTooLong."""
+    if msg is None:
+        return False
+    if not isinstance(msg, AssistantMessage):
+        return False
+    if not getattr(msg, "isApiErrorMessage", False):
+        return False
+    return getattr(msg, "_api_error", None) == "prompt_too_long"
+
+
+def _is_withheld_media_size(msg: Message | None) -> bool:
+    """Ch5/B.1: Media-size withholding detector. Mirrors TS isWithheldMediaSizeError."""
+    if msg is None:
+        return False
+    if not isinstance(msg, AssistantMessage):
+        return False
+    return getattr(msg, "_api_error", None) == "media_size"
+
+
+def _get_context_window(provider: Any, model: str) -> int:
+    """Ch5/B.4: Best-effort context-window lookup for the blocking-limit guard.
+
+    Defaults to 200_000 if unknown. A follow-up ticket can replace
+    this with proper per-model config; for now the goal is to make
+    the guard work for the common cases (Sonnet/Opus = 200k).
+    """
+    return getattr(provider, "context_window", None) or 200_000
+
+
 async def _call_model_sync(
     *,
     provider: BaseProvider,
@@ -309,7 +343,13 @@ async def _call_model_sync(
         if _diag:
             logger.warning("[DIAG] _call_model_sync: EXCEPTION after %.1fs: %s", time.monotonic() - _t0, e)
         error_str = str(e)
-        if "prompt is too long" in error_str.lower() or "prompt_too_long" in error_str.lower():
+        # Ch5/B.1: route through the typed helpers so PTL / media-size
+        # detection is consistent with the rest of the codebase.
+        from ..services.api.errors import (
+            is_media_size_error,
+            is_prompt_too_long_error,
+        )
+        if is_prompt_too_long_error(e):
             err_msg = _create_assistant_api_error_message(
                 PROMPT_TOO_LONG_ERROR_MESSAGE,
                 error="prompt_too_long",
@@ -323,6 +363,17 @@ async def _call_model_sync(
                 error="max_output_tokens",
             )
             err_msg._api_error = "max_output_tokens"  # type: ignore[attr-defined]
+            return [err_msg], []
+
+        # is_media_size_error takes str (not Exception) and handles
+        # case internally — pass the raw message body so the PDF-page
+        # regex (which expects the literal "PDF") can match.
+        if is_media_size_error(error_str):
+            err_msg = _create_assistant_api_error_message(
+                f"Media too large: {error_str}",
+                error="media_size",
+            )
+            err_msg._api_error = "media_size"  # type: ignore[attr-defined]
             return [err_msg], []
 
         raise
@@ -614,6 +665,14 @@ async def query(
         max_output_tokens_override=params.max_output_tokens_override,
     )
     config = build_query_config()
+    # Ch5/D.1: budget tracker is created only when both the runtime
+    # feature flag and the per-request task_budget are set. No prompt
+    # marker → no tracker → no overhead. Mirrors TS query.ts:295.
+    if params.task_budget and getattr(config, "token_budget_enabled", True):
+        from .token_budget import create_budget_tracker
+        budget_tracker = create_budget_tracker()
+    else:
+        budget_tracker = None
 
     while True:
         messages = state.messages
@@ -647,11 +706,31 @@ async def query(
                 # whether to fire. Without this the MIN_INPUT_TOKENS_FOR_AUTOCOMPACT
                 # guard short-circuits and auto-compact never triggers.
                 est_input_tokens = rough_token_count_estimation_for_messages(messages)
+
+                # Ch5/B.5 prereq: thread the caller-owned
+                # AutoCompactTracking instance into the pipeline before
+                # the call so auto_compact_if_needed mutates the same
+                # object the query loop holds via state.auto_compact_tracking.
+                # If the loop has no tracking yet, the pipeline creates
+                # a default one — capture it back into state below.
+                if state.auto_compact_tracking is not None:
+                    params.pipeline_config.autocompact_tracking = (
+                        state.auto_compact_tracking
+                    )
+
                 pipeline_result = await run_compression_pipeline(
                     messages,
                     input_token_count=est_input_tokens,
                     config=params.pipeline_config,
                 )
+
+                # Read the (possibly mutated) tracking object back into
+                # state for the next iteration. The pipeline's
+                # autocompact_tracking is now authoritative.
+                state.auto_compact_tracking = (
+                    params.pipeline_config.autocompact_tracking
+                )
+
                 if pipeline_result.tokens_saved > 0:
                     messages = pipeline_result.messages
                     if _diag:
@@ -662,6 +741,101 @@ async def query(
                         )
             except Exception:
                 logger.warning("Compression pipeline failed, continuing with original messages", exc_info=True)
+
+        # Ch5/B.4: Blocking-limit pre-emption guard.
+        # If the context is at the hard blocking limit, fail fast with
+        # a clear message instead of burning an API call that will 500.
+        # Mirrors TS query.ts:683-696.
+        try:
+            from ..services.compact.autocompact import (
+                calculate_token_warning_state,
+            )
+            # Skip cases (mirrors TS query.ts:644-660):
+            #   - compact/session_memory forked queries (deadlock risk —
+            #     the compact agent must run to REDUCE token count)
+            #   - the previous iteration was a recovery retry whose
+            #     messages were already validated under the limit
+            # We deliberately DO NOT skip when reactive_compact +
+            # autocompact are both enabled. The TS guard at
+            # query.ts:683-696 fires unconditionally on the proactive
+            # path; reactive_compact catches the *real* 413 from the
+            # API later, but this guard pre-empts the call so we don't
+            # burn API budget on retries-to-500.
+            skip_blocking = (
+                params.query_source in ("compact", "session_memory")
+                or (
+                    state.transition is not None
+                    and state.transition.reason
+                    in ("collapse_drain_retry", "reactive_compact_retry")
+                )
+            )
+            if not skip_blocking:
+                context_window = _get_context_window(
+                    params.provider,
+                    getattr(config, "model", ""),
+                )
+                token_usage = rough_token_count_estimation_for_messages(messages)
+                warning = calculate_token_warning_state(
+                    token_usage,
+                    context_window,
+                )
+                if warning.get("is_at_blocking_limit"):
+                    yield _create_assistant_api_error_message(
+                        PROMPT_TOO_LONG_ERROR_MESSAGE,
+                        error="invalid_request",
+                    )
+                    set_terminal(
+                        holder,
+                        natural_termination,
+                        Terminal(reason="blocking_limit"),
+                    )
+                    return
+        except Exception:
+            if _diag:
+                logger.warning("blocking_limit pre-emption check failed", exc_info=True)
+
+        # Ch5/B.5: autocompact-circuit-breaker pre-emption.
+        # When autocompact has failed 3+ times in a row AND the context
+        # is still above the autocompact threshold, fail fast — sending
+        # this to the API would just 500. Mirrors TS query.ts:705-725.
+        try:
+            from ..services.compact.autocompact import (
+                MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES,
+                calculate_token_warning_state as _calc_warning,
+                is_auto_compact_enabled as _is_auto_enabled,
+            )
+            tracking = state.auto_compact_tracking
+            consec = getattr(tracking, "consecutive_failures", 0) if tracking else 0
+            if (
+                consec >= MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES
+                and _is_auto_enabled()
+            ):
+                ctx_window = _get_context_window(
+                    params.provider,
+                    getattr(config, "model", ""),
+                )
+                tok_usage = rough_token_count_estimation_for_messages(messages)
+                warn = _calc_warning(tok_usage, ctx_window)
+                if warn.get("is_above_auto_compact_threshold"):
+                    yield _create_assistant_api_error_message(
+                        "The conversation has exceeded the context limit "
+                        "and automatic compaction has failed. Press esc "
+                        "twice to go up a few messages and try again, or "
+                        "start a new session with /new.",
+                        error="invalid_request",
+                    )
+                    set_terminal(
+                        holder,
+                        natural_termination,
+                        Terminal(reason="blocking_limit"),
+                    )
+                    return
+        except Exception:
+            if _diag:
+                logger.warning(
+                    "autocompact-circuit-breaker guard failed",
+                    exc_info=True,
+                )
 
         assistant_messages: list[AssistantMessage] = []
         tool_results: list[UserMessage] = []
@@ -681,9 +855,16 @@ async def query(
             needs_follow_up = len(tool_use_blocks) > 0
 
             for msg in assistant_messages:
-                withheld = False
-                if _is_withheld_max_output_tokens(msg):
-                    withheld = True
+                # Ch5/B.1: Withhold PTL, media-size, and max-output-tokens
+                # errors from the stream so SDK consumers don't disconnect
+                # before the loop can attempt recovery. The withheld
+                # message is still in assistant_messages for the recovery
+                # dispatch below to find.
+                withheld = (
+                    _is_withheld_max_output_tokens(msg)
+                    or _is_withheld_prompt_too_long(msg)
+                    or _is_withheld_media_size(msg)
+                )
                 if not withheld:
                     yield msg
 
@@ -711,6 +892,117 @@ async def query(
 
         if not needs_follow_up:
             last_message = assistant_messages[-1] if assistant_messages else None
+
+            # Ch5/B.2: Prompt-too-long and media-size error recovery via
+            # reactive_compact. One-shot per error type
+            # (has_attempted_reactive_compact gate). If recovery succeeds,
+            # continue with the compacted messages. If it fails or has
+            # already been attempted, surface the withheld error and exit
+            # cleanly with the appropriate Terminal reason — do NOT fall
+            # through to the generic isApiErrorMessage branch (which
+            # would mis-report this as `completed`).
+            is_withheld_ptl = _is_withheld_prompt_too_long(last_message)
+            is_withheld_media = _is_withheld_media_size(last_message)
+
+            # Ch5/B.3: Context-collapse drain runs BEFORE reactive_compact
+            # for PTL only (media errors skip this — collapse can't
+            # shrink images). Guarded on the previous transition: if we
+            # already drained on the prior iteration, fall through to
+            # reactive_compact. Mirrors TS query.ts:1160-1193.
+            if is_withheld_ptl and (
+                state.transition is None
+                or state.transition.reason != "collapse_drain_retry"
+            ):
+                try:
+                    from ..services.compact.context_collapse import (
+                        is_context_collapse_enabled,
+                        recover_from_overflow,
+                    )
+                    if is_context_collapse_enabled():
+                        drained = recover_from_overflow(
+                            messages, params.query_source,
+                        )
+                        if drained.committed > 0:
+                            state = QueryState(
+                                messages=drained.messages,
+                                tool_use_context=tool_use_context,
+                                auto_compact_tracking=state.auto_compact_tracking,
+                                max_output_tokens_recovery_count=max_output_tokens_recovery_count,
+                                has_attempted_reactive_compact=has_attempted_reactive_compact,
+                                max_output_tokens_override=None,
+                                stop_hook_active=None,
+                                turn_count=turn_count,
+                                continuation_nudge_count=state.continuation_nudge_count,
+                                pending_tool_use_summary=None,
+                                transition=Transition(
+                                    reason="collapse_drain_retry",
+                                    committed=drained.committed,
+                                ),
+                            )
+                            continue
+                except Exception:
+                    # Best-effort. If staging isn't available or the
+                    # drain crashes, fall through to reactive_compact.
+                    # Always log at warning level (not just _diag) so a
+                    # broken store is observable in production telemetry.
+                    logger.warning(
+                        "collapse-drain recovery failed, falling through to reactive_compact",
+                        exc_info=True,
+                    )
+
+            if is_withheld_ptl or is_withheld_media:
+                if not has_attempted_reactive_compact:
+                    try:
+                        from ..services.compact.reactive_compact import (
+                            ReactiveCompactResult,
+                            reactive_compact,
+                        )
+                        from ..services.api.errors import PromptTooLongError
+                        synthetic_err = PromptTooLongError(
+                            "withheld during streaming, recovering",
+                        )
+                        rc_result: ReactiveCompactResult = await reactive_compact(
+                            messages=messages,
+                            error=synthetic_err,
+                            provider=params.provider,
+                            model=config.model,
+                        )
+                    except Exception as rc_err:
+                        logger.exception("reactive_compact recovery crashed: %s", rc_err)
+                        rc_result = None  # type: ignore[assignment]
+
+                    if rc_result is not None and rc_result.compacted:
+                        # Yield the new messages so the consumer sees the boundary.
+                        for cmsg in rc_result.messages:
+                            yield cmsg
+                        state = QueryState(
+                            messages=rc_result.messages,
+                            tool_use_context=tool_use_context,
+                            auto_compact_tracking=None,
+                            max_output_tokens_recovery_count=max_output_tokens_recovery_count,
+                            has_attempted_reactive_compact=True,  # one-shot
+                            max_output_tokens_override=None,
+                            stop_hook_active=None,
+                            turn_count=turn_count,
+                            continuation_nudge_count=state.continuation_nudge_count,
+                            pending_tool_use_summary=None,
+                            transition=Transition(reason="reactive_compact_retry"),
+                        )
+                        continue
+
+                # Either no recovery attempt (already ran) OR the attempt
+                # failed. Surface the withheld error and exit with the
+                # appropriate Terminal reason.
+                if last_message is not None:
+                    yield last_message
+                set_terminal(
+                    holder,
+                    natural_termination,
+                    Terminal(
+                        reason="image_error" if is_withheld_media else "prompt_too_long",
+                    ),
+                )
+                return
 
             if _is_withheld_max_output_tokens(last_message):
                 if (
@@ -755,8 +1047,47 @@ async def query(
                 yield last_message  # type: ignore[arg-type]
 
             if last_message and getattr(last_message, "isApiErrorMessage", False):
+                # Death-spiral guard: when the last message is an API
+                # error, do NOT run any subsequent hooks/checks (the
+                # model never produced a real response). Mirrors TS
+                # query.ts:1341-1344.
                 set_terminal(holder, natural_termination, Terminal(reason="completed"))
                 return
+
+            # Ch5/D.2: Token budget check. If task_budget is set and we
+            # haven't yet exhausted 90% of `total`, inject a nudge
+            # message and continue.
+            if params.task_budget and budget_tracker is not None:
+                from .token_budget import ContinueDecision, check_token_budget
+                global_turn_tokens = sum(
+                    int((getattr(m, "usage", None) or {}).get("output_tokens", 0))
+                    for m in assistant_messages
+                )
+                decision = check_token_budget(
+                    budget_tracker,
+                    getattr(tool_use_context, "agent_id", None),
+                    int((params.task_budget or {}).get("total") or 0),
+                    global_turn_tokens,
+                )
+                if isinstance(decision, ContinueDecision):
+                    nudge = _create_user_message(
+                        decision.nudge_message,
+                        is_meta=True,
+                    )
+                    state = QueryState(
+                        messages=[*messages, *assistant_messages, nudge],
+                        tool_use_context=tool_use_context,
+                        auto_compact_tracking=state.auto_compact_tracking,
+                        max_output_tokens_recovery_count=0,
+                        has_attempted_reactive_compact=False,
+                        max_output_tokens_override=None,
+                        stop_hook_active=None,
+                        turn_count=turn_count,
+                        continuation_nudge_count=state.continuation_nudge_count,
+                        pending_tool_use_summary=None,
+                        transition=Transition(reason="token_budget_continuation"),
+                    )
+                    continue
 
             set_terminal(holder, natural_termination, Terminal(reason="completed"))
             return

--- a/src/services/api/errors.py
+++ b/src/services/api/errors.py
@@ -110,10 +110,17 @@ def is_invalid_api_key(error: Exception) -> bool:
 
 
 def is_media_size_error(raw: str) -> bool:
+    """Case-insensitive media-size-error detector.
+
+    Substring checks are normalized to lowercase; the PDF regex
+    uses ``re.IGNORECASE`` so capitalization in provider messages
+    doesn't change the outcome.
+    """
+    lowered = raw.lower()
     return (
-        ("image exceeds" in raw and "maximum" in raw)
-        or ("image dimensions exceed" in raw and "many-image" in raw)
-        or bool(re.search(r"maximum of \d+ PDF pages", raw))
+        ("image exceeds" in lowered and "maximum" in lowered)
+        or ("image dimensions exceed" in lowered and "many-image" in lowered)
+        or bool(re.search(r"maximum of \d+ PDF pages", raw, re.IGNORECASE))
     )
 
 

--- a/src/services/compact/context_collapse.py
+++ b/src/services/compact/context_collapse.py
@@ -46,9 +46,18 @@ class ContextCollapseStore:
 
     Each commit records a set of archived message UUIDs and the summary
     that replaces them in the projected view.
+
+    Ch5/B.3: also holds a "staged" set of commits that have been queued
+    but not yet promoted to the committed log. ``drain_staged()`` moves
+    them all into ``commits`` and returns the count of newly-promoted
+    commits. This separation lets the loop attempt a recovery via
+    collapse-drain on a 413 BEFORE falling through to reactive_compact.
     """
     commits: list[CollapseCommit] = field(default_factory=list)
     _enabled: bool = True
+    # Ch5/B.3: staged-but-not-committed collapse operations. These do
+    # NOT participate in project_view() until drain_staged() is called.
+    _staged: list[CollapseCommit] = field(default_factory=list)
 
     # ------------------------------------------------------------------
     # Public API
@@ -67,6 +76,40 @@ class ContextCollapseStore:
         if not archived_msg_ids or not summary:
             return
         self.commits.append(CollapseCommit(archived=list(archived_msg_ids), summary=summary))
+
+    def add_staged(self, archived_msg_ids: list[str], summary: str) -> None:
+        """Ch5/B.3: queue a collapse commit without making it visible
+        to ``project_view()`` until ``drain_staged()`` is called.
+
+        Mirrors the TS staged/committed distinction at
+        ``contextCollapse/index.ts``. A staged commit becomes a real
+        commit only when the loop drains the queue on a 413, so the
+        granular context is preserved as long as the conversation
+        stays under the limit.
+        """
+        if not archived_msg_ids or not summary:
+            return
+        self._staged.append(
+            CollapseCommit(archived=list(archived_msg_ids), summary=summary)
+        )
+
+    def drain_staged(self) -> int:
+        """Ch5/B.3: promote all staged commits into the committed log.
+
+        Returns the number of newly-promoted commits (0 if nothing
+        was staged). After draining, ``project_view()`` will include
+        the drained commits' summaries.
+        """
+        if not self._staged:
+            return 0
+        count = len(self._staged)
+        self.commits.extend(self._staged)
+        self._staged.clear()
+        return count
+
+    def staged_count(self) -> int:
+        """Return the number of staged-but-not-committed entries."""
+        return len(self._staged)
 
     def project_view(self, messages: list[Message]) -> list[Message]:
         """
@@ -123,6 +166,12 @@ class ContextCollapseStore:
     # ------------------------------------------------------------------
 
     def to_dict(self) -> dict[str, Any]:
+        # Staged entries are intentionally ephemeral — they exist
+        # only within a single REPL session's lifetime. If a session
+        # is persisted/restored, staged collapses are dropped (the
+        # next iteration's compression pipeline can re-stage them as
+        # needed). Mirrors TS semantics where the staged queue is a
+        # session-local optimization, not durable state.
         return {
             "commits": [c.to_dict() for c in self.commits],
             "enabled": self._enabled,
@@ -131,6 +180,7 @@ class ContextCollapseStore:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ContextCollapseStore:
         commits = [CollapseCommit.from_dict(c) for c in data.get("commits", [])]
+        # `_staged` deliberately starts empty on restore — see to_dict.
         return cls(commits=commits, _enabled=data.get("enabled", True))
 
 
@@ -155,3 +205,82 @@ def set_context_collapse_store(store: ContextCollapseStore | None) -> None:
     """Set or clear the global context collapse store."""
     global _global_store
     _global_store = store
+
+
+# ---------------------------------------------------------------------------
+# Ch5/B.3: PTL recovery via staged-collapse drain
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DrainResult:
+    """Outcome of :func:`recover_from_overflow`.
+
+    ``committed > 0`` means staged collapses were promoted to the
+    commit log; ``messages`` holds the drained view (with the now-
+    committed summaries projected in, ``isVirtual=False`` so the
+    summary reaches the API on retry).
+    ``committed == 0`` means there was nothing staged to drain —
+    caller should fall through to ``reactive_compact``.
+    """
+    messages: list[Message]
+    committed: int
+
+
+def recover_from_overflow(
+    messages: list[Message],
+    query_source: str,
+) -> DrainResult:
+    """Ch5/B.3: drain staged context-collapses on a real API 413.
+
+    Mirrors TS ``recoverFromOverflow`` at ``query.ts:1169``. The
+    chapter-§"Context Collapse" contract is:
+
+      1. The store carries STAGED collapses while the conversation
+         is still under the limit (preserve granular context).
+      2. When the API returns 413, drain the staged queue — all
+         staged collapses are now in the commit log.
+      3. ``project_view`` over ``messages`` now returns a smaller
+         array (archived spans replaced by their summaries).
+      4. Caller retries with the drained view.
+
+    Returns ``DrainResult(messages=messages, committed=0)`` if no
+    store is configured or no staged collapses exist, so the caller
+    falls through to ``reactive_compact`` cleanly.
+
+    Note on visibility: ``project_view`` marks summary messages as
+    ``isVirtual=True`` for the read-time UI-projection use case —
+    those are filtered from the API by ``normalize_messages_for_api``.
+    For drain-recovery the summary MUST reach the API, so we
+    explicitly clear ``isVirtual`` on the drained view before
+    returning. This is the API-bound projection.
+
+    ``query_source`` is accepted for parity with the TS signature
+    but not currently consumed — reserved for future per-source
+    drain policies (e.g., subagents may need different behavior).
+    """
+    _ = query_source  # reserved
+    store = get_context_collapse_state()
+    if store is None:
+        return DrainResult(messages=list(messages), committed=0)
+    committed_count = store.drain_staged()
+    if committed_count == 0:
+        return DrainResult(messages=list(messages), committed=0)
+
+    projected = store.project_view(messages)
+    # Clear isVirtual on the summary messages so they are NOT filtered
+    # out of the API call (read-time projection vs. API-bound
+    # projection — these are different use cases of project_view).
+    api_visible: list[Message] = []
+    for msg in projected:
+        if getattr(msg, "isVirtual", False):
+            try:
+                import copy as _copy
+                cloned = _copy.copy(msg)
+                cloned.isVirtual = False  # type: ignore[attr-defined]
+                api_visible.append(cloned)
+            except Exception:
+                api_visible.append(msg)
+        else:
+            api_visible.append(msg)
+    return DrainResult(messages=api_visible, committed=committed_count)

--- a/tests/test_query_phase_b3.py
+++ b/tests/test_query_phase_b3.py
@@ -1,0 +1,230 @@
+"""Ch5/B.3 acceptance tests: context-collapse drain on 413.
+
+Verifies:
+- ContextCollapseStore.add_staged + drain_staged round-trip
+- recover_from_overflow returns DrainResult with committed > 0 when
+  staged collapses exist
+- query.py runs collapse drain BEFORE reactive_compact on PTL when
+  staged collapses are present
+- has_attempted_reactive_compact is NOT flipped by the drain path
+- transition.reason == "collapse_drain_retry" on the intermediate state
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.providers.base import ChatResponse
+from src.query.query import QueryParams, run_query
+from src.services.compact.context_collapse import (
+    ContextCollapseStore,
+    DrainResult,
+    recover_from_overflow,
+    set_context_collapse_store,
+)
+from src.services.compact.reactive_compact import ReactiveCompactResult
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.types.messages import AssistantMessage, UserMessage
+from src.utils.abort_controller import AbortController
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_params(workspace: Path, provider: MagicMock, **kwargs) -> QueryParams:
+    registry = build_default_registry()
+    context = ToolContext(workspace_root=workspace)
+    return QueryParams(
+        messages=[UserMessage(content="Hi")],
+        system_prompt="You are helpful.",
+        tools=registry.list_tools(),
+        tool_registry=registry,
+        tool_use_context=context,
+        provider=provider,
+        abort_controller=AbortController(),
+        max_turns=kwargs.pop("max_turns", 10),
+        **kwargs,
+    )
+
+
+class TestStoreStaging(unittest.TestCase):
+    """Unit tests for add_staged / drain_staged / staged_count."""
+
+    def test_staged_does_not_appear_in_project_view(self):
+        store = ContextCollapseStore()
+        msg = UserMessage(content="x")
+        store.add_staged([msg.uuid], "summary text")
+        # Before drain: project_view sees no commits → no archives → msg passes through.
+        view = store.project_view([msg])
+        self.assertEqual(len(view), 1)
+
+    def test_drain_promotes_to_commits(self):
+        store = ContextCollapseStore()
+        msg = UserMessage(content="x")
+        store.add_staged([msg.uuid], "summary")
+        self.assertEqual(store.staged_count(), 1)
+        committed = store.drain_staged()
+        self.assertEqual(committed, 1)
+        self.assertEqual(store.staged_count(), 0)
+        view = store.project_view([msg])
+        self.assertEqual(len(view), 1)
+        self.assertTrue(getattr(view[0], "isVirtual", False))
+
+    def test_drain_empty_returns_zero(self):
+        store = ContextCollapseStore()
+        self.assertEqual(store.drain_staged(), 0)
+
+
+class TestRecoverFromOverflow(unittest.TestCase):
+    """Module-level recover_from_overflow contract."""
+
+    def tearDown(self):
+        set_context_collapse_store(None)
+
+    def test_no_store_returns_zero(self):
+        result = recover_from_overflow([], "repl_main_thread")
+        self.assertIsInstance(result, DrainResult)
+        self.assertEqual(result.committed, 0)
+
+    def test_drain_when_staged(self):
+        store = ContextCollapseStore()
+        m = UserMessage(content="x")
+        store.add_staged([m.uuid], "summary")
+        set_context_collapse_store(store)
+
+        result = recover_from_overflow([m], "repl_main_thread")
+        self.assertEqual(result.committed, 1)
+        # Per B.3 contract: isVirtual is False so the message is
+        # API-visible (the entire point of drain recovery is for the
+        # summary to reach the API).
+        self.assertEqual(len(result.messages), 1)
+        self.assertFalse(getattr(result.messages[0], "isVirtual", False))
+        content = result.messages[0].content
+        if isinstance(content, list):
+            joined = "".join(
+                getattr(b, "text", "") for b in content
+            )
+        else:
+            joined = str(content)
+        self.assertIn("summary", joined)
+
+
+class TestCollapseDrainRunsBeforeReactiveCompact(unittest.TestCase):
+    """Integration: on a 413, the loop drains the staged collapses
+    FIRST. Only if drain.committed == 0 (or already retried) does
+    reactive_compact fire."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        set_context_collapse_store(None)
+        self.tmp.cleanup()
+
+    def test_drain_runs_before_reactive_compact(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+
+        params = _make_params(self.workspace, provider)
+        # Stage a collapse of the initial user message with a known
+        # summary text. project_view replaces it with a summary
+        # message containing the text.
+        initial_msg = params.messages[0]
+        store = ContextCollapseStore()
+        store.add_staged([initial_msg.uuid], "DRAINED-SUMMARY-MARKER")
+        set_context_collapse_store(store)
+
+        call_count = {"n": 0}
+
+        def chat_side_effect(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("Prompt is too long.")
+            return ChatResponse(
+                content="Done after drain.",
+                model="test",
+                usage={"input_tokens": 5, "output_tokens": 3},
+                finish_reason="end_turn",
+                tool_uses=None,
+            )
+
+        provider.chat.side_effect = chat_side_effect
+
+        rc_mock = MagicMock()
+
+        async def rc_async(**kwargs):
+            return ReactiveCompactResult(
+                compacted=True,
+                messages=kwargs["messages"],
+                tokens_before=1000,
+                tokens_after=200,
+            )
+
+        rc_mock.side_effect = rc_async
+
+        with patch(
+            "src.services.compact.reactive_compact.reactive_compact",
+            new=rc_mock,
+        ):
+            _, terminal = _run(run_query(params))
+
+        # The drain path took priority → reactive_compact NOT called.
+        self.assertEqual(rc_mock.call_count, 0)
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(call_count["n"], 2)
+        # The DRAINED VIEW (with the summary block) reaches the second
+        # model call's input.
+        second_call_messages = provider.chat.call_args_list[1].args[0]
+        drained_payload = "\n".join(
+            str(m.get("content", "")) for m in second_call_messages
+        )
+        self.assertIn("DRAINED-SUMMARY-MARKER", drained_payload)
+
+    def test_no_staged_falls_through_to_reactive_compact(self):
+        store = ContextCollapseStore()
+        set_context_collapse_store(store)
+
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = [
+            RuntimeError("Prompt is too long."),
+            ChatResponse(
+                content="Done.",
+                model="test",
+                usage={"input_tokens": 5, "output_tokens": 3},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+        ]
+
+        rc_mock = MagicMock()
+
+        async def rc_async(**kwargs):
+            return ReactiveCompactResult(
+                compacted=True,
+                messages=[UserMessage(content="compacted")],
+                tokens_before=1000,
+                tokens_after=200,
+            )
+
+        rc_mock.side_effect = rc_async
+
+        params = _make_params(self.workspace, provider)
+        with patch(
+            "src.services.compact.reactive_compact.reactive_compact",
+            new=rc_mock,
+        ):
+            _, terminal = _run(run_query(params))
+
+        self.assertEqual(rc_mock.call_count, 1)
+        self.assertEqual(terminal.reason, "completed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_query_terminal.py
+++ b/tests/test_query_terminal.py
@@ -1,19 +1,16 @@
-"""Phase A acceptance tests: typed Terminal return values via the
-``run_query()`` helper and the ``TerminalHolder`` protocol.
+"""Phase A + B + D acceptance tests: typed Terminal return values
+plus recovery integration (PTL via reactive_compact, blocking-limit
+guard, autocompact circuit-breaker, token-budget continuation).
 
-Verifies the Phase A foundation — the 4 terminal reasons reachable
-on the un-extended loop body:
+PR 1 (Phase A) reached: completed, max_turns, aborted_streaming,
+aborted_tools, model_error.
 
-  * completed (normal completion)
-  * max_turns (max_turns limit hit)
-  * aborted_streaming (abort during model call)
-  * aborted_tools (abort during tool execution)
-  * model_error (unrecoverable exception in the model call)
+PR 2 adds: prompt_too_long, image_error, blocking_limit (with the
+autocompact-circuit-breaker variant), plus token-budget continuation
+behavior.
 
-The remaining 5 reasons (prompt_too_long, image_error,
-blocking_limit, stop_hook_prevented, hook_stopped) are reachable
-only after later phases land their recovery / hook / guard
-infrastructure.
+The remaining 2 reasons (stop_hook_prevented, hook_stopped) land
+when stop hooks are wired up in PR 3.
 """
 from __future__ import annotations
 
@@ -217,6 +214,309 @@ class TestTerminalModelError(unittest.TestCase):
         _, terminal = _run(run_query(params))
         self.assertEqual(terminal.reason, "model_error")
         self.assertIsNotNone(terminal.error)
+
+
+class TestTerminalPromptTooLong(unittest.TestCase):
+    """Ch5/B.2: PTL recovery exhausted → terminal `prompt_too_long`."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_ptl_with_no_recovery_returns_prompt_too_long(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = RuntimeError("Prompt is too long.")
+
+        with patch(
+            "src.services.compact.reactive_compact.reactive_compact",
+            new=MagicMock(),
+        ) as mock_rc:
+            from src.services.compact.reactive_compact import ReactiveCompactResult
+
+            async def fail_rc(**kwargs):
+                return ReactiveCompactResult(
+                    compacted=False,
+                    messages=kwargs["messages"],
+                    tokens_before=1000,
+                    error="mocked: no compaction",
+                )
+            mock_rc.side_effect = fail_rc
+
+            params = _make_params(workspace=self.workspace, provider=provider)
+            _, terminal = _run(run_query(params))
+            self.assertEqual(terminal.reason, "prompt_too_long")
+
+
+class TestPTLAfterReactiveCompact(unittest.TestCase):
+    """Regression guard: if reactive_compact succeeds once but the
+    model returns PTL again on the retry, the loop MUST surface the
+    PTL and return Terminal(prompt_too_long). Previously fell through
+    to a fake `completed` terminal."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_second_ptl_after_recovery_surfaces_terminal(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = RuntimeError("Prompt is too long.")
+
+        with patch(
+            "src.services.compact.reactive_compact.reactive_compact",
+            new=MagicMock(),
+        ) as mock_rc:
+            from src.services.compact.reactive_compact import ReactiveCompactResult
+
+            async def succeed_then_skip(**kwargs):
+                return ReactiveCompactResult(
+                    compacted=True,
+                    messages=[UserMessage(content="compacted summary")],
+                    tokens_before=1000,
+                    tokens_after=200,
+                )
+            mock_rc.side_effect = succeed_then_skip
+
+            params = _make_params(workspace=self.workspace, provider=provider)
+            _, terminal = _run(run_query(params))
+            self.assertEqual(terminal.reason, "prompt_too_long")
+            self.assertEqual(mock_rc.call_count, 1)
+
+
+class TestTerminalImageError(unittest.TestCase):
+    """Ch5/B.2: Media-size recovery exhausted → terminal `image_error`."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_media_size_with_no_recovery_returns_image_error(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = RuntimeError(
+            "Image exceeds the maximum size",
+        )
+
+        with patch(
+            "src.services.compact.reactive_compact.reactive_compact",
+            new=MagicMock(),
+        ) as mock_rc:
+            from src.services.compact.reactive_compact import ReactiveCompactResult
+
+            async def fail_rc(**kwargs):
+                return ReactiveCompactResult(
+                    compacted=False,
+                    messages=kwargs["messages"],
+                    tokens_before=1000,
+                    error="mocked: no compaction",
+                )
+            mock_rc.side_effect = fail_rc
+
+            params = _make_params(workspace=self.workspace, provider=provider)
+            _, terminal = _run(run_query(params))
+            self.assertEqual(terminal.reason, "image_error")
+
+
+class TestTokenBudgetIntegration(unittest.TestCase):
+    """Ch5/D.2: token-budget continuation injects nudge and re-enters loop."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_under_budget_continues_with_nudge(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="Partial answer.",
+            model="test",
+            usage={"input_tokens": 5, "output_tokens": 100},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        params = _make_params(workspace=self.workspace, provider=provider, max_turns=3)
+        params.task_budget = {"total": 1000}
+
+        messages, terminal = _run(run_query(params))
+        self.assertGreaterEqual(provider.chat.call_count, 2)
+        second_call_messages = provider.chat.call_args_list[1].args[0]
+        nudges = [
+            msg for msg in second_call_messages
+            if msg.get("role") == "user"
+            and "token target" in str(msg.get("content", ""))
+        ]
+        self.assertGreaterEqual(
+            len(nudges), 1,
+            f"Expected at least 1 budget nudge in 2nd call messages; got: {second_call_messages}",
+        )
+        self.assertNotEqual(terminal.reason, "model_error")
+
+    def test_no_budget_keeps_single_turn_behavior(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="One shot answer.",
+            model="test",
+            usage={"input_tokens": 5, "output_tokens": 100},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        params = _make_params(workspace=self.workspace, provider=provider)
+        _, terminal = _run(run_query(params))
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(provider.chat.call_count, 1)
+
+    def test_subagent_does_not_continue(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="Subagent answer.",
+            model="test",
+            usage={"input_tokens": 5, "output_tokens": 100},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        params = _make_params(workspace=self.workspace, provider=provider)
+        params.task_budget = {"total": 1000}
+        params.tool_use_context.agent_id = "subagent_1"
+
+        _, terminal = _run(run_query(params))
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(provider.chat.call_count, 1)
+
+
+class TestBlockingLimitPreemption(unittest.TestCase):
+    """Ch5/B.4: when context is at the hard blocking limit, fail fast
+    with terminal `blocking_limit` instead of letting the API 500."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_blocking_limit_skips_api_call(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="Should not be called",
+            model="test",
+            usage={"input_tokens": 0, "output_tokens": 0},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        params = _make_params(workspace=self.workspace, provider=provider)
+
+        with (
+            patch(
+                "src.services.compact.autocompact.is_auto_compact_enabled",
+                return_value=False,
+            ),
+            patch(
+                "src.services.compact.autocompact.calculate_token_warning_state",
+                return_value={
+                    "percent_left": 0,
+                    "is_above_warning_threshold": True,
+                    "is_above_error_threshold": True,
+                    "is_above_auto_compact_threshold": True,
+                    "is_at_blocking_limit": True,
+                },
+            ),
+        ):
+            _, terminal = _run(run_query(params))
+
+        self.assertEqual(terminal.reason, "blocking_limit")
+        provider.chat.assert_not_called()
+
+
+class TestAutocompactCircuitBreaker(unittest.TestCase):
+    """Ch5/B.5: when autocompact has tripped its 3-failure circuit
+    breaker AND the context is still over the autocompact threshold,
+    the loop returns `blocking_limit` with the chapter-quoted message
+    instead of burning another API call."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_circuit_breaker_returns_blocking_limit(self):
+        from src.services.compact.autocompact import AutoCompactTracking
+
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="Should not be called",
+            model="test",
+            usage={"input_tokens": 0, "output_tokens": 0},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        params = _make_params(workspace=self.workspace, provider=provider)
+
+        from src.query.query import query as query_gen
+        from src.query.transitions import TerminalHolder
+
+        async def consume_one_turn():
+            holder = TerminalHolder()
+            collected = []
+            with (
+                patch(
+                    "src.services.compact.autocompact.calculate_token_warning_state",
+                    return_value={
+                        "percent_left": 0,
+                        "is_above_warning_threshold": True,
+                        "is_above_error_threshold": True,
+                        "is_above_auto_compact_threshold": True,
+                        "is_at_blocking_limit": False,
+                    },
+                ),
+                patch(
+                    "src.services.compact.autocompact.is_auto_compact_enabled",
+                    return_value=True,
+                ),
+            ):
+                from src.services.compact.pipeline import PipelineConfig
+                params.pipeline_config = PipelineConfig(
+                    autocompact_tracking=AutoCompactTracking(
+                        consecutive_failures=3,
+                    ),
+                )
+                async for msg in query_gen(params, terminal_holder=holder):
+                    collected.append(msg)
+            return collected, holder.value
+
+        collected, terminal = _run(consume_one_turn())
+        self.assertEqual(terminal.reason, "blocking_limit")
+        api_errors = [
+            m for m in collected
+            if isinstance(m, AssistantMessage)
+            and getattr(m, "isApiErrorMessage", False)
+            and "automatic compaction" in str(getattr(m, "content", ""))
+        ]
+        self.assertGreaterEqual(len(api_errors), 1)
+        provider.chat.assert_not_called()
 
 
 class TestTerminalHolderDirectUsage(unittest.TestCase):


### PR DESCRIPTION
## Summary

PR **2 of 5** for chapter 5 (the agent loop). Stacks on #79. Wires the chapter-5 recovery ladder and token-budget integration into the canonical `query()` loop.

Five new terminal reasons become reachable: `prompt_too_long`, `image_error`, `blocking_limit` (×2 paths).

## What it adds

- **B.1 Withholding** — PTL, media-size, and max-output-tokens errors are withheld from the yielded stream so SDK consumers don't disconnect before recovery runs. `_call_model_sync` now routes errors through the typed `is_prompt_too_long_error` / `is_media_size_error` helpers.
- **B.2 PTL recovery** — on PTL/media error, loop calls `reactive_compact` (one-shot via `has_attempted_reactive_compact`). On success, retries with compacted messages. On failure or already-attempted, surfaces the withheld error and exits with `Terminal(reason="prompt_too_long" | "image_error")`. Regression test pins the "second PTL after successful recovery" case.
- **B.3 Context-collapse drain** — `ContextCollapseStore` gets `add_staged` / `drain_staged` / `staged_count`. New `recover_from_overflow` runs BEFORE `reactive_compact` on PTL; drains staged collapses and clears `isVirtual` so the projected summary reaches the API on retry.
- **B.4 Blocking-limit pre-emption** — checks `calculate_token_warning_state` before the API call. At the hard limit, yields a clean error and returns `Terminal(reason="blocking_limit")` without burning an API call.
- **B.5 Autocompact circuit-breaker** — after the compression pipeline, if `consecutive_failures >= 3` and context still above the autocompact threshold, returns `blocking_limit` with the chapter-quoted "automatic compaction has failed" message. Threads `AutoCompactTracking` through `PipelineConfig` so the failure count survives iterations.
- **D Token budget** — new `task_budget` field on `QueryParams`. `BudgetTracker` runs at loop entry; no-tool-use exit calls `check_token_budget` and on `ContinueDecision` injects a nudge and re-enters with `transition.reason="token_budget_continuation"`.

Also: `is_media_size_error` is now case-insensitive (the PDF-regex variant in particular needed the change) so callers don't have to normalize.

## Test plan

- [x] `tests/test_query_loop.py` (5)
- [x] `tests/test_query_terminal.py` (14) — extended with PTL recovery, image_error, blocking-limit, circuit-breaker, token-budget integration
- [x] `tests/test_query_phase_b3.py` (7) — NEW: staging round-trip, `recover_from_overflow` contract, drain-before-reactive-compact integration
- [x] `tests/test_query_error_recovery.py` (3)
- [x] `tests/test_query_engine.py` (9)
- [x] `tests/parity/test_query_state_parity.py` (18)
- [x] `tests/integration/test_query_integration.py` (5)
- [x] `tests/test_compression_pipeline.py` (12)
- [x] `tests/test_token_budget.py` (20)
- [x] `tests/test_reactive_compact.py` (18)

**111 tests pass.**

## Stack

PR 2 of 5. Depends on #79 (Phase A foundation). Follow-ups: PR 3 (hooks + fallback + nudge), PR 4 (deps + adapter), PR 5 (migration + cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)