### PR TITLE
fix(repl): trim Edit/Write diff color bar to leave terminal-edge margin

### DIFF
--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -1247,6 +1247,12 @@ class ClawcodexREPL:
         # produce negative padding.
         console_width = max(1, getattr(self.console, "width", 0) or 80)
 
+        # Color bar starts at the line-number column and ends 7 cols
+        # short of the right terminal edge, leaving visible breathing
+        # room on the right so the bar doesn't run flush against the
+        # screen border.
+        target_right = max(1, console_width - 7)
+
         diff = Text()
         rendered = 0
         truncated = False
@@ -1265,20 +1271,18 @@ class ClawcodexREPL:
                 # on newlines and produce blank rows between every entry.
                 stripped = raw.rstrip("\n").rstrip("\r")
                 if stripped.startswith("+"):
-                    # Match Claude Code's truecolor dark theme. Background
-                    # starts at the line-number column and extends to the
-                    # right edge by padding the trailing space with the
-                    # same bg, so added/removed rows read as solid bars
-                    # across the full width. Mirrors
-                    # ``typescript/src/components/StructuredDiff/Fallback.tsx:331-346``
-                    # (lineNumStr + sigil + content + ' '.repeat(padding))
-                    # and ``typescript/src/utils/theme.ts darkTheme``
+                    # Colors mirror ``typescript/src/utils/theme.ts darkTheme``
                     # (``diffAdded: 'rgb(34,92,43)'``,
-                    # ``diffRemoved: 'rgb(122,41,54)'``).
+                    # ``diffRemoved: 'rgb(122,41,54)'``). The bar begins
+                    # one column to the left of the line-number digits
+                    # (i.e. the gutter carries a 1-col leading bg pad).
                     body = stripped[1:]
-                    gutter = f"{new_lineno:>4} "
+                    num_str = str(new_lineno)
+                    lead = " " * max(0, 4 - len(num_str) - 1)
+                    gutter = f" {num_str} "
                     visible = len(gutter) + 1 + cell_len(body)
-                    padding = max(0, console_width - visible)
+                    padding = max(0, target_right - len(lead) - visible)
+                    diff.append(lead)
                     diff.append(gutter, style="on rgb(34,92,43)")
                     diff.append("+", style="bold on rgb(34,92,43)")
                     diff.append(body + " " * padding, style="on rgb(34,92,43)")
@@ -1286,9 +1290,12 @@ class ClawcodexREPL:
                     new_lineno += 1
                 elif stripped.startswith("-"):
                     body = stripped[1:]
-                    gutter = f"{old_lineno:>4} "
+                    num_str = str(old_lineno)
+                    lead = " " * max(0, 4 - len(num_str) - 1)
+                    gutter = f" {num_str} "
                     visible = len(gutter) + 1 + cell_len(body)
-                    padding = max(0, console_width - visible)
+                    padding = max(0, target_right - len(lead) - visible)
+                    diff.append(lead)
                     diff.append(gutter, style="on rgb(122,41,54)")
                     diff.append("-", style="bold on rgb(122,41,54)")
                     diff.append(body + " " * padding, style="on rgb(122,41,54)")


### PR DESCRIPTION
## Summary

* Re-shape the Edit/Write diff color bar so it reads as a discrete block instead of a full-row banner stretching to the terminal edge.
* **Left edge** now sits one column to the left of the line-number digits (the right-align padding stays *outside* the bar with no bg).
* **Right edge** now stops at `console_width - 7`, leaving visible breathing room on the right so the bar no longer kisses the screen border.

## Before / after

Before (terminal width 200):

```
[bg ▓▓▓▓ 64 -    delay = min(base_delay * (2 ** (attempt - 1)), max_delay)                                                                                                                                       ▓▓]
```

After:

```
 [bg ▓ 64 -    delay = min(base_delay * (2 ** (attempt - 1)), max_delay)                                                                                                                                 ▓]
```

Per-row layout:

```
[no-bg right-align lead][1 col bg pad][digits][space][sigil][body][trailing bg pad → console_width - 7]
```

## Why

The old `console_width` cap was inherited from the TS reference, but in Rich the bar there is laid out inside a fixed Ink container and so it visually ends well before the terminal edge. In our REPL the bar was painted with the actual terminal width, which made it overshoot. The new offsets restore the "block, not banner" look the user was after, with measurable right-edge breathing room.

## Scope

* `src/repl/core.py` — only `_format_edit_diff_preview` touched.
* The structured TUI renderer at `src/tui/widgets/structured_diff.py` is intentionally left alone — that surface wasn't part of the report and currently uses a separate `width_hint` knob.
* No tests asserted on the old colored layout (grepped both `rgb(34,92,43)` and `rgb(122,41,54)`), so nothing to update there.

## Test plan

- [ ] Restart REPL with the new code and trigger any Edit/MultiEdit on a file with ~2-digit line numbers — confirm bar starts 1 col left of the digits and ends ~7 cols short of the right edge.
- [ ] Confirm context (non-diff) rows still align column-wise with the colored diff rows for 1-3 digit line numbers.
- [ ] Verify behavior in a narrow terminal (~40 cols) — bar should clamp gracefully and not produce negative padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)