### PR TITLE
bridge phase 12b: Strategy-1 in-place reconnect

### DIFF
--- a/src/bridge/repl_bridge.py
+++ b/src/bridge/repl_bridge.py
@@ -465,20 +465,103 @@ class _BridgeState:
             pass
 
     async def _recreate_environment(self) -> bool:
-        """Re-register the environment + create a fresh session.
+        """Re-register the environment, then **try Strategy-1 reconnect
+        first** (preserve the active session via ``reconnect_session``
+        when the server resurrects the *same* env id); fall back to
+        **Strategy-2** (kill + create fresh session) otherwise.
 
-        Mirrors TS Strategy-2 on ``replBridge.ts:822``. Returns True on
-        success (caller resets the attempt counter), False on failure
-        (caller backs off and retries; the attempt counter persists so
-        we eventually give up).
+        Mirrors TS ``replBridge.ts:614-852``. Returns True on success
+        (caller resets the attempt counter), False on failure (caller
+        backs off and retries; the attempt counter persists so we
+        eventually give up).
 
-        Strategy-1 (in-place ``reconnect_session`` to keep the same
-        session ID + SSE seq-num) is deferred — it needs the
-        ``BridgeApiClient.reconnect_session`` happy path which the MVP
-        doesn't exercise, and the session-runner doesn't yet support
-        live resumption with a different ingress URL.
+        Strategy-1 preserves the local session subprocess and its
+        in-flight CCR client connection. It does NOT independently
+        preserve the SSE seq-num — that depends on the CCR client
+        surviving the env change, which today is best-effort.
         """
-        # If there's an active session, archive it before starting fresh.
+        # Strategy-1 only makes sense if the server hands back the
+        # SAME env id (TS ``tryReconnectInPlace`` at replBridge.ts:386-391
+        # bails when ``environmentId !== requestedEnvId``). Hint the
+        # server to reuse by setting ``reuse_environment_id`` before
+        # registering; restore it after so a future Strategy-2 cycle
+        # gets a fresh env if the server doesn't want to reuse.
+        prior_env_id = self.environment_id
+        prior_reuse = self.bridge_config.reuse_environment_id
+        # ``active_session_id`` reflects the currently-running work
+        # item (may differ from ``initial_session_id`` after earlier
+        # recreations). Strategy-1 preserves the *active* session.
+        prior_session_id = self.active_session_id
+        prior_work_id = self.active_work_id
+        had_active_session = self.active_session is not None
+        self.bridge_config.reuse_environment_id = prior_env_id
+        try:
+            try:
+                registration = await self.api.register_bridge_environment(
+                    self.bridge_config,
+                )
+            except Exception as err:  # noqa: BLE001
+                logger.warning(
+                    '[bridge:repl] Re-register failed: %s', err
+                )
+                return False
+        finally:
+            self.bridge_config.reuse_environment_id = prior_reuse
+        new_env_id = registration['environment_id']
+        new_env_secret = registration['environment_secret']
+
+        # ── Strategy-1: in-place reconnect ──────────────────────────
+        # Gate on (a) same env id AND (b) active session id AND (c)
+        # active session handle. (a) is the TS preconditon; (b) and (c)
+        # together mean there's a real session to preserve. If the
+        # server changed env id (despite our reuse hint), Strategy-1
+        # is unreachable — the prior session was bound to the dead env.
+        if (
+            new_env_id == prior_env_id
+            and prior_session_id is not None
+            and had_active_session
+        ):
+            try:
+                await self.api.reconnect_session(
+                    new_env_id, prior_session_id,
+                )
+            except Exception as err:  # noqa: BLE001
+                logger.info(
+                    '[bridge:repl] Strategy-1 reconnect refused '
+                    '(session=%s): %s — falling back to Strategy-2',
+                    prior_session_id, err,
+                )
+            else:
+                # Server accepted the reconnect. The OLD work item is
+                # now stale (its work-secret was bound to the dead env
+                # state) — clear it server-side and locally so the next
+                # poll can pick up a fresh work-secret. The subprocess
+                # itself keeps running; the next poll will redeliver
+                # work for the same session_id with a fresh JWT.
+                #
+                # Invariant: ``new_env_id == prior_env_id`` here (the
+                # gate above enforces it), so ``_safe_stop_work`` —
+                # which reads ``self.environment_id`` — hits the right
+                # env whether called before or after the swap below.
+                if prior_work_id is not None:
+                    await self._safe_stop_work(prior_work_id, force=False)
+                    self.active_work_id = None
+                self.environment_id = new_env_id
+                self.environment_secret = new_env_secret
+                logger.info(
+                    '[bridge:repl] Strategy-1 reconnect succeeded: '
+                    'env=%s session=%s (preserved)',
+                    new_env_id, prior_session_id,
+                )
+                return True
+
+        # ── Strategy-2: kill active session + create fresh ─────────
+        # Capture the session id we should archive BEFORE nulling the
+        # active fields below. Prefer the currently-running session id
+        # (what the user was actually doing) over the bridge's initial
+        # session id (which may be stale after an earlier recreation).
+        archive_id = self.active_session_id or self.initial_session_id
+        # If there's an active session, kill it before starting fresh.
         if self.active_session is not None:
             try:
                 self.active_session.kill()
@@ -494,25 +577,16 @@ class _BridgeState:
                 self.active_token_refresh = None
         # Best-effort archive of the prior session id.
         try:
-            await self.params.archive_session(self.initial_session_id)
+            await self.params.archive_session(archive_id)
         except Exception as err:  # noqa: BLE001
             logger.debug(
                 '[bridge:repl] archive of prior session failed '
                 'during recreation: %s', err
             )
-        # Re-register environment (server may hand back a fresh
-        # environment_id; we accept whatever it gives us).
-        try:
-            registration = await self.api.register_bridge_environment(
-                self.bridge_config,
-            )
-        except Exception as err:  # noqa: BLE001
-            logger.warning(
-                '[bridge:repl] Re-register failed: %s', err
-            )
-            return False
-        self.environment_id = registration['environment_id']
-        self.environment_secret = registration['environment_secret']
+        # Adopt the new env handles before create_session (the server
+        # binds the new session to whatever env we name).
+        self.environment_id = new_env_id
+        self.environment_secret = new_env_secret
         # Create a fresh session on the new environment.
         try:
             new_session_id = await self.params.create_session({
@@ -536,7 +610,7 @@ class _BridgeState:
         # ReplBridgeHandle is immutable; this is the internal copy).
         self.initial_session_id = new_session_id
         logger.info(
-            '[bridge:repl] Environment recreated: env=%s session=%s',
+            '[bridge:repl] Strategy-2 recreate complete: env=%s session=%s',
             self.environment_id, new_session_id,
         )
         return True

--- a/tests/bridge/test_repl_bridge.py
+++ b/tests/bridge/test_repl_bridge.py
@@ -751,3 +751,300 @@ async def test_send_control_request_forwards_when_active() -> None:
     assert any('control_cancel_request' in s for s in sent)
     spawner.handles[0].complete('completed')
     await handle.teardown()
+
+
+# ── Phase 12b: Strategy-1 in-place reconnect ─────────────────────────────
+#
+# These tests directly exercise ``_BridgeState._recreate_environment``
+# rather than going through the poll-404 flow, because the MVP's poll
+# loop intentionally suspends polling while a session is active (see
+# the ``self.active_session is not None`` branch at the top of
+# ``_poll_loop``). That's the right MVP behavior — a single-session
+# bridge has nothing to ask the server about while busy — but it means
+# the 404-detection path is exercised by other API calls in real life,
+# not by the poll. Testing ``_recreate_environment`` directly lets us
+# validate Strategy-1 ↔ Strategy-2 dispatch without inventing fake
+# heartbeat/SSE-error injection.
+
+
+@pytest.mark.asyncio
+async def test_strategy_1_reconnect_preserves_session_when_server_accepts(
+) -> None:
+    """When ``reconnect_session`` succeeds AND the server resurrected
+    the same env id, the daemon must NOT create a fresh session, NOT
+    kill the active one, NOT archive the old one — just clear the
+    stale work id, refresh the env_secret, and resume polling."""
+    work = {
+        'id': 'work-1', 'type': 'work', 'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_w1'},
+        'secret': _encode_work_secret(),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    params = _make_params()
+    params.max_env_recreation_attempts = 2
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    for _ in range(40):
+        await asyncio.sleep(0.01)
+        if spawner.handles:
+            break
+    assert spawner.handles
+    original_session = spawner.handles[0]
+    original_session_id = original_session.session_id
+
+    state = handle.write_messages.__self__  # type: ignore[attr-defined]
+    prior_env_id = state.environment_id
+    pre_archive = list(api.archive_calls)
+    pre_stop = list(api.stop_calls)
+
+    # Server honors ``reuse_environment_id`` — returns the same env id
+    # with a fresh secret. This is the Strategy-1 precondition.
+    api.register_result = {
+        'environment_id': prior_env_id,
+        'environment_secret': 'sec-srv-fresh',
+    }
+
+    ok = await state._recreate_environment()
+
+    assert ok is True
+    # Strategy-1 invoked with the SAME env id and original session id.
+    assert api.reconnect_calls == [(prior_env_id, original_session_id)]
+    # Env id unchanged; secret swapped to the fresh value.
+    assert state.environment_id == prior_env_id
+    assert state.environment_secret == 'sec-srv-fresh'
+    # Session NOT killed, NOT archived, NOT replaced.
+    assert not original_session._kill_called
+    assert api.archive_calls == pre_archive
+    assert state.active_session is original_session
+    assert state.active_session_id == original_session_id
+    # Stale work id is stopped (best-effort) and cleared so the next
+    # poll picks up a fresh work-secret bound to the new env-secret.
+    new_stops = [s for s in api.stop_calls if s not in pre_stop]
+    assert any(s[1] == 'work-1' for s in new_stops), (
+        f'stale work-id should be stop-worked; new_stops={new_stops!r}'
+    )
+    assert state.active_work_id is None
+    # ``reuse_environment_id`` hint was set and then cleared.
+    assert state.bridge_config.reuse_environment_id is None
+
+    original_session.complete('completed')
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_strategy_1_skipped_when_server_assigns_new_env_id(
+) -> None:
+    """If the server doesn't honor ``reuse_environment_id`` and hands
+    back a different env_id, Strategy-1 must be SKIPPED (the prior
+    session is bound to the dead env). Falls through to Strategy-2."""
+    work = {
+        'id': 'work-1', 'type': 'work', 'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_w1'},
+        'secret': _encode_work_secret(),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    params = _make_params()
+    params.max_env_recreation_attempts = 2
+
+    archived: list[str] = []
+    original_archive = params.archive_session
+    async def recording_archive(sid: str) -> None:
+        archived.append(sid)
+        return await original_archive(sid)
+    params.archive_session = recording_archive  # type: ignore[assignment]
+
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    for _ in range(40):
+        await asyncio.sleep(0.01)
+        if spawner.handles:
+            break
+    original_session = spawner.handles[0]
+    state = handle.write_messages.__self__  # type: ignore[attr-defined]
+
+    # Server returns a DIFFERENT env id — Strategy-1 precondition
+    # fails, fallback to Strategy-2.
+    api.register_result = {
+        'environment_id': 'env-srv-different',
+        'environment_secret': 'sec-srv-different',
+    }
+
+    ok = await state._recreate_environment()
+
+    assert ok is True
+    # Strategy-1 was NOT attempted — env-id mismatch short-circuited.
+    assert api.reconnect_calls == []
+    # Strategy-2 ran instead.
+    assert original_session._kill_called
+    assert original_session.session_id in archived
+    assert state.environment_id == 'env-srv-different'
+
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_strategy_1_falls_back_to_strategy_2_on_reconnect_refuse(
+) -> None:
+    """When ``reconnect_session`` raises, the daemon must fall back to
+    Strategy-2: kill the old session, archive it, create a fresh one."""
+    from src.bridge.exceptions import BridgeFatalError
+
+    work = {
+        'id': 'work-1', 'type': 'work', 'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_w1'},
+        'secret': _encode_work_secret(),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+
+    # reconnect_session refuses with a session-expired error.
+    async def reconnect_refuse(env_id: str, sid: str) -> None:
+        api.reconnect_calls.append((env_id, sid))
+        raise BridgeFatalError(
+            'session not found', status=404, error_type='session_expired',
+        )
+    api.reconnect_session = reconnect_refuse  # type: ignore[method-assign]
+
+    spawner = FakeSpawner()
+    params = _make_params()
+    params.max_env_recreation_attempts = 2
+
+    # Wrap params.archive_session to record what was archived.
+    archived: list[str] = []
+    original_archive = params.archive_session
+    async def recording_archive(sid: str) -> None:
+        archived.append(sid)
+        return await original_archive(sid)
+    params.archive_session = recording_archive  # type: ignore[assignment]
+
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    for _ in range(40):
+        await asyncio.sleep(0.01)
+        if spawner.handles:
+            break
+    original_session = spawner.handles[0]
+    original_session_id = original_session.session_id
+    state = handle.write_messages.__self__  # type: ignore[attr-defined]
+
+    # Server honors reuse — Strategy-1 precondition satisfied, but
+    # reconnect_session itself refuses → falls through to Strategy-2.
+    api.register_result = {
+        'environment_id': state.environment_id,  # same env id
+        'environment_secret': 'sec-srv-fresh',
+    }
+
+    ok = await state._recreate_environment()
+
+    # Strategy-1 was attempted first, then Strategy-2 took over.
+    assert ok is True
+    assert api.reconnect_calls == [(state.environment_id, original_session_id)]
+    # Strategy-2 effects:
+    assert original_session._kill_called, (
+        'Strategy-2 killed the original session'
+    )
+    assert original_session_id in archived, (
+        f'Strategy-2 should archive the active session id; '
+        f'archived={archived!r}'
+    )
+    # The internal session-id pointer was updated to the new session
+    # that create_session returned (default 'cse_test').
+    assert state.initial_session_id == 'cse_test'
+    assert state.active_session is None
+
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_strategy_1_skipped_when_no_active_session() -> None:
+    """If there's no active session at recreation time, Strategy-1 must
+    NOT call ``reconnect_session`` — there's no session id to preserve."""
+    api = FakeApiClient()
+    api.register_result = {
+        'environment_id': 'env-srv-2',
+        'environment_secret': 'sec-srv-2',
+    }
+    spawner = FakeSpawner()
+    params = _make_params()
+    params.max_env_recreation_attempts = 2
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    state = handle.write_messages.__self__  # type: ignore[attr-defined]
+    # No work has been dispatched, so no active session.
+    assert state.active_session is None
+    assert state.active_session_id is None
+
+    ok = await state._recreate_environment()
+
+    assert ok is True
+    # Strategy-1 skipped → no reconnect call.
+    assert api.reconnect_calls == []
+    # Strategy-2 path ran: re-registered env + created new session.
+    assert state.environment_id == 'env-srv-2'
+    assert state.initial_session_id == 'cse_test'
+
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_strategy_1_re_register_failure_returns_false() -> None:
+    """If the env re-registration itself fails, ``_recreate_environment``
+    must return False without attempting reconnect or fresh-session
+    create — the caller's retry loop will back off and try again."""
+    work = {
+        'id': 'work-1', 'type': 'work', 'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_w1'},
+        'secret': _encode_work_secret(),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    params = _make_params()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    for _ in range(40):
+        await asyncio.sleep(0.01)
+        if spawner.handles:
+            break
+    original_session = spawner.handles[0]
+
+    # Make register fail.
+    # Use a realistic transport-class failure (mirrors what
+    # ``_with_oauth_retry`` raises for 5xx).
+    from src.bridge.exceptions import BridgeFatalError
+    api.register_raises = BridgeFatalError(
+        'temporary backend outage', status=503,
+    )
+    state = handle.write_messages.__self__  # type: ignore[attr-defined]
+    pre_reconnect = list(api.reconnect_calls)
+    pre_archive = list(api.archive_calls)
+
+    ok = await state._recreate_environment()
+
+    assert ok is False
+    # Neither Strategy-1 nor Strategy-2 actions occurred after re-
+    # register failed.
+    assert api.reconnect_calls == pre_reconnect
+    assert api.archive_calls == pre_archive
+    assert not original_session._kill_called
+
+    original_session.complete('completed')
+    await handle.teardown()


