### PR TITLE
cli parity: transport factory, worker-state uploader, RemoteIO bridge

### DIFF
--- a/src/transports/__init__.py
+++ b/src/transports/__init__.py
@@ -1,9 +1,55 @@
-"""CCR Bridge v2 read/write transports.
+"""Wire-level transports + protocol-layer helpers for SDK sessions.
 
-Two halves:
+This package collects everything that lives under
+``typescript/src/cli/transports/`` plus the small ``RemoteIO``
+protocol-layer bridge from ``typescript/src/cli/remoteIO.ts`` (placed
+here because Python keeps sync ``cli_core`` separate from async
+transports — see ``my-docs/get-parity-by-folder/cli-gap-analysis.md``
+§2.5).
 
-  * ``sse_transport.SSETransport`` — read side (SSE long-poll).
-  * ``ccr_client.CCRClient`` — write side (HTTP POST batching + heartbeat).
+Public surface:
 
-Both consumed by ``src.bridge.repl_bridge_transport.create_v2_repl_transport``.
+* :class:`WebSocketTransport` — reconnecting WS read/write.
+* :class:`HybridTransport` — WS read + HTTP POST write (via
+  :class:`SerialBatchEventUploader`).
+* :class:`SSETransport` — SSE read + HTTP POST write (CCR v2).
+* :class:`SerialBatchEventUploader` — shared write-side queue.
+* :class:`CCRClient` — CCR v2 client wrapper. (TS exports a sibling
+  ``CCRInitError`` exception class which is not yet present in the
+  Python port; tracked in cli-gap-analysis.md §4.7.)
+* :class:`WorkerStateUploader` (+ :class:`WorkerStateUploaderConfig`)
+  — coalescing PUT /worker uploader.
+* :func:`get_transport_for_url` — factory selecting the right transport
+  by URL scheme + env vars.
+* :class:`RemoteIO` — StructuredIO-style bridge over a Transport
+  (WS/Hybrid only — see ``remote_io`` docstring for CCR v2 caveat).
+* :class:`Transport` — typing.Protocol every transport satisfies (sans
+  ``write``).
 """
+
+from __future__ import annotations
+
+from src.transports.ccr_client import CCRClient
+from src.transports.hybrid_transport import HybridTransport
+from src.transports.remote_io import RemoteIO
+from src.transports.serial_batch_event_uploader import SerialBatchEventUploader
+from src.transports.sse_transport import SSETransport
+from src.transports.transport_utils import Transport, get_transport_for_url
+from src.transports.websocket_transport import WebSocketTransport
+from src.transports.worker_state_uploader import (
+    WorkerStateUploader,
+    WorkerStateUploaderConfig,
+)
+
+__all__ = [
+    "CCRClient",
+    "HybridTransport",
+    "RemoteIO",
+    "SerialBatchEventUploader",
+    "SSETransport",
+    "Transport",
+    "WebSocketTransport",
+    "WorkerStateUploader",
+    "WorkerStateUploaderConfig",
+    "get_transport_for_url",
+]

--- a/src/transports/remote_io.py
+++ b/src/transports/remote_io.py
@@ -1,0 +1,317 @@
+"""Async StructuredIO-style bridge over a Transport.
+
+Port of ``typescript/src/cli/remoteIO.ts`` (structural skeleton).
+
+Lives in ``src/transports/`` (not ``src/cli_core/``) because Python's
+``cli_core`` is pure sync; ``RemoteIO`` is async (owns an async
+Transport, async input stream). See ``my-docs/get-parity-by-folder/
+cli-gap-analysis.md`` §2.5.
+
+Scope of this port
+------------------
+
+This is the **structural skeleton + bridge-mode keep-alive** only.
+
+In scope:
+
+* Constructor wires a Transport (via :func:`get_transport_for_url`),
+  binds ``set_on_data`` / ``set_on_close`` to an async input queue,
+  fires connect.
+* ``write(message)`` forwards to ``transport.write`` for WS/Hybrid
+  transports.
+* Bridge-mode (``CLAUDE_CODE_ENVIRONMENT_KIND == "bridge"``) stdout
+  echo of ``control_request`` messages.
+* Bridge-mode keep-alive task driven by
+  ``get_poll_interval_config().session_keepalive_interval_v2_ms``.
+* Initial-prompt consumption.
+
+Out of scope (TODOs, pinned by cli-gap-analysis.md §3.3 / §4.7)
+---------------------------------------------------------------
+
+* **CCR v2 write path.** ``SSETransport`` has no ``write`` method — the
+  TS code routes writes through ``CCRClient.writeEvent`` for that case
+  (TS ``remoteIO.ts:232-236``). Wiring the Python ``CCRClient`` (which
+  has a different constructor shape: ``(base_url, options,
+  http_client=…)`` + separate ``initialize(epoch)``) into ``RemoteIO``
+  requires deciding how the epoch is obtained — that belongs in the
+  ``ccr_client.py`` deep-port audit. **For this PR**,
+  ``RemoteIO.__init__`` raises ``NotImplementedError`` if the selected
+  transport doesn't expose ``write`` (currently only ``SSETransport``).
+* CCR v2 internal-event reader/writer registration
+  (``setInternalEventWriter``, ``setInternalEventReader``).
+* Session-state listeners (``setCommandLifecycleListener``,
+  ``setSessionStateChangedListener``,
+  ``setSessionMetadataChangedListener``).
+
+No-consumer note
+----------------
+
+No Python module instantiates ``RemoteIO`` today. The bridge runner has
+its own transport wiring in ``src/bridge/repl_bridge_transport.py``.
+This port satisfies inventory parity for
+``typescript/src/cli/remoteIO.ts``; tests cover the class via direct
+construction with monkeypatched transport stubs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from collections.abc import AsyncIterable, AsyncIterator
+from typing import Any
+
+from src.bridge.poll_config import get_poll_interval_config
+from src.cli_core.ndjson import ndjson_safe_dumps
+from src.transports.transport_utils import (
+    Transport,
+    get_transport_for_url,
+    is_env_truthy,
+)
+from src.utils.session_ingress_auth import (
+    get_session_ingress_auth_headers,
+    get_session_ingress_auth_token,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _is_debug_mode() -> bool:
+    """Port of TS ``isDebugMode()`` (utils/debug.ts:44-55).
+
+    TS checks ``DEBUG`` and ``DEBUG_SDK`` env vars (plus the ``--debug``
+    argv flag which is REPL-runtime-only). The argv check is not
+    relevant for RemoteIO; we mirror only the env-var portion.
+    """
+    return is_env_truthy(os.environ.get("DEBUG")) or is_env_truthy(
+        os.environ.get("DEBUG_SDK")
+    )
+
+
+# Sentinel object signaling end-of-stream on the input queue.
+_END_OF_STREAM: object = object()
+
+
+class RemoteIO:
+    """StructuredIO-style stdin/stdout bridge over a Transport.
+
+    Constructor MUST be called inside an asyncio running loop — it uses
+    ``asyncio.get_running_loop()`` to schedule the connect / keep-alive
+    / initial-prompt tasks.
+    """
+
+    def __init__(
+        self,
+        stream_url: str,
+        *,
+        initial_prompt: AsyncIterable[str] | None = None,
+        replay_user_messages: bool = False,
+    ) -> None:
+        self._url_str = stream_url
+        self._replay_user_messages = replay_user_messages
+        self._closed = False
+        # asyncio.Queue safe within the same event loop. _on_data is
+        # called from the transport's reader task on the same loop, so
+        # put_nowait is the correct primitive (no cross-thread concerns).
+        self._input_queue: asyncio.Queue[str | object] = asyncio.Queue()
+        self._input_iter: AsyncIterator[str] | None = None
+        self._keep_alive_task: asyncio.Task[None] | None = None
+        self._initial_prompt_task: asyncio.Task[None] | None = None
+        self._connect_task: asyncio.Task[None] | None = None
+
+        self._is_bridge = (
+            os.environ.get("CLAUDE_CODE_ENVIRONMENT_KIND") == "bridge"
+        )
+        self._is_debug = _is_debug_mode()
+
+        # Header building uses the canonical helpers. These handle BOTH
+        # bearer-auth JWTs AND session-key cookie auth for sk-ant-sid-*
+        # tokens. A hand-rolled "Authorization: Bearer <token>" header
+        # would silently break session-key tokens.
+        def build_headers() -> dict[str, str]:
+            h = dict(get_session_ingress_auth_headers())
+            er_version = os.environ.get("CLAUDE_CODE_ENVIRONMENT_RUNNER_VERSION")
+            if er_version:
+                h["x-environment-runner-version"] = er_version
+            return h
+
+        if get_session_ingress_auth_token() is None:
+            logger.error("[remote-io] No session ingress token available")
+
+        # TODO(parity): wire session_id from bootstrap once the
+        # equivalent of TS getSessionId() is ported. Currently None.
+        session_id: str | None = None
+
+        self._transport: Transport = get_transport_for_url(
+            self._url_str,
+            headers=build_headers(),
+            session_id=session_id,
+            refresh_headers=build_headers,
+        )
+
+        # CCR v2 write path is out of scope for this PR — see module
+        # docstring "Out of scope". Detect via the duck test: every
+        # WS/Hybrid transport has `write`; SSETransport does not.
+        # (TS uses a stricter `instanceof SSETransport` check at
+        # remoteIO.ts:121-125 in the inverse direction. Here a non-SSE
+        # transport that happens to lack `write` would also be rejected,
+        # which is fine — all real transports either have it or are
+        # known to be SSE.)
+        if not hasattr(self._transport, "write"):
+            raise NotImplementedError(
+                "RemoteIO does not support CCR v2 (SSETransport write path) "
+                "in this PR. The TS code routes CCR v2 writes through "
+                "CCRClient.writeEvent (remoteIO.ts:232-236); the Python "
+                "CCRClient has a different constructor that needs an epoch "
+                "from somewhere — wiring belongs in the ccr_client.py "
+                "deep-port audit. See cli-gap-analysis.md §3.3 / §4.7."
+            )
+
+        # on_data → input queue
+        self._transport.set_on_data(self._on_data)
+        # on_close → end-of-stream sentinel; signature takes the close
+        # code per WebSocketTransport.set_on_close (line 263) and
+        # SSETransport.set_on_close (line 109).
+        self._transport.set_on_close(self._on_close)
+
+        # Fire connect (no await; runs on the same loop).
+        loop = asyncio.get_running_loop()
+        self._connect_task = loop.create_task(self._transport.connect())
+
+        # Bridge-mode keep-alive timer.
+        if self._is_bridge:
+            interval_ms = get_poll_interval_config().session_keepalive_interval_v2_ms
+            if interval_ms > 0:
+                self._keep_alive_task = loop.create_task(
+                    self._keep_alive_loop(interval_ms / 1000)
+                )
+
+        # Initial prompt drain.
+        if initial_prompt is not None:
+            self._initial_prompt_task = loop.create_task(
+                self._consume_initial_prompt(initial_prompt)
+            )
+
+    # -- Input side ----------------------------------------------------------
+
+    def _on_data(self, data: str) -> None:
+        # Bridge + debug: echo to stdout.
+        if self._is_bridge and self._is_debug:
+            sys.stdout.write(data if data.endswith("\n") else data + "\n")
+            sys.stdout.flush()
+        self._input_queue.put_nowait(data)
+
+    def _on_close(self, code: int | None = None) -> None:
+        # Signature matches WebSocketTransport.set_on_close (line 263)
+        # and SSETransport.set_on_close (line 109). The close code is
+        # accepted but currently unused — the sentinel is what drives
+        # iterator termination.
+        del code  # unused
+        self._input_queue.put_nowait(_END_OF_STREAM)
+
+    @property
+    def input_stream(self) -> AsyncIterator[str]:
+        """Async iterator over inbound transport data.
+
+        Cached: every access returns the same generator so two callers
+        of ``io.input_stream`` don't fight over the queue (TS exposes a
+        singleton ``PassThrough``; we match the singleton semantics).
+        """
+        if self._input_iter is None:
+            self._input_iter = self._iter_input()
+        return self._input_iter
+
+    async def _iter_input(self) -> AsyncIterator[str]:
+        while True:
+            item = await self._input_queue.get()
+            if item is _END_OF_STREAM:
+                return
+            # Type-safe alternative to `assert isinstance(item, str)`
+            # which is stripped under -O. The queue only ever holds
+            # strings or the sentinel — narrow explicitly.
+            if not isinstance(item, str):
+                raise TypeError(
+                    f"RemoteIO input queue produced non-str non-sentinel: "
+                    f"{type(item).__name__}"
+                )
+            yield item
+
+    async def _consume_initial_prompt(self, prompt: AsyncIterable[str]) -> None:
+        async for chunk in prompt:
+            # Strip a SINGLE trailing newline, append a fresh one —
+            # matches TS `.replace(/\n$/, '')` exactly. Python's
+            # `rstrip("\n")` would strip MULTIPLE trailing newlines,
+            # changing the semantics for chunks like "abc\n\n" (TS
+            # preserves the second \n as a paragraph break).
+            s = str(chunk)
+            line = (s[:-1] if s.endswith("\n") else s) + "\n"
+            self._input_queue.put_nowait(line)
+
+    # -- Output side ---------------------------------------------------------
+
+    async def write(self, message: dict[str, Any]) -> None:
+        """Send a message over the transport.
+
+        In bridge mode, control_request messages are always echoed to
+        stdout (so the bridge parent can detect permission requests).
+        Other message types are echoed only in debug.
+        """
+        # Note: `write` was verified-present on this transport at
+        # construction time (the NotImplementedError gate above).
+        await self._transport.write(message)  # type: ignore[attr-defined]
+        if self._is_bridge:
+            if message.get("type") == "control_request" or self._is_debug:
+                sys.stdout.write(ndjson_safe_dumps(message) + "\n")
+                sys.stdout.flush()
+
+    # -- Keep-alive ----------------------------------------------------------
+
+    async def _keep_alive_loop(self, interval_s: float) -> None:
+        try:
+            while not self._closed:
+                await asyncio.sleep(interval_s)
+                if self._closed:
+                    return
+                try:
+                    await self.write({"type": "keep_alive"})
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("RemoteIO keep_alive write failed: %s", exc)
+        except asyncio.CancelledError:
+            pass
+
+    # -- Internal events (overridden by future CCR v2 wiring) -----------------
+
+    async def flush_internal_events(self) -> None:
+        """No-op default. Override when CCR v2 internal events land."""
+        return None
+
+    @property
+    def internal_events_pending(self) -> int:
+        """Always 0 in the base class — override when CCR v2 lands."""
+        return 0
+
+    # -- Lifecycle -----------------------------------------------------------
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._keep_alive_task is not None:
+            self._keep_alive_task.cancel()
+            self._keep_alive_task = None
+        if self._initial_prompt_task is not None:
+            self._initial_prompt_task.cancel()
+            self._initial_prompt_task = None
+        if self._connect_task is not None:
+            # If close() fires before the connect coroutine has run, the
+            # transport.close() below would race with a never-started
+            # connect — cancel it explicitly.
+            self._connect_task.cancel()
+            self._connect_task = None
+        try:
+            self._transport.close()
+        except Exception:  # noqa: BLE001
+            pass
+        # Wake any iterator that's blocked on the queue.
+        self._input_queue.put_nowait(_END_OF_STREAM)

--- a/src/transports/transport_utils.py
+++ b/src/transports/transport_utils.py
@@ -1,0 +1,134 @@
+"""Transport factory for SDK remote-control sessions.
+
+Port of ``typescript/src/cli/transports/transportUtils.ts``.
+
+Public surface
+--------------
+
+* :class:`Transport` — typing.Protocol capturing the shape every transport
+  in :mod:`src.transports` satisfies. Duck-typed; existing
+  ``WebSocketTransport`` / ``HybridTransport`` / ``SSETransport`` are
+  structurally compatible.
+* :func:`get_transport_for_url` — selects a transport class based on URL
+  scheme + the ``CLAUDE_CODE_USE_CCR_V2`` and
+  ``CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2`` env vars. Mirrors the TS
+  factory exactly.
+* :func:`is_env_truthy` — TS ``isEnvTruthy`` parity (case-insensitive
+  1/true/yes/on); shared with :mod:`src.transports.remote_io`.
+
+See ``my-docs/get-parity-by-folder/cli-refactoring-plan.md`` §2.1 for
+the source-of-truth design notes (signature adapter, Protocol shape).
+
+Notes on the Transport Protocol
+-------------------------------
+
+``write`` is NOT in the Protocol. ``SSETransport`` has no ``write``
+method (its write side is handled separately by
+``CCRClient.write_event``). Including ``write`` in the Protocol would
+make ``isinstance(sse, Transport)`` return False under
+``@runtime_checkable`` and silently break the CCR v2 type check.
+``RemoteIO`` enforces the write-capability check explicitly at
+construction time.
+
+``set_on_close`` takes ``Callable[[int | None], None]`` (the close code),
+matching the real transports at ``websocket_transport.py:263`` /
+``sse_transport.py:109``.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from typing import Protocol, runtime_checkable
+
+import httpx
+
+from src.transports.hybrid_transport import HybridTransport
+from src.transports.sse_transport import SSETransport
+from src.transports.websocket_transport import WebSocketTransport
+
+
+@runtime_checkable
+class Transport(Protocol):
+    """Shape every src.transports transport satisfies (sans ``write``).
+
+    The four common methods. ``write(...)`` is intentionally omitted —
+    SSETransport doesn't expose it (the write side is CCRClient's job).
+    """
+
+    async def connect(self) -> None: ...
+    def close(self) -> None: ...
+    def set_on_data(self, callback: Callable[[str], None]) -> None: ...
+    def set_on_close(self, callback: Callable[[int | None], None]) -> None: ...
+
+
+def is_env_truthy(value: str | None) -> bool:
+    """TS ``isEnvTruthy`` parity — 1/true/yes/on (case-insensitive)."""
+    if value is None:
+        return False
+    return value.lower() in ("1", "true", "yes", "on")
+
+
+def get_transport_for_url(
+    url: str | httpx.URL,
+    *,
+    headers: dict[str, str] | None = None,
+    session_id: str | None = None,
+    refresh_headers: Callable[[], dict[str, str]] | None = None,
+) -> Transport:
+    """Pick an appropriate transport for ``url`` + current env vars.
+
+    Selection (mirrors TS ``getTransportForUrl``):
+
+      1. ``CLAUDE_CODE_USE_CCR_V2`` truthy → ``SSETransport`` on
+         ``<url>/worker/events/stream`` (scheme rewritten ws→http,
+         wss→https).
+      2. URL is ws/wss + ``CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2``
+         truthy → ``HybridTransport``.
+      3. URL is ws/wss → ``WebSocketTransport``.
+      4. Otherwise: raise ``ValueError("Unsupported protocol: …")``.
+
+    All three transport constructors take ``url: str``; callers may pass
+    either ``str`` or ``httpx.URL`` and the factory normalizes to ``str``
+    before constructing.
+    """
+    headers = dict(headers or {})
+    url_str = url if isinstance(url, str) else str(url)
+    parsed = httpx.URL(url_str)
+
+    if is_env_truthy(os.environ.get("CLAUDE_CODE_USE_CCR_V2")):
+        # Rewrite the scheme + append the /worker/events/stream path.
+        # Use plain string manipulation to mirror the TS literal approach
+        # and avoid httpx.URL.copy_with(path=) URL-encoding edge cases.
+        sse_url_str = url_str
+        if sse_url_str.startswith("wss://"):
+            sse_url_str = "https://" + sse_url_str[len("wss://"):]
+        elif sse_url_str.startswith("ws://"):
+            sse_url_str = "http://" + sse_url_str[len("ws://"):]
+        sse_url_str = sse_url_str.rstrip("/") + "/worker/events/stream"
+        # SSETransport's auth-refresh callback is named `get_auth_headers`
+        # (not `refresh_headers`). The factory adapts; renaming the
+        # parameter is deferred per cli-gap-analysis.md §4.7.
+        return SSETransport(
+            sse_url_str,
+            headers=headers,
+            session_id=session_id,
+            get_auth_headers=refresh_headers,
+        )
+
+    if parsed.scheme in ("ws", "wss"):
+        if is_env_truthy(os.environ.get("CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2")):
+            return HybridTransport(
+                url_str,
+                headers=headers,
+                session_id=session_id,
+                refresh_headers=refresh_headers,
+            )
+        return WebSocketTransport(
+            url_str,
+            headers=headers,
+            session_id=session_id,
+            refresh_headers=refresh_headers,
+        )
+
+    raise ValueError(f"Unsupported protocol: {parsed.scheme}")

--- a/src/transports/worker_state_uploader.py
+++ b/src/transports/worker_state_uploader.py
@@ -1,0 +1,159 @@
+"""Coalescing PUT /worker uploader.
+
+Port of ``typescript/src/cli/transports/WorkerStateUploader.ts``.
+
+Contract (mirrors TS)
+---------------------
+
+* 1 in-flight PUT + 1 pending patch slot at any time.
+* New ``enqueue`` calls coalesce into the pending slot — never grows
+  beyond 1 slot of backpressure.
+* Top-level keys: last value wins.
+* Inside ``external_metadata`` / ``internal_metadata``: RFC 7396 merge
+  one level deep (overlay keys overwrite base; nulls preserved for
+  server-side delete).
+* On send failure: exponential backoff (``base * 2^(failures-1)``
+  clamped to ``max``) plus uniform jitter ``[0, jitter)``. Retries
+  indefinitely until success or ``close()``.
+* ``close()`` drops pending; an in-flight retry exits at the next
+  ``self._closed`` check.
+
+Calling convention
+------------------
+
+``enqueue`` is sync but uses ``asyncio.get_running_loop()`` to schedule
+the drain task. **Calling from a non-async context (no running event
+loop) raises ``RuntimeError``.** TS calls the equivalent ``enqueue``
+fire-and-forget from anywhere; Python callers must be inside an asyncio
+loop. Matches the pattern of sibling ``ccr_client.py`` /
+``hybrid_transport.py`` which also assume a running loop.
+
+See ``my-docs/get-parity-by-folder/cli-refactoring-plan.md`` §2.2 for
+the source-of-truth design notes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class WorkerStateUploaderConfig:
+    """Construction-time knobs for :class:`WorkerStateUploader`.
+
+    Attributes:
+        send: Async callable invoked once per drained payload. Returns
+            ``True`` on success, ``False`` to trigger a retry. Raising
+            an exception is treated as ``False``.
+        base_delay_ms: Initial exponential-backoff delay (failure 1).
+        max_delay_ms: Cap for the exponential growth.
+        jitter_ms: Width of the uniform jitter added to each backoff.
+    """
+
+    send: Callable[[dict[str, Any]], Awaitable[bool]]
+    base_delay_ms: int
+    max_delay_ms: int
+    jitter_ms: int
+
+
+class WorkerStateUploader:
+    """Single-slot coalescing PUT uploader. See module docstring."""
+
+    def __init__(self, config: WorkerStateUploaderConfig) -> None:
+        self._config = config
+        self._inflight: asyncio.Task[None] | None = None
+        self._pending: dict[str, Any] | None = None
+        self._closed = False
+
+    def enqueue(self, patch: dict[str, Any]) -> None:
+        """Enqueue a patch. Must be called from an async context.
+
+        Coalesces with any existing pending patch into a single slot.
+        Schedules the drain via ``loop.create_task`` if one isn't
+        already running.
+        """
+        if self._closed:
+            return
+        self._pending = (
+            _coalesce_patches(self._pending, patch)
+            if self._pending is not None
+            else dict(patch)
+        )
+        # Fire-and-forget drain. Requires a running event loop — see
+        # module docstring "Calling convention".
+        if self._inflight is None or self._inflight.done():
+            loop = asyncio.get_running_loop()
+            self._inflight = loop.create_task(self._drain())
+
+    def close(self) -> None:
+        """Drop pending; in-flight task exits at next ``_closed`` check."""
+        self._closed = True
+        self._pending = None
+
+    async def _drain(self) -> None:
+        # Iterative — matches TS's `.then(() => if (pending) drain())`
+        # pattern, which schedules a new task rather than recursing.
+        while not self._closed and self._pending is not None:
+            payload = self._pending
+            self._pending = None
+            await self._send_with_retry(payload)
+
+    async def _send_with_retry(self, payload: dict[str, Any]) -> None:
+        current = payload
+        failures = 0
+        while not self._closed:
+            try:
+                ok = await self._config.send(current)
+            except Exception:  # noqa: BLE001 — match TS behavior (treat throw as failure)
+                ok = False
+            if ok:
+                return
+            failures += 1
+            await asyncio.sleep(self._retry_delay(failures) / 1000)
+            # Absorb any patches that arrived during the retry.
+            if self._pending is not None and not self._closed:
+                current = _coalesce_patches(current, self._pending)
+                self._pending = None
+
+    def _retry_delay(self, failures: int) -> float:
+        """Exponential backoff, clamped, then jittered.
+
+        Order matters: clamp the exponential *before* adding jitter, so
+        the cap doesn't apply to the jittered value. Matches TS
+        ``WorkerStateUploader.retryDelay``.
+        """
+        exponential = min(
+            self._config.base_delay_ms * (2 ** (failures - 1)),
+            self._config.max_delay_ms,
+        )
+        return exponential + random.random() * self._config.jitter_ms
+
+
+def _coalesce_patches(
+    base: dict[str, Any] | None,
+    overlay: dict[str, Any],
+) -> dict[str, Any]:
+    """RFC 7396 merge one level deep inside metadata containers.
+
+    Top-level keys: overlay replaces base (last value wins).
+    ``external_metadata`` and ``internal_metadata`` keys: shallow merge
+    (overlay keys are added/overwritten; ``None`` values preserved so
+    the server can delete the corresponding key).
+    """
+    if base is None:
+        return dict(overlay)
+    merged = dict(base)
+    for key, value in overlay.items():
+        if (
+            key in ("external_metadata", "internal_metadata")
+            and isinstance(merged.get(key), dict)
+            and isinstance(value, dict)
+        ):
+            merged[key] = {**merged[key], **value}
+        else:
+            merged[key] = value
+    return merged

