### PR TITLE
commands: port model-tool exposure + skill listing (P0-4/P0-6)

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -11,7 +11,12 @@ from src.utils.startup_profiler import profile_checkpoint
 
 profile_checkpoint("command_system_imported")
 
-from .aggregator import clear_commands_cache, get_commands
+from .aggregator import (
+    clear_commands_cache,
+    get_commands,
+    get_skill_tool_commands,
+    get_slash_command_tool_skills,
+)
 from .argument_substitution import parse_argument_names, substitute_arguments
 from .builtins import (
     AUTO_FIX_COMMAND,
@@ -146,6 +151,8 @@ __all__ = [
     "make_bash_shell_executor",
     # Aggregator
     "get_commands",
+    "get_skill_tool_commands",
+    "get_slash_command_tool_skills",
     "clear_commands_cache",
     # Safe commands
     "REMOTE_SAFE_COMMANDS",

--- a/src/command_system/aggregator.py
+++ b/src/command_system/aggregator.py
@@ -8,6 +8,13 @@ to get the live, availability-filtered command set.
 Phase 1 merges builtin commands + filesystem skills (NOT plugins/workflows/dynamic
 skills — those subsystems are unported; see commands-gap-analysis.md §4.3). It reads
 builtins and skills directly (not the global registry), matching TS.
+
+Because ``get_commands`` already merges skills into the unified set, it ALSO
+provides the "skills are in the unified command set" guarantee that TS's
+bootstrap ``load_and_register_skills`` exists to provide — which is why P0-6 is
+satisfied here (Option A) without wiring that call into the execution registries.
+See ``load_and_register_skills`` and the Phase 3 plan §3 D-6 for the full
+rationale.
 """
 
 from __future__ import annotations
@@ -18,9 +25,28 @@ from pathlib import Path
 
 from .builtins import get_builtin_commands
 from .skills_integration import skill_to_prompt_command
-from .types import Command, is_command_enabled, meets_availability_requirement
+from .types import (
+    Command,
+    CommandType,
+    is_command_enabled,
+    meets_availability_requirement,
+)
 
 logger = logging.getLogger(__name__)
+
+
+# D-1a (Phase 3 / P0-4 — model-tool exposure). The Python skill loader emits a
+# *more granular* ``loaded_from`` than TS: ``user`` / ``project`` / ``managed`` /
+# ``plugin`` / ``mcp`` / ``bundled`` (``loader.py:_SOURCE_TO_LOADED_FROM``), where
+# TS tags *all* disk-skill-dir commands ``'skills'`` and only policy-managed
+# ``'managed'``. So Python's ``user`` and ``project`` are the equivalents of TS's
+# ``'skills'``. A *literal* port of ``loadedFrom === 'skills'`` would wrongly drop
+# the common-case user/project disk skills that have only an auto-derived
+# first-line description. We bridge the vocabulary HERE (inside the two views),
+# NOT in the loader — whose ``loaded_from`` other display/logic reads — so the
+# blast radius is just these functions. See
+# my-docs/get-parity-by-folder/commands-phase3-model-tool-exposure-plan.md §3 D-1a.
+SKILLS_DIR_BUCKET: frozenset[str] = frozenset({"skills", "user", "project"})
 
 
 @lru_cache(maxsize=32)
@@ -92,6 +118,110 @@ def get_commands(
     return result
 
 
+@lru_cache(maxsize=32)
+def get_skill_tool_commands(cwd: str | None = None) -> tuple[Command, ...]:
+    """ALL prompt-based commands the model may invoke.
+
+    This is the source for the model-facing "# Available Skills" system-prompt
+    listing (wired into ``build_full_system_prompt_blocks(skills=...)`` at
+    ``src/query/engine.py``). Port of ``getSkillToolCommands(cwd)``
+    (``typescript/src/commands.ts:587-605``).
+
+    Filters :func:`get_commands` to prompt commands that are model-invocable,
+    non-builtin, and either live in a skill-dir / bundled / commands_DEPRECATED
+    bucket OR carry an author-written description / ``when_to_use`` (the
+    managed/mcp/plugin escape hatch — see §2 of the plan doc). Uses the D-1a
+    :data:`SKILLS_DIR_BUCKET` bridge, not the raw TS ``'skills'`` literal.
+
+    Unlike :func:`get_slash_command_tool_skills`, this is NOT wrapped in
+    try/except (matching TS): :func:`get_commands` already swallows skill-load
+    failures, and the system-prompt assembler wraps the whole call.
+
+    cwd-memoized (the listing is stable within a session; R3 accepts staleness as
+    TS-parity). :func:`clear_commands_cache` resets THIS view's cwd cache. Note
+    the *rendered* "# Available Skills" prose is cached one layer down too —
+    ``_prompt_cache["skills"]`` (SESSION scope, in ``context_system``), cleared
+    by ``clear_context_caches()``. A full mid-session refresh of what the model
+    actually sees needs BOTH; ``clear_commands_cache`` alone is not sufficient.
+    """
+    result: list[Command] = []
+    for cmd in get_commands(cwd):
+        if cmd.command_type != CommandType.PROMPT:
+            continue
+        if getattr(cmd, "disable_model_invocation", False):
+            continue
+        if getattr(cmd, "source", "builtin") == "builtin":
+            continue
+        loaded_from = getattr(cmd, "loaded_from", "builtin")
+        in_bucket = loaded_from in SKILLS_DIR_BUCKET or loaded_from in (
+            "bundled",
+            "commands_DEPRECATED",
+        )
+        if (
+            in_bucket
+            or getattr(cmd, "has_user_specified_description", False)
+            or getattr(cmd, "when_to_use", None)
+        ):
+            result.append(cmd)
+    return tuple(result)
+
+
+@lru_cache(maxsize=32)
+def get_slash_command_tool_skills(cwd: str | None = None) -> tuple[Command, ...]:
+    """Skills-only subset used for SlashCommand-tool counts / init (NOT a tool).
+
+    Port of ``getSlashCommandToolSkills(cwd)``
+    (``typescript/src/commands.ts:610-632``). Note the deliberate TS asymmetries
+    vs :func:`get_skill_tool_commands`, preserved verbatim:
+
+    * does **not** exclude ``disable_model_invocation`` — there it is an
+      *inclusion* clause (a disabled-for-model skill still counts here);
+    * **always** requires ``has_user_specified_description or when_to_use``;
+    * the bucket adds ``'plugin'`` but omits ``'commands_DEPRECATED'``;
+    * the whole body is wrapped in try/except returning ``()`` (skills are
+      non-critical — matches the ``_load_skill_commands_cached`` house style of
+      degrading to empty on failure).
+
+    cwd-memoized; cleared by :func:`clear_commands_cache`.
+    """
+    try:
+        result: list[Command] = []
+        for cmd in get_commands(cwd):
+            if cmd.command_type != CommandType.PROMPT:
+                continue
+            if getattr(cmd, "source", "builtin") == "builtin":
+                continue
+            if not (
+                getattr(cmd, "has_user_specified_description", False)
+                or getattr(cmd, "when_to_use", None)
+            ):
+                continue
+            loaded_from = getattr(cmd, "loaded_from", "builtin")
+            in_bucket = loaded_from in SKILLS_DIR_BUCKET or loaded_from in (
+                "plugin",
+                "bundled",
+            )
+            if in_bucket or getattr(cmd, "disable_model_invocation", False):
+                result.append(cmd)
+        return tuple(result)
+    except Exception as exc:  # noqa: BLE001 — skills are non-critical (TS parity)
+        logger.debug("get_slash_command_tool_skills failed for %s: %s", cwd, exc)
+        return ()
+
+
 def clear_commands_cache() -> None:
-    """Clear the memoized skill-command cache. Port of clearCommandsCache()."""
+    """Clear all memoized command caches. Port of ``clearCommandsCache()``.
+
+    Covers the skill-load cache AND the two P0-4 model-tool views (R3: their
+    cwd-memoization is why a mid-session skill change needs this to show up).
+
+    Scope boundary: this clears only the *command-aggregation* caches in this
+    module. It does NOT touch the downstream prompt-assembly session cache
+    (``_prompt_cache["skills"]`` in ``context_system``) that holds the rendered
+    "# Available Skills" prose. Refreshing the model-facing listing mid-session
+    requires this call PLUS ``clear_context_caches()`` — kept decoupled on
+    purpose so the aggregator doesn't reach across into the prompt layer.
+    """
     _load_skill_commands_cached.cache_clear()
+    get_skill_tool_commands.cache_clear()
+    get_slash_command_tool_skills.cache_clear()

--- a/src/command_system/skills_integration.py
+++ b/src/command_system/skills_integration.py
@@ -56,6 +56,13 @@ def skill_to_prompt_command(skill: PromptSkill) -> PromptCommand:
         user_invocable=skill.user_invocable,
         loaded_from=skill.loaded_from,
         is_hidden=skill.is_hidden,
+        # R2 (Phase 3 / P0-4): propagate the loader-computed flag so the
+        # model-tool views can distinguish a real author-written description
+        # from an auto-derived first-line one. ``get_slash_command_tool_skills``
+        # *requires* this (or ``when_to_use``) to include a skill; without it
+        # the predicate could never fire for managed/MCP/plugin skills. See
+        # my-docs/get-parity-by-folder/commands-phase3-model-tool-exposure-plan.md §6 R2.
+        has_user_specified_description=skill.has_user_specified_description,
     )
 
 
@@ -81,6 +88,27 @@ def load_and_register_skills(
 ) -> list[PromptCommand]:
     """
     Load all skills and register them as commands.
+
+    .. note:: **P0-6 / why this is NOT called at bootstrap (intentional).**
+
+        The TS gap item "auto-register skills in bootstrap (call
+        ``load_and_register_skills``)" does NOT translate to a literal startup
+        call in Python, because Python split TS's single command list into three
+        surfaces (aggregator / ``CommandRegistry`` / skills-loader). The
+        aggregator (:func:`~src.command_system.aggregator.get_commands`) already
+        merges skills into the unified set, so listing/filtering/the P0-4 views
+        need no registration. The ONLY new behavior a literal call would add is
+        making skills resolvable via ``CommandRegistry.get(name)`` — and that is
+        a *regression*: it reroutes REPL ``/myskill arg`` execution onto
+        :meth:`PromptCommand.get_prompt_for_command` (bare arg-substitution),
+        dropping the base-dir header, ``${CLAUDE_SKILL_DIR}`` /
+        ``${CLAUDE_SESSION_ID}`` substitution, the gated shell-exec pass, and the
+        bundled-skill callable that ``_run_markdown_skill`` provides. So under
+        Phase 3 **Option A** this function stays available (tests, future
+        unification) but is deliberately left out of the REPL/TUI bootstrap.
+        Unifying execution correctly (fix the renderer first, then register) is
+        Phase 3.5 **Option B**. See
+        my-docs/get-parity-by-folder/commands-phase3-model-tool-exposure-plan.md §3 D-6.
 
     Args:
         project_root: Optional project root directory

--- a/src/query/engine.py
+++ b/src/query/engine.py
@@ -154,6 +154,16 @@ class QueryEngine:
             #    session blocks…, ⟨ephemeral⟩,
             #    request blocks…, ⟨ephemeral⟩,
             #    git-status block (uncached)]
+            # P0-4 (Phase 3 — model-tool exposure): feed the model the
+            # "# Available Skills" listing. ``get_skill_tool_commands`` is the
+            # filtered view over the unified command set (builtins + skills);
+            # passing it as ``skills=`` is what finally emits the section that
+            # the ``Skill`` tool's prompt already promises. Without this the
+            # parameter defaults to None and the section is never built. Local
+            # import keeps the command_system package off the module-load path.
+            # See my-docs/get-parity-by-folder/commands-phase3-model-tool-exposure-plan.md §3 D-2.
+            from ..command_system import get_skill_tool_commands
+
             blocks = build_full_system_prompt_blocks(
                 cwd=cwd,
                 append_system_prompt=self._config.append_system_prompt,
@@ -170,6 +180,7 @@ class QueryEngine:
                 # privacy guarantee at line 91).
                 provider=self._config.provider,
                 mcp_servers=self._config.mcp_servers,
+                skills=get_skill_tool_commands(cwd),
             )
             system_prompt = append_system_context_blocks(
                 blocks, parts.system_context,

--- a/tests/bridge/test_repl_bridge.py
+++ b/tests/bridge/test_repl_bridge.py
@@ -1733,18 +1733,30 @@ async def test_perpetual_pointer_updates_when_work_spawns_session(
     assert initial is not None
     assert initial.session_id == 'cse_test'
 
-    # Wait for the work item to be processed.
-    for _ in range(50):
+    # Wait for the work item to be processed AND the pointer rewrite to
+    # land. The spawn (which populates ``spawner.handles`` in
+    # ``_process_work``) and the pointer write are SEPARATE async steps —
+    # ``_update_pointer`` runs after the spawn and off-loads the file write
+    # to a worker thread via ``run_in_executor``. So breaking the poll on
+    # ``spawner.handles`` alone races ahead of the executor-thread pointer
+    # write under load, intermittently reading the stale bootstrap pointer.
+    # Poll the real post-condition (the pointer reflecting the work's id).
+    after_spawn = None
+    for _ in range(200):
         await asyncio.sleep(0.01)
-        if spawner.handles:
+        after_spawn = read_pointer(
+            params.dir, machine_name=params.machine_name,
+        )
+        if (
+            spawner.handles
+            and after_spawn is not None
+            and after_spawn.session_id == 'cse_from_work'
+        ):
             break
     assert spawner.handles
 
     # Pointer should now reflect the work's session_id, not the
     # bootstrap one.
-    after_spawn = read_pointer(
-        params.dir, machine_name=params.machine_name,
-    )
     assert after_spawn is not None
     assert after_spawn.session_id == 'cse_from_work'
     # ``created_at_ms`` is preserved across the update.
@@ -1778,14 +1790,23 @@ async def test_perpetual_pointer_clears_session_when_session_completes(
         params, api_client=api, spawner=spawner,
     )
     assert handle is not None
-    for _ in range(50):
+    # Same two-step race as
+    # test_perpetual_pointer_updates_when_work_spawns_session: the spawn
+    # populates spawner.handles, but the pointer write lands later via
+    # _update_pointer's run_in_executor hop. Poll the pointer itself.
+    mid = None
+    for _ in range(200):
         await asyncio.sleep(0.01)
-        if spawner.handles:
+        mid = read_pointer(
+            params.dir, machine_name=params.machine_name,
+        )
+        if (
+            spawner.handles
+            and mid is not None
+            and mid.session_id == 'cse_short_lived'
+        ):
             break
     # Pointer has the active session id at this point.
-    mid = read_pointer(
-        params.dir, machine_name=params.machine_name,
-    )
     assert mid is not None
     assert mid.session_id == 'cse_short_lived'
 

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -13,7 +13,13 @@ import pytest
 
 import src.skills.loader as skills_loader
 from src.command_system import aggregator
-from src.command_system.aggregator import clear_commands_cache, get_commands
+from src.command_system.aggregator import (
+    clear_commands_cache,
+    get_commands,
+    get_skill_tool_commands,
+    get_slash_command_tool_skills,
+)
+from src.command_system.skills_integration import skill_to_prompt_command
 from src.command_system.types import CommandAvailability, PromptCommand
 from src.skills.model import Skill
 
@@ -118,3 +124,199 @@ def test_skill_load_failure_is_resilient(monkeypatch, tmp_path):
 
     # A crashing skill loader must not take down command listing; builtins survive.
     assert "help" in {c.name for c in get_commands(str(tmp_path))}
+
+
+# ---------------------------------------------------------------------------
+# P0-4 model-tool exposure views (Phase 3): get_skill_tool_commands /
+# get_slash_command_tool_skills — typescript/src/commands.ts:587-632.
+#
+# Strategy: drive the real get_commands pipeline by patching the same two seams
+# the tests above use (get_builtin_commands + skills_loader.get_all_skills), so
+# Skill objects round-trip through skill_to_prompt_command (this also exercises
+# the R2 has_user_specified_description propagation end-to-end). The autouse
+# _clear_cmd_cache fixture clears the view caches too (clear_commands_cache now
+# resets all three lru_caches), isolating each test.
+# ---------------------------------------------------------------------------
+
+
+def _skill(
+    name: str,
+    *,
+    loaded_from: str = "skills",
+    disable_model_invocation: bool = False,
+    has_user_specified_description: bool = False,
+    when_to_use=None,
+    description: str = "a description",
+) -> Skill:
+    return Skill(
+        name=name,
+        description=description,
+        loaded_from=loaded_from,
+        disable_model_invocation=disable_model_invocation,
+        has_user_specified_description=has_user_specified_description,
+        when_to_use=when_to_use,
+    )
+
+
+def _install(monkeypatch, *, builtins=(), skills=()):
+    """Point the aggregator at a controlled builtin + skill set."""
+    monkeypatch.setattr(aggregator, "get_builtin_commands", lambda: list(builtins))
+    monkeypatch.setattr(skills_loader, "get_all_skills", lambda **kw: list(skills))
+
+
+# -- get_skill_tool_commands -------------------------------------------------
+
+
+def test_skill_tool_commands_includes_disk_and_bundled(monkeypatch, tmp_path):
+    _install(
+        monkeypatch,
+        skills=[_skill("disk", loaded_from="skills"), _skill("bun", loaded_from="bundled")],
+    )
+    names = {c.name for c in get_skill_tool_commands(str(tmp_path))}
+    assert {"disk", "bun"} <= names
+
+
+def test_skill_tool_commands_excludes_builtins(monkeypatch, tmp_path):
+    builtin = PromptCommand(name="init", description="d", source="builtin")
+    _install(monkeypatch, builtins=[builtin], skills=[_skill("real", loaded_from="skills")])
+    names = {c.name for c in get_skill_tool_commands(str(tmp_path))}
+    assert "init" not in names
+    assert "real" in names
+
+
+def test_skill_tool_commands_excludes_disable_model_invocation(monkeypatch, tmp_path):
+    # Security boundary: a skill the author marked non-model-invocable must never
+    # be advertised to the model (mirrors /permissions, which is also excluded by
+    # the command_type==PROMPT gate as a non-prompt command).
+    _install(
+        monkeypatch,
+        skills=[_skill("secret", loaded_from="skills", disable_model_invocation=True)],
+    )
+    names = {c.name for c in get_skill_tool_commands(str(tmp_path))}
+    assert "secret" not in names
+
+
+def test_skill_tool_commands_d1a_user_project_included(monkeypatch, tmp_path):
+    # D-1a regression guard: a user/project disk skill with only an auto-derived
+    # description (has_user_specified_description=False, when_to_use=None) MUST be
+    # included. A literal port of TS `loadedFrom==='skills'` would wrongly drop it.
+    _install(
+        monkeypatch,
+        skills=[
+            _skill("u", loaded_from="user"),
+            _skill("p", loaded_from="project"),
+        ],
+    )
+    names = {c.name for c in get_skill_tool_commands(str(tmp_path))}
+    assert {"u", "p"} <= names
+
+
+def test_skill_tool_commands_managed_without_metadata_excluded(monkeypatch, tmp_path):
+    # The flip side of D-1a: 'managed' is NOT in the auto-include bucket, so a
+    # managed skill with no author description / when_to_use is withheld.
+    _install(monkeypatch, skills=[_skill("m", loaded_from="managed")])
+    names = {c.name for c in get_skill_tool_commands(str(tmp_path))}
+    assert "m" not in names
+
+
+def test_skill_tool_commands_managed_with_description_included(monkeypatch, tmp_path):
+    # ...but the escape hatch fires the moment it has an author-written description.
+    _install(
+        monkeypatch,
+        skills=[_skill("m", loaded_from="managed", has_user_specified_description=True)],
+    )
+    names = {c.name for c in get_skill_tool_commands(str(tmp_path))}
+    assert "m" in names
+
+
+# -- get_slash_command_tool_skills -------------------------------------------
+
+
+def test_slash_skills_requires_description_or_when_to_use(monkeypatch, tmp_path):
+    _install(
+        monkeypatch,
+        skills=[
+            _skill("bare", loaded_from="skills"),  # no desc flag, no when_to_use
+            _skill("described", loaded_from="skills", has_user_specified_description=True),
+        ],
+    )
+    names = {c.name for c in get_slash_command_tool_skills(str(tmp_path))}
+    assert "bare" not in names
+    assert "described" in names
+
+
+def test_slash_skills_user_project_with_when_to_use_included(monkeypatch, tmp_path):
+    _install(
+        monkeypatch,
+        skills=[_skill("u", loaded_from="user", when_to_use="when editing")],
+    )
+    names = {c.name for c in get_slash_command_tool_skills(str(tmp_path))}
+    assert "u" in names
+
+
+def test_slash_skills_includes_disable_model_invocation(monkeypatch, tmp_path):
+    # Deliberate TS asymmetry: here disable_model_invocation is an *inclusion*
+    # clause (not an exclusion). With a description present, a managed skill that
+    # is NOT in the bucket still counts via disable_model_invocation=True.
+    _install(
+        monkeypatch,
+        skills=[
+            _skill(
+                "dmi",
+                loaded_from="managed",
+                disable_model_invocation=True,
+                has_user_specified_description=True,
+            )
+        ],
+    )
+    names = {c.name for c in get_slash_command_tool_skills(str(tmp_path))}
+    assert "dmi" in names
+
+
+def test_slash_skills_excludes_builtins(monkeypatch, tmp_path):
+    builtin = PromptCommand(
+        name="review", description="d", source="builtin",
+        has_user_specified_description=True,
+    )
+    _install(monkeypatch, builtins=[builtin], skills=[])
+    names = {c.name for c in get_slash_command_tool_skills(str(tmp_path))}
+    assert "review" not in names
+
+
+def test_slash_skills_returns_empty_on_failure(monkeypatch, tmp_path):
+    # The whole body is wrapped in try/except -> () (TS parity; skills non-critical).
+    def boom(cwd=None, **kw):
+        raise RuntimeError("aggregator exploded")
+
+    monkeypatch.setattr(aggregator, "get_commands", boom)
+    assert get_slash_command_tool_skills(str(tmp_path)) == ()
+
+
+# -- R2 propagation + caching ------------------------------------------------
+
+
+def test_has_user_specified_description_propagates():
+    # R2: skill_to_prompt_command must carry the loader-computed flag through so
+    # the views' description clause can fire.
+    on = skill_to_prompt_command(_skill("x", has_user_specified_description=True))
+    off = skill_to_prompt_command(_skill("y", has_user_specified_description=False))
+    assert on.has_user_specified_description is True
+    assert off.has_user_specified_description is False
+
+
+def test_views_are_memoized_and_cleared(monkeypatch, tmp_path):
+    calls = {"n": 0}
+
+    def counting(cwd=None, **kw):
+        calls["n"] += 1
+        return []
+
+    monkeypatch.setattr(aggregator, "get_commands", counting)
+    cwd = str(tmp_path)
+    get_skill_tool_commands(cwd)
+    get_skill_tool_commands(cwd)
+    assert calls["n"] == 1  # second call served from the view's cwd cache
+
+    clear_commands_cache()
+    get_skill_tool_commands(cwd)
+    assert calls["n"] == 2  # clear_commands_cache resets the view cache too

--- a/tests/test_prompt_assembly.py
+++ b/tests/test_prompt_assembly.py
@@ -211,6 +211,59 @@ class TestSystemPromptBlocks(unittest.TestCase):
         self.assertNotIn("cache_control", blocks[0])
 
 
+class TestSkillSectionWiring(unittest.TestCase):
+    """P0-4 wiring: ``skills=`` → the "# Available Skills" system-prompt block.
+
+    The model-facing skill listing was previously dead code — nothing ever
+    passed ``skills=`` into ``build_full_system_prompt_blocks``, so
+    ``_build_skill_section`` always short-circuited to None. Phase 3 wires
+    ``get_skill_tool_commands(cwd)`` in at ``src/query/engine.py``; these tests
+    pin the rendering contract that wiring depends on: a non-empty list emits a
+    block carrying each skill's name + description, and an empty/None list emits
+    no such block (plan §5 — port of TS ``getSkillToolCommands`` feeding the
+    system prompt). ``use_cache=False`` so the section rebuilds from the passed
+    list rather than the SESSION-scoped ``skills`` cache key.
+    """
+
+    def setUp(self):
+        from src.context_system.prompt_assembly import _get_session_start_date_iso
+        _get_session_start_date_iso.cache_clear()
+        clear_context_caches()
+
+    @staticmethod
+    def _skill_block(blocks):
+        hits = [b for b in blocks if "# Available Skills" in b.get("text", "")]
+        return hits[0]["text"] if hits else None
+
+    def test_skills_render_into_available_skills_block(self):
+        # Drive the same attribute-read path (.name/.description) the real
+        # view feeds, using PromptCommand so the test exercises the production
+        # type rather than a bespoke stub.
+        from src.command_system.types import PromptCommand
+        from src.context_system.prompt_assembly import build_full_system_prompt_blocks
+        skills = [
+            PromptCommand(name="alpha", description="does alpha things"),
+            PromptCommand(name="beta", description="does beta things"),
+        ]
+        blocks = build_full_system_prompt_blocks(cwd="/tmp", skills=skills, use_cache=False)
+        text = self._skill_block(blocks)
+        self.assertIsNotNone(text, "Expected a '# Available Skills' block")
+        self.assertIn("alpha", text)
+        self.assertIn("does alpha things", text)
+        self.assertIn("beta", text)
+        self.assertIn("does beta things", text)
+
+    def test_empty_skills_emits_no_section(self):
+        from src.context_system.prompt_assembly import build_full_system_prompt_blocks
+        blocks = build_full_system_prompt_blocks(cwd="/tmp", skills=[], use_cache=False)
+        self.assertIsNone(self._skill_block(blocks))
+
+    def test_none_skills_emits_no_section(self):
+        from src.context_system.prompt_assembly import build_full_system_prompt_blocks
+        blocks = build_full_system_prompt_blocks(cwd="/tmp", skills=None, use_cache=False)
+        self.assertIsNone(self._skill_block(blocks))
+
+
 class TestCacheTtlSelector(unittest.TestCase):
     """WI-2.2: ``cache_control`` ttl picks 5m vs 1h via ``should_1h_cache_ttl``."""
 

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -445,6 +445,99 @@ class TestEngineProducesCacheableSystemBlocks(unittest.TestCase):
             "Engine must emit exactly one boundary-marker block",
         )
 
+    def test_engine_wires_skill_listing_into_system_prompt(self):
+        """P0-4 end-to-end: a discoverable project skill reaches the model.
+
+        The unit tests in ``tests/test_aggregator.py`` prove the two filtered
+        views compute the right set, and ``tests/test_prompt_assembly.py``
+        proves ``_build_skill_section`` renders a listing. But neither
+        exercises the actual engine wiring at ``engine.py`` —
+        ``skills=get_skill_tool_commands(cwd)``. A regression that drops the
+        ``skills=`` kwarg, threads the wrong ``cwd``, or calls the slash-command
+        view instead would pass every one of those unit tests yet silently stop
+        advertising skills to the model.
+
+        This plants a real project skill under the engine's ``cwd``, drives one
+        turn, and asserts the assembled system-prompt block list contains the
+        ``# Available Skills`` listing with the fixture skill — closing the gap.
+        """
+        from src.command_system.aggregator import clear_commands_cache
+        from src.context_system.prompt_assembly import get_system_prompt_cache
+        from src.providers.anthropic_provider import AnthropicProvider
+        from src.skills.create import create_skill
+
+        # Plant a project skill discoverable from the engine's cwd:
+        # <cwd>/.claude/skills/<name>/SKILL.md → loaded_from="project", which
+        # is in SKILLS_DIR_BUCKET so get_skill_tool_commands includes it.
+        create_skill(
+            directory=self.workspace / ".claude" / "skills",
+            name="wiringdemo",
+            description="a wiring demo skill",
+            body="Hello from the wiring demo.",
+        )
+        # Refresh BOTH cache layers (see clear_commands_cache's docstring): the
+        # command-aggregation cwd cache AND the prompt-assembly session cache
+        # that holds the rendered "# Available Skills" prose. The latter is
+        # SESSION-scoped and keyed only by section-id (NOT cwd), so an earlier
+        # cold-start engine test in this run would otherwise serve its own
+        # (wiringdemo-less) listing here. Clean up after ourselves so a later
+        # test isn't served OUR wiringdemo listing.
+        skill_cache = get_system_prompt_cache()
+        clear_commands_cache()
+        skill_cache.invalidate("skills")
+        self.addCleanup(skill_cache.invalidate, "skills")
+        self.addCleanup(clear_commands_cache)
+
+        provider = MagicMock(spec=AnthropicProvider)
+        provider.model = "claude-sonnet-4-20250514"
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="ok",
+            model="claude-sonnet-4-20250514",
+            usage={
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            },
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        engine = self._make_engine_no_system_prompt(provider)
+
+        async def run():
+            async for _ in engine.submit_message("Hello"):
+                pass
+
+        _run(run())
+
+        self.assertTrue(provider.chat.called, "engine must invoke provider.chat")
+        system_arg = provider.chat.call_args.kwargs.get("system")
+        self.assertIsInstance(
+            system_arg, list,
+            f"Expected block-list shape, got {type(system_arg).__name__}",
+        )
+        skill_blocks = [
+            b for b in system_arg
+            if isinstance(b.get("text"), str) and "# Available Skills" in b["text"]
+        ]
+        self.assertEqual(
+            len(skill_blocks), 1,
+            "engine must emit exactly one '# Available Skills' block when a "
+            "project skill is discoverable — skills=get_skill_tool_commands(cwd) "
+            "must be threaded through _build_system_prompt_parts",
+        )
+        listing = skill_blocks[0]["text"]
+        self.assertIn(
+            "wiringdemo", listing,
+            "the fixture skill name must appear in the model-facing listing",
+        )
+        self.assertIn(
+            "a wiring demo skill", listing,
+            "the fixture skill description must appear in the listing",
+        )
+
     def test_engine_threads_mcp_servers_to_block_assembly(self):
         """Critic Phase 2 M1: engine MUST forward mcp_servers to the block builder.
 


### PR DESCRIPTION
## Summary

Ports **P0-4 (model-tool exposure)** and the **P0-6 (skill auto-registration)** documentation note from `typescript/src/commands.ts` — the layer that finally surfaces filesystem skills to the model through the existing `Skill` tool.

- **Two filtered views** over the unified `get_commands(cwd)` aggregator:
  - `get_skill_tool_commands(cwd)` — source for the model-facing `# Available Skills` system-prompt listing (`getSkillToolCommands`, commands.ts:587-605). NOT wrapped in try/except (parity).
  - `get_slash_command_tool_skills(cwd)` — counts/init only, NOT a separate tool (`getSlashCommandToolSkills`, commands.ts:610-632). Preserves the deliberate TS asymmetries verbatim: `disable_model_invocation` is an *inclusion* clause here, always requires `has_user_specified_description or when_to_use`, bucket adds `'plugin'` and omits `'commands_DEPRECATED'`, whole body wrapped in try/except → `()`.
- **D-1a vocabulary bridge** (`SKILLS_DIR_BUCKET = {'skills','user','project'}`): Python's loader emits a more granular `loaded_from` than TS's flat `'skills'`. The bridge lives in the two views (not the loader, whose `loaded_from` other display logic reads), so a literal port of `loadedFrom === 'skills'` doesn't drop common-case user/project disk skills.
- **R2 fix**: `skill_to_prompt_command` now propagates `has_user_specified_description` (was dropped, defaulting `False`), so the views' description clause can fire.
- **Engine wiring**: cold-start prompt assembly passes `skills=get_skill_tool_commands(cwd)` into `build_full_system_prompt_blocks` — without this the parameter defaults to `None` and the section the `Skill` tool already promises is never built.
- **P0-6 Option A (doc-only)**: the aggregator already merges skills into the unified set, so no registry bootstrap is wired — a literal `load_and_register_skills()` call would regress REPL skill execution (reroutes to the lossy `PromptCommand.get_prompt_for_command`). Documented as a `.. note::` with the Phase 3.5 follow-up scope.
- `clear_commands_cache` now clears all three caches; docstrings scope the claim and cross-reference the separate prompt-assembly session cache (`_prompt_cache["skills"]`, cleared by `clear_context_caches()`) rather than coupling the aggregator to `context_system`.

## Tests

- **+17 new tests**: 13 aggregator-view (`tests/test_aggregator.py`), 3 prompt-assembly wiring (`tests/test_prompt_assembly.py`), 1 engine end-to-end (`tests/test_query_engine.py`) that plants a real project skill, drives a turn, and asserts the `# Available Skills` block reaches the provider. Verified non-vacuous (fails when the `skills=` kwarg is dropped).
- **2 bridge pointer-race de-flakes** (`tests/bridge/test_repl_bridge.py`): poll the real post-condition (the written pointer value) instead of `spawner.handles` then an immediate read — the pointer lands later via `_update_pointer`'s `run_in_executor` hop.

## Test plan

- [x] `tests/test_aggregator.py tests/test_prompt_assembly.py tests/test_query_engine.py tests/bridge/test_repl_bridge.py` → 125 passed
- [x] Full suite git-stash A/B (`--continue-on-collection-errors`): baseline 6820 passed / 12 failed / 1 error vs. with-changes 6837 passed / 12 failed / 1 error — **failing sets byte-identical** (the 12 failures + 1 error are pre-existing environmental breakage: `zhipuai` ImportError in test_providers/test_repl, sandbox/PATH in parity/mcp). Zero new regressions; +17 = the new tests.
- [x] Principal-engineer critic review: **APPROVE** (independently re-verified the engine-test non-vacuity, the docstring fix, and the bridge race fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)