### PR TITLE
buddy: port headless core of typescript/src/buddy/ to Python

### DIFF
--- a/src/buddy/__init__.py
+++ b/src/buddy/__init__.py
@@ -1,16 +1,114 @@
-"""Python package placeholder for the archived `buddy` subsystem."""
+"""Python port of ``typescript/src/buddy/``.
 
+Headless core ports are present here; the Ink/React widget
+(``CompanionSprite``, ``useBuddyNotification``) is deferred per
+``my-docs/get-parity-by-folder/buddy-gap-analysis.md`` §3.3.
+"""
 from __future__ import annotations
 
 import json
 from pathlib import Path
 
-SNAPSHOT_PATH = Path(__file__).resolve().parent.parent / 'reference_data' / 'subsystems' / 'buddy.json'
+from src.buddy.companion import (
+    Roll,
+    SALT,
+    companion_user_id,
+    get_companion,
+    roll,
+    roll_with_seed,
+)
+from src.buddy.feature import is_buddy_enabled
+from src.buddy.notification import (
+    find_buddy_trigger_positions,
+    is_buddy_live,
+    is_buddy_teaser_window,
+)
+from src.buddy.observer import fire_companion_observer
+from src.buddy.prompt import (
+    build_companion_intro_attachment,
+    companion_intro_text,
+    format_companion_intro_attachments,
+)
+from src.buddy.soul import (
+    NAME_PREFIXES,
+    NAME_SUFFIXES,
+    PERSONALITIES,
+    create_stored_companion,
+)
+from src.buddy.sprites import (
+    BODIES,
+    HAT_LINES,
+    MIN_COLS_FOR_FULL_SPRITE,
+    render_face,
+    render_sprite,
+    sprite_frame_count,
+)
+from src.buddy.types import (
+    EYES,
+    HATS,
+    RARITIES,
+    RARITY_COLORS,
+    RARITY_STARS,
+    RARITY_WEIGHTS,
+    SPECIES,
+    STAT_NAMES,
+    Companion,
+    CompanionBones,
+    CompanionSoul,
+    Eye,
+    Hat,
+    Rarity,
+    Species,
+    StatName,
+    StoredCompanion,
+)
+
+
+SNAPSHOT_PATH = (
+    Path(__file__).resolve().parent.parent
+    / 'reference_data' / 'subsystems' / 'buddy.json'
+)
 _SNAPSHOT = json.loads(SNAPSHOT_PATH.read_text())
 
 ARCHIVE_NAME = _SNAPSHOT['archive_name']
 MODULE_COUNT = _SNAPSHOT['module_count']
 SAMPLE_FILES = tuple(_SNAPSHOT['sample_files'])
-PORTING_NOTE = f"Python placeholder package for '{ARCHIVE_NAME}' with {MODULE_COUNT} archived module references."
+PORTING_NOTE = (
+    f"Python port of '{ARCHIVE_NAME}' subsystem. Headless core ported; "
+    f"Ink/React widget (CompanionSprite, useBuddyNotification) deferred "
+    f"to future Textual companion-widget pass — see "
+    f"my-docs/get-parity-by-folder/buddy-gap-analysis.md §3.3."
+)
 
-__all__ = ['ARCHIVE_NAME', 'MODULE_COUNT', 'PORTING_NOTE', 'SAMPLE_FILES']
+
+# Private helpers (_get_or_create_user_id, _fnv1a_32, _pick_deterministic,
+# _mulberry32, _roll_from, etc.) are deliberately NOT re-exported.
+__all__ = [
+    # snapshot metadata
+    'ARCHIVE_NAME', 'MODULE_COUNT', 'PORTING_NOTE', 'SAMPLE_FILES',
+    # feature gate
+    'is_buddy_enabled',
+    # types
+    'Companion', 'CompanionBones', 'CompanionSoul', 'Eye', 'Hat',
+    'Rarity', 'Species', 'StatName', 'StoredCompanion',
+    # data
+    'EYES', 'HATS', 'RARITIES', 'RARITY_COLORS', 'RARITY_STARS',
+    'RARITY_WEIGHTS', 'SPECIES', 'STAT_NAMES',
+    # companion
+    'Roll', 'SALT',
+    'companion_user_id', 'get_companion', 'roll', 'roll_with_seed',
+    # sprites
+    'BODIES', 'HAT_LINES', 'MIN_COLS_FOR_FULL_SPRITE',
+    'render_face', 'render_sprite', 'sprite_frame_count',
+    # prompt
+    'build_companion_intro_attachment', 'companion_intro_text',
+    'format_companion_intro_attachments',
+    # observer
+    'fire_companion_observer',
+    # notification
+    'find_buddy_trigger_positions', 'is_buddy_live',
+    'is_buddy_teaser_window',
+    # soul
+    'NAME_PREFIXES', 'NAME_SUFFIXES', 'PERSONALITIES',
+    'create_stored_companion',
+]

--- a/src/buddy/companion.py
+++ b/src/buddy/companion.py
@@ -1,0 +1,261 @@
+"""Companion rolls + identity. Port of ``typescript/src/buddy/companion.ts``.
+
+The "bones + soul" split is load-bearing (gap-analysis §2.1): bones are
+regenerated on every read from ``hash(user_id + SALT)``; the soul is the
+only thing that persists. This means species renames and edits to
+``SPECIES`` never break stored companions, and editing
+``config['companion']`` can't fake a rarity.
+
+Divergence from TS: ``companion_user_id()`` reads
+``config['user_id']`` only (skipping the TS ``oauthAccount.accountUuid``
+fallback), because ``src/auth/claude_ai.py::OAuthAccountInfo`` does not
+yet expose ``account_uuid``. Documented in gap-analysis §2.7. Future
+auth-folder pass will add ``account_uuid`` to the fallback chain.
+
+Performance: the one-entry ``_roll_cache`` keys on ``user_id + SALT``;
+``companion_user_id()`` touches config (potentially file I/O), so
+caching the rolled value is meaningful on the per-turn observer path.
+See gap-analysis §2.2.
+"""
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+from typing import Callable, Sequence, TypeVar
+
+from src.buddy.types import (
+    EYES, HATS, RARITIES, RARITY_WEIGHTS, SPECIES, STAT_NAMES,
+    CompanionBones, Companion, Eye, Hat, Rarity, Species, StatName,
+)
+from src.config import load_config
+
+
+SALT = 'friend-2026-401'
+
+
+# --- Hash + PRNG -----------------------------------------------------
+
+def _hash_string(s: str) -> int:
+    """FNV-1a 32-bit, mirroring TS ``companion.ts:27-37`` plain branch.
+
+    TS includes a Bun fast-path; Python has no Bun runtime so we keep
+    only FNV-1a. See gap-analysis §3.4 S3.
+    """
+    h = 2166136261
+    for c in s:
+        h ^= ord(c)
+        h = (h * 16777619) & 0xFFFFFFFF
+    return h
+
+
+def _mulberry32(seed: int) -> Callable[[], float]:
+    """Bit-exact mulberry32 — TS ``companion.ts:16-25``.
+
+    TS source::
+
+        a = (a + 0x6d2b79f5) | 0
+        let t = Math.imul(a ^ (a >>> 15), 1 | a)
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+
+    Key detail: the second ``t = ... ^ t`` reads the OLD ``t`` on the
+    right of ``^`` (sequencing rule), so the assignment is
+    ``new_t = (old_t + inner) ^ old_t``. We hold ``old_t`` explicitly.
+
+    Math.imul is 32-bit signed multiply; emulated by masking
+    ``& 0xFFFFFFFF`` after the multiplication. Bit patterns match
+    regardless of signed/unsigned interpretation because subsequent
+    operations are bitwise.
+    """
+    a = seed & 0xFFFFFFFF
+
+    def rng() -> float:
+        nonlocal a
+        a = (a + 0x6D2B79F5) & 0xFFFFFFFF
+        # t = Math.imul(a ^ (a >>> 15), 1 | a)
+        t = ((a ^ (a >> 15)) * (1 | a)) & 0xFFFFFFFF
+        # t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+        old_t = t
+        inner = ((t ^ (t >> 7)) * (61 | t)) & 0xFFFFFFFF
+        t = ((t + inner) & 0xFFFFFFFF) ^ old_t
+        # return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+        return ((t ^ (t >> 14)) & 0xFFFFFFFF) / 4294967296.0
+
+    return rng
+
+
+# --- Roll ------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Roll:
+    """Result of a single roll: deterministic bones + an inspiration seed.
+
+    Mirrors TS ``Roll`` (companion.ts:86-89). The ``inspiration_seed``
+    is currently unused on the Python side but kept for parity.
+    """
+    bones: CompanionBones
+    inspiration_seed: int
+
+
+_T = TypeVar('_T')
+
+
+def _pick(rng: Callable[[], float], items: Sequence[_T]) -> _T:
+    """Index into items by ``floor(rng() * len)``.
+
+    TypeVar preserves the species/eye/hat-literal type at each call site
+    (mirrors TS generic ``pick<T>``).
+    """
+    return items[int(rng() * len(items))]
+
+
+_RARITY_FLOOR: dict[Rarity, int] = {
+    'common': 5,
+    'uncommon': 15,
+    'rare': 25,
+    'epic': 35,
+    'legendary': 50,
+}
+
+
+def _roll_rarity(rng: Callable[[], float]) -> Rarity:
+    """TS ``companion.ts:43-51``. Weighted choice."""
+    total = sum(RARITY_WEIGHTS.values())
+    roll_val = rng() * total
+    for r in RARITIES:
+        roll_val -= RARITY_WEIGHTS[r]
+        if roll_val < 0:
+            return r
+    return 'common'
+
+
+def _roll_stats(
+    rng: Callable[[], float], rarity: Rarity,
+) -> dict[StatName, int]:
+    """TS ``companion.ts:62-82``. One peak, one dump, rest scattered."""
+    floor = _RARITY_FLOOR[rarity]
+    peak = _pick(rng, STAT_NAMES)
+    dump = _pick(rng, STAT_NAMES)
+    while dump == peak:
+        dump = _pick(rng, STAT_NAMES)
+    out: dict[StatName, int] = {}
+    for name in STAT_NAMES:
+        if name == peak:
+            out[name] = min(100, floor + 50 + int(rng() * 30))
+        elif name == dump:
+            out[name] = max(1, floor - 10 + int(rng() * 15))
+        else:
+            out[name] = floor + int(rng() * 40)
+    return out
+
+
+def _roll_from(rng: Callable[[], float]) -> Roll:
+    """TS ``companion.ts:91-102``."""
+    rarity = _roll_rarity(rng)
+    species: Species = _pick(rng, SPECIES)
+    eye: Eye = _pick(rng, EYES)
+    hat: Hat = 'none' if rarity == 'common' else _pick(rng, HATS)
+    shiny = rng() < 0.01
+    stats = _roll_stats(rng, rarity)
+    bones = CompanionBones(
+        rarity=rarity,
+        species=species,
+        eye=eye,
+        hat=hat,
+        shiny=shiny,
+        stats=stats,
+    )
+    return Roll(bones=bones, inspiration_seed=int(rng() * 1_000_000_000))
+
+
+# --- Roll cache (gap-analysis §2.2) ---------------------------------
+
+_roll_cache: tuple[str, Roll] | None = None
+
+
+def roll(user_id: str) -> Roll:
+    """Single-entry roll cache keyed by ``user_id + SALT``.
+
+    TS hot paths (per-keystroke PromptInput, 500ms sprite tick) don't
+    exist in Python yet, but ``companion_user_id()`` touches config
+    (potentially file I/O when uncached) and the per-turn observer
+    fires per chat turn — caching the rolled value keeps roll() cheap.
+    """
+    global _roll_cache
+    key = user_id + SALT
+    if _roll_cache is not None and _roll_cache[0] == key:
+        return _roll_cache[1]
+    val = _roll_from(_mulberry32(_hash_string(key)))
+    _roll_cache = (key, val)
+    return val
+
+
+def roll_with_seed(seed: str) -> Roll:
+    """Roll from a caller-provided seed (no cache; not deterministic by user)."""
+    return _roll_from(_mulberry32(_hash_string(seed)))
+
+
+# --- User ID + companion --------------------------------------------
+
+def _get_or_create_user_id() -> str:
+    """Mirror of TS ``getOrCreateUserID()`` at ``config.ts:1858-1867``.
+
+    Reads Python ``config['user_id']``; creates a 32-byte hex on absence
+    (matching TS ``randomBytes(32).toString('hex')``) and persists via
+    ``ConfigManager.set_global``. Skips OAuth-accountUuid fallback
+    because ``OAuthAccountInfo`` doesn't expose it yet — see
+    gap-analysis §2.7.
+    """
+    cfg = load_config()
+    existing = cfg.get('user_id')
+    if isinstance(existing, str) and existing:
+        return existing
+    new_id = secrets.token_hex(32)
+    # Late import to avoid module-load cycles (config imports may pull
+    # in providers which transitively may want bootstrap state).
+    from src.config import _get_default_manager
+    _get_default_manager().set_global('user_id', new_id)
+    return new_id
+
+
+def companion_user_id() -> str:
+    """ID source for the deterministic bones roll. Pinned per §2.7."""
+    return _get_or_create_user_id()
+
+
+def get_companion() -> Companion | None:
+    """Read the persisted soul, merge with regenerated bones.
+
+    Returns ``None`` when no companion has been hatched yet. Mirrors TS
+    ``companion.ts:127-133`` semantics: missing soul → ``None``;
+    present soul → merge with fresh bones.
+    """
+    cfg = load_config()
+    stored = cfg.get('companion')
+    if not isinstance(stored, dict):
+        return None
+    bones = roll(companion_user_id()).bones
+    return Companion(
+        name=stored.get('name', ''),
+        personality=stored.get('personality', ''),
+        hatched_at=int(stored.get('hatched_at', 0)),
+        rarity=bones.rarity,
+        species=bones.species,
+        eye=bones.eye,
+        hat=bones.hat,
+        shiny=bones.shiny,
+        stats=dict(bones.stats),
+    )
+
+
+def _reset_roll_cache_for_tests() -> None:
+    """Pytest-gated escape hatch — see gap-analysis §5 / plan §5 risks."""
+    global _roll_cache
+    _roll_cache = None
+
+
+__all__ = [
+    'Roll', 'SALT',
+    'companion_user_id', 'get_companion',
+    'roll', 'roll_with_seed',
+]

