### PR TITLE
feat(ch06): sync materialization adapter (PR 2/5)

### DIFF
--- a/src/services/tool_execution/__init__.py
+++ b/src/services/tool_execution/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from .sync_adapter import (
+    ToolDispatchResult,
+    dispatch_full,
+    make_stub_assistant_message,
+)
 from .tool_execution import (
     MessageUpdateLazy,
     classify_tool_error,
@@ -35,12 +40,15 @@ __all__ = [
     "PersistResult",
     "PersistToolResultError",
     "PersistedToolResult",
+    "ToolDispatchResult",
     "build_large_tool_result_message",
     "classify_tool_error",
+    "dispatch_full",
     "generate_preview",
     "get_persistence_threshold",
     "is_persist_error",
     "is_tool_result_content_empty",
+    "make_stub_assistant_message",
     "maybe_persist_large_tool_result",
     "persist_tool_result",
     "process_tool_result_block",

--- a/src/services/tool_execution/sync_adapter.py
+++ b/src/services/tool_execution/sync_adapter.py
@@ -1,0 +1,349 @@
+"""Sync materialization adapter around ``run_tool_use``.
+
+The agent loop in ``src/tool_system/agent_loop.py`` and the main
+query loop's ``_dispatch_single_tool`` in ``src/query/query.py`` are
+synchronous (the latter is dispatched onto a thread via
+``asyncio.to_thread``). Both currently call
+``ToolRegistry.dispatch()`` which implements only 6 of the 14
+pipeline steps in ``ch06-tools.md`` — hooks, input backfill,
+``new_messages`` injection, ``context_modifier`` propagation, and
+telemetry-safe error classification are all silently skipped.
+
+The fully-implemented pipeline lives in
+``src/services/tool_execution/tool_execution.py:run_tool_use`` but
+its API is an ``AsyncGenerator[MessageUpdateLazy, None]`` — a
+mismatch with the sync, "return one ToolResult" call sites.
+
+This adapter materializes the async generator into a single
+``ToolDispatchResult`` dataclass with three side-channels surfaced
+explicitly: ``new_messages`` (sub-agent transcripts, system reminders),
+``context_modifier`` (mode changes like ``EnterPlanMode``), and the
+raw ``output`` (preserved typed-dict / typed-str / typed-list shape so
+sync callers branching on output shape continue to work).
+
+The contract is:
+
+- The FIRST tool_result block whose tool_use_id matches the call's id
+  is treated as the primary result. ``output`` is read from the
+  containing message's ``toolUseResult`` field (the run_tool_use
+  pipeline stashes raw ``ToolResult.data`` there, except when
+  ``agent_id`` is set — sub-agent path strips it, in which case we
+  fall back to the block's serialized content).
+- ``context_modifier`` is captured from any ``MessageUpdateLazy`` that
+  carries one (the pipeline only attaches one per call).
+- Everything else (pre-hook attachments, post-hook attachments,
+  ``ToolResult.new_messages`` from inside ``tool.call``, and
+  ``hook_stopped_continuation`` attachments) is bundled into
+  ``new_messages``. Callers append them after the primary result.
+
+The adapter is sync — it drives ``run_tool_use`` via ``asyncio.run``.
+All current production callers run on a thread with no event loop
+(``asyncio.to_thread`` for query.py; plain sync for agent_loop.py),
+so this is correct. If a future caller invokes ``dispatch_full`` from
+inside an event loop, that caller is responsible for using
+``asyncio.run_in_executor`` or a thread-bridge.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from src.tool_system.build_tool import Tool
+from src.tool_system.context import ToolContext
+from src.tool_system.protocol import ToolCall
+
+
+@dataclass
+class ToolDispatchResult:
+    """Materialized result from one tool call dispatched through the
+    full 13-step pipeline (``run_tool_use``).
+
+    See module docstring for field semantics.
+    """
+
+    tool_result_block: dict[str, Any]
+    """The ``{"type": "tool_result", "tool_use_id": ..., "content": ...,
+    "is_error": ...}`` block ready for inclusion in a UserMessage.
+    Already mapped + budgeted by Step 11 of the pipeline."""
+
+    is_error: bool
+    """Mirror of ``tool_result_block["is_error"]``."""
+
+    output: Any
+    """The raw ``ToolResult.data`` from the tool's ``call()``. Preserves
+    typed shape (dict / str / list) on success.
+
+    On error paths (validation failure, permission denial, tool
+    exception) ``output`` carries the pipeline-synthesized error
+    string (e.g. ``"Error: No way"``), NOT ``None`` — the
+    ``toolUseResult`` field that the adapter sources from is populated
+    even on short-circuit paths. **Branch on ``is_error`` BEFORE
+    reading ``output`` to distinguish a real None return from a
+    pipeline error.**
+
+    Sub-agent dispatches (``context.agent_id`` set) strip
+    ``toolUseResult`` to None; the adapter then falls back to the
+    serialized block content as a best-effort string."""
+
+    new_messages: list[Any] = field(default_factory=list)
+    """Auxiliary messages the caller must append to the conversation
+    after the primary tool result. Includes pre-hook attachments,
+    post-hook attachments, ``ToolResult.new_messages`` (sub-agent
+    transcripts, system reminders), and ``hook_stopped_continuation``
+    attachments."""
+
+    context_modifier: Callable[[ToolContext], ToolContext] | None = None
+    """Function returned by tools like ``EnterPlanMode`` that mutates
+    the ``ToolContext`` for subsequent tools in the same turn. Callers
+    are responsible for applying it (and for ordering: serial batches
+    apply immediately; concurrent batches queue until the batch ends)."""
+
+
+def _default_can_use_tool(
+    tool: Tool,
+    tool_input: dict[str, Any],
+    tool_use_context: ToolContext,
+    _assistant_message: Any,
+    _tool_use_id: str,
+    _force_decision: Any = None,
+) -> dict[str, Any]:
+    """Default permission resolver used when the caller doesn't supply
+    a ``can_use_tool`` callback.
+
+    Wraps ``has_permissions_to_use_tool`` from the permissions module so
+    the tool's own ``check_permissions`` method (and rule-based deny
+    checks) actually run. Without this default the pipeline's
+    ``resolve_hook_permission_decision`` falls through to "allow"
+    whenever ``can_use_tool`` is None, which makes tool-level deny
+    decisions silently ineffective.
+
+    ``ask`` decisions are resolved interactively via
+    ``handle_permission_ask`` (consulting
+    ``tool_use_context.permission_handler`` when set) so the adapter
+    matches the existing ``ToolRegistry.dispatch()`` semantics. When no
+    permission handler is registered, ``handle_permission_ask`` returns
+    a deny — same as ``dispatch()`` does today.
+
+    Returns the decision in the dict shape the pipeline expects:
+    ``{"behavior": "allow"|"deny", "message": str | None,
+       "updatedInput": dict | None}`` (``ask`` is always resolved here,
+    not propagated up).
+    """
+    from src.permissions.check import has_permissions_to_use_tool
+    from src.permissions.handler import handle_permission_ask
+    from src.permissions.types import PermissionAskDecision
+
+    decision = has_permissions_to_use_tool(
+        tool, tool_input, tool_use_context.permission_context,
+        tool_use_context=tool_use_context,
+    )
+
+    if isinstance(decision, PermissionAskDecision):
+        handler_cb = None
+        permission_handler = getattr(tool_use_context, "permission_handler", None)
+        if permission_handler is not None:
+            raw_handler = permission_handler
+
+            def _adapted_handler(
+                tn: str, msg: str, suggestions: Any,
+            ) -> tuple[bool, dict[str, Any] | None]:
+                allowed, _ = raw_handler(tn, msg, None)
+                return allowed, None
+
+            handler_cb = _adapted_handler
+        decision = handle_permission_ask(tool.name, decision, handler_cb)
+
+    payload: dict[str, Any] = {"behavior": getattr(decision, "behavior", "allow")}
+    msg = getattr(decision, "message", None)
+    if msg:
+        payload["message"] = msg
+    updated = getattr(decision, "updated_input", None)
+    if updated is not None:
+        payload["updatedInput"] = updated
+    return payload
+
+
+def dispatch_full(
+    tool_call: ToolCall,
+    tool_use_context: ToolContext,
+    assistant_message: Any,
+    *,
+    tools: list[Tool] | None = None,
+    can_use_tool: Any = None,
+) -> ToolDispatchResult:
+    """Sync wrapper that drives ``run_tool_use`` to completion.
+
+    Args:
+        tool_call: the call to dispatch (name + input + tool_use_id).
+        tool_use_context: the ``ToolContext`` the pipeline operates on.
+            Mutations made by hooks/budget tracking apply in place to
+            this context (the running aggregate counter, the
+            ``tool_use_id`` field, etc.).
+        assistant_message: the originating ``AssistantMessage`` that
+            emitted the tool call. Hooks have access to this. Callers
+            who don't have a real assistant message can construct a
+            stub via ``_make_stub_assistant_message`` (provided in
+            this module).
+        tools: explicit tool list for name lookup. Overrides
+            ``tool_use_context.options.tools`` when provided.
+        can_use_tool: optional ``CanUseToolFn`` hook for permission
+            override; ``None`` lets the pipeline use the default
+            ``has_permissions_to_use_tool`` flow.
+
+    Returns:
+        A ``ToolDispatchResult`` with the primary block, raw output,
+        any new messages, and the optional context modifier.
+
+    Raises:
+        Nothing from ``tool.call`` directly — exceptions inside the
+        pipeline are caught and surfaced as ``is_error=True`` results.
+        ``asyncio.run`` will surface a ``RuntimeError`` if called from
+        inside a running event loop — production callers are sync /
+        on worker threads, so this should not occur.
+    """
+    from src.services.tool_execution.streaming_executor import ToolUseBlock
+    from src.services.tool_execution.tool_execution import run_tool_use
+
+    tool_use_block = ToolUseBlock(
+        id=tool_call.tool_use_id or "",
+        name=tool_call.name,
+        input=tool_call.input,
+    )
+
+    # Provide a default permission resolver when the caller doesn't,
+    # otherwise the pipeline silently auto-allows every tool (see
+    # ``_default_can_use_tool`` docstring for context).
+    effective_can_use_tool = can_use_tool if can_use_tool is not None else _default_can_use_tool
+
+    async def _run() -> ToolDispatchResult:
+        primary_block: dict[str, Any] | None = None
+        is_error = False
+        output: Any = None
+        new_messages: list[Any] = []
+        context_modifier: Callable[[ToolContext], ToolContext] | None = None
+
+        async for update in run_tool_use(
+            tool_use_block,
+            assistant_message,
+            effective_can_use_tool,
+            tool_use_context,
+            tools=tools,
+        ):
+            msg = _msg_of(update)
+            ctx_mod = _ctx_mod_of(update)
+
+            if ctx_mod is not None and context_modifier is None:
+                context_modifier = ctx_mod
+
+            if msg is None:
+                continue
+
+            block = _primary_tool_result_block_for(msg, tool_call.tool_use_id)
+            if primary_block is None and block is not None:
+                primary_block = block
+                is_error = bool(block.get("is_error"))
+                # Prefer the raw ``ToolResult.data`` (stashed on
+                # ``toolUseResult``) so callers branching on dict/str
+                # shape keep working. When ``agent_id`` is set the
+                # pipeline strips this field — fall back to the
+                # serialized block content.
+                tur = getattr(msg, "toolUseResult", None)
+                output = tur if tur is not None else block.get("content")
+                continue
+
+            # Everything else is an auxiliary message — pre-hook
+            # attachment, post-hook attachment, ToolResult.new_messages,
+            # or a hook_stopped_continuation attachment. Caller appends
+            # these after the primary result.
+            new_messages.append(msg)
+
+        if primary_block is None:
+            # Pipeline yielded no tool_result block matching the call —
+            # synthesize an error block so the model gets a matched
+            # tool_use_id (otherwise the next API turn 400s on an
+            # unmatched tool_use).
+            primary_block = {
+                "type": "tool_result",
+                "tool_use_id": tool_call.tool_use_id or "",
+                "content": "<tool_use_error>No result yielded by pipeline</tool_use_error>",
+                "is_error": True,
+            }
+            is_error = True
+
+        return ToolDispatchResult(
+            tool_result_block=primary_block,
+            is_error=is_error,
+            output=output,
+            new_messages=new_messages,
+            context_modifier=context_modifier,
+        )
+
+    return asyncio.run(_run())
+
+
+def make_stub_assistant_message(uuid: str | None = None) -> Any:
+    """Construct a minimal ``AssistantMessage`` for callers that don't
+    have a real one.
+
+    Hooks may behave differently when handed a stub — they read
+    ``.content``, ``.uuid``, and occasionally ``.usage``. Slash-command
+    dispatches (no model in the loop) typically don't have hooks
+    configured that look at these fields, so the stub is fine. Callers
+    invoking the agent loop or query loop SHOULD pass the real
+    assistant message in scope.
+
+    Passing ``uuid=None`` (the default) generates a fresh uuid4 via
+    AssistantMessage's default_factory. Pass an explicit empty string
+    only if you want a deliberately-empty uuid (rarely useful).
+    """
+    from src.types.messages import AssistantMessage
+    if uuid is None:
+        return AssistantMessage(content=[])
+    return AssistantMessage(content=[], uuid=uuid)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _msg_of(update: Any) -> Any:
+    """Extract the ``.message`` from a ``MessageUpdateLazy`` (object or
+    dict shape)."""
+    if isinstance(update, dict):
+        return update.get("message")
+    return getattr(update, "message", None)
+
+
+def _ctx_mod_of(update: Any) -> Callable[[ToolContext], ToolContext] | None:
+    """Extract the ``modify_context`` function from a
+    ``MessageUpdateLazy.context_modifier`` (object or dict shape)."""
+    if isinstance(update, dict):
+        ctx_mod = update.get("context_modifier")
+    else:
+        ctx_mod = getattr(update, "context_modifier", None)
+    if ctx_mod is None:
+        return None
+    if isinstance(ctx_mod, dict):
+        return ctx_mod.get("modify_context")
+    return getattr(ctx_mod, "modify_context", None)
+
+
+def _primary_tool_result_block_for(msg: Any, tool_use_id: str | None) -> dict[str, Any] | None:
+    """Return the first ``tool_result`` content block in ``msg`` whose
+    ``tool_use_id`` matches ``tool_use_id``. None if not found.
+
+    The pipeline's first yielded message contains the primary result;
+    we still match by tool_use_id to be robust against ordering changes.
+    """
+    content = getattr(msg, "content", None)
+    if content is None and isinstance(msg, dict):
+        content = msg.get("content")
+    if not isinstance(content, list):
+        return None
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "tool_result":
+            if tool_use_id is None or block.get("tool_use_id") == tool_use_id:
+                return block
+    return None

--- a/src/services/tool_execution/tool_execution.py
+++ b/src/services/tool_execution/tool_execution.py
@@ -48,17 +48,32 @@ async def run_tool_use(
     assistant_message: AssistantMessage,
     can_use_tool: Any,
     tool_use_context: ToolContext,
+    *,
+    tools: "list[Any] | None" = None,
 ) -> AsyncGenerator[MessageUpdateLazy, None]:
+    """Run a single tool call through the full 13-step pipeline.
+
+    ``tools`` (optional) overrides ``tool_use_context.options.tools``
+    for the tool-name lookup. Useful for the sync adapter
+    (``dispatch_full``) which is given the tool list explicitly and
+    cannot rely on the context's ``options.tools`` being populated.
+    Defaults to None, in which case ``options.tools`` is used (legacy
+    behavior preserved).
+    """
     from src.tool_system.build_tool import find_tool_by_name
     from src.tool_system.registry import get_all_base_tools
 
     tool_name = tool_use.name
-    tool = find_tool_by_name(tool_use_context.options.tools, tool_name)
+    # ``options.tools`` defaults to ``[]`` via dataclass factory, but be
+    # defensive against future None-defaults (would yield a TypeError
+    # from find_tool_by_name's iteration over None).
+    lookup_tools = tools if tools is not None else (tool_use_context.options.tools or [])
+    tool = find_tool_by_name(lookup_tools, tool_name)
 
     if tool is None:
         try:
             from src.tool_system.registry import ToolRegistry
-            fallback_registry = ToolRegistry(tool_use_context.options.tools)
+            fallback_registry = ToolRegistry(lookup_tools)
             tool = fallback_registry.get(tool_name)
         except Exception:
             pass

--- a/tests/test_sync_adapter.py
+++ b/tests/test_sync_adapter.py
@@ -1,0 +1,260 @@
+"""Tests for src/services/tool_execution/sync_adapter.py.
+
+Verifies the sync materialization adapter correctly bridges
+``run_tool_use``'s async-generator output to a single
+``ToolDispatchResult`` consumable by sync callers.
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from src.permissions.types import (
+    PermissionAllowDecision,
+    PermissionDenyDecision,
+    PermissionPassthroughResult,
+    ToolPermissionContext,
+)
+from src.services.tool_execution.sync_adapter import (
+    ToolDispatchResult,
+    dispatch_full,
+    make_stub_assistant_message,
+)
+from src.tool_system.build_tool import Tool, build_tool
+from src.tool_system.context import ToolContext, ToolUseOptions
+from src.tool_system.protocol import ToolCall, ToolResult
+
+
+def _make_context() -> ToolContext:
+    tmp = tempfile.mkdtemp()
+    ctx = ToolContext(
+        workspace_root=Path(tmp),
+        permission_context=ToolPermissionContext(mode="bypassPermissions"),
+    )
+    return ctx
+
+
+def _make_tool(
+    name: str = "Echo",
+    output: Any = None,
+    new_messages: list[Any] | None = None,
+    context_modifier: Any = None,
+    is_concurrency_safe: bool = False,
+    check_permissions: Any = None,
+) -> Tool:
+    def _call(_inp: dict[str, Any], _ctx: ToolContext) -> ToolResult:
+        return ToolResult(
+            name=name,
+            output=output if output is not None else {"ok": True},
+            new_messages=new_messages,
+            context_modifier=context_modifier,
+        )
+    return build_tool(
+        name=name,
+        input_schema={"type": "object", "properties": {}},
+        call=_call,
+        is_concurrency_safe=lambda _i: is_concurrency_safe,
+        check_permissions=check_permissions,
+    )
+
+
+class TestDispatchFullSimple(unittest.TestCase):
+    """Happy-path: tool returns a dict, no auxiliary messages."""
+
+    def test_simple_dict_output(self) -> None:
+        ctx = _make_context()
+        tool = _make_tool("Echo", output={"hello": "world"})
+        call = ToolCall(name="Echo", input={}, tool_use_id="tu-1")
+        msg = make_stub_assistant_message()
+        result = dispatch_full(call, ctx, msg, tools=[tool])
+
+        self.assertIsInstance(result, ToolDispatchResult)
+        self.assertFalse(result.is_error)
+        self.assertEqual(result.output, {"hello": "world"})
+        self.assertEqual(result.tool_result_block["tool_use_id"], "tu-1")
+        self.assertEqual(result.tool_result_block["type"], "tool_result")
+        self.assertEqual(result.new_messages, [])
+        self.assertIsNone(result.context_modifier)
+
+    def test_string_output_preserved(self) -> None:
+        ctx = _make_context()
+        tool = _make_tool("Echo", output="raw string output")
+        call = ToolCall(name="Echo", input={}, tool_use_id="tu-2")
+        result = dispatch_full(call, ctx, make_stub_assistant_message(), tools=[tool])
+        # output is the raw ToolResult.data, preserved as a string
+        self.assertEqual(result.output, "raw string output")
+
+
+class TestDispatchFullToolsParameter(unittest.TestCase):
+    """``tools=`` kwarg overrides ``context.options.tools`` for lookup."""
+
+    def test_explicit_tools_used(self) -> None:
+        ctx = _make_context()
+        wrong_tool = _make_tool("WrongTool", output="wrong")
+        right_tool = _make_tool("RightTool", output="right")
+        ctx.options = ToolUseOptions(tools=[wrong_tool])
+        call = ToolCall(name="RightTool", input={}, tool_use_id="tu-x")
+        result = dispatch_full(call, ctx, make_stub_assistant_message(),
+                                tools=[right_tool])
+        self.assertFalse(result.is_error)
+        self.assertEqual(result.output, "right")
+
+    def test_unknown_tool_returns_error(self) -> None:
+        ctx = _make_context()
+        call = ToolCall(name="DoesNotExist", input={}, tool_use_id="tu-?")
+        result = dispatch_full(call, ctx, make_stub_assistant_message(), tools=[])
+        self.assertTrue(result.is_error)
+        self.assertIn("No such tool", str(result.tool_result_block.get("content", "")))
+
+
+class TestDispatchFullNewMessages(unittest.TestCase):
+    """``ToolResult.new_messages`` surfaces in ``result.new_messages``,
+    NOT in the primary tool_result block."""
+
+    def test_new_messages_propagated(self) -> None:
+        from src.types.messages import create_user_message
+
+        extra1 = create_user_message(content=[{"type": "text", "text": "extra one"}])
+        extra2 = create_user_message(content=[{"type": "text", "text": "extra two"}])
+
+        ctx = _make_context()
+        tool = _make_tool("AgentLike", output={"transcript": "..."}, new_messages=[extra1, extra2])
+        call = ToolCall(name="AgentLike", input={}, tool_use_id="tu-agent")
+        result = dispatch_full(call, ctx, make_stub_assistant_message(), tools=[tool])
+
+        self.assertFalse(result.is_error)
+        # Primary result still works
+        self.assertEqual(result.tool_result_block["tool_use_id"], "tu-agent")
+        # Both extras land in new_messages
+        self.assertEqual(len(result.new_messages), 2)
+
+
+class TestDispatchFullContextModifier(unittest.TestCase):
+    """``ToolResult.context_modifier`` surfaces in ``result.context_modifier``."""
+
+    def test_context_modifier_propagated(self) -> None:
+        def _modifier(c: ToolContext) -> ToolContext:
+            c.plan_mode = True
+            return c
+
+        ctx = _make_context()
+        tool = _make_tool("PlanLike", output={"ok": True}, context_modifier=_modifier)
+        call = ToolCall(name="PlanLike", input={}, tool_use_id="tu-plan")
+        result = dispatch_full(call, ctx, make_stub_assistant_message(), tools=[tool])
+
+        self.assertIsNotNone(result.context_modifier)
+        self.assertFalse(ctx.plan_mode)  # not yet applied
+        # Caller applies the modifier
+        result.context_modifier(ctx)
+        self.assertTrue(ctx.plan_mode)
+
+
+class TestDispatchFullPermissionDenied(unittest.TestCase):
+    """Permission denial surfaces as ``is_error=True``, no new_messages."""
+
+    def test_deny_returns_is_error(self) -> None:
+        def _deny(_inp: dict[str, Any], _ctx: Any):
+            return PermissionDenyDecision(
+                behavior="deny",
+                message="No way",
+            )
+
+        ctx = _make_context()
+        ctx.permission_context = ToolPermissionContext(mode="default")
+        tool = _make_tool("Blocked", output={"never": "called"}, check_permissions=_deny)
+        call = ToolCall(name="Blocked", input={}, tool_use_id="tu-deny")
+        result = dispatch_full(call, ctx, make_stub_assistant_message(), tools=[tool])
+
+        self.assertTrue(result.is_error)
+        self.assertEqual(result.new_messages, [])
+        # Output should be the error string from the tool_result block
+        # (toolUseResult on deny path carries the formatted error)
+        self.assertIn("No way", str(result.tool_result_block.get("content", "")))
+
+
+class TestDispatchFullAskPermission(unittest.TestCase):
+    """Permission ``ask`` is resolved interactively via
+    ``permission_handler`` (mirrors ``ToolRegistry.dispatch`` semantics)."""
+
+    def test_ask_with_handler_allow(self) -> None:
+        from src.permissions.types import PermissionAskDecision
+
+        def _ask(_inp: dict[str, Any], _ctx: Any):
+            return PermissionAskDecision(behavior="ask", message="confirm?")
+
+        ctx = _make_context()
+        ctx.permission_context = ToolPermissionContext(mode="default")
+        ctx.permission_handler = lambda name, msg, sug: (True, False)
+        tool = _make_tool("NeedApproval", output="done", check_permissions=_ask)
+        call = ToolCall(name="NeedApproval", input={}, tool_use_id="tu-ask-y")
+        result = dispatch_full(call, ctx, make_stub_assistant_message(), tools=[tool])
+        self.assertFalse(result.is_error)
+        self.assertEqual(result.output, "done")
+
+    def test_ask_with_handler_deny(self) -> None:
+        from src.permissions.types import PermissionAskDecision
+
+        def _ask(_inp: dict[str, Any], _ctx: Any):
+            return PermissionAskDecision(behavior="ask", message="confirm?")
+
+        ctx = _make_context()
+        ctx.permission_context = ToolPermissionContext(mode="default")
+        ctx.permission_handler = lambda name, msg, sug: (False, False)
+        tool = _make_tool("NeedApproval", output="done", check_permissions=_ask)
+        call = ToolCall(name="NeedApproval", input={}, tool_use_id="tu-ask-n")
+        result = dispatch_full(call, ctx, make_stub_assistant_message(), tools=[tool])
+        self.assertTrue(result.is_error)
+
+    def test_ask_without_handler_denies(self) -> None:
+        """Without a permission_handler, ask resolves to deny (parity
+        with ToolRegistry.dispatch behavior)."""
+        from src.permissions.types import PermissionAskDecision
+
+        def _ask(_inp: dict[str, Any], _ctx: Any):
+            return PermissionAskDecision(behavior="ask", message="confirm?")
+
+        ctx = _make_context()
+        ctx.permission_context = ToolPermissionContext(mode="default")
+        tool = _make_tool("NeedApproval", output="done", check_permissions=_ask)
+        call = ToolCall(name="NeedApproval", input={}, tool_use_id="tu-ask-?")
+        result = dispatch_full(call, ctx, make_stub_assistant_message(), tools=[tool])
+        self.assertTrue(result.is_error)
+
+
+class TestDispatchFullErrorClassification(unittest.TestCase):
+    """Exceptions inside tool.call are caught + classified by the pipeline."""
+
+    def test_tool_exception_is_classified(self) -> None:
+        def _broken(_inp: dict[str, Any], _ctx: ToolContext) -> ToolResult:
+            raise ValueError("kaboom")
+
+        tool = build_tool(
+            name="Broken",
+            input_schema={"type": "object", "properties": {}},
+            call=_broken,
+        )
+        ctx = _make_context()
+        call = ToolCall(name="Broken", input={}, tool_use_id="tu-err")
+        result = dispatch_full(call, ctx, make_stub_assistant_message(), tools=[tool])
+
+        self.assertTrue(result.is_error)
+        # The pipeline wraps the error in <tool_use_error>...
+        content = str(result.tool_result_block.get("content", ""))
+        self.assertIn("kaboom", content)
+
+
+class TestDispatchFullToolUseIdMatching(unittest.TestCase):
+    """The primary result block is matched by tool_use_id."""
+
+    def test_tool_use_id_propagated(self) -> None:
+        ctx = _make_context()
+        tool = _make_tool("Echo", output={"a": 1})
+        call = ToolCall(name="Echo", input={}, tool_use_id="unique-id-123")
+        result = dispatch_full(call, ctx, make_stub_assistant_message(), tools=[tool])
+        self.assertEqual(result.tool_result_block["tool_use_id"], "unique-id-123")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Introduces ``dispatch_full`` — a sync wrapper around the async
``run_tool_use`` pipeline — and the ``ToolDispatchResult`` dataclass.

This is the **foundation** for Phases 3-5, which migrate production
callers (``query.py``, ``agent_loop.py``) off the legacy 6-of-14-step
``ToolRegistry.dispatch()`` shortcut onto the full 13-step pipeline
(hooks, ``new_messages``, ``context_modifier``, error classification,
result budgeting). No behavior change in this PR — the adapter is
not yet wired into any production path.

### Why an adapter

- Production callers are sync (``asyncio.to_thread`` or plain),
  no event loop to ``async for`` over yields.
- ``dispatch()`` duplicating hook / backfill / classification logic
  would diverge two paths.

The adapter is the smallest correct bridge.

### Contract highlights

- **Tools lookup**: explicit ``tools=`` kwarg forwarded to
  ``run_tool_use`` (additive signature extension, no mutation of
  the shared ``ToolContext``)
- **Output preservation**: reads raw ``ToolResult.data`` from
  ``toolUseResult`` (preserves typed dict/str/list)
- **Default permission resolver**: wraps
  ``has_permissions_to_use_tool``; resolves ``ask`` via
  ``handle_permission_ask`` for parity with ``ToolRegistry.dispatch``
- **Sync via ``asyncio.run``**: all production callers run thread-side
  with no event loop

## Stack

- ✅ PR 1 — cleanup + FileReadTool Infinity (#90)
- **PR 2 — this PR** — sync adapter
- PR 3 — ``query.py`` routes through ``dispatch_full``
- PR 4 — ``agent_loop.py`` routes through ``dispatch_full``
- PR 5 — deferred-loading wiring + abort audit

Base: ``feat/ch06-pr1-readtool-cleanup``. Will rebase onto ``main``
once PR 1 lands.

## Test plan

- [x] ``tests/test_sync_adapter.py`` — 12 new tests pass
- [x] ``tests/test_tool_execution_integration.py`` — 9 pass (no
      regression from the ``tools=`` kwarg addition)
- [x] ``tests/test_orchestrator_concurrency.py`` — 7 pass
- [x] ``tests/test_streaming_executor_race.py`` — 7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)