### PR TITLE
feat(ch17/round2): memoize token estimation hot path

### DIFF
--- a/src/token_estimation.py
+++ b/src/token_estimation.py
@@ -3,12 +3,24 @@
 Provides rough token counting for messages and content blocks, plus
 accurate tiktoken-based counting when available. API-based counting
 is also supported for precise results.
+
+Ch17 round-2: text- and block-level memoization layer. The compact
+pipeline (`services/compact/compact.py:319,453,512`), reactive compact
+(`services/compact/reactive_compact.py:183,223`), and context analyzer
+(`context_system/context_analyzer.py`) call ``count_tokens`` /
+``count_messages_tokens`` repeatedly against largely-overlapping
+content within a single turn. Each tiktoken ``encode`` call is
+~100 us–10 ms; without the cache, a single compaction event pays
+that cost 3-5× over the same message list. The cache key is the
+content's hash, so identical content always hits regardless of which
+caller invoked it.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+from collections import OrderedDict
 from typing import Any, Optional, Sequence
 
 logger = logging.getLogger(__name__)
@@ -33,16 +45,125 @@ def _get_encoder() -> Optional[object]:
     return _encoder_cache
 
 
+# ---------------------------------------------------------------------------
+# Memoization layer (ch17 round-2)
+# ---------------------------------------------------------------------------
+
+_MAX_TEXT_CACHE = 4096
+_MAX_BLOCK_CACHE = 4096
+
+
+class _TokenCountCache:
+    """Content-keyed LRU cache for token counts.
+
+    Backed by ``OrderedDict`` rather than ``functools.lru_cache`` so we
+    can:
+      - Reset for tests via ``reset_token_cache()``.
+      - Expose hit/miss counters via ``get_token_cache_stats()``.
+      - Bound by size, not by function-argument hashability quirks.
+
+    Keys are the content itself (a string or any hashable value),
+    NOT ``hash(content)`` — Python's ``hash()`` is a 64-bit integer
+    and collisions between distinct inputs are possible (birthday
+    paradox is real at 4096 entries). Using the content directly as
+    the dict key lets Python's dict implementation handle collisions
+    correctly via ``__eq__`` after hashing.
+
+    Thread safety: Python's GIL serializes simple ``__getitem__`` /
+    ``__setitem__`` operations. Failure mode under concurrent writes is
+    a missed cache hit or a stale eviction, never an incorrect token
+    count.
+    """
+
+    __slots__ = ("_cache", "_max_size", "hits", "misses")
+
+    def __init__(self, max_size: int) -> None:
+        self._cache: OrderedDict[Any, int] = OrderedDict()
+        self._max_size = max_size
+        self.hits = 0
+        self.misses = 0
+
+    def get(self, key: Any) -> Optional[int]:
+        # Sentinel pattern so that a legitimately-cached 0 is still a hit.
+        # (We don't store None, but a future caller might cache 0 if they
+        # bypass the count_tokens short-circuit.)
+        sentinel: Any = _CACHE_MISS_SENTINEL
+        cached = self._cache.get(key, sentinel)
+        if cached is sentinel:
+            self.misses += 1
+            return None
+        self.hits += 1
+        self._cache.move_to_end(key)
+        return cached  # type: ignore[return-value]
+
+    def put(self, key: Any, value: int) -> None:
+        if key in self._cache:
+            self._cache.move_to_end(key)
+            self._cache[key] = value
+            return
+        self._cache[key] = value
+        if len(self._cache) > self._max_size:
+            # Evict the least-recently used entry (front of the OrderedDict).
+            self._cache.popitem(last=False)
+
+    def reset(self) -> None:
+        self._cache.clear()
+        self.hits = 0
+        self.misses = 0
+
+    def size(self) -> int:
+        return len(self._cache)
+
+
+# Module-level sentinel for the cache-miss check. Defined as a module-level
+# object so equality is identity-based and never accidentally satisfied by
+# a stored value (no token count is this object).
+_CACHE_MISS_SENTINEL: object = object()
+
+
+_TEXT_CACHE = _TokenCountCache(_MAX_TEXT_CACHE)
+_BLOCK_CACHE = _TokenCountCache(_MAX_BLOCK_CACHE)
+
+
+def get_token_cache_stats() -> dict[str, int]:
+    """Return hit/miss counters and current cache sizes.
+
+    Useful for observability (e.g., a future ``/tokens`` debug command)
+    and for tests that need to verify cache behaviour without timing.
+    """
+    return {
+        "text_cache_hits": _TEXT_CACHE.hits,
+        "text_cache_misses": _TEXT_CACHE.misses,
+        "block_cache_hits": _BLOCK_CACHE.hits,
+        "block_cache_misses": _BLOCK_CACHE.misses,
+        "text_cache_size": _TEXT_CACHE.size(),
+        "block_cache_size": _BLOCK_CACHE.size(),
+    }
+
+
+def reset_token_cache() -> None:
+    """Clear both caches and reset counters. Primarily for test isolation."""
+    _TEXT_CACHE.reset()
+    _BLOCK_CACHE.reset()
+
+
 def count_tokens(text: str) -> int:
     if not text:
         return 0
