### PR TITLE
bridge phase 2: cross-folder deps unblocking the orchestrators

### DIFF
--- a/src/auth/claude_ai.py
+++ b/src/auth/claude_ai.py
@@ -1,0 +1,275 @@
+"""claude.ai OAuth token + entitlement helpers.
+
+Ports the consumer-facing surface of ``typescript/src/utils/auth.ts``
+that the bridge subsystem needs:
+
+* ``get_claude_ai_oauth_tokens()`` — read the persisted OAuth token set.
+* ``get_oauth_account_info()`` — read the persisted account profile (org
+  UUID, plan, etc.).
+* ``is_claude_ai_subscriber()`` — entitlement check used by
+  ``is_bridge_enabled`` and ``getBridgeDisabledReason``.
+* ``has_profile_scope()`` — token-scope check used by the same.
+* ``check_and_refresh_oauth_token_if_needed()`` — proactive refresh
+  called before every bridge API request.
+* ``handle_oauth_401_error()`` — clear caches + force refresh after a
+  server-reported 401.
+
+Per refactoring plan §0.1 Q6: the TS file reads from a keychain-backed
+secure storage that hasn't been ported to Python. Until Phase 10 lands
+that storage layer, this module reads from environment variables as a
+dev-override path:
+
+* ``CLAUDE_AI_OAUTH_ACCESS_TOKEN`` — the OAuth access token.
+* ``CLAUDE_AI_OAUTH_REFRESH_TOKEN`` — the refresh token.
+* ``CLAUDE_AI_OAUTH_EXPIRES_AT`` — Unix-seconds expiry; defaults to
+  ``0.0`` (unknown) when unset, which ``_is_near_or_past_expiry``
+  treats as not-expiring (no refresh-warning fires for dev tokens).
+* ``CLAUDE_AI_OAUTH_SCOPES`` — space-separated scope list.
+* ``CLAUDE_AI_ORG_UUID`` — organization UUID.
+* ``CLAUDE_AI_SUBSCRIBER`` — truthy/falsy override for the entitlement
+  check (defaults: truthy when an access token is present).
+* ``CLAUDE_AI_OAUTH_REFRESH_FAILED`` — set by test code to simulate a
+  refresh failure.
+
+This is intentionally similar to the existing ``bridge_config.py`` env-
+override pattern (Phase 1). The public function signatures match what
+Phase 3 (``bridgeApi``) and Phase 5 (``remoteBridgeCore``) need — so
+swapping to a real keychain backend later is purely internal.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+
+from src.auth.oauth import OAuthTokens
+
+logger = logging.getLogger(__name__)
+
+
+# Env-var keys (centralized so tests can patch them in one place).
+ENV_ACCESS_TOKEN = 'CLAUDE_AI_OAUTH_ACCESS_TOKEN'
+ENV_REFRESH_TOKEN = 'CLAUDE_AI_OAUTH_REFRESH_TOKEN'
+ENV_EXPIRES_AT = 'CLAUDE_AI_OAUTH_EXPIRES_AT'
+ENV_SCOPES = 'CLAUDE_AI_OAUTH_SCOPES'
+ENV_ORG_UUID = 'CLAUDE_AI_ORG_UUID'
+ENV_SUBSCRIBER_OVERRIDE = 'CLAUDE_AI_SUBSCRIBER'
+ENV_REFRESH_FAILED = 'CLAUDE_AI_OAUTH_REFRESH_FAILED'
+
+
+_PROFILE_SCOPE = 'user:profile'
+_INFERENCE_SCOPE = 'user:inference'
+_REFRESH_BUFFER_SECONDS = 60.0
+"""Refresh tokens within this window of expiry rather than waiting until
+they're stale. Matches TS ``checkAndRefreshOAuthTokenIfNeeded`` buffer.
+"""
+
+
+@dataclass(frozen=True)
+class OAuthAccountInfo:
+    """Persisted account profile.
+
+    Mirrors the TS ``OauthAccount`` shape (only the fields the bridge
+    needs). Phase 10 will populate this from ``/api/oauth/profile``;
+    until then we read from env vars.
+    """
+
+    organization_uuid: str | None
+    email_address: str | None = None
+    is_subscriber: bool | None = None
+
+
+def get_claude_ai_oauth_tokens() -> OAuthTokens | None:
+    """Return the persisted claude.ai OAuth tokens, or ``None``.
+
+    Mirrors TS ``getClaudeAIOAuthTokens`` consumer-facing semantics.
+    Returns a plain ``OAuthTokens`` (no claude.ai-specific subclass —
+    callers only need ``access_token`` / ``refresh_token`` /
+    ``is_expired``).
+
+    Env-var path until Phase 10 keychain lands. Returns ``None`` when
+    no access token is set, matching TS "not logged in" semantics.
+    """
+    access_token = os.environ.get(ENV_ACCESS_TOKEN)
+    if not access_token:
+        return None
+    refresh_token = os.environ.get(ENV_REFRESH_TOKEN, '')
+    expires_at_raw = os.environ.get(ENV_EXPIRES_AT)
+    if expires_at_raw:
+        try:
+            expires_at = float(expires_at_raw)
+        except ValueError:
+            expires_at = 0.0
+    else:
+        # No env override → "unknown" (matches absence of expiry on
+        # imported tokens). ``_is_near_or_past_expiry`` treats 0.0 as
+        # not-expiring, so dev tokens don't trigger refresh warnings.
+        expires_at = 0.0
+    scope = os.environ.get(ENV_SCOPES, '')
+    return OAuthTokens(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        token_type='Bearer',
+        expires_at=expires_at,
+        scope=scope,
+    )
+
+
+def get_oauth_account_info() -> OAuthAccountInfo | None:
+    """Return the persisted claude.ai account profile, or ``None``.
+
+    Mirrors TS ``getOauthAccountInfo`` consumer-facing semantics. Used
+    by ``get_organization_uuid`` and the entitlement gate
+    ``getBridgeDisabledReason`` flow.
+
+    Env-var path until Phase 10. Returns ``None`` when no org UUID is
+    set (TS returns ``undefined`` for unconfigured accounts).
+    """
+    org_uuid = os.environ.get(ENV_ORG_UUID)
+    if not org_uuid:
+        return None
+    return OAuthAccountInfo(
+        organization_uuid=org_uuid,
+        email_address=None,
+        is_subscriber=_subscriber_override(),
+    )
+
+
+def is_claude_ai_subscriber() -> bool:
+    """Entitlement check used by ``is_bridge_enabled``.
+
+    Mirrors TS ``isClaudeAISubscriber`` on ``utils/auth.ts:1585-1591``.
+    The TS implementation is ``shouldUseClaudeAIAuth(getClaudeAIOAuthTokens()?.scopes)``,
+    which checks for the ``user:inference`` scope. That scope's
+    *practical* effect is to exclude Bedrock / Vertex / Console-only API
+    keys (none of which receive ``user:inference``), but the *mechanism*
+    is a positive scope check — replicate the mechanism, not the effect.
+
+    Python port resolution order:
+
+    * If ``CLAUDE_AI_SUBSCRIBER`` env-var override is set (test path),
+      honor it unconditionally.
+    * Otherwise: the persisted token must exist AND include the
+      ``user:inference`` scope. Tokens lacking the scope (e.g.
+      profile-only or api-only OAuth) return ``False`` — matches TS.
+    """
+    override = _subscriber_override()
+    if override is not None:
+        return override
+    tokens = get_claude_ai_oauth_tokens()
+    if tokens is None or not tokens.scope:
+        return False
+    return _INFERENCE_SCOPE in tokens.scope.split()
+
+
+def has_profile_scope() -> bool:
+    """Whether the persisted token includes the ``user:profile`` scope.
+
+    Mirrors TS ``hasProfileScope``. Used by
+    ``getBridgeDisabledReason`` to suggest re-login for tokens that
+    can't populate ``oauthAccount.organizationUuid``.
+
+    Env-var path: parses ``CLAUDE_AI_OAUTH_SCOPES``. Returns ``True``
+    when the scope is present, ``False`` otherwise.
+    """
+    tokens = get_claude_ai_oauth_tokens()
+    if tokens is None:
+        return False
+    if not tokens.scope:
+        return False
+    return _PROFILE_SCOPE in tokens.scope.split()
+
+
+async def check_and_refresh_oauth_token_if_needed() -> None:
+    """**No-op stub** — does NOT actually refresh tokens.
+
+    Mirrors the *signature* of TS ``checkAndRefreshOAuthTokenIfNeeded``,
+    but the *behavior* is intentionally a no-op until Phase 10 wires
+    keychain-backed refresh. TS callers invoke this proactively before
+    every bridge API call to avoid 401s; **Python callers will still get
+    401s when a token approaches expiry** because nothing here refreshes.
+
+    Emits a runtime warning when the persisted token is near or past
+    expiry so the gap is visible in logs — a Phase 5+ porter writing
+    against TS docs and expecting fresh tokens will see the warning
+    instead of silently shipping a token-staleness bug.
+
+    Errors are swallowed (matches TS best-effort behavior).
+    """
+    tokens = get_claude_ai_oauth_tokens()
+    if tokens is None:
+        return
+    if not _is_near_or_past_expiry(tokens):
+        return
+    logger.warning(
+        '[auth:claude_ai] token near/past expiry but '
+        'check_and_refresh_oauth_token_if_needed is a no-op stub — '
+        'Phase 10 keychain refresh not yet ported. 401 expected; '
+        'handle_oauth_401_error is also a no-op (see its docstring).'
+    )
+
+
+async def handle_oauth_401_error(
+    *, stale_token: str | None = None
+) -> bool:
+    """**No-op stub** — returns truthiness but does NOT refresh tokens.
+
+    Mirrors the *signature* of TS ``handleOAuth401Error``, but the
+    *behavior* is intentionally a no-op until Phase 10 wires keychain-
+    backed refresh. Returns ``True`` when a token is persisted (caller
+    will retry with the SAME token and likely get another 401) or
+    ``False`` when no token / refresh-failure-override is set.
+
+    The ``stale_token`` arg is accepted for forward compatibility —
+    Phase 10 keychain integration will compare it against the current
+    cached token to detect parallel refresh. The Python env-var path
+    ignores it.
+
+    Emits a runtime warning so Phase 5+ porters hitting a real 401 see
+    explicitly that no refresh happened.
+    """
+    if os.environ.get(ENV_REFRESH_FAILED):
+        return False
+    has_token = get_claude_ai_oauth_tokens() is not None
+    if has_token:
+        logger.warning(
+            '[auth:claude_ai] handle_oauth_401_error called but is a '
+            'no-op stub — token not refreshed, caller will retry with '
+            'the same token. Phase 10 keychain refresh not yet ported.'
+        )
+    return has_token
+
+
+def _is_near_or_past_expiry(tokens: OAuthTokens) -> bool:
+    """True when ``tokens`` expire within the refresh buffer."""
+    if tokens.expires_at <= 0:
+        return False  # Treat unknown-expiry as not-yet-expiring.
+    return tokens.expires_at - time.time() <= _REFRESH_BUFFER_SECONDS
+
+
+def _subscriber_override() -> bool | None:
+    """Parse ``CLAUDE_AI_SUBSCRIBER`` env var: True / False / None."""
+    raw = os.environ.get(ENV_SUBSCRIBER_OVERRIDE)
+    if raw is None:
+        return None
+    return raw.lower() in ('1', 'true', 'yes', 'on')
+
+
+__all__ = [
+    'ENV_ACCESS_TOKEN',
+    'ENV_EXPIRES_AT',
+    'ENV_ORG_UUID',
+    'ENV_REFRESH_FAILED',
+    'ENV_REFRESH_TOKEN',
+    'ENV_SCOPES',
+    'ENV_SUBSCRIBER_OVERRIDE',
+    'OAuthAccountInfo',
+    'check_and_refresh_oauth_token_if_needed',
+    'get_claude_ai_oauth_tokens',
+    'get_oauth_account_info',
+    'handle_oauth_401_error',
+    'has_profile_scope',
+    'is_claude_ai_subscriber',
+]

--- a/src/services/oauth/__init__.py
+++ b/src/services/oauth/__init__.py
@@ -1,0 +1,10 @@
+"""OAuth services package.
+
+Real OAuth flow lives in ``src/auth/oauth.py``; this package holds the
+service-layer helpers (``client.get_organization_uuid``, etc.) that
+mirror ``typescript/src/services/oauth/``.
+"""
+
+from src.services.oauth.client import get_organization_uuid
+
+__all__ = ['get_organization_uuid']

--- a/src/services/oauth/client.py
+++ b/src/services/oauth/client.py
@@ -1,0 +1,41 @@
+"""OAuth service-layer helpers used by the bridge HTTP client.
+
+Ports the **consumer-facing subset** of
+``typescript/src/services/oauth/client.ts`` that the bridge subsystem
+needs:
+
+* ``get_organization_uuid()`` — read the org UUID for HTTP headers
+  (``x-organization-uuid``).
+
+The TS file is 589 lines and includes the full OAuth login flow, token
+exchange, refresh wiring, and analytics. This Python port is a thin
+shim over ``src.auth.claude_ai.get_oauth_account_info()``; the full
+flow ports in Phase 10.
+"""
+
+from __future__ import annotations
+
+from src.auth.claude_ai import get_oauth_account_info
+
+
+async def get_organization_uuid() -> str | None:
+    """Return the current organization UUID, or ``None``.
+
+    Mirrors TS ``getOrganizationUUID`` consumer-facing semantics. Used
+    by ``createSession.ts``, ``getBridgeSession``, ``archiveBridgeSession``,
+    and ``updateBridgeSessionTitle`` to build the ``x-organization-uuid``
+    header. Returns ``None`` when no account is configured (matches TS
+    ``undefined`` for the unconfigured path).
+
+    Async because the TS counterpart awaits the keychain read; the
+    Python env-var path is synchronous but the signature is kept async
+    to make swapping to a real keychain in Phase 10 a non-breaking
+    change.
+    """
+    info = get_oauth_account_info()
+    if info is None:
+        return None
+    return info.organization_uuid
+
+
+__all__ = ['get_organization_uuid']

--- a/src/utils/combined_abort_signal.py
+++ b/src/utils/combined_abort_signal.py
@@ -1,0 +1,139 @@
+"""Combine multiple ``AbortSignal`` sources into a single derived signal.
+
+Ports ``typescript/src/utils/combinedAbortSignal.ts``.
+
+Used by ``bridgeApi`` (and Phase 5 orchestrators) to race a long-running
+HTTP call against caller cancellation + an optional per-call timeout. The
+returned signal aborts when *any* of: (a) the primary signal aborts,
+(b) the secondary signal aborts, or (c) the timeout elapses. Returns a
+``cleanup()`` so the caller can detach listeners + clear the timer when
+the operation completes normally — without cleanup, listeners accumulate
+on long-lived parent signals (the streaming executor creates one child
+per tool, etc.).
+
+Wraps the existing ``src.utils.abort_controller`` primitives rather than
+inventing a new one — that module's listener registration + once-fire
+semantics + child-controller pattern are already established and tested
+in the codebase.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Callable
+
+from src.utils.abort_controller import (
+    AbortSignal,
+    create_abort_controller,
+)
+
+
+@dataclass(frozen=True)
+class CombinedAbortSignal:
+    """A merged signal plus a cleanup function.
+
+    Mirrors TS ``{ signal, cleanup }`` return shape on
+    ``combinedAbortSignal.ts:18``. ``cleanup`` is idempotent — safe to
+    call multiple times; subsequent calls are no-ops.
+    """
+
+    signal: AbortSignal
+    cleanup: Callable[[], None]
+
+
+def create_combined_abort_signal(
+    primary: AbortSignal | None,
+    *,
+    secondary: AbortSignal | None = None,
+    timeout_seconds: float | None = None,
+) -> CombinedAbortSignal:
+    """Create a combined signal that aborts on any input source.
+
+    Mirrors TS ``createCombinedAbortSignal`` on
+    ``combinedAbortSignal.ts:15-60``. Keyword-only opts to make call
+    sites self-documenting (TS uses an options object; Python uses
+    kw-only — matches the existing ``get_bridge_status`` style).
+
+    **Note on the timeout parameter**: TS takes ``timeoutMs`` (ms);
+    Python takes ``timeout_seconds`` to match Python convention
+    (``asyncio.sleep``, ``httpx`` timeouts all use seconds). Callers
+    porting from TS should divide by 1000 at the call site.
+
+    **Note on the timeout reason**: TS sets the abort reason to a
+    ``DOMException('The operation timed out.', 'TimeoutError')``; the
+    Python port uses the literal string ``'timeout'``. Callers that
+    pattern-match the reason should adjust.
+
+    **Short-circuit**: if either input is already aborted on entry, the
+    returned signal is pre-aborted with a no-op cleanup. The timeout
+    is NOT armed in that case (matches TS lines 22-29).
+
+    Single-thread / single-asyncio-loop use only — concurrent calls
+    against the same parent signal are safe (each gets its own combined
+    controller + listener handles) but the cleanup must run on the same
+    loop that armed the timer.
+    """
+    combined = create_abort_controller()
+
+    if primary is not None and primary.aborted:
+        combined.abort(primary.reason)
+        return CombinedAbortSignal(signal=combined.signal, cleanup=lambda: None)
+    if secondary is not None and secondary.aborted:
+        combined.abort(secondary.reason)
+        return CombinedAbortSignal(signal=combined.signal, cleanup=lambda: None)
+
+    # Mutable state captured by the closures below. ``cleaned`` makes the
+    # cleanup idempotent; ``timer`` is the asyncio TimerHandle so we can
+    # cancel it on early cleanup.
+    state: dict[str, object] = {'cleaned': False, 'timer': None}
+
+    primary_listener: Callable[[], None] | None = None
+    secondary_listener: Callable[[], None] | None = None
+
+    def cleanup() -> None:
+        if state['cleaned']:
+            return
+        state['cleaned'] = True
+        timer = state['timer']
+        if timer is not None:
+            assert isinstance(timer, asyncio.TimerHandle)
+            timer.cancel()
+            state['timer'] = None
+        if primary is not None and primary_listener is not None:
+            primary.remove_listener(primary_listener)
+        if secondary is not None and secondary_listener is not None:
+            secondary.remove_listener(secondary_listener)
+
+    def abort_combined(reason: str | None) -> None:
+        cleanup()
+        combined.abort(reason)
+
+    def abort_from_primary() -> None:
+        abort_combined(primary.reason if primary is not None else None)
+
+    def abort_from_secondary() -> None:
+        abort_combined(secondary.reason if secondary is not None else None)
+
+    def abort_from_timeout() -> None:
+        abort_combined('timeout')
+
+    if timeout_seconds is not None:
+        # Defer scheduling to the running loop; raises RuntimeError if no
+        # loop is running. Matches TS setTimeout semantics (the equivalent
+        # call would only work in a JS event loop too).
+        loop = asyncio.get_running_loop()
+        state['timer'] = loop.call_later(timeout_seconds, abort_from_timeout)
+
+    if primary is not None:
+        primary_listener = primary.add_listener(abort_from_primary)
+    if secondary is not None:
+        secondary_listener = secondary.add_listener(abort_from_secondary)
+
+    return CombinedAbortSignal(signal=combined.signal, cleanup=cleanup)
+
+
+__all__ = [
+    'CombinedAbortSignal',
+    'create_combined_abort_signal',
+]

