### PR TITLE
commands: port statusline prompt command (Class-A completion)

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -55,6 +55,7 @@ from .safe_commands import (
     is_bridge_safe_command,
 )
 from .security_review import SECURITY_REVIEW_COMMAND
+from .statusline import STATUSLINE_COMMAND, StatuslineCommand
 from .shell_prompt import (
     execute_shell_commands_in_prompt,
     make_bash_shell_executor,
@@ -119,6 +120,8 @@ __all__ = [
     "AUTO_FIX_COMMAND",
     "REVIEW_COMMAND",
     "SECURITY_REVIEW_COMMAND",
+    "STATUSLINE_COMMAND",
+    "StatuslineCommand",
     "get_builtin_commands",
     "register_builtin_commands",
     # Moved-to-plugin factory + shell-at-prompt-build

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -24,6 +24,7 @@ from ..providers.base import BaseProvider
 from .engine import CommandContext, CommandResult, LocalCommandResult
 from .registry import CommandRegistry, get_command_registry, list_commands
 from .security_review import SECURITY_REVIEW_COMMAND
+from .statusline import STATUSLINE_COMMAND
 from .types import Command, CommandType, CompactionResult, LocalCommand, PromptCommand
 
 
@@ -1226,6 +1227,7 @@ def get_builtin_commands() -> list[Command]:
         AUTO_FIX_COMMAND,
         REVIEW_COMMAND,
         SECURITY_REVIEW_COMMAND,
+        STATUSLINE_COMMAND,
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)

--- a/src/command_system/statusline.py
+++ b/src/command_system/statusline.py
@@ -1,0 +1,58 @@
+"""statusline — Python port of TS commands/statusline.tsx (type: 'prompt').
+
+A dynamic ``prompt`` command: with no args it defaults the inner prompt to a
+fixed phrase; otherwise it embeds the user's trimmed args. The single text block
+instructs the model to spawn a ``statusline-setup`` subagent.
+
+Note: that subagent is not yet registered in Python (``src/agent/agent_definitions.py``
+ships only general-purpose/Explore/Plan/fork), so the emitted prompt is runtime-inert
+today — faithfully matching TS, where the command also only emits naming text and
+relies on a separately-registered agent. Porting ``tools/AgentTool/built-in/
+statuslineSetup.ts`` is a deferred follow-up.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.agent.constants import AGENT_TOOL_NAME
+
+from .types import CommandContext, PromptCommand
+
+# TS: args.trim() || 'Configure my statusLine from my shell PS1 configuration'
+_DEFAULT_STATUSLINE_INSTRUCTION = (
+    "Configure my statusLine from my shell PS1 configuration"
+)
+
+
+@dataclass(frozen=True)
+class StatuslineCommand(PromptCommand):
+    """Overrides get_prompt_for_command for the default-when-empty + f-string
+    template TS uses, which the base $ARGUMENTS substitution cannot express.
+
+    Frozen like its base (mirrors MovedToPluginCommand); adds no data fields, so
+    it stays comparable by the inherited fields (equality-by-data). Not hashable —
+    the base carries mutable list fields (allowed_tools/aliases) — but nothing
+    hashes commands; registration/dedupe is by .name.
+    """
+
+    async def get_prompt_for_command(
+        self, args: str, context: CommandContext
+    ) -> list[dict[str, Any]]:
+        prompt = args.strip() or _DEFAULT_STATUSLINE_INSTRUCTION
+        text = (
+            f'Create an {AGENT_TOOL_NAME} with subagent_type "statusline-setup" '
+            f'and the prompt "{prompt}"'
+        )
+        return [{"type": "text", "text": text}]
+
+
+STATUSLINE_COMMAND = StatuslineCommand(
+    name="statusline",
+    description="Set up OpenClaude's status line UI",
+    progress_message="setting up statusLine",
+    content_length=0,  # TS contentLength: 0 (dynamic content)
+    source="builtin",  # TS source: 'builtin'
+    allowed_tools=[AGENT_TOOL_NAME, "Read(~/**)", "Edit(~/.claude/settings.json)"],
+    disable_non_interactive=True,  # TS disableNonInteractive: true
+)

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -1,0 +1,125 @@
+"""Tests for the statusline builtin (Class-A completion chapter).
+
+Port of ``commands/statusline.tsx`` (type: 'prompt'). statusline is a *dynamic*
+prompt command: it overrides ``get_prompt_for_command`` instead of using the base
+``$ARGUMENTS`` substitution, because TS's ``args.trim() || <default phrase>`` fallback
+and the f-string template around ``AGENT_TOOL_NAME`` are not expressible that way.
+
+The produced text is asserted byte-exactly: ``AGENT_TOOL_NAME == "Agent"`` on both
+sides, so the output is identical to TS, not merely internally consistent.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.agent.constants import AGENT_TOOL_NAME
+from src.command_system import (
+    REMOTE_SAFE_COMMANDS,
+    STATUSLINE_COMMAND,
+    StatuslineCommand,
+    create_command_context,
+    get_builtin_commands,
+    get_commands,
+)
+from src.command_system.types import CommandType
+
+# The exact literal TS emits for empty args (note capital `L` in `statusLine` and the
+# trailing closing quote). Hardcoded — not built from AGENT_TOOL_NAME — so a change to
+# that constant trips test #6's cross-check rather than silently passing here.
+EXPECTED_DEFAULT = (
+    'Create an Agent with subagent_type "statusline-setup" '
+    'and the prompt "Configure my statusLine from my shell PS1 configuration"'
+)
+
+
+async def test_default_empty_args_exact_byte_match(tmp_path):
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+    result = await STATUSLINE_COMMAND.get_prompt_for_command("", ctx)
+
+    assert len(result) == 1
+    block = result[0]
+    assert block["type"] == "text"
+    text = block["text"]
+    assert text == EXPECTED_DEFAULT
+    # Boundary locks: no stray leading/trailing whitespace, prompt's closing quote
+    # is the final character (guards the f-string template edges).
+    assert text == text.strip()
+    assert text.endswith('"')
+
+
+async def test_whitespace_only_args_uses_default(tmp_path):
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+    result = await STATUSLINE_COMMAND.get_prompt_for_command("   ", ctx)
+    # strip() or default -> the whitespace-only input collapses to the default phrase.
+    assert result[0]["text"] == EXPECTED_DEFAULT
+
+
+async def test_custom_args_embedded_verbatim(tmp_path):
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+    result = await STATUSLINE_COMMAND.get_prompt_for_command("use my zsh theme", ctx)
+
+    text = result[0]["text"]
+    assert text == (
+        'Create an Agent with subagent_type "statusline-setup" '
+        'and the prompt "use my zsh theme"'
+    )
+    # The default phrase must NOT appear when the user supplied args.
+    assert "Configure my statusLine from my shell PS1 configuration" not in text
+
+
+async def test_args_trimmed_outer_internal_spacing_preserved(tmp_path):
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+    result = await STATUSLINE_COMMAND.get_prompt_for_command("  a  b  ", ctx)
+    # args.strip() == JS args.trim(): outer whitespace removed, internal run preserved.
+    assert result[0]["text"] == (
+        'Create an Agent with subagent_type "statusline-setup" and the prompt "a  b"'
+    )
+
+
+async def test_no_argument_substitution_and_no_quote_escaping(tmp_path):
+    # Faithfulness: statusline does NOT route through substitute_arguments, so a literal
+    # `$ARGUMENTS` (or `$@`) in the args is embedded verbatim, never expanded; and the
+    # nested double quotes are NOT escaped (TS embeds raw).
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+    result = await STATUSLINE_COMMAND.get_prompt_for_command('x "$ARGUMENTS" y', ctx)
+
+    text = result[0]["text"]
+    assert text == (
+        'Create an Agent with subagent_type "statusline-setup" '
+        'and the prompt "x "$ARGUMENTS" y"'
+    )
+    assert "\\" not in text  # no backslash escaping introduced
+
+
+def test_metadata_matches_ts_definition():
+    cmd = STATUSLINE_COMMAND
+    assert isinstance(cmd, StatuslineCommand)
+    assert cmd.name == "statusline"
+    assert cmd.description == "Set up OpenClaude's status line UI"
+    assert cmd.progress_message == "setting up statusLine"
+    assert cmd.command_type == CommandType.PROMPT
+    assert cmd.source == "builtin"
+    assert cmd.content_length == 0
+    assert cmd.disable_non_interactive is True
+    assert cmd.allowed_tools == [
+        AGENT_TOOL_NAME,
+        "Read(~/**)",
+        "Edit(~/.claude/settings.json)",
+    ]
+    # Cross-check: the hardcoded literal above is only correct because of this.
+    assert AGENT_TOOL_NAME == "Agent"
+
+
+def test_registered_in_builtins_and_aggregator():
+    builtin_names = [c.name for c in get_builtin_commands()]
+    assert "statusline" in builtin_names
+
+    all_names = [c.name for c in get_commands(cwd=str(Path.cwd()))]
+    assert "statusline" in all_names
+
+
+def test_remote_safe_name_now_resolves():
+    # safe_commands.py listed "statusline" as a forward-looking REMOTE_SAFE policy name;
+    # this chapter makes the name resolve to a real registered command.
+    assert "statusline" in REMOTE_SAFE_COMMANDS
+    assert "statusline" in {c.name for c in get_builtin_commands()}


### PR DESCRIPTION
## Summary
- Ports `commands/statusline.tsx` as a dynamic `prompt` command (`StatuslineCommand`, a frozen `PromptCommand` subclass that overrides `get_prompt_for_command`). The TS `args.trim() || <default phrase>` fallback and the f-string template around `AGENT_TOOL_NAME` aren't expressible through the base `$ARGUMENTS` substitution, so a subclass is used — mirroring the merged `MovedToPluginCommand` precedent.
- Output is **byte-identical** to TS (`AGENT_TOOL_NAME == "Agent"` on both sides): `Create an Agent with subagent_type "statusline-setup" and the prompt "<prompt>"`.
- Registered in `get_builtin_commands()` and re-exported from `src/command_system/__init__.py`. This makes the existing `REMOTE_SAFE_COMMANDS` `"statusline"` policy name (a forward-looking entry) resolve to a real command.
- **Known limitation (faithful to TS):** the emitted prompt names a `statusline-setup` subagent that isn't ported to the Python agent registry yet (`src/agent/agent_definitions.py` ships only general-purpose/Explore/Plan/fork), so it is runtime-inert today. TS likewise only emits naming text and relies on a separately registered agent. Porting `tools/AgentTool/built-in/statuslineSetup.ts` is a deferred follow-up.
- This chapter completes **Class A**: a triage of all 34 remaining `prompt`/`local` commands confirms `statusline` is the only clean, import-only candidate; the rest need an unported subsystem (`commit-message` → settings write-by-source + attribution-texts, `release-notes` → releaseNotes/version, `dream` → autoDream, …) or the P0-3 local-jsx bridge.

## Test plan
- [x] `tests/test_statusline.py` — 8 cases: byte-exact output (empty / whitespace / custom / internal-spacing / `$ARGUMENTS`-no-substitution + no-quote-escaping), full metadata parity, and registration (builtins + aggregator + REMOTE_SAFE name resolves). **8/8 pass.**
- [x] Full suite (`uv run --extra dev python -m pytest --ignore=tests/test_providers.py`): **6790 passed, 10 failed, 5 skipped**. All 10 failures are the pre-existing baseline, independent of this change — root-caused to `ImportError: cannot import name 'ZhipuAI'` in `src/providers/glm_provider.py:8` (6× `test_repl.py`, via `ClawcodexREPL(provider_name="glm")`) and the 4× `tests/parity/` tool-property/workspace baseline. None assert command lists/counts.
- [x] Diff scoped to exactly 4 files; unrelated `.gitignore`/`.gstack/` change deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)