### PR TITLE
docs: fix misleading base64-encoded-key placeholder in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,32 +297,32 @@ The configuration file is saved in in `~/.clawcodex/config.json`. Example struct
   "default_provider": "anthropic",
   "providers": {
     "anthropic": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://api.anthropic.com",
       "default_model": "claude-sonnet-4-6"
     },
     "openai": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://api.openai.com/v1",
       "default_model": "gpt-5.4"
     },
     "glm": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://open.bigmodel.cn/api/paas/v4",
       "default_model": "zai/glm-5"
     },
     "minimax": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://api.minimaxi.com/anthropic",
       "default_model": "MiniMax-M2.7"
     },
     "openrouter": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://openrouter.ai/api/v1",
       "default_model": "deepseek/deepseek-v4-pro"
     },
     "deepseek": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://api.deepseek.com",
       "default_model": "deepseek-v4-pro"
     }

--- a/docs/i18n/README_AR.md
+++ b/docs/i18n/README_AR.md
@@ -154,17 +154,17 @@ python -m src.cli login
   "default_provider": "glm",
   "providers": {
     "anthropic": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://api.anthropic.com",
       "default_model": "claude-sonnet-4-20250514"
     },
     "openai": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://api.openai.com/v1",
       "default_model": "gpt-4"
     },
     "glm": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://open.bigmodel.cn/api/paas/v4",
       "default_model": "glm-4.5"
     }

--- a/docs/i18n/README_FR.md
+++ b/docs/i18n/README_FR.md
@@ -154,17 +154,17 @@ Le fichier de configuration est enregistré dans `~/.clawcodex/config.json`. Exe
   "default_provider": "glm",
   "providers": {
     "anthropic": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://api.anthropic.com",
       "default_model": "claude-sonnet-4-20250514"
     },
     "openai": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://api.openai.com/v1",
       "default_model": "gpt-4"
     },
     "glm": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://open.bigmodel.cn/api/paas/v4",
       "default_model": "glm-4.5"
     }

--- a/docs/i18n/README_HI.md
+++ b/docs/i18n/README_HI.md
@@ -154,17 +154,17 @@ python -m src.cli login
   "default_provider": "glm",
   "providers": {
     "anthropic": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://api.anthropic.com",
       "default_model": "claude-sonnet-4-20250514"
     },
     "openai": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://api.openai.com/v1",
       "default_model": "gpt-4"
     },
     "glm": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://open.bigmodel.cn/api/paas/v4",
       "default_model": "glm-4.5"
     }

--- a/docs/i18n/README_PT.md
+++ b/docs/i18n/README_PT.md
@@ -154,17 +154,17 @@ O arquivo de configuração é salvo em `~/.clawcodex/config.json`. Exemplo de e
   "default_provider": "glm",
   "providers": {
     "anthropic": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://api.anthropic.com",
       "default_model": "claude-sonnet-4-20250514"
     },
     "openai": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://api.openai.com/v1",
       "default_model": "gpt-4"
     },
     "glm": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://open.bigmodel.cn/api/paas/v4",
       "default_model": "glm-4.5"
     }

--- a/docs/i18n/README_RU.md
+++ b/docs/i18n/README_RU.md
@@ -154,17 +154,17 @@ python -m src.cli login
   "default_provider": "glm",
   "providers": {
     "anthropic": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://api.anthropic.com",
       "default_model": "claude-sonnet-4-20250514"
     },
     "openai": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://api.openai.com/v1",
       "default_model": "gpt-4"
     },
     "glm": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://open.bigmodel.cn/api/paas/v4",
       "default_model": "glm-4.5"
     }

--- a/docs/i18n/README_ZH.md
+++ b/docs/i18n/README_ZH.md
@@ -217,22 +217,22 @@ clawcodex login
   "default_provider": "openai",
   "providers": {
     "anthropic": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://api.anthropic.com",
       "default_model": "claude-sonnet-4-6"
     },
     "openai": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://api.openai.com/v1",
       "default_model": "gpt-5.4"
     },
     "glm": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://open.bigmodel.cn/api/paas/v4",
       "default_model": "zai/glm-5"
     },
     "minimax": {
-      "api_key": "base64-encoded-key",
+      "api_key": "your-api-key",
       "base_url": "https://api.minimaxi.com/anthropic",
       "default_model": "MiniMax-M2.7"
     }


### PR DESCRIPTION
## Summary
- The README and all 6 i18n translations showed `"api_key": "base64-encoded-key"` in the `~/.clawcodex/config.json` example, implying keys are stored base64-encoded.
- In reality, `set_api_key` in `src/config.py` writes the raw string with no encoding or encryption — same as how most CLIs (including Claude Code) document their config files.
- Replaced the placeholder with `"your-api-key"` so the example matches actual behavior. 27 instances across 7 files (main `README.md` + `docs/i18n/README_{AR,FR,HI,PT,RU,ZH}.md`).

## Test plan
- [ ] `grep -r "base64-encoded-key" .` returns no matches
- [ ] Spot-check rendered README on GitHub to confirm the JSON example still parses visually
- [ ] No code changes; nothing to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)