### PR TITLE
feat(ch05/E): model fallback + continuation nudge + tombstones

### DIFF
--- a/src/query/continuation_signals.py
+++ b/src/query/continuation_signals.py
@@ -1,0 +1,89 @@
+"""Continuation-nudge detection — Ch5/E.4.
+
+Ported from TypeScript query.ts:1444-1505. When the model finishes
+without tool calls but signals intent to keep working (e.g., "Let me
+now create the file"), inject a polite nudge to keep working. Capped
+at MAX_CONTINUATION_NUDGES per turn to prevent infinite loops when
+the model keeps matching continuation signals without taking action.
+"""
+from __future__ import annotations
+
+import re
+
+MAX_CONTINUATION_NUDGES = 3
+
+NUDGE_MESSAGE = (
+    "Continue with the task. Use the appropriate tools to proceed."
+)
+
+# Action verbs that distinguish "I'll do X" from "I'll explain X".
+_ACTIONS = (
+    r"do|create|write|edit|update|fix|implement|add|run|check|"
+    r"make|build|set up"
+)
+
+# Always-on patterns (match regardless of message length).
+SIGNALS_ANY_LENGTH = [
+    re.compile(
+        rf"\bso now (i|let me|we) (need to|have to|should|must|will) "
+        rf"({_ACTIONS})\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\bnow i('ll| will) ({_ACTIONS}|go|proceed)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\blet me (go ahead and |now )?({_ACTIONS}|proceed)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\btime to ({_ACTIONS}|get started|begin)\b",
+        re.IGNORECASE,
+    ),
+]
+
+# Short-message-only patterns (apply only when len(text) < 80) to
+# avoid false positives in long explanatory text.
+SIGNALS_SHORT_ONLY = [
+    re.compile(
+        rf"\b(i('ll| will| need to| have to| must) (now )?({_ACTIONS}))\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\bnext,?\s+(i('ll| will)|let me|i need to) ({_ACTIONS})\b",
+        re.IGNORECASE,
+    ),
+]
+
+COMPLETION_MARKERS = re.compile(
+    r"\b(done|finished|completed|complete|summary|that's all|"
+    r"that is all|all set|hope this helps|let me know if)\b",
+    re.IGNORECASE,
+)
+
+SHORT_MESSAGE_THRESHOLD = 80
+
+
+def matches_continuation_signal(text: str) -> bool:
+    """Return True if ``text`` signals intent to continue working AND
+    does NOT contain completion markers.
+
+    The check has three rules:
+      1. Completion markers ("done", "hope this helps", ...) suppress
+         the nudge entirely — the model said it's done, take it at
+         its word.
+      2. "Any length" patterns ("so now I'll create...", "Let me now
+         proceed") match regardless of message length.
+      3. "Short only" patterns ("I'll fix...", "Next, I'll update...")
+         match only in short messages (< 80 chars) to avoid hitting
+         them in long explanatory text.
+    """
+    if COMPLETION_MARKERS.search(text):
+        return False
+    if any(p.search(text) for p in SIGNALS_ANY_LENGTH):
+        return True
+    if len(text) < SHORT_MESSAGE_THRESHOLD:
+        if any(p.search(text) for p in SIGNALS_SHORT_ONLY):
+            return True
+    return False

--- a/src/query/engine.py
+++ b/src/query/engine.py
@@ -9,6 +9,7 @@ from ..types.messages import (
     AssistantMessage,
     Message,
     SystemMessage,
+    TombstoneMessage,
     UserMessage,
 )
 from ..tool_system.build_tool import Tools
@@ -269,6 +270,25 @@ class QueryEngine:
 
         async for message in query(params):
             if isinstance(message, StreamEvent):
