### PR TITLE
bridge phase 12a: real --spawn worktree integration

### DIFF
--- a/src/bridge/bridge_main.py
+++ b/src/bridge/bridge_main.py
@@ -93,6 +93,11 @@ from src.bridge.work_secret import (
     build_ccr_v2_sdk_url,
     decode_work_secret,
 )
+from src.bridge.worktree import (
+    WorktreePaths,
+    create_agent_worktree,
+    remove_agent_worktree,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -456,6 +461,14 @@ class _BridgeDaemon:
         self.completed_work_ids: set[str] = set()
         self.session_timer_tasks: dict[str, asyncio.Task[None]] = {}
         self.timed_out_sessions: set[str] = set()
+        # Phase 12a: per-session git worktree paths for ``--spawn worktree``.
+        # Populated only when worktree creation succeeded; ``_on_session_done``
+        # and ``shutdown`` consult it for cleanup.
+        self.session_worktrees: dict[str, WorktreePaths] = {}
+        # Phase 12a: refs to the ``_on_session_done`` background tasks so
+        # ``shutdown`` can await them (they own per-session cleanup like
+        # worktree removal — letting them outlive shutdown leaks state).
+        self.session_done_tasks: dict[str, asyncio.Task[None]] = {}
 
         # Two-track exponential backoff state. Reset on any successful
         # poll (including empty-poll = no work).
@@ -618,17 +631,38 @@ class _BridgeDaemon:
         }
         working_dir = self.config.dir
         if self.config.spawn_mode == 'worktree':
-            # MVP: worktree mode not yet implemented; spawn in cwd with
-            # a one-line warning so operators see the gap.
-            logger.warning(
-                '[bridge:main] --spawn worktree not yet implemented; '
-                'spawning in %s instead', working_dir,
-            )
+            # Phase 12a: real ``git worktree`` integration. Best-effort:
+            # ``create_agent_worktree`` is documented to never raise and
+            # to fall back to base_dir on any failure (not a repo, git
+            # missing, subprocess timeout, etc.). The outer try/except
+            # is belt-and-braces — if a future change to that contract
+            # accidentally lets an exception escape, we'd rather spawn
+            # in cwd than crash the daemon.
+            try:
+                paths = await create_agent_worktree(working_dir, session_id)
+                working_dir = paths.working_dir
+                if paths.created:
+                    self.session_worktrees[session_id] = paths
+            except Exception as err:  # noqa: BLE001
+                logger.warning(
+                    '[bridge:main] worktree setup raised (continuing in '
+                    'base dir): %s', err,
+                )
+        # Invariant: at this point, neither ``session_timer_tasks`` nor
+        # ``session_done_tasks`` has a key for ``session_id`` — both are
+        # populated below, AFTER the spawn succeeds. The spawn-fail
+        # cleanup branch below therefore only needs to remove the
+        # worktree entry.
         try:
             session = self.spawner.spawn(spawn_opts, working_dir)
         except Exception as err:  # noqa: BLE001
             logger.error('[bridge:main] spawn failed: %s', err)
             await self._safe_stop_work(work_id, force=True)
+            # Clean up the worktree we just created — the session never
+            # started, so leaving it behind is just litter.
+            wt = self.session_worktrees.pop(session_id, None)
+            if wt is not None:
+                await remove_agent_worktree(wt)
             return
         self.active_sessions[session_id] = session
         self.session_work_ids[session_id] = work_id
@@ -657,8 +691,9 @@ class _BridgeDaemon:
             session_id, work_id,
             len(self.active_sessions), self.config.max_sessions,
         )
