### PR TITLE
bridge phase 15: JWT refresh wiring with v1/v2 split + existingHandle

### DIFF
--- a/src/bridge/bridge_main.py
+++ b/src/bridge/bridge_main.py
@@ -68,6 +68,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+from src.bridge.jwt_utils import TokenRefreshScheduler
 from src.bridge.bridge_api import (
     BridgeFatalError,
     create_bridge_api_client,
@@ -355,6 +356,7 @@ async def run_bridge_loop(
     backoff_config: BackoffConfig = DEFAULT_BACKOFF,
     initial_session_id: str | None = None,  # noqa: ARG001 future use
     poll_config: PollIntervalConfig = DEFAULT_POLL_CONFIG,
+    get_access_token: Callable[[], str | None] | None = None,
 ) -> None:
     """Run the multi-session work-poll loop.
 
@@ -367,6 +369,10 @@ async def run_bridge_loop(
       to ``backoff_config.shutdown_grace_ms``, SIGKILL stragglers
     * Best-effort stopWork on shutdown, with retry up to
       ``backoff_config.stop_work_base_delay_ms`` per attempt
+    * Phase 15: proactive JWT refresh per session, with v1/v2 split
+      (v1 pushes OAuth to child stdin; v2 triggers server re-dispatch
+      via ``reconnect_session``). Enabled when ``get_access_token`` is
+      provided; otherwise sessions use their initial JWT until expiry.
     """
     daemon = _BridgeDaemon(
         config=config,
@@ -377,6 +383,7 @@ async def run_bridge_loop(
         cancel_event=cancel_event,
         backoff_config=backoff_config,
         poll_config=poll_config,
+        get_access_token=get_access_token,
     )
     try:
         await daemon.run()
@@ -445,6 +452,7 @@ class _BridgeDaemon:
         cancel_event: asyncio.Event,
         backoff_config: BackoffConfig,
         poll_config: PollIntervalConfig,
+        get_access_token: Callable[[], str | None] | None = None,
     ) -> None:
         self.config = config
         self.environment_id = environment_id
@@ -470,6 +478,18 @@ class _BridgeDaemon:
         # ``shutdown`` can await them (they own per-session cleanup like
         # worktree removal — letting them outlive shutdown leaks state).
         self.session_done_tasks: dict[str, asyncio.Task[None]] = {}
+        # Phase 15: track which session ids run with use_ccr_v2=True so
+        # the JWT refresh callback can branch v1 (push token to child)
+        # vs v2 (server re-dispatch via reconnect_session). Mirrors TS
+        # ``v2Sessions`` set on ``bridgeMain.ts:276``.
+        self.v2_sessions: set[str] = set()
+        # Phase 15: proactive JWT refresh scheduler. Conditional on
+        # ``get_access_token`` being provided; matches TS pattern
+        # (``const tokenRefresh = getAccessToken ? createTokenRefreshScheduler(...) : null``).
+        self.token_refresh: TokenRefreshScheduler | None = (
+            self._build_token_refresh_scheduler(get_access_token)
+            if get_access_token is not None else None
+        )
 
         # Two-track exponential backoff state. Reset on any successful
         # poll (including empty-poll = no work).
@@ -484,6 +504,83 @@ class _BridgeDaemon:
             cap_ms=bc.general_cap_ms,
             give_up_ms=bc.general_give_up_ms,
         )
+
+    # ─── Phase 15: JWT refresh ──────────────────────────────────────
+
+    def _build_token_refresh_scheduler(
+        self,
+        get_access_token: Callable[[], str | None],
+    ) -> TokenRefreshScheduler:
+        """Create a per-daemon scheduler with v1/v2-aware ``on_refresh``.
+
+        Mirrors TS ``bridgeMain.ts:283-312``.
+
+        * **v2 (CCR worker endpoints)**: ``register_worker.go:32``
+          validates the JWT's ``session_id`` claim, so pushing an
+          OAuth token to the child's stdin would break subsequent
+          ``/worker/*`` requests. Instead, call
+          ``api.reconnect_session(env_id, session_id)`` — the server
+          re-dispatches the work item with a fresh JWT, which flows
+          through the next poll's ``_process_work``.
+        * **v1 (Session-Ingress)**: push the fresh OAuth token via
+          ``handle.update_access_token`` (session-ingress accepts
+          OAuth or JWT).
+        """
+        def on_refresh(session_id: str, fresh_token: str) -> None:
+            handle = self.active_sessions.get(session_id)
+            if handle is None:
+                # Session ended after the refresh was scheduled but
+                # before the callback fired. _on_session_done already
+                # cancelled the scheduler entry; if we got here anyway,
+                # just no-op.
+                return
+            if session_id in self.v2_sessions:
+                try:
+                    loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    logger.warning(
+                        '[bridge:main] token refresh fired outside an '
+                        'asyncio loop (sessionId=%s) — cannot dispatch '
+                        'v2 reconnect', session_id,
+                    )
+                    return
+                loop.create_task(
+                    self._safe_reconnect_for_refresh(session_id),
+                    name=f'bridge-main-refresh-{session_id}',
+                )
+                return
+            # v1: push fresh OAuth/JWT to child stdin.
+            try:
+                handle.update_access_token(fresh_token)
+            except Exception as err:  # noqa: BLE001
+                logger.warning(
+                    '[bridge:main] update_access_token via stdin '
+                    'failed for sessionId=%s: %s', session_id, err,
+                )
+
+        async def get_access_token_async() -> str | None:
+            return get_access_token()
+
+        return TokenRefreshScheduler(
+            get_access_token=get_access_token_async,
+            on_refresh=on_refresh,
+            label='bridge-main',
+        )
+
+    async def _safe_reconnect_for_refresh(self, session_id: str) -> None:
+        """v2 token-refresh helper. Calls ``api.reconnect_session``
+        and swallows errors — the next refresh fire will retry.
+
+        Mirrors TS ``bridgeMain.ts:295-305`` (``void
+        api.reconnectSession(...).catch(...)``).
+        """
+        try:
+            await self.api.reconnect_session(self.environment_id, session_id)
+        except Exception as err:  # noqa: BLE001
+            logger.warning(
+                '[bridge:main] v2 token refresh via reconnect_session '
+                'failed for sessionId=%s: %s', session_id, err,
+            )
 
     async def run(self) -> None:
         cfg = self.poll_config
@@ -614,6 +711,39 @@ class _BridgeDaemon:
             return
         await self._safe_ack(work_id, secret.session_ingress_token)
 