--- a/src/utils/message_mappers.py
+++ b/src/utils/message_mappers.py
@@ -1,0 +1,267 @@
+"""Convert internal Message types to wire-format SDKMessage dicts.
+
+Ports the **outbound half** of ``typescript/src/utils/messages/mappers.ts``.
+
+The TS file lives at ``utils/messages/mappers.ts``; the Python port uses
+a flat filename (``message_mappers.py``) because ``src/utils/messages.py``
+already exists as a single file (a name-collision with a subfolder would
+require relocating the existing module). Functional surface is identical.
+
+**Scope**: only ``to_sdk_messages`` is ported in Phase 2 — it's the one
+used by Phase 5 (``remoteBridgeCore``) and Phase 6 (``replBridge``) flush
+paths. The inbound mapper (``toInternalMessages``), compact-metadata
+helpers, ExitPlanMode v2 plan injection, and local-command-output
+synthesis are deferred:
+
+* ``toInternalMessages`` — not needed by the bridge orchestrators (the
+  v2 bridge reads inbound SDK messages via the existing
+  ``messaging.handle_ingress_message`` dispatcher).
+* Local-command-output synthesis — needs ``strip_ansi`` + LOCAL_COMMAND_*
+  XML constants + ``create_assistant_message``. Routed through the
+  fallthrough no-op for now; can be backfilled when a v2 bridge user
+  reports missing /cost or /voice output in the web UI.
+* ExitPlanMode v2 input normalization — needs ``utils/plans.get_plan()``;
+  same fallthrough no-op deferral.
+
+Both deferrals are safe: the affected message types are rare in bridge
+flushes, and skipping them just means slightly less context flows to the
+web client (matching what the v1 bridge did before TS added the
+synthesis paths).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.bootstrap.state import get_session_id
+from src.types.content_blocks import content_block_to_dict
+from src.types.messages import (
+    AssistantMessage,
+    Message,
+    SystemMessage,
+    UserMessage,
+)
+
+
+def to_sdk_messages(messages: list[Message]) -> list[dict[str, Any]]:
+    """Map local Message[] to wire-format SDKMessage[] dicts.
+
+    Mirrors TS ``toSDKMessages`` on ``utils/messages/mappers.ts:115-181``.
+
+    Returns a list of plain dicts (not TypedDicts) because the bridge
+    transport serializes via ``json.dumps`` and TypedDicts have no
+    runtime difference from regular dicts. Each dict carries:
+
+    * ``type``: ``"user"`` / ``"assistant"`` / ``"system"`` (compact_boundary)
+    * ``session_id``: from ``bootstrap.state.get_session_id()``
+    * ``parent_tool_use_id``: ``None`` (sub-agent context not used by bridge)
+    * ``uuid``: original message UUID (preserved for dedup on receipt)
+    * ``message``: the inner Anthropic-format payload (for user/assistant)
+    * ``timestamp`` / ``isSynthetic`` / ``tool_use_result``: user-only
+    * ``compact_metadata``: system compact_boundary only
+    * ``error``: assistant-only
+
+    Message types that don't map (``progress``, ``attachment``,
+    pure-input system, local_command without output, etc.) are silently
+    dropped — matches the TS ``flatMap`` returning ``[]``.
+    """
+    out: list[dict[str, Any]] = []
+    session_id = get_session_id()
+    for message in messages:
+        mapped = _map_one(message, session_id)
+        if mapped is not None:
+            out.append(mapped)
+    return out
+
+
+def _map_one(message: Message, session_id: str) -> dict[str, Any] | None:
+    """Map a single message to its SDK wire dict (or None to drop)."""
+    if isinstance(message, AssistantMessage):
+        return _assistant_to_sdk(message, session_id)
+    if isinstance(message, UserMessage):
+        return _user_to_sdk(message, session_id)
+    if isinstance(message, SystemMessage):
+        return _system_to_sdk(message, session_id)
+    # Other Message subtypes (progress, attachment, bare Message) are
+    # dropped — matches TS default branch returning [].
+    return None
+
+
+def _assistant_to_sdk(
+    message: AssistantMessage, session_id: str
+) -> dict[str, Any]:
+    """Mirror TS lines 118-128.
+
+    The inner ``message`` payload populates ``id``/``model``/``stop_reason``/
+    ``usage`` (when present on the source) — TS passes through the full
+    ``APIAssistantMessage`` and downstream consumers (Android
+    ``SdkAssistantMessage``, mobile-apps deserializers) expect these fields
+    to exist. See TS comment at ``mappers.ts:205-207``.
+    """
+    inner = _build_assistant_inner(message)
+    out: dict[str, Any] = {
+        'type': 'assistant',
+        'message': inner,
+        'session_id': session_id,
+        'parent_tool_use_id': None,
+        'uuid': message.uuid,
+    }
+    if message.error is not None:
+        out['error'] = message.error
+    return out
+
+
+def _user_to_sdk(message: UserMessage, session_id: str) -> dict[str, Any]:
+    """Mirror TS lines 130-147."""
+    inner = _build_user_inner(message)
+    out: dict[str, Any] = {
+        'type': 'user',
+        'message': inner,
+        'session_id': session_id,
+        'parent_tool_use_id': None,
+        'uuid': message.uuid,
+        'timestamp': message.timestamp,
+        'isSynthetic': _is_user_synthetic(message),
+    }
+    if message.toolUseResult is not None:
+        # Structured tool output — see TS comment lines 139-145 explaining
+        # why this rides on the protobuf catchall so web viewers can see
+        # things like BriefTool's file_uuid without polluting model context.
+        out['tool_use_result'] = message.toolUseResult
+    return out
+
+
+def _is_user_synthetic(message: UserMessage) -> bool:
+    """Per TS ``isSynthetic`` for user messages (``mappers.ts:138``):
+
+    ``message.isMeta || message.isVisibleInTranscriptOnly``
+
+    Python ``UserMessage`` has ``isMeta`` and ``isVirtual``; ``isVirtual``
+    is the closest analogue to TS ``isVisibleInTranscriptOnly`` (both
+    mean "not sent to the model, transcript-only"). Documented here so a
+    future porter doesn't reverse-engineer the mapping incorrectly.
+
+    Note: this is intentionally distinct from
+    ``src.utils.messages.is_synthetic`` — that helper covers assistant
+    messages too (model == SYNTHETIC_MODEL) and uses a different rule
+    for that case. The bridge wire format only needs the user-message
+    rule, so we keep it local.
+    """
+    return bool(message.isMeta or message.isVirtual)
+
+
+def _system_to_sdk(
+    message: SystemMessage, session_id: str
+) -> dict[str, Any] | None:
+    """Mirror TS lines 148-176.
+
+    Compact-boundary messages with metadata are emitted; local-command
+    messages are deferred (see module docstring).
+    """
+    if message.subtype == 'compact_boundary':
+        # Bare ``SystemMessage`` doesn't carry compactMetadata in the
+        # current Python type. Phase 5+ will add the field if needed —
+        # for now emit the system event without the metadata so the web
+        # UI at least knows a compaction happened.
+        meta = getattr(message, 'compactMetadata', None)
+        out: dict[str, Any] = {
+            'type': 'system',
+            'subtype': 'compact_boundary',
+            'session_id': session_id,
+            'uuid': message.uuid,
+        }
+        if meta is not None:
+            out['compact_metadata'] = _to_sdk_compact_metadata(meta)
+        return out
+    # local_command path deferred (see module docstring) — return None
+    # to drop, matching the TS ``return []`` fallthrough.
+    return None
+
+
+def _serialize_content(content: Any) -> Any:
+    """Convert a Message ``content`` field to its JSON-serializable form.
+
+    Lists get per-block conversion via ``content_block_to_dict``; strings
+    and other primitives pass through unchanged. Used by both the user
+    and assistant inner-message builders.
+    """
+    if isinstance(content, list):
+        return [
+            content_block_to_dict(b) if not isinstance(b, dict) else b
+            for b in content
+        ]
+    return content
+
+
+def _build_user_inner(message: UserMessage) -> dict[str, Any]:
+    """Build the inner ``message`` object for a user wire payload.
+
+    TS preserves ``message.message`` (the original API-shaped object).
+    Python doesn't carry that as a separate field; we reconstruct from
+    ``role`` + ``content`` so the wire shape matches Anthropic's
+    ``MessageParam``.
+    """
+    return {'role': message.role, 'content': _serialize_content(message.content)}
+
+
+def _build_assistant_inner(message: AssistantMessage) -> dict[str, Any]:
+    """Build the inner ``message`` object for an assistant wire payload.
+
+    Mirrors what TS ``SDKAssistantMessage.message`` carries: the full
+    ``APIAssistantMessage`` shape with ``id``, ``type``, ``role``,
+    ``model``, ``stop_reason``, ``usage``, ``content``. Downstream
+    consumers (Android ``SdkAssistantMessage`` deserializer, mobile-apps
+    parsers) require these fields — without them the message is rejected
+    or rendered malformed.
+
+    Python ``AssistantMessage`` doesn't carry an Anthropic-issued ``id``,
+    so we synthesize one from the message UUID (``msg_{uuid}``) which is
+    stable across re-emits and matches the wire-format prefix Anthropic
+    uses. ``type`` is always ``'message'`` (the only valid value).
+    Optional fields (``model``, ``stop_reason``, ``usage``) are emitted
+    when present on the source and elided when ``None`` to keep the
+    payload compact.
+    """
+    inner: dict[str, Any] = {
+        'id': f'msg_{message.uuid}',
+        'type': 'message',
+        'role': message.role,
+        'content': _serialize_content(message.content),
+    }
+    if message.model is not None:
+        inner['model'] = message.model
+    if message.stop_reason is not None:
+        inner['stop_reason'] = message.stop_reason
+    if message.usage is not None:
+        inner['usage'] = message.usage
+    return inner
+
+
+def _to_sdk_compact_metadata(meta: Any) -> dict[str, Any]:
+    """Mirror TS ``toSDKCompactMetadata`` on ``mappers.ts:78-93``.
+
+    Accepts either a dataclass-style object (``meta.trigger``,
+    ``meta.preTokens``, optional ``meta.preservedSegment``) or a dict.
+    Converts the inner ``preservedSegment`` camelCase keys to snake_case
+    wire format (``head_uuid``/``anchor_uuid``/``tail_uuid``).
+    """
+    def _attr(obj: Any, name: str) -> Any:
+        if isinstance(obj, dict):
+            return obj.get(name)
+        return getattr(obj, name, None)
+
+    out: dict[str, Any] = {
+        'trigger': _attr(meta, 'trigger'),
+        'pre_tokens': _attr(meta, 'preTokens'),
+    }
+    seg = _attr(meta, 'preservedSegment')
+    if seg is not None:
+        out['preserved_segment'] = {
+            'head_uuid': _attr(seg, 'headUuid'),
+            'anchor_uuid': _attr(seg, 'anchorUuid'),
+            'tail_uuid': _attr(seg, 'tailUuid'),
+        }
+    return out
+
+
+__all__ = ['to_sdk_messages']

--- a/src/utils/session_ingress_auth.py
+++ b/src/utils/session_ingress_auth.py
@@ -1,0 +1,114 @@
+"""Session-ingress auth token manager.
+
+Ports ``typescript/src/utils/sessionIngressAuth.ts``.
+
+Provides three primitives for the v2 bridge transport:
+
+* ``get_session_ingress_auth_token()`` — read the current token from
+  ``CLAUDE_CODE_SESSION_ACCESS_TOKEN`` env var. The TS implementation
+  also supports two fallbacks that the Python port intentionally skips:
+
+    * **File-descriptor fallback** (``CLAUDE_CODE_WEBSOCKET_AUTH_FILE_DESCRIPTOR``)
+      — needs ``fcntl`` + macOS/Linux ``/dev/fd`` vs ``/proc/self/fd``
+      branching; only used by the legacy CCR codepath.
+    * **Well-known file fallback** (``CLAUDE_SESSION_INGRESS_TOKEN_FILE``
+      or ``/home/claude/.claude/remote/.session_ingress_token``) — the
+      CCR subprocess hand-off path, not needed until CCR subprocess
+      spawning is ported (out of Phase 2 scope).
+
+  Both are deferred to a future phase that ports the CCR subprocess
+  stack; Phase 5 (``remoteBridgeCore``) reads the env var directly.
+
+* ``get_session_ingress_auth_headers()`` — build HTTP auth headers for
+  the current token. Session keys (``sk-ant-sid-*``) get cookie auth +
+  ``X-Organization-Uuid``; JWTs (everything else) get bearer auth.
+* ``update_session_ingress_auth_token(token)`` — set the env var in-process
+  for the next call (used by the REPL bridge to inject fresh JWTs after
+  token refresh without restarting the process).
+
+The CCRClient and SSETransport (``src/transports/``) already use
+``get_session_ingress_auth_token``-equivalent code via their ``GetAuthHeaders``
+callbacks. This module makes the canonical helper available to the
+broader bridge subsystem (Phase 5+ orchestrators) so per-instance
+callbacks aren't required for every call site.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+ENV_VAR_TOKEN = 'CLAUDE_CODE_SESSION_ACCESS_TOKEN'
+"""Env var holding the current session ingress token.
+
+Mirrors TS ``CLAUDE_CODE_SESSION_ACCESS_TOKEN`` references throughout
+``sessionIngressAuth.ts``.
+"""
+
+ENV_VAR_ORG_UUID = 'CLAUDE_CODE_ORGANIZATION_UUID'
+"""Env var holding the org UUID for session-key auth.
+
+Mirrors TS ``CLAUDE_CODE_ORGANIZATION_UUID`` on
+``sessionIngressAuth.ts:124``.
+"""
+
+_SESSION_KEY_PREFIX = 'sk-ant-sid'
+
+
+def get_session_ingress_auth_token() -> str | None:
+    """Return the current session-ingress auth token, or ``None``.
+
+    Mirrors the env-var portion of TS ``getSessionIngressAuthToken`` on
+    ``sessionIngressAuth.ts:101-110``. The TS function also falls back
+    to file-descriptor reading and a well-known file path; this Python
+    port skips both because no v2 caller uses them (env-var-only path
+    covers the bridge orchestrator and the REPL bridge transport refresh
+    flow).
+    """
+    value = os.environ.get(ENV_VAR_TOKEN)
+    return value or None
+
+
+def get_session_ingress_auth_headers() -> dict[str, str]:
+    """Build HTTP auth headers for the current session-ingress token.
+
+    Mirrors TS ``getSessionIngressAuthHeaders`` on
+    ``sessionIngressAuth.ts:117-131``.
+
+    * Session keys (``sk-ant-sid-*``): cookie auth via ``sessionKey=…``,
+      plus ``X-Organization-Uuid`` when ``CLAUDE_CODE_ORGANIZATION_UUID``
+      is set.
+    * JWTs (everything else): bearer auth via ``Authorization: Bearer …``.
+    * No token: empty dict.
+    """
+    token = get_session_ingress_auth_token()
+    if not token:
+        return {}
+    if token.startswith(_SESSION_KEY_PREFIX):
+        headers = {'Cookie': f'sessionKey={token}'}
+        org_uuid = os.environ.get(ENV_VAR_ORG_UUID)
+        if org_uuid:
+            headers['X-Organization-Uuid'] = org_uuid
+        return headers
+    return {'Authorization': f'Bearer {token}'}
+
+
+def update_session_ingress_auth_token(token: str) -> None:
+    """Update the session-ingress token in-process via the env var.
+
+    Mirrors TS ``updateSessionIngressAuthToken`` on
+    ``sessionIngressAuth.ts:138-140``. Used by the REPL bridge / Phase 5
+    orchestrator to inject a fresh JWT after token refresh without
+    restarting the process. Subsequent calls to
+    ``get_session_ingress_auth_token`` / ``_headers`` see the new value.
+    """
+    os.environ[ENV_VAR_TOKEN] = token
+
+
+__all__ = [
+    'ENV_VAR_ORG_UUID',
+    'ENV_VAR_TOKEN',
+    'get_session_ingress_auth_headers',
+    'get_session_ingress_auth_token',
+    'update_session_ingress_auth_token',
+]

