### PR TITLE
feat(ch08/round2): preserve bubble-mode prompts for async sub-agents

### DIFF
--- a/src/agent/run_agent.py
+++ b/src/agent/run_agent.py
@@ -110,8 +110,45 @@ def _build_permission_context(
     effective_mode: PermissionMode,
     is_async: bool,
 ) -> ToolPermissionContext:
-    """Build the permission context for the subagent."""
+    """Build the permission context for the subagent.
+
+    Mirrors the prompt-avoidance cascade in
+    ``typescript/src/tools/AgentTool/runAgent.ts:449-476``:
+
+    1. ``should_avoid_permission_prompts`` is True iff the parent already
+       avoids prompts OR the agent is async AND its effective mode is
+       not ``bubble``. Bubble mode preserves prompts even when async,
+       because the bubble path surfaces them to the parent terminal.
+    2. ``await_automated_checks_before_dialog`` is True for async agents
+       whose prompts are still enabled — today that means bubble mode.
+       It signals the permission system to run the classifier / hooks
+       before interrupting the user.
+
+    The TS implementation also reads ``canShowPermissionPrompts`` as an
+    explicit caller override. The Python ``RunAgentParams`` does not yet
+    plumb that flag, so the cascade reduces to the ``isAsync`` /
+    ``agentPermissionMode === 'bubble'`` branch. Round-2 docs flag the
+    full ``canShowPermissionPrompts`` thread-through as out-of-scope.
+    """
     parent_perm = parent_context.permission_context
+
+    # TS cascade: bubble mode is the only async mode that can still
+    # show prompts (they bubble to the parent terminal). Every other
+    # async agent must auto-deny rather than block on a missing UI.
+    if effective_mode == "bubble":
+        avoid_for_isolation = False
+    else:
+        avoid_for_isolation = is_async
+    should_avoid = (
+        parent_perm.should_avoid_permission_prompts or avoid_for_isolation
+    )
+
+    # Async-but-can-prompt agents wait for classifier / hooks before
+    # interrupting the user. Sync agents and prompt-avoiding agents
+    # skip this — there is either no async to wait inside of, or no
+    # dialog to delay.
+    await_automated = is_async and not should_avoid
+
     return ToolPermissionContext(
         mode=effective_mode,
         additional_working_directories=parent_perm.additional_working_directories,
@@ -119,9 +156,8 @@ def _build_permission_context(
         always_deny_rules=parent_perm.always_deny_rules,
         always_ask_rules=parent_perm.always_ask_rules,
         is_bypass_permissions_mode_available=parent_perm.is_bypass_permissions_mode_available,
-        should_avoid_permission_prompts=(
-            parent_perm.should_avoid_permission_prompts or is_async
-        ),
+        should_avoid_permission_prompts=should_avoid,
+        await_automated_checks_before_dialog=await_automated,
     )
 
 

--- a/src/permissions/loader.py
+++ b/src/permissions/loader.py
@@ -55,4 +55,5 @@ def apply_rules_to_context(
         always_ask_rules=ask_rules,
         is_bypass_permissions_mode_available=context.is_bypass_permissions_mode_available,
         should_avoid_permission_prompts=context.should_avoid_permission_prompts,
+        await_automated_checks_before_dialog=context.await_automated_checks_before_dialog,
     )

--- a/src/permissions/setup.py
+++ b/src/permissions/setup.py
@@ -172,6 +172,7 @@ def setup_permissions(
             always_ask_rules=context.always_ask_rules,
             is_bypass_permissions_mode_available=context.is_bypass_permissions_mode_available,
             should_avoid_permission_prompts=context.should_avoid_permission_prompts,
+            await_automated_checks_before_dialog=context.await_automated_checks_before_dialog,
         )
 
     shadowed = _detect_shadowed_rules(all_rules)

--- a/src/permissions/types.py
+++ b/src/permissions/types.py
@@ -331,6 +331,14 @@ class ToolPermissionContext:
     )
     is_bypass_permissions_mode_available: bool = False
     should_avoid_permission_prompts: bool = False
