### PR TITLE
feat(cost): show USD cost in REPL + TUI status bars

### DIFF
--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -697,12 +697,43 @@ class ClawcodexREPL:
                 f" (advisor: {adv_in} in / {adv_out} out)"
                 if (adv_in or adv_out) else ""
             )
+            # USD cost — directional estimate based on the upstream
+            # model's published per-token price. Proxies (litellm,
+            # openrouter, bedrock) may charge different rates; the
+            # displayed number is the upstream-list cost, not the
+            # exact invoice. Hidden when zero (no API turns yet this
+            # session).
+            from src.services.pricing import (
+                compute_session_cost,
+                format_cost_usd,
+            )
+            try:
+                from src.settings.settings import get_settings as _gs
+                _settings = _gs()
+                _advisor_model = (getattr(_settings, "advisor_model", "") or "").strip()
+            except Exception:
+                _advisor_model = ""
+            worker_cost, advisor_cost, total_cost = compute_session_cost(
+                worker_model=model,
+                worker_input_tokens=self._stats_input_tokens,
+                worker_output_tokens=self._stats_output_tokens,
+                advisor_model=_advisor_model,
+                advisor_input_tokens=adv_in,
+                advisor_output_tokens=adv_out,
+            )
+            # Space-separated label (matches TUI's "cost N" pattern;
+            # avoids the REPL/TUI label-style split critic flagged).
+            cost_part = (
+                f" · cost {format_cost_usd(total_cost)}"
+                if total_cost > 0 else ""
+            )
             return (
                 f" {provider} · {model} · {cwd} ·{advisor_part} "
                 f"turns: {self._stats_turns} · "
                 f"tokens: {self._stats_input_tokens} in / "
                 f"{self._stats_output_tokens} out"
-                f"{advisor_tokens} "
+                f"{advisor_tokens}"
+                f"{cost_part} "
             )
         except Exception:
             # Never let the toolbar break the input prompt.

--- a/src/services/cost_tracker.py
+++ b/src/services/cost_tracker.py
@@ -85,7 +85,11 @@ class CostTracker:
     _unknown_models: set[str] = field(default_factory=set)
 
     def record_usage(self, model: str, usage: dict[str, Any]) -> float:
-        pricing = _get_pricing(model)
+        # Legacy cost-tracker contract: always price something (the
+        # rolling session total has to be monotonic). For unknown
+        # models, fall back to DEFAULT_PRICING — divergent from the
+        # status-bar path, which suppresses unknowns entirely.
+        pricing = _get_pricing(model) or DEFAULT_PRICING
 
         input_tokens = int(usage.get("input_tokens", 0))
         output_tokens = int(usage.get("output_tokens", 0))
@@ -153,7 +157,7 @@ class CostTracker:
     def get_cache_savings(self) -> float:
         total_savings = 0.0
         for event in self._events:
-            pricing = _get_pricing(event.model)
+            pricing = _get_pricing(event.model) or DEFAULT_PRICING
             saved_per_token = pricing["input"] - pricing["cache_read"]
             total_savings += event.cache_read_input_tokens * saved_per_token
         return total_savings

--- a/src/services/pricing.py
+++ b/src/services/pricing.py
@@ -5,8 +5,16 @@ of cost state lives in ``src.bootstrap.state`` (via
 ``add_to_total_cost_state`` and friends); this module just computes the
 dollar cost of a usage record.
 