--- a/tests/transports/test_remote_io.py
+++ b/tests/transports/test_remote_io.py
@@ -1,0 +1,469 @@
+"""Tests for ``src.transports.remote_io``.
+
+Strategy
+--------
+
+Replace ``get_transport_for_url`` (the bound name inside
+``src.transports.remote_io``) with a stub that records callback wiring
+and exposes ``fire_on_data`` / ``fire_on_close`` helpers. No real
+network I/O.
+
+CCR v2 (SSE) write path is **out of scope for this PR**; a dedicated
+test confirms the constructor raises ``NotImplementedError`` when the
+stub transport omits ``write``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from src.transports import remote_io as remote_io_module
+from src.transports.remote_io import RemoteIO
+
+
+class _StubTransport:
+    """Records callbacks; exposes test helpers. Has ``write`` so the
+    SSE-write gate in RemoteIO.__init__ doesn't trip."""
+
+    def __init__(self) -> None:
+        self.on_data: Callable[[str], None] | None = None
+        self.on_close: Callable[[int | None], None] | None = None
+        self.connected = False
+        self.closed = False
+        self.written: list[dict[str, Any]] = []
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def write(self, message: dict[str, Any]) -> None:
+        self.written.append(message)
+
+    def close(self) -> None:
+        self.closed = True
+
+    def set_on_data(self, cb):
+        self.on_data = cb
+
+    def set_on_close(self, cb):
+        self.on_close = cb
+
+    # Test helpers (not part of the Transport contract)
+    def fire_on_data(self, data: str) -> None:
+        assert self.on_data is not None
+        self.on_data(data)
+
+    def fire_on_close(self, code: int | None = None) -> None:
+        assert self.on_close is not None
+        self.on_close(code)
+
+
+class _SseLikeStub:
+    """Stub WITHOUT a ``write`` method — simulates SSETransport."""
+
+    def __init__(self) -> None:
+        self.on_data: Callable[[str], None] | None = None
+        self.on_close: Callable[[int | None], None] | None = None
+
+    async def connect(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def set_on_data(self, cb):
+        self.on_data = cb
+
+    def set_on_close(self, cb):
+        self.on_close = cb
+
+
+@pytest.fixture
+def stub_transport(monkeypatch) -> _StubTransport:
+    """Replace get_transport_for_url with a stub-returning factory.
+
+    IMPORTANT: monkeypatch the **bound name** in remote_io.py, NOT in
+    transport_utils.py — Python's `from X import Y` binds Y as a local
+    reference at import time.
+    """
+    stub = _StubTransport()
+    stub.factory_calls: list[tuple[tuple, dict]] = []  # type: ignore[attr-defined]
+
+    def factory(*args, **kwargs):
+        stub.factory_calls.append((args, kwargs))  # type: ignore[attr-defined]
+        return stub
+
+    monkeypatch.setattr(
+        "src.transports.remote_io.get_transport_for_url", factory
+    )
+    return stub
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Ensure tests don't accidentally pick up the user's bridge env."""
+    monkeypatch.delenv("CLAUDE_CODE_ENVIRONMENT_KIND", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_ENVIRONMENT_RUNNER_VERSION", raising=False)
+    monkeypatch.delenv("DEBUG", raising=False)
+    monkeypatch.delenv("DEBUG_SDK", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Constructor wiring
+
+
+async def test_constructor_uses_get_transport_for_url(stub_transport):
+    io = RemoteIO("ws://example.com/x")
+    try:
+        # Callbacks were wired.
+        assert stub_transport.on_data is not None
+        assert stub_transport.on_close is not None
+        # Connect was scheduled.
+        assert io._connect_task is not None
+        await asyncio.sleep(0)
+        assert stub_transport.connected is True
+        # Factory got the URL + a refresh_headers callable forwarded.
+        assert len(stub_transport.factory_calls) == 1  # type: ignore[attr-defined]
+        args, kwargs = stub_transport.factory_calls[0]  # type: ignore[attr-defined]
+        assert args == ("ws://example.com/x",)
+        assert callable(kwargs.get("refresh_headers"))
+        # session_id is currently None (TODO marker in remote_io.py).
+        assert kwargs.get("session_id") is None
+    finally:
+        io.close()
+
+
+async def test_constructor_raises_for_transport_without_write(monkeypatch):
+    """SSE-equivalent stub: no `write` method → NotImplementedError."""
+    sse_stub = _SseLikeStub()
+    monkeypatch.setattr(
+        "src.transports.remote_io.get_transport_for_url",
+        lambda *a, **kw: sse_stub,
+    )
+    with pytest.raises(NotImplementedError, match="CCR v2"):
+        RemoteIO("https://example.com/x/worker/events/stream")
+
+
+# ---------------------------------------------------------------------------
+# Input side
+
+
+async def test_on_data_pushes_to_input_queue(stub_transport):
+    io = RemoteIO("ws://example.com/x")
+    try:
+        stub_transport.fire_on_data("hello\n")
+        stub_transport.fire_on_data("world\n")
+        # Iterate the stream and collect a couple of items.
+        out: list[str] = []
+        stream = io.input_stream
+        # Use a single-step iterator via anext + close.
+        iterator = stream.__aiter__()
+        out.append(await iterator.__anext__())
+        out.append(await iterator.__anext__())
+        assert out == ["hello\n", "world\n"]
+    finally:
+        io.close()
+
+
+async def test_on_close_ends_input_stream(stub_transport):
+    io = RemoteIO("ws://example.com/x")
+    try:
+        stub_transport.fire_on_data("a\n")
+        stub_transport.fire_on_close(code=1000)
+        out: list[str] = []
+        async for item in io.input_stream:
+            out.append(item)
+        assert out == ["a\n"]
+    finally:
+        io.close()
+
+
+async def test_initial_prompt_chunks_landed_in_input_queue(stub_transport):
+    async def chunks():
+        yield "first"
+        yield "second\n"
+
+    io = RemoteIO("ws://example.com/x", initial_prompt=chunks())
+    try:
+        # Let the initial_prompt task run.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert io._initial_prompt_task is not None
+        await io._initial_prompt_task
+        # Sentinel will end iteration after close.
+        stub_transport.fire_on_close(code=None)
+        out: list[str] = []
+        async for item in io.input_stream:
+            out.append(item)
+        assert out == ["first\n", "second\n"]
+    finally:
+        io.close()
+
+
+async def test_initial_prompt_preserves_internal_newlines(stub_transport):
+    """Verify the TS-parity `.replace(/\\n$/, '') + '\\n'` semantics:
+    only the SINGLE trailing newline is stripped, so `"abc\\n\\n"`
+    becomes `"abc\\n\\n"` (paragraph break preserved)."""
+
+    async def chunks():
+        yield "abc\n\n"
+        yield "no-trailing"
+
+    io = RemoteIO("ws://example.com/x", initial_prompt=chunks())
+    try:
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert io._initial_prompt_task is not None
+        await io._initial_prompt_task
+        stub_transport.fire_on_close(code=None)
+        out: list[str] = []
+        async for item in io.input_stream:
+            out.append(item)
+        # First chunk: one newline stripped, one re-added → "abc\n\n"
+        # Second chunk: no newline to strip, one added → "no-trailing\n"
+        assert out == ["abc\n\n", "no-trailing\n"]
+    finally:
+        io.close()
+
+
+async def test_input_stream_is_cached(stub_transport):
+    """Two property accesses return the same iterator object — TS
+    exposes a singleton PassThrough; we match that semantics."""
+    io = RemoteIO("ws://example.com/x")
+    try:
+        s1 = io.input_stream
+        s2 = io.input_stream
+        assert s1 is s2
+    finally:
+        io.close()
+
+
+async def test_iter_input_rejects_non_str_non_sentinel(stub_transport):
+    io = RemoteIO("ws://example.com/x")
+    try:
+        # Poison the queue directly.
+        io._input_queue.put_nowait(42)  # type: ignore[arg-type]
+        iterator = io.input_stream.__aiter__()
+        with pytest.raises(TypeError, match="non-str non-sentinel"):
+            await iterator.__anext__()
+    finally:
+        io.close()
+
+
+# ---------------------------------------------------------------------------
+# Output side
+
+
+async def test_write_calls_transport_write(stub_transport):
+    io = RemoteIO("ws://example.com/x")
+    try:
+        await io.write({"type": "user", "message": "hi"})
+        assert stub_transport.written == [{"type": "user", "message": "hi"}]
+    finally:
+        io.close()
+
+
+async def test_bridge_mode_echoes_control_request_to_stdout(
+    stub_transport, monkeypatch, capsys
+):
+    monkeypatch.setenv("CLAUDE_CODE_ENVIRONMENT_KIND", "bridge")
+    io = RemoteIO("ws://example.com/x")
+    try:
+        await io.write({"type": "control_request", "request_id": "r1"})
+        captured = capsys.readouterr()
+        line = captured.out.strip()
+        # Parses as JSON and matches the message.
+        assert json.loads(line) == {"type": "control_request", "request_id": "r1"}
+    finally:
+        io.close()
+
+
+async def test_non_bridge_mode_does_not_echo(stub_transport, capsys):
+    io = RemoteIO("ws://example.com/x")
+    try:
+        await io.write({"type": "control_request", "request_id": "r1"})
+        captured = capsys.readouterr()
+        assert captured.out == ""
+    finally:
+        io.close()
+
+
+async def test_bridge_mode_non_control_request_not_echoed_without_debug(
+    stub_transport, monkeypatch, capsys
+):
+    monkeypatch.setenv("CLAUDE_CODE_ENVIRONMENT_KIND", "bridge")
+    io = RemoteIO("ws://example.com/x")
+    try:
+        await io.write({"type": "user", "message": "hi"})
+        captured = capsys.readouterr()
+        assert captured.out == ""
+    finally:
+        io.close()
+
+
+async def test_bridge_mode_with_debug_echoes_any_message(
+    stub_transport, monkeypatch, capsys
+):
+    monkeypatch.setenv("CLAUDE_CODE_ENVIRONMENT_KIND", "bridge")
+    monkeypatch.setenv("DEBUG", "1")
+    io = RemoteIO("ws://example.com/x")
+    try:
+        await io.write({"type": "user", "message": "hi"})
+        captured = capsys.readouterr()
+        assert json.loads(captured.out.strip()) == {
+            "type": "user",
+            "message": "hi",
+        }
+    finally:
+        io.close()
+
+
+# ---------------------------------------------------------------------------
+# Keep-alive
+
+
+async def test_bridge_keep_alive_writes_periodically(
+    stub_transport, monkeypatch
+):
+    monkeypatch.setenv("CLAUDE_CODE_ENVIRONMENT_KIND", "bridge")
+    # Force a very small interval so the test budget stays tight.
+
+    class _StubConfig:
+        session_keepalive_interval_v2_ms = 10
+
+    monkeypatch.setattr(
+        "src.transports.remote_io.get_poll_interval_config",
+        lambda: _StubConfig(),
+    )
+    io = RemoteIO("ws://example.com/x")
+    try:
+        # Wait long enough for at least 2 ticks.
+        await asyncio.sleep(0.05)
+        keep_alives = [
+            m for m in stub_transport.written if m.get("type") == "keep_alive"
+        ]
+        assert len(keep_alives) >= 2
+    finally:
+        io.close()
+
+
+async def test_keep_alive_disabled_when_interval_zero(
+    stub_transport, monkeypatch
+):
+    monkeypatch.setenv("CLAUDE_CODE_ENVIRONMENT_KIND", "bridge")
+
+    class _StubConfig:
+        session_keepalive_interval_v2_ms = 0
+
+    monkeypatch.setattr(
+        "src.transports.remote_io.get_poll_interval_config",
+        lambda: _StubConfig(),
+    )
+    io = RemoteIO("ws://example.com/x")
+    try:
+        assert io._keep_alive_task is None
+        await asyncio.sleep(0.02)
+        assert all(
+            m.get("type") != "keep_alive" for m in stub_transport.written
+        )
+    finally:
+        io.close()
+
+
+async def test_keep_alive_disabled_when_not_bridge(
+    stub_transport, monkeypatch
+):
+    # Even with a positive interval, non-bridge mode skips keep-alive.
+    class _StubConfig:
+        session_keepalive_interval_v2_ms = 10
+
+    monkeypatch.setattr(
+        "src.transports.remote_io.get_poll_interval_config",
+        lambda: _StubConfig(),
+    )
+    io = RemoteIO("ws://example.com/x")
+    try:
+        assert io._keep_alive_task is None
+    finally:
+        io.close()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+
+
+async def test_close_cancels_keep_alive_initial_prompt_and_connect_tasks(
+    stub_transport, monkeypatch
+):
+    monkeypatch.setenv("CLAUDE_CODE_ENVIRONMENT_KIND", "bridge")
+
+    class _StubConfig:
+        session_keepalive_interval_v2_ms = 1000  # long enough that close races
+
+    monkeypatch.setattr(
+        "src.transports.remote_io.get_poll_interval_config",
+        lambda: _StubConfig(),
+    )
+
+    # Slow-down connect so close() catches it pre-completion.
+    connect_gate = asyncio.Event()
+
+    async def slow_connect(*args, **kwargs):
+        await connect_gate.wait()
+        stub_transport.connected = True
+
+    stub_transport.connect = slow_connect  # type: ignore[method-assign]
+
+    async def chunks():
+        # Never yields — keeps the initial_prompt task alive.
+        while True:
+            await asyncio.sleep(10)
+            yield "never"
+
+    io = RemoteIO("ws://example.com/x", initial_prompt=chunks())
+    keep_alive_task = io._keep_alive_task
+    initial_prompt_task = io._initial_prompt_task
+    connect_task = io._connect_task
+    assert keep_alive_task is not None
+    assert initial_prompt_task is not None
+    assert connect_task is not None
+
+    io.close()
+    # Let cancellations propagate.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert keep_alive_task.cancelled() or keep_alive_task.done()
+    assert initial_prompt_task.cancelled() or initial_prompt_task.done()
+    assert connect_task.cancelled() or connect_task.done()
+    assert stub_transport.closed is True
+    # Sanity: io's task refs cleared.
+    assert io._keep_alive_task is None
+    assert io._initial_prompt_task is None
+    assert io._connect_task is None
+
+
+async def test_close_idempotent(stub_transport):
+    io = RemoteIO("ws://example.com/x")
+    io.close()
+    io.close()  # second close must not raise
+
+
+async def test_flush_internal_events_default_returns_none(stub_transport):
+    io = RemoteIO("ws://example.com/x")
+    try:
+        result = await io.flush_internal_events()
+        assert result is None
+    finally:
+        io.close()
+
+
+async def test_internal_events_pending_default_zero(stub_transport):
+    io = RemoteIO("ws://example.com/x")
+    try:
+        assert io.internal_events_pending == 0
+    finally:
+        io.close()

--- a/tests/transports/test_transport_utils.py
+++ b/tests/transports/test_transport_utils.py
@@ -1,0 +1,209 @@
+"""Tests for ``src.transports.transport_utils``.
+
+Strategy
+--------
+
+Construct real ``WebSocketTransport`` / ``HybridTransport`` /
+``SSETransport`` instances and assert the factory picks the right one
+for each env-var configuration. No real network I/O: the real classes
+don't connect at construction, only on ``await connect()``.
+
+The Protocol-runtime-check test constructs the real classes (not
+stubs) so future signature drift surfaces here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.transports.hybrid_transport import HybridTransport
+from src.transports.sse_transport import SSETransport
+from src.transports.transport_utils import (
+    Transport,
+    get_transport_for_url,
+    is_env_truthy,
+)
+from src.transports.websocket_transport import WebSocketTransport
+
+
+# ---------------------------------------------------------------------------
+# is_env_truthy
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, False),
+        ("", False),
+        ("0", False),
+        ("false", False),
+        ("FALSE", False),
+        ("no", False),
+        ("off", False),
+        ("1", True),
+        ("true", True),
+        ("TRUE", True),
+        ("yes", True),
+        ("on", True),
+        ("On", True),
+    ],
+)
+def test_is_env_truthy(value, expected):
+    assert is_env_truthy(value) is expected
+
+
+# ---------------------------------------------------------------------------
+# Selection branches
+
+
+def test_ws_url_returns_websocket_transport(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_USE_CCR_V2", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2", raising=False)
+    t = get_transport_for_url("ws://example.com/session")
+    assert isinstance(t, WebSocketTransport)
+
+
+def test_wss_url_returns_websocket_transport(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_USE_CCR_V2", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2", raising=False)
+    t = get_transport_for_url("wss://example.com/session")
+    assert isinstance(t, WebSocketTransport)
+    # Not a HybridTransport (HybridTransport subclasses WebSocketTransport,
+    # so we also assert it's not the subclass).
+    assert not isinstance(t, HybridTransport)
+
+
+def test_post_for_ingress_env_returns_hybrid_transport(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_USE_CCR_V2", raising=False)
+    monkeypatch.setenv("CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2", "1")
+    t = get_transport_for_url("wss://example.com/session")
+    assert isinstance(t, HybridTransport)
+
+
+def test_ccr_v2_env_returns_sse_transport(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_USE_CCR_V2", "1")
+    monkeypatch.delenv("CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2", raising=False)
+    t = get_transport_for_url("wss://example.com/x")
+    assert isinstance(t, SSETransport)
+    # SSE URL was rewritten to https and got the events-stream path.
+    assert t._url == "https://example.com/x/worker/events/stream"
+
+
+def test_ccr_v2_rewrites_ws_scheme_to_http(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_USE_CCR_V2", "1")
+    t = get_transport_for_url("ws://example.com/x")
+    assert isinstance(t, SSETransport)
+    assert t._url == "http://example.com/x/worker/events/stream"
+
+
+def test_ccr_v2_strips_trailing_slash_before_appending_path(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_USE_CCR_V2", "1")
+    t = get_transport_for_url("wss://example.com/sessions/abc/")
+    assert isinstance(t, SSETransport)
+    # Trailing slash stripped, path appended exactly once.
+    assert t._url == "https://example.com/sessions/abc/worker/events/stream"
+
+
+def test_unsupported_scheme_raises_value_error(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_USE_CCR_V2", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2", raising=False)
+    with pytest.raises(ValueError, match="Unsupported protocol"):
+        get_transport_for_url("http://example.com/session")
+
+
+def test_ccr_v2_truthy_with_http_url_still_returns_sse(monkeypatch):
+    # The CCR v2 branch runs *before* the ws/wss check, so it accepts any
+    # URL (the scheme just isn't rewritten if it's already http/https).
+    monkeypatch.setenv("CLAUDE_CODE_USE_CCR_V2", "1")
+    t = get_transport_for_url("https://example.com/x")
+    assert isinstance(t, SSETransport)
+    assert t._url == "https://example.com/x/worker/events/stream"
+
+
+# ---------------------------------------------------------------------------
+# Callback wiring
+
+
+def test_refresh_headers_passed_through_for_ws(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_USE_CCR_V2", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2", raising=False)
+
+    def refresh():
+        return {"Authorization": "Bearer fresh"}
+
+    t = get_transport_for_url("ws://example.com/x", refresh_headers=refresh)
+    assert isinstance(t, WebSocketTransport)
+    assert t._refresh_headers is refresh
+
+
+def test_refresh_headers_passed_through_for_hybrid(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_USE_CCR_V2", raising=False)
+    monkeypatch.setenv("CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2", "1")
+
+    def refresh():
+        return {"Authorization": "Bearer fresh"}
+
+    t = get_transport_for_url("wss://example.com/x", refresh_headers=refresh)
+    assert isinstance(t, HybridTransport)
+    assert t._refresh_headers is refresh
+
+
+def test_refresh_headers_translated_to_get_auth_headers_for_sse(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_USE_CCR_V2", "1")
+
+    def refresh():
+        return {"Authorization": "Bearer fresh"}
+
+    t = get_transport_for_url("wss://example.com/x", refresh_headers=refresh)
+    assert isinstance(t, SSETransport)
+    # SSETransport stores the callable as _get_auth_headers (the
+    # factory translates refresh_headers → get_auth_headers).
+    assert t._get_auth_headers is refresh
+
+
+def test_headers_and_session_id_passed_through(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_USE_CCR_V2", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2", raising=False)
+    t = get_transport_for_url(
+        "wss://example.com/x",
+        headers={"X-Custom": "yes"},
+        session_id="abc-123",
+    )
+    assert isinstance(t, WebSocketTransport)
+    assert t._headers.get("X-Custom") == "yes"
+    assert t._session_id == "abc-123"
+
+
+def test_httpx_url_input_accepted(monkeypatch):
+    import httpx
+
+    monkeypatch.delenv("CLAUDE_CODE_USE_CCR_V2", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2", raising=False)
+    t = get_transport_for_url(httpx.URL("ws://example.com/x"))
+    assert isinstance(t, WebSocketTransport)
+
+
+# ---------------------------------------------------------------------------
+# Protocol shape
+
+
+def test_transport_protocol_runtime_check_for_websocket():
+    t = WebSocketTransport("ws://example.com/x")
+    assert isinstance(t, Transport)
+
+
+def test_transport_protocol_runtime_check_for_hybrid():
+    t = HybridTransport("ws://example.com/x")
+    assert isinstance(t, Transport)
+
+
+def test_transport_protocol_runtime_check_for_sse():
+    t = SSETransport("https://example.com/x/stream")
+    assert isinstance(t, Transport)
+
+
+def test_transport_protocol_rejects_object_missing_methods():
+    class NotATransport:
+        pass
+
+    assert not isinstance(NotATransport(), Transport)

--- a/tests/transports/test_worker_state_uploader.py
+++ b/tests/transports/test_worker_state_uploader.py
@@ -1,0 +1,315 @@
+"""Tests for ``src.transports.worker_state_uploader``.
+
+Strategy
+--------
+
+Inject an async ``send`` callable that records payloads and can be
+gated via an ``asyncio.Event`` to test the in-flight + pending
+coalescing invariant. Backoff is exercised with small base/max delays
+so the test budget stays tight (matches the convention in
+``test_serial_batch_event_uploader.py``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from typing import Any
+
+import pytest
+
+from src.transports.worker_state_uploader import (
+    WorkerStateUploader,
+    WorkerStateUploaderConfig,
+    _coalesce_patches,
+)
+
+
+def _config(send, *, base=5, max_=50, jitter=0):
+    return WorkerStateUploaderConfig(
+        send=send,
+        base_delay_ms=base,
+        max_delay_ms=max_,
+        jitter_ms=jitter,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _coalesce_patches (free function)
+
+
+def test_coalesce_top_level_keys_overwrite():
+    base = {"a": 1, "b": 2}
+    out = _coalesce_patches(base, {"b": 99, "c": 3})
+    assert out == {"a": 1, "b": 99, "c": 3}
+
+
+def test_coalesce_external_metadata_rfc7396_merge():
+    base = {"external_metadata": {"x": 1, "y": 2}}
+    out = _coalesce_patches(base, {"external_metadata": {"y": 99, "z": 3}})
+    assert out == {"external_metadata": {"x": 1, "y": 99, "z": 3}}
+
+
+def test_coalesce_internal_metadata_rfc7396_merge():
+    base = {"internal_metadata": {"x": 1}}
+    out = _coalesce_patches(base, {"internal_metadata": {"y": 2}})
+    assert out == {"internal_metadata": {"x": 1, "y": 2}}
+
+
+def test_coalesce_metadata_null_preserved_for_server_delete():
+    base = {"external_metadata": {"x": 1, "y": 2}}
+    out = _coalesce_patches(base, {"external_metadata": {"y": None}})
+    # None preserved — server deletes the key.
+    assert out == {"external_metadata": {"x": 1, "y": None}}
+
+
+def test_coalesce_non_metadata_dict_does_not_merge():
+    # Only external_metadata/internal_metadata get RFC 7396; other dicts
+    # are overwritten wholesale.
+    base = {"top": {"x": 1}}
+    out = _coalesce_patches(base, {"top": {"y": 2}})
+    assert out == {"top": {"y": 2}}
+
+
+def test_coalesce_none_base_returns_overlay_copy():
+    overlay = {"a": 1}
+    out = _coalesce_patches(None, overlay)
+    assert out == overlay
+    # Defensive: not the same object.
+    assert out is not overlay
+
+
+def test_coalesce_does_not_mutate_inputs():
+    base = {"external_metadata": {"x": 1}}
+    overlay = {"external_metadata": {"y": 2}}
+    base_snap = {"external_metadata": dict(base["external_metadata"])}
+    overlay_snap = {"external_metadata": dict(overlay["external_metadata"])}
+    _coalesce_patches(base, overlay)
+    assert base == base_snap
+    assert overlay == overlay_snap
+
+
+# ---------------------------------------------------------------------------
+# Single enqueue / drain
+
+
+async def test_single_enqueue_calls_send_once():
+    sent: list[dict[str, Any]] = []
+
+    async def send(payload):
+        sent.append(payload)
+        return True
+
+    u = WorkerStateUploader(_config(send))
+    u.enqueue({"worker_status": "ready"})
+    # Wait for the drain to finish.
+    assert u._inflight is not None
+    await u._inflight
+    assert sent == [{"worker_status": "ready"}]
+
+
+async def test_enqueue_while_inflight_only_one_pending_slot():
+    """Verify the 1-in-flight + 1-pending invariant.
+
+    Per TS contract: while a payload is in-flight, new enqueues go to a
+    fresh `pending` slot — they are NOT merged into the in-flight
+    payload (the in-flight payload is already committed to a network
+    call). The pending slot itself coalesces if enqueued multiple times.
+
+    After the in-flight completes, the pending slot is what drives the
+    next send.
+    """
+    sent: list[dict[str, Any]] = []
+    gate = asyncio.Event()
+
+    async def send(payload):
+        sent.append(payload)
+        # First call blocks until released; subsequent calls return
+        # immediately.
+        if len(sent) == 1:
+            await gate.wait()
+        return True
+
+    u = WorkerStateUploader(_config(send))
+    u.enqueue({"external_metadata": {"x": 1}})
+    # Let the first send start and block on the gate.
+    await asyncio.sleep(0)
+    # Two new patches arrive while #1 is in-flight. Both coalesce into
+    # pending (not into the in-flight payload).
+    u.enqueue({"external_metadata": {"y": 2}})
+    u.enqueue({"external_metadata": {"z": 3}})
+    # Release the gate; the iterative drain picks up the coalesced pending.
+    gate.set()
+    assert u._inflight is not None
+    await u._inflight
+    # Exactly two sends — first the original, second the coalesced pending.
+    # The pending slot merged {y:2} and {z:3} (RFC 7396) but NOT {x:1}.
+    assert sent == [
+        {"external_metadata": {"x": 1}},
+        {"external_metadata": {"y": 2, "z": 3}},
+    ]
+
+
+async def test_close_drops_pending_during_inflight():
+    """In-flight task started; before drain absorbs the next iteration,
+    close() drops pending and the iteration exits."""
+    sent: list[dict[str, Any]] = []
+    gate = asyncio.Event()
+
+    async def send(payload):
+        sent.append(payload)
+        if len(sent) == 1:
+            await gate.wait()
+        return True
+
+    u = WorkerStateUploader(_config(send))
+    u.enqueue({"worker_status": "ready"})
+    await asyncio.sleep(0)
+    # Stage a pending patch, then close before releasing the gate.
+    u.enqueue({"worker_status": "busy"})
+    u.close()
+    gate.set()
+    assert u._inflight is not None
+    await u._inflight
+    # Only the first send actually happened — close dropped pending
+    # before the iterative drain loop could pick it up.
+    assert sent == [{"worker_status": "ready"}]
+
+
+async def test_close_before_first_enqueue_blocks_subsequent_enqueue():
+    sent: list[dict[str, Any]] = []
+
+    async def send(payload):
+        sent.append(payload)
+        return True
+
+    u = WorkerStateUploader(_config(send))
+    u.close()
+    u.enqueue({"x": 1})
+    # Nothing was scheduled.
+    assert u._inflight is None
+    assert sent == []
+
+
+# ---------------------------------------------------------------------------
+# Send failure / retry
+
+
+async def test_send_failure_triggers_retry(monkeypatch):
+    monkeypatch.setattr(random, "random", lambda: 0.0)
+    sent: list[dict[str, Any]] = []
+
+    async def send(payload):
+        sent.append(payload)
+        return len(sent) >= 2  # first call fails, second succeeds
+
+    u = WorkerStateUploader(_config(send, base=1, max_=10, jitter=0))
+    u.enqueue({"a": 1})
+    assert u._inflight is not None
+    await u._inflight
+    assert sent == [{"a": 1}, {"a": 1}]
+
+
+async def test_send_exception_treated_as_failure(monkeypatch):
+    monkeypatch.setattr(random, "random", lambda: 0.0)
+    attempts = 0
+
+    async def send(payload):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("boom")
+        return True
+
+    u = WorkerStateUploader(_config(send, base=1, max_=10, jitter=0))
+    u.enqueue({"a": 1})
+    assert u._inflight is not None
+    await u._inflight
+    assert attempts == 2
+
+
+async def test_retry_absorbs_pending_patches(monkeypatch):
+    """A new enqueue *during the backoff* gets coalesced into the
+    next retry attempt.
+
+    Per TS contract: ``Absorbs any pending patches before each retry``
+    — distinct from the success path, where pending stays pending
+    until the next drain iteration. This test stages the new patch
+    while the in-flight send is *blocked before returning False*, so
+    the absorb step sees the pending patch when the backoff sleep
+    finishes.
+    """
+    monkeypatch.setattr(random, "random", lambda: 0.0)
+    sent: list[dict[str, Any]] = []
+    fail_gate = asyncio.Event()  # holds send #1 open before it returns False
+
+    async def send(payload):
+        sent.append(payload)
+        if len(sent) == 1:
+            # Block here BEFORE returning False so the test can stage a
+            # pending patch that the absorb step (between sleep and
+            # next send) will see.
+            await fail_gate.wait()
+            return False
+        return True  # retry succeeds
+
+    u = WorkerStateUploader(_config(send, base=1, max_=10, jitter=0))
+    u.enqueue({"external_metadata": {"x": 1}})
+    # Let the drain start and call send (which blocks on fail_gate).
+    await asyncio.sleep(0)
+    # Stage the pending patch BEFORE send returns False.
+    u.enqueue({"external_metadata": {"y": 2}})
+    # Now release send #1 → returns False → backoff (1ms) → absorb pending.
+    fail_gate.set()
+    assert u._inflight is not None
+    await u._inflight
+    # Send #2 saw the coalesced payload: original {x:1} + pending {y:2}.
+    assert sent == [
+        {"external_metadata": {"x": 1}},
+        {"external_metadata": {"x": 1, "y": 2}},
+    ]
+
+
+async def test_close_stops_retry_loop(monkeypatch):
+    monkeypatch.setattr(random, "random", lambda: 0.0)
+    sent: list[dict[str, Any]] = []
+
+    async def send(payload):
+        sent.append(payload)
+        return False  # always fails — would retry forever without close
+
+    u = WorkerStateUploader(_config(send, base=1, max_=5, jitter=0))
+    u.enqueue({"a": 1})
+    # Let two attempts happen.
+    await asyncio.sleep(0.02)
+    u.close()
+    assert u._inflight is not None
+    await u._inflight
+    # Some number of attempts happened, but the loop exited.
+    assert len(sent) >= 1
+
+
+# ---------------------------------------------------------------------------
+# _retry_delay (math correctness)
+
+
+def test_retry_delay_exponential_growth_then_clamp(monkeypatch):
+    monkeypatch.setattr(random, "random", lambda: 0.0)
+    u = WorkerStateUploader(_config(send=None, base=10, max_=100, jitter=0))  # type: ignore[arg-type]
+    # base * 2^(n-1)
+    assert u._retry_delay(1) == 10
+    assert u._retry_delay(2) == 20
+    assert u._retry_delay(3) == 40
+    assert u._retry_delay(4) == 80
+    # Clamp kicks in.
+    assert u._retry_delay(5) == 100
+    assert u._retry_delay(10) == 100
+
+
+def test_retry_delay_clamp_then_jitter(monkeypatch):
+    """Jitter is added AFTER clamp — so max delay + full jitter can
+    exceed max_delay_ms. Mirrors TS behavior."""
+    monkeypatch.setattr(random, "random", lambda: 1.0)  # max jitter
+    u = WorkerStateUploader(_config(send=None, base=10, max_=100, jitter=50))  # type: ignore[arg-type]
+    # Clamped exponential at attempt 10 is 100; jitter 50 added on top.
+    assert u._retry_delay(10) == 150


### PR DESCRIPTION
## Summary

Closes the infrastructure parity gap from `typescript/src/cli/` that had no Python counterpart. Ports the three structural files flagged in the gap analysis:

- **`src/transports/transport_utils.py`** — `get_transport_for_url()` factory selecting SSE / Hybrid / WebSocket by URL scheme + `CLAUDE_CODE_USE_CCR_V2` / `CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2` env vars; `Transport` Protocol; `SSETransport` `get_auth_headers` adapter.
- **`src/transports/worker_state_uploader.py`** — coalescing PUT /worker uploader: 1-inflight + 1-pending invariant, RFC 7396 metadata merge (nulls preserved), clamp-then-jitter exponential backoff, indefinite retry until `close()`.
- **`src/transports/remote_io.py`** — `RemoteIO` async StructuredIO+Transport bridge: bridge-mode keep-alive (driven by `session_keepalive_interval_v2_ms`), `control_request` stdout echo. CCR v2 write path is intentionally gated as `NotImplementedError` (deferred to the `ccr_client.py` deep-port audit).

Also refreshes the README "Latest News" section with updated counts (34k+ lines, 11k+ tests) and the CLI feature note.

Design notes and scope decisions are pinned in `my-docs/get-parity-by-folder/cli-gap-analysis.md` and `cli-refactoring-plan.md` (both Critic-reviewed). Out-of-scope items (control-protocol layer, `print.ts` orchestrator, handlers, `update.ts`) are enumerated there.

## Test plan

- [x] `pytest tests/transports/` — 142 pass (65 new: 30 transport_utils + 17 worker_state_uploader + 18 remote_io)
- [x] `pytest tests/transports/ tests/test_cli_core.py tests/bridge/` — 840 pass, no regressions
- [x] `python -c "from src.transports import *"` — no import errors
- [x] Transport Protocol runtime-check tests construct the real WS/Hybrid/SSE classes to catch signature drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)