### PR TITLE
fix(esc): propagate cancel signal into tool_context for subagents

### DIFF
--- a/src/query/engine.py
+++ b/src/query/engine.py
@@ -60,6 +60,14 @@ class QueryEngine:
         self._config = config
         self._mutable_messages: list[Message] = list(config.initial_messages or [])
         self._abort_controller = config.abort_controller or create_abort_controller()
+        # Mirror the controller onto the tool context. The query loop already
+        # reads ``params.abort_controller`` at turn boundaries, but the
+        # streaming tool executor, Bash supervisor, tool hooks and — most
+        # importantly — Agent subagents read ``context.abort_controller``
+        # to learn about ESC. Leaving the field ``None`` lets long-running
+        # tools (especially subagent dispatches) ignore the user's
+        # interrupt until they finish naturally.
+        self._config.tool_context.abort_controller = self._abort_controller
         self._total_usage: dict[str, int] = {"input_tokens": 0, "output_tokens": 0}
         self._session_id: str = uuid4().hex
         # Ch5/B.5 prereq — the autocompact circuit-breaker counter must
@@ -271,3 +279,7 @@ class QueryEngine:
 
     def reset_abort_controller(self) -> None:
         self._abort_controller = create_abort_controller()
+        # Keep the tool context's controller in sync with the engine's —
+        # otherwise the next turn's subagents and Bash commands would still
+        # be carrying the previous (possibly aborted) controller.
+        self._config.tool_context.abort_controller = self._abort_controller

--- a/src/tool_system/agent_loop.py
+++ b/src/tool_system/agent_loop.py
@@ -435,6 +435,13 @@ def run_agent_loop(
                 from ..tool_system.protocol import ToolCall
                 call = ToolCall(name=tool_name, input=tool_input, tool_use_id=tool_id)
                 result = tool_registry.dispatch(call, tool_context)
+                # Check immediately after dispatch. Most cancellable tools
+                # (Bash supervisor, Agent subagents) honour the abort signal
+                # by returning a partial/synthetic result rather than
+                # raising — so if we don't re-check here, the loop happily
+                # proceeds to the next tool (or burns an API turn) after
+                # the user has already pressed ESC.
+                _check_cancel()
                 result_output = result.output
                 if tool_name.lower() == "sendusermessage" and isinstance(result_output, dict):
                     msg = result_output.get("message")
@@ -473,6 +480,15 @@ def run_agent_loop(
                         "tool_call_id": tool_id,
                         "content": _build_openai_tool_result_content(result_output)
                     })
+            except AbortError:
+                # Never bury a user interrupt inside a tool-result message:
+                # the outer ``run_agent_loop`` caller (TUI bridge / REPL /
+                # headless) needs the exception to propagate so it can post
+                # ``Cancelled by user`` and unwind the worker thread.
+                # Swallowing it as a tool error would convert the abort
+                # into a synthetic error result and let the next API turn
+                # fire, defeating the whole purpose of ESC.
+                raise
             except Exception as e:
                 error_str = f"Error: {e}"
                 if verbose:

--- a/src/tui/agent_bridge.py
+++ b/src/tui/agent_bridge.py
@@ -91,6 +91,17 @@ class AgentBridge:
                 return False
             self._busy = True
             self._abort_controller = AbortController()
+            # Plumb the controller onto the tool context BEFORE we spawn
+            # the worker. Tools (Bash supervisor, Agent subagents, the
+            # streaming executor, tool hooks) read
+            # ``context.abort_controller`` to learn whether the user has
+            # asked to interrupt; without this assignment they see
+            # ``None`` and run to completion regardless of ESC. The Agent
+            # subagent path is the worst case — ``run_agent`` inherits
+            # the parent's controller via ``parent_context.abort_controller``,
+            # so a missing field here forces the subagent to mint a fresh
+            # controller that is never tripped by ESC.
+            self._tool_context.abort_controller = self._abort_controller
 
         self._session.conversation.add_user_message(prompt)
         self._post(AgentRunStarted(prompt=prompt))
@@ -215,6 +226,21 @@ class AgentBridge:
         self._state.clear_streaming_text()
         with self._busy_lock:
             self._busy = False
