### PR TITLE
commands: add prompt_text UIHost primitive (Phase 4 P1)

### DIFF
--- a/src/command_system/types.py
+++ b/src/command_system/types.py
@@ -288,10 +288,12 @@ class UIHost(Protocol):
     ``select``; ``display`` no-ops). Mirrors the TS pattern of injecting host
     callbacks into the command context.
 
-    The slice ships the two primitives every in-scope Class-B command needs:
-    a single ``select`` plus read-only ``display``. Multi-step primitives
-    (``confirm`` / ``text``) land with their first consumer in a later
-    chapter — the port grows by adding a method here and one line per adapter.
+    The slice ships the primitives in-scope Class-B commands need:
+    ``select`` (single choice), ``prompt_text`` (free-text line), plus
+    read-only ``display``. ``prompt_text`` lands with its first consumer
+    ``/export``. ``confirm`` stays deferred — TS expresses it as a 2-option
+    ``select`` over Yes/No, so it needs no new method. The port grows by
+    adding a method here and one line per adapter.
     """
 
     async def select(
@@ -305,6 +307,22 @@ class UIHost(Protocol):
         ``UIOption.value``, or ``None`` if cancelled."""
         ...
 
+    async def prompt_text(
+        self,
+        title: str,
+        *,
+        default: str = "",
+        placeholder: Optional[str] = None,
+    ) -> Optional[str]:
+        """Prompt for a single free-text line. Returns the submitted string,
+        which MAY be ``''`` — an empty submit is valid input, not a cancel
+        (mirrors TS ``TextInput.onSubmit('')``). Returns ``None`` *only* when
+        cancelled (Esc / EOF / Ctrl-C).
+
+        ``default`` pre-fills the editable value; ``placeholder`` is a hint
+        shown while the field is empty and is never submitted."""
+        ...
+
     async def display(self, title: str, body: str) -> None:
         """Show read-only information. No return value."""
         ...
@@ -313,10 +331,10 @@ class UIHost(Protocol):
 class NullUIHost:
     """UIHost for surfaces without a UI (SDK / non-interactive).
 
-    The *mutating* :meth:`select` raises :class:`InteractiveUnavailableError`
-    — deliberately NOT returning a default/``current`` value, which would read
-    as a false success. Only the read-only :meth:`display` no-ops. (Resolved
-    contract — see plan §4/§7.)
+    The *mutating* primitives :meth:`select` and :meth:`prompt_text` raise
+    :class:`InteractiveUnavailableError` — deliberately NOT returning a
+    default/``current`` value, which would read as a false success. Only the
+    read-only :meth:`display` no-ops. (Resolved contract — see plan §4/§7.)
     """
 
     _MSG = "This command needs an interactive surface (TUI or REPL)."
@@ -327,6 +345,15 @@ class NullUIHost:
         options: "Sequence[UIOption]",
         *,
         current: Optional[str] = None,
+    ) -> Optional[str]:
+        raise InteractiveUnavailableError(self._MSG)
+
+    async def prompt_text(
+        self,
+        title: str,
+        *,
+        default: str = "",
+        placeholder: Optional[str] = None,
     ) -> Optional[str]:
         raise InteractiveUnavailableError(self._MSG)
 

--- a/src/repl/ui_host.py
+++ b/src/repl/ui_host.py
@@ -74,6 +74,29 @@ class ReplUIHost:
             return None  # out of range -> cancel
         return opts[choice - 1].value
 
+    async def prompt_text(
+        self,
+        title: str,
+        *,
+        default: str = "",
+        placeholder: Optional[str] = None,
+    ) -> Optional[str]:
+        # Surface the default (else the placeholder) as an inline hint. Unlike
+        # select, an empty line is a VALID empty submit ('') — we do NOT
+        # substitute the default — and only EOF / Ctrl-C cancels (-> None).
+        hint = (
+            f" [{default}]"
+            if default
+            else (f" ({placeholder})" if placeholder else "")
+        )
+        prompt = f"{title}{hint}: "
+        loop = asyncio.get_running_loop()
+        try:
+            raw = await loop.run_in_executor(None, self._safe_input, prompt)
+        except (EOFError, KeyboardInterrupt):
+            return None
+        return "" if raw is None else raw
+
     async def display(self, title: str, body: str) -> None:
         self._print(f"\n{title}")
         if body:

--- a/src/tui/screens/generic_input.py
+++ b/src/tui/screens/generic_input.py
@@ -1,0 +1,69 @@
+"""Generic free-text input modal for the interactive-command bridge.
+
+Backs :meth:`src.tui.ui_host.TextualUIHost.prompt_text` so an interactive
+command (``CommandType.INTERACTIVE``) gets a TUI text prompt without defining
+its own screen. Mirrors :class:`src.tui.screens.generic_select.GenericSelectScreen`
+— the same ``DialogScreen`` vocabulary — but yields a single ``Input`` widget
+and the title/default/placeholder come from the command's
+``ctx.ui.prompt_text(...)`` call rather than being hardcoded.
+
+Resolves (via ``dismiss``) with the submitted string — which MAY be ``''`` (an
+empty submit is valid input, mirroring TS ``TextInput.onSubmit('')``) — or
+``None`` on cancel (Esc). That is the contract :class:`TextualUIHost` relays
+back to the command body.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator, Optional
+
+from textual.widget import Widget
+from textual.widgets import Input
+
+
+from .dialog_base import DialogScreen
+
+
+class GenericInputScreen(DialogScreen[Optional[str]]):
+    """Modal free-text prompt.
+
+    Resolves with the submitted value (Enter — empty string IS a valid
+    submit) or ``None`` (Esc / cancel).
+    """
+
+    footer_hint = "Enter to submit · Esc to cancel"
+
+    def __init__(
+        self,
+        *,
+        title: str,
+        default: str = "",
+        placeholder: Optional[str] = None,
+    ) -> None:
+        super().__init__()
+        # title_text drives DialogScreen.compose(); set after super().__init__
+        # (compose runs at mount, so the assignment is in time).
+        self.title_text = title
+        self._default = default
+        self._placeholder = placeholder
+        self._input: Input | None = None
+
+    def build_body(self) -> Iterator[Widget]:
+        self._input = Input(
+            value=self._default,
+            placeholder=self._placeholder or "",
+        )
+        yield self._input
+
+    def _post_mount(self) -> None:
+        if self._input is not None:
+            self._input.focus()
+
+    # ---- events ----
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        # Empty string is a valid submit (empty != cancel); only Esc cancels,
+        # via DialogScreen.action_cancel -> dismiss(None).
+        self.dismiss(event.value)
+
+
+__all__ = ["GenericInputScreen"]

--- a/src/tui/ui_host.py
+++ b/src/tui/ui_host.py
@@ -19,6 +19,7 @@ from typing import Optional, Sequence
 
 from src.command_system.types import UIOption
 
+from .screens.generic_input import GenericInputScreen
 from .screens.generic_select import GenericSelectScreen
 
 
@@ -44,6 +45,22 @@ class TextualUIHost:
                     title=title,
                     options=list(options),
                     current=current,
+                )
+            )
+
+    async def prompt_text(
+        self,
+        title: str,
+        *,
+        default: str = "",
+        placeholder: Optional[str] = None,
+    ) -> Optional[str]:
+        async with self._lock:
+            return await self._app.push_screen_wait(  # type: ignore[attr-defined]
+                GenericInputScreen(
+                    title=title,
+                    default=default,
+                    placeholder=placeholder,
                 )
             )
 

--- a/tests/test_prompt_text_primitive.py
+++ b/tests/test_prompt_text_primitive.py
@@ -1,0 +1,361 @@
+"""Tests for the ``prompt_text`` UIHost primitive (Phase 4, P1).
+
+``prompt_text`` is the second mutating primitive on the surface-agnostic
+``UIHost`` port (after ``select``). It reads a single free-text line and lands
+with its first consumer, ``/export``. The load-bearing divergence from
+``select`` — pinned across every surface here — is the empty case:
+
+  * ``select``: an empty REPL line / no selection means **cancel** (``None``).
+  * ``prompt_text``: an empty submit is a **valid empty string** (``''``),
+    mirroring TS ``TextInput.onSubmit('')``. ``None`` is returned *only* on a
+    real cancel (Esc / EOF / Ctrl-C).
+
+Coverage, per surface:
+  * ``NullUIHost`` — raises ``InteractiveUnavailableError`` (SDK / headless).
+  * ``ReplUIHost`` — typed value; empty ⇒ ``''`` (NOT cancel, NOT the default);
+    whitespace preserved; EOF / Ctrl-C ⇒ ``None``; default/placeholder hint.
+  * ``TextualUIHost`` — relays the modal value (incl. ``''``), relays cancel
+    ``None``, serializes overlapping prompts via the per-host lock.
+  * Engine seam — a consumer ``InteractiveCommand`` driving ``prompt_text``
+    round-trips through ``CommandEngine.execute`` (value, empty ⇒ value not
+    skip, null-surface ⇒ clean error).
+  * ``GenericInputScreen`` (real Textual, via Pilot) — empty Enter ⇒ ``''``,
+    typed Enter ⇒ value, prefilled default ⇒ default, Esc ⇒ ``None``.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.command_system import create_command_context
+from src.command_system.engine import CommandEngine
+from src.command_system.registry import CommandRegistry
+from src.command_system.types import (
+    InteractiveCommand,
+    InteractiveOutcome,
+    InteractiveUnavailableError,
+    NullUIHost,
+)
+from src.repl.ui_host import ReplUIHost
+from src.tui.screens.generic_input import GenericInputScreen
+from src.tui.ui_host import TextualUIHost
+
+
+# --------------------------------------------------------------------------- #
+# A. NullUIHost contract — mutating primitive raises (mirrors select)
+# --------------------------------------------------------------------------- #
+async def test_null_ui_prompt_text_raises_interactive_unavailable():
+    host = NullUIHost()
+    with pytest.raises(InteractiveUnavailableError):
+        await host.prompt_text("Filename", default="x", placeholder="p")
+
+
+# --------------------------------------------------------------------------- #
+# B. ReplUIHost — empty ⇒ '' (the divergence), and every cancel path
+# --------------------------------------------------------------------------- #
+async def test_repl_prompt_text_returns_typed_value():
+    host = ReplUIHost(safe_input=lambda _p: "report.md", console=None)
+    assert await host.prompt_text("Filename") == "report.md"
+
+
+async def test_repl_prompt_text_empty_is_empty_string_not_cancel():
+    # THE divergence from select: an empty line submits '' (valid), not None.
+    host = ReplUIHost(safe_input=lambda _p: "", console=None)
+    assert await host.prompt_text("Filename") == ""
+
+
+async def test_repl_prompt_text_does_not_substitute_default_on_empty():
+    # Empty ⇒ '' even when a default exists — the adapter never auto-fills the
+    # default (both surfaces keep "empty ⇒ ''"; the default is only a hint).
+    host = ReplUIHost(safe_input=lambda _p: "", console=None)
+    assert await host.prompt_text("Filename", default="conversation.md") == ""
+
+
+async def test_repl_prompt_text_preserves_whitespace_raw():
+    # The raw line is returned untouched (no strip) — distinct from select,
+    # which strips before validating the numeric choice.
+    host = ReplUIHost(safe_input=lambda _p: "  spaced name  ", console=None)
+    assert await host.prompt_text("Filename") == "  spaced name  "
+
+
+async def test_repl_prompt_text_none_raw_coerced_to_empty():
+    # Defensive: a safe_input returning None still yields '' (a submit), never
+    # a surprise None that the command body would read as a cancel.
+    host = ReplUIHost(safe_input=lambda _p: None, console=None)
+    assert await host.prompt_text("Filename") == ""
+
+
+async def test_repl_prompt_text_eof_cancels():
+    def _raise(_p):
+        raise EOFError
+
+    host = ReplUIHost(safe_input=_raise, console=None)
+    assert await host.prompt_text("Filename") is None
+
+
+async def test_repl_prompt_text_keyboard_interrupt_cancels():
+    def _raise(_p):
+        raise KeyboardInterrupt
+
+    host = ReplUIHost(safe_input=_raise, console=None)
+    assert await host.prompt_text("Filename") is None
+
+
+async def test_repl_prompt_text_surfaces_default_as_hint():
+    captured = {}
+
+    def _input(prompt):
+        captured["prompt"] = prompt
+        return "typed.md"
+
+    host = ReplUIHost(safe_input=_input, console=None)
+    await host.prompt_text("Save as", default="out.md", placeholder="path")
+    # Default takes precedence over placeholder in the inline hint.
+    assert "Save as" in captured["prompt"]
+    assert "[out.md]" in captured["prompt"]
+    assert "(path)" not in captured["prompt"]
+
+
+async def test_repl_prompt_text_surfaces_placeholder_when_no_default():
+    captured = {}
+
+    def _input(prompt):
+        captured["prompt"] = prompt
+        return ""
+
+    host = ReplUIHost(safe_input=_input, console=None)
+    await host.prompt_text("Save as", placeholder="path/to/file")
+    assert "(path/to/file)" in captured["prompt"]
+
+
+# --------------------------------------------------------------------------- #
+# C. TextualUIHost — relay (incl. '') + cancel + lock serialization
+# --------------------------------------------------------------------------- #
+async def test_tui_prompt_text_relays_typed_value_and_constructs_screen():
+    captured = {}
+
+    class _App:
+        async def push_screen_wait(self, screen):
+            captured["title"] = screen.title_text
+            captured["default"] = screen._default
+            captured["placeholder"] = screen._placeholder
+            return "typed.md"
+
+    host = TextualUIHost(_App())
+    result = await host.prompt_text("Filename", default="d.md", placeholder="p")
+
+    assert result == "typed.md"
+    assert captured == {"title": "Filename", "default": "d.md", "placeholder": "p"}
+
+
+async def test_tui_prompt_text_relays_empty_string_not_coerced():
+    # An empty submit from the screen survives the adapter as '' (not None).
+    class _App:
+        async def push_screen_wait(self, screen):
+            return ""
+
+    assert await TextualUIHost(_App()).prompt_text("t") == ""
+
+
+async def test_tui_prompt_text_relays_cancel_none():
+    class _App:
+        async def push_screen_wait(self, screen):
+            return None
+
+    assert await TextualUIHost(_App()).prompt_text("t") is None
+
+
+async def test_tui_prompt_text_serializes_overlapping_prompts():
+    # Same per-host lock contract as select (plan §8.1): the non-exclusive
+    # worker could overlap two prompts; the lock makes the second queue.
+    state = {"in_flight": 0, "max": 0}
+
+    class _App:
+        async def push_screen_wait(self, screen):
+            state["in_flight"] += 1
+            state["max"] = max(state["max"], state["in_flight"])
+            await asyncio.sleep(0.01)  # hold the modal "open"
+            state["in_flight"] -= 1
+            return screen._default
+
+    host = TextualUIHost(_App())
+    await asyncio.gather(
+        host.prompt_text("t", default="a"),
+        host.prompt_text("t", default="b"),
+    )
+    assert state["max"] == 1  # never two modals open at once
+
+
+# --------------------------------------------------------------------------- #
+# D. Engine path — a consumer command drives prompt_text end-to-end
+# --------------------------------------------------------------------------- #
+class _PromptingFakeUIHost:
+    """Scripts a ``prompt_text`` return value (or None) and records the call —
+    the free-text analogue of the bridge's ``FakeUIHost`` (which scripts
+    ``select``)."""
+
+    def __init__(self, value):
+        self._value = value
+        self.calls: list[dict] = []
+
+    async def prompt_text(self, title, *, default="", placeholder=None):
+        self.calls.append(
+            {"title": title, "default": default, "placeholder": placeholder}
+        )
+        return self._value
+
+
+class _PromptStub(InteractiveCommand):
+    """A minimal consumer: awaits one ``prompt_text`` and echoes the value.
+    ``None`` (cancel) maps to skip; ``''`` is a value and echoes ``got:``."""
+
+    async def run(self, args, context):
+        value = await context.ui.prompt_text("Filename", default="d.md")
+        if value is None:
+            return InteractiveOutcome.skip()
+        return InteractiveOutcome(message=f"got:{value}", display="system")
+
+
+def _registry_with(*commands) -> CommandRegistry:
+    reg = CommandRegistry()
+    for c in commands:
+        reg.register(c)
+    return reg
+
+
+async def test_engine_routes_prompt_text_value_to_text_result(tmp_path):
+    # Proves engine -> command.run -> ctx.ui.prompt_text -> outcome round-trips
+    # the typed value (and the kwargs reach the host).
+    ui = _PromptingFakeUIHost("report.md")
+    reg = _registry_with(_PromptStub(name="askname", description="d"))
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path, ui=ui)
+    eng = CommandEngine(registry=reg, workspace_root=tmp_path, context=ctx)
+
+    result = await eng.execute("/askname")
+
+    assert result.success is True
+    assert result.result_type == "text"
+    assert result.text == "got:report.md"
+    assert ui.calls[0] == {
+        "title": "Filename",
+        "default": "d.md",
+        "placeholder": None,
+    }
+
+
+async def test_engine_prompt_text_empty_string_is_a_value_not_skip(tmp_path):
+    # The divergence at the engine seam: an empty submit ('') flows through as
+    # a VALUE (text result), NOT a cancel/skip.
+    ui = _PromptingFakeUIHost("")
+    reg = _registry_with(_PromptStub(name="askname", description="d"))
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path, ui=ui)
+    eng = CommandEngine(registry=reg, workspace_root=tmp_path, context=ctx)
+
+    result = await eng.execute("/askname")
+
+    assert result.success is True
+    assert result.result_type == "text"
+    assert result.text == "got:"
+
+
+async def test_engine_prompt_text_on_null_surface_reports_clean_error(tmp_path):
+    # No UI wired -> engine substitutes NullUIHost -> prompt_text raises
+    # InteractiveUnavailableError -> engine returns a clean error result (no
+    # crash). Mirrors the select null-surface contract.
+    reg = _registry_with(_PromptStub(name="askname", description="d"))
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+    assert ctx.ui is None  # nothing wired; engine substitutes NullUIHost
+    eng = CommandEngine(registry=reg, workspace_root=tmp_path, context=ctx)
+
+    result = await eng.execute("/askname")
+
+    assert result.success is False
+    assert "interactive surface" in (result.error or "")
+
+
+# --------------------------------------------------------------------------- #
+# E. GenericInputScreen — construction + real Textual behavior via Pilot
+# --------------------------------------------------------------------------- #
+from textual.app import App, ComposeResult  # noqa: E402
+from textual.screen import Screen  # noqa: E402
+from textual.widgets import Static  # noqa: E402
+
+
+class _Host(Screen):
+    def compose(self) -> ComposeResult:
+        yield Static("host")
+
+
+class _DialogHost(App):
+    def on_mount(self) -> None:
+        self.push_screen(_Host())
+
+
+def _push(app: App, screen) -> asyncio.Future:
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future = loop.create_future()
+
+    def _callback(result):
+        if not future.done():
+            future.set_result(result)
+
+    app.push_screen(screen, callback=_callback)
+    return future
+
+
+def test_generic_input_screen_stores_construction_args():
+    # App-free: construction does not build the Input (that's build_body).
+    s = GenericInputScreen(title="Save as", default="d.md", placeholder="path")
+    assert s.title_text == "Save as"
+    assert s._default == "d.md"
+    assert s._placeholder == "path"
+    assert s._input is None
+    assert s.footer_hint == "Enter to submit · Esc to cancel"
+
+
+@pytest.mark.asyncio
+async def test_generic_input_screen_empty_enter_submits_empty_string():
+    # The load-bearing divergence at the real screen: Enter on an empty field
+    # dismisses with '' (a valid submit), NOT None (which is cancel).
+    app = _DialogHost()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        fut = _push(app, GenericInputScreen(title="Filename"))
+        await pilot.pause()
+        await pilot.press("enter")
+        assert await fut == ""
+
+
+@pytest.mark.asyncio
+async def test_generic_input_screen_typed_enter_submits_value():
+    app = _DialogHost()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        fut = _push(app, GenericInputScreen(title="Filename"))
+        await pilot.pause()
+        await pilot.press("r", "e", "p", "o", "r", "t")
+        await pilot.press("enter")
+        assert await fut == "report"
+
+
+@pytest.mark.asyncio
+async def test_generic_input_screen_prefilled_default_submits_default():
+    app = _DialogHost()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        fut = _push(app, GenericInputScreen(title="Filename", default="conversation.md"))
+        await pilot.pause()
+        await pilot.press("enter")  # accept the prefilled default unchanged
+        assert await fut == "conversation.md"
+
+
+@pytest.mark.asyncio
+async def test_generic_input_screen_escape_resolves_none():
+    app = _DialogHost()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        fut = _push(app, GenericInputScreen(title="Filename", default="x"))
+        await pilot.pause()
+        await pilot.press("escape")
+        assert await fut is None


