### PR TITLE
ch09/round2: thread rendered system prompt + worktree notice on fork

### DIFF
--- a/src/tool_system/context.py
+++ b/src/tool_system/context.py
@@ -181,6 +181,21 @@ class ToolContext:
     # untrusted, mirroring TS' ``shouldSkipHookDueToTrust`` gate.
     workspace_trusted: bool = False
 
+    # Chapter-9 / Fork Agents — captured bytes of the system prompt used on
+    # the parent's most recent API call. Threaded into fork children so the
+    # API request prefix is byte-identical across all parallel children
+    # (chapter 9 §"The Byte-Identical Prefix Trick", Layer 1). Mirrors
+    # ``toolUseContext.renderedSystemPrompt`` from
+    # ``typescript/src/tools/AgentTool/AgentTool.tsx:496``.
+    #
+    # When ``None``, the fork path falls back to recomputing the parent
+    # system prompt from ``options.custom_system_prompt`` or the active
+    # agent definition. That fallback can diverge under feature-flag
+    # transitions (GrowthBook cold→warm) and bust the prompt cache; the
+    # main loop should populate this field whenever it has the rendered
+    # bytes on hand for the parent's last turn.
+    rendered_system_prompt: str | None = None
+
     def __post_init__(self) -> None:
         self.workspace_root = Path(self.workspace_root).resolve()
         if self.cwd is None:

--- a/src/tool_system/tools/agent.py
+++ b/src/tool_system/tools/agent.py
@@ -41,6 +41,7 @@ from src.agent.constants import (
 )
 from src.agent.fork_subagent import (
     build_forked_messages,
+    build_worktree_notice,
     is_fork_subagent_enabled,
     is_in_fork_child,
 )