+        # Phase 15: existingHandle path. If this work item is for a
+        # session that's already running (e.g. server re-dispatched
+        # work after a v2 JWT refresh's ``reconnect_session`` call,
+        # or after a WS drop), push the fresh JWT to the live child
+        # and reschedule the refresh — DO NOT spawn a duplicate
+        # subprocess. Mirrors TS ``bridgeMain.ts:868-885``.
+        existing = self.active_sessions.get(session_id)
+        if existing is not None:
+            try:
+                existing.update_access_token(secret.session_ingress_token)
+            except Exception as err:  # noqa: BLE001
+                logger.warning(
+                    '[bridge:main] update_access_token for existing '
+                    'sessionId=%s failed: %s', session_id, err,
+                )
+            self.session_work_ids[session_id] = work_id
+            if self.token_refresh is not None:
+                try:
+                    self.token_refresh.schedule(
+                        session_id, secret.session_ingress_token,
+                    )
+                except Exception as err:  # noqa: BLE001
+                    logger.debug(
+                        '[bridge:main] reschedule token refresh for '
+                        'existing sessionId=%s failed: %s',
+                        session_id, err,
+                    )
+            logger.info(
+                '[bridge:main] Updated access token for existing '
+                'sessionId=%s workId=%s', session_id, work_id,
+            )
+            return
+
         # Phase 14c: dispatch v1 + v2 work items. v1 uses the bridge's
         # configured ``session_ingress_url`` (NOT ``secret.api_base_url``
         # — see TS ``bridgeMain.ts:905-907``: the secret's url may be a
@@ -697,6 +827,20 @@ class _BridgeDaemon:
             session_id, work_id,
             len(self.active_sessions), self.config.max_sessions,
         )
