### PR TITLE
feat(advisor): land phases 2-4 (provider, query, command+TUI)

### DIFF
--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -431,6 +431,197 @@ async def _compact_async(args: str, context: CommandContext) -> LocalCommandResu
         )
 
 
+def _read_current_advisor_model(context: CommandContext) -> str | None:
+    """Resolve the user's currently configured advisor model.
+
+    Prefers the reactive AppState store if the caller wired one (so a
+    just-issued ``/advisor`` from this session reads its own write
+    without a settings-cache roundtrip), and falls back to the
+    persisted settings — the source of truth on every restart.
+    """
+    store = getattr(context, "app_state_store", None)
+    if store is not None:
+        try:
+            state = store.get_state()
+            value = getattr(state, "advisor_model", None)
+            if value:
+                return value
+        except Exception:
+            pass
+    try:
+        from ..settings.settings import get_settings
+        configured = (get_settings().advisor_model or "").strip()
+        return configured or None
+    except Exception:
+        return None
+
+
+def _write_advisor_model(context: CommandContext, value: str | None) -> None:
+    """Persist a new advisor_model and update the reactive store if present.
+
+    Both writes are idempotent. When an AppState store is wired (e.g.
+    tests, future TUI wiring), ``replace_state`` fires
+    ``_on_advisor_model_change`` which itself writes to settings — so
+    we skip the direct settings write to avoid double-saving. When the
+    store is absent (the current TUI configuration), we update settings
+    directly via the same chokepoint the handler uses.
+    """
+    store = getattr(context, "app_state_store", None)
+    if store is not None:
+        from ..state.app_state import replace_state
+        store.set_state(lambda s: replace_state(s, advisor_model=value or None))
+        return
+    # No reactive store — write straight to settings + invalidate cache
+    # so the next API call picks up the change. Use the shared default
+    # ConfigManager (instead of a fresh one) so the in-process
+    # ``_global_cache`` field stays consistent for callers that read
+    # via ``load_config()`` / ``_get_default_manager().get_merged()``.
+    from .. import config as cfg_mod
+    from ..settings.settings import invalidate_settings_cache
+    mgr = cfg_mod._get_default_manager()
+    cfg = mgr.load_global()
+    settings_section = cfg.get("settings")
+    if not isinstance(settings_section, dict):
+        settings_section = {}
+    settings_section["advisor_model"] = value or ""
+    cfg["settings"] = settings_section
+    mgr.save_global(cfg)
+    invalidate_settings_cache()
+
+
+def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResult:
+    """Handle /advisor — configure the server-side advisor reviewer model.
+
+    Python port of typescript/src/commands/advisor.ts. Branches:
+      * no args → report current state (set/unset/inactive). Inactive =
+        a model is set but the running main-loop model doesn't support
+        the advisor tool.
+      * ``unset`` | ``off`` → clear the advisor model.
+      * ``<model>`` → resolve + validate + set.
+
+    Writes go to the reactive AppState store if the caller wired one
+    via ``CommandContext.app_state_store``; otherwise they go straight
+    to the global settings file. Either path produces the same end
+    state (settings.advisor_model is the canonical source) — the
+    distinction is whether mid-session subscribers see the change as
+    an in-process event or have to re-read settings.
+    """
+    from ..models.model import canonical_model_name, resolve_model
+    from ..models.validation import validate_model_name
+    from ..utils.advisor import (
+        can_user_configure_advisor,
+        is_valid_advisor_model,
+        model_supports_advisor,
+    )
+
+    arg = (args or "").strip().lower()
+    provider = getattr(context, "provider", None)
+
+    # Reject hard when /advisor is disabled by env var or by a non-first-
+    # party provider — otherwise the user would silently configure a value
+    # that no future request can use.
+    if not can_user_configure_advisor(provider):
+        return LocalCommandResult(
+            type="text",
+            value=(
+                "Advisor is unavailable in this configuration. "
+                "It requires the first-party Anthropic API and is disabled by "
+                "the CLAUDE_CODE_DISABLE_ADVISOR_TOOL env var."
+            ),
+        )
+
+    current_advisor = _read_current_advisor_model(context)
+    # Resolve the active main-loop model. Prefer the provider's own
+    # ``.model`` attribute (mirrors TS ``options.model`` source of truth
+    # — the value the next API call will actually use). Fall back to
+    # AppState.main_loop_model when the provider isn't carrying one.
+    main_loop_model = ""
+    if provider is not None:
+        main_loop_model = getattr(provider, "model", "") or ""
+    if not main_loop_model:
+        store = getattr(context, "app_state_store", None)
+        if store is not None:
+            try:
+                main_loop_model = getattr(store.get_state(), "main_loop_model", "") or ""
+            except Exception:
+                pass
+
+    if not arg:
+        if not current_advisor:
+            return LocalCommandResult(
+                type="text",
+                value=(
+                    "Advisor: not set\n"
+                    'Use "/advisor <model>" to enable (e.g. "/advisor opus").'
+                ),
+            )
+        if main_loop_model and not model_supports_advisor(main_loop_model):
+            return LocalCommandResult(
+                type="text",
+                value=(
+                    f"Advisor: {current_advisor} (inactive)\n"
+                    f"The current model ({main_loop_model}) does not support advisors."
+                ),
+            )
+        return LocalCommandResult(
+            type="text",
+            value=(
+                f"Advisor: {current_advisor}\n"
+                'Use "/advisor unset" to disable or "/advisor <model>" to change.'
+            ),
+        )
+
+    if arg in ("unset", "off"):
+        previous = current_advisor
+        if previous is not None:
+            _write_advisor_model(context, None)
+        return LocalCommandResult(
+            type="text",
+            value=(
+                f"Advisor disabled (was {previous})." if previous
+                else "Advisor already unset."
+            ),
+        )
+
+    # Treat the rest as a model identifier.
+    raw = (args or "").strip()
+    try:
+        resolved = resolve_model(raw)
+    except Exception as e:
+        return LocalCommandResult(
+            type="text",
+            value=f"Invalid advisor model: {e}",
+        )
+    if not validate_model_name(resolved):
+        return LocalCommandResult(
+            type="text",
+            value=f"Unknown model: {raw} ({resolved})",
+        )
+    if not is_valid_advisor_model(resolved):
+        return LocalCommandResult(
+            type="text",
+            value=f"The model {raw} ({resolved}) cannot be used as an advisor",
+        )
+
+    normalized = canonical_model_name(resolved)
+    _write_advisor_model(context, normalized)
+
+    if main_loop_model and not model_supports_advisor(main_loop_model):
+        return LocalCommandResult(
+            type="text",
+            value=(
+                f"Advisor set to {normalized}.\n"
+                f"Note: Your current model ({main_loop_model}) does not support "
+                "advisors. Switch to a supported model to use the advisor."
+            ),
+        )
+
+    return LocalCommandResult(
+        type="text",
+        value=f"Advisor set to {normalized}.",
+    )
+
+
 def compact_command_call(args: str, context: CommandContext) -> LocalCommandResult:
     """
     Handle /compact command - compact conversation context.
@@ -609,6 +800,23 @@ COMPACT_COMMAND = LocalCommand(
     supports_non_interactive=True,
 )
 
+# /advisor — server-side reviewer tool. Python port of
+# typescript/src/commands/advisor.ts. The `is_enabled` callable is read by
+# the help-listing and command-availability checks. We pass ``provider=None``
+# at command-list time because the registry doesn't know what provider is
+# active; the env-disable check still applies. Per-request provider gating
+# is enforced inside ``_call_model_sync`` so the user can't accidentally
+# silence the API by toggling /advisor under a non-first-party provider.
+from ..utils.advisor import can_user_configure_advisor as _can_user_configure_advisor
+
+ADVISOR_COMMAND = LocalCommand(
+    name="advisor",
+    description="Configure the advisor model",
+    argument_hint="[<model>|off]",
+    supports_non_interactive=True,
+    is_enabled=lambda: _can_user_configure_advisor(None),
+)
+
 INIT_COMMAND = PromptCommand(
     name="init",
     description="Initialize new CLAUDE.md file(s) and optional skills/hooks with codebase documentation",
@@ -669,6 +877,7 @@ SKILLS_COMMAND.set_call(skills_command_call)
 COST_COMMAND.set_call(cost_command_call)
 CONTEXT_COMMAND.set_call(context_command_call)
 COMPACT_COMMAND.set_call(compact_command_call)
+ADVISOR_COMMAND.set_call(advisor_command_call)
 
 
 def get_builtin_commands() -> list[Command]:
@@ -681,6 +890,7 @@ def get_builtin_commands() -> list[Command]:
         COST_COMMAND,
         CONTEXT_COMMAND,
         COMPACT_COMMAND,
+        ADVISOR_COMMAND,
         INIT_COMMAND,
     ]
 

--- a/src/command_system/engine.py
+++ b/src/command_system/engine.py
@@ -224,6 +224,8 @@ def create_command_context(
     history: Any = None,
     cwd: str | Path | None = None,
     config: dict[str, Any] | None = None,
+    app_state_store: Any = None,
+    provider: Any = None,
 ) -> CommandContext:
     """
     Create a command context.
