### PR TITLE
fix(tool_system): bypassPermissions skips working-dir allowlist

### DIFF
--- a/src/tool_system/context.py
+++ b/src/tool_system/context.py
@@ -261,6 +261,18 @@ class ToolContext:
             p = (base / p).resolve()
         else:
             p = p.resolve()
+        # Mirror TS ``shouldBypassPermissions`` at
+        # ``typescript/src/utils/permissions/permissions.ts:1268-1281``:
+        # bypassPermissions mode (set by --dangerously-skip-permissions),
+        # or plan mode when the user started with bypass available,
+        # short-circuits the working-directory allowlist so the tool can
+        # operate outside ``workspace_root``.
+        mode = self.permission_context.mode
+        if mode == "bypassPermissions" or (
+            mode == "plan"
+            and self.permission_context.is_bypass_permissions_mode_available
+        ):
+            return p
         roots = self.allowed_roots()
         if any(_is_within(p, root) for root in roots):
             return p


### PR DESCRIPTION
## Summary
- `ToolContext.ensure_allowed_path` raised `ToolPermissionError` for any path outside `workspace_root`, bypassing the upstream permission decision pipeline.
- Under `--dangerously-skip-permissions` (= `bypassPermissions` mode), reads/writes to absolute paths outside the project (e.g. `/tmp/...`) were rejected even though the user opted out of prompts.
- Mirrors the TS `shouldBypassPermissions` gate at `typescript/src/utils/permissions/permissions.ts:1268-1281`: `bypassPermissions` mode, or `plan` mode when the user originally started with bypass available, short-circuits the working-directory check.
- Default mode and `plan`-without-bypass continue to raise (unchanged).

## Test plan
- [x] Smoke-tested all four permission-mode combinations directly against `ensure_allowed_path` with an outside path; bypass cases pass, non-bypass cases still raise
- [x] `tests/test_memdir_write_carve_out.py` — 5/5 pass (the existing "outside path falls back to passthrough or ask" expectation still holds via the .md gate)
- [x] `tests/parity/test_permission_flow_parity.py` — 23/23 vectors pass (no upstream parity regression)
- [ ] Smoke-run the CLI with `--dangerously-skip-permissions` and read/write a path outside the project

🤖 Generated with [Claude Code](https://claude.com/claude-code)