### PR TITLE
feat(bootstrap): ch02 Phase 3 — unified launch_repl(args)

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -132,38 +132,14 @@ def main():
     run_production_setup(args)
     profile_checkpoint("phase3_end_phase4_start")
 
-    if args.print:
-        profile_checkpoint("mode_dispatch_print")
-        # ``phase4_dispatch``: launcher has chosen a mode and is about
-        # to call the mode runner. Not the same as "first render" — the
-        # mode runner is the one that paints. Per-mode first-render
-        # checkpoints are plan phase 2 work (would need a callback
-        # inside each runner).
-        profile_checkpoint("phase4_dispatch")
-        return _run_print_mode(args)
-
-    # Interactive path: decide between the Textual TUI (new default) and the
-    # legacy Rich REPL. Explicit flags win; otherwise auto-detect a compatible TTY.
-    explicit_tui: bool | None = None
-    if args.tui:
-        explicit_tui = True
-    elif getattr(args, 'legacy_repl', False) or args.no_tui:
-        explicit_tui = False
-
-    from src.entrypoints.tui import should_use_tui
-
-    if should_use_tui(explicit_tui):
-        profile_checkpoint("mode_dispatch_tui")
-        profile_checkpoint("phase4_dispatch")
-        return _run_tui_mode(args)
-
-    profile_checkpoint("mode_dispatch_repl")
-    profile_checkpoint("phase4_dispatch")
-    return start_repl(
-        stream=args.stream,
-        permission_mode=args._resolved_permission_mode,
-        is_bypass_permissions_mode_available=args._resolved_is_bypass_available,
-    )
+    # Plan-phase-3 wiring (ch02-bootstrap-refactoring-plan.md Phase 3):
+    # Chapter phase 4 — mode dispatch. Previously this was three
+    # inline if-branches in cli.main(); ``replLauncher.launch_repl(args)``
+    # now owns the dispatch decision so all paths flow through one
+    # router. Each launcher branch emits its own
+    # mode_dispatch_* + phase4_dispatch checkpoints before delegating.
+    from src.replLauncher import launch_repl
+    return launch_repl(args)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/src/replLauncher.py
+++ b/src/replLauncher.py
@@ -1,44 +1,40 @@
-"""REPL launcher shims.
+"""REPL launcher — chapter phase 4 dispatch.
 
-Mirrors the role of ``typescript/src/replLauncher.tsx`` in the Python
-port: a thin factory that decides how to boot the interactive REPL.
+Mirrors ``typescript/src/replLauncher.tsx``. The chapter's framing:
+"seven different code paths converge on replLauncher.tsx", though as
+noted in the gap analysis the TS reality is a print/headless ↔
+interactive-REPL split (TS actually splits print mode through
+``runHeadless`` separately from ``launchRepl``).
 
-**Current default**: the legacy ``prompt_toolkit + rich`` REPL at
-:mod:`src.repl.core`. The Textual TUI at :mod:`src.tui.app` is **opt-in**
-via the ``--tui`` flag, the ``CLAWCODEX_TUI=1`` environment variable, or
-the ``/tui`` slash command from within the legacy REPL. See
-:func:`src.entrypoints.tui.should_use_tui` for the policy.
+The Python launcher mirrors that pragmatic split:
 
-This module intentionally stays slim: the actual wiring lives in
-:mod:`src.entrypoints.tui` (Textual path) and :mod:`src.repl.core`
-(legacy path). Keeping a dedicated entrypoint here makes it easy for
-embedders (e.g. future ``replLauncher`` callers in the ``demos/`` tree)
-to pick a UI without reaching into the CLI module.
+* :func:`launch_repl(args)` is the single unified entry point that
+  ``cli.main()`` calls. It inspects ``args`` and dispatches to one of
+  three concrete mode runners (print, TUI, REPL).
+* The previous per-mode helpers in ``cli.py`` (``_run_print_mode``,
+  ``_run_tui_mode``, ``start_repl``) are kept but become thin wrappers
+  that ``launch_repl`` delegates to. This decouples the dispatch
+  decision from the dispatch wiring.
 
