### PR TITLE
feat(advisor): require explicit <provider>:<model> syntax (multi-provider rewrite)

### DIFF
--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -489,6 +489,65 @@ def _write_advisor_model(context: CommandContext, value: str | None) -> None:
     invalidate_settings_cache()
 
 
+def _read_current_advisor_provider(context: CommandContext) -> str:
+    """Resolve the current advisor_provider (store preferred, settings
+    fallback). Empty string = unset.
+    Mirrors ``_read_current_advisor_model``."""
+    store = getattr(context, "app_state_store", None)
+    if store is not None:
+        try:
+            v = getattr(store.get_state(), "advisor_provider", None)
+            return (v or "").strip()
+        except Exception:
+            pass
+    try:
+        from ..settings.settings import get_settings
+        return (getattr(get_settings(), "advisor_provider", "") or "").strip()
+    except Exception:
+        return ""
+
+
+def _write_advisor_provider(context: CommandContext, value: str | None) -> None:
+    """Persist advisor_provider (store preferred, settings fallback).
+    Mirrors ``_write_advisor_model`` — same dual-path persistence.
+    Empty / None clears the field."""
+    normalized = (value or "").strip()
+    store = getattr(context, "app_state_store", None)
+    if store is not None:
+        from ..state.app_state import replace_state
+        store.set_state(
+            lambda s: replace_state(s, advisor_provider=(normalized or None))
+        )
+        return
+    from .. import config as cfg_mod
+    from ..settings.settings import invalidate_settings_cache
+    mgr = cfg_mod._get_default_manager()
+    cfg = mgr.load_global()
+    settings_section = cfg.get("settings")
+    if not isinstance(settings_section, dict):
+        settings_section = {}
+    settings_section["advisor_provider"] = normalized
+    cfg["settings"] = settings_section
+    mgr.save_global(cfg)
+    invalidate_settings_cache()
+
+
+def _list_configured_providers() -> list[str]:
+    """Return the set of provider keys configured in
+    ``~/.clawcodex/config.json``. Used by /advisor to validate that the
+    user-supplied provider prefix refers to a real entry."""
+    try:
+        from .. import config as cfg_mod
+        mgr = cfg_mod._get_default_manager()
+        cfg = mgr.load_global()
+        providers = cfg.get("providers")
+        if isinstance(providers, dict):
+            return sorted(providers.keys())
+    except Exception:
+        pass
+    return []
+
+
 def _read_current_advisor_client_mode(context: CommandContext) -> bool:
     """Resolve the user's current advisor_client_mode flag (reactive
     store preferred, settings fallback). Mirrors
@@ -530,24 +589,30 @@ def _write_advisor_client_mode(context: CommandContext, value: bool) -> None:
 def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResult:
     """Handle /advisor — configure the reviewer model.
 
-    Branches (after parsing optional ``--client`` / ``--no-client`` flags):
-      * no args, no flags → status report (model + active mode).
-      * ``unset`` | ``off`` → clear advisor_model AND advisor_client_mode.
-      * ``--no-client`` (alone) → keep model, clear client-mode flag.
-      * ``<model>`` → resolve + validate the model has a known provider,
-        then persist. ``--client`` flag (if present) also persists
-        advisor_client_mode=True; absent flag preserves the existing
-        client_mode value (so ``--client`` is sticky).
+    Required argument shape: ``<provider>:<model>`` — both halves
+    explicit, separated by the first colon (so model strings
+    containing ``/`` or further ``:`` are preserved verbatim).
+    Provider must match a key in ``~/.clawcodex/config.json``'s
+    ``providers`` map; clawcodex is multi-provider and the same
+    model name (e.g. ``claude-opus-4-7``) can sit behind anthropic,
+    openai (litellm), openrouter, bedrock, etc. Name-based inference
+    was ambiguous and silently routed to the wrong endpoint.
 
-    The activation mode (server-side vs client-side) is decided at
-    request time by ``decide_advisor_mode`` based on the provider and
-    the stored ``(advisor_model, advisor_client_mode)`` pair. This
-    command writes both fields; it doesn't pick the mode.
+    Branches (after parsing optional ``--client`` / ``--no-client``):
+      * no args, no flags → status report (provider/model + mode).
+      * ``unset`` | ``off`` → clear advisor_model, advisor_provider,
+        and advisor_client_mode.
+      * ``--no-client`` alone → keep model+provider, clear client-mode.
+      * ``--client`` alone → keep model+provider, set client-mode.
+      * ``<provider>:<model>`` → validate provider exists in config,
+        persist both fields together. ``--client`` flag (if present)
+        also persists advisor_client_mode.
 
