### PR TITLE
feat(ch06/round2): populate to_auto_classifier_input on ~17 tools to match TS

### DIFF
--- a/src/tool_system/tools/ask_user_question.py
+++ b/src/tool_system/tools/ask_user_question.py
@@ -8,6 +8,22 @@ from ..errors import ToolInputError
 from ..protocol import ToolResult
 
 
+def _ask_user_question_classifier_input(input_data: dict) -> str:
+    """Mirror TS ``AskUserQuestionTool.toAutoClassifierInput`` --
+    join the question text from each question entry. Each entry may be
+    a string or a dict with a ``question`` field; tolerate both."""
+    qs = (input_data or {}).get("questions") or []
+    parts: list[str] = []
+    for q in qs:
+        if isinstance(q, str):
+            parts.append(q)
+        elif isinstance(q, dict):
+            text = q.get("question")
+            if isinstance(text, str):
+                parts.append(text)
+    return " | ".join(parts)
+
+
 def _ask_user_question_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
     questions = tool_input.get("questions")
     if not isinstance(questions, list) or not questions:
@@ -73,4 +89,5 @@ AskUserQuestionTool: Tool = build_tool(
     is_read_only=lambda _input: True,
     is_concurrency_safe=lambda _input: True,
     search_hint="ask question user input",
+    to_auto_classifier_input=_ask_user_question_classifier_input,
 )

--- a/src/tool_system/tools/brief.py
+++ b/src/tool_system/tools/brief.py
@@ -46,4 +46,8 @@ BriefTool: Tool = build_tool(
     max_result_size_chars=10_000,
     is_read_only=lambda _input: True,
     is_concurrency_safe=lambda _input: True,
+    # Mirrors TS BriefTool.toAutoClassifierInput, which returns
+    # ``input.message``. The Python schema names the field ``text``
+    # instead, so the classifier sees the message body itself.
+    to_auto_classifier_input=lambda input_data: (input_data or {}).get("text", "") or "",
 )

--- a/src/tool_system/tools/config.py
+++ b/src/tool_system/tools/config.py
@@ -33,6 +33,15 @@ def _set_setting(cfg: dict[str, Any], key: str, value: Any) -> None:
     cur[last] = value
 
 
+def _config_classifier_input(input_data: dict) -> str:
+    """Mirror TS ``ConfigTool.toAutoClassifierInput`` -- return just the
+    setting key for reads, ``"setting = value"`` for writes."""
+    d = input_data or {}
+    if "value" in d:
+        return f"{d.get('setting', '')} = {d.get('value')}"
+    return d.get("setting", "") or ""
+
+
 def _config_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
     from src import config as config_mod
 
@@ -82,4 +91,5 @@ ConfigTool: Tool = build_tool(
     description='Get or set Clawcodex configuration values.',
     max_result_size_chars=100_000,
     is_destructive=lambda _input: "value" in _input,
+    to_auto_classifier_input=_config_classifier_input,
 )

--- a/src/tool_system/tools/cron.py
+++ b/src/tool_system/tools/cron.py
@@ -47,6 +47,10 @@ CronCreateTool: Tool = build_tool(
     max_result_size_chars=100_000,
     is_read_only=lambda _input: True,
     is_concurrency_safe=lambda _input: True,
+    # Mirrors TS CronCreateTool.toAutoClassifierInput.
+    to_auto_classifier_input=lambda input_data: (
+        f"{(input_data or {}).get('cron', '')}: {(input_data or {}).get('prompt', '')}"
+    ),
 )
 
 
@@ -93,4 +97,6 @@ CronDeleteTool: Tool = build_tool(
     max_result_size_chars=100_000,
     is_read_only=lambda _input: True,
     is_concurrency_safe=lambda _input: True,
+    # Mirrors TS CronDeleteTool.toAutoClassifierInput.
+    to_auto_classifier_input=lambda input_data: (input_data or {}).get("id", "") or "",
 )

--- a/src/tool_system/tools/lsp.py
+++ b/src/tool_system/tools/lsp.py
@@ -42,4 +42,7 @@ LSPTool: Tool = build_tool(
     max_result_size_chars=100_000,
     is_read_only=lambda _input: True,
     is_concurrency_safe=lambda _input: True,
+    # LSP has no direct TS analogue but the security-relevant axis is
+    # the LSP method name; surface it for the classifier.
+    to_auto_classifier_input=lambda input_data: (input_data or {}).get("method", "") or "",
 )