-Composition diagram (entry-point relationships)::
+Plan reference: ``my-docs/ch02-bootstrap-refactoring-plan.md`` Phase 3.
 
-                        cli.main()
-                           |
-                   +-------+--------+
-                   v                v
-      cli._run_tui_mode (--tui)   cli.start_repl (default)
-                   |                |
-                   v                v
-       entrypoints.tui.run_tui   repl.core.PromptSession
-                   |                ^
-                   v                | (slash command /tui handoff)
-            tui.app.ClawCodexTUI ---+
-
-The handoff arrow is one-way: ``/tui`` from inside the legacy REPL boots
-the Textual UI and returns to the shell when the user exits the TUI; the
-legacy REPL does not auto-resume after the round trip (state carry-over
-is read-only via ``_replay_transcript_to_host``). See
-``my-docs/ch13-terminal-ui-refactoring-plan.md`` working assumption A12.
+Deferred to later plan phases:
+- ``--resume`` / ``--continue`` paths (session restore).
+- SDK mode (Agent SDK harness).
+- Pipe mode (stdin-only stream-json).
+These would each add a branch to :func:`launch_repl`; the chapter's
+"seven paths" total is achievable once they land.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "build_repl_banner",
+    "launch_repl",
+]
 
 
 def build_repl_banner() -> str:
@@ -50,32 +46,80 @@ def build_repl_banner() -> str:
     )
 
 
-def launch_repl(
-    *,
-    prefer_tui: bool | None = None,
-    workspace_root: Path | None = None,
-    stream: bool = True,
-) -> int:
-    """Boot the interactive UI.
+def launch_repl(args: Any) -> int:
+    """Chapter phase 4 launcher. Inspects ``args`` and dispatches to
+    the right mode runner.
 
-    Args:
-        prefer_tui: ``True`` forces the Textual TUI, ``False`` forces the
-            legacy Rich REPL, ``None`` auto-detects via
-            :func:`src.entrypoints.tui.should_use_tui`.
-        workspace_root: Override the workspace root for the Textual path.
-        stream: Whether the legacy REPL should enable live streaming.
+    Modes recognized (matches the cli.py argparse surface):
 
