### PR TITLE
feat(ch14): vim CommandState union + PersistentState dot-repeat + f/F/t/T motions

### DIFF
--- a/src/tui/vim_find.py
+++ b/src/tui/vim_find.py
@@ -1,0 +1,83 @@
+"""Vim find/till motions (``f`` / ``F`` / ``t`` / ``T``).
+
+Ch14 phase 3: ports the find-motion semantics from
+``typescript/src/utils/Cursor.ts:findCharacter`` plus the
+``OperatorFindState`` execution from ``typescript/src/vim/operators.ts:executeOperatorFind``.
+
+Find type semantics:
+
+* ``f<c>`` — forward search; cursor lands ON the next ``<c>``.
+* ``F<c>`` — backward search; cursor lands ON the previous ``<c>``.
+* ``t<c>`` — forward; cursor lands ONE BEFORE the next ``<c>``.
+* ``T<c>`` — backward; cursor lands ONE AFTER the previous ``<c>``.
+
+Count semantics: ``count`` repeats the search ``count`` times. ``3fa``
+finds the third 'a' forward.
+
+Boundary behaviour: searches operate on a single line (the row the
+cursor is on). Returns ``None`` if no match within the line.
+"""
+
+from __future__ import annotations
+
+from .vim_state import FindType
+
+
+def find_char(
+    line: str,
+    start_col: int,
+    char: str,
+    find_type: FindType,
+    count: int = 1,
+) -> int | None:
+    """Return the column of the ``count``-th ``char`` from ``start_col``.
+
+    ``find_type`` determines direction and exclusivity:
+
+    * ``f`` — forward, inclusive (land ON char)
+    * ``F`` — backward, inclusive (land ON char)
+    * ``t`` — forward, exclusive (land ONE BEFORE char)
+    * ``T`` — backward, exclusive (land ONE AFTER char)
+
+    Returns ``None`` if no match within the line. Returns ``None`` for
+    empty lines regardless of inputs.
+    """
+
+    if not line or not char:
+        return None
+    count = max(1, count)
+
+    if find_type in ("f", "t"):
+        # Forward: start AFTER the cursor cell.
+        idx = start_col + 1
+        last_found = -1
+        for _ in range(count):
+            idx = line.find(char, idx)
+            if idx < 0:
+                return None
+            last_found = idx
+            idx += 1
+        # ``f`` lands on char; ``t`` lands one before.
+        if find_type == "f":
+            return last_found
+        return max(start_col, last_found - 1)
+
+    # Backward branches: F / T.
+    # Start BEFORE the cursor cell.
+    idx = start_col - 1
+    last_found = -1
+    for _ in range(count):
+        if idx < 0:
+            return None
+        idx = line.rfind(char, 0, idx + 1)
+        if idx < 0:
+            return None
+        last_found = idx
+        idx -= 1
+    if find_type == "F":
+        return last_found
+    # T: one after.
+    return min(len(line) - 1, last_found + 1)
+
+
+__all__ = ["find_char"]

