### PR TITLE
feat(ch05/A-followup + G): QueryDeps + Terminal surfacing + outer two-layer wrapper

### DIFF
--- a/src/query/command_lifecycle.py
+++ b/src/query/command_lifecycle.py
@@ -1,0 +1,76 @@
+"""Ch5/G.3 — slash-command + task-notification lifecycle dispatch.
+
+Mirrors TS ``notifyCommandLifecycle`` at query.ts:1746-1823. The
+two-layer ``query()`` entry point (G.3) tracks UUIDs of slash
+commands and task notifications consumed during a turn; after the
+inner loop terminates NATURALLY (not via .aclose() or exception),
+the outer wrapper fires ``notify_command_lifecycle(uuid,
+"completed")`` for every consumed UUID. A failed turn does NOT
+declare its commands successful — chapter §"The Two-Layer Entry
+Point" documents the rationale.
+
+Today this is a minimal pub-sub stub: command-queue + slash-command
+infrastructure isn't wired into the Python port yet (the
+``_drain_pending_user_messages`` helper at query.py:119 drains the
+*agent-task* inbox, not a global command queue). When that
+infrastructure lands, the listener registry below is the integration
+seam.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable, Literal
+
+logger = logging.getLogger(__name__)
+
+LifecycleStatus = Literal["started", "completed", "failed"]
+
+# Listeners are simple callables that receive (uuid, status). Tests
+# can register a listener to assert that lifecycle events fired.
+_listeners: list[Callable[[str, LifecycleStatus], None]] = []
+
+
+def notify_command_lifecycle(uuid: str, status: LifecycleStatus) -> None:
+    """Notify all registered listeners that a command UUID transitioned
+    to ``status``.
+
+    Statuses:
+      * ``"started"`` — fired when the loop begins consuming the
+        command. Currently NOT emitted by the loop because Python
+        doesn't have the slash-command queue yet; reserved for
+        future integration.
+      * ``"completed"`` — fired by the outer ``query()`` wrapper
+        AFTER the inner loop terminates naturally. Skipped on
+        ``.aclose()``/exception so failed turns don't falsely
+        declare success.
+      * ``"failed"`` — reserved for future granular failure
+        reporting.
+    """
+    for listener in list(_listeners):
+        try:
+            listener(uuid, status)
+        except Exception:
+            logger.exception(
+                "Command-lifecycle listener raised for uuid=%s status=%s",
+                uuid, status,
+            )
+
+
+def register_lifecycle_listener(
+    listener: Callable[[str, LifecycleStatus], None],
+) -> Callable[[], None]:
+    """Register a listener and return an unregister callable."""
+    _listeners.append(listener)
+
+    def _unregister() -> None:
+        try:
+            _listeners.remove(listener)
+        except ValueError:
+            pass
+
+    return _unregister
+
+
+def clear_lifecycle_listeners() -> None:
+    """Test helper — drop all registered listeners."""
+    _listeners.clear()

--- a/src/query/deps.py
+++ b/src/query/deps.py
@@ -1,11 +1,60 @@
+"""Ch5/G.1 — narrow dependency injection container for the query loop.
+
+Mirrors TS query/deps.ts:21-40. The loop carries an immutable
+``QueryDeps`` snapshot with four function references (call_model,
+microcompact, autocompact, uuid). Tests pass a custom QueryDeps into
+QueryParams to inject fakes without monkey-patching module imports.
+
+The ``production_deps()`` factory wires up the real implementations
+from the canonical source paths (see import comments below — critic
+review flagged that the canonical sources are ``context_system`` for
+microcompact and ``services.compact.autocompact`` for
+``auto_compact_if_needed``, NOT re-exports through
+``services.compact.compact``).
+"""
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, AsyncGenerator, Callable
+from typing import Any, Callable
 from uuid import uuid4
 
 
 @dataclass
 class QueryDeps:
-    call_model: Callable[..., AsyncGenerator[Any, None]]
-    uuid: Callable[[], str] = field(default_factory=lambda: lambda: uuid4().hex)
+    """Four injected dependencies for the query loop.
+
+    Mirrors TS ``QueryDeps`` at query/deps.ts:21-31. Using callable
+    slots (not class instances) keeps the deps narrow and the test
+    seam tiny — a fake ``call_model`` can be a one-line lambda.
+    """
+    call_model: Callable[..., Any]
+    microcompact: Callable[..., Any]
+    autocompact: Callable[..., Any]
+    uuid: Callable[[], str] = field(
+        default_factory=lambda: lambda: uuid4().hex
+    )
+
+
+def production_deps() -> QueryDeps:
+    """Wire the real implementations.
+
+    Imports the canonical source paths (per critic review):
+      - ``microcompact_messages`` lives in
+        ``src/context_system/microcompact.py`` (re-exported through
+        ``services/compact/compact.py`` but the canonical source is
+        the context_system package).
+      - ``auto_compact_if_needed`` is the real export name in
+        ``src/services/compact/autocompact.py`` (NOT
+        ``autocompact_if_needed`` as a previous draft assumed).
+    """
+    # Local imports keep the deps module's import graph minimal and
+    # avoid pulling in heavy provider/registry code at startup.
+    from ..context_system.microcompact import microcompact_messages
+    from ..services.compact.autocompact import auto_compact_if_needed
+    from .query import _call_model_sync
+
+    return QueryDeps(
+        call_model=_call_model_sync,
+        microcompact=microcompact_messages,
+        autocompact=auto_compact_if_needed,
+    )

--- a/src/query/engine.py
+++ b/src/query/engine.py
@@ -28,6 +28,7 @@ from ..context_system.prompt_assembly import (
 )
 
 from .query import QueryParams, StreamEvent, query
+from .transitions import Terminal, TerminalHolder
 from ..services.compact.pipeline import PipelineConfig
 from ..services.compact.autocompact import AutoCompactTracking
 
@@ -69,6 +70,12 @@ class QueryEngine:
         # would reset the counter every prompt. Hold the SAME tracking
         # instance on the engine and reuse it.
         self._auto_compact_tracking: AutoCompactTracking = AutoCompactTracking()
+        # Ch5/A follow-up — the canonical query() loop writes a Terminal
+        # to its TerminalHolder just before exit. Expose the most recent
+        # Terminal so wrapper callers (REPL, headless, SDK) can
+        # discriminate why a turn stopped: ``completed``, ``aborted_*``,
+        # ``max_turns``, ``stop_hook_prevented``, etc.
+        self._last_terminal: Terminal | None = None
 
     @property
     def mutable_messages(self) -> list[Message]:
@@ -81,6 +88,22 @@ class QueryEngine:
     @property
     def total_usage(self) -> dict[str, int]:
         return dict(self._total_usage)
+
+    @property
+    def last_terminal(self) -> Terminal | None:
+        """Ch5/A follow-up — most recent Terminal yielded by query().
+
+        Set by submit_message() at the end of each turn. Callers can
+        switch on ``last_terminal.reason`` to discriminate why the
+        turn stopped (10 distinct reasons per chapter §"Terminal
+        States": ``completed``, ``aborted_streaming``, ``aborted_tools``,
+        ``max_turns``, ``stop_hook_prevented``, ``hook_stopped``,
+        ``prompt_too_long``, ``image_error``, ``blocking_limit``,
+        ``model_error``).
+
+        Returns None before the first ``submit_message`` has finished.
+        """
+        return self._last_terminal
 
     async def _build_system_prompt_parts(
         self,
@@ -268,7 +291,13 @@ class QueryEngine:
             task_budget=task_budget,
         )
 
-        async for message in query(params):
+        # Ch5/A follow-up — thread a TerminalHolder through query() so
+        # we can read the typed Terminal value after iteration. Without
+        # this the engine drops the terminal silently and callers cannot
+        # discriminate exit reason.
+        terminal_holder = TerminalHolder()
+
+        async for message in query(params, terminal_holder=terminal_holder):
             if isinstance(message, StreamEvent):
                 if on_message:
                     on_message(message)
@@ -306,6 +335,10 @@ class QueryEngine:
                 on_message(message)
 
             yield message
+
+        # Persist the Terminal so callers can inspect it via the
+        # ``last_terminal`` property after the generator is exhausted.
+        self._last_terminal = terminal_holder.value
 
     def interrupt(self) -> None:
         self._abort_controller.abort("user_interrupt")

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -25,6 +25,7 @@ from ..utils.abort_controller import AbortController
 from ..providers.base import BaseProvider, ChatResponse
 
 from .config import QueryConfig, build_query_config
+from .deps import QueryDeps
 from .transitions import (
     QueryState,
     Terminal,
@@ -82,6 +83,11 @@ class QueryParams:
     # provider-internal concern (rate-limit header parsing) that is
     # tracked as a separate ticket.
     fallback_provider: BaseProvider | None = None
+    # Ch5/G.1+G.2 — narrow dependency injection. Tests pass a custom
+    # ``QueryDeps`` to swap ``call_model`` for a fake without having
+    # to monkey-patch ``_call_model_sync`` at the module level. When
+    # ``deps`` is None, the loop falls back to ``production_deps()``.
+    deps: QueryDeps | None = None
 
 
 @dataclass
@@ -696,6 +702,16 @@ async def query(
     )
     config = build_query_config()
 
+    # Ch5/G.1+G.2 — resolve deps once per query() invocation. Tests
+    # pass their own QueryDeps to swap call_model for a fake; the
+    # production path uses production_deps() which wires
+    # _call_model_sync, microcompact_messages, and auto_compact_if_needed.
+    if params.deps is not None:
+        deps = params.deps
+    else:
+        from .deps import production_deps
+        deps = production_deps()
+
     # Ch5/D.1 — instantiate the budget tracker once per query() call
     # when both the config gate (token_budget_enabled) is on AND the
     # caller passed a task_budget. Mirrors TS query.ts:295. The tracker
@@ -867,7 +883,10 @@ async def query(
             while attempt_with_fallback:
                 attempt_with_fallback = False
                 try:
-                    returned_assistants, returned_tool_blocks = await _call_model_sync(
+                    # Ch5/G.2 — route through deps.call_model. The default
+                    # production deps wires this to _call_model_sync; tests
+                    # can pass a fake with the same signature.
+                    returned_assistants, returned_tool_blocks = await deps.call_model(
                         provider=current_provider,
                         messages=messages,
                         system_prompt=params.system_prompt,

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -674,27 +674,68 @@ async def query(
     *,
     terminal_holder: TerminalHolder | None = None,
 ) -> AsyncGenerator[Message | StreamEvent, None]:
-    """Canonical agent loop (chapter 5, Phase A foundation).
+    """Canonical agent loop — outer two-layer entry point (Ch5/G.3).
 
-    The async generator yields messages and stream events to the consumer.
+    Mirrors TS ``query.ts:224-243``. The outer wrapper delegates to
+    :func:`_query_loop_inner` while tracking the UUIDs of slash
+    commands and task notifications consumed during the turn. AFTER
+    the inner loop completes naturally (not via ``.aclose()`` or
+    exception), the outer fires
+    ``notify_command_lifecycle(uuid, "completed")`` for every consumed
+    UUID. If the inner crashes or is closed mid-iteration, the
+    completion notifications are skipped — a failed turn does not
+    declare its commands successful.
+
     The final ``Terminal`` is written to ``terminal_holder.value`` just
-    before the generator returns (Python async generators cannot return
-    values: PEP 525). Callers who care about the terminal pass their own
-    ``TerminalHolder`` and read its ``.value`` after iteration.
+    before the generator returns (Python async generators cannot
+    return values: PEP 525). Callers who care about the terminal pass
+    their own ``TerminalHolder`` and read its ``.value`` after
+    iteration. See :func:`run_query` for a convenience helper that
+    returns ``(messages, terminal)``.
+    """
+    holder = terminal_holder or TerminalHolder()
+    consumed_command_uuids: list[str] = []
+    natural_termination: list[bool] = [False]
 
