### PR TITLE
bridge: port capacity_wake + 7 leaf modules toward TS parity

### DIFF
--- a/src/bridge/__init__.py
+++ b/src/bridge/__init__.py
@@ -1,11 +1,16 @@
 """CCR bridge subsystem (Bridge v1 + Bridge v2 + shared primitives).
 
-Real implementations land here per ``my-docs/ch16-remote-refactoring-plan.md``.
-The ``ARCHIVE_NAME``/``MODULE_COUNT``/``SAMPLE_FILES``/``PORTING_NOTE``
-re-exports are preserved for backwards compat with
-``tests/test_porting_workspace.py:73-79`` (``from src import bridge`` then
-``bridge.MODULE_COUNT > 0``). New code uses full module paths instead, e.g.
-``from src.bridge.bounded_uuid_set import BoundedUUIDSet``.
+Real implementations land here per ``my-docs/get-parity-by-folder/
+bridge-refactoring-plan.md``. The ``ARCHIVE_NAME``/``MODULE_COUNT``/
+``SAMPLE_FILES``/``PORTING_NOTE`` re-exports are preserved for backwards
+compat with ``tests/test_porting_workspace.py:73-79`` (``from src import
+bridge`` then ``bridge.MODULE_COUNT > 0``).
+
+This module also re-exports the most-used Phase 1 leaves so consumers can
+write ``from src.bridge import BoundedUUIDSet`` rather than the full path.
+Per refactoring plan §4 risk row, every re-export must be importable
+cleanly with no Phase 2 module present — verified by the legacy
+test_porting_workspace test which would otherwise fail at import time.
 """
 
 from __future__ import annotations
@@ -21,4 +26,95 @@ MODULE_COUNT = _SNAPSHOT['module_count']
 SAMPLE_FILES = tuple(_SNAPSHOT['sample_files'])
 PORTING_NOTE = f"Python placeholder package for '{ARCHIVE_NAME}' with {MODULE_COUNT} archived module references."
 
-__all__ = ['ARCHIVE_NAME', 'MODULE_COUNT', 'PORTING_NOTE', 'SAMPLE_FILES']
+# -----------------------------------------------------------------------------
+# Phase 1 re-exports (Phase 2 deps not required for any of these imports)
+# -----------------------------------------------------------------------------
+
+from src.bridge.bounded_uuid_set import BoundedUUIDSet
+from src.bridge.bridge_permission_callbacks import (
+    BridgePermissionResponse,
+    is_bridge_permission_response,
+)
+from src.bridge.capacity_wake import CapacityWake, create_capacity_wake
+from src.bridge.close_codes import (
+    WS_CLOSE_EPOCH_MISMATCH,
+    WS_CLOSE_INIT_FAILURE,
+    WS_CLOSE_PERMANENT_UNAUTHORIZED,
+    WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED,
+    WS_CLOSE_SESSION_NOT_FOUND,
+)
+from src.bridge.exceptions import (
+    BridgeAuthError,
+    BridgeFatalError,
+    EpochSupersededError,
+)
+from src.bridge.flush_gate import FlushGate
+from src.bridge.inbound_messages import (
+    extract_inbound_message_fields,
+    normalize_image_blocks,
+)
+from src.bridge.poll_config_defaults import (
+    DEFAULT_POLL_CONFIG,
+    PollIntervalConfig,
+)
+from src.bridge.session_id_compat import (
+    set_cse_shim_gate,
+    to_compat_session_id,
+    to_infra_session_id,
+)
+from src.bridge.types import (
+    BRIDGE_LOGIN_ERROR,
+    BRIDGE_LOGIN_INSTRUCTION,
+    DEFAULT_SESSION_TIMEOUT_MS,
+    REMOTE_CONTROL_DISCONNECTED_MSG,
+    BridgeConfig,
+    SessionActivity,
+)
+from src.bridge.work_secret import (
+    WorkSecret,
+    build_ccr_v2_sdk_url,
+    build_sdk_url,
+    decode_work_secret,
+    same_session_id,
+)
+
+__all__ = [
+    # Legacy archive metadata (test_porting_workspace.py compat)
+    'ARCHIVE_NAME',
+    'MODULE_COUNT',
+    'PORTING_NOTE',
+    'SAMPLE_FILES',
+    # Phase 1 leaves
+    'BRIDGE_LOGIN_ERROR',
+    'BRIDGE_LOGIN_INSTRUCTION',
+    'BoundedUUIDSet',
+    'BridgeAuthError',
+    'BridgeConfig',
+    'BridgeFatalError',
+    'BridgePermissionResponse',
+    'CapacityWake',
+    'DEFAULT_POLL_CONFIG',
+    'DEFAULT_SESSION_TIMEOUT_MS',
+    'EpochSupersededError',
+    'FlushGate',
+    'PollIntervalConfig',
+    'REMOTE_CONTROL_DISCONNECTED_MSG',
+    'SessionActivity',
+    'WS_CLOSE_EPOCH_MISMATCH',
+    'WS_CLOSE_INIT_FAILURE',
+    'WS_CLOSE_PERMANENT_UNAUTHORIZED',
+    'WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED',
+    'WS_CLOSE_SESSION_NOT_FOUND',
+    'WorkSecret',
+    'build_ccr_v2_sdk_url',
+    'build_sdk_url',
+    'create_capacity_wake',
+    'decode_work_secret',
+    'extract_inbound_message_fields',
+    'is_bridge_permission_response',
+    'normalize_image_blocks',
+    'same_session_id',
+    'set_cse_shim_gate',
+    'to_compat_session_id',
+    'to_infra_session_id',
+]

--- a/src/bridge/bridge_enabled.py
+++ b/src/bridge/bridge_enabled.py
@@ -1,0 +1,101 @@
+"""Bridge enablement and entitlement gates.
+
+Ports ``typescript/src/bridge/bridgeEnabled.ts``.
+
+Per refactoring plan §0.1 Q2, GrowthBook is not wired in the Python build,
+so every gate is stubbed to a static value matching the v2-priority decision
+(§0.1 Q3 — v2-first). When/if GrowthBook integration lands in Phase 10, the
+stubs swap to real evaluators; callers see no API change.
+
+Returning ``True`` for ``is_bridge_enabled*`` is intentional — orchestrators
+(Phase 5+) need to be exercisable end-to-end without a runtime gate refusing
+them. The real entitlement decision belongs to the auth subsystem, which is
+out of scope for the Python port (per §0.1 Q6).
+"""
+
+from __future__ import annotations
+
+
+def is_bridge_enabled() -> bool:
+    """Cached, non-blocking entitlement check.
+
+    Mirrors TS ``isBridgeEnabled`` on ``bridgeEnabled.ts:28-36``. Always
+    True in the Python build — see module docstring.
+    """
+    return True
+
+
+async def is_bridge_enabled_blocking() -> bool:
+    """Blocking entitlement check (awaits GrowthBook in TS).
+
+    Mirrors TS ``isBridgeEnabledBlocking`` on ``bridgeEnabled.ts:50-55``.
+    Returns ``True`` synchronously — there's no GB to await.
+    """
+    return True
+
+
+async def get_bridge_disabled_reason() -> str | None:
+    """Diagnostic reason for "bridge not available", or None if enabled.
+
+    Mirrors TS ``getBridgeDisabledReason`` on ``bridgeEnabled.ts:70-87``.
+    Always None in the Python build (bridge always enabled per stubs).
+    """
+    return None
+
+
+def is_env_less_bridge_enabled() -> bool:
+    """Whether the env-less (v2) REPL bridge path is enabled.
+
+    Mirrors TS ``isEnvLessBridgeEnabled`` on ``bridgeEnabled.ts:126-130``.
+    Always True (v2-first per refactoring plan §0.1 Q3).
+    """
+    return True
+
+
+def is_cse_shim_enabled() -> bool:
+    """Whether the ``cse_*`` → ``session_*`` retag shim is active.
+
+    Mirrors TS ``isCseShimEnabled`` on ``bridgeEnabled.ts:141-148``. Always
+    True — matches the TS default and `session_id_compat.py`'s default-active
+    behavior when ``set_cse_shim_gate`` is never called.
+    """
+    return True
+
+
+def check_bridge_min_version() -> str | None:
+    """Returns an error message if CLI version is below the v1 min, else None.
+
+    Mirrors TS ``checkBridgeMinVersion`` on ``bridgeEnabled.ts:160-173``. The
+    Python build has no GrowthBook version floor, so always None.
+    """
+    return None
+
+
+def get_ccr_auto_connect_default() -> bool:
+    """Default for ``remote_control_at_startup``.
+
+    Mirrors TS ``getCcrAutoConnectDefault`` on ``bridgeEnabled.ts:185-189``.
+    Always False — the user must opt in.
+    """
+    return False
+
+
+def is_ccr_mirror_enabled() -> bool:
+    """Whether CCR mirror mode is enabled.
+
+    Mirrors TS ``isCcrMirrorEnabled`` on ``bridgeEnabled.ts:197-202``. Always
+    False in the Python build — mirror mode is a niche internal feature.
+    """
+    return False
+
+
+__all__ = [
+    'check_bridge_min_version',
+    'get_bridge_disabled_reason',
+    'get_ccr_auto_connect_default',
+    'is_bridge_enabled',
+    'is_bridge_enabled_blocking',
+    'is_ccr_mirror_enabled',
+    'is_cse_shim_enabled',
+    'is_env_less_bridge_enabled',
+]

