### PR TITLE
feat(ch03/round2): wire resume → bootstrap (cost block + Session.resume)

### DIFF
--- a/src/agent/session.py
+++ b/src/agent/session.py
@@ -15,12 +15,23 @@ to reconstruct the per-conversation Persistence record.
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 from datetime import datetime
 from typing import Optional
 from dataclasses import dataclass, field
 
-from src.bootstrap.state import get_session_id
+from src.bootstrap.state import (
+    get_model_usage,
+    get_session_id,
+    get_start_time,
+    get_total_api_duration,
+    get_total_api_duration_without_retries,
+    get_total_cost_usd,
+    get_total_lines_added,
+    get_total_lines_removed,
+    get_total_tool_duration,
+)
 
 from .conversation import Conversation
 
@@ -36,11 +47,21 @@ class Session:
     updated_at: str = field(default_factory=lambda: datetime.now().isoformat())
 
     def save(self):
-        """Save session to disk."""
+        """Save session to disk including a cost block.
+
+        Ch03 round-2 (R2.1): the ``cost`` key matches the schema read by
+        ``src/services/cost_restore.py:restore_cost_state_for_session``
+        so a save → load round-trip restores bootstrap counters
+        (`total_cost_usd`, durations, lines added/removed, per-model
+        usage). Previously this method emitted no cost block; the
+        restore reader hit defaults of 0 unconditionally.
+        """
         session_dir = Path.home() / ".clawcodex" / "sessions"
         session_dir.mkdir(parents=True, exist_ok=True)
 
         session_file = session_dir / f"{self.session_id}.json"
+
+        cost_block = _snapshot_cost_block()
 
         session_data = {
             "session_id": self.session_id,
@@ -48,7 +69,8 @@ class Session:
             "model": self.model,
             "conversation": self.conversation.to_dict(),
             "created_at": self.created_at,
-            "updated_at": datetime.now().isoformat()
+            "updated_at": datetime.now().isoformat(),
+            "cost": cost_block,
         }
 
         with open(session_file, 'w') as f:
@@ -92,3 +114,61 @@ class Session:
             provider=provider,
             model=model,
         )
+
+    @classmethod
+    def resume(cls, session_id: str) -> Optional['Session']:
+        """Resume a session: update bootstrap identity, restore cost,
+        reconstruct the per-conversation record from disk.
+
+        Ch03 round-2 (R2.2): single entry point that keeps the three
+        operations in lockstep (CC-34 single-setter discipline at the
+        resume layer). Callers (REPL ``/resume``, headless / SDK)
+        should use this rather than calling ``Session.load`` plus
+        ``switch_session`` plus ``restore_cost_state_for_session``
+        independently.
+
+        Order matters: ``switch_session`` fires BEFORE
+        ``restore_cost_state_for_session`` so any subscriber that reads
+        ``get_session_id()`` during the cost restore sees the loaded id.
+        """
+        from src.bootstrap.state import SessionId, switch_session
+        from src.services.cost_restore import restore_cost_state_for_session
+
+        loaded = cls.load(session_id)
+        if loaded is None:
+            return None
+        switch_session(SessionId(session_id))
+        restore_cost_state_for_session(session_id)
+        return loaded
+
+
+def _snapshot_cost_block() -> dict:
+    """Build the cost block written by ``Session.save``.
+
+    Shape matches the reader at
+    ``src/services/cost_restore.py:restore_cost_state_for_session``.
+    Module-private; tests can call via the public ``Session.save``.
+    """
+    return {
+        "total_cost_usd": get_total_cost_usd(),
+        "total_api_duration": get_total_api_duration(),
+        "total_api_duration_without_retries":
+            get_total_api_duration_without_retries(),
+        "total_tool_duration": get_total_tool_duration(),
+        "total_lines_added": get_total_lines_added(),
+        "total_lines_removed": get_total_lines_removed(),
+        # last_duration = elapsed since start_time. cost_restore uses
+        # this to back-date the new session's start_time so post-resume
+        # duration accumulators continue from where they left off.
+        "last_duration": time.time() - get_start_time(),
+        "model_usage": {
+            model: {
+                "input_tokens": u.input_tokens,
+                "output_tokens": u.output_tokens,
+                "cache_creation_input_tokens": u.cache_creation_input_tokens,
+                "cache_read_input_tokens": u.cache_read_input_tokens,
+                "cost_usd": u.cost_usd,
+            }
+            for model, u in get_model_usage().items()
+        },
+    }

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -2700,21 +2700,33 @@ class ClawcodexREPL:
     def load_session(self, session_id: str):
         """Load a previous session.
 
+        Ch03 round-2 (R2.2): delegates to ``Session.resume`` so the
+        bootstrap singleton's session id and cost counters are updated
+        in lockstep with the on-disk reconstruction. Without this
+        wiring the loaded conversation persists under the loaded id
+        but every bootstrap reader still sees the bootstrap-generated
+        UUID, and ``total_cost_usd`` restarts at 0.
+
         Args:
             session_id: Session ID to load
         """
         from src.agent import Session
