### PR TITLE
commands: port createMovedToPlugin factory + security-review (phase 1.5)

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -35,6 +35,10 @@ from .engine import (
     CommandResult,
     create_command_context,
 )
+from .moved_to_plugin import (
+    MovedToPluginCommand,
+    create_moved_to_plugin_command,
+)
 from .registry import (
     CommandRegistry,
     find_commands,
@@ -49,6 +53,11 @@ from .safe_commands import (
     REMOTE_SAFE_COMMANDS,
     filter_commands_for_remote_mode,
     is_bridge_safe_command,
+)
+from .security_review import SECURITY_REVIEW_COMMAND
+from .shell_prompt import (
+    execute_shell_commands_in_prompt,
+    make_bash_shell_executor,
 )
 from .skills_integration import (
     get_skill_command,
@@ -109,8 +118,14 @@ __all__ = [
     "INIT_COMMAND",
     "AUTO_FIX_COMMAND",
     "REVIEW_COMMAND",
+    "SECURITY_REVIEW_COMMAND",
     "get_builtin_commands",
     "register_builtin_commands",
+    # Moved-to-plugin factory + shell-at-prompt-build
+    "create_moved_to_plugin_command",
+    "MovedToPluginCommand",
+    "execute_shell_commands_in_prompt",
+    "make_bash_shell_executor",
     # Aggregator
     "get_commands",
     "clear_commands_cache",

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -23,6 +23,7 @@ from ..history import HistoryLog
 from ..providers.base import BaseProvider
 from .engine import CommandContext, CommandResult, LocalCommandResult
 from .registry import CommandRegistry, get_command_registry, list_commands
+from .security_review import SECURITY_REVIEW_COMMAND
 from .types import Command, CommandType, CompactionResult, LocalCommand, PromptCommand
 
 
@@ -1224,6 +1225,7 @@ def get_builtin_commands() -> list[Command]:
         INIT_COMMAND,
         AUTO_FIX_COMMAND,
         REVIEW_COMMAND,
+        SECURITY_REVIEW_COMMAND,
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)

--- a/src/command_system/moved_to_plugin.py
+++ b/src/command_system/moved_to_plugin.py
@@ -1,0 +1,90 @@
+"""create_moved_to_plugin_command — Python port of TS commands/createMovedToPluginCommand.ts.
+
+Builds a builtin 'prompt' command whose prompt depends on USER_TYPE: ant users get a
+static "this command moved to a plugin" message; everyone else dispatches to a private
+prompt builder (the command's real implementation while the marketplace is private).
+"""
+from __future__ import annotations
+
+import inspect
+import os
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Optional, Union
+
+from .types import CommandContext, PromptCommand
+
+# (args, context) -> prompt blocks. May be sync or async (TS returns a Promise).
+PrivatePromptBuilder = Callable[
+    [str, CommandContext],
+    Union[list[dict[str, Any]], Awaitable[list[dict[str, Any]]]],
+]
+
+
+def _moved_to_plugin_text(plugin_name: str, plugin_command: str) -> str:
+    """Verbatim from createMovedToPluginCommand.ts:48-57."""
+    return (
+        "This command has been moved to a plugin. Tell the user:\n\n"
+        "1. To install the plugin, run:\n"
+        f"   openclaude plugin install {plugin_name}@claude-code-marketplace\n\n"
+        f"2. After installation, use /{plugin_name}:{plugin_command} to run this command\n\n"
+        "3. For more information, see: "
+        f"https://github.com/anthropics/claude-code-marketplace/blob/main/{plugin_name}/README.md\n\n"
+        "Do not attempt to run the command. Simply inform the user about the plugin "
+        "installation."
+    )
+
+
+@dataclass(frozen=True)
+class MovedToPluginCommand(PromptCommand):
+    """A builtin prompt command gated on USER_TYPE (see createMovedToPluginCommand.ts).
+
+    Frozen like its base; the custom prompt builder is stored as a non-comparing,
+    non-repr field (mirrors LocalCommand._call_impl) so the frozen dataclass stays
+    hashable/comparable by its data fields.
+    """
+
+    plugin_name: str = ""
+    plugin_command: str = ""
+    _private_builder: Optional[PrivatePromptBuilder] = field(
+        default=None, repr=False, compare=False
+    )
+
+    async def get_prompt_for_command(
+        self, args: str, context: CommandContext
+    ) -> list[dict[str, Any]]:
+        # TS gates on process.env.USER_TYPE === 'ant' (createMovedToPluginCommand.ts:44).
+        if os.environ.get("USER_TYPE") == "ant":
+            return [
+                {
+                    "type": "text",
+                    "text": _moved_to_plugin_text(self.plugin_name, self.plugin_command),
+                }
+            ]
+        if self._private_builder is None:
+            raise ValueError(f"{self.name}: no private prompt builder configured")
+        result = self._private_builder(args, context)
+        if inspect.isawaitable(result):  # support async builders (TS returns a Promise)
+            result = await result
+        return result
+
+
+def create_moved_to_plugin_command(
+    *,
+    name: str,
+    description: str,
+    progress_message: str,
+    plugin_name: str,
+    plugin_command: str,
+    get_prompt_while_marketplace_is_private: PrivatePromptBuilder,
+) -> MovedToPluginCommand:
+    """Port of createMovedToPluginCommand({...}) — returns a builtin prompt command."""
+    return MovedToPluginCommand(
+        name=name,
+        description=description,
+        progress_message=progress_message,
+        content_length=0,  # dynamic content (TS contentLength: 0)
+        source="builtin",  # TS source: 'builtin'
+        plugin_name=plugin_name,
+        plugin_command=plugin_command,
+        _private_builder=get_prompt_while_marketplace_is_private,
+    )

--- a/src/command_system/security_review.py
+++ b/src/command_system/security_review.py
@@ -1,0 +1,252 @@
+"""security-review command — Python port of TS commands/security-review.ts.
+
+A moved-to-plugin builtin: ant users get the static plugin-install message; everyone
+else runs the real review prompt, which executes the four read-only ``git`` blocks at
+prompt-build time (status / diff name-only / log / full diff against ``origin/HEAD...``)
+and splices their output into the markdown sent to the model.
+
+The private builder calls the lower-level ``execute_shell_commands_in_prompt`` directly
+and IGNORES ``args`` — faithful to TS, which does not run any skill-style transforms
+(no base-dir header, no ``ARGUMENTS:`` append, no ``${…}`` substitution).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from src.skills.frontmatter import parse_frontmatter
+from src.utils.markdown_config_loader import parse_slash_command_tools_from_frontmatter
+
+from .moved_to_plugin import create_moved_to_plugin_command
+from .shell_prompt import execute_shell_commands_in_prompt, make_bash_shell_executor
+from .types import CommandContext
+
+# Verbatim from security-review.ts:6-196 (frontmatter + body). The four `git` blocks are
+# the inline `!`…`` form wrapped in plain ``` display fences (NOT the fenced ```! exec
+# form), so they are detected as inline shell blocks.
+SECURITY_REVIEW_MARKDOWN = """---
+allowed-tools: Bash(git diff:*), Bash(git status:*), Bash(git log:*), Bash(git show:*), Bash(git remote show:*), Read, Glob, Grep, LS, Task
+description: Complete a security review of the pending changes on the current branch
+---
+
+You are a senior security engineer conducting a focused security review of the changes on this branch.
+
+GIT STATUS:
+
+```
+!`git status`
+```
+
+FILES MODIFIED:
+
+```
+!`git diff --name-only origin/HEAD...`
+```
+
+COMMITS:
+
+```
+!`git log --no-decorate origin/HEAD...`
+```
+
+DIFF CONTENT:
+
+```
+!`git diff origin/HEAD...`
+```
+
+Review the complete diff above. This contains all code changes in the PR.
+
+
+OBJECTIVE:
+Perform a security-focused code review to identify HIGH-CONFIDENCE security vulnerabilities that could have real exploitation potential. This is not a general code review - focus ONLY on security implications newly added by this PR. Do not comment on existing security concerns.
+
+CRITICAL INSTRUCTIONS:
+1. MINIMIZE FALSE POSITIVES: Only flag issues where you're >80% confident of actual exploitability
+2. AVOID NOISE: Skip theoretical issues, style concerns, or low-impact findings
+3. FOCUS ON IMPACT: Prioritize vulnerabilities that could lead to unauthorized access, data breaches, or system compromise
+4. EXCLUSIONS: Do NOT report the following issue types:
+   - Denial of Service (DOS) vulnerabilities, even if they allow service disruption
+   - Secrets or sensitive data stored on disk (these are handled by other processes)
+   - Rate limiting or resource exhaustion issues
+
+SECURITY CATEGORIES TO EXAMINE:
+
+**Input Validation Vulnerabilities:**
+- SQL injection via unsanitized user input
+- Command injection in system calls or subprocesses
+- XXE injection in XML parsing
+- Template injection in templating engines
+- NoSQL injection in database queries
+- Path traversal in file operations
+
+**Authentication & Authorization Issues:**
+- Authentication bypass logic
+- Privilege escalation paths
+- Session management flaws
+- JWT token vulnerabilities
+- Authorization logic bypasses
+
+**Crypto & Secrets Management:**
+- Hardcoded API keys, passwords, or tokens
+- Weak cryptographic algorithms or implementations
+- Improper key storage or management
+- Cryptographic randomness issues
+- Certificate validation bypasses
+
+**Injection & Code Execution:**
+- Remote code execution via deseralization
+- Pickle injection in Python
+- YAML deserialization vulnerabilities
+- Eval injection in dynamic code execution
+- XSS vulnerabilities in web applications (reflected, stored, DOM-based)
+
+**Data Exposure:**
+- Sensitive data logging or storage
+- PII handling violations
+- API endpoint data leakage
+- Debug information exposure
+
+Additional notes:
+- Even if something is only exploitable from the local network, it can still be a HIGH severity issue
+
+ANALYSIS METHODOLOGY:
+
+Phase 1 - Repository Context Research (Use file search tools):
+- Identify existing security frameworks and libraries in use
+- Look for established secure coding patterns in the codebase
+- Examine existing sanitization and validation patterns
+- Understand the project's security model and threat model
+
+Phase 2 - Comparative Analysis:
+- Compare new code changes against existing security patterns
+- Identify deviations from established secure practices
+- Look for inconsistent security implementations
+- Flag code that introduces new attack surfaces
+
+Phase 3 - Vulnerability Assessment:
+- Examine each modified file for security implications
+- Trace data flow from user inputs to sensitive operations
+- Look for privilege boundaries being crossed unsafely
+- Identify injection points and unsafe deserialization
+
+REQUIRED OUTPUT FORMAT:
+
+You MUST output your findings in markdown. The markdown output should contain the file, line number, severity, category (e.g. `sql_injection` or `xss`), description, exploit scenario, and fix recommendation.
+
+For example:
+
+# Vuln 1: XSS: `foo.py:42`
+
+* Severity: High
+* Description: User input from `username` parameter is directly interpolated into HTML without escaping, allowing reflected XSS attacks
+* Exploit Scenario: Attacker crafts URL like /bar?q=<script>alert(document.cookie)</script> to execute JavaScript in victim's browser, enabling session hijacking or data theft
+* Recommendation: Use Flask's escape() function or Jinja2 templates with auto-escaping enabled for all user inputs rendered in HTML
+
+SEVERITY GUIDELINES:
+- **HIGH**: Directly exploitable vulnerabilities leading to RCE, data breach, or authentication bypass
+- **MEDIUM**: Vulnerabilities requiring specific conditions but with significant impact
+- **LOW**: Defense-in-depth issues or lower-impact vulnerabilities
+
+CONFIDENCE SCORING:
+- 0.9-1.0: Certain exploit path identified, tested if possible
+- 0.8-0.9: Clear vulnerability pattern with known exploitation methods
+- 0.7-0.8: Suspicious pattern requiring specific conditions to exploit
+- Below 0.7: Don't report (too speculative)
+
+FINAL REMINDER:
+Focus on HIGH and MEDIUM findings only. Better to miss some theoretical issues than flood the report with false positives. Each finding should be something a security engineer would confidently raise in a PR review.
+
+FALSE POSITIVE FILTERING:
+
+> You do not need to run commands to reproduce the vulnerability, just read the code to determine if it is a real vulnerability. Do not use the bash tool or write to any files.
+>
+> HARD EXCLUSIONS - Automatically exclude findings matching these patterns:
+> 1. Denial of Service (DOS) vulnerabilities or resource exhaustion attacks.
+> 2. Secrets or credentials stored on disk if they are otherwise secured.
+> 3. Rate limiting concerns or service overload scenarios.
+> 4. Memory consumption or CPU exhaustion issues.
+> 5. Lack of input validation on non-security-critical fields without proven security impact.
+> 6. Input sanitization concerns for GitHub Action workflows unless they are clearly triggerable via untrusted input.
+> 7. A lack of hardening measures. Code is not expected to implement all security best practices, only flag concrete vulnerabilities.
+> 8. Race conditions or timing attacks that are theoretical rather than practical issues. Only report a race condition if it is concretely problematic.
+> 9. Vulnerabilities related to outdated third-party libraries. These are managed separately and should not be reported here.
+> 10. Memory safety issues such as buffer overflows or use-after-free-vulnerabilities are impossible in rust. Do not report memory safety issues in rust or any other memory safe languages.
+> 11. Files that are only unit tests or only used as part of running tests.
+> 12. Log spoofing concerns. Outputting un-sanitized user input to logs is not a vulnerability.
+> 13. SSRF vulnerabilities that only control the path. SSRF is only a concern if it can control the host or protocol.
+> 14. Including user-controlled content in AI system prompts is not a vulnerability.
+> 15. Regex injection. Injecting untrusted content into a regex is not a vulnerability.
+> 16. Regex DOS concerns.
+> 16. Insecure documentation. Do not report any findings in documentation files such as markdown files.
+> 17. A lack of audit logs is not a vulnerability.
+>
+> PRECEDENTS -
+> 1. Logging high value secrets in plaintext is a vulnerability. Logging URLs is assumed to be safe.
+> 2. UUIDs can be assumed to be unguessable and do not need to be validated.
+> 3. Environment variables and CLI flags are trusted values. Attackers are generally not able to modify them in a secure environment. Any attack that relies on controlling an environment variable is invalid.
+> 4. Resource management issues such as memory or file descriptor leaks are not valid.
+> 5. Subtle or low impact web vulnerabilities such as tabnabbing, XS-Leaks, prototype pollution, and open redirects should not be reported unless they are extremely high confidence.
+> 6. React and Angular are generally secure against XSS. These frameworks do not need to sanitize or escape user input unless it is using dangerouslySetInnerHTML, bypassSecurityTrustHtml, or similar methods. Do not report XSS vulnerabilities in React or Angular components or tsx files unless they are using unsafe methods.
+> 7. Most vulnerabilities in github action workflows are not exploitable in practice. Before validating a github action workflow vulnerability ensure it is concrete and has a very specific attack path.
+> 8. A lack of permission checking or authentication in client-side JS/TS code is not a vulnerability. Client-side code is not trusted and does not need to implement these checks, they are handled on the server-side. The same applies to all flows that send untrusted data to the backend, the backend is responsible for validating and sanitizing all inputs.
+> 9. Only include MEDIUM findings if they are obvious and concrete issues.
+> 10. Most vulnerabilities in ipython notebooks (*.ipynb files) are not exploitable in practice. Before validating a notebook vulnerability ensure it is concrete and has a very specific attack path where untrusted input can trigger the vulnerability.
+> 11. Logging non-PII data is not a vulnerability even if the data may be sensitive. Only report logging vulnerabilities if they expose sensitive information such as secrets, passwords, or personally identifiable information (PII).
+> 12. Command injection vulnerabilities in shell scripts are generally not exploitable in practice since shell scripts generally do not run with untrusted user input. Only report command injection vulnerabilities in shell scripts if they are concrete and have a very specific attack path for untrusted input.
+>
+> SIGNAL QUALITY CRITERIA - For remaining findings, assess:
+> 1. Is there a concrete, exploitable vulnerability with a clear attack path?
+> 2. Does this represent a real security risk vs theoretical best practice?
+> 3. Are there specific code locations and reproduction steps?
+> 4. Would this finding be actionable for a security team?
+>
+> For each finding, assign a confidence score from 1-10:
+> - 1-3: Low confidence, likely false positive or noise
+> - 4-6: Medium confidence, needs investigation
+> - 7-10: High confidence, likely true vulnerability
+
+START ANALYSIS:
+
+Begin your analysis now. Do this in 3 steps:
+
+1. Use a sub-task to identify vulnerabilities. Use the repository exploration tools to understand the codebase context, then analyze the PR changes for security implications. In the prompt for this sub-task, include all of the above.
+2. Then for each vulnerability identified by the above sub-task, create a new sub-task to filter out false-positives. Launch these sub-tasks as parallel sub-tasks. In the prompt for these sub-tasks, include everything in the "FALSE POSITIVE FILTERING" instructions.
+3. Filter out any vulnerabilities where the sub-task reported a confidence less than 8.
+
+Your final reply must contain the markdown report and nothing else."""
+
+
+def _security_review_private_prompt(
+    args: str, context: CommandContext
+) -> list[dict[str, Any]]:
+    """Build the real security-review prompt (marketplace-private path).
+
+    TS ignores ``_args`` (security-review.ts:205); we accept-and-ignore for signature
+    parity — no skill-style argument substitution happens here.
+    """
+    parsed = parse_frontmatter(SECURITY_REVIEW_MARKDOWN)
+    allowed_tools = parse_slash_command_tools_from_frontmatter(
+        parsed.frontmatter.get("allowed-tools")
+    )
+    # Bridge CommandContext -> ToolContext (only workspace_root/cwd are needed; the
+    # default permission_context is bypassPermissions, matching the in-process path).
+    from src.tool_system.context import ToolContext  # lazy: keep tool_system off import chain
+
+    tool_context = ToolContext(workspace_root=context.workspace_root, cwd=context.cwd)
+    executor = make_bash_shell_executor(
+        tool_context, allowed_tools, slash_command_name="security-review"
+    )
+    processed = execute_shell_commands_in_prompt(
+        parsed.body, shell_executor=executor, slash_command_name="security-review"
+    )
+    return [{"type": "text", "text": processed}]
+
+
+SECURITY_REVIEW_COMMAND = create_moved_to_plugin_command(
+    name="security-review",
+    description="Complete a security review of the pending changes on the current branch",
+    progress_message="analyzing code changes for security risks",
+    plugin_name="security-review",
+    plugin_command="security-review",
+    get_prompt_while_marketplace_is_private=_security_review_private_prompt,
+)

--- a/src/command_system/shell_prompt.py
+++ b/src/command_system/shell_prompt.py
@@ -1,0 +1,122 @@
+"""Shell-exec-at-prompt-build for slash commands.
+
+Python port of typescript/src/utils/promptShellExecution.ts (executeShellCommandsInPrompt)
+plus the BashTool-backed executor pattern from src/tool_system/tools/skill.py
+(_make_shell_executor). Reuses the public shell-block primitives already ported in
+src/skills/runtime_substitution.py (find_shell_blocks / format_shell_output /
+format_shell_error) rather than re-deriving the regexes.
+
+Two divergences from TS, both deliberate and matching the already-shipped skills path:
+  * No permission gate. TS runs ``hasPermissionsToUseTool`` and BLOCKS any command not
+    matched by ``alwaysAllowRules.command`` (throws MalformedCommandError, block never
+    runs). Python's ``BashTool.call()`` bypasses the registry gate and runs every
+    detected block unconditionally under the ToolContext's permission mode
+    (bypassPermissions by default). The parsed ``allowed_tools`` list is accepted for
+    parity but not enforced yet.
+  * No abort on failure. TS throws and aborts the whole prompt build; Python embeds the
+    formatted error inline (``[Error: …]``) and continues, returning a complete prompt
+    with visible error text (DEV-2: surface as visible errors, not silent drops, without
+    crashing). See src/skills/runtime_substitution.py:140-157.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+from src.skills.runtime_substitution import (
+    find_shell_blocks,
+    format_shell_error,
+    format_shell_output,
+)
+
+logger = logging.getLogger(__name__)
+
+# (command, inline) -> rendered text to splice in. Identical contract to
+# runtime_substitution.ShellExecutor.
+ShellExecutor = Callable[[str, bool], str]
+
+
+def execute_shell_commands_in_prompt(
+    text: str,
+    *,
+    shell_executor: ShellExecutor,
+    slash_command_name: str = "",
+) -> str:
+    """Replace embedded shell blocks in ``text`` with their executed output.
+
+    Port of executeShellCommandsInPrompt (promptShellExecution.ts:73). Scans for
+    ``` ```! ... ``` ``` (fenced) and ``!`...``` (inline) forms via
+    ``find_shell_blocks``, runs each through ``shell_executor`` (which formats its own
+    success/error text), and splices the result back in.
+
+    Execution is sequential in ``find_shell_blocks`` order (TS uses ``Promise.all``);
+    this is collision-safe because ``str.replace(full_match, replacement, 1)`` targets
+    the first occurrence and the detected ``full_match`` strings do not nest. Unlike TS
+    — which raises MalformedCommandError on permission/exec failure and aborts the build
+    — a crashing executor is caught here and rendered inline so prompt-build never dies.
+    """
+    blocks = find_shell_blocks(text)
+    if not blocks:
+        return text
+    result = text
+    for full_match, command, inline in blocks:
+        try:
+            replacement = shell_executor(command, inline)
+        except Exception as exc:  # noqa: BLE001 — surface anything, never crash prompt build
+            logger.exception(
+                "shell executor crashed for %s command %r", slash_command_name, command
+            )
+            replacement = format_shell_error(exc, full_match, inline=inline)
+        result = result.replace(full_match, replacement, 1)
+    return result
+
+
+def make_bash_shell_executor(
+    tool_context,  # src.tool_system.context.ToolContext
+    allowed_tools: list[str] | None,
+    *,
+    slash_command_name: str,
+) -> ShellExecutor:
+    """Return a BashTool-backed ShellExecutor. Mirrors skill.py:_make_shell_executor.
+
+    ``allowed_tools`` is accepted for TS parity (TS injects it as
+    ``alwaysAllowRules.command`` for the call) but is NOT enforced — the Python
+    ``BashTool.call()`` path bypasses the registry permission gate and runs under the
+    ToolContext's permission mode (bypassPermissions by default). Precise injection is
+    deferred, identical to the documented skill limitation. ``BashTool`` is imported
+    lazily so importing this module never pulls ``tool_system`` onto the
+    ``command_system`` import chain.
+    """
+    from src.tool_system.tools.bash import BashTool  # lazy: keep tool_system off import chain
+
+    _ = allowed_tools  # acknowledged; precise injection deferred
+
+    def _exec(command: str, inline: bool) -> str:
+        try:
+            tr = BashTool.call({"command": command}, tool_context)
+        except Exception as exc:  # noqa: BLE001 — surface every failure inline
+            return format_shell_error(exc, command, inline=inline)
+
+        output = tr.output if isinstance(tr.output, dict) else {}
+        stdout = str(output.get("stdout", ""))
+        stderr = str(output.get("stderr", ""))
+        exit_code = output.get("exit_code")
+
+        # Non-zero exit: embed the failure text inline (matches TS' ShellError) but keep
+        # going so the rest of the prompt still renders.
+        if isinstance(exit_code, int) and exit_code != 0:
+            err_text = format_shell_output(stdout, stderr, inline=inline)
+            err_text = err_text or f"command failed (exit {exit_code})"
+            return format_shell_error(err_text, command, inline=inline)
+
+        if tr.is_error:
+            err_text = (
+                format_shell_output(stdout, stderr, inline=inline)
+                or output.get("error")
+                or "command failed"
+            )
+            return format_shell_error(str(err_text), command, inline=inline)
+
+        return format_shell_output(stdout, stderr, inline=inline)
+
+    return _exec

--- a/src/utils/markdown_config_loader.py
+++ b/src/utils/markdown_config_loader.py
@@ -177,3 +177,70 @@ def load_markdown_files_for_subdir(subdir: str, cwd: str) -> list[MarkdownFile]:
         _collect(project_dir, SOURCE_PROJECT)
 
     return results
+
+
+def parse_tool_list_from_cli(tools: list[str]) -> list[str]:
+    """Paren-aware tool-list splitter. Port of permissionSetup.ts:814 parseToolListFromCLI.
+
+    Splits each entry on commas AND spaces that fall OUTSIDE parentheses, so
+    ``Bash(git diff:*), Read`` -> ``["Bash(git diff:*)", "Read"]`` while a comma or
+    space *inside* ``(...)`` (e.g. ``Bash(git remote show:*)``) is preserved. Empty
+    fragments are dropped.
+    """
+    result: list[str] = []
+    for tool_string in tools:
+        if not tool_string:
+            continue
+        current = ""
+        in_parens = False
+        for ch in tool_string:
+            if ch == "(":
+                in_parens = True
+                current += ch
+            elif ch == ")":
+                in_parens = False
+                current += ch
+            elif ch == ",":
+                if in_parens:
+                    current += ch
+                elif current.strip():
+                    result.append(current.strip())
+                    current = ""
+                else:
+                    current = ""
+            elif ch == " ":
+                if in_parens:
+                    current += ch
+                elif current.strip():
+                    result.append(current.strip())
+                    current = ""
+                # else: drop a run of leading/separating spaces outside parens
+            else:
+                current += ch
+        if current.strip():
+            result.append(current.strip())
+    return result
+
+
+def parse_slash_command_tools_from_frontmatter(tools_value: Any) -> list[str]:
+    """Port of markdownConfigLoader.ts:135 parseSlashCommandToolsFromFrontmatter.
+
+    ``None`` -> ``[]`` (TS returns null and the caller coalesces to ``[]``); falsy
+    (``""`` / empty list) -> ``[]``; a ``str`` -> single-element input; a ``list`` ->
+    its string items only (non-strings dropped). A parsed ``"*"`` short-circuits to
+    ``["*"]`` (wildcard: allow everything).
+    """
+    if tools_value is None or tools_value == "" or tools_value == []:
+        return []
+    if isinstance(tools_value, str):
+        tools_array = [tools_value]
+    elif isinstance(tools_value, list):
+        tools_array = [t for t in tools_value if isinstance(t, str)]
+    else:
+        return []
+    if not tools_array:
+        return []
+    parsed = parse_tool_list_from_cli(tools_array)
+    if "*" in parsed:
+        return ["*"]
+    return parsed

--- a/tests/test_moved_to_plugin.py
+++ b/tests/test_moved_to_plugin.py
@@ -1,0 +1,117 @@
+"""Tests for the moved-to-plugin command factory (Phase 1.5).
+
+Covers ``create_moved_to_plugin_command`` / ``MovedToPluginCommand`` — the USER_TYPE gate
+(ant → static plugin-install text; everyone else → private builder), sync + async builder
+dispatch, and the builtin metadata. Port of ``createMovedToPluginCommand.ts``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.command_system import (
+    CommandType,
+    create_command_context,
+    create_moved_to_plugin_command,
+)
+
+
+def _make_command(builder):
+    return create_moved_to_plugin_command(
+        name="foo-cmd",
+        description="a foo command",
+        progress_message="fooing",
+        plugin_name="foo",
+        plugin_command="bar",
+        get_prompt_while_marketplace_is_private=builder,
+    )
+
+
+def _ctx(tmp_path: Path):
+    return create_command_context(workspace_root=tmp_path)
+
+
+def _raising_builder(args: str, context: Any) -> list[dict[str, Any]]:
+    raise AssertionError("private builder must NOT run on the ant branch")
+
+
+async def test_ant_branch_returns_static_text(monkeypatch, tmp_path):
+    monkeypatch.setenv("USER_TYPE", "ant")
+    cmd = _make_command(_raising_builder)
+
+    result = await cmd.get_prompt_for_command("", _ctx(tmp_path))
+
+    assert len(result) == 1
+    text = result[0]["text"]
+    # Verbatim moved-to-plugin message wiring (createMovedToPluginCommand.ts:48-57).
+    assert "openclaude plugin install foo@claude-code-marketplace" in text
+    assert "/foo:bar" in text
+    assert (
+        "https://github.com/anthropics/claude-code-marketplace/blob/main/foo/README.md"
+        in text
+    )
+
+
+async def test_private_branch_dispatches_to_builder(monkeypatch, tmp_path):
+    monkeypatch.delenv("USER_TYPE", raising=False)
+    sentinel = [{"type": "text", "text": "PRIVATE"}]
+    cmd = _make_command(lambda args, context: sentinel)
+
+    result = await cmd.get_prompt_for_command("", _ctx(tmp_path))
+
+    assert result == sentinel
+
+
+async def test_private_branch_awaits_async_builder(monkeypatch, tmp_path):
+    monkeypatch.delenv("USER_TYPE", raising=False)
+    sentinel = [{"type": "text", "text": "ASYNC-PRIVATE"}]
+
+    async def async_builder(args: str, context: Any) -> list[dict[str, Any]]:
+        return sentinel
+
+    cmd = _make_command(async_builder)
+
+    result = await cmd.get_prompt_for_command("", _ctx(tmp_path))
+
+    assert result == sentinel
+
+
+async def test_non_ant_user_type_takes_private_branch(monkeypatch, tmp_path):
+    # Any USER_TYPE other than exactly "ant" must take the private path.
+    monkeypatch.setenv("USER_TYPE", "external")
+    sentinel = [{"type": "text", "text": "PRIVATE"}]
+    cmd = _make_command(lambda args, context: sentinel)
+
+    result = await cmd.get_prompt_for_command("", _ctx(tmp_path))
+
+    assert result == sentinel
+
+
+async def test_missing_builder_on_private_branch_raises(monkeypatch, tmp_path):
+    monkeypatch.delenv("USER_TYPE", raising=False)
+    # Construct directly without a builder to exercise the guard.
+    cmd = create_moved_to_plugin_command(
+        name="no-builder",
+        description="d",
+        progress_message="p",
+        plugin_name="x",
+        plugin_command="y",
+        get_prompt_while_marketplace_is_private=None,  # type: ignore[arg-type]
+    )
+    with pytest.raises(ValueError, match="no private prompt builder"):
+        await cmd.get_prompt_for_command("", _ctx(tmp_path))
+
+
+def test_metadata():
+    cmd = _make_command(lambda args, context: [])
+    assert cmd.command_type == CommandType.PROMPT
+    assert cmd.source == "builtin"
+    assert cmd.content_length == 0
+    assert cmd.user_facing_name() == "foo-cmd"
+    assert cmd.name == "foo-cmd"
+    assert cmd.description == "a foo command"
+    assert cmd.progress_message == "fooing"
+    assert cmd.plugin_name == "foo"
+    assert cmd.plugin_command == "bar"

--- a/tests/test_security_review.py
+++ b/tests/test_security_review.py
@@ -1,0 +1,134 @@
+"""Tests for the security-review builtin (Phase 1.5).
+
+Covers the factory wiring (ant branch → static plugin text) and the real
+marketplace-private path, which executes the four read-only ``git`` blocks at
+prompt-build time in a throwaway git repo and splices their output into the prompt.
+Port of ``commands/security-review.ts``.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from src.command_system import (
+    SECURITY_REVIEW_COMMAND,
+    create_command_context,
+    get_commands,
+)
+
+# Literal inline shell markers from SECURITY_REVIEW_MARKDOWN — must all be gone after exec.
+GIT_MARKERS = [
+    "!`git status`",
+    "!`git diff --name-only origin/HEAD...`",
+    "!`git log --no-decorate origin/HEAD...`",
+    "!`git diff origin/HEAD...`",
+]
+
+
+def _init_git_repo(path: Path) -> None:
+    """Create a minimal git repo with one commit and a clean working tree.
+
+    Local identity + disabled gpg signing keep ``git commit`` working in CI sandboxes
+    that have no global git config. The hermetic env (``GIT_CONFIG_NOSYSTEM``, a
+    ``/dev/null`` global config, ``HOME`` pinned to the temp dir) also neutralizes any
+    hostile system/global ``core.hooksPath`` / ``init.templateDir`` that could otherwise
+    inject a failing commit hook. After the commit, ``git status`` reports a clean tree
+    (no remote, so the three ``origin/HEAD...`` blocks deliberately fail).
+    """
+    env = {
+        **os.environ,
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "HOME": str(path),
+    }
+
+    def run(*args: str) -> None:
+        subprocess.run(
+            ["git", *args],
+            cwd=path,
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    run("init")
+    run("config", "user.email", "test@example.com")
+    run("config", "user.name", "Test User")
+    run("config", "commit.gpgsign", "false")
+    (path / "app.py").write_text("print('hello')\n")
+    run("add", "-A")
+    run("commit", "-m", "initial commit")
+
+
+async def test_ant_branch_returns_static_plugin_text(monkeypatch, tmp_path):
+    monkeypatch.setenv("USER_TYPE", "ant")
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+
+    result = await SECURITY_REVIEW_COMMAND.get_prompt_for_command("", ctx)
+
+    assert len(result) == 1
+    text = result[0]["text"]
+    assert (
+        "openclaude plugin install security-review@claude-code-marketplace" in text
+    )
+    assert "/security-review:security-review" in text
+    # The ant branch must NOT shell out — none of the markdown body/exec appears.
+    assert "OBJECTIVE" not in text
+    assert "nothing to commit" not in text
+
+
+async def test_private_branch_runs_git_blocks(monkeypatch, tmp_path):
+    monkeypatch.delenv("USER_TYPE", raising=False)
+    _init_git_repo(tmp_path)
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+
+    result = await SECURITY_REVIEW_COMMAND.get_prompt_for_command("", ctx)
+
+    assert len(result) == 1
+    text = result[0]["text"]
+
+    # Every inline marker was executed and spliced away.
+    for marker in GIT_MARKERS:
+        assert marker not in text, f"marker still present: {marker}"
+
+    # `git status` ran in the temp repo and produced its real (clean-tree) output.
+    # These phrases appear nowhere in the static markdown body, so they prove exec.
+    assert "nothing to commit" in text or "working tree clean" in text
+
+    # The three `origin/HEAD...` blocks have no remote -> git exits 128 -> each renders
+    # the INLINE error form `[Error: ...]` (NOT `[Error]`: in Python
+    # `'[Error]' in '[Error: fatal…]'` is False). This is the non-zero-exit branch of
+    # make_bash_shell_executor (exec resilience), proving failures render inline without
+    # aborting the build.
+    assert "[Error:" in text
+    assert text.count("[Error:") >= 3
+
+    # Static body survives the transform.
+    assert "OBJECTIVE" in text
+    assert "START ANALYSIS" in text
+
+    # Frontmatter was stripped (parse_frontmatter -> body only).
+    assert "allowed-tools:" not in text
+
+
+async def test_args_are_ignored(monkeypatch, tmp_path):
+    # Faithfulness guard (§0.1): security-review ignores args — no skill-style
+    # `ARGUMENTS:` append, no `${…}` substitution.
+    monkeypatch.delenv("USER_TYPE", raising=False)
+    _init_git_repo(tmp_path)
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+
+    result = await SECURITY_REVIEW_COMMAND.get_prompt_for_command("ignored-pr-123", ctx)
+
+    text = result[0]["text"]
+    assert "ignored-pr-123" not in text
+    assert "ARGUMENTS:" not in text
+
+
+def test_security_review_listed_in_unfiltered_commands():
+    # §3.4 / layer check: security-review belongs in the normal LOCAL command set
+    # (get_commands), not the remote/bridge safe-sets (it shells out to git).
+    names = [c.name for c in get_commands(cwd=str(Path.cwd()))]
+    assert "security-review" in names

--- a/tests/test_shell_prompt.py
+++ b/tests/test_shell_prompt.py
@@ -1,0 +1,69 @@
+"""Tests for the generic shell-block splicer (Phase 1.5).
+
+``execute_shell_commands_in_prompt`` is the lower-level primitive security-review uses
+instead of ``render_skill_prompt`` (§0.1). These cases pin two load-bearing properties
+with pure fake executors (no subprocess):
+
+  * **R7 — literal replacement / `$`-backref safety.** The splice uses
+    ``str.replace(full_match, replacement, 1)``, which does NOT interpret ``$&`` / ``$1`` /
+    ``\\1`` as backreferences. This is the justification for diverging from TS's function
+    replacer; if a future refactor swaps in ``re.sub`` this test fails loudly.
+  * **R8 — orchestrator resilience.** A raising executor is caught and rendered inline
+    (``[Error: …]``); the build continues and never propagates.
+"""
+from __future__ import annotations
+
+from src.command_system.shell_prompt import execute_shell_commands_in_prompt
+
+
+def test_inline_block_replaced_with_executor_output():
+    out = execute_shell_commands_in_prompt(
+        "before !`echo hi` after", shell_executor=lambda cmd, inline: f"<{cmd}>"
+    )
+    assert out == "before <echo hi> after"
+
+
+def test_no_blocks_returns_text_unchanged():
+    text = "plain text, no shell blocks here"
+    out = execute_shell_commands_in_prompt(text, shell_executor=lambda c, i: "X")
+    assert out == text
+
+
+def test_replacement_with_dollar_and_backslash_is_literal():
+    # R7: none of these are interpreted as regex/replacement backreferences.
+    payload = r"price=$5 $& $1 $0 \1 \g<0> ${VAR}"
+    out = execute_shell_commands_in_prompt(
+        "X !`emit` Y", shell_executor=lambda cmd, inline: payload
+    )
+    assert out == f"X {payload} Y"
+
+
+def test_multiple_distinct_blocks_all_replaced():
+    out = execute_shell_commands_in_prompt(
+        "!`a`\n!`b`\n!`c`", shell_executor=lambda cmd, inline: cmd.upper()
+    )
+    assert out == "A\nB\nC"
+
+
+def test_crashing_executor_is_caught_and_rendered_inline():
+    # R8: orchestrator-level resilience — the error is embedded inline and the block is
+    # replaced (not left raw); the call returns normally instead of raising.
+    def boom(cmd, inline):
+        raise RuntimeError("kaboom")
+
+    out = execute_shell_commands_in_prompt("A !`bad` B", shell_executor=boom)
+    assert "!`bad`" not in out
+    assert "[Error:" in out
+    assert out.startswith("A ") and out.endswith(" B")
+
+
+def test_inline_flag_passed_to_executor():
+    seen: list[bool] = []
+
+    def record(cmd, inline):
+        seen.append(inline)
+        return "ok"
+
+    # An inline `!`…`` token reports inline=True (the form security-review's git blocks use).
+    execute_shell_commands_in_prompt("q !`x` r", shell_executor=record)
+    assert seen == [True]

--- a/tests/test_tool_list_parsing.py
+++ b/tests/test_tool_list_parsing.py
@@ -1,0 +1,80 @@
+"""Tests for the slash-command allowed-tools parsers (Phase 1.5).
+
+Covers ``parse_tool_list_from_cli`` (paren-aware comma/space splitter) and
+``parse_slash_command_tools_from_frontmatter`` (frontmatter-value normalizer with the
+``*`` wildcard short-circuit). Both live in ``src/utils/markdown_config_loader.py`` —
+ports of ``permissionSetup.ts:parseToolListFromCLI`` and
+``markdownConfigLoader.ts:parseSlashCommandToolsFromFrontmatter``.
+"""
+from __future__ import annotations
+
+from src.utils.markdown_config_loader import (
+    parse_slash_command_tools_from_frontmatter,
+    parse_tool_list_from_cli,
+)
+
+# The exact allowed-tools string shipped in security-review.ts frontmatter.
+SECURITY_REVIEW_ALLOWED_TOOLS = (
+    "Bash(git diff:*), Bash(git status:*), Bash(git log:*), "
+    "Bash(git show:*), Bash(git remote show:*), Read, Glob, Grep, LS, Task"
+)
+
+SECURITY_REVIEW_EXPECTED = [
+    "Bash(git diff:*)",
+    "Bash(git status:*)",
+    "Bash(git log:*)",
+    "Bash(git show:*)",
+    "Bash(git remote show:*)",
+    "Read",
+    "Glob",
+    "Grep",
+    "LS",
+    "Task",
+]
+
+
+def test_empty_inputs_return_empty_list():
+    assert parse_slash_command_tools_from_frontmatter(None) == []
+    assert parse_slash_command_tools_from_frontmatter("") == []
+    assert parse_slash_command_tools_from_frontmatter([]) == []
+
+
+def test_security_review_value_parses_exactly():
+    parsed = parse_slash_command_tools_from_frontmatter(SECURITY_REVIEW_ALLOWED_TOOLS)
+    assert parsed == SECURITY_REVIEW_EXPECTED
+
+
+def test_comma_inside_parens_is_preserved():
+    # The outer comma splits; the comma inside ``(...)`` is kept verbatim.
+    assert parse_tool_list_from_cli(["Bash(a, b:*), Read"]) == ["Bash(a, b:*)", "Read"]
+
+
+def test_space_outside_parens_splits():
+    assert parse_tool_list_from_cli(["Read Glob"]) == ["Read", "Glob"]
+
+
+def test_space_inside_parens_is_preserved():
+    # ``git remote show`` has spaces inside the parens — must survive as one token.
+    assert parse_tool_list_from_cli(["Bash(git remote show:*)"]) == [
+        "Bash(git remote show:*)"
+    ]
+
+
+def test_wildcard_short_circuits():
+    assert parse_slash_command_tools_from_frontmatter("Read, *") == ["*"]
+
+
+def test_list_input_drops_non_strings():
+    assert parse_slash_command_tools_from_frontmatter(["Read", 3, "Glob"]) == [
+        "Read",
+        "Glob",
+    ]
+
+
+def test_single_scalar_string():
+    assert parse_slash_command_tools_from_frontmatter("Read") == ["Read"]
+
+
+def test_unsupported_type_returns_empty():
+    # A dict (or any non-None/str/list) is not a valid tools value.
+    assert parse_slash_command_tools_from_frontmatter({"a": 1}) == []


### PR DESCRIPTION
## Summary

Completes **Phase 1.5** of the `commands/` folder port — a faithful port of `typescript/src/commands/security-review.ts` and its `createMovedToPlugin` scaffolding.

- **`moved_to_plugin.py`** — `MovedToPluginCommand` + `create_moved_to_plugin_command` factory. Returns static "install the plugin" text when `USER_TYPE == "ant"`, otherwise dispatches to a private prompt builder (sync or async via `inspect.isawaitable`).
- **`shell_prompt.py`** — `execute_shell_commands_in_prompt` + `make_bash_shell_executor`. Runs inline `` !`…` `` shell blocks at prompt-build time through a BashTool-backed executor, splicing stdout/stderr back into the prompt. Uses literal `str.replace` (not `re.sub`) so `$`/backslash output is never treated as a backreference.
- **`security_review.py`** — `SECURITY_REVIEW_COMMAND`. On the marketplace-private path it executes the four read-only `git` blocks (status, diff, log) and inlines their output into the verbatim-transcribed prompt body.
- **`markdown_config_loader.py`** — `parse_tool_list_from_cli` + `parse_slash_command_tools_from_frontmatter` (paren-aware tool-list parsing).
- Registered `SECURITY_REVIEW_COMMAND` in `builtins.get_builtin_commands` and re-exported the new surface from `command_system/__init__`.

### Two deliberate divergences from TS (consistent with the skills-runtime port)
- **No permission gate (R3):** blocks run under `bypassPermissions`; `allowed-tools` is parsed but not enforced/injected.
- **No abort on failure (R8):** a failing/raising block renders `[Error: …]` inline and the build continues, rather than throwing.

## Test plan
- [x] `tests/test_moved_to_plugin.py` — ant vs private branching, sync/async builders, metadata
- [x] `tests/test_security_review.py` — live `git` exec in a hermetic temp repo; markers spliced away; frontmatter stripped; args ignored; listed in `get_commands()`
- [x] `tests/test_shell_prompt.py` — literal `$`-backref safety, multi-block, crashing-executor resilience
- [x] `tests/test_tool_list_parsing.py` — paren-aware parsing edge cases
- [x] 25 new tests pass; full suite green except the 10 pre-existing failures (zhipuai `ImportError` + prior parity tests), proven identical on a clean baseline — zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)