### PR TITLE
feat(bootstrap): ch02 Phase 5 — schema migration runner

### DIFF
--- a/src/migrations/__init__.py
+++ b/src/migrations/__init__.py
@@ -1,16 +1,209 @@
-"""Python package placeholder for the archived `migrations` subsystem."""
+"""Schema migration runner — chapter §"The Migration System".
+
+Mirrors TS ``typescript/src/main.tsx``'s migration sequence (many
+``migrateXxxToYyy`` functions imported and invoked very early in the
+boot). The chapter §"The Migration System" describes the contract:
+
+> Each migration is a function with a version number. The system checks
+> the current schema version against the highest migration version,
+> runs pending migrations in order, and updates the version.
+> Migrations are idempotent and fast (operating on small local files,
+> not databases). The entire migration pass typically completes in
+> under 5ms. If a migration fails, it logs the error and continues —
+> availability beats strict consistency for local configuration.
+
+Plan reference: ``my-docs/ch02-bootstrap-refactoring-plan.md`` Phase 5.
+
+Migration storage: the schema version lives in the global config
+(``~/.clawcodex/config.json``) under the key ``schema_version`` (int,
+default 0). The migration runner reads this, finds all pending
+migrations registered via :func:`register_migration`, runs them in
+order, and writes the new version back.
+
+Most TS migrations are model-alias renames (Sonnet 1m → 4.5, Opus →
+Opus 1m, etc.) which don't apply to Python's provider surface. The
+runner is built without porting individual migrations — they can be
+added later as needed.
+
+**Adding a new migration**: create ``src/migrations/vN_short_name.py``
+with a top-level ``@register_migration(version=N, name="short_name")``
+decorator, then add ``from . import vN_short_name  # noqa: F401`` to
+this file's import block. The decorator-based registration is import-
+time, so the submodule must be imported before ``run_pending_migrations``
+runs.
+
+**Failed-migration semantics**: a migration that *raises* is logged
+and the runner moves on to the next. The failed migration's schema
+version is NOT written, but subsequent successful migrations DO
+update the version. Practical consequence: if v2 raises and v3
+succeeds, the disk ends up at v3 — v2 is permanently skipped on
+future startups. This matches the chapter's "availability beats
+strict consistency" stance: a broken migration shouldn't block
+future ones. Migrations must be designed so vN+1 doesn't depend on
+vN's effects.
+"""
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
+import logging
+from dataclasses import dataclass
+from typing import Callable
 
-SNAPSHOT_PATH = Path(__file__).resolve().parent.parent / 'reference_data' / 'subsystems' / 'migrations.json'
-_SNAPSHOT = json.loads(SNAPSHOT_PATH.read_text())
+__all__ = [
+    "Migration",
+    "register_migration",
+    "get_registered_migrations",
+    "clear_migrations_for_test_only",
+    "run_pending_migrations",
+    "get_schema_version",
+    "set_schema_version",
+    "SCHEMA_VERSION_KEY",
+]
 
-ARCHIVE_NAME = _SNAPSHOT['archive_name']
-MODULE_COUNT = _SNAPSHOT['module_count']
-SAMPLE_FILES = tuple(_SNAPSHOT['sample_files'])
-PORTING_NOTE = f"Python placeholder package for '{ARCHIVE_NAME}' with {MODULE_COUNT} archived module references."
 