+        from src.bootstrap.state import get_total_cost_usd
 
-        loaded_session = Session.load(session_id)
+        loaded_session = Session.resume(session_id)
         if loaded_session is None:
             self.console.print(f"[red]Session not found: {session_id}[/red]")
             return
 
-        # Replace current session
+        # Replace current session (bootstrap id + cost already restored
+        # by Session.resume).
         self.session = loaded_session
         self.console.print(f"[green]Session loaded: {session_id}[/green]")
         self.console.print(f"[dim]Provider: {loaded_session.provider}, Model: {loaded_session.model}[/dim]")
         self.console.print(f"[dim]Messages: {len(loaded_session.conversation.messages)}[/dim]")
+        restored_cost = get_total_cost_usd()
+        if restored_cost > 0:
+            self.console.print(f"[dim]Restored cost: ${restored_cost:.4f}[/dim]")
 
         # Show conversation history
         if loaded_session.conversation.messages:

--- a/tests/test_session_cost_persistence.py
+++ b/tests/test_session_cost_persistence.py
@@ -1,0 +1,137 @@
+"""Tests for ch03 round-2 R2.1: Session.save persists a cost block
+matching the cost_restore reader schema, and Session.resume restores it.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from src.agent.session import Session
+from src.agent.conversation import Conversation
+from src.bootstrap.state import (
+    ModelUsage,
+    add_to_tool_duration,
+    add_to_total_cost_state,
+    add_to_total_duration_state,
+    add_to_total_lines_changed,
+    get_total_cost_usd,
+    get_total_lines_added,
+    get_total_lines_removed,
+    get_total_tool_duration,
+    reset_state_for_tests,
+)
+
+
+class _SessionDirFixture:
+    """Helper: redirect ~/.clawcodex to a tmpdir via Path.home patching."""
+
+    def __init__(self, tmp_home: Path) -> None:
+        self.tmp_home = tmp_home
+        self._patch = mock.patch.object(Path, "home", return_value=tmp_home)
+
+    def __enter__(self):
+        self._patch.start()
+        return self
+
+    def __exit__(self, *args):
+        self._patch.stop()
+
+
+class SaveCostBlockTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_state_for_tests()
+        self.tmpdir = Path(self._mk_tmpdir())
+        self._fixture = _SessionDirFixture(self.tmpdir).__enter__()
+
+    def tearDown(self) -> None:
+        self._fixture.__exit__(None, None, None)
+        reset_state_for_tests()
+
+    def _mk_tmpdir(self) -> str:
+        import tempfile
+        return tempfile.mkdtemp(prefix="ch03-r2-")
+
+    def _read_saved(self, sid: str) -> dict:
+        path = self.tmpdir / ".clawcodex" / "sessions" / f"{sid}.json"
+        return json.loads(path.read_text())
+
+    def test_save_emits_cost_block_with_current_state(self) -> None:
+        # Prime bootstrap state.
+        usage = ModelUsage(
+            input_tokens=100,
+            output_tokens=50,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+            cost_usd=0.0123,
+        )
+        add_to_total_cost_state(0.0123, usage, "claude-opus-4-7")
+        add_to_total_duration_state(2500, 2000)
+        add_to_tool_duration(1500)
+        add_to_total_lines_changed(10, 5)
+
+        sess = Session.create("anthropic", "claude-opus-4-7")
+        sess.save()
+
+        data = self._read_saved(sess.session_id)
+        cost = data.get("cost")
+        self.assertIsNotNone(cost, "save() must emit a 'cost' key")
+        self.assertAlmostEqual(cost["total_cost_usd"], 0.0123, places=6)
+        self.assertEqual(cost["total_api_duration"], 2500)
+        self.assertEqual(cost["total_api_duration_without_retries"], 2000)
+        self.assertEqual(cost["total_tool_duration"], 1500)
+        self.assertEqual(cost["total_lines_added"], 10)
+        self.assertEqual(cost["total_lines_removed"], 5)
+        self.assertIn("last_duration", cost)
+        self.assertIn("model_usage", cost)
+        mu = cost["model_usage"]
+        self.assertIn("claude-opus-4-7", mu)
+        self.assertEqual(mu["claude-opus-4-7"]["input_tokens"], 100)
+        self.assertEqual(mu["claude-opus-4-7"]["output_tokens"], 50)
+        self.assertAlmostEqual(
+            mu["claude-opus-4-7"]["cost_usd"], 0.0123, places=6
+        )
+
+    def test_save_emits_empty_model_usage_when_no_usage_recorded(self) -> None:
+        sess = Session.create("anthropic", "claude-opus-4-7")
+        sess.save()
+
+        cost = self._read_saved(sess.session_id)["cost"]
+        self.assertEqual(cost["model_usage"], {})
+        self.assertEqual(cost["total_cost_usd"], 0.0)
+        self.assertEqual(cost["total_lines_added"], 0)
+
+    def test_save_then_resume_round_trip(self) -> None:
+        usage = ModelUsage(
+            input_tokens=200,
+            output_tokens=80,
+            cache_creation_input_tokens=10,
+            cache_read_input_tokens=20,
+            cost_usd=0.05,
+        )
+        add_to_total_cost_state(0.05, usage, "claude-sonnet-4-6")
+        add_to_total_duration_state(5000, 4500)
+        add_to_tool_duration(2000)
+        add_to_total_lines_changed(42, 8)
+
+        sess = Session.create("anthropic", "claude-sonnet-4-6")
+        sess.save()
+        sid = sess.session_id
+
+        # Wipe bootstrap state — simulates a process restart.
+        reset_state_for_tests()
+        self.assertEqual(get_total_cost_usd(), 0.0)
+        self.assertEqual(get_total_lines_added(), 0)
+
+        resumed = Session.resume(sid)
+        self.assertIsNotNone(resumed)
+        self.assertAlmostEqual(get_total_cost_usd(), 0.05, places=6)
+        self.assertEqual(get_total_lines_added(), 42)
+        self.assertEqual(get_total_lines_removed(), 8)
+        self.assertEqual(get_total_tool_duration(), 2000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Closes two reciprocal gaps that left round-1's resume plumbing inert.
- **R2.1**: `Session.save` now persists a `cost` block matching the schema read by `src/services/cost_restore.py` (was: missing entirely → restore always defaulted to 0).
- **R2.2**: `Session.resume(sid)` (new classmethod) combines the three lockstep ops — `switch_session` → `restore_cost_state_for_session` → `Session.load` — into a single CC-34-style entry point. `ClawcodexREPL.load_session` delegates to it.

## What changed

- `src/agent/session.py`: `Session.save` emits `cost` block; `Session.resume(sid)` classmethod added; new `_snapshot_cost_block()` helper.
- `src/repl/core.py:load_session`: routes through `Session.resume`; surfaces restored cost in welcome banner.
- `tests/test_session_cost_persistence.py` (new, 3 tests).

Backed by `my-docs/ch03-state-round2-gap-analysis.md` + `my-docs/ch03-state-round2-plan.md`.

## Test plan

- [x] New tests: 3/3 pass
- [x] Adjacent: `test_cost_tracker*`, `test_session_resume`, `test_resume_agent`, `test_session_migration`, `test_session_memory_compact` — 76/76 pass
- [x] Prior chapters (ch01 porting workspace, ch02 init prefetch): 83/83 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)