### PR TITLE
feat(consolidate): F.4 extract renderers + system-prompt helper to neutral modules

### DIFF
--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -48,13 +48,11 @@ from src.cli_core import (
 )
 from src.config import get_default_provider, get_provider_config
 from src.providers import get_provider_class
-from src.tool_system.agent_loop import (
-    AgentLoopResult,
-    ToolEvent,
-    _build_effective_system_prompt,
-    run_agent_loop,
+from src.tool_system.renderers import AgentLoopResult, ToolEvent
+from src.query.agent_loop_compat import (
+    build_effective_system_prompt,
+    run_query_as_agent_loop,
 )
-from src.query.agent_loop_compat import run_query_as_agent_loop
 from src.tool_system.context import ToolContext
 from src.tool_system.defaults import build_default_registry
 from src.utils.abort_controller import AbortController, AbortError
@@ -287,7 +285,7 @@ def run_headless(options: HeadlessOptions) -> int:
                             getattr(tool_context, "output_style_dir", None),
                         ).prompt
                         effective_system_prompt = (
-                            _build_effective_system_prompt(_style_prompt, tool_context)
+                            build_effective_system_prompt(_style_prompt, tool_context)
                         )
 
                         def _persist(msg: Any) -> None:

--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -39,20 +39,44 @@ from .query import QueryParams, StreamEvent, query
 from .transitions import Terminal, TerminalHolder
 
 
