### PR TITLE
fix(diff render): match Claude Code's add/remove bar layout

### DIFF
--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -162,6 +162,7 @@ class _SlashOnlyCompleter(Completer):
         return None, 0
 
 try:
+    from rich.cells import cell_len
     from rich.console import Console, Group
     from rich.align import Align
     from rich.panel import Panel
@@ -173,6 +174,9 @@ except ModuleNotFoundError:  # pragma: no cover
     class Console:  # type: ignore
         def print(self, *args, **kwargs):
             return None
+
+    def cell_len(s):  # type: ignore
+        return len(s)
 
     Group = None  # type: ignore
     Align = None  # type: ignore
@@ -1004,6 +1008,11 @@ class ClawcodexREPL:
         summary = _format_edit_summary_text(adds, removes) or "no changes"
         summary_text = Text(summary, style="dim")
 
+        # Snap to a sane width: ``self.console.width`` falls back to 80
+        # when stdout is not a TTY. Fenced to 1 so degenerate widths don't
+        # produce negative padding.
+        console_width = max(1, getattr(self.console, "width", 0) or 80)
+
         diff = Text()
         rendered = 0
         truncated = False
@@ -1022,25 +1031,40 @@ class ClawcodexREPL:
                 # on newlines and produce blank rows between every entry.
                 stripped = raw.rstrip("\n").rstrip("\r")
                 if stripped.startswith("+"):
-                    # Match Claude Code's TUI: default terminal foreground
-                    # on an ANSI ``green`` / ``red`` background, so added
-                    # and removed lines read as solid bars regardless of
-                    # the user's terminal theme. Mirrors
-                    # ``typescript/src/utils/theme.ts``'s ANSI themes —
-                    # ``diffAdded: 'ansi:green'``, ``diffRemoved: 'ansi:red'``.
-                    diff.append(f"     {new_lineno:>4}  ", style="on green")
-                    diff.append("+ ", style="bold on green")
-                    diff.append(stripped[1:] + "\n", style="on green")
+                    # Match Claude Code's truecolor dark theme. Background
+                    # starts at the line-number column and extends to the
+                    # right edge by padding the trailing space with the
+                    # same bg, so added/removed rows read as solid bars
+                    # across the full width. Mirrors
+                    # ``typescript/src/components/StructuredDiff/Fallback.tsx:331-346``
+                    # (lineNumStr + sigil + content + ' '.repeat(padding))
+                    # and ``typescript/src/utils/theme.ts darkTheme``
+                    # (``diffAdded: 'rgb(34,92,43)'``,
+                    # ``diffRemoved: 'rgb(122,41,54)'``).
+                    body = stripped[1:]
+                    gutter = f"{new_lineno:>4} "
+                    visible = len(gutter) + 1 + cell_len(body)
+                    padding = max(0, console_width - visible)
+                    diff.append(gutter, style="on rgb(34,92,43)")
+                    diff.append("+", style="bold on rgb(34,92,43)")
+                    diff.append(body + " " * padding, style="on rgb(34,92,43)")
+                    diff.append("\n")
                     new_lineno += 1
                 elif stripped.startswith("-"):
-                    diff.append(f"     {old_lineno:>4}  ", style="on red")
-                    diff.append("- ", style="bold on red")
-                    diff.append(stripped[1:] + "\n", style="on red")
+                    body = stripped[1:]
+                    gutter = f"{old_lineno:>4} "
+                    visible = len(gutter) + 1 + cell_len(body)
+                    padding = max(0, console_width - visible)
+                    diff.append(gutter, style="on rgb(122,41,54)")
+                    diff.append("-", style="bold on rgb(122,41,54)")
+                    diff.append(body + " " * padding, style="on rgb(122,41,54)")
+                    diff.append("\n")
                     old_lineno += 1
                 else:
                     body = stripped[1:] if stripped.startswith(" ") else stripped
-                    diff.append(f"     {old_lineno:>4}    ", style="dim")
-                    diff.append(body + "\n", style="dim")
+                    # Context lines have no bg; keep gutter width aligned
+                    # with add/remove rows so columns line up.
+                    diff.append(f"{old_lineno:>4}  " + body + "\n", style="dim")
                     old_lineno += 1
                     new_lineno += 1
                 rendered += 1

--- a/src/tui/widgets/structured_diff.py
+++ b/src/tui/widgets/structured_diff.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable
 
+from rich.cells import cell_len
 from rich.text import Text
 from textual.widgets import Static
 
@@ -191,39 +192,42 @@ def render_diff(lines: Iterable[DiffLine], *, width_hint: int = 100) -> Text:
             out.append("\n")
             continue
         if line.kind == "add":