+        # Phase 15: track v1/v2 + schedule JWT refresh.
+        if use_ccr_v2:
+            self.v2_sessions.add(session_id)
+        if self.token_refresh is not None:
+            try:
+                self.token_refresh.schedule(
+                    session_id, secret.session_ingress_token,
+                )
+            except Exception as err:  # noqa: BLE001
+                logger.debug(
+                    '[bridge:main] schedule token refresh failed for '
+                    'sessionId=%s (likely undecodable JWT — session '
+                    'uses initial token): %s', session_id, err,
+                )
         # Phase 12a: track the wait-done task so ``shutdown`` can await
         # any in-flight cleanup (worktree removal, stop_work, etc.).
         self.session_done_tasks[session_id] = asyncio.create_task(
@@ -752,6 +896,12 @@ class _BridgeDaemon:
         if work_id is not None:
             await self._safe_stop_work(work_id, force=False)
             self.completed_work_ids.add(work_id)
+        # Phase 15: cancel the pending JWT refresh for this session
+        # so it can't fire on a dead handle. ``cancel`` is a no-op if
+        # the session was never scheduled (e.g. undecodable JWT).
+        if self.token_refresh is not None:
+            self.token_refresh.cancel(session_id)
+        self.v2_sessions.discard(session_id)
         self.active_sessions.pop(session_id, None)
         self.session_work_ids.pop(session_id, None)
         self.session_compat_ids.pop(session_id, None)
@@ -791,6 +941,16 @@ class _BridgeDaemon:
         """
         active_snapshot = list(self.active_sessions.values())
         work_id_snapshot = dict(self.session_work_ids)
+
+        # Phase 15: cancel all pending JWT refresh timers so they
+        # don't fire mid-shutdown against dead session handles. Also
+        # clear ``v2_sessions`` since a future ``_BridgeDaemon`` may
+        # be reconstructed (currently ``run_bridge_loop`` makes a
+        # fresh daemon per call, but the clear here is defensive
+        # hygiene).
+        if self.token_refresh is not None:
+            self.token_refresh.cancel_all()
+        self.v2_sessions.clear()
 
         # Cancel any pending per-session timeout watchdogs so they
         # don't fire mid-shutdown and inject confusing log lines.
@@ -1016,6 +1176,7 @@ async def bridge_main(
             api,
             spawner,
             cancel_event,
+            get_access_token=get_access_token,
         )
     except BridgeHeadlessPermanentError as err:
         logger.error('[bridge:main] Permanent error: %s', err)

--- a/src/bridge/repl_bridge.py
+++ b/src/bridge/repl_bridge.py
@@ -3,39 +3,8 @@
 Ports the **public surface + happy path** of
 ``typescript/src/bridge/replBridge.ts`` (~2400 lines in TS).
 
-**Scope decision**: A full Phase 6 port (perpetual mode, dual v1/v2
-transport, multi-attempt env recreation on 404, crash-recovery pointer
-integration, dropped-batch telemetry, deterministic poll-loop backoff,
-work-id dedup across stale redeliveries, etc.) is 2-3 weeks per the
-refactoring plan. For autonomous porting in one session, this module
-implements the structural skeleton + single-session happy path:
-
-* Register environment → create session
-* Work-poll loop with dual v1 (session-ingress WS) / v2 (CCR) dispatch
-* Spawn session via Phase 4 ``session_runner``
-* ``ReplBridgeHandle`` surface — write_messages / control / teardown
-* Teardown — stop_work + archive + deregister
-
-What is **explicitly deferred** (with TODOs at the call sites):
-
-* **Perpetual mode** (crash-recovery pointer integration, env reuse via
-  ``reuseEnvironmentId``). Caller must set ``perpetual=False``.
-* **Env recreation** (the Strategy-1 / Strategy-2 reconnect dance after
-  a poll 404). Module logs the 404, fires ``on_state_change('failed')``,
-  and exits the poll loop. Phase 8 ``bridgeMain`` is the right place to
-  build the full recreation flow.
-* **JWT refresh integration with the spawned session** — the
-  ``TokenRefreshScheduler`` exists; wiring it to ``session.update_access_token``
-  on refresh is left to a follow-up. For now sessions use their initial
-  JWT until expiry.
-* **Multi-session** — the MVP handles one session at a time; second poll
-  result is rejected. Phase 8 ``bridgeMain`` handles the multi-session
-  daemon case via spawn-mode dispatch.
-* **Backoff/give-up logic** — the poll loop uses a fixed interval from
-  the config. The full TS backoff machinery (two-track error counters,
-  process-suspension detection, 10-min give-up) lands in Phase 8.
-* **Dropped-batch telemetry** + **work-id completion dedup** — both
-  log-only enhancements; deferred.
+This module is the single-session bridge orchestrator. The
+multi-session daemon variant lives in ``bridge_main.py``.
 
 What IS ported in full:
 
@@ -44,10 +13,43 @@ What IS ported in full:
 * Single-session lifecycle: register → poll → spawn → done → archive
 * Idempotent teardown
 * OAuth + env-secret auth via ``bridge_api``
+* Dual v1 (session-ingress WS) / v2 (CCR) dispatch — phase 14c
+* Crash-recovery pointer + perpetual mode — phase 12c
+* Env recreation: Strategy-1 in-place reconnect via
+  ``api.reconnect_session``; Strategy-2 kill+create-fresh on
+  poll 404 — phase 12b
+* Init-time pointer session validation via ``reconnect_session`` —
+  phase 13
+* JWT refresh with v1/v2-aware dispatch (v1: push token to child
+  stdin; v2: trigger server re-dispatch via ``reconnect_session``)
+  — phase 15
 
-This is sufficient to validate the bridge_api + session_runner + v2
-transport integration end-to-end. Phase 8 will fill in the multi-
-session + reconnect + perpetual surface.
+What is **explicitly deferred**:
+
+* **Multi-session** — this module handles one session at a time;
+  second poll result is rejected. ``bridge_main.py`` is the
+  multi-session daemon orchestrator.
+* **v2 JWT refresh round-trip is best-effort in this module.**
+  Phase 15 wires the v2 ``on_refresh`` callback to call
+  ``api.reconnect_session(env_id, session_id)``, which causes the
+  server to re-dispatch the work item with a fresh JWT. **But**
+  the poll loop here (``_poll_loop``) skips polling while
+  ``active_session is not None``, so the re-dispatch sits in the
+  server queue and may expire its lease before the active session
+  completes. The existingHandle path in ``_process_work`` will
+  route the fresh JWT correctly **if and only if** the poll
+  happens to fire between the reconnect and lease expiry —
+  unlikely in practice. v2 long-running sessions on this
+  single-session bridge will silently die at JWT expiry; for
+  guaranteed v2 refresh delivery, use ``bridge_main.py``'s
+  multi-session daemon which polls continuously at the
+  at-capacity interval.
+* **Backoff/give-up logic** — the poll loop uses a fixed interval
+  from the config. The full TS backoff machinery (two-track error
+  counters, process-suspension detection, 10-min give-up) lands
+  in a future phase.
+* **Dropped-batch telemetry** + **work-id completion dedup** — both
+  log-only enhancements; deferred.
 """
 
 from __future__ import annotations
@@ -493,6 +495,12 @@ class _BridgeState:
     active_work_id: str | None = None
     active_session_id: str | None = None
     active_token_refresh: TokenRefreshScheduler | None = None
+    #: Phase 15 — v1/v2 flag of the currently-active work item, used
+    #: by the JWT refresh callback to route between
+    #: ``session.update_access_token`` (v1) and
+    #: ``api.reconnect_session`` (v2). Set in ``_process_work``;
+    #: cleared in ``_await_session_done``.
+    active_use_ccr_v2: bool = False
     torn_down: bool = False
 
     # Per-session telemetry-style counters. Dropped batches is a count
@@ -832,6 +840,47 @@ class _BridgeState:
         # redispatch it after the reclaim window.
         await self._safe_ack(work_id, secret.session_ingress_token)
 
+        # Phase 15: existingHandle path. If this work item is for a
+        # session that's already running (e.g. server re-dispatched
+        # after a v2 JWT refresh's ``reconnect_session`` call), push
+        # the fresh JWT to the live child and reschedule the refresh
+        # — DO NOT spawn a duplicate subprocess. Mirrors TS
+        # ``bridgeMain.ts:868-885``. The repl_bridge is single-session
+        # so this triggers exactly when the active session's id
+        # matches the inbound work; any other inbound work for the
+        # at-capacity bridge is rejected by ``_poll_loop`` (which
+        # short-circuits the poll when ``active_session is not None``).
+        if (
+            self.active_session is not None
+            and self.active_session_id == session_id
+        ):
+            try:
+                self.active_session.update_access_token(
+                    secret.session_ingress_token,
+                )
+            except Exception as err:  # noqa: BLE001
+                logger.warning(
+                    '[bridge:repl] update_access_token for existing '
+                    'sessionId=%s failed: %s', session_id, err,
+                )
+            self.active_work_id = work_id
+            if self.active_token_refresh is not None:
+                try:
+                    self.active_token_refresh.schedule(
+                        session_id, secret.session_ingress_token,
+                    )
+                except Exception as err:  # noqa: BLE001
+                    logger.debug(
+                        '[bridge:repl] reschedule token refresh for '
+                        'existing sessionId=%s failed: %s',
+                        session_id, err,
+                    )
+            logger.info(
+                '[bridge:repl] Updated access token for existing '
+                'sessionId=%s workId=%s', session_id, work_id,
+            )
+            return
+
         # Phase 14c: dispatch v1 (session-ingress WS) and v2 (CCR)
         # work items both — the child SDK constructs its own
         # transport from sdk_url + access_token (via env vars set
@@ -856,6 +905,10 @@ class _BridgeState:
         # ``CLAUDE_CODE_SESSION_ACCESS_TOKEN`` regardless of v1/v2;
         # the child runs the appropriate transport.
         use_ccr_v2 = bool(secret.use_code_sessions)
+        # Phase 15: record the flag so the JWT refresh callback can
+        # dispatch v1 (push-token-to-child) vs v2 (reconnect_session)
+        # appropriately. Cleared in ``_await_session_done``.
+        self.active_use_ccr_v2 = use_ccr_v2
         if use_ccr_v2:
             sdk_url = build_ccr_v2_sdk_url(secret.api_base_url, session_id)
         else:
@@ -924,8 +977,44 @@ class _BridgeState:
         )
 
     def _build_token_refresh_scheduler(self) -> TokenRefreshScheduler:
-        """Create a scheduler whose ``on_refresh`` forwards to the child."""
-        def on_refresh(_session_id: str, fresh_token: str) -> None:
+        """Create a scheduler with v1/v2-aware ``on_refresh``.
+
+        Phase 15: v1 and v2 diverge on how to refresh.
+
+        * **v2 (CCR worker endpoints)**: CCR validates the JWT's
+          ``session_id`` claim (TS ``register_worker.go:32``), so
+          pushing an OAuth token to the child's stdin would break
+          subsequent ``/worker/*`` requests. Instead, call
+          ``api.reconnect_session(env_id, session_id)`` — the
+          server re-dispatches the work item with a fresh JWT,
+          which flows through the next poll's ``_process_work``.
+        * **v1 (Session-Ingress)**: session-ingress accepts OAuth
+          or JWT, so push the fresh OAuth token directly to the
+          child via ``session.update_access_token``.
+
+        Matches TS ``bridgeMain.ts:286-308``.
+        """
+        def on_refresh(session_id: str, fresh_token: str) -> None:
+            if self.active_use_ccr_v2:
+                # v2: schedule the async reconnect_session call.
+                # ``on_refresh`` is sync but reconnect is async; fire
+                # it as a task and don't await — the scheduler's
+                # follow-up timer fires regardless.
+                try:
+                    loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    logger.warning(
+                        '[bridge:repl] token refresh fired outside an '
+                        'asyncio loop (sessionId=%s) — cannot dispatch '
+                        'v2 reconnect', session_id,
+                    )
+                    return
+                loop.create_task(
+                    self._safe_reconnect_for_refresh(session_id),
+                    name=f'bridge-repl-refresh-{session_id}',
+                )
+                return
+            # v1: push fresh OAuth/JWT to child stdin.
             session = self.active_session
             if session is None:
                 return