-__all__ = ['ARCHIVE_NAME', 'MODULE_COUNT', 'PORTING_NOTE', 'SAMPLE_FILES']
+_logger = logging.getLogger("clawcodex.migrations")
+
+
+SCHEMA_VERSION_KEY = "schema_version"
+
+
+@dataclass(frozen=True)
+class Migration:
+    """A single schema migration.
+
+    Each migration has a version number (monotonically increasing)
+    and a callable that runs the actual upgrade. The callable should:
+
+    - Be idempotent (safe to re-run if the version write fails).
+    - Be fast (local-file mutations only, no network).
+    - Not raise on partial state (degrade gracefully).
+    - Return ``None``.
+
+    The chapter's philosophy: "availability beats strict consistency
+    for local configuration." A failed migration logs an error and
+    the runner continues to the next.
+    """
+
+    version: int
+    name: str
+    fn: Callable[[], None]
+
+
+_registry: list[Migration] = []
+
+
+def register_migration(version: int, name: str) -> Callable[[Callable[[], None]], Callable[[], None]]:
+    """Decorator: register a migration in the runner's registry.
+
+    Usage::
+
+        @register_migration(version=1, name="rename_opus_to_opus_1m")
+        def _migrate_opus_to_opus_1m() -> None:
+            ...
+
+    Registration happens at module-import time. Migration modules
+    should be imported before ``run_pending_migrations()`` is called —
+    typically from this package's ``__init__`` if/when migrations are
+    added. For plan-phase-5 the registry is empty by design (no
+    migrations to run yet); the runner is structurally in place for
+    future migrations.
+    """
+
+    def decorator(fn: Callable[[], None]) -> Callable[[], None]:
+        _registry.append(Migration(version=version, name=name, fn=fn))
+        # Keep the registry sorted by version so the runner can iterate
+        # in order without re-sorting on every call.
+        _registry.sort(key=lambda m: m.version)
+        return fn
+
+    return decorator
+
+
+def get_registered_migrations() -> tuple[Migration, ...]:
+    """Return the currently-registered migrations, sorted by version."""
+    return tuple(_registry)
+
+
+def clear_migrations_for_test_only() -> None:
+    """Wipe the registry. Test-only."""
+    import os
+    if os.environ.get("PYTEST_CURRENT_TEST") is None:
+        raise RuntimeError(
+            "clear_migrations_for_test_only can only be called in tests"
+        )
+    _registry.clear()
+
+
+def get_schema_version() -> int:
+    """Read the current schema version from the global config.
+
+    Returns ``0`` (the default for a fresh install) when the key is
+    missing. Lazy import of ``ConfigManager`` avoids early-cycle risk.
+    """
+    try:
+        from src.config import ConfigManager
+        cm = ConfigManager()
+        return int(cm.load_global().get(SCHEMA_VERSION_KEY, 0))
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        _logger.debug("schema version read failed: %s; assuming 0", exc)
+        return 0
+
+
+def set_schema_version(version: int) -> None:
+    """Write the schema version to the global config.
+
+    Best-effort: any exception is logged but doesn't crash the migration
+    pass. Future migrations will re-attempt on the next startup.
+    """
+    try:
+        from src.config import ConfigManager
+        cm = ConfigManager()
+        config = cm.load_global()
+        config[SCHEMA_VERSION_KEY] = int(version)
+        cm.save_global(config)
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        _logger.warning("schema version write failed: %s", exc)
+
+
+def run_pending_migrations() -> int:
+    """Run all migrations with version > current schema version.
+
+    Returns the number of migrations that ran (0 if none pending).
+
+    Each migration runs inside its own try/except — a failure logs
+    and is skipped, matching the chapter's "availability beats strict
+    consistency" stance. The schema version is updated AFTER each
+    successful migration (not at the end), with two consequences:
+
+    1. **Process-crash resilience**: if v1 succeeds, the version
+       writes to disk; if the process is killed before v2 runs, the
+       next startup correctly picks up at v2.
+    2. **Failed-migration semantics**: if v2 raises and v3 succeeds,
+       disk = v3 — v2 is NOT retried on subsequent startups. See the
+       module docstring §"Failed-migration semantics" for the
+       rationale.
+    """
+    current = get_schema_version()
+    pending = [m for m in _registry if m.version > current]
+    if not pending:
+        return 0
+
+    ran = 0
+    for migration in pending:
+        try:
+            _logger.info(
+                "running migration v%d (%s)",
+                migration.version,
+                migration.name,
+            )
+            migration.fn()
+            set_schema_version(migration.version)
+            ran += 1
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            _logger.error(
+                "migration v%d (%s) failed: %s; continuing",
+                migration.version,
+                migration.name,
+                exc,
+            )
+    return ran

--- a/src/setup.py
+++ b/src/setup.py
@@ -157,9 +157,10 @@ def run_production_setup(args: Any = None) -> None:
     session-memory) and are scoped for later plan phases.
 
     1. Python-version check (>=3.10 per pyproject.toml).
-    2. Hook config snapshot freeze (``captureHooksConfigSnapshot``).
-    3. ``tengu_started`` beacon (success-rate denominator).
-    4. ``tengu_exit`` previous-session metrics log (if available).
+    2. Schema migration runner (``run_pending_migrations``).
+    3. Hook config snapshot freeze (``captureHooksConfigSnapshot``).
+    4. ``tengu_started`` beacon (success-rate denominator).
+    5. ``tengu_exit`` previous-session metrics log (if available).
 
     Raises ``SystemExit(1)`` if the Python version is below the
     supported minimum — matches TS behavior at setup.ts:71-78.