-        # Fire-and-forget wait-done.
-        asyncio.create_task(
+        # Phase 12a: track the wait-done task so ``shutdown`` can await
+        # any in-flight cleanup (worktree removal, stop_work, etc.).
+        self.session_done_tasks[session_id] = asyncio.create_task(
             self._on_session_done(session_id),
             name=f'bridge-await-{session_id}',
         )
@@ -717,11 +752,29 @@ class _BridgeDaemon:
         # ``discard`` doesn't return a value; check membership first.
         was_timeout = session_id in self.timed_out_sessions
         self.timed_out_sessions.discard(session_id)
+        # Phase 12a: remove the per-session worktree (best-effort).
+        # The ``pop`` happens BEFORE the await so a concurrent
+        # ``shutdown`` sweep can't double-claim this entry. The
+        # ``session_done_tasks.pop`` at the end of this method closes
+        # the cleanup-tracking loop the same way.
+        wt = self.session_worktrees.pop(session_id, None)
+        if wt is not None:
+            try:
+                await remove_agent_worktree(wt)
+            except Exception as err:  # noqa: BLE001
+                logger.warning(
+                    '[bridge:main] worktree cleanup failed for %s: %s',
+                    session_id, err,
+                )
         timeout_marker = ' (TIMEOUT)' if was_timeout else ''
         logger.info(
             '[bridge:main] Session done session_id=%s status=%s%s',
             session_id, status, timeout_marker,
         )
+        # Drop the self-reference last so ``shutdown`` doesn't try to
+        # await a completed task (it's already finished anyway, but a
+        # stale dict entry is just litter for a long-running daemon).
+        self.session_done_tasks.pop(session_id, None)
 
     async def shutdown(self) -> None:
         """SIGTERM all sessions, wait up to ``shutdown_grace_ms``, SIGKILL
@@ -771,6 +824,55 @@ class _BridgeDaemon:
         # Stop all outstanding work items.
         for work_id in work_id_snapshot.values():
             await self._safe_stop_work(work_id, force=True)
+
+        # Phase 12a: wait for any in-flight ``_on_session_done`` tasks
+        # to finish — they own per-session cleanup (worktree removal,
+        # stop_work) and racing against them leaves orphaned state on
+        # disk. Bounded by a short timeout so a stuck cleanup task
+        # can't hang shutdown indefinitely. On timeout we cancel the
+        # stragglers and drain them — letting them outlive shutdown
+        # would leak both ``WorktreePaths`` refs and live ``git``
+        # subprocesses, which matters because ``shutdown`` is
+        # documented as idempotent and may be called multiple times.
+        done_snapshot = [
+            t for t in self.session_done_tasks.values() if not t.done()
+        ]
+        if done_snapshot:
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*done_snapshot, return_exceptions=True),
+                    timeout=2.0,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    '[bridge:main] %d session-done task(s) didn\'t '
+                    'finish within 2s during shutdown — cancelling',
+                    len(done_snapshot),
+                )
+                for t in done_snapshot:
+                    if not t.done():
+                        t.cancel()
+                # Drain. The cancelled tasks return promptly with
+                # ``CancelledError``; ``_run_git``'s try/finally then
+                # kills any subprocess that was mid-``communicate()``
+                # so we don't leak ``git`` processes past shutdown.
+                await asyncio.gather(*done_snapshot, return_exceptions=True)
+
+        # Phase 12a: clean up any worktrees still on the books. After
+        # the wait above, ``_on_session_done`` has handled most of
+        # these — what remains is sessions that never completed (e.g.
+        # because the grace timeout expired before SIGKILL took effect).
+        # Best-effort — orphaned worktrees are recoverable via
+        # ``git worktree prune``.
+        for wt in list(self.session_worktrees.values()):
+            try:
+                await remove_agent_worktree(wt)
+            except Exception as err:  # noqa: BLE001
+                logger.warning(
+                    '[bridge:main] shutdown worktree cleanup failed: %s',
+                    err,
+                )
+        self.session_worktrees.clear()
 
         # Deregister the environment (best-effort).
         try:

--- a/src/bridge/worktree.py
+++ b/src/bridge/worktree.py
@@ -1,0 +1,220 @@
+"""Per-session git worktree helper for ``--spawn worktree`` mode.
+
+When the bridge runs multi-session with ``--spawn worktree``, each
+session is given an isolated working tree under
+``<base>/.claude/worktrees/agent-<session_id>/`` so concurrent edits
+don't stomp each other. This module owns the create/remove plumbing.
+
+The path layout (``<base>/.claude/worktrees/agent-<sid>/``) is a
+clawcodex convention. Crash-recovery — sweeping orphan worktrees from
+a previous run on daemon startup — is intentionally out of scope for
+this phase; it belongs with the perpetual-mode work in Phase 12c.
+
+Best-effort semantics
+---------------------
+``create_agent_worktree`` never raises. If the base dir isn't a git
+repo, the session_id contains path-unsafe characters, the git binary
+is missing, a subprocess fails or hangs, or the filesystem refuses
+``mkdir`` — all roads lead to a fallback ``WorktreePaths`` with
+``created=False`` and a warning log. The session still runs; it just
+won't be isolated.
+
+Subprocesses are deadline-bounded (see ``_GIT_TIMEOUT_S``) so a stuck
+``git worktree add`` from e.g. a wedged filesystem lock can't hang
+the daemon's poll loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Strict allowlist for the directory-name portion of an agent worktree.
+# Session IDs nominally arrive as ``cse_<hex>`` from the server, but the
+# work-secret payload isn't strongly typed, so a malformed value could
+# otherwise become a path-traversal vector (``session_id='../escape'``
+# would land the worktree outside ``<base>/.claude/worktrees/``).
+_SESSION_ID_RE = re.compile(r'^[A-Za-z0-9_-]{1,64}$')
+
+# Wall-clock cap for any single git subprocess. ``git worktree add``
+# and ``--force remove`` are normally sub-second, but can hang on a
+# stuck ``.git/index.lock`` or a slow network filesystem. The cap
+# turns a hang into a fallback (for add) or a logged warning (for
+# remove) instead of a wedged daemon.
+_GIT_TIMEOUT_S = 10.0
+
+
+@dataclass
+class WorktreePaths:
+    """Bookkeeping handle returned by :func:`create_agent_worktree`.
+
+    Attributes
+    ----------
+    base_dir
+        Original working directory passed to ``create_agent_worktree``.
+        Used as ``cwd`` for the eventual ``git worktree remove`` call.
+    working_dir
+        What the session should actually run in. Equal to the new
+        worktree path on success; equal to ``base_dir`` on fallback.
+    created
+        ``True`` if a real git worktree was created (and therefore must
+        be removed on cleanup). ``False`` if we fell back to ``base_dir``.
+    """
+
+    base_dir: str
+    working_dir: str
+    created: bool
+
+
+async def _run_git(*args: str, cwd: str) -> tuple[int, str]:
+    """Run ``git <args>`` in ``cwd``. Returns ``(returncode, stderr)``.
+
+    stdout is discarded — worktree commands don't return data we need.
+    Every failure mode — missing git binary, cwd unreadable, subprocess
+    spawn failure, communicate timeout — is converted to a non-zero
+    return code so callers can fall back on a simple rc check. The
+    one thing this CAN'T do is hang: ``_GIT_TIMEOUT_S`` caps the wait
+    and we ``kill()`` the subprocess on timeout.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            'git', *args,
+            cwd=cwd,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except (OSError, ValueError) as err:
+        # FileNotFoundError (git not on PATH), PermissionError (cwd
+        # not +x), NotADirectoryError, etc. — all OSError subclasses.
+        # ValueError can come from create_subprocess_exec when args
+        # contain NULs.
+        return -1, str(err)
+    # The try/finally guarantees we kill the subprocess on every exit
+    # path: timeout, ``CancelledError`` from a parent task, or any
+    # other exception. Without it, a cancelled ``_run_git`` leaves the
+    # ``git`` process running after the daemon has shut down — see
+    # the cancellation-cleanup discussion in the Phase 12a review.
+    try:
+        try:
+            _, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(), timeout=_GIT_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            return -1, f'git timed out after {_GIT_TIMEOUT_S:.2f}s'
+    finally:
+        if proc.returncode is None:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            # Drain so the transport releases its FDs. Bounded so a
+            # truly wedged process can't hang the finally block.
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=1.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                pass
+    rc = proc.returncode if proc.returncode is not None else -1
+    return rc, stderr_bytes.decode('utf-8', 'replace')
+
+
+async def _is_git_repo(path: str) -> bool:
+    rc, _ = await _run_git('rev-parse', '--is-inside-work-tree', cwd=path)
+    return rc == 0
+
+
+async def create_agent_worktree(
+    base_dir: str, session_id: str,
+) -> WorktreePaths:
+    """Create ``<base>/.claude/worktrees/agent-<session_id>/`` as a
+    detached worktree of ``base_dir``.
+
+    Returns a :class:`WorktreePaths` with ``created=True`` on success.
+    On any failure — bad session_id, not a git repo, mkdir error, git
+    command error, subprocess timeout — falls back to ``base_dir``
+    with ``created=False`` and a warning log. Never raises.
+    """
+    # Validate session_id before it touches the filesystem. The
+    # work-secret payload type is loose (server-provided string), so
+    # nothing else stops a malicious or buggy ``id`` value from
+    # turning into a path-traversal write target.
+    if not _SESSION_ID_RE.match(session_id):
+        logger.warning(
+            '[worktree] session_id %r is not allowlist-safe — '
+            'spawning in base dir', session_id,
+        )
+        return WorktreePaths(
+            base_dir=base_dir, working_dir=base_dir, created=False,
+        )
+
+    if not await _is_git_repo(base_dir):
+        logger.warning(
+            '[worktree] %s is not a git repo — spawning in base dir',
+            base_dir,
+        )
+        return WorktreePaths(
+            base_dir=base_dir, working_dir=base_dir, created=False,
+        )
+
+    target = os.path.join(
+        base_dir, '.claude', 'worktrees', f'agent-{session_id}',
+    )
+    parent = os.path.dirname(target)
+    try:
+        os.makedirs(parent, exist_ok=True)
+    except OSError as err:
+        logger.warning(
+            '[worktree] mkdir(%s) failed: %s — spawning in base dir',
+            parent, err,
+        )
+        return WorktreePaths(
+            base_dir=base_dir, working_dir=base_dir, created=False,
+        )
+
+    # ``--detach`` avoids polluting the branch namespace; the worktree
+    # starts on whatever commit the base dir's HEAD pointed at when
+    # we ran ``git worktree add`` (concurrent ``git reset`` is racy
+    # but acceptable for an ephemeral agent worktree). It has no
+    # branch attached, so ``--force`` removal stays clean later.
+    rc, stderr = await _run_git(
+        'worktree', 'add', '--detach', target, 'HEAD', cwd=base_dir,
+    )
+    if rc != 0:
+        logger.warning(
+            '[worktree] git worktree add failed (rc=%d): %s — '
+            'spawning in base dir', rc, stderr.strip(),
+        )
+        return WorktreePaths(
+            base_dir=base_dir, working_dir=base_dir, created=False,
+        )
+
+    logger.info('[worktree] Created %s for session %s', target, session_id)
+    return WorktreePaths(
+        base_dir=base_dir, working_dir=target, created=True,
+    )
+
+
+async def remove_agent_worktree(paths: WorktreePaths) -> None:
+    """Best-effort remove. No-op if ``paths.created`` is ``False``.
+
+    Uses ``--force`` so uncommitted edits in the session's worktree
+    don't block cleanup — the entire point of an agent worktree is
+    that we don't care about its working state after the session ends.
+    """
+    if not paths.created:
+        return
+    rc, stderr = await _run_git(
+        'worktree', 'remove', '--force', paths.working_dir,
+        cwd=paths.base_dir,
+    )
+    if rc != 0:
+        logger.warning(
+            '[worktree] git worktree remove failed (rc=%d): %s',
+            rc, stderr.strip(),
+        )
+        return
+    logger.info('[worktree] Removed %s', paths.working_dir)

--- a/tests/bridge/test_bridge_main.py
+++ b/tests/bridge/test_bridge_main.py
@@ -863,3 +863,247 @@ async def test_bridge_main_permanent_error_returns_three() -> None:
         cancel_event=cancel,
     )
     assert code == 3
+
+
+# ── Phase 12a: worktree spawn-mode integration ──────────────────────────
+
+
+def _init_git_repo(repo_path: str) -> None:
+    """Helper: initialize a real git repo with one commit."""
+    import subprocess
+    subprocess.run(
+        ['git', 'init', '--initial-branch=main'], cwd=repo_path,
+        check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    subprocess.run(
+        ['git', 'config', 'user.email', 'test@example.com'],
+        cwd=repo_path, check=True,
+    )
+    subprocess.run(
+        ['git', 'config', 'user.name', 'Test'],
+        cwd=repo_path, check=True,
+    )
+    subprocess.run(
+        ['git', 'config', 'commit.gpgsign', 'false'],
+        cwd=repo_path, check=True,
+    )
+    with open(f'{repo_path}/README.md', 'w', encoding='utf-8') as fh:
+        fh.write('hello\n')
+    subprocess.run(
+        ['git', 'add', 'README.md'], cwd=repo_path, check=True,
+    )
+    subprocess.run(
+        ['git', 'commit', '-m', 'init'], cwd=repo_path, check=True,
+        stdout=subprocess.DEVNULL,
+    )
+
+
+@pytest.mark.asyncio
+async def test_spawn_worktree_creates_isolated_dir_and_cleans_up(
+    tmp_path,
+) -> None:
+    """``--spawn worktree`` against a git repo gives the session an
+    isolated working dir, then removes it when the session ends."""
+    import os
+    repo = str(tmp_path / 'repo')
+    os.makedirs(repo)
+    _init_git_repo(repo)
+
+    work = {
+        'id': 'w1', 'type': 'work', 'environment_id': 'env-srv',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_wt1'},
+        'secret': _encode_work_secret(),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    cancel = asyncio.Event()
+    cfg = _bridge_config()
+    cfg.dir = repo
+    cfg.spawn_mode = 'worktree'
+
+    task = asyncio.create_task(run_bridge_loop(
+        cfg, 'env-srv', 'sec-srv', api, spawner, cancel,
+    ))
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if spawner.spawns:
+            break
+
+    assert len(spawner.spawns) == 1
+    _opts, wd = spawner.spawns[0]
+    # The spawner was handed the worktree path, not the base repo.
+    expected = os.path.join(repo, '.claude', 'worktrees', 'agent-cse_wt1')
+    assert wd == expected
+    assert os.path.isdir(expected)
+
+    # Complete the session — the worktree should be removed.
+    spawner.handles[0].complete('completed')
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if not os.path.isdir(expected):
+            break
+    assert not os.path.isdir(expected), (
+        'worktree should be cleaned up after session completion'
+    )
+
+    cancel.set()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_spawn_worktree_falls_back_when_not_a_repo(tmp_path) -> None:
+    """If ``cfg.dir`` isn't a git repo, ``--spawn worktree`` falls back
+    to ``cfg.dir`` itself rather than refusing to spawn."""
+    work = {
+        'id': 'w1', 'type': 'work', 'environment_id': 'env-srv',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_wt2'},
+        'secret': _encode_work_secret(),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    cancel = asyncio.Event()
+    cfg = _bridge_config()
+    cfg.dir = str(tmp_path)  # not a git repo
+    cfg.spawn_mode = 'worktree'
+
+    task = asyncio.create_task(run_bridge_loop(
+        cfg, 'env-srv', 'sec-srv', api, spawner, cancel,
+    ))
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if spawner.spawns:
+            break
+
+    assert len(spawner.spawns) == 1
+    _opts, wd = spawner.spawns[0]
+    # Fell back to base dir — no worktree created.
+    assert wd == str(tmp_path)
+    spawner.handles[0].complete('completed')
+    cancel.set()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_shutdown_removes_orphaned_worktrees(tmp_path) -> None:
+    """If the daemon is shut down with a still-active worktree session,
+    the worktree directory must not be left behind on disk."""
+    import os
+    repo = str(tmp_path / 'repo')
+    os.makedirs(repo)
+    _init_git_repo(repo)
+
+    work = {
+        'id': 'w1', 'type': 'work', 'environment_id': 'env-srv',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_wt3'},
+        'secret': _encode_work_secret(),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    cancel = asyncio.Event()
+    cfg = _bridge_config()
+    cfg.dir = repo
+    cfg.spawn_mode = 'worktree'
+
+    task = asyncio.create_task(run_bridge_loop(
+        cfg, 'env-srv', 'sec-srv', api, spawner, cancel,
+    ))
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if spawner.spawns:
+            break
+
+    expected = os.path.join(repo, '.claude', 'worktrees', 'agent-cse_wt3')
+    assert os.path.isdir(expected)
+    # Trigger shutdown WITHOUT completing the session first.
+    cancel.set()
+    # Have the spawner's handle "exit" once it's been killed, so
+    # ``shutdown`` can proceed past the wait_for-grace step. Capture
+    # the task handle so we can await it explicitly and prevent test
+    # leakage across the suite.
+
+    async def complete_after_kill() -> None:
+        for _ in range(50):
+            await asyncio.sleep(0.01)
+            if spawner.handles[0].killed:
+                spawner.handles[0].complete('interrupted')
+                return
+
+    helper = asyncio.create_task(complete_after_kill())
+    try:
+        await task
+    finally:
+        if not helper.done():
+            helper.cancel()
+        await asyncio.gather(helper, return_exceptions=True)
+    assert not os.path.isdir(expected), (
+        'worktree should be cleaned up by daemon shutdown'
+    )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_bounded_when_session_done_task_is_slow(
+    monkeypatch, tmp_path,
+) -> None:
+    """If ``_on_session_done`` is mid-cleanup when shutdown runs and
+    doesn't finish within 2s, shutdown cancels it and returns within
+    a bounded time — it must not hang forever on the cleanup task."""
+    import os
+    from src.bridge import bridge_main as bm
+
+    repo = str(tmp_path / 'repo')
+    os.makedirs(repo)
+    _init_git_repo(repo)
+
+    # Replace ``remove_agent_worktree`` with a slow stub so the
+    # done-task is genuinely stuck during shutdown.
+    async def slow_remove(_paths):
+        await asyncio.sleep(30)
+
+    monkeypatch.setattr(bm, 'remove_agent_worktree', slow_remove)
+
+    work = {
+        'id': 'w1', 'type': 'work', 'environment_id': 'env-srv',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_slow_done'},
+        'secret': _encode_work_secret(),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    cancel = asyncio.Event()
+    cfg = _bridge_config()
+    cfg.dir = repo
+    cfg.spawn_mode = 'worktree'
+
+    task = asyncio.create_task(run_bridge_loop(
+        cfg, 'env-srv', 'sec-srv', api, spawner, cancel,
+    ))
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if spawner.spawns:
+            break
+
+    # Complete the session so ``_on_session_done`` enters the slow
+    # ``remove_agent_worktree`` path. Then cancel the loop — shutdown
+    # should hit the 2s wait_for timeout and cancel the stragglers.
+    spawner.handles[0].complete('completed')
+    await asyncio.sleep(0.05)  # let _on_session_done get into slow_remove
+    cancel.set()
+
+    loop = asyncio.get_running_loop()
+    start = loop.time()
+    await task
+    elapsed = loop.time() - start
+    # Shutdown should complete within ~3s — the 2s wait_for plus
+    # a small drain budget after cancellation. Without the bounded
+    # wait, this would hang for 30s on the slow_remove sleep.
+    assert elapsed < 5.0, (
+        f'shutdown took {elapsed:.2f}s — should be bounded by 2s '
+        f'wait_for + cancel drain'
+    )

--- a/tests/bridge/test_worktree.py
+++ b/tests/bridge/test_worktree.py
@@ -1,0 +1,354 @@
+"""Tests for ``src.bridge.worktree`` — real-git happy/fallback paths.
+
+These tests use real ``git`` subprocesses in pytest tmp dirs. They
+require ``git`` on PATH; if it's missing they degrade to fallback
+assertions (which is the right semantic — the helper itself falls back
+when git is missing, so the test asserts that contract).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+
+import pytest
+
+from src.bridge.worktree import (
+    WorktreePaths,
+    create_agent_worktree,
+    remove_agent_worktree,
+)
+
+
+def _git(args: list[str], cwd: str) -> None:
+    """Synchronous git helper used to set up fixture repos."""
+    subprocess.run(
+        ['git', *args], cwd=cwd, check=True,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+
+@pytest.fixture()
+def git_repo(tmp_path):
+    """Create an initialized repo with one commit. Returns the path."""
+    repo = tmp_path / 'repo'
+    repo.mkdir()
+    _git(['init', '--initial-branch=main'], cwd=str(repo))
+    _git(['config', 'user.email', 'test@example.com'], cwd=str(repo))
+    _git(['config', 'user.name', 'Test'], cwd=str(repo))
+    _git(['config', 'commit.gpgsign', 'false'], cwd=str(repo))
+    (repo / 'README.md').write_text('hello\n')
+    _git(['add', 'README.md'], cwd=str(repo))
+    _git(['commit', '-m', 'init'], cwd=str(repo))
+    return str(repo)
+
+
+# ── happy path ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_then_remove_happy_path(git_repo: str) -> None:
+    """A fresh worktree is created at the conventional path and removed
+    cleanly. ``created=True`` and the working_dir actually exists and
+    is its own checkout."""
+    paths = await create_agent_worktree(git_repo, 'sess-abc')
+    try:
+        assert paths.created is True
+        assert paths.base_dir == git_repo
+        expected = os.path.join(
+            git_repo, '.claude', 'worktrees', 'agent-sess-abc',
+        )
+        assert paths.working_dir == expected
+        # The worktree exists on disk with the README from HEAD.
+        assert os.path.isdir(expected)
+        assert os.path.exists(os.path.join(expected, 'README.md'))
+        # ``git worktree list`` confirms the new worktree.
+        out = subprocess.check_output(
+            ['git', 'worktree', 'list'], cwd=git_repo,
+        ).decode()
+        assert expected in out
+    finally:
+        await remove_agent_worktree(paths)
+
+    # After removal: directory is gone and ``git worktree list`` no
+    # longer mentions it.
+    assert not os.path.isdir(paths.working_dir)
+    out = subprocess.check_output(
+        ['git', 'worktree', 'list'], cwd=git_repo,
+    ).decode()
+    assert 'agent-sess-abc' not in out
+
+
+@pytest.mark.asyncio
+async def test_remove_is_idempotent_when_not_created(tmp_path) -> None:
+    """``created=False`` paths are a no-op on remove — never raises,
+    never invokes git."""
+    paths = WorktreePaths(
+        base_dir=str(tmp_path), working_dir=str(tmp_path), created=False,
+    )
+    # Should not raise even though base_dir isn't a git repo.
+    await remove_agent_worktree(paths)
+
+
+# ── session_id validation (path traversal guard) ───────────────────────
+
+
+@pytest.mark.parametrize('bad_id', [
+    '../escape',
+    '..',
+    'foo/bar',
+    'foo\\bar',
+    '',
+    'a' * 65,  # too long
+    'has space',
+    'with;semi',
+    'with.dot',  # dot is not in our allowlist
+])
+@pytest.mark.asyncio
+async def test_session_id_validation_falls_back(
+    git_repo: str, bad_id: str,
+) -> None:
+    """Any session_id that fails the allowlist must fall back to the
+    base dir without invoking git. No worktree dir is created."""
+    paths = await create_agent_worktree(git_repo, bad_id)
+    assert paths.created is False
+    assert paths.working_dir == git_repo
+    # No .claude/worktrees/agent-<bad> is created.
+    expected = os.path.join(
+        git_repo, '.claude', 'worktrees', f'agent-{bad_id}',
+    )
+    assert not os.path.exists(expected)
+
+
+@pytest.mark.parametrize('good_id', [
+    'cse_abc123',
+    'session-with-dashes',
+    'session_with_underscores',
+    'a',
+    'A1' * 32,  # exactly 64 chars
+])
+@pytest.mark.asyncio
+async def test_session_id_validation_accepts_allowlist(
+    git_repo: str, good_id: str,
+) -> None:
+    """Allowlist-conformant session_ids create real worktrees."""
+    paths = await create_agent_worktree(git_repo, good_id)
+    try:
+        assert paths.created is True
+        assert paths.working_dir.endswith(f'agent-{good_id}')
+    finally:
+        await remove_agent_worktree(paths)
+
+
+# ── fallback paths ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fallback_when_not_a_git_repo(tmp_path) -> None:
+    """A non-repo base dir falls back to itself with ``created=False``;
+    nothing on disk changes."""
+    base = str(tmp_path)
+    paths = await create_agent_worktree(base, 'sess-x')
+    assert paths.created is False
+    assert paths.working_dir == base
+    assert paths.base_dir == base
+    # No .claude/worktrees created on fallback.
+    assert not os.path.exists(os.path.join(base, '.claude', 'worktrees'))
+
+
+@pytest.mark.asyncio
+async def test_fallback_when_worktree_add_fails(
+    git_repo: str, monkeypatch,
+) -> None:
+    """If ``git worktree add`` returns non-zero (e.g. path already
+    occupied as a worktree), we fall back instead of raising."""
+    # Pre-create the target as a real worktree, so a second ``add`` at
+    # the same path is guaranteed to fail.
+    target = os.path.join(
+        git_repo, '.claude', 'worktrees', 'agent-sess-dupe',
+    )
+    os.makedirs(os.path.dirname(target), exist_ok=True)
+    subprocess.run(
+        ['git', 'worktree', 'add', '--detach', target, 'HEAD'],
+        cwd=git_repo, check=True,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+    try:
+        paths = await create_agent_worktree(git_repo, 'sess-dupe')
+        # ``git worktree add`` should refuse to overwrite, falling back.
+        assert paths.created is False
+        assert paths.working_dir == git_repo
+    finally:
+        # Cleanup the seeded worktree directly.
+        subprocess.run(
+            ['git', 'worktree', 'remove', '--force', target],
+            cwd=git_repo, stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_with_uncommitted_edits_in_worktree(
+    git_repo: str,
+) -> None:
+    """A worktree with dirty edits is still removable via ``--force``."""
+    paths = await create_agent_worktree(git_repo, 'sess-dirty')
+    assert paths.created is True
+    # Simulate the session writing files inside the worktree.
+    dirty = os.path.join(paths.working_dir, 'session-output.txt')
+    with open(dirty, 'w', encoding='utf-8') as fh:
+        fh.write('mid-session output\n')
+    # Remove should still succeed because we pass --force.
+    await remove_agent_worktree(paths)
+    assert not os.path.isdir(paths.working_dir)
+
+
+# ── error & timeout handling ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_git_returns_negative_rc_when_git_binary_missing(
+    monkeypatch, tmp_path,
+) -> None:
+    """If the git binary can't be spawned (FileNotFoundError /
+    PermissionError / etc.), ``create_agent_worktree`` must fall back
+    rather than propagate the OSError."""
+    from src.bridge import worktree as wt_mod
+
+    async def fail_subprocess(*_a, **_kw):
+        raise PermissionError('mocked permission denied')
+
+    monkeypatch.setattr(
+        asyncio, 'create_subprocess_exec', fail_subprocess,
+    )
+    paths = await wt_mod.create_agent_worktree(
+        str(tmp_path), 'cse_perm_fail',
+    )
+    assert paths.created is False
+    assert paths.working_dir == str(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_run_git_times_out_and_falls_back(
+    monkeypatch, tmp_path,
+) -> None:
+    """A wedged git subprocess (communicate never returns) must be
+    killed by the timeout path; ``create_agent_worktree`` falls back."""
+    from src.bridge import worktree as wt_mod
+
+    # Shorten the timeout for the test.
+    monkeypatch.setattr(wt_mod, '_GIT_TIMEOUT_S', 0.05)
+
+    class WedgedProc:
+        returncode = None
+
+        async def communicate(self):
+            # Block forever — simulating a hung ``git`` process.
+            await asyncio.sleep(60)
+            return b'', b''
+
+        def kill(self):
+            pass
+
+        async def wait(self):
+            return 0
+
+    async def fake_subprocess(*_a, **_kw):
+        return WedgedProc()
+
+    monkeypatch.setattr(
+        asyncio, 'create_subprocess_exec', fake_subprocess,
+    )
+    # _is_git_repo's call to _run_git will time out first; we fall
+    # back because that returns non-zero.
+    paths = await wt_mod.create_agent_worktree(
+        str(tmp_path), 'cse_wedged',
+    )
+    assert paths.created is False
+    assert paths.working_dir == str(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_run_git_kills_subprocess_on_cancellation(
+    monkeypatch, tmp_path,
+) -> None:
+    """If the outer task is cancelled mid-``communicate()``, the
+    subprocess must be killed in the ``finally`` block — not left
+    running past the cancellation."""
+    from src.bridge import worktree as wt_mod
+
+    kill_called: list[bool] = []
+    wait_called: list[bool] = []
+
+    class CancellableProc:
+        returncode: int | None = None
+
+        async def communicate(self):
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                # Simulate the kernel's behavior: when the parent
+                # task is cancelled, communicate() raises before
+                # the subprocess exits on its own.
+                raise
+            return b'', b''
+
+        def kill(self):
+            kill_called.append(True)
+            self.returncode = -9
+
+        async def wait(self):
+            wait_called.append(True)
+            return self.returncode or -9
+
+    proc = CancellableProc()
+
+    async def fake_subprocess(*_a, **_kw):
+        return proc
+
+    monkeypatch.setattr(
+        asyncio, 'create_subprocess_exec', fake_subprocess,
+    )
+
+    task = asyncio.create_task(
+        wt_mod._run_git('rev-parse', '--is-inside-work-tree', cwd=str(tmp_path)),
+    )
+    # Yield once so the task starts and reaches `await communicate()`.
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    # The finally block must have killed and drained the subprocess.
+    assert kill_called == [True], 'kill() should fire on cancel'
+    assert wait_called == [True], 'wait() should drain after kill'
+
+
+# ── concurrency ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_multiple_sessions_get_distinct_worktrees(
+    git_repo: str,
+) -> None:
+    """Two sessions in the same base dir get isolated worktrees and
+    each has its own HEAD checkout."""
+    paths_a = await create_agent_worktree(git_repo, 'sess-a')
+    paths_b = await create_agent_worktree(git_repo, 'sess-b')
+    try:
+        assert paths_a.created and paths_b.created
+        assert paths_a.working_dir != paths_b.working_dir
+        # Editing in one doesn't affect the other.
+        with open(
+            os.path.join(paths_a.working_dir, 'a.txt'),
+            'w', encoding='utf-8',
+        ) as fh:
+            fh.write('a\n')
+        assert not os.path.exists(
+            os.path.join(paths_b.working_dir, 'a.txt'),
+        )
+    finally:
+        await remove_agent_worktree(paths_a)
+        await remove_agent_worktree(paths_b)


### PR DESCRIPTION
## Summary

Replaces the Phase 8 MVP stub (`logger.warning('--spawn worktree not yet implemented')`) with full `git worktree` plumbing. Multi-session daemons running `--spawn worktree` now get isolated per-session working directories under `<base>/.claude/worktrees/agent-<session_id>/`.

## What's new

### `src/bridge/worktree.py` (new module)
- `create_agent_worktree(base_dir, session_id) -> WorktreePaths` — best-effort, never raises
  - **Strict session_id allowlist** `^[A-Za-z0-9_-]{1,64}$` defends against path-traversal from malformed work-secret payloads
  - Subprocess deadline-bounded (10s cap) with kill-on-cancel via try/finally
  - Falls back to `base_dir` on any failure (not a repo, mkdir error, git error, timeout, cancel)
- `remove_agent_worktree(paths)` — no-op when `created=False`; uses `--force`

### `src/bridge/bridge_main.py` wiring
- New bookkeeping dicts: `session_worktrees` (worktree paths) and `session_done_tasks` (refs to fire-and-forget done tasks)
- `_process_work` creates worktree before spawn, cleans up on spawn failure
- `_on_session_done` removes worktree on session exit
- `shutdown` awaits in-flight done-tasks (2s cap), cancels + drains stragglers, then sweeps remaining worktrees

## CRITIC review

**Round 1 — 2 BLOCKING + 5 MAJOR issues found, all fixed:**
- BLOCKING #1: Path traversal via unvalidated session_id → strict allowlist + 14 parametrized regression tests
- BLOCKING #2: Unhandled `OSError` in `_run_git` → broadened catch, belt-and-braces try/except at call site
- MAJOR #1: No subprocess deadline → 10s cap, kill, drain
- MAJOR #2: Stuck done-tasks leaked on timeout → cancel + drain
- MAJOR #3: Race-comment missing → invariant comments added
- MAJOR #4: Test task leak → captured + awaited in `finally`
- MAJOR #5: TS-parity claim unverifiable → downgraded to "clawcodex convention"

**Round 2 — APPROVED.** Residual cancellation-leak (subprocess not killed on outer-task cancel) addressed in the same branch via `try/finally` in `_run_git` + new regression test.

## Test plan

- [x] **627/627 bridge tests pass** (was 600 at Phase 11c baseline, +27 new)
- [x] 23 unit tests in `test_worktree.py` covering happy paths, all fallback paths, validation, timeout, cancellation, concurrency
- [x] 4 integration tests in `test_bridge_main.py` covering spawn → run → cleanup, fallback, shutdown sweep, bounded shutdown on slow cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)