### PR TITLE
commands: port /output-style deprecation notice (Class A)

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -73,6 +73,7 @@ from .skills_integration import (
     skill_to_prompt_command,
 )
 from .permissions_command import PERMISSIONS_COMMAND, PermissionsCommand
+from .output_style_command import OUTPUT_STYLE_COMMAND, OutputStyleCommand
 from .types import (
     Command,
     CommandAvailability,
@@ -144,6 +145,8 @@ __all__ = [
     "StatuslineCommand",
     "PERMISSIONS_COMMAND",
     "PermissionsCommand",
+    "OUTPUT_STYLE_COMMAND",
+    "OutputStyleCommand",
     "get_builtin_commands",
     "register_builtin_commands",
     # Moved-to-plugin factory + shell-at-prompt-build

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -23,6 +23,7 @@ from ..history import HistoryLog
 from ..providers.base import BaseProvider
 from .engine import CommandContext, CommandResult, LocalCommandResult
 from .registry import CommandRegistry, get_command_registry, list_commands
+from .output_style_command import OUTPUT_STYLE_COMMAND
 from .permissions_command import PERMISSIONS_COMMAND
 from .security_review import SECURITY_REVIEW_COMMAND
 from .statusline import STATUSLINE_COMMAND
@@ -1230,6 +1231,7 @@ def get_builtin_commands() -> list[Command]:
         SECURITY_REVIEW_COMMAND,
         STATUSLINE_COMMAND,
         PERMISSIONS_COMMAND,
+        OUTPUT_STYLE_COMMAND,
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)

--- a/src/command_system/output_style_command.py
+++ b/src/command_system/output_style_command.py
@@ -1,0 +1,52 @@
+"""output-style — deprecated ``/output-style`` command (port of TS local-jsx).
+
+The TypeScript command (``typescript/src/commands/output-style/``) is a
+``local-jsx`` command that renders nothing interactive: its ``call`` immediately
+invokes ``onDone(<deprecation notice>, { display: 'system' })``. It exists only
+to tell users the feature moved to ``/config``.
+
+Ported as an :class:`InteractiveCommand` because ``local-jsx`` maps onto
+``CommandType.INTERACTIVE`` (same remote-safety blocking by type). Unlike the
+``/permissions`` exemplar it never touches ``context.ui`` — :meth:`run` returns
+the deprecation :class:`InteractiveOutcome` directly, so it behaves identically
+on every surface (REPL, Textual, and ``NullUIHost`` headless).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .types import (
+    CommandContext,
+    InteractiveCommand,
+    InteractiveOutcome,
+)
+
+# Verbatim from typescript/src/commands/output-style/output-style.tsx.
+_DEPRECATION_NOTICE = (
+    "/output-style has been deprecated. Use /config to change your output "
+    "style, or set it in your settings file. Changes take effect on the next "
+    "session."
+)
+
+
+@dataclass(frozen=True)
+class OutputStyleCommand(InteractiveCommand):
+    """Emit the deprecation notice and nothing else. Frozen + no new fields
+    (the ``PermissionsCommand`` pattern); behavior lives entirely in
+    :meth:`run`."""
+
+    async def run(self, args: str, context: CommandContext) -> InteractiveOutcome:
+        return InteractiveOutcome(
+            message=_DEPRECATION_NOTICE,
+            display="system",
+        )
+
+
+OUTPUT_STYLE_COMMAND = OutputStyleCommand(
+    name="output-style",
+    description="Deprecated: use /config to change output style",
+    is_hidden=True,
+)
+
+
+__all__ = ["OUTPUT_STYLE_COMMAND", "OutputStyleCommand"]

--- a/tests/test_output_style_command.py
+++ b/tests/test_output_style_command.py
@@ -1,0 +1,162 @@
+"""Tests for the ``/output-style`` deprecation command (Class A port).
+
+Ports ``typescript/src/commands/output-style/`` — a ``local-jsx`` command that
+renders nothing interactive and just emits a deprecation notice via
+``onDone(..., { display: 'system' })``. The Python port is an
+:class:`InteractiveCommand` (the ``local-jsx`` analogue, blocked remotely by
+type) whose :meth:`run` returns the notice *without* touching ``context.ui``.
+
+The keystone difference from the ``/permissions`` exemplar: because ``run`` never
+calls ``ui.select``, the command is **surface-independent** — it produces the
+same text on the REPL, the Textual TUI, and the headless ``NullUIHost`` (SDK)
+surface where ``select`` would raise. The engine test on a null surface is what
+pins that guarantee.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.command_system import (
+    OUTPUT_STYLE_COMMAND,
+    OutputStyleCommand,
+    create_command_context,
+    get_builtin_commands,
+    get_commands,
+    is_bridge_safe_command,
+)
+from src.command_system.engine import CommandEngine
+from src.command_system.registry import CommandRegistry
+from src.command_system.types import CommandType, InteractiveOutcome
+
+# Verbatim from typescript/src/commands/output-style/output-style.tsx.
+_EXPECTED = (
+    "/output-style has been deprecated. Use /config to change your output "
+    "style, or set it in your settings file. Changes take effect on the next "
+    "session."
+)
+
+
+class _RecordingUIHost:
+    """A wired UI surface that records calls — used to prove the command
+    never touches it (no ``select`` / ``display``)."""
+
+    def __init__(self) -> None:
+        self.select_calls: list[tuple] = []
+        self.display_calls: list[tuple] = []
+
+    async def select(self, title, options, *, current=None):  # pragma: no cover
+        self.select_calls.append((title, options, current))
+        return None
+
+    async def display(self, title, body):  # pragma: no cover
+        self.display_calls.append((title, body))
+
+
+def _ctx(tmp_path: Path, ui=None):
+    return create_command_context(
+        workspace_root=tmp_path, cwd=tmp_path, ui=ui
+    )
+
+
+def _registry_with(*commands) -> CommandRegistry:
+    reg = CommandRegistry()
+    for c in commands:
+        reg.register(c)
+    return reg
+
+
+# --------------------------------------------------------------------------- #
+# A. Metadata + registration
+# --------------------------------------------------------------------------- #
+def test_output_style_registered_in_builtins_and_aggregator():
+    # Hidden commands are NOT filtered by the aggregator (only availability /
+    # is_enabled are), so it surfaces in get_commands like any other builtin.
+    assert "output-style" in {c.name for c in get_builtin_commands()}
+    assert "output-style" in {c.name for c in get_commands(cwd=str(Path.cwd()))}
+
+
+def test_output_style_metadata_mirrors_ts():
+    assert isinstance(OUTPUT_STYLE_COMMAND, OutputStyleCommand)
+    assert OUTPUT_STYLE_COMMAND.name == "output-style"
+    assert OUTPUT_STYLE_COMMAND.description == (
+        "Deprecated: use /config to change output style"
+    )
+    # local-jsx -> INTERACTIVE (so the remote-safety gate blocks it by type).
+    assert OUTPUT_STYLE_COMMAND.command_type == CommandType.INTERACTIVE
+    # TS sets only type/name/description/isHidden; everything else defaults.
+    assert OUTPUT_STYLE_COMMAND.is_hidden is True
+    assert OUTPUT_STYLE_COMMAND.disable_model_invocation is False
+    assert OUTPUT_STYLE_COMMAND.user_invocable is True
+
+
+# --------------------------------------------------------------------------- #
+# B. run() — surface-independent, never touches ctx.ui
+# --------------------------------------------------------------------------- #
+async def test_run_returns_deprecation_notice_as_system(tmp_path):
+    ui = _RecordingUIHost()
+    outcome = await OUTPUT_STYLE_COMMAND.run("", _ctx(tmp_path, ui))
+
+    assert isinstance(outcome, InteractiveOutcome)
+    assert outcome.message == _EXPECTED
+    assert outcome.display == "system"
+    assert outcome.should_query is False
+    # Crucially: it rendered nothing interactive (no select / no display).
+    assert ui.select_calls == []
+    assert ui.display_calls == []
+
+
+async def test_run_works_with_no_ui_wired(tmp_path):
+    # No UI on the context at all -> still fine, because run() never reaches
+    # for ctx.ui. This is the SDK / headless surface.
+    outcome = await OUTPUT_STYLE_COMMAND.run("", _ctx(tmp_path, ui=None))
+    assert outcome.message == _EXPECTED
+    assert outcome.display == "system"
+
+
+async def test_run_ignores_arguments(tmp_path):
+    # TS ``call(onDone)`` takes no args; passing some must not change behavior.
+    outcome = await OUTPUT_STYLE_COMMAND.run("anything here", _ctx(tmp_path))
+    assert outcome.message == _EXPECTED
+    assert outcome.display == "system"
+
+
+# --------------------------------------------------------------------------- #
+# C. Engine INTERACTIVE path — reachable + correct on a NULL surface
+# --------------------------------------------------------------------------- #
+async def test_engine_routes_to_text_result_on_null_surface(tmp_path):
+    # Unlike /permissions (which calls ui.select and so ERRORS when the engine
+    # substitutes NullUIHost), output-style yields a clean text result with no
+    # UI wired — proving the deprecation reaches users on every surface.
+    reg = _registry_with(OUTPUT_STYLE_COMMAND)
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+    assert ctx.ui is None  # nothing wired; engine will substitute NullUIHost
+    eng = CommandEngine(registry=reg, workspace_root=tmp_path, context=ctx)
+
+    result = await eng.execute("/output-style")
+
+    assert result.success is True
+    assert result.result_type == "text"
+    assert result.text == _EXPECTED
+    assert result.display == "system"
+
+
+# --------------------------------------------------------------------------- #
+# D. Bridge-safety BY TYPE + TUI dispatch fall-through
+# --------------------------------------------------------------------------- #
+def test_output_style_blocked_from_remote_by_type():
+    # INTERACTIVE commands are never bridge-safe (mirrors TS, where local-jsx is
+    # always remote-blocked) — even though this one renders no UI.
+    assert is_bridge_safe_command(OUTPUT_STYLE_COMMAND) is False
+
+
+def test_dispatch_local_command_falls_through_for_output_style():
+    # The TUI's direct-dispatch table must NOT claim /output-style; it has to
+    # fall through to the async registry path where the INTERACTIVE arm lives.
+    from src.tui.commands import dispatch_local_command
+
+    res = dispatch_local_command(
+        "/output-style", session=None, workspace_root=Path("."), tool_registry=None
+    )
+    assert res.handled is False


### PR DESCRIPTION
## Summary
- Ports `typescript/src/commands/output-style/` to Python. The TS command is a `local-jsx` that renders nothing interactive — it just emits a deprecation notice steering users to `/config`.
- Modeled as an `InteractiveCommand` (the established `local-jsx` analogue: routed to the engine's INTERACTIVE arm and blocked from remote **by type**, matching TS where `local-jsx` is always remote-blocked). Its `run()` returns the notice **without touching `context.ui`**, so the command is surface-independent and works on the headless `NullUIHost` (SDK) surface where `select` would raise.
- Registered in `get_builtin_commands()` and exported from `command_system.__init__`, consistent with `PERMISSIONS_COMMAND` / `STATUSLINE_COMMAND`.

Faithful-parity notes: only the fields TS sets are set (`name`, `description`, `is_hidden=True`); the deprecation string is byte-for-byte identical to the TS literal; no `disable_model_invocation` (TS does not set it).

## Test plan
- [x] 8 new tests in `tests/test_output_style_command.py` pin: builtin+aggregator registration, metadata mirrors TS, the byte-for-byte notice with `display="system"`, that `run()` never calls `ui.select`/`display`, the engine null-surface → clean text path, remote-block-by-type, and TUI dispatch fall-through.
- [x] Related command_system suites green (77 passed).
- [x] Full-suite regression unchanged vs. baseline: +8 new passing tests (6845→6853), same 12 pre-existing failures + 1 error (zhipuai ImportError, parity sandbox, mcp PATH — all unrelated).
- [x] Critic review: APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)