--- a/src/tool_system/tools/mcp.py
+++ b/src/tool_system/tools/mcp.py
@@ -214,4 +214,11 @@ MCPTool: Tool = build_tool(
     max_result_size_chars=100_000,
     is_destructive=lambda _input: True,
     is_mcp=True,
+    # No direct TS analogue (per-server MCP wrappers each carry their
+    # own classifier helper). Surface server + tool name so a future
+    # LLM classifier has the identity pair to match deny rules
+    # against.
+    to_auto_classifier_input=lambda input_data: (
+        f"{(input_data or {}).get('server', '')} {(input_data or {}).get('tool', '')}".strip()
+    ),
 )

--- a/src/tool_system/tools/mcp_resources.py
+++ b/src/tool_system/tools/mcp_resources.py
@@ -158,6 +158,8 @@ ListMcpResourcesTool: Tool = build_tool(
     is_concurrency_safe=lambda _input: True,
     is_mcp=True,
     search_hint="list resources from connected MCP servers",
+    # Mirrors TS ListMcpResourcesTool.toAutoClassifierInput.
+    to_auto_classifier_input=lambda input_data: (input_data or {}).get("server", "") or "",
 )
 
 
@@ -206,4 +208,8 @@ ReadMcpResourceTool: Tool = build_tool(
     is_concurrency_safe=lambda _input: True,
     is_mcp=True,
     search_hint="read a specific MCP resource by URI",
+    # Mirrors TS ReadMcpResourceTool.toAutoClassifierInput.
+    to_auto_classifier_input=lambda input_data: (
+        f"{(input_data or {}).get('server', '')} {(input_data or {}).get('uri', '')}"
+    ),
 )

--- a/src/tool_system/tools/plan_mode.py
+++ b/src/tool_system/tools/plan_mode.py
@@ -97,4 +97,10 @@ ExitPlanModeTool: Tool = build_tool(
     description="Exit plan mode after writing a plan; may persist plan to disk.",
     max_result_size_chars=100_000,
     is_destructive=lambda _input: True,
+    # Surface the first ~200 chars of the proposed plan so a future
+    # classifier can spot prompt-injection text being shipped through
+    # plan-mode exit.
+    to_auto_classifier_input=lambda input_data: (
+        ((input_data or {}).get("plan") or "")[:200]
+    ),
 )

--- a/src/tool_system/tools/read.py
+++ b/src/tool_system/tools/read.py
@@ -528,4 +528,9 @@ ReadTool: Tool = build_tool(
     search_hint="read file cat view open",
     is_search_or_read_command=lambda _input: SearchOrReadResult(is_read=True),
     get_activity_description=lambda input_data: f"Reading {(input_data or {}).get('file_path', '')}" if input_data else None,
+    # Mirrors TS FileReadTool.toAutoClassifierInput -- returns the
+    # file_path verbatim. The auto-mode classifier sees the path
+    # being read, which is sufficient context for the read-vs-leak
+    # decision. See ch06-tools.md "Apply This".
+    to_auto_classifier_input=lambda input_data: (input_data or {}).get("file_path", ""),
 )

--- a/src/tool_system/tools/send_message.py
+++ b/src/tool_system/tools/send_message.py
@@ -515,6 +515,22 @@ async def _send_message_call(tool_input: dict[str, Any], context: ToolContext) -
     )
 
 
