### PR TITLE
ch16(round2): tristate ConnectionState in SessionsWebSocket

### DIFF
--- a/src/remote/sessions_websocket.py
+++ b/src/remote/sessions_websocket.py
@@ -16,6 +16,15 @@ Reconnection strategy is **discriminated by close code** (per chapter
 Per Risk #22 in the refactoring plan: the ``websockets`` library does
 NOT auto-reconnect (unlike JS WebSocket event handlers). We implement
 an explicit reconnect loop with the discriminated retry strategy.
+
+Lifecycle state machine (round-2): the WS lives in one of three states
+— ``closed``, ``connecting``, ``connected``. ``connecting`` exists
+purely to make ``connect()`` single-flight; ``connected`` gates the
+send paths. Mirrors TS ``WebSocketState`` at
+``SessionsWebSocket.ts:38``. A separate ``_user_disconnected`` latch
+distinguishes a *transient* closed state (waiting on a budgeted
+reconnect timer) from a *permanent* closed state (user called
+``disconnect()``).
 """
 
 from __future__ import annotations
@@ -26,6 +35,7 @@ import logging
 import uuid as _uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from typing import Literal
 
 import websockets
 from websockets.asyncio.client import connect as ws_connect
@@ -36,6 +46,11 @@ from src.bridge.close_codes import (
 )
 
 logger = logging.getLogger(__name__)
+
+#: Tristate WS lifecycle. Mirrors TS ``WebSocketState`` at
+#: ``SessionsWebSocket.ts:38``. ``connecting`` exists for one purpose:
+#: prevent re-entrant ``connect()`` calls from racing the open handshake.
+ConnectionState = Literal["closed", "connecting", "connected"]
 
 #: Constant retry delay matching ``SessionsWebSocket.ts:17``.
 RECONNECT_DELAY_SECONDS = 2.0
@@ -114,21 +129,57 @@ class SessionsWebSocket:
         self._ws: websockets.asyncio.client.ClientConnection | None = None
         self._reader_task: asyncio.Task[None] | None = None
         self._reconnect_task: asyncio.Task[None] | None = None
-        self._closed = False
+        #: Tristate WS state. Mirrors TS ``SessionsWebSocket.ts:84``. Starts
+        #: ``"closed"`` so a fresh instance is not mistaken for "connected".
+        self._state: ConnectionState = "closed"
+        #: Set True only by ``disconnect()`` (user-requested permanent
+        #: close). Distinct from ``_state == "closed"`` which can also
+        #: mean "between connections, waiting to reconnect". Once set,
+        #: any reconnect-schedule path becomes a no-op until
+        #: ``reconnect()`` clears it.
+        self._user_disconnected = False
         self._reconnect_attempts = 0
         self._not_found_retries = 0
 
     # ─── State queries ────────────────────────────────────────────────
 
     def is_connected(self) -> bool:
-        return self._ws is not None and not self._closed
+        """True only after the WS open handshake has completed.
+
+        Mirrors TS ``SessionsWebSocket.ts:362-364`` (``state === 'connected'``).
+        Does NOT return True during the ``connecting`` handshake window.
+        """
+        return self._state == "connected"
+
+    @property
+    def state(self) -> ConnectionState:
+        """Read-only view of the WS lifecycle state (testing + debugging)."""
+        return self._state
 
     # ─── Lifecycle ────────────────────────────────────────────────────
 
     async def connect(self) -> None:
-        """Open the WS and start the reader. Returns once open OR raises."""
-        if self._closed:
+        """Open the WS and start the reader. Returns once open OR raises.
+
+        Single-flight: re-entrant calls during ``connecting`` or
+        ``connected`` are no-ops. Mirrors TS guard at
+        ``SessionsWebSocket.ts:101-104``. Permanent: returns immediately
+        if ``disconnect()`` was called (use ``reconnect()`` to clear).
+        """
+        if self._state in ("connecting", "connected"):
+            logger.debug(
+                '[SessionsWebSocket] connect() called in state=%s; ignoring',
+                self._state,
+            )
             return
+        if self._user_disconnected:
+            logger.debug(
+                '[SessionsWebSocket] connect() called after disconnect(); ignoring'
+            )
+            return
+        # Transition: closed → connecting BEFORE the await so subsequent
+        # callers see the in-flight state.
+        self._state = "connecting"
         url = (
             f'{self._base_url}/v1/sessions/ws/{self._session_id}/subscribe'
             f'?organization_uuid={self._org_uuid}'
@@ -144,11 +195,31 @@ class SessionsWebSocket:
                 ping_interval=PING_INTERVAL_SECONDS,
             )
         except (websockets.exceptions.WebSocketException, OSError) as exc:
+            # Transition: connecting → closed on raise. Fire on_error,
+            # then let the budgeted reconnect path decide whether to
+            # retry.
+            self._state = "closed"
             await self._invoke(self._callbacks.on_error, exc)
             self._schedule_reconnect_or_close()
             return
 
+        # Post-await race: ``disconnect()`` may have run while we awaited
+        # ``ws_connect``. If so, state is no longer "connecting" — close
+        # the orphan WS and bail without starting the reader.
+        if self._state != "connecting":
+            logger.debug(
+                '[SessionsWebSocket] disconnect() ran during handshake (state=%s); '
+                'closing orphan WS',
+                self._state,
+            )
+            try:
+                await ws.close()
+            except (websockets.exceptions.ConnectionClosed, OSError):
+                pass
+            return
+
         self._ws = ws
+        self._state = "connected"
         self._reconnect_attempts = 0
         self._not_found_retries = 0
         await self._invoke(self._callbacks.on_connected)
@@ -157,10 +228,35 @@ class SessionsWebSocket:
         )
 
     async def disconnect(self) -> None:
-        """Permanent close — no reconnects, fire on_close."""
-        self._closed = True
+        """Permanent close — no reconnects, fire on_close on next close event.
+
+        Re-entrant safe. Sets ``_user_disconnected`` so:
+          - any in-flight ``connect()`` (mid ``ws_connect`` await) bails
+            after returning, closing the orphan WS;
+          - any scheduled-but-not-yet-fired reconnect callback no-ops;
+          - subsequent ``connect()`` calls are rejected until
+            ``reconnect()`` clears the latch.
+        """
+        was_quiescent = (
+            self._state == "closed"
+            and self._user_disconnected
+            and self._ws is None
+            and (self._reader_task is None or self._reader_task.done())
+        )
+        # Transition first so any in-flight connect() coroutine sees the
+        # change after its ``await ws_connect()`` returns.
+        self._state = "closed"
+        # Mark as user-requested permanent close so any in-flight
+        # reconnect scheduler (triggered by _on_ws_close just before
+        # this call) or scheduled connect() callback bails out.
+        self._user_disconnected = True
+        # Always cancel any pending reconnect task — even when state was
+        # already "closed", a budgeted reconnect may be sleeping and we
+        # want it to never fire.
         if self._reconnect_task is not None and not self._reconnect_task.done():
             self._reconnect_task.cancel()
+        if was_quiescent:
+            return
         ws, self._ws = self._ws, None
         if self._reader_task is not None and not self._reader_task.done():
             self._reader_task.cancel()
@@ -179,9 +275,18 @@ class SessionsWebSocket:
 
         Used when the subscription is known stale (e.g., after the
         worker container shutdown the server detected on its side).
+        Transitions to ``closed`` before the grace sleep so the eventual
+        ``connect()`` clears its singleflight guard. Also clears the
+        ``_user_disconnected`` latch so a previously-disconnected
+        instance can be re-armed (TS ``reconnect()`` mirrors the same
+        intent at ``SessionsWebSocket.ts:393-403``).
         """
         self._reconnect_attempts = 0
         self._not_found_retries = 0
+        self._user_disconnected = False
+        # Move to closed so a subsequent connect() is not rejected by
+        # the singleflight guard.
+        self._state = "closed"
         ws, self._ws = self._ws, None
         if ws is not None:
             try:
@@ -201,9 +306,16 @@ class SessionsWebSocket:
     # ─── Send API ─────────────────────────────────────────────────────
 
     async def send_control_response(self, response: dict) -> None:
-        """Send a ``control_response`` (e.g., permission decision)."""
-        if self._ws is None or self._closed:
-            logger.warning('[SessionsWebSocket] cannot send: not connected')
+        """Send a ``control_response`` (e.g., permission decision).
+
+        Mirrors TS ``SessionsWebSocket.ts:328-335`` — gated strictly on
+        ``state === 'connected'`` so a mid-handshake send (state
+        ``"connecting"``) is dropped, not transmitted.
+        """
+        if self._state != "connected" or self._ws is None:
+            logger.warning(
+                '[SessionsWebSocket] cannot send: state=%s', self._state
+            )
             return
         try:
             await self._ws.send(json.dumps(response))
@@ -211,9 +323,14 @@ class SessionsWebSocket:
             logger.warning('[SessionsWebSocket] send failed: %s', exc)
 
     async def send_control_request(self, inner: dict) -> None:
-        """Wrap ``inner`` in a ``control_request`` envelope and send."""
-        if self._ws is None or self._closed:
-            logger.warning('[SessionsWebSocket] cannot send: not connected')
+        """Wrap ``inner`` in a ``control_request`` envelope and send.
+
+        State-gated identically to ``send_control_response``.
+        """
+        if self._state != "connected" or self._ws is None:
+            logger.warning(
+                '[SessionsWebSocket] cannot send: state=%s', self._state
+            )
             return
         envelope = {
             'type': 'control_request',
@@ -255,16 +372,28 @@ class SessionsWebSocket:
         4003 → permanent stop, fire on_close.
         4001 → max 3 retries with linear backoff.
         other → max 5 attempts with constant delay.
+
+        Transitions ``connected → closed`` before evaluating the close
+        code so any concurrent caller sees the closed state.
         """
-        if self._closed:
+        if self._state == "closed":
             return
+        self._state = "closed"
         self._ws = None
+
+        # If the user already disconnected, do nothing — the reader
+        # itself was cancelled by disconnect(), so we're cleaning up
+        # after a race the user already chose to lose.
+        if self._user_disconnected:
+            logger.debug(
+                '[SessionsWebSocket] _on_ws_close after disconnect(); no reconnect'
+            )
+            return
 
         if close_code == WS_CLOSE_PERMANENT_UNAUTHORIZED:
             logger.debug(
                 '[SessionsWebSocket] permanent close 4003; not reconnecting'
             )
-            self._closed = True
             asyncio.get_running_loop().create_task(
                 self._invoke(self._callbacks.on_close)
             )
@@ -276,7 +405,6 @@ class SessionsWebSocket:
                 logger.debug(
                     '[SessionsWebSocket] 4001 retry budget exhausted; not reconnecting'
                 )
-                self._closed = True
                 asyncio.get_running_loop().create_task(
                     self._invoke(self._callbacks.on_close)
                 )
@@ -289,7 +417,6 @@ class SessionsWebSocket:
         self._reconnect_attempts += 1
         if self._reconnect_attempts > MAX_RECONNECT_ATTEMPTS:
             logger.debug('[SessionsWebSocket] not reconnecting (budget exhausted)')
-            self._closed = True
             asyncio.get_running_loop().create_task(
                 self._invoke(self._callbacks.on_close)
             )
@@ -297,12 +424,17 @@ class SessionsWebSocket:
         self._schedule_reconnect_with_delay(RECONNECT_DELAY_SECONDS)
 
     def _schedule_reconnect_or_close(self) -> None:
-        """Initial-connect failure path: same retry strategy as transient close."""
-        if self._closed:
+        """Initial-connect failure path: same retry strategy as transient close.
+
+        Called from ``connect()``'s ws_connect ``except`` branch (state
+        was just set to ``"closed"``). Bails if the user has disconnected.
+        """
+        if self._user_disconnected:
+            return
+        if self._state != "closed":
             return
         self._reconnect_attempts += 1
         if self._reconnect_attempts > MAX_RECONNECT_ATTEMPTS:
-            self._closed = True
             asyncio.get_running_loop().create_task(
                 self._invoke(self._callbacks.on_close)
             )
@@ -316,7 +448,10 @@ class SessionsWebSocket:
                 await asyncio.sleep(delay_seconds)
             except asyncio.CancelledError:
                 return
-            if self._closed:
+            # If the user called disconnect() during the sleep, the
+            # latch is set; bail. Also bail if state has moved away
+            # from "closed" (e.g., a manual reconnect() ran).
+            if self._user_disconnected or self._state != "closed":
                 return
             await self.connect()
 
@@ -335,6 +470,7 @@ class SessionsWebSocket:
 
 
 __all__ = [
+    'ConnectionState',
     'GetAccessToken',
     'MAX_RECONNECT_ATTEMPTS',
     'MAX_SESSION_NOT_FOUND_RETRIES',

--- a/tests/remote/test_sessions_websocket.py
+++ b/tests/remote/test_sessions_websocket.py
@@ -303,3 +303,245 @@ async def test_send_control_request_wraps_in_envelope():
     finally:
         ws_server.close()
         await ws_server.wait_closed()
+
+
+# ─── Round-2: state-machine / re-entrancy tests ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_connect_is_singleflight():
+    """Two ``connect()`` calls in flight must produce only one WS handshake.
+
+    Round-2 fix: the second call enters ``connect()``, sees state is
+    ``"connecting"``, and bails immediately.
+    """
+    class _SlowAcceptServer:
+        def __init__(self) -> None:
+            self.connection_count = 0
+            self._lock = asyncio.Lock()
+
+        async def handler(self, ws):
+            async with self._lock:
+                self.connection_count += 1
+            try:
+                await asyncio.sleep(0.3)
+            except asyncio.CancelledError:
+                pass
+
+    server = _SlowAcceptServer()
+    port = _free_port()
+    ws_server = await ws_serve(server.handler, '127.0.0.1', port)
+    try:
+        callbacks = SessionsWebSocketCallbacks(on_message=lambda m: None)
+        ws = SessionsWebSocket(
+            'sid', 'org', lambda: 'tok', callbacks,
+            base_url=f'ws://127.0.0.1:{port}',
+        )
+        task_a = asyncio.create_task(ws.connect())
+        task_b = asyncio.create_task(ws.connect())
+        await asyncio.gather(task_a, task_b)
+        await asyncio.sleep(0.1)
+        assert server.connection_count == 1, (
+            f'expected single-flight connect, got {server.connection_count} '
+            'WS handshakes'
+        )
+        assert ws.is_connected()
+        assert ws.state == 'connected'
+        await ws.disconnect()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_send_before_connected_is_dropped():
+    """Send during the ``connecting`` window is dropped, not transmitted.
+
+    Round-2 fix: ``send_control_response`` and ``send_control_request``
+    gate strictly on ``state == 'connected'``.
+    """
+    class _EchoServer:
+        async def handler(self, ws):
+            try:
+                async for raw in ws:
+                    pass
+            except websockets.exceptions.ConnectionClosed:
+                pass
+
+    server = _EchoServer()
+    port = _free_port()
+    ws_server = await ws_serve(server.handler, '127.0.0.1', port)
+    try:
+        callbacks = SessionsWebSocketCallbacks(on_message=lambda m: None)
+        ws = SessionsWebSocket(
+            'sid', 'org', lambda: 'tok', callbacks,
+            base_url=f'ws://127.0.0.1:{port}',
+        )
+        # Simulate the in-handshake window directly: state is "connecting"
+        # but no WS is assigned. Both send paths must early-return rather
+        # than raising on ``self._ws.send`` (which would AttributeError).
+        ws._state = 'connecting'  # type: ignore[assignment]
+        ws._ws = None
+        await ws.send_control_response({'type': 'control_response', 'response': {}})
+        await ws.send_control_request({'subtype': 'interrupt'})
+        assert ws.is_connected() is False
+        ws._state = 'closed'  # type: ignore[assignment]
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_during_handshake_unwinds_cleanly():
+    """``disconnect()`` mid ``connect()`` transitions to closed and closes
+    the orphan WS that ``ws_connect`` returns after disconnect.
+    """
+    connections_seen: list[object] = []
+    closed_event = asyncio.Event()
+
+    class _SlowAcceptServer:
+        async def handler(self, ws):
+            connections_seen.append(ws)
+            try:
+                async for _ in ws:
+                    pass
+            except websockets.exceptions.ConnectionClosed:
+                pass
+            closed_event.set()
+
+    server = _SlowAcceptServer()
+    port = _free_port()
+    ws_server = await ws_serve(server.handler, '127.0.0.1', port)
+    try:
+        callbacks = SessionsWebSocketCallbacks(on_message=lambda m: None)
+        ws = SessionsWebSocket(
+            'sid', 'org', lambda: 'tok', callbacks,
+            base_url=f'ws://127.0.0.1:{port}',
+        )
+        connect_task = asyncio.create_task(ws.connect())
+        await asyncio.sleep(0.0)
+        await ws.disconnect()
+        await connect_task
+        assert ws.state == 'closed'
+        assert ws.is_connected() is False
+        if connections_seen:
+            await asyncio.wait_for(closed_event.wait(), timeout=2.0)
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_state_progresses_through_connecting_to_connected():
+    """Observable state machine: closed → connecting → connected on success."""
+    states: list[str] = []
+
+    class _Server:
+        async def handler(self, ws):
+            try:
+                await asyncio.sleep(0.2)
+            except asyncio.CancelledError:
+                pass
+
+    server = _Server()
+    port = _free_port()
+    ws_server = await ws_serve(server.handler, '127.0.0.1', port)
+    try:
+        callbacks = SessionsWebSocketCallbacks(on_message=lambda m: None)
+        ws = SessionsWebSocket(
+            'sid', 'org', lambda: 'tok', callbacks,
+            base_url=f'ws://127.0.0.1:{port}',
+        )
+        assert ws.state == 'closed'
+        states.append(ws.state)
+
+        connect_task = asyncio.create_task(ws.connect())
+        for _ in range(50):
+            if ws.state == 'connecting':
+                states.append('connecting')
+                break
+            await asyncio.sleep(0)
+        await connect_task
+        states.append(ws.state)
+        assert ws.state == 'connected'
+        assert ws.is_connected() is True
+        assert states[0] == 'closed'
+        assert 'connecting' in states
+        assert states[-1] == 'connected'
+        await ws.disconnect()
+        assert ws.state == 'closed'
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_double_disconnect_is_idempotent():
+    """``disconnect()`` after ``disconnect()`` must be a no-op."""
+    class _Server:
+        async def handler(self, ws):
+            try:
+                async for _ in ws:
+                    pass
+            except websockets.exceptions.ConnectionClosed:
+                pass
+
+    server = _Server()
+    port = _free_port()
+    ws_server = await ws_serve(server.handler, '127.0.0.1', port)
+    try:
+        callbacks = SessionsWebSocketCallbacks(on_message=lambda m: None)
+        ws = SessionsWebSocket(
+            'sid', 'org', lambda: 'tok', callbacks,
+            base_url=f'ws://127.0.0.1:{port}',
+        )
+        await ws.connect()
+        assert ws.is_connected()
+        await ws.disconnect()
+        assert ws.state == 'closed'
+        await ws.disconnect()
+        assert ws.state == 'closed'
+        assert ws.is_connected() is False
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_clears_user_disconnected_latch():
+    """``reconnect()`` after ``disconnect()`` re-arms the WS."""
+    class _Server:
+        def __init__(self) -> None:
+            self.connection_count = 0
+
+        async def handler(self, ws):
+            self.connection_count += 1
+            try:
+                async for _ in ws:
+                    pass
+            except websockets.exceptions.ConnectionClosed:
+                pass
+
+    server = _Server()
+    port = _free_port()
+    ws_server = await ws_serve(server.handler, '127.0.0.1', port)
+    try:
+        callbacks = SessionsWebSocketCallbacks(on_message=lambda m: None)
+        ws = SessionsWebSocket(
+            'sid', 'org', lambda: 'tok', callbacks,
+            base_url=f'ws://127.0.0.1:{port}',
+        )
+        await ws.connect()
+        await ws.disconnect()
+        # connect() after disconnect must be rejected.
+        await ws.connect()
+        assert ws.state == 'closed'
+        assert server.connection_count == 1
+        # reconnect() clears the latch and re-arms.
+        await ws.reconnect()
+        assert ws.is_connected()
+        assert server.connection_count == 2
+        await ws.disconnect()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()


### PR DESCRIPTION
## Summary

- Port the TS `WebSocketState` tristate (`closed | connecting | connected`) into `src/remote/sessions_websocket.py`, replacing the single `_closed` bool that conflated mid-handshake with fully open.
- Add a `_user_disconnected` latch so a transient reconnect scheduled by `_on_ws_close` cannot fire after the user has called `disconnect()`.
- `connect()` is now single-flight: re-entrant calls during `connecting`/`connected` are no-ops, and the post-`ws_connect` race check closes any orphan WS produced by a mid-handshake `disconnect()`. Send paths gate strictly on `state == "connected"`.

## Why

The Python `SessionsWebSocket` had no single-flight guard on `connect()` (TS `SessionsWebSocket.ts:101-104`) and `is_connected()` returned True while the WS object existed but the open handshake hadn't fully landed (TS `:362-364` checks `state === 'connected'`). Under concurrency — e.g., a scheduled reconnect task firing while `reconnect()` is already in flight, or two callers both invoking `connect()` — this leaked WS handles and let sends fire on a not-yet-open socket.

Round-1 ported the protocol (close-code branching, retry budgets, ping interval); this round closes the lifecycle gap.

## Test plan

- [x] `pytest tests/remote/test_sessions_websocket.py -q` — 13 passed (7 existing + 6 new state-machine tests):
  - `test_concurrent_connect_is_singleflight` — two parallel `connect()` calls produce one WS handshake
  - `test_send_before_connected_is_dropped` — sends in `connecting` state are dropped, not AttributeError
  - `test_disconnect_during_handshake_unwinds_cleanly` — `disconnect()` during the `ws_connect` await closes the orphan
  - `test_state_progresses_through_connecting_to_connected` — observable transitions
  - `test_double_disconnect_is_idempotent`
  - `test_reconnect_clears_user_disconnected_latch` — `reconnect()` re-arms a disconnected instance
- [x] `pytest tests/remote/test_sessions_websocket.py tests/test_porting_workspace.py tests/test_no_top_level_decoys.py -q` — 74 passed
- [x] `pytest tests/bridge/ tests/remote/ -q` — 203 passed (no regression)

## Out of scope

- `RemoteSessionManager.connect()` schedules `SessionsWebSocket.connect()` via `loop.create_task` — touching it would expand scope and the fix in the WS itself is sufficient.
- Other transports (`ReplBridgeTransport` close codes 4090/4091/4092) — already in round-1.
- Pre-existing failures (`zhipuai`, `mcp_doctor` PATH) — out of scope per repo conventions.

## Docs

- `/Users/ericlee2/workspace/clawcodex/my-docs/ch16-remote-round2-gap-analysis.md`
- `/Users/ericlee2/workspace/clawcodex/my-docs/ch16-remote-round2-plan.md`

Generated with [Claude Code](https://claude.com/claude-code)