### PR TITLE
bridge phase 16: eager pointer clear on env-mismatch (phase-13 follow-up)

### DIFF
--- a/src/bridge/repl_bridge.py
+++ b/src/bridge/repl_bridge.py
@@ -329,6 +329,17 @@ async def init_bridge_core(
     # we'd captured from the pointer is bound to the dead env and
     # would be useless against the new env, so drop it — create_session
     # will mint a fresh one below.
+    #
+    # Phase 16 / phase-13 follow-up: also clear the stale pointer
+    # eagerly. Phase 12c's original behavior relied on the post-
+    # ``create_session`` pointer write to overwrite the stale entry,
+    # but if ``create_session`` itself fails after this branch fires,
+    # the stale pointer survives on disk and a subsequent restart
+    # would re-hint the dead env again. TS clears on any failure to
+    # reuse the prior pointer (``prior && !reusedPriorSession`` at
+    # ``replBridge.ts:429-431``) — Python mirrors this with two
+    # clears: here for the env-mismatch case, and at the reconnect-
+    # validation block below for the all-candidates-refused case.
     if (
         pointer is not None
         and registration['environment_id'] != pointer.environment_id
@@ -339,6 +350,7 @@ async def init_bridge_core(
             pointer.environment_id, registration['environment_id'],
         )
         reuse_session_id = None
+        clear_pointer(params.dir)
 
     # ── 2. Validate the pointer's session id, reuse or create ──────────
     # Phase 13: before trusting ``reuse_session_id``, actively probe the

--- a/tests/bridge/test_repl_bridge.py
+++ b/tests/bridge/test_repl_bridge.py
@@ -1497,6 +1497,50 @@ async def test_perpetual_falls_back_when_server_assigns_new_env_id(
 
 
 @pytest.mark.asyncio
+async def test_perpetual_env_mismatch_clears_stale_pointer_eagerly(
+    tmp_path,
+) -> None:
+    """Phase 16: on env-mismatch, the stale pointer is cleared
+    eagerly so that if ``create_session`` subsequently fails, a
+    next-start doesn't re-hint the dead env again. Mirrors TS
+    ``replBridge.ts:429-431``."""
+    from src.bridge.bridge_pointer import read_pointer, write_pointer
+
+    params = _make_params(perpetual=True)
+    params.dir = str(tmp_path)
+    write_pointer(
+        params.dir,
+        bridge_id=params.bridge_id,
+        environment_id='env-srv-OLD',
+        session_id='cse_dead',
+        machine_name=params.machine_name,
+    )
+    api = FakeApiClient()
+    # Server returns DIFFERENT env id (mismatch).
+    api.register_result = {
+        'environment_id': 'env-srv-FRESH',
+        'environment_secret': 'sec-fresh',
+    }
+    # Make create_session fail so we can observe the post-mismatch
+    # pointer state — without the eager clear, a stale pointer with
+    # env-srv-OLD would survive on disk.
+    async def failing_create(_opts: dict[str, Any]) -> str | None:
+        return None
+    params.create_session = failing_create  # type: ignore[assignment]
+
+    handle = await init_bridge_core(
+        params, api_client=api, spawner=FakeSpawner(),
+    )
+    # init_bridge_core returns None when create_session fails.
+    assert handle is None
+    # Pointer was cleared on env-mismatch BEFORE create_session ran;
+    # the subsequent create_session failure didn't leave a stale
+    # env-srv-OLD pointer on disk. The pointer file is gone.
+    p = read_pointer(params.dir, machine_name=params.machine_name)
+    assert p is None
+
+
+@pytest.mark.asyncio
 async def test_perpetual_ignores_stale_pointer_from_different_dir(
     tmp_path,
 ) -> None:


### PR DESCRIPTION
## Summary

Phase 12c's env-mismatch branch in `init_bridge_core` nulled `reuse_session_id` but did **not** clear the stale pointer on disk. If `create_session` subsequently failed (returned None or raised), `init_bridge_core` returned None and the stale pointer survived — a next-start would re-hint the dead env again, requiring another full register cycle to discover the same mismatch.

TS clears on any failure to reuse the prior pointer (`prior && !reusedPriorSession` at `replBridge.ts:429-431`). Python now mirrors this with two clears: this one for env-mismatch, and the existing one at the reconnect-validation block (phase 13) for the all-candidates-refused case.

## What's new

`src/bridge/repl_bridge.py` — added `clear_pointer(params.dir)` after `reuse_session_id = None` in the env-mismatch branch. Comment block explains the divergence + cites TS line.

## CRITIC review

One round, APPROVE. One minor comment tweak applied (parity-docs precision — clarified that TS clears on both env-mismatch AND reconnect-exhausted, which Python now mirrors via two separate clears).

## Test plan

- [x] **45/45 repl_bridge tests pass** (+1 new test)
- [x] `test_perpetual_env_mismatch_clears_stale_pointer_eagerly`: seeds pointer (env-srv-OLD), configures server to return env-srv-FRESH, forces create_session to return None. Asserts init returned None AND the pointer file is gone post-init. Verified the test fails without the source fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)