### PR TITLE
commands: safe-command filter, getCommands aggregator, auto-fix/review

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -11,8 +11,10 @@ from src.utils.startup_profiler import profile_checkpoint
 
 profile_checkpoint("command_system_imported")
 
+from .aggregator import clear_commands_cache, get_commands
 from .argument_substitution import parse_argument_names, substitute_arguments
 from .builtins import (
+    AUTO_FIX_COMMAND,
     CLEAR_COMMAND,
     COMPACT_COMMAND,
     CONTEXT_COMMAND,
@@ -20,6 +22,7 @@ from .builtins import (
     EXIT_COMMAND,
     HELP_COMMAND,
     INIT_COMMAND,
+    REVIEW_COMMAND,
     SKILLS_COMMAND,
     execute_command_async,
     execute_command_sync,
@@ -40,6 +43,12 @@ from .registry import (
     has_command,
     list_commands,
     register_command,
+)
+from .safe_commands import (
+    BRIDGE_SAFE_COMMANDS,
+    REMOTE_SAFE_COMMANDS,
+    filter_commands_for_remote_mode,
+    is_bridge_safe_command,
 )
 from .skills_integration import (
     get_skill_command,
@@ -98,8 +107,18 @@ __all__ = [
     "CONTEXT_COMMAND",
     "COMPACT_COMMAND",
     "INIT_COMMAND",
+    "AUTO_FIX_COMMAND",
+    "REVIEW_COMMAND",
     "get_builtin_commands",
     "register_builtin_commands",
+    # Aggregator
+    "get_commands",
+    "clear_commands_cache",
+    # Safe commands
+    "REMOTE_SAFE_COMMANDS",
+    "BRIDGE_SAFE_COMMANDS",
+    "is_bridge_safe_command",
+    "filter_commands_for_remote_mode",
     # Skills integration
     "skill_to_prompt_command",
     "register_skill_as_command",

--- a/src/command_system/aggregator.py
+++ b/src/command_system/aggregator.py
@@ -1,0 +1,97 @@
+"""
+Unified command aggregator.
+
+Python port of getCommands(cwd) / loadAllCommands(cwd) from
+typescript/src/commands.ts:473-541 — the single entry point every consumer should call
+to get the live, availability-filtered command set.
+
+Phase 1 merges builtin commands + filesystem skills (NOT plugins/workflows/dynamic
+skills — those subsystems are unported; see commands-gap-analysis.md §4.3). It reads
+builtins and skills directly (not the global registry), matching TS.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+from pathlib import Path
+
+from .builtins import get_builtin_commands
+from .skills_integration import skill_to_prompt_command
+from .types import Command, is_command_enabled, meets_availability_requirement
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=32)
+def _load_skill_commands_cached(cwd: str) -> tuple[Command, ...]:
+    """
+    Load filesystem skills for ``cwd`` and convert them to PromptCommands.
+
+    Cached by cwd because skill discovery does disk I/O + frontmatter parsing.
+    Builtins are intentionally NOT cached here (they're cheap and their is_enabled
+    gates must stay fresh). Failures degrade to an empty tuple — skills are
+    non-critical and must never break command listing (mirrors TS).
+    """
+    try:
+        from ..skills.loader import get_all_skills
+        skills = get_all_skills(project_root=cwd)
+        return tuple(skill_to_prompt_command(s) for s in skills)
+    except Exception as exc:  # noqa: BLE001 — skills are non-critical
+        logger.debug("skill loading failed for %s: %s", cwd, exc)
+        return ()
+
+
+def get_commands(
+    cwd: str | Path | None = None,
+    *,
+    is_claude_ai_subscriber: bool = False,
+    is_console_user: bool = False,
+) -> list[Command]:
+    """
+    Return commands available to the current user for ``cwd``.
+
+    Merges builtins (fresh) + filesystem skills (cached by cwd), then filters by
+    availability + is_enabled FRESH on every call so auth/flag changes take effect
+    immediately. De-duplicated by name (builtins own their names — see below).
+
+    Port of commands.ts:500 getCommands(cwd).
+    """
+    cwd_key = str(cwd) if cwd is not None else str(Path.cwd())
+
+    # Builtins fresh (re-evaluates conditional appends); skills cached by cwd.
+    all_commands: list[Command] = [
+        *get_builtin_commands(),
+        *_load_skill_commands_cached(cwd_key),
+    ]
+
+    seen: set[str] = set()
+    result: list[Command] = []
+    for cmd in all_commands:
+        if cmd.name in seen:
+            continue  # name already claimed by an earlier command
+        # Reserve the name BEFORE filtering: a builtin owns its name even when it is
+        # disabled/unavailable, so a same-named skill (enumerated later) can never
+        # shadow it. Builtins are enumerated first -> builtins win. This diverges
+        # from TS's filter-then-dedupe order on purpose (prevents a user skill named
+        # `help`/`clear` from shadowing a core builtin).
+        #
+        # This assumes filter-gated builtins (is_enabled / availability) are never
+        # meant to be *replaced* by a same-named skill. A command that should yield
+        # to a skill must instead be omitted from the source list entirely (an
+        # "append-gate", like buddy's is_buddy_command_enabled()), so it never
+        # reaches this loop and never reserves its name.
+        seen.add(cmd.name)
+        if not meets_availability_requirement(
+            cmd, is_claude_ai_subscriber, is_console_user
+        ):
+            continue
+        if not is_command_enabled(cmd):
+            continue
+        result.append(cmd)
+    return result
+
+
+def clear_commands_cache() -> None:
+    """Clear the memoized skill-command cache. Port of clearCommandsCache()."""
+    _load_skill_commands_cached.cache_clear()

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -1093,6 +1093,64 @@ INIT_COMMAND = PromptCommand(
     source="builtin",
 )
 
+# Port of typescript/src/commands/auto-fix.ts (type: 'prompt'). Text is verbatim.
+AUTO_FIX_PROMPT = (
+    "The user wants to configure auto-fix settings. Auto-fix automatically runs lint "
+    "and test commands after AI file edits, feeding errors back for self-repair.\n\n"
+    "Current settings location: `.claude/settings.json` or "
+    "`.claude/settings.local.json`\n\n"
+    "Example configuration:\n```json\n{\n  \"autoFix\": {\n    \"enabled\": true,\n"
+    "    \"lint\": \"eslint . --fix\",\n    \"test\": \"bun test\",\n"
+    "    \"maxRetries\": 3,\n    \"timeout\": 30000\n  }\n}\n```\n\n"
+    "Ask the user what lint and test commands they use, then help them set up the "
+    "configuration."
+)
+
+# Port of the /review half of typescript/src/commands/review.ts (LOCAL_REVIEW_PROMPT).
+# TS uses an indented template literal; this is intentionally dedented (the model is
+# indentation-insensitive). `${args}` becomes `$ARGUMENTS` for substitute_arguments.
+REVIEW_PROMPT = """
+You are an expert code reviewer. Follow these steps:
+
+1. If no PR number is provided in the args, run `gh pr list` to show open PRs
+2. If a PR number is provided, run `gh pr view <number>` to get PR details
+3. Run `gh pr diff <number>` to get the diff
+4. Analyze the changes and provide a thorough code review that includes:
+   - Overview of what the PR does
+   - Analysis of code quality and style
+   - Specific suggestions for improvements
+   - Any potential issues or risks
+
+Keep your review concise but thorough. Focus on:
+- Code correctness
+- Following project conventions
+- Performance implications
+- Test coverage
+- Security considerations
+
+Format your review with clear sections and bullet points.
+
+PR number: $ARGUMENTS
+"""
+
+AUTO_FIX_COMMAND = PromptCommand(
+    name="auto-fix",
+    description="Configure auto-fix: run lint/test after AI edits",
+    markdown_content=AUTO_FIX_PROMPT,
+    progress_message="Configuring auto-fix...",
+    content_length=0,
+    source="builtin",
+)
+
+REVIEW_COMMAND = PromptCommand(
+    name="review",
+    description="Review a pull request",
+    markdown_content=REVIEW_PROMPT,
+    progress_message="reviewing pull request",
+    content_length=0,
+    source="builtin",
+)
+
 
 # Synchronous versions for REPL integration
 def execute_command_sync(cmd_name: str, args: str, context: CommandContext) -> tuple[bool, str | None, str | None]:
@@ -1164,6 +1222,8 @@ def get_builtin_commands() -> list[Command]:
         COMPACT_COMMAND,
         ADVISOR_COMMAND,
         INIT_COMMAND,
+        AUTO_FIX_COMMAND,
+        REVIEW_COMMAND,
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)

--- a/src/command_system/safe_commands.py
+++ b/src/command_system/safe_commands.py
@@ -1,0 +1,61 @@
+"""
+Remote / bridge safe-command filtering.
+
+Python port of the REMOTE_SAFE_COMMANDS / BRIDGE_SAFE_COMMANDS / isBridgeSafeCommand
+logic in typescript/src/commands.ts:643-712. Gates which slash commands may run in
+--remote mode and over the Remote Control bridge (mobile/web), now load-bearing after
+the CLI-parity transport port (src/transports/).
+
+Membership is by command NAME (not object identity as in TS): a frozenset of names is
+stable across registry instances and lets the policy name commands that are not ported
+yet (the allowlist is a forward-looking policy, not a runtime object set).
+"""
+
+from __future__ import annotations
+
+from .types import Command, CommandType
+
+# Safe in --remote mode: only affect local TUI state; no fs/git/shell/IDE/MCP.
+# TS commands.ts:643-662 (18 commands).
+REMOTE_SAFE_COMMANDS: frozenset[str] = frozenset({
+    "session", "exit", "clear", "help", "theme", "logo", "color", "vim",
+    "cost", "usage", "copy", "btw", "feedback", "plan", "keybindings",
+    "statusline", "stickers", "mobile",
+})
+
+# 'local' commands explicitly safe over the Remote Control bridge: produce text
+# output that streams back to mobile/web, no terminal-only side effects.
+# TS commands.ts:676-685 (6 commands). 'summary' is an ant-internal import in TS
+# (kept here as a forward-looking policy name; not yet ported).
+BRIDGE_SAFE_COMMANDS: frozenset[str] = frozenset({
+    "compact", "clear", "cost", "summary", "release-notes", "files",
+})
+
+
+def is_bridge_safe_command(cmd: Command) -> bool:
+    """
+    Whether a slash command is safe to execute when its input arrived over the
+    Remote Control bridge. Port of commands.ts:697-701.
+
+    Rule: 'prompt' commands expand to text -> always safe; 'local' commands need an
+    explicit opt-in via BRIDGE_SAFE_COMMANDS; any future interactive ('local-jsx')
+    type renders UI and is always blocked. Python has no interactive type yet, so the
+    branches reduce to PROMPT -> True, LOCAL -> allowlist.
+    """
+    if cmd.command_type == CommandType.PROMPT:
+        return True  # prompt commands expand to text -> always safe
+    if cmd.command_type == CommandType.LOCAL:
+        return cmd.name in BRIDGE_SAFE_COMMANDS
+    # Any future interactive ('local-jsx') type renders UI -> blocked by default.
+    return False
+
+
+def filter_commands_for_remote_mode(commands: list[Command]) -> list[Command]:
+    """Keep only commands safe for --remote mode. Port of commands.ts:709-711.
+
+    Expects the DEDUPED output of get_commands() (where builtins own their names),
+    not a raw skill list. Membership is by NAME, so a user skill named e.g. 'clear'
+    would pass this filter unless the aggregator's dedupe has already let the builtin
+    claim that name first (the TS caller likewise feeds getCommands() output here).
+    """
+    return [cmd for cmd in commands if cmd.name in REMOTE_SAFE_COMMANDS]

--- a/src/command_system/types.py
+++ b/src/command_system/types.py
@@ -89,7 +89,8 @@ class CommandBase:
     version: Optional[str] = None
     disable_model_invocation: bool = False
     user_invocable: bool = True
-    loaded_from: str = "builtin"  # "builtin" | "skills" | "plugin" | "bundled" | "mcp"
+    loaded_from: str = "builtin"  # "builtin" | "skills" | "plugin" | "bundled" | "mcp" | "commands_DEPRECATED"
+    is_mcp: bool = False  # True for commands sourced from an MCP server (TS CommandBase.isMcp)
     kind: Optional[str] = None  # "workflow" or None
     immediate: bool = False
     is_sensitive: bool = False

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,0 +1,120 @@
+"""Tests for src/command_system/aggregator.py.
+
+Port-parity tests for get_commands(cwd) / clear_commands_cache() — the unified
+command aggregator (typescript/src/commands.ts:473-541). Covers: builtins+skills
+merge, availability + is_enabled filtering (re-evaluated fresh each call), name
+de-duplication under the "builtins own their names" rule, per-cwd skill-cache
+memoization, and skill-loader-failure resilience.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import src.skills.loader as skills_loader
+from src.command_system import aggregator
+from src.command_system.aggregator import clear_commands_cache, get_commands
+from src.command_system.types import CommandAvailability, PromptCommand
+from src.skills.model import Skill
+
+
+@pytest.fixture(autouse=True)
+def _clear_cmd_cache():
+    """The skill-command cache is process-global (lru_cache); isolate each test."""
+    clear_commands_cache()
+    yield
+    clear_commands_cache()
+
+
+def test_baseline_includes_builtins():
+    names = {c.name for c in get_commands()}
+    assert {"auto-fix", "review", "help", "compact"} <= names
+
+
+def test_no_duplicate_names():
+    names = [c.name for c in get_commands()]
+    assert len(names) == len(set(names))
+
+
+def test_disabled_builtin_is_filtered_out(monkeypatch):
+    disabled = PromptCommand(
+        name="zzz-disabled", description="d", is_enabled=lambda: False,
+    )
+    monkeypatch.setattr(aggregator, "get_builtin_commands", lambda: [disabled])
+    monkeypatch.setattr(skills_loader, "get_all_skills", lambda **kw: [])
+    assert "zzz-disabled" not in {c.name for c in get_commands()}
+
+
+def test_availability_gate_excludes_when_not_subscriber(monkeypatch):
+    gated = PromptCommand(
+        name="zzz-claude-ai",
+        description="d",
+        availability=[CommandAvailability.CLAUDE_AI],
+    )
+    monkeypatch.setattr(aggregator, "get_builtin_commands", lambda: [gated])
+    monkeypatch.setattr(skills_loader, "get_all_skills", lambda **kw: [])
+
+    excluded = {c.name for c in get_commands(is_claude_ai_subscriber=False)}
+    assert "zzz-claude-ai" not in excluded
+
+    included = {c.name for c in get_commands(is_claude_ai_subscriber=True)}
+    assert "zzz-claude-ai" in included
+
+
+def test_builtin_wins_dedupe_when_both_enabled(monkeypatch):
+    builtin_help = PromptCommand(name="help", description="builtin", source="builtin")
+    skill_help = Skill(name="help", description="skill", loaded_from="skills")
+    monkeypatch.setattr(aggregator, "get_builtin_commands", lambda: [builtin_help])
+    monkeypatch.setattr(skills_loader, "get_all_skills", lambda **kw: [skill_help])
+
+    helps = [c for c in get_commands() if c.name == "help"]
+    assert len(helps) == 1
+    assert helps[0].source == "builtin"
+
+
+def test_builtin_wins_dedupe_even_when_builtin_disabled(monkeypatch):
+    """Reserve-name-first rule: a disabled builtin still claims its name, so a
+    same-named *enabled* skill cannot leak through. Guards the deliberate
+    divergence from TS's filter-then-dedupe ordering.
+    """
+    disabled_builtin = PromptCommand(
+        name="zzz", description="builtin", source="builtin", is_enabled=lambda: False,
+    )
+    enabled_skill = Skill(name="zzz", description="skill", loaded_from="skills")
+    monkeypatch.setattr(
+        aggregator, "get_builtin_commands", lambda: [disabled_builtin]
+    )
+    monkeypatch.setattr(skills_loader, "get_all_skills", lambda **kw: [enabled_skill])
+
+    assert "zzz" not in {c.name for c in get_commands()}
+
+
+def test_skill_load_is_memoized_per_cwd(monkeypatch, tmp_path):
+    calls = {"n": 0}
+
+    def fake_get_all_skills(*, project_root=None, user_skills_dir=None):
+        calls["n"] += 1
+        return []
+
+    # Patch the module attribute: the function-local `from ..skills.loader import
+    # get_all_skills` inside _load_skill_commands_cached resolves against this.
+    monkeypatch.setattr(skills_loader, "get_all_skills", fake_get_all_skills)
+
+    cwd = str(tmp_path)
+    get_commands(cwd)
+    get_commands(cwd)
+    assert calls["n"] == 1  # second call served from the per-cwd cache
+
+    clear_commands_cache()
+    get_commands(cwd)
+    assert calls["n"] == 2  # cache cleared -> recomputed
+
+
+def test_skill_load_failure_is_resilient(monkeypatch, tmp_path):
+    def boom(*, project_root=None, user_skills_dir=None):
+        raise RuntimeError("skill discovery exploded")
+
+    monkeypatch.setattr(skills_loader, "get_all_skills", boom)
+
+    # A crashing skill loader must not take down command listing; builtins survive.
+    assert "help" in {c.name for c in get_commands(str(tmp_path))}

--- a/tests/test_class_a_commands.py
+++ b/tests/test_class_a_commands.py
@@ -1,0 +1,53 @@
+"""Tests for the Class A prompt commands ported in Phase 1: /auto-fix and /review.
+
+Ports typescript/src/commands/auto-fix.ts and the /review half of review.ts.
+Verifies prompt-text fidelity, $ARGUMENTS interpolation, and command metadata.
+Async tests need no decorator — pytest is configured with asyncio_mode="auto".
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+from src.command_system.builtins import AUTO_FIX_COMMAND, REVIEW_COMMAND
+from src.command_system.engine import create_command_context
+from src.command_system.types import CommandType
+
+
+def _ctx():
+    tmp = tempfile.gettempdir()
+    return create_command_context(workspace_root=tmp, cwd=tmp)
+
+
+async def test_auto_fix_prompt_content():
+    blocks = await AUTO_FIX_COMMAND.get_prompt_for_command("", _ctx())
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "text"
+    text = blocks[0]["text"]
+    assert "autoFix" in text
+    assert ".claude/settings.json" in text
+
+
+async def test_review_prompt_with_args_interpolates_arguments():
+    blocks = await REVIEW_COMMAND.get_prompt_for_command("1234", _ctx())
+    text = blocks[0]["text"]
+    # Substring (not .endswith): the prompt template has a trailing newline.
+    assert "PR number: 1234" in text
+    assert "$ARGUMENTS" not in text
+
+
+async def test_review_prompt_no_args():
+    blocks = await REVIEW_COMMAND.get_prompt_for_command("", _ctx())
+    text = blocks[0]["text"]
+    assert "gh pr list" in text
+    assert "PR number:" in text  # placeholder collapses to empty, label remains
+    assert "$ARGUMENTS" not in text
+
+
+def test_class_a_command_metadata():
+    for cmd in (AUTO_FIX_COMMAND, REVIEW_COMMAND):
+        assert cmd.command_type == CommandType.PROMPT
+        assert cmd.source == "builtin"
+        assert cmd.disable_model_invocation is False
+    assert AUTO_FIX_COMMAND.name == "auto-fix"
+    assert REVIEW_COMMAND.name == "review"

--- a/tests/test_safe_commands.py
+++ b/tests/test_safe_commands.py
@@ -1,0 +1,50 @@
+"""Tests for src/command_system/safe_commands.py.
+
+Port of REMOTE_SAFE_COMMANDS / BRIDGE_SAFE_COMMANDS / isBridgeSafeCommand /
+filterCommandsForRemoteMode from typescript/src/commands.ts:643-712.
+"""
+
+from __future__ import annotations
+
+from src.command_system.safe_commands import (
+    BRIDGE_SAFE_COMMANDS,
+    REMOTE_SAFE_COMMANDS,
+    filter_commands_for_remote_mode,
+    is_bridge_safe_command,
+)
+from src.command_system.types import LocalCommand, PromptCommand
+
+
+def test_remote_safe_set_size_and_contents():
+    assert len(REMOTE_SAFE_COMMANDS) == 18
+    # 'model' is intentionally excluded — the footgun the filter exists to stop.
+    assert "model" not in REMOTE_SAFE_COMMANDS
+    assert {"session", "exit", "clear", "help", "mobile"} <= REMOTE_SAFE_COMMANDS
+
+
+def test_bridge_safe_set_size_and_contents():
+    assert len(BRIDGE_SAFE_COMMANDS) == 6
+    assert BRIDGE_SAFE_COMMANDS == {
+        "compact", "clear", "cost", "summary", "release-notes", "files",
+    }
+
+
+def test_prompt_command_is_always_bridge_safe():
+    # 'prompt' commands expand to text -> always safe, regardless of name.
+    assert is_bridge_safe_command(PromptCommand(name="anything", description="d")) is True
+
+
+def test_local_command_bridge_safe_only_if_allowlisted():
+    assert is_bridge_safe_command(LocalCommand(name="compact", description="d")) is True
+    assert is_bridge_safe_command(LocalCommand(name="help", description="d")) is False
+
+
+def test_filter_commands_for_remote_mode_keeps_only_safe_names():
+    clear = LocalCommand(name="clear", description="d")    # in REMOTE_SAFE
+    help_ = LocalCommand(name="help", description="d")      # in REMOTE_SAFE
+    doctor = LocalCommand(name="doctor", description="d")   # NOT in REMOTE_SAFE
+    init = PromptCommand(name="init", description="d")      # NOT in REMOTE_SAFE
+    result = filter_commands_for_remote_mode([clear, help_, doctor, init])
+    assert {c.name for c in result} == {"clear", "help"}
+    assert doctor not in result
+    assert init not in result


### PR DESCRIPTION
## Summary
- Phase 1 of the `typescript/src/commands/` parity gap, ported into `src/command_system/`.
- **safe_commands.py** (new): `REMOTE_SAFE_COMMANDS` (18) / `BRIDGE_SAFE_COMMANDS` (6), `is_bridge_safe_command`, `filter_commands_for_remote_mode` — ports `commands.ts:643-712`; gates what runs in `--remote` mode and over the Remote Control bridge.
- **aggregator.py** (new): `get_commands(cwd)` merging builtins + filesystem skills with dedupe-by-name, availability + `is_enabled` filtering (re-evaluated fresh each call), lru-cached skill loading — ports `commands.ts:473-541`.
- **builtins.py**: `AUTO_FIX_COMMAND` + `REVIEW_COMMAND` (`PromptCommand`s; prompt text verbatim from `auto-fix.ts` / `review.ts`), wired into `get_builtin_commands()`.
- **types.py**: `is_mcp` field on `CommandBase` (parity with TS `CommandBase.isMcp`).

Two deliberate divergences from TS, both reviewed: safe sets are keyed by **name** (not object identity) so the policy is stable across registries and can name unported commands; and `get_commands` reserves a name **before** the availability/`is_enabled` filters so a disabled/unavailable builtin still owns its name and a same-named skill cannot shadow a core builtin. The two reinforce remote/bridge safety. Gap analysis + plan in `my-docs/get-parity-by-folder/`.

## Test plan
- [x] 17 new unit tests pass (`test_safe_commands` / `test_aggregator` / `test_class_a_commands`)
- [x] Full suite: 6757 passed; the 10 failures are pre-existing (broken `zhipuai` stub + untouched tool/permission parity), proven identical on a clean baseline — zero regressions
- [x] CRITIC review: APPROVE (prompt text byte-verified vs TS; safe-set names name-checked against TS command objects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)