### PR TITLE
bridge phase 5 (MVP): v2 env-less Remote Control orchestrator

### DIFF
--- a/src/bridge/__init__.py
+++ b/src/bridge/__init__.py
@@ -93,6 +93,22 @@ from src.bridge.repl_bridge_handle import (
     get_self_bridge_compat_id,
     set_repl_bridge_handle,
 )
+
+
+# Lazy re-export of the Phase 5 orchestrator surface. ``remote_bridge_core``
+# transitively imports ``repl_bridge_transport`` → ``src.transports.ccr_client``
+# → ``src.bridge.exceptions``. Eagerly importing here triggers a circular
+# import the first time any consumer starts at ``src.transports.ccr_client``
+# (the ``exceptions`` import re-enters ``bridge/__init__.py`` mid-load).
+# PEP 562 ``__getattr__`` defers the import until first attribute access,
+# which by then has ``bridge/__init__.py`` fully loaded.
+def __getattr__(name: str) -> object:
+    if name in ('init_env_less_bridge_core', 'EnvLessBridgeParams',
+                'RemoteBridgeHandle'):
+        from src.bridge import remote_bridge_core as _rbc
+
+        return getattr(_rbc, name)
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
 from src.bridge.session_id_compat import (
     set_cse_shim_gate,
     to_compat_session_id,
@@ -136,10 +152,12 @@ __all__ = [
     'DEFAULT_POLL_CONFIG',
     'DEFAULT_SESSION_TIMEOUT_MS',
     'EnvLessBridgeConfig',
+    'EnvLessBridgeParams',
     'EpochSupersededError',
     'FlushGate',
     'PollIntervalConfig',
     'REMOTE_CONTROL_DISCONNECTED_MSG',
+    'RemoteBridgeHandle',
     'SessionActivity',
     'WS_CLOSE_EPOCH_MISMATCH',
     'WS_CLOSE_INIT_FAILURE',
@@ -170,6 +188,7 @@ __all__ = [
     'get_poll_interval_config',
     'get_repl_bridge_handle',
     'get_self_bridge_compat_id',
+    'init_env_less_bridge_core',
     'is_bridge_permission_response',
     'normalize_image_blocks',
     'same_session_id',

--- a/src/bridge/remote_bridge_core.py
+++ b/src/bridge/remote_bridge_core.py
@@ -1,0 +1,1176 @@
+"""Env-less Remote Control bridge core — Phase 5 MVP.
+
+Ports ``typescript/src/bridge/remoteBridgeCore.ts``.
+
+"Env-less" means no Environments API layer — this connects directly to
+the session-ingress (CCR v2) layer:
+
+  1. POST ``/v1/code/sessions``              → ``cse_*`` session id
+  2. POST ``/v1/code/sessions/{id}/bridge``  → worker JWT + epoch + TTL
+  3. ``create_v2_repl_transport``            → SSE reads + CCRClient writes
+  4. ``TokenRefreshScheduler``               → proactive ``/bridge`` re-call before expiry
+  5. 401 on SSE                              → re-fetch ``/bridge`` and rebuild transport
+
+No register/poll/ack/stop/heartbeat/deregister environment lifecycle.
+Each ``/bridge`` call bumps ``worker_epoch`` server-side, so any refresh
+path must rebuild the transport (a JWT-only swap leaves the old
+CCRClient heartbeating with a stale epoch → 409 within 20s).
+
+**MVP scope** (this Phase 5 port intentionally defers a few things):
+
+* **No connect-timeout telemetry** — TS arms a ``setTimeout`` that
+  emits ``tengu_bridge_repl_connect_timeout`` if neither onConnect nor
+  onClose fires before ``cfg.connect_timeout_ms``. The Python port logs
+  the deadline as a debug warning instead; analytics wiring lands in
+  Phase 10.
+* **No CCR mirror-mode telemetry** — the ``CCR_MIRROR`` feature flag
+  branches on telemetry event names; we route everything through
+  ``tengu_bridge_repl_*`` for now.
+* **Trusted-device token** — passes ``None`` (no Phase 10 keychain).
+* **``ConnectCause`` enum** — kept as a string for log clarity but not
+  used for telemetry discriminator (no analytics in this build).
+
+What IS ported in full:
+
+* OAuth → ``/code/sessions`` → ``/bridge`` init with retry+jitter
+* v2 transport build (SSE + CCRClient via existing factory)
+* FlushGate + dual-set UUID dedup (echo + re-delivery)
+* Proactive JWT refresh via ``TokenRefreshScheduler`` (epoch-bumping
+  rebuild on fire)
+* 401 SSE recovery (token refresh + rebuild)
+* ``ReplBridgeHandle``-style return surface: ``write_messages``,
+  ``write_sdk_messages``, ``send_control_request``,
+  ``send_control_response``, ``send_cancel_request``, ``send_result``,
+  ``teardown``
+* Idempotent teardown: cancel scheduler → drop gate → reportState idle →
+  write result → archive (with 401 retry) → close
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable
+
+import httpx
+
+from src.bridge.bounded_uuid_set import BoundedUUIDSet
+from src.bridge.code_session_api import (
+    RemoteCredentials,
+    create_code_session,
+    fetch_remote_credentials,
+)
+from src.bridge.env_less_bridge_config import (
+    DEFAULT_ENV_LESS_BRIDGE_CONFIG,
+    EnvLessBridgeConfig,
+    get_env_less_bridge_config,
+)
+from src.bridge.flush_gate import FlushGate
+from src.bridge.jwt_utils import TokenRefreshScheduler
+from src.bridge.messaging import (
+    extract_title_text,
+    handle_ingress_message,
+    is_eligible_bridge_message,
+    make_result_message,
+)
+from src.bridge.messaging_handlers import (
+    ServerControlRequestHandlers,
+    handle_server_control_request,
+)
+from src.bridge.repl_bridge_transport import (
+    ReplBridgeTransport,
+    V2TransportOptions,
+    create_v2_repl_transport,
+)
+from src.bridge.session_id_compat import to_compat_session_id
+from src.bridge.work_secret import build_ccr_v2_sdk_url
+from src.types.messages import Message
+from src.utils.message_mappers import to_sdk_messages
+
+logger = logging.getLogger(__name__)
+
+
+_TEARDOWN_RESULT_WRITE_TIMEOUT_SECONDS = 0.5
+"""Cap on the teardown result-write enqueue wait. ``gracefulShutdown``
+races teardown against a 2s budget; 0.5s leaves headroom for archive +
+close while still containing back-pressure stalls."""
+
+
+# ── Public types ──────────────────────────────────────────────────────────
+
+
+BridgeState = str
+"""Lifecycle states emitted via ``on_state_change``: ``'ready'``,
+``'connected'``, ``'reconnecting'``, ``'failed'``. Kept as ``str`` to
+stay compatible with Phase 6+ orchestrators that share the same union.
+"""
+
+
+OnInboundMessage = Callable[[dict[str, Any]], Any]
+OnUserMessage = Callable[[str, str], bool]
+OnPermissionResponse = Callable[[dict[str, Any]], None]
+OnInterrupt = Callable[[], None]
+OnSetModel = Callable[[str | None], None]
+OnSetMaxThinkingTokens = Callable[[int | None], None]
+OnSetPermissionMode = Callable[[str], Any]
+OnStateChange = Callable[..., None]
+"""``on_state_change(state, detail=None)`` — kept as ``...`` so call
+sites can omit detail."""
+
+OnAuth401 = Callable[[str], Awaitable[bool]]
+GetAccessToken = Callable[[], str | None]
+
+
+@dataclass
+class EnvLessBridgeParams:
+    """Configuration for ``init_env_less_bridge_core``.
+
+    Mirrors TS ``EnvLessBridgeParams`` on ``remoteBridgeCore.ts:89-131``.
+    Required: ``base_url``, ``org_uuid``, ``title``, ``get_access_token``,
+    ``initial_history_cap``. All callbacks are optional.
+    """
+
+    base_url: str
+    org_uuid: str
+    title: str
+    get_access_token: GetAccessToken
+    initial_history_cap: int
+    initial_messages: list[Message] | None = None
+    on_auth_401: OnAuth401 | None = None
+    on_inbound_message: OnInboundMessage | None = None
+    on_user_message: OnUserMessage | None = None
+    on_permission_response: OnPermissionResponse | None = None
+    on_interrupt: OnInterrupt | None = None
+    on_set_model: OnSetModel | None = None
+    on_set_max_thinking_tokens: OnSetMaxThinkingTokens | None = None
+    on_set_permission_mode: OnSetPermissionMode | None = None
+    on_state_change: OnStateChange | None = None
+    outbound_only: bool = False
+    tags: list[str] | None = None
+
+
+@dataclass
+class RemoteBridgeHandle:
+    """Opaque handle returned by ``init_env_less_bridge_core``.
+
+    Mirrors the consumer-facing surface of TS ``ReplBridgeHandle``
+    (``remoteBridgeCore.ts:763-886``). All write methods are sync
+    fire-and-forget — the underlying transport batches writes via
+    ``SerialBatchEventUploader``. ``teardown`` is async and idempotent.
+    """
+
+    bridge_session_id: str
+    environment_id: str  # always empty for env-less
+    session_ingress_url: str
+    write_messages: Callable[[list[Message]], None]
+    write_sdk_messages: Callable[[list[dict[str, Any]]], None]
+    send_control_request: Callable[[dict[str, Any]], None]
+    send_control_response: Callable[[dict[str, Any]], None]
+    send_cancel_request: Callable[[str], None]
+    send_result: Callable[[], None]
+    teardown: Callable[[], Awaitable[None]]
+
+
+# ── Init ──────────────────────────────────────────────────────────────────
+
+
+async def init_env_less_bridge_core(
+    params: EnvLessBridgeParams,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+    config: EnvLessBridgeConfig | None = None,
+    transport_factory: Callable[
+        [V2TransportOptions], Awaitable[ReplBridgeTransport]
+    ] | None = None,
+) -> RemoteBridgeHandle | None:
+    """Create a session, fetch a worker JWT, connect the v2 transport.
+
+    Returns ``None`` on any pre-flight failure (session create failed,
+    ``/bridge`` failed, transport setup failed). Caller surfaces this as
+    a generic "initialization failed" state.
+
+    Test seams (kw-only — production callers omit):
+
+    * ``http_client``: optional injected ``httpx.AsyncClient`` for the
+      ``/code/sessions``, ``/bridge``, and ``archive`` calls.
+    * ``config``: override ``EnvLessBridgeConfig`` (otherwise fetched
+      via ``get_env_less_bridge_config()`` which currently returns
+      defaults).
+    * ``transport_factory``: override the v2 transport constructor for
+      tests so they can inject a fake without hitting the SSE/CCR layer.
+    """
+    cfg = config if config is not None else await get_env_less_bridge_config()
+    factory = transport_factory or create_v2_repl_transport
+
+    # ── 1. OAuth pre-check ─────────────────────────────────────────────
+    access_token = params.get_access_token()
+    if not access_token:
+        logger.debug('[remote-bridge] No OAuth token')
+        return None
+
+    # ── 2. Create session (POST /v1/code/sessions) ─────────────────────
+    timeout_seconds = cfg.http_timeout_ms / 1000.0
+    session_id = await _with_retry(
+        lambda: create_code_session(
+            params.base_url,
+            access_token,
+            params.title,
+            timeout_seconds=timeout_seconds,
+            tags=params.tags,
+            client=http_client,
+        ),
+        'createCodeSession',
+        cfg,
+    )
+    if session_id is None:
+        _fire_state(params.on_state_change, 'failed',
+                    'Session creation failed — see debug log')
+        return None
+    logger.debug('[remote-bridge] Created session %s', session_id)
+
+    # ── 3. Fetch bridge credentials ────────────────────────────────────
+    credentials = await _with_retry(
+        lambda: fetch_remote_credentials(
+            session_id,
+            params.base_url,
+            access_token,
+            timeout_seconds=timeout_seconds,
+            client=http_client,
+        ),
+        'fetchRemoteCredentials',
+        cfg,
+    )
+    if credentials is None:
+        _fire_state(params.on_state_change, 'failed',
+                    'Remote credentials fetch failed — see debug log')
+        await _safe_archive_session(
+            session_id,
+            params.base_url,
+            access_token,
+            params.org_uuid,
+            timeout_seconds,
+            http_client,
+        )
+        return None
+    logger.debug(
+        '[remote-bridge] Fetched bridge credentials (expires_in=%ss)',
+        credentials.expires_in,
+    )
+
+    # ── 4. Build v2 transport ──────────────────────────────────────────
+    session_url = build_ccr_v2_sdk_url(credentials.api_base_url, session_id)
+    try:
+        transport = await factory(
+            V2TransportOptions(
+                session_url=session_url,
+                ingress_token=credentials.worker_jwt,
+                session_id=session_id,
+                epoch=credentials.worker_epoch,
+                heartbeat_interval_seconds=cfg.heartbeat_interval_ms / 1000.0,
+                heartbeat_jitter_fraction=cfg.heartbeat_jitter_fraction,
+                outbound_only=params.outbound_only,
+                # Per-instance closure — keeps the worker JWT out of
+                # ``CLAUDE_CODE_SESSION_ACCESS_TOKEN`` env which mcp/client
+                # would otherwise leak to user-configured MCP servers.
+                # Frozen at construction: transport is fully rebuilt on
+                # refresh (rebuild_transport below) with a fresh closure.
+                get_auth_token=_freeze_token(credentials.worker_jwt),
+            )
+        )
+    except Exception as err:  # noqa: BLE001  surface as pre-flight failure
+        logger.error('[remote-bridge] v2 transport setup failed: %s', err)
+        _fire_state(params.on_state_change, 'failed',
+                    f'Transport setup failed: {err}')
+        await _safe_archive_session(
+            session_id,
+            params.base_url,
+            access_token,
+            params.org_uuid,
+            timeout_seconds,
+            http_client,
+        )
+        return None
+    logger.debug(
+        '[remote-bridge] v2 transport created (epoch=%s)',
+        credentials.worker_epoch,
+    )
+    _fire_state(params.on_state_change, 'ready')
+
+    # ── 5. State (closures shared by all callbacks) ────────────────────
+    state = _BridgeState(
+        params=params,
+        cfg=cfg,
+        session_id=session_id,
+        credentials=credentials,
+        transport=transport,
+        http_client=http_client,
+        transport_factory=factory,
+    )
+
+    # ── 6. JWT refresh scheduler ───────────────────────────────────────
+    refresh = TokenRefreshScheduler(
+        get_access_token=_async_refresh_token(params),
+        on_refresh=state.on_jwt_refresh,
+        label='remote',
+        refresh_buffer_ms=cfg.token_refresh_buffer_ms,
+    )
+    state.refresh = refresh
+    refresh.schedule_from_expires_in(session_id, credentials.expires_in)
+
+    # ── 7. Wire transport callbacks ────────────────────────────────────
+    state.wire_transport_callbacks()
+
+    # Start the flushGate BEFORE connect *unconditionally* so any
+    # write_messages() / send_* calls that arrive during the handshake
+    # are queued instead of dropped. The Python ``CCRClient.write_event``
+    # silently drops messages while ``_initialized is False`` (unlike
+    # TS's ``SerialBatchEventUploader`` which queues), so any pre-onConnect
+    # write would be lost without this gate. The gate is drained in
+    # ``_on_connect`` once the new transport's CCR is initialized.
+    state.flush_gate.start()
+    transport.connect()
+
+    # ── 8. Return handle ───────────────────────────────────────────────
+    return RemoteBridgeHandle(
+        bridge_session_id=session_id,
+        environment_id='',
+        session_ingress_url=credentials.api_base_url,
+        write_messages=state.write_messages,
+        write_sdk_messages=state.write_sdk_messages,
+        send_control_request=state.send_control_request,
+        send_control_response=state.send_control_response,
+        send_cancel_request=state.send_cancel_request,
+        send_result=state.send_result,
+        teardown=state.teardown,
+    )
+
+
+# ── Internal state machine (one instance per bridge) ──────────────────────
+
+
+@dataclass
+class _BridgeState:
+    """All mutable state for one env-less bridge.
+
+    Lives in its own class so the closure-heavy TS code maps cleanly to
+    Python — each "inner function" in TS becomes a method that reads/
+    writes ``self``.
+    """
+
+    params: EnvLessBridgeParams
+    cfg: EnvLessBridgeConfig
+    session_id: str
+    credentials: RemoteCredentials
+    transport: ReplBridgeTransport
+    http_client: httpx.AsyncClient | None
+    transport_factory: Callable[
+        [V2TransportOptions], Awaitable[ReplBridgeTransport]
+    ]
+    refresh: TokenRefreshScheduler | None = None
+
+    recent_posted_uuids: BoundedUUIDSet = field(init=False)
+    initial_message_uuids: set[str] = field(default_factory=set)
+    recent_inbound_uuids: BoundedUUIDSet = field(init=False)
+    flush_gate: FlushGate[Message] = field(default_factory=FlushGate)
+
+    initial_flush_done: bool = False
+    torn_down: bool = False
+    auth_recovery_in_flight: bool = False
+    user_message_callback_done: bool = False
+    connect_cause: str = 'initial'
+
+    def __post_init__(self) -> None:
+        # UUID dedup ring buffers, sized per env-less config.
+        self.recent_posted_uuids = BoundedUUIDSet(
+            self.cfg.uuid_dedup_buffer_size
+        )
+        self.recent_inbound_uuids = BoundedUUIDSet(
+            self.cfg.uuid_dedup_buffer_size
+        )
+
+        # Seed dedup with initial-history UUIDs so server echoes of the
+        # flushed history are recognized as our own.
+        if self.params.initial_messages:
+            for msg in self.params.initial_messages:
+                self.initial_message_uuids.add(msg.uuid)
+                self.recent_posted_uuids.add(msg.uuid)
+
+        # Latch onUserMessage as already-done when no callback was wired.
+        self.user_message_callback_done = self.params.on_user_message is None
+
+    # ── Callback wiring ────────────────────────────────────────────────
+
+    def wire_transport_callbacks(self) -> None:
+        """Wire SSE setOnConnect / setOnData / setOnClose callbacks.
+
+        Re-callable after a transport rebuild — captures ``self.transport``
+        lazily via the closures so the new transport receives the wiring.
+        """
+        active_transport = self.transport
+        self.transport.set_on_connect(
+            lambda: self._on_connect(active_transport)
+        )
+        self.transport.set_on_data(self._on_data)
+        self.transport.set_on_close(self._on_close)
+
+    def _on_connect(self, flush_transport: ReplBridgeTransport) -> None:
+        """Fired when the transport handshake completes (CCR initialized).
+
+        At this point ``CCRClient.is_initialized`` is True (the v2 transport
+        wires this callback after ``await ccr.initialize()`` resolves), so
+        it's safe to drain the flushGate — any queued writes will reach the
+        uploader and be POSTed. Flushes initial history first if present.
+
+        ``flush_transport`` is captured at wire time — if a 401/teardown
+        swaps ``self.transport`` mid-flush, the stale callback is a no-op
+        (matches TS guard pattern).
+        """
+        logger.debug('[remote-bridge] v2 transport connected')
+        if (
+            not self.initial_flush_done
+            and self.params.initial_messages
+            and len(self.params.initial_messages) > 0
+        ):
+            self.initial_flush_done = True
+            asyncio.create_task(
+                self._flush_history_then_drain(flush_transport)
+            )
+            return
+        # No initial flush — drain any pre-connect queued writes
+        # (``write_messages`` calls that landed during the handshake) and
+        # close the gate so subsequent writes go straight to the uploader.
+        if self.flush_gate.active:
+            self._drain_flush_gate()
+        _fire_state(self.params.on_state_change, 'connected')
+
+    async def _flush_history_then_drain(
+        self, flush_transport: ReplBridgeTransport
+    ) -> None:
+        """Async wrapper for flush + drain. Mirrors TS .finally() chain.
+
+        Stale-transport guards: if the transport was swapped mid-flush
+        (401 recovery, teardown), skip the drain — the new transport's
+        re-wired onConnect will re-flush.
+        """
+        try:
+            assert self.params.initial_messages is not None
+            await self._flush_history(self.params.initial_messages)
+        except Exception as err:  # noqa: BLE001  log + carry on
+            logger.warning('[remote-bridge] flushHistory failed: %s', err)
+        finally:
+            if (
+                self.transport is flush_transport
+                and not self.torn_down
+                and not self.auth_recovery_in_flight
+            ):
+                self._drain_flush_gate()
+                _fire_state(self.params.on_state_change, 'connected')
+
+    def _on_data(self, data: str) -> None:
+        """Route an SSE event line to the ingress handler."""
+        params = self.params
+        transport = self.transport
+
+        on_permission_response_wrapped: OnPermissionResponse | None = None
+        if params.on_permission_response is not None:
+            inner = params.on_permission_response
+
+            def wrapped(response: dict[str, Any]) -> None:
+                # Remote client answered the prompt — turn resumes.
+                # Without reportState('running'), the server stays on
+                # ``requires_action`` until the next user message or
+                # turn-end result.
+                transport.report_state({'state': 'running'})
+                inner(response)
+
+            on_permission_response_wrapped = wrapped
+
+        def on_control_request(request: dict[str, Any]) -> None:
+            handle_server_control_request(
+                request,
+                ServerControlRequestHandlers(
+                    transport=transport,  # type: ignore[arg-type]
+                    session_id=self.session_id,
+                    outbound_only=params.outbound_only,
+                    on_interrupt=params.on_interrupt,
+                    on_set_model=params.on_set_model,
+                    on_set_max_thinking_tokens=params.on_set_max_thinking_tokens,
+                    on_set_permission_mode=params.on_set_permission_mode,
+                ),
+            )
+
+        handle_ingress_message(
+            data,
+            self.recent_posted_uuids,
+            self.recent_inbound_uuids,
+            params.on_inbound_message,
+            on_permission_response_wrapped,
+            on_control_request,
+        )
+
+    def _on_close(self, code: int | None) -> None:
+        """Fired when the transport closes terminally.
+
+        Per TS comment: onClose fires only for TERMINAL failures —
+        401 (JWT invalid), 4090 (epoch mismatch), 4091 (init failed),
+        or SSE reconnect-budget exhausted. Transient drops are handled
+        inside SSETransport. 401 is recoverable (fetch fresh JWT,
+        rebuild transport); other codes are dead-ends.
+        """
+        if self.torn_down:
+            return
+        logger.debug('[remote-bridge] v2 transport closed (code=%s)', code)
+        if code == 401 and not self.auth_recovery_in_flight:
+            asyncio.create_task(self._recover_from_auth_failure())
+            return
+        _fire_state(
+            self.params.on_state_change, 'failed',
+            f'Transport closed (code {code})',
+        )
+
+    # ── Transport rebuild (shared by proactive refresh + 401 recovery) ──
+
+    async def _rebuild_transport(
+        self,
+        fresh: RemoteCredentials,
+        cause: str,
+    ) -> None:
+        """Replace the transport with a fresh JWT+epoch.
+
+        Caller MUST set ``self.auth_recovery_in_flight = True`` before
+        calling (synchronously, before any ``await``) and clear it in a
+        ``finally``. Moving that here would be too late to prevent a
+        double ``/bridge`` fetch.
+        """
+        self.connect_cause = cause
+        # Queue writes during rebuild — once /bridge returns, the old
+        # transport's epoch is stale and its next write/heartbeat 409s.
+        # ``deactivate()`` (vs ``drop()``) on success leaves queued items
+        # for the new transport's ``_on_connect`` to drain.
+        self.flush_gate.start()
+        success = False
+        try:
+            old_seq = self.transport.get_last_sequence_num()
+            self.transport.close()
+            self.transport = await self.transport_factory(
+                V2TransportOptions(
+                    session_url=build_ccr_v2_sdk_url(
+                        fresh.api_base_url, self.session_id
+                    ),
+                    ingress_token=fresh.worker_jwt,
+                    session_id=self.session_id,
+                    epoch=fresh.worker_epoch,
+                    heartbeat_interval_seconds=(
+                        self.cfg.heartbeat_interval_ms / 1000.0
+                    ),
+                    heartbeat_jitter_fraction=(
+                        self.cfg.heartbeat_jitter_fraction
+                    ),
+                    initial_sequence_num=old_seq,
+                    outbound_only=self.params.outbound_only,
+                    get_auth_token=_freeze_token(fresh.worker_jwt),
+                )
+            )
+            if self.torn_down:
+                # Teardown fired during the async factory window — don't
+                # wire/connect/schedule; we'd re-arm timers after cancelAll
+                # and fire onInboundMessage into a torn-down bridge.
+                self.transport.close()
+                return
+            self.wire_transport_callbacks()
+            self.transport.connect()
+            if self.refresh is not None:
+                self.refresh.schedule_from_expires_in(
+                    self.session_id, fresh.expires_in
+                )
+            self.credentials = fresh
+            # Leave the gate active — the new transport's ``_on_connect``
+            # will drain it once CCR.initialize() resolves. Python
+            # ``CCRClient.write_event`` silently drops while
+            # ``_initialized is False`` (TS ``SerialBatchEventUploader``
+            # queues instead — known divergence), so draining here would
+            # lose every queued message between now and the SSE/CCR
+            # handshake completing.
+            success = True
+        finally:
+            # Failure path (exception unwound the try, or torn_down
+            # short-circuit): drop the queued items because the new
+            # transport isn't going to come up.
+            if not success:
+                self.flush_gate.drop()
+
+    # ── 401 recovery ───────────────────────────────────────────────────
+
+    async def _recover_from_auth_failure(self) -> None:
+        """Recover from a 401 on the SSE stream.
+
+        Refresh OAuth, re-fetch ``/bridge``, rebuild transport. Shared
+        ``auth_recovery_in_flight`` flag with the proactive refresh path
+        prevents double-bumping epoch.
+        """
+        if self.auth_recovery_in_flight:
+            return
+        self.auth_recovery_in_flight = True
+        _fire_state(
+            self.params.on_state_change, 'reconnecting',
+            'JWT expired — refreshing',
+        )
+        logger.debug('[remote-bridge] 401 on SSE — attempting JWT refresh')
+        try:
+            # getAccessToken() returns expired tokens as non-None strings
+            # — unconditional OAuth refresh below catches that.
+            stale = self.params.get_access_token()
+            if self.params.on_auth_401 is not None:
+                await self.params.on_auth_401(stale or '')
+            oauth_token = self.params.get_access_token() or stale
+            if not oauth_token or self.torn_down:
+                if not self.torn_down:
+                    _fire_state(
+                        self.params.on_state_change, 'failed',
+                        'JWT refresh failed: no OAuth token',
+                    )
+                return
+            fresh = await _with_retry(
+                lambda: fetch_remote_credentials(
+                    self.session_id,
+                    self.params.base_url,
+                    oauth_token,
+                    timeout_seconds=self.cfg.http_timeout_ms / 1000.0,
+                    client=self.http_client,
+                ),
+                'fetchRemoteCredentials (recovery)',
+                self.cfg,
+            )
+            if fresh is None or self.torn_down:
+                if not self.torn_down:
+                    _fire_state(
+                        self.params.on_state_change, 'failed',
+                        'JWT refresh failed after 401',
+                    )
+                return
+            # If 401 interrupted the initial flush, writeBatch may have
+            # silently no-op'd on the closed uploader. Reset so the new
+            # onConnect re-flushes.
+            self.initial_flush_done = False
+            await self._rebuild_transport(fresh, 'auth_401_recovery')
+            logger.debug('[remote-bridge] Transport rebuilt after 401')
+        except Exception as err:  # noqa: BLE001  log + surface
+            logger.error(
+                '[remote-bridge] 401 recovery failed: %s', err
+            )
+            if not self.torn_down:
+                _fire_state(
+                    self.params.on_state_change, 'failed',
+                    f'JWT refresh failed: {err}',
+                )
+        finally:
+            self.auth_recovery_in_flight = False
+
+    def on_jwt_refresh(self, session_id: str, oauth_token: str) -> None:
+        """Called by ``TokenRefreshScheduler`` 5min before JWT expiry.
+
+        Re-fetches ``/bridge`` and rebuilds the transport. Serialized
+        against ``recover_from_auth_failure`` via ``auth_recovery_in_flight``
+        so a laptop-wake double-fire doesn't bump epoch twice.
+        """
+        async def _do() -> None:
+            if self.auth_recovery_in_flight or self.torn_down:
+                logger.debug(
+                    '[remote-bridge] Recovery already in flight, '
+                    'skipping proactive refresh'
+                )
+                return
+            self.auth_recovery_in_flight = True
+            try:
+                fresh = await _with_retry(
+                    lambda: fetch_remote_credentials(
+                        session_id,
+                        self.params.base_url,
+                        oauth_token,
+                        timeout_seconds=self.cfg.http_timeout_ms / 1000.0,
+                        client=self.http_client,
+                    ),
+                    'fetchRemoteCredentials (proactive)',
+                    self.cfg,
+                )
+                if fresh is None or self.torn_down:
+                    return
+                await self._rebuild_transport(fresh, 'proactive_refresh')
+                logger.debug(
+                    '[remote-bridge] Transport rebuilt (proactive refresh)'
+                )
+            except Exception as err:  # noqa: BLE001
+                logger.error(
+                    '[remote-bridge] Proactive refresh rebuild failed: %s',
+                    err,
+                )
+                if not self.torn_down:
+                    _fire_state(
+                        self.params.on_state_change, 'failed',
+                        f'Refresh failed: {err}',
+                    )
+            finally:
+                self.auth_recovery_in_flight = False
+
+        asyncio.create_task(_do())
+
+    # ── History flush + drain ──────────────────────────────────────────
+
+    async def _flush_history(self, msgs: list[Message]) -> None:
+        """POST a capped, eligible-only slice of initial history.
+
+        Cap via ``initial_history_cap``; filter via
+        ``is_eligible_bridge_message``. The cap takes the *tail* to keep
+        the most recent context. If the eligible tail is a user message
+        (pre-cap), reports state ``'running'`` so the web UI shows the
+        turn-in-progress indicator immediately on connect.
+        """
+        eligible = [m for m in msgs if is_eligible_bridge_message(_msg_dict(m))]
+        cap = self.params.initial_history_cap
+        capped = (
+            eligible[-cap:] if cap > 0 and len(eligible) > cap else eligible
+        )
+        if len(capped) < len(eligible):
+            logger.debug(
+                '[remote-bridge] Capped initial flush: %s -> %s (cap=%s)',
+                len(eligible), len(capped), cap,
+            )
+        events = [
+            {**m, 'session_id': self.session_id}
+            for m in to_sdk_messages(capped)
+        ]
+        if not events:
+            return
+        # Pre-cap eligible tail decides reportState: the cap may truncate
+        # to a user message even when the actual trailing message is
+        # assistant. Match TS behavior exactly.
+        if eligible and _msg_dict(eligible[-1]).get('type') == 'user':
+            self.transport.report_state({'state': 'running'})
+        logger.debug(
+            '[remote-bridge] Flushing %s history events', len(events)
+        )
+        await self.transport.write_batch(events)
+
+    def _drain_flush_gate(self) -> None:
+        """Send any messages queued during the flush window."""
+        msgs = self.flush_gate.end()
+        if not msgs:
+            return
+        for msg in msgs:
+            self.recent_posted_uuids.add(msg.uuid)
+        events = [
+            {**m, 'session_id': self.session_id}
+            for m in to_sdk_messages(msgs)
+        ]
+        if any(_msg_dict(m).get('type') == 'user' for m in msgs):
+            self.transport.report_state({'state': 'running'})
+        logger.debug(
+            '[remote-bridge] Drained %s queued message(s) after flush',
+            len(msgs),
+        )
+        asyncio.create_task(self.transport.write_batch(events))
+
+    # ── Public handle methods ──────────────────────────────────────────
+
+    def write_messages(self, messages: list[Message]) -> None:
+        """Write a batch of local Message[] to the transport."""
+        filtered = [
+            m for m in messages
+            if is_eligible_bridge_message(_msg_dict(m))
+            and m.uuid not in self.initial_message_uuids
+            and not self.recent_posted_uuids.has(m.uuid)
+        ]
+        if not filtered:
+            return
+
+        # Title derivation — scan BEFORE the flushGate check so prompts
+        # queued during flush still count.
+        if not self.user_message_callback_done:
+            for m in filtered:
+                text = extract_title_text(_msg_dict(m))
+                cb = self.params.on_user_message
+                if text is not None and cb is not None and cb(text, self.session_id):
+                    self.user_message_callback_done = True
+                    break
+
+        if self.flush_gate.enqueue(*filtered):
+            logger.debug(
+                '[remote-bridge] Queued %s message(s) during flush',
+                len(filtered),
+            )
+            return
+
+        for msg in filtered:
+            self.recent_posted_uuids.add(msg.uuid)
+        events = [
+            {**m, 'session_id': self.session_id}
+            for m in to_sdk_messages(filtered)
+        ]
+        if any(_msg_dict(m).get('type') == 'user' for m in filtered):
+            self.transport.report_state({'state': 'running'})
+        logger.debug(
+            '[remote-bridge] Sending %s message(s)', len(filtered)
+        )
+        asyncio.create_task(self.transport.write_batch(events))
+
+    def write_sdk_messages(self, messages: list[dict[str, Any]]) -> None:
+        """Write pre-shaped SDK messages (used by the daemon path)."""
+        filtered = [
+            m for m in messages
+            if not m.get('uuid') or not self.recent_posted_uuids.has(m['uuid'])
+        ]
+        if not filtered:
+            return
+        for msg in filtered:
+            uid = msg.get('uuid')
+            if uid:
+                self.recent_posted_uuids.add(uid)
+        events = [{**m, 'session_id': self.session_id} for m in filtered]
+        asyncio.create_task(self.transport.write_batch(events))
+
+    def send_control_request(self, request: dict[str, Any]) -> None:
+        if self.auth_recovery_in_flight:
+            logger.debug(
+                '[remote-bridge] Dropping control_request during '
+                '401 recovery: %s', request.get('request_id'),
+            )
+            return
+        event = {**request, 'session_id': self.session_id}
+        inner = request.get('request') or {}
+        if inner.get('subtype') == 'can_use_tool':
+            self.transport.report_state({'state': 'requires_action'})
+        asyncio.create_task(self.transport.write(event))
+        logger.debug(
+            '[remote-bridge] Sent control_request request_id=%s',
+            request.get('request_id'),
+        )
+
+    def send_control_response(self, response: dict[str, Any]) -> None:
+        if self.auth_recovery_in_flight:
+            logger.debug(
+                '[remote-bridge] Dropping control_response during 401 recovery'
+            )
+            return
+        event = {**response, 'session_id': self.session_id}
+        self.transport.report_state({'state': 'running'})
+        asyncio.create_task(self.transport.write(event))
+        logger.debug('[remote-bridge] Sent control_response')
+
+    def send_cancel_request(self, request_id: str) -> None:
+        if self.auth_recovery_in_flight:
+            logger.debug(
+                '[remote-bridge] Dropping control_cancel_request '
+                'during 401 recovery: %s', request_id,
+            )
+            return
+        event = {
+            'type': 'control_cancel_request',
+            'request_id': request_id,
+            'session_id': self.session_id,
+        }
+        # Hook/classifier/channel/recheck resolved the permission locally
+        # — interactiveHandler calls only cancelRequest (no sendResponse)
+        # on those paths, so without this the server stays on
+        # requires_action.
+        self.transport.report_state({'state': 'running'})
+        asyncio.create_task(self.transport.write(event))
+        logger.debug(
+            '[remote-bridge] Sent control_cancel_request request_id=%s',
+            request_id,
+        )
+
+    def send_result(self) -> None:
+        if self.auth_recovery_in_flight:
+            logger.debug(
+                '[remote-bridge] Dropping result during 401 recovery'
+            )
+            return
+        self.transport.report_state({'state': 'idle'})
+        asyncio.create_task(
+            self.transport.write(make_result_message(self.session_id))
+        )
+        logger.debug('[remote-bridge] Sent result')
+
+    # ── Teardown ───────────────────────────────────────────────────────
+
+    async def teardown(self) -> None:
+        """Idempotent shutdown.
+
+        1. Cancel JWT refresh scheduler.
+        2. Drop the flush gate (any queued messages are lost — transport
+           is about to close).
+        3. ``reportState('idle')`` + write result message (fire-and-forget;
+           archive latency covers the uploader drain).
+        4. Archive the session via the v2 compat archive endpoint, with a
+           single 401 retry through ``on_auth_401``.
+        5. Close the transport.
+        """
+        if self.torn_down:
+            return
+        self.torn_down = True
+        if self.refresh is not None:
+            self.refresh.cancel_all()
+        self.flush_gate.drop()
+
+        # Fire the result message before archive. ``transport.write()``
+        # in Python awaits enqueue into ``CCRClient.SerialBatchEventUploader``
+        # (fast on the happy path) but blocks up to ``producer_timeout_seconds``
+        # (default 30s) when the queue is full. ``gracefulShutdown`` races
+        # this against a 2s cap, so bound the wait tightly — losing the
+        # result message under back-pressure is preferable to blocking
+        # teardown past the cap.
+        self.transport.report_state({'state': 'idle'})
+        try:
+            await asyncio.wait_for(
+                self.transport.write(make_result_message(self.session_id)),
+                timeout=_TEARDOWN_RESULT_WRITE_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                '[remote-bridge] Result write timed out after %ss '
+                '(producer queue back-pressure)',
+                _TEARDOWN_RESULT_WRITE_TIMEOUT_SECONDS,
+            )
+        except Exception as err:  # noqa: BLE001  log + carry on
+            logger.warning('[remote-bridge] Result write failed: %s', err)
+
+        token = self.params.get_access_token()
+        archive_timeout = self.cfg.teardown_archive_timeout_ms / 1000.0
+        status = await _archive_v2_session(
+            self.session_id,
+            self.params.base_url,
+            token,
+            self.params.org_uuid,
+            archive_timeout,
+            self.http_client,
+        )
+
+        # Single 401 retry — token might be stale post-laptop-wake.
+        if status == 401 and self.params.on_auth_401 is not None:
+            try:
+                await self.params.on_auth_401(token or '')
+                token = self.params.get_access_token()
+                status = await _archive_v2_session(
+                    self.session_id,
+                    self.params.base_url,
+                    token,
+                    self.params.org_uuid,
+                    archive_timeout,
+                    self.http_client,
+                )
+            except Exception as err:  # noqa: BLE001
+                logger.error(
+                    '[remote-bridge] Teardown 401 retry threw: %s', err
+                )
+
+        self.transport.close()
+        logger.debug(
+            '[remote-bridge] Torn down (archive=%s)', status
+        )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _freeze_token(token: str) -> Callable[[], str | None]:
+    """Capture the JWT in a closure so the transport reads it stably.
+
+    Per-instance auth header source; bypasses
+    ``CLAUDE_CODE_SESSION_ACCESS_TOKEN`` env var which mcp/client reads
+    ungatedly. Frozen at construction — the transport is fully rebuilt
+    on JWT refresh, so the closure is reissued each time.
+    """
+    return lambda: token
+
+
+def _fire_state(
+    cb: OnStateChange | None,
+    state: BridgeState,
+    detail: str | None = None,
+) -> None:
+    """Invoke ``on_state_change`` if wired, swallowing exceptions."""
+    if cb is None:
+        return
+    try:
+        if detail is None:
+            cb(state)
+        else:
+            cb(state, detail)
+    except Exception as err:  # noqa: BLE001
+        logger.warning(
+            '[remote-bridge] on_state_change callback raised: %s', err
+        )
+
+
+def _msg_dict(msg: Message | dict[str, Any]) -> dict[str, Any]:
+    """Coerce a Message dataclass to the wire-format dict shape.
+
+    The dict-shaped predicates in ``bridge.messaging`` mirror the TS
+    wire format where user/assistant messages have a nested
+    ``message: {role, content}`` field. Python ``UserMessage`` /
+    ``AssistantMessage`` keep ``role`` and ``content`` flat at the top
+    level, so a shallow ``vars()`` would give ``extract_title_text``
+    nothing to extract. We synthesize the nested ``message`` field
+    on top of the flat ``vars()`` so both ``is_eligible_bridge_message``
+    (reads ``type``/``isVirtual``/``subtype``) AND ``extract_title_text``
+    (reads ``message.content``) work against the same dict.
+    """
+    if isinstance(msg, dict):
+        return msg
+    flat = vars(msg).copy()
+    msg_type = flat.get('type')
+    # Only user/assistant carry inner ``message.content`` in the wire
+    # format; system and others stay flat.
+    if msg_type in ('user', 'assistant') and 'message' not in flat:
+        flat['message'] = {
+            'role': flat.get('role', msg_type),
+            'content': flat.get('content'),
+        }
+    return flat
+
+
+async def _with_retry(
+    fn: Callable[[], Awaitable[Any]],
+    label: str,
+    cfg: EnvLessBridgeConfig,
+) -> Any:
+    """Retry an async init call with exponential backoff + jitter.
+
+    Mirrors TS ``withRetry`` on ``remoteBridgeCore.ts:891-913``. Returns
+    the first non-``None`` result; ``None`` after all attempts indicates
+    permanent failure (caller logs + degrades).
+    """
+    max_attempts = cfg.init_retry_max_attempts
+    for attempt in range(1, max_attempts + 1):
+        result = await fn()
+        if result is not None:
+            return result
+        if attempt < max_attempts:
+            base_ms = cfg.init_retry_base_delay_ms * (2 ** (attempt - 1))
+            jitter_ms = (
+                base_ms
+                * cfg.init_retry_jitter_fraction
+                * (2 * random.random() - 1)
+            )
+            delay_ms = min(base_ms + jitter_ms, cfg.init_retry_max_delay_ms)
+            logger.debug(
+                '[remote-bridge] %s failed (attempt %s/%s), '
+                'retrying in %sms',
+                label, attempt, max_attempts, round(delay_ms),
+            )
+            await asyncio.sleep(delay_ms / 1000.0)
+    return None
+
+
+def _async_refresh_token(
+    params: EnvLessBridgeParams,
+) -> Callable[[], Awaitable[str | None]]:
+    """Build the async token getter for the JWT refresh scheduler.
+
+    Always attempts OAuth refresh first — ``get_access_token()`` returns
+    expired tokens as non-None strings (no expiresAt check), so we can't
+    rely on truthiness alone. Passes the stale token to ``on_auth_401``
+    so keychain-comparison can detect parallel refresh (Phase 10 wiring).
+    """
+    async def _refresh() -> str | None:
+        stale = params.get_access_token()
+        if params.on_auth_401 is not None:
+            await params.on_auth_401(stale or '')
+        return params.get_access_token() or stale
+
+    return _refresh
+
+
+async def _safe_archive_session(
+    session_id: str,
+    base_url: str,
+    access_token: str | None,
+    org_uuid: str,
+    timeout_seconds: float,
+    http_client: httpx.AsyncClient | None,
+) -> None:
+    """Best-effort archive used by the pre-flight failure paths.
+
+    Wraps ``_archive_v2_session`` and swallows all exceptions — the
+    caller is already about to return ``None`` from init, so any archive
+    failure shouldn't prevent that.
+    """
+    try:
+        await _archive_v2_session(
+            session_id, base_url, access_token, org_uuid,
+            timeout_seconds, http_client,
+        )
+    except Exception as err:  # noqa: BLE001
+        logger.debug(
+            '[remote-bridge] Pre-flight archive failed: %s', err
+        )
+
+
+_ARCHIVE_BETA_HEADER = 'ccr-byoc-2025-07-29'
+_ANTHROPIC_VERSION = '2023-06-01'
+
+
+async def _archive_v2_session(
+    session_id: str,
+    base_url: str,
+    access_token: str | None,
+    org_uuid: str,
+    timeout_seconds: float,
+    http_client: httpx.AsyncClient | None,
+) -> int | str:
+    """Archive a v2 session via the compat ``/v1/sessions/{id}/archive`` endpoint.
+
+    Mirrors TS ``archiveSession`` on ``remoteBridgeCore.ts:963-1008``.
+    The v2 archive lives at the compat layer (``/v1/sessions/*``, not
+    ``/v1/code/sessions/*``) and requires distinct headers vs.
+    ``bridge_api.archive_session`` (which targets the environments API):
+
+    * ``anthropic-beta: ccr-byoc-2025-07-29``  (compat byoc)
+    * ``x-organization-uuid``                  (required by compat gateway)
+
+    Returns the HTTP status code on success, or ``'no_token'`` /
+    ``'timeout'`` / ``'error'`` on failure. Idempotent — 409 (already
+    archived) is success.
+    """
+    if not access_token:
+        return 'no_token'
+    compat_id = to_compat_session_id(session_id)
+    headers = {
+        'Authorization': f'Bearer {access_token}',
+        'Content-Type': 'application/json',
+        'anthropic-version': _ANTHROPIC_VERSION,
+        'anthropic-beta': _ARCHIVE_BETA_HEADER,
+        'x-organization-uuid': org_uuid,
+    }
+    url = f'{base_url.rstrip("/")}/v1/sessions/{compat_id}/archive'
+    try:
+        if http_client is not None:
+            response = await http_client.post(
+                url, headers=headers, json={}, timeout=timeout_seconds,
+            )
+        else:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    url, headers=headers, json={}, timeout=timeout_seconds,
+                )
+    except httpx.TimeoutException:
+        logger.debug('[remote-bridge] Archive %s timed out', compat_id)
+        return 'timeout'
+    except httpx.HTTPError as err:
+        logger.debug('[remote-bridge] Archive %s failed: %s', compat_id, err)
+        return 'error'
+    logger.debug(
+        '[remote-bridge] Archive %s status=%s', compat_id, response.status_code
+    )
+    return response.status_code
+
+
+__all__ = [
+    'BridgeState',
+    'DEFAULT_ENV_LESS_BRIDGE_CONFIG',
+    'EnvLessBridgeParams',
+    'RemoteBridgeHandle',
+    'init_env_less_bridge_core',
+]

--- a/tests/bridge/test_remote_bridge_core.py
+++ b/tests/bridge/test_remote_bridge_core.py
@@ -1,0 +1,1109 @@
+"""Tests for ``src.bridge.remote_bridge_core`` — the Phase 5 MVP.
+
+Uses a fake v2 transport (no SSE / no CCRClient) injected via
+``transport_factory`` so we can exercise the full orchestrator code path
+including refresh, rebuild, teardown, and 401 recovery without going to
+the network. The HTTP layer (code-session create + /bridge fetch +
+archive) is mocked via ``httpx.MockTransport``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from src.bridge.env_less_bridge_config import (
+    DEFAULT_ENV_LESS_BRIDGE_CONFIG,
+    EnvLessBridgeConfig,
+)
+from src.bridge.remote_bridge_core import (
+    EnvLessBridgeParams,
+    RemoteBridgeHandle,
+    init_env_less_bridge_core,
+)
+from src.bridge.repl_bridge_transport import V2TransportOptions
+from src.types.messages import UserMessage
+
+
+# ── Test doubles ──────────────────────────────────────────────────────────
+
+
+class FakeTransport:
+    """Minimal in-memory ``ReplBridgeTransport`` for orchestrator tests.
+
+    Tracks every method call so tests can assert what the orchestrator
+    requested. Models the production ``CCRClient.write_event`` semantics
+    where writes issued before ``_initialized`` is True are dropped
+    (incrementing ``dropped_batch_count``) — this catches BLOCKING
+    regressions where the orchestrator doesn't queue properly during
+    handshake/rebuild.
+
+    Two modes:
+
+    * ``defer_connect=False`` (default) — ``connect()`` synchronously
+      flips ``initialized`` and fires ``set_on_connect``. Simulates a
+      transport that handshakes instantly.
+    * ``defer_connect=True`` — ``connect()`` schedules but does NOT
+      complete handshake until ``trigger_connect_complete()`` is called.
+      Use this to reproduce the pre-init write window.
+    """
+
+    def __init__(self, *, defer_connect: bool = False) -> None:
+        self.writes: list[dict[str, Any]] = []
+        self.batches: list[list[dict[str, Any]]] = []
+        self.states: list[Any] = []
+        self.closed: bool = False
+        self.connect_called: bool = False
+        self.initialized: bool = False
+        self.dropped: int = 0
+        self.last_seq_num: int = 0
+        self._defer_connect = defer_connect
+        self._on_connect: Any = None
+        self._on_data: Any = None
+        self._on_close: Any = None
+
+    async def write(self, message: dict[str, Any]) -> None:
+        if self.closed or not self.initialized:
+            self.dropped += 1
+            return
+        self.writes.append(message)
+
+    async def write_batch(self, messages: list[dict[str, Any]]) -> None:
+        if self.closed or not self.initialized:
+            self.dropped += 1
+            return
+        self.batches.append(list(messages))
+
+    def close(self) -> None:
+        self.closed = True
+
+    def is_connected_status(self) -> bool:
+        return self.initialized and not self.closed
+
+    def get_state_label(self) -> str:
+        return 'fake'
+
+    def set_on_data(self, cb: Any) -> None:
+        self._on_data = cb
+
+    def set_on_close(self, cb: Any) -> None:
+        self._on_close = cb
+
+    def set_on_connect(self, cb: Any) -> None:
+        self._on_connect = cb
+
+    def connect(self) -> None:
+        self.connect_called = True
+        if not self._defer_connect:
+            self.trigger_connect_complete()
+
+    def get_last_sequence_num(self) -> int:
+        return self.last_seq_num
+
+    @property
+    def dropped_batch_count(self) -> int:
+        return self.dropped
+
+    def report_state(self, state: Any) -> None:
+        self.states.append(state)
+
+    def report_metadata(self, metadata: Any) -> None:  # noqa: ARG002
+        pass
+
+    def report_delivery(self, event_id: str, status: str) -> None:  # noqa: ARG002
+        pass
+
+    async def flush(self) -> None:
+        pass
+
+    # Test-only hooks
+    def trigger_close(self, code: int | None = None) -> None:
+        if self._on_close is not None:
+            self._on_close(code)
+
+    def trigger_data(self, payload: str) -> None:
+        if self._on_data is not None:
+            self._on_data(payload)
+
+    def trigger_connect_complete(self) -> None:
+        """Flip ``initialized`` and fire the on_connect callback."""
+        self.initialized = True
+        if self._on_connect is not None:
+            self._on_connect()
+
+
+def _b64url(payload: dict[str, Any]) -> str:
+    raw = json.dumps(payload).encode('utf-8')
+    return base64.urlsafe_b64encode(raw).rstrip(b'=').decode('ascii')
+
+
+def _short_config() -> EnvLessBridgeConfig:
+    """Default config with shorter timings so retries are fast."""
+    return EnvLessBridgeConfig(
+        init_retry_max_attempts=1,
+        init_retry_base_delay_ms=100,
+        init_retry_max_delay_ms=500,
+        http_timeout_ms=2000,
+        connect_timeout_ms=5000,
+        teardown_archive_timeout_ms=1000,
+    )
+
+
+def _make_http_handler(
+    *,
+    create_session_status: int = 200,
+    create_session_id: str = 'cse_abc123',
+    bridge_status: int = 200,
+    bridge_payload: dict[str, Any] | None = None,
+    archive_status: int = 200,
+) -> Any:
+    """Build an httpx MockTransport handler covering the three endpoints.
+
+    Returns ``(handler, calls)`` where ``calls`` is a list of
+    ``(path, headers, body)`` tuples for assertions.
+    """
+    calls: list[tuple[str, dict[str, str], Any]] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        path = req.url.path
+        body = json.loads(req.content) if req.content else None
+        calls.append((path, dict(req.headers), body))
+        if path == '/v1/code/sessions':
+            if create_session_status >= 400:
+                return httpx.Response(create_session_status, json={
+                    'error': {'type': 'create_failed'}
+                })
+            return httpx.Response(200, json={
+                'session': {'id': create_session_id},
+            })
+        if path.startswith('/v1/code/sessions/') and path.endswith('/bridge'):
+            if bridge_status >= 400:
+                return httpx.Response(bridge_status, json={
+                    'error': {'type': 'bridge_failed'}
+                })
+            payload = bridge_payload or {
+                'worker_jwt': 'jwt-1',
+                'api_base_url': 'https://api.example.com',
+                'expires_in': 3600,
+                'worker_epoch': 5,
+            }
+            return httpx.Response(200, json=payload)
+        if path.startswith('/v1/sessions/') and path.endswith('/archive'):
+            return httpx.Response(archive_status, json={})
+        return httpx.Response(404, json={'error': 'no route'})
+
+    return handler, calls
+
+
+def _make_params(
+    transport: FakeTransport,
+    **overrides: Any,
+) -> tuple[EnvLessBridgeParams, dict[str, Any], list[Any]]:
+    """Build the standard EnvLessBridgeParams + capture buckets for callbacks."""
+    state_changes: list[Any] = []
+    inbound_log: list[Any] = []
+
+    def fake_transport_factory(opts: V2TransportOptions) -> Any:
+        async def _make() -> FakeTransport:
+            # Pin the most-recent opts for assertions if needed.
+            transport.last_opts = opts  # type: ignore[attr-defined]
+            return transport
+        return _make()
+
+    base = dict(
+        base_url='https://api.example.com',
+        org_uuid='org-1',
+        title='Test session',
+        get_access_token=lambda: 'tok-oauth',
+        initial_history_cap=200,
+        on_state_change=lambda *a: state_changes.append(a),
+        on_inbound_message=lambda msg: inbound_log.append(msg),
+    )
+    base.update(overrides)
+    return (
+        EnvLessBridgeParams(**base),
+        {
+            'state_changes': state_changes,
+            'inbound_log': inbound_log,
+            'transport_factory': fake_transport_factory,
+        },
+        [],
+    )
+
+
+# ── Init: happy path ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_init_returns_handle_on_happy_path() -> None:
+    transport = FakeTransport()
+    handler, calls = _make_http_handler()
+    params, ctx, _ = _make_params(transport)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params,
+            http_client=client,
+            config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+
+        assert handle is not None
+        assert isinstance(handle, RemoteBridgeHandle)
+        assert handle.bridge_session_id == 'cse_abc123'
+        assert handle.environment_id == ''  # always empty for env-less
+        assert handle.session_ingress_url == 'https://api.example.com'
+        assert transport.connect_called
+        # State transitions: 'ready' (post-init) → 'connected' (post-onConnect, no flush)
+        assert ('ready',) in ctx['state_changes']
+        assert ('connected',) in ctx['state_changes']
+        # HTTP calls: /sessions then /bridge
+        assert calls[0][0] == '/v1/code/sessions'
+        assert calls[1][0].startswith('/v1/code/sessions/') and calls[1][0].endswith('/bridge')
+        await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_init_returns_none_when_no_oauth_token() -> None:
+    transport = FakeTransport()
+    handler, _calls = _make_http_handler()
+    params, ctx, _ = _make_params(transport, get_access_token=lambda: None)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params,
+            http_client=client,
+            config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+
+    assert handle is None
+    assert not transport.connect_called
+
+
+@pytest.mark.asyncio
+async def test_init_returns_none_when_session_create_fails() -> None:
+    transport = FakeTransport()
+    handler, _calls = _make_http_handler(create_session_status=500)
+    params, ctx, _ = _make_params(transport)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params,
+            http_client=client,
+            config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+
+    assert handle is None
+    # State: failed callback fires
+    assert any('failed' in str(s) for s in ctx['state_changes'])
+
+
+@pytest.mark.asyncio
+async def test_init_returns_none_when_bridge_credentials_fail() -> None:
+    transport = FakeTransport()
+    handler, calls = _make_http_handler(bridge_status=500)
+    params, ctx, _ = _make_params(transport)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params,
+            http_client=client,
+            config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+
+    assert handle is None
+    # Pre-flight archive attempted (best-effort)
+    archive_calls = [c for c in calls if '/archive' in c[0]]
+    assert len(archive_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_init_archives_on_transport_factory_failure() -> None:
+    transport = FakeTransport()
+    handler, calls = _make_http_handler()
+    params, ctx, _ = _make_params(transport)
+
+    def failing_factory(opts: V2TransportOptions) -> Any:
+        async def _raise() -> FakeTransport:
+            raise RuntimeError('boom')
+        return _raise()
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params,
+            http_client=client,
+            config=_short_config(),
+            transport_factory=failing_factory,
+        )
+
+    assert handle is None
+    archive_calls = [c for c in calls if '/archive' in c[0]]
+    assert len(archive_calls) == 1
+    # Failed state fired
+    assert any('failed' in str(s) for s in ctx['state_changes'])
+
+
+# ── Write paths ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_write_messages_sends_via_transport_batch() -> None:
+    transport = FakeTransport()
+    handler, _ = _make_http_handler()
+    params, ctx, _ = _make_params(transport)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        handle.write_messages([UserMessage(content='hi', uuid='u-1')])
+        # Give the fire-and-forget create_task a chance to run.
+        await asyncio.sleep(0)
+        assert len(transport.batches) == 1
+        assert transport.batches[0][0]['uuid'] == 'u-1'
+        assert transport.batches[0][0]['session_id'] == 'cse_abc123'
+        # A user message triggers report_state('running')
+        assert any(s.get('state') == 'running' for s in transport.states)
+        await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_write_messages_dedups_against_initial_messages() -> None:
+    transport = FakeTransport()
+    handler, _ = _make_http_handler()
+    initial = [UserMessage(content='first', uuid='u-init')]
+    params, ctx, _ = _make_params(transport, initial_messages=initial)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        await asyncio.sleep(0)
+        # Initial flush via the connect callback wrote 1 batch.
+        initial_batch_count = len(transport.batches)
+
+        # Now try to re-write the SAME uuid — should be filtered.
+        handle.write_messages([UserMessage(content='first', uuid='u-init')])
+        await asyncio.sleep(0)
+        assert len(transport.batches) == initial_batch_count
+        await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_write_messages_dedups_against_recent_posted() -> None:
+    transport = FakeTransport()
+    handler, _ = _make_http_handler()
+    params, ctx, _ = _make_params(transport)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        msg = UserMessage(content='hi', uuid='u-dup')
+        handle.write_messages([msg])
+        await asyncio.sleep(0)
+        handle.write_messages([msg])  # same uuid, second write
+        await asyncio.sleep(0)
+        # Only one batch — the second write was deduped.
+        assert len(transport.batches) == 1
+        await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_write_messages_queues_during_flush() -> None:
+    """Writes that arrive while flush_gate is active are queued.
+
+    Post BLOCKING-1 fix, the gate starts unconditionally on init. When
+    the synchronous fake transport's onConnect fires during connect(),
+    it schedules the async flush_history task — between scheduling and
+    running, the gate is still active. A write that lands here is
+    correctly enqueued and drained later.
+    """
+    transport = FakeTransport()
+    handler, _ = _make_http_handler()
+    initial = [UserMessage(content='history', uuid='u-init')]
+    params, ctx, _ = _make_params(transport, initial_messages=initial)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        # The history flush task has been scheduled but not run; gate is active.
+        handle.write_messages([UserMessage(content='live', uuid='u-live')])
+        # Now let the scheduled tasks run.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        # Eventually a batch with the live message appears (after drain).
+        all_uuids = [
+            m['uuid'] for batch in transport.batches for m in batch
+        ]
+        assert 'u-live' in all_uuids
+        await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_write_messages_drops_unsendable_types() -> None:
+    """Non-eligible message types (e.g. progress) are filtered out."""
+    from src.types.messages import ProgressMessage
+
+    transport = FakeTransport()
+    handler, _ = _make_http_handler()
+    params, ctx, _ = _make_params(transport)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        handle.write_messages([
+            ProgressMessage(content='', uuid='p-1', toolUseID='t-1'),
+        ])
+        await asyncio.sleep(0)
+        # No batch written.
+        assert transport.batches == []
+        await handle.teardown()
+
+
+# ── send_* control methods ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_control_request_writes_event() -> None:
+    transport = FakeTransport()
+    handler, _ = _make_http_handler()
+    params, ctx, _ = _make_params(transport)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        handle.send_control_request({
+            'type': 'control_request',
+            'request_id': 'req-1',
+            'request': {'subtype': 'can_use_tool'},
+        })
+        await asyncio.sleep(0)
+        assert len(transport.writes) >= 1
+        # Latest write carries the request_id and session_id.
+        sent = next(w for w in transport.writes if w.get('request_id') == 'req-1')
+        assert sent['session_id'] == 'cse_abc123'
+        # can_use_tool triggers reportState('requires_action')
+        assert any(s.get('state') == 'requires_action' for s in transport.states)
+        await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_send_result_writes_result_message() -> None:
+    transport = FakeTransport()
+    handler, _ = _make_http_handler()
+    params, ctx, _ = _make_params(transport)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        before = len(transport.writes)
+        handle.send_result()
+        await asyncio.sleep(0)
+        assert len(transport.writes) == before + 1
+        assert transport.writes[-1]['type'] == 'result'
+        # Reports state idle.
+        assert any(s.get('state') == 'idle' for s in transport.states)
+        await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_send_cancel_request_writes_event() -> None:
+    transport = FakeTransport()
+    handler, _ = _make_http_handler()
+    params, ctx, _ = _make_params(transport)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        handle.send_cancel_request('req-cancel')
+        await asyncio.sleep(0)
+        cancel_writes = [w for w in transport.writes if w.get('type') == 'control_cancel_request']
+        assert len(cancel_writes) == 1
+        assert cancel_writes[0]['request_id'] == 'req-cancel'
+        await handle.teardown()
+
+
+# ── Teardown ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_teardown_writes_result_and_archives() -> None:
+    transport = FakeTransport()
+    handler, calls = _make_http_handler()
+    params, ctx, _ = _make_params(transport)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        await handle.teardown()
+
+    # Archive HTTP call fired.
+    archive_calls = [c for c in calls if '/archive' in c[0]]
+    assert len(archive_calls) == 1
+    # Compat retag: cse_abc123 → session_abc123 in the archive URL.
+    assert 'session_abc123' in archive_calls[0][0]
+    # Result message written before close.
+    result_writes = [w for w in transport.writes if w.get('type') == 'result']
+    assert len(result_writes) == 1
+    # Transport closed.
+    assert transport.closed
+
+
+@pytest.mark.asyncio
+async def test_teardown_is_idempotent() -> None:
+    transport = FakeTransport()
+    handler, calls = _make_http_handler()
+    params, ctx, _ = _make_params(transport)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        await handle.teardown()
+        await handle.teardown()  # must not raise or double-archive
+
+    archive_calls = [c for c in calls if '/archive' in c[0]]
+    assert len(archive_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_teardown_retries_archive_on_401() -> None:
+    transport = FakeTransport()
+    calls: list[tuple[str, dict[str, str], Any]] = []
+    archive_call_count = [0]
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        path = req.url.path
+        body = json.loads(req.content) if req.content else None
+        calls.append((path, dict(req.headers), body))
+        if path == '/v1/code/sessions':
+            return httpx.Response(200, json={'session': {'id': 'cse_x'}})
+        if path.endswith('/bridge'):
+            return httpx.Response(200, json={
+                'worker_jwt': 'jwt-1', 'api_base_url': 'https://api.example.com',
+                'expires_in': 3600, 'worker_epoch': 5,
+            })
+        if path.endswith('/archive'):
+            archive_call_count[0] += 1
+            if archive_call_count[0] == 1:
+                return httpx.Response(401, json={})
+            return httpx.Response(200, json={})
+        return httpx.Response(404)
+
+    refresh_attempts = [0]
+
+    async def on_auth_401(_stale: str) -> bool:
+        refresh_attempts[0] += 1
+        return True
+
+    params, ctx, _ = _make_params(
+        transport,
+        on_auth_401=on_auth_401,
+    )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        await handle.teardown()
+
+    # Archive called twice (initial 401 + retry); refresh fired once.
+    assert archive_call_count[0] == 2
+    assert refresh_attempts[0] == 1
+
+
+# ── Inbound message routing ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_inbound_user_message_fires_callback() -> None:
+    transport = FakeTransport()
+    handler, _ = _make_http_handler()
+    params, ctx, _ = _make_params(transport)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        # Simulate an inbound user message via the data callback.
+        payload = json.dumps({
+            'type': 'user',
+            'message': {'role': 'user', 'content': 'remote prompt'},
+            'uuid': 'inbound-1',
+        })
+        transport.trigger_data(payload)
+        await asyncio.sleep(0)
+        # Callback fired with the parsed dict.
+        assert len(ctx['inbound_log']) == 1
+        assert ctx['inbound_log'][0]['uuid'] == 'inbound-1'
+        await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_inbound_user_echo_is_filtered() -> None:
+    """Server echoes of our own posted messages are deduped."""
+    transport = FakeTransport()
+    handler, _ = _make_http_handler()
+    params, ctx, _ = _make_params(transport)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        # Post a message, then receive it back.
+        handle.write_messages([UserMessage(content='hi', uuid='u-echo')])
+        await asyncio.sleep(0)
+        # Server echoes it back.
+        payload = json.dumps({
+            'type': 'user',
+            'message': {'role': 'user', 'content': 'hi'},
+            'uuid': 'u-echo',
+        })
+        transport.trigger_data(payload)
+        await asyncio.sleep(0)
+        # Inbound callback NOT fired for the echo.
+        assert len(ctx['inbound_log']) == 0
+        await handle.teardown()
+
+
+# ── 401 recovery ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_close_401_triggers_recovery() -> None:
+    """A 401 SSE close triggers OAuth refresh + transport rebuild."""
+    transport = FakeTransport()
+    calls: list[tuple[str, dict[str, str], Any]] = []
+    bridge_call_count = [0]
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        path = req.url.path
+        calls.append((path, dict(req.headers), None))
+        if path == '/v1/code/sessions':
+            return httpx.Response(200, json={'session': {'id': 'cse_x'}})
+        if path.endswith('/bridge'):
+            bridge_call_count[0] += 1
+            return httpx.Response(200, json={
+                'worker_jwt': f'jwt-{bridge_call_count[0]}',
+                'api_base_url': 'https://api.example.com',
+                'expires_in': 3600,
+                'worker_epoch': bridge_call_count[0],
+            })
+        if path.endswith('/archive'):
+            return httpx.Response(200, json={})
+        return httpx.Response(404)
+
+    # The second factory call returns a fresh fake transport so the
+    # rebuild path uses a separate object — lets us verify the swap.
+    transports = [transport, FakeTransport()]
+    factory_call_count = [0]
+
+    def factory(opts: V2TransportOptions) -> Any:
+        async def _make() -> FakeTransport:
+            t = transports[factory_call_count[0]]
+            factory_call_count[0] += 1
+            return t
+        return _make()
+
+    async def on_auth_401(_stale: str) -> bool:
+        return True
+
+    params = EnvLessBridgeParams(
+        base_url='https://api.example.com',
+        org_uuid='org-1',
+        title='t',
+        get_access_token=lambda: 'oauth-tok',
+        initial_history_cap=200,
+        on_auth_401=on_auth_401,
+    )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=factory,
+        )
+        assert handle is not None
+
+        # Trigger the 401 SSE close.
+        transport.trigger_close(401)
+        # Wait for the spawned recovery task to complete.
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            if factory_call_count[0] == 2:
+                break
+
+    # Rebuild happened: factory called twice, /bridge called twice.
+    assert factory_call_count[0] == 2
+    assert bridge_call_count[0] == 2
+
+
+@pytest.mark.asyncio
+async def test_on_close_non_401_marks_failed() -> None:
+    transport = FakeTransport()
+    handler, _ = _make_http_handler()
+    params, ctx, _ = _make_params(transport)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        transport.trigger_close(4090)  # epoch mismatch — terminal
+        await asyncio.sleep(0)
+        assert any('failed' in str(s) for s in ctx['state_changes'])
+        await handle.teardown()
+
+
+# ── on_user_message title-derivation callback ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_user_message_called_until_returns_true() -> None:
+    transport = FakeTransport()
+    handler, _ = _make_http_handler()
+    user_msg_calls: list[tuple[str, str]] = []
+
+    def on_user_message(text: str, sid: str) -> bool:
+        user_msg_calls.append((text, sid))
+        return len(user_msg_calls) >= 2  # done after 2nd call
+
+    params, ctx, _ = _make_params(
+        transport,
+        on_user_message=on_user_message,
+    )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        handle.write_messages([UserMessage(content='msg-1', uuid='u-1')])
+        handle.write_messages([UserMessage(content='msg-2', uuid='u-2')])
+        handle.write_messages([UserMessage(content='msg-3', uuid='u-3')])
+        await asyncio.sleep(0)
+        # Called for u-1 (returned False) and u-2 (returned True); not for u-3.
+        assert len(user_msg_calls) == 2
+        assert user_msg_calls[0][0] == 'msg-1'
+        assert user_msg_calls[1][0] == 'msg-2'
+        await handle.teardown()
+
+
+# ── Refresh scheduler integration ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_init_schedules_token_refresh() -> None:
+    """The refresh scheduler is armed with the credentials' expires_in."""
+    transport = FakeTransport()
+    handler, _ = _make_http_handler()
+    params, ctx, _ = _make_params(transport)
+
+    # Patch TokenRefreshScheduler.schedule_from_expires_in to verify it's called.
+    with patch(
+        'src.bridge.remote_bridge_core.TokenRefreshScheduler.schedule_from_expires_in'
+    ) as mock_sched:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            handle = await init_env_less_bridge_core(
+                params, http_client=client, config=_short_config(),
+                transport_factory=ctx['transport_factory'],
+            )
+            assert handle is not None
+            mock_sched.assert_called_once_with('cse_abc123', 3600)
+            await handle.teardown()
+
+
+# ── State callback ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_write_during_handshake_does_not_drop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test per CRITIC BLOCKING-1.
+
+    Production ``CCRClient.write_event`` silently drops while
+    ``_initialized is False``. The orchestrator MUST start the flush_gate
+    on init (not only when initial_messages is set) so any write between
+    ``init_env_less_bridge_core`` returning and the first ``_on_connect``
+    is queued, not dropped.
+    """
+    transport = FakeTransport(defer_connect=True)
+    handler, _ = _make_http_handler()
+    params, ctx, _ = _make_params(transport)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        # CCR is NOT yet initialized — a naive write would drop.
+        assert not transport.initialized
+
+        handle.write_messages([UserMessage(content='pre-init', uuid='u-pre')])
+        await asyncio.sleep(0)
+        # No batch yet (write was queued in the flush_gate).
+        assert transport.batches == []
+        assert transport.dropped == 0
+
+        # Now complete the handshake — the on_connect callback drains
+        # the gate, which finally sends the queued batch.
+        transport.trigger_connect_complete()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        # Batch landed; nothing dropped.
+        all_uuids = [m['uuid'] for batch in transport.batches for m in batch]
+        assert 'u-pre' in all_uuids
+        assert transport.dropped == 0
+        await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_write_during_rebuild_does_not_drop() -> None:
+    """Regression test per CRITIC BLOCKING-2.
+
+    A JWT-refresh rebuild creates a new transport. Writes that race the
+    new transport's CCR.initialize() must NOT be drained early — the
+    orchestrator should leave the gate active until the new transport's
+    ``_on_connect`` fires.
+    """
+    initial_transport = FakeTransport()
+    rebuild_transport = FakeTransport(defer_connect=True)
+    handler, _ = _make_http_handler()
+
+    transports = [initial_transport, rebuild_transport]
+    factory_calls = [0]
+
+    def factory(opts: V2TransportOptions) -> Any:
+        async def _make() -> FakeTransport:
+            t = transports[factory_calls[0]]
+            factory_calls[0] += 1
+            return t
+        return _make()
+
+    async def on_auth_401(_stale: str) -> bool:
+        return True
+
+    params = EnvLessBridgeParams(
+        base_url='https://api.example.com', org_uuid='org-1', title='t',
+        get_access_token=lambda: 'oauth-tok',
+        initial_history_cap=200, on_auth_401=on_auth_401,
+    )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=factory,
+        )
+        assert handle is not None
+        # Trigger 401 SSE close → kicks off recovery → rebuild.
+        initial_transport.trigger_close(401)
+        # Let the rebuild task progress through its awaits to where
+        # the new transport.connect() has been called but CCR isn't
+        # yet initialized.
+        for _ in range(10):
+            await asyncio.sleep(0.01)
+            if rebuild_transport.connect_called:
+                break
+
+        assert rebuild_transport.connect_called
+        assert not rebuild_transport.initialized
+
+        # Write during the rebuild window — naively this would drop.
+        handle.write_messages([
+            UserMessage(content='during-rebuild', uuid='u-rb')
+        ])
+        await asyncio.sleep(0)
+
+        # No batch yet (write queued in gate).
+        assert rebuild_transport.batches == []
+        assert rebuild_transport.dropped == 0
+
+        # Complete the new transport's handshake.
+        rebuild_transport.trigger_connect_complete()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        # Queued message landed on the new transport.
+        all_uuids = [
+            m['uuid']
+            for batch in rebuild_transport.batches
+            for m in batch
+        ]
+        assert 'u-rb' in all_uuids
+        assert rebuild_transport.dropped == 0
+        await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_teardown_result_write_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test per CRITIC MAJOR-1.
+
+    Teardown's result-write must be bounded so a stuck queue can't block
+    teardown past ``gracefulShutdown``'s 2s budget.
+    """
+    transport = FakeTransport()
+    handler, _ = _make_http_handler()
+    params, ctx, _ = _make_params(transport)
+
+    # Make transport.write() block forever to simulate back-pressure.
+    async def _hang(_message: dict[str, Any]) -> None:
+        await asyncio.sleep(60)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        # Patch ONLY the post-init write so the orchestrator's pre-flight
+        # writes succeed. ``monkeypatch.setattr`` auto-undoes the patch
+        # at test end.
+        monkeypatch.setattr(transport, 'write', _hang)
+
+        # Teardown should NOT take 60s — the bounded wait_for caps it.
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        await handle.teardown()
+        elapsed = loop.time() - start
+        # Generous slack but well under the 30s default producer timeout.
+        assert elapsed < 2.0, f'teardown took {elapsed}s (must be < 2s)'
+
+
+@pytest.mark.asyncio
+async def test_mid_flush_401_re_flushes_history() -> None:
+    """Regression test per CRITIC Q7.
+
+    If a 401 SSE close fires WHILE the initial-history flush is in
+    progress, the orchestrator resets ``initial_flush_done`` and the new
+    transport's ``_on_connect`` re-flushes the history (so no messages
+    are lost in the gap).
+    """
+    initial_transport = FakeTransport()
+    rebuild_transport = FakeTransport()
+    handler, _ = _make_http_handler()
+    transports = [initial_transport, rebuild_transport]
+    factory_calls = [0]
+
+    def factory(opts: V2TransportOptions) -> Any:
+        async def _make() -> FakeTransport:
+            t = transports[factory_calls[0]]
+            factory_calls[0] += 1
+            return t
+        return _make()
+
+    async def on_auth_401(_stale: str) -> bool:
+        return True
+
+    initial = [
+        UserMessage(content='h1', uuid='h-1'),
+        UserMessage(content='h2', uuid='h-2'),
+    ]
+    params = EnvLessBridgeParams(
+        base_url='https://api.example.com', org_uuid='org-1', title='t',
+        get_access_token=lambda: 'oauth-tok',
+        initial_history_cap=200, on_auth_401=on_auth_401,
+        initial_messages=initial,
+    )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=factory,
+        )
+        assert handle is not None
+        # Initial flush wrote history to the first transport.
+        await asyncio.sleep(0)
+        first_batch_uuids = [
+            m['uuid'] for batch in initial_transport.batches for m in batch
+        ]
+        assert 'h-1' in first_batch_uuids and 'h-2' in first_batch_uuids
+
+        # Trigger 401 → recovery → rebuild.
+        initial_transport.trigger_close(401)
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            if factory_calls[0] == 2:
+                break
+
+        # The new transport's on_connect already fired (FakeTransport
+        # defaults to non-deferred). It should have re-flushed history.
+        await asyncio.sleep(0)
+        rebuild_batch_uuids = [
+            m['uuid'] for batch in rebuild_transport.batches for m in batch
+        ]
+        assert 'h-1' in rebuild_batch_uuids
+        assert 'h-2' in rebuild_batch_uuids
+        await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_state_changes_fire_in_order() -> None:
+    transport = FakeTransport()
+    handler, _ = _make_http_handler()
+    state_log: list[Any] = []
+    params, ctx, _ = _make_params(
+        transport,
+        on_state_change=lambda *a: state_log.append(a),
+    )
+    ctx['state_changes'] = state_log  # rewire
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        handle = await init_env_less_bridge_core(
+            params, http_client=client, config=_short_config(),
+            transport_factory=ctx['transport_factory'],
+        )
+        assert handle is not None
+        await handle.teardown()
+
+    # ready fires before connected.
+    ready_idx = state_log.index(('ready',))
+    connected_idx = state_log.index(('connected',))
+    assert ready_idx < connected_idx


### PR DESCRIPTION
## Summary — the MVP milestone 🎉

**This is the first end-to-end v2 Remote Control bridge in Python.** With this PR, a Python process can create a CCR session, fetch worker JWT credentials, open the v2 transport (SSE reads + CCRClient writes), exchange messages, handle proactive token refresh + 401 recovery, and archive on teardown — all without the env-based poll/dispatch lifecycle that the v1 path requires.

Ports `typescript/src/bridge/remoteBridgeCore.ts` (~1000 lines) → `src/bridge/remote_bridge_core.py` (~770 lines).

## Public surface

`src/bridge/remote_bridge_core.py`:
- `init_env_less_bridge_core(params, *, http_client?, config?, transport_factory?) -> RemoteBridgeHandle | None`
- `EnvLessBridgeParams` dataclass — required + optional config
- `RemoteBridgeHandle` — `write_messages`, `write_sdk_messages`, `send_control_request`, `send_control_response`, `send_cancel_request`, `send_result`, `teardown`

## Key behaviors

- POST `/v1/code/sessions` → `cse_*` session id (with retry+jitter via `_with_retry`)
- POST `/v1/code/sessions/{id}/bridge` → worker JWT + epoch + TTL
- `create_v2_repl_transport` (SSE + CCRClient via existing factory)
- `TokenRefreshScheduler` with proactive `/bridge` re-call before expiry (5min buffer)
- **401 SSE recovery** — refresh OAuth + re-fetch `/bridge` + rebuild transport with new epoch
- **Dual-set UUID dedup** — echo dedup + re-delivery dedup, seeded with initial-history UUIDs
- **FlushGate queues pre-init / pre-CCR-ready writes** so no message is dropped during handshake or rebuild
- **Idempotent teardown**: cancel scheduler → drop gate → reportState idle → bounded result write (0.5s cap) → archive with 401 retry → close

## Intentional divergences from TS (documented)

- **Unconditional `flush_gate.start()` on init + across rebuild**: Python `CCRClient.write_event` silently drops pre-init writes (TS `SerialBatchEventUploader` queues them). Worked around at the orchestrator layer.
- **Teardown `transport.write` is bounded with `asyncio.wait_for(0.5s)`**: TS uses fire-and-forget; Python's `producer_timeout_seconds` defaults to 30s which would blow `gracefulShutdown`'s 2s budget.
- **v2 archive helper inlined**: uses `anthropic-beta: ccr-byoc-2025-07-29` + `x-organization-uuid` (compat layer) — distinct from `bridge_api.archive_session` which targets the environments API.
- **PEP 562 `__getattr__` in `bridge/__init__.py`**: avoids a circular import via `remote_bridge_core → repl_bridge_transport → ccr_client → exceptions → bridge/__init__`.

## Deferrals (Phase 10 follow-ups)

- Connect-timeout telemetry (`tengu_bridge_repl_connect_timeout`)
- CCR mirror-mode telemetry differentiation
- Trusted-device token (currently `None`)
- `ConnectCause` enum used only for log clarity, not telemetry discriminator
- Latent stale-callback guard asymmetry (CRITIC follow-up; not reachable on any known production code path)

## Test plan

- [x] `uv run pytest tests/bridge` — **449/449 pass** (27 new + 422 existing)
- [x] `uv run pytest tests/test_porting_workspace.py` — 23/23 pass (circular import resolved via PEP 562)
- [x] Smoke: `from src.transports.ccr_client import CCRClient` (the previously-broken starting point) now resolves
- [x] Smoke: `from src import bridge; bridge.init_env_less_bridge_core` lazy-resolves
- [x] CRITIC review: APPROVE after 2 rounds (resolved BLOCKING circular-import, BLOCKING pre-init drop, BLOCKING pre-CCR-ready rebuild drop, MAJOR unbounded teardown write, MAJOR FakeTransport modeled init state, MAJOR misleading TS-divergence comment)

**4 regression tests pin the BLOCKING bugs** so they can't re-regress:
- `test_write_during_handshake_does_not_drop` — write between init-return and `_on_connect` is queued, not dropped.
- `test_write_during_rebuild_does_not_drop` — write during JWT-refresh rebuild lands on the new transport post-init, never dropped.
- `test_teardown_result_write_is_bounded` — `transport.write` patched to hang 60s; teardown still completes in <2s.
- `test_mid_flush_401_re_flushes_history` — 401 close during initial flush triggers re-flush on the rebuilt transport (history preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)