-    See :func:`run_query` for a convenience helper that consumes the
-    generator and returns ``(messages, terminal)``.
+    inner = _query_loop_inner(
+        params,
+        terminal_holder=holder,
+        consumed_command_uuids=consumed_command_uuids,
+        natural_termination=natural_termination,
+    )
+    try:
+        async for msg in inner:
+            yield msg
+    finally:
+        # Fire completed-lifecycle ONLY on natural termination. If we
+        # got here via .aclose() or an unhandled exception bubbling
+        # up, ``natural_termination[0]`` is still False and we
+        # silently drop the completion notifications. Mirrors TS at
+        # query.ts:240-243 ("a failed turn should not mark commands
+        # as successfully processed").
+        if natural_termination[0] and consumed_command_uuids:
+            from .command_lifecycle import notify_command_lifecycle
+            for uuid in consumed_command_uuids:
+                notify_command_lifecycle(uuid, "completed")
 
-    This PR (Phase A) introduces the typed Terminal infrastructure;
-    recovery integration, stop hooks, token budget, model fallback,
-    and continuation nudge land in subsequent PRs.
+
+async def _query_loop_inner(
+    params: QueryParams,
+    *,
+    terminal_holder: TerminalHolder,
+    consumed_command_uuids: list[str],
+    natural_termination: list[bool],
+) -> AsyncGenerator[Message | StreamEvent, None]:
+    """Inner agent loop — does all the real work (chapter 5).
+
+    Separated from the outer ``query()`` wrapper so the outer can
+    gate command-lifecycle dispatch on natural termination. The
+    ``consumed_command_uuids`` list is shared-mutable — when the
+    inner consumes a slash command, it appends the UUID; the outer
+    reads the final list after iteration.
     """
     _diag = os.environ.get("CLAWCODEX_DEBUG", "").lower() in ("1", "true", "yes")
