### PR TITLE
feat(ch18/round2): architecture-stats inspector for the six core abstractions

### DIFF
--- a/scripts/audit/architecture_stats.py
+++ b/scripts/audit/architecture_stats.py
@@ -1,0 +1,199 @@
+"""Architecture-observability inspector.
+
+Chapter 18 (Epilogue) reflects on the codebase as six core abstractions and
+claims that "behavioral complexity concentrates in a small number of
+high-density files." This module produces a Python-port equivalent of that
+reading aid: for each of the six abstractions named in the book's closing,
+report the package's footprint (files, LOC, lines/file) and surface the
+high-density files (>= ``HIGH_DENSITY_THRESHOLD`` LOC) inside it.
+
+Book references:
+
+- ``claude-code-from-source/book/ch18-epilogue.md`` §Closing (line 127) —
+  enumerates the six abstractions in the order this module preserves:
+  generator loop, tools, memory, hooks, rendering engine, MCP.
+- Same file §The Cost of Complexity (line 75) — establishes the
+  "high-density files" heuristic and cites 1.7k / 4.9k / 5k LOC examples
+  from the TS reference. ``HIGH_DENSITY_THRESHOLD = 500`` is the
+  order-of-magnitude floor that catches meaningful clusters.
+
+Wired as ``python -m scripts.audit.main architecture-stats``. Importable as
+``scripts.audit.architecture_stats.build_architecture_stats``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+# Sentinel above which a file is called out as a "high-density" file.
+# See module docstring for the rationale.
+HIGH_DENSITY_THRESHOLD = 500
+
+# Six core abstractions, in the order the book enumerates them in §Closing
+# (line 127). The order is load-bearing for the test that pins the map; do
+# not reshuffle without updating ``test_six_abstractions_present``.
+ABSTRACTION_MAP: tuple[tuple[str, str], ...] = (
+    ("Generator loop", "src/query"),
+    ("Tools", "src/tool_system"),
+    ("Memory", "src/memdir"),
+    ("Hooks", "src/hooks"),
+    ("Rendering engine", "src/tui"),
+    ("MCP", "src/services/mcp"),
+)
+
+# At most this many high-density files are reported per abstraction. Keeping
+# the per-section list short keeps the report readable; the threshold is the
+# real signal.
+MAX_HIGH_DENSITY_PER_ABSTRACTION = 3
+
+
+def _repo_root() -> Path:
+    # scripts/audit/architecture_stats.py -> scripts/audit -> scripts -> repo
+    return Path(__file__).resolve().parent.parent.parent
+
+
+@dataclass(frozen=True)
+class HighDensityFile:
+    """A single >= HIGH_DENSITY_THRESHOLD LOC file inside an abstraction."""
+
+    relative_path: str
+    line_count: int
+
+
+@dataclass(frozen=True)
+class AbstractionStats:
+    """Per-abstraction footprint."""
+
+    name: str
+    package: str
+    file_count: int
+    line_count: int
+    high_density_files: tuple[HighDensityFile, ...]
+
+    @property
+    def lines_per_file(self) -> float:
+        if self.file_count == 0:
+            return 0.0
+        return self.line_count / self.file_count
+
+
+@dataclass(frozen=True)
+class ArchitectureStats:
+    """The full six-abstraction report."""
+
+    abstractions: tuple[AbstractionStats, ...]
+    total_files: int
+    total_lines: int
+
+    def as_markdown(self) -> str:
+        return _render_markdown(self)
+
+
+def _walk_python_files(package_dir: Path) -> list[Path]:
+    if not package_dir.exists():
+        return []
+    return sorted(p for p in package_dir.rglob("*.py") if p.is_file())
+
+
+def _count_lines(path: Path) -> int:
+    try:
+        with path.open("rb") as fh:
+            return sum(1 for _ in fh)
+    except OSError:
+        return 0
+
+
+def _build_abstraction(name: str, package_rel: str, root: Path) -> AbstractionStats:
+    package_dir = root / package_rel
+    files = _walk_python_files(package_dir)
+    sized: list[tuple[Path, int]] = [(p, _count_lines(p)) for p in files]
+    total_lines = sum(lc for _, lc in sized)
+
+    high = sorted(
+        (
+            HighDensityFile(
+                relative_path=str(p.relative_to(root)),
+                line_count=lc,
+            )
+            for p, lc in sized
+            if lc >= HIGH_DENSITY_THRESHOLD
+        ),
+        key=lambda f: f.line_count,
+        reverse=True,
+    )
+
+    return AbstractionStats(
+        name=name,
+        package=package_rel,
+        file_count=len(files),
+        line_count=total_lines,
+        high_density_files=tuple(high[:MAX_HIGH_DENSITY_PER_ABSTRACTION]),
+    )
+
+
+def build_architecture_stats(root: Path | None = None) -> ArchitectureStats:
+    """Build the six-abstraction report.
+
+    ``root`` defaults to the repo root; passing an explicit value lets tests
+    point at a fixture tree.
+    """
+
+    repo_root = root if root is not None else _repo_root()
+    abstractions = tuple(
+        _build_abstraction(name, package_rel, repo_root)
+        for name, package_rel in ABSTRACTION_MAP
+    )
+    return ArchitectureStats(
+        abstractions=abstractions,
+        total_files=sum(a.file_count for a in abstractions),
+        total_lines=sum(a.line_count for a in abstractions),
+    )
+
+
+def _render_markdown(stats: ArchitectureStats) -> str:
+    lines: list[str] = []
+    lines.append("# Architecture Stats")
+    lines.append("")
+    lines.append(
+        "The book's epilogue identifies six core abstractions "
+        "(ch18 §Closing). This is their Python port footprint."
+    )
+    lines.append("")
+    lines.append("| # | Abstraction | Package | Files | Lines | Lines/file |")
+    lines.append("|---|---|---|---:|---:|---:|")
+    for idx, abstraction in enumerate(stats.abstractions, start=1):
+        lines.append(
+            f"| {idx} | {abstraction.name} | `{abstraction.package}` | "
+            f"{abstraction.file_count} | {abstraction.line_count} | "
+            f"{abstraction.lines_per_file:.0f} |"
+        )
+    lines.append("")
+    lines.append(
+        f"**Totals:** {stats.total_files} files, {stats.total_lines} lines "
+        f"across the six abstractions."
+    )
+    lines.append("")
+    lines.append(f"## High-density files (>= {HIGH_DENSITY_THRESHOLD} LOC)")
+    lines.append("")
+    lines.append(
+        "Per the chapter's claim that complexity concentrates in a small "
+        "number of files (ch18 §The Cost of Complexity)."
+    )
+    lines.append("")
+    any_dense = False
+    for abstraction in stats.abstractions:
+        if not abstraction.high_density_files:
+            continue
+        any_dense = True
+        lines.append(f"### {abstraction.name}")
+        for hd in abstraction.high_density_files:
+            lines.append(f"- `{hd.relative_path}` — {hd.line_count} lines")
+        lines.append("")
+    if not any_dense:
+        lines.append(
+            "_No files meet the high-density threshold; "
+            "all abstractions are evenly distributed._"
+        )
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/scripts/audit/main.py
+++ b/scripts/audit/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 
+from .architecture_stats import build_architecture_stats
 from .bootstrap_graph import build_bootstrap_graph
 from .command_graph import build_command_graph
 from .commands import execute_command, get_command, get_commands, render_command_index
@@ -28,6 +29,11 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers.add_parser('command-graph', help='show command graph segmentation')
     subparsers.add_parser('tool-pool', help='show assembled tool pool with default settings')
     subparsers.add_parser('bootstrap-graph', help='show the mirrored bootstrap/runtime graph stages')
+    subparsers.add_parser(
+        'architecture-stats',
+        help="map the book's six core abstractions (ch18 §Closing) to their "
+             "Python package footprints and surface high-density files",
+    )
     list_parser = subparsers.add_parser('subsystems', help='list the current Python modules in the workspace')
     list_parser.add_argument('--limit', type=int, default=32)
 
@@ -115,6 +121,9 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if args.command == 'bootstrap-graph':
         print(build_bootstrap_graph().as_markdown())
+        return 0
+    if args.command == 'architecture-stats':
+        print(build_architecture_stats().as_markdown())
         return 0
     if args.command == 'subsystems':
         for subsystem in manifest.top_level_modules[: args.limit]:

--- a/tests/test_architecture_stats.py
+++ b/tests/test_architecture_stats.py
@@ -1,0 +1,122 @@
+"""Tests for the ch18 architecture-stats inspector.
+
+Pins the six-abstraction map declared in ``ch18-epilogue-plan.md`` so a
+rename of any mapped package (or a quiet reshuffle of the order) is caught
+in CI rather than at "why is the inspector empty?" time. See also
+``my-docs/ch18-epilogue-gap-analysis.md``.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.audit.architecture_stats import (
+    ABSTRACTION_MAP,
+    HIGH_DENSITY_THRESHOLD,
+    MAX_HIGH_DENSITY_PER_ABSTRACTION,
+    build_architecture_stats,
+)
+
+
+# Pinned names + packages from the book's §Closing list (line 127).
+EXPECTED_ABSTRACTIONS: tuple[tuple[str, str], ...] = (
+    ("Generator loop", "src/query"),
+    ("Tools", "src/tool_system"),
+    ("Memory", "src/memdir"),
+    ("Hooks", "src/hooks"),
+    ("Rendering engine", "src/tui"),
+    ("MCP", "src/services/mcp"),
+)
+
+
+def _repo_root() -> Path:
+    # tests/test_architecture_stats.py -> tests -> repo
+    return Path(__file__).resolve().parent.parent
+
+
+class ArchitectureStatsTests(unittest.TestCase):
+    def test_six_abstractions_present(self) -> None:
+        """The map must have exactly six entries, in the book's order."""
+        self.assertEqual(ABSTRACTION_MAP, EXPECTED_ABSTRACTIONS)
+
+        stats = build_architecture_stats()
+        self.assertEqual(len(stats.abstractions), 6)
+        for got, (expected_name, expected_pkg) in zip(
+            stats.abstractions, EXPECTED_ABSTRACTIONS
+        ):
+            self.assertEqual(got.name, expected_name)
+            self.assertEqual(got.package, expected_pkg)
+
+    def test_each_package_exists_on_disk(self) -> None:
+        """A package rename should fail this test, not silently zero out."""
+        root = _repo_root()
+        for _, package_rel in EXPECTED_ABSTRACTIONS:
+            package_dir = root / package_rel
+            self.assertTrue(
+                package_dir.is_dir(),
+                f"abstraction package missing on disk: {package_dir}",
+            )
+            py_files = list(package_dir.rglob("*.py"))
+            self.assertGreaterEqual(
+                len(py_files),
+                1,
+                f"abstraction {package_rel} has no .py files — likely a rename",
+            )
+
+    def test_each_abstraction_has_nonzero_size(self) -> None:
+        """Structural check, deliberately not a snapshot."""
+        stats = build_architecture_stats()
+        for abstraction in stats.abstractions:
+            self.assertGreaterEqual(abstraction.file_count, 1)
+            # 100 LOC floor — small enough not to break on cleanup, large
+            # enough to detect "wired to an empty package".
+            self.assertGreaterEqual(abstraction.line_count, 100)
+            self.assertGreater(abstraction.lines_per_file, 0)
+
+    def test_markdown_render_includes_all_six(self) -> None:
+        stats = build_architecture_stats()
+        rendered = stats.as_markdown()
+        self.assertIn("# Architecture Stats", rendered)
+        for name, package in EXPECTED_ABSTRACTIONS:
+            self.assertIn(name, rendered)
+            self.assertIn(package, rendered)
+        self.assertIn("Totals:", rendered)
+        self.assertIn(f"{HIGH_DENSITY_THRESHOLD}", rendered)
+
+    def test_high_density_files_capped_per_abstraction(self) -> None:
+        stats = build_architecture_stats()
+        for abstraction in stats.abstractions:
+            self.assertLessEqual(
+                len(abstraction.high_density_files),
+                MAX_HIGH_DENSITY_PER_ABSTRACTION,
+                f"{abstraction.name} reported too many high-density files",
+            )
+            for hd in abstraction.high_density_files:
+                self.assertGreaterEqual(hd.line_count, HIGH_DENSITY_THRESHOLD)
+                self.assertTrue(hd.relative_path.startswith(abstraction.package))
+
+    def test_high_density_threshold_constant(self) -> None:
+        """A drive-by tweak to the threshold should require code review.
+
+        The 500-LOC floor is justified in
+        ``scripts/audit/architecture_stats.py`` and
+        ``my-docs/ch18-epilogue-plan.md``; pin it.
+        """
+        self.assertEqual(HIGH_DENSITY_THRESHOLD, 500)
+        self.assertEqual(MAX_HIGH_DENSITY_PER_ABSTRACTION, 3)
+
+    def test_totals_match_per_abstraction_sums(self) -> None:
+        stats = build_architecture_stats()
+        self.assertEqual(
+            stats.total_files,
+            sum(a.file_count for a in stats.abstractions),
+        )
+        self.assertEqual(
+            stats.total_lines,
+            sum(a.line_count for a in stats.abstractions),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_porting_workspace.py
+++ b/tests/test_porting_workspace.py
@@ -235,6 +235,22 @@ class PortingWorkspaceTests(unittest.TestCase):
         self.assertIn('Mirrored command', registry.command('review').execute('review security'))
         self.assertIn('Mirrored tool', registry.tool('MCPTool').execute('fetch mcp resources'))
 
+    def test_architecture_stats_cli_runs(self) -> None:
+        """ch18 round-2: the six-abstraction inspector ships as an audit
+        subcommand. See ``my-docs/ch18-epilogue-plan.md``.
+        """
+        result = subprocess.run(
+            [sys.executable, '-m', 'scripts.audit.main', 'architecture-stats'],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn('Architecture Stats', result.stdout)
+        # Sanity-check the markdown contains the book's named abstractions.
+        for expected in ('Generator loop', 'Tools', 'Memory', 'Hooks',
+                         'Rendering engine', 'MCP'):
+            self.assertIn(expected, result.stdout)
+
     def test_bootstrap_graph_and_direct_modes_run(self) -> None:
         graph_result = subprocess.run([sys.executable, '-m', 'scripts.audit.main', 'bootstrap-graph'], check=True, capture_output=True, text=True)
         direct_result = subprocess.run([sys.executable, '-m', 'scripts.audit.main', 'direct-connect-mode', 'workspace'], check=True, capture_output=True, text=True)


### PR DESCRIPTION
## Summary

- Chapter 18's epilogue (§Closing, line 127) identifies **six core abstractions** — generator loop, tools, memory, hooks, rendering engine, MCP — and claims (§The Cost of Complexity, line 75) that "behavioral complexity concentrates in a small number of high-density files." The Python port had no way to verify either claim.
- Adds `python -m scripts.audit.main architecture-stats` — maps each abstraction to its Python package, reports files / lines / lines-per-file, and surfaces files >= 500 LOC (capped at 3 per abstraction). Output is the same Markdown style as the existing audit inspectors.
- Pins the abstraction map with a regression test so a package rename fails loudly instead of silently zeroing the inspector. `HIGH_DENSITY_THRESHOLD = 500` is also pinned.

## Files

- `scripts/audit/architecture_stats.py` (new, ~155 LOC) — `ABSTRACTION_MAP`, `build_architecture_stats()`, dataclasses, Markdown renderer.
- `scripts/audit/main.py` — wire the new subcommand (+9 LOC).
- `tests/test_architecture_stats.py` (new) — pin the map, the threshold, and the order; assert each mapped package exists on disk and has >= 100 LOC.
- `tests/test_porting_workspace.py` — CLI smoke test matching the pattern used by every other audit subcommand.

## Sample output

```
| # | Abstraction       | Package              | Files | Lines | Lines/file |
|---|-------------------|----------------------|------:|------:|-----------:|
| 1 | Generator loop    | `src/query`          |     9 |  2433 |        270 |
| 2 | Tools             | `src/tool_system`    |    56 | 10815 |        193 |
| 3 | Memory            | `src/memdir`         |     9 |  1901 |        211 |
| 4 | Hooks             | `src/hooks`          |    13 |  2133 |        164 |
| 5 | Rendering engine  | `src/tui`            |    69 | 12376 |        179 |
| 6 | MCP               | `src/services/mcp`   |    32 |  7583 |        237 |
```

## Test plan

- [x] `pytest tests/test_architecture_stats.py tests/test_porting_workspace.py tests/test_no_top_level_decoys.py -q` — 69 passed
- [x] `python -m scripts.audit.main architecture-stats` renders the Markdown report
- [x] Critic / simplify review pass — fixed two off-by-one path-arithmetic comments

Round-2 docs saved to `my-docs/ch18-epilogue-gap-analysis.md` and `my-docs/ch18-epilogue-plan.md` (outside the repo per the project convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)