### PR TITLE
fix(repl): use list_tools() in /tools and /context handlers

### DIFF
--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -1902,7 +1902,7 @@ class ClawcodexREPL:
             self.show_help()
 
         elif cmd == '/tools':
-            names = [spec.name for spec in self.tool_registry.list_specs()]
+            names = [spec.name for spec in self.tool_registry.list_tools()]
             names.sort(key=str.lower)
             self.console.print("\n[bold]Available tools:[/bold]")
             for name in names:
@@ -1995,7 +1995,7 @@ class ClawcodexREPL:
                     "description": spec.description,
                     "input_schema": dict(spec.input_schema) if hasattr(spec.input_schema, "keys") else spec.input_schema,
                 }
-                for spec in self.tool_registry.list_specs()
+                for spec in self.tool_registry.list_tools()
             ]
             self.command_context.config["system_prompt"] = ""
             # Try new command system

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -209,6 +209,37 @@ class TestREPL(unittest.TestCase):
                         for args, _kwargs in repl.console.print.call_args_list
                     ))
 
+    def test_handle_command_tools_lists_registered_tools(self):
+        """/tools must call ToolRegistry.list_tools() and print each name.
+
+        Regression: the handler previously called the non-existent
+        ``list_specs()`` and crashed with AttributeError on every invocation.
+        """
+        from types import SimpleNamespace
+        with patch('src.config.get_config_path', return_value=self.config_dir / "config.json"):
+            with patch('src.repl.core.Session.create'):
+                with patch('src.repl.core.get_provider_class') as mock_provider_class:
+                    mock_provider = Mock()
+                    mock_provider.model = "glm-4.5"
+                    mock_provider_class.return_value = mock_provider
+
+                    repl = ClawcodexREPL(provider_name="glm")
+                    repl.tool_registry = SimpleNamespace(
+                        list_tools=lambda: [
+                            SimpleNamespace(name="Bash"),
+                            SimpleNamespace(name="Read"),
+                        ]
+                    )
+                    repl.console.print = Mock()
+                    repl.handle_command("/tools")
+
+                    printed = " ".join(
+                        str(args[0]) for args, _ in repl.console.print.call_args_list if args
+                    )
+                    self.assertIn("Available tools:", printed)
+                    self.assertIn("Bash", printed)
+                    self.assertIn("Read", printed)
+
     def test_chat_uses_true_api_stream_for_simple_prompt(self):
         """Simple prompts should use provider.chat_stream when stream mode is enabled."""
         with patch('src.config.get_config_path', return_value=self.config_dir / "config.json"):


### PR DESCRIPTION
## Summary
- `/tools` crashed with `AttributeError: 'ToolRegistry' object has no attribute 'list_specs'` — `ToolRegistry` exposes `list_tools()`, not `list_specs()`. Every other call site in the codebase already uses `list_tools()` (e.g. `src/tui/commands.py:167`, `src/tool_system/agent_loop.py:311`, `src/entrypoints/tui.py:231`).
- Fixed the same latent bug at `src/repl/core.py:1998` in the `/context` handler — it would have crashed identically when invoked.
- Added a regression test (`test_handle_command_tools_lists_registered_tools`) so a future rename doesn't reintroduce this.

## Repro (before)
```
> /tools
AttributeError: 'ToolRegistry' object has no attribute 'list_specs'
  at src/repl/core.py:1905
```

## Test plan
- [x] New regression test passes: `pytest tests/test_repl.py::TestREPL::test_handle_command_tools_lists_registered_tools`
- [x] Manual: `/tools` now prints the bullet-listed tool names
- [x] No other call sites of `list_specs` remain (`grep -rn list_specs src/ tests/` → empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)