+def _send_message_classifier_input(input_data: dict) -> str:
+    """Mirror TS ``SendMessageTool.toAutoClassifierInput``. The TS
+    classifier collapses string and structured envelope messages into
+    a single line: ``to {to}: {message}`` for plain text, ``to {to}:
+    <{type}>`` for structured envelopes."""
+    d = input_data or {}
+    to = d.get("to", "")
+    msg = d.get("message", "")
+    if isinstance(msg, str):
+        return f"to {to}: {msg}"
+    if isinstance(msg, dict):
+        t = msg.get("type", "structured")
+        return f"to {to}: <{t}>"
+    return f"to {to}"
+
+
 SendMessageTool: Tool = build_tool(
     name=SEND_MESSAGE_TOOL_NAME,
     input_schema=SEND_MESSAGE_INPUT_SCHEMA,
@@ -535,6 +551,7 @@ SendMessageTool: Tool = build_tool(
     # mailbox writes are thread-safe (per A6/C5), but TS doesn't
     # declare the tool as concurrency-safe either; mirror that until
     # there's a demonstrated need.
+    to_auto_classifier_input=_send_message_classifier_input,
 )
 
 

--- a/src/tool_system/tools/send_user_message.py
+++ b/src/tool_system/tools/send_user_message.py
@@ -76,4 +76,8 @@ SendUserMessageTool: Tool = build_tool(
     max_result_size_chars=100_000,
     is_read_only=lambda _input: True,
     is_concurrency_safe=lambda _input: True,
+    # Surface the user-facing message body to the classifier so any
+    # future LLM classifier can spot prompt-injection attempts via
+    # this channel.
+    to_auto_classifier_input=lambda input_data: (input_data or {}).get("message", "") or "",
 )

--- a/src/tool_system/tools/sleep.py
+++ b/src/tool_system/tools/sleep.py
@@ -33,4 +33,7 @@ SleepTool: Tool = build_tool(
     max_result_size_chars=1000,
     is_read_only=lambda _input: True,
     is_concurrency_safe=lambda _input: True,
+    # Sleep has no TS counterpart toAutoClassifierInput; surface the
+    # duration since that is the only meaningful axis.
+    to_auto_classifier_input=lambda input_data: f"{(input_data or {}).get('seconds', 0)}s",
 )

--- a/src/tool_system/tools/task_stop.py
+++ b/src/tool_system/tools/task_stop.py
@@ -115,4 +115,11 @@ Stops a running background task by its ID.
     max_result_size_chars=1000,
     is_read_only=lambda _input: True,
     is_concurrency_safe=lambda _input: True,
+    # Mirrors TS TaskStopTool.toAutoClassifierInput, including the
+    # KillShell-era ``shell_id`` fallback.
+    to_auto_classifier_input=lambda input_data: (
+        (input_data or {}).get("task_id")
+        or (input_data or {}).get("shell_id")
+        or ""
+    ),
 )

--- a/src/tool_system/tools/tasks_v2.py
+++ b/src/tool_system/tools/tasks_v2.py
@@ -18,6 +18,41 @@ def _new_task_id() -> str:
 
 
 # ---------------------------------------------------------------------------
+# Auto-mode classifier helpers — mirror TS Task{Create,Get,Update,Output}
+# ``toAutoClassifierInput``. The classifier never sees the full task body;
+# it sees a compact identity/intent line so any future LLM classifier can
+# focus on shape over content.
+# ---------------------------------------------------------------------------
+
+
+def _task_create_classifier_input(input_data: dict) -> str:
+    return (input_data or {}).get("subject", "") or ""
+
+
+def _task_get_classifier_input(input_data: dict) -> str:
+    return (input_data or {}).get("taskId", "") or ""
+
+
+def _task_update_classifier_input(input_data: dict) -> str:
+    d = input_data or {}
+    parts: list[str] = []
+    tid = d.get("taskId")
+    if tid:
+        parts.append(str(tid))
+    status = d.get("status")
+    if status:
+        parts.append(str(status))
+    subject = d.get("subject")
+    if subject:
+        parts.append(str(subject))
+    return " ".join(parts)
+
+
+def _task_output_classifier_input(input_data: dict) -> str:
+    return (input_data or {}).get("task_id", "") or ""
+
+
+# ---------------------------------------------------------------------------
 # Result formatting helpers (port of TS mapToolResultToToolResultBlockParam)
 # ---------------------------------------------------------------------------
 
@@ -190,6 +225,7 @@ All tasks are created with status `pending`.
     is_read_only=lambda _input: True,
     is_concurrency_safe=lambda _input: True,
     is_enabled=is_todo_v2_enabled,
+    to_auto_classifier_input=_task_create_classifier_input,
 )
 
 
@@ -252,6 +288,7 @@ Returns full task details:
     is_read_only=lambda _input: True,
     is_concurrency_safe=lambda _input: True,
     is_enabled=is_todo_v2_enabled,
+    to_auto_classifier_input=_task_get_classifier_input,
 )
 
 
@@ -500,6 +537,7 @@ Set up task dependencies:
     is_read_only=lambda _input: True,
     is_concurrency_safe=lambda _input: True,
     is_enabled=is_todo_v2_enabled,
+    to_auto_classifier_input=_task_update_classifier_input,
 )
 
 
@@ -743,4 +781,5 @@ Get the output of a running or completed background task.
     max_result_size_chars=100_000,
     is_read_only=lambda _input: True,
     is_concurrency_safe=lambda _input: True,
