### PR TITLE
feat(advisor): client-side mode for 3P providers (any provider, any model)

### DIFF
--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -489,52 +489,109 @@ def _write_advisor_model(context: CommandContext, value: str | None) -> None:
     invalidate_settings_cache()
 
 
+def _read_current_advisor_client_mode(context: CommandContext) -> bool:
+    """Resolve the user's current advisor_client_mode flag (reactive
+    store preferred, settings fallback). Mirrors
+    ``_read_current_advisor_model``."""
+    store = getattr(context, "app_state_store", None)
+    if store is not None:
+        try:
+            return bool(getattr(store.get_state(), "advisor_client_mode", False))
+        except Exception:
+            pass
+    try:
+        from ..settings.settings import get_settings
+        return bool(getattr(get_settings(), "advisor_client_mode", False))
+    except Exception:
+        return False
+
+
+def _write_advisor_client_mode(context: CommandContext, value: bool) -> None:
+    """Persist advisor_client_mode (store-preferred, settings fallback).
+    Mirrors ``_write_advisor_model`` — same dual-path persistence."""
+    store = getattr(context, "app_state_store", None)
+    if store is not None:
+        from ..state.app_state import replace_state
+        store.set_state(lambda s: replace_state(s, advisor_client_mode=bool(value)))
+        return
+    from .. import config as cfg_mod
+    from ..settings.settings import invalidate_settings_cache
+    mgr = cfg_mod._get_default_manager()
+    cfg = mgr.load_global()
+    settings_section = cfg.get("settings")
+    if not isinstance(settings_section, dict):
+        settings_section = {}
+    settings_section["advisor_client_mode"] = bool(value)
+    cfg["settings"] = settings_section
+    mgr.save_global(cfg)
+    invalidate_settings_cache()
+
+
 def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResult:
-    """Handle /advisor — configure the server-side advisor reviewer model.
+    """Handle /advisor — configure the reviewer model.
 
-    Python port of typescript/src/commands/advisor.ts. Branches:
-      * no args → report current state (set/unset/inactive). Inactive =
-        a model is set but the running main-loop model doesn't support
-        the advisor tool.
-      * ``unset`` | ``off`` → clear the advisor model.
-      * ``<model>`` → resolve + validate + set.
+    Branches (after parsing optional ``--client`` / ``--no-client`` flags):
+      * no args, no flags → status report (model + active mode).
+      * ``unset`` | ``off`` → clear advisor_model AND advisor_client_mode.
+      * ``--no-client`` (alone) → keep model, clear client-mode flag.
+      * ``<model>`` → resolve + validate the model has a known provider,
+        then persist. ``--client`` flag (if present) also persists
+        advisor_client_mode=True; absent flag preserves the existing
+        client_mode value (so ``--client`` is sticky).
 
-    Writes go to the reactive AppState store if the caller wired one
-    via ``CommandContext.app_state_store``; otherwise they go straight
+    The activation mode (server-side vs client-side) is decided at
+    request time by ``decide_advisor_mode`` based on the provider and
+    the stored ``(advisor_model, advisor_client_mode)`` pair. This
+    command writes both fields; it doesn't pick the mode.
+
+    Writes go to the reactive AppState store when wired, falling back
     to the global settings file. Either path produces the same end
