### PR TITLE
bridge phase 17: hourly pointer mtime refresh for perpetual mode

### DIFF
--- a/src/bridge/repl_bridge.py
+++ b/src/bridge/repl_bridge.py
@@ -106,6 +106,14 @@ from src.bridge.work_secret import (
 logger = logging.getLogger(__name__)
 
 
+# Phase 17: hourly pointer-mtime refresh interval for perpetual mode.
+# Mirrors TS ``replBridge.ts:1541`` (``60 * 60_000`` ms = 1 hour).
+# Long-running sessions touch the pointer once per interval so the
+# mtime stays fresh; without this, a future TTL check on the pointer
+# would reject it after a few hours of no user activity.
+POINTER_MTIME_REFRESH_INTERVAL_S = 60.0 * 60.0
+
+
 # ── Public types ──────────────────────────────────────────────────────────
 
 
@@ -468,6 +476,13 @@ async def init_bridge_core(
             machine_name=params.machine_name,
             created_at_ms=pointer_created_at_ms,
         )
+        # Phase 17: start the periodic mtime-refresh task. Skipped in
+        # non-perpetual mode since the pointer is cleared on teardown
+        # anyway.
+        state.pointer_mtime_task = asyncio.create_task(
+            state._pointer_mtime_refresh_loop(),
+            name='bridge-repl-pointer-mtime-refresh',
+        )
     state.start_poll_loop()
 
     _fire_state(params.on_state_change, 'ready')
@@ -528,6 +543,11 @@ class _BridgeState:
     # operators can see how long a perpetual bridge has been alive.
     perpetual: bool = False
     pointer_created_at_ms: int | None = None
+    #: Phase 17: periodic pointer-mtime refresh task. Started in
+    #: perpetual mode at init; touches the pointer once per hour so
+    #: long-running sessions don't leave a stale mtime that triggers
+    #: the next-start TTL check (when one lands). Cancelled in teardown.
+    pointer_mtime_task: asyncio.Task[None] | None = None
 
     async def _update_pointer(self, *, session_id: str | None) -> None:
         """No-op when not perpetual; otherwise rewrite the pointer with
@@ -560,6 +580,51 @@ class _BridgeState:
         if not self.perpetual:
             return
         await asyncio.to_thread(clear_pointer, self.params.dir)
+
+    async def _pointer_mtime_refresh_loop(self) -> None:
+        """Phase 17: periodic pointer-mtime refresh for perpetual mode.
+
+        Mirrors TS ``replBridge.ts:1522-1543`` — a daemon idle for
+        many hours without a user prompt would have a stale pointer
+        mtime; when the next-start TTL check (future phase) lands, it
+        would reject the pointer and force a fresh session. Touching
+        the pointer hourly keeps long-running sessions recoverable.
+
+        The write is atomic via ``write_pointer``'s tmpfile + os.replace
+        primitive, so a race with ``_recreate_environment``'s own
+        pointer write cannot leave a half-corrupt file. The race is
+        benign in the common case (Strategy-1 updates env+session in
+        a tight window) but **narrowly inconsistent in Strategy-2**:
+        between the env-id swap and the new session-id assignment,
+        ``active_session_id`` is briefly ``None`` while
+        ``environment_id`` is already the new one. A refresh tick
+        landing in that window writes ``(new_env_id, session_id=None)``;
+        if the refresh's write *follows* Strategy-2's final write,
+        the pointer ends as ``(new_env_id, None)`` instead of
+        ``(new_env_id, new_session_id)``. The next start would resume
+        the env but mint a fresh session — recoverable, not corrupt.
+        Strategy-2 has already killed the prior session by that point,
+        so user-visible continuity was already lost. TS guards against
+        this with a ``reconnectPromise`` skip; we accept the benign
+        race in exchange for a simpler implementation.
+
+        Loop exits on ``CancelledError`` (teardown cancels the task,
+        catches cancellation from either the sleep or the inner
+        ``_update_pointer`` await).
+        """
+        try:
+            while not self.torn_down:
+                await asyncio.sleep(POINTER_MTIME_REFRESH_INTERVAL_S)
+                if self.torn_down:
+                    return
+                # ``active_session_id`` may be None between sessions
+                # (post ``_await_session_done``); ``_update_pointer``
+                # handles None correctly by writing a null session_id.
+                await self._update_pointer(
+                    session_id=self.active_session_id,
+                )
+        except asyncio.CancelledError:
+            return
 
     # ── Poll loop ───────────────────────────────────────────────────────
 
@@ -1227,6 +1292,18 @@ class _BridgeState:
                 await self.poll_task
             except (asyncio.CancelledError, Exception):  # noqa: BLE001
                 pass
+
+        # Phase 17: cancel the periodic pointer-mtime refresh task.
+        # The loop also checks ``torn_down`` between sleeps, but
+        # cancelling here ends it immediately instead of waiting up to
+        # an hour for the next tick.
+        if self.pointer_mtime_task is not None:
+            self.pointer_mtime_task.cancel()
+            try:
+                await self.pointer_mtime_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+            self.pointer_mtime_task = None
 
         # Cancel the JWT refresh scheduler so any pending refresh
         # doesn't write to a dead stdin during teardown.

--- a/tests/bridge/test_repl_bridge.py
+++ b/tests/bridge/test_repl_bridge.py
@@ -1497,6 +1497,86 @@ async def test_perpetual_falls_back_when_server_assigns_new_env_id(
 
 
 @pytest.mark.asyncio
+async def test_perpetual_starts_pointer_mtime_refresh_task(tmp_path) -> None:
+    """Phase 17: in perpetual mode, the periodic pointer-mtime refresh
+    task is started at init."""
+    params = _make_params(perpetual=True)
+    params.dir = str(tmp_path)
+    handle = await init_bridge_core(
+        params, api_client=FakeApiClient(), spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    state = handle.write_messages.__self__  # type: ignore[attr-defined]
+    assert state.pointer_mtime_task is not None
+    assert not state.pointer_mtime_task.done()
+    await handle.teardown()
+    # Task is cancelled + cleared on teardown.
+    assert state.pointer_mtime_task is None
+
+
+@pytest.mark.asyncio
+async def test_non_perpetual_does_not_start_pointer_mtime_task(
+    tmp_path,
+) -> None:
+    """Phase 17: non-perpetual mode skips the mtime refresh task —
+    the pointer is cleared on teardown anyway, no maintenance needed."""
+    params = _make_params(perpetual=False)
+    params.dir = str(tmp_path)
+    handle = await init_bridge_core(
+        params, api_client=FakeApiClient(), spawner=FakeSpawner(),
+    )
+    assert handle is not None
+    state = handle.write_messages.__self__  # type: ignore[attr-defined]
+    assert state.pointer_mtime_task is None
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
+async def test_pointer_mtime_task_fires_and_advances_updated_at_ms(
+    tmp_path, monkeypatch,
+) -> None:
+    """Phase 17: when the refresh interval elapses, the pointer's
+    ``updated_at_ms`` advances (proves the task fires + writes)."""
+    from src.bridge import repl_bridge as rb
+    from src.bridge.bridge_pointer import read_pointer
+
+    # Short interval so the test finishes in ~0.1s instead of 1h.
+    monkeypatch.setattr(rb, 'POINTER_MTIME_REFRESH_INTERVAL_S', 0.05)
+
+    params = _make_params(perpetual=True)
+    params.dir = str(tmp_path)
+    handle = await init_bridge_core(
+        params, api_client=FakeApiClient(), spawner=FakeSpawner(),
+    )
+    assert handle is not None
+
+    # Snapshot the initial pointer state.
+    initial = read_pointer(
+        params.dir, machine_name=params.machine_name,
+    )
+    assert initial is not None
+    initial_updated_at_ms = initial.updated_at_ms
+    initial_created_at_ms = initial.created_at_ms
+
+    # Wait for at least one refresh tick to fire.
+    await asyncio.sleep(0.1)
+
+    refreshed = read_pointer(
+        params.dir, machine_name=params.machine_name,
+    )
+    assert refreshed is not None
+    # updated_at_ms advanced (mtime refresh happened).
+    assert refreshed.updated_at_ms > initial_updated_at_ms
+    # created_at_ms preserved (the daemon's install time doesn't reset).
+    assert refreshed.created_at_ms == initial_created_at_ms
+    # bridge_id + env_id unchanged.
+    assert refreshed.bridge_id == initial.bridge_id
+    assert refreshed.environment_id == initial.environment_id
+
+    await handle.teardown()
+
+
+@pytest.mark.asyncio
 async def test_perpetual_env_mismatch_clears_stale_pointer_eagerly(
     tmp_path,
 ) -> None:


### PR DESCRIPTION
## Summary

Phase 12c added the crash-recovery pointer for perpetual mode, written at every lifecycle transition (init, work spawn, session done, recreations, teardown). But a long-running session that doesn't see lifecycle events for many hours would leave the pointer mtime stale; when the next-start TTL check lands (future phase), it would reject the pointer and force a fresh session.

Phase 17 ports TS `replBridge.ts:1522-1543` — a 60-min interval timer that touches the pointer's mtime to keep long-running sessions recoverable.

## What's new

`src/bridge/repl_bridge.py`:
- `POINTER_MTIME_REFRESH_INTERVAL_S = 3600.0` (matches TS 60 * 60_000 ms).
- `_BridgeState.pointer_mtime_task` field.
- `_pointer_mtime_refresh_loop` — sleeps the interval, writes pointer with current env_id + session_id. Loops until `torn_down`.
- `init_bridge_core` starts the task after `start_poll_loop()` only when perpetual.
- `teardown` cancels + awaits.

`bridge_main.py` is NOT modified — it doesn't use bridge_pointer (perpetual-mode pointer is repl_bridge-only).

### Race-window decision

TS guards with `if (reconnectPromise) return` to skip the refresh during a reconnect. Python omits the guard: `write_pointer`'s `os.replace` primitive makes the write atomic, so a race produces one of two valid snapshots, never a corrupt half-write. Strategy-2 has a narrow window where `session_id` is briefly None between env+session swaps; a refresh landing there would write `(new_env, None)`, but the post-race state is **recoverable** (resume env + fresh session) and Strategy-2 has already killed the prior session anyway. Documented in the docstring.

## CRITIC review

One round, APPROVE. Minor doc tightens applied (race-window claim tightened to acknowledge the narrow Strategy-2 window; stale line reference removed).

## Test plan

- [x] **760/760 transport + bridge tests pass** (+3 new)
- [x] `test_perpetual_starts_pointer_mtime_refresh_task` — task exists post-init, cancelled+cleared after teardown
- [x] `test_non_perpetual_does_not_start_pointer_mtime_task` — task is None in non-perpetual mode
- [x] `test_pointer_mtime_task_fires_and_advances_updated_at_ms` — monkeypatches interval to 0.05s; asserts `updated_at_ms` advances while `created_at_ms`/`bridge_id`/`env_id` are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)