### PR TITLE
feat(ch05): stop-hooks user/system context threading + minor critic items

### DIFF
--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -518,6 +518,8 @@ async def execute_stop_hooks(
     tool_use_context: Any = None,
     messages: list[Any] | None = None,
     agent_type: str | None = None,
+    user_context: dict[str, str] | None = None,
+    system_context: dict[str, str] | None = None,
 ) -> AsyncGenerator[dict[str, Any], None]:
     event = "SubagentStop" if subagent_id else "Stop"
 
@@ -529,6 +531,14 @@ async def execute_stop_hooks(
         stdin_data["subagent_id"] = subagent_id
     if agent_type:
         stdin_data["agent_type"] = agent_type
+    # Ch5/C.1 follow-up — surface user_context (CLAUDE.md, date) and
+    # system_context (git status, etc.) to Stop hooks so a hook script
+    # can make decisions based on per-session context. Mirrors the TS
+    # forwarding that lands these in the hook's stdin payload.
+    if user_context:
+        stdin_data["user_context"] = dict(user_context)
+    if system_context:
+        stdin_data["system_context"] = dict(system_context)
 
     async for result in _run_hooks_for_event(
         event,

--- a/src/query/engine.py
+++ b/src/query/engine.py
@@ -62,7 +62,16 @@ class QueryEngine:
         self._config = config
         self._mutable_messages: list[Message] = list(config.initial_messages or [])
         self._abort_controller = config.abort_controller or create_abort_controller()
-        self._total_usage: dict[str, int] = {"input_tokens": 0, "output_tokens": 0}
+        # Critic-flagged cache-token gap — track all four usage fields
+        # the Anthropic API surfaces. Cache fields are zero on
+        # non-Anthropic providers (GLM, OpenAI compat) and on
+        # cold-cache turns.
+        self._total_usage: dict[str, int] = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        }
         self._session_id: str = uuid4().hex
         # Ch5/B.5 prereq — the autocompact circuit-breaker counter must
         # survive across submit_message calls so 3 consecutive failures

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -270,7 +270,7 @@ async def _call_model_sync(
     *,
     provider: BaseProvider,
     messages: list[Message],
-    system_prompt: str,
+    system_prompt: str | list[dict[str, Any]],
     tools: Tools,
     max_output_tokens_override: int | None = None,
 ) -> tuple[list[AssistantMessage], list[ToolUseBlock]]:
@@ -942,12 +942,20 @@ async def _query_loop_inner(
                         # No fallback configured — re-raise into outer
                         # exception handler below (Terminal(model_error)).
                         raise
-                    # Tombstone any partial assistant messages from the
-                    # failed attempt so the UI removes them from the
-                    # transcript. Yield orphaned-tool-result blocks so
-                    # the API protocol invariant (every tool_use has a
-                    # tool_result) holds for the partial state we're
-                    # discarding. Mirrors TS at query.ts:978-1005.
+                    # Both blocks below are no-ops in the current
+                    # non-streaming Python loop (``deps.call_model``
+                    # returns the full response or raises; partial
+                    # ``assistant_messages`` is always [] when this
+                    # except fires). They are wired anyway so a future
+                    # streaming-provider port — where the model can
+                    # emit partial tool_use blocks before raising —
+                    # gets protocol-correct behavior for free:
+                    #   1. Orphaned-tool-result blocks pair every
+                    #      tool_use with a tool_result so the next API
+                    #      call doesn't 400 on a half-written turn.
+                    #   2. Tombstones tell the UI to remove the partial
+                    #      messages from the transcript.
+                    # Mirrors TS at query.ts:978-1005.
                     for orphan_msg in _yield_missing_tool_result_blocks(
                         assistant_messages, "Model fallback triggered",
                     ):
@@ -1252,6 +1260,11 @@ async def _query_loop_inner(
                     tool_use_context=tool_use_context,
                     query_source=params.query_source,
                     stop_hook_active=state.stop_hook_active,
+                    # Ch5/C.1 follow-up — thread user/system context through
+                    # to the hook executor so Stop hooks see the same
+                    # per-session context blocks the model received.
+                    user_context=params.user_context,
+                    system_context=params.system_context,
                 ):
                     if isinstance(emitted, StopHookResult):
                         stop_result = emitted

--- a/src/query/stop_hooks.py
+++ b/src/query/stop_hooks.py
@@ -39,7 +39,7 @@ class StopHookResult:
 async def handle_stop_hooks(
     messages_for_query: list[Message],
     assistant_messages: list[AssistantMessage],
-    system_prompt: str,
+    system_prompt: str | list[dict[str, Any]],
     tool_use_context: Any,
     query_source: str,
     stop_hook_active: bool | None = None,
@@ -57,6 +57,8 @@ async def handle_stop_hooks(
         query_source,
         stop_hook_active,
         result,
+        user_context=user_context,
+        system_context=system_context,
     ):
         emitted.append(msg_or_result)
 
@@ -66,10 +68,12 @@ async def handle_stop_hooks(
 async def handle_stop_hooks_streaming(
     messages_for_query: list[Message],
     assistant_messages: list[AssistantMessage],
-    system_prompt: str,
+    system_prompt: str | list[dict[str, Any]],
     tool_use_context: Any,
     query_source: str,
     stop_hook_active: bool | None = None,
+    user_context: dict[str, str] | None = None,
+    system_context: dict[str, str] | None = None,
 ) -> AsyncGenerator[Message | StopHookResult, None]:
     result = StopHookResult()
 
@@ -81,6 +85,8 @@ async def handle_stop_hooks_streaming(
         query_source,
         stop_hook_active,
         result,
+        user_context=user_context,
+        system_context=system_context,
     ):
         yield msg
 
@@ -90,11 +96,13 @@ async def handle_stop_hooks_streaming(
 async def _handle_stop_hooks_generator(
     messages_for_query: list[Message],
     assistant_messages: list[AssistantMessage],
-    system_prompt: str,
+    system_prompt: str | list[dict[str, Any]],
     tool_use_context: Any,
     query_source: str,
     stop_hook_active: bool | None,
     result_out: StopHookResult,
+    user_context: dict[str, str] | None = None,
+    system_context: dict[str, str] | None = None,
 ) -> AsyncGenerator[Message, None]:
     hook_start_time = time.time()
 
@@ -128,6 +136,8 @@ async def _handle_stop_hooks_generator(
             tool_use_context=tool_use_context,
             messages=all_messages,
             agent_type=agent_type,
+            user_context=user_context,
+            system_context=system_context,
         ):
             if hook_result.get("message"):
                 msg = hook_result["message"]

--- a/tests/test_query_stop_hooks.py
+++ b/tests/test_query_stop_hooks.py
@@ -410,5 +410,77 @@ class TestStopHooksDeathSpiralGuards(_StopHooksTestBase):
         self.assertEqual(holder.value.reason, "prompt_too_long")
 
 
+class TestStopHooksContextThreading(_StopHooksTestBase):
+    """C.1 follow-up — user_context and system_context thread all the
+    way to execute_stop_hooks (and into the hook stdin payload)."""
+
+    def test_user_and_system_context_arrive_at_executor(self):
+        """End-to-end: query() forwards user_context/system_context
+        to handle_stop_hooks_streaming → _handle_stop_hooks_generator
+        → execute_stop_hooks. Captured via a patched executor."""
+        from src.providers.base import ChatResponse
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="Done.",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 5},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        captured: dict = {}
+
+        async def fake_execute_stop_hooks(**kw):
+            captured.update(kw)
+            return
+            yield  # make this a generator
+
+        # Patch has_hook_for_event to return True so the executor is
+        # actually reached.
+        async def fake_has_hook_for_event(event, ctx):
+            return True
+
+        params = QueryParams(
+            messages=[UserMessage(content="Hi")],
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=5,
+            user_context={"PROJECT_DOC": "treat all writes as drafts"},
+            system_context={"GIT_STATUS": "M src/foo.py"},
+        )
+        holder = TerminalHolder()
+
+        async def run():
+            with patch(
+                "src.hooks.hook_executor.execute_stop_hooks",
+                side_effect=fake_execute_stop_hooks,
+            ), patch(
+                "src.hooks.hook_executor.has_hook_for_event",
+                return_value=True,
+            ):
+                async for _ in query(params, terminal_holder=holder):
+                    pass
+
+        _run(run())
+
+        self.assertEqual(holder.value.reason, "completed")
+        # The captured kwargs must include both contexts.
+        self.assertIn("user_context", captured)
+        self.assertIn("system_context", captured)
+        self.assertEqual(
+            captured["user_context"],
+            {"PROJECT_DOC": "treat all writes as drafts"},
+        )
+        self.assertEqual(
+            captured["system_context"],
+            {"GIT_STATUS": "M src/foo.py"},
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_query_token_budget.py
+++ b/tests/test_query_token_budget.py
@@ -263,5 +263,116 @@ class TestTokenBudgetContinuation(_Base):
         self.assertEqual(provider.chat.call_count, 1)
 
 
+class TestEngineSubmitMessageStripsBudgetMarker(unittest.TestCase):
+    """D.3 integration — QueryEngine.submit_message strips the +500k
+    marker from the user prompt AND sets task_budget on QueryParams."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.temp_dir.name)
+        self.registry = build_default_registry()
+        self.context = ToolContext(workspace_root=self.workspace)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_engine_strips_plus_marker_and_engages_budget(self):
+        """When the user prompt starts with +500k, the engine strips
+        the marker before storing the user message AND the budget
+        tracker is engaged inside query() (proven by a continuation
+        nudge being injected when output is below the 90% threshold)."""
+        from src.providers.base import ChatResponse
+        from src.query.engine import QueryEngine, QueryEngineConfig
+
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = [
+            ChatResponse(
+                content="Working on it.",
+                model="test",
+                usage={"input_tokens": 10, "output_tokens": 100},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+            ChatResponse(
+                content="Final.",
+                model="test",
+                usage={"input_tokens": 30, "output_tokens": 470_000},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+        ]
+
+        engine = QueryEngine(QueryEngineConfig(
+            cwd=self.workspace,
+            provider=provider,
+            tool_registry=self.registry,
+            tools=self.registry.list_tools(),
+            tool_context=self.context,
+            system_prompt="You are helpful.",
+            max_turns=10,
+        ))
+
+        async def run():
+            async for _ in engine.submit_message(
+                "+500k continue refactoring the auth module",
+            ):
+                pass
+
+        asyncio.run(run())
+
+        # The stored user message must NOT contain "+500k" — the
+        # engine stripped it before append.
+        stored_users = [
+            m for m in engine.get_messages() if isinstance(m, UserMessage)
+        ]
+        self.assertGreaterEqual(len(stored_users), 1)
+        first_user_text = str(stored_users[0].content)
+        self.assertNotIn("+500k", first_user_text)
+        self.assertIn("continue refactoring", first_user_text)
+
+        # Budget engaged → loop continued past turn 1 (100 tokens, under
+        # 90% threshold), then stopped on turn 2 (470k tokens, over).
+        self.assertEqual(provider.chat.call_count, 2)
+        self.assertIsNotNone(engine.last_terminal)
+        self.assertEqual(engine.last_terminal.reason, "completed")
+
+    def test_engine_no_marker_does_not_engage_budget(self):
+        """When the user prompt has no +500k marker, the budget
+        tracker is NOT engaged — the loop exits after the first turn
+        regardless of token count."""
+        from src.providers.base import ChatResponse
+        from src.query.engine import QueryEngine, QueryEngineConfig
+
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="Done.",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 100},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        engine = QueryEngine(QueryEngineConfig(
+            cwd=self.workspace,
+            provider=provider,
+            tool_registry=self.registry,
+            tools=self.registry.list_tools(),
+            tool_context=self.context,
+            system_prompt="You are helpful.",
+            max_turns=10,
+        ))
+
+        async def run():
+            async for _ in engine.submit_message("just do it"):
+                pass
+
+        asyncio.run(run())
+
+        self.assertEqual(provider.chat.call_count, 1)
+        self.assertEqual(engine.last_terminal.reason, "completed")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Threads `user_context` / `system_context` from `query()` all the way through to the hook executor's stdin payload, plus a batch of minor critic items. Stacked on top of PR #104.

**Stop-hooks user/system context threading:**
- Extends `handle_stop_hooks`, `handle_stop_hooks_streaming`, `_handle_stop_hooks_generator` (in `src/query/stop_hooks.py`) and `execute_stop_hooks` (in `src/hooks/hook_executor.py`) to accept `user_context: dict[str, str] | None` and `system_context: dict[str, str] | None`.
- `execute_stop_hooks` lands them on `stdin_data["user_context"]` / `stdin_data["system_context"]` so a hook script can make decisions based on per-session context (CLAUDE.md contents, git status, etc.) — the same context the model sees.
- `query.py` forwards `params.user_context` / `params.system_context` to `handle_stop_hooks_streaming`.

**Minor items:**
- `system_prompt: str` → `str | list[dict[str, Any]]` in `_call_model_sync` and the `handle_stop_hooks*` family (matches `QueryParams.system_prompt`'s actual accepted shapes).
- Cache-token tracking: add `cache_creation_input_tokens` and `cache_read_input_tokens` to `engine._total_usage`. (Adapter-side cache-token tracking ships in PR9.)
- Stale fallback orphan/tombstone comment at `query.py:~915` reworded to clarify the blocks are no-ops in the current non-streaming Python loop (but wired for forward-compat).

Note: the cherry-pick of the original commit dropped its `agent_loop_compat.py` portions (those files don't exist in this stack yet — they ship in PR9 / Phase F).

## Test plan

- [x] New `test_user_and_system_context_arrive_at_executor` in `tests/test_query_stop_hooks.py` (patches `execute_stop_hooks`, captures kwargs, asserts both dicts arrive end-to-end).
- [x] New `test_engine_strips_plus_marker_and_engages_budget` + `test_engine_no_marker_does_not_engage_budget` integration tests in `tests/test_query_token_budget.py` (engine path, asserts stored user message has the `+500k` stripped + the budget engages).
- [x] 17 tests pass in the directly-affected files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)