-    Returns:
-        A conventional process exit code.
+    * ``args.print`` → headless / print mode (`_dispatch_print`).
+    * ``args.tui`` or auto-detected TUI environment → Textual UI
+      (`_dispatch_tui`).
+    * else → legacy ``prompt_toolkit`` + Rich REPL (`_dispatch_repl`).
+
+    All three branches emit ``profile_checkpoint("phase4_dispatch")``
+    before delegating, so the chapter's phase-4 boundary is observable
+    regardless of which mode wins.
+
+    **Precondition for the REPL branch:** ``args`` must have
+    ``_resolved_permission_mode`` and ``_resolved_is_bypass_available``
+    populated. ``cli._resolve_permission_state(args)`` is the canonical
+    populator and is called from ``cli.main()`` before this function.
+    The print and TUI branches read their own permission state from
+    ``args.permission_mode`` and friends (via the per-mode helpers'
+    option translation in ``_run_print_mode`` / ``_run_tui_mode``).
+    Callers invoking ``launch_repl`` from harnesses outside
+    ``cli.main()`` (future SDK shims, test rigs) must set these fields
+    before delegating to the REPL branch.
+
+    Returns a conventional CLI exit code.
     """
+    from src.utils.startup_profiler import profile_checkpoint
+
+    if getattr(args, "print", False):
+        profile_checkpoint("mode_dispatch_print")
+        profile_checkpoint("phase4_dispatch")
+        return _dispatch_print(args)
+
+    explicit_tui: bool | None = None
+    if getattr(args, "tui", False):
+        explicit_tui = True
+    elif getattr(args, "legacy_repl", False) or getattr(args, "no_tui", False):
+        explicit_tui = False
 
     from src.entrypoints.tui import should_use_tui
 
-    if should_use_tui(prefer_tui):
-        from src.entrypoints.tui import TUIOptions, run_tui
+    if should_use_tui(explicit_tui):
+        profile_checkpoint("mode_dispatch_tui")
+        profile_checkpoint("phase4_dispatch")
+        return _dispatch_tui(args)
 
-        return run_tui(TUIOptions(workspace_root=workspace_root, stream=stream))
+    profile_checkpoint("mode_dispatch_repl")
+    profile_checkpoint("phase4_dispatch")
+    return _dispatch_repl(args)
 
+
+def _dispatch_print(args: Any) -> int:
+    """Dispatch to headless / print mode. Delegates to
+    ``cli._run_print_mode`` to avoid duplicating the option-validation
+    logic (which is dense and shared by other CLI entry points)."""
+    from src.cli import _run_print_mode
+    return _run_print_mode(args)
+
+
+def _dispatch_tui(args: Any) -> int:
+    """Dispatch to the Textual TUI. Delegates to ``cli._run_tui_mode``."""
+    from src.cli import _run_tui_mode
+    return _run_tui_mode(args)
+
+
+def _dispatch_repl(args: Any) -> int:
+    """Dispatch to the legacy prompt_toolkit + Rich REPL."""
     from src.cli import start_repl
-
-    return start_repl(stream=stream)
+    return start_repl(
+        stream=getattr(args, "stream", False),
+        permission_mode=args._resolved_permission_mode,
+        is_bypass_permissions_mode_available=(
+            args._resolved_is_bypass_available
+        ),
+    )

--- a/tests/test_repl_launcher.py
+++ b/tests/test_repl_launcher.py
@@ -1,0 +1,176 @@
+"""Unit tests for ``src/replLauncher.py:launch_repl`` (plan phase 3).
+
+Verifies that the chapter phase-4 dispatch logic (previously inline in
+``cli.main()``) is correctly factored into ``launch_repl(args)`` and
+delegates to the right mode runner.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from unittest import mock
+
+import pytest
+
+from src.bootstrap.state import reset_state_for_tests
+from src.replLauncher import build_repl_banner, launch_repl
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    reset_state_for_tests()
+    yield
+    reset_state_for_tests()
+
+
+def _make_args(**kwargs) -> types.SimpleNamespace:
+    """Build a minimal argparse-ish namespace for tests."""
+    defaults = dict(
+        print=False,
+        tui=False,
+        legacy_repl=False,
+        no_tui=False,
+        stream=False,
+        _resolved_permission_mode="default",
+        _resolved_is_bypass_available=False,
+    )
+    defaults.update(kwargs)
+    return types.SimpleNamespace(**defaults)
+
+
+class TestBuildReplBanner(unittest.TestCase):
+    def test_banner_returns_string(self) -> None:
+        banner = build_repl_banner()
+        self.assertIsInstance(banner, str)
+        self.assertGreater(len(banner), 0)
+
+
+class TestLaunchReplPrintMode(unittest.TestCase):
+    """``args.print=True`` must dispatch to print mode unconditionally."""
+
+    def test_print_mode_dispatches_to_run_print_mode(self) -> None:
+        with mock.patch("src.cli._run_print_mode", return_value=0) as mock_print, \
+                mock.patch("src.cli._run_tui_mode") as mock_tui, \
+                mock.patch("src.cli.start_repl") as mock_repl:
+            rc = launch_repl(_make_args(print=True))
+        self.assertEqual(rc, 0)
+        mock_print.assert_called_once()
+        mock_tui.assert_not_called()
+        mock_repl.assert_not_called()
+
+    def test_print_mode_overrides_tui_flag(self) -> None:
+        # When --print is set, --tui is ignored. Mirrors TS's
+        # main.tsx behavior.
+        with mock.patch("src.cli._run_print_mode", return_value=0) as mock_print, \
+                mock.patch("src.cli._run_tui_mode") as mock_tui:
+            launch_repl(_make_args(print=True, tui=True))
+        mock_print.assert_called_once()
+        mock_tui.assert_not_called()
+
+
+class TestLaunchReplTuiMode(unittest.TestCase):
+    def test_explicit_tui_flag_dispatches_to_tui(self) -> None:
+        with mock.patch("src.entrypoints.tui.should_use_tui", return_value=True), \
+                mock.patch("src.cli._run_tui_mode", return_value=0) as mock_tui, \
+                mock.patch("src.cli.start_repl") as mock_repl:
+            rc = launch_repl(_make_args(tui=True))
+        self.assertEqual(rc, 0)
+        mock_tui.assert_called_once()
+        mock_repl.assert_not_called()
+
+    def test_legacy_repl_flag_forces_repl(self) -> None:
+        # --legacy-repl forces the REPL branch even if should_use_tui
+        # would otherwise return True.
+        with mock.patch("src.entrypoints.tui.should_use_tui", return_value=False) as mock_should, \
+                mock.patch("src.cli.start_repl", return_value=0) as mock_repl:
+            launch_repl(_make_args(legacy_repl=True))
+        mock_should.assert_called_once_with(False)
+        mock_repl.assert_called_once()
+
+    def test_no_tui_flag_forces_repl(self) -> None:
+        with mock.patch("src.entrypoints.tui.should_use_tui", return_value=False) as mock_should, \
+                mock.patch("src.cli.start_repl", return_value=0):
+            launch_repl(_make_args(no_tui=True))
+        mock_should.assert_called_once_with(False)
+
+
+class TestLaunchReplDefaultMode(unittest.TestCase):
+    """When no flag is set, auto-detect (defer to should_use_tui)."""
+
+    def test_default_falls_through_to_should_use_tui(self) -> None:
+        # When neither --tui nor --legacy-repl nor --no-tui is set,
+        # the launcher calls should_use_tui(None) to let it auto-detect.
+        with mock.patch(
+            "src.entrypoints.tui.should_use_tui", return_value=False
+        ) as mock_should, mock.patch("src.cli.start_repl", return_value=0):
+            launch_repl(_make_args())
+        mock_should.assert_called_once_with(None)
+
+    def test_auto_detected_tui_dispatches_to_tui(self) -> None:
+        with mock.patch("src.entrypoints.tui.should_use_tui", return_value=True), \
+                mock.patch("src.cli._run_tui_mode", return_value=0) as mock_tui:
+            launch_repl(_make_args())
+        mock_tui.assert_called_once()
+
+
+class TestLaunchReplProfileCheckpoints(unittest.TestCase):
+    """Each mode branch must emit phase4_dispatch + its mode_dispatch_*
+    checkpoint."""
+
+    def setUp(self) -> None:
+        from src.utils import startup_profiler
+        self._was_enabled = startup_profiler._PROFILING_ENABLED
+        startup_profiler._PROFILING_ENABLED = True
+        startup_profiler.reset_profiler_for_test_only()
+
+    def tearDown(self) -> None:
+        from src.utils import startup_profiler
+        startup_profiler._PROFILING_ENABLED = self._was_enabled
+        startup_profiler.reset_profiler_for_test_only()
+
+    def test_print_mode_checkpoints(self) -> None:
+        from src.utils import startup_profiler
+        with mock.patch("src.cli._run_print_mode", return_value=0):
+            launch_repl(_make_args(print=True))
+        names = [n for n, _ in startup_profiler.get_internal_phase_log()]
+        self.assertIn("mode_dispatch_print", names)
+        self.assertIn("phase4_dispatch", names)
+
+    def test_tui_mode_checkpoints(self) -> None:
+        from src.utils import startup_profiler
+        with mock.patch("src.entrypoints.tui.should_use_tui", return_value=True), \
+                mock.patch("src.cli._run_tui_mode", return_value=0):
+            launch_repl(_make_args(tui=True))
+        names = [n for n, _ in startup_profiler.get_internal_phase_log()]
+        self.assertIn("mode_dispatch_tui", names)
+        self.assertIn("phase4_dispatch", names)
+
+    def test_repl_mode_checkpoints(self) -> None:
+        from src.utils import startup_profiler
+        with mock.patch("src.entrypoints.tui.should_use_tui", return_value=False), \
+                mock.patch("src.cli.start_repl", return_value=0):
+            launch_repl(_make_args())
+        names = [n for n, _ in startup_profiler.get_internal_phase_log()]
+        self.assertIn("mode_dispatch_repl", names)
+        self.assertIn("phase4_dispatch", names)
+
+
+class TestCliMainCallsLauncher(unittest.TestCase):
+    """Integration: cli.main now calls launch_repl(args) instead of
+    inline mode dispatch. Verify the wiring."""
+
+    def test_cli_main_invokes_launch_repl(self) -> None:
+        with mock.patch("src.init.run_pre_action"), \
+                mock.patch("src.cli._resolve_permission_state"), \
+                mock.patch("src.setup.run_production_setup"), \
+                mock.patch("src.replLauncher.launch_repl", return_value=0) as mock_launch, \
+                mock.patch.object(sys, "argv", ["clawcodex"]):
+            from src import cli
+            cli.main()
+            mock_launch.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements **plan phase 3** of the `ch02-bootstrap` refactor — chapter 2's Phase 4 (launcher). Closes **C4.1** from the gap analysis (`launch_repl is dead code on every path`).