@@ -170,6 +171,9 @@ def run_production_setup(args: Any = None) -> None:
 
     _check_python_version()
     profile_checkpoint("setup_python_version_checked")
+
+    _run_pending_migrations()
+    profile_checkpoint("setup_migrations_run")
 
     _capture_hook_snapshot()
     profile_checkpoint("setup_hook_snapshot_captured")
@@ -191,6 +195,26 @@ def _check_python_version() -> None:
             f"Found Python {actual}.\n"
         )
         raise SystemExit(1)
+
+
+def _run_pending_migrations() -> None:
+    """Run schema migrations registered via ``src.migrations``.
+
+    Plan phase 5: mirrors the chapter §"The Migration System". For
+    plan phase 5 the registry is empty (no migrations ported yet);
+    this substep is the seam where future migrations plug in.
+
+    Best-effort: failures are logged inside the runner and don't
+    crash setup. Matches the chapter's "availability beats strict
+    consistency" stance.
+    """
+    try:
+        from src.migrations import run_pending_migrations
+        ran = run_pending_migrations()
+        if ran:
+            _logger.info("ran %d migration(s) at startup", ran)
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        _logger.warning("migrations runner failed: %s", exc)
 
 
 def _capture_hook_snapshot() -> None:

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,237 @@
+"""Unit tests for ``src/migrations/__init__.py`` (plan phase 5).
+
+Verifies the migration runner contract: registration, version
+ordering, idempotency, partial-run resilience.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from src.migrations import (
+    SCHEMA_VERSION_KEY,
+    Migration,
+    clear_migrations_for_test_only,
+    get_registered_migrations,
+    get_schema_version,
+    register_migration,
+    run_pending_migrations,
+    set_schema_version,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_migrations():
+    clear_migrations_for_test_only()
+    yield
+    clear_migrations_for_test_only()
+
+
+class TestRegisterMigration(unittest.TestCase):
+    def test_decorator_registers_migration(self) -> None:
+        @register_migration(version=1, name="test_m1")
+        def m1() -> None:
+            pass
+
+        registered = get_registered_migrations()
+        self.assertEqual(len(registered), 1)
+        self.assertEqual(registered[0].version, 1)
+        self.assertEqual(registered[0].name, "test_m1")
+        self.assertIs(registered[0].fn, m1)
+
+    def test_migrations_sorted_by_version(self) -> None:
+        # Register out of order; runner sorts by version.
+        @register_migration(version=3, name="m3")
+        def m3() -> None:
+            pass
+
+        @register_migration(version=1, name="m1")
+        def m1() -> None:
+            pass
+
+        @register_migration(version=2, name="m2")
+        def m2() -> None:
+            pass
+
+        registered = get_registered_migrations()
+        versions = [m.version for m in registered]
+        self.assertEqual(versions, [1, 2, 3])
+
+    def test_clear_outside_pytest_raises(self) -> None:
+        import os
+        saved = os.environ.pop("PYTEST_CURRENT_TEST", None)
+        try:
+            with self.assertRaises(RuntimeError):
+                clear_migrations_for_test_only()
+        finally:
+            if saved is not None:
+                os.environ["PYTEST_CURRENT_TEST"] = saved
+
+
+class TestSchemaVersion(unittest.TestCase):
+    def test_get_returns_zero_when_unset(self) -> None:
+        with mock.patch("src.config.ConfigManager.load_global", return_value={}):
+            self.assertEqual(get_schema_version(), 0)
+
+    def test_get_returns_stored_value(self) -> None:
+        with mock.patch(
+            "src.config.ConfigManager.load_global",
+            return_value={SCHEMA_VERSION_KEY: 5},
+        ):
+            self.assertEqual(get_schema_version(), 5)
+
+    def test_get_returns_zero_on_read_failure(self) -> None:
+        with mock.patch(
+            "src.config.ConfigManager.load_global",
+            side_effect=RuntimeError("disk fail"),
+        ):
+            # Best-effort: read failure returns 0 rather than raising.
+            self.assertEqual(get_schema_version(), 0)
+
+    def test_set_writes_to_global_config(self) -> None:
+        # Use a real ConfigManager pointing at a temp file.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp) / "config.json"
+            with mock.patch(
+                "src.config.get_global_config_path",
+                return_value=tmp_path,
+            ):
+                set_schema_version(7)
+                self.assertTrue(tmp_path.exists())
+                data = json.loads(tmp_path.read_text())
+                self.assertEqual(data[SCHEMA_VERSION_KEY], 7)
+
+    def test_set_failure_does_not_raise(self) -> None:
+        with mock.patch(
+            "src.config.ConfigManager.save_global",
+            side_effect=RuntimeError("disk fail"),
+        ):
+            # Best-effort: must not raise.
+            set_schema_version(5)
+
+
+class TestRunPendingMigrations(unittest.TestCase):
+    def test_no_migrations_returns_zero(self) -> None:
+        with mock.patch("src.migrations.get_schema_version", return_value=0):
+            self.assertEqual(run_pending_migrations(), 0)
+
+    def test_runs_pending_migrations_in_order(self) -> None:
+        call_log: list[int] = []
+
+        @register_migration(version=1, name="m1")
+        def m1() -> None:
+            call_log.append(1)
+
+        @register_migration(version=2, name="m2")
+        def m2() -> None:
+            call_log.append(2)
+
+        @register_migration(version=3, name="m3")
+        def m3() -> None:
+            call_log.append(3)
+
+        with mock.patch("src.migrations.get_schema_version", return_value=0), \
+                mock.patch("src.migrations.set_schema_version") as mock_set:
+            ran = run_pending_migrations()
+            self.assertEqual(ran, 3)
+            self.assertEqual(call_log, [1, 2, 3])
+            # Each successful migration writes its version.
+            self.assertEqual(mock_set.call_count, 3)
+            mock_set.assert_any_call(1)
+            mock_set.assert_any_call(2)
+            mock_set.assert_any_call(3)
+
+    def test_skips_already_run_migrations(self) -> None:
+        call_log: list[int] = []
+
+        @register_migration(version=1, name="m1")
+        def m1() -> None:
+            call_log.append(1)
+
+        @register_migration(version=2, name="m2")
+        def m2() -> None:
+            call_log.append(2)
+
+        # Current schema is at v1; only m2 should run.
+        with mock.patch("src.migrations.get_schema_version", return_value=1), \
+                mock.patch("src.migrations.set_schema_version"):
+            ran = run_pending_migrations()
+            self.assertEqual(ran, 1)
+            self.assertEqual(call_log, [2])
+
+    def test_failed_migration_does_not_block_later_ones(self) -> None:
+        """Chapter §"The Migration System": availability beats consistency.
+        A failed migration logs and is skipped; the runner continues."""
+        call_log: list[int] = []
+
+        @register_migration(version=1, name="m1")
+        def m1() -> None:
+            call_log.append(1)
+
+        @register_migration(version=2, name="m2_fails")
+        def m2() -> None:
+            call_log.append(2)
+            raise RuntimeError("simulated failure")
+
+        @register_migration(version=3, name="m3")
+        def m3() -> None:
+            call_log.append(3)
+
+        with mock.patch("src.migrations.get_schema_version", return_value=0), \
+                mock.patch("src.migrations.set_schema_version") as mock_set:
+            ran = run_pending_migrations()
+            # m1 and m3 ran (count 2); m2 failed and is skipped.
+            self.assertEqual(ran, 2)
+            self.assertEqual(call_log, [1, 2, 3])  # m2 was attempted
+            # Schema version written for m1 and m3, NOT m2.
+            written = [args[0] for args, _ in mock_set.call_args_list]
+            self.assertIn(1, written)
+            self.assertNotIn(2, written)
+            self.assertIn(3, written)
+
+    def test_schema_version_updated_per_migration(self) -> None:
+        """Important property: schema version is written AFTER each
+        successful migration (not at the end), so a crash mid-pass
+        can be resumed on the next startup."""
+
+        @register_migration(version=1, name="m1")
+        def m1() -> None:
+            pass
+
+        @register_migration(version=2, name="m2")
+        def m2() -> None:
+            pass
+
+        with mock.patch("src.migrations.get_schema_version", return_value=0), \
+                mock.patch("src.migrations.set_schema_version") as mock_set:
+            run_pending_migrations()
+            # Order matters: 1 before 2.
+            calls = [args[0] for args, _ in mock_set.call_args_list]
+            self.assertEqual(calls, [1, 2])
+
+
+class TestSetupWiresMigrationRunner(unittest.TestCase):
+    """Integration: run_production_setup includes the migration step."""
+
+    def test_setup_calls_run_pending_migrations(self) -> None:
+        from src.bootstrap.state import reset_state_for_tests
+        from src.hooks.snapshot import reset_hook_snapshot_for_test_only
+        reset_state_for_tests()
+        reset_hook_snapshot_for_test_only()
+
+        with mock.patch(
+            "src.migrations.run_pending_migrations", return_value=0
+        ) as mock_run:
+            from src.setup import run_production_setup
+            run_production_setup(args=None)
+            mock_run.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements **plan phase 5** of the `ch02-bootstrap` refactor — chapter 2's "The Migration System." Closes **M6.1** from the gap analysis (`No migration runner; src/migrations/ is empty`).

Stacked on #87 (Phase 4). Merge order: #84 → #85 → #86 → #87 → this PR. After this lands, the **entire ch02-bootstrap refactor is complete** across all 5 plan phases.

## What's new

**Migration runner** (rewrite of `src/migrations/__init__.py`):
- `@register_migration(version, name)` decorator API for self-registering migration submodules.
- `Migration` frozen dataclass (immutable, sorted by version).
- `get_schema_version` / `set_schema_version` persist to global config (`~/.clawcodex/config.json` under `schema_version`).
- `run_pending_migrations()` iterates pending migrations (version > current schema version), commits the version per-migration after each success, isolates failures per the chapter's "availability beats strict consistency" stance.
- Empty registry in v0.5 — future migration submodules plug in via explicit imports.

**Setup wiring** (`src/setup.py`):
- `_run_pending_migrations()` substep between the Python-version check and the hook snapshot capture.
- Profile checkpoint `setup_migrations_run` after the substep.

## Architectural property delivered

The chapter §"The Migration System": *"Each migration is a function with a version number. The system checks the current schema version against the highest migration version, runs pending migrations in order, and updates the version. Migrations are idempotent and fast. If a migration fails, it logs the error and continues — availability beats strict consistency for local configuration."*

All five chapter contract points are honored:
- Version-numbered functions ✓ (via `Migration.version`).
- Idempotent + fast ✓ (design encourages it; frozen dataclass, no async, no I/O beyond config).
- Highest-version diff ✓ (`run_pending_migrations` filters by `m.version > current`).
- Failures log + continue ✓ (per-migration try/except, schema version commits per-migration).
- Availability over consistency ✓ (read failure returns 0; write failure logs; migration raise skips to next).

## Test plan

**14 new tests** in `tests/test_migrations.py`:
- Registration (decorator, sort-by-version, test-gate).
- Schema version (get/set, read failure, write failure, write to disk).
- Runner (no-op, runs in order, skips already-run, failed migration doesn't block later ones, per-migration commit).
- Integration (`run_production_setup` calls the runner).

- [x] 14 new tests pass.
- [x] 220 pre-existing bootstrap+hook+launcher+bare tests still pass.
- [x] Full filtered suite passes (~4042 tests, no regressions).
- [x] Profile log shows `setup_migrations_run` between `setup_python_version_checked` and `setup_hook_snapshot_captured` at 0.75ms (essentially free with the empty registry).

## Plan-vs-impl

P5.1 (migration runner) — ✅ implemented.

P5.2 (port individual migrations) — deferred. TS migrations are mostly model-alias renames (Sonnet 1m → 4.5, Opus → Opus 1m, etc.) which don't apply to Python's provider surface. Skipped by design.

P5.3 (delete stub modules, rename main.py) — deferred. `main.py` is the parity-audit tool with no production callers, but renaming is a churn-only PR. Acceptable follow-up.

P5.4 (more profile checkpoints) — deferred. Current coverage (23 checkpoints with the new migrations one) is sufficient for budget enforcement.

P5.5 (project scan prefetch wiring) — deferred. Needs design (what to scan, where to stash).

P5.6 (eagerLoadSettings analog) — deferred. Needs settings-layer flag-awareness.

## Final ch02-bootstrap summary

| Plan phase | Chapter phase | C-tier gaps closed | PR |
|---|---|---|---|
| 1 | Phase 2 (init) | C2 (memoized init + trust boundary) | #84 |
| 2 | Phase 3 (setup) | C3 (setup as production primitive + hook snapshot wired end-to-end) | #85 |
| 3 | Phase 4 (launcher) | C4 (unified launch_repl chokepoint) | #86 |
| 4 | Phase 0 (fast-path) | C1.1 (--bare flag with end-to-end prefetch skip) | #87 |
| 5 | Migrations | M6.1 (migration runner framework) | this PR |

M-tier closures across phases: M3.1 (Python version check), M3.4 (tengu_exit structurally wired), M6.1 (migrations), M7.1 (interactive state ordering via run_pre_action). Several M-items remain deferred per gap-analysis hedges (M0.2 startup banner, M3.6 session-memory lazy-vs-startup, M8.1 early input capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)