### PR TITLE
feat(ch05/C+E): stop hooks, model fallback, continuation nudge

### DIFF
--- a/src/query/continuation_signals.py
+++ b/src/query/continuation_signals.py
@@ -1,0 +1,74 @@
+"""Continuation-nudge detection.
+
+Ported verbatim from TypeScript ``query.ts:1444-1505``. When the model
+finishes without tool calls but signals intent to continue (e.g.,
+"Let me now create the file"), the loop injects a polite nudge to
+keep working. Capped at ``MAX_CONTINUATION_NUDGES`` per turn.
+
+The regex set is deliberately tight: require explicit action verbs
+and exclude common explanatory phrasing to reduce false positives.
+Short-message-only patterns guard against false positives in
+explanatory prose.
+"""
+from __future__ import annotations
+
+import re
+
+MAX_CONTINUATION_NUDGES = 3
+
+# Action verbs that distinguish "I'll do X" from "I'll explain X".
+_ACTIONS = (
+    "do|create|write|edit|update|fix|implement|add|run|check|"
+    "make|build|set up"
+)
+
+# Always-on patterns (regardless of message length).
+SIGNALS_ANY_LENGTH = [
+    re.compile(
+        rf"\bso now (i|let me|we) (need to|have to|should|must|will) "
+        rf"({_ACTIONS})\b"
+    ),
+    re.compile(
+        rf"\bnow i('ll| will) ({_ACTIONS}|go|proceed)\b"
+    ),
+    re.compile(
+        rf"\blet me (go ahead and |now )?({_ACTIONS}|proceed)\b"
+    ),
+    re.compile(
+        rf"\btime to ({_ACTIONS}|get started|begin)\b"
+    ),
+]
+
+# Short-message-only patterns (avoid false positives in
+# explanatory text). Apply only when len(text) < 80.
+SIGNALS_SHORT_ONLY = [
+    re.compile(
+        rf"\b(i('ll| will| need to| have to| must) (now )?({_ACTIONS}))\b"
+    ),
+    re.compile(
+        rf"\bnext,?\s+(i('ll| will)|let me|i need to) ({_ACTIONS})\b"
+    ),
+]
+
+COMPLETION_MARKERS = re.compile(
+    r"\b(done|finished|completed|complete|summary|that's all|"
+    r"that is all|all set|hope this helps|let me know if)\b"
+)
+
+NUDGE_MESSAGE = "Continue with the task. Use the appropriate tools to proceed."
+
+
+def matches_continuation_signal(text: str) -> bool:
+    """Returns True if the text signals intent to continue without
+    tool calls, AND does not contain completion markers.
+
+    The text should already be lowercased by the caller.
+    """
+    if COMPLETION_MARKERS.search(text):
+        return False
+    if any(p.search(text) for p in SIGNALS_ANY_LENGTH):
+        return True
+    if len(text) < 80:
+        if any(p.search(text) for p in SIGNALS_SHORT_ONLY):
+            return True
+    return False

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -74,6 +74,10 @@ class QueryParams:
     # `check_token_budget` after each completion and may continue
     # with a nudge message until 90% of `total` is reached.
     task_budget: dict[str, int] | None = None
+    # Ch5/E.2: Fallback model for FallbackTriggeredError recovery.
+    # When the provider raises FallbackTriggeredError and this is
+    # set, the loop switches to this model and retries the request.
+    fallback_model: str | None = None
 
 
 @dataclass
@@ -226,6 +230,35 @@ def _get_context_window(provider: Any, model: str) -> int:
     return getattr(provider, "context_window", None) or 200_000
 
 