--- a/src/bridge/bridge_permission_callbacks.py
+++ b/src/bridge/bridge_permission_callbacks.py
@@ -1,0 +1,101 @@
+"""Bridge permission callbacks Protocol.
+
+Ports ``typescript/src/bridge/bridgePermissionCallbacks.ts``.
+
+Defines the bridge-side surface for handling permission requests routed
+from the server: a ``BridgePermissionResponse`` payload (``allow`` /
+``deny`` with optional input rewrite + updated permissions), a type guard
+for validating parsed wire payloads, and a ``BridgePermissionCallbacks``
+Protocol bundling the send/receive surface that orchestrators wire to the
+transport.
+
+The richer ``AllowResponse``/``DenyResponse`` discriminated union (used
+post-parse) lives in ``messaging.py``; this module is the lower-level
+TypedDict + type-guard layer.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Protocol, TypedDict, TypeGuard
+
+
+class BridgePermissionResponse(TypedDict, total=False):
+    """Permission response payload as it appears on the wire.
+
+    Mirrors TS ``BridgePermissionResponse`` on ``bridgePermissionCallbacks.ts:3-8``.
+    ``behavior`` is required; the other fields are optional and only meaningful
+    when ``behavior == 'allow'`` (updatedInput / updatedPermissions) or
+    ``'deny'`` (message).
+
+    **camelCase field names are intentional**: this TypedDict is the
+    *pre-normalization* wire shape sent by the claude.ai web app. The
+    *post-normalization* discriminated union (``AllowResponse`` /
+    ``DenyResponse`` in ``messaging.py``) uses snake_case Python idioms.
+    The router (``messaging.normalize_control_message_keys``) converts
+    between the two.
+    """
+
+    behavior: str  # 'allow' | 'deny'
+    updatedInput: dict[str, Any]
+    updatedPermissions: list[dict[str, Any]]
+    message: str
+
+
+def is_bridge_permission_response(
+    value: object,
+) -> TypeGuard[BridgePermissionResponse]:
+    """Type guard for a parsed control_response payload.
+
+    Mirrors TS ``isBridgePermissionResponse`` on
+    ``bridgePermissionCallbacks.ts:32-40``. Checks the required ``behavior``
+    discriminant rather than using an unsafe cast.
+    """
+    if not isinstance(value, dict):
+        return False
+    behavior = value.get('behavior')
+    return behavior == 'allow' or behavior == 'deny'
+
+
+class BridgePermissionCallbacks(Protocol):
+    """Send/receive surface for permission requests.
+
+    Mirrors TS ``BridgePermissionCallbacks`` on
+    ``bridgePermissionCallbacks.ts:10-27``. Wired by orchestrators to a
+    transport (``ReplBridgeHandle``) and a request registry. Implementations
+    are stateful (the ``on_response`` handler registry); the Protocol just
+    declares the surface.
+    """
+
+    def send_request(
+        self,
+        request_id: str,
+        tool_name: str,
+        input: dict[str, Any],
+        tool_use_id: str,
+        description: str,
+        permission_suggestions: list[dict[str, Any]] | None = None,
+        blocked_path: str | None = None,
+    ) -> None: ...
+
+    def send_response(
+        self, request_id: str, response: BridgePermissionResponse
+    ) -> None: ...
+
+    def cancel_request(self, request_id: str) -> None:
+        """Cancel a pending control_request so the web app can dismiss its prompt."""
+        ...
+
+    def on_response(
+        self,
+        request_id: str,
+        handler: Callable[[BridgePermissionResponse], None],
+    ) -> Callable[[], None]:
+        """Register a one-shot response handler. Returns an unsubscribe callable."""
+        ...
+
+
+__all__ = [
+    'BridgePermissionCallbacks',
+    'BridgePermissionResponse',
+    'is_bridge_permission_response',
+]

--- a/src/bridge/capacity_wake.py
+++ b/src/bridge/capacity_wake.py
@@ -1,0 +1,114 @@
+"""Shared capacity-wake primitive for bridge poll loops.
+
+Ports ``typescript/src/bridge/capacityWake.ts``.
+
+The TS implementation merges a long-lived outer abort signal with a short-lived
+"wake" controller so a poll loop can sleep while at capacity but wake early
+when (a) the outer shutdown signal fires, or (b) capacity frees up (session
+done / transport lost). This Python port substitutes ``asyncio.Event`` for
+``AbortSignal`` and tracks per-``signal()``-call cleanup so callers can release
+listeners deterministically when their sleep resolves normally.
+
+The Python API mirrors TS:
+
+* ``CapacityWake.signal()`` returns a ``CapacitySignal`` whose ``.event`` is
+  set when *either* the outer signal or the wake controller fires. Callers
+  use ``await wait_first(event, ...)`` or ``await event.wait()`` then call
+  ``cleanup()`` to detach listeners.
+* ``CapacityWake.wake()`` aborts the current wake controller and arms a
+  fresh one so subsequent ``signal()`` calls return a new pair.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass
+class CapacitySignal:
+    """A merged signal that fires when either source fires.
+
+    ``event`` is an ``asyncio.Event`` that becomes set when *either* the outer
+    signal or the wake controller fires. ``cleanup`` detaches the listeners
+    so the caller's sleep can release resources when it resolves normally.
+    """
+
+    event: asyncio.Event
+    cleanup: Callable[[], None]
+
+
+class CapacityWake:
+    """Wake-on-demand abstraction for bridge poll loops.
+
+    See module docstring. Single-loop use only — concurrent ``wake()`` from
+    different asyncio tasks is undefined; callers serialize externally.
+    """
+
+    def __init__(self, outer_signal: asyncio.Event) -> None:
+        self._outer_signal = outer_signal
+        self._wake_event = asyncio.Event()
+
+    def wake(self) -> None:
+        """Abort the current at-capacity sleep and arm a fresh wake event.
+
+        Mirrors TS ``wake()``: any existing ``signal()`` returned earlier
+        fires immediately (its merged event becomes set), and any subsequent
+        ``signal()`` call returns a fresh pair tied to a new internal event.
+        """
+        previous = self._wake_event
+        self._wake_event = asyncio.Event()
+        previous.set()
+
+    def signal(self) -> CapacitySignal:
+        """Build a merged signal for a single at-capacity sleep.
+
+        The returned ``event`` is set when either the outer signal or this
+        wake controller fires. ``cleanup`` cancels the background watcher
+        tasks; callers should call it when their sleep resolves normally so
+        the tasks don't leak. If either source has already fired by the time
+        ``signal()`` is called, the merged event is returned pre-set with a
+        no-op cleanup (matches TS short-circuit on lines 39-42).
+
+        **Async constraint**: Must be called from inside a running asyncio
+        event loop — ``signal()`` spawns watcher tasks via
+        ``asyncio.create_task`` which raises ``RuntimeError`` if invoked
+        from sync code with no current loop. The short-circuit path (either
+        source pre-fired) avoids this and is safe to call from sync code,
+        but callers must not rely on that behavior.
+        """
+        merged = asyncio.Event()
+
+        if self._outer_signal.is_set() or self._wake_event.is_set():
+            merged.set()
+            return CapacitySignal(event=merged, cleanup=lambda: None)
+
+        # Snapshot the current wake event: if wake() is called between this
+        # signal() returning and the caller awaiting, we still want to fire
+        # via the *original* event (matches TS captured-binding semantics on
+        # capacityWake.ts:44 where capSig = wakeController.signal).
+        wake_event = self._wake_event
+        outer_signal = self._outer_signal
+
+        async def _watch_outer() -> None:
+            await outer_signal.wait()
+            merged.set()
+
+        async def _watch_wake() -> None:
+            await wake_event.wait()
+            merged.set()
+
+        outer_task = asyncio.create_task(_watch_outer())
+        wake_task = asyncio.create_task(_watch_wake())
+
+        def _cleanup() -> None:
+            outer_task.cancel()
+            wake_task.cancel()
+
+        return CapacitySignal(event=merged, cleanup=_cleanup)
+
+
+def create_capacity_wake(outer_signal: asyncio.Event) -> CapacityWake:
+    """Factory mirroring TS ``createCapacityWake(outerSignal)``."""
+    return CapacityWake(outer_signal)

--- a/src/bridge/debug_utils.py
+++ b/src/bridge/debug_utils.py
@@ -1,0 +1,186 @@
+"""Debug logging utilities for the bridge subsystem.
+
+Ports ``typescript/src/bridge/debugUtils.ts``.
+
+Helpers for redacting secrets, truncating debug bodies, extracting error
+messages from HTTP errors, and emitting analytics events for skipped bridge
+init. The TS file uses axios-specific error types; Python uses ``httpx`` or
+plain ``Exception`` — the API is generalized as ``describe_http_error``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEBUG_MSG_LIMIT = 2000
+
+_SECRET_FIELD_NAMES = (
+    'session_ingress_token',
+    'environment_secret',
+    'access_token',
+    'secret',
+    'token',
+)
+
+_SECRET_PATTERN = re.compile(
+    r'"(' + '|'.join(_SECRET_FIELD_NAMES) + r')"\s*:\s*"([^"]*)"',
+)
+
+_REDACT_MIN_LENGTH = 16
+
+
+def redact_secrets(s: str) -> str:
+    """Replace secret-field values in a JSON-like string with redacted forms.
+
+    Mirrors TS ``redactSecrets`` on ``debugUtils.ts:26-34``. Short tokens
+    (<16 chars) are fully redacted; longer ones keep the first 8 + last 4
+    chars so debug logs are still triagable while not leaking the secret.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        field = match.group(1)
+        value = match.group(2)
+        if len(value) < _REDACT_MIN_LENGTH:
+            return f'"{field}":"[REDACTED]"'
+        return f'"{field}":"{value[:8]}...{value[-4:]}"'
+
+    return _SECRET_PATTERN.sub(_replace, s)
+
+
+def debug_truncate(s: str) -> str:
+    """Truncate a string for debug logging, collapsing newlines.
+
+    Mirrors TS ``debugTruncate`` on ``debugUtils.ts:37-43``.
+    """
+    flat = s.replace('\n', '\\n')
+    if len(flat) <= DEBUG_MSG_LIMIT:
+        return flat
+    return flat[:DEBUG_MSG_LIMIT] + f'... ({len(flat)} chars)'
+
+
+def debug_body(data: Any) -> str:
+    """Truncate a JSON-serializable value for debug logging, with redaction.
+
+    Mirrors TS ``debugBody`` on ``debugUtils.ts:46-53``. Strings pass through
+    as-is; everything else is JSON-encoded first.
+
+    **Behavioral divergence from TS** (intentional): the Python port passes
+    ``default=str`` to ``json.dumps`` so non-JSON-serializable values
+    (sets, datetimes, custom classes) render as their ``str()`` repr instead
+    of throwing. TS ``jsonStringify`` throws on non-serializable values.
+    The Python behavior is strictly safer for debug logging — no caller
+    should rely on the throw.
+    """
+    if isinstance(data, str):
+        raw = data
+    else:
+        try:
+            raw = json.dumps(data, default=str)
+        except (TypeError, ValueError):
+            raw = repr(data)
+    s = redact_secrets(raw)
+    if len(s) <= DEBUG_MSG_LIMIT:
+        return s
+    return s[:DEBUG_MSG_LIMIT] + f'... ({len(s)} chars)'
+
+
+def describe_http_error(err: object) -> str:
+    """Extract a descriptive error message from an HTTP error.
+
+    Mirrors TS ``describeAxiosError`` on ``debugUtils.ts:60-82``. Renamed
+    for Python (httpx, not axios). For responses with a structured error
+    body, appends the server's ``message`` / ``error.message`` field.
+
+    Works with httpx ``HTTPStatusError`` (has ``.response.json()``),
+    ``RequestError`` (no response), and plain ``Exception``. Best-effort —
+    returns just ``str(err)`` when the response isn't structured.
+    """
+    msg = str(err)
+    response = getattr(err, 'response', None)
+    if response is None:
+        return msg
+    try:
+        data = response.json() if hasattr(response, 'json') else None
+    except Exception:
+        return msg
+    detail = extract_error_detail(data)
+    if detail:
+        return f'{msg}: {detail}'
+    return msg
+
+
+def extract_http_status(err: object) -> int | None:
+    """Extract the HTTP status code from an error, if present.
+
+    Mirrors TS ``extractHttpStatus`` on ``debugUtils.ts:88-100``. Returns
+    ``None`` for non-HTTP errors (network failures, timeouts without a
+    response).
+    """
+    response = getattr(err, 'response', None)
+    if response is None:
+        return None
+    status = getattr(response, 'status_code', None)
+    if isinstance(status, int):
+        return status
+    # httpx uses ``status_code``; some libraries use ``status``.
+    status = getattr(response, 'status', None)
+    if isinstance(status, int):
+        return status
+    return None
+
+
+def extract_error_detail(data: Any) -> str | None:
+    """Pull a human-readable message out of an API error response body.
+
+    Mirrors TS ``extractErrorDetail`` on ``debugUtils.ts:106-121``. Checks
+    ``data['message']`` first, then ``data['error']['message']``.
+    """
+    if not isinstance(data, dict):
+        return None
+    message = data.get('message')
+    if isinstance(message, str):
+        return message
+    error = data.get('error')
+    if isinstance(error, dict):
+        inner = error.get('message')
+        if isinstance(inner, str):
+            return inner
+    return None
+
+
+def log_bridge_skip(
+    reason: str,
+    debug_msg: str | None = None,
+    v2: bool | None = None,
+) -> None:
+    """Log a bridge init skip — debug message + analytics event.
+
+    Mirrors TS ``logBridgeSkip`` on ``debugUtils.ts:128-141``. The TS version
+    sends a ``tengu_bridge_repl_skipped`` analytics event via ``logEvent``;
+    the Python port logs at INFO level since no GrowthBook analytics client
+    exists yet (per refactoring-plan §0.1 Q2 — analytics stubbed).
+    """
+    if debug_msg:
+        logger.debug(debug_msg)
+    extra: dict[str, Any] = {'reason': reason}
+    if v2 is not None:
+        extra['v2'] = v2
+    logger.info('bridge_skip reason=%s%s', reason,
+                f' v2={v2}' if v2 is not None else '')
+
+
+__all__ = [
+    'DEBUG_MSG_LIMIT',
+    'debug_body',
+    'debug_truncate',
+    'describe_http_error',
+    'extract_error_detail',
+    'extract_http_status',
+    'log_bridge_skip',
+    'redact_secrets',
+]

--- a/src/bridge/exceptions.py
+++ b/src/bridge/exceptions.py
@@ -26,4 +26,37 @@ class BridgeAuthError(Exception):
     """
 
 
-__all__ = ['BridgeAuthError', 'EpochSupersededError']
+class BridgeFatalError(Exception):
+    """Non-retryable error from the environments API.
+
+    Mirrors TS ``BridgeFatalError`` exported from ``bridgeApi.ts:56-66``.
+    Carries the HTTP status code and an optional server-provided error type
+    (e.g. ``'environment_expired'``, ``'lifetime'``). Callers use
+    ``is_expired_error_type(err.error_type)`` (Phase 3) to decide between
+    teardown-and-recreate (expired) vs. fail-loudly (genuine 401/403).
+
+    Args:
+        message: Human-readable detail (typically ``f'{verb} {status}'``).
+        status: HTTP status code.
+        error_type: Optional server-provided error code from the response
+            body's ``data.error.type`` field.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        status: int,
+        error_type: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.error_type = error_type
+
+    def __repr__(self) -> str:
+        return (
+            f'BridgeFatalError(status={self.status}, '
+            f'error_type={self.error_type!r}, message={str(self)!r})'
+        )
+
+
+__all__ = ['BridgeAuthError', 'BridgeFatalError', 'EpochSupersededError']