### PR DESCRIPTION
## Summary

Adds Strategy-1 in-place reconnect to the env-recreation flow. When the bridge env is lost, the daemon now tries to **preserve the active session** by asking the server to reattach it via `reconnect_session`, falling back to Strategy-2 (kill + create fresh) only if the server refuses.

### Strategy-1 mechanics

1. Set `bridge_config.reuse_environment_id = prior_env_id` (TS `replBridge.ts:698-712` parity, restored in `finally`)
2. Re-register env
3. **Gate**: `new_env_id == prior_env_id` AND `prior_session_id is not None` AND `had_active_session`
4. `api.reconnect_session(new_env_id, prior_session_id)` — on success: stop the stale work item, clear `active_work_id`, swap env handles, return True

The subprocess keeps running; the next poll picks up a fresh work-secret + fresh JWT naturally.

### Strategy-2 side fix

`archive_session(self.initial_session_id)` → `archive_session(active_session_id or initial_session_id)`. The previous code archived a stale "initial" id when the lost session was actually the active work-item one.

## CRITIC review

**Round 1 — 2 BLOCKING + 4 MAJOR issues found, all fixed:**
- BLOCKING #1: Missing `reuse_environment_id` semantics → set/restore + env-id-equality gate + new test for the mismatch case
- BLOCKING #2: Dangling `work_id` on Strategy-1 success → stop + clear before env-handle swap
- MAJOR (JWT lifecycle): Resolved via #2 — next poll fetches fresh secret
- MAJOR (SSE seq-num docstring): Rewrote, now accurate
- MAJOR (log level, concurrent guard): Justified / deferred to 12c

**Round 2 — APPROVED.** One nit addressed: invariant comment added at the stop-work site.

## Test plan

- [x] **632/632 bridge tests pass** (was 627 at Phase 12a baseline, +5 new)
- [x] 5 new tests: happy path, fallback on refuse, skipped when no active session, skipped when env-id mismatch, re-register failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)