--- a/src/tui/vim_persistent.py
+++ b/src/tui/vim_persistent.py
@@ -1,0 +1,395 @@
+"""Vim ``PersistentState`` + ``RecordedChange`` + ``replay()``.
+
+Ch14 phase 2: ports ``typescript/src/vim/types.ts:81-119`` — vim's
+cross-command memory that powers the dot-repeat (``.``), find-repeat
+(``;`` / ``,``), and paste-mode-awareness (``register_is_linewise``)
+features.
+
+Design contract (D4-D5, D10 of the refactoring plan):
+
+* :class:`PersistentState` lives on :class:`vim.VimState` (one instance
+  per :class:`PromptInput`) and is shared across the single-line surface
+  on ``main`` today and the multi-line ``TextArea`` surface that lands
+  with ``feat/ch13/integration``.
+* :class:`RecordedChange` is a buffer-agnostic record of what to replay;
+  it does NOT capture cursor position or buffer state — replay runs at
+  the *current* cursor.
+* :func:`replay` routes through the wave-1 ``vim_operators.apply_operator``
+  + ``vim_text_objects.find_text_object`` + ``vim_find.find_char``
+  machinery, constructing a :class:`vim_buffer.VimBuffer` from
+  ``ctx.get_text()`` (the D10 adapter). This reuses the same execution
+  path as the original change, so dot-repeat semantics match.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, Union
+
+from .vim_state import FindType, Operator, TextObjScope
+
+# Map operator name → its self-repeat key (`d` for delete, etc.). Mirrors
+# the inverse map in :mod:`vim_state`; duplicated here to avoid an
+# import cycle on a constant.
+_OPERATOR_SELF_REPEAT: dict[Operator, str] = {
+    "delete": "d",
+    "change": "c",
+    "yank": "y",
+}
+
+if TYPE_CHECKING:
+    from .vim_state import TransitionContext
+
+
+# ---- RecordedChange (10 variants, mirroring typescript/src/vim/types.ts) ---
+
+
+@dataclass(frozen=True)
+class InsertChange:
+    text: str
+    type: Literal["insert"] = "insert"
+
+
+@dataclass(frozen=True)
+class OperatorChange:
+    op: Operator
+    motion: str
+    count: int
+    type: Literal["operator"] = "operator"
+
+
+@dataclass(frozen=True)
+class OperatorTextObjChange:
+    op: Operator
+    obj_type: str
+    scope: TextObjScope
+    count: int
+    type: Literal["operatorTextObj"] = "operatorTextObj"
+
+
+@dataclass(frozen=True)
+class OperatorFindChange:
+    op: Operator
+    find: FindType
+    char: str
+    count: int
+    type: Literal["operatorFind"] = "operatorFind"
+
+
+@dataclass(frozen=True)
+class ReplaceChange:
+    char: str
+    count: int
+    type: Literal["replace"] = "replace"
+
+
+@dataclass(frozen=True)
+class XChange:
+    count: int
+    type: Literal["x"] = "x"
+
+
+@dataclass(frozen=True)
+class ToggleCaseChange:
+    count: int
+    type: Literal["toggleCase"] = "toggleCase"
+
+
+@dataclass(frozen=True)
+class IndentChange:
+    dir: Literal[">", "<"]
+    count: int
+    type: Literal["indent"] = "indent"
+
+
+@dataclass(frozen=True)
+class OpenLineChange:
+    direction: Literal["above", "below"]
+    type: Literal["openLine"] = "openLine"
+
+
+@dataclass(frozen=True)
+class JoinChange:
+    count: int
+    type: Literal["join"] = "join"
+
+
+RecordedChange = Union[
+    InsertChange,
+    OperatorChange,
+    OperatorTextObjChange,
+    OperatorFindChange,
+    ReplaceChange,
+    XChange,
+    ToggleCaseChange,
+    IndentChange,
+    OpenLineChange,
+    JoinChange,
+]
+
+
+# ---- PersistentState ------------------------------------------------------
+
+
+@dataclass
+class PersistentState:
+    """Cross-command memory for vim mode.
+
+    Lives on :class:`vim.VimState`. One instance per ``PromptInput`` —
+    different prompts don't share registers.
+    """
+
+    last_change: RecordedChange | None = None
+    last_find: tuple[FindType, str] | None = None
+    register: str = ""
+    register_is_linewise: bool = False
+
+    def record(self, change: RecordedChange) -> None:
+        self.last_change = change
+
+    def record_find(self, find_type: FindType, char: str) -> None:
+        self.last_find = (find_type, char)
+
+    def set_register(self, content: str, *, linewise: bool) -> None:
+        self.register = content
+        self.register_is_linewise = linewise
+
+
+# ---- replay() -------------------------------------------------------------
+
+
+def replay(change: RecordedChange, ctx: "TransitionContext") -> None:
+    """Re-execute ``change`` at the current cursor.
+
+    Routes through the wave-1 ``vim_operators.apply_operator`` /
+    ``find_text_object`` / ``find_char`` machinery via a temporary
+    :class:`vim_buffer.VimBuffer` constructed from ``ctx.get_text()``
+    (D10 adapter). The cursor position used is the CURRENT cursor
+    (``ctx.get_cursor()``), not whatever it was when the change was
+    originally recorded.
+    """
+
+    # Lazy imports to break circular dependencies and keep import cost low.
+    from .vim_buffer import Cursor, Range, VimBuffer
+    from .vim_find import find_char
+    from .vim_operators import _indent_range, _resolve_motion_range, apply_operator
+    from .vim_text_objects import find_text_object
+
+    match change:
+        case OperatorChange(op=op, motion=motion, count=count):
+            text = ctx.get_text()
+            cur = ctx.get_cursor()
+            buf = VimBuffer(text)
+            buf.set_cursor(cur.row, cur.col)
+            if motion == "gg":
+                target_row = max(0, count - 1)
+                rng = Range(
+                    start=Cursor(row=target_row, col=0),
+                    end=Cursor(row=cur.row, col=len(buf.line(cur.row))),
+                )
+            elif motion == _OPERATOR_SELF_REPEAT[op]:  # dd/yy/cc — line-wise
+                end_row = min(cur.row + count - 1, buf.line_count - 1)
+                affected_lines = buf.lines[cur.row : end_row + 1]
+                affected = "\n".join(affected_lines) + "\n"
+                if op in ("delete", "change"):
+                    if end_row + 1 < buf.line_count:
+                        line_rng = Range(
+                            start=Cursor(row=cur.row, col=0),
+                            end=Cursor(row=end_row + 1, col=0),
+                        )
+                    elif cur.row > 0:
+                        line_rng = Range(
+                            start=Cursor(
+                                row=cur.row - 1,
+                                col=len(buf.line(cur.row - 1)),
+                            ),
+                            end=Cursor(row=end_row, col=len(buf.line(end_row))),
+                        )
+                    else:
+                        line_rng = Range(
+                            start=Cursor(row=0, col=0),
+                            end=Cursor(row=end_row, col=len(buf.line(end_row))),
+                        )
+                    buf.delete(line_rng)
+                    ctx.set_text(buf.text)
+                    ctx.set_cursor(buf.cursor)
+                ctx.set_register(affected, True)
+                return
+            else:
+                resolved = _resolve_motion_range(buf, buf.cursor, motion, count=count)
+                if resolved is None:
+                    return
+                rng = resolved
+            register_list = [ctx.get_register()[0]]
+            apply_operator(buf, rng.normalised(), op[0], yank_buffer=register_list)
+            ctx.set_text(buf.text)
+            ctx.set_cursor(buf.cursor)
+            ctx.set_register(register_list[0], _is_linewise_motion(motion))
+
+        case OperatorTextObjChange(op=op, obj_type=obj_type, scope=scope, count=_):
+            text = ctx.get_text()
+            cur = ctx.get_cursor()
+            buf = VimBuffer(text)
+            buf.set_cursor(cur.row, cur.col)
+            specifier = ("i" if scope == "inner" else "a") + obj_type
+            rng = find_text_object(buf, buf.cursor, specifier)
+            if rng is None:
+                return
+            register_list = [ctx.get_register()[0]]
+            apply_operator(buf, rng, op[0], yank_buffer=register_list)
+            ctx.set_text(buf.text)
+            ctx.set_cursor(buf.cursor)
+            ctx.set_register(register_list[0], False)
+
+        case OperatorFindChange(op=op, find=find_type, char=char, count=count):
+            text = ctx.get_text()
+            cur = ctx.get_cursor()
+            buf = VimBuffer(text)
+            buf.set_cursor(cur.row, cur.col)
+            line = buf.line(cur.row) if cur.row < buf.line_count else ""
+            target_col = find_char(line, cur.col, char, find_type, count)
+            if target_col is None:
+                return
+            # Per TS `getOperatorRangeForFind`
+            # (typescript/src/vim/operators.ts:482-491): findCharacter has
+            # already shifted target_col one-toward-cursor for t/T, so
+            # the operator range treats it as the endpoint regardless of
+            # find_type.
+            cur_end = Cursor(row=cur.row, col=cur.col + 1)
+            target_end = Cursor(row=cur.row, col=target_col + 1)
+            target_pos = Cursor(row=cur.row, col=target_col)
+            if find_type in ("f", "t"):
+                rng = Range(start=cur, end=target_end)
+            else:  # F or T
+                rng = Range(start=target_pos, end=cur_end)
+            register_list = [ctx.get_register()[0]]
+            apply_operator(buf, rng.normalised(), op[0], yank_buffer=register_list)
+            ctx.set_text(buf.text)
+            ctx.set_cursor(buf.cursor)
+            ctx.set_register(register_list[0], False)
+
+        case XChange(count=count):
+            text = ctx.get_text()
+            cur = ctx.get_cursor()
+            buf = VimBuffer(text)
+            buf.set_cursor(cur.row, cur.col)
+            line = buf.line(cur.row) if cur.row < buf.line_count else ""
+            end_col = min(cur.col + count, len(line))
+            if end_col == cur.col:
+                return
+            removed = buf.delete(
+                Range(start=cur, end=Cursor(row=cur.row, col=end_col))
+            )
+            ctx.set_text(buf.text)
+            ctx.set_cursor(buf.cursor)
+            ctx.set_register(removed, False)
+
+        case ToggleCaseChange(count=count):
+            text = ctx.get_text()
+            cur = ctx.get_cursor()
+            buf = VimBuffer(text)
+            line = buf.line(cur.row) if cur.row < buf.line_count else ""
+            end_col = min(cur.col + count, len(line))
+            if end_col == cur.col:
+                return
+            toggled = "".join(
+                c.upper() if c.islower() else c.lower()
+                for c in line[cur.col:end_col]
+            )
+            new_line = line[: cur.col] + toggled + line[end_col:]
+            lines = list(buf.lines)
+            lines[cur.row] = new_line
+            ctx.set_text("\n".join(lines))
+            ctx.set_cursor(Cursor(row=cur.row, col=end_col))
+
+        case ReplaceChange(char=char, count=count):
+            text = ctx.get_text()
+            cur = ctx.get_cursor()
+            buf = VimBuffer(text)
+            line = buf.line(cur.row) if cur.row < buf.line_count else ""
+            end_col = min(cur.col + count, len(line))
+            if end_col == cur.col:
+                return
+            replaced = char * (end_col - cur.col)
+            new_line = line[: cur.col] + replaced + line[end_col:]
+            lines = list(buf.lines)
+            lines[cur.row] = new_line
+            ctx.set_text("\n".join(lines))
+            ctx.set_cursor(Cursor(row=cur.row, col=end_col - 1))
+
+        case IndentChange(dir=direction, count=count):
+            text = ctx.get_text()
+            cur = ctx.get_cursor()
+            buf = VimBuffer(text)
+            end_row = min(cur.row + count - 1, buf.line_count - 1)
+            end_line = buf.line(end_row)
+            rng = Range(
+                start=Cursor(row=cur.row, col=0),
+                end=Cursor(row=end_row, col=len(end_line)),
+            )
+            _indent_range(buf, rng, indent_amount=1 if direction == ">" else -1)
+            ctx.set_text(buf.text)
+
+        case InsertChange(text=inserted):
+            current_text = ctx.get_text()
+            cur = ctx.get_cursor()
+            buf = VimBuffer(current_text)
+            buf.set_cursor(cur.row, cur.col)
+            buf.insert(inserted)
+            ctx.set_text(buf.text)
+            ctx.set_cursor(buf.cursor)
+
+        case OpenLineChange(direction=direction):
+            text = ctx.get_text()
+            cur = ctx.get_cursor()
+            buf = VimBuffer(text)
+            lines = list(buf.lines)
+            insert_row = cur.row + 1 if direction == "below" else cur.row
+            lines.insert(insert_row, "")
+            ctx.set_text("\n".join(lines))
+            ctx.set_cursor(Cursor(row=insert_row, col=0))
+
+        case JoinChange(count=count):
+            text = ctx.get_text()
+            cur = ctx.get_cursor()
+            buf = VimBuffer(text)
+            lines = list(buf.lines)
+            if cur.row + 1 >= len(lines):
+                return
+            joined_count = 0
+            for _ in range(count):
+                if cur.row + 1 >= len(lines):
+                    break
+                # Join current with next, separator = " "
+                combined = lines[cur.row].rstrip() + " " + lines[cur.row + 1].lstrip()
+                lines[cur.row] = combined
+                del lines[cur.row + 1]
+                joined_count += 1
+            if joined_count > 0:
+                ctx.set_text("\n".join(lines))
+
+        case _:  # pragma: no cover - exhaustiveness guard
+            from typing import assert_never
+
+            assert_never(change)
+
+
+def _is_linewise_motion(motion: str) -> bool:
+    return motion in ("j", "k", "gg", "gj", "gk")
+
+
+__all__ = [
+    "IndentChange",
+    "InsertChange",
+    "JoinChange",
+    "OpenLineChange",
+    "OperatorChange",
+    "OperatorFindChange",
+    "OperatorTextObjChange",
+    "PersistentState",
+    "RecordedChange",
+    "ReplaceChange",
+    "ToggleCaseChange",
+    "XChange",
+    "replay",
+]

--- a/src/tui/vim_state.py
+++ b/src/tui/vim_state.py
@@ -1,0 +1,965 @@
+"""Discriminated `CommandState` union + pure `transition()` for vim Normal mode.
+
+Ch14 phase 1: ports ``typescript/src/vim/types.ts`` (the 11-variant
+discriminated union — chapter prose says 12, source has 11) and
+``typescript/src/vim/transitions.ts`` (the pure dispatch function).
+
+Design contract (D1-D11 of ``my-docs/ch14-input-interaction-refactoring-plan.md``):
+
+* :class:`CommandState` is a frozen-dataclass discriminated union; each
+  variant carries exactly the data the next transition needs and no more.
+* :func:`transition` is pure — same ``(state, key, ctx)`` yields the same
+  ``(next, execute)`` ``TransitionResult``. Side effects live in the
+  optional ``execute`` closure, which the caller invokes.
+* :class:`TransitionContext` mirrors TS ``OperatorContext`` (primitives
+  on the buffer-and-cursor: ``get_text``, ``set_text``, ``get_cursor``,
+  ``set_cursor``, ``get_register``, ``set_register``, ``get_last_find``,
+  ``set_last_find``, ``get_last_change``, ``record_change``,
+  ``enter_insert``). Callers wire the primitives to either the single-line
+  Textual ``Input`` (via the :mod:`vim_buffer` adapter) or the multi-line
+  ``TextArea`` once ``feat/ch13/integration`` lands.
+* Dot-repeat and find-repeat are entry points handled in
+  :func:`_from_idle` and route through :class:`vim_persistent.PersistentState`
+  via the ``ctx.get_last_change`` / ``ctx.get_last_find`` primitives.
+
+The exhaustive ``match`` in :func:`transition` covers all 11 variants;
+a 12th variant added later will trip the ``assert_never`` guard in debug
+builds.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable, Literal, Union
+
+if TYPE_CHECKING:
+    from .vim_buffer import Cursor
+    from .vim_persistent import RecordedChange
+
+
+Operator = Literal["delete", "change", "yank"]
+FindType = Literal["f", "F", "t", "T"]
+TextObjScope = Literal["inner", "around"]
+MAX_VIM_COUNT = 10000
+
+
+# ---- Command states (11 variants, mirroring typescript/src/vim/types.ts) ----
+
+
+@dataclass(frozen=True)
+class IdleState:
+    type: Literal["idle"] = "idle"
+
+
+@dataclass(frozen=True)
+class CountState:
+    digits: str
+    type: Literal["count"] = "count"
+
+
+@dataclass(frozen=True)
+class OperatorState:
+    op: Operator
+    count: int
+    type: Literal["operator"] = "operator"
+
+
+@dataclass(frozen=True)
+class OperatorCountState:
+    op: Operator
+    count: int
+    digits: str
+    type: Literal["operatorCount"] = "operatorCount"
+
+
+@dataclass(frozen=True)
+class OperatorFindState:
+    op: Operator
+    count: int
+    find: FindType
+    type: Literal["operatorFind"] = "operatorFind"
+
+
+@dataclass(frozen=True)
+class OperatorTextObjState:
+    op: Operator
+    count: int
+    scope: TextObjScope
+    type: Literal["operatorTextObj"] = "operatorTextObj"
+
+
+@dataclass(frozen=True)
+class FindState:
+    find: FindType
+    count: int
+    type: Literal["find"] = "find"
+
+
+@dataclass(frozen=True)
+class GState:
+    count: int
+    type: Literal["g"] = "g"
+
+
+@dataclass(frozen=True)
+class OperatorGState:
+    op: Operator
+    count: int
+    type: Literal["operatorG"] = "operatorG"
+
+
+@dataclass(frozen=True)
+class ReplaceState:
+    count: int
+    type: Literal["replace"] = "replace"
+
+
+@dataclass(frozen=True)
+class IndentState:
+    dir: Literal[">", "<"]
+    count: int
+    type: Literal["indent"] = "indent"
+
+
+CommandState = Union[
+    IdleState,
+    CountState,
+    OperatorState,
+    OperatorCountState,
+    OperatorFindState,
+    OperatorTextObjState,
+    FindState,
+    GState,
+    OperatorGState,
+    ReplaceState,
+    IndentState,
+]
+
+
+# ---- Transition result + context ------------------------------------------
+
+
+@dataclass(frozen=True)
+class TransitionResult:
+    """Result of one transition. ``next`` is the new state (omit = stay).
+
+    ``execute`` is an optional callable that performs the side effect.
+    The caller decides when to invoke it (caller may choose to skip it
+    for tests, for instance).
+    """
+
+    next: CommandState | None = None
+    execute: Callable[[], None] | None = None
+
+
+@dataclass
+class TransitionContext:
+    """Buffer-and-cursor primitives the executor closures call into.
+
+    Mirrors TS ``OperatorContext`` (``typescript/src/vim/operators.ts:26``).
+    The single-line ``PromptInput`` surface wires these against a
+    :class:`vim_buffer.VimBuffer` constructed from ``Input.value``
+    (per D10); the multi-line ``TextArea`` surface (post-ch13/integration)
+    wires them against the TextArea's own buffer.
+
+    Contracts:
+
+    * ``set_text`` is permitted to invalidate cursor position — callers
+      MUST invoke ``set_text`` before ``set_cursor``.
+    * ``ctx.set_cursor(Cursor)`` is distinct from
+      :meth:`vim_buffer.VimBuffer.set_cursor(row, col)`; the former
+      writes back to the production surface, the latter mutates a
+      scratch buffer.
+    """
+
+    get_cursor: Callable[[], "Cursor"]
+    set_cursor: Callable[["Cursor"], None]
+    get_text: Callable[[], str]
+    set_text: Callable[[str], None]
+    set_register: Callable[[str, bool], None]
+    get_register: Callable[[], tuple[str, bool]]
+    get_last_find: Callable[[], tuple[FindType, str] | None]
+    set_last_find: Callable[[FindType, str], None]
+    get_last_change: Callable[[], "RecordedChange | None"]
+    record_change: Callable[["RecordedChange"], None]
+    # RESERVED. ``enter_insert(col)`` switches the surrounding vim mode
+    # into INSERT at the given column. Currently unused by Phase 1-3
+    # executors — the existing ``vim.py.handle()`` keeps its own insert
+    # transitions for live keystrokes (OD5 hybrid handle), and dot-repeat
+    # replays do NOT enter insert mode (matches real vim's ``.`` after
+    # ``cw``). Wire this when ch13/integration consumes ``transition()``
+    # for live ``c`` operators.
+    enter_insert: Callable[[int], None] | None = None
+
+
+# ---- Key groups -----------------------------------------------------------
+
+_OPERATOR_KEYS: dict[str, Operator] = {"d": "delete", "c": "change", "y": "yank"}
+_FIND_KEYS = frozenset({"f", "F", "t", "T"})
+_SIMPLE_MOTIONS = frozenset(
+    {"h", "j", "k", "l", "0", "^", "$", "w", "b", "e", "W", "B", "E"}
+)
+_TEXT_OBJ_SCOPES: dict[str, TextObjScope] = {"i": "inner", "a": "around"}
+
+
+def _clamp_count(value: int) -> int:
+    return max(1, min(value, MAX_VIM_COUNT))
+
+
+# ---- Top-level dispatch ---------------------------------------------------
+
+
+def transition(
+    state: CommandState, key: str, ctx: TransitionContext
+) -> TransitionResult:
+    """Dispatch ``(state, key)`` → ``TransitionResult``. Pure.
+
+    Adding a 12th variant in the future trips the ``assert_never`` guard
+    at runtime in debug builds — the exhaustiveness check the chapter's
+    TS source enforces at compile time.
+    """
+
+    match state:
+        case IdleState():
+            return _from_idle(key, ctx)
+        case CountState(digits=digits):
+            return _from_count(digits, key, ctx)
+        case OperatorState(op=op, count=count):
+            return _from_operator(op, count, key, ctx)
+        case OperatorCountState(op=op, count=count, digits=digits):
+            return _from_operator_count(op, count, digits, key, ctx)
+        case OperatorFindState(op=op, count=count, find=find_type):
+            return _from_operator_find(op, count, find_type, key, ctx)
+        case OperatorTextObjState(op=op, count=count, scope=scope):
+            return _from_operator_text_obj(op, count, scope, key, ctx)
+        case FindState(find=find_type, count=count):
+            return _from_find(find_type, count, key, ctx)
+        case GState(count=count):
+            return _from_g(count, key, ctx)
+        case OperatorGState(op=op, count=count):
+            return _from_operator_g(op, count, key, ctx)
+        case ReplaceState(count=count):
+            return _from_replace(count, key, ctx)
+        case IndentState(dir=direction, count=count):
+            return _from_indent(direction, count, key, ctx)
+        case _:  # pragma: no cover - exhaustiveness guard
+            from typing import assert_never
+
+            assert_never(state)
+
+
+# ---- Per-state handlers ---------------------------------------------------
+
+
+def _from_idle(key: str, ctx: TransitionContext) -> TransitionResult:
+    """``IdleState`` is the entry point — covers the full vim vocabulary."""
+
+    # Counts (1-9 — 0 is the "start of line" motion in idle).
+    if key.isdigit() and key != "0":
+        return TransitionResult(next=CountState(digits=key))
+
+    # Operators.
+    if key in _OPERATOR_KEYS:
+        return TransitionResult(next=OperatorState(op=_OPERATOR_KEYS[key], count=1))
+
+    # Find motions.
+    if key in _FIND_KEYS:
+        return TransitionResult(next=FindState(find=key, count=1))  # type: ignore[arg-type]
+
+    # G-prefix (``gg``, ``gj``, ``gk``).
+    if key == "g":
+        return TransitionResult(next=GState(count=1))
+
+    # Replace (``r<c>``).
+    if key == "r":
+        return TransitionResult(next=ReplaceState(count=1))
+
+    # Indent (``>>`` / ``<<``).
+    if key in (">", "<"):
+        return TransitionResult(next=IndentState(dir=key, count=1))  # type: ignore[arg-type]
+
+    # Simple motions execute immediately.
+    if key in _SIMPLE_MOTIONS:
+        return TransitionResult(execute=_motion_executor(ctx, key, count=1))
+
+    # Dot-repeat.
+    if key == ".":
+        last_change = ctx.get_last_change()
+        if last_change is None:
+            return TransitionResult()
+        # Lazy import to break the vim_state ↔ vim_persistent cycle
+        # (vim_persistent imports Operator/FindType from vim_state).
+        from .vim_persistent import replay
+
+        return TransitionResult(execute=lambda: replay(last_change, ctx))
+
+    # Find-repeat (``;`` / ``,``). The repeat keys never update
+    # ``last_find`` — they consult it and (for ``,``) flip the direction
+    # in-place. This matches real vim's ``;``/``,`` semantics.
+    if key in (";", ","):
+        last_find = ctx.get_last_find()
+        if last_find is None:
+            return TransitionResult()
+        find_type, char = last_find
+        if key == ",":
+            flipped: FindType = {"f": "F", "F": "f", "t": "T", "T": "t"}[find_type]
+            find_type = flipped
+        return TransitionResult(
+            execute=_find_executor(
+                ctx, find_type, char, count=1, update_last_find=False
+            )
+        )
+
+    # Immediate single-key commands.
+    if key == "x":
+        return TransitionResult(execute=_x_executor(ctx, count=1))
+    if key == "~":
+        return TransitionResult(execute=_toggle_case_executor(ctx, count=1))
+
+    # Unknown / unhandled — stay in idle.
+    return TransitionResult()
+
+
+def _from_count(
+    digits: str, key: str, ctx: TransitionContext
+) -> TransitionResult:
+    """``CountState`` accumulates digits, then transitions on operator/motion."""
+
+    if key.isdigit():
+        # Saturate at MAX_VIM_COUNT.
+        new_digits = digits + key
+        if int(new_digits) > MAX_VIM_COUNT:
+            new_digits = str(MAX_VIM_COUNT)
+        return TransitionResult(next=CountState(digits=new_digits))
+
+    count = _clamp_count(int(digits))
+
+    if key in _OPERATOR_KEYS:
+        return TransitionResult(
+            next=OperatorState(op=_OPERATOR_KEYS[key], count=count)
+        )
+
+    if key in _FIND_KEYS:
+        return TransitionResult(next=FindState(find=key, count=count))  # type: ignore[arg-type]
+
+    if key == "g":
+        return TransitionResult(next=GState(count=count))
+
+    if key == "r":
+        return TransitionResult(next=ReplaceState(count=count))
+
+    if key in (">", "<"):
+        return TransitionResult(next=IndentState(dir=key, count=count))  # type: ignore[arg-type]
+
+    if key in _SIMPLE_MOTIONS:
+        return TransitionResult(
+            next=IdleState(),
+            execute=_motion_executor(ctx, key, count=count),
+        )
+
+    if key == "x":
+        return TransitionResult(
+            next=IdleState(),
+            execute=_x_executor(ctx, count=count),
+        )
+
+    # Any other key abandons the count.
+    return TransitionResult(next=IdleState())
+
+
+def _from_operator(
+    op: Operator, count: int, key: str, ctx: TransitionContext
+) -> TransitionResult:
+    """``OperatorState`` waits for a motion, text-object, find, or self-repeat."""
+
+    # Self-repeat (``dd`` / ``cc`` / ``yy``).
+    if key == _OPERATOR_KEYS_INV[op]:
+        return TransitionResult(
+            next=IdleState(),
+            execute=_line_op_executor(ctx, op, count=count),
+        )
+
+    # Count after operator → operatorCount.
+    if key.isdigit() and key != "0":
+        return TransitionResult(
+            next=OperatorCountState(op=op, count=count, digits=key)
+        )
+
+    # Text object scope.
+    if key in _TEXT_OBJ_SCOPES:
+        return TransitionResult(
+            next=OperatorTextObjState(
+                op=op, count=count, scope=_TEXT_OBJ_SCOPES[key]
+            )
+        )
+
+    # Find motion under operator.
+    if key in _FIND_KEYS:
+        return TransitionResult(
+            next=OperatorFindState(op=op, count=count, find=key)  # type: ignore[arg-type]
+        )
+
+    # G-prefix under operator (``dgg``).
+    if key == "g":
+        return TransitionResult(next=OperatorGState(op=op, count=count))
+
+    # Simple motion executes the operator over the motion's range.
+    if key in _SIMPLE_MOTIONS:
+        return TransitionResult(
+            next=IdleState(),
+            execute=_operator_motion_executor(ctx, op, key, count=count),
+        )
+
+    # Unknown — abandon.
+    return TransitionResult(next=IdleState())
+
+
+_OPERATOR_KEYS_INV = {v: k for k, v in _OPERATOR_KEYS.items()}
+
+
+def _from_operator_count(
+    op: Operator, count: int, digits: str, key: str, ctx: TransitionContext
+) -> TransitionResult:
+    """``OperatorCountState`` — accumulating count after an operator."""
+
+    if key.isdigit():
+        new_digits = digits + key
+        if int(new_digits) > MAX_VIM_COUNT:
+            new_digits = str(MAX_VIM_COUNT)
+        return TransitionResult(
+            next=OperatorCountState(op=op, count=count, digits=new_digits)
+        )
+
+    motion_count = _clamp_count(int(digits))
+    effective = _clamp_count(count * motion_count)
+
+    if key in _SIMPLE_MOTIONS:
+        return TransitionResult(
+            next=IdleState(),
+            execute=_operator_motion_executor(ctx, op, key, count=effective),
+        )
+
+    if key in _FIND_KEYS:
+        return TransitionResult(
+            next=OperatorFindState(op=op, count=effective, find=key)  # type: ignore[arg-type]
+        )
+
+    if key in _TEXT_OBJ_SCOPES:
+        return TransitionResult(
+            next=OperatorTextObjState(
+                op=op, count=effective, scope=_TEXT_OBJ_SCOPES[key]
+            )
+        )
+
+    return TransitionResult(next=IdleState())
+
+
+def _from_operator_find(
+    op: Operator, count: int, find_type: FindType, key: str, ctx: TransitionContext
+) -> TransitionResult:
+    """``OperatorFindState`` — next key is the target character."""
+
+    char = key
+    return TransitionResult(
+        next=IdleState(),
+        execute=_operator_find_executor(ctx, op, find_type, char, count=count),
+    )
+
+
+def _from_operator_text_obj(
+    op: Operator, count: int, scope: TextObjScope, key: str, ctx: TransitionContext
+) -> TransitionResult:
+    """``OperatorTextObjState`` — next key is the text-object kind."""
+
+    obj_type = key
+    return TransitionResult(
+        next=IdleState(),
+        execute=_operator_text_obj_executor(
+            ctx, op, obj_type, scope, count=count
+        ),
+    )
+
+
+def _from_find(
+    find_type: FindType, count: int, key: str, ctx: TransitionContext
+) -> TransitionResult:
+    """``FindState`` — next key is the target character; cursor moves."""
+
+    char = key
+    return TransitionResult(
+        next=IdleState(),
+        execute=_find_executor(ctx, find_type, char, count=count),
+    )
+
+
+def _from_g(count: int, key: str, ctx: TransitionContext) -> TransitionResult:
+    """``GState`` — ``gg`` jumps to start; ``gj``/``gk`` line-wise nav."""
+
+    if key == "g":
+        return TransitionResult(
+            next=IdleState(),
+            execute=_gg_executor(ctx, count=count),
+        )
+    if key in ("j", "k"):
+        return TransitionResult(
+            next=IdleState(),
+            execute=_motion_executor(ctx, key, count=count),
+        )
+    return TransitionResult(next=IdleState())
+
+
+def _from_operator_g(
+    op: Operator, count: int, key: str, ctx: TransitionContext
+) -> TransitionResult:
+    """``OperatorGState`` — ``dgg`` deletes from cursor to start."""
+
+    if key == "g":
+        return TransitionResult(
+            next=IdleState(),
+            execute=_operator_gg_executor(ctx, op, count=count),
+        )
+    return TransitionResult(next=IdleState())
+
+
+def _from_replace(
+    count: int, key: str, ctx: TransitionContext
+) -> TransitionResult:
+    """``ReplaceState`` — next key is the replacement character."""
+
+    char = key
+    return TransitionResult(
+        next=IdleState(),
+        execute=_replace_executor(ctx, char, count=count),
+    )
+
+
+def _from_indent(
+    direction: Literal[">", "<"], count: int, key: str, ctx: TransitionContext
+) -> TransitionResult:
+    """``IndentState`` — ``>>`` / ``<<`` indents the current line."""
+
+    if key == direction:
+        return TransitionResult(
+            next=IdleState(),
+            execute=_indent_executor(ctx, direction, count=count),
+        )
+    return TransitionResult(next=IdleState())
+
+
+# ---- Executor closures ----------------------------------------------------
+#
+# Each executor returns a callable that, when invoked, mutates ``ctx``.
+# Executors are the boundary between the pure state machine and the
+# effectful buffer surface.
+
+
+def _motion_executor(
+    ctx: TransitionContext, motion: str, *, count: int
+) -> Callable[[], None]:
+    """Cursor-positioning motion executor.
+
+    Distinct from operator-motion: a standalone motion lands the cursor
+    *on* the target cell (vim's "exclusive at last char" rule for ``w``
+    /``W``/``e``/``E``), while the same motion used with an operator
+    extends the range one past for word starts. This executor only
+    handles standalone motion.
+    """
+
+    def go() -> None:
+        from .vim_buffer import Cursor, VimBuffer
+        from .vim_operators import _resolve_motion_range
+
+        buf = VimBuffer(ctx.get_text())
+        cur = ctx.get_cursor()
+        buf.set_cursor(cur.row, cur.col)
+        # Line-start / line-end motions: standalone shortcut so they
+        # always work even when the buffer is empty (`_resolve_motion_range`
+        # may return an empty Range that confuses the caller).
+        if motion == "0":
+            ctx.set_cursor(Cursor(row=cur.row, col=0))
+            return
+        if motion == "$":
+            line = buf.line(cur.row) if cur.row < buf.line_count else ""
+            ctx.set_cursor(Cursor(row=cur.row, col=len(line)))
+            return
+        rng = _resolve_motion_range(buf, buf.cursor, motion, count=count)
+        if rng is None:
+            return
+        norm = rng.normalised()
+        if motion in ("h", "k", "b", "B", "^"):
+            ctx.set_cursor(norm.start)
+        elif motion in ("e", "E"):
+            # ``e`` lands on the LAST char of the word, not one past.
+            # The range's end is exclusive (one past last); decrement
+            # to land on the last char.
+            line = buf.line(norm.end.row) if norm.end.row < buf.line_count else ""
+            target_col = max(norm.start.col, norm.end.col - 1)
+            target_col = min(target_col, max(0, len(line) - 1))
+            ctx.set_cursor(Cursor(row=norm.end.row, col=target_col))
+        else:
+            ctx.set_cursor(norm.end)
+
+    return go
+
+
+def _x_executor(ctx: TransitionContext, *, count: int) -> Callable[[], None]:
+    def go() -> None:
+        from .vim_buffer import Cursor, Range, VimBuffer
+        from .vim_persistent import XChange
+
+        text = ctx.get_text()
+        cur = ctx.get_cursor()
+        buf = VimBuffer(text)
+        buf.set_cursor(cur.row, cur.col)
+        line = buf.line(cur.row) if cur.row < buf.line_count else ""
+        end_col = min(cur.col + count, len(line))
+        if end_col == cur.col:
+            return
+        removed = buf.delete(Range(start=cur, end=Cursor(cur.row, end_col)))
+        ctx.set_text(buf.text)
+        ctx.set_cursor(buf.cursor)
+        ctx.set_register(removed, False)
+        ctx.record_change(XChange(count=count))
+
+    return go
+
+
+def _toggle_case_executor(
+    ctx: TransitionContext, *, count: int
+) -> Callable[[], None]:
+    def go() -> None:
+        from .vim_buffer import Cursor, VimBuffer
+        from .vim_persistent import ToggleCaseChange
+
+        text = ctx.get_text()
+        cur = ctx.get_cursor()
+        buf = VimBuffer(text)
+        buf.set_cursor(cur.row, cur.col)
+        line = buf.line(cur.row) if cur.row < buf.line_count else ""
+        end_col = min(cur.col + count, len(line))
+        if end_col == cur.col:
+            return
+        toggled = "".join(
+            c.upper() if c.islower() else c.lower() for c in line[cur.col:end_col]
+        )
+        new_line = line[: cur.col] + toggled + line[end_col:]
+        lines = list(buf.lines)
+        lines[cur.row] = new_line
+        ctx.set_text("\n".join(lines))
+        ctx.set_cursor(Cursor(row=cur.row, col=end_col))
+        ctx.record_change(ToggleCaseChange(count=count))
+
+    return go
+
+
+def _line_op_executor(
+    ctx: TransitionContext, op: Operator, *, count: int
+) -> Callable[[], None]:
+    """``dd`` / ``yy`` / ``cc`` — line-wise op.
+
+    Spans the deletion to also remove the inter-line newline so we don't
+    leave a leading or trailing empty line. Falls back to deleting the
+    preceding newline when the target lines are at the end of the buffer.
+    """
+
+    def go() -> None:
+        from .vim_buffer import Cursor, Range, VimBuffer
+        from .vim_persistent import OperatorChange
+
+        text = ctx.get_text()
+        cur = ctx.get_cursor()
+        buf = VimBuffer(text)
+        buf.set_cursor(cur.row, cur.col)
+        end_row = min(cur.row + count - 1, buf.line_count - 1)
+        affected_lines = buf.lines[cur.row : end_row + 1]
+        affected = "\n".join(affected_lines) + "\n"
+        if op in ("delete", "change"):
+            if end_row + 1 < buf.line_count:
+                rng = Range(
+                    start=Cursor(row=cur.row, col=0),
+                    end=Cursor(row=end_row + 1, col=0),
+                )
+            elif cur.row > 0:
+                rng = Range(
+                    start=Cursor(row=cur.row - 1, col=len(buf.line(cur.row - 1))),
+                    end=Cursor(row=end_row, col=len(buf.line(end_row))),
+                )
+            else:
+                rng = Range(
+                    start=Cursor(row=0, col=0),
+                    end=Cursor(row=end_row, col=len(buf.line(end_row))),
+                )
+            buf.delete(rng)
+            ctx.set_text(buf.text)
+            ctx.set_cursor(buf.cursor)
+        ctx.set_register(affected, True)
+        ctx.record_change(
+            OperatorChange(op=op, motion=_OPERATOR_KEYS_INV[op], count=count)
+        )
+
+    return go
+
+
+def _operator_motion_executor(
+    ctx: TransitionContext, op: Operator, motion: str, *, count: int
+) -> Callable[[], None]:
+    def go() -> None:
+        from .vim_buffer import VimBuffer
+        from .vim_operators import _resolve_motion_range, apply_operator
+        from .vim_persistent import OperatorChange
+
+        text = ctx.get_text()
+        cur = ctx.get_cursor()
+        buf = VimBuffer(text)
+        buf.set_cursor(cur.row, cur.col)
+        rng = _resolve_motion_range(buf, buf.cursor, motion, count=count)
+        if rng is None:
+            return
+        register_list = [ctx.get_register()[0]]
+        apply_operator(buf, rng, op[0], yank_buffer=register_list)
+        ctx.set_text(buf.text)
+        ctx.set_cursor(buf.cursor)
+        # Linewise classification — single source of truth lives in
+        # vim_persistent so the executor and the replay path always
+        # agree.
+        from .vim_persistent import _is_linewise_motion
+
+        ctx.set_register(register_list[0], _is_linewise_motion(motion))
+        ctx.record_change(OperatorChange(op=op, motion=motion, count=count))
+
+    return go
+
+
+def _operator_find_executor(
+    ctx: TransitionContext,
+    op: Operator,
+    find_type: FindType,
+    char: str,
+    *,
+    count: int,
+) -> Callable[[], None]:
+    def go() -> None:
+        from .vim_buffer import Cursor, Range, VimBuffer
+        from .vim_find import find_char
+        from .vim_operators import apply_operator
+        from .vim_persistent import OperatorFindChange
+
+        text = ctx.get_text()
+        cur = ctx.get_cursor()
+        buf = VimBuffer(text)
+        buf.set_cursor(cur.row, cur.col)
+        line = buf.line(cur.row) if cur.row < buf.line_count else ""
+        # last_find is always set on attempt (vim semantics — successful
+        # or not, the user can ``;`` after).
+        ctx.set_last_find(find_type, char)
+        target_col = find_char(line, cur.col, char, find_type, count)
+        if target_col is None:
+            return
+        # Operator+find: the cursor cell is ALWAYS included (cursor side
+        # uses cur.col + 1). For target_col, `find_char` has already
+        # adjusted the offset for t/T (it returns one-toward-cursor from
+        # the matched char) — see TS `getOperatorRangeForFind` in
+        # typescript/src/vim/operators.ts:482-491: "findType is unused
+        # because findCharacter already adjusts the offset for t/T
+        # motions. All find types are treated as inclusive here." So we
+        # treat target_col as the endpoint without re-shifting per
+        # find_type.
+        cur_end = Cursor(row=cur.row, col=cur.col + 1)
+        target_end = Cursor(row=cur.row, col=target_col + 1)
+        target_pos = Cursor(row=cur.row, col=target_col)
+        if find_type in ("f", "t"):
+            rng = Range(start=cur, end=target_end)
+        else:  # F or T
+            rng = Range(start=target_pos, end=cur_end)
+        register_list = [ctx.get_register()[0]]
+        apply_operator(buf, rng.normalised(), op[0], yank_buffer=register_list)
+        ctx.set_text(buf.text)
+        ctx.set_cursor(buf.cursor)
+        ctx.set_register(register_list[0], False)
+        ctx.record_change(
+            OperatorFindChange(op=op, find=find_type, char=char, count=count)
+        )
+
+    return go
+
+
+def _operator_text_obj_executor(
+    ctx: TransitionContext,
+    op: Operator,
+    obj_type: str,
+    scope: TextObjScope,
+    *,
+    count: int,
+) -> Callable[[], None]:
+    def go() -> None:
+        from .vim_buffer import VimBuffer
+        from .vim_operators import apply_operator
+        from .vim_persistent import OperatorTextObjChange
+        from .vim_text_objects import find_text_object
+
+        text = ctx.get_text()
+        cur = ctx.get_cursor()
+        buf = VimBuffer(text)
+        buf.set_cursor(cur.row, cur.col)
+        specifier = ("i" if scope == "inner" else "a") + obj_type
+        rng = find_text_object(buf, buf.cursor, specifier)
+        if rng is None:
+            return
+        register_list = [ctx.get_register()[0]]
+        apply_operator(buf, rng, op[0], yank_buffer=register_list)
+        ctx.set_text(buf.text)
+        ctx.set_cursor(buf.cursor)
+        ctx.set_register(register_list[0], False)
+        ctx.record_change(
+            OperatorTextObjChange(
+                op=op, obj_type=obj_type, scope=scope, count=count
+            )
+        )
+
+    return go
+
+
+def _find_executor(
+    ctx: TransitionContext,
+    find_type: FindType,
+    char: str,
+    *,
+    count: int,
+    update_last_find: bool = True,
+) -> Callable[[], None]:
+    """Cursor-only find executor.
+
+    ``update_last_find=True`` (the default, for user-typed ``f``/``F``
+    /``t``/``T``) records the find on attempt (vim semantics — failed
+    attempts still update so ``;`` can retry). ``update_last_find=False``
+    for ``;``/``,`` repeats so the stored direction isn't overwritten.
+    """
+
+    def go() -> None:
+        from .vim_buffer import Cursor, VimBuffer
+        from .vim_find import find_char
+
+        text = ctx.get_text()
+        cur = ctx.get_cursor()
+        buf = VimBuffer(text)
+        line = buf.line(cur.row) if cur.row < buf.line_count else ""
+        if update_last_find:
+            ctx.set_last_find(find_type, char)
+        target_col = find_char(line, cur.col, char, find_type, count)
+        if target_col is None:
+            return
+        ctx.set_cursor(Cursor(row=cur.row, col=target_col))
+
+    return go
+
+
+def _replace_executor(
+    ctx: TransitionContext, char: str, *, count: int
+) -> Callable[[], None]:
+    def go() -> None:
+        from .vim_buffer import Cursor, VimBuffer
+        from .vim_persistent import ReplaceChange
+
+        text = ctx.get_text()
+        cur = ctx.get_cursor()
+        buf = VimBuffer(text)
+        line = buf.line(cur.row) if cur.row < buf.line_count else ""
+        end_col = min(cur.col + count, len(line))
+        if end_col == cur.col:
+            return
+        replaced = char * (end_col - cur.col)
+        new_line = line[: cur.col] + replaced + line[end_col:]
+        lines = list(buf.lines)
+        lines[cur.row] = new_line
+        ctx.set_text("\n".join(lines))
+        ctx.set_cursor(Cursor(row=cur.row, col=end_col - 1))
+        ctx.record_change(ReplaceChange(char=char, count=count))
+
+    return go
+
+
+def _indent_executor(
+    ctx: TransitionContext, direction: Literal[">", "<"], *, count: int
+) -> Callable[[], None]:
+    def go() -> None:
+        from .vim_buffer import Cursor, Range, VimBuffer
+        from .vim_operators import _indent_range
+        from .vim_persistent import IndentChange
+
+        text = ctx.get_text()
+        cur = ctx.get_cursor()
+        buf = VimBuffer(text)
+        end_row = min(cur.row + count - 1, buf.line_count - 1)
+        end_line = buf.line(end_row)
+        rng = Range(
+            start=Cursor(row=cur.row, col=0),
+            end=Cursor(row=end_row, col=len(end_line)),
+        )
+        _indent_range(buf, rng, indent_amount=1 if direction == ">" else -1)
+        ctx.set_text(buf.text)
+        ctx.record_change(IndentChange(dir=direction, count=count))
+
+    return go
+
+
+def _gg_executor(ctx: TransitionContext, *, count: int) -> Callable[[], None]:
+    """``gg`` — go to first line (or line ``count`` if specified)."""
+
+    def go() -> None:
+        from .vim_buffer import Cursor
+
+        target_row = max(0, count - 1)
+        ctx.set_cursor(Cursor(row=target_row, col=0))
+
+    return go
+
+
+def _operator_gg_executor(
+    ctx: TransitionContext, op: Operator, *, count: int
+) -> Callable[[], None]:
+    """``dgg`` — delete from cursor to first line."""
+
+    def go() -> None:
+        from .vim_buffer import Cursor, Range, VimBuffer
+        from .vim_operators import apply_operator
+        from .vim_persistent import OperatorChange
+
+        text = ctx.get_text()
+        cur = ctx.get_cursor()
+        buf = VimBuffer(text)
+        target_row = max(0, count - 1)
+        rng = Range(
+            start=Cursor(row=target_row, col=0),
+            end=Cursor(row=cur.row, col=len(buf.line(cur.row))),
+        )
+        register_list = [ctx.get_register()[0]]
+        apply_operator(buf, rng, op[0], yank_buffer=register_list)
+        ctx.set_text(buf.text)
+        ctx.set_cursor(buf.cursor)
+        ctx.set_register(register_list[0], True)
+        ctx.record_change(OperatorChange(op=op, motion="gg", count=count))
+
+    return go
+
+
+__all__ = [
+    "CountState",
+    "CommandState",
+    "FindState",
+    "FindType",
+    "GState",
+    "IdleState",
+    "IndentState",
+    "MAX_VIM_COUNT",
+    "Operator",
+    "OperatorCountState",
+    "OperatorFindState",
+    "OperatorGState",
+    "OperatorState",
+    "OperatorTextObjState",
+    "ReplaceState",
+    "TextObjScope",
+    "TransitionContext",
+    "TransitionResult",
+    "transition",
+]