-    state (settings.advisor_model is the canonical source) — the
-    distinction is whether mid-session subscribers see the change as
-    an in-process event or have to re-read settings.
+    state — settings.advisor_model and settings.advisor_client_mode
+    are the canonical sources.
     """
     from ..models.model import canonical_model_name, resolve_model
     from ..models.validation import validate_model_name
     from ..utils.advisor import (
+        ADVISOR_MODE_CLIENT_SIDE,
+        ADVISOR_MODE_INACTIVE,
+        ADVISOR_MODE_SERVER_SIDE,
         can_user_configure_advisor,
-        is_valid_advisor_model,
-        model_supports_advisor,
+        decide_advisor_mode,
+        infer_provider_for_model,
     )
 
-    arg = (args or "").strip().lower()
     provider = getattr(context, "provider", None)
 
-    # Reject hard when /advisor is disabled by env var or by a non-first-
-    # party provider — otherwise the user would silently configure a value
-    # that no future request can use.
+    # Hard-reject only when env-disabled (the user would silently
+    # configure a value that no request can use).
     if not can_user_configure_advisor(provider):
         return LocalCommandResult(
             type="text",
             value=(
-                "Advisor is unavailable in this configuration. "
-                "It requires the first-party Anthropic API and is disabled by "
-                "the CLAUDE_CODE_DISABLE_ADVISOR_TOOL env var."
+                "Advisor is disabled by the CLAUDE_CODE_DISABLE_ADVISOR_TOOL "
+                "env var."
             ),
         )
 
+    # Tokenize raw args so flag handling is order-insensitive. A
+    # trailing or leading ``--client`` / ``--no-client`` should peel
+    # off cleanly without breaking the model identifier.
+    raw_tokens = (args or "").strip().split()
+    force_client_flag: bool | None = None  # None = no flag passed
+    rest_tokens: list[str] = []
+    for tok in raw_tokens:
+        if tok == "--client":
+            force_client_flag = True
+        elif tok == "--no-client":
+            force_client_flag = False
+        else:
+            rest_tokens.append(tok)
+    arg = " ".join(rest_tokens).strip()
+    arg_lower = arg.lower()
+
     current_advisor = _read_current_advisor_model(context)
-    # Resolve the active main-loop model. Prefer the provider's own
-    # ``.model`` attribute (mirrors TS ``options.model`` source of truth
-    # — the value the next API call will actually use). Fall back to
-    # AppState.main_loop_model when the provider isn't carrying one.
+    current_client_mode = _read_current_advisor_client_mode(context)
+
     main_loop_model = ""
     if provider is not None:
         main_loop_model = getattr(provider, "model", "") or ""
@@ -546,35 +603,93 @@ def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResu
             except Exception:
                 pass
 
-    if not arg:
+    def _render_status() -> str:
+        """Format the current state for the no-args branch."""
+        if not current_advisor:
+            return (
+                "Advisor: not set\n"
+                'Use "/advisor <model>" to enable (e.g. "/advisor opus", '
+                '"/advisor gemini-2.5-pro").'
+            )
+        mode = decide_advisor_mode(
+            provider,
+            main_loop_model,
+            current_advisor,
+            force_client_mode=current_client_mode,
+        )
+        mode_label = {
+            ADVISOR_MODE_SERVER_SIDE: "active (server-side)",
+            ADVISOR_MODE_CLIENT_SIDE: "active (client-side)",
+            ADVISOR_MODE_INACTIVE: "inactive",
+        }.get(mode, "inactive")
+        suffix = ""
+        if current_client_mode:
+            suffix = " [--client forced]"
+        if mode == ADVISOR_MODE_INACTIVE:
+            inactive_reason = (
+                f"The current model ({main_loop_model}) cannot be paired "
+                f"with {current_advisor!r} (no known provider for the "
+                "advisor model)."
+                if main_loop_model
+                else f"No known provider for advisor model {current_advisor!r}."
+            )
+            return (
+                f"Advisor: {current_advisor} — {mode_label}{suffix}\n"
+                f"{inactive_reason}"
+            )
+        return (
+            f"Advisor: {current_advisor} — {mode_label}{suffix}\n"
+            'Use "/advisor unset" to disable or "/advisor <model>" to change.'
+        )
+
+    # No model arg, no flags → status only.
+    if not arg and force_client_flag is None:
+        return LocalCommandResult(type="text", value=_render_status())
+
+    # --no-client alone (no model) → just clear the forced-client flag.
+    if not arg and force_client_flag is False:
+        if not current_client_mode:
+            return LocalCommandResult(
+                type="text", value="Advisor client mode already off.",
+            )
+        _write_advisor_client_mode(context, False)
+        return LocalCommandResult(
+            type="text",
+            value=(
+                "Advisor client mode disabled. "
+                "Server-side will be used when applicable."
+            ),
+        )
+
+    # --client alone (no model) → just turn on the forced-client flag.
+    if not arg and force_client_flag is True:
         if not current_advisor:
             return LocalCommandResult(
                 type="text",
                 value=(
-                    "Advisor: not set\n"
-                    'Use "/advisor <model>" to enable (e.g. "/advisor opus").'
+                    "Cannot force client mode: no advisor model is set. "
+                    'Use "/advisor <model> --client" together.'
                 ),
             )
-        if main_loop_model and not model_supports_advisor(main_loop_model):
+        if current_client_mode:
             return LocalCommandResult(
-                type="text",
-                value=(
-                    f"Advisor: {current_advisor} (inactive)\n"
-                    f"The current model ({main_loop_model}) does not support advisors."
-                ),
+                type="text", value="Advisor client mode already on.",
             )
+        _write_advisor_client_mode(context, True)
         return LocalCommandResult(
             type="text",
             value=(
-                f"Advisor: {current_advisor}\n"
-                'Use "/advisor unset" to disable or "/advisor <model>" to change.'
+                "Advisor client mode enabled. The advisor will run via "
+                "client-side dispatch on every request."
             ),
         )
 
-    if arg in ("unset", "off"):
+    if arg_lower in ("unset", "off"):
         previous = current_advisor
         if previous is not None:
             _write_advisor_model(context, None)
+        if current_client_mode:
+            _write_advisor_client_mode(context, False)
         return LocalCommandResult(
             type="text",
             value=(
@@ -584,7 +699,7 @@ def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResu
         )
 
     # Treat the rest as a model identifier.
-    raw = (args or "").strip()
+    raw = arg
     try:
         resolved = resolve_model(raw)
     except Exception as e:
@@ -597,28 +712,55 @@ def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResu
             type="text",
             value=f"Unknown model: {raw} ({resolved})",
         )
-    if not is_valid_advisor_model(resolved):
+    # We no longer require ``is_valid_advisor_model`` (the strict
+    # opus-4-6/sonnet-4-6 gate) — client-side mode accepts any model
+    # that routes to a known provider. The router check is what
+    # actually matters: without it, ``execute_client_advisor`` would
+    # fail at request time and silently degrade.
+    if infer_provider_for_model(resolved) is None:
         return LocalCommandResult(
             type="text",
-            value=f"The model {raw} ({resolved}) cannot be used as an advisor",
+            value=(
+                f"Cannot use {raw} ({resolved}) as advisor: no known "
+                "provider for this model. Try a model listed in "
+                "PROVIDER_INFO, or use a provider-prefixed name "
+                "(e.g. 'anthropic/claude-sonnet-4.5')."
+            ),
         )
 
     normalized = canonical_model_name(resolved)
     _write_advisor_model(context, normalized)
+    if force_client_flag is True:
+        _write_advisor_client_mode(context, True)
+    elif force_client_flag is False:
+        _write_advisor_client_mode(context, False)
 
-    if main_loop_model and not model_supports_advisor(main_loop_model):
-        return LocalCommandResult(
-            type="text",
-            value=(
-                f"Advisor set to {normalized}.\n"
-                f"Note: Your current model ({main_loop_model}) does not support "
-                "advisors. Switch to a supported model to use the advisor."
-            ),
+    # Report what mode the chosen pair lands in, so the user can spot
+    # mismatches immediately (e.g., they expected server-side but the
+    # main model doesn't qualify).
+    effective_client_mode = (
+        force_client_flag
+        if force_client_flag is not None
+        else current_client_mode
+    )
+    chosen_mode = decide_advisor_mode(
+        provider,
+        main_loop_model,
+        normalized,
+        force_client_mode=effective_client_mode,
+    )
+    if chosen_mode == ADVISOR_MODE_SERVER_SIDE:
+        mode_msg = "Will run server-side (Anthropic beta path)."
+    elif chosen_mode == ADVISOR_MODE_CLIENT_SIDE:
+        mode_msg = "Will run client-side (separate API call)."
+    else:
+        mode_msg = (
+            "Note: advisor is currently inactive (no path applies for "
+            f"main loop {main_loop_model!r} + advisor {normalized!r})."
         )
-
     return LocalCommandResult(
         type="text",
-        value=f"Advisor set to {normalized}.",
+        value=f"Advisor set to {normalized}. {mode_msg}",
     )
 
 
@@ -811,8 +953,8 @@ from ..utils.advisor import can_user_configure_advisor as _can_user_configure_ad
 
 ADVISOR_COMMAND = LocalCommand(
     name="advisor",
-    description="Configure the advisor model",
-    argument_hint="[<model>|off]",
+    description="Configure the advisor model (server-side on 1P Anthropic, client-side on any provider)",
+    argument_hint="[<model> [--client] | --no-client | off]",
     supports_non_interactive=True,
     is_enabled=lambda: _can_user_configure_advisor(None),
 )

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -288,64 +288,74 @@ async def _call_model_sync(
     from ..types.messages import normalize_messages_for_api
     from ..utils.advisor import (
         ADVISOR_BETA_HEADER,
+        ADVISOR_MODE_CLIENT_SIDE,
+        ADVISOR_MODE_INACTIVE,
+        ADVISOR_MODE_SERVER_SIDE,
         ADVISOR_TOOL_INSTRUCTIONS,
         build_advisor_tool_schema,
-        is_advisor_enabled,
-        is_valid_advisor_model,
-        model_supports_advisor,
+        build_client_advisor_tool_schema,
+        decide_advisor_mode,
         strip_advisor_blocks,
     )
 
-    # Advisor activation decision — server-side parity with TS
-    # claude.ts:1094-1130. Activation requires ALL of:
-    # 1. Provider is first-party Anthropic (no custom base_url) and the
-    #    CLAUDE_CODE_DISABLE_ADVISOR_TOOL env switch is not set.
-    # 2. ``settings.advisor_model`` is non-empty (the user opted in via
-    #    /advisor; ``_on_advisor_model_change`` persists writes here).
-    # 3. The main-loop model supports calling the advisor tool
-    #    (opus-4-6 / sonnet-4-6 — older models reject the schema).
-    # 4. The configured advisor model itself is a valid advisor target.
-    # A stale advisor_model setting under a non-supporting model is
-    # silently ignored — never sent to the API. Mirrors the TS
-    # "skipping advisor — base model X does not support advisor" branch.
+    # Advisor activation decision. Three outcomes:
+    #
+    # * SERVER_SIDE: 1P Anthropic provider + opus-4-6/sonnet-4-6 main
+    #   loop + valid server-side advisor target. Carries the beta
+    #   header and the ``advisor_20260301`` schema; the API runs the
+    #   reviewer model server-side. Optimal path — single roundtrip,
+    #   cache-friendly.
+    # * CLIENT_SIDE: any provider, any tool-calling main loop, any
+    #   advisor model that routes to a known provider. Registers
+    #   ``advisor`` as a regular client-side tool; the dispatcher
+    #   (``src/tool_system/tools/advisor.py``) makes a separate API
+    #   call to the configured advisor model. Two roundtrips but
+    #   provider-agnostic.
+    # * INACTIVE: no advisor on this request (env-disabled, no
+    #   advisor_model set, or no path can be resolved).
+    #
+    # The full decision table lives in ``decide_advisor_mode``. Any
+    # exception during the predicate degrades to INACTIVE rather than
+    # killing the turn (critic M1 from the original advisor PR).
     main_loop_model = getattr(provider, "model", "") or ""
-    advisor_active = False
+    advisor_mode = ADVISOR_MODE_INACTIVE
     advisor_model_normalized: str | None = None
-    # Wrap the ENTIRE activation predicate so any failure (transient
-    # import, future provider type that throws on the first-party
-    # check, settings cache contention) defaults to "advisor inactive"
-    # instead of failing the turn. Critic M1: previously the env/
-    # provider check was outside the inner try, so an exception in
-    # ``is_first_party_provider`` would propagate to the caller.
     try:
-        if is_advisor_enabled(provider):
-            from ..settings.settings import get_settings
-            configured = (get_settings().advisor_model or "").strip()
-            if configured and model_supports_advisor(main_loop_model):
-                from ..models.model import canonical_model_name
-                candidate = canonical_model_name(configured)
-                if is_valid_advisor_model(candidate):
-                    advisor_active = True
-                    advisor_model_normalized = candidate
+        from ..settings.settings import get_settings
+        settings = get_settings()
+        configured = (getattr(settings, "advisor_model", "") or "").strip()
+        force_client = bool(getattr(settings, "advisor_client_mode", False))
+        if configured:
+            from ..models.model import canonical_model_name
+            candidate = canonical_model_name(configured)
+            advisor_mode = decide_advisor_mode(
+                provider,
+                main_loop_model,
+                candidate,
+                force_client_mode=force_client,
+            )
+            if advisor_mode != ADVISOR_MODE_INACTIVE:
+                advisor_model_normalized = candidate
     except Exception:
-        # Don't let advisor activation issues kill the turn. The
-        # historical advisor blocks (if any) will still be stripped
-        # below since advisor_active is False.
         logger.exception(
             "Advisor activation check failed; treating advisor as inactive"
         )
-        advisor_active = False
+        advisor_mode = ADVISOR_MODE_INACTIVE
         advisor_model_normalized = None
 
     api_messages = normalize_messages_for_api(messages)
 
-    # When the advisor beta header is NOT going on this request, strip
-    # any historical advisor blocks — the API 400s on
-    # ``server_tool_use(name=advisor)`` and ``advisor_tool_result`` blocks
-    # without the matching beta. Mirror of TS claude.ts:1332-1334.
-    # Always-on when advisor is inactive (provider switch, env disable,
-    # base model unsupported, or user ran /advisor unset).
-    if not advisor_active:
+    # Server-side advisor blocks (``server_tool_use(name=advisor)`` and
+    # ``advisor_tool_result``) require the beta header on every request
+    # that carries them — the API 400s otherwise. Strip from history on
+    # any request that won't send the header.
+    #
+    # In CLIENT_SIDE mode the advisor surfaces as regular
+    # ``tool_use``/``tool_result`` blocks, which pass through normal
+    # message handling untouched. Only the SERVER_SIDE shape is gated
+    # by the header, so stripping is keyed off "current request carries
+    # the beta" — which is exactly SERVER_SIDE-and-only-SERVER_SIDE.
+    if advisor_mode != ADVISOR_MODE_SERVER_SIDE:
         api_messages = strip_advisor_blocks(api_messages)
 
     # --- Diagnostic tracing ---
@@ -404,12 +414,19 @@ async def _call_model_sync(
     # append) stays in place. If we prepended or interleaved, toggling
     # /advisor would shift the marker and bust the prompt cache. Mirrors
     # TS claude.ts:1411-1421 explicitly.
-    if advisor_active:
+    #
+    # The schema shape differs by mode: server-side carries the dated
+    # ``advisor_20260301`` discriminator + model field; client-side is
+    # a regular tool_use schema with no params, routed through the
+    # tool registry's AdvisorTool.
+    if advisor_mode == ADVISOR_MODE_SERVER_SIDE:
         tool_schemas.append(build_advisor_tool_schema(advisor_model_normalized))
+    elif advisor_mode == ADVISOR_MODE_CLIENT_SIDE:
+        tool_schemas.append(build_client_advisor_tool_schema())
 
     call_kwargs: dict[str, Any] = {"tools": tool_schemas}
 
-    if advisor_active:
+    if advisor_mode == ADVISOR_MODE_SERVER_SIDE:
         # Opt into the server-side advisor tool. ``betas`` lives outside
         # ``extra_headers`` because the SDK auto-converts it into the
         # ``anthropic-beta`` header AND filters out 3P-incompatible
@@ -417,22 +434,30 @@ async def _call_model_sync(
         # the advisor beta; if other betas are introduced, change this
         # to ``call_kwargs.setdefault("betas", []).append(...)``.
         call_kwargs["betas"] = [ADVISOR_BETA_HEADER]
+        # CLIENT_SIDE deliberately does NOT set betas — 3P endpoints
+        # reject the advisor beta, and 1P-with-force-client doesn't
+        # need it because the advisor schema is a regular tool here.
 
     from ..providers.anthropic_provider import AnthropicProvider
     from ..providers.minimax_provider import MinimaxProvider
 
     is_anthropic = isinstance(provider, (AnthropicProvider, MinimaxProvider))
+    advisor_instructions_active = advisor_mode != ADVISOR_MODE_INACTIVE
     if is_anthropic:
         # Forward whatever shape the engine produced — str or list[dict].
         # The SDK's ``system`` param accepts ``Union[str, Iterable[TextBlockParam]]``;
         # cache_control markers on blocks engage server-side prompt caching.
         #
-        # When the advisor is active, append ``ADVISOR_TOOL_INSTRUCTIONS``
-        # AFTER the existing system prompt blocks. This mirrors TS
-        # claude.ts:1395 (the advisor instructions come AFTER the cached
-        # system blocks, so they land in the request-scope partition and
-        # toggling /advisor doesn't churn the cached prefix).
-        if advisor_active:
+        # When the advisor is active (server OR client side), append
+        # ``ADVISOR_TOOL_INSTRUCTIONS`` AFTER the existing system prompt
+        # blocks. Mirrors TS claude.ts:1395 — the advisor instructions
+        # come AFTER the cached system blocks, so they land in the
+        # request-scope partition and toggling /advisor doesn't churn
+        # the cached prefix. The instruction text is provider-agnostic
+        # (tells the model "use the advisor tool"), so it works for
+        # both the server-side ``server_tool_use`` invocation and the
+        # client-side regular ``tool_use`` invocation.
+        if advisor_instructions_active:
             if isinstance(system_prompt, list):
                 system_prompt = list(system_prompt) + [
                     {"type": "text", "text": ADVISOR_TOOL_INSTRUCTIONS}
@@ -476,6 +501,15 @@ async def _call_model_sync(
             )
         else:
             flattened = system_prompt
+        # CLIENT_SIDE on a 3P provider: append the advisor instructions
+        # to the flattened system prompt so the model knows how + when
+        # to invoke the ``advisor`` tool. (Server-side instructions
+        # only land on 1P, handled by the is_anthropic branch above.)
+        if advisor_instructions_active and advisor_mode == ADVISOR_MODE_CLIENT_SIDE:
+            if flattened:
+                flattened = f"{flattened}\n\n{ADVISOR_TOOL_INSTRUCTIONS}"
+            else:
+                flattened = ADVISOR_TOOL_INSTRUCTIONS
         api_messages = [{"role": "system", "content": flattened}, *api_messages]
 
     if max_output_tokens_override is not None:
@@ -1433,6 +1467,17 @@ async def query(
                 "[DIAG] query loop: running %d tools in %d batches: %s",
                 len(tool_use_blocks), len(_batches), _batch_desc,
             )
+
+        # Snapshot the current conversation onto the ToolContext so
+        # tools that need history (currently: the client-side advisor)
+        # can read it via ``ctx.messages``. The list is the post-pipeline
+        # message stream up to and including the assistant message that
+        # just emitted the tool_use blocks we're about to dispatch. The
+        # advisor strips its own prior blocks via
+        # ``build_advisor_forwarded_messages`` before forwarding. Other
+        # tools ignore the field (the existing default factory was an
+        # empty list, so behavior is unchanged for them).
+        tool_use_context.messages = list(messages)
 
         tool_results = await _run_tools_partitioned(
             tool_use_blocks,

--- a/src/settings/types.py
+++ b/src/settings/types.py
@@ -69,11 +69,17 @@ class SettingsSchema:
     # Model
     model: str = ""
     small_fast_model: str = ""
-    # Advisor — server-side reviewer tool. Empty string = unset (no /advisor).
+    # Advisor — reviewer tool. Empty string = unset (no /advisor).
     # Persisted analogue of TS appState.advisorModel; the /advisor slash
     # command writes here, and _call_model_sync reads from here at request
     # time. See src/utils/advisor.py.
     advisor_model: str = ""
+    # Force client-side advisor mode (tool dispatch + separate API call)
+    # even when the main provider is first-party Anthropic. Default False
+    # lets the server-side beta path engage when applicable. Set via
+    # ``/advisor <model> --client``. See decide_advisor_mode() in
+    # src/utils/advisor.py for the full activation table.
+    advisor_client_mode: bool = False
 
     # Provider
     provider: str = "anthropic"

--- a/src/state/app_state.py
+++ b/src/state/app_state.py
@@ -97,6 +97,14 @@ class AppState:
     # the settings cache so the next API call picks up the new value.
     advisor_model: str | None = None
 
+    # Force client-side advisor mode. False = auto (server-side when
+    # possible, client-side otherwise). True = always client-side even
+    # on 1P Anthropic (lets users pair a non-Anthropic advisor with an
+    # Anthropic main loop, or get transparency on the advisor call).
+    # Persisted to ``settings.advisor_client_mode`` via
+    # ``_on_advisor_client_mode_change``.
+    advisor_client_mode: bool = False
+
 
 def replace_state(state: AppState, **changes: Any) -> AppState:
     """Return a copy of ``state`` with ``changes`` applied. Equivalent
