### PR TITLE
bridge phase 14c: HybridTransport + v1 dispatch wiring

### DIFF
--- a/src/bridge/bridge_main.py
+++ b/src/bridge/bridge_main.py
@@ -91,6 +91,7 @@ from src.bridge.types import (
 )
 from src.bridge.work_secret import (
     build_ccr_v2_sdk_url,
+    build_sdk_url,
     decode_work_secret,
 )
 from src.bridge.worktree import (
@@ -613,20 +614,25 @@ class _BridgeDaemon:
             return
         await self._safe_ack(work_id, secret.session_ingress_token)
 
-        # MVP: CCR v2 only. v1 work (use_code_sessions = False) is rejected.
+        # Phase 14c: dispatch v1 + v2 work items. v1 uses the bridge's
+        # configured ``session_ingress_url`` (NOT ``secret.api_base_url``
+        # — see TS ``bridgeMain.ts:905-907``: the secret's url may be a
+        # remote proxy/tunnel that doesn't know about locally-created
+        # sessions). v2 uses ``secret.api_base_url`` (the
+        # server-controlled CCR endpoint). The child SDK constructs
+        # its own transport from sdk_url + access_token.
         use_ccr_v2 = bool(secret.use_code_sessions)
-        if not use_ccr_v2:
-            logger.warning(
-                '[bridge:main] v1 session-ingress not supported in MVP'
+        if use_ccr_v2:
+            sdk_url = build_ccr_v2_sdk_url(secret.api_base_url, session_id)
+        else:
+            sdk_url = build_sdk_url(
+                self.config.session_ingress_url, session_id,
             )
-            await self._safe_stop_work(work_id, force=True)
-            return
-        sdk_url = build_ccr_v2_sdk_url(secret.api_base_url, session_id)
         spawn_opts: SessionSpawnOpts = {
             'session_id': session_id,
             'sdk_url': sdk_url,
             'access_token': secret.session_ingress_token,
-            'use_ccr_v2': True,
+            'use_ccr_v2': use_ccr_v2,
             'worker_epoch': 0,  # MVP: full port fetches via /worker/register
         }
         working_dir = self.config.dir

--- a/src/bridge/repl_bridge.py
+++ b/src/bridge/repl_bridge.py
@@ -11,16 +11,13 @@ refactoring plan. For autonomous porting in one session, this module
 implements the structural skeleton + single-session happy path:
 
 * Register environment → create session
-* Work-poll loop (basic, v2-only transport)
+* Work-poll loop with dual v1 (session-ingress WS) / v2 (CCR) dispatch
 * Spawn session via Phase 4 ``session_runner``
 * ``ReplBridgeHandle`` surface — write_messages / control / teardown
 * Teardown — stop_work + archive + deregister
 
 What is **explicitly deferred** (with TODOs at the call sites):
 
-* **v1 transport** (``HybridTransport`` POST writes + WS reads) — v2 is
-  the going-forward path; v1 is being deprecated server-side. Module
-  raises ``NotImplementedError`` if work secrets indicate v1 only.
 * **Perpetual mode** (crash-recovery pointer integration, env reuse via
   ``reuseEnvironmentId``). Caller must set ``perpetual=False``.
 * **Env recreation** (the Strategy-1 / Strategy-2 reconnect dance after
@@ -835,17 +832,36 @@ class _BridgeState:
         # redispatch it after the reclaim window.
         await self._safe_ack(work_id, secret.session_ingress_token)
 
-        # MVP: v2 transport only (CCR). Detect v1 (session-ingress WS)
-        # via the URL and refuse for now.
+        # Phase 14c: dispatch v1 (session-ingress WS) and v2 (CCR)
+        # work items both — the child SDK constructs its own
+        # transport from sdk_url + access_token (via env vars set
+        # in build_child_env). v1 work items used to be refused at
+        # this site; that gate is now lifted.
+        #
+        # v1 / v2 use DIFFERENT URL sources:
+        # * v2 (CCR) uses ``secret.api_base_url`` — the CCR control
+        #   plane is the server-controlled endpoint and the secret
+        #   carries the authoritative one for this work item.
+        # * v1 (session-ingress) uses ``params.session_ingress_url``
+        #   — the bridge's own configured ingress URL. Using
+        #   ``secret.api_base_url`` would break proxy/tunnel setups
+        #   where the secret's URL points to a remote that doesn't
+        #   know about locally-created sessions (TS comment at
+        #   ``bridgeMain.ts:905-907``; ``replBridge.ts:1471``).
+        #
+        # The auth split is also different: v1 session-ingress
+        # accepts OAuth or JWT; v2 CCR /worker/* requires the JWT.
+        # The Python parent always forwards the JWT (carried by
+        # ``secret.session_ingress_token``) to the child as
+        # ``CLAUDE_CODE_SESSION_ACCESS_TOKEN`` regardless of v1/v2;
+        # the child runs the appropriate transport.
         use_ccr_v2 = bool(secret.use_code_sessions)
-        if not use_ccr_v2:
-            logger.warning(
-                '[bridge:repl] v1 (session-ingress) transport not yet '
-                'implemented in Phase 6 MVP — v2 only. Stopping work.'
+        if use_ccr_v2:
+            sdk_url = build_ccr_v2_sdk_url(secret.api_base_url, session_id)
+        else:
+            sdk_url = build_sdk_url(
+                self.params.session_ingress_url, session_id,
             )
-            await self._safe_stop_work(work_id, force=True)
-            return
-        sdk_url = build_ccr_v2_sdk_url(secret.api_base_url, session_id)
         # NOTE: Phase 6 full port will fetch worker_epoch via the v2
         # /worker/register call. The MVP uses 0 as a placeholder since
         # session_runner threads it into the child's env vars only when

--- a/src/bridge/repl_bridge_transport.py
+++ b/src/bridge/repl_bridge_transport.py
@@ -3,15 +3,16 @@
 Ports the consumer-facing surface of
 ``typescript/src/bridge/replBridgeTransport.ts:23-369``.
 
-Two halves:
+Three pieces:
 
   * ``ReplBridgeTransport`` Protocol — the 14-method contract that
     ``replBridge`` writes against. v1 and v2 implementations conform.
   * ``create_v2_repl_transport`` — the v2 factory: SSE reads +
     ``CCRClient`` writes, with the epoch-mismatch handler that closes
     both transports + raises ``EpochSupersededError`` to unwind callers.
-
-The v1 factory is **not yet implemented** (out of Phase 6 scope).
+  * ``create_v1_repl_transport`` — phase 14c v1 factory: thin
+    pass-through over :class:`HybridTransport` (WS reads + POST
+    writes via ``SerialBatchEventUploader``).
 """
 
 from __future__ import annotations
@@ -28,6 +29,7 @@ from src.bridge.close_codes import (
 )
 from src.bridge.exceptions import EpochSupersededError
 from src.transports.ccr_client import CCRClient, CCRClientOptions
+from src.transports.hybrid_transport import HybridTransport
 from src.transports.sse_transport import SSEEvent, SSETransport
 
 logger = logging.getLogger(__name__)
@@ -314,11 +316,97 @@ async def create_v2_repl_transport(opts: V2TransportOptions) -> _V2ReplTransport
     return transport
 
 
-def create_v1_repl_transport(*args: Any, **kwargs: Any) -> ReplBridgeTransport:
-    """Stub. v1 is deferred to Phase 6 per the refactoring plan."""
-    raise NotImplementedError(
-        'v1 ReplBridgeTransport is deferred to Phase 6 — see ch16 refactoring plan'
-    )
+class _V1ReplTransport:
+    """v1 adapter — wraps :class:`HybridTransport` into the
+    :class:`ReplBridgeTransport` Protocol surface.
+
+    ``HybridTransport`` already has the full write/read API (it
+    extends ``WebSocketTransport``); this adapter is a thin
+    pass-through so the consumer's ``transport`` variable has a
+    single type regardless of v1/v2.
+
+    Mirrors TS ``replBridgeTransport.ts:78-103``.
+    """
+
+    def __init__(self, hybrid: 'HybridTransport') -> None:
+        self._hybrid = hybrid
+
+    async def write(self, message: dict[str, Any]) -> None:
+        await self._hybrid.write(message)
+
+    async def write_batch(self, messages: list[dict[str, Any]]) -> None:
+        await self._hybrid.write_batch(messages)
+
+    def close(self) -> None:
+        """Sync close. Inherits ``HybridTransport.close``'s drop-on-close
+        semantics for queued POSTs (grace flush is best-effort within
+        ``CLOSE_GRACE_S``). Callers wanting guaranteed delivery should
+        ``await self.flush()`` first."""
+        self._hybrid.close()
+
+    def is_connected_status(self) -> bool:
+        return self._hybrid.is_connected_status()
+
+    def get_state_label(self) -> str:
+        return self._hybrid.get_state_label()
+
+    def set_on_data(self, cb: Callable[[str], None]) -> None:
+        self._hybrid.set_on_data(cb)
+
+    def set_on_close(self, cb: Callable[[int | None], None]) -> None:
+        self._hybrid.set_on_close(cb)
+
+    def set_on_connect(self, cb: Callable[[], None]) -> None:
+        self._hybrid.set_on_connect(cb)
+
+    def connect(self) -> None:
+        """Schedule the WS connect as a background task.
+
+        ``HybridTransport.connect`` (inherited from
+        ``WebSocketTransport``) is async; the ``ReplBridgeTransport``
+        Protocol's ``connect`` is sync (fire-and-forget). Schedule the
+        coroutine and return immediately, matching the v2 factory's
+        equivalent pattern (``_V2ReplTransport.connect``).
+        """
+        loop = asyncio.get_running_loop()
+        loop.create_task(
+            self._hybrid.connect(), name='v1-repl-transport-connect',
+        )
+
+    def get_last_sequence_num(self) -> int:
+        """v1 always returns 0 — the Session-Ingress WS doesn't use
+        SSE-style sequence numbers. Mirrors TS line 94 comment."""
+        return 0
+
+    @property
+    def dropped_batch_count(self) -> int:
+        return self._hybrid.dropped_batch_count
+
+    # ─── v2-only no-ops (Protocol requires them) ─────────────────────
+
+    def report_state(self, state: dict[str, Any]) -> None:
+        return None
+
+    def report_metadata(self, metadata: dict[str, Any]) -> None:
+        return None
+
+    def report_delivery(self, event_id: str, status: str) -> None:
+        return None
+
+    async def flush(self) -> None:
+        """Drain pending POSTs. Delegates to the hybrid's flush which
+        runs the uploader's drain to completion."""
+        await self._hybrid.flush()
+
+
+def create_v1_repl_transport(hybrid: 'HybridTransport') -> ReplBridgeTransport:
+    """Build a v1 :class:`ReplBridgeTransport` from a
+    :class:`HybridTransport`.
+
+    Thin no-op adapter so ``replBridge``'s ``transport`` variable
+    has a single type. Mirrors TS ``replBridgeTransport.ts:78-103``.
+    """
+    return _V1ReplTransport(hybrid)
 
 
 __all__ = [

--- a/src/transports/hybrid_transport.py
+++ b/src/transports/hybrid_transport.py
@@ -1,0 +1,388 @@
+"""Hybrid transport — WebSocket reads + HTTP POST writes.
+
+Ports ``typescript/src/cli/transports/HybridTransport.ts``.
+
+Design overview
+---------------
+
+Subclasses :class:`WebSocketTransport` (the reconnecting WS client
+from phase 14a). The read side is fully inherited — incoming frames
+fire ``on_data`` via the parent's reader loop. The write side is
+overridden to POST through :class:`SerialBatchEventUploader`
+(phase 14b) instead of using the inherited WS ``send``.
+
+Write flow::
+
+    write(stream_event) ─┐
+                         │ (100ms timer)
+                         ▼
+    write(other) ────► uploader.enqueue()  (SerialBatchEventUploader)
+                         ▲    │
+    write_batch() ───────┘    │ serial, batched, retries with backoff,
+                              │ backpressure at max_queue_size.
+                              ▼
+                         _post_once()  (single httpx POST; raises on retryable)
+
+``stream_event`` messages accumulate in ``_stream_event_buffer`` for
+up to ``BATCH_FLUSH_INTERVAL_S`` (100ms) before being enqueued — this
+reduces POST count for high-volume content deltas. A non-stream
+write flushes any buffered stream events first to preserve order.
+
+Why serialize?
+~~~~~~~~~~~~~~
+
+Bridge mode fires writes via fire-and-forget (``loop.create_task(
+transport.write(...))``). Without serialization, concurrent POSTs to
+the same session-ingress endpoint would race in Firestore on the
+server side, producing retry storms and oncall pages.
+
+What this transport doesn't do
+------------------------------
+
+* No parent-side consumer wires this into ``repl_bridge.py`` today —
+  the Python parent only orchestrates lifecycle. The class is a
+  library primitive for future parent-side relay use and for TS
+  parity. Phase 14c's actual user-visible win is the dispatch
+  wiring at ``src/bridge/repl_bridge.py:840-848`` which builds the
+  v1 session-ingress URL and passes it to the child; the child SDK
+  constructs its own transport from the URL + access token.
+* No proxy / mTLS plumbing — ``httpx``'s defaults handle the common
+  case; production deployments can add when needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from typing import Any
+from urllib.parse import urlparse, urlunparse
+
+import httpx
+
+from src.transports.serial_batch_event_uploader import (
+    SerialBatchEventUploader,
+    SerialBatchEventUploaderConfig,
+)
+from src.transports.websocket_transport import (
+    WebSocketTransport,
+    WebSocketTransportOptions,
+)
+from src.utils.session_ingress_auth import get_session_ingress_auth_token
+
+logger = logging.getLogger(__name__)
+
+
+#: Delay before flushing accumulated ``stream_event`` messages. Mirrors
+#: TS ``BATCH_FLUSH_INTERVAL_MS``.
+BATCH_FLUSH_INTERVAL_S = 0.1
+
+#: Per-attempt POST timeout. Bounds how long a single stuck request
+#: can block the serialized queue. Mirrors TS ``POST_TIMEOUT_MS``.
+POST_TIMEOUT_S = 15.0
+
+#: Grace period for queued writes on ``close()``. Best-effort; not a
+#: delivery guarantee under degraded network. Mirrors TS ``CLOSE_GRACE_MS``.
+CLOSE_GRACE_S = 3.0
+
+# Uploader knobs — mirror TS hardcoded values in ``HybridTransport.ts:76-92``.
+# Session-ingress accepts arbitrary batch sizes; events naturally batch
+# during in-flight POSTs so ``_MAX_BATCH_SIZE`` just bounds payload size.
+# ``_MAX_QUEUE_SIZE`` is high enough to be a memory-only bound since bridge
+# callers don't await write (backpressure doesn't apply).
+_MAX_BATCH_SIZE = 500
+_MAX_QUEUE_SIZE = 100_000
+_BASE_DELAY_MS = 500.0
+_MAX_DELAY_MS = 8000.0
+_JITTER_MS = 1000.0
+
+
+class HybridTransport(WebSocketTransport):
+    """v1 transport — WS reads (inherited) + HTTP POST writes.
+
+    Use this when the work secret indicates a v1 session-ingress
+    endpoint (``use_code_sessions=False``). The CCR-v2 path uses
+    SSE + CCRClient via ``src.transports.sse_transport`` and
+    ``src.transports.ccr_client`` instead.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        headers: dict[str, str] | None = None,
+        session_id: str | None = None,
+        refresh_headers: Callable[[], dict[str, str]] | None = None,
+        options: WebSocketTransportOptions | None = None,
+        *,
+        max_consecutive_failures: int | None = None,
+        on_batch_dropped: Callable[[int, int], None] | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        super().__init__(
+            url, headers, session_id, refresh_headers, options,
+        )
+        # ``_post_url`` is derived once from the WS URL at construction.
+        # ``_url`` doesn't mutate today, but if a future refactor lets
+        # it change, callers must rebuild the transport.
+        self._post_url = _convert_ws_url_to_post_url(url)
+        # Caller-injected client (tests) takes precedence; otherwise
+        # pool a single client across all POSTs so we don't pay TLS
+        # handshake on every request — matches TS axios's default
+        # connection pooling.
+        if http_client is not None:
+            self._http_client = http_client
+            self._owns_http_client = False
+        else:
+            self._http_client = httpx.AsyncClient(timeout=POST_TIMEOUT_S)
+            self._owns_http_client = True
+        self._stream_event_buffer: list[dict[str, Any]] = []
+        self._stream_event_timer: asyncio.TimerHandle | None = None
+        self._uploader: SerialBatchEventUploader[dict[str, Any]] = (
+            SerialBatchEventUploader(
+                SerialBatchEventUploaderConfig(
+                    max_batch_size=_MAX_BATCH_SIZE,
+                    max_queue_size=_MAX_QUEUE_SIZE,
+                    base_delay_ms=_BASE_DELAY_MS,
+                    max_delay_ms=_MAX_DELAY_MS,
+                    jitter_ms=_JITTER_MS,
+                    max_consecutive_failures=max_consecutive_failures,
+                    on_batch_dropped=on_batch_dropped,
+                    send=self._post_once,
+                )
+            )
+        )
+        logger.debug('HybridTransport: POST URL = %s', self._post_url)
+
+    @property
+    def dropped_batch_count(self) -> int:
+        """Snapshot before/after ``write_batch()`` to detect silent
+        drops via ``max_consecutive_failures``. Delegates to the
+        underlying uploader."""
+        return self._uploader.dropped_batch_count
+
+    # ─── Write API (overrides parent's WS-based ``write``) ───────────
+
+    async def write(self, message: dict[str, Any]) -> None:
+        """Enqueue a message for POST. Returns after the bytes are
+        accepted by the uploader (which then drains serially).
+
+        ``stream_event`` messages accumulate for up to
+        ``BATCH_FLUSH_INTERVAL_S`` before being enqueued — reduces POST
+        count for high-volume content deltas. All other message types
+        flush any buffered stream events first to preserve order, then
+        enqueue + flush this message.
+        """
+        if message.get('type') == 'stream_event':
+            # Delay: accumulate stream_events briefly before enqueueing.
+            self._stream_event_buffer.append(message)
+            if self._stream_event_timer is None:
+                loop = asyncio.get_running_loop()
+                self._stream_event_timer = loop.call_later(
+                    BATCH_FLUSH_INTERVAL_S,
+                    self._on_stream_event_timer_fire,
+                )
+            return
+        # Non-stream: flush buffered stream_events (ordering), then this.
+        buffered = self._take_stream_events()
+        await self._uploader.enqueue(buffered + [message])
+        await self._uploader.flush()
+
+    async def write_batch(self, messages: list[dict[str, Any]]) -> None:
+        """Enqueue a batch of messages. Buffered stream events go first."""
+        buffered = self._take_stream_events()
+        await self._uploader.enqueue(buffered + list(messages))
+        await self._uploader.flush()
+
+    async def flush(self) -> None:
+        """Block until all queued POSTs (including buffered
+        stream_events) have been sent. Used by ``replBridge``'s initial
+        history flush before firing ``on_state_change('connected')``.
+        """
+        buffered = self._take_stream_events()
+        if buffered:
+            await self._uploader.enqueue(buffered)
+        await self._uploader.flush()
+
+    def close(self) -> None:
+        """Sync close. Cancels stream-event timer, drops the buffer,
+        kicks a grace-bounded flush of the uploader, then closes the
+        WS reader via the parent.
+
+        Doesn't fire ``on_close`` (matches parent semantics — user
+        knows they closed). The grace-flush is fire-and-forget so
+        ``close()`` returns immediately; **callers wanting guaranteed
+        delivery should** ``await transport.flush()`` **first**.
+        Pending POSTs that don't drain within ``CLOSE_GRACE_S`` are
+        dropped — best-effort, not a delivery guarantee under
+        degraded network.
+
+        If an HTTP client was owned by this transport (i.e. no
+        ``http_client=`` was injected by the caller), it is closed
+        after the grace flush. Caller-injected clients are NOT
+        closed — the caller owns the lifecycle.
+        """
+        if self._stream_event_timer is not None:
+            self._stream_event_timer.cancel()
+            self._stream_event_timer = None
+        self._stream_event_buffer = []
+        uploader = self._uploader
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(
+                self._grace_close_uploader(uploader),
+                name='hybrid-transport-close-grace',
+            )
+        except RuntimeError:
+            # No running loop — close the uploader synchronously.
+            # Pending POSTs are dropped; matches "last-resort" semantics.
+            uploader.close()
+            # And the owned client can't be closed without a loop —
+            # let GC reclaim it (httpx clients have a __del__ that
+            # warns about un-closed clients; acceptable trade-off
+            # since this branch is hit only outside async contexts).
+        super().close()
+
+    # ─── Internal ────────────────────────────────────────────────────
+
+    def _take_stream_events(self) -> list[dict[str, Any]]:
+        """Cancel the delay timer and drain the buffer."""
+        if self._stream_event_timer is not None:
+            self._stream_event_timer.cancel()
+            self._stream_event_timer = None
+        buffered, self._stream_event_buffer = self._stream_event_buffer, []
+        return buffered
+
+    def _on_stream_event_timer_fire(self) -> None:
+        """``call_later`` callback. Fire-and-forget enqueue of the
+        buffered stream events. The uploader handles serialization
+        + retry; we don't await the enqueue here (the callback is
+        sync; we just want the work scheduled)."""
+        self._stream_event_timer = None
+        buffered, self._stream_event_buffer = self._stream_event_buffer, []
+        if not buffered:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(
+                self._uploader.enqueue(buffered),
+                name='hybrid-transport-stream-flush',
+            )
+        except RuntimeError:
+            logger.warning(
+                'HybridTransport: no running loop in stream-timer fire; '
+                'dropping %d stream events', len(buffered),
+            )
+
+    async def _grace_close_uploader(
+        self, uploader: SerialBatchEventUploader[dict[str, Any]],
+    ) -> None:
+        """Best-effort flush within ``CLOSE_GRACE_S``; then close
+        the uploader + the owned HTTP client unconditionally."""
+        try:
+            await asyncio.wait_for(uploader.flush(), timeout=CLOSE_GRACE_S)
+        except asyncio.TimeoutError:
+            logger.debug(
+                'HybridTransport: close grace expired with pending writes',
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug('HybridTransport: grace flush error: %s', exc)
+        finally:
+            uploader.close()
+            if self._owns_http_client:
+                try:
+                    await self._http_client.aclose()
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(
+                        'HybridTransport: http_client aclose error: %s',
+                        exc,
+                    )
+
+    async def _post_once(self, events: list[dict[str, Any]]) -> None:
+        """Single-attempt POST. Mirrors TS ``HybridTransport.postOnce``.
+
+        * No session token → log + return (uploader treats as success;
+          events are silently lost — matches TS).
+        * 2xx → return.
+        * 4xx non-429 → log + return (permanent; drop from queue).
+        * 429 / 5xx → raise so the uploader retries with backoff.
+        * Network error → raise (uploader retries).
+        """
+        session_token = get_session_ingress_auth_token()
+        if not session_token:
+            logger.debug(
+                'HybridTransport: no session token available for POST',
+            )
+            return
+
+        headers = {
+            'Authorization': f'Bearer {session_token}',
+            'Content-Type': 'application/json',
+        }
+
+        try:
+            response = await self._http_client.post(
+                self._post_url,
+                json={'events': events},
+                headers=headers,
+            )
+        except httpx.RequestError as exc:
+            logger.debug(
+                'HybridTransport: POST network error: %s', exc,
+            )
+            raise
+
+        if 200 <= response.status_code < 300:
+            logger.debug(
+                'HybridTransport: POST success count=%d', len(events),
+            )
+            return
+        if 400 <= response.status_code < 500 and response.status_code != 429:
+            logger.warning(
+                'HybridTransport: POST returned %d (permanent); '
+                'dropping %d events', response.status_code, len(events),
+            )
+            return
+        # 429 / 5xx — retryable.
+        logger.warning(
+            'HybridTransport: POST returned %d (retryable)',
+            response.status_code,
+        )
+        raise RuntimeError(f'POST failed with {response.status_code}')
+
+
+def _convert_ws_url_to_post_url(ws_url: str) -> str:
+    """Convert a WebSocket URL to the matching HTTP POST endpoint.
+
+    From: ``wss://api.example.com/v2/session_ingress/ws/<session_id>``
+    To:   ``https://api.example.com/v2/session_ingress/session/<session_id>/events``
+
+    Mirrors TS ``convertWsUrlToPostUrl`` at ``HybridTransport.ts:268-282``.
+    """
+    parsed = urlparse(ws_url)
+    if parsed.scheme == 'wss':
+        scheme = 'https'
+    elif parsed.scheme == 'ws':
+        scheme = 'http'
+    else:
+        # Pass through unknown schemes (shouldn't happen for v1 URLs
+        # built by ``build_sdk_url``).
+        scheme = parsed.scheme
+
+    # Replace only the first occurrence — match TS behavior and defend
+    # against a (pathological) session_id that contained ``/ws/``.
+    path = parsed.path.replace('/ws/', '/session/', 1)
+    if not path.endswith('/events'):
+        path = (path + 'events') if path.endswith('/') else (path + '/events')
+
+    return urlunparse((
+        scheme, parsed.netloc, path, parsed.params,
+        parsed.query, parsed.fragment,
+    ))
+
+
+__all__ = [
+    'BATCH_FLUSH_INTERVAL_S',
+    'CLOSE_GRACE_S',
+    'HybridTransport',
+    'POST_TIMEOUT_S',
+]

--- a/tests/bridge/test_bridge_main.py
+++ b/tests/bridge/test_bridge_main.py
@@ -298,14 +298,18 @@ class FakeSpawner:
         return h
 
 
-def _encode_work_secret() -> str:
+def _encode_work_secret(
+    *,
+    use_ccr_v2: bool = True,
+    api_base_url: str = 'https://api.example.com',
+) -> str:
     payload = {
         'version': 1,
         'session_ingress_token': 'sess-jwt',
-        'api_base_url': 'https://api.example.com',
+        'api_base_url': api_base_url,
         'sources': [],
         'auth': [],
-        'use_code_sessions': True,
+        'use_code_sessions': use_ccr_v2,
     }
     raw = json.dumps(payload).encode('utf-8')
     return base64.urlsafe_b64encode(raw).rstrip(b'=').decode('ascii')
@@ -385,6 +389,63 @@ async def test_run_loop_spawns_session_for_v2_work() -> None:
     assert opts['use_ccr_v2'] is True
     # Ack happened.
     assert any(w == 'work-1' for _e, w, _t in api.ack_calls)
+
+    # Complete the session + cancel the loop.
+    spawner.handles[0].complete('completed')
+    cancel.set()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_run_loop_spawns_session_for_v1_work() -> None:
+    """Phase 14c: v1 work items dispatch in the daemon path. The
+    session-ingress URL is derived from ``config.session_ingress_url``
+    (NOT ``secret.api_base_url``, which may point at a remote
+    proxy/tunnel — see TS ``bridgeMain.ts:905-907``). Distinct hosts
+    catch a regression to either side."""
+    work = {
+        'id': 'work-v1', 'type': 'work', 'environment_id': 'env-srv',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_v1'},
+        'secret': _encode_work_secret(
+            use_ccr_v2=False,
+            api_base_url='https://remote-proxy.example.com',
+        ),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    cancel = asyncio.Event()
+
+    # Override session_ingress_url so it's distinct from the secret's
+    # api_base_url — the v1 dispatch must pick session_ingress_url.
+    config = _bridge_config()
+    config.session_ingress_url = 'https://bridge-local.example.com'
+
+    async def runner() -> None:
+        await run_bridge_loop(
+            config, 'env-srv', 'sec-srv', api, spawner, cancel,
+        )
+
+    task = asyncio.create_task(runner())
+    for _ in range(30):
+        await asyncio.sleep(0.01)
+        if spawner.spawns:
+            break
+
+    assert len(spawner.spawns) == 1
+    opts, _wd = spawner.spawns[0]
+    # Spawn URL derived from the bridge's session_ingress_url, NOT
+    # the secret's api_base_url. Without this split the daemon would
+    # (incorrectly) build the WS URL against remote-proxy.example.com.
+    assert opts['sdk_url'] == (
+        'wss://bridge-local.example.com/v1/session_ingress/ws/cse_v1'
+    )
+    assert opts['use_ccr_v2'] is False
+    assert opts['access_token'] == 'sess-jwt'
+    # Work was ack'd, NOT stopped (the v1 refusal gate is lifted).
+    assert any(w == 'work-v1' for _e, w, _t in api.ack_calls)
+    assert not any(w == 'work-v1' for _e, w, _f in api.stop_calls)
 
     # Complete the session + cancel the loop.
     spawner.handles[0].complete('completed')

--- a/tests/bridge/test_repl_bridge.py
+++ b/tests/bridge/test_repl_bridge.py
@@ -353,32 +353,107 @@ async def test_poll_loop_spawns_session_for_work_item() -> None:
 
 
 @pytest.mark.asyncio
-async def test_poll_loop_stops_work_for_v1_secret() -> None:
-    """MVP rejects v1 (non-CCR-v2) work."""
+async def test_poll_loop_dispatches_v1_work_with_session_ingress_url() -> None:
+    """Phase 14c: v1 work items spawn with the session-ingress WS URL
+    derived from ``params.session_ingress_url`` (NOT from
+    ``secret.api_base_url`` — see TS ``bridgeMain.ts:905-907``).
+    The work secret's ``api_base_url`` is set to a DIFFERENT host so a
+    regression to ``secret.api_base_url`` would be caught here."""
+    # Work secret carries a "remote proxy/tunnel" api_base_url that
+    # is intentionally distinct from the bridge's configured
+    # session_ingress_url. v1 must use the bridge's ingress URL,
+    # not the proxy URL.
+    import base64
+    import json
+    secret_payload = {
+        'version': 1,
+        'session_ingress_token': 'sess-jwt-abc',
+        'api_base_url': 'https://remote-proxy.example.com',
+        'sources': [],
+        'auth': [],
+        'use_code_sessions': False,
+    }
+    raw = json.dumps(secret_payload).encode('utf-8')
+    encoded_secret = base64.urlsafe_b64encode(raw).rstrip(b'=').decode('ascii')
+
     work = {
         'id': 'work-v1',
         'type': 'work',
         'environment_id': 'env-srv-1',
         'state': 'pending',
         'data': {'type': 'session', 'id': 'cse_v1'},
-        'secret': _encode_work_secret(use_ccr_v2=False),
+        'secret': encoded_secret,
         'created_at': '2026-05-24',
     }
     api = FakeApiClient(poll_results=[work])
     spawner = FakeSpawner()
     params = _make_params()
+    # Override session_ingress_url so it differs from the secret's
+    # api_base_url — proves v1 picks the right source.
+    params.session_ingress_url = 'https://bridge-local.example.com'
     handle = await init_bridge_core(
         params, api_client=api, spawner=spawner,
     )
     assert handle is not None
     for _ in range(20):
         await asyncio.sleep(0.01)
-        if api.stop_calls:
+        if spawner.spawns:
             break
-    # Stopped the work (force=True for unsupported secret format).
-    assert any(work_id == 'work-v1' for _e, work_id, _f in api.stop_calls)
-    # No session spawned.
-    assert spawner.spawns == []
+    assert len(spawner.spawns) == 1
+    opts, _working_dir = spawner.spawns[0]
+    # Session-ingress WS URL derived from the BRIDGE's session_ingress_url,
+    # not from the secret's api_base_url. Without this distinction the
+    # v1 dispatch would (incorrectly) use 'remote-proxy.example.com'.
+    assert opts['sdk_url'] == (
+        'wss://bridge-local.example.com/v1/session_ingress/ws/cse_v1'
+    )
+    assert opts['use_ccr_v2'] is False
+    assert opts['access_token'] == 'sess-jwt-abc'
+    # Work was ack'd, NOT stopped.
+    assert any(work_id == 'work-v1' for _e, work_id, _t in api.ack_calls)
+    assert not any(
+        work_id == 'work-v1' for _e, work_id, _f in api.stop_calls
+    )
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_poll_loop_dispatches_v2_work_with_ccr_v2_url() -> None:
+    """Phase 14c regression: v2 work uses ``secret.api_base_url``
+    (the server-controlled CCR endpoint), distinct from the bridge's
+    ``session_ingress_url``. Verifies the v2 path didn't accidentally
+    pick up the v1 URL source."""
+    work = {
+        'id': 'work-v2',
+        'type': 'work',
+        'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_v2'},
+        'secret': _encode_work_secret(use_ccr_v2=True),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    params = _make_params()
+    # Distinct host from secret.api_base_url so we'd notice if the
+    # builder accidentally pulled from session_ingress_url instead.
+    params.session_ingress_url = 'https://bridge-local.example.com'
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if spawner.spawns:
+            break
+    assert len(spawner.spawns) == 1
+    opts, _working_dir = spawner.spawns[0]
+    # CCR v2 URL — uses secret.api_base_url ('api.example.com'), NOT
+    # the bridge's session_ingress_url ('bridge-local.example.com').
+    assert opts['sdk_url'] == (
+        'https://api.example.com/v1/code/sessions/cse_v2'
+    )
+    assert opts['use_ccr_v2'] is True
     await handle.teardown()
 
 

--- a/tests/bridge/test_repl_bridge_transport.py
+++ b/tests/bridge/test_repl_bridge_transport.py
@@ -28,10 +28,117 @@ def _sse_body(events: list[tuple[str, str]]) -> bytes:
     return ('\n'.join(out) + '\n').encode('utf-8')
 
 
+# ─── Phase 14c: v1 adapter ────────────────────────────────────────────
+
+
 @pytest.mark.asyncio
-async def test_v1_factory_raises_not_implemented():
-    with pytest.raises(NotImplementedError):
-        create_v1_repl_transport()
+async def test_v1_adapter_passes_through_to_hybrid(monkeypatch) -> None:
+    """The v1 adapter is a thin pass-through over HybridTransport;
+    verify the read-side callback wiring (set_on_data) is forwarded."""
+    from src.transports.hybrid_transport import HybridTransport
+    from src.transports.websocket_transport import WebSocketTransportOptions
+
+    monkeypatch.setenv('CLAUDE_CODE_SESSION_ACCESS_TOKEN', 'tok')
+    hybrid = HybridTransport(
+        url='wss://api.test/v2/session_ingress/ws/sid',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+    )
+    v1 = create_v1_repl_transport(hybrid)
+    received: list[str] = []
+    v1.set_on_data(received.append)
+    # Hybrid is closed/idle; on_data wiring is verifiable via the
+    # underlying hybrid attribute (delegate confirmed).
+    assert hybrid._on_data_cb is not None
+    # State-label / connected-status pass-throughs.
+    assert v1.get_state_label() == 'idle'
+    assert v1.is_connected_status() is False
+    v1.close()
+    assert v1.is_connected_status() is False
+
+
+@pytest.mark.asyncio
+async def test_v1_adapter_get_last_sequence_num_is_zero() -> None:
+    """v1 doesn't use SSE seq nums; always returns 0 (mirrors TS
+    replBridgeTransport.ts:94)."""
+    from src.transports.hybrid_transport import HybridTransport
+    from src.transports.websocket_transport import WebSocketTransportOptions
+
+    hybrid = HybridTransport(
+        url='wss://api.test/v2/session_ingress/ws/sid',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+    )
+    v1 = create_v1_repl_transport(hybrid)
+    assert v1.get_last_sequence_num() == 0
+    v1.close()
+
+
+@pytest.mark.asyncio
+async def test_v1_adapter_v2_only_methods_are_noops() -> None:
+    """report_state / report_metadata / report_delivery are v2-only;
+    in v1 they must be no-ops (don't raise)."""
+    from src.transports.hybrid_transport import HybridTransport
+    from src.transports.websocket_transport import WebSocketTransportOptions
+
+    hybrid = HybridTransport(
+        url='wss://api.test/v2/session_ingress/ws/sid',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+    )
+    v1 = create_v1_repl_transport(hybrid)
+    v1.report_state({'requires_action': True})
+    v1.report_metadata({'key': 'value'})
+    v1.report_delivery('event-id', 'processed')
+    v1.close()
+
+
+@pytest.mark.asyncio
+async def test_v1_adapter_dropped_batch_count_proxies(monkeypatch) -> None:
+    """``dropped_batch_count`` delegates to the hybrid's uploader."""
+    from src.transports.hybrid_transport import HybridTransport
+    from src.transports.websocket_transport import WebSocketTransportOptions
+
+    hybrid = HybridTransport(
+        url='wss://api.test/v2/session_ingress/ws/sid',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+    )
+    v1 = create_v1_repl_transport(hybrid)
+    assert v1.dropped_batch_count == 0
+    # Simulate a drop by bumping the underlying counter.
+    hybrid._uploader._dropped_batches = 3
+    assert v1.dropped_batch_count == 3
+    v1.close()
+
+
+@pytest.mark.asyncio
+async def test_v1_adapter_connect_schedules_task_without_blocking() -> None:
+    """``connect()`` is sync (per Protocol); schedules the hybrid's
+    async ``connect()`` as a fire-and-forget task. Match the v2
+    factory's equivalent pattern.
+
+    Targets a bound-then-released local port so ``connect`` gets
+    ECONNREFUSED instantly (no privileged-port quirks, no silent
+    drops in restrictive-network CI)."""
+    import socket as _socket
+    from src.transports.hybrid_transport import HybridTransport
+    from src.transports.websocket_transport import WebSocketTransportOptions
+
+    # Bind to a free port, then close the socket immediately — the
+    # port is now unbound and a connect() to it gets ECONNREFUSED.
+    with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as s:
+        s.bind(('127.0.0.1', 0))
+        port = s.getsockname()[1]
+
+    hybrid = HybridTransport(
+        url=f'ws://127.0.0.1:{port}',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+    )
+    v1 = create_v1_repl_transport(hybrid)
+    # connect() must return immediately even with a doomed target.
+    v1.connect()
+    # Give the scheduled task a tick to run (and fail).
+    await asyncio.sleep(0.1)
+    # Transport ends up in 'closed' state because auto_reconnect=False.
+    assert hybrid.is_closed_status()
+    v1.close()
 
 
 @pytest.mark.asyncio

--- a/tests/transports/test_hybrid_transport.py
+++ b/tests/transports/test_hybrid_transport.py
@@ -1,0 +1,445 @@
+"""Tests for ``src.transports.hybrid_transport.HybridTransport``.
+
+Strategy
+--------
+- WS read side: in-process WS server via ``websockets.asyncio.server.serve``
+  (pattern from ``tests/transports/test_websocket_transport.py``).
+- POST write side: ``httpx.MockTransport`` injected via the
+  ``http_client=`` constructor kwarg (pattern from
+  ``tests/transports/test_sse_transport.py``).
+- Auth: ``monkeypatch.setenv('CLAUDE_CODE_SESSION_ACCESS_TOKEN', ...)``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from typing import Any
+
+import httpx
+import pytest
+import websockets
+from websockets.asyncio.server import serve as ws_serve
+
+from src.transports.hybrid_transport import (
+    CLOSE_GRACE_S,
+    HybridTransport,
+    _convert_ws_url_to_post_url,
+)
+from src.transports.websocket_transport import WebSocketTransportOptions
+
+
+pytestmark = pytest.mark.integration
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('127.0.0.1', 0))
+        return s.getsockname()[1]
+
+
+class _MockPostHandler:
+    """httpx.MockTransport handler that captures POSTs and scripts responses."""
+
+    def __init__(
+        self,
+        *,
+        response_sequence: list[int] | None = None,
+        default_status: int = 200,
+    ) -> None:
+        # Per-POST status code sequence; falls back to default after exhaust.
+        self.response_sequence = list(response_sequence or [])
+        self.default_status = default_status
+        self.requests: list[httpx.Request] = []
+        self.posted_events: list[list[dict[str, Any]]] = []
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        body = json.loads(request.content.decode('utf-8'))
+        self.posted_events.append(body.get('events', []))
+        if self.response_sequence:
+            status = self.response_sequence.pop(0)
+        else:
+            status = self.default_status
+        return httpx.Response(status, json={'ok': True})
+
+
+class _ScriptedWsServer:
+    """Minimal in-process WS server — pushes optional initial frames,
+    keeps connection open until client closes."""
+
+    def __init__(self, initial_frames: list[str] | None = None) -> None:
+        self.initial_frames = list(initial_frames or [])
+        self.connection_count = 0
+
+    async def handler(self, ws) -> None:
+        self.connection_count += 1
+        for frame in self.initial_frames:
+            try:
+                await ws.send(frame)
+            except (
+                websockets.exceptions.ConnectionClosed, OSError,
+            ):
+                return
+        try:
+            async for _raw in ws:
+                pass
+        except (websockets.exceptions.ConnectionClosed, OSError):
+            return
+
+
+async def _wait_for(predicate, timeout_s: float = 2.0, step_s: float = 0.01):
+    import time
+    deadline = time.monotonic() + timeout_s
+    last = None
+    while time.monotonic() < deadline:
+        last = predicate()
+        if last:
+            return last
+        await asyncio.sleep(step_s)
+    return last
+
+
+# ─── Pure helpers ──────────────────────────────────────────────────────
+
+
+def test_convert_ws_url_wss_to_https() -> None:
+    out = _convert_ws_url_to_post_url(
+        'wss://api.example.com/v2/session_ingress/ws/sid123',
+    )
+    assert out == (
+        'https://api.example.com/v2/session_ingress/session/sid123/events'
+    )
+
+
+def test_convert_ws_url_ws_to_http() -> None:
+    out = _convert_ws_url_to_post_url(
+        'ws://localhost:8080/v2/session_ingress/ws/sid',
+    )
+    assert out == 'http://localhost:8080/v2/session_ingress/session/sid/events'
+
+
+def test_convert_ws_url_preserves_query() -> None:
+    out = _convert_ws_url_to_post_url(
+        'wss://h/v2/session_ingress/ws/sid?x=1',
+    )
+    assert out == 'https://h/v2/session_ingress/session/sid/events?x=1'
+
+
+# ─── Write paths ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_write_non_stream_event_posts_immediately(monkeypatch) -> None:
+    monkeypatch.setenv('CLAUDE_CODE_SESSION_ACCESS_TOKEN', 'tok-123')
+    mock = _MockPostHandler()
+    client = httpx.AsyncClient(transport=httpx.MockTransport(mock))
+    t = HybridTransport(
+        url='wss://api.test/v2/session_ingress/ws/sid',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+        http_client=client,
+    )
+    await t.write({'type': 'control_request', 'uuid': 'u1'})
+    await _wait_for(lambda: bool(mock.requests))
+    assert len(mock.requests) == 1
+    req = mock.requests[0]
+    assert req.method == 'POST'
+    assert req.url.scheme == 'https'
+    assert req.url.path == '/v2/session_ingress/session/sid/events'
+    assert req.headers['authorization'] == 'Bearer tok-123'
+    assert mock.posted_events[0] == [
+        {'type': 'control_request', 'uuid': 'u1'},
+    ]
+    t.close()
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_write_stream_event_buffers_then_flushes_after_timer(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv('CLAUDE_CODE_SESSION_ACCESS_TOKEN', 'tok')
+    mock = _MockPostHandler()
+    client = httpx.AsyncClient(transport=httpx.MockTransport(mock))
+    t = HybridTransport(
+        url='wss://api.test/v2/session_ingress/ws/sid',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+        http_client=client,
+    )
+    await t.write({'type': 'stream_event', 'uuid': 's1'})
+    await t.write({'type': 'stream_event', 'uuid': 's2'})
+    await t.write({'type': 'stream_event', 'uuid': 's3'})
+    # Buffer not flushed yet (timer is 100ms).
+    await asyncio.sleep(0.02)
+    assert mock.requests == []
+    # After the timer fires, all three events are POSTed together.
+    await _wait_for(lambda: bool(mock.requests), timeout_s=1.0)
+    assert len(mock.requests) == 1
+    assert [e['uuid'] for e in mock.posted_events[0]] == ['s1', 's2', 's3']
+    t.close()
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_write_non_stream_flushes_buffered_stream_events_first(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv('CLAUDE_CODE_SESSION_ACCESS_TOKEN', 'tok')
+    mock = _MockPostHandler()
+    client = httpx.AsyncClient(transport=httpx.MockTransport(mock))
+    t = HybridTransport(
+        url='wss://api.test/v2/session_ingress/ws/sid',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+        http_client=client,
+    )
+    await t.write({'type': 'stream_event', 'uuid': 's1'})
+    await t.write({'type': 'stream_event', 'uuid': 's2'})
+    # The control message flushes buffered stream events first.
+    await t.write({'type': 'control_request', 'uuid': 'c1'})
+    await _wait_for(lambda: bool(mock.requests))
+    # All three in one POST, in order.
+    assert len(mock.requests) == 1
+    uuids = [e['uuid'] for e in mock.posted_events[0]]
+    assert uuids == ['s1', 's2', 'c1']
+    t.close()
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_write_batch_posts_all(monkeypatch) -> None:
+    monkeypatch.setenv('CLAUDE_CODE_SESSION_ACCESS_TOKEN', 'tok')
+    mock = _MockPostHandler()
+    client = httpx.AsyncClient(transport=httpx.MockTransport(mock))
+    t = HybridTransport(
+        url='wss://api.test/v2/session_ingress/ws/sid',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+        http_client=client,
+    )
+    await t.write_batch([
+        {'type': 'a', 'uuid': 'u1'},
+        {'type': 'b', 'uuid': 'u2'},
+        {'type': 'c', 'uuid': 'u3'},
+    ])
+    await _wait_for(lambda: bool(mock.requests))
+    assert len(mock.requests) == 1
+    assert len(mock.posted_events[0]) == 3
+    t.close()
+    await client.aclose()
+
+
+# ─── Retry / drop behavior ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_post_retries_on_5xx(monkeypatch) -> None:
+    """503 → retry → 200. Two POST attempts observed."""
+    monkeypatch.setenv('CLAUDE_CODE_SESSION_ACCESS_TOKEN', 'tok')
+    mock = _MockPostHandler(response_sequence=[503, 200])
+    client = httpx.AsyncClient(transport=httpx.MockTransport(mock))
+    t = HybridTransport(
+        url='wss://api.test/v2/session_ingress/ws/sid',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+        http_client=client,
+    )
+    await t.write({'type': 'control_request', 'uuid': 'u1'})
+    # Default uploader backoff base is 500ms — wait long enough for retry.
+    await _wait_for(lambda: len(mock.requests) >= 2, timeout_s=3.0)
+    assert len(mock.requests) == 2
+    t.close()
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_post_retries_on_429(monkeypatch) -> None:
+    """429 → retry → 200."""
+    monkeypatch.setenv('CLAUDE_CODE_SESSION_ACCESS_TOKEN', 'tok')
+    mock = _MockPostHandler(response_sequence=[429, 200])
+    client = httpx.AsyncClient(transport=httpx.MockTransport(mock))
+    t = HybridTransport(
+        url='wss://api.test/v2/session_ingress/ws/sid',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+        http_client=client,
+    )
+    await t.write({'type': 'control_request', 'uuid': 'u1'})
+    await _wait_for(lambda: len(mock.requests) >= 2, timeout_s=3.0)
+    assert len(mock.requests) == 2
+    t.close()
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_post_drops_on_4xx_non_429(monkeypatch) -> None:
+    """400 → permanent drop; uploader's send returns; next write succeeds."""
+    monkeypatch.setenv('CLAUDE_CODE_SESSION_ACCESS_TOKEN', 'tok')
+    mock = _MockPostHandler(response_sequence=[400, 200])
+    client = httpx.AsyncClient(transport=httpx.MockTransport(mock))
+    t = HybridTransport(
+        url='wss://api.test/v2/session_ingress/ws/sid',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+        http_client=client,
+    )
+    # First write: server returns 400 — dropped silently, no retry.
+    await t.write({'type': 'a', 'uuid': 'u1'})
+    await _wait_for(lambda: len(mock.requests) >= 1, timeout_s=1.0)
+    assert len(mock.requests) == 1
+    # Second write: server returns 200 — accepted.
+    await t.write({'type': 'b', 'uuid': 'u2'})
+    await _wait_for(lambda: len(mock.requests) >= 2, timeout_s=1.0)
+    assert len(mock.requests) == 2
+    t.close()
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_post_skipped_when_no_session_token(monkeypatch) -> None:
+    """Without ``CLAUDE_CODE_SESSION_ACCESS_TOKEN``, ``_post_once``
+    returns silently. The events are effectively dropped — matches TS."""
+    monkeypatch.delenv('CLAUDE_CODE_SESSION_ACCESS_TOKEN', raising=False)
+    mock = _MockPostHandler()
+    client = httpx.AsyncClient(transport=httpx.MockTransport(mock))
+    t = HybridTransport(
+        url='wss://api.test/v2/session_ingress/ws/sid',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+        http_client=client,
+    )
+    await t.write({'type': 'a', 'uuid': 'u1'})
+    # Let the uploader's drain run.
+    await asyncio.sleep(0.1)
+    # No POSTs — the auth check short-circuited.
+    assert mock.requests == []
+    t.close()
+    await client.aclose()
+
+
+# ─── Close behavior ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_close_drops_stream_event_buffer(monkeypatch) -> None:
+    """Buffered stream events should NOT be POSTed after close."""
+    monkeypatch.setenv('CLAUDE_CODE_SESSION_ACCESS_TOKEN', 'tok')
+    mock = _MockPostHandler()
+    client = httpx.AsyncClient(transport=httpx.MockTransport(mock))
+    t = HybridTransport(
+        url='wss://api.test/v2/session_ingress/ws/sid',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+        http_client=client,
+    )
+    # Buffer 2 stream events (don't await the timer).
+    await t.write({'type': 'stream_event', 'uuid': 's1'})
+    await t.write({'type': 'stream_event', 'uuid': 's2'})
+    # Close before the timer fires.
+    t.close()
+    # Wait long enough that the timer WOULD have fired had close not cancelled it.
+    await asyncio.sleep(0.2)
+    # Nothing posted.
+    assert mock.requests == []
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_dropped_batch_count_proxies_uploader(monkeypatch) -> None:
+    """Force a batch drop via persistent 5xx + max_consecutive_failures=2;
+    ``transport.dropped_batch_count`` reflects the uploader's counter."""
+    monkeypatch.setenv('CLAUDE_CODE_SESSION_ACCESS_TOKEN', 'tok')
+    mock = _MockPostHandler(default_status=503)
+    client = httpx.AsyncClient(transport=httpx.MockTransport(mock))
+    t = HybridTransport(
+        url='wss://api.test/v2/session_ingress/ws/sid',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+        http_client=client,
+        max_consecutive_failures=2,
+    )
+    assert t.dropped_batch_count == 0
+    await t.write({'type': 'a', 'uuid': 'u1'})
+    # Wait for 2 attempts to fail + the batch to be dropped.
+    await _wait_for(lambda: t.dropped_batch_count >= 1, timeout_s=5.0)
+    assert t.dropped_batch_count == 1
+    t.close()
+    await client.aclose()
+
+
+# ─── Inherited WS read path still works ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_inherited_websocket_read_path_still_works() -> None:
+    """``HybridTransport`` doesn't override read-side behavior; the
+    parent ``WebSocketTransport`` reader must still fire ``on_data``
+    for inbound frames."""
+    wss = _ScriptedWsServer(initial_frames=['inbound-frame-1'])
+    port = _free_port()
+    ws_server = await ws_serve(wss.handler, '127.0.0.1', port)
+    try:
+        received: list[str] = []
+        t = HybridTransport(
+            url=f'ws://127.0.0.1:{port}/v2/session_ingress/ws/sid',
+            options=WebSocketTransportOptions(auto_reconnect=False),
+        )
+        t.set_on_data(received.append)
+        await t.connect()
+        await _wait_for(lambda: received == ['inbound-frame-1'])
+        assert received == ['inbound-frame-1']
+        assert wss.connection_count == 1
+        t.close()
+    finally:
+        ws_server.close()
+        await ws_server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_close_grace_does_not_block_caller(monkeypatch) -> None:
+    """``close()`` must return synchronously even with a slow POST in
+    flight — the grace flush is fire-and-forget. We use a slow
+    ``httpx.MockTransport`` handler that holds the POST until a
+    release event so the test cleans up promptly without waiting
+    out the full ``CLOSE_GRACE_S`` budget.
+    """
+    import time
+
+    monkeypatch.setenv('CLAUDE_CODE_SESSION_ACCESS_TOKEN', 'tok')
+    release = asyncio.Event()
+
+    async def slow_handler(_request: httpx.Request) -> httpx.Response:
+        # Hold the POST until the test releases us at teardown.
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            pass
+        return httpx.Response(200, json={'ok': True})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(slow_handler))
+    t = HybridTransport(
+        url='wss://api.test/v2/session_ingress/ws/sid',
+        options=WebSocketTransportOptions(auto_reconnect=False),
+        http_client=client,
+    )
+    # write() awaits the uploader's flush, which won't return while
+    # the POST is held by slow_handler — fire-and-forget the write task.
+    write_task = asyncio.create_task(
+        t.write({'type': 'a', 'uuid': 'u1'}),
+        name='test-stuck-write',
+    )
+    # Yield so the drain enters the stuck POST.
+    await asyncio.sleep(0.05)
+    # Now close — must return immediately even though drain is stuck.
+    start = time.monotonic()
+    t.close()
+    elapsed = time.monotonic() - start
+    assert elapsed < CLOSE_GRACE_S * 0.5, (
+        f'close() should return sync, but took {elapsed:.3f}s'
+    )
+    # Cleanup: release the slow handler + cancel the orphan write
+    # task so the test loop drains cleanly without waiting
+    # CLOSE_GRACE_S.
+    release.set()
+    write_task.cancel()
+    try:
+        await write_task
+    except (asyncio.CancelledError, Exception):
+        pass
+    # Give the grace task a moment to observe the released event
+    # and exit through uploader.close().
+    await asyncio.sleep(0.05)
+    await client.aclose()


### PR DESCRIPTION
## Summary

Third and final v1-transport sub-phase. Composes phase 14a's `WebSocketTransport` (PR #217) + phase 14b's `SerialBatchEventUploader` (PR #218) into `HybridTransport`. Adds the trivial `create_v1_repl_transport` adapter. And **lifts the v1 dispatch refusal at both `repl_bridge.py:840-848` and `bridge_main.py:616-622`** so v1 (session-ingress) work items now flow end-to-end.

A v1 work item now flows: poll → decode secret → build v1 session-ingress URL → spawn child with `use_ccr_v2=False` → child handles its own transport against the v1 endpoint.

**Architectural note**: in the Python port, the *parent* bridge only orchestrates lifecycle; the child Claude Code subprocess constructs and uses the transport via env vars (`build_child_env` at `src/bridge/session_runner.py:117-127`). So `HybridTransport` lands as a **library primitive** with no immediate consumer in `repl_bridge.py` — it exists for TS parity and as the foundation for future parent-side relay. The dispatch wiring is the load-bearing change.

## What's new

### `src/transports/hybrid_transport.py` (new module)

`HybridTransport(WebSocketTransport)` — subclasses the v1 read primitive (14a) and overrides write/write_batch/flush/close to POST through `SerialBatchEventUploader` (14b).

- **Stream-event delay buffer**: messages with `type == 'stream_event'` accumulate in a 100ms timer-flushed buffer (reduces POST count for high-volume content deltas). Non-stream writes flush the buffer first to preserve order.
- **`_post_once`**: uses `httpx` with `get_session_ingress_auth_token()` for `Authorization: Bearer`. 2xx returns; 4xx non-429 logs + returns (permanent drop); 429/5xx raises so uploader retries; network errors raise.
- **Pooled HTTP client**: constructor pools a single `httpx.AsyncClient` (caller-injected takes precedence) and closes it in the grace task. Matches TS axios's default connection pooling rather than per-POST handshake.
- **`close()`** is sync; cancels stream-event timer, drops buffer, schedules a grace-bounded `uploader.flush()` (`CLOSE_GRACE_S=3s`) then `uploader.close()` as a fire-and-forget task. Owned HTTP client is closed in the same task.
- **`_convert_ws_url_to_post_url`**: `wss://` → `https://`, `/ws/` → `/session/` (first-occurrence only), ensures `/events` suffix.

### `src/bridge/repl_bridge_transport.py`

Replaced the `NotImplementedError` stub with `_V1ReplTransport` class + `create_v1_repl_transport(hybrid)` factory. Thin pass-through wrapping `HybridTransport` into the `ReplBridgeTransport` Protocol. `connect()` schedules the hybrid's async connect as a fire-and-forget task (matches the v2 factory). `get_last_sequence_num()` returns 0 (v1 doesn't use SSE seq nums). v2-only methods (`report_state`, `report_metadata`, `report_delivery`) are no-ops. Mirrors TS `replBridgeTransport.ts:78-103`.

### `src/bridge/repl_bridge.py` + `src/bridge/bridge_main.py` — dispatch wiring

Both dispatch sites now use a conditional URL builder:

- **v1 path**: `build_sdk_url(params.session_ingress_url, session_id)` — uses the **bridge's configured** ingress URL.
- **v2 path**: `build_ccr_v2_sdk_url(secret.api_base_url, session_id)` — uses the **server-controlled** CCR endpoint.

The URL-source split is critical in proxy/tunnel topologies where `secret.api_base_url` points to a remote that doesn't know about locally-created sessions (TS `bridgeMain.ts:905-907`, `replBridge.ts:1471`). The CRITIC's round-1 review caught this — initial implementation incorrectly used `secret.api_base_url` for v1 too, which would have silently broken any proxied deployment.

Detailed in-source comment block documents the v1/v2 URL-source split + auth-token-forwarding asymmetry.

## CRITIC review

**Round 1 — REQUEST CHANGES** (1 BLOCKING + 4 MAJOR + 6 MINOR):
- **BLOCKING**: v1 URL source was `secret.api_base_url` instead of `params.session_ingress_url`. Real parity bug — would break proxy/tunnel deployments. Fixed at BOTH dispatch sites (`repl_bridge.py` + `bridge_main.py`). Regression tests use **distinct hosts** for `session_ingress_url` vs `secret.api_base_url` so a future drive-by edit can't silently regress to either side.
- **MAJOR**: `_post_once` constructed a fresh `httpx.AsyncClient` per POST → TCP/TLS handshake per request. Fixed by pooling in `__init__`.
- **MAJOR**: `bridge_main.py:616-622` v1 refusal also needed lifting — same dual-URL-source logic added.
- **MAJOR**: `test_close_grace_does_not_block_caller` mutated a frozen dataclass via `object.__setattr__`. Rewrote to use `httpx.MockTransport` with an async slow_handler — exercises the documented injection point.
- **MAJOR**: `ws://127.0.0.1:1` (privileged port) test target. Replaced with bind-free-port-then-release pattern for instant ECONNREFUSED.
- 3 of 6 MINORs applied (stale docstrings, missing close-semantics callouts, `path.replace` first-occurrence).

**Round 2 — APPROVE** with 2 follow-ups, both applied: dropped unused `import json` from `hybrid_transport.py`; added `test_run_loop_spawns_session_for_v1_work` in `test_bridge_main.py` (cheap insurance against the daemon path silently regressing).

## Non-goals (deferred to follow-up phases)

- **No parent-side `HybridTransport` consumer** — the Python parent only orchestrates lifecycle; the child SDK constructs the transport from env vars. Parent-side relay is a future feature (probably part of a Python UI phase).
- **`CCRClient` migration to `SerialBatchEventUploader`** — TS uses the uploader for v2 too; Python `CCRClient` has its own ad-hoc queue. Orthogonal cleanup.
- **Real session-ingress integration tests** — tests use in-process WS + `httpx.MockTransport`. End-to-end against a real backend is a separate phase.

## Test plan

- [x] **744/744 transport + bridge tests pass** (was 723 at phase 14b baseline; +21 net = 15 hybrid + 5 adapter + 1 v1-dispatch (repl) + 1 v2-regression (repl) + 1 v1-dispatch (bridge_main) - 1 deleted stale v1-refusal + 0 (replaced)).
- [x] **15 tests in `test_hybrid_transport.py`**: URL derivation, write paths (immediate POST / delay buffer / ordering / batch), retry/drop matrix (5xx / 429 / 4xx non-429 / no token), close behavior (drops buffer / grace doesn't block), dropped_batch_count proxy, inherited WS read path.
- [x] **5 new tests in `test_repl_bridge_transport.py`** for the v1 adapter: pass-through, `get_last_sequence_num==0`, v2-only no-ops, dropped_batch_count proxy, connect() schedules without blocking (using bind-then-release port pattern).
- [x] **2 new tests in `test_repl_bridge.py`** + **1 new test in `test_bridge_main.py`** for v1 dispatch, all using distinct `session_ingress_url` vs `secret.api_base_url` so the BLOCKING parity bug couldn't regress silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)