--- a/src/buddy/feature.py
+++ b/src/buddy/feature.py
@@ -1,0 +1,18 @@
+"""Buddy feature gate. Port of ``typescript/src/buddy/feature.ts``.
+
+Always returns ``True``. Symbol exists so call sites are auditable
+(grep-able) and a future env-var or config gate can be wired here
+without touching every consumer.
+
+See ``my-docs/get-parity-by-folder/buddy-gap-analysis.md`` §4.7 and
+``buddy-refactoring-plan.md`` §2.1 for the pinned always-True decision.
+"""
+from __future__ import annotations
+
+
+def is_buddy_enabled() -> bool:
+    """Whether the companion / buddy subsystem is active in this build."""
+    return True
+
+
+__all__ = ['is_buddy_enabled']

--- a/src/buddy/notification.py
+++ b/src/buddy/notification.py
@@ -1,0 +1,62 @@
+"""Buddy notification helpers + date gates + trigger highlights.
+
+Ports the non-React parts of ``typescript/src/buddy/useBuddyNotification.tsx``.
+The React hook ``useBuddyNotification`` itself stays deferred (Class C1
+in ``my-docs/get-parity-by-folder/buddy-gap-analysis.md`` §3.3) — Python
+has no notification context outside Textual yet, and the rainbow
+renderer needs a Textual host.
+
+The TS dead ``"external" === 'ant'`` branch is dropped here: Python has
+no equivalent build-substitution facility. See gap-analysis §2.4.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+from src.buddy.feature import is_buddy_enabled
+
+
+def is_buddy_teaser_window() -> bool:
+    """Whether today falls inside the April 1-7 2026 teaser window.
+
+    Local date, not UTC — mirrors TS ``useBuddyNotification.tsx:12-16``.
+    The teaser window is a 24h rolling sweep across timezones (avoids
+    a UTC-midnight spike on soul-gen load).
+    """
+    d = datetime.now()
+    return d.year == 2026 and d.month == 4 and d.day <= 7
+
+
+def is_buddy_live() -> bool:
+    """Whether the buddy feature is live (post April 1 2026).
+
+    Mirrors TS ``useBuddyNotification.tsx:17-21``.
+    """
+    d = datetime.now()
+    return d.year > 2026 or (d.year == 2026 and d.month >= 4)
+
+
+_BUDDY_TRIGGER_RE = re.compile(r'/buddy\b')
+
+
+def find_buddy_trigger_positions(text: str) -> list[dict[str, int]]:
+    """Return character ranges where ``/buddy`` appears (word-bounded).
+
+    Mirrors TS ``useBuddyNotification.tsx:79-97``. Returns a list of
+    ``{"start": int, "end": int}`` dicts so callers can apply highlight
+    styling to those character ranges in a future PromptInput widget.
+    """
+    if not is_buddy_enabled():
+        return []
+    return [
+        {'start': m.start(), 'end': m.end()}
+        for m in _BUDDY_TRIGGER_RE.finditer(text)
+    ]
+
+
+__all__ = [
+    'find_buddy_trigger_positions',
+    'is_buddy_live',
+    'is_buddy_teaser_window',
+]

--- a/src/buddy/observer.py
+++ b/src/buddy/observer.py
@@ -1,0 +1,138 @@
+"""Per-turn companion observer.
+
+Port of ``typescript/src/buddy/observer.ts``. Headless in Python: the
+function calls ``on_reaction(quip)`` and has no built-in UI side effect.
+The REPL caller decides what to do with the quip (today: a no-op until
+the Textual companion sprite lands; future: an AppState write).
+
+Known divergence-from-intuition: by the time the observer reads the
+most recent user message, the REPL has already prepended at-mention
+reminders and may have appended the companion-intro system-reminder to
+``user_input`` (per ``src/repl/core.py`` WI-10 edits). The
+``"/buddy"`` / companion-name match therefore can match against
+system-reminder text rather than the user's actually-typed words.
+TS has the exact same behavior (TS also prepends and reads from
+``messagesRef.current``); this is parity-correct, not a Python-side bug.
+See ``my-docs/get-parity-by-folder/buddy-refactoring-plan.md`` §2.11
+Edit 2 closing note.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, Sequence
+
+from src.buddy.companion import get_companion
+from src.config import load_config
+
+
+_DIRECT_REPLIES: tuple[str, ...] = (
+    'I am observing.',
+    'I am helping from the corner.',
+    'I saw that.',
+    'Still here.',
+    'Watching closely.',
+)
+
+_PET_REPLIES: tuple[str, ...] = (
+    'happy chirp',
+    'tiny victory dance',
+    'quietly approves',
+    'wiggles with joy',
+    'looks pleased',
+)
+
+
+def _fnv1a_32(s: str) -> int:
+    """FNV-1a 32-bit. Duplicated from ``src/buddy/companion.py`` and
+    ``src/buddy/soul.py`` — see gap-analysis §2.8."""
+    h = 2166136261
+    for c in s:
+        h ^= ord(c)
+        h = (h * 16777619) & 0xFFFFFFFF
+    return h
+
+
+def _pick_deterministic(items: Sequence[str], seed: str) -> str:
+    return items[_fnv1a_32(seed) % len(items)]
+
+
+def _get_last_user_text(messages: Iterable[Any]) -> str | None:
+    """Return the most recent user message's text, or None.
+
+    TS uses ``getUserMessageText`` from ``utils/messages.ts``. Python
+    doesn't have a 1:1 port; we walk messages backward looking for
+    ``type='user'`` and extract text from string or block-list content.
+    """
+    last_user = None
+    for msg in messages:
+        m_type = getattr(msg, 'type', None)
+        if m_type is None and isinstance(msg, dict):
+            m_type = msg.get('type')
+        if m_type == 'user':
+            last_user = msg
+
+    if last_user is None:
+        return None
+
+    content = getattr(last_user, 'content', None)
+    if content is None and isinstance(last_user, dict):
+        content = last_user.get('content')
+
+    if isinstance(content, str):
+        stripped = content.strip()
+        return stripped if stripped else None
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                if block.get('type') == 'text':
+                    parts.append(str(block.get('text', '')))
+            else:
+                # Dataclass content block (TextBlock etc.) — best-effort.
+                btype = getattr(block, 'type', None)
+                if btype == 'text':
+                    parts.append(str(getattr(block, 'text', '')))
+        joined = ' '.join(parts).strip()
+        return joined if joined else None
+    return None
+
+
+def fire_companion_observer(
+    messages: Iterable[Any],
+    on_reaction: Callable[[str | None], None],
+) -> None:
+    """TS ``observer.ts:35-65``.
+
+    Synchronous in Python (TS was async-marked but never awaits — the
+    body is pure CPU).
+    """
+    companion = get_companion()
+    if companion is None:
+        return
+    if load_config().get('companion_muted', False):
+        return
+
+    text = _get_last_user_text(messages)
+    if not text:
+        return
+
+    lower = text.lower()
+    companion_name_lower = companion.name.lower()
+
+    if '/buddy' in lower:
+        on_reaction(
+            _pick_deterministic(_PET_REPLIES, text + companion.name)
+        )
+        return
+
+    if (
+        companion_name_lower in lower
+        or 'buddy' in lower
+        or 'companion' in lower
+    ):
+        reply = _pick_deterministic(
+            _DIRECT_REPLIES, text + companion.personality
+        )
+        on_reaction(f"{companion.name}: {reply}")
+
+
+__all__ = ['fire_companion_observer']

--- a/src/buddy/prompt.py
+++ b/src/buddy/prompt.py
@@ -1,0 +1,137 @@
+"""Companion-intro attachment + system-prompt text.
+
+Port of ``typescript/src/buddy/prompt.ts``.
+
+Two functions:
+
+* :func:`companion_intro_text` — the system-prompt block (TS prompt.ts:7-13).
+* :func:`build_companion_intro_attachment` — guards + dedup + attachment
+  dict construction (TS prompt.ts:15-35). Signature matches TS exactly
+  (only ``messages`` argument; ``companion`` resolved internally) per
+  ``my-docs/get-parity-by-folder/buddy-gap-analysis.md`` §4.6 item 1.
+
+Plus :func:`format_companion_intro_attachments` — a SIBLING formatter
+to ``src.command_system.input_processing.format_at_mention_attachments``
+that renders the companion-intro into a ``<system-reminder>`` block.
+The two formatters are kept separate so neither's scope creeps into the
+other (gap-analysis §4.6 item 2).
+
+No null-rendering filter needed in Python: ``src/tui/widgets/
+transcript_view.py`` does not auto-walk ``AttachmentMessage`` instances;
+intro text reaches the model via prepend to ``user_input``, and the
+``AttachmentMessage`` marker is invisible to both renderer and API.
+See gap-analysis §3.6, §2.9.
+"""
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from src.buddy.companion import get_companion
+from src.buddy.feature import is_buddy_enabled
+from src.config import load_config
+from src.types.messages import AttachmentMessage
+
+
+def companion_intro_text(name: str, species: str) -> str:
+    """System-prompt block describing the companion to the model.
+
+    Mirrors TS ``prompt.ts:7-13`` byte-for-byte except for the leading
+    ``# Companion`` heading and the f-string interpolation.
+    """
+    return (
+        f"# Companion\n\n"
+        f"A small {species} named {name} sits beside the user's input box "
+        f"and occasionally comments in a speech bubble. You're not {name} — "
+        f"it's a separate watcher.\n\n"
+        f"When the user addresses {name} directly (by name), its bubble "
+        f"will answer. Your job in that moment is to stay out of the way: "
+        f"respond in ONE line or less, or just answer any part of the "
+        f"message meant for you. Don't explain that you're not {name} — "
+        f"they know. Don't narrate what {name} might say — the bubble "
+        f"handles that."
+    )
+
+
+def build_companion_intro_attachment(
+    messages: Iterable[Any] | None,
+) -> list[dict[str, Any]]:
+    """Build the companion-intro attachment, or ``[]``.
+
+    Returns ``[]`` when ANY of:
+
+    * buddy is disabled,
+    * no companion hatched (``get_companion()`` returns ``None``),
+    * companion is muted (``config['companion_muted']`` truthy),
+    * this companion has already been announced in this conversation
+      (dedup loop walks ``messages`` for an ``AttachmentMessage`` whose
+      ``attachments`` list contains a ``companion_intro`` matching the
+      current companion's name).
+
+    Otherwise returns a one-element list ``[{"kind": "companion_intro",
+    "name": ..., "species": ...}]``.
+
+    Dedup-loop shape mirrors TS ``prompt.ts:23-28`` adapted to Python's
+    plural ``msg.attachments`` list (TS has singular ``msg.attachment``).
+    See gap-analysis §2.8 for the key-rename (``"kind"`` vs TS's
+    ``"type"``) rationale.
+
+    Does NOT mutate state.
+    """
+    if not is_buddy_enabled():
+        return []
+    companion = get_companion()
+    if companion is None:
+        return []
+    if load_config().get('companion_muted', False):
+        return []
+
+    for msg in messages or []:
+        if not isinstance(msg, AttachmentMessage):
+            continue
+        for att in (msg.attachments or []):
+            if not isinstance(att, dict):
+                continue
+            if att.get('kind') == 'companion_intro' and att.get('name') == companion.name:
+                return []
+
+    return [{
+        'kind': 'companion_intro',
+        'name': companion.name,
+        'species': companion.species,
+    }]
+
+
+def format_companion_intro_attachments(
+    attachments: list[dict[str, Any]],
+) -> str:
+    """Render companion-intro attachments as concatenated <system-reminder>s.
+
+    Sibling formatter to
+    ``src.command_system.input_processing.format_at_mention_attachments``.
+    Filters for ``kind == "companion_intro"`` and ignores other kinds
+    (so callers can pass a heterogenous attachment list safely, though
+    in practice ``build_companion_intro_attachment`` returns only this
+    kind).
+
+    Concatenation order at the REPL caller per gap-analysis §4.6 item 2:
+    at-mention text FIRST, then this formatter's output appended.
+    """
+    blocks: list[str] = []
+    for att in attachments:
+        if not isinstance(att, dict):
+            continue
+        if att.get('kind') != 'companion_intro':
+            continue
+        text = companion_intro_text(
+            att.get('name', ''),
+            att.get('species', ''),
+        )
+        blocks.append(f"<system-reminder>\n{text}\n</system-reminder>")
+    return '\n\n'.join(blocks)
+
+
+__all__ = [
+    'build_companion_intro_attachment',
+    'companion_intro_text',
+    'format_companion_intro_attachments',
+]

--- a/src/buddy/soul.py
+++ b/src/buddy/soul.py
@@ -1,0 +1,75 @@
+"""Deterministic soul generator.
+
+Splits ``NAME_PREFIXES`` / ``NAME_SUFFIXES`` / ``PERSONALITIES`` out of
+TS ``commands/buddy/buddy.tsx`` per
+``my-docs/get-parity-by-folder/buddy-gap-analysis.md`` §4.1: this
+module owns persistent soul data; ``PET_REACTIONS`` lives in
+``src/command_system/buddy_command.py`` because it's live (re-seeded
+on every pet via ``time.time()``) rather than persistent.
+"""
+from __future__ import annotations
+
+import time
+from typing import Sequence
+
+from src.buddy.types import StoredCompanion
+
+
+NAME_PREFIXES: tuple[str, ...] = (
+    'Byte', 'Echo', 'Glint', 'Miso', 'Nova',
+    'Pixel', 'Rune', 'Static', 'Vector', 'Whisk',
+)
+
+NAME_SUFFIXES: tuple[str, ...] = (
+    'bean', 'bit', 'bud', 'dot', 'ling',
+    'loop', 'moss', 'patch', 'puff', 'spark',
+)
+
+PERSONALITIES: tuple[str, ...] = (
+    'Curious and quietly encouraging',
+    'A patient little watcher with strong debugging instincts',
+    'Playful, observant, and suspicious of flaky tests',
+    'Calm under pressure and fond of clean diffs',
+    'A tiny terminal gremlin who likes successful builds',
+)
+
+
+def _fnv1a_32(s: str) -> int:
+    """FNV-1a 32-bit hash, matching TS ``buddy.tsx:49-56``.
+
+    Duplicated from ``src/buddy/companion.py`` and
+    ``src/buddy/observer.py``. Three duplications of 5 lines is fine —
+    see gap-analysis §2.8.
+    """
+    h = 2166136261
+    for c in s:
+        h ^= ord(c)
+        h = (h * 16777619) & 0xFFFFFFFF
+    return h
+
+
+def _pick_deterministic(items: Sequence[str], seed: str) -> str:
+    return items[_fnv1a_32(seed) % len(items)]
+
+
+def create_stored_companion(user_id: str) -> StoredCompanion:
+    """Mirror of TS ``commands/buddy/buddy.tsx:66-78``.
+
+    Returns a fresh ``StoredCompanion`` with deterministic name and
+    personality keyed off ``user_id``. ``hatched_at`` is unix milliseconds
+    at call time (the only non-deterministic field — same as TS).
+    """
+    prefix = _pick_deterministic(NAME_PREFIXES, f"{user_id}:prefix")
+    suffix = _pick_deterministic(NAME_SUFFIXES, f"{user_id}:suffix")
+    personality = _pick_deterministic(PERSONALITIES, f"{user_id}:personality")
+    return {
+        'name': f"{prefix}{suffix}",
+        'personality': f"{personality}.",
+        'hatched_at': int(time.time() * 1000),
+    }
+
+
+__all__ = [
+    'NAME_PREFIXES', 'NAME_SUFFIXES', 'PERSONALITIES',
+    'create_stored_companion',
+]

