### PR TITLE
fix: widen GLMProvider import exception to catch ImportError (zhipuai<2.0)

### DIFF
--- a/src/providers/glm_provider.py
+++ b/src/providers/glm_provider.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 
 try:
     from zhipuai import ZhipuAI  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover
+except ImportError:  # catches both ModuleNotFoundError and bare ImportError (e.g. zhipuai<2.0 where ZhipuAI symbol moved)
     ZhipuAI = None
 
 from .openai_compatible import OpenAICompatibleProvider


### PR DESCRIPTION
## Fix: widen GLMProvider import exception to catch ImportError

### Problem
When  is installed, `from zhipuai import ZhipuAI` raises a bare `ImportError` (not `ModuleNotFoundError`) because the `ZhipuAI` symbol was moved across major versions. The narrow `except ModuleNotFoundError` clause doesn't catch this, causing `ClawcodexREPL(provider_name='glm')` to crash at import time.

### Fix
Widen the exception clause from `ModuleNotFoundError` to `ImportError` (its superclass), which catches both:
- `ModuleNotFoundError` — zhipuai not installed
- `ImportError` — zhipuai installed but `ZhipuAI` symbol not found (e.g. zhipuai<2.0)

Fixes #166.

### Verification
`python3 -m py_compile src/providers/glm_provider.py` ✅

### Diff
```diff
-    except ModuleNotFoundError:  # pragma: no cover
+    except ImportError:  # catches both ModuleNotFoundError and bare ImportError (e.g. zhipuai<2.0 where ZhipuAI symbol moved)
```