### PR TITLE
bridge phase 13: validate pointer's session_id at init via reconnect_session

### DIFF
--- a/src/bridge/repl_bridge.py
+++ b/src/bridge/repl_bridge.py
@@ -81,7 +81,10 @@ from src.bridge.poll_config_defaults import (
     DEFAULT_POLL_CONFIG,
     PollIntervalConfig,
 )
-from src.bridge.session_id_compat import to_compat_session_id
+from src.bridge.session_id_compat import (
+    to_compat_session_id,
+    to_infra_session_id,
+)
 from src.bridge.session_runner import (
     PermissionRequest,
     SessionSpawnerDeps,
@@ -338,24 +341,56 @@ async def init_bridge_core(
         )
         reuse_session_id = None
 
-    # ── 2. Reuse or create session ─────────────────────────────────────
+    # ── 2. Validate the pointer's session id, reuse or create ──────────
+    # Phase 13: before trusting ``reuse_session_id``, actively probe the
+    # server via ``reconnect_session``. Without this, a session archived
+    # between restarts would resurface only after a full 404 poll cycle.
+    # Try both ``session_*`` and ``cse_*`` tags because the pointer was
+    # written under an unknown v2-compat-gate state (see TS
+    # ``replBridge.ts:392-415`` for the same rationale).
+    if reuse_session_id is not None:
+        candidates: list[str] = [reuse_session_id]
+        infra_id = to_infra_session_id(reuse_session_id)
+        if infra_id != reuse_session_id:
+            candidates.append(infra_id)
+        reconnect_ok = False
+        for candidate in candidates:
+            try:
+                await api_client.reconnect_session(
+                    environment_id, candidate,
+                )
+            # Intentionally broad (mirrors TS replBridge.ts:410):
+            # transient failures (5xx, network) conservatively fall
+            # through to fresh session rather than risk reusing a
+            # session whose state is undefined. ``CancelledError``
+            # inherits from ``BaseException`` and is not caught here.
+            except Exception as err:  # noqa: BLE001
+                logger.debug(
+                    '[bridge:repl] reconnect_session(%s) failed: %s',
+                    candidate, err,
+                )
+                continue
+            logger.debug(
+                '[bridge:repl] reconnect_session(%s) succeeded',
+                candidate,
+            )
+            reconnect_ok = True
+            break
+        if not reconnect_ok:
+            logger.info(
+                '[bridge:repl] Perpetual: session %s no longer reachable '
+                '(all %d candidate(s) refused) — creating fresh',
+                reuse_session_id, len(candidates),
+            )
+            clear_pointer(params.dir)
+            reuse_session_id = None
+
     session_id: str | None
     if reuse_session_id is not None:
-        # Trust the pointer's session id. The poll loop / next work
-        # item will surface an error if the server has already
-        # archived it, at which point our standard recreation flow
-        # takes over (Strategy-1 or Strategy-2).
-        #
-        # TODO(phase-13): probe the server (e.g. via a lightweight
-        # ``session.status`` lookup, or by treating the first poll as
-        # validation) before trusting blindly. Today a long-archived
-        # session resumes optimistically and only surfaces the error
-        # via the standard 404 → recreate flow — possibly after a
-        # full poll cycle of dead time.
         session_id = reuse_session_id
         logger.info(
             '[bridge:repl] Perpetual: reusing session_id=%s '
-            'from pointer', session_id,
+            '(reconnect-validated)', session_id,
         )
     else:
         try:

--- a/tests/bridge/test_repl_bridge.py
+++ b/tests/bridge/test_repl_bridge.py
@@ -1114,6 +1114,9 @@ async def test_perpetual_resumes_session_when_pointer_and_env_reuse_succeed(
     assert api.register_calls, 'expected register call'
     sent_config = api.register_calls[-1]
     assert sent_config.reuse_environment_id == 'env-srv-7'
+    # Phase 13: reuse only after the server confirms the session is
+    # still alive via reconnect_session.
+    assert api.reconnect_calls == [('env-srv-7', 'cse_resumed')]
     # Session reused, NOT created.
     assert handle.bridge_session_id == 'cse_resumed'
     assert create_calls == []
@@ -1411,4 +1414,263 @@ async def test_perpetual_pointer_updates_after_strategy_2_recreation(
     # Updated_at_ms bumped (or at least not regressed).
     assert after.updated_at_ms >= initial.updated_at_ms
 
+    await handle.teardown()
+
+
+# ── Phase 13: validate pointer's session_id via reconnect ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_perpetual_validates_session_via_reconnect_before_reuse(
+    tmp_path,
+) -> None:
+    """Phase 13: when reuse is eligible (env resurrected), init must
+    call ``reconnect_session`` to validate the session is still alive
+    before skipping ``create_session``."""
+    from src.bridge.bridge_pointer import read_pointer, write_pointer
+
+    params = _make_params(perpetual=True)
+    params.dir = str(tmp_path)
+    write_pointer(
+        params.dir,
+        bridge_id=params.bridge_id,
+        environment_id='env-srv-A',
+        session_id='cse_alive',
+        machine_name=params.machine_name,
+    )
+    api = FakeApiClient()
+    api.register_result = {
+        'environment_id': 'env-srv-A',
+        'environment_secret': 'sec-a',
+    }
+    create_calls: list[Any] = []
+    original_create = params.create_session
+    async def recording_create(opts: dict[str, Any]) -> str | None:
+        create_calls.append(opts)
+        return await original_create(opts)
+    params.create_session = recording_create  # type: ignore[assignment]
+
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    # Exactly one reconnect attempt (cse_ tag has no session_ variant).
+    assert api.reconnect_calls == [('env-srv-A', 'cse_alive')]
+    # Validation passed → session reused, no create_session.
+    assert create_calls == []
+    assert handle.bridge_session_id == 'cse_alive'
+    # Pointer still present (validation passed, not cleared).
+    p = read_pointer(params.dir, machine_name=params.machine_name)
+    assert p is not None
+    assert p.session_id == 'cse_alive'
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_perpetual_falls_back_when_reconnect_session_refused(
+    tmp_path,
+) -> None:
+    """Phase 13: when the server refuses ``reconnect_session`` for every
+    candidate id, init must clear the pointer, mint a fresh session via
+    ``create_session``, and write the fresh id into the pointer."""
+    from src.bridge.bridge_pointer import read_pointer, write_pointer
+    from src.bridge.exceptions import BridgeFatalError
+
+    params = _make_params(perpetual=True)
+    params.dir = str(tmp_path)
+    write_pointer(
+        params.dir,
+        bridge_id=params.bridge_id,
+        environment_id='env-srv-B',
+        session_id='cse_dead',
+        machine_name=params.machine_name,
+    )
+    api = FakeApiClient()
+    api.register_result = {
+        'environment_id': 'env-srv-B',
+        'environment_secret': 'sec-b',
+    }
+    # Every reconnect attempt is refused (e.g., session was reaped).
+    async def reconnect_refuse(env_id: str, sid: str) -> None:
+        api.reconnect_calls.append((env_id, sid))
+        raise BridgeFatalError('Session not found', status=404)
+    api.reconnect_session = reconnect_refuse  # type: ignore[method-assign]
+
+    # Capture the original created_at_ms to verify continuity.
+    original = read_pointer(
+        params.dir, machine_name=params.machine_name,
+    )
+    assert original is not None
+    original_created_at_ms = original.created_at_ms
+
+    create_calls: list[Any] = []
+    original_create = params.create_session
+    async def recording_create(opts: dict[str, Any]) -> str | None:
+        create_calls.append(opts)
+        return await original_create(opts)
+    params.create_session = recording_create  # type: ignore[assignment]
+
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    # All candidates tried (cse_dead is already cse_, so just one).
+    assert api.reconnect_calls == [('env-srv-B', 'cse_dead')]
+    # Validation failed → fall through to create_session.
+    assert create_calls, 'create_session must have been called'
+    # Bridge holds the freshly-minted session id, not the dead one.
+    assert handle.bridge_session_id == 'cse_test'
+    # Pointer was rewritten with the fresh session id (init re-writes
+    # the pointer after create_session lands a new session).
+    p = read_pointer(params.dir, machine_name=params.machine_name)
+    assert p is not None
+    assert p.session_id == 'cse_test'
+    assert p.environment_id == 'env-srv-B'
+    # created_at_ms must persist across the clear+rewrite — it's the
+    # daemon install time, not a per-session timestamp.
+    assert p.created_at_ms == original_created_at_ms
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_perpetual_reconnect_tries_session_then_cse_flavor(
+    tmp_path,
+) -> None:
+    """Phase 13: when the pointer's id is ``session_*`` tagged, init must
+    try the ``session_*`` form first and fall back to the ``cse_*``
+    form on failure (the server's v2-compat-gate may flip between
+    pointer-write and pointer-read). The canonical session id used
+    by the bridge afterward is the pointer's original tag — TS uses
+    ``prior.sessionId`` regardless of which candidate validated."""
+    from src.bridge.bridge_pointer import write_pointer
+    from src.bridge.exceptions import BridgeFatalError
+
+    params = _make_params(perpetual=True)
+    params.dir = str(tmp_path)
+    # Pointer was written when the gate was OFF (session_* tag).
+    write_pointer(
+        params.dir,
+        bridge_id=params.bridge_id,
+        environment_id='env-srv-C',
+        session_id='session_xyz',
+        machine_name=params.machine_name,
+    )
+    api = FakeApiClient()
+    api.register_result = {
+        'environment_id': 'env-srv-C',
+        'environment_secret': 'sec-c',
+    }
+    # First attempt (session_xyz) fails — gate has since flipped ON;
+    # second attempt (cse_xyz) succeeds.
+    call_count = {'n': 0}
+    async def reconnect_flaky(env_id: str, sid: str) -> None:
+        api.reconnect_calls.append((env_id, sid))
+        call_count['n'] += 1
+        if call_count['n'] == 1:
+            raise BridgeFatalError('Session not found', status=404)
+        # Second call succeeds.
+    api.reconnect_session = reconnect_flaky  # type: ignore[method-assign]
+
+    create_calls: list[Any] = []
+    original_create = params.create_session
+    async def recording_create(opts: dict[str, Any]) -> str | None:
+        create_calls.append(opts)
+        return await original_create(opts)
+    params.create_session = recording_create  # type: ignore[assignment]
+
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    # Both candidates tried, in the right order.
+    assert api.reconnect_calls == [
+        ('env-srv-C', 'session_xyz'),
+        ('env-srv-C', 'cse_xyz'),
+    ]
+    # Validation succeeded on the second attempt → no create_session.
+    assert create_calls == []
+    # Canonical id is the pointer's original tag, matching TS behavior.
+    assert handle.bridge_session_id == 'session_xyz'
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_perpetual_reconnect_stops_at_first_success(
+    tmp_path,
+) -> None:
+    """Phase 13: when the first candidate (``session_*``) succeeds, the
+    second (``cse_*``) must not be attempted — the ``break`` after a
+    success guards against wasted server round-trips. Inverse of
+    ``test_perpetual_reconnect_tries_session_then_cse_flavor``."""
+    from src.bridge.bridge_pointer import write_pointer
+
+    params = _make_params(perpetual=True)
+    params.dir = str(tmp_path)
+    # Pointer with session_* tag → two candidates would be generated.
+    write_pointer(
+        params.dir,
+        bridge_id=params.bridge_id,
+        environment_id='env-srv-D',
+        session_id='session_yyy',
+        machine_name=params.machine_name,
+    )
+    api = FakeApiClient()
+    api.register_result = {
+        'environment_id': 'env-srv-D',
+        'environment_secret': 'sec-d',
+    }
+    # First (and only) reconnect attempt succeeds — default
+    # FakeApiClient.reconnect_session does nothing on success.
+
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    # ONLY the session_* form was tried; cse_yyy was never attempted.
+    assert api.reconnect_calls == [('env-srv-D', 'session_yyy')]
+    assert handle.bridge_session_id == 'session_yyy'
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_perpetual_skips_reconnect_validation_when_env_mismatch(
+    tmp_path,
+) -> None:
+    """Phase 13: when the server hands back a different env id than the
+    one the pointer requested, ``reuse_session_id`` is already nulled
+    by the env-mismatch branch and the reconnect validation block
+    must NOT fire (the session is bound to the dead env anyway)."""
+    from src.bridge.bridge_pointer import write_pointer
+
+    params = _make_params(perpetual=True)
+    params.dir = str(tmp_path)
+    write_pointer(
+        params.dir,
+        bridge_id=params.bridge_id,
+        environment_id='env-srv-OLD',
+        session_id='cse_orphan',
+        machine_name=params.machine_name,
+    )
+    api = FakeApiClient()
+    api.register_result = {
+        'environment_id': 'env-srv-FRESH',
+        'environment_secret': 'sec-fresh',
+    }
+    create_calls: list[Any] = []
+    original_create = params.create_session
+    async def recording_create(opts: dict[str, Any]) -> str | None:
+        create_calls.append(opts)
+        return await original_create(opts)
+    params.create_session = recording_create  # type: ignore[assignment]
+
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    # Validation skipped entirely — env mismatch already invalidated
+    # the pointer's session id.
+    assert api.reconnect_calls == []
+    # Fresh session was created.
+    assert create_calls, 'create_session must have been called'
+    assert handle.bridge_session_id == 'cse_test'
     await handle.teardown()


### PR DESCRIPTION
## Summary

Closes the `TODO(phase-13)` left by phase 12c at `src/bridge/repl_bridge.py:349`. On perpetual-mode restart, the bridge previously **blindly trusted** the pointer's `session_id` once the server resurrected the env. If the session had been archived between restarts (server-side TTL, reaper, etc.), the daemon would run under a dead session id until the standard 404 → recreate flow kicked in — wasting up to a full poll cycle of dead air.

Phase 13 ports TS `tryReconnectInPlace` (`replBridge.ts:382-431`): before trusting the pointer, actively probe via `api.reconnect_session(env_id, candidate)`. Try both `cse_*` and `session_*` flavors to handle the v2-compat-gate state being unknown at pointer-write time. On any failure (4xx, transient 5xx, or network), clear the pointer and fall through to fresh `create_session`. On success, keep the pointer's original tag as the canonical session id (matches TS line 444).

## What's new

### `src/bridge/repl_bridge.py`

- **Import**: add `to_infra_session_id` to the `session_id_compat` import.
- **Validation block** (~lines 344-388): replaces the blind-trust branch. Builds candidates list (`[reuse_session_id]` + the infra-tagged form if different), iterates calling `reconnect_session`, breaks on first success.
  - Broad `except Exception` (mirrors TS `replBridge.ts:410`): transient errors fall through conservatively rather than risk reusing a dead session. `CancelledError` (BaseException-derived) is **not** caught — intent comment added at the catch site.
  - On all-failed: `clear_pointer(params.dir)` (sync — runs once at init, off the hot path) + `reuse_session_id = None` → fall through to `create_session`.
  - On success: keep `reuse_session_id` unchanged (TS uses `prior.sessionId` regardless of which candidate validated).
  - Logging: DEBUG per failed candidate, DEBUG on success ("reconnect_session(X) succeeded"), INFO on all-failed ("session X no longer reachable — creating fresh").
- **Reuse log** updated to "(reconnect-validated)" so logs distinguish phase 13 from phase 12c trust.
- **TODO removed** at the call site.

### Pre-existing phase-12c divergence with TS — not addressed in this PR

The env-mismatch branch (lines 333-342) nulls `reuse_session_id` but does **not** clear the pointer. TS calls `clearBridgePointer` unconditionally in this case (`replBridge.ts:429-431`). Functionally equivalent in the success case (the post-create_session pointer write overwrites it), but if `create_session` itself fails between env-mismatch and rewrite, Python leaves a stale pointer on disk. Scoped out of phase 13 to keep this PR surgical; flagged as a follow-up.

## CRITIC review

**Round 1 — APPROVE** with one MAJOR + 4 MINOR, none blocking. All applied:
- MAJOR: per-candidate success log was missing → dual-candidate scenarios couldn't be distinguished in logs. Added at the success path.
- MINOR (×4): intent comment for broad `except Exception` (preempts "broad except is a smell" reflex by naming `CancelledError` explicitly); soften failure log wording from "no longer valid" → "no longer reachable" (more honest about what we observed); inverse-success test (proves `break` short-circuits the second candidate); `created_at_ms` continuity assertion (guards phase 12c install-time invariant through the phase 13 clear+rewrite).

**Round 2 — APPROVE** with no regressions.

## Test plan

- [x] **663/663 bridge tests pass** (was 658 at phase 12c baseline, +5 new)
- [x] 5 new tests in `test_repl_bridge.py`:
  - `test_perpetual_validates_session_via_reconnect_before_reuse` — happy path
  - `test_perpetual_falls_back_when_reconnect_session_refused` — all candidates refuse → clear + create fresh; `created_at_ms` preserved
  - `test_perpetual_reconnect_tries_session_then_cse_flavor` — dual-flavor retry; canonical id is pointer's original tag
  - `test_perpetual_reconnect_stops_at_first_success` — first success short-circuits the loop
  - `test_perpetual_skips_reconnect_validation_when_env_mismatch` — env mismatch already drops reuse_session_id → validation is a no-op
- [x] Existing test `test_perpetual_resumes_session_when_pointer_and_env_reuse_succeed` extended with `api.reconnect_calls` assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)