@@ -938,12 +1027,14 @@ class _BridgeState:
                 )
 
         async def get_access_token() -> str | None:
-            # OAuth token getter for the refresh chain. Bridge sessions
-            # never need to refresh the OAuth token themselves (the
-            # ingress JWT is independently re-issued by the server's
-            # poll flow) — return None so the scheduler treats this as
-            # "no proactive OAuth refresh needed" and just fires the
-            # follow-up timer.
+            # OAuth token getter for the refresh chain. Phase 15:
+            # returns the parent's current OAuth token, which the
+            # scheduler then passes to ``on_refresh``. v1 pushes
+            # this token to the child via stdin; v2 ignores the
+            # token value and calls ``reconnect_session`` instead
+            # (the token's value only matters to the v1 branch —
+            # but the scheduler needs the call to return a non-None
+            # value to fire ``on_refresh`` at all).
             return self.params.get_access_token()
 
         return TokenRefreshScheduler(
@@ -951,6 +1042,21 @@ class _BridgeState:
             on_refresh=on_refresh,
             label='repl-bridge',
         )
+
+    async def _safe_reconnect_for_refresh(self, session_id: str) -> None:
+        """v2 token-refresh helper. Calls ``api.reconnect_session``
+        and swallows errors — the next refresh fire will retry.
+
+        Mirrors TS ``bridgeMain.ts:295-305`` (``void
+        api.reconnectSession(...).catch(...)``).
+        """
+        try:
+            await self.api.reconnect_session(self.environment_id, session_id)
+        except Exception as err:  # noqa: BLE001
+            logger.warning(
+                '[bridge:repl] v2 token refresh via reconnect_session '
+                'failed for sessionId=%s: %s', session_id, err,
+            )
 
     async def _await_session_done(self, work_id: str) -> None:
         if self.active_session is None:
@@ -966,10 +1072,14 @@ class _BridgeState:
             '[bridge:repl] Session done (status=%s)', status
         )
         # Cancel the JWT refresh scheduler — the session is done so any
-        # pending refresh would write to a dead stdin.
+        # pending refresh would write to a dead stdin (v1) or trigger
+        # a reconnect for an archived session (v2).
         if self.active_token_refresh is not None:
             self.active_token_refresh.cancel_all()
             self.active_token_refresh = None
+        # Phase 15: clear the v1/v2 flag so a future spawn starts
+        # with a clean v1/v2 default until ``_process_work`` sets it.
+        self.active_use_ccr_v2 = False
         # Stop the work item to free the server-side lease.
         await self._safe_stop_work(work_id, force=False)
         self.active_session = None

--- a/tests/bridge/test_bridge_main.py
+++ b/tests/bridge/test_bridge_main.py
@@ -198,6 +198,8 @@ class FakeApiClient:
         self.stop_calls: list[tuple[str, str, bool]] = []
         self.deregister_calls: list[str] = []
         self.register_calls: list[Any] = []
+        # Phase 15: capture reconnect_session calls for v2 refresh tests.
+        self.reconnect_calls: list[tuple[str, str]] = []
 
     async def register_bridge_environment(self, config: Any) -> dict[str, str]:
         self.register_calls.append(config)
@@ -223,8 +225,8 @@ class FakeApiClient:
     async def archive_session(self, sid: str) -> None:
         pass
 
-    async def reconnect_session(self, *_a: Any) -> None:
-        pass
+    async def reconnect_session(self, env_id: str, session_id: str) -> None:
+        self.reconnect_calls.append((env_id, session_id))
 
     async def heartbeat_work(self, *_a: Any) -> dict[str, Any]:
         return {'lease_extended': True, 'state': 'running'}
@@ -276,7 +278,9 @@ class FakeSessionHandle:
         pass
 
     def update_access_token(self, token: str) -> None:
-        pass
+        # Phase 15: record the new token so refresh tests can assert
+        # it propagated to the child.
+        self._access_token = token
 
     def complete(self, status: SessionDoneStatus = 'completed') -> None:
         if not self._done.done():
@@ -451,6 +455,312 @@ async def test_run_loop_spawns_session_for_v1_work() -> None:
     spawner.handles[0].complete('completed')
     cancel.set()
     await task
