### PR TITLE
bridge phase 12c: perpetual mode + crash-recovery pointer

### DIFF
--- a/src/bridge/bridge_pointer.py
+++ b/src/bridge/bridge_pointer.py
@@ -1,0 +1,259 @@
+"""Crash-recovery pointer for perpetual-mode bridges.
+
+The pointer is a small JSON file written under the daemon's working
+directory at ``<dir>/.claude/bridge-pointer.json``. It records the
+identity (``bridge_id``, ``environment_id``, ``session_id``) of the
+currently-running bridge so that a subsequent restart (after a clean
+shutdown OR a crash) can:
+
+* Reuse the same ``environment_id`` via ``reuse_environment_id`` —
+  the server may resurrect the env state if the lease hasn't expired.
+* Resume the same ``session_id`` rather than spawning a fresh
+  Claude Code subprocess (preserves history, in-flight work, etc.).
+* Detect a different host or working directory (``machine_name`` /
+  ``dir`` mismatch) and drop the pointer instead of corrupting another
+  daemon's state.
+
+Best-effort semantics
+---------------------
+Every operation in this module is best-effort:
+
+* :func:`read_pointer` returns ``None`` on any IO/JSON failure rather
+  than raising — perpetual mode degrades to "fresh env+session" if the
+  pointer is unreadable.
+* :func:`write_pointer` swallows IO errors with a warning log — a
+  failed write means the next restart won't recover, but it doesn't
+  break the running daemon.
+* :func:`clear_pointer` ignores missing-file errors (no-op).
+
+Schema (version 1)
+------------------
+::
+
+    {
+      "schema_version": 1,
+      "bridge_id": "<uuid>",
+      "environment_id": "<server-assigned>",
+      "session_id": "<server-assigned or None>",
+      "machine_name": "<hostname>",
+      "dir": "<absolute working directory>",
+      "created_at_ms": <int>,
+      "updated_at_ms": <int>
+    }
+
+Mismatched ``schema_version``, ``machine_name``, or ``dir`` causes
+:func:`read_pointer` to return ``None`` (treats the pointer as stale).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import asdict, dataclass
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA_VERSION = 1
+_POINTER_REL = os.path.join('.claude', 'bridge-pointer.json')
+
+
+@dataclass
+class BridgePointer:
+    """In-memory representation of the pointer file. Mirrors the
+    on-disk JSON schema 1:1.
+
+    Fields
+    ------
+    bridge_id
+        Client-generated stable identity. Survives across restarts —
+        the daemon picks a new one only if the pointer is dropped.
+    environment_id
+        Server-assigned env id from the most recent registration.
+    session_id
+        Currently-active session id; may be ``None`` when no session
+        is running (e.g., right after init but before first poll).
+    machine_name
+        Hostname captured at write time. ``read_pointer`` rejects
+        the file if this doesn't match the current host.
+    dir
+        Working directory captured at write time. Rejected on mismatch.
+    created_at_ms / updated_at_ms
+        Milliseconds since epoch. ``created_at`` is set once;
+        ``updated_at`` bumps on every write.
+    """
+
+    bridge_id: str
+    environment_id: str
+    session_id: str | None
+    machine_name: str
+    dir: str
+    created_at_ms: int
+    updated_at_ms: int
+
+    def to_json(self) -> dict[str, object]:
+        d = asdict(self)
+        d['schema_version'] = _SCHEMA_VERSION
+        return d
+
+
+def _pointer_path(working_dir: str) -> str:
+    return os.path.join(working_dir, _POINTER_REL)
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def read_pointer(
+    working_dir: str, *, machine_name: str,
+) -> BridgePointer | None:
+    """Return the pointer for ``working_dir`` if one exists and is
+    valid for the current host, else ``None``.
+
+    Returns ``None`` for any of: file missing, JSON malformed,
+    ``schema_version`` mismatch, ``machine_name`` mismatch, ``dir``
+    mismatch (the file was written by another working tree using a
+    shared HOME), or any required field missing/wrong type.
+    """
+    path = _pointer_path(working_dir)
+    try:
+        with open(path, 'r', encoding='utf-8') as fh:
+            raw = fh.read()
+    except FileNotFoundError:
+        return None
+    except OSError as err:
+        logger.warning(
+            '[bridge:pointer] read %s failed: %s — treating as absent',
+            path, err,
+        )
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as err:
+        logger.warning(
+            '[bridge:pointer] %s is not valid JSON (%s) — treating as absent',
+            path, err,
+        )
+        return None
+    if not isinstance(data, dict):
+        return None
+    if data.get('schema_version') != _SCHEMA_VERSION:
+        logger.info(
+            '[bridge:pointer] schema_version mismatch in %s '
+            '(file=%r, expected=%r) — treating as absent',
+            path, data.get('schema_version'), _SCHEMA_VERSION,
+        )
+        return None
+    # Required string fields.
+    try:
+        bridge_id = str(data['bridge_id'])
+        environment_id = str(data['environment_id'])
+        file_machine = str(data['machine_name'])
+        file_dir = str(data['dir'])
+        created_at_ms = int(data['created_at_ms'])
+        updated_at_ms = int(data['updated_at_ms'])
+    except (KeyError, TypeError, ValueError) as err:
+        logger.info(
+            '[bridge:pointer] %s missing or malformed required fields '
+            '(%s) — treating as absent', path, err,
+        )
+        return None
+    session_id_raw = data.get('session_id')
+    session_id = (
+        str(session_id_raw) if isinstance(session_id_raw, str) else None
+    )
+
+    # Host/dir staleness check. Two daemons running in different
+    # checkouts of the same repo (or different machines mounting the
+    # same NFS HOME) could otherwise collide on each other's pointers.
+    if file_machine != machine_name:
+        logger.info(
+            '[bridge:pointer] %s machine mismatch (file=%r, current=%r) '
+            '— treating as absent', path, file_machine, machine_name,
+        )
+        return None
+    if os.path.abspath(file_dir) != os.path.abspath(working_dir):
+        logger.info(
+            '[bridge:pointer] %s dir mismatch (file=%r, current=%r) '
+            '— treating as absent', path, file_dir, working_dir,
+        )
+        return None
+
+    return BridgePointer(
+        bridge_id=bridge_id,
+        environment_id=environment_id,
+        session_id=session_id,
+        machine_name=file_machine,
+        dir=file_dir,
+        created_at_ms=created_at_ms,
+        updated_at_ms=updated_at_ms,
+    )
+
+
+def write_pointer(
+    working_dir: str, *,
+    bridge_id: str,
+    environment_id: str,
+    session_id: str | None,
+    machine_name: str,
+    created_at_ms: int | None = None,
+) -> None:
+    """Write/overwrite the pointer for ``working_dir``.
+
+    ``created_at_ms`` defaults to the current time on first write;
+    callers preserving a pre-existing pointer's identity should pass
+    its ``created_at_ms`` so the field doesn't reset on every update.
+
+    Writes through a tmpfile + ``os.replace`` for atomicity — a crash
+    during the write cannot leave a half-written pointer that
+    ``read_pointer`` then parses incorrectly.
+    """
+    path = _pointer_path(working_dir)
+    now = _now_ms()
+    pointer = BridgePointer(
+        bridge_id=bridge_id,
+        environment_id=environment_id,
+        session_id=session_id,
+        machine_name=machine_name,
+        dir=working_dir,
+        created_at_ms=created_at_ms if created_at_ms is not None else now,
+        updated_at_ms=now,
+    )
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+    except OSError as err:
+        logger.warning(
+            '[bridge:pointer] mkdir(%s) failed: %s — pointer not written',
+            os.path.dirname(path), err,
+        )
+        return
+    tmp_path = f'{path}.tmp'
+    try:
+        with open(tmp_path, 'w', encoding='utf-8') as fh:
+            json.dump(pointer.to_json(), fh, indent=2)
+        os.replace(tmp_path, path)
+    except OSError as err:
+        logger.warning(
+            '[bridge:pointer] write %s failed: %s — pointer not written',
+            path, err,
+        )
+        # Best-effort cleanup of the tmpfile.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+
+def clear_pointer(working_dir: str) -> None:
+    """Remove the pointer for ``working_dir``. No-op if missing."""
+    path = _pointer_path(working_dir)
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        return
+    except OSError as err:
+        logger.warning(
+            '[bridge:pointer] unlink(%s) failed: %s', path, err,
+        )

--- a/src/bridge/repl_bridge.py
+++ b/src/bridge/repl_bridge.py
@@ -57,6 +57,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -68,6 +69,12 @@ from src.bridge.bridge_api import (
     BridgeFatalError,
     create_bridge_api_client,
     is_expired_error_type,
+)
+from src.bridge.bridge_pointer import (
+    BridgePointer,
+    clear_pointer,
+    read_pointer,
+    write_pointer,
 )
 from src.bridge.jwt_utils import TokenRefreshScheduler
 from src.bridge.poll_config_defaults import (
@@ -236,13 +243,6 @@ async def init_bridge_core(
       the real subprocess.
     * ``runner_version``: header value for ``x-environment-runner-version``.
     """
