### PR TITLE
fix: @image.png mentions hallucinate; image tool_result stringified

### DIFF
--- a/src/agent/conversation.py
+++ b/src/agent/conversation.py
@@ -35,8 +35,13 @@ class Conversation:
         normalized_content = _normalize_message_content(content)
         self.messages.append(create_message(role, normalized_content))
 
-    def add_user_message(self, text: str):
-        self.add_message("user", text)
+    def add_user_message(self, content: MessageContent):
+        # ``MessageContent = str | list[ContentBlock]``: ``add_message`` ->
+        # ``_normalize_message_content`` already handles both shapes, so
+        # callers can pass a multi-block content list (e.g. text + image
+        # blocks from @image.png @-mentions) the same way they pass a
+        # plain string.
+        self.add_message("user", content)
 
     def add_assistant_message(self, content: MessageContent):
         self.add_message("assistant", content)

--- a/src/command_system/input_processing.py
+++ b/src/command_system/input_processing.py
@@ -11,6 +11,7 @@ Handles:
 
 from __future__ import annotations
 
+import base64 as _base64
 import os
 import re
 from dataclasses import dataclass, field
@@ -46,7 +47,12 @@ _URL_RE = re.compile(
     r"https?://[^\s<>\"'`\[\](){}]+",
     re.IGNORECASE,
 )
-_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
+# Extensions ``_extract_image_paths`` treats as images for ``ParsedInput.
+# image_paths``. Aligned with the Read tool's ``IMAGE_EXTENSIONS`` so the
+# parse-time hint and the @-mention expansion agree on what counts as an
+# image. SVG and BMP are intentionally excluded: the API doesn't accept
+# SVG, and Pillow's BMP path isn't part of the parity surface.
+_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
 _ESCAPE_RE = re.compile(r"^\\(/)")  # Escaped slash
 
 
@@ -160,24 +166,143 @@ def _extract_urls(text: str) -> list[str]:
 
 _MAX_DIR_ENTRIES = 1000
 
+# Image extensions handled as inline image content blocks (not text). Must
+# match ``IMAGE_EXTENSIONS`` in ``src/tool_system/tools/read.py`` so the
+# @-mention pipeline and the Read tool agree on what counts as an image.
+_AT_MENTION_IMAGE_EXTENSIONS = frozenset({"png", "jpg", "jpeg", "gif", "webp"})
+
+
+def _try_build_image_attachment(
+    expanded: str,
+    display_path: str,
+) -> dict[str, Any] | None:
+    """Try to build an ``image`` attachment from a file path.
+
+    Returns ``None`` if the file is empty, unreadable, or Pillow can't
+    decode it. On ``None`` the caller drops the attachment silently: the
+    user still sees the path in their prompt text, and the model can call
+    ``Read`` explicitly to surface a real error.
+
+    Mirrors the Read tool's image branch (``src/tool_system/tools/read.py``):
+    bounded byte read, magic-byte format sniff, resize to the 3.75 MB /
+    1568 px envelope, return base64 + media_type. Using the same pipeline
+    means a misnamed ``.png`` containing JPEG bytes gets
+    ``media_type=image/jpeg`` the same way the Read tool reports it.
+    """
+    try:
+        st = os.stat(expanded)
+    except OSError:
+        return None
+    if st.st_size == 0:
+        return None
+
+    # Lazy import keeps this module's import cheap when the user never
+    # uses image @-mentions (Pillow takes ~25 ms to import).
+    from ..utils.image_processor import (
+        API_IMAGE_MAX_BASE64_SIZE,
+        IMAGE_READ_SAFETY_CAP,
+        ImageProcessingError,
+        compress_image_to_token_budget,
+        detect_image_format_from_buffer,
+        estimate_image_tokens_from_base64_length,
+        maybe_resize_image,
+        read_file_bytes,
+    )
+
+    try:
+        buf = read_file_bytes(Path(expanded), IMAGE_READ_SAFETY_CAP)
+    except OSError:
+        return None
+    if not buf:
+        return None
+
+    detected_media = detect_image_format_from_buffer(buf)
+    try:
+        result = maybe_resize_image(buf, st.st_size, format_hint=detected_media)
+    except ImageProcessingError:
+        # Pillow couldn't decode: bytes aren't a real image despite the
+        # extension. Skip rather than ship corrupt bytes the API would
+        # reject.
+        return None
+
+    # Token-budget fallback. ``maybe_resize_image`` may return a still-
+    # oversize buffer when even q=20 JPEG at 1568px doesn't fit the 3.75
+    # MB envelope (see image_processor.maybe_resize_image:331-350). The
+    # Read tool runs a final ``compress_image_to_token_budget`` step from
+    # the ORIGINAL buffer to force the payload under the API's 5 MB
+    # base64 cap (read.py:506-518). Without that step, oversize image
+    # @-mentions land a too-large base64 on the conversation and the
+    # Anthropic provider rejects the entire turn via
+    # ``validate_images_for_api``.
+    base64_len = ((len(result.data) + 2) // 3) * 4
+    if base64_len > API_IMAGE_MAX_BASE64_SIZE:
+        # Pick the same token budget the Read tool would use so we
+        # produce identically-sized payloads either way.
+        max_tokens = _get_read_max_output_tokens()
+        try:
+            compressed = compress_image_to_token_budget(buf, max_tokens, detected_media)
+            # Only adopt the compressed result if it actually fits under
+            # the API limit. If both attempts are oversize, drop the
+            # attachment rather than ship a payload the API will reject
+            # at the next turn -- the user's path is still in the text
+            # prompt and they can call Read explicitly for an error.
+            comp_b64_len = ((len(compressed.data) + 2) // 3) * 4
+            if comp_b64_len <= API_IMAGE_MAX_BASE64_SIZE:
+                result = compressed
+            else:
+                return None
+        except ImageProcessingError:
+            return None
+
+    b64 = _base64.b64encode(result.data).decode("ascii")
+    return {
+        "kind": "image",
+        "path": expanded,
+        "display_path": display_path,
+        "base64": b64,
+        "media_type": result.media_type,
+    }
+
+
+def _get_read_max_output_tokens() -> int:
+    """Return the Read tool's max-output-tokens budget.
+
+    Centralised so the @-mention image branch and the Read tool agree on
+    the compression target. Mirrors ``_get_max_output_tokens`` in
+    ``src/tool_system/tools/read.py``.
+    """
+    override = os.environ.get("CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS")
+    if override:
+        try:
+            val = int(override)
+            if val > 0:
+                return val
+        except ValueError:
+            pass
+    return 25_000
+
 
 def expand_at_mentions(
     text: str,
     *,
     cwd: str | None = None,
-) -> tuple[str, list[dict[str, str]]]:
+) -> tuple[str, list[dict[str, Any]]]:
     """Resolve ``@path`` mentions and build context attachments.
 
     Mirrors ``processAtMentionedFiles`` in
     ``typescript/src/utils/attachments.ts``: if a mention resolves to a
     directory we build a ``Listed directory`` attachment containing its
-    entries (up to 1000); if it resolves to a readable file we attach the
+    entries (up to 1000); if it resolves to a readable image file
+    (png/jpg/jpeg/gif/webp) we attach a ``kind="image"`` attachment with
+    base64 + media_type via the image pipeline, so the REPL can inline it
+    as a real image content block in the user message instead of mojibake
+    in a system-reminder. Other readable files we attach the
     file's contents verbatim. The returned ``text`` is left unchanged — the
     caller prepends / appends the attachments before sending to the model.
     """
     cwd = cwd or os.getcwd()
     seen: set[str] = set()
-    attachments: list[dict[str, str]] = []
+    attachments: list[dict[str, Any]] = []
 
     for match in _FILE_MENTION_RE.finditer(text):
         raw = match.group(1).rstrip(".,!?:;\"'`)]}")
@@ -217,12 +342,28 @@ def expand_at_mentions(
                     }
                 )
             elif os.path.isfile(expanded):