+    to_auto_classifier_input=_task_output_classifier_input,
 )

--- a/src/tool_system/tools/team.py
+++ b/src/tool_system/tools/team.py
@@ -63,6 +63,8 @@ TeamCreateTool: Tool = build_tool(
     max_result_size_chars=100_000,
     is_read_only=lambda _input: True,
     is_concurrency_safe=lambda _input: True,
+    # Mirrors TS TeamCreateTool.toAutoClassifierInput.
+    to_auto_classifier_input=lambda input_data: (input_data or {}).get("team_name", "") or "",
 )
 
 

--- a/src/tool_system/tools/todo_write.py
+++ b/src/tool_system/tools/todo_write.py
@@ -72,4 +72,8 @@ TodoWriteTool: Tool = build_tool(
     is_read_only=lambda _input: True,
     is_concurrency_safe=lambda _input: True,
     is_enabled=lambda: not is_todo_v2_enabled(),
+    # Mirrors TS TodoWriteTool.toAutoClassifierInput -- compact count
+    # so the classifier sees the size, not the content (which is
+    # often verbose plan text).
+    to_auto_classifier_input=lambda input_data: f"{len(((input_data or {}).get('todos') or []))} items",
 )

--- a/src/tool_system/tools/tool_search.py
+++ b/src/tool_system/tools/tool_search.py
@@ -65,4 +65,7 @@ def make_tool_search_tool(registry: ToolRegistry) -> Tool:
         max_result_size_chars=100_000,
         is_read_only=lambda _input: True,
         is_concurrency_safe=lambda _input: True,
+        # ToolSearch's classifier-input is the query the model wants
+        # to search for -- already compact enough for the classifier.
+        to_auto_classifier_input=lambda input_data: (input_data or {}).get("query", "") or "",
     )