--- a/src/bridge/inbound_messages.py
+++ b/src/bridge/inbound_messages.py
@@ -1,0 +1,143 @@
+"""Process inbound user messages from the bridge.
+
+Ports ``typescript/src/bridge/inboundMessages.ts``.
+
+Two responsibilities:
+
+1. ``extract_inbound_message_fields`` — pull (content, uuid) off a parsed
+   SDKMessage of type ``user`` for enqueueing. Returns ``None`` when the
+   message should be skipped (non-user, missing/empty content).
+
+2. ``normalize_image_blocks`` — fix camelCase ``mediaType`` → snake_case
+   ``media_type`` on image blocks from bridge clients (iOS/web composer).
+   Returns the original list when no normalization is needed (zero-alloc
+   happy path).
+
+The TS file uses ``detectImageFormatFromBase64`` from ``utils/imageResizer.js``;
+the Python port inlines a small magic-byte sniffer since the only formats
+needed are PNG / JPEG / GIF / WebP.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+
+def detect_image_format_from_base64(data: str) -> str:
+    """Sniff PNG / JPEG / GIF / WebP from the first 12 base64-decoded bytes.
+
+    Inlined substitute for TS ``utils/imageResizer.detectImageFormatFromBase64``.
+    Returns the Anthropic ``media_type`` string. Falls back to ``image/png``
+    when the format cannot be identified (matches what the upstream API
+    would default to and avoids breaking the request on a slightly-malformed
+    payload).
+    """
+    try:
+        decoded = base64.b64decode(data[:24])  # 24 base64 chars ≈ 16 bytes
+    except (ValueError, base64.binascii.Error):  # type: ignore[attr-defined]
+        return 'image/png'
+
+    if len(decoded) < 4:
+        return 'image/png'
+    # PNG: 89 50 4E 47
+    if decoded[:4] == b'\x89PNG':
+        return 'image/png'
+    # JPEG: FF D8 FF
+    if decoded[:3] == b'\xff\xd8\xff':
+        return 'image/jpeg'
+    # GIF: 47 49 46 38 (GIF8)
+    if decoded[:4] == b'GIF8':
+        return 'image/gif'
+    # WebP: RIFF + WEBP at offset 8
+    if len(decoded) >= 12 and decoded[:4] == b'RIFF' and decoded[8:12] == b'WEBP':
+        return 'image/webp'
+    return 'image/png'
+
+
+def extract_inbound_message_fields(
+    msg: dict[str, Any],
+) -> tuple[Any, str | None] | None:
+    """Extract (content, uuid) from a parsed user SDKMessage, or None to skip.
+
+    Mirrors TS ``extractInboundMessageFields`` on ``inboundMessages.ts:21-40``.
+    Returns ``None`` for non-user messages and for empty content (which is
+    also what the TS function returns via ``undefined``).
+
+    **Return shape divergence from TS**: TS returns an object
+    ``{ content, uuid }``; Python returns a tuple ``(content, uuid)`` —
+    matches Python idiom. Phase 5+ orchestrator porters should unpack the
+    tuple, not destructure as if it were a dict.
+
+    Image content blocks are normalized as a side effect of returning them
+    via ``normalize_image_blocks``.
+    """
+    if msg.get('type') != 'user':
+        return None
+    inner = msg.get('message') or {}
+    content = inner.get('content')
+    if not content:
+        return None
+    if isinstance(content, list) and len(content) == 0:
+        return None
+
+    raw_uuid = msg.get('uuid')
+    uuid_str = raw_uuid if isinstance(raw_uuid, str) else None
+
+    if isinstance(content, list):
+        return normalize_image_blocks(content), uuid_str
+    return content, uuid_str
+
+
+def normalize_image_blocks(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Fix malformed image source blocks. Returns input ref on the happy path.
+
+    Mirrors TS ``normalizeImageBlocks`` on ``inboundMessages.ts:52-73``.
+    Bridge clients may send ``mediaType`` (camelCase) instead of
+    ``media_type`` (snake_case), or omit it entirely. Without normalization
+    the upstream API rejects the request with "media_type: Field required".
+
+    Fast-path: scan blocks; if none are malformed, return the input list
+    reference unchanged (zero allocation).
+    """
+    if not any(_is_malformed_base64_image(b) for b in blocks):
+        return blocks
+
+    out: list[dict[str, Any]] = []
+    for block in blocks:
+        if not _is_malformed_base64_image(block):
+            out.append(block)
+            continue
+        source = block.get('source') or {}
+        camel = source.get('mediaType')
+        media_type: str
+        if isinstance(camel, str) and camel:
+            media_type = camel
+        else:
+            data = source.get('data', '')
+            data_str = data if isinstance(data, str) else ''
+            media_type = detect_image_format_from_base64(data_str)
+        new_source = {
+            'type': 'base64',
+            'media_type': media_type,
+            'data': source.get('data', ''),
+        }
+        out.append({**block, 'source': new_source})
+    return out
+
+
+def _is_malformed_base64_image(block: dict[str, Any]) -> bool:
+    """A base64 image block missing the snake_case ``media_type`` field."""
+    if block.get('type') != 'image':
+        return False
+    source = block.get('source') or {}
+    if source.get('type') != 'base64':
+        return False
+    return 'media_type' not in source
+
+
+__all__ = [
+    'detect_image_format_from_base64',
+    'extract_inbound_message_fields',
+    'normalize_image_blocks',
+]

--- a/src/bridge/poll_config_defaults.py
+++ b/src/bridge/poll_config_defaults.py
@@ -1,0 +1,95 @@
+"""Bridge poll interval default constants.
+
+Ports ``typescript/src/bridge/pollConfigDefaults.ts``.
+
+Extracted from ``poll_config.py`` (Phase 2) so callers that don't need live
+GrowthBook tuning (e.g. daemon via Agent SDK) can import the defaults
+without pulling in the schema validation layer. Matches TS organization on
+``pollConfigDefaults.ts:1-7``.
+
+Numeric values match TS exactly; tests in ``test_poll_config_defaults.py``
+assert this for every field.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# Numeric constants
+# ---------------------------------------------------------------------------
+
+POLL_INTERVAL_MS_NOT_AT_CAPACITY: int = 2000
+"""Poll interval when actively seeking work (no transport / below maxSessions).
+
+Mirrors TS ``POLL_INTERVAL_MS_NOT_AT_CAPACITY`` on ``pollConfigDefaults.ts:13``.
+"""
+
+POLL_INTERVAL_MS_AT_CAPACITY: int = 600_000
+"""Poll interval when the transport is connected. 10 minutes.
+
+Mirrors TS ``POLL_INTERVAL_MS_AT_CAPACITY`` on ``pollConfigDefaults.ts:30``.
+Bounded by the server's BRIDGE_LAST_POLL_TTL (4h) and max_poll_stale_seconds
+(24h); 10min gives 24× headroom on the Redis TTL.
+"""
+
+MULTISESSION_POLL_INTERVAL_MS_NOT_AT_CAPACITY: int = POLL_INTERVAL_MS_NOT_AT_CAPACITY
+MULTISESSION_POLL_INTERVAL_MS_PARTIAL_CAPACITY: int = POLL_INTERVAL_MS_NOT_AT_CAPACITY
+MULTISESSION_POLL_INTERVAL_MS_AT_CAPACITY: int = POLL_INTERVAL_MS_AT_CAPACITY
+
+
+# ---------------------------------------------------------------------------
+# Config dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PollIntervalConfig:
+    """Tunable poll-loop intervals for the bridge.
+
+    Mirrors TS ``PollIntervalConfig`` on ``pollConfigDefaults.ts:44-53``.
+    Frozen because instances are shared across the poll loop (single source
+    of truth per call); mutations would race with the loop reading the
+    fields.
+
+    Field naming follows the TS wire-format snake_case (matches what
+    GrowthBook served when v1 was production-tuned).
+    """
+
+    poll_interval_ms_not_at_capacity: int
+    poll_interval_ms_at_capacity: int
+    non_exclusive_heartbeat_interval_ms: int
+    multisession_poll_interval_ms_not_at_capacity: int
+    multisession_poll_interval_ms_partial_capacity: int
+    multisession_poll_interval_ms_at_capacity: int
+    reclaim_older_than_ms: int
+    session_keepalive_interval_v2_ms: int
+
+
+DEFAULT_POLL_CONFIG: PollIntervalConfig = PollIntervalConfig(
+    poll_interval_ms_not_at_capacity=POLL_INTERVAL_MS_NOT_AT_CAPACITY,
+    poll_interval_ms_at_capacity=POLL_INTERVAL_MS_AT_CAPACITY,
+    non_exclusive_heartbeat_interval_ms=0,
+    multisession_poll_interval_ms_not_at_capacity=MULTISESSION_POLL_INTERVAL_MS_NOT_AT_CAPACITY,
+    multisession_poll_interval_ms_partial_capacity=MULTISESSION_POLL_INTERVAL_MS_PARTIAL_CAPACITY,
+    multisession_poll_interval_ms_at_capacity=MULTISESSION_POLL_INTERVAL_MS_AT_CAPACITY,
+    reclaim_older_than_ms=5000,
+    session_keepalive_interval_v2_ms=120_000,
+)
+"""Default poll config matching TS ``DEFAULT_POLL_CONFIG``.
+
+See TS comments at ``pollConfigDefaults.ts:55-82`` for the rationale behind
+each value (heartbeat disabled by default, 5s reclaim matches server
+DEFAULT_RECLAIM_OLDER_THAN_MS, 2min keepalive prevents upstream-proxy GC).
+"""
+
+
+__all__ = [
+    'DEFAULT_POLL_CONFIG',
+    'MULTISESSION_POLL_INTERVAL_MS_AT_CAPACITY',
+    'MULTISESSION_POLL_INTERVAL_MS_NOT_AT_CAPACITY',
+    'MULTISESSION_POLL_INTERVAL_MS_PARTIAL_CAPACITY',
+    'POLL_INTERVAL_MS_AT_CAPACITY',
+    'POLL_INTERVAL_MS_NOT_AT_CAPACITY',
+    'PollIntervalConfig',
+]

--- a/src/bridge/session_id_compat.py
+++ b/src/bridge/session_id_compat.py
@@ -1,0 +1,81 @@
+"""Session ID tag translation helpers for the CCR v2 compat layer.
+
+Ports ``typescript/src/bridge/sessionIdCompat.ts``.
+
+The CCR v2 compat layer issues tagged IDs in two prefixes:
+
+* ``cse_*`` — the v2 infrastructure tag (work poll, worker endpoints).
+* ``session_*`` — the v1 compat tag (client-facing /v1/sessions endpoints).
+
+Both encode the same underlying UUID. The translation helpers re-tag IDs as
+needed when calls cross layers. The ``set_cse_shim_gate()`` hook lets a
+caller inject a kill-switch for the shim without this module needing to
+import bridge_enabled.py (mirrors TS module-isolation reasoning at
+``sessionIdCompat.ts:11-13``).
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+_CSE_PREFIX = 'cse_'
+_SESSION_PREFIX = 'session_'
+
+_cse_shim_enabled: Callable[[], bool] | None = None
+
+
+def set_cse_shim_gate(gate: Callable[[], bool]) -> None:
+    """Register the cse_-shim kill-switch.
+
+    Mirrors TS ``setCseShimGate`` on ``sessionIdCompat.ts:21-23``. When the
+    gate returns ``False``, ``to_compat_session_id`` becomes a no-op. The
+    gate defaults to "active" (shim on) when this is never called, matching
+    TS ``isCseShimEnabled()``'s default-true behavior.
+    """
+    global _cse_shim_enabled
+    _cse_shim_enabled = gate
+
+
+def to_compat_session_id(session_id: str) -> str:
+    """Re-tag a ``cse_*`` session ID to ``session_*`` for the v1 compat API.
+
+    Mirrors TS ``toCompatSessionId`` on ``sessionIdCompat.ts:38-42``.
+    No-op for IDs that aren't ``cse_*``. When the cse-shim gate is disabled,
+    also a no-op (returns input unchanged).
+    """
+    if not session_id.startswith(_CSE_PREFIX):
+        return session_id
+    if _cse_shim_enabled is not None and not _cse_shim_enabled():
+        return session_id
+    return _SESSION_PREFIX + session_id[len(_CSE_PREFIX):]
+
+
+def to_infra_session_id(session_id: str) -> str:
+    """Re-tag a ``session_*`` ID to ``cse_*`` for infrastructure-layer calls.
+
+    Mirrors TS ``toInfraSessionId`` on ``sessionIdCompat.ts:54-57``. Inverse
+    of ``to_compat_session_id``. No-op for IDs that aren't ``session_*``.
+    Unlike the compat direction, this is NOT gated by the cse-shim — once
+    a caller crosses below the compat layer, the infra tag is what the
+    server expects regardless of the shim's state.
+    """
+    if not session_id.startswith(_SESSION_PREFIX):
+        return session_id
+    return _CSE_PREFIX + session_id[len(_SESSION_PREFIX):]
+
+
+def _reset_shim_gate_for_testing() -> None:
+    """Reset module-global gate to ``None`` (tests only).
+
+    Test cleanup helper — not part of the public API. Callers must not
+    rely on this in production code.
+    """
+    global _cse_shim_enabled
+    _cse_shim_enabled = None
+
+
+__all__ = [
+    'set_cse_shim_gate',
+    'to_compat_session_id',
+    'to_infra_session_id',
+]

