### PR TITLE
feat(ch11/round2): port team-memory defense-in-depth + combined prompt

### DIFF
--- a/src/memdir/__init__.py
+++ b/src/memdir/__init__.py
@@ -60,6 +60,21 @@ from .paths import (
     is_auto_memory_enabled,
     sanitize_path,
 )
+from .team_mem_paths import (
+    PathTraversalError,
+    get_team_mem_entrypoint,
+    get_team_mem_path,
+    is_team_mem_file,
+    is_team_mem_path,
+    is_team_memory_enabled,
+    validate_team_mem_key,
+    validate_team_mem_write_path,
+)
+from .team_mem_prompts import (
+    DIRS_EXIST_GUIDANCE,
+    TYPES_SECTION_COMBINED,
+    build_combined_memory_prompt,
+)
 
 __all__ = [
     # paths
@@ -108,4 +123,16 @@ __all__ = [
     "memory_age_days",
     "memory_freshness_note",
     "memory_freshness_text",
+    # team memory
+    "DIRS_EXIST_GUIDANCE",
+    "PathTraversalError",
+    "TYPES_SECTION_COMBINED",
+    "build_combined_memory_prompt",
+    "get_team_mem_entrypoint",
+    "get_team_mem_path",
+    "is_team_mem_file",
+    "is_team_mem_path",
+    "is_team_memory_enabled",
+    "validate_team_mem_key",
+    "validate_team_mem_write_path",
 ]

--- a/src/memdir/memdir.py
+++ b/src/memdir/memdir.py
@@ -291,15 +291,35 @@ def build_memory_prompt(
 def load_memory_prompt() -> str | None:
     """Top-level dispatch for the auto-memory system prompt section.
 
-    Returns ``None`` when auto-memory is disabled. Otherwise creates the
-    memory directory if it does not exist and returns the assembled
-    prompt section.
+    Returns ``None`` when auto-memory is disabled. Otherwise creates
+    the memory directory(ies) if they do not exist and returns the
+    assembled prompt section.
 
-    KAIROS daily-log mode and team-memory combined mode are deferred
-    (Slice D in the refactor plan).
+    Dispatch order matches TS ``loadMemoryPrompt``:
+
+    1. Auto-memory disabled → ``None``.
+    2. Team memory enabled → combined private + team prompt.
+    3. Else → single-directory auto-memory prompt.
+
+    KAIROS daily-log mode is still deferred (Slice D in the refactor
+    plan).
     """
     if not is_auto_memory_enabled():
         return None
+
+    # Lazy import to avoid a circular import at module load time
+    # (team_mem_prompts imports from this module).
+    from .team_mem_paths import get_team_mem_path, is_team_memory_enabled
+
+    if is_team_memory_enabled():
+        from .team_mem_prompts import build_combined_memory_prompt
+
+        # team_dir is nested under auto_dir, so creating team_dir with
+        # parents=True creates auto_dir as a side effect.
+        team_dir = get_team_mem_path()
+        ensure_memory_dir_exists(team_dir)
+        return build_combined_memory_prompt()
+
     auto_dir = get_auto_mem_path()
     ensure_memory_dir_exists(auto_dir)
     return build_memory_prompt(

--- a/src/memdir/team_mem_paths.py
+++ b/src/memdir/team_mem_paths.py
@@ -237,14 +237,15 @@ def _is_real_path_within_team_dir(real_candidate: str) -> bool:
 def is_team_mem_path(file_path: str) -> bool:
     """String-level prefix check: is *file_path* under the team dir?
 
-    ``os.path.normpath`` eliminates ``..`` segments so ``team/../etc``
-    is rejected. Does NOT resolve symlinks — use
+    Uses ``os.path.abspath`` (mirrors TS ``path.resolve``) to convert
+    relative paths to absolute and eliminate ``..`` segments so
+    ``team/../etc`` is rejected. Does NOT resolve symlinks — use
     :func:`validate_team_mem_write_path` or :func:`validate_team_mem_key`
     for write-side validation, which add symlink resolution.
     """
     if not file_path:
         return False
-    resolved = os.path.normpath(file_path)
+    resolved = os.path.abspath(file_path)
     team_dir = get_team_mem_path()
     # team_dir already ends with os.sep (from get_team_mem_path).
     # Also accept exact match (resolved + sep == team_dir).

--- a/src/memdir/team_mem_paths.py
+++ b/src/memdir/team_mem_paths.py
@@ -1,0 +1,309 @@
+"""Team-memory path resolution and three-layer path-traversal defense.
+
+Ports `typescript/src/memdir/teamMemPaths.ts`. Team memory is a
+``team/`` subdirectory under the per-project auto-memory directory, so
+disabling auto-memory transitively disables team memory.
+
+The chapter's "Defense in Depth" section motivates three layers:
+
+1. **Input sanitization** (`_sanitize_path_key`) — rejects null bytes,
+   URL-encoded traversals (``%2e%2e%2f``), NFKC normalization attacks
+   (fullwidth ``．．／`` normalizes to ASCII ``../``), backslashes, and
+   absolute paths.
+2. **String-level containment** (`os.path.abspath`/`os.path.normpath`)
+   — normalizes ``..`` segments and checks the candidate is inside
+   ``teamDir + sep`` so ``team-evil/`` cannot match ``team/``.
+3. **Symlink resolution** (`_realpath_deepest_existing`) — resolves
+   symlinks on the deepest existing ancestor and re-joins the
+   non-existing tail, catching attacks where a symlink inside
+   ``team/`` points outside.
+
+All validation failures raise :class:`PathTraversalError`. No partial
+successes, no fallbacks — fail closed.
+
+Sync rather than async (TS is async because Node's ``fs.promises`` is).
+Python's ``os.path.realpath``/``os.path.islink`` are sync and the
+``load_memory_prompt()`` call site is sync.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import unicodedata
+import urllib.parse
+
+from .paths import (
+    _is_env_truthy,
+    get_auto_mem_path,
+    is_auto_memory_enabled,
+)
+
+__all__ = [
+    "PathTraversalError",
+    "is_team_memory_enabled",
+    "get_team_mem_path",
+    "get_team_mem_entrypoint",
+    "is_team_mem_path",
+    "is_team_mem_file",
+    "validate_team_mem_write_path",
+    "validate_team_mem_key",
+]
+
+
+class PathTraversalError(Exception):
+    """Raised when path validation detects a traversal or injection attempt.
+
+    All three defense layers raise this single exception type so that
+    callers can ``except PathTraversalError`` once and skip a malicious
+    entry without aborting an entire batch.
+    """
+
+
+def _sanitize_path_key(key: str) -> str:
+    """Reject dangerous patterns in a server-supplied relative key.
+
+    Mirrors TS ``sanitizePathKey``. Raises :class:`PathTraversalError`
+    on any of: null byte, URL-encoded traversal, NFKC-normalization
+    attack, backslash, absolute path.
+    """
+    # Null bytes truncate paths in C-based syscalls.
+    if "\0" in key:
+        raise PathTraversalError(f'Null byte in path key: "{key}"')
+
+    # URL-encoded traversals (e.g. %2e%2e%2f → ../).
+    try:
+        decoded = urllib.parse.unquote(key, errors="strict")
+    except (UnicodeDecodeError, ValueError):
+        # Malformed percent-encoding — not valid URL-encoding, so no
+        # URL-encoded traversal is possible. Fall through.
+        decoded = key
+    if decoded != key and (".." in decoded or "/" in decoded):
+        raise PathTraversalError(f'URL-encoded traversal in path key: "{key}"')
+
+    # NFKC normalization attack: fullwidth ．．／ (U+FF0E U+FF0F) normalizes
+    # to ASCII ../ under NFKC. While Python's os.path treats these as
+    # literal bytes, downstream layers or filesystems may normalize —
+    # reject for defense in depth.
+    normalized = unicodedata.normalize("NFKC", key)
+    if normalized != key and (
+        ".." in normalized
+        or "/" in normalized
+        or "\\" in normalized
+        or "\0" in normalized
+    ):
+        raise PathTraversalError(
+            f'Unicode-normalized traversal in path key: "{key}"'
+        )
+
+    # Backslash (Windows separator used as traversal vector).
+    if "\\" in key:
+        raise PathTraversalError(f'Backslash in path key: "{key}"')
+
+    # Absolute paths.
+    if key.startswith("/"):
+        raise PathTraversalError(f'Absolute path key: "{key}"')
+
+    return key
+
+
+def is_team_memory_enabled() -> bool:
+    """Whether team-memory features are active.
+
+    Team memory is a subdirectory of auto-memory, so it requires
+    auto-memory to be enabled. Behind that, gated on
+    ``CLAUDE_CODE_TEAM_MEMORY`` env var (defaults to off).
+
+    The TS gate is a GrowthBook feature flag (``tengu_herring_clock``).
+    Python's analytics surface is not yet ported (ch16 scope), so we
+    expose the same shape via env var.
+    """
+    if not is_auto_memory_enabled():
+        return False
+    return _is_env_truthy(os.environ.get("CLAUDE_CODE_TEAM_MEMORY"))
+
+
+def get_team_mem_path() -> str:
+    """Team-memory directory: ``<auto_mem>/team/`` with trailing sep.
+
+    NFC-normalized to match the auto-memory contract (see
+    :func:`src.memdir.paths.get_auto_mem_path`). The trailing separator
+    is load-bearing for the prefix-attack check
+    (``team-evil/`` must not match ``team/``).
+    """
+    return unicodedata.normalize(
+        "NFC", os.path.join(get_auto_mem_path(), "team") + os.sep
+    )
+
+
+def get_team_mem_entrypoint() -> str:
+    """``MEMORY.md`` inside the team-memory directory."""
+    return os.path.join(get_auto_mem_path(), "team", "MEMORY.md")
+
+
+def _realpath_deepest_existing(absolute_path: str) -> str:
+    """Resolve symlinks on the deepest existing ancestor of *absolute_path*.
+
+    The target file may not exist yet (we may be about to create it),
+    so we walk up the directory tree until ``realpath(strict=True)``
+    succeeds, then rejoin the non-existing tail onto the resolved
+    ancestor.
+
+    SECURITY: ``os.path.normpath`` does NOT resolve symlinks. An
+    attacker who places a symlink inside ``teamDir`` pointing outside
+    (e.g. to ``~/.ssh/authorized_keys``) would pass a normpath-only
+    containment check. Using ``realpath()`` on the deepest existing
+    ancestor compares actual filesystem locations.
+
+    Raises :class:`PathTraversalError` on:
+      * A dangling symlink in *absolute_path* itself (the link entry
+        exists, but the target does not — writing would still follow
+        it and create the target outside teamDir).
+      * Symlink loop (``ELOOP``).
+      * Unverifiable containment (``EACCES``, ``EIO``).
+    """
+    tail: list[str] = []
+    current = absolute_path
+    while True:
+        parent = os.path.dirname(current)
+        if current == parent:
+            # Reached filesystem root without finding an existing ancestor.
+            # Fall back to the input — the caller's containment check
+            # will reject if appropriate.
+            return absolute_path
+
+        try:
+            real_current = os.path.realpath(current, strict=True)
+            if not tail:
+                return real_current
+            # Rejoin the non-existing tail in reverse (deepest popped first).
+            return os.path.join(real_current, *reversed(tail))
+        except OSError as exc:
+            code = exc.errno
+            if code in (errno.ENOENT, errno.ENOTDIR):
+                # ENOENT could be truly non-existent OR a dangling
+                # symlink whose target does not exist. ``os.path.islink``
+                # distinguishes: true for the dangling-symlink case.
+                if os.path.islink(current):
+                    raise PathTraversalError(
+                        f'Dangling symlink detected (target does not exist): "{current}"'
+                    ) from exc
+                # Otherwise: walk up and try the parent.
+            elif code == errno.ELOOP:
+                raise PathTraversalError(
+                    f'Symlink loop detected in path: "{current}"'
+                ) from exc
+            elif code == errno.ENAMETOOLONG:
+                # Treat like ENOENT — walk up to find an ancestor.
+                pass
+            else:
+                # EACCES, EIO, EPERM, etc. — cannot verify containment.
+                # Wrap as PathTraversalError so callers can skip this entry.
+                raise PathTraversalError(
+                    f'Cannot verify path containment ({code}): "{current}"'
+                ) from exc
+
+        # Walk up. Pop the deepest non-existing segment onto the tail.
+        tail.append(current[len(parent) + len(os.sep):])
+        current = parent
+
+
+def _is_real_path_within_team_dir(real_candidate: str) -> bool:
+    """Check whether *real_candidate* is inside the real team directory.
+
+    Both sides are realpath'd so the comparison is between canonical
+    filesystem locations. If the team directory does not exist yet,
+    returns ``True``: a symlink-escape requires a pre-existing symlink
+    inside ``teamDir``, which itself requires ``teamDir`` to exist.
+
+    Returns ``False`` on permission or other I/O errors (fail closed).
+    """
+    team_dir = get_team_mem_path().rstrip("/\\")
+    try:
+        real_team_dir = os.path.realpath(team_dir, strict=True)
+    except OSError as exc:
+        if exc.errno in (errno.ENOENT, errno.ENOTDIR):
+            # Team dir doesn't exist — symlink escape impossible.
+            return True
+        # EACCES, EIO, etc. — fail closed.
+        return False
+    if real_candidate == real_team_dir:
+        return True
+    # Trailing-sep prefix check: ``/foo/team-evil`` must not match
+    # ``/foo/team``.
+    return real_candidate.startswith(real_team_dir + os.sep)
+
+
+def is_team_mem_path(file_path: str) -> bool:
+    """String-level prefix check: is *file_path* under the team dir?
+
+    ``os.path.normpath`` eliminates ``..`` segments so ``team/../etc``
+    is rejected. Does NOT resolve symlinks — use
+    :func:`validate_team_mem_write_path` or :func:`validate_team_mem_key`
+    for write-side validation, which add symlink resolution.
+    """
+    if not file_path:
+        return False
+    resolved = os.path.normpath(file_path)
+    team_dir = get_team_mem_path()
+    # team_dir already ends with os.sep (from get_team_mem_path).
+    # Also accept exact match (resolved + sep == team_dir).
+    return resolved.startswith(team_dir) or resolved + os.sep == team_dir
+
+
+def is_team_mem_file(file_path: str) -> bool:
+    """Whether *file_path* is a team-memory file and team-memory is on."""
+    return is_team_memory_enabled() and is_team_mem_path(file_path)
+
+
+def validate_team_mem_write_path(file_path: str) -> str:
+    """Validate that *file_path* is safe for writing to the team dir.
+
+    Returns the resolved absolute path. Raises
+    :class:`PathTraversalError` on null bytes, ``..`` escape, or
+    symlink-based escape.
+    """
+    if "\0" in file_path:
+        raise PathTraversalError(f'Null byte in path: "{file_path}"')
+
+    # First pass: normalize .. segments and check string-level containment.
+    resolved = os.path.abspath(file_path)
+    team_dir = get_team_mem_path()
+    if not resolved.startswith(team_dir):
+        raise PathTraversalError(
+            f'Path escapes team memory directory: "{file_path}"'
+        )
+
+    # Second pass: resolve symlinks on the deepest existing ancestor
+    # and verify real-path containment.
+    real_path = _realpath_deepest_existing(resolved)
+    if not _is_real_path_within_team_dir(real_path):
+        raise PathTraversalError(
+            f'Path escapes team memory directory via symlink: "{file_path}"'
+        )
+    return resolved
+
+
+def validate_team_mem_key(relative_key: str) -> str:
+    """Validate a relative path key (e.g. from a team-sync server).
+
+    Sanitizes the key, joins it with the team directory, then runs the
+    same two-pass validation as :func:`validate_team_mem_write_path`.
+    Returns the resolved absolute path.
+    """
+    _sanitize_path_key(relative_key)
+    team_dir = get_team_mem_path()
+    full_path = os.path.join(team_dir, relative_key)
+
+    resolved = os.path.abspath(full_path)
+    if not resolved.startswith(team_dir):
+        raise PathTraversalError(
+            f'Key escapes team memory directory: "{relative_key}"'
+        )
+
+    real_path = _realpath_deepest_existing(resolved)
+    if not _is_real_path_within_team_dir(real_path):
+        raise PathTraversalError(
+            f'Key escapes team memory directory via symlink: "{relative_key}"'
+        )
+    return resolved

--- a/src/memdir/team_mem_prompts.py
+++ b/src/memdir/team_mem_prompts.py
@@ -1,0 +1,205 @@
+"""Combined private-and-team memory prompt builder.
+
+Ports `typescript/src/memdir/teamMemPrompts.ts`. Emitted when both
+auto-memory and team-memory are active. Uses a COMBINED variant of the
+type taxonomy that adds ``<scope>`` tags and swaps the single-directory
+prose for a two-directory variant.
+
+The :data:`TYPES_SECTION_COMBINED` constant lives in this module rather
+than in ``memory_types.py`` because it is consumed exclusively here.
+Eval-tuned prose — do NOT paraphrase any of the strings.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .memdir import (
+    ENTRYPOINT_NAME,
+    MAX_ENTRYPOINT_LINES,
+)
+from .memory_types import (
+    MEMORY_DRIFT_CAVEAT,
+    MEMORY_FRONTMATTER_EXAMPLE,
+    TRUSTING_RECALL_SECTION,
+    WHAT_NOT_TO_SAVE_SECTION,
+)
+from .paths import get_auto_mem_path
+from .team_mem_paths import get_team_mem_path
+
+__all__ = [
+    "TYPES_SECTION_COMBINED",
+    "DIRS_EXIST_GUIDANCE",
+    "build_combined_memory_prompt",
+]
+
+
+# Plural form of ``DIR_EXISTS_GUIDANCE`` from memdir.py. Used in the
+# combined-prompt header sentence that mentions both directories.
+DIRS_EXIST_GUIDANCE = (
+    "Both directories already exist — write to them directly with the "
+    "Write tool (do not run mkdir or check for their existence)."
+)
+
+
+# Verbatim from ``typescript/src/memdir/memoryTypes.ts``. Adds ``<scope>``
+# tags per type and uses ``private``/``team`` qualifiers in examples.
+TYPES_SECTION_COMBINED: tuple[str, ...] = (
+    "## Types of memory",
+    "",
+    "There are several discrete types of memory that you can store in your memory system. Each type below declares a <scope> of `private`, `team`, or guidance for choosing between the two.",
+    "",
+    "<types>",
+    "<type>",
+    "    <name>user</name>",
+    "    <scope>always private</scope>",
+    "    <description>Contain information about the user's role, goals, responsibilities, and knowledge. Great user memories help you tailor your future behavior to the user's preferences and perspective. Your goal in reading and writing these memories is to build up an understanding of who the user is and how you can be most helpful to them specifically. For example, you should collaborate with a senior software engineer differently than a student who is coding for the very first time. Keep in mind, that the aim here is to be helpful to the user. Avoid writing memories about the user that could be viewed as a negative judgement or that are not relevant to the work you're trying to accomplish together.</description>",
+    "    <when_to_save>When you learn any details about the user's role, preferences, responsibilities, or knowledge</when_to_save>",
+    "    <how_to_use>When your work should be informed by the user's profile or perspective. For example, if the user is asking you to explain a part of the code, you should answer that question in a way that is tailored to the specific details that they will find most valuable or that helps them build their mental model in relation to domain knowledge they already have.</how_to_use>",
+    "    <examples>",
+    "    user: I'm a data scientist investigating what logging we have in place",
+    "    assistant: [saves private user memory: user is a data scientist, currently focused on observability/logging]",
+    "",
+    "    user: I've been writing Go for ten years but this is my first time touching the React side of this repo",
+    "    assistant: [saves private user memory: deep Go expertise, new to React and this project's frontend — frame frontend explanations in terms of backend analogues]",
+    "    </examples>",
+    "</type>",
+    "<type>",
+    "    <name>feedback</name>",
+    "    <scope>default to private. Save as team only when the guidance is clearly a project-wide convention that every contributor should follow (e.g., a testing policy, a build invariant), not a personal style preference.</scope>",
+    "    <description>Guidance the user has given you about how to approach work — both what to avoid and what to keep doing. These are a very important type of memory to read and write as they allow you to remain coherent and responsive to the way you should approach work in the project. Record from failure AND success: if you only save corrections, you will avoid past mistakes but drift away from approaches the user has already validated, and may grow overly cautious. Before saving a private feedback memory, check that it doesn't contradict a team feedback memory — if it does, either don't save it or note the override explicitly.</description>",
+    "    <when_to_save>Any time the user corrects your approach (\"no not that\", \"don't\", \"stop doing X\") OR confirms a non-obvious approach worked (\"yes exactly\", \"perfect, keep doing that\", accepting an unusual choice without pushback). Corrections are easy to notice; confirmations are quieter — watch for them. In both cases, save what is applicable to future conversations, especially if surprising or not obvious from the code. Include *why* so you can judge edge cases later.</when_to_save>",
+    "    <how_to_use>Let these memories guide your behavior so that the user and other users in the project do not need to offer the same guidance twice.</how_to_use>",
+    "    <body_structure>Lead with the rule itself, then a **Why:** line (the reason the user gave — often a past incident or strong preference) and a **How to apply:** line (when/where this guidance kicks in). Knowing *why* lets you judge edge cases instead of blindly following the rule.</body_structure>",
+    "    <examples>",
+    "    user: don't mock the database in these tests — we got burned last quarter when mocked tests passed but the prod migration failed",
+    "    assistant: [saves team feedback memory: integration tests must hit a real database, not mocks. Reason: prior incident where mock/prod divergence masked a broken migration. Team scope: this is a project testing policy, not a personal preference]",
+    "",
+    "    user: stop summarizing what you just did at the end of every response, I can read the diff",
+    "    assistant: [saves private feedback memory: this user wants terse responses with no trailing summaries. Private because it's a communication preference, not a project convention]",
+    "",
+    "    user: yeah the single bundled PR was the right call here, splitting this one would've just been churn",
+    "    assistant: [saves private feedback memory: for refactors in this area, user prefers one bundled PR over many small ones. Confirmed after I chose this approach — a validated judgment call, not a correction]",
+    "    </examples>",
+    "</type>",
+    "<type>",
+    "    <name>project</name>",
+    "    <scope>private or team, but strongly bias toward team</scope>",
+    "    <description>Information that you learn about ongoing work, goals, initiatives, bugs, or incidents within the project that is not otherwise derivable from the code or git history. Project memories help you understand the broader context and motivation behind the work users are working on within this working directory.</description>",
+    "    <when_to_save>When you learn who is doing what, why, or by when. These states change relatively quickly so try to keep your understanding of this up to date. Always convert relative dates in user messages to absolute dates when saving (e.g., \"Thursday\" → \"2026-03-05\"), so the memory remains interpretable after time passes.</when_to_save>",
+    "    <how_to_use>Use these memories to more fully understand the details and nuance behind the user's request, anticipate coordination issues across users, make better informed suggestions.</how_to_use>",
+    "    <body_structure>Lead with the fact or decision, then a **Why:** line (the motivation — often a constraint, deadline, or stakeholder ask) and a **How to apply:** line (how this should shape your suggestions). Project memories decay fast, so the why helps future-you judge whether the memory is still load-bearing.</body_structure>",
+    "    <examples>",
+    "    user: we're freezing all non-critical merges after Thursday — mobile team is cutting a release branch",
+    "    assistant: [saves team project memory: merge freeze begins 2026-03-05 for mobile release cut. Flag any non-critical PR work scheduled after that date]",
+    "",
+    "    user: the reason we're ripping out the old auth middleware is that legal flagged it for storing session tokens in a way that doesn't meet the new compliance requirements",
+    "    assistant: [saves team project memory: auth middleware rewrite is driven by legal/compliance requirements around session token storage, not tech-debt cleanup — scope decisions should favor compliance over ergonomics]",
+    "    </examples>",
+    "</type>",
+    "<type>",
+    "    <name>reference</name>",
+    "    <scope>usually team</scope>",
+    "    <description>Stores pointers to where information can be found in external systems. These memories allow you to remember where to look to find up-to-date information outside of the project directory.</description>",
+    "    <when_to_save>When you learn about resources in external systems and their purpose. For example, that bugs are tracked in a specific project in Linear or that feedback can be found in a specific Slack channel.</when_to_save>",
+    "    <how_to_use>When the user references an external system or information that may be in an external system.</how_to_use>",
+    "    <examples>",
+    "    user: check the Linear project \"INGEST\" if you want context on these tickets, that's where we track all pipeline bugs",
+    "    assistant: [saves team reference memory: pipeline bugs are tracked in Linear project \"INGEST\"]",
+    "",
+    "    user: the Grafana board at grafana.internal/d/api-latency is what oncall watches — if you're touching request handling, that's the thing that'll page someone",
+    "    assistant: [saves team reference memory: grafana.internal/d/api-latency is the oncall latency dashboard — check it when editing request-path code]",
+    "    </examples>",
+    "</type>",
+    "</types>",
+    "",
+)
+
+
+def _how_to_save_section(skip_index: bool) -> list[str]:
+    if skip_index:
+        return [
+            "## How to save memories",
+            "",
+            "Write each memory to its own file in the chosen directory (private or team, per the type's scope guidance) using this frontmatter format:",
+            "",
+            *MEMORY_FRONTMATTER_EXAMPLE,
+            "",
+            "- Keep the name, description, and type fields in memory files up-to-date with the content",
+            "- Organize memory semantically by topic, not chronologically",
+            "- Update or remove memories that turn out to be wrong or outdated",
+            "- Do not write duplicate memories. First check if there is an existing memory you can update before writing a new one.",
+        ]
+    return [
+        "## How to save memories",
+        "",
+        "Saving a memory is a two-step process:",
+        "",
+        "**Step 1** — write the memory to its own file in the chosen directory (private or team, per the type's scope guidance) using this frontmatter format:",
+        "",
+        *MEMORY_FRONTMATTER_EXAMPLE,
+        "",
+        f"**Step 2** — add a pointer to that file in the same directory's `{ENTRYPOINT_NAME}`. Each directory (private and team) has its own `{ENTRYPOINT_NAME}` index — each entry should be one line, under ~150 characters: `- [Title](file.md) — one-line hook`. They have no frontmatter. Never write memory content directly into a `{ENTRYPOINT_NAME}`.",
+        "",
+        f"- Both `{ENTRYPOINT_NAME}` indexes are loaded into your conversation context — lines after {MAX_ENTRYPOINT_LINES} will be truncated, so keep them concise",
+        "- Keep the name, description, and type fields in memory files up-to-date with the content",
+        "- Organize memory semantically by topic, not chronologically",
+        "- Update or remove memories that turn out to be wrong or outdated",
+        "- Do not write duplicate memories. First check if there is an existing memory you can update before writing a new one.",
+    ]
+
+
+def build_combined_memory_prompt(
+    extra_guidelines: Iterable[str] | None = None,
+    skip_index: bool = False,
+) -> str:
+    """Assemble the prompt section for combined private + team memory.
+
+    Closed four-type taxonomy (user / feedback / project / reference)
+    with per-type ``<scope>`` guidance embedded in the type blocks.
+    Mirrors TS ``buildCombinedMemoryPrompt`` line-for-line — the prose
+    is eval-tuned and must not be paraphrased.
+    """
+    auto_dir = get_auto_mem_path()
+    team_dir = get_team_mem_path()
+
+    lines: list[str] = [
+        "# Memory",
+        "",
+        f"You have a persistent, file-based memory system with two directories: a private directory at `{auto_dir}` and a shared team directory at `{team_dir}`. {DIRS_EXIST_GUIDANCE}",
+        "",
+        "You should build up this memory system over time so that future conversations can have a complete picture of who the user is, how they'd like to collaborate with you, what behaviors to avoid or repeat, and the context behind the work the user gives you.",
+        "",
+        "If the user explicitly asks you to remember something, save it immediately as whichever type fits best. If they ask you to forget something, find and remove the relevant entry.",
+        "",
+        "## Memory scope",
+        "",
+        "There are two scope levels:",
+        "",
+        f"- private: memories that are private between you and the current user. They persist across conversations with only this specific user and are stored at the root `{auto_dir}`.",
+        f"- team: memories that are shared with and contributed by all of the users who work within this project directory. Team memories are synced at the beginning of every session and they are stored at `{team_dir}`.",
+        "",
+        *TYPES_SECTION_COMBINED,
+        *WHAT_NOT_TO_SAVE_SECTION,
+        "- You MUST avoid saving sensitive data within shared team memories. For example, never save API keys or user credentials.",
+        "",
+        *_how_to_save_section(skip_index),
+        "",
+        "## When to access memories",
+        "- When memories (personal or team) seem relevant, or the user references prior work with them or others in their organization.",
+        "- You MUST access memory when the user explicitly asks you to check, recall, or remember.",
+        "- If the user says to *ignore* or *not use* memory: proceed as if MEMORY.md were empty. Do not apply remembered facts, cite, compare against, or mention memory content.",
+        MEMORY_DRIFT_CAVEAT,
+        "",
+        *TRUSTING_RECALL_SECTION,
+        "",
+        "## Memory and other forms of persistence",
+        "Memory is one of several persistence mechanisms available to you as you assist the user in a given conversation. The distinction is often that memory can be recalled in future conversations and should not be used for persisting information that is only useful within the scope of the current conversation.",
+        "- When to use or update a plan instead of memory: If you are about to start a non-trivial implementation task and would like to reach alignment with the user on your approach you should use a Plan rather than saving this information to memory. Similarly, if you already have a plan within the conversation and you have changed your approach persist that change by updating the plan rather than saving a memory.",
+        "- When to use or update tasks instead of memory: When you need to break your work in current conversation into discrete steps or keep track of your progress use tasks instead of saving to memory. Tasks are great for persisting information about the work that needs to be done in the current conversation, but memory should be reserved for information that will be useful in future conversations.",
+    ]
+    if extra_guidelines:
+        for guideline in extra_guidelines:
+            if guideline:
+                lines.append(guideline)
+    return "\n".join(lines)

--- a/tests/test_memdir_team_mem_paths.py
+++ b/tests/test_memdir_team_mem_paths.py
@@ -1,0 +1,290 @@
+"""Tests for src/memdir/team_mem_paths.py — defense-in-depth path validation."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.memdir.team_mem_paths import (
+    PathTraversalError,
+    _realpath_deepest_existing,
+    _sanitize_path_key,
+    get_team_mem_entrypoint,
+    get_team_mem_path,
+    is_team_mem_file,
+    is_team_mem_path,
+    is_team_memory_enabled,
+    validate_team_mem_key,
+    validate_team_mem_write_path,
+)
+
+_TRACKED_ENV = (
+    "CLAUDE_COWORK_MEMORY_PATH_OVERRIDE",
+    "CLAUDE_CODE_TEAM_MEMORY",
+    "CLAUDE_CODE_DISABLE_AUTO_MEMORY",
+    "CLAUDE_CODE_SIMPLE",
+    "CLAUDE_CODE_REMOTE",
+    "CLAUDE_CODE_REMOTE_MEMORY_DIR",
+)
+
+
+class _EnvFixture(unittest.TestCase):
+    """Mixin that snapshots/restores the tracked memory env vars."""
+
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in _TRACKED_ENV}
+        for k in _TRACKED_ENV:
+            os.environ.pop(k, None)
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+class SanitizePathKeyTest(unittest.TestCase):
+    def test_plain_key_accepted(self):
+        self.assertEqual(
+            _sanitize_path_key("feedback_testing.md"), "feedback_testing.md"
+        )
+
+    def test_nested_subdir_accepted(self):
+        self.assertEqual(_sanitize_path_key("subdir/file.md"), "subdir/file.md")
+
+    def test_null_byte_rejected(self):
+        with self.assertRaises(PathTraversalError):
+            _sanitize_path_key("foo\0bar")
+
+    def test_url_encoded_traversal_rejected(self):
+        with self.assertRaises(PathTraversalError):
+            _sanitize_path_key("%2e%2e%2fetc")
+
+    def test_url_encoded_slash_rejected(self):
+        with self.assertRaises(PathTraversalError):
+            _sanitize_path_key("foo%2fbar")
+
+    def test_malformed_percent_does_not_raise(self):
+        # %ZZ is not valid URL-encoding, so it cannot encode a traversal.
+        self.assertEqual(_sanitize_path_key("foo%ZZbar"), "foo%ZZbar")
+
+    def test_nfkc_fullwidth_dotdot_rejected(self):
+        # Fullwidth ．．／ (U+FF0E U+FF0F) → ASCII ../ under NFKC.
+        with self.assertRaises(PathTraversalError):
+            _sanitize_path_key("．．／etc")
+
+    def test_backslash_rejected(self):
+        with self.assertRaises(PathTraversalError):
+            _sanitize_path_key("foo\\bar")
+
+    def test_absolute_path_rejected(self):
+        with self.assertRaises(PathTraversalError):
+            _sanitize_path_key("/etc/passwd")
+
+
+class IsTeamMemoryEnabledTest(_EnvFixture):
+    def test_default_off(self):
+        self.assertFalse(is_team_memory_enabled())
+
+    def test_flag_on_auto_on(self):
+        os.environ["CLAUDE_CODE_TEAM_MEMORY"] = "1"
+        self.assertTrue(is_team_memory_enabled())
+
+    def test_flag_on_auto_off(self):
+        os.environ["CLAUDE_CODE_TEAM_MEMORY"] = "1"
+        # Disabling auto-memory transitively disables team memory.
+        os.environ["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] = "1"
+        self.assertFalse(is_team_memory_enabled())
+
+    def test_flag_falsy_off(self):
+        os.environ["CLAUDE_CODE_TEAM_MEMORY"] = "0"
+        self.assertFalse(is_team_memory_enabled())
+
+
+class GetTeamMemPathTest(_EnvFixture):
+    def test_trailing_separator(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ["CLAUDE_COWORK_MEMORY_PATH_OVERRIDE"] = tmp
+            self.assertTrue(get_team_mem_path().endswith(os.sep))
+
+    def test_under_auto_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ["CLAUDE_COWORK_MEMORY_PATH_OVERRIDE"] = tmp
+            from src.memdir.paths import get_auto_mem_path
+
+            self.assertTrue(get_team_mem_path().startswith(get_auto_mem_path()))
+
+    def test_entrypoint_is_memory_md(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ["CLAUDE_COWORK_MEMORY_PATH_OVERRIDE"] = tmp
+            self.assertTrue(get_team_mem_entrypoint().endswith("MEMORY.md"))
+
+
+class IsTeamMemPathTest(_EnvFixture):
+    def setUp(self):
+        super().setUp()
+        self._tmp = tempfile.TemporaryDirectory()
+        os.environ["CLAUDE_COWORK_MEMORY_PATH_OVERRIDE"] = self._tmp.name
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        super().tearDown()
+
+    def test_path_inside_accepted(self):
+        path = os.path.join(get_team_mem_path(), "feedback_testing.md")
+        self.assertTrue(is_team_mem_path(path))
+
+    def test_prefix_attack_rejected(self):
+        # team-evil/ must not match team/ — trailing sep prevents this.
+        sibling = get_team_mem_path().rstrip(os.sep) + "-evil/foo.md"
+        self.assertFalse(is_team_mem_path(sibling))
+
+    def test_traversal_rejected(self):
+        # The .. should be normalized away, escaping the team dir.
+        escaping = os.path.join(
+            get_team_mem_path(), "..", "..", "etc", "passwd"
+        )
+        self.assertFalse(is_team_mem_path(escaping))
+
+    def test_empty_returns_false(self):
+        self.assertFalse(is_team_mem_path(""))
+
+    def test_is_team_mem_file_requires_enabled(self):
+        path = os.path.join(get_team_mem_path(), "feedback_testing.md")
+        # Flag off by default — even an inside path is not a "team file".
+        self.assertFalse(is_team_mem_file(path))
+        os.environ["CLAUDE_CODE_TEAM_MEMORY"] = "1"
+        self.assertTrue(is_team_mem_file(path))
+
+
+class ValidateTeamMemWritePathTest(_EnvFixture):
+    def setUp(self):
+        super().setUp()
+        self._tmp = tempfile.TemporaryDirectory()
+        os.environ["CLAUDE_COWORK_MEMORY_PATH_OVERRIDE"] = self._tmp.name
+        Path(get_team_mem_path()).mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        super().tearDown()
+
+    def test_happy_path(self):
+        path = os.path.join(get_team_mem_path(), "feedback_testing.md")
+        resolved = validate_team_mem_write_path(path)
+        self.assertTrue(resolved.startswith(get_team_mem_path()))
+
+    def test_null_byte_rejected(self):
+        path = os.path.join(get_team_mem_path(), "bad\0file.md")
+        with self.assertRaises(PathTraversalError):
+            validate_team_mem_write_path(path)
+
+    def test_string_level_escape_rejected(self):
+        path = os.path.join(
+            get_team_mem_path(), "..", "..", "etc", "passwd"
+        )
+        with self.assertRaises(PathTraversalError):
+            validate_team_mem_write_path(path)
+
+    def test_symlink_escape_rejected(self):
+        # Create a symlink inside teamDir pointing to a sibling outside.
+        with tempfile.TemporaryDirectory() as outside:
+            link = os.path.join(get_team_mem_path(), "evil")
+            os.symlink(outside, link)
+            target = os.path.join(link, "stolen.md")
+            with self.assertRaises(PathTraversalError):
+                validate_team_mem_write_path(target)
+
+    def test_existing_inside_file_passes(self):
+        inside = os.path.join(get_team_mem_path(), "existing.md")
+        Path(inside).write_text("content", encoding="utf-8")
+        resolved = validate_team_mem_write_path(inside)
+        # On macOS /var resolves to /private/var. Compare realpaths.
+        self.assertEqual(
+            os.path.realpath(resolved), os.path.realpath(inside)
+        )
+
+
+class ValidateTeamMemKeyTest(_EnvFixture):
+    def setUp(self):
+        super().setUp()
+        self._tmp = tempfile.TemporaryDirectory()
+        os.environ["CLAUDE_COWORK_MEMORY_PATH_OVERRIDE"] = self._tmp.name
+        Path(get_team_mem_path()).mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        super().tearDown()
+
+    def test_happy_path(self):
+        resolved = validate_team_mem_key("project_freeze.md")
+        self.assertTrue(resolved.startswith(get_team_mem_path()))
+
+    def test_url_encoded_rejected(self):
+        with self.assertRaises(PathTraversalError):
+            validate_team_mem_key("%2e%2e%2fetc%2fpasswd")
+
+    def test_absolute_key_rejected(self):
+        with self.assertRaises(PathTraversalError):
+            validate_team_mem_key("/etc/passwd")
+
+    def test_traversal_key_rejected(self):
+        # _sanitize_path_key allows literal "..", but the second-pass
+        # containment check catches the join-and-resolve escape.
+        with self.assertRaises(PathTraversalError):
+            validate_team_mem_key("../../etc/passwd")
+
+    def test_backslash_key_rejected(self):
+        with self.assertRaises(PathTraversalError):
+            validate_team_mem_key("foo\\bar")
+
+    def test_symlink_escape_rejected(self):
+        with tempfile.TemporaryDirectory() as outside:
+            link = os.path.join(get_team_mem_path(), "evil-link")
+            os.symlink(outside, link)
+            with self.assertRaises(PathTraversalError):
+                validate_team_mem_key("evil-link/stolen.md")
+
+
+class RealpathDeepestExistingTest(_EnvFixture):
+    def setUp(self):
+        super().setUp()
+        self._tmp = tempfile.TemporaryDirectory()
+        os.environ["CLAUDE_COWORK_MEMORY_PATH_OVERRIDE"] = self._tmp.name
+        Path(get_team_mem_path()).mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        super().tearDown()
+
+    def test_tail_rejoin_for_nonexistent_target(self):
+        tail_path = os.path.join(
+            get_team_mem_path(), "new_subdir", "file.md"
+        )
+        result = _realpath_deepest_existing(tail_path)
+        team_real = os.path.realpath(get_team_mem_path().rstrip(os.sep))
+        self.assertTrue(result.startswith(team_real))
+        self.assertTrue(
+            result.endswith(os.path.join("new_subdir", "file.md"))
+        )
+
+    def test_existing_path_resolves_to_realpath(self):
+        f = Path(get_team_mem_path()) / "real.md"
+        f.write_text("hi", encoding="utf-8")
+        result = _realpath_deepest_existing(str(f))
+        self.assertEqual(result, os.path.realpath(str(f)))
+
+    def test_dangling_symlink_detected(self):
+        # Symlink pointing to a non-existent target — writing through
+        # this would still follow the link and create the target outside
+        # teamDir.
+        link = os.path.join(get_team_mem_path(), "dangling")
+        os.symlink(os.path.join(self._tmp.name, "nowhere"), link)
+        with self.assertRaises(PathTraversalError):
+            _realpath_deepest_existing(link)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memdir_team_mem_prompts.py
+++ b/tests/test_memdir_team_mem_prompts.py
@@ -1,0 +1,180 @@
+"""Tests for src/memdir/team_mem_prompts.py — combined memory prompt."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from src.memdir.team_mem_prompts import (
+    TYPES_SECTION_COMBINED,
+    build_combined_memory_prompt,
+)
+
+_TRACKED_ENV = (
+    "CLAUDE_COWORK_MEMORY_PATH_OVERRIDE",
+    "CLAUDE_CODE_TEAM_MEMORY",
+)
+
+
+class _EnvFixture(unittest.TestCase):
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in _TRACKED_ENV}
+        for k in _TRACKED_ENV:
+            os.environ.pop(k, None)
+        self._tmp = tempfile.TemporaryDirectory()
+        os.environ["CLAUDE_COWORK_MEMORY_PATH_OVERRIDE"] = self._tmp.name
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+class BuildCombinedMemoryPromptTest(_EnvFixture):
+    def test_mentions_both_directories(self):
+        prompt = build_combined_memory_prompt()
+        self.assertIn("private directory at", prompt)
+        self.assertIn("shared team directory at", prompt)
+
+    def test_includes_memory_scope_section(self):
+        prompt = build_combined_memory_prompt()
+        self.assertIn("## Memory scope", prompt)
+        self.assertIn("- private:", prompt)
+        self.assertIn("- team:", prompt)
+
+    def test_includes_scope_tags_from_combined_types(self):
+        prompt = build_combined_memory_prompt()
+        self.assertIn("<scope>", prompt)
+        self.assertIn("always private", prompt)
+        self.assertIn("usually team", prompt)
+
+    def test_includes_no_secrets_warning(self):
+        prompt = build_combined_memory_prompt()
+        self.assertIn(
+            "MUST avoid saving sensitive data within shared team memories",
+            prompt,
+        )
+
+    def test_two_step_save_default(self):
+        prompt = build_combined_memory_prompt()
+        self.assertIn("Step 1", prompt)
+        self.assertIn("Step 2", prompt)
+        self.assertIn("Both `MEMORY.md` indexes are loaded", prompt)
+
+    def test_skip_index_drops_two_step_language(self):
+        prompt = build_combined_memory_prompt(skip_index=True)
+        self.assertNotIn("**Step 1**", prompt)
+        self.assertNotIn("**Step 2**", prompt)
+        # Per-scope guidance still appears.
+        self.assertIn("private or team", prompt)
+
+    def test_extra_guidelines_appended(self):
+        guidelines = ["EXTRA_GUIDELINE_SENTINEL_42"]
+        prompt = build_combined_memory_prompt(extra_guidelines=guidelines)
+        self.assertIn("EXTRA_GUIDELINE_SENTINEL_42", prompt)
+
+    def test_empty_extra_guideline_skipped(self):
+        prompt = build_combined_memory_prompt(extra_guidelines=["", None])  # type: ignore[list-item]
+        # No exception; empty strings filtered.
+        self.assertIn("Memory and other forms of persistence", prompt)
+
+    def test_includes_trusting_recall_section(self):
+        prompt = build_combined_memory_prompt()
+        self.assertIn("## Before recommending from memory", prompt)
+
+    def test_includes_drift_caveat(self):
+        prompt = build_combined_memory_prompt()
+        self.assertIn("Memory records can become stale over time", prompt)
+
+    def test_includes_dirs_exist_guidance(self):
+        prompt = build_combined_memory_prompt()
+        self.assertIn("Both directories already exist", prompt)
+
+
+class CombinedTypesSectionTest(unittest.TestCase):
+    """Shape assertions for TYPES_SECTION_COMBINED.
+
+    The COMBINED variant must include a ``<scope>`` tag for each of the
+    four memory types and use team/private qualifiers in examples.
+    """
+
+    def test_lists_all_four_types(self):
+        joined = "\n".join(TYPES_SECTION_COMBINED)
+        for t in ("user", "feedback", "project", "reference"):
+            self.assertIn(f"<name>{t}</name>", joined)
+
+    def test_each_type_has_scope_tag(self):
+        # One scope OPEN tag per type block (the intro sentence references
+        # `<scope>` as a literal too — count only indented tag lines).
+        scope_lines = [
+            line
+            for line in TYPES_SECTION_COMBINED
+            if line.startswith("    <scope>")
+        ]
+        self.assertEqual(len(scope_lines), 4)
+
+    def test_scope_values_present(self):
+        joined = "\n".join(TYPES_SECTION_COMBINED)
+        self.assertIn("always private", joined)
+        self.assertIn("usually team", joined)
+        # The feedback-type guidance is unique to COMBINED.
+        self.assertIn("default to private", joined)
+
+    def test_examples_use_private_team_qualifiers(self):
+        joined = "\n".join(TYPES_SECTION_COMBINED)
+        self.assertIn("[saves private user memory:", joined)
+        self.assertIn("[saves team", joined)
+
+
+class TeamMemoryDispatchTest(_EnvFixture):
+    """``load_memory_prompt()`` switches to the combined prompt when
+    ``CLAUDE_CODE_TEAM_MEMORY`` is set."""
+
+    def test_flag_off_returns_single_directory_prompt(self):
+        from src.memdir import load_memory_prompt
+
+        prompt = load_memory_prompt()
+        self.assertIsNotNone(prompt)
+        # Single-directory header
+        self.assertIn("# auto memory", prompt)
+        # Combined prompt's header / no-secrets warning must NOT appear.
+        self.assertNotIn("## Memory scope", prompt)
+        self.assertNotIn(
+            "MUST avoid saving sensitive data within shared team memories",
+            prompt,
+        )
+
+    def test_flag_on_returns_combined_prompt(self):
+        os.environ["CLAUDE_CODE_TEAM_MEMORY"] = "1"
+        from src.memdir import load_memory_prompt
+
+        prompt = load_memory_prompt()
+        self.assertIsNotNone(prompt)
+        # Combined header is "# Memory" (not "# auto memory")
+        self.assertIn("# Memory", prompt)
+        self.assertIn("## Memory scope", prompt)
+        self.assertIn(
+            "MUST avoid saving sensitive data within shared team memories",
+            prompt,
+        )
+
+    def test_flag_on_creates_team_directory(self):
+        os.environ["CLAUDE_CODE_TEAM_MEMORY"] = "1"
+        from pathlib import Path
+
+        from src.memdir import get_team_mem_path, load_memory_prompt
+
+        team_dir = get_team_mem_path().rstrip(os.sep)
+        load_memory_prompt()
+        self.assertTrue(
+            Path(team_dir).is_dir(),
+            f"expected {team_dir} to exist after load_memory_prompt()",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes ch11 gap **B2** (team-memdir unported) from the ch01 gap analysis. Ports `typescript/src/memdir/teamMemPaths.ts` and `teamMemPrompts.ts` to Python with the three-layer defense-in-depth from chapter §"Team Memory":

- **`src/memdir/team_mem_paths.py`** — `PathTraversalError` + sanitization (null bytes, URL-encoded traversals, NFKC fullwidth attacks, backslashes, absolute paths), string-level containment with trailing-sep prefix protection, and symlink resolution on the deepest existing ancestor (`_realpath_deepest_existing`) including dangling-symlink detection.
- **`src/memdir/team_mem_prompts.py`** — `build_combined_memory_prompt()` with the `## Memory scope` section, `TYPES_SECTION_COMBINED` (verbatim from TS — adds `<scope>` tags and private/team example qualifiers), and the eval-tuned "MUST avoid saving sensitive data" warning.
- **`src/memdir/memdir.py`** — wires the team branch into `load_memory_prompt()` (lazy import to avoid circular dep, recursive mkdir on the nested `team/` dir creates both directories).
- **53 new unit tests** covering each defense layer (URL-encoded, NFKC fullwidth, symlink escape, dangling symlinks, prefix attack `team-evil/` vs `team/`), happy path, dispatch behavior, and `TYPES_SECTION_COMBINED` shape.

Gating: team-memory uses `CLAUDE_CODE_TEAM_MEMORY` env var (TS uses GrowthBook `tengu_herring_clock`; analytics surface is ch16 scope). Auto-memory remains the parent gate — disabling auto-memory transitively disables team memory.

## Test plan
- [x] `pytest tests/test_memdir_team_mem_paths.py tests/test_memdir_team_mem_prompts.py tests/test_porting_workspace.py tests/test_no_top_level_decoys.py -q` → 114 passed
- [x] Regression: full memdir suite (120 tests) green
- [x] Self-review against TS reference — three defense layers each represented; `is_team_mem_path` uses `abspath` to match TS `path.resolve()` semantics

Out of scope (deferred): KAIROS daily-log prompt, team-sync watcher, `tengu_team_memdir_disabled` telemetry, GrowthBook integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)