### PR TITLE
ch14/round2: route bracketed paste through PromptInput atomically

### DIFF
--- a/src/tui/messages.py
+++ b/src/tui/messages.py
@@ -30,6 +30,8 @@ from typing import Any
 
 from textual.message import Message
 
+from .paste import PasteInfo
+
 
 @dataclass
 class AgentRunStarted(Message):
@@ -147,3 +149,24 @@ class CancelRequested(Message):
     """
 
     pass
+
+
+@dataclass
+class PromptPasted(Message):
+    """Bracketed-paste landed in the :class:`PromptInput` widget.
+
+    Mirrors :class:`PromptSubmitted` but fires *after* the paste has
+    already been inserted into the input buffer. The host listens to
+    decide whether to surface a "Pasted N chars" footer hint or, when
+    :attr:`PasteInfo.is_image_drag` is true, offer to attach the file
+    instead of submitting the path text.
+
+    See chapter 14 of ``claude-code-from-source/book`` — the chapter
+    calls out the ``isPasted`` discriminator as "critical for security",
+    because content inside a bracketed-paste envelope must not be
+    interpreted as commands. This message is the round-2 carrier for
+    that flag on the Python side; downstream rounds will fan out to the
+    footer/status surfaces.
+    """
+
+    info: PasteInfo

--- a/src/tui/paste.py
+++ b/src/tui/paste.py
@@ -1,0 +1,177 @@
+"""Bracketed-paste classification helpers.
+
+Ports the contract carved out by ``typescript/src/hooks/usePasteHandler.ts``
+and the ``isPasted`` discriminator on ``ParsedKey``
+(``typescript/src/ink/parse-keypress.ts``). Chapter 14 of
+``claude-code-from-source`` calls this flag "critical for security": when
+the terminal wraps content between ``ESC [200~`` and ``ESC [201~``, the
+parser must keep the bytes inside that envelope from being interpreted
+as commands (a paste containing ``\x03`` would otherwise be a free
+Ctrl+C, and a paste of ``gg`` in vim mode would fire ``transcript.top``
+instead of inserting the literal characters).
+
+In Textual the demarcation is already done for us — the runtime emits a
+single ``textual.events.Paste`` carrying the concatenated text. This
+module is the pure-Python classification layer that the ``PromptInput``
+widget consults to decide:
+
+* whether the paste is empty (macOS Cmd+V image paste sentinel),
+* whether it looks like a drag of an image file (so the host can offer
+  to attach it instead of inserting the path string), and
+* how many lines and characters were pasted (for the "Pasted N chars"
+  hint surface that round 3 will wire to the footer).
+
+No Textual import here — the helpers are unit-testable in isolation and
+shared by both the prompt widget and any future paste-aware surface
+(transcript search, message-selector inline editor).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Mirrors ``usePasteHandler.PASTE_THRESHOLD`` (32 chars in the ink
+# reference, raised to 64 here because Textual already framed the event
+# as a Paste — the heuristic is only a fallback for terminals without
+# bracketed paste support).
+PASTE_THRESHOLD: int = 64
+
+# Image file extensions the host can plausibly attach.  Lowercase only;
+# ``detect_image_drag`` lowercases candidates before lookup. The set
+# matches the recognised media types in
+# ``typescript/src/utils/file/isImageFilePath.ts`` plus ``.heic``/``.heif``
+# (which iPhone screenshots use natively).
+IMAGE_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".webp",
+        ".bmp",
+        ".heic",
+        ".heif",
+        ".svg",
+        ".avif",
+    }
+)
+
+# Split on whitespace that precedes the start of an absolute path. Two
+# forms cover macOS/Linux (``/foo``) and Windows (``C:\foo``). The TS
+# reference uses the same regex in ``usePasteHandler.wrappedOnInput``.
+_PATH_SPLIT_RE = re.compile(r"\s+(?=/|[A-Za-z]:\\)")
+
+
+@dataclass(frozen=True)
+class PasteInfo:
+    """Result of classifying a single bracketed-paste payload.
+
+    Attributes:
+        text: The literal pasted text (unmodified — escape sequences
+            and control characters survive intact).
+        length: ``len(text)``. Cached so consumers do not call
+            ``len()`` repeatedly on multi-megabyte pastes.
+        is_empty: ``True`` when ``text`` is empty. macOS sends an empty
+            bracketed-paste envelope when the user Cmd+V's an image
+            from the clipboard; host code interprets this as a
+            "check clipboard for image" trigger.
+        is_image_drag: ``True`` when the paste looks like one or more
+            drag-and-drop image file paths.
+        line_count: Number of newline-delimited lines (``1`` for a paste
+            that contains no ``\n``). Used by the host to surface a
+            "Pasted N lines" hint.
+    """
+
+    text: str
+    length: int
+    is_empty: bool
+    is_image_drag: bool
+    line_count: int
+
+
+def detect_image_drag(text: str) -> bool:
+    """Return ``True`` if ``text`` looks like a drag of one or more image files.
+
+    The heuristic intentionally matches the TS reference so behaviour is
+    consistent across the two ports:
+
+    1. Strip leading/trailing whitespace.
+    2. Split the payload on whitespace that precedes ``/`` or ``X:\\``
+       (the start of an absolute path on Unix/Windows). This catches
+       "two files dropped at once" pastes (`"/a/foo.png /b/bar.jpg"`).
+    3. Further split each token on newlines (some terminals deliver
+       multi-file drops as one path per line).
+    4. Strip each candidate and check the extension lowercase against
+       :data:`IMAGE_EXTENSIONS`.
+
+    Returns ``True`` if *any* candidate matches, ``False`` otherwise.
+    A pure-text paste, a URL, or a code snippet will never return
+    ``True`` because none of those have a known image extension at the
+    end of an absolute-looking path.
+    """
+
+    stripped = text.strip()
+    if not stripped:
+        return False
+    for token in _PATH_SPLIT_RE.split(stripped):
+        for raw_line in token.split("\n"):
+            candidate = raw_line.strip()
+            # Only treat candidates that look absolute. Avoid false-
+            # positives on plain words by requiring either a leading
+            # ``/`` or a drive-letter prefix on Windows.
+            if not candidate or not (
+                candidate.startswith("/") or _looks_like_windows_path(candidate)
+            ):
+                continue
+            dot = candidate.rfind(".")
+            if dot != -1 and candidate[dot:].lower() in IMAGE_EXTENSIONS:
+                return True
+    return False
+
+
+def _looks_like_windows_path(candidate: str) -> bool:
+    """Return ``True`` if ``candidate`` starts with a drive letter prefix."""
+
+    return (
+        len(candidate) >= 3
+        and candidate[0].isalpha()
+        and candidate[1] == ":"
+        and candidate[2] == "\\"
+    )
+
+
+def classify_paste(text: str) -> PasteInfo:
+    """Return a :class:`PasteInfo` describing the bracketed-paste payload.
+
+    The function is total — every string produces a well-formed
+    :class:`PasteInfo`, including the empty string (which yields
+    ``is_empty=True``). Callers should branch on ``is_empty`` before
+    trying to insert ``text`` into a widget; an empty paste means the
+    host should query the clipboard for an image instead of writing a
+    zero-length string into the input buffer.
+    """
+
+    length = len(text)
+    is_empty = length == 0
+    is_image_drag = False if is_empty else detect_image_drag(text)
+    # ``str.count`` is O(n) but a single pass per paste is cheap even
+    # for multi-megabyte payloads. Add 1 for the trailing line that
+    # never ends with ``\n``.
+    line_count = 1 + text.count("\n") if not is_empty else 0
+    return PasteInfo(
+        text=text,
+        length=length,
+        is_empty=is_empty,
+        is_image_drag=is_image_drag,
+        line_count=line_count,
+    )
+
+
+__all__ = [
+    "IMAGE_EXTENSIONS",
+    "PASTE_THRESHOLD",
+    "PasteInfo",
+    "classify_paste",
+    "detect_image_drag",
+]

--- a/src/tui/widgets/prompt_input.py
+++ b/src/tui/widgets/prompt_input.py
@@ -29,7 +29,8 @@ from textual.message import Message
 from textual.widgets import Input, OptionList
 from textual.widgets.option_list import Option
 
-from ..messages import CancelRequested
+from ..messages import CancelRequested, PromptPasted
+from ..paste import PasteInfo, classify_paste
 from ..vim import VimState
 from .prompt_input_footer import PromptInputFooter
 from .prompt_input_mode_indicator import PromptInputModeIndicator
@@ -40,6 +41,50 @@ class PromptSubmitted(Message):
     """User pressed Enter on a non-empty prompt."""
 
     text: str
+
+
+class _PasteAwareInput(Input):
+    """``Input`` subclass that routes bracketed paste through the host.
+
+    The stock Textual ``Input._on_paste`` truncates the payload to the
+    first line and bypasses any custom paste handler on the parent
+    widget. That destroys the very property chapter 14 calls out as
+    "critical for security" — the bracketed-paste envelope must travel
+    intact so the host can decide whether it is a literal text insert,
+    an image-file drag, or an empty-paste image-clipboard sentinel.
+
+    This subclass intercepts ``events.Paste`` before the stock handler
+    runs and forwards it to the surrounding :class:`PromptInput` via
+    ``parent.handle_paste``. The Input itself does not insert anything;
+    the host owns the buffer mutation so vim-mode shims, slash-popup
+    suppression, and history-pointer hygiene all happen in one place.
+    """
+
+    def _on_paste(self, event: events.Paste) -> None:  # type: ignore[override]
+        # Walk up the widget tree looking for a parent that knows how
+        # to absorb a bracketed paste. ``hasattr`` avoids a forward
+        # reference to :class:`PromptInput` (which is declared below
+        # to keep the file readable top-down).
+        node = self.parent
+        for _ in range(8):  # bounded walk; the tree is always shallow.
+            if node is None:
+                break
+            handler = getattr(node, "handle_paste", None)
+            if callable(handler):
+                handler(event.text)
+                # ``prevent_default`` is what stops Textual's MRO
+                # walker from also invoking the stock
+                # ``Input._on_paste`` (which would truncate the
+                # payload to the first line and double-insert).
+                # ``stop`` then halts bubbling to ancestor widgets so
+                # the host does not see the raw Paste twice.
+                event.prevent_default()
+                event.stop()
+                return
+            node = getattr(node, "parent", None)
+        # Fallback to the stock behaviour if we've been re-parented
+        # outside a :class:`PromptInput` host.
+        super()._on_paste(event)
 
 
 class _SlashSuggestions(OptionList):
@@ -83,10 +128,13 @@ class PromptInput(Vertical):
         self._words_provider = words_provider
         self._history: list[str] = []
         self._history_pos: int | None = None
-        self._input = Input(placeholder="Type a prompt, or / for commands")
+        self._input = _PasteAwareInput(placeholder="Type a prompt, or / for commands")
         self._suggestions = _SlashSuggestions(classes="-hidden")
         self._vim = VimState(enabled=vim_mode)
         self._yank_buffer: str = ""
+        # Round 2 / WI-R2.5: most-recent bracketed paste classification.
+        # Test seam — the host reads :class:`PromptPasted` instead.
+        self._last_paste: PasteInfo | None = None
         # Round 2 / WI-R2.4: passive status surfaces around the input.
         # The mode indicator subscribes to ``VimState`` directly; the
         # footer reads ``VimState.enabled`` lazily. Both mounted as
@@ -116,6 +164,46 @@ class PromptInput(Vertical):
 
         self._input.value = value or ""
         self._hide_suggestions()
+
+    # ---- bracketed paste ----
+    def handle_paste(self, text: str) -> PasteInfo:
+        """Insert a bracketed-paste payload as a single atomic operation.
+
+        Bypasses the slash-popup recomputer, the history pointer, and
+        the vim chord tracker — pasted characters must always reach the
+        buffer literally even when they happen to spell a chord prefix.
+        Chapter 14 calls this the ``isPasted`` invariant; the Python
+        port honours it by funnelling every bracketed paste through
+        this single entry point.
+
+        Returns the :class:`PasteInfo` so callers (typically tests) can
+        assert on classification without having to listen for the
+        :class:`PromptPasted` message.
+        """
+
+        info = classify_paste(text)
+        self._last_paste = info
+        if not info.is_empty:
+            inp = self._input
+            value = inp.value or ""
+            pos = max(0, min(inp.cursor_position, len(value)))
+            new_value = value[:pos] + info.text + value[pos:]
+            inp.value = new_value
+            inp.cursor_position = pos + info.length
+        # Pasted content must never reopen the slash palette; the user
+        # paste-bombed the prompt and likely wants to keep typing or
+        # submit. Same rationale as the TS ``usePasteHandler`` reset.
+        self._hide_suggestions()
+        # Paste must never disturb the history cursor — leaving
+        # ``_history_pos`` untouched here is the explicit contract.
+        self.post_message(PromptPasted(info=info))
+        return info
+
+    @property
+    def last_paste(self) -> PasteInfo | None:
+        """Most recent classified paste (test seam)."""
+
+        return self._last_paste
 
     def action_clear_draft(self) -> None:
         self.clear()

--- a/tests/tui/test_paste_handling.py
+++ b/tests/tui/test_paste_handling.py
@@ -1,0 +1,325 @@
+"""Unit + widget tests for bracketed-paste handling in :class:`PromptInput`.
+
+Chapter 14 round 2 gap: the ``isPasted`` discriminator (TS ``ParsedKey``)
+must survive into the Python port. Today Textual already classifies the
+inbound escape sequence as a single :class:`textual.events.Paste`; this
+test suite locks the contract that :class:`PromptInput` routes that
+event into a single atomic ``handle_paste`` call that bypasses the
+slash-popup recomputer, the history pointer, and the vim chord tracker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("textual")
+
+from textual import events
+from textual.app import App, ComposeResult
+
+from src.tui.messages import PromptPasted
+from src.tui.paste import (
+    IMAGE_EXTENSIONS,
+    PASTE_THRESHOLD,
+    PasteInfo,
+    classify_paste,
+    detect_image_drag,
+)
+from src.tui.widgets.prompt_input import PromptInput
+
+
+# ---- pure-function tests --------------------------------------------------
+
+
+def test_paste_threshold_is_positive_int():
+    """Threshold is a guard against false-positive paste detection."""
+
+    assert isinstance(PASTE_THRESHOLD, int)
+    assert PASTE_THRESHOLD > 0
+
+
+def test_image_extensions_includes_common_formats():
+    """The recognised-extensions set must cover the obvious cases."""
+
+    for ext in (".png", ".jpg", ".jpeg", ".gif", ".webp"):
+        assert ext in IMAGE_EXTENSIONS
+
+
+def test_classify_paste_text_only():
+    info = classify_paste("hello world from the clipboard")
+    assert info.text == "hello world from the clipboard"
+    assert info.length == len("hello world from the clipboard")
+    assert info.is_empty is False
+    assert info.is_image_drag is False
+    assert info.line_count == 1
+
+
+def test_classify_paste_multiline_counts_lines():
+    info = classify_paste("line1\nline2\nline3")
+    assert info.line_count == 3
+    assert info.is_empty is False
+
+
+def test_classify_paste_trailing_newline_counted():
+    info = classify_paste("hello\n")
+    # A trailing ``\n`` means two lines: "hello" + the empty trailing line.
+    assert info.line_count == 2
+
+
+def test_classify_paste_empty():
+    info = classify_paste("")
+    assert info.is_empty is True
+    assert info.length == 0
+    assert info.is_image_drag is False
+    assert info.line_count == 0
+
+
+def test_classify_paste_is_frozen():
+    info = classify_paste("x")
+    with pytest.raises(Exception):
+        info.text = "y"  # type: ignore[misc]
+
+
+def test_detect_image_drag_unix_path():
+    assert detect_image_drag("/Users/me/foo.png") is True
+
+
+def test_detect_image_drag_windows_path():
+    assert detect_image_drag(r"C:\Users\me\bar.jpg") is True
+
+
+def test_detect_image_drag_space_prefix():
+    # Drag often arrives with a leading space (terminal artifact).
+    assert detect_image_drag(" /tmp/a.png") is True
+
+
+def test_detect_image_drag_newline_separated_drops():
+    payload = "/tmp/a.png\n/tmp/b.jpg"
+    assert detect_image_drag(payload) is True
+
+
+def test_detect_image_drag_two_files_space_separated():
+    payload = "/tmp/a.png /tmp/b.jpg"
+    assert detect_image_drag(payload) is True
+
+
+def test_detect_image_drag_negative_plain_text():
+    assert detect_image_drag("just regular text") is False
+
+
+def test_detect_image_drag_negative_url():
+    # URLs share the slash prefix but lack a path-extension pattern.
+    assert detect_image_drag("https://example.com/foo") is False
+
+
+def test_detect_image_drag_negative_unknown_extension():
+    assert detect_image_drag("/tmp/notes.txt") is False
+
+
+def test_detect_image_drag_empty_string():
+    assert detect_image_drag("") is False
+
+
+def test_detect_image_drag_case_insensitive_extension():
+    # macOS Preview sometimes hands you UPPERCASE extensions.
+    assert detect_image_drag("/tmp/SHOT.PNG") is True
+
+
+def test_detect_image_drag_requires_absolute_path():
+    # A bare filename without a path should not trigger image-drag detection
+    # because the host has nowhere to read the file from.
+    assert detect_image_drag("foo.png") is False
+
+
+# ---- widget integration ---------------------------------------------------
+
+
+class _Host(App):
+    def __init__(self, prompt: PromptInput) -> None:
+        super().__init__()
+        self._prompt = prompt
+        self.paste_events: list[PromptPasted] = []
+
+    def compose(self) -> ComposeResult:
+        yield self._prompt
+
+    def on_prompt_pasted(self, message: PromptPasted) -> None:
+        self.paste_events.append(message)
+
+
+def _make_prompt(vim_mode: bool = False) -> PromptInput:
+    return PromptInput(
+        words_provider=lambda: ["/help", "/exit", "/repl"],
+        vim_mode=vim_mode,
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_paste_inserts_text_atomically():
+    prompt = _make_prompt()
+    host = _Host(prompt)
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        info = prompt.handle_paste("hello pasted world")
+        await pilot.pause()
+        assert info.length == len("hello pasted world")
+        assert info.is_image_drag is False
+        # The buffer contains the whole payload (Textual would have
+        # truncated to first line under the stock _on_paste).
+        assert prompt._input.value == "hello pasted world"
+        assert prompt._input.cursor_position == len("hello pasted world")
+        assert prompt.last_paste is not None
+        assert prompt.last_paste.text == "hello pasted world"
+
+
+@pytest.mark.asyncio
+async def test_handle_paste_multiline_preserved():
+    prompt = _make_prompt()
+    host = _Host(prompt)
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        prompt.handle_paste("line1\nline2\nline3")
+        await pilot.pause()
+        # Stock Input._on_paste would have kept only "line1"; verify the
+        # whole multi-line payload survives.
+        assert prompt._input.value == "line1\nline2\nline3"
+        assert prompt.last_paste is not None
+        assert prompt.last_paste.line_count == 3
+
+
+@pytest.mark.asyncio
+async def test_paste_does_not_advance_history_pointer():
+    prompt = _make_prompt()
+    host = _Host(prompt)
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        # Prime the history with a prior submission.
+        prompt._history.append("earlier prompt")
+        prompt._history_pos = None
+        prompt.handle_paste("pasted content\n")
+        await pilot.pause()
+        # Paste must not touch history navigation state.
+        assert prompt._history_pos is None
+        assert prompt._history == ["earlier prompt"]
+
+
+@pytest.mark.asyncio
+async def test_paste_hides_slash_suggestions():
+    prompt = _make_prompt()
+    host = _Host(prompt)
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        # Pretend the popup was open just before the paste landed.
+        prompt._suggestions.remove_class("-hidden")
+        prompt.handle_paste("paste body")
+        await pilot.pause()
+        assert prompt._suggestions.has_class("-hidden")
+
+
+@pytest.mark.asyncio
+async def test_paste_with_vim_mode_bypasses_chord_tracker():
+    """Pasted ``dd`` must NOT fire the ``delete-line`` chord.
+
+    Mirrors chapter 14's "pasted ``\\x03`` should not be Ctrl+C" rule.
+    ``dd`` is the simplest vim chord the port supports; the test
+    guarantees that a paste containing ``dd`` lands as literal text
+    rather than triggering the line-delete action.
+    """
+
+    prompt = _make_prompt(vim_mode=True)
+    host = _Host(prompt)
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        # Drive the state machine into NORMAL by feeding Escape.
+        prompt._vim.handle("escape")
+        prompt.handle_paste("dd")
+        await pilot.pause()
+        # Buffer received the literal two characters.
+        assert prompt._input.value == "dd"
+        # Vim chord buffer should be untouched (paste path bypasses it).
+        assert prompt._vim._pending == ""
+
+
+@pytest.mark.asyncio
+async def test_paste_posts_prompt_pasted_message():
+    prompt = _make_prompt()
+    host = _Host(prompt)
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        prompt.handle_paste("payload")
+        await pilot.pause()
+        assert len(host.paste_events) == 1
+        assert isinstance(host.paste_events[0].info, PasteInfo)
+        assert host.paste_events[0].info.text == "payload"
+
+
+@pytest.mark.asyncio
+async def test_empty_paste_signals_image_clipboard_check():
+    prompt = _make_prompt()
+    host = _Host(prompt)
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        prompt.handle_paste("")
+        await pilot.pause()
+        assert prompt._input.value == ""
+        assert prompt.last_paste is not None
+        assert prompt.last_paste.is_empty is True
+        # Host still gets a message so it can poke the clipboard.
+        assert len(host.paste_events) == 1
+        assert host.paste_events[0].info.is_empty is True
+
+
+@pytest.mark.asyncio
+async def test_image_drag_paste_flags_payload():
+    prompt = _make_prompt()
+    host = _Host(prompt)
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        prompt.handle_paste("/Users/me/screenshot.png")
+        await pilot.pause()
+        assert prompt.last_paste is not None
+        assert prompt.last_paste.is_image_drag is True
+        # The path string is still inserted — image attaching is a
+        # follow-up round; the metadata gives the host a chance to
+        # offer the user an attach action instead.
+        assert prompt._input.value == "/Users/me/screenshot.png"
+
+
+@pytest.mark.asyncio
+async def test_paste_routes_through_subclassed_input():
+    """An ``events.Paste`` posted to ``_input`` is intercepted by our subclass."""
+
+    prompt = _make_prompt()
+    host = _Host(prompt)
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        prompt._input.focus()
+        # Fire the Paste event directly at the input. The custom
+        # _on_paste handler should walk up to PromptInput and route
+        # through handle_paste; the buffer should contain the *full*
+        # multi-line payload (stock Input truncates to first line).
+        prompt._input.post_message(events.Paste(text="multi\nline\npaste"))
+        await pilot.pause()
+        assert prompt._input.value == "multi\nline\npaste"
+        assert prompt.last_paste is not None
+        assert prompt.last_paste.line_count == 3
+        # And the host received the bubbled-up message.
+        assert any(
+            evt.info.text == "multi\nline\npaste" for evt in host.paste_events
+        )
+
+
+@pytest.mark.asyncio
+async def test_handle_paste_inserts_at_cursor():
+    """Cursor in the middle of existing text → paste splices, not appends."""
+
+    prompt = _make_prompt()
+    host = _Host(prompt)
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        prompt._input.value = "abcXYZ"
+        prompt._input.cursor_position = 3
+        prompt.handle_paste("-PASTED-")
+        await pilot.pause()
+        assert prompt._input.value == "abc-PASTED-XYZ"
+        assert prompt._input.cursor_position == 3 + len("-PASTED-")


### PR DESCRIPTION
## Summary

- Wires a dedicated bracketed-paste path on `PromptInput`: a `_PasteAwareInput` subclass overrides `_on_paste`, calls `prevent_default()` + `stop()` to defeat Textual's MRO-walks-all-handlers dispatch, and forwards the full payload to a new `handle_paste(text)` entry point.
- Adds `src/tui/paste.py` with `PasteInfo` + `classify_paste` + `detect_image_drag` (pure-Python helpers; no Textual dep) and a `PromptPasted` `Message` carrying the `PasteInfo` so downstream surfaces (footer hint, clipboard-image fallback) can subscribe.
- Honors chapter 14's `isPasted` security invariant: pasted bytes bypass the vim chord tracker, the slash-popup recomputer, and the history pointer — so a pasted `dd` lands as literal text instead of triggering `delete-line`.

## Test plan

- [x] `pytest tests/tui/test_paste_handling.py tests/tui/test_keybindings.py tests/tui/test_prompt_input_footer.py tests/tui/test_prompt_input_mode_indicator.py tests/tui/test_slash_token_parser.py tests/test_porting_workspace.py tests/test_no_top_level_decoys.py -q` -> 127 passed.
- [x] `pytest tests/tui -q` -> 525 passed, 2 skipped (no regressions).
- [x] 28 new tests cover: empty paste (macOS image sentinel), multi-line preservation, image-drag detection (Unix/Windows/space-prefix/newline-separated/case-insensitive ext), URL false-positive, vim chord bypass, history-pointer untouched, slash-popup hidden, mid-buffer cursor splicing, and end-to-end routing through `events.Paste -> _PasteAwareInput._on_paste -> handle_paste`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)