### PR TITLE
feat(bootstrap): ch02 Phase 1 — memoized init() + trust boundary

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -97,24 +97,40 @@ def main():
     if args.config:
         return show_config()
 
+    # Plan-phase-1 wiring (ch02-bootstrap-refactoring-plan.md P1.5):
+    # ``run_pre_action(args)`` is the Python analog of Commander's
+    # ``preAction`` hook. It runs the memoized ``init()`` (chapter
+    # phase 2 — safe env vars + graceful-shutdown + API preconnect)
+    # and mutates interactive bootstrap state.
+    #
+    # MUST PRECEDE ``_resolve_permission_state`` so init-side env-var
+    # application can affect permission resolution. ``--version`` /
+    # ``--config`` short-circuit above, so the chapter's
+    # "fast paths skip init" property is preserved.
+    #
+    # The API-preconnect call previously lived here at module level;
+    # it now runs inside ``init()`` so it overlaps with any callers
+    # of ``init()`` (REPL, headless, etc.), not just the cli.py path.
+    profile_checkpoint("phase0_end_phase2_start")
+    from src.init import run_pre_action
+    run_pre_action(args)
+    profile_checkpoint("phase2_end_phase3_start")
+
     # Resolve permission state ONCE here so all modes (print/TUI/REPL) honor
     # ``--dangerously-skip-permissions`` consistently. Mirrors
     # ``typescript/src/main.tsx:1383-1389``.
     _resolve_permission_state(args)
     profile_checkpoint("permissions_resolved")
-
-    # WI-4.5: fire a HEAD request to the Anthropic API endpoint in the
-    # background to warm DNS/TLS while we finish CLI setup. Mirrors TS's
-    # ``preconnectAnthropicApi()`` early-call in ``main.tsx``. Skipped when
-    # a proxy or custom base URL is configured (see
-    # ``utils/api_preconnect.py:should_skip_preconnect``). The worker
-    # thread has its own try/except, so we don't wrap the call here —
-    # ``ImportError`` should surface visibly during dev.
-    from src.utils.api_preconnect import start_api_preconnect
-    start_api_preconnect()
+    profile_checkpoint("phase3_end_phase4_start")
 
     if args.print:
         profile_checkpoint("mode_dispatch_print")
+        # ``phase4_dispatch``: launcher has chosen a mode and is about
+        # to call the mode runner. Not the same as "first render" — the
+        # mode runner is the one that paints. Per-mode first-render
+        # checkpoints are plan phase 2 work (would need a callback
+        # inside each runner).
+        profile_checkpoint("phase4_dispatch")
         return _run_print_mode(args)
 
     # Interactive path: decide between the Textual TUI (new default) and the
@@ -129,9 +145,11 @@ def main():
 
     if should_use_tui(explicit_tui):
         profile_checkpoint("mode_dispatch_tui")
+        profile_checkpoint("phase4_dispatch")
         return _run_tui_mode(args)
 
     profile_checkpoint("mode_dispatch_repl")
+    profile_checkpoint("phase4_dispatch")
     return start_repl(
         stream=args.stream,
         permission_mode=args._resolved_permission_mode,

--- a/src/entrypoints/tui.py
+++ b/src/entrypoints/tui.py
@@ -58,13 +58,12 @@ def run_tui(options: TUIOptions) -> int:
             2,
         )
 
-    # Match typescript/src/bootstrap/state.ts: tool gating like
-    # ``isTodoV2Enabled()`` reads this flag, so set it BEFORE we build the
-    # registry.
-    from src.bootstrap.state import set_is_interactive
-
-    set_is_interactive(True)
-
+    # ``is_interactive`` is set during bootstrap phase 2 by
+    # ``src.init.run_pre_action`` (called from ``cli.main``) before any
+    # entry point runs. Previously we set it here too, but that was the
+    # M7.1 gap closed in plan phase 1 of ch02-bootstrap. The TUI
+    # entrypoint can rely on ``get_is_interactive()`` already being
+    # ``True`` by the time this function runs.
     workspace_root = options.workspace_root or Path.cwd()
 
     # Build provider ------------------------------------------------------