--- a/src/utils/teleport/__init__.py
+++ b/src/utils/teleport/__init__.py
@@ -1,0 +1,11 @@
+"""Teleport utilities package.
+
+Mirrors ``typescript/src/utils/teleport/``. Only the consumer-facing
+``api.get_oauth_headers`` is ported in Phase 2 — the rest of the
+teleport stack (peer discovery, message relay) is out of scope for the
+bridge orchestrator port.
+"""
+
+from src.utils.teleport.api import ANTHROPIC_VERSION, get_oauth_headers
+
+__all__ = ['ANTHROPIC_VERSION', 'get_oauth_headers']

--- a/src/utils/teleport/api.py
+++ b/src/utils/teleport/api.py
@@ -1,0 +1,40 @@
+"""HTTP header builder for OAuth-authenticated requests.
+
+Ports the consumer-facing ``getOAuthHeaders`` helper from
+``typescript/src/utils/teleport/api.ts``. The rest of the TS file (the
+teleport API client) is out of scope for the bridge orchestrator port.
+
+Used by ``createSession.ts``, ``archiveBridgeSession``,
+``updateBridgeSessionTitle``, and the v1 ``bridgeApi.ts`` to build the
+standard ``Authorization`` + ``anthropic-version`` + ``Content-Type``
+header set for OAuth-authed requests.
+"""
+
+from __future__ import annotations
+
+
+ANTHROPIC_VERSION = '2023-06-01'
+"""Anthropic API version header value.
+
+Mirrors TS hardcoded ``'anthropic-version': '2023-06-01'`` used across
+the codebase. Centralized here to match TS's pattern of building it
+into ``getOAuthHeaders``.
+"""
+
+
+def get_oauth_headers(access_token: str) -> dict[str, str]:
+    """Build the OAuth-auth header set for an HTTP request.
+
+    Mirrors TS ``getOAuthHeaders`` on ``utils/teleport/api.ts``. Returns
+    a fresh dict so callers can ``.update()`` it with request-specific
+    headers (e.g. ``anthropic-beta``, ``x-organization-uuid``) without
+    mutating shared state.
+    """
+    return {
+        'Authorization': f'Bearer {access_token}',
+        'Content-Type': 'application/json',
+        'anthropic-version': ANTHROPIC_VERSION,
+    }
+
+
+__all__ = ['ANTHROPIC_VERSION', 'get_oauth_headers']

