### PR TITLE
feat(assistant): port sessionHistory + AssistantSessionChooser stub from TS

### DIFF
--- a/src/assistant/__init__.py
+++ b/src/assistant/__init__.py
@@ -5,6 +5,16 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from src.assistant.session_chooser import AssistantSessionChooser
+from src.assistant.session_history import (
+    HISTORY_PAGE_SIZE,
+    HistoryAuthCtx,
+    HistoryPage,
+    create_history_auth_ctx,
+    fetch_latest_events,
+    fetch_older_events,
+)
+
 SNAPSHOT_PATH = Path(__file__).resolve().parent.parent / 'reference_data' / 'subsystems' / 'assistant.json'
 _SNAPSHOT = json.loads(SNAPSHOT_PATH.read_text())
 
@@ -13,4 +23,16 @@ MODULE_COUNT = _SNAPSHOT['module_count']
 SAMPLE_FILES = tuple(_SNAPSHOT['sample_files'])
 PORTING_NOTE = f"Python placeholder package for '{ARCHIVE_NAME}' with {MODULE_COUNT} archived module references."
 
-__all__ = ['ARCHIVE_NAME', 'MODULE_COUNT', 'PORTING_NOTE', 'SAMPLE_FILES']
+__all__ = [
+    'ARCHIVE_NAME',
+    'AssistantSessionChooser',
+    'HISTORY_PAGE_SIZE',
+    'HistoryAuthCtx',
+    'HistoryPage',
+    'MODULE_COUNT',
+    'PORTING_NOTE',
+    'SAMPLE_FILES',
+    'create_history_auth_ctx',
+    'fetch_latest_events',
+    'fetch_older_events',
+]

