### PR TITLE
feat(advisor): surface advisor model + mode in REPL/TUI status bars

### DIFF
--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -677,8 +677,16 @@ class ClawcodexREPL:
             model = getattr(self.provider, "model", "") or "?"
             cwd_full = str(self.tool_context.cwd or self.tool_context.workspace_root)
             cwd = self._shorten_path_text(cwd_full) or cwd_full
+            # Optional advisor segment — appears between cwd and turns
+            # when ``/advisor`` is set. Mode label (server/client/inactive)
+            # reflects what the NEXT request will do given the current
+            # provider + main model, so a stale config under an
+            # unsupported provider shows "(inactive)" rather than lying.
+            from src.utils.advisor import format_advisor_status
+            advisor_seg = format_advisor_status(self.provider, model)
+            advisor_part = f" {advisor_seg} ·" if advisor_seg else ""
             return (
-                f" {provider} · {model} · {cwd} · "
+                f" {provider} · {model} · {cwd} ·{advisor_part} "
                 f"turns: {self._stats_turns} · "
                 f"tokens: {self._stats_input_tokens} in / "
                 f"{self._stats_output_tokens} out "

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -193,6 +193,10 @@ class ClawCodexTUI(App):
             workspace_root=self.workspace_root,
             words_provider=self._slash_command_words,
             suggestions_provider=self._slash_command_suggestions,
+            # Pass the live BaseProvider so the status line's advisor
+            # segment can call ``decide_advisor_mode(provider, ...)``
+            # and show the correct mode label (server/client/inactive).
+            provider_instance=self.provider,
         )
         self.push_screen(self._repl_screen)
 

--- a/src/tui/screens/repl.py
+++ b/src/tui/screens/repl.py
@@ -71,6 +71,7 @@ class REPLScreen(Screen):
         workspace_root: Path,
         words_provider: Callable[[], list[str]],
         suggestions_provider: Callable[[], list["CommandSuggestion"]] | None = None,
+        provider_instance: object | None = None,
     ) -> None:
         super().__init__()
         self._version = version
@@ -79,6 +80,7 @@ class REPLScreen(Screen):
         self._workspace_root = Path(workspace_root)
         self._words_provider = words_provider
         self._suggestions_provider = suggestions_provider
+        self._provider_instance = provider_instance
 
         self.header_widget = StartupHeader(
             version=version,
@@ -91,6 +93,7 @@ class REPLScreen(Screen):
             provider=provider,
             model=model,
             workspace_root=self._workspace_root,
+            provider_instance=provider_instance,
         )
         self.prompt_input = PromptInput(
             words_provider=words_provider,

--- a/src/tui/widgets/status_line.py
+++ b/src/tui/widgets/status_line.py
@@ -53,11 +53,20 @@ class StatusLine(Static):
         model: str,
         workspace_root: Path,
         app_state: AppState | None = None,
+        provider_instance: object | None = None,
     ) -> None:
         self._provider = provider
         self._model = model
         self._workspace_root = Path(workspace_root)
         self._app_state = app_state
+        # Live provider instance (BaseProvider) — used ONLY for the
+        # advisor status segment so ``format_advisor_status`` can call
+        # ``is_advisor_enabled(provider)`` and pick the right mode
+        # label. Optional: when omitted, the advisor segment shows
+        # "(client)" as the conservative default for any configured
+        # advisor (since SERVER_SIDE requires the instance to verify
+        # first-party).
+        self._provider_instance = provider_instance
         self._frame = 0
         self._timer = None
         initial = Text(f"{provider} · {model}    ready    turn 0")
@@ -129,7 +138,27 @@ class StatusLine(Static):
             if secs > 0:
                 elapsed = f" {secs}s"
 
-        left = f"{self._provider} · {self._model}"
+        left_parts = [f"{self._provider} · {self._model}"]
+        # Optional advisor segment — appears next to provider/model
+        # when ``/advisor`` is configured. Mode label reflects what
+        # the NEXT request will actually do (server/client/inactive)
+        # so a stale config under an unsupported provider doesn't
+        # silently lie. Shared formatter with the legacy REPL
+        # bottom_toolbar so both surfaces render identically.
+        try:
+            from src.utils.advisor import format_advisor_status
+            # Pass the live provider instance when available so the
+            # mode label (server/client/inactive) reflects what the
+            # next request will actually do. Falls back to None (=
+            # "client" default) when the instance isn't plumbed.
+            advisor_seg = format_advisor_status(
+                self._provider_instance, self._model,
+            )
+        except Exception:
+            advisor_seg = None
+        if advisor_seg:
+            left_parts.append(advisor_seg)
+        left = " · ".join(left_parts)
         cwd = self._display_cwd()
         middle = f"{spinner} {verb}{elapsed}" if self.is_thinking else verb
         right_bits: list[str] = [f"turn {self.turns}"]