@@ -241,7 +242,7 @@ def make_agent_tool(
         fork_prompt = prompt
 
         if is_fork_path:
-            from src.types.messages import AssistantMessage
+            from src.types.messages import AssistantMessage, create_user_message
 
             parent_assistant: AssistantMessage | None = None
             for msg in reversed(context.messages):
@@ -250,12 +251,30 @@ def make_agent_tool(
                     break
 
             forked_pair = build_forked_messages(prompt, parent_assistant)
+
+            # Fork + worktree: append the translation notice as a trailing
+            # user message so it appears as the most recent guidance the
+            # child sees. Mirrors
+            # ``typescript/src/tools/AgentTool/AgentTool.tsx:610-614``. The
+            # notice is plain text — it does NOT contain the
+            # ``<fork-boilerplate>`` tag, so the message-scan recursion guard
+            # is unaffected.
+            worktree_cwd = _resolve_fork_worktree_cwd(context)
+            if worktree_cwd is not None:
+                parent_cwd_str = str(context.cwd or context.workspace_root)
+                notice_text = build_worktree_notice(parent_cwd_str, worktree_cwd)
+                forked_pair = list(forked_pair) + [
+                    create_user_message(content=notice_text)
+                ]
+
             fork_context_messages = list(context.messages) + forked_pair
             fork_use_exact_tools = True
             fork_query_source = f"agent:builtin:{FORK_SUBAGENT_TYPE}"
-            # Best-effort parent system prompt: derived from the active
-            # agent definition or falling back to None. Threading the
-            # exact rendered bytes from the main loop is a follow-up.
+            # Parent system prompt: prefers ``context.rendered_system_prompt``
+            # (byte-identical to the parent's last API call) and falls back
+            # to recomputing via the active agent def. See
+            # ``_resolve_parent_system_prompt`` docstring for the full
+            # cascade, which mirrors ``AgentTool.tsx:495-511``.
             fork_parent_system_prompt = _resolve_parent_system_prompt(context, agent_definitions)
             # ``run_agent`` will append a UserMessage built from ``prompt``
             # to whatever ``context_messages`` it receives. We have already
@@ -639,20 +658,30 @@ def _resolve_parent_system_prompt(
     context: ToolContext,
     agent_definitions: list[AgentDefinition],
 ) -> str | None:
-    """Best-effort parent-system-prompt resolution for fork children.
+    """Resolve the parent system prompt for fork children.
 
-    The TS implementation threads the parent's already-rendered
-    ``renderedSystemPrompt`` so the bytes are identical to the parent's
-    last API call. We do not yet propagate the rendered bytes from the
-    main loop, so this helper falls back to:
+    Mirrors the layered fallback in
+    ``typescript/src/tools/AgentTool/AgentTool.tsx:495-511``:
 
-    1. ``context.options.custom_system_prompt`` if provided.
-    2. The active agent definition's ``get_system_prompt()`` output.
-    3. ``None`` (let the FORK_AGENT empty prompt fall through to the
-       default).
+    1. ``context.rendered_system_prompt`` — the bytes captured from the
+       parent's most recent API call. Preferred path: identical to the
+       parent's cached prefix, so the fork child's API request hits the
+       prompt cache without recomputing anything that might have shifted
+       (chapter 9 §"The Byte-Identical Prefix Trick", Layer 1).
+    2. ``context.options.custom_system_prompt`` — explicit caller
+       override.
+    3. The active agent definition's ``get_system_prompt()`` output —
+       recompute fallback. Useful for tests and SDK callers that never
+       populated the rendered field but still want a coherent prompt.
+    4. ``None`` — let ``get_agent_system_prompt`` fall through to
+       ``DEFAULT_AGENT_PROMPT``.
 
     Returns ``None`` when no candidate is available.
     """
+    rendered = getattr(context, "rendered_system_prompt", None)
+    if isinstance(rendered, str) and rendered.strip():
+        return rendered
+
     custom = getattr(context.options, "custom_system_prompt", None)
     if isinstance(custom, str) and custom.strip():
         return custom
@@ -667,6 +696,26 @@ def _resolve_parent_system_prompt(
                 return None
 
     return None
+
+
+def _resolve_fork_worktree_cwd(context: ToolContext) -> str | None:
+    """Return the worktree cwd string for a fork child, or ``None``.
+
+    Mirrors the ``isForkPath && worktreeInfo`` branch in
+    ``typescript/src/tools/AgentTool/AgentTool.tsx:610-614``. Only return
+    a non-None value when the active context has a worktree root that
+    differs from the parent's working directory — otherwise the notice
+    would be misleading ("you are operating in an isolated worktree at
+    /same/path").
+    """
+    wt_root = getattr(context, "worktree_root", None)
+    if wt_root is None:
+        return None
+    wt_path = str(wt_root)
+    parent_cwd = str(context.cwd or context.workspace_root)
+    if not wt_path or wt_path == parent_cwd:
+        return None
+    return wt_path
 
 
 def _sync_collect_agent_messages(params: RunAgentParams) -> list[Any]:

--- a/tests/test_agent_tool_fork.py
+++ b/tests/test_agent_tool_fork.py
@@ -241,3 +241,280 @@ def test_fork_disabled_in_non_interactive_session(
     # Even with the env flag, non-interactive sessions skip the fork path.
     assert captured["agent_type"] == "general-purpose"
     assert captured["use_exact_tools"] is False
+
+
+# ---------------------------------------------------------------------------
+# Round-2: cache-determinism — parent system prompt threading
+# ---------------------------------------------------------------------------
+
+
+def test_fork_uses_rendered_system_prompt_when_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``context.rendered_system_prompt`` is the preferred fallback chain entry.
+
+    Mirrors ``AgentTool.tsx:496-497`` — the captured parent bytes win over
+    any recomputation path.
+    """
+    _set_fork_env(monkeypatch, enabled=True)
+    registry = build_default_registry(provider=object())
+    context = _make_interactive_context(tmp_path)
+    context.rendered_system_prompt = "PARENT_BYTES_FROM_LAST_TURN"
+    # Set both lower-priority fallbacks too — the rendered field must win.
+    context.options.custom_system_prompt = "SHOULD_NOT_WIN"
+
+    captured: dict[str, object] = {}
+
+    async def _fake_run_agent(params):
+        captured["parent_system_prompt"] = params.parent_system_prompt
+        captured["agent_type"] = params.agent_definition.agent_type
+        yield AssistantMessage(content=[TextBlock(text="done")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _fake_run_agent):
+        registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={"description": "test", "prompt": "go"},
+            ),
+            context,
+        )
+
+    assert captured["agent_type"] == FORK_AGENT.agent_type
+    assert captured["parent_system_prompt"] == "PARENT_BYTES_FROM_LAST_TURN"
+
+
+def test_fork_falls_back_to_custom_system_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When no rendered prompt is captured, ``custom_system_prompt`` wins."""
+    _set_fork_env(monkeypatch, enabled=True)
+    registry = build_default_registry(provider=object())
+    context = _make_interactive_context(tmp_path)
+    context.rendered_system_prompt = None
+    context.options.custom_system_prompt = "CUSTOM_PROMPT_BYTES"
+
+    captured: dict[str, object] = {}
+
+    async def _fake_run_agent(params):
+        captured["parent_system_prompt"] = params.parent_system_prompt
+        yield AssistantMessage(content=[TextBlock(text="done")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _fake_run_agent):
+        registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={"description": "test", "prompt": "go"},
+            ),
+            context,
+        )
+
+    assert captured["parent_system_prompt"] == "CUSTOM_PROMPT_BYTES"
+
+
+def test_fork_falls_back_to_active_agent_def_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Third fallback: recompute via the active agent definition's prompt."""
+    _set_fork_env(monkeypatch, enabled=True)
+    registry = build_default_registry(provider=object())
+    context = _make_interactive_context(tmp_path)
+    context.rendered_system_prompt = None
+    context.options.custom_system_prompt = None
+    context.agent_type = "general-purpose"
+
+    captured: dict[str, object] = {}
+
+    async def _fake_run_agent(params):
+        captured["parent_system_prompt"] = params.parent_system_prompt
+        yield AssistantMessage(content=[TextBlock(text="done")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _fake_run_agent):
+        registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={"description": "test", "prompt": "go"},
+            ),
+            context,
+        )
+
+    prompt = captured["parent_system_prompt"]
+    assert isinstance(prompt, str) and prompt
+    # The general-purpose agent prompt mentions "agent for Claw Codex".
+    assert "agent for Claw Codex" in prompt
+
+
+def test_fork_parent_system_prompt_none_when_no_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No rendered prompt + no custom + no active agent_type → None.
+
+    Lets ``get_agent_system_prompt`` fall through to ``DEFAULT_AGENT_PROMPT``
+    rather than asserting.
+    """
+    _set_fork_env(monkeypatch, enabled=True)
+    registry = build_default_registry(provider=object())
+    context = _make_interactive_context(tmp_path)
+    context.rendered_system_prompt = None
+    context.options.custom_system_prompt = None
+    context.agent_type = None
+
+    captured: dict[str, object] = {}
+
+    async def _fake_run_agent(params):
+        captured["parent_system_prompt"] = params.parent_system_prompt
+        yield AssistantMessage(content=[TextBlock(text="done")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _fake_run_agent):
+        registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={"description": "test", "prompt": "go"},
+            ),
+            context,
+        )
+
+    assert captured["parent_system_prompt"] is None
+
+
+# ---------------------------------------------------------------------------
+# Round-2: fork + worktree notice
+# ---------------------------------------------------------------------------
+
+
+def test_fork_appends_worktree_notice_when_worktree_root_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fork running inside a worktree appends the translation notice.
+
+    Mirrors ``AgentTool.tsx:610-614``. The notice is the LAST user message
+    so it appears as the most recent guidance the child sees.
+    """
+    _set_fork_env(monkeypatch, enabled=True)
+    registry = build_default_registry(provider=object())
+    context = _make_interactive_context(tmp_path)
+    repo_dir = tmp_path / "repo"
+    worktree_dir = tmp_path / "wt-1234"
+    repo_dir.mkdir()
+    worktree_dir.mkdir()
+    context.cwd = repo_dir
+    context.worktree_root = worktree_dir
+
+    captured: dict[str, object] = {}
+
+    async def _fake_run_agent(params):
+        captured["context_messages"] = list(params.context_messages or [])
+        yield AssistantMessage(content=[TextBlock(text="ok")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _fake_run_agent):
+        registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={"description": "test", "prompt": "go"},
+            ),
+            context,
+        )
+
+    msgs = captured["context_messages"]
+    assert isinstance(msgs, list) and len(msgs) >= 2
+    last = msgs[-1]
+    assert isinstance(last, UserMessage)
+    text = last.content if isinstance(last.content, str) else "".join(
+        b.text for b in last.content if isinstance(b, TextBlock)
+    )
+    assert str(repo_dir) in text
+    assert str(worktree_dir) in text
+    assert "isolated git worktree" in text
+    # And the notice must NOT carry the fork-boilerplate tag so the
+    # recursion-guard message scan stays unaffected.
+    assert "<fork-boilerplate>" not in text
+
+
+def test_fork_skips_worktree_notice_when_worktree_root_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default contexts (no worktree_root) get no notice."""
+    _set_fork_env(monkeypatch, enabled=True)
+    registry = build_default_registry(provider=object())
+    context = _make_interactive_context(tmp_path)
+    assert context.worktree_root is None
+
+    captured: dict[str, object] = {}
+
+    async def _fake_run_agent(params):
+        captured["context_messages"] = list(params.context_messages or [])
+        yield AssistantMessage(content=[TextBlock(text="ok")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _fake_run_agent):
+        registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={"description": "test", "prompt": "go"},
+            ),
+            context,
+        )
+
+    msgs = captured["context_messages"]
+    # No worktree notice means the trailing user message is the directive,
+    # which DOES carry the boilerplate tag.
+    last = msgs[-1]
+    assert isinstance(last, UserMessage)
+    blocks = list(last.content) if isinstance(last.content, list) else []
+    assert any(
+        isinstance(b, TextBlock) and "<fork-boilerplate>" in b.text
+        for b in blocks
+    )
+
+
+def test_fork_skips_worktree_notice_when_root_matches_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """worktree_root == cwd is a degenerate no-op; skip the notice."""
+    _set_fork_env(monkeypatch, enabled=True)
+    registry = build_default_registry(provider=object())
+    context = _make_interactive_context(tmp_path)
+    context.cwd = tmp_path
+    context.worktree_root = tmp_path
+
+    captured: dict[str, object] = {}
+
+    async def _fake_run_agent(params):
+        captured["context_messages"] = list(params.context_messages or [])
+        yield AssistantMessage(content=[TextBlock(text="ok")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _fake_run_agent):
+        registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={"description": "test", "prompt": "go"},
+            ),
+            context,
+        )
+
+    msgs = captured["context_messages"]
+    last = msgs[-1]
+    assert isinstance(last, UserMessage)
+    # The last message must still be the directive (no extra plain-text notice).
+    if isinstance(last.content, list):
+        assert any(
+            isinstance(b, TextBlock) and "<fork-boilerplate>" in b.text
+            for b in last.content
+        )
+    else:
+        assert "<fork-boilerplate>" in last.content
+
+
+def test_fork_worktree_notice_does_not_trip_recursion_guard(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The worktree notice must NOT contain the fork boilerplate tag.
+
+    Otherwise a fork child inheriting this message would trip the
+    message-scan recursion guard on its own first turn.
+    """
+    from src.agent.fork_subagent import build_worktree_notice, is_in_fork_child
+
+    notice = build_worktree_notice("/repo", "/tmp/wt-1234")
+    assert "<fork-boilerplate>" not in notice
+
+    fake_msg = create_user_message(content=[TextBlock(text=notice)])
+    assert is_in_fork_child([fake_msg]) is False


