### PR TITLE
feat(advisor): rewrite client-side advisor prompt for real critique

### DIFF
--- a/src/utils/advisor.py
+++ b/src/utils/advisor.py
@@ -277,16 +277,31 @@ ADVISOR_MODE_CLIENT_SIDE = "client_side"
 # provider as the system message. Kept short — the conversation we
 # forward is the substantive context, and the prompt's role is just to
 # orient the advisor model on what kind of feedback to produce.
-CLIENT_ADVISOR_SYSTEM_PROMPT = """You are a senior reviewer model. Another model is working through a task and has paused to consult you. The conversation forwarded below is everything the worker model has seen so far: the user's request, every tool call the worker made, every result.
+CLIENT_ADVISOR_SYSTEM_PROMPT = """You are a senior reviewer being consulted by a junior worker model that has paused mid-task to get your judgment. The conversation below is everything the worker has seen and done so far: the user's task, every tool call the worker made, every result.
 
-Your job: produce concise, high-signal advice that helps the worker decide what to do next. Concretely:
+# CRITICAL — read these before responding
 
-- If the worker's interpretation of the task or its current approach looks wrong, say so and explain the better path.
-- If you spot a bug, a missed constraint, a hidden invariant, or a step the worker is about to skip, name it.
-- If the worker is at a fork between approaches, recommend one and explain the tradeoff.
-- If the worker is done, sanity-check: did they actually solve what was asked? What edge cases didn't they cover?
+1. **DO NOT restate, summarize, or echo back the worker's plan.** They already know what they're doing. Restating is worse than useless — it wastes their context window and your turn. If you find yourself writing "your plan is to ..." STOP and delete that paragraph.
 
-Keep it tight — short paragraphs, no preamble. Don't repeat what the worker already knows. Don't add disclaimers about being an AI. Write directly to the worker model in second person."""
+2. **DO NOT respond in the worker's voice.** Never write "I will...", "My plan is...", "Let me...". You are NOT the worker. You are the reviewer talking AT the worker. Use "you" / "your" / "the plan" — second-person, never first-person.
+
+3. **Your only value is the gap.** Tell the worker what they CAN'T see — what they missed, what's risky, what better approach exists. Anything the worker already wrote in their own message is something they already know — never repeat it.
+
+# Output shape
+
+Reply in this exact format. No preamble. No sign-off.
+
+**Gaps:** 1-3 short bullets on what's missing, wrong, or unclear in the plan. If nothing material → write "Nothing material missing." (one bullet, no more).
+
+**Risks:** 1-3 short bullets on what could break, surprise, or bite later. Concrete failure modes only — not generic disclaimers.
+
+**Do next:** ONE sentence. The single most-important next action.
+
+If the worker's whole approach is fundamentally wrong, skip the format and write a short "Stop — rethink: ..." paragraph instead, then the one-sentence next action.
+
+# Style
+
+Terse. Concrete. Write directly. No hedging ("you might want to consider"), no flattery ("good plan, but..."), no disclaimers ("as an AI..."), no "I think". Cut every sentence that isn't load-bearing."""
 
 
 # Tool-use shape that the main-loop model sees in client-side mode.
