### PR TITLE
bridge phase 14b: port SerialBatchEventUploader (v1 write-side foundation)

### DIFF
--- a/src/transports/serial_batch_event_uploader.py
+++ b/src/transports/serial_batch_event_uploader.py
@@ -1,0 +1,503 @@
+"""Serial batched POST queue with retry/backoff and backpressure.
+
+Ports ``typescript/src/cli/transports/SerialBatchEventUploader.ts``.
+
+Used by ``HybridTransport`` (phase 14c) for the v1 POST writes, and
+by ``CCRClient`` in TS for v2 — the Python v2 transport
+(``src/transports/ccr_client.py``) currently has its own ad-hoc queue
+that may be migrated to this uploader in a future cleanup.
+
+Design overview
+---------------
+
+The class is a single-producer-single-consumer queue with serialized
+upload semantics:
+
+* ``enqueue(events)`` adds items to a pending buffer. Returns
+  immediately when there's space; awaits when the buffer would
+  exceed ``max_queue_size`` (backpressure).
+* A single drain task is in flight at any time — guarded by
+  ``_draining``. It pulls batches off the pending head (up to
+  ``max_batch_size`` items, optionally capped by
+  ``max_batch_bytes``), calls ``config.send(batch)``, and on success
+  releases backpressure waiters.
+* On send failure: the batch is re-queued at the front and the
+  drain sleeps for ``_retry_delay(failures, retry_after_ms)``
+  before the next attempt. ``RetryableError`` carries a
+  server-supplied ``retry_after_ms`` that overrides the exponential
+  schedule for that attempt (clamped to ``[base, max]`` + jitter to
+  prevent thundering herd).
+* When ``max_consecutive_failures`` is set and reached for a single
+  batch: drop the batch, fire ``on_batch_dropped``, increment
+  ``dropped_batch_count``, and advance to the next pending item with
+  a fresh failure budget.
+* ``flush()`` resolves immediately when the queue is empty and not
+  draining; otherwise blocks until the drain settles.
+* ``close()`` drops the pending queue, releases all waiters
+  (backpressure + flush), and short-circuits any in-flight backoff
+  sleep so the drain can exit promptly. It is sync — callers wanting
+  to await pending completion should ``await flush()`` first.
+
+Python-specific notes vs TS
+---------------------------
+
+* TS Promise-based waiters → ``asyncio.Future`` lists.
+* TS ``setTimeout`` for the backoff sleep → ``asyncio.wait_for`` on
+  a close-event so close() can interrupt the sleep.
+* TS ``Buffer.byteLength(jsonStringify(item))`` → ``len(json.dumps(item).encode('utf-8'))``.
+* TS lets ``JSON.stringify`` raise on un-serializable items
+  (BigInt, circular refs, throwing toJSON); Python's ``json.dumps``
+  raises ``TypeError`` / ``ValueError``. Same handling: drop the
+  poison item in place inside ``_take_batch``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import random
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+logger = logging.getLogger(__name__)
+
+
+T = TypeVar('T')
+
+
+class RetryableError(Exception):
+    """Raise from ``config.send`` to wait a server-supplied duration.
+
+    Mirrors TS ``RetryableError``. ``retry_after_ms`` is clamped to
+    ``[base_delay_ms, max_delay_ms]`` and a uniform jitter is added
+    so the client neither hot-loops nor stalls, and many sessions
+    sharing a rate limit don't all pounce at the same instant.
+    Without ``retry_after_ms``, behaves like any other thrown error
+    (exponential backoff).
+    """
+
+    def __init__(
+        self, message: str, retry_after_ms: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.retry_after_ms = retry_after_ms
+
+
+@dataclass(frozen=True)
+class SerialBatchEventUploaderConfig(Generic[T]):
+    """Construction-time configuration for ``SerialBatchEventUploader``.
+
+    Mirrors TS ``SerialBatchEventUploaderConfig``.
+    """
+
+    #: Max items per POST. ``1`` = no batching.
+    max_batch_size: int
+    #: Max pending items before ``enqueue`` awaits.
+    max_queue_size: int
+    #: The actual HTTP call. Caller controls payload format. Must
+    #: raise on transient failures so the uploader retries; return
+    #: cleanly on success.
+    send: Callable[[list[T]], Awaitable[None]]
+    #: Base delay for exponential backoff (ms).
+    base_delay_ms: float
+    #: Max delay cap (ms).
+    max_delay_ms: float
+    #: Random jitter range added to retry delay (uniform [0, jitter_ms)).
+    jitter_ms: float
+    #: Max serialized bytes per POST. First item always goes alone
+    #: regardless of size; subsequent items only if cumulative JSON
+    #: bytes stay under this. ``None`` = no byte limit.
+    max_batch_bytes: int | None = None
+    #: After this many consecutive ``send`` failures, drop the batch
+    #: and move on. ``None`` = retry indefinitely.
+    max_consecutive_failures: int | None = None
+    #: Called when a batch is dropped via ``max_consecutive_failures``.
+    on_batch_dropped: Callable[[int, int], None] | None = None
+
+    def __post_init__(self) -> None:
+        # Footgun prevention. TS doesn't validate, but a zero
+        # max_batch_size would loop forever (take_batch returns []
+        # → drain `if not batch: continue` → infinite loop) and a
+        # zero max_queue_size blocks every enqueue forever.
+        if self.max_batch_size < 1:
+            raise ValueError(
+                f'max_batch_size must be >= 1 (got {self.max_batch_size})',
+            )
+        if self.max_queue_size < 1:
+            raise ValueError(
+                f'max_queue_size must be >= 1 (got {self.max_queue_size})',
+            )
+        if self.base_delay_ms < 0:
+            raise ValueError(
+                f'base_delay_ms must be >= 0 (got {self.base_delay_ms})',
+            )
+        if self.max_delay_ms < self.base_delay_ms:
+            raise ValueError(
+                f'max_delay_ms ({self.max_delay_ms}) must be >= '
+                f'base_delay_ms ({self.base_delay_ms})',
+            )
+        if self.jitter_ms < 0:
+            raise ValueError(
+                f'jitter_ms must be >= 0 (got {self.jitter_ms})',
+            )
+        if (
+            self.max_batch_bytes is not None
+            and self.max_batch_bytes < 1
+        ):
+            raise ValueError(
+                f'max_batch_bytes (when set) must be >= 1 '
+                f'(got {self.max_batch_bytes})',
+            )
+        if (
+            self.max_consecutive_failures is not None
+            and self.max_consecutive_failures < 1
+        ):
+            raise ValueError(
+                f'max_consecutive_failures (when set) must be >= 1 '
+                f'(got {self.max_consecutive_failures})',
+            )
+
+
+class SerialBatchEventUploader(Generic[T]):
+    """Serial batched POST queue with retry/backoff/backpressure.
+
+    See module docstring for design overview.
+
+    Lifecycle::
+
+        config = SerialBatchEventUploaderConfig(
+            max_batch_size=50,
+            max_queue_size=1000,
+            send=my_send_fn,
+            base_delay_ms=500.0,
+            max_delay_ms=8000.0,
+            jitter_ms=1000.0,
+        )
+        uploader = SerialBatchEventUploader(config)
+        await uploader.enqueue(event)
+        await uploader.enqueue([event1, event2])
+        await uploader.flush()   # block until drain settles
+        uploader.close()         # drop pending, release waiters
+    """
+
+    def __init__(self, config: SerialBatchEventUploaderConfig[T]) -> None:
+        self._config = config
+        self._pending: list[T] = []
+        self._pending_at_close = 0
+        self._draining = False
+        self._closed = False
+        self._backpressure_waiters: list[asyncio.Future[None]] = []
+        self._flush_waiters: list[asyncio.Future[None]] = []
+        self._dropped_batches = 0
+        # Set by ``close()``; consulted by ``_sleep`` to short-circuit
+        # an in-flight backoff sleep so the drain can exit promptly.
+        self._close_event = asyncio.Event()
+        self._drain_task: asyncio.Task[None] | None = None
+
+    # ─── Public read-only state ──────────────────────────────────────
+
+    @property
+    def dropped_batch_count(self) -> int:
+        """Monotonic count of batches dropped via
+        ``max_consecutive_failures``. Callers snapshot before
+        ``flush()`` and compare after to detect silent drops —
+        ``flush()`` resolves normally even when batches were dropped.
+        """
+        return self._dropped_batches
+
+    @property
+    def pending_count(self) -> int:
+        """Pending queue depth. After ``close()``, returns the count
+        at close time — ``close()`` clears the queue but shutdown
+        diagnostics may want to read this after.
+        """
+        return self._pending_at_close if self._closed else len(self._pending)
+
+    # ─── Public lifecycle ────────────────────────────────────────────
+
+    async def enqueue(self, events: T | list[T]) -> None:
+        """Add events to the pending buffer.
+
+        Returns immediately when there's space; awaits if the buffer
+        would exceed ``max_queue_size`` (backpressure). No-op when
+        the uploader is closed.
+
+        Accepts a single item or a list — matches TS ``enqueue``.
+        Note: caller can't distinguish a list-valued ``T`` from a
+        list of ``T``; mirror TS and treat any ``list`` as a batch.
+        """
+        if self._closed:
+            return
+        items: list[T] = (
+            events if isinstance(events, list) else [events]  # type: ignore[list-item]
+        )
+        if not items:
+            return
+
+        # Backpressure: wait until there's space. Loop because multiple
+        # waiters released at once may collectively still exceed capacity.
+        while (
+            len(self._pending) + len(items) > self._config.max_queue_size
+            and not self._closed
+        ):
+            fut: asyncio.Future[None] = (
+                asyncio.get_running_loop().create_future()
+            )
+            self._backpressure_waiters.append(fut)
+            try:
+                await fut
+            except asyncio.CancelledError:
+                # Best-effort: remove from list so a later release
+                # doesn't try to set a cancelled future. Cancellation
+                # propagates per asyncio convention.
+                if fut in self._backpressure_waiters:
+                    self._backpressure_waiters.remove(fut)
+                raise
+
+        if self._closed:
+            return
+        self._pending.extend(items)
+        self._kick_drain()
+
+    async def flush(self) -> None:
+        """Block until pending is empty.
+
+        Returns immediately when the queue is empty and not draining.
+        Used at turn boundaries and graceful shutdown.
+
+        **Note**: if ``max_consecutive_failures`` is ``None`` (default —
+        retry indefinitely) and the upstream is failing persistently,
+        ``flush()`` will not return until ``close()`` is called.
+        Callers wanting a bounded flush should set
+        ``max_consecutive_failures`` or wrap the call in
+        ``asyncio.wait_for``.
+        """
+        if not self._pending and not self._draining:
+            return
+        self._kick_drain()
+        fut: asyncio.Future[None] = (
+            asyncio.get_running_loop().create_future()
+        )
+        self._flush_waiters.append(fut)
+        await fut
+
+    def close(self) -> None:
+        """Drop pending events and stop processing. Sync.
+
+        Resolves any blocked ``enqueue()`` and ``flush()`` callers.
+        Short-circuits any in-flight backoff sleep via the close-event.
+        Idempotent — second call is a no-op.
+
+        Callers wanting to await pending completion should
+        ``await flush()`` *before* ``close()``; this method drops
+        whatever's still pending.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        self._pending_at_close = len(self._pending)
+        self._pending = []
+        self._close_event.set()
+        for fut in self._backpressure_waiters:
+            if not fut.done():
+                fut.set_result(None)
+        self._backpressure_waiters = []
+        for fut in self._flush_waiters:
+            if not fut.done():
+                fut.set_result(None)
+        self._flush_waiters = []
+
+    # ─── Internal ────────────────────────────────────────────────────
+
+    def _kick_drain(self) -> None:
+        """Schedule a drain task if not already running.
+
+        Singleflight via ``_draining`` and ``_drain_task.done()`` —
+        a re-entrant kick is a no-op. The drain task fires the
+        actual ``_drain`` coroutine which loops over pending until
+        empty or close.
+        """
+        if self._draining or self._closed:
+            return
+        if self._drain_task is not None and not self._drain_task.done():
+            return
+        loop = asyncio.get_running_loop()
+        self._drain_task = loop.create_task(
+            self._drain(), name='serial-batch-uploader-drain',
+        )
+
+    async def _drain(self) -> None:
+        """Drain loop. Mirrors TS ``drain()``.
+
+        At most one instance runs at a time (guarded by
+        ``_draining``). Sends batches serially. On failure, sleeps
+        ``_retry_delay`` and retries; on success, releases backpressure.
+        On exit (pending empty or closed), resolves any flush waiters.
+        """
+        if self._draining or self._closed:
+            return
+        self._draining = True
+        failures = 0
+        try:
+            while self._pending and not self._closed:
+                batch = self._take_batch()
+                if not batch:
+                    continue
+
+                try:
+                    await self._config.send(batch)
+                    failures = 0
+                except asyncio.CancelledError:
+                    raise
+                except Exception as err:  # noqa: BLE001
+                    failures += 1
+                    if (
+                        self._config.max_consecutive_failures is not None
+                        and failures
+                        >= self._config.max_consecutive_failures
+                    ):
+                        self._dropped_batches += 1
+                        cb = self._config.on_batch_dropped
+                        if cb is not None:
+                            try:
+                                cb(len(batch), failures)
+                            except Exception as cb_err:  # noqa: BLE001
+                                logger.warning(
+                                    '[batch-uploader] on_batch_dropped '
+                                    'raised: %s', cb_err,
+                                )
+                        failures = 0
+                        # Free any backpressure waiters even though
+                        # the batch was dropped — we made room.
+                        self._release_backpressure()
+                        continue
+                    # Re-queue the failed batch at the front. ``batch +
+                    # pending`` allocates once; ``unshift`` equivalents
+                    # would re-index every pending item batch-size times.
+                    self._pending = batch + self._pending
+                    retry_after_ms = (
+                        err.retry_after_ms
+                        if isinstance(err, RetryableError) else None
+                    )
+                    await self._sleep(
+                        self._retry_delay(failures, retry_after_ms),
+                    )
+                    continue
+
+                # Success: release backpressure waiters if space opened up.
+                self._release_backpressure()
+        finally:
+            self._draining = False
+            # Pending empty (whether by success drain or close)?
+            # Resolve all flush waiters.
+            if not self._pending:
+                for fut in self._flush_waiters:
+                    if not fut.done():
+                        fut.set_result(None)
+                self._flush_waiters = []
+
+    def _take_batch(self) -> list[T]:
+        """Pull the next batch from pending head.
+
+        Respects both ``max_batch_size`` and (when set)
+        ``max_batch_bytes``. First item always goes in regardless of
+        size; subsequent items only if cumulative JSON bytes stay
+        under ``max_batch_bytes``.
+
+        Un-serializable items (sets, objects without a JSON encoder,
+        circular refs — anything ``json.dumps`` raises on) are dropped
+        in place — leaving them at ``pending[0]`` would poison the
+        queue and hang ``flush()`` forever.
+
+        **Note**: the count-only path (``max_batch_bytes is None``)
+        does NOT screen items via ``json.dumps``. Callers using
+        count-only mode must either ensure items are JSON-serializable
+        themselves or set ``max_consecutive_failures`` so a poison
+        batch can be bounded.
+        """
+        max_batch_size = self._config.max_batch_size
+        max_batch_bytes = self._config.max_batch_bytes
+        if max_batch_bytes is None:
+            batch = self._pending[:max_batch_size]
+            del self._pending[:max_batch_size]
+            return batch
+        # Byte-limited path. Iterate from index 0; un-serializable items
+        # are deleted in place (index doesn't advance for the deletion).
+        total_bytes = 0
+        count = 0
+        i = 0
+        while i < len(self._pending) and count < max_batch_size:
+            try:
+                item_bytes = len(
+                    json.dumps(self._pending[i]).encode('utf-8'),
+                )
+            except (TypeError, ValueError) as exc:
+                logger.warning(
+                    '[batch-uploader] dropping un-serializable item '
+                    'at index %d: %s', i, exc,
+                )
+                del self._pending[i]
+                continue
+            # First item always taken; subsequent only if it fits.
+            if count > 0 and total_bytes + item_bytes > max_batch_bytes:
+                break
+            total_bytes += item_bytes
+            count += 1
+            i += 1
+        batch = self._pending[:count]
+        del self._pending[:count]
+        return batch
+
+    def _retry_delay(
+        self, failures: int, retry_after_ms: float | None,
+    ) -> float:
+        """Compute the next retry delay in ms.
+
+        ``retry_after_ms`` path: clamp to ``[base, max]`` + uniform
+        jitter ``[0, jitter_ms)``. Without ``retry_after_ms``:
+        exponential ``min(base * 2^(failures-1), max) + jitter``.
+        """
+        jitter = random.random() * self._config.jitter_ms
+        if retry_after_ms is not None:
+            clamped = max(
+                self._config.base_delay_ms,
+                min(retry_after_ms, self._config.max_delay_ms),
+            )
+            return clamped + jitter
+        exponential = min(
+            self._config.base_delay_ms * (2 ** (failures - 1)),
+            self._config.max_delay_ms,
+        )
+        return exponential + jitter
+
+    def _release_backpressure(self) -> None:
+        """Resolve all pending backpressure waiters."""
+        waiters = self._backpressure_waiters
+        self._backpressure_waiters = []
+        for fut in waiters:
+            if not fut.done():
+                fut.set_result(None)
+
+    async def _sleep(self, ms: float) -> None:
+        """Sleep for ``ms`` milliseconds; short-circuited by ``close()``.
+
+        Returns normally on timeout (sleep completed) or early when
+        ``_close_event`` is set (close fired). The drain loop's
+        ``while ... and not self._closed`` check handles the
+        post-sleep exit.
+        """
+        try:
+            await asyncio.wait_for(
+                self._close_event.wait(), timeout=ms / 1000.0,
+            )
+        except asyncio.TimeoutError:
+            return
+
+
+__all__ = [
+    'RetryableError',
+    'SerialBatchEventUploader',
+    'SerialBatchEventUploaderConfig',
+]