--- a/src/assistant/session_chooser.py
+++ b/src/assistant/session_chooser.py
@@ -1,0 +1,37 @@
+"""Stub mirror of ``typescript/src/assistant/AssistantSessionChooser.tsx``.
+
+The upstream TS file is itself a stub annotated
+``// Stub — AssistantSessionChooser not included in source snapshot``.
+We mirror the stub here so the parity audit reflects that *both* trees
+are intentionally empty. The Python REPL has no interactive picker for
+``claude assistant`` yet; this module exists so future ports of
+``dialogLaunchers`` / ``main.tsx`` have a real import target with the
+same export name (``AssistantSessionChooser``, PascalCase) as the TS
+source — no rename needed at the call sites.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+
+def AssistantSessionChooser(  # noqa: N802 — mirrors TS React component name
+    sessions: Sequence[Any],
+    on_select: Callable[[str], None],
+    on_cancel: Callable[[], None],
+) -> None:
+    """Pick a session to attach to. No-op stub (returns ``None``).
+
+    Matches the TS prop shape ``{ sessions, onSelect, onCancel }`` so
+    callers can be ported without changing call sites. Name is PascalCase
+    to match the TS React component export — a future port of
+    ``dialogLaunchers.tsx::launchAssistantSessionChooser`` should be able
+    to write ``from src.assistant.session_chooser import AssistantSessionChooser``
+    without an alias.
+    """
+    del sessions, on_select, on_cancel  # silence unused-argument linters
+    return None
+
+
+__all__ = ['AssistantSessionChooser']

--- a/src/assistant/session_history.py
+++ b/src/assistant/session_history.py
@@ -1,0 +1,214 @@
+"""Paginated assistant session-events client.
+
+Port of ``typescript/src/assistant/sessionHistory.ts (88 lines)``.
+
+Fetches pages of ``SDKMessage`` events from
+``GET ${base_url}/v1/sessions/${session_id}/events``. Used by the
+``claude assistant`` viewer-only REPL to lazy-load history on scroll-up.
+
+Signature deviation from TS:
+  TS ``createHistoryAuthCtx(sessionId)`` reads OAuth creds globally via
+  ``prepareApiRequest``. The Python project has no equivalent global, so
+  ``create_history_auth_ctx`` takes ``access_token``, ``org_uuid``, and
+  ``base_url`` explicitly. Matches ``bridge/code_session_api.py`` and
+  ``remote/remote_session_manager.py`` conventions. See the gap-analysis
+  doc for the named-and-rejected alternative.
+
+Error policy mirrors TS exactly (gap-analysis §2.1 bullet 4):
+  * HTTP failure / non-200 (any 4xx/5xx) → return ``None``.
+  * ``resp.json()`` raise → return ``None``.
+  * Body not a dict → return ``None``.
+  * Body is a dict but ``data`` missing / not a list → ``events=[]`` and
+    still return a ``HistoryPage`` (not ``None``).
+  * ``first_id`` is pass-through (``None`` if missing).
+  * ``has_more`` is pass-through with a ``False`` default for missing key —
+    mirrors TS JS-coercion of ``undefined`` to falsy.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Final
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+HISTORY_PAGE_SIZE: Final[int] = 100
+
+_ANTHROPIC_VERSION: Final[str] = '2023-06-01'
+_ANTHROPIC_BETA_CCR_BYOC: Final[str] = 'ccr-byoc-2025-07-29'
+_DEFAULT_TIMEOUT_SECONDS: Final[float] = 15.0
+
+
+@dataclass(frozen=True)
+class HistoryPage:
+    """One page of session events.
+
+    ``events`` is chronological within the page. ``first_id`` is the
+    oldest event ID in the page — the ``before_id`` cursor for the
+    next-older page. ``has_more=True`` means older events exist.
+    """
+
+    events: list[dict[str, Any]]
+    first_id: str | None
+    has_more: bool
+
+
+@dataclass(frozen=True)
+class HistoryAuthCtx:
+    """Reusable auth bundle for paged history fetches.
+
+    Built once via ``create_history_auth_ctx``, reused across pages.
+    ``headers`` is typed as ``Mapping`` (read-only contract); the
+    implementation passes a plain ``dict`` but consumers must not
+    mutate it.
+    """
+
+    base_url: str
+    headers: Mapping[str, str]
+
+
+def _oauth_headers(access_token: str, org_uuid: str) -> dict[str, str]:
+    """Combined header helper.
+
+    Bundles two concerns that TS separates: ``getOAuthHeaders(accessToken)``
+    (Authorization + Content-Type + anthropic-version) **and** the
+    ``anthropic-beta`` / ``x-organization-uuid`` pinning that TS does at
+    the ``createHistoryAuthCtx`` call site. Merging them here keeps the
+    builder pure; the wire output is byte-identical to TS.
+
+    Keeps ``Content-Type: application/json`` on the GET for parity even
+    though there is no request body (TS shares ``getOAuthHeaders`` with
+    POST callers — see gap-analysis §2.1 bullet 7).
+    """
+    return {
+        'Authorization': f'Bearer {access_token}',
+        'Content-Type': 'application/json',
+        'anthropic-version': _ANTHROPIC_VERSION,
+        'anthropic-beta': _ANTHROPIC_BETA_CCR_BYOC,
+        'x-organization-uuid': org_uuid,
+    }
+
+
+async def create_history_auth_ctx(
+    session_id: str,
+    access_token: str,
+    org_uuid: str,
+    *,
+    base_url: str = 'https://api.anthropic.com',
+) -> HistoryAuthCtx:
+    """Build a reusable auth context bound to a session.
+
+    Pure builder — no I/O. Kept ``async`` for parity with TS even though
+    the Python implementation performs no I/O. A future Python port of
+    ``prepare_api_request`` may add token-fetch I/O here without changing
+    the call sites.
+    """
+    return HistoryAuthCtx(
+        base_url=f'{base_url.rstrip("/")}/v1/sessions/{session_id}/events',
+        headers=_oauth_headers(access_token, org_uuid),
+    )
+
+
+async def _fetch_page(
+    ctx: HistoryAuthCtx,
+    params: dict[str, str | int | bool],
+    label: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> HistoryPage | None:
+    """Shared GET wrapper. Returns ``None`` on any failure (network,
+    timeout, non-200, non-dict body, JSON parse error).
+
+    The ``label`` arg appears only in the debug log line and disambiguates
+    the two call sites in postmortems (matches TS line 59).
+    """
+    try:
+        if client is None:
+            async with httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT_SECONDS) as fresh:
+                resp = await fresh.get(
+                    ctx.base_url, headers=ctx.headers, params=params,
+                )
+        else:
+            resp = await client.get(
+                ctx.base_url,
+                headers=ctx.headers,
+                params=params,
+                timeout=_DEFAULT_TIMEOUT_SECONDS,
+            )
+    except (httpx.HTTPError, httpx.TimeoutException):
+        logger.debug('[%s] HTTP error', label)
+        return None
+
+    if resp.status_code != 200:
+        logger.debug('[%s] HTTP %d', label, resp.status_code)
+        return None
+
+    try:
+        data = resp.json()
+    except ValueError:
+        logger.debug('[%s] non-JSON body', label)
+        return None
+
+    if not isinstance(data, dict):
+        logger.debug('[%s] body is not a dict', label)
+        return None
+
+    events_raw = data.get('data')
+    events: list[dict[str, Any]] = events_raw if isinstance(events_raw, list) else []
+    return HistoryPage(
+        events=events,
+        first_id=data.get('first_id'),
+        # ``False`` default mirrors TS JS-coercion of missing ``has_more``
+        # (undefined → falsy). No bool() cast — server is contract source.
+        has_more=data.get('has_more', False),
+    )
+
+
+async def fetch_latest_events(
+    ctx: HistoryAuthCtx,
+    limit: int = HISTORY_PAGE_SIZE,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> HistoryPage | None:
+    """Newest page: last ``limit`` events, chronological, via
+    ``anchor_to_latest=true``. ``has_more=True`` means older events exist.
+    Mirrors TS ``fetchLatestEvents``.
+    """
+    return await _fetch_page(
+        ctx,
+        {'limit': limit, 'anchor_to_latest': True},
+        'fetch_latest_events',
+        client=client,
+    )
+
+
+async def fetch_older_events(
+    ctx: HistoryAuthCtx,
+    before_id: str,
+    limit: int = HISTORY_PAGE_SIZE,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> HistoryPage | None:
+    """Older page: events immediately before ``before_id`` cursor.
+    Mirrors TS ``fetchOlderEvents``.
+    """
+    return await _fetch_page(
+        ctx,
+        {'limit': limit, 'before_id': before_id},
+        'fetch_older_events',
+        client=client,
+    )
+
+
+__all__ = [
+    'HISTORY_PAGE_SIZE',
+    'HistoryAuthCtx',
+    'HistoryPage',
+    'create_history_auth_ctx',
+    'fetch_latest_events',
+    'fetch_older_events',
+]

--- a/tests/assistant/test_session_chooser.py
+++ b/tests/assistant/test_session_chooser.py
@@ -1,0 +1,41 @@
+"""Tests for ``src.assistant.session_chooser``.
+
+The chooser is a stub-mirror of the TS React component (which is itself
+a stub upstream — see assistant-gap-analysis.md §2.2). These tests pin
+the stub contract so a future implementation lands without breaking
+the call shape.
+"""
+
+from __future__ import annotations
+
+from src.assistant.session_chooser import AssistantSessionChooser
+
+
+def test_stub_returns_none():
+    result = AssistantSessionChooser(
+        sessions=[],
+        on_select=lambda _id: None,
+        on_cancel=lambda: None,
+    )
+    assert result is None
+
+
+def test_callbacks_are_not_invoked():
+    select_calls: list[str] = []
+    cancel_calls: list[None] = []
+
+    def on_select(session_id: str) -> None:
+        select_calls.append(session_id)
+
+    def on_cancel() -> None:
+        cancel_calls.append(None)
+
+    AssistantSessionChooser(
+        sessions=[{'id': 'sess_1'}, {'id': 'sess_2'}],
+        on_select=on_select,
+        on_cancel=on_cancel,
+    )
+
+    # Stub must not invoke either callback.
+    assert select_calls == []
+    assert cancel_calls == []

--- a/tests/assistant/test_session_history.py
+++ b/tests/assistant/test_session_history.py
@@ -1,0 +1,419 @@
+"""Tests for ``src.assistant.session_history``.
+
+Covers the contract laid out in
+``my-docs/get-parity-by-folder/assistant-gap-analysis.md`` §7.4 and
+``assistant-refactoring-plan.md`` §3.2.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from src.assistant.session_history import (
+    HISTORY_PAGE_SIZE,
+    HistoryAuthCtx,
+    HistoryPage,
+    create_history_auth_ctx,
+    fetch_latest_events,
+    fetch_older_events,
+)
+
+
+# ─── create_history_auth_ctx ────────────────────────────────────────────
+
+
+class TestCreateHistoryAuthCtx:
+    @pytest.mark.asyncio
+    async def test_url_includes_session_id(self):
+        ctx = await create_history_auth_ctx(
+            'sess_abc', access_token='tok', org_uuid='org_1',
+        )
+        assert ctx.base_url == 'https://api.anthropic.com/v1/sessions/sess_abc/events'
+
+    @pytest.mark.asyncio
+    async def test_default_base_url_exact(self):
+        ctx = await create_history_auth_ctx(
+            'sess_abc', access_token='tok', org_uuid='org_1',
+        )
+        # Pin the exact default — if anyone changes it, the regression
+        # shows up here, not silently in prod.
+        assert ctx.base_url == 'https://api.anthropic.com/v1/sessions/sess_abc/events'
+
+    @pytest.mark.asyncio
+    async def test_custom_base_url_trims_trailing_slash(self):
+        ctx = await create_history_auth_ctx(
+            'sess_x', access_token='t', org_uuid='o',
+            base_url='https://api.test/',
+        )
+        assert ctx.base_url == 'https://api.test/v1/sessions/sess_x/events'
+
+    @pytest.mark.asyncio
+    async def test_custom_base_url_no_trailing_slash(self):
+        ctx = await create_history_auth_ctx(
+            'sess_x', access_token='t', org_uuid='o',
+            base_url='https://api.test',
+        )
+        assert ctx.base_url == 'https://api.test/v1/sessions/sess_x/events'
+
+    @pytest.mark.asyncio
+    async def test_headers_include_all_pinned_values(self):
+        ctx = await create_history_auth_ctx(
+            'sess_1', access_token='my_tok', org_uuid='my_org',
+        )
+        assert ctx.headers['Authorization'] == 'Bearer my_tok'
+        assert ctx.headers['Content-Type'] == 'application/json'
+        assert ctx.headers['anthropic-version'] == '2023-06-01'
+        assert ctx.headers['anthropic-beta'] == 'ccr-byoc-2025-07-29'
+        assert ctx.headers['x-organization-uuid'] == 'my_org'
+
+
+# ─── fetch_latest_events ────────────────────────────────────────────────
+
+
+def _make_ctx(base_url: str = 'https://api.test') -> HistoryAuthCtx:
+    """Build a HistoryAuthCtx synchronously for tests (the builder is
+    pure; we don't need the async wrapper just to construct a value)."""
+    return HistoryAuthCtx(
+        base_url=f'{base_url}/v1/sessions/sess_t/events',
+        headers={
+            'Authorization': 'Bearer tok',
+            'Content-Type': 'application/json',
+            'anthropic-version': '2023-06-01',
+            'anthropic-beta': 'ccr-byoc-2025-07-29',
+            'x-organization-uuid': 'org_t',
+        },
+    )
+
+
+class TestFetchLatestEvents:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_history_page(self):
+        captured: dict[str, object] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured['url'] = str(req.url)
+            captured['query'] = dict(req.url.params)
+            return httpx.Response(
+                200,
+                json={
+                    'data': [{'type': 'user', 'uuid': 'evt_1'}],
+                    'has_more': True,
+                    'first_id': 'evt_1',
+                    'last_id': 'evt_1',
+                },
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            page = await fetch_latest_events(_make_ctx(), client=client)
+
+        assert page is not None
+        assert page.events == [{'type': 'user', 'uuid': 'evt_1'}]
+        assert page.first_id == 'evt_1'
+        assert page.has_more is True
+        # Default limit is 100 and anchor_to_latest=true on the happy path.
+        assert captured['query'].get('limit') == '100'
+        assert captured['query'].get('anchor_to_latest') == 'true'
+
+    @pytest.mark.asyncio
+    async def test_default_limit_is_100(self):
+        captured: dict[str, object] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured['query'] = dict(req.url.params)
+            return httpx.Response(200, json={'data': [], 'has_more': False, 'first_id': None})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            await fetch_latest_events(_make_ctx(), client=client)
+        assert captured['query']['limit'] == '100'
+        # Sanity: confirm the module-level constant is the same number.
+        assert HISTORY_PAGE_SIZE == 100
+
+    @pytest.mark.asyncio
+    async def test_uses_anchor_to_latest_query_param(self):
+        captured: dict[str, object] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured['query'] = dict(req.url.params)
+            return httpx.Response(200, json={'data': [], 'has_more': False, 'first_id': None})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            await fetch_latest_events(_make_ctx(), client=client)
+        # httpx serializes booleans lowercase — locks the contract from
+        # gap-analysis §6 risk register.
+        assert captured['query']['anchor_to_latest'] == 'true'
+
+    @pytest.mark.asyncio
+    async def test_custom_limit_is_honored(self):
+        captured: dict[str, object] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured['query'] = dict(req.url.params)
+            return httpx.Response(200, json={'data': [], 'has_more': False, 'first_id': None})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            await fetch_latest_events(_make_ctx(), limit=50, client=client)
+        assert captured['query']['limit'] == '50'
+
+    @pytest.mark.asyncio
+    async def test_non_200_4xx_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, content=b'not found')
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            page = await fetch_latest_events(_make_ctx(), client=client)
+        assert page is None
+
+    @pytest.mark.asyncio
+    async def test_non_200_5xx_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, content=b'unavailable')
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            page = await fetch_latest_events(_make_ctx(), client=client)
+        # 5xx must also return None — proves the "more permissive than
+        # sibling teleport endpoints" contract from gap-analysis §2.1
+        # bullet 1.
+        assert page is None
+
+    @pytest.mark.asyncio
+    async def test_network_error_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError('refused')
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            page = await fetch_latest_events(_make_ctx(), client=client)
+        assert page is None
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            raise httpx.TimeoutException('slow')
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            page = await fetch_latest_events(_make_ctx(), client=client)
+        assert page is None
+
+    @pytest.mark.asyncio
+    async def test_non_json_body_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b'not json')
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            page = await fetch_latest_events(_make_ctx(), client=client)
+        assert page is None
+
+    @pytest.mark.asyncio
+    async def test_body_not_a_dict_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=[1, 2, 3])
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            page = await fetch_latest_events(_make_ctx(), client=client)
+        assert page is None
+
+    @pytest.mark.asyncio
+    async def test_data_missing_returns_empty_events(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={'has_more': False, 'first_id': None},
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            page = await fetch_latest_events(_make_ctx(), client=client)
+        assert page == HistoryPage(events=[], first_id=None, has_more=False)
+
+    @pytest.mark.asyncio
+    async def test_data_is_null_returns_empty_events(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, json={'data': None, 'has_more': True, 'first_id': 'evt_2'},
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            page = await fetch_latest_events(_make_ctx(), client=client)
+        # null data is treated the same as "missing or not a list".
+        assert page == HistoryPage(events=[], first_id='evt_2', has_more=True)
+
+    @pytest.mark.asyncio
+    async def test_data_not_a_list_preserves_pass_through_fields(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={'data': 'oops', 'has_more': True, 'first_id': 'evt_1'},
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            page = await fetch_latest_events(_make_ctx(), client=client)
+        # The point of this test: when data is malformed, first_id and
+        # has_more must still survive (no None synthesis).
+        assert page == HistoryPage(events=[], first_id='evt_1', has_more=True)
+
+    @pytest.mark.asyncio
+    async def test_has_more_missing_defaults_to_false(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={'data': [], 'first_id': None})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            page = await fetch_latest_events(_make_ctx(), client=client)
+        assert page is not None
+        assert page.has_more is False
+
+    @pytest.mark.asyncio
+    async def test_first_id_pass_through_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, json={'data': [], 'has_more': False, 'first_id': None},
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            page = await fetch_latest_events(_make_ctx(), client=client)
+        assert page is not None
+        assert page.first_id is None
+
+    @pytest.mark.asyncio
+    async def test_first_id_pass_through_concrete(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, json={'data': [], 'has_more': True, 'first_id': 'evt_42'},
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            page = await fetch_latest_events(_make_ctx(), client=client)
+        assert page is not None
+        assert page.first_id == 'evt_42'
+
+
+# ─── fetch_older_events ─────────────────────────────────────────────────
+
+
+class TestFetchOlderEvents:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_history_page(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    'data': [{'type': 'assistant', 'uuid': 'evt_0'}],
+                    'has_more': False,
+                    'first_id': 'evt_0',
+                },
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            page = await fetch_older_events(_make_ctx(), before_id='evt_x', client=client)
+        assert page is not None
+        assert page.events == [{'type': 'assistant', 'uuid': 'evt_0'}]
+        assert page.first_id == 'evt_0'
+        assert page.has_more is False
+
+    @pytest.mark.asyncio
+    async def test_uses_before_id_query_param(self):
+        captured: dict[str, object] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured['query'] = dict(req.url.params)
+            return httpx.Response(200, json={'data': [], 'has_more': False, 'first_id': None})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            await fetch_older_events(_make_ctx(), before_id='evt_abc', client=client)
+        assert captured['query']['before_id'] == 'evt_abc'
+        assert captured['query']['limit'] == '100'
+        # anchor_to_latest must NOT appear on the older-page query.
+        assert 'anchor_to_latest' not in captured['query']
+
+    @pytest.mark.asyncio
+    async def test_custom_limit_is_honored(self):
+        captured: dict[str, object] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured['query'] = dict(req.url.params)
+            return httpx.Response(200, json={'data': [], 'has_more': False, 'first_id': None})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            await fetch_older_events(_make_ctx(), before_id='evt_a', limit=25, client=client)
+        assert captured['query']['limit'] == '25'
+
+    @pytest.mark.asyncio
+    async def test_non_200_returns_none(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, content=b'oops')
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            page = await fetch_older_events(_make_ctx(), before_id='evt_a', client=client)
+        assert page is None
+
+
+# ─── Default-client (no `client` kwarg) branch ──────────────────────────
+
+
+class TestDefaultClient:
+    """Covers the ``client is None`` branch of ``_fetch_page`` where the
+    helper builds a fresh ``httpx.AsyncClient`` itself. Tests inject the
+    mock transport via monkeypatching ``httpx.AsyncClient``."""
+
+    @pytest.mark.asyncio
+    async def test_default_client_branch(self, monkeypatch):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, json={'data': [], 'has_more': False, 'first_id': None},
+            )
+
+        transport = httpx.MockTransport(handler)
+        # Wrap the real AsyncClient so the production code can build it
+        # without ever opening a real socket.
+        from src.assistant import session_history as mod
+
+        original = mod.httpx.AsyncClient
+
+        def patched(*args, **kwargs):
+            kwargs.setdefault('transport', transport)
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(mod.httpx, 'AsyncClient', patched)
+        page = await fetch_latest_events(_make_ctx())  # no client= kwarg
+        assert page is not None
+        assert page.events == []
+
+
+# ─── URL composition ────────────────────────────────────────────────────
+
+
+class TestUrlCorrectness:
+    @pytest.mark.asyncio
+    async def test_endpoint_path_is_v1_sessions_events(self):
+        captured: dict[str, object] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured['path'] = req.url.path
+            return httpx.Response(200, json={'data': [], 'has_more': False, 'first_id': None})
+
+        ctx = await create_history_auth_ctx(
+            'sess_xyz', access_token='t', org_uuid='o',
+            base_url='https://api.test',
+        )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            await fetch_latest_events(ctx, client=client)
+        assert captured['path'] == '/v1/sessions/sess_xyz/events'
+
+    @pytest.mark.asyncio
+    async def test_headers_sent_on_request(self):
+        captured: dict[str, object] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured['headers'] = dict(req.headers)
+            return httpx.Response(200, json={'data': [], 'has_more': False, 'first_id': None})
+
+        ctx = await create_history_auth_ctx(
+            'sess_y', access_token='real_tok', org_uuid='real_org',
+            base_url='https://api.test',
+        )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            await fetch_latest_events(ctx, client=client)
+        headers = captured['headers']
+        assert headers['authorization'] == 'Bearer real_tok'
+        assert headers['content-type'] == 'application/json'
+        assert headers['anthropic-version'] == '2023-06-01'
+        assert headers['anthropic-beta'] == 'ccr-byoc-2025-07-29'
+        assert headers['x-organization-uuid'] == 'real_org'


### PR DESCRIPTION
## Summary
- Port `typescript/src/assistant/sessionHistory.ts` (88 LOC) to `src/assistant/session_history.py` — paginated session-events client (`HistoryPage`, `HistoryAuthCtx`, `create_history_auth_ctx`, `fetch_latest_events`, `fetch_older_events`).
- Mirror the upstream `AssistantSessionChooser.tsx` stub as `src/assistant/session_chooser.py` with PascalCase name so a future `dialogLaunchers` port can import without renaming.
- Update `src/assistant/__init__.py` to re-export the new names; existing placeholder fields preserved.

## Parity notes
- Wire shape preserved: URL path `/v1/sessions/{id}/events`, all five pinned headers (`Authorization`, `Content-Type`, `anthropic-version`, `anthropic-beta: ccr-byoc-2025-07-29`, `x-organization-uuid`), 15s timeout, lowercase `anchor_to_latest=true` query param.
- Four-case body-coercion contract from TS preserved: HTTP failure / non-200 / non-JSON / non-dict → `None`; malformed `data` → `events=[]` with `first_id` and `has_more` pass-through.
- `has_more` defaults to `False` when missing — mirrors TS JS-coercion of `undefined` to falsy.
- Signature deviation from TS: `create_history_auth_ctx` takes `access_token` and `org_uuid` explicitly (no `prepare_api_request` global yet in Python). Matches `bridge/code_session_api.py` + `remote/remote_session_manager.py` convention.

Planning docs (in `my-docs/get-parity-by-folder/`, gitignored):
- `assistant-gap-analysis.md`
- `assistant-refactoring-plan.md`

Both were iterated through 4 rounds of critic review before implementation.

## Test plan
- [x] `pytest tests/assistant/ -q` → 30 passed, 0 skipped
- [x] `pytest tests/assistant/ --cov=src.assistant` → 100% line coverage (71/71 stmts)
- [x] Regression smoke: `pytest tests/bridge/ tests/remote/ tests/assistant/ -q` → 232 passed
- [x] Critic agent APPROVED the implementation as merge-ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)