-    Writes go to the reactive AppState store when wired, falling back
-    to the global settings file. Either path produces the same end
-    state — settings.advisor_model and settings.advisor_client_mode
-    are the canonical sources.
+    Examples:
+      * ``/advisor anthropic:claude-opus-4-7``  (direct Anthropic API)
+      * ``/advisor openai:claude-opus-4-7``     (litellm/proxy via openai provider)
+      * ``/advisor openrouter:anthropic/claude-opus-4.1``
+      * ``/advisor gemini:gemini-2.5-pro``
     """
     from ..models.model import canonical_model_name, resolve_model
     from ..models.validation import validate_model_name
@@ -557,7 +622,6 @@ def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResu
         ADVISOR_MODE_SERVER_SIDE,
         can_user_configure_advisor,
         decide_advisor_mode,
-        infer_provider_for_model,
     )
 
     provider = getattr(context, "provider", None)
@@ -590,6 +654,7 @@ def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResu
     arg_lower = arg.lower()
 
     current_advisor = _read_current_advisor_model(context)
+    current_provider = _read_current_advisor_provider(context)
     current_client_mode = _read_current_advisor_client_mode(context)
 
     main_loop_model = ""
@@ -605,17 +670,51 @@ def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResu
 
     def _render_status() -> str:
         """Format the current state for the no-args branch."""
-        if not current_advisor:
+        if not current_advisor or not current_provider:
+            # Either field missing → effectively unset. Show what's
+            # there (if anything) so users can fix a partial config.
+            partial = ""
+            if current_advisor and not current_provider:
+                partial = (
+                    f"\n(Found advisor_model={current_advisor!r} but no "
+                    "advisor_provider — clear with /advisor unset then "
+                    "re-run with the explicit syntax.)"
+                )
+            elif current_provider and not current_advisor:
+                partial = (
+                    f"\n(Found advisor_provider={current_provider!r} but "
+                    "no advisor_model — clear with /advisor unset.)"
+                )
+            # Critic C1: surface advisor_client_mode even on partial
+            # configs so the user sees stored state that would silently
+            # activate as soon as both fields land.
+            if current_client_mode:
+                partial += (
+                    "\n(advisor_client_mode is ON but won't engage "
+                    "until both advisor_model and advisor_provider "
+                    "are set.)"
+                )
+            providers = _list_configured_providers()
+            providers_hint = (
+                f"Configured providers: {', '.join(providers)}.\n"
+                if providers else ""
+            )
             return (
                 "Advisor: not set\n"
-                'Use "/advisor <model>" to enable (e.g. "/advisor opus", '
-                '"/advisor gemini-2.5-pro").'
+                f"{providers_hint}"
+                "Use \"/advisor <provider>:<model>\" to enable, e.g.:\n"
+                '  /advisor anthropic:claude-opus-4-7   (direct Anthropic)\n'
+                '  /advisor openai:claude-opus-4-7      (via openai-compat, '
+                'e.g. litellm)\n'
+                '  /advisor openrouter:anthropic/claude-opus-4.1'
+                f"{partial}"
             )
         mode = decide_advisor_mode(
             provider,
             main_loop_model,
             current_advisor,
             force_client_mode=current_client_mode,
+            advisor_provider=current_provider,
         )
         mode_label = {
             ADVISOR_MODE_SERVER_SIDE: "active (server-side)",
@@ -625,21 +724,10 @@ def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResu
         suffix = ""
         if current_client_mode:
             suffix = " [--client forced]"
-        if mode == ADVISOR_MODE_INACTIVE:
-            inactive_reason = (
-                f"The current model ({main_loop_model}) cannot be paired "
-                f"with {current_advisor!r} (no known provider for the "
-                "advisor model)."
-                if main_loop_model
-                else f"No known provider for advisor model {current_advisor!r}."
-            )
-            return (
-                f"Advisor: {current_advisor} — {mode_label}{suffix}\n"
-                f"{inactive_reason}"
-            )
         return (
-            f"Advisor: {current_advisor} — {mode_label}{suffix}\n"
-            'Use "/advisor unset" to disable or "/advisor <model>" to change.'
+            f"Advisor: {current_provider}:{current_advisor} — {mode_label}{suffix}\n"
+            'Use "/advisor unset" to disable or '
+            '"/advisor <provider>:<model>" to change.'
         )
 
     # No model arg, no flags → status only.
@@ -662,13 +750,16 @@ def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResu
         )
 
     # --client alone (no model) → just turn on the forced-client flag.
+    # Critic C2: both fields are required before the flag matters; a
+    # partial config + --client would silently fail at request time.
     if not arg and force_client_flag is True:
-        if not current_advisor:
+        if not current_advisor or not current_provider:
             return LocalCommandResult(
                 type="text",
                 value=(
-                    "Cannot force client mode: no advisor model is set. "
-                    'Use "/advisor <model> --client" together.'
+                    "Cannot force client mode: advisor is not fully "
+                    "configured. Use \"/advisor <provider>:<model> "
+                    "--client\" together."
                 ),
             )
         if current_client_mode:
@@ -685,51 +776,84 @@ def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResu
         )
 
     if arg_lower in ("unset", "off"):
-        previous = current_advisor
-        if previous is not None:
+        previous_model = current_advisor
+        previous_provider = current_provider
+        if previous_model:
             _write_advisor_model(context, None)
+        if previous_provider:
+            _write_advisor_provider(context, None)
         if current_client_mode:
             _write_advisor_client_mode(context, False)
+        if previous_model or previous_provider:
+            prior = (
+                f"{previous_provider}:{previous_model}"
+                if previous_provider and previous_model
+                else (previous_model or previous_provider or "?")
+            )
+            return LocalCommandResult(
+                type="text", value=f"Advisor disabled (was {prior}).",
+            )
+        return LocalCommandResult(
+            type="text", value="Advisor already unset.",
+        )
+
+    # Parse <provider>:<model> — provider must be a known config key.
+    raw = arg
+    if ":" not in raw:
+        providers = _list_configured_providers()
+        providers_hint = (
+            f" Configured providers: {', '.join(providers)}."
+            if providers else ""
+        )
         return LocalCommandResult(
             type="text",
             value=(
-                f"Advisor disabled (was {previous})." if previous
-                else "Advisor already unset."
+                "Advisor requires explicit <provider>:<model> syntax.\n"
+                f"Got: {raw!r}.{providers_hint}\n"
+                'Example: /advisor anthropic:claude-opus-4-7'
             ),
         )
-
-    # Treat the rest as a model identifier.
-    raw = arg
-    try:
-        resolved = resolve_model(raw)
-    except Exception as e:
+    provider_part, model_part = raw.split(":", 1)
+    provider_part = provider_part.strip()
+    model_part = model_part.strip()
+    if not provider_part or not model_part:
         return LocalCommandResult(
             type="text",
-            value=f"Invalid advisor model: {e}",
+            value=(
+                "Invalid syntax. Expected <provider>:<model> with both "
+                f"halves non-empty. Got: {raw!r}."
+            ),
+        )
+    # Critic S3: validate against the configured providers list
+    # unconditionally. ``_list_configured_providers`` is empty only
+    # when ``load_global`` crashes (its try/except swallows then
+    # returns []) — in that pathological case a clearer signal is
+    # better than a friendly silent-skip that lets bad input through.
+    configured = _list_configured_providers()
+    if provider_part not in configured:
+        return LocalCommandResult(
+            type="text",
+            value=(
+                f"Unknown provider {provider_part!r}. Configured: "
+                f"{', '.join(configured) or '(none — check ~/.clawcodex/config.json)'}. "
+                "Configure new providers in ~/.clawcodex/config.json."
+            ),
+        )
+    try:
+        resolved = resolve_model(model_part)
+    except Exception as e:
+        return LocalCommandResult(
+            type="text", value=f"Invalid advisor model: {e}",
         )
     if not validate_model_name(resolved):
         return LocalCommandResult(
             type="text",
-            value=f"Unknown model: {raw} ({resolved})",
-        )
-    # We no longer require ``is_valid_advisor_model`` (the strict
-    # opus-4-6/sonnet-4-6 gate) — client-side mode accepts any model
-    # that routes to a known provider. The router check is what
-    # actually matters: without it, ``execute_client_advisor`` would
-    # fail at request time and silently degrade.
-    if infer_provider_for_model(resolved) is None:
-        return LocalCommandResult(
-            type="text",
-            value=(
-                f"Cannot use {raw} ({resolved}) as advisor: no known "
-                "provider for this model. Try a model listed in "
-                "PROVIDER_INFO, or use a provider-prefixed name "
-                "(e.g. 'anthropic/claude-sonnet-4.5')."
-            ),
+            value=f"Unknown model: {model_part} ({resolved})",
         )
 
     normalized = canonical_model_name(resolved)
     _write_advisor_model(context, normalized)
+    _write_advisor_provider(context, provider_part)
     if force_client_flag is True:
         _write_advisor_client_mode(context, True)
     elif force_client_flag is False:
@@ -748,6 +872,7 @@ def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResu
         main_loop_model,
         normalized,
         force_client_mode=effective_client_mode,
+        advisor_provider=provider_part,
     )
     if chosen_mode == ADVISOR_MODE_SERVER_SIDE:
         mode_msg = "Will run server-side (Anthropic beta path)."
@@ -760,7 +885,7 @@ def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResu
         )
     return LocalCommandResult(
         type="text",
-        value=f"Advisor set to {normalized}. {mode_msg}",
+        value=f"Advisor set to {provider_part}:{normalized}. {mode_msg}",
     )
 
 

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -334,6 +334,7 @@ async def _call_model_sync(
         from ..settings.settings import get_settings
         settings = get_settings()
         configured = (getattr(settings, "advisor_model", "") or "").strip()
+        configured_provider = (getattr(settings, "advisor_provider", "") or "").strip()
         force_client = bool(getattr(settings, "advisor_client_mode", False))
         if configured:
             from ..models.model import canonical_model_name
@@ -343,6 +344,7 @@ async def _call_model_sync(
                 main_loop_model,
                 candidate,
                 force_client_mode=force_client,
+                advisor_provider=configured_provider,
             )
             if advisor_mode != ADVISOR_MODE_INACTIVE:
                 advisor_model_normalized = candidate

--- a/src/settings/types.py
+++ b/src/settings/types.py
@@ -74,6 +74,15 @@ class SettingsSchema:
     # command writes here, and _call_model_sync reads from here at request
     # time. See src/utils/advisor.py.
     advisor_model: str = ""
+    # Provider key (matches ~/.clawcodex/config.json's providers map) that
+    # serves the advisor call. REQUIRED when advisor_model is set —
+    # clawcodex is multi-provider and the same model name (e.g.
+    # ``claude-opus-4-7``) can live behind anthropic, openai (litellm),
+    # openrouter, bedrock, ... so name-based inference is ambiguous.
+    # The /advisor command writes both fields together via the
+    # ``<provider>:<model>`` syntax. Empty + advisor_model set = misconfig
+    # that surfaces as a clear error at the first advisor call.
+    advisor_provider: str = ""
     # Force client-side advisor mode (tool dispatch + separate API call)
     # even when the main provider is first-party Anthropic. Default False
     # lets the server-side beta path engage when applicable. Set via

--- a/src/state/app_state.py
+++ b/src/state/app_state.py
@@ -97,6 +97,12 @@ class AppState:
     # the settings cache so the next API call picks up the new value.
     advisor_model: str | None = None
 
+    # Provider key (matches ``~/.clawcodex/config.json``'s providers map)
+    # for the advisor model. REQUIRED when advisor_model is set —
+    # see ``src/settings/types.py:advisor_provider`` for the rationale.
+    # Persisted via ``_on_advisor_provider_change`` alongside advisor_model.
+    advisor_provider: str | None = None
+
     # Force client-side advisor mode. False = auto (server-side when
     # possible, client-side otherwise). True = always client-side even
     # on 1P Anthropic (lets users pair a non-Anthropic advisor with an
@@ -275,6 +281,40 @@ def _on_advisor_model_change(old: AppState, new: AppState) -> None:
         )
 
 
+def _on_advisor_provider_change(old: AppState, new: AppState) -> None:
+    """Persist advisor_provider to user settings + invalidate the read cache.
+
+    Same persistence pattern as :func:`_on_advisor_model_change`. Written
+    alongside advisor_model by the /advisor command (both fields are part
+    of the ``<provider>:<model>`` argument and move together). Surfaces
+    as ``settings.advisor_provider`` for the read channel; see
+    ``src/utils/advisor.py`` for the consumer side.
+    """
+    if old.advisor_provider == new.advisor_provider:
+        return
+    from src import config as cfg_mod
+    from src.settings.settings import invalidate_settings_cache
+    try:
+        mgr = cfg_mod._get_default_manager()
+        cfg = mgr.load_global()
+        settings_section = cfg.get("settings")
+        if not isinstance(settings_section, dict):
+            settings_section = {}
+        settings_section["advisor_provider"] = new.advisor_provider or ""
+        cfg["settings"] = settings_section
+        mgr.save_global(cfg)
+        invalidate_settings_cache()
+        logger.debug(
+            "AppState.advisor_provider %s -> %s — persisted + cache invalidated",
+            old.advisor_provider,
+            new.advisor_provider,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to persist advisor_provider to settings; in-memory value still active"
+        )
+
+
 def _on_advisor_client_mode_change(old: AppState, new: AppState) -> None:
     """Persist advisor_client_mode to user settings + invalidate the read cache.
 