+                if on_message:
+                    on_message(message)
+                yield message
+                continue
+
+            # Ch5/E.5 — handle tombstones. A TombstoneMessage signals
+            # that a previous message (carried by ``message.message``)
+            # should be REMOVED from the transcript, not appended. The
+            # query loop emits these on the fallback path so the UI
+            # discards partial assistant messages from the failed
+            # attempt. Mirrors TS at query.ts:794 + UI listener.
+            if isinstance(message, TombstoneMessage):
+                if message.message is not None:
+                    target_uuid = getattr(message.message, "uuid", None)
+                    if target_uuid is not None:
+                        self._mutable_messages = [
+                            m for m in self._mutable_messages
+                            if getattr(m, "uuid", None) != target_uuid
+                        ]
                 if on_message:
                     on_message(message)
                 yield message

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -188,6 +188,24 @@ def _yield_missing_tool_result_blocks(
     return results
 
 
+def _extract_assistant_text(msg: AssistantMessage) -> str:
+    """Ch5/E.4 — concatenate text from an assistant message's content.
+
+    The content may be a plain string or a list of blocks. This helper
+    joins all TextBlock text into a single string for regex matching
+    against continuation signals.
+    """
+    content = msg.content
+    if isinstance(content, str):
+        return content
+    parts: list[str] = []
+    for block in content:
+        text = getattr(block, "text", None)
+        if isinstance(text, str):
+            parts.append(text)
+    return " ".join(parts)
+
+
 def _get_context_window(provider: BaseProvider) -> int:
     """Ch5/B.4 — return the model's context-window size in tokens.
 
@@ -835,17 +853,57 @@ async def query(
         tool_use_blocks: list[ToolUseBlock] = []
         needs_follow_up = False
 
+        # Ch5/E.2 — attempt-with-fallback loop. On FallbackTriggeredError,
+        # swap to params.fallback_provider and retry. Mirrors TS at
+        # query.ts:727-1029. Per critic-revised plan, we swap the
+        # PROVIDER (not a model name kwarg), because the provider
+        # object IS the model in the existing dispatch.
+        current_provider = params.provider
+        attempt_with_fallback = True
+        from ..services.api.errors import FallbackTriggeredError
+        from ..types.messages import TombstoneMessage, create_system_message
+
         try:
-            returned_assistants, returned_tool_blocks = await _call_model_sync(
-                provider=params.provider,
-                messages=messages,
-                system_prompt=params.system_prompt,
-                tools=params.tools,
-                max_output_tokens_override=max_output_tokens_override,
-            )
-            assistant_messages = returned_assistants
-            tool_use_blocks = returned_tool_blocks
-            needs_follow_up = len(tool_use_blocks) > 0
+            while attempt_with_fallback:
+                attempt_with_fallback = False
+                try:
+                    returned_assistants, returned_tool_blocks = await _call_model_sync(
+                        provider=current_provider,
+                        messages=messages,
+                        system_prompt=params.system_prompt,
+                        tools=params.tools,
+                        max_output_tokens_override=max_output_tokens_override,
+                    )
+                    assistant_messages = returned_assistants
+                    tool_use_blocks = returned_tool_blocks
+                    needs_follow_up = len(tool_use_blocks) > 0
+                except FallbackTriggeredError as fb:
+                    if params.fallback_provider is None:
+                        # No fallback configured — re-raise into outer
+                        # exception handler below (Terminal(model_error)).
+                        raise
+                    # Tombstone any partial assistant messages from the
+                    # failed attempt so the UI removes them from the
+                    # transcript. Yield orphaned-tool-result blocks so
+                    # the API protocol invariant (every tool_use has a
+                    # tool_result) holds for the partial state we're
+                    # discarding. Mirrors TS at query.ts:978-1005.
+                    for orphan_msg in _yield_missing_tool_result_blocks(
+                        assistant_messages, "Model fallback triggered",
+                    ):
+                        yield orphan_msg
+                    for partial in assistant_messages:
+                        yield TombstoneMessage(message=partial)
+                    assistant_messages = []
+                    tool_use_blocks = []
+                    # Swap provider and retry.
+                    current_provider = params.fallback_provider
+                    yield create_system_message(
+                        f"Switched to {fb.fallback_model} due to high "
+                        f"demand for {fb.original_model}",
+                        level="warning",
+                    )
+                    attempt_with_fallback = True
 
             for msg in assistant_messages:
                 # Ch5/B.1 — three-source withholding pattern.
@@ -1174,6 +1232,48 @@ async def query(
                 # else: StopDecision — fall through to completion. The
                 # decision.completion_event is logged by callers when
                 # diminishing-returns early-stop fires.
+
+            # Ch5/E.4 — continuation nudge. After the token-budget check
+            # declines to continue (or no budget was set), inspect the
+            # last assistant text. If it signals intent to continue
+            # ("Let me now create the file"), inject a nudge user
+            # message and re-enter the loop. Capped at
+            # MAX_CONTINUATION_NUDGES=3 to prevent infinite nudge loops.
+            # Mirrors TS query.ts:1444-1505.
+            from .continuation_signals import (
+                MAX_CONTINUATION_NUDGES,
+                NUDGE_MESSAGE,
+                matches_continuation_signal,
+            )
+
+            if (
+                assistant_messages
+                and (params.max_turns is None or turn_count < params.max_turns)
+                and state.continuation_nudge_count < MAX_CONTINUATION_NUDGES
+            ):
+                last_text = _extract_assistant_text(
+                    assistant_messages[-1]
+                )
+                if matches_continuation_signal(last_text):
+                    nudge_msg = _create_user_message(
+                        NUDGE_MESSAGE, is_meta=True,
+                    )
+                    state = QueryState(
+                        messages=[*messages, *assistant_messages, nudge_msg],
+                        tool_use_context=tool_use_context,
+                        auto_compact_tracking=state.auto_compact_tracking,
+                        max_output_tokens_recovery_count=0,
+                        has_attempted_reactive_compact=False,
+                        max_output_tokens_override=None,
+                        stop_hook_active=None,
+                        turn_count=turn_count,
+                        pending_tool_use_summary=state.pending_tool_use_summary,
+                        continuation_nudge_count=(
+                            state.continuation_nudge_count + 1
+                        ),
+                        transition=Transition(reason="continuation_nudge"),
+                    )
+                    continue
 
             set_terminal(holder, natural_termination, Terminal(reason="completed"))
             return

--- a/src/types/messages.py
+++ b/src/types/messages.py
@@ -112,6 +112,18 @@ class AttachmentMessage(UserMessage):
     attachments: list[dict[str, Any]] = field(default_factory=list)
 
 
+# Ch5/E.5 — tombstone signal. Emitted by query() on model-fallback retry
+# to tell consumers (QueryEngine, REPL, TUI) to REMOVE the matching
+# message from the transcript (rather than append the tombstone). The
+# fallback path also tombstones partial assistant messages from the
+# failed attempt so the UI's transcript reflects only the successful
+# fallback retry. Mirrors TS at query.ts:794.
+@dataclass
+class TombstoneMessage:
+    type: str = "tombstone"
+    message: Message | None = None
+
+
 MessageLike: TypeAlias = Message | Mapping[str, Any]
 
 TypedMessage: TypeAlias = (

--- a/tests/test_query_fallback_and_nudge.py
+++ b/tests/test_query_fallback_and_nudge.py
@@ -1,0 +1,322 @@
+"""Ch5/E — query() ↔ FallbackTriggeredError + continuation-nudge tests.
+
+Covers:
+  E.2 — FallbackTriggeredError swaps the provider, tombstones partial
+        assistant messages, emits a "Switched to..." system message,
+        and retries on the fallback provider.
+  E.4 — continuation-nudge regex set (in src/query/continuation_signals.py)
+        fires at no-tool-use exit with intent-to-continue text; capped
+        at MAX_CONTINUATION_NUDGES=3.
+  E.5 — TombstoneMessage is handled by QueryEngine.submit_message
+        (matching message removed from _mutable_messages, not appended).
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from src.providers.base import ChatResponse
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.types.messages import AssistantMessage, SystemMessage, TombstoneMessage, UserMessage
+from src.utils.abort_controller import AbortController
+
+from src.query.query import QueryParams, query
+from src.query.transitions import TerminalHolder
+from src.services.api.errors import FallbackTriggeredError
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.temp_dir.name)
+        self.registry = build_default_registry()
+        self.context = ToolContext(workspace_root=self.workspace)
+        self.abort = AbortController()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+
+class TestContinuationSignals(unittest.TestCase):
+    """E.4 — regex matchers in src/query/continuation_signals.py."""
+
+    def test_intent_to_continue_short_message(self):
+        from src.query.continuation_signals import matches_continuation_signal
+        # SIGNALS_SHORT_ONLY pattern: short message with action verb.
+        self.assertTrue(matches_continuation_signal("I'll fix the bug now."))
+        self.assertTrue(matches_continuation_signal("Next, I'll update the file."))
+
+    def test_intent_to_continue_any_length(self):
+        from src.query.continuation_signals import matches_continuation_signal
+        # SIGNALS_ANY_LENGTH pattern.
+        self.assertTrue(matches_continuation_signal(
+            "OK so now I'll create the file. " + ("x " * 100)
+        ))
+        self.assertTrue(matches_continuation_signal(
+            "Let me now proceed with the implementation."
+        ))
+
+    def test_completion_marker_suppresses(self):
+        from src.query.continuation_signals import matches_continuation_signal
+        self.assertFalse(matches_continuation_signal(
+            "Let me now show you the result. Hope this helps!"
+        ))
+        self.assertFalse(matches_continuation_signal("I'm done."))
+        self.assertFalse(matches_continuation_signal(
+            "Now I'll proceed. All set."
+        ))
+
+    def test_long_explanatory_text_does_not_match_short_pattern(self):
+        from src.query.continuation_signals import matches_continuation_signal
+        long_text = (
+            "When considering whether to do this, you'll need to think "
+            "carefully about the implications for downstream consumers "
+            "and whether the additional complexity is justified. "
+            "Note however that the costs are real."
+        )
+        # SIGNALS_SHORT_ONLY would match "you'll need to do" but the
+        # text is > 80 chars, so it's gated off.
+        self.assertFalse(matches_continuation_signal(long_text))
+
+    def test_unrelated_text_does_not_match(self):
+        from src.query.continuation_signals import matches_continuation_signal
+        self.assertFalse(matches_continuation_signal(
+            "The function returns a tuple."
+        ))
+
+
+class TestContinuationNudge(_Base):
+    """E.4 — query() injects nudge when last assistant text signals
+    intent to continue and turn_count < max_turns."""
+
+    def test_nudge_fires_on_continuation_signal(self):
+        """When the model returns intent-to-continue text with no tool
+        calls, the loop injects a nudge and re-enters."""
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = [
+            ChatResponse(
+                content="So now I'll create the file.",
+                model="test",
+                usage={"input_tokens": 10, "output_tokens": 10},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+            ChatResponse(
+                content="OK, file created. All set.",
+                model="test",
+                usage={"input_tokens": 30, "output_tokens": 10},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+        ]
+
+        params = QueryParams(
+            messages=[UserMessage(content="Help")],
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=5,
+        )
+        holder = TerminalHolder()
+
+        async def run():
+            async for _ in query(params, terminal_holder=holder):
+                pass
+
+        _run(run())
+
+        self.assertEqual(holder.value.reason, "completed")
+        # Two model calls — nudge injected after the first prompted a
+        # continuation; second turn had completion marker ("All set").
+        self.assertEqual(provider.chat.call_count, 2)
+
+    def test_nudge_suppressed_by_completion_marker(self):
+        """When the model's text contains a completion marker (e.g.
+        'hope this helps!'), the nudge does NOT fire and the loop
+        completes after the first turn."""
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="Let me now show you. Hope this helps!",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 10},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        params = QueryParams(
+            messages=[UserMessage(content="Explain")],
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=5,
+        )
+        holder = TerminalHolder()
+
+        async def run():
+            async for _ in query(params, terminal_holder=holder):
+                pass
+
+        _run(run())
+
+        self.assertEqual(holder.value.reason, "completed")
+        self.assertEqual(provider.chat.call_count, 1)
+
+    def test_nudge_capped_at_three(self):
+        """The continuation-nudge count is capped at MAX_CONTINUATION_NUDGES=3.
+        After 3 nudges, the loop falls through to Terminal(completed)
+        rather than a 4th nudge."""
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        # Every response signals "let me now ..." (continuation intent).
+        provider.chat.return_value = ChatResponse(
+            content="Let me now create the file.",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 10},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        params = QueryParams(
+            messages=[UserMessage(content="Help")],
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=10,
+        )
+        holder = TerminalHolder()
+
+        async def run():
+            async for _ in query(params, terminal_holder=holder):
+                pass
+
+        _run(run())
+
+        self.assertEqual(holder.value.reason, "completed")
+        # 1 initial + 3 nudge retries = 4 model calls total (4th nudge
+        # is blocked by the cap).
+        self.assertEqual(provider.chat.call_count, 4)
+
+
+class TestModelFallback(_Base):
+    """E.2 — FallbackTriggeredError handling."""
+
+    def test_no_fallback_provider_propagates_error(self):
+        """When params.fallback_provider is None, FallbackTriggeredError
+        propagates out as Terminal(model_error)."""
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = FallbackTriggeredError(
+            original_model="opus-1", fallback_model="sonnet-1",
+        )
+
+        params = QueryParams(
+            messages=[UserMessage(content="Help")],
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=5,
+            fallback_provider=None,
+        )
+        holder = TerminalHolder()
+
+        async def run():
+            async for _ in query(params, terminal_holder=holder):
+                pass
+
+        _run(run())
+
+        self.assertEqual(holder.value.reason, "model_error")
+
+    def test_fallback_swaps_provider_and_retries(self):
+        """E.2: FallbackTriggeredError on the primary provider swaps
+        to params.fallback_provider, emits a 'Switched to ...' system
+        message, and completes on the fallback."""
+        primary = MagicMock()
+        primary.chat_stream_response.side_effect = NotImplementedError()
+        primary.chat.side_effect = FallbackTriggeredError(
+            original_model="opus-1", fallback_model="sonnet-1",
+        )
+
+        fallback = MagicMock()
+        fallback.chat_stream_response.side_effect = NotImplementedError()
+        fallback.chat.return_value = ChatResponse(
+            content="Done on fallback.",
+            model="sonnet-1",
+            usage={"input_tokens": 50, "output_tokens": 30},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        params = QueryParams(
+            messages=[UserMessage(content="Long prompt")],
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=primary,
+            abort_controller=self.abort,
+            max_turns=5,
+            fallback_provider=fallback,
+        )
+        holder = TerminalHolder()
+        collected: list = []
+
+        async def run():
+            async for msg in query(params, terminal_holder=holder):
+                collected.append(msg)
+
+        _run(run())
+
+        self.assertEqual(holder.value.reason, "completed")
+        # Primary was called once (raised the fallback signal);
+        # fallback was called once (succeeded).
+        self.assertEqual(primary.chat.call_count, 1)
+        self.assertEqual(fallback.chat.call_count, 1)
+        # A "Switched to ..." system message was yielded.
+        switch_msgs = [
+            m for m in collected
+            if isinstance(m, SystemMessage)
+            and "Switched to" in str(getattr(m, "content", ""))
+        ]
+        self.assertEqual(len(switch_msgs), 1)
+
+
+class TestTombstoneMessage(unittest.TestCase):
+    """E.5 — TombstoneMessage type."""
+
+    def test_tombstone_message_has_default_type_tombstone(self):
+        tm = TombstoneMessage()
+        self.assertEqual(tm.type, "tombstone")
+        self.assertIsNone(tm.message)
+
+    def test_tombstone_with_message_carried(self):
+        am = AssistantMessage(content="partial")
+        tm = TombstoneMessage(message=am)
+        self.assertEqual(tm.type, "tombstone")
+        self.assertIs(tm.message, am)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase E of the chapter-5 agent-loop refactor. Closes **C4** (model fallback unimplemented) and **M1** (continuation nudge unimplemented). Stacked on top of PR #101 (Phase D).

- **E.2** — Wrap the call_model invocation in a `while attempt_with_fallback` loop. On `FallbackTriggeredError`, swap to `params.fallback_provider` (provider-object swap, not model-name kwarg — per critic-revised design, the existing dispatch already routes through the provider). Yield orphaned-tool-result blocks + tombstones for partial assistant_messages from the failed attempt; emit a "Switched to <fallback> due to high demand for <original>" system message; retry.
- **E.4** — New `src/query/continuation_signals.py` module with the regex set ported from TS query.ts:1444-1505. `matches_continuation_signal` honors three categories: any-length patterns, short-only patterns (< 80 chars), completion markers (suppress). The loop calls it after the budget check declines to continue; capped at `MAX_CONTINUATION_NUDGES=3` to prevent infinite nudge loops.
- **E.5** — New `TombstoneMessage` dataclass in `src/types/messages.py`. `QueryEngine.submit_message` handles it by REMOVING the matching message (by uuid) from `_mutable_messages` rather than appending the tombstone.

Out-of-scope follow-up: the *triggering* of `FallbackTriggeredError` from real provider 529 responses is wired in a later PR in this stack.

## Test plan

- [x] 12 acceptance tests in `tests/test_query_fallback_and_nudge.py`: 5 regex-matcher tests, 3 loop-integration nudge tests (fire / suppress / cap), 2 model-fallback tests, 2 TombstoneMessage type tests.
- [x] 105 tests pass across the full query suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)