+
+
+# ─── Phase 15: JWT refresh wiring with v1/v2 split ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_daemon_schedules_token_refresh_on_spawn() -> None:
+    """Direct daemon unit test (full integration): construct a
+    ``_BridgeDaemon`` with ``get_access_token`` wired, invoke
+    ``_process_work`` with a real-decodable JWT, assert the daemon
+    actually scheduled a refresh + tracks the v2 session id."""
+    import base64
+    import json
+    import time
+
+    from src.bridge.bridge_main import _BridgeDaemon, DEFAULT_BACKOFF
+    from src.bridge.poll_config_defaults import DEFAULT_POLL_CONFIG
+
+    # Build a JWT with a real ``exp`` claim 1 hour out so the
+    # scheduler can decode it and arm a timer (without a real exp,
+    # ``schedule`` silently no-ops at jwt_utils.py:151-162).
+    payload = {'exp': int(time.time()) + 3600, 'session_id': 'cse_v2'}
+    payload_b64 = base64.urlsafe_b64encode(
+        json.dumps(payload).encode('utf-8'),
+    ).rstrip(b'=').decode('ascii')
+    real_jwt = f'header.{payload_b64}.signature'
+
+    secret_payload = {
+        'version': 1,
+        'session_ingress_token': real_jwt,
+        'api_base_url': 'https://api.example.com',
+        'sources': [],
+        'auth': [],
+        'use_code_sessions': True,
+    }
+    raw = json.dumps(secret_payload).encode('utf-8')
+    encoded_secret = base64.urlsafe_b64encode(raw).rstrip(b'=').decode('ascii')
+
+    api = FakeApiClient()
+    spawner = FakeSpawner()
+    daemon = _BridgeDaemon(
+        config=_bridge_config(),
+        environment_id='env-srv',
+        environment_secret='sec',
+        api=api,
+        spawner=spawner,
+        cancel_event=asyncio.Event(),
+        backoff_config=DEFAULT_BACKOFF,
+        poll_config=DEFAULT_POLL_CONFIG,
+        get_access_token=lambda: 'oauth-tok',
+    )
+    assert daemon.token_refresh is not None
+
+    work = {
+        'id': 'work-v2',
+        'type': 'work',
+        'environment_id': 'env-srv',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_v2'},
+        'secret': encoded_secret,
+        'created_at': '2026-05-26',
+    }
+    await daemon._process_work(work)
+
+    # v2 session id tracked.
+    assert 'cse_v2' in daemon.v2_sessions
+    # Scheduler armed a real timer (real JWT decoded → timer in
+    # ``_timers`` dict, not silently no-op'd).
+    assert 'cse_v2' in daemon.token_refresh._timers
+    # Spawn happened (not the existingHandle short-circuit).
+    assert len(spawner.spawns) == 1
+
+    # Cleanup: complete + run _on_session_done.
+    spawner.handles[0].complete('completed')
+    done_task = daemon.session_done_tasks.get('cse_v2')
+    if done_task is not None:
+        await done_task
+    # Scheduler cancelled the timer + v2_sessions discarded.
+    assert 'cse_v2' not in daemon.v2_sessions
+    assert 'cse_v2' not in daemon.token_refresh._timers
+
+
+@pytest.mark.asyncio
+async def test_daemon_existing_handle_path_updates_token() -> None:
+    """Phase 15 CRITIC: when work arrives for a session already in
+    ``active_sessions`` (e.g. server re-dispatched after a v2 JWT
+    refresh), the daemon updates the existing handle's token + reschedules
+    the refresh, and does NOT spawn a duplicate subprocess. Mirrors
+    TS ``bridgeMain.ts:868-885``."""
+    import base64
+    import json
+    import time
+
+    from src.bridge.bridge_main import _BridgeDaemon, DEFAULT_BACKOFF
+    from src.bridge.poll_config_defaults import DEFAULT_POLL_CONFIG
+
+    payload = {'exp': int(time.time()) + 3600, 'session_id': 'cse_v2'}
+    payload_b64 = base64.urlsafe_b64encode(
+        json.dumps(payload).encode('utf-8'),
+    ).rstrip(b'=').decode('ascii')
+    real_jwt = f'header.{payload_b64}.signature'
+    secret_payload = {
+        'version': 1,
+        'session_ingress_token': real_jwt,
+        'api_base_url': 'https://api.example.com',
+        'sources': [],
+        'auth': [],
+        'use_code_sessions': True,
+    }
+    raw = json.dumps(secret_payload).encode('utf-8')
+    encoded_secret = base64.urlsafe_b64encode(raw).rstrip(b'=').decode('ascii')
+
+    api = FakeApiClient()
+    spawner = FakeSpawner()
+    daemon = _BridgeDaemon(
+        config=_bridge_config(),
+        environment_id='env-srv',
+        environment_secret='sec',
+        api=api,
+        spawner=spawner,
+        cancel_event=asyncio.Event(),
+        backoff_config=DEFAULT_BACKOFF,
+        poll_config=DEFAULT_POLL_CONFIG,
+        get_access_token=lambda: 'oauth-tok',
+    )
+    # Pre-populate an active session for cse_v2 (simulates the
+    # session already running when the re-dispatched work arrives).
+    existing_handle = FakeSessionHandle('cse_v2', 'OLD-token')
+    daemon.active_sessions['cse_v2'] = existing_handle
+    daemon.v2_sessions.add('cse_v2')
+    daemon.session_work_ids['cse_v2'] = 'old-work-id'
+
+    work = {
+        'id': 'work-redispatched',
+        'type': 'work',
+        'environment_id': 'env-srv',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_v2'},
+        'secret': encoded_secret,
+        'created_at': '2026-05-26',
+    }
+    await daemon._process_work(work)
+
+    # NO new spawn — existing handle was updated in place.
+    assert spawner.spawns == []
+    # Existing handle's token was updated to the fresh JWT.
+    assert existing_handle.access_token == real_jwt
+    # work_id was bumped to the new redispatch.
+    assert daemon.session_work_ids['cse_v2'] == 'work-redispatched'
+    # Refresh was rescheduled (real JWT → timer armed).
+    assert 'cse_v2' in daemon.token_refresh._timers
+    # Existing handle remains in active_sessions.
+    assert daemon.active_sessions['cse_v2'] is existing_handle
+
+
+@pytest.mark.asyncio
+async def test_daemon_token_refresh_v1_pushes_to_handle() -> None:
+    """Direct daemon unit test: simulate a v1 session, fire
+    ``on_refresh`` via the scheduler's stored callback, assert the
+    fresh token landed on ``handle.update_access_token``."""
+    from src.bridge.bridge_main import _BridgeDaemon, DEFAULT_BACKOFF
+    from src.bridge.poll_config_defaults import DEFAULT_POLL_CONFIG
+
+    api = FakeApiClient()
+    spawner = FakeSpawner()
+    daemon = _BridgeDaemon(
+        config=_bridge_config(),
+        environment_id='env-srv',
+        environment_secret='sec',
+        api=api,
+        spawner=spawner,
+        cancel_event=asyncio.Event(),
+        backoff_config=DEFAULT_BACKOFF,
+        poll_config=DEFAULT_POLL_CONFIG,
+        get_access_token=lambda: 'oauth-tok',
+    )
+    assert daemon.token_refresh is not None
+    # Prime active_sessions with a v1 session (NOT in v2_sessions).
+    handle = FakeSessionHandle('cse_v1', 'initial-jwt')
+    daemon.active_sessions['cse_v1'] = handle
+    # Fire the refresh callback directly.
+    daemon.token_refresh._on_refresh('cse_v1', 'fresh-oauth-token')
+    await asyncio.sleep(0.01)
+    # v1: token pushed to the child.
+    assert handle.access_token == 'fresh-oauth-token'
+    # v1: reconnect_session NOT called.
+    assert api.reconnect_calls == []
+
+
+@pytest.mark.asyncio
+async def test_daemon_token_refresh_v2_calls_reconnect() -> None:
+    """v2: ``on_refresh`` schedules ``api.reconnect_session(env, sid)``
+    instead of pushing to the child. The fresh token does NOT touch
+    ``handle.update_access_token``."""
+    from src.bridge.bridge_main import _BridgeDaemon, DEFAULT_BACKOFF
+    from src.bridge.poll_config_defaults import DEFAULT_POLL_CONFIG
+
+    api = FakeApiClient()
+    spawner = FakeSpawner()
+    daemon = _BridgeDaemon(
+        config=_bridge_config(),
+        environment_id='env-srv',
+        environment_secret='sec',
+        api=api,
+        spawner=spawner,
+        cancel_event=asyncio.Event(),
+        backoff_config=DEFAULT_BACKOFF,
+        poll_config=DEFAULT_POLL_CONFIG,
+        get_access_token=lambda: 'oauth-tok',
+    )
+    assert daemon.token_refresh is not None
+    handle = FakeSessionHandle('cse_v2', 'initial-jwt')
+    daemon.active_sessions['cse_v2'] = handle
+    daemon.v2_sessions.add('cse_v2')
+
+    daemon.token_refresh._on_refresh('cse_v2', 'fresh-oauth-token')
+    # The reconnect_session call is scheduled as an async task.
+    await asyncio.sleep(0.05)
+    assert api.reconnect_calls == [('env-srv', 'cse_v2')]
+    # v2: stdin update did NOT happen.
+    assert handle.access_token == 'initial-jwt'
+
+
+@pytest.mark.asyncio
+async def test_daemon_token_refresh_v2_failure_swallowed() -> None:
+    """v2 ``reconnect_session`` raising in the refresh path must not
+    propagate; the next scheduled refresh will retry naturally."""
+    from src.bridge.bridge_main import _BridgeDaemon, DEFAULT_BACKOFF
+    from src.bridge.poll_config_defaults import DEFAULT_POLL_CONFIG
+
+    api = FakeApiClient()
+    async def reconnect_raise(_env: str, _sid: str) -> None:
+        raise RuntimeError('server unavailable')
+    api.reconnect_session = reconnect_raise  # type: ignore[method-assign]
+    spawner = FakeSpawner()
+    daemon = _BridgeDaemon(
+        config=_bridge_config(),
+        environment_id='env-srv',
+        environment_secret='sec',
+        api=api,
+        spawner=spawner,
+        cancel_event=asyncio.Event(),
+        backoff_config=DEFAULT_BACKOFF,
+        poll_config=DEFAULT_POLL_CONFIG,
+        get_access_token=lambda: 'oauth-tok',
+    )
+    assert daemon.token_refresh is not None
+    handle = FakeSessionHandle('cse_v2', 'initial-jwt')
+    daemon.active_sessions['cse_v2'] = handle
+    daemon.v2_sessions.add('cse_v2')
+
+    daemon.token_refresh._on_refresh('cse_v2', 'fresh-token')
+    await asyncio.sleep(0.05)
+    # No exception escaped. Daemon state intact.
+    assert 'cse_v2' in daemon.active_sessions
+    assert 'cse_v2' in daemon.v2_sessions
+
+
+@pytest.mark.asyncio
+async def test_daemon_token_refresh_skipped_for_dead_session() -> None:
+    """If the session ended between schedule and fire,
+    ``handle is None`` short-circuits the callback — no stdin push,
+    no reconnect."""
+    from src.bridge.bridge_main import _BridgeDaemon, DEFAULT_BACKOFF
+    from src.bridge.poll_config_defaults import DEFAULT_POLL_CONFIG
+
+    api = FakeApiClient()
+    daemon = _BridgeDaemon(
+        config=_bridge_config(),
+        environment_id='env-srv',
+        environment_secret='sec',
+        api=api,
+        spawner=FakeSpawner(),
+        cancel_event=asyncio.Event(),
+        backoff_config=DEFAULT_BACKOFF,
+        poll_config=DEFAULT_POLL_CONFIG,
+        get_access_token=lambda: 'oauth-tok',
+    )
+    assert daemon.token_refresh is not None
+    # No active session for cse_gone.
+    daemon.token_refresh._on_refresh('cse_gone', 'fresh-token')
+    await asyncio.sleep(0.02)
+    assert api.reconnect_calls == []
+
+
+@pytest.mark.asyncio
+async def test_daemon_without_get_access_token_has_no_scheduler() -> None:
+    """When ``get_access_token`` is None (the default), the daemon
+    constructs no scheduler — sessions use their initial JWT until
+    expiry. Matches TS ``getAccessToken ? createTokenRefreshScheduler
+    : null`` at ``bridgeMain.ts:283``."""
+    from src.bridge.bridge_main import _BridgeDaemon, DEFAULT_BACKOFF
+    from src.bridge.poll_config_defaults import DEFAULT_POLL_CONFIG
+
+    daemon = _BridgeDaemon(
+        config=_bridge_config(),
+        environment_id='env-srv',
+        environment_secret='sec',
+        api=FakeApiClient(),
+        spawner=FakeSpawner(),
+        cancel_event=asyncio.Event(),
+        backoff_config=DEFAULT_BACKOFF,
+        poll_config=DEFAULT_POLL_CONFIG,
+        # No get_access_token kwarg.
+    )
+    assert daemon.token_refresh is None
 
 
 @pytest.mark.asyncio

