### PR TITLE
fix(repl): populate /context system_prompt with the real prompt

### DIFF
--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -203,6 +203,7 @@ from src.providers import get_provider_class
 from src.providers.anthropic_provider import AnthropicProvider
 from src.providers.base import ChatMessage
 from src.providers.minimax_provider import MinimaxProvider
+from src.context_system.prompt_assembly import build_full_system_prompt
 from src.services.api.claude import tool_to_api_schema
 from src.tool_system.context import ToolContext
 from src.tool_system.defaults import build_default_registry
@@ -1988,12 +1989,22 @@ class ClawcodexREPL:
 
         elif cmd == '/context':
             # Populate command context config for context analysis
+            style_name = getattr(self.tool_context, "output_style_name", None)
+            style_dir = getattr(self.tool_context, "output_style_dir", None)
+            style_prompt = resolve_output_style(style_name, style_dir).prompt
+            tools = self.tool_registry.list_tools()
+
             self.command_context.config["provider"] = self.provider
             self.command_context.config["model"] = self.provider.model
             self.command_context.config["tool_schemas"] = [
-                tool_to_api_schema(spec) for spec in self.tool_registry.list_tools()
+                tool_to_api_schema(spec) for spec in tools
             ]
-            self.command_context.config["system_prompt"] = ""
+            self.command_context.config["system_prompt"] = build_full_system_prompt(
+                cwd=str(self.tool_context.workspace_root),
+                tools=tools,
+                tool_registry=self.tool_registry,
+                append_system_prompt=style_prompt,
+            )
             # Try new command system
             try:
                 handled, result_text = self._try_execute_new_command('context', '')

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -262,6 +262,9 @@ class TestREPL(unittest.TestCase):
             description=lambda _i: "Run a shell command",
         )
 
+        sentinel = "REGRESSION_SENTINEL_3F2A_style_prompt_was_plumbed_through"
+        style_stub = SimpleNamespace(prompt=sentinel)
+
         with patch('src.config.get_config_path', return_value=self.config_dir / "config.json"):
             with patch('src.repl.core.Session.create'):
                 with patch('src.repl.core.get_provider_class') as mock_provider_class:
@@ -274,7 +277,8 @@ class TestREPL(unittest.TestCase):
                     repl._try_execute_new_command = Mock(return_value=(False, None))
                     repl.console.print = Mock()
 
-                    repl.handle_command("/context")
+                    with patch('src.repl.core.resolve_output_style', return_value=style_stub):
+                        repl.handle_command("/context")
 
                     schemas = repl.command_context.config["tool_schemas"]
                     self.assertEqual(len(schemas), 1)
@@ -282,6 +286,15 @@ class TestREPL(unittest.TestCase):
                     self.assertIsInstance(schemas[0]["description"], str)
                     self.assertEqual(schemas[0]["description"], "Run a shell command")
                     self.assertEqual(schemas[0]["input_schema"], {"type": "object"})
+
+                    # Regression: system_prompt must reflect the real prompt,
+                    # not be hard-coded to "" (which made the analyzer's
+                    # token estimate silently miss the entire system prompt).
+                    # The sentinel proves the style_prompt was actually
+                    # threaded through build_full_system_prompt.
+                    system_prompt = repl.command_context.config["system_prompt"]
+                    self.assertIsInstance(system_prompt, str)
+                    self.assertIn(sentinel, system_prompt)
 
     def test_chat_uses_true_api_stream_for_simple_prompt(self):
         """Simple prompts should use provider.chat_stream when stream mode is enabled."""


### PR DESCRIPTION
Stacked on #163. GitHub will auto-retarget the base to `main` when #163 merges.

## Summary
- The `/context` analyzer reads `system_prompt` from `command_context.config` to estimate token cost (`src/context_system/context_analyzer.py:196`). The REPL was hard-coding it to `""`, so the displayed estimate was always missing the entire system prompt — often the biggest single contributor to the prompt budget.
- Replace with a real `build_full_system_prompt(...)` call using the same parameters `QueryEngine` uses at chat time (`cwd`, `tools`, `tool_registry`, `append_system_prompt` resolved from the active output style).
- The sync helper is sufficient: the async engine path exists only to produce `cache_control` block markers, which are a wire-format concern with no effect on token counting (analyzer just calls `count_tokens(system_prompt)`).
- `/compact` left alone — its handler (`_compact_async`) does not consume `system_prompt`, so the same `= ""` line there is harmless legacy.

## Test plan
- [x] Updated `test_handle_command_context_resolves_tool_descriptions_to_strings` to assert `system_prompt` contains a sentinel passed via `append_system_prompt` (proves the plumbing works end-to-end, not just that the string is non-empty).
- [x] Both `/context` and `/tools` regression tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)