--- a/src/bridge/types.py
+++ b/src/bridge/types.py
@@ -1,0 +1,500 @@
+"""Bridge subsystem types.
+
+Ports ``typescript/src/bridge/types.ts``. Consolidated type module
+containing dataclasses, TypedDicts, Protocols, and module-level constants
+shared across the bridge subsystem. The TS file mixes wire-format types
+(``WorkData``, ``WorkResponse``) with dependency-injection Protocols
+(``BridgeApiClient``, ``SessionHandle``, ``SessionSpawner``, ``BridgeLogger``);
+Python keeps the same arrangement so callers see one type module per TS file.
+
+For wire-level message types (``SDKMessage``, ``SDKControlRequest`` etc.) see
+``src.bridge.sdk_types`` — those live separately because they cross multiple
+TS files.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Literal,
+    Protocol,
+    TypedDict,
+    Union,
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_SESSION_TIMEOUT_MS: int = 24 * 60 * 60 * 1000
+"""Default per-session timeout (24 hours).
+
+Mirrors TS ``DEFAULT_SESSION_TIMEOUT_MS`` on ``types.ts:2``.
+"""
+
+BRIDGE_LOGIN_INSTRUCTION: str = (
+    'Remote Control is only available with claude.ai subscriptions. '
+    'Please use `/login` to sign in with your claude.ai account.'
+)
+"""Reusable login guidance appended to bridge auth errors.
+
+Mirrors TS ``BRIDGE_LOGIN_INSTRUCTION`` on ``types.ts:5-6``.
+"""
+
+BRIDGE_LOGIN_ERROR: str = (
+    'Error: You must be logged in to use Remote Control.\n\n'
+    + BRIDGE_LOGIN_INSTRUCTION
+)
+"""Full error printed when ``claude remote-control`` is run without auth.
+
+Mirrors TS ``BRIDGE_LOGIN_ERROR`` on ``types.ts:9-11``.
+"""
+
+REMOTE_CONTROL_DISCONNECTED_MSG: str = 'Remote Control disconnected.'
+"""Shown when the user disconnects Remote Control via /remote-control or
+ultraplan launch.
+
+Mirrors TS ``REMOTE_CONTROL_DISCONNECTED_MSG`` on ``types.ts:14``.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Wire protocol types (environments API)
+# ---------------------------------------------------------------------------
+
+
+WorkDataType = Literal['session', 'healthcheck']
+
+
+class WorkData(TypedDict):
+    """Inner data payload of a work poll response.
+
+    Mirrors TS ``WorkData`` on ``types.ts:18-21``.
+    """
+
+    type: WorkDataType
+    id: str
+
+
+class WorkResponse(TypedDict):
+    """Top-level work poll response from the environments API.
+
+    Mirrors TS ``WorkResponse`` on ``types.ts:23-31``. ``secret`` is base64url-
+    encoded JSON (a ``WorkSecret``); use ``decode_work_secret`` to parse it.
+    """
+
+    id: str
+    type: Literal['work']
+    environment_id: str
+    state: str
+    data: WorkData
+    secret: str
+    created_at: str
+
+
+SessionDoneStatus = Literal['completed', 'failed', 'interrupted']
+"""Mirrors TS ``SessionDoneStatus`` on ``types.ts:53``."""
+
+SessionActivityType = Literal['tool_start', 'text', 'result', 'error']
+"""Mirrors TS ``SessionActivityType`` on ``types.ts:55``."""
+
+
+@dataclass(frozen=True)
+class SessionActivity:
+    """A single activity event seen on the child's NDJSON stream.
+
+    Mirrors TS ``SessionActivity`` on ``types.ts:57-61``. Used in the ring
+    buffer maintained by ``SessionRunner``.
+    """
+
+    type: SessionActivityType
+    summary: str
+    timestamp: float
+
+
+SpawnMode = Literal['single-session', 'worktree', 'same-dir']
+"""How ``claude remote-control`` chooses session working directories.
+
+Mirrors TS ``SpawnMode`` on ``types.ts:69``:
+- ``single-session``: one session in cwd, bridge tears down when it ends
+- ``worktree``: persistent server, every session gets an isolated git worktree
+- ``same-dir``: persistent server, every session shares cwd
+"""
+
+
+BridgeWorkerType = Literal['claude_code', 'claude_code_assistant']
+"""Well-known ``worker_type`` values this codebase produces.
+
+Mirrors TS ``BridgeWorkerType`` on ``types.ts:79``. The backend treats this
+field as an opaque string; this narrow type is for internal exhaustiveness.
+"""
+
+
+@dataclass
+class BridgeConfig:
+    """Configuration for a single bridge instance.
+
+    Mirrors TS ``BridgeConfig`` on ``types.ts:81-115``. Mutable because
+    ``spawn_mode`` can change at runtime when the user presses ``w`` to
+    toggle between same-dir and worktree mode (see ``bridgeMain.ts``).
+    """
+
+    dir: str
+    machine_name: str
+    branch: str
+    git_repo_url: str | None
+    max_sessions: int
+    spawn_mode: SpawnMode
+    verbose: bool
+    sandbox: bool
+    bridge_id: str
+    worker_type: str
+    environment_id: str
+    api_base_url: str
+    session_ingress_url: str
+    reuse_environment_id: str | None = None
+    debug_file: str | None = None
+    session_timeout_ms: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# Permission response event (control_response wrapper)
+# ---------------------------------------------------------------------------
+
+
+class _PermissionResponseInner(TypedDict):
+    subtype: Literal['success']
+    request_id: str
+    response: dict[str, Any]
+
+
+class PermissionResponseEvent(TypedDict):
+    """A ``control_response`` event sent back to a session via the events API.
+
+    Mirrors TS ``PermissionResponseEvent`` on ``types.ts:124-131``.
+    """
+
+    type: Literal['control_response']
+    response: _PermissionResponseInner
+
+
+# ---------------------------------------------------------------------------
+# Dependency-injection Protocols
+# ---------------------------------------------------------------------------
+
+
+class BridgeApiClient(Protocol):
+    """HTTP client surface for the environments API.
+
+    Mirrors TS ``BridgeApiClient`` on ``types.ts:133-176``. Concrete
+    implementation lands in Phase 3 (``src/bridge/bridge_api.py``); this
+    Protocol exists so orchestrators (Phase 5+) can be ported and unit-tested
+    against fakes before the real client is built.
+    """
+
+    async def register_bridge_environment(
+        self, config: BridgeConfig
+    ) -> dict[str, str]:
+        """POST /v1/environments/bridge. Returns ``{environment_id, environment_secret}``."""
+        ...
+
+    async def poll_for_work(
+        self,
+        environment_id: str,
+        environment_secret: str,
+        cancel_event: Any | None = None,
+        reclaim_older_than_ms: int | None = None,
+    ) -> WorkResponse | None:
+        """GET .../work/poll. Returns ``None`` when no work is queued."""
+        ...
+
+    async def acknowledge_work(
+        self, environment_id: str, work_id: str, session_token: str
+    ) -> None:
+        """POST .../work/{workId}/ack."""
+        ...
+
+    async def stop_work(
+        self, environment_id: str, work_id: str, force: bool
+    ) -> None:
+        """POST .../work/{workId}/stop."""
+        ...
+
+    async def deregister_environment(self, environment_id: str) -> None:
+        """DELETE /v1/environments/bridge/{environmentId}."""
+        ...
+
+    async def send_permission_response_event(
+        self,
+        session_id: str,
+        event: PermissionResponseEvent,
+        session_token: str,
+    ) -> None:
+        """POST /v1/sessions/{sessionId}/events."""
+        ...
+
+    async def archive_session(self, session_id: str) -> None:
+        """POST /v1/sessions/{sessionId}/archive."""
+        ...
+
+    async def reconnect_session(
+        self, environment_id: str, session_id: str
+    ) -> None:
+        """POST .../bridge/reconnect — force-stop stale workers + re-queue."""
+        ...
+
+    async def heartbeat_work(
+        self, environment_id: str, work_id: str, session_token: str
+    ) -> dict[str, Any]:
+        """POST .../work/{workId}/heartbeat. Returns ``{lease_extended, state}``."""
+        ...
+
+
+class SessionHandle(Protocol):
+    """Handle returned by a session spawner for one running child CLI.
+
+    Mirrors TS ``SessionHandle`` on ``types.ts:178-190``. The TS version has
+    a ``done: Promise<SessionDoneStatus>``; Python uses ``asyncio.Future`` or
+    ``asyncio.Task`` — Protocol method signatures express it as
+    ``async def wait_done()``.
+    """
+
+    @property
+    def session_id(self) -> str: ...
+
+    @property
+    def access_token(self) -> str: ...
+
+    @property
+    def activities(self) -> list[SessionActivity]:
+        """Ring buffer of recent activities (last ~10)."""
+        ...
+
+    @property
+    def current_activity(self) -> SessionActivity | None: ...
+
+    @property
+    def last_stderr(self) -> list[str]:
+        """Ring buffer of last stderr lines."""
+        ...
+
+    async def wait_done(self) -> SessionDoneStatus:
+        """Block until the child exits and return the final status."""
+        ...
+
+    def kill(self) -> None:
+        """SIGTERM the child (graceful)."""
+        ...
+
+    def force_kill(self) -> None:
+        """SIGKILL the child (immediate)."""
+        ...
+
+    def write_stdin(self, data: str) -> None:
+        """Write directly to child stdin."""
+        ...
+
+    def update_access_token(self, token: str) -> None:
+        """Update the access token (e.g. after refresh)."""
+        ...
+
+
+class SessionSpawnOpts(TypedDict, total=False):
+    """Spawn-time options for one session.
+
+    Mirrors TS ``SessionSpawnOpts`` on ``types.ts:192-207``. ``use_ccr_v2``
+    + ``worker_epoch`` are required together for the v2 transport path;
+    ``on_first_user_message`` is fired once on first real user prompt for
+    title derivation.
+    """
+
+    session_id: str  # required
+    sdk_url: str  # required
+    access_token: str  # required
+    use_ccr_v2: bool
+    worker_epoch: int
+    on_first_user_message: Callable[[str], None]
+
+
+class SessionSpawner(Protocol):
+    """Factory for child CLI processes.
+
+    Mirrors TS ``SessionSpawner`` on ``types.ts:209-211``.
+    """
+
+    def spawn(self, opts: SessionSpawnOpts, working_dir: str) -> SessionHandle: ...
+
+
+class BridgeLogger(Protocol):
+    """Status / activity logger for the bridge.
+
+    Mirrors TS ``BridgeLogger`` on ``types.ts:213-262``. The TS surface is
+    sprawling (17+ methods) because it owns terminal rendering. Phase 9
+    delivers the concrete implementation; Phase 1 just establishes the
+    Protocol so orchestrators can be wired against a fake/no-op logger.
+    """
+
+    def print_banner(
+        self, config: BridgeConfig, environment_id: str
+    ) -> None: ...
+
+    def log_session_start(self, session_id: str, prompt: str) -> None: ...
+
+    def log_session_complete(
+        self, session_id: str, duration_ms: float
+    ) -> None: ...
+
+    def log_session_failed(self, session_id: str, error: str) -> None: ...
+
+    def log_status(self, message: str) -> None: ...
+
+    def log_verbose(self, message: str) -> None: ...
+
+    def log_error(self, message: str) -> None: ...
+
+    def log_reconnected(self, disconnected_ms: float) -> None: ...
+
+    def update_idle_status(self) -> None: ...
+
+    def update_reconnecting_status(
+        self, delay_str: str, elapsed_str: str
+    ) -> None: ...
+
+    def update_session_status(
+        self,
+        session_id: str,
+        elapsed: str,
+        activity: SessionActivity,
+        trail: list[str],
+    ) -> None: ...
+
+    def clear_status(self) -> None: ...
+
+    def set_repo_info(self, repo_name: str, branch: str) -> None: ...
+
+    def set_debug_log_path(self, path: str) -> None: ...
+
+    def set_attached(self, session_id: str) -> None: ...
+
+    def update_failed_status(self, error: str) -> None: ...
+
+    def toggle_qr(self) -> None: ...
+
+    def update_session_count(
+        self, active: int, max_sessions: int, mode: SpawnMode
+    ) -> None: ...
+
+    def set_spawn_mode_display(
+        self, mode: Literal['same-dir', 'worktree'] | None
+    ) -> None: ...
+
+    def add_session(self, session_id: str, url: str) -> None: ...
+
+    def update_session_activity(
+        self, session_id: str, activity: SessionActivity
+    ) -> None: ...
+
+    def set_session_title(self, session_id: str, title: str) -> None: ...
+
+    def remove_session(self, session_id: str) -> None: ...
+
+    def refresh_display(self) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# ReplBridgeHandle Protocol (referenced by repl_bridge_handle.py)
+# ---------------------------------------------------------------------------
+
+
+class ReplBridgeHandle(Protocol):
+    """Opaque handle returned by ``init_bridge_core`` / ``init_env_less_bridge_core``.
+
+    Mirrors the consumer-facing surface of TS ``ReplBridgeHandle``
+    (``replBridge.ts`` and ``remoteBridgeCore.ts``). Implementations land in
+    Phase 5 (env-less) and Phase 6 (env-based); the Protocol exists in
+    Phase 1 so ``repl_bridge_handle.py`` (process-global pointer) and other
+    consumers can be ported now.
+
+    ``bridge_session_id`` is exposed for compat-ID derivation in
+    ``repl_bridge_handle.get_self_bridge_compat_id()``.
+    """
+
+    @property
+    def bridge_session_id(self) -> str: ...
+
+    @property
+    def environment_id(self) -> str: ...
+
+    @property
+    def session_ingress_url(self) -> str: ...
+
+    async def write_messages(self, messages: list[Any]) -> None: ...
+
+    async def write_sdk_messages(self, messages: list[Any]) -> None: ...
+
+    async def send_control_request(
+        self, request_id: str, request: dict[str, Any]
+    ) -> None: ...
+
+    async def send_control_response(
+        self, request_id: str, response: dict[str, Any]
+    ) -> None: ...
+
+    async def send_cancel_request(self, request_id: str) -> None: ...
+
+    async def send_result(self) -> None: ...
+
+    async def teardown(self) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Internal aliases for type-checking
+# ---------------------------------------------------------------------------
+
+
+GetAccessToken = Callable[[], Union[str, None, Awaitable[Union[str, None]]]]
+"""Sync-or-async access-token getter used widely across the bridge.
+
+Mirrors the TS pattern of ``() => string | undefined | Promise<...>``.
+"""
+
+OnAuth401 = Callable[[str | None], Awaitable[bool]]
+"""Async callback invoked on a 401. Returns True if token refresh succeeded.
+
+Mirrors TS ``onAuth401`` callbacks scattered across ``bridgeApi.ts``,
+``remoteBridgeCore.ts``, and ``replBridge.ts``.
+"""
+
+
+__all__ = [
+    'BRIDGE_LOGIN_ERROR',
+    'BRIDGE_LOGIN_INSTRUCTION',
+    'BridgeApiClient',
+    'BridgeConfig',
+    'BridgeLogger',
+    'BridgeWorkerType',
+    'DEFAULT_SESSION_TIMEOUT_MS',
+    'GetAccessToken',
+    'OnAuth401',
+    'PermissionResponseEvent',
+    'REMOTE_CONTROL_DISCONNECTED_MSG',
+    'ReplBridgeHandle',
+    'SessionActivity',
+    'SessionActivityType',
+    'SessionDoneStatus',
+    'SessionHandle',
+    'SessionSpawnOpts',
+    'SessionSpawner',
+    'SpawnMode',
+    'WorkData',
+    'WorkDataType',
+    'WorkResponse',
+]
+
+# Re-affirm WorkDataType is exported (Literal alias — appears in WorkData).
+# Listed above explicitly so downstream consumers can write
+# ``from src.bridge.types import WorkDataType``.

