### PR TITLE
feat(palette): rich two-column slash-command autocomplete in REPL + TUI

### DIFF
--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -85,6 +85,20 @@ except ModuleNotFoundError:  # pragma: no cover
             raise EOFError()
 
 
+def _fuzzy_subseq(name: str, partial: str) -> bool:
+    """Lightweight subsequence match (``partial`` chars appear in order)."""
+
+    if not partial:
+        return True
+    i = 0
+    for ch in name:
+        if ch == partial[i]:
+            i += 1
+            if i == len(partial):
+                return True
+    return False
+
+
 class _SlashOnlyCompleter(Completer):
     """Trigger autocompletion only for slash commands, matching the reference
     Claude Code behavior.
@@ -98,13 +112,16 @@ class _SlashOnlyCompleter(Completer):
     * In every other case (plain words like ``hello``, ``ex``, etc.) return
       no completions so the user can type freely without a suggestion popup.
 
-    The underlying list of command words is provided as a callable so it can
-    be refreshed dynamically (skills, plugin commands, …) without replacing
-    the completer instance.
+    When a ``suggestions_provider`` is supplied it carries descriptions and
+    optional ``[workflow]`` tags, which surface in the prompt_toolkit menu
+    as ``display_meta`` — the same two-column layout the TS reference uses.
+    The legacy ``words_provider`` is still honoured for callers that only
+    have the flat name list.
     """
 
-    def __init__(self, words_provider):
+    def __init__(self, words_provider, suggestions_provider=None):
         self._words_provider = words_provider
+        self._suggestions_provider = suggestions_provider
 
     def get_completions(self, document, complete_event):  # type: ignore[override]
         text = document.text_before_cursor
@@ -112,6 +129,16 @@ class _SlashOnlyCompleter(Completer):
         if token is None:
             return
         partial = token[1:].lower()  # strip leading '/'
+        start_position = token_start - len(text)
+
+        if self._suggestions_provider is not None:
+            try:
+                suggestions = self._suggestions_provider() or []
+            except Exception:
+                suggestions = []
+            yield from self._rich_completions(suggestions, partial, start_position)
+            return
+
         words = self._words_provider() or []
         seen: set[str] = set()
         for word in words:
@@ -123,12 +150,93 @@ class _SlashOnlyCompleter(Completer):
                 continue
             if not partial or key.startswith(partial):
                 seen.add(key)
-                start_position = token_start - len(text)
                 yield Completion(
                     text=word,
                     start_position=start_position,
                     display=word,
                 )
