### PR TITLE
refactor(repl): extract style-prompt helper and log silent dispatcher failures

### DIFF
--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -190,11 +190,14 @@ except ModuleNotFoundError:  # pragma: no cover
             self.text = text
 from pathlib import Path
 import asyncio
+import logging
 import sys
 import json
 import threading
 from collections import deque
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 from src.agent import Session
 from src.config import get_provider_config
@@ -1989,9 +1992,7 @@ class ClawcodexREPL:
 
         elif cmd == '/context':
             # Populate command context config for context analysis
-            style_name = getattr(self.tool_context, "output_style_name", None)
-            style_dir = getattr(self.tool_context, "output_style_dir", None)
-            style_prompt = resolve_output_style(style_name, style_dir).prompt
+            style_prompt = self._resolve_active_style_prompt()
             tools = self.tool_registry.list_tools()
 
             self.command_context.config["provider"] = self.provider
@@ -2005,14 +2006,13 @@ class ClawcodexREPL:
                 tool_registry=self.tool_registry,
                 append_system_prompt=style_prompt,
             )
-            # Try new command system
             try:
                 handled, result_text = self._try_execute_new_command('context', '')
                 if handled and result_text:
                     self.console.print(Markdown(result_text))
                     return
             except Exception:
-                pass
+                logger.exception("/context dispatch failed")
             self.console.print("[yellow]/context analysis unavailable in this context.[/yellow]")
 
         elif cmd == '/compact':
@@ -2020,14 +2020,13 @@ class ClawcodexREPL:
             self.command_context.config["provider"] = self.provider
             self.command_context.config["model"] = self.provider.model
             self.command_context.config["system_prompt"] = ""
-            # Try new command system
             try:
                 handled, result_text = self._try_execute_new_command('compact', '')
                 if handled and result_text:
                     self.console.print("\n[green]" + result_text + "[/green]")
                     return
             except Exception:
-                pass
+                logger.exception("/compact dispatch failed")
             # Simple fallback: just clear conversation
             self.session.conversation.clear()
             self._engine_messages = []
@@ -2180,10 +2179,13 @@ class ClawcodexREPL:
     def _provider_uses_system_kwarg(self) -> bool:
         return isinstance(self.provider, (AnthropicProvider, MinimaxProvider))
 
-    def _build_direct_stream_payload(self) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    def _resolve_active_style_prompt(self) -> str:
         style_name = getattr(self.tool_context, "output_style_name", None)
         style_dir = getattr(self.tool_context, "output_style_dir", None)
