### PR TITLE
feat(ch06): route agent_loop.py through dispatch_full (PR 4/5)

### DIFF
--- a/src/agent/conversation.py
+++ b/src/agent/conversation.py
@@ -49,6 +49,22 @@ class Conversation:
         )
         self.add_message("user", [block])
 
+    def append_raw_message(self, message: Message) -> None:
+        """Append a Message instance preserving its subclass identity.
+
+        ``add_message`` constructs a fresh ``Message`` via
+        ``create_message`` which drops subclass-specific fields
+        (AttachmentMessage's ``attachments``, SystemMessage's
+        ``subtype``/``preventContinuation``, AssistantMessage's
+        ``model``/``usage``, etc.). Use this method when routing
+        pipeline-yielded messages (sub-agent transcripts, hook
+        attachments, system reminders) where those fields carry
+        semantic payload.
+        """
+        if len(self.messages) >= self.max_history:
+            self.messages.pop(0)
+        self.messages.append(message)
+
     def get_messages(self) -> list[dict[str, Any]]:
         return normalize_messages_for_api(self.messages)
 

--- a/src/tool_system/agent_loop.py
+++ b/src/tool_system/agent_loop.py
@@ -6,16 +6,26 @@ import json
 from dataclasses import dataclass
 from typing import Any, Callable
 
+import logging
+
 from .registry import ToolRegistry
 from .context import ToolContext
+from .protocol import ToolCall
 from ..agent.conversation import Conversation
+from ..services.tool_execution import (
+    dispatch_full,
+    make_stub_assistant_message,
+)
 from ..types.content_blocks import TextBlock, ToolUseBlock
+from ..types.messages import AssistantMessage as _AssistantMessage
 from ..context_system import build_context_prompt
 from ..outputStyles import resolve_output_style
 from ..providers.base import BaseProvider, ChatResponse
 from ..providers.anthropic_provider import AnthropicProvider
 from ..providers.minimax_provider import MinimaxProvider
 from ..utils.abort_controller import AbortError, AbortSignal
+
+logger = logging.getLogger(__name__)
 
 
 def _is_anthropic_provider(provider: BaseProvider) -> bool:
@@ -326,6 +336,15 @@ def run_agent_loop(
 
     for turn in range(max_turns):
         _check_cancel()
+        # WI-5.1: reset the per-message aggregate counter at each turn
+        # boundary. The 200K cap is PER USER MESSAGE (the next batch of
+        # tool results sent to the model), not cumulative across the
+        # whole session. Without this reset the counter grows
+        # monotonically and after ~200K of cumulative output every
+        # subsequent block force-persists regardless of its individual
+        # size. Mirrors ``query.py`` reset at the top of the per-turn
+        # loop.
+        tool_context.tool_result_chars_so_far = 0
         if _is_anthropic_provider(provider):
             api_messages = conversation.get_messages()
         else:
@@ -414,8 +433,54 @@ def run_agent_loop(
                 num_turns=turn_count,
             )
 
-        # Call each tool
+        # Build a real AssistantMessage carrying the just-emitted
+        # tool_use blocks so the full pipeline's hooks can see the
+        # originating assistant turn.
+        try:
+            _amsg_blocks: list = []
+            if final_assistant_content:
+                _amsg_blocks.append(TextBlock(type="text", text=final_assistant_content))
+            for _tu in tool_uses:
+                _amsg_blocks.append(ToolUseBlock(
+                    type="tool_use",
+                    id=_tu["id"],
+                    name=_tu["name"],
+                    input=_tu["input"],
+                ))
+            assistant_msg_for_dispatch = _AssistantMessage(content=_amsg_blocks)
+        except (TypeError, ValueError):
+            # Defense in depth: bug in block construction should fall
+            # back to a stub rather than crash the whole loop.
+            assistant_msg_for_dispatch = make_stub_assistant_message()
+
+        # Call each tool through the full 13-step pipeline via dispatch_full.
+        # This replaces the legacy ToolRegistry.dispatch() shortcut so:
+        # - PreToolUse/PostToolUse hooks fire.
+        # - Per-tool max_result_size_chars + 200K aggregate budget engage.
+        # - ToolResult.new_messages flow into the conversation.
+        # - ToolResult.context_modifier mutates tool_context for the
+        #   next tool call in this same turn (matches TS serial-batch
+        #   semantics — agent_loop runs one tool at a time).
+        # - Errors are telemetry-safe-classified into <tool_use_error>.
+
+        # ``current_tool_context`` is the local-mutable view that
+        # propagates context_modifier returns to the next tool in this
+        # turn. Most modifiers mutate in place and return None (no-op
+        # rebind); clone-style modifiers return a new context that we
+        # adopt for subsequent dispatches.
+        current_tool_context = tool_context
         for tool_use in tool_uses:
+            # Two-tier abort handling (Phase 6 audit):
+            # 1. ``_check_cancel()`` — agent_loop's caller-supplied
+            #    ``cancel_signal`` (e.g., REPL's Ctrl+C handler). Fires
+            #    BEFORE the next tool starts.
+            # 2. ``dispatch_full → run_tool_use`` checks
+            #    ``tool_use_context.abort_controller.signal.aborted`` at
+            #    ``tool_execution.py:99-105`` — separate signal that
+            #    may be set by hooks or external observers.
+            # Mid-execution abort (Ctrl+C while Bash subprocess is
+            # running) is NOT yet supported; deferred to a follow-up
+            # that moves Bash to ``asyncio.create_subprocess_exec``.
             _check_cancel()
             tool_id = tool_use["id"]
             tool_name = tool_use["name"]
@@ -431,11 +496,31 @@ def run_agent_loop(
                         tool_use_id=tool_id,
                     ),
                 )