+
+    def _rich_completions(self, suggestions, partial, start_position):
+        """Yield ``Completion`` entries with ``display`` + ``display_meta``.
+
+        Matches the TS ranking: exact name → exact alias → prefix name →
+        prefix alias → fuzzy. Aliases are surfaced in ``(alias)`` only
+        when the typed prefix matched the alias, so an unmatched partial
+        does not pollute the menu with every alternate name.
+        """
+
+        scored: list[tuple[int, int, Any, str | None]] = []
+        seen: set[str] = set()
+        for idx, sugg in enumerate(suggestions):
+            name = getattr(sugg, "name", None)
+            if not isinstance(name, str) or not name:
+                continue
+            name_lc = name.lower()
+            if name_lc in seen:
+                continue
+            aliases = tuple(getattr(sugg, "aliases", ()) or ())
+            matched_alias: str | None = None
+            rank: int | None = None
+            if not partial:
+                rank = 0
+            elif name_lc == partial:
+                rank = 0
+            else:
+                exact_alias = next(
+                    (a for a in aliases if a.lower() == partial), None
+                )
+                if exact_alias:
+                    rank = 1
+                    matched_alias = exact_alias
+                elif name_lc.startswith(partial):
+                    rank = 2
+                else:
+                    prefix_alias = next(
+                        (a for a in aliases if a.lower().startswith(partial)),
+                        None,
+                    )
+                    if prefix_alias:
+                        rank = 3
+                        matched_alias = prefix_alias
+                    elif _fuzzy_subseq(name_lc, partial):
+                        rank = 5
+                    else:
+                        fuzzy_alias = next(
+                            (a for a in aliases if _fuzzy_subseq(a.lower(), partial)),
+                            None,
+                        )
+                        if fuzzy_alias:
+                            rank = 6
+                            matched_alias = fuzzy_alias
+            if rank is None:
+                continue
+            seen.add(name_lc)
+            secondary = idx if not partial else len(name)
+            scored.append((rank, secondary, sugg, matched_alias))
+
+        scored.sort(key=lambda t: (t[0], t[1], t[2].name.lower()))
+
+        for _, _, sugg, matched_alias in scored:
+            alias_text = f" ({matched_alias})" if matched_alias else ""
+            display_text = f"/{sugg.name}{alias_text}"
+            display_styled = [("class:completion.command", display_text)]
+            description = (getattr(sugg, "description", "") or "").strip()
+            tag = getattr(sugg, "tag", None)
+            meta_parts: list[tuple[str, str]] = []
+            if tag:
+                meta_parts.append(("class:completion.tag", f"[{tag}] "))
+            if description:
+                # Collapse internal whitespace so multi-line descriptions
+                # render as one row in the prompt_toolkit menu.
+                meta_parts.append(
+                    ("class:completion.description", " ".join(description.split()))
+                )
+            yield Completion(
+                text=f"/{sugg.name}",
+                start_position=start_position,
+                display=display_styled,
+                display_meta=meta_parts if meta_parts else None,
+            )
 
     @staticmethod
     def _current_slash_token(text: str) -> tuple[str | None, int]:
@@ -428,7 +536,10 @@ class ClawcodexREPL:
         # interfering with the other's trigger.
         from prompt_toolkit.completion import merge_completers
 
-        self._slash_completer = _SlashOnlyCompleter(self._get_slash_command_words)
+        self._slash_completer = _SlashOnlyCompleter(
+            self._get_slash_command_words,
+            suggestions_provider=self._get_slash_command_suggestions,
+        )
         self._at_completer = AtFileCompleter(
             cwd=str(self.tool_context.workspace_root)
         )
@@ -528,6 +639,18 @@ class ClawcodexREPL:
                 # background highlight.
                 'prompt': 'bold fg:ansiblue bg:#262626',
                 'bottom-toolbar': 'fg:#888888 bg:default',
+                # Slash-command completion menu (two-column layout:
+                # /name on the left, [tag] + description on the right).
+                # Mirrors the TS reference where unselected rows are dim
+                # and the highlighted row inverts on a tinted background.
+                'completion-menu': 'bg:default',
+                'completion-menu.completion': 'fg:#bfbfbf bg:default',
+                'completion-menu.completion.current': 'fg:#ffffff bg:#005f87 bold',
+                'completion-menu.meta.completion': 'fg:#7a7a7a bg:default',
+                'completion-menu.meta.completion.current': 'fg:#dadada bg:#005f87',
+                'completion.command': 'bold fg:ansigreen',
+                'completion.tag': 'italic fg:ansicyan',
+                'completion.description': 'fg:#9a9a9a',
             }),
             key_bindings=self.bindings,
             complete_while_typing=True,
@@ -909,6 +1032,50 @@ class ClawcodexREPL:
             deduped.append(w)
         return deduped
 