+            # Drop the per-run controller from the shared tool context so
+            # the next ``submit()`` starts from a clean state. Leaving an
+            # aborted controller in place would cause the next prompt's
+            # first tool dispatch to see ``signal.aborted == True`` and
+            # short-circuit before the user has even pressed ESC.
+            #
+            # Safety note: ``_finish`` runs on the worker thread *after*
+            # ``run_agent_loop`` has returned or raised, so no in-flight
+            # tool can be reading ``context.abort_controller`` from this
+            # thread at the moment we clear it. Detached background
+            # processes (e.g. ``spawn_background_bash``) capture their
+            # own controller reference at spawn time rather than re-
+            # reading the context field, so clearing here doesn't orphan
+            # them either.
+            self._tool_context.abort_controller = None
 
     # ---- permission bridge ----
     def _permission_handler(

--- a/tests/test_esc_cancel_propagation.py
+++ b/tests/test_esc_cancel_propagation.py
@@ -1,0 +1,366 @@
+"""Regression tests for ESC cancellation propagating into subagents.
+
+Before this fix, the AgentBridge / QueryEngine wired their AbortController
+into the agent loop's ``cancel_signal`` parameter but never assigned it to
+``tool_context.abort_controller``. As a consequence:
+
+* Long-running tools that read ``context.abort_controller`` (Bash, Agent
+  subagents, the streaming executor, tool hooks) saw ``None`` and ran to
+  completion regardless of ESC.
+* Sync Agent subagents in particular created a *fresh* AbortController
+  inside ``run_agent`` (because the parent's was None) — the user's ESC
+  press had nowhere to land, so subagents could chew through dozens of
+  tool calls before naturally finishing.
+
+These tests pin the new behaviour:
+
+* The agent loop re-raises ``AbortError`` rather than burying it in a
+  synthetic tool-result message.
+* A cancel that fires *during* a tool dispatch is noticed before the
+  next tool call (or the next API turn) starts.
+* The TUI bridge and the REPL query engine both plumb the controller
+  onto the tool context, so subagents and other downstream tools see
+  the same signal the UI tripped.
+"""
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.providers.base import ChatResponse
+from src.tool_system.agent_loop import run_agent_loop
+from src.tool_system.context import ToolContext
+from src.tool_system.protocol import ToolResult
+from src.tool_system.registry import ToolRegistry
+from src.tool_system.build_tool import build_tool
+from src.utils.abort_controller import AbortController, AbortError
+
+
+class _FakeAnthropic:
+    """Stub provider that looks like an Anthropic provider to the loop."""
+
+    def __init__(self, responses: list[ChatResponse]):
+        self._responses = list(responses)
+        self.calls = 0
+
+    def chat_stream_response(self, *_args: Any, **_kwargs: Any) -> ChatResponse:
+        raise NotImplementedError  # force the non-stream path
+
+    def chat(self, *_args: Any, **_kwargs: Any) -> ChatResponse:
+        self.calls += 1
+        if not self._responses:
+            return ChatResponse(
+                content="",
+                model="test",
+                usage={"input_tokens": 0, "output_tokens": 0},
+                finish_reason="end_turn",
+                tool_uses=None,
+            )
+        return self._responses.pop(0)
+
+
+# Make ``_is_anthropic_provider`` happy without importing the real SDK class.
+def _patch_anthropic_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.tool_system import agent_loop
+
+    monkeypatch.setattr(agent_loop, "_is_anthropic_provider", lambda _p: True)
+
+
+def _make_context(workspace: Path) -> ToolContext:
+    return ToolContext(workspace_root=workspace)
+
+
+def _build_registry_with_blocking_tool(
+    block_event: threading.Event,
+    abort_check: dict[str, bool],
+    entered_event: threading.Event,
+) -> ToolRegistry:
+    """Build a registry with a single ``Slow`` tool that polls its abort signal.
+
+    The tool sets ``entered_event`` on its first poll so the test thread
+    can wait for tool entry *before* tripping the abort — a deterministic
+    handshake replaces the previous sleep-based race. The tool then
+    blocks until either (a) the abort signal fires, or (b) ``block_event``
+    is set explicitly by the test. Recording into ``abort_check`` lets us
+    assert that the tool actually observed the signal coming from
+    ``context.abort_controller`` (rather than completing on its own).
+    """
+
+    def _call(_input: dict[str, Any], context: ToolContext) -> ToolResult:
+        controller = getattr(context, "abort_controller", None)
+        signal = getattr(controller, "signal", None) if controller else None
+        abort_check["controller_present"] = controller is not None
+        entered_event.set()
+        # Spin until aborted or the escape hatch trips. A real tool would
+        # poll its inner work loop the same way the Bash supervisor does
+        # in ``_run_bash_with_abort``. The 2s escape hatch turns a stuck
+        # test into a loud assertion failure rather than a hang, so a
+        # regression is still visible in CI logs.
+        for _ in range(200):  # ~2 seconds at 10ms cadence
+            if signal is not None and signal.aborted:
+                abort_check["saw_abort"] = True
+                return ToolResult(
+                    name="Slow", output={"interrupted": True}, is_error=False
+                )
+            if block_event.wait(timeout=0.01):
+                break
+        return ToolResult(name="Slow", output={"ran_to_completion": True})
+
+    tool = build_tool(
+        name="Slow",
+        input_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        call=_call,
+        prompt=lambda: "Slow no-op",
+        description=lambda _i: "slow",
+    )
+    registry = ToolRegistry()
+    registry.register(tool)
+    return registry
+
+
+def test_agent_loop_propagates_cancel_set_via_tool_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ESC trips ``tool_context.abort_controller`` mid-dispatch → loop unwinds.
+
+    Models the TUI bridge contract after the fix: the bridge writes its
+    controller to ``tool_context.abort_controller`` before the worker
+    thread starts the loop. A cancel that fires while a long tool is
+    running must (a) reach the running tool through ``context.abort_controller``
+    and (b) unwind the outer loop without burying the abort in a tool
+    error.
+    """
+    _patch_anthropic_check(monkeypatch)
+
+    block_event = threading.Event()
+    entered_event = threading.Event()
+    abort_check: dict[str, bool] = {}
+    registry = _build_registry_with_blocking_tool(
+        block_event, abort_check, entered_event
+    )
+
+    provider = _FakeAnthropic(
+        responses=[
+            ChatResponse(
+                content="",
+                model="test",
+                usage={"input_tokens": 1, "output_tokens": 1},
+                finish_reason="tool_use",
+                tool_uses=[{"id": "call_1", "name": "Slow", "input": {}}],
+            ),
+            ChatResponse(  # would only be reached if the abort were ignored
+                content="should never run",
+                model="test",
+                usage={"input_tokens": 1, "output_tokens": 1},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+        ]
+    )
+
+    controller = AbortController()
+    context = _make_context(tmp_path)
+    # Mirror the bridge's submit(): plumb the controller onto the context
+    # before kicking off the loop.
+    context.abort_controller = controller
+
+    from src.agent.conversation import Conversation
+
+    conv = Conversation()
+    conv.add_user_message("kick it off")
+
+    def _trip_when_tool_enters() -> None:
+        # Deterministic handshake: wait for the Slow tool to actually
+        # enter its poll loop before we trip the abort. This avoids a
+        # sleep-based race on CI where the scheduler might keep the
+        # main thread running long enough that the abort fires before
+        # dispatch reaches the tool. The 5s ceiling turns a wedged
+        # test into a loud failure instead of an indefinite hang.
+        assert entered_event.wait(timeout=5.0), "Slow tool never entered"
+        controller.abort("user_interrupt")
+
+    threading.Thread(target=_trip_when_tool_enters, daemon=True).start()
+
+    with pytest.raises(AbortError):
+        run_agent_loop(
+            conversation=conv,
+            provider=provider,
+            tool_registry=registry,
+            tool_context=context,
+            max_turns=5,
+            stream=False,
+            cancel_signal=controller.signal,
+        )
+
+    # The Slow tool MUST have actually observed the abort via the context.
+    assert abort_check.get("controller_present") is True
+    assert abort_check.get("saw_abort") is True
+    # The loop must NOT have issued a second API call to the model after
+    # cancellation — the abort should propagate before the next turn.
+    assert provider.calls == 1
+
+
+def test_agent_loop_does_not_swallow_abort_error_as_tool_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A tool that raises ``AbortError`` is propagated, not stringified.
+
+    The previous ``except Exception`` swallowed every non-system exception
+    into a synthetic ``Error: ...`` tool result and continued the loop.
+    That meant a tool which raised AbortError directly (rare, but legal —
+    e.g. a tool that calls ``signal.throw_if_aborted()``) would have its
+    user-interrupt converted into a regular error result and the next
+    API turn would still fire.
+    """
+    _patch_anthropic_check(monkeypatch)
+
+    def _call(_input: dict[str, Any], _context: ToolContext) -> ToolResult:
+        raise AbortError("user_interrupt")
+
+    tool = build_tool(
+        name="Raiser",
+        input_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        call=_call,
+        prompt=lambda: "raises",
+        description=lambda _i: "raises",
+    )
+    registry = ToolRegistry()
+    registry.register(tool)
+
+    provider = _FakeAnthropic(
+        responses=[
+            ChatResponse(
+                content="",
+                model="test",
+                usage={"input_tokens": 1, "output_tokens": 1},
+                finish_reason="tool_use",
+                tool_uses=[{"id": "call_1", "name": "Raiser", "input": {}}],
+            ),
+        ]
+    )
+
+    controller = AbortController()
+    context = _make_context(tmp_path)
+    context.abort_controller = controller
+
+    from src.agent.conversation import Conversation
+
+    conv = Conversation()
+    conv.add_user_message("kick it off")
+
+    with pytest.raises(AbortError):
+        run_agent_loop(
+            conversation=conv,
+            provider=provider,
+            tool_registry=registry,
+            tool_context=context,
+            max_turns=5,
+            stream=False,
+            cancel_signal=controller.signal,
+        )
+
+    # The loop must not have issued a follow-up API call after the abort.
+    assert provider.calls == 1
+
+
+def test_query_engine_plumbs_abort_controller_into_tool_context(
+    tmp_path: Path,
+) -> None:
+    """REPL's QueryEngine wires its controller onto ``tool_context`` at init.
+
+    Before the fix the engine's controller was passed only as
+    ``QueryParams.abort_controller``; subagents and Bash, which read
+    ``context.abort_controller``, saw ``None``. The engine must now mirror
+    the controller onto the shared context so the same signal that the
+    query loop checks at turn boundaries is also visible to downstream
+    tools.
+    """
+    from src.query.engine import QueryEngine, QueryEngineConfig
+
+    context = ToolContext(workspace_root=tmp_path)
+    # Pre-condition: a freshly constructed context has no abort controller.
+    assert context.abort_controller is None
+
+    cfg = QueryEngineConfig(
+        cwd=tmp_path,
+        provider=MagicMock(),
+        tool_registry=ToolRegistry(),
+        tools=[],
+        tool_context=context,
+    )
+    engine = QueryEngine(cfg)
+
+    # Post-fix: the engine's controller is now visible on the context.
+    assert context.abort_controller is engine._abort_controller
+
+    # Interrupting the engine trips the context-visible signal.
+    engine.interrupt()
+    assert context.abort_controller is not None
+    assert context.abort_controller.signal.aborted is True
+
+    # Reset replaces the controller on both the engine and the context.
+    engine.reset_abort_controller()
+    assert context.abort_controller is engine._abort_controller
+    assert context.abort_controller.signal.aborted is False
+
+
+def test_agent_bridge_plumbs_abort_controller_into_tool_context(
+    tmp_path: Path,
+) -> None:
+    """TUI bridge writes its per-run controller onto the tool context.
+
+    The Agent subagent path (``run_agent``) inherits the parent's
+    controller via ``parent_context.abort_controller``. If the bridge
+    fails to plumb that field, the subagent creates a fresh controller
+    that ESC never trips — exactly the regression this test guards.
+    """
+    from src.agent import Session
+    from src.tui.agent_bridge import AgentBridge
+    from src.tui.state import AppState
+
+    posted: list[Any] = []
+
+    def _post(msg: Any) -> None:
+        posted.append(msg)
+
+    # ``_run_worker`` swallows the agent thread so the bridge stays
+    # in this thread for the assertions — we never actually call
+    # ``run_agent_loop`` in this unit test.
+    def _no_run_worker(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    context = ToolContext(workspace_root=tmp_path)
+    assert context.abort_controller is None
+
+    bridge = AgentBridge(
+        post_message=_post,
+        session=Session.create("test", "test-model"),
+        provider=MagicMock(),
+        tool_registry=ToolRegistry(),
+        tool_context=context,
+        app_state=AppState(),
+        run_worker=_no_run_worker,
+    )
+
+    submitted = bridge.submit("hello")
+    assert submitted is True
+
+    # The controller created inside submit() must be visible on the
+    # shared tool context — this is the wiring that lets subagents
+    # honour ESC.
+    assert context.abort_controller is bridge._abort_controller
+
+    # Cancelling trips both objects (they are the same controller).
+    assert bridge.cancel() is True
+    assert context.abort_controller is not None
+    assert context.abort_controller.signal.aborted is True
+
+    # Finishing a run clears the per-run controller from the shared
+    # context so the next prompt doesn't start with a stale aborted
+    # signal that would short-circuit every tool dispatch.
+    bridge._finish()
+    assert context.abort_controller is None


### PR DESCRIPTION
## Summary
- ESC tripped an `AbortController` but `tool_context.abort_controller` was never assigned that controller, so downstream readers (Bash supervisor, streaming executor, tool hooks, and most critically **sync Agent subagents**) saw `None` and ignored the user's interrupt
- Sync subagents in `src/agent/run_agent.py:279-283` fell through to `abort_controller = AbortController()` — a fresh, disconnected controller — so ESC had nowhere to land and the subagent ran to natural completion (user's transcript showed a 6+ minute general-purpose subagent that ignored ESC entirely)
- Wire the per-run controller onto `tool_context.abort_controller` in both the TUI bridge (`submit()` plumbs, `_finish()` clears) and the REPL `QueryEngine` (init + `reset_abort_controller`), and harden `agent_loop` to re-raise `AbortError` and re-check cancel after each dispatch

## Root cause
The cancellation path had broken plumbing. `AgentBridge` created `self._abort_controller`, passed `controller.signal` to `run_agent_loop(cancel_signal=...)`, but **never wrote it to `self._tool_context.abort_controller`**. The agent loop's `_check_cancel()` therefore only fired at top-level turn/tool boundaries. Long-running tools that *do* read `context.abort_controller` (Bash, sync Agent subagents) saw `None` and either ran to completion or, in the subagent case, minted a fresh disconnected controller that ESC could never trip.

## Changes
- **`src/tui/agent_bridge.py`** — `submit()` plumbs the per-run controller onto `tool_context.abort_controller`; `_finish()` clears it under the busy lock so the next prompt doesn't start with a stale aborted signal
- **`src/query/engine.py`** — `__init__` and `reset_abort_controller()` mirror the engine's controller onto `tool_context.abort_controller` (REPL path)
- **`src/tool_system/agent_loop.py`** — re-check cancel immediately after `tool_registry.dispatch(...)` returns (most cancellable tools return a partial result rather than raising); split the catch block so `AbortError` re-raises instead of being stringified into a synthetic tool-result error that would burn another API turn
- **`tests/test_esc_cancel_propagation.py`** — 4 new regression tests: mid-dispatch cancel from a worker thread (event-driven handshake, not sleep-based), `AbortError` re-raise contract, `QueryEngine` plumbing, `AgentBridge` plumbing

## Test plan
- [x] `tests/test_esc_cancel_propagation.py` — 4 new regression tests pass
- [x] 135 directly related tests pass (abort/query/subagent/streaming/agent_tool/agent_loop)
- [x] 236 broader related tests pass (also bash, orchestrator, tool_execution, tool_hooks)
- [x] Critic subagent review: APPROVE
- [ ] Manual: run a Claude Code session, kick off an Agent subagent, press ESC mid-run, verify the run unwinds within a second instead of waiting minutes

## Follow-ups (separate PRs)
The Critic flagged three non-blocking adjacent gaps; tracked as follow-up tickets:
1. Headless (`clawcodex -p ...`) has the same conceptual gap under SIGINT mid-tool
2. `ToolContext.abort_controller` could be made non-optional with a default to eliminate the "field is None" hazard class entirely
3. Tools that don't poll the signal at all (Read of huge files, Glob, Grep, WebFetch, WebSearch, MCP) can't be interrupted mid-call even with this wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)