--- a/tests/tui/test_vim_find.py
+++ b/tests/tui/test_vim_find.py
@@ -1,0 +1,85 @@
+"""Tests for ``src/tui/vim_find.py`` — ``f`` / ``F`` / ``t`` / ``T`` motions.
+
+Phase 3 of the ch14 refactor. The string ``"hello world"`` has 'o' at
+indices 4 and 7, 'l' at 2/3/9, ' ' at 5.
+"""
+
+from __future__ import annotations
+
+from src.tui.vim_find import find_char
+
+
+def test_f_forward_lands_on_char():
+    """``f<o>`` from index 0 finds the first 'o' at index 4."""
+
+    assert find_char("hello world", 0, "o", "f") == 4
+
+
+def test_F_backward_lands_on_char():
+    """``F<o>`` from index 9 finds the previous 'o' at index 7 (NOT 4)."""
+
+    assert find_char("hello world", 9, "o", "F") == 7
+
+
+def test_t_forward_stops_one_before():
+    """``t<o>`` from index 0 lands at index 3 (one before 'o' at 4)."""
+
+    assert find_char("hello world", 0, "o", "t") == 3
+
+
+def test_T_backward_stops_one_after():
+    """``T<o>`` from index 9 lands at index 8 (one after 'o' at 7)."""
+
+    assert find_char("hello world", 9, "o", "T") == 8
+
+
+def test_F_count_two_reaches_first_o():
+    """``2F<o>`` from index 9 reaches the first 'o' at index 4."""
+
+    assert find_char("hello world", 9, "o", "F", count=2) == 4
+
+
+def test_T_count_two_reaches_one_after_first_o():
+    """``2T<o>`` from index 9 reaches one after the first 'o' (index 5)."""
+
+    assert find_char("hello world", 9, "o", "T", count=2) == 5
+
+
+def test_count_repeats_forward():
+    """``3f<a>`` in 'aaaa' from index 0 finds the third 'a' at index 3."""
+
+    assert find_char("aaaa", 0, "a", "f", count=3) == 3
+
+
+def test_not_found_returns_none():
+    assert find_char("hello world", 0, "z", "f") is None
+    assert find_char("hello world", 10, "z", "F") is None
+
+
+def test_empty_line_returns_none():
+    assert find_char("", 0, "a", "f") is None
+    assert find_char("", 0, "a", "F") is None
+
+
+def test_forward_no_room_returns_none():
+    """``f<o>`` from the end of the line — no further 'o' forward."""
+
+    assert find_char("hello world", 7, "o", "f") is None
+
+
+def test_backward_from_zero_returns_none():
+    """``F<o>`` from index 0 — nothing before the cursor to search."""
+
+    assert find_char("hello world", 0, "o", "F") is None
+
+
+def test_count_overshoots_returns_none():
+    """``5f<a>`` in 'aaaa' from index 0 — only 3 'a's after cursor."""
+
+    assert find_char("aaaa", 0, "a", "f", count=5) is None
+
+
+def test_empty_char_returns_none():
+    """Defensive: empty char string yields no match."""
+
+    assert find_char("hello", 0, "", "f") is None

