### PR TITLE
feat(ch05/B.3): context-collapse drain before reactive_compact

### DIFF
--- a/src/query/query.py
+++ b/src/query/query.py
@@ -1087,6 +1087,53 @@ async def _query_loop_inner(
                 and not has_attempted_reactive_compact
                 and config.reactive_compact_enabled
             ):
+                # Ch5/B.3 — context-collapse drain runs FIRST. Mirrors
+                # TS query.ts:1160-1193. If the agent had been holding
+                # back staged collapses, an overflow forces them now.
+                # The drain is one-shot per recovery attempt: if the
+                # previous transition already drained and we're STILL
+                # 413'ing, fall through to reactive_compact.
+                if (
+                    is_withheld_ptl
+                    and config.context_collapse_enabled
+                    and (
+                        state.transition is None
+                        or state.transition.reason != "collapse_drain_retry"
+                    )
+                ):
+                    from ..services.compact.context_collapse import (
+                        is_context_collapse_enabled,
+                        recover_from_overflow,
+                    )
+                    if is_context_collapse_enabled():
+                        drained = recover_from_overflow(
+                            messages, params.query_source,
+                        )
+                        if drained.committed > 0:
+                            for msg in drained.messages:
+                                yield msg
+                            state = QueryState(
+                                messages=drained.messages,
+                                tool_use_context=tool_use_context,
+                                auto_compact_tracking=state.auto_compact_tracking,
+                                max_output_tokens_recovery_count=max_output_tokens_recovery_count,
+                                # Don't set has_attempted yet — drain is
+                                # a separate recovery layer; reactive
+                                # compact still gets its one shot if
+                                # the drain doesn't free enough tokens.
+                                has_attempted_reactive_compact=has_attempted_reactive_compact,
+                                max_output_tokens_override=None,
+                                stop_hook_active=state.stop_hook_active,
+                                turn_count=turn_count,
+                                pending_tool_use_summary=state.pending_tool_use_summary,
+                                continuation_nudge_count=state.continuation_nudge_count,
+                                transition=Transition(
+                                    reason="collapse_drain_retry",
+                                    committed=drained.committed,
+                                ),
+                            )
+                            continue
+
                 from ..services.compact.reactive_compact import (
                     ReactiveCompactResult,
                     reactive_compact,

--- a/src/services/compact/context_collapse.py
+++ b/src/services/compact/context_collapse.py
@@ -46,8 +46,17 @@ class ContextCollapseStore:
 
     Each commit records a set of archived message UUIDs and the summary
     that replaces them in the projected view.
+
+    Two queues exist:
+      * ``commits`` — applied collapses; ``project_view`` honors them.
+      * ``staged`` — proposed collapses awaiting commit. Held in
+        suspension until ``drain_staged()`` promotes them into
+        ``commits``. The Ch5/B.3 PTL-recovery path drains staged
+        collapses when an overflow forces a real 413 from the API,
+        so collapses the agent had been debating actually fire.
     """
     commits: list[CollapseCommit] = field(default_factory=list)
+    staged: list[CollapseCommit] = field(default_factory=list)
     _enabled: bool = True
 
     # ------------------------------------------------------------------
@@ -63,10 +72,37 @@ class ContextCollapseStore:
         self._enabled = value
 
     def add_commit(self, archived_msg_ids: list[str], summary: str) -> None:
-        """Record a new collapse commit."""
+        """Record a new collapse commit (immediately applied)."""
         if not archived_msg_ids or not summary:
             return
         self.commits.append(CollapseCommit(archived=list(archived_msg_ids), summary=summary))
+
+    def add_staged(self, archived_msg_ids: list[str], summary: str) -> None:
+        """Ch5/B.3 — record a proposed collapse without applying it.
+
+        Staged collapses are NOT honored by ``project_view`` until
+        promoted via ``drain_staged()``. The query loop's PTL recovery
+        path calls ``recover_from_overflow`` on a real 413, which
+        drains the staged queue to apply pending collapses that the
+        agent had been holding back.
+        """
+        if not archived_msg_ids or not summary:
+            return
+        self.staged.append(CollapseCommit(archived=list(archived_msg_ids), summary=summary))
+
+    def drain_staged(self) -> int:
+        """Ch5/B.3 — promote all staged collapses into ``commits``.
+
+        Returns the number of commits promoted. Called by
+        :func:`recover_from_overflow` and downstream by the PTL
+        recovery path.
+        """
+        count = len(self.staged)
+        if count == 0:
+            return 0
+        self.commits.extend(self.staged)
+        self.staged.clear()
+        return count
 
     def project_view(self, messages: list[Message]) -> list[Message]:
         """
@@ -115,8 +151,9 @@ class ContextCollapseStore:
         return result
 
     def clear(self) -> None:
-        """Remove all commits."""
+        """Remove all commits AND staged proposals."""
         self.commits.clear()
+        self.staged.clear()
 
     # ------------------------------------------------------------------
     # Serialization
@@ -125,13 +162,15 @@ class ContextCollapseStore:
     def to_dict(self) -> dict[str, Any]:
         return {
             "commits": [c.to_dict() for c in self.commits],
+            "staged": [c.to_dict() for c in self.staged],
             "enabled": self._enabled,
         }
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ContextCollapseStore:
         commits = [CollapseCommit.from_dict(c) for c in data.get("commits", [])]
-        return cls(commits=commits, _enabled=data.get("enabled", True))
+        staged = [CollapseCommit.from_dict(c) for c in data.get("staged", [])]
+        return cls(commits=commits, staged=staged, _enabled=data.get("enabled", True))
 
 
 # ---------------------------------------------------------------------------
@@ -155,3 +194,45 @@ def set_context_collapse_store(store: ContextCollapseStore | None) -> None:
     """Set or clear the global context collapse store."""
     global _global_store
     _global_store = store
+
+
+@dataclass
+class DrainResult:
+    """Outcome of recover_from_overflow.
+
+    ``committed > 0`` means staged collapses were promoted into the
+    commit log; ``messages`` is the freshly projected view that
+    incorporates them. ``committed == 0`` means nothing to drain —
+    the caller should fall through to reactive_compact.
+    """
+    messages: list[Message]
+    committed: int
+
+
+def recover_from_overflow(
+    messages: list[Message],
+    query_source: str,
+) -> DrainResult:
+    """Ch5/B.3 — drain staged context-collapses on a real API 413.
+
+    Mirrors TS ``recoverFromOverflow`` at query.ts:1169. Used by the
+    query loop's PTL recovery path BEFORE reactive_compact. If no
+    ContextCollapseStore is set, or the store is disabled, or no
+    staged collapses are present, returns ``DrainResult(messages,
+    committed=0)`` so the caller falls through to reactive_compact.
+
+    The ``query_source`` parameter mirrors the TS signature; it is
+    currently unused in Python — callers that need source-specific
+    behavior (e.g. skip drain on session_memory forks) can read it
+    in a future iteration.
+    """
+    store = get_context_collapse_state()
+    if store is None or not store.enabled:
+        return DrainResult(messages=messages, committed=0)
+    committed_count = store.drain_staged()
+    if committed_count == 0:
+        return DrainResult(messages=messages, committed=0)
+    return DrainResult(
+        messages=store.project_view(messages),
+        committed=committed_count,
+    )

--- a/tests/test_context_collapse_drain.py
+++ b/tests/test_context_collapse_drain.py
@@ -1,0 +1,310 @@
+"""Ch5/B.3 — ContextCollapseStore staging + recover_from_overflow tests.
+
+Verifies the contracts:
+  * `add_staged` records proposed collapses without applying them.
+  * `project_view` does NOT honor staged collapses (only commits).
+  * `drain_staged` promotes staged → commits and returns the count.
+  * `recover_from_overflow` drains the store and reprojects the
+    messages on a real overflow; returns DrainResult(committed=0)
+    when the store is empty/disabled/None.
+  * The query loop's PTL recovery path calls `recover_from_overflow`
+    BEFORE `reactive_compact`, so a successful drain short-circuits
+    the more expensive reactive-compact LLM call.
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.providers.base import ChatResponse
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.types.messages import AssistantMessage, UserMessage
+from src.types.content_blocks import TextBlock
+from src.utils.abort_controller import AbortController
+
+from src.services.compact.context_collapse import (
+    ContextCollapseStore,
+    CollapseCommit,
+    DrainResult,
+    recover_from_overflow,
+    set_context_collapse_store,
+)
+from src.query.query import QueryParams, query
+from src.query.transitions import TerminalHolder
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestContextCollapseStaging(unittest.TestCase):
+    """B.3 — staging API on ContextCollapseStore."""
+
+    def test_add_staged_does_not_affect_project_view(self):
+        """A staged collapse is NOT honored by project_view until
+        drained."""
+        msg_uuid = "a-b-c"
+        msg = UserMessage(content="hello", uuid=msg_uuid)
+        store = ContextCollapseStore()
+        store.add_staged([msg_uuid], "stand-in summary")
+
+        # project_view leaves the message untouched.
+        view = store.project_view([msg])
+        self.assertEqual(len(view), 1)
+        self.assertEqual(view[0].uuid, msg_uuid)
+
+    def test_drain_staged_promotes_to_commits(self):
+        msg_uuid = "uuid-1"
+        msg = UserMessage(content="hello", uuid=msg_uuid)
+        store = ContextCollapseStore()
+        store.add_staged([msg_uuid], "stand-in summary")
+
+        n = store.drain_staged()
+        self.assertEqual(n, 1)
+        self.assertEqual(len(store.commits), 1)
+        self.assertEqual(len(store.staged), 0)
+
+        # Now project_view honors the (formerly staged) collapse.
+        view = store.project_view([msg])
+        self.assertEqual(len(view), 1)
+        # The summary message replaces the original.
+        self.assertTrue(getattr(view[0], "isVirtual", False))
+
+    def test_drain_staged_returns_zero_when_empty(self):
+        store = ContextCollapseStore()
+        self.assertEqual(store.drain_staged(), 0)
+
+
+class TestRecoverFromOverflow(unittest.TestCase):
+    """B.3 — recover_from_overflow helper function."""
+
+    def tearDown(self):
+        # Reset the module-level global so tests don't bleed state.
+        set_context_collapse_store(None)
+
+    def test_no_store_returns_zero(self):
+        set_context_collapse_store(None)
+        msg = UserMessage(content="hi", uuid="x")
+        result = recover_from_overflow([msg], "repl_main_thread")
+        self.assertIsInstance(result, DrainResult)
+        self.assertEqual(result.committed, 0)
+        self.assertEqual(result.messages, [msg])
+
+    def test_disabled_store_returns_zero(self):
+        store = ContextCollapseStore()
+        store.enabled = False
+        store.add_staged(["x"], "summary")
+        set_context_collapse_store(store)
+
+        msg = UserMessage(content="hi", uuid="x")
+        result = recover_from_overflow([msg], "repl_main_thread")
+        self.assertEqual(result.committed, 0)
+        # The staged item is NOT drained when disabled.
+        self.assertEqual(len(store.staged), 1)
+        self.assertEqual(len(store.commits), 0)
+
+    def test_empty_staged_returns_zero(self):
+        store = ContextCollapseStore()
+        set_context_collapse_store(store)
+        msg = UserMessage(content="hi", uuid="x")
+        result = recover_from_overflow([msg], "repl_main_thread")
+        self.assertEqual(result.committed, 0)
+
+    def test_drains_and_reprojects(self):
+        msg_uuid = "msg-1"
+        msg = UserMessage(content="long history", uuid=msg_uuid)
+        store = ContextCollapseStore()
+        store.add_staged([msg_uuid], "[summary]")
+        set_context_collapse_store(store)
+
+        result = recover_from_overflow([msg], "repl_main_thread")
+        self.assertEqual(result.committed, 1)
+        # The message was replaced by the summary in the projected view.
+        self.assertEqual(len(result.messages), 1)
+        self.assertTrue(getattr(result.messages[0], "isVirtual", False))
+
+
+class TestCollapseDrainInLoop(unittest.TestCase):
+    """B.3 integration — query() drains staged collapses BEFORE
+    reactive_compact on a PTL recovery."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.temp_dir.name)
+        self.registry = build_default_registry()
+        self.context = ToolContext(workspace_root=self.workspace)
+        self.abort = AbortController()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+        set_context_collapse_store(None)
+
+    def test_drain_runs_before_reactive_compact(self):
+        """When the model raises PTL and the collapse store has staged
+        commits, the loop drains FIRST. If the drained projection then
+        successfully fits, reactive_compact does NOT need to fire."""
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = [
+            Exception("Prompt is too long"),  # turn 1 — triggers drain
+            ChatResponse(  # turn 2 (post-drain): OK
+                content="Done.",
+                model="test",
+                usage={"input_tokens": 10, "output_tokens": 5},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+        ]
+
+        # Seed the global store with a staged collapse so the drain
+        # has something to promote.
+        msg_uuid = "long-msg-1"
+        store = ContextCollapseStore()
+        store.add_staged([msg_uuid], "[collapsed history]")
+        set_context_collapse_store(store)
+
+        # Mock reactive_compact so we can assert it was NOT called.
+        reactive_calls = []
+
+        async def fake_reactive_compact(messages, error, provider, model, **kw):
+            reactive_calls.append(1)
+            from src.services.compact.reactive_compact import (
+                ReactiveCompactResult,
+            )
+            return ReactiveCompactResult(
+                compacted=True,
+                messages=[UserMessage(content="reactive summary")],
+                tokens_before=0,
+            )
+
+        # Build an initial messages list that includes the message we
+        # staged a collapse for.
+        params = QueryParams(
+            messages=[UserMessage(content="long history", uuid=msg_uuid)],
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=5,
+        )
+        holder = TerminalHolder()
+
+        # Override config to enable context-collapse for this test.
+        from src.query.config import FrozenQueryConfig
+        cfg = FrozenQueryConfig(
+            context_collapse_enabled=True,
+            reactive_compact_enabled=True,
+        )
+
+        async def run():
+            with patch(
+                "src.services.compact.reactive_compact.reactive_compact",
+                side_effect=fake_reactive_compact,
+            ), patch(
+                "src.query.query.build_query_config",
+                return_value=cfg,
+            ):
+                async for _ in query(params, terminal_holder=holder):
+                    pass
+
+        _run(run())
+
+        # The loop should have:
+        #   1. Hit PTL on turn 1.
+        #   2. Drained the staged collapse, set transition=
+        #      collapse_drain_retry, retried.
+        #   3. Turn 2 succeeded with the drained-projection messages.
+        # reactive_compact was NEVER called because the drain
+        # succeeded on the first overflow.
+        self.assertEqual(holder.value.reason, "completed")
+        self.assertEqual(provider.chat.call_count, 2)
+        self.assertEqual(
+            len(reactive_calls), 0,
+            "Drain should short-circuit reactive_compact when staged "
+            "commits were drained successfully",
+        )
+
+    def test_drain_oneshot_then_fall_through_to_reactive_compact(self):
+        """If the drain runs once and the post-drain retry STILL
+        raises PTL, the loop falls through to reactive_compact (the
+        drain is one-shot per recovery attempt)."""
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = [
+            Exception("Prompt is too long"),  # turn 1 — triggers drain
+            Exception("Prompt is too long"),  # turn 2 (post-drain) — still PTL
+            ChatResponse(  # turn 3 (post-reactive-compact): OK
+                content="Done.",
+                model="test",
+                usage={"input_tokens": 10, "output_tokens": 5},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+        ]
+
+        msg_uuid = "long-msg-1"
+        store = ContextCollapseStore()
+        store.add_staged([msg_uuid], "[collapsed history]")
+        set_context_collapse_store(store)
+
+        reactive_calls = []
+
+        async def fake_reactive_compact(messages, error, provider, model, **kw):
+            reactive_calls.append(1)
+            from src.services.compact.reactive_compact import (
+                ReactiveCompactResult,
+            )
+            return ReactiveCompactResult(
+                compacted=True,
+                messages=[UserMessage(content="reactive summary")],
+                tokens_before=0,
+            )
+
+        params = QueryParams(
+            messages=[UserMessage(content="long history", uuid=msg_uuid)],
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=5,
+        )
+        holder = TerminalHolder()
+
+        from src.query.config import FrozenQueryConfig
+        cfg = FrozenQueryConfig(
+            context_collapse_enabled=True,
+            reactive_compact_enabled=True,
+        )
+
+        async def run():
+            with patch(
+                "src.services.compact.reactive_compact.reactive_compact",
+                side_effect=fake_reactive_compact,
+            ), patch(
+                "src.query.query.build_query_config",
+                return_value=cfg,
+            ):
+                async for _ in query(params, terminal_holder=holder):
+                    pass
+
+        _run(run())
+
+        # 3 model calls: PTL → drain → PTL → reactive_compact → OK.
+        self.assertEqual(provider.chat.call_count, 3)
+        # reactive_compact called exactly once (after drain
+        # one-shot exhausted).
+        self.assertEqual(len(reactive_calls), 1)
+        self.assertEqual(holder.value.reason, "completed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase B.3 of the chapter-5 agent-loop refactor. Closes the deferred B.3 follow-up — the context-collapse drain that runs BEFORE reactive_compact on a real API 413. Stacked on top of PR #103.

**`ContextCollapseStore` staging API:**
- New `staged: list[CollapseCommit]` field — held in suspension; NOT honored by `project_view` until promoted.
- `add_staged(archived_ids, summary)` — record a proposed collapse without applying.
- `drain_staged() -> int` — promote all staged to `commits`; returns count.
- `clear()` now clears both queues; `to_dict()` / `from_dict()` round-trip staged.

**`recover_from_overflow(messages, query_source) -> DrainResult`:**
- Mirrors TS `recoverFromOverflow` at query.ts:1169. Drains the global store on a real 413; returns `DrainResult(committed=0)` when no store / disabled / nothing staged so the caller falls through to reactive_compact.

**Loop wiring (`query.py`):**
- In the no-tool-use PTL-recovery branch, BEFORE reactive_compact: if `config.context_collapse_enabled` AND the previous transition wasn't already `collapse_drain_retry` (one-shot guard), call `recover_from_overflow`. On `committed > 0`, yield the projected view and re-enter with `transition.reason="collapse_drain_retry"`. `has_attempted_reactive_compact` is preserved (drain is a separate recovery layer).

## Test plan

- [x] 9 acceptance tests in `tests/test_context_collapse_drain.py`: staging API (3), recover_from_overflow helper (4), loop integration (2 — drain short-circuits reactive_compact; one-shot guard falls through to reactive_compact on second 413).
- [x] 129 tests pass across the full query suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)