### PR TITLE
fix(command_system): drop stale src.setup import from builtins

### DIFF
--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -21,7 +21,6 @@ from ..context_system.microcompact import microcompact_messages, strip_images_fr
 from ..cost_tracker import CostTracker
 from ..history import HistoryLog
 from ..providers.base import BaseProvider
-from ..setup import run_setup
 from .engine import CommandContext, CommandResult, LocalCommandResult
 from .registry import CommandRegistry, get_command_registry, list_commands
 from .types import Command, CommandType, CompactionResult, LocalCommand, PromptCommand


### PR DESCRIPTION
## Summary
- `src/command_system/builtins.py` imported `run_setup` from `..setup` but never called it.
- The `91e3f38` refactor moved `src/setup.py` → `scripts/audit/setup.py`, leaving the import dangling.
- Result: `ModuleNotFoundError: No module named 'src.setup'` on REPL startup (any code path that pulls in `builtins.py`).

## Test plan
- [x] `python3 -c "from src.command_system import builtins"` imports cleanly
- [x] `python3 -c "from src.repl import ClawcodexREPL"` imports cleanly
- [x] `grep -rn "from src.setup\|from ..setup" src/` returns no results
- [ ] Smoke-run the CLI end-to-end in the user's environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)