### PR TITLE
feat(advisor) 2/4: preserve advisor blocks in ChatResponse round-trip

### DIFF
--- a/src/providers/anthropic_provider.py
+++ b/src/providers/anthropic_provider.py
@@ -141,12 +141,44 @@ class AnthropicProvider(BaseProvider):
         return bool(self._client_kwargs.get("base_url"))
 
     def _build_chat_response(self, response: Any) -> ChatResponse:
-        """Convert Anthropic SDK response into the shared ChatResponse shape."""
+        """Convert Anthropic SDK response into the shared ChatResponse shape.
+
+        Beyond the text + ``tool_use`` projection used by the rest of
+        the agentic loop, we also preserve advisor server-tool blocks
+        (``server_tool_use`` with ``name=='advisor'`` and the
+        ``advisor_tool_result`` follow-up). They must round-trip through
+        conversation history so that on the next turn the API sees a
+        valid use/result pair; stripping them here would either lose the
+        advisor's analysis or — worse — leave an orphan ``server_tool_use``
+        that the API rejects on replay. See ``src/utils/advisor.py``.
+
+        The SDK parses unknown discriminator values (e.g.
+        ``advisor_tool_result``) leniently via ``construct_type`` — the
+        block lands as the first matching union variant (typically
+        ``BetaTextBlock``) but the original fields (``type``,
+        ``tool_use_id``, ``content``) are preserved on the instance.
+        ``model_dump()`` round-trips them as a dict for downstream replay.
+        """
         content_text = ""
         tool_uses: list[dict[str, Any]] = []
+        raw_content_blocks: list[dict[str, Any]] = []
 
         for block in response.content:
             block_type = getattr(block, "type", "text")
+            block_name = getattr(block, "name", None)
+            is_advisor = block_type == "advisor_tool_result" or (
+                block_type == "server_tool_use" and block_name == "advisor"
+            )
+            if is_advisor:
+                dump = getattr(block, "model_dump", None)
+                if callable(dump):
+                    raw_content_blocks.append(dict(dump(exclude_none=True)))
+                else:
+                    # Fallback for non-Pydantic shapes (test doubles, etc.).
+                    raw_content_blocks.append(
+                        {k: v for k, v in vars(block).items() if v is not None}
+                    )
+                continue
             if block_type == "text":
                 text_val = getattr(block, "text", "")
                 if text_val is not None:
@@ -165,6 +197,7 @@ class AnthropicProvider(BaseProvider):
             usage=_extract_usage_dict(usage),
             finish_reason=str(getattr(response, "stop_reason", "stop")),
             tool_uses=tool_uses if tool_uses else None,