+                display_path = os.path.relpath(expanded, cwd)
+                # Image branch FIRST -- opening a PNG/JPEG in text mode
+                # produces mojibake (utf-8 replacement chars over the binary
+                # bytes), and the old wrapper shipped that garbage to the
+                # model inside a ``<system-reminder>Contents of foo.png:``
+                # block. The model would latch onto any ASCII fragments
+                # (XMP metadata, type tags) and hallucinate the rest.
+                ext = os.path.splitext(expanded)[1].lstrip(".").lower()
+                if ext in _AT_MENTION_IMAGE_EXTENSIONS:
+                    img_att = _try_build_image_attachment(expanded, display_path)
+                    if img_att is not None:
+                        attachments.append(img_att)
+                    # Image read failed (empty, undecodable, ...): drop the
+                    # attachment silently. The user's prompt text still
+                    # contains the path, so the model can call ``Read``
+                    # explicitly to see a real error.
+                    continue
                 try:
                     with open(expanded, "r", encoding="utf-8", errors="replace") as fh:
                         data = fh.read()
                 except OSError:
                     continue
-                display_path = os.path.relpath(expanded, cwd)
                 attachments.append(
                     {
                         "kind": "file",
@@ -237,10 +378,17 @@ def expand_at_mentions(
     return text, attachments
 
 
-def format_at_mention_attachments(attachments: list[dict[str, str]]) -> str:
+def format_at_mention_attachments(attachments: list[dict[str, Any]]) -> str:
     """Render attachments produced by :func:`expand_at_mentions` and
     :func:`expand_agent_mentions` as a single string ready to be prepended to
     the user message. Empty input returns ``""``.
+
+    Image attachments (``kind="image"``) are intentionally skipped here:
+    they carry binary base64 data that must reach the model as an actual
+    image content block (via :func:`build_image_content_blocks`), not as
+    text inside a ``<system-reminder>``. Rendering them as text would
+    reintroduce the mojibake/hallucination failure mode this module was
+    rewritten to prevent.
     """
     if not attachments:
         return ""
@@ -261,6 +409,9 @@ def format_at_mention_attachments(attachments: list[dict[str, str]]) -> str:
                 f"```\n{att['content']}\n```\n"
                 f"</system-reminder>"
             )
+        elif kind == "image":
+            # See docstring -- handled separately as a content block.
+            continue
         elif kind == "agent_mention":
             # Mirrors ``typescript/src/utils/messages.ts`` ``agent_mention``
             # case: the reminder nudges the model to delegate to the named
@@ -274,6 +425,37 @@ def format_at_mention_attachments(attachments: list[dict[str, str]]) -> str:
                 f"</system-reminder>"
             )
     return "\n\n".join(blocks)
+
+
+def build_image_content_blocks(
+    attachments: list[dict[str, Any]],
+) -> list["ImageBlock"]:
+    """Build ``ImageBlock`` instances from ``kind="image"`` attachments.
+
+    The REPL appends these after the text portion of the user message so
+    the API receives a mixed text+image content list, matching the TS
+    @-mention flow which auto-Reads the image and inlines it.
+    """
+    from ..types.content_blocks import ImageBlock
+
+    blocks: list[ImageBlock] = []
+    for att in attachments:
+        if att.get("kind") != "image":
+            continue
+        b64 = att.get("base64")
+        media_type = att.get("media_type")
+        if not b64 or not media_type:
+            continue
+        blocks.append(
+            ImageBlock(
+                source={
+                    "type": "base64",
+                    "media_type": media_type,
+                    "data": b64,
+                },
+            )
+        )
+    return blocks
 
 
 def expand_agent_mentions(

--- a/src/providers/openai_compatible.py
+++ b/src/providers/openai_compatible.py
@@ -13,14 +13,53 @@ from typing import Any, Generator, Optional
 from .base import BaseProvider, ChatResponse, MessageInput, TextChunkCallback
 
 
+def _anthropic_image_block_to_openai(block: dict[str, Any]) -> dict[str, Any] | None:
+    """Translate an Anthropic image content block to OpenAI's
+    ``image_url`` shape.
+
+    Anthropic: ``{"type": "image", "source": {"type": "base64",
+    "media_type": "image/png", "data": "..."}}``.
+    OpenAI:    ``{"type": "image_url", "image_url": {"url":
+    "data:image/png;base64,..."}}``.
+
+    Returns ``None`` when the block isn't a recognisable Anthropic image
+    block (caller should keep the original).
+    """
+    if not isinstance(block, dict) or block.get("type") != "image":
+        return None
+    source = block.get("source")
+    if not isinstance(source, dict):
+        return None
+    if source.get("type") != "base64":
+        return None
+    media_type = source.get("media_type") or "image/png"
+    data = source.get("data")
+    if not data or not isinstance(data, str):
+        # Producer-bug guard: an empty/missing data field would generate
+        # ``data:image/png;base64,`` which OpenAI rejects with a confusing
+        # error. Return ``None`` so the caller keeps the original block --
+        # the upstream serializer will surface the malformed shape instead
+        # of silently producing a request the server will fail.
+        return None
+    return {
+        "type": "image_url",
+        "image_url": {"url": f"data:{media_type};base64,{data}"},
+    }
+
+
 def _convert_anthropic_messages_to_openai(
     messages: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """Convert Anthropic-format messages to OpenAI chat-completion format.
 
-    Handles two transformations:
+    Handles three transformations:
     1. Assistant messages with tool_use content blocks → assistant + tool_calls
     2. User messages with tool_result content blocks → role=tool messages
+    3. Anthropic image content blocks (in user messages or tool_result
+       payloads) → OpenAI ``image_url`` data-URI blocks. Required because
+       both @image.png @-mentions and Read-tool image returns ship
+       Anthropic-shape blocks; without translation, OpenAI-compatible
+       providers either reject the request or silently drop the image.
     """
     result: list[dict[str, Any]] = []
     for msg in messages:
@@ -92,7 +131,10 @@ def _convert_anthropic_messages_to_openai(
                 if isinstance(block, dict) and block.get("type") == "tool_result":
                     tool_results.append(block)
                 else:
-                    non_tool_blocks.append(block)
+                    # Translate Anthropic image blocks to OpenAI ``image_url``
+                    # shape; pass everything else through unchanged.
+                    translated = _anthropic_image_block_to_openai(block) if isinstance(block, dict) else None
+                    non_tool_blocks.append(translated if translated is not None else block)
 
             # Emit non-tool content first as user message
             if non_tool_blocks:
@@ -101,12 +143,25 @@ def _convert_anthropic_messages_to_openai(
             # Emit each tool_result as a separate role=tool message
             for tr in tool_results:
                 raw_content = tr.get("content", "")
+                # Collect any image blocks separately. OpenAI's ``role=tool``
+                # message only accepts a text ``content`` string -- it
+                # rejects multimodal content. So we split: emit the text
+                # body as the tool message, then immediately follow with a
+                # synthetic ``role=user`` message that carries the image
+                # blocks via ``image_url``. The model sees the image
+                # alongside the tool result, which is the closest semantic
+                # match to Anthropic's native multimodal tool_result.
+                image_blocks_from_tool: list[dict[str, Any]] = []
                 if isinstance(raw_content, list):
                     # Flatten nested content blocks to text
                     parts = []
                     for item in raw_content:
                         if isinstance(item, dict) and item.get("type") == "text":
                             parts.append(item.get("text", ""))
+                        elif isinstance(item, dict) and item.get("type") == "image":
+                            translated_img = _anthropic_image_block_to_openai(item)
+                            if translated_img is not None:
+                                image_blocks_from_tool.append(translated_img)
                         elif isinstance(item, str):
                             parts.append(item)
                         else:
@@ -117,11 +172,31 @@ def _convert_anthropic_messages_to_openai(
                 else:
                     flat_content = str(raw_content)
 
+                # OpenAI requires ``content`` to be a non-empty string on
+                # tool messages; if the original was image-only, leave a
+                # short pointer so the tool_call is paired with something.
+                # The follow-up ``role=user`` message carrying the
+                # ``image_url`` block is NOT linked to ``tool_call_id`` --
+                # OpenAI's wire format has no way to attach a tool_call_id
+                # to a user message. The model sees ``tool(text result)``
+                # followed by ``user(image)`` and may briefly treat the
+                # trailing user message as a new prompt. The placeholder
+                # text reduces that risk, but it's a known OpenAI-API
+                # limitation we cannot fully paper over; on Anthropic the
+                # equivalent stays as a single multimodal tool_result.
+                if not flat_content and image_blocks_from_tool:
+                    flat_content = "[image content delivered in the following message]"
+
                 result.append({
                     "role": "tool",
                     "tool_call_id": tr.get("tool_use_id", ""),
                     "content": flat_content,
                 })
+                if image_blocks_from_tool:
+                    result.append({
+                        "role": "user",
+                        "content": image_blocks_from_tool,
+                    })
             continue
 
         # Fallback

--- a/src/query/engine.py
+++ b/src/query/engine.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, AsyncGenerator, Callable
 from uuid import uuid4
 
+from ..types.content_blocks import ContentBlock
 from ..types.messages import (
     AssistantMessage,
     Message,
@@ -190,10 +191,14 @@ class QueryEngine:
 
     async def submit_message(
         self,
-        prompt: str,
+        prompt: str | list[ContentBlock],
         *,
         on_message: Callable[[Message | StreamEvent], None] | None = None,
     ) -> AsyncGenerator[Message | StreamEvent, None]:
+        # ``MessageContent = str | list[ContentBlock]`` already supports
+        # both shapes; the list form lets callers attach image/document
+        # content blocks alongside the text prompt (e.g. from @image.png
+        # @-mentions in the REPL).
         user_msg = UserMessage(content=prompt)
         self._mutable_messages.append(user_msg)
 

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -678,21 +678,31 @@ def _dispatch_single_tool(
                 # size is what counts toward the budget — not the
                 # original 200K output).
                 tool_use_context.tool_result_chars_so_far += compute_block_chars(api_block)
-            content_str = api_block.get("content", "")
-            if not isinstance(content_str, str):
-                content_str = json.dumps(content_str, ensure_ascii=False)
+            raw_content = api_block.get("content", "")
+            # Preserve list-of-content-blocks shape so multimodal tool_results
+            # (e.g. Read's image content blocks, bash data:image/... captures)
+            # reach the API as proper image/document blocks instead of being
+            # JSON-stringified into text. The Anthropic API rejects images
+            # delivered as text and the model just sees JSON gibberish in the
+            # tool_result content otherwise. ``ToolResultBlock.content`` and
+            # ``content_block_to_dict`` already handle list shape end-to-end
+            # (see content_blocks.py:159-173).
+            if isinstance(raw_content, (str, list)):
+                result_content: str | list[Any] = raw_content
+            else:
+                result_content = str(raw_content)
         elif isinstance(result.output, str):
-            content_str = result.output
+            result_content = result.output
         elif isinstance(result.output, dict):
-            content_str = json.dumps(result.output, ensure_ascii=False)
+            result_content = json.dumps(result.output, ensure_ascii=False)
         else:
-            content_str = str(result.output)
+            result_content = str(result.output)
 
         result_msg = UserMessage(
             content=[
                 ToolResultBlock(
                     tool_use_id=block.id,
-                    content=content_str,
+                    content=result_content,
                     is_error=result.is_error,
                     metadata=metadata,
                 )

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -2285,10 +2285,12 @@ class ClawcodexREPL:
         # sees the message. Port of
         # ``typescript/src/utils/attachments.ts#processAtMentionedFiles``.
         from src.command_system.input_processing import (
+            build_image_content_blocks,
             expand_agent_mentions,
             expand_at_mentions,
             format_at_mention_attachments,
         )
+        from src.types.content_blocks import TextBlock
 
         cwd_for_mentions = str(self.tool_context.cwd or self.tool_context.workspace_root)
         _, at_attachments = expand_at_mentions(user_input, cwd=cwd_for_mentions)
@@ -2306,16 +2308,43 @@ class ClawcodexREPL:
             attachment_text = format_at_mention_attachments(all_attachments)
             user_input = f"{attachment_text}\n\n{user_input}" if attachment_text else user_input
             for att in at_attachments:
-                kind = "directory" if att["kind"] == "directory" else "file"
-                self.console.print(
-                    f"[dim]  ⎿  Listed {kind} {att['display_path']}{'/' if kind == 'directory' else ''}[/dim]"
-                )
+                kind = att.get("kind")
+                if kind == "image":
+                    # TS shows "Read 1 file (ctrl+o to expand)" for image
+                    # @-mentions; we mirror the user-facing intent without
+                    # the count (one mention -> one line).
+                    self.console.print(
+                        f"[dim]  ⎿  Read image {att['display_path']}[/dim]"
+                    )
+                else:
+                    label = "directory" if kind == "directory" else "file"
+                    self.console.print(
+                        f"[dim]  ⎿  Listed {label} {att['display_path']}{'/' if kind == 'directory' else ''}[/dim]"
+                    )
             for att in agent_attachments:
                 self.console.print(
                     f"[dim]  ⎿  Invoking agent @{att['agent_type']}[/dim]"
                 )
 
-        self.session.conversation.add_user_message(user_input)
+        # Image @-mentions become real image content blocks on the user
+        # message so the model sees the image directly (matches TS's
+        # auto-Read-on-@image behaviour, and stops the model from
+        # hallucinating about mojibake'd PNG bytes in a system-reminder).
+        # When images are present, ``user_message_content`` is a mixed
+        # ``[TextBlock, ImageBlock, ...]`` list; otherwise it is just the
+        # text string. Both shapes are accepted by ``add_user_message``
+        # and ``engine.submit_message`` (``MessageContent = str |
+        # list[ContentBlock]``).
+        image_blocks = build_image_content_blocks(at_attachments)
+        if image_blocks:
+            user_message_content: str | list[Any] = [
+                TextBlock(text=user_input),
+                *image_blocks,
+            ]
+        else:
+            user_message_content = user_input
+
+        self.session.conversation.add_user_message(user_message_content)
 
         try:
             self.console.print("\n[bold]Assistant[/bold]")
@@ -2331,7 +2360,10 @@ class ClawcodexREPL:
                         pass
                 stream_started = True
 
-            if self._should_try_direct_stream(user_input):
+            # Direct-stream skips the tool loop; it can only carry plain
+            # text. If the user attached an image, fall through to the
+            # full engine path so the image content block survives.
+            if not image_blocks and self._should_try_direct_stream(user_input):
                 def on_text_chunk_direct(chunk: str) -> None:
                     if not chunk:
                         return
@@ -2438,7 +2470,7 @@ class ClawcodexREPL:
                     pending_task_flush = False
                     self._render_task_snapshot()
 
-                async for msg in engine.submit_message(user_input):
+                async for msg in engine.submit_message(user_message_content):
                     if isinstance(msg, StreamEvent):
                         if msg.type == "stream_request_start":
                             api_call_count += 1

--- a/tests/parity/test_e2e_file_read.py
+++ b/tests/parity/test_e2e_file_read.py
@@ -526,6 +526,126 @@ class TestE2EFileRead(unittest.TestCase):
         self.assertEqual(block["source"]["data"], "ABCD")
         self.assertEqual(block["source"]["media_type"], "image/png")
 
+    def test_dispatch_preserves_image_under_aggregate_threshold_pressure(self) -> None:
+        """The aggregate-budget gate must short-circuit on image content.
+
+        ``maybe_persist_large_tool_result``'s ``_has_image_block`` guard
+        is the load-bearing line that keeps image bytes from being
+        force-persisted to a wrapper-text message when the per-message
+        aggregate budget is nearly full. This test pre-loads the
+        running aggregate to one byte below
+        ``MAX_TOOL_RESULTS_PER_MESSAGE_CHARS`` and asserts the image
+        tool_result still arrives as a list of content blocks (not a
+        ``<persisted-output>`` wrapper)."""
+        from PIL import Image
+        from src.query.query import _dispatch_single_tool
+        from src.services.tool_execution.tool_result_persistence import (
+            MAX_TOOL_RESULTS_PER_MESSAGE_CHARS,
+        )
+        from src.tool_system.registry import get_all_base_tools
+        from src.types.content_blocks import ToolResultBlock, ToolUseBlock
+
+        png = self.root / "under_pressure.png"
+        Image.new("RGB", (48, 48), color="purple").save(png, format="PNG")
+
+        # Pre-load the running aggregate to within 1 byte of the cap.
+        # If ``_has_image_block`` didn't short-circuit, the image block
+        # would be force-persisted (persist_tool_result would refuse
+        # because of the non-text branch, and the original block would
+        # come back wrapped in a text marker).
+        self.ctx.tool_result_chars_so_far = MAX_TOOL_RESULTS_PER_MESSAGE_CHARS - 1
+
+        tools = get_all_base_tools(self.registry)
+        tu = ToolUseBlock(id="tu_agg", name="Read", input={"file_path": str(png)})
+        primary, _extras = _dispatch_single_tool(tu, self.registry, self.ctx, tools)
+
+        body = primary.content[0].content
+        self.assertIsInstance(body, list,
+            "Aggregate-pressure path collapsed image to text instead of "
+            "short-circuiting via _has_image_block")
+        self.assertEqual(body[0]["type"], "image")
+        # The aggregate counter must NOT have grown by the image bytes:
+        # ``_content_size`` returns 0 for image blocks
+        # (tool_result_persistence.py:159-163), and the dispatcher's
+        # ``+= compute_block_chars(api_block)`` therefore adds 0.
+        # Pins the "image bytes don't pollute the per-message budget"
+        # invariant so a future change to ``_content_size`` that started
+        # counting base64 length would fail loudly here.
+        self.assertEqual(
+            self.ctx.tool_result_chars_so_far,
+            MAX_TOOL_RESULTS_PER_MESSAGE_CHARS - 1,
+            "Image bytes leaked into tool_result_chars_so_far counter",
+        )
+
+    def test_dispatch_preserves_image_list_content_not_json_stringified(self) -> None:
+        """Regression for Bug B: ``_dispatch_single_tool`` must keep the
+        Read tool's image content as a LIST of content blocks, not
+        ``json.dumps`` it into a string.
+
+        Before the fix, ``query.py:_dispatch_single_tool`` ran
+        ``json.dumps(content)`` on any non-string content, which turned
+        ``[{"type": "image", "source": ...}]`` into the literal text
+        ``'[{"type": "image", "source": ...}]'``. The Anthropic API then
+        received an image tool_result whose content was text JSON; the
+        model couldn't see the actual image and would hallucinate.
+
+        This test drives a real PNG through ``_dispatch_single_tool``
+        AND then through ``normalize_messages_for_api`` to lock in the
+        full wire shape: the API payload's tool_result content must be
+        a list whose first element is an ``image`` content block."""
+        from PIL import Image
+        from src.query.query import _dispatch_single_tool
+        from src.tool_system.registry import get_all_base_tools
+        from src.types.content_blocks import ToolResultBlock, ToolUseBlock
+        from src.types.messages import AssistantMessage, normalize_messages_for_api
+
+        png = self.root / "regression.png"
+        # Tiny so no resize kicks in -- we want the raw image block path.
+        Image.new("RGB", (32, 32), color="red").save(png, format="PNG")
+
+        # Production callers always pass ``tools``; without it the
+        # dispatcher takes the legacy fallback branch and JSON-dumps the
+        # raw output dict. Pass it explicitly so we exercise the
+        # ``process_tool_result_block`` branch where Bug B lived.
+        tools = get_all_base_tools(self.registry)
+        tu = ToolUseBlock(id="tu_regress_b", name="Read", input={"file_path": str(png)})
+        primary, _extras = _dispatch_single_tool(tu, self.registry, self.ctx, tools)
+
+        # Direct check on the ToolResultBlock the dispatcher built.
+        self.assertIsInstance(primary.content[0], ToolResultBlock)
+        body = primary.content[0].content
+        self.assertIsInstance(
+            body, list,
+            "Bug B regression: tool_result.content is a string instead of "
+            "a list of content blocks — image was JSON-stringified.",
+        )
+        self.assertEqual(body[0]["type"], "image")
+        self.assertEqual(body[0]["source"]["type"], "base64")
+        self.assertEqual(body[0]["source"]["media_type"], "image/png")
+        self.assertGreater(len(body[0]["source"]["data"]), 0)
+
+        # End-to-end through normalize_messages_for_api: the API would
+        # receive an image content block, not a text JSON blob.
+        asst = AssistantMessage(content=[tu])
+        normalized = normalize_messages_for_api([asst, primary])
+        # Find the tool_result block in the normalized output
+        api_tool_results = []
+        for m in normalized:
+            content = m.get("content") if isinstance(m, dict) else None
+            if not isinstance(content, list):
+                continue
+            for blk in content:
+                if isinstance(blk, dict) and blk.get("type") == "tool_result":
+                    api_tool_results.append(blk)
+        self.assertEqual(len(api_tool_results), 1)
+        api_body = api_tool_results[0]["content"]
+        self.assertIsInstance(
+            api_body, list,
+            "API payload regressed: tool_result.content arrived as a string",
+        )
+        self.assertEqual(api_body[0]["type"], "image")
+        self.assertEqual(api_body[0]["source"]["media_type"], "image/png")
+
 
 class TestE2EGlobGrep(unittest.TestCase):
     """End-to-end Glob and Grep search flows."""

--- a/tests/test_at_mention_images.py
+++ b/tests/test_at_mention_images.py
@@ -1,0 +1,335 @@
+"""Regression tests for Bug A: ``@image.png`` @-mentions.
+
+Before the fix, ``expand_at_mentions`` opened image files with
+``open(path, "r", encoding="utf-8", errors="replace")`` and shipped the
+resulting mojibake to the model inside a
+``<system-reminder>Contents of foo.png:...```...</system-reminder>`` block.
+The model would latch onto ASCII fragments (e.g. PNG XMP metadata strings)
+and hallucinate. The fix routes image files through the same image
+pipeline the Read tool uses (magic-byte sniff + resize) and returns a
+``kind="image"`` attachment carrying base64 + media_type, which the REPL
+inlines as an actual image content block on the user message.
+"""
+
+from __future__ import annotations
+
+import io
+import tempfile
+import unittest
+from pathlib import Path
+
+from PIL import Image
+
+from src.command_system.input_processing import (
+    build_image_content_blocks,
+    expand_at_mentions,
+    format_at_mention_attachments,
+)
+from src.types.content_blocks import ImageBlock, TextBlock
+from src.types.messages import UserMessage, normalize_messages_for_api
+
+
+def _write_png(path: Path, *, size: tuple[int, int] = (64, 64), color: str = "red") -> None:
+    Image.new("RGB", size, color=color).save(path, format="PNG")
+
+
+def _write_jpeg(path: Path, *, size: tuple[int, int] = (64, 64), color: str = "blue") -> None:
+    Image.new("RGB", size, color=color).save(path, format="JPEG", quality=80)
+
+
+class TestExpandAtMentionsImages(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def test_png_at_mention_returns_image_attachment(self) -> None:
+        """``@foo.png`` produces a ``kind="image"`` attachment with
+        base64 + media_type, NOT a text ``kind="file"`` with mojibake."""
+        png = self.tmp / "screenshot.png"
+        _write_png(png)
+        _, atts = expand_at_mentions(f"see @{png}", cwd=str(self.tmp))
+        self.assertEqual(len(atts), 1)
+        self.assertEqual(atts[0]["kind"], "image")
+        self.assertEqual(atts[0]["media_type"], "image/png")
+        self.assertGreater(len(atts[0]["base64"]), 0)
+        # The old bug shipped raw bytes under "content" -- the image
+        # attachment must NOT carry that field, so the text formatter
+        # cannot accidentally fall back to wrapping it.
+        self.assertNotIn("content", atts[0])
+
+    def test_jpeg_at_mention_returns_image_attachment(self) -> None:
+        jpg = self.tmp / "photo.jpg"
+        _write_jpeg(jpg)
+        _, atts = expand_at_mentions(f"see @{jpg}", cwd=str(self.tmp))
+        self.assertEqual(atts[0]["kind"], "image")
+        self.assertEqual(atts[0]["media_type"], "image/jpeg")
+
+    def test_misnamed_png_with_jpeg_bytes_detects_as_jpeg(self) -> None:
+        """Magic-byte detection wins over extension: a ``.png`` file
+        containing JPEG bytes returns ``media_type=image/jpeg`` so the
+        Anthropic API doesn't reject the wrong-typed image. Mirrors the
+        Read tool's behaviour at ``src/tool_system/tools/read.py``."""
+        mis = self.tmp / "wrongext.png"
+        buf = io.BytesIO()
+        Image.new("RGB", (32, 32), color="green").save(buf, format="JPEG", quality=80)
+        mis.write_bytes(buf.getvalue())
+        _, atts = expand_at_mentions(f"see @{mis}", cwd=str(self.tmp))
+        self.assertEqual(atts[0]["kind"], "image")
+        self.assertEqual(
+            atts[0]["media_type"], "image/jpeg",
+            "magic-byte sniffing should override the .png extension",
+        )
+
+    def test_empty_image_dropped_silently(self) -> None:
+        """Empty image files produce no attachment (rather than shipping
+        empty base64 or text-mode garbage)."""
+        empty = self.tmp / "empty.png"
+        empty.write_bytes(b"")
+        _, atts = expand_at_mentions(f"see @{empty}", cwd=str(self.tmp))
+        self.assertEqual(atts, [])
+
+    def test_undecodable_png_dropped_silently(self) -> None:
+        """Files with an image extension but garbage bytes are dropped
+        rather than shipped — Pillow refuses to decode, and we'd rather
+        skip than send bytes the API will reject."""
+        fake = self.tmp / "fake.png"
+        fake.write_bytes(b"not an image at all, just bytes")
+        _, atts = expand_at_mentions(f"see @{fake}", cwd=str(self.tmp))
+        self.assertEqual(atts, [])
+
+    def test_text_at_mention_still_works(self) -> None:
+        """Non-image @-mentions remain unchanged: ``kind="file"`` with
+        the file's contents as text."""
+        md = self.tmp / "doc.md"
+        md.write_text("# title\nbody\n")
+        _, atts = expand_at_mentions(f"see @{md}", cwd=str(self.tmp))
+        self.assertEqual(len(atts), 1)
+        self.assertEqual(atts[0]["kind"], "file")
+        self.assertIn("title", atts[0]["content"])
+
+    def test_directory_at_mention_still_works(self) -> None:
+        """Directory @-mentions remain unchanged: ``kind="directory"``."""
+        sub = self.tmp / "sub"
+        sub.mkdir()
+        (sub / "a.txt").write_text("a")
+        _, atts = expand_at_mentions(f"see @{sub}", cwd=str(self.tmp))
+        self.assertEqual(atts[0]["kind"], "directory")
+        self.assertIn("a.txt", atts[0]["content"])
+
+
+class TestFormatAtMentionAttachmentsImages(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def test_image_only_produces_no_text_wrapper(self) -> None:
+        """An image-only attachment list renders to an empty string.
+
+        Critical: NO ``<system-reminder>Contents of ...``` text — the old
+        bug wrapped binary bytes there and the model hallucinated."""
+        png = self.tmp / "x.png"
+        _write_png(png)
+        _, atts = expand_at_mentions(f"@{png}", cwd=str(self.tmp))
+        rendered = format_at_mention_attachments(atts)
+        self.assertEqual(rendered, "")
+
+    def test_mixed_image_and_text_renders_only_text(self) -> None:
+        """When the user mixes an image and a text file mention, the
+        text wrapper covers the text file only; the image is excluded
+        from the system-reminder."""
+        png = self.tmp / "x.png"
+        _write_png(png)
+        md = self.tmp / "y.md"
+        md.write_text("# y")
+        _, atts = expand_at_mentions(f"@{png} @{md}", cwd=str(self.tmp))
+        rendered = format_at_mention_attachments(atts)
+        self.assertIn("Contents of y.md", rendered)
+        self.assertNotIn("Contents of x.png", rendered)
+
+
+class TestBuildImageContentBlocks(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def test_image_attachments_become_image_blocks(self) -> None:
+        png = self.tmp / "x.png"
+        _write_png(png)
+        _, atts = expand_at_mentions(f"@{png}", cwd=str(self.tmp))
+        blocks = build_image_content_blocks(atts)
+        self.assertEqual(len(blocks), 1)
+        self.assertIsInstance(blocks[0], ImageBlock)
+        self.assertEqual(blocks[0].source["type"], "base64")
+        self.assertEqual(blocks[0].source["media_type"], "image/png")
+        self.assertGreater(len(blocks[0].source["data"]), 0)
+
+    def test_non_image_attachments_are_ignored(self) -> None:
+        md = self.tmp / "x.md"
+        md.write_text("# hi")
+        _, atts = expand_at_mentions(f"@{md}", cwd=str(self.tmp))
+        blocks = build_image_content_blocks(atts)
+        self.assertEqual(blocks, [])
+
+    def test_empty_attachments_returns_empty_list(self) -> None:
+        self.assertEqual(build_image_content_blocks([]), [])
+
+    def test_attachment_missing_base64_or_media_type_skipped(self) -> None:
+        """Defensive: a buggy producer dropping ``base64`` or ``media_type``
+        should not crash; the malformed attachment is just skipped."""
+        blocks = build_image_content_blocks(
+            [{"kind": "image", "base64": "abc"}],
+        )
+        self.assertEqual(blocks, [])
+        blocks = build_image_content_blocks(
+            [{"kind": "image", "media_type": "image/png"}],
+        )
+        self.assertEqual(blocks, [])
+
+
+class TestImageAttachmentCompressionFallback(unittest.TestCase):
+    """Regression coverage for the BLOCKER fix added in
+    ``_try_build_image_attachment``: when ``maybe_resize_image`` returns a
+    still-oversize buffer, we run ``compress_image_to_token_budget`` from
+    the ORIGINAL buffer to force the payload under the 5 MB base64 API
+    cap; if BOTH attempts are oversize, we drop the attachment.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def test_oversize_image_compressed_under_api_limit(self) -> None:
+        """A real oversize image (random-noise PNG that doesn't compress
+        well even after resize) lands under
+        ``API_IMAGE_MAX_BASE64_SIZE`` thanks to the token-budget
+        compression fallback. Pre-fix, the same input lands a >5 MB
+        base64 payload that the Anthropic provider rejects at the next
+        turn via ``validate_images_for_api``."""
+        import os
+
+        from src.utils.image_processor import API_IMAGE_MAX_BASE64_SIZE
+        from src.command_system.input_processing import _try_build_image_attachment
+
+        # 4000x4000 of random-ish noise to defeat PNG palette compression
+        # and force the resize+JPEG fallback in maybe_resize_image to
+        # still exceed the 3.75 MB raw / 5 MB base64 envelope. Pillow
+        # encodes this >10 MB.
+        rng = os.urandom(4000 * 4000 * 3)
+        oversized = self.tmp / "oversized.png"
+        Image.frombytes("RGB", (4000, 4000), rng).save(oversized, format="PNG")
+        self.assertGreater(
+            oversized.stat().st_size, API_IMAGE_MAX_BASE64_SIZE,
+            "test setup: random-noise PNG must exceed the API cap for the "
+            "compression branch to engage",
+        )
+        att = _try_build_image_attachment(str(oversized), "oversized.png")
+        self.assertIsNotNone(att)
+        b64_len = len(att["base64"])
+        self.assertLessEqual(
+            b64_len, API_IMAGE_MAX_BASE64_SIZE,
+            f"Compression fallback failed to bring base64 under the API "
+            f"limit: {b64_len} > {API_IMAGE_MAX_BASE64_SIZE}",
+        )
+
+    def test_doubly_oversize_image_dropped_silently(self) -> None:
+        """If both ``maybe_resize_image`` and
+        ``compress_image_to_token_budget`` return oversize buffers,
+        ``_try_build_image_attachment`` returns ``None`` rather than
+        shipping a payload the API would reject. Monkeypatched here so
+        we don't need a pathological input that defeats both steps."""
+        from src.command_system import input_processing as ip_mod
+        from src.utils import image_processor as ip_proc
+
+        png = self.tmp / "tiny.png"
+        _write_png(png)
+
+        real_resize = ip_proc.maybe_resize_image
+        real_compress = ip_proc.compress_image_to_token_budget
+
+        # Force the resize step to return a "still oversize" payload
+        # (synthetic 6 MB ASCII) so the compress branch engages.
+        def fake_resize(buf, original_size, format_hint=None):
+            return ip_proc.ResizeResult(
+                data=b"x" * (6 * 1024 * 1024),
+                media_type="image/png",
+                dimensions=None,
+            )
+
+        # Then force the compress step to ALSO return oversize, so the
+        # drop branch engages.
+        def fake_compress(buf, max_tokens, media_type=None):
+            return ip_proc.ResizeResult(
+                data=b"x" * (6 * 1024 * 1024),
+                media_type="image/png",
+                dimensions=None,
+            )
+
+        ip_proc.maybe_resize_image = fake_resize
+        ip_proc.compress_image_to_token_budget = fake_compress
+        try:
+            att = ip_mod._try_build_image_attachment(str(png), "tiny.png")
+            self.assertIsNone(att,
+                "Both resize and compress oversize -> attachment must be "
+                "dropped to avoid the API rejecting the next turn")
+        finally:
+            ip_proc.maybe_resize_image = real_resize
+            ip_proc.compress_image_to_token_budget = real_compress
+
+
+class TestEndToEndAtImageMention(unittest.TestCase):
+    """Bug A end-to-end: ``@png`` → mixed-content user message → API."""
+
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def _compose(self, user_text: str) -> dict:
+        _, atts = expand_at_mentions(user_text, cwd=str(self.tmp))
+        attachment_text = format_at_mention_attachments(atts)
+        text_part = (
+            f"{attachment_text}\n\n{user_text}" if attachment_text else user_text
+        )
+        image_blocks = build_image_content_blocks(atts)
+        um = UserMessage(content=[TextBlock(text=text_part), *image_blocks])
+        return normalize_messages_for_api([um])[0]
+
+    def test_at_image_mention_yields_text_plus_image_api_payload(self) -> None:
+        png = self.tmp / "screenshot.png"
+        _write_png(png, size=(160, 100), color=(120, 60, 200))
+        msg = self._compose(f"what is this @{png}")
+        self.assertEqual(msg["role"], "user")
+        self.assertEqual([b["type"] for b in msg["content"]], ["text", "image"])
+        self.assertNotIn("Contents of screenshot.png", msg["content"][0]["text"])
+        src = msg["content"][1]["source"]
+        self.assertEqual(src["type"], "base64")
+        self.assertEqual(src["media_type"], "image/png")
+        self.assertGreater(len(src["data"]), 0)
+
+    def test_multi_image_at_mention_yields_text_plus_multiple_image_blocks(self) -> None:
+        a = self.tmp / "a.png"
+        b = self.tmp / "b.png"
+        _write_png(a, size=(60, 40), color="red")
+        _write_png(b, size=(60, 40), color="blue")
+        msg = self._compose(f"compare these @{a} @{b}")
+        # Exactly one text + two image blocks, in order.
+        self.assertEqual([t["type"] for t in msg["content"]], ["text", "image", "image"])
+        # Each image carries distinct bytes (sanity: not the same file
+        # served twice).
+        d1 = msg["content"][1]["source"]["data"]
+        d2 = msg["content"][2]["source"]["data"]
+        self.assertNotEqual(d1, d2)
+
+    def test_mixed_text_and_image_at_mentions_compose_correctly(self) -> None:
+        png = self.tmp / "screenshot.png"
+        _write_png(png, size=(60, 40))
+        md = self.tmp / "notes.md"
+        md.write_text("# investigate\nFollow up here.\n")
+        msg = self._compose(f"see @{md} and @{png}")
+        # One text block carries the markdown contents (via the text
+        # @-mention's system-reminder wrap) and the user's own prompt;
+        # the image lands as a separate image block. NO mojibake from
+        # the .png.
+        self.assertEqual([b["type"] for b in msg["content"]], ["text", "image"])
+        text = msg["content"][0]["text"]
+        self.assertIn("Contents of notes.md", text)
+        self.assertIn("Follow up here", text)
+        self.assertNotIn("Contents of screenshot.png", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openai_compat_image_translation.py
+++ b/tests/test_openai_compat_image_translation.py
@@ -1,0 +1,203 @@
+"""Tests for Anthropic→OpenAI image-block translation in the
+OpenAI-compatible provider converter.
+
+Anthropic shape: ``{"type": "image", "source": {"type": "base64",
+"media_type": "image/png", "data": "..."}}``.
+OpenAI shape:    ``{"type": "image_url", "image_url": {"url":
+"data:image/png;base64,..."}}``.
+
+Required because two features now ship Anthropic-shape image blocks
+through the user-message and tool_result paths:
+1. ``@image.png`` @-mentions in the REPL inline an image block on the
+   user message.
+2. The Read tool returns image content blocks in its tool_result.
+
+Without translation, OpenAI-compatible providers (OpenAI, GLM, Minimax,
+DeepSeek, OpenRouter) either reject the request outright or silently
+drop the image.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.providers.openai_compatible import (
+    _anthropic_image_block_to_openai,
+    _convert_anthropic_messages_to_openai,
+)
+
+
+class TestAnthropicImageBlockToOpenAI(unittest.TestCase):
+    def test_valid_block_translates_to_image_url(self) -> None:
+        out = _anthropic_image_block_to_openai({
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": "ABCD"},
+        })
+        self.assertEqual(out, {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,ABCD"},
+        })
+
+    def test_jpeg_media_type_preserved(self) -> None:
+        out = _anthropic_image_block_to_openai({
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/jpeg", "data": "XYZ"},
+        })
+        self.assertEqual(out["image_url"]["url"], "data:image/jpeg;base64,XYZ")
+
+    def test_non_image_block_returns_none(self) -> None:
+        self.assertIsNone(_anthropic_image_block_to_openai({"type": "text", "text": "hi"}))
+
+    def test_missing_source_returns_none(self) -> None:
+        self.assertIsNone(_anthropic_image_block_to_openai({"type": "image"}))
+
+    def test_url_source_returns_none(self) -> None:
+        """We only translate base64 sources; URL sources aren't supported
+        by the Anthropic image branch in this codebase, so reject."""
+        self.assertIsNone(_anthropic_image_block_to_openai({
+            "type": "image",
+            "source": {"type": "url", "url": "https://example.com/x.png"},
+        }))
+
+    def test_missing_media_type_defaults_to_png(self) -> None:
+        """Defensive: an attachment missing media_type still translates
+        with a safe default so the API doesn't reject ``data:;base64,``."""
+        out = _anthropic_image_block_to_openai({
+            "type": "image",
+            "source": {"type": "base64", "data": "AAA"},
+        })
+        self.assertEqual(out["image_url"]["url"], "data:image/png;base64,AAA")
+
+    def test_empty_data_returns_none(self) -> None:
+        """An empty ``data`` field would produce ``data:image/png;base64,``
+        which OpenAI rejects with a confusing error. The translator
+        returns ``None`` so the caller keeps the original (malformed)
+        block, surfacing the producer bug instead of papering over it."""
+        self.assertIsNone(_anthropic_image_block_to_openai({
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": ""},
+        }))
+        self.assertIsNone(_anthropic_image_block_to_openai({
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png"},
+        }))
+
+
+class TestConvertUserMessageWithImage(unittest.TestCase):
+    """Image blocks in user messages (e.g. from @image.png @-mentions)
+    must come out as OpenAI ``image_url`` blocks."""
+
+    def test_user_text_plus_image_translates(self) -> None:
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what is this?"},
+                {"type": "image",
+                 "source": {"type": "base64", "media_type": "image/png", "data": "ABCD"}},
+            ],
+        }]
+        out = _convert_anthropic_messages_to_openai(messages)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["role"], "user")
+        self.assertEqual([b["type"] for b in out[0]["content"]], ["text", "image_url"])
+        self.assertEqual(
+            out[0]["content"][1]["image_url"]["url"],
+            "data:image/png;base64,ABCD",
+        )
+
+    def test_multi_image_user_message_translates_all_images(self) -> None:
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "compare"},
+                {"type": "image",
+                 "source": {"type": "base64", "media_type": "image/png", "data": "AAA"}},
+                {"type": "image",
+                 "source": {"type": "base64", "media_type": "image/jpeg", "data": "BBB"}},
+            ],
+        }]
+        out = _convert_anthropic_messages_to_openai(messages)
+        self.assertEqual([b["type"] for b in out[0]["content"]], ["text", "image_url", "image_url"])
+        self.assertIn("png;base64,AAA", out[0]["content"][1]["image_url"]["url"])
+        self.assertIn("jpeg;base64,BBB", out[0]["content"][2]["image_url"]["url"])
+
+    def test_user_message_text_only_unchanged(self) -> None:
+        """A plain-text user message must pass through unchanged so we
+        don't regress the existing string-content path."""
+        messages = [{"role": "user", "content": "plain text"}]
+        out = _convert_anthropic_messages_to_openai(messages)
+        self.assertEqual(out, [{"role": "user", "content": "plain text"}])
+
+
+class TestConvertToolResultWithImage(unittest.TestCase):
+    """Image blocks inside tool_result content (from the Read tool) get
+    extracted into a synthetic user message with ``image_url`` since
+    OpenAI's ``role=tool`` message only accepts string content."""
+
+    def test_tool_result_with_image_splits_into_tool_then_user_image(self) -> None:
+        messages = [
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "tu_1", "name": "Read", "input": {}},
+            ]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "tu_1", "content": [
+                    {"type": "image",
+                     "source": {"type": "base64", "media_type": "image/png", "data": "XYZ"}},
+                ]},
+            ]},
+        ]
+        out = _convert_anthropic_messages_to_openai(messages)
+        # 1) assistant w/ tool_calls
+        self.assertEqual(out[0]["role"], "assistant")
+        self.assertEqual(out[0]["tool_calls"][0]["id"], "tu_1")
+        # 2) role=tool with placeholder text (image-only originals get a
+        #    pointer so the tool_call has SOMETHING to pair with).
+        self.assertEqual(out[1]["role"], "tool")
+        self.assertEqual(out[1]["tool_call_id"], "tu_1")
+        self.assertTrue(out[1]["content"], "tool message content must be non-empty")
+        # 3) synthetic user message carrying the image_url
+        self.assertEqual(out[2]["role"], "user")
+        self.assertEqual(out[2]["content"][0]["type"], "image_url")
+        self.assertIn("png;base64,XYZ", out[2]["content"][0]["image_url"]["url"])
+
+    def test_tool_result_with_text_and_image_splits_text_to_tool_image_to_user(self) -> None:
+        messages = [
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "tu_2", "name": "Read", "input": {}},
+            ]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "tu_2", "content": [
+                    {"type": "text", "text": "Here is the image"},
+                    {"type": "image",
+                     "source": {"type": "base64", "media_type": "image/jpeg", "data": "JJJ"}},
+                ]},
+            ]},
+        ]
+        out = _convert_anthropic_messages_to_openai(messages)
+        tool_msgs = [m for m in out if m.get("role") == "tool"]
+        self.assertEqual(len(tool_msgs), 1)
+        self.assertIn("Here is the image", tool_msgs[0]["content"])
+        # The image becomes its own following user message.
+        idx = out.index(tool_msgs[0])
+        self.assertEqual(out[idx + 1]["role"], "user")
+        self.assertEqual(out[idx + 1]["content"][0]["type"], "image_url")
+
+    def test_tool_result_text_only_unchanged_no_extra_user_message(self) -> None:
+        """A text-only tool_result must NOT spawn an extra synthetic user
+        message — regression guard for the split."""
+        messages = [
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "tu_t", "name": "Bash", "input": {}},
+            ]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "tu_t", "content": "hello world"},
+            ]},
+        ]
+        out = _convert_anthropic_messages_to_openai(messages)
+        # assistant + tool message exactly (no extra user message)
+        roles = [m["role"] for m in out]
+        self.assertEqual(roles, ["assistant", "tool"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User reported wildly wrong output when asking about an `@`-mentioned image. Same provider + model:

- **Python (before):** "The screenshot shows a Google search results page for the query 'how to use claude code'."
- **TypeScript:** "The image shows an aerial view of a white research or expedition-style ship..."

Two independent bugs both contribute. The recently merged PR #154 (image-handling parity) fixed the Read tool's image pipeline but missed both of these paths.

### Bug A — `@image.png` reads PNG as UTF-8 text and floods system-reminder with mojibake

`src/command_system/input_processing.py:expand_at_mentions` was opening **every** `@`-mentioned file with `open(path, "r", encoding="utf-8", errors="replace")`. For a PNG that produces utf-8 replacement chars over the binary bytes — and `format_at_mention_attachments` wrapped the garbage in `<system-reminder>Contents of foo.png:\n\`\`\`\n<garbage>\n\`\`\`\n</system-reminder>` and prepended it to the user message. The model latched onto ASCII fragments (PNG XMP "Screenshot" metadata, type tags) and hallucinated the rest.

**Fix:** detect image extensions (`png/jpg/jpeg/gif/webp`, aligned with the Read tool's `IMAGE_EXTENSIONS`) BEFORE the text-mode `open()`. Image files go through the same pipeline the Read tool uses (post-#154): bounded byte read → magic-byte format sniff → `maybe_resize_image` → `compress_image_to_token_budget` fallback when still over the 5 MB base64 API ceiling. Return a `kind="image"` attachment carrying `base64` + `media_type`. The REPL builds a mixed `[TextBlock, ImageBlock, ...]` user message via new helper `build_image_content_blocks` so the API receives a real multimodal payload — matching TS's auto-Read-on-`@image` behaviour.

### Bug B — `_dispatch_single_tool` JSON-stringifies list content, destroying image blocks

`src/query/query.py:_dispatch_single_tool` was running `json.dumps` on any non-string tool_result content, turning Read's properly-shaped `[{"type": "image", "source": {...}}]` into a text JSON blob. The Anthropic API then received an image tool_result whose content was text JSON; the model literally could not see the image and would continue hallucinating even after explicitly calling Read. PR #154's regression test only checked for the synthetic-error placeholder so this slipped through.

**Fix:** preserve list shape end-to-end. `ToolResultBlock.content` already accepts `str | list[Any]`; `maybe_persist_large_tool_result` already short-circuits image lists via `_has_image_block`; `content_block_to_dict` already serializes per-element. The dispatcher just needed to stop coercing.

### Collateral fix — Anthropic image blocks didn't translate for OpenAI-compatible providers

`_convert_anthropic_messages_to_openai` was passing Anthropic image blocks through unchanged — OpenAI/GLM/Minimax/DeepSeek/OpenRouter either rejected the request or silently dropped the image. This was pre-existing (Read tool images had the same problem post-#154) but my `@image.png` work would have widened the attack surface, so addressed it here.

- New `_anthropic_image_block_to_openai` translates `{"type": "image", "source": {"type": "base64", ...}}` → `{"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}`.
- For tool_result content with images: emits `role=tool` (text body, with a placeholder when image-only) followed by a synthetic `role=user` carrying the `image_url` blocks. Unavoidable split since OpenAI's `role=tool` doesn't accept multimodal content. Comment in-place documents the model-perception risk.
- Empty-data guard returns `None` rather than producing `data:image/png;base64,` (which OpenAI rejects with a confusing error).

### Signature widening

- `Conversation.add_user_message(content: str | list[ContentBlock])`
- `QueryEngine.submit_message(prompt: str | list[ContentBlock])`

Both bodies already supported list content via `_normalize_message_content` / `MessageContent`; only the annotations changed, so existing string-callers (TUI, headless) are unaffected.

### REPL UX

Image @-mentions skip the direct-stream short-circuit (it can only carry plain text) and print `Read image <path>` instead of `Listed file <path>`.

## Test plan

- [x] **29 new tests** across `tests/test_at_mention_images.py` (17), `tests/test_openai_compat_image_translation.py` (13), and `tests/parity/test_e2e_file_read.py` (+2 covering Bug B dispatcher list-preservation and the aggregate-budget pressure path).
- [x] Bug A coverage: single + multi-image + mixed text+image `@`-mentions; magic-byte detection beats extension (misnamed `.png` with JPEG bytes); empty/undecodable images dropped silently; oversize-image compression brings base64 under API limit (real 4000×4000 random-noise PNG); doubly-oversize image dropped (monkeypatched); end-to-end through `normalize_messages_for_api`.
- [x] Bug B coverage: dispatcher returns list content with `{"type": "image", ...}`; full pipeline through `normalize_messages_for_api` yields proper image block in API payload; aggregate-pressure path (image still survives at `tool_result_chars_so_far = MAX - 1`, counter NOT bumped by image bytes).
- [x] OpenAI translation coverage: valid/invalid block translation; JPEG/PNG/missing-media-type defaults; empty-data guard; tool_result image-only + image+text + text-only-no-regression paths.
- [x] **Wider suite: 4984 pass, 0 new failures.** 9 pre-existing failures (mcp/zhipuai import issues + workspace-path tests) unchanged.
- [x] Manual REPL smoke: critic-agent verified the BLOCKER fix against a real 48 MB random-noise PNG (compresses to 1.16 MB base64, doubly-oversize drops). Final manual REPL test with a real screenshot still recommended before declaring shipped.
- [x] **Critic review loop: APPROVE after three rounds.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)