### PR TITLE
fix(read): remove buggy MIME check, add image branch (TS parity)

### DIFF
--- a/src/tool_system/tools/read.py
+++ b/src/tool_system/tools/read.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import base64 as _base64
 import json as _json
 import os
-import mimetypes
 from pathlib import Path
 from typing import Any
 
@@ -110,6 +110,20 @@ _BINARY_EXTENSION_EXEMPTIONS = frozenset([".pdf", ".svg"])
 
 # Image extensions this tool can render natively.
 IMAGE_EXTENSIONS = frozenset(["png", "jpg", "jpeg", "gif", "webp"])
+
+# Map image extension -> API media_type. jpg/jpeg both → image/jpeg.
+IMAGE_MIME_TYPES = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "webp": "image/webp",
+}
+
+# Cap raw image read at 3.75 MB so the base64 payload stays under Anthropic's
+# 5 MB API image limit (base64 inflates by 4/3). Mirrors TS IMAGE_TARGET_RAW_SIZE
+# in typescript/src/constants/apiLimits.ts.
+MAX_IMAGE_SIZE_BYTES = (5 * 1024 * 1024 * 3) // 4
 
 
 def _has_blocked_binary_extension(file_path: str) -> bool:
@@ -334,22 +348,40 @@ def _read_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
             },
         )
 
-    # --- Binary detection (MIME-based fallback for extensions not in the set) ---
-    mime, _ = mimetypes.guess_type(str(path))
-    is_binary = mime is not None and not mime.startswith("text/") and mime not in {
-        "application/json",
-        "application/xml",
-        "application/javascript",
-        "application/x-sh",
-        "application/x-python",
-        "application/toml",
-        "application/yaml",
-    }
-
-    if is_binary:
-        raise ToolInputError(
-            f"This tool cannot read binary files. The file '{path.name}' appears to be "
-            f"a binary file ({mime}). Please use appropriate tools for binary file analysis."
+    # --- Image ---
+    # Mirrors TS FileReadTool.ts: image extensions exempted from the binary
+    # blocklist are routed to the image reader here. Without this branch,
+    # IMAGE_EXTENSIONS files would fall through to the text reader and return
+    # garbage (UTF-8 replacement chars).
+    #
+    # NOTE: deliberately does NOT call context.mark_file_read(). The dedup
+    # path at lines 293-305 would otherwise replay subsequent image reads as
+    # a text "file_unchanged" stub, silently dropping the image content from
+    # the model's view. TS excludes images and PDFs from readFileState for
+    # the same reason -- see FileReadTool.ts:528-529.
+    ext_no_dot = suffix.lstrip(".")
+    if ext_no_dot in IMAGE_EXTENSIONS:
+        if stat.st_size == 0:
+            raise ToolInputError(f"Image file is empty: {path}")
+        if stat.st_size > MAX_IMAGE_SIZE_BYTES:
+            raise ToolInputError(
+                f"Image file ({stat.st_size:,} bytes) exceeds maximum allowed size "
+                f"({MAX_IMAGE_SIZE_BYTES:,} bytes). The Anthropic API rejects "
+                f"images whose base64 payload exceeds 5 MB."
+            )
+        img_bytes = path.read_bytes()
+        b64 = _base64.b64encode(img_bytes).decode("ascii")
+        return ToolResult(
+            name="Read",
+            output={
+                "type": "image",
+                "file": {
+                    "filePath": str(path),
+                    "base64": b64,
+                    "type": IMAGE_MIME_TYPES[ext_no_dot],
+                    "originalSize": stat.st_size,
+                },
+            },
         )
 
     # --- File size pre-check (prevents reading multi-GB files into memory) ---
@@ -454,6 +486,27 @@ def _read_map_result_to_api(output: Any, tool_use_id: str) -> dict[str, Any]:
                 "type": "tool_result",
                 "tool_use_id": tool_use_id,
                 "content": f"PDF file read: {file_path} ({size:,} bytes)",
+            }
+
+        if result_type == "image":
+            # _read_call always populates base64+type from IMAGE_MIME_TYPES; if
+            # they're missing here the producer is buggy and we want a loud
+            # KeyError rather than a silently mislabeled image (e.g. JPEG bytes
+            # tagged as PNG would be rejected by the API with a confusing error).
+            file_data = output["file"]
+            return {
+                "type": "tool_result",
+                "tool_use_id": tool_use_id,
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "data": file_data["base64"],
+                            "media_type": file_data["type"],
+                        },
+                    },
+                ],
             }
 
     # Fallback: serialize anything else

--- a/tests/parity/test_e2e_file_read.py
+++ b/tests/parity/test_e2e_file_read.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from src.tool_system.context import ToolContext
 from src.tool_system.defaults import build_default_registry
-from src.tool_system.errors import ToolPermissionError
+from src.tool_system.errors import ToolInputError, ToolPermissionError
 from src.tool_system.protocol import ToolCall
 
 