+    # REPL-only built-ins not covered by the shared TUI ``LOCAL_BUILTINS``.
+    # Used to seed descriptions for the prompt_toolkit completion menu so
+    # ``/save`` etc. show meta text alongside the registry-backed entries.
+    _REPL_EXTRA_BUILTIN_DESCRIPTIONS: dict[str, str] = {
+        "save": "Save the conversation to a file",
+        "load": "Load a saved conversation",
+        "tool": "Inspect or invoke a single tool",
+        "init": "Initialize a CLAUDE.md for this workspace",
+        "tui": "Switch to the Textual TUI",
+    }
+
+    def _get_slash_command_suggestions(self) -> list[Any]:
+        """Return rich slash-command entries (name + description + tag).
+
+        Drives the prompt_toolkit completion menu's two-column display
+        (command name on the left, description as ``display_meta`` on
+        the right) and stays in lock-step with the TUI palette by
+        reusing :func:`src.tui.commands.build_command_suggestions`. Adds
+        the REPL-only built-ins (``/save``, ``/load``, ``/tool``,
+        ``/init``, ``/tui``) that the shared builder doesn't know about.
+        """
+
+        try:
+            from src.tui.commands import CommandSuggestion, build_command_suggestions
+
+            cwd = self.tool_context.cwd or self.tool_context.workspace_root
+            base = build_command_suggestions(cwd, self.tool_context)
+
+            have = {s.name.lower() for s in base if hasattr(s, "name")}
+            extra: list[Any] = []
+            for name, description in self._REPL_EXTRA_BUILTIN_DESCRIPTIONS.items():
+                if name in have:
+                    continue
+                extra.append(CommandSuggestion(name=name, description=description))
+            # Built-ins lead the menu, then registry/skills (the order
+            # ``build_command_suggestions`` already produces).
+            return [
+                *(s for s in base if getattr(s, "source", "") == "builtin"),
+                *extra,
+                *(s for s in base if getattr(s, "source", "") != "builtin"),
+            ]
+        except Exception:
+            return []
+
     def _refresh_completer(self) -> None:
         # The slash + ``@``-file completers are stable for the lifetime
         # of the REPL: ``_SlashOnlyCompleter`` reads its word list
