### PR TITLE
feat(ch02): consume keychain + MDM prefetches in init()

### DIFF
--- a/src/init.py
+++ b/src/init.py
@@ -32,8 +32,16 @@ from functools import cache
 
 from src.permissions.trust_boundary import (
     apply_safe_config_environment_variables,
+    extract_mdm_safe_env,
+)
+from src.prefetch import (
+    get_or_start_keychain_prefetch,
+    get_or_start_mdm_raw_read,
+    wait_and_read_keychain,
+    wait_and_read_mdm,
 )
 from src.utils.api_preconnect import start_api_preconnect
+from src.utils.keychain_stash import stash_keychain_credentials
 from src.utils.graceful_shutdown import (
     register_cleanup,  # noqa: F401 — exposed for callers to register cleanups
     setup_graceful_shutdown,
@@ -65,8 +73,22 @@ def init() -> None:
     to mark the seam where future work plugs in.
     """
     profile_checkpoint("init_function_start")
+
+    # ch02 round-2 PR-1 (G1): consume the keychain + MDM prefetches that
+    # ``src/cli.py`` fires at module import. The Popens are already
+    # running; ``wait_and_read_*`` blocks for at most the supplied
+    # timeout. Both helpers return ``None`` on any failure — silent
+    # degrade is intentional (TS behavior).
+    _logger.info("init: consuming keychain + MDM prefetches")
+    stash_keychain_credentials(
+        wait_and_read_keychain(get_or_start_keychain_prefetch(), timeout=5.0)
+    )
+    mdm_payload = wait_and_read_mdm(get_or_start_mdm_raw_read(), timeout=2.0)
+    mdm_safe_env = extract_mdm_safe_env(mdm_payload)
+    profile_checkpoint("init_after_prefetch_consumption")
+
     _logger.info("init: applying safe env vars")
-    apply_safe_config_environment_variables()
+    apply_safe_config_environment_variables(extra_env=mdm_safe_env)
     profile_checkpoint("init_safe_env_vars_applied")
 
     _logger.info("init: setting up graceful shutdown")

--- a/src/permissions/trust_boundary.py
+++ b/src/permissions/trust_boundary.py
@@ -30,6 +30,7 @@ __all__ = [
     "is_safe_env_key",
     "apply_safe_config_environment_variables",
     "apply_full_config_environment_variables",
+    "extract_mdm_safe_env",
 ]
 
 
@@ -186,6 +187,7 @@ def is_safe_env_key(key: str) -> bool:
 
 def apply_safe_config_environment_variables(
     config_env: Mapping[str, str] | None = None,
+    extra_env: Mapping[str, str] | None = None,
 ) -> None:
     """Apply only the safe subset of config.env to os.environ.
 
@@ -194,7 +196,18 @@ def apply_safe_config_environment_variables(
     NOT overwrite pre-existing process env (matches TS behavior at
     managedEnv.ts:60-65 which checks ``process.env[key] === undefined``
     before writing).
+
+    ``extra_env`` carries managed-config (MDM) values; ch02 round-2 PR-1
+    (G1) consumes the MDM prefetch this way. Order matters: MDM values
+    apply FIRST (lowest precedence — they are defaults), then config-file
+    values via ``setdefault`` so any prior environment OR earlier MDM
+    value wins over a later config-file write. This matches TS where the
+    union is built before any single application.
     """
+    if extra_env:
+        for key, value in extra_env.items():
+            if is_safe_env_key(key):
+                os.environ.setdefault(key, value)
     if config_env is None:
         config_env = _load_config_env()
     for key, value in config_env.items():
@@ -215,6 +228,38 @@ def apply_full_config_environment_variables(
         config_env = _load_config_env()
     for key, value in config_env.items():
         os.environ[key] = value  # full apply: overwrites
+
+
+def extract_mdm_safe_env(payload: str | None) -> dict[str, str]:
+    """Parse an MDM plist-as-JSON payload and return the safe env subset.
+
+    ``payload`` is the stdout from ``plutil -convert json -o -
+    /Library/Managed Preferences/com.anthropic.claude-code.plist`` (see
+    ``src/prefetch.py:start_mdm_raw_read``). Failure modes (None, empty,
+    malformed JSON, missing ``env`` key, non-dict ``env``) all silently
+    return ``{}`` — init() must never raise due to MDM failures.
+
+    Only keys passing ``is_safe_env_key`` survive; values are coerced
+    to strings (matching the env-var contract).
+    """
+    if not payload:
+        return {}
+    import json
+
+    try:
+        parsed = json.loads(payload)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    env = parsed.get("env")
+    if not isinstance(env, dict):
+        return {}
+    return {
+        str(k): str(v)
+        for k, v in env.items()
+        if v is not None and is_safe_env_key(str(k))
+    }
 
 
 def _load_config_env() -> dict[str, str]:

--- a/src/utils/keychain_stash.py
+++ b/src/utils/keychain_stash.py
@@ -1,0 +1,57 @@
+"""In-memory stash for the keychain prefetch result.
+
+Chapter 2 round-2 PR-1 (G1): the keychain prefetch fires at module
+import (`src/cli.py:22-31`) but the result was never consumed. This
+module gives `init()` somewhere to park the value so the auth/OAuth
+layer can pick it up lazily without re-shelling-out to ``security``.
+
+The stash is module-private state; first non-None set wins (idempotent
+under the memoized ``init()``). On platforms where the prefetch yields
+``None`` (non-macOS, ``security`` unavailable), readers see ``None`` and
+fall back to interactive credential resolution — same posture as TS.
+
+See:
+  - ``claude-code-from-source/book/ch02-bootstrap.md`` §"Phase 1"
+  - ``my-docs/ch02-bootstrap-gap-analysis.md`` §G1
+  - ``my-docs/ch02-bootstrap-refactoring-plan.md`` W1.2
+"""
+
+from __future__ import annotations
+
+import os
+
+__all__ = [
+    "stash_keychain_credentials",
+    "read_stashed_keychain",
+    "reset_stashed_keychain_for_test_only",
+]
+
+
+_KEYCHAIN_VALUE: str | None = None
+
+
+def stash_keychain_credentials(value: str | None) -> None:
+    """Park a keychain prefetch result for later consumers.
+
+    First non-``None`` value wins. Subsequent calls are silent no-ops
+    so that the memoized ``init()`` can call this from multiple entry
+    points without clobbering an earlier successful read.
+    """
+    global _KEYCHAIN_VALUE
+    if _KEYCHAIN_VALUE is None and value is not None:
+        _KEYCHAIN_VALUE = value
+
+
+def read_stashed_keychain() -> str | None:
+    """Return the stashed keychain value, or ``None`` if unset."""
+    return _KEYCHAIN_VALUE
+
+
+def reset_stashed_keychain_for_test_only() -> None:
+    """Reset the stash. Test-only — gated by ``PYTEST_CURRENT_TEST``."""
+    if os.environ.get("PYTEST_CURRENT_TEST") is None:
+        raise RuntimeError(
+            "reset_stashed_keychain_for_test_only can only be called in tests"
+        )
+    global _KEYCHAIN_VALUE
+    _KEYCHAIN_VALUE = None

--- a/tests/test_init_prefetch_consumption.py
+++ b/tests/test_init_prefetch_consumption.py
@@ -1,0 +1,253 @@
+"""Tests for ch02 round-2 PR-1 (G1): init() consumes prefetch results.
+
+Covers:
+- MDM payload parsing (extract_mdm_safe_env) — safe vs unsafe keys,
+  malformed inputs, missing fields, None / empty.
+- Keychain stash semantics — set/read, idempotence, None handling.
+- init() integration — MDM payload threaded into
+  apply_safe_config_environment_variables(extra_env=...).
+- Precedence — config-file values still win over MDM extras (setdefault).
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from src.init import init, reset_init_for_test_only
+from src.permissions.trust_boundary import (
+    apply_safe_config_environment_variables,
+    extract_mdm_safe_env,
+)
+from src.utils.keychain_stash import (
+    read_stashed_keychain,
+    reset_stashed_keychain_for_test_only,
+    stash_keychain_credentials,
+)
+
+
+_SAFE_KEY = "ANTHROPIC_MODEL"
+_UNSAFE_KEY = "ANTHROPIC_API_KEY"
+
+
+class ExtractMdmSafeEnvTests(unittest.TestCase):
+    def test_filters_to_safe_keys_only(self) -> None:
+        payload = (
+            '{"env": {"' + _SAFE_KEY + '": "claude-opus-4-7", '
+            '"' + _UNSAFE_KEY + '": "sk-secret"}}'
+        )
+        result = extract_mdm_safe_env(payload)
+        self.assertEqual(result, {_SAFE_KEY: "claude-opus-4-7"})
+
+    def test_returns_empty_dict_for_none_payload(self) -> None:
+        self.assertEqual(extract_mdm_safe_env(None), {})
+
+    def test_returns_empty_dict_for_empty_payload(self) -> None:
+        self.assertEqual(extract_mdm_safe_env(""), {})
+
+    def test_returns_empty_dict_for_malformed_json(self) -> None:
+        self.assertEqual(extract_mdm_safe_env('{not valid json'), {})
+
+    def test_returns_empty_dict_for_missing_env_key(self) -> None:
+        self.assertEqual(extract_mdm_safe_env('{"other": 1}'), {})
+
+    def test_returns_empty_dict_for_non_dict_env(self) -> None:
+        self.assertEqual(extract_mdm_safe_env('{"env": "not a dict"}'), {})
+
+    def test_returns_empty_dict_for_non_dict_root(self) -> None:
+        self.assertEqual(extract_mdm_safe_env('["a", "b"]'), {})
+
+    def test_skips_none_values(self) -> None:
+        payload = '{"env": {"' + _SAFE_KEY + '": null}}'
+        self.assertEqual(extract_mdm_safe_env(payload), {})
+
+    def test_coerces_non_string_values(self) -> None:
+        payload = '{"env": {"' + _SAFE_KEY + '": 42}}'
+        self.assertEqual(extract_mdm_safe_env(payload), {_SAFE_KEY: "42"})
+
+
+class KeychainStashTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_stashed_keychain_for_test_only()
+
+    def tearDown(self) -> None:
+        reset_stashed_keychain_for_test_only()
+
+    def test_set_and_read(self) -> None:
+        stash_keychain_credentials("secret-token")
+        self.assertEqual(read_stashed_keychain(), "secret-token")
+
+    def test_none_initial_state(self) -> None:
+        self.assertIsNone(read_stashed_keychain())
+
+    def test_idempotent_first_wins(self) -> None:
+        stash_keychain_credentials("first")
+        stash_keychain_credentials("second")
+        self.assertEqual(read_stashed_keychain(), "first")
+
+    def test_none_stash_leaves_state_unchanged(self) -> None:
+        stash_keychain_credentials("token")
+        stash_keychain_credentials(None)
+        self.assertEqual(read_stashed_keychain(), "token")
+
+    def test_none_stash_on_empty_state_stays_none(self) -> None:
+        stash_keychain_credentials(None)
+        self.assertIsNone(read_stashed_keychain())
+
+
+class ApplySafeEnvExtraTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original = os.environ.get(_SAFE_KEY)
+        os.environ.pop(_SAFE_KEY, None)
+
+    def tearDown(self) -> None:
+        if self._original is None:
+            os.environ.pop(_SAFE_KEY, None)
+        else:
+            os.environ[_SAFE_KEY] = self._original
+
+    def test_extra_env_applies_safe_keys(self) -> None:
+        apply_safe_config_environment_variables(
+            config_env={}, extra_env={_SAFE_KEY: "from-mdm"}
+        )
+        self.assertEqual(os.environ.get(_SAFE_KEY), "from-mdm")
+
+    def test_extra_env_ignores_unsafe_keys(self) -> None:
+        apply_safe_config_environment_variables(
+            config_env={},
+            extra_env={_UNSAFE_KEY: "sk-leaked"},
+        )
+        self.assertIsNone(os.environ.get(_UNSAFE_KEY))
+
+    def test_extra_env_loses_to_existing_environ(self) -> None:
+        os.environ[_SAFE_KEY] = "from-env"
+        apply_safe_config_environment_variables(
+            config_env={}, extra_env={_SAFE_KEY: "from-mdm"}
+        )
+        # setdefault: pre-existing wins
+        self.assertEqual(os.environ.get(_SAFE_KEY), "from-env")
+
+    def test_config_env_overrides_extra_env_via_setdefault_ordering(self) -> None:
+        # extra_env applies FIRST via setdefault, then config_env via
+        # setdefault. So if both target the same key with no pre-existing
+        # env, extra_env wins (first writer to setdefault).
+        apply_safe_config_environment_variables(
+            config_env={_SAFE_KEY: "from-config"},
+            extra_env={_SAFE_KEY: "from-mdm"},
+        )
+        self.assertEqual(os.environ.get(_SAFE_KEY), "from-mdm")
+
+
+class InitConsumesPrefetchesTests(unittest.TestCase):
+    """Integration: init() pulls keychain + MDM through to env application."""
+
+    def setUp(self) -> None:
+        reset_init_for_test_only()
+        reset_stashed_keychain_for_test_only()
+        self._original_safe = os.environ.get(_SAFE_KEY)
+        os.environ.pop(_SAFE_KEY, None)
+
+    def tearDown(self) -> None:
+        reset_init_for_test_only()
+        reset_stashed_keychain_for_test_only()
+        if self._original_safe is None:
+            os.environ.pop(_SAFE_KEY, None)
+        else:
+            os.environ[_SAFE_KEY] = self._original_safe
+
+    def _patch_prefetches(
+        self,
+        keychain_value: str | None,
+        mdm_payload: str | None,
+    ):
+        # Patch the symbols where init.py imported them — not at source.
+        keychain_patch = mock.patch(
+            "src.init.wait_and_read_keychain", return_value=keychain_value
+        )
+        mdm_patch = mock.patch(
+            "src.init.wait_and_read_mdm", return_value=mdm_payload
+        )
+        # Avoid spawning real Popens during the test.
+        ks_patch = mock.patch(
+            "src.init.get_or_start_keychain_prefetch",
+            return_value=mock.MagicMock(),
+        )
+        ms_patch = mock.patch(
+            "src.init.get_or_start_mdm_raw_read",
+            return_value=mock.MagicMock(),
+        )
+        # Avoid network preconnect during the test.
+        preconnect_patch = mock.patch("src.init.start_api_preconnect")
+        # Don't touch signal handlers.
+        shutdown_patch = mock.patch("src.init.setup_graceful_shutdown")
+        return (
+            keychain_patch,
+            mdm_patch,
+            ks_patch,
+            ms_patch,
+            preconnect_patch,
+            shutdown_patch,
+        )
+
+    def test_init_stashes_keychain_value(self) -> None:
+        patches = self._patch_prefetches(
+            keychain_value="kc-token",
+            mdm_payload=None,
+        )
+        try:
+            for p in patches:
+                p.start()
+            init()
+            self.assertEqual(read_stashed_keychain(), "kc-token")
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_init_applies_mdm_safe_env(self) -> None:
+        payload = '{"env": {"' + _SAFE_KEY + '": "mdm-claude"}}'
+        patches = self._patch_prefetches(
+            keychain_value=None,
+            mdm_payload=payload,
+        )
+        try:
+            for p in patches:
+                p.start()
+            init()
+            self.assertEqual(os.environ.get(_SAFE_KEY), "mdm-claude")
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_init_handles_both_none_silently(self) -> None:
+        patches = self._patch_prefetches(
+            keychain_value=None,
+            mdm_payload=None,
+        )
+        try:
+            for p in patches:
+                p.start()
+            init()  # must not raise
+            self.assertIsNone(read_stashed_keychain())
+            self.assertIsNone(os.environ.get(_SAFE_KEY))
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_init_handles_malformed_mdm_silently(self) -> None:
+        patches = self._patch_prefetches(
+            keychain_value=None,
+            mdm_payload="{not valid json",
+        )
+        try:
+            for p in patches:
+                p.start()
+            init()  # must not raise
+            self.assertIsNone(os.environ.get(_SAFE_KEY))
+        finally:
+            for p in patches:
+                p.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Round-2 PR-1 for ch02 bootstrap (gap **G1**): keychain + MDM prefetch subprocesses already fire at module import via `src/cli.py`, but `wait_and_read_keychain` / `wait_and_read_mdm` had zero production callers. Result was thrown away on atexit.
- Wires consumption through `init()`: keychain value stashed for the auth layer; MDM safe-key subset threaded into `apply_safe_config_environment_variables(extra_env=...)`.
- Silent degrade on every failure mode (None payload, malformed JSON, missing fields, non-dict env, timeout). `init()` never raises from MDM/keychain failures.

## What changed

- `src/utils/keychain_stash.py` (new): module-private parking spot, first-non-None-wins.
- `src/permissions/trust_boundary.py`:
  - `apply_safe_config_environment_variables` gains `extra_env` kwarg.
  - `extract_mdm_safe_env(payload)` parses plist-as-JSON, returns safe subset.
- `src/init.py`: reads both prefetches, threads through; adds `init_after_prefetch_consumption` profiler checkpoint.
- `tests/test_init_prefetch_consumption.py` (new, 22 tests).

Backed by:
- `my-docs/ch02-bootstrap-gap-analysis.md`
- `my-docs/ch02-bootstrap-refactoring-plan.md`

Critic agent: APPROVE-WITH-NITS (precedence note flagged as plan-level decision; ship it).

## Test plan

- [x] `pytest tests/test_init_prefetch_consumption.py` — 22/22 pass
- [x] `pytest tests/test_init.py tests/test_prefetch.py tests/test_trust_boundary.py` — 47 pass, no regression
- [x] `pytest tests/test_porting_workspace.py tests/test_no_top_level_decoys.py` — 61 pass
- [x] `python -m src.cli --help` — production CLI unchanged
- [x] Pre-existing failures (zhipuai SDK version, python-not-in-PATH) confirmed unrelated

## Out of scope (deferred)

- **G2**: post-render deferred prefetch lane (git status, model capabilities, system context).
- **G3**: trust-boundary plumbing — replace hard-coded `set_session_trust_accepted(True)`.
- **G4**: Phase 3 setup split between init and launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)