--- a/tests/bridge/test_async_cancel_canary.py
+++ b/tests/bridge/test_async_cancel_canary.py
@@ -1,0 +1,238 @@
+"""Asyncio cancellation canary tests (Phase 0.3).
+
+Validates the patterns that ``replBridge.ts`` and ``remoteBridgeCore.ts``
+will need when ported to Python. Builds confidence that ``asyncio.Event`` +
+``asyncio.CancelledError`` can stand in for TS's ``AbortSignal`` cleanly.
+
+Three patterns covered:
+
+1. ``asyncio.sleep`` interrupted by ``cancel()`` (basic shutdown unwind).
+2. Combined cancel sources (substitute for TS ``combinedAbortSignal.ts``).
+3. Generation-counter pattern for in-flight callback invalidation
+   (substitute for TS ``TokenRefreshScheduler``'s generation counter at
+   ``jwtUtils.ts:96-99``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+# -----------------------------------------------------------------------------
+# Pattern 1: asyncio.sleep interrupted by cancel()
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sleep_interrupted_by_cancel() -> None:
+    """A task awaiting asyncio.sleep raises CancelledError on cancel()."""
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def sleeper() -> None:
+        started.set()
+        try:
+            await asyncio.sleep(60)  # would otherwise block forever
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    task = asyncio.create_task(sleeper())
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_sleep_interrupted_by_event_via_wait_for() -> None:
+    """Pattern: race asyncio.sleep against an event using asyncio.wait().
+
+    This is the substitute for TS's ``setTimeout(resolve, ms)`` raced against
+    ``signal.aborted`` — when the event fires first, the sleep is cancelled.
+    """
+    stop = asyncio.Event()
+
+    async def stopper() -> None:
+        await asyncio.sleep(0.01)
+        stop.set()
+
+    asyncio.create_task(stopper())
+
+    sleep_task = asyncio.create_task(asyncio.sleep(60))
+    stop_task = asyncio.create_task(stop.wait())
+    done, pending = await asyncio.wait(
+        {sleep_task, stop_task},
+        return_when=asyncio.FIRST_COMPLETED,
+        timeout=2.0,
+    )
+    for t in pending:
+        t.cancel()
+
+    assert stop_task in done
+    assert sleep_task in pending  # the sleep was cancelled, not completed
+    assert stop.is_set()
+
+
+# -----------------------------------------------------------------------------
+# Pattern 2: Combined cancel sources (substitute for combinedAbortSignal.ts)
+# -----------------------------------------------------------------------------
+
+
+async def _combined_event_wait(*events: asyncio.Event) -> None:
+    """Helper: wait until any of the provided events is set.
+
+    Substitute for TS ``combinedAbortSignal([a, b, c])``. Cleans up its
+    watcher tasks before returning so it doesn't leak listeners.
+    """
+    if any(e.is_set() for e in events):
+        return
+    tasks = [asyncio.create_task(e.wait()) for e in events]
+    try:
+        done, pending = await asyncio.wait(
+            tasks, return_when=asyncio.FIRST_COMPLETED
+        )
+        for t in pending:
+            t.cancel()
+    finally:
+        for t in tasks:
+            if not t.done():
+                t.cancel()
+
+
+@pytest.mark.asyncio
+async def test_combined_signal_first_source_fires() -> None:
+    """Combined-signal returns when the first source fires."""
+    a = asyncio.Event()
+    b = asyncio.Event()
+    c = asyncio.Event()
+
+    async def fire_a() -> None:
+        await asyncio.sleep(0.01)
+        a.set()
+
+    asyncio.create_task(fire_a())
+    await asyncio.wait_for(_combined_event_wait(a, b, c), timeout=1.0)
+    assert a.is_set()
+    assert not b.is_set()
+    assert not c.is_set()
+
+
+@pytest.mark.asyncio
+async def test_combined_signal_short_circuit_when_pre_set() -> None:
+    """If a source is already set on entry, return immediately."""
+    a = asyncio.Event()
+    b = asyncio.Event()
+    a.set()
+    # Must not block.
+    await asyncio.wait_for(_combined_event_wait(a, b), timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_combined_signal_cleans_up_pending_listeners() -> None:
+    """When one source fires, the other watchers are cancelled (no leak)."""
+    a = asyncio.Event()
+    b = asyncio.Event()
+    c = asyncio.Event()
+
+    me = asyncio.current_task()
+    tasks_before = {t for t in asyncio.all_tasks() if not t.done()} - {me}
+
+    async def fire_a() -> None:
+        await asyncio.sleep(0.01)
+        a.set()
+
+    asyncio.create_task(fire_a())
+    await asyncio.wait_for(_combined_event_wait(a, b, c), timeout=1.0)
+    await asyncio.sleep(0)  # let cancellations propagate
+
+    tasks_after = {t for t in asyncio.all_tasks() if not t.done()} - {me}
+    # Allow up to 1 residual (the fire_a task) but no growing leak.
+    assert len(tasks_after) <= len(tasks_before) + 1
+
+
+# -----------------------------------------------------------------------------
+# Pattern 3: Generation counter for in-flight callback invalidation
+# (substitute for TokenRefreshScheduler's generation pattern)
+# -----------------------------------------------------------------------------
+
+
+class GenerationGuard:
+    """Pattern: serialize an async refresh callback by generation.
+
+    Mirrors ``jwtUtils.ts:96-99`` ``nextGeneration(sessionId)`` and the
+    check at line 178 (``generations.get(sessionId) !== gen``). When
+    ``schedule()`` is called, the generation bumps; an in-flight async
+    refresh that completes against a stale generation is dropped.
+    """
+
+    def __init__(self) -> None:
+        self._gen = 0
+
+    def next_gen(self) -> int:
+        self._gen += 1
+        return self._gen
+
+    def is_current(self, gen: int) -> bool:
+        return self._gen == gen
+
+
+@pytest.mark.asyncio
+async def test_generation_counter_invalidates_stale_callback() -> None:
+    """An async callback that fires after the generation bumps is dropped."""
+    guard = GenerationGuard()
+    fired = []
+
+    async def maybe_apply(gen: int, value: str) -> None:
+        await asyncio.sleep(0.02)  # simulate I/O
+        if not guard.is_current(gen):
+            return  # stale — bail
+        fired.append(value)
+
+    g1 = guard.next_gen()
+    t1 = asyncio.create_task(maybe_apply(g1, 'first'))
+
+    # User cancels/reschedules — bump generation.
+    g2 = guard.next_gen()
+    t2 = asyncio.create_task(maybe_apply(g2, 'second'))
+
+    await asyncio.gather(t1, t2)
+    # Only the second (current-generation) callback should have fired.
+    assert fired == ['second']
+
+
+@pytest.mark.asyncio
+async def test_generation_counter_allows_multiple_in_order_callbacks() -> None:
+    """Sequential same-generation callbacks all fire (no false invalidation)."""
+    guard = GenerationGuard()
+    fired = []
+
+    async def maybe_apply(gen: int, value: str) -> None:
+        await asyncio.sleep(0)  # yield once
+        if not guard.is_current(gen):
+            return
+        fired.append(value)
+
+    gen = guard.next_gen()
+    await asyncio.gather(
+        maybe_apply(gen, 'a'),
+        maybe_apply(gen, 'b'),
+        maybe_apply(gen, 'c'),
+    )
+    assert sorted(fired) == ['a', 'b', 'c']
+
+
+@pytest.mark.asyncio
+async def test_generation_counter_resets_via_explicit_bump() -> None:
+    """Cancelling all timers = bump all generations (jwtUtils.ts:243-247)."""
+    guard = GenerationGuard()
+    g1 = guard.next_gen()
+    g2 = guard.next_gen()
+    g3 = guard.next_gen()
+
+    assert guard.is_current(g3)
+    assert not guard.is_current(g1)
+    assert not guard.is_current(g2)

--- a/tests/bridge/test_bridge_enabled.py
+++ b/tests/bridge/test_bridge_enabled.py
@@ -1,0 +1,55 @@
+"""Tests for ``src.bridge.bridge_enabled`` (all stubs)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.bridge import bridge_enabled as be
+
+
+def test_is_bridge_enabled_true() -> None:
+    assert be.is_bridge_enabled() is True
+
+
+@pytest.mark.asyncio
+async def test_is_bridge_enabled_blocking_true() -> None:
+    assert await be.is_bridge_enabled_blocking() is True
+
+
+@pytest.mark.asyncio
+async def test_get_bridge_disabled_reason_none() -> None:
+    assert await be.get_bridge_disabled_reason() is None
+
+
+def test_is_env_less_bridge_enabled_true() -> None:
+    assert be.is_env_less_bridge_enabled() is True
+
+
+def test_is_cse_shim_enabled_true() -> None:
+    assert be.is_cse_shim_enabled() is True
+
+
+def test_check_bridge_min_version_none() -> None:
+    assert be.check_bridge_min_version() is None
+
+
+def test_get_ccr_auto_connect_default_false() -> None:
+    assert be.get_ccr_auto_connect_default() is False
+
+
+def test_is_ccr_mirror_enabled_false() -> None:
+    assert be.is_ccr_mirror_enabled() is False
+
+
+def test_all_exports_present() -> None:
+    expected = {
+        'check_bridge_min_version',
+        'get_bridge_disabled_reason',
+        'get_ccr_auto_connect_default',
+        'is_bridge_enabled',
+        'is_bridge_enabled_blocking',
+        'is_ccr_mirror_enabled',
+        'is_cse_shim_enabled',
+        'is_env_less_bridge_enabled',
+    }
+    assert set(be.__all__) == expected

