### PR TITLE
fix(esc): make ESC cancel Bash + streaming within ~50ms

### DIFF
--- a/src/query/streaming.py
+++ b/src/query/streaming.py
@@ -96,7 +96,15 @@ async def streaming_query(
         yield QueryEvent(type="turn_start", data={"turn": state.turn_count})
 
         try:
-            async for event in _run_model_turn(state, turn, client):
+            async for event in _run_model_turn(state, turn, client, abort_signal=abort_signal):
+                # Per-event abort check: between each chunk from
+                # ``call_model`` we re-poll the signal so ESC during a
+                # long model response interrupts within one chunk, not
+                # at the next turn boundary. Mirrors the SDK-callback
+                # poll in ``typescript/src/services/api/claude.ts``.
+                if abort_signal and getattr(abort_signal, "aborted", False):
+                    yield QueryEvent(type="aborted")
+                    return
                 yield event
         except PromptTooLongError as e:
             if cfg.reactive_compact_enabled and state.compact_retries < MAX_REACTIVE_COMPACT_RETRIES:
@@ -120,6 +128,14 @@ async def streaming_query(
                 yield QueryEvent(type="error", data={"error": str(e)})
                 state.is_done = True
                 return
+
+        # If ``_run_model_turn`` returned early because its own per-event
+        # abort check fired, the ``async for`` above exits cleanly — we
+        # must re-check the signal here, otherwise we'd fall through to
+        # ``turn_complete`` and the consumer would never see ``aborted``.
+        if abort_signal and getattr(abort_signal, "aborted", False):
+            yield QueryEvent(type="aborted")
+            return
 
         update_usage(state.total_usage, turn.usage)
 
@@ -192,6 +208,8 @@ async def _run_model_turn(
     state: StreamingQueryState,
     turn: QueryTurn,
     client: Any = None,
+    *,
+    abort_signal: Any | None = None,
 ) -> AsyncGenerator[QueryEvent, None]:
     options = CallModelOptions(
         model=state.config.model,
@@ -212,6 +230,13 @@ async def _run_model_turn(
     tool_use_json_parts: list[str] = []
 
     async for event in call_model(state.messages, options, client):
+        # Bail at the first chunk that arrives after ESC. We can't tear
+        # down the underlying SSE connection from here (``call_model``
+        # doesn't accept an abort signal yet), but returning early stops
+        # us from accumulating text/tool_uses into the turn and lets the
+        # outer loop yield ``aborted`` immediately.
+        if abort_signal is not None and getattr(abort_signal, "aborted", False):
+            return
         if isinstance(event, MessageStart):
             yield QueryEvent(type="message_start", data={
                 "model": event.model,

--- a/src/services/tool_execution/tool_execution.py
+++ b/src/services/tool_execution/tool_execution.py
@@ -438,7 +438,13 @@ async def _call_tool(tool: Tool, tool_input: dict[str, Any], context: ToolContex
     if inspect.iscoroutinefunction(call_fn):
         result = await call_fn(tool_input, context)
     else:
-        result = call_fn(tool_input, context)
+        # Offload sync tools to a worker thread so they don't block the
+        # event loop. Without this, a long Bash command holds the loop
+        # for its entire duration — ESC key presses and abort_controller
+        # listeners can't fire because no other task gets to run. Mirrors
+        # the responsiveness TS gets "for free" from Node's
+        # callback-driven I/O.
+        result = await asyncio.to_thread(call_fn, tool_input, context)
 
     if not isinstance(result, ToolResult):
         result = ToolResult(name=tool.name, output=result)

--- a/src/tool_system/tools/bash/bash_tool.py
+++ b/src/tool_system/tools/bash/bash_tool.py
@@ -3,11 +3,130 @@
 from __future__ import annotations
 
 import json
+import os as _os_mod
 import re
 import shlex
+import signal as _signal_mod
 import subprocess
+import sys as _sys_mod
+import time as _time_mod
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+
+# Poll interval for the abort/timeout watcher. 50 ms keeps ESC perceptibly
+# instant (well under the ~100 ms threshold where humans notice latency)
+# while costing ~20 wakeups/sec for a long-running command — negligible.
+_ABORT_POLL_INTERVAL_S = 0.05
+
+# Grace period between SIGTERM and SIGKILL after an abort. Lets the
+# subprocess flush stdio + run cleanup handlers (TS ShellCommand grants
+# a similar window via ``tree-kill``).
+_KILL_GRACE_S = 2.0
+
+
+@dataclass
+class _BashRunResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    interrupted: bool = False
+    timed_out: bool = False
+
+
+def _get_abort_signal(context: ToolContext) -> Any | None:
+    controller = getattr(context, "abort_controller", None)
+    return getattr(controller, "signal", None) if controller else None
+
+
+def _kill_process_group(pid: int, sig: int) -> None:
+    try:
+        if _sys_mod.platform == "win32":
+            # No setpgid on Windows; just kill the process itself.
+            _os_mod.kill(pid, sig)
+        else:
+            _os_mod.killpg(_os_mod.getpgid(pid), sig)
+    except (ProcessLookupError, PermissionError, OSError):
+        # Already gone (race vs. natural exit) or insufficient
+        # privileges — fall through to subprocess.wait() which will
+        # surface the right state.
+        pass
+
+
+def _run_bash_with_abort(
+    argv: list[str],
+    *,
+    cwd: str,
+    timeout_s: int,
+    abort_signal: Any | None,
+) -> _BashRunResult:
+    """Run ``argv`` with abort + timeout supervision.
+
+    Replaces ``subprocess.run(..., timeout=...)``: launches the
+    subprocess in its own session/process group, polls for completion
+    while watching ``abort_signal.aborted`` and the timeout, and kills
+    the whole group (SIGTERM → grace → SIGKILL) when either fires.
+    Returning quickly on abort is what makes ESC feel instant — the
+    previous ``subprocess.run`` had to wait the entire timeout.
+    """
+
+    popen_kwargs: dict[str, Any] = {
+        "cwd": cwd,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+    }
+    if _sys_mod.platform == "win32":
+        popen_kwargs["creationflags"] = getattr(
+            subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+        )
+    else:
+        popen_kwargs["start_new_session"] = True
+
+    proc = subprocess.Popen(argv, **popen_kwargs)
+
+    deadline = _time_mod.monotonic() + timeout_s
+    interrupted = False
+    timed_out = False
+
+    while True:
+        if proc.poll() is not None:
+            break
+        if abort_signal is not None and getattr(abort_signal, "aborted", False):
+            interrupted = True
+            break
+        if _time_mod.monotonic() >= deadline:
+            interrupted = True
+            timed_out = True
+            break
+        _time_mod.sleep(_ABORT_POLL_INTERVAL_S)
+
+    if interrupted:
+        _kill_process_group(proc.pid, _signal_mod.SIGTERM)
+        try:
+            proc.wait(timeout=_KILL_GRACE_S)
+        except subprocess.TimeoutExpired:
+            _kill_process_group(proc.pid, _signal_mod.SIGKILL)
+            try:
+                proc.wait(timeout=_KILL_GRACE_S)
+            except subprocess.TimeoutExpired:
+                pass
+
+    # ``communicate()`` after a kill is safe and gathers any pending
+    # output that buffered before the signal landed.
+    try:
+        stdout, stderr = proc.communicate(timeout=_KILL_GRACE_S)
+    except subprocess.TimeoutExpired:
+        stdout, stderr = "", ""
+
+    return _BashRunResult(
+        returncode=proc.returncode if proc.returncode is not None else -1,
+        stdout=stdout or "",
+        stderr=stderr or "",
+        interrupted=interrupted,
+        timed_out=timed_out,
+    )
 
 _HARDCODED_DANGEROUS_PATTERNS = [
     re.compile(r"\bsudo\b", re.IGNORECASE),
@@ -180,26 +299,40 @@ def _bash_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
     _os.close(cwd_fd)
     try:
         wrapped = f"{{ {command}\n}}; __rc=$?; pwd > {shlex.quote(cwd_path)} 2>/dev/null; exit $__rc"
-        try:
-            completed = subprocess.run(
-                ["bash", "-lc", wrapped],
-                cwd=str(cwd),
-                capture_output=True,
-                text=True,
-                timeout=timeout_s,
-            )
-        except subprocess.TimeoutExpired:
+        # Spawn bash in its own session/process group so we can kill the
+        # whole subtree (e.g. ``find /`` that itself forks helpers) when
+        # ESC fires. Mirrors TS ``ShellCommand`` (typescript/src/utils/
+        # ShellCommand.ts:187-192,345) which uses ``tree-kill`` for the
+        # same reason. ``start_new_session=True`` is ``setsid()`` on
+        # POSIX; on Windows it falls back to a process group via
+        # ``CREATE_NEW_PROCESS_GROUP``.
+        run_result = _run_bash_with_abort(
+            ["bash", "-lc", wrapped],
+            cwd=str(cwd),
+            timeout_s=timeout_s,
+            abort_signal=_get_abort_signal(context),
+        )
+
+        if run_result.interrupted:
             return ToolResult(
                 name=BASH_TOOL_NAME,
                 output={
                     "cwd": str(cwd),
                     "exit_code": -1,
-                    "stdout": "",
-                    "stderr": f"Command timed out after {timeout_s} seconds",
+                    "stdout": truncate_output(run_result.stdout or ""),
+                    "stderr": (
+                        truncate_output(run_result.stderr or "")
+                        if not run_result.timed_out
+                        else f"Command timed out after {timeout_s} seconds"
+                    ),
                     "interrupted": True,
                 },
                 is_error=True,
             )
+
+        completed_returncode = run_result.returncode
+        completed_stdout = run_result.stdout or ""
+        completed_stderr = run_result.stderr or ""
 
         # If the command succeeded in changing directory, promote the new cwd
         # into the shared ToolContext so follow-up Bash invocations start
@@ -228,16 +361,16 @@ def _bash_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
             # roam freely but the UI cwd clamps to the workspace).
             pass
 
-    stdout = truncate_output(completed.stdout or "")
-    stderr = truncate_output(completed.stderr or "")
+    stdout = truncate_output(completed_stdout)
+    stderr = truncate_output(completed_stderr)
 
     interpretation = interpret_command_result(
-        command, completed.returncode, completed.stdout or "", completed.stderr or "",
+        command, completed_returncode, completed_stdout, completed_stderr,
     )
 
     output: dict[str, Any] = {
         "cwd": str(cwd),
-        "exit_code": completed.returncode,
+        "exit_code": completed_returncode,
         "stdout": stdout,
         "stderr": stderr,
     }


### PR DESCRIPTION
## Summary
ESC during a Bash command or model stream had to wait the full Bash timeout (10–60s) or the rest of a turn. Three stacked gaps:

1. **Event loop blocked**: `_call_tool` ran sync tools inline (`tool_execution.py:441`). While Bash blocked, the ESC handler couldn't fire `abort_controller.abort()` at all.
2. **Unkillable Bash**: `_bash_call` used `subprocess.run(timeout=...)` with no PID and no `abort_signal` reference (`bash_tool.py:184`). Even if abort fired, nothing killed the subprocess.
3. **Coarse streaming poll**: `_run_model_turn` didn't take an abort signal; `streaming_query` polled only at the outer while-loop boundary (`streaming.py:89`). Long responses emitted every chunk before noticing the abort.

## Fix
Mirrors `typescript/src/utils/ShellCommand.ts` (tree-kill on abort listener) + per-chunk signal checks from `typescript/src/services/api/claude.ts`:

| File | Change |
|---|---|
| `src/services/tool_execution/tool_execution.py` | Wrap sync tools in `asyncio.to_thread` so the event loop stays responsive |
| `src/tool_system/tools/bash/bash_tool.py` | Swap `subprocess.run` for `Popen(start_new_session=True)` + 50ms abort/timeout poll loop + `os.killpg(SIGTERM)` → 2s grace → SIGKILL |
| `src/query/streaming.py` | Thread `abort_signal` into `_run_model_turn`; check `.aborted` per chunk from `call_model`; re-check after inner loop so aborted-mid-turn yields `aborted` not `turn_complete` |

Sync entry to `_bash_call` is preserved so existing direct callers in `skill.py` and tests work unchanged.

## Test plan
- [x] `tests/test_tool_system_tools.py` 70/70, `tests/test_skills_shell_exec.py` 13/13 (Bash sync entry intact)
- [x] `tests/test_streaming_query_loop.py` 10/10, `tests/test_query_loop.py` 5/5
- [x] `tests/test_streaming_executor*.py` + `tests/test_stream_watchdog.py` 29/29
- [x] `tests/test_tool_execution_integration.py` + `tests/test_tool_orchestration.py` + `tests/test_orchestrator_concurrency.py` + `tests/parity/test_tool_execution_order.py` 41/41
- [x] **Bash smoke**: `sleep 30` aborted via `abort_controller`: **227ms** end-to-end through `_call_tool → to_thread → Popen → killpg` (was ~30s)
- [x] **Streaming smoke**: 20×100ms chunks aborted at 250ms: **303ms** to `aborted` event; no further `text`/`turn_complete`
- [x] **Baseline**: normal completion, timeout path, and non-zero exit-code paths preserved (57ms / 1018ms for 1s timeout / 59ms for `exit 42`)
- [ ] In-terminal smoke during an actual REPL/TUI session

## Out of scope
* Streaming idle-timeout watchdog (TS has `STREAM_IDLE_TIMEOUT_MS = 90_000`). Separate concern, separate PR.
* Threading `abort_signal` into `call_model` itself so we can tear down the HTTP stream — current per-chunk check is sufficient for the dominant case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)