--- a/src/init.py
+++ b/src/init.py
@@ -1,0 +1,181 @@
+"""Bootstrap init — chapter phase 2 of the bootstrap pipeline.
+
+Mirrors ``typescript/src/entrypoints/init.ts``. The memoize property is
+load-bearing: multiple entry points (REPL, headless, MCP fast-path if
+it grows to need init) may each call ``init()``, and each call must
+observe an already-initialized environment without re-running the
+substeps. ``functools.cache`` is the canonical memoize.
+
+See:
+  - ``claude-code-from-source/book/ch02-bootstrap.md`` §"Phase 2"
+  - ``my-docs/ch02-bootstrap-gap-analysis.md`` §2 Phase 2
+  - ``my-docs/ch02-bootstrap-refactoring-plan.md`` P1.3-P1.6
+
+Architectural split
+-------------------
+
+``init()`` is the per-process idempotent setup (memoized, no args).
+``run_pre_action(args)`` is the per-invocation hook (called from
+``cli.main()`` after argparse, takes ``args`` so future flag-handling
+like ``--bare`` can branch on CLI flags without leaking into init).
+This split mirrors TS's separation of ``init()`` (called from
+Commander's ``preAction`` hook) and the action-handler body that runs
+per-command.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from functools import cache
+
+from src.permissions.trust_boundary import (
+    apply_safe_config_environment_variables,
+)
+from src.utils.api_preconnect import start_api_preconnect
+from src.utils.graceful_shutdown import (
+    register_cleanup,  # noqa: F401 — exposed for callers to register cleanups
+    setup_graceful_shutdown,
+)
+from src.utils.startup_profiler import profile_checkpoint
+
+__all__ = [
+    "init",
+    "run_pre_action",
+    "reset_init_for_test_only",
+]
+
+
+_logger = logging.getLogger("clawcodex.init")
+
+
+@cache
+def init() -> None:
+    """Bootstrap initialization. Idempotent across multiple callers.
+
+    Substeps (each profiled):
+    1. ``apply_safe_config_environment_variables`` — pre-trust env subset.
+    2. ``setup_graceful_shutdown`` — SIGINT/SIGTERM handlers.
+    3. ``start_api_preconnect`` — DNS+TLS warmup (moved from cli.main).
+    4. Placeholder for plan-phase-2: remote-managed-settings init.
+    5. Placeholder for plan-phase-2: policy-limits init.
+
+    The placeholder substeps are no-ops for plan phase 1; they exist
+    to mark the seam where future work plugs in.
+    """
+    profile_checkpoint("init_function_start")
+    _logger.info("init: applying safe env vars")
+    apply_safe_config_environment_variables()
+    profile_checkpoint("init_safe_env_vars_applied")
+
+    _logger.info("init: setting up graceful shutdown")
+    setup_graceful_shutdown()
+    profile_checkpoint("init_after_graceful_shutdown")
+
+    _logger.info("init: starting API preconnect")
+    start_api_preconnect()
+    profile_checkpoint("init_after_api_preconnect")
+
+    _placeholder_initialize_remote_managed_settings()
+    _placeholder_initialize_policy_limits()
+    profile_checkpoint("init_function_end")
+
+
+def _placeholder_initialize_remote_managed_settings() -> None:
+    """No-op. Plan phase 2 will wire remote-managed-settings here."""
+
+
+def _placeholder_initialize_policy_limits() -> None:
+    """No-op. Plan phase 2 will wire policy-limits service here."""
+
+
+def run_pre_action(args: object) -> None:
+    """Python analog of Commander's ``preAction`` hook.
+
+    Called from ``cli.main()`` after argparse parses, before
+    ``_resolve_permission_state`` and mode dispatch. Mirrors the
+    ``program.hook('preAction', ...)`` pattern at
+    ``typescript/src/main.tsx:911``.
+
+    The split between ``init()`` and ``run_pre_action()`` exists
+    because:
+
+    * ``init()`` is meant to be called from multiple entry points
+      (each one calls it once; memoize handles dedup).
+    * ``run_pre_action`` takes ``args`` so per-invocation flag handling
+      (e.g., future ``--bare`` env injection) can branch on CLI flags
+      without leaking into ``init()``.
+    """
+    profile_checkpoint("pre_action_start")
+    init()
+    profile_checkpoint("pre_action_after_init")
+
+    # P1.6: interactive bootstrap state mutators move into preAction
+    # so subsystems that read ``get_is_interactive()`` during init or
+    # setup see the right value. Lazy import to avoid bootstrap state
+    # being pulled in by ``init.py``-importers that only want ``init``.
+    from src.bootstrap.state import (
+        set_client_type,
+        set_is_interactive,
+        set_session_trust_accepted,
+    )
+
+    set_is_interactive(_determine_is_interactive(args))
+    set_client_type(_determine_client_type())
+
+    # Plan phase 1 default: trust the current directory until the
+    # trust-dialog ships in plan phase 2/3 (see A4 working assumption).
+    # Propagating the implicit "trusted" decision through the existing
+    # state setter keeps ``hooks/trust_gate.py`` and
+    # ``tool_system/context.py:workspace_trusted`` consumers behaving
+    # correctly.
+    # TODO(plan-phase-2): replace with checkHasTrustDialogAccepted()
+    # analog once the trust dialog ships.
+    set_session_trust_accepted(True)
+
+    profile_checkpoint("pre_action_end")
+
+
+def _determine_is_interactive(args: object) -> bool:
+    """Mirrors TS ``isInteractiveSession`` (main.tsx:803-816)."""
+    if getattr(args, "print", False):
+        return False
+    if not sys.stdout.isatty():
+        return False
+    return True
+
+
+# Recognized values of ``CLAUDE_CODE_ENTRYPOINT``. Mirrors TS
+# main.tsx:822-838. Unknown values fall back to ``cli`` (defensive
+# default — an attacker setting this env var to a random string
+# shouldn't change client-type-gated behavior).
+_KNOWN_CLIENT_TYPES = frozenset({
+    "sdk-py",
+    "sdk-ts",
+    "sdk-cli",
+    "cli",
+    "claude-vscode",
+})
+
+
+def _determine_client_type() -> str:
+    """Mirrors TS main.tsx:822-838 — read CLAUDE_CODE_ENTRYPOINT."""
+    entrypoint = os.environ.get("CLAUDE_CODE_ENTRYPOINT", "")
+    if entrypoint in _KNOWN_CLIENT_TYPES:
+        return entrypoint
+    return "cli"
+
+
+def reset_init_for_test_only() -> None:
+    """Reset the memoize cache. Test-only.
+
+    Gated by ``PYTEST_CURRENT_TEST`` so production callers cannot
+    accidentally re-run init mid-session. Matches the discipline used
+    by ``bootstrap.state.reset_state_for_tests``.
+    """
+    if os.environ.get("PYTEST_CURRENT_TEST") is None:
+        raise RuntimeError(
+            "reset_init_for_test_only can only be called in tests"
+        )
+    init.cache_clear()

--- a/src/permissions/trust_boundary.py
+++ b/src/permissions/trust_boundary.py
@@ -1,0 +1,240 @@
+"""Two-stage env-var trust boundary — chapter 2 §"The Trust Boundary".
+
+Mirrors TS ``applySafeConfigEnvironmentVariables`` /
+``applyConfigEnvironmentVariables`` from
+``typescript/src/utils/managedEnv.ts``. The architectural insight: env
+vars from project-level config can be poisoned by a malicious clone, so
+we read them in two passes — only a *safe subset* applies pre-trust.
+
+The safe subset is a *verbatim port* of TS's ``SAFE_ENV_VARS`` set from
+``typescript/src/utils/managedEnvConstants.ts:109-194``. Default-deny:
+anything not in ``SAFE_ENV_KEYS`` is treated as unsafe.
+
+The ``UNSAFE_ENV_KEYS`` set is technically redundant with default-deny
+but exists for auditability — security reviewers should be able to grep
+for ``PATH`` / ``LD_PRELOAD`` / ``NODE_EXTRA_CA_CERTS`` and see them
+explicitly excluded.
+
+Plan reference: ``my-docs/ch02-bootstrap-refactoring-plan.md`` P1.1.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Mapping
+
+__all__ = [
+    "SAFE_ENV_KEYS",
+    "UNSAFE_ENV_KEYS",
+    "UNSAFE_ENV_PREFIXES",
+    "is_safe_env_key",
+    "apply_safe_config_environment_variables",
+    "apply_full_config_environment_variables",
+]
+
+
+# Allow-list ported verbatim from
+# ``typescript/src/utils/managedEnvConstants.ts:109-194``. The exclusions
+# (NODE_EXTRA_CA_CERTS, ANTHROPIC_BASE_URL, HTTP_PROXY, etc.) are
+# intentional security controls — DO NOT add them here. If a key needs
+# to be set pre-trust, port the corresponding TS entry; if it isn't on
+# the TS list, it goes through the post-trust
+# ``apply_full_config_environment_variables`` instead.
+SAFE_ENV_KEYS: frozenset[str] = frozenset({
+    # Model selection (Anthropic + Vertex + Bedrock)
+    "ANTHROPIC_CUSTOM_HEADERS",
+    "ANTHROPIC_CUSTOM_MODEL_OPTION",
+    "ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION",
+    "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL_DESCRIPTION",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL_SUPPORTED_CAPABILITIES",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL_DESCRIPTION",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL_SUPPORTED_CAPABILITIES",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL_SUPPORTED_CAPABILITIES",
+    "ANTHROPIC_MODEL",
+    "ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION",
+    "ANTHROPIC_SMALL_FAST_MODEL",
+    "AWS_DEFAULT_REGION",
+    "AWS_PROFILE",
+    "AWS_REGION",
+    # Bash tool tuning
+    "BASH_DEFAULT_TIMEOUT_MS",
+    "BASH_MAX_OUTPUT_LENGTH",
+    "BASH_MAX_TIMEOUT_MS",
+    "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR",
+    # CLAUDE_CODE_* runtime flags
+    "CLAUDE_CODE_API_KEY_HELPER_TTL_MS",
+    "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+    "CLAUDE_CODE_DISABLE_TERMINAL_TITLE",
+    "CLAUDE_CODE_ENABLE_TELEMETRY",
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS",
+    "CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL",
+    "CLAUDE_CODE_MAX_OUTPUT_TOKENS",
+    "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+    "CLAUDE_CODE_SKIP_FOUNDRY_AUTH",
+    "CLAUDE_CODE_SKIP_VERTEX_AUTH",
+    "CLAUDE_CODE_SUBAGENT_MODEL",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_FOUNDRY",
+    "CLAUDE_CODE_USE_GITHUB",
+    "CLAUDE_CODE_USE_VERTEX",
+    # Feature disables (no security impact)
+    "DISABLE_AUTOUPDATER",
+    "DISABLE_BUG_COMMAND",
+    "DISABLE_COST_WARNINGS",
+    "DISABLE_ERROR_REPORTING",
+    "DISABLE_FEEDBACK_COMMAND",
+    "DISABLE_TELEMETRY",
+    # Tool budgets
+    "ENABLE_TOOL_SEARCH",
+    "MAX_MCP_OUTPUT_TOKENS",
+    "MAX_THINKING_TOKENS",
+    "MCP_TIMEOUT",
+    "MCP_TOOL_TIMEOUT",
+    # OpenTelemetry config (sans endpoint, which is dangerous)
+    "OTEL_EXPORTER_OTLP_HEADERS",
+    "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+    "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
+    "OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE",
+    "OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY",
+    "OTEL_EXPORTER_OTLP_METRICS_HEADERS",
+    "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
+    "OTEL_EXPORTER_OTLP_PROTOCOL",
+    "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+    "OTEL_LOG_TOOL_DETAILS",
+    "OTEL_LOG_USER_PROMPTS",
+    "OTEL_LOGS_EXPORT_INTERVAL",
+    "OTEL_LOGS_EXPORTER",
+    "OTEL_METRIC_EXPORT_INTERVAL",
+    "OTEL_METRICS_EXPORTER",
+    "OTEL_METRICS_INCLUDE_ACCOUNT_UUID",
+    "OTEL_METRICS_INCLUDE_SESSION_ID",
+    "OTEL_METRICS_INCLUDE_VERSION",
+    "OTEL_RESOURCE_ATTRIBUTES",
+    # Misc
+    "USE_BUILTIN_RIPGREP",
+    "VERTEX_REGION_CLAUDE_3_5_HAIKU",
+    "VERTEX_REGION_CLAUDE_3_5_SONNET",
+    "VERTEX_REGION_CLAUDE_3_7_SONNET",
+    "VERTEX_REGION_CLAUDE_4_0_OPUS",
+    "VERTEX_REGION_CLAUDE_4_0_SONNET",
+    "VERTEX_REGION_CLAUDE_4_1_OPUS",
+    "VERTEX_REGION_CLAUDE_4_5_SONNET",
+    "VERTEX_REGION_CLAUDE_4_6_SONNET",
+    "VERTEX_REGION_CLAUDE_HAIKU_4_5",
+})
+
+
+# Explicit unsafe set. Redundant with default-deny (anything not in
+# SAFE_ENV_KEYS is unsafe) but exists for auditability — security
+# reviewers should be able to grep for these names and see them
+# explicitly excluded. Anchored to chapter §"The Trust Boundary" and
+# TS managedEnvConstants.ts:92-103 ("TRUST ATTACKER-CONTROLLED SERVER"
+# / "REDIRECT TO ATTACKER-CONTROLLED SERVER" comment blocks).
+UNSAFE_ENV_PREFIXES: tuple[str, ...] = ("LD_", "DYLD_")
+UNSAFE_ENV_KEYS: frozenset[str] = frozenset({
+    # PATH hijacking / shared-library injection
+    "PATH",
+    "PYTHONPATH",
+    "NODE_OPTIONS",
+    # TRUST ATTACKER-CONTROLLED SERVER (TS managedEnvConstants.ts:99-103)
+    "NODE_EXTRA_CA_CERTS",
+    "NODE_TLS_REJECT_UNAUTHORIZED",
+    # REDIRECT TO ATTACKER-CONTROLLED SERVER (TS managedEnvConstants.ts:95-97)
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_BEDROCK_BASE_URL",
+    "ANTHROPIC_FOUNDRY_BASE_URL",
+    "ANTHROPIC_VERTEX_BASE_URL",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+    # SWITCH TO ATTACKER-CONTROLLED PROJECT (TS managedEnvConstants.ts:105-108)
+    "ANTHROPIC_FOUNDRY_RESOURCE",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "AWS_BEARER_TOKEN_BEDROCK",
+})
+
+
+def is_safe_env_key(key: str) -> bool:
+    """True iff this key is safe to apply pre-trust.
+
+    Match priority: explicit unsafe set > unsafe prefix match > safe
+    allow-list. Anything that doesn't match the safe list returns
+    False (default-deny).
+    """
+    if key in UNSAFE_ENV_KEYS:
+        return False
+    if any(key.startswith(prefix) for prefix in UNSAFE_ENV_PREFIXES):
+        return False
+    return key in SAFE_ENV_KEYS
+
+
+def apply_safe_config_environment_variables(
+    config_env: Mapping[str, str] | None = None,
+) -> None:
+    """Apply only the safe subset of config.env to os.environ.
+
+    Called from ``init()`` before the trust dialog. Mirrors TS
+    ``applySafeConfigEnvironmentVariables``. Uses ``setdefault`` — does
+    NOT overwrite pre-existing process env (matches TS behavior at
+    managedEnv.ts:60-65 which checks ``process.env[key] === undefined``
+    before writing).
+    """
+    if config_env is None:
+        config_env = _load_config_env()
+    for key, value in config_env.items():
+        if is_safe_env_key(key):
+            os.environ.setdefault(key, value)
+
+
+def apply_full_config_environment_variables(
+    config_env: Mapping[str, str] | None = None,
+) -> None:
+    """Apply the full config.env to os.environ, including unsafe.
+
+    Called ONLY after the trust dialog has been accepted. Mirrors TS
+    ``applyConfigEnvironmentVariables``. Overwrites pre-existing values
+    (full apply: unsafe-vars-from-config win over inherited).
+    """
+    if config_env is None:
+        config_env = _load_config_env()
+    for key, value in config_env.items():
+        os.environ[key] = value  # full apply: overwrites
+
+
+def _load_config_env() -> dict[str, str]:
+    """Load the ``env`` subkey from the user's global config.
+
+    Reads from ``ConfigManager.load_global()`` only. TS reads from
+    user/policy/flag sources pre-trust (`managedEnv.ts:106-110`);
+    project/local sources are attacker-controllable (a malicious clone
+    could ship a ``.claude/config.json``) and must be deferred to the
+    post-trust ``apply_full_config_environment_variables``.
+
+    Returns ``{}`` when no ``env`` is configured. The lazy import of
+    ``ConfigManager`` avoids a circular import at module-load.
+    """
+    from src.config import ConfigManager  # lazy: avoid early-cycle risk
+
+    cm = ConfigManager()
+    global_env = cm.load_global().get("env") or {}
+    return {
+        str(k): str(v)
+        for k, v in global_env.items()
+        if v is not None
+    }

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -270,13 +270,13 @@ class ClawcodexREPL:
         permission_mode: str = "default",
         is_bypass_permissions_mode_available: bool = False,
     ):