+    # When True, async sub-agents that can still surface prompts (today:
+    # bubble mode) wait for the classifier / permission hooks to run
+    # before interrupting the user. Mirrors TS
+    # ``awaitAutomatedChecksBeforeDialog`` set in
+    # ``typescript/src/tools/AgentTool/runAgent.ts:471-475``. Defaulting
+    # to ``False`` keeps existing call sites unchanged; the field is
+    # set only by ``run_agent._build_permission_context`` for now.
+    await_automated_checks_before_dialog: bool = False
 
     @classmethod
     def from_iterables(

--- a/src/permissions/updates.py
+++ b/src/permissions/updates.py
@@ -102,6 +102,7 @@ def _replace_ruleset(
         "always_ask_rules": dict(context.always_ask_rules),
         "is_bypass_permissions_mode_available": context.is_bypass_permissions_mode_available,
         "should_avoid_permission_prompts": context.should_avoid_permission_prompts,
+        "await_automated_checks_before_dialog": context.await_automated_checks_before_dialog,
     }
     kwargs[key] = current
     return ToolPermissionContext(**kwargs)
@@ -137,6 +138,7 @@ def apply_permission_update(
             always_ask_rules=dict(context.always_ask_rules),
             is_bypass_permissions_mode_available=context.is_bypass_permissions_mode_available,
             should_avoid_permission_prompts=context.should_avoid_permission_prompts,
+            await_automated_checks_before_dialog=context.await_automated_checks_before_dialog,
         )
 
     if isinstance(update, PermissionUpdateAddRules):
@@ -191,6 +193,7 @@ def apply_permission_update(
             always_ask_rules=dict(context.always_ask_rules),
             is_bypass_permissions_mode_available=context.is_bypass_permissions_mode_available,
             should_avoid_permission_prompts=context.should_avoid_permission_prompts,
+            await_automated_checks_before_dialog=context.await_automated_checks_before_dialog,
         )
 
     if isinstance(update, PermissionUpdateRemoveDirectories):
@@ -209,6 +212,7 @@ def apply_permission_update(
             always_ask_rules=dict(context.always_ask_rules),
             is_bypass_permissions_mode_available=context.is_bypass_permissions_mode_available,
             should_avoid_permission_prompts=context.should_avoid_permission_prompts,
+            await_automated_checks_before_dialog=context.await_automated_checks_before_dialog,
         )
 
     return context

--- a/tests/test_agent_bubble_propagation.py
+++ b/tests/test_agent_bubble_propagation.py
@@ -1,0 +1,176 @@
+"""Round-2 coverage for bubble-mode propagation into async sub-agents.
+
+Mirrors ``typescript/src/tools/AgentTool/runAgent.ts:449-476`` (Step 5
+of the sub-agent lifecycle described in
+``book/ch08-sub-agents.md:252-305``).
+
+The TS cascade for ``shouldAvoidPermissionPrompts`` is:
+
+    canShowPermissionPrompts !== undefined
+        ? !canShowPermissionPrompts
+        : agentPermissionMode === 'bubble'
+            ? false
+            : isAsync
+
+Python does not yet plumb ``canShowPermissionPrompts`` through
+``RunAgentParams``; the cascade reduces to the bubble / isAsync
+branch. The full plumbing is tracked in a future round, see
+``my-docs/ch08-sub-agents-gap-analysis.md`` ("Adjacent Observations").
+
+These tests focus on the bubble-mode preservation gap closed in this
+PR. They cover the full 2-by-2-by-2 matrix over ``mode`` (bubble vs
+default), ``is_async``, and parent ``should_avoid`` (True vs False).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.agent.agent_definitions import AgentDefinition
+from src.agent.run_agent import (
+    _build_permission_context,
+    resolve_permission_mode,
+)
+from src.permissions.types import PermissionMode, ToolPermissionContext
+from src.tool_system.context import ToolContext
+from src.utils.abort_controller import AbortController
+
+
+def _make_context(
+    mode: PermissionMode = "default",
+    *,
+    parent_avoids: bool = False,
+) -> ToolContext:
+    return ToolContext(
+        workspace_root=Path("/tmp/test-ws"),
+        permission_context=ToolPermissionContext(
+            mode=mode,
+            should_avoid_permission_prompts=parent_avoids,
+        ),
+        abort_controller=AbortController(),
+    )
+
+
+def _make_agent(
+    permission_mode: PermissionMode | None = None,
+) -> AgentDefinition:
+    return AgentDefinition(
+        agent_type="test-bubble",
+        when_to_use="test",
+        permission_mode=permission_mode,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Matrix: (effective_mode, is_async, parent_avoids) -> (should_avoid, await)
+# ---------------------------------------------------------------------------
+
+# Row format: (effective_mode, is_async, parent_avoids,
+#              expected_should_avoid, expected_await)
+MATRIX = [
+    # bubble + sync — prompts always enabled, no await flag.
+    ("bubble",  False, False, False, False),
+    ("bubble",  False, True,  True,  False),  # parent override wins
+    # bubble + async — prompts enabled, await classifier first.
+    ("bubble",  True,  False, False, True),
+    ("bubble",  True,  True,  True,  False),  # parent override wins
+    # default + sync — prompts enabled (sync always prompts directly).
+    ("default", False, False, False, False),
+    ("default", False, True,  True,  False),
+    # default + async — prompts disabled (no terminal to bubble to).
+    ("default", True,  False, True,  False),
+    ("default", True,  True,  True,  False),
+]
+
+
+@pytest.mark.parametrize(
+    "effective_mode,is_async,parent_avoids,exp_avoid,exp_await",
+    MATRIX,
+)
+def test_permission_cascade_matrix(
+    effective_mode: PermissionMode,
+    is_async: bool,
+    parent_avoids: bool,
+    exp_avoid: bool,
+    exp_await: bool,
+) -> None:
+    """Full 2-by-2-by-2 matrix matches the TS cascade.
+
+    Each row is a single line of
+    ``typescript/src/tools/AgentTool/runAgent.ts:449-476`` evaluated
+    against fixed inputs.
+    """
+    ctx = _make_context(parent_avoids=parent_avoids)
+
+    perm = _build_permission_context(ctx, effective_mode, is_async=is_async)
+
+    assert perm.should_avoid_permission_prompts is exp_avoid, (
+        f"mode={effective_mode} is_async={is_async} "
+        f"parent_avoids={parent_avoids} -> expected should_avoid={exp_avoid}"
+    )
+    assert perm.await_automated_checks_before_dialog is exp_await, (
+        f"mode={effective_mode} is_async={is_async} "
+        f"parent_avoids={parent_avoids} -> expected await={exp_await}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration: resolve_permission_mode + _build_permission_context
+# ---------------------------------------------------------------------------
+
+def test_bubble_agent_round_trip_through_resolver() -> None:
+    """Defining a bubble agent + running async yields the bubble cascade.
+
+    Confirms the public API surface (call site of
+    ``run_agent._build_permission_context`` after
+    ``resolve_permission_mode``) produces the bubble exception, not
+    just the bare ``_build_permission_context`` helper.
+    """
+    parent = _make_context(mode="default")
+    agent = _make_agent(permission_mode="bubble")
+
+    effective = resolve_permission_mode(parent, agent, is_async=True)
+    assert effective == "bubble"
+
+    perm = _build_permission_context(parent, effective, is_async=True)
+
+    assert perm.mode == "bubble"
+    assert perm.should_avoid_permission_prompts is False
+    assert perm.await_automated_checks_before_dialog is True
+
+
+def test_bypass_parent_blocks_bubble_override() -> None:
+    """Permissive parent modes still win over the agent's bubble mode.
+
+    ``resolve_permission_mode`` returns ``bypassPermissions``, not
+    ``bubble``, so the build step never sees the bubble path.
+    """
+    parent = _make_context(mode="bypassPermissions")
+    agent = _make_agent(permission_mode="bubble")
+
+    effective = resolve_permission_mode(parent, agent, is_async=True)
+    assert effective == "bypassPermissions"
+
+    perm = _build_permission_context(parent, effective, is_async=True)
+
+    # bypassPermissions is not bubble — the async path applies the
+    # default avoidance.
+    assert perm.should_avoid_permission_prompts is True
+    assert perm.await_automated_checks_before_dialog is False
+
+
+def test_no_field_pollution_on_sync_default() -> None:
+    """The default + sync path leaves both flags False.
+
+    Guards against accidentally setting either flag in the most common
+    code path (sync general-purpose agent).
+    """
+    parent = _make_context(mode="default")
+    agent = _make_agent(permission_mode=None)
+
+    effective = resolve_permission_mode(parent, agent, is_async=False)
+    perm = _build_permission_context(parent, effective, is_async=False)
+
+    assert perm.should_avoid_permission_prompts is False
+    assert perm.await_automated_checks_before_dialog is False

--- a/tests/test_agent_permission_inheritance.py
+++ b/tests/test_agent_permission_inheritance.py
@@ -121,8 +121,13 @@ class TestBuildPermissionContext:
 
         assert perm.should_avoid_permission_prompts is False
 
-    def test_async_always_avoids_prompts(self):
-        """Async agents always suppress permission prompts."""
+    def test_async_default_mode_avoids_prompts(self):
+        """Async agents in non-bubble modes suppress permission prompts.
+
+        Bubble mode is exempted because its prompts surface to the
+        parent terminal (covered by the bubble tests below). Mirrors
+        ``typescript/src/tools/AgentTool/runAgent.ts:449-464``.
+        """
         ctx = _make_context(
             "default",
             should_avoid_permission_prompts=False,
@@ -131,6 +136,69 @@ class TestBuildPermissionContext:
         perm = _build_permission_context(ctx, "default", is_async=True)
 
         assert perm.should_avoid_permission_prompts is True
+        # default + async does NOT wait for automated checks — there is
+        # no dialog to delay because prompts are off.
+        assert perm.await_automated_checks_before_dialog is False
+
+    def test_async_bubble_keeps_prompts_enabled(self):
+        """Async bubble agents bubble prompts up to the parent terminal.
+
+        ``shouldAvoidPermissionPrompts`` stays False so the bubble path
+        in ``permissions/check.py:183`` can produce an escalation deny
+        rather than a generic headless deny. Mirrors
+        ``typescript/src/tools/AgentTool/runAgent.ts:453-458``.
+        """
+        ctx = _make_context(
+            "default",
+            should_avoid_permission_prompts=False,
+        )
+
+        perm = _build_permission_context(ctx, "bubble", is_async=True)
+
+        assert perm.should_avoid_permission_prompts is False
+
+    def test_async_bubble_sets_await_automated_checks(self):
+        """Async-but-promptable agents wait for classifier / hooks.
+
+        Mirrors ``typescript/src/tools/AgentTool/runAgent.ts:471-475``.
+        """
+        ctx = _make_context("default")
+
+        perm = _build_permission_context(ctx, "bubble", is_async=True)
+
+        assert perm.await_automated_checks_before_dialog is True
+
+    def test_sync_bubble_no_await_flag(self):
+        """Sync bubble agents do not need the await-checks signal.
+
+        The flag is for *async* agents that still allow prompts. Sync
+        agents always prompt directly.
+        """
+        ctx = _make_context("default")
+
+        perm = _build_permission_context(ctx, "bubble", is_async=False)
+
+        assert perm.should_avoid_permission_prompts is False
+        assert perm.await_automated_checks_before_dialog is False
+
+    def test_parent_avoids_prompts_propagates_even_for_bubble(self):
+        """Headless parent forces avoidance regardless of agent mode.
+
+        If the parent (or SDK consumer) already configured
+        ``should_avoid_permission_prompts=True``, the agent cannot
+        re-enable prompts by being in bubble mode — the parent's
+        explicit policy wins.
+        """
+        ctx = _make_context(
+            "default",
+            should_avoid_permission_prompts=True,
+        )
+
+        perm = _build_permission_context(ctx, "bubble", is_async=True)
+
+        assert perm.should_avoid_permission_prompts is True
+        # No dialog will fire, so no need to wait for automated checks.
+        assert perm.await_automated_checks_before_dialog is False
 
     def test_effective_mode_applied(self):
         """Effective mode is set on the built permission context."""


### PR DESCRIPTION
## Summary

Round-2 gap closure for Chapter 8 (Sub-Agents). The Python
`_build_permission_context()` collapsed `should_avoid_permission_prompts`
to `parent or is_async`, silently disabling the bubble-mode escalation
path for any background sub-agent. TS preserves prompts in bubble mode
regardless of sync/async (`typescript/src/tools/AgentTool/runAgent.ts:449-476`)
because bubble mode delivers prompts to the parent terminal — async by
itself does not imply no terminal is available.

- `ToolPermissionContext` gains `await_automated_checks_before_dialog`
  to mirror the TS field of the same purpose.
- `run_agent._build_permission_context` implements the TS cascade:
  bubble bypasses the async avoidance, and async-but-can-prompt agents
  set the await-classifier flag so background spawns don't barge in
  before automated checks have a chance to resolve a permission.
- All four other `ToolPermissionContext` rebuilders in the permissions
  package preserve the new field.

## Reference

- Book: `book/ch08-sub-agents.md:252-305` (Step 5: Permission Isolation)
- TS: `typescript/src/tools/AgentTool/runAgent.ts:425-492`
- Docs: `my-docs/ch08-sub-agents-gap-analysis.md` + `my-docs/ch08-sub-agents-plan.md`

## Test plan

- [x] `tests/test_agent_permission_inheritance.py` — existing test renamed + four new cases (bubble keeps prompts, await flag, sync bubble baseline, parent override).
- [x] `tests/test_agent_bubble_propagation.py` (new) — full 2x2x2 matrix over `(mode, is_async, parent_avoids)` plus three integration tests via `resolve_permission_mode`.
- [x] Guard suite green: `test_porting_workspace.py`, `test_no_top_level_decoys.py`.
- [x] No regression in adjacent permission tests: `test_permission_auto_bubble.py`, `test_permission_updates.py`, `test_permission_cycle.py`, `test_subagent_context.py` (179 tests pass total).

Generated with [Claude Code](https://claude.com/claude-code)