+    cached = _TEXT_CACHE.get(text)
+    if cached is not None:
+        return cached
     encoder = _get_encoder()
     if encoder is not None:
         try:
-            return len(encoder.encode(text))
+            result = len(encoder.encode(text))
+            _TEXT_CACHE.put(text, result)
+            return result
         except Exception:
             pass
-    return max(1, len(text) // 4)
+    result = max(1, len(text) // 4)
+    _TEXT_CACHE.put(text, result)
+    return result
 
 
 def rough_token_count_estimation(content: str, bytes_per_token: int = 4) -> int:
@@ -105,7 +226,36 @@ def rough_token_count_estimation_for_content(
     return total
 
 
-def rough_token_count_estimation_for_block(block: Any) -> int:
+def _block_cache_key(block: Any) -> Optional[tuple]:
+    """Stable cache key for a content block.
+
+    Returns ``None`` when the block isn't cacheable (e.g., a custom
+    object whose JSON-serialisation raises). Returning ``None`` short-
+    circuits the cache lookup; the caller falls through to the
+    uncached compute path. No exception ever propagates to the caller.
+
+    Key shape (used as a dict key — Python's dict handles hash
+    collisions correctly via ``__eq__``):
+      - ``str`` blocks → ``("str", text)``
+      - ``dict`` blocks → ``(block_type, json_str)`` where
+        ``json_str`` is the deterministic JSON projection of the dict.
+        Dict insertion order is preserved in Python 3.7+, so two
+        structurally-identical dicts produce byte-identical JSON.
+      - other → ``None``
+    """
+    if isinstance(block, str):
+        return ("str", block)
+    if isinstance(block, dict):
+        block_type = block.get("type", "")
+        try:
+            payload = _json_stringify(block)
+        except Exception:
+            return None
+        return (block_type, payload)
+    return None
+
+
+def _rough_token_count_estimation_for_block_impl(block: Any) -> int:
     if isinstance(block, str):
         return rough_token_count_estimation(block)
 
@@ -136,6 +286,18 @@ def rough_token_count_estimation_for_block(block: Any) -> int:
         return rough_token_count_estimation(str(data))
 
     return rough_token_count_estimation(_json_stringify(block))
+
+
+def rough_token_count_estimation_for_block(block: Any) -> int:
+    key = _block_cache_key(block)
+    if key is not None:
+        cached = _BLOCK_CACHE.get(key)
+        if cached is not None:
+            return cached
+    result = _rough_token_count_estimation_for_block_impl(block)
+    if key is not None:
+        _BLOCK_CACHE.put(key, result)
+    return result
 
 
 def count_messages_tokens(messages: list[dict[str, Any]]) -> int:

--- a/tests/test_token_estimation_cache.py
+++ b/tests/test_token_estimation_cache.py
@@ -1,0 +1,347 @@
+"""Tests for token estimation memoization (ch17 round-2).
+
+The cache layer in ``src/token_estimation.py`` lives at two levels:
+
+  - ``count_tokens(text)`` is wrapped by ``_TEXT_CACHE`` (LRU 4096),
+    keyed on ``hash(text)``.
+  - ``rough_token_count_estimation_for_block(block)`` is wrapped by
+    ``_BLOCK_CACHE`` (LRU 4096), keyed on a stable JSON-projection
+    hash of the block.
+
+These tests verify:
+  - Hit/miss counters via ``get_token_cache_stats()``.
+  - LRU bounded-memory behaviour.
+  - Hash-determinism for structurally identical dict blocks.
+  - End-to-end memoization across ``count_messages_tokens``.
+  - Structural performance assertion: two passes over the same
+    message list invoke tiktoken's encoder exactly N unique-string
+    times, not 2 * N.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src import token_estimation
+from src.token_estimation import (
+    _MAX_TEXT_CACHE,
+    count_messages_tokens,
+    count_tokens,
+    get_token_cache_stats,
+    reset_token_cache,
+    rough_token_count_estimation_for_block,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache_fixture():
+    """Ensure every test starts and ends with empty caches and zero counters."""
+    reset_token_cache()
+    yield
+    reset_token_cache()
+
+
+# ---------------------------------------------------------------------------
+# Text-level cache (count_tokens)
+# ---------------------------------------------------------------------------
+
+
+class TestTextCache:
+    def test_first_call_is_miss(self):
+        count_tokens("hello world")
+        stats = get_token_cache_stats()
+        assert stats["text_cache_misses"] == 1
+        assert stats["text_cache_hits"] == 0
+
+    def test_second_call_is_hit(self):
+        count_tokens("hello world")
+        count_tokens("hello world")
+        stats = get_token_cache_stats()
+        assert stats["text_cache_misses"] == 1
+        assert stats["text_cache_hits"] == 1
+
+    def test_repeated_same_text_only_misses_once(self):
+        for _ in range(50):
+            count_tokens("repeated text")
+        stats = get_token_cache_stats()
+        assert stats["text_cache_misses"] == 1
+        assert stats["text_cache_hits"] == 49
+
+    def test_different_strings_are_misses(self):
+        count_tokens("first")
+        count_tokens("second")
+        count_tokens("third")
+        stats = get_token_cache_stats()
+        assert stats["text_cache_misses"] == 3
+        assert stats["text_cache_hits"] == 0
+
+    def test_empty_string_bypasses_cache(self):
+        count_tokens("")
+        stats = get_token_cache_stats()
+        # Empty string short-circuits before the cache layer.
+        assert stats["text_cache_misses"] == 0
+        assert stats["text_cache_hits"] == 0
+
+    def test_cached_value_matches_uncached_value(self):
+        first = count_tokens("the quick brown fox")
+        second = count_tokens("the quick brown fox")
+        assert first == second
+
+    def test_cache_size_grows_with_unique_inputs(self):
+        for i in range(10):
+            count_tokens(f"unique-string-{i}")
+        stats = get_token_cache_stats()
+        assert stats["text_cache_size"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Block-level cache (rough_token_count_estimation_for_block)
+# ---------------------------------------------------------------------------
+
+
+class TestBlockCache:
+    def test_identical_text_blocks_hit(self):
+        block = {"type": "text", "text": "hello world"}
+        rough_token_count_estimation_for_block(block)
+        rough_token_count_estimation_for_block(block)
+        stats = get_token_cache_stats()
+        assert stats["block_cache_misses"] == 1
+        assert stats["block_cache_hits"] == 1
+
+    def test_structurally_identical_dicts_hit(self):
+        # Two separate dict instances with the same content.
+        block_a = {"type": "text", "text": "shared"}
+        block_b = {"type": "text", "text": "shared"}
+        assert block_a is not block_b
+        rough_token_count_estimation_for_block(block_a)
+        rough_token_count_estimation_for_block(block_b)
+        stats = get_token_cache_stats()
+        assert stats["block_cache_misses"] == 1
+        assert stats["block_cache_hits"] == 1
+
+    def test_different_block_types_miss(self):
+        rough_token_count_estimation_for_block({"type": "text", "text": "hi"})
+        rough_token_count_estimation_for_block({"type": "image", "source": {"data": "x"}})
+        rough_token_count_estimation_for_block({"type": "tool_use", "name": "Bash", "input": {}})
+        stats = get_token_cache_stats()
+        assert stats["block_cache_misses"] == 3
+        assert stats["block_cache_hits"] == 0
+
+    def test_string_block_caches_via_block_path(self):
+        rough_token_count_estimation_for_block("repeated")
+        rough_token_count_estimation_for_block("repeated")
+        stats = get_token_cache_stats()
+        assert stats["block_cache_misses"] == 1
+        assert stats["block_cache_hits"] == 1
+
+    def test_tool_use_block_with_dict_input_caches(self):
+        block = {"type": "tool_use", "name": "Bash", "input": {"command": "ls -la"}}
+        rough_token_count_estimation_for_block(block)
+        rough_token_count_estimation_for_block(block)
+        stats = get_token_cache_stats()
+        assert stats["block_cache_hits"] == 1
+
+    def test_unserializable_block_does_not_crash(self):
+        # An object that fails JSON serialization should fall through to
+        # the impl path without caching, and without raising.
+        class _NotSerializable:
+            pass
+
+        # Wrap it in a dict so the block path is exercised.
+        block = {"type": "unknown", "weird": _NotSerializable()}
+        # Should not raise; result may be any non-negative int.
+        result = rough_token_count_estimation_for_block(block)
+        assert isinstance(result, int)
+        assert result >= 0
+
+
+# ---------------------------------------------------------------------------
+# Aggregation through count_messages_tokens
+# ---------------------------------------------------------------------------
+
+
+def _make_messages(n: int) -> list[dict[str, Any]]:
+    return [
+        {"role": "user", "content": f"message number {i}"}
+        for i in range(n)
+    ]
+
+
+class TestMessagesAggregation:
+    def test_second_count_messages_tokens_call_has_zero_new_misses(self):
+        messages = _make_messages(20)
+        count_messages_tokens(messages)
+        stats_after_first = get_token_cache_stats()
+        misses_after_first = stats_after_first["text_cache_misses"]
+
+        count_messages_tokens(messages)
+        stats_after_second = get_token_cache_stats()
+        # No new misses on the second pass — every text was cached.
+        assert stats_after_second["text_cache_misses"] == misses_after_first
+
+    def test_grown_list_only_new_messages_miss(self):
+        messages = _make_messages(10)
+        count_messages_tokens(messages)
+        misses_after_first = get_token_cache_stats()["text_cache_misses"]
+
+        # Add 3 new messages, re-run.
+        messages.extend(_make_messages(13)[10:])
+        count_messages_tokens(messages)
+        stats = get_token_cache_stats()
+        # Exactly 3 new texts → 3 new misses. (The "role" string "user"
+        # only misses once across all calls.)
+        new_misses = stats["text_cache_misses"] - misses_after_first
+        assert new_misses == 3
+
+    def test_complex_message_with_list_content_cached_via_blocks(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Block one"},
+                    {"type": "text", "text": "Block two"},
+                ],
+            }
+        ]
+        first = count_messages_tokens(messages)
+        second = count_messages_tokens(messages)
+        assert first == second
+        # The text strings inside the blocks should be cached.
+        stats = get_token_cache_stats()
+        assert stats["text_cache_hits"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Bounded-memory / LRU eviction
+# ---------------------------------------------------------------------------
+
+
+class TestLRUEviction:
+    def test_text_cache_evicts_oldest_when_full(self):
+        for i in range(_MAX_TEXT_CACHE + 10):
+            count_tokens(f"unique-text-{i}")
+        stats = get_token_cache_stats()
+        # Capped at max size; never grows beyond it.
+        assert stats["text_cache_size"] == _MAX_TEXT_CACHE
+
+    def test_evicted_entry_misses_again(self):
+        # Fill the cache.
+        for i in range(_MAX_TEXT_CACHE):
+            count_tokens(f"slot-{i}")
+        misses_after_fill = get_token_cache_stats()["text_cache_misses"]
+        # Add one more — evicts "slot-0".
+        count_tokens("brand-new")
+        # Now access "slot-0" again — must miss.
+        count_tokens("slot-0")
+        stats = get_token_cache_stats()
+        # Two new misses: "brand-new" + re-access of evicted "slot-0".
+        assert stats["text_cache_misses"] == misses_after_fill + 2
+
+    def test_recently_accessed_survives_eviction(self):
+        for i in range(_MAX_TEXT_CACHE):
+            count_tokens(f"slot-{i}")
+        misses_after_fill = get_token_cache_stats()["text_cache_misses"]
+        # Re-access "slot-0" — moves it to MRU.
+        count_tokens("slot-0")
+        # Insert one new entry — should evict "slot-1" (now LRU), not slot-0.
+        count_tokens("displacer")
+        # Re-access slot-0 again — must still hit.
+        count_tokens("slot-0")
+        stats = get_token_cache_stats()
+        # Misses incurred since the fill: just "displacer" = 1.
+        assert stats["text_cache_misses"] == misses_after_fill + 1
+
+
+# ---------------------------------------------------------------------------
+# Stats / reset
+# ---------------------------------------------------------------------------
+
+
+class TestStats:
+    def test_initial_stats_zero(self):
+        stats = get_token_cache_stats()
+        assert stats["text_cache_hits"] == 0
+        assert stats["text_cache_misses"] == 0
+        assert stats["block_cache_hits"] == 0
+        assert stats["block_cache_misses"] == 0
+        assert stats["text_cache_size"] == 0
+        assert stats["block_cache_size"] == 0
+
+    def test_reset_clears_everything(self):
+        count_tokens("warmup")
+        rough_token_count_estimation_for_block({"type": "text", "text": "warmup"})
+        reset_token_cache()
+        stats = get_token_cache_stats()
+        assert stats == {
+            "text_cache_hits": 0,
+            "text_cache_misses": 0,
+            "block_cache_hits": 0,
+            "block_cache_misses": 0,
+            "text_cache_size": 0,
+            "block_cache_size": 0,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Structural performance assertion (encoder call count, not wall-clock)
+# ---------------------------------------------------------------------------
+
+
+class TestEncoderCallCount:
+    """Verify that the cache prevents redundant tiktoken encoding.
+
+    We patch the module-level ``_get_encoder`` to return a counting
+    proxy. After two ``count_messages_tokens`` passes over the same
+    list, the encode call count must equal the count after a single
+    pass — no redundant work on the second go.
+    """
+
+    def test_two_passes_invoke_encoder_only_for_unique_strings(self):
+        real_encoder = token_estimation._get_encoder()
+        call_count = {"n": 0}
+
+        class _CountingEncoder:
+            def encode(self, text: str):
+                call_count["n"] += 1
+                if real_encoder is not None:
+                    return real_encoder.encode(text)
+                return list(text.encode("utf-8"))[: max(1, len(text) // 4)]
+
+        proxy = _CountingEncoder()
+        with patch.object(token_estimation, "_get_encoder", return_value=proxy):
+            messages = _make_messages(15)
+            count_messages_tokens(messages)
+            calls_after_first = call_count["n"]
+            assert calls_after_first > 0  # sanity: encoder was used
+
+            count_messages_tokens(messages)
+            calls_after_second = call_count["n"]
+
+        # Second pass added zero encoder calls — every string was cached.
+        assert calls_after_second == calls_after_first
+
+
+# ---------------------------------------------------------------------------
+# Determinism: cache key stability
+# ---------------------------------------------------------------------------
+
+
+class TestCacheKeyDeterminism:
+    def test_dict_key_order_matters_for_hash(self):
+        """Python 3.7+ preserves dict insertion order; same insertion
+        order → same JSON projection → same cache key.
+
+        Two dicts with different insertion order produce different
+        JSON. The test verifies the cache still returns correct
+        results (just two cache slots instead of one). The token
+        count value is identical regardless.
+        """
+        block_a = {"type": "text", "text": "hi"}
+        block_b = {"text": "hi", "type": "text"}
+        count_a = rough_token_count_estimation_for_block(block_a)
+        count_b = rough_token_count_estimation_for_block(block_b)
+        # Values agree even though they live in separate cache slots.
+        assert count_a == count_b


### PR DESCRIPTION
## Summary

- Adds a two-level content-keyed LRU memoization layer (`_TEXT_CACHE`, `_BLOCK_CACHE`, 4096 entries each) to `src/token_estimation.py`, eliminating redundant `tiktoken.encode` work when `count_tokens` / `count_messages_tokens` / `rough_token_count_estimation_for_block` are called repeatedly against the same content within a turn.
- Hot-path consumers benefiting today (no caller changes needed): `services/compact/compact.py:319,453,512` (3x per compaction), `services/compact/reactive_compact.py:183,223` (2x per reactive compact), `context_system/context_analyzer.py:225` (every `/context` UI refresh and analyze pass), and the `/cost` command.
- Caches are content-keyed (NOT `hash(text)`-keyed) to avoid 64-bit hash collisions that would silently return wrong counts at the 4096-entry birthday-paradox threshold.

## Round-2 Gap

Round-1's gap analysis identified `count_tokens` / `count_messages_tokens` as the central token-accounting primitives but did not flag their lack of caching. The chapter's "Section Memoization" pattern (`systemPromptSection(name, compute)`) extends naturally to token estimation. Round-1 plan landed Phase 0 (instrumentation), Phase 1 (cache_control + date memoization), Phase 4 (deferred imports, fast-path dispatch), and other items; this round-2 work closes a CPU/latency hole inside the token-accounting layer that was orthogonal to all of those.

Docs: `my-docs/ch17-performance-round2-gap-analysis.md`, `my-docs/ch17-performance-round2-plan.md` (in the parent repo's gitignored `my-docs/`).

## Implementation Notes

- `_TokenCountCache` uses `OrderedDict` + `move_to_end` for O(1) LRU.
- Module-level sentinel (`_CACHE_MISS_SENTINEL`) for cache-miss detection so a legitimately-cached 0 still counts as a hit.
- `_block_cache_key(block)` returns `None` for unhashable / unserializable blocks → falls through to compute path, no exception escapes.
- `get_token_cache_stats()` exposes `{text_cache_hits, text_cache_misses, block_cache_hits, block_cache_misses, text_cache_size, block_cache_size}` for observability.
- `reset_token_cache()` for test isolation (autouse fixture in the new test file).

## Test plan

- [x] `tests/test_token_estimation_cache.py` (new, 23 cases): hit/miss counters, LRU eviction with MRU survival, structural perf assertion (tiktoken-encoder call count is constant across two passes over the same messages, not 2x), unserializable-block safety, key-determinism for structurally-identical dicts.
- [x] `tests/test_token_estimation.py` (43 existing cases) — unchanged, green.
- [x] `tests/test_token_estimation_full.py` (existing cases) — unchanged, green.
- [x] `tests/test_porting_workspace.py` + `tests/test_no_top_level_decoys.py` — green.
- [x] Broader smoke: `tests/` filtered to compaction / context_analyzer — 254 passed (test_providers.py has a pre-existing collection error unrelated to this work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)