-                # Use dispatch to get proper validation and result wrapping
-                from ..tool_system.protocol import ToolCall
                 call = ToolCall(name=tool_name, input=tool_input, tool_use_id=tool_id)
-                result = tool_registry.dispatch(call, tool_context)
-                result_output = result.output
+                dispatch_result = dispatch_full(
+                    call,
+                    current_tool_context,
+                    assistant_msg_for_dispatch,
+                    tools=list(tool_registry.list_tools()),
+                )
+                # ``result_output`` keeps the typed shape (dict / str /
+                # list) so the SendUserMessage / StructuredOutput
+                # special cases below continue to read ``.get(...)``
+                # from a dict, not a stringified blob.
+                result_output = dispatch_result.output
+                is_error = dispatch_result.is_error
+
+                # ``tool_result_content`` is the already-budgeted +
+                # mapped string that should reach the model.
+                # ``map_result_to_api`` + Step-11 persistence have
+                # already run inside the pipeline; we route this
+                # (not raw ``output``) into the conversation so
+                # oversized results carry the <persisted-output>
+                # wrapper and empty results carry the no-output marker.
+                tool_result_content = dispatch_result.tool_result_block.get(
+                    "content", "",
+                )
+
                 if tool_name.lower() == "sendusermessage" and isinstance(result_output, dict):
                     msg = result_output.get("message")
                     if isinstance(msg, str):
@@ -461,18 +546,69 @@ def run_agent_loop(
                         tool_name=tool_name,
                         tool_output=result_output,
                         tool_use_id=tool_id,
-                        is_error=result.is_error,
+                        is_error=is_error,
                     ),
                 )
                 if _is_anthropic_provider(provider):
-                    conversation.add_tool_result_message(tool_id, result_output)
+                    conversation.add_tool_result_message(
+                        tool_id, tool_result_content, is_error=is_error,
+                    )
                 else:
-                    # Add tool result in OpenAI format
+                    # Tool_result_content is already a string for the
+                    # OpenAI shape — no further json.dumps needed.
+                    if not isinstance(tool_result_content, str):
+                        tool_result_content = _build_openai_tool_result_content(
+                            tool_result_content,
+                        )
                     openai_messages.append({
                         "role": "tool",
                         "tool_call_id": tool_id,
-                        "content": _build_openai_tool_result_content(result_output)
+                        "content": tool_result_content,
                     })
