### PR TITLE
bridge phase 10 (polish): inbound_attachments + trusted_device stub

### DIFF
--- a/src/bridge/inbound_attachments.py
+++ b/src/bridge/inbound_attachments.py
@@ -1,0 +1,272 @@
+"""Resolve ``file_uuid`` attachments on inbound bridge user messages.
+
+Ports ``typescript/src/bridge/inboundAttachments.ts``.
+
+Web composer uploads files via cookie-authed ``/api/{org}/upload``, then
+sends ``file_uuid`` alongside the message. This module fetches each via
+GET ``/api/oauth/files/{uuid}/content`` (OAuth-authed, same store),
+writes to ``~/.claude/uploads/{sessionId}/``, and returns ``@path`` refs
+the Read tool can pick up.
+
+**Best-effort**: any failure (no token, network, non-2xx, disk) logs at
+debug and skips that attachment. The message still reaches Claude, just
+without the ``@path`` ref.
+
+The Phase 10 caveat: ``get_bridge_access_token()`` returns ``None`` in
+the Python build until Phase 10 wires the keychain OAuth read — so this
+module degrades to "extract attachments + skip resolution" until then.
+The shape of the module is correct; only the network fetch is gated.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import re
+import uuid
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from src.bootstrap.state import get_session_id
+from src.bridge.bridge_config import get_bridge_access_token, get_bridge_base_url
+
+logger = logging.getLogger(__name__)
+
+
+_DOWNLOAD_TIMEOUT_SECONDS = 30.0
+
+
+_SAFE_FILENAME_RE = re.compile(r'[^a-zA-Z0-9._-]')
+
+
+# ── Public surface ────────────────────────────────────────────────────────
+
+
+def extract_inbound_attachments(msg: Any) -> list[dict[str, str]]:
+    """Pull ``file_attachments`` off a loosely-typed inbound message.
+
+    Mirrors TS ``extractInboundAttachments`` on ``inboundAttachments.ts:42-48``.
+    Returns a list of ``{file_uuid, file_name}`` dicts; empty when the
+    message has no ``file_attachments`` field or the field is malformed.
+    """
+    if not isinstance(msg, dict):
+        return []
+    raw = msg.get('file_attachments')
+    if not isinstance(raw, list):
+        return []
+    out: list[dict[str, str]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        file_uuid = item.get('file_uuid')
+        file_name = item.get('file_name')
+        if isinstance(file_uuid, str) and isinstance(file_name, str):
+            out.append({'file_uuid': file_uuid, 'file_name': file_name})
+    return out
+
+
+async def resolve_inbound_attachments(
+    attachments: list[dict[str, str]],
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> str:
+    """Fetch every attachment, write to disk, return the ``@path`` ref prefix.
+
+    Mirrors TS ``resolveInboundAttachments`` on
+    ``inboundAttachments.ts:123-134``. Returns the empty string when
+    nothing resolves (no auth token, all fetches failed, no
+    attachments). Multiple successful resolutions are joined with
+    spaces and end with a trailing space.
+
+    The quoted ``@"/path/with spaces"`` form prevents the
+    ``extractAtMentionedFiles`` consumer from truncating home dirs that
+    contain spaces (e.g. ``/Users/John Smith/``).
+    """
+    if not attachments:
+        return ''
+    _debug(f'resolving {len(attachments)} attachment(s)')
+    paths: list[str] = []
+    for att in attachments:
+        path = await _resolve_one(att, http_client=http_client)
+        if path is not None:
+            paths.append(path)
+    if not paths:
+        return ''
+    return ' '.join(f'@"{p}"' for p in paths) + ' '
+
+
+def prepend_path_refs(content: Any, prefix: str) -> Any:
+    """Prepend ``@path`` refs to message content.
+
+    Mirrors TS ``prependPathRefs`` on ``inboundAttachments.ts:142-161``.
+    For string content: simple concatenation. For list content
+    (mixed text + image): target the LAST text block so the consumer's
+    ``processedBlocks[-1]`` read picks them up. If there's no text
+    block, append one at the end.
+
+    Returns the original content unchanged when ``prefix`` is empty
+    (zero-allocation happy path).
+    """
+    if not prefix:
+        return content
+    if isinstance(content, str):
+        return prefix + content
+    if not isinstance(content, list):
+        return content
+    # Find the LAST text block index.
+    last_text_idx = -1
+    for i, block in enumerate(content):
+        if isinstance(block, dict) and block.get('type') == 'text':
+            last_text_idx = i
+    if last_text_idx >= 0:
+        block = content[last_text_idx]
+        existing_text = block.get('text', '') if isinstance(block, dict) else ''
+        new_block = {**block, 'text': prefix + existing_text}
+        return [
+            *content[:last_text_idx],
+            new_block,
+            *content[last_text_idx + 1:],
+        ]
+    # No text block — append one.
+    return [*content, {'type': 'text', 'text': prefix.rstrip()}]
+
+
+async def resolve_and_prepend(
+    msg: Any,
+    content: Any,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> Any:
+    """Convenience: extract + resolve + prepend in one call.
+
+    Mirrors TS ``resolveAndPrepend`` on ``inboundAttachments.ts:167-175``.
+    No-op when the message has no ``file_attachments`` field (returns
+    the same content reference).
+    """
+    attachments = extract_inbound_attachments(msg)
+    if not attachments:
+        return content
+    prefix = await resolve_inbound_attachments(
+        attachments, http_client=http_client,
+    )
+    return prepend_path_refs(content, prefix)
+
+
+# ── Internals ─────────────────────────────────────────────────────────────
+
+
+def _sanitize_filename(name: str) -> str:
+    """Strip path components + keep only filename-safe chars.
+
+    Mirrors TS ``sanitizeFileName`` on ``inboundAttachments.ts:55-58``.
+    File name comes from the network, so treat as untrusted even though
+    the web composer controls it.
+    """
+    base = os.path.basename(name)
+    cleaned = _SAFE_FILENAME_RE.sub('_', base)
+    return cleaned or 'attachment'
+
+
+def _uploads_dir() -> Path:
+    """Per-session uploads directory under ``~/.claude/uploads/``.
+
+    Mirrors TS ``uploadsDir`` on ``inboundAttachments.ts:60-62``. The TS
+    version reads ``getClaudeConfigHomeDir()`` (which honors a
+    ``CLAUDE_CONFIG_DIR`` env override); the Python port checks the
+    same env var first, falling back to ``~/.claude``.
+    """
+    override = os.environ.get('CLAUDE_CONFIG_DIR')
+    home = Path(override) if override else Path.home() / '.claude'
+    return home / 'uploads' / str(get_session_id())
+
+
+def _debug(message: str) -> None:
+    """One-line debug logger matching the TS ``debug()`` style."""
+    logger.debug('[bridge:inbound-attach] %s', message)
+
+
+async def _resolve_one(
+    att: dict[str, str],
+    *,
+    http_client: httpx.AsyncClient | None,
+) -> str | None:
+    """Fetch + write one attachment. Returns absolute path or None.
+
+    Mirrors TS ``resolveOne`` on ``inboundAttachments.ts:68-117``.
+    """
+    token = get_bridge_access_token()
+    if not token:
+        _debug('skip: no oauth token')
+        return None
+
+    base_url = get_bridge_base_url()
+    file_uuid = att['file_uuid']
+    file_name = att['file_name']
+    url = (
+        f'{base_url.rstrip("/")}'
+        f'/api/oauth/files/{_urlencode_segment(file_uuid)}/content'
+    )
+
+    try:
+        if http_client is not None:
+            response = await http_client.get(
+                url,
+                headers={'Authorization': f'Bearer {token}'},
+                timeout=_DOWNLOAD_TIMEOUT_SECONDS,
+            )
+        else:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    url,
+                    headers={'Authorization': f'Bearer {token}'},
+                    timeout=_DOWNLOAD_TIMEOUT_SECONDS,
+                )
+    except httpx.HTTPError as err:
+        _debug(f'fetch {file_uuid} threw: {err}')
+        return None
+
+    if response.status_code != 200:
+        _debug(f'fetch {file_uuid} failed: status={response.status_code}')
+        return None
+    data = response.content
+
+    # ``uuid_prefix-safe_name`` makes collisions impossible across
+    # messages and within one message (same filename, different files).
+    safe_name = _sanitize_filename(file_name)
+    prefix_source = file_uuid[:8] or uuid.uuid4().hex[:8]
+    prefix = _SAFE_FILENAME_RE.sub('_', prefix_source)
+    out_dir = _uploads_dir()
+    out_path = out_dir / f'{prefix}-{safe_name}'
+
+    try:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path.write_bytes(data)
+    except OSError as err:
+        _debug(f'write {out_path} failed: {err}')
+        return None
+
+    _debug(f'resolved {file_uuid} -> {out_path} ({len(data)} bytes)')
+    return str(out_path)
+
+
+def _urlencode_segment(value: str) -> str:
+    """Minimal URL-segment encoder for the file UUID path component.
+
+    Mirrors TS ``encodeURIComponent(att.file_uuid)``. We use Python's
+    ``urllib.parse.quote`` with no safe chars so any non-alphanumeric
+    character is escaped.
+    """
+    from urllib.parse import quote
+
+    return quote(value, safe='')
+
+
+__all__ = [
+    'extract_inbound_attachments',
+    'prepend_path_refs',
+    'resolve_and_prepend',
+    'resolve_inbound_attachments',
+]

--- a/src/bridge/trusted_device.py
+++ b/src/bridge/trusted_device.py
@@ -1,0 +1,97 @@
+"""Trusted-device token source for bridge sessions — Phase 10 stub.
+
+Ports the consumer-facing surface of
+``typescript/src/bridge/trustedDevice.ts``.
+
+**Phase 10 stub**: The full TS implementation reads a device token from
+OS-specific secure storage (Keychain on macOS, DPAPI on Windows,
+libsecret on Linux), enrolls via POST ``/auth/trusted_devices`` during
+login, and gates the header on a GrowthBook flag. The Python build has
+none of those layers yet, so this module exposes the same public API
+returning ``None`` (header omitted; server falls through to its
+no-enforcement path).
+
+Two env-var overrides are honored so callers (test scripts, daemon
+wrappers, CI rigs) can inject a token without OS secure storage:
+
+* ``CLAUDE_TRUSTED_DEVICE_TOKEN`` — direct token override (matches the
+  same env var TS recognizes).
+
+The ``enroll_trusted_device()`` async function is a no-op stub today;
+implementing it requires the OAuth keychain + ``secure_storage``
+modules that don't exist in the Python build yet (Phase 10 follow-up).
+
+The function signatures match TS so a future swap to real keychain-
+backed storage is non-breaking for callers.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+_ENV_TOKEN = 'CLAUDE_TRUSTED_DEVICE_TOKEN'
+
+
+def get_trusted_device_token() -> str | None:
+    """Return the trusted-device token to send as ``X-Trusted-Device-Token``.
+
+    Mirrors TS ``getTrustedDeviceToken`` on ``trustedDevice.ts:54-59``.
+    Returns ``None`` to omit the header (server treats this as "no
+    elevated auth"), unless ``CLAUDE_TRUSTED_DEVICE_TOKEN`` is set.
+
+    Phase 10 will swap the ``None`` fallback for a keychain read.
+    """
+    value = os.environ.get(_ENV_TOKEN)
+    return value or None
+
+
+def clear_trusted_device_token_cache() -> None:
+    """Clear the (currently in-memory only) trusted-device-token cache.
+
+    Mirrors TS ``clearTrustedDeviceTokenCache`` on ``trustedDevice.ts:61-63``.
+    No-op in the env-var-only Python build — the env var is the source
+    of truth, no separate cache exists.
+    """
+    return None
+
+
+def clear_trusted_device_token() -> None:
+    """Clear the persisted trusted-device token from secure storage.
+
+    Mirrors TS ``clearTrustedDeviceToken`` on ``trustedDevice.ts:69-86``.
+    No-op until Phase 10 keychain integration lands. The env var (if
+    set) is not cleared — that's an external configuration concern.
+    """
+    return None
+
+
+async def enroll_trusted_device() -> None:
+    """Enroll this device via POST ``/auth/trusted_devices`` (no-op stub).
+
+    Mirrors TS ``enrollTrustedDevice`` on ``trustedDevice.ts:97-210``.
+    The TS implementation requires the OAuth keychain (to read the
+    access token + persist the issued device_token), the secure storage
+    layer (OS-specific keychain backend), and the GrowthBook gate
+    (``tengu_sessions_elevated_auth_enforcement``). All three are
+    out-of-scope for the current Python build.
+
+    A future Phase 10 expansion will fill this in. Until then the
+    function is a no-op that emits a debug log so a caller hitting it
+    sees the gap.
+    """
+    logger.debug(
+        '[trusted-device] enroll_trusted_device is a no-op stub — '
+        'Phase 10 keychain integration not yet ported'
+    )
+
+
+__all__ = [
+    'clear_trusted_device_token',
+    'clear_trusted_device_token_cache',
+    'enroll_trusted_device',
+    'get_trusted_device_token',
+]