@@ -267,6 +275,39 @@ def _on_advisor_model_change(old: AppState, new: AppState) -> None:
         )
 
 
+def _on_advisor_client_mode_change(old: AppState, new: AppState) -> None:
+    """Persist advisor_client_mode to user settings + invalidate the read cache.
+
+    Same persistence pattern as ``_on_advisor_model_change`` — writes the
+    boolean into the user-scoped global config and invalidates the cache
+    so the next ``_call_model_sync`` turn picks up the new value without
+    a process restart.
+    """
+    if old.advisor_client_mode == new.advisor_client_mode:
+        return
+    from src import config as cfg_mod
+    from src.settings.settings import invalidate_settings_cache
+    try:
+        mgr = cfg_mod._get_default_manager()
+        cfg = mgr.load_global()
+        settings_section = cfg.get("settings")
+        if not isinstance(settings_section, dict):
+            settings_section = {}
+        settings_section["advisor_client_mode"] = bool(new.advisor_client_mode)
+        cfg["settings"] = settings_section
+        mgr.save_global(cfg)
+        invalidate_settings_cache()
+        logger.debug(
+            "AppState.advisor_client_mode %s -> %s — persisted + cache invalidated",
+            old.advisor_client_mode,
+            new.advisor_client_mode,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to persist advisor_client_mode to settings; in-memory value still active"
+        )
+
+
 # Registry. EVERY field in AppState must appear here as a handler
 # (function-form, including explicit no-ops). The coverage test enforces
 # this — adding a new AppState field without a handler entry fails
@@ -278,6 +319,7 @@ _FIELD_HANDLERS: dict[str, Callable[[AppState, AppState], None]] = {
     "permission_mode": _on_permission_mode_change,
     "initial_message": _on_initial_message_change,
     "advisor_model": _on_advisor_model_change,
+    "advisor_client_mode": _on_advisor_client_mode_change,
 }
 
 

--- a/src/tool_system/tools/__init__.py
+++ b/src/tool_system/tools/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from ..build_tool import Tool
 
+from .advisor import AdvisorTool
 from .agent import make_agent_tool
 from .ask_user_question import AskUserQuestionTool
 from .bash import BashTool