--- a/src/buddy/sprites.py
+++ b/src/buddy/sprites.py
@@ -1,0 +1,530 @@
+"""ASCII sprite library. Port of ``typescript/src/buddy/sprites.ts``.
+
+Each species has 3 frames; each frame is 5 lines of 12 characters with
+``{E}`` placeholders for the eye glyph. ``render_sprite()`` substitutes
+the eye and optionally overwrites line 0 with the hat.
+
+Shift rule (sprites.ts:467): when ``hat == 'none'`` AND every frame of
+the species has a blank ``lines[0]``, the rendered output drops line 0
+(reducing height from 5 to 4). When at least one frame uses line 0 for
+a fidget (penguin's ``~ ~`` waddle, dragon's ``~ ~``, robot's antenna
+sparkle, etc.), the height stays 5 even with no hat — otherwise the
+sprite would jump up and down between frames.
+
+See ``my-docs/get-parity-by-folder/buddy-gap-analysis.md`` §4.2 for the
+"port this even though the consumer (Textual widget) is deferred"
+rationale.
+"""
+from __future__ import annotations
+
+from src.buddy.types import CompanionBones, Eye, Hat, Species
+
+
+# --- Sprite width constants -----------------------------------------
+
+# Reserved-column threshold for the Textual companion widget (deferred
+# Class C). Kept here so the future widget reads it from the data layer.
+MIN_COLS_FOR_FULL_SPRITE: int = 100
+
+
+# --- Bodies ---------------------------------------------------------
+
+# Each species → 3 frames; each frame → 5 strings of width 12. ``{E}``
+# is the eye-glyph placeholder. Direct port of TS ``BODIES`` table at
+# sprites.ts:26-441. ASCII-only.
+BODIES: dict[Species, tuple[tuple[str, ...], ...]] = {
+    'duck': (
+        (
+            '            ',
+            '    __      ',
+            '  <({E} )___  ',
+            '   (  ._>   ',
+            '    `--´    ',
+        ),
+        (
+            '            ',
+            '    __      ',
+            '  <({E} )___  ',
+            '   (  ._>   ',
+            '    `--´~   ',
+        ),
+        (
+            '            ',
+            '    __      ',
+            '  <({E} )___  ',
+            '   (  .__>  ',
+            '    `--´    ',
+        ),
+    ),
+    'goose': (
+        (
+            '            ',
+            '     ({E}>    ',
+            '     ||     ',
+            '   _(__)_   ',
+            '    ^^^^    ',
+        ),
+        (
+            '            ',
+            '    ({E}>     ',
+            '     ||     ',
+            '   _(__)_   ',
+            '    ^^^^    ',
+        ),
+        (
+            '            ',
+            '     ({E}>>   ',
+            '     ||     ',
+            '   _(__)_   ',
+            '    ^^^^    ',
+        ),
+    ),
+    'blob': (
+        (
+            '            ',
+            '   .----.   ',
+            '  ( {E}  {E} )  ',
+            '  (      )  ',
+            '   `----´   ',
+        ),
+        (
+            '            ',
+            '  .------.  ',
+            ' (  {E}  {E}  ) ',
+            ' (        ) ',
+            '  `------´  ',
+        ),
+        (
+            '            ',
+            '    .--.    ',
+            '   ({E}  {E})   ',
+            '   (    )   ',
+            '    `--´    ',
+        ),
+    ),
+    'cat': (
+        (
+            '            ',
+            '   /\\_/\\    ',
+            '  ( {E}   {E})  ',
+            '  (  ω  )   ',
+            '  (")_(")   ',
+        ),
+        (
+            '            ',
+            '   /\\_/\\    ',
+            '  ( {E}   {E})  ',
+            '  (  ω  )   ',
+            '  (")_(")~  ',
+        ),
+        (
+            '            ',
+            '   /\\-/\\    ',
+            '  ( {E}   {E})  ',
+            '  (  ω  )   ',
+            '  (")_(")   ',
+        ),
+    ),
+    'dragon': (
+        (
+            '            ',
+            '  /^\\  /^\\  ',
+            ' <  {E}  {E}  > ',
+            ' (   ~~   ) ',
+            '  `-vvvv-´  ',
+        ),
+        (
+            '            ',
+            '  /^\\  /^\\  ',
+            ' <  {E}  {E}  > ',
+            ' (        ) ',
+            '  `-vvvv-´  ',
+        ),
+        (
+            '   ~    ~   ',
+            '  /^\\  /^\\  ',
+            ' <  {E}  {E}  > ',
+            ' (   ~~   ) ',
+            '  `-vvvv-´  ',
+        ),
+    ),
+    'octopus': (
+        (
+            '            ',
+            '   .----.   ',
+            '  ( {E}  {E} )  ',
+            '  (______)  ',
+            '  /\\/\\/\\/\\  ',
+        ),
+        (
+            '            ',
+            '   .----.   ',
+            '  ( {E}  {E} )  ',
+            '  (______)  ',
+            '  \\/\\/\\/\\/  ',
+        ),
+        (
+            '     o      ',
+            '   .----.   ',
+            '  ( {E}  {E} )  ',
+            '  (______)  ',
+            '  /\\/\\/\\/\\  ',
+        ),
+    ),
+    'owl': (
+        (
+            '            ',
+            '   /\\  /\\   ',
+            '  (({E})({E}))  ',
+            '  (  ><  )  ',
+            '   `----´   ',
+        ),
+        (
+            '            ',
+            '   /\\  /\\   ',
+            '  (({E})({E}))  ',
+            '  (  ><  )  ',
+            '   .----.   ',
+        ),
+        (
+            '            ',
+            '   /\\  /\\   ',
+            '  (({E})(-))  ',
+            '  (  ><  )  ',
+            '   `----´   ',
+        ),
+    ),
+    'penguin': (
+        (
+            '            ',
+            '  .---.     ',
+            '  ({E}>{E})     ',
+            ' /(   )\\    ',
+            '  `---´     ',
+        ),
+        (
+            '            ',
+            '  .---.     ',
+            '  ({E}>{E})     ',
+            ' |(   )|    ',
+            '  `---´     ',
+        ),
+        (
+            '  .---.     ',
+            '  ({E}>{E})     ',
+            ' /(   )\\    ',
+            '  `---´     ',
+            '   ~ ~      ',
+        ),
+    ),
+    'turtle': (
+        (
+            '            ',
+            '   _,--._   ',
+            '  ( {E}  {E} )  ',
+            ' /[______]\\ ',
+            '  ``    ``  ',
+        ),
+        (
+            '            ',
+            '   _,--._   ',
+            '  ( {E}  {E} )  ',
+            ' /[______]\\ ',
+            '   ``  ``   ',
+        ),
+        (
+            '            ',
+            '   _,--._   ',
+            '  ( {E}  {E} )  ',
+            ' /[======]\\ ',
+            '  ``    ``  ',
+        ),
+    ),
+    'snail': (
+        (
+            '            ',
+            ' {E}    .--.  ',
+            '  \\  ( @ )  ',
+            '   \\_`--´   ',
+            '  ~~~~~~~   ',
+        ),
+        (
+            '            ',
+            '  {E}   .--.  ',
+            '  |  ( @ )  ',
+            '   \\_`--´   ',
+            '  ~~~~~~~   ',
+        ),
+        (
+            '            ',
+            ' {E}    .--.  ',
+            '  \\  ( @  ) ',
+            '   \\_`--´   ',
+            '   ~~~~~~   ',
+        ),
+    ),
+    'ghost': (
+        (
+            '            ',
+            '   .----.   ',
+            '  / {E}  {E} \\  ',
+            '  |      |  ',
+            '  ~`~``~`~  ',
+        ),
+        (
+            '            ',
+            '   .----.   ',
+            '  / {E}  {E} \\  ',
+            '  |      |  ',
+            '  `~`~~`~`  ',
+        ),
+        (
+            '    ~  ~    ',
+            '   .----.   ',
+            '  / {E}  {E} \\  ',
+            '  |      |  ',
+            '  ~~`~~`~~  ',
+        ),
+    ),
+    'axolotl': (
+        (
+            '            ',
+            '}~(______)~{',
+            '}~({E} .. {E})~{',
+            '  ( .--. )  ',
+            '  (_/  \\_)  ',
+        ),
+        (
+            '            ',
+            '~}(______){~',
+            '~}({E} .. {E}){~',
+            '  ( .--. )  ',
+            '  (_/  \\_)  ',
+        ),
+        (
+            '            ',
+            '}~(______)~{',
+            '}~({E} .. {E})~{',
+            '  (  --  )  ',
+            '  ~_/  \\_~  ',
+        ),
+    ),
+    'capybara': (
+        (
+            '            ',
+            '  n______n  ',
+            ' ( {E}    {E} ) ',
+            ' (   oo   ) ',
+            '  `------´  ',
+        ),
+        (
+            '            ',
+            '  n______n  ',
+            ' ( {E}    {E} ) ',
+            ' (   Oo   ) ',
+            '  `------´  ',
+        ),
+        (
+            '    ~  ~    ',
+            '  u______n  ',
+            ' ( {E}    {E} ) ',
+            ' (   oo   ) ',
+            '  `------´  ',
+        ),
+    ),
+    'cactus': (
+        (
+            '            ',
+            ' n  ____  n ',
+            ' | |{E}  {E}| | ',
+            ' |_|    |_| ',
+            '   |    |   ',
+        ),
+        (
+            '            ',
+            '    ____    ',
+            ' n |{E}  {E}| n ',
+            ' |_|    |_| ',
+            '   |    |   ',
+        ),
+        (
+            ' n        n ',
+            ' |  ____  | ',
+            ' | |{E}  {E}| | ',
+            ' |_|    |_| ',
+            '   |    |   ',
+        ),
+    ),
+    'robot': (
+        (
+            '            ',
+            '   .[||].   ',
+            '  [ {E}  {E} ]  ',
+            '  [ ==== ]  ',
+            '  `------´  ',
+        ),
+        (
+            '            ',
+            '   .[||].   ',
+            '  [ {E}  {E} ]  ',
+            '  [ -==- ]  ',
+            '  `------´  ',
+        ),
+        (
+            '     *      ',
+            '   .[||].   ',
+            '  [ {E}  {E} ]  ',
+            '  [ ==== ]  ',
+            '  `------´  ',
+        ),
+    ),
+    'rabbit': (
+        (
+            '            ',
+            '   (\\__/)   ',
+            '  ( {E}  {E} )  ',
+            ' =(  ..  )= ',
+            '  (")__(")  ',
+        ),
+        (
+            '            ',
+            '   (|__/)   ',
+            '  ( {E}  {E} )  ',
+            ' =(  ..  )= ',
+            '  (")__(")  ',
+        ),
+        (
+            '            ',
+            '   (\\__/)   ',
+            '  ( {E}  {E} )  ',
+            ' =( .  . )= ',
+            '  (")__(")  ',
+        ),
+    ),
+    'mushroom': (
+        (
+            '            ',
+            ' .-o-OO-o-. ',
+            '(__________)',
+            '   |{E}  {E}|   ',
+            '   |____|   ',
+        ),
+        (
+            '            ',
+            ' .-O-oo-O-. ',
+            '(__________)',
+            '   |{E}  {E}|   ',
+            '   |____|   ',
+        ),
+        (
+            '   . o  .   ',
+            ' .-o-OO-o-. ',
+            '(__________)',
+            '   |{E}  {E}|   ',
+            '   |____|   ',
+        ),
+    ),
+    'chonk': (
+        (
+            '            ',
+            '  /\\    /\\  ',
+            ' ( {E}    {E} ) ',
+            ' (   ..   ) ',
+            '  `------´  ',
+        ),
+        (
+            '            ',
+            '  /\\    /|  ',
+            ' ( {E}    {E} ) ',
+            ' (   ..   ) ',
+            '  `------´  ',
+        ),
+        (
+            '            ',
+            '  /\\    /\\  ',
+            ' ( {E}    {E} ) ',
+            ' (   ..   ) ',
+            '  `------´~ ',
+        ),
+    ),
+}
+
+
+# --- Hats -----------------------------------------------------------
+
+HAT_LINES: dict[Hat, str] = {
+    'none':      '',
+    'crown':     '   \\^^^/    ',
+    'tophat':    '   [___]    ',
+    'propeller': '    -+-     ',
+    'halo':      '   (   )    ',
+    'wizard':    '    /^\\     ',
+    'beanie':    '   (___)    ',
+    'tinyduck':  '    ,>      ',
+}
+
+
+# --- Rendering ------------------------------------------------------
+
+def render_sprite(bones: CompanionBones, frame: int = 0) -> list[str]:
+    """Render the sprite for ``bones`` at the given fidget ``frame``.
+
+    Returns a list of 4 or 5 strings (see shift-rule in module
+    docstring). Mirrors TS ``sprites.ts:454-469``.
+    """
+    frames = BODIES[bones.species]
+    raw = frames[frame % len(frames)]
+    body = [line.replace('{E}', bones.eye) for line in raw]
+    lines = list(body)
+    # Replace blank line 0 with hat IF a hat is requested AND line 0 is
+    # blank in this particular frame.
+    if bones.hat != 'none' and not lines[0].strip():
+        lines[0] = HAT_LINES[bones.hat]
+    # Drop blank hat slot — wastes a row in the Card and ambient sprite
+    # when there's no hat AND the frame isn't using line 0 for fidget.
+    # Shift is ONLY safe when ALL frames have a blank line 0 (otherwise
+    # heights oscillate between fidget frames).
+    if not lines[0].strip() and all(not f[0].strip() for f in frames):
+        lines.pop(0)
+    return lines
+
+
+def sprite_frame_count(species: Species) -> int:
+    """Number of fidget frames available for ``species``. Always 3 today."""
+    return len(BODIES[species])
+
+
+def render_face(bones: CompanionBones) -> str:
+    """Compact one-line face for narrow-terminal mode.
+
+    Mirrors TS ``sprites.ts:475-514`` switch via a dict lookup.
+    """
+    e: Eye = bones.eye
+    faces: dict[Species, str] = {
+        'duck':     f'({e}>',
+        'goose':    f'({e}>',
+        'blob':     f'({e}{e})',
+        'cat':      f'={e}ω{e}=',
+        'dragon':   f'<{e}~{e}>',
+        'octopus':  f'~({e}{e})~',
+        'owl':      f'({e})({e})',
+        'penguin':  f'({e}>)',
+        'turtle':   f'[{e}_{e}]',
+        'snail':    f'{e}(@)',
+        'ghost':    f'/{e}{e}\\',
+        'axolotl':  f'}}{e}.{e}{{',
+        'capybara': f'({e}oo{e})',
+        'cactus':   f'|{e}  {e}|',
+        'robot':    f'[{e}{e}]',
+        'rabbit':   f'({e}..{e})',
+        'mushroom': f'|{e}  {e}|',
+        'chonk':    f'({e}.{e})',
+    }
+    return faces[bones.species]
+
+
+__all__ = [
+    'MIN_COLS_FOR_FULL_SPRITE',
+    'BODIES', 'HAT_LINES',
+    'render_face', 'render_sprite', 'sprite_frame_count',
+]

