### PR TITLE
bridge phase 14a: port WebSocketTransport (v1 read-side foundation)

### DIFF
--- a/src/transports/websocket_transport.py
+++ b/src/transports/websocket_transport.py
@@ -1,0 +1,961 @@
+"""Reconnecting WebSocket transport for the v1 (Session-Ingress) bridge path.
+
+Ports ``typescript/src/cli/transports/WebSocketTransport.ts``.
+
+Design overview
+---------------
+
+The v1 read side of ``HybridTransport`` (phase 14c) needs a WebSocket
+client that survives proxy disconnects, app/laptop sleep, and brief
+backend rolls. This module implements that client.
+
+Key behaviors (all mirror TS):
+
+* **Reconnection state machine** — exponential backoff with ±25%
+  jitter, 10-minute give-up budget. On give-up, fire ``on_close`` and
+  stop.
+* **Permanent close codes** (1002 / 4001 / 4003) — close immediately
+  without retry. Exception: ``4003`` retries once if ``refresh_headers``
+  returns a different ``Authorization`` (e.g. session-ingress token
+  was just minted by the parent).
+* **Sleep / suspension detection** — gap > 60 s between reconnect
+  attempts OR between ping-tick callback invocations → assume the
+  process was suspended, reset the reconnect budget, and retry.
+  Combats laptop-lid-close where the socket has gone stale but the
+  pong path doesn't surface it until the next NAT timeout.
+* **Replay-on-reconnect** — every outbound message carrying a ``uuid``
+  is held in a bounded ring (1000 entries). On reconnect-open, those
+  are replayed so the server can pick up where the previous transport
+  left off. Server is responsible for UUID-based dedup; the ring is
+  not cleared post-replay (see TS comment at ``replayBufferedMessages``).
+* **Keep-alive data frames** — every 5 min the transport sends
+  ``{"type":"keep_alive"}\\n`` so an idle proxy (e.g. Cloudflare 5 min
+  RST) doesn't kill the connection. Gated off when ``CLAUDE_CODE_REMOTE``
+  is truthy (CCR sessions have their own activity heartbeats).
+
+Python-specific simplifications vs. TS
+--------------------------------------
+
+* **Protocol pings are delegated to the ``websockets`` library**
+  (``ping_interval`` / ``ping_timeout``) instead of being manually
+  driven. TS does manual ``ws.ping()`` with pong-receipt tracking
+  because the underlying ``ws`` package surfaces pong events; the
+  Python ``websockets`` library encapsulates that.
+* **A separate ``_ping_tick_loop`` task** remains in addition to
+  ``websockets``'s auto-ping — its only job is the wall-clock
+  suspension detector. The TS code conflates the two; here they are
+  decoupled.
+* **No Bun-vs-Node WS adapter** — Python uses ``websockets`` throughout.
+* **No diagnostics-events surface yet** — the TS event names are
+  preserved as ``logger.info`` strings so future telemetry can grep
+  for them.
+
+What this module does NOT do
+----------------------------
+
+* No POST writes (that's ``HybridTransport`` in phase 14c, which
+  ``override``s ``write`` to dispatch through ``SerialBatchEventUploader``).
+* No session-activity callback wiring — Python has no equivalent yet.
+* No proxy / mTLS option helpers — the ``websockets`` defaults handle
+  the common case; production deployments can re-add when needed.
+
+Subclassing contract for ``HybridTransport``
+--------------------------------------------
+
+The single-underscore attributes (``_state``, ``_ws``, ``_url``, plus
+``_send_line``, ``_do_disconnect``) are intended for subclass use.
+``HybridTransport`` will override ``write`` entirely; the buffer +
+``_last_sent_id`` plumbing in this class is only used by direct
+``WebSocketTransport`` callers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import random
+import time
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import websockets
+from websockets.asyncio.client import ClientConnection
+from websockets.asyncio.client import connect as ws_connect
+
+from src.utils.env import is_env_truthy
+
+logger = logging.getLogger(__name__)
+
+
+# ─── Constants (mirror TS lines 20-46) ────────────────────────────────────
+
+#: Max buffered messages held for replay on reconnect. Mirrors TS
+#: ``DEFAULT_MAX_BUFFER_SIZE``.
+DEFAULT_MAX_BUFFER_SIZE = 1000
+
+#: Base delay for exponential backoff between reconnects (ms). Mirrors TS.
+DEFAULT_BASE_RECONNECT_DELAY_MS = 1000
+
+#: Backoff cap (ms). Mirrors TS.
+DEFAULT_MAX_RECONNECT_DELAY_MS = 30_000
+
+#: After this much elapsed time across all reconnect attempts, give up
+#: and fire ``on_close``. Mirrors TS ``DEFAULT_RECONNECT_GIVE_UP_MS``.
+DEFAULT_RECONNECT_GIVE_UP_MS = 600_000
+
+#: Suspension-detector tick interval (s). Separate from the ``websockets``
+#: library's protocol-ping interval — this is just a wall-clock-gap
+#: monitor.
+DEFAULT_PING_TICK_INTERVAL_S = 10.0
+
+#: Keep-alive data-frame interval (s). Mirrors TS ``DEFAULT_KEEPALIVE_INTERVAL``.
+DEFAULT_KEEPALIVE_INTERVAL_S = 300.0
+
+#: Wall-clock gap above which we infer system sleep/suspension.
+#: Mirrors TS ``SLEEP_DETECTION_THRESHOLD_MS``.
+SLEEP_DETECTION_THRESHOLD_MS = 60_000
+
+#: WebSocket close codes the server uses to indicate a permanent
+#: rejection. ``4003`` is retried once if ``refresh_headers`` is
+#: available (token refresh) — see ``_handle_connection_error``.
+PERMANENT_CLOSE_CODES = frozenset({1002, 4001, 4003})
+
+#: Data-frame payload sent on the keep-alive interval. Newline matters —
+#: the server side parses NDJSON. Built once at module load (instead of
+#: a hand-typed JSON literal) so a typo can't drift the wire format
+#: vs. what the server's JSON parser expects.
+KEEP_ALIVE_FRAME = json.dumps({'type': 'keep_alive'}) + '\n'
+
+#: Close code reported when the WS dropped without a server-sent close
+#: frame (e.g. proxy RST, TCP reset, abrupt server kill). Used as the
+#: fallback when ``websockets``'s ``ConnectionClosed.rcvd`` is ``None``.
+_ABNORMAL_CLOSURE_CODE = 1006
+
+#: ``websockets`` library protocol-ping interval (s). Underwrites the
+#: ``ping_interval`` kwarg on ``ws_connect``. Library default is 20 s;
+#: we use the TS value (10 s) for consistency.
+_PROTOCOL_PING_INTERVAL_S = 10.0
+
+
+WebSocketTransportState = Literal[
+    'idle', 'connected', 'reconnecting', 'closing', 'closed',
+]
+
+
+@dataclass
+class WebSocketTransportOptions:
+    """Construction-time knobs. Mirrors TS ``WebSocketTransportOptions``."""
+
+    #: When ``False``, the transport does not automatically reconnect on
+    #: disconnect. The caller (e.g. ``replBridge`` poll loop) is
+    #: expected to drive reconnection. Defaults to ``True``.
+    auto_reconnect: bool = True
+    #: Reserved for telemetry gating. Currently a no-op (Python has no
+    #: ``tengu_ws_transport_*`` analytics surface) but kept for parity
+    #: so call sites don't change later.
+    is_bridge: bool = False
+    #: Suspension-detector tick interval. Tests use a short interval to
+    #: avoid sleeping the test process for ``DEFAULT_PING_TICK_INTERVAL_S``.
+    ping_tick_interval_s: float = DEFAULT_PING_TICK_INTERVAL_S
+    #: Keep-alive interval. Tests use a short interval so the keep-alive
+    #: frame is observed within the test timeout.
+    keepalive_interval_s: float = DEFAULT_KEEPALIVE_INTERVAL_S
+
+
+def _monotonic_ms() -> int:
+    """Module-level alias for monotonic-time-in-ms.
+
+    Used by every timing decision (backoff math, sleep detection, budget
+    exhaustion). Tests monkeypatch this at the module level to make
+    those decisions deterministic.
+    """
+    return int(time.monotonic() * 1000)
+
+
+class WebSocketTransport:
+    """Reconnecting WebSocket client. See module docstring.
+
+    Lifecycle::
+
+        t = WebSocketTransport(url, headers={'Authorization': '...'})
+        t.set_on_data(lambda line: ...)
+        t.set_on_connect(lambda: ...)
+        t.set_on_close(lambda code: ...)
+        await t.connect()
+        await t.write({'type': 'x', 'uuid': '...'})
+        t.close()
+
+    All callbacks are invoked synchronously from the event loop;
+    long-running callback work should be off-loaded by the caller.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        headers: dict[str, str] | None = None,
+        session_id: str | None = None,
+        refresh_headers: Callable[[], dict[str, str]] | None = None,
+        options: WebSocketTransportOptions | None = None,
+    ) -> None:
+        self._url = url
+        # Defensive copy — caller can keep mutating their dict without
+        # racing us; reconnect-with-refresh uses ``_headers.update(...)``.
+        self._headers: dict[str, str] = dict(headers or {})
+        self._session_id = session_id
+        self._refresh_headers = refresh_headers
+        opts = options or WebSocketTransportOptions()
+        self._auto_reconnect = opts.auto_reconnect
+        self._is_bridge = opts.is_bridge
+        self._ping_tick_interval_s = opts.ping_tick_interval_s
+        self._keepalive_interval_s = opts.keepalive_interval_s
+
+        self._ws: ClientConnection | None = None
+        self._state: WebSocketTransportState = 'idle'
+
+        self._on_data_cb: Callable[[str], None] | None = None
+        self._on_connect_cb: Callable[[], None] | None = None
+        self._on_close_cb: Callable[[int | None], None] | None = None
+
+        # Replay buffer — bounded ring of every UUID-tagged outbound.
+        # ``deque(maxlen=N)`` evicts oldest on overflow, matching TS
+        # ``CircularBuffer.add``.
+        self._message_buffer: deque[dict[str, Any]] = deque(
+            maxlen=DEFAULT_MAX_BUFFER_SIZE,
+        )
+        self._last_sent_id: str | None = None
+
+        # Reconnection state.
+        self._reconnect_attempts = 0
+        self._reconnect_start_time_ms: int | None = None
+        self._last_reconnect_attempt_ms: int | None = None
+        self._last_activity_ms = 0
+
+        self._reader_task: asyncio.Task[None] | None = None
+        self._reconnect_task: asyncio.Task[None] | None = None
+        self._ping_tick_task: asyncio.Task[None] | None = None
+        self._keepalive_task: asyncio.Task[None] | None = None
+
+    # ─── State queries ────────────────────────────────────────────────
+
+    def is_connected_status(self) -> bool:
+        """Write-ready check. Mirrors TS ``isConnectedStatus``."""
+        return self._state == 'connected'
+
+    def is_closed_status(self) -> bool:
+        """Terminal-state check. Mirrors TS ``isClosedStatus``."""
+        return self._state == 'closed'
+
+    def get_state_label(self) -> str:
+        """Returns the state name (one of ``WebSocketTransportState``)."""
+        return self._state
+
+    # ─── Callback registration ────────────────────────────────────────
+
+    def set_on_data(self, callback: Callable[[str], None]) -> None:
+        self._on_data_cb = callback
+
+    def set_on_connect(self, callback: Callable[[], None]) -> None:
+        self._on_connect_cb = callback
+
+    def set_on_close(self, callback: Callable[[int | None], None]) -> None:
+        self._on_close_cb = callback
+
+    # ─── Lifecycle ────────────────────────────────────────────────────
+
+    async def connect(self) -> None:
+        """Open the WS, fire ``on_connect`` on success, start the reader.
+
+        Single-flight: rejects re-entrant calls when the state is not
+        ``idle`` / ``reconnecting``. On exception, transitions to
+        ``closed`` via ``_handle_connection_error`` (which will schedule
+        a retry when applicable).
+        """
+        if self._state not in ('idle', 'reconnecting'):
+            logger.warning(
+                'WebSocketTransport: cli_websocket_connect_failed '
+                '(state=%s)', self._state,
+            )
+            return
+        self._state = 'reconnecting'
+        connect_start_ms = _monotonic_ms()
+
+        # Per-attempt headers. The reconnect path may mutate ``self._headers``
+        # via ``refresh_headers``; on every connect attempt we materialize
+        # the current view + the X-Last-Request-Id replay anchor.
+        headers = dict(self._headers)
+        if self._last_sent_id:
+            headers['X-Last-Request-Id'] = self._last_sent_id
+            logger.debug(
+                'WebSocketTransport: adding X-Last-Request-Id=%s',
+                self._last_sent_id,
+            )
+
+        logger.debug('WebSocketTransport: opening %s', self._url)
+        logger.info('WebSocketTransport: cli_websocket_connect_opening')
+
+        try:
+            ws = await ws_connect(
+                self._url,
+                additional_headers=headers,
+                ping_interval=_PROTOCOL_PING_INTERVAL_S,
+            )
+        except (websockets.exceptions.WebSocketException, OSError) as exc:
+            logger.warning(
+                'WebSocketTransport: cli_websocket_connect_error: %s', exc,
+            )
+            self._handle_connection_error(close_code=None)
+            return
+
+        # Post-await race: ``close()`` may have run while we awaited
+        # the handshake. ``close()`` itself synchronously finalizes
+        # state through ``'closing'`` → ``'closed'``, so we only see
+        # ``'closed'`` here (never the intermediate ``'closing'``).
+        # Drop the orphan WS without starting the reader.
+        if self._state not in ('reconnecting', 'idle'):
+            logger.debug(
+                'WebSocketTransport: close() ran during handshake '
+                '(state=%s); dropping orphan WS', self._state,
+            )
+            try:
+                await ws.close()
+            except (websockets.exceptions.ConnectionClosed, OSError):
+                pass
+            return
+
+        self._ws = ws
+        connect_duration_ms = _monotonic_ms() - connect_start_ms
+        logger.info(
+            'WebSocketTransport: cli_websocket_connect_connected '
+            'duration_ms=%d', connect_duration_ms,
+        )
+        self._handle_open_event()
+
+    def close(self) -> None:
+        """Idempotent close. Cancels reconnect timer, stops periodic
+        tasks, closes the WS, and transitions to ``closed``. Mirrors
+        TS ``close`` (TS leaves the state at ``closing`` and relies on
+        the WS event handler to finalize; Python finalizes here because
+        the reader task gets cancelled and no event surfaces the
+        transition otherwise).
+
+        Stays sync (returns immediately) — the actual WS close is
+        scheduled via the running loop. Async drain is the caller's
+        responsibility (replBridge teardown awaits archive before
+        calling close()). Does NOT fire ``on_close`` — the user
+        initiated this close and already knows.
+        """
+        if self._reconnect_task is not None and not self._reconnect_task.done():
+            self._reconnect_task.cancel()
+        self._state = 'closing'
+        self._do_disconnect()
+        self._state = 'closed'
+
+    async def write(self, message: dict[str, Any]) -> None:
+        """Send a message. Buffered (for replay) if UUID-tagged, plus
+        sent immediately when connected. Mirrors TS ``write``.
+
+        Returns when the bytes have been handed to the WS — the
+        ``websockets`` library buffers internally, so resolution
+        precedes wire delivery. Caller awaits when ordering vs.
+        archive matters (initial flush in ``replBridge``).
+        """
+        # Buffer UUID-tagged messages for replay on reconnect.
+        msg_uuid = message.get('uuid')
+        if isinstance(msg_uuid, str):
+            self._message_buffer.append(message)
+            self._last_sent_id = msg_uuid
+
+        if self._state != 'connected':
+            # Buffered for replay (if UUID-tagged); silent drop otherwise.
+            return
+
+        line = json.dumps(message) + '\n'
+        session_label = (
+            f' session={self._session_id}' if self._session_id else ''
+        )
+        detail_label = self._control_message_detail_label(message)
+        logger.debug(
+            'WebSocketTransport: sending type=%s%s%s',
+            message.get('type'), session_label, detail_label,
+        )
+        self._send_line(line)
+
+    # ─── Protected (subclass-facing) ─────────────────────────────────
+
+    def _send_line(self, line: str) -> bool:
+        """Schedule a send. Returns ``True`` when the task was queued.
+
+        Sync because ``websockets`` client's ``send`` is async, but
+        fire-and-forget callers (TS ``ws.send(line)`` semantics) don't
+        want to await. Send failures surface via the task's
+        ``done_callback`` — see :meth:`_on_send_done` — and route into
+        ``_handle_connection_error`` so the reconnect path fires.
+
+        Subclasses (``HybridTransport`` in phase 14c) reuse this to send
+        the keep-alive frame and any direct WS writes; the POST-based
+        write path lives in their ``override``.
+        """
+        ws = self._ws
+        if ws is None or self._state != 'connected':
+            logger.info(
+                'WebSocketTransport: cli_websocket_send_not_connected',
+            )
+            return False
+        try:
+            # ``ClientConnection.send`` is async; schedule and don't
+            # await — matches TS ``ws.send(line)`` semantics.
+            send_task = asyncio.get_running_loop().create_task(
+                ws.send(line),
+                name=f'ws-send:{self._session_id or hex(id(self))}',
+            )
+        except RuntimeError as exc:
+            # No running loop (e.g. send from outside async context).
+            # No way to schedule; treat as a connection error.
+            logger.warning(
+                'WebSocketTransport: cli_websocket_send_error: %s', exc,
+            )
+            self._handle_connection_error(close_code=None)
+            return False
+        # ``_last_activity_ms`` is updated at queue time, not at wire
+        # time — the difference is at most one event-loop iteration on
+        # a healthy socket, and on an unhealthy socket the done-callback
+        # below will fire reconnect anyway.
+        self._last_activity_ms = _monotonic_ms()
+        send_task.add_done_callback(self._on_send_done)
+        return True
+
+    def _on_send_done(self, task: asyncio.Task[None]) -> None:
+        """Done-callback for ``ws.send`` tasks.
+
+        Without this, send failures (the WS dropped under us) vanish
+        into asyncio's "Task exception was never retrieved" graveyard.
+        With it: ``ConnectionClosed`` / ``OSError`` route into the
+        reconnect state machine.
+
+        If we're already past ``'connected'`` (a concurrent reader-loop
+        failure or ``close()`` raced us), the reconnect path is already
+        running — short-circuit so a single underlying drop doesn't
+        compound ``_reconnect_attempts`` or replace the pending
+        reconnect task with a longer-delayed one.
+        """
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is None:
+            return
+        if self._state != 'connected':
+            return
+        if isinstance(
+            exc, (websockets.exceptions.ConnectionClosed, OSError),
+        ):
+            logger.warning(
+                'WebSocketTransport: cli_websocket_send_error: %s', exc,
+            )
+            self._handle_connection_error(close_code=None)
+        else:
+            logger.warning(
+                'WebSocketTransport: send task unexpected error: %s',
+                exc,
+            )
+
+    def _do_disconnect(self) -> None:
+        """Stop periodic tasks, cancel reader, and close the WS.
+
+        Mirrors TS ``doDisconnect``. Idempotent — safe to call multiple
+        times. Does NOT change ``_state`` (the caller controls that —
+        ``close`` sets ``closing``, ``_handle_connection_error`` runs
+        the state machine).
+        """
+        self._stop_ping_tick()
+        self._stop_keepalive()
+        if self._reader_task is not None and not self._reader_task.done():
+            self._reader_task.cancel()
+        ws, self._ws = self._ws, None
+        if ws is not None:
+            # ``ws.close()`` is async on ``websockets`` library. Fire
+            # without awaiting to keep ``close()`` sync. The reader task
+            # cancellation above will tear down the read side.
+            try:
+                asyncio.get_running_loop().create_task(
+                    ws.close(), name='ws-close',
+                )
+            except RuntimeError:
+                # No running loop (e.g. close from outside async context).
+                # The WS will be GC'd; not great, but acceptable for a
+                # last-resort close path.
+                pass
+
+    # ─── Connection-state machine ─────────────────────────────────────
+
+    def _handle_open_event(self) -> None:
+        """Run on successful WS open. Mirrors TS ``handleOpenEvent``.
+
+        Resets reconnect counters, transitions to ``connected``, fires
+        ``on_connect``, starts the reader / ping-tick / keepalive
+        loops, and replays any buffered messages held over from a
+        previous transport.
+        """
+        if self._is_bridge and self._reconnect_start_time_ms is not None:
+            logger.info(
+                'WebSocketTransport: tengu_ws_transport_reconnected '
+                'attempts=%d downtimeMs=%d',
+                self._reconnect_attempts,
+                _monotonic_ms() - self._reconnect_start_time_ms,
+            )
+
+        self._reconnect_attempts = 0
+        self._reconnect_start_time_ms = None
+        self._last_reconnect_attempt_ms = None
+        self._last_activity_ms = _monotonic_ms()
+        self._state = 'connected'
+
+        if self._on_connect_cb is not None:
+            try:
+                self._on_connect_cb()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    'WebSocketTransport: on_connect_cb raised: %s', exc,
+                )
+
+        self._start_ping_tick()
+        self._start_keepalive()
+        loop = asyncio.get_running_loop()
+        self._reader_task = loop.create_task(
+            self._run_reader_loop(), name='ws-transport-reader',
+        )
+
+        # Replay any held messages now that the WS is up again. Pass
+        # ``None`` because the ``websockets`` library doesn't surface
+        # the server's upgrade response headers in a stable way —
+        # without ``X-Last-Request-Id`` from the server we can't
+        # confirm what was received, so we replay everything and rely
+        # on server-side UUID dedup. Mirrors TS Bun behavior at
+        # ``onBunOpen`` (``replayBufferedMessages('')``). The eviction
+        # branch of ``_replay_buffered_messages`` remains for future
+        # parity when the response header is plumbed through.
+        self._replay_buffered_messages(None)
+
+    async def _run_reader_loop(self) -> None:
+        """Iterate inbound frames, dispatch to ``on_data``.
+
+        Termination triggers ``_handle_connection_error`` with the
+        observed close code (so the reconnect state machine fires).
+        Cancellation is silent — ``close()`` cancels this task.
+        """
+        ws = self._ws
+        if ws is None:
+            return
+        try:
+            async for raw in ws:
+                text = raw if isinstance(raw, str) else raw.decode('utf-8')
+                self._last_activity_ms = _monotonic_ms()
+                logger.info(
+                    'WebSocketTransport: cli_websocket_message_received '
+                    'length=%d', len(text),
+                )
+                if self._on_data_cb is not None:
+                    try:
+                        self._on_data_cb(text)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            'WebSocketTransport: on_data_cb raised: %s',
+                            exc,
+                        )
+        except asyncio.CancelledError:
+            raise
+        except websockets.exceptions.ConnectionClosed as exc:
+            # ``rcvd`` is the close frame received from the peer (the
+            # canonical source for the close code post-websockets 13).
+            # When ``rcvd`` is ``None`` the WS dropped without a
+            # close frame (proxy RST, TCP reset, abrupt server kill);
+            # report ABNORMAL_CLOSURE so the reconnect path treats it
+            # as transient rather than as a missing-code edge case.
+            code = exc.rcvd.code if exc.rcvd is not None else _ABNORMAL_CLOSURE_CODE
+            self._handle_connection_error(close_code=code)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                'WebSocketTransport: reader loop error: %s', exc,
+            )
+            self._handle_connection_error(close_code=None)
+
+    def _handle_connection_error(self, close_code: int | None) -> None:
+        """Run the reconnect state machine on disconnect.
+
+        Mirrors TS ``handleConnectionError``. Always fires close-event
+        logs; transitions to ``closed`` on permanent codes /
+        ``auto_reconnect=False`` / budget-exhausted; otherwise schedules
+        a backoff-delayed reconnect.
+        """
+        ms_since_activity = (
+            _monotonic_ms() - self._last_activity_ms
+            if self._last_activity_ms > 0 else -1
+        )
+        logger.debug(
+            'WebSocketTransport: cli_websocket_disconnected '
+            'close_code=%s ms_since_activity=%d', close_code, ms_since_activity,
+        )
+        if self._is_bridge:
+            logger.info(
+                'WebSocketTransport: tengu_ws_transport_closed '
+                'close_code=%s msSinceLastActivity=%d wasConnected=%s '
+                'reconnectAttempts=%d',
+                close_code, ms_since_activity,
+                self._state == 'connected', self._reconnect_attempts,
+            )
+
+        # Tear down the WS + listeners first so subsequent state
+        # transitions don't race the old reader.
+        self._do_disconnect()
+
+        if self._state in ('closing', 'closed'):
+            return
+
+        # 4003 retry-once-with-fresh-headers path. Mirrors TS lines
+        # 426-438. The standard permanent-codes branch below would
+        # otherwise terminate without giving the parent a chance to
+        # mint a fresh ingress token.
+        headers_refreshed = False
+        if close_code == 4003 and self._refresh_headers is not None:
+            try:
+                fresh = self._refresh_headers()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    'WebSocketTransport: refresh_headers raised: %s', exc,
+                )
+                fresh = {}
+            new_auth = fresh.get('Authorization')
+            cur_auth = self._headers.get('Authorization')
+            if new_auth and new_auth != cur_auth:
+                self._headers.update(fresh)
+                headers_refreshed = True
+                logger.debug(
+                    'WebSocketTransport: 4003 received but headers '
+                    'refreshed, scheduling reconnect',
+                )
+                logger.info(
+                    'WebSocketTransport: cli_websocket_4003_token_refreshed',
+                )
+
+        if (
+            close_code is not None
+            and close_code in PERMANENT_CLOSE_CODES
+            and not headers_refreshed
+        ):
+            logger.warning(
+                'WebSocketTransport: cli_websocket_permanent_close '
+                'close_code=%d', close_code,
+            )
+            self._state = 'closed'
+            self._fire_on_close(close_code)
+            return
+
+        if not self._auto_reconnect:
+            self._state = 'closed'
+            self._fire_on_close(close_code)
+            return
+
+        now_ms = _monotonic_ms()
+        if self._reconnect_start_time_ms is None:
+            self._reconnect_start_time_ms = now_ms
+
+        # Sleep detection — if the gap since our last reconnect ATTEMPT
+        # exceeds the threshold, the machine likely slept. Reset the
+        # budget. Mirrors TS lines 476-488.
+        if (
+            self._last_reconnect_attempt_ms is not None
+            and now_ms - self._last_reconnect_attempt_ms
+            > SLEEP_DETECTION_THRESHOLD_MS
+        ):
+            logger.info(
+                'WebSocketTransport: cli_websocket_sleep_detected '
+                'gap_ms=%d',
+                now_ms - self._last_reconnect_attempt_ms,
+            )
+            self._reconnect_start_time_ms = now_ms
+            self._reconnect_attempts = 0
+        self._last_reconnect_attempt_ms = now_ms
+
+        elapsed = now_ms - self._reconnect_start_time_ms
+        if elapsed >= DEFAULT_RECONNECT_GIVE_UP_MS:
+            logger.error(
+                'WebSocketTransport: cli_websocket_reconnect_exhausted '
+                'attempts=%d elapsed_ms=%d',
+                self._reconnect_attempts, elapsed,
+            )
+            self._state = 'closed'
+            self._fire_on_close(close_code)
+            return
+
+        # Refresh headers (e.g. session token) ahead of the retry, if
+        # we didn't already via the 4003 path.
+        if not headers_refreshed and self._refresh_headers is not None:
+            try:
+                fresh = self._refresh_headers()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    'WebSocketTransport: refresh_headers raised: %s', exc,
+                )
+                fresh = {}
+            if fresh:
+                self._headers.update(fresh)
+                logger.debug(
+                    'WebSocketTransport: refreshed headers for reconnect',
+                )
+
+        self._state = 'reconnecting'
+        self._reconnect_attempts += 1
+
+        base_delay = min(
+            DEFAULT_BASE_RECONNECT_DELAY_MS * (2 ** (self._reconnect_attempts - 1)),
+            DEFAULT_MAX_RECONNECT_DELAY_MS,
+        )
+        jitter_range = base_delay * 0.25
+        # Uniform in [-jitter_range, +jitter_range].
+        delay_ms = max(0.0, base_delay + jitter_range * (2 * random.random() - 1))
+
+        logger.debug(
+            'WebSocketTransport: reconnecting in %dms (attempt=%d, '
+            'elapsed=%ds)',
+            int(delay_ms), self._reconnect_attempts, elapsed // 1000,
+        )
+        logger.info(
+            'WebSocketTransport: cli_websocket_reconnect_attempt '
+            'attempts=%d', self._reconnect_attempts,
+        )
+        if self._is_bridge:
+            logger.info(
+                'WebSocketTransport: tengu_ws_transport_reconnecting '
+                'attempt=%d elapsedMs=%d delayMs=%d',
+                self._reconnect_attempts, elapsed, int(delay_ms),
+            )
+
+        # Cancel any prior pending reconnect to avoid duplicates.
+        if (
+            self._reconnect_task is not None
+            and not self._reconnect_task.done()
+        ):
+            self._reconnect_task.cancel()
+        loop = asyncio.get_running_loop()
+        self._reconnect_task = loop.create_task(
+            self._sleep_then_reconnect(delay_ms / 1000.0),
+            name='ws-transport-reconnect',
+        )
+
+    async def _sleep_then_reconnect(self, delay_s: float) -> None:
+        try:
+            await asyncio.sleep(delay_s)
+        except asyncio.CancelledError:
+            return
+        # If close() ran during the sleep, bail.
+        if self._state in ('closing', 'closed'):
+            return
+        await self.connect()
+
+    def _replay_buffered_messages(self, last_id: str | None) -> None:
+        """Replay buffered outbound messages after a reconnect.
+
+        If ``last_id`` is set (X-Last-Request-Id header from a prior
+        connect), the server has confirmed receipt of all messages up
+        to and including that UUID — evict them and replay only the
+        unconfirmed tail. Otherwise replay everything.
+
+        Mirrors TS ``replayBufferedMessages``. The buffer is **not
+        cleared** post-replay — server-side dedup catches doubles, and
+        a connection that drops again before the server processes a
+        message can re-replay safely.
+        """
+        if not self._message_buffer:
+            return
+
+        if last_id:
+            confirmed_idx: int | None = None
+            for i, msg in enumerate(self._message_buffer):
+                if msg.get('uuid') == last_id:
+                    confirmed_idx = i
+                    break
+            if confirmed_idx is not None:
+                # Drop everything up to and including the confirmed id;
+                # rebuild the deque with the unconfirmed tail.
+                evict_count = confirmed_idx + 1
+                remaining = list(self._message_buffer)[evict_count:]
+                self._message_buffer.clear()
+                self._message_buffer.extend(remaining)
+                if not remaining:
+                    self._last_sent_id = None
+                logger.debug(
+                    'WebSocketTransport: evicted %d confirmed messages, '
+                    '%d remaining', evict_count, len(remaining),
+                )
+                logger.info(
+                    'WebSocketTransport: '
+                    'cli_websocket_evicted_confirmed_messages '
+                    'evicted=%d remaining=%d',
+                    evict_count, len(remaining),
+                )
+
+        if not self._message_buffer:
+            logger.debug('WebSocketTransport: no messages to replay')
+            logger.info(
+                'WebSocketTransport: cli_websocket_no_messages_to_replay',
+            )
+            return
+
+        logger.debug(
+            'WebSocketTransport: replaying %d buffered messages',
+            len(self._message_buffer),
+        )
+        logger.info(
+            'WebSocketTransport: cli_websocket_messages_to_replay '
+            'count=%d', len(self._message_buffer),
+        )
+        # Snapshot the list since _send_line failure path may trigger
+        # _do_disconnect which would mutate `_message_buffer` if a
+        # subsequent reconnect raced (it won't in steady state but
+        # snapshot guards against pathological loops).
+        for msg in list(self._message_buffer):
+            line = json.dumps(msg) + '\n'
+            if not self._send_line(line):
+                # Send-line returned False — the WS isn't currently
+                # write-ready (state changed under us). Trigger the
+                # reconnect path here and stop replaying so we don't
+                # pile work on the dead WS.
+                self._handle_connection_error(close_code=None)
+                break
+
+    # ─── Periodic tasks ───────────────────────────────────────────────
+
+    def _start_ping_tick(self) -> None:
+        """Start the wall-clock suspension detector.
+
+        The ``websockets`` library handles protocol pings internally;
+        this task only watches for tick-callback gaps > 60 s as the
+        signal of process suspension (laptop sleep, SIGSTOP, VM pause).
+        """
+        self._stop_ping_tick()
+        loop = asyncio.get_running_loop()
+        self._ping_tick_task = loop.create_task(
+            self._ping_tick_loop(), name='ws-transport-ping-tick',
+        )
+
+    def _stop_ping_tick(self) -> None:
+        if (
+            self._ping_tick_task is not None
+            and not self._ping_tick_task.done()
+        ):
+            self._ping_tick_task.cancel()
+        self._ping_tick_task = None
+
+    async def _ping_tick_loop(self) -> None:
+        last_tick_ms = _monotonic_ms()
+        try:
+            while True:
+                await asyncio.sleep(self._ping_tick_interval_s)
+                if self._state != 'connected':
+                    return
+                now_ms = _monotonic_ms()
+                gap = now_ms - last_tick_ms
+                last_tick_ms = now_ms
+                if gap > SLEEP_DETECTION_THRESHOLD_MS:
+                    logger.info(
+                        'WebSocketTransport: '
+                        'cli_websocket_sleep_detected_on_ping gap_ms=%d',
+                        gap,
+                    )
+                    # _handle_connection_error mutates state — return after.
+                    self._handle_connection_error(close_code=None)
+                    return
+        except asyncio.CancelledError:
+            return
+
+    def _start_keepalive(self) -> None:
+        """Start the proxy-keep-alive data-frame loop.
+
+        Skipped when ``CLAUDE_CODE_REMOTE`` is truthy — CCR sessions
+        run their own activity heartbeats.
+        """
+        self._stop_keepalive()
+        if is_env_truthy('CLAUDE_CODE_REMOTE'):
+            return
+        loop = asyncio.get_running_loop()
+        self._keepalive_task = loop.create_task(
+            self._keepalive_loop(), name='ws-transport-keepalive',
+        )
+
+    def _stop_keepalive(self) -> None:
+        if (
+            self._keepalive_task is not None
+            and not self._keepalive_task.done()
+        ):
+            self._keepalive_task.cancel()
+        self._keepalive_task = None
+
+    async def _keepalive_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._keepalive_interval_s)
+                if self._state != 'connected' or self._ws is None:
+                    return
+                try:
+                    self._send_line(KEEP_ALIVE_FRAME)
+                    logger.debug(
+                        'WebSocketTransport: sent periodic keep_alive frame',
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        'WebSocketTransport: cli_websocket_keepalive_failed: '
+                        '%s', exc,
+                    )
+        except asyncio.CancelledError:
+            return
+
+    # ─── Internal helpers ────────────────────────────────────────────
+
+    def _fire_on_close(self, close_code: int | None) -> None:
+        cb = self._on_close_cb
+        if cb is None:
+            return
+        try:
+            cb(close_code)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                'WebSocketTransport: on_close_cb raised: %s', exc,
+            )
+
+    @staticmethod
+    def _control_message_detail_label(message: dict[str, Any]) -> str:
+        msg_type = message.get('type')
+        if msg_type == 'control_request':
+            req = message.get('request') or {}
+            subtype = req.get('subtype')
+            request_id = message.get('request_id')
+            tool_name = req.get('tool_name') if subtype == 'can_use_tool' else None
+            base = f' subtype={subtype} request_id={request_id}'
+            if tool_name:
+                base += f' tool={tool_name}'
+            return base
+        if msg_type == 'control_response':
+            resp = message.get('response') or {}
+            return (
+                f' subtype={resp.get("subtype")} '
+                f'request_id={resp.get("request_id")}'
+            )
+        return ''
+
+
+__all__ = [
+    'DEFAULT_BASE_RECONNECT_DELAY_MS',
+    'DEFAULT_KEEPALIVE_INTERVAL_S',
+    'DEFAULT_MAX_BUFFER_SIZE',
+    'DEFAULT_MAX_RECONNECT_DELAY_MS',
+    'DEFAULT_PING_TICK_INTERVAL_S',
+    'DEFAULT_RECONNECT_GIVE_UP_MS',
+    'KEEP_ALIVE_FRAME',
+    'PERMANENT_CLOSE_CODES',
+    'SLEEP_DETECTION_THRESHOLD_MS',
+    'WebSocketTransport',
+    'WebSocketTransportOptions',
+    'WebSocketTransportState',
+]