--- a/src/utils/advisor.py
+++ b/src/utils/advisor.py
@@ -428,6 +428,66 @@ def decide_advisor_mode(
     return ADVISOR_MODE_CLIENT_SIDE if advisor_routes else ADVISOR_MODE_INACTIVE
 
 
+# Human-readable mode labels for status displays.
+_ADVISOR_MODE_LABELS: dict[str, str] = {
+    ADVISOR_MODE_SERVER_SIDE: "server",
+    ADVISOR_MODE_CLIENT_SIDE: "client",
+    ADVISOR_MODE_INACTIVE: "inactive",
+}
+
+
+def format_advisor_status(
+    provider: "BaseProvider | None",
+    main_loop_model: str | None,
+) -> str | None:
+    """Render a compact one-segment status string for the bottom toolbar.
+
+    Returns e.g. ``"advisor: opus-4-7 (client)"`` when an advisor is
+    configured, or ``None`` when it isn't (caller omits the segment
+    entirely). The mode label comes from :func:`decide_advisor_mode`
+    so the display reflects what the next request will actually do —
+    a stale configuration under an unsupported main loop shows
+    ``"(inactive)"`` rather than silently lying about the state.
+
+    Shared between :mod:`src.repl.core` (prompt-toolkit bottom_toolbar)
+    and :mod:`src.tui.widgets.status_line` (Textual widget) so both
+    surfaces format the advisor identically.
+
+    Any unexpected failure (settings cache contention, future provider
+    that throws on inspection) returns ``None`` — the status row must
+    never be the thing that breaks the input prompt.
+    """
+    try:
+        from src.settings.settings import get_settings
+        from src.models.model import canonical_model_name
+    except Exception:
+        return None
+    try:
+        settings = get_settings()
+        advisor_model = (getattr(settings, "advisor_model", "") or "").strip()
+        if not advisor_model:
+            return None
+        canonical = canonical_model_name(advisor_model)
+        force_client = bool(getattr(settings, "advisor_client_mode", False))
+        mode = decide_advisor_mode(
+            provider,
+            main_loop_model,
+            canonical,
+            force_client_mode=force_client,
+        )
+    except Exception:
+        return None
+    label = _ADVISOR_MODE_LABELS.get(mode, mode)
+    # Strip the ``claude-`` family prefix for compactness; everyone
+    # reading the toolbar already knows what brand is in play. Other
+    # provider prefixes (``gemini-``, ``zai/``, etc.) keep their full
+    # name because the brand IS the disambiguator there.
+    display = canonical
+    if display.lower().startswith("claude-"):
+        display = display[len("claude-") :]
+    return f"advisor: {display} ({label})"
+
+
 CLIENT_ADVISOR_PROMPT_SUFFIX = (
     "Now produce advice in the format your system prompt specified "
     "(Gaps / Risks / Do next). DO NOT restate or paraphrase the plan "
@@ -770,6 +830,7 @@ __all__ = [
     "execute_client_advisor",
     "extract_advisor_error_code",
     "extract_advisor_result_text",
+    "format_advisor_status",
     "infer_provider_for_model",
     "is_advisor_block",
     "is_advisor_enabled",

--- a/tests/test_advisor_client_side.py
+++ b/tests/test_advisor_client_side.py
@@ -262,6 +262,54 @@ class TestBuildAdvisorForwardedMessages(unittest.TestCase):
         for m in out:
             self.assertNotIn("[Tool call: advisor", m["content"])
 
+    def test_format_advisor_status_compact_label(self) -> None:
+        """``format_advisor_status`` returns a single short segment with
+        the canonical model (claude- prefix stripped) + the mode label.
+        Used by both the legacy REPL bottom_toolbar and the TUI
+        StatusLine widget."""
+        from src.utils.advisor import format_advisor_status
+        from unittest.mock import patch
+        # Mock settings to return a configured advisor model.
+        with patch("src.utils.advisor._env_truthy", return_value=False), \
+             patch("src.settings.settings.get_settings") as get_s, \
+             patch("src.models.model.canonical_model_name", side_effect=lambda x: x):
+            fake = type("S", (), {"advisor_model": "claude-opus-4-7", "advisor_client_mode": False})()
+            get_s.return_value = fake
+            out = format_advisor_status(None, "claude-haiku-4-5")
+        self.assertIsNotNone(out)
+        # claude- prefix stripped for brevity
+        self.assertIn("opus-4-7", out)
+        self.assertNotIn("claude-opus", out)
+        # Mode label is one of the three known values
+        self.assertTrue(
+            "(server)" in out or "(client)" in out or "(inactive)" in out,
+            f"unexpected mode label in: {out!r}",
+        )
+
+    def test_format_advisor_status_returns_none_when_unset(self) -> None:
+        from src.utils.advisor import format_advisor_status
+        from unittest.mock import patch
+        with patch("src.utils.advisor._env_truthy", return_value=False), \
+             patch("src.settings.settings.get_settings") as get_s:
+            fake = type("S", (), {"advisor_model": "", "advisor_client_mode": False})()
+            get_s.return_value = fake
+            out = format_advisor_status(None, "claude-haiku-4-5")
+        self.assertIsNone(out)
+
+    def test_format_advisor_status_returns_none_when_env_disabled(self) -> None:
+        from src.utils.advisor import format_advisor_status
+        from unittest.mock import patch
+        import os
+        with patch.dict(os.environ, {"CLAUDE_CODE_DISABLE_ADVISOR_TOOL": "1"}, clear=False), \
+             patch("src.settings.settings.get_settings") as get_s, \
+             patch("src.models.model.canonical_model_name", side_effect=lambda x: x):
+            fake = type("S", (), {"advisor_model": "claude-opus-4-7", "advisor_client_mode": False})()
+            get_s.return_value = fake
+            out = format_advisor_status(None, "claude-haiku-4-5")
+        # Even with model set, env-disable → mode is INACTIVE → label shows
+        self.assertIsNotNone(out)
+        self.assertIn("(inactive)", out)
+
     def test_strips_orphan_pairing_cruft_user_message(self) -> None:
         """The orphan-pairing pass injects a synthetic
         ``[Tool result missing due to internal error]`` user message


### PR DESCRIPTION
## Summary

When `/advisor` is configured, both the legacy REPL bottom toolbar and the TUI StatusLine widget now show a compact `advisor: <model> (<mode>)` segment next to provider/model. At a glance, users see which reviewer is configured and whether it'll fire **server-side**, **client-side**, or sit **inactive**.

## Display format

\`\`\`
 openai · claude-haiku-4-5 · ~/workspace/clawcodex · advisor: opus-4-7 (client) · turns: 1 · tokens: 1234 in / 567 out
\`\`\`

- **`claude-`** family prefix stripped for brevity — the user already knows what brand they configured.
- **Mode label** comes from `decide_advisor_mode(provider, main_model, advisor_model, force_client_mode)` so it reflects what the NEXT request will actually do. A stale config under an unsupported provider shows `(inactive)` rather than silently lying.
- **Other provider prefixes** (`gemini-`, `zai/`, etc.) keep their full name because the brand IS the disambiguator there.

## Files

| File | Change |
|---|---|
| `src/utils/advisor.py` | New `format_advisor_status(provider, main_model)` helper. Returns the segment string or `None` if not configured. Robust to all internal failures (status row must never break the input prompt). |
| `src/repl/core.py` | `_bottom_toolbar` calls the helper and inserts the segment between cwd and turn count when non-None. |
| `src/tui/widgets/status_line.py` | `_compose_text` appends the segment next to provider/model on the left. New optional `provider_instance` constructor parameter. |
| `src/tui/screens/repl.py` | `REPLScreen` gains optional `provider_instance` parameter that it forwards to `StatusLine`. |
| `src/tui/app.py` | Passes `self.provider` (live `BaseProvider`) to `REPLScreen` so the mode predicate can call `is_advisor_enabled(provider)` and distinguish server-side from client-side. |

## Tests

- `test_format_advisor_status_compact_label` — verifies the claude- prefix stripping + mode label shape
- `test_format_advisor_status_returns_none_when_unset` — null case
- `test_format_advisor_status_returns_none_when_env_disabled` — env kill switch surfaces as `(inactive)` label
- Full advisor + TUI suites pass (117 + 525)

## Live verified

With the user's actual production config (haiku-4-5 main + opus-4-7 advisor via litellm.singula.ai):

\`\`\`
Bottom toolbar segment: 'advisor: opus-4-7 (client)'
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)