-    if params.perpetual:
-        raise NotImplementedError(
-            'Phase 6 MVP does not yet implement perpetual mode '
-            '(crash-recovery pointer + env reuse). Full port lands in a '
-            'future revision; set perpetual=False for now.'
-        )
-
     if api_client is None:
         api_client = create_bridge_api_client(
             base_url=params.base_url,
@@ -251,6 +251,32 @@ async def init_bridge_core(
             on_auth_401=params.on_auth_401,
             client=http_client,
         )
+
+    # ── 0. Perpetual mode: try crash-recovery pointer ──────────────────
+    # Mirrors TS ``initReplBridge`` / ``replBridge.ts`` recovery dance:
+    # if the previous run left a pointer, attempt to reuse its env id
+    # (server may resurrect the lease) and its session id (subprocess
+    # restart resumes the same conversation). Any failure — pointer
+    # absent, stale, register-with-reuse rejected, etc. — drops us
+    # back into the fresh-env+fresh-session bootstrap path.
+    pointer: BridgePointer | None = None
+    reuse_session_id: str | None = None
+    pointer_created_at_ms: int | None = None
+    effective_bridge_id = params.bridge_id
+    if params.perpetual:
+        pointer = read_pointer(
+            params.dir, machine_name=params.machine_name,
+        )
+        if pointer is not None:
+            logger.info(
+                '[bridge:repl] Perpetual: found recovery pointer '
+                'bridge_id=%s env=%s session=%s — attempting reuse',
+                pointer.bridge_id, pointer.environment_id,
+                pointer.session_id,
+            )
+            effective_bridge_id = pointer.bridge_id
+            reuse_session_id = pointer.session_id
+            pointer_created_at_ms = pointer.created_at_ms
 
     # ── 1. Register environment ────────────────────────────────────────
     bridge_config = BridgeConfig(
@@ -262,11 +288,19 @@ async def init_bridge_core(
         spawn_mode=_validated_spawn_mode(params.spawn_mode),
         verbose=False,
         sandbox=False,
-        bridge_id=params.bridge_id,
+        bridge_id=effective_bridge_id,
         worker_type=params.worker_type,
-        environment_id=params.bridge_id,  # client-generated; server may swap
+        # client-generated placeholder; the server returns the real
+        # env id in the registration response and we overwrite then.
+        environment_id=effective_bridge_id,
         api_base_url=params.base_url,
         session_ingress_url=params.session_ingress_url,
+        # Hint server to resurrect the pointer's env. If the server
+        # ignores it (env lease expired), it'll just assign a fresh
+        # id and we'll fall through to creating a new session.
+        reuse_environment_id=(
+            pointer.environment_id if pointer is not None else None
+        ),
     )
     try:
         registration = await api_client.register_bridge_environment(
@@ -276,6 +310,11 @@ async def init_bridge_core(
         logger.error('[bridge:repl] Registration failed: %s', err)
         _fire_state(params.on_state_change, 'failed',
                     f'Registration failed: {err}')
+        # A stale pointer that the server fully rejects (rather than
+        # just declining to reuse) is dead weight — clear it so the
+        # next start doesn't re-fail the same way.
+        if params.perpetual:
+            clear_pointer(params.dir)
         return None
     environment_id = registration['environment_id']
     environment_secret = registration['environment_secret']
@@ -283,28 +322,66 @@ async def init_bridge_core(
         '[bridge:repl] Registered environment_id=%s', environment_id
     )
 
-    # ── 2. Create initial session ──────────────────────────────────────
-    try:
-        session_id = await params.create_session({
-            'environment_id': environment_id,
-            'title': params.title,
-            'gitRepoUrl': params.git_repo_url,
-            'branch': params.branch,
-        })
-    except Exception as err:  # noqa: BLE001
-        logger.error('[bridge:repl] Session creation threw: %s', err)
-        session_id = None
-    if session_id is None:
-        _fire_state(params.on_state_change, 'failed',
-                    'Session creation failed')
+    # If we asked for env reuse and the server gave us back a DIFFERENT
+    # env id, the resurrection didn't happen. The reuse_session_id
+    # we'd captured from the pointer is bound to the dead env and
+    # would be useless against the new env, so drop it — create_session
+    # will mint a fresh one below.
+    if (
+        pointer is not None
+        and registration['environment_id'] != pointer.environment_id
+    ):
+        logger.info(
+            '[bridge:repl] Perpetual: server didn\'t resurrect env '
+            '(pointer=%s, got=%s) — falling back to fresh session',
+            pointer.environment_id, registration['environment_id'],
+        )
+        reuse_session_id = None
+
+    # ── 2. Reuse or create session ─────────────────────────────────────
+    session_id: str | None
+    if reuse_session_id is not None:
+        # Trust the pointer's session id. The poll loop / next work
+        # item will surface an error if the server has already
+        # archived it, at which point our standard recreation flow
+        # takes over (Strategy-1 or Strategy-2).
+        #
+        # TODO(phase-13): probe the server (e.g. via a lightweight
+        # ``session.status`` lookup, or by treating the first poll as
+        # validation) before trusting blindly. Today a long-archived
+        # session resumes optimistically and only surfaces the error
+        # via the standard 404 → recreate flow — possibly after a
+        # full poll cycle of dead time.
+        session_id = reuse_session_id
+        logger.info(
+            '[bridge:repl] Perpetual: reusing session_id=%s '
+            'from pointer', session_id,
+        )
+    else:
         try:
-            await api_client.deregister_environment(environment_id)
+            session_id = await params.create_session({
+                'environment_id': environment_id,
+                'title': params.title,
+                'gitRepoUrl': params.git_repo_url,
+                'branch': params.branch,
+            })
         except Exception as err:  # noqa: BLE001
-            logger.debug(
-                '[bridge:repl] Deregister-after-create-fail failed: %s', err
+            logger.error(
+                '[bridge:repl] Session creation threw: %s', err
             )
-        return None
-    logger.debug('[bridge:repl] Created session_id=%s', session_id)
+            session_id = None
+        if session_id is None:
+            _fire_state(params.on_state_change, 'failed',
+                        'Session creation failed')
+            try:
+                await api_client.deregister_environment(environment_id)
+            except Exception as err:  # noqa: BLE001
+                logger.debug(
+                    '[bridge:repl] Deregister-after-create-fail failed: %s',
+                    err,
+                )
+            return None
+        logger.debug('[bridge:repl] Created session_id=%s', session_id)
 
     # ── 3. Build the spawner (if not test-injected) ────────────────────
     if spawner is None:
@@ -323,7 +400,28 @@ async def init_bridge_core(
         environment_secret=environment_secret,
         initial_session_id=session_id,
         bridge_config=bridge_config,
+        perpetual=params.perpetual,
+        pointer_created_at_ms=pointer_created_at_ms,
     )
+    # Write the pointer immediately so a crash before the first poll
+    # still leaves a recoverable state for the next start. Compute the
+    # ``created_at_ms`` locally — passing it both to ``write_pointer``
+    # AND storing it on ``state.pointer_created_at_ms`` ensures future
+    # updates preserve the original timestamp. Doing this via a
+    # read-back from the file would silently lose the value if the
+    # write failed (write_pointer is best-effort and logs-and-swallows).
+    if params.perpetual:
+        if pointer_created_at_ms is None:
+            pointer_created_at_ms = int(time.time() * 1000)
+        state.pointer_created_at_ms = pointer_created_at_ms
+        write_pointer(
+            params.dir,
+            bridge_id=effective_bridge_id,
+            environment_id=environment_id,
+            session_id=session_id,
+            machine_name=params.machine_name,
+            created_at_ms=pointer_created_at_ms,
+        )
     state.start_poll_loop()
 
     _fire_state(params.on_state_change, 'ready')
@@ -370,6 +468,46 @@ class _BridgeState:
     # — surfaces silent message loss that would otherwise be invisible.
     dropped_batch_count: int = 0
     env_recreation_attempts: int = 0
+
+    # Phase 12c: perpetual mode + crash-recovery pointer state.
+    # ``perpetual`` decides whether to write/update/clear the pointer
+    # on lifecycle events. ``pointer_created_at_ms`` carries forward
+    # the pointer's original creation timestamp across recreations so
+    # operators can see how long a perpetual bridge has been alive.
+    perpetual: bool = False
+    pointer_created_at_ms: int | None = None
+
+    async def _update_pointer(self, *, session_id: str | None) -> None:
+        """No-op when not perpetual; otherwise rewrite the pointer with
+        the current env_id + given session_id. Called at every
+        lifecycle transition (init, work-spawned, session-done,
+        recreate) so a crash always leaves a recoverable on-disk state.
+
+        ``write_pointer`` does synchronous file IO; we delegate it to
+        a worker thread so a slow disk (NFS, etc.) can't stall the
+        event loop. Best-effort — failures are logged by the writer.
+        """
+        if not self.perpetual:
+            return
+        await asyncio.to_thread(
+            write_pointer,
+            self.params.dir,
+            bridge_id=self.bridge_config.bridge_id,
+            environment_id=self.environment_id,
+            session_id=session_id,
+            machine_name=self.params.machine_name,
+            created_at_ms=self.pointer_created_at_ms,
+        )
+
+    async def _clear_pointer(self) -> None:
+        """No-op when not perpetual; otherwise remove the pointer
+        file. Called when the bridge tears down cleanly so the next
+        start doesn't try to resume a state that's no longer valid.
+
+        Also off-loaded to a worker thread (see ``_update_pointer``)."""
+        if not self.perpetual:
+            return
+        await asyncio.to_thread(clear_pointer, self.params.dir)
 
     # ── Poll loop ───────────────────────────────────────────────────────
 
@@ -548,6 +686,9 @@ class _BridgeState:
                     self.active_work_id = None
                 self.environment_id = new_env_id
                 self.environment_secret = new_env_secret
+                # Phase 12c: env+session preserved; pointer just needs
+                # a touch so ``updated_at_ms`` reflects the activity.
+                await self._update_pointer(session_id=prior_session_id)
                 logger.info(
                     '[bridge:repl] Strategy-1 reconnect succeeded: '
                     'env=%s session=%s (preserved)',
@@ -609,6 +750,10 @@ class _BridgeState:
         # Replace the bookkeeping handle's session id (the external
         # ReplBridgeHandle is immutable; this is the internal copy).
         self.initial_session_id = new_session_id
+        # Phase 12c: env+session were both swapped; rewrite the pointer
+        # so a crash at this point recovers into the NEW state rather
+        # than the dead one.
+        await self._update_pointer(session_id=new_session_id)
         logger.info(
             '[bridge:repl] Strategy-2 recreate complete: env=%s session=%s',
             self.environment_id, new_session_id,
@@ -689,6 +834,11 @@ class _BridgeState:
             return
         self.active_work_id = work_id
         self.active_session_id = session_id
+        # Phase 12c: the server may dispatch work for a session id we
+        # didn't bootstrap with (e.g. after a server-side session
+        # migration). Refresh the pointer so a crash mid-session
+        # recovers into the right session, not the init bootstrap.
+        await self._update_pointer(session_id=session_id)
         # Wire JWT refresh: token expires after a finite window
         # (typically 1h); without a refresh, long sessions silently
         # break when the ingress token expires. The scheduler fires
@@ -774,6 +924,11 @@ class _BridgeState:
         self.active_session = None
         self.active_work_id = None
         self.active_session_id = None
+        # Phase 12c: the session just finished — clear ``session_id``
+        # in the pointer so a crash before the next poll doesn't try
+        # to resurrect an archived session. The pointer keeps its
+        # bridge_id + env_id so the next start can still reuse the env.
+        await self._update_pointer(session_id=None)
 
     async def _safe_ack(self, work_id: str, session_token: str) -> None:
         try:
@@ -944,6 +1099,13 @@ class _BridgeState:
             logger.warning(
                 '[bridge:repl] deregister failed: %s', err
             )
+
+        # Phase 12c: clean teardown → remove pointer. A future restart
+        # should start fresh, not try to resurrect an env we just
+        # deregistered. Best-effort; a leftover pointer is harmless
+        # because read_pointer's host/dir staleness checks plus the
+        # server's expiry will eventually drop it.
+        await self._clear_pointer()
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────

--- a/tests/bridge/test_bridge_pointer.py
+++ b/tests/bridge/test_bridge_pointer.py
@@ -1,0 +1,234 @@
+"""Tests for ``src.bridge.bridge_pointer``.
+
+Covers schema validation, round-trip, host/dir staleness checks, and
+the atomic-write contract.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from src.bridge.bridge_pointer import (
+    BridgePointer,
+    clear_pointer,
+    read_pointer,
+    write_pointer,
+)
+
+
+# ── round-trip ──────────────────────────────────────────────────────────
+
+
+def test_write_then_read_round_trip(tmp_path) -> None:
+    """A freshly-written pointer reads back with the same fields."""
+    working_dir = str(tmp_path)
+    write_pointer(
+        working_dir,
+        bridge_id='br-1',
+        environment_id='env-srv-1',
+        session_id='cse_a',
+        machine_name='host-1',
+    )
+    p = read_pointer(working_dir, machine_name='host-1')
+    assert p is not None
+    assert p.bridge_id == 'br-1'
+    assert p.environment_id == 'env-srv-1'
+    assert p.session_id == 'cse_a'
+    assert p.machine_name == 'host-1'
+    assert os.path.abspath(p.dir) == os.path.abspath(working_dir)
+    assert p.created_at_ms > 0
+    assert p.updated_at_ms >= p.created_at_ms
+
+
+def test_session_id_none_is_serialized_and_parsed(tmp_path) -> None:
+    """``session_id=None`` survives the round-trip — represents a
+    bridge that's registered but hasn't received its first work yet."""
+    write_pointer(
+        str(tmp_path),
+        bridge_id='br-1',
+        environment_id='env-srv-1',
+        session_id=None,
+        machine_name='host-1',
+    )
+    p = read_pointer(str(tmp_path), machine_name='host-1')
+    assert p is not None
+    assert p.session_id is None
+
+
+def test_write_preserves_created_at(tmp_path) -> None:
+    """When ``created_at_ms`` is passed explicitly, it overrides the
+    default (current time) — used to preserve the original timestamp
+    across recreations within a perpetual run."""
+    write_pointer(
+        str(tmp_path),
+        bridge_id='br-1',
+        environment_id='env-srv-1',
+        session_id='cse_a',
+        machine_name='host-1',
+        created_at_ms=1_000_000,
+    )
+    p = read_pointer(str(tmp_path), machine_name='host-1')
+    assert p is not None
+    assert p.created_at_ms == 1_000_000
+    assert p.updated_at_ms >= 1_000_000
+
+
+# ── absent / corrupt files ─────────────────────────────────────────────
+
+
+def test_read_missing_file_returns_none(tmp_path) -> None:
+    assert read_pointer(str(tmp_path), machine_name='host-1') is None
+
+
+def test_read_malformed_json_returns_none(tmp_path) -> None:
+    """A pointer file with non-JSON content reads as absent — never
+    raises into the daemon's startup path."""
+    path = os.path.join(str(tmp_path), '.claude', 'bridge-pointer.json')
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as fh:
+        fh.write('not json at all { ')
+    assert read_pointer(str(tmp_path), machine_name='host-1') is None
+
+
+@pytest.mark.parametrize('missing_field', [
+    'bridge_id', 'environment_id', 'machine_name',
+    'dir', 'created_at_ms', 'updated_at_ms',
+])
+def test_read_missing_required_field_returns_none(
+    tmp_path, missing_field: str,
+) -> None:
+    """A pointer that's missing any required field is treated as absent."""
+    base = {
+        'schema_version': 1,
+        'bridge_id': 'br-1',
+        'environment_id': 'env-srv-1',
+        'session_id': 'cse_a',
+        'machine_name': 'host-1',
+        'dir': str(tmp_path),
+        'created_at_ms': 1000,
+        'updated_at_ms': 2000,
+    }
+    del base[missing_field]
+    path = os.path.join(str(tmp_path), '.claude', 'bridge-pointer.json')
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as fh:
+        json.dump(base, fh)
+    assert read_pointer(str(tmp_path), machine_name='host-1') is None
+
+
+def test_read_wrong_schema_version_returns_none(tmp_path) -> None:
+    """Future schema versions can't be parsed by older code; safer to
+    treat them as absent than to misinterpret."""
+    path = os.path.join(str(tmp_path), '.claude', 'bridge-pointer.json')
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as fh:
+        json.dump({
+            'schema_version': 999,
+            'bridge_id': 'br-1',
+            'environment_id': 'env-srv-1',
+            'session_id': None,
+            'machine_name': 'host-1',
+            'dir': str(tmp_path),
+            'created_at_ms': 1000,
+            'updated_at_ms': 2000,
+        }, fh)
+    assert read_pointer(str(tmp_path), machine_name='host-1') is None
+
+
+# ── staleness ──────────────────────────────────────────────────────────
+
+
+def test_read_rejects_mismatched_machine_name(tmp_path) -> None:
+    """A pointer written by host A must NOT be readable from host B —
+    even if the file path is the same (could happen on a shared
+    NFS HOME). Prevents cross-host state corruption."""
+    write_pointer(
+        str(tmp_path),
+        bridge_id='br-1',
+        environment_id='env-srv-1',
+        session_id='cse_a',
+        machine_name='host-A',
+    )
+    assert read_pointer(str(tmp_path), machine_name='host-B') is None
+    # Original host still reads it fine.
+    assert read_pointer(str(tmp_path), machine_name='host-A') is not None
+
+
+def test_read_rejects_mismatched_dir(tmp_path) -> None:
+    """A pointer file moved (via symlink or rename) to a different dir
+    is rejected — the ``dir`` field captures the absolute path at
+    write time and read_pointer verifies it matches."""
+    # Write under tmp_path, then physically move the .claude/ dir to
+    # a sibling and try to read from there.
+    write_pointer(
+        str(tmp_path),
+        bridge_id='br-1',
+        environment_id='env-srv-1',
+        session_id='cse_a',
+        machine_name='host-1',
+    )
+    sibling = tmp_path.parent / 'sibling'
+    sibling.mkdir()
+    os.rename(
+        os.path.join(str(tmp_path), '.claude'),
+        os.path.join(str(sibling), '.claude'),
+    )
+    assert read_pointer(str(sibling), machine_name='host-1') is None
+
+
+# ── clear ──────────────────────────────────────────────────────────────
+
+
+def test_clear_removes_the_file(tmp_path) -> None:
+    write_pointer(
+        str(tmp_path),
+        bridge_id='br-1', environment_id='env-srv-1',
+        session_id=None, machine_name='host-1',
+    )
+    assert read_pointer(str(tmp_path), machine_name='host-1') is not None
+    clear_pointer(str(tmp_path))
+    assert read_pointer(str(tmp_path), machine_name='host-1') is None
+
+
+def test_clear_missing_file_is_noop(tmp_path) -> None:
+    """Idempotent — clearing when no pointer exists must not raise."""
+    clear_pointer(str(tmp_path))  # no exception
+    assert read_pointer(str(tmp_path), machine_name='host-1') is None
+
+
+# ── atomic write ───────────────────────────────────────────────────────
+
+
+def test_write_replaces_atomically(tmp_path) -> None:
+    """Successive writes leave a valid pointer (no half-written file)."""
+    for i in range(5):
+        write_pointer(
+            str(tmp_path),
+            bridge_id='br-1',
+            environment_id=f'env-srv-{i}',
+            session_id=f'cse_{i}',
+            machine_name='host-1',
+        )
+        p = read_pointer(str(tmp_path), machine_name='host-1')
+        assert p is not None
+        assert p.environment_id == f'env-srv-{i}'
+        assert p.session_id == f'cse_{i}'
+
+
+def test_write_creates_claude_subdir_if_missing(tmp_path) -> None:
+    """If ``<dir>/.claude/`` doesn't exist yet, write_pointer creates
+    it — operators shouldn't have to pre-provision the directory."""
+    working_dir = str(tmp_path / 'fresh')
+    os.makedirs(working_dir)
+    assert not os.path.exists(os.path.join(working_dir, '.claude'))
+    write_pointer(
+        working_dir,
+        bridge_id='br-1', environment_id='env-srv-1',
+        session_id=None, machine_name='host-1',
+    )
+    assert os.path.exists(
+        os.path.join(working_dir, '.claude', 'bridge-pointer.json')
+    )

--- a/tests/bridge/test_repl_bridge.py
+++ b/tests/bridge/test_repl_bridge.py
@@ -224,12 +224,31 @@ def _make_params(
 
 
 @pytest.mark.asyncio
-async def test_perpetual_mode_not_yet_supported() -> None:
+async def test_perpetual_mode_writes_pointer_on_init(tmp_path) -> None:
+    """Phase 12c: ``perpetual=True`` now succeeds (no more
+    NotImplementedError) and writes the pointer file after init."""
+    from src.bridge.bridge_pointer import read_pointer
+
     params = _make_params(perpetual=True)
-    with pytest.raises(NotImplementedError, match='perpetual'):
-        await init_bridge_core(
-            params, api_client=FakeApiClient(), spawner=FakeSpawner(),
-        )
+    params.dir = str(tmp_path)  # write pointer here, not /tmp/test
+    api = FakeApiClient()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    pointer = read_pointer(
+        params.dir, machine_name=params.machine_name,
+    )
+    assert pointer is not None
+    assert pointer.environment_id == 'env-srv-1'
+    assert pointer.session_id == 'cse_test'
+    assert pointer.bridge_id == params.bridge_id
+    await handle.teardown()
+    # Clean teardown → pointer removed.
+    after = read_pointer(
+        params.dir, machine_name=params.machine_name,
+    )
+    assert after is None
 
 
 @pytest.mark.asyncio
@@ -1047,4 +1066,349 @@ async def test_strategy_1_re_register_failure_returns_false() -> None:
     assert not original_session._kill_called
 
     original_session.complete('completed')
+    await handle.teardown()
+
+
+# ── Phase 12c: perpetual mode + crash-recovery pointer ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_perpetual_resumes_session_when_pointer_and_env_reuse_succeed(
+    tmp_path,
+) -> None:
+    """When ``perpetual=True`` and the pointer exists, init must reuse
+    both the env id (via ``reuse_environment_id``) and the session id
+    (skipping ``create_session`` entirely)."""
+    from src.bridge.bridge_pointer import write_pointer
+
+    params = _make_params(perpetual=True)
+    params.dir = str(tmp_path)
+    # Seed a pointer pointing at env-srv-7 / session cse_resumed.
+    write_pointer(
+        params.dir,
+        bridge_id=params.bridge_id,
+        environment_id='env-srv-7',
+        session_id='cse_resumed',
+        machine_name=params.machine_name,
+    )
+    # Configure the fake API to "resurrect" the env id when reuse is
+    # requested.
+    api = FakeApiClient()
+    api.register_result = {
+        'environment_id': 'env-srv-7',
+        'environment_secret': 'sec-srv-7',
+    }
+    # Track create_session calls so we can assert it was NOT called.
+    create_calls: list[Any] = []
+    original_create = params.create_session
+    async def recording_create(opts: dict[str, Any]) -> str | None:
+        create_calls.append(opts)
+        return await original_create(opts)
+    params.create_session = recording_create  # type: ignore[assignment]
+
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    # ``reuse_environment_id`` was hinted in the register call.
+    assert api.register_calls, 'expected register call'
+    sent_config = api.register_calls[-1]
+    assert sent_config.reuse_environment_id == 'env-srv-7'
+    # Session reused, NOT created.
+    assert handle.bridge_session_id == 'cse_resumed'
+    assert create_calls == []
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_perpetual_falls_back_when_server_assigns_new_env_id(
+    tmp_path,
+) -> None:
+    """If the server ignores ``reuse_environment_id`` and returns a
+    different env id, init must drop the pointer's session id (it's
+    bound to the dead env) and create a fresh session."""
+    from src.bridge.bridge_pointer import write_pointer
+
+    params = _make_params(perpetual=True)
+    params.dir = str(tmp_path)
+    write_pointer(
+        params.dir,
+        bridge_id=params.bridge_id,
+        environment_id='env-srv-OLD',
+        session_id='cse_dead',
+        machine_name=params.machine_name,
+    )
+    api = FakeApiClient()
+    # Server doesn't honor reuse — returns a different env id.
+    api.register_result = {
+        'environment_id': 'env-srv-FRESH',
+        'environment_secret': 'sec-fresh',
+    }
+    create_calls: list[Any] = []
+    original_create = params.create_session
+    async def recording_create(opts: dict[str, Any]) -> str | None:
+        create_calls.append(opts)
+        return await original_create(opts)
+    params.create_session = recording_create  # type: ignore[assignment]
+
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    # Hint was sent, but the server gave back a different id.
+    assert api.register_calls[-1].reuse_environment_id == 'env-srv-OLD'
+    # Fresh session was created (not reused).
+    assert create_calls, 'create_session should have been called'
+    assert handle.bridge_session_id == 'cse_test'  # default fake result
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_perpetual_ignores_stale_pointer_from_different_dir(
+    tmp_path,
+) -> None:
+    """A pointer file written for a different working directory must
+    be rejected; init starts fresh as if no pointer existed."""
+    from src.bridge.bridge_pointer import write_pointer
+    import json
+    import os
+
+    params = _make_params(perpetual=True)
+    params.dir = str(tmp_path)
+    # Write a pointer that claims a DIFFERENT dir.
+    pointer_dir = os.path.join(params.dir, '.claude')
+    os.makedirs(pointer_dir, exist_ok=True)
+    with open(
+        os.path.join(pointer_dir, 'bridge-pointer.json'),
+        'w', encoding='utf-8',
+    ) as fh:
+        json.dump({
+            'schema_version': 1,
+            'bridge_id': 'br-old',
+            'environment_id': 'env-srv-OLD',
+            'session_id': 'cse_old',
+            'machine_name': params.machine_name,
+            'dir': '/some/other/working/dir',
+            'created_at_ms': 1000,
+            'updated_at_ms': 2000,
+        }, fh)
+    api = FakeApiClient()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    # Stale pointer should not have hinted reuse.
+    assert api.register_calls[-1].reuse_environment_id is None
+    # Fresh session created.
+    assert handle.bridge_session_id == 'cse_test'
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_perpetual_clears_pointer_on_clean_teardown(tmp_path) -> None:
+    """``teardown()`` must remove the pointer so a subsequent start
+    doesn't try to resume an env we just deregistered."""
+    from src.bridge.bridge_pointer import read_pointer
+
+    params = _make_params(perpetual=True)
+    params.dir = str(tmp_path)
+    handle = await init_bridge_core(
+        params, api_client=FakeApiClient(), spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    # Pointer exists during the run.
+    assert read_pointer(
+        params.dir, machine_name=params.machine_name,
+    ) is not None
+    await handle.teardown()
+    # Pointer removed after teardown.
+    assert read_pointer(
+        params.dir, machine_name=params.machine_name,
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_non_perpetual_does_not_write_pointer(tmp_path) -> None:
+    """``perpetual=False`` (the default) must NOT write a pointer —
+    avoiding pointer pollution in non-recovery use cases."""
+    from src.bridge.bridge_pointer import read_pointer
+
+    params = _make_params(perpetual=False)
+    params.dir = str(tmp_path)
+    handle = await init_bridge_core(
+        params, api_client=FakeApiClient(), spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    assert read_pointer(
+        params.dir, machine_name=params.machine_name,
+    ) is None
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_perpetual_pointer_updates_when_work_spawns_session(
+    tmp_path,
+) -> None:
+    """When ``_process_work`` spawns a session for a server-provided
+    session_id (which may differ from the bootstrap id), the pointer
+    must be rewritten so a mid-session crash recovers correctly."""
+    from src.bridge.bridge_pointer import read_pointer
+
+    work = {
+        'id': 'work-1', 'type': 'work', 'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_from_work'},
+        'secret': _encode_work_secret(),
+        'created_at': '2026-05-24',
+    }
+    params = _make_params(perpetual=True)
+    params.dir = str(tmp_path)
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    # Initial pointer has the bootstrap session id.
+    initial = read_pointer(
+        params.dir, machine_name=params.machine_name,
+    )
+    assert initial is not None
+    assert initial.session_id == 'cse_test'
+
+    # Wait for the work item to be processed.
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if spawner.handles:
+            break
+    assert spawner.handles
+
+    # Pointer should now reflect the work's session_id, not the
+    # bootstrap one.
+    after_spawn = read_pointer(
+        params.dir, machine_name=params.machine_name,
+    )
+    assert after_spawn is not None
+    assert after_spawn.session_id == 'cse_from_work'
+    # ``created_at_ms`` is preserved across the update.
+    assert after_spawn.created_at_ms == initial.created_at_ms
+
+    spawner.handles[0].complete('completed')
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_perpetual_pointer_clears_session_when_session_completes(
+    tmp_path,
+) -> None:
+    """After ``_await_session_done`` runs, the pointer must drop its
+    ``session_id`` (set it to None) — a crash before the next poll
+    would otherwise try to resurrect an archived session."""
+    from src.bridge.bridge_pointer import read_pointer
+
+    work = {
+        'id': 'work-1', 'type': 'work', 'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_short_lived'},
+        'secret': _encode_work_secret(),
+        'created_at': '2026-05-24',
+    }
+    params = _make_params(perpetual=True)
+    params.dir = str(tmp_path)
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if spawner.handles:
+            break
+    # Pointer has the active session id at this point.
+    mid = read_pointer(
+        params.dir, machine_name=params.machine_name,
+    )
+    assert mid is not None
+    assert mid.session_id == 'cse_short_lived'
+
+    # Session ends.
+    spawner.handles[0].complete('completed')
+    # Wait for _await_session_done to run.
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        p = read_pointer(
+            params.dir, machine_name=params.machine_name,
+        )
+        if p is not None and p.session_id is None:
+            break
+
+    final = read_pointer(
+        params.dir, machine_name=params.machine_name,
+    )
+    assert final is not None
+    assert final.session_id is None, (
+        'pointer should null session_id after session completes'
+    )
+    # Env id is unchanged so the next start can still resume the env.
+    assert final.environment_id == mid.environment_id
+    assert final.bridge_id == mid.bridge_id
+
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_perpetual_pointer_updates_after_strategy_2_recreation(
+    tmp_path,
+) -> None:
+    """After Strategy-2 swaps env+session, the pointer must reflect
+    the NEW identities — a crash mid-recreation should recover into
+    the new env, not the dead one."""
+    from src.bridge.bridge_pointer import read_pointer
+
+    # Cycle the fake create_session through distinct ids so the
+    # "after recreate" session id is observably different from
+    # the initial one.
+    session_ids = iter(['cse_initial', 'cse_after_strat2'])
+    async def cycling_create(_opts: dict[str, Any]) -> str | None:
+        return next(session_ids)
+    params = _make_params(perpetual=True)
+    params.dir = str(tmp_path)
+    params.create_session = cycling_create  # type: ignore[assignment]
+    api = FakeApiClient()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    initial = read_pointer(
+        params.dir, machine_name=params.machine_name,
+    )
+    assert initial is not None
+    initial_env = initial.environment_id
+    initial_session = initial.session_id
+    assert initial_session == 'cse_initial'
+
+    state = handle.write_messages.__self__  # type: ignore[attr-defined]
+    # Force Strategy-2: server hands back a DIFFERENT env id.
+    api.register_result = {
+        'environment_id': 'env-srv-strategy2',
+        'environment_secret': 'sec-s2',
+    }
+    ok = await state._recreate_environment()
+    assert ok is True
+
+    after = read_pointer(
+        params.dir, machine_name=params.machine_name,
+    )
+    assert after is not None
+    assert after.environment_id == 'env-srv-strategy2'
+    assert after.environment_id != initial_env
+    # Strategy-2 minted a new session id from the cycling fixture.
+    assert after.session_id == 'cse_after_strat2'
+    assert after.session_id != initial_session
+    # Created_at_ms preserved across the update.
+    assert after.created_at_ms == initial.created_at_ms
+    # Updated_at_ms bumped (or at least not regressed).
+    assert after.updated_at_ms >= initial.updated_at_ms
+
     await handle.teardown()


### PR DESCRIPTION
## Summary

Lifts the `NotImplementedError` on `params.perpetual=True` and adds end-to-end pointer-based session resumption across restarts. After this PR, a perpetual bridge that crashes (or is cleanly killed by SIGTERM) can recover its `environment_id` and `session_id` from disk on the next start, skipping both env re-registration AND session create when the server honors the reuse hint.

## What's new

### `src/bridge/bridge_pointer.py` (new module)
- `BridgePointer` dataclass — schema_version 1, fields: bridge_id, environment_id, session_id (nullable), machine_name, dir, created_at_ms, updated_at_ms
- `read_pointer` — best-effort, returns None on any failure (missing, malformed, schema mismatch, host/dir mismatch)
- `write_pointer` — atomic via tmpfile + `os.replace`, swallows OSError with warning
- `clear_pointer` — idempotent
- File: `<working_dir>/.claude/bridge-pointer.json`

### `src/bridge/repl_bridge.py` wiring
- Pre-flight reads pointer → uses env_id for `reuse_environment_id` hint, session_id for skip-create
- If server returns a different env_id, drops captured session_id (bound to dead env)
- Pointer updates at every lifecycle transition: init, `_process_work` spawn, `_await_session_done`, Strategy-1 success, Strategy-2 success, teardown
- All pointer disk IO off-loaded via `asyncio.to_thread` so slow disks don't stall the event loop

## CRITIC review

**Round 1 — 2 BLOCKING + 1 MAJOR + sync-IO concern, all fixed:**
- BLOCKING #1: `_process_work` didn't update pointer with server-assigned session_id → fixed + regression test
- BLOCKING #2: `_await_session_done` left stale session_id in pointer → fixed + regression test
- MAJOR: `created_at_ms` plumbing via read-back lost value on write failure → compute locally, store on state before write
- Sync IO blocking event loop → `asyncio.to_thread`

**Round 2 — APPROVED.** Nit (clarifying comment for `environment_id=effective_bridge_id`) addressed in same branch.

## Test plan

- [x] **658/658 bridge tests pass** (was 632 at Phase 12b baseline, +26 new)
- [x] 18 pointer unit tests covering schema, round-trip, all failure modes, atomic write, staleness
- [x] 8 perpetual integration tests covering happy path, env-reuse refused, stale pointer, non-perpetual no-op, Strategy-2 update, work-spawn update, session-done null, clean teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)