### PR TITLE
bridge phase 7 (MVP slice): initReplBridge bootstrap layer

### DIFF
--- a/src/bridge/init_repl_bridge.py
+++ b/src/bridge/init_repl_bridge.py
@@ -1,0 +1,356 @@
+"""REPL bridge bootstrap — Phase 7 MVP slice.
+
+Ports ``typescript/src/bridge/initReplBridge.ts`` (570 lines).
+
+The TS file is a thick bootstrap layer that reads bootstrap state (cwd,
+session ID, git context, OAuth tokens, persisted title), runs pre-flight
+checks (auth, version, org UUID, entitlement), branches between the
+env-less (v2) and env-based (v1) bridge cores via the
+``tengu_bridge_repl_v2`` GrowthBook gate, and wires the two-stage
+title-derivation pipeline (instant placeholder + async Haiku
+regeneration).
+
+This Phase 7 MVP ports the structural skeleton:
+
+* ``init_repl_bridge(options) -> ReplBridgeHandle | None``
+* Pre-flight: OAuth token, org UUID, entitlement (via Phase 1 stubs)
+* v1/v2 branching based on ``is_env_less_bridge_enabled() and not perpetual``
+* Delegates to Phase 5 ``init_env_less_bridge_core`` (v2) or Phase 6
+  ``init_bridge_core`` (v1, MVP slice)
+* ``derive_title(raw)`` — synchronous quick placeholder (strip display
+  tags, first sentence, truncate to 50 chars)
+
+Explicit deferrals (Phase 10 follow-ups):
+
+* **Two-stage Haiku title generation** — requires ``generate_session_title``
+  from a future ``utils/session_title.py`` port (Haiku model call with
+  15s timeout + fire-and-forget guards). Until then, only ``derive_title``'s
+  instant placeholder is used; long-form titles wait for the user to
+  rename via ``/rename``.
+* **OAuth waterfall** (proactive refresh + cross-process backoff) —
+  ``check_and_refresh_oauth_token_if_needed`` is a no-op stub today
+  (Phase 2). The MVP just reads the token and proceeds.
+* **KAIROS / assistant-mode worker_type detection** — defaults to
+  ``claude_code``. Future port can extend.
+* **Policy-limits gating** — TS calls ``isPolicyAllowed`` + waits for
+  policy limits to load. The MVP skips this.
+* **``previously_flushed_uuids``** — propagated to ``init_bridge_core``
+  but the MVP doesn't maintain it across sessions yet.
+
+The function signature matches TS so a future expansion is non-breaking.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from src.auth.claude_ai import (
+    has_profile_scope,
+    is_claude_ai_subscriber,
+)
+from src.bridge.bridge_config import (
+    get_bridge_access_token,
+    get_bridge_base_url,
+)
+from src.bridge.bridge_enabled import (
+    check_bridge_min_version,
+    is_env_less_bridge_enabled,
+)
+from src.bridge.debug_utils import log_bridge_skip
+from src.bridge.env_less_bridge_config import (
+    check_env_less_bridge_min_version,
+)
+from src.bridge.remote_bridge_core import (
+    EnvLessBridgeParams,
+    init_env_less_bridge_core,
+)
+from src.bridge.repl_bridge import (
+    BridgeCoreParams,
+    ReplBridgeHandle,
+    init_bridge_core,
+)
+from src.services.oauth.client import get_organization_uuid
+
+logger = logging.getLogger(__name__)
+
+
+# ── Public surface ────────────────────────────────────────────────────────
+
+
+OnInboundMessage = Callable[[dict[str, Any]], Any]
+OnUserMessage = Callable[[str, str], bool]
+OnPermissionResponse = Callable[[dict[str, Any]], None]
+OnInterrupt = Callable[[], None]
+OnSetModel = Callable[[str | None], None]
+OnSetMaxThinkingTokens = Callable[[int | None], None]
+OnSetPermissionMode = Callable[[str], Any]
+OnStateChange = Callable[..., None]
+
+
+@dataclass
+class InitBridgeOptions:
+    """Caller-supplied configuration for ``init_repl_bridge``.
+
+    Mirrors TS ``InitBridgeOptions`` consumer surface. Most fields are
+    optional callbacks; the only required-by-policy field is
+    ``initial_name`` (which defaults to a generated session title).
+    """
+
+    initial_name: str | None = None
+    initial_messages: list[Any] | None = None
+    previously_flushed_uuids: set[str] | None = None
+    perpetual: bool = False
+    outbound_only: bool = False
+    tags: list[str] | None = None
+    initial_history_cap: int = 200
+
+    on_inbound_message: OnInboundMessage | None = None
+    on_user_message: OnUserMessage | None = None
+    on_permission_response: OnPermissionResponse | None = None
+    on_interrupt: OnInterrupt | None = None
+    on_set_model: OnSetModel | None = None
+    on_set_max_thinking_tokens: OnSetMaxThinkingTokens | None = None
+    on_set_permission_mode: OnSetPermissionMode | None = None
+    on_state_change: OnStateChange | None = None
+
+    # Inject sync createSession / archiveSession for v1 path — daemon /
+    # REPL wrappers fill these with their own org-scoped HTTP wrappers.
+    # MVP provides defaults that wire through the v2 ``code_session_api``
+    # which is sufficient for the env-less code path.
+    create_session: (
+        Callable[[dict[str, Any]], Awaitable[str | None]] | None
+    ) = None
+    archive_session: Callable[[str], Awaitable[None]] | None = None
+
+
+async def init_repl_bridge(
+    options: InitBridgeOptions | None = None,
+    *,
+    machine_name: str = 'localhost',
+    branch: str = 'main',
+    git_repo_url: str | None = None,
+    working_dir: str = '.',
+) -> ReplBridgeHandle | Any | None:
+    """Bootstrap the REPL bridge: pre-flight + v1/v2 branching + delegate.
+
+    Returns the bridge handle (``ReplBridgeHandle`` for v1 or
+    ``RemoteBridgeHandle`` for v2) on success, or ``None`` on any
+    pre-flight failure.
+
+    Mirrors TS ``initReplBridge`` consumer surface. The wrapper fields
+    (``machine_name``, ``branch``, ``git_repo_url``, ``working_dir``) are
+    explicit kw-only args here rather than being read from bootstrap
+    state — the Python port doesn't bind to the REPL's bootstrap layer
+    yet, so callers supply them. A future expansion can default them
+    from ``src/bootstrap/state``.
+    """
+    opts = options or InitBridgeOptions()
+
+    # ── 1. OAuth token pre-check ───────────────────────────────────────
+    access_token = get_bridge_access_token()
+    if not access_token:
+        log_bridge_skip(
+            'no_oauth_token',
+            '[bridge:repl] Skipping: no OAuth token',
+        )
+        _fire_state(opts.on_state_change, 'failed', '/login')
+        return None
+
+    # ── 2. Entitlement check (subscriber + profile scope) ──────────────
+    if not is_claude_ai_subscriber():
+        log_bridge_skip(
+            'not_subscriber',
+            '[bridge:repl] Skipping: not a claude.ai subscriber',
+        )
+        _fire_state(opts.on_state_change, 'failed', '/login')
+        return None
+    if not has_profile_scope():
+        log_bridge_skip(
+            'no_profile_scope',
+            '[bridge:repl] Skipping: token missing user:profile scope',
+        )
+        _fire_state(opts.on_state_change, 'failed', '/login')
+        return None
+
+    # ── 3. Org UUID (needed by both v1 and v2 paths) ───────────────────
+    org_uuid = await get_organization_uuid()
+    if not org_uuid:
+        log_bridge_skip(
+            'no_org_uuid',
+            '[bridge:repl] Skipping: no org UUID',
+        )
+        _fire_state(opts.on_state_change, 'failed', '/login')
+        return None
+
+    title = opts.initial_name or 'Remote Control session'
+    base_url = get_bridge_base_url()
+
+    # ── 4. v1/v2 branching ─────────────────────────────────────────────
+    # The env-less (v2) path skips the Environments API entirely. Per
+    # TS comment: perpetual mode is env-coupled and falls back to v1.
+    if is_env_less_bridge_enabled() and not opts.perpetual:
+        version_error = await check_env_less_bridge_min_version()
+        if version_error:
+            log_bridge_skip(
+                'version_too_old',
+                f'[bridge:repl] Skipping: {version_error}',
+                v2=True,
+            )
+            _fire_state(
+                opts.on_state_change, 'failed',
+                'run `openclaude update` to upgrade',
+            )
+            return None
+        logger.debug(
+            '[bridge:repl] Using env-less bridge path '
+            '(tengu_bridge_repl_v2 stub returns True)'
+        )
+        return await init_env_less_bridge_core(EnvLessBridgeParams(
+            base_url=base_url,
+            org_uuid=org_uuid,
+            title=title,
+            get_access_token=get_bridge_access_token,
+            initial_history_cap=opts.initial_history_cap,
+            initial_messages=opts.initial_messages,
+            on_inbound_message=opts.on_inbound_message,
+            on_user_message=opts.on_user_message,
+            on_permission_response=opts.on_permission_response,
+            on_interrupt=opts.on_interrupt,
+            on_set_model=opts.on_set_model,
+            on_set_max_thinking_tokens=opts.on_set_max_thinking_tokens,
+            on_set_permission_mode=opts.on_set_permission_mode,
+            on_state_change=opts.on_state_change,
+            outbound_only=opts.outbound_only,
+            tags=opts.tags,
+        ))
+
+    # ── v1 path: env-based (register/poll/ack/heartbeat) ──────────────
+    version_error_sync = check_bridge_min_version()
+    if version_error_sync:
+        log_bridge_skip(
+            'version_too_old',
+            f'[bridge:repl] Skipping: {version_error_sync}',
+        )
+        _fire_state(
+            opts.on_state_change, 'failed',
+            'run `openclaude update` to upgrade',
+        )
+        return None
+
+    # v1 path requires create_session + archive_session injections.
+    # Without them we can't delegate to init_bridge_core. MVP returns
+    # None with a clear log so the caller can wire them.
+    if opts.create_session is None or opts.archive_session is None:
+        log_bridge_skip(
+            'v1_path_missing_callbacks',
+            '[bridge:repl] Skipping: v1 path requires create_session + '
+            'archive_session callbacks (Phase 7 MVP — wrappers come later)',
+        )
+        _fire_state(
+            opts.on_state_change, 'failed',
+            'v1 path not yet supported in MVP',
+        )
+        return None
+
+    return await init_bridge_core(BridgeCoreParams(
+        dir=working_dir,
+        machine_name=machine_name,
+        branch=branch,
+        git_repo_url=git_repo_url,
+        title=title,
+        base_url=base_url,
+        session_ingress_url=base_url,
+        worker_type='claude_code',
+        get_access_token=get_bridge_access_token,
+        create_session=opts.create_session,
+        archive_session=opts.archive_session,
+        on_inbound_message=opts.on_inbound_message,
+        on_user_message=opts.on_user_message,
+        on_permission_response=opts.on_permission_response,
+        on_interrupt=opts.on_interrupt,
+        on_set_model=opts.on_set_model,
+        on_set_max_thinking_tokens=opts.on_set_max_thinking_tokens,
+        on_set_permission_mode=opts.on_set_permission_mode,
+        on_state_change=opts.on_state_change,
+        initial_history_cap=opts.initial_history_cap,
+        initial_messages=opts.initial_messages,
+        perpetual=opts.perpetual,
+    ))
+
+
+# ── Title derivation ──────────────────────────────────────────────────────
+
+
+TITLE_MAX_LEN = 50
+
+
+_FIRST_SENTENCE_RE = re.compile(r'^(.*?[.!?])\s', re.DOTALL)
+_WHITESPACE_RE = re.compile(r'\s+')
+_DISPLAY_TAG_RE = re.compile(
+    r'<([a-z][\w-]*)(?:\s[^>]*)?>[\s\S]*?</\1>\n?',
+)
+
+
+def _strip_display_tags(text: str) -> str:
+    """Strip XML display tags (mirrors TS ``stripDisplayTagsAllowEmpty``).
+
+    Returns the empty string (not the original) when all content is tags,
+    matching the TS contract.
+    """
+    return _DISPLAY_TAG_RE.sub('', text)
+
+
+def derive_title(raw: str) -> str | None:
+    """Quick placeholder title from a raw user message.
+
+    Mirrors TS ``deriveTitle`` on ``initReplBridge.ts:556-569``:
+
+    1. Strip ``<ide_opened_file>``, ``<session-start-hook>``, etc.
+       (display tags injected by IDE/hooks).
+    2. Take the first sentence (terminator: ``.``, ``!``, ``?``).
+    3. Collapse newlines/tabs into single spaces.
+    4. Truncate to 50 chars (with an ``…`` if truncated).
+
+    Returns ``None`` for empty / pure-display-tag content so callers
+    can fall through to the generated title.
+    """
+    clean = _strip_display_tags(raw)
+    match = _FIRST_SENTENCE_RE.match(clean)
+    first_sentence = match.group(1) if match else clean
+    flat = _WHITESPACE_RE.sub(' ', first_sentence).strip()
+    if not flat:
+        return None
+    if len(flat) > TITLE_MAX_LEN:
+        return flat[:TITLE_MAX_LEN - 1] + '…'
+    return flat
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _fire_state(
+    cb: OnStateChange | None,
+    state: str,
+    detail: str | None = None,
+) -> None:
+    if cb is None:
+        return
+    try:
+        if detail is None:
+            cb(state)
+        else:
+            cb(state, detail)
+    except Exception as err:  # noqa: BLE001
+        logger.warning('[bridge:repl] on_state_change raised: %s', err)
+
+
+__all__ = [
+    'TITLE_MAX_LEN',
+    'InitBridgeOptions',
+    'derive_title',
+    'init_repl_bridge',
+]

--- a/tests/bridge/test_init_repl_bridge.py
+++ b/tests/bridge/test_init_repl_bridge.py
@@ -1,0 +1,242 @@
+"""Tests for ``src.bridge.init_repl_bridge`` (Phase 7 MVP slice)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.bridge.init_repl_bridge import (
+    TITLE_MAX_LEN,
+    InitBridgeOptions,
+    derive_title,
+    init_repl_bridge,
+)
+
+
+# ── derive_title ────────────────────────────────────────────────────────
+
+
+def test_derive_title_simple_first_sentence() -> None:
+    assert derive_title('Hello world. This is a test.') == 'Hello world.'
+
+
+def test_derive_title_no_sentence_terminator() -> None:
+    """No `.!?` → return the whole text (collapsed/trimmed)."""
+    assert derive_title('hello world no period') == 'hello world no period'
+
+
+def test_derive_title_collapses_whitespace() -> None:
+    assert derive_title('hello\n\nworld\t\tagain') == 'hello world again'
+
+
+def test_derive_title_truncates_at_50_with_ellipsis() -> None:
+    text = 'x' * 100
+    out = derive_title(text)
+    assert out is not None
+    assert len(out) == TITLE_MAX_LEN
+    assert out.endswith('…')
+
+
+def test_derive_title_returns_none_for_empty() -> None:
+    assert derive_title('') is None
+    assert derive_title('   \n\t  ') is None
+
+
+def test_derive_title_returns_none_for_pure_display_tags() -> None:
+    """If content is only display tags, return None to fall through."""
+    assert derive_title('<ide_opened_file>foo.py</ide_opened_file>') is None
+
+
+def test_derive_title_strips_display_tags() -> None:
+    """Display tags are stripped before sentence detection."""
+    raw = '<ide_opened_file>foo.py</ide_opened_file>Fix the bug.'
+    assert derive_title(raw) == 'Fix the bug.'
+
+
+def test_derive_title_under_max_length_unchanged() -> None:
+    assert derive_title('Short prompt.') == 'Short prompt.'
+
+
+def test_derive_title_question_terminator() -> None:
+    assert derive_title('What is X? Then Y.') == 'What is X?'
+
+
+def test_derive_title_exclamation_terminator() -> None:
+    assert derive_title('Wait! That is wrong.') == 'Wait!'
+
+
+# ── init_repl_bridge — pre-flight failures ──────────────────────────────
+
+
+def _no_claude_env() -> dict[str, str]:
+    return {
+        k: v for k, v in os.environ.items()
+        if not k.startswith('CLAUDE_AI_')
+        and not k.startswith('CLAUDE_BRIDGE_')
+    }
+
+
+@pytest.mark.asyncio
+async def test_init_returns_none_when_no_oauth_token() -> None:
+    state_log: list[Any] = []
+    opts = InitBridgeOptions(
+        on_state_change=lambda *a: state_log.append(a),
+    )
+    with patch.dict(os.environ, _no_claude_env(), clear=True):
+        out = await init_repl_bridge(opts)
+    assert out is None
+    assert any('failed' in str(s) for s in state_log)
+
+
+@pytest.mark.asyncio
+async def test_init_returns_none_when_not_subscriber() -> None:
+    """No CLAUDE_AI_OAUTH_ACCESS_TOKEN means is_claude_ai_subscriber → False."""
+    env = _no_claude_env() | {'CLAUDE_BRIDGE_OAUTH_TOKEN': 'override-tok'}
+    state_log: list[Any] = []
+    opts = InitBridgeOptions(
+        on_state_change=lambda *a: state_log.append(a),
+    )
+    with patch.dict(os.environ, env, clear=True):
+        out = await init_repl_bridge(opts)
+    # We pass the OAuth token override, but is_claude_ai_subscriber
+    # checks the claude_ai env vars separately and returns False.
+    assert out is None
+    assert any('failed' in str(s) for s in state_log)
+
+
+@pytest.mark.asyncio
+async def test_init_returns_none_when_subscriber_but_no_org_uuid() -> None:
+    """Has subscriber + profile scope but no org UUID → fail."""
+    env = _no_claude_env() | {
+        'CLAUDE_BRIDGE_OAUTH_TOKEN': 'override-tok',
+        'CLAUDE_AI_OAUTH_ACCESS_TOKEN': 'ai-tok',
+        'CLAUDE_AI_OAUTH_SCOPES': 'user:inference user:profile',
+        # NO CLAUDE_AI_ORG_UUID
+    }
+    state_log: list[Any] = []
+    opts = InitBridgeOptions(
+        on_state_change=lambda *a: state_log.append(a),
+    )
+    with patch.dict(os.environ, env, clear=True):
+        out = await init_repl_bridge(opts)
+    assert out is None
+    assert any('failed' in str(s) for s in state_log)
+
+
+# ── init_repl_bridge — v1/v2 delegation ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_init_delegates_to_env_less_when_subscriber_and_org_uuid() -> None:
+    """Happy preflight → routes through init_env_less_bridge_core."""
+    env = _no_claude_env() | {
+        'CLAUDE_BRIDGE_OAUTH_TOKEN': 'override-tok',
+        'CLAUDE_AI_OAUTH_ACCESS_TOKEN': 'ai-tok',
+        'CLAUDE_AI_OAUTH_SCOPES': 'user:inference user:profile',
+        'CLAUDE_AI_ORG_UUID': 'org-123',
+    }
+    captured: list[Any] = []
+
+    async def fake_init_env_less(params: Any, **_kw: Any) -> Any:
+        captured.append(params)
+        return 'fake-handle'
+
+    opts = InitBridgeOptions(initial_name='My session')
+    with patch.dict(os.environ, env, clear=True):
+        with patch(
+            'src.bridge.init_repl_bridge.init_env_less_bridge_core',
+            side_effect=fake_init_env_less,
+        ):
+            out = await init_repl_bridge(opts)
+    assert out == 'fake-handle'
+    assert len(captured) == 1
+    assert captured[0].title == 'My session'
+    assert captured[0].org_uuid == 'org-123'
+    assert captured[0].initial_history_cap == 200
+
+
+@pytest.mark.asyncio
+async def test_init_uses_default_title_when_none() -> None:
+    env = _no_claude_env() | {
+        'CLAUDE_BRIDGE_OAUTH_TOKEN': 'override-tok',
+        'CLAUDE_AI_OAUTH_ACCESS_TOKEN': 'ai-tok',
+        'CLAUDE_AI_OAUTH_SCOPES': 'user:inference user:profile',
+        'CLAUDE_AI_ORG_UUID': 'org-123',
+    }
+    captured: list[Any] = []
+
+    async def fake_init(params: Any, **_kw: Any) -> Any:
+        captured.append(params)
+        return 'h'
+
+    opts = InitBridgeOptions()
+    with patch.dict(os.environ, env, clear=True):
+        with patch(
+            'src.bridge.init_repl_bridge.init_env_less_bridge_core',
+            side_effect=fake_init,
+        ):
+            await init_repl_bridge(opts)
+    assert captured[0].title == 'Remote Control session'
+
+
+@pytest.mark.asyncio
+async def test_init_v1_path_fails_without_callbacks() -> None:
+    """Perpetual=True forces v1; missing create_session callback → fail."""
+    env = _no_claude_env() | {
+        'CLAUDE_BRIDGE_OAUTH_TOKEN': 'override-tok',
+        'CLAUDE_AI_OAUTH_ACCESS_TOKEN': 'ai-tok',
+        'CLAUDE_AI_OAUTH_SCOPES': 'user:inference user:profile',
+        'CLAUDE_AI_ORG_UUID': 'org-123',
+    }
+    state_log: list[Any] = []
+    opts = InitBridgeOptions(
+        perpetual=True,
+        on_state_change=lambda *a: state_log.append(a),
+    )
+    with patch.dict(os.environ, env, clear=True):
+        out = await init_repl_bridge(opts)
+    assert out is None
+    assert any('failed' in str(s) for s in state_log)
+
+
+@pytest.mark.asyncio
+async def test_init_passes_through_callbacks_to_env_less() -> None:
+    """Optional callbacks land on the EnvLessBridgeParams."""
+    env = _no_claude_env() | {
+        'CLAUDE_BRIDGE_OAUTH_TOKEN': 'override-tok',
+        'CLAUDE_AI_OAUTH_ACCESS_TOKEN': 'ai-tok',
+        'CLAUDE_AI_OAUTH_SCOPES': 'user:inference user:profile',
+        'CLAUDE_AI_ORG_UUID': 'org-123',
+    }
+    captured: list[Any] = []
+
+    async def fake_init(params: Any, **_kw: Any) -> Any:
+        captured.append(params)
+        return 'h'
+
+    def on_inbound(_msg: Any) -> None:
+        pass
+
+    def on_interrupt() -> None:
+        pass
+
+    opts = InitBridgeOptions(
+        on_inbound_message=on_inbound,
+        on_interrupt=on_interrupt,
+        tags=['ccr-mirror'],
+        outbound_only=True,
+    )
+    with patch.dict(os.environ, env, clear=True):
+        with patch(
+            'src.bridge.init_repl_bridge.init_env_less_bridge_core',
+            side_effect=fake_init,
+        ):
+            await init_repl_bridge(opts)
+    p = captured[0]
+    assert p.on_inbound_message is on_inbound
+    assert p.on_interrupt is on_interrupt
+    assert p.tags == ['ccr-mirror']
+    assert p.outbound_only is True


### PR DESCRIPTION
## Summary

Ports `typescript/src/bridge/initReplBridge.ts` (570 lines) MVP slice — the REPL bootstrap layer that runs pre-flight checks and branches between Phase 5 (env-less) and Phase 6 (env-based) orchestrators.

## Surface

- `init_repl_bridge(options, *, machine_name, branch, git_repo_url, working_dir)` — entry point
- `InitBridgeOptions` dataclass with callbacks
- `derive_title(raw) -> str | None` — quick placeholder title
- `TITLE_MAX_LEN = 50`

## Pre-flight pipeline

1. OAuth token check
2. Entitlement: `is_claude_ai_subscriber()` + `has_profile_scope()`
3. Org UUID (Phase 2 helper)
4. v1/v2 branch: env-less when enabled + not perpetual

## Explicit Phase 10 deferrals

- Two-stage Haiku title generation
- OAuth waterfall (proactive refresh + cross-process backoff)
- KAIROS / assistant-mode worker_type detection
- Policy-limits gating
- `previously_flushed_uuids` cross-session persistence

## Test plan

- [x] **573/573 bridge tests pass** (17 new)
- [x] Tests cover: title derivation (10 cases), preflight failures (3), v2 delegation, default title, v1 callbacks rejection, callback forwarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)