### PR TITLE
bridge: complete Phase 1 leaves (config + URL + handle pointer)

### DIFF
--- a/src/bridge/__init__.py
+++ b/src/bridge/__init__.py
@@ -31,9 +31,26 @@ PORTING_NOTE = f"Python placeholder package for '{ARCHIVE_NAME}' with {MODULE_CO
 # -----------------------------------------------------------------------------
 
 from src.bridge.bounded_uuid_set import BoundedUUIDSet
+from src.bridge.bridge_config import (
+    get_bridge_access_token,
+    get_bridge_base_url,
+    get_bridge_base_url_override,
+    get_bridge_token_override,
+)
 from src.bridge.bridge_permission_callbacks import (
     BridgePermissionResponse,
     is_bridge_permission_response,
+)
+from src.bridge.bridge_status_util import (
+    BridgeStatusInfo,
+    build_active_footer_text,
+    build_bridge_connect_url,
+    build_bridge_session_url,
+    build_idle_footer_text,
+    format_duration,
+    get_bridge_status,
+    truncate_to_width,
+    wrap_with_osc8_link,
 )
 from src.bridge.capacity_wake import CapacityWake, create_capacity_wake
 from src.bridge.close_codes import (
@@ -42,6 +59,11 @@ from src.bridge.close_codes import (
     WS_CLOSE_PERMANENT_UNAUTHORIZED,
     WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED,
     WS_CLOSE_SESSION_NOT_FOUND,
+)
+from src.bridge.env_less_bridge_config import (
+    DEFAULT_ENV_LESS_BRIDGE_CONFIG,
+    EnvLessBridgeConfig,
+    get_env_less_bridge_config,
 )
 from src.bridge.exceptions import (
     BridgeAuthError,
@@ -53,9 +75,15 @@ from src.bridge.inbound_messages import (
     extract_inbound_message_fields,
     normalize_image_blocks,
 )
+from src.bridge.poll_config import get_poll_interval_config
 from src.bridge.poll_config_defaults import (
     DEFAULT_POLL_CONFIG,
     PollIntervalConfig,
+)
+from src.bridge.repl_bridge_handle import (
+    get_repl_bridge_handle,
+    get_self_bridge_compat_id,
+    set_repl_bridge_handle,
 )
 from src.bridge.session_id_compat import (
     set_cse_shim_gate,
@@ -92,9 +120,12 @@ __all__ = [
     'BridgeConfig',
     'BridgeFatalError',
     'BridgePermissionResponse',
+    'BridgeStatusInfo',
     'CapacityWake',
+    'DEFAULT_ENV_LESS_BRIDGE_CONFIG',
     'DEFAULT_POLL_CONFIG',
     'DEFAULT_SESSION_TIMEOUT_MS',
+    'EnvLessBridgeConfig',
     'EpochSupersededError',
     'FlushGate',
     'PollIntervalConfig',
@@ -106,15 +137,32 @@ __all__ = [
     'WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED',
     'WS_CLOSE_SESSION_NOT_FOUND',
     'WorkSecret',
+    'build_active_footer_text',
+    'build_bridge_connect_url',
+    'build_bridge_session_url',
     'build_ccr_v2_sdk_url',
+    'build_idle_footer_text',
     'build_sdk_url',
     'create_capacity_wake',
     'decode_work_secret',
     'extract_inbound_message_fields',
+    'format_duration',
+    'get_bridge_access_token',
+    'get_bridge_base_url',
+    'get_bridge_base_url_override',
+    'get_bridge_status',
+    'get_bridge_token_override',
+    'get_env_less_bridge_config',
+    'get_poll_interval_config',
+    'get_repl_bridge_handle',
+    'get_self_bridge_compat_id',
     'is_bridge_permission_response',
     'normalize_image_blocks',
     'same_session_id',
     'set_cse_shim_gate',
+    'set_repl_bridge_handle',
     'to_compat_session_id',
     'to_infra_session_id',
+    'truncate_to_width',
+    'wrap_with_osc8_link',
 ]

--- a/src/bridge/bridge_config.py
+++ b/src/bridge/bridge_config.py
@@ -1,0 +1,80 @@
+"""Shared bridge auth/URL resolution.
+
+Ports ``typescript/src/bridge/bridgeConfig.ts``.
+
+Consolidates the ``CLAUDE_BRIDGE_*`` internal-only dev overrides that were
+previously copy-pasted across the bridge subsystem. Two layers:
+
+* ``*_override()`` returns the env var if set, else ``None``.
+* The non-``_override`` wrapper falls through to the real OAuth store /
+  config.
+
+Per refactoring plan §0.1 Q6 + §2 item 9: the OAuth fallthrough (TS
+``getClaudeAIOAuthTokens()?.accessToken``) is **not yet ported in the
+Python build**. ``get_bridge_access_token`` returns ``None`` on
+fallthrough (callers treat as "not logged in"). ``get_bridge_base_url``
+returns ``_DEFAULT_PRODUCTION_BASE_URL`` (matches TS production
+``getOauthConfig().BASE_API_URL`` after the GA OAuth config was finalized
+— Anthropic's production API host). When Phase 2 lands the real OAuth
+helpers, the fallthroughs will switch to the keychain reader; callers
+see no API change.
+"""
+
+from __future__ import annotations
+
+import os
+
+_DEFAULT_PRODUCTION_BASE_URL = 'https://api.anthropic.com'
+"""Fallback when no override AND no Phase 2 OAuth config is available.
+
+Mirrors TS ``getOauthConfig().BASE_API_URL`` for the production build. The
+TS function reads from an OAuth config object populated at startup; the
+Python port lands the constant inline until that config layer is ported.
+"""
+
+
+def get_bridge_token_override() -> str | None:
+    """Dev override: ``CLAUDE_BRIDGE_OAUTH_TOKEN``, else ``None``.
+
+    Mirrors TS ``getBridgeTokenOverride`` on ``bridgeConfig.ts:18-20``.
+    Empty string is treated as unset (matches the TS ``|| undefined``).
+    """
+    value = os.environ.get('CLAUDE_BRIDGE_OAUTH_TOKEN')
+    return value or None
+
+
+def get_bridge_base_url_override() -> str | None:
+    """Dev override: ``CLAUDE_BRIDGE_BASE_URL``, else ``None``.
+
+    Mirrors TS ``getBridgeBaseUrlOverride`` on ``bridgeConfig.ts:23-25``.
+    """
+    value = os.environ.get('CLAUDE_BRIDGE_BASE_URL')
+    return value or None
+
+
+def get_bridge_access_token() -> str | None:
+    """Access token for bridge API calls.
+
+    Mirrors TS ``getBridgeAccessToken`` on ``bridgeConfig.ts:31-33``.
+    Returns the dev override if set, else ``None`` (Phase 2 will swap
+    this fallthrough for the OAuth keychain read).
+    """
+    return get_bridge_token_override()
+
+
+def get_bridge_base_url() -> str:
+    """Base URL for bridge API calls.
+
+    Mirrors TS ``getBridgeBaseUrl`` on ``bridgeConfig.ts:39-41``. Always
+    returns a non-``None`` URL. Returns the dev override if set, else the
+    production base URL constant.
+    """
+    return get_bridge_base_url_override() or _DEFAULT_PRODUCTION_BASE_URL
+
+
+__all__ = [
+    'get_bridge_access_token',
+    'get_bridge_base_url',
+    'get_bridge_base_url_override',
+    'get_bridge_token_override',
+]

--- a/src/bridge/bridge_status_util.py
+++ b/src/bridge/bridge_status_util.py
@@ -1,0 +1,448 @@
+"""Status-line formatting + URL helpers for the bridge UI.
+
+Ports ``typescript/src/bridge/bridgeStatusUtil.ts``.
+
+The TS file pulls from four upstream modules:
+
+* ``utils/format.formatDuration`` + ``truncateToWidth``
+* ``constants/product.getClaudeAiBaseUrl`` + ``getRemoteSessionUrl``
+* ``ink/stringWidth.stringWidth``
+* ``utils/intl.getGraphemeSegmenter``
+
+This module:
+
+* **Imports** ``format_duration`` from ``src.utils.format`` (already
+  ported, more sophisticated than what TS bridge needs — see "Behavior
+  note" below).
+* **Inlines** ``truncate_to_width``, ``string_width``, the grapheme
+  segmenter, and the claude.ai URL helpers per refactoring plan §2 item
+  13. ``wcwidth`` substitutes for ``stringWidth`` (handles CJK + emoji
+  width correctly), and the ``regex`` package's ``\\X`` grapheme pattern
+  substitutes for ``Intl.Segmenter``. The URL builders are inlined as
+  production-only constants/functions until ``constants/product.py`` is
+  ported.
+
+**Behavior note on ``format_duration``**: TS ``utils/format.ts:formatDuration``
+has no hours/days branch — anything ≥1h renders as ``"60m"``, ``"120m"``,
+etc. The Python ``src.utils.format.format_duration`` extends this with
+days/hours and ``hide_trailing_zeros`` / ``most_significant_only``
+flags. We re-export it unmodified; bridge UI sites that need TS-exact
+output should be aware of the divergence (mostly cosmetic — affects only
+the very long-duration case which the bridge rarely hits). Trailing-zero
+seconds are not hidden by default (e.g. ``"1m 0s"`` not ``"1m"``); pass
+``hide_trailing_zeros=True`` to match TS bridge exactly.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Literal
+
+import regex
+import wcwidth
+
+# Re-export the canonical format_duration so callers can write
+# ``from src.bridge.bridge_status_util import format_duration``. See
+# module docstring "Behavior note" for the divergence vs TS bridge.
+from src.utils.format import format_duration  # noqa: F401  re-export
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+StatusState = Literal['idle', 'attached', 'titled', 'reconnecting', 'failed']
+"""Mirrors TS ``StatusState`` on ``bridgeStatusUtil.ts:10-15``."""
+
+TOOL_DISPLAY_EXPIRY_MS: int = 30_000
+"""How long a tool activity line stays visible after last tool_start (ms).
+
+Mirrors TS ``TOOL_DISPLAY_EXPIRY_MS`` on ``bridgeStatusUtil.ts:18``.
+"""
+
+SHIMMER_INTERVAL_MS: int = 150
+"""Interval for the shimmer animation tick (ms).
+
+Mirrors TS ``SHIMMER_INTERVAL_MS`` on ``bridgeStatusUtil.ts:21``.
+"""
+
+FAILED_FOOTER_TEXT: str = 'Something went wrong, please try again'
+"""Footer text shown when the bridge has failed.
+
+Mirrors TS ``FAILED_FOOTER_TEXT`` on ``bridgeStatusUtil.ts:154``.
+"""
+
+
+_CLAUDE_AI_PRODUCTION_BASE: str = 'https://claude.ai'
+"""Production claude.ai base URL.
+
+Inlined substitute for TS ``getClaudeAiBaseUrl()`` happy-path return.
+Staging / FedStart variants land when ``constants/product.py`` is ported.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Inlined utility helpers (substitute for cross-folder TS imports)
+# ---------------------------------------------------------------------------
+
+
+def string_width(s: str) -> int:
+    """Visual width of a string in terminal columns.
+
+    Inlined substitute for TS ``ink/stringWidth``. Uses ``wcwidth`` which
+    correctly handles CJK (2 cols), emoji (typically 2 cols), and ANSI
+    escape sequences (0 cols).
+    """
+    if not s:
+        return 0
+    # ``wcwidth.wcswidth`` returns -1 if the string contains a control
+    # character that has no defined width. Treat those as 0 to match the
+    # TS string-width behavior (which strips control chars before measuring).
+    w = wcwidth.wcswidth(_strip_ansi(s))
+    return max(w, 0)
+
+
+def truncate_to_width(s: str, max_width: int) -> str:
+    """Truncate a string to ``max_width`` visual columns with ellipsis.
+
+    Inlined substitute for TS ``utils/format.truncateToWidth``. Appends
+    ``'…'`` (1 col) when truncation occurs; if ``max_width`` is too small
+    to fit even the ellipsis, returns the empty string. Grapheme-aware so
+    multi-byte chars don't get split in the middle.
+
+    **ANSI-aware**: SGR escape sequences (``\\x1b[...m``) and OSC 8
+    hyperlink markers contribute zero visual width and are kept whole —
+    they will never be split mid-escape, even when truncation lands on
+    a colored substring. After truncation, all open SGR groups are
+    implicitly closed by the upstream renderer's ``\\x1b[0m`` reset (the
+    bridge UI always appends one); callers that don't do this should
+    append ``'\\x1b[0m'`` to the result to avoid color bleed.
+    """
+    if max_width <= 0:
+        return ''
+    if string_width(s) <= max_width:
+        return s
+    if max_width == 1:
+        return '…'
+    # Walk the string as a sequence of (token, visible_width) pairs where
+    # token is either an ANSI escape (width 0, kept whole) or a Unicode
+    # grapheme (width per wcwidth). Accumulate visible tokens until
+    # adding the next would exceed budget = max_width - 1, then switch
+    # to "truncated" mode where we keep emitting zero-width tokens only
+    # so trailing ``\x1b[0m`` resets (and any other escapes in the tail)
+    # survive — preventing color bleed into terminal output that follows.
+    budget = max_width - 1
+    out: list[str] = []
+    acc = 0
+    truncated = False
+    for token, width in _iter_tokens(s):
+        if width == 0:
+            out.append(token)
+            continue
+        if truncated:
+            continue  # post-break visible content is dropped
+        if acc + width > budget:
+            truncated = True
+            continue
+        out.append(token)
+        acc += width
+    return ''.join(out) + '…'
+
+
+# Backwards-compat alias matching TS export name ``truncatePrompt``.
+truncate_prompt = truncate_to_width
+
+
+_ANSI_RE = regex.compile(r'\x1b\[[0-9;]*m|\x1b\]8;;[^\x07]*\x07')
+
+
+def _strip_ansi(s: str) -> str:
+    """Strip ANSI SGR + OSC 8 hyperlink sequences for width calculation."""
+    return _ANSI_RE.sub('', s)
+
+
+def _grapheme_split(s: str) -> list[str]:
+    """Split a string into Unicode graphemes.
+
+    Substitute for TS ``Intl.Segmenter``. Uses the ``regex`` package's
+    ``\\X`` (extended grapheme cluster) pattern, which is the canonical
+    Unicode definition.
+    """
+    return regex.findall(r'\X', s)
+
+
+def _iter_tokens(s: str):
+    """Iterate ``(token, visible_width)`` pairs preserving ANSI escapes.
+
+    Yields ANSI SGR / OSC 8 sequences as zero-width whole tokens so
+    ``truncate_to_width`` never splits them mid-escape. Non-escape spans
+    are grapheme-split via ``\\X`` and yielded one cluster at a time with
+    their ``wcwidth`` value.
+    """
+    pos = 0
+    for match in _ANSI_RE.finditer(s):
+        if match.start() > pos:
+            for grapheme in regex.findall(r'\X', s[pos:match.start()]):
+                yield grapheme, max(wcwidth.wcswidth(grapheme), 0)
+        yield match.group(0), 0
+        pos = match.end()
+    if pos < len(s):
+        for grapheme in regex.findall(r'\X', s[pos:]):
+            yield grapheme, max(wcwidth.wcswidth(grapheme), 0)
+
+
+def get_claude_ai_base_url(ingress_url: str | None = None) -> str:
+    """Base URL for claude.ai links shown in the terminal UI.
+
+    Inlined substitute for TS ``constants/product.getClaudeAiBaseUrl``.
+    The TS version derives staging/FedStart variants from ``ingress_url``;
+    this Python port returns the production URL unconditionally until
+    ``constants/product.py`` is ported.
+    """
+    return _CLAUDE_AI_PRODUCTION_BASE
+
+
+def get_remote_session_url(
+    session_id: str,
+    ingress_url: str | None = None,
+) -> str:
+    """Build the claude.ai/code URL for an attached session.
+
+    Inlined substitute for TS ``constants/product.getRemoteSessionUrl``.
+    Performs the same ``cse_`` → ``session_`` retag the TS version does
+    (so the URL is browser-routable through the v1 compat layer).
+    """
+    if session_id.startswith('cse_'):
+        compat_id = 'session_' + session_id[len('cse_'):]
+    else:
+        compat_id = session_id
+    return f'{get_claude_ai_base_url(ingress_url)}/code/{compat_id}'
+
+
+# ---------------------------------------------------------------------------
+# Public timestamp / formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def timestamp() -> str:
+    """Format current local time as ``HH:MM:SS``.
+
+    Mirrors TS ``timestamp`` on ``bridgeStatusUtil.ts:23-29``.
+    """
+    now = time.localtime()
+    return f'{now.tm_hour:02d}:{now.tm_min:02d}:{now.tm_sec:02d}'
+
+
+def abbreviate_activity(summary: str) -> str:
+    """Abbreviate a tool activity summary for the trail display.
+
+    Mirrors TS ``abbreviateActivity`` on ``bridgeStatusUtil.ts:34-36``.
+    """
+    return truncate_to_width(summary, 30)
+
+
+# ---------------------------------------------------------------------------
+# URL builders for the bridge
+# ---------------------------------------------------------------------------
+
+
+def build_bridge_connect_url(
+    environment_id: str,
+    ingress_url: str | None = None,
+) -> str:
+    """URL shown when the bridge is idle (waiting for a session).
+
+    Mirrors TS ``buildBridgeConnectUrl`` on ``bridgeStatusUtil.ts:39-45``.
+    """
+    base = get_claude_ai_base_url(ingress_url)
+    return f'{base}/code?bridge={environment_id}'
+
+
+def build_bridge_session_url(
+    session_id: str,
+    environment_id: str,
+    ingress_url: str | None = None,
+) -> str:
+    """URL shown when a session is attached.
+
+    Mirrors TS ``buildBridgeSessionUrl`` on ``bridgeStatusUtil.ts:52-58``.
+    Delegates to ``get_remote_session_url`` for the cse_→session_ retag,
+    then appends the v1-specific ``?bridge={environment_id}`` query.
+    """
+    base = get_remote_session_url(session_id, ingress_url)
+    return f'{base}?bridge={environment_id}'
+
+
+# ---------------------------------------------------------------------------
+# Shimmer animation math
+# ---------------------------------------------------------------------------
+
+
+def compute_glimmer_index(tick: int, message_width: int) -> int:
+    """Compute the column index for a reverse-sweep shimmer animation.
+
+    Mirrors TS ``computeGlimmerIndex`` on ``bridgeStatusUtil.ts:61-67``.
+    Walks right-to-left, off-screen-padded by 10 cols on each side so the
+    shimmer doesn't visually stick at the edges.
+    """
+    cycle_length = message_width + 20
+    return message_width + 10 - (tick % cycle_length)
+
+
+@dataclass(frozen=True)
+class ShimmerSegments:
+    """Three-segment split of a string by visual column position.
+
+    Mirrors TS ``{before, shimmer, after}`` return on
+    ``bridgeStatusUtil.ts:82``.
+    """
+
+    before: str
+    shimmer: str
+    after: str
+
+
+def compute_shimmer_segments(text: str, glimmer_index: int) -> ShimmerSegments:
+    """Split text into three segments by visual column position.
+
+    Mirrors TS ``computeShimmerSegments`` on ``bridgeStatusUtil.ts:79-111``.
+    Multi-byte chars + emoji + CJK are kept whole; the split is by
+    cumulative column position, not codepoint count.
+
+    Returns ``before``, ``shimmer`` (≤ 3 cols centered on
+    ``glimmer_index``), and ``after``. When the shimmer is offscreen,
+    everything goes into ``before``.
+    """
+    message_width = string_width(text)
+    shimmer_start = glimmer_index - 1
+    shimmer_end = glimmer_index + 1
+
+    if shimmer_start >= message_width or shimmer_end < 0:
+        return ShimmerSegments(before=text, shimmer='', after='')
+
+    clamped_start = max(0, shimmer_start)
+    col_pos = 0
+    before = []
+    shimmer = []
+    after = []
+    for grapheme in _grapheme_split(text):
+        seg_width = string_width(grapheme)
+        if col_pos + seg_width <= clamped_start:
+            before.append(grapheme)
+        elif col_pos > shimmer_end:
+            after.append(grapheme)
+        else:
+            shimmer.append(grapheme)
+        col_pos += seg_width
+
+    return ShimmerSegments(
+        before=''.join(before),
+        shimmer=''.join(shimmer),
+        after=''.join(after),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Status state machine
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BridgeStatusInfo:
+    """Computed bridge status label and color from connection state.
+
+    Mirrors TS ``BridgeStatusInfo`` on ``bridgeStatusUtil.ts:115-121``.
+    """
+
+    label: str
+    color: Literal['error', 'warning', 'success']
+
+
+def get_bridge_status(
+    *,
+    error: str | None,
+    connected: bool,
+    session_active: bool,
+    reconnecting: bool,
+) -> BridgeStatusInfo:
+    """Derive a status label + color from the bridge connection state.
+
+    Mirrors TS ``getBridgeStatus`` on ``bridgeStatusUtil.ts:124-141``.
+    Keyword-only args to make call sites self-documenting (TS uses an
+    object literal; Python uses kw-only).
+    """
+    if error:
+        return BridgeStatusInfo(label='Remote Control failed', color='error')
+    if reconnecting:
+        return BridgeStatusInfo(
+            label='Remote Control reconnecting', color='warning'
+        )
+    if session_active or connected:
+        return BridgeStatusInfo(
+            label='Remote Control active', color='success'
+        )
+    return BridgeStatusInfo(
+        label='Remote Control connecting…', color='warning'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Footer text builders
+# ---------------------------------------------------------------------------
+
+
+def build_idle_footer_text(url: str) -> str:
+    """Footer text shown when bridge is idle (Ready state).
+
+    Mirrors TS ``buildIdleFooterText`` on ``bridgeStatusUtil.ts:144-146``.
+    """
+    return f'Code everywhere with the Claude app or {url}'
+
+
+def build_active_footer_text(url: str) -> str:
+    """Footer text shown when a session is active (Connected state).
+
+    Mirrors TS ``buildActiveFooterText`` on ``bridgeStatusUtil.ts:149-151``.
+    """
+    return f'Continue coding in the Claude app or {url}'
+
+
+# ---------------------------------------------------------------------------
+# Terminal hyperlink wrapping
+# ---------------------------------------------------------------------------
+
+
+def wrap_with_osc8_link(text: str, url: str) -> str:
+    """Wrap text in an OSC 8 terminal hyperlink. Zero visual width.
+
+    Mirrors TS ``wrapWithOsc8Link`` on ``bridgeStatusUtil.ts:161-163``.
+    Strippable by ``_strip_ansi`` so ``string_width`` returns the visible
+    text width only.
+    """
+    return f'\x1b]8;;{url}\x07{text}\x1b]8;;\x07'
+
+
+__all__ = [
+    'BridgeStatusInfo',
+    'FAILED_FOOTER_TEXT',
+    'SHIMMER_INTERVAL_MS',
+    'ShimmerSegments',
+    'StatusState',
+    'TOOL_DISPLAY_EXPIRY_MS',
+    'abbreviate_activity',
+    'build_active_footer_text',
+    'build_bridge_connect_url',
+    'build_bridge_session_url',
+    'build_idle_footer_text',
+    'compute_glimmer_index',
+    'compute_shimmer_segments',
+    'format_duration',
+    'get_bridge_status',
+    'get_claude_ai_base_url',
+    'get_remote_session_url',
+    'string_width',
+    'timestamp',
+    'truncate_prompt',
+    'truncate_to_width',
+    'wrap_with_osc8_link',
+]

--- a/src/bridge/env_less_bridge_config.py
+++ b/src/bridge/env_less_bridge_config.py
@@ -1,0 +1,142 @@
+"""Env-less (v2) bridge timing config.
+
+Ports ``typescript/src/bridge/envLessBridgeConfig.ts``.
+
+Defines the per-session timing knobs used by the v2 (env-less) bridge
+path: init retry backoff, HTTP timeouts, JWT refresh buffer, heartbeat
+cadence, archive teardown deadline, connect timeout, version floor, and
+the app-upgrade nudge bit. Numeric values match TS exactly so the port is
+behavior-preserving — see ``test_env_less_bridge_config.py`` for the
+contract.
+
+Per refactoring plan §0.1 Q2, GrowthBook is not wired in the Python build;
+``get_env_less_bridge_config()`` returns the validated defaults rather than
+fetching ``tengu_bridge_repl_v2_config`` from the GrowthBook client. When
+GB lands in Phase 10, the function swaps to fetch + validate; callers see
+no API change.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from src.bridge.bridge_enabled import is_env_less_bridge_enabled
+
+
+class EnvLessBridgeConfig(BaseModel):
+    """Validated env-less bridge timing config.
+
+    Mirrors TS ``EnvLessBridgeConfig`` on ``envLessBridgeConfig.ts:7-42``.
+    Field names + numeric values + bounds match TS Zod schema exactly.
+
+    Bounds are enforced by ``Field(..., ge=..., le=...)``; out-of-range
+    inputs trigger a ``ValidationError`` and the caller falls back to
+    ``DEFAULT_ENV_LESS_BRIDGE_CONFIG`` (matching the TS pattern of
+    rejecting the whole object on any field violation).
+
+    ``strict=True`` matches TS Zod's no-coercion semantics: ``z.number()``
+    rejects strings, ``z.boolean()`` rejects strings — pydantic v2 with
+    ``strict=True`` does the same. Without this, a GrowthBook payload
+    with JSON-string integers ("5" instead of 5) would silently coerce
+    and validate, hiding upstream schema drift.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    init_retry_max_attempts: int = Field(default=3, ge=1, le=10)
+    init_retry_base_delay_ms: int = Field(default=500, ge=100)
+    init_retry_jitter_fraction: float = Field(default=0.25, ge=0.0, le=1.0)
+    init_retry_max_delay_ms: int = Field(default=4000, ge=500)
+    http_timeout_ms: int = Field(default=10_000, ge=2000)
+    uuid_dedup_buffer_size: int = Field(default=2000, ge=100, le=50_000)
+    # Server TTL is 60s. Floor 5s prevents thrash; cap 30s keeps ≥2× margin.
+    heartbeat_interval_ms: int = Field(default=20_000, ge=5_000, le=30_000)
+    # ±fraction per beat. Cap 0.5: at 30s × 1.5 = 45s worst case, still
+    # under the 60s server TTL.
+    heartbeat_jitter_fraction: float = Field(default=0.1, ge=0.0, le=0.5)
+    # Floor 30s prevents tight-looping. Cap 30min rejects buffer-vs-delay
+    # semantic inversion (see TS comment lines 80-86).
+    token_refresh_buffer_ms: int = Field(
+        default=300_000, ge=30_000, le=1_800_000
+    )
+    # Cap 2000 keeps this under gracefulShutdown's 2s cleanup race.
+    teardown_archive_timeout_ms: int = Field(default=1500, ge=500, le=2000)
+    # Observed p99 connect ~2-3s; 15s = ~5× headroom. Floor 5s, cap 60s.
+    connect_timeout_ms: int = Field(default=15_000, ge=5_000, le=60_000)
+    min_version: str = Field(default='0.0.0')
+    should_show_app_upgrade_message: bool = False
+
+
+DEFAULT_ENV_LESS_BRIDGE_CONFIG: EnvLessBridgeConfig = EnvLessBridgeConfig()
+"""Defaults matching TS ``DEFAULT_ENV_LESS_BRIDGE_CONFIG`` on
+``envLessBridgeConfig.ts:44-58`` exactly. See ``test_env_less_bridge_config.py``
+for the per-field assertion contract.
+"""
+
+
+async def get_env_less_bridge_config() -> EnvLessBridgeConfig:
+    """Fetch + validate the env-less bridge timing config.
+
+    Mirrors TS ``getEnvLessBridgeConfig`` on ``envLessBridgeConfig.ts:130-137``.
+    The TS version fetches ``tengu_bridge_repl_v2_config`` from GrowthBook
+    and parses it through the Zod schema; on any validation error, falls
+    back to the defaults. The Python port returns defaults directly — see
+    module docstring for the rationale.
+    """
+    return DEFAULT_ENV_LESS_BRIDGE_CONFIG
+
+
+def validate_env_less_bridge_config_raw(
+    raw: object,
+) -> EnvLessBridgeConfig:
+    """Validate a raw dict against the schema; fall back to defaults on error.
+
+    Public helper for downstream callers (Phase 10 GrowthBook integration
+    or test code) that have a raw payload and want the same "reject the
+    whole object on any field violation" semantics TS Zod provides.
+    """
+    if not isinstance(raw, dict):
+        return DEFAULT_ENV_LESS_BRIDGE_CONFIG
+    try:
+        return EnvLessBridgeConfig.model_validate(raw)
+    except ValidationError:
+        return DEFAULT_ENV_LESS_BRIDGE_CONFIG
+
+
+async def check_env_less_bridge_min_version() -> str | None:
+    """Returns an error message if CLI version is below v2 min, else None.
+
+    Mirrors TS ``checkEnvLessBridgeMinVersion`` on
+    ``envLessBridgeConfig.ts:147-153``. The Python build has no semver
+    comparator wired and no GrowthBook-served min_version (default
+    ``'0.0.0'`` passes everything), so this always returns ``None``.
+    """
+    cfg = await get_env_less_bridge_config()
+    if cfg.min_version == '0.0.0':
+        return None
+    # When a real min_version arrives via Phase 10 GB integration, swap
+    # this branch for a real semver comparison.
+    return None
+
+
+async def should_show_app_upgrade_message() -> bool:
+    """Whether to nudge users toward upgrading their claude.ai app.
+
+    Mirrors TS ``shouldShowAppUpgradeMessage`` on
+    ``envLessBridgeConfig.ts:161-165``. True only when (a) the v2 bridge
+    is active AND (b) the config bit is set.
+    """
+    if not is_env_less_bridge_enabled():
+        return False
+    cfg = await get_env_less_bridge_config()
+    return cfg.should_show_app_upgrade_message
+
+
+__all__ = [
+    'DEFAULT_ENV_LESS_BRIDGE_CONFIG',
+    'EnvLessBridgeConfig',
+    'check_env_less_bridge_min_version',
+    'get_env_less_bridge_config',
+    'should_show_app_upgrade_message',
+    'validate_env_less_bridge_config_raw',
+]

--- a/src/bridge/poll_config.py
+++ b/src/bridge/poll_config.py
@@ -1,0 +1,186 @@
+"""Bridge poll-loop interval validator + accessor.
+
+Ports ``typescript/src/bridge/pollConfig.ts``.
+
+Pydantic v2 schema for the bridge poll-interval config served via the
+``tengu_bridge_poll_interval_config`` GrowthBook feature. The schema has
+two cross-field validators that enforce **at-capacity liveness**:
+
+* (single-session) heartbeat > 0 OR ``poll_interval_ms_at_capacity`` > 0
+* (multisession)   heartbeat > 0 OR ``multisession_poll_interval_ms_at_capacity`` > 0
+
+Without those refinements, a fat-fingered config that disables both
+heartbeat AND at-capacity poll would tight-loop the bridge's throttle
+sites at HTTP-round-trip speed (no sleep between checks). Same defense
+the TS Zod schema provides via ``.refine()`` on
+``pollConfig.ts:74-91``.
+
+Per refactoring plan §0.1 Q2, GrowthBook is not wired in the Python
+build; ``get_poll_interval_config()`` returns ``DEFAULT_POLL_CONFIG``
+directly. The validator exists for Phase 10 / test code that wants to
+exercise the schema on raw inputs.
+"""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    model_validator,
+)
+
+from src.bridge.poll_config_defaults import (
+    DEFAULT_POLL_CONFIG,
+    PollIntervalConfig,
+)
+
+
+class _PollIntervalSchema(BaseModel):
+    """Pydantic validator that mirrors TS Zod ``pollIntervalConfigSchema``.
+
+    Field-level bounds + cross-field refines + per-field defaults match
+    TS exactly. After validation, ``.to_dataclass()`` converts to the
+    frozen ``PollIntervalConfig`` dataclass that the rest of the codebase
+    consumes (the dataclass is hashable + frozen — properties the poll
+    loop relies on).
+
+    ``poll_interval_ms_at_capacity`` and the multisession at-capacity
+    variant accept 0 (= disabled) OR >= 100; values 1-99 are rejected to
+    catch unit-confusion (ops thinks "seconds", enters 10).
+
+    ``strict=True`` matches TS Zod's no-coercion semantics. See
+    ``env_less_bridge_config.EnvLessBridgeConfig`` for the same rationale.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    poll_interval_ms_not_at_capacity: int = Field(
+        default=DEFAULT_POLL_CONFIG.poll_interval_ms_not_at_capacity,
+        ge=100,
+    )
+    poll_interval_ms_at_capacity: int = Field(
+        default=DEFAULT_POLL_CONFIG.poll_interval_ms_at_capacity,
+    )
+    non_exclusive_heartbeat_interval_ms: int = Field(
+        default=DEFAULT_POLL_CONFIG.non_exclusive_heartbeat_interval_ms,
+        ge=0,
+    )
+    multisession_poll_interval_ms_not_at_capacity: int = Field(
+        default=DEFAULT_POLL_CONFIG.multisession_poll_interval_ms_not_at_capacity,
+        ge=100,
+    )
+    multisession_poll_interval_ms_partial_capacity: int = Field(
+        default=DEFAULT_POLL_CONFIG.multisession_poll_interval_ms_partial_capacity,
+        ge=100,
+    )
+    multisession_poll_interval_ms_at_capacity: int = Field(
+        default=DEFAULT_POLL_CONFIG.multisession_poll_interval_ms_at_capacity,
+    )
+    reclaim_older_than_ms: int = Field(
+        default=DEFAULT_POLL_CONFIG.reclaim_older_than_ms,
+        ge=1,
+    )
+    session_keepalive_interval_v2_ms: int = Field(
+        default=DEFAULT_POLL_CONFIG.session_keepalive_interval_v2_ms,
+        ge=0,
+    )
+
+    @model_validator(mode='after')
+    def _validate_at_capacity_liveness(self) -> Self:
+        """Enforce the two TS ``.refine()`` cross-field invariants.
+
+        Mirrors TS ``pollConfig.ts:74-91``. Both single-session AND
+        multisession at-capacity loops must have *some* liveness signal:
+        either a positive heartbeat interval or a positive at-capacity
+        poll interval. All-zero is rejected; the caller falls back to
+        ``DEFAULT_POLL_CONFIG`` via ``get_poll_interval_config``.
+        """
+        if (
+            self.non_exclusive_heartbeat_interval_ms == 0
+            and self.poll_interval_ms_at_capacity == 0
+        ):
+            raise ValueError(
+                'at-capacity liveness requires '
+                'non_exclusive_heartbeat_interval_ms > 0 or '
+                'poll_interval_ms_at_capacity > 0'
+            )
+        if (
+            self.non_exclusive_heartbeat_interval_ms == 0
+            and self.multisession_poll_interval_ms_at_capacity == 0
+        ):
+            raise ValueError(
+                'at-capacity liveness requires '
+                'non_exclusive_heartbeat_interval_ms > 0 or '
+                'multisession_poll_interval_ms_at_capacity > 0'
+            )
+        return self
+
+    @model_validator(mode='after')
+    def _validate_at_capacity_zero_or_min(self) -> Self:
+        """``poll_interval_ms_at_capacity`` must be 0 (disabled) OR >= 100.
+
+        Mirrors TS refine on ``pollConfig.ts:34-38`` and ``63-65``. Values
+        1-99 are rejected as "unit confusion".
+        """
+        v = self.poll_interval_ms_at_capacity
+        if v != 0 and v < 100:
+            raise ValueError(
+                'poll_interval_ms_at_capacity must be 0 (disabled) or ≥100ms'
+            )
+        v = self.multisession_poll_interval_ms_at_capacity
+        if v != 0 and v < 100:
+            raise ValueError(
+                'multisession_poll_interval_ms_at_capacity must be 0 '
+                '(disabled) or ≥100ms'
+            )
+        return self
+
+    def to_dataclass(self) -> PollIntervalConfig:
+        """Convert the validated schema model into the frozen dataclass."""
+        return PollIntervalConfig(
+            poll_interval_ms_not_at_capacity=self.poll_interval_ms_not_at_capacity,
+            poll_interval_ms_at_capacity=self.poll_interval_ms_at_capacity,
+            non_exclusive_heartbeat_interval_ms=self.non_exclusive_heartbeat_interval_ms,
+            multisession_poll_interval_ms_not_at_capacity=self.multisession_poll_interval_ms_not_at_capacity,
+            multisession_poll_interval_ms_partial_capacity=self.multisession_poll_interval_ms_partial_capacity,
+            multisession_poll_interval_ms_at_capacity=self.multisession_poll_interval_ms_at_capacity,
+            reclaim_older_than_ms=self.reclaim_older_than_ms,
+            session_keepalive_interval_v2_ms=self.session_keepalive_interval_v2_ms,
+        )
+
+
+def get_poll_interval_config() -> PollIntervalConfig:
+    """Return the validated poll-interval config.
+
+    Mirrors TS ``getPollIntervalConfig`` on ``pollConfig.ts:102-110``.
+    The TS version fetches ``tengu_bridge_poll_interval_config`` from
+    GrowthBook and validates it; on failure, falls back to defaults.
+    Python returns the defaults directly — no GrowthBook in this build.
+    """
+    return DEFAULT_POLL_CONFIG
+
+
+def validate_poll_interval_config_raw(raw: object) -> PollIntervalConfig:
+    """Validate a raw dict against the schema; fall back to defaults on error.
+
+    Public helper for downstream callers (Phase 10 GrowthBook integration
+    or tests) that have a raw payload and want TS Zod's "reject the whole
+    object on any field violation" semantics.
+    """
+    if not isinstance(raw, dict):
+        return DEFAULT_POLL_CONFIG
+    try:
+        model = _PollIntervalSchema.model_validate(raw)
+    except ValidationError:
+        return DEFAULT_POLL_CONFIG
+    return model.to_dataclass()
+
+
+__all__ = [
+    'get_poll_interval_config',
+    'validate_poll_interval_config_raw',
+]

--- a/src/bridge/repl_bridge_handle.py
+++ b/src/bridge/repl_bridge_handle.py
@@ -1,0 +1,100 @@
+"""Process-global pointer to the active REPL bridge handle.
+
+Ports ``typescript/src/bridge/replBridgeHandle.ts``.
+
+Callers outside the React tree that owns the bridge (tools, slash
+commands) need a way to invoke handle methods (subscribe, send control
+events, etc.). Same one-bridge-per-process justification as
+``bridge_debug.ts`` — the handle's closure captures the session ID and
+``get_access_token`` that created the session.
+
+Set from the orchestrator (Phase 5/6) when init completes; cleared on
+teardown. Reading is best-effort: ``None`` means no bridge is connected.
+
+⚠️ **Phase 1 caveat — multi-peer dedup is BROKEN until Phase 2** ⚠️
+
+The TS version calls ``utils/concurrentSessions.updateSessionBridgeId()``
+on every set, which publishes the local bridge ID so other peers can
+dedup. That cross-folder dep lives in Phase 2 (per refactoring plan §5
+second-wave list). The Python port replaces it with a debug-logged
+TODO-noop until Phase 2 lands the publisher. Operationally this means
+**two concurrent Python bridges in the same workspace will not dedup
+against each other** — both will appear in claude.ai/code session lists.
+The public API of this module is unaffected; only the cross-process
+side effect is missing.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from src.bridge.session_id_compat import to_compat_session_id
+from src.bridge.types import ReplBridgeHandle
+
+logger = logging.getLogger(__name__)
+
+_handle: ReplBridgeHandle | None = None
+
+
+def set_repl_bridge_handle(h: ReplBridgeHandle | None) -> None:
+    """Register (or clear) the active REPL bridge handle.
+
+    Mirrors TS ``setReplBridgeHandle`` on ``replBridgeHandle.ts:18-23``.
+
+    The TS version also calls
+    ``updateSessionBridgeId(getSelfBridgeCompatId() ?? null)`` to publish
+    the local bridge ID for cross-peer dedup. That helper doesn't exist
+    in Python yet (Phase 2). Until then, calling ``set_repl_bridge_handle``
+    just updates the in-process pointer; cross-process dedup is a no-op.
+    """
+    global _handle
+    _handle = h
+    # TODO(phase2): once src/utils/concurrent_sessions.py exists, call
+    #   update_session_bridge_id(get_self_bridge_compat_id())
+    # to publish the local bridge ID so other peers can dedup us out.
+    # Until then, cross-peer dedup is silently broken — a debug log keeps
+    # the gap visible during development.
+    logger.debug(
+        '[bridge:handle] %s (multi-peer dedup not yet wired — Phase 2)',
+        'set' if h is not None else 'cleared',
+    )
+
+
+def get_repl_bridge_handle() -> ReplBridgeHandle | None:
+    """Get the active REPL bridge handle, or ``None`` if not connected.
+
+    Mirrors TS ``getReplBridgeHandle`` on ``replBridgeHandle.ts:25-27``.
+    """
+    return _handle
+
+
+def get_self_bridge_compat_id() -> str | None:
+    """Our own bridge session ID in the ``session_*`` compat format.
+
+    Mirrors TS ``getSelfBridgeCompatId`` on ``replBridgeHandle.ts:33-36``.
+    Returns ``None`` when no bridge is connected. The retag from ``cse_*``
+    to ``session_*`` matches what ``/v1/sessions`` responses use, so
+    server-driven peer dedup compares apples to apples.
+    """
+    h = get_repl_bridge_handle()
+    if h is None:
+        return None
+    return to_compat_session_id(h.bridge_session_id)
+
+
+def _reset_for_testing() -> None:
+    """Clear the module-global pointer (tests only).
+
+    Test cleanup helper — not part of the public API. The Phase 1 module
+    pattern (see ``session_id_compat._reset_shim_gate_for_testing``)
+    establishes this as the convention.
+    """
+    global _handle
+    _handle = None
+
+
+__all__ = [
+    'get_repl_bridge_handle',
+    'get_self_bridge_compat_id',
+    'set_repl_bridge_handle',
+]

--- a/tests/bridge/test_bridge_config.py
+++ b/tests/bridge/test_bridge_config.py
@@ -1,0 +1,83 @@
+"""Tests for ``src.bridge.bridge_config``."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from src.bridge.bridge_config import (
+    get_bridge_access_token,
+    get_bridge_base_url,
+    get_bridge_base_url_override,
+    get_bridge_token_override,
+)
+
+
+def _no_bridge_env() -> dict[str, str]:
+    """Env without the CLAUDE_BRIDGE_* overrides."""
+    return {
+        k: v for k, v in os.environ.items()
+        if not k.startswith('CLAUDE_BRIDGE_')
+    }
+
+
+def test_token_override_set_returns_value() -> None:
+    env = _no_bridge_env() | {'CLAUDE_BRIDGE_OAUTH_TOKEN': 'tok-123'}
+    with patch.dict(os.environ, env, clear=True):
+        assert get_bridge_token_override() == 'tok-123'
+
+
+def test_token_override_unset_returns_none() -> None:
+    with patch.dict(os.environ, _no_bridge_env(), clear=True):
+        assert get_bridge_token_override() is None
+
+
+def test_token_override_empty_string_returns_none() -> None:
+    """Empty string is treated as unset (matches TS ``|| undefined``)."""
+    env = _no_bridge_env() | {'CLAUDE_BRIDGE_OAUTH_TOKEN': ''}
+    with patch.dict(os.environ, env, clear=True):
+        assert get_bridge_token_override() is None
+
+
+def test_base_url_override_set_returns_value() -> None:
+    env = _no_bridge_env() | {'CLAUDE_BRIDGE_BASE_URL': 'https://staging.example.com'}
+    with patch.dict(os.environ, env, clear=True):
+        assert get_bridge_base_url_override() == 'https://staging.example.com'
+
+
+def test_base_url_override_unset_returns_none() -> None:
+    with patch.dict(os.environ, _no_bridge_env(), clear=True):
+        assert get_bridge_base_url_override() is None
+
+
+def test_get_bridge_access_token_returns_override() -> None:
+    env = _no_bridge_env() | {'CLAUDE_BRIDGE_OAUTH_TOKEN': 'tok-xyz'}
+    with patch.dict(os.environ, env, clear=True):
+        assert get_bridge_access_token() == 'tok-xyz'
+
+
+def test_get_bridge_access_token_falls_through_to_none() -> None:
+    """Fallthrough returns None until Phase 2 lands the OAuth keychain read."""
+    with patch.dict(os.environ, _no_bridge_env(), clear=True):
+        assert get_bridge_access_token() is None
+
+
+def test_get_bridge_base_url_returns_override() -> None:
+    env = _no_bridge_env() | {'CLAUDE_BRIDGE_BASE_URL': 'https://dev.example.com'}
+    with patch.dict(os.environ, env, clear=True):
+        assert get_bridge_base_url() == 'https://dev.example.com'
+
+
+def test_get_bridge_base_url_falls_through_to_production() -> None:
+    """Fallthrough returns the inline production constant."""
+    with patch.dict(os.environ, _no_bridge_env(), clear=True):
+        assert get_bridge_base_url() == 'https://api.anthropic.com'
+
+
+def test_get_bridge_base_url_always_returns_non_none() -> None:
+    """``get_bridge_base_url()`` must never return None — TS signature
+    is ``string``, not ``string | undefined``."""
+    with patch.dict(os.environ, _no_bridge_env(), clear=True):
+        result = get_bridge_base_url()
+    assert isinstance(result, str)
+    assert len(result) > 0

--- a/tests/bridge/test_bridge_status_util.py
+++ b/tests/bridge/test_bridge_status_util.py
@@ -1,0 +1,407 @@
+"""Tests for ``src.bridge.bridge_status_util``."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from src.bridge.bridge_status_util import (
+    FAILED_FOOTER_TEXT,
+    SHIMMER_INTERVAL_MS,
+    TOOL_DISPLAY_EXPIRY_MS,
+    abbreviate_activity,
+    build_active_footer_text,
+    build_bridge_connect_url,
+    build_bridge_session_url,
+    build_idle_footer_text,
+    compute_glimmer_index,
+    compute_shimmer_segments,
+    format_duration,
+    get_bridge_status,
+    get_claude_ai_base_url,
+    get_remote_session_url,
+    string_width,
+    timestamp,
+    truncate_to_width,
+    wrap_with_osc8_link,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_tool_display_expiry_ms_matches_ts() -> None:
+    assert TOOL_DISPLAY_EXPIRY_MS == 30_000
+
+
+def test_shimmer_interval_ms_matches_ts() -> None:
+    assert SHIMMER_INTERVAL_MS == 150
+
+
+def test_failed_footer_text_matches_ts() -> None:
+    assert FAILED_FOOTER_TEXT == 'Something went wrong, please try again'
+
+
+# ---------------------------------------------------------------------------
+# format_duration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ('ms', 'expected'),
+    [
+        # ``format_duration`` is the canonical ``src.utils.format`` helper —
+        # see module docstring "Behavior note". It uses ``floor`` (not
+        # JS round-half-up) for the seconds-only branch and adds hours/
+        # days for ms >= 1h, which diverges from TS ``bridgeStatusUtil``'s
+        # re-export of TS ``utils/format``. Tests pin the actual behavior
+        # of the canonical Python helper, not the TS-exact bridge variant.
+        (0, '0s'),
+        (500, '0s'),        # floor(0.5) = 0
+        (1_499, '1s'),
+        (1_500, '1s'),      # floor(1.5) = 1 (not Math.round → 2)
+        (59_999, '59s'),    # floor(59.999) = 59
+        (60_000, '1m 0s'),  # hide_trailing_zeros=False default
+        (60_500, '1m 1s'),
+        (75_000, '1m 15s'),
+        # utils/format adds hours branch (TS bridge has none).
+        (3_600_000, '1h 0m 0s'),
+        (3_660_000, '1h 1m 0s'),
+    ],
+)
+def test_format_duration(ms: int, expected: str) -> None:
+    assert format_duration(ms) == expected
+
+
+def test_format_duration_negative_uses_decimal_branch() -> None:
+    """Negative ms hits the ``ms < 1`` decimal branch in utils/format.
+
+    Documents the divergence: ``utils/format`` returns ``"-0.5s"``;
+    TS bridge would render ``"0s"`` (Math.round(-0.5/1000) == 0). The
+    bridge UI never passes negative durations in practice (elapsed times
+    are non-negative by construction).
+    """
+    assert format_duration(-500) == '-0.5s'
+
+
+# ---------------------------------------------------------------------------
+# string_width + truncate_to_width
+# ---------------------------------------------------------------------------
+
+
+def test_string_width_ascii() -> None:
+    assert string_width('hello') == 5
+
+
+def test_string_width_empty() -> None:
+    assert string_width('') == 0
+
+
+def test_string_width_cjk_is_double() -> None:
+    """CJK characters are 2 cols wide each."""
+    assert string_width('你好') == 4
+
+
+def test_string_width_strips_ansi() -> None:
+    """ANSI escape codes shouldn't count toward visual width."""
+    s = '\x1b[31mred\x1b[0m'
+    assert string_width(s) == 3
+
+
+def test_truncate_to_width_short_string_unchanged() -> None:
+    assert truncate_to_width('hi', 10) == 'hi'
+
+
+def test_truncate_to_width_at_boundary_unchanged() -> None:
+    assert truncate_to_width('hello', 5) == 'hello'
+
+
+def test_truncate_to_width_truncates_with_ellipsis() -> None:
+    out = truncate_to_width('hello world', 6)
+    assert out == 'hello…'
+    assert string_width(out) == 6
+
+
+def test_truncate_to_width_zero_returns_empty() -> None:
+    assert truncate_to_width('hello', 0) == ''
+
+
+def test_truncate_to_width_one_returns_ellipsis_only() -> None:
+    assert truncate_to_width('hello', 1) == '…'
+
+
+def test_truncate_to_width_cjk_grapheme_aware() -> None:
+    """CJK characters aren't split mid-codepoint."""
+    out = truncate_to_width('你好世界', 5)
+    # '你' = 2 cols, ellipsis = 1 col; budget 4 fits one '你', another
+    # '好' would push to 4 then ellipsis pushes to 5 — should be '你好…'.
+    assert out == '你好…'
+    assert string_width(out) == 5
+
+
+def test_truncate_to_width_cjk_overflow_returns_ellipsis_only() -> None:
+    """If budget is too small to fit any CJK character, return just '…'.
+
+    Regression test pinned per CRITIC feedback — locks current behavior:
+    width budget 2 minus ellipsis 1 = 1 col for content, but a CJK char
+    is 2 cols so nothing fits → output is just the ellipsis (1 col).
+    """
+    out = truncate_to_width('你你', 2)
+    assert out == '…'
+    assert string_width(out) == 1
+
+
+def test_truncate_to_width_preserves_ansi_escapes_whole() -> None:
+    """ANSI SGR sequences are zero-width and never split mid-escape.
+
+    Regression test per CRITIC feedback. Before the fix, the grapheme
+    splitter would chop ``\\x1b[31m`` into 5 separate "graphemes" each
+    counted as 1 col by ``string_width``, producing partial escapes that
+    bleed color into the terminal.
+    """
+    s = '\x1b[31mhello\x1b[0m world'
+    out = truncate_to_width(s, 6)
+    # The escape sequences are zero-width and kept whole; visible
+    # content trims at 5 cols ('hello'), then ellipsis.
+    # Order must be: red-open, "hello", red-close, ellipsis.
+    assert '\x1b[31m' in out  # opening SGR intact
+    assert '\x1b[0m' in out   # closing SGR intact
+    assert 'hello' in out
+    assert out.endswith('…')
+    # Visible width must equal max_width.
+    assert string_width(out) == 6
+
+
+def test_truncate_to_width_with_ansi_mid_truncation() -> None:
+    """ANSI escapes inside a truncated region are still preserved."""
+    # 'a\x1b[31mbc' = a(1) + ansi(0) + b(1) + c(1) = 3 cols visible.
+    # truncate to 2 cols: budget 1 + ellipsis 1 → only 'a' + ansi + '…'.
+    s = 'a\x1b[31mbc'
+    out = truncate_to_width(s, 2)
+    # 'a', then the ansi (zero-width, always emitted), then '…'.
+    assert out == 'a\x1b[31m…'
+    assert string_width(out) == 2
+
+
+def test_truncate_to_width_preserves_ansi_closer_after_break() -> None:
+    """A trailing ``\\x1b[0m`` reset in the tail still gets emitted.
+
+    Regression test per CRITIC follow-up: previously the loop ``break``'d
+    on the first over-budget visible token and dropped any post-break
+    zero-width tokens. That would leave colored output bleeding into
+    everything written after the truncated string. Now we keep iterating
+    and emit only the zero-width tokens.
+    """
+    s = 'a\x1b[31mb\x1b[0mc'
+    out = truncate_to_width(s, 2)
+    # Budget 1 visible col + 1 ellipsis col. 'a' fits, opening SGR
+    # zero-width emitted, 'b' over budget, closing SGR zero-width emitted,
+    # 'c' dropped, then ellipsis.
+    assert '\x1b[31m' in out
+    assert '\x1b[0m' in out  # closer preserved
+    assert 'a' in out
+    assert out.endswith('…')
+    assert string_width(out) == 2
+
+
+def test_truncate_to_width_osc8_link_treated_as_zero_width() -> None:
+    """OSC 8 hyperlinks (\\x1b]8;;url\\x07text\\x1b]8;;\\x07) preserved.
+
+    The two OSC 8 markers each contribute 0 visual width; only the text
+    in between is measured for truncation.
+    """
+    s = '\x1b]8;;https://x.com\x07link\x1b]8;;\x07 tail'
+    # Visible width = 4 (link) + 1 (space) + 4 (tail) = 9.
+    assert string_width(s) == 9
+    out = truncate_to_width(s, 5)
+    # OSC 8 markers preserved, 'link' fits exactly, then ellipsis.
+    assert '\x1b]8;;https://x.com\x07' in out
+    assert '\x1b]8;;\x07' in out
+    assert out.endswith('…')
+    assert string_width(out) == 5
+
+
+# ---------------------------------------------------------------------------
+# timestamp + abbreviate_activity
+# ---------------------------------------------------------------------------
+
+
+def test_timestamp_format() -> None:
+    out = timestamp()
+    assert re.match(r'^\d{2}:\d{2}:\d{2}$', out) is not None
+
+
+def test_abbreviate_activity_short_unchanged() -> None:
+    assert abbreviate_activity('hi') == 'hi'
+
+
+def test_abbreviate_activity_long_truncated_to_30_cols() -> None:
+    long = 'Reading ' + 'a' * 100
+    out = abbreviate_activity(long)
+    assert string_width(out) == 30
+    assert out.endswith('…')
+
+
+# ---------------------------------------------------------------------------
+# URL helpers
+# ---------------------------------------------------------------------------
+
+
+def test_get_claude_ai_base_url_production() -> None:
+    assert get_claude_ai_base_url() == 'https://claude.ai'
+
+
+def test_get_claude_ai_base_url_ingress_param_ignored() -> None:
+    """``ingress_url`` is a no-op until constants/product.py is ported."""
+    assert get_claude_ai_base_url('https://staging.example.com') == 'https://claude.ai'
+
+
+def test_get_remote_session_url_retags_cse_to_session() -> None:
+    out = get_remote_session_url('cse_abc123')
+    assert out == 'https://claude.ai/code/session_abc123'
+
+
+def test_get_remote_session_url_idempotent_on_session_prefix() -> None:
+    out = get_remote_session_url('session_xyz')
+    assert out == 'https://claude.ai/code/session_xyz'
+
+
+def test_build_bridge_connect_url() -> None:
+    out = build_bridge_connect_url('env-1')
+    assert out == 'https://claude.ai/code?bridge=env-1'
+
+
+def test_build_bridge_session_url_includes_bridge_param() -> None:
+    out = build_bridge_session_url('cse_abc', 'env-1')
+    assert out == 'https://claude.ai/code/session_abc?bridge=env-1'
+
+
+# ---------------------------------------------------------------------------
+# Shimmer math
+# ---------------------------------------------------------------------------
+
+
+def test_compute_glimmer_index_decreases_with_tick() -> None:
+    """At tick=0 index is message_width+10; at tick=1 it's message_width+9."""
+    width = 20
+    assert compute_glimmer_index(0, width) == 30
+    assert compute_glimmer_index(1, width) == 29
+
+
+def test_compute_glimmer_index_cycles() -> None:
+    """Cycle length is message_width+20."""
+    width = 20
+    cycle = width + 20
+    assert compute_glimmer_index(0, width) == compute_glimmer_index(cycle, width)
+
+
+def test_compute_shimmer_segments_offscreen_left_returns_all_in_before() -> None:
+    text = 'hello'
+    out = compute_shimmer_segments(text, glimmer_index=10)
+    # message_width=5, shimmer_start=9 >= 5 → offscreen right, all before.
+    assert out.before == 'hello'
+    assert out.shimmer == ''
+    assert out.after == ''
+
+
+def test_compute_shimmer_segments_offscreen_right_returns_all_in_before() -> None:
+    text = 'hello'
+    out = compute_shimmer_segments(text, glimmer_index=-10)
+    # shimmer_end=-9 < 0 → offscreen left, all before per TS.
+    assert out.before == 'hello'
+    assert out.shimmer == ''
+    assert out.after == ''
+
+
+def test_compute_shimmer_segments_splits_at_index() -> None:
+    text = 'abcdefghij'
+    out = compute_shimmer_segments(text, glimmer_index=5)
+    # shimmer_start=4 shimmer_end=6 → cols [4,6] inclusive in shimmer.
+    # before = cols 0-3 = 'abcd'; shimmer = 'efg'; after = 'hij'.
+    assert out.before == 'abcd'
+    assert out.shimmer == 'efg'
+    assert out.after == 'hij'
+
+
+def test_compute_shimmer_segments_preserves_total_text() -> None:
+    """before + shimmer + after must reconstruct the original text."""
+    text = 'the quick brown fox'
+    for idx in range(-5, 30):
+        out = compute_shimmer_segments(text, glimmer_index=idx)
+        assert out.before + out.shimmer + out.after == text
+
+
+# ---------------------------------------------------------------------------
+# get_bridge_status
+# ---------------------------------------------------------------------------
+
+
+def test_get_bridge_status_error_wins() -> None:
+    """Error takes precedence over connected/session_active/reconnecting."""
+    info = get_bridge_status(
+        error='boom', connected=True, session_active=True, reconnecting=True
+    )
+    assert info.label == 'Remote Control failed'
+    assert info.color == 'error'
+
+
+def test_get_bridge_status_reconnecting_when_no_error() -> None:
+    info = get_bridge_status(
+        error=None, connected=False, session_active=False, reconnecting=True
+    )
+    assert info.label == 'Remote Control reconnecting'
+    assert info.color == 'warning'
+
+
+def test_get_bridge_status_active_when_connected() -> None:
+    info = get_bridge_status(
+        error=None, connected=True, session_active=False, reconnecting=False
+    )
+    assert info.label == 'Remote Control active'
+    assert info.color == 'success'
+
+
+def test_get_bridge_status_active_when_session_active() -> None:
+    info = get_bridge_status(
+        error=None, connected=False, session_active=True, reconnecting=False
+    )
+    assert info.label == 'Remote Control active'
+    assert info.color == 'success'
+
+
+def test_get_bridge_status_connecting_when_idle() -> None:
+    info = get_bridge_status(
+        error=None, connected=False, session_active=False, reconnecting=False
+    )
+    assert info.label.startswith('Remote Control connecting')
+    assert info.color == 'warning'
+
+
+# ---------------------------------------------------------------------------
+# Footer + OSC 8
+# ---------------------------------------------------------------------------
+
+
+def test_build_idle_footer_text() -> None:
+    out = build_idle_footer_text('https://claude.ai/code?bridge=env-1')
+    assert 'Code everywhere with the Claude app' in out
+    assert 'https://claude.ai/code?bridge=env-1' in out
+
+
+def test_build_active_footer_text() -> None:
+    out = build_active_footer_text('https://claude.ai/code/session_x')
+    assert 'Continue coding in the Claude app' in out
+    assert 'https://claude.ai/code/session_x' in out
+
+
+def test_wrap_with_osc8_link_zero_visual_width() -> None:
+    """OSC 8 hyperlink markers have zero visual width per terminal spec."""
+    visible = 'click here'
+    wrapped = wrap_with_osc8_link(visible, 'https://example.com')
+    assert visible in wrapped
+    assert '\x1b]8;;https://example.com\x07' in wrapped
+    assert '\x1b]8;;\x07' in wrapped
+    assert string_width(wrapped) == string_width(visible)

--- a/tests/bridge/test_env_less_bridge_config.py
+++ b/tests/bridge/test_env_less_bridge_config.py
@@ -1,0 +1,150 @@
+"""Tests for ``src.bridge.env_less_bridge_config``.
+
+Every TS default must match the Python default exactly — behavior-
+preservation contract per refactoring plan §3.9.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.bridge.env_less_bridge_config import (
+    DEFAULT_ENV_LESS_BRIDGE_CONFIG,
+    EnvLessBridgeConfig,
+    check_env_less_bridge_min_version,
+    get_env_less_bridge_config,
+    should_show_app_upgrade_message,
+    validate_env_less_bridge_config_raw,
+)
+
+
+def test_defaults_match_ts() -> None:
+    """Mirrors TS ``envLessBridgeConfig.ts:44-58`` field-by-field."""
+    cfg = DEFAULT_ENV_LESS_BRIDGE_CONFIG
+    assert cfg.init_retry_max_attempts == 3
+    assert cfg.init_retry_base_delay_ms == 500
+    assert cfg.init_retry_jitter_fraction == 0.25
+    assert cfg.init_retry_max_delay_ms == 4000
+    assert cfg.http_timeout_ms == 10_000
+    assert cfg.uuid_dedup_buffer_size == 2000
+    assert cfg.heartbeat_interval_ms == 20_000
+    assert cfg.heartbeat_jitter_fraction == 0.1
+    assert cfg.token_refresh_buffer_ms == 300_000
+    assert cfg.teardown_archive_timeout_ms == 1500
+    assert cfg.connect_timeout_ms == 15_000
+    assert cfg.min_version == '0.0.0'
+    assert cfg.should_show_app_upgrade_message is False
+
+
+@pytest.mark.asyncio
+async def test_get_env_less_bridge_config_returns_defaults() -> None:
+    """No GrowthBook in Python build → defaults always."""
+    cfg = await get_env_less_bridge_config()
+    assert cfg == DEFAULT_ENV_LESS_BRIDGE_CONFIG
+
+
+@pytest.mark.asyncio
+async def test_check_min_version_returns_none_for_default() -> None:
+    assert await check_env_less_bridge_min_version() is None
+
+
+@pytest.mark.asyncio
+async def test_should_show_app_upgrade_message_false_default() -> None:
+    """Default has the flag off → returns False even though v2 enabled."""
+    assert await should_show_app_upgrade_message() is False
+
+
+def test_validate_raw_rejects_out_of_range_heartbeat() -> None:
+    """``heartbeat_interval_ms`` floor 5000 — values below fall back to defaults."""
+    raw = {'heartbeat_interval_ms': 1000}
+    out = validate_env_less_bridge_config_raw(raw)
+    assert out == DEFAULT_ENV_LESS_BRIDGE_CONFIG
+
+
+def test_validate_raw_rejects_out_of_range_heartbeat_high() -> None:
+    """``heartbeat_interval_ms`` cap 30000 — values above fall back to defaults."""
+    raw = {'heartbeat_interval_ms': 60_000}
+    out = validate_env_less_bridge_config_raw(raw)
+    assert out == DEFAULT_ENV_LESS_BRIDGE_CONFIG
+
+
+def test_validate_raw_rejects_inverted_token_refresh_buffer() -> None:
+    """Cap 1_800_000 catches the buffer-vs-delay semantic inversion."""
+    raw = {'token_refresh_buffer_ms': 2_000_000}
+    out = validate_env_less_bridge_config_raw(raw)
+    assert out == DEFAULT_ENV_LESS_BRIDGE_CONFIG
+
+
+def test_validate_raw_partial_input_uses_defaults_for_omitted() -> None:
+    """A valid partial override merges into defaults for omitted fields."""
+    raw = {'heartbeat_interval_ms': 25_000}
+    out = validate_env_less_bridge_config_raw(raw)
+    assert out.heartbeat_interval_ms == 25_000
+    # All other fields stay at defaults.
+    assert out.connect_timeout_ms == 15_000
+    assert out.token_refresh_buffer_ms == 300_000
+
+
+def test_validate_raw_non_dict_returns_defaults() -> None:
+    assert validate_env_less_bridge_config_raw(None) == DEFAULT_ENV_LESS_BRIDGE_CONFIG
+    assert validate_env_less_bridge_config_raw('garbage') == DEFAULT_ENV_LESS_BRIDGE_CONFIG
+    assert validate_env_less_bridge_config_raw([1, 2, 3]) == DEFAULT_ENV_LESS_BRIDGE_CONFIG
+
+
+def test_validate_raw_full_override_accepted() -> None:
+    """A complete, well-formed override yields a non-default config."""
+    raw = {
+        'init_retry_max_attempts': 5,
+        'init_retry_base_delay_ms': 1000,
+        'init_retry_jitter_fraction': 0.5,
+        'init_retry_max_delay_ms': 8000,
+        'http_timeout_ms': 20_000,
+        'uuid_dedup_buffer_size': 5000,
+        'heartbeat_interval_ms': 25_000,
+        'heartbeat_jitter_fraction': 0.2,
+        'token_refresh_buffer_ms': 600_000,
+        'teardown_archive_timeout_ms': 1800,
+        'connect_timeout_ms': 30_000,
+        'min_version': '1.2.3',
+        'should_show_app_upgrade_message': True,
+    }
+    out = validate_env_less_bridge_config_raw(raw)
+    assert out.init_retry_max_attempts == 5
+    assert out.should_show_app_upgrade_message is True
+    assert out.min_version == '1.2.3'
+
+
+def test_env_less_bridge_config_constructible_directly() -> None:
+    """Direct construction with kwargs works (test-helper path)."""
+    cfg = EnvLessBridgeConfig(heartbeat_interval_ms=15_000)
+    assert cfg.heartbeat_interval_ms == 15_000
+    assert cfg.connect_timeout_ms == 15_000  # default
+
+
+def test_env_less_bridge_config_rejects_out_of_range_construction() -> None:
+    """Direct construction enforces bounds."""
+    with pytest.raises(Exception):  # pydantic ValidationError
+        EnvLessBridgeConfig(heartbeat_interval_ms=1)
+
+
+def test_strict_mode_rejects_string_for_int_field() -> None:
+    """``strict=True`` mirrors Zod ``z.number()`` — no string coercion.
+
+    Regression test per CRITIC feedback: without ``strict=True``, pydantic
+    silently coerces ``"5"`` to ``5``, hiding upstream GrowthBook schema
+    drift. TS Zod rejects this.
+    """
+    raw = {'init_retry_max_attempts': '5'}
+    assert validate_env_less_bridge_config_raw(raw) == DEFAULT_ENV_LESS_BRIDGE_CONFIG
+
+
+def test_strict_mode_rejects_float_for_int_field() -> None:
+    """``strict=True`` rejects floats for int fields (no truncation)."""
+    raw = {'init_retry_max_attempts': 3.5}
+    assert validate_env_less_bridge_config_raw(raw) == DEFAULT_ENV_LESS_BRIDGE_CONFIG
+
+
+def test_strict_mode_rejects_string_for_bool_field() -> None:
+    """``strict=True`` rejects ``"true"`` as a bool."""
+    raw = {'should_show_app_upgrade_message': 'true'}
+    assert validate_env_less_bridge_config_raw(raw) == DEFAULT_ENV_LESS_BRIDGE_CONFIG

--- a/tests/bridge/test_poll_config.py
+++ b/tests/bridge/test_poll_config.py
@@ -1,0 +1,150 @@
+"""Tests for ``src.bridge.poll_config``.
+
+Field-level validation, cross-field validators, fall-back-to-defaults
+behavior, and the at-capacity liveness invariant from TS Zod schema
+``pollConfig.ts:74-91``.
+"""
+
+from __future__ import annotations
+
+from src.bridge.poll_config import (
+    get_poll_interval_config,
+    validate_poll_interval_config_raw,
+)
+from src.bridge.poll_config_defaults import DEFAULT_POLL_CONFIG
+
+
+def _good_raw() -> dict[str, int]:
+    """Minimum valid raw payload (matches defaults)."""
+    return {
+        'poll_interval_ms_not_at_capacity': 2000,
+        'poll_interval_ms_at_capacity': 600_000,
+        'non_exclusive_heartbeat_interval_ms': 0,
+        'multisession_poll_interval_ms_not_at_capacity': 2000,
+        'multisession_poll_interval_ms_partial_capacity': 2000,
+        'multisession_poll_interval_ms_at_capacity': 600_000,
+        'reclaim_older_than_ms': 5000,
+        'session_keepalive_interval_v2_ms': 120_000,
+    }
+
+
+def test_get_poll_interval_config_returns_defaults() -> None:
+    assert get_poll_interval_config() == DEFAULT_POLL_CONFIG
+
+
+def test_validate_raw_well_formed_returns_validated_dataclass() -> None:
+    out = validate_poll_interval_config_raw(_good_raw())
+    assert out == DEFAULT_POLL_CONFIG
+
+
+def test_validate_raw_rejects_below_floor_seek_interval() -> None:
+    """``poll_interval_ms_not_at_capacity`` floor 100ms."""
+    raw = _good_raw()
+    raw['poll_interval_ms_not_at_capacity'] = 50
+    assert validate_poll_interval_config_raw(raw) == DEFAULT_POLL_CONFIG
+
+
+def test_validate_raw_accepts_zero_at_capacity_with_heartbeat() -> None:
+    """At-cap = 0 (disabled) requires heartbeat > 0 for liveness."""
+    raw = _good_raw()
+    raw['poll_interval_ms_at_capacity'] = 0
+    raw['multisession_poll_interval_ms_at_capacity'] = 0
+    raw['non_exclusive_heartbeat_interval_ms'] = 60_000
+    out = validate_poll_interval_config_raw(raw)
+    assert out.poll_interval_ms_at_capacity == 0
+    assert out.non_exclusive_heartbeat_interval_ms == 60_000
+
+
+def test_validate_raw_rejects_unit_confusion() -> None:
+    """``poll_interval_ms_at_capacity`` must be 0 OR >= 100; 50 → reject."""
+    raw = _good_raw()
+    raw['poll_interval_ms_at_capacity'] = 50
+    assert validate_poll_interval_config_raw(raw) == DEFAULT_POLL_CONFIG
+
+
+def test_validate_raw_rejects_all_zero_liveness_single_session() -> None:
+    """Cross-field invariant: heartbeat=0 AND at-cap=0 is rejected."""
+    raw = _good_raw()
+    raw['non_exclusive_heartbeat_interval_ms'] = 0
+    raw['poll_interval_ms_at_capacity'] = 0
+    # Keep multisession heartbeat OR multisession_at_capacity satisfied so
+    # the single-session refine is the first to trigger.
+    raw['multisession_poll_interval_ms_at_capacity'] = 600_000
+    assert validate_poll_interval_config_raw(raw) == DEFAULT_POLL_CONFIG
+
+
+def test_validate_raw_rejects_all_zero_liveness_multisession() -> None:
+    """Same invariant for multisession path."""
+    raw = _good_raw()
+    raw['non_exclusive_heartbeat_interval_ms'] = 0
+    raw['multisession_poll_interval_ms_at_capacity'] = 0
+    # Keep single-session liveness so multisession refine is the first to trigger.
+    raw['poll_interval_ms_at_capacity'] = 600_000
+    assert validate_poll_interval_config_raw(raw) == DEFAULT_POLL_CONFIG
+
+
+def test_validate_raw_non_dict_returns_defaults() -> None:
+    assert validate_poll_interval_config_raw(None) == DEFAULT_POLL_CONFIG
+    assert validate_poll_interval_config_raw('garbage') == DEFAULT_POLL_CONFIG
+    assert validate_poll_interval_config_raw([1, 2]) == DEFAULT_POLL_CONFIG
+
+
+def test_validate_raw_partial_input_uses_field_defaults() -> None:
+    """A partial payload merges with field defaults (no fall-back)."""
+    raw = {'non_exclusive_heartbeat_interval_ms': 30_000}
+    out = validate_poll_interval_config_raw(raw)
+    # Custom field honored.
+    assert out.non_exclusive_heartbeat_interval_ms == 30_000
+    # Field-level defaults filled in.
+    assert out.poll_interval_ms_at_capacity == 600_000
+    assert out.reclaim_older_than_ms == 5000
+
+
+def test_validate_raw_rejects_reclaim_below_one() -> None:
+    """``reclaim_older_than_ms`` floor 1ms (server's ge=1 constraint)."""
+    raw = _good_raw()
+    raw['reclaim_older_than_ms'] = 0
+    assert validate_poll_interval_config_raw(raw) == DEFAULT_POLL_CONFIG
+
+
+def test_validate_raw_accepts_session_keepalive_zero() -> None:
+    """``session_keepalive_interval_v2_ms`` 0 = disabled — allowed."""
+    raw = _good_raw()
+    raw['session_keepalive_interval_v2_ms'] = 0
+    out = validate_poll_interval_config_raw(raw)
+    assert out.session_keepalive_interval_v2_ms == 0
+
+
+def test_validate_raw_rejects_unit_confusion_multisession() -> None:
+    """Multisession at-cap also enforces zero-or-≥100 rule."""
+    raw = _good_raw()
+    raw['multisession_poll_interval_ms_at_capacity'] = 50
+    assert validate_poll_interval_config_raw(raw) == DEFAULT_POLL_CONFIG
+
+
+def test_strict_mode_rejects_string_for_int_field() -> None:
+    """``strict=True`` mirrors Zod ``z.number()`` — no string coercion."""
+    raw = _good_raw()
+    raw['poll_interval_ms_not_at_capacity'] = '2000'  # type: ignore[assignment]
+    assert validate_poll_interval_config_raw(raw) == DEFAULT_POLL_CONFIG
+
+
+def test_strict_mode_rejects_float_for_int_field() -> None:
+    """``strict=True`` rejects floats for int fields."""
+    raw = _good_raw()
+    raw['poll_interval_ms_at_capacity'] = 600_000.5  # type: ignore[assignment]
+    assert validate_poll_interval_config_raw(raw) == DEFAULT_POLL_CONFIG
+
+
+def test_combined_unit_confusion_and_liveness_fail_falls_back() -> None:
+    """Any combination of validation failures falls back to defaults.
+
+    Per CRITIC feedback: the specific ordering of which validator fires
+    first doesn't matter; what matters is that *any* failure yields
+    defaults. Pins the contract.
+    """
+    raw = _good_raw()
+    raw['non_exclusive_heartbeat_interval_ms'] = 0
+    raw['multisession_poll_interval_ms_at_capacity'] = 50  # unit-confusion
+    raw['poll_interval_ms_at_capacity'] = 0  # liveness fails
+    assert validate_poll_interval_config_raw(raw) == DEFAULT_POLL_CONFIG

--- a/tests/bridge/test_repl_bridge_handle.py
+++ b/tests/bridge/test_repl_bridge_handle.py
@@ -1,0 +1,91 @@
+"""Tests for ``src.bridge.repl_bridge_handle``."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.bridge.repl_bridge_handle import (
+    _reset_for_testing,
+    get_repl_bridge_handle,
+    get_self_bridge_compat_id,
+    set_repl_bridge_handle,
+)
+
+
+class _FakeHandle:
+    """Minimal duck-typed ReplBridgeHandle for tests."""
+
+    def __init__(
+        self,
+        bridge_session_id: str,
+        environment_id: str = 'env-1',
+        session_ingress_url: str = 'https://api.example.com',
+    ) -> None:
+        self.bridge_session_id = bridge_session_id
+        self.environment_id = environment_id
+        self.session_ingress_url = session_ingress_url
+
+    write_messages = AsyncMock()
+    write_sdk_messages = AsyncMock()
+    send_control_request = AsyncMock()
+    send_control_response = AsyncMock()
+    send_cancel_request = AsyncMock()
+    send_result = AsyncMock()
+    teardown = AsyncMock()
+
+
+@pytest.fixture(autouse=True)
+def _reset_handle() -> None:
+    _reset_for_testing()
+
+
+def test_get_handle_default_none() -> None:
+    assert get_repl_bridge_handle() is None
+
+
+def test_set_and_get_handle_round_trip() -> None:
+    h = _FakeHandle(bridge_session_id='cse_abc')
+    set_repl_bridge_handle(h)  # type: ignore[arg-type]
+    assert get_repl_bridge_handle() is h
+
+
+def test_set_to_none_clears_handle() -> None:
+    h = _FakeHandle(bridge_session_id='cse_abc')
+    set_repl_bridge_handle(h)  # type: ignore[arg-type]
+    set_repl_bridge_handle(None)
+    assert get_repl_bridge_handle() is None
+
+
+def test_get_self_bridge_compat_id_returns_none_when_no_handle() -> None:
+    assert get_self_bridge_compat_id() is None
+
+
+def test_get_self_bridge_compat_id_retags_cse_to_session() -> None:
+    """``cse_uuid`` is rewritten to ``session_uuid`` for peer dedup."""
+    h = _FakeHandle(bridge_session_id='cse_abc123')
+    set_repl_bridge_handle(h)  # type: ignore[arg-type]
+    assert get_self_bridge_compat_id() == 'session_abc123'
+
+
+def test_get_self_bridge_compat_id_idempotent_on_session_prefix() -> None:
+    h = _FakeHandle(bridge_session_id='session_xyz')
+    set_repl_bridge_handle(h)  # type: ignore[arg-type]
+    assert get_self_bridge_compat_id() == 'session_xyz'
+
+
+def test_get_self_bridge_compat_id_returns_input_for_unprefixed() -> None:
+    h = _FakeHandle(bridge_session_id='bare-uuid')
+    set_repl_bridge_handle(h)  # type: ignore[arg-type]
+    assert get_self_bridge_compat_id() == 'bare-uuid'
+
+
+def test_replacement_handle_overrides_previous() -> None:
+    """Calling set with a new handle replaces the old one wholesale."""
+    h1 = _FakeHandle(bridge_session_id='cse_first')
+    h2 = _FakeHandle(bridge_session_id='cse_second')
+    set_repl_bridge_handle(h1)  # type: ignore[arg-type]
+    set_repl_bridge_handle(h2)  # type: ignore[arg-type]
+    assert get_repl_bridge_handle() is h2
+    assert get_self_bridge_compat_id() == 'session_second'


### PR DESCRIPTION
## Summary

Ports the remaining five Phase 1 bridge modules from `typescript/src/bridge/` that were deferred from #200 because they inline cross-folder helpers or need pydantic schema validation.

**New modules** (`src/bridge/`):
- `env_less_bridge_config.py` — pydantic v2 schema (`strict=True`) mirroring TS `EnvLessBridgeConfig` Zod schema; defaults match TS exactly.
- `poll_config.py` — pydantic v2 schema with cross-field `model_validator`s enforcing the at-capacity liveness invariant (heartbeat > 0 OR `poll_interval_ms_at_capacity` > 0) and the zero-or-≥100 unit-confusion rule; both single-session AND multisession paths covered.
- `bridge_config.py` — env-override helpers (`CLAUDE_BRIDGE_OAUTH_TOKEN`, `CLAUDE_BRIDGE_BASE_URL`); fallthrough returns `None` for token and an inline production URL constant for base URL (per refactoring plan §0.1 Q6 — OAuth keychain port deferred to Phase 2).
- `bridge_status_util.py` — URL builders, shimmer animation math, status state machine, OSC 8 link wrapping. Re-exports the canonical `src.utils.format.format_duration`; inlines 3 cross-folder deps (`truncate_to_width` with ANSI-aware grapheme iteration; claude.ai base URL; remote-session URL with `cse_` → `session_` retag).
- `repl_bridge_handle.py` — process-global pointer to the active REPL bridge handle; multi-peer dedup via `concurrent_sessions` is a TODO-noop with debug-log marker until Phase 2 (loud docstring caveat included).

**Extension:**
- `__init__.py`: 20 new re-exports (56 total in `__all__`) covering the new modules' consumer-facing surface. All re-exports remain tolerant of missing Phase 2 modules.

**ANSI safety**: `truncate_to_width` walks the input as `(token, visible_width)` pairs where ANSI SGR / OSC 8 escapes are zero-width whole tokens. Escape sequences are never split mid-byte, and trailing closers (``\x1b[0m``) in the tail are preserved post-truncation so color doesn't bleed into following terminal output. Three regression tests pin this.

**What's still missing** (deferred to follow-up PRs):
- Phase 2 cross-folder deps: `toSDKMessages`, OAuth helpers (`getClaudeAIOAuthTokens`, `handleOAuth401Error`), `combinedAbortSignal`, `concurrentSessions.updateSessionBridgeId`, `sessionTitle`, `worktree`, ...
- `inbound_attachments.py` (needs `bootstrap/state.getSessionId` from Phase 2)
- Orchestrators: `bridgeMain.ts`, `replBridge.ts`, `remoteBridgeCore.ts`, `initReplBridge.ts`
- HTTP client: `bridgeApi.ts`
- Session runner: `sessionRunner.ts`

## Test plan

- [x] `uv run pytest tests/bridge/` — **370/370 pass** (91 new + 279 existing)
- [x] `uv run pytest tests/test_porting_workspace.py` — 23/23 pass; `from src import bridge; bridge.MODULE_COUNT == 31` still works
- [x] `uv run python -c "from src import bridge; print(len(bridge.__all__))"` — 56 exports
- [x] CRITIC review: APPROVE after 2 rounds (resolved `format_duration` duplication via canonical re-export; fixed `truncate_to_width` ANSI corruption with regression tests; added pydantic `strict=True` regression tests; made `repl_bridge_handle` Phase 2 caveat docstring-loud + debug-logged)
- [ ] CI green
- [ ] Reviewer spot-checks: ANSI-aware `truncate_to_width` (`test_truncate_to_width_preserves_ansi_*`); cross-field `poll_config` validators (`test_validate_raw_rejects_all_zero_liveness_*`); strict-mode pydantic (`test_strict_mode_rejects_string_for_*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)