@@ -414,8 +429,12 @@ def decide_advisor_mode(
 
 
 CLIENT_ADVISOR_PROMPT_SUFFIX = (
-    "Please review the conversation above and give me your advice on what "
-    "to do next. Be concrete."
+    "Now produce advice in the format your system prompt specified "
+    "(Gaps / Risks / Do next). DO NOT restate or paraphrase the plan "
+    "above — the worker already wrote it. Tell them only what they "
+    "can't see: what's missing, what's risky, what to do next. If "
+    "their plan is already solid, say 'Nothing material missing.' "
+    "and recommend the single next action."
 )
 
 
@@ -488,6 +507,12 @@ def _flatten_content_for_advisor(content: Any) -> str:
             if isinstance(t, str) and t.strip():
                 parts.append(t)
         elif bt in ("tool_use", "server_tool_use", "mcp_tool_use"):
+            # Drop the worker's OWN advisor call — the marker would
+            # invite the reviewer to "answer the call" in the worker's
+            # voice rather than give fresh advice. The reviewer
+            # already knows it IS the advisor.
+            if block.get("name") == ADVISOR_TOOL_NAME:
+                continue
             parts.append(_tool_use_to_text(block))
         elif bt == "tool_result":
             parts.append(_tool_result_to_text(block))
@@ -499,6 +524,27 @@ def _flatten_content_for_advisor(content: Any) -> str:
             # Unknown block — preserve the type signal but no payload.
             parts.append(f"[{bt}]")
     return "\n".join(parts).strip()
+
+
+_ADVISOR_PAIRING_CRUFT = (
+    "[Tool result missing due to internal error]",
+    "[Tool use interrupted]",
+)
+
+
+def _is_advisor_pairing_cruft(text: str) -> bool:
+    """True if the message is just orphan-pairing-pass injected cruft.
+
+    ``normalize_messages_for_api`` runs ``ensure_tool_result_pairing``
+    which, on the in-flight worker advisor tool_use, injects a
+    synthetic tool_result UserMessage with a "[Tool result missing
+    due to internal error]" placeholder. That cruft is meaningful to
+    the API (keeps tool_use/tool_result pairing valid) but
+    counterproductive to the advisor (looks like a real tool failure
+    the advisor should react to). Strip it from the forwarded view.
+    """
+    t = text.strip()
+    return any(cruft in t for cruft in _ADVISOR_PAIRING_CRUFT)
 
 
 def build_advisor_forwarded_messages(
@@ -539,6 +585,16 @@ def build_advisor_forwarded_messages(
         role = msg.get("role")
         text = _flatten_content_for_advisor(msg.get("content"))
         if not text:
+            continue
+        # Drop the orphan-pairing-pass artifact: a synthetic user
+        # message containing only "[Tool result missing due to
+        # internal error]" wraps the in-flight worker advisor call.
+        # It's required for downstream API tool_use/tool_result
+        # pairing but tells the advisor "your worker just failed",
+        # confusing the response. The worker's own tool_use was
+        # already dropped from the flattened content above; the
+        # synthetic result has no surviving partner anyway.
+        if _is_advisor_pairing_cruft(text):
             continue
         flattened.append({"role": role, "content": text})
 

--- a/tests/test_advisor_client_side.py
+++ b/tests/test_advisor_client_side.py
@@ -244,6 +244,44 @@ class TestBuildAdvisorForwardedMessages(unittest.TestCase):
                         self.assertNotEqual(b.get("type"), "server_tool_use")
                         self.assertNotEqual(b.get("type"), "advisor_tool_result")
 
+    def test_strips_worker_self_advisor_tool_use_marker(self) -> None:
+        """The worker's own ``tool_use(name=advisor)`` is what triggered
+        the advisor call. Including a `[Tool call: advisor({})]` marker
+        in the flattened text invites the advisor to LARP as the
+        worker. Strip it so the advisor sees the conversation as if
+        it's being asked to opine, not to ack a tool invocation."""
+        from src.types.messages import AssistantMessage, UserMessage
+        msgs = [
+            UserMessage(content="task"),
+            AssistantMessage(content=[
+                {"type": "text", "text": "thinking about it"},
+                {"type": "tool_use", "id": "t1", "name": "advisor", "input": {}},
+            ]),
+        ]
+        out = build_advisor_forwarded_messages(msgs)
+        for m in out:
+            self.assertNotIn("[Tool call: advisor", m["content"])
+
+    def test_strips_orphan_pairing_cruft_user_message(self) -> None:
+        """The orphan-pairing pass injects a synthetic
+        ``[Tool result missing due to internal error]`` user message
+        to keep tool_use/tool_result pairing valid for the API. That
+        cruft must be filtered from the advisor's view — otherwise
+        the advisor thinks the worker just hit a tool failure and
+        responds to that instead of the actual task."""
+        from src.types.messages import AssistantMessage, UserMessage
+        msgs = [
+            UserMessage(content="real task"),
+            AssistantMessage(content=[
+                {"type": "text", "text": "my plan is X"},
+                {"type": "tool_use", "id": "t1", "name": "advisor", "input": {}},
+            ]),
+        ]
+        out = build_advisor_forwarded_messages(msgs)
+        joined = "\n".join(m["content"] for m in out)
+        self.assertNotIn("[Tool result missing due to internal error]", joined)
+        self.assertNotIn("[Tool use interrupted]", joined)
+
     def test_returns_plain_dicts_safe_to_send(self) -> None:
         from src.types.messages import UserMessage
         out = build_advisor_forwarded_messages([UserMessage(content="hello")])


### PR DESCRIPTION
## Summary

Followup to the post-Stage-4 real-test verification (#187). The wiring works end-to-end, but the live React-blog test revealed that `claude-opus-4-7` (as client-side advisor) was just echoing the worker's plan back instead of giving fresh critique. This PR rewrites the advisor system prompt + cleans up two artifacts in the forwarded conversation that were confusing the reviewer.

## Why not just copy the TypeScript reference?

Per the user's ask — I read `typescript/src/utils/advisor.ts`. It doesn't define a separate advisor system prompt because the TS implementation uses the **server-side** Anthropic API for the advisor — the reviewer's system prompt is baked into Anthropic's server, not the client. The TS client only injects `ADVISOR_TOOL_INSTRUCTIONS` into the worker's system prompt (we already mirror that byte-for-byte, SHA-pinned).

The client-side path is a Python extension with no TS equivalent. The reviewer-side prompt is my own invention. This PR is the v2 take after seeing v1's failure mode in production.

## What changed

### `CLIENT_ADVISOR_SYSTEM_PROMPT` rewritten

v1 was "keep it tight, don't repeat what worker knows" — gentle hints, no hard rule. v2 has three numbered CRITICAL rules at the top:

1. DO NOT restate, summarize, or echo the worker's plan
2. DO NOT respond in the worker's voice ("I will...", "My plan is...")
3. Your only value is the gap — what the worker can't see

Plus an explicit output shape:

\`\`\`
**Gaps:** 1-3 short bullets ("Nothing material missing." if none)
**Risks:** 1-3 short bullets on concrete failure modes  
**Do next:** ONE sentence — the single most-important action
\`\`\`

Plus terse style guidance — no preamble, no sign-off, no hedging, no AI disclaimers.

### `CLIENT_ADVISOR_PROMPT_SUFFIX` strengthened

Belt-and-suspenders with the system prompt. The synthetic user message that closes the forwarded conversation now explicitly repeats the format expectation + the "don't restate" rule.

### `build_advisor_forwarded_messages` cleanup

Two artifacts dropped from the advisor's view:

* **Worker's own `tool_use(name=advisor)` block.** Previously flattened to `[Tool call: advisor({})]` — but the advisor already knows it IS the advisor; the marker just invited it to "answer the call" in the worker's voice.
* **Orphan-pairing-pass synthetic user message.** `normalize_messages_for_api` injects `[Tool result missing due to internal error]` to keep tool_use/tool_result pairing valid for downstream API calls. To the advisor that looks like "your worker just hit a tool failure" — and it responds to that instead of the actual task. Now filtered.

## Verified live

Same problematic worker plan that previously got echoed back, run through the standalone adapter with the new prompts (haiku-4-5 main + opus-4-7 advisor via litellm.singula.ai). Real critique:

> **Gaps:**
> - No styling story — even one global CSS file or a Layout with nav links matters; without nav from Post back to Home users are stuck.
> - No 404 / catch-all route; unknown `:id` will crash on `posts.find(...).title`.
> - Missing `@types/react`, `@types/react-dom`, `@vitejs/plugin-react` in deps — easy to forget.
> 
> **Risks:**
> - `BrowserRouter` breaks on static hosts without SPA fallback; use `createBrowserRouter` or document it.
> - Strict TS + `noUncheckedIndexedAccess` will surface the undefined-post bug at compile time — handle it now, not later.
> - `id` from `useParams` is `string | undefined`; comparing to a numeric post id silently fails.
> 
> **Do next:** Scaffold with `npm create vite@latest -- --template react-ts` instead of hand-rolling configs, then add the router and pages on top.

Three real bugs caught (string|undefined comparison, no 404 handling, missing @types deps). Clean format. No echo.

## Test plan

- New: `test_strips_worker_self_advisor_tool_use_marker` — verifies the worker's own `[Tool call: advisor({})]` marker doesn't leak into forwarded content.
- New: `test_strips_orphan_pairing_cruft_user_message` — verifies the orphan-pairing pass's synthetic message is filtered out.
- All 36 `test_advisor_client_side.py` tests pass.
- Full advisor suite (66 tests) pass.

## Out of scope

- Changing the model's `ADVISOR_TOOL_INSTRUCTIONS` (the worker-facing instruction block) — that's SHA-pinned to TS and works fine for triggering advisor invocations.
- Server-side advisor prompt (Anthropic owns that; we never see it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)