@@ -40,6 +41,7 @@ from .worktree import EnterWorktreeTool, ExitWorktreeTool
 from .write import WriteTool
 
 ALL_STATIC_TOOLS: list[Tool] = [
+    AdvisorTool,
     AskUserQuestionTool,
     BashTool,
     BriefTool,
@@ -84,6 +86,7 @@ ALL_STATIC_TOOLS: list[Tool] = [
 
 __all__ = [
     "ALL_STATIC_TOOLS",
+    "AdvisorTool",
     "AskUserQuestionTool",
     "BashTool",
     "BriefTool",

--- a/src/tool_system/tools/advisor.py
+++ b/src/tool_system/tools/advisor.py
@@ -1,0 +1,99 @@
+"""Client-side advisor tool — the dispatch handler for ``tool_use(name=advisor)``.
+
+This tool only fires in client-side advisor mode (3P providers or
+``advisor_client_mode=True``). The server-side path emits
+``server_tool_use`` blocks that the API handles; that path never
+reaches this dispatcher.
+
+The tool takes no parameters: the conversation history is forwarded
+implicitly via ``ToolContext.messages`` (populated by ``_call_model_sync``
+before the per-turn tool round). The advisor's reply is returned as
+plain text in the ``ToolResult``.
+
+``is_enabled`` is permanently False so the tool stays out of ``/tools``
+listings and out of the default schema produced by ``get_tools``;
+``_call_model_sync`` appends the schema manually only when client-side
+mode is active for the request. The registry still finds the tool by
+name when the dispatcher routes a matching ``tool_use`` block.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..build_tool import Tool, build_tool
+from ..context import ToolContext
+from ..protocol import ToolResult
+
+
+def _advisor_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
+    # Local imports to avoid pulling settings / providers at module load
+    # — this tool sits in the static registry and we don't want every
+    # boot path to wake those packages.
+    from src.settings.settings import get_settings
+    from src.utils.advisor import (
+        build_advisor_forwarded_messages,
+        execute_client_advisor,
+    )
+
+    settings = get_settings()
+    advisor_model = (getattr(settings, "advisor_model", "") or "").strip()
+    if not advisor_model:
+        # Defensive: the schema should never be exposed when advisor_model
+        # is empty, so reaching this branch means activation drifted from
+        # configuration. Surface as a tool failure (not a turn-killer) so
+        # the worker keeps moving.
+        return ToolResult(
+            name="advisor",
+            output="Advisor unavailable: no advisor_model configured.",
+            is_error=True,
+        )
+
+    history = list(getattr(context, "messages", []) or [])
+    forwarded = build_advisor_forwarded_messages(history)
+
+    abort = getattr(context, "abort_controller", None)
+    abort_signal = getattr(abort, "signal", None) if abort is not None else None
+
+    ok, text = execute_client_advisor(
+        advisor_model,
+        forwarded,
+        abort_signal=abort_signal,
+    )
+    return ToolResult(
+        name="advisor",
+        output=text,
+        is_error=not ok,
+    )
+
+
+# The schema sent to the API is built in ``src/utils/advisor.py`` via
+# ``build_client_advisor_tool_schema`` — kept there alongside the
+# server-side schema so both wire formats live in one place. The
+# ``input_schema`` here mirrors that exactly so registry validation
+# (``validate_json_schema``) accepts the empty-args call.
+AdvisorTool: Tool = build_tool(
+    name="advisor",
+    input_schema={
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+    call=_advisor_call,
+    prompt="",
+    description=(
+        "Consult a stronger reviewer model. The conversation is forwarded "
+        "automatically; takes no parameters."
+    ),
+    # is_enabled=False keeps the tool out of /tools and out of the
+    # default schema list. _call_model_sync injects the schema manually
+    # when client-side mode is active for the request. Registry lookup
+    # by name (used by dispatch) is unaffected by this flag.
+    is_enabled=lambda: False,
+    is_read_only=lambda _input: True,
+    is_concurrency_safe=lambda _input: True,
+    # Generous: advisor responses can be substantial. The TUI row trims
+    # for display; the full text rides as tool_result content into the
+    # next turn.
+    max_result_size_chars=50_000,
+)

--- a/src/tui/agent_bridge.py
+++ b/src/tui/agent_bridge.py
@@ -330,6 +330,40 @@ class AgentBridge:
             advisor_model = (get_settings().advisor_model or "") or None
         except Exception:
             advisor_model = None
+        # Client-side advisor results land on the NEXT (user-role)
+        # message after the assistant's tool_use, since the dispatcher
+        # routes the call through the tool registry. Build a lookup
+        # of ``tool_use_id → (text, is_error)`` from user messages so
+        # the inner loop can pair without an O(N²) walk.
+        client_side_results: dict[str, tuple[str, bool]] = {}
+        for msg in messages[start_idx:]:
+            mcontent = getattr(msg, "content", None)
+            if not isinstance(mcontent, list):
+                continue
+            for blk in mcontent:
+                if not isinstance(blk, dict):
+                    continue
+                if blk.get("type") != "tool_result":
+                    continue
+                use_id = blk.get("tool_use_id")
+                if not isinstance(use_id, str) or not use_id:
+                    continue
+                rc = blk.get("content")
+                # tool_result.content can be a string or a list of
+                # content blocks (multimodal tools). The advisor only
+                # ever emits string content (advisor's reply text).
+                if isinstance(rc, str):
+                    text = rc
+                elif isinstance(rc, list):
+                    parts: list[str] = []
+                    for b in rc:
+                        if isinstance(b, dict) and isinstance(b.get("text"), str):
+                            parts.append(b["text"])
+                    text = "\n".join(parts)
+                else:
+                    text = str(rc) if rc is not None else ""
+                client_side_results[use_id] = (text, bool(blk.get("is_error")))
+
         for msg in messages[start_idx:]:
             content = getattr(msg, "content", None)
             if not isinstance(content, list):
@@ -345,6 +379,49 @@ class AgentBridge:
                 if not isinstance(bid, str) or not bid:
                     continue
                 if bid in self._emitted_advisor_ids:
+                    continue
+                # Client-side advisor: regular tool_use(name="advisor")
+                # on an assistant message; the result is on a later
+                # user-role message. We've already indexed those above.
+                if btype == "tool_use" and bname == "advisor":
+                    self._post(
+                        AdvisorEventMessage(
+                            kind="start",
+                            tool_use_id=bid,
+                            advisor_model=advisor_model,
+                        )
+                    )
+                    pair = client_side_results.get(bid)
+                    if pair is None:
+                        # The dispatcher hasn't produced a result yet
+                        # (turn in flight, or interrupted). Synthesize
+                        # the interrupted event so the row doesn't spin
+                        # forever. If the result lands later, the
+                        # ``_emitted_advisor_ids`` guard prevents
+                        # double-rendering.
+                        self._post(
+                            AdvisorEventMessage(
+                                kind="result",
+                                tool_use_id=bid,
+                                advisor_model=advisor_model,
+                                error_code="interrupted",
+                            )
+                        )
+                    else:
+                        result_text, is_err = pair
+                        self._post(
+                            AdvisorEventMessage(
+                                kind="result",
+                                tool_use_id=bid,
+                                advisor_model=advisor_model,
+                                text=None if is_err else result_text,
+                                error_code=(
+                                    result_text[:120] if is_err and result_text
+                                    else ("error" if is_err else None)
+                                ),
+                            )
+                        )
+                    self._emitted_advisor_ids.add(bid)
                     continue
                 if btype == "server_tool_use" and bname == "advisor":
                     self._post(

--- a/src/utils/advisor.py
+++ b/src/utils/advisor.py
@@ -1,20 +1,31 @@
-"""Advisor tool integration — Python port of typescript/src/utils/advisor.ts.
+"""Advisor tool integration.
 
-The advisor is a server-side tool: when the model emits an advisor
-``server_tool_use`` block, the Anthropic API runs a stronger reviewer model
-on the conversation so far and returns an ``advisor_tool_result`` block.
-The client never executes anything — its only responsibilities are:
+There are TWO execution modes:
 
-1. opt the request into the ``advisor-tool-2026-03-01`` beta,
-2. declare the advisor tool schema in ``tools[]`` (cache-preserving append),
-3. inject ``ADVISOR_TOOL_INSTRUCTIONS`` into the system prompt,
-4. preserve the resulting blocks in conversation history,
-5. strip them on requests that won't carry the beta header (the API would
-   400 otherwise).
+**Server-side** (Anthropic 1P only — Python port of TS ``advisor.ts``):
+The model emits a ``server_tool_use(name=advisor)`` block; the Anthropic
+API runs a stronger reviewer model on the conversation so far and inlines
+an ``advisor_tool_result`` block into the same response. The client only:
 
-Provider gating is strict: any non-first-party Anthropic provider
-(Bedrock/Vertex shims, OpenAI-compat, Gemini, etc.) MUST NOT see the header
-or the schema — 3P endpoints 400 on the unknown tool type.
+1. opts the request into the ``advisor-tool-2026-03-01`` beta,
+2. declares the advisor schema in ``tools[]`` (cache-preserving append),
+3. injects ``ADVISOR_TOOL_INSTRUCTIONS`` into the system prompt,
+4. preserves the resulting blocks in conversation history,
+5. strips them on requests that won't carry the beta header.
+
+**Client-side** (any provider — no TS equivalent, Python extension):
+The model emits a regular ``tool_use(name="advisor")`` block; the agent
+intercepts it, makes a *separate* API call to whatever advisor model the
+user configured (could be Anthropic Opus, Gemini, GLM, etc.), and feeds
+the response back as a ``tool_result`` block. Two roundtrips per advisor
+call but works with any tool-calling main-loop model and any advisor
+provider.
+
+The client picks server-side automatically when the main provider is 1P
+Anthropic AND the chosen advisor model is a valid server-side target;
+otherwise falls back to client-side. Users can also force client-side
+even on 1P via the ``advisor_client_mode`` setting (useful for non-
+Anthropic advisors on Anthropic main loops, or for transparency).
 """
 
 from __future__ import annotations
@@ -111,17 +122,15 @@ def is_advisor_enabled(provider: "BaseProvider | None") -> bool:
 def can_user_configure_advisor(provider: "BaseProvider | None" = None) -> bool:
     """Whether the user is allowed to configure /advisor in this process.
 
-    The slash command needs to render in command lists even before a
-    provider is built (e.g. ``--help``), so when ``provider`` is None we
-    fall back to the env-disable check only. Once a provider exists, we
-    additionally require it to be first-party Anthropic; otherwise
-    /advisor would silently no-op every request and the UI would lie.
+    Originally a first-party-only gate (so the slash command wouldn't
+    silently no-op on 3P providers). Now that client-side mode lets
+    /advisor work on any provider, this only enforces the env-disable
+    kill switch. The provider argument is retained for API stability —
+    callers (slash-command visibility, /advisor command itself) used
+    to pass it. Once an entirely 3P-disabled environment is wanted,
+    this is still the chokepoint to add a check.
     """
-    if _env_truthy(_DISABLE_ENV):
-        return False
-    if provider is None:
-        return True
-    return is_advisor_enabled(provider)
+    return not _env_truthy(_DISABLE_ENV)
 
 
 def _block_field(block: Any, key: str) -> Any:
@@ -254,15 +263,268 @@ def strip_advisor_blocks(
     return result if changed else messages
 
 
+# ---------------------------------------------------------------------------
+# Client-side advisor mode (Python extension — no TS equivalent)
+# ---------------------------------------------------------------------------
+
+# Activation mode for a given turn — picked by ``decide_advisor_mode``.
+ADVISOR_MODE_INACTIVE = "inactive"
+ADVISOR_MODE_SERVER_SIDE = "server_side"
+ADVISOR_MODE_CLIENT_SIDE = "client_side"
+
+
+# The client-side advisor's *own* system prompt. Sent to the advisor
+# provider as the system message. Kept short — the conversation we
+# forward is the substantive context, and the prompt's role is just to
+# orient the advisor model on what kind of feedback to produce.
+CLIENT_ADVISOR_SYSTEM_PROMPT = """You are a senior reviewer model. Another model is working through a task and has paused to consult you. The conversation forwarded below is everything the worker model has seen so far: the user's request, every tool call the worker made, every result.
+
+Your job: produce concise, high-signal advice that helps the worker decide what to do next. Concretely:
+
+- If the worker's interpretation of the task or its current approach looks wrong, say so and explain the better path.
+- If you spot a bug, a missed constraint, a hidden invariant, or a step the worker is about to skip, name it.
+- If the worker is at a fork between approaches, recommend one and explain the tradeoff.
+- If the worker is done, sanity-check: did they actually solve what was asked? What edge cases didn't they cover?
+
+Keep it tight — short paragraphs, no preamble. Don't repeat what the worker already knows. Don't add disclaimers about being an AI. Write directly to the worker model in second person."""
+
+
+# Tool-use shape that the main-loop model sees in client-side mode.
+# Regular ``tool_use``-style entry (NOT ``server_tool_use``) with empty
+# parameters — the advisor takes the full conversation implicitly, the
+# model just invokes the tool with no args. The dispatcher (see
+# ``src/tool_system/tools/advisor.py``) maps the call to
+# ``execute_client_advisor``.
+CLIENT_ADVISOR_TOOL_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+def build_client_advisor_tool_schema() -> dict[str, Any]:
+    """``tools[]`` entry that exposes the client-side advisor to the model.
+
+    Regular tool-use shape (NOT ``server_tool_use``) so any provider that
+    supports tool calling can route the invocation. Description doubles
+    as a one-line "what does this do" for the model — the full policy
+    lives in ``ADVISOR_TOOL_INSTRUCTIONS`` (system prompt).
+    """
+    return {
+        "name": ADVISOR_TOOL_NAME,
+        "description": (
+            "Consult a stronger reviewer model. Takes no parameters; the "
+            "current conversation is forwarded automatically. Returns the "
+            "reviewer's advice as text."
+        ),
+        "input_schema": dict(CLIENT_ADVISOR_TOOL_INPUT_SCHEMA),
+    }
+
+
+def infer_provider_for_model(model: str) -> str | None:
+    """Best-effort model → provider lookup.
+
+    Walks ``PROVIDER_INFO`` for an exact match first; falls back to
+    well-known prefix conventions. Returns ``None`` when the model
+    can't be confidently routed — callers should surface a clear error
+    to the user rather than silently picking the wrong endpoint.
+
+    The exact-match path covers the common case (user typed
+    ``gemini-2.5-pro`` and Gemini lists it). The prefix fallback covers
+    canonical names that PROVIDER_INFO's allowlist hasn't been refreshed
+    for (e.g. a new ``claude-opus-4-7`` not yet in the list — still
+    clearly Anthropic). Order matters: ``zai/`` before generic
+    ``vendor/<model>`` so OpenRouter doesn't steal GLM models.
+    """
+    if not model:
+        return None
+    # Local import to avoid pulling the providers package at module load.
+    from src.providers import PROVIDER_INFO
+
+    for name, info in PROVIDER_INFO.items():
+        if model in info.get("available_models", []):
+            return name
+
+    m = model.lower()
+    if m.startswith("zai/"):
+        return "glm"
+    if m.startswith("claude-"):
+        return "anthropic"
+    if m.startswith("gpt-") or m.startswith("o1") or m.startswith("o3"):
+        return "openai"
+    if m.startswith("gemini-"):
+        return "gemini"
+    if m.startswith("minimax-") or model.startswith("MiniMax-") or model == "M2-her":
+        return "minimax"
+    if m.startswith("deepseek-"):
+        return "deepseek"
+    # ``<vendor>/<model>`` shape after the more-specific prefix checks
+    # above. Catches OpenRouter routes like ``anthropic/claude-3.5-sonnet``.
+    if "/" in model:
+        return "openrouter"
+    return None
+
+
+def decide_advisor_mode(
+    provider: "BaseProvider | None",
+    main_loop_model: str | None,
+    advisor_model: str | None,
+    *,
+    force_client_mode: bool = False,
+) -> str:
+    """Pick activation mode for the upcoming turn.
+
+    Returns one of:
+    * ``ADVISOR_MODE_INACTIVE`` — no advisor on this request.
+    * ``ADVISOR_MODE_SERVER_SIDE`` — Anthropic 1P beta path.
+    * ``ADVISOR_MODE_CLIENT_SIDE`` — separate provider call from the
+      tool dispatcher.
+
+    Decision tree:
+
+    1. ``advisor_model`` empty / env-disabled → INACTIVE.
+    2. ``force_client_mode`` set → CLIENT_SIDE iff the advisor model
+       routes to a known provider; else INACTIVE.
+    3. 1P + main_loop_model supports server advisor + advisor_model is
+       a valid server target → SERVER_SIDE (the optimized path; one
+       roundtrip, prompt-cache friendly).
+    4. Otherwise, if the advisor model routes to a known provider →
+       CLIENT_SIDE (works with any main-loop tool-calling model).
+    5. Else INACTIVE — the configured advisor model can't be reached.
+    """
+    if _env_truthy(_DISABLE_ENV):
+        return ADVISOR_MODE_INACTIVE
+    if not advisor_model:
+        return ADVISOR_MODE_INACTIVE
+
+    advisor_routes = infer_provider_for_model(advisor_model) is not None
+
+    if force_client_mode:
+        return ADVISOR_MODE_CLIENT_SIDE if advisor_routes else ADVISOR_MODE_INACTIVE
+
+    if (
+        provider is not None
+        and is_advisor_enabled(provider)
+        and model_supports_advisor(main_loop_model)
+        and is_valid_advisor_model(advisor_model)
+    ):
+        return ADVISOR_MODE_SERVER_SIDE
+
+    return ADVISOR_MODE_CLIENT_SIDE if advisor_routes else ADVISOR_MODE_INACTIVE
+
+
+def build_advisor_forwarded_messages(
+    messages: list[Any],
+) -> list[dict[str, Any]]:
+    """Normalize + strip advisor-specific blocks before forwarding to the
+    client-side advisor.
+
+    The advisor model should see the *substance* of the conversation —
+    user's task, worker's text replies, tool calls, tool results — but
+    NOT the advisor's own prior consultations (which would balloon the
+    forwarded context and confuse the reviewer about whose advice is
+    whose). We also strip out the advisor tool schema entry from any
+    serialized tool list, but since this function only handles the
+    messages array, the schema-stripping happens at the request-build
+    site (we don't forward tools[] to the advisor anyway).
+
+    Accepts the same shape as ``normalize_messages_for_api`` produces.
+    Returns a plain list of dicts safe to send to any provider.
+    """
+    # Local import — same cycle-avoidance reason as elsewhere in this
+    # module. ``normalize_messages_for_api`` projects typed Message
+    # objects to API dicts; we then run the existing advisor-blocks
+    # stripper to drop the prior consultations.
+    from src.types.messages import normalize_messages_for_api
+
+    api_messages = normalize_messages_for_api(messages)
+    return strip_advisor_blocks(api_messages)
+
+
+def execute_client_advisor(
+    advisor_model: str,
+    forwarded_messages: list[dict[str, Any]],
+    *,
+    abort_signal: Any = None,
+) -> tuple[bool, str]:
+    """Run one client-side advisor consultation.
+
+    Returns ``(ok, text)``: when ``ok`` is True, ``text`` is the
+    advisor's advice; when False, ``text`` is a short error message
+    suitable for surfacing as a tool_result with ``is_error=True``.
+
+    Provider routing goes through ``infer_provider_for_model`` →
+    ``get_provider_class`` + ``get_provider_config`` — the same path
+    the main loop uses for its own provider, so user-configured API
+    keys / base URLs / auth headers are reused. No advisor-specific
+    credentials.
+
+    Network failures, model errors, and missing-config conditions are
+    all caught and surfaced as ``(False, "...")`` rather than raised —
+    a tool that throws inside dispatch kills the turn, but a failed
+    advisor consultation should just leave the worker model uninformed
+    and let it continue.
+    """
+    provider_name = infer_provider_for_model(advisor_model)
+    if provider_name is None:
+        return (False, f"Advisor unavailable: cannot route model {advisor_model!r} to a known provider.")
+
+    try:
+        from src.config import get_provider_config
+        from src.providers import get_provider_class
+
+        provider_cls = get_provider_class(provider_name)
+        cfg = dict(get_provider_config(provider_name))
+        # The provider config supplies base_url / api_key / etc.; we
+        # override the model with the advisor's specific choice so it
+        # doesn't inherit the user's main-loop model from the same
+        # provider's default. ``ChatProvider.__init__`` expects the
+        # model on the instance, not in the messages array.
+        cfg["model"] = advisor_model
+        provider = provider_cls(**cfg)
+    except Exception as e:  # noqa: BLE001 — surface as advisor failure
+        return (False, f"Advisor unavailable: failed to construct provider for {advisor_model!r}: {e}")
+
+    # The advisor doesn't make tool calls — it just emits advice text —
+    # so we send an empty tools list. Forward the conversation as
+    # user-role context wrapped under our advisor system prompt.
+    try:
+        response = provider.chat(
+            messages=forwarded_messages,
+            system=CLIENT_ADVISOR_SYSTEM_PROMPT,
+            tools=[],
+            max_tokens=4096,
+            stream=False,
+            abort_signal=abort_signal,
+        )
+    except Exception as e:  # noqa: BLE001 — surface as advisor failure
+        return (False, f"Advisor unavailable: {type(e).__name__}: {e}")
+
+    text = getattr(response, "content", None) or ""
+    if not isinstance(text, str) or not text.strip():
+        return (False, "Advisor returned no text content.")
+    return (True, text)
+
+
 __all__ = [
     "ADVISOR_BETA_HEADER",
+    "ADVISOR_MODE_CLIENT_SIDE",
+    "ADVISOR_MODE_INACTIVE",
+    "ADVISOR_MODE_SERVER_SIDE",
     "ADVISOR_TOOL_INSTRUCTIONS",
     "ADVISOR_TOOL_NAME",
     "ADVISOR_TOOL_TYPE",
+    "CLIENT_ADVISOR_SYSTEM_PROMPT",
+    "CLIENT_ADVISOR_TOOL_INPUT_SCHEMA",
+    "build_advisor_forwarded_messages",
     "build_advisor_tool_schema",
+    "build_client_advisor_tool_schema",
     "can_user_configure_advisor",
+    "decide_advisor_mode",
+    "execute_client_advisor",
     "extract_advisor_error_code",
     "extract_advisor_result_text",
+    "infer_provider_for_model",
     "is_advisor_block",
     "is_advisor_enabled",
     "is_valid_advisor_model",

--- a/tests/test_advisor_client_side.py
+++ b/tests/test_advisor_client_side.py
@@ -1,0 +1,394 @@
+"""Client-side advisor path — helpers, dispatcher, end-to-end activation.
+
+The Python-only client-side mode lets ``/advisor`` work on any provider
+by routing advisor invocations through the tool dispatcher (a regular
+``tool_use(name="advisor")`` block) instead of the Anthropic
+server-side beta.
+
+Test surface:
+  * ``decide_advisor_mode`` — full activation truth table.
+  * ``infer_provider_for_model`` — known + prefix + unknown shapes.
+  * ``build_advisor_forwarded_messages`` — strips prior advisor blocks
+    so they don't leak into the advisor's own forwarded context.
+  * ``execute_client_advisor`` — wires through provider factory,
+    returns text on success, error string on failure.
+  * ``AdvisorTool._advisor_call`` — reads ctx.messages, forwards
+    through execute, returns ToolResult.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from src.tool_system.context import ToolContext
+from src.tool_system.tools.advisor import AdvisorTool
+from src.utils.advisor import (
+    ADVISOR_MODE_CLIENT_SIDE,
+    ADVISOR_MODE_INACTIVE,
+    ADVISOR_MODE_SERVER_SIDE,
+    build_advisor_forwarded_messages,
+    build_client_advisor_tool_schema,
+    decide_advisor_mode,
+    execute_client_advisor,
+    infer_provider_for_model,
+)
+
+
+class TestInferProviderForModel(unittest.TestCase):
+    def test_exact_match_anthropic(self) -> None:
+        self.assertEqual(infer_provider_for_model("claude-opus-4-6"), "anthropic")
+        self.assertEqual(infer_provider_for_model("claude-sonnet-4-6"), "anthropic")
+
+    def test_exact_match_openai(self) -> None:
+        self.assertEqual(infer_provider_for_model("gpt-5.4"), "openai")
+
+    def test_exact_match_glm(self) -> None:
+        self.assertEqual(infer_provider_for_model("zai/glm-5"), "glm")
+
+    def test_exact_match_gemini(self) -> None:
+        self.assertEqual(infer_provider_for_model("gemini-2.5-pro"), "gemini")
+
+    def test_prefix_fallback_anthropic(self) -> None:
+        # claude-opus-4-7 isn't in PROVIDER_INFO yet but the prefix
+        # rule routes it cleanly.
+        self.assertEqual(
+            infer_provider_for_model("claude-opus-4-7-future"), "anthropic"
+        )
+
+    def test_prefix_fallback_gemini(self) -> None:
+        self.assertEqual(infer_provider_for_model("gemini-3.0-pro"), "gemini")
+
+    def test_vendor_slash_routes_to_openrouter(self) -> None:
+        # ``anthropic/claude-…`` is an OpenRouter route, not Anthropic
+        # direct — the ``/`` shape after the more-specific prefix
+        # checks routes to openrouter.
+        self.assertEqual(
+            infer_provider_for_model("anthropic/claude-sonnet-4.5"), "openrouter"
+        )
+        self.assertEqual(
+            infer_provider_for_model("meta-llama/llama-3.3-70b-instruct"),
+            "openrouter",
+        )
+
+    def test_glm_prefix_beats_openrouter_slash(self) -> None:
+        # zai/ prefix is checked before the generic vendor/<model>
+        # rule, so GLM stays with the GLM provider.
+        self.assertEqual(infer_provider_for_model("zai/glm-4.7"), "glm")
+
+    def test_unknown_model_returns_none(self) -> None:
+        self.assertIsNone(infer_provider_for_model("totally-fake-zzz-9999"))
+        self.assertIsNone(infer_provider_for_model(""))
+        self.assertIsNone(infer_provider_for_model(None))  # type: ignore[arg-type]
+
+
+class TestDecideAdvisorMode(unittest.TestCase):
+    """Mode-decision truth table."""
+
+    def setUp(self) -> None:
+        os.environ.pop("CLAUDE_CODE_DISABLE_ADVISOR_TOOL", None)
+
+    def _first_party_provider(self) -> MagicMock:
+        provider = MagicMock()
+        provider.has_custom_endpoint = MagicMock(return_value=False)
+        return provider
+
+    def _third_party_provider(self) -> MagicMock:
+        provider = MagicMock()
+        provider.has_custom_endpoint = MagicMock(return_value=True)
+        return provider
+
+    def test_inactive_when_no_advisor_model(self) -> None:
+        mode = decide_advisor_mode(
+            self._first_party_provider(), "claude-opus-4-6", ""
+        )
+        self.assertEqual(mode, ADVISOR_MODE_INACTIVE)
+
+    def test_inactive_when_env_disabled(self) -> None:
+        with patch.dict(
+            os.environ, {"CLAUDE_CODE_DISABLE_ADVISOR_TOOL": "1"}, clear=False
+        ):
+            mode = decide_advisor_mode(
+                self._first_party_provider(),
+                "claude-opus-4-6",
+                "claude-opus-4-6",
+            )
+            self.assertEqual(mode, ADVISOR_MODE_INACTIVE)
+
+    def test_server_side_for_1p_with_valid_models(self) -> None:
+        with patch(
+            "src.state.cache_state.is_first_party_provider",
+            return_value=True,
+        ):
+            mode = decide_advisor_mode(
+                self._first_party_provider(),
+                "claude-opus-4-6",
+                "claude-opus-4-6",
+            )
+            self.assertEqual(mode, ADVISOR_MODE_SERVER_SIDE)
+
+    def test_client_side_when_1p_with_force_client(self) -> None:
+        with patch(
+            "src.state.cache_state.is_first_party_provider",
+            return_value=True,
+        ):
+            mode = decide_advisor_mode(
+                self._first_party_provider(),
+                "claude-opus-4-6",
+                "claude-opus-4-6",
+                force_client_mode=True,
+            )
+            self.assertEqual(mode, ADVISOR_MODE_CLIENT_SIDE)
+
+    def test_client_side_for_1p_with_unsupported_base_model(self) -> None:
+        # opus-4-5 doesn't support server-side advisor → falls back
+        # to client-side as long as the advisor model routes.
+        with patch(
+            "src.state.cache_state.is_first_party_provider",
+            return_value=True,
+        ):
+            mode = decide_advisor_mode(
+                self._first_party_provider(),
+                "claude-opus-4-5",
+                "claude-opus-4-6",
+            )
+            self.assertEqual(mode, ADVISOR_MODE_CLIENT_SIDE)
+
+    def test_client_side_for_3p_provider(self) -> None:
+        # 3P never qualifies for server-side; client-side is the only
+        # path. The main loop's model doesn't matter here.
+        with patch(
+            "src.state.cache_state.is_first_party_provider",
+            return_value=False,
+        ):
+            mode = decide_advisor_mode(
+                self._third_party_provider(),
+                "gpt-5.4",
+                "claude-opus-4-6",
+            )
+            self.assertEqual(mode, ADVISOR_MODE_CLIENT_SIDE)
+
+    def test_client_side_cross_provider(self) -> None:
+        # 1P main loop with a Gemini advisor — server-side rejects
+        # the Gemini model, falls through to client-side which routes
+        # gemini-2.5-pro to the gemini provider.
+        with patch(
+            "src.state.cache_state.is_first_party_provider",
+            return_value=True,
+        ):
+            mode = decide_advisor_mode(
+                self._first_party_provider(),
+                "claude-opus-4-6",
+                "gemini-2.5-pro",
+            )
+            self.assertEqual(mode, ADVISOR_MODE_CLIENT_SIDE)
+
+    def test_inactive_when_force_client_but_unrouted_model(self) -> None:
+        # Even with force_client_mode, an unroutable advisor model
+        # returns INACTIVE — there's no provider to send the request to.
+        mode = decide_advisor_mode(
+            self._first_party_provider(),
+            "claude-opus-4-6",
+            "totally-fake-xyz-9999",
+            force_client_mode=True,
+        )
+        self.assertEqual(mode, ADVISOR_MODE_INACTIVE)
+
+    def test_inactive_when_no_provider_and_no_force(self) -> None:
+        # Provider=None + no force_client + advisor_model set: the
+        # server-side gate fails (needs is_advisor_enabled which needs
+        # a provider), and client-side activates as long as advisor
+        # routes. This matches the "/advisor pre-startup" surface.
+        mode = decide_advisor_mode(None, "claude-opus-4-6", "claude-opus-4-6")
+        # No provider → can't check first-party → falls to client-side
+        # (advisor model routes to anthropic).
+        self.assertEqual(mode, ADVISOR_MODE_CLIENT_SIDE)
+
+
+class TestBuildAdvisorForwardedMessages(unittest.TestCase):
+    """Forwarded messages must strip prior advisor blocks so the
+    advisor doesn't see its own previous consultations as input."""
+
+    def test_strips_server_side_advisor_blocks(self) -> None:
+        from src.types.messages import AssistantMessage, UserMessage
+        msgs = [
+            UserMessage(content="hi"),
+            AssistantMessage(
+                content=[
+                    {"type": "text", "text": "thinking"},
+                    {
+                        "type": "server_tool_use",
+                        "id": "srv_1",
+                        "name": "advisor",
+                        "input": {},
+                    },
+                    {
+                        "type": "advisor_tool_result",
+                        "tool_use_id": "srv_1",
+                        "content": {"type": "advisor_result", "text": "old advice"},
+                    },
+                    {"type": "text", "text": "after"},
+                ],
+            ),
+        ]
+        out = build_advisor_forwarded_messages(msgs)
+        for m in out:
+            if m.get("role") != "assistant":
+                continue
+            c = m.get("content")
+            if isinstance(c, list):
+                for b in c:
+                    if isinstance(b, dict):
+                        self.assertNotEqual(b.get("type"), "server_tool_use")
+                        self.assertNotEqual(b.get("type"), "advisor_tool_result")
+
+    def test_returns_plain_dicts_safe_to_send(self) -> None:
+        from src.types.messages import UserMessage
+        out = build_advisor_forwarded_messages([UserMessage(content="hello")])
+        self.assertTrue(all(isinstance(m, dict) for m in out))
+
+
+class TestExecuteClientAdvisor(unittest.TestCase):
+    """``execute_client_advisor`` integration — provider factory wiring."""
+
+    def test_returns_text_on_success(self) -> None:
+        fake_provider = MagicMock()
+        fake_provider.chat = MagicMock(return_value=MagicMock(content="here is advice"))
+        with patch(
+            "src.providers.get_provider_class", return_value=lambda **kw: fake_provider
+        ):
+            with patch(
+                "src.config.get_provider_config", return_value={"api_key": "test"}
+            ):
+                ok, text = execute_client_advisor(
+                    "claude-opus-4-6", [{"role": "user", "content": "hi"}]
+                )
+        self.assertTrue(ok)
+        self.assertEqual(text, "here is advice")
+        # The provider got the advisor's system prompt and an empty
+        # tools list.
+        kw = fake_provider.chat.call_args.kwargs
+        self.assertEqual(kw.get("tools"), [])
+        self.assertIn("system", kw)
+        self.assertIn("reviewer", kw["system"].lower())
+
+    def test_returns_error_when_model_unroutable(self) -> None:
+        ok, text = execute_client_advisor(
+            "totally-fake-zzz-9999", [{"role": "user", "content": "hi"}]
+        )
+        self.assertFalse(ok)
+        self.assertIn("cannot route", text.lower())
+
+    def test_returns_error_when_provider_raises(self) -> None:
+        fake_provider = MagicMock()
+        fake_provider.chat = MagicMock(side_effect=RuntimeError("network down"))
+        with patch(
+            "src.providers.get_provider_class", return_value=lambda **kw: fake_provider
+        ):
+            with patch(
+                "src.config.get_provider_config", return_value={"api_key": "test"}
+            ):
+                ok, text = execute_client_advisor(
+                    "claude-opus-4-6", [{"role": "user", "content": "hi"}]
+                )
+        self.assertFalse(ok)
+        self.assertIn("network down", text)
+
+    def test_returns_error_when_response_empty(self) -> None:
+        fake_provider = MagicMock()
+        fake_provider.chat = MagicMock(return_value=MagicMock(content=""))
+        with patch(
+            "src.providers.get_provider_class", return_value=lambda **kw: fake_provider
+        ):
+            with patch(
+                "src.config.get_provider_config", return_value={"api_key": "test"}
+            ):
+                ok, text = execute_client_advisor(
+                    "claude-opus-4-6", [{"role": "user", "content": "hi"}]
+                )
+        self.assertFalse(ok)
+        self.assertIn("no text", text.lower())
+
+
+class TestAdvisorTool(unittest.TestCase):
+    """The registered AdvisorTool — wires ctx.messages → execute."""
+
+    def setUp(self) -> None:
+        import tempfile
+        from pathlib import Path
+        self._tmpdir = Path(tempfile.mkdtemp(prefix="advisor_tool_test_"))
+
+    def test_is_hidden_from_default_pool(self) -> None:
+        # is_enabled=False keeps it out of /tools and the default schema
+        # construction. _call_model_sync injects the schema manually
+        # when client-side mode is active.
+        self.assertFalse(AdvisorTool.is_enabled())
+
+    def test_call_returns_advice_text(self) -> None:
+        ctx = ToolContext(workspace_root=self._tmpdir)
+        ctx.messages = [{"role": "user", "content": "task"}]
+        from src.settings.settings import get_settings
+        # Patch settings to provide an advisor_model so the tool doesn't
+        # short-circuit on the "no model configured" branch.
+        fake_settings = MagicMock()
+        fake_settings.advisor_model = "claude-opus-4-6"
+        with patch("src.settings.settings.get_settings", return_value=fake_settings):
+            with patch(
+                "src.utils.advisor.execute_client_advisor",
+                return_value=(True, "use the foo pattern"),
+            ):
+                result = AdvisorTool.call({}, ctx)
+        self.assertEqual(result.name, "advisor")
+        self.assertEqual(result.output, "use the foo pattern")
+        self.assertFalse(result.is_error)
+
+    def test_call_marks_error_when_execute_fails(self) -> None:
+        ctx = ToolContext(workspace_root=self._tmpdir)
+        ctx.messages = [{"role": "user", "content": "task"}]
+        fake_settings = MagicMock()
+        fake_settings.advisor_model = "claude-opus-4-6"
+        with patch("src.settings.settings.get_settings", return_value=fake_settings):
+            with patch(
+                "src.utils.advisor.execute_client_advisor",
+                return_value=(False, "Advisor unavailable: foo"),
+            ):
+                result = AdvisorTool.call({}, ctx)
+        self.assertTrue(result.is_error)
+        self.assertIn("unavailable", result.output)
+
+    def test_call_when_no_model_configured_returns_error(self) -> None:
+        ctx = ToolContext(workspace_root=self._tmpdir)
+        fake_settings = MagicMock()
+        fake_settings.advisor_model = ""
+        with patch("src.settings.settings.get_settings", return_value=fake_settings):
+            result = AdvisorTool.call({}, ctx)
+        self.assertTrue(result.is_error)
+        self.assertIn("no advisor_model", result.output.lower())
+
+
+class TestClientAdvisorToolSchema(unittest.TestCase):
+    """The schema sent to the API in client-side mode is regular
+    tool_use shape — no ``type`` discriminator (that's the server-side
+    ``advisor_20260301`` field)."""
+
+    def test_schema_is_regular_tool_use_shape(self) -> None:
+        schema = build_client_advisor_tool_schema()
+        self.assertEqual(schema["name"], "advisor")
+        self.assertIn("description", schema)
+        self.assertIn("input_schema", schema)
+        # Crucially absent — the type discriminator would crash 3P endpoints.
+        self.assertNotIn("type", schema)
+
+    def test_schema_input_takes_no_params(self) -> None:
+        schema = build_client_advisor_tool_schema()
+        props = schema["input_schema"].get("properties")
+        self.assertEqual(props, {})
+        self.assertEqual(
+            schema["input_schema"].get("additionalProperties"), False
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_advisor_command.py
+++ b/tests/test_advisor_command.py
@@ -117,7 +117,8 @@ class _IsolatedEnv:
 
 
 class TestAdvisorCommandGate(unittest.TestCase):
-    """The /advisor command refuses to run under non-first-party providers."""
+    """The /advisor command refuses to run when env-disabled. Provider
+    type is no longer a gate — client-side mode covers 3P."""
 
     def test_refuses_when_env_disabled(self) -> None:
         with _IsolatedEnv():
@@ -126,14 +127,18 @@ class TestAdvisorCommandGate(unittest.TestCase):
             ):
                 ctx = _make_context(provider=_fake_first_party_provider())
                 res = advisor_command_call("claude-opus-4-6", ctx)
-                self.assertIn("unavailable", res.value.lower())
+                self.assertIn("disabled", res.value.lower())
 
-    def test_refuses_with_non_first_party_provider(self) -> None:
+    def test_works_with_non_first_party_provider(self) -> None:
+        # Pre-client-side, this rejected. Post-client-side, 3P provider
+        # is fine — the advisor runs via the dispatcher's separate API
+        # call.
         with _IsolatedEnv():
             provider = MagicMock()  # Not an AnthropicProvider
+            provider.model = "gpt-5.4"
             ctx = _make_context(provider=provider)
             res = advisor_command_call("claude-opus-4-6", ctx)
-            self.assertIn("unavailable", res.value.lower())
+            self.assertIn("Advisor set to claude-opus-4-6", res.value)
 
 
 class TestAdvisorCommandStorePath(unittest.TestCase):
@@ -177,18 +182,19 @@ class TestAdvisorCommandStorePath(unittest.TestCase):
             self.assertIn("already unset", res.value.lower())
             self.assertEqual(store.writes, [])
 
-    def test_inactive_warning_when_base_model_unsupported(self) -> None:
+    def test_client_side_when_base_model_unsupported_for_server(self) -> None:
+        # Pre-client-side: this case warned "not supported". Now the
+        # base model just falls back to client-side dispatch — the
+        # command reports the actual mode chosen.
         with _IsolatedEnv():
             store = _FakeStore()
-            # Main loop on an older model — advisor can be SET but never
-            # actually fires until the user switches the base model.
             provider = _fake_first_party_provider("claude-opus-4-5")
             ctx = _make_context(store=store, provider=provider)
             res = advisor_command_call("claude-opus-4-6", ctx)
             self.assertIn("Advisor set to claude-opus-4-6", res.value)
-            self.assertIn("not support", res.value.lower())
+            self.assertIn("client-side", res.value.lower())
 
-    def test_no_arg_inactive_when_set_but_unsupported_base(self) -> None:
+    def test_no_arg_shows_client_side_for_unsupported_base(self) -> None:
         with _IsolatedEnv():
             from src.state.app_state import AppState
             store = _FakeStore(initial=AppState(advisor_model="claude-opus-4-6"))
@@ -196,31 +202,30 @@ class TestAdvisorCommandStorePath(unittest.TestCase):
             ctx = _make_context(store=store, provider=provider)
             res = advisor_command_call("", ctx)
             self.assertIn("Advisor: claude-opus-4-6", res.value)
-            self.assertIn("inactive", res.value.lower())
+            # Now active client-side rather than "inactive".
+            self.assertIn("client-side", res.value.lower())
 
-    def test_rejects_non_advisor_model(self) -> None:
+    def test_accepts_non_server_side_advisor_model(self) -> None:
+        # haiku-4-5 isn't valid for server-side, but it routes to
+        # anthropic and works client-side. The command should accept
+        # it (previously it was rejected by is_valid_advisor_model).
         with _IsolatedEnv():
             store = _FakeStore()
             ctx = _make_context(store=store, provider=_fake_first_party_provider())
             res = advisor_command_call("haiku", ctx)
-            # The resolver normalizes "haiku" to a haiku model id, which
-            # is_valid_advisor_model rejects.
-            self.assertIn("cannot be used as an advisor", res.value)
-            self.assertEqual(store.writes, [])
+            self.assertIn("Advisor set to", res.value)
+            self.assertEqual(len(store.writes), 1)
 
-    def test_rejects_unknown_model(self) -> None:
+    def test_rejects_unroutable_model(self) -> None:
+        # A model that doesn't resolve to any provider must still be
+        # rejected — the client-side path needs a provider to call.
         with _IsolatedEnv():
             store = _FakeStore()
             ctx = _make_context(store=store, provider=_fake_first_party_provider())
-            # validate_model_name accepts any ≥2 char string that
-            # doesn't violate known patterns, so an unknown but
-            # well-formed string may slip past that check and be
-            # rejected at the is_valid_advisor_model gate. Either
-            # rejection is acceptable; just verify nothing is written.
-            res = advisor_command_call("zzz-not-a-model-9999", ctx)
+            res = advisor_command_call("totally-fake-provider-zzz-9999", ctx)
             self.assertTrue(
                 "Unknown" in res.value
-                or "cannot be used as an advisor" in res.value,
+                or "no known provider" in res.value.lower(),
                 f"unexpected reject path: {res.value!r}",
             )
             self.assertEqual(store.writes, [])

--- a/tests/test_advisor_helpers.py
+++ b/tests/test_advisor_helpers.py
@@ -183,10 +183,9 @@ class TestIsAdvisorEnabled(unittest.TestCase):
 
 
 class TestCanUserConfigureAdvisor(unittest.TestCase):
-    """The slash-command visibility gate. Loosened relative to
-    ``is_advisor_enabled`` because the command needs to appear in
-    listings even when no provider has been built yet (``--help``
-    etc.). Strict provider gating still applies at request time."""
+    """The slash-command visibility gate. Loosened to env-only after
+    client-side mode shipped — /advisor is now valid on any provider.
+    """
 
     def test_enabled_when_no_provider_and_no_env_disable(self) -> None:
         with patch.dict(os.environ, {}, clear=False):
@@ -199,13 +198,16 @@ class TestCanUserConfigureAdvisor(unittest.TestCase):
         ):
             self.assertFalse(can_user_configure_advisor(None))
 
-    def test_disabled_with_third_party_provider(self) -> None:
+    def test_enabled_with_third_party_provider(self) -> None:
+        # Pre-client-side, this was False. Post-client-side, /advisor
+        # works on 3P (the client-side path dispatches to whatever
+        # advisor model is configured) so we no longer reject upfront.
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("CLAUDE_CODE_DISABLE_ADVISOR_TOOL", None)
             with patch(
                 "src.state.cache_state.is_first_party_provider", return_value=False
             ):
-                self.assertFalse(can_user_configure_advisor(MagicMock()))
+                self.assertTrue(can_user_configure_advisor(MagicMock()))
 
 
 class TestIsAdvisorBlock(unittest.TestCase):

--- a/tests/test_advisor_request_wiring.py
+++ b/tests/test_advisor_request_wiring.py
@@ -256,16 +256,17 @@ class TestAdvisorInactivePaths(unittest.TestCase):
         self._iso.exit()
 
     def _assert_inactive(self, cap: _Capture) -> None:
+        """Assert NO advisor of either flavor leaks into the request."""
         self.assertNotIn("betas", cap.call_kwargs)
         tools = cap.call_kwargs.get("tools") or []
         for t in tools:
             self.assertNotEqual(
                 t.get("type"), "advisor_20260301",
-                "advisor schema must not be sent when inactive",
+                "server-side schema must not be sent when inactive",
             )
             self.assertNotEqual(
                 t.get("name"), "advisor",
-                "advisor name must not appear in tools when inactive",
+                "advisor tool must not appear in tools when inactive",
             )
         sysp = cap.call_kwargs.get("system", "") or ""
         if isinstance(sysp, list):
@@ -275,6 +276,38 @@ class TestAdvisorInactivePaths(unittest.TestCase):
         else:
             sysp_text = sysp
         self.assertNotIn("# Advisor Tool", sysp_text)
+
+    def _assert_server_side_not_sent(self, cap: _Capture) -> None:
+        """Assert SERVER-SIDE artifacts absent — but CLIENT-SIDE may be present."""
+        self.assertNotIn("betas", cap.call_kwargs)
+        tools = cap.call_kwargs.get("tools") or []
+        for t in tools:
+            self.assertNotEqual(
+                t.get("type"), "advisor_20260301",
+                "server-side schema must not leak in client-side mode",
+            )
+
+    def _assert_client_side_active(self, cap: _Capture) -> None:
+        """Assert CLIENT-SIDE: regular-shape advisor tool + instructions."""
+        self._assert_server_side_not_sent(cap)
+        tools = cap.call_kwargs.get("tools") or []
+        advisor_tools = [t for t in tools if t.get("name") == "advisor"]
+        self.assertEqual(
+            len(advisor_tools), 1,
+            "client-side mode must register the regular-tool advisor",
+        )
+        # Regular tool shape — no ``type`` discriminator, just name +
+        # description + input_schema.
+        self.assertNotIn("type", advisor_tools[0])
+        self.assertIn("input_schema", advisor_tools[0])
+        sysp = cap.call_kwargs.get("system", "") or ""
+        if isinstance(sysp, list):
+            sysp_text = "\n".join(
+                b.get("text", "") for b in sysp if isinstance(b, dict)
+            )
+        else:
+            sysp_text = sysp
+        self.assertIn("# Advisor Tool", sysp_text)
 
     def test_no_advisor_when_settings_unset(self) -> None:
         _set_settings(advisor_model="")
@@ -293,30 +326,48 @@ class TestAdvisorInactivePaths(unittest.TestCase):
             _run(provider, [UserMessage(content="x")])
             self._assert_inactive(cap)
 
-    def test_no_advisor_when_anthropic_has_custom_endpoint(self) -> None:
+    def test_no_advisor_when_advisor_model_does_not_route(self) -> None:
+        # An advisor model string that doesn't match any provider's
+        # available_models AND doesn't match a known prefix → no
+        # client-side route → INACTIVE. The strict "valid for
+        # server-side" gate is gone; only the routing gate remains.
+        _set_settings(advisor_model="some-totally-unknown-model-xyz")
+        cap = _Capture()
+        provider = _stub_provider_class(AnthropicProvider, cap)
+        _run(provider, [UserMessage(content="x")])
+        self._assert_inactive(cap)
+
+    def test_client_side_when_anthropic_has_custom_endpoint(self) -> None:
+        # Custom-endpoint Anthropic is treated as 3P for server-side
+        # purposes (no beta header, no advisor_20260301 schema), but
+        # client-side mode covers it now.
         _set_settings(advisor_model="claude-opus-4-6")
         cap = _Capture()
         provider = _stub_provider_class(AnthropicProvider, cap)
-        # Simulate a custom base_url (Bedrock shim, self-hosted proxy).
         provider.has_custom_endpoint = MagicMock(return_value=True)
         _run(provider, [UserMessage(content="x")])
-        self._assert_inactive(cap)
+        self._assert_client_side_active(cap)
 
-    def test_no_advisor_when_base_model_unsupported(self) -> None:
+    def test_client_side_when_base_model_does_not_support_server_side(self) -> None:
+        # opus-4-5 doesn't support the server-side beta — under the
+        # old strict rules, advisor went inactive. Now it falls back to
+        # client-side (any tool-calling main loop works).
         _set_settings(advisor_model="claude-opus-4-6")
         cap = _Capture()
         provider = _stub_provider_class(AnthropicProvider, cap)
-        # Stale main model — advisor must not piggy-back on an older model.
         provider.model = "claude-opus-4-5"
         _run(provider, [UserMessage(content="x")])
-        self._assert_inactive(cap)
+        self._assert_client_side_active(cap)
 
-    def test_no_advisor_when_advisor_model_invalid(self) -> None:
+    def test_client_side_when_advisor_is_haiku(self) -> None:
+        # haiku-4-5 isn't a valid server-side advisor (only opus-4-6 /
+        # sonnet-4-6 are) — but it routes to anthropic and works
+        # client-side.
         _set_settings(advisor_model="claude-haiku-4-5")
         cap = _Capture()
         provider = _stub_provider_class(AnthropicProvider, cap)
         _run(provider, [UserMessage(content="x")])
-        self._assert_inactive(cap)
+        self._assert_client_side_active(cap)
 
     def test_advisor_blocks_stripped_when_inactive(self) -> None:
         # The previous turn left advisor blocks in history, but the


### PR DESCRIPTION
## Summary
- Extends `/advisor` to work on any provider (GLM, Gemini, OpenAI, OpenRouter, Bedrock-shimmed Anthropic, etc.) by adding a **client-side execution path**. The server-side Anthropic beta stays the optimized default when applicable; client-side activates for 3P providers, non-server-side advisor models, or when forced via `--client`.
- New flags: `/advisor <model> --client` (force client-side), `/advisor --no-client` (clear), `/advisor unset` (clear all).
- Now also supports **cross-provider** pairings: e.g. GLM main loop with Anthropic Opus advisor, or Anthropic main with Gemini advisor.

## Mode-decision table

| Provider | Force `--client` | Advisor model | Mode |
|---|---|---|---|
| 1P Anthropic | off | opus-4-6 / sonnet-4-6 | **Server-side** (unchanged, optimal) |
| 1P Anthropic | on | any routable | **Client-side** |
| 1P Anthropic | off | non-server-side (e.g. haiku, gemini) | **Client-side** |
| 3P | n/a | any routable | **Client-side** |
| any | any | unroutable model | Inactive |

## What changes

### Activation
- `decide_advisor_mode(provider, main_model, advisor_model, force_client_mode)` returns `server_side` / `client_side` / `inactive`.
- `infer_provider_for_model(model)` does exact-match in `PROVIDER_INFO`, then well-known prefix fallback (`claude-*` → anthropic, `gemini-*` → gemini, `zai/*` → glm, `<vendor>/*` → openrouter, etc.). Rejects ambiguous strings rather than guessing.

### Client-side path
- `AdvisorTool` registered in `src/tool_system/tools/advisor.py` with `is_enabled=lambda: False` (hidden from `/tools` listings; registry still finds it for dispatch).
- `_call_model_sync` injects the regular-tool-shape schema only when client-side mode is active for the request. Cache-friendly: appended after the regular tools and after the cached system blocks.
- `AdvisorTool.call(input, ctx)` reads `ctx.messages`, strips prior advisor blocks via `build_advisor_forwarded_messages`, calls `execute_client_advisor`.
- `execute_client_advisor` resolves the advisor's provider via the existing `get_provider_class` + `get_provider_config` (reuses user-configured API keys), makes one non-streaming `chat()` call with the advisor's own system prompt and empty tools, returns `(ok, text_or_error)`. Never raises — degrades to a tool_result error on failure.

### `/advisor` command
- Drops strict `is_valid_advisor_model` rejection (the opus-4-6/sonnet-4-6 server-side gate). Now only requires the model to route via `infer_provider_for_model`.
- Parses `--client` / `--no-client` flags (order-insensitive).
- Status output shows the actual mode picked: `Advisor: <model> — active (server-side|client-side|inactive) [--client forced?]`.

### Settings + state
- `SettingsSchema.advisor_client_mode: bool = False`
- `AppState.advisor_client_mode` with `_on_advisor_client_mode_change` (persists to global settings + invalidates cache, matches the existing advisor_model handler pattern).

### TUI
- `AgentBridge._emit_advisor_events` extended: also detects client-side `tool_use(name=\"advisor\")` on assistant messages plus the matching `tool_result` on subsequent user messages. Emits the same `AdvisorEventMessage` types so the existing widget renders both flavors.

### Loosened gates
- `can_user_configure_advisor`: was 1P-only, now env-only. `/advisor` works on any provider.

## Test plan

Verified locally (`/Users/ericlee2/workspace/clawcodex/.venv/bin/pytest`):

- [x] tests/test_advisor_helpers.py — **32 passed** (1 updated: 3P provider now allowed)
- [x] tests/test_advisor_orphan_pairing.py — 6 passed
- [x] tests/test_advisor_chat_response_roundtrip.py — 6 passed
- [x] tests/test_advisor_command.py — **14 passed** (4 updated for new semantics)
- [x] tests/test_advisor_request_wiring.py — **13 passed** (3 inactive cases now correctly activate client-side)
- [x] tests/test_advisor_client_side.py — **30 new tests** (mode decision table, model routing, forwarded message stripping, execute_client_advisor success/failure/empty, AdvisorTool call paths, schema shape)
- [x] tests/test_app_state.py — 16 passed
- [x] tests/integration/test_advisor_smoke.py — 3 passed
- [x] tests/test_tool_system_tools.py + test_tool_registry_pipeline.py — 99 passed (regression)
- [x] tests/test_settings*.py + tests/test_query*.py — 70 passed (regression)
- **Total: 120 advisor tests + 169 collateral tests passed**

## Design choices

1. **Server-side stays the optimized path** — when 1P + valid models, no behavior change. One roundtrip, prompt-cache friendly, beta-header gated.
2. **Cache stability preserved** — both modes append schema + instructions at the end. Toggling `/advisor` doesn't churn the cached prefix.
3. **Reviewer doesn't see its own prior consultations** — `build_advisor_forwarded_messages` strips advisor blocks before forwarding. Each consultation is independent.
4. **Failure mode is degradation** — `execute_client_advisor` catches every exception and surfaces as `is_error=True` tool_result. The turn doesn't die.
5. **Reuses existing provider config** — no new API key surface. The advisor's provider goes through the same registry as the main loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)