-    holder = terminal_holder or TerminalHolder()
-    # Inner-only flag for the future outer two-layer wrapper (Phase G).
-    # Until that lands, the flag is local; set_terminal still writes it
-    # so every exit site uses the canonical helper.
-    natural_termination: list[bool] = [False]
+    holder = terminal_holder
     state = QueryState(
         messages=list(params.messages),
         tool_use_context=params.tool_use_context,

--- a/tests/test_query_command_lifecycle.py
+++ b/tests/test_query_command_lifecycle.py
@@ -1,0 +1,272 @@
+"""Ch5/G.3 — outer query() wrapper + command-lifecycle dispatch tests.
+
+Verifies the contracts from chapter 5 §"The Two-Layer Entry Point":
+  * The outer query() wrapper tracks consumed_command_uuids.
+  * On NATURAL termination, notify_command_lifecycle(uuid, "completed")
+    fires for every consumed UUID.
+  * On .aclose() / exception, the completion notifications are
+    SKIPPED — a failed turn does not falsely declare success.
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from src.providers.base import ChatResponse
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.types.messages import UserMessage
+from src.utils.abort_controller import AbortController
+
+from src.query.query import QueryParams, query
+from src.query.transitions import TerminalHolder
+from src.query.command_lifecycle import (
+    clear_lifecycle_listeners,
+    register_lifecycle_listener,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.temp_dir.name)
+        self.registry = build_default_registry()
+        self.context = ToolContext(workspace_root=self.workspace)
+        self.abort = AbortController()
+        clear_lifecycle_listeners()
+
+    def tearDown(self):
+        clear_lifecycle_listeners()
+        self.temp_dir.cleanup()
+
+
+class TestCommandLifecycleListener(_Base):
+    """G.3 — register/notify lifecycle listener contract."""
+
+    def test_register_and_unregister_listener(self):
+        events = []
+        unregister = register_lifecycle_listener(
+            lambda uuid, status: events.append((uuid, status)),
+        )
+        from src.query.command_lifecycle import notify_command_lifecycle
+        notify_command_lifecycle("cmd-1", "completed")
+        self.assertEqual(events, [("cmd-1", "completed")])
+
+        unregister()
+        notify_command_lifecycle("cmd-2", "completed")
+        # After unregister, no more events.
+        self.assertEqual(events, [("cmd-1", "completed")])
+
+    def test_clear_lifecycle_listeners(self):
+        events = []
+        register_lifecycle_listener(
+            lambda uuid, status: events.append((uuid, status)),
+        )
+        clear_lifecycle_listeners()
+        from src.query.command_lifecycle import notify_command_lifecycle
+        notify_command_lifecycle("cmd", "completed")
+        self.assertEqual(events, [])
+
+
+class TestOuterQueryWrapper(_Base):
+    """G.3 — the outer query() wrapper fires lifecycle events only on
+    natural termination."""
+
+    def _params(self, provider):
+        return QueryParams(
+            messages=[UserMessage(content="Hi")],
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=5,
+        )
+
+    def test_no_consumed_uuids_no_lifecycle_events(self):
+        """With no consumed_command_uuids appended, the outer wrapper
+        fires nothing — even on a successful turn."""
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="Done.",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 5},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        events = []
+        register_lifecycle_listener(
+            lambda uuid, status: events.append((uuid, status)),
+        )
+
+        params = self._params(provider)
+        holder = TerminalHolder()
+
+        async def run():
+            async for _ in query(params, terminal_holder=holder):
+                pass
+
+        _run(run())
+        self.assertEqual(holder.value.reason, "completed")
+        self.assertEqual(events, [])
+
+    def test_consumed_uuids_fire_on_natural_termination(self):
+        """When the inner loop appends UUIDs to consumed_command_uuids,
+        the outer wrapper fires `notify_command_lifecycle(uuid,
+        "completed")` for each on natural termination."""
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="Done.",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 5},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        events = []
+        register_lifecycle_listener(
+            lambda uuid, status: events.append((uuid, status)),
+        )
+
+        # Monkey-patch the inner loop to append UUIDs to simulate
+        # slash-command consumption. We can't easily wire the real
+        # slash-command queue (out of ch05 scope), so this exercises
+        # the wrapper's dispatch directly.
+        # ``from src.query.query import _query_loop_inner`` won't work
+        # because src/query/__init__.py re-exports the ``query``
+        # function, shadowing the submodule. Use importlib explicitly.
+        import importlib
+        query_module = importlib.import_module("src.query.query")
+
+        original_inner = query_module._query_loop_inner
+
+        async def patched_inner(
+            params,
+            *,
+            terminal_holder,
+            consumed_command_uuids,
+            natural_termination,
+        ):
+            consumed_command_uuids.append("cmd-abc")
+            consumed_command_uuids.append("cmd-xyz")
+            async for msg in original_inner(
+                params,
+                terminal_holder=terminal_holder,
+                consumed_command_uuids=consumed_command_uuids,
+                natural_termination=natural_termination,
+            ):
+                yield msg
+
+        params = self._params(provider)
+        holder = TerminalHolder()
+
+        async def run():
+            query_module._query_loop_inner = patched_inner
+            try:
+                async for _ in query(params, terminal_holder=holder):
+                    pass
+            finally:
+                query_module._query_loop_inner = original_inner
+
+        _run(run())
+
+        self.assertEqual(holder.value.reason, "completed")
+        # Both UUIDs fired with "completed" status, IN ORDER.
+        self.assertEqual(events, [
+            ("cmd-abc", "completed"),
+            ("cmd-xyz", "completed"),
+        ])
+
+    def test_aclose_skips_lifecycle_events(self):
+        """If the outer generator is closed mid-iteration (consumer
+        calls .aclose() or stops iterating early), the natural-
+        termination flag stays False and the completion notifications
+        are SKIPPED. Chapter §"The Two-Layer Entry Point": "a failed
+        turn does not mark commands as successfully processed.""\""""
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="thinking",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 5},
+            finish_reason="tool_use",
+            tool_uses=[{
+                "id": "tool_1",
+                "name": "Bash",
+                "input": {"command": "true", "description": "noop"},
+            }],
+        )
+
+        events = []
+        register_lifecycle_listener(
+            lambda uuid, status: events.append((uuid, status)),
+        )
+
+        # ``from src.query.query import _query_loop_inner`` won't work
+        # because src/query/__init__.py re-exports the ``query``
+        # function, shadowing the submodule. Use importlib explicitly.
+        import importlib
+        query_module = importlib.import_module("src.query.query")
+
+        original_inner = query_module._query_loop_inner
+
+        async def patched_inner(
+            params,
+            *,
+            terminal_holder,
+            consumed_command_uuids,
+            natural_termination,
+        ):
+            consumed_command_uuids.append("cmd-abc")
+            # Yield one message then have the consumer stop iterating.
+            count = 0
+            async for msg in original_inner(
+                params,
+                terminal_holder=terminal_holder,
+                consumed_command_uuids=consumed_command_uuids,
+                natural_termination=natural_termination,
+            ):
+                count += 1
+                yield msg
+                if count >= 2:
+                    # Caller will stop iterating after this. We never
+                    # set natural_termination[0] = True.
+                    return
+
+        params = self._params(provider)
+        holder = TerminalHolder()
+
+        async def run():
+            query_module._query_loop_inner = patched_inner
+            try:
+                gen = query(params, terminal_holder=holder)
+                count = 0
+                async for _ in gen:
+                    count += 1
+                    if count >= 2:
+                        break
+                # Force generator finalization via aclose.
+                await gen.aclose()
+            finally:
+                query_module._query_loop_inner = original_inner
+
+        _run(run())
+
+        # Lifecycle events MUST NOT fire — natural_termination[0]
+        # never flipped to True.
+        self.assertEqual(events, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_query_deps.py
+++ b/tests/test_query_deps.py
@@ -1,0 +1,159 @@
+"""Ch5/G.1+G.2 — QueryDeps injection seam tests.
+
+Verifies the contract from chapter 5 §"Dependency Injection":
+  G.1 — QueryDeps exposes 4 slots (call_model, microcompact,
+        autocompact, uuid) with a production_deps() factory.
+  G.2 — query() routes the model call through deps.call_model; a
+        custom QueryDeps injected via QueryParams.deps replaces the
+        production wiring without monkey-patching module imports.
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.types.messages import AssistantMessage, UserMessage
+from src.types.content_blocks import TextBlock
+from src.utils.abort_controller import AbortController
+
+from src.query.query import QueryParams, query
+from src.query.deps import QueryDeps, production_deps
+from src.query.transitions import TerminalHolder
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestProductionDeps(unittest.TestCase):
+    """G.1 — production_deps() wires the canonical imports."""
+
+    def test_production_deps_has_all_four_slots(self):
+        deps = production_deps()
+        self.assertTrue(callable(deps.call_model))
+        self.assertTrue(callable(deps.microcompact))
+        self.assertTrue(callable(deps.autocompact))
+        self.assertTrue(callable(deps.uuid))
+
+    def test_uuid_factory_returns_hex_string(self):
+        deps = production_deps()
+        u = deps.uuid()
+        self.assertIsInstance(u, str)
+        # uuid4().hex returns 32 hex chars without dashes.
+        self.assertEqual(len(u), 32)
+
+
+class TestInjectedDeps(unittest.TestCase):
+    """G.2 — query() routes call_model through deps.call_model."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.temp_dir.name)
+        self.registry = build_default_registry()
+        self.context = ToolContext(workspace_root=self.workspace)
+        self.abort = AbortController()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_custom_call_model_is_invoked(self):
+        """When QueryParams.deps is set, query() uses deps.call_model
+        instead of the default _call_model_sync."""
+        call_count = {"n": 0}
+        from unittest.mock import MagicMock
+
+        # The default provider's chat methods must NOT be called when a
+        # custom call_model is injected. We attach an explicit assertion.
+        provider = MagicMock()
+        provider.chat.side_effect = AssertionError(
+            "Provider.chat must not be called when custom deps "
+            "intercepts call_model"
+        )
+        provider.chat_stream_response.side_effect = AssertionError(
+            "Provider.chat_stream_response must not be called when "
+            "custom deps intercepts call_model"
+        )
+
+        async def fake_call_model(**kw):
+            call_count["n"] += 1
+            return (
+                [AssistantMessage(
+                    content=[TextBlock(text="OK from fake")],
+                    stop_reason="end_turn",
+                )],
+                [],
+            )
+
+        # Use production_deps() as a base, then override call_model.
+        deps = production_deps()
+        deps.call_model = fake_call_model
+
+        params = QueryParams(
+            messages=[UserMessage(content="hi")],
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=5,
+            deps=deps,
+        )
+        holder = TerminalHolder()
+
+        async def run():
+            async for _ in query(params, terminal_holder=holder):
+                pass
+
+        _run(run())
+
+        self.assertEqual(call_count["n"], 1)
+        self.assertEqual(holder.value.reason, "completed")
+
+    def test_default_falls_back_to_production_deps(self):
+        """When QueryParams.deps is None, query() resolves
+        production_deps() — the existing test suite already exercises
+        this path implicitly; this test makes the contract explicit."""
+        from unittest.mock import MagicMock
+        from src.providers.base import ChatResponse
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="OK",
+            model="test",
+            usage={"input_tokens": 1, "output_tokens": 1},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        params = QueryParams(
+            messages=[UserMessage(content="hi")],
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=5,
+            # deps=None — exercise the default path.
+        )
+        holder = TerminalHolder()
+
+        async def run():
+            async for _ in query(params, terminal_holder=holder):
+                pass
+
+        _run(run())
+
+        self.assertEqual(holder.value.reason, "completed")
+        # provider.chat WAS called — proving the default production_deps
+        # routed through _call_model_sync → provider.
+        self.assertGreaterEqual(provider.chat.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -125,6 +125,35 @@ class TestQueryEngine(unittest.TestCase):
         self.assertIsInstance(engine.session_id, str)
         self.assertGreater(len(engine.session_id), 0)
 
+    def test_last_terminal_starts_none(self):
+        """Ch5/A follow-up: before any submit_message, last_terminal is None."""
+        engine = self._make_engine(MagicMock())
+        self.assertIsNone(engine.last_terminal)
+
+    def test_last_terminal_set_after_submit_message(self):
+        """Ch5/A follow-up: after submit_message completes, the engine
+        exposes the Terminal so callers can discriminate why the loop
+        stopped."""
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="Done.",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 5},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+        engine = self._make_engine(provider)
+
+        async def run():
+            async for _ in engine.submit_message("Hi"):
+                pass
+
+        _run(run())
+
+        self.assertIsNotNone(engine.last_terminal)
+        self.assertEqual(engine.last_terminal.reason, "completed")
+
 
 class TestEngineProducesCacheableSystemBlocks(unittest.TestCase):
     """Joint WI-1.1 + WI-1.2 acceptance: end-to-end engine produces blocks.


### PR DESCRIPTION
## Summary

Phase A follow-up + Phase G (G.1, G.2, G.3) of the chapter-5 agent-loop refactor. Stacked on top of PR #102 (Phase E).

**A follow-up — thread `TerminalHolder` through `QueryEngine.run()`:**
- `QueryEngine.submit_message` now declares a `TerminalHolder` and passes it into `query(...)`. After the generator exhausts, the typed Terminal is persisted on `self._last_terminal`.
- New `QueryEngine.last_terminal` property exposes the most recent Terminal so REPL/headless/SDK callers can switch on `terminal.reason` (10 distinct reasons per chapter §"Terminal States").

**G.1 — expand `QueryDeps` to 4 slots:**
- `src/query/deps.py`: `QueryDeps` now has `call_model`, `microcompact`, `autocompact`, `uuid` fields, mirroring TS `query/deps.ts:21-31`.
- New `production_deps()` factory wires the canonical imports (`microcompact_messages` from `src/context_system/microcompact.py`; `auto_compact_if_needed` from `src/services/compact/autocompact.py`).

**G.2 — thread `QueryDeps` through `query()`:**
- `QueryParams.deps: QueryDeps | None = None`. On entry, `deps = params.deps or production_deps()`. The call_model dispatch in the attempt-with-fallback block goes through `deps.call_model(...)` so tests can inject a fake without monkey-patching module imports.

**G.3 — outer two-layer wrapper (`query()` → `_query_loop_inner`):**
- `query()` is now a thin outer that delegates to `_query_loop_inner` via a forwarding `async for` loop. The outer owns the `TerminalHolder`, `consumed_command_uuids` list, and `natural_termination` flag.
- After the inner terminates *naturally* (not via `.aclose()` or exception), the outer's `finally` fires `notify_command_lifecycle(uuid, "completed")` for every consumed UUID. On crash or external close, the completions are silently dropped — chapter §"The Two-Layer Entry Point": "a failed turn does not mark commands as successfully processed."
- New `src/query/command_lifecycle.py` with a pub-sub `register_lifecycle_listener` API. The slash-command queue isn't wired into the Python port yet; the integration seam is `consumed_command_uuids.append(uuid)` inside the inner loop.

## Test plan

- [x] 6 new acceptance tests in `tests/test_query_engine.py` (last_terminal property), `tests/test_query_deps.py` (4-slot factory + injection seam), `tests/test_query_command_lifecycle.py` (register/unregister, no-UUIDs no-fire, completed fires in order, aclose skips).
- [x] 111 tests pass across the full query suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)