Stacked on #85 (Phase 2). Merge order: #84 → #85 → this PR.

## What's new

**Modified modules:**
- `src/replLauncher.py` — rewrote `launch_repl(args)` from a thin one-mode shim into the unified phase-4 router. Inspects `args`, dispatches via private helpers `_dispatch_print` / `_dispatch_tui` / `_dispatch_repl`. Each helper emits the right `mode_dispatch_*` + `phase4_dispatch` profile checkpoints before delegating to the underlying mode runner.
- `src/cli.py` — collapsed ~30 lines of inline print/TUI/REPL dispatch into a single `return launch_repl(args)` call at the end of `main()`.

**New tests:**
- `tests/test_repl_launcher.py` — 12 tests covering print mode, TUI mode (explicit + legacy override + no-tui override), default mode (auto-detect via `should_use_tui(None)`), profile-checkpoint emission per branch, and the `cli.main → launch_repl` wiring invariant.

## Key design decisions

1. **Per-mode helpers stay in cli.py.** I considered moving `_run_print_mode` / `_run_tui_mode` / `start_repl` physically into `replLauncher.py`, but the option-validation logic inside each (e.g., `_run_print_mode`'s `--input-format stream-json` cross-flag checks) is dense and has its own test coverage. Moving it would be a much larger, riskier diff for zero architectural gain. The launcher decouples *decision* from *wiring* — the wiring stays where it was.

2. **Lazy imports resolve the cli↔launcher cycle.** `cli.py` imports `launch_repl` lazily inside `main()`; `replLauncher.py` imports `cli._run_*` lazily inside each `_dispatch_*`. Both directions verified — no ImportError at module load.

3. **Profile checkpoints move into the launcher.** Each branch fires its own pair (`mode_dispatch_print` + `phase4_dispatch`, etc.) closer to the actual decision. Easier to trace in profile reports.

4. **`getattr(args, "field", default)`** defensive pattern lets the launcher gracefully handle partial `args` namespaces from tests or future SDK callers.

## Architectural property verified

The chapter's "all paths converge on the launcher" framing is now true (modulo the deferred `--resume`/`--continue`/SDK/pipe modes which are feature ports, not refactor scope). Verified end-to-end via `TestCliMainCallsLauncher.test_cli_main_invokes_launch_repl` — the integration test that catches any future regression that re-introduces inline dispatch in cli.py.

## Test plan

- [x] 12 new launcher tests pass.
- [x] 191 pre-existing bootstrap+hook tests still pass.
- [x] 111 ToolContext-using tests still pass.
- [x] `clawcodex --version` works.
- [x] Smoke profile shows the launcher hop firing once per invocation, with `mode_dispatch_*` + `phase4_dispatch` in correct order. Total startup ~61ms.

## Deferred

- **P3.3** (`--resume`, `--continue` session-restore paths) — needs the session-restore code path, which doesn't exist in Python yet. Feature port, not refactor scope.
- **P3.4** (SDK and pipe-mode paths) — pending Python Agent SDK port.

Each deferral is a `launch_repl` branch addition that doesn't change the architectural shape.

## Gap analysis closure

- **C4.1** (`launch_repl is dead code`): ✅ closed in behavior.
- **C4.2** (missing modes): partial — print/TUI/REPL all wired through the launcher; `--resume`/`--continue`/SDK/pipe still missing as feature ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)