+
+                # Append any new_messages from the pipeline (AgentTool
+                # sub-agent transcripts, hook attachments, system
+                # reminders, hook_stopped_continuation attachments)
+                # AFTER the primary tool result so they appear in
+                # submission order.
+                #
+                # Use ``append_raw_message`` (not ``add_message``) to
+                # preserve subclass-specific fields:
+                # - AttachmentMessage's ``attachments`` payload (hook
+                #   stop-continuation metadata, sub-agent transcripts)
+                # - SystemMessage's ``subtype``/``preventContinuation``
+                # - AssistantMessage's ``model``/``usage``/``stop_reason``
+                # ``add_message`` round-trips through ``create_message``
+                # which drops everything but ``role``+``content``.
+                for extra in dispatch_result.new_messages:
+                    if hasattr(extra, "role") and hasattr(extra, "content"):
+                        try:
+                            conversation.append_raw_message(extra)
+                        except Exception as extra_exc:  # noqa: BLE001
+                            logger.warning(
+                                "failed to append new_message after %s (%s): %s",
+                                tool_name, tool_id, extra_exc,
+                            )
+                            continue
+
+                # Apply context_modifier (serial — agent_loop runs one
+                # tool at a time, so the next iteration sees the
+                # mutated context). Clone-style modifiers return a new
+                # context; in-place modifiers return None.
+                if dispatch_result.context_modifier is not None:
+                    try:
+                        new_ctx = dispatch_result.context_modifier(current_tool_context)
+                        if new_ctx is not None:
+                            current_tool_context = new_ctx
+                    except Exception as mod_exc:  # noqa: BLE001
+                        # Failed modifier shouldn't crash the loop —
+                        # next tool gets the prior context. Log so the
+                        # bug is diagnosable.
+                        logger.warning(
+                            "context_modifier raised on %s (%s); "
+                            "continuing with prior context: %s",
+                            tool_name, tool_id, mod_exc,
+                        )
             except Exception as e:
                 error_str = f"Error: {e}"
                 if verbose:

--- a/tests/test_agent_loop_dispatch_full.py
+++ b/tests/test_agent_loop_dispatch_full.py
@@ -1,0 +1,422 @@
+"""Tests for Phase-4 ``agent_loop.py`` refactor.
+
+Verifies the simpler agent loop now correctly:
+
+* Routes tool calls through ``dispatch_full`` (full 13-step pipeline)
+* Honors per-tool ``max_result_size_chars`` budgeting
+* Propagates ``ToolResult.new_messages`` into the conversation
+* Applies ``ToolResult.context_modifier`` so the next tool sees it
+* Preserves the typed-shape ``output`` for sendusermessage /
+  structuredoutput special-cases
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from src.agent.conversation import Conversation
+from src.permissions.types import ToolPermissionContext
+from src.providers.base import ChatResponse
+from src.tool_system.agent_loop import run_agent_loop
+from src.tool_system.build_tool import build_tool
+from src.tool_system.context import ToolContext
+from src.tool_system.protocol import ToolResult
+from src.tool_system.registry import ToolRegistry
+
+
+def _make_context() -> ToolContext:
+    tmp = tempfile.mkdtemp()
+    return ToolContext(
+        workspace_root=Path(tmp),
+        permission_context=ToolPermissionContext(mode="bypassPermissions"),
+    )
+
+
+def _stub_provider(tool_uses_first_turn: list[dict[str, Any]],
+                   final_text: str = "done"):
+    """Build an Anthropic-shaped mock provider that returns one
+    tool-use turn followed by a final text turn."""
+    provider = MagicMock()
+    provider.chat_stream_response.side_effect = NotImplementedError()
+
+    r1 = ChatResponse(
+        content="thinking",
+        model="claude-test",
+        usage={"input_tokens": 1, "output_tokens": 1},
+        finish_reason="tool_use",
+        tool_uses=tool_uses_first_turn,
+    )
+    r2 = ChatResponse(
+        content=final_text,
+        model="claude-test",
+        usage={"input_tokens": 1, "output_tokens": 1},
+        finish_reason="stop",
+        tool_uses=None,
+    )
+    provider.chat.side_effect = [r1, r2]
+    # Make isinstance(provider, AnthropicProvider) return True so the
+    # agent_loop takes the Anthropic-shaped result path.
+    from src.providers.anthropic_provider import AnthropicProvider
+    provider.__class__ = AnthropicProvider
+    return provider
+
+
+class TestAgentLoopDispatchFull(unittest.TestCase):
+    """``run_agent_loop`` routes each tool use through ``dispatch_full``."""
+
+    def test_simple_tool_dispatched_and_result_in_conversation(self) -> None:
+        called: list[dict[str, Any]] = []
+
+        def _call(inp, _ctx):
+            called.append(inp)
+            return ToolResult(name="Echo", output={"echo": inp.get("text", "")})
+
+        tool = build_tool(
+            name="Echo",
+            input_schema={
+                "type": "object",
+                "properties": {"text": {"type": "string"}},
+                "required": ["text"],
+            },
+            call=_call,
+        )
+        registry = ToolRegistry([tool])
+        ctx = _make_context()
+        provider = _stub_provider([
+            {"id": "tu1", "name": "Echo", "input": {"text": "hi"}},
+        ])
+
+        conv = Conversation()
+        conv.add_user_message("say hi")
+
+        result = run_agent_loop(
+            conversation=conv,
+            provider=provider,
+            tool_registry=registry,
+            tool_context=ctx,
+        )
+
+        self.assertEqual(result.response_text, "done")
+        self.assertEqual(len(called), 1)
+        self.assertEqual(called[0]["text"], "hi")
+
+
+class TestAgentLoopAggregateBudget(unittest.TestCase):
+    """Per-tool budgeting now engages on the agent_loop path
+    (was missing pre-Phase-4)."""
+
+    def test_oversized_output_persisted_to_disk(self) -> None:
+        # 80K output > 50K default threshold → must be persisted.
+        big = "X" * 80_000
+
+        def _call(_inp, _ctx):
+            return ToolResult(name="Big", output=big)
+
+        tool = build_tool(
+            name="Big",
+            input_schema={"type": "object", "properties": {}},
+            call=_call,
+            max_result_size_chars=50_000,
+        )
+        registry = ToolRegistry([tool])
+        ctx = _make_context()
+        provider = _stub_provider([
+            {"id": "tu1", "name": "Big", "input": {}},
+        ])
+
+        conv = Conversation()
+        conv.add_user_message("trigger big tool")
+
+        run_agent_loop(
+            conversation=conv,
+            provider=provider,
+            tool_registry=registry,
+            tool_context=ctx,
+        )
+
+        # Walk the conversation to find the tool_result block.
+        # Pre-Phase-4: would contain the raw 80K output.
+        # Post-Phase-4: must contain the <persisted-output> wrapper.
+        found_persisted = False
+        for msg in conv.messages:
+            if not isinstance(msg.content, list):
+                continue
+            for block in msg.content:
+                content_val = getattr(block, "content", None)
+                if isinstance(content_val, str) and "<persisted-output>" in content_val:
+                    found_persisted = True
+        self.assertTrue(
+            found_persisted,
+            "Oversized tool result was NOT routed through persistence — "
+            "agent_loop is not engaging Step 11 budgeting",
+        )
+
+
+class TestAgentLoopContextModifier(unittest.TestCase):
+    """``ToolResult.context_modifier`` mutates the context so the
+    NEXT tool in the same turn sees it (serial semantics)."""
+
+    def test_context_modifier_applied_between_tools(self) -> None:
+        seen_states: list[bool] = []
+
+        def _set_plan_mode(c: ToolContext) -> ToolContext:
+            c.plan_mode = True
+            return c
+
+        def _planner_call(_inp, _ctx):
+            return ToolResult(
+                name="Planner",
+                output={"ok": True},
+                context_modifier=_set_plan_mode,
+            )
+
+        def _capture_call(_inp, c):
+            seen_states.append(c.plan_mode)
+            return ToolResult(name="Capture", output={"saw": c.plan_mode})
+
+        planner = build_tool(
+            name="Planner",
+            input_schema={"type": "object", "properties": {}},
+            call=_planner_call,
+        )
+        capture = build_tool(
+            name="Capture",
+            input_schema={"type": "object", "properties": {}},
+            call=_capture_call,
+        )
+        registry = ToolRegistry([planner, capture])
+        ctx = _make_context()
+        provider = _stub_provider([
+            {"id": "tu1", "name": "Planner", "input": {}},
+            {"id": "tu2", "name": "Capture", "input": {}},
+        ])
+
+        conv = Conversation()
+        conv.add_user_message("enter plan and capture")
+        run_agent_loop(
+            conversation=conv,
+            provider=provider,
+            tool_registry=registry,
+            tool_context=ctx,
+        )
+        self.assertTrue(seen_states, "Capture tool didn't run")
+        self.assertTrue(
+            seen_states[0],
+            "Capture saw plan_mode=False; modifier from previous tool "
+            "in the same turn was not applied. agent_loop is not "
+            "honoring context_modifier",
+        )
+
+
+class TestAgentLoopNewMessages(unittest.TestCase):
+    """``ToolResult.new_messages`` are appended to the conversation."""
+
+    def test_new_messages_appended(self) -> None:
+        from src.types.messages import create_user_message
+
+        extra = create_user_message(content="extra context note")
+
+        def _agent_like_call(_inp, _ctx):
+            return ToolResult(
+                name="AgentLike",
+                output={"transcript": "..."},
+                new_messages=[extra],
+            )
+
+        tool = build_tool(
+            name="AgentLike",
+            input_schema={"type": "object", "properties": {}},
+            call=_agent_like_call,
+        )
+        registry = ToolRegistry([tool])
+        ctx = _make_context()
+        provider = _stub_provider([
+            {"id": "tu1", "name": "AgentLike", "input": {}},
+        ])
+
+        conv = Conversation()
+        conv.add_user_message("invoke agent")
+        run_agent_loop(
+            conversation=conv,
+            provider=provider,
+            tool_registry=registry,
+            tool_context=ctx,
+        )
+
+        # Walk conversation messages looking for the extra context note
+        found_extra = False
+        for msg in conv.messages:
+            content = msg.content
+            if isinstance(content, str) and "extra context note" in content:
+                found_extra = True
+                break
+            if isinstance(content, list):
+                for block in content:
+                    text = (
+                        block.get("text") if isinstance(block, dict)
+                        else getattr(block, "text", None)
+                    )
+                    if isinstance(text, str) and "extra context note" in text:
+                        found_extra = True
+                        break
+        self.assertTrue(
+            found_extra,
+            "ToolResult.new_messages not appended to the agent_loop conversation",
+        )
+
+
+class TestAgentLoopAttachmentPreservation(unittest.TestCase):
+    """``new_messages`` carrying AttachmentMessage / SystemMessage
+    must preserve subclass-specific fields (attachments, subtype,
+    preventContinuation, etc.). The append path must use
+    ``append_raw_message``, NOT ``add_message`` (which strips them).
+    """
+
+    def test_attachment_message_attachments_field_preserved(self) -> None:
+        from src.types.messages import AttachmentMessage
+
+        att = AttachmentMessage(
+            content="",
+            attachments=[{"type": "hook_stopped_continuation",
+                          "hook_name": "PreToolUse:Edit"}],
+        )
+
+        def _call(_inp, _ctx):
+            return ToolResult(
+                name="HookExample",
+                output={"ok": True},
+                new_messages=[att],
+            )
+
+        tool = build_tool(
+            name="HookExample",
+            input_schema={"type": "object", "properties": {}},
+            call=_call,
+        )
+        registry = ToolRegistry([tool])
+        ctx = _make_context()
+        provider = _stub_provider([
+            {"id": "tu1", "name": "HookExample", "input": {}},
+        ])
+
+        conv = Conversation()
+        conv.add_user_message("invoke")
+        run_agent_loop(
+            conversation=conv,
+            provider=provider,
+            tool_registry=registry,
+            tool_context=ctx,
+        )
+
+        # Find the AttachmentMessage in the conversation
+        found = None
+        for msg in conv.messages:
+            if isinstance(msg, AttachmentMessage):
+                found = msg
+                break
+        self.assertIsNotNone(found, "AttachmentMessage not preserved as subclass")
+        self.assertEqual(
+            found.attachments,
+            [{"type": "hook_stopped_continuation",
+              "hook_name": "PreToolUse:Edit"}],
+            "AttachmentMessage.attachments dropped — agent_loop used "
+            "add_message instead of append_raw_message",
+        )
+
+
+class TestAgentLoopAggregateCounterReset(unittest.TestCase):
+    """``tool_use_context.tool_result_chars_so_far`` must reset to 0
+    at the top of each turn, not grow monotonically.
+
+    Without the reset, a long session accumulates the counter and
+    eventually every block triggers force-persistence regardless of
+    its individual size.
+    """
+
+    def test_counter_reset_between_turns(self) -> None:
+        # Tool returns a small output that should NOT be persisted
+        # on its own. Two turns: turn 1 returns the output, turn 2
+        # returns nothing (model emits no tool_use, ending the loop).
+        def _call(_inp, _ctx):
+            return ToolResult(name="Small", output="ok")
+
+        tool = build_tool(
+            name="Small",
+            input_schema={"type": "object", "properties": {}},
+            call=_call,
+        )
+        registry = ToolRegistry([tool])
+        ctx = _make_context()
+        # Simulate a high "from prior session" counter that would
+        # force-persist on the next call if not reset.
+        ctx.tool_result_chars_so_far = 250_000
+
+        provider = _stub_provider([
+            {"id": "tu1", "name": "Small", "input": {}},
+        ])
+
+        conv = Conversation()
+        conv.add_user_message("trigger")
+        run_agent_loop(
+            conversation=conv,
+            provider=provider,
+            tool_registry=registry,
+            tool_context=ctx,
+        )
+
+        # The tool returned "ok" — only a few chars. The counter
+        # should reflect that small block's size (post-reset), not
+        # 250K+small.
+        self.assertLess(
+            ctx.tool_result_chars_so_far, 1000,
+            f"Counter not reset between turns; ended at "
+            f"{ctx.tool_result_chars_so_far} — should be <1000 "
+            f"after reset + one small block",
+        )
+
+
+class TestAgentLoopPreservesTypedOutput(unittest.TestCase):
+    """The SendUserMessage / StructuredOutput special cases read
+    ``.get("message")`` / ``.get("structured_output")`` on the tool
+    output. ``dispatch_full.output`` preserves typed dict shape
+    (NOT a stringified blob) so these branches keep working."""
+
+    def test_sendusermessage_typed_output(self) -> None:
+        def _call(_inp, _ctx):
+            return ToolResult(
+                name="SendUserMessage",
+                output={"message": "user-visible text", "status": "sent"},
+            )
+
+        tool = build_tool(
+            name="SendUserMessage",
+            input_schema={"type": "object", "properties": {}},
+            call=_call,
+        )
+        registry = ToolRegistry([tool])
+        ctx = _make_context()
+        provider = _stub_provider([
+            {"id": "tu1", "name": "SendUserMessage", "input": {}},
+        ], final_text="")  # Empty final text — last_user_visible_message takes over.
+
+        conv = Conversation()
+        conv.add_user_message("show the user something")
+        result = run_agent_loop(
+            conversation=conv,
+            provider=provider,
+            tool_registry=registry,
+            tool_context=ctx,
+        )
+
+        # When the model's final response is empty, the loop falls back
+        # to the last user-visible message. Verify the message field
+        # was read out of the TYPED dict output (not a stringified
+        # blob), proving dispatch_full surfaces the raw output.
+        self.assertEqual(result.response_text, "user-visible text")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Migrates the simpler agent loop (REPL print mode + SDK callers) off
the legacy ``ToolRegistry.dispatch()`` shortcut onto the full 13-step
pipeline via ``dispatch_full`` (PR 2). Mirrors PR 3's query-loop
migration for the second production code path.

## Observable changes

Same as PR 3 — hooks now fire, sub-agent ``new_messages`` flow into
the transcript, ``context_modifier`` works, errors are
telemetry-safe-classified. No change for users without configured
hooks.

## Phase-specific work

- **``Conversation.append_raw_message(message)``** — new method that
  appends a ``Message`` instance preserving subclass identity. Needed
  because ``add_message(role, content)`` round-trips through
  ``create_message`` and drops subclass-specific fields. Without
  this, ``AttachmentMessage.attachments`` (hook stop-continuation
  payload) and ``SystemMessage.subtype`` / ``preventContinuation``
  would silently disappear from sub-agent transcripts and hook
  attachments.
- **Per-turn aggregate counter reset** at the top of each turn,
  mirroring ``query.py``. Without this the counter grows monotonically
  across the session and every block force-persists after ~200K
  cumulative output (the 200K cap is per-message, not per-session).
- **AssistantMessage construction** from the response so the pipeline
  hooks see the originating assistant turn.
- **Module-level imports** for ``dispatch_full``,
  ``make_stub_assistant_message``, ``AssistantMessage``, ``ToolCall``
  — hoisted out of the per-iteration hot path.
- **Two-tier abort comment** documenting the separation between
  ``cancel_signal`` (REPL Ctrl+C) and ``abort_controller`` (pipeline
  internal).
- **Logged failures** on ``context_modifier`` and
  ``append_raw_message`` exceptions — replaces silent ``pass``.

## Stack

- ✅ PR 1 — cleanup + FileReadTool Infinity (#90)
- ✅ PR 2 — sync adapter (#91)
- ✅ PR 3 — ``query.py`` routes through ``dispatch_full`` (#92)
- **PR 4 — this PR** — ``agent_loop.py`` routes through ``dispatch_full``
- PR 5 — deferred-loading wiring + abort audit

Base: ``feat/ch06-pr3-query-route``. Will rebase onto ``main`` as PRs
1-3 land.

## Test plan

- [x] ``tests/test_agent_loop_dispatch_full.py`` — 7 new tests pass
- [x] ``tests/test_agent_loop.py`` — 20 existing tests still pass
- [x] AttachmentMessage subclass preservation regression test
- [x] Aggregate counter reset between turns regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)