--- a/tests/bridge/test_repl_bridge.py
+++ b/tests/bridge/test_repl_bridge.py
@@ -629,6 +629,261 @@ async def test_dropped_batch_count_increments_on_write_failure() -> None:
     await handle.teardown()
 
 
+# ── Phase 15: JWT refresh v1/v2 split ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_v1_token_refresh_pushes_to_session_via_stdin() -> None:
+    """v1 work item (use_code_sessions=False): on_refresh pushes the
+    fresh OAuth/JWT to the child via session.update_access_token,
+    and does NOT call api.reconnect_session."""
+    work = {
+        'id': 'work-v1', 'type': 'work', 'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_v1'},
+        'secret': _encode_work_secret(use_ccr_v2=False),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    params = _make_params()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    for _ in range(30):
+        await asyncio.sleep(0.01)
+        if spawner.handles:
+            break
+    assert spawner.handles
+    state = handle.write_messages.__self__  # type: ignore[attr-defined]
+    assert state.active_use_ccr_v2 is False
+    # Snapshot the initial reconnect_calls count (Strategy-1 reconnect
+    # is unrelated; this guards against test ordering surprises).
+    initial_reconnects = len(api.reconnect_calls)
+
+    # Fire on_refresh directly via the scheduler's stored callback.
+    state.active_token_refresh._on_refresh('cse_v1', 'fresh-oauth-token')
+    # Let any scheduled tasks run.
+    await asyncio.sleep(0.02)
+    # v1 path: token pushed to child stdin.
+    assert spawner.handles[0].access_token == 'fresh-oauth-token'
+    # v1 must NOT call reconnect_session.
+    assert len(api.reconnect_calls) == initial_reconnects
+
+    spawner.handles[0].complete('completed')
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_v2_token_refresh_calls_reconnect_session() -> None:
+    """v2 work item (use_code_sessions=True): on_refresh schedules
+    api.reconnect_session(env_id, session_id), and does NOT push to
+    the child's stdin (CCR worker endpoints validate the JWT's
+    session_id claim — pushing OAuth would break them)."""
+    work = {
+        'id': 'work-v2', 'type': 'work', 'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_v2'},
+        'secret': _encode_work_secret(use_ccr_v2=True),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    params = _make_params()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    for _ in range(30):
+        await asyncio.sleep(0.01)
+        if spawner.handles:
+            break
+    assert spawner.handles
+    state = handle.write_messages.__self__  # type: ignore[attr-defined]
+    assert state.active_use_ccr_v2 is True
+
+    initial_reconnects = len(api.reconnect_calls)
+    initial_child_token = spawner.handles[0].access_token
+
+    state.active_token_refresh._on_refresh('cse_v2', 'fresh-oauth-token')
+    # Let the scheduled reconnect task run.
+    await asyncio.sleep(0.05)
+    # v2 path: reconnect_session called with (env, session_id).
+    assert len(api.reconnect_calls) == initial_reconnects + 1
+    env_id, sid = api.reconnect_calls[-1]
+    assert sid == 'cse_v2'
+    # Child's access_token unchanged — v2 doesn't push via stdin.
+    assert spawner.handles[0].access_token == initial_child_token
+
+    spawner.handles[0].complete('completed')
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_v2_token_refresh_reconnect_failure_swallowed() -> None:
+    """If api.reconnect_session raises during v2 refresh, no
+    exception propagates and the bridge state is preserved (the
+    scheduler's follow-up timer will retry naturally)."""
+    work = {
+        'id': 'work-v2', 'type': 'work', 'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_v2'},
+        'secret': _encode_work_secret(use_ccr_v2=True),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    params = _make_params()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    for _ in range(30):
+        await asyncio.sleep(0.01)
+        if spawner.handles:
+            break
+    state = handle.write_messages.__self__  # type: ignore[attr-defined]
+
+    # Make reconnect_session raise.
+    async def reconnect_raise(_env: str, _sid: str) -> None:
+        raise RuntimeError('server unavailable')
+    api.reconnect_session = reconnect_raise  # type: ignore[method-assign]
+
+    # Fire on_refresh — must not raise.
+    state.active_token_refresh._on_refresh('cse_v2', 'fresh-oauth-token')
+    await asyncio.sleep(0.05)
+    # Bridge state is intact.
+    assert state.active_session is not None
+    assert state.active_use_ccr_v2 is True
+
+    spawner.handles[0].complete('completed')
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_session_done_clears_v2_flag() -> None:
+    """After a v2 session completes, ``active_use_ccr_v2`` is reset
+    to False so the next spawn starts clean."""
+    work = {
+        'id': 'work-v2', 'type': 'work', 'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_v2'},
+        'secret': _encode_work_secret(use_ccr_v2=True),
+        'created_at': '2026-05-24',
+    }
+    api = FakeApiClient(poll_results=[work])
+    spawner = FakeSpawner()
+    params = _make_params()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    for _ in range(30):
+        await asyncio.sleep(0.01)
+        if spawner.handles:
+            break
+    state = handle.write_messages.__self__  # type: ignore[attr-defined]
+    assert state.active_use_ccr_v2 is True
+
+    spawner.handles[0].complete('completed')
+    # Wait for _await_session_done to run.
+    for _ in range(30):
+        await asyncio.sleep(0.01)
+        if not state.active_use_ccr_v2:
+            break
+    assert state.active_use_ccr_v2 is False
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_existing_handle_path_updates_token_for_redispatched_work(
+) -> None:
+    """Phase 15 CRITIC: when work arrives for an already-active session
+    (e.g. server re-dispatched after a v2 JWT refresh), the bridge
+    updates the existing handle's token + reschedules the refresh,
+    and does NOT spawn a duplicate subprocess. Mirrors TS
+    ``bridgeMain.ts:868-885``."""
+    import base64
+    import json
+    import time
+
+    payload = {'exp': int(time.time()) + 3600, 'session_id': 'cse_v2'}
+    payload_b64 = base64.urlsafe_b64encode(
+        json.dumps(payload).encode('utf-8'),
+    ).rstrip(b'=').decode('ascii')
+    real_jwt = f'header.{payload_b64}.signature'
+
+    # First work item: triggers normal spawn.
+    secret_v2_initial: dict[str, Any] = {
+        'version': 1,
+        'session_ingress_token': real_jwt,
+        'api_base_url': 'https://api.example.com',
+        'sources': [],
+        'auth': [],
+        'use_code_sessions': True,
+    }
+    raw_v2 = json.dumps(secret_v2_initial).encode('utf-8')
+    encoded_v2 = base64.urlsafe_b64encode(raw_v2).rstrip(b'=').decode('ascii')
+    initial_work = {
+        'id': 'work-1', 'type': 'work', 'environment_id': 'env-srv-1',
+        'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_v2'},
+        'secret': encoded_v2,
+        'created_at': '2026-05-26',
+    }
+    api = FakeApiClient(poll_results=[initial_work])
+    spawner = FakeSpawner()
+    params = _make_params()
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=spawner,
+    )
+    assert handle is not None
+    for _ in range(30):
+        await asyncio.sleep(0.01)
+        if spawner.handles:
+            break
+    assert len(spawner.spawns) == 1
+    existing_handle = spawner.handles[0]
+    state = handle.write_messages.__self__  # type: ignore[attr-defined]
+    assert state.active_session is existing_handle
+    initial_work_id = state.active_work_id
+
+    # Simulate a server re-dispatch: synthesize a second work item
+    # with the SAME session_id but a different work_id (the server
+    # would issue a new work_id on re-dispatch) + a fresh JWT.
+    fresh_payload = {
+        'exp': int(time.time()) + 7200, 'session_id': 'cse_v2',
+    }
+    fresh_b64 = base64.urlsafe_b64encode(
+        json.dumps(fresh_payload).encode('utf-8'),
+    ).rstrip(b'=').decode('ascii')
+    fresh_jwt = f'header.{fresh_b64}.signature'
+    secret_v2_redispatch = {**secret_v2_initial, 'session_ingress_token': fresh_jwt}
+    raw_re = json.dumps(secret_v2_redispatch).encode('utf-8')
+    encoded_re = base64.urlsafe_b64encode(raw_re).rstrip(b'=').decode('ascii')
+    redispatch_work = {
+        'id': 'work-redispatched', 'type': 'work',
+        'environment_id': 'env-srv-1', 'state': 'pending',
+        'data': {'type': 'session', 'id': 'cse_v2'},
+        'secret': encoded_re,
+        'created_at': '2026-05-26',
+    }
+    # Invoke _process_work directly with the redispatch.
+    await state._process_work(redispatch_work)
+    # NO new spawn.
+    assert len(spawner.spawns) == 1
+    # Existing handle's token bumped.
+    assert existing_handle.access_token == fresh_jwt
+    # work_id rolled to the redispatch.
+    assert state.active_work_id == 'work-redispatched'
+    assert state.active_work_id != initial_work_id
+
+    # Cleanup.
+    existing_handle.complete('completed')
+    await handle.teardown()
+
+
 @pytest.mark.asyncio
 async def test_jwt_refresh_scheduler_armed_on_spawn() -> None:
     """When a session is spawned, the JWT refresh scheduler is created."""


