### PR TITLE
feat(ch15/round2): strict MCP server-config validation with rich error messages

### DIFF
--- a/src/services/mcp/__init__.py
+++ b/src/services/mcp/__init__.py
@@ -117,6 +117,7 @@ from .types import (
     ServerCapabilities,
     ServerInfo,
     parse_server_config,
+    validate_server_config,
 )
 
 __all__ = [
@@ -181,6 +182,7 @@ __all__ = [
     "get_mcp_tools_commands_and_resources",
     "prefetch_all_mcp_resources",
     "parse_server_config",
+    "validate_server_config",
     "expand_env_vars_in_string",
     "build_mcp_http_client",
     "build_mcp_timeout",

--- a/src/services/mcp/config.py
+++ b/src/services/mcp/config.py
@@ -13,6 +13,7 @@ from urllib.parse import parse_qs, unquote, urlparse
 
 from .env_expansion import expand_env_vars_in_string
 from .types import (
+    KNOWN_TRANSPORT_TYPES,
     ConfigScope,
     McpHTTPServerConfig,
     McpSSEServerConfig,
@@ -21,6 +22,7 @@ from .types import (
     McpWebSocketServerConfig,
     ScopedMcpServerConfig,
     parse_server_config,
+    validate_server_config,
 )
 
 logger = logging.getLogger(__name__)
@@ -267,17 +269,22 @@ def parse_mcp_config(
             )
             continue
 
-        parsed = parse_server_config(raw_config)
+        parsed, validation_messages = validate_server_config(raw_config)
         if parsed is None:
-            errors.append(
-                ValidationError(
-                    path=f"mcpServers.{name}",
-                    message="Invalid server configuration",
-                    file=file_path,
-                    scope=scope,
-                    server_name=name,
+            # validate_server_config always populates at least one message
+            # when it returns None; fall back is defensive only.
+            messages = validation_messages or ["Invalid server configuration"]
+            for msg in messages:
+                errors.append(
+                    ValidationError(
+                        path=f"mcpServers.{name}",
+                        message=msg,
+                        suggestion=_suggestion_for_message(msg),
+                        file=file_path,
+                        scope=scope,
+                        server_name=name,
+                    )
                 )
-            )
             continue
 
         if expand_vars:
@@ -673,6 +680,35 @@ def _notices_to_validation_errors(notices: list[str]) -> list[ValidationError]:
         )
         for msg in notices
     ]
+
+
+def _suggestion_for_message(message: str) -> str | None:
+    """Derive a friendly remediation hint from a validator message.
+
+    Round-2 polish for ``parse_mcp_config()`` — keeps the validator pure
+    (just messages) while surfacing actionable next steps via the
+    ``ValidationError.suggestion`` channel that existing UI / doctor
+    callers already render. Returns ``None`` when no specific suggestion
+    applies (the message alone is self-explanatory).
+    """
+    if "is required" in message:
+        # "url is required" -> "Add a `url` field to the server config"
+        field = message.split(" is required", 1)[0].strip()
+        return f"Add a `{field}` field to the server config"
+    if "cannot be empty" in message:
+        field = message.split(" cannot be empty", 1)[0].strip()
+        return f"Set `{field}` to a non-empty string"
+    if "must use https://" in message:
+        return "Use an https:// URL for OAuth metadata discovery"
+    if "unknown transport type" in message:
+        return f"Use one of: {', '.join(KNOWN_TRANSPORT_TYPES)}"
+    if "must be a list of strings" in message:
+        return "Provide `args` as a JSON array of strings"
+    if "must be an object mapping strings to strings" in message:
+        return "Provide a JSON object whose values are all strings"
+    if "must be a string" in message:
+        return "Wrap the value in quotes so it parses as a string"
+    return None
 
 
 _enterprise_exists_cache: bool | None = None

--- a/src/services/mcp/types.py
+++ b/src/services/mcp/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, get_args
 
 ConfigScope = Literal[
     "local", "user", "project", "dynamic", "enterprise", "claudeai", "managed"
@@ -197,42 +197,169 @@ class MCPCliState:
     normalized_names: dict[str, str] | None = None
 
 
-def parse_server_config(data: dict[str, Any]) -> McpServerConfig | None:
-    server_type = data.get("type")
+# Derived from ``TransportType`` so the validator (and any caller that
+# needs the enumerated list, e.g. for error suggestions) stays in sync
+# if the Literal gains a new entry.
+KNOWN_TRANSPORT_TYPES: tuple[str, ...] = get_args(TransportType)
+
+
+def _validate_str_str_dict(
+    value: Any, field_name: str, errors: list[str]
+) -> dict[str, str] | None:
+    """Validate that ``value`` is a ``dict[str, str]``; append errors and return None on failure."""
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        errors.append(f"{field_name} must be an object mapping strings to strings")
+        return None
+    cleaned: dict[str, str] = {}
+    ok = True
+    for k, v in value.items():
+        if not isinstance(k, str):
+            errors.append(f"{field_name} key {k!r} must be a string")
+            ok = False
+            continue
+        if not isinstance(v, str):
+            errors.append(f"{field_name} value for {k!r} must be a string")
+            ok = False
+            continue
+        cleaned[k] = v
+    return cleaned if ok else None
+
+
+def _validate_string_field(
+    value: Any,
+    field_name: str,
+    errors: list[str],
+    *,
+    required: bool = False,
+    allow_empty: bool = True,
+) -> str | None:
+    """Validate that ``value`` is a string. Append errors as needed."""
+    if value is None:
+        if required:
+            errors.append(f"{field_name} is required")
+        return None
+    if not isinstance(value, str):
+        errors.append(f"{field_name} must be a string")
+        return None
+    if not allow_empty and value == "":
+        errors.append(f"{field_name} cannot be empty")
+        return None
+    return value
+
+
+def validate_server_config(data: Any) -> tuple[McpServerConfig | None, list[str]]:
+    """Validate raw MCP server config data with rich error messages.
+
+    Mirrors the Zod schemas in ``typescript/src/services/mcp/types.ts``
+    (``McpStdioServerConfigSchema`` and friends, lines 28-122). Returns a
+    ``(config, errors)`` tuple: on success ``config`` is the parsed dataclass
+    and ``errors`` is empty; on failure ``config`` is ``None`` and ``errors``
+    is a list of human-readable validation messages.
+
+    Unlike the older ``parse_server_config()`` (which silently returned
+    ``None`` on bad input and *raised* ``KeyError`` for missing ``url`` / ``name``
+    on remote/sdk configs), this function never raises on user-supplied data
+    and surfaces every per-field violation. Callers that want the legacy
+    ``Optional[McpServerConfig]`` return type can call ``parse_server_config``
+    which delegates here and discards the messages.
+    """
+    errors: list[str] = []
+
+    if not isinstance(data, dict):
+        return None, ["server config must be an object"]
+
+    server_type_raw = data.get("type")
+    if server_type_raw is not None and not isinstance(server_type_raw, str):
+        return None, [f"type must be a string, got {type(server_type_raw).__name__}"]
+
+    server_type: str | None = server_type_raw
+    if server_type is not None and server_type not in KNOWN_TRANSPORT_TYPES:
+        expected = ", ".join(KNOWN_TRANSPORT_TYPES)
+        return None, [
+            f"unknown transport type: {server_type!r}. Expected one of: {expected}"
+        ]
+
     # ``authServerMetadataUrl`` is the camelCase JSON key (Phase 4 WI-4.1
     # escape hatch). Accept both spellings so existing configs work either way.
-    asm_url = data.get("authServerMetadataUrl") or data.get("auth_server_metadata_url")
-    if server_type == "sse":
-        return McpSSEServerConfig(
-            url=data["url"],
-            headers=data.get("headers"),
-            headers_helper=data.get("headersHelper"),
+    asm_raw = data.get("authServerMetadataUrl")
+    if asm_raw is None:
+        asm_raw = data.get("auth_server_metadata_url")
+    asm_url: str | None = None
+    if asm_raw is not None:
+        asm_url = _validate_string_field(asm_raw, "authServerMetadataUrl", errors)
+        if asm_url is not None and not asm_url.startswith("https://"):
+            errors.append("authServerMetadataUrl must use https://")
+            asm_url = None
+
+    if server_type in ("sse", "http", "ws"):
+        url = _validate_string_field(
+            data.get("url"), "url", errors, required=True, allow_empty=False
+        )
+        headers = _validate_str_str_dict(data.get("headers"), "headers", errors)
+        headers_helper = _validate_string_field(
+            data.get("headersHelper"), "headersHelper", errors
+        )
+        if errors or url is None:
+            return None, errors
+        remote_ctor = {
+            "sse": McpSSEServerConfig,
+            "http": McpHTTPServerConfig,
+            "ws": McpWebSocketServerConfig,
+        }[server_type]
+        return remote_ctor(
+            url=url,
+            headers=headers,
+            headers_helper=headers_helper,
             auth_server_metadata_url=asm_url,
+        ), errors
+
+    if server_type == "sdk":
+        name = _validate_string_field(
+            data.get("name"), "name", errors, required=True, allow_empty=False
         )
-    elif server_type == "http":
-        return McpHTTPServerConfig(
-            url=data["url"],
-            headers=data.get("headers"),
-            headers_helper=data.get("headersHelper"),
-            auth_server_metadata_url=asm_url,
-        )
-    elif server_type == "ws":
-        return McpWebSocketServerConfig(
-            url=data["url"],
-            headers=data.get("headers"),
-            headers_helper=data.get("headersHelper"),
-            auth_server_metadata_url=asm_url,
-        )
-    elif server_type == "sdk":
-        return McpSdkServerConfig(name=data["name"])
-    elif server_type == "stdio" or server_type is None:
-        command = data.get("command")
-        if not command:
-            return None
-        return McpStdioServerConfig(
-            command=command,
-            args=data.get("args", []),
-            env=data.get("env"),
-            type=server_type,
-        )
-    return None
+        if errors or name is None:
+            return None, errors
+        return McpSdkServerConfig(name=name), errors
+
+    # stdio (default branch — type is "stdio" or omitted)
+    command = _validate_string_field(
+        data.get("command"), "command", errors, required=True, allow_empty=False
+    )
+
+    args_raw = data.get("args")
+    args: list[str] = []
+    if args_raw is not None:
+        if not isinstance(args_raw, list):
+            errors.append("args must be a list of strings")
+        else:
+            invalid_indices = [
+                i for i, v in enumerate(args_raw) if not isinstance(v, str)
+            ]
+            if invalid_indices:
+                errors.append(
+                    f"args[{invalid_indices[0]}] must be a string"
+                )
+            else:
+                args = list(args_raw)
+
+    env = _validate_str_str_dict(data.get("env"), "env", errors)
+
+    if errors or command is None:
+        return None, errors
+    return McpStdioServerConfig(
+        command=command,
+        args=args,
+        env=env,
+        type=server_type,  # preserves "stdio" if explicitly set, else None
+    ), errors
+
+
+def parse_server_config(data: dict[str, Any]) -> McpServerConfig | None:
+    """Back-compat wrapper. Returns the parsed config or ``None`` on any failure.
+
+    Prefer :func:`validate_server_config` when you want the error messages.
+    """
+    config, _errors = validate_server_config(data)
+    return config

--- a/tests/test_mcp_config_validation.py
+++ b/tests/test_mcp_config_validation.py
@@ -1,0 +1,395 @@
+"""Round-2 tests for strict MCP server config validation.
+
+Covers ``validate_server_config`` (rich errors) and the wiring through
+``parse_mcp_config()`` (per-field ``ValidationError`` rows with suggestions).
+
+Maps to ``my-docs/ch15-mcp-round2-plan.md`` work-items WI-1 / WI-2 / WI-3 / WI-4.
+TS canonical: ``typescript/src/services/mcp/types.ts:28-122`` Zod schemas.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.mcp.config import parse_mcp_config
+from src.services.mcp.types import (
+    McpHTTPServerConfig,
+    McpSSEServerConfig,
+    McpStdioServerConfig,
+    parse_server_config,
+    validate_server_config,
+)
+
+
+class TestValidateServerConfig:
+    """Each case mirrors a row of the §2 table in the round-2 gap analysis."""
+
+    # --- Negative cases (the round-2 fixes) ---
+
+    def test_sse_missing_url_returns_error_no_keyerror(self) -> None:
+        config, errors = validate_server_config({"type": "sse"})
+        assert config is None
+        assert any("url" in e and "required" in e for e in errors), errors
+
+    def test_http_missing_url_returns_error_no_keyerror(self) -> None:
+        config, errors = validate_server_config({"type": "http"})
+        assert config is None
+        assert any("url" in e and "required" in e for e in errors), errors
+
+    def test_ws_missing_url_returns_error_no_keyerror(self) -> None:
+        config, errors = validate_server_config({"type": "ws"})
+        assert config is None
+        assert any("url" in e and "required" in e for e in errors), errors
+
+    def test_sdk_missing_name_returns_error_no_keyerror(self) -> None:
+        config, errors = validate_server_config({"type": "sdk"})
+        assert config is None
+        assert any("name" in e and "required" in e for e in errors), errors
+
+    def test_sse_non_string_url_returns_error(self) -> None:
+        config, errors = validate_server_config({"type": "sse", "url": 12345})
+        assert config is None
+        assert any("url must be a string" in e for e in errors), errors
+
+    def test_stdio_non_list_args_returns_error(self) -> None:
+        config, errors = validate_server_config(
+            {"type": "stdio", "command": "py", "args": "not-a-list"}
+        )
+        assert config is None
+        assert any("args must be a list of strings" in e for e in errors), errors
+
+    def test_stdio_non_string_arg_element_returns_error(self) -> None:
+        config, errors = validate_server_config(
+            {"type": "stdio", "command": "py", "args": ["ok", 123]}
+        )
+        assert config is None
+        assert any("args[1]" in e for e in errors), errors
+
+    def test_stdio_non_string_env_value_returns_error(self) -> None:
+        config, errors = validate_server_config(
+            {"type": "stdio", "command": "py", "env": {"X": 123}}
+        )
+        assert config is None
+        assert any("env value for 'X' must be a string" in e for e in errors), errors
+
+    def test_stdio_non_dict_env_returns_error(self) -> None:
+        config, errors = validate_server_config(
+            {"type": "stdio", "command": "py", "env": "not-a-dict"}
+        )
+        assert config is None
+        assert any("env must be an object" in e for e in errors), errors
+
+    def test_http_non_https_auth_server_metadata_url_returns_error(self) -> None:
+        config, errors = validate_server_config(
+            {
+                "type": "http",
+                "url": "https://x",
+                "authServerMetadataUrl": "http://bad",
+            }
+        )
+        assert config is None
+        assert any("authServerMetadataUrl must use https://" in e for e in errors), errors
+
+    def test_http_non_string_auth_server_metadata_url_returns_error(self) -> None:
+        config, errors = validate_server_config(
+            {"type": "http", "url": "https://x", "authServerMetadataUrl": 123}
+        )
+        assert config is None
+        assert any(
+            "authServerMetadataUrl must be a string" in e for e in errors
+        ), errors
+
+    def test_stdio_empty_command_returns_error(self) -> None:
+        config, errors = validate_server_config({"type": "stdio", "command": ""})
+        assert config is None
+        assert any("command cannot be empty" in e for e in errors), errors
+
+    def test_stdio_missing_command_returns_error(self) -> None:
+        config, errors = validate_server_config({"type": "stdio"})
+        assert config is None
+        assert any("command is required" in e for e in errors), errors
+
+    def test_stdio_non_string_command_returns_error(self) -> None:
+        config, errors = validate_server_config({"type": "stdio", "command": 123})
+        assert config is None
+        assert any("command must be a string" in e for e in errors), errors
+
+    def test_unknown_transport_type_returns_friendly_error(self) -> None:
+        config, errors = validate_server_config({"type": "unknown_type"})
+        assert config is None
+        assert any(
+            "unknown transport type" in e
+            and "stdio" in e
+            and "sse" in e
+            and "http" in e
+            for e in errors
+        ), errors
+
+    def test_non_dict_input_returns_error_not_crash(self) -> None:
+        config, errors = validate_server_config("not-a-dict")
+        assert config is None
+        assert errors == ["server config must be an object"]
+
+    def test_non_string_type_field_returns_error(self) -> None:
+        config, errors = validate_server_config({"type": 12345, "command": "py"})
+        assert config is None
+        assert any("type must be a string" in e for e in errors), errors
+
+    def test_sse_non_string_headers_value_returns_error(self) -> None:
+        config, errors = validate_server_config(
+            {"type": "sse", "url": "https://x", "headers": {"X": 1}}
+        )
+        assert config is None
+        assert any("headers value for 'X'" in e for e in errors), errors
+
+    def test_sse_non_string_headers_helper_returns_error(self) -> None:
+        config, errors = validate_server_config(
+            {"type": "sse", "url": "https://x", "headersHelper": ["not", "a", "str"]}
+        )
+        assert config is None
+        assert any("headersHelper must be a string" in e for e in errors), errors
+
+    # --- Positive cases (regression guard) ---
+
+    def test_valid_stdio_with_type(self) -> None:
+        config, errors = validate_server_config(
+            {"type": "stdio", "command": "python", "args": ["-m", "server"]}
+        )
+        assert errors == []
+        assert isinstance(config, McpStdioServerConfig)
+        assert config.command == "python"
+        assert config.args == ["-m", "server"]
+
+    def test_valid_stdio_implicit_type(self) -> None:
+        config, errors = validate_server_config({"command": "python"})
+        assert errors == []
+        assert isinstance(config, McpStdioServerConfig)
+
+    def test_valid_sse(self) -> None:
+        config, errors = validate_server_config(
+            {"type": "sse", "url": "https://example.com/sse"}
+        )
+        assert errors == []
+        assert isinstance(config, McpSSEServerConfig)
+
+    def test_valid_http_with_https_metadata_url(self) -> None:
+        config, errors = validate_server_config(
+            {
+                "type": "http",
+                "url": "https://example.com/mcp",
+                "authServerMetadataUrl": "https://auth.example.com/.well-known/x",
+            }
+        )
+        assert errors == []
+        assert isinstance(config, McpHTTPServerConfig)
+        assert config.auth_server_metadata_url == (
+            "https://auth.example.com/.well-known/x"
+        )
+
+    def test_valid_stdio_with_env(self) -> None:
+        config, errors = validate_server_config(
+            {"type": "stdio", "command": "py", "env": {"FOO": "bar"}}
+        )
+        assert errors == []
+        assert isinstance(config, McpStdioServerConfig)
+        assert config.env == {"FOO": "bar"}
+
+    def test_multiple_errors_accumulate(self) -> None:
+        # Both bad type and bad asm_url should be reported separately
+        # (or, if type is invalid, that short-circuits — both behaviors are
+        # acceptable; the contract is "at least one descriptive error").
+        config, errors = validate_server_config({"type": "unknown"})
+        assert config is None
+        assert len(errors) >= 1
+
+    def test_multiple_errors_in_one_stdio_config(self) -> None:
+        # Empty command + bad args + bad env: should report all three.
+        config, errors = validate_server_config(
+            {
+                "type": "stdio",
+                "command": "",
+                "args": "not-a-list",
+                "env": {"X": 123},
+            }
+        )
+        assert config is None
+        # We expect at least the command + args + env errors (3 distinct).
+        joined = " | ".join(errors)
+        assert "command cannot be empty" in joined, errors
+        assert "args must be a list of strings" in joined, errors
+        assert "env value for 'X' must be a string" in joined, errors
+
+
+class TestParseServerConfigBackCompat:
+    """The legacy ``parse_server_config`` returns ``Optional[McpServerConfig]``
+    and must not raise on any input — including the previously-crashing cases.
+    """
+
+    def test_sse_missing_url_returns_none_not_keyerror(self) -> None:
+        # Before round 2 this raised ``KeyError: 'url'``.
+        assert parse_server_config({"type": "sse"}) is None
+
+    def test_sdk_missing_name_returns_none_not_keyerror(self) -> None:
+        # Before round 2 this raised ``KeyError: 'name'``.
+        assert parse_server_config({"type": "sdk"}) is None
+
+    def test_existing_happy_paths_still_work(self) -> None:
+        assert (
+            parse_server_config({"type": "stdio", "command": "py"}) is not None
+        )
+        assert (
+            parse_server_config({"type": "sse", "url": "https://x"}) is not None
+        )
+        assert (
+            parse_server_config({"type": "http", "url": "https://x"}) is not None
+        )
+        assert (
+            parse_server_config({"type": "sdk", "name": "my-sdk-server"}) is not None
+        )
+        # implicit-stdio
+        assert parse_server_config({"command": "py"}) is not None
+
+    def test_existing_negative_paths_still_return_none(self) -> None:
+        assert parse_server_config({"type": "unknown_type"}) is None
+        assert parse_server_config({"type": "stdio"}) is None  # no command
+
+
+class TestParseMcpConfigSurfacesValidationMessages:
+    """``parse_mcp_config()`` should attach one ``ValidationError`` per
+    validator message (instead of the old single "Invalid server configuration"
+    catch-all), with paths scoped to the offending server name and
+    suggestions where the message has an obvious fix.
+    """
+
+    def test_per_server_path_attached(self) -> None:
+        result = parse_mcp_config(
+            {"mcpServers": {"broken": {"type": "sse"}}},
+            expand_vars=False,
+        )
+        assert result.config == {}
+        paths = [e.path for e in result.errors]
+        assert "mcpServers.broken" in paths
+
+    def test_url_required_message_propagates(self) -> None:
+        result = parse_mcp_config(
+            {"mcpServers": {"broken": {"type": "sse"}}},
+            expand_vars=False,
+        )
+        msgs = [e.message for e in result.errors]
+        assert any("url" in m and "required" in m for m in msgs), msgs
+
+    def test_https_only_auth_server_metadata_url_message_propagates(self) -> None:
+        result = parse_mcp_config(
+            {
+                "mcpServers": {
+                    "bad-asm": {
+                        "type": "http",
+                        "url": "https://x",
+                        "authServerMetadataUrl": "http://bad",
+                    }
+                }
+            },
+            expand_vars=False,
+        )
+        assert result.config == {}
+        msgs = [e.message for e in result.errors]
+        assert any("authServerMetadataUrl must use https://" in m for m in msgs), msgs
+
+    def test_https_only_message_has_helpful_suggestion(self) -> None:
+        result = parse_mcp_config(
+            {
+                "mcpServers": {
+                    "bad-asm": {
+                        "type": "http",
+                        "url": "https://x",
+                        "authServerMetadataUrl": "http://bad",
+                    }
+                }
+            },
+            expand_vars=False,
+        )
+        suggestions = [e.suggestion for e in result.errors if e.suggestion]
+        assert any("https://" in s for s in suggestions), suggestions
+
+    def test_missing_field_has_add_field_suggestion(self) -> None:
+        result = parse_mcp_config(
+            {"mcpServers": {"broken": {"type": "sse"}}},
+            expand_vars=False,
+        )
+        suggestions = [e.suggestion for e in result.errors if e.suggestion]
+        assert any("Add a `url`" in s for s in suggestions), suggestions
+
+    def test_unknown_transport_type_has_enumerated_suggestion(self) -> None:
+        result = parse_mcp_config(
+            {"mcpServers": {"weird": {"type": "totally-bogus"}}},
+            expand_vars=False,
+        )
+        suggestions = [e.suggestion for e in result.errors if e.suggestion]
+        assert any("stdio" in s and "sse" in s for s in suggestions), suggestions
+
+    def test_multiple_errors_per_server_each_emit_validation_row(self) -> None:
+        result = parse_mcp_config(
+            {
+                "mcpServers": {
+                    "multibroken": {
+                        "type": "stdio",
+                        "command": "",
+                        "args": "not-a-list",
+                        "env": {"X": 123},
+                    }
+                }
+            },
+            expand_vars=False,
+        )
+        assert result.config == {}
+        # 3 messages from the validator -> 3 ValidationError rows for this
+        # server (plus possibly the suggestion-derived stuff). At minimum we
+        # want one per field-error.
+        server_errors = [
+            e for e in result.errors if e.server_name == "multibroken"
+        ]
+        assert len(server_errors) >= 3, server_errors
+        joined = " | ".join(e.message for e in server_errors)
+        assert "command cannot be empty" in joined
+        assert "args must be a list of strings" in joined
+        assert "env value for 'X' must be a string" in joined
+
+    def test_valid_and_invalid_servers_coexist(self) -> None:
+        result = parse_mcp_config(
+            {
+                "mcpServers": {
+                    "good": {"type": "stdio", "command": "py"},
+                    "bad": {"type": "sse"},  # missing url
+                }
+            },
+            expand_vars=False,
+        )
+        # Good server still parses; bad server surfaces validation errors.
+        assert result.config is not None
+        assert "good" in result.config
+        assert "bad" not in result.config
+        bad_errors = [e for e in result.errors if e.server_name == "bad"]
+        assert any("url" in e.message for e in bad_errors)
+        good_errors = [e for e in result.errors if e.server_name == "good"]
+        assert good_errors == []
+
+    def test_all_errors_have_fatal_severity_by_default(self) -> None:
+        result = parse_mcp_config(
+            {"mcpServers": {"broken": {"type": "sse"}}},
+            expand_vars=False,
+        )
+        # Fatal severity is the dataclass default; we just verify the rich
+        # validator messages don't accidentally downgrade.
+        for e in result.errors:
+            if e.server_name == "broken":
+                assert e.severity == "fatal"
+
+    def test_server_with_non_dict_config_still_errors_clearly(self) -> None:
+        # Pre-existing behavior: top-level "must be an object" error.
+        # The round-2 validator should preserve this for parity.
+        result = parse_mcp_config(
+            {"mcpServers": {"broken": "not-a-dict"}},
+            expand_vars=False,
+        )
+        bad_errors = [e for e in result.errors if e.server_name == "broken"]
+        assert bad_errors, "should emit at least one error for non-dict server config"


### PR DESCRIPTION
## Summary

Round-2 focused gap closure for **Chapter 15 (MCP)**. Mirrors the Zod schemas in `typescript/src/services/mcp/types.ts` so user-supplied MCP server configs are validated at parse time with descriptive messages — replacing two failure modes that diverge from the TS canonical:

1. **`KeyError` crashes** on common malformed inputs (e.g. `{"type": "sse"}` with no `url`, `{"type": "sdk"}` with no `name`) — TS Zod surfaces a clean "Required" message; Python today bubbles up a Python traceback.
2. **Silent accepts** of wrong-type fields (non-string `url`, non-list `args`, non-string `env` values, `http://` `authServerMetadataUrl`) — TS Zod rejects with a typed-error path; Python today forwards bad values into transport code where they fail with low-context errors deep in `httpx` / `urlparse`.

### What changed

- New `validate_server_config(data) -> tuple[McpServerConfig | None, list[str]]` in `services/mcp/types.py` returning one message per per-field violation.
- Validates: `command` is a non-empty string; `args` is `list[str]`; `env` / `headers` are `dict[str, str]`; `url` / `name` / `headersHelper` are strings; `authServerMetadataUrl` is an `https://` string; transport `type` is one of the enumerated set (derived from `TransportType` via `get_args` — no duplicated tuple).
- `parse_server_config()` stays as a back-compat `Optional` wrapper.
- `parse_mcp_config()` now emits **one `ValidationError` per validator message** with a friendly `suggestion` (e.g. "Add a \`url\` field to the server config", "Use an https:// URL for OAuth metadata discovery") instead of the catch-all "Invalid server configuration".
- 40 new tests in `tests/test_mcp_config_validation.py` covering every divergence row from the round-2 gap analysis plus the back-compat guarantee.

LOC: 212 source / 395 test (source within the 150-300 round-2 budget).

Round-2 docs at `my-docs/ch15-mcp-round2-gap-analysis.md` (95 lines) + `my-docs/ch15-mcp-round2-plan.md` (140 lines).

## Test plan

- [x] `pytest tests/test_mcp_config_validation.py -q` — 40/40 pass
- [x] `pytest tests/test_mcp_types.py tests/test_mcp_config.py tests/test_mcp_config_full.py -q` — full back-compat preserved (existing 152 tests still green; same pre-existing PATH-related failure unrelated to this change)
- [x] `pytest tests/test_porting_workspace.py tests/test_no_top_level_decoys.py -q` — 61/61 pass
- [x] Critic / simplify review applied: removed duplicated transport-type tuple, factored copy-paste branch over `sse`/`http`/`ws`, removed redundant `None` guard.

Pre-existing failures (PATH-dependent `python` lookups in `test_mcp_config_full.py::test_valid_command` and `test_mcp_doctor.py::test_valid_command`) are out of scope per the round-2 task brief.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)