### PR TITLE
bridge phase 6 (MVP slice): env-based orchestrator skeleton

### DIFF
--- a/src/bridge/repl_bridge.py
+++ b/src/bridge/repl_bridge.py
@@ -1,0 +1,712 @@
+"""Env-based bridge orchestrator — Phase 6 MVP slice.
+
+Ports the **public surface + happy path** of
+``typescript/src/bridge/replBridge.ts`` (~2400 lines in TS).
+
+**Scope decision**: A full Phase 6 port (perpetual mode, dual v1/v2
+transport, multi-attempt env recreation on 404, crash-recovery pointer
+integration, dropped-batch telemetry, deterministic poll-loop backoff,
+work-id dedup across stale redeliveries, etc.) is 2-3 weeks per the
+refactoring plan. For autonomous porting in one session, this module
+implements the structural skeleton + single-session happy path:
+
+* Register environment → create session
+* Work-poll loop (basic, v2-only transport)
+* Spawn session via Phase 4 ``session_runner``
+* ``ReplBridgeHandle`` surface — write_messages / control / teardown
+* Teardown — stop_work + archive + deregister
+
+What is **explicitly deferred** (with TODOs at the call sites):
+
+* **v1 transport** (``HybridTransport`` POST writes + WS reads) — v2 is
+  the going-forward path; v1 is being deprecated server-side. Module
+  raises ``NotImplementedError`` if work secrets indicate v1 only.
+* **Perpetual mode** (crash-recovery pointer integration, env reuse via
+  ``reuseEnvironmentId``). Caller must set ``perpetual=False``.
+* **Env recreation** (the Strategy-1 / Strategy-2 reconnect dance after
+  a poll 404). Module logs the 404, fires ``on_state_change('failed')``,
+  and exits the poll loop. Phase 8 ``bridgeMain`` is the right place to
+  build the full recreation flow.
+* **JWT refresh integration with the spawned session** — the
+  ``TokenRefreshScheduler`` exists; wiring it to ``session.update_access_token``
+  on refresh is left to a follow-up. For now sessions use their initial
+  JWT until expiry.
+* **Multi-session** — the MVP handles one session at a time; second poll
+  result is rejected. Phase 8 ``bridgeMain`` handles the multi-session
+  daemon case via spawn-mode dispatch.
+* **Backoff/give-up logic** — the poll loop uses a fixed interval from
+  the config. The full TS backoff machinery (two-track error counters,
+  process-suspension detection, 10-min give-up) lands in Phase 8.
+* **Dropped-batch telemetry** + **work-id completion dedup** — both
+  log-only enhancements; deferred.
+
+What IS ported in full:
+
+* Public types: ``ReplBridgeHandle``, ``BridgeState``, ``BridgeCoreParams``
+* ``init_bridge_core(params, *, http_client?, api_client?, spawner?)`` — the factory
+* Single-session lifecycle: register → poll → spawn → done → archive
+* Idempotent teardown
+* OAuth + env-secret auth via ``bridge_api``
+
+This is sufficient to validate the bridge_api + session_runner + v2
+transport integration end-to-end. Phase 8 will fill in the multi-
+session + reconnect + perpetual surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from src.bridge.bridge_api import (
+    BridgeFatalError,
+    create_bridge_api_client,
+    is_expired_error_type,
+)
+from src.bridge.poll_config_defaults import (
+    DEFAULT_POLL_CONFIG,
+    PollIntervalConfig,
+)
+from src.bridge.session_id_compat import to_compat_session_id
+from src.bridge.session_runner import (
+    PermissionRequest,
+    SessionSpawnerDeps,
+    create_session_spawner,
+)
+from src.bridge.types import (
+    BridgeApiClient,
+    BridgeConfig,
+    SessionActivity,
+    SessionHandle,
+    SessionSpawnOpts,
+    SessionSpawner,
+)
+from src.bridge.work_secret import (
+    build_ccr_v2_sdk_url,
+    build_sdk_url,
+    decode_work_secret,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ── Public types ──────────────────────────────────────────────────────────
+
+
+BridgeState = str
+"""``'ready'`` | ``'connected'`` | ``'reconnecting'`` | ``'failed'``."""
+
+
+# Forward references via Any so we don't have to pre-define types in this
+# already-busy module. Real Message / SDK types live in their own modules.
+OnInboundMessage = Callable[[dict[str, Any]], Any]
+OnUserMessage = Callable[[str, str], bool]
+OnPermissionResponse = Callable[[dict[str, Any]], None]
+OnInterrupt = Callable[[], None]
+OnSetModel = Callable[[str | None], None]
+OnSetMaxThinkingTokens = Callable[[int | None], None]
+OnSetPermissionMode = Callable[[str], Any]
+OnStateChange = Callable[..., None]
+OnAuth401 = Callable[[str], Awaitable[bool]]
+GetAccessToken = Callable[[], str | None]
+
+
+@dataclass
+class BridgeCoreParams:
+    """Explicit-param input to ``init_bridge_core``.
+
+    Mirrors TS ``BridgeCoreParams`` on ``replBridge.ts:92-222``. Required
+    fields first; everything optional defaults sensibly.
+    """
+
+    # Identity
+    dir: str
+    machine_name: str
+    branch: str
+    git_repo_url: str | None
+    title: str
+
+    # URLs
+    base_url: str
+    session_ingress_url: str
+    worker_type: str
+
+    # Auth
+    get_access_token: GetAccessToken
+
+    # Session creation (injected for daemon vs REPL flexibility)
+    create_session: Callable[[dict[str, Any]], Awaitable[str | None]]
+    """``async def create_session({environment_id, title, gitRepoUrl, branch})
+    -> session_id | None``. Daemon/REPL wrappers pass distinct implementations
+    that differ in how they build the org-scoped HTTP headers."""
+
+    archive_session: Callable[[str], Awaitable[None]]
+    """``async def archive_session(session_id)`` — best-effort archival
+    on teardown; MUST NOT throw."""
+
+    # Optional callbacks
+    on_auth_401: OnAuth401 | None = None
+    on_inbound_message: OnInboundMessage | None = None
+    on_user_message: OnUserMessage | None = None
+    on_permission_response: OnPermissionResponse | None = None
+    on_interrupt: OnInterrupt | None = None
+    on_set_model: OnSetModel | None = None
+    on_set_max_thinking_tokens: OnSetMaxThinkingTokens | None = None
+    on_set_permission_mode: OnSetPermissionMode | None = None
+    on_state_change: OnStateChange | None = None
+
+    # Config getters
+    get_poll_interval_config: Callable[[], PollIntervalConfig] = (
+        lambda: DEFAULT_POLL_CONFIG
+    )
+    get_current_title: Callable[[], str] | None = None
+
+    # Identity for the env registration
+    max_sessions: int = 1
+    spawn_mode: str = 'single-session'  # 'single-session' | 'same-dir' | 'worktree'
+    bridge_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+    # MVP scope: perpetual mode is not yet supported.
+    perpetual: bool = False
+
+    # Initial history (currently unused by the MVP slice — recorded for
+    # future Phase 6 work that integrates with remote_bridge_core's
+    # flush_gate pattern).
+    initial_messages: list[Any] | None = None
+    initial_history_cap: int = 200
+
+
+@dataclass
+class ReplBridgeHandle:
+    """Opaque handle returned by ``init_bridge_core``.
+
+    Mirrors TS ``ReplBridgeHandle`` on ``replBridge.ts:71-82``. All
+    write methods are sync fire-and-forget; ``teardown`` is async and
+    idempotent.
+    """
+
+    bridge_session_id: str
+    environment_id: str
+    session_ingress_url: str
+    write_messages: Callable[[list[Any]], None]
+    write_sdk_messages: Callable[[list[dict[str, Any]]], None]
+    send_control_request: Callable[[dict[str, Any]], None]
+    send_control_response: Callable[[dict[str, Any]], None]
+    send_cancel_request: Callable[[str], None]
+    send_result: Callable[[], None]
+    teardown: Callable[[], Awaitable[None]]
+
+
+# ── init_bridge_core ──────────────────────────────────────────────────────
+
+
+async def init_bridge_core(
+    params: BridgeCoreParams,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+    api_client: BridgeApiClient | None = None,
+    spawner: SessionSpawner | None = None,
+    runner_version: str = 'py-bridge-mvp',
+) -> ReplBridgeHandle | None:
+    """Set up the env-based bridge: register → create session → start poll loop.
+
+    Returns ``None`` on any pre-flight failure (no OAuth, env registration
+    failed, initial session creation failed). The returned handle stays
+    alive until ``teardown()`` is called or the (single) session ends.
+
+    Test seams (kw-only):
+
+    * ``http_client``: optional ``httpx.AsyncClient`` for the bridge API.
+    * ``api_client``: pre-built ``BridgeApiClient`` (overrides
+      ``http_client`` if provided). Tests use this to inject fakes.
+    * ``spawner``: pre-built ``SessionSpawner``. Tests use this to skip
+      the real subprocess.
+    * ``runner_version``: header value for ``x-environment-runner-version``.
+    """
+    if params.perpetual:
+        raise NotImplementedError(
+            'Phase 6 MVP does not yet implement perpetual mode '
+            '(crash-recovery pointer + env reuse). Full port lands in a '
+            'future revision; set perpetual=False for now.'
+        )
+
+    if api_client is None:
+        api_client = create_bridge_api_client(
+            base_url=params.base_url,
+            get_access_token=params.get_access_token,
+            runner_version=runner_version,
+            on_auth_401=params.on_auth_401,
+            client=http_client,
+        )
+
+    # ── 1. Register environment ────────────────────────────────────────
+    bridge_config = BridgeConfig(
+        dir=params.dir,
+        machine_name=params.machine_name,
+        branch=params.branch,
+        git_repo_url=params.git_repo_url,
+        max_sessions=params.max_sessions,
+        spawn_mode=_validated_spawn_mode(params.spawn_mode),
+        verbose=False,
+        sandbox=False,
+        bridge_id=params.bridge_id,
+        worker_type=params.worker_type,
+        environment_id=params.bridge_id,  # client-generated; server may swap
+        api_base_url=params.base_url,
+        session_ingress_url=params.session_ingress_url,
+    )
+    try:
+        registration = await api_client.register_bridge_environment(
+            bridge_config
+        )
+    except BridgeFatalError as err:
+        logger.error('[bridge:repl] Registration failed: %s', err)
+        _fire_state(params.on_state_change, 'failed',
+                    f'Registration failed: {err}')
+        return None
+    environment_id = registration['environment_id']
+    environment_secret = registration['environment_secret']
+    logger.debug(
+        '[bridge:repl] Registered environment_id=%s', environment_id
+    )
+
+    # ── 2. Create initial session ──────────────────────────────────────
+    try:
+        session_id = await params.create_session({
+            'environment_id': environment_id,
+            'title': params.title,
+            'gitRepoUrl': params.git_repo_url,
+            'branch': params.branch,
+        })
+    except Exception as err:  # noqa: BLE001
+        logger.error('[bridge:repl] Session creation threw: %s', err)
+        session_id = None
+    if session_id is None:
+        _fire_state(params.on_state_change, 'failed',
+                    'Session creation failed')
+        try:
+            await api_client.deregister_environment(environment_id)
+        except Exception as err:  # noqa: BLE001
+            logger.debug(
+                '[bridge:repl] Deregister-after-create-fail failed: %s', err
+            )
+        return None
+    logger.debug('[bridge:repl] Created session_id=%s', session_id)
+
+    # ── 3. Build the spawner (if not test-injected) ────────────────────
+    if spawner is None:
+        spawner = create_session_spawner(SessionSpawnerDeps(
+            exec_path='claude',  # caller-overridable in future
+            verbose=False,
+            sandbox=False,
+        ))
+
+    # ── 4. State machine + poll loop ──────────────────────────────────
+    state = _BridgeState(
+        params=params,
+        api=api_client,
+        spawner=spawner,
+        environment_id=environment_id,
+        environment_secret=environment_secret,
+        initial_session_id=session_id,
+    )
+    state.start_poll_loop()
+
+    _fire_state(params.on_state_change, 'ready')
+
+    return ReplBridgeHandle(
+        bridge_session_id=session_id,
+        environment_id=environment_id,
+        session_ingress_url=params.session_ingress_url,
+        write_messages=state.write_messages,
+        write_sdk_messages=state.write_sdk_messages,
+        send_control_request=state.send_control_request,
+        send_control_response=state.send_control_response,
+        send_cancel_request=state.send_cancel_request,
+        send_result=state.send_result,
+        teardown=state.teardown,
+    )
+
+
+# ── Internal state machine ────────────────────────────────────────────────
+
+
+@dataclass
+class _BridgeState:
+    """Shared mutable state for one bridge."""
+
+    params: BridgeCoreParams
+    api: BridgeApiClient
+    spawner: SessionSpawner
+    environment_id: str
+    environment_secret: str
+    initial_session_id: str
+
+    poll_task: asyncio.Task[None] | None = None
+    poll_cancel: asyncio.Event = field(default_factory=asyncio.Event)
+    active_session: SessionHandle | None = None
+    active_work_id: str | None = None
+    torn_down: bool = False
+
+    # ── Poll loop ───────────────────────────────────────────────────────
+
+    def start_poll_loop(self) -> None:
+        self.poll_task = asyncio.create_task(
+            self._poll_loop(),
+            name=f'bridge-poll-{self.environment_id}',
+        )
+
+    async def _poll_loop(self) -> None:
+        cfg = self.params.get_poll_interval_config()
+        interval = cfg.poll_interval_ms_not_at_capacity / 1000.0
+        while not self.poll_cancel.is_set() and not self.torn_down:
+            try:
+                if self.active_session is not None:
+                    # At capacity for the MVP — single session at a time.
+                    # Sleep at the at-capacity interval, then re-check.
+                    await self._sleep_or_cancel(
+                        cfg.poll_interval_ms_at_capacity / 1000.0
+                    )
+                    continue
+
+                work = await self.api.poll_for_work(
+                    self.environment_id, self.environment_secret,
+                )
+                if work is None:
+                    await self._sleep_or_cancel(interval)
+                    continue
+
+                await self._process_work(work)
+            except BridgeFatalError as err:
+                if is_expired_error_type(err.error_type) or err.status == 404:
+                    # MVP: log + give up on the poll loop. Phase 8 will
+                    # implement Strategy-1/Strategy-2 env recreation.
+                    logger.error(
+                        '[bridge:repl] Environment expired or not found '
+                        '(MVP gives up — Phase 8 implements recreation): %s',
+                        err,
+                    )
+                    _fire_state(
+                        self.params.on_state_change, 'failed',
+                        f'Environment lost ({err.status})',
+                    )
+                    return
+                logger.error('[bridge:repl] Poll fatal error: %s', err)
+                _fire_state(
+                    self.params.on_state_change, 'failed', str(err),
+                )
+                return
+            except (asyncio.CancelledError, KeyboardInterrupt):
+                raise
+            except Exception as err:  # noqa: BLE001
+                logger.warning('[bridge:repl] Poll loop error: %s', err)
+                await self._sleep_or_cancel(interval)
+
+    async def _sleep_or_cancel(self, seconds: float) -> None:
+        """Sleep up to ``seconds``, waking early on cancellation."""
+        try:
+            await asyncio.wait_for(self.poll_cancel.wait(), timeout=seconds)
+        except asyncio.TimeoutError:
+            pass
+
+    async def _process_work(self, work: dict[str, Any]) -> None:
+        """Handle one work item from the poll."""
+        work_id = work.get('id')
+        if not isinstance(work_id, str):
+            logger.warning('[bridge:repl] Work missing id: %s', work)
+            return
+        data = work.get('data') or {}
+        if not isinstance(data, dict):
+            logger.warning('[bridge:repl] Work missing data: %s', work)
+            return
+        work_type = data.get('type')
+        if work_type == 'healthcheck':
+            # Acknowledge and move on.
+            await self._safe_ack(work_id, self.environment_secret)
+            return
+        if work_type != 'session':
+            logger.warning(
+                '[bridge:repl] Unknown work type: %s', work_type
+            )
+            return
+
+        # Decode the work secret to get the session token + URL.
+        try:
+            secret = decode_work_secret(work.get('secret') or '')
+        except Exception as err:  # noqa: BLE001
+            logger.error(
+                '[bridge:repl] Failed to decode work secret: %s', err
+            )
+            await self._safe_stop_work(work_id, force=True)
+            return
+
+        session_id = data.get('id')
+        if not isinstance(session_id, str):
+            logger.warning('[bridge:repl] Work session.id missing')
+            return
+
+        # Acknowledge — claims the work item so the server doesn't
+        # redispatch it after the reclaim window.
+        await self._safe_ack(work_id, secret.session_ingress_token)
+
+        # MVP: v2 transport only (CCR). Detect v1 (session-ingress WS)
+        # via the URL and refuse for now.
+        use_ccr_v2 = bool(secret.use_code_sessions)
+        if not use_ccr_v2:
+            logger.warning(
+                '[bridge:repl] v1 (session-ingress) transport not yet '
+                'implemented in Phase 6 MVP — v2 only. Stopping work.'
+            )
+            await self._safe_stop_work(work_id, force=True)
+            return
+        sdk_url = build_ccr_v2_sdk_url(secret.api_base_url, session_id)
+        # NOTE: Phase 6 full port will fetch worker_epoch via the v2
+        # /worker/register call. The MVP uses 0 as a placeholder since
+        # session_runner threads it into the child's env vars only when
+        # use_ccr_v2 is True.
+
+        # Spawn the child.
+        spawn_opts: SessionSpawnOpts = {
+            'session_id': session_id,
+            'sdk_url': sdk_url,
+            'access_token': secret.session_ingress_token,
+            'use_ccr_v2': use_ccr_v2,
+            'worker_epoch': 0,
+        }
+        try:
+            self.active_session = self.spawner.spawn(
+                spawn_opts, self.params.dir,
+            )
+        except Exception as err:  # noqa: BLE001
+            logger.error('[bridge:repl] Spawn failed: %s', err)
+            await self._safe_stop_work(work_id, force=True)
+            return
+        self.active_work_id = work_id
+        _fire_state(self.params.on_state_change, 'connected')
+        logger.debug(
+            '[bridge:repl] Spawned session_id=%s work_id=%s',
+            session_id, work_id,
+        )
+
+        # Wait for the session to complete, then clean up.
+        asyncio.create_task(
+            self._await_session_done(work_id),
+            name=f'bridge-session-await-{session_id}',
+        )
+
+    async def _await_session_done(self, work_id: str) -> None:
+        if self.active_session is None:
+            return
+        try:
+            status = await self.active_session.wait_done()
+        except Exception as err:  # noqa: BLE001
+            logger.warning(
+                '[bridge:repl] wait_done raised: %s', err
+            )
+            status = 'failed'
+        logger.debug(
+            '[bridge:repl] Session done (status=%s)', status
+        )
+        # Stop the work item to free the server-side lease.
+        await self._safe_stop_work(work_id, force=False)
+        self.active_session = None
+        self.active_work_id = None
+
+    async def _safe_ack(self, work_id: str, session_token: str) -> None:
+        try:
+            await self.api.acknowledge_work(
+                self.environment_id, work_id, session_token,
+            )
+        except Exception as err:  # noqa: BLE001
+            logger.warning(
+                '[bridge:repl] ack failed for work_id=%s: %s',
+                work_id, err,
+            )
+
+    async def _safe_stop_work(self, work_id: str, *, force: bool) -> None:
+        try:
+            await self.api.stop_work(
+                self.environment_id, work_id, force,
+            )
+        except Exception as err:  # noqa: BLE001
+            logger.warning(
+                '[bridge:repl] stop_work failed for work_id=%s: %s',
+                work_id, err,
+            )
+
+    # ── Public handle methods (MVP) ────────────────────────────────────
+    # The MVP wires the write methods to the active session's stdin via
+    # NDJSON. Phase 6 full port will use the bridge's events endpoint
+    # (POST /v1/sessions/{id}/events) for some of these — particularly
+    # control_response — but the simpler "forward to child stdin"
+    # pattern matches what the env-based path historically did.
+
+    def write_messages(self, messages: list[Any]) -> None:
+        """Forward local messages to the child via stdin (MVP).
+
+        Phase 6 full port: route through the bridge events POST so
+        messages also reach claude.ai. The MVP just forwards to the
+        child so the local session sees them.
+        """
+        if self.active_session is None or not messages:
+            return
+        # MVP: serialize each message as an NDJSON line and write to
+        # the child stdin. The real wire format is more elaborate (see
+        # message_mappers.to_sdk_messages) and is wired in Phase 6 full.
+        for msg in messages:
+            try:
+                import json
+                line = json.dumps({
+                    'type': 'user',
+                    'message': {
+                        'role': 'user',
+                        'content': getattr(msg, 'content', ''),
+                    },
+                    'uuid': getattr(msg, 'uuid', None),
+                }) + '\n'
+                self.active_session.write_stdin(line)
+            except Exception as err:  # noqa: BLE001
+                logger.warning(
+                    '[bridge:repl] write_messages failed: %s', err
+                )
+
+    def write_sdk_messages(self, messages: list[dict[str, Any]]) -> None:
+        """Forward pre-shaped SDK messages to the child (MVP)."""
+        if self.active_session is None:
+            return
+        import json
+        for msg in messages:
+            try:
+                self.active_session.write_stdin(json.dumps(msg) + '\n')
+            except Exception as err:  # noqa: BLE001
+                logger.warning(
+                    '[bridge:repl] write_sdk_messages failed: %s', err
+                )
+
+    def send_control_request(self, request: dict[str, Any]) -> None:
+        if self.active_session is None:
+            return
+        import json
+        self.active_session.write_stdin(json.dumps(request) + '\n')
+
+    def send_control_response(self, response: dict[str, Any]) -> None:
+        # Phase 6 full port: route via api.send_permission_response_event
+        # (POST /v1/sessions/{id}/events) instead of the child's stdin.
+        # The MVP keeps it on stdin for symmetry with write_messages.
+        if self.active_session is None:
+            return
+        import json
+        self.active_session.write_stdin(json.dumps(response) + '\n')
+
+    def send_cancel_request(self, request_id: str) -> None:
+        if self.active_session is None:
+            return
+        import json
+        self.active_session.write_stdin(json.dumps({
+            'type': 'control_cancel_request',
+            'request_id': request_id,
+        }) + '\n')
+
+    def send_result(self) -> None:
+        # MVP: no-op. The child emits its own result message when it
+        # finishes a turn; this exists for API parity with remote_bridge_core.
+        pass
+
+    # ── Teardown ───────────────────────────────────────────────────────
+
+    async def teardown(self) -> None:
+        """Stop poll loop → kill active session → stop work → archive → deregister.
+
+        Idempotent — safe to call multiple times.
+        """
+        if self.torn_down:
+            return
+        self.torn_down = True
+        self.poll_cancel.set()
+        if self.poll_task is not None:
+            self.poll_task.cancel()
+            try:
+                await self.poll_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+
+        # Kill the active session if any.
+        if self.active_session is not None:
+            try:
+                self.active_session.kill()
+            except Exception as err:  # noqa: BLE001
+                logger.warning('[bridge:repl] kill failed: %s', err)
+            # Give it a brief grace, then force.
+            try:
+                await asyncio.wait_for(
+                    self.active_session.wait_done(), timeout=2.0,
+                )
+            except asyncio.TimeoutError:
+                try:
+                    self.active_session.force_kill()
+                except Exception as err:  # noqa: BLE001
+                    logger.warning(
+                        '[bridge:repl] force_kill failed: %s', err
+                    )
+
+        # Stop any active work.
+        if self.active_work_id is not None:
+            await self._safe_stop_work(self.active_work_id, force=True)
+
+        # Archive the initial session (best-effort).
+        try:
+            await self.params.archive_session(self.initial_session_id)
+        except Exception as err:  # noqa: BLE001
+            logger.warning(
+                '[bridge:repl] archive_session failed: %s', err
+            )
+
+        # Deregister the environment.
+        try:
+            await self.api.deregister_environment(self.environment_id)
+        except Exception as err:  # noqa: BLE001
+            logger.warning(
+                '[bridge:repl] deregister failed: %s', err
+            )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _validated_spawn_mode(mode: str) -> Any:
+    """Cast a user-supplied spawn-mode string to the Literal type."""
+    if mode not in ('single-session', 'worktree', 'same-dir'):
+        raise ValueError(f'Invalid spawn_mode: {mode!r}')
+    return mode
+
+
+def _fire_state(
+    cb: OnStateChange | None,
+    state: BridgeState,
+    detail: str | None = None,
+) -> None:
+    if cb is None:
+        return
+    try:
+        if detail is None:
+            cb(state)
+        else:
+            cb(state, detail)
+    except Exception as err:  # noqa: BLE001
+        logger.warning(
+            '[bridge:repl] on_state_change raised: %s', err
+        )
+
+
+__all__ = [
+    'BridgeCoreParams',
+    'BridgeState',
+    'ReplBridgeHandle',
+    'init_bridge_core',
+]

--- a/tests/bridge/test_repl_bridge.py
+++ b/tests/bridge/test_repl_bridge.py
@@ -1,0 +1,607 @@
+"""Tests for ``src.bridge.repl_bridge`` (Phase 6 MVP slice).
+
+Strategy:
+- Inject a fake ``BridgeApiClient`` + fake ``SessionSpawner`` so we
+  don't need real HTTP or subprocesses.
+- Cover: init register/create happy path, init failure paths,
+  perpetual-mode NotImplementedError, poll loop processes one session,
+  teardown cleans up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from typing import Any
+
+import pytest
+
+from src.bridge.repl_bridge import (
+    BridgeCoreParams,
+    ReplBridgeHandle,
+    init_bridge_core,
+)
+from src.bridge.types import SessionDoneStatus
+
+
+# ── Test doubles ──────────────────────────────────────────────────────────
+
+
+class FakeApiClient:
+    """In-memory ``BridgeApiClient``. Tests script behavior."""
+
+    def __init__(
+        self,
+        *,
+        register_result: dict[str, str] | None = None,
+        register_raises: Exception | None = None,
+        poll_results: list[Any] | None = None,
+        heartbeat_result: dict[str, Any] | None = None,
+    ) -> None:
+        self.register_result = register_result or {
+            'environment_id': 'env-srv-1',
+            'environment_secret': 'sec-srv',
+        }
+        self.register_raises = register_raises
+        self.poll_results = poll_results or []  # consumed in order; None = no work
+        self.heartbeat_result = heartbeat_result or {
+            'lease_extended': True, 'state': 'running',
+        }
+
+        # Call logs
+        self.register_calls: list[Any] = []
+        self.poll_calls: list[Any] = []
+        self.ack_calls: list[tuple[str, str, str]] = []
+        self.stop_calls: list[tuple[str, str, bool]] = []
+        self.deregister_calls: list[str] = []
+        self.archive_calls: list[str] = []
+        self.reconnect_calls: list[tuple[str, str]] = []
+        self.heartbeat_calls: list[tuple[str, str, str]] = []
+        self.event_calls: list[tuple[str, dict[str, Any], str]] = []
+
+    async def register_bridge_environment(self, config: Any) -> dict[str, str]:
+        self.register_calls.append(config)
+        if self.register_raises is not None:
+            raise self.register_raises
+        return self.register_result
+
+    async def poll_for_work(self, env_id: str, secret: str, *_a: Any, **_kw: Any) -> Any:
+        self.poll_calls.append((env_id, secret))
+        if not self.poll_results:
+            return None
+        return self.poll_results.pop(0)
+
+    async def acknowledge_work(self, env_id: str, work_id: str, tok: str) -> None:
+        self.ack_calls.append((env_id, work_id, tok))
+
+    async def stop_work(self, env_id: str, work_id: str, force: bool) -> None:
+        self.stop_calls.append((env_id, work_id, force))
+
+    async def deregister_environment(self, env_id: str) -> None:
+        self.deregister_calls.append(env_id)
+
+    async def archive_session(self, sid: str) -> None:
+        self.archive_calls.append(sid)
+
+    async def reconnect_session(self, env_id: str, sid: str) -> None:
+        self.reconnect_calls.append((env_id, sid))
+
+    async def heartbeat_work(
+        self, env_id: str, work_id: str, tok: str
+    ) -> dict[str, Any]:
+        self.heartbeat_calls.append((env_id, work_id, tok))
+        return self.heartbeat_result
+
+    async def send_permission_response_event(
+        self, sid: str, event: dict[str, Any], tok: str
+    ) -> None:
+        self.event_calls.append((sid, event, tok))
+
+
+class FakeSessionHandle:
+    """In-memory SessionHandle for spawn tests."""
+
+    def __init__(self, session_id: str, access_token: str) -> None:
+        self._session_id = session_id
+        self._access_token = access_token
+        self._stdin: list[str] = []
+        self._kill_called = False
+        self._force_kill_called = False
+        self._done_future: asyncio.Future[SessionDoneStatus] = (
+            asyncio.get_event_loop().create_future()
+        )
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @property
+    def access_token(self) -> str:
+        return self._access_token
+
+    @property
+    def activities(self) -> list[Any]:
+        return []
+
+    @property
+    def current_activity(self) -> Any:
+        return None
+
+    @property
+    def last_stderr(self) -> list[str]:
+        return []
+
+    async def wait_done(self) -> SessionDoneStatus:
+        return await self._done_future
+
+    def kill(self) -> None:
+        self._kill_called = True
+
+    def force_kill(self) -> None:
+        self._force_kill_called = True
+
+    def write_stdin(self, data: str) -> None:
+        self._stdin.append(data)
+
+    def update_access_token(self, token: str) -> None:
+        self._access_token = token
+
+    # Test hook
+    def complete(self, status: SessionDoneStatus = 'completed') -> None:
+        if not self._done_future.done():
+            self._done_future.set_result(status)
+
+
+class FakeSpawner:
+    """In-memory ``SessionSpawner``."""
+
+    def __init__(self) -> None:
+        self.spawns: list[tuple[Any, str]] = []
+        self.handles: list[FakeSessionHandle] = []
+
+    def spawn(self, opts: Any, working_dir: str) -> FakeSessionHandle:
+        self.spawns.append((opts, working_dir))
+        h = FakeSessionHandle(
+            session_id=opts['session_id'],
+            access_token=opts['access_token'],
+        )
+        self.handles.append(h)
+        return h
+
+
+def _encode_work_secret(use_ccr_v2: bool = True) -> str:
+    payload = {
+        'version': 1,
+        'session_ingress_token': 'sess-jwt-abc',
+        'api_base_url': 'https://api.example.com',
+        'sources': [],
+        'auth': [],
+        'use_code_sessions': use_ccr_v2,
+    }
+    raw = json.dumps(payload).encode('utf-8')
+    return base64.urlsafe_b64encode(raw).rstrip(b'=').decode('ascii')
+
+
+def _make_params(
+    create_session_result: str | None = 'cse_test',
+    create_session_raises: Exception | None = None,
+    archive_raises: Exception | None = None,
+    perpetual: bool = False,
+) -> BridgeCoreParams:
+    state_log: list[Any] = []
+
+    async def create_session(opts: dict[str, Any]) -> str | None:
+        if create_session_raises is not None:
+            raise create_session_raises
+        return create_session_result
+
+    async def archive_session(sid: str) -> None:
+        if archive_raises is not None:
+            raise archive_raises
+
+    params = BridgeCoreParams(
+        dir='/tmp/test',
+        machine_name='test-host',
+        branch='main',
+        git_repo_url=None,
+        title='Test',
+        base_url='https://api.example.com',
+        session_ingress_url='https://api.example.com',
+        worker_type='claude_code',
+        get_access_token=lambda: 'tok-oauth',
+        create_session=create_session,
+        archive_session=archive_session,
+        on_state_change=lambda *a: state_log.append(a),
+        perpetual=perpetual,
+    )
+    # Smuggle state log onto params for tests.
+    params._state_log = state_log  # type: ignore[attr-defined]
+    return params
+
+
+# ── Init / pre-flight ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_perpetual_mode_not_yet_supported() -> None:
+    params = _make_params(perpetual=True)
+    with pytest.raises(NotImplementedError, match='perpetual'):
+        await init_bridge_core(
+            params, api_client=FakeApiClient(), spawner=FakeSpawner(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_init_happy_path_returns_handle() -> None:
+    params = _make_params()
+    api = FakeApiClient()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+
+    assert handle is not None
+    assert isinstance(handle, ReplBridgeHandle)
+    assert handle.bridge_session_id == 'cse_test'
+    assert handle.environment_id == 'env-srv-1'
+    assert handle.session_ingress_url == 'https://api.example.com'
+    assert len(api.register_calls) == 1
+    # state log includes ('ready',)
+    assert ('ready',) in params._state_log  # type: ignore[attr-defined]
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_init_returns_none_when_register_fails() -> None:
+    from src.bridge.exceptions import BridgeFatalError
+
+    params = _make_params()
+    api = FakeApiClient(
+        register_raises=BridgeFatalError('boom', status=500),
+    )
+    out = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert out is None
+    # State log records the failure.
+    assert any('failed' in str(s) for s in params._state_log)  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_init_deregisters_when_session_create_fails() -> None:
+    params = _make_params(create_session_result=None)
+    api = FakeApiClient()
+    out = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert out is None
+    # Deregister was called as cleanup.
+    assert api.deregister_calls == ['env-srv-1']
+
+
+@pytest.mark.asyncio
+async def test_init_handles_create_session_exception() -> None:
+    params = _make_params(
+        create_session_raises=RuntimeError('boom in create'),
+    )
+    api = FakeApiClient()
+    out = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert out is None
+    assert api.deregister_calls == ['env-srv-1']
+
+
+# ── Poll loop processes work ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_poll_loop_spawns_session_for_work_item() -> None:
+    work = {
+        'id': 'work-1',
+        'type': 'work',
+        'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_w1'},
+        'secret': _encode_work_secret(),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    params = _make_params()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    # Let the poll loop pick up the work.
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if spawner.spawns:
+            break
+
+    # Spawned exactly once with the work's session ID + token.
+    assert len(spawner.spawns) == 1
+    opts, working_dir = spawner.spawns[0]
+    assert opts['session_id'] == 'cse_w1'
+    assert opts['access_token'] == 'sess-jwt-abc'
+    assert opts['use_ccr_v2'] is True
+    assert working_dir == '/tmp/test'
+    # Work item was ack'd.
+    assert any(work_id == 'work-1' for _e, work_id, _t in api.ack_calls)
+    # State 'connected' fired.
+    assert ('connected',) in params._state_log  # type: ignore[attr-defined]
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_poll_loop_stops_work_for_v1_secret() -> None:
+    """MVP rejects v1 (non-CCR-v2) work."""
+    work = {
+        'id': 'work-v1',
+        'type': 'work',
+        'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_v1'},
+        'secret': _encode_work_secret(use_ccr_v2=False),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    params = _make_params()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if api.stop_calls:
+            break
+    # Stopped the work (force=True for unsupported secret format).
+    assert any(work_id == 'work-v1' for _e, work_id, _f in api.stop_calls)
+    # No session spawned.
+    assert spawner.spawns == []
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_poll_loop_handles_healthcheck_work() -> None:
+    """Healthcheck work is ack'd without spawning."""
+    work = {
+        'id': 'hc-1',
+        'type': 'work',
+        'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'healthcheck', 'id': 'hc-1'},
+        'secret': _encode_work_secret(),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    params = _make_params()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if api.ack_calls:
+            break
+    assert spawner.spawns == []  # no session spawned for healthcheck
+    # Healthcheck still uses the env secret for the ack (we don't decode
+    # the work secret on healthcheck — short-circuit). The MVP passes
+    # env_secret as the ack token for healthcheck.
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_poll_loop_gives_up_on_404() -> None:
+    """MVP: 404 (env lost) fires 'failed' and exits poll loop.
+
+    Full Phase 6/8 will implement env recreation here.
+    """
+    from src.bridge.exceptions import BridgeFatalError
+
+    api = FakeApiClient()
+    spawner = FakeSpawner()
+    params = _make_params()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+
+    # Inject a 404 on the next poll.
+    async def poll_404(*_a: Any, **_kw: Any) -> Any:
+        raise BridgeFatalError('not found', status=404)
+
+    api.poll_for_work = poll_404  # type: ignore[method-assign]
+    # Let the loop hit the 404.
+    for _ in range(30):
+        await asyncio.sleep(0.01)
+        if any('failed' in str(s) for s in params._state_log):  # type: ignore[attr-defined]
+            break
+    assert any('failed' in str(s) for s in params._state_log)  # type: ignore[attr-defined]
+    await handle.teardown()
+
+
+# ── Teardown ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_teardown_archives_and_deregisters() -> None:
+    api = FakeApiClient()
+    params = _make_params()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    await handle.teardown()
+    assert api.deregister_calls == ['env-srv-1']
+    # Initial session was archived via the injected callback (not via API).
+
+
+@pytest.mark.asyncio
+async def test_teardown_is_idempotent() -> None:
+    api = FakeApiClient()
+    params = _make_params()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    await handle.teardown()
+    await handle.teardown()
+    # Only one deregister.
+    assert len(api.deregister_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_teardown_kills_active_session() -> None:
+    work = {
+        'id': 'work-1',
+        'type': 'work',
+        'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_w1'},
+        'secret': _encode_work_secret(),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    params = _make_params()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    # Wait for spawn.
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if spawner.handles:
+            break
+    fake_session = spawner.handles[0]
+
+    # Teardown — should kill, wait briefly, then close.
+    # Since the fake's wait_done blocks forever, teardown will hit the
+    # 2s force_kill timeout. Speed it up by completing it manually shortly.
+    async def auto_complete() -> None:
+        await asyncio.sleep(0.05)
+        fake_session.complete('interrupted')
+
+    asyncio.create_task(auto_complete())
+    await handle.teardown()
+
+    assert fake_session._kill_called
+
+
+@pytest.mark.asyncio
+async def test_teardown_archives_via_injected_callback() -> None:
+    """``params.archive_session`` is called on teardown."""
+    archived: list[str] = []
+
+    async def archive(sid: str) -> None:
+        archived.append(sid)
+
+    params = _make_params()
+    params.archive_session = archive  # override
+    api = FakeApiClient()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    await handle.teardown()
+    assert archived == ['cse_test']
+
+
+@pytest.mark.asyncio
+async def test_teardown_swallows_archive_exceptions() -> None:
+    """Archive errors must not prevent deregister."""
+    params = _make_params(archive_raises=RuntimeError('archive boom'))
+    api = FakeApiClient()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    await handle.teardown()
+    # Deregister still happened.
+    assert api.deregister_calls == ['env-srv-1']
+
+
+# ── Write methods (MVP forwards to child stdin) ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_write_messages_forwards_to_active_session() -> None:
+    from src.types.messages import UserMessage
+
+    work = {
+        'id': 'work-1', 'type': 'work', 'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_w1'},
+        'secret': _encode_work_secret(),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    params = _make_params()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if spawner.handles:
+            break
+
+    handle.write_messages([UserMessage(content='hello', uuid='u-1')])
+    sent = spawner.handles[0]._stdin
+    assert len(sent) == 1
+    parsed = json.loads(sent[0])
+    assert parsed['type'] == 'user'
+    assert parsed['uuid'] == 'u-1'
+    assert parsed['message']['content'] == 'hello'
+    # Clean teardown.
+    spawner.handles[0].complete('completed')
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_write_messages_noop_when_no_active_session() -> None:
+    """write_messages is a no-op until a session has been spawned."""
+    from src.types.messages import UserMessage
+
+    api = FakeApiClient()
+    params = _make_params()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    # No session yet — write must not crash.
+    handle.write_messages([UserMessage(content='hi', uuid='u-x')])
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_send_control_request_forwards_when_active() -> None:
+    work = {
+        'id': 'work-1', 'type': 'work', 'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_w1'},
+        'secret': _encode_work_secret(),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    params = _make_params()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if spawner.handles:
+            break
+    handle.send_control_request({'type': 'control_request', 'request_id': 'r1'})
+    handle.send_cancel_request('r1')
+    sent = spawner.handles[0]._stdin
+    assert any('control_request' in s for s in sent)
+    assert any('control_cancel_request' in s for s in sent)
+    spawner.handles[0].complete('completed')
+    await handle.teardown()


### PR DESCRIPTION
## Summary — Phase 6 MVP slice

Ports the **public surface + single-session happy path** of `typescript/src/bridge/replBridge.ts` (~2400 lines in TS). Full Phase 6 is 2-3 weeks per the refactoring plan; this MVP delivers the structural scaffold so **Phase 8** (multi-session daemon) has the v2 env-based building blocks to build on.

## Surface (`src/bridge/repl_bridge.py`)

- `init_bridge_core(params, *, http_client?, api_client?, spawner?, runner_version?) -> ReplBridgeHandle | None`
- `BridgeCoreParams` dataclass
- `ReplBridgeHandle` — `write_messages`, `write_sdk_messages`, `send_control_request`, `send_control_response`, `send_cancel_request`, `send_result`, `teardown`

## Happy-path lifecycle (single session, v2 only)

1. Register environment via Phase 3 `bridge_api`
2. Create session via injected callback
3. Start work-poll loop (basic fixed-interval)
4. Process one work item: decode secret → ack → spawn via Phase 4 `session_runner` → wait done → stop_work
5. Forward `write_messages` / control requests to child stdin
6. Teardown: stop poll, kill session, stop work, archive, deregister

## Explicit deferrals (TODOs at each call site)

- **Perpetual mode** (crash-recovery pointer + env reuse) → raises `NotImplementedError`
- **v1 transport** (HybridTransport) → stops work + logs
- **Env recreation on 404** (Strategy-1/Strategy-2 reconnect dance) → logs + fires `'failed'`
- **JWT refresh** → session uses initial token
- **Multi-session** → one at a time; Phase 8 fills in
- **Backoff/give-up** → fixed interval; full machinery in Phase 8
- **Dropped-batch telemetry + work-id completion dedup** → not ported

## Test plan

- [x] `uv run pytest tests/bridge` — **509/509 pass** (17 new + 492 existing)
- [x] 17 tests cover: init happy path, register failure, session-create failure, deregister-on-fail, perpetual NotImplementedError, work poll spawn, v1-secret rejection, healthcheck handling, 404 give-up, teardown idempotency + kill + archive + deregister, write_messages forwarding, control request forwarding
- [ ] CI green

This MVP intentionally trades feature completeness for shipping a working orchestrator that exercises Phases 3+4 end-to-end. The deferred items each have a clear TODO at the call site so a future Phase 6 expansion or Phase 8 multi-session daemon can fill them in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)