--- a/src/buddy/types.py
+++ b/src/buddy/types.py
@@ -1,0 +1,175 @@
+"""Buddy data types — port of ``typescript/src/buddy/types.ts``.
+
+Five concept tiers (rarity / species / eye / hat / stat) plus the bones-
+and-soul shape types underlying ``Companion``.
+
+``RARITY_COLORS`` values are Python palette field names (matching
+``src.tui.theme.Palette`` fields), not raw color strings. Consumers
+``getattr(palette, RARITY_COLORS[rarity])`` to materialize.
+See ``my-docs/get-parity-by-folder/buddy-gap-analysis.md`` §3.5 / §4.4
+for the TS-key → Python-key mapping rationale.
+
+Audit-trail: TS encodes each species name via ``String.fromCharCode``
+to keep canary-class strings out of the build output for a build-time
+``excluded-strings.txt`` grep. The Python build has no such check, so
+the species literals here are plain strings. If a future Python build
+adds a similar canary scan, reconstruct via ``chr()`` at module load.
+See gap-analysis §2.3.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, TypedDict
+
+
+# --- Rarity ----------------------------------------------------------
+
+Rarity = Literal['common', 'uncommon', 'rare', 'epic', 'legendary']
+
+RARITIES: tuple[Rarity, ...] = (
+    'common', 'uncommon', 'rare', 'epic', 'legendary',
+)
+
+
+# --- Species ---------------------------------------------------------
+
+Species = Literal[
+    'duck', 'goose', 'blob', 'cat', 'dragon', 'octopus', 'owl',
+    'penguin', 'turtle', 'snail', 'ghost', 'axolotl', 'capybara',
+    'cactus', 'robot', 'rabbit', 'mushroom', 'chonk',
+]
+
+SPECIES: tuple[Species, ...] = (
+    'duck', 'goose', 'blob', 'cat', 'dragon', 'octopus', 'owl',
+    'penguin', 'turtle', 'snail', 'ghost', 'axolotl', 'capybara',
+    'cactus', 'robot', 'rabbit', 'mushroom', 'chonk',
+)
+
+
+# --- Eye glyphs ------------------------------------------------------
+
+Eye = Literal['·', '✦', '×', '◉', '@', '°']
+
+EYES: tuple[Eye, ...] = ('·', '✦', '×', '◉', '@', '°')
+
+
+# --- Hats ------------------------------------------------------------
+
+Hat = Literal[
+    'none', 'crown', 'tophat', 'propeller', 'halo',
+    'wizard', 'beanie', 'tinyduck',
+]
+
+HATS: tuple[Hat, ...] = (
+    'none', 'crown', 'tophat', 'propeller', 'halo',
+    'wizard', 'beanie', 'tinyduck',
+)
+
+
+# --- Stat names ------------------------------------------------------
+
+StatName = Literal['DEBUGGING', 'PATIENCE', 'CHAOS', 'WISDOM', 'SNARK']
+
+STAT_NAMES: tuple[StatName, ...] = (
+    'DEBUGGING', 'PATIENCE', 'CHAOS', 'WISDOM', 'SNARK',
+)
+
+
+# --- Shape types -----------------------------------------------------
+
+@dataclass(frozen=True)
+class CompanionBones:
+    """Deterministic-from-userId portion of a companion. Never persists.
+
+    Regenerating on every read means species renames or edits to
+    ``SPECIES`` don't break stored companions, and editing
+    ``config['companion']`` can't fake a rarity.
+    """
+    rarity: Rarity
+    species: Species
+    eye: Eye
+    hat: Hat
+    shiny: bool
+    stats: dict[StatName, int]
+
+
+class CompanionSoul(TypedDict):
+    """Persisted-in-config portion. Plain dict for JSON-roundtrip."""
+    name: str
+    personality: str
+
+
+class StoredCompanion(TypedDict):
+    """What actually goes into ``config['companion']`` — soul + hatched_at.
+
+    Snake_case ``hatched_at`` matches Python convention. TS uses
+    camelCase ``hatchedAt``. Python and TS write to different config
+    files (``~/.clawcodex/config.json`` vs ``~/.openclaude.json``) so
+    there's no cross-port migration concern. See gap-analysis §4.8.
+    """
+    name: str
+    personality: str
+    hatched_at: int  # unix milliseconds
+
+
+@dataclass(frozen=True)
+class Companion:
+    """Live companion: bones (regenerated) + soul (persisted) + hatched_at."""
+    name: str
+    personality: str
+    hatched_at: int
+    rarity: Rarity
+    species: Species
+    eye: Eye
+    hat: Hat
+    shiny: bool
+    stats: dict[StatName, int]
+
+
+# --- Rarity-keyed constants ------------------------------------------
+
+RARITY_WEIGHTS: dict[Rarity, int] = {
+    'common': 60,
+    'uncommon': 25,
+    'rare': 10,
+    'epic': 4,
+    'legendary': 1,
+}
+
+RARITY_STARS: dict[Rarity, str] = {
+    'common': '★',
+    'uncommon': '★★',
+    'rare': '★★★',
+    'epic': '★★★★',
+    'legendary': '★★★★★',
+}
+
+# RARITY_COLORS values are src/tui/theme.py Palette field names,
+# NOT theme color strings. Consumers materialize via
+# ``getattr(palette, RARITY_COLORS[rarity])``.
+#
+# Mapped from TS keys (inactive/success/permission/autoAccept/warning)
+# to Python palette keys per gap-analysis §3.5 / §4.4. Some TS keys
+# (``inactive``, ``permission``, ``autoAccept``) don't exist on the
+# Python palette today; the mapping picks the closest semantic match.
+RARITY_COLORS: dict[Rarity, str] = {
+    'common':    'text_muted',  # was TS 'inactive'
+    'uncommon':  'success',
+    'rare':      'primary',     # was TS 'permission'  (blue)
+    'epic':      'secondary',   # was TS 'autoAccept'  (violet)
+    'legendary': 'warning',
+}
+
+
+__all__ = [
+    # Literals + tuples
+    'Rarity', 'RARITIES',
+    'Species', 'SPECIES',
+    'Eye', 'EYES',
+    'Hat', 'HATS',
+    'StatName', 'STAT_NAMES',
+    # Shape types
+    'CompanionBones', 'CompanionSoul', 'StoredCompanion', 'Companion',
+    # Rarity-keyed constants
+    'RARITY_WEIGHTS', 'RARITY_STARS', 'RARITY_COLORS',
+]

--- a/src/command_system/buddy_command.py
+++ b/src/command_system/buddy_command.py
@@ -1,0 +1,194 @@
+"""``/buddy`` command — hatch / pet / status / mute / unmute / help.
+
+Port of ``typescript/src/commands/buddy/buddy.tsx`` with TS ``local-jsx``
+semantics stripped to ``LocalCommand`` textual returns per
+``my-docs/get-parity-by-folder/buddy-gap-analysis.md`` §2.6.
+
+``PET_REACTIONS`` lives in this file (not in ``src/buddy/soul.py``)
+because each pet re-seeds the pick from ``time.time()`` — it's transient
+reaction text, not part of the persistent soul. See gap-analysis §4.1.
+
+Help/info argument parsing matches TS exactly via the shared lists in
+``src/constants/xml.py`` (``COMMON_HELP_ARGS``, ``COMMON_INFO_ARGS``).
+Notably ``?`` routes to INFO (status), not HELP.
+
+Divergence (gap-analysis §4.9): TS ``/buddy pet`` returns
+``display: 'skip'`` because the user feedback is the speech-bubble
+animation; Python returns
+``LocalCommandResult(type="text", value=reaction)`` so the headless /
+Textual REPL produces *some* visible feedback (without it, a successful
+pet would be silent).
+
+The pet path also persists ``config['companion_pet_at']`` (top-level,
+snake_case mirror of TS's transient AppState field ``companionPetAt``).
+A future Textual sprite reads this for the heart-burst animation. See
+plan §1.3.
+"""
+from __future__ import annotations
+
+import time
+from typing import Sequence
+
+from src.buddy.companion import companion_user_id, get_companion
+from src.buddy.feature import is_buddy_enabled
+from src.buddy.soul import create_stored_companion
+from src.command_system.types import (
+    CommandContext, LocalCommand, LocalCommandResult,
+)
+from src.config import _get_default_manager, load_config
+from src.constants.xml import COMMON_HELP_ARGS, COMMON_INFO_ARGS
+
+
+PET_REACTIONS: tuple[str, ...] = (
+    'leans into the headpat',
+    'does a proud little bounce',
+    'emits a content beep',
+    'looks delighted',
+    'wiggles happily',
+)
+
+_HELP_TEXT = (
+    "Usage: /buddy [status|mute|unmute]\n\n"
+    "Run /buddy with no args to hatch your companion the first time, "
+    "then pet it on later runs."
+)
+
+
+# Local FNV-1a + pick — duplicated from ``src/buddy/soul.py`` and
+# ``src/buddy/observer.py`` per gap-analysis §2.8: 5 lines × 3 modules
+# is preferable to cross-module imports of underscore-prefixed private
+# symbols.
+def _fnv1a_32(s: str) -> int:
+    h = 2166136261
+    for c in s:
+        h ^= ord(c)
+        h = (h * 16777619) & 0xFFFFFFFF
+    return h
+
+
+def _pick_deterministic(items: Sequence[str], seed: str) -> str:
+    return items[_fnv1a_32(seed) % len(items)]
+
+
+def _title_case(s: str) -> str:
+    return s[:1].upper() + s[1:] if s else s
+
+
+def _save_companion(stored: dict) -> None:
+    mgr = _get_default_manager()
+    mgr.set_global('companion', stored)
+    mgr.set_global('companion_muted', False)
+
+
+def _set_companion_muted(muted: bool) -> None:
+    _get_default_manager().set_global('companion_muted', muted)
+
+
+def buddy_command_call(args: str, context: CommandContext) -> LocalCommandResult:
+    """``/buddy`` command body.
+
+    Parsing precedence (matches TS ``buddy.tsx:104-184``):
+
+    1. ``help`` / ``-h`` / ``--help`` → help text
+    2. ``status`` or any ``COMMON_INFO_ARGS`` entry (incl. ``?``) → status
+    3. ``mute`` / ``unmute`` → toggle + confirmation
+    4. any other non-empty arg → help text
+    5. empty arg + no companion → hatch
+    6. empty arg + companion exists → pet
+    """
+    arg = (args or '').strip().lower()
+
+    # Note: TS routes '?' to INFO (status), NOT HELP — preserve that mapping.
+    if arg in COMMON_HELP_ARGS:
+        return LocalCommandResult(type='text', value=_HELP_TEXT)
+
+    if arg in COMMON_INFO_ARGS:
+        companion = get_companion()
+        if companion is None:
+            return LocalCommandResult(
+                type='text',
+                value='No buddy hatched yet. Run /buddy to hatch one.',
+            )
+        return LocalCommandResult(
+            type='text',
+            value=(
+                f"{companion.name} is your {_title_case(companion.rarity)} "
+                f"{companion.species}. {companion.personality}"
+            ),
+        )
+
+    if arg in ('mute', 'unmute'):
+        muted = arg == 'mute'
+        _set_companion_muted(muted)
+        return LocalCommandResult(
+            type='text',
+            value=f"Buddy {'muted' if muted else 'unmuted'}.",
+        )
+
+    if arg != '':
+        return LocalCommandResult(type='text', value=_HELP_TEXT)
+
+    # Empty arg: hatch (first time) or pet (subsequent).
+    companion = get_companion()
+    if companion is None:
+        user_id = companion_user_id()
+        stored = create_stored_companion(user_id)
+        _save_companion(stored)
+        # Re-read with fresh bones merged for the species-name line.
+        companion = get_companion()
+        if companion is None:
+            # Defensive: should never happen — _save_companion succeeded.
+            return LocalCommandResult(
+                type='text', value='Failed to hatch companion (state error).',
+            )
+        return LocalCommandResult(
+            type='text',
+            value=(
+                f"{companion.name} the {companion.species} is now your buddy. "
+                f"Run /buddy again to pet them."
+            ),
+        )
+
+    # Pet path. Per §4.9: return text instead of TS's display='skip'.
+    now_ms = int(time.time() * 1000)
+    reaction = _pick_deterministic(
+        PET_REACTIONS,
+        f"{now_ms}:{companion.name}",
+    )
+    # Persist the pet timestamp at TOP-LEVEL config (snake_case mirror of
+    # TS's camelCase AppState ``companionPetAt``). TS stores this on
+    # AppState transiently; Python has no AppState slice yet, so we
+    # persist to config so a future Textual sprite can read the
+    # last-pet time on startup. Name pinned per plan §1.3.
+    _get_default_manager().set_global('companion_pet_at', now_ms)
+    return LocalCommandResult(
+        type='text',
+        value=f"{companion.name} {reaction}",
+    )
+
+
+BUDDY_COMMAND = LocalCommand(
+    name='buddy',
+    description='Hatch, pet, and manage your OpenClaude companion',
+    argument_hint='[status|mute|unmute|help]',
+    immediate=True,
+)
+BUDDY_COMMAND.set_call(buddy_command_call)
+
+
+def is_buddy_command_enabled() -> bool:
+    """Whether the ``/buddy`` command should be registered.
+
+    Today this is just ``is_buddy_enabled()`` — but giving it a named
+    helper makes the gate point explicit at the registration site in
+    ``command_system.builtins``.
+    """
+    return is_buddy_enabled()
+
+
+__all__ = [
+    'BUDDY_COMMAND',
+    'PET_REACTIONS',
+    'buddy_command_call',
+    'is_buddy_command_enabled',
+]

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -1149,7 +1149,12 @@ ADVISOR_COMMAND.set_call(advisor_command_call)
 
 def get_builtin_commands() -> list[Command]:
     """Get all built-in commands."""
-    return [
+    # Local import keeps the gate readable at the call site and avoids
+    # pulling buddy module dependencies into command_system on bare
+    # `import` of this module — matches pattern used elsewhere.
+    from .buddy_command import BUDDY_COMMAND, is_buddy_command_enabled
+
+    cmds: list[Command] = [
         HELP_COMMAND,
         CLEAR_COMMAND,
         EXIT_COMMAND,
@@ -1160,6 +1165,9 @@ def get_builtin_commands() -> list[Command]:
         ADVISOR_COMMAND,
         INIT_COMMAND,
     ]
+    if is_buddy_command_enabled():
+        cmds.append(BUDDY_COMMAND)
+    return cmds
 
 
 def register_builtin_commands(registry: CommandRegistry | None = None) -> None:

--- a/src/constants/xml.py
+++ b/src/constants/xml.py
@@ -26,6 +26,20 @@ WORKTREE_PATH_TAG: Final[str] = "worktree-path"
 WORKTREE_BRANCH_TAG: Final[str] = "worktree-branch"
 
 
+# Common argument patterns for slash commands that request help.
+# Mirrors ``typescript/src/constants/xml.ts:69`` verbatim.
+COMMON_HELP_ARGS: Final[tuple[str, ...]] = ('help', '-h', '--help')
+
+# Common argument patterns for slash commands that request current state/info.
+# Mirrors ``typescript/src/constants/xml.ts:72-86`` verbatim. Notably ``?``
+# lives here, NOT in ``COMMON_HELP_ARGS`` — so ``/cmd ?`` means
+# "show status", not "help".
+COMMON_INFO_ARGS: Final[tuple[str, ...]] = (
+    'list', 'show', 'display', 'current', 'view', 'get', 'check',
+    'describe', 'print', 'version', 'about', 'status', '?',
+)
+
+
 __all__ = [
     "TASK_NOTIFICATION_TAG",
     "TASK_ID_TAG",
@@ -41,4 +55,6 @@ __all__ = [
     "WORKTREE_TAG",
     "WORKTREE_PATH_TAG",
     "WORKTREE_BRANCH_TAG",
+    "COMMON_HELP_ARGS",
+    "COMMON_INFO_ARGS",
 ]

--- a/src/reference_data/subsystems/buddy.json
+++ b/src/reference_data/subsystems/buddy.json
@@ -1,10 +1,12 @@
 {
   "archive_name": "buddy",
   "package_name": "buddy",
-  "module_count": 6,
+  "module_count": 8,
   "sample_files": [
     "buddy/CompanionSprite.tsx",
     "buddy/companion.ts",
+    "buddy/feature.ts",
+    "buddy/observer.ts",
     "buddy/prompt.ts",
     "buddy/sprites.ts",
     "buddy/types.ts",

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -2672,6 +2672,28 @@ class ClawcodexREPL:
                     f"[dim]  ⎿  Invoking agent @{att['agent_type']}[/dim]"
                 )
 
+        # Companion intro (port of TS prompt.ts + utils/attachments.ts).
+        # Build the intro attachment list, then append the
+        # <system-reminder> AFTER any at-mention text per
+        # my-docs/get-parity-by-folder/buddy-refactoring-plan.md §4.6
+        # item 2. Final user_input shape:
+        #   [at-mention reminder]\n\n[user typed text]\n\n[companion-intro reminder]
+        from src.buddy.feature import is_buddy_enabled
+        from src.buddy.prompt import (
+            build_companion_intro_attachment,
+            format_companion_intro_attachments,
+        )
+        intro_atts: list[dict[str, Any]] = []
+        if is_buddy_enabled():
+            intro_atts = build_companion_intro_attachment(self._engine_messages)
+            if intro_atts:
+                intro_text = format_companion_intro_attachments(intro_atts)
+                if intro_text:
+                    user_input = (
+                        f"{user_input}\n\n{intro_text}"
+                        if user_input else intro_text
+                    )
+
         # Image @-mentions become real image content blocks on the user
         # message so the model sees the image directly (matches TS's
         # auto-Read-on-@image behaviour, and stops the model from
@@ -3027,6 +3049,39 @@ class ClawcodexREPL:
             engine.reset_abort_controller()
 
             self._engine_messages = engine.get_messages()
+            # Append the dedup marker for the companion-intro
+            # (my-docs/get-parity-by-folder/buddy-refactoring-plan.md
+            # §4.6 item 3). content=[] means the API serialization sees
+            # nothing — that's correct: the intro text was already
+            # delivered via the prepend above. The marker exists so the
+            # NEXT turn's build_companion_intro_attachment() dedup walk
+            # sees it and short-circuits.
+            if intro_atts:
+                from src.types.messages import create_attachment_message
+                self._engine_messages.append(
+                    create_attachment_message(intro_atts[0])
+                )
+
+            # Fire the per-turn companion observer (port of TS
+            # screens/REPL.tsx:2846-2849). The on_reaction callback is a
+            # no-op for now per plan §1.3 — reactions are invisible to
+            # the user until the Textual companion sprite lands. The
+            # call site itself is the integration point future contributors
+            # need to preserve; plan §6 acceptance criterion 7 greps for
+            # it.
+            if is_buddy_enabled():
+                from src.buddy.observer import fire_companion_observer
+
+                def _record_reaction(reaction: str | None) -> None:
+                    # No-op: avoids scope-creeping this edit with a
+                    # `logger` import repl/core.py doesn't otherwise
+                    # have. When a Textual sprite + companion_reaction
+                    # AppState slice land, replace this with an AppState
+                    # write.
+                    return
+
+                fire_companion_observer(self._engine_messages, _record_reaction)
+
             self._stats_turns += 1
 
             if not last_text_was_printed and response_text:

--- a/tests/buddy/conftest.py
+++ b/tests/buddy/conftest.py
@@ -1,0 +1,92 @@
+"""Shared fixtures for ``tests/buddy/``.
+
+Most tests need an in-memory config (mocking ``load_config`` and
+``_get_default_manager``) to avoid touching the real
+``~/.clawcodex/config.json``. The ``isolated_config`` fixture below
+gives every test a fresh empty config; tests can pre-populate fields
+on the returned dict before the system-under-test reads it.
+
+Also resets the buddy roll cache between tests — module-level cache
+state would otherwise leak across tests that mock distinct user_ids.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+
+@dataclass
+class FakeConfigManager:
+    """In-memory ``ConfigManager`` substitute.
+
+    Mirrors the small subset of ``src.config.ConfigManager`` that the
+    buddy code reads: ``get_merged()`` returns the stored dict;
+    ``set_global(key, value)`` updates it and clears no cache (there
+    isn't one).
+    """
+    _data: dict[str, Any] = field(default_factory=dict)
+
+    def get_merged(self) -> dict[str, Any]:
+        return dict(self._data)
+
+    def load_global(self) -> dict[str, Any]:
+        return dict(self._data)
+
+    def save_global(self, data: dict[str, Any]) -> None:
+        self._data = dict(data)
+
+    def set_global(self, key: str, value: Any) -> None:
+        self._data[key] = value
+
+    def invalidate(self) -> None:
+        return
+
+
+@pytest.fixture
+def isolated_config(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Return a mutable in-memory config visible to all `src.config`
+    consumers in the buddy subsystem.
+
+    Yields the underlying dict so tests can pre-populate fields:
+
+        def test_X(isolated_config):
+            isolated_config['companion'] = {...}
+            ...
+    """
+    fake = FakeConfigManager()
+
+    def _load_config() -> dict[str, Any]:
+        return fake.get_merged()
+
+    def _get_default_manager() -> FakeConfigManager:
+        return fake
+
+    monkeypatch.setattr('src.config.load_config', _load_config)
+    monkeypatch.setattr('src.config._get_default_manager', _get_default_manager)
+    # Many buddy modules `from src.config import load_config` — re-bind
+    # at each module that did a `from src.config import load_config` so
+    # they pick up the fake. Modules that do a late
+    # `from src.config import _get_default_manager` are covered by the
+    # `src.config._get_default_manager` patch above.
+    monkeypatch.setattr('src.buddy.companion.load_config', _load_config)
+    monkeypatch.setattr('src.buddy.prompt.load_config', _load_config)
+    monkeypatch.setattr('src.buddy.observer.load_config', _load_config)
+    monkeypatch.setattr(
+        'src.command_system.buddy_command.load_config', _load_config,
+    )
+    monkeypatch.setattr(
+        'src.command_system.buddy_command._get_default_manager',
+        _get_default_manager,
+    )
+    return fake._data
+
+
+@pytest.fixture(autouse=True)
+def _reset_buddy_roll_cache() -> None:
+    """Reset the module-level ``_roll_cache`` between every test."""
+    from src.buddy.companion import _reset_roll_cache_for_tests
+    _reset_roll_cache_for_tests()
+    yield
+    _reset_roll_cache_for_tests()

--- a/tests/buddy/test_buddy_command.py
+++ b/tests/buddy/test_buddy_command.py
@@ -1,0 +1,152 @@
+"""``/buddy`` command behavior."""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.command_system.buddy_command import (
+    BUDDY_COMMAND,
+    PET_REACTIONS,
+    buddy_command_call,
+)
+from src.command_system.types import CommandContext, LocalCommandResult
+
+
+def _ctx(workspace_root: Any = None) -> CommandContext:
+    from pathlib import Path
+    return CommandContext(
+        workspace_root=workspace_root or Path('/tmp'),
+        cwd=Path('/tmp'),
+        conversation=None,
+        cost_tracker=None,
+        history=None,
+    )
+
+
+def test_help_arg_returns_help_text(isolated_config: dict[str, Any]) -> None:
+    r = buddy_command_call('help', _ctx())
+    assert r.type == 'text'
+    assert 'Usage: /buddy' in r.value
+
+
+def test_question_mark_routes_to_info_not_help(
+    isolated_config: dict[str, Any],
+) -> None:
+    """TS contract: `?` is in COMMON_INFO_ARGS, not COMMON_HELP_ARGS,
+    so `/buddy ?` should report status (or "no buddy hatched"), NOT
+    show the help text."""
+    r = buddy_command_call('?', _ctx())
+    # No companion yet → status path returns the not-hatched message
+    assert 'No buddy hatched yet' in r.value
+    assert 'Usage' not in r.value
+
+
+def test_status_no_companion(isolated_config: dict[str, Any]) -> None:
+    r = buddy_command_call('status', _ctx())
+    assert 'No buddy hatched yet' in r.value
+
+
+def test_status_with_companion(isolated_config: dict[str, Any]) -> None:
+    isolated_config['user_id'] = 'fixed-id'
+    isolated_config['companion'] = {
+        'name': 'Bytespark',
+        'personality': 'Curious.',
+        'hatched_at': 0,
+    }
+    r = buddy_command_call('status', _ctx())
+    assert 'Bytespark' in r.value
+    assert 'Curious.' in r.value
+
+
+def test_mute_sets_companion_muted_true(
+    isolated_config: dict[str, Any],
+) -> None:
+    r = buddy_command_call('mute', _ctx())
+    assert 'muted' in r.value.lower()
+    assert isolated_config.get('companion_muted') is True
+
+
+def test_unmute_sets_companion_muted_false(
+    isolated_config: dict[str, Any],
+) -> None:
+    isolated_config['companion_muted'] = True
+    r = buddy_command_call('unmute', _ctx())
+    assert 'unmuted' in r.value.lower()
+    assert isolated_config.get('companion_muted') is False
+
+
+def test_unknown_arg_returns_help(isolated_config: dict[str, Any]) -> None:
+    r = buddy_command_call('explode', _ctx())
+    assert 'Usage: /buddy' in r.value
+
+
+def test_no_args_hatches_when_absent(
+    isolated_config: dict[str, Any],
+) -> None:
+    """Empty arg + no companion → hatch."""
+    isolated_config['user_id'] = 'alice-id'
+    assert 'companion' not in isolated_config
+    r = buddy_command_call('', _ctx())
+    # Config should have a companion now
+    stored = isolated_config.get('companion')
+    assert stored is not None
+    assert 'name' in stored
+    assert 'personality' in stored
+    assert 'hatched_at' in stored
+    assert stored['name'] in r.value
+
+
+def test_no_args_pets_when_present(
+    isolated_config: dict[str, Any],
+) -> None:
+    """Empty arg + companion exists → pet (writes companion_pet_at)."""
+    isolated_config['user_id'] = 'fixed-id'
+    isolated_config['companion'] = {
+        'name': 'Bytespark', 'personality': 'p.', 'hatched_at': 1,
+    }
+    r = buddy_command_call('', _ctx())
+    assert any(reaction in r.value for reaction in PET_REACTIONS)
+    # Top-level config['companion_pet_at'] should be set (plan §1.3)
+    assert 'companion_pet_at' in isolated_config
+    assert isinstance(isolated_config['companion_pet_at'], int)
+
+
+def test_pet_reaction_deterministic_same_timestamp(
+    isolated_config: dict[str, Any],
+) -> None:
+    """Two pets at the same time produce the same reaction (deterministic)."""
+    isolated_config['user_id'] = 'fixed-id'
+    isolated_config['companion'] = {
+        'name': 'Bytespark', 'personality': 'p.', 'hatched_at': 1,
+    }
+    fixed_ts = 1_700_000_000.0
+    with patch('src.command_system.buddy_command.time.time', return_value=fixed_ts):
+        r1 = buddy_command_call('', _ctx())
+        r2 = buddy_command_call('', _ctx())
+    assert r1.value == r2.value
+
+
+def test_buddy_command_registered_when_enabled() -> None:
+    """``get_builtin_commands`` returns BUDDY_COMMAND when buddy enabled."""
+    from src.command_system.builtins import get_builtin_commands
+    cmds = get_builtin_commands()
+    assert any(c.name == 'buddy' for c in cmds)
+
+
+def test_buddy_command_omitted_when_disabled() -> None:
+    """When ``is_buddy_command_enabled`` returns False, no BUDDY_COMMAND."""
+    from src.command_system.builtins import get_builtin_commands
+    with patch(
+        'src.command_system.buddy_command.is_buddy_enabled',
+        return_value=False,
+    ):
+        cmds = get_builtin_commands()
+        assert not any(c.name == 'buddy' for c in cmds)
+
+
+def test_buddy_command_shape() -> None:
+    """The BUDDY_COMMAND object is a LocalCommand with the right name."""
+    assert BUDDY_COMMAND.name == 'buddy'
+    assert BUDDY_COMMAND.immediate is True

--- a/tests/buddy/test_companion.py
+++ b/tests/buddy/test_companion.py
@@ -1,0 +1,165 @@
+"""Companion module: hash, PRNG, roll cache, user_id, get_companion."""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.buddy.companion import (
+    SALT,
+    _get_or_create_user_id,
+    _hash_string,
+    _mulberry32,
+    _reset_roll_cache_for_tests,
+    companion_user_id,
+    get_companion,
+    roll,
+    roll_with_seed,
+)
+from src.buddy.types import RARITIES
+
+
+def test_hash_is_deterministic() -> None:
+    assert _hash_string('alice') == _hash_string('alice')
+    assert _hash_string('alice') != _hash_string('bob')
+
+
+def test_hash_is_unsigned_32bit() -> None:
+    """Output fits in [0, 2^32)."""
+    for s in ['', 'a', 'alice', 'a' * 1000]:
+        h = _hash_string(s)
+        assert 0 <= h < 2**32
+
+
+def test_mulberry32_is_deterministic() -> None:
+    rng1 = _mulberry32(42)
+    rng2 = _mulberry32(42)
+    for _ in range(10):
+        assert rng1() == rng2()
+
+
+def test_mulberry32_output_in_range() -> None:
+    rng = _mulberry32(0xDEADBEEF)
+    for _ in range(100):
+        x = rng()
+        assert 0.0 <= x < 1.0
+
+
+def test_roll_with_seed_deterministic(isolated_config: dict[str, Any]) -> None:
+    """Same seed → same bones (no cache; pure function)."""
+    r1 = roll_with_seed('test-seed')
+    r2 = roll_with_seed('test-seed')
+    assert r1.bones == r2.bones
+
+
+def test_roll_cache_returns_same_instance(isolated_config: dict[str, Any]) -> None:
+    """Cache hit returns the same Roll instance."""
+    _reset_roll_cache_for_tests()
+    isolated_config['user_id'] = 'alice'
+    r1 = roll('alice')
+    r2 = roll('alice')
+    assert r1 is r2  # cache hit, not just equality
+
+
+def test_roll_different_user_ids_differ(isolated_config: dict[str, Any]) -> None:
+    """Different user_ids → likely different bones (rarity may collide
+    but at least one bones field differs in practice)."""
+    _reset_roll_cache_for_tests()
+    r_alice = roll('alice')
+    r_bob = roll('bob')
+    # Strong claim: with FNV-1a, 'alice' and 'bob' hashes differ enough
+    # that at least one bones field differs.
+    assert (
+        r_alice.bones.species != r_bob.bones.species
+        or r_alice.bones.eye != r_bob.bones.eye
+        or r_alice.bones.rarity != r_bob.bones.rarity
+    )
+
+
+def test_rarity_is_valid(isolated_config: dict[str, Any]) -> None:
+    """roll() always produces a rarity in RARITIES."""
+    _reset_roll_cache_for_tests()
+    for user in ['alice', 'bob', 'carol', 'dave', 'erin', 'frank', 'grace']:
+        _reset_roll_cache_for_tests()
+        r = roll(user)
+        assert r.bones.rarity in RARITIES
+
+
+def test_common_has_no_hat(isolated_config: dict[str, Any]) -> None:
+    """TS contract (companion.ts:97): common-rarity rolls always have
+    ``hat='none'``.
+
+    Iterate a deterministic seed range; collect all common-rarity rolls
+    and assert each one has hat=='none'. With common weight 60/100 and
+    100 seeds, statistical probability of zero commons is ~10^-22 —
+    effectively impossible but the loop still asserts ≥1 to detect a
+    pathological hash-collision drift.
+    """
+    common_count = 0
+    for i in range(100):
+        r = roll_with_seed(f'seed-{i}')
+        if r.bones.rarity == 'common':
+            common_count += 1
+            assert r.bones.hat == 'none', (
+                f"seed-{i}: common rarity with non-none hat {r.bones.hat!r}"
+            )
+    assert common_count >= 1, (
+        "expected at least one 'common' across 100 deterministic seeds — "
+        "potential PRNG drift if zero"
+    )
+
+
+def test_get_or_create_user_id_persists_when_absent(
+    isolated_config: dict[str, Any],
+) -> None:
+    """When `config['user_id']` is missing, generate hex and persist."""
+    assert 'user_id' not in isolated_config
+    uid = _get_or_create_user_id()
+    assert isinstance(uid, str)
+    # secrets.token_hex(32) returns 64 hex chars
+    assert len(uid) == 64
+    assert isolated_config['user_id'] == uid
+
+
+def test_get_or_create_user_id_returns_existing(
+    isolated_config: dict[str, Any],
+) -> None:
+    """When `config['user_id']` exists, return it without writing."""
+    isolated_config['user_id'] = 'pre-existing-id'
+    uid = _get_or_create_user_id()
+    assert uid == 'pre-existing-id'
+
+
+def test_companion_user_id_uses_config_user_id(
+    isolated_config: dict[str, Any],
+) -> None:
+    isolated_config['user_id'] = 'fixed-id'
+    assert companion_user_id() == 'fixed-id'
+
+
+def test_get_companion_returns_none_when_no_stored(
+    isolated_config: dict[str, Any],
+) -> None:
+    assert get_companion() is None
+
+
+def test_get_companion_merges_soul_and_bones(
+    isolated_config: dict[str, Any],
+) -> None:
+    """Soul fields persist; bones regenerate deterministically."""
+    isolated_config['user_id'] = 'fixed-id'
+    isolated_config['companion'] = {
+        'name': 'Bytespark',
+        'personality': 'Test personality.',
+        'hatched_at': 1234567890,
+    }
+    _reset_roll_cache_for_tests()
+    c = get_companion()
+    assert c is not None
+    assert c.name == 'Bytespark'
+    assert c.personality == 'Test personality.'
+    assert c.hatched_at == 1234567890
+    # Bones should match deterministic roll for fixed-id
+    expected_bones = roll('fixed-id').bones
+    assert c.rarity == expected_bones.rarity
+    assert c.species == expected_bones.species

--- a/tests/buddy/test_notification.py
+++ b/tests/buddy/test_notification.py
@@ -1,0 +1,91 @@
+"""Date-gates + buddy-trigger regex."""
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from src.buddy.notification import (
+    find_buddy_trigger_positions,
+    is_buddy_live,
+    is_buddy_teaser_window,
+)
+
+
+def _freeze(year: int, month: int, day: int) -> object:
+    """Helper to patch datetime.now() inside notification module."""
+    fake = datetime(year, month, day, 12, 0, 0)
+
+    class _FakeDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None) -> 'datetime':
+            return fake
+
+    return patch('src.buddy.notification.datetime', _FakeDateTime)
+
+
+def test_teaser_window_april_3_2026_true() -> None:
+    with _freeze(2026, 4, 3):
+        assert is_buddy_teaser_window() is True
+
+
+def test_teaser_window_april_8_2026_false() -> None:
+    with _freeze(2026, 4, 8):
+        assert is_buddy_teaser_window() is False
+
+
+def test_teaser_window_march_31_2026_false() -> None:
+    with _freeze(2026, 3, 31):
+        assert is_buddy_teaser_window() is False
+
+
+def test_teaser_window_april_2027_false() -> None:
+    """Only April 1-7 of 2026 — not later years."""
+    with _freeze(2027, 4, 3):
+        assert is_buddy_teaser_window() is False
+
+
+def test_buddy_live_april_2026_true() -> None:
+    with _freeze(2026, 4, 15):
+        assert is_buddy_live() is True
+
+
+def test_buddy_live_may_2026_true() -> None:
+    with _freeze(2026, 5, 27):
+        assert is_buddy_live() is True
+
+
+def test_buddy_live_march_2026_false() -> None:
+    with _freeze(2026, 3, 15):
+        assert is_buddy_live() is False
+
+
+def test_buddy_live_2027_true() -> None:
+    with _freeze(2027, 1, 1):
+        assert is_buddy_live() is True
+
+
+def test_find_triggers_basic() -> None:
+    result = find_buddy_trigger_positions('hi /buddy there')
+    assert result == [{'start': 3, 'end': 9}]
+
+
+def test_find_triggers_word_boundary() -> None:
+    """``/buddyfoo`` should not match — word boundary required."""
+    assert find_buddy_trigger_positions('hi /buddyfoo') == []
+
+
+def test_find_triggers_multiple() -> None:
+    result = find_buddy_trigger_positions('/buddy and /buddy')
+    assert len(result) == 2
+    assert result[0]['start'] == 0
+    assert result[1]['start'] == 11
+
+
+def test_find_triggers_empty_text() -> None:
+    assert find_buddy_trigger_positions('') == []
+
+
+def test_find_triggers_no_match() -> None:
+    assert find_buddy_trigger_positions('nothing special') == []

--- a/tests/buddy/test_observer.py
+++ b/tests/buddy/test_observer.py
@@ -1,0 +1,145 @@
+"""Per-turn observer behavior."""
+from __future__ import annotations
+
+from typing import Any
+
+from src.buddy.observer import fire_companion_observer
+from src.types.messages import create_user_message
+
+
+def _hatch(config: dict[str, Any], name: str = 'Bytespark') -> None:
+    """Helper to set up a hatched companion in the isolated config."""
+    config['user_id'] = 'fixed-id'
+    config['companion'] = {
+        'name': name,
+        'personality': 'Curious test personality.',
+        'hatched_at': 0,
+    }
+
+
+def test_observer_silent_when_no_companion(
+    isolated_config: dict[str, Any],
+) -> None:
+    called: list[str | None] = []
+    fire_companion_observer([create_user_message('hello')], called.append)
+    assert called == []
+
+
+def test_observer_silent_when_muted(
+    isolated_config: dict[str, Any],
+) -> None:
+    _hatch(isolated_config)
+    isolated_config['companion_muted'] = True
+    called: list[str | None] = []
+    fire_companion_observer(
+        [create_user_message('Bytespark hi!')], called.append,
+    )
+    assert called == []
+
+
+def test_observer_silent_on_no_user_message(
+    isolated_config: dict[str, Any],
+) -> None:
+    _hatch(isolated_config)
+    called: list[str | None] = []
+    fire_companion_observer([], called.append)
+    assert called == []
+
+
+def test_observer_pet_reply_on_slash_buddy(
+    isolated_config: dict[str, Any],
+) -> None:
+    _hatch(isolated_config)
+    called: list[str | None] = []
+    fire_companion_observer(
+        [create_user_message('/buddy please')], called.append,
+    )
+    assert len(called) == 1
+    # Pet reply is one of the _PET_REPLIES strings (lowercased phrases)
+    from src.buddy.observer import _PET_REPLIES
+    assert called[0] in _PET_REPLIES
+
+
+def test_observer_direct_reply_on_name_mention(
+    isolated_config: dict[str, Any],
+) -> None:
+    _hatch(isolated_config, name='Bytespark')
+    called: list[str | None] = []
+    fire_companion_observer(
+        [create_user_message('hey Bytespark, look at this')], called.append,
+    )
+    assert len(called) == 1
+    msg = called[0]
+    assert msg is not None
+    # Format: "{name}: {reply}"
+    assert msg.startswith('Bytespark: ')
+    from src.buddy.observer import _DIRECT_REPLIES
+    assert any(msg.endswith(r) for r in _DIRECT_REPLIES)
+
+
+def test_observer_direct_reply_on_buddy_word(
+    isolated_config: dict[str, Any],
+) -> None:
+    _hatch(isolated_config)
+    called: list[str | None] = []
+    fire_companion_observer(
+        [create_user_message('hey buddy what now')], called.append,
+    )
+    assert len(called) == 1
+    assert called[0] is not None
+    assert called[0].startswith('Bytespark: ')
+
+
+def test_observer_direct_reply_on_companion_word(
+    isolated_config: dict[str, Any],
+) -> None:
+    _hatch(isolated_config)
+    called: list[str | None] = []
+    fire_companion_observer(
+        [create_user_message('what does my companion think?')], called.append,
+    )
+    assert len(called) == 1
+
+
+def test_observer_silent_on_unrelated_text(
+    isolated_config: dict[str, Any],
+) -> None:
+    _hatch(isolated_config)
+    called: list[str | None] = []
+    fire_companion_observer(
+        [create_user_message('just normal code review please')], called.append,
+    )
+    assert called == []
+
+
+def test_observer_deterministic_per_text(
+    isolated_config: dict[str, Any],
+) -> None:
+    """Same input → same reaction."""
+    _hatch(isolated_config)
+    a: list[str | None] = []
+    b: list[str | None] = []
+    fire_companion_observer(
+        [create_user_message('Bytespark hi!')], a.append,
+    )
+    fire_companion_observer(
+        [create_user_message('Bytespark hi!')], b.append,
+    )
+    assert a == b
+
+
+def test_observer_uses_last_user_message(
+    isolated_config: dict[str, Any],
+) -> None:
+    """The observer reads the MOST RECENT user message, not all of them."""
+    _hatch(isolated_config)
+    called: list[str | None] = []
+    msgs = [
+        create_user_message('boring first message'),
+        create_user_message('/buddy please'),
+    ]
+    fire_companion_observer(msgs, called.append)
+    assert len(called) == 1
+    # Should be a pet reply (triggered by the /buddy in the LAST message)
+    from src.buddy.observer import _PET_REPLIES
+    assert called[0] in _PET_REPLIES

--- a/tests/buddy/test_prompt.py
+++ b/tests/buddy/test_prompt.py
@@ -1,0 +1,135 @@
+"""Prompt module: intro text, attachment build + dedup, formatter."""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.buddy.prompt import (
+    build_companion_intro_attachment,
+    companion_intro_text,
+    format_companion_intro_attachments,
+)
+from src.types.messages import AttachmentMessage, create_attachment_message
+
+
+def test_intro_text_contains_name_and_species() -> None:
+    text = companion_intro_text('Bytespark', 'duck')
+    assert 'Bytespark' in text
+    assert 'duck' in text
+    assert '# Companion' in text
+
+
+def test_build_returns_empty_when_no_companion(
+    isolated_config: dict[str, Any],
+) -> None:
+    """No companion in config → []."""
+    assert build_companion_intro_attachment([]) == []
+
+
+def test_build_returns_empty_when_muted(
+    isolated_config: dict[str, Any],
+) -> None:
+    isolated_config['user_id'] = 'fixed-id'
+    isolated_config['companion'] = {
+        'name': 'Bytespark', 'personality': 'p.', 'hatched_at': 0,
+    }
+    isolated_config['companion_muted'] = True
+    assert build_companion_intro_attachment([]) == []
+
+
+def test_build_returns_attachment_when_eligible(
+    isolated_config: dict[str, Any],
+) -> None:
+    isolated_config['user_id'] = 'fixed-id'
+    isolated_config['companion'] = {
+        'name': 'Bytespark', 'personality': 'p.', 'hatched_at': 0,
+    }
+    result = build_companion_intro_attachment([])
+    assert len(result) == 1
+    att = result[0]
+    assert att['kind'] == 'companion_intro'
+    assert att['name'] == 'Bytespark'
+    assert 'species' in att
+
+
+def test_build_dedups_against_marker_in_engine_messages(
+    isolated_config: dict[str, Any],
+) -> None:
+    """When messages already contain an AttachmentMessage for the same
+    companion name, build returns []."""
+    isolated_config['user_id'] = 'fixed-id'
+    isolated_config['companion'] = {
+        'name': 'Bytespark', 'personality': 'p.', 'hatched_at': 0,
+    }
+    marker = create_attachment_message({
+        'kind': 'companion_intro',
+        'name': 'Bytespark',
+        'species': 'duck',
+    })
+    assert build_companion_intro_attachment([marker]) == []
+
+
+def test_build_does_not_dedup_against_different_name(
+    isolated_config: dict[str, Any],
+) -> None:
+    isolated_config['user_id'] = 'fixed-id'
+    isolated_config['companion'] = {
+        'name': 'Bytespark', 'personality': 'p.', 'hatched_at': 0,
+    }
+    marker = create_attachment_message({
+        'kind': 'companion_intro',
+        'name': 'OtherName',
+        'species': 'duck',
+    })
+    result = build_companion_intro_attachment([marker])
+    assert len(result) == 1
+
+
+def test_format_emits_system_reminder() -> None:
+    out = format_companion_intro_attachments([{
+        'kind': 'companion_intro', 'name': 'Bytespark', 'species': 'duck',
+    }])
+    assert '<system-reminder>' in out
+    assert '</system-reminder>' in out
+    assert 'Bytespark' in out
+    assert 'duck' in out
+
+
+def test_format_ignores_other_kinds() -> None:
+    out = format_companion_intro_attachments([
+        {'kind': 'file', 'path': 'foo'},
+        {'kind': 'directory', 'path': 'bar/'},
+    ])
+    assert out == ''
+
+
+def test_format_empty_input() -> None:
+    assert format_companion_intro_attachments([]) == ''
+
+
+def test_normalize_marker_followed_by_user_does_not_double_user_turn(
+    isolated_config: dict[str, Any],
+) -> None:
+    """Empty-content normalization fragility check (plan §5).
+
+    The dedup marker has ``content=[]``. After ``normalize_messages_for_api``,
+    a marker followed by a user message should merge into a single user
+    entry — NOT emit two separate user turns. If this test ever breaks,
+    the buddy marker shape needs revisiting.
+    """
+    from src.types.messages import (
+        UserMessage, create_user_message, normalize_messages_for_api,
+    )
+    marker = create_attachment_message({
+        'kind': 'companion_intro', 'name': 'X', 'species': 'duck',
+    })
+    user = create_user_message('hello world')
+    out = normalize_messages_for_api([marker, user])
+    user_entries = [m for m in out if m.get('role') == 'user']
+    # The marker's empty content gets merged with the following user
+    # message (predicate at src/types/messages.py:527-535). Expect ONE
+    # merged user entry, not two.
+    assert len(user_entries) == 1, (
+        f"expected 1 merged user entry, got {len(user_entries)}: {out!r}"
+    )

--- a/tests/buddy/test_soul.py
+++ b/tests/buddy/test_soul.py
@@ -1,0 +1,63 @@
+"""Soul generator: deterministic name + personality + hatched_at."""
+from __future__ import annotations
+
+import re
+
+from src.buddy.soul import (
+    NAME_PREFIXES,
+    NAME_SUFFIXES,
+    PERSONALITIES,
+    create_stored_companion,
+)
+
+
+def test_create_stored_companion_deterministic_except_hatched_at() -> None:
+    """Same user_id → same name + personality; hatched_at varies."""
+    a = create_stored_companion('alice')
+    b = create_stored_companion('alice')
+    assert a['name'] == b['name']
+    assert a['personality'] == b['personality']
+    # hatched_at can equal if calls happen in same millisecond, but both
+    # are still positive ints.
+    assert a['hatched_at'] >= 0
+    assert b['hatched_at'] >= 0
+
+
+def test_different_users_get_different_souls() -> None:
+    """alice vs bob → at least one of name/personality differs."""
+    a = create_stored_companion('alice')
+    b = create_stored_companion('bob')
+    assert a['name'] != b['name'] or a['personality'] != b['personality']
+
+
+def test_name_format() -> None:
+    """Name is `<Prefix><suffix>` where prefix is title-cased and
+    suffix is lowercase."""
+    c = create_stored_companion('test')
+    name = c['name']
+    # Find which prefix and suffix were chosen
+    matched_prefix = next(
+        (p for p in NAME_PREFIXES if name.startswith(p)), None,
+    )
+    assert matched_prefix is not None, f"name {name!r} starts with no prefix"
+    rest = name[len(matched_prefix):]
+    assert rest in NAME_SUFFIXES, f"name suffix {rest!r} not in NAME_SUFFIXES"
+
+
+def test_personality_ends_with_period() -> None:
+    """Personality is `<base>.` per TS buddy.tsx:74."""
+    c = create_stored_companion('test')
+    assert c['personality'].endswith('.')
+    # The base (without the trailing dot) should be one of the
+    # PERSONALITIES entries.
+    base = c['personality'][:-1]
+    assert base in PERSONALITIES
+
+
+def test_hatched_at_is_unix_millis() -> None:
+    """hatched_at is a positive int in milliseconds (TS contract)."""
+    import time
+    before = int(time.time() * 1000)
+    c = create_stored_companion('x')
+    after = int(time.time() * 1000)
+    assert before <= c['hatched_at'] <= after

--- a/tests/buddy/test_sprites.py
+++ b/tests/buddy/test_sprites.py
@@ -1,0 +1,263 @@
+"""Sprite library: rendering invariants over all 18 species."""
+from __future__ import annotations
+
+import pytest
+
+from src.buddy.sprites import (
+    BODIES,
+    HAT_LINES,
+    MIN_COLS_FOR_FULL_SPRITE,
+    render_face,
+    render_sprite,
+    sprite_frame_count,
+)
+from src.buddy.types import CompanionBones, EYES, HATS, SPECIES
+
+
+@pytest.mark.parametrize("species", SPECIES)
+def test_eye_substituted_in_all_frames(species: str) -> None:
+    """No remaining ``{E}`` tokens after rendering."""
+    bones = CompanionBones(
+        rarity='common', species=species, eye='·', hat='none',
+        shiny=False, stats={},
+    )
+    for frame in range(3):
+        lines = render_sprite(bones, frame=frame)
+        for line in lines:
+            assert '{E}' not in line, (
+                f"{species} frame {frame}: {{E}} not substituted"
+            )
+
+
+@pytest.mark.parametrize("species", SPECIES)
+def test_eye_glyph_appears(species: str) -> None:
+    """The eye glyph should appear somewhere in the rendered output."""
+    bones = CompanionBones(
+        rarity='common', species=species, eye='@', hat='none',
+        shiny=False, stats={},
+    )
+    lines = render_sprite(bones, frame=0)
+    assert any('@' in line for line in lines), (
+        f"{species}: eye glyph not found in rendered sprite"
+    )
+
+
+@pytest.mark.parametrize("species", SPECIES)
+def test_line_count_with_hat_none(species: str) -> None:
+    """With ``hat='none'``, line count is 4 IF every frame has blank
+    line 0 (shift fires), else 5."""
+    frames = BODIES[species]
+    all_frames_blank_top = all(not f[0].strip() for f in frames)
+    bones = CompanionBones(
+        rarity='common', species=species, eye='·', hat='none',
+        shiny=False, stats={},
+    )
+    lines = render_sprite(bones, frame=0)
+    expected = 4 if all_frames_blank_top else 5
+    assert len(lines) == expected, (
+        f"{species}: expected {expected} lines (all_blank_top={all_frames_blank_top}), got {len(lines)}"
+    )
+
+
+@pytest.mark.parametrize("species", SPECIES)
+def test_line_count_with_hat_keeps_5(species: str) -> None:
+    """With any hat other than 'none', no shift; line count stays 5."""
+    bones = CompanionBones(
+        rarity='rare', species=species, eye='·', hat='crown',
+        shiny=False, stats={},
+    )
+    # Skip species whose frame-0 line 0 is non-blank (hat won't fit;
+    # render_sprite leaves line 0 alone in that case).
+    if BODIES[species][0][0].strip():
+        pytest.skip(f"{species} frame-0 line 0 is non-blank")
+    lines = render_sprite(bones, frame=0)
+    assert len(lines) == 5
+    assert 'crown' not in lines[0]  # crown content, not name
+    assert lines[0] == HAT_LINES['crown']
+
+
+@pytest.mark.parametrize("species", SPECIES)
+def test_width_bounded(species: str) -> None:
+    """All rendered lines have width ≤ 12 (sprite-body width)."""
+    bones = CompanionBones(
+        rarity='common', species=species, eye='·', hat='none',
+        shiny=False, stats={},
+    )
+    for frame in range(3):
+        for line in render_sprite(bones, frame=frame):
+            assert len(line) <= 12, (
+                f"{species} frame {frame}: line width {len(line)} > 12: {line!r}"
+            )
+
+
+@pytest.mark.parametrize("species", SPECIES)
+def test_frame_count_is_3(species: str) -> None:
+    assert sprite_frame_count(species) == 3
+
+
+@pytest.mark.parametrize("species", SPECIES)
+def test_render_face_contains_eye(species: str) -> None:
+    """The compact face for each species contains the eye glyph."""
+    for eye in EYES:
+        bones = CompanionBones(
+            rarity='common', species=species, eye=eye, hat='none',
+            shiny=False, stats={},
+        )
+        face = render_face(bones)
+        assert eye in face, (
+            f"{species}: eye {eye!r} not in face {face!r}"
+        )
+        assert '{E}' not in face
+
+
+def test_min_cols_constant() -> None:
+    """MIN_COLS_FOR_FULL_SPRITE matches TS const."""
+    assert MIN_COLS_FOR_FULL_SPRITE == 100
+
+
+def test_hat_lines_has_all_hats() -> None:
+    """Every Hat literal must have a HAT_LINES entry."""
+    assert set(HAT_LINES.keys()) == set(HATS)
+
+
+def test_bodies_has_all_species() -> None:
+    assert set(BODIES.keys()) == set(SPECIES)
+
+
+# Content snapshot — one line per species per frame, sourced from TS
+# typescript/src/buddy/sprites.ts (BODIES table). Catches single-character
+# drifts that the structural tests above miss (e.g. mushroom's
+# .-o-OO-o-. vs .-O-oo-O-. alternation pattern).
+_EXPECTED_BODIES: dict[str, tuple[tuple[str, ...], ...]] = {
+    'duck': (
+        ('            ', '    __      ', '  <({E} )___  ', '   (  ._>   ', '    `--´    '),
+        ('            ', '    __      ', '  <({E} )___  ', '   (  ._>   ', '    `--´~   '),
+        ('            ', '    __      ', '  <({E} )___  ', '   (  .__>  ', '    `--´    '),
+    ),
+    'goose': (
+        ('            ', '     ({E}>    ', '     ||     ', '   _(__)_   ', '    ^^^^    '),
+        ('            ', '    ({E}>     ', '     ||     ', '   _(__)_   ', '    ^^^^    '),
+        ('            ', '     ({E}>>   ', '     ||     ', '   _(__)_   ', '    ^^^^    '),
+    ),
+    'blob': (
+        ('            ', '   .----.   ', '  ( {E}  {E} )  ', '  (      )  ', '   `----´   '),
+        ('            ', '  .------.  ', ' (  {E}  {E}  ) ', ' (        ) ', '  `------´  '),
+        ('            ', '    .--.    ', '   ({E}  {E})   ', '   (    )   ', '    `--´    '),
+    ),
+    'cat': (
+        ('            ', '   /\\_/\\    ', '  ( {E}   {E})  ', '  (  ω  )   ', '  (")_(")   '),
+        ('            ', '   /\\_/\\    ', '  ( {E}   {E})  ', '  (  ω  )   ', '  (")_(")~  '),
+        ('            ', '   /\\-/\\    ', '  ( {E}   {E})  ', '  (  ω  )   ', '  (")_(")   '),
+    ),
+    'dragon': (
+        ('            ', '  /^\\  /^\\  ', ' <  {E}  {E}  > ', ' (   ~~   ) ', '  `-vvvv-´  '),
+        ('            ', '  /^\\  /^\\  ', ' <  {E}  {E}  > ', ' (        ) ', '  `-vvvv-´  '),
+        ('   ~    ~   ', '  /^\\  /^\\  ', ' <  {E}  {E}  > ', ' (   ~~   ) ', '  `-vvvv-´  '),
+    ),
+    'octopus': (
+        ('            ', '   .----.   ', '  ( {E}  {E} )  ', '  (______)  ', '  /\\/\\/\\/\\  '),
+        ('            ', '   .----.   ', '  ( {E}  {E} )  ', '  (______)  ', '  \\/\\/\\/\\/  '),
+        ('     o      ', '   .----.   ', '  ( {E}  {E} )  ', '  (______)  ', '  /\\/\\/\\/\\  '),
+    ),
+    'owl': (
+        ('            ', '   /\\  /\\   ', '  (({E})({E}))  ', '  (  ><  )  ', '   `----´   '),
+        ('            ', '   /\\  /\\   ', '  (({E})({E}))  ', '  (  ><  )  ', '   .----.   '),
+        ('            ', '   /\\  /\\   ', '  (({E})(-))  ', '  (  ><  )  ', '   `----´   '),
+    ),
+    'penguin': (
+        ('            ', '  .---.     ', '  ({E}>{E})     ', ' /(   )\\    ', '  `---´     '),
+        ('            ', '  .---.     ', '  ({E}>{E})     ', ' |(   )|    ', '  `---´     '),
+        ('  .---.     ', '  ({E}>{E})     ', ' /(   )\\    ', '  `---´     ', '   ~ ~      '),
+    ),
+    'turtle': (
+        ('            ', '   _,--._   ', '  ( {E}  {E} )  ', ' /[______]\\ ', '  ``    ``  '),
+        ('            ', '   _,--._   ', '  ( {E}  {E} )  ', ' /[______]\\ ', '   ``  ``   '),
+        ('            ', '   _,--._   ', '  ( {E}  {E} )  ', ' /[======]\\ ', '  ``    ``  '),
+    ),
+    'snail': (
+        ('            ', ' {E}    .--.  ', '  \\  ( @ )  ', '   \\_`--´   ', '  ~~~~~~~   '),
+        ('            ', '  {E}   .--.  ', '  |  ( @ )  ', '   \\_`--´   ', '  ~~~~~~~   '),
+        ('            ', ' {E}    .--.  ', '  \\  ( @  ) ', '   \\_`--´   ', '   ~~~~~~   '),
+    ),
+    'ghost': (
+        ('            ', '   .----.   ', '  / {E}  {E} \\  ', '  |      |  ', '  ~`~``~`~  '),
+        ('            ', '   .----.   ', '  / {E}  {E} \\  ', '  |      |  ', '  `~`~~`~`  '),
+        ('    ~  ~    ', '   .----.   ', '  / {E}  {E} \\  ', '  |      |  ', '  ~~`~~`~~  '),
+    ),
+    'axolotl': (
+        ('            ', '}~(______)~{', '}~({E} .. {E})~{', '  ( .--. )  ', '  (_/  \\_)  '),
+        ('            ', '~}(______){~', '~}({E} .. {E}){~', '  ( .--. )  ', '  (_/  \\_)  '),
+        ('            ', '}~(______)~{', '}~({E} .. {E})~{', '  (  --  )  ', '  ~_/  \\_~  '),
+    ),
+    'capybara': (
+        ('            ', '  n______n  ', ' ( {E}    {E} ) ', ' (   oo   ) ', '  `------´  '),
+        ('            ', '  n______n  ', ' ( {E}    {E} ) ', ' (   Oo   ) ', '  `------´  '),
+        ('    ~  ~    ', '  u______n  ', ' ( {E}    {E} ) ', ' (   oo   ) ', '  `------´  '),
+    ),
+    'cactus': (
+        ('            ', ' n  ____  n ', ' | |{E}  {E}| | ', ' |_|    |_| ', '   |    |   '),
+        ('            ', '    ____    ', ' n |{E}  {E}| n ', ' |_|    |_| ', '   |    |   '),
+        (' n        n ', ' |  ____  | ', ' | |{E}  {E}| | ', ' |_|    |_| ', '   |    |   '),
+    ),
+    'robot': (
+        ('            ', '   .[||].   ', '  [ {E}  {E} ]  ', '  [ ==== ]  ', '  `------´  '),
+        ('            ', '   .[||].   ', '  [ {E}  {E} ]  ', '  [ -==- ]  ', '  `------´  '),
+        ('     *      ', '   .[||].   ', '  [ {E}  {E} ]  ', '  [ ==== ]  ', '  `------´  '),
+    ),
+    'rabbit': (
+        ('            ', '   (\\__/)   ', '  ( {E}  {E} )  ', ' =(  ..  )= ', '  (")__(")  '),
+        ('            ', '   (|__/)   ', '  ( {E}  {E} )  ', ' =(  ..  )= ', '  (")__(")  '),
+        ('            ', '   (\\__/)   ', '  ( {E}  {E} )  ', ' =( .  . )= ', '  (")__(")  '),
+    ),
+    'mushroom': (
+        ('            ', ' .-o-OO-o-. ', '(__________)', '   |{E}  {E}|   ', '   |____|   '),
+        ('            ', ' .-O-oo-O-. ', '(__________)', '   |{E}  {E}|   ', '   |____|   '),
+        ('   . o  .   ', ' .-o-OO-o-. ', '(__________)', '   |{E}  {E}|   ', '   |____|   '),
+    ),
+    'chonk': (
+        ('            ', '  /\\    /\\  ', ' ( {E}    {E} ) ', ' (   ..   ) ', '  `------´  '),
+        ('            ', '  /\\    /|  ', ' ( {E}    {E} ) ', ' (   ..   ) ', '  `------´  '),
+        ('            ', '  /\\    /\\  ', ' ( {E}    {E} ) ', ' (   ..   ) ', '  `------´~ '),
+    ),
+}
+
+
+@pytest.mark.parametrize("species", SPECIES)
+def test_bodies_match_ts_source(species: str) -> None:
+    """Content snapshot: every line of every frame of every species
+    matches the expected value sourced from
+    ``typescript/src/buddy/sprites.ts``. Catches single-character
+    drifts that the structural tests miss.
+    """
+    expected = _EXPECTED_BODIES[species]
+    actual = BODIES[species]
+    assert len(actual) == len(expected), (
+        f"{species}: frame count drift (got {len(actual)}, expected {len(expected)})"
+    )
+    for frame_idx, (exp_frame, act_frame) in enumerate(zip(expected, actual)):
+        assert len(act_frame) == len(exp_frame), (
+            f"{species} frame {frame_idx}: line count drift"
+        )
+        for line_idx, (exp_line, act_line) in enumerate(zip(exp_frame, act_frame)):
+            assert act_line == exp_line, (
+                f"{species} frame {frame_idx} line {line_idx} drift:\n"
+                f"  expected: {exp_line!r}\n"
+                f"  actual:   {act_line!r}"
+            )
+
+
+def test_expected_bodies_covers_all_species() -> None:
+    """Guard: snapshot table must cover every species."""
+    assert set(_EXPECTED_BODIES.keys()) == set(SPECIES)
+
+
+def test_penguin_stays_5_lines_with_no_hat() -> None:
+    """Penguin's frame 2 uses line 0 for the `~ ~` waddle, so the
+    shift should NOT fire even with hat='none'. Regression check for
+    the ALL-frames vs SOME-frames distinction in render_sprite."""
+    bones = CompanionBones(
+        rarity='common', species='penguin', eye='·', hat='none',
+        shiny=False, stats={},
+    )
+    lines = render_sprite(bones, frame=0)
+    assert len(lines) == 5

--- a/tests/buddy/test_types.py
+++ b/tests/buddy/test_types.py
@@ -1,0 +1,54 @@
+"""Type/constants invariants."""
+from __future__ import annotations
+
+import dataclasses
+
+from src.buddy.types import (
+    EYES,
+    HATS,
+    RARITIES,
+    RARITY_COLORS,
+    RARITY_STARS,
+    RARITY_WEIGHTS,
+    SPECIES,
+    STAT_NAMES,
+)
+
+
+def test_rarity_keys_match_across_dicts() -> None:
+    """RARITY_WEIGHTS / RARITY_STARS / RARITY_COLORS keys == RARITIES."""
+    assert set(RARITY_WEIGHTS.keys()) == set(RARITIES)
+    assert set(RARITY_STARS.keys()) == set(RARITIES)
+    assert set(RARITY_COLORS.keys()) == set(RARITIES)
+
+
+def test_rarity_colors_values_are_palette_keys() -> None:
+    """Every RARITY_COLORS value must be a valid Palette field name."""
+    from src.tui.theme import Palette
+    palette_fields = {f.name for f in dataclasses.fields(Palette)}
+    for rarity, key in RARITY_COLORS.items():
+        assert key in palette_fields, (
+            f"RARITY_COLORS[{rarity!r}] = {key!r} is not a Palette field"
+        )
+
+
+def test_species_count() -> None:
+    assert len(SPECIES) == 18
+
+
+def test_eyes_count() -> None:
+    assert len(EYES) == 6
+
+
+def test_hats_count_and_includes_none() -> None:
+    assert len(HATS) == 8
+    assert 'none' in HATS
+
+
+def test_stat_names_count() -> None:
+    assert len(STAT_NAMES) == 5
+
+
+def test_rarity_weights_sum() -> None:
+    """Total weight is 100 (TS contract from types.ts:126-132)."""
+    assert sum(RARITY_WEIGHTS.values()) == 100


### PR DESCRIPTION
## Summary

Folder-parity port of `typescript/src/buddy/` → `src/buddy/`. Ports the ~700 LOC headless core (8 of the TS folder's 8 files, minus the Ink/React widget portions) and wires the `/buddy` command + observer + companion-intro attachment into the Python REPL.

- **Headless core ported now**: feature gate, type system, soul-and-bones companion generation (deterministic-from-`user_id` bones never persist; soul persists), ASCII sprite library (18 species × 3 frames), system-prompt intro attachment with dedup, per-turn observer, date gates and `/buddy` regex.
- **`/buddy` command** (LocalCommand): hatch / pet / status / mute / unmute / help. Registered via `command_system/builtins.py::get_builtin_commands()` gated on `is_buddy_enabled()`.
- **REPL integration** in `src/repl/core.py::chat()` (3 minimal edits): prepend companion-intro `<system-reminder>` to user text; append dedup marker `AttachmentMessage` after engine completion; fire per-turn observer.
- **Ink/React widget deferred** (Class C): `CompanionSprite`, `CompanionFloatingBubble`, `useBuddyNotification` hook, `companion_reserved_columns`. The Python Textual TUI has no companion mount point yet; the ported data layer makes that future pass a thin shell.

Design docs (pinned decisions, every load-bearing claim cited to source):
- `my-docs/get-parity-by-folder/buddy-gap-analysis.md`
- `my-docs/get-parity-by-folder/buddy-refactoring-plan.md`

Both went through multiple rounds of critic review (APPROVE).

### Pinned decisions worth flagging at review

- **`companion_user_id()` divergence**: reads Python `config["user_id"]` only — skips the TS `oauthAccount.accountUuid` fallback because `OAuthAccountInfo` doesn't expose `account_uuid` yet. Documented in `src/buddy/companion.py`. One-time discrepancy that disappears when a future auth-folder pass adds the field.
- **`companion_intro` integration**: intro text reaches the model via prepend to user-message text (matches Python's at-mention pattern); a separate `AttachmentMessage` marker (`content=[]`, invisible to API and renderer) carries dedup state. See `buddy-gap-analysis.md §2.9, §4.6`.
- **`/buddy pet`**: returns `LocalCommandResult(type="text", value=reaction)` instead of TS's `display:'skip'` — without UI animation, silent-on-success was the wrong UX. `companion_pet_at` persists at top-level config (snake_case).
- **`COMMON_HELP_ARGS` / `COMMON_INFO_ARGS`** additively ported to `src/constants/xml.py`. `?` routes to INFO (status), not HELP — matches TS exactly.
- **Plain string species literals**: TS encodes species names via `String.fromCharCode` to bypass a build-time canary scan; Python has no equivalent check, so plain strings + an audit-trail comment (see `src/buddy/types.py`).

## Test plan

- [x] `uv run python -m pytest tests/buddy/` → **221 passed** in 0.48s
  - Includes a content snapshot for all 270 sprite-library cells (18 species × 3 frames × 5 lines) sourced from TS, plus a coverage guard. Caught one drift during critic review (mushroom frame 2).
  - Includes the empty-content normalize-merge fragility guard for the dedup marker (`test_normalize_marker_followed_by_user_does_not_double_user_turn`).
- [x] Adjacent regression sweep: `pytest tests/test_no_top_level_decoys.py tests/test_command_system.py tests/test_app_state.py tests/test_message_normalization.py tests/test_message_types.py tests/test_messages_utility.py` → **129 passed**, 0 regressions.
- [x] Smoke import: `python -c "from src.buddy import is_buddy_enabled, get_companion, render_sprite, build_companion_intro_attachment, fire_companion_observer; print('ok')"` → ok
- [x] Class C deferred items NOT created (no `CompanionSprite` Textual widget; no `useBuddyNotification`; no `companion_reserved_columns`).
- [x] `grep "fire_companion_observer" src/repl/core.py` → 2 (regression guard against future contributors removing the per-turn hook).
- [ ] Manual `/buddy` smoke (hatch + pet + status + mute + unmute) — covered by unit tests; recommended to spot-check in a REPL before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)