@@ -235,6 +237,10 @@ def create_command_context(
         history: History log object
         cwd: Current working directory (defaults to workspace_root)
         config: Optional configuration dict
+        app_state_store: Optional reactive AppState store. Commands that
+            mutate global session state (e.g. /advisor) need this.
+        provider: Optional active LLM provider. Commands that gate on
+            provider type (e.g. /advisor) need this.
 
     Returns:
         CommandContext instance
@@ -249,4 +255,6 @@ def create_command_context(
         cost_tracker=cost_tracker,
         history=history,
         config=config or {},
+        app_state_store=app_state_store,
+        provider=provider,
     )

--- a/src/command_system/types.py
+++ b/src/command_system/types.py
@@ -54,6 +54,20 @@ class CommandContext:
     cost_tracker: Any
     history: Any
     config: dict[str, Any] = field(default_factory=dict)
+    # Optional handles for commands that need to read or mutate
+    # cross-session state. Default to None so existing call sites that
+    # build CommandContext positionally / partially still work.
+    #
+    # ``app_state_store`` is the reactive AppState store created at TUI /
+    # REPL startup. /advisor uses it to read the current advisor model
+    # and to flip it via ``set_state`` (which fires the persistence
+    # handler in ``src/state/app_state.py``).
+    #
+    # ``provider`` is the currently-active LLM provider; /advisor checks
+    # it to decide whether the user can configure the advisor at all
+    # (only first-party Anthropic supports it).
+    app_state_store: Any = None
+    provider: Any = None
 
 
 # Protocol for local command callables

--- a/src/providers/anthropic_provider.py
+++ b/src/providers/anthropic_provider.py
@@ -141,12 +141,44 @@ class AnthropicProvider(BaseProvider):
         return bool(self._client_kwargs.get("base_url"))
 
     def _build_chat_response(self, response: Any) -> ChatResponse:
-        """Convert Anthropic SDK response into the shared ChatResponse shape."""
+        """Convert Anthropic SDK response into the shared ChatResponse shape.
+
+        Beyond the text + ``tool_use`` projection used by the rest of
+        the agentic loop, we also preserve advisor server-tool blocks
+        (``server_tool_use`` with ``name=='advisor'`` and the
+        ``advisor_tool_result`` follow-up). They must round-trip through
+        conversation history so that on the next turn the API sees a
+        valid use/result pair; stripping them here would either lose the
+        advisor's analysis or — worse — leave an orphan ``server_tool_use``
+        that the API rejects on replay. See ``src/utils/advisor.py``.
+
+        The SDK parses unknown discriminator values (e.g.
+        ``advisor_tool_result``) leniently via ``construct_type`` — the
+        block lands as the first matching union variant (typically
+        ``BetaTextBlock``) but the original fields (``type``,
+        ``tool_use_id``, ``content``) are preserved on the instance.
+        ``model_dump()`` round-trips them as a dict for downstream replay.
+        """
         content_text = ""
         tool_uses: list[dict[str, Any]] = []
+        raw_content_blocks: list[dict[str, Any]] = []
 
         for block in response.content:
             block_type = getattr(block, "type", "text")
+            block_name = getattr(block, "name", None)
+            is_advisor = block_type == "advisor_tool_result" or (
+                block_type == "server_tool_use" and block_name == "advisor"
+            )
+            if is_advisor:
+                dump = getattr(block, "model_dump", None)
+                if callable(dump):
+                    raw_content_blocks.append(dict(dump(exclude_none=True)))
+                else:
+                    # Fallback for non-Pydantic shapes (test doubles, etc.).
+                    raw_content_blocks.append(
+                        {k: v for k, v in vars(block).items() if v is not None}
+                    )
+                continue
             if block_type == "text":
                 text_val = getattr(block, "text", "")
                 if text_val is not None:
@@ -165,6 +197,7 @@ class AnthropicProvider(BaseProvider):
             usage=_extract_usage_dict(usage),
             finish_reason=str(getattr(response, "stop_reason", "stop")),
             tool_uses=tool_uses if tool_uses else None,
+            raw_content_blocks=raw_content_blocks or None,
         )
 
     def chat(

--- a/src/providers/base.py
+++ b/src/providers/base.py
@@ -32,6 +32,14 @@ class ChatResponse:
     finish_reason: str
     reasoning_content: Optional[str] = None
     tool_uses: Optional[list[dict[str, Any]]] = None
+    # Raw content blocks the provider chose not to project into
+    # ``content``/``tool_uses`` — currently the server-side advisor's
+    # ``server_tool_use`` (name=advisor) and ``advisor_tool_result``
+    # blocks. The query loop appends these to assistant history as
+    # opaque passthrough dicts so the next turn can replay them. None
+    # when the response had no such blocks. See
+    # ``src/utils/advisor.py`` for the policy.
+    raw_content_blocks: Optional[list[dict[str, Any]]] = None
 
 
 MessageInput: TypeAlias = ChatMessage | dict[str, Any]

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -286,8 +286,67 @@ async def _call_model_sync(
     abort_signal: Any = None,
 ) -> tuple[list[AssistantMessage], list[ToolUseBlock]]:
     from ..types.messages import normalize_messages_for_api
+    from ..utils.advisor import (
+        ADVISOR_BETA_HEADER,
+        ADVISOR_TOOL_INSTRUCTIONS,
+        build_advisor_tool_schema,
+        is_advisor_enabled,
+        is_valid_advisor_model,
+        model_supports_advisor,
+        strip_advisor_blocks,
+    )
+
+    # Advisor activation decision — server-side parity with TS
+    # claude.ts:1094-1130. Activation requires ALL of:
+    # 1. Provider is first-party Anthropic (no custom base_url) and the
+    #    CLAUDE_CODE_DISABLE_ADVISOR_TOOL env switch is not set.
+    # 2. ``settings.advisor_model`` is non-empty (the user opted in via
+    #    /advisor; ``_on_advisor_model_change`` persists writes here).
+    # 3. The main-loop model supports calling the advisor tool
+    #    (opus-4-6 / sonnet-4-6 — older models reject the schema).
+    # 4. The configured advisor model itself is a valid advisor target.
+    # A stale advisor_model setting under a non-supporting model is
+    # silently ignored — never sent to the API. Mirrors the TS
+    # "skipping advisor — base model X does not support advisor" branch.
+    main_loop_model = getattr(provider, "model", "") or ""
+    advisor_active = False
+    advisor_model_normalized: str | None = None
+    # Wrap the ENTIRE activation predicate so any failure (transient
+    # import, future provider type that throws on the first-party
+    # check, settings cache contention) defaults to "advisor inactive"
+    # instead of failing the turn. Critic M1: previously the env/
+    # provider check was outside the inner try, so an exception in
+    # ``is_first_party_provider`` would propagate to the caller.
+    try:
+        if is_advisor_enabled(provider):
+            from ..settings.settings import get_settings
+            configured = (get_settings().advisor_model or "").strip()
+            if configured and model_supports_advisor(main_loop_model):
+                from ..models.model import canonical_model_name
+                candidate = canonical_model_name(configured)
+                if is_valid_advisor_model(candidate):
+                    advisor_active = True
+                    advisor_model_normalized = candidate
+    except Exception:
+        # Don't let advisor activation issues kill the turn. The
+        # historical advisor blocks (if any) will still be stripped
+        # below since advisor_active is False.
+        logger.exception(
+            "Advisor activation check failed; treating advisor as inactive"
+        )
+        advisor_active = False
+        advisor_model_normalized = None
 
     api_messages = normalize_messages_for_api(messages)
+
+    # When the advisor beta header is NOT going on this request, strip
+    # any historical advisor blocks — the API 400s on
+    # ``server_tool_use(name=advisor)`` and ``advisor_tool_result`` blocks
+    # without the matching beta. Mirror of TS claude.ts:1332-1334.
+    # Always-on when advisor is inactive (provider switch, env disable,
+    # base model unsupported, or user ran /advisor unset).
+    if not advisor_active:
+        api_messages = strip_advisor_blocks(api_messages)
 
     # --- Diagnostic tracing ---
     _diag = os.environ.get("CLAWCODEX_DEBUG", "").lower() in ("1", "true", "yes")
@@ -339,7 +398,25 @@ async def _call_model_sync(
             "input_schema": dict(tool.input_schema),
         })
 
+    # Append the advisor schema AFTER the regular tools so the
+    # ``cache_control`` marker (which conventionally lives on the last
+    # cached tool — the final entry in ``tool_schemas`` before this
+    # append) stays in place. If we prepended or interleaved, toggling
+    # /advisor would shift the marker and bust the prompt cache. Mirrors
+    # TS claude.ts:1411-1421 explicitly.
+    if advisor_active:
+        tool_schemas.append(build_advisor_tool_schema(advisor_model_normalized))
+
     call_kwargs: dict[str, Any] = {"tools": tool_schemas}
+
+    if advisor_active:
+        # Opt into the server-side advisor tool. ``betas`` lives outside
+        # ``extra_headers`` because the SDK auto-converts it into the
+        # ``anthropic-beta`` header AND filters out 3P-incompatible
+        # entries on Bedrock/Vertex transports. Currently we send only
+        # the advisor beta; if other betas are introduced, change this
+        # to ``call_kwargs.setdefault("betas", []).append(...)``.
+        call_kwargs["betas"] = [ADVISOR_BETA_HEADER]
 
     from ..providers.anthropic_provider import AnthropicProvider
     from ..providers.minimax_provider import MinimaxProvider