### PR DESCRIPTION
## Summary
- Adds `prompt_text`, the second mutating primitive on the surface-agnostic `UIHost` bridge (after `select`) — reads a single free-text line. Lands with its first consumer `/export` in P2/P3.
- **Load-bearing divergence from `select`:** an empty submit is a valid empty string `''` (mirrors TS `TextInput.onSubmit('')`); `None` is returned only on a real cancel (Esc / EOF / Ctrl-C). The REPL adapter never strips and never auto-substitutes the default.
- `confirm` stays deferred — TS expresses it as a 2-option Yes/No `select`, so it needs no new method.

## Changes
- `command_system/types.py` — `prompt_text` on the `UIHost` Protocol + `NullUIHost.prompt_text` (raises `InteractiveUnavailableError`); docstrings updated.
- `tui/screens/generic_input.py` (new) — `GenericInputScreen`, mirrors `GenericSelectScreen` with one `Input` widget.
- `repl/ui_host.py` + `tui/ui_host.py` — REPL (inline-prompt) and Textual (modal, per-host-lock-serialized) adapters.
- `tests/test_prompt_text_primitive.py` (new) — 22 tests.

## Test plan
- [x] `tests/test_prompt_text_primitive.py` — 22 passed, incl. 4 Pilot tests on the real screen (empty Enter ⇒ `''`, typed ⇒ value, prefilled default ⇒ default, Esc ⇒ `None`) and an engine-path consumer test
- [x] sibling `tests/test_interactive_bridge.py` + `tests/tui/test_phase3_dialogs.py` — green, no regressions
- [x] critic-reviewed (2 rounds → APPROVE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)