-Extracted from the (deprecated) ``src/services/cost_tracker.py`` as part
-of Phase 2.3 of the ch03 state refactor.
+Pricing mirrors ``typescript/src/utils/modelCost.ts``: published Anthropic
+list prices per million tokens for first-party direct calls. Proxies
+(litellm, openrouter, bedrock, vertex) may apply different rates;
+``compute_cost`` reports the upstream model price regardless of how the
+request is actually routed. Users running through a proxy should treat
+the displayed cost as a directional estimate.
+
+For non-Anthropic models we fall back to ``DEFAULT_PRICING`` (sonnet-tier
+rates) — accurate per-provider tables are a future followup; for now the
+default gives the right order-of-magnitude.
 """
 
 from __future__ import annotations
@@ -14,77 +22,159 @@ from __future__ import annotations
 from typing import Any
 
 
-PRICING: dict[str, dict[str, float]] = {
-    "claude-opus-4-20250514": {
-        "input": 15.0 / 1_000_000,
-        "output": 75.0 / 1_000_000,
-        "cache_creation": 18.75 / 1_000_000,
-        "cache_read": 1.50 / 1_000_000,
-    },
-    "claude-sonnet-4-20250514": {
-        "input": 3.0 / 1_000_000,
-        "output": 15.0 / 1_000_000,
-        "cache_creation": 3.75 / 1_000_000,
-        "cache_read": 0.30 / 1_000_000,
-    },
-    "claude-3-7-sonnet-20250219": {
-        "input": 3.0 / 1_000_000,
-        "output": 15.0 / 1_000_000,
-        "cache_creation": 3.75 / 1_000_000,
-        "cache_read": 0.30 / 1_000_000,
-    },
-    "claude-3-5-sonnet-20241022": {
-        "input": 3.0 / 1_000_000,
-        "output": 15.0 / 1_000_000,
-        "cache_creation": 3.75 / 1_000_000,
-        "cache_read": 0.30 / 1_000_000,
-    },
-    "claude-3-5-sonnet-20240620": {
-        "input": 3.0 / 1_000_000,
-        "output": 15.0 / 1_000_000,
-        "cache_creation": 3.75 / 1_000_000,
-        "cache_read": 0.30 / 1_000_000,
-    },
-    "claude-3-haiku-20240307": {
-        "input": 0.25 / 1_000_000,
-        "output": 1.25 / 1_000_000,
-        "cache_creation": 0.30 / 1_000_000,
-        "cache_read": 0.03 / 1_000_000,
-    },
-    "claude-3-5-haiku-20241022": {
-        "input": 1.0 / 1_000_000,
-        "output": 5.0 / 1_000_000,
-        "cache_creation": 1.25 / 1_000_000,
-        "cache_read": 0.10 / 1_000_000,
-    },
-}
-
-DEFAULT_PRICING: dict[str, float] = {
+# Pricing tiers (USD per million tokens) — mirrors TS modelCost.ts.
+_TIER_3_15 = {
     "input": 3.0 / 1_000_000,
     "output": 15.0 / 1_000_000,
     "cache_creation": 3.75 / 1_000_000,
     "cache_read": 0.30 / 1_000_000,
 }
+_TIER_15_75 = {
+    "input": 15.0 / 1_000_000,
+    "output": 75.0 / 1_000_000,
+    "cache_creation": 18.75 / 1_000_000,
+    "cache_read": 1.50 / 1_000_000,
+}
+_TIER_5_25 = {
+    "input": 5.0 / 1_000_000,
+    "output": 25.0 / 1_000_000,
+    "cache_creation": 6.25 / 1_000_000,
+    "cache_read": 0.50 / 1_000_000,
+}
+_TIER_HAIKU_45 = {
+    "input": 1.0 / 1_000_000,
+    "output": 5.0 / 1_000_000,
+    "cache_creation": 1.25 / 1_000_000,
+    "cache_read": 0.10 / 1_000_000,
+}
+_TIER_HAIKU_35 = {
+    "input": 0.80 / 1_000_000,
+    "output": 4.0 / 1_000_000,
+    "cache_creation": 1.0 / 1_000_000,
+    "cache_read": 0.08 / 1_000_000,
+}
+_TIER_HAIKU_3 = {
+    "input": 0.25 / 1_000_000,
+    "output": 1.25 / 1_000_000,
+    "cache_creation": 0.30 / 1_000_000,
+    "cache_read": 0.03 / 1_000_000,
+}
 
 
-def get_pricing(model: str) -> dict[str, float]:
-    """Return per-token prices for ``model``. Falls back to the closest
-    prefix match, then to ``DEFAULT_PRICING``."""
+# Exact-match table — keyed by canonical model name. Order DOESN'T matter
+# for exact match but DOES matter for the prefix fallback below
+# (more-specific keys must come first). See ``get_pricing``.
+PRICING: dict[str, dict[str, float]] = {
+    # Haiku family
+    "claude-haiku-4-5": _TIER_HAIKU_45,
+    "claude-3-5-haiku-20241022": _TIER_HAIKU_45,
+    "claude-3-haiku-20240307": _TIER_HAIKU_3,
+    # Sonnet family — all on the standard 3/15 tier
+    "claude-sonnet-4-6": _TIER_3_15,
+    "claude-sonnet-4-5": _TIER_3_15,
+    "claude-sonnet-4-20250514": _TIER_3_15,
+    "claude-3-7-sonnet-20250219": _TIER_3_15,
+    "claude-3-5-sonnet-20241022": _TIER_3_15,
+    "claude-3-5-sonnet-20240620": _TIER_3_15,
+    # Opus family — 4.5+ on the 5/25 tier, 4.0/4.1 on 15/75
+    "claude-opus-4-7": _TIER_5_25,
+    "claude-opus-4-6": _TIER_5_25,
+    "claude-opus-4-5": _TIER_5_25,
+    "claude-opus-4-1": _TIER_15_75,
+    "claude-opus-4-20250514": _TIER_15_75,
+}
+
+
+# Legacy alias — older callers (cost_tracker facade) still default to
+# the sonnet-3/15 tier when a model is missing. The status-bar path
+# uses ``get_pricing`` which returns None for unknowns and skips the
+# segment rather than silently mispricing (see critic C1 below).
+DEFAULT_PRICING: dict[str, float] = _TIER_3_15
+
+
+# Family prefixes for fallback when an exact match misses. Order
+# matters: longer/more-specific *canonical-form* prefixes first within
+# a family. Critic C2: the bare ``claude-opus-4`` prefix was REMOVED
+# — it forced future variants (claude-opus-4-9-future) onto the legacy
+# 15/75 tier, but the modern Opus trend (4-5/4-6/4-7) is on the 5/25
+# tier. Unknown opus-4.x now falls through to None instead of being
+# tagged with the wrong price.
+_FAMILY_PREFIXES: list[tuple[str, dict[str, float]]] = [
+    ("claude-haiku-4", _TIER_HAIKU_45),
+    ("claude-3-5-haiku", _TIER_HAIKU_45),
+    ("claude-3-haiku", _TIER_HAIKU_3),
+    ("claude-opus-4-7", _TIER_5_25),
+    ("claude-opus-4-6", _TIER_5_25),
+    ("claude-opus-4-5", _TIER_5_25),
+    ("claude-opus-4-1", _TIER_15_75),
+    ("claude-sonnet-4", _TIER_3_15),
+    ("claude-3-7-sonnet", _TIER_3_15),
+    ("claude-3-5-sonnet", _TIER_3_15),
+]
+
+
+def get_pricing(model: str) -> dict[str, float] | None:
+    """Return per-token prices for ``model``, or ``None`` if unknown.
+
+    Lookup order:
+      1. Exact match in ``PRICING``.
+      2. Strip a leading ``<vendor>/`` segment (openrouter convention,
+         e.g. ``anthropic/claude-opus-4.1``) and retry exact match.
+      3. Family-prefix match against ``_FAMILY_PREFIXES``.
+      4. ``None`` — caller decides whether to suppress the cost
+         display (status-bar path) or fall back to ``DEFAULT_PRICING``
+         (legacy cost-tracker facade).
+
+    Critic C1: returning ``None`` instead of a generic Sonnet-tier
+    fallback prevents silently mispricing non-Claude models by 10×
+    (DeepSeek $0.27/$1.10 vs sonnet $3/$15) or 3-5× (Gemini, GPT-5).
+    The user picks "no number" over "wrong number" for status-bar
+    honesty; per-provider tier tables are a future PR.
+    """
+    if not model:
+        return None
     if model in PRICING:
         return PRICING[model]
-    for prefix, pricing in PRICING.items():
-        if model.startswith(prefix.rsplit("-", 1)[0]):
+    if "/" in model:
+        bare = model.split("/", 1)[1]
+        if bare in PRICING:
+            return PRICING[bare]
+        for prefix, pricing in _FAMILY_PREFIXES:
+            if bare.startswith(prefix):
+                return pricing
+    for prefix, pricing in _FAMILY_PREFIXES:
+        if model.startswith(prefix):
             return pricing
-    return DEFAULT_PRICING
+    return None
+
+
+def is_known_pricing(model: str) -> bool:
+    """True iff ``model`` has a real pricing entry (not the legacy
+    default fallback). Callers that need a "show or hide?" flag for
+    cost UI can use this instead of inspecting the return shape."""
+    return get_pricing(model) is not None
 
 
 def compute_cost(model: str, usage: dict[str, Any]) -> float:
-    """Compute USD cost for a usage record. Pure function."""
+    """Compute USD cost for a usage record. Pure function.
+
+    Returns 0.0 when the model has no pricing entry (rather than
+    guessing with ``DEFAULT_PRICING``). The legacy cost-tracker facade
+    that wants the old "always charge something" behavior should call
+    ``get_pricing(model) or DEFAULT_PRICING`` explicitly.
+
+    Reads ``input_tokens``, ``output_tokens``,
+    ``cache_creation_input_tokens``, and ``cache_read_input_tokens``
+    from ``usage``. Missing keys default to zero so callers that only
+    track input+output still get a sensible result.
+    """
     pricing = get_pricing(model)
-    input_tokens = int(usage.get("input_tokens", 0))
-    output_tokens = int(usage.get("output_tokens", 0))
-    cache_creation = int(usage.get("cache_creation_input_tokens", 0))
-    cache_read = int(usage.get("cache_read_input_tokens", 0))
+    if pricing is None:
+        return 0.0
+    input_tokens = int(usage.get("input_tokens", 0) or 0)
+    output_tokens = int(usage.get("output_tokens", 0) or 0)
+    cache_creation = int(usage.get("cache_creation_input_tokens", 0) or 0)
+    cache_read = int(usage.get("cache_read_input_tokens", 0) or 0)
     return (
         input_tokens * pricing["input"]
         + output_tokens * pricing["output"]
@@ -93,4 +183,76 @@ def compute_cost(model: str, usage: dict[str, Any]) -> float:
     )
 
 
-__all__ = ["PRICING", "DEFAULT_PRICING", "get_pricing", "compute_cost"]
+def format_cost_usd(amount: float) -> str:
+    """Render a USD amount compactly for the status bar.
+
+    * ``< $0.01`` → 4 decimals (``$0.0034``) so sub-cent activity is
+      visible.
+    * ``< $10``   → 3 decimals (``$1.234``) — typical session range,
+      cents-accurate.
+    * ``≥ $10``   → 2 decimals (``$12.34``) — penny-rounding is fine
+      when the order of magnitude is high.
+
+    Always shows ``$0.0000`` (not blank) for non-positive amounts so the
+    caller can omit the segment with a single zero-check rather than
+    parsing the format.
+    """
+    if amount <= 0:
+        return "$0.0000"
+    if amount < 0.01:
+        return f"${amount:.4f}"
+    if amount < 10:
+        return f"${amount:.3f}"
+    return f"${amount:.2f}"
+
+
+def compute_session_cost(
+    *,
+    worker_model: str | None,
+    worker_input_tokens: int,
+    worker_output_tokens: int,
+    worker_cache_creation_tokens: int = 0,
+    worker_cache_read_tokens: int = 0,
+    advisor_model: str | None = None,
+    advisor_input_tokens: int = 0,
+    advisor_output_tokens: int = 0,
+) -> tuple[float, float, float]:
+    """Compute (worker_cost, advisor_cost, total_cost) for a session.
+
+    Caller passes the running token accumulators from whichever surface
+    is rendering (REPL bottom_toolbar reads its ``_stats_*``, TUI
+    StatusLine reads ``state.usage``). The function does the per-model
+    pricing lookups and returns the three dollar amounts so the caller
+    can format/display however it wants.
+
+    Worker cache token counts default to zero — callers that don't
+    track cache separately (most of them, today) just get input+output
+    pricing. Advisor cache is ignored entirely; the advisor's separate
+    API call doesn't get cache hits across runs.
+    """
+    worker_cost = 0.0
+    if worker_model and (worker_input_tokens or worker_output_tokens):
+        worker_cost = compute_cost(worker_model, {
+            "input_tokens": worker_input_tokens,
+            "output_tokens": worker_output_tokens,
+            "cache_creation_input_tokens": worker_cache_creation_tokens,
+            "cache_read_input_tokens": worker_cache_read_tokens,
+        })
+    advisor_cost = 0.0
+    if advisor_model and (advisor_input_tokens or advisor_output_tokens):
+        advisor_cost = compute_cost(advisor_model, {
+            "input_tokens": advisor_input_tokens,
+            "output_tokens": advisor_output_tokens,
+        })
+    return worker_cost, advisor_cost, worker_cost + advisor_cost
+
+
+__all__ = [
+    "PRICING",
+    "DEFAULT_PRICING",
+    "get_pricing",
+    "is_known_pricing",
+    "compute_cost",
+    "compute_session_cost",
+    "format_cost_usd",
+]

--- a/src/tui/widgets/status_line.py
+++ b/src/tui/widgets/status_line.py
@@ -165,7 +165,9 @@ class StatusLine(Static):
         if self.queued:
             right_bits.append(f"queued {self.queued}")
         if state and state.usage:
-            total = state.usage.get("input_tokens", 0) + state.usage.get("output_tokens", 0)
+            in_t = state.usage.get("input_tokens", 0)
+            out_t = state.usage.get("output_tokens", 0)
+            total = in_t + out_t
             if total:
                 right_bits.append(f"tokens {total}")
             # Advisor token segment — appears next to worker tokens
@@ -180,6 +182,32 @@ class StatusLine(Static):
             adv_out = state.usage.get("advisor_output_tokens", 0)
             if adv_in or adv_out:
                 right_bits.append(f"advisor {adv_in}/{adv_out}")
+            # USD cost segment — uses the shared compute_session_cost
+            # helper so REPL and TUI render identical numbers for the
+            # same usage. Directional estimate based on upstream model
+            # prices; proxies (litellm/openrouter/bedrock) may bill
+            # differently. Hidden when zero.
+            try:
+                from src.services.pricing import (
+                    compute_session_cost,
+                    format_cost_usd,
+                )
+                from src.settings.settings import get_settings
+                _adv_model = (
+                    getattr(get_settings(), "advisor_model", "") or ""
+                ).strip()
+                _, _, total_cost = compute_session_cost(
+                    worker_model=self._model,
+                    worker_input_tokens=in_t,
+                    worker_output_tokens=out_t,
+                    advisor_model=_adv_model,
+                    advisor_input_tokens=adv_in,
+                    advisor_output_tokens=adv_out,
+                )
+                if total_cost > 0:
+                    right_bits.append(f"cost {format_cost_usd(total_cost)}")
+            except Exception:
+                pass
         right = " · ".join(right_bits)
         return Text(f"{left}    {middle}    {cwd}    {right}")
 

--- a/tests/test_cost_tracker.py
+++ b/tests/test_cost_tracker.py
@@ -10,9 +10,13 @@ class TestGetPricing:
         pricing = _get_pricing("claude-sonnet-4-20250514")
         assert pricing == PRICING["claude-sonnet-4-20250514"]
 
-    def test_unknown_model_defaults(self):
+    def test_unknown_model_returns_none(self):
+        # Post status-bar refactor: get_pricing returns None for
+        # unknowns. The legacy cost-tracker that needs "always
+        # something" falls back to DEFAULT_PRICING at its call site
+        # (services/cost_tracker.py::record_usage).
         pricing = _get_pricing("some-unknown-model")
-        assert pricing == DEFAULT_PRICING
+        assert pricing is None
 
     def test_prefix_matching(self):
         pricing = _get_pricing("claude-3-5-sonnet-20241022-v2")

--- a/tests/test_cost_tracker_facade.py
+++ b/tests/test_cost_tracker_facade.py
@@ -125,9 +125,12 @@ class TestPricing(unittest.TestCase):
         self.assertAlmostEqual(p["input"], 15.0 / 1_000_000)
         self.assertAlmostEqual(p["output"], 75.0 / 1_000_000)
 
-    def test_get_pricing_falls_back_to_default(self) -> None:
+    def test_get_pricing_returns_none_for_unknown(self) -> None:
+        # Post status-bar refactor: get_pricing returns None for
+        # unknowns. DEFAULT_PRICING is still exported but is only
+        # used by the legacy cost-tracker facade's per-event fallback.
         p = get_pricing("some-future-model-not-in-table")
-        self.assertEqual(p, DEFAULT_PRICING)
+        self.assertIsNone(p)
 
     def test_compute_cost_basic(self) -> None:
         cost = compute_cost(

--- a/tests/test_pricing_status_bar.py
+++ b/tests/test_pricing_status_bar.py
@@ -1,0 +1,218 @@
+"""Pricing helpers backing the status-bar cost display.
+
+Covers ``get_pricing`` prefix matching, ``compute_cost`` for the modern
+model lineup, ``compute_session_cost`` worker+advisor accumulation, and
+``format_cost_usd`` decimal-place selection by magnitude.
+"""
+from __future__ import annotations
+
+import unittest
+
+from src.services.pricing import (
+    DEFAULT_PRICING,
+    PRICING,
+    compute_cost,
+    compute_session_cost,
+    format_cost_usd,
+    get_pricing,
+)
+
+
+class TestGetPricing(unittest.TestCase):
+    def test_exact_match_haiku_4_5(self) -> None:
+        p = get_pricing("claude-haiku-4-5")
+        self.assertEqual(p["input"], 1.0 / 1_000_000)
+        self.assertEqual(p["output"], 5.0 / 1_000_000)
+
+    def test_exact_match_opus_4_7(self) -> None:
+        # Opus 4.7 sits on the 5/25 tier (per TS modelCost.ts mirror).
+        p = get_pricing("claude-opus-4-7")
+        self.assertEqual(p["input"], 5.0 / 1_000_000)
+        self.assertEqual(p["output"], 25.0 / 1_000_000)
+
+    def test_exact_match_sonnet_4_6(self) -> None:
+        p = get_pricing("claude-sonnet-4-6")
+        self.assertEqual(p["input"], 3.0 / 1_000_000)
+        self.assertEqual(p["output"], 15.0 / 1_000_000)
+
+    def test_family_prefix_falls_back_for_future_opus_variant(self) -> None:
+        # A model name not in the exact table but matching the
+        # ``claude-opus-4-7`` family prefix → 5/25 tier.
+        p = get_pricing("claude-opus-4-7-future-experimental")
+        self.assertEqual(p["input"], 5.0 / 1_000_000)
+
+    def test_family_prefix_falls_back_for_future_haiku_variant(self) -> None:
+        p = get_pricing("claude-haiku-4-9-experimental")
+        self.assertEqual(p["input"], 1.0 / 1_000_000)
+
+    def test_openrouter_vendor_prefix_stripped(self) -> None:
+        # ``anthropic/claude-opus-4-7`` should price as if the bare
+        # model name was passed in.
+        p = get_pricing("anthropic/claude-opus-4-7")
+        self.assertEqual(p["input"], 5.0 / 1_000_000)
+
+    def test_unknown_model_returns_none(self) -> None:
+        # Critic C1: unknowns return None instead of mispricing as
+        # Sonnet 3/15 (which would be ~10× off for DeepSeek-tier
+        # models the user actually runs).
+        self.assertIsNone(get_pricing("totally-unknown-model-xyz"))
+        self.assertIsNone(get_pricing("deepseek/deepseek-v4-pro"))
+        self.assertIsNone(get_pricing("gpt-5.4"))
+
+    def test_empty_model_returns_none(self) -> None:
+        self.assertIsNone(get_pricing(""))
+
+    def test_legacy_default_pricing_still_exported(self) -> None:
+        # ``DEFAULT_PRICING`` is kept for the legacy cost-tracker
+        # facade (``services/cost_tracker.py`` falls back to it when
+        # get_pricing returns None to preserve the always-charge-
+        # something contract). New callers should NOT use it.
+        self.assertEqual(DEFAULT_PRICING["input"], 3.0 / 1_000_000)
+
+    def test_no_bare_opus_4_prefix(self) -> None:
+        # Critic C2: ``claude-opus-4`` bare prefix was removed so an
+        # unknown opus-4.x variant (e.g. ``claude-opus-4-9-future``)
+        # falls through to None rather than tagging with the legacy
+        # 15/75 tier. Mismatch tier = surprising-large status-bar
+        # number = lost user trust.
+        self.assertIsNone(get_pricing("claude-opus-4-9-future"))
+        # But the known 4.5/4.6/4.7 variants still resolve to 5/25.
+        self.assertEqual(
+            get_pricing("claude-opus-4-7")["input"], 5.0 / 1_000_000,
+        )
+
+
+class TestComputeCost(unittest.TestCase):
+    def test_input_plus_output_no_cache(self) -> None:
+        cost = compute_cost("claude-haiku-4-5", {
+            "input_tokens": 1_000_000,
+            "output_tokens": 1_000_000,
+        })
+        # 1M input @ $1 + 1M output @ $5 = $6 exactly
+        self.assertAlmostEqual(cost, 6.0, places=6)
+
+    def test_cache_creation_and_read_charged(self) -> None:
+        cost = compute_cost("claude-opus-4-7", {
+            "input_tokens": 1_000_000,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 1_000_000,
+            "cache_read_input_tokens": 1_000_000,
+        })
+        # opus-4-7 (5/25 tier): $5 input + $6.25 cache_creation + $0.50 cache_read
+        self.assertAlmostEqual(cost, 5.0 + 6.25 + 0.50, places=6)
+
+    def test_missing_keys_default_to_zero(self) -> None:
+        # No tokens at all → free.
+        self.assertEqual(compute_cost("claude-opus-4-7", {}), 0.0)
+
+    def test_none_values_treated_as_zero(self) -> None:
+        # Defensive: usage dict might have explicit None from a
+        # stale-cache response.
+        cost = compute_cost("claude-opus-4-7", {
+            "input_tokens": None,
+            "output_tokens": 100,
+        })
+        # 100 output @ opus-4-7's $25/M = $0.0025
+        self.assertAlmostEqual(cost, 100 * (25.0 / 1_000_000), places=8)
+
+
+class TestComputeSessionCost(unittest.TestCase):
+    def test_worker_only(self) -> None:
+        worker, advisor, total = compute_session_cost(
+            worker_model="claude-haiku-4-5",
+            worker_input_tokens=10_000,
+            worker_output_tokens=5_000,
+        )
+        # 10k @ $1/M + 5k @ $5/M
+        expected = 10_000 * (1.0 / 1_000_000) + 5_000 * (5.0 / 1_000_000)
+        self.assertAlmostEqual(worker, expected, places=8)
+        self.assertEqual(advisor, 0.0)
+        self.assertEqual(total, worker)
+
+    def test_worker_plus_advisor(self) -> None:
+        worker, advisor, total = compute_session_cost(
+            worker_model="claude-haiku-4-5",
+            worker_input_tokens=10_000,
+            worker_output_tokens=5_000,
+            advisor_model="claude-opus-4-7",
+            advisor_input_tokens=2_000,
+            advisor_output_tokens=1_000,
+        )
+        expected_worker = 10_000 * (1.0 / 1_000_000) + 5_000 * (5.0 / 1_000_000)
+        expected_advisor = 2_000 * (5.0 / 1_000_000) + 1_000 * (25.0 / 1_000_000)
+        self.assertAlmostEqual(worker, expected_worker, places=8)
+        self.assertAlmostEqual(advisor, expected_advisor, places=8)
+        self.assertAlmostEqual(total, expected_worker + expected_advisor, places=8)
+
+    def test_advisor_unset_skips_advisor_cost(self) -> None:
+        # Empty advisor_model + non-zero advisor tokens → zero advisor
+        # cost (don't price an unconfigured advisor; the tokens belong
+        # to something else).
+        _, advisor, _ = compute_session_cost(
+            worker_model="claude-haiku-4-5",
+            worker_input_tokens=0,
+            worker_output_tokens=0,
+            advisor_model="",
+            advisor_input_tokens=100,
+            advisor_output_tokens=50,
+        )
+        self.assertEqual(advisor, 0.0)
+
+    def test_zero_tokens_short_circuits(self) -> None:
+        worker, advisor, total = compute_session_cost(
+            worker_model="claude-haiku-4-5",
+            worker_input_tokens=0,
+            worker_output_tokens=0,
+        )
+        self.assertEqual(worker, 0.0)
+        self.assertEqual(advisor, 0.0)
+        self.assertEqual(total, 0.0)
+
+
+class TestFormatCostUsd(unittest.TestCase):
+    def test_zero_renders_padded(self) -> None:
+        # Always 4 decimals for zero so callers' string-length
+        # assumptions don't break.
+        self.assertEqual(format_cost_usd(0.0), "$0.0000")
+        self.assertEqual(format_cost_usd(-1.0), "$0.0000")
+
+    def test_sub_cent_uses_4_decimals(self) -> None:
+        self.assertEqual(format_cost_usd(0.0034), "$0.0034")
+        self.assertEqual(format_cost_usd(0.001234), "$0.0012")
+
+    def test_under_ten_dollars_uses_3_decimals(self) -> None:
+        self.assertEqual(format_cost_usd(0.012), "$0.012")
+        self.assertEqual(format_cost_usd(1.2345), "$1.234")
+        self.assertEqual(format_cost_usd(9.999), "$9.999")
+
+    def test_over_ten_dollars_uses_2_decimals(self) -> None:
+        self.assertEqual(format_cost_usd(10.0), "$10.00")
+        self.assertEqual(format_cost_usd(12.3456), "$12.35")
+        self.assertEqual(format_cost_usd(1234.5), "$1234.50")
+
+    def test_boundary_at_one_cent(self) -> None:
+        # ``< 0.01`` cutoff — exactly $0.01 should use 3 decimals
+        # (cents-precision range), not 4-decimal sub-cent format.
+        self.assertEqual(format_cost_usd(0.01), "$0.010")
+        # Just below the cutoff stays at 4 decimals.
+        self.assertEqual(format_cost_usd(0.0099), "$0.0099")
+
+    def test_boundary_at_ten_dollars(self) -> None:
+        # ``< 10`` cutoff — exactly $10.00 uses penny-rounding,
+        # just below stays at 3 decimals.
+        self.assertEqual(format_cost_usd(10.0), "$10.00")
+        self.assertEqual(format_cost_usd(9.99), "$9.990")
+
+    def test_compute_cost_unknown_model_returns_zero(self) -> None:
+        # Critic C1: instead of mispricing, compute_cost returns 0
+        # for unknowns — the status bar's "hidden when zero" check
+        # naturally suppresses the segment.
+        cost = compute_cost("totally-unknown-model-xyz", {
+            "input_tokens": 1_000_000,
+            "output_tokens": 1_000_000,
+        })
+        self.assertEqual(cost, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The status bar already shows token counts split by worker vs advisor (from PR #191). This PR adds the dollar cost segment — same split, summed into one display number.

## Display

\`\`\`
REPL: ... tokens: 5400 in / 320 out (advisor: 1326 in / 282 out) · cost \$0.021
TUI:  ... tokens 5720 · advisor 1326/282 · cost \$0.021
\`\`\`

Hidden when zero — either no API turns yet, or the worker/advisor model isn't in our known-pricing list (see critic C1 fix below).

## Pricing tiers — mirror of TS `modelCost.ts`

| Tier | $/Mtok input | $/Mtok output | Models |
|---|---|---|---|
| HAIKU_45 | 1 | 5 | haiku-4-5, 3-5-haiku |
| 3_15 | 3 | 15 | sonnet-4-6, sonnet-4-5, sonnet-4, 3-7-sonnet, 3-5-sonnet |
| 5_25 | 5 | 25 | opus-4-7, opus-4-6, opus-4-5 |
| 15_75 | 15 | 75 | opus-4-0, opus-4-1 (legacy) |

Lookup: exact match → strip openrouter `<vendor>/` prefix → family prefix → None.

## Critic-driven fixes (one round, all addressed)

- **C1** (critical): `DEFAULT_PRICING` was Sonnet 3/15 — would silently misprice DeepSeek/Gemini/GPT-5 by ~10×. Now unknowns return None and the cost segment is suppressed. Honesty over false precision.
- **C2** (critical): bare `claude-opus-4` prefix would have routed future variants (e.g. `claude-opus-4-9`) onto the legacy 15/75 tier. Dropped.
- **C3** (critical): dead `claude-haiku-3-5` prefix removed (canonical form is `claude-3-5-haiku-…`).
- **S5**: unified status bar to `cost \$X.XXX` (space-separated) on both REPL and TUI — was inconsistent.

## Files

| File | Change |
|---|---|
| `src/services/pricing.py` | Rewrote with TS-mirrored tiers, modern models, family prefixes, openrouter vendor-prefix handling. New `get_pricing` returns dict or None. New helpers `is_known_pricing`, `compute_session_cost`, `format_cost_usd`. |
| `src/services/cost_tracker.py` | Legacy facade now `get_pricing(model) or DEFAULT_PRICING` — preserves always-charge-something contract while the new path sees None. |
| `src/repl/core.py` | `_bottom_toolbar` appends cost segment. |
| `src/tui/widgets/status_line.py` | `_compose_text` appends cost segment to right_bits. |
| `tests/test_pricing_status_bar.py` | New, 24 tests. |

## Tests

- **658 passed** across the full advisor + adapter + TUI + smoke + cost_tracker + new pricing suites.
- Live helper output (your config: haiku-4-5 worker + opus-4-7 advisor):
  - typical session: \$0.021 total
  - heavy session: \$3.150 total

## Honest caveat

Cost reflects upstream Anthropic list prices. Routes through litellm/openrouter/bedrock may bill differently (your actual invoice could be a markup or a discount). The displayed number is a directional estimate, not your invoice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)