--- a/tests/bridge/test_bridge_permission_callbacks.py
+++ b/tests/bridge/test_bridge_permission_callbacks.py
@@ -1,0 +1,66 @@
+"""Tests for ``src.bridge.bridge_permission_callbacks``."""
+
+from __future__ import annotations
+
+from src.bridge.bridge_permission_callbacks import (
+    BridgePermissionCallbacks,
+    BridgePermissionResponse,
+    is_bridge_permission_response,
+)
+
+
+def test_is_bridge_permission_response_accepts_allow() -> None:
+    assert is_bridge_permission_response({'behavior': 'allow'}) is True
+
+
+def test_is_bridge_permission_response_accepts_deny() -> None:
+    assert is_bridge_permission_response({'behavior': 'deny', 'message': 'no'}) is True
+
+
+def test_is_bridge_permission_response_rejects_missing_behavior() -> None:
+    assert is_bridge_permission_response({'message': 'no'}) is False
+
+
+def test_is_bridge_permission_response_rejects_invalid_behavior() -> None:
+    assert is_bridge_permission_response({'behavior': 'maybe'}) is False
+
+
+def test_is_bridge_permission_response_rejects_non_dict() -> None:
+    assert is_bridge_permission_response(None) is False
+    assert is_bridge_permission_response('allow') is False
+    assert is_bridge_permission_response([{'behavior': 'allow'}]) is False
+
+
+def test_bridge_permission_response_typed_dict_usable() -> None:
+    resp: BridgePermissionResponse = {'behavior': 'allow'}
+    assert resp['behavior'] == 'allow'
+
+    full: BridgePermissionResponse = {
+        'behavior': 'allow',
+        'updatedInput': {'foo': 1},
+        'updatedPermissions': [{'rule': 'x'}],
+        'message': 'ok',
+    }
+    assert full['updatedInput'] == {'foo': 1}
+
+
+def test_protocol_accepts_duck_typed_impl() -> None:
+    """BridgePermissionCallbacks is structural — any matching object works."""
+
+    class _Fake:
+        def send_request(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            pass
+
+        def send_response(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            pass
+
+        def cancel_request(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            pass
+
+        def on_response(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            return lambda: None
+
+    impl = _Fake()
+    # All four methods must be present.
+    for method in ('send_request', 'send_response', 'cancel_request', 'on_response'):
+        assert hasattr(impl, method)

--- a/tests/bridge/test_capacity_wake.py
+++ b/tests/bridge/test_capacity_wake.py
@@ -1,0 +1,199 @@
+"""Tests for ``src.bridge.capacity_wake``.
+
+Covers the 5 categories from refactoring plan §2 Phase 0:
+(a) wake during sleep aborts sleep
+(b) outer abort propagates
+(c) cleanup removes listeners (no leaked tasks)
+(d) double-wake re-arms a fresh controller
+(e) race between outer + capacity abort
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.bridge.capacity_wake import CapacityWake, create_capacity_wake
+
+
+@pytest.mark.asyncio
+async def test_wake_during_sleep_aborts_sleep() -> None:
+    """(a) Calling wake() while a signal-merged event is awaited fires it immediately."""
+    outer = asyncio.Event()
+    cw = create_capacity_wake(outer)
+
+    sig = cw.signal()
+    assert not sig.event.is_set()
+
+    async def waker() -> None:
+        await asyncio.sleep(0.01)
+        cw.wake()
+
+    asyncio.create_task(waker())
+    await asyncio.wait_for(sig.event.wait(), timeout=1.0)
+    assert sig.event.is_set()
+    sig.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_outer_abort_propagates() -> None:
+    """(b) Setting the outer abort signal fires the merged event."""
+    outer = asyncio.Event()
+    cw = create_capacity_wake(outer)
+
+    sig = cw.signal()
+    assert not sig.event.is_set()
+
+    outer.set()
+    await asyncio.wait_for(sig.event.wait(), timeout=1.0)
+    assert sig.event.is_set()
+    sig.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_removes_listeners() -> None:
+    """(c) cleanup() cancels the watcher tasks so they don't leak."""
+    outer = asyncio.Event()
+    cw = create_capacity_wake(outer)
+
+    sig = cw.signal()
+    # Get all running tasks before cleanup; should include the two watchers.
+    tasks_before = {t for t in asyncio.all_tasks() if not t.done()}
+    # The current task is one of them; exclude it for a stable count.
+    me = asyncio.current_task()
+    watcher_count_before = len(tasks_before - {me})
+    assert watcher_count_before >= 2
+
+    sig.cleanup()
+    # Give the event loop a tick to process the cancellations.
+    await asyncio.sleep(0)
+    tasks_after = {t for t in asyncio.all_tasks() if not t.done()}
+    watcher_count_after = len(tasks_after - {me})
+    assert watcher_count_after < watcher_count_before
+
+
+@pytest.mark.asyncio
+async def test_double_wake_rearms_fresh_controller() -> None:
+    """(d) After wake(), a new signal() call returns a fresh, unset event.
+
+    Mirrors TS lines 30-34: wake() aborts the previous controller and
+    arms a new one. A subsequent signal() must reflect the new controller,
+    not the previously-fired one.
+    """
+    outer = asyncio.Event()
+    cw = create_capacity_wake(outer)
+
+    sig1 = cw.signal()
+    cw.wake()
+    # sig1 should now be set (its wake source fired).
+    await asyncio.wait_for(sig1.event.wait(), timeout=1.0)
+    sig1.cleanup()
+
+    # A fresh signal() must not be pre-set (fresh wake event).
+    sig2 = cw.signal()
+    assert not sig2.event.is_set()
+
+    # And the new signal() must still be wake-able.
+    cw.wake()
+    await asyncio.wait_for(sig2.event.wait(), timeout=1.0)
+    assert sig2.event.is_set()
+    sig2.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_race_between_outer_and_capacity_abort() -> None:
+    """(e) When both outer and wake fire concurrently, the merged event is set.
+
+    Mirrors TS lines 39-42: the short-circuit checks both sources at signal
+    creation time. We test the post-creation race too.
+    """
+    outer = asyncio.Event()
+    cw = create_capacity_wake(outer)
+
+    sig = cw.signal()
+
+    # Both fire "simultaneously".
+    cw.wake()
+    outer.set()
+
+    await asyncio.wait_for(sig.event.wait(), timeout=1.0)
+    assert sig.event.is_set()
+    sig.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_short_circuit_when_outer_already_set() -> None:
+    """signal() returns a pre-set event when outer is already aborted.
+
+    Mirrors TS lines 39-42 short-circuit path.
+    """
+    outer = asyncio.Event()
+    outer.set()
+    cw = create_capacity_wake(outer)
+
+    sig = cw.signal()
+    assert sig.event.is_set()
+    # cleanup must be safe to call even on the short-circuit path.
+    sig.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_short_circuit_when_wake_already_fired_then_signal() -> None:
+    """If wake() fires before any signal() call, the next signal() is NOT pre-set.
+
+    Per TS semantics: wake() re-arms a fresh controller (line 32-33), so the
+    previously-set wake event is discarded. A subsequent signal() ties to
+    the *new* wake event, not the old one.
+    """
+    outer = asyncio.Event()
+    cw = create_capacity_wake(outer)
+
+    cw.wake()  # Fires + re-arms.
+    sig = cw.signal()
+    assert not sig.event.is_set()
+    sig.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_outer_event_set_during_signal_wait() -> None:
+    """Setting outer mid-wait triggers the merged event (regression case)."""
+    outer = asyncio.Event()
+    cw = create_capacity_wake(outer)
+
+    sig = cw.signal()
+
+    async def aborter() -> None:
+        await asyncio.sleep(0.01)
+        outer.set()
+
+    asyncio.create_task(aborter())
+    await asyncio.wait_for(sig.event.wait(), timeout=1.0)
+    assert sig.event.is_set()
+    sig.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_signal_returned_after_outer_aborts_is_pre_set() -> None:
+    """A signal() call AFTER outer aborts must be pre-set with no leaked tasks."""
+    outer = asyncio.Event()
+    cw = create_capacity_wake(outer)
+    outer.set()
+
+    me = asyncio.current_task()
+    tasks_before = {t for t in asyncio.all_tasks() if not t.done()} - {me}
+
+    sig = cw.signal()
+    assert sig.event.is_set()
+    sig.cleanup()
+
+    tasks_after = {t for t in asyncio.all_tasks() if not t.done()} - {me}
+    # No new watcher tasks were spawned on the short-circuit path.
+    assert len(tasks_after) <= len(tasks_before)
+
+
+def test_create_capacity_wake_returns_capacity_wake() -> None:
+    """Factory returns a CapacityWake instance."""
+    outer = asyncio.Event()
+    cw = create_capacity_wake(outer)
+    assert isinstance(cw, CapacityWake)

--- a/tests/bridge/test_debug_utils.py
+++ b/tests/bridge/test_debug_utils.py
@@ -1,0 +1,130 @@
+"""Tests for ``src.bridge.debug_utils``."""
+
+from __future__ import annotations
+
+import json
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from src.bridge.debug_utils import (
+    DEBUG_MSG_LIMIT,
+    debug_body,
+    debug_truncate,
+    describe_http_error,
+    extract_error_detail,
+    extract_http_status,
+    log_bridge_skip,
+    redact_secrets,
+)
+
+
+def test_redact_secrets_short_token_fully_redacted() -> None:
+    """Short tokens (<16 chars) become ``[REDACTED]``."""
+    s = '{"access_token":"shortone"}'
+    assert redact_secrets(s) == '{"access_token":"[REDACTED]"}'
+
+
+def test_redact_secrets_long_token_partial() -> None:
+    """Long tokens keep first 8 + last 4 chars."""
+    token = 'abcd1234EFGH5678ZZZZ'  # 20 chars >= 16
+    s = f'{{"session_ingress_token":"{token}"}}'
+    out = redact_secrets(s)
+    assert 'abcd1234...ZZZZ' in out
+    # The middle (1234EFGH5678) must not appear.
+    assert 'EFGH5678' not in out
+    assert '"session_ingress_token":' in out
+
+
+def test_redact_secrets_covers_all_field_names() -> None:
+    fields = ['session_ingress_token', 'environment_secret', 'access_token', 'secret', 'token']
+    for field in fields:
+        s = f'{{"{field}":"verylongtokenvaluexxx"}}'
+        out = redact_secrets(s)
+        assert 'verylongtoken' not in out, f'field {field} not redacted'
+
+
+def test_redact_secrets_leaves_unrelated_fields_alone() -> None:
+    s = '{"user_id":"u-123","access_token":"verylongtokenxxxxxx"}'
+    out = redact_secrets(s)
+    assert '"user_id":"u-123"' in out
+    assert 'verylongtoken' not in out
+
+
+def test_debug_truncate_short_string_unchanged() -> None:
+    assert debug_truncate('hello') == 'hello'
+
+
+def test_debug_truncate_collapses_newlines() -> None:
+    assert debug_truncate('a\nb\nc') == 'a\\nb\\nc'
+
+
+def test_debug_truncate_long_string_truncated() -> None:
+    s = 'x' * (DEBUG_MSG_LIMIT + 100)
+    out = debug_truncate(s)
+    assert out.startswith('x' * 200)
+    assert f'({len(s)} chars)' in out
+    assert len(out) < len(s)
+
+
+def test_debug_body_dict_serialized_and_redacted() -> None:
+    payload = {'access_token': 'verylongtokenxxxxx', 'msg': 'hi'}
+    out = debug_body(payload)
+    assert 'verylongtoken' not in out
+    assert 'hi' in out
+
+
+def test_debug_body_string_passes_through_with_redaction() -> None:
+    out = debug_body('{"token":"verylongtokenxxxxx"}')
+    assert 'verylongtoken' not in out
+
+
+def test_extract_http_status_with_response_attr() -> None:
+    err = SimpleNamespace(response=SimpleNamespace(status_code=404))
+    assert extract_http_status(err) == 404
+
+
+def test_extract_http_status_no_response_returns_none() -> None:
+    err = Exception('plain error')
+    assert extract_http_status(err) is None
+
+
+def test_extract_error_detail_finds_message_field() -> None:
+    assert extract_error_detail({'message': 'bad'}) == 'bad'
+
+
+def test_extract_error_detail_finds_nested_error_message() -> None:
+    assert extract_error_detail({'error': {'message': 'denied'}}) == 'denied'
+
+
+def test_extract_error_detail_returns_none_for_missing() -> None:
+    assert extract_error_detail({'unrelated': 'data'}) is None
+    assert extract_error_detail('not a dict') is None
+    assert extract_error_detail(None) is None
+
+
+def test_describe_http_error_appends_detail() -> None:
+    response = SimpleNamespace(json=lambda: {'message': 'unauthorized'})
+    err = SimpleNamespace(response=response, __str__=lambda self: 'HTTP 401')
+    # SimpleNamespace doesn't accept __str__ override above; build manually.
+
+    class _Err(Exception):
+        def __init__(self) -> None:
+            super().__init__('HTTP 401')
+            self.response = response
+
+    out = describe_http_error(_Err())
+    assert 'HTTP 401' in out
+    assert 'unauthorized' in out
+
+
+def test_describe_http_error_no_response_returns_str() -> None:
+    err = ValueError('plain')
+    assert describe_http_error(err) == 'plain'
+
+
+def test_log_bridge_skip_emits_info_log(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.INFO, logger='src.bridge.debug_utils'):
+        log_bridge_skip('no_token', debug_msg='cache miss', v2=True)
+    assert any('no_token' in rec.message for rec in caplog.records)

--- a/tests/bridge/test_inbound_messages.py
+++ b/tests/bridge/test_inbound_messages.py
@@ -1,0 +1,167 @@
+"""Tests for ``src.bridge.inbound_messages``."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from src.bridge.inbound_messages import (
+    detect_image_format_from_base64,
+    extract_inbound_message_fields,
+    normalize_image_blocks,
+)
+
+
+# ---------------------------------------------------------------------------
+# detect_image_format_from_base64
+# ---------------------------------------------------------------------------
+
+
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode('ascii')
+
+
+def test_detect_png() -> None:
+    assert detect_image_format_from_base64(_b64(b'\x89PNG\r\n\x1a\n' + b'\x00' * 8)) == 'image/png'
+
+
+def test_detect_jpeg() -> None:
+    assert detect_image_format_from_base64(_b64(b'\xff\xd8\xff\xe0' + b'\x00' * 8)) == 'image/jpeg'
+
+
+def test_detect_gif() -> None:
+    assert detect_image_format_from_base64(_b64(b'GIF89a' + b'\x00' * 8)) == 'image/gif'
+
+
+def test_detect_webp() -> None:
+    assert (
+        detect_image_format_from_base64(_b64(b'RIFF\x00\x00\x00\x00WEBPVP8 '))
+        == 'image/webp'
+    )
+
+
+def test_detect_unknown_defaults_to_png() -> None:
+    assert detect_image_format_from_base64(_b64(b'\x00\x00\x00\x00' + b'\x00' * 8)) == 'image/png'
+
+
+def test_detect_malformed_base64_defaults_to_png() -> None:
+    assert detect_image_format_from_base64('not!valid!base64') == 'image/png'
+
+
+# ---------------------------------------------------------------------------
+# extract_inbound_message_fields
+# ---------------------------------------------------------------------------
+
+
+def test_extract_returns_none_for_non_user() -> None:
+    assert extract_inbound_message_fields({'type': 'assistant', 'message': {'content': 'hi'}}) is None
+
+
+def test_extract_returns_none_for_missing_content() -> None:
+    assert extract_inbound_message_fields({'type': 'user', 'message': {}}) is None
+    assert extract_inbound_message_fields({'type': 'user'}) is None
+
+
+def test_extract_returns_none_for_empty_array_content() -> None:
+    msg = {'type': 'user', 'message': {'content': []}}
+    assert extract_inbound_message_fields(msg) is None
+
+
+def test_extract_returns_string_content() -> None:
+    msg = {'type': 'user', 'message': {'content': 'hello'}, 'uuid': 'u-1'}
+    out = extract_inbound_message_fields(msg)
+    assert out == ('hello', 'u-1')
+
+
+def test_extract_returns_none_uuid_when_missing() -> None:
+    msg = {'type': 'user', 'message': {'content': 'hello'}}
+    out = extract_inbound_message_fields(msg)
+    assert out == ('hello', None)
+
+
+def test_extract_returns_list_content_normalized() -> None:
+    blocks = [{'type': 'text', 'text': 'hi'}]
+    msg = {'type': 'user', 'message': {'content': blocks}, 'uuid': 'u-2'}
+    out = extract_inbound_message_fields(msg)
+    assert out is not None
+    assert out[0] == blocks
+    assert out[1] == 'u-2'
+
+
+# ---------------------------------------------------------------------------
+# normalize_image_blocks (the hot path of the file)
+# ---------------------------------------------------------------------------
+
+
+def test_well_formed_blocks_returned_by_reference() -> None:
+    """Happy path: same list object returned (zero-allocation)."""
+    blocks = [
+        {'type': 'text', 'text': 'hi'},
+        {
+            'type': 'image',
+            'source': {'type': 'base64', 'media_type': 'image/png', 'data': 'abc'},
+        },
+    ]
+    out = normalize_image_blocks(blocks)
+    assert out is blocks
+
+
+def test_camel_case_mediatype_normalized_to_snake() -> None:
+    blocks = [
+        {
+            'type': 'image',
+            'source': {'type': 'base64', 'mediaType': 'image/jpeg', 'data': 'abc'},
+        },
+    ]
+    out = normalize_image_blocks(blocks)
+    assert out is not blocks
+    assert out[0]['source']['media_type'] == 'image/jpeg'
+    # The new source dict has only type/media_type/data; the old camelCase
+    # field must be absent (not just hidden behind a same-value alias).
+    assert 'mediaType' not in out[0]['source']
+    assert out[0]['source']['type'] == 'base64'
+    assert out[0]['source']['data'] == 'abc'
+
+
+def test_missing_media_type_derived_from_base64() -> None:
+    """If neither mediaType nor media_type is set, sniff from base64 data."""
+    png_data = _b64(b'\x89PNG' + b'\x00' * 12)
+    blocks = [
+        {
+            'type': 'image',
+            'source': {'type': 'base64', 'data': png_data},
+        },
+    ]
+    out = normalize_image_blocks(blocks)
+    assert out[0]['source']['media_type'] == 'image/png'
+
+
+def test_text_blocks_preserved_in_mixed_content() -> None:
+    blocks = [
+        {'type': 'text', 'text': 'desc'},
+        {
+            'type': 'image',
+            'source': {'type': 'base64', 'mediaType': 'image/png', 'data': 'd'},
+        },
+    ]
+    out = normalize_image_blocks(blocks)
+    assert out[0] == {'type': 'text', 'text': 'desc'}
+    assert out[1]['source']['media_type'] == 'image/png'
+
+
+def test_non_base64_source_not_touched() -> None:
+    """URL-source images are unaffected by the snake_case fix."""
+    blocks = [
+        {
+            'type': 'image',
+            'source': {'type': 'url', 'url': 'https://x/y.png'},
+        },
+    ]
+    out = normalize_image_blocks(blocks)
+    assert out is blocks  # fast path: not malformed
+
+
+def test_empty_blocks_returns_input() -> None:
+    blocks: list[dict[str, object]] = []
+    assert normalize_image_blocks(blocks) is blocks

--- a/tests/bridge/test_poll_config_defaults.py
+++ b/tests/bridge/test_poll_config_defaults.py
@@ -1,0 +1,90 @@
+"""Tests for ``src.bridge.poll_config_defaults``.
+
+Each TS default must match the Python default exactly — this is a
+behavior-preservation contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.bridge.poll_config_defaults import (
+    DEFAULT_POLL_CONFIG,
+    MULTISESSION_POLL_INTERVAL_MS_AT_CAPACITY,
+    MULTISESSION_POLL_INTERVAL_MS_NOT_AT_CAPACITY,
+    MULTISESSION_POLL_INTERVAL_MS_PARTIAL_CAPACITY,
+    POLL_INTERVAL_MS_AT_CAPACITY,
+    POLL_INTERVAL_MS_NOT_AT_CAPACITY,
+    PollIntervalConfig,
+)
+
+
+def test_poll_interval_ms_not_at_capacity_is_2000() -> None:
+    """Mirrors TS ``pollConfigDefaults.ts:13``."""
+    assert POLL_INTERVAL_MS_NOT_AT_CAPACITY == 2000
+
+
+def test_poll_interval_ms_at_capacity_is_600000() -> None:
+    """Mirrors TS ``pollConfigDefaults.ts:30`` — 10 minutes."""
+    assert POLL_INTERVAL_MS_AT_CAPACITY == 600_000
+
+
+def test_multisession_defaults_match_single_session() -> None:
+    """Mirrors TS ``pollConfigDefaults.ts:39-42``."""
+    assert MULTISESSION_POLL_INTERVAL_MS_NOT_AT_CAPACITY == POLL_INTERVAL_MS_NOT_AT_CAPACITY
+    assert MULTISESSION_POLL_INTERVAL_MS_PARTIAL_CAPACITY == POLL_INTERVAL_MS_NOT_AT_CAPACITY
+    assert MULTISESSION_POLL_INTERVAL_MS_AT_CAPACITY == POLL_INTERVAL_MS_AT_CAPACITY
+
+
+def test_default_poll_config_field_values() -> None:
+    """Every field of DEFAULT_POLL_CONFIG matches TS DEFAULT_POLL_CONFIG."""
+    assert DEFAULT_POLL_CONFIG.poll_interval_ms_not_at_capacity == 2000
+    assert DEFAULT_POLL_CONFIG.poll_interval_ms_at_capacity == 600_000
+    # 0 = heartbeat disabled by default (matches TS comment lines 58-65).
+    assert DEFAULT_POLL_CONFIG.non_exclusive_heartbeat_interval_ms == 0
+    assert DEFAULT_POLL_CONFIG.multisession_poll_interval_ms_not_at_capacity == 2000
+    assert DEFAULT_POLL_CONFIG.multisession_poll_interval_ms_partial_capacity == 2000
+    assert DEFAULT_POLL_CONFIG.multisession_poll_interval_ms_at_capacity == 600_000
+    # 5s reclaim matches server DEFAULT_RECLAIM_OLDER_THAN_MS (work_service.py:24).
+    assert DEFAULT_POLL_CONFIG.reclaim_older_than_ms == 5000
+    # 2min keepalive prevents upstream-proxy GC of idle remote-control sessions.
+    assert DEFAULT_POLL_CONFIG.session_keepalive_interval_v2_ms == 120_000
+
+
+def test_default_poll_config_is_frozen() -> None:
+    """PollIntervalConfig is frozen; field assignment raises."""
+    with pytest.raises(Exception):  # FrozenInstanceError
+        DEFAULT_POLL_CONFIG.poll_interval_ms_at_capacity = 999  # type: ignore[misc]
+
+
+def test_poll_interval_config_constructible() -> None:
+    """PollIntervalConfig can be constructed with custom values."""
+    cfg = PollIntervalConfig(
+        poll_interval_ms_not_at_capacity=1000,
+        poll_interval_ms_at_capacity=10_000,
+        non_exclusive_heartbeat_interval_ms=20_000,
+        multisession_poll_interval_ms_not_at_capacity=1000,
+        multisession_poll_interval_ms_partial_capacity=1000,
+        multisession_poll_interval_ms_at_capacity=10_000,
+        reclaim_older_than_ms=5000,
+        session_keepalive_interval_v2_ms=60_000,
+    )
+    assert cfg.poll_interval_ms_at_capacity == 10_000
+
+
+def test_at_capacity_liveness_invariant_default() -> None:
+    """Default config satisfies the at-capacity liveness invariant.
+
+    Mirrors TS ``pollConfig.ts:74-91`` refine: either heartbeat > 0 OR
+    poll_interval_ms_at_capacity > 0. The default has heartbeat=0 but
+    poll_interval_ms_at_capacity=600000 — invariant holds via the second clause.
+    """
+    cfg = DEFAULT_POLL_CONFIG
+    assert (
+        cfg.non_exclusive_heartbeat_interval_ms > 0
+        or cfg.poll_interval_ms_at_capacity > 0
+    )
+    assert (
+        cfg.non_exclusive_heartbeat_interval_ms > 0
+        or cfg.multisession_poll_interval_ms_at_capacity > 0
+    )

--- a/tests/bridge/test_session_id_compat.py
+++ b/tests/bridge/test_session_id_compat.py
@@ -1,0 +1,115 @@
+"""Tests for ``src.bridge.session_id_compat`` and the extended exceptions."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.bridge.exceptions import BridgeFatalError
+from src.bridge.session_id_compat import (
+    _reset_shim_gate_for_testing,
+    set_cse_shim_gate,
+    to_compat_session_id,
+    to_infra_session_id,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_shim() -> None:
+    """Each test starts with the gate unset (default-active shim)."""
+    _reset_shim_gate_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# session_id_compat
+# ---------------------------------------------------------------------------
+
+
+def test_to_compat_session_id_translates_cse_to_session() -> None:
+    assert to_compat_session_id('cse_abc123') == 'session_abc123'
+
+
+def test_to_compat_session_id_idempotent_on_session_id() -> None:
+    """Already-session_ IDs pass through unchanged."""
+    assert to_compat_session_id('session_xyz') == 'session_xyz'
+
+
+def test_to_compat_session_id_idempotent_on_unprefixed() -> None:
+    """Bare UUIDs (no prefix) pass through unchanged."""
+    assert to_compat_session_id('abc123') == 'abc123'
+
+
+def test_to_compat_session_id_gate_disabled_returns_input() -> None:
+    """When the shim gate returns False, cse_* IDs pass through unchanged."""
+    set_cse_shim_gate(lambda: False)
+    assert to_compat_session_id('cse_abc') == 'cse_abc'
+
+
+def test_to_compat_session_id_gate_enabled_translates() -> None:
+    """When the shim gate returns True (explicit), translation still happens."""
+    set_cse_shim_gate(lambda: True)
+    assert to_compat_session_id('cse_abc') == 'session_abc'
+
+
+def test_to_infra_session_id_translates_session_to_cse() -> None:
+    assert to_infra_session_id('session_abc') == 'cse_abc'
+
+
+def test_to_infra_session_id_not_gated_by_shim() -> None:
+    """Even when shim is disabled, session_ → cse_ translation still happens.
+
+    Mirrors TS comment at ``sessionIdCompat.ts:54`` — the infra direction is
+    NOT gated because infrastructure-layer calls always need the cse_* tag.
+    """
+    set_cse_shim_gate(lambda: False)
+    assert to_infra_session_id('session_abc') == 'cse_abc'
+
+
+def test_to_infra_session_id_idempotent_on_cse() -> None:
+    assert to_infra_session_id('cse_abc') == 'cse_abc'
+
+
+def test_to_infra_session_id_idempotent_on_unprefixed() -> None:
+    assert to_infra_session_id('xyz123') == 'xyz123'
+
+
+def test_round_trip_cse_to_session_and_back() -> None:
+    """compat(infra(session_X)) round-trip returns the original."""
+    original = 'session_uuid-123'
+    infra = to_infra_session_id(original)
+    assert infra == 'cse_uuid-123'
+    back = to_compat_session_id(infra)
+    assert back == original
+
+
+# ---------------------------------------------------------------------------
+# Extended BridgeFatalError
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_fatal_error_carries_status_and_type() -> None:
+    err = BridgeFatalError('Poll 401', status=401, error_type='unauthorized')
+    assert err.status == 401
+    assert err.error_type == 'unauthorized'
+    assert str(err) == 'Poll 401'
+
+
+def test_bridge_fatal_error_optional_error_type() -> None:
+    """``error_type`` defaults to None when server returns no error body."""
+    err = BridgeFatalError('Poll 503', status=503)
+    assert err.status == 503
+    assert err.error_type is None
+
+
+def test_bridge_fatal_error_is_exception() -> None:
+    """Must be raisable and catchable like any Python exception."""
+    with pytest.raises(BridgeFatalError) as exc_info:
+        raise BridgeFatalError('test', status=410, error_type='environment_expired')
+    assert exc_info.value.status == 410
+    assert exc_info.value.error_type == 'environment_expired'
+
+
+def test_bridge_fatal_error_repr_includes_fields() -> None:
+    err = BridgeFatalError('Poll 401', status=401, error_type='lifetime')
+    r = repr(err)
+    assert 'status=401' in r
+    assert 'lifetime' in r

--- a/tests/bridge/test_types.py
+++ b/tests/bridge/test_types.py
@@ -1,0 +1,189 @@
+"""Tests for ``src.bridge.types``.
+
+Validates that:
+- Constants match TS values exactly.
+- Protocols accept duck-typed implementations.
+- Dataclasses construct and round-trip.
+- TypedDicts are usable as plain dict literals.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.bridge import types as bt
+from src.bridge.types import (
+    BRIDGE_LOGIN_ERROR,
+    BRIDGE_LOGIN_INSTRUCTION,
+    DEFAULT_SESSION_TIMEOUT_MS,
+    REMOTE_CONTROL_DISCONNECTED_MSG,
+    BridgeConfig,
+    SessionActivity,
+    WorkData,
+    WorkResponse,
+)
+
+
+def test_default_session_timeout_matches_ts() -> None:
+    """``types.ts:2`` ``DEFAULT_SESSION_TIMEOUT_MS = 24 * 60 * 60 * 1000``."""
+    assert DEFAULT_SESSION_TIMEOUT_MS == 24 * 60 * 60 * 1000
+    assert DEFAULT_SESSION_TIMEOUT_MS == 86_400_000
+
+
+def test_login_messages_match_ts() -> None:
+    """``BRIDGE_LOGIN_INSTRUCTION`` text matches TS verbatim."""
+    assert 'Remote Control is only available with claude.ai' in BRIDGE_LOGIN_INSTRUCTION
+    assert '/login' in BRIDGE_LOGIN_INSTRUCTION
+    assert 'Error: You must be logged in' in BRIDGE_LOGIN_ERROR
+    assert BRIDGE_LOGIN_INSTRUCTION in BRIDGE_LOGIN_ERROR
+
+
+def test_remote_control_disconnected_message() -> None:
+    assert REMOTE_CONTROL_DISCONNECTED_MSG == 'Remote Control disconnected.'
+
+
+def test_session_activity_is_frozen_dataclass() -> None:
+    a = SessionActivity(type='tool_start', summary='Reading foo.py', timestamp=1.5)
+    assert a.type == 'tool_start'
+    assert a.summary == 'Reading foo.py'
+    assert a.timestamp == 1.5
+    with pytest.raises(Exception):  # FrozenInstanceError or AttributeError
+        a.type = 'text'  # type: ignore[misc]
+
+
+def test_bridge_config_is_mutable() -> None:
+    """``BridgeConfig`` must be mutable so ``spawn_mode`` can flip at runtime."""
+    cfg = BridgeConfig(
+        dir='/tmp',
+        machine_name='test',
+        branch='main',
+        git_repo_url=None,
+        max_sessions=1,
+        spawn_mode='single-session',
+        verbose=False,
+        sandbox=False,
+        bridge_id='abc',
+        worker_type='claude_code',
+        environment_id='env-1',
+        api_base_url='https://api.example.com',
+        session_ingress_url='https://ingress.example.com',
+    )
+    assert cfg.spawn_mode == 'single-session'
+    cfg.spawn_mode = 'worktree'  # must not raise
+    assert cfg.spawn_mode == 'worktree'
+    assert cfg.reuse_environment_id is None
+    assert cfg.debug_file is None
+
+
+def test_work_response_typed_dict_usable_as_literal() -> None:
+    """``WorkResponse`` is a TypedDict — plain dict literals satisfy it."""
+    data: WorkData = {'type': 'session', 'id': 'sess-1'}
+    response: WorkResponse = {
+        'id': 'work-1',
+        'type': 'work',
+        'environment_id': 'env-1',
+        'state': 'pending',
+        'data': data,
+        'secret': 'base64stuff',
+        'created_at': '2026-05-23T00:00:00Z',
+    }
+    assert response['type'] == 'work'
+    assert response['data']['type'] == 'session'
+
+
+def test_protocols_accept_duck_typed_impls() -> None:
+    """``BridgeApiClient`` Protocol accepts any object with matching methods.
+
+    Verifies the Protocol is structural (not nominal) — implementations don't
+    have to inherit from it.
+    """
+
+    class _Fake:
+        async def register_bridge_environment(self, config: BridgeConfig) -> dict[str, str]:
+            return {'environment_id': 'e', 'environment_secret': 's'}
+
+        async def poll_for_work(self, *args: Any, **kwargs: Any) -> WorkResponse | None:
+            return None
+
+        async def acknowledge_work(self, *args: Any) -> None:
+            return None
+
+        async def stop_work(self, *args: Any) -> None:
+            return None
+
+        async def deregister_environment(self, *args: Any) -> None:
+            return None
+
+        async def send_permission_response_event(self, *args: Any) -> None:
+            return None
+
+        async def archive_session(self, *args: Any) -> None:
+            return None
+
+        async def reconnect_session(self, *args: Any) -> None:
+            return None
+
+        async def heartbeat_work(self, *args: Any) -> dict[str, Any]:
+            return {'lease_extended': True, 'state': 'running'}
+
+    fake = _Fake()
+    # Type-check at runtime: hasattr lookups for each protocol method.
+    expected = {
+        'register_bridge_environment',
+        'poll_for_work',
+        'acknowledge_work',
+        'stop_work',
+        'deregister_environment',
+        'send_permission_response_event',
+        'archive_session',
+        'reconnect_session',
+        'heartbeat_work',
+    }
+    actual = {name for name in expected if hasattr(fake, name)}
+    assert actual == expected
+
+
+def test_repl_bridge_handle_protocol_shape() -> None:
+    """``ReplBridgeHandle`` Protocol has the consumer-facing methods used by repl_bridge_handle.py."""
+    # Just confirm the Protocol is importable and has the expected attribute names.
+    expected_methods = {
+        'bridge_session_id',
+        'environment_id',
+        'session_ingress_url',
+        'write_messages',
+        'write_sdk_messages',
+        'send_control_request',
+        'send_control_response',
+        'send_cancel_request',
+        'send_result',
+        'teardown',
+    }
+    # ``Protocol`` keeps its declared members in __dict__ for runtime checks.
+    member_names = {name for name in dir(bt.ReplBridgeHandle) if not name.startswith('_')}
+    for m in expected_methods:
+        assert m in member_names, f'ReplBridgeHandle missing {m}'
+
+
+def test_all_export_completeness() -> None:
+    """``__all__`` covers every public symbol the orchestrators will need."""
+    must_export = {
+        'BRIDGE_LOGIN_ERROR',
+        'BRIDGE_LOGIN_INSTRUCTION',
+        'BridgeApiClient',
+        'BridgeConfig',
+        'BridgeLogger',
+        'DEFAULT_SESSION_TIMEOUT_MS',
+        'PermissionResponseEvent',
+        'REMOTE_CONTROL_DISCONNECTED_MSG',
+        'ReplBridgeHandle',
+        'SessionActivity',
+        'SessionHandle',
+        'SessionSpawner',
+        'SpawnMode',
+        'WorkData',
+        'WorkResponse',
+    }
+    for sym in must_export:
+        assert sym in bt.__all__, f'{sym} missing from __all__'


### PR DESCRIPTION
## Summary

First pass at porting the `typescript/src/bridge/` folder to Python — Phase 0 + the trivial-leaf subset of Phase 1 from a per-folder parity plan. Adds modules with **zero cross-folder dependencies** plus an asyncio cancellation-pattern de-risking spike.

**New modules** (`src/bridge/`):
- `capacity_wake.py` — `asyncio.Event` substitute for TS `AbortSignal` merge-and-wake (ports `bridge/capacityWake.ts`)
- `types.py` — consolidated Protocols (`BridgeApiClient`, `SessionHandle`, `SessionSpawner`, `BridgeLogger`, `ReplBridgeHandle`), value types, and constants
- `session_id_compat.py` — `cse_` ↔ `session_` tag translation with shim-gate hook
- `debug_utils.py` — secret redaction, error formatters, `log_bridge_skip`
- `bridge_enabled.py` — entitlement gates (stubbed to defaults; no GrowthBook in this build)
- `bridge_permission_callbacks.py` — wire-format `BridgePermissionResponse` TypedDict + type guard + Protocol
- `inbound_messages.py` — user-message extraction + image-block `mediaType` → `media_type` normalization with inlined magic-byte format sniffer (PNG/JPEG/GIF/WebP)
- `poll_config_defaults.py` — `PollIntervalConfig` + `DEFAULT_POLL_CONFIG` matching TS values exactly

**Extensions:**
- `exceptions.py` — adds `BridgeFatalError(status, error_type)` for the upcoming `bridgeApi.ts` port
- `__init__.py` — re-exports 32 Phase 1 symbols while preserving the legacy archive-metadata fields (`MODULE_COUNT`, etc.) for `test_porting_workspace.py`

**What's still missing** (deferred to follow-up PRs):
- Orchestrators: `bridgeMain.ts`, `replBridge.ts`, `remoteBridgeCore.ts`, `initReplBridge.ts`
- HTTP client: `bridgeApi.ts`
- Session runner: `sessionRunner.ts`
- UI: `bridgeUI.ts`, `bridgeStatusUtil.ts`
- Cross-folder dependencies: `toSDKMessages`, OAuth helpers, `combinedAbortSignal`, etc.

Planning docs (gap analysis, refactoring plan, transport contract audit) live locally in `my-docs/get-parity-by-folder/` — gitignored per repo convention, available on request.

## Test plan

- [x] `uv run pytest tests/bridge/` — 270/270 pass (99 new + 171 existing)
- [x] `uv run pytest tests/test_porting_workspace.py` — 23/23 pass; `from src import bridge; bridge.MODULE_COUNT > 0` still works after `__init__.py` rewrite
- [x] `uv run python -c "from src import bridge; print(len(bridge.__all__))"` — 36 symbols importable cleanly with no Phase 2 modules present
- [ ] CI green
- [ ] Reviewer spot-checks: `capacity_wake.py` semantics vs `bridge/capacityWake.ts`; `inbound_messages.normalize_image_blocks` zero-alloc fast path; `__init__.py` tolerance of missing Phase 2 modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)