### PR TITLE
feat(advisor) 1/4: helpers + settings field + orphan tool_use guard

### DIFF
--- a/src/settings/types.py
+++ b/src/settings/types.py
@@ -69,6 +69,11 @@ class SettingsSchema:
     # Model
     model: str = ""
     small_fast_model: str = ""
+    # Advisor — server-side reviewer tool. Empty string = unset (no /advisor).
+    # Persisted analogue of TS appState.advisorModel; the /advisor slash
+    # command writes here, and _call_model_sync reads from here at request
+    # time. See src/utils/advisor.py.
+    advisor_model: str = ""
 
     # Provider
     provider: str = "anthropic"

--- a/src/types/messages.py
+++ b/src/types/messages.py
@@ -399,6 +399,20 @@ def ensure_tool_result_pairing(
             i += 1
             continue
 
+        # Pre-pass: collect server-side tool_result IDs (e.g.
+        # ``advisor_tool_result``, ``mcp_tool_result``). Server tools
+        # emit both the use and the result blocks in the SAME assistant
+        # message — if the stream was interrupted before the result
+        # arrived, the use has no matching result and the API rejects
+        # with e.g. "advisor tool use without corresponding
+        # advisor_tool_result". Mirrors TS messages.ts:5217-5223.
+        server_result_ids: set[str] = set()
+        for block in content:
+            if isinstance(block, dict):
+                tool_use_id = block.get("tool_use_id")
+                if isinstance(tool_use_id, str):
+                    server_result_ids.add(tool_use_id)
+
         seen_tool_use_ids: set[str] = set()
         final_content = []
         for block in content:
@@ -408,6 +422,15 @@ def ensure_tool_result_pairing(
                     continue
                 all_seen_tool_use_ids.add(block_id)
                 seen_tool_use_ids.add(block_id)
+            # Drop orphan server_tool_use / mcp_tool_use blocks whose
+            # matching ``*_tool_result`` never made it into the same
+            # message (interrupted stream). Mirrors TS messages.ts:5247.
+            if (
+                isinstance(block, dict)
+                and block.get("type") in ("server_tool_use", "mcp_tool_use")
+                and block.get("id") not in server_result_ids
+            ):
+                continue
             final_content.append(block)
 
         if not final_content:

--- a/src/utils/advisor.py
+++ b/src/utils/advisor.py
@@ -1,0 +1,271 @@
+"""Advisor tool integration — Python port of typescript/src/utils/advisor.ts.
+
+The advisor is a server-side tool: when the model emits an advisor
+``server_tool_use`` block, the Anthropic API runs a stronger reviewer model
+on the conversation so far and returns an ``advisor_tool_result`` block.
+The client never executes anything — its only responsibilities are:
+
+1. opt the request into the ``advisor-tool-2026-03-01`` beta,
+2. declare the advisor tool schema in ``tools[]`` (cache-preserving append),
+3. inject ``ADVISOR_TOOL_INSTRUCTIONS`` into the system prompt,
+4. preserve the resulting blocks in conversation history,
+5. strip them on requests that won't carry the beta header (the API would
+   400 otherwise).
+
+Provider gating is strict: any non-first-party Anthropic provider
+(Bedrock/Vertex shims, OpenAI-compat, Gemini, etc.) MUST NOT see the header
+or the schema — 3P endpoints 400 on the unknown tool type.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.providers.base import BaseProvider
+
+
+# Wire-format constants — these strings are load-bearing for API parity with
+# the TypeScript reference. Do NOT edit without coordinating a matching change
+# in typescript/src/constants/betas.ts and typescript/src/utils/advisor.ts.
+ADVISOR_BETA_HEADER = "advisor-tool-2026-03-01"
+ADVISOR_TOOL_TYPE = "advisor_20260301"
+ADVISOR_TOOL_NAME = "advisor"
+
+
+# Byte-for-byte copy of typescript/src/utils/advisor.ts:130-145. The prompt
+# IS the "when to invoke" policy — drift here changes model behavior.
+ADVISOR_TOOL_INSTRUCTIONS = """# Advisor Tool
+
+You have access to an `advisor` tool backed by a stronger reviewer model. It takes NO parameters -- when you call it, your entire conversation history is automatically forwarded. The advisor sees the task, every tool call you've made, every result you've seen.
+
+Call advisor BEFORE substantive work -- before writing code, before committing to an interpretation, before building on an assumption. If the task requires orientation first (finding files, reading code, seeing what's there), do that, then call advisor. Orientation is not substantive work. Writing, editing, and declaring an answer are.
+
+Also call advisor:
+- When you believe the task is complete. BEFORE this call, make your deliverable durable: write the file, stage the change, save the result. The advisor call takes time; if the session ends during it, a durable result persists and an unwritten one doesn't.
+- When stuck -- errors recurring, approach not converging, results that don't fit.
+- When considering a change of approach.
+
+On tasks longer than a few steps, call advisor at least once before committing to an approach and once before declaring done. On short reactive tasks where the next action is dictated by tool output you just read, you don't need to keep calling -- the advisor adds most of its value on the first call, before the approach crystallizes.
+
+Give the advice serious weight. If you follow a step and it fails empirically, or you have primary-source evidence that contradicts a specific claim (the file says X, the code does Y), adapt. A passing self-test is not evidence the advice is wrong -- it's evidence your test doesn't check what the advice is checking.
+
+If you've already retrieved data pointing one way and the advisor points another: don't silently switch. Surface the conflict in one more advisor call -- \"I found X, you suggest Y, which constraint breaks the tie?\" The advisor saw your evidence but may have underweighted it; a reconcile call is cheaper than committing to the wrong branch."""
+
+
+_DISABLE_ENV = "CLAUDE_CODE_DISABLE_ADVISOR_TOOL"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_ADVISOR_PLACEHOLDER_TEXT = "[Advisor response]"
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
+
+
+def model_supports_advisor(model: str | None) -> bool:
+    """Whether the main-loop model can call the advisor tool.
+
+    Mirror of TS ``modelSupportsAdvisor`` at typescript/src/utils/advisor.ts:89.
+    The USER_TYPE=ant escape hatch matches the TS behavior so internal users
+    can dogfood advisor on unreleased model strings.
+    """
+    m = (model or "").lower()
+    return (
+        "opus-4-6" in m
+        or "sonnet-4-6" in m
+        or os.environ.get("USER_TYPE") == "ant"
+    )
+
+
+def is_valid_advisor_model(model: str | None) -> bool:
+    """Whether a model string is allowed in the ``model`` field of the
+    advisor tool schema. Identical predicate to ``model_supports_advisor``
+    in the TS reference (typescript/src/utils/advisor.ts:99).
+    """
+    m = (model or "").lower()
+    return (
+        "opus-4-6" in m
+        or "sonnet-4-6" in m
+        or os.environ.get("USER_TYPE") == "ant"
+    )
+
+
+def is_advisor_enabled(provider: "BaseProvider | None") -> bool:
+    """Whether the current process+provider may carry the advisor beta header.
+
+    Env-disable shortcut beats provider check. Without a provider (e.g. a
+    pre-startup query about command availability) we cannot know what
+    endpoint we'll talk to, so we conservatively return False.
+    """
+    if _env_truthy(_DISABLE_ENV):
+        return False
+    if provider is None:
+        return False
+    # Local import to avoid a top-level cycle: cache_state may import from
+    # providers in the future and we don't want to lock that.
+    from src.state.cache_state import is_first_party_provider
+    return is_first_party_provider(provider)
+
+
+def can_user_configure_advisor(provider: "BaseProvider | None" = None) -> bool:
+    """Whether the user is allowed to configure /advisor in this process.
+
+    The slash command needs to render in command lists even before a
+    provider is built (e.g. ``--help``), so when ``provider`` is None we
+    fall back to the env-disable check only. Once a provider exists, we
+    additionally require it to be first-party Anthropic; otherwise
+    /advisor would silently no-op every request and the UI would lie.
+    """
+    if _env_truthy(_DISABLE_ENV):
+        return False
+    if provider is None:
+        return True
+    return is_advisor_enabled(provider)
+
+
+def _block_field(block: Any, key: str) -> Any:
+    """Read ``block[key]`` whether ``block`` is a dict-like or attr-style object."""
+    if isinstance(block, Mapping):
+        return block.get(key)
+    return getattr(block, key, None)
+
+
+def is_advisor_block(block: Any) -> bool:
+    """Detect an advisor server-tool-use or its result block.
+
+    Mirror of TS ``isAdvisorBlock`` at typescript/src/utils/advisor.ts:36.
+    Accepts both API-shape dicts and typed SDK objects.
+    """
+    if block is None:
+        return False
+    bt = _block_field(block, "type")
+    if bt == "advisor_tool_result":
+        return True
+    if bt == "server_tool_use":
+        return _block_field(block, "name") == ADVISOR_TOOL_NAME
+    return False
+
+
+def build_advisor_tool_schema(model: str) -> dict[str, Any]:
+    """Return the ``tools[]`` entry that opts a request into the advisor.
+
+    The shape mirrors typescript/src/services/api/claude.ts:1417 — the API
+    expects a server tool with the dated type discriminator, a literal
+    name of ``advisor``, and the chosen advisor model in ``model``.
+    """
+    return {
+        "type": ADVISOR_TOOL_TYPE,
+        "name": ADVISOR_TOOL_NAME,
+        "model": model,
+    }
+
+
+def _content_is_only_placeholders(content: list[Any]) -> bool:
+    """True iff every block is non-substantive (would yield no UI text).
+
+    Matches TS stripAdvisorBlocks's "empty / thinking-only / blank-text"
+    fallback condition at typescript/src/utils/messages.ts:5489-5495.
+    """
+    for block in content:
+        bt = _block_field(block, "type")
+        if bt in ("thinking", "redacted_thinking"):
+            continue
+        if bt == "text":
+            text = _block_field(block, "text") or ""
+            if not text or not str(text).strip():
+                continue
+            return False
+        return False
+    return True
+
+
+def extract_advisor_result_text(content: Any) -> str | None:
+    """Pull the human-readable advice text from an advisor_tool_result.
+
+    The advisor's ``content`` field is a tagged union::
+
+        {type: 'advisor_result',         text: '...'}
+        {type: 'advisor_redacted_result', encrypted_content: '...'}
+        {type: 'advisor_tool_result_error', error_code: '...'}
+
+    Returns the text for ``advisor_result``, ``None`` for the other
+    shapes (use ``extract_advisor_error_code`` for the error branch;
+    redacted is intentionally opaque to the client).
+    """
+    if not isinstance(content, Mapping):
+        return None
+    if content.get("type") == "advisor_result":
+        text = content.get("text")
+        if isinstance(text, str) and text:
+            return text
+    return None
+
+
+def extract_advisor_error_code(content: Any) -> str | None:
+    """Pull the error_code string from an advisor_tool_result_error content."""
+    if not isinstance(content, Mapping):
+        return None
+    if content.get("type") == "advisor_tool_result_error":
+        code = content.get("error_code")
+        if isinstance(code, str):
+            return code
+    return None
+
+
+def strip_advisor_blocks(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Drop advisor blocks from assistant content for API replay.
+
+    Mirror of TS ``stripAdvisorBlocks`` at typescript/src/utils/messages.ts:5478.
+    Used on requests that will NOT carry the advisor beta header — the API
+    400s on advisor blocks in history when the header is absent.
+
+    When stripping empties an assistant message (or leaves only
+    thinking/blank text), inserts a ``[Advisor response]`` placeholder so
+    the API doesn't reject empty assistant content.
+
+    The input list is not mutated; messages whose content changed are
+    shallow-cloned, others are passed by reference.
+    """
+    changed = False
+    result: list[dict[str, Any]] = []
+    for msg in messages:
+        if not isinstance(msg, Mapping) or msg.get("role") != "assistant":
+            result.append(msg)
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            result.append(msg)
+            continue
+        filtered = [b for b in content if not is_advisor_block(b)]
+        if len(filtered) == len(content):
+            result.append(msg)
+            continue
+        changed = True
+        if not filtered or _content_is_only_placeholders(filtered):
+            filtered = list(filtered) + [
+                {"type": "text", "text": _ADVISOR_PLACEHOLDER_TEXT}
+            ]
+        new_msg = dict(msg)
+        new_msg["content"] = filtered
+        result.append(new_msg)
+    return result if changed else messages
+
+
+__all__ = [
+    "ADVISOR_BETA_HEADER",
+    "ADVISOR_TOOL_INSTRUCTIONS",
+    "ADVISOR_TOOL_NAME",
+    "ADVISOR_TOOL_TYPE",
+    "build_advisor_tool_schema",
+    "can_user_configure_advisor",
+    "extract_advisor_error_code",
+    "extract_advisor_result_text",
+    "is_advisor_block",
+    "is_advisor_enabled",
+    "is_valid_advisor_model",
+    "model_supports_advisor",
+    "strip_advisor_blocks",
+]

--- a/tests/test_advisor_helpers.py
+++ b/tests/test_advisor_helpers.py
@@ -1,0 +1,407 @@
+"""Unit tests for ``src/utils/advisor.py`` — the gate predicates, block
+detection, message-stripping pass, and schema builder for the
+server-side advisor tool.
+
+These tests cover the byte-for-byte parity surface against TS
+``utils/advisor.ts`` plus the Python-specific gating helpers we added
+on top.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from src.utils.advisor import (
+    ADVISOR_BETA_HEADER,
+    ADVISOR_TOOL_INSTRUCTIONS,
+    ADVISOR_TOOL_NAME,
+    ADVISOR_TOOL_TYPE,
+    build_advisor_tool_schema,
+    can_user_configure_advisor,
+    is_advisor_block,
+    is_advisor_enabled,
+    is_valid_advisor_model,
+    model_supports_advisor,
+    strip_advisor_blocks,
+)
+
+
+class TestConstants(unittest.TestCase):
+    def test_beta_header_value(self) -> None:
+        # This string is load-bearing for API parity with TS — any change
+        # silently shifts what the API accepts.
+        self.assertEqual(ADVISOR_BETA_HEADER, "advisor-tool-2026-03-01")
+
+    def test_tool_type_value(self) -> None:
+        self.assertEqual(ADVISOR_TOOL_TYPE, "advisor_20260301")
+
+    def test_tool_name_value(self) -> None:
+        self.assertEqual(ADVISOR_TOOL_NAME, "advisor")
+
+    def test_instructions_byte_identical_to_ts(self) -> None:
+        # Pinned SHA256 of the TS template literal at
+        # ``typescript/src/utils/advisor.ts:130-145`` (verified during
+        # implementation). Drift in this prompt changes when the model
+        # decides to call the advisor — keep them locked together.
+        #
+        # If the TS source is reachable from this checkout (it lives at
+        # ``<repo_root>/typescript/`` outside the worktree), also do
+        # the live byte-equality check. Either path is enough to fail
+        # loudly on drift.
+        import hashlib
+        import re
+        from pathlib import Path
+
+        expected_sha = (
+            "35a8fb57145324fe579360bbe94086f432187092ed1c53e3f147254f3afc674b"
+        )
+        actual_sha = hashlib.sha256(
+            ADVISOR_TOOL_INSTRUCTIONS.encode("utf-8")
+        ).hexdigest()
+        self.assertEqual(
+            actual_sha,
+            expected_sha,
+            "ADVISOR_TOOL_INSTRUCTIONS bytes drifted from TS — re-sync from "
+            "typescript/src/utils/advisor.ts:130 and update the SHA pin.",
+        )
+
+        # Live cross-check when the TS source is reachable. We walk
+        # parent directories from this test file to find the
+        # ``typescript/`` peer, then read the literal. Skip silently
+        # when it isn't around (e.g. inside a Python-only worktree).
+        ts_path: Path | None = None
+        for parent in Path(__file__).resolve().parents:
+            cand = parent / "typescript" / "src" / "utils" / "advisor.ts"
+            if cand.exists():
+                ts_path = cand
+                break
+        if ts_path is None:
+            return
+        src = ts_path.read_text()
+        m = re.search(
+            r"ADVISOR_TOOL_INSTRUCTIONS = `(.+?)`$",
+            src,
+            re.DOTALL | re.MULTILINE,
+        )
+        self.assertIsNotNone(m, "failed to extract TS template literal")
+        # The only template-literal escapes used in this string are
+        # backslash-backtick (used to wrap the word ``advisor`` in
+        # backticks). Translate to plain backtick to compare against
+        # Python's raw string.
+        ts_text = m.group(1).replace(r"\`", "`")
+        self.assertEqual(ts_text, ADVISOR_TOOL_INSTRUCTIONS)
+
+
+class TestModelSupportsAdvisor(unittest.TestCase):
+    """Mirror TS ``modelSupportsAdvisor`` and ``isValidAdvisorModel`` —
+    predicates collapse to: opus-4-6 / sonnet-4-6 / USER_TYPE=ant."""
+
+    def test_opus_4_6_supported(self) -> None:
+        self.assertTrue(model_supports_advisor("claude-opus-4-6"))
+        self.assertTrue(model_supports_advisor("CLAUDE-OPUS-4-6"))  # case-insensitive
+        self.assertTrue(is_valid_advisor_model("claude-opus-4-6"))
+
+    def test_sonnet_4_6_supported(self) -> None:
+        self.assertTrue(model_supports_advisor("claude-sonnet-4-6"))
+        self.assertTrue(is_valid_advisor_model("claude-sonnet-4-6"))
+
+    def test_older_models_unsupported(self) -> None:
+        for m in [
+            "claude-opus-4-5",
+            "claude-sonnet-4-5",
+            "claude-opus-4-1",
+            "claude-3-5-sonnet-20241022",
+            "claude-haiku-4-5",
+            "",
+        ]:
+            with self.subTest(model=m):
+                self.assertFalse(model_supports_advisor(m))
+                self.assertFalse(is_valid_advisor_model(m))
+
+    def test_none_treated_as_unsupported(self) -> None:
+        self.assertFalse(model_supports_advisor(None))
+        self.assertFalse(is_valid_advisor_model(None))
+
+    @patch.dict(os.environ, {"USER_TYPE": "ant"})
+    def test_ant_escape_hatch_supports_unknown_model(self) -> None:
+        # TS preserves this escape so internal users can dogfood the
+        # advisor against pre-release models — keep parity.
+        self.assertTrue(model_supports_advisor("claude-some-future-thing"))
+        self.assertTrue(is_valid_advisor_model("claude-some-future-thing"))
+
+
+class TestIsAdvisorEnabled(unittest.TestCase):
+    """``is_advisor_enabled`` collapses TS ``isAdvisorEnabled``'s
+    env-disable + first-party-only check (we drop GrowthBook — see plan
+    section "Intentional divergences from TS")."""
+
+    def _fake_first_party_provider(self) -> MagicMock:
+        from src.providers.anthropic_provider import AnthropicProvider
+        provider = MagicMock(spec=AnthropicProvider)
+        provider.has_custom_endpoint.return_value = False
+        # spec'd MagicMock + isinstance check requires the spec class to
+        # be the actual class; patch the cache-state lookup to accept
+        # the mock. Simpler: patch is_first_party_provider directly.
+        return provider
+
+    @patch("src.utils.advisor.os.environ", {})
+    def test_disabled_when_no_provider(self) -> None:
+        self.assertFalse(is_advisor_enabled(None))
+
+    def test_disabled_by_env_var(self) -> None:
+        with patch.dict(
+            os.environ, {"CLAUDE_CODE_DISABLE_ADVISOR_TOOL": "1"}, clear=False
+        ):
+            provider = MagicMock()
+            self.assertFalse(is_advisor_enabled(provider))
+
+    def test_truthy_env_values_disable(self) -> None:
+        for v in ["1", "true", "TRUE", "yes", "On"]:
+            with patch.dict(
+                os.environ, {"CLAUDE_CODE_DISABLE_ADVISOR_TOOL": v}, clear=False
+            ):
+                with self.subTest(env=v):
+                    self.assertFalse(is_advisor_enabled(MagicMock()))
+
+    def test_enabled_for_first_party_anthropic(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CLAUDE_CODE_DISABLE_ADVISOR_TOOL", None)
+            with patch(
+                "src.state.cache_state.is_first_party_provider", return_value=True
+            ):
+                self.assertTrue(is_advisor_enabled(MagicMock()))
+
+    def test_disabled_for_third_party_provider(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CLAUDE_CODE_DISABLE_ADVISOR_TOOL", None)
+            with patch(
+                "src.state.cache_state.is_first_party_provider", return_value=False
+            ):
+                self.assertFalse(is_advisor_enabled(MagicMock()))
+
+
+class TestCanUserConfigureAdvisor(unittest.TestCase):
+    """The slash-command visibility gate. Loosened relative to
+    ``is_advisor_enabled`` because the command needs to appear in
+    listings even when no provider has been built yet (``--help``
+    etc.). Strict provider gating still applies at request time."""
+
+    def test_enabled_when_no_provider_and_no_env_disable(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CLAUDE_CODE_DISABLE_ADVISOR_TOOL", None)
+            self.assertTrue(can_user_configure_advisor(None))
+
+    def test_disabled_by_env_var_even_without_provider(self) -> None:
+        with patch.dict(
+            os.environ, {"CLAUDE_CODE_DISABLE_ADVISOR_TOOL": "1"}, clear=False
+        ):
+            self.assertFalse(can_user_configure_advisor(None))
+
+    def test_disabled_with_third_party_provider(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CLAUDE_CODE_DISABLE_ADVISOR_TOOL", None)
+            with patch(
+                "src.state.cache_state.is_first_party_provider", return_value=False
+            ):
+                self.assertFalse(can_user_configure_advisor(MagicMock()))
+
+
+class TestIsAdvisorBlock(unittest.TestCase):
+    def test_advisor_tool_result_detected(self) -> None:
+        self.assertTrue(is_advisor_block({"type": "advisor_tool_result"}))
+
+    def test_advisor_server_tool_use_detected(self) -> None:
+        self.assertTrue(
+            is_advisor_block(
+                {"type": "server_tool_use", "name": "advisor", "id": "srv_1"}
+            )
+        )
+
+    def test_non_advisor_server_tool_use_rejected(self) -> None:
+        # Other server tools (web_search, code_execution, ...) MUST NOT
+        # be misidentified as advisor blocks — they have their own
+        # round-trip semantics.
+        self.assertFalse(
+            is_advisor_block(
+                {"type": "server_tool_use", "name": "web_search", "id": "srv_2"}
+            )
+        )
+
+    def test_plain_blocks_rejected(self) -> None:
+        for block in [
+            {"type": "text", "text": "hi"},
+            {"type": "tool_use", "id": "x", "name": "Bash"},
+            {"type": "tool_result", "tool_use_id": "x", "content": ""},
+            {"type": "thinking", "thinking": "..."},
+            {},
+            None,
+        ]:
+            with self.subTest(block=block):
+                self.assertFalse(is_advisor_block(block))
+
+    def test_attribute_style_object_accepted(self) -> None:
+        class FakeBlock:
+            type = "advisor_tool_result"
+            tool_use_id = "x"
+
+        self.assertTrue(is_advisor_block(FakeBlock()))
+
+
+class TestStripAdvisorBlocks(unittest.TestCase):
+    """Parity with TS ``stripAdvisorBlocks``."""
+
+    def test_returns_input_unchanged_when_no_advisor_blocks(self) -> None:
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": [{"type": "text", "text": "yo"}]},
+        ]
+        out = strip_advisor_blocks(msgs)
+        # Identity return is part of the contract — keeps the caller's
+        # ``list is messages`` checks valid.
+        self.assertIs(out, msgs)
+
+    def test_strips_advisor_blocks_from_assistant(self) -> None:
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "before"},
+                    {
+                        "type": "server_tool_use",
+                        "id": "sx",
+                        "name": "advisor",
+                        "input": {},
+                    },
+                    {
+                        "type": "advisor_tool_result",
+                        "tool_use_id": "sx",
+                        "content": {"type": "advisor_result", "text": "advice"},
+                    },
+                    {"type": "text", "text": "after"},
+                ],
+            }
+        ]
+        out = strip_advisor_blocks(msgs)
+        types = [b["type"] for b in out[0]["content"]]
+        self.assertEqual(types, ["text", "text"])
+        self.assertEqual([b["text"] for b in out[0]["content"]], ["before", "after"])
+
+    def test_inserts_placeholder_when_content_becomes_empty(self) -> None:
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "server_tool_use", "id": "s", "name": "advisor", "input": {}},
+                ],
+            }
+        ]
+        out = strip_advisor_blocks(msgs)
+        self.assertEqual(out[0]["content"], [{"type": "text", "text": "[Advisor response]"}])
+
+    def test_inserts_placeholder_when_only_thinking_remains(self) -> None:
+        # TS treats thinking / redacted_thinking / blank-text as
+        # "non-substantive" — the placeholder MUST still appear.
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "..."},
+                    {"type": "server_tool_use", "id": "s", "name": "advisor", "input": {}},
+                ],
+            }
+        ]
+        out = strip_advisor_blocks(msgs)
+        types = [b["type"] for b in out[0]["content"]]
+        self.assertIn("text", types)
+        self.assertTrue(
+            any(b.get("text") == "[Advisor response]" for b in out[0]["content"])
+        )
+
+    def test_inserts_placeholder_when_only_blank_text_remains(self) -> None:
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "   "},  # whitespace-only
+                    {
+                        "type": "advisor_tool_result",
+                        "tool_use_id": "s",
+                        "content": {"type": "advisor_result", "text": "x"},
+                    },
+                ],
+            }
+        ]
+        out = strip_advisor_blocks(msgs)
+        self.assertTrue(
+            any(b.get("text") == "[Advisor response]" for b in out[0]["content"])
+        )
+
+    def test_no_placeholder_when_substantive_text_remains(self) -> None:
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "real answer"},
+                    {
+                        "type": "advisor_tool_result",
+                        "tool_use_id": "s",
+                        "content": {"type": "advisor_result", "text": "x"},
+                    },
+                ],
+            }
+        ]
+        out = strip_advisor_blocks(msgs)
+        self.assertEqual(out[0]["content"], [{"type": "text", "text": "real answer"}])
+
+    def test_user_messages_passthrough(self) -> None:
+        # User messages are not assistant-shaped — advisor blocks never
+        # land there in practice, but the stripper must still pass them
+        # through untouched.
+        msgs = [
+            {"role": "user", "content": "hello"},
+            {"role": "user", "content": [{"type": "text", "text": "world"}]},
+        ]
+        out = strip_advisor_blocks(msgs)
+        self.assertIs(out, msgs)
+
+    def test_does_not_mutate_input(self) -> None:
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "before"},
+                    {"type": "server_tool_use", "id": "s", "name": "advisor", "input": {}},
+                ],
+            }
+        ]
+        out = strip_advisor_blocks(msgs)
+        # Input retained server_tool_use; output didn't.
+        self.assertEqual(len(msgs[0]["content"]), 2)
+        self.assertEqual(len(out[0]["content"]), 1)
+
+
+class TestBuildAdvisorToolSchema(unittest.TestCase):
+    def test_schema_shape(self) -> None:
+        schema = build_advisor_tool_schema("claude-opus-4-6")
+        self.assertEqual(
+            schema,
+            {
+                "type": "advisor_20260301",
+                "name": "advisor",
+                "model": "claude-opus-4-6",
+            },
+        )
+
+    def test_returns_dict_not_typeddict(self) -> None:
+        # The result has to be a plain dict so the SDK passes it through
+        # to the JSON body without Pydantic validating against the
+        # known BetaToolUnionParam list (which excludes advisor_20260301
+        # in 0.88.0).
+        schema = build_advisor_tool_schema("claude-sonnet-4-6")
+        self.assertIs(type(schema), dict)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_advisor_orphan_pairing.py
+++ b/tests/test_advisor_orphan_pairing.py
@@ -1,0 +1,190 @@
+"""Tests for the orphan ``server_tool_use`` strip pass added to
+``ensure_tool_result_pairing`` in ``src/types/messages.py``.
+
+The advisor is a server tool: both the ``server_tool_use`` (name=advisor)
+and the matching ``advisor_tool_result`` blocks land in the SAME
+assistant message when the round-trip succeeds. If the stream is
+interrupted before the result arrives, the use block is left dangling
+and the API rejects subsequent turns with::
+
+    400: advisor tool use without corresponding advisor_tool_result
+
+The strip pass mirrors TS ``messages.ts:5247-5255``: drop orphan
+``server_tool_use`` / ``mcp_tool_use`` blocks whose id has no matching
+``*_tool_result`` block in the same assistant message.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.types.messages import ensure_tool_result_pairing
+
+
+class TestOrphanServerToolUseStripping(unittest.TestCase):
+    def test_orphan_advisor_use_stripped(self) -> None:
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "thinking…"},
+                    {
+                        "type": "server_tool_use",
+                        "id": "srv_orphan",
+                        "name": "advisor",
+                        "input": {},
+                    },
+                ],
+            },
+        ]
+        out = ensure_tool_result_pairing(msgs)
+        types = [b["type"] for b in out[0]["content"]]
+        self.assertNotIn("server_tool_use", types)
+        self.assertIn("text", types)
+
+    def test_paired_advisor_use_and_result_retained(self) -> None:
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "server_tool_use",
+                        "id": "srv_paired",
+                        "name": "advisor",
+                        "input": {},
+                    },
+                    {
+                        "type": "advisor_tool_result",
+                        "tool_use_id": "srv_paired",
+                        "content": {"type": "advisor_result", "text": "ok"},
+                    },
+                    {"type": "text", "text": "done"},
+                ],
+            },
+        ]
+        out = ensure_tool_result_pairing(msgs)
+        types = [b["type"] for b in out[0]["content"]]
+        self.assertEqual(
+            types, ["server_tool_use", "advisor_tool_result", "text"]
+        )
+
+    def test_orphan_mcp_use_stripped(self) -> None:
+        # TS strips mcp_tool_use orphans by the same rule — port both
+        # for symmetry. Mirrors the rationale at messages.ts:5247.
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "mcp_tool_use",
+                        "id": "mcp_orphan",
+                        "name": "search",
+                        "input": {},
+                    },
+                    {"type": "text", "text": "tail"},
+                ],
+            },
+        ]
+        out = ensure_tool_result_pairing(msgs)
+        types = [b["type"] for b in out[0]["content"]]
+        self.assertNotIn("mcp_tool_use", types)
+        self.assertEqual(types, ["text"])
+
+    def test_empty_after_orphan_strip_gets_placeholder(self) -> None:
+        # The TS placeholder text is ``[Tool use interrupted]`` (TS
+        # messages.ts:5265); the Python port matches at messages.py:414.
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "server_tool_use",
+                        "id": "srv_orphan",
+                        "name": "advisor",
+                        "input": {},
+                    },
+                ],
+            },
+        ]
+        out = ensure_tool_result_pairing(msgs)
+        self.assertEqual(
+            out[0]["content"], [{"type": "text", "text": "[Tool use interrupted]"}]
+        )
+
+    def test_normal_tool_use_unaffected_by_orphan_pass(self) -> None:
+        # Regular client-side tool_use orphans are handled by the
+        # forward-pairing pass that inserts a synthetic tool_result on
+        # the next user message — NOT by the orphan-server-tool strip.
+        # The two behaviors must coexist; verify a regular tool_use
+        # passes through this pass unchanged.
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool_x",
+                        "name": "Bash",
+                        "input": {"command": "ls"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool_x",
+                        "content": "drwxr-xr-x  .",
+                    },
+                ],
+            },
+        ]
+        out = ensure_tool_result_pairing(msgs)
+        # The tool_use survives because it has a matching tool_result.
+        self.assertEqual(out[0]["content"][0]["type"], "tool_use")
+        self.assertEqual(out[1]["content"][0]["type"], "tool_result")
+
+    def test_multiple_assistant_messages_strip_independently(self) -> None:
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "server_tool_use",
+                        "id": "srv_a",
+                        "name": "advisor",
+                        "input": {},
+                    },
+                    {
+                        "type": "advisor_tool_result",
+                        "tool_use_id": "srv_a",
+                        "content": {"type": "advisor_result", "text": "ok"},
+                    },
+                ],
+            },
+            {"role": "user", "content": "next"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "server_tool_use",
+                        "id": "srv_b",
+                        "name": "advisor",
+                        "input": {},
+                    },
+                ],
+            },
+        ]
+        out = ensure_tool_result_pairing(msgs)
+        # Message 0: pair retained.
+        m0_types = [b["type"] for b in out[0]["content"]]
+        self.assertEqual(m0_types, ["server_tool_use", "advisor_tool_result"])
+        # Message 2: orphan stripped, placeholder inserted.
+        m2_types = [b["type"] for b in out[-1]["content"]]
+        self.assertEqual(m2_types, ["text"])
+        self.assertEqual(out[-1]["content"][0]["text"], "[Tool use interrupted]")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
First in a 4-PR stack porting `/advisor` from TypeScript at server-side parity. This PR lands the runtime-inert foundation; activation lands in PR 3.

## Summary
- **`src/utils/advisor.py` (NEW)** — constants (`ADVISOR_BETA_HEADER`, `ADVISOR_TOOL_TYPE`, `ADVISOR_TOOL_INSTRUCTIONS`), provider/env gates, block predicates, schema builder, `strip_advisor_blocks`, and `extract_advisor_{result_text,error_code}`. `ADVISOR_TOOL_INSTRUCTIONS` is byte-for-byte from `typescript/src/utils/advisor.ts:130-145`; a SHA pin plus live cross-check catch drift.
- **`src/settings/types.py`** — adds `advisor_model: str = ""` to `SettingsSchema`. Empty string = unset; future layers read at request time.
- **`src/types/messages.py`** — extends `ensure_tool_result_pairing` to strip orphan `server_tool_use` and `mcp_tool_use` blocks whose matching `*_tool_result` never landed in the same assistant message (interrupted stream). Mirrors TS `messages.ts:5217-5255`. Prevents the API from 400-ing the next turn after a mid-advisor ESC.

## Stack
- PR 1 (this PR) → `main`
- PR 2 (provider preservation) → this branch
- PR 3 (query wiring) → PR 2
- PR 4 (slash command + TUI) → PR 3

## Test plan
- [x] `tests/test_advisor_helpers.py` — 32 tests: constants, all gates, block detection (dict + attribute-style), strip pass shapes including the empty/thinking-only placeholder fallback, schema shape, SHA + live TS byte-equality.
- [x] `tests/test_advisor_orphan_pairing.py` — 6 tests: advisor orphan stripped; pair retained; mcp orphan stripped; empty-content placeholder; regular client tool_use unaffected; multi-message independence.
- [x] No regressions in 92 adjacent tests (settings, messages utility, command system, tool normalization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)