### PR TITLE
feat(ch05/B): wire PTL recovery + blocking-limit guards into query loop

### DIFF
--- a/src/query/engine.py
+++ b/src/query/engine.py
@@ -28,6 +28,7 @@ from ..context_system.prompt_assembly import (
 
 from .query import QueryParams, StreamEvent, query
 from ..services.compact.pipeline import PipelineConfig
+from ..services.compact.autocompact import AutoCompactTracking
 
 
 @dataclass
@@ -61,6 +62,12 @@ class QueryEngine:
         self._abort_controller = config.abort_controller or create_abort_controller()
         self._total_usage: dict[str, int] = {"input_tokens": 0, "output_tokens": 0}
         self._session_id: str = uuid4().hex
+        # Ch5/B.5 prereq — the autocompact circuit-breaker counter must
+        # survive across submit_message calls so 3 consecutive failures
+        # actually trip the breaker. A fresh PipelineConfig per submit
+        # would reset the counter every prompt. Hold the SAME tracking
+        # instance on the engine and reuse it.
+        self._auto_compact_tracking: AutoCompactTracking = AutoCompactTracking()
 
     @property
     def mutable_messages(self) -> list[Message]:
@@ -211,6 +218,11 @@ class QueryEngine:
             provider=self._config.provider,
             model=getattr(self._config.provider, 'model', '') or '',
             read_file_state=read_file_state or None,
+            # Ch5/B.5 — thread the session-scoped tracking instance so
+            # the autocompact circuit-breaker can count consecutive
+            # failures across user prompts. ``auto_compact_if_needed``
+            # mutates ``tracking.consecutive_failures`` in place.
+            autocompact_tracking=self._auto_compact_tracking,
         )
 
         params = QueryParams(

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -184,12 +184,58 @@ def _yield_missing_tool_result_blocks(
     return results
 
 
+def _get_context_window(provider: BaseProvider) -> int:
+    """Ch5/B.4 — return the model's context-window size in tokens.
+
+    Defaults to 200_000 (the Claude family default) when the provider
+    doesn't expose a real integer ``context_window`` attribute.
+
+    The ``isinstance(_, int)`` guard handles MagicMock test fixtures:
+    a MagicMock returns another mock for unset attributes, so a naive
+    ``getattr(..., None) or default`` would short-circuit past the
+    default. Be explicit about the type so the loop is robust to test
+    doubles.
+    """
+    cw = getattr(provider, "context_window", None)
+    if isinstance(cw, int) and cw > 0:
+        return cw
+    return 200_000
+
+
 def _is_withheld_max_output_tokens(msg: Message | None) -> bool:
     if msg is None:
         return False
     if not isinstance(msg, AssistantMessage):
         return False
     return getattr(msg, "_api_error", None) == "max_output_tokens"
+
+
+def _is_withheld_prompt_too_long(msg: Message | None) -> bool:
+    """Ch5/B.1 — mirrors TS ``isWithheldPromptTooLong`` at query.ts:877.
+
+    Returns True for an assistant message that carries an
+    ``_api_error == "prompt_too_long"`` tag. The query loop checks this
+    after streaming to suppress the message from the yield stream until
+    PTL recovery (reactive_compact) has been attempted (B.2).
+    """
+    if msg is None:
+        return False
+    if not isinstance(msg, AssistantMessage):
+        return False
+    return getattr(msg, "_api_error", None) == "prompt_too_long"
+
+
+def _is_withheld_media_size(msg: Message | None) -> bool:
+    """Ch5/B.1 — mirrors TS ``isWithheldMediaSizeError`` at query.ts:892.
+
+    Returns True for an assistant message that carries an
+    ``_api_error == "media_size"`` tag.
+    """
+    if msg is None:
+        return False
+    if not isinstance(msg, AssistantMessage):
+        return False
+    return getattr(msg, "_api_error", None) == "media_size"
 
 
 async def _call_model_sync(
@@ -323,6 +369,19 @@ async def _call_model_sync(
                 error="max_output_tokens",
             )
             err_msg._api_error = "max_output_tokens"  # type: ignore[attr-defined]
+            return [err_msg], []
+
+        # Ch5/B.1 — tag media-size errors so the loop can withhold them
+        # and (in B.2) route through reactive-compact recovery. Mirrors
+        # TS `isWithheldMediaSizeError` at query.ts:892. `is_media_size_error`
+        # expects a str (substring match), so pass error_str explicitly.
+        from ..services.api.errors import is_media_size_error
+        if is_media_size_error(error_str):
+            err_msg = _create_assistant_api_error_message(
+                f"Media too large: {error_str}",
+                error="media_size",
+            )
+            err_msg._api_error = "media_size"  # type: ignore[attr-defined]
             return [err_msg], []
 
         raise
@@ -641,6 +700,7 @@ async def query(
 
         # --- Phase 0: Compression Pipeline ---
         # Mirrors TS query loop Phase 0: toolResultBudget → snip → microcompact → collapse → autocompact
+        snip_tokens_freed = 0
         if params.pipeline_config is not None:
             try:
                 # Estimate input tokens so layer 5 (autocompact) can decide
@@ -654,6 +714,7 @@ async def query(
                 )
                 if pipeline_result.tokens_saved > 0:
                     messages = pipeline_result.messages
+                    snip_tokens_freed = pipeline_result.tokens_saved
                     if _diag:
                         logger.warning(
                             "[DIAG] Compression pipeline saved %d tokens (layers: %s)",
@@ -662,6 +723,99 @@ async def query(
                         )
             except Exception:
                 logger.warning("Compression pipeline failed, continuing with original messages", exc_info=True)
+
+        # Ch5/B.4 + B.5 — pre-emption guards before the API call.
+        # Two distinct guards:
+        #   B.4: hard blocking limit (auto-compact off OR no other
+        #        recovery available) — saves the 500 the API would
+        #        return anyway.
+        #   B.5: autocompact circuit-breaker tripped (3 consecutive
+        #        failures) AND we're still over the autocompact
+        #        threshold — gives the user an actionable message
+        #        instead of an opaque 500.
+        # Skip when this iteration is a recovery retry (the messages
+        # were already validated under the limit), or when this is a
+        # compact/session_memory forked query (those need to run to
+        # REDUCE the token count, blocking would deadlock).
+        from ..services.compact.autocompact import (
+            MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES,
+            calculate_token_warning_state,
+            is_auto_compact_enabled,
+        )
+
+        skip_blocking_guards = (
+            params.query_source in ("compact", "session_memory")
+            or (
+                state.transition is not None
+                and state.transition.reason
+                in ("collapse_drain_retry", "reactive_compact_retry")
+            )
+        )
+
+        if not skip_blocking_guards:
+            context_window = _get_context_window(params.provider)
+            # NB: ``messages`` here is already the post-pipeline list (we
+            # reassigned ``messages = pipeline_result.messages`` above when
+            # the pipeline freed tokens). So ``rough_token_count_estimation``
+            # already reflects all compression-layer savings; subtracting
+            # ``snip_tokens_freed`` again would double-count. The variable
+            # is retained for B.5 logging / future TS-style snip-only
+            # measurement, but the guard math uses the post-pipeline count
+            # directly.
+            token_usage = rough_token_count_estimation_for_messages(messages)
+            warning = calculate_token_warning_state(token_usage, context_window)
+
+            # B.5 (checked first — gives the more actionable message
+            # when the breaker has tripped). Mirrors TS query.ts:705-725.
+            tracking = state.auto_compact_tracking or (
+                params.pipeline_config.autocompact_tracking
+                if params.pipeline_config is not None
+                else None
+            )
+            consec = (
+                getattr(tracking, "consecutive_failures", 0)
+                if tracking is not None
+                else 0
+            )
+            if (
+                consec >= MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES
+                and is_auto_compact_enabled()
+                and warning["is_above_auto_compact_threshold"]
+            ):
+                yield _create_assistant_api_error_message(
+                    content=(
+                        "The conversation has exceeded the context limit "
+                        "and automatic compaction has failed. Press esc twice "
+                        "to go up a few messages and try again, or start a "
+                        "new session with /new."
+                    ),
+                    error="invalid_request",
+                )
+                set_terminal(
+                    holder, natural_termination, Terminal(reason="blocking_limit"),
+                )
+                return
+
+            # B.4 (hard blocking limit). Mirrors TS query.ts:683-696.
+            # Only fires when reactive-compact recovery is NOT available
+            # — otherwise we let the API 413 and the B.2 recovery path
+            # handle it. This matches TS: the guard exists to short-
+            # circuit only when no recovery would catch the 500 anyway.
+            elif (
+                warning["is_at_blocking_limit"]
+                and not (
+                    config.reactive_compact_enabled
+                    and is_auto_compact_enabled()
+                )
+            ):
+                yield _create_assistant_api_error_message(
+                    content=PROMPT_TOO_LONG_ERROR_MESSAGE,
+                    error="invalid_request",
+                )
+                set_terminal(
+                    holder, natural_termination, Terminal(reason="blocking_limit"),
+                )
+                return
 
         assistant_messages: list[AssistantMessage] = []
         tool_results: list[UserMessage] = []
@@ -681,9 +835,17 @@ async def query(
             needs_follow_up = len(tool_use_blocks) > 0
 
             for msg in assistant_messages:
-                withheld = False
-                if _is_withheld_max_output_tokens(msg):
-                    withheld = True
+                # Ch5/B.1 — three-source withholding pattern.
+                # Mirrors TS query.ts:866-903. Recoverable errors are
+                # suppressed from the yield stream so SDK consumers
+                # (Cowork, the desktop app) don't disconnect mid-recovery.
+                # If recovery exhausts, the message is surfaced later by
+                # the dispatch code in the no-follow-up branch (B.2).
+                withheld = (
+                    _is_withheld_max_output_tokens(msg)
+                    or _is_withheld_prompt_too_long(msg)
+                    or _is_withheld_media_size(msg)
+                )
                 if not withheld:
                     yield msg
 
@@ -753,6 +915,133 @@ async def query(
                     continue
 
                 yield last_message  # type: ignore[arg-type]
+
+            # Ch5/B.2 — PTL / media-size recovery via reactive_compact.
+            # Mirrors TS query.ts:1195-1260. When the streaming model
+            # returned a withheld PTL or media-size error AND we have
+            # not yet attempted reactive_compact in this loop iteration,
+            # try to compact and retry. The one-shot guard
+            # (``has_attempted_reactive_compact``) prevents the
+            # death-spiral failure mode documented in chapter §"Death
+            # Spiral Guard": without it, a compact-then-still-413 loop
+            # burns thousands of API calls.
+            is_withheld_ptl = _is_withheld_prompt_too_long(last_message)
+            is_withheld_media = _is_withheld_media_size(last_message)
+
+            # Phase B post-critic: if the guard ALREADY tripped (we tried
+            # reactive_compact this turn and the post-compact retry STILL
+            # raised PTL/media), surface the withheld error and emit the
+            # appropriate Terminal — do NOT fall through to the
+            # "API error → Terminal(completed)" path. Mirrors TS at
+            # query.ts:1244-1252.
+            if (
+                (is_withheld_ptl or is_withheld_media)
+                and has_attempted_reactive_compact
+            ):
+                if last_message is not None:
+                    yield last_message
+                set_terminal(
+                    holder,
+                    natural_termination,
+                    Terminal(
+                        reason="image_error"
+                        if is_withheld_media
+                        else "prompt_too_long"
+                    ),
+                )
+                return
+
+            if (
+                (is_withheld_ptl or is_withheld_media)
+                and not has_attempted_reactive_compact
+                and config.reactive_compact_enabled
+            ):
+                from ..services.compact.reactive_compact import (
+                    ReactiveCompactResult,
+                    reactive_compact,
+                )
+                from ..services.api.errors import PromptTooLongError
+
+                # Synthesize an exception for reactive_compact's
+                # is_prompt_too_long_error check. The withheld
+                # message holds the original error string; we don't
+                # need to round-trip it precisely because
+                # reactive_compact only uses the exception for
+                # classification.
+                synthetic_err = PromptTooLongError(
+                    "withheld during streaming, recovering"
+                )
+                result: ReactiveCompactResult = await reactive_compact(
+                    messages=messages,
+                    error=synthetic_err,
+                    provider=params.provider,
+                    model=config.model,
+                )
+                if result.compacted:
+                    # ReactiveCompactResult.messages is list[Message]
+                    # (verified 2026-05-12 against reactive_compact.py
+                    # :33-39, :205-210, :230-236; the field
+                    # concatenates CompactionResult.summary_messages
+                    # which is list[UserMessage], with
+                    # messages_to_keep which is list[Message]).
+                    post_compact_messages: list[Message] = result.messages
+                    for msg in post_compact_messages:
+                        yield msg
+                    # Critic finding (Phase B post-review): a successful
+                    # reactive_compact MUST reset the engine's autocompact
+                    # circuit-breaker counter. Otherwise the next iteration's
+                    # B.5 guard re-reads the engine's persistent
+                    # ``consecutive_failures`` (still ≥3 if the breaker
+                    # tripped earlier in the session) and would trip
+                    # ``Terminal(blocking_limit)`` immediately even though
+                    # we just successfully compacted. Mirrors TS query.ts
+                    # auto-compact success path (resets failures to 0).
+                    if (
+                        params.pipeline_config is not None
+                        and params.pipeline_config.autocompact_tracking is not None
+                    ):
+                        params.pipeline_config.autocompact_tracking.consecutive_failures = 0
+                    state = QueryState(
+                        messages=post_compact_messages,
+                        tool_use_context=tool_use_context,
+                        # Carry the engine's tracking through the retry so
+                        # next iteration's B.5 reads the post-reset count.
+                        auto_compact_tracking=(
+                            params.pipeline_config.autocompact_tracking
+                            if params.pipeline_config is not None
+                            else None
+                        ),
+                        max_output_tokens_recovery_count=max_output_tokens_recovery_count,
+                        has_attempted_reactive_compact=True,  # one-shot
+                        max_output_tokens_override=None,
+                        stop_hook_active=state.stop_hook_active,
+                        turn_count=turn_count,
+                        pending_tool_use_summary=state.pending_tool_use_summary,
+                        continuation_nudge_count=state.continuation_nudge_count,
+                        transition=Transition(reason="reactive_compact_retry"),
+                    )
+                    continue
+
+                # No recovery — surface the (until-now withheld) error
+                # and exit with the appropriate Terminal reason.
+                # DEATH-SPIRAL GUARD: do NOT fall through to a future
+                # stop-hooks call here. Mirrors TS query.ts:1244-1252
+                # ("error -> hook blocking -> retry -> error -> ...
+                # the hook injects more tokens each cycle"). When C.1
+                # lands the stop-hooks dispatch, this early return
+                # must remain.
+                if last_message is not None:
+                    yield last_message
+                set_terminal(
+                    holder,
+                    natural_termination,
+                    Terminal(
+                        reason="image_error"
+                        if is_withheld_media
+                        else "prompt_too_long"
+                    ),
+                )
+                return
 
             if last_message and getattr(last_message, "isApiErrorMessage", False):
                 set_terminal(holder, natural_termination, Terminal(reason="completed"))

--- a/tests/test_query_error_recovery.py
+++ b/tests/test_query_error_recovery.py
@@ -170,5 +170,415 @@ class TestRecoveryExhaustion(unittest.TestCase):
         self.assertLessEqual(provider.chat.call_count, 6)
 
 
+class TestPhaseBPromptTooLongRecovery(unittest.TestCase):
+    """Ch5/B.1+B.2 — withholding + reactive_compact recovery for PTL."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.temp_dir.name)
+        self.registry = build_default_registry()
+        self.context = ToolContext(workspace_root=self.workspace)
+        self.abort = AbortController()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _build_params(self, provider):
+        from src.query.transitions import TerminalHolder
+        params = QueryParams(
+            messages=[UserMessage(content="Long task")],
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=10,
+        )
+        return params, TerminalHolder()
+
+    def test_ptl_message_withheld_from_stream(self):
+        """B.1: PTL error tagged in _call_model_sync should NOT yield
+        through to the consumer; recovery (B.2) replaces it."""
+        from unittest.mock import MagicMock
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+
+        # First call: simulate PTL error from the API
+        provider.chat.side_effect = [
+            Exception("Prompt is too long: 250000 tokens > 200000"),
+            ChatResponse(
+                content="Recovered output",
+                model="test",
+                usage={"input_tokens": 100, "output_tokens": 50},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+        ]
+
+        # Mock reactive_compact to return success (so the recovery path
+        # fires and the loop continues to the second model call).
+        from src.services.compact.reactive_compact import ReactiveCompactResult
+
+        async def fake_reactive_compact(messages, error, provider, model, **kw):
+            return ReactiveCompactResult(
+                compacted=True,
+                messages=[UserMessage(content="[summary]")],
+                tokens_before=250_000,
+                tokens_after=10_000,
+            )
+
+        params, holder = self._build_params(provider)
+        collected = []
+
+        async def run():
+            from src.query.query import query
+            with unittest.mock.patch(
+                "src.services.compact.reactive_compact.reactive_compact",
+                side_effect=fake_reactive_compact,
+            ):
+                async for msg in query(params, terminal_holder=holder):
+                    collected.append(msg)
+
+        _run(run())
+
+        # No assistant message in the stream should carry the PTL error tag —
+        # the withheld message was suppressed and replaced by the recovery
+        # output.
+        ptl_messages = [
+            m for m in collected
+            if isinstance(m, AssistantMessage)
+            and getattr(m, "_api_error", None) == "prompt_too_long"
+        ]
+        self.assertEqual(
+            ptl_messages, [],
+            "PTL message must be withheld from stream during recovery",
+        )
+
+    def test_ptl_triggers_reactive_compact_and_terminal_completed(self):
+        """B.2: when reactive_compact succeeds, the loop continues and
+        terminates as `completed` (not `prompt_too_long`)."""
+        from unittest.mock import MagicMock
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = [
+            Exception("Prompt is too long"),
+            ChatResponse(
+                content="Done.",
+                model="test",
+                usage={"input_tokens": 100, "output_tokens": 20},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+        ]
+
+        from src.services.compact.reactive_compact import ReactiveCompactResult
+
+        async def fake_reactive_compact(messages, error, provider, model, **kw):
+            return ReactiveCompactResult(
+                compacted=True,
+                messages=[UserMessage(content="[summary]")],
+                tokens_before=250_000,
+                tokens_after=5_000,
+            )
+
+        params, holder = self._build_params(provider)
+
+        async def run():
+            from src.query.query import query
+            with unittest.mock.patch(
+                "src.services.compact.reactive_compact.reactive_compact",
+                side_effect=fake_reactive_compact,
+            ):
+                async for _ in query(params, terminal_holder=holder):
+                    pass
+
+        _run(run())
+
+        self.assertIsNotNone(holder.value, "Terminal must be set")
+        self.assertEqual(holder.value.reason, "completed")
+        self.assertEqual(provider.chat.call_count, 2)
+
+    def test_ptl_compact_failure_surfaces_terminal(self):
+        """B.2: when reactive_compact returns compacted=False, the loop
+        surfaces the PTL message and exits with terminal `prompt_too_long`.
+        (Single-iteration exit; covers the no-recovery-available path.)"""
+        from unittest.mock import MagicMock
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = lambda *a, **kw: (_ for _ in ()).throw(
+            Exception("Prompt is too long")
+        )
+
+        from src.services.compact.reactive_compact import ReactiveCompactResult
+
+        compact_calls = []
+
+        async def fake_reactive_compact(messages, error, provider, model, **kw):
+            compact_calls.append(1)
+            return ReactiveCompactResult(
+                compacted=False,
+                messages=list(messages),
+                tokens_before=250_000,
+                error="Failed to reduce context",
+            )
+
+        params, holder = self._build_params(provider)
+        collected = []
+
+        async def run():
+            from src.query.query import query
+            with unittest.mock.patch(
+                "src.services.compact.reactive_compact.reactive_compact",
+                side_effect=fake_reactive_compact,
+            ):
+                async for msg in query(params, terminal_holder=holder):
+                    collected.append(msg)
+
+        _run(run())
+
+        self.assertIsNotNone(holder.value)
+        self.assertEqual(holder.value.reason, "prompt_too_long")
+        self.assertEqual(len(compact_calls), 1)
+        # Last assistant message must be the surfaced PTL error.
+        ptl = [m for m in collected if isinstance(m, AssistantMessage)
+               and getattr(m, "_api_error", None) == "prompt_too_long"]
+        self.assertEqual(len(ptl), 1)
+
+    def test_ptl_one_shot_guard_post_compact_does_not_retry(self):
+        """B.2 ONE-SHOT GUARD (post-critic-strengthening): reactive_compact
+        succeeds first; the post-compact retry then ALSO raises PTL; the
+        guard (``has_attempted_reactive_compact=True`` carried in
+        ``QueryState``) prevents a second reactive_compact attempt; the
+        terminal is `prompt_too_long` and the second PTL message IS
+        surfaced (first one was withheld during the recovery attempt)."""
+        from unittest.mock import MagicMock
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        # Both calls raise PTL — first triggers reactive_compact (which
+        # succeeds), second still raises after compaction.
+        provider.chat.side_effect = lambda *a, **kw: (_ for _ in ()).throw(
+            Exception("Prompt is too long")
+        )
+
+        from src.services.compact.reactive_compact import ReactiveCompactResult
+
+        compact_calls = []
+
+        async def fake_reactive_compact(messages, error, provider, model, **kw):
+            compact_calls.append(1)
+            return ReactiveCompactResult(
+                compacted=True,
+                messages=[UserMessage(content="[summary]")],
+                tokens_before=250_000,
+                tokens_after=10_000,
+            )
+
+        params, holder = self._build_params(provider)
+
+        async def run():
+            from src.query.query import query
+            with unittest.mock.patch(
+                "src.services.compact.reactive_compact.reactive_compact",
+                side_effect=fake_reactive_compact,
+            ):
+                async for _ in query(params, terminal_holder=holder):
+                    pass
+
+        _run(run())
+
+        self.assertIsNotNone(holder.value)
+        self.assertEqual(holder.value.reason, "prompt_too_long")
+        # One-shot guard: reactive_compact called EXACTLY ONCE even though
+        # the second model call ALSO raised PTL. Without the guard, the
+        # loop would attempt reactive_compact a second time and burn API
+        # budget in the death-spiral pattern documented in chapter §"Death
+        # Spiral Guard" point 1.
+        self.assertEqual(
+            len(compact_calls), 1,
+            "has_attempted_reactive_compact one-shot guard must prevent "
+            "a second reactive_compact attempt within the same loop turn",
+        )
+        # Two model calls: first raised PTL (triggered recovery), second
+        # raised PTL (post-recovery, surfaced as Terminal).
+        self.assertEqual(provider.chat.call_count, 2)
+
+    def test_media_size_message_withheld_and_recovers(self):
+        """B.1: media-size errors are tagged and withheld;
+        B.2: recovery via reactive_compact succeeds, terminal `completed`."""
+        from unittest.mock import MagicMock
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = [
+            Exception("image exceeds the maximum allowed dimensions"),
+            ChatResponse(
+                content="Done.",
+                model="test",
+                usage={"input_tokens": 100, "output_tokens": 20},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+        ]
+
+        from src.services.compact.reactive_compact import ReactiveCompactResult
+
+        async def fake_reactive_compact(messages, error, provider, model, **kw):
+            return ReactiveCompactResult(
+                compacted=True,
+                messages=[UserMessage(content="[summary]")],
+                tokens_before=10_000,
+                tokens_after=5_000,
+            )
+
+        params, holder = self._build_params(provider)
+        collected = []
+
+        async def run():
+            from src.query.query import query
+            with unittest.mock.patch(
+                "src.services.compact.reactive_compact.reactive_compact",
+                side_effect=fake_reactive_compact,
+            ):
+                async for msg in query(params, terminal_holder=holder):
+                    collected.append(msg)
+
+        _run(run())
+
+        media_msgs = [
+            m for m in collected
+            if isinstance(m, AssistantMessage)
+            and getattr(m, "_api_error", None) == "media_size"
+        ]
+        self.assertEqual(media_msgs, [], "media-size message must be withheld")
+        self.assertEqual(holder.value.reason, "completed")
+
+
+class TestPhaseBBlockingLimitPreemption(unittest.TestCase):
+    """Ch5/B.4 + B.5 — pre-emption guards before the API call."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.temp_dir.name)
+        self.registry = build_default_registry()
+        self.context = ToolContext(workspace_root=self.workspace)
+        self.abort = AbortController()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_blocking_limit_preemption(self):
+        """B.4: when context is past blocking limit AND no recovery is
+        available (autocompact off), yield blocking_limit terminal
+        without calling the provider."""
+        import os
+        from unittest.mock import MagicMock, patch
+        from src.query.transitions import TerminalHolder
+
+        provider = MagicMock()
+        provider.context_window = 10_000  # tiny window
+
+        # With cw=10_000 the effective window floors at 33_000 (reserved
+        # 20k + AUTOCOMPACT_BUFFER 13k), so blocking_limit ~= 30_000.
+        # "x " * 200_000 yields ~50k estimated tokens, comfortably over.
+        big_text = "x " * 200_000  # ~50k tokens
+        messages = [UserMessage(content=big_text)]
+
+        params = QueryParams(
+            messages=messages,
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=10,
+        )
+        holder = TerminalHolder()
+
+        async def run():
+            from src.query.query import query
+            with patch.dict(os.environ, {"DISABLE_AUTO_COMPACT": "1"}):
+                async for _ in query(params, terminal_holder=holder):
+                    pass
+
+        _run(run())
+
+        self.assertIsNotNone(holder.value)
+        self.assertEqual(holder.value.reason, "blocking_limit")
+        # Provider was never called (this is the whole point of the guard).
+        provider.chat.assert_not_called()
+        provider.chat_stream_response.assert_not_called()
+
+    def test_autocompact_circuit_breaker_returns_blocking_limit(self):
+        """B.5: when autocompact has failed 3 times AND we're still
+        above the threshold, return blocking_limit cleanly (vs.
+        burning another 500)."""
+        import os
+        from unittest.mock import MagicMock, patch
+        from src.query.transitions import TerminalHolder
+        from src.services.compact.autocompact import AutoCompactTracking
+        from src.services.compact.pipeline import PipelineConfig
+
+        provider = MagicMock()
+        provider.context_window = 100_000
+        # If the guard fires, the provider is never called. We add a
+        # canned response just in case the guard misses, so the test
+        # fails loudly with a different message.
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="Should not be reached",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 5},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        big_text = "y " * 200_000  # ~100k tokens, well above autocompact threshold
+        messages = [UserMessage(content=big_text)]
+
+        tracking = AutoCompactTracking(consecutive_failures=3)
+
+        # Pipeline config carries the tripped tracking. The pipeline
+        # itself will short-circuit autocompact (since failures>=3),
+        # so the breaker stays tripped and the B.5 guard fires.
+        pipeline_config = PipelineConfig(
+            provider=provider,
+            model="test",
+            autocompact_tracking=tracking,
+        )
+
+        params = QueryParams(
+            messages=messages,
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=10,
+            pipeline_config=pipeline_config,
+        )
+        holder = TerminalHolder()
+
+        collected = []
+
+        async def run():
+            from src.query.query import query
+            async for msg in query(params, terminal_holder=holder):
+                collected.append(msg)
+
+        _run(run())
+
+        self.assertIsNotNone(holder.value)
+        self.assertEqual(holder.value.reason, "blocking_limit")
+        # Verify the user-visible message mentions automatic compaction.
+        msgs = [m for m in collected if isinstance(m, AssistantMessage)]
+        self.assertTrue(
+            any("automatic compaction" in str(getattr(m, "content", ""))
+                for m in msgs),
+            f"Expected 'automatic compaction' in surfaced message, got {msgs}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Chapter 5 / Phase B of the agent-loop refactor. Closes the highest-severity gap-analysis items: **C1** (PTL has no recovery) and **C5** (blocking-limit pre-emption missing). Follows Phase A (typed Terminal foundation, already on main as `a203f81`).

- **B.1** Withhold `prompt_too_long`, `media_size`, and `max_output_tokens` errors from the yield stream; tag media-size errors in `_call_model_sync`.
- **B.2** Wire `reactive_compact` into the no-tool-use branch for PTL/media-size recovery. One-shot guard via `has_attempted_reactive_compact`; on exhaustion surface the withheld error + `Terminal(prompt_too_long)`/`Terminal(image_error)`. Death-spiral comment cross-references chapter §"Death Spiral Guard" point 1.
- **B.4** Blocking-limit pre-emption guard before the API call (skipped on compact/session_memory query_source and on collapse_drain_retry/reactive_compact_retry transitions).
- **B.5** Autocompact circuit-breaker pre-emption guard (3 consecutive failures + above autocompact threshold → `Terminal(blocking_limit)`). Engine wiring: `QueryEngine._auto_compact_tracking` persists across `submit_message` calls so the breaker counter actually trips in production.

`b419df0`'s minor cleanup (drop the dead `_is_prompt_too_long_message` helper) is intentionally deferred — the helper is unreferenced from Phase A onward, so leaving it for a later cleanup PR is harmless.

## Test plan

- [x] 7 new acceptance tests in `tests/test_query_error_recovery.py`: withheld PTL/media, reactive_compact success path, one-shot guard, blocking-limit pre-emption, autocompact circuit-breaker pre-emption.
- [x] 80 tests pass across `query_loop`, `query_error_recovery`, `query_terminal`, `query_engine`, `parity/query_state_parity`, `compression_pipeline`, `agent_loop`.

Related: chapter-5 gap analysis (`my-docs/ch05-agent-loop-gap-analysis.md`) and refactoring plan (`my-docs/ch05-agent-loop-refactoring-plan.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)