### PR TITLE
feat(ch12/round2): per-hook shell selection for command hooks

### DIFF
--- a/src/hooks/__init__.py
+++ b/src/hooks/__init__.py
@@ -20,6 +20,7 @@ from .hook_types import (
     PostSamplingHookInput,
     PostToolUseHookInput,
     PreToolUseHookInput,
+    ShellType,
     StopHookInput,
     UserPromptSubmitHookInput,
 )
@@ -30,6 +31,12 @@ from .registry import (
     get_global_hook_registry,
     reset_global_hook_registry,
 )
+from .shell_invocation import (
+    DEFAULT_HOOK_SHELL,
+    SHELL_TYPES,
+    build_powershell_args,
+    find_powershell_path,
+)
 
 __all__ = [
     "ALL_HOOK_EVENTS",
@@ -37,6 +44,7 @@ __all__ = [
     "HTTP_HOOK_TIMEOUT_MS",
     "TOOL_HOOK_EXECUTION_TIMEOUT_MS",
     "AsyncHookRegistry",
+    "DEFAULT_HOOK_SHELL",
     "HookConfig",
     "HookEvent",
     "HookProgress",
@@ -48,8 +56,12 @@ __all__ = [
     "PostToolUseHookInput",
     "PreToolUseHookInput",
     "RegisteredHook",
+    "SHELL_TYPES",
+    "ShellType",
     "StopHookInput",
     "UserPromptSubmitHookInput",
+    "build_powershell_args",
+    "find_powershell_path",
     "get_global_hook_registry",
     "reset_global_hook_registry",
     "HookConfigManager",

--- a/src/hooks/config_manager.py
+++ b/src/hooks/config_manager.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from .hook_types import HookConfig, HookEvent, HookSource, ALL_HOOK_EVENTS
 from .registry import AsyncHookRegistry
+from .shell_invocation import SHELL_TYPES, ShellType
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +45,17 @@ def _get_settings_path() -> Path:
 
 def _parse_hook_config(raw: dict[str, Any], source: HookSource | None = None) -> HookConfig:
     hook_type = raw.get("type", "command")
+
+    # Round-2 / Ch12 — per-hook shell selection. Only meaningful for
+    # ``type == "command"`` (matches TS schema where ``shell`` only appears on
+    # BashCommandHookSchema). Unknown values are dropped here and recorded as
+    # validator errors by ``validate_hook_configs``; the parser stays
+    # permissive so a single bad entry doesn't black-hole the whole snapshot.
+    shell_raw = raw.get("shell")
+    shell: ShellType | None = (
+        shell_raw if isinstance(shell_raw, str) and shell_raw in SHELL_TYPES else None  # type: ignore[assignment]
+    )
+
     return HookConfig(
         type=hook_type,
         command=raw.get("command", ""),
@@ -59,6 +71,7 @@ def _parse_hook_config(raw: dict[str, Any], source: HookSource | None = None) ->
         # skill-hook registration time (Phase 3).
         if_condition=raw.get("if_condition") or raw.get("if"),
         once=bool(raw.get("once", False)),
+        shell=shell,
         source=source if source is not None else HookSource.USER_SETTINGS,
     )
 
@@ -129,6 +142,24 @@ def validate_hook_configs(
                         index=i,
                         field="command",
                         message="Command hook must have a 'command' field",
+                    ))
+                # Round-2 / Ch12 — validate ``shell`` for command hooks only.
+                # TS ``BashCommandHookSchema.shell`` enforces ``z.enum(SHELL_TYPES)``;
+                # we surface unknown values here so settings authors see them.
+                # Mirrors TS where ``parseSettingsFile`` would reject the entry
+                # whole; we keep the parser permissive (drop the bad value)
+                # but flag the error so the failure is visible in the
+                # ``/hooks`` UI / logs.
+                shell_raw = hook_raw.get("shell")
+                if shell_raw is not None and shell_raw not in SHELL_TYPES:
+                    errors.append(HookValidationError(
+                        event=event_name,
+                        index=i,
+                        field="shell",
+                        message=(
+                            f"Unknown shell type: {shell_raw!r}. "
+                            f"Must be one of {SHELL_TYPES}."
+                        ),
                     ))
             elif hook_type == "http":
                 if not hook_raw.get("url"):

--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -216,13 +216,52 @@ async def _execute_command_hook(
     try:
         stdin_json = json.dumps(stdin_data, default=str)
 
-        process = await asyncio.create_subprocess_shell(
-            command,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=_build_hook_env(hook, stdin_data, tool_use_context),
-        )
+        # Round-2 / Ch12 — per-hook shell selection. ``shell="powershell"``
+        # spawns ``pwsh`` with explicit argv and skips the bash-shell path.
+        # ``None`` / ``"bash"`` keeps the historical ``create_subprocess_shell``
+        # invocation. Mirrors the TS branch at
+        # ``typescript/src/utils/hooks.ts:1098-1125``.
+        if hook.shell == "powershell":
+            from .shell_invocation import build_powershell_args, find_powershell_path
+
+            pwsh_path = find_powershell_path()
+            if pwsh_path is None:
+                duration_ms = int((time.monotonic() - start_time) * 1000)
+                # Error string mirrors TS at typescript/src/utils/hooks.ts:1102-1106
+                # verbatim (single quotes around 'powershell' as in the TS source)
+                # so log scrapers / regression tests written against TS messages
+                # transfer unchanged.
+                return HookResult(
+                    blocking_error=(
+                        f"Hook \"{command}\" has shell: 'powershell' but no "
+                        "PowerShell executable (pwsh or powershell) was found "
+                        "on PATH. Install PowerShell, or remove "
+                        "\"shell\": \"powershell\" to use bash."
+                    ),
+                    exit_code=-1,
+                    duration_ms=duration_ms,
+                    command=command,
+                )
+            process = await asyncio.create_subprocess_exec(
+                pwsh_path,
+                *build_powershell_args(command),
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=_build_hook_env(hook, stdin_data, tool_use_context),
+            )
+        else:
+            # Default (bash on POSIX via /bin/sh, the historical path).
+            # An explicit ``shell="bash"`` lands here too — it's a no-op
+            # alias for ``None`` per the chapter's "defaults to bash"
+            # contract.
+            process = await asyncio.create_subprocess_shell(
+                command,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=_build_hook_env(hook, stdin_data, tool_use_context),
+            )
 
         try:
             stdout_bytes, stderr_bytes = await asyncio.wait_for(

--- a/src/hooks/hook_types.py
+++ b/src/hooks/hook_types.py
@@ -115,6 +115,12 @@ ALL_HOOK_EVENTS: list[HookEvent] = [
 HookType = Literal["command", "agent", "http", "prompt"]
 
 
+# Re-exported here so callers can ``from src.hooks.hook_types import ShellType``
+# without pulling in ``shell_invocation`` (which would import ``shutil``).
+# The canonical definition lives in ``src/hooks/shell_invocation.py``.
+ShellType = Literal["bash", "powershell"]
+
+
 # ---------------------------------------------------------------------------
 # Hook source — Chapter-12 / Phase-1 / WI-1.2
 # ---------------------------------------------------------------------------
@@ -250,6 +256,16 @@ class HookConfig:
     # registration → execution; not parsed from settings.json (only set at
     # skill-hook registration time in Phase 3).
     skill_root: str | None = None
+
+    # Round-2 / Ch12 — per-hook shell selection. ``None`` means "use the
+    # platform default" (bash on POSIX via /bin/sh); ``"bash"`` is an
+    # explicit alias for that same path; ``"powershell"`` spawns ``pwsh``
+    # with the canonical ``-NoProfile -NonInteractive -Command <cmd>`` argv.
+    # Mirrors TS ``BashCommandHookSchema.shell`` at
+    # ``typescript/src/schemas/hooks.ts:36-41``. Only meaningful for
+    # ``type == "command"`` — non-command hooks ignore this field (matches
+    # TS where ``shell`` only appears on the command schema).
+    shell: ShellType | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/hooks/shell_invocation.py
+++ b/src/hooks/shell_invocation.py
@@ -1,0 +1,82 @@
+"""Per-hook shell selection — Chapter 12 round 2.
+
+Command hooks can opt into PowerShell execution via the ``shell`` field on
+each ``HookConfig``. Mirrors:
+
+* ``typescript/src/utils/shell/shellProvider.ts:1-3`` — the ``SHELL_TYPES``
+  enum and the ``DEFAULT_HOOK_SHELL`` constant.
+* ``typescript/src/utils/shell/powershellProvider.ts:11-13`` —
+  ``buildPowerShellArgs``: the canonical ``-NoProfile -NonInteractive
+  -Command <cmd>`` flag set.
+
+This module owns nothing about path conversion (Windows / Git Bash), profile
+sourcing, or env propagation — those stay in ``hook_executor`` where the
+subprocess actually spawns. The split keeps this file small enough to mock
+cheaply in tests.
+"""
+
+from __future__ import annotations
+
+import shutil
+from typing import Literal
+
+# Tuple, not frozenset — preserves iteration order so error messages list
+# valid choices in TS-shipping order ("bash" first).
+SHELL_TYPES: tuple[str, ...] = ("bash", "powershell")
+
+ShellType = Literal["bash", "powershell"]
+
+# The bash path is the historical default and the only one exercised on
+# POSIX before this round. Matches ``DEFAULT_HOOK_SHELL`` in
+# ``shellProvider.ts:3``. HookConfig.shell == None is treated as this
+# default by the executor.
+DEFAULT_HOOK_SHELL: ShellType = "bash"
+
+
+def build_powershell_args(cmd: str) -> list[str]:
+    """Return the argv list for spawning ``pwsh`` with ``cmd``.
+
+    Mirrors ``buildPowerShellArgs`` in
+    ``typescript/src/utils/shell/powershellProvider.ts:11-13``:
+
+    * ``-NoProfile``     — skip user profile scripts (faster, deterministic).
+    * ``-NonInteractive`` — fail fast instead of prompting for input.
+    * ``-Command``       — execute the literal string that follows.
+
+    The caller invokes ``asyncio.create_subprocess_exec(pwsh_path,
+    *build_powershell_args(cmd), ...)`` — explicit argv with no intervening
+    shell. This matches the TS ``spawn(pwshPath, buildPowerShellArgs(cmd),
+    ...)`` call at ``typescript/src/utils/hooks.ts:1108``.
+    """
+    return ["-NoProfile", "-NonInteractive", "-Command", cmd]
+
+
+def find_powershell_path() -> str | None:
+    """Locate PowerShell on PATH.
+
+    Preference order matches TS ``getCachedPowerShellPath`` semantics:
+
+    1. ``pwsh`` — cross-platform PowerShell 6+. Present on macOS / Linux when
+       installed via Homebrew / package manager; on Windows when installed
+       from the Microsoft Store or MSI.
+    2. ``powershell`` — Windows-only Windows-PowerShell 5.1. Always present
+       on Windows; absent everywhere else.
+
+    Returns ``None`` if neither executable is on PATH. The caller surfaces a
+    deterministic blocking error to the hook author.
+
+    No caching here — ``shutil.which`` is cheap (one filesystem walk per
+    PATH entry) and tests rely on monkeypatching it. The TS version caches
+    because spawn-per-hook adds up across a long session; we can add
+    ``@functools.lru_cache`` later if profiling shows it matters.
+    """
+    return shutil.which("pwsh") or shutil.which("powershell")
+
+
+__all__ = [
+    "SHELL_TYPES",
+    "ShellType",
+    "DEFAULT_HOOK_SHELL",
+    "build_powershell_args",
+    "find_powershell_path",
+]

--- a/tests/test_hook_shell_selection.py
+++ b/tests/test_hook_shell_selection.py
@@ -1,0 +1,354 @@
+"""Tests for per-hook shell selection — Chapter 12 round 2.
+
+Covers ``HookConfig.shell``, settings.json parsing, validator behaviour, and
+the executor branch that swaps between ``create_subprocess_shell`` (bash) and
+``create_subprocess_exec(pwsh, ...)`` (powershell). Mirrors TS coverage of
+``shell`` in ``schemas/hooks.ts`` and ``utils/hooks.ts``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.hooks.config_manager import (
+    _parse_hook_config,
+    load_hooks_from_settings,
+    validate_hook_configs,
+)
+from src.hooks.hook_executor import _execute_command_hook
+from src.hooks.hook_types import HookConfig, HookSource
+from src.hooks.shell_invocation import (
+    DEFAULT_HOOK_SHELL,
+    SHELL_TYPES,
+    build_powershell_args,
+    find_powershell_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestShellInvocationConstants:
+    def test_shell_types_lists_bash_first(self) -> None:
+        # Bash first matches TS shipping order (typescript/src/utils/shell/shellProvider.ts:1).
+        assert SHELL_TYPES == ("bash", "powershell")
+
+    def test_default_is_bash(self) -> None:
+        assert DEFAULT_HOOK_SHELL == "bash"
+
+
+# ---------------------------------------------------------------------------
+# build_powershell_args
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPowerShellArgs:
+    def test_exact_argv_matches_ts(self) -> None:
+        # Matches typescript/src/utils/shell/powershellProvider.ts:11-13 exactly.
+        args = build_powershell_args("Write-Host hi")
+        assert args == ["-NoProfile", "-NonInteractive", "-Command", "Write-Host hi"]
+
+    def test_preserves_command_string_verbatim(self) -> None:
+        # No quoting / escaping — pwsh's -Command consumes the literal string.
+        cmd = "Get-Content 'a b'; echo \"$x\""
+        args = build_powershell_args(cmd)
+        assert args[-1] == cmd
+        assert args[:3] == ["-NoProfile", "-NonInteractive", "-Command"]
+
+    def test_empty_command_is_still_legal_argv(self) -> None:
+        # No validation here — the executor's path-missing check fires first.
+        assert build_powershell_args("") == ["-NoProfile", "-NonInteractive", "-Command", ""]
+
+
+# ---------------------------------------------------------------------------
+# find_powershell_path
+# ---------------------------------------------------------------------------
+
+
+class TestFindPowerShellPath:
+    def test_prefers_pwsh(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[str] = []
+
+        def fake_which(name: str) -> str | None:
+            calls.append(name)
+            return "/usr/local/bin/pwsh" if name == "pwsh" else None
+
+        monkeypatch.setattr("src.hooks.shell_invocation.shutil.which", fake_which)
+        assert find_powershell_path() == "/usr/local/bin/pwsh"
+        # Doesn't bother checking "powershell" if "pwsh" hits.
+        assert calls == ["pwsh"]
+
+    def test_falls_back_to_powershell(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_which(name: str) -> str | None:
+            return r"C:\Windows\System32\powershell.exe" if name == "powershell" else None
+
+        monkeypatch.setattr("src.hooks.shell_invocation.shutil.which", fake_which)
+        assert find_powershell_path() == r"C:\Windows\System32\powershell.exe"
+
+    def test_returns_none_when_neither_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("src.hooks.shell_invocation.shutil.which", lambda _name: None)
+        assert find_powershell_path() is None
+
+
+# ---------------------------------------------------------------------------
+# HookConfig.shell default
+# ---------------------------------------------------------------------------
+
+
+class TestHookConfigShellField:
+    def test_default_is_none(self) -> None:
+        # None == "use the platform default" (bash on POSIX).
+        hook = HookConfig(type="command", command="echo hi")
+        assert hook.shell is None
+
+    def test_explicit_bash(self) -> None:
+        hook = HookConfig(type="command", command="echo hi", shell="bash")
+        assert hook.shell == "bash"
+
+    def test_explicit_powershell(self) -> None:
+        hook = HookConfig(type="command", command="Write-Host hi", shell="powershell")
+        assert hook.shell == "powershell"
+
+
+# ---------------------------------------------------------------------------
+# Settings.json parsing — _parse_hook_config + load_hooks_from_settings
+# ---------------------------------------------------------------------------
+
+
+class TestParseHookConfigShell:
+    def test_parses_powershell(self) -> None:
+        hook = _parse_hook_config({"type": "command", "command": "x", "shell": "powershell"})
+        assert hook.shell == "powershell"
+
+    def test_parses_bash(self) -> None:
+        hook = _parse_hook_config({"type": "command", "command": "x", "shell": "bash"})
+        assert hook.shell == "bash"
+
+    def test_missing_shell_is_none(self) -> None:
+        hook = _parse_hook_config({"type": "command", "command": "x"})
+        assert hook.shell is None
+
+    def test_unknown_shell_drops_to_none(self) -> None:
+        # Parser stays permissive — validator catches it. The snapshot still
+        # loads with the hook running on the default shell rather than
+        # black-holing the whole config.
+        hook = _parse_hook_config({"type": "command", "command": "x", "shell": "fish"})
+        assert hook.shell is None
+
+    def test_non_string_shell_drops_to_none(self) -> None:
+        hook = _parse_hook_config({"type": "command", "command": "x", "shell": 42})
+        assert hook.shell is None
+
+
+class TestLoadHooksFromSettings:
+    def test_roundtrip_powershell(self) -> None:
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+            json.dump(
+                {
+                    "hooks": {
+                        "PreToolUse": [
+                            {"type": "command", "command": "Write-Host hi", "shell": "powershell"}
+                        ]
+                    }
+                },
+                fh,
+            )
+            path = fh.name
+        try:
+            snapshot = load_hooks_from_settings(path)
+            hooks = snapshot.hooks["PreToolUse"]
+            assert len(hooks) == 1
+            assert hooks[0].shell == "powershell"
+            assert hooks[0].command == "Write-Host hi"
+        finally:
+            Path(path).unlink()
+
+
+# ---------------------------------------------------------------------------
+# Validator
+# ---------------------------------------------------------------------------
+
+
+class TestValidatorShell:
+    def test_bash_accepted(self) -> None:
+        errors = validate_hook_configs(
+            {"PreToolUse": [{"type": "command", "command": "x", "shell": "bash"}]}
+        )
+        assert errors == []
+
+    def test_powershell_accepted(self) -> None:
+        errors = validate_hook_configs(
+            {"PreToolUse": [{"type": "command", "command": "x", "shell": "powershell"}]}
+        )
+        assert errors == []
+
+    def test_unknown_shell_emits_error(self) -> None:
+        errors = validate_hook_configs(
+            {"PreToolUse": [{"type": "command", "command": "x", "shell": "fish"}]}
+        )
+        assert len(errors) == 1
+        assert errors[0].field == "shell"
+        assert errors[0].severity == "error"
+        assert "fish" in errors[0].message
+        assert "bash" in errors[0].message and "powershell" in errors[0].message
+
+    def test_missing_shell_no_error(self) -> None:
+        # Absent ``shell`` is fine — falls through to the default.
+        errors = validate_hook_configs(
+            {"PreToolUse": [{"type": "command", "command": "x"}]}
+        )
+        assert errors == []
+
+    def test_shell_on_non_command_hook_is_ignored(self) -> None:
+        # TS only puts ``shell`` on BashCommandHookSchema. Python mirrors that:
+        # a stray ``shell`` on prompt / agent / http hooks isn't validated
+        # (and isn't read by the parser into HookConfig.shell anyway).
+        errors = validate_hook_configs(
+            {
+                "PreToolUse": [
+                    {"type": "prompt", "promptText": "x", "shell": "anything"},
+                    {"type": "http", "url": "https://example.com", "shell": "garbage"},
+                    {"type": "agent", "agentInstructions": "x", "shell": "garbage"},
+                ]
+            }
+        )
+        # No ``shell`` errors. (Other validators may run, but this assertion
+        # is scoped to the field we care about.)
+        assert [e for e in errors if e.field == "shell"] == []
+
+
+# ---------------------------------------------------------------------------
+# _execute_command_hook — bash branch (default / explicit / unrecognized)
+# ---------------------------------------------------------------------------
+
+
+class _StubProcess:
+    """Stand-in for ``asyncio.subprocess.Process`` with controllable stdout/stderr/code."""
+
+    def __init__(self, stdout: bytes = b"", stderr: bytes = b"", returncode: int = 0):
+        self._stdout = stdout
+        self._stderr = stderr
+        self.returncode = returncode
+
+    async def communicate(self, _stdin: bytes | None = None):
+        return self._stdout, self._stderr
+
+    def kill(self):  # pragma: no cover - timeout path is not exercised here
+        pass
+
+
+class TestExecutorBashPath:
+    @pytest.mark.asyncio
+    async def test_default_uses_subprocess_shell(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, object] = {}
+
+        async def fake_shell(cmd, *, stdin, stdout, stderr, env):
+            captured["used"] = "shell"
+            captured["cmd"] = cmd
+            return _StubProcess(stdout=b"ok\n", returncode=0)
+
+        async def fake_exec(*_args, **_kwargs):  # pragma: no cover - shouldn't be called
+            captured["used"] = "exec"
+            return _StubProcess()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_shell", fake_shell)
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+        hook = HookConfig(type="command", command="echo ok")  # shell=None
+        result = await _execute_command_hook(hook, {"hook_event": "PreToolUse"})
+
+        assert captured["used"] == "shell"
+        assert captured["cmd"] == "echo ok"
+        assert result.exit_code == 0
+
+    @pytest.mark.asyncio
+    async def test_explicit_bash_uses_subprocess_shell(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, object] = {}
+
+        async def fake_shell(cmd, *, stdin, stdout, stderr, env):
+            captured["used"] = "shell"
+            return _StubProcess(returncode=0)
+
+        async def fake_exec(*_args, **_kwargs):  # pragma: no cover
+            captured["used"] = "exec"
+            return _StubProcess()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_shell", fake_shell)
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+        hook = HookConfig(type="command", command="echo ok", shell="bash")
+        await _execute_command_hook(hook, {"hook_event": "PreToolUse"})
+        assert captured["used"] == "shell"
+
+
+# ---------------------------------------------------------------------------
+# _execute_command_hook — powershell branch
+# ---------------------------------------------------------------------------
+
+
+class TestExecutorPowerShellPath:
+    @pytest.mark.asyncio
+    async def test_spawns_pwsh_with_canonical_argv(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, object] = {}
+
+        async def fake_exec(prog, *args, stdin, stdout, stderr, env):
+            captured["prog"] = prog
+            captured["args"] = list(args)
+            return _StubProcess(stdout=b"", returncode=0)
+
+        async def fake_shell(*_args, **_kwargs):  # pragma: no cover - shouldn't be called
+            captured["fallback_called"] = True
+            return _StubProcess()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setattr(asyncio, "create_subprocess_shell", fake_shell)
+        monkeypatch.setattr(
+            "src.hooks.shell_invocation.shutil.which",
+            lambda name: "/usr/local/bin/pwsh" if name == "pwsh" else None,
+        )
+
+        hook = HookConfig(type="command", command="Write-Host hi", shell="powershell")
+        result = await _execute_command_hook(hook, {"hook_event": "PreToolUse"})
+
+        assert captured["prog"] == "/usr/local/bin/pwsh"
+        assert captured["args"] == [
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "Write-Host hi",
+        ]
+        assert "fallback_called" not in captured
+        assert result.exit_code == 0
+
+    @pytest.mark.asyncio
+    async def test_blocking_error_when_pwsh_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def fake_exec(*_args, **_kwargs):  # pragma: no cover - shouldn't be called
+            return _StubProcess()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setattr("src.hooks.shell_invocation.shutil.which", lambda _name: None)
+
+        hook = HookConfig(type="command", command="Write-Host hi", shell="powershell")
+        result = await _execute_command_hook(hook, {"hook_event": "PreToolUse"})
+
+        assert result.blocking_error is not None
+        assert "no PowerShell executable" in result.blocking_error
+        assert "powershell" in result.blocking_error
+        assert result.exit_code == -1
+        assert result.command == "Write-Host hi"
+
+    @pytest.mark.asyncio
+    async def test_blocking_error_preserves_command_in_message(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("src.hooks.shell_invocation.shutil.which", lambda _name: None)
+        hook = HookConfig(type="command", command="DoSomethingPS", shell="powershell")
+        result = await _execute_command_hook(hook, {"hook_event": "PreToolUse"})
+        assert "DoSomethingPS" in (result.blocking_error or "")


### PR DESCRIPTION
## Summary

- Port TS per-hook `shell` field (`bash` | `powershell`) for command hooks. Mirrors `BashCommandHookSchema.shell` (`typescript/src/schemas/hooks.ts:36-41`) and the executor branch at `typescript/src/utils/hooks.ts:1098-1125`.
- `shell="powershell"` spawns `pwsh -NoProfile -NonInteractive -Command <cmd>` via `asyncio.create_subprocess_exec`; missing pwsh returns a deterministic blocking error (exact-match TS string at `utils/hooks.ts:1102-1106`).
- Default (`shell=None` or `"bash"`) keeps the existing `create_subprocess_shell` path — regression-free.

## Files

- NEW `src/hooks/shell_invocation.py` — `SHELL_TYPES`, `DEFAULT_HOOK_SHELL`, `build_powershell_args`, `find_powershell_path`.
- `src/hooks/hook_types.py` — added `shell` field on `HookConfig` + `ShellType` literal export.
- `src/hooks/config_manager.py` — permissive parse + validator error for unknown shell.
- `src/hooks/hook_executor.py` — branch in `_execute_command_hook`.
- `src/hooks/__init__.py` — re-exports.
- NEW `tests/test_hook_shell_selection.py` — 27 tests covering constants, argv parity, path discovery (mocked), parser, validator, both executor branches.

## Docs

- `my-docs/ch12-extensibility-round2-gap-analysis.md`
- `my-docs/ch12-extensibility-round2-plan.md`

## Test plan

- [x] `tests/test_hook_shell_selection.py` (27 tests)
- [x] `tests/test_porting_workspace.py` + `tests/test_no_top_level_decoys.py` (no regression)
- [x] Full hook sweep `tests/test_hook_*.py tests/integration/test_phase_c_hooks.py` (167/167 pass)
- [x] Smoke test against real `/bin/sh` (echo command) and pwsh-missing path (blocking_error string matches TS)

LOC: ~440 (~110 src, ~330 tests; within the ~150-300 task budget when counting only source code).

Constraints honored:
- ONE focused gap.
- No touching of `query/`, `memdir/`, `tool_system/`, `tasks/`, `tui/`, `coordinator/`, `remote/`, `services/tool_execution/`.
- Pre-existing unmerged round-1 phases (2-9) explicitly out of scope.

Round-2 of Chapter 12 (Extensibility) of the Claude Code → Python port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)