--- a/tests/tui/test_vim_persistent.py
+++ b/tests/tui/test_vim_persistent.py
@@ -1,0 +1,427 @@
+"""Tests for ``src/tui/vim_persistent.py`` — ``PersistentState`` +
+``RecordedChange`` + ``replay()`` (dot-repeat machinery).
+
+Phase 2 of the ch14 refactor. Verifies that each ``RecordedChange``
+variant replays correctly via ``replay()`` against a fake context,
+that ``PersistentState`` accumulates state across commands, and that
+the integration of dot-repeat (`.`) and find-repeat (`;`/`,`) through
+the state machine produces correct results.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from src.tui.vim_buffer import Cursor
+from src.tui.vim_persistent import (
+    IndentChange,
+    InsertChange,
+    JoinChange,
+    OpenLineChange,
+    OperatorChange,
+    OperatorFindChange,
+    OperatorTextObjChange,
+    PersistentState,
+    RecordedChange,
+    ReplaceChange,
+    ToggleCaseChange,
+    XChange,
+    replay,
+)
+from src.tui.vim_state import (
+    FindState,
+    IdleState,
+    OperatorState,
+    TransitionContext,
+    transition,
+)
+
+
+@dataclass
+class _FakeCtx:
+    """Shared fake ctx — identical to test_vim_transitions.py for parity."""
+
+    text: str = ""
+    cursor: Cursor = field(default_factory=lambda: Cursor(0, 0))
+    register_content: str = ""
+    register_linewise: bool = False
+    last_find: tuple[str, str] | None = None
+    last_change: RecordedChange | None = None
+    changes_recorded: list[RecordedChange] = field(default_factory=list)
+
+    def as_transition_context(self) -> TransitionContext:
+        return TransitionContext(
+            get_cursor=lambda: self.cursor,
+            set_cursor=self._set_cursor,
+            get_text=lambda: self.text,
+            set_text=self._set_text,
+            set_register=self._set_register,
+            get_register=lambda: (self.register_content, self.register_linewise),
+            get_last_find=lambda: self.last_find,  # type: ignore[return-value]
+            set_last_find=self._set_last_find,
+            get_last_change=lambda: self.last_change,
+            record_change=self._record_change,
+        )
+
+    def _set_cursor(self, cursor: Cursor) -> None:
+        self.cursor = cursor
+
+    def _set_text(self, text: str) -> None:
+        self.text = text
+
+    def _set_register(self, content: str, linewise: bool) -> None:
+        self.register_content = content
+        self.register_linewise = linewise
+
+    def _set_last_find(self, find_type, char):  # type: ignore[no-untyped-def]
+        self.last_find = (find_type, char)
+
+    def _record_change(self, change: RecordedChange) -> None:
+        self.changes_recorded.append(change)
+        self.last_change = change
+
+
+# ---- PersistentState basics -----------------------------------------------
+
+
+def test_persistent_state_defaults():
+    p = PersistentState()
+    assert p.last_change is None
+    assert p.last_find is None
+    assert p.register == ""
+    assert p.register_is_linewise is False
+
+
+def test_persistent_state_record_change():
+    p = PersistentState()
+    p.record(OperatorChange(op="delete", motion="w", count=1))
+    assert p.last_change == OperatorChange(op="delete", motion="w", count=1)
+
+
+def test_persistent_state_record_find():
+    p = PersistentState()
+    p.record_find("f", "a")
+    assert p.last_find == ("f", "a")
+
+
+def test_persistent_state_set_register_linewise():
+    p = PersistentState()
+    p.set_register("line one\n", linewise=True)
+    assert p.register == "line one\n"
+    assert p.register_is_linewise is True
+
+
+# ---- replay() per-variant -------------------------------------------------
+
+
+def test_replay_operator_change_dw():
+    """After `dw`, dot-replay deletes another word at the current cursor."""
+
+    ctx = _FakeCtx(text="hello world there", cursor=Cursor(0, 0))
+    change = OperatorChange(op="delete", motion="w", count=1)
+    replay(change, ctx.as_transition_context())
+    assert ctx.text == "world there"
+
+
+def test_replay_operator_change_dd_clears_line():
+    """`dd` on a single-line buffer clears it."""
+
+    ctx = _FakeCtx(text="hello", cursor=Cursor(0, 0))
+    change = OperatorChange(op="delete", motion="d", count=1)
+    replay(change, ctx.as_transition_context())
+    assert ctx.text == ""
+    assert ctx.register_linewise is True
+
+
+def test_replay_operator_text_obj_change():
+    """ciw on word boundary."""
+
+    ctx = _FakeCtx(text="hello world", cursor=Cursor(0, 6))
+    change = OperatorTextObjChange(
+        op="change", obj_type="w", scope="inner", count=1
+    )
+    replay(change, ctx.as_transition_context())
+    assert ctx.text == "hello "
+
+
+def test_replay_operator_find_change_df_inclusive():
+    """`df"` deletes from cursor through the quote (inclusive)."""
+
+    ctx = _FakeCtx(text='hello"world', cursor=Cursor(0, 0))
+    change = OperatorFindChange(op="delete", find="f", char='"', count=1)
+    replay(change, ctx.as_transition_context())
+    assert ctx.text == "world"
+
+
+def test_replay_operator_find_change_dF_inclusive():
+    """`dF"` from after the quote deletes through cursor inclusive."""
+
+    ctx = _FakeCtx(text='abc"def', cursor=Cursor(0, 6))  # cursor on 'f'
+    change = OperatorFindChange(op="delete", find="F", char='"', count=1)
+    replay(change, ctx.as_transition_context())
+    # Deletes '"def' — keeps 'abc'.
+    assert ctx.text == "abc"
+
+
+def test_replay_operator_find_change_dT_exclusive_with_cursor():
+    """`dT<h>` from `hello world` cursor on 'o' (col 7).
+
+    Vim/TS semantics: ``dT`` deletes ``[motion-target, cursor]`` inclusive.
+    ``find_char`` for T returns the motion target (one-after the matched
+    char) directly; operator-find treats it as the endpoint without
+    further adjustment (TS ``vim/operators.ts:482-491``).
+
+    Here ``find_char`` returns col 1 (one-after 'h' at col 0). Range is
+    therefore ``[1, 8)`` → deletes "ello wo" → result "hrld".
+    """
+
+    ctx = _FakeCtx(text="hello world", cursor=Cursor(0, 7))
+    change = OperatorFindChange(op="delete", find="T", char="h", count=1)
+    replay(change, ctx.as_transition_context())
+    assert ctx.text == "hrld"
+
+
+def test_replay_operator_find_change_dT_at_line_end():
+    """``dT<h>`` from col 4 of "hello" (cursor on 'o', last char).
+
+    find_char returns col 1 (one-after 'h' at col 0). Range [1, 5) →
+    deletes "ello" → result "h".
+    """
+
+    ctx = _FakeCtx(text="hello", cursor=Cursor(0, 4))
+    change = OperatorFindChange(op="delete", find="T", char="h", count=1)
+    replay(change, ctx.as_transition_context())
+    assert ctx.text == "h"
+
+
+def test_replay_operator_find_change_dt_exclusive():
+    """`dt<o>` deletes up to but not including the next 'o'."""
+
+    ctx = _FakeCtx(text="hello world", cursor=Cursor(0, 0))
+    change = OperatorFindChange(op="delete", find="t", char="o", count=1)
+    replay(change, ctx.as_transition_context())
+    # Deletes "hell" — stops one before 'o'.
+    assert ctx.text == "o world"
+
+
+def test_replay_x_change():
+    ctx = _FakeCtx(text="hello", cursor=Cursor(0, 1))
+    change = XChange(count=1)
+    replay(change, ctx.as_transition_context())
+    assert ctx.text == "hllo"
+
+
+def test_replay_toggle_case_change():
+    ctx = _FakeCtx(text="hello", cursor=Cursor(0, 0))
+    change = ToggleCaseChange(count=3)
+    replay(change, ctx.as_transition_context())
+    assert ctx.text == "HELlo"
+
+
+def test_replay_replace_change():
+    ctx = _FakeCtx(text="hello", cursor=Cursor(0, 0))
+    change = ReplaceChange(char="X", count=2)
+    replay(change, ctx.as_transition_context())
+    assert ctx.text == "XXllo"
+
+
+def test_replay_indent_change_right():
+    ctx = _FakeCtx(text="hello", cursor=Cursor(0, 0))
+    change = IndentChange(dir=">", count=1)
+    replay(change, ctx.as_transition_context())
+    assert ctx.text == "  hello"
+
+
+def test_replay_indent_change_left():
+    ctx = _FakeCtx(text="    hello", cursor=Cursor(0, 0))
+    change = IndentChange(dir="<", count=1)
+    replay(change, ctx.as_transition_context())
+    assert ctx.text == "  hello"
+
+
+def test_replay_insert_change():
+    ctx = _FakeCtx(text="hello", cursor=Cursor(0, 5))
+    change = InsertChange(text=" world")
+    replay(change, ctx.as_transition_context())
+    assert ctx.text == "hello world"
+
+
+def test_replay_open_line_below():
+    ctx = _FakeCtx(text="line one\nline two", cursor=Cursor(0, 4))
+    change = OpenLineChange(direction="below")
+    replay(change, ctx.as_transition_context())
+    assert ctx.text == "line one\n\nline two"
+    assert ctx.cursor == Cursor(1, 0)
+
+
+def test_replay_open_line_above():
+    ctx = _FakeCtx(text="line one\nline two", cursor=Cursor(1, 0))
+    change = OpenLineChange(direction="above")
+    replay(change, ctx.as_transition_context())
+    assert ctx.text == "line one\n\nline two"
+    assert ctx.cursor == Cursor(1, 0)
+
+
+def test_replay_join_change():
+    ctx = _FakeCtx(text="line one\nline two", cursor=Cursor(0, 0))
+    change = JoinChange(count=1)
+    replay(change, ctx.as_transition_context())
+    assert ctx.text == "line one line two"
+
+
+# ---- Integration: dot-repeat through the state machine --------------------
+
+
+def test_dot_repeat_after_dw_via_state_machine():
+    """Full flow: feed `dw` through transition, then `.` replays it."""
+
+    ctx = _FakeCtx(text="hello world there", cursor=Cursor(0, 0))
+    txn = ctx.as_transition_context()
+
+    # 1. `d` enters OperatorState.
+    r1 = transition(IdleState(), "d", txn)
+    assert isinstance(r1.next, OperatorState)
+
+    # 2. `w` executes the operator-motion.
+    r2 = transition(r1.next, "w", txn)
+    assert r2.execute is not None
+    r2.execute()
+    assert ctx.text == "world there"
+    assert ctx.last_change == OperatorChange(op="delete", motion="w", count=1)
+
+    # 3. `.` in idle replays the last change at the current cursor.
+    r3 = transition(IdleState(), ".", txn)
+    assert r3.execute is not None
+    r3.execute()
+    assert ctx.text == "there"
+
+
+def test_dot_repeat_before_any_change_is_noop():
+    ctx = _FakeCtx(text="hello", cursor=Cursor(0, 0))
+    result = transition(IdleState(), ".", ctx.as_transition_context())
+    assert result.execute is None
+    assert ctx.text == "hello"
+
+
+def test_dot_repeat_after_x():
+    ctx = _FakeCtx(text="hello", cursor=Cursor(0, 0))
+    txn = ctx.as_transition_context()
+    transition(IdleState(), "x", txn).execute()  # type: ignore[misc]
+    assert ctx.text == "ello"
+    transition(IdleState(), ".", txn).execute()  # type: ignore[misc]
+    assert ctx.text == "llo"
+
+
+def test_dot_repeat_after_replace():
+    ctx = _FakeCtx(text="hello", cursor=Cursor(0, 0))
+    txn = ctx.as_transition_context()
+    # `r!` — replace state then char
+    r1 = transition(IdleState(), "r", txn)
+    r2 = transition(r1.next, "!", txn)
+    r2.execute()  # type: ignore[misc]
+    assert ctx.text == "!ello"
+    # Move cursor and dot-repeat
+    ctx.cursor = Cursor(0, 2)
+    transition(IdleState(), ".", txn).execute()  # type: ignore[misc]
+    assert ctx.text == "!e!lo"
+
+
+# ---- Integration: find-repeat through the state machine ------------------
+
+
+def test_semicolon_repeats_find_forward():
+    ctx = _FakeCtx(text="ababab", cursor=Cursor(0, 0))
+    txn = ctx.as_transition_context()
+
+    # `fa` finds first 'a' after cursor (at index 2)
+    r1 = transition(IdleState(), "f", txn)
+    assert isinstance(r1.next, FindState)
+    r2 = transition(r1.next, "a", txn)
+    r2.execute()  # type: ignore[misc]
+    assert ctx.cursor == Cursor(0, 2)
+    assert ctx.last_find == ("f", "a")
+
+    # `;` repeats — next 'a' at index 4
+    r3 = transition(IdleState(), ";", txn)
+    r3.execute()  # type: ignore[misc]
+    assert ctx.cursor == Cursor(0, 4)
+
+
+def test_comma_reverses_find_direction():
+    ctx = _FakeCtx(text="abab", cursor=Cursor(0, 0))
+    txn = ctx.as_transition_context()
+
+    # `fb` — find next 'b' at index 1
+    r1 = transition(IdleState(), "f", txn)
+    r2 = transition(r1.next, "b", txn)
+    r2.execute()  # type: ignore[misc]
+    assert ctx.cursor == Cursor(0, 1)
+
+    # `,` reverses → F → searches backward — no 'b' before index 1
+    r3 = transition(IdleState(), ",", txn)
+    r3.execute()  # type: ignore[misc]
+    # No backward 'b' from index 1 → cursor unchanged
+    assert ctx.cursor == Cursor(0, 1)
+
+    # Move cursor right, then `,` again
+    ctx.cursor = Cursor(0, 3)  # at second 'b'
+    transition(IdleState(), ",", txn).execute()  # type: ignore[misc]
+    # F from index 3 finds 'b' at index 1
+    assert ctx.cursor == Cursor(0, 1)
+
+
+# ---- Linewise register flag drives paste behavior -------------------------
+
+
+def test_linewise_register_after_dd():
+    """`dd` sets register_is_linewise=True."""
+
+    ctx = _FakeCtx(text="line one\nline two", cursor=Cursor(0, 0))
+    txn = ctx.as_transition_context()
+    r1 = transition(IdleState(), "d", txn)
+    r2 = transition(r1.next, "d", txn)
+    r2.execute()  # type: ignore[misc]
+    assert ctx.register_linewise is True
+    assert ctx.register_content == "line one\n"
+
+
+def test_characterwise_register_after_dw():
+    """`dw` sets register_is_linewise=False."""
+
+    ctx = _FakeCtx(text="hello world", cursor=Cursor(0, 0))
+    txn = ctx.as_transition_context()
+    r1 = transition(IdleState(), "d", txn)
+    r2 = transition(r1.next, "w", txn)
+    r2.execute()  # type: ignore[misc]
+    assert ctx.register_linewise is False
+
+
+# ---- Count multiplication through dot-repeat ------------------------------
+
+
+def test_dot_repeat_after_3d2w_deletes_six_words():
+    """3d2w → effective count 6 → dot-repeat re-deletes 6 words."""
+
+    ctx = _FakeCtx(
+        text="a b c d e f g h i j k l m", cursor=Cursor(0, 0)
+    )
+    txn = ctx.as_transition_context()
+
+    # Manually drive 3 → d → 2 → w
+    state = IdleState()
+    r = transition(state, "3", txn)
+    state = r.next  # CountState
+    r = transition(state, "d", txn)
+    state = r.next  # OperatorState(count=3)
+    r = transition(state, "2", txn)
+    state = r.next  # OperatorCountState(count=3, digits="2")
+    r = transition(state, "w", txn)
+    r.execute()  # type: ignore[misc]
+    # 6 words deleted
+    assert ctx.text == "g h i j k l m"
+    # Recorded change has effective count
+    assert ctx.last_change == OperatorChange(op="delete", motion="w", count=6)
+
+    # Now `.` replays — deletes 6 more words
+    transition(IdleState(), ".", txn).execute()  # type: ignore[misc]
+    assert ctx.text == "m"

--- a/tests/tui/test_vim_transitions.py
+++ b/tests/tui/test_vim_transitions.py
@@ -1,0 +1,464 @@
+"""Tests for ``src/tui/vim_state.py`` — discriminated `CommandState`
+union and pure `transition()` function.
+
+Phase 1 of the ch14 refactor. Covers all 11 state variants + the count
+clamp + the purity invariant (calling transition twice yields the same
+(next, side-effects-determined)).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from src.tui.vim_buffer import Cursor
+from src.tui.vim_persistent import (
+    OperatorChange,
+    PersistentState,
+    RecordedChange,
+    ReplaceChange,
+    XChange,
+)
+from src.tui.vim_state import (
+    MAX_VIM_COUNT,
+    CountState,
+    FindState,
+    GState,
+    IdleState,
+    IndentState,
+    OperatorCountState,
+    OperatorFindState,
+    OperatorGState,
+    OperatorState,
+    OperatorTextObjState,
+    ReplaceState,
+    TransitionContext,
+    transition,
+)
+
+
+@dataclass
+class _FakeCtx:
+    """Dict-backed ``TransitionContext`` for tests.
+
+    Captures all primitives without touching Textual or a real buffer.
+    Stores enough state that executors can mutate it and tests can
+    inspect the result.
+    """
+
+    text: str = "hello world"
+    cursor: Cursor = field(default_factory=lambda: Cursor(0, 0))
+    register_content: str = ""
+    register_linewise: bool = False
+    last_find: tuple[str, str] | None = None
+    last_change: RecordedChange | None = None
+    changes_recorded: list[RecordedChange] = field(default_factory=list)
+    entered_insert_at: int | None = None
+
+    def as_transition_context(self) -> TransitionContext:
+        return TransitionContext(
+            get_cursor=lambda: self.cursor,
+            set_cursor=self._set_cursor,
+            get_text=lambda: self.text,
+            set_text=self._set_text,
+            set_register=self._set_register,
+            get_register=lambda: (self.register_content, self.register_linewise),
+            get_last_find=lambda: self.last_find,  # type: ignore[return-value]
+            set_last_find=self._set_last_find,
+            get_last_change=lambda: self.last_change,
+            record_change=self._record_change,
+            enter_insert=lambda offset: setattr(self, "entered_insert_at", offset),
+        )
+
+    def _set_cursor(self, cursor: Cursor) -> None:
+        self.cursor = cursor
+
+    def _set_text(self, text: str) -> None:
+        self.text = text
+
+    def _set_register(self, content: str, linewise: bool) -> None:
+        self.register_content = content
+        self.register_linewise = linewise
+
+    def _set_last_find(self, find_type, char):  # type: ignore[no-untyped-def]
+        self.last_find = (find_type, char)
+
+    def _record_change(self, change: RecordedChange) -> None:
+        self.changes_recorded.append(change)
+        self.last_change = change
+
+
+# ---- Idle state -----------------------------------------------------------
+
+
+def test_idle_count_enters_count_state():
+    ctx = _FakeCtx().as_transition_context()
+    result = transition(IdleState(), "3", ctx)
+    assert result.next == CountState(digits="3")
+    assert result.execute is None
+
+
+def test_idle_zero_is_motion_not_count():
+    """'0' in idle is the start-of-line motion, NOT a count digit."""
+
+    ctx = _FakeCtx()
+    result = transition(IdleState(), "0", ctx.as_transition_context())
+    # Stays in idle; executes the motion.
+    assert result.next is None
+    assert result.execute is not None
+    result.execute()
+    assert ctx.cursor == Cursor(0, 0)
+
+
+def test_idle_d_enters_operator_state():
+    ctx = _FakeCtx().as_transition_context()
+    result = transition(IdleState(), "d", ctx)
+    assert result.next == OperatorState(op="delete", count=1)
+
+
+def test_idle_c_enters_operator_state_change():
+    ctx = _FakeCtx().as_transition_context()
+    result = transition(IdleState(), "c", ctx)
+    assert result.next == OperatorState(op="change", count=1)
+
+
+def test_idle_y_enters_operator_state_yank():
+    ctx = _FakeCtx().as_transition_context()
+    result = transition(IdleState(), "y", ctx)
+    assert result.next == OperatorState(op="yank", count=1)
+
+
+def test_idle_f_enters_find_state():
+    ctx = _FakeCtx().as_transition_context()
+    result = transition(IdleState(), "f", ctx)
+    assert result.next == FindState(find="f", count=1)
+
+
+def test_idle_g_enters_g_state():
+    ctx = _FakeCtx().as_transition_context()
+    result = transition(IdleState(), "g", ctx)
+    assert result.next == GState(count=1)
+
+
+def test_idle_r_enters_replace_state():
+    ctx = _FakeCtx().as_transition_context()
+    result = transition(IdleState(), "r", ctx)
+    assert result.next == ReplaceState(count=1)
+
+
+def test_idle_indent_enters_indent_state():
+    ctx = _FakeCtx().as_transition_context()
+    result = transition(IdleState(), ">", ctx)
+    assert result.next == IndentState(dir=">", count=1)
+
+
+def test_idle_simple_motion_executes_immediately():
+    ctx = _FakeCtx()
+    ctx.cursor = Cursor(0, 2)
+    result = transition(IdleState(), "l", ctx.as_transition_context())
+    assert result.next is None
+    assert result.execute is not None
+    result.execute()
+    assert ctx.cursor.col == 3
+
+
+def test_idle_e_motion_lands_on_last_word_char():
+    """``e`` lands on the LAST char of the word, not one past."""
+
+    ctx = _FakeCtx(text="hello world", cursor=Cursor(0, 0))
+    result = transition(IdleState(), "e", ctx.as_transition_context())
+    assert result.execute is not None
+    result.execute()
+    # 'hello' ends at col 4 (the 'o'). 'e' must land ON the 'o', not the
+    # space at col 5.
+    assert ctx.cursor == Cursor(0, 4)
+
+
+def test_idle_w_motion_lands_at_word_start():
+    """``w`` lands AT the start of the next word."""
+
+    ctx = _FakeCtx(text="hello world", cursor=Cursor(0, 0))
+    result = transition(IdleState(), "w", ctx.as_transition_context())
+    assert result.execute is not None
+    result.execute()
+    assert ctx.cursor == Cursor(0, 6)
+
+
+def test_idle_x_executes_immediately_and_records():
+    ctx = _FakeCtx(text="hello", cursor=Cursor(0, 1))
+    result = transition(IdleState(), "x", ctx.as_transition_context())
+    assert result.execute is not None
+    result.execute()
+    assert ctx.text == "hllo"
+    assert ctx.changes_recorded == [XChange(count=1)]
+
+
+def test_idle_unknown_key_stays_idle():
+    ctx = _FakeCtx().as_transition_context()
+    result = transition(IdleState(), "Z", ctx)
+    assert result.next is None
+    assert result.execute is None
+
+
+# ---- Count state ----------------------------------------------------------
+
+
+def test_count_accumulates_digits():
+    ctx = _FakeCtx().as_transition_context()
+    result = transition(CountState(digits="3"), "5", ctx)
+    assert result.next == CountState(digits="35")
+
+
+def test_count_saturates_at_max():
+    ctx = _FakeCtx().as_transition_context()
+    result = transition(CountState(digits="9999"), "9", ctx)
+    # 99999 saturates to 10000
+    assert result.next == CountState(digits=str(MAX_VIM_COUNT))
+
+
+def test_count_then_operator_carries_count():
+    ctx = _FakeCtx().as_transition_context()
+    result = transition(CountState(digits="3"), "d", ctx)
+    assert result.next == OperatorState(op="delete", count=3)
+
+
+def test_count_then_motion_executes_with_count():
+    ctx = _FakeCtx(text="abcdef", cursor=Cursor(0, 0))
+    result = transition(CountState(digits="3"), "l", ctx.as_transition_context())
+    assert result.next == IdleState()
+    assert result.execute is not None
+    result.execute()
+    assert ctx.cursor.col == 3
+
+
+# ---- Operator state -------------------------------------------------------
+
+
+def test_operator_self_repeat_is_line_op():
+    """``dd`` enters line-wise delete."""
+
+    ctx = _FakeCtx(text="line one\nline two", cursor=Cursor(0, 0))
+    result = transition(
+        OperatorState(op="delete", count=1), "d", ctx.as_transition_context()
+    )
+    assert result.next == IdleState()
+    assert result.execute is not None
+    result.execute()
+    assert ctx.text == "line two"
+    assert ctx.register_linewise is True
+
+
+def test_operator_count_after_d_enters_operator_count():
+    ctx = _FakeCtx().as_transition_context()
+    result = transition(OperatorState(op="delete", count=1), "2", ctx)
+    assert result.next == OperatorCountState(op="delete", count=1, digits="2")
+
+
+def test_operator_text_obj_scope():
+    ctx = _FakeCtx().as_transition_context()
+    result = transition(OperatorState(op="delete", count=1), "i", ctx)
+    assert result.next == OperatorTextObjState(
+        op="delete", count=1, scope="inner"
+    )
+
+
+def test_operator_find_state():
+    ctx = _FakeCtx().as_transition_context()
+    result = transition(OperatorState(op="delete", count=1), "f", ctx)
+    assert result.next == OperatorFindState(op="delete", count=1, find="f")
+
+
+def test_operator_motion_executes_operator_motion():
+    ctx = _FakeCtx(text="hello world", cursor=Cursor(0, 0))
+    result = transition(
+        OperatorState(op="delete", count=1), "w", ctx.as_transition_context()
+    )
+    assert result.next == IdleState()
+    assert result.execute is not None
+    result.execute()
+    assert ctx.text == "world"
+    assert ctx.register_content == "hello "
+    # Recorded change supports dot-repeat
+    assert any(
+        isinstance(c, OperatorChange) and c.motion == "w" for c in ctx.changes_recorded
+    )
+
+
+# ---- OperatorCount state --------------------------------------------------
+
+
+def test_operator_count_multiplies_counts():
+    """3d2w → count=6 (matches TS transitions.ts:328 effectiveCount)."""
+
+    ctx = _FakeCtx().as_transition_context()
+    # We arrived at OperatorCountState(op='delete', count=3, digits='2');
+    # next key 'w' executes with effective count 6.
+    state = OperatorCountState(op="delete", count=3, digits="2")
+    result = transition(state, "w", ctx)
+    assert result.next == IdleState()
+    # Verify by inspecting what would be recorded — execute and check
+    fake_ctx = _FakeCtx(text="a b c d e f g", cursor=Cursor(0, 0))
+    result = transition(state, "w", fake_ctx.as_transition_context())
+    result.execute()  # type: ignore[misc]
+    recorded = fake_ctx.changes_recorded[-1]
+    assert isinstance(recorded, OperatorChange)
+    assert recorded.count == 6
+
+
+def test_operator_count_accumulates_digits():
+    ctx = _FakeCtx().as_transition_context()
+    result = transition(
+        OperatorCountState(op="delete", count=3, digits="2"), "5", ctx
+    )
+    assert result.next == OperatorCountState(op="delete", count=3, digits="25")
+
+
+def test_operator_count_multiplication_saturates():
+    """``9999d9999w`` saturates the effective count at MAX_VIM_COUNT."""
+
+    ctx = _FakeCtx(text="a b c d e", cursor=Cursor(0, 0))
+    state = OperatorCountState(op="delete", count=9999, digits="9999")
+    result = transition(state, "w", ctx.as_transition_context())
+    assert result.execute is not None
+    result.execute()
+    # 9999 * 9999 = 99,980,001 → saturates to MAX_VIM_COUNT.
+    recorded = ctx.changes_recorded[-1]
+    assert recorded.count == MAX_VIM_COUNT
+
+
+# ---- Find / OperatorFind / Replace states ---------------------------------
+
+
+def test_find_state_executes_motion():
+    ctx = _FakeCtx(text="hello world", cursor=Cursor(0, 0))
+    result = transition(
+        FindState(find="f", count=1), "o", ctx.as_transition_context()
+    )
+    assert result.next == IdleState()
+    result.execute()  # type: ignore[misc]
+    assert ctx.cursor == Cursor(0, 4)
+    assert ctx.last_find == ("f", "o")
+
+
+def test_operator_find_executes_delete_through_char():
+    ctx = _FakeCtx(text="change me\"end", cursor=Cursor(0, 0))
+    result = transition(
+        OperatorFindState(op="change", count=1, find="f"),
+        '"',
+        ctx.as_transition_context(),
+    )
+    assert result.next == IdleState()
+    result.execute()  # type: ignore[misc]
+    # 'cf"' deletes from cursor through the quote (inclusive).
+    assert ctx.text == "end"
+
+
+def test_replace_state_replaces_char():
+    ctx = _FakeCtx(text="hello", cursor=Cursor(0, 1))
+    result = transition(
+        ReplaceState(count=1), "X", ctx.as_transition_context()
+    )
+    assert result.next == IdleState()
+    result.execute()  # type: ignore[misc]
+    assert ctx.text == "hXllo"
+
+
+# ---- G state --------------------------------------------------------------
+
+
+def test_g_gg_goes_to_buffer_start():
+    ctx = _FakeCtx(text="line one\nline two\nline three", cursor=Cursor(2, 5))
+    result = transition(GState(count=1), "g", ctx.as_transition_context())
+    assert result.next == IdleState()
+    result.execute()  # type: ignore[misc]
+    assert ctx.cursor == Cursor(0, 0)
+
+
+def test_operator_g_dgg_deletes_to_top():
+    ctx = _FakeCtx(text="line one\nline two\nline three", cursor=Cursor(2, 0))
+    result = transition(
+        OperatorGState(op="delete", count=1), "g", ctx.as_transition_context()
+    )
+    assert result.next == IdleState()
+    result.execute()  # type: ignore[misc]
+    # Deletes lines 0..2 inclusive — everything.
+    assert ctx.text == ""
+
+
+def test_operator_g_dgg_sets_linewise_register():
+    """``dgg`` records the register as linewise."""
+
+    ctx = _FakeCtx(text="line one\nline two", cursor=Cursor(1, 0))
+    result = transition(
+        OperatorGState(op="delete", count=1), "g", ctx.as_transition_context()
+    )
+    result.execute()  # type: ignore[misc]
+    assert ctx.register_linewise is True
+
+
+# ---- Indent state ---------------------------------------------------------
+
+
+def test_indent_state_double_arrow_indents():
+    ctx = _FakeCtx(text="hello", cursor=Cursor(0, 0))
+    result = transition(
+        IndentState(dir=">", count=1), ">", ctx.as_transition_context()
+    )
+    assert result.next == IdleState()
+    result.execute()  # type: ignore[misc]
+    assert ctx.text == "  hello"
+
+
+# ---- Purity invariant -----------------------------------------------------
+
+
+def test_transition_is_pure():
+    """Calling transition twice with the same args yields the same TransitionResult.
+
+    This is the property-test purity check from G1.
+    """
+
+    # Use a state that's not derived from ctx-dependent execution.
+    state = IdleState()
+    key = "d"
+    ctx1 = _FakeCtx().as_transition_context()
+    ctx2 = _FakeCtx().as_transition_context()
+    r1 = transition(state, key, ctx1)
+    r2 = transition(state, key, ctx2)
+    assert r1.next == r2.next
+
+
+def test_transition_does_not_mutate_state():
+    """``transition()`` does not mutate the input state (it's frozen anyway)."""
+
+    state = OperatorState(op="delete", count=1)
+    ctx = _FakeCtx().as_transition_context()
+    _result = transition(state, "w", ctx)
+    # The frozen dataclass refuses mutation, so this is a hard guarantee.
+    assert state == OperatorState(op="delete", count=1)
+
+
+# ---- Frozen dataclass invariant -------------------------------------------
+
+
+def test_all_states_are_frozen():
+    import dataclasses
+
+    import src.tui.vim_state as vs
+
+    for state_cls in [
+        vs.IdleState,
+        vs.CountState,
+        vs.OperatorState,
+        vs.OperatorCountState,
+        vs.OperatorFindState,
+        vs.OperatorTextObjState,
+        vs.FindState,
+        vs.GState,
+        vs.OperatorGState,
+        vs.ReplaceState,
+        vs.IndentState,
+    ]:
+        assert dataclasses.is_dataclass(state_cls)
+        # Frozen check: attempting to mutate raises FrozenInstanceError.
+        params = state_cls.__dataclass_params__  # type: ignore[attr-defined]
+        assert params.frozen is True, f"{state_cls.__name__} not frozen"


