### PR TITLE
feat(ch10/round2): align coordinator user_context with TS SIMPLE branch

### DIFF
--- a/src/coordinator/mode.py
+++ b/src/coordinator/mode.py
@@ -22,6 +22,7 @@ import logging
 import os
 from typing import Final, Iterable, Literal, TYPE_CHECKING
 
+from src.agent.constants import ASYNC_AGENT_ALLOWED_TOOLS
 from src.utils.env import is_env_truthy
 
 if TYPE_CHECKING:
@@ -130,6 +131,36 @@ def filter_worker_tools(all_tools: Iterable["Tool"]) -> list["Tool"]:
 # ---------------------------------------------------------------------------
 
 
+# Tools surfaced in SIMPLE mode. Mirrors the literal list at
+# ``coordinatorMode.ts:88-91`` (``[BASH_TOOL_NAME, FILE_READ_TOOL_NAME,
+# FILE_EDIT_TOOL_NAME]``). Kept as a module-level tuple so the
+# round-2 ch10 sort-and-render path has one source of truth.
+_SIMPLE_MODE_WORKER_TOOLS: Final[tuple[str, ...]] = ("Bash", "Read", "Edit")
+
+
+def _build_worker_tools_string() -> str:
+    """Build the comma-separated worker tools list for the coordinator
+    user context. Mirrors ``coordinatorMode.ts:88-95``.
+
+    SIMPLE branch (``CLAUDE_CODE_SIMPLE`` truthy): the literal three
+    tools ``[Bash, Read, Edit]``, sorted alphabetically. This matches
+    the SIMPLE worker-capabilities sentence in the coordinator system
+    prompt (``prompt.py:78-81``) so the coordinator's prompt and
+    user-context agree on what workers can do.
+
+    Default branch: ``ASYNC_AGENT_ALLOWED_TOOLS - INTERNAL_WORKER_TOOLS``
+    sorted alphabetically. Reading from ``ASYNC_AGENT_ALLOWED_TOOLS``
+    rather than hardcoding the list ties the rendered context to the
+    same source of truth as the actual runtime tool filter — adding
+    or removing a tool from the async-allowed set automatically
+    flows through to the coordinator's user context.
+    """
+    if is_env_truthy("CLAUDE_CODE_SIMPLE"):
+        return ", ".join(sorted(_SIMPLE_MODE_WORKER_TOOLS))
+    eligible = ASYNC_AGENT_ALLOWED_TOOLS - INTERNAL_WORKER_TOOLS
+    return ", ".join(sorted(eligible))
+
+
 def get_coordinator_user_context(
     mcp_clients: Iterable[object] | None = None,
     *,
@@ -142,25 +173,22 @@ def get_coordinator_user_context(
     not in coordinator mode (the section is gated on mode, not on
     tools-list shape — non-coordinator agents shouldn't see it). When
     coordinator mode is active, returns ``{"workerToolsContext": "..."}``
-    with the three tool names + optional MCP server names + optional
-    scratchpad note.
+    with the appropriate tool names + optional MCP server names +
+    optional scratchpad note.
 
-    The scratchpad block is gated by the ``tengu_scratch`` feature
-    flag in TS; for chapter-10 we surface the note only when
-    ``scratchpad_dir`` is supplied (the actual scratchpad creation
-    is out-of-scope per plan §3 — wire-up only).
+    The worker tools list now branches on ``CLAUDE_CODE_SIMPLE`` to
+    match TS exactly (round-2 fix); see ``_build_worker_tools_string``.
+
+    The scratchpad block is gated by the ``tengu_scratch`` Statsig
+    feature flag in TS; Python has no Statsig infra yet (backlog
+    item #5 in ``ch10-phase11-backlog.md``), so for now we surface
+    the note unconditionally when ``scratchpad_dir`` is supplied.
+    The actual scratchpad creation is out-of-scope per plan §3.
     """
     if not is_coordinator_mode():
         return {}
 
-    # Pre-compute the worker tools list. We can't import the full
-    # registry here (would circular), so we list the canonical names
-    # the chapter mentions and let the actual tool filter at the
-    # registry level decide what the worker actually has.
-    worker_tools = (
-        "Read, Bash, Edit, Glob, Grep, Write, WebSearch, WebFetch, "
-        "TodoWrite, Skill, EnterWorktree, ExitWorktree"
-    )
+    worker_tools = _build_worker_tools_string()
 
     parts = [f"Workers spawned via Agent have access to these tools: {worker_tools}"]
 

--- a/tests/coordinator/__snapshots__/user_context_default.snap.txt
+++ b/tests/coordinator/__snapshots__/user_context_default.snap.txt
@@ -1,0 +1,1 @@
+Workers spawned via Agent have access to these tools: Bash, Edit, EnterWorktree, ExitWorktree, Glob, Grep, Read, Skill, TodoWrite, WebFetch, WebSearch, Write

--- a/tests/coordinator/__snapshots__/user_context_simple.snap.txt
+++ b/tests/coordinator/__snapshots__/user_context_simple.snap.txt
@@ -1,0 +1,1 @@
+Workers spawned via Agent have access to these tools: Bash, Edit, Read

--- a/tests/coordinator/test_mode.py
+++ b/tests/coordinator/test_mode.py
@@ -8,10 +8,14 @@ Covers:
   everything else (incl. MCP).
 * ``get_coordinator_user_context`` activation gate + content shape.
 * ``is_fork_subagent_enabled`` is False under coordinator mode (WI-8.6).
+* Round-2: ``get_coordinator_user_context`` honors ``CLAUDE_CODE_SIMPLE``
+  branch and renders ``ASYNC_AGENT_ALLOWED_TOOLS - INTERNAL_WORKER_TOOLS``
+  sorted (parity with ``coordinatorMode.ts:88-95``).
 """
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -248,6 +252,151 @@ def test_user_context_worker_tools_matches_async_allowed_tools(
             f"ASYNC_AGENT_ALLOWED_TOOLS — update prompt.py / mode.py "
             f"to keep them in sync."
         )
+
+
+# ---------------------------------------------------------------------------
+# Round-2 — CLAUDE_CODE_SIMPLE branch + sort-order parity with TS
+# (``coordinatorMode.ts:88-95``)
+# ---------------------------------------------------------------------------
+
+
+def test_user_context_simple_branch_three_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SIMPLE branch returns exactly ``Bash, Edit, Read`` (sorted)
+    — the literal three-tool list from TS ``coordinatorMode.ts:88-91``.
+    Larger-list tools must NOT appear in SIMPLE mode."""
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    monkeypatch.setenv("CLAUDE_CODE_SIMPLE", "1")
+    ctx = get_coordinator_user_context()
+    body = ctx["workerToolsContext"]
+    assert "Bash, Edit, Read" in body
+    # Tools that exist in ASYNC_AGENT_ALLOWED_TOOLS but not SIMPLE must
+    # NOT leak through.
+    assert "WebSearch" not in body
+    assert "TodoWrite" not in body
+    assert "Glob" not in body
+
+
+def test_user_context_default_branch_sorted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default branch must render tools alphabetically sorted —
+    matches TS ``.sort().join(', ')`` at ``coordinatorMode.ts:94``."""
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    monkeypatch.delenv("CLAUDE_CODE_SIMPLE", raising=False)
+    ctx = get_coordinator_user_context()
+    body = ctx["workerToolsContext"]
+    line = next(l for l in body.splitlines() if "Workers spawned" in l)
+    tools_part = line.split(":", 1)[1].strip()
+    tools = [t.strip() for t in tools_part.split(",")]
+    assert tools == sorted(tools), (
+        f"Worker tools must be alphabetically sorted; got: {tools}"
+    )
+
+
+def test_user_context_default_branch_matches_async_allowed_exactly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inverse of the existing N1 guard
+    (``test_user_context_worker_tools_matches_async_allowed_tools``).
+
+    N1 checks every ASYNC tool appears in the rendered context. This
+    test checks the rendered context contains EXACTLY
+    ``ASYNC_AGENT_ALLOWED_TOOLS - INTERNAL_WORKER_TOOLS`` — catching
+    both drift directions:
+
+    * Tool added to ASYNC_AGENT_ALLOWED_TOOLS but not coordinator → N1
+      catches it.
+    * Tool added to coordinator user context but not ASYNC list →
+      this test catches it.
+    """
+    from src.agent.constants import ASYNC_AGENT_ALLOWED_TOOLS
+
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    monkeypatch.delenv("CLAUDE_CODE_SIMPLE", raising=False)
+    ctx = get_coordinator_user_context()
+    body = ctx["workerToolsContext"]
+    line = next(l for l in body.splitlines() if "Workers spawned" in l)
+    rendered = set(t.strip() for t in line.split(":", 1)[1].strip().split(","))
+    expected = ASYNC_AGENT_ALLOWED_TOOLS - INTERNAL_WORKER_TOOLS
+    assert rendered == expected, (
+        f"Worker tools drift detected.\n"
+        f"  Rendered: {sorted(rendered)}\n"
+        f"  Expected: {sorted(expected)}\n"
+        f"  Missing : {sorted(expected - rendered)}\n"
+        f"  Extra   : {sorted(rendered - expected)}"
+    )
+
+
+def test_user_context_simple_off_returns_full_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sanity: flipping ``CLAUDE_CODE_SIMPLE`` off reverts to the full
+    async-allowed list — confirms the branch is live, not stuck."""
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    monkeypatch.setenv("CLAUDE_CODE_SIMPLE", "1")
+    ctx_simple = get_coordinator_user_context()
+    monkeypatch.delenv("CLAUDE_CODE_SIMPLE", raising=False)
+    ctx_default = get_coordinator_user_context()
+    assert ctx_simple != ctx_default
+    assert "WebSearch" not in ctx_simple["workerToolsContext"]
+    assert "WebSearch" in ctx_default["workerToolsContext"]
+
+
+def test_user_context_simple_snapshot(
+    monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest,
+) -> None:
+    """Byte-exact snapshot pin for SIMPLE branch. Breaking this test
+    is the deliberate review gate for any change to the SIMPLE-mode
+    worker tools list — same pattern the prompt.py snapshots use."""
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    monkeypatch.setenv("CLAUDE_CODE_SIMPLE", "1")
+    body = get_coordinator_user_context()["workerToolsContext"]
+    snap_path = (
+        Path(request.path).parent / "__snapshots__" / "user_context_simple.snap.txt"
+    )
+    expected = snap_path.read_text().rstrip("\n")
+    assert body == expected
+
+
+def test_user_context_default_snapshot(
+    monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest,
+) -> None:
+    """Byte-exact snapshot pin for the default branch. Updates require
+    a deliberate snapshot refresh (mirrors the prompt.py snapshot
+    discipline at ``test_prompt.py``)."""
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    monkeypatch.delenv("CLAUDE_CODE_SIMPLE", raising=False)
+    body = get_coordinator_user_context()["workerToolsContext"]
+    snap_path = (
+        Path(request.path).parent / "__snapshots__" / "user_context_default.snap.txt"
+    )
+    expected = snap_path.read_text().rstrip("\n")
+    assert body == expected
+
+
+def test_user_context_simple_with_mcp_and_scratchpad(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SIMPLE branch composes correctly with MCP servers + scratchpad —
+    confirms the SIMPLE branch only swaps the tools list and leaves
+    the rest of the structure intact."""
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    monkeypatch.setenv("CLAUDE_CODE_SIMPLE", "1")
+
+    class _MCPClient:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    ctx = get_coordinator_user_context(
+        [_MCPClient("github")], scratchpad_dir="/tmp/scratch"
+    )
+    body = ctx["workerToolsContext"]
+    assert "Bash, Edit, Read" in body
+    assert "WebSearch" not in body  # SIMPLE doesn't leak default tools
+    assert "github" in body
+    assert "/tmp/scratch" in body
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Closes the parity gap between Python `get_coordinator_user_context()` and TS `coordinatorMode.ts:80-109` — Python hardcoded a single 12-tool string; TS branches on `CLAUDE_CODE_SIMPLE` and derives the default list from `ASYNC_AGENT_ALLOWED_TOOLS - INTERNAL_WORKER_TOOLS` sorted.
- Extracts `_build_worker_tools_string()` helper in `src/coordinator/mode.py`. SIMPLE branch returns `Bash, Edit, Read` (matches the SIMPLE worker-capabilities sentence the prompt already emits); default branch reads from `ASYNC_AGENT_ALLOWED_TOOLS` so future tool additions flow through automatically.
- Adds 7 new tests in `tests/coordinator/test_mode.py`: SIMPLE branch shape, sort-order guard, drift-guard (inverse of the existing N1 guard — catches extras-in-Python too), SIMPLE-off sanity, two byte-exact snapshot fixtures, and SIMPLE+MCP+scratchpad composition.
- Scratchpad `tengu_scratch` Statsig gate stays deferred per `ch10-phase11-backlog.md` item #5 (no Statsig infra in Python yet).

## Test plan
- [x] `pytest tests/coordinator/test_mode.py tests/test_porting_workspace.py tests/test_no_top_level_decoys.py -q` → 96 passed
- [x] `pytest tests/coordinator/ -q` → 49 passed (no regressions in the wider coordinator suite)
- [x] Manual verification: rendered SIMPLE and default contexts match TS line-for-line (snapshot fixtures pinned)

Round-2 docs (not in this PR; local notes):
- `my-docs/ch10-coordination-round2-gap-analysis.md`
- `my-docs/ch10-coordination-round2-plan.md`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>