### PR TITLE
bridge phase 3: port bridgeApi.ts HTTP client

### DIFF
--- a/src/bridge/__init__.py
+++ b/src/bridge/__init__.py
@@ -31,6 +31,14 @@ PORTING_NOTE = f"Python placeholder package for '{ARCHIVE_NAME}' with {MODULE_CO
 # -----------------------------------------------------------------------------
 
 from src.bridge.bounded_uuid_set import BoundedUUIDSet
+from src.bridge.bridge_api import (
+    ANTHROPIC_VERSION,
+    BETA_HEADER,
+    create_bridge_api_client,
+    is_expired_error_type,
+    is_suppressible_403,
+    validate_bridge_id,
+)
 from src.bridge.bridge_config import (
     get_bridge_access_token,
     get_bridge_base_url,
@@ -112,7 +120,9 @@ __all__ = [
     'MODULE_COUNT',
     'PORTING_NOTE',
     'SAMPLE_FILES',
-    # Phase 1 leaves
+    # Phase 1 leaves + Phase 3 HTTP client surface
+    'ANTHROPIC_VERSION',
+    'BETA_HEADER',
     'BRIDGE_LOGIN_ERROR',
     'BRIDGE_LOGIN_INSTRUCTION',
     'BoundedUUIDSet',
@@ -137,6 +147,10 @@ __all__ = [
     'WS_CLOSE_RECONNECT_BUDGET_EXHAUSTED',
     'WS_CLOSE_SESSION_NOT_FOUND',
     'WorkSecret',
+    'create_bridge_api_client',
+    'is_expired_error_type',
+    'is_suppressible_403',
+    'validate_bridge_id',
     'build_active_footer_text',
     'build_bridge_connect_url',
     'build_bridge_session_url',

--- a/src/bridge/bridge_api.py
+++ b/src/bridge/bridge_api.py
@@ -1,0 +1,740 @@
+"""OAuth-authenticated HTTP client for the bridge environments API.
+
+Ports ``typescript/src/bridge/bridgeApi.ts``.
+
+Wraps the ``/v1/environments/bridge/*``, ``/v1/sessions/*``, and ``/v1/work/*``
+endpoints behind the ``BridgeApiClient`` Protocol (defined in
+``src.bridge.types``). The client handles:
+
+* OAuth bearer auth + ``X-Trusted-Device-Token`` + ``anthropic-version`` +
+  ``anthropic-beta: environments-2025-11-01`` headers.
+* Path-segment validation (``validate_bridge_id``) so server-provided IDs
+  can't trigger path traversal.
+* One-shot 401 retry via the injected ``on_auth_401`` callback (mirrors
+  ``handleOAuth401Error`` in TS) — only on mutation endpoints that use
+  OAuth tokens directly; poll / ack / heartbeat use the environment
+  secret or session token so they don't go through the retry wrapper.
+* ``BridgeFatalError`` for 401/403/404/410 plus standard ``Exception``
+  for 429 / other 5xx-suppressed errors. ``handle_error_status`` is the
+  central router.
+* Empty-poll log throttling (first poll + every 100th) to keep debug
+  logs readable when the bridge sits idle for hours.
+
+Backed by ``httpx.AsyncClient``. Tests inject a ``MockTransport`` via
+the ``client`` parameter to ``create_bridge_api_client`` (same pattern
+as ``code_session_api.py``).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Awaitable, Callable
+
+import httpx
+
+from src.bridge.debug_utils import debug_body, extract_error_detail
+from src.bridge.exceptions import BridgeFatalError
+from src.bridge.types import (
+    BRIDGE_LOGIN_INSTRUCTION,
+    BridgeApiClient,
+    BridgeConfig,
+    PermissionResponseEvent,
+    WorkResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Anthropic-beta header value for the environments API. Mirrors TS
+# ``BETA_HEADER`` on ``bridgeApi.ts:38``.
+BETA_HEADER = 'environments-2025-11-01'
+
+ANTHROPIC_VERSION = '2023-06-01'
+
+# httpx default timeout for bridge requests (seconds). Matches TS
+# axios ``timeout: 10_000`` / ``15_000`` on the registration call.
+_DEFAULT_REQUEST_TIMEOUT_SECONDS = 10.0
+_REGISTRATION_TIMEOUT_SECONDS = 15.0
+
+
+# Allowlist pattern for server-provided IDs used in URL path segments.
+# Mirrors TS ``SAFE_ID_PATTERN`` on ``bridgeApi.ts:41``.
+_SAFE_ID_PATTERN = re.compile(r'^[a-zA-Z0-9_-]+$')
+
+
+def validate_bridge_id(value: str, label: str) -> str:
+    """Validate that a server-provided ID is safe to interpolate into URLs.
+
+    Mirrors TS ``validateBridgeId`` on ``bridgeApi.ts:48-53``. Rejects
+    path traversal (``../../admin``) and IDs containing slashes, dots, or
+    other special characters. Raises ``ValueError`` on rejection so the
+    bug surfaces at the call site rather than producing a malformed URL.
+    """
+    if not value or not _SAFE_ID_PATTERN.match(value):
+        raise ValueError(f'Invalid {label}: contains unsafe characters')
+    return value
+
+
+# ── Public predicates ─────────────────────────────────────────────────────
+
+
+def is_expired_error_type(error_type: str | None) -> bool:
+    """Mirrors TS ``isExpiredErrorType`` on ``bridgeApi.ts:503-508``.
+
+    Used by callers to distinguish "session expired, recreate" from
+    "permission denied, fail loud" on a 403/410.
+    """
+    if not error_type:
+        return False
+    return 'expired' in error_type or 'lifetime' in error_type
+
+
+def is_suppressible_403(err: BridgeFatalError) -> bool:
+    """Whether a 403 is a known-suppressible scope/permission error.
+
+    Mirrors TS ``isSuppressible403`` on ``bridgeApi.ts:516-524``. Some
+    403s are for scopes like ``external_poll_sessions`` or
+    ``environments:manage`` that don't affect core functionality —
+    callers can hide these from the user.
+    """
+    if err.status != 403:
+        return False
+    message = str(err)
+    return (
+        'external_poll_sessions' in message
+        or 'environments:manage' in message
+    )
+
+
+# ── Factory + client implementation ───────────────────────────────────────
+
+
+OnDebug = Callable[[str], None]
+OnAuth401 = Callable[[str], Awaitable[bool]]
+GetAccessToken = Callable[[], str | None]
+GetTrustedDeviceToken = Callable[[], str | None]
+
+
+def create_bridge_api_client(
+    *,
+    base_url: str,
+    get_access_token: GetAccessToken,
+    runner_version: str,
+    on_debug: OnDebug | None = None,
+    on_auth_401: OnAuth401 | None = None,
+    get_trusted_device_token: GetTrustedDeviceToken | None = None,
+    client: httpx.AsyncClient | None = None,
+) -> BridgeApiClient:
+    """Factory mirroring TS ``createBridgeApiClient(deps)``.
+
+    Returns an object that satisfies the ``BridgeApiClient`` Protocol
+    from ``src.bridge.types``.
+
+    Args (kw-only to match the readability of the TS options object):
+        base_url: Bridge API root URL (e.g. ``https://api.anthropic.com``).
+        get_access_token: Sync callable returning the current OAuth token
+            or ``None``. Called before every OAuth-authed request.
+        runner_version: Version string sent as the
+            ``x-environment-runner-version`` header.
+        on_debug: Optional sync callable for debug log lines. When absent,
+            messages route to the module logger at DEBUG level.
+        on_auth_401: Optional async callback invoked on a 401. Should
+            attempt to refresh the OAuth token and return ``True`` on
+            success. When absent, 401s go straight to ``BridgeFatalError``.
+            See TS comment on ``bridgeApi.ts:17-25`` for why this is
+            injected rather than imported.
+        get_trusted_device_token: Optional sync callable returning the
+            ``X-Trusted-Device-Token`` header value, or ``None`` to omit
+            the header.
+        client: Optional ``httpx.AsyncClient`` for test injection. When
+            ``None``, a fresh client is created per request (and closed
+            after) — fine for tests/scripts but loses connection pooling
+            and adds ~10ms TLS handshake per call. **Strongly recommended
+            to pass a long-lived client in production** (especially for
+            the polling loop in Phase 6 — at 2s poll interval that's
+            ~300 wasted handshakes/hour).
+    """
+    return _BridgeApiClient(
+        base_url=base_url,
+        get_access_token=get_access_token,
+        runner_version=runner_version,
+        on_debug=on_debug,
+        on_auth_401=on_auth_401,
+        get_trusted_device_token=get_trusted_device_token,
+        client=client,
+    )
+
+
+class _BridgeApiClient:
+    """Concrete implementation of ``BridgeApiClient``.
+
+    Not exported — callers construct via ``create_bridge_api_client`` so
+    the Protocol stays the public surface.
+    """
+
+    _EMPTY_POLL_LOG_INTERVAL = 100
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        get_access_token: GetAccessToken,
+        runner_version: str,
+        on_debug: OnDebug | None,
+        on_auth_401: OnAuth401 | None,
+        get_trusted_device_token: GetTrustedDeviceToken | None,
+        client: httpx.AsyncClient | None,
+    ) -> None:
+        self._base_url = base_url.rstrip('/')
+        self._get_access_token = get_access_token
+        self._runner_version = runner_version
+        self._on_debug = on_debug
+        self._on_auth_401 = on_auth_401
+        self._get_trusted_device_token = get_trusted_device_token
+        self._client = client
+        self._consecutive_empty_polls = 0
+
+    # ── internal helpers ────────────────────────────────────────────────
+
+    def _debug(self, msg: str) -> None:
+        if self._on_debug is not None:
+            self._on_debug(msg)
+        else:
+            logger.debug(msg)
+
+    def _headers(self, access_token: str) -> dict[str, str]:
+        """Mirror TS ``getHeaders`` on ``bridgeApi.ts:76-89``."""
+        headers = {
+            'Authorization': f'Bearer {access_token}',
+            'Content-Type': 'application/json',
+            'anthropic-version': ANTHROPIC_VERSION,
+            'anthropic-beta': BETA_HEADER,
+            'x-environment-runner-version': self._runner_version,
+        }
+        if self._get_trusted_device_token is not None:
+            token = self._get_trusted_device_token()
+            if token:
+                headers['X-Trusted-Device-Token'] = token
+        return headers
+
+    def _resolve_auth(self) -> str:
+        """Mirror TS ``resolveAuth`` on ``bridgeApi.ts:91-97``.
+
+        **Behavioral divergence (intentional)**: TS throws a plain
+        ``Error(BRIDGE_LOGIN_INSTRUCTION)``; we throw a
+        ``BridgeFatalError(status=401)`` so callers can catch the typed
+        error and inspect ``.status`` rather than string-matching the
+        message. Same observable failure (request never goes out), but
+        Python callers get a richer signal.
+        """
+        token = self._get_access_token()
+        if not token:
+            raise BridgeFatalError(BRIDGE_LOGIN_INSTRUCTION, status=401)
+        return token
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        access_token: str,
+        json_body: Any = None,
+        params: dict[str, Any] | None = None,
+        timeout_seconds: float = _DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    ) -> httpx.Response:
+        """Single HTTP request via the injected or freshly-created client.
+
+        On the no-injected-client fallback path, a fresh ``AsyncClient``
+        is constructed per call — TLS handshake + no connection pooling —
+        which is fine for tests / scripts but suboptimal for polling
+        loops. Production callers should pass a long-lived ``client``;
+        see the factory docstring.
+        """
+        url = f'{self._base_url}{path}'
+        kwargs: dict[str, Any] = {
+            'headers': self._headers(access_token),
+            'timeout': timeout_seconds,
+        }
+        if json_body is not None:
+            kwargs['json'] = json_body
+        if params is not None:
+            kwargs['params'] = params
+        if self._client is not None:
+            return await self._client.request(method, url, **kwargs)
+        return await self._send_with_fresh_client(method, url, kwargs)
+
+    async def _send_with_fresh_client(
+        self,
+        method: str,
+        url: str,
+        kwargs: dict[str, Any],
+    ) -> httpx.Response:
+        """Per-request client fallback. Extracted as a seam for tests.
+
+        Tests monkeypatch this method to verify the no-injected-client
+        production path (factory called without ``client=``). Production
+        callers should not subclass.
+        """
+        async with httpx.AsyncClient() as client:
+            return await client.request(method, url, **kwargs)
+
+    async def _with_oauth_retry(
+        self,
+        do_request: Callable[[str], Awaitable[httpx.Response]],
+        context: str,
+    ) -> httpx.Response:
+        """Execute an OAuth-authed request, retrying once on 401.
+
+        Mirrors TS ``withOAuthRetry`` on ``bridgeApi.ts:106-139``. The
+        retry only fires when ``on_auth_401`` is wired and returns
+        ``True``; otherwise the 401 falls through to
+        ``_handle_error_status`` which raises ``BridgeFatalError``.
+        """
+        access_token = self._resolve_auth()
+        response = await do_request(access_token)
+        if response.status_code != 401:
+            return response
+        if self._on_auth_401 is None:
+            self._debug(
+                f'[bridge:api] {context}: 401 received, no refresh handler'
+            )
+            return response
+        self._debug(
+            f'[bridge:api] {context}: 401 received, attempting token refresh'
+        )
+        refreshed = await self._on_auth_401(access_token)
+        if refreshed:
+            self._debug(
+                f'[bridge:api] {context}: Token refreshed, retrying request'
+            )
+            new_token = self._resolve_auth()
+            retry_response = await do_request(new_token)
+            if retry_response.status_code != 401:
+                return retry_response
+            self._debug(
+                f'[bridge:api] {context}: Retry after refresh also got 401'
+            )
+        else:
+            self._debug(f'[bridge:api] {context}: Token refresh failed')
+        return response
+
+    # ── BridgeApiClient methods ─────────────────────────────────────────
+
+    async def register_bridge_environment(
+        self, config: BridgeConfig
+    ) -> dict[str, str]:
+        """POST ``/v1/environments/bridge``. Mirror TS lines 142-197."""
+        self._debug(
+            f'[bridge:api] POST /v1/environments/bridge '
+            f'bridgeId={config.bridge_id}'
+        )
+
+        body: dict[str, Any] = {
+            'machine_name': config.machine_name,
+            'directory': config.dir,
+            'branch': config.branch,
+            'git_repo_url': config.git_repo_url,
+            'max_sessions': config.max_sessions,
+            'metadata': {'worker_type': config.worker_type},
+        }
+        if config.reuse_environment_id:
+            body['environment_id'] = config.reuse_environment_id
+
+        async def do(access_token: str) -> httpx.Response:
+            return await self._request(
+                'POST',
+                '/v1/environments/bridge',
+                access_token=access_token,
+                json_body=body,
+                timeout_seconds=_REGISTRATION_TIMEOUT_SECONDS,
+            )
+
+        response = await self._with_oauth_retry(do, 'Registration')
+        data = _safe_json(response)
+        _handle_error_status(response.status_code, data, 'Registration')
+        # Mirror the defensive guard pattern from heartbeat_work — a 200
+        # with a non-JSON body (gateway HTML page, truncated response,
+        # content-type mismatch) surfaces as ``data == None`` here, and
+        # ``data.get(...)`` below would crash with ``AttributeError``.
+        if not isinstance(data, dict):
+            raise BridgeFatalError(
+                'Registration: malformed response — non-JSON body',
+                status=response.status_code,
+            )
+        env_id = data.get('environment_id')
+        env_secret = data.get('environment_secret')
+        if not isinstance(env_id, str) or not isinstance(env_secret, str):
+            raise BridgeFatalError(
+                'Registration: malformed response — '
+                'missing environment_id / environment_secret',
+                status=response.status_code,
+            )
+        self._debug(
+            f'[bridge:api] POST /v1/environments/bridge -> '
+            f'{response.status_code} environment_id={env_id}'
+        )
+        self._debug(f'[bridge:api] >>> {debug_body(body)}')
+        self._debug(f'[bridge:api] <<< {debug_body(data)}')
+        return {'environment_id': env_id, 'environment_secret': env_secret}
+
+    async def poll_for_work(
+        self,
+        environment_id: str,
+        environment_secret: str,
+        cancel_event: Any | None = None,  # noqa: ARG002  Phase 5 wiring
+        reclaim_older_than_ms: int | None = None,
+    ) -> WorkResponse | None:
+        """GET ``.../work/poll``. Mirror TS lines 199-247.
+
+        ``cancel_event`` is accepted for Protocol parity but not yet
+        wired — Phase 5 will inject an ``asyncio.Event`` and we'll
+        connect it via ``create_combined_abort_signal``. For now httpx's
+        request-level timeout handles slow polls; caller-driven
+        cancellation requires only task cancellation (``task.cancel()``)
+        which httpx honors natively.
+        """
+        validate_bridge_id(environment_id, 'environment_id')
+
+        # Reset and capture; restore only when the response is truly empty.
+        prev_empty_polls = self._consecutive_empty_polls
+        self._consecutive_empty_polls = 0
+
+        params: dict[str, Any] | None = (
+            {'reclaim_older_than_ms': reclaim_older_than_ms}
+            if reclaim_older_than_ms is not None
+            else None
+        )
+        response = await self._request(
+            'GET',
+            f'/v1/environments/{environment_id}/work/poll',
+            access_token=environment_secret,
+            params=params,
+        )
+        data = _safe_json(response)
+        _handle_error_status(response.status_code, data, 'Poll')
+
+        # ``data is None`` → no work. Matches TS ``!response.data`` for the
+        # null branch exactly. Anything else (including malformed empty
+        # dict ``{}``) falls through so the orchestrator can detect a
+        # server-contract violation rather than silently treating it as
+        # "no work."
+        if data is None:
+            self._consecutive_empty_polls = prev_empty_polls + 1
+            if (
+                self._consecutive_empty_polls == 1
+                or self._consecutive_empty_polls % self._EMPTY_POLL_LOG_INTERVAL == 0
+            ):
+                self._debug(
+                    f'[bridge:api] GET .../work/poll -> '
+                    f'{response.status_code} (no work, '
+                    f'{self._consecutive_empty_polls} consecutive empty polls)'
+                )
+            return None
+
+        inner = data.get('data') if isinstance(data, dict) else None
+        inner_type = inner.get('type') if isinstance(inner, dict) else None
+        inner_id = inner.get('id') if isinstance(inner, dict) else None
+        self._debug(
+            f'[bridge:api] GET .../work/poll -> {response.status_code} '
+            f'workId={data.get("id")} type={inner_type}'
+            + (f' sessionId={inner_id}' if inner_id else '')
+        )
+        self._debug(f'[bridge:api] <<< {debug_body(data)}')
+        return data  # type: ignore[return-value]
+
+    async def acknowledge_work(
+        self, environment_id: str, work_id: str, session_token: str
+    ) -> None:
+        """POST ``.../work/{id}/ack``. Mirror TS lines 249-271."""
+        validate_bridge_id(environment_id, 'environment_id')
+        validate_bridge_id(work_id, 'work_id')
+        self._debug(f'[bridge:api] POST .../work/{work_id}/ack')
+        response = await self._request(
+            'POST',
+            f'/v1/environments/{environment_id}/work/{work_id}/ack',
+            access_token=session_token,
+            json_body={},
+        )
+        data = _safe_json(response)
+        _handle_error_status(response.status_code, data, 'Acknowledge')
+        self._debug(
+            f'[bridge:api] POST .../work/{work_id}/ack -> {response.status_code}'
+        )
+
+    async def stop_work(
+        self, environment_id: str, work_id: str, force: bool
+    ) -> None:
+        """POST ``.../work/{id}/stop``. Mirror TS lines 273-299."""
+        validate_bridge_id(environment_id, 'environment_id')
+        validate_bridge_id(work_id, 'work_id')
+        self._debug(
+            f'[bridge:api] POST .../work/{work_id}/stop force={force}'
+        )
+
+        async def do(access_token: str) -> httpx.Response:
+            return await self._request(
+                'POST',
+                f'/v1/environments/{environment_id}/work/{work_id}/stop',
+                access_token=access_token,
+                json_body={'force': force},
+            )
+
+        response = await self._with_oauth_retry(do, 'StopWork')
+        data = _safe_json(response)
+        _handle_error_status(response.status_code, data, 'StopWork')
+        self._debug(
+            f'[bridge:api] POST .../work/{work_id}/stop -> {response.status_code}'
+        )
+
+    async def deregister_environment(self, environment_id: str) -> None:
+        """DELETE ``/v1/environments/bridge/{id}``. Mirror TS lines 301-323."""
+        validate_bridge_id(environment_id, 'environment_id')
+        self._debug(
+            f'[bridge:api] DELETE /v1/environments/bridge/{environment_id}'
+        )
+
+        async def do(access_token: str) -> httpx.Response:
+            return await self._request(
+                'DELETE',
+                f'/v1/environments/bridge/{environment_id}',
+                access_token=access_token,
+            )
+
+        response = await self._with_oauth_retry(do, 'Deregister')
+        data = _safe_json(response)
+        _handle_error_status(response.status_code, data, 'Deregister')
+        self._debug(
+            f'[bridge:api] DELETE /v1/environments/bridge/{environment_id} '
+            f'-> {response.status_code}'
+        )
+
+    async def archive_session(self, session_id: str) -> None:
+        """POST ``/v1/sessions/{id}/archive``. Mirror TS lines 325-356.
+
+        409 is treated as success (idempotent — session already archived).
+        """
+        validate_bridge_id(session_id, 'session_id')
+        self._debug(f'[bridge:api] POST /v1/sessions/{session_id}/archive')
+
+        async def do(access_token: str) -> httpx.Response:
+            return await self._request(
+                'POST',
+                f'/v1/sessions/{session_id}/archive',
+                access_token=access_token,
+                json_body={},
+            )
+
+        response = await self._with_oauth_retry(do, 'ArchiveSession')
+        if response.status_code == 409:
+            self._debug(
+                f'[bridge:api] POST /v1/sessions/{session_id}/archive '
+                f'-> 409 (already archived)'
+            )
+            return
+        data = _safe_json(response)
+        _handle_error_status(response.status_code, data, 'ArchiveSession')
+        self._debug(
+            f'[bridge:api] POST /v1/sessions/{session_id}/archive '
+            f'-> {response.status_code}'
+        )
+
+    async def reconnect_session(
+        self, environment_id: str, session_id: str
+    ) -> None:
+        """POST ``.../bridge/reconnect``. Mirror TS lines 358-385."""
+        validate_bridge_id(environment_id, 'environment_id')
+        validate_bridge_id(session_id, 'session_id')
+        self._debug(
+            f'[bridge:api] POST /v1/environments/{environment_id}'
+            f'/bridge/reconnect session_id={session_id}'
+        )
+
+        async def do(access_token: str) -> httpx.Response:
+            return await self._request(
+                'POST',
+                f'/v1/environments/{environment_id}/bridge/reconnect',
+                access_token=access_token,
+                json_body={'session_id': session_id},
+            )
+
+        response = await self._with_oauth_retry(do, 'ReconnectSession')
+        data = _safe_json(response)
+        _handle_error_status(response.status_code, data, 'ReconnectSession')
+        self._debug(
+            f'[bridge:api] POST .../bridge/reconnect -> {response.status_code}'
+        )
+
+    async def heartbeat_work(
+        self, environment_id: str, work_id: str, session_token: str
+    ) -> dict[str, Any]:
+        """POST ``.../work/{id}/heartbeat``. Mirror TS lines 387-417."""
+        validate_bridge_id(environment_id, 'environment_id')
+        validate_bridge_id(work_id, 'work_id')
+        self._debug(f'[bridge:api] POST .../work/{work_id}/heartbeat')
+        response = await self._request(
+            'POST',
+            f'/v1/environments/{environment_id}/work/{work_id}/heartbeat',
+            access_token=session_token,
+            json_body={},
+        )
+        data = _safe_json(response)
+        _handle_error_status(response.status_code, data, 'Heartbeat')
+        if not isinstance(data, dict):
+            raise BridgeFatalError(
+                'Heartbeat: malformed response',
+                status=response.status_code,
+            )
+        self._debug(
+            f'[bridge:api] POST .../work/{work_id}/heartbeat -> '
+            f'{response.status_code} lease_extended={data.get("lease_extended")} '
+            f'state={data.get("state")}'
+        )
+        return data
+
+    async def send_permission_response_event(
+        self,
+        session_id: str,
+        event: PermissionResponseEvent,
+        session_token: str,
+    ) -> None:
+        """POST ``/v1/sessions/{id}/events``. Mirror TS lines 419-450."""
+        validate_bridge_id(session_id, 'session_id')
+        event_type = event.get('type', '<unknown>')
+        self._debug(
+            f'[bridge:api] POST /v1/sessions/{session_id}/events '
+            f'type={event_type}'
+        )
+        body = {'events': [event]}
+        response = await self._request(
+            'POST',
+            f'/v1/sessions/{session_id}/events',
+            access_token=session_token,
+            json_body=body,
+        )
+        data = _safe_json(response)
+        _handle_error_status(
+            response.status_code, data, 'SendPermissionResponseEvent'
+        )
+        self._debug(
+            f'[bridge:api] POST /v1/sessions/{session_id}/events '
+            f'-> {response.status_code}'
+        )
+        self._debug(f'[bridge:api] >>> {debug_body(body)}')
+        self._debug(f'[bridge:api] <<< {debug_body(data)}')
+
+
+# ── Error handling ────────────────────────────────────────────────────────
+
+
+def _extract_error_type_from_data(data: Any) -> str | None:
+    """Pull ``data.error.type`` from a structured error body.
+
+    Mirrors TS ``extractErrorTypeFromData`` on ``bridgeApi.ts:526-539``.
+    Internal helper — not exported (but tested via the public error
+    paths it feeds into).
+    """
+    if not isinstance(data, dict):
+        return None
+    error = data.get('error')
+    if not isinstance(error, dict):
+        return None
+    error_type = error.get('type')
+    if isinstance(error_type, str):
+        return error_type
+    return None
+
+
+def _safe_json(response: httpx.Response) -> Any:
+    """Best-effort ``response.json()`` — returns ``None`` on parse error."""
+    try:
+        return response.json()
+    except (ValueError, httpx.DecodingError):
+        return None
+
+
+def _handle_error_status(
+    status: int,
+    data: Any,
+    context: str,
+) -> None:
+    """Raise ``BridgeFatalError`` (or generic ``Exception``) on non-2xx.
+
+    Mirrors TS ``handleErrorStatus`` on ``bridgeApi.ts:454-500``. Maps
+    each well-known status to a typed exception with the most useful
+    diagnostic message we can build from the response body.
+
+    200 / 204 → no-op.
+    401 → BridgeFatalError(401) with login instruction.
+    403 → BridgeFatalError(403); special-cases expired-error-type as
+          "Remote Control session has expired".
+    404 → BridgeFatalError(404); detail-or-default message.
+    410 → BridgeFatalError(410) tagged ``environment_expired``.
+    429 → Plain ``Exception`` (not fatal; caller backs off).
+    other → Plain ``Exception``.
+    """
+    if status in (200, 204):
+        return
+    detail = extract_error_detail(data)
+    error_type = _extract_error_type_from_data(data)
+
+    if status == 401:
+        raise BridgeFatalError(
+            f'{context}: Authentication failed (401)'
+            + (f': {detail}' if detail else '')
+            + f'. {BRIDGE_LOGIN_INSTRUCTION}',
+            status=401,
+            error_type=error_type,
+        )
+    if status == 403:
+        if is_expired_error_type(error_type):
+            message = (
+                'Remote Control session has expired. Please restart '
+                'with `claude remote-control` or /remote-control.'
+            )
+        else:
+            message = (
+                f'{context}: Access denied (403)'
+                + (f': {detail}' if detail else '')
+                + '. Check your organization permissions.'
+            )
+        raise BridgeFatalError(message, status=403, error_type=error_type)
+    if status == 404:
+        raise BridgeFatalError(
+            detail
+            or (
+                f'{context}: Not found (404). Remote Control may not be '
+                'available for this organization.'
+            ),
+            status=404,
+            error_type=error_type,
+        )
+    if status == 410:
+        raise BridgeFatalError(
+            detail
+            or (
+                'Remote Control session has expired. Please restart with '
+                '`claude remote-control` or /remote-control.'
+            ),
+            status=410,
+            error_type=error_type or 'environment_expired',
+        )
+    if status == 429:
+        raise Exception(
+            f'{context}: Rate limited (429). Polling too frequently.'
+        )
+    raise Exception(
+        f'{context}: Failed with status {status}'
+        + (f': {detail}' if detail else '')
+    )
+
+
+__all__ = [
+    'ANTHROPIC_VERSION',
+    'BETA_HEADER',
+    'BridgeFatalError',  # re-exported for callers that catch it
+    'create_bridge_api_client',
+    'is_expired_error_type',
+    'is_suppressible_403',
+    'validate_bridge_id',
+]

--- a/tests/bridge/test_bridge_api.py
+++ b/tests/bridge/test_bridge_api.py
@@ -1,0 +1,884 @@
+"""Tests for ``src.bridge.bridge_api`` — the bridge HTTP client.
+
+Uses ``httpx.MockTransport`` (same pattern as ``test_code_session_api``)
+to intercept requests and return scripted responses. No real network.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable
+
+import httpx
+import pytest
+
+from src.bridge import bridge_api
+from src.bridge.bridge_api import (
+    ANTHROPIC_VERSION,
+    BETA_HEADER,
+    create_bridge_api_client,
+    is_expired_error_type,
+    is_suppressible_403,
+    validate_bridge_id,
+)
+from src.bridge.exceptions import BridgeFatalError
+from src.bridge.types import BridgeConfig
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+def _make_config(**overrides: Any) -> BridgeConfig:
+    defaults = dict(
+        dir='/tmp/repo',
+        machine_name='test-host',
+        branch='main',
+        git_repo_url='https://github.com/owner/repo',
+        max_sessions=1,
+        spawn_mode='single-session',
+        verbose=False,
+        sandbox=False,
+        bridge_id='br-1',
+        worker_type='claude_code',
+        environment_id='env-client-1',
+        api_base_url='https://api.example.com',
+        session_ingress_url='https://api.example.com',
+    )
+    defaults.update(overrides)
+    return BridgeConfig(**defaults)
+
+
+def _mock_client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def _make_client(
+    handler: Callable[[httpx.Request], httpx.Response],
+    *,
+    base_url: str = 'https://api.example.com',
+    get_access_token: Callable[[], str | None] | None = None,
+    on_auth_401: Any = None,
+    get_trusted_device_token: Callable[[], str | None] | None = None,
+    runner_version: str = 'py-test-0.1',
+):
+    return create_bridge_api_client(
+        base_url=base_url,
+        get_access_token=get_access_token or (lambda: 'tok-1'),
+        runner_version=runner_version,
+        on_auth_401=on_auth_401,
+        get_trusted_device_token=get_trusted_device_token,
+        client=_mock_client(handler),
+    )
+
+
+# ── Pure helpers ──────────────────────────────────────────────────────────
+
+
+def test_validate_bridge_id_accepts_alphanumeric_and_dash_underscore() -> None:
+    assert validate_bridge_id('env_abc-123', 'env') == 'env_abc-123'
+
+
+def test_validate_bridge_id_rejects_empty() -> None:
+    with pytest.raises(ValueError, match='env'):
+        validate_bridge_id('', 'env')
+
+
+@pytest.mark.parametrize(
+    'bad', ['../admin', 'has/slash', 'has.dot', 'has space', 'a%40b']
+)
+def test_validate_bridge_id_rejects_unsafe(bad: str) -> None:
+    with pytest.raises(ValueError, match='env'):
+        validate_bridge_id(bad, 'env')
+
+
+def test_is_expired_error_type_matches_substrings() -> None:
+    assert is_expired_error_type('environment_expired') is True
+    assert is_expired_error_type('lifetime_exceeded') is True
+    assert is_expired_error_type('not_found') is False
+    assert is_expired_error_type(None) is False
+    assert is_expired_error_type('') is False
+
+
+def test_is_suppressible_403_only_for_known_messages() -> None:
+    err = BridgeFatalError(
+        'StopWork: Access denied (403): missing scope external_poll_sessions',
+        status=403,
+    )
+    assert is_suppressible_403(err) is True
+
+    other = BridgeFatalError(
+        'StopWork: Access denied (403): organization disabled',
+        status=403,
+    )
+    assert is_suppressible_403(other) is False
+
+    not_403 = BridgeFatalError('boom', status=404)
+    assert is_suppressible_403(not_403) is False
+
+
+# ── Headers + auth ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_request_includes_oauth_and_beta_headers() -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen['headers'] = dict(req.headers)
+        return httpx.Response(200, json={'environment_id': 'e', 'environment_secret': 's'})
+
+    client = _make_client(handler)
+    await client.register_bridge_environment(_make_config())
+
+    assert seen['headers']['authorization'] == 'Bearer tok-1'
+    assert seen['headers']['content-type'] == 'application/json'
+    assert seen['headers']['anthropic-version'] == ANTHROPIC_VERSION
+    assert seen['headers']['anthropic-beta'] == BETA_HEADER
+    assert seen['headers']['x-environment-runner-version'] == 'py-test-0.1'
+    assert 'x-trusted-device-token' not in seen['headers']
+
+
+@pytest.mark.asyncio
+async def test_request_includes_trusted_device_token_when_provided() -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen['headers'] = dict(req.headers)
+        return httpx.Response(200, json={'environment_id': 'e', 'environment_secret': 's'})
+
+    client = _make_client(handler, get_trusted_device_token=lambda: 'tdt-xyz')
+    await client.register_bridge_environment(_make_config())
+    assert seen['headers']['x-trusted-device-token'] == 'tdt-xyz'
+
+
+@pytest.mark.asyncio
+async def test_request_omits_trusted_device_token_when_callback_returns_none() -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen['headers'] = dict(req.headers)
+        return httpx.Response(200, json={'environment_id': 'e', 'environment_secret': 's'})
+
+    client = _make_client(handler, get_trusted_device_token=lambda: None)
+    await client.register_bridge_environment(_make_config())
+    assert 'x-trusted-device-token' not in seen['headers']
+
+
+@pytest.mark.asyncio
+async def test_request_raises_when_no_oauth_token() -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={})
+
+    client = _make_client(handler, get_access_token=lambda: None)
+    with pytest.raises(BridgeFatalError):
+        await client.register_bridge_environment(_make_config())
+
+
+# ── register_bridge_environment ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_register_sends_expected_body() -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen['body'] = json.loads(req.content)
+        seen['url'] = str(req.url)
+        return httpx.Response(200, json={
+            'environment_id': 'env-srv', 'environment_secret': 'sec-srv'
+        })
+
+    client = _make_client(handler)
+    cfg = _make_config(branch='feature', max_sessions=3, worker_type='claude_code_assistant')
+    out = await client.register_bridge_environment(cfg)
+
+    assert out == {'environment_id': 'env-srv', 'environment_secret': 'sec-srv'}
+    assert seen['url'] == 'https://api.example.com/v1/environments/bridge'
+    assert seen['body']['machine_name'] == 'test-host'
+    assert seen['body']['directory'] == '/tmp/repo'
+    assert seen['body']['branch'] == 'feature'
+    assert seen['body']['git_repo_url'] == 'https://github.com/owner/repo'
+    assert seen['body']['max_sessions'] == 3
+    assert seen['body']['metadata'] == {'worker_type': 'claude_code_assistant'}
+    assert 'environment_id' not in seen['body']  # no reuse
+
+
+@pytest.mark.asyncio
+async def test_register_includes_environment_id_when_reusing() -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen['body'] = json.loads(req.content)
+        return httpx.Response(200, json={
+            'environment_id': 'env-srv', 'environment_secret': 'sec-srv'
+        })
+
+    client = _make_client(handler)
+    cfg = _make_config(reuse_environment_id='env-prev')
+    await client.register_bridge_environment(cfg)
+    assert seen['body']['environment_id'] == 'env-prev'
+
+
+@pytest.mark.asyncio
+async def test_register_401_no_handler_raises_fatal() -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={'error': {'type': 'unauthorized'}})
+
+    client = _make_client(handler)
+    with pytest.raises(BridgeFatalError) as exc:
+        await client.register_bridge_environment(_make_config())
+    assert exc.value.status == 401
+
+
+@pytest.mark.asyncio
+async def test_register_410_raises_fatal_with_expired_error_type() -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(410, json={'message': 'gone'})
+
+    client = _make_client(handler)
+    with pytest.raises(BridgeFatalError) as exc:
+        await client.register_bridge_environment(_make_config())
+    assert exc.value.status == 410
+    assert exc.value.error_type == 'environment_expired'
+
+
+@pytest.mark.asyncio
+async def test_register_429_raises_non_fatal_exception() -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, json={'message': 'rate limited'})
+
+    client = _make_client(handler)
+    with pytest.raises(Exception) as exc:
+        await client.register_bridge_environment(_make_config())
+    assert not isinstance(exc.value, BridgeFatalError)
+    assert '429' in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_register_malformed_response_raises_fatal() -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={'environment_id': 'e'})  # missing secret
+
+    client = _make_client(handler)
+    with pytest.raises(BridgeFatalError, match='malformed'):
+        await client.register_bridge_environment(_make_config())
+
+
+# ── OAuth 401 retry ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_oauth_retry_refreshes_and_succeeds_on_second_attempt() -> None:
+    """Refresh callback returns True → second request must use the refreshed token."""
+    tokens = iter(['stale', 'fresh'])
+    call_log: list[tuple[str, str | None]] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        auth = req.headers.get('authorization')
+        call_log.append((req.method, auth))
+        if auth == 'Bearer stale':
+            return httpx.Response(401)
+        return httpx.Response(200, json={
+            'environment_id': 'e', 'environment_secret': 's'
+        })
+
+    refresh_calls: list[str] = []
+
+    async def on_auth_401(stale: str) -> bool:
+        refresh_calls.append(stale)
+        return True
+
+    client = _make_client(
+        handler,
+        get_access_token=lambda: next(tokens),
+        on_auth_401=on_auth_401,
+    )
+    out = await client.register_bridge_environment(_make_config())
+    assert out['environment_id'] == 'e'
+    assert refresh_calls == ['stale']
+    assert call_log == [
+        ('POST', 'Bearer stale'),
+        ('POST', 'Bearer fresh'),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_oauth_retry_returns_401_when_refresh_returns_false() -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={})
+
+    async def on_auth_401(_stale: str) -> bool:
+        return False
+
+    client = _make_client(handler, on_auth_401=on_auth_401)
+    with pytest.raises(BridgeFatalError) as exc:
+        await client.register_bridge_environment(_make_config())
+    assert exc.value.status == 401
+
+
+@pytest.mark.asyncio
+async def test_oauth_retry_returns_401_when_retry_also_401() -> None:
+    """Refresh succeeds but retry also gets 401 → fatal."""
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={})
+
+    refresh_count = [0]
+
+    async def on_auth_401(_stale: str) -> bool:
+        refresh_count[0] += 1
+        return True
+
+    client = _make_client(handler, on_auth_401=on_auth_401)
+    with pytest.raises(BridgeFatalError) as exc:
+        await client.register_bridge_environment(_make_config())
+    assert exc.value.status == 401
+    # Refresh attempted exactly once (no infinite loop).
+    assert refresh_count[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_oauth_retry_skipped_for_non_401() -> None:
+    """Non-401 errors don't trigger the refresh callback."""
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    refresh_calls: list[str] = []
+
+    async def on_auth_401(stale: str) -> bool:
+        refresh_calls.append(stale)
+        return True
+
+    client = _make_client(handler, on_auth_401=on_auth_401)
+    with pytest.raises(BridgeFatalError) as exc:
+        await client.register_bridge_environment(_make_config())
+    assert exc.value.status == 404
+    assert refresh_calls == []
+
+
+# ── poll_for_work ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_poll_returns_none_on_empty_body() -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=None)
+
+    client = _make_client(handler)
+    out = await client.poll_for_work('env-1', 'env-sec')
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_poll_returns_work_response_when_present() -> None:
+    work_payload = {
+        'id': 'work-1',
+        'type': 'work',
+        'environment_id': 'env-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'sess-1'},
+        'secret': 'base64stuff',
+        'created_at': '2026-05-23T00:00:00Z',
+    }
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=work_payload)
+
+    client = _make_client(handler)
+    out = await client.poll_for_work('env-1', 'env-sec')
+    assert out is not None
+    assert out['id'] == 'work-1'
+    assert out['data']['id'] == 'sess-1'
+
+
+@pytest.mark.asyncio
+async def test_poll_passes_reclaim_param() -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen['url'] = str(req.url)
+        return httpx.Response(200, json=None)
+
+    client = _make_client(handler)
+    await client.poll_for_work('env-1', 'env-sec', reclaim_older_than_ms=5000)
+    assert 'reclaim_older_than_ms=5000' in seen['url']
+
+
+@pytest.mark.asyncio
+async def test_poll_omits_reclaim_param_when_none() -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen['url'] = str(req.url)
+        return httpx.Response(200, json=None)
+
+    client = _make_client(handler)
+    await client.poll_for_work('env-1', 'env-sec')
+    assert 'reclaim_older_than_ms' not in seen['url']
+
+
+@pytest.mark.asyncio
+async def test_poll_uses_environment_secret_not_oauth_token() -> None:
+    """Poll auths with the env secret, NOT the OAuth token."""
+    seen: dict[str, str | None] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen['auth'] = req.headers.get('authorization')
+        return httpx.Response(200, json=None)
+
+    client = _make_client(handler, get_access_token=lambda: 'oauth-tok')
+    await client.poll_for_work('env-1', 'env-secret-xyz')
+    # poll uses env secret directly — no oauth-tok in header
+    assert seen['auth'] == 'Bearer env-secret-xyz'
+
+
+@pytest.mark.asyncio
+async def test_poll_validates_environment_id() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        raise AssertionError('should not reach network')
+
+    client = _make_client(handler)
+    with pytest.raises(ValueError):
+        await client.poll_for_work('../bad', 'sec')
+
+
+# ── acknowledge_work / stop_work / heartbeat_work ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ack_validates_and_posts() -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen['url'] = str(req.url)
+        seen['method'] = req.method
+        return httpx.Response(200, json={})
+
+    client = _make_client(handler)
+    await client.acknowledge_work('env-1', 'work-1', 'session-tok')
+    assert seen['method'] == 'POST'
+    assert seen['url'].endswith('/v1/environments/env-1/work/work-1/ack')
+
+
+@pytest.mark.asyncio
+async def test_stop_work_sends_force_field() -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen['body'] = json.loads(req.content)
+        return httpx.Response(200, json={})
+
+    client = _make_client(handler)
+    await client.stop_work('env-1', 'work-1', force=True)
+    assert seen['body'] == {'force': True}
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_returns_dict() -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={
+            'lease_extended': True,
+            'state': 'running',
+            'last_heartbeat': '2026-05-23T00:00:00Z',
+            'ttl_seconds': 60,
+        })
+
+    client = _make_client(handler)
+    out = await client.heartbeat_work('env-1', 'work-1', 'sess-tok')
+    assert out['lease_extended'] is True
+    assert out['state'] == 'running'
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_malformed_raises_fatal() -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b'not-json')
+
+    client = _make_client(handler)
+    with pytest.raises(BridgeFatalError, match='malformed'):
+        await client.heartbeat_work('env-1', 'work-1', 'sess-tok')
+
+
+# ── deregister_environment ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_deregister_sends_delete() -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen['method'] = req.method
+        seen['url'] = str(req.url)
+        return httpx.Response(204)
+
+    client = _make_client(handler)
+    await client.deregister_environment('env-1')
+    assert seen['method'] == 'DELETE'
+    assert seen['url'].endswith('/v1/environments/bridge/env-1')
+
+
+# ── archive_session ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_archive_session_success() -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={})
+
+    client = _make_client(handler)
+    await client.archive_session('sess-1')
+
+
+@pytest.mark.asyncio
+async def test_archive_session_409_is_success() -> None:
+    """409 → already archived → idempotent success, no raise."""
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(409, json={'message': 'already archived'})
+
+    client = _make_client(handler)
+    # Must not raise.
+    await client.archive_session('sess-1')
+
+
+@pytest.mark.asyncio
+async def test_archive_session_404_raises_fatal() -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={'message': 'not found'})
+
+    client = _make_client(handler)
+    with pytest.raises(BridgeFatalError) as exc:
+        await client.archive_session('sess-1')
+    assert exc.value.status == 404
+
+
+# ── reconnect_session ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reconnect_session_sends_session_id_field() -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen['body'] = json.loads(req.content)
+        return httpx.Response(200, json={})
+
+    client = _make_client(handler)
+    await client.reconnect_session('env-1', 'sess-1')
+    assert seen['body'] == {'session_id': 'sess-1'}
+
+
+# ── send_permission_response_event ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_permission_response_event_wraps_in_events_array() -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen['body'] = json.loads(req.content)
+        return httpx.Response(200, json={})
+
+    client = _make_client(handler)
+    event = {
+        'type': 'control_response',
+        'response': {
+            'subtype': 'success',
+            'request_id': 'req-1',
+            'response': {'behavior': 'allow'},
+        },
+    }
+    await client.send_permission_response_event('sess-1', event, 'sess-tok')
+    assert seen['body'] == {'events': [event]}
+
+
+# ── 403 expired-vs-permission branching ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_403_with_expired_error_type_uses_expiry_message() -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={'error': {'type': 'session_expired'}})
+
+    client = _make_client(handler)
+    with pytest.raises(BridgeFatalError) as exc:
+        await client.stop_work('env-1', 'work-1', force=False)
+    assert exc.value.status == 403
+    assert exc.value.error_type == 'session_expired'
+    assert 'expired' in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_403_without_expired_error_type_uses_permission_message() -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            403, json={'error': {'type': 'forbidden'}, 'message': 'denied'}
+        )
+
+    client = _make_client(handler)
+    with pytest.raises(BridgeFatalError) as exc:
+        await client.stop_work('env-1', 'work-1', force=False)
+    assert 'Access denied' in str(exc.value)
+    assert 'denied' in str(exc.value)
+
+
+# ── Empty-poll throttling ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_empty_poll_logs_first_then_every_100th() -> None:
+    """Verify that the consecutive-empty-poll counter triggers debug logs only on the
+    first poll and every 100th — not after every individual empty poll."""
+    logs: list[str] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=None)
+
+    client = create_bridge_api_client(
+        base_url='https://api.example.com',
+        get_access_token=lambda: 'tok-1',
+        runner_version='py-test-0.1',
+        on_debug=lambda msg: logs.append(msg),
+        client=_mock_client(handler),
+    )
+
+    for _ in range(101):
+        await client.poll_for_work('env-1', 'env-sec')
+
+    # Counter-related debug messages: poll 1 and poll 100 only.
+    empty_logs = [m for m in logs if 'consecutive empty polls' in m]
+    assert len(empty_logs) == 2
+    assert 'no work, 1 consecutive' in empty_logs[0]
+    assert 'no work, 100 consecutive' in empty_logs[1]
+
+    # Pin the 101st-poll behavior: the count keeps incrementing but no
+    # additional log fires (guards against an off-by-one modulo bug
+    # that would otherwise also pass the two assertions above).
+    await client.poll_for_work('env-1', 'env-sec')
+    await client.poll_for_work('env-1', 'env-sec')
+    empty_logs_after = [m for m in logs if 'consecutive empty polls' in m]
+    assert len(empty_logs_after) == 2
+
+
+@pytest.mark.asyncio
+async def test_poll_response_resets_empty_streak() -> None:
+    """A non-empty poll between empty ones resets the counter."""
+    logs: list[str] = []
+
+    responses = iter([
+        httpx.Response(200, json=None),
+        httpx.Response(200, json={
+            'id': 'w-1',
+            'type': 'work',
+            'environment_id': 'e',
+            'state': 'pending',
+            'data': {'type': 'session', 'id': 's-1'},
+            'secret': 'b64',
+            'created_at': '2026-05-23T00:00:00Z',
+        }),
+        httpx.Response(200, json=None),  # back to empty
+    ])
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return next(responses)
+
+    client = create_bridge_api_client(
+        base_url='https://api.example.com',
+        get_access_token=lambda: 'tok-1',
+        runner_version='py-test-0.1',
+        on_debug=lambda msg: logs.append(msg),
+        client=_mock_client(handler),
+    )
+    await client.poll_for_work('env-1', 'sec')
+    await client.poll_for_work('env-1', 'sec')
+    await client.poll_for_work('env-1', 'sec')
+
+    empty_logs = [m for m in logs if 'consecutive empty polls' in m]
+    # First empty (counter→1), then non-empty (resets), then empty (counter→1 again).
+    assert len(empty_logs) == 2
+    assert 'no work, 1 consecutive' in empty_logs[0]
+    assert 'no work, 1 consecutive' in empty_logs[1]
+
+
+# ── base_url normalization ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_register_non_json_body_raises_fatal() -> None:
+    """200 with HTML/text body must surface as BridgeFatalError, not AttributeError.
+
+    Regression test per CRITIC blocking fix. Realistic scenarios: gateway
+    returns an HTML 200 (auth pages, CDN errors with 200), truncated
+    response, content-type mismatch.
+    """
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b'<html>maintenance</html>')
+
+    client = _make_client(handler)
+    with pytest.raises(BridgeFatalError, match='non-JSON body'):
+        await client.register_bridge_environment(_make_config())
+
+
+@pytest.mark.asyncio
+async def test_poll_empty_dict_falls_through_to_work_response() -> None:
+    """Per CRITIC fix: `{}` is NOT no-work — only `null` body is.
+
+    A server-issued `{}` would surface as a (malformed) WorkResponse so
+    the orchestrator can detect server-contract violations rather than
+    silently treating them as 'no work available'.
+    """
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={})
+
+    client = _make_client(handler)
+    out = await client.poll_for_work('env-1', 'env-sec')
+    # The {} body falls through and is returned as-is (not None).
+    assert out == {}
+
+
+@pytest.mark.asyncio
+async def test_register_401_logs_no_refresh_handler() -> None:
+    """When ``on_auth_401`` is unset, the 401 path emits a diagnostic log."""
+    logs: list[str] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={'error': {'type': 'unauthorized'}})
+
+    client = create_bridge_api_client(
+        base_url='https://api.example.com',
+        get_access_token=lambda: 'tok-1',
+        runner_version='py-test-0.1',
+        on_debug=lambda msg: logs.append(msg),
+        client=_mock_client(handler),
+    )
+    with pytest.raises(BridgeFatalError):
+        await client.register_bridge_environment(_make_config())
+    assert any('no refresh handler' in m for m in logs)
+
+
+@pytest.mark.asyncio
+async def test_register_redacts_environment_secret_in_debug_log() -> None:
+    """Debug logs must not leak environment_secret unredacted.
+
+    Security regression guard — ``debug_body`` redacts ``environment_secret``
+    via the centralized SECRET_FIELD_NAMES list in ``debug_utils``.
+    """
+    logs: list[str] = []
+    long_secret = 'super-secret-environment-key-do-not-leak-12345'
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={
+            'environment_id': 'e',
+            'environment_secret': long_secret,
+        })
+
+    client = create_bridge_api_client(
+        base_url='https://api.example.com',
+        get_access_token=lambda: 'tok-1',
+        runner_version='py-test-0.1',
+        on_debug=lambda msg: logs.append(msg),
+        client=_mock_client(handler),
+    )
+    await client.register_bridge_environment(_make_config())
+    # Secret must appear redacted in any log, never in full.
+    joined = '\n'.join(logs)
+    assert long_secret not in joined, 'environment_secret leaked unredacted'
+
+
+@pytest.mark.asyncio
+async def test_httpx_connect_error_propagates() -> None:
+    """Network errors (httpx.ConnectError) propagate unwrapped to the caller.
+
+    No silent swallowing of network failures — the orchestrator's poll
+    loop relies on seeing these so its backoff logic can fire.
+    """
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError('connection refused')
+
+    client = _make_client(handler)
+    with pytest.raises(httpx.ConnectError):
+        await client.poll_for_work('env-1', 'env-sec')
+
+
+@pytest.mark.asyncio
+async def test_httpx_timeout_error_propagates() -> None:
+    """``httpx.TimeoutException`` propagates the same way."""
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout('timed out')
+
+    client = _make_client(handler)
+    with pytest.raises(httpx.ReadTimeout):
+        await client.poll_for_work('env-1', 'env-sec')
+
+
+@pytest.mark.asyncio
+async def test_poll_with_pre_aborted_cancel_event_still_completes() -> None:
+    """The ``cancel_event`` parameter is currently a no-op (Phase 5 wires it).
+
+    Pins the "ignored for now" contract — if Phase 5 wiring is forgotten,
+    this test still passes (event ignored), but a future regression that
+    starts honoring it should add a new test that REPLACES this one.
+    """
+    import asyncio
+
+    triggered = asyncio.Event()
+    triggered.set()
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=None)
+
+    client = _make_client(handler)
+    # Despite the pre-triggered event, the call completes normally.
+    out = await client.poll_for_work('env-1', 'env-sec', cancel_event=triggered)
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_no_injected_client_path_uses_fresh_async_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The factory's no-injected-client fallback creates an AsyncClient per request.
+
+    Regression test per CRITIC MAJOR: previously the production path
+    (``client=None``) had zero test coverage. Monkeypatches the
+    ``_send_with_fresh_client`` seam to record invocation and serve a
+    canned response without going to the network.
+    """
+    calls: list[tuple[str, str]] = []
+
+    async def fake_send(self, method, url, kwargs):  # type: ignore[no-untyped-def]
+        calls.append((method, url))
+        return httpx.Response(200, json={
+            'environment_id': 'e-fresh', 'environment_secret': 's-fresh',
+        })
+
+    monkeypatch.setattr(
+        bridge_api._BridgeApiClient,
+        '_send_with_fresh_client',
+        fake_send,
+    )
+
+    client = create_bridge_api_client(
+        base_url='https://api.example.com',
+        get_access_token=lambda: 'tok-1',
+        runner_version='py-test-0.1',
+        # client= deliberately omitted to exercise the fresh-client path
+    )
+    out = await client.register_bridge_environment(_make_config())
+    assert out == {'environment_id': 'e-fresh', 'environment_secret': 's-fresh'}
+    assert calls == [('POST', 'https://api.example.com/v1/environments/bridge')]
+
+
+@pytest.mark.asyncio
+async def test_base_url_trailing_slash_is_stripped() -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen['url'] = str(req.url)
+        return httpx.Response(200, json={
+            'environment_id': 'e', 'environment_secret': 's'
+        })
+
+    client = _make_client(handler, base_url='https://api.example.com/')
+    await client.register_bridge_environment(_make_config())
+    # No double slashes in the URL.
+    assert '//v1/' not in seen['url']
+    assert seen['url'] == 'https://api.example.com/v1/environments/bridge'


### PR DESCRIPTION
## Summary

Ports `typescript/src/bridge/bridgeApi.ts` (~540 lines) — the OAuth-authed HTTP client for the bridge environments API. Built on `httpx.AsyncClient`; uses `httpx.MockTransport` in tests (same pattern as `code_session_api.py`).

This unblocks Phase 6 (env-based `replBridge` orchestrator) and partially unblocks Phase 5 (`remoteBridgeCore` uses `archive_session` only).

## Surface

`src/bridge/bridge_api.py`:
- `create_bridge_api_client(...)` — factory returning a `BridgeApiClient` Protocol implementation
- 9 methods: `register_bridge_environment`, `poll_for_work`, `acknowledge_work`, `stop_work`, `deregister_environment`, `archive_session`, `reconnect_session`, `heartbeat_work`, `send_permission_response_event`
- `validate_bridge_id(value, label)` — path-segment safety guard
- `is_expired_error_type` / `is_suppressible_403` — error predicates used by callers
- `ANTHROPIC_VERSION` + `BETA_HEADER` constants
- `BridgeFatalError` re-export

## Key behaviors (mirror TS)

- **One-shot 401 retry** via injected `on_auth_401` callback; the retry only fires when the callback returns `True` and never recurses
- **Empty-poll log throttling** — first poll + every 100th; counter resets on any non-empty response or error
- **`archive_session` treats 409 as idempotent success**
- **401/403/404/410** raise `BridgeFatalError`; **429/other** raise plain `Exception`
- **403 with 'expired' error_type** uses session-expiry message
- **Defensive guards on register/heartbeat responses** prevent `AttributeError` on non-JSON 200 bodies (gateway HTML, truncation, etc.)
- **Path validation** rejects `../`, `/`, `.`, whitespace, percent-encoded chars before URL interpolation

## Intentional divergences from TS (documented in docstrings)

- `_resolve_auth` raises `BridgeFatalError(401)` instead of plain `Error` so callers can pattern-match on `.status`
- `poll_for_work` uses `data is None` (exact TS parity for `null`) so empty `{}` falls through as a server-contract violation rather than silently no-work
- Factory uses keyword-only opts (Pythonic) instead of TS options object
- No-injected-client path goes via `_send_with_fresh_client` seam so the production fallback is verifiable via `monkeypatch`

## Test coverage (52 new tests)

- Headers (OAuth + trusted device token + omit-when-None)
- All 9 methods' URL/body/headers/error paths
- OAuth 401 retry: refresh-success, refresh-fail, double-401-no-loop, non-401-skips-retry
- Poll counter: first-log, every-100th, reset-on-non-empty, off-by-one guard at 101+102
- `base_url` trailing-slash normalization
- Non-JSON body defenses (the BLOCKING regression test)
- Empty-dict poll falls through (exact TS parity)
- `httpx.ConnectError` / `httpx.ReadTimeout` propagate unwrapped
- Secret redaction in debug logs (security regression guard)
- No-injected-client production path via seam monkeypatch
- `cancel_event` no-op contract pinned (Phase 5 wires it)

## Test plan

- [x] `uv run pytest tests/bridge` — **422/422 pass** (52 new + 370 existing)
- [x] CRITIC review: APPROVE after 2 rounds (resolved BLOCKING `AttributeError` crash on non-JSON 200, MAJOR empty-dict poll divergence, MAJOR untested no-injected-client path, MAJOR missing network-error tests)
- [x] `__init__.py` re-exports: `create_bridge_api_client`, `validate_bridge_id`, `is_expired_error_type`, `is_suppressible_403`, `ANTHROPIC_VERSION`, `BETA_HEADER` (62 symbols total in `__all__`)
- [ ] CI green
- [ ] Reviewer spot-checks: OAuth retry semantics (`test_oauth_retry_returns_401_when_retry_also_401`); non-JSON guard (`test_register_non_json_body_raises_fatal`); secret redaction (`test_register_redacts_environment_secret_in_debug_log`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)