--- a/tests/transports/test_websocket_transport.py
+++ b/tests/transports/test_websocket_transport.py
@@ -1,0 +1,813 @@
+"""Tests for ``src.transports.websocket_transport.WebSocketTransport``.
+
+Strategy
+--------
+Runs an in-process WebSocket server via
+``websockets.asyncio.server.serve``. Per-connection behavior is
+controlled by a ``_ScriptedServer`` fixture: scripted close codes,
+optional initial frames, captures inbound messages.
+
+Timing-dependent tests monkeypatch ``websocket_transport._monotonic_ms``
+to make the reconnect state machine deterministic (avoids real-time
+sleeps in the test process).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import pytest
+import websockets
+from websockets.asyncio.server import serve as ws_serve
+
+from src.transports import websocket_transport as wst
+from src.transports.websocket_transport import (
+    DEFAULT_RECONNECT_GIVE_UP_MS,
+    SLEEP_DETECTION_THRESHOLD_MS,
+    WebSocketTransport,
+    WebSocketTransportOptions,
+)
+
+
+pytestmark = pytest.mark.integration
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('127.0.0.1', 0))
+        return s.getsockname()[1]
+
+
+class _ScriptedServer:
+    """In-process WS server with per-connection control.
+
+    Each new connection consumes the next item from ``close_codes``
+    (None = stay open) and ``initial_frames`` (None = nothing extra).
+    All inbound text frames are appended to ``received`` until close.
+    """
+
+    def __init__(
+        self,
+        *,
+        close_codes: list[int | None] | None = None,
+        initial_frames: list[list[str] | None] | None = None,
+    ) -> None:
+        self.close_codes: list[int | None] = list(close_codes or [])
+        self.initial_frames: list[list[str] | None] = list(
+            initial_frames or [],
+        )
+        self.connection_count = 0
+        self.received: list[str] = []
+        self.connections_received: list[list[str]] = []
+        # Per-connection observed request headers for assertions.
+        self.connection_headers: list[dict[str, str]] = []
+        # Lifecycle event: connection-opened. Tests await this to know
+        # the handshake completed server-side.
+        self.connection_opened_count = 0
+
+    async def handler(self, ws) -> None:
+        self.connection_count += 1
+        self.connection_opened_count += 1
+        # Capture this connection's request headers.
+        try:
+            self.connection_headers.append(dict(ws.request.headers))
+        except AttributeError:
+            self.connection_headers.append({})
+        per_conn: list[str] = []
+        self.connections_received.append(per_conn)
+
+        # Send any initial frames for this connection.
+        idx = self.connection_count - 1
+        if idx < len(self.initial_frames) and self.initial_frames[idx]:
+            for frame in self.initial_frames[idx]:
+                try:
+                    await ws.send(frame)
+                except (
+                    websockets.exceptions.ConnectionClosed, OSError,
+                ):
+                    return
+
+        # If a close code is scheduled for this connection, fire it.
+        if idx < len(self.close_codes) and self.close_codes[idx] is not None:
+            code = self.close_codes[idx]
+            assert code is not None  # narrow for type-checker
+            try:
+                await ws.close(code=code, reason='scripted close')
+            except (websockets.exceptions.ConnectionClosed, OSError):
+                pass
+            return
+
+        # Otherwise: receive until the client closes.
+        try:
+            async for raw in ws:
+                text = raw if isinstance(raw, str) else raw.decode('utf-8')
+                self.received.append(text)
+                per_conn.append(text)
+        except (websockets.exceptions.ConnectionClosed, OSError):
+            return
+
+
+async def _start_server(
+    server: _ScriptedServer, port: int,
+):
+    return await ws_serve(server.handler, '127.0.0.1', port)
+
+
+async def _wait_for(predicate, timeout_s: float = 3.0, step_s: float = 0.02):
+    """Poll a callable until it returns truthy or timeout. Returns last value."""
+    deadline = asyncio.get_event_loop().time() + timeout_s
+    last = None
+    while asyncio.get_event_loop().time() < deadline:
+        last = predicate()
+        if last:
+            return last
+        await asyncio.sleep(step_s)
+    return last
+
+
+@pytest.mark.asyncio
+async def test_connect_then_receive_data() -> None:
+    server = _ScriptedServer(initial_frames=[['hello world']])
+    port = _free_port()
+    ws_server = await _start_server(server, port)
+    try:
+        received: list[str] = []
+        t = WebSocketTransport(
+            url=f'ws://127.0.0.1:{port}',
+            options=WebSocketTransportOptions(auto_reconnect=False),
+        )
+        t.set_on_data(received.append)
+        await t.connect()
+        assert t.is_connected_status()
+        await _wait_for(lambda: received == ['hello world'])
+        assert received == ['hello world']
+        assert t.get_state_label() == 'connected'
+        t.close()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_connect_fires_on_connect_callback() -> None:
+    server = _ScriptedServer()
+    port = _free_port()
+    ws_server = await _start_server(server, port)
+    try:
+        fired = asyncio.Event()
+        t = WebSocketTransport(
+            url=f'ws://127.0.0.1:{port}',
+            options=WebSocketTransportOptions(auto_reconnect=False),
+        )
+        t.set_on_connect(lambda: fired.set())
+        await t.connect()
+        await asyncio.wait_for(fired.wait(), timeout=2.0)
+        t.close()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_close_transitions_to_closed() -> None:
+    server = _ScriptedServer()
+    port = _free_port()
+    ws_server = await _start_server(server, port)
+    try:
+        t = WebSocketTransport(
+            url=f'ws://127.0.0.1:{port}',
+            options=WebSocketTransportOptions(auto_reconnect=False),
+        )
+        await t.connect()
+        assert t.is_connected_status()
+        t.close()
+        # close() is synchronous and finalizes state to 'closed'.
+        assert t.get_state_label() == 'closed'
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_write_sends_when_connected() -> None:
+    server = _ScriptedServer()
+    port = _free_port()
+    ws_server = await _start_server(server, port)
+    try:
+        t = WebSocketTransport(
+            url=f'ws://127.0.0.1:{port}',
+            options=WebSocketTransportOptions(auto_reconnect=False),
+        )
+        await t.connect()
+        await t.write({'type': 'control_request', 'uuid': 'u1'})
+        # The send is fire-and-forget — give the loop a tick.
+        await _wait_for(lambda: bool(server.received))
+        assert len(server.received) == 1
+        # JSON-encoded + newline.
+        assert server.received[0].endswith('\n')
+        assert '"uuid": "u1"' in server.received[0]
+        t.close()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_write_buffers_when_disconnected_replays_on_connect() -> None:
+    server = _ScriptedServer()
+    port = _free_port()
+    ws_server = await _start_server(server, port)
+    try:
+        t = WebSocketTransport(
+            url=f'ws://127.0.0.1:{port}',
+            options=WebSocketTransportOptions(auto_reconnect=False),
+        )
+        # Buffer two messages while disconnected (state='idle').
+        await t.write({'type': 'a', 'uuid': 'u1'})
+        await t.write({'type': 'b', 'uuid': 'u2'})
+        # Server has not seen anything yet.
+        assert server.received == []
+        await t.connect()
+        # Both should now arrive on the server.
+        await _wait_for(lambda: len(server.received) >= 2)
+        assert len(server.received) == 2
+        assert '"uuid": "u1"' in server.received[0]
+        assert '"uuid": "u2"' in server.received[1]
+        t.close()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+def test_replay_evicts_messages_up_to_confirmed_id() -> None:
+    """Direct unit test of ``_replay_buffered_messages`` eviction logic.
+
+    The helper is exercised from ``_handle_open_event`` with
+    ``None`` (replay-everything) today because Python doesn't yet
+    plumb the server's ``X-Last-Request-Id`` response header through.
+    But the eviction branch must work for future parity when that
+    plumbing lands.
+    """
+    sent: list[str] = []
+    t = WebSocketTransport(
+        url='ws://127.0.0.1:1',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+    )
+    # Patch _send_line to capture the replay frames without needing a
+    # real WS attached.
+    def _capture(line: str) -> bool:
+        sent.append(line)
+        return True
+    t._send_line = _capture  # type: ignore[assignment]
+    t._state = 'connected'  # type: ignore[assignment]
+    t._message_buffer.append({'type': 'a', 'uuid': 'u1'})
+    t._message_buffer.append({'type': 'b', 'uuid': 'u2'})
+    t._message_buffer.append({'type': 'c', 'uuid': 'u3'})
+
+    # Server reports it has received up through u2 → u1+u2 are evicted,
+    # only u3 should be replayed.
+    t._replay_buffered_messages('u2')
+
+    assert len(sent) == 1
+    assert '"uuid": "u3"' in sent[0]
+    # Buffer was rewritten to hold only the unconfirmed tail.
+    assert [m['uuid'] for m in t._message_buffer] == ['u3']
+
+
+def test_replay_all_when_no_confirmed_id() -> None:
+    """When ``last_id`` is None / empty, replay the entire buffer.
+
+    Matches TS Bun behavior (``replayBufferedMessages('')`` at
+    ``WebSocketTransport.ts:206``). Server-side UUID dedup is the
+    safety net against re-delivering already-processed messages.
+    """
+    sent: list[str] = []
+    t = WebSocketTransport(
+        url='ws://127.0.0.1:1',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+    )
+    def _capture(line: str) -> bool:
+        sent.append(line)
+        return True
+    t._send_line = _capture  # type: ignore[assignment]
+    t._state = 'connected'  # type: ignore[assignment]
+    t._message_buffer.append({'type': 'a', 'uuid': 'u1'})
+    t._message_buffer.append({'type': 'b', 'uuid': 'u2'})
+
+    t._replay_buffered_messages(None)
+
+    assert len(sent) == 2
+    assert '"uuid": "u1"' in sent[0]
+    assert '"uuid": "u2"' in sent[1]
+
+
+@pytest.mark.asyncio
+async def test_buffered_messages_replay_on_reconnect_after_transient_close(
+) -> None:
+    """End-to-end: buffered writes survive a transient close + replay
+    on the next successful connect.
+
+    First server connection closes with 1011 (transient); the second
+    accepts traffic. After the second open, the client should replay
+    the buffered messages — server should observe them on the second
+    connection (since they weren't sent on the first).
+    """
+    server = _ScriptedServer(close_codes=[1011, None])
+    port = _free_port()
+    ws_server = await _start_server(server, port)
+    try:
+        t = WebSocketTransport(
+            url=f'ws://127.0.0.1:{port}',
+            options=WebSocketTransportOptions(
+                auto_reconnect=True,
+                ping_tick_interval_s=999.0,
+                keepalive_interval_s=999.0,
+            ),
+        )
+        # Pre-load the buffer.
+        await t.write({'type': 'a', 'uuid': 'u1'})
+        await t.write({'type': 'b', 'uuid': 'u2'})
+
+        await t.connect()
+        # Wait for the second connection to open + accept the replay.
+        await _wait_for(
+            lambda: t.is_connected_status()
+            and len(server.connections_received) >= 2
+            and len(server.connections_received[1]) >= 2,
+            timeout_s=5.0,
+        )
+        # Both messages were observed on the second connection.
+        assert len(server.connections_received[1]) >= 2
+        joined = ''.join(server.connections_received[1])
+        assert '"uuid": "u1"' in joined
+        assert '"uuid": "u2"' in joined
+        t.close()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_permanent_close_4001_no_reconnect() -> None:
+    server = _ScriptedServer(close_codes=[4001])
+    port = _free_port()
+    ws_server = await _start_server(server, port)
+    try:
+        on_close_codes: list[int | None] = []
+        t = WebSocketTransport(
+            url=f'ws://127.0.0.1:{port}',
+            options=WebSocketTransportOptions(auto_reconnect=True),
+        )
+        t.set_on_close(on_close_codes.append)
+        await t.connect()
+        await _wait_for(lambda: t.is_closed_status(), timeout_s=3.0)
+        # Only one connection attempt — 4001 is permanent.
+        await asyncio.sleep(0.2)  # ensure no second attempt sneaks in
+        assert server.connection_count == 1
+        assert on_close_codes == [4001]
+        assert t.is_closed_status()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_permanent_close_4003_with_refresh_headers_retries() -> None:
+    server = _ScriptedServer(close_codes=[4003, None])
+    port = _free_port()
+    ws_server = await _start_server(server, port)
+    try:
+        # On 4003, return a *new* Authorization → retry should fire.
+        fresh_count = {'n': 0}
+        def refresh() -> dict[str, str]:
+            fresh_count['n'] += 1
+            return {'Authorization': f'Bearer fresh-{fresh_count["n"]}'}
+
+        t = WebSocketTransport(
+            url=f'ws://127.0.0.1:{port}',
+            headers={'Authorization': 'Bearer initial'},
+            refresh_headers=refresh,
+            options=WebSocketTransportOptions(
+                auto_reconnect=True,
+                ping_tick_interval_s=999.0,
+                keepalive_interval_s=999.0,
+            ),
+        )
+        await t.connect()
+        await _wait_for(
+            lambda: server.connection_count >= 2, timeout_s=5.0,
+        )
+        # Second connection used the refreshed Authorization.
+        auth2 = server.connection_headers[1].get('authorization')
+        assert auth2 is not None
+        assert 'fresh-' in auth2
+        t.close()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_permanent_close_4003_no_refresh_headers_stops() -> None:
+    server = _ScriptedServer(close_codes=[4003])
+    port = _free_port()
+    ws_server = await _start_server(server, port)
+    try:
+        on_close_codes: list[int | None] = []
+        t = WebSocketTransport(
+            url=f'ws://127.0.0.1:{port}',
+            # No refresh_headers.
+            options=WebSocketTransportOptions(auto_reconnect=True),
+        )
+        t.set_on_close(on_close_codes.append)
+        await t.connect()
+        await _wait_for(lambda: t.is_closed_status(), timeout_s=3.0)
+        await asyncio.sleep(0.2)
+        assert server.connection_count == 1
+        assert on_close_codes == [4003]
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_auto_reconnect_false_goes_straight_to_closed() -> None:
+    server = _ScriptedServer(close_codes=[1011])
+    port = _free_port()
+    ws_server = await _start_server(server, port)
+    try:
+        on_close_codes: list[int | None] = []
+        t = WebSocketTransport(
+            url=f'ws://127.0.0.1:{port}',
+            options=WebSocketTransportOptions(auto_reconnect=False),
+        )
+        t.set_on_close(on_close_codes.append)
+        await t.connect()
+        await _wait_for(lambda: t.is_closed_status(), timeout_s=2.0)
+        await asyncio.sleep(0.2)
+        assert server.connection_count == 1
+        assert on_close_codes == [1011]
+        assert t.is_closed_status()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_transient_close_reconnects() -> None:
+    # First connect: server closes immediately with 1011 (transient).
+    # Second connect: server stays open.
+    server = _ScriptedServer(close_codes=[1011, None])
+    port = _free_port()
+    ws_server = await _start_server(server, port)
+    try:
+        t = WebSocketTransport(
+            url=f'ws://127.0.0.1:{port}',
+            options=WebSocketTransportOptions(
+                auto_reconnect=True,
+                ping_tick_interval_s=999.0,
+                keepalive_interval_s=999.0,
+            ),
+        )
+        # Use a very small backoff base for the test by patching the
+        # base delay so the test finishes in <2s.
+        await t.connect()
+        await _wait_for(
+            lambda: server.connection_count >= 2 and t.is_connected_status(),
+            timeout_s=5.0,
+        )
+        assert server.connection_count >= 2
+        assert t.is_connected_status()
+        t.close()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_budget_exhaustion_fires_on_close(
+    monkeypatch,
+) -> None:
+    """When cumulative reconnect time exceeds the give-up budget,
+    transition straight to ``closed`` and fire ``on_close`` once.
+
+    Direct state-machine test — primes the state to simulate several
+    prior failed attempts under the budget, then jumps monotonic past
+    the budget and fires another close. No real WS needed; tests would
+    otherwise need 10+ minutes of wall-clock time."""
+    now_ref = {'ms': 0}
+    def fake_monotonic_ms() -> int:
+        return now_ref['ms']
+    monkeypatch.setattr(wst, '_monotonic_ms', fake_monotonic_ms)
+
+    on_close_codes: list[int | None] = []
+    t = WebSocketTransport(
+        url='ws://127.0.0.1:1',  # never actually connects
+        options=WebSocketTransportOptions(
+            auto_reconnect=True,
+            ping_tick_interval_s=999.0,
+            keepalive_interval_s=999.0,
+        ),
+    )
+    t.set_on_close(on_close_codes.append)
+
+    # Prime: several attempts already accumulated under the budget,
+    # state is mid-reconnect.
+    t._reconnect_start_time_ms = 0
+    t._last_reconnect_attempt_ms = DEFAULT_RECONNECT_GIVE_UP_MS - 1000
+    t._reconnect_attempts = 5
+    t._state = 'reconnecting'  # type: ignore[assignment]
+
+    # Jump past the budget.
+    now_ref['ms'] = DEFAULT_RECONNECT_GIVE_UP_MS + 1
+
+    # Fire another close-event (transient code) — budget exhausted →
+    # state='closed', on_close fires once with the code that arrived.
+    t._handle_connection_error(close_code=1011)
+
+    assert t.is_closed_status()
+    assert on_close_codes == [1011]
+    # No reconnect task scheduled past the budget exhaustion.
+    assert t._reconnect_task is None or t._reconnect_task.done()
+
+
+@pytest.mark.asyncio
+async def test_sleep_detection_resets_reconnect_budget(monkeypatch) -> None:
+    """A 70-second gap between attempts resets reconnect_attempts to 0."""
+    now_ref = {'ms': 0}
+    def fake_monotonic_ms() -> int:
+        return now_ref['ms']
+    monkeypatch.setattr(wst, '_monotonic_ms', fake_monotonic_ms)
+
+    t = WebSocketTransport(
+        url='ws://127.0.0.1:1',  # nothing listening; we won't connect()
+        options=WebSocketTransportOptions(
+            auto_reconnect=True,
+            ping_tick_interval_s=999.0,
+            keepalive_interval_s=999.0,
+        ),
+    )
+    # Prime the state machine: simulate two prior reconnect attempts
+    # already accumulated under the original budget window.
+    t._reconnect_attempts = 2
+    t._reconnect_start_time_ms = 0
+    t._last_reconnect_attempt_ms = 0
+    # Now jump forward past the sleep-detection threshold.
+    jump_ms = SLEEP_DETECTION_THRESHOLD_MS + 10_000
+    now_ref['ms'] = jump_ms
+
+    # Stop the test before the actual reconnect coroutine tries to
+    # connect to nowhere — we just want to observe the budget reset.
+    # Cancel the reconnect task immediately after.
+    t._handle_connection_error(close_code=None)
+    if t._reconnect_task is not None:
+        t._reconnect_task.cancel()
+
+    # After the sleep-detection branch: attempts was reset to 0, then
+    # the bottom of the function bumps it to 1.
+    assert t._reconnect_attempts == 1
+    # And reconnect_start_time_ms was reset to "now".
+    assert t._reconnect_start_time_ms == jump_ms
+
+
+@pytest.mark.asyncio
+async def test_keepalive_frame_sent_periodically(monkeypatch) -> None:
+    # Force CLAUDE_CODE_REMOTE off so keepalive runs; monkeypatch
+    # restores the original value (if any) on teardown.
+    monkeypatch.delenv('CLAUDE_CODE_REMOTE', raising=False)
+    server = _ScriptedServer()
+    port = _free_port()
+    ws_server = await _start_server(server, port)
+    try:
+        t = WebSocketTransport(
+            url=f'ws://127.0.0.1:{port}',
+            options=WebSocketTransportOptions(
+                auto_reconnect=False,
+                ping_tick_interval_s=999.0,
+                keepalive_interval_s=0.1,
+            ),
+        )
+        await t.connect()
+        await _wait_for(
+            lambda: any(
+                '"type": "keep_alive"' in m for m in server.received
+            ),
+            timeout_s=2.0,
+        )
+        assert any(
+            '"type": "keep_alive"' in m for m in server.received
+        )
+        t.close()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_keepalive_skipped_when_claude_code_remote_truthy(
+    monkeypatch,
+) -> None:
+    server = _ScriptedServer()
+    port = _free_port()
+    ws_server = await _start_server(server, port)
+    try:
+        monkeypatch.setenv('CLAUDE_CODE_REMOTE', '1')
+        t = WebSocketTransport(
+            url=f'ws://127.0.0.1:{port}',
+            options=WebSocketTransportOptions(
+                auto_reconnect=False,
+                ping_tick_interval_s=999.0,
+                keepalive_interval_s=0.1,
+            ),
+        )
+        await t.connect()
+        # Wait 0.5 s — plenty for 5 keepalive intervals; none should fire.
+        await asyncio.sleep(0.5)
+        assert all(
+            '"type": "keep_alive"' not in m for m in server.received
+        )
+        t.close()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_get_state_label_transitions() -> None:
+    server = _ScriptedServer()
+    port = _free_port()
+    ws_server = await _start_server(server, port)
+    try:
+        t = WebSocketTransport(
+            url=f'ws://127.0.0.1:{port}',
+            options=WebSocketTransportOptions(auto_reconnect=False),
+        )
+        assert t.get_state_label() == 'idle'
+        await t.connect()
+        assert t.get_state_label() == 'connected'
+        t.close()
+        # close() is sync and finalizes through 'closing' → 'closed'
+        # in the same call. No 'closing' window is observable.
+        assert t.get_state_label() == 'closed'
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_double_connect_is_noop_when_connected() -> None:
+    server = _ScriptedServer()
+    port = _free_port()
+    ws_server = await _start_server(server, port)
+    try:
+        t = WebSocketTransport(
+            url=f'ws://127.0.0.1:{port}',
+            options=WebSocketTransportOptions(auto_reconnect=False),
+        )
+        await t.connect()
+        # Second connect while already connected: rejected.
+        await t.connect()
+        # Only one server-side connection.
+        assert server.connection_count == 1
+        t.close()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_close_during_reconnect_cancels_pending_attempt() -> None:
+    # Start with a closed-immediately server so the client schedules a
+    # reconnect attempt; then close() before the timer fires.
+    server = _ScriptedServer(close_codes=[1011])
+    port = _free_port()
+    ws_server = await _start_server(server, port)
+    try:
+        t = WebSocketTransport(
+            url=f'ws://127.0.0.1:{port}',
+            options=WebSocketTransportOptions(
+                auto_reconnect=True,
+                ping_tick_interval_s=999.0,
+                keepalive_interval_s=999.0,
+            ),
+        )
+        await t.connect()
+        # Wait for the first attempt to fail and a reconnect to be
+        # scheduled (state goes to 'reconnecting').
+        await _wait_for(
+            lambda: t.get_state_label() == 'reconnecting', timeout_s=3.0,
+        )
+        # Close — must cancel the pending reconnect task.
+        t.close()
+        # Wait a beat to see if the reconnect fires anyway.
+        await asyncio.sleep(0.3)
+        # Connection count is exactly 1 — no second attempt.
+        assert server.connection_count == 1
+        # close() + orphan-WS finalizer should land the transport on
+        # 'closed' (post-CRITIC fix — was previously stuck at 'closing').
+        await _wait_for(
+            lambda: t.get_state_label() == 'closed', timeout_s=1.0,
+        )
+        assert t.get_state_label() == 'closed'
+        # Reconnect task either cancelled or completed (returned early
+        # because state was 'closing').
+        if t._reconnect_task is not None:
+            assert t._reconnect_task.done() or t._reconnect_task.cancelled()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_send_failure_routes_to_handle_connection_error() -> None:
+    """Phase-14a CRITIC: when ``ws.send`` raises mid-flight, the
+    fire-and-forget task's done-callback must route to
+    ``_handle_connection_error`` so the reconnect path fires.
+
+    Without the ``add_done_callback`` wiring, send failures would
+    vanish into asyncio's 'task exception was never retrieved'
+    graveyard and the transport would silently report success.
+    """
+    class _FakeWs:
+        """Stand-in for ``websockets`` client connection. ``send`` always
+        raises ``ConnectionResetError`` — the canonical 'socket dead
+        underneath us' failure mode."""
+
+        async def send(self, _line: str) -> None:
+            raise ConnectionResetError('socket gone')
+
+        async def close(self) -> None:
+            return
+
+    on_close_codes: list[int | None] = []
+    t = WebSocketTransport(
+        url='ws://127.0.0.1:1',
+        options=WebSocketTransportOptions(
+            auto_reconnect=False,
+            ping_tick_interval_s=999.0,
+            keepalive_interval_s=999.0,
+        ),
+    )
+    t.set_on_close(on_close_codes.append)
+    # Manually wire the fake WS + flag 'connected' so _send_line proceeds.
+    t._ws = _FakeWs()  # type: ignore[assignment]
+    t._state = 'connected'  # type: ignore[assignment]
+
+    # Schedule the send. _send_line returns True (the task is queued);
+    # the failure surfaces via _on_send_done in the next loop tick.
+    assert t._send_line('{"type":"x"}\n') is True
+
+    # Yield to the loop so the send-task can run + the done-callback
+    # can fire _handle_connection_error.
+    await _wait_for(lambda: t.is_closed_status(), timeout_s=1.0)
+    assert t.is_closed_status()
+    # on_close fired once. ``close_code`` is ``None`` (send-failure path
+    # doesn't carry a close code from the WS).
+    assert on_close_codes == [None]
+
+
+@pytest.mark.asyncio
+async def test_reconnect_sends_x_last_request_id_header() -> None:
+    """Phase-14a CRITIC: when reconnecting after a buffered write,
+    the new connection's request headers must carry
+    ``X-Last-Request-Id`` set to the local last-sent UUID. This is
+    the wire-level signal to the server about how far we got, and is
+    the bedrock for replay-eviction once the server's response
+    header is plumbed through (future phase).
+    """
+    server = _ScriptedServer(close_codes=[1011, None])
+    port = _free_port()
+    ws_server = await _start_server(server, port)
+    try:
+        t = WebSocketTransport(
+            url=f'ws://127.0.0.1:{port}',
+            options=WebSocketTransportOptions(
+                auto_reconnect=True,
+                ping_tick_interval_s=999.0,
+                keepalive_interval_s=999.0,
+            ),
+        )
+        # Pre-buffer a write so _last_sent_id is set before connect.
+        await t.write({'type': 'a', 'uuid': 'u-anchor'})
+
+        await t.connect()
+        await _wait_for(
+            lambda: server.connection_count >= 2 and t.is_connected_status(),
+            timeout_s=5.0,
+        )
+        # First connection's request also carried the header (because
+        # we pre-buffered before connect).
+        assert (
+            server.connection_headers[0].get('x-last-request-id')
+            == 'u-anchor'
+        )
+        # And the reconnect attempt carried it too.
+        assert (
+            server.connection_headers[1].get('x-last-request-id')
+            == 'u-anchor'
+        )
+        t.close()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()


### PR DESCRIPTION
## Summary

The Python port of `bridge/` has full v2 (CCR-based) transport via `src/transports/sse_transport.py` + `src/transports/ccr_client.py`, but **v1 (Session-Ingress) is missing entirely** — `repl_bridge.py:840-848` currently refuses any work item whose `secret.use_code_sessions` is `False`. The v1 path needs three building blocks in dependency order: a reconnecting WS client (this phase), a serial batched POST queue (14b), and a `HybridTransport` that composes them + dispatch wiring (14c). Phase 14a delivers the first.

Ports `typescript/src/cli/transports/WebSocketTransport.ts` (800 LoC TS) to `src/transports/websocket_transport.py`.

## What's new

### `src/transports/websocket_transport.py` (new module)

**`WebSocketTransport` class** — reconnecting WS reader with replay-on-reconnect, periodic keepalive, 4003-with-refresh-headers retry path, and a wall-clock-gap suspension detector.

- **Reconnection state machine**: exponential backoff (base 1s, cap 30s, ±25% jitter), 10-min give-up budget, sleep detection (>60s gap between attempts resets the budget).
- **Permanent close codes** (1002 / 4001 / 4003) terminate immediately. Exception: 4003 retries once if `refresh_headers` returns a new `Authorization` (e.g. parent just minted a fresh session-ingress token).
- **Replay-on-reconnect**: bounded `deque(maxlen=1000)` of UUID-tagged outbound messages. On reconnect-open, replays everything (Bun-style — Python doesn't plumb the server's `X-Last-Request-Id` response header through). The eviction branch in `_replay_buffered_messages` is retained for future parity when that plumbing lands.
- **`close()`** synchronously finalizes through `'closing'` → `'closed'` (TS leaves the state at `closing` and relies on the event handler to finalize; Python finalizes here because the reader task gets cancelled and no event surfaces the transition otherwise).
- **`_send_line`** is fire-and-forget; the new `_on_send_done` callback routes `ConnectionClosed` / `OSError` into `_handle_connection_error` so send failures actually trigger reconnect instead of vanishing into asyncio's "Task exception was never retrieved" graveyard.
- **Protected hooks** (`_state`, `_ws`, `_send_line`, `_do_disconnect`) for the `HybridTransport` subclass in phase 14c.

### Python-specific simplifications vs TS

- `websockets` library handles protocol-level pings/pongs (TS manually drives `ws.ping()` because the `ws` package exposes pong events directly). A separate `_ping_tick_loop` remains for the wall-clock-gap suspension detector — that's a wall-clock concern, not a protocol-ping one.
- No Bun-vs-Node WS adapter (single `websockets` library throughout).
- `tengu_ws_transport_*` analytics events not ported (no Python analytics surface yet); preserved as `logger.info` strings with the same names so future telemetry can grep.
- Proxy / mTLS option helpers deferred — `websockets` defaults handle the common case; production deployments can add when needed.

## Non-goals (deferred to follow-up phases)

- **Phase 14b**: `SerialBatchEventUploader` port — needed by `HybridTransport`'s POST path.
- **Phase 14c**: `HybridTransport` (subclasses `WebSocketTransport` and `override`s `write` to use the POST uploader), `create_v1_repl_transport` adapter, and the dispatch wiring in `repl_bridge.py:840-848` that currently refuses v1 work items.
- **Session-activity callback wiring** — TS uses `registerSessionActivityCallback` to forward user-activity signals into a keep-alive write. Python has no `session_activity` module yet; the periodic 5-min keepalive still fires regardless.
- **Server-side `X-Last-Request-Id` response header** plumbing for precise replay eviction — Python `websockets` doesn't surface upgrade response headers in a stable way; the eviction branch in `_replay_buffered_messages` is kept for the future-state but unused today.

## CRITIC review

**Round 1 — REQUEST CHANGES** (1 BLOCKING + 3 MAJOR + 4 MINOR):
- BLOCKING: `_send_line` swallowed send failures silently. The `ws.send(line)` task had no `done_callback`, so `ConnectionClosed` / `OSError` from inside the task ended up in asyncio's "Task exception was never retrieved" graveyard — the reconnect path was effectively dead from send errors. Fixed by attaching `_on_send_done` and routing connection errors into `_handle_connection_error`.
- MAJOR: `_env_truthy` duplicated the canonical `src.utils.env.is_env_truthy` (different accepted values + no strip). Removed local helper; imported the canonical.
- MAJOR: `close()` mid-handshake left state stuck at `'closing'` forever — the reader task was cancelled before it could fire `_handle_connection_error`. Fixed by making `close()` finalize synchronously through `'closing'` → `'closed'`.
- MAJOR: Missing test for the silent-send-failure regression. Added `test_send_failure_routes_to_handle_connection_error` (negative-mutation verified — without the BLOCKING fix, this test surfaces the original failure).
- MINOR: Deprecated `exc.code` fallback → `_ABNORMAL_CLOSURE_CODE = 1006` constant; hand-typed `KEEP_ALIVE_FRAME` → `json.dumps`; env-mutating test → `monkeypatch.setenv`; loose `'closing' | 'closed'` assertions tightened to `== 'closed'`.

**Round 2 — APPROVE** with 5 minor cleanups, all applied: unused imports removed, dead orphan-WS finalizer branch dropped (now redundant with `close()` finalize), misleading `_replay_buffered_messages` comment corrected, `_on_send_done` early-return guard for already-non-connected states, magic `70_000` test value replaced with `SLEEP_DETECTION_THRESHOLD_MS + 10_000`.

## Test plan

- [x] **698/698 transport + bridge tests pass** (was 696 at phase 13 baseline, +2 new tests beyond the original 20 from CRITIC additions)
- [x] **22 tests in `test_websocket_transport.py`** using in-process `websockets.asyncio.server.serve` per the `tests/remote/test_sessions_websocket.py:34-55` pattern, covering: connect/data/close, write buffer + replay, eviction unit tests (both with and without confirmed id), replay-after-transient-close end-to-end, permanent 4001 / 4003-refresh / 4003-no-refresh paths, `auto_reconnect=False`, transient close → reconnect, budget exhaustion (state-machine unit test with monkeypatched monotonic), sleep detection resets budget, keepalive sent / skipped when `CLAUDE_CODE_REMOTE`, state-label transitions, double-connect noop, close-during-reconnect, silent-send-failure-routes-to-reconnect, X-Last-Request-Id outbound header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)