--- a/tests/transports/test_serial_batch_event_uploader.py
+++ b/tests/transports/test_serial_batch_event_uploader.py
@@ -1,0 +1,718 @@
+"""Tests for ``src.transports.serial_batch_event_uploader``.
+
+Strategy
+--------
+No external infrastructure — tests inject an async ``send`` callable
+via the config that captures batches and can be made to raise.
+
+Timing-dependent tests measure elapsed time via ``time.monotonic``
+or use very short delays (~10ms) so the test runs in a reasonable
+budget without monkeypatching the event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+from src.transports.serial_batch_event_uploader import (
+    RetryableError,
+    SerialBatchEventUploader,
+    SerialBatchEventUploaderConfig,
+)
+
+
+def _make_config(
+    send,
+    *,
+    max_batch_size: int = 10,
+    max_queue_size: int = 100,
+    base_delay_ms: float = 10.0,
+    max_delay_ms: float = 100.0,
+    jitter_ms: float = 5.0,
+    max_batch_bytes: int | None = None,
+    max_consecutive_failures: int | None = None,
+    on_batch_dropped=None,
+) -> SerialBatchEventUploaderConfig[dict[str, Any]]:
+    """Helper — small delays so test budgets stay tight."""
+    return SerialBatchEventUploaderConfig(
+        max_batch_size=max_batch_size,
+        max_queue_size=max_queue_size,
+        send=send,
+        base_delay_ms=base_delay_ms,
+        max_delay_ms=max_delay_ms,
+        jitter_ms=jitter_ms,
+        max_batch_bytes=max_batch_bytes,
+        max_consecutive_failures=max_consecutive_failures,
+        on_batch_dropped=on_batch_dropped,
+    )
+
+
+async def _wait_for(predicate, timeout_s: float = 2.0, step_s: float = 0.005):
+    """Poll a callable until truthy or timeout."""
+    deadline = time.monotonic() + timeout_s
+    last = None
+    while time.monotonic() < deadline:
+        last = predicate()
+        if last:
+            return last
+        await asyncio.sleep(step_s)
+    return last
+
+
+# ── Enqueue + batching ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enqueue_single_item_sends() -> None:
+    sent: list[list[dict[str, Any]]] = []
+
+    async def send(batch):
+        sent.append(batch)
+
+    u = SerialBatchEventUploader(_make_config(send))
+    await u.enqueue({'id': 1})
+    await u.flush()
+    assert sent == [[{'id': 1}]]
+
+
+@pytest.mark.asyncio
+async def test_enqueue_batches_up_to_max_batch_size() -> None:
+    sent: list[list[dict[str, Any]]] = []
+    # Use an event to gate the first send so subsequent enqueues
+    # pile up in pending before drain proceeds.
+    gate = asyncio.Event()
+
+    async def send(batch):
+        await gate.wait()
+        sent.append(batch)
+
+    u = SerialBatchEventUploader(_make_config(send, max_batch_size=3))
+    # Enqueue 10 items individually — first send is blocked on gate,
+    # so items 2-10 accumulate in pending.
+    for i in range(10):
+        await u.enqueue({'id': i})
+    # Now release the gate and let the drain work through.
+    gate.set()
+    await u.flush()
+    # 10 items, max_batch_size=3 → 4 send calls (3+3+3+1)
+    assert len(sent) == 4
+    assert [len(b) for b in sent] == [3, 3, 3, 1]
+    # All items present, in order.
+    assert [m['id'] for batch in sent for m in batch] == list(range(10))
+
+
+@pytest.mark.asyncio
+async def test_enqueue_respects_max_batch_bytes() -> None:
+    """First item always goes in regardless of size; subsequent items
+    only if cumulative JSON bytes stay under max_batch_bytes."""
+    sent: list[list[dict[str, Any]]] = []
+    gate = asyncio.Event()
+
+    async def send(batch):
+        await gate.wait()
+        sent.append(batch)
+
+    # Each item serializes to about 16 bytes ({"id": N}).
+    # max_batch_bytes=50 → about 2-3 items per batch.
+    u = SerialBatchEventUploader(_make_config(
+        send, max_batch_size=10, max_batch_bytes=50,
+    ))
+    for i in range(6):
+        await u.enqueue({'id': i})
+    gate.set()
+    await u.flush()
+    # All 6 items dispatched, but in multiple batches under the byte cap.
+    assert sum(len(b) for b in sent) == 6
+    assert len(sent) >= 2, 'byte limit should split into multiple batches'
+    for batch in sent:
+        # Verify each batch's serialized size respects the rule —
+        # either it's a single item (always allowed) or its serialized
+        # bytes are within the cap.
+        import json
+        total = sum(len(json.dumps(m).encode('utf-8')) for m in batch)
+        assert len(batch) == 1 or total <= 50
+
+
+@pytest.mark.asyncio
+async def test_enqueue_first_item_alone_when_larger_than_max_bytes() -> None:
+    """Phase-14b CRITIC: explicit test for the "first item always goes
+    alone if it would otherwise exceed max_batch_bytes" branch. Pack
+    a 200-byte first item followed by tiny items into a 50-byte cap;
+    the first item dispatches alone in its own batch."""
+    sent: list[list[dict[str, Any]]] = []
+    gate = asyncio.Event()
+
+    async def send(batch):
+        await gate.wait()
+        sent.append(batch)
+
+    u = SerialBatchEventUploader(_make_config(
+        send, max_batch_size=10, max_batch_bytes=50,
+    ))
+    # ~200-byte payload — much larger than the 50-byte cap.
+    big = {'payload': 'x' * 200}
+    await u.enqueue([big, {'id': 'small-1'}, {'id': 'small-2'}])
+    gate.set()
+    await u.flush()
+    # First batch is the big item alone.
+    assert sent[0] == [big]
+    # Small items follow in a subsequent batch.
+    assert sum(len(b) for b in sent[1:]) == 2
+
+
+@pytest.mark.asyncio
+async def test_enqueue_drops_unserializable_items_in_place() -> None:
+    """A poison item (e.g. set, lambda) at the head of the queue is
+    dropped during ``_take_batch`` instead of poisoning subsequent
+    flush calls. Only requires max_batch_bytes to be set (which
+    triggers the byte-limited path that calls json.dumps)."""
+    sent: list[list[Any]] = []
+
+    async def send(batch):
+        sent.append(batch)
+
+    u = SerialBatchEventUploader(_make_config(
+        send, max_batch_size=10, max_batch_bytes=1000,
+    ))
+    # The set() item raises TypeError on json.dumps; should be dropped.
+    poison: Any = {1, 2, 3}
+    await u.enqueue([{'id': 1}, poison, {'id': 2}])
+    await u.flush()
+    # Poison item dropped — sent batches contain only the two dicts.
+    flat = [m for batch in sent for m in batch]
+    assert len(flat) == 2
+    assert all('id' in m for m in flat)
+
+
+@pytest.mark.asyncio
+async def test_enqueue_accepts_array_or_single() -> None:
+    sent: list[list[dict[str, Any]]] = []
+    gate = asyncio.Event()
+
+    async def send(batch):
+        await gate.wait()
+        sent.append(batch)
+
+    u = SerialBatchEventUploader(_make_config(send, max_batch_size=10))
+    await u.enqueue({'id': 1})            # single
+    await u.enqueue([{'id': 2}, {'id': 3}])  # list
+    gate.set()
+    await u.flush()
+    flat = [m for batch in sent for m in batch]
+    assert [m['id'] for m in flat] == [1, 2, 3]
+
+
+# ── Backpressure ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enqueue_blocks_when_max_queue_size_exceeded() -> None:
+    gate = asyncio.Event()
+    sent: list[list[dict[str, Any]]] = []
+
+    async def send(batch):
+        await gate.wait()
+        sent.append(batch)
+
+    u = SerialBatchEventUploader(_make_config(
+        send, max_batch_size=1, max_queue_size=1,
+    ))
+    # enqueue {1}: 0+1<=1, pending=[{1}], kick drain.
+    await u.enqueue({'id': 1})
+    # Yield so drain can run, take [{1}], and block on the gate.
+    # After this, pending=[].
+    await asyncio.sleep(0.02)
+    # enqueue {2}: 0+1<=1, pending=[{2}] (queue at capacity now).
+    await u.enqueue({'id': 2})
+    # enqueue {3}: 1+1>1 → blocks until drain frees space.
+    third_done = asyncio.Event()
+
+    async def third():
+        await u.enqueue({'id': 3})
+        third_done.set()
+
+    third_task = asyncio.create_task(third())
+    # Yield — third should still be waiting under backpressure (drain
+    # is blocked on gate so pending stays at 1).
+    await asyncio.sleep(0.05)
+    assert not third_done.is_set(), (
+        'third enqueue must block under backpressure'
+    )
+    # Release the gate so drain can consume → backpressure releases.
+    gate.set()
+    await asyncio.wait_for(third_done.wait(), timeout=1.0)
+    await u.flush()
+    await third_task
+    flat = [m['id'] for batch in sent for m in batch]
+    assert flat == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_enqueue_after_drain_releases_multiple_waiters() -> None:
+    """Multiple blocked enqueues all eventually wake + complete after
+    drain processes pending. Each new waiter may still re-block once
+    while the next pending item drains, so this is a "stress" check
+    of the release loop, not a single-cycle assertion."""
+    gate = asyncio.Event()
+    sent: list[list[dict[str, Any]]] = []
+
+    async def send(batch):
+        await gate.wait()
+        sent.append(batch)
+
+    u = SerialBatchEventUploader(_make_config(
+        send, max_batch_size=10, max_queue_size=1,
+    ))
+    await u.enqueue({'id': 0})   # pending=[{0}]
+    await asyncio.sleep(0.02)    # drain pops {0}, blocks on gate
+    await u.enqueue({'id': 1})   # pending=[{1}] (at capacity)
+    completed: list[int] = []
+
+    async def add(i: int):
+        await u.enqueue({'id': i})
+        completed.append(i)
+
+    waiters = [asyncio.create_task(add(i)) for i in range(2, 4)]
+    await asyncio.sleep(0.05)
+    # Both 2 and 3 should be blocked (queue full at 1, drain stuck on gate).
+    assert completed == []
+    gate.set()
+    await asyncio.wait_for(asyncio.gather(*waiters), timeout=2.0)
+    assert sorted(completed) == [2, 3]
+
+
+# ── Flush ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_flush_returns_immediately_when_empty() -> None:
+    async def send(batch):
+        raise AssertionError('should not be called')
+
+    u = SerialBatchEventUploader(_make_config(send))
+    # Pending is empty, not draining — flush returns immediately.
+    start = time.monotonic()
+    await u.flush()
+    elapsed_ms = (time.monotonic() - start) * 1000
+    assert elapsed_ms < 50  # generous bound; should be near-zero
+
+
+@pytest.mark.asyncio
+async def test_flush_blocks_until_drained() -> None:
+    gate = asyncio.Event()
+    sent: list[list[dict[str, Any]]] = []
+
+    async def send(batch):
+        await gate.wait()
+        sent.append(batch)
+
+    u = SerialBatchEventUploader(_make_config(send, max_batch_size=10))
+    for i in range(5):
+        await u.enqueue({'id': i})
+    flush_done = asyncio.Event()
+
+    async def flush():
+        await u.flush()
+        flush_done.set()
+
+    flush_task = asyncio.create_task(flush())
+    await asyncio.sleep(0.05)
+    assert not flush_done.is_set()
+    gate.set()
+    await asyncio.wait_for(flush_done.wait(), timeout=1.0)
+    await flush_task
+    assert sum(len(b) for b in sent) == 5
+
+
+@pytest.mark.asyncio
+async def test_flush_during_failure_retries_resolves_after_success() -> None:
+    """Flush blocks across retry attempts; resolves when drain finally
+    succeeds and pending is empty."""
+    call_count = {'n': 0}
+
+    async def send(batch):
+        call_count['n'] += 1
+        if call_count['n'] < 3:
+            raise RuntimeError(f'transient #{call_count["n"]}')
+        # 3rd call succeeds.
+
+    u = SerialBatchEventUploader(_make_config(
+        send, base_delay_ms=5.0, max_delay_ms=20.0, jitter_ms=2.0,
+    ))
+    await u.enqueue({'id': 1})
+    # Flush awaits across the retry cycles.
+    await asyncio.wait_for(u.flush(), timeout=2.0)
+    assert call_count['n'] == 3
+
+
+# ── Retry / backoff ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_failure_retries_with_exponential_backoff() -> None:
+    """Successive failures should produce increasing delays. Measured
+    via gaps between send-call timestamps."""
+    call_times_ms: list[float] = []
+    fail_until = 4  # succeed on the 4th attempt
+
+    async def send(batch):
+        call_times_ms.append(time.monotonic() * 1000)
+        if len(call_times_ms) < fail_until:
+            raise RuntimeError('transient')
+
+    u = SerialBatchEventUploader(_make_config(
+        send,
+        base_delay_ms=20.0,
+        max_delay_ms=200.0,
+        jitter_ms=0.0,  # zero jitter for deterministic measurement
+    ))
+    await u.enqueue({'id': 1})
+    await u.flush()
+    assert len(call_times_ms) == fail_until
+    # Gap[i] = delay between attempt i and i+1.
+    gaps = [
+        call_times_ms[i+1] - call_times_ms[i]
+        for i in range(len(call_times_ms) - 1)
+    ]
+    # base=20, attempts 1/2/3 → delays 20/40/80 ms (zero jitter).
+    # Tolerate event-loop scheduling slop.
+    assert gaps[0] >= 15.0, f'first retry gap too short: {gaps[0]}ms'
+    assert gaps[1] >= 35.0, f'second retry gap too short: {gaps[1]}ms'
+    assert gaps[2] >= 75.0, f'third retry gap too short: {gaps[2]}ms'
+    # And monotonically non-decreasing (within scheduling noise).
+    assert gaps[1] > gaps[0] - 10
+    assert gaps[2] > gaps[1] - 10
+
+
+@pytest.mark.asyncio
+async def test_failure_retries_indefinitely_without_max_consecutive() -> None:
+    """Without max_consecutive_failures, the uploader retries forever
+    until close()."""
+    call_count = {'n': 0}
+
+    async def send(batch):
+        call_count['n'] += 1
+        raise RuntimeError('always fails')
+
+    u = SerialBatchEventUploader(_make_config(
+        send, base_delay_ms=5.0, max_delay_ms=10.0, jitter_ms=0.0,
+    ))
+    await u.enqueue({'id': 1})
+    # Wait for several retry cycles.
+    await asyncio.sleep(0.1)
+    early_count = call_count['n']
+    assert early_count >= 3, (
+        'expected several retries within 100ms with 5ms base delay'
+    )
+    # Close stops the retry loop.
+    u.close()
+    await asyncio.sleep(0.05)
+    final_count = call_count['n']
+    # After close, no more sends should fire — allow ≤1 for an in-flight
+    # call that started before close was observed.
+    assert final_count - early_count <= 1
+
+
+@pytest.mark.asyncio
+async def test_max_consecutive_failures_drops_batch_and_advances() -> None:
+    """After max_consecutive_failures fails for the same batch, drop
+    it, increment dropped_batch_count, and advance to the next item."""
+    sent: list[list[dict[str, Any]]] = []
+    fail_count = {'n': 0}
+    fail_for_first = True
+
+    async def send(batch):
+        # Only the FIRST batch fails — once it's dropped, subsequent
+        # batches succeed cleanly.
+        if fail_for_first and batch and batch[0].get('id') == 'poison':
+            fail_count['n'] += 1
+            raise RuntimeError(f'fail #{fail_count["n"]}')
+        sent.append(batch)
+
+    u = SerialBatchEventUploader(_make_config(
+        send,
+        max_batch_size=1,
+        base_delay_ms=2.0,
+        max_delay_ms=5.0,
+        jitter_ms=0.0,
+        max_consecutive_failures=3,
+    ))
+    # Poison item that always fails, followed by a normal item.
+    await u.enqueue({'id': 'poison'})
+    await u.enqueue({'id': 'ok'})
+    await u.flush()
+    # Poison batch was dropped after 3 failures.
+    assert u.dropped_batch_count == 1
+    assert fail_count['n'] == 3
+    # 'ok' batch went through.
+    assert sent == [[{'id': 'ok'}]]
+
+
+@pytest.mark.asyncio
+async def test_on_batch_dropped_callback_fires() -> None:
+    dropped_calls: list[tuple[int, int]] = []
+
+    def on_batch_dropped(batch_size: int, failures: int) -> None:
+        dropped_calls.append((batch_size, failures))
+
+    async def send(batch):
+        raise RuntimeError('always')
+
+    u = SerialBatchEventUploader(_make_config(
+        send,
+        max_batch_size=2,
+        base_delay_ms=2.0,
+        max_delay_ms=5.0,
+        jitter_ms=0.0,
+        max_consecutive_failures=2,
+        on_batch_dropped=on_batch_dropped,
+    ))
+    await u.enqueue([{'id': 1}, {'id': 2}])
+    await u.flush()
+    assert dropped_calls == [(2, 2)]
+
+
+@pytest.mark.asyncio
+async def test_retryable_error_honors_retry_after_ms() -> None:
+    """RetryableError with retry_after_ms uses that delay (clamped) +
+    jitter, overriding the exponential schedule."""
+    call_times_ms: list[float] = []
+
+    async def send(batch):
+        call_times_ms.append(time.monotonic() * 1000)
+        if len(call_times_ms) == 1:
+            raise RetryableError('rate-limit', retry_after_ms=50.0)
+        # 2nd call succeeds.
+
+    u = SerialBatchEventUploader(_make_config(
+        send,
+        base_delay_ms=5.0,    # exponential would give ~5ms
+        max_delay_ms=100.0,
+        jitter_ms=0.0,
+    ))
+    await u.enqueue({'id': 1})
+    await u.flush()
+    assert len(call_times_ms) == 2
+    gap = call_times_ms[1] - call_times_ms[0]
+    # Server hint dominates over exponential's ~5ms.
+    assert gap >= 45.0, f'expected ~50ms gap from retry_after_ms, got {gap}ms'
+
+
+@pytest.mark.asyncio
+async def test_retryable_error_clamps_below_base_delay() -> None:
+    """retry_after_ms smaller than base_delay_ms is clamped up."""
+    call_times_ms: list[float] = []
+
+    async def send(batch):
+        call_times_ms.append(time.monotonic() * 1000)
+        if len(call_times_ms) == 1:
+            raise RetryableError('hint-too-small', retry_after_ms=1.0)
+
+    u = SerialBatchEventUploader(_make_config(
+        send,
+        base_delay_ms=30.0,   # clamp floor
+        max_delay_ms=100.0,
+        jitter_ms=0.0,
+    ))
+    await u.enqueue({'id': 1})
+    await u.flush()
+    gap = call_times_ms[1] - call_times_ms[0]
+    assert gap >= 25.0, f'expected clamp to ~30ms, got {gap}ms'
+
+
+@pytest.mark.asyncio
+async def test_retryable_error_clamps_above_max_delay() -> None:
+    """retry_after_ms larger than max_delay_ms is clamped down."""
+    call_times_ms: list[float] = []
+
+    async def send(batch):
+        call_times_ms.append(time.monotonic() * 1000)
+        if len(call_times_ms) == 1:
+            raise RetryableError('hint-too-big', retry_after_ms=999_999.0)
+
+    u = SerialBatchEventUploader(_make_config(
+        send,
+        base_delay_ms=5.0,
+        max_delay_ms=50.0,    # clamp ceiling
+        jitter_ms=0.0,
+    ))
+    await u.enqueue({'id': 1})
+    await u.flush()
+    gap = call_times_ms[1] - call_times_ms[0]
+    assert gap >= 40.0, f'expected ≥40ms, got {gap}ms'
+    assert gap < 200.0, f'expected ≤ ~max_delay_ms (with slop), got {gap}ms'
+
+
+# ── Close ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_close_drops_pending_and_pending_count_snapshots() -> None:
+    """close() drops pending; pending_count returns the snapshot."""
+    gate = asyncio.Event()
+
+    async def send(batch):
+        await gate.wait()
+
+    u = SerialBatchEventUploader(_make_config(send, max_batch_size=1))
+    for i in range(5):
+        await u.enqueue({'id': i})
+    # Yield once to let drain start and consume the first batch (it
+    # then blocks on the gate). After this, pending depth is 4.
+    await asyncio.sleep(0.02)
+    snapshot_before_close = u.pending_count
+    assert snapshot_before_close >= 4
+    u.close()
+    # After close, pending_count returns the snapshot count at close
+    # time (not 0, even though the queue was cleared).
+    assert u.pending_count == snapshot_before_close
+    # Subsequent enqueue is a no-op.
+    await u.enqueue({'id': 'late'})
+    assert u.pending_count == snapshot_before_close
+    gate.set()
+    # Release the in-flight send so it can complete cleanly.
+    await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_close_releases_blocked_backpressure_waiters() -> None:
+    gate = asyncio.Event()
+
+    async def send(batch):
+        await gate.wait()
+
+    u = SerialBatchEventUploader(_make_config(
+        send, max_batch_size=1, max_queue_size=1,
+    ))
+    await u.enqueue({'id': 0})    # pending=[{0}]
+    await asyncio.sleep(0.02)     # drain consumes [{0}], blocks on gate
+    await u.enqueue({'id': 1})    # pending=[{1}] (at capacity)
+    waiter_done = asyncio.Event()
+
+    async def waiter():
+        # 1+1>1 → blocks until either drain frees space or close()
+        # releases the waiter.
+        await u.enqueue({'id': 2})
+        waiter_done.set()
+
+    waiter_task = asyncio.create_task(waiter())
+    await asyncio.sleep(0.05)
+    assert not waiter_done.is_set()
+    u.close()
+    # Backpressure waiter should resolve immediately after close.
+    await asyncio.wait_for(waiter_done.wait(), timeout=1.0)
+    await waiter_task
+    gate.set()
+    await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_close_releases_blocked_flush_waiters() -> None:
+    gate = asyncio.Event()
+
+    async def send(batch):
+        await gate.wait()
+
+    u = SerialBatchEventUploader(_make_config(send))
+    await u.enqueue({'id': 1})
+    flush_done = asyncio.Event()
+
+    async def flusher():
+        await u.flush()
+        flush_done.set()
+
+    flush_task = asyncio.create_task(flusher())
+    await asyncio.sleep(0.05)
+    assert not flush_done.is_set()
+    u.close()
+    # Flush waiter should resolve immediately on close.
+    await asyncio.wait_for(flush_done.wait(), timeout=1.0)
+    await flush_task
+    gate.set()
+    await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_close_during_sleep_interrupts_backoff() -> None:
+    """Drain is sleeping in a backoff cycle; close fires; drain exits
+    cleanly without waiting out the sleep."""
+    sent_count = {'n': 0}
+
+    async def send(batch):
+        sent_count['n'] += 1
+        raise RuntimeError('forever')
+
+    u = SerialBatchEventUploader(_make_config(
+        send,
+        base_delay_ms=500.0,   # long enough to test interruption
+        max_delay_ms=1000.0,
+        jitter_ms=0.0,
+    ))
+    await u.enqueue({'id': 1})
+    # Wait for the first send to fire (failure → drain enters sleep).
+    await _wait_for(lambda: sent_count['n'] >= 1, timeout_s=0.5)
+    # Now close — should interrupt the in-flight 500ms sleep.
+    start = time.monotonic()
+    u.close()
+    # Give the drain a brief tick to observe close + exit.
+    await asyncio.sleep(0.05)
+    elapsed_ms = (time.monotonic() - start) * 1000
+    # If sleep weren't interrupted, we'd need 500ms+ here.
+    assert elapsed_ms < 200, (
+        f'close should interrupt backoff sleep, but {elapsed_ms}ms elapsed'
+    )
+
+
+@pytest.mark.asyncio
+async def test_close_is_idempotent() -> None:
+    async def send(batch):
+        return
+
+    u = SerialBatchEventUploader(_make_config(send))
+    u.close()
+    u.close()  # second call is no-op
+    assert u.pending_count == 0
+
+
+# ── Misc ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dropped_batch_count_monotonic() -> None:
+    fail_first_two = {'n': 0}
+
+    async def send(batch):
+        fail_first_two['n'] += 1
+        if fail_first_two['n'] <= 4:  # 2 batches × 2 failures each
+            raise RuntimeError('fail')
+
+    u = SerialBatchEventUploader(_make_config(
+        send,
+        max_batch_size=1,
+        base_delay_ms=1.0,
+        max_delay_ms=2.0,
+        jitter_ms=0.0,
+        max_consecutive_failures=2,
+    ))
+    await u.enqueue([{'id': 'a'}, {'id': 'b'}, {'id': 'c'}])
+    await u.flush()
+    # Two batches dropped (a and b), one delivered (c).
+    assert u.dropped_batch_count == 2
+
+
+@pytest.mark.asyncio
+async def test_enqueue_empty_list_is_noop() -> None:
+    called = {'n': 0}
+
+    async def send(batch):
+        called['n'] += 1
+
+    u = SerialBatchEventUploader(_make_config(send))
+    await u.enqueue([])
+    await asyncio.sleep(0.05)
+    assert called['n'] == 0
+    assert u.pending_count == 0


### PR DESCRIPTION
## Summary

Second of three v1-transport building blocks for `HybridTransport` (phase 14c). The uploader is a **standalone primitive**: serial batched POST queue with retry/backoff, optional backpressure, and a `max_consecutive_failures` drop policy. TS uses it from both v1 (HybridTransport) and v2 (CCRClient) — keeping it separate lets phase 14c compose without reimplementing.

Faithful port of `typescript/src/cli/transports/SerialBatchEventUploader.ts` (275 LoC TS → ~500 LoC Python including the new `__post_init__` validation).

## What's new

### `src/transports/serial_batch_event_uploader.py` (new module)

- **`RetryableError`** — exception type for server-supplied delays (e.g. 429 Retry-After). `retry_after_ms` is clamped to `[base_delay_ms, max_delay_ms]` + uniform jitter so a misbehaving server can't hot-loop or stall, and many sessions sharing a rate limit don't all pounce at the same instant.
- **`SerialBatchEventUploaderConfig[T]`** — frozen dataclass with `__post_init__` validation (max_batch_size ≥ 1, max_queue_size ≥ 1, base ≤ max delay, jitter ≥ 0, etc.). Footgun prevention beyond what TS does — `max_batch_size=0` would loop drain forever in TS too.
- **`SerialBatchEventUploader[T]`** generic class:
  - `async enqueue(events: T | list[T])` — awaits when queue would exceed `max_queue_size` (backpressure).
  - `async flush()` — returns immediately when empty; otherwise blocks until drain settles. Docstring now flags that without `max_consecutive_failures` set, persistent server failure means `flush()` blocks until `close()`.
  - `close()` — sync; drops pending, releases backpressure/flush waiters, short-circuits any in-flight backoff sleep via `asyncio.Event`.
  - `@property dropped_batch_count` / `@property pending_count` — observability for shutdown diagnostics.
  - Singleflight drain via `_draining` boolean + `_drain_task` reference.
  - On failure: re-queue batch at front via `batch + pending` (single allocation, matches TS comment about avoiding unshift's O(n × batch_size) cost).
  - Backoff: `min(base * 2^(failures-1), max) + jitter` OR `retry_after_ms` (clamped + jitter) when `RetryableError`.
  - `_take_batch` byte-limit path: first item always taken regardless of size; subsequent items only if cumulative `len(json.dumps(item).encode('utf-8'))` stays under cap; un-serializable items dropped in place to avoid queue poisoning.

### Python-specific notes vs TS

- TS Promise-based waiters → `asyncio.Future` lists.
- TS `setTimeout` for backoff → `asyncio.wait_for` on a close-event (`TimeoutError` = normal sleep completion; event set = close fired).
- TS `Buffer.byteLength(jsonStringify(...))` → `len(json.dumps(...).encode('utf-8'))`.
- TS `JSON.stringify` raises on un-serializable items (BigInt, circular refs) → Python `json.dumps` raises `TypeError` / `ValueError`; same drop-in-place handling.

## Non-goals (deferred to follow-up phases)

- **Phase 14c**: `HybridTransport` subclasses `WebSocketTransport` (phase 14a) + composes with this uploader for the v1 POST path. Adds `create_v1_repl_transport` adapter + dispatch wiring in `repl_bridge.py:840-848` that currently refuses v1 work items.
- **Python `CCRClient` migration to this uploader** — TS uses it for v2 too; Python `src/transports/ccr_client.py` has its own ad-hoc queue. Migration is orthogonal cleanup, not in scope for v1 work.

## CRITIC review

**One round — APPROVE** with 8 MINOR items, no blockers. The critic verified the singleflight drain race, the backpressure waiter list management, the flush early-return condition, and the `asyncio.TimeoutError` compatibility floor. Applied:
- Docstring fix for `_take_batch` "un-hashable" wording → "sets, objects without a JSON encoder, circular refs"
- Docstring note that count-only mode (`max_batch_bytes=None`) does NOT screen items via `json.dumps`
- `flush()` docstring warning about persistent-failure semantics
- `field(default=None)` → direct default (cosmetic)
- `__post_init__` config validation (footgun prevention beyond TS)
- Explicit first-item-too-big test (the `count > 0 and ...` byte-limit branch was previously only implicitly covered)

Deferred: drain-task exception retrieval (optional polish); `T | list[T]` typing ambiguity (accepted tradeoff matching TS).

## Test plan

- [x] **723/723 transport + bridge tests pass** (was 698 at phase 14a baseline, +25 new)
- [x] **25 tests in `test_serial_batch_event_uploader.py`** grouped by behavior:
  - Enqueue + batching (6): single, batches up to max_batch_size, byte-limit splits, first-item-too-big, drops un-serializable, accepts single/list arg.
  - Backpressure (2): blocks when over capacity, multiple waiters all eventually complete.
  - Flush (3): returns immediately when empty, blocks until drained, blocks across retry-then-success cycle.
  - Retry/backoff (7): exponential gaps (zero-jitter for measurement), indefinite-without-cap (verified via several attempts then close), drop+counter, callback, RetryableError honors/clamps-below/clamps-above retry_after_ms.
  - Close (5): drops pending+snapshot, releases backpressure waiters, releases flush waiters, interrupts in-flight backoff sleep, idempotent.
  - Misc (2): dropped_batch_count monotonic across multiple drops, empty list noop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)