### PR TITLE
bridge phase 11c: init_repl_bridge polish (OAuth refresh + worker_type override)

### DIFF
--- a/src/bridge/init_repl_bridge.py
+++ b/src/bridge/init_repl_bridge.py
@@ -49,6 +49,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from src.auth.claude_ai import (
+    check_and_refresh_oauth_token_if_needed,
     has_profile_scope,
     is_claude_ai_subscriber,
 )
@@ -126,6 +127,23 @@ class InitBridgeOptions:
     ) = None
     archive_session: Callable[[str], Awaitable[None]] | None = None
 
+    # Phase 11c hooks:
+
+    # Override the ``worker_type`` metadata sent at env registration.
+    # Mirrors TS KAIROS / assistant-mode detection where the worker
+    # advertises itself as ``claude_code_assistant`` so the claude.ai
+    # session picker can filter it into the assistant tab. Defaults to
+    # ``claude_code``. Callers can pass a callable so detection runs at
+    # init time (e.g. reading bootstrap state).
+    worker_type: str | Callable[[], str] = 'claude_code'
+
+    # Whether to run a proactive OAuth-token refresh during pre-flight.
+    # The check_and_refresh_oauth_token_if_needed call is a no-op stub
+    # today (Phase 2 deferral) but emits a warning if a near-expiry
+    # token is detected; flipping this off skips the warning when
+    # callers know they're using a long-lived token.
+    proactive_oauth_refresh: bool = True
+
 
 async def init_repl_bridge(
     options: InitBridgeOptions | None = None,
@@ -150,7 +168,25 @@ async def init_repl_bridge(
     """
     opts = options or InitBridgeOptions()
 
-    # ── 1. OAuth token pre-check ───────────────────────────────────────
+    # ── 1. Proactive OAuth refresh ─────────────────────────────────────
+    # Phase 11c addition: run the refresh waterfall BEFORE reading the
+    # access token. Real impl (Phase 10 keychain port) refreshes tokens
+    # near expiry; the current stub is a no-op that emits a warning
+    # when expiry is detected — useful signal for diagnosing 401s in
+    # tests / dev.
+    if opts.proactive_oauth_refresh:
+        try:
+            await check_and_refresh_oauth_token_if_needed()
+        except Exception as err:  # noqa: BLE001
+            # Best-effort: never block init on a refresh failure. The
+            # subsequent token read + entitlement check will fail
+            # explicitly if the token actually is stale.
+            logger.debug(
+                '[bridge:repl] proactive OAuth refresh raised '
+                '(continuing): %s', err
+            )
+
+    # ── 2. OAuth token pre-check ───────────────────────────────────────
     access_token = get_bridge_access_token()
     if not access_token:
         log_bridge_skip(
@@ -256,6 +292,12 @@ async def init_repl_bridge(
         )
         return None
 
+    # Phase 11c: resolve worker_type from callable-or-string.
+    worker_type = (
+        opts.worker_type()
+        if callable(opts.worker_type)
+        else opts.worker_type
+    )
     return await init_bridge_core(BridgeCoreParams(
         dir=working_dir,
         machine_name=machine_name,
@@ -264,7 +306,7 @@ async def init_repl_bridge(
         title=title,
         base_url=base_url,
         session_ingress_url=base_url,
-        worker_type='claude_code',
+        worker_type=worker_type,
         get_access_token=get_bridge_access_token,
         create_session=opts.create_session,
         archive_session=opts.archive_session,

--- a/tests/bridge/test_init_repl_bridge.py
+++ b/tests/bridge/test_init_repl_bridge.py
@@ -203,6 +203,178 @@ async def test_init_v1_path_fails_without_callbacks() -> None:
 
 
 @pytest.mark.asyncio
+async def test_proactive_oauth_refresh_called_by_default() -> None:
+    """Phase 11c: proactive_oauth_refresh=True (default) → refresh fires."""
+    env = _no_claude_env() | {
+        'CLAUDE_BRIDGE_OAUTH_TOKEN': 'override-tok',
+        'CLAUDE_AI_OAUTH_ACCESS_TOKEN': 'ai-tok',
+        'CLAUDE_AI_OAUTH_SCOPES': 'user:inference user:profile',
+        'CLAUDE_AI_ORG_UUID': 'org-123',
+    }
+    refresh_calls = [0]
+
+    async def fake_refresh() -> None:
+        refresh_calls[0] += 1
+
+    async def fake_init(params: Any, **_kw: Any) -> Any:
+        return 'fake-handle'
+
+    with patch.dict(os.environ, env, clear=True):
+        with patch(
+            'src.bridge.init_repl_bridge.check_and_refresh_oauth_token_if_needed',
+            side_effect=fake_refresh,
+        ), patch(
+            'src.bridge.init_repl_bridge.init_env_less_bridge_core',
+            side_effect=fake_init,
+        ):
+            await init_repl_bridge(InitBridgeOptions())
+    assert refresh_calls[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_proactive_oauth_refresh_skipped_when_disabled() -> None:
+    """`proactive_oauth_refresh=False` → refresh is NOT called."""
+    env = _no_claude_env() | {
+        'CLAUDE_BRIDGE_OAUTH_TOKEN': 'override-tok',
+        'CLAUDE_AI_OAUTH_ACCESS_TOKEN': 'ai-tok',
+        'CLAUDE_AI_OAUTH_SCOPES': 'user:inference user:profile',
+        'CLAUDE_AI_ORG_UUID': 'org-123',
+    }
+    refresh_calls = [0]
+
+    async def fake_refresh() -> None:
+        refresh_calls[0] += 1
+
+    async def fake_init(params: Any, **_kw: Any) -> Any:
+        return 'fake-handle'
+
+    with patch.dict(os.environ, env, clear=True):
+        with patch(
+            'src.bridge.init_repl_bridge.check_and_refresh_oauth_token_if_needed',
+            side_effect=fake_refresh,
+        ), patch(
+            'src.bridge.init_repl_bridge.init_env_less_bridge_core',
+            side_effect=fake_init,
+        ):
+            opts = InitBridgeOptions(proactive_oauth_refresh=False)
+            await init_repl_bridge(opts)
+    assert refresh_calls[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_proactive_oauth_refresh_failure_doesnt_block_init() -> None:
+    """A raising refresh must NOT cause init to fail — best-effort."""
+    env = _no_claude_env() | {
+        'CLAUDE_BRIDGE_OAUTH_TOKEN': 'override-tok',
+        'CLAUDE_AI_OAUTH_ACCESS_TOKEN': 'ai-tok',
+        'CLAUDE_AI_OAUTH_SCOPES': 'user:inference user:profile',
+        'CLAUDE_AI_ORG_UUID': 'org-123',
+    }
+
+    async def boom_refresh() -> None:
+        raise RuntimeError('keychain locked')
+
+    async def fake_init(params: Any, **_kw: Any) -> Any:
+        return 'h'
+
+    with patch.dict(os.environ, env, clear=True):
+        with patch(
+            'src.bridge.init_repl_bridge.check_and_refresh_oauth_token_if_needed',
+            side_effect=boom_refresh,
+        ), patch(
+            'src.bridge.init_repl_bridge.init_env_less_bridge_core',
+            side_effect=fake_init,
+        ):
+            out = await init_repl_bridge(InitBridgeOptions())
+    # Init succeeded despite refresh failure.
+    assert out == 'h'
+
+
+@pytest.mark.asyncio
+async def test_worker_type_string_passed_to_v1_path() -> None:
+    """Phase 11c: opts.worker_type (str) flows into BridgeCoreParams."""
+    env = _no_claude_env() | {
+        'CLAUDE_BRIDGE_OAUTH_TOKEN': 'override-tok',
+        'CLAUDE_AI_OAUTH_ACCESS_TOKEN': 'ai-tok',
+        'CLAUDE_AI_OAUTH_SCOPES': 'user:inference user:profile',
+        'CLAUDE_AI_ORG_UUID': 'org-123',
+    }
+    captured: list[Any] = []
+
+    async def fake_v1(params: Any, **_kw: Any) -> Any:
+        captured.append(params)
+        return 'v1-handle'
+
+    async def cs(_o: dict[str, Any]) -> str | None:
+        return 'cse_test'
+
+    async def ar(_s: str) -> None:
+        pass
+
+    # Force v1 by setting perpetual=True (which falls back to v1 per
+    # the documented v1/v2 branch).
+    opts = InitBridgeOptions(
+        perpetual=True,
+        create_session=cs,
+        archive_session=ar,
+        worker_type='claude_code_assistant',
+    )
+
+    with patch.dict(os.environ, env, clear=True):
+        with patch(
+            'src.bridge.init_repl_bridge.init_bridge_core',
+            side_effect=fake_v1,
+        ):
+            await init_repl_bridge(opts)
+    assert len(captured) == 1
+    assert captured[0].worker_type == 'claude_code_assistant'
+
+
+@pytest.mark.asyncio
+async def test_worker_type_callable_invoked_at_init() -> None:
+    """Phase 11c: opts.worker_type (callable) is invoked + result used."""
+    env = _no_claude_env() | {
+        'CLAUDE_BRIDGE_OAUTH_TOKEN': 'override-tok',
+        'CLAUDE_AI_OAUTH_ACCESS_TOKEN': 'ai-tok',
+        'CLAUDE_AI_OAUTH_SCOPES': 'user:inference user:profile',
+        'CLAUDE_AI_ORG_UUID': 'org-123',
+    }
+    invocations = [0]
+
+    def compute_worker_type() -> str:
+        invocations[0] += 1
+        return 'dynamic_worker'
+
+    captured: list[Any] = []
+
+    async def fake_v1(params: Any, **_kw: Any) -> Any:
+        captured.append(params)
+        return 'v1-handle'
+
+    async def cs(_o: dict[str, Any]) -> str | None:
+        return 'cse_test'
+
+    async def ar(_s: str) -> None:
+        pass
+
+    opts = InitBridgeOptions(
+        perpetual=True,
+        create_session=cs,
+        archive_session=ar,
+        worker_type=compute_worker_type,
+    )
+
+    with patch.dict(os.environ, env, clear=True):
+        with patch(
+            'src.bridge.init_repl_bridge.init_bridge_core',
+            side_effect=fake_v1,
+        ):
+            await init_repl_bridge(opts)
+    assert invocations[0] == 1
+    assert captured[0].worker_type == 'dynamic_worker'
+
+
+@pytest.mark.asyncio
 async def test_init_passes_through_callbacks_to_env_less() -> None:
     """Optional callbacks land on the EnvLessBridgeParams."""
     env = _no_claude_env() | {


### PR DESCRIPTION
## Summary

Fills in three Phase 7 MVP deferrals.

### Proactive OAuth refresh waterfall
- New step 1: `await check_and_refresh_oauth_token_if_needed()` BEFORE reading bridge access token
- Mirrors TS `initReplBridge.ts:169-241`
- Best-effort: exceptions from refresh are logged + continued
- `opts.proactive_oauth_refresh: bool = True` flag (default on)

### KAIROS / assistant-mode worker_type override
- `opts.worker_type: str | Callable[[], str] = 'claude_code'`
- Resolved at init time (callable invoked once)
- Result flows to `BridgeCoreParams.worker_type` → env registration
- Mirrors TS check at `initReplBridge.ts:478-486` where KAIROS + `isAssistantMode()` picks `'claude_code_assistant'`

### `previously_flushed_uuids` (noted)
The parity-plan deferral mentioned wiring this through. The field already lives on `InitBridgeOptions`. v2 doesn't need it (TS comment at `initReplBridge.ts:441-446`), and Phase 6 MVP slice doesn't yet read it. Leaving as pass-through.

## Test plan

- [x] **600/600 bridge tests pass** (5 new + 595 existing)
- [x] 5 new tests covering: refresh called by default, skipped when disabled, failure-doesn't-block-init, worker_type string, worker_type callable

🤖 Generated with [Claude Code](https://claude.com/claude-code)