### PR TITLE
fix(bash): distinguish timeout from ESC-abort in tool_result

### DIFF
--- a/src/tool_system/tools/bash/bash_tool.py
+++ b/src/tool_system/tools/bash/bash_tool.py
@@ -20,10 +20,13 @@ from typing import Any
 # while costing ~20 wakeups/sec for a long-running command — negligible.
 _ABORT_POLL_INTERVAL_S = 0.05
 
-# Grace period between SIGTERM and SIGKILL after an abort. Lets the
-# subprocess flush stdio + run cleanup handlers (TS ShellCommand grants
-# a similar window via ``tree-kill``).
-_KILL_GRACE_S = 2.0
+# Bound on how long we wait for the kernel to reap a SIGKILL'd process
+# before falling through to drain pipes via ``communicate()``. SIGKILL
+# itself is uncatchable; a non-trivial wait here only happens when the
+# child is stuck in an uninterruptible kernel wait (e.g. an NFS mount
+# that lost the server). Mirrors the spirit of TS's ``tree-kill`` reap
+# in that we bound the post-kill drain, not the pre-kill grace.
+_KILL_REAP_TIMEOUT_S = 2.0
 
 
 @dataclass
@@ -105,26 +108,35 @@ def _run_bash_with_abort(
             interrupted = True
             break
         if _time_mod.monotonic() >= deadline:
-            interrupted = True
             timed_out = True
             break
         _time_mod.sleep(_ABORT_POLL_INTERVAL_S)
 
-    if interrupted:
-        _kill_process_group(proc.pid, _signal_mod.SIGTERM)
+    # Mirrors TS ``ShellCommand.ts:337-343`` (``#doKill``): both the
+    # abort and timeout paths actually call ``treeKill(pid, 'SIGKILL')``
+    # — the SIGTERM passed into ``#doKill(SIGTERM)`` from the timeout
+    # handler is a *label* used downstream by ``#handleExit`` to choose
+    # the stderr prefix, not the signal actually sent. Send SIGKILL
+    # immediately in both cases for byte-for-byte parity and to keep
+    # ESC latency under the ~50ms target tracked by PR #130.
+    # ``interrupted`` / ``timed_out`` are the source-of-truth
+    # discriminator for downstream callers; the exit-code label is
+    # rewritten in ``_bash_call``.
+    if interrupted or timed_out:
+        _kill_process_group(proc.pid, _signal_mod.SIGKILL)
         try:
-            proc.wait(timeout=_KILL_GRACE_S)
+            proc.wait(timeout=_KILL_REAP_TIMEOUT_S)
         except subprocess.TimeoutExpired:
-            _kill_process_group(proc.pid, _signal_mod.SIGKILL)
-            try:
-                proc.wait(timeout=_KILL_GRACE_S)
-            except subprocess.TimeoutExpired:
-                pass
+            # SIGKILL is uncatchable, so this only happens when the
+            # process is in an uninterruptible kernel wait (e.g. stuck
+            # on an NFS mount). Nothing more we can do — fall through
+            # to ``communicate()`` to drain whatever pipes are open.
+            pass
 
     # ``communicate()`` after a kill is safe and gathers any pending
     # output that buffered before the signal landed.
     try:
-        stdout, stderr = proc.communicate(timeout=_KILL_GRACE_S)
+        stdout, stderr = proc.communicate(timeout=_KILL_REAP_TIMEOUT_S)
     except subprocess.TimeoutExpired:
         stdout, stderr = "", ""
 
@@ -153,6 +165,7 @@ from ...errors import ToolInputError, ToolPermissionError
 from ...protocol import ToolResult
 from src.permissions.bash_security import check_bash_command_safety
 from src.permissions.types import PermissionPassthroughResult, PermissionResult
+from src.utils.format import format_duration
 
 from .background import spawn_background_bash
 from .command_semantics import interpret_command_result
@@ -322,20 +335,68 @@ def _bash_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
         )
 
         if run_result.interrupted:
+            # ESC-abort path. Mirrors TS ``BashTool.tsx:610-630`` where
+            # ``interrupted=true`` triggers the ``<error>Command was
+            # aborted before completion</error>`` appendage and sets
+            # ``is_error=true`` on the API block.
             return ToolResult(
                 name=BASH_TOOL_NAME,
                 output={
                     "cwd": str(cwd),
                     "exit_code": -1,
                     "stdout": truncate_output(run_result.stdout or ""),
-                    "stderr": (
-                        truncate_output(run_result.stderr or "")
-                        if not run_result.timed_out
-                        else f"Command timed out after {timeout_s} seconds"
-                    ),
+                    "stderr": truncate_output(run_result.stderr or ""),
                     "interrupted": True,
                 },
                 is_error=True,
+            )
+
+        if run_result.timed_out:
+            # Timeout path. Mirrors TS ``ShellCommand.ts:323-328``:
+            # prepend the duration marker to whatever stderr was
+            # captured, leave ``interrupted=false``, and let
+            # ``_bash_map_result_to_api`` emit ``is_error=false`` — the
+            # duration string in stderr is the model-facing signal, the
+            # ``<error>`` tag is reserved for user-initiated abort.
+            # Without this split the timeout case looked identical to
+            # ESC and the model retried timed-out commands on resume.
+            #
+            # Formatting parity:
+            #   * ``format_duration`` is the Python port of TS
+            #     ``formatDuration`` (src/utils/format.py mirrors
+            #     typescript/src/utils/format.ts:34-95). It produces
+            #     ``30s`` / ``2m 0s`` / ``1h 5m 12s`` — exactly the
+            #     string TS embeds in the marker. ``timeout_s * 1000``
+            #     converts to ms because ``format_duration`` and the
+            #     TS reference both take ms.
+            #   * ``prepend_stderr`` mirrors TS ``ShellCommand.ts:56-58``
+            #     — a SINGLE SPACE separator (not newline), and the
+            #     existing stderr is passed through unmodified so a
+            #     trailing newline or leading whitespace the model
+            #     might use as a delimiter survives the prepend.
+            #   * ``exit_code = 143`` mirrors TS ``ShellCommand.ts:50``
+            #     (``SIGTERM = 143``) — the label for the timeout path,
+            #     decoupled from whatever signal Popen actually reports
+            #     (which would be ``-9`` on Unix after our SIGKILL).
+            existing_stderr = run_result.stderr or ""
+            timeout_marker = (
+                f"Command timed out after {format_duration(timeout_s * 1000)}"
+            )
+            stderr_with_marker = (
+                f"{timeout_marker} {existing_stderr}"
+                if existing_stderr
+                else timeout_marker
+            )
+            return ToolResult(
+                name=BASH_TOOL_NAME,
+                output={
+                    "cwd": str(cwd),
+                    "exit_code": 143,
+                    "stdout": truncate_output(run_result.stdout or ""),
+                    "stderr": truncate_output(stderr_with_marker),
+                    "timed_out": True,
+                },
+                is_error=False,
             )
 
         completed_returncode = run_result.returncode

