### PR TITLE
feat(consolidate): route headless+TUI through canonical query() loop

### DIFF
--- a/src/agent/conversation.py
+++ b/src/agent/conversation.py
@@ -26,7 +26,20 @@ from ..types.messages import (
 @dataclass
 class Conversation:
     messages: list[Message] = field(default_factory=list)
-    max_history: int = 100
+    # Bumped from 100 to 2000 (critic ch05/F-consolidation S2).
+    # The headless+TUI cutover routes tool_use AND tool_result blocks
+    # through ``add_message`` separately (multiple messages per agent
+    # turn), so a 30-turn run with ~3 tools/turn produces ~120 messages
+    # per single user prompt — well past the old 100-cap. The cap
+    # silently truncates from the head, which removes the ORIGINAL
+    # user prompt; subsequent API calls go out without the task
+    # description and the model degrades. 2000 is enough to cover a
+    # long agentic session without changing the truncation semantics;
+    # if a deployment needs unbounded history it can override at
+    # construction. Compaction (``CompressionPipeline`` /
+    # ``/compact``) is the right tool for serious context management;
+    # this cap is just a memory-safety backstop.
+    max_history: int = 2000
 
     def add_message(self, role: str, content: MessageContent):
         if len(self.messages) >= self.max_history:

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -296,10 +296,21 @@ def run_headless(options: HeadlessOptions) -> int:
                             # so the next turn can pair tool_use IDs to
                             # results. Plain add_assistant_message
                             # loses the structure.
+                            # Critic S3: log + re-raise on failure
+                            # rather than swallow; a persist error
+                            # means the conversation is corrupted and
+                            # the next API call will reject it. Better
+                            # to surface now than to debug a 400 later.
                             try:
                                 session.conversation.add_message(msg.role, msg.content)
                             except Exception:
-                                pass
+                                import logging
+                                logging.getLogger(__name__).exception(
+                                    "Failed to persist message into "
+                                    "conversation: role=%s",
+                                    getattr(msg, "role", "?"),
+                                )
+                                raise
 
                         compat_result = _asyncio.run(run_query_as_agent_loop(
                             initial_messages=list(session.conversation.messages),
@@ -311,7 +322,13 @@ def run_headless(options: HeadlessOptions) -> int:
                             on_event=on_event,
                             on_text_chunk=on_text_chunk,
                             on_message=_persist,
-                            cancel_signal=abort_controller.signal,
+                            # Critic C2: pass the OWNING controller so
+                            # the provider's chat_stream_response listens
+                            # on the same signal the SIGINT handler trips.
+                            # Passing only ``cancel_signal=signal`` would
+                            # force the adapter to mint a fresh controller
+                            # and break the mid-stream tear-down path.
+                            abort_controller=abort_controller,
                         ))
                         # Re-wrap into legacy AgentLoopResult shape so
                         # downstream usage/num_turns/response_text code

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -48,7 +48,13 @@ from src.cli_core import (
 )
 from src.config import get_default_provider, get_provider_config
 from src.providers import get_provider_class
-from src.tool_system.agent_loop import ToolEvent, run_agent_loop
+from src.tool_system.agent_loop import (
+    AgentLoopResult,
+    ToolEvent,
+    _build_effective_system_prompt,
+    run_agent_loop,
+)
+from src.query.agent_loop_compat import run_query_as_agent_loop
 from src.tool_system.context import ToolContext
 from src.tool_system.defaults import build_default_registry
 from src.utils.abort_controller import AbortController, AbortError
@@ -265,17 +271,60 @@ def run_headless(options: HeadlessOptions) -> int:
                 try:
                     in_agent_loop.value = True
                     try:
-                        result = run_agent_loop(
-                            conversation=session.conversation,
+                        # Ch5/F.2 cutover: route headless through the
+                        # canonical query() loop via the F.1 adapter.
+                        # Headless is single-shot per prompt and starts
+                        # its own event loop, so ``asyncio.run`` is the
+                        # right pattern. Pre-build the effective system
+                        # prompt (CLAUDE.md + git status + style) so the
+                        # cold-start context reaches query() unchanged
+                        # — the legacy run_agent_loop did this inside
+                        # the loop; the adapter doesn't.
+                        import asyncio as _asyncio
+                        from src.outputStyles import resolve_output_style
+                        _style_prompt = resolve_output_style(
+                            getattr(tool_context, "output_style_name", None),
+                            getattr(tool_context, "output_style_dir", None),
+                        ).prompt
+                        effective_system_prompt = (
+                            _build_effective_system_prompt(_style_prompt, tool_context)
+                        )
+
+                        def _persist(msg: Any) -> None:
+                            # BLOCKING #2 fix: persist FULL message
+                            # (including tool_use/tool_result blocks)
+                            # so the next turn can pair tool_use IDs to
+                            # results. Plain add_assistant_message
+                            # loses the structure.
+                            try:
+                                session.conversation.add_message(msg.role, msg.content)
+                            except Exception:
+                                pass
+
+                        compat_result = _asyncio.run(run_query_as_agent_loop(
+                            initial_messages=list(session.conversation.messages),
                             provider=provider,
                             tool_registry=tool_registry,
                             tool_context=tool_context,
+                            system_prompt=effective_system_prompt,
                             max_turns=options.max_turns,
-                            stream=bool(on_text_chunk),
-                            verbose=options.verbose,
                             on_event=on_event,
                             on_text_chunk=on_text_chunk,
+                            on_message=_persist,
                             cancel_signal=abort_controller.signal,
+                        ))
+                        # Re-wrap into legacy AgentLoopResult shape so
+                        # downstream usage/num_turns/response_text code
+                        # stays untouched. ``usage if num_turns > 0
+                        # else None`` preserves the dict|None contract.
+                        result = AgentLoopResult(
+                            response_text=compat_result.response_text,
+                            usage=(
+                                compat_result.usage
+                                if compat_result.num_turns > 0
+                                else None
+                            ),
+                            num_turns=compat_result.num_turns,
                         )
                     finally:
                         # Flip BEFORE the outer except block can run so a

--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -39,8 +39,13 @@ from .query import QueryParams, StreamEvent, query
 from .transitions import Terminal, TerminalHolder
 
 
-# Re-use the existing ToolEvent + handler typedefs so callers don't
-# have to refactor their event-handling code.
+# Re-use the renderer types + helpers. Post Ch5/F.4 the canonical
+# home is ``src/tui/tool_summary_renderers.py``; we still import via
+# ``src.tool_system.agent_loop`` because ``src/tui/__init__.py``
+# pulls in the full TUI app graph (app → agent_bridge →
+# agent_loop_compat) and that creates a circular import. The
+# tool_system.agent_loop re-export is back-compat-stable; both paths
+# resolve to the same objects.
 from ..tool_system.agent_loop import (
     ToolEvent,
     ToolEventHandler,
@@ -73,6 +78,7 @@ async def run_query_as_agent_loop(
     max_turns: int = 20,
     on_event: ToolEventHandler | None = None,
     on_text_chunk: TextChunkHandler | None = None,
+    on_message: Callable[[Message], None] | None = None,
     cancel_signal: AbortSignal | None = None,
     abort_controller: AbortController | None = None,
 ) -> AgentLoopRunResult:
@@ -85,9 +91,19 @@ async def run_query_as_agent_loop(
 
     The ``on_event`` callback receives :class:`ToolEvent` instances
     for every tool_use observed in the model's responses and every
-    tool_result yielded by the loop. ``on_text_chunk`` receives the
-    assistant text in chunks (currently the whole text on
-    completion, since streaming-text-chunk wiring is provider-side).
+    tool_result yielded by the loop.
+
+    ``on_text_chunk`` is forwarded into the QueryParams so the
+    provider's streaming layer fires text chunks LIVE (per-delta).
+    Callers MUST provide this if they need real-time text rendering
+    (TUI live streaming, ESC-mid-stream cancel teardown).
+
+    ``on_message`` is fired for EVERY :class:`Message` yielded by the
+    loop (Anthropic-shape AssistantMessage with full content blocks
+    including tool_use, UserMessage with tool_result blocks, etc.).
+    Use this to persist the full conversation transcript faithfully —
+    `response_text` alone loses tool_use/tool_result structure across
+    multi-turn sessions.
 
     ``cancel_signal`` is bridged into the loop's abort_controller so
     user-initiated cancels (Ctrl+C, /exit) propagate cleanly. When
@@ -107,6 +123,13 @@ async def run_query_as_agent_loop(
         provider=provider,
         abort_controller=abort_controller,
         max_turns=max_turns,
+        # Critic-flagged: forward on_text_chunk into QueryParams so
+        # the provider's chat_stream_response fires chunks LIVE. The
+        # adapter must NOT call on_text_chunk(full_text) once at the
+        # end — that breaks TUI live streaming AND the
+        # ESC-mid-stream-cancel path which relies on the chunk
+        # callback raising AbortError from inside the SDK stream.
+        on_text_chunk=on_text_chunk,
     )
 
     holder = TerminalHolder()
@@ -129,6 +152,12 @@ async def run_query_as_agent_loop(
                 )
 
         if isinstance(msg, AssistantMessage):
+            # Fire on_message FIRST so callers can persist the full
+            # message (tool_use blocks intact). Otherwise multi-turn
+            # sessions lose Anthropic's tool_use → tool_result
+            # pairings between turns.
+            if on_message is not None:
+                on_message(msg)
             num_turns += 1
             # Sum usage across turns.
             mu = getattr(msg, "usage", None) or {}
@@ -152,25 +181,36 @@ async def run_query_as_agent_loop(
                         ))
             if text_parts:
                 last_assistant_text = " ".join(text_parts).strip()
-                if on_text_chunk is not None and last_assistant_text:
-                    on_text_chunk(last_assistant_text)
+                # NB: do NOT fire on_text_chunk here. It was already
+                # fired LIVE by the provider's chat_stream_response
+                # via QueryParams.on_text_chunk threading. Firing
+                # again would duplicate the entire response into the
+                # caller's stream.
             continue
 
-        if isinstance(msg, UserMessage) and on_event is not None:
+        if isinstance(msg, UserMessage):
             # Tool result(s) arrive as UserMessages with ToolResultBlock
-            # content. Dispatch as tool_result events.
+            # content. Persist the full message (so the next turn's
+            # API call can pair tool_use IDs to their results) AND
+            # dispatch tool_result events.
             content = msg.content
             if isinstance(content, list):
-                for block in content:
-                    if isinstance(block, ToolResultBlock):
-                        on_event(ToolEvent(
-                            kind="tool_result",
-                            tool_name="",
-                            tool_use_id=block.tool_use_id,
-                            tool_output=block.content,
-                            is_error=bool(block.is_error),
-                            error=str(block.content) if block.is_error else None,
-                        ))
+                has_tool_result = any(
+                    isinstance(block, ToolResultBlock) for block in content
+                )
+                if has_tool_result and on_message is not None:
+                    on_message(msg)
+                if on_event is not None:
+                    for block in content:
+                        if isinstance(block, ToolResultBlock):
+                            on_event(ToolEvent(
+                                kind="tool_result",
+                                tool_name="",
+                                tool_use_id=block.tool_use_id,
+                                tool_output=block.content,
+                                is_error=bool(block.is_error),
+                                error=str(block.content) if block.is_error else None,
+                            ))
 
     response_text = last_assistant_text or " ".join(response_text_parts).strip()
     return AgentLoopRunResult(

--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -33,7 +33,7 @@ from ..types.messages import (
     Message,
     UserMessage,
 )
-from ..utils.abort_controller import AbortController, AbortSignal
+from ..utils.abort_controller import AbortController, AbortError, AbortSignal
 
 from .query import QueryParams, StreamEvent, query
 from .transitions import Terminal, TerminalHolder
@@ -109,10 +109,27 @@ async def run_query_as_agent_loop(
     user-initiated cancels (Ctrl+C, /exit) propagate cleanly. When
     not supplied, the function constructs its own AbortController.
     """
-    abort_controller = abort_controller or AbortController()
-    if cancel_signal is not None and cancel_signal.aborted:
-        # Pre-cancel — bridge the abort upfront so the loop exits early.
-        abort_controller.abort(cancel_signal.reason or "user_interrupt")
+    # Critic C2 fix: do NOT mint a fresh controller when the caller
+    # provided one. The provider's chat_stream_response listens on
+    # ``QueryParams.abort_controller.signal`` to tear down HTTP streams
+    # mid-flight on ESC. A fresh controller breaks that wiring — ESC
+    # would flip the user's signal but the provider would never see it
+    # because the per-message bridge below only fires when query()
+    # yields a message, and a tool-use-only turn yields nothing during
+    # the multi-second generation. Caller's controller IS the user's
+    # signal source; reuse it.
+    if abort_controller is None:
+        if cancel_signal is not None:
+            # We received only the signal, not its owning controller.
+            # Mint a new controller and bridge cancellation into it
+            # both pre- and per-iteration (legacy fallback path).
+            abort_controller = AbortController()
+            if cancel_signal.aborted:
+                abort_controller.abort(
+                    cancel_signal.reason or "user_interrupt"
+                )
+        else:
+            abort_controller = AbortController()
 
     params = QueryParams(
         messages=list(initial_messages),
@@ -152,12 +169,21 @@ async def run_query_as_agent_loop(
                 )
 
         if isinstance(msg, AssistantMessage):
-            # Fire on_message FIRST so callers can persist the full
-            # message (tool_use blocks intact). Otherwise multi-turn
-            # sessions lose Anthropic's tool_use → tool_result
-            # pairings between turns.
-            if on_message is not None:
+            # Critic S1 fix: skip persisting API-error messages and
+            # meta messages. The legacy run_agent_loop never added
+            # these to the user's Conversation — letting them through
+            # poisons multi-prompt sessions (the model sees prior
+            # error text as its own past output, and PTL errors
+            # persisted as assistant messages fertilize a PTL death
+            # spiral on the next turn).
+            _is_api_error = bool(getattr(msg, "isApiErrorMessage", False))
+            _is_meta = bool(getattr(msg, "isMeta", False))
+            if on_message is not None and not _is_api_error and not _is_meta:
                 on_message(msg)
+            if _is_api_error:
+                # Don't count error turns or surface their text as the
+                # "response" — those are exit signals, not output.
+                continue
             num_turns += 1
             # Sum usage across turns.
             mu = getattr(msg, "usage", None) or {}
@@ -192,7 +218,11 @@ async def run_query_as_agent_loop(
             # Tool result(s) arrive as UserMessages with ToolResultBlock
             # content. Persist the full message (so the next turn's
             # API call can pair tool_use IDs to their results) AND
-            # dispatch tool_result events.
+            # dispatch tool_result events. Skip meta (interruption /
+            # cancellation synthesized by query.py) — those are loop
+            # bookkeeping, not real user turns.
+            if bool(getattr(msg, "isMeta", False)):
+                continue
             content = msg.content
             if isinstance(content, list):
                 has_tool_result = any(
@@ -211,6 +241,23 @@ async def run_query_as_agent_loop(
                                 is_error=bool(block.is_error),
                                 error=str(block.content) if block.is_error else None,
                             ))
+
+    # Critic C1 fix: surface terminal abort/error reasons as exceptions
+    # so callers' existing ``except AbortError`` / ``except Exception``
+    # paths fire. Without this, ESC during the loop sets a Terminal but
+    # the adapter returns normally — headless reports exit 0 instead of
+    # 130 with subtype:cancelled, TUI shows a blank response instead of
+    # "Cancelled by user". Mirrors the AbortError raise legacy
+    # run_agent_loop did at agent_loop.py:345-347.
+    terminal = holder.value
+    if terminal is not None:
+        reason = getattr(terminal, "reason", None) or ""
+        if reason in ("aborted_streaming", "aborted_tools", "interrupted"):
+            raise AbortError(
+                getattr(abort_controller.signal, "reason", None)
+                or reason
+                or "user_interrupt"
+            )
 
     response_text = last_assistant_text or " ".join(response_text_parts).strip()
     return AgentLoopRunResult(

--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -1,0 +1,181 @@
+"""Ch5/F.1 — compatibility adapter from query() → AgentLoopResult shape.
+
+The headless and TUI production paths currently invoke
+``run_agent_loop()`` (synchronous, no recovery ladder, no stop hooks,
+no token budget). This adapter wraps the canonical ``query()`` async
+generator and exposes the same return shape as ``run_agent_loop``, so
+callers can migrate one entry point at a time.
+
+Per the refactoring plan's F.3 critic-revised decision:
+  * **Headless callers** (single-shot ``claude -p``) should wrap the
+    adapter in ``asyncio.run()`` — the entry already starts its own
+    event loop and runs to completion.
+  * **TUI callers** (Textual ``@work(thread=True)`` workers) should
+    invoke the adapter via ``asyncio.new_event_loop()`` inside the
+    worker thread so the UI's event loop stays free. Do NOT use
+    ``@work(thread=False)`` — it would put the loop on Textual's
+    main event loop and block UI rendering during model streams.
+
+The adapter does NOT touch ``run_agent_loop`` itself; existing call
+sites continue to work until they're migrated.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from ..tool_system.context import ToolContext
+from ..tool_system.registry import ToolRegistry
+from ..providers.base import BaseProvider
+from ..types.content_blocks import TextBlock, ToolUseBlock, ToolResultBlock
+from ..types.messages import (
+    AssistantMessage,
+    Message,
+    UserMessage,
+)
+from ..utils.abort_controller import AbortController, AbortSignal
+
+from .query import QueryParams, StreamEvent, query
+from .transitions import Terminal, TerminalHolder
+
+
+# Re-use the existing ToolEvent + handler typedefs so callers don't
+# have to refactor their event-handling code.
+from ..tool_system.agent_loop import (
+    ToolEvent,
+    ToolEventHandler,
+    TextChunkHandler,
+    summarize_tool_use,
+    summarize_tool_result,
+)
+
+
+@dataclass(frozen=True)
+class AgentLoopRunResult:
+    """Adapter result shape. Mirrors the existing
+    :class:`src.tool_system.agent_loop.AgentLoopResult` for callers
+    that previously consumed ``run_agent_loop``, AND adds a typed
+    ``terminal`` so wrappers can discriminate exit reason.
+    """
+    response_text: str
+    usage: dict[str, int]
+    num_turns: int
+    terminal: Terminal | None = None
+
+
+async def run_query_as_agent_loop(
+    *,
+    initial_messages: list[Message],
+    provider: BaseProvider,
+    tool_registry: ToolRegistry,
+    tool_context: ToolContext,
+    system_prompt: str | list[dict[str, Any]] = "You are a helpful assistant.",
+    max_turns: int = 20,
+    on_event: ToolEventHandler | None = None,
+    on_text_chunk: TextChunkHandler | None = None,
+    cancel_signal: AbortSignal | None = None,
+    abort_controller: AbortController | None = None,
+) -> AgentLoopRunResult:
+    """Drive the canonical query() loop and adapt to AgentLoopResult.
+
+    Parameters mirror the existing ``run_agent_loop`` signature where
+    practical, but the adapter takes ``initial_messages`` directly
+    instead of a ``Conversation`` — the typed messages are the same
+    shape query() consumes natively.
+
+    The ``on_event`` callback receives :class:`ToolEvent` instances
+    for every tool_use observed in the model's responses and every
+    tool_result yielded by the loop. ``on_text_chunk`` receives the
+    assistant text in chunks (currently the whole text on
+    completion, since streaming-text-chunk wiring is provider-side).
+
+    ``cancel_signal`` is bridged into the loop's abort_controller so
+    user-initiated cancels (Ctrl+C, /exit) propagate cleanly. When
+    not supplied, the function constructs its own AbortController.
+    """
+    abort_controller = abort_controller or AbortController()
+    if cancel_signal is not None and cancel_signal.aborted:
+        # Pre-cancel — bridge the abort upfront so the loop exits early.
+        abort_controller.abort(cancel_signal.reason or "user_interrupt")
+
+    params = QueryParams(
+        messages=list(initial_messages),
+        system_prompt=system_prompt,
+        tools=tool_registry.list_tools(),
+        tool_registry=tool_registry,
+        tool_use_context=tool_context,
+        provider=provider,
+        abort_controller=abort_controller,
+        max_turns=max_turns,
+    )
+
+    holder = TerminalHolder()
+    response_text_parts: list[str] = []
+    usage: dict[str, int] = {"input_tokens": 0, "output_tokens": 0}
+    num_turns = 0
+    last_assistant_text = ""
+
+    async for msg in query(params, terminal_holder=holder):
+        if isinstance(msg, StreamEvent):
+            continue
+
+        # Bridge cancel_signal: if it fires mid-stream, propagate to
+        # the loop's abort_controller. The loop checks signal.aborted
+        # at iteration boundaries so the next check will exit.
+        if cancel_signal is not None and cancel_signal.aborted:
+            if not abort_controller.signal.aborted:
+                abort_controller.abort(
+                    cancel_signal.reason or "user_interrupt"
+                )
+
+        if isinstance(msg, AssistantMessage):
+            num_turns += 1
+            # Sum usage across turns.
+            mu = getattr(msg, "usage", None) or {}
+            usage["input_tokens"] += mu.get("input_tokens", 0)
+            usage["output_tokens"] += mu.get("output_tokens", 0)
+            # Capture text content and tool_use events.
+            text_parts: list[str] = []
+            content = msg.content
+            if isinstance(content, str):
+                text_parts.append(content)
+            else:
+                for block in content:
+                    if isinstance(block, TextBlock):
+                        text_parts.append(block.text)
+                    elif isinstance(block, ToolUseBlock) and on_event is not None:
+                        on_event(ToolEvent(
+                            kind="tool_use",
+                            tool_name=block.name,
+                            tool_input=block.input,
+                            tool_use_id=block.id,
+                        ))
+            if text_parts:
+                last_assistant_text = " ".join(text_parts).strip()
+                if on_text_chunk is not None and last_assistant_text:
+                    on_text_chunk(last_assistant_text)
+            continue
+
+        if isinstance(msg, UserMessage) and on_event is not None:
+            # Tool result(s) arrive as UserMessages with ToolResultBlock
+            # content. Dispatch as tool_result events.
+            content = msg.content
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, ToolResultBlock):
+                        on_event(ToolEvent(
+                            kind="tool_result",
+                            tool_name="",
+                            tool_use_id=block.tool_use_id,
+                            tool_output=block.content,
+                            is_error=bool(block.is_error),
+                            error=str(block.content) if block.is_error else None,
+                        ))
+
+    response_text = last_assistant_text or " ".join(response_text_parts).strip()
+    return AgentLoopRunResult(
+        response_text=response_text,
+        usage=usage,
+        num_turns=num_turns,
+        terminal=holder.value,
+    )

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -71,6 +71,15 @@ class QueryParams:
     user_context: dict[str, str] | None = None
     system_context: dict[str, str] | None = None
     pipeline_config: PipelineConfig | None = None
+    # Ch5/F-followup: live streaming text callback. When set, the
+    # provider's chat_stream_response receives this callback so each
+    # SSE text-delta drives the UI in real time. Critical for the
+    # TUI/headless live-stream UX after the F.2/F.3 migration to this
+    # loop — without it, callers see the entire response materialize
+    # at once after the model turn completes. The callback can also
+    # raise AbortError from inside the SDK's stream context to tear
+    # down the HTTP socket on ESC.
+    on_text_chunk: Callable[[str], None] | None = None
 
 
 @dataclass
@@ -284,6 +293,7 @@ async def _call_model_sync(
     tools: Tools,
     max_output_tokens_override: int | None = None,
     abort_signal: Any = None,
+    on_text_chunk: Callable[[str], None] | None = None,
 ) -> tuple[list[AssistantMessage], list[ToolUseBlock]]:
     from ..types.messages import normalize_messages_for_api
     from ..utils.advisor import (
@@ -538,9 +548,26 @@ async def _call_model_sync(
             # plumb, ESC during a tool-use-only response (no intermediate
             # text chunks for an ``on_text_chunk`` to observe) waits the
             # full model latency before the outer query loop bails.
-            response = provider.chat_stream_response(
-                api_messages, abort_signal=abort_signal, **call_kwargs,
-            )
+            # Forward on_text_chunk so the SDK fires chunks live (and
+            # the chunk callback can raise AbortError to tear down the
+            # stream mid-flight). Falls back to a kwargless call if
+            # the provider's signature doesn't accept on_text_chunk.
+            if on_text_chunk is not None:
+                try:
+                    response = provider.chat_stream_response(
+                        api_messages,
+                        on_text_chunk=on_text_chunk,
+                        abort_signal=abort_signal,
+                        **call_kwargs,
+                    )
+                except TypeError:
+                    response = provider.chat_stream_response(
+                        api_messages, abort_signal=abort_signal, **call_kwargs,
+                    )
+            else:
+                response = provider.chat_stream_response(
+                    api_messages, abort_signal=abort_signal, **call_kwargs,
+                )
         except (NotImplementedError, AttributeError):
             if _diag:
                 logger.warning("[DIAG] _call_model_sync: streaming not supported, falling back to chat()")
@@ -1229,6 +1256,7 @@ async def query(
                 tools=params.tools,
                 max_output_tokens_override=max_output_tokens_override,
                 abort_signal=params.abort_controller.signal,
+                on_text_chunk=params.on_text_chunk,
             )
             assistant_messages = returned_assistants
             tool_use_blocks = returned_tool_blocks

--- a/src/query/streaming.py
+++ b/src/query/streaming.py
@@ -1,3 +1,24 @@
+"""SSE event-stream loop — planned migration target (Ch5/F.5).
+
+This module is a parallel implementation of the agent loop that emits
+fine-grained SSE events (MessageStart/TextDelta/ToolUseStart/...). It
+has **no production consumers** in ``src/`` — only test files
+reference it. Per the refactoring plan's F.5 decision, ``streaming_query``
+is retained as an in-progress migration target rather than being
+deleted.
+
+**Important.** This module does NOT yet have the chapter-5 recovery
+infrastructure wired in: no prompt-too-long recovery via
+``reactive_compact``, no stop-hooks dispatch, no token-budget
+continuation, no model fallback. Those features live in the canonical
+``query()`` async generator at :func:`src.query.query.query`. If your
+work needs the production-ready loop, use that one.
+
+When/if the team decides to migrate FROM ``run_agent_loop`` and
+``query()`` TO ``streaming_query``, the chapter-5 recovery ladder
+needs to be re-ported into this module (Phases B/C/D/E equivalents).
+That migration is tracked as a separate follow-up ticket.
+"""
 from __future__ import annotations
 
 import asyncio

--- a/src/tui/agent_bridge.py
+++ b/src/tui/agent_bridge.py
@@ -25,7 +25,13 @@ from pathlib import Path
 from typing import Any, Callable
 
 from src.agent import Session
-from src.tool_system.agent_loop import ToolEvent, run_agent_loop
+from src.tool_system.agent_loop import (
+    AgentLoopResult,
+    ToolEvent,
+    _build_effective_system_prompt,
+    run_agent_loop,  # retained for back-compat imports; no longer called
+)
+from src.query.agent_loop_compat import run_query_as_agent_loop
 from src.tool_system.context import ToolContext
 from src.tool_system.registry import ToolRegistry
 from src.utils.abort_controller import AbortController, AbortError
@@ -195,17 +201,60 @@ class AgentBridge:
             self._post(AssistantChunk(text=chunk))
 
         try:
-            result = run_agent_loop(
-                conversation=self._session.conversation,
-                provider=self._provider,
-                tool_registry=self._tool_registry,
-                tool_context=self._tool_context,
-                max_turns=self._max_turns,
-                stream=self._stream,
-                verbose=False,
-                on_event=_on_event,
-                on_text_chunk=_on_text if self._stream else None,
-                cancel_signal=controller.signal if controller is not None else None,
+            # Ch5/F.3 cutover: route TUI through the canonical query()
+            # loop via the F.1 adapter. The Textual ``@work(thread=True)``
+            # worker doesn't have an asyncio loop, so we spin up a fresh
+            # one INSIDE the worker thread (NOT on the main loop —
+            # ``@work(thread=False)`` would block Textual's UI rendering
+            # during model streams). Pre-build the effective system
+            # prompt (CLAUDE.md, style, git status) — legacy
+            # run_agent_loop did this internally; the adapter doesn't.
+            import asyncio as _asyncio
+            from src.outputStyles import resolve_output_style
+            _style_prompt = resolve_output_style(
+                getattr(self._tool_context, "output_style_name", None),
+                getattr(self._tool_context, "output_style_dir", None),
+            ).prompt
+            effective_system_prompt = _build_effective_system_prompt(
+                _style_prompt, self._tool_context,
+            )
+
+            def _persist(msg: Any) -> None:
+                # BLOCKING #2 fix: persist FULL message (tool_use /
+                # tool_result blocks included) so subsequent turns can
+                # pair tool_use IDs to results. Plain
+                # ``add_assistant_message`` loses block structure.
+                try:
+                    self._session.conversation.add_message(msg.role, msg.content)
+                except Exception:
+                    pass
+
+            _loop = _asyncio.new_event_loop()
+            try:
+                compat_result = _loop.run_until_complete(run_query_as_agent_loop(
+                    initial_messages=list(self._session.conversation.messages),
+                    provider=self._provider,
+                    tool_registry=self._tool_registry,
+                    tool_context=self._tool_context,
+                    system_prompt=effective_system_prompt,
+                    max_turns=self._max_turns,
+                    on_event=_on_event,
+                    on_text_chunk=_on_text if self._stream else None,
+                    on_message=_persist,
+                    cancel_signal=(
+                        controller.signal if controller is not None else None
+                    ),
+                ))
+            finally:
+                _loop.close()
+            result = AgentLoopResult(
+                response_text=compat_result.response_text,
+                usage=(
+                    compat_result.usage
+                    if compat_result.num_turns > 0
+                    else None
+                ),
+                num_turns=compat_result.num_turns,
             )
         except AbortError:
             self._post(

--- a/src/tui/agent_bridge.py
+++ b/src/tui/agent_bridge.py
@@ -224,10 +224,19 @@ class AgentBridge:
                 # tool_result blocks included) so subsequent turns can
                 # pair tool_use IDs to results. Plain
                 # ``add_assistant_message`` loses block structure.
+                # Critic S3: log failures instead of swallowing — a
+                # persist failure means the conversation is corrupted
+                # for the next turn (tool_use without tool_result will
+                # 400 at the API). Surface it now, not later.
                 try:
                     self._session.conversation.add_message(msg.role, msg.content)
                 except Exception:
-                    pass
+                    import logging
+                    logging.getLogger(__name__).exception(
+                        "Failed to persist message into conversation: "
+                        "role=%s; next-turn API may reject the call.",
+                        getattr(msg, "role", "?"),
+                    )
 
             _loop = _asyncio.new_event_loop()
             try:
@@ -241,9 +250,10 @@ class AgentBridge:
                     on_event=_on_event,
                     on_text_chunk=_on_text if self._stream else None,
                     on_message=_persist,
-                    cancel_signal=(
-                        controller.signal if controller is not None else None
-                    ),
+                    # Critic C2: pass the OWNING controller (not just
+                    # its signal) so the provider sees the same signal
+                    # ESC trips. See same fix in headless.py for why.
+                    abort_controller=controller,
                 ))
             finally:
                 _loop.close()

--- a/tests/test_agent_loop_compat.py
+++ b/tests/test_agent_loop_compat.py
@@ -145,8 +145,12 @@ class TestAgentLoopCompatAdapter(unittest.TestCase):
         self.assertIn("tool_result", kinds)
 
     def test_adapter_handles_cancel_signal(self):
-        """F.1: a pre-set cancel_signal causes the loop to exit
-        immediately via aborted_streaming/aborted_tools."""
+        """Critic C1: a pre-set cancel_signal causes the adapter to raise
+        AbortError so callers' existing ``except AbortError`` paths fire
+        (headless emits ``cancelled`` ResultEvent + exit 130; TUI posts
+        ``AgentRunFinished(error="Cancelled by user")``). Without this
+        the cutover regressed headless to exit 0 with no signal."""
+        from src.utils.abort_controller import AbortError
         provider = MagicMock()
         provider.chat_stream_response.side_effect = NotImplementedError()
         provider.chat.return_value = ChatResponse(
@@ -160,18 +164,16 @@ class TestAgentLoopCompatAdapter(unittest.TestCase):
         cancel = AbortController()
         cancel.abort("user_interrupt")
 
-        result = _run(run_query_as_agent_loop(
-            initial_messages=[UserMessage(content="Hi")],
-            provider=provider,
-            tool_registry=self.registry,
-            tool_context=self.context,
-            system_prompt="You are helpful.",
-            max_turns=5,
-            cancel_signal=cancel.signal,
-        ))
-
-        self.assertIsNotNone(result.terminal)
-        self.assertIn(result.terminal.reason, ("aborted_streaming", "aborted_tools"))
+        with self.assertRaises(AbortError):
+            _run(run_query_as_agent_loop(
+                initial_messages=[UserMessage(content="Hi")],
+                provider=provider,
+                tool_registry=self.registry,
+                tool_context=self.context,
+                system_prompt="You are helpful.",
+                max_turns=5,
+                cancel_signal=cancel.signal,
+            ))
 
 
 class TestLiveStreamingAndPersistence(unittest.TestCase):

--- a/tests/test_agent_loop_compat.py
+++ b/tests/test_agent_loop_compat.py
@@ -174,5 +174,139 @@ class TestAgentLoopCompatAdapter(unittest.TestCase):
         self.assertIn(result.terminal.reason, ("aborted_streaming", "aborted_tools"))
 
 
+class TestLiveStreamingAndPersistence(unittest.TestCase):
+    """Critic-flagged BLOCKING fixes — live streaming + full-message
+    persistence."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.temp_dir.name)
+        self.registry = build_default_registry()
+        self.context = ToolContext(workspace_root=self.workspace)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_on_text_chunk_forwarded_to_provider_for_live_streaming(self):
+        """Critic BLOCKING #1: on_text_chunk must reach the provider's
+        chat_stream_response so chunks fire LIVE during the model
+        stream — not once at the end."""
+        provider = MagicMock()
+        provider.chat.return_value = ChatResponse(
+            content="full text",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 5},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        # Make chat_stream_response a real callable that fires
+        # on_text_chunk per simulated chunk and returns a ChatResponse.
+        def fake_stream(api_messages, **kwargs):
+            cb = kwargs.get("on_text_chunk")
+            if cb is not None:
+                for chunk in ["hel", "lo, ", "world"]:
+                    cb(chunk)
+            return ChatResponse(
+                content="hello, world",
+                model="test",
+                usage={"input_tokens": 10, "output_tokens": 5},
+                finish_reason="end_turn",
+                tool_uses=None,
+            )
+        provider.chat_stream_response.side_effect = fake_stream
+
+        chunks: list[str] = []
+
+        def collector(text: str) -> None:
+            chunks.append(text)
+
+        result = _run(run_query_as_agent_loop(
+            initial_messages=[UserMessage(content="say hi")],
+            provider=provider,
+            tool_registry=self.registry,
+            tool_context=self.context,
+            system_prompt="You are helpful.",
+            max_turns=2,
+            on_text_chunk=collector,
+        ))
+
+        self.assertEqual(result.terminal.reason, "completed")
+        # Three live chunks fired by the provider — proving the
+        # callback was threaded all the way through, NOT a single
+        # post-hoc fire of the full text.
+        self.assertEqual(chunks, ["hel", "lo, ", "world"])
+
+    def test_on_message_persists_full_message_objects(self):
+        """Critic BLOCKING #2: on_message must fire for every yielded
+        Message so callers can persist the full structure
+        (tool_use blocks intact for Anthropic multi-turn). Not
+        response_text alone."""
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        # Turn 1: tool_use. Turn 2: text-only completion.
+        provider.chat.side_effect = [
+            ChatResponse(
+                content="thinking",
+                model="test",
+                usage={"input_tokens": 10, "output_tokens": 5},
+                finish_reason="tool_use",
+                tool_uses=[{
+                    "id": "tool_1",
+                    "name": "Bash",
+                    "input": {"command": "true", "description": "noop"},
+                }],
+            ),
+            ChatResponse(
+                content="Done.",
+                model="test",
+                usage={"input_tokens": 50, "output_tokens": 5},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+        ]
+
+        persisted: list = []
+
+        def keep_full(msg) -> None:
+            persisted.append(msg)
+
+        result = _run(run_query_as_agent_loop(
+            initial_messages=[UserMessage(content="run noop")],
+            provider=provider,
+            tool_registry=self.registry,
+            tool_context=self.context,
+            system_prompt="You are helpful.",
+            max_turns=5,
+            on_message=keep_full,
+        ))
+
+        self.assertEqual(result.terminal.reason, "completed")
+        # We expect at least: assistant turn 1 (with tool_use),
+        # user (with tool_result), assistant turn 2 (text).
+        from src.types.messages import AssistantMessage as _AM, UserMessage as _UM
+        from src.types.content_blocks import ToolUseBlock, ToolResultBlock
+        assistants = [m for m in persisted if isinstance(m, _AM)]
+        self.assertGreaterEqual(len(assistants), 2)
+        # First assistant must carry a ToolUseBlock — proving full
+        # structure was preserved (not just text).
+        first_blocks = assistants[0].content
+        self.assertTrue(
+            isinstance(first_blocks, list)
+            and any(isinstance(b, ToolUseBlock) for b in first_blocks),
+            "Full ToolUseBlock structure must be persisted, not "
+            "just text. Got: %r" % first_blocks,
+        )
+        # A user-message with tool_result must also be persisted
+        # so the next API call can pair tool_use IDs.
+        users_with_tool_result = [
+            m for m in persisted
+            if isinstance(m, _UM)
+            and isinstance(m.content, list)
+            and any(isinstance(b, ToolResultBlock) for b in m.content)
+        ]
+        self.assertGreaterEqual(len(users_with_tool_result), 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_agent_loop_compat.py
+++ b/tests/test_agent_loop_compat.py
@@ -1,0 +1,178 @@
+"""Ch5/F.1 — adapter tests for run_query_as_agent_loop.
+
+Verifies that the canonical query() loop can be driven through an
+AgentLoopResult-shaped interface so the headless and TUI production
+paths can migrate off the legacy run_agent_loop.
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from src.providers.base import ChatResponse
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.types.messages import UserMessage
+from src.utils.abort_controller import AbortController
+
+from src.query.agent_loop_compat import (
+    AgentLoopRunResult,
+    run_query_as_agent_loop,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestAgentLoopCompatAdapter(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.temp_dir.name)
+        self.registry = build_default_registry()
+        self.context = ToolContext(workspace_root=self.workspace)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_adapter_returns_agent_loop_run_result_shape(self):
+        """F.1: the adapter returns an AgentLoopRunResult with the
+        same fields as the legacy AgentLoopResult, plus a Terminal."""
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="Hello from query()",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 5},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        result = _run(run_query_as_agent_loop(
+            initial_messages=[UserMessage(content="Hi")],
+            provider=provider,
+            tool_registry=self.registry,
+            tool_context=self.context,
+            system_prompt="You are helpful.",
+            max_turns=5,
+        ))
+
+        self.assertIsInstance(result, AgentLoopRunResult)
+        self.assertEqual(result.response_text, "Hello from query()")
+        self.assertEqual(result.usage["input_tokens"], 10)
+        self.assertEqual(result.usage["output_tokens"], 5)
+        self.assertGreaterEqual(result.num_turns, 1)
+        self.assertIsNotNone(result.terminal)
+        self.assertEqual(result.terminal.reason, "completed")
+
+    def test_adapter_propagates_terminal_max_turns(self):
+        """F.1: when max_turns is reached, the adapter surfaces
+        Terminal(reason='max_turns')."""
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        # Always returns a tool_use so the loop never exits cleanly.
+        provider.chat.return_value = ChatResponse(
+            content="thinking",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 5},
+            finish_reason="tool_use",
+            tool_uses=[{
+                "id": "tool_1",
+                "name": "Bash",
+                "input": {"command": "true", "description": "noop"},
+            }],
+        )
+
+        result = _run(run_query_as_agent_loop(
+            initial_messages=[UserMessage(content="Hi")],
+            provider=provider,
+            tool_registry=self.registry,
+            tool_context=self.context,
+            system_prompt="You are helpful.",
+            max_turns=2,
+        ))
+
+        self.assertIsNotNone(result.terminal)
+        self.assertEqual(result.terminal.reason, "max_turns")
+
+    def test_adapter_dispatches_on_event(self):
+        """F.1: on_event receives tool_use and tool_result events."""
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = [
+            ChatResponse(
+                content="Let me run a command",
+                model="test",
+                usage={"input_tokens": 10, "output_tokens": 5},
+                finish_reason="tool_use",
+                tool_uses=[{
+                    "id": "tool_1",
+                    "name": "Bash",
+                    "input": {"command": "true", "description": "noop"},
+                }],
+            ),
+            ChatResponse(
+                content="Done.",
+                model="test",
+                usage={"input_tokens": 50, "output_tokens": 5},
+                finish_reason="end_turn",
+                tool_uses=None,
+            ),
+        ]
+
+        events = []
+
+        def collector(event):
+            events.append(event)
+
+        result = _run(run_query_as_agent_loop(
+            initial_messages=[UserMessage(content="Run something")],
+            provider=provider,
+            tool_registry=self.registry,
+            tool_context=self.context,
+            system_prompt="You are helpful.",
+            max_turns=5,
+            on_event=collector,
+        ))
+
+        # Should have at least one tool_use event and at least one
+        # tool_result event.
+        kinds = [e.kind for e in events]
+        self.assertIn("tool_use", kinds)
+        self.assertIn("tool_result", kinds)
+
+    def test_adapter_handles_cancel_signal(self):
+        """F.1: a pre-set cancel_signal causes the loop to exit
+        immediately via aborted_streaming/aborted_tools."""
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="should not reach",
+            model="test",
+            usage={"input_tokens": 10, "output_tokens": 5},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        cancel = AbortController()
+        cancel.abort("user_interrupt")
+
+        result = _run(run_query_as_agent_loop(
+            initial_messages=[UserMessage(content="Hi")],
+            provider=provider,
+            tool_registry=self.registry,
+            tool_context=self.context,
+            system_prompt="You are helpful.",
+            max_turns=5,
+            cancel_signal=cancel.signal,
+        ))
+
+        self.assertIsNotNone(result.terminal)
+        self.assertIn(result.terminal.reason, ("aborted_streaming", "aborted_tools"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_headless_cli.py
+++ b/tests/test_headless_cli.py
@@ -240,14 +240,17 @@ def test_headless_without_skip_permissions_installs_auto_deny_handler(fake_wirin
     fake_wiring.append(_text_response("ok"))
 
     captured: dict = {}
-    original = headless_mod.run_agent_loop
+    # Headless now routes through ``run_query_as_agent_loop`` (the F.1
+    # adapter) instead of the legacy ``run_agent_loop``. Patch the
+    # actual production call site.
+    original = headless_mod.run_query_as_agent_loop
 
-    def _capture(*args, **kwargs):
+    async def _capture(*args, **kwargs):
         captured["tool_context"] = kwargs["tool_context"]
-        return original(*args, **kwargs)
+        return await original(*args, **kwargs)
 
     import src.entrypoints.headless as mod
-    mod.run_agent_loop = _capture  # type: ignore[assignment]
+    mod.run_query_as_agent_loop = _capture  # type: ignore[assignment]
     try:
         code = run_headless(
             HeadlessOptions(
@@ -259,7 +262,7 @@ def test_headless_without_skip_permissions_installs_auto_deny_handler(fake_wirin
             )
         )
     finally:
-        mod.run_agent_loop = original  # type: ignore[assignment]
+        mod.run_query_as_agent_loop = original  # type: ignore[assignment]
 
     assert code == 0
     ctx = captured["tool_context"]
@@ -273,14 +276,17 @@ def test_headless_with_skip_permissions_clears_handler(fake_wiring, tmp_path):
     fake_wiring.append(_text_response("ok"))
 
     captured: dict = {}
-    original = headless_mod.run_agent_loop
+    # Headless now routes through ``run_query_as_agent_loop`` (the F.1
+    # adapter) instead of the legacy ``run_agent_loop``. Patch the
+    # actual production call site.
+    original = headless_mod.run_query_as_agent_loop
 
-    def _capture(*args, **kwargs):
+    async def _capture(*args, **kwargs):
         captured["tool_context"] = kwargs["tool_context"]
-        return original(*args, **kwargs)
+        return await original(*args, **kwargs)
 
     import src.entrypoints.headless as mod
-    mod.run_agent_loop = _capture  # type: ignore[assignment]
+    mod.run_query_as_agent_loop = _capture  # type: ignore[assignment]
     try:
         run_headless(
             HeadlessOptions(
@@ -293,7 +299,7 @@ def test_headless_with_skip_permissions_clears_handler(fake_wiring, tmp_path):
             )
         )
     finally:
-        mod.run_agent_loop = original  # type: ignore[assignment]
+        mod.run_query_as_agent_loop = original  # type: ignore[assignment]
 
     ctx = captured["tool_context"]
     assert ctx.permission_handler is None


### PR DESCRIPTION
## Summary

Eliminates a long-standing duplication: the codebase had **two per-turn agent loops**, with the main user-facing paths (TUI + headless) on the *less capable* one. This PR routes both through the canonical `query.query` loop via the F.1 adapter resurrected from the orphaned `ch05/F` stack.

| | `agent_loop.py` (deprecated by this PR) | `query.py` (canonical) |
|---|---|---|
| Compression / autocompact | No | Yes |
| Reactive compact on context-overflow | No | Yes |
| Hard-limit blocking guards | No | Yes |
| Autocompact circuit breaker | No | Yes |
| Model fallback on error | No | Yes |
| Terminal state machine | No | Yes |
| Tool-result aggregate budget | No | Yes (200K/turn) |
| Before this PR | **TUI, headless** | REPL chat path, Agent subagents |
| After this PR | (no callers; kept for back-compat imports) | **TUI, headless**, REPL chat path, Agent subagents |

## Concrete bug class this fixes

The recent `/advisor` mode (PR #182) was wired only into `query._call_model_sync`. The TUI + headless paths use `agent_loop.run_agent_loop`, which never invoked the advisor. The bug shipped to production; PR #184 retroactively patched it into `agent_loop.py` too. After this consolidation, features only need to land in `query._call_model_sync` — no second wiring required.

## Prior art

The exact consolidation was attempted twice as `ch05/F`:
- PR #82 (`feat(ch05/G+F.1)`) — the adapter
- PR #83 (`feat(ch05/F+cleanup)`) — first cutover attempt
- PR #107 (`feat(ch05/F)`) — polished re-attempt with post-critic fixes

All merged into stacked parent branches, **none reached main** — same orphan-stack pattern as the recent advisor PRs. Determined this was merge-mechanics, not technical regressions (no inline reviews on either PR; the post-critic followup at `1c74653` already addressed all real issues).

This PR resurrects the work onto current main + applies post-implementation critic-review fixes.

## What landed

1. **F.1 adapter** (`src/query/agent_loop_compat.py`, 221 lines) — cherry-picked from `993c9a1`. Async function `run_query_as_agent_loop` that drives `query.query` and returns an `AgentLoopRunResult` source-compatible with the legacy `AgentLoopResult`. Includes `on_text_chunk` (live SSE streaming), `on_event` (tool events), `on_message` (full-message persistence with structure preserved), `abort_controller` / `cancel_signal` (cancellation bridge).

2. **`query.py` plumbing** — added `on_text_chunk: Callable[[str], None] | None` to `QueryParams`; `_call_model_sync` forwards it to `provider.chat_stream_response` so text deltas fire live (critical for the TUI live-stream UX after the cutover).

3. **Headless cutover** (`src/entrypoints/headless.py`) — replaced `run_agent_loop(...)` inside the existing multi-prompt for-loop with `asyncio.run(run_query_as_agent_loop(...))`. Preserved all surrounding scaffolding: SIGINT handler, in_agent_loop flag flipping, AbortError propagation, per-iteration error handling, partial-text events, aggregate tool events, exit-code classification. Pre-builds the effective system prompt so cold-start CLAUDE.md + style + git-status still reaches `query()`.

4. **TUI cutover** (`src/tui/agent_bridge.py`) — same migration inside the existing `@work(thread=True)` worker. Fresh `asyncio.new_event_loop()` per turn (deliberately NOT on Textual's main loop — that would block UI rendering during model streams).

5. **Test fixture update** (`tests/test_headless_cli.py`) — 2 monkey-patches now target `run_query_as_agent_loop` instead of legacy `run_agent_loop`.

## Critic-review fixes (commit 2)

Pre-merge critic flagged 2 critical + 2 significant regressions. All fixed:

- **C1**: Adapter never raised `AbortError` on cancellation. ESC → headless exit 0 (legacy: 130 + `cancelled` event); TUI → blank `AgentRunFinished` with no error string. Fix: inspect `holder.value` after loop, raise `AbortError` on `aborted_streaming`/`aborted_tools`/`interrupted` terminal reasons.
- **C2**: Adapter minted a fresh `AbortController` even when caller had one. Provider's `chat_stream_response` listened on the wrong signal — ESC during a tool-use-only turn waited the full model latency. Fix: accept caller's controller directly; headless + TUI now pass `abort_controller=` instead of `cancel_signal=signal`.
- **S1**: API-error and meta messages got persisted into the user's Conversation, poisoning multi-prompt sessions (hallucinations from prior errors, PTL death spirals). Fix: skip `isApiErrorMessage`/`isMeta` in `on_message`.
- **S2**: `Conversation.max_history = 100` silently truncated long sessions (cutover persists ~3-5× more messages per turn). Pop'ing index 0 removed the original user prompt. Fix: bump cap to 2000.
- **S3** (bonus): bare `except Exception: pass` in `_persist` swallowed corruption errors. Fix: log in TUI (UI keeps running), re-raise in headless (fail loud).

## Verified

- **Tests**: 653 passed (advisor + adapter + headless + TUI + query + tool_system).
- **Live**: headless run with `--provider openai --model claude-haiku-4-5` + advisor `claude-opus-4-7`, both proxied through litellm.singula.ai. Files created, exit 0, no API errors.

## What's NOT in this PR (deliberately)

- F.4 renderer extraction (move `summarize_tool_use` / `summarize_tool_result` / `ToolEvent` / `AgentLoopResult` to a neutral module). Not needed to fix the bug class — `agent_loop.py` is still imported for these symbols.
- Deletion of `agent_loop.py`. Stage 4 — should wait until this cutover burns in for at least a few days. The advisor wiring I added to `agent_loop.py` in PR #184 is now dead code, but kept for the same reason.

## Rollback plan

Single PR; revert if any regression surfaces. `agent_loop.py` still exists with its full implementation, so the revert restores the old loop without touching anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)