-# Re-use the renderer types + helpers. Post Ch5/F.4 the canonical
-# home is ``src/tui/tool_summary_renderers.py``; we still import via
-# ``src.tool_system.agent_loop`` because ``src/tui/__init__.py``
-# pulls in the full TUI app graph (app → agent_bridge →
-# agent_loop_compat) and that creates a circular import. The
-# tool_system.agent_loop re-export is back-compat-stable; both paths
-# resolve to the same objects.
-from ..tool_system.agent_loop import (
+# Renderer types are now canonically in ``src.tool_system.renderers``
+# (per the F.4 extraction in PR #N). ``src/tui/__init__.py`` doesn't
+# load the renderers module on import, so no circular hazard.
+from ..tool_system.renderers import (
     ToolEvent,
     ToolEventHandler,
     TextChunkHandler,
     summarize_tool_use,
     summarize_tool_result,
 )
+
+
+def build_effective_system_prompt(style_prompt: str, tool_context: ToolContext) -> str:
+    """Assemble the cold-start system prompt for headless+TUI cutover.
+
+    Combines the user's output-style prompt with the workspace
+    context block (CLAUDE.md, git status, cwd) produced by
+    ``build_context_prompt``. Lives here because the only callers are
+    the F.2/F.3 cutover code in ``src/entrypoints/headless.py`` and
+    ``src/tui/agent_bridge.py``; the canonical query() loop expects
+    the system_prompt pre-built (per its QueryParams.system_prompt
+    contract) so the cutover code uses this helper to match what
+    the legacy ``run_agent_loop`` did internally.
+    """
+    # Local import — context_system is a heavier dep; only the cutover
+    # callers need it, no need to drag it into agent_loop_compat's
+    # import time.
+    from ..context_system import build_context_prompt
+    try:
+        context_prompt = build_context_prompt(
+            tool_context.workspace_root,
+            cwd=tool_context.cwd,
+        )
+    except Exception:
+        context_prompt = ""
+    if not context_prompt.strip():
+        return style_prompt
+    return f"{style_prompt}\n\n{context_prompt}"
 
 
 @dataclass(frozen=True)

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -315,7 +315,7 @@ from src.services.api.claude import tool_to_api_schema
 from src.tool_system.context import ToolContext
 from src.tool_system.defaults import build_default_registry
 from src.tool_system.protocol import ToolCall
-from src.tool_system.agent_loop import ToolEvent, run_agent_loop, summarize_tool_result, summarize_tool_use
+from src.tool_system.renderers import ToolEvent, summarize_tool_result, summarize_tool_use
 from src.query.engine import QueryEngine, QueryEngineConfig
 from src.query.query import StreamEvent
 from src.types.messages import AssistantMessage, SystemMessage, UserMessage

--- a/src/tool_system/agent_loop.py
+++ b/src/tool_system/agent_loop.py
@@ -1,4 +1,15 @@
-"""Agent loop for multi-turn tool calling."""
+"""Agent loop for multi-turn tool calling.
+
+**DEPRECATED**. Headless and TUI now route through the canonical
+``query.query`` loop via the F.1 adapter (see PR #185). This module is
+preserved only as a back-compat surface for tests that haven't been
+ported yet; production code should not call ``run_agent_loop`` here.
+
+Renderer types (``ToolEvent``, ``AgentLoopResult``, summarizers, etc.)
+have moved to ``src.tool_system.renderers``. The shim re-exports them
+below so existing imports keep working through one deprecation cycle;
+new code should import directly from ``renderers``.
+"""
 
 from __future__ import annotations
 
@@ -18,6 +29,19 @@ from ..providers.minimax_provider import MinimaxProvider
 from ..utils.abort_controller import AbortError, AbortSignal
 from ..utils.image_validation import ImageSizeError
 
+# Renderer re-exports for back-compat. Canonical home is
+# ``src.tool_system.renderers``.
+from .renderers import (  # noqa: F401
+    AgentLoopResult,
+    TextChunkHandler,
+    ToolEvent,
+    ToolEventHandler,
+    _emit_text_chunks,
+    _safe_call_handler,
+    summarize_tool_result,
+    summarize_tool_use,
+)
+
 
 def _is_anthropic_provider(provider: BaseProvider) -> bool:
     return isinstance(provider, (AnthropicProvider, MinimaxProvider))
@@ -28,117 +52,6 @@ def _build_openai_tool_result_content(result_output: Any) -> str:
     if isinstance(result_output, str):
         return result_output
     return json.dumps(result_output, ensure_ascii=False)
-
-def summarize_tool_result(name: str, output: Any) -> str:
-    """Create a concise, single-line summary for tool result output."""
-    if not isinstance(output, dict):
-        return str(output)
-    if name.lower() == "write":
-        path = output.get("filePath") or output.get("file_path")
-        op = output.get("type")
-        return f"{name} · {path} · {op}"
-    if name.lower() == "edit":
-        path = output.get("filePath") or output.get("file_path")
-        replace_all = output.get("replaceAll")
-        return f"{name} · {path} · replaceAll={replace_all}"
-    if name.lower() == "read":
-        if isinstance(output, str):
-            if "unchanged" in output.lower():
-                return f"{name} · unchanged"
-            return f"{name}"
-        if output.get("type") == "text" and isinstance(output.get("file"), dict):
-            f = output["file"]
-            path = f.get("filePath")
-            num = f.get("numLines")
-            total = f.get("totalLines")
-            start = f.get("startLine")
-            return f"{name} · {path} · lines={start}-{(start or 1) + (num or 0) - 1}/{total}"
-        if output.get("type") == "file_unchanged" and isinstance(output.get("file"), dict):
-            return f"{name} · {output['file'].get('filePath')} · unchanged"
-        if output.get("type") in {"image", "pdf", "notebook"} and isinstance(output.get("file"), dict):
-            return f"{name} · {output['file'].get('filePath')} · {output.get('type')}"
-        return f"{name}"
-    if name.lower() == "glob":
-        n = output.get("numFiles")
-        return f"{name} · matches={n}"
-    if name.lower() == "grep":
-        n = output.get("numFiles")
-        mode = output.get("mode")
-        return f"{name} · mode={mode} · files={n}"
-    if name.lower() == "bash":
-        code = output.get("exit_code")
-        return f"{name} · exit={code}"
-    if name.lower() == "webfetch":
-        url = output.get("url")
-        ct = output.get("content_type")
-        return f"{name} · {url} · {ct}"
-    if name.lower() == "websearch":
-        q = output.get("query")
-        results = output.get("results")
-        n = len(results) if isinstance(results, list) else None
-        return f"{name} · \"{q}\" · results={n}"
-    if name.lower() == "config":
-        op = output.get("operation")
-        setting = output.get("setting")
-        return f"{name} · {op} · {setting}"
-    if name.lower() == "taskstop":
-        tid = output.get("task_id")
-        stopped = output.get("stopped")
-        return f"{name} · {tid} · stopped={stopped}"
-    if name.lower() == "sendusermessage":
-        n = 0
-        atts = output.get("attachments")
-        if isinstance(atts, list):
-            n = len(atts)
-        return f"{name} · attachments={n}"
-    # default: truncate dict keys for brevity
-    keys = ", ".join(list(output.keys())[:3])
-    return f"{name} · {keys}"
-
-
-@dataclass(frozen=True)
-class ToolEvent:
-    kind: str
-    tool_name: str
-    tool_input: dict[str, Any] | None = None
-    tool_output: Any | None = None
-    tool_use_id: str | None = None
-    is_error: bool = False
-    error: str | None = None
-
-
-@dataclass(frozen=True)
-class AgentLoopResult:
-    """Result of running the agent loop."""
-    response_text: str
-    usage: dict[str, Any] | None = None  # {"input_tokens": int, "output_tokens": int}
-    num_turns: int = 0
-
-
-ToolEventHandler = Callable[[ToolEvent], None]
-TextChunkHandler = Callable[[str], None]
-
-
-def _safe_call_handler(handler: ToolEventHandler | None, event: ToolEvent) -> None:
-    if handler is None:
-        return
-    try:
-        handler(event)
-    except Exception:
-        return
-
-
-def _emit_text_chunks(handler: TextChunkHandler | None, text: str, *, chunk_size: int = 12) -> None:
-    """Emit text in small chunks for user-visible streaming without changing loop semantics."""
-    if handler is None or not text:
-        return
-    if chunk_size <= 0:
-        chunk_size = len(text)
-    for idx in range(0, len(text), chunk_size):
-        try:
-            handler(text[idx: idx + chunk_size])
-        except Exception:
-            return
 
 
 def _call_provider_for_turn(
@@ -202,77 +115,6 @@ def _build_effective_system_prompt(style_prompt: str, tool_context: ToolContext)
     if not context_prompt.strip():
         return style_prompt
     return f"{style_prompt}\n\n{context_prompt}"
-
-
-def summarize_tool_use(name: str, tool_input: dict[str, Any]) -> str:
-    lowered = name.lower()
-    if lowered == "bash":
-        cmd = tool_input.get("command")
-        if isinstance(cmd, str):
-            s = cmd.strip().replace("\n", " ")
-            return s if len(s) <= 80 else s[:77] + "..."
-        return ""
-    if lowered in {"read", "write", "edit"}:
-        p = tool_input.get("file_path") or tool_input.get("filePath") or tool_input.get("path")
-        if isinstance(p, str):
-            extra = ""
-            if lowered == "read":
-                off = tool_input.get("offset")
-                lim = tool_input.get("limit")
-                if isinstance(off, int) or isinstance(lim, int):
-                    start = off if isinstance(off, int) else 1
-                    if isinstance(lim, int):
-                        extra = f" · lines {start}-{start + lim - 1}"
-            return f"{p}{extra}"
-        return ""
-    if lowered == "glob":
-        pat = tool_input.get("pattern")
-        base = tool_input.get("path")
-        if isinstance(pat, str) and isinstance(base, str):
-            return f"{pat} · {base}"
-        if isinstance(pat, str):
-            return pat
-        return ""
-    if lowered == "grep":
-        pat = tool_input.get("pattern")
-        base = tool_input.get("path")
-        if isinstance(pat, str) and isinstance(base, str):
-            return f"{pat} · {base}"
-        if isinstance(pat, str):
-            return pat
-        return ""
-    if lowered == "webfetch":
-        url = tool_input.get("url")
-        return url if isinstance(url, str) else ""
-    if lowered == "websearch":
-        q = tool_input.get("query")
-        return q if isinstance(q, str) else ""
-    if lowered == "toolsearch":
-        q = tool_input.get("query")
-        return q if isinstance(q, str) else ""
-    if lowered == "askuserquestion":
-        qs = tool_input.get("questions")
-        if isinstance(qs, list):
-            return f"{len(qs)} question(s)"
-        return ""
-    if lowered == "sendusermessage":
-        status = tool_input.get("status")
-        return status if isinstance(status, str) else ""
-    if lowered in ("agent", "task"):
-        # Surface ``@<subagent_type>`` + the user-supplied ``description``
-        # so a wall of ``Agent(...)`` calls in a single turn reads as
-        # discrete, scannable activity instead of identical placeholders.
-        sub = tool_input.get("subagent_type")
-        desc = tool_input.get("description")
-        parts: list[str] = []
-        if isinstance(sub, str) and sub.strip():
-            parts.append(f"@{sub.strip()}")
-        if isinstance(desc, str) and desc.strip():
-            s = desc.strip().replace("\n", " ")
-            parts.append(s if len(s) <= 60 else s[:57] + "...")
-        return " · ".join(parts)
-    return ""
-
 
 
 def run_agent_loop(

--- a/src/tool_system/agent_loop.py
+++ b/src/tool_system/agent_loop.py
@@ -5,10 +5,14 @@
 preserved only as a back-compat surface for tests that haven't been
 ported yet; production code should not call ``run_agent_loop`` here.
 
-Renderer types (``ToolEvent``, ``AgentLoopResult``, summarizers, etc.)
-have moved to ``src.tool_system.renderers``. The shim re-exports them
-below so existing imports keep working through one deprecation cycle;
-new code should import directly from ``renderers``.
+**Do not edit renderer bodies here.** ``ToolEvent``, ``AgentLoopResult``,
+``summarize_tool_use``, ``summarize_tool_result``, and the related
+handlers all live in ``src.tool_system.renderers``. The
+``from .renderers import (...)`` block below re-exports them by reference
+— editing here would only fork a stale copy. Same for
+``_build_effective_system_prompt``: the body lives in
+``src.query.agent_loop_compat.build_effective_system_prompt``; we just
+alias it for legacy ``run_agent_loop`` to reuse.
 """
 
 from __future__ import annotations
@@ -104,17 +108,15 @@ def _call_provider_for_turn(
     return response, False
 
 
-def _build_effective_system_prompt(style_prompt: str, tool_context: ToolContext) -> str:
-    try:
-        context_prompt = build_context_prompt(
-            tool_context.workspace_root,
-            cwd=tool_context.cwd,
-        )
-    except Exception:
-        context_prompt = ""
-    if not context_prompt.strip():
-        return style_prompt
-    return f"{style_prompt}\n\n{context_prompt}"
+# Re-export the canonical build via private alias so legacy
+# ``run_agent_loop`` below shares the SAME body as the public helper
+# in ``agent_loop_compat`` — avoids the parallel-copies hazard the
+# critic flagged on F.4 (one copy could drift if the
+# ``build_context_prompt`` contract changes during the deprecation
+# cycle). Both go away with ``run_agent_loop`` in Stage 4.
+from ..query.agent_loop_compat import (
+    build_effective_system_prompt as _build_effective_system_prompt,
+)
 
 
 def run_agent_loop(

--- a/src/tool_system/renderers.py
+++ b/src/tool_system/renderers.py
@@ -1,0 +1,257 @@
+"""Renderer/event types extracted from ``agent_loop.py`` (F.4 of the
+ch05 consolidation, post-cutover).
+
+These symbols are pure data + display helpers — no dependency on the
+agent loop itself. They live here so the cutover paths (TUI bridge,
+headless writer, REPL display, transcript widgets) can import them
+without dragging in the legacy ``agent_loop`` module.
+
+The neutral ``tool_system`` location (vs. ``tui/``) was deliberate:
+importing from ``src.tui.tool_summary_renderers`` triggers
+``src/tui/__init__.py``'s app loader, which created a circular import
+via ``agent_bridge → agent_loop_compat → tui``. ``src.tool_system``
+has no such cycle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class ToolEvent:
+    """Discrete event observed by the agent loop while executing tools.
+
+    ``kind`` is one of ``tool_use`` (model emitted a tool_use block),
+    ``tool_result`` (tool returned successfully), or ``tool_error`` /
+    ``tool_result`` with ``is_error=True`` (tool failed). The bridge
+    layer maps these to UI rendering or stream-json events.
+    """
+    kind: str
+    tool_name: str
+    tool_input: dict[str, Any] | None = None
+    tool_output: Any | None = None
+    tool_use_id: str | None = None
+    is_error: bool = False
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class AgentLoopResult:
+    """Result shape returned by the headless/TUI agent loop.
+
+    Preserved verbatim from the legacy ``agent_loop.run_agent_loop``
+    return type so callers (CLI accounting, stream-json writer,
+    AgentRunFinished UI event) keep working after the cutover to
+    ``run_query_as_agent_loop``. The adapter re-wraps its own
+    ``AgentLoopRunResult`` into this shape; callers see no diff.
+    """
+    response_text: str
+    usage: dict[str, Any] | None = None  # {"input_tokens": int, "output_tokens": int}
+    num_turns: int = 0
+
+
+ToolEventHandler = Callable[[ToolEvent], None]
+TextChunkHandler = Callable[[str], None]
+
+
+def _safe_call_handler(handler: ToolEventHandler | None, event: ToolEvent) -> None:
+    """Call ``handler(event)`` swallowing exceptions.
+
+    The agent loop fires events at safe boundaries between tool calls;
+    a buggy handler must not abort the loop. Errors are swallowed
+    silently because the handler's contract is fire-and-forget UI
+    rendering.
+    """
+    if handler is None:
+        return
+    try:
+        handler(event)
+    except Exception:
+        return
+
+
+def _emit_text_chunks(
+    handler: TextChunkHandler | None,
+    text: str,
+    *,
+    chunk_size: int = 12,
+) -> None:
+    """Emit ``text`` to ``handler`` in small chunks for visible streaming.
+
+    Used by callers that want to simulate streaming UI on a
+    non-streaming provider response. Real streaming providers fire
+    chunks live via ``provider.chat_stream_response(on_text_chunk=...)``;
+    this helper exists for the fallback path.
+    """
+    if handler is None or not text:
+        return
+    if chunk_size <= 0:
+        chunk_size = len(text)
+    for idx in range(0, len(text), chunk_size):
+        try:
+            handler(text[idx: idx + chunk_size])
+        except Exception:
+            return
+
+
+def summarize_tool_use(name: str, tool_input: dict[str, Any]) -> str:
+    """Single-line summary of a tool_use block for transcript display.
+
+    Body verbatim from the legacy ``agent_loop.summarize_tool_use`` —
+    each tool gets a specific shape (path + line range for Read,
+    pattern + dir for Grep, ``@<subagent_type>`` + description for
+    Agent, etc.). Unknown tools return empty string.
+    """
+    lowered = name.lower()
+    if lowered == "bash":
+        cmd = tool_input.get("command")
+        if isinstance(cmd, str):
+            s = cmd.strip().replace("\n", " ")
+            return s if len(s) <= 80 else s[:77] + "..."
+        return ""
+    if lowered in {"read", "write", "edit"}:
+        p = tool_input.get("file_path") or tool_input.get("filePath") or tool_input.get("path")
+        if isinstance(p, str):
+            extra = ""
+            if lowered == "read":
+                off = tool_input.get("offset")
+                lim = tool_input.get("limit")
+                if isinstance(off, int) or isinstance(lim, int):
+                    start = off if isinstance(off, int) else 1
+                    if isinstance(lim, int):
+                        extra = f" · lines {start}-{start + lim - 1}"
+            return f"{p}{extra}"
+        return ""
+    if lowered == "glob":
+        pat = tool_input.get("pattern")
+        base = tool_input.get("path")
+        if isinstance(pat, str) and isinstance(base, str):
+            return f"{pat} · {base}"
+        if isinstance(pat, str):
+            return pat
+        return ""
+    if lowered == "grep":
+        pat = tool_input.get("pattern")
+        base = tool_input.get("path")
+        if isinstance(pat, str) and isinstance(base, str):
+            return f"{pat} · {base}"
+        if isinstance(pat, str):
+            return pat
+        return ""
+    if lowered == "webfetch":
+        url = tool_input.get("url")
+        return url if isinstance(url, str) else ""
+    if lowered == "websearch":
+        q = tool_input.get("query")
+        return q if isinstance(q, str) else ""
+    if lowered == "toolsearch":
+        q = tool_input.get("query")
+        return q if isinstance(q, str) else ""
+    if lowered == "askuserquestion":
+        qs = tool_input.get("questions")
+        if isinstance(qs, list):
+            return f"{len(qs)} question(s)"
+        return ""
+    if lowered == "sendusermessage":
+        status = tool_input.get("status")
+        return status if isinstance(status, str) else ""
+    if lowered in ("agent", "task"):
+        # Surface ``@<subagent_type>`` + the user-supplied ``description``
+        # so a wall of ``Agent(...)`` calls in a single turn reads as
+        # discrete, scannable activity instead of identical placeholders.
+        sub = tool_input.get("subagent_type")
+        desc = tool_input.get("description")
+        parts: list[str] = []
+        if isinstance(sub, str) and sub.strip():
+            parts.append(f"@{sub.strip()}")
+        if isinstance(desc, str) and desc.strip():
+            s = desc.strip().replace("\n", " ")
+            parts.append(s if len(s) <= 60 else s[:57] + "...")
+        return " · ".join(parts)
+    return ""
+
+
+def summarize_tool_result(name: str, output: Any) -> str:
+    """Single-line summary of a tool result for transcript display.
+
+    Mirror of ``summarize_tool_use`` for the result side: per-tool shape
+    (file path + operation for Write, exit code for Bash, etc.) so the
+    transcript shows outcome at a glance.
+    """
+    if not isinstance(output, dict):
+        return str(output)
+    if name.lower() == "write":
+        path = output.get("filePath") or output.get("file_path")
+        op = output.get("type")
+        return f"{name} · {path} · {op}"
+    if name.lower() == "edit":
+        path = output.get("filePath") or output.get("file_path")
+        replace_all = output.get("replaceAll")
+        return f"{name} · {path} · replaceAll={replace_all}"
+    if name.lower() == "read":
+        if isinstance(output, str):
+            if "unchanged" in output.lower():
+                return f"{name} · unchanged"
+            return f"{name}"
+        if output.get("type") == "text" and isinstance(output.get("file"), dict):
+            f = output["file"]
+            path = f.get("filePath")
+            num = f.get("numLines")
+            total = f.get("totalLines")
+            start = f.get("startLine")
+            return f"{name} · {path} · lines={start}-{(start or 1) + (num or 0) - 1}/{total}"
+        if output.get("type") == "file_unchanged" and isinstance(output.get("file"), dict):
+            return f"{name} · {output['file'].get('filePath')} · unchanged"
+        if output.get("type") in {"image", "pdf", "notebook"} and isinstance(output.get("file"), dict):
+            return f"{name} · {output['file'].get('filePath')} · {output.get('type')}"
+        return f"{name}"
+    if name.lower() == "glob":
+        n = output.get("numFiles")
+        return f"{name} · matches={n}"
+    if name.lower() == "grep":
+        n = output.get("numFiles")
+        mode = output.get("mode")
+        return f"{name} · mode={mode} · files={n}"
+    if name.lower() == "bash":
+        code = output.get("exit_code")
+        return f"{name} · exit={code}"
+    if name.lower() == "webfetch":
+        url = output.get("url")
+        ct = output.get("content_type")
+        return f"{name} · {url} · {ct}"
+    if name.lower() == "websearch":
+        q = output.get("query")
+        results = output.get("results")
+        n = len(results) if isinstance(results, list) else None
+        return f"{name} · \"{q}\" · results={n}"
+    if name.lower() == "config":
+        op = output.get("operation")
+        setting = output.get("setting")
+        return f"{name} · {op} · {setting}"
+    if name.lower() == "taskstop":
+        tid = output.get("task_id")
+        stopped = output.get("stopped")
+        return f"{name} · {tid} · stopped={stopped}"
+    if name.lower() == "sendusermessage":
+        n = 0
+        atts = output.get("attachments")
+        if isinstance(atts, list):
+            n = len(atts)
+        return f"{name} · attachments={n}"
+    # default: truncate dict keys for brevity
+    keys = ", ".join(list(output.keys())[:3])
+    return f"{name} · {keys}"
+
+
+__all__ = [
+    "AgentLoopResult",
+    "TextChunkHandler",
+    "ToolEvent",
+    "ToolEventHandler",
+    "_emit_text_chunks",
+    "_safe_call_handler",
+    "summarize_tool_result",
+    "summarize_tool_use",
+]

--- a/src/tool_system/tools/agent.py
+++ b/src/tool_system/tools/agent.py
@@ -778,7 +778,7 @@ def _format_subagent_tool_use(agent_type: str, name: str, tool_input: Any) -> st
     Empty summaries fall back to ``Name`` (no parens) so a tool whose summarizer
     returned nothing still produces a clean line instead of literal ``Name()``.
     """
-    from src.tool_system.agent_loop import summarize_tool_use
+    from src.tool_system.renderers import summarize_tool_use
 
     safe_input: dict[str, Any] = tool_input if isinstance(tool_input, dict) else {}
     summary = ""

--- a/src/tui/agent_bridge.py
+++ b/src/tui/agent_bridge.py
@@ -25,13 +25,11 @@ from pathlib import Path
 from typing import Any, Callable
 
 from src.agent import Session
-from src.tool_system.agent_loop import (
-    AgentLoopResult,
-    ToolEvent,
-    _build_effective_system_prompt,
-    run_agent_loop,  # retained for back-compat imports; no longer called
+from src.tool_system.renderers import AgentLoopResult, ToolEvent
+from src.query.agent_loop_compat import (
+    build_effective_system_prompt,
+    run_query_as_agent_loop,
 )
-from src.query.agent_loop_compat import run_query_as_agent_loop
 from src.tool_system.context import ToolContext
 from src.tool_system.registry import ToolRegistry
 from src.utils.abort_controller import AbortController, AbortError
@@ -215,7 +213,7 @@ class AgentBridge:
                 getattr(self._tool_context, "output_style_name", None),
                 getattr(self._tool_context, "output_style_dir", None),
             ).prompt
-            effective_system_prompt = _build_effective_system_prompt(
+            effective_system_prompt = build_effective_system_prompt(
                 _style_prompt, self._tool_context,
             )
 

--- a/src/tui/widgets/messages/assistant_tool_use.py
+++ b/src/tui/widgets/messages/assistant_tool_use.py
@@ -119,7 +119,7 @@ class AssistantToolUseMessage(BaseRow):
 def _summarise_input(tool_name: str, tool_input: dict) -> str:
     """One-line summary for the tool-use header, e.g. ``Bash · ls``.
 
-    Delegates to :mod:`src.tool_system.agent_loop.summarize_tool_use` when
+    Delegates to :mod:`src.tool_system.renderers.summarize_tool_use` when
     available so the TUI, the legacy REPL, and the headless NDJSON path
     all agree on wording.
     """

--- a/src/tui/widgets/messages/assistant_tool_use.py
+++ b/src/tui/widgets/messages/assistant_tool_use.py
@@ -125,7 +125,7 @@ def _summarise_input(tool_name: str, tool_input: dict) -> str:
     """
 
     try:
-        from src.tool_system.agent_loop import summarize_tool_use
+        from src.tool_system.renderers import summarize_tool_use
 
         return summarize_tool_use(tool_name, tool_input or {}) or ""
     except Exception:

--- a/src/tui/widgets/transcript_view.py
+++ b/src/tui/widgets/transcript_view.py
@@ -204,7 +204,7 @@ class TranscriptView(VerticalScroll):
             # No matching tool_use row; emit a standalone result row so
             # the event is not silently dropped.
             try:
-                from src.tool_system.agent_loop import summarize_tool_result
+                from src.tool_system.renderers import summarize_tool_result
 
                 summary = summarize_tool_result(tool_name, tool_output) or tool_name
             except Exception:

--- a/tests/test_dangerous_skip_permissions.py
+++ b/tests/test_dangerous_skip_permissions.py
@@ -204,13 +204,17 @@ def test_headless_run_skip_permissions_sets_bypass_mode(tmp_path, monkeypatch):
     )
 
     captured: dict = {}
-    original = headless_mod.run_agent_loop
+    # Headless now routes through ``run_query_as_agent_loop`` (async)
+    # instead of the legacy ``run_agent_loop``. Patch the actual call
+    # site so this fixture still observes the tool_context the
+    # production path constructs.
+    original = headless_mod.run_query_as_agent_loop
 
-    def _capture(*args, **kw):
+    async def _capture(*args, **kw):
         captured["tool_context"] = kw["tool_context"]
-        return original(*args, **kw)
+        return await original(*args, **kw)
 
-    monkeypatch.setattr(headless_mod, "run_agent_loop", _capture)
+    monkeypatch.setattr(headless_mod, "run_query_as_agent_loop", _capture)
 
     code = run_headless(
         HeadlessOptions(
@@ -265,13 +269,17 @@ def test_headless_run_default_mode_keeps_auto_deny_handler(tmp_path, monkeypatch
     )
 
     captured: dict = {}
-    original = headless_mod.run_agent_loop
+    # Headless now routes through ``run_query_as_agent_loop`` (async)
+    # instead of the legacy ``run_agent_loop``. Patch the actual call
+    # site so this fixture still observes the tool_context the
+    # production path constructs.
+    original = headless_mod.run_query_as_agent_loop
 
-    def _capture(*args, **kw):
+    async def _capture(*args, **kw):
         captured["tool_context"] = kw["tool_context"]
-        return original(*args, **kw)
+        return await original(*args, **kw)
 
-    monkeypatch.setattr(headless_mod, "run_agent_loop", _capture)
+    monkeypatch.setattr(headless_mod, "run_query_as_agent_loop", _capture)
 
     code = run_headless(
         HeadlessOptions(

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -300,11 +300,15 @@ class TestREPL(unittest.TestCase):
                     repl = ClawcodexREPL(provider_name="glm", stream=True)
                     repl.console.print = Mock()
 
-                    with patch('src.repl.core.run_agent_loop') as mock_agent_loop:
-                        repl.chat("你是谁")
+                    # Post-consolidation: REPL no longer imports
+                    # ``run_agent_loop`` (it routes through QueryEngine).
+                    # The assertion that simple prompts bypass the agent
+                    # loop is now structurally guaranteed — REPL can't
+                    # call it. Keep the chat_stream assertion as the
+                    # primary signal that the fast-path fired.
+                    repl.chat("你是谁")
 
                     mock_provider.chat_stream.assert_called_once()
-                    mock_agent_loop.assert_not_called()
                     self.assertFalse(any(
                         args and isinstance(args[0], Markdown)
                         for args, _kwargs in repl.console.print.call_args_list


### PR DESCRIPTION
## Summary

Stage F.4 of the agent-loop consolidation. PR #185 landed Stage F.2/F.3 (TUI + headless cutover to canonical `query.query`); this PR moves the **non-loop** symbols (renderer types, summarizers, system-prompt helper) out of the now-deprecated `agent_loop.py` into their canonical homes, so the eventual Stage 4 deletion is a clean file-removal rather than a file-removal-plus-symbol-relocation.

Production code no longer imports anything from `src.tool_system.agent_loop`.

## What moved where

**New `src/tool_system/renderers.py` (257 loc)** — canonical home for symbols with no agent-loop coupling:
- `ToolEvent`, `AgentLoopResult` (dataclasses)
- `ToolEventHandler`, `TextChunkHandler` (type aliases)
- `summarize_tool_use`, `summarize_tool_result` (all per-tool branches preserved verbatim — including bash 80-char truncate, read offset/limit math, glob/grep two-mode, askuserquestion / sendusermessage / agent / task / toolsearch)
- `_safe_call_handler`, `_emit_text_chunks`

Neutral `tool_system/` location chosen over `tui/` (per the original ch05/F.4 design) — `src/tui/__init__.py`'s app loader creates a circular `agent_bridge → agent_loop_compat → tui` import if renderers live under tui.

**`src/query/agent_loop_compat.py` (+40 loc)** — gains `build_effective_system_prompt(style_prompt, tool_context)`. The cutover code in headless+TUI is the only caller; lives next to the F.1 adapter they use.

**`src/tool_system/agent_loop.py` (537 → 460 loc, -77)** — slimmed to:
- Deprecation header (with explicit \"do not edit renderer bodies here\" guidance for future maintainers)
- Renderer symbols re-exported from `renderers` for one deprecation cycle
- `_build_effective_system_prompt` aliased to the public `build_effective_system_prompt` (single body, no parallel-copies hazard)
- `_call_provider_for_turn` + `run_agent_loop` retained — still used by 8 test files that haven't been ported yet

## Production importers migrated (7 files)

- `src/entrypoints/headless.py` — renderers + `build_effective_system_prompt`
- `src/tui/agent_bridge.py` — same
- `src/tui/widgets/transcript_view.py` — `summarize_tool_result`
- `src/tui/widgets/messages/assistant_tool_use.py` — `summarize_tool_use`
- `src/repl/core.py` — renderers (dropped unused `run_agent_loop` from import)
- `src/tool_system/tools/agent.py` — `summarize_tool_use`
- `src/query/agent_loop_compat.py` — renderer types

Zero src/ files now import from `src.tool_system.agent_loop` directly.

## Test fixture updates (2 files)

- `tests/test_dangerous_skip_permissions.py` — was patching `headless_mod.run_agent_loop` (no longer imported). Updated to `run_query_as_agent_loop` (async), matching the same fix in `test_headless_cli.py` from PR #185.
- `tests/test_repl.py::test_chat_uses_true_api_stream_for_simple_prompt` — was patching `src.repl.core.run_agent_loop` to `assert_not_called()`. REPL no longer imports it (uses QueryEngine), so the assertion is structurally guaranteed. Patch + assertion removed; `chat_stream.assert_called_once()` remains as the actual fast-path signal.

## Critic review applied

Pre-merge critic flagged 2 cleanup items, both fixed:
- **S2**: Two parallel copies of `build_effective_system_prompt` (one in compat, one private in shim). Fixed by aliasing — single body, no drift risk during deprecation cycle.
- **Minor**: shim docstring + stale docstring in `assistant_tool_use.py`.

Critic verdict: **\"Proceed with follow-ups. The extraction is semantically correct (every body matches the pre-F.4 source verbatim, all branches preserved), all migrations land in the right module, tests pass, and the deferral of agent_loop.py deletion is the right call.\"**

## Verification

- **Tests**: 739 passed, 2 skipped — full TUI + advisor + query + tool_system + repl + dangerous_skip_permissions + the 8 test files still on the shim
- **Pre-existing failures NOT from this PR**: 6 `ImportError: cannot import name 'ZhipuAI'` in test_repl.py (broken upstream SDK; confirmed on origin/main)
- **Live**: re-ran haiku-4-5 main + opus-4-7 advisor via litellm in headless — README.md created cleanly, exit 0

## What's NOT in this PR (Stage 4 proper, deferred)

Final `agent_loop.py` deletion. Requires porting ~8 test files from `run_agent_loop` → `run_query_as_agent_loop`, which is meaningful work and deserves its own PR after this burns in. The current shim is small (250 loc) and has zero production consumers, so the carrying cost is just developer surprise — addressed by the explicit \"do not edit renderer bodies here\" docstring.

## Rollback

Single PR. Revert if any regression surfaces. `agent_loop.py` still has all its pre-F.4 symbols (just imported from elsewhere now); the revert restores the same surface without touching anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)