--- a/tests/auth/test_claude_ai.py
+++ b/tests/auth/test_claude_ai.py
@@ -1,0 +1,341 @@
+"""Tests for ``src.auth.claude_ai``."""
+
+from __future__ import annotations
+
+import os
+import time
+from unittest.mock import patch
+
+import pytest
+
+from src.auth.claude_ai import (
+    ENV_ACCESS_TOKEN,
+    ENV_EXPIRES_AT,
+    ENV_ORG_UUID,
+    ENV_REFRESH_FAILED,
+    ENV_REFRESH_TOKEN,
+    ENV_SCOPES,
+    ENV_SUBSCRIBER_OVERRIDE,
+    OAuthAccountInfo,
+    check_and_refresh_oauth_token_if_needed,
+    get_claude_ai_oauth_tokens,
+    get_oauth_account_info,
+    handle_oauth_401_error,
+    has_profile_scope,
+    is_claude_ai_subscriber,
+)
+from src.auth.oauth import OAuthTokens
+
+
+def _no_claude_env() -> dict[str, str]:
+    return {
+        k: v for k, v in os.environ.items()
+        if not k.startswith('CLAUDE_AI_')
+    }
+
+
+# ---------------------------------------------------------------------------
+# get_claude_ai_oauth_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_tokens_none_when_no_access_token() -> None:
+    with patch.dict(os.environ, _no_claude_env(), clear=True):
+        assert get_claude_ai_oauth_tokens() is None
+
+
+def test_tokens_returns_oauth_tokens_with_access_token() -> None:
+    env = _no_claude_env() | {ENV_ACCESS_TOKEN: 'tok-abc'}
+    with patch.dict(os.environ, env, clear=True):
+        tokens = get_claude_ai_oauth_tokens()
+    assert tokens is not None
+    assert isinstance(tokens, OAuthTokens)
+    assert tokens.access_token == 'tok-abc'
+    assert tokens.refresh_token == ''
+    assert tokens.token_type == 'Bearer'
+
+
+def test_tokens_uses_explicit_refresh_token() -> None:
+    env = _no_claude_env() | {
+        ENV_ACCESS_TOKEN: 'tok-abc',
+        ENV_REFRESH_TOKEN: 'ref-xyz',
+    }
+    with patch.dict(os.environ, env, clear=True):
+        tokens = get_claude_ai_oauth_tokens()
+    assert tokens is not None
+    assert tokens.refresh_token == 'ref-xyz'
+
+
+def test_tokens_parses_expires_at() -> None:
+    env = _no_claude_env() | {
+        ENV_ACCESS_TOKEN: 'tok',
+        ENV_EXPIRES_AT: '1800000000',
+    }
+    with patch.dict(os.environ, env, clear=True):
+        tokens = get_claude_ai_oauth_tokens()
+    assert tokens is not None
+    assert tokens.expires_at == 1800000000.0
+
+
+def test_tokens_falls_back_for_unparseable_expires() -> None:
+    """Garbage in expires_at → 0.0 (treated as unknown)."""
+    env = _no_claude_env() | {
+        ENV_ACCESS_TOKEN: 'tok',
+        ENV_EXPIRES_AT: 'not-a-number',
+    }
+    with patch.dict(os.environ, env, clear=True):
+        tokens = get_claude_ai_oauth_tokens()
+    assert tokens is not None
+    assert tokens.expires_at == 0.0
+
+
+def test_tokens_defaults_expires_at_to_zero_when_unset() -> None:
+    """No expires_at env → 0.0 (unknown), matches absence-of-expiry on
+    imported tokens. ``_is_near_or_past_expiry`` treats this as not
+    expiring so refresh warnings don't fire on dev tokens.
+    """
+    env = _no_claude_env() | {ENV_ACCESS_TOKEN: 'tok'}
+    with patch.dict(os.environ, env, clear=True):
+        tokens = get_claude_ai_oauth_tokens()
+    assert tokens is not None
+    assert tokens.expires_at == 0.0
+
+
+# ---------------------------------------------------------------------------
+# get_oauth_account_info
+# ---------------------------------------------------------------------------
+
+
+def test_account_info_none_without_org_uuid() -> None:
+    with patch.dict(os.environ, _no_claude_env(), clear=True):
+        assert get_oauth_account_info() is None
+
+
+def test_account_info_returns_org_uuid_when_set() -> None:
+    env = _no_claude_env() | {ENV_ORG_UUID: 'org-123'}
+    with patch.dict(os.environ, env, clear=True):
+        info = get_oauth_account_info()
+    assert isinstance(info, OAuthAccountInfo)
+    assert info.organization_uuid == 'org-123'
+
+
+def test_account_info_picks_up_subscriber_override() -> None:
+    env = _no_claude_env() | {
+        ENV_ORG_UUID: 'org-1',
+        ENV_SUBSCRIBER_OVERRIDE: 'true',
+    }
+    with patch.dict(os.environ, env, clear=True):
+        info = get_oauth_account_info()
+    assert info is not None
+    assert info.is_subscriber is True
+
+
+# ---------------------------------------------------------------------------
+# is_claude_ai_subscriber
+# ---------------------------------------------------------------------------
+
+
+def test_subscriber_false_when_no_token_and_no_override() -> None:
+    with patch.dict(os.environ, _no_claude_env(), clear=True):
+        assert is_claude_ai_subscriber() is False
+
+
+def test_subscriber_false_when_token_lacks_inference_scope() -> None:
+    """Per TS: needs ``user:inference`` scope, not just any token."""
+    env = _no_claude_env() | {ENV_ACCESS_TOKEN: 'tok'}
+    with patch.dict(os.environ, env, clear=True):
+        assert is_claude_ai_subscriber() is False
+
+
+def test_subscriber_false_when_only_other_scopes() -> None:
+    """``api`` or ``user:profile`` alone do not grant subscriber status."""
+    env = _no_claude_env() | {
+        ENV_ACCESS_TOKEN: 'tok',
+        ENV_SCOPES: 'api user:profile',
+    }
+    with patch.dict(os.environ, env, clear=True):
+        assert is_claude_ai_subscriber() is False
+
+
+def test_subscriber_true_when_inference_scope_present() -> None:
+    env = _no_claude_env() | {
+        ENV_ACCESS_TOKEN: 'tok',
+        ENV_SCOPES: 'api user:inference',
+    }
+    with patch.dict(os.environ, env, clear=True):
+        assert is_claude_ai_subscriber() is True
+
+
+def test_subscriber_override_false_wins_over_token() -> None:
+    env = _no_claude_env() | {
+        ENV_ACCESS_TOKEN: 'tok',
+        ENV_SCOPES: 'user:inference',
+        ENV_SUBSCRIBER_OVERRIDE: 'false',
+    }
+    with patch.dict(os.environ, env, clear=True):
+        assert is_claude_ai_subscriber() is False
+
+
+def test_subscriber_override_true_wins_over_no_token() -> None:
+    env = _no_claude_env() | {ENV_SUBSCRIBER_OVERRIDE: '1'}
+    with patch.dict(os.environ, env, clear=True):
+        assert is_claude_ai_subscriber() is True
+
+
+# ---------------------------------------------------------------------------
+# has_profile_scope
+# ---------------------------------------------------------------------------
+
+
+def test_profile_scope_false_when_no_token() -> None:
+    with patch.dict(os.environ, _no_claude_env(), clear=True):
+        assert has_profile_scope() is False
+
+
+def test_profile_scope_false_when_scope_unset() -> None:
+    env = _no_claude_env() | {ENV_ACCESS_TOKEN: 'tok'}
+    with patch.dict(os.environ, env, clear=True):
+        assert has_profile_scope() is False
+
+
+def test_profile_scope_true_when_present() -> None:
+    env = _no_claude_env() | {
+        ENV_ACCESS_TOKEN: 'tok',
+        ENV_SCOPES: 'api user:profile',
+    }
+    with patch.dict(os.environ, env, clear=True):
+        assert has_profile_scope() is True
+
+
+def test_profile_scope_false_when_other_scopes() -> None:
+    env = _no_claude_env() | {
+        ENV_ACCESS_TOKEN: 'tok',
+        ENV_SCOPES: 'api',
+    }
+    with patch.dict(os.environ, env, clear=True):
+        assert has_profile_scope() is False
+
+
+def test_profile_scope_does_not_partial_match() -> None:
+    """``user:profile`` is required as a whole token, not as a substring."""
+    env = _no_claude_env() | {
+        ENV_ACCESS_TOKEN: 'tok',
+        ENV_SCOPES: 'api user:profile_other',
+    }
+    with patch.dict(os.environ, env, clear=True):
+        assert has_profile_scope() is False
+
+
+# ---------------------------------------------------------------------------
+# check_and_refresh_oauth_token_if_needed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_noop_when_no_token() -> None:
+    with patch.dict(os.environ, _no_claude_env(), clear=True):
+        # Should not raise.
+        await check_and_refresh_oauth_token_if_needed()
+
+
+@pytest.mark.asyncio
+async def test_refresh_noop_when_token_not_near_expiry() -> None:
+    env = _no_claude_env() | {
+        ENV_ACCESS_TOKEN: 'tok',
+        ENV_EXPIRES_AT: str(time.time() + 3600),
+    }
+    with patch.dict(os.environ, env, clear=True):
+        await check_and_refresh_oauth_token_if_needed()
+
+
+@pytest.mark.asyncio
+async def test_refresh_noop_when_expires_unknown() -> None:
+    """expires_at=0 → unknown — don't refresh (matches TS)."""
+    env = _no_claude_env() | {
+        ENV_ACCESS_TOKEN: 'tok',
+        ENV_EXPIRES_AT: '0',
+    }
+    with patch.dict(os.environ, env, clear=True):
+        await check_and_refresh_oauth_token_if_needed()
+
+
+# ---------------------------------------------------------------------------
+# handle_oauth_401_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_401_returns_true_when_token_present() -> None:
+    env = _no_claude_env() | {ENV_ACCESS_TOKEN: 'tok'}
+    with patch.dict(os.environ, env, clear=True):
+        assert await handle_oauth_401_error() is True
+
+
+@pytest.mark.asyncio
+async def test_handle_401_returns_false_when_no_token() -> None:
+    with patch.dict(os.environ, _no_claude_env(), clear=True):
+        assert await handle_oauth_401_error() is False
+
+
+@pytest.mark.asyncio
+async def test_handle_401_returns_false_when_refresh_failure_set() -> None:
+    env = _no_claude_env() | {
+        ENV_ACCESS_TOKEN: 'tok',
+        ENV_REFRESH_FAILED: '1',
+    }
+    with patch.dict(os.environ, env, clear=True):
+        assert await handle_oauth_401_error() is False
+
+
+@pytest.mark.asyncio
+async def test_handle_401_accepts_stale_token_kwarg() -> None:
+    """The ``stale_token`` arg is accepted (Phase 10 will use it)."""
+    env = _no_claude_env() | {ENV_ACCESS_TOKEN: 'tok'}
+    with patch.dict(os.environ, env, clear=True):
+        assert await handle_oauth_401_error(stale_token='old') is True
+
+
+# ---------------------------------------------------------------------------
+# No-op stub warnings (CRITIC follow-up: make silent staleness loud)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_and_refresh_warns_when_token_near_expiry(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A near-expiry token should emit a WARNING that refresh is a no-op."""
+    env = _no_claude_env() | {
+        ENV_ACCESS_TOKEN: 'tok',
+        ENV_EXPIRES_AT: str(time.time() + 10),  # 10s out — within buffer
+    }
+    with patch.dict(os.environ, env, clear=True):
+        with caplog.at_level('WARNING', logger='src.auth.claude_ai'):
+            await check_and_refresh_oauth_token_if_needed()
+    assert any('no-op stub' in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_check_and_refresh_no_warning_when_token_fresh(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    env = _no_claude_env() | {
+        ENV_ACCESS_TOKEN: 'tok',
+        ENV_EXPIRES_AT: str(time.time() + 3600),
+    }
+    with patch.dict(os.environ, env, clear=True):
+        with caplog.at_level('WARNING', logger='src.auth.claude_ai'):
+            await check_and_refresh_oauth_token_if_needed()
+    assert not any('no-op stub' in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_handle_401_warns_when_token_present(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``handle_oauth_401_error`` must warn that refresh is a no-op."""
+    env = _no_claude_env() | {ENV_ACCESS_TOKEN: 'tok'}
+    with patch.dict(os.environ, env, clear=True):
+        with caplog.at_level('WARNING', logger='src.auth.claude_ai'):
+            await handle_oauth_401_error()
+    assert any('no-op stub' in rec.message for rec in caplog.records)

--- a/tests/services/test_oauth_client.py
+++ b/tests/services/test_oauth_client.py
@@ -1,0 +1,28 @@
+"""Tests for ``src.services.oauth.client``."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from src.auth.claude_ai import ENV_ORG_UUID
+from src.services.oauth.client import get_organization_uuid
+
+
+def _no_claude_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if not k.startswith('CLAUDE_AI_')}
+
+
+@pytest.mark.asyncio
+async def test_get_organization_uuid_none_when_unset() -> None:
+    with patch.dict(os.environ, _no_claude_env(), clear=True):
+        assert await get_organization_uuid() is None
+
+
+@pytest.mark.asyncio
+async def test_get_organization_uuid_returns_env_value() -> None:
+    env = _no_claude_env() | {ENV_ORG_UUID: 'org-abc'}
+    with patch.dict(os.environ, env, clear=True):
+        assert await get_organization_uuid() == 'org-abc'

--- a/tests/utils/test_combined_abort_signal.py
+++ b/tests/utils/test_combined_abort_signal.py
@@ -1,0 +1,134 @@
+"""Tests for ``src.utils.combined_abort_signal``."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.utils.abort_controller import create_abort_controller
+from src.utils.combined_abort_signal import (
+    CombinedAbortSignal,
+    create_combined_abort_signal,
+)
+
+
+def test_primary_abort_propagates() -> None:
+    parent = create_abort_controller()
+    combined = create_combined_abort_signal(parent.signal)
+    assert not combined.signal.aborted
+    parent.abort('parent')
+    assert combined.signal.aborted
+    assert combined.signal.reason == 'parent'
+    combined.cleanup()
+
+
+def test_secondary_abort_propagates() -> None:
+    a = create_abort_controller()
+    b = create_abort_controller()
+    combined = create_combined_abort_signal(a.signal, secondary=b.signal)
+    b.abort('secondary-source')
+    assert combined.signal.aborted
+    assert combined.signal.reason == 'secondary-source'
+    combined.cleanup()
+
+
+def test_either_input_aborts_returns_pre_aborted_with_noop_cleanup() -> None:
+    """If primary is already aborted on entry, return pre-aborted signal."""
+    a = create_abort_controller()
+    a.abort('pre')
+    combined = create_combined_abort_signal(a.signal)
+    assert combined.signal.aborted
+    assert combined.signal.reason == 'pre'
+    # cleanup must be safe to call.
+    combined.cleanup()
+    combined.cleanup()  # idempotent
+
+
+def test_secondary_pre_aborted_short_circuits() -> None:
+    a = create_abort_controller()
+    b = create_abort_controller()
+    b.abort('secondary-pre')
+    combined = create_combined_abort_signal(a.signal, secondary=b.signal)
+    assert combined.signal.aborted
+    assert combined.signal.reason == 'secondary-pre'
+
+
+def test_no_inputs_returns_unaborted_signal() -> None:
+    """All-None inputs are legal — caller may add the timeout only."""
+    combined = create_combined_abort_signal(None)
+    assert not combined.signal.aborted
+    combined.cleanup()
+
+
+def test_cleanup_removes_listener_from_parent() -> None:
+    """After cleanup, aborting the parent must NOT fire the combined signal."""
+    parent = create_abort_controller()
+    combined = create_combined_abort_signal(parent.signal)
+    combined.cleanup()
+    parent.abort('after-cleanup')
+    assert not combined.signal.aborted
+
+
+def test_cleanup_is_idempotent() -> None:
+    parent = create_abort_controller()
+    combined = create_combined_abort_signal(parent.signal)
+    combined.cleanup()
+    combined.cleanup()
+    combined.cleanup()  # no exception
+
+
+@pytest.mark.asyncio
+async def test_timeout_aborts_combined_signal() -> None:
+    combined = create_combined_abort_signal(None, timeout_seconds=0.05)
+    await asyncio.sleep(0.1)
+    assert combined.signal.aborted
+    assert combined.signal.reason == 'timeout'
+    combined.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_cancels_timer() -> None:
+    """If caller cleans up before the timeout fires, the signal stays alive."""
+    combined = create_combined_abort_signal(None, timeout_seconds=10.0)
+    combined.cleanup()
+    await asyncio.sleep(0.02)
+    assert not combined.signal.aborted
+
+
+@pytest.mark.asyncio
+async def test_primary_abort_cancels_pending_timer() -> None:
+    """When the parent aborts first, the timer should be cleaned up."""
+    parent = create_abort_controller()
+    combined = create_combined_abort_signal(
+        parent.signal, timeout_seconds=10.0
+    )
+    parent.abort('parent-wins')
+    await asyncio.sleep(0.02)
+    assert combined.signal.aborted
+    assert combined.signal.reason == 'parent-wins'
+
+
+@pytest.mark.asyncio
+async def test_pre_aborted_short_circuit_does_not_arm_timer() -> None:
+    """Short-circuit path: no timer is created, even if timeout is provided."""
+    parent = create_abort_controller()
+    parent.abort('pre')
+    # Should not raise RuntimeError("no running event loop") even when
+    # called without one — but we're in an asyncio context here so the
+    # alternative path would not raise either; the real assertion is that
+    # the timer doesn't fire and cleanup is a no-op.
+    combined = create_combined_abort_signal(
+        parent.signal, timeout_seconds=0.01
+    )
+    await asyncio.sleep(0.05)
+    # Reason should still be 'pre', not 'timeout'.
+    assert combined.signal.reason == 'pre'
+
+
+def test_returns_combined_abort_signal_dataclass() -> None:
+    parent = create_abort_controller()
+    combined = create_combined_abort_signal(parent.signal)
+    assert isinstance(combined, CombinedAbortSignal)
+    assert hasattr(combined, 'signal')
+    assert hasattr(combined, 'cleanup')

--- a/tests/utils/test_message_mappers.py
+++ b/tests/utils/test_message_mappers.py
@@ -1,0 +1,219 @@
+"""Tests for ``src.utils.message_mappers.to_sdk_messages``."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from src.types.messages import (
+    AssistantMessage,
+    Message,
+    ProgressMessage,
+    SystemMessage,
+    UserMessage,
+)
+from src.utils.message_mappers import to_sdk_messages
+
+
+@patch('src.utils.message_mappers.get_session_id', return_value='sess-test')
+def test_empty_input_returns_empty_list(_mock: Any) -> None:
+    assert to_sdk_messages([]) == []
+
+
+@patch('src.utils.message_mappers.get_session_id', return_value='sess-1')
+def test_user_message_maps_to_user_sdk_shape(_mock: Any) -> None:
+    msg = UserMessage(content='hello', uuid='u-1', timestamp='2026-05-23T00:00:00')
+    [out] = to_sdk_messages([msg])
+    assert out['type'] == 'user'
+    assert out['session_id'] == 'sess-1'
+    assert out['parent_tool_use_id'] is None
+    assert out['uuid'] == 'u-1'
+    assert out['timestamp'] == '2026-05-23T00:00:00'
+    assert out['isSynthetic'] is False
+    assert out['message'] == {'role': 'user', 'content': 'hello'}
+
+
+@patch('src.utils.message_mappers.get_session_id', return_value='sess-1')
+def test_user_message_sets_isSynthetic_when_isMeta(_mock: Any) -> None:
+    msg = UserMessage(content='nudge', uuid='u-2', isMeta=True)
+    [out] = to_sdk_messages([msg])
+    assert out['isSynthetic'] is True
+
+
+@patch('src.utils.message_mappers.get_session_id', return_value='sess-1')
+def test_user_message_sets_isSynthetic_when_isVirtual(_mock: Any) -> None:
+    msg = UserMessage(content='hidden', uuid='u-3', isVirtual=True)
+    [out] = to_sdk_messages([msg])
+    assert out['isSynthetic'] is True
+
+
+@patch('src.utils.message_mappers.get_session_id', return_value='sess-1')
+def test_user_message_omits_tool_use_result_when_none(_mock: Any) -> None:
+    msg = UserMessage(content='hi', uuid='u-4')
+    [out] = to_sdk_messages([msg])
+    assert 'tool_use_result' not in out
+
+
+@patch('src.utils.message_mappers.get_session_id', return_value='sess-1')
+def test_user_message_includes_tool_use_result_when_set(_mock: Any) -> None:
+    msg = UserMessage(
+        content='hi',
+        uuid='u-5',
+        toolUseResult={'output': 'ok', 'file_uuid': 'f-1'},
+    )
+    [out] = to_sdk_messages([msg])
+    assert out['tool_use_result'] == {'output': 'ok', 'file_uuid': 'f-1'}
+
+
+@patch('src.utils.message_mappers.get_session_id', return_value='sess-1')
+def test_assistant_message_maps_to_assistant_sdk_shape(_mock: Any) -> None:
+    msg = AssistantMessage(content='reply', uuid='a-1')
+    [out] = to_sdk_messages([msg])
+    assert out['type'] == 'assistant'
+    assert out['session_id'] == 'sess-1'
+    assert out['parent_tool_use_id'] is None
+    assert out['uuid'] == 'a-1'
+    # ``message`` must include id/type/role/content for downstream parsers.
+    assert out['message']['id'] == 'msg_a-1'
+    assert out['message']['type'] == 'message'
+    assert out['message']['role'] == 'assistant'
+    assert out['message']['content'] == 'reply'
+    assert 'error' not in out
+
+
+@patch('src.utils.message_mappers.get_session_id', return_value='sess-1')
+def test_assistant_message_preserves_model_stop_reason_usage(_mock: Any) -> None:
+    """Regression test: id/model/stop_reason/usage must survive the mapping.
+
+    Per CRITIC blocking fix: TS preserves the full ``APIAssistantMessage``
+    so Android ``SdkAssistantMessage`` and mobile-apps deserializers can
+    parse the wire payload. Previously the Python port stripped these
+    fields, producing structurally-thin messages.
+    """
+    msg = AssistantMessage(
+        content='reply',
+        uuid='a-2',
+        model='claude-opus-4-7',
+        stop_reason='end_turn',
+        usage={'input_tokens': 10, 'output_tokens': 20},
+    )
+    [out] = to_sdk_messages([msg])
+    inner = out['message']
+    assert inner['id'] == 'msg_a-2'
+    assert inner['type'] == 'message'
+    assert inner['role'] == 'assistant'
+    assert inner['model'] == 'claude-opus-4-7'
+    assert inner['stop_reason'] == 'end_turn'
+    assert inner['usage'] == {'input_tokens': 10, 'output_tokens': 20}
+
+
+@patch('src.utils.message_mappers.get_session_id', return_value='sess-1')
+def test_assistant_message_omits_optional_fields_when_none(_mock: Any) -> None:
+    """Optional fields are elided when ``None`` on the source."""
+    msg = AssistantMessage(content='r', uuid='a-3')  # model/stop_reason/usage all None
+    [out] = to_sdk_messages([msg])
+    inner = out['message']
+    assert 'model' not in inner
+    assert 'stop_reason' not in inner
+    assert 'usage' not in inner
+
+
+@patch('src.utils.message_mappers.get_session_id', return_value='sess-1')
+def test_assistant_message_includes_error_when_set(_mock: Any) -> None:
+    msg = AssistantMessage(
+        content='', uuid='a-2', error={'type': 'overloaded'}
+    )
+    [out] = to_sdk_messages([msg])
+    assert out['error'] == {'type': 'overloaded'}
+
+
+@patch('src.utils.message_mappers.get_session_id', return_value='sess-1')
+def test_assistant_message_with_list_content_serializes_blocks(
+    _mock: Any,
+) -> None:
+    """Content list (e.g. text + tool_use) gets passed through to dict form."""
+    msg = AssistantMessage(
+        content=[{'type': 'text', 'text': 'hi'}],
+        uuid='a-3',
+    )
+    [out] = to_sdk_messages([msg])
+    assert out['message']['role'] == 'assistant'
+    assert out['message']['content'] == [{'type': 'text', 'text': 'hi'}]
+
+
+@patch('src.utils.message_mappers.get_session_id', return_value='sess-1')
+def test_system_compact_boundary_maps_to_system_sdk(_mock: Any) -> None:
+    msg = SystemMessage(
+        content='Conversation compacted',
+        uuid='s-1',
+        subtype='compact_boundary',
+    )
+    [out] = to_sdk_messages([msg])
+    assert out == {
+        'type': 'system',
+        'subtype': 'compact_boundary',
+        'session_id': 'sess-1',
+        'uuid': 's-1',
+    }
+
+
+@patch('src.utils.message_mappers.get_session_id', return_value='sess-1')
+def test_system_compact_boundary_includes_metadata_when_present(
+    _mock: Any,
+) -> None:
+    """Compact metadata is converted with camelCase→snake_case."""
+    meta = {
+        'trigger': 'auto',
+        'preTokens': 12345,
+        'preservedSegment': {
+            'headUuid': 'h-1',
+            'anchorUuid': 'a-1',
+            'tailUuid': 't-1',
+        },
+    }
+    msg = SystemMessage(
+        content='compact',
+        uuid='s-2',
+        subtype='compact_boundary',
+    )
+    msg.compactMetadata = meta  # type: ignore[attr-defined]
+    [out] = to_sdk_messages([msg])
+    assert out['compact_metadata'] == {
+        'trigger': 'auto',
+        'pre_tokens': 12345,
+        'preserved_segment': {
+            'head_uuid': 'h-1',
+            'anchor_uuid': 'a-1',
+            'tail_uuid': 't-1',
+        },
+    }
+
+
+@patch('src.utils.message_mappers.get_session_id', return_value='sess-1')
+def test_system_local_command_is_deferred(_mock: Any) -> None:
+    """The local_command path is deferred per module docstring — dropped."""
+    msg = SystemMessage(
+        content='<local-command-stdout>hi</local-command-stdout>',
+        uuid='s-3',
+        subtype='local_command',
+    )
+    assert to_sdk_messages([msg]) == []
+
+
+@patch('src.utils.message_mappers.get_session_id', return_value='sess-1')
+def test_progress_message_is_dropped(_mock: Any) -> None:
+    """Non-user/assistant/system_compact messages are silently dropped."""
+    msg = ProgressMessage(content='', uuid='p-1', toolUseID='t-1')
+    assert to_sdk_messages([msg]) == []
+
+
+@patch('src.utils.message_mappers.get_session_id', return_value='sess-1')
+def test_mixed_messages_preserves_order(_mock: Any) -> None:
+    msgs: list[Message] = [
+        UserMessage(content='1', uuid='u-1'),
+        AssistantMessage(content='2', uuid='a-1'),
+        UserMessage(content='3', uuid='u-2'),
+    ]
+    out = to_sdk_messages(msgs)
+    assert [m['uuid'] for m in out] == ['u-1', 'a-1', 'u-2']
+    assert [m['type'] for m in out] == ['user', 'assistant', 'user']

--- a/tests/utils/test_session_ingress_auth.py
+++ b/tests/utils/test_session_ingress_auth.py
@@ -1,0 +1,100 @@
+"""Tests for ``src.utils.session_ingress_auth``."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from src.utils.session_ingress_auth import (
+    ENV_VAR_ORG_UUID,
+    ENV_VAR_TOKEN,
+    get_session_ingress_auth_headers,
+    get_session_ingress_auth_token,
+    update_session_ingress_auth_token,
+)
+
+
+def _no_si_env() -> dict[str, str]:
+    """Env without the session-ingress vars."""
+    return {
+        k: v for k, v in os.environ.items()
+        if k not in (ENV_VAR_TOKEN, ENV_VAR_ORG_UUID)
+    }
+
+
+def test_get_token_returns_env_value() -> None:
+    env = _no_si_env() | {ENV_VAR_TOKEN: 'jwt-abc'}
+    with patch.dict(os.environ, env, clear=True):
+        assert get_session_ingress_auth_token() == 'jwt-abc'
+
+
+def test_get_token_returns_none_when_unset() -> None:
+    with patch.dict(os.environ, _no_si_env(), clear=True):
+        assert get_session_ingress_auth_token() is None
+
+
+def test_get_token_returns_none_when_empty_string() -> None:
+    """Empty string treated as unset (matches TS truthy check)."""
+    env = _no_si_env() | {ENV_VAR_TOKEN: ''}
+    with patch.dict(os.environ, env, clear=True):
+        assert get_session_ingress_auth_token() is None
+
+
+def test_headers_empty_when_no_token() -> None:
+    with patch.dict(os.environ, _no_si_env(), clear=True):
+        assert get_session_ingress_auth_headers() == {}
+
+
+def test_headers_bearer_for_jwt_token() -> None:
+    """JWTs (anything not ``sk-ant-sid-*``) use bearer auth."""
+    env = _no_si_env() | {ENV_VAR_TOKEN: 'eyJhbGc.payload.sig'}
+    with patch.dict(os.environ, env, clear=True):
+        h = get_session_ingress_auth_headers()
+    assert h == {'Authorization': 'Bearer eyJhbGc.payload.sig'}
+
+
+def test_headers_cookie_for_session_key() -> None:
+    """``sk-ant-sid-*`` tokens use cookie auth, no Authorization header."""
+    env = _no_si_env() | {ENV_VAR_TOKEN: 'sk-ant-sid-abc'}
+    with patch.dict(os.environ, env, clear=True):
+        h = get_session_ingress_auth_headers()
+    assert h == {'Cookie': 'sessionKey=sk-ant-sid-abc'}
+
+
+def test_headers_cookie_includes_org_uuid_when_set() -> None:
+    """Session-key auth pulls ``X-Organization-Uuid`` from env."""
+    env = _no_si_env() | {
+        ENV_VAR_TOKEN: 'sk-ant-sid-abc',
+        ENV_VAR_ORG_UUID: 'org-123',
+    }
+    with patch.dict(os.environ, env, clear=True):
+        h = get_session_ingress_auth_headers()
+    assert h == {
+        'Cookie': 'sessionKey=sk-ant-sid-abc',
+        'X-Organization-Uuid': 'org-123',
+    }
+
+
+def test_headers_cookie_omits_org_uuid_when_unset() -> None:
+    env = _no_si_env() | {ENV_VAR_TOKEN: 'sk-ant-sid-abc'}
+    with patch.dict(os.environ, env, clear=True):
+        h = get_session_ingress_auth_headers()
+    assert 'X-Organization-Uuid' not in h
+
+
+def test_update_token_sets_env_var_for_subsequent_calls() -> None:
+    with patch.dict(os.environ, _no_si_env(), clear=True):
+        assert get_session_ingress_auth_token() is None
+        update_session_ingress_auth_token('jwt-new')
+        assert get_session_ingress_auth_token() == 'jwt-new'
+        # Headers reflect the new token immediately.
+        assert get_session_ingress_auth_headers() == {
+            'Authorization': 'Bearer jwt-new'
+        }
+
+
+def test_update_token_overwrites_previous_value() -> None:
+    env = _no_si_env() | {ENV_VAR_TOKEN: 'jwt-old'}
+    with patch.dict(os.environ, env, clear=True):
+        update_session_ingress_auth_token('jwt-new')
+        assert get_session_ingress_auth_token() == 'jwt-new'

--- a/tests/utils/test_teleport_api.py
+++ b/tests/utils/test_teleport_api.py
@@ -1,0 +1,31 @@
+"""Tests for ``src.utils.teleport.api``."""
+
+from __future__ import annotations
+
+from src.utils.teleport.api import ANTHROPIC_VERSION, get_oauth_headers
+
+
+def test_anthropic_version_matches_ts() -> None:
+    assert ANTHROPIC_VERSION == '2023-06-01'
+
+
+def test_get_oauth_headers_shape() -> None:
+    h = get_oauth_headers('tok-xyz')
+    assert h == {
+        'Authorization': 'Bearer tok-xyz',
+        'Content-Type': 'application/json',
+        'anthropic-version': '2023-06-01',
+    }
+
+
+def test_get_oauth_headers_returns_fresh_dict_each_call() -> None:
+    """Callers ``.update()`` the result; must not share state."""
+    a = get_oauth_headers('tok')
+    b = get_oauth_headers('tok')
+    a['x-test'] = 'mutated'
+    assert 'x-test' not in b
+
+
+def test_get_oauth_headers_includes_token_in_authorization() -> None:
+    h = get_oauth_headers('xyzABC123')
+    assert h['Authorization'] == 'Bearer xyzABC123'


### PR DESCRIPTION
## Summary

Ports the **first-wave cross-folder dependencies** from the bridge parity plan. None of these live under `src/bridge/` — they sit at the framework layer that the bridge subsystem consumes, and are the blockers identified in `bridge-gap-analysis.md` §5 that must land before Phase 5 (`remoteBridgeCore`, the v2 env-less orchestrator) or Phase 3 (`bridgeApi` HTTP client) can be built.

**New modules** (8 total):

**`src/utils/`**
- `combined_abort_signal.py` — merge primary + optional secondary signals with an optional asyncio timeout; idempotent cleanup; built on top of the existing `AbortController` primitives.
- `session_ingress_auth.py` — env-var-backed token getter + auth header builder (Cookie auth for `sk-ant-sid-*`, Bearer for JWTs). FD and well-known-file fallbacks explicitly deferred per docstring.
- `message_mappers.py` — `to_sdk_messages` converts local `Message[]` to wire-format `SDKMessage` dicts. Assistant messages carry `id` / `type` / `role` / `content` / `model` / `stop_reason` / `usage` so Android + mobile parsers can deserialize them. Local-command and ExitPlanMode v2 paths deferred per docstring.
- `teleport/api.py` — `get_oauth_headers` builds the standard OAuth + `Content-Type` + `anthropic-version` header set used by `createSession.ts` et al.

**`src/auth/`**
- `claude_ai.py` — claude.ai-specific OAuth token + entitlement helpers (`get_claude_ai_oauth_tokens`, `get_oauth_account_info`, `is_claude_ai_subscriber` [checks `user:inference` scope per TS], `has_profile_scope`, `check_and_refresh_oauth_token_if_needed`, `handle_oauth_401_error`). Env-var dev-override path until Phase 10 keychain integration lands. The two refresh-related stubs emit `logger.warning` lines so Phase 3+ porters see the gap immediately instead of silently shipping token-staleness bugs.

**`src/services/oauth/`**
- `client.py` — `get_organization_uuid` thin shim over `claude_ai.get_oauth_account_info`. Async signature kept for Phase 10 forward compat (real impl will fetch `/api/oauth/profile` when org UUID isn't cached).

**What's still missing** (deferred to follow-up PRs):
- Phase 1 follow-up `src/bridge/inbound_attachments.py` — now unblocked (needs `getSessionId` which exists), can land next session if desired.
- Phase 3: `src/bridge/bridge_api.py` (HTTP client with OAuth-401 retry, env registration, polling, ack, stop, heartbeat).
- Phase 4: `src/bridge/session_runner.py` (child-CLI spawner).
- Phase 5: `src/bridge/remote_bridge_core.py` (v2 env-less MVP orchestrator).
- Phases 6-10: v1 path, daemon, UI, polish.

## Test plan

- [x] `uv run pytest tests/bridge tests/utils tests/auth tests/services` — **521/521 pass** (81 new + 440 existing)
- [x] CRITIC review: APPROVE after 2 rounds (resolved BLOCKING assistant-message field-stripping; MAJOR `is_claude_ai_subscriber` scope semantics; MAJOR silent token-refresh no-op via `logger.warning`; MAJOR `is_synthetic` DRY via `_is_user_synthetic` helper)
- [ ] CI green
- [ ] Reviewer spot-checks: `_build_assistant_inner` field preservation (`test_assistant_message_preserves_model_stop_reason_usage`); `user:inference` scope check (`test_subscriber_false_when_only_other_scopes`); no-op stub warnings (`test_check_and_refresh_warns_when_token_near_expiry`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)