@@ -112,6 +112,161 @@ class TestE2EFileRead(unittest.TestCase):
         tool = self.registry.get("Read")
         self.assertIsNotNone(tool)
         self.assertTrue(tool.is_read_only({"file_path": str(self.test_file)}))
+
+    # ---- Binary handling regression tests (parity with TS FileReadTool) ----
+
+    def test_read_svg_file_as_text(self) -> None:
+        """SVG must read as text. Regression: mimetypes.guess_type('foo.svg')
+        returns 'image/svg+xml', which the old MIME fallback wrongly treated as
+        binary. TS FileReadTool has no MIME check and reads SVG as text."""
+        svg = self.root / "favicon.svg"
+        svg.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg"><circle r="5"/></svg>'
+        )
+        result = self.registry.dispatch(
+            ToolCall(name="Read", input={"file_path": str(svg)}),
+            self.ctx,
+        )
+        self.assertFalse(result.is_error)
+        self.assertEqual(result.output["type"], "text")
+        self.assertIn("<svg", result.output["file"]["content"])
+
+    def test_read_rust_file_as_text(self) -> None:
+        """Rust .rs must read as text. Regression: mimetypes.guess_type('foo.rs')
+        returns 'application/rls-services+xml' on Python's default db, which the
+        old MIME fallback wrongly treated as binary."""
+        rs = self.root / "main.rs"
+        rs.write_text('fn main() { println!("hi"); }\n')
+        result = self.registry.dispatch(
+            ToolCall(name="Read", input={"file_path": str(rs)}),
+            self.ctx,
+        )
+        self.assertFalse(result.is_error)
+        self.assertEqual(result.output["type"], "text")
+        self.assertIn("fn main", result.output["file"]["content"])
+
+    def test_read_png_returns_image_block(self) -> None:
+        """PNG reads as image content. Mirrors TS callInner's image branch."""
+        import base64
+        png_bytes = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR" + b"\x00" * 100
+        png = self.root / "test.png"
+        png.write_bytes(png_bytes)
+        result = self.registry.dispatch(
+            ToolCall(name="Read", input={"file_path": str(png)}),
+            self.ctx,
+        )
+        self.assertFalse(result.is_error)
+        self.assertEqual(result.output["type"], "image")
+        self.assertEqual(result.output["file"]["type"], "image/png")
+        self.assertEqual(
+            base64.b64decode(result.output["file"]["base64"]),
+            png_bytes,
+        )
+        self.assertEqual(result.output["file"]["originalSize"], len(png_bytes))
+
+    def test_read_jpg_returns_image_block(self) -> None:
+        """JPG maps to image/jpeg (not image/jpg). Same for .jpeg."""
+        jpg = self.root / "photo.jpg"
+        jpg.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 50)
+        result = self.registry.dispatch(
+            ToolCall(name="Read", input={"file_path": str(jpg)}),
+            self.ctx,
+        )
+        self.assertFalse(result.is_error)
+        self.assertEqual(result.output["type"], "image")
+        self.assertEqual(result.output["file"]["type"], "image/jpeg")
+
+        jpeg = self.root / "photo.jpeg"
+        jpeg.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 50)
+        result2 = self.registry.dispatch(
+            ToolCall(name="Read", input={"file_path": str(jpeg)}),
+            self.ctx,
+        )
+        self.assertFalse(result2.is_error)
+        self.assertEqual(result2.output["file"]["type"], "image/jpeg")
+
+    def test_read_oversized_image_rejected(self) -> None:
+        """Image > 3.75 MB (TS IMAGE_TARGET_RAW_SIZE) must be rejected so the
+        base64 payload stays under Anthropic's 5 MB API image limit."""
+        from src.tool_system.tools.read import MAX_IMAGE_SIZE_BYTES
+        big = self.root / "huge.png"
+        big.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * (MAX_IMAGE_SIZE_BYTES + 1))
+        with self.assertRaises(ToolInputError) as cm:
+            self.registry.dispatch(
+                ToolCall(name="Read", input={"file_path": str(big)}),
+                self.ctx,
+            )
+        self.assertIn("exceeds maximum", str(cm.exception).lower())
+
+    def test_read_exe_still_blocked(self) -> None:
+        """The extension blocklist still rejects truly binary files after the
+        MIME-check removal. Guards against the cleanup loosening the gate."""
+        exe = self.root / "evil.exe"
+        exe.write_bytes(b"MZ\x90\x00" + b"\x00" * 50)
+        with self.assertRaises(ToolInputError) as cm:
+            self.registry.dispatch(
+                ToolCall(name="Read", input={"file_path": str(exe)}),
+                self.ctx,
+            )
+        self.assertIn("binary", str(cm.exception).lower())
+
+    def test_read_png_twice_returns_image_both_times(self) -> None:
+        """Re-reading the same image must NOT collapse to a file_unchanged
+        text stub. Regression: the image branch must skip mark_file_read so
+        dedup at _read_call lines 293-305 never matches. TS skips images in
+        readFileState for the same reason (FileReadTool.ts:528-529)."""
+        png = self.root / "stable.png"
+        png.write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR" + b"\x00" * 50)
+        r1 = self.registry.dispatch(
+            ToolCall(name="Read", input={"file_path": str(png)}),
+            self.ctx,
+        )
+        r2 = self.registry.dispatch(
+            ToolCall(name="Read", input={"file_path": str(png)}),
+            self.ctx,
+        )
+        self.assertEqual(r1.output["type"], "image")
+        self.assertEqual(r2.output["type"], "image")
+        self.assertEqual(r1.output["file"]["base64"], r2.output["file"]["base64"])
+
+    def test_read_empty_image_rejected(self) -> None:
+        """An empty image file must raise rather than silently emit an empty
+        base64 string (which the API would reject confusingly). Mirrors TS
+        FileReadTool.ts:1112-1114 'Image file is empty: ${filePath}'."""
+        empty = self.root / "empty.png"
+        empty.write_bytes(b"")
+        with self.assertRaises(ToolInputError) as cm:
+            self.registry.dispatch(
+                ToolCall(name="Read", input={"file_path": str(empty)}),
+                self.ctx,
+            )
+        self.assertIn("empty", str(cm.exception).lower())
+
+    def test_image_api_mapping(self) -> None:
+        """_read_map_result_to_api emits an image content block for type=image,
+        matching TS FileReadTool.ts mapToolResultToToolResultBlockParam."""
+        from src.tool_system.tools.read import _read_map_result_to_api
+        mapped = _read_map_result_to_api(
+            {
+                "type": "image",
+                "file": {
+                    "filePath": "/tmp/x.png",
+                    "base64": "ABCD",
+                    "type": "image/png",
+                    "originalSize": 100,
+                },
+            },
+            "tu_123",
+        )
+        self.assertEqual(mapped["type"], "tool_result")
+        self.assertEqual(mapped["tool_use_id"], "tu_123")
+        self.assertIsInstance(mapped["content"], list)
+        self.assertEqual(len(mapped["content"]), 1)
+        block = mapped["content"][0]
+        self.assertEqual(block["type"], "image")
+        self.assertEqual(block["source"]["type"], "base64")
+        self.assertEqual(block["source"]["data"], "ABCD")
+        self.assertEqual(block["source"]["media_type"], "image/png")
 
 
 class TestE2EGlobGrep(unittest.TestCase):