### PR DESCRIPTION
## Summary

Round-2 cache-determinism fixes for the fork-subagent path so parallel
children produce byte-identical API request prefixes (chapter 9, "The
Byte-Identical Prefix Trick").

- `ToolContext` gains `rendered_system_prompt: str | None`. Captures the
  bytes used on the parent's most recent API call so the fork child
  doesn't have to recompute (recomputation diverges under GrowthBook
  cold/warm flips). Default `None` — fully back-compat.
- `_resolve_parent_system_prompt` now prefers `rendered_system_prompt`,
  then `options.custom_system_prompt`, then the active agent
  definition's prompt. Mirrors `AgentTool.tsx:495-511`.
- Fork-on-worktree appends `build_worktree_notice(...)` as a trailing
  user message when `context.worktree_root` is set AND differs from
  cwd. Mirrors `AgentTool.tsx:610-614`. The notice is plain text — no
  `<fork-boilerplate>` tag — so the message-scan recursion guard stays
  unaffected.

Docs at `my-docs/ch09-fork-agents-gap-analysis.md` and
`my-docs/ch09-fork-agents-plan.md`.

## Test plan

- [x] `pytest tests/test_agent_tool_fork.py tests/test_fork_subagent.py
      tests/test_porting_workspace.py tests/test_no_top_level_decoys.py`
      passes (101/101).
- [x] Broader regression sweep on agent-related suites passes (122/122
      across `test_agent_bubble_propagation`, `test_agent_loop`,
      `test_agent_permission_inheritance`, `test_agent_tool_async`,
      `test_agent_toolkit_filtering`, `test_subagent_context`,
      `test_resume_agent`).
- [x] 7 new tests cover: rendered prompt preferred, custom fallback,
      active-def fallback, no-fallback returns None, worktree notice
      appended when root set, skipped when unset, skipped when root
      matches cwd, plus a recursion-guard parity assertion.

Generated with [Claude Code](https://claude.com/claude-code)