### PR DESCRIPTION
## Summary

Closes the ch14-distinct vim gaps that ch13's plan didn't cover:

- **C14-2** — Ports the 11-variant discriminated `CommandState` union + pure `transition(state, key, ctx) → TransitionResult` from TS `vim/types.ts` + `vim/transitions.ts`. Effects are returned as closures over `TransitionContext` primitives, never executed inside `transition()` itself. Exhaustiveness via `match`/`case` + `assert_never`.
- **C14-1** — Adds `PersistentState` (`last_change`, `last_find`, `register`, `register_is_linewise`) + 10-variant `RecordedChange` union + buffer-agnostic `replay()` that routes through wave-1 `VimBuffer` / `apply_operator` / `find_text_object`. Powers dot-repeat (`.`), find-repeat (`;`/`,`), and linewise paste classification.
- **C14-8** — Adds `f` / `F` / `t` / `T` find motions via new `vim_find.find_char`, wired through `FindState` / `OperatorFindState` variants. Operator-find composition (`cf\"`, `dF\"`, `dT<h>`) shares a single endpoint calculation per TS `getOperatorRangeForFind`.

### Design

- `vim_state.py` is the state machine; `vim_persistent.py` is the memory layer.
- Existing `vim.py` single-line handler is **unchanged** per OD5 hybrid handle for backward compat (existing `i/a/h/l/x/dd/yy` paths preserved).
- **D10 single-line ↔ multi-line bridge**: executors construct `VimBuffer(ctx.get_text())`, apply the operator, write back via `ctx.set_text/set_cursor` — gives the wave-1 modules their first production consumer (incidentally closes part of C14-11).
- `MAX_VIM_COUNT = 10000` clamp on `count` / `operatorCount` (matches TS `vim/types.ts:182`); `3d2w` records `count=6` (multiplied) so dot-repeat does the right thing.
- `last_find` updates on attempt for live `f/F/t/T` (vim semantic); `;` / `,` consult-only via `update_last_find=False`.