@@ -349,6 +426,33 @@ async def _call_model_sync(
         # Forward whatever shape the engine produced — str or list[dict].
         # The SDK's ``system`` param accepts ``Union[str, Iterable[TextBlockParam]]``;
         # cache_control markers on blocks engage server-side prompt caching.
+        #
+        # When the advisor is active, append ``ADVISOR_TOOL_INSTRUCTIONS``
+        # AFTER the existing system prompt blocks. This mirrors TS
+        # claude.ts:1395 (the advisor instructions come AFTER the cached
+        # system blocks, so they land in the request-scope partition and
+        # toggling /advisor doesn't churn the cached prefix).
+        if advisor_active:
+            if isinstance(system_prompt, list):
+                system_prompt = list(system_prompt) + [
+                    {"type": "text", "text": ADVISOR_TOOL_INSTRUCTIONS}
+                ]
+            elif isinstance(system_prompt, str):
+                system_prompt = (
+                    f"{system_prompt}\n\n{ADVISOR_TOOL_INSTRUCTIONS}"
+                    if system_prompt
+                    else ADVISOR_TOOL_INSTRUCTIONS
+                )
+            else:
+                # Defensive: the upstream contract is
+                # ``str | list[dict[str, Any]]``. A future caller that
+                # passes something else (e.g. None, a TextBlock object)
+                # silently loses the instructions if we don't warn.
+                logger.warning(
+                    "Advisor active but system_prompt has unexpected type "
+                    "%s — ADVISOR_TOOL_INSTRUCTIONS NOT injected",
+                    type(system_prompt).__name__,
+                )
         call_kwargs["system"] = system_prompt
     else:
         # Non-Anthropic providers (OpenAI-compat, GLM, etc.) consume the
@@ -497,6 +601,18 @@ async def _call_model_sync(
             )
             assistant_blocks.append(block)
             tool_use_blocks.append(block)
+
+    # Preserve advisor server-tool blocks as passthrough dicts so the
+    # next turn can replay them to the API as a matched use/result pair.
+    # ``normalize_messages_for_api`` round-trips dict blocks unchanged
+    # (via ``content_block_to_dict``), and ``ensure_tool_result_pairing``
+    # treats the advisor pair as a self-contained server-side
+    # use/result on the assistant message (already paired in-message).
+    # Stripping happens centrally in this function when ``advisor_active``
+    # is False on a future turn.
+    if response.raw_content_blocks:
+        for raw in response.raw_content_blocks:
+            assistant_blocks.append(dict(raw))
 
     stop_reason = response.finish_reason or "end_turn"
 

--- a/src/state/app_state.py
+++ b/src/state/app_state.py
@@ -90,6 +90,13 @@ class AppState:
     # to process at startup. TS: AppStateStore.ts:406.
     initial_message: str | None = None
 
+    # Advisor model (TS: AppStateStore.ts advisorModel). None = no /advisor.
+    # Writes here fire ``_on_advisor_model_change``, which persists into
+    # ``settings.advisor_model`` (the read channel — see
+    # ``src/utils/advisor.py`` and ``src/query/query.py``) and invalidates
+    # the settings cache so the next API call picks up the new value.
+    advisor_model: str | None = None
+
 
 def replace_state(state: AppState, **changes: Any) -> AppState:
     """Return a copy of ``state`` with ``changes`` applied. Equivalent
@@ -211,6 +218,55 @@ def _on_initial_message_change(old: AppState, new: AppState) -> None:
     return
 
 
+def _on_advisor_model_change(old: AppState, new: AppState) -> None:
+    """Persist advisor_model to user settings + invalidate the read cache.
+
+    Mirrors TS ``commands/advisor.ts:49`` (``updateSettingsForSource(
+    'userSettings', { advisorModel })``). The persistence pattern matches
+    the existing TODO on ``_on_main_loop_model_change`` — settings are
+    layered as ``global > project > local``; we write the user-scoped
+    global level only. After persisting, the in-memory settings cache must
+    be invalidated so the next ``get_settings()`` call (which
+    ``_call_model_sync`` makes per-turn) reflects the new value
+    immediately. Without the invalidate, mid-session toggles would only
+    take effect after a process restart.
+    """
+    if old.advisor_model == new.advisor_model:
+        return
+    # Local imports avoid making this module's import time pay for the
+    # settings stack on cold start. Use the SHARED default ConfigManager
+    # so callers reading via ``load_config()`` / the global cache see
+    # the new value, not a stale in-memory snapshot from before the
+    # write.
+    from src import config as cfg_mod
+    from src.settings.settings import invalidate_settings_cache
+    try:
+        mgr = cfg_mod._get_default_manager()
+        cfg = mgr.load_global()
+        settings_section = cfg.get("settings")
+        if not isinstance(settings_section, dict):
+            settings_section = {}
+        # None / "" both map to "unset" — write empty string for
+        # round-trip fidelity with the SettingsSchema default.
+        settings_section["advisor_model"] = new.advisor_model or ""
+        cfg["settings"] = settings_section
+        mgr.save_global(cfg)
+        invalidate_settings_cache()
+        logger.debug(
+            "AppState.advisor_model %s -> %s — persisted + cache invalidated",
+            old.advisor_model,
+            new.advisor_model,
+        )
+    except Exception:
+        # The slash command already reported success to the user based on
+        # the in-memory store update; surface persistence failures via the
+        # log but don't propagate (the in-memory change still works for
+        # the current process; only re-launches would lose the setting).
+        logger.exception(
+            "Failed to persist advisor_model to settings; in-memory value still active"
+        )
+
+
 # Registry. EVERY field in AppState must appear here as a handler
 # (function-form, including explicit no-ops). The coverage test enforces
 # this — adding a new AppState field without a handler entry fails
@@ -221,6 +277,7 @@ _FIELD_HANDLERS: dict[str, Callable[[AppState, AppState], None]] = {
     "expanded_view": _on_expanded_view_change,
     "permission_mode": _on_permission_mode_change,
     "initial_message": _on_initial_message_change,
+    "advisor_model": _on_advisor_model_change,
 }
 
 

--- a/src/tui/__init__.py
+++ b/src/tui/__init__.py
@@ -13,6 +13,7 @@ interactive stacks can evolve independently.
 
 from .app import ClawCodexTUI
 from .messages import (
+    AdvisorEventMessage,
     AgentRunFinished,
     AgentRunStarted,
     AssistantChunk,
@@ -22,6 +23,7 @@ from .messages import (
 
 __all__ = [
     "ClawCodexTUI",
+    "AdvisorEventMessage",
     "AgentRunFinished",
     "AgentRunStarted",
     "AssistantChunk",

--- a/src/tui/agent_bridge.py
+++ b/src/tui/agent_bridge.py
@@ -31,6 +31,7 @@ from src.tool_system.registry import ToolRegistry
 from src.utils.abort_controller import AbortController, AbortError
 
 from .messages import (
+    AdvisorEventMessage,
     AgentRunFinished,
     AgentRunStarted,
     AssistantChunk,
@@ -77,6 +78,36 @@ class AgentBridge:
         # Wire permission handler: the tool dispatcher calls this from
         # the worker thread, we post to the UI and block on an Event.
         tool_context.permission_handler = self._permission_handler
+        # Advisor IDs we've already mirrored to the UI. The high-level
+        # SDK stream doesn't give us per-event hooks for server tools,
+        # so the bridge inspects the assembled conversation after each
+        # turn — without dedup, every turn would re-emit the same
+        # events for blocks that landed in earlier turns.
+        #
+        # ``_last_scanned_msg_index`` is an optimization: iterating the
+        # full message list on every turn is O(N*B). Tracking how far
+        # we've scanned lets us start at the new tail instead. Reset
+        # together with ``_emitted_advisor_ids`` via
+        # ``reset_advisor_dedup`` whenever the message list is
+        # truncated or replaced.
+        self._emitted_advisor_ids: set[str] = set()
+        self._last_scanned_msg_index: int = 0
+
+    def reset_advisor_dedup(self) -> None:
+        """Drop the advisor-dedup state.
+
+        Call this when conversation history is wiped or summarized so
+        the IDs we tracked no longer correspond to anything in the
+        live message list — keeping them around leaks memory (bounded:
+        one UUID per advisor call ever made) and risks suppressing a
+        legitimate re-render if a post-compact replay reuses an ID.
+        The TUI wires this on ``/clear`` (``tui/app.py:__clear__`` and
+        the idle-return "clear" choice). Other reset paths
+        (``/compact``, programmatic message wipe) don't yet trigger it;
+        the leak is harmless until they do.
+        """
+        self._emitted_advisor_ids.clear()
+        self._last_scanned_msg_index = 0
 
     # ---- public API ----
     @property
@@ -200,6 +231,19 @@ class AgentBridge:
             return
 
         self._post(AssistantMessage(text=result.response_text))
+        # Surface any advisor activity from this run as transcript rows.
+        # The Python provider path doesn't emit per-event hooks for
+        # server tools (the SDK's high-level ``messages.stream`` only
+        # signals text deltas to ``on_text_chunk``), so the bridge
+        # inspects the final assembled assistant content. This is
+        # idempotent across turns: ``_emit_advisor_events`` only posts
+        # events for advisor blocks added during the current run.
+        try:
+            self._emit_advisor_events()
+        except Exception:
+            # Never let an advisor-rendering issue mask the model's
+            # actual response.
+            pass
         if result.usage:
             try:
                 self._state.usage.update(
@@ -246,6 +290,110 @@ class AgentBridge:
             # reading the context field, so replacing here doesn't
             # orphan them either.
             self._tool_context.abort_controller = AbortController()
+
+    # ---- advisor rendering ----
+    def _emit_advisor_events(self) -> None:
+        """Scan the conversation for advisor blocks and post UI events for new ones.
+
+        Iterates the assembled assistant messages (which now persist
+        advisor blocks via ``ChatResponse.raw_content_blocks`` — see
+        ``src/providers/anthropic_provider.py:_build_chat_response``)
+        and posts one ``AdvisorEventMessage(kind="start")`` and one
+        ``AdvisorEventMessage(kind="result")`` per advisor pair. Both
+        emit in order so the transcript can mount the row in its
+        running state before flipping it to done.
+
+        Starts iteration at ``self._last_scanned_msg_index`` and
+        advances the cursor at the end. This avoids the O(N×B) per-
+        turn cost that grows over a long session — we only scan
+        messages that landed since the last scan, which on a healthy
+        agentic loop is just the latest assistant turn.
+        """
+        from src.utils.advisor import (
+            extract_advisor_error_code,
+            extract_advisor_result_text,
+        )
+        messages = getattr(self._session.conversation, "messages", None)
+        if not messages:
+            return
+        # Defend against a wipe (e.g. /clear): if the conversation
+        # shrank since last scan, the index is stale. Start over.
+        start_idx = self._last_scanned_msg_index
+        if start_idx > len(messages):
+            start_idx = 0
+        # Read the active advisor model from settings; ``server_tool_use``
+        # blocks don't include it (it's parameterized on the schema, not
+        # echoed back), but the user-facing label is much friendlier
+        # with the model name attached.
+        try:
+            from src.settings.settings import get_settings
+            advisor_model = (get_settings().advisor_model or "") or None
+        except Exception:
+            advisor_model = None
+        for msg in messages[start_idx:]:
+            content = getattr(msg, "content", None)
+            if not isinstance(content, list):
+                continue
+            # Pair-finding pass: collect (use_id → use_block_index) and
+            # (use_id → result_content) within this assistant message.
+            for i, block in enumerate(content):
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type")
+                bname = block.get("name")
+                bid = block.get("id") or block.get("tool_use_id")
+                if not isinstance(bid, str) or not bid:
+                    continue
+                if bid in self._emitted_advisor_ids:
+                    continue
+                if btype == "server_tool_use" and bname == "advisor":
+                    self._post(
+                        AdvisorEventMessage(
+                            kind="start",
+                            tool_use_id=bid,
+                            advisor_model=advisor_model,
+                        )
+                    )
+                    # Look for a matching advisor_tool_result anywhere
+                    # later in the same assistant message.
+                    result_block = None
+                    for later in content[i + 1:]:
+                        if (
+                            isinstance(later, dict)
+                            and later.get("type") == "advisor_tool_result"
+                            and later.get("tool_use_id") == bid
+                        ):
+                            result_block = later
+                            break
+                    if result_block is None:
+                        # No result on this assistant turn — the use was
+                        # interrupted. Synthesize an error event so the
+                        # UI doesn't leave the row spinning forever.
+                        self._post(
+                            AdvisorEventMessage(
+                                kind="result",
+                                tool_use_id=bid,
+                                advisor_model=advisor_model,
+                                error_code="interrupted",
+                            )
+                        )
+                        self._emitted_advisor_ids.add(bid)
+                        continue
+                    rcontent = result_block.get("content")
+                    text = extract_advisor_result_text(rcontent)
+                    err_code = extract_advisor_error_code(rcontent)
+                    self._post(
+                        AdvisorEventMessage(
+                            kind="result",
+                            tool_use_id=bid,
+                            advisor_model=advisor_model,
+                            text=text,
+                            error_code=err_code,
+                        )
+                    )
+                    self._emitted_advisor_ids.add(bid)
+        # Cursor forward so the next scan only inspects new messages.
+        self._last_scanned_msg_index = len(messages)
 
     # ---- permission bridge ----
     def _permission_handler(

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -363,6 +363,7 @@ class ClawCodexTUI(App):
             return
         if result.system_text == "__clear__":
             transcript.clear_transcript()
+            self._agent_bridge.reset_advisor_dedup()
             return
         if result.system_text:
             transcript.append_system(result.system_text, style="muted")
@@ -494,6 +495,7 @@ class ClawCodexTUI(App):
         def _on_choice(action: str) -> None:
             if action == "clear":
                 transcript.clear_transcript()
+                self._agent_bridge.reset_advisor_dedup()
                 transcript.append_system("Conversation cleared.", style="muted")
                 self.announcer.announce("Conversation cleared.")
             elif action == "never":
@@ -790,6 +792,7 @@ class ClawCodexTUI(App):
                 conversation=self.session.conversation,
                 cost_tracker=CostTracker(),
                 history=HistoryLog(),
+                provider=self.provider,
             )
         except Exception:
             self._command_context = None

--- a/src/tui/messages.py
+++ b/src/tui/messages.py
@@ -86,6 +86,27 @@ class ToolEventMessage(Message):
 
 
 @dataclass
+class AdvisorEventMessage(Message):
+    """Server-side advisor activity surfaced as a transcript row.
+
+    The Python streaming path doesn't expose per-event hooks for
+    server tools, so the bridge inspects the assembled assistant
+    message at end-of-turn and posts one of these per
+    ``server_tool_use(name=advisor)`` + ``advisor_tool_result`` pair.
+
+    ``kind`` is either ``"start"`` (the use block on its own) or
+    ``"result"`` (the matched result, carrying ``text`` or
+    ``error_code``).
+    """
+
+    kind: str
+    tool_use_id: str
+    advisor_model: str | None = None
+    text: str | None = None
+    error_code: str | None = None
+
+
+@dataclass
 class AgentRunFinished(Message):
     """Emitted when the agent loop returns (success or error)."""
 

--- a/src/tui/screens/repl.py
+++ b/src/tui/screens/repl.py
@@ -27,6 +27,7 @@ from textual.app import ComposeResult
 from textual.screen import Screen
 
 from ..messages import (
+    AdvisorEventMessage,
     AgentRunFinished,
     AgentRunStarted,
     AssistantChunk,
@@ -158,6 +159,15 @@ class REPLScreen(Screen):
             tool_use_id=message.tool_use_id,
             is_error=message.is_error,
             error=message.error,
+        )
+
+    def on_advisor_event_message(self, message: AdvisorEventMessage) -> None:
+        self.transcript.append_advisor_event(
+            kind=message.kind,
+            tool_use_id=message.tool_use_id,
+            advisor_model=message.advisor_model,
+            text=message.text,
+            error_code=message.error_code,
         )
 
     def on_agent_run_finished(self, message: AgentRunFinished) -> None:

--- a/src/tui/widgets/messages/__init__.py
+++ b/src/tui/widgets/messages/__init__.py
@@ -22,6 +22,7 @@ from .base import BaseRow, SystemMessage
 from .user_text import UserTextMessage
 from .assistant_text import AssistantTextMessage
 from .assistant_tool_use import AssistantToolUseMessage
+from .assistant_advisor import AssistantAdvisorMessage
 from .tool_result import ToolResultRow
 
 __all__ = [
@@ -30,5 +31,6 @@ __all__ = [
     "UserTextMessage",
     "AssistantTextMessage",
     "AssistantToolUseMessage",
+    "AssistantAdvisorMessage",
     "ToolResultRow",
 ]

--- a/src/tui/widgets/messages/assistant_advisor.py
+++ b/src/tui/widgets/messages/assistant_advisor.py
@@ -1,0 +1,190 @@
+"""Advisor transcript row.
+
+Port of ``typescript/src/components/messages/AdvisorMessage.tsx``. Two
+forms exist in the TS reference and we mirror both:
+
+1. **In-progress** — a ``server_tool_use(name="advisor")`` arrives. The
+   row shows ``Advising using <model>`` with a rotating glyph.
+2. **Completed** — the corresponding ``advisor_tool_result`` arrives.
+   The row swaps to a dim ``✓ Advisor reviewed`` body; in verbose mode
+   the full advice text is shown directly. Errors show
+   ``Advisor unavailable (<code>)`` in the error color.
+
+The widget transitions in-place so the user's scroll position is
+preserved (matching the rest of the transcript). Spinner animation is
+left to the row's status header; we don't run a per-frame timer here
+to avoid a Textual ``set_interval`` for every advisor call — the row
+re-renders when ``mark_done`` / ``mark_error`` fires.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.reactive import reactive
+from textual.widgets import Static
+
+from .base import BaseRow, RowHeader
+
+
+# Verbose mode is read from settings on every advisor result. We keep it
+# as a module-level default so tests can monkeypatch the lookup, and the
+# widget falls back to the dim "Advisor reviewed" summary when settings
+# can't be read (cold-start, test harnesses).
+def _advisor_verbose_mode() -> bool:
+    try:
+        from src.settings.settings import get_settings
+        # ``output_style.show_thinking`` doubles as the verbose toggle —
+        # the existing knob the user already uses to opt into long
+        # in-transcript text. Keeps us from introducing yet another
+        # setting just for this widget.
+        return bool(getattr(get_settings().output_style, "show_thinking", False))
+    except Exception:
+        return False
+
+
+class AssistantAdvisorMessage(BaseRow):
+    """Transcript row dedicated to the server-side advisor tool."""
+
+    DEFAULT_CSS = """
+    AssistantAdvisorMessage {
+        height: auto;
+    }
+    AssistantAdvisorMessage > Static.-advisor-body {
+        padding: 0 1;
+        color: $text-muted;
+    }
+    """
+
+    status: reactive[str] = reactive("requested")
+
+    def __init__(
+        self,
+        *,
+        tool_use_id: str,
+        advisor_model: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.tool_use_id = tool_use_id
+        self.advisor_model = advisor_model or ""
+        self._body_text: str = ""
+        self._error_code: str | None = None
+
+    # ---- composition ----
+    def compose(self) -> ComposeResult:
+        header = RowHeader(self._header_text(), markup=False)
+        header.add_class("-tool")
+        yield header
+        # Body is mounted with placeholder content; ``mark_done`` /
+        # ``mark_error`` swap it via ``Static.update`` once the result
+        # arrives. Pre-result it stays empty (the header already says
+        # "Advising using …").
+        yield Static(Text(""), markup=False, classes="-advisor-body")
+
+    # ---- lifecycle updates ----
+    def mark_running(self) -> None:
+        self._set_status("running")
+
+    def mark_done(self, text: str | None) -> None:
+        self._body_text = text or ""
+        self._set_status("done")
+        self._refresh_body()
+
+    def mark_error(self, error_code: str | None) -> None:
+        self._error_code = error_code or "error"
+        self._set_status("error")
+        self._refresh_body()
+
+    # ---- internals ----
+    def _set_status(self, status: str) -> None:
+        self.status = status
+        header = self._header_widget()
+        if header is None:
+            return
+        header.remove_class("-tool", "-tool-success", "-tool-error")
+        if status == "done":
+            header.add_class("-tool-success")
+        elif status == "error":
+            header.add_class("-tool-error")
+        else:
+            header.add_class("-tool")
+        header.update(self._header_text())
+
+    def _refresh_body(self) -> None:
+        body = self._body_widget()
+        if body is None:
+            return
+        body.update(self._body_renderable())
+
+    def _header_text(self) -> Text:
+        glyph = {
+            "requested": "○",
+            "running": "◐",
+            "done": "✓",
+            "error": "✗",
+        }.get(self.status, "•")
+        if self.status in ("requested", "running"):
+            label = "Advising"
+            if self.advisor_model:
+                label = f"Advising using {self.advisor_model}"
+            return Text(f"{glyph} {label}")
+        if self.status == "done":
+            return Text(f"{glyph} Advisor reviewed")
+        return Text(f"{glyph} Advisor unavailable")
+
+    def _body_renderable(self) -> Text:
+        if self.status == "error":
+            code = self._error_code or "error"
+            return Text(f"Advisor unavailable ({code})", style="red")
+        if self.status == "done":
+            if _advisor_verbose_mode() and self._body_text:
+                return Text(self._body_text, style="dim")
+            return Text(
+                "Advisor has reviewed the conversation and will apply the feedback",
+                style="dim",
+            )
+        return Text("")
+
+    def _header_widget(self) -> RowHeader | None:
+        try:
+            for header in self.query(RowHeader):
+                return header
+        except Exception:
+            return None
+        return None
+
+    def _body_widget(self) -> Static | None:
+        try:
+            for body in self.query(Static):
+                if body.has_class("-advisor-body"):
+                    return body
+        except Exception:
+            return None
+        return None
+
+    def snapshot(self) -> Text:
+        """Compact snapshot used by the post-exit scrollback dump."""
+        status_color = {
+            "done": "bold green",
+            "error": "bold red",
+        }.get(self.status, "bold #f5c451")
+        return Text(str(self._header_text()), style=status_color)
+
+
+# Helpers used to live here but are pure (no Textual deps), so they
+# moved to ``src/utils/advisor.py`` for reuse by the agent bridge,
+# tests, and any future telemetry consumer. Re-export so existing
+# import paths keep working.
+from src.utils.advisor import (
+    extract_advisor_error_code,
+    extract_advisor_result_text,
+)
+
+
+__all__ = [
+    "AssistantAdvisorMessage",
+    "extract_advisor_error_code",
+    "extract_advisor_result_text",
+]

--- a/src/tui/widgets/transcript_view.py
+++ b/src/tui/widgets/transcript_view.py
@@ -25,6 +25,7 @@ from textual.widget import Widget
 from textual.widgets import Static
 
 from .messages import (
+    AssistantAdvisorMessage,
     AssistantTextMessage,
     AssistantToolUseMessage,
     SystemMessage,
@@ -60,6 +61,12 @@ class TranscriptView(VerticalScroll):
         # Tool-use rows indexed by ``tool_use_id`` so ``tool_result`` /
         # ``tool_error`` events can find the matching activity widget.
         self._tool_rows: dict[str, AssistantToolUseMessage] = {}
+        # Advisor rows indexed by ``tool_use_id``. Kept separate from
+        # ``_tool_rows`` so the eviction sweep can distinguish them and
+        # so the lifecycle ("start" → "result") is unambiguous —
+        # advisor rows have no surrounding ToolEvent stream the way
+        # regular tools do.
+        self._advisor_rows: dict[str, AssistantAdvisorMessage] = {}
         # Insertion-ordered list of rows we've mounted. Textual's
         # ``self.children`` lags behind ``mount()`` until the event
         # loop ticks, so we track the order ourselves to make the
@@ -237,6 +244,55 @@ class TranscriptView(VerticalScroll):
         self.mount(SystemMessage(f"{tool_name} [{kind}]", style="muted"))
         self._scroll_end()
 
+    def append_advisor_event(
+        self,
+        *,
+        kind: str,
+        tool_use_id: str,
+        advisor_model: str | None = None,
+        text: str | None = None,
+        error_code: str | None = None,
+    ) -> None:
+        """Add or update an advisor row.
+
+        ``kind="start"`` mounts a fresh row in the in-progress state.
+        ``kind="result"`` looks up the row by ``tool_use_id`` and swaps
+        it into the done/error terminal state. If we see a result
+        without a prior start (e.g. the bridge inspects history after a
+        resume where the start landed before the UI was up), we mount
+        the row directly in the terminal state so the event isn't
+        silently dropped.
+        """
+        self._retire_active_assistant()
+        if kind == "start":
+            if tool_use_id in self._advisor_rows:
+                return
+            row = AssistantAdvisorMessage(
+                tool_use_id=tool_use_id, advisor_model=advisor_model
+            )
+            self._advisor_rows[tool_use_id] = row
+            self.mount(row)
+            row.mark_running()
+            self._scroll_end()
+            return
+        if kind == "result":
+            row = self._advisor_rows.pop(tool_use_id, None)
+            if row is None:
+                # Result without a start — mount fresh and finalise.
+                row = AssistantAdvisorMessage(
+                    tool_use_id=tool_use_id, advisor_model=advisor_model
+                )
+                self.mount(row)
+            if error_code:
+                row.mark_error(error_code)
+            else:
+                row.mark_done(text)
+            self._scroll_end()
+            return
+        # Unknown kind — surface as a muted system row.
+        self.mount(SystemMessage(f"advisor [{kind}]", style="muted"))
+        self._scroll_end()
+
     def append_system(self, text: str, *, style: str = "muted") -> None:
         """Append a system / informational row.
 
@@ -254,6 +310,7 @@ class TranscriptView(VerticalScroll):
     def clear_transcript(self) -> None:
         self._active_assistant = None
         self._tool_rows.clear()
+        self._advisor_rows.clear()
         self._mounted_rows.clear()
         try:
             for child in list(self.children):
@@ -332,6 +389,12 @@ class TranscriptView(VerticalScroll):
             if (
                 isinstance(row, AssistantToolUseMessage)
                 and row.tool_use_id in self._tool_rows
+            ):
+                idx += 1
+                continue
+            if (
+                isinstance(row, AssistantAdvisorMessage)
+                and row.tool_use_id in self._advisor_rows
             ):
                 idx += 1
                 continue

--- a/tests/integration/test_advisor_smoke.py
+++ b/tests/integration/test_advisor_smoke.py
@@ -1,0 +1,323 @@
+"""End-to-end advisor smoke tests against a mocked Anthropic SDK stream.
+
+Two scenarios:
+  1. Happy path — the stream emits text + advisor server_tool_use +
+     advisor_tool_result + text. Verify the assembled assistant message
+     preserves all four blocks AND the next-turn outbound request
+     includes the use/result pair in history (because the beta header
+     keeps going).
+  2. Interrupt path — the stream emits text + advisor server_tool_use
+     without a matching result (simulating ESC mid-advisor). Verify
+     the next turn's outbound message has the orphan ``server_tool_use``
+     stripped by ``ensure_tool_result_pairing`` so the API doesn't 400.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+import unittest
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from src.providers.anthropic_provider import AnthropicProvider
+from src.providers.base import ChatResponse
+from src.query.query import _call_model_sync
+from src.types.messages import AssistantMessage, UserMessage
+
+
+class _Isolation:
+    """Override the module-level config-path constants to a tmp dir.
+
+    See ``tests/test_advisor_request_wiring.py`` for the rationale —
+    ``src/config.py`` freezes the path constants at import time so a
+    plain ``HOME`` patch is too late.
+    """
+
+    def __init__(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="advisor_smoke_")
+        self._saved_global = None
+        self._saved_history = None
+        self._saved_dir = None
+
+    def enter(self) -> None:
+        import src.config as cfg_mod
+        from pathlib import Path as _P
+        self._saved_global = cfg_mod.GLOBAL_CONFIG_FILE
+        self._saved_history = cfg_mod.HISTORY_FILE
+        self._saved_dir = cfg_mod.GLOBAL_CONFIG_DIR
+        cfg_mod.GLOBAL_CONFIG_FILE = _P(self._tmp) / ".clawcodex" / "config.json"
+        cfg_mod.HISTORY_FILE = _P(self._tmp) / ".clawcodex" / "history.jsonl"
+        cfg_mod.GLOBAL_CONFIG_DIR = _P(self._tmp) / ".clawcodex"
+        cfg_mod._default_manager = None
+        from src.settings.settings import invalidate_settings_cache
+        invalidate_settings_cache()
+
+    def exit(self) -> None:
+        import src.config as cfg_mod
+        cfg_mod.GLOBAL_CONFIG_FILE = self._saved_global
+        cfg_mod.HISTORY_FILE = self._saved_history
+        cfg_mod.GLOBAL_CONFIG_DIR = self._saved_dir
+        cfg_mod._default_manager = None
+        from src.settings.settings import invalidate_settings_cache
+        invalidate_settings_cache()
+
+
+def _isolate_env():
+    return _Isolation()
+
+
+def _set_advisor(value: str) -> None:
+    import src.config as cfg_mod
+    from src.config import ConfigManager
+    from src.settings.settings import invalidate_settings_cache
+    cfg_mod._default_manager = None
+    mgr = ConfigManager()
+    cfg = mgr.load_global()
+    sub = cfg.get("settings") if isinstance(cfg.get("settings"), dict) else {}
+    sub["advisor_model"] = value
+    cfg["settings"] = sub
+    mgr.save_global(cfg)
+    invalidate_settings_cache()
+
+
+def _build_fake_anthropic_response(content_blocks: list[dict]) -> Any:
+    """Build a fake ChatResponse with all the blocks the SDK would surface.
+
+    We bypass ``messages.stream`` entirely and stub
+    ``chat_stream_response`` to return the assembled ChatResponse — the
+    SDK code path is exercised by ``test_provider_anthropic.py``
+    elsewhere; here we want to verify the query layer assembles blocks
+    correctly when the provider does its job.
+    """
+    raw_blocks: list[dict] = []
+    text_content = ""
+    tool_uses: list[dict] = []
+    for block in content_blocks:
+        btype = block.get("type")
+        if btype == "text":
+            text_content += block.get("text", "")
+        elif btype == "tool_use":
+            tool_uses.append({
+                "id": block["id"],
+                "name": block["name"],
+                "input": block.get("input", {}),
+            })
+        elif btype in ("server_tool_use", "advisor_tool_result"):
+            raw_blocks.append(dict(block))
+    return ChatResponse(
+        content=text_content,
+        model="claude-opus-4-6",
+        usage={"input_tokens": 5, "output_tokens": 20},
+        finish_reason="end_turn",
+        tool_uses=tool_uses or None,
+        raw_content_blocks=raw_blocks or None,
+    )
+
+
+class _Capture:
+    api_messages: list = None
+    call_kwargs: dict = None
+
+
+def _make_provider(captured: _Capture, *, response_blocks: list[dict]):
+    provider = MagicMock(spec=AnthropicProvider)
+    provider.has_custom_endpoint = MagicMock(return_value=False)
+    provider.model = "claude-opus-4-6"
+
+    def fake_chat_stream_response(api_messages, *, abort_signal=None, **kwargs):
+        captured.api_messages = list(api_messages)
+        captured.call_kwargs = dict(kwargs)
+        return _build_fake_anthropic_response(response_blocks)
+
+    provider.chat_stream_response = fake_chat_stream_response
+    return provider
+
+
+class TestAdvisorHappyPath(unittest.TestCase):
+    def setUp(self) -> None:
+        self._iso = _isolate_env()
+        self._iso.enter()
+        os.environ.pop("CLAUDE_CODE_DISABLE_ADVISOR_TOOL", None)
+        _set_advisor("claude-opus-4-6")
+
+    def tearDown(self) -> None:
+        # _iso.exit() restores the real config paths AND clears the
+        # singleton cache; any write here would leak onto the real
+        # user's config file. The tmp dir from .enter() is its own
+        # world — no additional cleanup write needed.
+        self._iso.exit()
+
+    def test_advisor_pair_preserved_in_history(self) -> None:
+        cap = _Capture()
+        response_blocks = [
+            {"type": "text", "text": "Let me check with the advisor. "},
+            {
+                "type": "server_tool_use",
+                "id": "srv_001",
+                "name": "advisor",
+                "input": {},
+            },
+            {
+                "type": "advisor_tool_result",
+                "tool_use_id": "srv_001",
+                "content": {"type": "advisor_result", "text": "Looks good."},
+            },
+            {"type": "text", "text": "Proceeding."},
+        ]
+        provider = _make_provider(cap, response_blocks=response_blocks)
+        # Turn 1.
+        result_msgs, _ = asyncio.run(_call_model_sync(
+            provider=provider,
+            messages=[UserMessage(content="What should I do?")],
+            system_prompt="sys",
+            tools=[],
+        ))
+        # The assembled AssistantMessage MUST carry the advisor pair as
+        # raw passthrough dicts so the next turn can replay them.
+        self.assertEqual(len(result_msgs), 1)
+        asst = result_msgs[0]
+        types = []
+        for b in asst.content if isinstance(asst.content, list) else []:
+            if isinstance(b, dict):
+                types.append(b.get("type"))
+            else:
+                types.append(getattr(b, "type", "?"))
+        self.assertIn("server_tool_use", types)
+        self.assertIn("advisor_tool_result", types)
+
+        # Turn 2 — feed the assistant message back and confirm the API
+        # payload preserves the pair (beta header still going, so no
+        # strip should happen).
+        cap2 = _Capture()
+        provider2 = _make_provider(cap2, response_blocks=[
+            {"type": "text", "text": "ok"},
+        ])
+        asyncio.run(_call_model_sync(
+            provider=provider2,
+            messages=[
+                UserMessage(content="What should I do?"),
+                asst,
+                UserMessage(content="now what?"),
+            ],
+            system_prompt="sys",
+            tools=[],
+        ))
+        # Beta header still attached (advisor still active).
+        self.assertIn("advisor-tool-2026-03-01", cap2.call_kwargs.get("betas", []))
+        # Advisor blocks survived through normalize → ensure_pairing.
+        asst_payload = next(
+            m for m in cap2.api_messages if m.get("role") == "assistant"
+        )
+        api_types = [b.get("type") for b in asst_payload["content"]]
+        self.assertIn("server_tool_use", api_types)
+        self.assertIn("advisor_tool_result", api_types)
+
+
+class TestAdvisorInterruptPath(unittest.TestCase):
+    def setUp(self) -> None:
+        self._iso = _isolate_env()
+        self._iso.enter()
+        os.environ.pop("CLAUDE_CODE_DISABLE_ADVISOR_TOOL", None)
+        _set_advisor("claude-opus-4-6")
+
+    def tearDown(self) -> None:
+        # _iso.exit() restores the real config paths AND clears the
+        # singleton cache; any write here would leak onto the real
+        # user's config file. The tmp dir from .enter() is its own
+        # world — no additional cleanup write needed.
+        self._iso.exit()
+
+    def test_orphan_use_stripped_next_turn(self) -> None:
+        cap = _Capture()
+        # Simulate an interrupted advisor — the use block landed but
+        # the result never did (ESC mid-call). The provider returns it
+        # as a raw passthrough block; the next turn must strip it.
+        response_blocks = [
+            {"type": "text", "text": "consulting"},
+            {
+                "type": "server_tool_use",
+                "id": "srv_orphan",
+                "name": "advisor",
+                "input": {},
+            },
+        ]
+        provider = _make_provider(cap, response_blocks=response_blocks)
+        result_msgs, _ = asyncio.run(_call_model_sync(
+            provider=provider,
+            messages=[UserMessage(content="Help me")],
+            system_prompt="sys",
+            tools=[],
+        ))
+        asst = result_msgs[0]
+
+        # Turn 2 — the next request must drop the orphan
+        # ``server_tool_use`` (else the API rejects with "advisor tool
+        # use without corresponding advisor_tool_result").
+        cap2 = _Capture()
+        provider2 = _make_provider(cap2, response_blocks=[
+            {"type": "text", "text": "ok"},
+        ])
+        asyncio.run(_call_model_sync(
+            provider=provider2,
+            messages=[
+                UserMessage(content="Help me"),
+                asst,
+                UserMessage(content="continue"),
+            ],
+            system_prompt="sys",
+            tools=[],
+        ))
+        asst_payload = next(
+            m for m in cap2.api_messages if m.get("role") == "assistant"
+        )
+        api_types = [b.get("type") for b in asst_payload["content"]]
+        self.assertNotIn(
+            "server_tool_use", api_types,
+            "Orphan server_tool_use (advisor) MUST be stripped before send",
+        )
+
+    def test_orphan_stripped_even_with_beta_active(self) -> None:
+        # Critical: the strip pass in ensure_tool_result_pairing applies
+        # regardless of whether the beta header is going — it removes
+        # orphans because the API rejects them in ALL cases, not just
+        # when the header is absent.
+        cap = _Capture()
+        provider = _make_provider(cap, response_blocks=[
+            {
+                "type": "server_tool_use",
+                "id": "srv_orphan_2",
+                "name": "advisor",
+                "input": {},
+            },
+        ])
+        asst_msg = AssistantMessage(content=[
+            {
+                "type": "server_tool_use",
+                "id": "srv_orphan_2",
+                "name": "advisor",
+                "input": {},
+            },
+        ])
+        asyncio.run(_call_model_sync(
+            provider=provider,
+            messages=[
+                UserMessage(content="hi"),
+                asst_msg,
+                UserMessage(content="x"),
+            ],
+            system_prompt="sys",
+            tools=[],
+        ))
+        # Beta IS going (active advisor) — but the orphan still strips.
+        self.assertIn("advisor-tool-2026-03-01", cap.call_kwargs.get("betas", []))
+        asst_payload = next(
+            m for m in cap.api_messages if m.get("role") == "assistant"
+        )
+        api_types = [b.get("type") for b in asst_payload["content"]]
+        self.assertNotIn("server_tool_use", api_types)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_advisor_chat_response_roundtrip.py
+++ b/tests/test_advisor_chat_response_roundtrip.py
@@ -1,0 +1,259 @@
+"""Defensive round-trip test for `_build_chat_response` advisor preservation.
+
+The Anthropic Python SDK 0.88.0 parses unknown content-block discriminators
+via `construct_type` (lenient), which materializes the block as the first
+matching union variant (typically `ParsedTextBlock` for an
+`advisor_tool_result`) but preserves the original fields (`type`,
+`tool_use_id`, `content`) as attributes accessible via `model_dump()`.
+
+If a future SDK upgrade tightens that path — Pydantic v3, a stricter
+discriminator handler, an `extra="ignore"` config — the advisor pair would
+silently lose its content and the next turn would fail with API 400s on
+replay. This test pins the round-trip contract so a regression in the SDK
+or a refactor of `_build_chat_response` is caught locally.
+
+Covers all three discriminated shapes of advisor_tool_result content:
+  - advisor_result (text)
+  - advisor_redacted_result (encrypted_content)
+  - advisor_tool_result_error (error_code)
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from anthropic._models import construct_type
+from anthropic.types.beta import BetaRawMessageStreamEvent
+from anthropic.lib.streaming._messages import accumulate_event
+
+from src.providers.anthropic_provider import AnthropicProvider
+
+
+def _build_sdk_message_with_blocks(blocks: list[dict]) -> object:
+    """Materialize a real SDK ParsedMessage via the same accumulate path
+    the streaming provider uses, so the round-trip mirrors production."""
+    events_raw = [
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_x",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": "claude-opus-4-6",
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 0},
+            },
+        }
+    ]
+    for idx, block in enumerate(blocks):
+        events_raw.append(
+            {"type": "content_block_start", "index": idx, "content_block": block}
+        )
+        events_raw.append({"type": "content_block_stop", "index": idx})
+    events_raw.append(
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": 5},
+        }
+    )
+    events_raw.append({"type": "message_stop"})
+
+    snapshot = None
+    for raw in events_raw:
+        ev = construct_type(type_=BetaRawMessageStreamEvent, value=raw)
+        snapshot = accumulate_event(event=ev, current_snapshot=snapshot)
+    return snapshot
+
+
+class TestAdvisorBlockPreservation(unittest.TestCase):
+    """Build a fake assistant response, push it through the SDK's
+    ``accumulate_event`` machinery, then through
+    ``AnthropicProvider._build_chat_response``, and verify the
+    ``raw_content_blocks`` list contains the advisor blocks with all
+    their original fields intact.
+    """
+
+    def _provider(self) -> AnthropicProvider:
+        # __init__ stores kwargs lazily; we don't need a real client.
+        p = AnthropicProvider(api_key="fake", model="claude-opus-4-6")
+        return p
+
+    def test_advisor_result_content_preserved(self) -> None:
+        blocks = [
+            {"type": "text", "text": "ok"},
+            {
+                "type": "server_tool_use",
+                "id": "srv_1",
+                "name": "advisor",
+                "input": {},
+            },
+            {
+                "type": "advisor_tool_result",
+                "tool_use_id": "srv_1",
+                "content": {"type": "advisor_result", "text": "looks good"},
+            },
+        ]
+        snapshot = _build_sdk_message_with_blocks(blocks)
+        chat = self._provider()._build_chat_response(snapshot)
+        self.assertIsNotNone(chat.raw_content_blocks)
+        types = [b.get("type") for b in chat.raw_content_blocks]
+        self.assertEqual(
+            types,
+            ["server_tool_use", "advisor_tool_result"],
+            "advisor pair must be preserved in raw_content_blocks",
+        )
+        # The server_tool_use block keeps its name + id.
+        use = next(b for b in chat.raw_content_blocks if b["type"] == "server_tool_use")
+        self.assertEqual(use.get("name"), "advisor")
+        self.assertEqual(use.get("id"), "srv_1")
+        # The result block keeps its tool_use_id and full content dict.
+        result = next(b for b in chat.raw_content_blocks if b["type"] == "advisor_tool_result")
+        self.assertEqual(result.get("tool_use_id"), "srv_1")
+        self.assertEqual(
+            result.get("content"),
+            {"type": "advisor_result", "text": "looks good"},
+        )
+
+    def test_advisor_redacted_result_content_preserved(self) -> None:
+        blocks = [
+            {
+                "type": "server_tool_use",
+                "id": "srv_r",
+                "name": "advisor",
+                "input": {},
+            },
+            {
+                "type": "advisor_tool_result",
+                "tool_use_id": "srv_r",
+                "content": {
+                    "type": "advisor_redacted_result",
+                    "encrypted_content": "AAAA==",
+                },
+            },
+        ]
+        snapshot = _build_sdk_message_with_blocks(blocks)
+        chat = self._provider()._build_chat_response(snapshot)
+        result = next(
+            b for b in (chat.raw_content_blocks or [])
+            if b.get("type") == "advisor_tool_result"
+        )
+        # The opaque envelope MUST round-trip exactly — redacted
+        # results are the whole reason advisor exists for sensitive
+        # workloads; dropping encrypted_content would silently
+        # downgrade history fidelity.
+        self.assertEqual(
+            result.get("content"),
+            {"type": "advisor_redacted_result", "encrypted_content": "AAAA=="},
+        )
+
+    def test_advisor_tool_result_error_content_preserved(self) -> None:
+        blocks = [
+            {
+                "type": "server_tool_use",
+                "id": "srv_e",
+                "name": "advisor",
+                "input": {},
+            },
+            {
+                "type": "advisor_tool_result",
+                "tool_use_id": "srv_e",
+                "content": {
+                    "type": "advisor_tool_result_error",
+                    "error_code": "rate_limit",
+                },
+            },
+        ]
+        snapshot = _build_sdk_message_with_blocks(blocks)
+        chat = self._provider()._build_chat_response(snapshot)
+        result = next(
+            b for b in (chat.raw_content_blocks or [])
+            if b.get("type") == "advisor_tool_result"
+        )
+        # The error_code is the only signal the UI uses to render
+        # "Advisor unavailable (<code>)" — losing it would silently
+        # turn errors into "Advisor reviewed" successes.
+        self.assertEqual(
+            result.get("content"),
+            {"type": "advisor_tool_result_error", "error_code": "rate_limit"},
+        )
+
+    def test_advisor_use_alone_preserved_when_no_result(self) -> None:
+        # Interrupted advisor: use without matching result. We MUST
+        # preserve the use block so the orphan-strip pass in
+        # ensure_tool_result_pairing can find it and drop it on the
+        # next API replay.
+        blocks = [
+            {
+                "type": "server_tool_use",
+                "id": "srv_orphan",
+                "name": "advisor",
+                "input": {},
+            },
+        ]
+        snapshot = _build_sdk_message_with_blocks(blocks)
+        chat = self._provider()._build_chat_response(snapshot)
+        self.assertEqual(len(chat.raw_content_blocks or []), 1)
+        use = chat.raw_content_blocks[0]
+        self.assertEqual(use["type"], "server_tool_use")
+        self.assertEqual(use["name"], "advisor")
+        self.assertEqual(use["id"], "srv_orphan")
+
+    def test_non_advisor_server_tools_not_in_raw_content_blocks(self) -> None:
+        # Only ADVISOR server-tool blocks should land in
+        # raw_content_blocks. Other server tools (web_search,
+        # code_execution, ...) have their own handling and would
+        # leak into history wrongly if scooped up here.
+        blocks = [
+            {
+                "type": "server_tool_use",
+                "id": "srv_ws",
+                "name": "web_search",
+                "input": {"query": "anthropic news"},
+            },
+        ]
+        snapshot = _build_sdk_message_with_blocks(blocks)
+        chat = self._provider()._build_chat_response(snapshot)
+        # Either None or empty — both signal "no advisor blocks".
+        self.assertFalse(chat.raw_content_blocks)
+
+    def test_text_and_tool_use_still_projected_normally(self) -> None:
+        # The advisor-preservation pass MUST NOT regress the existing
+        # text/tool_use projection. Mixed block stream:
+        blocks = [
+            {"type": "text", "text": "hello"},
+            {
+                "type": "tool_use",
+                "id": "tu_1",
+                "name": "Bash",
+                "input": {"command": "ls"},
+            },
+            {
+                "type": "server_tool_use",
+                "id": "srv_a",
+                "name": "advisor",
+                "input": {},
+            },
+            {
+                "type": "advisor_tool_result",
+                "tool_use_id": "srv_a",
+                "content": {"type": "advisor_result", "text": "ok"},
+            },
+            {"type": "text", "text": " world"},
+        ]
+        snapshot = _build_sdk_message_with_blocks(blocks)
+        chat = self._provider()._build_chat_response(snapshot)
+        # Text concatenated from text blocks (existing behavior).
+        self.assertEqual(chat.content, "hello world")
+        # tool_use surfaced.
+        self.assertEqual(len(chat.tool_uses or []), 1)
+        self.assertEqual(chat.tool_uses[0]["id"], "tu_1")
+        # Advisor pair preserved.
+        self.assertEqual(len(chat.raw_content_blocks or []), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_advisor_command.py
+++ b/tests/test_advisor_command.py
@@ -1,0 +1,290 @@
+"""Tests for the /advisor slash command (src/command_system/builtins.py).
+
+Each branch of the TS reference (typescript/src/commands/advisor.ts) is
+covered:
+  * no-arg → unset / set / inactive
+  * unset / off → clear
+  * <model> → resolve + validate + set
+  * invalid model / non-advisor model rejection
+  * non-supported base model warning (advisor set, but inactive)
+
+The command writes through ``_write_advisor_model`` which prefers the
+reactive AppState store when present and falls back to direct settings
+writes. Tests cover BOTH paths.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.command_system.builtins import advisor_command_call
+from src.command_system.types import CommandContext
+
+
+def _make_context(
+    *,
+    store: object | None = None,
+    provider: object | None = None,
+) -> CommandContext:
+    """Build a minimal CommandContext for command tests."""
+    root = Path(tempfile.gettempdir())
+    return CommandContext(
+        workspace_root=root,
+        cwd=root,
+        conversation=None,
+        cost_tracker=None,
+        history=None,
+        app_state_store=store,
+        provider=provider,
+    )
+
+
+def _fake_first_party_provider(model: str = "claude-opus-4-6") -> MagicMock:
+    """Create a provider mock that the `/advisor` gate accepts."""
+    from src.providers.anthropic_provider import AnthropicProvider
+    provider = MagicMock(spec=AnthropicProvider)
+    provider.has_custom_endpoint.return_value = False
+    provider.model = model
+    return provider
+
+
+class _FakeStore:
+    """Minimal stand-in for the reactive AppState store used by tests."""
+
+    def __init__(self, initial=None) -> None:
+        from src.state.app_state import AppState
+        self.state = initial if initial is not None else AppState()
+        self.writes: list = []
+
+    def get_state(self):
+        return self.state
+
+    def set_state(self, fn) -> None:
+        new_state = fn(self.state)
+        self.writes.append(new_state)
+        self.state = new_state
+
+
+class _IsolatedEnv:
+    """Context manager: isolate ALL config persistence to a tmp dir.
+
+    ``src/config.py`` evaluates ``GLOBAL_CONFIG_FILE = Path.home() /
+    ".clawcodex/config.json"`` at import time, so patching ``HOME``
+    after import is too late — writes would land on the real user's
+    config file. We monkeypatch the module-level constant directly to
+    a fresh tmp path inside each test scope.
+
+    Also resets the settings cache + default manager singleton so
+    nothing stale leaks across test boundaries.
+    """
+
+    def __init__(self) -> None:
+        self._tmp = None
+        self._patches: list = []
+        self._saved_global_path = None
+        self._saved_history_path = None
+
+    def __enter__(self):
+        import src.config as cfg_mod
+        self._tmp = Path(tempfile.mkdtemp(prefix="advisor_test_"))
+        # Save and override the module-level config-path constants.
+        # We can't use patch.object for plain Path constants reliably
+        # because the writer reads them via the module reference.
+        self._saved_global_path = cfg_mod.GLOBAL_CONFIG_FILE
+        self._saved_history_path = cfg_mod.HISTORY_FILE
+        cfg_mod.GLOBAL_CONFIG_FILE = self._tmp / ".clawcodex" / "config.json"
+        cfg_mod.HISTORY_FILE = self._tmp / ".clawcodex" / "history.jsonl"
+        cfg_mod.GLOBAL_CONFIG_DIR = self._tmp / ".clawcodex"
+        cfg_mod._default_manager = None
+
+        os.environ.pop("CLAUDE_CODE_DISABLE_ADVISOR_TOOL", None)
+        from src.settings.settings import invalidate_settings_cache
+        invalidate_settings_cache()
+        return self
+
+    def __exit__(self, *a):
+        import src.config as cfg_mod
+        cfg_mod.GLOBAL_CONFIG_FILE = self._saved_global_path
+        cfg_mod.HISTORY_FILE = self._saved_history_path
+        cfg_mod.GLOBAL_CONFIG_DIR = self._saved_global_path.parent
+        cfg_mod._default_manager = None
+        from src.settings.settings import invalidate_settings_cache
+        invalidate_settings_cache()
+
+
+class TestAdvisorCommandGate(unittest.TestCase):
+    """The /advisor command refuses to run under non-first-party providers."""
+
+    def test_refuses_when_env_disabled(self) -> None:
+        with _IsolatedEnv():
+            with patch.dict(
+                os.environ, {"CLAUDE_CODE_DISABLE_ADVISOR_TOOL": "1"}, clear=False
+            ):
+                ctx = _make_context(provider=_fake_first_party_provider())
+                res = advisor_command_call("claude-opus-4-6", ctx)
+                self.assertIn("unavailable", res.value.lower())
+
+    def test_refuses_with_non_first_party_provider(self) -> None:
+        with _IsolatedEnv():
+            provider = MagicMock()  # Not an AnthropicProvider
+            ctx = _make_context(provider=provider)
+            res = advisor_command_call("claude-opus-4-6", ctx)
+            self.assertIn("unavailable", res.value.lower())
+
+
+class TestAdvisorCommandStorePath(unittest.TestCase):
+    """When a reactive AppState store is wired, writes go through it."""
+
+    def test_no_arg_reports_unset(self) -> None:
+        with _IsolatedEnv():
+            store = _FakeStore()
+            ctx = _make_context(store=store, provider=_fake_first_party_provider())
+            res = advisor_command_call("", ctx)
+            self.assertIn("not set", res.value)
+            self.assertIn("/advisor <model>", res.value)
+            self.assertEqual(store.writes, [])
+
+    def test_set_advisor_model(self) -> None:
+        with _IsolatedEnv():
+            store = _FakeStore()
+            ctx = _make_context(
+                store=store, provider=_fake_first_party_provider("claude-opus-4-6")
+            )
+            res = advisor_command_call("claude-opus-4-6", ctx)
+            self.assertIn("Advisor set to claude-opus-4-6", res.value)
+            self.assertEqual(len(store.writes), 1)
+            self.assertEqual(store.writes[-1].advisor_model, "claude-opus-4-6")
+
+    def test_unset_clears_when_set(self) -> None:
+        with _IsolatedEnv():
+            from src.state.app_state import AppState
+            store = _FakeStore(initial=AppState(advisor_model="claude-opus-4-6"))
+            ctx = _make_context(store=store, provider=_fake_first_party_provider())
+            res = advisor_command_call("unset", ctx)
+            self.assertIn("disabled", res.value.lower())
+            self.assertIn("claude-opus-4-6", res.value)
+            self.assertEqual(store.writes[-1].advisor_model, None)
+
+    def test_unset_idempotent_when_not_set(self) -> None:
+        with _IsolatedEnv():
+            store = _FakeStore()
+            ctx = _make_context(store=store, provider=_fake_first_party_provider())
+            res = advisor_command_call("off", ctx)
+            self.assertIn("already unset", res.value.lower())
+            self.assertEqual(store.writes, [])
+
+    def test_inactive_warning_when_base_model_unsupported(self) -> None:
+        with _IsolatedEnv():
+            store = _FakeStore()
+            # Main loop on an older model — advisor can be SET but never
+            # actually fires until the user switches the base model.
+            provider = _fake_first_party_provider("claude-opus-4-5")
+            ctx = _make_context(store=store, provider=provider)
+            res = advisor_command_call("claude-opus-4-6", ctx)
+            self.assertIn("Advisor set to claude-opus-4-6", res.value)
+            self.assertIn("not support", res.value.lower())
+
+    def test_no_arg_inactive_when_set_but_unsupported_base(self) -> None:
+        with _IsolatedEnv():
+            from src.state.app_state import AppState
+            store = _FakeStore(initial=AppState(advisor_model="claude-opus-4-6"))
+            provider = _fake_first_party_provider("claude-opus-4-5")
+            ctx = _make_context(store=store, provider=provider)
+            res = advisor_command_call("", ctx)
+            self.assertIn("Advisor: claude-opus-4-6", res.value)
+            self.assertIn("inactive", res.value.lower())
+
+    def test_rejects_non_advisor_model(self) -> None:
+        with _IsolatedEnv():
+            store = _FakeStore()
+            ctx = _make_context(store=store, provider=_fake_first_party_provider())
+            res = advisor_command_call("haiku", ctx)
+            # The resolver normalizes "haiku" to a haiku model id, which
+            # is_valid_advisor_model rejects.
+            self.assertIn("cannot be used as an advisor", res.value)
+            self.assertEqual(store.writes, [])
+
+    def test_rejects_unknown_model(self) -> None:
+        with _IsolatedEnv():
+            store = _FakeStore()
+            ctx = _make_context(store=store, provider=_fake_first_party_provider())
+            # validate_model_name accepts any ≥2 char string that
+            # doesn't violate known patterns, so an unknown but
+            # well-formed string may slip past that check and be
+            # rejected at the is_valid_advisor_model gate. Either
+            # rejection is acceptable; just verify nothing is written.
+            res = advisor_command_call("zzz-not-a-model-9999", ctx)
+            self.assertTrue(
+                "Unknown" in res.value
+                or "cannot be used as an advisor" in res.value,
+                f"unexpected reject path: {res.value!r}",
+            )
+            self.assertEqual(store.writes, [])
+
+
+class TestAdvisorCommandSettingsPath(unittest.TestCase):
+    """When no store is wired, writes go to the global settings file."""
+
+    def test_set_persists_to_settings(self) -> None:
+        with _IsolatedEnv():
+            ctx = _make_context(provider=_fake_first_party_provider())
+            res = advisor_command_call("claude-opus-4-6", ctx)
+            self.assertIn("Advisor set to claude-opus-4-6", res.value)
+            # Read back via the settings stack (fresh load).
+            from src.settings.settings import get_settings, invalidate_settings_cache
+            invalidate_settings_cache()
+            self.assertEqual(get_settings().advisor_model, "claude-opus-4-6")
+
+    def test_unset_persists_to_settings(self) -> None:
+        with _IsolatedEnv():
+            ctx = _make_context(provider=_fake_first_party_provider())
+            advisor_command_call("claude-opus-4-6", ctx)
+            # Now unset it.
+            res = advisor_command_call("off", ctx)
+            self.assertIn("disabled", res.value.lower())
+            from src.settings.settings import get_settings, invalidate_settings_cache
+            invalidate_settings_cache()
+            self.assertEqual(get_settings().advisor_model, "")
+
+    def test_set_invalidates_settings_cache(self) -> None:
+        # After the command runs, the next get_settings() call must
+        # observe the new value — otherwise mid-session toggles would
+        # be invisible to _call_model_sync until process restart.
+        with _IsolatedEnv():
+            from src.settings.settings import get_settings
+            # Prime the cache.
+            self.assertEqual(get_settings().advisor_model, "")
+            ctx = _make_context(provider=_fake_first_party_provider())
+            advisor_command_call("claude-opus-4-6", ctx)
+            # No explicit invalidate — the command must do it.
+            self.assertEqual(get_settings().advisor_model, "claude-opus-4-6")
+
+
+class TestAdvisorCommandStorePathInvalidatesCache(unittest.TestCase):
+    """When the reactive AppState store is wired, the _on_change handler
+    is responsible for persisting to settings AND invalidating the
+    cache. Verify the round trip — without this, mid-session toggles
+    via the store wouldn't show up in the next _call_model_sync read.
+    """
+
+    def test_store_setstate_invalidates_settings_cache(self) -> None:
+        with _IsolatedEnv():
+            from src.settings.settings import get_settings
+            from src.state.app_state import create_app_state_store, replace_state
+            store = create_app_state_store()
+            # Prime cache.
+            self.assertEqual(get_settings().advisor_model, "")
+            ctx = _make_context(store=store, provider=_fake_first_party_provider())
+            advisor_command_call("claude-opus-4-6", ctx)
+            # Store handler should have written + invalidated.
+            self.assertEqual(get_settings().advisor_model, "claude-opus-4-6")
+            # And the store itself reflects the value.
+            self.assertEqual(store.get_state().advisor_model, "claude-opus-4-6")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_advisor_request_wiring.py
+++ b/tests/test_advisor_request_wiring.py
@@ -1,0 +1,389 @@
+"""Verify the request-time wiring in ``src/query/query.py:_call_model_sync``.
+
+Three classes of assertion:
+  * Activation gate: advisor decision == (first-party Anthropic AND
+    settings.advisor_model AND model_supports_advisor AND
+    is_valid_advisor_model).
+  * On activation: schema appended after regular tools, beta header
+    set, instructions appended to system_prompt, advisor blocks NOT
+    stripped from outgoing messages.
+  * Off activation: schema absent, beta absent, instructions absent,
+    advisor blocks STRIPPED from outgoing messages (so the API doesn't
+    400 on a stale server_tool_use without the beta header).
+
+Tests intercept ``provider.chat_stream_response`` to inspect the kwargs
+the query layer would have sent to the SDK. This avoids opening any
+network connection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+import unittest
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from src.providers.anthropic_provider import AnthropicProvider
+from src.providers.base import ChatResponse
+from src.query.query import _call_model_sync
+from src.types.messages import AssistantMessage, UserMessage
+
+
+class _Capture:
+    """Holds the kwargs captured from a single ``chat_stream_response`` call."""
+    api_messages: list = None
+    call_kwargs: dict = None
+
+
+def _stub_provider_class(provider_cls, captured: _Capture) -> Any:
+    """Create a provider instance that records the kwargs it was called with."""
+    if provider_cls is AnthropicProvider:
+        provider = MagicMock(spec=AnthropicProvider)
+        provider.has_custom_endpoint = MagicMock(return_value=False)
+    else:
+        provider = MagicMock(spec=provider_cls)
+    provider.model = "claude-opus-4-6"
+
+    def fake_chat_stream_response(api_messages, *, abort_signal=None, **kwargs):
+        captured.api_messages = list(api_messages)
+        captured.call_kwargs = dict(kwargs)
+        return ChatResponse(
+            content="ok",
+            model="claude-opus-4-6",
+            usage={"input_tokens": 1, "output_tokens": 1},
+            finish_reason="end_turn",
+            tool_uses=None,
+            raw_content_blocks=None,
+        )
+
+    provider.chat_stream_response = fake_chat_stream_response
+    return provider
+
+
+class _Isolation:
+    """Helper that monkeypatches the config-file paths to a tmp dir.
+
+    ``src/config.py`` evaluates ``GLOBAL_CONFIG_FILE = Path.home() /
+    ".clawcodex/config.json"`` at import time, so patching ``HOME``
+    after import is too late — writes would land on the real user's
+    config file. We override the module-level constant directly.
+
+    The helper is used as a class with ``enter()`` / ``exit()`` from
+    test setUp / tearDown rather than via ``with`` so existing
+    setUp/tearDown shapes don't need restructuring.
+    """
+
+    def __init__(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="advisor_wire_")
+        self._saved_global = None
+        self._saved_history = None
+        self._saved_dir = None
+
+    def enter(self) -> None:
+        import src.config as cfg_mod
+        self._saved_global = cfg_mod.GLOBAL_CONFIG_FILE
+        self._saved_history = cfg_mod.HISTORY_FILE
+        self._saved_dir = cfg_mod.GLOBAL_CONFIG_DIR
+        from pathlib import Path as _P
+        cfg_mod.GLOBAL_CONFIG_FILE = _P(self._tmp) / ".clawcodex" / "config.json"
+        cfg_mod.HISTORY_FILE = _P(self._tmp) / ".clawcodex" / "history.jsonl"
+        cfg_mod.GLOBAL_CONFIG_DIR = _P(self._tmp) / ".clawcodex"
+        cfg_mod._default_manager = None
+        from src.settings.settings import invalidate_settings_cache
+        invalidate_settings_cache()
+
+    def exit(self) -> None:
+        import src.config as cfg_mod
+        cfg_mod.GLOBAL_CONFIG_FILE = self._saved_global
+        cfg_mod.HISTORY_FILE = self._saved_history
+        cfg_mod.GLOBAL_CONFIG_DIR = self._saved_dir
+        cfg_mod._default_manager = None
+        from src.settings.settings import invalidate_settings_cache
+        invalidate_settings_cache()
+
+
+def _isolate_env():
+    """Build an _Isolation helper. setUp/tearDown call .enter/.exit."""
+    return _Isolation()
+
+
+def _set_settings(**kwargs):
+    """Write keys into the global settings file + invalidate cache."""
+    import src.config as cfg_mod
+    from src.config import ConfigManager
+    from src.settings.settings import invalidate_settings_cache
+    cfg_mod._default_manager = None
+    mgr = ConfigManager()
+    cfg = mgr.load_global()
+    sub = cfg.get("settings") if isinstance(cfg.get("settings"), dict) else {}
+    sub.update(kwargs)
+    cfg["settings"] = sub
+    mgr.save_global(cfg)
+    invalidate_settings_cache()
+
+
+def _run(provider, messages, system_prompt="hi", tools=None):
+    return asyncio.run(
+        _call_model_sync(
+            provider=provider,
+            messages=messages,
+            system_prompt=system_prompt,
+            tools=tools or [],
+        )
+    )
+
+
+class TestAdvisorActiveOnFirstPartyAnthropic(unittest.TestCase):
+    """Full activation path: beta header + schema + instructions added."""
+
+    def setUp(self) -> None:
+        self._iso = _isolate_env()
+        self._iso.enter()
+        os.environ.pop("CLAUDE_CODE_DISABLE_ADVISOR_TOOL", None)
+        _set_settings(advisor_model="claude-opus-4-6")
+
+    def tearDown(self) -> None:
+        # _iso.exit() restores the real config paths AND clears the
+        # singleton cache; the tmp dir from .enter() is its own world,
+        # so no additional cleanup write is needed (and any write here
+        # would land on the real user's config — see the isolation
+        # helper docstring above).
+        self._iso.exit()
+
+    def test_beta_header_attached(self) -> None:
+        cap = _Capture()
+        provider = _stub_provider_class(AnthropicProvider, cap)
+        _run(provider, [UserMessage(content="please")])
+        self.assertIn("betas", cap.call_kwargs)
+        self.assertIn("advisor-tool-2026-03-01", cap.call_kwargs["betas"])
+
+    def test_schema_appended_after_regular_tools(self) -> None:
+        cap = _Capture()
+        provider = _stub_provider_class(AnthropicProvider, cap)
+
+        class _FakeTool:
+            name = "Bash"
+            input_schema = {"type": "object", "properties": {}}
+            def prompt(self) -> str:
+                return "fake bash tool"
+
+        _run(provider, [UserMessage(content="x")], tools=[_FakeTool()])
+        tools = cap.call_kwargs["tools"]
+        # Regular tool first, advisor LAST — preserves the cache_control
+        # marker position from any other tool.
+        self.assertEqual(tools[0]["name"], "Bash")
+        self.assertEqual(tools[-1]["type"], "advisor_20260301")
+        self.assertEqual(tools[-1]["name"], "advisor")
+        self.assertEqual(tools[-1]["model"], "claude-opus-4-6")
+
+    def test_instructions_appended_to_string_system_prompt(self) -> None:
+        cap = _Capture()
+        provider = _stub_provider_class(AnthropicProvider, cap)
+        _run(provider, [UserMessage(content="x")], system_prompt="base prompt")
+        sysp = cap.call_kwargs.get("system")
+        self.assertIsInstance(sysp, str)
+        self.assertIn("base prompt", sysp)
+        self.assertIn("# Advisor Tool", sysp)
+
+    def test_instructions_appended_to_block_list_system_prompt(self) -> None:
+        cap = _Capture()
+        provider = _stub_provider_class(AnthropicProvider, cap)
+        sysp_in = [
+            {"type": "text", "text": "block 1"},
+            {"type": "text", "text": "block 2", "cache_control": {"type": "ephemeral"}},
+        ]
+        _run(provider, [UserMessage(content="x")], system_prompt=sysp_in)
+        sysp_out = cap.call_kwargs.get("system")
+        self.assertIsInstance(sysp_out, list)
+        # Instructions land at the END so the cache_control marker on
+        # block 2 keeps its position relative to the prefix.
+        self.assertEqual(sysp_out[-1]["type"], "text")
+        self.assertIn("# Advisor Tool", sysp_out[-1]["text"])
+        # Earlier blocks (including the cached one) are unchanged.
+        self.assertEqual(sysp_out[0]["text"], "block 1")
+        self.assertEqual(sysp_out[1]["text"], "block 2")
+        self.assertIn("cache_control", sysp_out[1])
+
+    def test_advisor_blocks_in_history_are_kept(self) -> None:
+        # When the request will carry the beta header, historical
+        # advisor blocks must round-trip back to the API as a valid
+        # use/result pair.
+        cap = _Capture()
+        provider = _stub_provider_class(AnthropicProvider, cap)
+        prior = AssistantMessage(
+            content=[
+                {"type": "text", "text": "before"},
+                {
+                    "type": "server_tool_use",
+                    "id": "srv_1",
+                    "name": "advisor",
+                    "input": {},
+                },
+                {
+                    "type": "advisor_tool_result",
+                    "tool_use_id": "srv_1",
+                    "content": {"type": "advisor_result", "text": "advice"},
+                },
+            ],
+        )
+        _run(provider, [UserMessage(content="hi"), prior, UserMessage(content="next")])
+        # Inspect the assistant message in the API payload.
+        asst = next(
+            m for m in cap.api_messages
+            if m.get("role") == "assistant"
+        )
+        types = [b["type"] for b in asst["content"]]
+        self.assertIn("server_tool_use", types)
+        self.assertIn("advisor_tool_result", types)
+
+
+class TestAdvisorInactivePaths(unittest.TestCase):
+    """Negative cases — schema/header/instructions MUST NOT be sent."""
+
+    def setUp(self) -> None:
+        self._iso = _isolate_env()
+        self._iso.enter()
+        os.environ.pop("CLAUDE_CODE_DISABLE_ADVISOR_TOOL", None)
+
+    def tearDown(self) -> None:
+        # _iso.exit() restores the real config paths AND clears the
+        # singleton cache; the tmp dir from .enter() is its own world,
+        # so no additional cleanup write is needed (and any write here
+        # would land on the real user's config — see the isolation
+        # helper docstring above).
+        self._iso.exit()
+
+    def _assert_inactive(self, cap: _Capture) -> None:
+        self.assertNotIn("betas", cap.call_kwargs)
+        tools = cap.call_kwargs.get("tools") or []
+        for t in tools:
+            self.assertNotEqual(
+                t.get("type"), "advisor_20260301",
+                "advisor schema must not be sent when inactive",
+            )
+            self.assertNotEqual(
+                t.get("name"), "advisor",
+                "advisor name must not appear in tools when inactive",
+            )
+        sysp = cap.call_kwargs.get("system", "") or ""
+        if isinstance(sysp, list):
+            sysp_text = "\n".join(
+                b.get("text", "") for b in sysp if isinstance(b, dict)
+            )
+        else:
+            sysp_text = sysp
+        self.assertNotIn("# Advisor Tool", sysp_text)
+
+    def test_no_advisor_when_settings_unset(self) -> None:
+        _set_settings(advisor_model="")
+        cap = _Capture()
+        provider = _stub_provider_class(AnthropicProvider, cap)
+        _run(provider, [UserMessage(content="x")])
+        self._assert_inactive(cap)
+
+    def test_no_advisor_when_env_disabled(self) -> None:
+        _set_settings(advisor_model="claude-opus-4-6")
+        with patch.dict(
+            os.environ, {"CLAUDE_CODE_DISABLE_ADVISOR_TOOL": "1"}, clear=False
+        ):
+            cap = _Capture()
+            provider = _stub_provider_class(AnthropicProvider, cap)
+            _run(provider, [UserMessage(content="x")])
+            self._assert_inactive(cap)
+
+    def test_no_advisor_when_anthropic_has_custom_endpoint(self) -> None:
+        _set_settings(advisor_model="claude-opus-4-6")
+        cap = _Capture()
+        provider = _stub_provider_class(AnthropicProvider, cap)
+        # Simulate a custom base_url (Bedrock shim, self-hosted proxy).
+        provider.has_custom_endpoint = MagicMock(return_value=True)
+        _run(provider, [UserMessage(content="x")])
+        self._assert_inactive(cap)
+
+    def test_no_advisor_when_base_model_unsupported(self) -> None:
+        _set_settings(advisor_model="claude-opus-4-6")
+        cap = _Capture()
+        provider = _stub_provider_class(AnthropicProvider, cap)
+        # Stale main model — advisor must not piggy-back on an older model.
+        provider.model = "claude-opus-4-5"
+        _run(provider, [UserMessage(content="x")])
+        self._assert_inactive(cap)
+
+    def test_no_advisor_when_advisor_model_invalid(self) -> None:
+        _set_settings(advisor_model="claude-haiku-4-5")
+        cap = _Capture()
+        provider = _stub_provider_class(AnthropicProvider, cap)
+        _run(provider, [UserMessage(content="x")])
+        self._assert_inactive(cap)
+
+    def test_advisor_blocks_stripped_when_inactive(self) -> None:
+        # The previous turn left advisor blocks in history, but the
+        # current request will NOT carry the beta header (e.g. user
+        # ran /advisor unset). The API would 400 if we sent them.
+        _set_settings(advisor_model="")  # inactive
+        cap = _Capture()
+        provider = _stub_provider_class(AnthropicProvider, cap)
+        prior = AssistantMessage(
+            content=[
+                {"type": "text", "text": "before"},
+                {
+                    "type": "server_tool_use",
+                    "id": "srv_1",
+                    "name": "advisor",
+                    "input": {},
+                },
+                {
+                    "type": "advisor_tool_result",
+                    "tool_use_id": "srv_1",
+                    "content": {"type": "advisor_result", "text": "advice"},
+                },
+                {"type": "text", "text": "after"},
+            ],
+        )
+        _run(provider, [UserMessage(content="hi"), prior, UserMessage(content="next")])
+        asst = next(
+            m for m in cap.api_messages if m.get("role") == "assistant"
+        )
+        types = [b["type"] for b in asst["content"]]
+        self.assertNotIn("server_tool_use", types)
+        self.assertNotIn("advisor_tool_result", types)
+
+
+class TestAdvisorActivationDefensive(unittest.TestCase):
+    """The activation predicate is wrapped in a single try/except so any
+    failure (transient import, future provider that throws on
+    `has_custom_endpoint`, settings cache contention) defaults to
+    "advisor inactive" rather than failing the turn. Critic-flagged
+    nit: the fix had no dedicated test — adding one here.
+    """
+
+    def test_activation_exception_does_not_kill_turn(self) -> None:
+        # Force `is_advisor_enabled` to raise inside `_call_model_sync`.
+        # The expected behavior is: caught, advisor_active=False, the
+        # request proceeds without the beta header or schema.
+        iso = _isolate_env()
+        iso.enter()
+        try:
+            _set_settings(advisor_model="claude-opus-4-6")
+            cap = _Capture()
+            provider = _stub_provider_class(AnthropicProvider, cap)
+            with patch(
+                "src.utils.advisor.is_advisor_enabled",
+                side_effect=RuntimeError("synthetic gate failure"),
+            ):
+                # Must not raise; should fall through to a non-advisor
+                # request.
+                result, _ = _run(provider, [UserMessage(content="hi")])
+            self.assertEqual(len(result), 1)
+            self.assertNotIn("betas", cap.call_kwargs)
+            tools = cap.call_kwargs.get("tools") or []
+            for t in tools:
+                self.assertNotEqual(t.get("type"), "advisor_20260301")
+        finally:
+            iso.exit()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Lands the three remaining advisor phases onto `main`. The original stacked PRs (#177, #178, #179) merged into each other's branches but never bubbled up to `main` — this PR cherry-picks the three feature commits onto a fresh branch from current `main`.
- **Phase 02** (provider preservation, 6052f77 → 8258b59): `ChatResponse.raw_content_blocks` opaque passthrough + `AnthropicProvider._build_chat_response` recognizes advisor `server_tool_use` / `advisor_tool_result` blocks and round-trips them via `model_dump`.
- **Phase 03** (query wiring, 14a9c6e → d75c653): `_call_model_sync` activation predicate (4 ANDed gates), beta header + cache-preserving tool-schema append + system-prompt instruction injection; `AppState.advisor_model` with `_on_advisor_model_change` persistence + cache invalidation.
- **Phase 04** (command + TUI, 258f2ea → 039dad8): `/advisor <model>` slash command + `AssistantAdvisorMessage` transcript row + `AgentBridge` advisor-event scanning with dedup.

Phase 01 is already on `main` via #176.

## Test plan
Verified locally on the cherry-picked tree (`/Users/ericlee2/workspace/clawcodex/.venv/bin/pytest`):
- [x] `tests/test_advisor_helpers.py` — 32 passed
- [x] `tests/test_advisor_orphan_pairing.py` — 6 passed
- [x] `tests/test_advisor_chat_response_roundtrip.py` — 6 passed
- [x] `tests/test_advisor_command.py` — 14 passed
- [x] `tests/test_advisor_request_wiring.py` — 12 passed
- [x] `tests/test_app_state.py` — 16 passed
- [x] `tests/integration/test_advisor_smoke.py` — 3 passed
- **Total: 89/89 passed**

## Notes
- No conflicts during cherry-pick — merge base was `2cdc3142` (the phase-01 commit already on `main`).
- 3P-provider gating preserved: advisor pipeline (header, schema, instructions, slash command visibility) is strictly first-party Anthropic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)