-        # Mark this process as running an interactive session BEFORE we build
-        # the tool registry. Tools like TaskCreate / TaskUpdate / TodoWrite
-        # toggle themselves on/off via ``is_todo_v2_enabled()`` which reads
-        # this flag (mirroring ``typescript/src/bootstrap/state.ts``).
-        from src.bootstrap.state import set_is_interactive
-
-        set_is_interactive(True)
+        # ``is_interactive`` is set during bootstrap phase 2 by
+        # ``src.init.run_pre_action`` (called from ``cli.main``) before
+        # the REPL constructor runs. Previously we set it here too,
+        # but that was the M7.1 gap closed in plan phase 1 of
+        # ch02-bootstrap. The REPL can rely on
+        # ``get_is_interactive()`` already being ``True`` by the time
+        # this constructor runs.
 
         # Stash the resolved permission state so ``ToolContext`` honors
         # ``--dangerously-skip-permissions`` / ``--permission-mode`` flags

--- a/src/utils/graceful_shutdown.py
+++ b/src/utils/graceful_shutdown.py
@@ -1,0 +1,143 @@
+"""SIGINT / SIGTERM / atexit-coordinated graceful shutdown.
+
+Mirrors ``typescript/src/utils/gracefulShutdown.ts`` +
+``typescript/src/utils/cleanupRegistry.ts``. Idempotent registration,
+single-execution semantics across the atexit / signal-handler paths.
+
+Plan reference: ``my-docs/ch02-bootstrap-refactoring-plan.md`` P1.2.
+
+Design notes
+------------
+* **Single execution under racing handlers.** A SIGTERM can fire while
+  atexit is already running, and ``sys.exit`` inside the signal handler
+  triggers atexit a second time. ``_shutdown_started`` is the
+  one-shot latch that ensures each cleanup runs exactly once regardless
+  of which path triggers the drain.
+* **Best-effort cleanups.** Exceptions inside individual cleanups are
+  caught and logged to stderr; they never propagate. This matches the
+  TS reference, which is explicit that "we never want a buggy cleanup
+  to block process exit."
+* **Thread safety.** ``register_cleanup`` may be called from worker
+  threads (e.g., the api_preconnect worker). The lock protects the
+  list during append/iterate; we snapshot the list under the lock,
+  then run callbacks outside the lock to avoid deadlock if a cleanup
+  itself re-registers.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import signal
+import sys
+import threading
+from typing import Callable
+
+__all__ = [
+    "register_cleanup",
+    "setup_graceful_shutdown",
+    "graceful_shutdown_sync",
+    "reset_for_test_only",
+]
+
+
+_cleanups: list[Callable[[], None]] = []
+_cleanups_lock = threading.Lock()
+_shutdown_started = False
+_setup_done = False
+
+
+def register_cleanup(fn: Callable[[], None]) -> None:
+    """Register an idempotent cleanup to run on shutdown.
+
+    Cleanups must be safe to call more than once (the drain may be
+    re-entered between SIGTERM and atexit). Register order ≈ run order,
+    but don't depend on it for correctness.
+    """
+    with _cleanups_lock:
+        _cleanups.append(fn)
+
+
+def setup_graceful_shutdown() -> None:
+    """Install SIGINT / SIGTERM / atexit handlers. Idempotent.
+
+    Mirrors TS ``setupGracefulShutdown``. Called from ``init()``.
+    Safe to call multiple times — second call is a no-op.
+
+    Signal handlers fail silently on non-main-thread invocation (test
+    contexts run setup from worker threads); this matches TS's
+    permissive registration.
+    """
+    global _setup_done
+    if _setup_done:
+        return
+    _setup_done = True
+
+    def _signal_handler(signum: int, _frame: object) -> None:
+        # Encode the signal in the exit code: 128 + signal number is
+        # the POSIX convention (e.g., SIGINT=2 → exit 130).
+        graceful_shutdown_sync(128 + signum)
+
+    try:
+        signal.signal(signal.SIGINT, _signal_handler)
+        signal.signal(signal.SIGTERM, _signal_handler)
+    except ValueError:
+        # signal.signal raises ValueError when called off the main
+        # thread; this is OK in test contexts where setup may run
+        # under pytest-xdist workers.
+        pass
+
+    atexit.register(_run_all_cleanups)
+
+
+def _run_all_cleanups() -> None:
+    """Drain registered cleanups exactly once.
+
+    Re-entry guard: if the drain has already started (because SIGTERM
+    fired first and called sys.exit → atexit), subsequent calls
+    no-op. The list is snapshotted under the lock so a cleanup that
+    re-registers (rare) doesn't iterate forever.
+    """
+    global _shutdown_started
+    with _cleanups_lock:
+        if _shutdown_started:
+            return
+        _shutdown_started = True
+        pending = list(_cleanups)
+    for fn in pending:
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            try:
+                name = getattr(fn, "__name__", repr(fn))
+                sys.stderr.write(f"cleanup error in {name}: {exc}\n")
+            except Exception:
+                pass  # last-resort: never block exit on logging
+
+
+def graceful_shutdown_sync(code: int = 0) -> None:
+    """Run all cleanups then exit with ``code``.
+
+    Mirrors TS ``gracefulShutdownSync``. Used by signal handlers and
+    error paths that need a coordinated exit (not bare ``sys.exit``).
+    """
+    _run_all_cleanups()
+    sys.exit(code)
+
+
+def reset_for_test_only() -> None:
+    """Wipe registered cleanups and the setup-done latch. Test-only.
+
+    Gated by ``PYTEST_CURRENT_TEST`` so production callers cannot
+    accidentally re-arm the signal handlers mid-session. Matches the
+    discipline used by ``bootstrap.state.reset_state_for_tests``.
+    """
+    if os.environ.get("PYTEST_CURRENT_TEST") is None:
+        raise RuntimeError(
+            "reset_for_test_only can only be called in tests"
+        )
+    global _shutdown_started, _setup_done
+    with _cleanups_lock:
+        _cleanups.clear()
+        _shutdown_started = False
+        _setup_done = False

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -1,0 +1,127 @@
+"""Unit tests for ``src/utils/graceful_shutdown.py`` (P1.2).
+
+The signal-handler path tests (SIGTERM during prefetch, SIGINT before
+prefetch) live in ``tests/test_init_integration.py`` because they need
+real subprocess isolation. These unit tests exercise the in-process
+APIs only.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import pytest
+
+from src.utils import graceful_shutdown as gs
+
+
+@pytest.fixture(autouse=True)
+def _reset_graceful_shutdown():
+    """Reset the module-level state before/after every test."""
+    gs.reset_for_test_only()
+    yield
+    gs.reset_for_test_only()
+
+
+class TestRegisterCleanupAndDrain(unittest.TestCase):
+    def test_register_runs_cleanup_on_drain(self) -> None:
+        calls = []
+        gs.register_cleanup(lambda: calls.append("a"))
+        gs._run_all_cleanups()
+        self.assertEqual(calls, ["a"])
+
+    def test_register_runs_in_order(self) -> None:
+        calls = []
+        gs.register_cleanup(lambda: calls.append(1))
+        gs.register_cleanup(lambda: calls.append(2))
+        gs.register_cleanup(lambda: calls.append(3))
+        gs._run_all_cleanups()
+        self.assertEqual(calls, [1, 2, 3])
+
+
+class TestDrainIdempotent(unittest.TestCase):
+    def test_double_call_fires_cleanup_once(self) -> None:
+        calls = []
+        gs.register_cleanup(lambda: calls.append("only-once"))
+        gs._run_all_cleanups()
+        gs._run_all_cleanups()
+        self.assertEqual(calls, ["only-once"])
+
+    def test_drain_after_cleanup_is_noop(self) -> None:
+        # Once shutdown has started, additional registrations are
+        # ignored (the snapshot under the lock has already been taken).
+        calls = []
+        gs.register_cleanup(lambda: calls.append("first"))
+        gs._run_all_cleanups()
+        gs.register_cleanup(lambda: calls.append("late"))
+        gs._run_all_cleanups()
+        self.assertEqual(calls, ["first"])
+
+
+class TestCleanupExceptionsDoNotBlock(unittest.TestCase):
+    def test_exception_in_first_cleanup_does_not_skip_second(self) -> None:
+        calls = []
+
+        def boom() -> None:
+            raise RuntimeError("intentional")
+
+        gs.register_cleanup(boom)
+        gs.register_cleanup(lambda: calls.append("survived"))
+        gs._run_all_cleanups()
+        self.assertEqual(calls, ["survived"])
+
+
+class TestSetupIdempotent(unittest.TestCase):
+    def test_setup_graceful_shutdown_only_installs_once(self) -> None:
+        # The second call should be a no-op. We can't directly observe
+        # signal.signal calls without a fixture, but the _setup_done
+        # latch is the implementation that guarantees the property.
+        gs.setup_graceful_shutdown()
+        first_state = gs._setup_done
+        gs.setup_graceful_shutdown()
+        second_state = gs._setup_done
+        self.assertTrue(first_state)
+        self.assertTrue(second_state)
+
+    def test_setup_handles_non_main_thread_silently(self) -> None:
+        # On a non-main thread, signal.signal raises ValueError. The
+        # function must catch and proceed. We simulate by patching
+        # signal.signal to raise.
+        gs.reset_for_test_only()
+        with mock.patch("signal.signal", side_effect=ValueError("not main thread")):
+            gs.setup_graceful_shutdown()  # must not raise
+
+
+class TestGracefulShutdownSync(unittest.TestCase):
+    def test_calls_sys_exit_with_code(self) -> None:
+        # graceful_shutdown_sync calls sys.exit, which raises SystemExit.
+        calls = []
+        gs.register_cleanup(lambda: calls.append("drained"))
+        with self.assertRaises(SystemExit) as ctx:
+            gs.graceful_shutdown_sync(42)
+        self.assertEqual(ctx.exception.code, 42)
+        self.assertEqual(calls, ["drained"])
+
+    def test_default_exit_code_zero(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            gs.graceful_shutdown_sync()
+        self.assertEqual(ctx.exception.code, 0)
+
+
+class TestResetGate(unittest.TestCase):
+    def test_reset_outside_pytest_raises(self) -> None:
+        # The reset is gated by PYTEST_CURRENT_TEST. The autouse fixture
+        # sets it, so directly unsetting and calling reset must raise.
+        import os
+        saved = os.environ.pop("PYTEST_CURRENT_TEST", None)
+        try:
+            with self.assertRaises(RuntimeError):
+                gs.reset_for_test_only()
+        finally:
+            if saved is not None:
+                os.environ["PYTEST_CURRENT_TEST"] = saved
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,210 @@
+"""Unit tests for ``src/init.py`` (P1.3, P1.4, P1.6).
+
+Verifies the memoize property, substep ordering, run_pre_action
+behavior, and the interactive-state setters.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+import pytest
+
+from src import init as init_module
+from src.bootstrap.state import (
+    get_client_type,
+    get_is_interactive,
+    get_session_trust_accepted,
+    reset_state_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_init_and_state():
+    """Reset the init memoize cache and bootstrap state per test."""
+    init_module.reset_init_for_test_only()
+    reset_state_for_tests()
+    # Also reset graceful_shutdown so signal handlers aren't sticky.
+    from src.utils import graceful_shutdown as gs
+    gs.reset_for_test_only()
+    yield
+    init_module.reset_init_for_test_only()
+    reset_state_for_tests()
+    gs.reset_for_test_only()
+
+
+class TestInitRunsSubstepsInOrder(unittest.TestCase):
+    """init() must call its substeps in the chapter's documented order."""
+
+    def test_substep_call_order(self) -> None:
+        call_log: list[str] = []
+        with mock.patch.object(
+            init_module,
+            "apply_safe_config_environment_variables",
+            side_effect=lambda *a, **kw: call_log.append("safe_env"),
+        ), mock.patch.object(
+            init_module,
+            "setup_graceful_shutdown",
+            side_effect=lambda *a, **kw: call_log.append("graceful_shutdown"),
+        ), mock.patch.object(
+            init_module,
+            "start_api_preconnect",
+            side_effect=lambda *a, **kw: call_log.append("api_preconnect"),
+        ):
+            init_module.init()
+
+        self.assertEqual(
+            call_log,
+            ["safe_env", "graceful_shutdown", "api_preconnect"],
+            "init() substeps must run in chapter order",
+        )
+
+
+class TestInitIsMemoized(unittest.TestCase):
+    """The @cache decorator ensures the substeps run exactly once per
+    process, regardless of how many callers invoke init()."""
+
+    def test_three_calls_run_substeps_once(self) -> None:
+        with mock.patch.object(
+            init_module, "apply_safe_config_environment_variables"
+        ) as mock_safe, mock.patch.object(
+            init_module, "setup_graceful_shutdown"
+        ) as mock_shutdown, mock.patch.object(
+            init_module, "start_api_preconnect"
+        ) as mock_preconnect:
+            init_module.init()
+            init_module.init()
+            init_module.init()
+
+            self.assertEqual(mock_safe.call_count, 1)
+            self.assertEqual(mock_shutdown.call_count, 1)
+            self.assertEqual(mock_preconnect.call_count, 1)
+
+
+class TestResetClearsCache(unittest.TestCase):
+    def test_reset_re_runs_substeps(self) -> None:
+        with mock.patch.object(
+            init_module, "apply_safe_config_environment_variables"
+        ) as mock_safe:
+            init_module.init()
+            init_module.reset_init_for_test_only()
+            init_module.init()
+            self.assertEqual(mock_safe.call_count, 2)
+
+    def test_reset_outside_pytest_raises(self) -> None:
+        saved = os.environ.pop("PYTEST_CURRENT_TEST", None)
+        try:
+            with self.assertRaises(RuntimeError):
+                init_module.reset_init_for_test_only()
+        finally:
+            if saved is not None:
+                os.environ["PYTEST_CURRENT_TEST"] = saved
+
+
+class TestInitDoesNotApplyUnsafeEnv(unittest.TestCase):
+    """End-to-end: init() must NOT touch PATH or other unsafe vars."""
+
+    def test_path_is_not_modified_by_init(self) -> None:
+        # Setup: pretend the user's global config has both safe and
+        # unsafe keys. apply_safe_config_environment_variables (real,
+        # not mocked) should only apply the safe one.
+        config_env = {
+            "PATH": "/opt/evil/bin",
+            "ANTHROPIC_MODEL": "claude-sonnet-4-6",
+        }
+        original_path = os.environ.get("PATH", "")
+
+        with mock.patch(
+            "src.permissions.trust_boundary._load_config_env",
+            return_value=config_env,
+        ), mock.patch.object(init_module, "setup_graceful_shutdown"), \
+                mock.patch.object(init_module, "start_api_preconnect"):
+            os.environ.pop("ANTHROPIC_MODEL", None)
+            init_module.init()
+
+        try:
+            # PATH unchanged.
+            self.assertEqual(os.environ.get("PATH", ""), original_path)
+            # ANTHROPIC_MODEL was applied (safe).
+            self.assertEqual(os.environ.get("ANTHROPIC_MODEL"), "claude-sonnet-4-6")
+        finally:
+            os.environ.pop("ANTHROPIC_MODEL", None)
+
+
+class TestRunPreActionCallsInit(unittest.TestCase):
+    def test_pre_action_invokes_init(self) -> None:
+        with mock.patch.object(init_module, "init") as mock_init:
+            args = types.SimpleNamespace(print=False)
+            init_module.run_pre_action(args)
+            mock_init.assert_called_once()
+
+
+class TestRunPreActionSetsInteractive(unittest.TestCase):
+    def test_default_args_interactive_true_when_tty(self) -> None:
+        # We can't make sys.stdout a real TTY in unittest, so patch
+        # isatty to return True.
+        with mock.patch.object(init_module, "init"), \
+                mock.patch.object(sys.stdout, "isatty", return_value=True):
+            args = types.SimpleNamespace(print=False)
+            init_module.run_pre_action(args)
+            self.assertTrue(get_is_interactive())
+
+    def test_print_mode_sets_interactive_false(self) -> None:
+        with mock.patch.object(init_module, "init"):
+            args = types.SimpleNamespace(print=True)
+            init_module.run_pre_action(args)
+            self.assertFalse(get_is_interactive())
+
+    def test_non_tty_stdout_sets_interactive_false(self) -> None:
+        with mock.patch.object(init_module, "init"), \
+                mock.patch.object(sys.stdout, "isatty", return_value=False):
+            args = types.SimpleNamespace(print=False)
+            init_module.run_pre_action(args)
+            self.assertFalse(get_is_interactive())
+
+
+class TestRunPreActionSetsClientType(unittest.TestCase):
+    def test_default_when_env_unset(self) -> None:
+        with mock.patch.object(init_module, "init"), \
+                mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CLAUDE_CODE_ENTRYPOINT", None)
+            args = types.SimpleNamespace(print=False)
+            init_module.run_pre_action(args)
+            self.assertEqual(get_client_type(), "cli")
+
+    def test_sdk_py_override(self) -> None:
+        with mock.patch.object(init_module, "init"), \
+                mock.patch.dict(os.environ, {"CLAUDE_CODE_ENTRYPOINT": "sdk-py"}):
+            args = types.SimpleNamespace(print=False)
+            init_module.run_pre_action(args)
+            self.assertEqual(get_client_type(), "sdk-py")
+
+    def test_unknown_value_falls_back_to_cli(self) -> None:
+        # Defensive default: an attacker setting this env var to a
+        # random string shouldn't change behavior.
+        with mock.patch.object(init_module, "init"), \
+                mock.patch.dict(os.environ, {"CLAUDE_CODE_ENTRYPOINT": "totally-random"}):
+            args = types.SimpleNamespace(print=False)
+            init_module.run_pre_action(args)
+            self.assertEqual(get_client_type(), "cli")
+
+
+class TestRunPreActionSetsTrustAccepted(unittest.TestCase):
+    """A6 / P1.6: plan-phase-1 default is `set_session_trust_accepted(True)`
+    so existing trust-gate consumers behave correctly."""
+
+    def test_pre_action_sets_trust_accepted_true(self) -> None:
+        # Pre-state: default False.
+        self.assertFalse(get_session_trust_accepted())
+        with mock.patch.object(init_module, "init"):
+            args = types.SimpleNamespace(print=False)
+            init_module.run_pre_action(args)
+        self.assertTrue(get_session_trust_accepted())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_init_integration.py
+++ b/tests/test_init_integration.py
@@ -1,0 +1,351 @@
+"""Integration tests for the plan-phase-1 bootstrap pipeline (P1.7).
+
+These tests cover the architectural properties (init runs once, fast
+paths skip init, profile checkpoints land in order, signal-path
+cleanups fire) that aren't easy to assert in pure unit tests.
+
+The subprocess-based tests (5a, 5b, 5c) use ``subprocess.Popen`` to
+isolate signal-handler behavior — sending SIGTERM into the test
+process itself would break pytest.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+import time
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from src import init as init_module
+from src.bootstrap.state import reset_state_for_tests
+from src.utils import graceful_shutdown as gs
+from src.utils import startup_profiler
+
+
+WORKTREE_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(autouse=True)
+def _reset_everything():
+    init_module.reset_init_for_test_only()
+    reset_state_for_tests()
+    gs.reset_for_test_only()
+    startup_profiler.reset_profiler_for_test_only()
+    yield
+    init_module.reset_init_for_test_only()
+    reset_state_for_tests()
+    gs.reset_for_test_only()
+    startup_profiler.reset_profiler_for_test_only()
+
+
+# ---------------------------------------------------------------------------
+# 1. init runs exactly once across multiple "entry points"
+# ---------------------------------------------------------------------------
+
+
+class TestInitRunsExactlyOnceAcrossEntries(unittest.TestCase):
+    """Chapter §"Apply This: Memoize your init function" — multiple
+    entry points each calling init() must run substeps once total."""
+
+    def test_three_entry_points_run_substeps_once_each(self) -> None:
+        with mock.patch.object(
+            init_module, "apply_safe_config_environment_variables"
+        ) as mock_safe, mock.patch.object(
+            init_module, "setup_graceful_shutdown"
+        ) as mock_shutdown, mock.patch.object(
+            init_module, "start_api_preconnect"
+        ) as mock_preconnect:
+            # Simulate three different entry points all calling init.
+            def entry_repl() -> None:
+                init_module.init()
+
+            def entry_headless() -> None:
+                init_module.init()
+
+            def entry_sdk() -> None:
+                init_module.init()
+
+            entry_repl()
+            entry_headless()
+            entry_sdk()
+
+            self.assertEqual(mock_safe.call_count, 1)
+            self.assertEqual(mock_shutdown.call_count, 1)
+            self.assertEqual(mock_preconnect.call_count, 1)
+
+
+# ---------------------------------------------------------------------------
+# 2. Fast paths never reach run_pre_action
+# ---------------------------------------------------------------------------
+
+
+class TestFastPathSkipsInit(unittest.TestCase):
+    """--version goes through the pre-argparse fast-path at
+    cli.py:52-55 OR the post-argparse short-circuit at line 92-95;
+    neither reaches ``run_pre_action``."""
+
+    def test_version_fast_path_does_not_call_pre_action(self) -> None:
+        # The pre-argparse fast-path checks for one-flag --version.
+        with mock.patch("src.init.run_pre_action") as mock_pre_action:
+            with mock.patch.object(sys, "argv", ["clawcodex", "--version"]):
+                from src import cli
+                cli.main()
+            mock_pre_action.assert_not_called()
+
+    def test_post_argparse_version_short_circuit_skips_init(self) -> None:
+        # Multi-arg argv triggers argparse (pre-argparse fast-path
+        # requires len(sys.argv) == 2). The args.version short-circuit
+        # at cli.py:92-95 must also skip init.
+        with mock.patch("src.init.run_pre_action") as mock_pre_action:
+            with mock.patch.object(
+                sys, "argv", ["clawcodex", "--version", "--debug"]
+            ):
+                # argparse rejects unknown flags, so use a known one
+                # that doesn't change behavior:
+                # ``--version`` alone, but force the pre-argparse
+                # fast-path to miss by adding a no-op extra flag.
+                # Easiest: use ``--version`` + ``--legacy-repl`` (both
+                # parse, and ``args.version`` short-circuits first).
+                pass
+            with mock.patch.object(
+                sys, "argv", ["clawcodex", "--version", "--legacy-repl"]
+            ):
+                from src import cli
+                cli.main()
+            mock_pre_action.assert_not_called()
+
+    def test_post_argparse_config_short_circuit_skips_init(self) -> None:
+        # Same property for --config short-circuit.
+        with mock.patch("src.init.run_pre_action") as mock_pre_action, \
+                mock.patch("src.cli.show_config", return_value=0):
+            with mock.patch.object(
+                sys, "argv", ["clawcodex", "--config", "--legacy-repl"]
+            ):
+                from src import cli
+                cli.main()
+            mock_pre_action.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 3. Default invocation runs run_pre_action exactly once
+# ---------------------------------------------------------------------------
+
+
+class TestPreActionRunsForDefaultInvocation(unittest.TestCase):
+    def test_pre_action_called_once_for_default_repl(self) -> None:
+        # We patch the actual REPL launcher so the test doesn't drag
+        # in the full provider/registry/etc. stack. _resolve_permission_state
+        # is allowed to run because cli.start_repl reads args._resolved_*.
+        with mock.patch("src.init.run_pre_action") as mock_pre, \
+                mock.patch("src.cli.start_repl", return_value=0), \
+                mock.patch("src.entrypoints.tui.should_use_tui", return_value=False), \
+                mock.patch.object(sys, "argv", ["clawcodex"]):
+            from src import cli
+            cli.main()
+            mock_pre.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 4. Safe-env applies safe; PATH stays untouched
+# ---------------------------------------------------------------------------
+
+
+class TestInitSafeEnvApplyBeforeUnsafe(unittest.TestCase):
+    def test_safe_applied_unsafe_skipped(self) -> None:
+        config_env = {
+            "ANTHROPIC_MODEL": "claude-sonnet-4-6",  # safe
+            "PATH": "/opt/evil/bin",                 # unsafe
+        }
+        original_path = os.environ.get("PATH", "")
+        with mock.patch(
+            "src.permissions.trust_boundary._load_config_env",
+            return_value=config_env,
+        ), mock.patch.object(init_module, "setup_graceful_shutdown"), \
+                mock.patch.object(init_module, "start_api_preconnect"):
+            os.environ.pop("ANTHROPIC_MODEL", None)
+            try:
+                init_module.init()
+                self.assertEqual(os.environ["ANTHROPIC_MODEL"], "claude-sonnet-4-6")
+                self.assertEqual(os.environ.get("PATH", ""), original_path)
+            finally:
+                os.environ.pop("ANTHROPIC_MODEL", None)
+
+
+# ---------------------------------------------------------------------------
+# 5. Atexit drain coexists with prefetch atexit
+# ---------------------------------------------------------------------------
+
+
+class TestGracefulShutdownCoexistsWithPrefetchAtexit(unittest.TestCase):
+    def test_drain_runs_cleanup_and_does_not_block(self) -> None:
+        # Register a cleanup, then call drain. Verify the cleanup
+        # fires. Doesn't actually need a prefetch subprocess to verify
+        # the API surface — that's covered by test_prefetch.py.
+        calls = []
+        gs.register_cleanup(lambda: calls.append("graceful_drained"))
+        gs._run_all_cleanups()
+        self.assertEqual(calls, ["graceful_drained"])
+
+
+# ---------------------------------------------------------------------------
+# 5a-5c. Signal-handler paths (subprocess-isolated)
+# ---------------------------------------------------------------------------
+
+
+def _run_in_subprocess(
+    code: str,
+    signal_after_ms: float | None = None,
+    signal_name: str = "SIGTERM",
+    timeout: float = 5.0,
+) -> tuple[int, str, str]:
+    """Run ``code`` in a fresh Python subprocess, optionally sending it
+    ``signal_name`` after ``signal_after_ms`` ms. Returns
+    (returncode, stdout, stderr).
+    """
+    import signal as _signal
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(WORKTREE_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    proc = subprocess.Popen(
+        [sys.executable, "-c", code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    if signal_after_ms is not None:
+        time.sleep(signal_after_ms / 1000.0)
+        try:
+            proc.send_signal(getattr(_signal, signal_name))
+        except ProcessLookupError:
+            pass  # already exited
+    try:
+        out, err = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        out, err = proc.communicate()
+    return proc.returncode, out.decode("utf-8", errors="replace"), err.decode("utf-8", errors="replace")
+
+
+class TestSigtermPathRunsCleanups(unittest.TestCase):
+    """SIGTERM → signal handler → graceful_shutdown_sync →
+    _run_all_cleanups → sys.exit(128+15=143). Cleanups fire."""
+
+    def test_sigterm_triggers_drain(self) -> None:
+        code = textwrap.dedent(
+            """
+            import sys, time
+            from src.utils.graceful_shutdown import (
+                register_cleanup, setup_graceful_shutdown,
+            )
+            register_cleanup(lambda: print("DRAINED", flush=True))
+            setup_graceful_shutdown()
+            # Sleep long enough for the parent to send SIGTERM.
+            time.sleep(3.0)
+            print("LIVE", flush=True)
+            """
+        )
+        rc, out, err = _run_in_subprocess(
+            code, signal_after_ms=200, signal_name="SIGTERM"
+        )
+        self.assertIn("DRAINED", out, msg=f"cleanup did not fire. err={err}")
+        # 128+15 == 143 (SIGTERM exit code).
+        self.assertEqual(rc, 143, msg=f"unexpected rc={rc}. out={out} err={err}")
+
+
+class TestSigintDuringPrefetch(unittest.TestCase):
+    """SIGINT while a prefetch handle is in-flight must not leave a zombie."""
+
+    def test_sigint_during_prefetch_clean_exit(self) -> None:
+        code = textwrap.dedent(
+            """
+            import time
+            from src.utils.graceful_shutdown import setup_graceful_shutdown
+            from src.prefetch import get_or_start_keychain_prefetch
+            setup_graceful_shutdown()
+            handle = get_or_start_keychain_prefetch()
+            # Sleep long enough for the parent to send SIGINT.
+            time.sleep(3.0)
+            print("LIVE", flush=True)
+            """
+        )
+        rc, out, err = _run_in_subprocess(
+            code, signal_after_ms=100, signal_name="SIGINT"
+        )
+        # SIGINT exit code is 128+2 == 130.
+        self.assertEqual(rc, 130, msg=f"unexpected rc={rc}. out={out} err={err}")
+
+
+class TestSigintBeforePrefetchStarted(unittest.TestCase):
+    """SIGINT before any prefetch is fired must exit cleanly (no
+    'cleanup error' messages, code 130)."""
+
+    def test_sigint_before_any_prefetch(self) -> None:
+        code = textwrap.dedent(
+            """
+            import time
+            from src.utils.graceful_shutdown import setup_graceful_shutdown
+            setup_graceful_shutdown()
+            time.sleep(3.0)
+            print("LIVE", flush=True)
+            """
+        )
+        rc, out, err = _run_in_subprocess(
+            code, signal_after_ms=50, signal_name="SIGINT"
+        )
+        self.assertEqual(rc, 130, msg=f"unexpected rc={rc}. err={err}")
+        # No "cleanup error" lines should appear in stderr.
+        self.assertNotIn("cleanup error", err)
+
+
+# ---------------------------------------------------------------------------
+# 6. Profile checkpoints recorded in order
+# ---------------------------------------------------------------------------
+
+
+class TestProfileCheckpointsRecorded(unittest.TestCase):
+    """When CLAUDE_CODE_PROFILE_STARTUP is set, calling run_pre_action
+    must emit the expected sequence of checkpoints."""
+
+    def test_pre_action_emits_expected_checkpoints(self) -> None:
+        # We have to manually enable profiling for this test since the
+        # latch in startup_profiler is captured at module-import.
+        startup_profiler._PROFILING_ENABLED = True
+        try:
+            startup_profiler.reset_profiler_for_test_only()
+
+            args = types.SimpleNamespace(print=False)
+            init_module.run_pre_action(args)
+
+            names = [name for name, _ in startup_profiler.get_internal_phase_log()]
+            # Must contain (at minimum) the expected pre_action_* and
+            # init_* checkpoints. Order matters.
+            self.assertIn("pre_action_start", names)
+            self.assertIn("init_function_start", names)
+            self.assertIn("init_safe_env_vars_applied", names)
+            self.assertIn("init_after_graceful_shutdown", names)
+            self.assertIn("init_after_api_preconnect", names)
+            self.assertIn("init_function_end", names)
+            self.assertIn("pre_action_after_init", names)
+            self.assertIn("pre_action_end", names)
+
+            # Sanity: pre_action_start comes before pre_action_end.
+            self.assertLess(
+                names.index("pre_action_start"),
+                names.index("pre_action_end"),
+            )
+        finally:
+            # Restore the latch's original state (read from env at
+            # module-import). The autouse fixture also calls reset.
+            startup_profiler._PROFILING_ENABLED = (
+                startup_profiler._read_env_gate()
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_trust_boundary.py
+++ b/tests/test_trust_boundary.py
@@ -1,0 +1,237 @@
+"""Unit tests for ``src/permissions/trust_boundary.py`` (P1.1).
+
+Mirrors the chapter §"The Trust Boundary" semantic: only the safe env-
+var subset applies pre-trust; everything else (PATH, LD_PRELOAD,
+NODE_EXTRA_CA_CERTS, proxies, base URLs, API keys) is excluded by
+default-deny.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+import pytest
+
+from src.permissions.trust_boundary import (
+    SAFE_ENV_KEYS,
+    UNSAFE_ENV_KEYS,
+    UNSAFE_ENV_PREFIXES,
+    apply_full_config_environment_variables,
+    apply_safe_config_environment_variables,
+    is_safe_env_key,
+)
+
+
+class TestSafeKeyAllowList(unittest.TestCase):
+    def test_every_entry_in_safe_env_keys_is_safe(self) -> None:
+        # Every key in the allow-list must classify as safe — round-trip
+        # verifies no entry is shadowed by UNSAFE_ENV_KEYS or by a
+        # prefix match.
+        for key in SAFE_ENV_KEYS:
+            with self.subTest(key=key):
+                self.assertTrue(
+                    is_safe_env_key(key),
+                    f"{key!r} is in SAFE_ENV_KEYS but is_safe_env_key returns False",
+                )
+
+    def test_set_size_matches_ts_port(self) -> None:
+        # Sanity check: TS managedEnvConstants.ts:109-194 has 82 entries
+        # in SAFE_ENV_VARS. Our port should match exactly. If a future
+        # WI legitimately changes the count, update both this number
+        # and the corresponding TS comment.
+        self.assertEqual(
+            len(SAFE_ENV_KEYS),
+            82,
+            "SAFE_ENV_KEYS count drifted from the TS port",
+        )
+
+
+class TestUnsafeKeysBlocked(unittest.TestCase):
+    def test_path_returns_false(self) -> None:
+        self.assertFalse(is_safe_env_key("PATH"))
+
+    def test_pythonpath_returns_false(self) -> None:
+        self.assertFalse(is_safe_env_key("PYTHONPATH"))
+
+    def test_node_options_returns_false(self) -> None:
+        self.assertFalse(is_safe_env_key("NODE_OPTIONS"))
+
+    def test_node_extra_ca_certs_returns_false(self) -> None:
+        # The round-1 critic-blocking-issue case: TS explicitly flags
+        # NODE_EXTRA_CA_CERTS as "TRUST ATTACKER-CONTROLLED SERVER"
+        # (managedEnvConstants.ts:99-103).
+        self.assertFalse(is_safe_env_key("NODE_EXTRA_CA_CERTS"))
+
+    def test_anthropic_base_url_returns_false(self) -> None:
+        # "REDIRECT TO ATTACKER-CONTROLLED SERVER"
+        # (managedEnvConstants.ts:95-97).
+        self.assertFalse(is_safe_env_key("ANTHROPIC_BASE_URL"))
+
+    def test_anthropic_api_key_returns_false(self) -> None:
+        # "SWITCH TO ATTACKER-CONTROLLED PROJECT"
+        # (managedEnvConstants.ts:105-108).
+        self.assertFalse(is_safe_env_key("ANTHROPIC_API_KEY"))
+
+
+class TestUnsafePrefixesBlocked(unittest.TestCase):
+    def test_ld_preload_returns_false(self) -> None:
+        self.assertFalse(is_safe_env_key("LD_PRELOAD"))
+
+    def test_ld_library_path_returns_false(self) -> None:
+        self.assertFalse(is_safe_env_key("LD_LIBRARY_PATH"))
+
+    def test_dyld_insert_libraries_returns_false(self) -> None:
+        self.assertFalse(is_safe_env_key("DYLD_INSERT_LIBRARIES"))
+
+
+class TestUnknownKeyDefaultDeny(unittest.TestCase):
+    def test_random_key_returns_false(self) -> None:
+        # Default-deny: anything not in the allow-list returns False.
+        self.assertFalse(is_safe_env_key("FOO_BAR_BAZ"))
+
+    def test_empty_string_returns_false(self) -> None:
+        self.assertFalse(is_safe_env_key(""))
+
+
+class TestApplySafeDoesNotApplyUnsafe(unittest.TestCase):
+    def test_unsafe_keys_excluded_from_safe_apply(self, *, monkeypatch=None):
+        # Use a synthetic config_env so we don't depend on real disk
+        # state. Pass it explicitly to bypass _load_config_env.
+        config_env = {
+            "ANTHROPIC_MODEL": "claude-sonnet-4-6",  # safe
+            "PATH": "/opt/evil/bin",                 # unsafe
+            "NODE_EXTRA_CA_CERTS": "/opt/evil.crt",  # unsafe
+            "LD_PRELOAD": "/opt/evil.so",            # unsafe (prefix)
+            "DISABLE_TELEMETRY": "1",                # safe
+        }
+        with mock.patch.dict(os.environ, {}, clear=False):
+            # Remove any pre-existing keys to make the test deterministic
+            for k in ("ANTHROPIC_MODEL", "DISABLE_TELEMETRY", "PATH",
+                      "NODE_EXTRA_CA_CERTS", "LD_PRELOAD"):
+                os.environ.pop(k, None)
+            apply_safe_config_environment_variables(config_env)
+
+            self.assertEqual(os.environ.get("ANTHROPIC_MODEL"), "claude-sonnet-4-6")
+            self.assertEqual(os.environ.get("DISABLE_TELEMETRY"), "1")
+            # Unsafe keys: NOT applied.
+            self.assertNotEqual(os.environ.get("PATH"), "/opt/evil/bin")
+            self.assertIsNone(os.environ.get("NODE_EXTRA_CA_CERTS"))
+            self.assertIsNone(os.environ.get("LD_PRELOAD"))
+
+
+class TestApplySafeDoesNotOverwriteExisting(unittest.TestCase):
+    def test_setdefault_semantics(self) -> None:
+        # Pre-existing process env wins; setdefault doesn't clobber.
+        config_env = {"ANTHROPIC_MODEL": "from-config"}
+        with mock.patch.dict(os.environ, {"ANTHROPIC_MODEL": "from-shell"}, clear=False):
+            apply_safe_config_environment_variables(config_env)
+            self.assertEqual(os.environ["ANTHROPIC_MODEL"], "from-shell")
+
+
+class TestApplyFullOverwritesUnsafe(unittest.TestCase):
+    def test_full_apply_writes_unsafe_keys(self) -> None:
+        # Post-trust: the full apply writes everything, including
+        # explicitly-unsafe keys.
+        config_env = {"PATH": "/opt/safe/bin", "ANTHROPIC_MODEL": "claude-4"}
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PATH", None)
+            os.environ.pop("ANTHROPIC_MODEL", None)
+            apply_full_config_environment_variables(config_env)
+            self.assertEqual(os.environ.get("PATH"), "/opt/safe/bin")
+            self.assertEqual(os.environ.get("ANTHROPIC_MODEL"), "claude-4")
+
+    def test_full_apply_overwrites_existing(self) -> None:
+        # Full apply uses assignment, not setdefault — so a config value
+        # wins over the shell value, mirroring TS's post-trust behavior.
+        config_env = {"ANTHROPIC_MODEL": "from-config"}
+        with mock.patch.dict(os.environ, {"ANTHROPIC_MODEL": "from-shell"}, clear=False):
+            apply_full_config_environment_variables(config_env)
+            self.assertEqual(os.environ["ANTHROPIC_MODEL"], "from-config")
+
+
+class TestLoadConfigEnvFallthrough(unittest.TestCase):
+    """Risk-register row 3: load_global must fall through cleanly
+    when no global config exists.
+    """
+
+    def test_no_global_config_does_not_raise(self) -> None:
+        # apply_safe_config_environment_variables() with no arg loads
+        # from disk. On a fresh test machine without ~/.clawcodex/config.json
+        # this should succeed and apply nothing (returns empty dict).
+        # Mock ConfigManager.load_global to return {} (no env subkey)
+        # so the test doesn't depend on user-local config.
+        with mock.patch("src.config.ConfigManager.load_global", return_value={}):
+            apply_safe_config_environment_variables()  # must not raise
+
+
+class TestLoadConfigEnvOnlyReadsGlobal(unittest.TestCase):
+    """Security invariant: _load_config_env reads ONLY load_global,
+    never load_project / load_local. A malicious project clone
+    shipping ``.claude/config.json`` with ``env: {PATH: /opt/evil}``
+    must NOT poison the pre-trust env.
+
+    Per the chapter §"The Trust Boundary" and the TS reference
+    (managedEnv.ts:106-110, which reads from user/policy/flag sources
+    only). The plan's risk-register row 3 committed to this test.
+    """
+
+    def test_project_env_not_applied_pre_trust(self) -> None:
+        # Simulate the attack: global config has no env, but project
+        # config has a malicious PATH.
+        attacker_env = {"PATH": "/opt/evil/bin"}
+        original_path = os.environ.get("PATH", "")
+
+        # The implementation should only read load_global. If it
+        # reads load_project / load_local, the attacker's PATH would
+        # be in config_env and then is_safe_env_key("PATH") returns
+        # False so it's still not applied — but the security goal is
+        # to never even read the project config in the first place.
+        # We assert both: load_project is NOT called, and PATH stays
+        # unchanged.
+        with mock.patch(
+            "src.config.ConfigManager.load_global", return_value={"env": {}}
+        ) as mock_global, mock.patch(
+            "src.config.ConfigManager.load_project", return_value={"env": attacker_env}
+        ) as mock_project, mock.patch(
+            "src.config.ConfigManager.load_local", return_value={"env": attacker_env}
+        ) as mock_local:
+            apply_safe_config_environment_variables()
+            # PATH unchanged — defense-in-depth from is_safe_env_key.
+            self.assertEqual(os.environ.get("PATH", ""), original_path)
+            # _load_config_env reads only the global source.
+            mock_global.assert_called_once()
+            mock_project.assert_not_called()
+            mock_local.assert_not_called()
+
+
+class TestUnsafeKeySetIsAuditable(unittest.TestCase):
+    """Documented audit guarantees: the explicit unsafe set has
+    every name the chapter / TS reference calls out by name."""
+
+    def test_chapter_mentioned_keys_are_explicitly_unsafe(self) -> None:
+        # Chapter §"The Trust Boundary": "PATH, LD_PRELOAD, NODE_OPTIONS".
+        # All three must be explicitly enumerated (PATH/NODE_OPTIONS in
+        # the set; LD_PRELOAD via UNSAFE_ENV_PREFIXES).
+        self.assertIn("PATH", UNSAFE_ENV_KEYS)
+        self.assertIn("NODE_OPTIONS", UNSAFE_ENV_KEYS)
+        self.assertIn("LD_", UNSAFE_ENV_PREFIXES)
+
+    def test_ts_attack_category_keys_explicitly_unsafe(self) -> None:
+        # TS managedEnvConstants.ts:92-103 comment block enumerates the
+        # explicit "DANGEROUS" categories. Audit that we keep them all.
+        for expected in (
+            "NODE_EXTRA_CA_CERTS",
+            "NODE_TLS_REJECT_UNAUTHORIZED",
+            "ANTHROPIC_BASE_URL",
+            "HTTP_PROXY",
+            "ANTHROPIC_API_KEY",
+            "AWS_BEARER_TOKEN_BEDROCK",
+        ):
+            with self.subTest(key=expected):
+                self.assertIn(expected, UNSAFE_ENV_KEYS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements **plan phase 1** of the `ch02-bootstrap` refactor — book chapter 2 ("Starting Fast — The Bootstrap Pipeline"). Closes the largest C-tier gap from the gap analysis: the chapter's memoized `init()` + two-stage trust boundary did not exist in the Python port.

The TypeScript reference (`typescript/src/entrypoints/init.ts`) is a ~340-line memoized async function that runs before any Commander subcommand handler. Phase 1 ports the architectural skeleton: a single `init()` function, idempotent across multiple entry points (REPL, headless, future SDK), gated by a safe-vs-full env-var partition that matches the chapter's §"The Trust Boundary" security model.

## What's new

**Modules:**
- `src/init.py` — `@functools.cache`-memoized `init()` + `run_pre_action(args)` (Python's `preAction` analog). Substeps run in chapter order: safe env vars → graceful shutdown → API preconnect. Interactive bootstrap state setters move here (closes M7.1 state-ordering gap from gap analysis §3.3).
- `src/permissions/trust_boundary.py` — Two-stage env-var partition. `SAFE_ENV_KEYS` is a verbatim 82-entry port of TS `managedEnvConstants.ts:109-194`. `NODE_EXTRA_CA_CERTS`, `NODE_TLS_REJECT_UNAUTHORIZED`, proxy vars, and API-key vars are explicitly in `UNSAFE_ENV_KEYS` per the chapter's "TRUST ATTACKER-CONTROLLED SERVER" / "REDIRECT TO ATTACKER-CONTROLLED SERVER" comment block.
- `src/utils/graceful_shutdown.py` — `SIGINT`/`SIGTERM`/atexit-coordinated cleanup registry. Thread-safe registration, re-entry-safe drain (signal-during-atexit and atexit-during-signal both handled), best-effort cleanup with exception isolation.

**Wiring:**
- `cli.py`: phase-boundary profile checkpoints at every chapter-phase transition. `run_pre_action(args)` called after the post-argparse `--version`/`--config` short-circuits (preserves the chapter's "fast paths never pay init cost" property). Duplicate `start_api_preconnect` call removed (now lives inside `init()`).
- `entrypoints/tui.py`, `repl/core.py`: redundant `set_is_interactive(True)` calls removed — state is now set by `run_pre_action` before any entrypoint runs.

## Architectural properties verified

| Property | How verified |
|---|---|
| Fast paths skip `init()` | `--version` profile records ONLY `cli_main_entry`. Tests cover both pre-argparse and post-argparse fast-path arms. |
| `init()` runs exactly once across callers | `TestInitIsMemoized` and `TestInitRunsExactlyOnceAcrossEntries` assert call counts. |
| Trust boundary excludes attacker-controlled env | `TestUnsafeKeysBlocked` covers `PATH`, `NODE_EXTRA_CA_CERTS`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`, `LD_PRELOAD`, etc. |
| `_load_config_env` reads ONLY global config | `TestLoadConfigEnvOnlyReadsGlobal` asserts `load_project` / `load_local` are NOT called pre-trust (defense-in-depth on top of the `is_safe_env_key` allow-list). |
| Graceful shutdown drains on SIGINT / SIGTERM | Subprocess-isolated tests (`TestSigtermPathRunsCleanups`, `TestSigintDuringPrefetch`, `TestSigintBeforePrefetchStarted`) spawn real Python subprocesses, send real signals, assert correct exit codes (143 / 130) and cleanup output. |

## Test results

- **55 new tests pass** (test_trust_boundary, test_graceful_shutdown, test_init, test_init_integration).
- **78 pre-existing bootstrap-adjacent tests pass** (test_prefetch, test_bootstrap_state, test_permission_setup, test_memory_prefetch).
- 8 failures elsewhere in the suite (test_repl, parity/test_structural_parity_r2) are **pre-existing on `main`** — caused by Python 3.14 + `zhipuai` version incompatibility and a missing `mcp` package dependency, unrelated to this change.

## Measured impact

Full pipeline (interactive `-p hello` invocation) runs at **~45ms** end-to-end on this machine — well under the chapter's 300ms budget. Slowest individual phase is `permissions_resolved` at ~26ms (covered by gap analysis M3.3 — already ported in `permissions/dangerous_safety.py`).

## What's deferred to subsequent PRs

- **Plan phase 2**: chapter phase 3 (`setup()`) — make `run_setup()` callable from `cli.py`, freeze the existing `HookConfigSnapshot`, `initSinks`, `tengu_started`, Python-version check, `--worktree` startup creation. Estimated 1.5-2× this PR's scope.
- **Plan phase 3**: chapter phase 4 (launcher) — extract unified `launch_repl(args)`, add `--resume`/`--continue`/SDK/pipe paths.
- **Plan phase 4**: chapter phase 0 (fast-path expansion) — add `--bare`, `--update`, early-input capture, startup banner.
- **Plan phase 5**: migrations runner + delete stub modules + rename `main.py` parity tool.

## Test plan

- [x] All new unit tests pass (`pytest tests/test_trust_boundary.py tests/test_graceful_shutdown.py tests/test_init.py`).
- [x] All new integration tests pass (`pytest tests/test_init_integration.py`).
- [x] All pre-existing bootstrap tests still pass (`pytest tests/test_prefetch.py tests/test_bootstrap_state.py tests/test_permission_setup.py tests/test_memory_prefetch.py`).
- [x] `clawcodex --version` returns the version and exits 0.
- [x] `clawcodex --config` shows the configuration and exits 0.
- [x] `CLAUDE_CODE_PROFILE_STARTUP=1 clawcodex --version` records ONLY `cli_main_entry` (verifies fast-path-skips-init).
- [x] `CLAUDE_CODE_PROFILE_STARTUP=1 clawcodex -p hello` records all 5 phase-boundary checkpoints in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)