### PR TITLE
fix(bash): redirect child stdin to /dev/null so isatty(0) is false

### DIFF
--- a/src/tool_system/tools/bash/background.py
+++ b/src/tool_system/tools/bash/background.py
@@ -73,9 +73,13 @@ def spawn_background_bash(
         f"exit $__rc"
     )
 
+    # ``stdin=DEVNULL`` mirrors the foreground bash path: prevents background
+    # commands that read fd 0 from blocking on a TTY inherited from clawcodex's
+    # REPL (see bash_tool.py:_run_bash_with_abort for the same reasoning).
     proc = subprocess.Popen(
         ["bash", "-lc", wrapped],
         cwd=str(cwd),
+        stdin=subprocess.DEVNULL,
         stdout=output_handle,
         stderr=subprocess.STDOUT,
         start_new_session=True,

--- a/src/tool_system/tools/bash/bash_tool.py
+++ b/src/tool_system/tools/bash/bash_tool.py
@@ -71,8 +71,14 @@ def _run_bash_with_abort(
     previous ``subprocess.run`` had to wait the entire timeout.
     """
 
+    # ``stdin=DEVNULL`` matches TS ``Shell.ts`` (stdio[0] = 'pipe' with the
+    # writable end never written to). Without this the child inherits the
+    # parent's stdin -- when clawcodex runs in a terminal, that's a TTY, and
+    # scaffolders like ``npm create vite`` see ``isatty(0)`` and try to prompt
+    # for confirmation, hanging the command until timeout.
     popen_kwargs: dict[str, Any] = {
         "cwd": cwd,
+        "stdin": subprocess.DEVNULL,
         "stdout": subprocess.PIPE,
         "stderr": subprocess.PIPE,
         "text": True,

--- a/tests/test_tool_system_tools.py
+++ b/tests/test_tool_system_tools.py
@@ -193,6 +193,75 @@ class TestBashTool(ToolSystemTests):
         with self.assertRaises(Exception):
             BashTool.call({"command": "sudo echo nope"}, self.ctx)
 
+    def _run_bash_with_pty_parent_stdin(self, tool_input: dict) -> dict:
+        # Dup a real pty over fd 0 for the duration of one BashTool.call to
+        # simulate clawcodex's REPL inheriting a terminal -- the failure mode
+        # the ``stdin=DEVNULL`` fix prevents. Returns the call's output dict.
+        import os
+        import pty
+        if not hasattr(pty, "openpty"):  # pragma: no cover - non-POSIX
+            self.skipTest("openpty unavailable")
+        master, slave = pty.openpty()
+        saved_stdin = os.dup(0)
+        try:
+            os.dup2(slave, 0)
+            return BashTool.call(tool_input, self.ctx).output
+        finally:
+            os.dup2(saved_stdin, 0)
+            os.close(saved_stdin)
+            os.close(slave)
+            os.close(master)
+
+    def test_bash_child_stdin_is_not_a_tty(self) -> None:
+        # Regression for the ``npm create vite`` hang: child commands must
+        # see ``isatty(0) == false`` even when clawcodex itself was launched
+        # from a terminal. With ``stdin=DEVNULL`` on the spawn, the child
+        # reports NOTTY despite the parent's fd 0 being a real pty.
+        out = self._run_bash_with_pty_parent_stdin(
+            {"command": "if [ -t 0 ]; then echo TTY; else echo NOTTY; fi"},
+        )
+        self.assertEqual(out["exit_code"], 0)
+        self.assertEqual(out["stdout"].strip(), "NOTTY")
+
+    def test_bash_child_stdin_reads_eof(self) -> None:
+        # ``DEVNULL`` (not ``PIPE`` without writes) means a child that
+        # actually reads from fd 0 gets EOF immediately rather than blocking
+        # forever. Run under a pty parent stdin so we're actually testing
+        # DEVNULL vs inherited-TTY -- under bare pytest fd 0 is already a
+        # pipe so this would pass spuriously without the pty trick.
+        out = self._run_bash_with_pty_parent_stdin(
+            {"command": "cat; echo done=$?", "timeout_s": 5},
+        )
+        self.assertEqual(out["exit_code"], 0)
+        self.assertIn("done=0", out["stdout"])
+
+    def test_bash_background_child_stdin_is_not_a_tty(self) -> None:
+        # Same regression as the foreground path -- a backgrounded
+        # ``npm create vite`` would otherwise hang waiting on the inherited
+        # TTY. Verify by reading the captured log after the bg task reaps.
+        import time
+        res = self._run_bash_with_pty_parent_stdin(
+            {
+                "command": "if [ -t 0 ]; then echo TTY; else echo NOTTY; fi",
+                "run_in_background": True,
+            },
+        )
+        task_id = res["backgroundTaskId"]
+        log_path = Path(res["outputFilePath"])
+        deadline = time.time() + 5.0
+        log_contents = ""
+        while time.time() < deadline:
+            entry = self.ctx.background_bash_tasks.get(task_id, {})
+            if entry.get("exit_code") is not None:
+                log_contents = log_path.read_text(encoding="utf-8", errors="replace")
+                break
+            time.sleep(0.05)
+        # First non-empty log line is the command's output; trailing lines are
+        # the background wrapper's ``__CLAWCODEX_EXIT__=0`` marker.
+        stripped = log_contents.strip()
+        first_line = stripped.splitlines()[0] if stripped else ""
+        self.assertEqual(first_line, "NOTTY")
+
 
 class TestWebFetchTool(ToolSystemTests):
     def test_web_fetch_blocks_file_scheme(self) -> None:


### PR DESCRIPTION
## Summary

- `subprocess.Popen` in the Bash tool didn't set `stdin`, so the child inherited the parent's fd 0. When clawcodex's REPL ran in a terminal, that fd 0 was a real TTY — and scaffolders like `npm create vite` call `isatty(0)`, see TRUE, switch to interactive prompts, and hang until timeout because nothing feeds the prompt. The bash tool then returned `(Bash completed with no output)` and no project was created.
- Fix: set `stdin=subprocess.DEVNULL` at both spawn sites — foreground (`_run_bash_with_abort` in `bash_tool.py`) and background (`spawn_background_bash` in `background.py`). Matches the spirit of TS `Shell.ts`'s `stdio: ['pipe', ...]` (non-TTY child fd 0); DEVNULL is slightly stronger because child reads return EOF immediately rather than blocking forever on an empty pipe.
- Three new regression tests in `tests/test_tool_system_tools.py` dup a real pty over fd 0 before calling `BashTool.call`, reproducing the production failure mode. Confirmed all three fail when the fix is reverted.

## Test plan

- [x] `pytest tests/test_tool_system_tools.py::TestBashTool -v` — 5/5 pass with fix; the 3 new TTY tests fail without it (verified by reverting `stdin=DEVNULL` and rerunning — `'TTY\n'` vs `'NOTTY'` for the two `isatty` tests, `exit_code -1` from 5s timeout for the EOF test).
- [x] Broader sweep: `pytest tests/test_tool_system_tools.py tests/test_tool_execution_integration.py tests/test_skills_shell_exec.py tests/test_bash_security.py tests/test_bash_permissions_full.py tests/test_bash_parser.py` — 217 passed, 0 failed.
- [x] End-to-end: with a real pty on parent fd 0, `BashTool.call({"command": "npm create vite@latest e2e-vite -- --template react-ts"})` exits 0 and scaffolds the full project. Pre-fix this hung to timeout with empty output.
- [x] Two-round Critic review — APPROVE on the final state.

## Follow-up (out of scope)

Env-override parity with TS `Shell.ts:332-333` is a separate pre-existing gap — Python doesn't pass `env={...GIT_EDITOR: 'true', CLAUDECODE: '1', subprocessEnv()}` to `Popen`, so children inherit the parent's environment verbatim and tools like `git commit` without `-m` will hit EOF on their editor input rather than the clean exit `GIT_EDITOR=true` would produce. Should be a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)