--- a/tests/test_bash_timeout_vs_esc.py
+++ b/tests/test_bash_timeout_vs_esc.py
@@ -1,0 +1,248 @@
+"""Regression tests for bash timeout vs ESC-cancel distinction.
+
+Before this fix, the Python bash supervisor (``_run_bash_with_abort``)
+set ``interrupted=True`` on BOTH ESC-abort and timeout. The two paths
+then collapsed into one tool_result shape:
+
+* content ends with ``<error>Command was aborted before completion</error>``
+* ``is_error: True``
+
+The TS reference at ``typescript/src/utils/ShellCommand.ts:135-141, 302,
+323-328`` and ``typescript/src/tools/BashTool/BashTool.tsx:610-630``
+deliberately keeps the two paths distinct:
+
+* **ESC abort**: SIGKILL → exit code 137 → ``interrupted=true`` →
+  ``is_error=true`` → ``<error>Command was aborted before completion</error>``
+* **Timeout**: SIGTERM → exit code 143 → ``interrupted=false`` →
+  ``is_error=false`` → stderr is prepended with
+  ``"Command timed out after <duration>"`` and the ``<error>`` tag is NOT
+  added.
+
+Why the asymmetry: ``is_error=true`` is a Claude API signal that the
+tool failed. ESC is a user-initiated rejection so the model should not
+retry. Timeout is a non-fatal runtime condition; the model reads the
+duration marker in stderr and decides whether to retry with a longer
+timeout, change the approach, or give up — the ``<error>`` tag would
+falsely promote a timeout to a tool failure.
+
+These tests pin the parity at three layers:
+
+1. ``_run_bash_with_abort`` returns ``interrupted=False, timed_out=True``
+   on timeout (and the converse on ESC).
+2. ``_bash_call`` produces distinct ToolResult shapes for the two cases.
+3. ``_bash_map_result_to_api`` only emits the ``<error>`` tag and
+   ``is_error=True`` for the ESC path.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+from src.tool_system.context import ToolContext
+from src.tool_system.tools.bash.bash_tool import (
+    BASH_TOOL_NAME,
+    _bash_map_result_to_api,
+    _run_bash_with_abort,
+)
+from src.utils.abort_controller import AbortController
+
+
+def test_run_bash_with_abort_sets_only_timed_out_on_timeout(tmp_path: Path) -> None:
+    """Pure supervisor test: a command that exceeds ``timeout_s`` returns
+    ``interrupted=False`` and ``timed_out=True``. Mirrors TS where the
+    timeout path is labelled with the SIGTERM exit code (143) while
+    ``interrupted`` is reserved for the SIGKILL/ESC path.
+    """
+    start = time.monotonic()
+    result = _run_bash_with_abort(
+        ["bash", "-lc", "sleep 3; echo done"],
+        cwd=str(tmp_path),
+        timeout_s=1,
+        abort_signal=None,
+    )
+    elapsed = time.monotonic() - start
+
+    assert result.timed_out is True
+    assert result.interrupted is False, (
+        "timeout must NOT set interrupted=True — TS distinguishes the two via "
+        "the result-label exit code (SIGKILL=137 for ESC, SIGTERM=143 for "
+        "timeout). Conflating them makes the model treat timed-out commands "
+        "as user-cancelled and retry them on resume."
+    )
+    # Sanity: SIGKILL takes effect near-instantly; the timeout deadline
+    # is 1s + at most one ``_ABORT_POLL_INTERVAL_S`` (50ms) jitter.
+    assert elapsed < 3.0, (
+        f"timeout supervisor should have killed the process well under "
+        f"the 3s sleep, took {elapsed:.2f}s"
+    )
+
+
+def test_run_bash_with_abort_sets_only_interrupted_on_esc(tmp_path: Path) -> None:
+    """Pure supervisor test: when the abort signal fires, the result must
+    be ``interrupted=True`` and ``timed_out=False`` regardless of how long
+    the command would have taken. Mirrors TS where the abort path is
+    labelled with SIGKILL=137.
+    """
+    ctrl = AbortController()
+
+    def _trip_abort() -> None:
+        # Give the subprocess time to actually start before we trip the
+        # abort. 100ms is well within the supervisor's poll cadence and
+        # the OS process-launch window on any reasonable host.
+        time.sleep(0.1)
+        ctrl.abort("user_interrupt")
+
+    threading.Thread(target=_trip_abort, daemon=True).start()
+
+    result = _run_bash_with_abort(
+        ["bash", "-lc", "sleep 3; echo done"],
+        cwd=str(tmp_path),
+        timeout_s=30,  # well above the abort time
+        abort_signal=ctrl.signal,
+    )
+
+    assert result.interrupted is True
+    assert result.timed_out is False
+
+
+def test_bash_map_result_to_api_timeout_emits_no_error_tag(tmp_path: Path) -> None:
+    """Tool-result mapping: a timeout payload (``timed_out=True``, no
+    ``interrupted`` key) must produce ``is_error=False`` and MUST NOT
+    append ``<error>Command was aborted before completion</error>`` to
+    the content. The stderr-embedded duration marker is the only
+    model-facing signal — mirrors TS at
+    ``BashTool.tsx:610-630`` where ``is_error: interrupted`` is the
+    sole gate.
+    """
+    # The stderr string here uses ``format_duration``-style markup
+    # (``30s``, not ``30 seconds``) — matches what ``_bash_call`` actually
+    # writes when it composes the timeout payload via
+    # ``src/utils/format.py:format_duration``.
+    output = {
+        "cwd": str(tmp_path),
+        "exit_code": 143,
+        "stdout": "partial\n",
+        "stderr": "Command timed out after 30s",
+        "timed_out": True,
+    }
+    block = _bash_map_result_to_api(output, "call_t")
+
+    assert block["is_error"] is False, (
+        "timeout must NOT set is_error=True — the Claude API treats "
+        "is_error=true as a hard tool failure signal that encourages the "
+        "model to retry; for a timeout the duration marker is the signal."
+    )
+    assert "Command timed out after 30s" in block["content"]
+    assert (
+        "<error>Command was aborted before completion</error>"
+        not in block["content"]
+    ), (
+        "the ``<error>`` tag is reserved for user-initiated abort (ESC). "
+        "Emitting it on timeout collapses the two cases together and makes "
+        "the model misread timeouts as user cancellations."
+    )
+
+
+def test_bash_map_result_to_api_esc_emits_error_tag(tmp_path: Path) -> None:
+    """Tool-result mapping: an ESC payload (``interrupted=True``) must
+    produce ``is_error=True`` AND append the ``<error>`` tag — preserves
+    the existing ESC behavior the REJECT_MESSAGE override in
+    ``_dispatch_single_tool`` relies on as a fallback.
+    """
+    output = {
+        "cwd": str(tmp_path),
+        "exit_code": -1,
+        "stdout": "",
+        "stderr": "",
+        "interrupted": True,
+    }
+    block = _bash_map_result_to_api(output, "call_e")
+
+    assert block["is_error"] is True
+    assert (
+        "<error>Command was aborted before completion</error>" in block["content"]
+    )
+
+
+def test_bash_call_timeout_payload_shape(tmp_path: Path) -> None:
+    """End-to-end ``_bash_call`` test: a command that times out produces
+    a ToolResult with ``is_error=False``, the stderr prepended with the
+    timeout marker, and the output dict carries ``timed_out=True`` and
+    NO ``interrupted`` key. This is the contract the model-facing
+    mapping relies on. Duration marker uses ``format_duration`` so the
+    1-second timeout renders as ``1s`` (TS parity).
+    """
+    from src.tool_system.tools.bash.bash_tool import _bash_call
+
+    ctx = ToolContext(workspace_root=tmp_path)
+    ctx.cwd = tmp_path
+
+    result = _bash_call(
+        {"command": "sleep 3; echo done", "timeout_s": 1},
+        ctx,
+    )
+
+    assert isinstance(result.output, dict)
+    assert result.output.get("timed_out") is True
+    assert "interrupted" not in result.output, (
+        "timeout must NOT also write the interrupted key — the two fields "
+        "are the TS-parity discriminator between ESC-abort and timeout. "
+        "Writing both (even as False) would let downstream readers that "
+        "do truthy checks misroute."
+    )
+    assert "Command timed out after 1s" in result.output.get("stderr", "")
+    assert result.is_error is False, (
+        "_bash_call must mirror TS by setting is_error=False on timeout; "
+        "the duration marker in stderr is the signal."
+    )
+
+
+def test_bash_call_esc_payload_shape(tmp_path: Path) -> None:
+    """End-to-end ``_bash_call`` test: ESC-abort produces a ToolResult
+    with ``is_error=True``, ``interrupted=True``, and NO ``timed_out``
+    key. The mapping layer will then emit the ``<error>`` tag.
+    """
+    from src.tool_system.tools.bash.bash_tool import _bash_call
+
+    ctx = ToolContext(workspace_root=tmp_path)
+    ctx.cwd = tmp_path
+    ctrl = AbortController()
+    ctx.abort_controller = ctrl
+
+    def _trip_abort() -> None:
+        time.sleep(0.1)
+        ctrl.abort("user_interrupt")
+
+    threading.Thread(target=_trip_abort, daemon=True).start()
+
+    result = _bash_call(
+        {"command": "sleep 3; echo done", "timeout_s": 30},
+        ctx,
+    )
+
+    assert isinstance(result.output, dict)
+    assert result.output.get("interrupted") is True
+    assert "timed_out" not in result.output, (
+        "ESC-abort must NOT also write the timed_out key — the two fields "
+        "are the TS-parity discriminator between ESC-abort and timeout."
+    )
+    assert result.is_error is True
+
+
+def test_run_bash_with_abort_natural_exit_sets_neither_flag(tmp_path: Path) -> None:
+    """Sanity check: a command that exits normally must have BOTH
+    ``interrupted`` and ``timed_out`` False. Guards against a regression
+    where a code change accidentally sets one of them on the happy path.
+    """
+    result = _run_bash_with_abort(
+        ["bash", "-lc", "echo hello"],
+        cwd=str(tmp_path),
+        timeout_s=10,
+        abort_signal=None,
+    )
+
+    assert result.interrupted is False
+    assert result.timed_out is False
+    assert result.returncode == 0
+    assert "hello" in result.stdout


### PR DESCRIPTION
## Summary

- Before this change, ESC-abort and timeout produced an indistinguishable bash tool_result (both ended with `<error>Command was aborted before completion</error>` and `is_error=True`). On resume, the model often retried timed-out commands as if they had been user-cancelled.
- The TS reference at `ShellCommand.ts:135-141, 302, 323-328` and `BashTool.tsx:610-630` distinguishes the two via the result-label exit code: ESC → 137 → `interrupted=true` → `<error>` tag + `is_error=true`; timeout → 143 (label only, kill is still SIGKILL) → `interrupted=false` → stderr prepended with `Command timed out after <duration>`, no `<error>` tag, `is_error=false`.
- This PR mirrors that split in Python. `_BashRunResult.interrupted` is now set only on ESC-abort; the timeout case sets only `timed_out=True`. `_bash_call` emits two distinct payloads. Both paths SIGKILL immediately (matching TS `#doKill`, dropping the previous SIGTERM-with-grace-then-SIGKILL escalation, keeping ESC latency under the ~50ms target). The duration marker is formatted via the existing `format_duration` helper for byte parity with TS `formatDuration` (`30s`, `2m 0s`, `1h 5m 12s`).

## After the fix

The model now sees:

- **ESC**: tool_result content ends with `<error>Command was aborted before completion</error>`, `is_error=true`. (Unchanged from before, and on the production REPL path the REJECT_MESSAGE override from PR #150 takes precedence.)
- **Timeout**: tool_result content has `Command timed out after 30s ` prepended to whatever stderr was captured, `is_error=false`, no `<error>` tag. The model can read the duration and decide whether to retry with a longer timeout, change approach, or stop — without the API treating it as a hard tool failure.

## TS parity

- Kill signal: TS `#doKill` always calls `treeKill(pid, 'SIGKILL')` regardless of the `code` label argument. Python now also SIGKILLs immediately for both paths.
- Exit code label: timeout writes `143` (TS `SIGTERM = 143`); ESC keeps `-1` (pre-existing Python convention; out of scope to change).
- Duration formatting: `format_duration(timeout_s * 1000)` is byte-equivalent to TS `formatDuration` (spot-checked `1000 → '1s'`, `30000 → '30s'`, `90000 → '1m 30s'`, `3600000 → '1h 0m 0s'`).
- `prependStderr` separator: single space (matches TS `ShellCommand.ts:56-58`), no `.strip()` on the existing stderr (preserves trailing newline / leading whitespace that the model might use as a delimiter).

## Test plan

- [x] New regression file `tests/test_bash_timeout_vs_esc.py` — 7 tests covering supervisor return values, `_bash_call` ToolResult shapes, and `_bash_map_result_to_api` API-block emissions for both paths.
- [x] Wider sweep: 227/227 tests pass across `test_bash_timeout_vs_esc + test_subagent_abort_isolation + test_esc_reject_message_dispatch + test_esc_cancel_propagation + test_abort_controller* + test_streaming_executor_interruptible + test_tool_execution_integration + test_fast_path_dispatch + test_tool_result_budget + test_query_loop + test_query_engine + test_bash_parser + test_bash_security + test_bash_permissions_full + test_ripgrep_abort`
- [x] Critic review: APPROVE after two revision rounds (first round closed three blockers around `format_duration` parity, separator, and `.strip()`; second round closed three minors around stale constant naming, import placement, and orphan imports).

## Follow-up

A separate small PR will land the regression tests for the second critic follow-up from PR #150 — `tests/test_subagent_abort_isolation.py` pins the invariants that async subagents have a fresh-unlinked controller and sync subagents share the parent's controller reference. The verification confirmed Python already mirrors TS at `runAgent.ts:533-541`, so it's pure test coverage with no production-code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