-        style_prompt = resolve_output_style(style_name, style_dir).prompt
+        return resolve_output_style(style_name, style_dir).prompt
+
+    def _build_direct_stream_payload(self) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        style_prompt = self._resolve_active_style_prompt()
 
         if self._provider_uses_system_kwarg():
             return self.session.conversation.get_messages(), (
@@ -2444,11 +2446,7 @@ class ClawcodexREPL:
                     self.console.print("\n")
                     return
 
-            from src.outputStyles import resolve_output_style
-
-            style_name = getattr(self.tool_context, "output_style_name", None)
-            style_dir = getattr(self.tool_context, "output_style_dir", None)
-            style_prompt = resolve_output_style(style_name, style_dir).prompt
+            style_prompt = self._resolve_active_style_prompt()
 
             tools = self.tool_registry.list_tools()
 

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -296,6 +296,66 @@ class TestREPL(unittest.TestCase):
                     self.assertIsInstance(system_prompt, str)
                     self.assertIn(sentinel, system_prompt)
 
+    def test_handle_command_context_logs_dispatch_failure(self):
+        """A failure inside _try_execute_new_command must be logged, not silently swallowed."""
+        with patch('src.config.get_config_path', return_value=self.config_dir / "config.json"):
+            with patch('src.repl.core.Session.create'):
+                with patch('src.repl.core.get_provider_class') as mock_provider_class:
+                    mock_provider = Mock()
+                    mock_provider.model = "glm-4.5"
+                    mock_provider_class.return_value = mock_provider
+
+                    repl = ClawcodexREPL(provider_name="glm")
+                    repl._try_execute_new_command = Mock(
+                        side_effect=RuntimeError("analyzer exploded")
+                    )
+                    repl.console.print = Mock()
+
+                    with self.assertLogs("src.repl.core", level="ERROR") as cm:
+                        repl.handle_command("/context")
+
+                    self.assertTrue(any(
+                        "/context dispatch failed" in rec.getMessage()
+                        for rec in cm.records
+                    ))
+                    self.assertTrue(any(
+                        "analyzer exploded" in (rec.exc_text or "")
+                        for rec in cm.records
+                    ))
+
+    def test_handle_command_compact_logs_dispatch_failure(self):
+        """/compact must log dispatcher failures too — pins symmetry with /context."""
+        with patch('src.config.get_config_path', return_value=self.config_dir / "config.json"):
+            with patch('src.repl.core.Session.create') as mock_session_factory:
+                mock_session = Mock()
+                mock_session.conversation = Mock()
+                mock_session_factory.return_value = mock_session
+
+                with patch('src.repl.core.get_provider_class') as mock_provider_class:
+                    mock_provider = Mock()
+                    mock_provider.model = "glm-4.5"
+                    mock_provider_class.return_value = mock_provider
+
+                    repl = ClawcodexREPL(provider_name="glm")
+                    repl._try_execute_new_command = Mock(
+                        side_effect=RuntimeError("compactor exploded")
+                    )
+                    repl.console.print = Mock()
+
+                    with self.assertLogs("src.repl.core", level="ERROR") as cm:
+                        repl.handle_command("/compact")
+
+                    self.assertTrue(any(
+                        "/compact dispatch failed" in rec.getMessage()
+                        for rec in cm.records
+                    ))
+                    self.assertTrue(any(
+                        "compactor exploded" in (rec.exc_text or "")
+                        for rec in cm.records
+                    ))
+                    # Fallback path must still run after the failure.
+                    mock_session.conversation.clear.assert_called_once()
+
     def test_chat_uses_true_api_stream_for_simple_prompt(self):
         """Simple prompts should use provider.chat_stream when stream mode is enabled."""
         with patch('src.config.get_config_path', return_value=self.config_dir / "config.json"):


### PR DESCRIPTION
Stacked on #164. GitHub will auto-retarget the base to `main` when the upstream PRs merge.

Two small cleanups suggested by the reviewer on the previous PRs:

## 1. Extract `_resolve_active_style_prompt()` helper
The `style_name` / `style_dir` / `resolve_output_style(...).prompt` lookup had accumulated three copies — in `/context`, `_build_direct_stream_payload`, and the chat path. Two of the three drifted: the chat-path copy carried a redundant inline `from src.outputStyles import resolve_output_style` even though the top-level import covers it.

Now one private helper, three call sites. Removed the stale inline re-import along the way.

## 2. Log silent dispatcher failures in `/context` and `/compact`
The `except Exception: pass` around `_try_execute_new_command` swallowed dispatcher failures with no diagnostic trail. The user got a generic fallback message, the log got nothing.

Replaced with `logger.exception(...)` at ERROR level (matches the repo convention used in `src/config.py:23`, `src/token_estimation.py:26`, etc.). User-visible fallback messages are unchanged — only the silent swallow becomes a visible record.

`/compact`'s `system_prompt = ""` is left alone — its handler (`_compact_async`) doesn't consume the key, so it's harmless legacy and out of scope here.

## Test plan
- [x] New `test_handle_command_context_logs_dispatch_failure` and `test_handle_command_compact_logs_dispatch_failure` assert that a forced `RuntimeError` from the dispatcher both gets logged with the right message AND surfaces the original exception text via `exc_text`.
- [x] All four `/context` and `/tools` regression tests in this chain pass.
- [x] Pre-existing test_repl.py failures (6 × `ZhipuAI` ImportError) are unchanged — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)