--- a/tests/bridge/test_inbound_attachments.py
+++ b/tests/bridge/test_inbound_attachments.py
@@ -1,0 +1,280 @@
+"""Tests for ``src.bridge.inbound_attachments``."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from src.bridge.inbound_attachments import (
+    extract_inbound_attachments,
+    prepend_path_refs,
+    resolve_and_prepend,
+    resolve_inbound_attachments,
+)
+
+
+# ── extract_inbound_attachments ──────────────────────────────────────────
+
+
+def test_extract_returns_empty_for_non_dict() -> None:
+    assert extract_inbound_attachments(None) == []
+    assert extract_inbound_attachments('string') == []
+    assert extract_inbound_attachments(42) == []
+
+
+def test_extract_returns_empty_for_missing_field() -> None:
+    assert extract_inbound_attachments({}) == []
+    assert extract_inbound_attachments({'other': 'value'}) == []
+
+
+def test_extract_returns_empty_for_non_list_attachments() -> None:
+    assert extract_inbound_attachments({'file_attachments': 'not a list'}) == []
+    assert extract_inbound_attachments({'file_attachments': None}) == []
+
+
+def test_extract_returns_well_formed_list() -> None:
+    msg = {
+        'file_attachments': [
+            {'file_uuid': 'abc-123', 'file_name': 'foo.png'},
+            {'file_uuid': 'def-456', 'file_name': 'bar.txt'},
+        ],
+    }
+    out = extract_inbound_attachments(msg)
+    assert out == [
+        {'file_uuid': 'abc-123', 'file_name': 'foo.png'},
+        {'file_uuid': 'def-456', 'file_name': 'bar.txt'},
+    ]
+
+
+def test_extract_skips_malformed_entries() -> None:
+    """Items without both file_uuid and file_name are dropped."""
+    msg = {
+        'file_attachments': [
+            {'file_uuid': 'a', 'file_name': 'ok.png'},
+            {'file_uuid': 'b'},  # no file_name → dropped
+            'not a dict',         # not a dict → dropped
+            {'file_name': 'c'},   # no file_uuid → dropped
+            {'file_uuid': 123, 'file_name': 'wrong-type'},  # non-string uuid → dropped
+        ],
+    }
+    out = extract_inbound_attachments(msg)
+    assert out == [{'file_uuid': 'a', 'file_name': 'ok.png'}]
+
+
+# ── prepend_path_refs ────────────────────────────────────────────────────
+
+
+def test_prepend_noop_when_empty_prefix() -> None:
+    """Empty prefix returns the same content reference."""
+    s = 'hello'
+    assert prepend_path_refs(s, '') is s
+    blocks = [{'type': 'text', 'text': 'hi'}]
+    assert prepend_path_refs(blocks, '') is blocks
+
+
+def test_prepend_string_content_concatenates() -> None:
+    assert prepend_path_refs('hello', '@"/tmp/foo.png" ') == '@"/tmp/foo.png" hello'
+
+
+def test_prepend_targets_last_text_block_in_list() -> None:
+    """When content is a list, the last text block gets the prefix."""
+    blocks = [
+        {'type': 'text', 'text': 'first text'},
+        {'type': 'image', 'source': {}},
+        {'type': 'text', 'text': 'last text'},
+    ]
+    out = prepend_path_refs(blocks, '@"/tmp/x.png" ')
+    assert out[0] == {'type': 'text', 'text': 'first text'}
+    assert out[1] == {'type': 'image', 'source': {}}
+    assert out[2] == {'type': 'text', 'text': '@"/tmp/x.png" last text'}
+
+
+def test_prepend_appends_text_block_when_none_exists() -> None:
+    """List with no text block → append one (trailing space stripped)."""
+    blocks = [{'type': 'image', 'source': {}}]
+    out = prepend_path_refs(blocks, '@"/tmp/x.png" ')
+    assert out == [
+        {'type': 'image', 'source': {}},
+        {'type': 'text', 'text': '@"/tmp/x.png"'},
+    ]
+
+
+def test_prepend_non_string_non_list_returns_unchanged() -> None:
+    """Unrecognized content shapes pass through (defensive)."""
+    assert prepend_path_refs(123, '@"foo" ') == 123
+
+
+# ── resolve_inbound_attachments + _resolve_one ───────────────────────────
+
+
+@pytest.fixture
+def _isolated_uploads_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pin uploads to a temp dir so tests don't touch ~/.claude/uploads."""
+    monkeypatch.setenv('CLAUDE_CONFIG_DIR', str(tmp_path))
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_empty_for_no_attachments() -> None:
+    assert await resolve_inbound_attachments([]) == ''
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_empty_when_no_oauth_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No CLAUDE_BRIDGE_OAUTH_TOKEN → skip all resolution → empty prefix."""
+    # Strip any override.
+    monkeypatch.delenv('CLAUDE_BRIDGE_OAUTH_TOKEN', raising=False)
+    # Force get_bridge_access_token to return None.
+    with patch(
+        'src.bridge.inbound_attachments.get_bridge_access_token',
+        return_value=None,
+    ):
+        out = await resolve_inbound_attachments(
+            [{'file_uuid': 'a', 'file_name': 'foo.png'}],
+        )
+    assert out == ''
+
+
+@pytest.mark.asyncio
+async def test_resolve_writes_attachment_and_returns_at_path(
+    _isolated_uploads_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy path: fetches via httpx, writes to disk, returns @"path" prefix."""
+    monkeypatch.setenv('CLAUDE_BRIDGE_OAUTH_TOKEN', 'tok-abc')
+
+    expected_content = b'PNG bytes here'
+    fetched_urls: list[str] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        fetched_urls.append(str(req.url))
+        return httpx.Response(200, content=expected_content)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        out = await resolve_inbound_attachments(
+            [{'file_uuid': 'abc-12345', 'file_name': 'my image.png'}],
+            http_client=client,
+        )
+
+    # Returned prefix is the quoted @path form with trailing space.
+    assert out.startswith('@"')
+    assert out.endswith('" ')
+    # The file was actually written.
+    assert len(fetched_urls) == 1
+    assert '/api/oauth/files/abc-12345/content' in fetched_urls[0]
+    # File on disk under the isolated uploads dir.
+    # Output is `@"<path>" ` — strip leading `@"` and trailing `" `.
+    path_in_prefix = out[2:-2]
+    written = Path(path_in_prefix)
+    assert written.exists()
+    assert written.read_bytes() == expected_content
+    # Filename was sanitized (space → underscore).
+    assert ' ' not in written.name
+
+
+@pytest.mark.asyncio
+async def test_resolve_skips_failed_fetches(
+    _isolated_uploads_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-200 responses are skipped, not raised. Returns empty when all fail."""
+    monkeypatch.setenv('CLAUDE_BRIDGE_OAUTH_TOKEN', 'tok-abc')
+
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={'error': 'not found'})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        out = await resolve_inbound_attachments(
+            [{'file_uuid': 'a', 'file_name': 'foo.png'}],
+            http_client=client,
+        )
+    assert out == ''
+
+
+@pytest.mark.asyncio
+async def test_resolve_swallows_network_errors(
+    _isolated_uploads_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv('CLAUDE_BRIDGE_OAUTH_TOKEN', 'tok-abc')
+
+    def handler(_req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError('boom')
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        out = await resolve_inbound_attachments(
+            [{'file_uuid': 'a', 'file_name': 'foo.png'}],
+            http_client=client,
+        )
+    # Network error → skip → empty prefix.
+    assert out == ''
+
+
+@pytest.mark.asyncio
+async def test_resolve_handles_mixed_success_and_failure(
+    _isolated_uploads_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When some attachments resolve and others fail, only successful ones appear."""
+    monkeypatch.setenv('CLAUDE_BRIDGE_OAUTH_TOKEN', 'tok-abc')
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        # Only 'good-uuid' resolves; 'bad-uuid' 404s.
+        if 'good-uuid' in str(req.url):
+            return httpx.Response(200, content=b'data')
+        return httpx.Response(404)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        out = await resolve_inbound_attachments(
+            [
+                {'file_uuid': 'bad-uuid', 'file_name': 'bad.png'},
+                {'file_uuid': 'good-uuid', 'file_name': 'good.png'},
+            ],
+            http_client=client,
+        )
+    # Only good-uuid in the prefix.
+    assert 'good.png' in out
+    assert 'bad.png' not in out
+
+
+# ── resolve_and_prepend (the convenience function) ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_prepend_noop_for_no_attachments() -> None:
+    """Returns content unchanged when message has no file_attachments."""
+    content = 'hello'
+    out = await resolve_and_prepend({'no_attachments': True}, content)
+    assert out is content
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_prepend_end_to_end(
+    _isolated_uploads_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv('CLAUDE_BRIDGE_OAUTH_TOKEN', 'tok-abc')
+
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b'data')
+
+    msg = {
+        'file_attachments': [
+            {'file_uuid': 'uuid-1', 'file_name': 'foo.png'},
+        ],
+    }
+    content = 'look at this image'
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        out = await resolve_and_prepend(msg, content, http_client=client)
+    # Prefix was prepended.
+    assert isinstance(out, str)
+    assert out.endswith('look at this image')
+    assert out.startswith('@"')
+    assert 'foo.png' in out

--- a/tests/bridge/test_trusted_device.py
+++ b/tests/bridge/test_trusted_device.py
@@ -1,0 +1,50 @@
+"""Tests for ``src.bridge.trusted_device`` (Phase 10 stub)."""
+
+from __future__ import annotations
+
+import os
+import pytest
+from unittest.mock import patch
+
+from src.bridge.trusted_device import (
+    clear_trusted_device_token,
+    clear_trusted_device_token_cache,
+    enroll_trusted_device,
+    get_trusted_device_token,
+)
+
+
+def test_get_token_returns_none_when_env_unset() -> None:
+    env = {k: v for k, v in os.environ.items() if k != 'CLAUDE_TRUSTED_DEVICE_TOKEN'}
+    with patch.dict(os.environ, env, clear=True):
+        assert get_trusted_device_token() is None
+
+
+def test_get_token_returns_env_var_when_set() -> None:
+    env = {'CLAUDE_TRUSTED_DEVICE_TOKEN': 'tdt-abc'}
+    with patch.dict(os.environ, env, clear=True):
+        assert get_trusted_device_token() == 'tdt-abc'
+
+
+def test_get_token_treats_empty_string_as_unset() -> None:
+    env = {'CLAUDE_TRUSTED_DEVICE_TOKEN': ''}
+    with patch.dict(os.environ, env, clear=True):
+        assert get_trusted_device_token() is None
+
+
+def test_clear_token_cache_is_noop() -> None:
+    """Cache clear is a no-op in env-var-only build."""
+    clear_trusted_device_token_cache()
+
+
+def test_clear_token_is_noop() -> None:
+    """Token clear is a no-op until Phase 10 keychain integration."""
+    clear_trusted_device_token()
+
+
+@pytest.mark.asyncio
+async def test_enroll_is_noop_stub(caplog: pytest.LogCaptureFixture) -> None:
+    """Enrollment emits a debug log + returns; does not raise."""
+    with caplog.at_level('DEBUG', logger='src.bridge.trusted_device'):
+        await enroll_trusted_device()
+    assert any('no-op stub' in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Closes out the two remaining `src/bridge/` leaf modules deferred in earlier phases.

### `inbound_attachments.py` (~280 lines)

Full port of `typescript/src/bridge/inboundAttachments.ts`:
- `extract_inbound_attachments(msg)` — pull `file_attachments` off loosely-typed messages
- `resolve_inbound_attachments(attachments)` — fetch each via GET `/api/oauth/files/{uuid}/content`, write to per-session `~/.claude/uploads/{sessionId}/`, return `@"path"` prefix
- `prepend_path_refs(content, prefix)` — prepend to string content or target the LAST text block in a list
- `resolve_and_prepend(msg, content)` — convenience wrapper
- Honors `CLAUDE_CONFIG_DIR` env override; sanitizes filenames; best-effort failure handling

### `trusted_device.py` (~80 lines, Phase 10 stub)

- `get_trusted_device_token()` returns `CLAUDE_TRUSTED_DEVICE_TOKEN` env var or `None` (no Keychain/DPAPI/libsecret yet)
- `clear_*` are no-ops
- `enroll_trusted_device()` async stub logs a debug line
- Signatures match TS so future keychain-backed implementation is non-breaking

## Test plan

- [x] `uv run pytest tests/bridge tests/test_porting_workspace.py` — **556/556 pass** (24 new)
- [x] Coverage: extract (None/non-dict/missing/malformed), prepend (string/list/no-text-block/empty), resolve (no-token/failed/network-error/mixed), trusted device (env-var/empty/no-ops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)