### PR TITLE
feat(ch05/E.2): provider-side FallbackTriggeredError trigger

### DIFF
--- a/src/query/query.py
+++ b/src/query/query.py
@@ -920,20 +920,49 @@ async def _query_loop_inner(
         from ..services.api.errors import FallbackTriggeredError
         from ..types.messages import TombstoneMessage, create_system_message
 
+        # Ch5/E.2 production trigger — translate provider 529 errors
+        # into FallbackTriggeredError when a fallback provider is
+        # configured. Wrapped here as a small closure so the
+        # while-attempt loop's exception handling stays clean (Python
+        # except clauses don't re-evaluate after one matches, so
+        # mixing the translator and the handler in sibling clauses is
+        # error-prone). Without this, a provider 529 would propagate
+        # out of the inner try as a generic exception → outer handler
+        # → Terminal(model_error), missing the fallback path.
+        async def _call_model_with_fallback_signal():
+            from ..services.api.errors import is_overloaded_error
+            try:
+                return await deps.call_model(
+                    provider=current_provider,
+                    messages=messages,
+                    system_prompt=params.system_prompt,
+                    tools=params.tools,
+                    max_output_tokens_override=max_output_tokens_override,
+                )
+            except FallbackTriggeredError:
+                # Already a fallback signal — let it through unchanged.
+                raise
+            except Exception as e:
+                if (
+                    params.fallback_provider is not None
+                    and is_overloaded_error(e)
+                ):
+                    raise FallbackTriggeredError(
+                        original_model=getattr(current_provider, "model", "?"),
+                        fallback_model=getattr(params.fallback_provider, "model", "?"),
+                    ) from e
+                raise
+
         try:
             while attempt_with_fallback:
                 attempt_with_fallback = False
                 try:
-                    # Ch5/G.2 — route through deps.call_model. The default
-                    # production deps wires this to _call_model_sync; tests
-                    # can pass a fake with the same signature.
-                    returned_assistants, returned_tool_blocks = await deps.call_model(
-                        provider=current_provider,
-                        messages=messages,
-                        system_prompt=params.system_prompt,
-                        tools=params.tools,
-                        max_output_tokens_override=max_output_tokens_override,
-                    )
+                    # Ch5/G.2 — route through deps.call_model (wrapped
+                    # in the fallback-signal closure above). The
+                    # default production deps wires call_model to
+                    # _call_model_sync; tests can pass a fake with
+                    # the same signature.
+                    returned_assistants, returned_tool_blocks = await _call_model_with_fallback_signal()
                     assistant_messages = returned_assistants
                     tool_use_blocks = returned_tool_blocks
                     needs_follow_up = len(tool_use_blocks) > 0

--- a/tests/test_query_fallback_and_nudge.py
+++ b/tests/test_query_fallback_and_nudge.py
@@ -249,6 +249,93 @@ class TestModelFallback(_Base):
 
         self.assertEqual(holder.value.reason, "model_error")
 
+    def test_overloaded_error_translates_to_fallback_when_provider_set(self):
+        """E.2 production trigger: when the primary provider raises an
+        OverloadedError (529) AND a fallback_provider is configured,
+        the loop's _call_model_with_fallback_signal closure translates
+        the 529 into a FallbackTriggeredError, which the existing
+        fallback handler catches and swaps providers for. The user
+        sees a "Switched to ..." system message."""
+        from src.services.api.errors import OverloadedError
+
+        primary = MagicMock()
+        primary.model = "opus-1"
+        primary.chat_stream_response.side_effect = NotImplementedError()
+        primary.chat.side_effect = OverloadedError("529 overloaded")
+
+        fallback = MagicMock()
+        fallback.model = "sonnet-1"
+        fallback.chat_stream_response.side_effect = NotImplementedError()
+        fallback.chat.return_value = ChatResponse(
+            content="OK on fallback.",
+            model="sonnet-1",
+            usage={"input_tokens": 50, "output_tokens": 30},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        params = QueryParams(
+            messages=[UserMessage(content="Long prompt")],
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=primary,
+            abort_controller=self.abort,
+            max_turns=5,
+            fallback_provider=fallback,
+        )
+        holder = TerminalHolder()
+        collected: list = []
+
+        async def run():
+            async for msg in query(params, terminal_holder=holder):
+                collected.append(msg)
+
+        _run(run())
+
+        self.assertEqual(holder.value.reason, "completed")
+        self.assertEqual(primary.chat.call_count, 1)
+        self.assertEqual(fallback.chat.call_count, 1)
+        switch_msgs = [
+            m for m in collected
+            if isinstance(m, SystemMessage)
+            and "Switched to" in str(getattr(m, "content", ""))
+        ]
+        self.assertEqual(len(switch_msgs), 1)
+
+    def test_overloaded_error_no_fallback_propagates(self):
+        """E.2 production trigger negative case: when no fallback_provider
+        is set, an OverloadedError propagates as Terminal(model_error)
+        — the closure does NOT translate it."""
+        from src.services.api.errors import OverloadedError
+
+        primary = MagicMock()
+        primary.model = "opus-1"
+        primary.chat_stream_response.side_effect = NotImplementedError()
+        primary.chat.side_effect = OverloadedError("529 overloaded")
+
+        params = QueryParams(
+            messages=[UserMessage(content="Long prompt")],
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=primary,
+            abort_controller=self.abort,
+            max_turns=5,
+            fallback_provider=None,
+        )
+        holder = TerminalHolder()
+
+        async def run():
+            async for _ in query(params, terminal_holder=holder):
+                pass
+
+        _run(run())
+
+        self.assertEqual(holder.value.reason, "model_error")
+
     def test_fallback_swaps_provider_and_retries(self):
         """E.2: FallbackTriggeredError on the primary provider swaps
         to params.fallback_provider, emits a 'Switched to ...' system


### PR DESCRIPTION
## Summary

Wires the Phase E fallback path so it actually fires in production. Stacked on top of PR #105.

Previously: `FallbackTriggeredError` was a defined exception type with handler logic, but nothing in production ever raised it. The catch path was inert.

Now: a small `_call_model_with_fallback_signal` closure inside the query loop's per-iteration setup wraps `deps.call_model` and translates exceptions:
- `FallbackTriggeredError` → re-raise unchanged.
- Any other Exception that satisfies `is_overloaded_error(e)` AND `params.fallback_provider is not None` → raise `FallbackTriggeredError(original_model=current.model, fallback_model=fallback.model) from e`.
- All other exceptions → re-raise unchanged.

The existing E.2 handler then swaps providers and retries. No provider changes required.

The closure approach is deliberate: chaining `except FallbackTriggeredError` and `except Exception` as siblings is error-prone (Python doesn't re-evaluate sibling except clauses after one matches). Encapsulating the translation in a closure keeps the existing handler clean.

## Test plan

- [x] 2 new acceptance tests in `tests/test_query_fallback_and_nudge.py`:
  - `test_overloaded_error_translates_to_fallback_when_provider_set`: primary raises OverloadedError, fallback configured → Terminal(completed), fallback.chat called, "Switched to ..." system message yielded.
  - `test_overloaded_error_no_fallback_propagates`: primary raises OverloadedError, `fallback_provider=None` → Terminal(model_error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)