### PR DESCRIPTION
## Summary

The bridge has a `TokenRefreshScheduler` (`src/bridge/jwt_utils.py`) that fires 5 minutes before the session-ingress JWT expires. But the `on_refresh` callback was either **broken for v2** (`repl_bridge.py` unconditionally pushed to child stdin — which would break CCR worker endpoints that validate the JWT's `session_id` claim per `register_worker.go:32`) or **entirely missing** (`bridge_main.py` had no scheduler — daemon sessions silently died at JWT expiry, the CC-1263 case).

Phase 15 wires both correctly with the **v1/v2 split per TS `bridgeMain.ts:286-308`**:

- **v2 (CCR worker endpoints)**: call `api.reconnect_session(env_id, session_id)`. The server re-dispatches the work item with a fresh JWT, which flows through the next poll's `_process_work` and lands on the existing handle via the new `existingHandle` path.
- **v1 (Session-Ingress)**: call `handle.update_access_token(oauth_token)`. Session-ingress accepts OAuth or JWT.

## What's new

### `src/bridge/repl_bridge.py`

- Module docstring cleaned up — stale 12b/12c "deferred" bullets removed; current capabilities listed; v2 refresh limitation documented honestly.
- `_BridgeState.active_use_ccr_v2: bool` — set in `_process_work`, cleared in `_await_session_done`.
- `_build_token_refresh_scheduler.on_refresh` — v1/v2 dispatch.
- New `_safe_reconnect_for_refresh` async helper (broad-except + warning log).
- **`existingHandle` path in `_process_work`** — when work arrives for the already-active session_id (server re-dispatch after v2 refresh), push the fresh JWT to the live handle + reschedule + return. NO duplicate spawn.

### `src/bridge/bridge_main.py`

- New `get_access_token: Callable[[], str | None] | None = None` kwarg on `run_bridge_loop` + `_BridgeDaemon`. CLI entry point (`_bridge_main_async`) passes its existing `get_access_token` through.
- `_BridgeDaemon.v2_sessions: set[str]` + `token_refresh: TokenRefreshScheduler | None` (conditional on `get_access_token`).
- `_build_token_refresh_scheduler` + `_safe_reconnect_for_refresh` matching TS `bridgeMain.ts:286-308`.
- `_process_work`: schedule refresh on spawn; track v2 session ids.
- **`existingHandle` path in `_process_work`** — same shape as `repl_bridge`. Without this, v2 refresh's `reconnect_session` redispatch would spawn a **duplicate child** for the same session_id, orphaning the original. This was the CRITIC round-1 BLOCKING fix.
- `_on_session_done`: cancel scheduler entry + discard from `v2_sessions`.
- `shutdown`: `cancel_all()` + `v2_sessions.clear()` for hygiene.

### Why the v1/v2 split matters

v2 CCR worker endpoints (`register_worker.go:32`) validate the JWT's `session_id` claim. Pushing an OAuth token to the child via stdin would break subsequent `/worker/*` requests. The v2 path **must** go through server-side re-dispatch (`reconnect_session`), which mints a fresh JWT with the right `session_id` claim and re-delivers the work item. The bridge picks it up in the next poll, the `existingHandle` path routes it to the live child, and the child's transport reconnects with the fresh JWT.

v1 Session-Ingress accepts either OAuth or JWT, so the simple "push fresh token to child stdin" path works there directly.

## CRITIC review

**Round 1 — REQUEST CHANGES** (2 BLOCKING + 3 MAJOR + several MINORs):

- **BLOCKING #1**: `existingHandle` path missing in `bridge_main._process_work`. Without it, v2 refresh's redispatch would spawn a duplicate child for the same session_id, orphaning the original. Fixed at both `repl_bridge` and `bridge_main` dispatch sites with regression tests in both.
- **BLOCKING #2**: `repl_bridge._poll_loop` skips polling while active, so v2 refresh's reconnect succeeds but the redispatch never gets picked up — round-trip is non-functional in the single-session bridge. **Documented as an explicit non-goal** in the module docstring (with a pointer to use `bridge_main.py` for guaranteed v2 refresh). The `existingHandle` path is still added so that *if* a poll happens to fire between the reconnect and lease expiry, the fresh JWT routes correctly.
- **MAJOR #1**: `test_daemon_schedules_token_refresh_on_spawn` was weak (used a non-JWT token that silently no-op'd the scheduler). Rewrote with a real-decodable JWT + direct `_BridgeDaemon` construction + assertions on `daemon.token_refresh._timers` membership.
- **MAJOR #2**: `v2_sessions` never cleared on shutdown. Added `.clear()` after `cancel_all`.
- **MAJOR #3**: Stale comment on `get_access_token`. Updated to reflect actual semantics.

**Round 2 — APPROVE.** All fixes verified. Empirically confirmed that removing the `existingHandle` early-return causes the new regression tests to fail with the expected "duplicate spawn" message. 756/756 tests pass.

## Test plan

- [x] **756/756 transport + bridge tests pass** (was 744 at phase 14c baseline, +12 net)
- [x] **5 new tests in `test_repl_bridge.py`**: v1 push-to-stdin, v2 reconnect_session, v2 failure swallowed, session done clears v2 flag, existingHandle redispatch path
- [x] **7 new tests in `test_bridge_main.py`**: daemon schedules refresh on spawn (with real JWT + timer-armed assertion), v1 push-to-handle, v2 calls reconnect, v2 failure swallowed, refresh skipped for dead session, no scheduler when get_access_token absent, existingHandle redispatch path
- [x] FakeApiClient widened with `reconnect_calls` capture (additive — no existing-test impact)
- [x] FakeSessionHandle.update_access_token now records the new token

## Non-goals (deferred to follow-up phases)

- **`remote_bridge_core.py` scheduler migration** — orthogonal; its existing wiring is correct for the v2-env-less orchestrator.
- **`CCRClient` migration to `SerialBatchEventUploader`** — orthogonal; not v1/v2-related.
- **`repl_bridge` poll-while-active for guaranteed v2 refresh** — explicit non-goal; `bridge_main` is the multi-session path that gets this for free via continuous polling. Documented in `repl_bridge.py`'s module docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)