### PR DESCRIPTION
## Summary

- **Removes the `mimetypes.guess_type()` fallback** in `src/tool_system/tools/read.py` that wrongly rejected SVG, Rust `.rs`, and other text files whose MIME type doesn't start with `text/`. TypeScript `FileReadTool` has no such check; only the extension-based `hasBinaryExtension` gate exists. The fallback also masked the image-handling gap by rejecting PNG/JPG with a "binary file" message.
- **Adds an image-handling branch** mirroring TS (`typescript/src/tools/FileReadTool/FileReadTool.ts:868-894, 654-668`): base64-encodes and returns `type='image'` with a 3.75 MB raw-size cap matching TS `IMAGE_TARGET_RAW_SIZE` (keeps the base64 payload under the API's 5 MB image limit). Skips `context.mark_file_read()` so re-reads aren't collapsed into a text `file_unchanged` stub — TS skips images in `readFileState` for the same reason. Empty images raise instead of silently emitting empty base64. Result mapper uses bracket access so a buggy producer fails loudly rather than mislabeling MIME.
- **9 regression tests** in `tests/parity/test_e2e_file_read.py`.

## Why

The agent's screen log showed it falling back to `cat trump-blog/public/favicon.svg` via Bash — because `Read` had refused with a misleading "binary file (image/svg+xml)" error. Empirically reproduced: pre-fix Python rejected `.svg`, `.rs`, `.png`, `.jpg`; post-fix all four work as TS does (`.svg`/`.rs` as text, `.png`/`.jpg` as image content blocks).

## Test plan

- [x] `uv run pytest tests/parity/test_e2e_file_read.py -v` — 20 passed, 1 pre-existing failure (`test_read_outside_workspace_blocked`, broken by commit `8d0f253` introducing `bypassPermissions` as the default `ToolContext` permission mode; confirmed identical on unmodified codebase, not caused by this PR).
- [x] Wider `uv run pytest tests/parity/` — 362 pass.
- [x] Manually reproduced bug pre-fix (SVG rejected) and confirmed fix (SVG reads as text, PNG returns image block).
- [x] Critic review loop completed with APPROVE after one round of feedback (fixed: dedup-on-image, empty-image rejection, loud-failure mapper).

## Out of scope

- Image compression/resize and the `sharp`-backed token-budget path in TS (separate effort, depends on Pillow + token-budget infra we don't have).
- The line-prefix format difference (TS `   N→` vs Python `N\t`) — cosmetic, doesn't affect binary handling.
- The pre-existing `test_read_outside_workspace_blocked` failure — separate `bypassPermissions`-default issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)