### Out of Scope

- No port of `parse-keypress.ts` / `termio/tokenize.ts` — Textual handles tokenizing and multi-protocol decoding.
- C14-4..C14-7, C14-10..C14-11 are covered by `feat/ch13/integration` (pending merge); this PR is additive and does not duplicate.
- C14-3 (defensive `is_pasted` chord gate), C14-9 (leading-count in operator parser), C14-13 (stdin-gap mode-reassert) deferred to Phase 4 follow-ups.

### Critic Review

All three artifacts (gap analysis, refactoring plan, implementation) passed multi-round Critic review with verdict **APPROVE**. Three implementation iterations addressed: F/T operator-find off-by-one, self-repeat discriminator, `last_find`-on-attempt vs repeat semantics, `e`/`E` cursor landing (one-past → on-last-char), linewise classification consistency.

## Test plan

- [x] 79 new pytest cases pass (`tests/tui/test_vim_transitions.py`, `test_vim_persistent.py`, `test_vim_find.py`)
- [x] 473 broader TUI tests pass, 2 skipped, no regressions
- [x] All 11 `CommandState` variants exercised
- [x] All 10 `RecordedChange` variants exercised via `replay()`
- [x] Dot-repeat after `dw`, `cw`, `r!`, `x`, `~`, `>>`, `dd` verified
- [x] Find-repeat (`;` forward, `,` reverse) verified
- [x] Linewise vs characterwise register flag (`dd` vs `dw`) verified
- [x] `MAX_VIM_COUNT` saturation under `9999d9999w` verified
- [x] F/T operator-find inclusive range verified at multiple cursor positions
- [ ] Manual smoke in Kitty/iTerm via `/tui` — single-line vim mode still works for non-dot/find users (existing `vim.py` paths preserved per OD5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)