+def _extract_text(msg: AssistantMessage) -> str:
+    """Ch5/E.4: Join the text blocks of an AssistantMessage into a
+    single string. Used by the continuation-nudge detector."""
+    content = msg.content
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            text = getattr(block, "text", None)
+            if isinstance(text, str):
+                parts.append(text)
+        return " ".join(parts)
+    return ""
+
+
+def _matches_continuation_signal(text: str) -> bool:
+    """Indirection so tests / monkeypatching can override per-test."""
+    from .continuation_signals import matches_continuation_signal
+    return matches_continuation_signal(text)
+
+
+def _continuation_max_nudges() -> int:
+    """Module-level cap. Indirection lets a test bump or zero the cap
+    without monkeypatching the chapter-faithful constant."""
+    from .continuation_signals import MAX_CONTINUATION_NUDGES
+    return MAX_CONTINUATION_NUDGES
+
+
 async def _call_model_sync(
     *,
     provider: BaseProvider,
@@ -233,7 +266,11 @@ async def _call_model_sync(
     system_prompt: str,
     tools: Tools,
     max_output_tokens_override: int | None = None,
+    model: str | None = None,
 ) -> tuple[list[AssistantMessage], list[ToolUseBlock]]:
+    # Ch5/E.2: optional `model` override. When set, passed through to
+    # the provider as a `model` kwarg so the attempt-with-fallback
+    # loop can switch backends without rebuilding the provider.
     from ..types.messages import normalize_messages_for_api
 
     api_messages = normalize_messages_for_api(messages)
@@ -326,6 +363,11 @@ async def _call_model_sync(
     if max_output_tokens_override is not None:
         call_kwargs["max_tokens"] = max_output_tokens_override
 
+    if model is not None:
+        # Ch5/E.2: backend model override. Providers that don't
+        # consume `model` will ignore the kwarg via **kwargs.
+        call_kwargs["model"] = model
+
     # TS callModel() uses SSE streaming for faster first-byte latency and
     # progressive text display.  Use chat_stream_response() which streams
     # internally and reassembles the full ChatResponse.  Fall back to the
@@ -342,6 +384,12 @@ async def _call_model_sync(
     except Exception as e:
         if _diag:
             logger.warning("[DIAG] _call_model_sync: EXCEPTION after %.1fs: %s", time.monotonic() - _t0, e)
+        # FallbackTriggeredError must propagate so the outer loop's
+        # attempt-with-fallback catch site can switch the model and retry.
+        from ..services.api.errors import FallbackTriggeredError
+        if isinstance(e, FallbackTriggeredError):
+            raise
+
         error_str = str(e)
         # Ch5/B.1: route through the typed helpers so PTL / media-size
         # detection is consistent with the rest of the codebase.
@@ -842,14 +890,48 @@ async def query(
         tool_use_blocks: list[ToolUseBlock] = []
         needs_follow_up = False
 
+        # Ch5/E.2: attempt-with-fallback loop. If the provider raises
+        # FallbackTriggeredError and params.fallback_model is set,
+        # switch model and retry. Mirrors TS query.ts:727-1029.
+        attempt_with_fallback = True
+        current_model: str | None = None  # provider's default on first try
         try:
-            returned_assistants, returned_tool_blocks = await _call_model_sync(
-                provider=params.provider,
-                messages=messages,
-                system_prompt=params.system_prompt,
-                tools=params.tools,
-                max_output_tokens_override=max_output_tokens_override,
-            )
+            while attempt_with_fallback:
+                attempt_with_fallback = False
+                try:
+                    returned_assistants, returned_tool_blocks = await _call_model_sync(
+                        provider=params.provider,
+                        messages=messages,
+                        system_prompt=params.system_prompt,
+                        tools=params.tools,
+                        max_output_tokens_override=max_output_tokens_override,
+                        model=current_model,
+                    )
+                except Exception as inner_e:
+                    from ..services.api.errors import FallbackTriggeredError
+                    if (
+                        isinstance(inner_e, FallbackTriggeredError)
+                        and params.fallback_model
+                    ):
+                        current_model = params.fallback_model
+                        attempt_with_fallback = True
+                        # Ch5/E.5: _call_model_sync is sync-from-the-loop's-POV
+                        # (returns a complete list) and does not stream
+                        # partial assistants. There's nothing to tombstone
+                        # here; clear local state and emit the warning.
+                        # (Full streaming-executor port is a separate ticket.)
+                        assistant_messages = []
+                        tool_use_blocks = []
+                        needs_follow_up = False
+                        from ..types.messages import create_system_message
+                        yield create_system_message(
+                            f"Switched to {inner_e.fallback_model} due to "
+                            f"high demand for {inner_e.original_model}",
+                            level="warning",
+                        )
+                        continue  # while attempt_with_fallback
+                    raise
+
             assistant_messages = returned_assistants
             tool_use_blocks = returned_tool_blocks
             needs_follow_up = len(tool_use_blocks) > 0
@@ -1047,12 +1129,93 @@ async def query(
                 yield last_message  # type: ignore[arg-type]
 
             if last_message and getattr(last_message, "isApiErrorMessage", False):
-                # Death-spiral guard: when the last message is an API
-                # error, do NOT run any subsequent hooks/checks (the
-                # model never produced a real response). Mirrors TS
+                # Ch5/C.3 death-spiral guard: skip stop hooks when the
+                # last message is an API error. The model never produced
+                # a real response — hooks evaluating it create a death
+                # spiral: error → hook blocking → retry → error → … (the
+                # hook injects more tokens each cycle). Mirrors TS
                 # query.ts:1341-1344.
                 set_terminal(holder, natural_termination, Terminal(reason="completed"))
                 return
+
+            # Ch5/C.1: Stop hooks. Fire only when the model finished
+            # without tool use AND not on an API-error short-circuit.
+            # Uses the streaming variant so progress/attachment messages
+            # reach the consumer in real time, matching TS query.ts:1346-1355.
+            if config.stop_hooks_enabled:
+                try:
+                    from .stop_hooks import (
+                        StopHookResult as _StopHookResult,
+                        handle_stop_hooks_streaming,
+                    )
+
+                    # Coerce block-list system_prompt to str for the
+                    # hook context (hook executors don't consume the
+                    # cache-control markers — they just see the text).
+                    sp_for_hook: str
+                    if isinstance(params.system_prompt, str):
+                        sp_for_hook = params.system_prompt
+                    elif isinstance(params.system_prompt, list):
+                        sp_for_hook = "\n\n".join(
+                            str(b.get("text", "")) for b in params.system_prompt
+                            if isinstance(b, dict)
+                        )
+                    else:
+                        sp_for_hook = str(params.system_prompt)
+
+                    stop_result: _StopHookResult | None = None
+                    async for emitted in handle_stop_hooks_streaming(
+                        messages_for_query=messages,
+                        assistant_messages=assistant_messages,
+                        system_prompt=sp_for_hook,
+                        tool_use_context=tool_use_context,
+                        query_source=params.query_source,
+                        stop_hook_active=state.stop_hook_active,
+                        user_context=params.user_context,
+                        system_context=params.system_context,
+                    ):
+                        if isinstance(emitted, _StopHookResult):
+                            stop_result = emitted
+                        else:
+                            yield emitted
+                except Exception:
+                    logger.exception("Stop hook integration failed; treating as no-op")
+                    stop_result = None
+
+                if stop_result is not None:
+                    if stop_result.prevent_continuation:
+                        set_terminal(
+                            holder,
+                            natural_termination,
+                            Terminal(reason="stop_hook_prevented"),
+                        )
+                        return
+
+                    if stop_result.blocking_errors:
+                        # Ch5/C.4: Preserve has_attempted_reactive_compact
+                        # across stop-hook retries. Resetting to False
+                        # caused an infinite loop in TS (chapter line 337):
+                        # compact → still too long → error → stop hook
+                        # blocking → compact → ... burning thousands of
+                        # API calls.
+                        state = QueryState(
+                            messages=[
+                                *messages,
+                                *assistant_messages,
+                                *stop_result.blocking_errors,
+                            ],
+                            tool_use_context=tool_use_context,
+                            auto_compact_tracking=state.auto_compact_tracking,
+                            max_output_tokens_recovery_count=0,
+                            has_attempted_reactive_compact=has_attempted_reactive_compact,
+                            max_output_tokens_override=None,
+                            stop_hook_active=True,  # Ch5/C.2: suppress re-firing
+                            turn_count=turn_count,
+                            continuation_nudge_count=state.continuation_nudge_count,
+                            pending_tool_use_summary=None,
+                            transition=Transition(reason="stop_hook_blocking"),
+                        )
+                        continue
 
             # Ch5/D.2: Token budget check. If task_budget is set and we
             # haven't yet exhausted 90% of `total`, inject a nudge
@@ -1086,6 +1249,36 @@ async def query(
                         continuation_nudge_count=state.continuation_nudge_count,
                         pending_tool_use_summary=None,
                         transition=Transition(reason="token_budget_continuation"),
+                    )
+                    continue
+
+            # Ch5/E.4: continuation nudge. Runs AFTER the budget check
+            # declined to continue. Detects "I'll do X" / "let me Y"
+            # signals when the model returned no tool calls, and injects
+            # a polite nudge to keep working. Capped at
+            # MAX_CONTINUATION_NUDGES per turn to prevent infinite loops.
+            if (
+                assistant_messages
+                and turn_count < (params.max_turns or float("inf"))
+                and state.continuation_nudge_count
+                < _continuation_max_nudges()
+            ):
+                last_text = _extract_text(assistant_messages[-1]).lower()
+                if _matches_continuation_signal(last_text):
+                    from .continuation_signals import NUDGE_MESSAGE
+                    nudge = _create_user_message(NUDGE_MESSAGE, is_meta=True)
+                    state = QueryState(
+                        messages=[*messages, *assistant_messages, nudge],
+                        tool_use_context=tool_use_context,
+                        auto_compact_tracking=state.auto_compact_tracking,
+                        max_output_tokens_recovery_count=0,
+                        has_attempted_reactive_compact=False,
+                        max_output_tokens_override=None,
+                        stop_hook_active=None,
+                        turn_count=turn_count,
+                        continuation_nudge_count=state.continuation_nudge_count + 1,
+                        pending_tool_use_summary=None,
+                        transition=Transition(reason="continuation_nudge"),
                     )
                     continue
 

--- a/src/query/stop_hooks.py
+++ b/src/query/stop_hooks.py
@@ -70,7 +70,13 @@ async def handle_stop_hooks_streaming(
     tool_use_context: Any,
     query_source: str,
     stop_hook_active: bool | None = None,
+    **_future_kwargs: Any,  # Ch5/C.1: user_context/system_context etc.
 ) -> AsyncGenerator[Message | StopHookResult, None]:
+    # ``_future_kwargs`` captures user_context/system_context (and any
+    # similar additions) so callers can pass them for signature
+    # symmetry with handle_stop_hooks (non-streaming). The underlying
+    # _handle_stop_hooks_generator does not consume them today; they
+    # are reserved for future template-aware hooks.
     result = StopHookResult()
 
     async for msg in _handle_stop_hooks_generator(

--- a/tests/test_query_phase_e.py
+++ b/tests/test_query_phase_e.py
@@ -1,0 +1,234 @@
+"""Phase E acceptance tests: model fallback (E.1-E.3, E.5) and
+continuation nudge (E.4).
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from src.providers.base import ChatResponse
+from src.query.continuation_signals import (
+    MAX_CONTINUATION_NUDGES,
+    matches_continuation_signal,
+)
+from src.query.query import QueryParams, run_query
+from src.query.transitions import Terminal
+from src.services.api.errors import FallbackTriggeredError
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.types.messages import AssistantMessage, SystemMessage, UserMessage
+from src.utils.abort_controller import AbortController
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_params(workspace: Path, provider: MagicMock, **kwargs) -> QueryParams:
+    registry = build_default_registry()
+    context = ToolContext(workspace_root=workspace)
+    return QueryParams(
+        messages=[UserMessage(content="Hi")],
+        system_prompt="You are helpful.",
+        tools=registry.list_tools(),
+        tool_registry=registry,
+        tool_use_context=context,
+        provider=provider,
+        abort_controller=AbortController(),
+        max_turns=kwargs.pop("max_turns", 10),
+        **kwargs,
+    )
+
+
+# --- E.4: continuation signal regex tests --------------------------
+
+
+class TestContinuationSignals(unittest.TestCase):
+    """Unit tests for the regex set in continuation_signals."""
+
+    def test_so_now_i_need_to_action_matches(self):
+        self.assertTrue(matches_continuation_signal("so now i need to write the file"))
+
+    def test_now_ill_action_matches(self):
+        self.assertTrue(matches_continuation_signal("now i'll create the file"))
+
+    def test_let_me_action_matches(self):
+        self.assertTrue(matches_continuation_signal("let me update the config"))
+
+    def test_time_to_action_matches(self):
+        self.assertTrue(matches_continuation_signal("time to begin"))
+
+    def test_completion_marker_suppresses(self):
+        self.assertFalse(matches_continuation_signal(
+            "let me write the file. that's all done now."
+        ))
+
+    def test_explanatory_text_does_not_match(self):
+        self.assertFalse(matches_continuation_signal(
+            "the function will read the file and parse the contents"
+        ))
+
+    def test_short_pattern_only_for_short_text(self):
+        self.assertTrue(matches_continuation_signal("i'll write the file."))
+        long_text = "here is a long explanation. " * 5 + "i'll write the file."
+        self.assertFalse(matches_continuation_signal(long_text))
+
+
+# --- E.4: continuation nudge integration ---------------------------
+
+
+class TestContinuationNudgeIntegration(unittest.TestCase):
+    """The loop injects a nudge user message when a continuation
+    signal fires; capped at MAX_CONTINUATION_NUDGES."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_nudge_fires_on_continuation_signal(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = [
+            ChatResponse(
+                content="let me now write the file",
+                model="test",
+                usage={"input_tokens": 5, "output_tokens": 6},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+            ChatResponse(
+                content="Done.",
+                model="test",
+                usage={"input_tokens": 8, "output_tokens": 2},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+        ]
+
+        params = _make_params(self.workspace, provider)
+        _, terminal = _run(run_query(params))
+
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(provider.chat.call_count, 2)
+
+        second_call_messages = provider.chat.call_args_list[1].args[0]
+        nudges = [
+            msg for msg in second_call_messages
+            if msg.get("role") == "user"
+            and "Continue with the task" in str(msg.get("content", ""))
+        ]
+        self.assertGreaterEqual(len(nudges), 1)
+
+    def test_nudge_capped_at_max(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="let me now write the file",
+            model="test",
+            usage={"input_tokens": 5, "output_tokens": 6},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        params = _make_params(
+            self.workspace, provider, max_turns=MAX_CONTINUATION_NUDGES + 5,
+        )
+        _, terminal = _run(run_query(params))
+
+        self.assertEqual(
+            provider.chat.call_count, MAX_CONTINUATION_NUDGES + 1,
+            f"Expected {MAX_CONTINUATION_NUDGES + 1} calls; got {provider.chat.call_count}",
+        )
+        self.assertEqual(terminal.reason, "completed")
+
+    def test_completion_marker_suppresses_nudge(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="let me show you the result. all done.",
+            model="test",
+            usage={"input_tokens": 5, "output_tokens": 8},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        params = _make_params(self.workspace, provider)
+        _, terminal = _run(run_query(params))
+
+        self.assertEqual(provider.chat.call_count, 1)
+        self.assertEqual(terminal.reason, "completed")
+
+
+# --- E.1-E.2-E.5: model fallback integration -----------------------
+
+
+class TestModelFallback(unittest.TestCase):
+    """When FallbackTriggeredError is raised and params.fallback_model
+    is set, the loop switches model and retries the request."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_fallback_switches_model_and_retries(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = [
+            FallbackTriggeredError(
+                original_model="claude-opus-4-7",
+                fallback_model="claude-sonnet-4-6",
+            ),
+            ChatResponse(
+                content="Done from fallback.",
+                model="claude-sonnet-4-6",
+                usage={"input_tokens": 5, "output_tokens": 3},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+        ]
+
+        params = _make_params(
+            self.workspace, provider, fallback_model="claude-sonnet-4-6",
+        )
+        messages, terminal = _run(run_query(params))
+
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(provider.chat.call_count, 2)
+
+        system_msgs = [
+            m for m in messages
+            if isinstance(m, SystemMessage)
+            and "Switched to" in str(m.content)
+        ]
+        self.assertGreaterEqual(len(system_msgs), 1)
+
+        second_call = provider.chat.call_args_list[1]
+        passed_model = second_call.kwargs.get("model")
+        self.assertEqual(passed_model, "claude-sonnet-4-6")
+
+    def test_no_fallback_model_propagates_error(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = FallbackTriggeredError(
+            original_model="opus",
+            fallback_model="sonnet",
+        )
+
+        params = _make_params(self.workspace, provider)
+        _, terminal = _run(run_query(params))
+
+        self.assertEqual(terminal.reason, "model_error")
+        self.assertIsInstance(terminal.error, FallbackTriggeredError)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_query_stop_hooks_integration.py
+++ b/tests/test_query_stop_hooks_integration.py
@@ -1,0 +1,388 @@
+"""Phase C acceptance tests: stop hooks fire from query() at no-tool-use exit.
+
+Covers:
+- C.1: handle_stop_hooks_streaming is invoked when needs_follow_up=False
+- C.1: prevent_continuation → Terminal(reason="stop_hook_prevented")
+- C.1: blocking_errors → loop continues with stop_hook_active=True
+- C.2: stop_hook_active passed on retry
+- C.3: skip stop hooks when last message is API error (twice: PTL path + generic)
+- C.4: preserve has_attempted_reactive_compact across stop-hook retry
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.providers.base import ChatResponse
+from src.query.query import QueryParams, run_query
+from src.query.transitions import Terminal
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.types.messages import AssistantMessage, UserMessage
+from src.utils.abort_controller import AbortController
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_params(workspace: Path, provider: MagicMock, max_turns: int = 10) -> QueryParams:
+    registry = build_default_registry()
+    context = ToolContext(workspace_root=workspace)
+    return QueryParams(
+        messages=[UserMessage(content="Hi")],
+        system_prompt="You are helpful.",
+        tools=registry.list_tools(),
+        tool_registry=registry,
+        tool_use_context=context,
+        provider=provider,
+        abort_controller=AbortController(),
+        max_turns=max_turns,
+    )
+
+
+class TestStopHookPreventContinuation(unittest.TestCase):
+    """C.1: prevent_continuation hooks return Terminal(stop_hook_prevented)."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_prevent_continuation_returns_stop_hook_prevented(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="I'm done.",
+            model="test",
+            usage={"input_tokens": 5, "output_tokens": 5},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        from src.query.stop_hooks import StopHookResult
+
+        async def fake_streaming(*args, **kwargs):
+            yield StopHookResult(blocking_errors=[], prevent_continuation=True)
+
+        params = _make_params(self.workspace, provider)
+        with patch(
+            "src.query.stop_hooks.handle_stop_hooks_streaming",
+            side_effect=lambda *a, **kw: fake_streaming(*a, **kw),
+        ):
+            _, terminal = _run(run_query(params))
+        self.assertEqual(terminal.reason, "stop_hook_prevented")
+
+
+class TestStopHookBlockingErrors(unittest.TestCase):
+    """C.1: blocking_errors trigger a retry with stop_hook_active=True."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_blocking_errors_retry_then_complete(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = [
+            ChatResponse(
+                content="I'm done.",
+                model="test",
+                usage={"input_tokens": 5, "output_tokens": 5},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+            ChatResponse(
+                content="Fixed the lint issue.",
+                model="test",
+                usage={"input_tokens": 5, "output_tokens": 5},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+        ]
+
+        from src.query.stop_hooks import StopHookResult
+        call_count = {"n": 0}
+
+        async def fake_streaming(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                err_msg = UserMessage(content="Lint says fix line 42", isMeta=True)
+                yield StopHookResult(
+                    blocking_errors=[err_msg],
+                    prevent_continuation=False,
+                )
+            else:
+                yield StopHookResult(blocking_errors=[], prevent_continuation=False)
+
+        params = _make_params(self.workspace, provider)
+        with patch(
+            "src.query.stop_hooks.handle_stop_hooks_streaming",
+            side_effect=lambda *a, **kw: fake_streaming(*a, **kw),
+        ):
+            _, terminal = _run(run_query(params))
+
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(provider.chat.call_count, 2)
+        self.assertEqual(call_count["n"], 2)
+
+
+class TestStopHookActiveFlag(unittest.TestCase):
+    """C.2: stop_hook_active=True passed on retry."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_stop_hook_active_set_on_retry(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = [
+            ChatResponse(
+                content="Done.",
+                model="test",
+                usage={"input_tokens": 5, "output_tokens": 5},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+            ChatResponse(
+                content="Done again.",
+                model="test",
+                usage={"input_tokens": 5, "output_tokens": 5},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+        ]
+
+        from src.query.stop_hooks import StopHookResult
+        call_count = {"n": 0}
+        observed_flags: list[bool | None] = []
+
+        async def fake_streaming(*args, **kwargs):
+            call_count["n"] += 1
+            observed_flags.append(kwargs.get("stop_hook_active"))
+            if call_count["n"] == 1:
+                err = UserMessage(content="blocked", isMeta=True)
+                yield StopHookResult(
+                    blocking_errors=[err],
+                    prevent_continuation=False,
+                )
+            else:
+                yield StopHookResult(blocking_errors=[], prevent_continuation=False)
+
+        params = _make_params(self.workspace, provider)
+        with patch(
+            "src.query.stop_hooks.handle_stop_hooks_streaming",
+            side_effect=lambda *a, **kw: fake_streaming(*a, **kw),
+        ):
+            _run(run_query(params))
+
+        self.assertEqual(len(observed_flags), 2)
+        self.assertIn(observed_flags[0], (None, False))
+        self.assertTrue(observed_flags[1])
+
+
+class TestStopHookSkippedOnApiError(unittest.TestCase):
+    """C.3: when last message is API error (PTL exhaustion path),
+    stop hooks must NOT fire."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_api_error_skips_stop_hooks(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = RuntimeError("Prompt is too long.")
+
+        from src.services.compact.reactive_compact import ReactiveCompactResult
+
+        async def fail_rc(**kwargs):
+            return ReactiveCompactResult(
+                compacted=False,
+                messages=kwargs["messages"],
+                tokens_before=1000,
+                error="mocked",
+            )
+
+        invoked = {"n": 0}
+
+        async def fake_streaming(*args, **kwargs):
+            invoked["n"] += 1
+            from src.query.stop_hooks import StopHookResult
+            yield StopHookResult(blocking_errors=[], prevent_continuation=False)
+
+        params = _make_params(self.workspace, provider)
+        with (
+            patch(
+                "src.services.compact.reactive_compact.reactive_compact",
+                side_effect=fail_rc,
+            ),
+            patch(
+                "src.query.stop_hooks.handle_stop_hooks_streaming",
+                side_effect=lambda *a, **kw: fake_streaming(*a, **kw),
+            ),
+        ):
+            _, terminal = _run(run_query(params))
+
+        self.assertEqual(terminal.reason, "prompt_too_long")
+        self.assertEqual(invoked["n"], 0)
+
+
+class TestStopHookPreservesReactiveCompactFlag(unittest.TestCase):
+    """C.4: has_attempted_reactive_compact is NOT reset on blocking-error retry."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_reactive_compact_flag_preserved_across_stop_hook_retry(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = [
+            RuntimeError("Prompt is too long."),
+            ChatResponse(
+                content="Done.",
+                model="test",
+                usage={"input_tokens": 5, "output_tokens": 5},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+            RuntimeError("Prompt is too long."),
+        ]
+
+        from src.services.compact.reactive_compact import ReactiveCompactResult
+
+        async def succeed_rc(**kwargs):
+            return ReactiveCompactResult(
+                compacted=True,
+                messages=[UserMessage(content="summarized")],
+                tokens_before=1000,
+                tokens_after=200,
+            )
+
+        hook_calls = {"n": 0}
+
+        async def fake_streaming(*args, **kwargs):
+            from src.query.stop_hooks import StopHookResult
+            hook_calls["n"] += 1
+            if hook_calls["n"] == 1:
+                yield StopHookResult(
+                    blocking_errors=[UserMessage(content="lint", isMeta=True)],
+                    prevent_continuation=False,
+                )
+            else:
+                yield StopHookResult(blocking_errors=[], prevent_continuation=False)
+
+        rc_mock = MagicMock(side_effect=succeed_rc)
+
+        params = _make_params(self.workspace, provider)
+        with (
+            patch(
+                "src.services.compact.reactive_compact.reactive_compact",
+                new=rc_mock,
+            ),
+            patch(
+                "src.query.stop_hooks.handle_stop_hooks_streaming",
+                side_effect=lambda *a, **kw: fake_streaming(*a, **kw),
+            ),
+        ):
+            _, terminal = _run(run_query(params))
+
+        # Turn 3's PTL surfaces as prompt_too_long (no re-attempted
+        # reactive_compact). reactive_compact was called exactly ONCE.
+        self.assertEqual(rc_mock.call_count, 1)
+        self.assertEqual(terminal.reason, "prompt_too_long")
+
+
+class TestStopHookSkippedOnGenericApiError(unittest.TestCase):
+    """C.3 part 2: when last_message is an API error for ANY reason
+    (not just PTL exhaustion), stop hooks must NOT fire."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_invalid_request_api_error_skips_stop_hooks(self):
+        # Synthesize an AssistantMessage flagged isApiErrorMessage=True
+        # via a fake provider whose `chat` returns a response that
+        # makes _call_model_sync emit such a message. Easiest path:
+        # raise a generic exception, which the outer handler turns into
+        # an api-error AssistantMessage and exits as model_error.
+        #
+        # The model_error path actually exits BEFORE reaching the
+        # no-tool-use branch — so we instead simulate a different path
+        # by mocking the loop to produce an empty-content assistant
+        # message that's marked isApiErrorMessage=True via a custom
+        # provider-side path. Simplest: trip the PTL recovery
+        # exhaustion (which yields the withheld error). That's what
+        # TestStopHookSkippedOnApiError above already covers. This
+        # test pins a parallel path: when the final message has
+        # isApiErrorMessage=True from a non-PTL cause.
+        #
+        # We patch _call_model_sync directly to return such a message.
+        from src.types.content_blocks import TextBlock
+
+        async def fake_api_error_call(**kwargs):
+            err = AssistantMessage(
+                content=[TextBlock(text="API rejected the request.")],
+                isApiErrorMessage=True,
+            )
+            err._api_error = "invalid_request"  # type: ignore[attr-defined]
+            return [err], []
+
+        invoked = {"n": 0}
+
+        async def fake_streaming(*args, **kwargs):
+            from src.query.stop_hooks import StopHookResult
+            invoked["n"] += 1
+            yield StopHookResult(blocking_errors=[], prevent_continuation=False)
+
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = AssertionError(
+            "real provider must not be called",
+        )
+
+        params = _make_params(self.workspace, provider)
+
+        with (
+            patch(
+                "src.query.query._call_model_sync",
+                side_effect=fake_api_error_call,
+            ),
+            patch(
+                "src.query.stop_hooks.handle_stop_hooks_streaming",
+                side_effect=lambda *a, **kw: fake_streaming(*a, **kw),
+            ),
+        ):
+            _, terminal = _run(run_query(params))
+
+        # Terminal is "completed" per chapter §"Death Spiral Guard"
+        # (API error → skip stop hooks → return completed). The
+        # important assertion is that the hook never fired.
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(invoked["n"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR **3 of 5** for chapter 5 (the agent loop). Stacks on #80. Wires three user-visible features into the canonical `query()` loop.

Adds the `stop_hook_prevented` terminal reason (1 more of the 10).

## What it adds

**Phase C — Stop hooks integration:**
- Calls `handle_stop_hooks_streaming` at the no-tool-use exit (after recovery and after the API-error short-circuit). Forwards yielded messages/attachments live.
- `prevent_continuation` → `Terminal(reason="stop_hook_prevented")`.
- `blocking_errors` → state rebuild with `stop_hook_active=True` and `transition=stop_hook_blocking`, then continue. **Preserves `has_attempted_reactive_compact` across the retry** — chapter §"Death Spiral Guard": resetting to `False` burns thousands of API calls.
- C.3 death-spiral guard: when last message is an API error, skip hooks entirely.
- Extends `handle_stop_hooks_streaming` with `**_future_kwargs` so the user/system_context call sites compile.

**Phase E — Model fallback + continuation nudge:**
- Adds `fallback_model` field to `QueryParams`; adds `model` kwarg to `_call_model_sync` (passed through to provider).
- Wraps `_call_model_sync` in an attempt-with-fallback `while` loop. On `FallbackTriggeredError` + `params.fallback_model`, switches model and retries. Re-raises `FallbackTriggeredError` from `_call_model_sync`'s generic exception handler so the wrapper catches it.
- On fallback: emits a user-visible warning system message ("Switched to X due to high demand for Y"). Streaming-executor port is a separate ticket, so no partials to tombstone today.
- New `src/query/continuation_signals.py` with the verbatim TS regex set. Public `matches_continuation_signal()`.
- Continuation-nudge dispatch in `query.py` AFTER the budget check declines to continue. Capped at `MAX_CONTINUATION_NUDGES=3`. `transition=continuation_nudge`.

## Test plan

- [x] `tests/test_query_loop.py` (5)
- [x] `tests/test_query_terminal.py` (14)
- [x] `tests/test_query_phase_b3.py` (7)
- [x] `tests/test_query_stop_hooks_integration.py` (6) — NEW: prevent_continuation, blocking_errors retry, stop_hook_active flag, two flavors of API-error skip, has_attempted_reactive_compact preservation across retry
- [x] `tests/test_query_phase_e.py` (12) — NEW: 7 continuation-signal unit + 3 nudge integration + 2 model-fallback integration
- [x] `tests/test_query_error_recovery.py` (3)
- [x] `tests/test_query_engine.py` (9)
- [x] `tests/parity/test_query_state_parity.py` (18)
- [x] `tests/integration/test_query_integration.py` (5)

**79 tests pass.**

## Stack

PR 3 of 5. Depends on #80 (recovery + budget). Follow-ups: PR 4 (deps + adapter), PR 5 (migration + cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)