### PR TITLE
fix(openrouter): break image_unsupported context-stuck loop

### DIFF
--- a/src/query/engine.py
+++ b/src/query/engine.py
@@ -269,7 +269,36 @@ class QueryEngine:
             self._mutable_messages.append(message)
 
             if on_message:
+                # Contract: on_message callbacks must NOT mirror engine
+                # state (read get_messages() / mutable_messages) — the
+                # image-unsupported strip below runs after on_message,
+                # so a mirror taken here may see un-stripped state for
+                # one frame. Production callers don't mirror here today
+                # (only legacy run_agent.py uses on_message at all, and
+                # it consumes content directly), so this is a contract
+                # note for future callers rather than a current defect.
                 on_message(message)
+
+            # Image-unsupported recovery: the provider rejected the
+            # request because the model has zero image capability. The
+            # user's image-bearing message is now in _mutable_messages
+            # and would re-trigger the same 404 on every subsequent
+            # submit_message() call. Strip image blocks (keeping the
+            # text intent) so text-only follow-ups work. The TypeScript
+            # reference expects the user to manually rewind via the Ink
+            # MessageSelector ("Double press esc to go back"); the Rich
+            # REPL has no equivalent UI, so we recover automatically
+            # here. Mirrored by repl/core.py for session.conversation.
+            if (
+                isinstance(message, AssistantMessage)
+                and getattr(message, "_api_error", None) == "image_unsupported"
+            ):
+                from ..context_system.microcompact import (
+                    strip_images_from_typed_messages,
+                )
+                self._mutable_messages = strip_images_from_typed_messages(
+                    self._mutable_messages
+                )
 
             yield message
 

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -450,6 +450,36 @@ async def _call_model_sync(
             err_msg._api_error = "media_size"  # type: ignore[attr-defined]
             return [err_msg], []
 
+        # Model-capability rejection: the selected model has zero image
+        # support, so the request can never succeed as long as the image
+        # stays in conversation context. Tag the error so the engine
+        # strips images from history (see QueryEngine.submit_message)
+        # and surfaces a clear user-facing message instead of the raw
+        # provider 404. The user-facing wording shape follows TS's
+        # friendly error messages (e.g. getPdfInvalidErrorMessage at
+        # typescript/src/services/api/errors.ts) but the case itself
+        # is Python-new — TS has no dedicated handler for this
+        # capability rejection, so don't grep TS for an analog branch.
+        # See IMAGE_UNSUPPORTED_ERROR_MESSAGE in services/api/errors.py
+        # for the longer rationale.
+        from ..services.api.errors import (
+            IMAGE_UNSUPPORTED_ERROR_MESSAGE,
+            is_image_unsupported_error,
+        )
+        if is_image_unsupported_error(error_str):
+            err_msg = _create_assistant_api_error_message(
+                IMAGE_UNSUPPORTED_ERROR_MESSAGE,
+                error="image_unsupported",
+            )
+            err_msg._api_error = "image_unsupported"  # type: ignore[attr-defined]
+            # Preserve raw provider wording so a future bug report
+            # ("the fix didn't work") has the actual 404 payload to
+            # debug against, instead of just the friendly message.
+            # Mirrors TS's ``errorDetails: error.message`` at
+            # typescript/src/services/api/errors.ts:752.
+            err_msg.errorDetails = error_str
+            return [err_msg], []
+
         raise
 
     assistant_blocks: list[Any] = []

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -2271,6 +2271,33 @@ class ClawcodexREPL:
         self.console.print()
         return True
 
+    def _sanitize_conversation_for_api_error(self, msg: Any) -> None:
+        """If the assistant message signals an API error that requires
+        history sanitization, mutate ``session.conversation.messages``
+        in place to match the engine's sanitized state.
+
+        Today only ``image_unsupported`` triggers a strip: the user's
+        image-bearing UserMessage stays in ``session.conversation``
+        otherwise, and the direct-stream path (line ~2186 of this file)
+        reads ``session.conversation.messages`` rather than
+        ``engine.get_messages()`` — so without this mirror, a short
+        text-only follow-up routed through ``_stream_direct_response``
+        would hit the same provider with the still-cached image.
+
+        Extracted into a method so the REPL handler stays terse AND so
+        this load-bearing behaviour has a direct unit-test surface
+        (test_repl_conversation_sanitization).
+        """
+        if getattr(msg, "_api_error", None) == "image_unsupported":
+            from src.context_system.microcompact import (
+                strip_images_from_typed_messages,
+            )
+            self.session.conversation.messages = (
+                strip_images_from_typed_messages(
+                    self.session.conversation.messages
+                )
+            )
+
     def chat(self, user_input: str, max_turns: int | None = None):
         """Send message to LLM and display response.
 
@@ -2492,6 +2519,14 @@ class ClawcodexREPL:
 
                     if isinstance(msg, AssistantMessage):
                         self.session.conversation.add_assistant_message(msg.content)
+                        # Engine-side mirror: the engine has just stripped
+                        # image blocks from _mutable_messages; keep
+                        # session.conversation in sync so the persisted
+                        # JSONL and the direct-stream path (which reads
+                        # session.conversation directly) don't carry stale
+                        # image content. See QueryEngine.submit_message for
+                        # the engine side of this pair.
+                        self._sanitize_conversation_for_api_error(msg)
                         usage = getattr(msg, "usage", None)
                         if isinstance(usage, dict):
                             in_toks = int(usage.get("input_tokens", 0) or 0)

--- a/src/services/api/errors.py
+++ b/src/services/api/errors.py
@@ -6,6 +6,27 @@ from typing import Any
 
 API_ERROR_MESSAGE_PREFIX = "API Error"
 PROMPT_TOO_LONG_ERROR_MESSAGE = "Prompt is too long"
+# Surfaced when the provider rejects an image because the selected model
+# does not accept image input (e.g. OpenRouter routing a request to a
+# text-only DeepSeek endpoint and returning
+# "No endpoints found that support image input" / 404).
+#
+# The user-facing wording follows the shape of TypeScript's friendly
+# error messages at typescript/src/services/api/errors.ts (e.g.
+# getPdfInvalidErrorMessage / getImageTooLargeErrorMessage) — clear
+# about what happened and what the user can do. The TypeScript code
+# has no dedicated handler for this specific capability rejection (the
+# error would land in the catch-all at typescript/src/query.ts:1065),
+# so this Python branch is genuinely new behaviour, not a port. We
+# additionally strip the offending image from history (see
+# QueryEngine.submit_message); TypeScript expects the user to manually
+# "Double press esc" via the Ink MessageSelector, which the Rich REPL
+# does not have.
+IMAGE_UNSUPPORTED_ERROR_MESSAGE = (
+    "The current model does not accept image input. The image has been "
+    "removed from conversation history so subsequent requests will work. "
+    "Switch to a vision-capable model to process images."
+)
 
 
 class PromptTooLongError(Exception):
@@ -117,6 +138,28 @@ def is_media_size_error(raw: str) -> bool:
     )
 
 
+def is_image_unsupported_error(raw: str) -> bool:
+    """Detect provider errors meaning "this model does not accept image input".
+
+    Distinct from ``is_media_size_error`` (image too large): the model
+    has zero image capability, so stripping or resizing won't help —
+    history must be sanitized so the request can be re-issued text-only.
+
+    Pattern set covers OpenRouter's real wording plus likely paraphrases
+    from other OpenAI-compatible providers. Match is case-insensitive
+    because providers paraphrase casing inconsistently.
+    """
+    low = raw.lower()
+    return (
+        "no endpoints found that support image" in low
+        or "does not support image" in low
+        or "doesn't support image" in low
+        or "image input is not supported" in low
+        or "image_input_not_supported" in low
+        or "model does not accept image" in low
+    )
+
+
 @dataclass(frozen=True)
 class ErrorClassification:
     retryable: bool
@@ -143,6 +186,17 @@ def categorize_retryable_api_error(error: Exception) -> ErrorClassification:
         return ErrorClassification(
             retryable=False,
             error_type="prompt_too_long",
+            message=str(error),
+        )
+
+    if is_image_unsupported_error(str(error)):
+        # Model-capability rejection — retrying won't help. The query
+        # layer tags it ``image_unsupported`` and the engine strips
+        # images from history; this classification keeps the retry
+        # layer from looping on a permanent failure.
+        return ErrorClassification(
+            retryable=False,
+            error_type="image_unsupported",
             message=str(error),
         )
 

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -7,12 +7,14 @@ from src.services.api.errors import (
     APITimeoutError,
     ErrorClassification,
     FallbackTriggeredError,
+    IMAGE_UNSUPPORTED_ERROR_MESSAGE,
     InvalidAPIKeyError,
     MaxOutputTokensError,
     OverloadedError,
     PromptTooLongError,
     RateLimitError,
     categorize_retryable_api_error,
+    is_image_unsupported_error,
     is_invalid_api_key,
     is_media_size_error,
     is_overloaded_error,
@@ -146,6 +148,67 @@ class TestIsMediaSizeError(unittest.TestCase):
         self.assertFalse(is_media_size_error("some other error"))
 
 
+class TestIsImageUnsupportedError(unittest.TestCase):
+    # Pin every substring the classifier matches so a downstream regex
+    # refactor can't silently narrow the set and reintroduce the
+    # context-stuck bug for any one provider's wording.
+    def test_openrouter_404_phrase(self) -> None:
+        self.assertTrue(
+            is_image_unsupported_error(
+                "Error code: 404 - {'error': {'message': "
+                "'No endpoints found that support image input', 'code': 404}}"
+            )
+        )
+
+    def test_paraphrase_does_not_support(self) -> None:
+        self.assertTrue(
+            is_image_unsupported_error("This model does not support image input")
+        )
+
+    def test_paraphrase_doesnt_support(self) -> None:
+        self.assertTrue(
+            is_image_unsupported_error("Selected model doesn't support image content")
+        )
+
+    def test_paraphrase_image_input_is_not_supported(self) -> None:
+        self.assertTrue(
+            is_image_unsupported_error("Image input is not supported by deepseek-v4")
+        )
+
+    def test_paraphrase_snake_case_code(self) -> None:
+        self.assertTrue(is_image_unsupported_error("error: image_input_not_supported"))
+
+    def test_paraphrase_model_does_not_accept(self) -> None:
+        self.assertTrue(
+            is_image_unsupported_error("Model does not accept image content blocks")
+        )
+
+    def test_case_insensitive(self) -> None:
+        self.assertTrue(
+            is_image_unsupported_error("NO ENDPOINTS FOUND THAT SUPPORT IMAGE INPUT")
+        )
+
+    # Negative cases — make sure we don't accidentally classify adjacent
+    # but distinct errors (PTL, media-size, generic 404) as
+    # image_unsupported, which would route them away from their own
+    # recovery paths.
+    def test_negative_prompt_too_long(self) -> None:
+        self.assertFalse(
+            is_image_unsupported_error("prompt is too long: 250000 tokens > 200000")
+        )
+
+    def test_negative_media_size(self) -> None:
+        self.assertFalse(
+            is_image_unsupported_error("image exceeds the maximum allowed size")
+        )
+
+    def test_negative_generic_404(self) -> None:
+        self.assertFalse(is_image_unsupported_error("404 Not Found"))
+
+    def test_negative_empty(self) -> None:
+        self.assertFalse(is_image_unsupported_error(""))
+
+
 class TestCategorizeRetryableApiError(unittest.TestCase):
     def test_rate_limit_retryable(self) -> None:
         result = categorize_retryable_api_error(RateLimitError())
@@ -191,6 +254,25 @@ class TestCategorizeRetryableApiError(unittest.TestCase):
         result = categorize_retryable_api_error(ValueError("bad value"))
         self.assertFalse(result.retryable)
         self.assertEqual(result.error_type, "unknown")
+
+    def test_image_unsupported_not_retryable(self) -> None:
+        # Pins the contract used by the engine's strip-and-recover path:
+        # the retry layer must NOT loop on a permanent capability error.
+        err = Exception("No endpoints found that support image input")
+        result = categorize_retryable_api_error(err)
+        self.assertFalse(result.retryable)
+        self.assertEqual(result.error_type, "image_unsupported")
+
+
+class TestImageUnsupportedErrorMessage(unittest.TestCase):
+    def test_message_mentions_strip_and_alternative(self) -> None:
+        # Pins user-facing wording: must (1) say the image was removed
+        # so the user understands why future turns "forget" the image,
+        # and (2) suggest a class of alternative model (kept provider-
+        # neutral so the suggestion doesn't go stale when model names
+        # change).
+        self.assertIn("removed from conversation history", IMAGE_UNSUPPORTED_ERROR_MESSAGE)
+        self.assertIn("vision-capable", IMAGE_UNSUPPORTED_ERROR_MESSAGE)
 
 
 if __name__ == "__main__":

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -125,6 +125,223 @@ class TestQueryEngine(unittest.TestCase):
         self.assertIsInstance(engine.session_id, str)
         self.assertGreater(len(engine.session_id), 0)
 
+    def test_image_unsupported_strips_images_from_mutable_messages(self):
+        """When the provider rejects images, the engine must strip
+        image blocks from history so the NEXT submit_message() call
+        doesn't re-trip the same error on an unrelated text-only
+        request. This is the engine-side mirror of the OpenRouter +
+        DeepSeek context-stuck loop.
+
+        Pins three invariants:
+        1. The user's text intent (TextBlock) survives — only the
+           rejected image bytes are dropped.
+        2. The placeholder text "[image]" appears so the model can
+           still see that an image WAS there.
+        3. No ImageBlock instances or dict-shape image blocks remain
+           anywhere in get_messages() — including ToolResultBlock-
+           nested image content (the realistic Read-tool case).
+        """
+        from src.types.content_blocks import (
+            ImageBlock, TextBlock, ToolResultBlock,
+        )
+
+        provider = MagicMock()
+        err = Exception(
+            "Error code: 404 - {'error': {'message': "
+            "'No endpoints found that support image input', 'code': 404}}"
+        )
+        provider.chat_stream_response.side_effect = err
+        provider.chat.side_effect = err
+
+        # Seed initial_messages with a tool_result-nested image (mirrors
+        # what the Read tool produces when reading an image file —
+        # src/tool_system/tools/read.py emits a ToolResultBlock whose
+        # content is a list containing a dict-shape image block). This
+        # is the realistic case that produced the original bug, in
+        # addition to direct @-mention images.
+        nested_image_dict = {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "BBBB",
+            },
+        }
+        prior_user_with_nested = UserMessage(content=[
+            TextBlock(text="prior turn"),
+            ToolResultBlock(
+                tool_use_id="tool_use_prior",
+                content=[nested_image_dict],
+            ),
+        ])
+
+        engine = QueryEngine(QueryEngineConfig(
+            cwd=self.workspace,
+            provider=provider,
+            tool_registry=self.registry,
+            tools=self.registry.list_tools(),
+            tool_context=self.context,
+            system_prompt="You are helpful.",
+            max_turns=10,
+            initial_messages=[prior_user_with_nested],
+        ))
+
+        async def run():
+            async for _ in engine.submit_message([
+                TextBlock(text="describe this picture"),
+                ImageBlock(source={
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": "AAAA",
+                }),
+            ]):
+                pass
+
+        _run(run())
+
+        msgs = engine.get_messages()
+        # Find the last user message we just submitted.
+        user_msgs = [m for m in msgs if isinstance(m, UserMessage)]
+        self.assertGreaterEqual(len(user_msgs), 2)
+        last_user = user_msgs[-1]
+        self.assertIsInstance(last_user.content, list)
+
+        text_blocks = [
+            b for b in last_user.content
+            if isinstance(b, TextBlock)
+        ]
+        # (1) text intent preserved
+        texts = [b.text for b in text_blocks]
+        self.assertIn("describe this picture", texts)
+        # (2) placeholder present
+        self.assertIn("[image]", texts)
+
+        # (3) no ImageBlock instances or dict-shape image blocks
+        # remain anywhere in get_messages — INCLUDING nested in
+        # ToolResultBlock.content. Recurses one level deep to mirror
+        # the realistic Read-tool case (a deeper nesting walker is
+        # bounded by strip_images_from_typed_messages itself; one
+        # level is the production shape).
+        def assert_no_images_in(blocks: list, where: str) -> None:
+            for block in blocks:
+                self.assertNotIsInstance(
+                    block, ImageBlock,
+                    f"ImageBlock must be stripped after image_unsupported error ({where})",
+                )
+                if isinstance(block, dict):
+                    self.assertNotEqual(
+                        block.get("type"), "image",
+                        f"dict-shape image block must be stripped ({where})",
+                    )
+                # Recurse into ToolResultBlock.content
+                if isinstance(block, ToolResultBlock) and isinstance(block.content, list):
+                    assert_no_images_in(block.content, f"{where} > tool_result")
+
+        for i, m in enumerate(msgs):
+            if isinstance(m.content, list):
+                assert_no_images_in(m.content, f"message[{i}]")
+
+    def test_image_unsupported_error_does_not_recur_on_next_submit(self):
+        """End-to-end regression for the user's reported bug: after the
+        image-unsupported error fires, a second submit_message() with a
+        text-only prompt must reach the provider WITHOUT any image
+        blocks in the messages payload. The strip step is what fixes
+        the original context-stuck loop, so the test must inspect the
+        actual provider call args (not just count) to demonstrate it."""
+        from src.types.content_blocks import ImageBlock, TextBlock
+
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        # First call: provider rejects the image.
+        # Second call: provider succeeds (because images are stripped).
+        success = ChatResponse(
+            content="Here is your blog app plan...",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 8},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+        provider.chat.side_effect = [
+            Exception("No endpoints found that support image input"),
+            success,
+        ]
+
+        engine = self._make_engine(provider)
+
+        async def run():
+            # Turn 1: image-bearing message → error.
+            async for _ in engine.submit_message([
+                TextBlock(text="describe"),
+                ImageBlock(source={
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": "AAAA",
+                }),
+            ]):
+                pass
+            # Turn 2: unrelated text-only request — MUST succeed.
+            collected_text: list[str] = []
+            async for m in engine.submit_message("create a blog app"):
+                if isinstance(m, AssistantMessage):
+                    if isinstance(m.content, str):
+                        collected_text.append(m.content)
+                    elif isinstance(m.content, list):
+                        for b in m.content:
+                            if isinstance(b, TextBlock):
+                                collected_text.append(b.text)
+            return collected_text
+
+        result = _run(run())
+        self.assertIn("Here is your blog app plan...", result,
+                      "second turn must succeed after image strip")
+        # Provider was called twice (turn 1 errored, turn 2 succeeded).
+        self.assertEqual(provider.chat.call_count, 2)
+
+        # The bug fix is meaningful only if turn 2's API call carries
+        # NO image content. Inspect the actual messages payload sent
+        # to provider.chat on the second call. A regression that
+        # left the image in history would show up here as an
+        # ImageBlock instance or {"type": "image"} dict, even though
+        # the call still returned `success` because the mock is
+        # unconditional. This pins the real invariant: the wire
+        # payload no longer carries the offending image.
+        second_call_kwargs = provider.chat.call_args_list[1].kwargs
+        second_call_args = provider.chat.call_args_list[1].args
+        # The first positional arg or `messages=` kwarg holds the list.
+        messages_arg = (
+            second_call_kwargs.get("messages")
+            if "messages" in second_call_kwargs
+            else (second_call_args[0] if second_call_args else None)
+        )
+        self.assertIsNotNone(messages_arg, "provider.chat must be called with messages")
+
+        def _collect_images(content, into):
+            if not isinstance(content, list):
+                return
+            for block in content:
+                if isinstance(block, ImageBlock):
+                    into.append(block)
+                    continue
+                if isinstance(block, dict) and block.get("type") == "image":
+                    into.append(block)
+                    continue
+                # Recurse into tool_result content (dict or typed).
+                if isinstance(block, dict) and block.get("type") == "tool_result":
+                    _collect_images(block.get("content"), into)
+                inner = getattr(block, "content", None)
+                if isinstance(inner, list):
+                    _collect_images(inner, into)
+
+        leaked: list = []
+        for m in messages_arg:
+            content = m.get("content") if isinstance(m, dict) else getattr(m, "content", None)
+            _collect_images(content, leaked)
+        self.assertEqual(
+            leaked, [],
+            "no image blocks may reach the provider on the post-strip turn; "
+            f"found {len(leaked)} leaked image block(s): {leaked!r}",
+        )
+
 
 class TestEngineProducesCacheableSystemBlocks(unittest.TestCase):
     """Joint WI-1.1 + WI-1.2 acceptance: end-to-end engine produces blocks.

--- a/tests/test_query_error_recovery.py
+++ b/tests/test_query_error_recovery.py
@@ -453,6 +453,93 @@ class TestPhaseBPromptTooLongRecovery(unittest.TestCase):
         self.assertEqual(holder.value.reason, "completed")
 
 
+class TestImageUnsupportedClassification(unittest.TestCase):
+    """Image-unsupported errors must be classified at _call_model_sync so
+    the engine can strip image history (instead of bubbling through the
+    generic catch-all that loses the tag)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.temp_dir.name)
+        self.registry = build_default_registry()
+        self.context = ToolContext(workspace_root=self.workspace)
+        self.abort = AbortController()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_openrouter_404_yields_tagged_api_error(self):
+        """OpenRouter's "No endpoints found that support image input"
+        must surface as a tagged ``_api_error == "image_unsupported"``
+        AssistantMessage — NOT a generic ``isApiErrorMessage`` with no
+        tag. The tag is what triggers the engine's strip-and-recover
+        path, so dropping it would re-introduce the context-stuck bug."""
+        from unittest.mock import MagicMock
+        from src.types.content_blocks import ImageBlock, TextBlock
+        from src.services.api.errors import IMAGE_UNSUPPORTED_ERROR_MESSAGE
+
+        provider = MagicMock()
+        # _call_model_sync prefers chat_stream_response; falling back to
+        # chat only on NotImplementedError. Raise the 404 from both so
+        # we don't depend on the streaming/sync code path.
+        err = Exception(
+            "Error code: 404 - {'error': {'message': "
+            "'No endpoints found that support image input', 'code': 404}}"
+        )
+        provider.chat_stream_response.side_effect = err
+        provider.chat.side_effect = err
+
+        messages = [
+            UserMessage(content=[
+                TextBlock(text="describe"),
+                ImageBlock(source={
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": "AAAA",
+                }),
+            ])
+        ]
+        params = QueryParams(
+            messages=messages,
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=2,
+        )
+
+        collected = []
+
+        async def run():
+            async for msg in query(params):
+                collected.append(msg)
+
+        _run(run())
+
+        tagged = [
+            m for m in collected
+            if isinstance(m, AssistantMessage)
+            and getattr(m, "_api_error", None) == "image_unsupported"
+        ]
+        self.assertEqual(
+            len(tagged), 1,
+            "exactly one image_unsupported-tagged AssistantMessage must reach the consumer",
+        )
+        self.assertTrue(tagged[0].isApiErrorMessage)
+        # Message must be the user-friendly constant, not the raw 404.
+        self.assertEqual(tagged[0].content, IMAGE_UNSUPPORTED_ERROR_MESSAGE)
+        # errorDetails must preserve the raw provider payload — a
+        # future bug-reporter ("the fix didn't work for me") needs the
+        # actual 404 text to diagnose, not just the friendly message.
+        self.assertIsNotNone(tagged[0].errorDetails)
+        self.assertIn(
+            "No endpoints found that support image input",
+            tagged[0].errorDetails or "",
+        )
+
+
 class TestPhaseBBlockingLimitPreemption(unittest.TestCase):
     """Ch5/B.4 + B.5 — pre-emption guards before the API call."""
 

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -638,5 +638,224 @@ class TestSession(unittest.TestCase):
                 self.assertEqual(loaded.conversation.messages[0].content, "Test message")
 
 
+class TestREPLConversationSanitization(unittest.TestCase):
+    """Pins the REPL-side mirror of the engine's image-strip recovery.
+
+    The bug: an image-bearing UserMessage that triggered an
+    `image_unsupported` API error stays in `session.conversation` after
+    the engine strips its own `_mutable_messages`. The direct-stream
+    path (_build_direct_stream_payload) reads
+    `session.conversation.messages` directly — so without this mirror,
+    a short text-only follow-up routed through `_stream_direct_response`
+    would re-trigger the same 404 against Anthropic/Minimax providers.
+
+    Tests `_sanitize_conversation_for_api_error` directly (extracted
+    from the engine-loop handler for testability) so a regression
+    that removes the strip call or breaks the tag check is caught.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.config_dir = Path(self.temp_dir) / ".clawcodex"
+        self.config_dir.mkdir(parents=True, exist_ok=True)
+        self.config_file = self.config_dir / "config.json"
+        test_config = {
+            "default_provider": "openrouter",
+            "providers": {
+                "openrouter": {
+                    "api_key": "sk-or-test-key-12345678",
+                    "base_url": "https://openrouter.ai/api/v1",
+                    "default_model": "deepseek/deepseek-v4-pro",
+                }
+            }
+        }
+        with open(self.config_file, 'w') as f:
+            json.dump(test_config, f)
+        self._global_config_patcher = patch.object(
+            config_module, "GLOBAL_CONFIG_FILE", self.config_file
+        )
+        self._global_config_patcher.start()
+        config_module._default_manager = None
+
+    def tearDown(self):
+        self._global_config_patcher.stop()
+        config_module._default_manager = None
+
+    def _make_repl(self):
+        # Build the smallest valid REPL fixture for unit-level testing
+        # of the sanitization helper. We need a real `session.conversation`
+        # (so the helper has something to mutate); everything else is mocked.
+        with patch('src.repl.core.Session.create') as mock_session_create:
+            session = Mock()
+            session.conversation = Conversation()
+            session.session_id = "test-session"
+            session.provider = "openrouter"
+            session.model = "deepseek/deepseek-v4-pro"
+            mock_session_create.return_value = session
+
+            with patch('src.repl.core.get_provider_class') as mock_provider_class:
+                mock_provider = Mock()
+                mock_provider.model = "deepseek/deepseek-v4-pro"
+                mock_provider_class.return_value = mock_provider
+
+                repl = ClawcodexREPL(provider_name="openrouter")
+                repl.session = session
+                return repl
+
+    def test_image_unsupported_strips_images_from_conversation(self):
+        """When an image_unsupported AssistantMessage is passed to the
+        sanitizer, image blocks must be removed from
+        session.conversation.messages — direct-stream path correctness
+        depends on this."""
+        from src.types.content_blocks import ImageBlock, TextBlock
+        from src.types.messages import AssistantMessage
+
+        repl = self._make_repl()
+
+        repl.session.conversation.add_user_message([
+            TextBlock(text="describe this image"),
+            ImageBlock(source={
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "AAAA",
+            }),
+        ])
+
+        err_msg = AssistantMessage(
+            content="image not supported text",
+            isApiErrorMessage=True,
+        )
+        err_msg._api_error = "image_unsupported"  # type: ignore[attr-defined]
+
+        repl._sanitize_conversation_for_api_error(err_msg)
+
+        # User's text intent must survive; the image bytes get the
+        # "[image]" placeholder (matches strip_images_from_typed_messages
+        # contract).
+        user_msgs = [m for m in repl.session.conversation.messages
+                     if m.role == "user"]
+        self.assertEqual(len(user_msgs), 1)
+        content = user_msgs[0].content
+        self.assertIsInstance(content, list)
+        texts = [b.text for b in content if isinstance(b, TextBlock)]
+        self.assertIn("describe this image", texts)
+        self.assertIn("[image]", texts)
+        for block in content:
+            self.assertNotIsInstance(block, ImageBlock)
+
+    def test_no_strip_when_error_tag_absent(self):
+        """A regular assistant message (or one with a different
+        _api_error tag) must NOT strip images — the strip is gated on
+        the specific image_unsupported tag, so adjacent errors
+        (prompt_too_long, etc.) keep their own recovery semantics."""
+        from src.types.content_blocks import ImageBlock, TextBlock
+        from src.types.messages import AssistantMessage
+
+        repl = self._make_repl()
+        repl.session.conversation.add_user_message([
+            TextBlock(text="describe"),
+            ImageBlock(source={
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "AAAA",
+            }),
+        ])
+
+        # Non-error success message: no-op.
+        ok_msg = AssistantMessage(content="here is the description")
+        repl._sanitize_conversation_for_api_error(ok_msg)
+        user_content = repl.session.conversation.messages[0].content
+        self.assertTrue(
+            any(isinstance(b, ImageBlock) for b in user_content),
+            "image must survive when no _api_error tag is set",
+        )
+
+        # Different error tag: no-op too (prompt_too_long has its own
+        # recovery via reactive_compact and must not trip image strip).
+        ptl_msg = AssistantMessage(
+            content="prompt too long",
+            isApiErrorMessage=True,
+        )
+        ptl_msg._api_error = "prompt_too_long"  # type: ignore[attr-defined]
+        repl._sanitize_conversation_for_api_error(ptl_msg)
+        user_content = repl.session.conversation.messages[0].content
+        self.assertTrue(
+            any(isinstance(b, ImageBlock) for b in user_content),
+            "image must survive when a non-image_unsupported tag is set",
+        )
+
+    def test_chat_invokes_sanitization_for_image_unsupported(self):
+        """Wiring test: the engine-loop handler in REPL.chat MUST call
+        ``_sanitize_conversation_for_api_error`` when the engine yields
+        an image_unsupported AssistantMessage. Without this test, the
+        helper could exist + be unit-tested while the call site is
+        silently removed — and the bug would re-appear only at runtime
+        on the direct-stream path."""
+        from src.types.content_blocks import ImageBlock, TextBlock
+        from src.types.messages import AssistantMessage
+
+        repl = self._make_repl()
+
+        # Seed the conversation with an image-bearing user message so
+        # if the strip is invoked, we have something to strip.
+        repl.session.conversation.add_user_message([
+            TextBlock(text="describe"),
+            ImageBlock(source={
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "AAAA",
+            }),
+        ])
+
+        # Mock the engine's submit_message to yield exactly one
+        # AssistantMessage tagged image_unsupported. This is the
+        # message-shape the production query() function yields for the
+        # OpenRouter 404.
+        async def fake_submit_message(content):
+            err_msg = AssistantMessage(
+                content="image not supported text",
+                isApiErrorMessage=True,
+            )
+            err_msg._api_error = "image_unsupported"  # type: ignore[attr-defined]
+            yield err_msg
+
+        sanitize_spy = Mock(wraps=repl._sanitize_conversation_for_api_error)
+        repl._sanitize_conversation_for_api_error = sanitize_spy  # type: ignore[method-assign]
+
+        # Patch QueryEngine.__init__ -> .submit_message to use our fake.
+        # ``chat()`` constructs a QueryEngine inline, so we patch the
+        # class to return a mock with our fake_submit_message.
+        with patch('src.repl.core.QueryEngine') as mock_engine_class:
+            mock_engine = Mock()
+            mock_engine.submit_message = fake_submit_message
+            mock_engine.reset_abort_controller = Mock()
+            mock_engine.get_messages = Mock(return_value=[])
+            mock_engine_class.return_value = mock_engine
+
+            # Suppress console output so the test runs silently.
+            repl.console.print = Mock()
+            # Ensure the test's prompt routes through the QueryEngine
+            # path (the direct-stream path doesn't go through the
+            # handler we're testing). A long-enough prompt with a
+            # code keyword forces _should_try_direct_stream to return
+            # False; see core.py:2199-2238.
+            repl.chat("please read README.md and summarize it for me carefully")
+
+        sanitize_spy.assert_called()
+        # And it must have been called with the tagged AssistantMessage,
+        # not some other message — pinning the call-site code path.
+        call_args_list = sanitize_spy.call_args_list
+        self.assertTrue(
+            any(
+                len(call.args) >= 1
+                and isinstance(call.args[0], AssistantMessage)
+                and getattr(call.args[0], "_api_error", None) == "image_unsupported"
+                for call in call_args_list
+            ),
+            "sanitization must be called with the image_unsupported AssistantMessage; "
+            f"got call_args_list={call_args_list!r}",
+        )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

- OpenRouter + a text-only model (e.g. `deepseek/deepseek-v4-pro`) + an `@`-mentioned image returned 404 *"No endpoints found that support image input"* — and that error then re-fired on every subsequent text-only prompt because the image content was never removed from history. Session became unusable.
- Classify the error in `_call_model_sync` (tag `_api_error=\"image_unsupported\"`, `errorDetails` preserves the raw 404), surface a friendly user-facing message, and auto-strip image blocks from history via the existing `strip_images_from_typed_messages` helper. Engine sanitizes `_mutable_messages`; REPL mirrors the strip into `session.conversation` so the direct-stream path and persisted JSONL stay consistent.
- Approach mirrors TypeScript's `errors.ts:730-754` classification pattern. Auto-strip is a Python-specific addition because the Rich REPL has no equivalent to the Ink `MessageSelector` rewind UI that TS expects the user to use after these errors.

## Test plan

- [x] `uv run pytest tests/test_api_errors.py -q` — classifier + retryable categorization + wording pin
- [x] `uv run pytest tests/test_query_error_recovery.py -q` — `_call_model_sync` tags the error, `errorDetails` preserved
- [x] `uv run pytest tests/test_query_engine.py -q` — engine strips top-level + `ToolResultBlock`-nested images; end-to-end regression inspects `provider.chat.call_args_list[1]` to confirm no images leak on turn 2
- [x] `uv run pytest tests/test_repl.py::TestREPLConversationSanitization -q` — helper strips correctly + no-op on non-`image_unsupported` tags + wiring test confirms the call site at `core.py:2529` actually invokes the helper during `chat()`
- [x] `uv run pytest tests/ -q -k image --ignore=tests/integration --ignore=tests/test_providers.py --ignore-glob='tests/test_mcp_*'` — 178 image-related tests pass (no regressions)
- [ ] Manual: OpenRouter + DeepSeek, `@`-mention an image, observe friendly error; then send an unrelated text-only prompt — must succeed (this is the bug fix)
- [ ] Manual: regression check — same flow against `anthropic/claude-sonnet-4.5` via OpenRouter, image flow still works

(6 pre-existing `test_repl.py::TestREPL` failures from a broken `zhipuai` package version are environment-only, confirmed reproducible against `HEAD` with these changes stashed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)