### PR TITLE
feat(ch04/round2): add message-level cache_control breakpoints

### DIFF
--- a/src/services/api/__init__.py
+++ b/src/services/api/__init__.py
@@ -1,4 +1,4 @@
-from .claude import StreamEvent, call_model, tool_to_api_schema
+from .claude import StreamEvent, add_cache_breakpoints, call_model, tool_to_api_schema
 from .errors import (
     FallbackTriggeredError,
     MaxOutputTokensError,
@@ -24,6 +24,7 @@ __all__ = [
     "RetryContext",
     "StreamEvent",
     "accumulate_usage",
+    "add_cache_breakpoints",
     "call_model",
     "categorize_retryable_api_error",
     "normalize_tool_arguments",

--- a/src/services/api/claude.py
+++ b/src/services/api/claude.py
@@ -131,6 +131,109 @@ def _build_tool_schemas(tools: list[Any]) -> list[dict[str, Any]]:
     return [tool_to_api_schema(t) for t in tools]
 
 
+def add_cache_breakpoints(
+    messages: list[dict[str, Any]],
+    *,
+    enable_prompt_caching: bool = True,
+    skip_cache_write: bool = False,
+) -> list[dict[str, Any]]:
+    """Place exactly one ``cache_control`` marker on the last message.
+
+    Mirrors the load-bearing invariant of TS ``addCacheBreakpoints``
+    (``services/api/claude.ts:3107``): one and only one ``cache_control``
+    marker per request, attached to the last block of the marker message.
+    Two markers would extend a doomed cache prefix by one turn and waste
+    storage on mycro's KVCC; zero markers leave every multi-turn
+    conversation re-billing its history at full rate.
+
+    The marker lands on the last message by default. When ``skip_cache_write``
+    is True it shifts to the second-to-last message — the fire-and-forget
+    fork pattern from TS line 3127-3132. With fewer than two messages and
+    ``skip_cache_write=True`` the call is a graceful no-op (no negative
+    indexing).
+
+    The mycro-internal ``useCachedMC`` / ``cache_edits`` / ``cache_reference``
+    machinery from TS is intentionally omitted — those are backend-specific
+    features with no public API contract.
+
+    The function never mutates its input. The marker message is shallow-
+    cloned, its content list is shallow-cloned, and the final block is
+    shallow-cloned before ``cache_control`` is attached. Earlier messages
+    and earlier blocks in the marker message are passed through by
+    reference so the cost is O(1) extra allocations regardless of history
+    length.
+
+    Args:
+        messages: API-shape message list (each ``{"role": ..., "content": ...}``).
+        enable_prompt_caching: When False, returns ``messages`` unchanged
+            (round-1 follow-up: model-aware disable lives elsewhere; this
+            is the request-level kill switch).
+        skip_cache_write: When True, place the marker on the SECOND-to-last
+            message.
+
+    Returns:
+        A new list with at most one message shallow-cloned. The marker is a
+        plain ``{"type": "ephemeral"}`` dict — TTL/scope upgrades happen on
+        the system-prompt array, not at the message level.
+    """
+    if not enable_prompt_caching:
+        return messages
+    if not messages:
+        return list(messages)
+
+    marker_index = len(messages) - 2 if skip_cache_write else len(messages) - 1
+    if marker_index < 0:
+        # skip_cache_write with one message — graceful no-op.
+        return list(messages)
+
+    out: list[dict[str, Any]] = list(messages)
+    msg = out[marker_index]
+    content = msg.get("content")
+    cache_control = {"type": "ephemeral"}
+
+    if isinstance(content, str):
+        new_content: list[dict[str, Any]] = [
+            {"type": "text", "text": content, "cache_control": cache_control}
+        ]
+    elif isinstance(content, list):
+        if not content:
+            # Empty block list — wrap an empty text block so the marker
+            # has somewhere to live. Matches TS, which always emits at
+            # least one block for the marker message.
+            new_content = [
+                {"type": "text", "text": "", "cache_control": cache_control}
+            ]
+        else:
+            new_content = list(content[:-1])
+            last_block = content[-1]
+            if isinstance(last_block, dict):
+                cloned_block = dict(last_block)
+                cloned_block["cache_control"] = cache_control
+            else:
+                cloned_block = {
+                    "type": "text",
+                    "text": str(last_block),
+                    "cache_control": cache_control,
+                }
+            new_content.append(cloned_block)
+    else:
+        # Unknown content shape (None, int, ...). Coerce to a single text
+        # block so we still emit a marker. This matches TS's "always wrap"
+        # behaviour for stringy content.
+        new_content = [
+            {
+                "type": "text",
+                "text": "" if content is None else str(content),
+                "cache_control": cache_control,
+            }
+        ]
+
+    cloned_msg = dict(msg)
+    cloned_msg["content"] = new_content
+    out[marker_index] = cloned_msg
+    return out
+
+
 @dataclass
 class CallModelOptions:
     model: str = "claude-sonnet-4-6"
@@ -145,6 +248,11 @@ class CallModelOptions:
     structured_output: dict[str, Any] | None = None
     extra_headers: dict[str, str] | None = None
     extra_body: dict[str, Any] | None = None
+    # Round-2 (ch04): message-level prompt caching.
+    # Mirrors TS ``enablePromptCaching`` / ``skipCacheWrite`` args to
+    # ``addCacheBreakpoints``. Default True matches TS production default.
+    enable_prompt_caching: bool = True
+    skip_cache_write: bool = False
 
 
 async def call_model(
@@ -169,10 +277,20 @@ async def call_model(
         system_blocks = _build_system_blocks(opts.system_prompt)
         tool_schemas = _build_tool_schemas(opts.tools)
 
+        # Round-2 (ch04): attach one message-level cache_control marker so
+        # multi-turn conversations benefit from server-side ephemeral
+        # prompt caching. See ``add_cache_breakpoints`` docstring for the
+        # invariant being maintained.
+        api_messages = add_cache_breakpoints(
+            messages,
+            enable_prompt_caching=opts.enable_prompt_caching,
+            skip_cache_write=opts.skip_cache_write,
+        )
+
         create_kwargs: dict[str, Any] = {
             "model": opts.model,
             "max_tokens": opts.max_tokens,
-            "messages": messages,
+            "messages": api_messages,
         }
 
         if system_blocks:

--- a/tests/test_message_cache_breakpoints.py
+++ b/tests/test_message_cache_breakpoints.py
@@ -1,0 +1,296 @@
+"""Tests for ch04 round-2: message-level ``cache_control`` breakpoints.
+
+Mirrors the load-bearing invariant of TS ``addCacheBreakpoints``
+(``typescript/src/services/api/claude.ts:3107``): exactly one
+``cache_control`` marker per request, attached to the last block of the
+marker message; ``skip_cache_write`` shifts it to the second-to-last
+message; the function never mutates its input.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import pytest
+
+from src.services.api import add_cache_breakpoints
+from src.services.api.claude import CallModelOptions, call_model
+
+
+# ---------------------------------------------------------------------------
+# Pure-function unit tests
+# ---------------------------------------------------------------------------
+
+
+def _count_cache_control(messages: list[dict[str, Any]]) -> int:
+    """Count cache_control markers across every block of every message."""
+    count = 0
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and "cache_control" in block:
+                    count += 1
+        elif isinstance(content, dict) and "cache_control" in content:
+            count += 1
+    return count
+
+
+def test_empty_messages_returns_empty_list() -> None:
+    out = add_cache_breakpoints([])
+    assert out == []
+    # Defensive: caller mutating the result must not pollute the input.
+    out.append({"role": "user", "content": "x"})
+    assert add_cache_breakpoints([]) == []
+
+
+def test_disabled_returns_input_unchanged() -> None:
+    messages = [{"role": "user", "content": "hi"}]
+    out = add_cache_breakpoints(messages, enable_prompt_caching=False)
+    assert out is messages
+    assert _count_cache_control(out) == 0
+
+
+def test_single_string_content_message_wrapped_and_marked() -> None:
+    messages = [{"role": "user", "content": "hi"}]
+    out = add_cache_breakpoints(messages)
+    assert len(out) == 1
+    assert out[0]["role"] == "user"
+    content = out[0]["content"]
+    assert isinstance(content, list)
+    assert content == [
+        {"type": "text", "text": "hi", "cache_control": {"type": "ephemeral"}}
+    ]
+
+
+def test_single_list_content_marker_on_last_block_only() -> None:
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "first"},
+                {"type": "text", "text": "middle"},
+                {"type": "text", "text": "last"},
+            ],
+        }
+    ]
+    out = add_cache_breakpoints(messages)
+    content = out[0]["content"]
+    assert "cache_control" not in content[0]
+    assert "cache_control" not in content[1]
+    assert content[2]["cache_control"] == {"type": "ephemeral"}
+    assert _count_cache_control(out) == 1
+
+
+def test_multi_message_marker_on_last_only() -> None:
+    messages = [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "two"},
+        {"role": "user", "content": "three"},
+        {"role": "assistant", "content": "four"},
+        {"role": "user", "content": "five"},
+    ]
+    out = add_cache_breakpoints(messages)
+    # Only the last message carries the marker.
+    assert _count_cache_control(out) == 1
+    assert "cache_control" in out[-1]["content"][-1]
+    # All other messages still in their original (unmarked) string form
+    # because they were passed through by reference.
+    for i in range(4):
+        assert out[i] is messages[i]
+        assert isinstance(out[i]["content"], str)
+
+
+def test_skip_cache_write_shifts_marker_to_second_to_last() -> None:
+    messages = [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "two"},
+        {"role": "user", "content": "three"},
+    ]
+    out = add_cache_breakpoints(messages, skip_cache_write=True)
+    assert _count_cache_control(out) == 1
+    # Marker on index 1 (second-to-last), not index 2 (last).
+    assert isinstance(out[1]["content"], list)
+    assert out[1]["content"][-1]["cache_control"] == {"type": "ephemeral"}
+    # Last message untouched.
+    assert out[2] is messages[2]
+    assert isinstance(out[2]["content"], str)
+
+
+def test_skip_cache_write_single_message_is_noop() -> None:
+    messages = [{"role": "user", "content": "only"}]
+    out = add_cache_breakpoints(messages, skip_cache_write=True)
+    # Graceful no-op: no negative indexing, no markers.
+    assert _count_cache_control(out) == 0
+    # Returned list is a shallow copy but messages pass through unchanged.
+    assert out[0] is messages[0]
+
+
+def test_skip_cache_write_empty_list_is_noop() -> None:
+    assert add_cache_breakpoints([], skip_cache_write=True) == []
+
+
+def test_does_not_mutate_input_list() -> None:
+    messages = [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": [{"type": "text", "text": "two"}]},
+    ]
+    snapshot = copy.deepcopy(messages)
+    _ = add_cache_breakpoints(messages)
+    # Input completely unchanged.
+    assert messages == snapshot
+    assert _count_cache_control(messages) == 0
+
+
+def test_does_not_mutate_input_content_blocks() -> None:
+    last_block = {"type": "text", "text": "tail"}
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "head"}, last_block],
+        }
+    ]
+    out = add_cache_breakpoints(messages)
+    # Returned last block is a clone (different object) and unmarked
+    # original remains pristine.
+    assert out[0]["content"][-1] is not last_block
+    assert "cache_control" not in last_block
+    assert "cache_control" in out[0]["content"][-1]
+    # Earlier block reused by reference (no spurious clone cost).
+    assert out[0]["content"][0] is messages[0]["content"][0]
+
+
+def test_empty_block_list_gets_wrapper_marker_block() -> None:
+    messages = [{"role": "user", "content": []}]
+    out = add_cache_breakpoints(messages)
+    # Empty list now contains a single empty text block carrying the marker.
+    assert out[0]["content"] == [
+        {"type": "text", "text": "", "cache_control": {"type": "ephemeral"}}
+    ]
+
+
+def test_non_dict_last_block_is_wrapped_into_text_block() -> None:
+    # Pathological input — list whose last element isn't a block dict.
+    messages = [{"role": "user", "content": ["bare-string"]}]
+    out = add_cache_breakpoints(messages)
+    assert out[0]["content"] == [
+        {"type": "text", "text": "bare-string", "cache_control": {"type": "ephemeral"}}
+    ]
+
+
+def test_none_content_coerced_to_empty_text_block_with_marker() -> None:
+    messages = [{"role": "user", "content": None}]
+    out = add_cache_breakpoints(messages)
+    assert out[0]["content"] == [
+        {"type": "text", "text": "", "cache_control": {"type": "ephemeral"}}
+    ]
+
+
+def test_unknown_scalar_content_coerced_via_str() -> None:
+    messages = [{"role": "user", "content": 42}]
+    out = add_cache_breakpoints(messages)
+    assert out[0]["content"] == [
+        {"type": "text", "text": "42", "cache_control": {"type": "ephemeral"}}
+    ]
+
+
+def test_marker_message_role_preserved() -> None:
+    messages = [
+        {"role": "user", "content": "ping"},
+        {"role": "assistant", "content": "pong"},
+    ]
+    out = add_cache_breakpoints(messages)
+    assert out[-1]["role"] == "assistant"
+    assert "cache_control" in out[-1]["content"][-1]
+
+
+# ---------------------------------------------------------------------------
+# Integration: cache_control wiring through ``call_model``
+# ---------------------------------------------------------------------------
+
+
+class _StubStream:
+    """Minimal async-iterable stub for ``messages.create(stream=True)``."""
+
+    def __aiter__(self) -> "_StubStream":
+        return self
+
+    async def __anext__(self) -> Any:  # noqa: D401 - protocol method
+        raise StopAsyncIteration
+
+
+class _StubMessages:
+    def __init__(self) -> None:
+        self.last_kwargs: dict[str, Any] | None = None
+
+    async def create(self, **kwargs: Any) -> _StubStream:
+        self.last_kwargs = kwargs
+        return _StubStream()
+
+
+class _StubClient:
+    def __init__(self) -> None:
+        self.messages = _StubMessages()
+
+
+@pytest.mark.asyncio
+async def test_call_model_passes_marked_messages_to_client() -> None:
+    client = _StubClient()
+    history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "second"},
+        {"role": "user", "content": "third"},
+    ]
+    # Drain the generator so the create call runs.
+    events = [ev async for ev in call_model(history, CallModelOptions(), client)]
+    # Generator may emit just the trailing UsageEvent — that's fine.
+    assert events  # at minimum the trailing usage event
+
+    assert client.messages.last_kwargs is not None
+    sent = client.messages.last_kwargs["messages"]
+    # Exactly one cache_control marker, on the last message's last block.
+    assert _count_cache_control(sent) == 1
+    last = sent[-1]
+    assert isinstance(last["content"], list)
+    assert last["content"][-1]["cache_control"] == {"type": "ephemeral"}
+    # Input not mutated.
+    assert _count_cache_control(history) == 0
+    assert isinstance(history[-1]["content"], str)
+
+
+@pytest.mark.asyncio
+async def test_call_model_disabled_caching_skips_marker() -> None:
+    client = _StubClient()
+    history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "second"},
+        {"role": "user", "content": "third"},
+    ]
+    opts = CallModelOptions(enable_prompt_caching=False)
+    _ = [ev async for ev in call_model(history, opts, client)]
+
+    assert client.messages.last_kwargs is not None
+    sent = client.messages.last_kwargs["messages"]
+    assert _count_cache_control(sent) == 0
+    # When caching is off the function pass-throughs the original list.
+    assert sent is history
+
+
+@pytest.mark.asyncio
+async def test_call_model_skip_cache_write_shifts_marker() -> None:
+    client = _StubClient()
+    history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "second"},
+        {"role": "user", "content": "third"},
+    ]
+    opts = CallModelOptions(skip_cache_write=True)
+    _ = [ev async for ev in call_model(history, opts, client)]
+
+    assert client.messages.last_kwargs is not None
+    sent = client.messages.last_kwargs["messages"]
+    assert _count_cache_control(sent) == 1
+    # Marker on index 1, not index 2.
+    assert isinstance(sent[1]["content"], list)
+    assert sent[1]["content"][-1]["cache_control"] == {"type": "ephemeral"}


### PR DESCRIPTION
## Summary

- **Round-2 / single most impactful gap** from `ch04-api-layer-gap-analysis.md`: round-1 (Phases A–F) deferred message-level prompt-cache markers as "follow-up", but the same doc ranks them as the *single largest* prompt-cache miss for any multi-turn conversation. This PR closes that gap.
- Adds `add_cache_breakpoints(messages, *, enable_prompt_caching, skip_cache_write)` in `src/services/api/claude.py` mirroring the load-bearing invariant of TS `addCacheBreakpoints` (`typescript/src/services/api/claude.ts:3107`): **exactly one** `cache_control: {"type": "ephemeral"}` marker per request, on the last block of the marker message.
- `CallModelOptions` gains `enable_prompt_caching: bool = True` and `skip_cache_write: bool = False`; `call_model` runs `add_cache_breakpoints` just before `client.messages.create(...)`.

The mycro-internal `useCachedMC` / `cache_edits` / `cache_reference` machinery from TS is intentionally omitted — backend-specific features with no public API contract.

## Behaviour

- Default marker placement: last message, last block.
- `skip_cache_write=True`: marker shifts to second-to-last message (matches TS line 3127-3132 fire-and-forget fork pattern).
- String content wrapped into a single text block; None / empty / scalar content coerced into a one-block text wrapper so the marker always has a home.
- Function never mutates its input — marker message + content list + final block are shallow-cloned; earlier messages and earlier blocks pass through by reference (O(1) extra allocations).

## Test plan

- [x] `pytest tests/test_message_cache_breakpoints.py` — 18 new tests, all green
- [x] `pytest tests/test_porting_workspace.py tests/test_no_top_level_decoys.py tests/test_api_retry.py` — green (regression)
- [x] Pre-existing zhipuai SDK + python-not-in-PATH failures confirmed out of scope (same set fails on origin/main pre-change)

Docs: `my-docs/ch04-api-layer-round2-gap-analysis.md` + `my-docs/ch04-api-layer-round2-plan.md` (gitignored).

Refs round-1 gap analysis line 638-640 ("largest single missed cache opportunity").

Generated with [Claude Code](https://claude.com/claude-code)