@@ -925,7 +1092,8 @@ class ClawcodexREPL:
                 )
             if not hasattr(self, "_slash_completer") or self._slash_completer is None:
                 self._slash_completer = _SlashOnlyCompleter(
-                    self._get_slash_command_words
+                    self._get_slash_command_words,
+                    suggestions_provider=self._get_slash_command_suggestions,
                 )
             self.completer = merge_completers(
                 [self._slash_completer, self._at_completer]

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -29,6 +29,8 @@ from .a11y import Announcer, describe_status
 from .agent_bridge import AgentBridge
 from .commands import (
     CommandDispatchResult,
+    CommandSuggestion,
+    build_command_suggestions,
     build_command_words,
     dispatch_local_command,
     dispatch_registry_command,
@@ -190,6 +192,7 @@ class ClawCodexTUI(App):
             model=self.model,
             workspace_root=self.workspace_root,
             words_provider=self._slash_command_words,
+            suggestions_provider=self._slash_command_suggestions,
         )
         self.push_screen(self._repl_screen)
 
@@ -827,6 +830,9 @@ class ClawCodexTUI(App):
 
     def _slash_command_words(self) -> list[str]:
         return build_command_words(self.workspace_root, self.tool_context)
+
+    def _slash_command_suggestions(self) -> list[CommandSuggestion]:
+        return build_command_suggestions(self.workspace_root, self.tool_context)
 
     def _post_to_screen(self, message: Any) -> None:
         target = self._repl_screen or self

--- a/src/tui/commands.py
+++ b/src/tui/commands.py
@@ -78,33 +78,101 @@ class CommandDispatchResult:
     error: str | None = None
 
 
-def build_command_words(
-    workspace_root: Path,
-    tool_context: Any | None = None,
-) -> list[str]:
-    """Return the flat list of slash words shown in the completion popup.
+@dataclass(frozen=True)
+class CommandSuggestion:
+    """A rich slash-command entry shown in the completion popup.
 
-    Sources, in order:
-      * Local built-ins from :data:`LOCAL_BUILTINS`.
-      * Every command registered with :func:`register_builtin_commands`
-        plus any aliases.
-      * Discovered skill names (mirrors the REPL behavior).
+    Mirrors the TS ``SuggestionItem`` shape just enough to render the
+    two-column ``/name  description`` layout. ``tag`` is an optional
+    short label (e.g. ``"workflow"``) and ``aliases`` is the list of
+    alternative names — both surface in the display row.
     """
 
-    words: list[str] = list(LOCAL_BUILTINS)
+    name: str  # without the leading slash
+    description: str = ""
+    aliases: tuple[str, ...] = ()
+    tag: str | None = None
+    source: str = "builtin"
+
+    @property
+    def slash(self) -> str:
+        return f"/{self.name}"
+
+
+_LOCAL_BUILTIN_DESCRIPTIONS: dict[str, str] = {
+    "/help": "Show available slash commands",
+    "/exit": "Exit the CLI",
+    "/quit": "Exit the CLI",
+    "/q": "Exit the CLI",
+    "/repl": "Alias for /exit (kept for parity)",
+    "/clear": "Clear the conversation transcript",
+    "/tools": "List available tools",
+    "/stream": "Toggle streaming output",
+    "/render-last": "Re-render the last assistant message",
+    "/skills": "List discovered skills",
+    "/model": "Choose the active model",
+    "/effort": "Choose reasoning effort",
+    "/history": "Open prompt history",
+    "/cost": "Show session token + cost usage",
+    "/idle": "Configure idle-mode preferences",
+    "/theme": "Change the color theme",
+    "/diff": "Show pending diff",
+    "/mcp": "Manage MCP servers",
+    "/tasks": "Browse background tasks",
+    "/rewind": "Rewind conversation to an earlier turn",
+}
+
+
+def build_command_suggestions(
+    workspace_root: Path,
+    tool_context: Any | None = None,
+) -> list[CommandSuggestion]:
+    """Return rich slash-command entries for the completion popup.
+
+    Mirrors :func:`build_command_words` but carries descriptions,
+    aliases, and tags so the popup can render the same two-column
+    layout the TypeScript reference uses.
+    """
+
+    out: list[CommandSuggestion] = []
+    seen: set[str] = set()
+
+    def push(sugg: CommandSuggestion) -> None:
+        key = sugg.name.lower()
+        if key in seen:
+            return
+        seen.add(key)
+        out.append(sugg)
+
+    for word in LOCAL_BUILTINS:
+        push(
+            CommandSuggestion(
+                name=word[1:],
+                description=_LOCAL_BUILTIN_DESCRIPTIONS.get(word, ""),
+                source="builtin",
+            )
+        )
 
     try:
         from src.command_system.builtins import register_builtin_commands
         from src.command_system.registry import CommandRegistry, get_command_registry
 
-        # The global registry may not have been seeded yet (first TUI
-        # boot), so ensure at least the built-ins are present.
         register_builtin_commands(None)
         registry: CommandRegistry = get_command_registry()
         for cmd in registry.list_commands():
-            words.append(f"/{cmd.name}")
-            for alias in getattr(cmd, "aliases", []) or []:
-                words.append(f"/{alias}")
+            if getattr(cmd, "is_hidden", False):
+                continue
+            aliases = tuple(getattr(cmd, "aliases", []) or [])
+            tag = "workflow" if getattr(cmd, "kind", None) == "workflow" else None
+            push(
+                CommandSuggestion(
+                    name=cmd.name,
+                    description=getattr(cmd, "description", "") or "",
+                    aliases=aliases,
+                    tag=tag,
+                    source=getattr(cmd, "loaded_from", "builtin") or "builtin",
+                )
+            )
     except Exception:
         pass
 
@@ -113,19 +181,40 @@ def build_command_words(
 
         cwd = getattr(tool_context, "cwd", None) or workspace_root
         for skill in get_all_skills(project_root=cwd):
-            words.append(f"/{skill.name}")
+            push(
+                CommandSuggestion(
+                    name=skill.name,
+                    description=getattr(skill, "description", "") or "",
+                    source="skills",
+                )
+            )
     except Exception:
         pass
 
+    return out
+
+
+def build_command_words(
+    workspace_root: Path,
+    tool_context: Any | None = None,
+) -> list[str]:
+    """Return the flat list of slash words shown in the completion popup.
+
+    Kept as a backwards-compatible wrapper around
+    :func:`build_command_suggestions`. New callers should prefer the
+    rich variant so descriptions surface in the popup.
+    """
+
+    words: list[str] = []
     seen: set[str] = set()
-    deduped: list[str] = []
-    for word in words:
-        key = word.lower()
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(word)
-    return deduped
+    for sugg in build_command_suggestions(workspace_root, tool_context):
+        for w in (sugg.slash, *(f"/{a}" for a in sugg.aliases)):
+            key = w.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            words.append(w)
+    return words
 
 
 def dispatch_local_command(

--- a/src/tui/screens/repl.py
+++ b/src/tui/screens/repl.py
@@ -46,6 +46,7 @@ from ..widgets.transcript_view import Transcript
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..app import ClawCodexTUI
+    from ..commands import CommandSuggestion
 
 
 class REPLScreen(Screen):
@@ -69,6 +70,7 @@ class REPLScreen(Screen):
         model: str,
         workspace_root: Path,
         words_provider: Callable[[], list[str]],
+        suggestions_provider: Callable[[], list["CommandSuggestion"]] | None = None,
     ) -> None:
         super().__init__()
         self._version = version
@@ -76,6 +78,7 @@ class REPLScreen(Screen):
         self._model = model
         self._workspace_root = Path(workspace_root)
         self._words_provider = words_provider
+        self._suggestions_provider = suggestions_provider
 
         self.header_widget = StartupHeader(
             version=version,
@@ -89,7 +92,10 @@ class REPLScreen(Screen):
             model=model,
             workspace_root=self._workspace_root,
         )
-        self.prompt_input = PromptInput(words_provider=words_provider)
+        self.prompt_input = PromptInput(
+            words_provider=words_provider,
+            suggestions_provider=suggestions_provider,
+        )
         # ARIA live region — stays height: 1 and only announces the
         # most recent status change. Mounted just above the status
         # bar so it's adjacent to the prompt for single-sweep reads.

--- a/src/tui/widgets/prompt_input.py
+++ b/src/tui/widgets/prompt_input.py
@@ -20,8 +20,9 @@ Phase 2 to swap in a ``TextArea`` without changing the public surface.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from typing import Any, Callable
 
+from rich.text import Text
 from textual import events
 from textual.app import ComposeResult
 from textual.containers import Vertical
@@ -29,6 +30,7 @@ from textual.message import Message
 from textual.widgets import Input, OptionList
 from textual.widgets.option_list import Option
 
+from ..commands import CommandSuggestion
 from ..messages import CancelRequested, PromptPasted
 from ..paste import PasteInfo, classify_paste
 from ..vim import VimState
@@ -87,12 +89,24 @@ class _PasteAwareInput(Input):
         super()._on_paste(event)
 
 
+_NAME_COLUMN_WIDTH = 22  # left column reserved for "/name (alias)"
+_MAX_VISIBLE_SUGGESTIONS = 10
+
+
 class _SlashSuggestions(OptionList):
     DEFAULT_CSS = """
     _SlashSuggestions {
         max-height: 10;
-        border: round $primary;
-        background: $surface;
+        border: none;
+        padding: 0;
+        background: $background;
+    }
+    _SlashSuggestions > .option-list--option {
+        padding: 0 1;
+    }
+    _SlashSuggestions > .option-list--option-highlighted {
+        background: $boost;
+        text-style: bold;
     }
     _SlashSuggestions.-hidden {
         display: none;
@@ -122,10 +136,12 @@ class PromptInput(Vertical):
         self,
         *,
         words_provider: Callable[[], list[str]],
+        suggestions_provider: Callable[[], list[CommandSuggestion]] | None = None,
         vim_mode: bool = False,
     ) -> None:
         super().__init__()
         self._words_provider = words_provider
+        self._suggestions_provider = suggestions_provider
         self._history: list[str] = []
         self._history_pos: int | None = None
         self._input = _PasteAwareInput(placeholder="Type a prompt, or / for commands")
@@ -355,28 +371,34 @@ class PromptInput(Vertical):
             self._hide_suggestions()
             return
         partial = token[1:].lower()
-        words = self._words_provider() or []
-        matches: list[str] = []
-        seen: set[str] = set()
-        for word in words:
-            if not isinstance(word, str) or not word.startswith("/"):
-                continue
-            name = word[1:]
-            key = name.lower()
-            if key in seen:
-                continue
-            if not partial or _fuzzy_match(key, partial):
-                seen.add(key)
-                matches.append(word)
-                if len(matches) >= 12:
-                    break
-        if not matches:
+
+        options = self._build_suggestion_options(partial)
+        if not options:
             self._hide_suggestions()
             return
         self._suggestions.clear_options()
-        self._suggestions.add_options([Option(word, id=word) for word in matches])
+        self._suggestions.add_options(options)
         self._suggestions.highlighted = 0
         self._suggestions.remove_class("-hidden")
+
+    def _build_suggestion_options(self, partial: str) -> list[Option]:
+        """Return the rich Option rows to show under the prompt.
+
+        Prefers the rich ``suggestions_provider`` (two-column ``/name +
+        description`` layout to match the TS reference); falls back to
+        the ``words_provider`` string list when no rich source exists
+        (legacy tests, embedded uses).
+        """
+
+        if self._suggestions_provider is not None:
+            try:
+                suggestions = self._suggestions_provider() or []
+            except Exception:
+                suggestions = []
+            return _options_from_suggestions(suggestions, partial)
+
+        words = self._words_provider() or []
+        return _options_from_words(words, partial)
 
     def _hide_suggestions(self) -> None:
         if not self._suggestions.has_class("-hidden"):
@@ -402,6 +424,135 @@ class PromptInput(Vertical):
                 return
         self._input.value = self._history[self._history_pos]
         self._input.cursor_position = len(self._input.value)
+
+
+def _options_from_suggestions(
+    suggestions: list[CommandSuggestion],
+    partial: str,
+) -> list[Option]:
+    """Filter + rank rich command suggestions, then render two-column rows.
+
+    Sort order matches the TS ranking spirit: exact name → exact alias
+    → prefix name → prefix alias → fuzzy subsequence. Duplicates (same
+    name) are collapsed; aliases are surfaced only when the user typed
+    them so an unmatched ``/com<TAB>`` does not get polluted with the
+    full alias list.
+    """
+
+    scored: list[tuple[int, int, CommandSuggestion, str | None]] = []
+    seen: set[str] = set()
+    for idx, sugg in enumerate(suggestions):
+        if not isinstance(sugg, CommandSuggestion):
+            continue
+        name_lc = sugg.name.lower()
+        if name_lc in seen:
+            continue
+        matched_alias: str | None = None
+        rank: int | None = None
+        if not partial:
+            # Preserve the provider's order — built-ins first, then
+            # skills — by collapsing every entry into one rank bucket
+            # and tiebreaking on the insertion index below.
+            rank = 0
+        elif name_lc == partial:
+            rank = 0
+        else:
+            alias_exact = next(
+                (a for a in sugg.aliases if a.lower() == partial), None
+            )
+            if alias_exact:
+                rank = 1
+                matched_alias = alias_exact
+            elif name_lc.startswith(partial):
+                rank = 2
+            else:
+                alias_prefix = next(
+                    (a for a in sugg.aliases if a.lower().startswith(partial)),
+                    None,
+                )
+                if alias_prefix:
+                    rank = 3
+                    matched_alias = alias_prefix
+                elif _fuzzy_match(name_lc, partial):
+                    rank = 5
+                else:
+                    alias_fuzzy = next(
+                        (a for a in sugg.aliases if _fuzzy_match(a.lower(), partial)),
+                        None,
+                    )
+                    if alias_fuzzy:
+                        rank = 6
+                        matched_alias = alias_fuzzy
+        if rank is None:
+            continue
+        seen.add(name_lc)
+        # Tiebreak: for an empty partial preserve insertion order so
+        # built-ins lead skills; otherwise shorter names (closer to
+        # the typed prefix) sort first, then alphabetically.
+        secondary = idx if not partial else len(sugg.name)
+        scored.append((rank, secondary, sugg, matched_alias))
+
+    scored.sort(key=lambda t: (t[0], t[1], t[2].name.lower()))
+    scored = scored[:_MAX_VISIBLE_SUGGESTIONS]
+    return [
+        Option(_render_suggestion_row(sugg, matched_alias), id=sugg.slash)
+        for _, _, sugg, matched_alias in scored
+    ]
+
+
+def _options_from_words(words: list[Any], partial: str) -> list[Option]:
+    """Fallback renderer for the legacy ``words_provider`` path.
+
+    Produces the same plain ``/name`` rows the older popup used, with
+    the same fuzzy filter — so older callers / tests keep working
+    while richer surfaces opt into the two-column layout.
+    """
+
+    matches: list[str] = []
+    seen: set[str] = set()
+    for word in words:
+        if not isinstance(word, str) or not word.startswith("/"):
+            continue
+        key = word[1:].lower()
+        if key in seen:
+            continue
+        if not partial or _fuzzy_match(key, partial):
+            seen.add(key)
+            matches.append(word)
+            if len(matches) >= _MAX_VISIBLE_SUGGESTIONS:
+                break
+    return [Option(word, id=word) for word in matches]
+
+
+def _render_suggestion_row(
+    sugg: CommandSuggestion,
+    matched_alias: str | None,
+) -> Text:
+    """Render one slash-command row as a Rich ``Text`` with two columns.
+
+    Column 1: ``/name`` (plus ``(alias)`` if the user typed an alias),
+    padded to :data:`_NAME_COLUMN_WIDTH`. Column 2: optional
+    ``[tag]`` then the command description. The whole row is dim by
+    default; OptionList's highlighted-row CSS overlays bold + boost
+    background on the selected entry (see ``_SlashSuggestions``).
+    """
+
+    alias_text = f" ({matched_alias})" if matched_alias else ""
+    name_segment = f"{sugg.slash}{alias_text}"
+    if len(name_segment) > _NAME_COLUMN_WIDTH - 1:
+        name_segment = name_segment[: _NAME_COLUMN_WIDTH - 2] + "…"
+    pad = max(1, _NAME_COLUMN_WIDTH - len(name_segment))
+
+    row = Text(no_wrap=True, overflow="ellipsis", style="dim")
+    row.append(name_segment, style="bold")
+    row.append(" " * pad)
+    if sugg.tag:
+        row.append(f"[{sugg.tag}] ", style="italic cyan")
+    if sugg.description:
+        # Collapse internal whitespace so multi-line descriptions render
+        # cleanly on a single row (the OptionList truncates with "…").
+        row.append(" ".join(sugg.description.split()))
+    return row
 
 
 def _fuzzy_match(name: str, partial: str) -> bool:


### PR DESCRIPTION
## Summary
- Default REPL (prompt_toolkit) and Textual TUI now render slash-command autocomplete with the same two-column look as the TS reference: `/command` on the left, description (plus optional `[workflow]` tag) on the right.
- Single source of truth: new `build_command_suggestions()` in `src/tui/commands.py` feeds both surfaces, pulling descriptions/aliases/tags from `LOCAL_BUILTINS`, the command registry, and discovered skills.
- Default REPL: `_SlashOnlyCompleter` now yields `Completion(display=..., display_meta=...)` with ranking exact-name → exact-alias → prefix-name → prefix-alias → fuzzy. Added `completion-menu*` styles so the menu reads bold-green name + dim description, with the highlighted row inverting on a tinted background.
- Textual TUI: `_SlashSuggestions` is now borderless with `$boost` highlight; rows are built from a Rich `Text` with a left column (`/name (alias)` padded to 22 chars, bold) and right column (`[tag]` italic-cyan + dim description).
- Backwards compatible: the old `words_provider` path still works for callers / tests that only have flat name lists.

## Test plan
- [x] `uv run pytest tests/test_slash_completer.py tests/tui/ tests/test_command_system.py` — 560 passed
- [ ] Manually open the default REPL: type `/` and confirm two-column menu with descriptions
- [ ] Manually open the TUI (`/tui`): type `/` and confirm borderless inline list with descriptions and highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)