@@ -319,6 +359,7 @@ _FIELD_HANDLERS: dict[str, Callable[[AppState, AppState], None]] = {
     "permission_mode": _on_permission_mode_change,
     "initial_message": _on_initial_message_change,
     "advisor_model": _on_advisor_model_change,
+    "advisor_provider": _on_advisor_provider_change,
     "advisor_client_mode": _on_advisor_client_mode_change,
 }
 

--- a/src/tool_system/tools/advisor.py
+++ b/src/tool_system/tools/advisor.py
@@ -38,14 +38,19 @@ def _advisor_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResul
 
     settings = get_settings()
     advisor_model = (getattr(settings, "advisor_model", "") or "").strip()
-    if not advisor_model:
-        # Defensive: the schema should never be exposed when advisor_model
-        # is empty, so reaching this branch means activation drifted from
-        # configuration. Surface as a tool failure (not a turn-killer) so
-        # the worker keeps moving.
+    advisor_provider = (getattr(settings, "advisor_provider", "") or "").strip()
+    if not advisor_model or not advisor_provider:
+        # Defensive: the schema should never be exposed when either
+        # half is empty, so reaching this branch means activation
+        # drifted from configuration. Surface as a tool failure (not
+        # a turn-killer) so the worker keeps moving.
         return ToolResult(
             name="advisor",
-            output="Advisor unavailable: no advisor_model configured.",
+            output=(
+                "Advisor unavailable: requires both advisor_provider "
+                "and advisor_model. Run /advisor <provider>:<model> "
+                "to configure."
+            ),
             is_error=True,
         )
 
@@ -55,17 +60,15 @@ def _advisor_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResul
     abort = getattr(context, "abort_controller", None)
     abort_signal = getattr(abort, "signal", None) if abort is not None else None
 
-    # ``_active_provider`` is set by ``_call_model_sync`` before the
-    # tool round (dynamic attr, not a dataclass field). Letting
-    # ``execute_client_advisor`` see it enables the "reuse main
-    # provider when it's a proxy" routing — without it, an advisor
-    # running on a litellm-backed openai-compat session would bypass
-    # the proxy and hit api.anthropic.com directly.
+    # ``main_provider`` is no longer consulted for routing — the
+    # provider is now explicit via ``advisor_provider``. Kept here for
+    # the signature only.
     main_provider = getattr(context, "_active_provider", None)
 
     ok, text, usage = execute_client_advisor(
         advisor_model,
         forwarded,
+        advisor_provider=advisor_provider,
         abort_signal=abort_signal,
         main_provider=main_provider,
     )

--- a/src/utils/advisor.py
+++ b/src/utils/advisor.py
@@ -336,56 +336,13 @@ def build_client_advisor_tool_schema() -> dict[str, Any]:
     }
 
 
-def infer_provider_for_model(model: str) -> str | None:
-    """Best-effort model → provider lookup.
-
-    Walks ``PROVIDER_INFO`` for an exact match first; falls back to
-    well-known prefix conventions. Returns ``None`` when the model
-    can't be confidently routed — callers should surface a clear error
-    to the user rather than silently picking the wrong endpoint.
-
-    The exact-match path covers the common case (user typed
-    ``gemini-2.5-pro`` and Gemini lists it). The prefix fallback covers
-    canonical names that PROVIDER_INFO's allowlist hasn't been refreshed
-    for (e.g. a new ``claude-opus-4-7`` not yet in the list — still
-    clearly Anthropic). Order matters: ``zai/`` before generic
-    ``vendor/<model>`` so OpenRouter doesn't steal GLM models.
-    """
-    if not model:
-        return None
-    # Local import to avoid pulling the providers package at module load.
-    from src.providers import PROVIDER_INFO
-
-    for name, info in PROVIDER_INFO.items():
-        if model in info.get("available_models", []):
-            return name
-
-    m = model.lower()
-    if m.startswith("zai/"):
-        return "glm"
-    if m.startswith("claude-"):
-        return "anthropic"
-    if m.startswith("gpt-") or m.startswith("o1") or m.startswith("o3"):
-        return "openai"
-    if m.startswith("gemini-"):
-        return "gemini"
-    if m.startswith("minimax-") or model.startswith("MiniMax-") or model == "M2-her":
-        return "minimax"
-    if m.startswith("deepseek-"):
-        return "deepseek"
-    # ``<vendor>/<model>`` shape after the more-specific prefix checks
-    # above. Catches OpenRouter routes like ``anthropic/claude-3.5-sonnet``.
-    if "/" in model:
-        return "openrouter"
-    return None
-
-
 def decide_advisor_mode(
     provider: "BaseProvider | None",
     main_loop_model: str | None,
     advisor_model: str | None,
     *,
     force_client_mode: bool = False,
+    advisor_provider: str | None = None,
 ) -> str:
     """Pick activation mode for the upcoming turn.
 
@@ -398,21 +355,37 @@ def decide_advisor_mode(
     Decision tree:
 
     1. ``advisor_model`` empty / env-disabled → INACTIVE.
-    2. ``force_client_mode`` set → CLIENT_SIDE iff the advisor model
-       routes to a known provider; else INACTIVE.
-    3. 1P + main_loop_model supports server advisor + advisor_model is
-       a valid server target → SERVER_SIDE (the optimized path; one
-       roundtrip, prompt-cache friendly).
-    4. Otherwise, if the advisor model routes to a known provider →
-       CLIENT_SIDE (works with any main-loop tool-calling model).
-    5. Else INACTIVE — the configured advisor model can't be reached.
+    2. ``advisor_provider`` empty → INACTIVE (the multi-provider
+       rewrite requires explicit provider; name-based inference was
+       removed because the same model name can sit behind multiple
+       providers).
+    3. ``force_client_mode`` set → CLIENT_SIDE iff the advisor
+       provider is a configured key; else INACTIVE.
+    4. 1P + main_loop_model supports server advisor + advisor_model is
+       a valid server target + advisor_provider == "anthropic" →
+       SERVER_SIDE (the optimized path; one roundtrip, prompt-cache
+       friendly). Server-side only makes sense when the advisor call
+       lands on the same Anthropic API as the main loop.
+    5. Otherwise, if the advisor provider is configured → CLIENT_SIDE.
+    6. Else INACTIVE — the configured advisor can't be reached.
     """
     if _env_truthy(_DISABLE_ENV):
         return ADVISOR_MODE_INACTIVE
     if not advisor_model:
         return ADVISOR_MODE_INACTIVE
+    if not advisor_provider:
+        return ADVISOR_MODE_INACTIVE
 
-    advisor_routes = infer_provider_for_model(advisor_model) is not None
+    # Provider must be configured in ~/.clawcodex/config.json. Use the
+    # provider class registry as the lightweight check (a key with no
+    # class registered can't be instantiated anyway).
+    advisor_routes = False
+    try:
+        from src.providers import get_provider_class
+        get_provider_class(advisor_provider)
+        advisor_routes = True
+    except Exception:
+        advisor_routes = False
 
     if force_client_mode:
         return ADVISOR_MODE_CLIENT_SIDE if advisor_routes else ADVISOR_MODE_INACTIVE
@@ -422,6 +395,7 @@ def decide_advisor_mode(
         and is_advisor_enabled(provider)
         and model_supports_advisor(main_loop_model)
         and is_valid_advisor_model(advisor_model)
+        and advisor_provider == "anthropic"
     ):
         return ADVISOR_MODE_SERVER_SIDE
 