+            raw_content_blocks=raw_content_blocks or None,
         )
 
     def chat(

--- a/src/providers/base.py
+++ b/src/providers/base.py
@@ -32,6 +32,14 @@ class ChatResponse:
     finish_reason: str
     reasoning_content: Optional[str] = None
     tool_uses: Optional[list[dict[str, Any]]] = None
+    # Raw content blocks the provider chose not to project into
+    # ``content``/``tool_uses`` — currently the server-side advisor's
+    # ``server_tool_use`` (name=advisor) and ``advisor_tool_result``
+    # blocks. The query loop appends these to assistant history as
+    # opaque passthrough dicts so the next turn can replay them. None
+    # when the response had no such blocks. See
+    # ``src/utils/advisor.py`` for the policy.
+    raw_content_blocks: Optional[list[dict[str, Any]]] = None
 
 
 MessageInput: TypeAlias = ChatMessage | dict[str, Any]

--- a/tests/test_advisor_chat_response_roundtrip.py
+++ b/tests/test_advisor_chat_response_roundtrip.py
@@ -1,0 +1,259 @@
+"""Defensive round-trip test for `_build_chat_response` advisor preservation.
+
+The Anthropic Python SDK 0.88.0 parses unknown content-block discriminators
+via `construct_type` (lenient), which materializes the block as the first
+matching union variant (typically `ParsedTextBlock` for an
+`advisor_tool_result`) but preserves the original fields (`type`,
+`tool_use_id`, `content`) as attributes accessible via `model_dump()`.
+
+If a future SDK upgrade tightens that path — Pydantic v3, a stricter
+discriminator handler, an `extra="ignore"` config — the advisor pair would
+silently lose its content and the next turn would fail with API 400s on
+replay. This test pins the round-trip contract so a regression in the SDK
+or a refactor of `_build_chat_response` is caught locally.
+
+Covers all three discriminated shapes of advisor_tool_result content:
+  - advisor_result (text)
+  - advisor_redacted_result (encrypted_content)
+  - advisor_tool_result_error (error_code)
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from anthropic._models import construct_type
+from anthropic.types.beta import BetaRawMessageStreamEvent
+from anthropic.lib.streaming._messages import accumulate_event
+
+from src.providers.anthropic_provider import AnthropicProvider
+
+
+def _build_sdk_message_with_blocks(blocks: list[dict]) -> object:
+    """Materialize a real SDK ParsedMessage via the same accumulate path
+    the streaming provider uses, so the round-trip mirrors production."""
+    events_raw = [
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_x",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": "claude-opus-4-6",
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 0},
+            },
+        }
+    ]
+    for idx, block in enumerate(blocks):
+        events_raw.append(
+            {"type": "content_block_start", "index": idx, "content_block": block}
+        )
+        events_raw.append({"type": "content_block_stop", "index": idx})
+    events_raw.append(
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": 5},
+        }
+    )
+    events_raw.append({"type": "message_stop"})
+
+    snapshot = None
+    for raw in events_raw:
+        ev = construct_type(type_=BetaRawMessageStreamEvent, value=raw)
+        snapshot = accumulate_event(event=ev, current_snapshot=snapshot)
+    return snapshot
+
+
+class TestAdvisorBlockPreservation(unittest.TestCase):
+    """Build a fake assistant response, push it through the SDK's
+    ``accumulate_event`` machinery, then through
+    ``AnthropicProvider._build_chat_response``, and verify the
+    ``raw_content_blocks`` list contains the advisor blocks with all
+    their original fields intact.
+    """
+
+    def _provider(self) -> AnthropicProvider:
+        # __init__ stores kwargs lazily; we don't need a real client.
+        p = AnthropicProvider(api_key="fake", model="claude-opus-4-6")
+        return p
+
+    def test_advisor_result_content_preserved(self) -> None:
+        blocks = [
+            {"type": "text", "text": "ok"},
+            {
+                "type": "server_tool_use",
+                "id": "srv_1",
+                "name": "advisor",
+                "input": {},
+            },
+            {
+                "type": "advisor_tool_result",
+                "tool_use_id": "srv_1",
+                "content": {"type": "advisor_result", "text": "looks good"},
+            },
+        ]
+        snapshot = _build_sdk_message_with_blocks(blocks)
+        chat = self._provider()._build_chat_response(snapshot)
+        self.assertIsNotNone(chat.raw_content_blocks)
+        types = [b.get("type") for b in chat.raw_content_blocks]
+        self.assertEqual(
+            types,
+            ["server_tool_use", "advisor_tool_result"],
+            "advisor pair must be preserved in raw_content_blocks",
+        )
+        # The server_tool_use block keeps its name + id.
+        use = next(b for b in chat.raw_content_blocks if b["type"] == "server_tool_use")
+        self.assertEqual(use.get("name"), "advisor")
+        self.assertEqual(use.get("id"), "srv_1")
+        # The result block keeps its tool_use_id and full content dict.
+        result = next(b for b in chat.raw_content_blocks if b["type"] == "advisor_tool_result")
+        self.assertEqual(result.get("tool_use_id"), "srv_1")
+        self.assertEqual(
+            result.get("content"),
+            {"type": "advisor_result", "text": "looks good"},
+        )
+
+    def test_advisor_redacted_result_content_preserved(self) -> None:
+        blocks = [
+            {
+                "type": "server_tool_use",
+                "id": "srv_r",
+                "name": "advisor",
+                "input": {},
+            },
+            {
+                "type": "advisor_tool_result",
+                "tool_use_id": "srv_r",
+                "content": {
+                    "type": "advisor_redacted_result",
+                    "encrypted_content": "AAAA==",
+                },
+            },
+        ]
+        snapshot = _build_sdk_message_with_blocks(blocks)
+        chat = self._provider()._build_chat_response(snapshot)
+        result = next(
+            b for b in (chat.raw_content_blocks or [])
+            if b.get("type") == "advisor_tool_result"
+        )
+        # The opaque envelope MUST round-trip exactly — redacted
+        # results are the whole reason advisor exists for sensitive
+        # workloads; dropping encrypted_content would silently
+        # downgrade history fidelity.
+        self.assertEqual(
+            result.get("content"),
+            {"type": "advisor_redacted_result", "encrypted_content": "AAAA=="},
+        )
+
+    def test_advisor_tool_result_error_content_preserved(self) -> None:
+        blocks = [
+            {
+                "type": "server_tool_use",
+                "id": "srv_e",
+                "name": "advisor",
+                "input": {},
+            },
+            {
+                "type": "advisor_tool_result",
+                "tool_use_id": "srv_e",
+                "content": {
+                    "type": "advisor_tool_result_error",
+                    "error_code": "rate_limit",
+                },
+            },
+        ]
+        snapshot = _build_sdk_message_with_blocks(blocks)
+        chat = self._provider()._build_chat_response(snapshot)
+        result = next(
+            b for b in (chat.raw_content_blocks or [])
+            if b.get("type") == "advisor_tool_result"
+        )
+        # The error_code is the only signal the UI uses to render
+        # "Advisor unavailable (<code>)" — losing it would silently
+        # turn errors into "Advisor reviewed" successes.
+        self.assertEqual(
+            result.get("content"),
+            {"type": "advisor_tool_result_error", "error_code": "rate_limit"},
+        )
+
+    def test_advisor_use_alone_preserved_when_no_result(self) -> None:
+        # Interrupted advisor: use without matching result. We MUST
+        # preserve the use block so the orphan-strip pass in
+        # ensure_tool_result_pairing can find it and drop it on the
+        # next API replay.
+        blocks = [
+            {
+                "type": "server_tool_use",
+                "id": "srv_orphan",
+                "name": "advisor",
+                "input": {},
+            },
+        ]
+        snapshot = _build_sdk_message_with_blocks(blocks)
+        chat = self._provider()._build_chat_response(snapshot)
+        self.assertEqual(len(chat.raw_content_blocks or []), 1)
+        use = chat.raw_content_blocks[0]
+        self.assertEqual(use["type"], "server_tool_use")
+        self.assertEqual(use["name"], "advisor")
+        self.assertEqual(use["id"], "srv_orphan")
+
+    def test_non_advisor_server_tools_not_in_raw_content_blocks(self) -> None:
+        # Only ADVISOR server-tool blocks should land in
+        # raw_content_blocks. Other server tools (web_search,
+        # code_execution, ...) have their own handling and would
+        # leak into history wrongly if scooped up here.
+        blocks = [
+            {
+                "type": "server_tool_use",
+                "id": "srv_ws",
+                "name": "web_search",
+                "input": {"query": "anthropic news"},
+            },
+        ]
+        snapshot = _build_sdk_message_with_blocks(blocks)
+        chat = self._provider()._build_chat_response(snapshot)
+        # Either None or empty — both signal "no advisor blocks".
+        self.assertFalse(chat.raw_content_blocks)
+
+    def test_text_and_tool_use_still_projected_normally(self) -> None:
+        # The advisor-preservation pass MUST NOT regress the existing
+        # text/tool_use projection. Mixed block stream:
+        blocks = [
+            {"type": "text", "text": "hello"},
+            {
+                "type": "tool_use",
+                "id": "tu_1",
+                "name": "Bash",
+                "input": {"command": "ls"},
+            },
+            {
+                "type": "server_tool_use",
+                "id": "srv_a",
+                "name": "advisor",
+                "input": {},
+            },
+            {
+                "type": "advisor_tool_result",
+                "tool_use_id": "srv_a",
+                "content": {"type": "advisor_result", "text": "ok"},
+            },
+            {"type": "text", "text": " world"},
+        ]
+        snapshot = _build_sdk_message_with_blocks(blocks)
+        chat = self._provider()._build_chat_response(snapshot)
+        # Text concatenated from text blocks (existing behavior).
+        self.assertEqual(chat.content, "hello world")
+        # tool_use surfaced.
+        self.assertEqual(len(chat.tool_uses or []), 1)
+        self.assertEqual(chat.tool_uses[0]["id"], "tu_1")
+        # Advisor pair preserved.
+        self.assertEqual(len(chat.raw_content_blocks or []), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
2/4 in the `/advisor` stack. Stacked on #176.

## Summary
The Anthropic provider's `_build_chat_response` projects the SDK stream into `(content, tool_uses, ...)` for the agent loop, but drops everything else — including server-side advisor blocks. Once PR 3 wires activation, those blocks need to round-trip through history so the next turn's API call sees a matched `server_tool_use(name=advisor)` + `advisor_tool_result` pair.

- **`src/providers/base.py`** — adds `ChatResponse.raw_content_blocks: Optional[list[dict]] = None`, the channel for passthrough blocks the projector chose not to flatten.
- **`src/providers/anthropic_provider.py`** — extends `_build_chat_response` to collect blocks where `type == 'advisor_tool_result'` or `(type == 'server_tool_use' and name == 'advisor')`, serialize via `block.model_dump(exclude_none=True)`, and attach to `raw_content_blocks`. The SDK's lenient `construct_type` preserves the original fields on unknown discriminators (verified empirically against `anthropic==0.88.0`).

Other server tools (web_search, code_execution, etc.) are deliberately NOT scooped up — they have their own SDK projection.

## Stack
- PR 1 (#176) — helpers + settings + orphan guard
- **PR 2 (this PR)** → #176
- PR 3 (query wiring) → this branch
- PR 4 (slash command + TUI) → PR 3

## Test plan
- [x] `tests/test_advisor_chat_response_roundtrip.py` — 6 tests: builds a real SDK ParsedMessage via `accumulate_event` for each discriminated `advisor_tool_result` content shape (`advisor_result`, `advisor_redacted_result`, `advisor_tool_result_error`), the orphan case, the non-advisor server-tool exclusion, and a mixed-block case.
- [x] Pins the SDK round-trip contract — a future SDK upgrade (Pydantic v3, stricter discriminator handler) that silently drops extra fields on unknown discriminators would fail the `encrypted_content` and `error_code` assertions locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)