### PR TITLE
fix(repl): resolve Tool.description to string in /context schema payload

### DIFF
--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -203,6 +203,7 @@ from src.providers import get_provider_class
 from src.providers.anthropic_provider import AnthropicProvider
 from src.providers.base import ChatMessage
 from src.providers.minimax_provider import MinimaxProvider
+from src.services.api.claude import tool_to_api_schema
 from src.tool_system.context import ToolContext
 from src.tool_system.defaults import build_default_registry
 from src.tool_system.protocol import ToolCall
@@ -1990,12 +1991,7 @@ class ClawcodexREPL:
             self.command_context.config["provider"] = self.provider
             self.command_context.config["model"] = self.provider.model
             self.command_context.config["tool_schemas"] = [
-                spec.to_dict() if hasattr(spec, "to_dict") else {
-                    "name": spec.name,
-                    "description": spec.description,
-                    "input_schema": dict(spec.input_schema) if hasattr(spec.input_schema, "keys") else spec.input_schema,
-                }
-                for spec in self.tool_registry.list_tools()
+                tool_to_api_schema(spec) for spec in self.tool_registry.list_tools()
             ]
             self.command_context.config["system_prompt"] = ""
             # Try new command system

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -240,6 +240,49 @@ class TestREPL(unittest.TestCase):
                     self.assertIn("Bash", printed)
                     self.assertIn("Read", printed)
 
+    def test_handle_command_context_resolves_tool_descriptions_to_strings(self):
+        """/context must populate tool_schemas with string descriptions.
+
+        Regression: Tool.description is a Callable[[dict], str], not a string.
+        The handler previously stuffed the callable straight into the
+        ``tool_schemas`` payload; downstream consumers expecting a string
+        would receive a function reference.
+        """
+        from types import SimpleNamespace
+        from src.tool_system.build_tool import build_tool
+        from src.tool_system.protocol import ToolResult
+
+        def _noop(_input, _ctx):
+            return ToolResult(name="X", output={}, is_error=False)
+
+        real_tool = build_tool(
+            name="Bash",
+            input_schema={"type": "object"},
+            call=_noop,
+            description=lambda _i: "Run a shell command",
+        )
+
+        with patch('src.config.get_config_path', return_value=self.config_dir / "config.json"):
+            with patch('src.repl.core.Session.create'):
+                with patch('src.repl.core.get_provider_class') as mock_provider_class:
+                    mock_provider = Mock()
+                    mock_provider.model = "glm-4.5"
+                    mock_provider_class.return_value = mock_provider
+
+                    repl = ClawcodexREPL(provider_name="glm")
+                    repl.tool_registry = SimpleNamespace(list_tools=lambda: [real_tool])
+                    repl._try_execute_new_command = Mock(return_value=(False, None))
+                    repl.console.print = Mock()
+
+                    repl.handle_command("/context")
+
+                    schemas = repl.command_context.config["tool_schemas"]
+                    self.assertEqual(len(schemas), 1)
+                    self.assertEqual(schemas[0]["name"], "Bash")
+                    self.assertIsInstance(schemas[0]["description"], str)
+                    self.assertEqual(schemas[0]["description"], "Run a shell command")
+                    self.assertEqual(schemas[0]["input_schema"], {"type": "object"})
+
     def test_chat_uses_true_api_stream_for_simple_prompt(self):
         """Simple prompts should use provider.chat_stream when stream mode is enabled."""
         with patch('src.config.get_config_path', return_value=self.config_dir / "config.json"):


### PR DESCRIPTION
Follow-up to #162. Addresses the two non-blocking observations the reviewer flagged in the `/context` handler.

## Summary
- `Tool.description` is `Callable[[dict], str]` (see `src/tool_system/build_tool.py:49`), not a string. The `/context` handler was passing the callable straight into `tool_schemas`, so the downstream context analyzer received a function reference where it expected a string.
- The `hasattr(spec, "to_dict")` branch was dead code — `Tool` is a dataclass with no `to_dict` method, so that branch was never taken.
- Both are fixed by reusing the existing `tool_to_api_schema` helper from `src/services/api/claude.py`, which is the same converter the real API call site uses. Single source of truth for the `{name, description, input_schema}` shape.

## Test plan
- [x] New regression test `test_handle_command_context_resolves_tool_descriptions_to_strings` asserts the populated `tool_schemas[0]["description"]` is a `str`, not a callable.
- [x] Existing `/tools` regression test still passes.
- [x] No circular import — `src/services/api/claude.py` only depends on stdlib + sibling `.errors` and `.logging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)