@@ -465,6 +439,7 @@ def format_advisor_status(
     try:
         settings = get_settings()
         advisor_model = (getattr(settings, "advisor_model", "") or "").strip()
+        advisor_provider = (getattr(settings, "advisor_provider", "") or "").strip()
         if not advisor_model:
             return None
         canonical = canonical_model_name(advisor_model)
@@ -474,6 +449,7 @@ def format_advisor_status(
             main_loop_model,
             canonical,
             force_client_mode=force_client,
+            advisor_provider=advisor_provider,
         )
     except Exception:
         return None
@@ -485,7 +461,16 @@ def format_advisor_status(
     display = canonical
     if display.lower().startswith("claude-"):
         display = display[len("claude-") :]
-    return f"advisor: {display} ({label})"
+    # Qualify with the provider so the user can spot a misroute
+    # (e.g. accidentally hitting api.anthropic.com instead of litellm).
+    # Falls back to "?" when provider is missing — partial config,
+    # already covered by the INACTIVE mode label.
+    # Critic S1: colon-separated to match the /advisor slash command
+    # input syntax. Lets the user copy the bar value into /advisor
+    # verbatim. Splits unambiguously on the first colon even when the
+    # model name itself contains slashes (openrouter convention).
+    qualified = f"{advisor_provider or '?'}:{display}"
+    return f"advisor: {qualified} ({label})"
 
 
 CLIENT_ADVISOR_PROMPT_SUFFIX = (
@@ -665,33 +650,11 @@ def build_advisor_forwarded_messages(
     return flattened
 
 
-def _provider_is_using_custom_endpoint(provider: Any) -> bool:
-    """True if the provider is pointed at a non-default base URL.
-
-    Heuristic for "this provider is a proxy that can serve other
-    models" (litellm, openrouter, custom-deployment Anthropic shim,
-    etc.). When True, ``execute_client_advisor`` prefers the SAME
-    provider+config for the advisor call rather than inferring a
-    direct upstream from the model name — the user explicitly chose
-    a proxy, so route through it.
-    """
-    from src.providers import PROVIDER_INFO
-    base_url = getattr(provider, "base_url", None)
-    if not base_url:
-        return False
-    name = provider.__class__.__name__.replace("Provider", "").lower()
-    info = PROVIDER_INFO.get(name)
-    if info is None:
-        # Unknown class — assume the user customized it for a reason.
-        return True
-    default = info.get("default_base_url", "")
-    return base_url.rstrip("/") != default.rstrip("/")
-
-
 def execute_client_advisor(
     advisor_model: str,
     forwarded_messages: list[dict[str, Any]],
     *,
+    advisor_provider: str = "",
     abort_signal: Any = None,
     main_provider: Any = None,
 ) -> tuple[bool, str, dict[str, int]]:
@@ -705,18 +668,18 @@ def execute_client_advisor(
     a session-level counter so the status bar can show advisor token
     spend separately from the worker's.
 
-    Provider routing:
-    * If ``main_provider`` was passed AND it has a custom base URL
-      (i.e. the user is talking to a proxy like litellm/openrouter
-      that proxies arbitrary models), reuse the main provider's class
-      and config with the advisor's model — the proxy will handle it.
-      Without this, a litellm user would have their advisor call
-      bounce direct to api.anthropic.com instead of through their
-      configured proxy.
-    * Otherwise, infer the advisor's provider from the model name and
-      build a fresh provider from the user's saved config for that
-      provider. This handles the "advisor on a different provider"
-      case (e.g. Anthropic main + Gemini advisor).
+    Provider routing (post the multi-provider rewrite): use the
+    explicit ``advisor_provider`` key as a lookup into
+    ``~/.clawcodex/config.json``'s ``providers`` map and instantiate
+    the matching provider class with that entry's api_key + base_url,
+    overriding the model. The ``/advisor`` command writes the
+    provider key alongside the model so this function never has to
+    infer.
+
+    ``main_provider`` is no longer consulted for routing — clawcodex
+    is multi-provider, every advisor call says exactly which provider
+    it wants. The argument is preserved on the signature for callers
+    that pass it for backwards compatibility; it's ignored.
 
     Network failures, model errors, and missing-config conditions are
     all caught and surfaced as ``(False, "...", {0,0})`` rather than
@@ -725,23 +688,36 @@ def execute_client_advisor(
     uninformed and let it continue.
     """
     _zero_usage: dict[str, int] = {"input_tokens": 0, "output_tokens": 0}
+    if not advisor_provider:
+        return (
+            False,
+            "Advisor unavailable: advisor_provider is not set. Run "
+            "/advisor <provider>:<model> to configure.",
+            _zero_usage,
+        )
     try:
         from src.config import get_provider_config
         from src.providers import get_provider_class
 
-        if main_provider is not None and _provider_is_using_custom_endpoint(
-            main_provider
-        ):
-            # Reuse main provider's class + config; just swap the model.
-            provider_cls = main_provider.__class__
-            name = provider_cls.__name__.replace("Provider", "").lower()
-            cfg_raw = dict(get_provider_config(name))
-        else:
-            provider_name = infer_provider_for_model(advisor_model)
-            if provider_name is None:
-                return (False, f"Advisor unavailable: cannot route model {advisor_model!r} to a known provider.", _zero_usage)
-            provider_cls = get_provider_class(provider_name)
-            cfg_raw = dict(get_provider_config(provider_name))
+        try:
+            provider_cls = get_provider_class(advisor_provider)
+        except Exception:
+            return (
+                False,
+                f"Advisor unavailable: provider {advisor_provider!r} has "
+                "no registered Provider class. Check the provider key "
+                "in ~/.clawcodex/config.json.",
+                _zero_usage,
+            )
+        try:
+            cfg_raw = dict(get_provider_config(advisor_provider))
+        except Exception:
+            return (
+                False,
+                f"Advisor unavailable: provider {advisor_provider!r} is "
+                "not configured in ~/.clawcodex/config.json.",
+                _zero_usage,
+            )
 
         # ``get_provider_config`` returns the raw config dict shape
         # (api_key, base_url, default_model) which doesn't match the
@@ -755,7 +731,7 @@ def execute_client_advisor(
             model=advisor_model,
         )
     except Exception as e:  # noqa: BLE001 — surface as advisor failure
-        return (False, f"Advisor unavailable: failed to construct provider for {advisor_model!r}: {e}", _zero_usage)
+        return (False, f"Advisor unavailable: failed to construct {advisor_provider!r} provider for {advisor_model!r}: {e}", _zero_usage)
 
     # System-prompt delivery is provider-specific:
     #   * Anthropic-shaped providers (AnthropicProvider / MinimaxProvider)
@@ -845,7 +821,6 @@ __all__ = [
     "extract_advisor_error_code",
     "extract_advisor_result_text",
     "format_advisor_status",
-    "infer_provider_for_model",
     "is_advisor_block",
     "is_advisor_enabled",
     "is_valid_advisor_model",

--- a/tests/integration/test_advisor_smoke.py
+++ b/tests/integration/test_advisor_smoke.py
@@ -77,6 +77,12 @@ def _set_advisor(value: str) -> None:
     cfg = mgr.load_global()
     sub = cfg.get("settings") if isinstance(cfg.get("settings"), dict) else {}
     sub["advisor_model"] = value
+    # Post multi-provider rewrite: advisor_provider is required for
+    # the advisor to be considered active. Default to "anthropic" for
+    # these smoke tests since they all exercise the first-party
+    # server-side path; tests overriding to a non-anthropic provider
+    # would need to set this explicitly.
+    sub["advisor_provider"] = "anthropic" if value else ""
     cfg["settings"] = sub
     mgr.save_global(cfg)
     invalidate_settings_cache()

--- a/tests/test_advisor_client_side.py
+++ b/tests/test_advisor_client_side.py
@@ -7,7 +7,6 @@ server-side beta.
 
 Test surface:
   * ``decide_advisor_mode`` — full activation truth table.
-  * ``infer_provider_for_model`` — known + prefix + unknown shapes.
   * ``build_advisor_forwarded_messages`` — strips prior advisor blocks
     so they don't leak into the advisor's own forwarded context.
   * ``execute_client_advisor`` — wires through provider factory,
@@ -33,55 +32,7 @@ from src.utils.advisor import (
     build_client_advisor_tool_schema,
     decide_advisor_mode,
     execute_client_advisor,
-    infer_provider_for_model,
 )
-
-
-class TestInferProviderForModel(unittest.TestCase):
-    def test_exact_match_anthropic(self) -> None:
-        self.assertEqual(infer_provider_for_model("claude-opus-4-6"), "anthropic")
-        self.assertEqual(infer_provider_for_model("claude-sonnet-4-6"), "anthropic")
-
-    def test_exact_match_openai(self) -> None:
-        self.assertEqual(infer_provider_for_model("gpt-5.4"), "openai")
-
-    def test_exact_match_glm(self) -> None:
-        self.assertEqual(infer_provider_for_model("zai/glm-5"), "glm")
-
-    def test_exact_match_gemini(self) -> None:
-        self.assertEqual(infer_provider_for_model("gemini-2.5-pro"), "gemini")
-
-    def test_prefix_fallback_anthropic(self) -> None:
-        # claude-opus-4-7 isn't in PROVIDER_INFO yet but the prefix
-        # rule routes it cleanly.
-        self.assertEqual(
-            infer_provider_for_model("claude-opus-4-7-future"), "anthropic"
-        )
-
-    def test_prefix_fallback_gemini(self) -> None:
-        self.assertEqual(infer_provider_for_model("gemini-3.0-pro"), "gemini")
-
-    def test_vendor_slash_routes_to_openrouter(self) -> None:
-        # ``anthropic/claude-…`` is an OpenRouter route, not Anthropic
-        # direct — the ``/`` shape after the more-specific prefix
-        # checks routes to openrouter.
-        self.assertEqual(
-            infer_provider_for_model("anthropic/claude-sonnet-4.5"), "openrouter"
-        )
-        self.assertEqual(
-            infer_provider_for_model("meta-llama/llama-3.3-70b-instruct"),
-            "openrouter",
-        )
-
-    def test_glm_prefix_beats_openrouter_slash(self) -> None:
-        # zai/ prefix is checked before the generic vendor/<model>
-        # rule, so GLM stays with the GLM provider.
-        self.assertEqual(infer_provider_for_model("zai/glm-4.7"), "glm")
-
-    def test_unknown_model_returns_none(self) -> None:
-        self.assertIsNone(infer_provider_for_model("totally-fake-zzz-9999"))
-        self.assertIsNone(infer_provider_for_model(""))
-        self.assertIsNone(infer_provider_for_model(None))  # type: ignore[arg-type]
 
 
 class TestDecideAdvisorMode(unittest.TestCase):
@@ -118,6 +69,7 @@ class TestDecideAdvisorMode(unittest.TestCase):
             self.assertEqual(mode, ADVISOR_MODE_INACTIVE)
 
     def test_server_side_for_1p_with_valid_models(self) -> None:
+        # Server-side now requires advisor_provider == "anthropic" too.
         with patch(
             "src.state.cache_state.is_first_party_provider",
             return_value=True,
@@ -126,6 +78,7 @@ class TestDecideAdvisorMode(unittest.TestCase):
                 self._first_party_provider(),
                 "claude-opus-4-6",
                 "claude-opus-4-6",
+                advisor_provider="anthropic",
             )
             self.assertEqual(mode, ADVISOR_MODE_SERVER_SIDE)
 
@@ -139,12 +92,13 @@ class TestDecideAdvisorMode(unittest.TestCase):
                 "claude-opus-4-6",
                 "claude-opus-4-6",
                 force_client_mode=True,
+                advisor_provider="anthropic",
             )
             self.assertEqual(mode, ADVISOR_MODE_CLIENT_SIDE)
 
     def test_client_side_for_1p_with_unsupported_base_model(self) -> None:
         # opus-4-5 doesn't support server-side advisor → falls back
-        # to client-side as long as the advisor model routes.
+        # to client-side as long as the advisor provider is configured.
         with patch(
             "src.state.cache_state.is_first_party_provider",
             return_value=True,
@@ -153,6 +107,7 @@ class TestDecideAdvisorMode(unittest.TestCase):
                 self._first_party_provider(),
                 "claude-opus-4-5",
                 "claude-opus-4-6",
+                advisor_provider="anthropic",
             )
             self.assertEqual(mode, ADVISOR_MODE_CLIENT_SIDE)
 
@@ -167,13 +122,14 @@ class TestDecideAdvisorMode(unittest.TestCase):
                 self._third_party_provider(),
                 "gpt-5.4",
                 "claude-opus-4-6",
+                advisor_provider="anthropic",
             )
             self.assertEqual(mode, ADVISOR_MODE_CLIENT_SIDE)
 
     def test_client_side_cross_provider(self) -> None:
         # 1P main loop with a Gemini advisor — server-side rejects
-        # the Gemini model, falls through to client-side which routes
-        # gemini-2.5-pro to the gemini provider.
+        # because advisor_provider != "anthropic"; falls through to
+        # client-side with the gemini provider.
         with patch(
             "src.state.cache_state.is_first_party_provider",
             return_value=True,
@@ -182,29 +138,32 @@ class TestDecideAdvisorMode(unittest.TestCase):
                 self._first_party_provider(),
                 "claude-opus-4-6",
                 "gemini-2.5-pro",
+                advisor_provider="gemini",
             )
             self.assertEqual(mode, ADVISOR_MODE_CLIENT_SIDE)
 
-    def test_inactive_when_force_client_but_unrouted_model(self) -> None:
-        # Even with force_client_mode, an unroutable advisor model
-        # returns INACTIVE — there's no provider to send the request to.
+    def test_inactive_when_force_client_but_unknown_provider(self) -> None:
+        # Even with force_client_mode, an unknown provider key
+        # returns INACTIVE — no Provider class to instantiate.
         mode = decide_advisor_mode(
             self._first_party_provider(),
             "claude-opus-4-6",
             "totally-fake-xyz-9999",
             force_client_mode=True,
+            advisor_provider="not-a-real-provider-zzz",
         )
         self.assertEqual(mode, ADVISOR_MODE_INACTIVE)
 
-    def test_inactive_when_no_provider_and_no_force(self) -> None:
-        # Provider=None + no force_client + advisor_model set: the
-        # server-side gate fails (needs is_advisor_enabled which needs
-        # a provider), and client-side activates as long as advisor
-        # routes. This matches the "/advisor pre-startup" surface.
-        mode = decide_advisor_mode(None, "claude-opus-4-6", "claude-opus-4-6")
-        # No provider → can't check first-party → falls to client-side
-        # (advisor model routes to anthropic).
-        self.assertEqual(mode, ADVISOR_MODE_CLIENT_SIDE)
+    def test_inactive_when_advisor_provider_missing(self) -> None:
+        # Multi-provider rewrite: advisor_provider is now REQUIRED.
+        # Even with a valid advisor_model and a first-party main
+        # provider, missing advisor_provider → INACTIVE. This guards
+        # against the pre-rewrite hardcoded ``claude-`` → anthropic
+        # inference silently routing to the wrong endpoint.
+        mode = decide_advisor_mode(
+            None, "claude-opus-4-6", "claude-opus-4-6"
+        )
+        self.assertEqual(mode, ADVISOR_MODE_INACTIVE)
 
 
 class TestBuildAdvisorForwardedMessages(unittest.TestCase):
@@ -273,13 +232,15 @@ class TestBuildAdvisorForwardedMessages(unittest.TestCase):
         with patch("src.utils.advisor._env_truthy", return_value=False), \
              patch("src.settings.settings.get_settings") as get_s, \
              patch("src.models.model.canonical_model_name", side_effect=lambda x: x):
-            fake = type("S", (), {"advisor_model": "claude-opus-4-7", "advisor_client_mode": False})()
+            fake = type("S", (), {"advisor_model": "claude-opus-4-7", "advisor_provider": "anthropic", "advisor_client_mode": False})()
             get_s.return_value = fake
             out = format_advisor_status(None, "claude-haiku-4-5")
         self.assertIsNotNone(out)
         # claude- prefix stripped for brevity
         self.assertIn("opus-4-7", out)
         self.assertNotIn("claude-opus", out)
+        # Colon-separated qualifier (matches /advisor input syntax).
+        self.assertIn("anthropic:opus-4-7", out)
         # Mode label is one of the three known values
         self.assertTrue(
             "(server)" in out or "(client)" in out or "(inactive)" in out,
@@ -291,7 +252,7 @@ class TestBuildAdvisorForwardedMessages(unittest.TestCase):
         from unittest.mock import patch
         with patch("src.utils.advisor._env_truthy", return_value=False), \
              patch("src.settings.settings.get_settings") as get_s:
-            fake = type("S", (), {"advisor_model": "", "advisor_client_mode": False})()
+            fake = type("S", (), {"advisor_model": "", "advisor_provider": "", "advisor_client_mode": False})()
             get_s.return_value = fake
             out = format_advisor_status(None, "claude-haiku-4-5")
         self.assertIsNone(out)
@@ -303,7 +264,7 @@ class TestBuildAdvisorForwardedMessages(unittest.TestCase):
         with patch.dict(os.environ, {"CLAUDE_CODE_DISABLE_ADVISOR_TOOL": "1"}, clear=False), \
              patch("src.settings.settings.get_settings") as get_s, \
              patch("src.models.model.canonical_model_name", side_effect=lambda x: x):
-            fake = type("S", (), {"advisor_model": "claude-opus-4-7", "advisor_client_mode": False})()
+            fake = type("S", (), {"advisor_model": "claude-opus-4-7", "advisor_provider": "anthropic", "advisor_client_mode": False})()
             get_s.return_value = fake
             out = format_advisor_status(None, "claude-haiku-4-5")
         # Even with model set, env-disable → mode is INACTIVE → label shows
@@ -372,7 +333,8 @@ class TestExecuteClientAdvisor(unittest.TestCase):
                 "src.config.get_provider_config", return_value={"api_key": "test"}
             ):
                 ok, text, _usage = execute_client_advisor(
-                    "claude-opus-4-6", [{"role": "user", "content": "hi"}]
+                    "claude-opus-4-6", [{"role": "user", "content": "hi"}],
+                    advisor_provider="anthropic",
                 )
         self.assertTrue(ok)
         self.assertEqual(text, "here is advice")
@@ -394,7 +356,8 @@ class TestExecuteClientAdvisor(unittest.TestCase):
                 "src.config.get_provider_config", return_value={"api_key": "test"}
             ):
                 ok, text, _usage = execute_client_advisor(
-                    "gpt-5.4", [{"role": "user", "content": "hi"}]
+                    "gpt-5.4", [{"role": "user", "content": "hi"}],
+                    advisor_provider="openai",
                 )
         self.assertTrue(ok)
         self.assertEqual(text, "advice from openai")
@@ -406,12 +369,22 @@ class TestExecuteClientAdvisor(unittest.TestCase):
         self.assertIn("reviewer", forwarded_messages[0]["content"].lower())
         self.assertEqual(forwarded_messages[1]["role"], "user")
 
-    def test_returns_error_when_model_unroutable(self) -> None:
+    def test_returns_error_when_provider_missing(self) -> None:
+        # Multi-provider rewrite: empty advisor_provider → fail-fast.
         ok, text, _usage = execute_client_advisor(
-            "totally-fake-zzz-9999", [{"role": "user", "content": "hi"}]
+            "claude-opus-4-7", [{"role": "user", "content": "hi"}]
         )
         self.assertFalse(ok)
-        self.assertIn("cannot route", text.lower())
+        self.assertIn("advisor_provider", text.lower())
+
+    def test_returns_error_when_provider_unknown(self) -> None:
+        # An unknown provider key (no Provider class registered) → fail-fast.
+        ok, text, _usage = execute_client_advisor(
+            "claude-opus-4-7", [{"role": "user", "content": "hi"}],
+            advisor_provider="totally-fake-zzz-9999",
+        )
+        self.assertFalse(ok)
+        self.assertIn("provider", text.lower())
 
     def test_returns_error_when_provider_raises(self) -> None:
         fake_provider = self._make_anthropic_shaped_provider()
@@ -425,7 +398,8 @@ class TestExecuteClientAdvisor(unittest.TestCase):
                 "src.config.get_provider_config", return_value={"api_key": "test"}
             ):
                 ok, text, _usage = execute_client_advisor(
-                    "claude-opus-4-6", [{"role": "user", "content": "hi"}]
+                    "claude-opus-4-6", [{"role": "user", "content": "hi"}],
+                    advisor_provider="anthropic",
                 )
         self.assertFalse(ok)
         self.assertIn("network down", text)
@@ -439,27 +413,18 @@ class TestExecuteClientAdvisor(unittest.TestCase):
                 "src.config.get_provider_config", return_value={"api_key": "test"}
             ):
                 ok, text, _usage = execute_client_advisor(
-                    "claude-opus-4-6", [{"role": "user", "content": "hi"}]
+                    "claude-opus-4-6", [{"role": "user", "content": "hi"}],
+                    advisor_provider="anthropic",
                 )
         self.assertFalse(ok)
         self.assertIn("no text", text.lower())
 
-    def test_routes_through_main_provider_when_proxy(self) -> None:
-        # User's main provider is OpenAI pointed at litellm (custom
-        # base_url). The advisor model is claude-opus-4-7 which would
-        # normally infer to Anthropic — but the proxy assumption says
-        # "use the same proxy for both". We expect the advisor to be
-        # built via OpenAIProvider, NOT AnthropicProvider.
+    def test_uses_explicit_provider_for_routing(self) -> None:
+        # Multi-provider rewrite: ``advisor_provider`` decides routing,
+        # NOT the model name. Even if the model name looks like an
+        # Anthropic model, passing ``advisor_provider="openai"`` should
+        # build via the openai provider config (e.g. litellm).
         from src.providers.openai_provider import OpenAIProvider
-        # Make the main provider look like an OpenAI proxy: base_url
-        # set to something other than the default openai endpoint.
-        main_provider = MagicMock(spec=OpenAIProvider)
-        main_provider.base_url = "https://litellm.singula.ai"
-        main_provider.__class__ = OpenAIProvider
-
-        # Spy on the constructor — the advisor provider should be
-        # built from OpenAIProvider, not from infer_provider_for_model's
-        # anthropic result.
         constructed = {}
 
         def _fake_openai_init(**kwargs: Any) -> Any:
@@ -467,56 +432,32 @@ class TestExecuteClientAdvisor(unittest.TestCase):
             constructed["kwargs"] = kwargs
             inst = MagicMock(spec=OpenAIProvider)
             inst.chat_stream_response = MagicMock(
-                return_value=MagicMock(content="proxied advice")
+                return_value=MagicMock(content="via openai litellm"),
             )
             return inst
 
         with patch(
-            "src.config.get_provider_config",
-            return_value={"api_key": "k", "base_url": "https://litellm.singula.ai"},
+            "src.providers.get_provider_class",
+            return_value=lambda **kw: _fake_openai_init(**kw),
         ):
-            with patch.object(OpenAIProvider, "__new__", lambda cls, **kw: _fake_openai_init(**kw)):
+            with patch(
+                "src.config.get_provider_config",
+                return_value={
+                    "api_key": "k",
+                    "base_url": "https://litellm.singula.ai",
+                },
+            ):
                 ok, text, _usage = execute_client_advisor(
                     "claude-opus-4-7",
                     [{"role": "user", "content": "hi"}],
-                    main_provider=main_provider,
+                    advisor_provider="openai",
                 )
         self.assertTrue(ok)
-        self.assertEqual(text, "proxied advice")
-        self.assertEqual(constructed["cls"], "OpenAIProvider")
-        # Model swapped to the advisor's choice, base_url preserved
-        # (came from get_provider_config).
+        self.assertEqual(text, "via openai litellm")
         self.assertEqual(constructed["kwargs"]["model"], "claude-opus-4-7")
         self.assertEqual(
-            constructed["kwargs"]["base_url"], "https://litellm.singula.ai"
+            constructed["kwargs"]["base_url"], "https://litellm.singula.ai",
         )
-
-    def test_uses_inferred_provider_when_main_is_not_proxy(self) -> None:
-        # 1P Anthropic main loop (default base_url). Advisor model is
-        # gemini-2.5-pro → should route via inference to Gemini, NOT
-        # reuse the Anthropic main provider.
-        from src.providers.anthropic_provider import AnthropicProvider
-        main_provider = MagicMock(spec=AnthropicProvider)
-        main_provider.base_url = "https://api.anthropic.com"  # default
-
-        fake_gemini = MagicMock()
-        fake_gemini.chat_stream_response = MagicMock(
-            return_value=MagicMock(content="gemini says hi")
-        )
-        with patch(
-            "src.providers.get_provider_class",
-            return_value=lambda **kw: fake_gemini,
-        ):
-            with patch(
-                "src.config.get_provider_config", return_value={"api_key": "k"}
-            ):
-                ok, text, _usage = execute_client_advisor(
-                    "gemini-2.5-pro",
-                    [{"role": "user", "content": "hi"}],
-                    main_provider=main_provider,
-                )
-        self.assertTrue(ok)
-        self.assertEqual(text, "gemini says hi")
 
     def test_falls_back_to_chat_when_stream_unimplemented(self) -> None:
         # Older / stub providers may not implement chat_stream_response.
@@ -534,7 +475,8 @@ class TestExecuteClientAdvisor(unittest.TestCase):
                 "src.config.get_provider_config", return_value={"api_key": "test"}
             ):
                 ok, text, _usage = execute_client_advisor(
-                    "claude-opus-4-6", [{"role": "user", "content": "hi"}]
+                    "claude-opus-4-6", [{"role": "user", "content": "hi"}],
+                    advisor_provider="anthropic",
                 )
         self.assertTrue(ok)
         self.assertEqual(text, "fallback worked")
@@ -566,6 +508,7 @@ class TestAdvisorTool(unittest.TestCase):
         # short-circuit on the "no model configured" branch.
         fake_settings = MagicMock()
         fake_settings.advisor_model = "claude-opus-4-6"
+        fake_settings.advisor_provider = "anthropic"
         with patch("src.settings.settings.get_settings", return_value=fake_settings):
             with patch(
                 "src.utils.advisor.execute_client_advisor",
@@ -581,6 +524,7 @@ class TestAdvisorTool(unittest.TestCase):
         ctx.messages = [{"role": "user", "content": "task"}]
         fake_settings = MagicMock()
         fake_settings.advisor_model = "claude-opus-4-6"
+        fake_settings.advisor_provider = "anthropic"
         with patch("src.settings.settings.get_settings", return_value=fake_settings):
             with patch(
                 "src.utils.advisor.execute_client_advisor",
@@ -599,6 +543,7 @@ class TestAdvisorTool(unittest.TestCase):
         ctx.messages = [{"role": "user", "content": "task"}]
         fake_settings = MagicMock()
         fake_settings.advisor_model = "claude-opus-4-6"
+        fake_settings.advisor_provider = "anthropic"
         with patch("src.settings.settings.get_settings", return_value=fake_settings):
             with patch(
                 "src.utils.advisor.execute_client_advisor",
@@ -620,10 +565,11 @@ class TestAdvisorTool(unittest.TestCase):
         ctx = ToolContext(workspace_root=self._tmpdir)
         fake_settings = MagicMock()
         fake_settings.advisor_model = ""
+        fake_settings.advisor_provider = ""
         with patch("src.settings.settings.get_settings", return_value=fake_settings):
             result = AdvisorTool.call({}, ctx)
         self.assertTrue(result.is_error)
-        self.assertIn("no advisor_model", result.output.lower())
+        self.assertIn("advisor_provider", result.output.lower())
 
 
 class TestClientAdvisorToolSchema(unittest.TestCase):

--- a/tests/test_advisor_command.py
+++ b/tests/test_advisor_command.py
@@ -126,7 +126,7 @@ class TestAdvisorCommandGate(unittest.TestCase):
                 os.environ, {"CLAUDE_CODE_DISABLE_ADVISOR_TOOL": "1"}, clear=False
             ):
                 ctx = _make_context(provider=_fake_first_party_provider())
-                res = advisor_command_call("claude-opus-4-6", ctx)
+                res = advisor_command_call("anthropic:claude-opus-4-6", ctx)
                 self.assertIn("disabled", res.value.lower())
 
     def test_works_with_non_first_party_provider(self) -> None:
@@ -137,8 +137,8 @@ class TestAdvisorCommandGate(unittest.TestCase):
             provider = MagicMock()  # Not an AnthropicProvider
             provider.model = "gpt-5.4"
             ctx = _make_context(provider=provider)
-            res = advisor_command_call("claude-opus-4-6", ctx)
-            self.assertIn("Advisor set to claude-opus-4-6", res.value)
+            res = advisor_command_call("anthropic:claude-opus-4-6", ctx)
+            self.assertIn("Advisor set to anthropic:claude-opus-4-6", res.value)
 
 
 class TestAdvisorCommandStorePath(unittest.TestCase):
@@ -150,7 +150,7 @@ class TestAdvisorCommandStorePath(unittest.TestCase):
             ctx = _make_context(store=store, provider=_fake_first_party_provider())
             res = advisor_command_call("", ctx)
             self.assertIn("not set", res.value)
-            self.assertIn("/advisor <model>", res.value)
+            self.assertIn("/advisor <provider>:<model>", res.value)
             self.assertEqual(store.writes, [])
 
     def test_set_advisor_model(self) -> None:
@@ -159,20 +159,26 @@ class TestAdvisorCommandStorePath(unittest.TestCase):
             ctx = _make_context(
                 store=store, provider=_fake_first_party_provider("claude-opus-4-6")
             )
-            res = advisor_command_call("claude-opus-4-6", ctx)
-            self.assertIn("Advisor set to claude-opus-4-6", res.value)
-            self.assertEqual(len(store.writes), 1)
+            res = advisor_command_call("anthropic:claude-opus-4-6", ctx)
+            self.assertIn("Advisor set to anthropic:claude-opus-4-6", res.value)
+            # Two writes — model AND provider land separately on the store.
+            self.assertEqual(len(store.writes), 2)
             self.assertEqual(store.writes[-1].advisor_model, "claude-opus-4-6")
+            self.assertEqual(store.writes[-1].advisor_provider, "anthropic")
 
     def test_unset_clears_when_set(self) -> None:
         with _IsolatedEnv():
             from src.state.app_state import AppState
-            store = _FakeStore(initial=AppState(advisor_model="claude-opus-4-6"))
+            store = _FakeStore(initial=AppState(
+                advisor_model="claude-opus-4-6",
+                advisor_provider="anthropic",
+            ))
             ctx = _make_context(store=store, provider=_fake_first_party_provider())
             res = advisor_command_call("unset", ctx)
             self.assertIn("disabled", res.value.lower())
-            self.assertIn("claude-opus-4-6", res.value)
+            self.assertIn("anthropic:claude-opus-4-6", res.value)
             self.assertEqual(store.writes[-1].advisor_model, None)
+            self.assertEqual(store.writes[-1].advisor_provider, None)
 
     def test_unset_idempotent_when_not_set(self) -> None:
         with _IsolatedEnv():
@@ -190,44 +196,55 @@ class TestAdvisorCommandStorePath(unittest.TestCase):
             store = _FakeStore()
             provider = _fake_first_party_provider("claude-opus-4-5")
             ctx = _make_context(store=store, provider=provider)
-            res = advisor_command_call("claude-opus-4-6", ctx)
-            self.assertIn("Advisor set to claude-opus-4-6", res.value)
+            res = advisor_command_call("anthropic:claude-opus-4-6", ctx)
+            self.assertIn("Advisor set to anthropic:claude-opus-4-6", res.value)
             self.assertIn("client-side", res.value.lower())
 
     def test_no_arg_shows_client_side_for_unsupported_base(self) -> None:
         with _IsolatedEnv():
             from src.state.app_state import AppState
-            store = _FakeStore(initial=AppState(advisor_model="claude-opus-4-6"))
+            store = _FakeStore(initial=AppState(
+                advisor_model="claude-opus-4-6",
+                advisor_provider="anthropic",
+            ))
             provider = _fake_first_party_provider("claude-opus-4-5")
             ctx = _make_context(store=store, provider=provider)
             res = advisor_command_call("", ctx)
-            self.assertIn("Advisor: claude-opus-4-6", res.value)
+            self.assertIn("Advisor: anthropic:claude-opus-4-6", res.value)
             # Now active client-side rather than "inactive".
             self.assertIn("client-side", res.value.lower())
 
     def test_accepts_non_server_side_advisor_model(self) -> None:
-        # haiku-4-5 isn't valid for server-side, but it routes to
-        # anthropic and works client-side. The command should accept
-        # it (previously it was rejected by is_valid_advisor_model).
+        # haiku-4-5 isn't valid for server-side, but it works
+        # client-side. The command should accept it.
         with _IsolatedEnv():
             store = _FakeStore()
             ctx = _make_context(store=store, provider=_fake_first_party_provider())
-            res = advisor_command_call("haiku", ctx)
+            res = advisor_command_call("anthropic:haiku", ctx)
             self.assertIn("Advisor set to", res.value)
-            self.assertEqual(len(store.writes), 1)
+            # Two writes — model and provider land separately.
+            self.assertEqual(len(store.writes), 2)
 
-    def test_rejects_unroutable_model(self) -> None:
-        # A model that doesn't resolve to any provider must still be
-        # rejected — the client-side path needs a provider to call.
+    def test_rejects_unknown_provider(self) -> None:
+        # An unknown provider key must be rejected — clawcodex needs a
+        # registered Provider class to instantiate. The old test
+        # (rejects_unroutable_model) checked rejection by MODEL name;
+        # that's no longer a thing since the provider is explicit.
         with _IsolatedEnv():
             store = _FakeStore()
             ctx = _make_context(store=store, provider=_fake_first_party_provider())
-            res = advisor_command_call("totally-fake-provider-zzz-9999", ctx)
-            self.assertTrue(
-                "Unknown" in res.value
-                or "no known provider" in res.value.lower(),
-                f"unexpected reject path: {res.value!r}",
-            )
+            res = advisor_command_call("not-a-real-provider-zzz:foo-model", ctx)
+            self.assertIn("Unknown provider", res.value)
+            self.assertEqual(store.writes, [])
+
+    def test_rejects_missing_colon(self) -> None:
+        # Bare model name (no provider:) must be rejected; the old
+        # behavior of "/advisor opus" silently inferring is gone.
+        with _IsolatedEnv():
+            store = _FakeStore()
+            ctx = _make_context(store=store, provider=_fake_first_party_provider())
+            res = advisor_command_call("claude-opus-4-6", ctx)
+            self.assertIn("<provider>:<model>", res.value)
             self.assertEqual(store.writes, [])
 
 
@@ -237,8 +254,8 @@ class TestAdvisorCommandSettingsPath(unittest.TestCase):
     def test_set_persists_to_settings(self) -> None:
         with _IsolatedEnv():
             ctx = _make_context(provider=_fake_first_party_provider())
-            res = advisor_command_call("claude-opus-4-6", ctx)
-            self.assertIn("Advisor set to claude-opus-4-6", res.value)
+            res = advisor_command_call("anthropic:claude-opus-4-6", ctx)
+            self.assertIn("Advisor set to anthropic:claude-opus-4-6", res.value)
             # Read back via the settings stack (fresh load).
             from src.settings.settings import get_settings, invalidate_settings_cache
             invalidate_settings_cache()
@@ -247,7 +264,7 @@ class TestAdvisorCommandSettingsPath(unittest.TestCase):
     def test_unset_persists_to_settings(self) -> None:
         with _IsolatedEnv():
             ctx = _make_context(provider=_fake_first_party_provider())
-            advisor_command_call("claude-opus-4-6", ctx)
+            advisor_command_call("anthropic:claude-opus-4-6", ctx)
             # Now unset it.
             res = advisor_command_call("off", ctx)
             self.assertIn("disabled", res.value.lower())
@@ -264,7 +281,7 @@ class TestAdvisorCommandSettingsPath(unittest.TestCase):
             # Prime the cache.
             self.assertEqual(get_settings().advisor_model, "")
             ctx = _make_context(provider=_fake_first_party_provider())
-            advisor_command_call("claude-opus-4-6", ctx)
+            advisor_command_call("anthropic:claude-opus-4-6", ctx)
             # No explicit invalidate — the command must do it.
             self.assertEqual(get_settings().advisor_model, "claude-opus-4-6")
 
@@ -284,7 +301,7 @@ class TestAdvisorCommandStorePathInvalidatesCache(unittest.TestCase):
             # Prime cache.
             self.assertEqual(get_settings().advisor_model, "")
             ctx = _make_context(store=store, provider=_fake_first_party_provider())
-            advisor_command_call("claude-opus-4-6", ctx)
+            advisor_command_call("anthropic:claude-opus-4-6", ctx)
             # Store handler should have written + invalidated.
             self.assertEqual(get_settings().advisor_model, "claude-opus-4-6")
             # And the store itself reflects the value.

--- a/tests/test_advisor_request_wiring.py
+++ b/tests/test_advisor_request_wiring.py
@@ -142,7 +142,7 @@ class TestAdvisorActiveOnFirstPartyAnthropic(unittest.TestCase):
         self._iso = _isolate_env()
         self._iso.enter()
         os.environ.pop("CLAUDE_CODE_DISABLE_ADVISOR_TOOL", None)
-        _set_settings(advisor_model="claude-opus-4-6")
+        _set_settings(advisor_model="claude-opus-4-6", advisor_provider="anthropic")
 
     def tearDown(self) -> None:
         # _iso.exit() restores the real config paths AND clears the
@@ -317,7 +317,7 @@ class TestAdvisorInactivePaths(unittest.TestCase):
         self._assert_inactive(cap)
 
     def test_no_advisor_when_env_disabled(self) -> None:
-        _set_settings(advisor_model="claude-opus-4-6")
+        _set_settings(advisor_model="claude-opus-4-6", advisor_provider="anthropic")
         with patch.dict(
             os.environ, {"CLAUDE_CODE_DISABLE_ADVISOR_TOOL": "1"}, clear=False
         ):
@@ -326,12 +326,17 @@ class TestAdvisorInactivePaths(unittest.TestCase):
             _run(provider, [UserMessage(content="x")])
             self._assert_inactive(cap)
 
-    def test_no_advisor_when_advisor_model_does_not_route(self) -> None:
-        # An advisor model string that doesn't match any provider's
-        # available_models AND doesn't match a known prefix → no
-        # client-side route → INACTIVE. The strict "valid for
-        # server-side" gate is gone; only the routing gate remains.
-        _set_settings(advisor_model="some-totally-unknown-model-xyz")
+    def test_no_advisor_when_provider_unknown(self) -> None:
+        # Post multi-provider rewrite: routing is decided by the
+        # explicit advisor_provider, not the model name. An UNKNOWN
+        # provider key (no registered Provider class) → INACTIVE.
+        # The old "unknown model name" scenario no longer triggers
+        # this branch — model names aren't validated against any list
+        # in client-side mode.
+        _set_settings(
+            advisor_model="claude-opus-4-6",
+            advisor_provider="not-a-real-provider-zzz",
+        )
         cap = _Capture()
         provider = _stub_provider_class(AnthropicProvider, cap)
         _run(provider, [UserMessage(content="x")])
@@ -341,7 +346,7 @@ class TestAdvisorInactivePaths(unittest.TestCase):
         # Custom-endpoint Anthropic is treated as 3P for server-side
         # purposes (no beta header, no advisor_20260301 schema), but
         # client-side mode covers it now.
-        _set_settings(advisor_model="claude-opus-4-6")
+        _set_settings(advisor_model="claude-opus-4-6", advisor_provider="anthropic")
         cap = _Capture()
         provider = _stub_provider_class(AnthropicProvider, cap)
         provider.has_custom_endpoint = MagicMock(return_value=True)
@@ -352,7 +357,7 @@ class TestAdvisorInactivePaths(unittest.TestCase):
         # opus-4-5 doesn't support the server-side beta — under the
         # old strict rules, advisor went inactive. Now it falls back to
         # client-side (any tool-calling main loop works).
-        _set_settings(advisor_model="claude-opus-4-6")
+        _set_settings(advisor_model="claude-opus-4-6", advisor_provider="anthropic")
         cap = _Capture()
         provider = _stub_provider_class(AnthropicProvider, cap)
         provider.model = "claude-opus-4-5"
@@ -363,7 +368,7 @@ class TestAdvisorInactivePaths(unittest.TestCase):
         # haiku-4-5 isn't a valid server-side advisor (only opus-4-6 /
         # sonnet-4-6 are) — but it routes to anthropic and works
         # client-side.
-        _set_settings(advisor_model="claude-haiku-4-5")
+        _set_settings(advisor_model="claude-haiku-4-5", advisor_provider="anthropic")
         cap = _Capture()
         provider = _stub_provider_class(AnthropicProvider, cap)
         _run(provider, [UserMessage(content="x")])
@@ -417,7 +422,7 @@ class TestAdvisorActivationDefensive(unittest.TestCase):
         iso = _isolate_env()
         iso.enter()
         try:
-            _set_settings(advisor_model="claude-opus-4-6")
+            _set_settings(advisor_model="claude-opus-4-6", advisor_provider="anthropic")
             cap = _Capture()
             provider = _stub_provider_class(AnthropicProvider, cap)
             with patch(


### PR DESCRIPTION
## Summary

**Breaking change.** The `/advisor` command no longer infers the provider from the model name. clawcodex is multi-provider — `claude-opus-4-7` can live behind `anthropic` (direct), `openai` (litellm proxy), `openrouter`, `bedrock`, etc. Name-based inference silently routed to the wrong endpoint.

The user's test case surfaced this concretely: with `claude-opus-4-7` configured in the openai provider entry (pointing at litellm.singula.ai) but the anthropic entry having no credits, `/advisor claude-opus-4-7` would hit `api.anthropic.com` and 400 with `credit balance too low`.

## New syntax

\`\`\`
/advisor anthropic:claude-opus-4-7        # direct Anthropic
/advisor openai:claude-opus-4-7           # via litellm/proxy
/advisor openrouter:anthropic/claude-opus-4.1
/advisor gemini:gemini-2.5-pro
\`\`\`

Splits on the first colon so model names with slashes/colons round-trip cleanly. Validates the provider key against `~/.clawcodex/config.json`'s `providers` map.

## What changed

| Layer | Change |
|---|---|
| `src/settings/types.py` | New `advisor_provider: str = ""` field. |
| `src/state/app_state.py` | New `AppState.advisor_provider` + `_on_advisor_provider_change` subscription. |
| `src/command_system/builtins.py` | `/advisor` requires `<provider>:<model>` syntax. New helpers `_read_current_advisor_provider`, `_write_advisor_provider`, `_list_configured_providers`. |
| `src/utils/advisor.py` | `execute_client_advisor` takes `advisor_provider` (no inference). `decide_advisor_mode` requires `advisor_provider`. `format_advisor_status` shows `openai:opus-4-7` (colon, matches /advisor input). |
| `src/query/query.py` | Reads `settings.advisor_provider` and forwards to `decide_advisor_mode`. |
| `src/tool_system/tools/advisor.py` | Refuses if either `advisor_model` or `advisor_provider` is empty. |
| Tests | 4 files updated: all `/advisor` invocations rewritten, fixtures set both fields, new tests for `test_rejects_missing_colon` and `test_rejects_unknown_provider`. |

## Dead code removed

* `infer_provider_for_model` (the model→provider prefix inference)
* `_provider_is_using_custom_endpoint` (the "reuse main provider if it has a custom endpoint" heuristic)
* `TestInferProviderForModel` test class
* Removed from `__all__`

These were the inference layer that the rewrite explicitly drops.

## Critic-driven fixes (one round, all addressed)

* **C1**: partial-config status now surfaces `advisor_client_mode` when ON so users see stored state that would silently activate once both fields are filled.
* **C2**: `--client alone` checks BOTH `current_advisor` AND `current_provider` before enabling.
* **C3**: stale `<model>` syntax hint in an error message replaced with `<provider>:<model>`.
* **S1**: status bar uses colon (`anthropic:opus-4-7`) matching `/advisor` input syntax. User can copy from bar to command verbatim.
* **S3**: dropped fragile `if configured` guard — corrupt-config silent-skip turned into a loud error.

## Breaking change migration

Existing users with `settings.advisor_model = "claude-opus-4-7"` (no `advisor_provider` set) will see:

* Status bar: `advisor: ?/opus-4-7 (inactive)`
* `/advisor` no-args: `Advisor: not set\n(Found advisor_model='claude-opus-4-7' but no advisor_provider — clear with /advisor unset then re-run with the explicit syntax.)\nUse "/advisor <provider>:<model>" to enable, e.g.:\n  /advisor anthropic:claude-opus-4-7   (direct Anthropic)\n  /advisor openai:claude-opus-4-7      (via openai-compat, e.g. litellm)\n  /advisor openrouter:anthropic/claude-opus-4.1`

No silent failures; clear migration path.

## Tests

* **677 passed** across the full advisor + adapter + TUI + helpers + smoke + headless suites.

## Live verified

The user's exact scenario:

\`\`\`
~/.clawcodex/config.json:
  settings:
    advisor_model: claude-opus-4-7
    advisor_provider: openai      # was missing — now required
  providers.openai.base_url: https://litellm.singula.ai

clawcodex --provider openrouter --model deepseek/deepseek-v4-pro -p "..."
\`\`\`

Result: deepseek worker called advisor, the advisor request went via openai/litellm (NOT direct Anthropic), opus-4-7 returned real advice — *"use heapq.nlargest(k, nums) for O(n log k) time. Handle edge cases: k <= 0 returns [], k >= len(nums) returns sorted..."*. The previous 400-credit-balance error is gone. Files created, exit 0, num_turns=6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)