-            # Match Claude Code's TUI: default terminal foreground on an
-            # ANSI ``green`` background so the entire row reads as a solid
-            # bar. Mirrors ``typescript/src/utils/theme.ts``'s ANSI themes
-            # (``diffAdded: 'ansi:green'``).
-            prefix = _fmt_line_no(None, line.new_lineno)
-            out.append(prefix, style="on green")
-            out.append("+ ", style="bold on green")
-            out.append(line.text, style="on green")
+            # Match Claude Code: bg starts at the line-number column and
+            # extends to ``width_hint`` so the row reads as a solid bar
+            # across the full width. Mirrors
+            # ``typescript/src/components/StructuredDiff/Fallback.tsx:331-346``
+            # and ``typescript/src/utils/theme.ts darkTheme.diffAdded
+            # 'rgb(34,92,43)'``.
+            gutter = _fmt_line_no(line.new_lineno)
+            visible = len(gutter) + 1 + cell_len(line.text)
+            padding = max(0, width_hint - visible)
+            out.append(gutter, style="on rgb(34,92,43)")
+            out.append("+", style="bold on rgb(34,92,43)")
+            out.append(line.text + " " * padding, style="on rgb(34,92,43)")
             out.append("\n")
         elif line.kind == "remove":
-            prefix = _fmt_line_no(line.old_lineno, None)
-            out.append(prefix, style="on red")
-            out.append("- ", style="bold on red")
-            out.append(line.text, style="on red")
+            # Mirrors ``darkTheme.diffRemoved: 'rgb(122,41,54)'``.
+            gutter = _fmt_line_no(line.old_lineno)
+            visible = len(gutter) + 1 + cell_len(line.text)
+            padding = max(0, width_hint - visible)
+            out.append(gutter, style="on rgb(122,41,54)")
+            out.append("-", style="bold on rgb(122,41,54)")
+            out.append(line.text + " " * padding, style="on rgb(122,41,54)")
             out.append("\n")
         else:  # context
-            prefix = _fmt_line_no(line.old_lineno, line.new_lineno)
-            out.append(prefix, style="dim")
-            out.append("  ", style="dim")
+            # No bg on context rows; pad gutter to the same column width
+            # as add/remove so the content aligns vertically.
+            gutter = _fmt_line_no(line.new_lineno or line.old_lineno)
+            out.append(gutter + " ", style="dim")
             out.append(line.text, style="")
             out.append("\n")
     return out
 
 
-def _fmt_line_no(old: int | None, new: int | None) -> str:
-    """Return a 9-char gutter ``'  12  15 '`` / ``'      15 '`` etc."""
+def _fmt_line_no(n: int | None) -> str:
+    """Return a 5-char gutter ``'  12 '`` (right-padded line number + space)."""
 
-    def _cell(n: int | None) -> str:
-        if n is None:
-            return "    "
-        return f"{n:4d}"
-
-    return f"{_cell(old)} {_cell(new)} "
+    return f"{0 if n is None else n:>4} "
 
 
 class StructuredDiff(Static):

--- a/tests/tui/test_phase3_dialogs.py
+++ b/tests/tui/test_phase3_dialogs.py
@@ -231,8 +231,11 @@ def test_edit_activity_result_body_renders_summary_and_diff():
     assert body is not None
     rendered = "".join(part.plain for part in body.renderables)
     assert "Added 2 lines, removed 2 lines" in rendered
-    assert "+ new line" in rendered
-    assert "- old line" in rendered
+    # Single-char sigil immediately followed by the source line, matching
+    # ``typescript/src/components/StructuredDiff/Fallback.tsx`` (no trailing
+    # space after ``+``/``-``).
+    assert "+new line" in rendered
+    assert "-old line" in rendered
 
 
 def test_edit_activity_result_body_create_fallback():


### PR DESCRIPTION
## Summary
Brings the REPL and TUI diff renderers in line with the Claude Code reference. Before this change three things were off:

1. Background used harsh ANSI `green`/`red` instead of the truecolor `darkTheme` palette.
2. Five spaces of bg-colored padding sat **before** the line number, so the colored bar started left of the number column.
3. The colored span ended at the source content, leaving the right side of each row uncolored instead of extending to the terminal edge.

This patch mirrors `typescript/src/components/StructuredDiff/Fallback.tsx:331-346` and `typescript/src/utils/theme.ts darkTheme`:
- `rgb(34,92,43)` / `rgb(122,41,54)` for `diffAdded` / `diffRemoved`.
- Drop the leading 5-space pad — bg now starts at the line-number column.
- Single-char `+`/`-` sigil (matches TS; source indentation supplies visual spacing).
- Pad each colored row to `console.width` / `width_hint` with bg-colored spaces so the bar reaches the right edge.
- `\n` lives outside the styled span so terminals with BCE don't bleed the bg into the next row.

`structured_diff.py` drops the two-column `_fmt_line_no` (old + new) in favor of TS's single line-number column. Context rows still have no bg and align column-wise with the colored rows.

## Test plan
- [x] `tests/tui/test_phase3_dialogs.py` — 24/24 pass (one assertion updated for single-char sigil format: `+new line` instead of `+ new line`)
- [x] Visual smoke: rendered a sample patch at widths 80 and 100 — bg starts at the line number and extends to the right edge for both add and remove rows; context rows are uncolored and column-aligned
- [ ] In-terminal smoke during an actual REPL Edit/MultiEdit run

🤖 Generated with [Claude Code](https://claude.com/claude-code)