--- a/src/tool_system/tools/web_fetch.py
+++ b/src/tool_system/tools/web_fetch.py
@@ -369,6 +369,19 @@ Usage notes:
   - For GitHub URLs, prefer using the gh CLI via Bash instead (e.g., gh pr view, gh issue view, gh api)."""
 
 
+def _web_fetch_classifier_input(input_data: dict) -> str:
+    """Mirror TS ``WebFetchTool.toAutoClassifierInput`` -- include the
+    secondary-model prompt when present so the classifier can spot
+    URL-as-data-exfiltration patterns where the URL is innocuous but
+    the prompt does the work."""
+    d = input_data or {}
+    url = d.get("url", "")
+    prompt = d.get("prompt")
+    if prompt:
+        return f"{url}: {prompt}"
+    return url
+
+
 # -- Tool Definition -----------------------------------------------------------
 
 WebFetchTool: Tool = build_tool(
@@ -398,4 +411,5 @@ WebFetchTool: Tool = build_tool(
     check_permissions=_check_permissions,
     search_hint="web fetch url http download",
     get_activity_description=lambda input_data: f"Fetching {(input_data or {}).get('url', '')}..." if input_data else None,
+    to_auto_classifier_input=_web_fetch_classifier_input,
 )

--- a/src/tool_system/tools/web_search.py
+++ b/src/tool_system/tools/web_search.py
@@ -386,4 +386,6 @@ WebSearchTool: Tool = build_tool(
     get_activity_description=lambda input_data: (
         f"Searching for {(input_data or {}).get('query', '')!r}" if input_data else None
     ),
+    # Mirrors TS WebSearchTool.toAutoClassifierInput (returns the query).
+    to_auto_classifier_input=lambda input_data: (input_data or {}).get("query", ""),
 )

--- a/src/tool_system/tools/worktree.py
+++ b/src/tool_system/tools/worktree.py
@@ -52,6 +52,8 @@ EnterWorktreeTool: Tool = build_tool(
     strict=True,
     max_result_size_chars=100_000,
     is_destructive=lambda _input: True,
+    # Mirrors TS EnterWorktreeTool.toAutoClassifierInput.
+    to_auto_classifier_input=lambda input_data: (input_data or {}).get("name", "") or "",
 )
 
 
@@ -76,4 +78,9 @@ ExitWorktreeTool: Tool = build_tool(
     strict=True,
     max_result_size_chars=100_000,
     is_destructive=lambda _input: True,
+    # Mirrors TS ExitWorktreeTool.toAutoClassifierInput -- returns
+    # input.action. Python's ExitWorktree schema does not yet model
+    # action=remove vs keep; fall through gracefully to "" until the
+    # schema catches up.
+    to_auto_classifier_input=lambda input_data: (input_data or {}).get("action", "") or "",
 )

--- a/tests/test_tool_classifier_input.py
+++ b/tests/test_tool_classifier_input.py
@@ -1,0 +1,350 @@
+"""Round-2 parity test for ``Tool.to_auto_classifier_input``.
+
+See ``my-docs/ch06-tools-round2-gap-analysis.md``. TS book ch06 lists
+``toAutoClassifierInput`` as one of the five "core" Tool interface
+methods (`book/ch06-tools.md` lines 11-19) and as a fail-closed
+default in "Apply This" -- a tool that forgets to override it returns
+``""`` and the classifier silently skips it.
+
+This test:
+
+1. Verifies each Python tool that has a TS counterpart with a
+   ``toAutoClassifierInput`` override produces a non-empty
+   classifier-input string for representative input.
+2. Verifies the default (``Tool`` with no override) still returns
+   ``""`` -- the fail-closed contract is preserved.
+3. Verifies the TS shapes for the cases TS pins down (e.g.
+   ``TodoWrite`` returns ``"N items"``, ``Config`` returns
+   ``"setting = value"``).
+
+Note on tasks_v2: TaskCreate / TaskGet / TaskList / TaskUpdate /
+TaskOutput are gated by the ``is_todo_v2_enabled`` feature flag. The
+test imports them directly (bypassing registry filtering) so the
+classifier-input assertion runs regardless of flag state.
+"""
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+from src.tool_system.build_tool import Tool, build_tool
+from src.tool_system.tools import (
+    AskUserQuestionTool,
+    BriefTool,
+    ClipboardReadTool,
+    ClipboardWriteTool,
+    ConfigTool,
+    CronCreateTool,
+    CronDeleteTool,
+    CronListTool,
+    EnterPlanModeTool,
+    EnterWorktreeTool,
+    ExitPlanModeTool,
+    ExitWorktreeTool,
+    LSPTool,
+    ListMcpResourcesTool,
+    MCPTool,
+    ReadMcpResourceTool,
+    ReadTool,
+    SendMessageTool,
+    SendUserMessageTool,
+    SleepTool,
+    StatusTool,
+    StructuredOutputTool,
+    TaskCreateTool,
+    TaskGetTool,
+    TaskListTool,
+    TaskOutputTool,
+    TaskStopTool,
+    TaskUpdateTool,
+    TeamCreateTool,
+    TeamDeleteTool,
+    TodoWriteTool,
+    WebFetchTool,
+    WebSearchTool,
+)
+
+
+# (tool, sample_input, predicate(actual_value: str) -> bool, description)
+# Predicates instead of exact strings so the test tolerates safe
+# concatenation differences while still locking in the substring the
+# classifier must see.
+TOOLS_TABLE: list[tuple[Tool, dict[str, Any], object, str]] = [
+    # File / read-side
+    (ReadTool, {"file_path": "/tmp/example.py"},
+     lambda v: v == "/tmp/example.py",
+     "Read should return file_path verbatim"),
+
+    # Web
+    (WebFetchTool, {"url": "https://example.com", "prompt": "summarize page"},
+     lambda v: "https://example.com" in v and "summarize page" in v,
+     "WebFetch should include both url and prompt when prompt is set"),
+    (WebFetchTool, {"url": "https://example.com"},
+     lambda v: v == "https://example.com",
+     "WebFetch should fall back to url-only when prompt is absent"),
+    (WebSearchTool, {"query": "anthropic api docs"},
+     lambda v: v == "anthropic api docs",
+     "WebSearch should return the query verbatim"),
+
+    # Interactive
+    (AskUserQuestionTool, {"questions": [{"question": "Are you sure?"}, {"question": "Why?"}]},
+     lambda v: "Are you sure?" in v and "Why?" in v,
+     "AskUserQuestion should join question text"),
+    (AskUserQuestionTool, {"questions": ["just a string"]},
+     lambda v: "just a string" in v,
+     "AskUserQuestion should tolerate plain string entries"),
+
+    # Todo / Task
+    (TodoWriteTool, {"todos": [{"content": "a"}, {"content": "b"}]},
+     lambda v: v == "2 items",
+     "TodoWrite should report count, not contents"),
+    (TaskCreateTool, {"subject": "Fix auth bug", "description": "..."},
+     lambda v: v == "Fix auth bug",
+     "TaskCreate should return subject"),
+    (TaskGetTool, {"taskId": "T123"},
+     lambda v: v == "T123",
+     "TaskGet should return taskId"),
+    (TaskUpdateTool, {"taskId": "T1", "status": "in_progress", "subject": "Updated"},
+     lambda v: "T1" in v and "in_progress" in v and "Updated" in v,
+     "TaskUpdate should join taskId + status + subject"),
+    (TaskOutputTool, {"task_id": "T123"},
+     lambda v: v == "T123",
+     "TaskOutput should return task_id"),
+    (TaskStopTool, {"task_id": "T123"},
+     lambda v: v == "T123",
+     "TaskStop should prefer task_id"),
+    (TaskStopTool, {"shell_id": "S456"},
+     lambda v: v == "S456",
+     "TaskStop should fall back to shell_id (KillShell compat)"),
+    (TaskListTool, {},
+     lambda v: v == "",
+     "TaskList has no input; default empty string is correct"),
+
+    # Worktree / Plan
+    (EnterWorktreeTool, {"name": "wt-feature"},
+     lambda v: v == "wt-feature",
+     "EnterWorktree should return name"),
+    (ExitWorktreeTool, {},
+     lambda v: v == "",
+     "ExitWorktree default when action absent"),
+    (ExitPlanModeTool, {"plan": "step 1\nstep 2"},
+     lambda v: v.startswith("step 1"),
+     "ExitPlanMode should surface plan prefix"),
+    (EnterPlanModeTool, {},
+     lambda v: v == "",
+     "EnterPlanMode default (no input)"),
+
+    # Cron
+    (CronCreateTool, {"cron": "0 * * * *", "prompt": "summarize logs"},
+     lambda v: "0 * * * *" in v and "summarize logs" in v,
+     "CronCreate should include schedule and prompt"),
+    (CronDeleteTool, {"id": "cron-abc"},
+     lambda v: v == "cron-abc",
+     "CronDelete should return id"),
+    (CronListTool, {},
+     lambda v: v == "",
+     "CronList has no input; default empty string is correct"),
+
+    # MCP
+    (ListMcpResourcesTool, {"server": "fileserver"},
+     lambda v: v == "fileserver",
+     "ListMcpResources should return server"),
+    (ReadMcpResourceTool, {"server": "fs", "uri": "file:///tmp/a"},
+     lambda v: "fs" in v and "file:///tmp/a" in v,
+     "ReadMcpResource should include server and uri"),
+    (MCPTool, {"server": "s1", "tool": "echo"},
+     lambda v: "s1" in v and "echo" in v,
+     "MCP should include server and tool"),
+
+    # Config / Team / Brief
+    (ConfigTool, {"setting": "default_provider"},
+     lambda v: v == "default_provider",
+     "Config read should return setting key alone"),
+    (ConfigTool, {"setting": "default_provider", "value": "anthropic"},
+     lambda v: v == "default_provider = anthropic",
+     "Config write should return setting = value"),
+    (BriefTool, {"text": "deploy is done"},
+     lambda v: v == "deploy is done",
+     "Brief should return message body"),
+    (TeamCreateTool, {"team_name": "platform"},
+     lambda v: v == "platform",
+     "TeamCreate should return team_name"),
+    (TeamDeleteTool, {},
+     lambda v: v == "",
+     "TeamDelete has no input; default empty string is correct"),
+
+    # Messaging
+    (SendMessageTool, {"to": "alice", "message": "hello"},
+     lambda v: v == "to alice: hello",
+     "SendMessage plain text → 'to <to>: <message>'"),
+    (SendMessageTool, {"to": "bob", "message": {"type": "shutdown_request"}},
+     lambda v: v == "to bob: <shutdown_request>",
+     "SendMessage structured envelope → 'to <to>: <type>'"),
+    (SendUserMessageTool, {"message": "deployment done", "status": "normal"},
+     lambda v: v == "deployment done",
+     "SendUserMessage should return message body"),
+
+    # Misc
+    (LSPTool, {"method": "textDocument/hover"},
+     lambda v: v == "textDocument/hover",
+     "LSP should return method"),
+    (SleepTool, {"seconds": 5},
+     lambda v: "5" in v,
+     "Sleep should surface the duration"),
+    (StructuredOutputTool, {"foo": "bar"},
+     lambda v: v == "",
+     "StructuredOutput has no security-relevant input shape; default empty is correct"),
+    (StatusTool, {},
+     lambda v: v == "",
+     "Status takes no input; default empty is correct"),
+    (ClipboardReadTool, {},
+     lambda v: v == "",
+     "ClipboardRead takes no input; default empty is correct"),
+    (ClipboardWriteTool, {"content": "hello"},
+     lambda v: v == "",
+     "ClipboardWrite default (kept until a TS counterpart appears)"),
+]
+
+
+def _noop_call(tool_input: dict[str, Any], context: Any) -> Any:  # pragma: no cover
+    from src.tool_system.protocol import ToolResult
+    return ToolResult(name="Noop", output={})
+
+
+class TestToAutoClassifierInputParity(unittest.TestCase):
+    """Walk the table; assert each tool emits the expected shape."""
+
+    def test_each_tool_emits_expected_classifier_input(self) -> None:
+        for tool, sample, predicate, description in TOOLS_TABLE:
+            with self.subTest(tool=tool.name, description=description):
+                value = tool.to_auto_classifier_input(sample)
+                self.assertIsInstance(value, str, f"{tool.name}: result must be str (got {type(value).__name__})")
+                self.assertTrue(
+                    predicate(value),
+                    f"{tool.name} ({description}): unexpected classifier "
+                    f"input. Got: {value!r}",
+                )
+
+    def test_default_is_empty_string(self) -> None:
+        """Fail-closed default: a tool with no override returns ``""``."""
+        t = build_tool(
+            name="DefaultTool",
+            input_schema={"type": "object", "properties": {}},
+            call=_noop_call,
+        )
+        self.assertEqual(t.to_auto_classifier_input({}), "")
+        self.assertEqual(t.to_auto_classifier_input({"anything": 1}), "")
+
+
+class TestToolsWithTSCounterpartHaveOverride(unittest.TestCase):
+    """Smoke test: every tool whose TS counterpart has a
+    ``toAutoClassifierInput`` override should have one in Python too.
+
+    This is a regression guard: if a future contributor adds a new
+    Python tool that mirrors a TS-with-classifier-input tool but
+    forgets the override, this test points at it. We list the tools
+    by their Python registry name explicitly so removing one fails
+    loudly.
+    """
+
+    EXPECTED_OVERRIDES = {
+        "Read", "WebFetch", "WebSearch", "AskUserQuestion",
+        "TodoWrite", "TaskCreate", "TaskGet", "TaskUpdate",
+        "TaskOutput", "TaskStop", "EnterWorktree", "ExitWorktree",
+        "ExitPlanMode", "CronCreate", "CronDelete",
+        "ListMcpResourcesTool", "ReadMcpResourceTool", "MCP",
+        "Config", "Brief", "TeamCreate", "SendMessage",
+        "SendUserMessage", "LSP", "Sleep", "ToolSearch",
+        "Edit", "Write", "Grep", "Glob", "NotebookEdit", "Bash",
+        "Skill", "Agent",
+    }
+
+    def test_each_expected_tool_overrides_classifier_input(self) -> None:
+        """For every expected tool, calling
+        ``to_auto_classifier_input`` with a representative input
+        should produce a non-empty string."""
+        from src.tool_system.tools import ALL_STATIC_TOOLS
+
+        # Build a name → tool map (also include the make_*_tool
+        # factories so we test ToolSearch and Agent).
+        by_name = {t.name: t for t in ALL_STATIC_TOOLS}
+
+        # ToolSearch and Agent are constructed via factory; pull them
+        # out separately so the test does not depend on registry
+        # construction.
+        from src.tool_system.registry import ToolRegistry
+        from src.tool_system.tools.tool_search import make_tool_search_tool
+        from src.tool_system.tools.agent import make_agent_tool
+        registry = ToolRegistry()
+        for t in ALL_STATIC_TOOLS:
+            registry.register(t)
+        by_name["ToolSearch"] = make_tool_search_tool(registry)
+        by_name["Agent"] = make_agent_tool(registry)
+
+        # Representative inputs for the override check. Each input
+        # MUST produce a non-empty string. We do not match shape here
+        # (the TOOLS_TABLE test above does that); we just verify the
+        # tool didn't silently fall through to the empty-string
+        # default.
+        non_empty_samples: dict[str, dict[str, Any]] = {
+            "Read": {"file_path": "/x"},
+            "WebFetch": {"url": "https://x"},
+            "WebSearch": {"query": "x"},
+            "AskUserQuestion": {"questions": [{"question": "?"}]},
+            "TodoWrite": {"todos": [{"content": "a"}]},
+            "TaskCreate": {"subject": "x"},
+            "TaskGet": {"taskId": "x"},
+            "TaskUpdate": {"taskId": "x"},
+            "TaskOutput": {"task_id": "x"},
+            "TaskStop": {"task_id": "x"},
+            "EnterWorktree": {"name": "x"},
+            "ExitWorktree": {"action": "remove"},
+            "ExitPlanMode": {"plan": "x"},
+            "CronCreate": {"cron": "* * * * *", "prompt": "x"},
+            "CronDelete": {"id": "x"},
+            "ListMcpResourcesTool": {"server": "x"},
+            "ReadMcpResourceTool": {"server": "x", "uri": "y"},
+            "MCP": {"server": "x", "tool": "y"},
+            "Config": {"setting": "x"},
+            "Brief": {"text": "x"},
+            "TeamCreate": {"team_name": "x"},
+            "SendMessage": {"to": "u", "message": "m"},
+            "SendUserMessage": {"message": "x", "status": "normal"},
+            "LSP": {"method": "x"},
+            "Sleep": {"seconds": 1},
+            "ToolSearch": {"query": "x"},
+            "Edit": {"file_path": "/x", "old_string": "a", "new_string": "b"},
+            "Write": {"file_path": "/x", "content": "y"},
+            "Grep": {"pattern": "x"},
+            "Glob": {"pattern": "x"},
+            "NotebookEdit": {"notebook_path": "/x", "new_source": "y"},
+            "Bash": {"command": "ls"},
+            "Skill": {"skill": "x"},
+            "Agent": {"prompt": "do x"},
+        }
+
+        missing: list[str] = []
+        empty_outputs: list[tuple[str, Any]] = []
+        for name in self.EXPECTED_OVERRIDES:
+            tool = by_name.get(name)
+            if tool is None:
+                missing.append(name)
+                continue
+            sample = non_empty_samples.get(name, {})
+            value = tool.to_auto_classifier_input(sample)
+            if not isinstance(value, str) or value == "":
+                empty_outputs.append((name, value))
+
+        self.assertEqual(
+            missing, [],
+            f"Expected tools not in registry: {missing}",
+        )
+        self.assertEqual(
+            empty_outputs, [],
+            "These tools should override to_auto_classifier_input but "
+            f"returned empty/falsy: {empty_outputs}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Round-2 closes the field-level fidelity gap that round-1 (my-docs/ch06-tools-gap-analysis.md) deferred: Python's `Tool` interface already declares `to_auto_classifier_input` with a fail-closed empty-string default, but only 9 of ~30 tools overrode it -- vs 31 of ~45 in the TS reference. Book chapter ch06-tools.md "Apply This" explicitly cites this as part of the fail-closed design pattern.

- Adds `to_auto_classifier_input` overrides to ~17 tools, each mirroring TS `toAutoClassifierInput` semantics (Read, WebFetch, WebSearch, AskUserQuestion, TodoWrite, EnterWorktree, ExitWorktree, CronCreate/Delete, Brief, Config, ListMcpResources, ReadMcpResource, MCP, SendMessage, SendUserMessage, TaskCreate/Get/Update/Output/Stop, TeamCreate, ExitPlanMode, LSP, Sleep, ToolSearch).
- Introduces helpers for non-trivial cases (`_config_classifier_input`, `_send_message_classifier_input`, `_ask_user_question_classifier_input`, `_task_{create,get,update,output}_classifier_input`).
- Adds `tests/test_tool_classifier_input.py` -- table-driven parity test, regression guard for missing overrides, default-empty-string contract.
- ~150 LOC of overrides + ~280 LOC of tests; no production behavior change today (Python's `auto_mode_classify` is heuristic-only; round-1 Gap 5 deferred the LLM classifier work).

Docs: `my-docs/ch06-tools-round2-gap-analysis.md`, `my-docs/ch06-tools-round2-plan.md`.

## Test plan

- [x] `pytest tests/test_tool_classifier_input.py tests/test_porting_workspace.py tests/test_no_top_level_decoys.py -q` is green
- [x] `pytest tests/test_build_tool.py tests/test_tool_system_tools.py tests/test_tool_registry_pipeline.py -q` is green
- [x] `pytest tests/parity -q` is green (357 passed)
- [x] Pre-existing failures (zhipuai import, mcp_doctor PATH) confirmed unrelated and out of scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)