### PR TITLE
feat(headless): SIGINT mid-tool cancels via AbortController

### DIFF
--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -25,11 +25,12 @@ from __future__ import annotations
 
 import io
 import os
+import signal as _signal
 import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import IO, Iterable, Optional
+from typing import IO, Callable, Iterable, Optional
 
 from src.agent import Session
 from src.cli_core import (
@@ -50,6 +51,7 @@ from src.providers import get_provider_class
 from src.tool_system.agent_loop import ToolEvent, run_agent_loop
 from src.tool_system.context import ToolContext
 from src.tool_system.defaults import build_default_registry
+from src.utils.abort_controller import AbortController, AbortError
 
 
 OUTPUT_FORMATS = ("text", "json", "stream-json")
@@ -161,12 +163,20 @@ def run_headless(options: HeadlessOptions) -> int:
         effective_mode = options.permission_mode or "default"
         bypass_available = bool(options.is_bypass_permissions_mode_available)
 
+    # Per-session abort controller. SIGINT trips this so the running
+    # tool (Bash supervisor, Agent subagent) unwinds immediately rather
+    # than waiting for the next safe interpreter bytecode boundary.
+    # Without this wiring, Ctrl-C only fires ``KeyboardInterrupt`` at
+    # the next safe boundary — which can be several minutes for a
+    # subprocess.wait() or an in-flight subagent.
+    abort_controller = AbortController()
     tool_context = ToolContext(
         workspace_root=workspace_root,
         permission_context=ToolPermissionContext(
             mode=effective_mode,  # type: ignore[arg-type]
             is_bypass_permissions_mode_available=bypass_available,
         ),
+        abort_controller=abort_controller,
     )
     tool_context.options.is_non_interactive_session = True
     if options.skip_permissions or effective_mode == "bypassPermissions":
@@ -213,58 +223,124 @@ def run_headless(options: HeadlessOptions) -> int:
     exit_code = 0
     start = time.monotonic()
 
-    for user_msg in inputs:
-        session.conversation.add_user_message(user_msg.text)
-
-        on_event = _build_event_bridge(writer, aggregate_tool_events)
-        on_text_chunk = None
-        if writer is not None and options.include_partial_messages:
-            def _emit_partial(chunk: str) -> None:
-                writer.write(PartialTextEvent(text=chunk))
-
-            on_text_chunk = _emit_partial
-
+    # Two-mode SIGINT handler:
+    # * Idle (waiting on stdin for the next stream-json input) → raise
+    #   ``KeyboardInterrupt`` immediately so the blocking read returns.
+    # * In-flight ``run_agent_loop`` → first strike trips the controller
+    #   (cooperative unwind), second strike force-quits via
+    #   ``KeyboardInterrupt``. Both map to exit 130.
+    # See ``_install_sigint_handler`` for the full handler logic; the
+    # for-loop's outer ``except (AbortError, KeyboardInterrupt)`` is the
+    # single chokepoint that catches whatever the handler raises.
+    # ``restore_sigint`` runs in the ``finally`` so we don't leak global
+    # signal state to embedders.
+    in_agent_loop = _InAgentLoopFlag()
+    restore_sigint = _install_sigint_handler(
+        abort_controller, in_agent_loop, stderr
+    )
+    try:
+        # Cancellation is caught at the for-loop level (not per-iteration)
+        # so that a SIGINT landing on ANY cancellation point unwinds to one
+        # place that emits the cancelled ResultEvent: the iterator step
+        # (``StreamJsonReader``'s blocking stdin read in idle mode), the
+        # agent loop itself, or the post-success accounting between them.
+        # The inner per-iteration ``except Exception`` keeps per-turn
+        # tool/provider error handling local — it must NOT catch
+        # ``AbortError``/``KeyboardInterrupt`` (Python catches them via
+        # ``Exception`` only when they inherit from it; ``AbortError`` does
+        # but ``KeyboardInterrupt`` does not, so we exclude AbortError
+        # explicitly).
         try:
-            result = run_agent_loop(
-                conversation=session.conversation,
-                provider=provider,
-                tool_registry=tool_registry,
-                tool_context=tool_context,
-                max_turns=options.max_turns,
-                stream=bool(on_text_chunk),
-                verbose=options.verbose,
-                on_event=on_event,
-                on_text_chunk=on_text_chunk,
-            )
-        except KeyboardInterrupt:
+            for user_msg in inputs:
+                session.conversation.add_user_message(user_msg.text)
+
+                on_event = _build_event_bridge(writer, aggregate_tool_events)
+                on_text_chunk = None
+                if writer is not None and options.include_partial_messages:
+                    def _emit_partial(chunk: str) -> None:
+                        writer.write(PartialTextEvent(text=chunk))
+
+                    on_text_chunk = _emit_partial
+
+                try:
+                    in_agent_loop.value = True
+                    try:
+                        result = run_agent_loop(
+                            conversation=session.conversation,
+                            provider=provider,
+                            tool_registry=tool_registry,
+                            tool_context=tool_context,
+                            max_turns=options.max_turns,
+                            stream=bool(on_text_chunk),
+                            verbose=options.verbose,
+                            on_event=on_event,
+                            on_text_chunk=on_text_chunk,
+                            cancel_signal=abort_controller.signal,
+                        )
+                    finally:
+                        # Flip BEFORE the outer except block can run so a
+                        # SIGINT landing between ``run_agent_loop`` returning
+                        # and the next iterator step is correctly classified
+                        # as idle. (``AbortError`` is a subclass of
+                        # ``Exception`` and would otherwise be re-raised
+                        # through this finally too — so we set the flag
+                        # back to False regardless of how we leave.)
+                        in_agent_loop.value = False
+                except AbortError:
+                    # Re-raise to the outer ``except`` so the cancelled
+                    # ResultEvent is emitted in exactly one place.
+                    raise
+                except Exception as exc:
+                    exit_code = 1
+                    if writer is not None:
+                        writer.write(
+                            ResultEvent(
+                                subtype="error",
+                                session_id=session.session_id,
+                                num_turns=num_turns_total,
+                                result=str(exc),
+                                duration_ms=int((time.monotonic() - start) * 1000),
+                                is_error=True,
+                                error=str(exc),
+                            )
+                        )
+                    else:
+                        print(f"error: {exc}", file=stderr)
+                    break
+
+                num_turns_total += result.num_turns
+                if result.usage:
+                    for key, value in result.usage.items():
+                        usage_total[key] = usage_total.get(key, 0) + int(value)
+
+                if writer is not None:
+                    writer.write(AssistantEvent(text=result.response_text))
+                aggregate_text.append(result.response_text)
+        except (AbortError, KeyboardInterrupt):
+            # Cancellation from ANY point in the loop body lands here:
+            # * ``AbortError`` from a cooperative unwind inside
+            #   ``run_agent_loop`` (first SIGINT, in-flight mode).
+            # * ``KeyboardInterrupt`` from the SIGINT handler's idle
+            #   branch (raised mid-``inputs.__iter__()`` while blocked on
+            #   stdin), or from the in-flight second-strike force-quit.
+            # All map to exit 130 for shell parity. ``error`` is left
+            # unset — ``subtype: "cancelled"`` already carries the
+            # signal, and pairing ``is_error=False`` with a populated
+            # ``error`` field would confuse consumers.
             exit_code = 130
-            break
-        except Exception as exc:
-            exit_code = 1
             if writer is not None:
                 writer.write(
                     ResultEvent(
-                        subtype="error",
+                        subtype="cancelled",
                         session_id=session.session_id,
                         num_turns=num_turns_total,
-                        result=str(exc),
+                        result="",
                         duration_ms=int((time.monotonic() - start) * 1000),
-                        is_error=True,
-                        error=str(exc),
+                        is_error=False,
                     )
                 )
-            else:
-                print(f"error: {exc}", file=stderr)
-            break
-
-        num_turns_total += result.num_turns
-        if result.usage:
-            for key, value in result.usage.items():
-                usage_total[key] = usage_total.get(key, 0) + int(value)
-
-        if writer is not None:
-            writer.write(AssistantEvent(text=result.response_text))
-        aggregate_text.append(result.response_text)
+    finally:
+        restore_sigint()
 
     duration_ms = int((time.monotonic() - start) * 1000)
     final_text = "\n\n".join(t for t in aggregate_text if t).strip()
@@ -274,9 +350,15 @@ def run_headless(options: HeadlessOptions) -> int:
             stdout.write(final_text + "\n")
             stdout.flush()
     elif options.output_format == "json":
+        if exit_code == 0:
+            json_subtype = "success"
+        elif exit_code == 130:
+            json_subtype = "cancelled"
+        else:
+            json_subtype = "error"
         payload = {
             "type": "result",
-            "subtype": "error" if exit_code not in (0, 130) else "success",
+            "subtype": json_subtype,
             "session_id": session.session_id,
             "provider": provider_name,
             "model": getattr(provider, "model", None),
@@ -306,6 +388,118 @@ def run_headless(options: HeadlessOptions) -> int:
 
 # ---------------------------------------------------------------------------
 # Helpers
+
+
+class _InAgentLoopFlag:
+    """Mutable shared flag indicating whether ``run_agent_loop`` is in flight.
+
+    Read by the SIGINT handler to decide between cooperative abort
+    (in-flight: trip the controller, let the loop unwind at the next
+    safe boundary) and immediate raise (idle, e.g. blocked on
+    ``StreamJsonReader``'s stdin read: the only way to make the read
+    return is to actually raise ``KeyboardInterrupt`` on the same
+    thread — Python 3 auto-retries EINTR'd reads when the handler
+    didn't raise, per PEP 475).
+    """
+
+    __slots__ = ("value",)
+
+    def __init__(self) -> None:
+        self.value = False
+
+
+def _install_sigint_handler(
+    controller: AbortController,
+    in_agent_loop: _InAgentLoopFlag,
+    stderr: IO[str],
+) -> Callable[[], None]:
+    """Install a context-aware SIGINT handler.
+
+    - **Idle** (``in_agent_loop.value`` is False, e.g. blocked on
+      stdin reading the next stream-json input): raise
+      ``KeyboardInterrupt`` immediately. Python 3 PEP 475 retries
+      EINTR'd ``read()`` calls when the signal handler did NOT raise,
+      so a cooperative abort here would *hang the stdin read* until
+      the user hit Ctrl-C a second time — a UX regression vs. the
+      pre-fix behaviour where the first Ctrl-C raised at the next
+      bytecode boundary and exited the program. Raising on the first
+      strike restores parity with that pre-fix path.
+
+    - **Cooperative** (in-flight ``run_agent_loop``, first strike):
+      trip ``controller``. Every abort-aware site — the agent loop's
+      ``_check_cancel`` boundaries, the Bash supervisor's poll loop,
+      the subagent query loop, the streaming executor's per-tool
+      controller, hook gates — sees the signal and unwinds gracefully
+      with a partial result that's appended to the conversation. A
+      message is printed to stderr so the user knows the request was
+      received but unwind may take a moment.
+
+    - **Cooperative** (in-flight, second strike): re-install the
+      platform default handler (defense-in-depth against a possible
+      third strike landing during unwind) and raise
+      ``KeyboardInterrupt`` directly. This is the force-quit escape
+      hatch for the rare case where a tool doesn't honour the abort.
+
+    Returns a callable that restores whatever handler was installed
+    before us, so embedders that drive ``run_headless`` from inside a
+    larger program don't have their global signal state mutated.
+
+    ``signal.signal`` is only callable from the main thread; if we are
+    not the main thread (e.g. an SDK harness that runs headless in a
+    worker thread), the install is skipped and the returned restore is
+    a no-op. Cancellation in that case falls back to the agent loop's
+    natural turn-boundary checks via ``KeyboardInterrupt`` propagation
+    from whatever signal facility the embedder is using.
+    """
+
+    previous = _signal.getsignal(_signal.SIGINT)
+
+    def _handler(signum, frame):
+        if not in_agent_loop.value:
+            # Idle on input — raise so the blocking stdin read returns.
+            # No need to swap to ``default_int_handler``: there's no
+            # cooperative-unwind escalation state to escalate from, and
+            # ``restore_sigint()`` in the ``finally`` block will revert
+            # the user's pre-existing handler shortly after the raise
+            # unwinds out of ``run_headless``. A second SIGINT before
+            # that finally runs would just re-enter this handler and
+            # raise again — fine.
+            raise KeyboardInterrupt
+        if controller.signal.aborted:
+            # Second strike during cooperative unwind: re-arm the
+            # platform default handler (so any third strike terminates
+            # the process the usual way) and raise the force-quit.
+            _signal.signal(_signal.SIGINT, _signal.default_int_handler)
+            raise KeyboardInterrupt
+        controller.abort("user_interrupt")
+        try:
+            # Plain ASCII for portability — some legacy Windows code
+            # pages can't encode U+2026 and would silently drop the
+            # message via the outer except.
+            stderr.write("\nCancelling... (Ctrl-C again to force quit)\n")
+            stderr.flush()
+        except Exception:
+            # A broken stderr (closed pipe etc.) must not stop the
+            # cancellation from propagating — the controller is already
+            # tripped, the agent loop will unwind regardless.
+            pass
+
+    try:
+        _signal.signal(_signal.SIGINT, _handler)
+    except (ValueError, OSError):
+        # Not in main thread (ValueError) or SIGINT not supported on
+        # this platform (OSError on some Windows configurations).
+        # Fall back to the agent loop's natural turn-boundary cancel
+        # checks via ``KeyboardInterrupt`` — the pre-fix behaviour.
+        return lambda: None
+
+    def _restore() -> None:
+        try:
+            _signal.signal(_signal.SIGINT, previous)
+        except (ValueError, OSError):
+            pass
+
+    return _restore
 
 
 def _filter_registry(registry, *, keep) -> None:

--- a/tests/test_headless_sigint.py
+++ b/tests/test_headless_sigint.py
@@ -1,0 +1,420 @@
+"""Regression tests for headless SIGINT cancellation.
+
+Before this fix, ``run_headless`` only caught ``KeyboardInterrupt``
+between agent-loop turns. Tools that wrap long blocking IO (the Bash
+supervisor's ``subprocess.wait()``, an Agent subagent's nested asyncio
+loop) absorbed Ctrl-C silently until the Python interpreter reached a
+safe bytecode boundary — minutes later, in the worst case.
+
+This file pins the new behaviour:
+
+* ``run_headless`` constructs an ``AbortController`` and plumbs it onto
+  the ``ToolContext``, so every reader (Bash supervisor, streaming
+  executor, tool hooks, subagent inheritance) sees the same signal.
+* The agent loop's ``cancel_signal`` parameter receives the same signal
+  so the loop's turn-boundary checks unwind promptly.
+* The SIGINT helper is **context-aware** via a shared
+  ``_InAgentLoopFlag``:
+    - **In-flight** (mid-``run_agent_loop``): two-strike. First SIGINT
+      trips the controller (cooperative unwind through abort-aware
+      sites). Second SIGINT raises ``KeyboardInterrupt`` directly as
+      the force-quit escape hatch.
+    - **Idle** (blocked on stdin between prompts, e.g.
+      ``StreamJsonReader``): first SIGINT raises ``KeyboardInterrupt``
+      immediately so the blocking read returns. Cooperative abort
+      would be wrong here — Python 3 PEP 475 auto-retries ``EINTR``'d
+      reads when the handler didn't raise, so a cooperative path
+      would hang the stdin read.
+* Whichever path fired, ``run_headless`` exits 130 (shell parity for
+  SIGINT) and emits a stream-json ``ResultEvent(subtype="cancelled")``.
+  JSON output mode reports ``subtype: "cancelled"``.
+* When the helper runs off the main thread (or on a platform without
+  SIGINT support), the install is a no-op and headless still works.
+"""
+from __future__ import annotations
+
+import io
+import json
+import signal as _signal
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.cli_core import UserInputMessage
+from src.entrypoints import HeadlessOptions, run_headless
+from src.entrypoints import headless as headless_mod
+from src.providers.base import ChatResponse
+from src.utils.abort_controller import AbortController, AbortError
+
+
+class _CancellingProvider:
+    """Provider whose first response triggers a tool-use that raises AbortError."""
+
+    def __init__(self, api_key: str, base_url=None, model=None, *, on_chat=None):
+        self.api_key = api_key
+        self.base_url = base_url
+        self.model = model or "fake-model"
+        self.calls = 0
+        self._on_chat = on_chat
+
+    def chat(self, messages, tools=None, **kwargs):
+        self.calls += 1
+        if self._on_chat is not None:
+            self._on_chat()
+        return ChatResponse(
+            content="",
+            model=self.model,
+            usage={"input_tokens": 1, "output_tokens": 1},
+            finish_reason="tool_use",
+            tool_uses=[{"id": "call_1", "name": "FakeTool", "input": {}}],
+        )
+
+    def chat_stream(self, *_args, **_kwargs):
+        raise NotImplementedError
+
+
+def _patch_provider_only(monkeypatch, *, on_chat=None):
+    """Patch the provider getters and registry with cancelling fakes."""
+
+    from src.tool_system.protocol import ToolResult
+    from src.tool_system.build_tool import build_tool
+
+    def _fake_tool_call(_input, context):
+        # Read the controller from the context so the test can pin
+        # that the wiring is in place (context.abort_controller is what
+        # tools see when they introspect the abort signal).
+        # If the controller is tripped, return an interrupted result;
+        # otherwise, trip it ourselves to simulate the SIGINT firing
+        # mid-tool.
+        if not context.abort_controller.signal.aborted:
+            context.abort_controller.abort("user_interrupt")
+        return ToolResult(name="FakeTool", output={"interrupted": True})
+
+    fake_tool = build_tool(
+        name="FakeTool",
+        input_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        call=_fake_tool_call,
+        prompt=lambda: "test tool",
+        description=lambda _i: "fake",
+    )
+
+    class _Registry:
+        _tools = [fake_tool]
+
+        def list_tools(self):
+            return list(self._tools)
+
+        def dispatch(self, call, context):
+            return _fake_tool_call(call.input, context)
+
+    def _fake_provider_class(provider_name):
+        return lambda api_key, base_url=None, model=None: _CancellingProvider(
+            api_key, base_url, model, on_chat=on_chat
+        )
+
+    monkeypatch.setattr(headless_mod, "get_provider_class", _fake_provider_class)
+    monkeypatch.setattr(
+        headless_mod,
+        "get_provider_config",
+        lambda name: {"api_key": "test-key", "default_model": "fake-model"},
+    )
+    monkeypatch.setattr(headless_mod, "get_default_provider", lambda: "anthropic")
+    monkeypatch.setattr(
+        headless_mod, "build_default_registry", lambda provider=None: _Registry()
+    )
+
+
+def test_headless_mid_tool_cancel_emits_cancelled_result(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A tool that trips the controller mid-dispatch yields exit 130.
+
+    Models the SIGINT-mid-tool path: the user presses Ctrl-C, the
+    signal handler trips the AbortController, and the next safe
+    boundary check in the agent loop unwinds. ``stream-json`` output
+    must include a ``subtype: "cancelled"`` ResultEvent (with
+    ``is_error: False`` — the user cancelled, not the run failed),
+    and the headless return code must be 130 for shell parity. No
+    ``assistant`` event should leak before the result — the partial
+    output is dropped on the cancel path.
+    """
+    _patch_provider_only(monkeypatch)
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    code = run_headless(
+        HeadlessOptions(
+            prompt="kick off a tool",
+            output_format="stream-json",
+            skip_permissions=True,
+            stdout=stdout,
+            stderr=stderr,
+            workspace_root=tmp_path,
+        )
+    )
+
+    assert code == 130
+    lines = [ln for ln in stdout.getvalue().splitlines() if ln.strip()]
+    parsed = [json.loads(ln) for ln in lines]
+    result_events = [p for p in parsed if p.get("type") == "result"]
+    assert len(result_events) == 1
+    assert result_events[0]["subtype"] == "cancelled"
+    assert result_events[0]["is_error"] is False
+    assert "error" not in result_events[0] or not result_events[0]["error"]
+    # No assistant event should leak on the cancel path — the partial
+    # response (if any) is dropped along with the rest of the run state.
+    assert not [p for p in parsed if p.get("type") == "assistant"]
+
+
+def test_headless_json_mode_reports_cancelled_subtype(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``--output-format json`` reports ``subtype: cancelled`` on SIGINT.
+
+    Previously the only non-success exit codes were 1 (error) and 130
+    (KeyboardInterrupt), and the json payload coerced 130 to
+    ``subtype: "success"`` to avoid the error flag — misleading for a
+    user who explicitly cancelled. The new mapping distinguishes the
+    cancellation case so downstream consumers can tell ``success``,
+    ``cancelled``, and ``error`` apart.
+    """
+    _patch_provider_only(monkeypatch)
+
+    stdout = io.StringIO()
+    code = run_headless(
+        HeadlessOptions(
+            prompt="kick off a tool",
+            output_format="json",
+            skip_permissions=True,
+            stdout=stdout,
+            stderr=io.StringIO(),
+            workspace_root=tmp_path,
+        )
+    )
+
+    assert code == 130
+    payload = json.loads(stdout.getvalue().strip())
+    assert payload["subtype"] == "cancelled"
+    # The is_error flag is still False — the user cancelled, this is
+    # not an exceptional condition from the run's perspective.
+    assert payload["is_error"] is False
+
+
+def test_headless_idle_sigint_during_stdin_read_emits_cancelled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """End-to-end: SIGINT during the stream-json stdin read exits cleanly.
+
+    Models the bug the Critic flagged: a Ctrl-C landing while
+    ``StreamJsonReader.__iter__`` is blocked on the next stdin line
+    must produce exit 130 + a ``subtype: "cancelled"`` ResultEvent,
+    not a Python traceback. The idle-mode SIGINT handler raises
+    ``KeyboardInterrupt`` to unblock the read; the for-loop's
+    ``except (AbortError, KeyboardInterrupt)`` then emits the
+    cancelled event in exactly one place.
+
+    Reproduces by patching ``headless_mod.StreamJsonReader`` so the
+    iterator raises ``KeyboardInterrupt`` on its second ``__next__``
+    (after delivering one prompt, blocking on the second — exactly
+    what a SIGINT would cause on a real stdin read).
+    """
+    _patch_provider_only(
+        monkeypatch,
+    )
+
+    class _SigintingReader:
+        """Iterator yielding one input then raising KeyboardInterrupt.
+
+        Models the blocking ``StreamJsonReader.__iter__`` returning
+        normally for the first line and getting interrupted on the
+        second — exactly what the idle-mode SIGINT path produces.
+        """
+
+        def __init__(self, *_args, **_kwargs):
+            self._yielded = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if not self._yielded:
+                self._yielded = True
+                return UserInputMessage(text="first prompt", raw={})
+            # Simulate the idle-mode handler raising while blocked
+            # on the next stdin read.
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(headless_mod, "StreamJsonReader", _SigintingReader)
+
+    # The provider's first turn must NOT use tools — we want the agent
+    # loop to complete cleanly so the cancel comes from the *iterator's*
+    # next step, not from inside the agent loop. A plain text response
+    # achieves that.
+    class _TextOnceProvider:
+        def __init__(self, *_args, **_kwargs):
+            self._consumed = False
+            self.model = "fake-model"
+
+        def chat(self, *_args, **_kwargs):
+            self._consumed = True
+            return ChatResponse(
+                content="ok",
+                model="fake-model",
+                usage={"input_tokens": 1, "output_tokens": 1},
+                finish_reason="end_turn",
+                tool_uses=None,
+            )
+
+        def chat_stream(self, *_args, **_kwargs):
+            raise NotImplementedError
+
+    monkeypatch.setattr(
+        headless_mod, "get_provider_class", lambda _name: _TextOnceProvider
+    )
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    code = run_headless(
+        HeadlessOptions(
+            prompt=None,
+            input_format="stream-json",
+            output_format="stream-json",
+            skip_permissions=True,
+            stdin=io.StringIO(),  # unused — our patched reader ignores it
+            stdout=stdout,
+            stderr=stderr,
+            workspace_root=tmp_path,
+        )
+    )
+
+    assert code == 130, f"expected exit 130, got {code}; stdout: {stdout.getvalue()}"
+    lines = [ln for ln in stdout.getvalue().splitlines() if ln.strip()]
+    parsed = [json.loads(ln) for ln in lines]
+    result_events = [p for p in parsed if p.get("type") == "result"]
+    assert len(result_events) == 1
+    assert result_events[0]["subtype"] == "cancelled"
+    assert result_events[0]["is_error"] is False
+    # The first prompt's assistant reply IS emitted — it completed
+    # before the cancel landed. Pin that: cancellation must not erase
+    # already-shipped work, only short-circuit further iteration.
+    assistant_events = [p for p in parsed if p.get("type") == "assistant"]
+    assert len(assistant_events) == 1
+    assert assistant_events[0]["text"] == "ok"
+
+
+def test_install_sigint_handler_in_loop_two_strike() -> None:
+    """Cooperative mode: first strike trips controller, second raises.
+
+    With ``in_agent_loop.value == True`` (the agent loop is in flight),
+    the first SIGINT cooperatively trips the controller so abort-aware
+    sites can unwind gracefully. The second SIGINT is the force-quit
+    escape hatch: it raises ``KeyboardInterrupt`` directly and also
+    re-installs the platform default handler as defense in depth — a
+    rare third strike landing during unwind then terminates the process
+    via SIGINT's default action rather than re-entering our handler.
+    """
+    controller = AbortController()
+    in_loop = headless_mod._InAgentLoopFlag()
+    in_loop.value = True
+    stderr = io.StringIO()
+
+    # Capture the previous handler so we can restore at the end.
+    previous = _signal.getsignal(_signal.SIGINT)
+    try:
+        restore = headless_mod._install_sigint_handler(controller, in_loop, stderr)
+
+        # Look up the installed handler and simulate signal delivery.
+        installed = _signal.getsignal(_signal.SIGINT)
+        assert callable(installed)
+        assert installed is not previous  # actually installed something
+
+        # First strike: trip the controller, no raise.
+        installed(_signal.SIGINT, None)
+        assert controller.signal.aborted is True
+        assert controller.signal.reason == "user_interrupt"
+        assert "Cancelling" in stderr.getvalue()
+
+        # Second strike: must raise KeyboardInterrupt as the force-
+        # quit escape hatch. The handler also restores the default
+        # SIGINT handler so a third hit terminates the process the
+        # ordinary way.
+        with pytest.raises(KeyboardInterrupt):
+            installed(_signal.SIGINT, None)
+
+        restore()
+    finally:
+        # Defensive: ensure we don't leak our handler to other tests.
+        _signal.signal(_signal.SIGINT, previous)
+
+
+def test_install_sigint_handler_idle_raises_immediately() -> None:
+    """Idle mode: first strike raises so blocking stdin reads return.
+
+    When ``in_agent_loop.value == False`` (between agent-loop runs, e.g.
+    blocked on ``StreamJsonReader``'s stdin read for the next input),
+    a cooperative abort would be a UX regression: Python 3 PEP 475
+    auto-retries ``EINTR``-interrupted reads when the signal handler
+    didn't raise, so the read would keep blocking and the user would
+    have to hit Ctrl-C twice to exit. Idle-mode SIGINT must raise
+    ``KeyboardInterrupt`` directly to make the read return.
+    """
+    controller = AbortController()
+    in_loop = headless_mod._InAgentLoopFlag()
+    in_loop.value = False  # idle on stdin
+    stderr = io.StringIO()
+
+    previous = _signal.getsignal(_signal.SIGINT)
+    try:
+        restore = headless_mod._install_sigint_handler(controller, in_loop, stderr)
+        installed = _signal.getsignal(_signal.SIGINT)
+
+        # First strike while idle must raise, not just trip the controller.
+        with pytest.raises(KeyboardInterrupt):
+            installed(_signal.SIGINT, None)
+        # The controller is NOT cooperatively tripped on idle — there's
+        # nothing to cooperatively unwind; we just exit the process.
+        assert controller.signal.aborted is False
+
+        restore()
+    finally:
+        _signal.signal(_signal.SIGINT, previous)
+
+
+def test_install_sigint_handler_off_main_thread_is_noop() -> None:
+    """Calling the installer from a worker thread is a safe no-op.
+
+    ``signal.signal()`` only works in the main thread of the main
+    interpreter. An SDK consumer that drives ``run_headless`` from a
+    worker thread (or an embedded interpreter that disables signals)
+    must not crash on install — cancellation falls back to the agent
+    loop's natural turn-boundary checks, which is the pre-fix behaviour.
+    """
+    controller = AbortController()
+    in_loop = headless_mod._InAgentLoopFlag()
+    stderr = io.StringIO()
+    result: dict[str, object] = {}
+
+    def _thread_body() -> None:
+        try:
+            restore = headless_mod._install_sigint_handler(
+                controller, in_loop, stderr
+            )
+            result["restore_callable"] = callable(restore)
+            # Restore is a no-op when install was skipped; call it
+            # anyway and ensure it doesn't raise.
+            restore()
+            result["restored_cleanly"] = True
+        except Exception as exc:  # pragma: no cover — failure path
+            result["error"] = exc
+
+    t = threading.Thread(target=_thread_body)
+    t.start()
+    t.join(timeout=5.0)
+    assert not t.is_alive(), "install_sigint_handler hung on a worker thread"
+    assert "error" not in result, f"install raised on a worker thread: {result.get('error')}"
+    assert result.get("restore_callable") is True
+    assert result.get("restored_cleanly") is True
+    # The controller must still be untripped — there's no signal to deliver.
+    assert controller.signal.aborted is False


### PR DESCRIPTION
## Summary
- Adds the headless equivalent of PR #135: Ctrl-C mid-tool now actually unwinds Bash subprocesses and Agent subagents instead of waiting minutes for the next safe Python bytecode boundary
- Context-aware SIGINT handler: **idle** (blocked on stream-json stdin) raises immediately so the read returns; **in-flight** trips the controller cooperatively, with a second-strike force-quit escape hatch
- New `subtype: "cancelled"` for JSON output mode replaces the misleading `subtype: "success"` that exit 130 used to map to

## Why
PR #135 fixed ESC propagation into subagents for the TUI. The Critic flagged that headless had the same conceptual gap under SIGINT — `clawcodex -p "..."` users hitting Ctrl-C on a long-running bash or subagent had to wait for the next turn boundary. This PR closes that gap.

## Changes
- **`src/entrypoints/headless.py`**:
  - Construct an `AbortController` per session, pass to `ToolContext(abort_controller=...)`, pass `cancel_signal=...` to `run_agent_loop`
  - New `_InAgentLoopFlag` class — a tiny mutable shared boolean read by the SIGINT handler to decide between idle (raise immediately) and in-flight (cooperative) modes
  - New `_install_sigint_handler()` helper installs the context-aware handler; returns a restore callable that runs in `finally` so embedders don't lose their pre-existing handler. Off-main-thread (`ValueError`) and SIGINT-unsupported platforms (`OSError`) gracefully degrade to a no-op
  - Restructured the main loop with a single `except (AbortError, KeyboardInterrupt)` wrapping the entire for-loop — every cancellation point (idle iterator step, in-flight cooperative `AbortError`, in-flight force-quit `KeyboardInterrupt`) lands at one chokepoint that emits one `ResultEvent(subtype="cancelled")` and exits 130
  - JSON output `subtype` mapping: `0 → "success"`, `130 → "cancelled"`, else `"error"` (previously `0/130 → "success"`)

- **`tests/test_headless_sigint.py`** (new) — 6 regression tests:
  - `test_headless_mid_tool_cancel_emits_cancelled_result` — end-to-end mid-tool cancel via stream-json
  - `test_headless_json_mode_reports_cancelled_subtype` — JSON mode reports `subtype: "cancelled"` with `is_error: False`
  - `test_headless_idle_sigint_during_stdin_read_emits_cancelled` — end-to-end: SIGINT during `StreamJsonReader.__next__()` produces exit 130 + cancelled event (Critic verified this is load-bearing by sabotaging the outer catch)
  - `test_install_sigint_handler_in_loop_two_strike` — handler-level: first strike trips controller, second raises KeyboardInterrupt
  - `test_install_sigint_handler_idle_raises_immediately` — handler-level: idle-mode first strike raises directly without tripping the controller (PEP 475 rationale)
  - `test_install_sigint_handler_off_main_thread_is_noop` — install from worker thread returns a no-op restore without raising

## Test plan
- [x] 16 headless tests pass (10 pre-existing + 6 new)
- [x] 154 directly related tests pass
- [x] 4394 broader related tests pass
- [x] Critic subagent review: APPROVE (after two iterations — caught a real bug in v1 where idle-mode `KeyboardInterrupt` escaped uncaught, fixed in v2)
- [ ] Manual: `clawcodex -p "run a 30s bash sleep then say hi"` + Ctrl-C → exit within ~1s with `subtype: "cancelled"` instead of waiting for the sleep to finish

## Dependencies
- Stacked on **#137** (which is stacked on #135). Once #135 + #137 land on main, rebase this onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)