### PR TITLE
commands: multi-format conversation export renderers (Phase 4 P2)

### DIFF
--- a/src/utils/export_formats.py
+++ b/src/utils/export_formats.py
@@ -1,0 +1,228 @@
+"""Export format types and helpers for multi-format conversation export.
+
+Faithful port of ``typescript/src/utils/exportFormats.ts``. The TS code maps
+filesystem paths with node's ``path`` module (``extname``/``isAbsolute``/
+``join``); the Python port uses :mod:`os.path`, whose ``splitext``/``isabs``/
+``join`` behave identically on the cases these helpers care about (verified
+against the ported test fixtures, including ``'conversation.'`` -> ``'.'`` and
+dotfiles like ``'.env'`` having no extension).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import List, NamedTuple, Optional
+
+try:  # Python 3.8+ Literal
+    from typing import Literal
+except ImportError:  # pragma: no cover - fallback for very old runtimes
+    from typing_extensions import Literal  # type: ignore
+
+ExportFormat = Literal["text", "markdown", "json"]
+
+
+def normalize_export_format(value: str) -> Optional[ExportFormat]:
+    """Normalize a user-provided format string to an :data:`ExportFormat`.
+
+    Returns ``None`` for unrecognized values.
+    """
+    lower = value.lower().strip()
+    if lower in ("text", "txt"):
+        return "text"
+    if lower in ("markdown", "md"):
+        return "markdown"
+    if lower == "json":
+        return "json"
+    return None
+
+
+def infer_export_format_from_filename(filename: str) -> Optional[ExportFormat]:
+    """Infer export format from a filename's extension.
+
+    Returns ``None`` if the extension doesn't map to a known format.
+    """
+    ext = os.path.splitext(filename)[1]
+    if not ext or ext == ".":
+        return None
+    return normalize_export_format(ext[1:])
+
+
+def extension_for_export_format(format: ExportFormat) -> str:
+    """Get the canonical file extension for an export format."""
+    if format == "text":
+        return ".txt"
+    if format == "markdown":
+        return ".md"
+    return ".json"
+
+
+def ensure_export_filename_extension(
+    filename: str,
+    format: ExportFormat,
+    *,
+    preserve_markdown_extension: bool = False,
+) -> str:
+    """Ensure a filename has the correct extension for the export format.
+
+    Strips any existing extension and appends the canonical one.
+    """
+    ext = extension_for_export_format(format)
+    current_ext = os.path.splitext(filename)[1]
+    if (
+        format == "markdown"
+        and preserve_markdown_extension
+        and current_ext.lower() == ".markdown"
+    ):
+        return filename
+    if current_ext:
+        base = filename[:-1] if current_ext == "." else filename[: -len(current_ext)]
+    else:
+        base = filename
+    return base + ext
+
+
+def resolve_export_filepath(cwd: str, filename: str) -> str:
+    return filename if os.path.isabs(filename) else os.path.join(cwd, filename)
+
+
+SUPPORTED_FORMATS = "Supported formats: text, markdown, json."
+
+
+class _Token(NamedTuple):
+    value: str
+    quoted: bool
+
+
+def _tokenize_export_args(args: str) -> "tuple[List[_Token], Optional[str]]":
+    tokens: List[_Token] = []
+    current = ""
+    quote: Optional[str] = None
+    token_started = False
+    token_quoted = False
+
+    i = 0
+    n = len(args)
+    while i < n:
+        ch = args[i]
+
+        if quote is not None:
+            if ch == quote:
+                quote = None
+                i += 1
+                continue
+            if quote == '"' and ch == "\\" and i + 1 < n:
+                nxt = args[i + 1]
+                if nxt == '"' or nxt == "\\":
+                    current += nxt
+                    i += 2
+                    continue
+            current += ch
+            i += 1
+            continue
+
+        if ch == '"' or ch == "'":
+            quote = ch
+            token_started = True
+            token_quoted = True
+            i += 1
+            continue
+
+        if ch.isspace():
+            if token_started:
+                tokens.append(_Token(current, token_quoted))
+                current = ""
+                token_started = False
+                token_quoted = False
+            i += 1
+            continue
+
+        current += ch
+        token_started = True
+        i += 1
+
+    if quote is not None:
+        return tokens, "Unterminated quoted string in /export arguments."
+
+    if token_started:
+        tokens.append(_Token(current, token_quoted))
+
+    return tokens, None
+
+
+@dataclass(frozen=True)
+class ParsedExportArgs:
+    filename: Optional[str] = None
+    format: Optional[ExportFormat] = None
+    error: Optional[str] = None
+
+
+def parse_export_args(args: str) -> ParsedExportArgs:
+    """Parse ``/export`` command arguments.
+
+    Supported flags: ``--format <value>`` or ``-f <value>``.
+
+    Returns parsed filename, format, and optional error string.
+    """
+    tokens, tok_error = _tokenize_export_args(args)
+    if tok_error:
+        return ParsedExportArgs(error=tok_error)
+
+    if len(tokens) == 0:
+        return ParsedExportArgs()
+
+    fmt: Optional[ExportFormat] = None
+    error: Optional[str] = None
+    filename_tokens: List[str] = []
+
+    i = 0
+    n = len(tokens)
+    while i < n:
+        token = tokens[i]
+        if not token.quoted and token.value == "--":
+            filename_tokens.extend(t.value for t in tokens[i + 1 :])
+            break
+        if not token.quoted and token.value in ("--format", "-f"):
+            i += 1
+            value = tokens[i].value if i < n else None
+            if not value:
+                error = f"Missing value for {token.value}. {SUPPORTED_FORMATS}"
+                break
+            normalized = normalize_export_format(value)
+            if not normalized:
+                error = f"Unsupported export format: {value}. {SUPPORTED_FORMATS}"
+                break
+            fmt = normalized
+        elif (
+            not token.quoted
+            and token.value.startswith("-")
+            and token.value != "-"
+        ):
+            error = (
+                f"Unsupported export option: {token.value}. "
+                "Supported options: --format, -f."
+            )
+            break
+        else:
+            filename_tokens.append(token.value)
+        i += 1
+
+    filename = " ".join(filename_tokens) if filename_tokens else None
+
+    if error:
+        return ParsedExportArgs(filename=filename, format=fmt, error=error)
+
+    return ParsedExportArgs(filename=filename, format=fmt)
+
+
+__all__ = [
+    "ExportFormat",
+    "ParsedExportArgs",
+    "SUPPORTED_FORMATS",
+    "ensure_export_filename_extension",
+    "extension_for_export_format",
+    "infer_export_format_from_filename",
+    "normalize_export_format",
+    "parse_export_args",
+    "resolve_export_filepath",
+]

--- a/src/utils/export_renderer.py
+++ b/src/utils/export_renderer.py
@@ -1,0 +1,806 @@
+"""Structured, surface-agnostic conversation export renderers.
+
+Port of the *pure* renderers in ``typescript/src/utils/exportRenderer.tsx``:
+``renderMessagesToMarkdown``, ``renderMessagesToJSON``, a from-scratch
+plain-text transcriber, and the ``render_messages_for_export`` dispatcher.
+
+Deliberate divergences from the TS source (documented for parity review):
+
+* **No Ink/terminal renderer.** TS's ``text`` format streams the React/Ink UI
+  through ``renderToAnsiString``; that is surface-coupled and cannot be
+  line-ported. Python's ``text`` format is a standalone plain-text transcript
+  walking the same structured content as the markdown renderer (minus markdown
+  syntax). The async ``streamRenderedMessages``/``renderMessagesToPlainText``
+  Ink path is intentionally NOT ported.
+* **Terminal-output envelope parser scoped out.** Python ``src/`` never emits
+  ``<bash-stdout>``/``<local-command-stdout>``/``<bash-input>`` (grep-confirmed
+  zero occurrences), so ``getTerminalOutputs``/``parseTerminalOutputs`` would
+  always return ``None``. Those branches are dead and omitted.
+* **Internal-text tags.** Of TS's nine ``INTERNAL_TEXT_TAGS`` only
+  ``<task-notification>`` is live in Python (``src/constants/xml.py``; emitted
+  by the coordinator/task-notification path as user-role content). So
+  ``strip_top_level_internal_text`` strips ``<system-reminder>`` +
+  ``<task-notification>`` blocks only.
+* **Synthetic-content markers.** Mirror TS ``isSyntheticContent``'s five
+  bracketed *display literals* verbatim (see ``_SYNTHETIC_FIRST_TEXTS``), so the
+  synthetic-message filter stays byte-identical to TS.
+
+Messages may be flat dataclasses (``src/types/messages.py`` — ``.content``
+directly) or plain dicts/wire objects (TS-style ``{'message': {'content': …}}``
+or flat ``{'content': …}``). Content blocks may be block dataclasses or dicts.
+Block reads use camel/snake fallbacks so both shapes serialize identically; the
+JSON output is always camelCase (``toolUseId``/``isError``), wire-compatible
+with TS exports.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import is_dataclass
+from datetime import datetime, timezone
+from typing import Any, List, Optional
+
+from src.constants.xml import TASK_NOTIFICATION_TAG
+from src.types.content_blocks import content_block_to_dict
+from src.types.messages import (
+    INTERRUPT_MESSAGE,
+    INTERRUPT_MESSAGE_FOR_TOOL_USE,
+    SYNTHETIC_TOOL_RESULT_PLACEHOLDER,
+)
+from src.utils.export_formats import ExportFormat
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+
+SKIP_MESSAGE_TYPES = frozenset({"progress", "attachment"})
+SKIP_SYSTEM_SUBTYPES = frozenset({"api_metrics"})
+
+# Only <task-notification> of TS's INTERNAL_TEXT_TAGS is live in Python.
+INTERNAL_TEXT_TAGS = [TASK_NOTIFICATION_TAG]
+
+# First-text-block markers identifying a synthetic (interrupt/cancel/reject/
+# no-response) message that should be excluded from export. These mirror the
+# five *bracketed display literals* hard-coded in TS ``isSyntheticContent``
+# (exportRenderer.tsx:584-588) verbatim — NOT the semantic message constants.
+# Two equal Python constants (``INTERRUPT_MESSAGE`` /
+# ``INTERRUPT_MESSAGE_FOR_TOOL_USE``); the other three are pure display strings
+# with no Python equivalent (Python's ``CANCEL_MESSAGE`` / ``REJECT_MESSAGE`` /
+# ``NO_RESPONSE_REQUESTED`` are full sentences, not these brackets), so they are
+# ported as literals to keep the synthetic-message filter byte-identical to TS.
+_SYNTHETIC_FIRST_TEXTS = frozenset(
+    {
+        INTERRUPT_MESSAGE,  # "[Request interrupted by user]"
+        INTERRUPT_MESSAGE_FOR_TOOL_USE,  # "[Request interrupted by user for tool use]"
+        "[Request cancelled]",
+        "[Tool use rejected]",
+        "[No response requested]",
+    }
+)
+
+_SYSTEM_REMINDER_RE = re.compile(
+    r"<system-reminder\b[^>]*>.*?</system-reminder>", re.DOTALL
+)
+
+
+def _internal_tag_regex(tag: str) -> "re.Pattern[str]":
+    escaped = re.escape(tag)
+    return re.compile(rf"<{escaped}\b[^>]*>.*?</{escaped}>", re.DOTALL)
+
+
+_INTERNAL_TEXT_TAG_REGEXES = [_internal_tag_regex(tag) for tag in INTERNAL_TEXT_TAGS]
+
+
+# --------------------------------------------------------------------------- #
+# Low-level helpers
+# --------------------------------------------------------------------------- #
+
+
+def _now_iso() -> str:
+    """JS ``new Date().toISOString()`` shape: ``YYYY-MM-DDTHH:MM:SS.mmmZ``."""
+    now = datetime.now(timezone.utc)
+    return now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now.microsecond // 1000:03d}Z"
+
+
+def strip_system_reminder_blocks(text: str) -> str:
+    return _SYSTEM_REMINDER_RE.sub("", text).strip()
+
+
+def strip_top_level_internal_text(text: str) -> str:
+    stripped = strip_system_reminder_blocks(text)
+    for regex in _INTERNAL_TEXT_TAG_REGEXES:
+        stripped = regex.sub("", stripped)
+    return stripped.strip()
+
+
+def is_internal_text(text: str) -> bool:
+    return len(strip_top_level_internal_text(text)) == 0
+
+
+def looks_like_json(s: str) -> bool:
+    trimmed = s.strip()
+    return (trimmed.startswith("{") and trimmed.endswith("}")) or (
+        trimmed.startswith("[") and trimmed.endswith("]")
+    )
+
+
+def markdown_fence_for(content: str) -> str:
+    longest = 0
+    for match in re.finditer(r"`+", content):
+        longest = max(longest, len(match.group(0)))
+    return "`" * max(3, longest + 1)
+
+
+def safe_json_value(value: Any, seen: Optional[set] = None) -> Any:
+    """Circular-safe JSON-able projection. Strings get system-reminder blocks
+    stripped (NOT the broader internal-text tags — matches TS ``safeJsonValue``).
+    """
+    if seen is None:
+        seen = set()
+
+    if value is None or isinstance(value, (str, int, float, bool)):
+        if isinstance(value, str):
+            return strip_system_reminder_blocks(value)
+        return value
+
+    if isinstance(value, (list, tuple)):
+        if id(value) in seen:
+            return "[Circular]"
+        seen.add(id(value))
+        try:
+            return [safe_json_value(item, seen) for item in value]
+        except Exception:
+            return "[Unserializable]"
+        finally:
+            seen.discard(id(value))
+
+    if isinstance(value, Mapping):
+        if id(value) in seen:
+            return "[Circular]"
+        seen.add(id(value))
+        try:
+            result: dict[str, Any] = {}
+            try:
+                keys = list(value.keys())
+            except Exception:
+                return "[Unserializable]"
+            for key in keys:
+                try:
+                    result[key] = safe_json_value(value[key], seen)
+                except Exception:
+                    result[key] = "[Unserializable]"
+            return result
+        finally:
+            seen.discard(id(value))
+
+    if is_dataclass(value) and not isinstance(value, type):
+        return safe_json_value(content_block_to_dict(value), seen)
+
+    return str(value)
+
+
+def safe_stringify(value: Any, indent: Optional[int] = None) -> str:
+    try:
+        projected = safe_json_value(value)
+        if indent is None:
+            return json.dumps(projected, separators=(",", ":"), ensure_ascii=False)
+        return json.dumps(projected, indent=indent, ensure_ascii=False)
+    except Exception:
+        return str(value)
+
+
+# --------------------------------------------------------------------------- #
+# Message / block accessors (dataclass + dict dual-mode)
+# --------------------------------------------------------------------------- #
+
+
+def _field(msg: Any, name: str, default: Any = None) -> Any:
+    if isinstance(msg, Mapping):
+        return msg.get(name, default)
+    return getattr(msg, name, default)
+
+
+def _is_msg_obj(msg: Any) -> bool:
+    return msg is not None and not isinstance(msg, (str, bytes, bool, int, float))
+
+
+def _is_obj(block: Any) -> bool:
+    """Mirror of JS ``!!block && typeof block === 'object'`` (arrays included)."""
+    return block is not None and not isinstance(block, (str, bytes, bool, int, float))
+
+
+def _btype(block: Any) -> Any:
+    if isinstance(block, Mapping):
+        return block.get("type")
+    return getattr(block, "type", None)
+
+
+def _btext(block: Any) -> Any:
+    if isinstance(block, Mapping):
+        return block.get("text")
+    return getattr(block, "text", None)
+
+
+def _bcontent(block: Any) -> Any:
+    if isinstance(block, Mapping):
+        return block.get("content")
+    return getattr(block, "content", None)
+
+
+def _normalize_block(block: Any) -> dict:
+    return dict(block) if isinstance(block, Mapping) else content_block_to_dict(block)
+
+
+def extract_message_content(msg: Any) -> Any:
+    if isinstance(msg, Mapping):
+        nested = msg.get("message")
+        if isinstance(nested, Mapping):
+            return nested.get("content")
+        if "content" in msg:
+            return msg["content"]
+        return None
+    nested = getattr(msg, "message", None)
+    if isinstance(nested, Mapping):
+        return nested.get("content")
+    return getattr(msg, "content", None)
+
+
+# --------------------------------------------------------------------------- #
+# Block predicates
+# --------------------------------------------------------------------------- #
+
+
+def is_text_block(block: Any) -> bool:
+    return _is_obj(block) and _btype(block) == "text" and isinstance(_btext(block), str)
+
+
+def is_tool_result_block(block: Any) -> bool:
+    return _is_obj(block) and _btype(block) == "tool_result"
+
+
+def is_internal_text_block(block: Any) -> bool:
+    return is_text_block(block) and is_internal_text(_btext(block))
+
+
+def is_tool_result_message_content(content: Any) -> bool:
+    if not isinstance(content, list):
+        return False
+    if not any(is_tool_result_block(b) for b in content):
+        return False
+    return all(is_tool_result_block(b) or is_internal_text_block(b) for b in content)
+
+
+def is_synthetic_tool_result_block(block: Any) -> bool:
+    if not is_tool_result_block(block):
+        return False
+    content = _bcontent(block)
+    if content == SYNTHETIC_TOOL_RESULT_PLACEHOLDER:
+        return True
+    if isinstance(content, list):
+        return all(
+            is_text_block(item) and _btext(item) == SYNTHETIC_TOOL_RESULT_PLACEHOLDER
+            for item in content
+        )
+    return False
+
+
+def is_synthetic_content(content: Any) -> bool:
+    if not isinstance(content, list):
+        return False
+    first = content[0] if content else None
+    has_synthetic_tool_result = any(is_synthetic_tool_result_block(b) for b in content)
+    if is_text_block(first) and _btext(first) in _SYNTHETIC_FIRST_TEXTS:
+        return True
+    return has_synthetic_tool_result and all(
+        is_synthetic_tool_result_block(b) or is_internal_text_block(b) for b in content
+    )
+
+
+def is_known_message_type(message_type: str) -> bool:
+    return message_type in ("user", "assistant", "system", "tool")
+
+
+def has_exportable_structured_content(content: Any) -> bool:
+    if content is None:
+        return False
+    if isinstance(content, str):
+        return len(content.strip()) > 0 and not is_internal_text(content)
+    if not isinstance(content, list):
+        return True
+    for block in content:
+        if is_text_block(block):
+            text = _btext(block)
+            if len(text.strip()) > 0 and not is_internal_text(text):
+                return True
+            continue
+        if not _is_obj(block):
+            if block is not None:
+                return True
+            continue
+        block_type = _btype(block)
+        if block_type in ("thinking", "redacted_thinking"):
+            continue
+        return True
+    return False
+
+
+def should_export_structured_message(msg: Any, msg_type: str) -> bool:
+    if msg_type in SKIP_MESSAGE_TYPES:
+        return False
+    if msg_type == "system":
+        subtype = _field(msg, "subtype", None)
+        subtype_str = "" if subtype is None else str(subtype)
+        if subtype_str in SKIP_SYSTEM_SUBTYPES:
+            return False
+    if _field(msg, "isMeta") is True or _field(msg, "isCompactSummary") is True:
+        return False
+    content = extract_message_content(msg)
+    if is_synthetic_content(content):
+        return False
+    return has_exportable_structured_content(content) or not is_known_message_type(
+        msg_type
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Type / role mapping
+# --------------------------------------------------------------------------- #
+
+
+def message_heading(message_type: str) -> str:
+    if message_type == "user":
+        return "User"
+    if message_type == "assistant":
+        return "Assistant"
+    if message_type == "system":
+        return "System"
+    if message_type == "tool":
+        return "Tool Result"
+    return (message_type[:1].upper() + message_type[1:]) if message_type else message_type
+
+
+def to_role(message_type: str) -> str:
+    return message_type if message_type in ("user", "assistant", "system", "tool") else "unknown"
+
+
+def to_exported_message_type(msg_type: str, content: Any) -> str:
+    if is_tool_result_message_content(content):
+        return "tool"
+    if msg_type in ("user", "assistant", "system", "tool"):
+        return msg_type
+    if msg_type != "unknown":
+        return "unknown"
+    return msg_type
+
+
+def to_role_for_content(msg_type: str, content: Any) -> str:
+    if is_tool_result_message_content(content):
+        return "tool"
+    return to_role(msg_type)
+
+
+# --------------------------------------------------------------------------- #
+# Markdown renderer
+# --------------------------------------------------------------------------- #
+
+
+def render_text_markdown(text: str, lines: List[str]) -> None:
+    if not text:
+        return
+    stripped = strip_top_level_internal_text(text)
+    if not stripped:
+        return
+    lines.append(stripped)
+    lines.append("")
+
+
+def render_unknown_content_markdown(content: Any, lines: List[str]) -> None:
+    lines.append("*[unknown content]*")
+    lines.append("")
+    serialized = safe_stringify(content, 2)
+    marker = markdown_fence_for(serialized)
+    lines.append(f"{marker}json")
+    lines.append(serialized)
+    lines.append(marker)
+    lines.append("")
+
+
+def render_content_block_markdown(
+    block: dict, lines: List[str], skip_subheading: bool = False
+) -> None:
+    block_type = block.get("type")
+
+    if block_type == "text":
+        text = block.get("text")
+        render_text_markdown(text if isinstance(text, str) else "", lines)
+        return
+
+    if block_type == "tool_use":
+        name = block.get("name")
+        name = name if isinstance(name, str) else "unknown"
+        lines.append(f"### Tool Use: {name}")
+        lines.append("")
+        tool_input = block.get("input")
+        if tool_input is not None:
+            input_json = safe_stringify(tool_input, 2)
+            marker = markdown_fence_for(input_json)
+            lines.append(f"{marker}json")
+            lines.append(input_json)
+            lines.append(marker)
+            lines.append("")
+        return
+
+    if block_type == "tool_result":
+        if not skip_subheading:
+            lines.append("### Tool Result")
+            lines.append("")
+        result_content = block.get("content")
+        if result_content is not None:
+            as_string = (
+                strip_system_reminder_blocks(result_content)
+                if isinstance(result_content, str)
+                else safe_stringify(result_content, 2)
+            )
+            fence = "json" if looks_like_json(as_string) else "text"
+            marker = markdown_fence_for(as_string)
+            lines.append(f"{marker}{fence}")
+            lines.append(as_string)
+            lines.append(marker)
+            lines.append("")
+        if block.get("isError") or block.get("is_error"):
+            lines.append("*(Error)*")
+            lines.append("")
+        return
+
+    if block_type == "image":
+        lines.append("[Image attachment]")
+        lines.append("")
+        return
+
+    if block_type == "thinking":
+        return
+
+    if block_type == "redacted_thinking":
+        return
+
+    label = block_type if block_type is not None else "unknown"
+    lines.append(f"*[{label} content block]*")
+    lines.append("")
+    serialized = safe_stringify(block, 2)
+    marker = markdown_fence_for(serialized)
+    lines.append(f"{marker}json")
+    lines.append(serialized)
+    lines.append(marker)
+    lines.append("")
+
+
+def render_messages_to_markdown(messages: Any) -> str:
+    lines: List[str] = []
+    lines.append("# Conversation Export")
+    lines.append("")
+    lines.append(f"Exported: {_now_iso()}")
+    lines.append("Format: Markdown")
+    lines.append("")
+
+    for msg in messages:
+        if not _is_msg_obj(msg):
+            continue
+        raw_type = _field(msg, "type", None)
+        msg_type = "unknown" if raw_type is None else str(raw_type)
+        if not should_export_structured_message(msg, msg_type):
+            continue
+
+        content = extract_message_content(msg)
+        if content is None:
+            continue
+
+        is_tool_result_message = msg_type in ("user", "tool") and (
+            is_tool_result_message_content(content)
+        )
+        heading = "Tool Result" if is_tool_result_message else message_heading(msg_type)
+
+        content_lines: List[str] = []
+        if isinstance(content, str):
+            render_text_markdown(content, content_lines)
+        elif isinstance(content, list):
+            for block in content:
+                if not _is_obj(block):
+                    render_unknown_content_markdown(block, content_lines)
+                    continue
+                render_content_block_markdown(
+                    _normalize_block(block), content_lines, is_tool_result_message
+                )
+            if len(content_lines) > 0:
+                content_lines.append("")
+        else:
+            render_unknown_content_markdown(content, content_lines)
+
+        if all(line == "" for line in content_lines):
+            continue
+
+        lines.append(f"## {heading}")
+        lines.append("")
+        lines.extend(content_lines)
+
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# JSON renderer
+# --------------------------------------------------------------------------- #
+
+
+def serialize_content_block(block: Any) -> Any:
+    if not _is_obj(block):
+        return {"type": "unknown", "value": safe_json_value(block)}
+
+    b = _normalize_block(block)
+    raw_type = b.get("type")
+    block_type = raw_type if isinstance(raw_type, str) else "unknown"
+
+    if block_type == "text":
+        text = b.get("text")
+        if not isinstance(text, str):
+            return {"type": "text", "text": ""}
+        return {"type": "text", "text": strip_top_level_internal_text(text)}
+
+    if block_type == "tool_use":
+        result: dict[str, Any] = {"type": "tool_use"}
+        if b.get("id") is not None:
+            result["id"] = safe_json_value(b.get("id"))
+        if b.get("name") is not None:
+            result["name"] = str(b.get("name"))
+        if b.get("input") is not None:
+            result["input"] = safe_json_value(b.get("input"))
+        return result
+
+    if block_type == "tool_result":
+        tool_use_id = b.get("tool_use_id")
+        if tool_use_id is None:
+            tool_use_id = b.get("toolUseId")
+        is_error = b.get("is_error")
+        if is_error is None:
+            is_error = b.get("isError")
+        result = {"type": "tool_result"}
+        if tool_use_id is not None:
+            result["toolUseId"] = str(tool_use_id)
+        if b.get("content") is not None:
+            result["content"] = safe_json_value(b.get("content"))
+        if is_error is not None:
+            result["isError"] = bool(is_error)
+        return result
+
+    if block_type == "image":
+        result = {"type": "image"}
+        if b.get("source") is not None:
+            result["source"] = safe_json_value(b.get("source"))
+        return result
+
+    if block_type in ("thinking", "redacted_thinking"):
+        return []
+
+    return {"type": block_type, "value": safe_json_value(b)}
+
+
+def serialize_content_blocks(content: Any) -> List[Any]:
+    if content is None:
+        return []
+    if isinstance(content, str):
+        return [{"type": "text", "text": strip_top_level_internal_text(content)}]
+    if not isinstance(content, list):
+        return [{"type": "unknown", "value": safe_json_value(content)}]
+
+    out: List[Any] = []
+    for block in content:
+        if is_text_block(block) and is_internal_text(_btext(block)):
+            continue
+        serialized = serialize_content_block(block)
+        if isinstance(serialized, list):
+            out.extend(serialized)
+        else:
+            out.append(serialized)
+    return out
+
+
+def render_messages_to_json(messages: Any) -> str:
+    filtered: List[tuple] = []
+    for source_index, msg in enumerate(messages):
+        if not _is_msg_obj(msg):
+            continue
+        raw_type = _field(msg, "type", None)
+        msg_type_filter = "" if raw_type is None else str(raw_type)
+        if should_export_structured_message(msg, msg_type_filter):
+            filtered.append((msg, source_index))
+
+    exported: List[dict] = []
+    for index, (msg, source_index) in enumerate(filtered):
+        raw_type = _field(msg, "type", None)
+        msg_type = "unknown" if raw_type is None else str(raw_type)
+        content = extract_message_content(msg)
+        exported_type = to_exported_message_type(msg_type, content)
+        role = to_role_for_content(msg_type, content)
+
+        result: dict[str, Any] = {
+            "index": index,
+            "sourceIndex": source_index,
+            "type": exported_type,
+            "role": role,
+            "content": serialize_content_blocks(content),
+        }
+        if exported_type == "unknown" and msg_type and msg_type != "unknown":
+            result["rawType"] = msg_type
+        subtype = _field(msg, "subtype", None)
+        if isinstance(subtype, str):
+            result["subtype"] = subtype
+        timestamp = _field(msg, "timestamp", None)
+        if isinstance(timestamp, str):
+            result["timestamp"] = timestamp
+        exported.append(result)
+
+    output = {
+        "version": 1,
+        "format": "json",
+        "exportedAt": _now_iso(),
+        "messageCount": len(exported),
+        "messages": exported,
+    }
+    return safe_stringify(output, 2)
+
+
+# --------------------------------------------------------------------------- #
+# Plain-text renderer (from-scratch transcript; see module docstring)
+# --------------------------------------------------------------------------- #
+
+
+def _plain_block_lines(block: dict, lines: List[str], skip_subheading: bool) -> None:
+    block_type = block.get("type")
+
+    if block_type == "text":
+        text = block.get("text")
+        stripped = strip_top_level_internal_text(text) if isinstance(text, str) else ""
+        if stripped:
+            lines.append(stripped)
+            lines.append("")
+        return
+
+    if block_type == "tool_use":
+        name = block.get("name")
+        name = name if isinstance(name, str) else "unknown"
+        lines.append(f"Tool Use: {name}")
+        tool_input = block.get("input")
+        if tool_input is not None:
+            lines.append(safe_stringify(tool_input, 2))
+        lines.append("")
+        return
+
+    if block_type == "tool_result":
+        if not skip_subheading:
+            lines.append("Tool Result")
+        result_content = block.get("content")
+        if result_content is not None:
+            as_string = (
+                strip_system_reminder_blocks(result_content)
+                if isinstance(result_content, str)
+                else safe_stringify(result_content, 2)
+            )
+            if as_string:
+                lines.append(as_string)
+        if block.get("isError") or block.get("is_error"):
+            lines.append("(Error)")
+        lines.append("")
+        return
+
+    if block_type == "image":
+        lines.append("[Image attachment]")
+        lines.append("")
+        return
+
+    if block_type in ("thinking", "redacted_thinking"):
+        return
+
+    label = block_type if block_type is not None else "unknown"
+    lines.append(f"[{label} content block]")
+    lines.append(safe_stringify(block, 2))
+    lines.append("")
+
+
+def render_messages_to_plain_text(messages: Any) -> str:
+    lines: List[str] = []
+    lines.append("Conversation Export")
+    lines.append("")
+    lines.append(f"Exported: {_now_iso()}")
+    lines.append("Format: Text")
+    lines.append("")
+
+    for msg in messages:
+        if not _is_msg_obj(msg):
+            continue
+        raw_type = _field(msg, "type", None)
+        msg_type = "unknown" if raw_type is None else str(raw_type)
+        if not should_export_structured_message(msg, msg_type):
+            continue
+
+        content = extract_message_content(msg)
+        if content is None:
+            continue
+
+        is_tool_result_message = msg_type in ("user", "tool") and (
+            is_tool_result_message_content(content)
+        )
+        heading = "Tool Result" if is_tool_result_message else message_heading(msg_type)
+
+        content_lines: List[str] = []
+        if isinstance(content, str):
+            stripped = strip_top_level_internal_text(content)
+            if stripped:
+                content_lines.append(stripped)
+                content_lines.append("")
+        elif isinstance(content, list):
+            for block in content:
+                if not _is_obj(block):
+                    content_lines.append(str(block))
+                    content_lines.append("")
+                    continue
+                _plain_block_lines(
+                    _normalize_block(block), content_lines, is_tool_result_message
+                )
+        else:
+            content_lines.append(str(content))
+            content_lines.append("")
+
+        if all(line == "" for line in content_lines):
+            continue
+
+        lines.append(heading)
+        lines.append("")
+        lines.extend(content_lines)
+
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# Dispatcher
+# --------------------------------------------------------------------------- #
+
+
+def render_messages_for_export(messages: Any, *, format: ExportFormat) -> str:
+    if format == "text":
+        return render_messages_to_plain_text(messages)
+    if format == "markdown":
+        return render_messages_to_markdown(messages)
+    if format == "json":
+        return render_messages_to_json(messages)
+    raise ValueError(f"Unknown export format: {format!r}")
+
+
+__all__ = [
+    "SKIP_MESSAGE_TYPES",
+    "SKIP_SYSTEM_SUBTYPES",
+    "INTERNAL_TEXT_TAGS",
+    "extract_message_content",
+    "has_exportable_structured_content",
+    "is_internal_text",
+    "is_known_message_type",
+    "is_synthetic_content",
+    "is_tool_result_message_content",
+    "looks_like_json",
+    "markdown_fence_for",
+    "message_heading",
+    "render_content_block_markdown",
+    "render_messages_for_export",
+    "render_messages_to_json",
+    "render_messages_to_markdown",
+    "render_messages_to_plain_text",
+    "safe_json_value",
+    "safe_stringify",
+    "serialize_content_block",
+    "serialize_content_blocks",
+    "should_export_structured_message",
+    "strip_system_reminder_blocks",
+    "strip_top_level_internal_text",
+    "to_exported_message_type",
+    "to_role",
+    "to_role_for_content",
+]

--- a/tests/test_export_formats.py
+++ b/tests/test_export_formats.py
@@ -1,0 +1,252 @@
+"""Tests for :mod:`src.utils.export_formats`.
+
+Faithful port of ``typescript/src/utils/exportFormats.test.ts`` (242 lines). The
+TS suite drives the same six public helpers; Python keeps the assertions
+one-to-one, only translating ``null`` -> ``None``, the ``preserveMarkdownExtension``
+option object -> the ``preserve_markdown_extension`` keyword, and the parsed
+result objects -> :class:`~src.utils.export_formats.ParsedExportArgs` field reads.
+"""
+
+from __future__ import annotations
+
+from src.utils.export_formats import (
+    ParsedExportArgs,
+    ensure_export_filename_extension,
+    extension_for_export_format,
+    infer_export_format_from_filename,
+    normalize_export_format,
+    parse_export_args,
+    resolve_export_filepath,
+)
+
+
+# --------------------------------------------------------------------------- #
+# normalize_export_format
+# --------------------------------------------------------------------------- #
+
+
+class TestNormalizeExportFormat:
+    def test_normalizes_text_variants(self) -> None:
+        assert normalize_export_format("text") == "text"
+        assert normalize_export_format("txt") == "text"
+        assert normalize_export_format("TEXT") == "text"
+        assert normalize_export_format(" TxT ") == "text"
+
+    def test_normalizes_markdown_variants(self) -> None:
+        assert normalize_export_format("markdown") == "markdown"
+        assert normalize_export_format("md") == "markdown"
+        assert normalize_export_format("Markdown") == "markdown"
+        assert normalize_export_format(" MD ") == "markdown"
+
+    def test_normalizes_json(self) -> None:
+        assert normalize_export_format("json") == "json"
+        assert normalize_export_format("JSON") == "json"
+        assert normalize_export_format(" Json ") == "json"
+
+    def test_returns_none_for_unknown(self) -> None:
+        assert normalize_export_format("xml") is None
+        assert normalize_export_format("") is None
+        assert normalize_export_format("csv") is None
+
+
+# --------------------------------------------------------------------------- #
+# infer_export_format_from_filename
+# --------------------------------------------------------------------------- #
+
+
+class TestInferExportFormatFromFilename:
+    def test_infers_from_txt(self) -> None:
+        assert infer_export_format_from_filename("a.txt") == "text"
+
+    def test_infers_from_md(self) -> None:
+        assert infer_export_format_from_filename("a.md") == "markdown"
+
+    def test_infers_from_markdown(self) -> None:
+        assert infer_export_format_from_filename("a.markdown") == "markdown"
+
+    def test_infers_from_json(self) -> None:
+        assert infer_export_format_from_filename("a.json") == "json"
+
+    def test_returns_none_for_no_extension(self) -> None:
+        assert infer_export_format_from_filename("a") is None
+
+    def test_returns_none_for_unknown_extension(self) -> None:
+        assert infer_export_format_from_filename("a.csv") is None
+
+
+# --------------------------------------------------------------------------- #
+# extension_for_export_format
+# --------------------------------------------------------------------------- #
+
+
+class TestExtensionForExportFormat:
+    def test_returns_txt_for_text(self) -> None:
+        assert extension_for_export_format("text") == ".txt"
+
+    def test_returns_md_for_markdown(self) -> None:
+        assert extension_for_export_format("markdown") == ".md"
+
+    def test_returns_json_for_json(self) -> None:
+        assert extension_for_export_format("json") == ".json"
+
+
+# --------------------------------------------------------------------------- #
+# ensure_export_filename_extension
+# --------------------------------------------------------------------------- #
+
+
+class TestEnsureExportFilenameExtension:
+    def test_adds_extension_when_none(self) -> None:
+        assert ensure_export_filename_extension("a", "text") == "a.txt"
+
+    def test_replaces_wrong_extension_for_markdown(self) -> None:
+        assert ensure_export_filename_extension("a.json", "markdown") == "a.md"
+
+    def test_replaces_wrong_extension_for_json(self) -> None:
+        assert ensure_export_filename_extension("a.txt", "json") == "a.json"
+
+    def test_handles_name_with_dots(self) -> None:
+        assert (
+            ensure_export_filename_extension("my.conversation.txt", "json")
+            == "my.conversation.json"
+        )
+
+    def test_normalizes_trailing_dot_filenames_without_duplicating_separators(
+        self,
+    ) -> None:
+        assert ensure_export_filename_extension("conversation.", "json") == "conversation.json"
+
+    def test_does_not_treat_dots_in_directory_names_as_filename_extensions(
+        self,
+    ) -> None:
+        assert (
+            ensure_export_filename_extension("logs.v1/transcript", "json")
+            == "logs.v1/transcript.json"
+        )
+
+    def test_does_not_treat_a_dotfile_name_as_an_extension_only_filename(self) -> None:
+        assert ensure_export_filename_extension(".env", "text") == ".env.txt"
+
+    def test_preserves_correct_extension(self) -> None:
+        assert ensure_export_filename_extension("a.md", "markdown") == "a.md"
+
+    def test_preserves_supported_markdown_extension(self) -> None:
+        assert (
+            ensure_export_filename_extension(
+                "a.markdown", "markdown", preserve_markdown_extension=True
+            )
+            == "a.markdown"
+        )
+
+    def test_canonicalizes_markdown_to_md_by_default(self) -> None:
+        assert ensure_export_filename_extension("a.markdown", "markdown") == "a.md"
+
+
+# --------------------------------------------------------------------------- #
+# parse_export_args
+# --------------------------------------------------------------------------- #
+
+
+class TestParseExportArgs:
+    def test_empty_args(self) -> None:
+        assert parse_export_args("") == ParsedExportArgs()
+
+    def test_filename_only(self) -> None:
+        assert parse_export_args("transcript.txt") == ParsedExportArgs(
+            filename="transcript.txt"
+        )
+
+    def test_format_json_with_filename(self) -> None:
+        assert parse_export_args("--format json transcript") == ParsedExportArgs(
+            format="json", filename="transcript"
+        )
+
+    def test_f_md_with_filename(self) -> None:
+        assert parse_export_args("-f md transcript.txt") == ParsedExportArgs(
+            format="markdown", filename="transcript.txt"
+        )
+
+    def test_format_flag_overrides_extension(self) -> None:
+        result = parse_export_args("--format json transcript.txt")
+        assert result.format == "json"
+        assert result.filename == "transcript.txt"
+
+    def test_unsupported_format_returns_error(self) -> None:
+        result = parse_export_args("--format xml transcript")
+        assert result.error is not None
+        assert "Unsupported export format: xml" in result.error
+
+    def test_unsupported_dash_prefixed_option_returns_error(self) -> None:
+        result = parse_export_args("--formt json transcript")
+        assert result.error is not None
+        assert "Unsupported export option: --formt" in result.error
+
+    def test_missing_format_value_returns_error(self) -> None:
+        result = parse_export_args("--format")
+        assert result.error is not None
+        assert "Missing value for --format" in result.error
+
+    def test_f_short_form(self) -> None:
+        assert parse_export_args("-f text conversation") == ParsedExportArgs(
+            format="text", filename="conversation"
+        )
+
+    def test_format_markdown(self) -> None:
+        assert parse_export_args("--format markdown output") == ParsedExportArgs(
+            format="markdown", filename="output"
+        )
+
+    def test_preserves_filenames_with_spaces(self) -> None:
+        assert parse_export_args("my conversation.txt") == ParsedExportArgs(
+            filename="my conversation.txt"
+        )
+
+    def test_preserves_filename_with_spaces_and_format_flag(self) -> None:
+        assert parse_export_args("--format json my conversation") == ParsedExportArgs(
+            format="json", filename="my conversation"
+        )
+
+    def test_format_flag_after_filename(self) -> None:
+        assert parse_export_args("output --format json") == ParsedExportArgs(
+            format="json", filename="output"
+        )
+
+    def test_parses_quoted_filenames(self) -> None:
+        assert parse_export_args('--format json "my conversation"') == ParsedExportArgs(
+            format="json", filename="my conversation"
+        )
+
+    def test_treats_quoted_flag_looking_tokens_as_filenames(self) -> None:
+        assert parse_export_args('"--format"') == ParsedExportArgs(filename="--format")
+
+    def test_supports_double_dash_terminator_for_dash_leading_filenames(self) -> None:
+        assert parse_export_args("-- --format") == ParsedExportArgs(filename="--format")
+
+    def test_parses_quoted_format_values(self) -> None:
+        assert parse_export_args('--format "md" transcript') == ParsedExportArgs(
+            format="markdown", filename="transcript"
+        )
+
+    def test_reports_unterminated_quoted_strings(self) -> None:
+        result = parse_export_args('--format json "my conversation')
+        assert result.error is not None
+        assert "Unterminated quoted string" in result.error
+
+
+# --------------------------------------------------------------------------- #
+# resolve_export_filepath
+# --------------------------------------------------------------------------- #
+
+
+class TestResolveExportFilepath:
+    def test_resolves_relative_export_filenames_under_cwd(self) -> None:
+        assert (
+            resolve_export_filepath("/work/project", "transcript.md")
+            == "/work/project/transcript.md"
+        )
+
+    def test_preserves_absolute_export_filenames(self) -> None:
+        assert (
+            resolve_export_filepath("/work/project", "/tmp/transcript.md")
+            == "/tmp/transcript.md"
+        )

--- a/tests/test_export_renderer.py
+++ b/tests/test_export_renderer.py
@@ -1,0 +1,975 @@
+"""Tests for :mod:`src.utils.export_renderer`.
+
+Ports the *pure-renderer* portions of ``typescript/src/utils/exportRenderer.test.ts``:
+``renderMessagesToMarkdown`` and ``renderMessagesToJSON``. Plus a fresh
+plain-text suite (no TS reference exists — TS's ``text`` format streams Ink,
+which is surface-coupled and not line-ported; Python's ``text`` format is a
+standalone structured transcript).
+
+Two deliberate adaptations from the TS fixtures (documented for parity review):
+
+* **Terminal-output fixtures skipped.** TS exercises a ``<bash-stdout>`` /
+  ``<local-command-stdout>`` / ``<bash-input>`` envelope parser. Python ``src/``
+  never emits those wrappers (grep-confirmed zero occurrences), so the parser is
+  dead code and was not ported; its fixtures are intentionally absent here.
+
+* **``<command-name>`` -> ``<task-notification>``.** TS's ``INTERNAL_TEXT_TAGS``
+  includes nine tags; of those only ``<task-notification>`` is live in Python
+  (``src/constants/xml.py`` — emitted by the coordinator as user-role content).
+  The "internal text block filtering" fixtures therefore use
+  ``<task-notification>`` where TS used ``<command-name>``; the *behavior* under
+  test (internal wrappers stripped, surrounding visible text preserved) is
+  identical.
+
+Fixtures use the TS wire shape ``{type, message: {role, content}, timestamp}``;
+the renderer's dual-mode accessors read this exactly as they read flat Python
+dataclasses.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List
+
+from src.types.messages import (
+    CANCEL_MESSAGE,
+    INTERRUPT_MESSAGE,
+    SYNTHETIC_TOOL_RESULT_PLACEHOLDER,
+)
+from src.utils.export_renderer import (
+    render_messages_to_json,
+    render_messages_to_markdown,
+    render_messages_to_plain_text,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fixture builders (mirror the TS test's Message-shaped helpers)
+# --------------------------------------------------------------------------- #
+
+
+def user_message(text: str) -> Dict[str, Any]:
+    return {
+        "type": "user",
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+        "timestamp": "2026-05-13T12:00:00Z",
+    }
+
+
+def assistant_message(text: str) -> Dict[str, Any]:
+    return {
+        "type": "assistant",
+        "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+        "timestamp": "2026-05-13T12:00:01Z",
+    }
+
+
+def tool_use_message(tool_name: str, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": "tool-123", "name": tool_name, "input": tool_input}
+            ],
+        },
+        "timestamp": "2026-05-13T12:00:02Z",
+    }
+
+
+def tool_result_message(content: str, is_error: bool = False) -> Dict[str, Any]:
+    return {
+        "type": "tool",
+        "message": {
+            "role": "tool",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "tool-123",
+                    "content": content,
+                    "is_error": is_error,
+                }
+            ],
+        },
+        "timestamp": "2026-05-13T12:00:03Z",
+    }
+
+
+def _parse(messages: List[Any]) -> Dict[str, Any]:
+    return json.loads(render_messages_to_json(messages))
+
+
+# --------------------------------------------------------------------------- #
+# renderMessagesToMarkdown
+# --------------------------------------------------------------------------- #
+
+
+class TestRenderMessagesToMarkdown:
+    def test_includes_conversation_export_header(self) -> None:
+        md = render_messages_to_markdown([user_message("hello")])
+        assert "# Conversation Export" in md
+        assert "Format: Markdown" in md
+
+    def test_includes_exported_timestamp(self) -> None:
+        md = render_messages_to_markdown([])
+        assert re.search(r"Exported: \d{4}-\d{2}-\d{2}T", md)
+
+    def test_renders_user_and_assistant_headings(self) -> None:
+        md = render_messages_to_markdown([user_message("hello"), assistant_message("world")])
+        assert "## User" in md
+        assert "## Assistant" in md
+
+    def test_preserves_text_content(self) -> None:
+        md = render_messages_to_markdown([user_message("hello world")])
+        assert "hello world" in md
+
+    def test_renders_tool_use_blocks(self) -> None:
+        md = render_messages_to_markdown([tool_use_message("Bash", {"command": "ls -la"})])
+        assert "### Tool Use: Bash" in md
+        assert "```json" in md
+        assert "ls -la" in md
+
+    def test_uses_longer_fence_when_tool_input_contains_backticks(self) -> None:
+        md = render_messages_to_markdown([tool_use_message("Bash", {"command": 'printf "```"'})])
+        assert "````json" in md
+        assert 'printf \\"```\\"' in md
+
+    def test_renders_tool_result_blocks(self) -> None:
+        md = render_messages_to_markdown([tool_result_message("file1.txt\nfile2.txt")])
+        assert "## Tool Result" in md
+        assert "file1.txt" in md
+        # No duplicate sub-heading since the message heading already says it.
+        assert "### Tool Result" not in md
+
+    def test_uses_longer_fence_when_tool_output_contains_backticks(self) -> None:
+        md = render_messages_to_markdown([tool_result_message("before\n```\ninside\n```\nafter")])
+        assert "````text" in md
+        assert "before\n```\ninside\n```\nafter" in md
+
+    def test_marks_errored_tool_results_from_runtime_is_error_field(self) -> None:
+        md = render_messages_to_markdown([tool_result_message("failure output", True)])
+        assert "failure output" in md
+        assert "*(Error)*" in md
+
+    def test_renders_tool_result_from_runtime_shape(self) -> None:
+        runtime_tool_result = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "tu-1", "content": "output text"}],
+            },
+        }
+        md = render_messages_to_markdown([runtime_tool_result])
+        assert "## Tool Result" in md
+        assert "output text" in md
+        assert "## User" not in md
+        assert "### Tool Result" not in md
+
+    def test_does_not_label_mixed_human_text_and_tool_result_as_tool_result(self) -> None:
+        mixed_message = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tu-1", "content": "tool output"},
+                    {"type": "text", "text": "human follow-up"},
+                ],
+            },
+        }
+        md = render_messages_to_markdown([mixed_message])
+        assert "## User" in md
+        assert "### Tool Result" in md
+        assert "human follow-up" in md
+
+    def test_treats_system_reminder_siblings_as_tool_result_metadata(self) -> None:
+        runtime_tool_result = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tu-1", "content": "tool output"},
+                    {"type": "text", "text": "<system-reminder>note</system-reminder>"},
+                ],
+            },
+        }
+        md = render_messages_to_markdown([runtime_tool_result])
+        assert "## Tool Result" in md
+        assert "## User" not in md
+        assert "<system-reminder>" not in md
+
+    def test_handles_empty_messages_array(self) -> None:
+        md = render_messages_to_markdown([])
+        assert "# Conversation Export" in md
+        assert "## User" not in md
+
+    def test_handles_null_messages_gracefully(self) -> None:
+        md = render_messages_to_markdown([None, None])
+        assert "# Conversation Export" in md
+
+    def test_renders_image_placeholder(self) -> None:
+        msg = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "image", "source": {"type": "base64", "media_type": "image/png"}}],
+            },
+        }
+        md = render_messages_to_markdown([msg])
+        assert "[Image attachment]" in md
+
+    def test_skips_progress_messages(self) -> None:
+        progress_msg = {
+            "type": "progress",
+            "message": {"role": "user", "content": [{"type": "text", "text": "Loading..."}]},
+        }
+        md = render_messages_to_markdown([progress_msg, user_message("hello")])
+        assert "## Progress" not in md
+        assert "## User" in md
+
+    def test_skips_attachment_messages(self) -> None:
+        att_msg = {"type": "attachment", "attachment": {"type": "file", "name": "test.txt"}}
+        md = render_messages_to_markdown([att_msg, user_message("hello")])
+        assert "## Attachment" not in md
+        assert "## User" in md
+
+    def test_skips_system_api_metrics_messages(self) -> None:
+        metrics_msg = {
+            "type": "system",
+            "subtype": "api_metrics",
+            "message": {"role": "system", "content": []},
+        }
+        md = render_messages_to_markdown([metrics_msg, user_message("hello")])
+        assert "## System" not in md
+        assert "## User" in md
+
+    def test_skips_messages_with_empty_content(self) -> None:
+        empty_msg = {"type": "system", "message": {"role": "system", "content": []}}
+        md = render_messages_to_markdown([empty_msg, user_message("hello")])
+        assert "## System" not in md
+        assert "## User" in md
+
+    def test_skips_thinking_blocks(self) -> None:
+        msg = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "thinking", "thinking": "Let me think about this..."}],
+            },
+        }
+        md = render_messages_to_markdown([msg])
+        assert "Let me think about this..." not in md
+        assert "## Assistant" not in md
+
+    def test_skips_redacted_thinking_blocks(self) -> None:
+        msg = {
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "redacted_thinking"}]},
+        }
+        md = render_messages_to_markdown([msg])
+        assert "redacted_thinking" not in md
+        assert "## Assistant" not in md
+
+    def test_renders_top_level_system_message_content(self) -> None:
+        md = render_messages_to_markdown(
+            [{"type": "system", "subtype": "local_command", "content": "local command output"}]
+        )
+        assert "## System" in md
+        assert "local command output" in md
+
+    def test_renders_unknown_content_block_payload(self) -> None:
+        md = render_messages_to_markdown(
+            [
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "server_tool_use", "id": "srv-1", "name": "web_search"}],
+                    },
+                }
+            ]
+        )
+        assert "*[server_tool_use content block]*" in md
+        assert "```json" in md
+        assert '"id": "srv-1"' in md
+        assert '"name": "web_search"' in md
+
+    def test_handles_malformed_numeric_message_types(self) -> None:
+        md = render_messages_to_markdown(
+            [{"type": 42, "message": {"content": [{"type": "text", "text": "numeric type"}]}}]
+        )
+        assert "## 42" in md
+        assert "numeric type" in md
+
+    def test_skips_internal_meta_and_breadcrumb_messages(self) -> None:
+        # Adaptation: <command-name> -> <task-notification> (Python's only live
+        # internal text tag). isMeta + internal-text-only messages are dropped.
+        md = render_messages_to_markdown(
+            [
+                {
+                    "type": "user",
+                    "isMeta": True,
+                    "message": {"role": "user", "content": [{"type": "text", "text": "internal caveat"}]},
+                },
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "<task-notification>note</task-notification>"},
+                },
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "<system-reminder>hidden</system-reminder>"},
+                },
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "<system-reminder>hidden array</system-reminder>"}],
+                    },
+                },
+                user_message("visible user text"),
+            ]
+        )
+        assert "internal caveat" not in md
+        assert "<task-notification>" not in md
+        assert "<system-reminder>" not in md
+        assert "visible user text" in md
+
+    def test_filters_internal_text_blocks_preserving_mixed_real_content(self) -> None:
+        md = render_messages_to_markdown(
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "<task-notification>note</task-notification>"},
+                            {"type": "text", "text": "real user content"},
+                        ],
+                    },
+                }
+            ]
+        )
+        assert "## User" in md
+        assert "real user content" in md
+        assert "<task-notification>" not in md
+
+    def test_does_not_drop_visible_text_containing_internal_tag_wrappers(self) -> None:
+        md = render_messages_to_markdown(
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "visible before <task-notification>x</task-notification> visible after",
+                            }
+                        ],
+                    },
+                }
+            ]
+        )
+        assert "## User" in md
+        assert "visible before  visible after" in md
+        assert "<task-notification>" not in md
+
+    def test_strips_system_reminders_embedded_in_visible_text(self) -> None:
+        md = render_messages_to_markdown(
+            [user_message("visible before <system-reminder>hidden</system-reminder> visible after")]
+        )
+        assert "visible before  visible after" in md
+        assert "<system-reminder>" not in md
+        assert "hidden" not in md
+
+    def test_renders_fallback_for_non_array_unknown_content(self) -> None:
+        md = render_messages_to_markdown([{"type": "custom", "content": {"value": 42}}])
+        assert "## Custom" in md
+        assert "*[unknown content]*" in md
+        assert '"value": 42' in md
+
+    def test_renders_fallback_for_primitive_array_entries(self) -> None:
+        md = render_messages_to_markdown(
+            [{"type": "assistant", "message": {"role": "assistant", "content": ["primitive content"]}}]
+        )
+        assert "## Assistant" in md
+        assert "*[unknown content]*" in md
+        assert "primitive content" in md
+
+
+# --------------------------------------------------------------------------- #
+# renderMessagesToJSON
+# --------------------------------------------------------------------------- #
+
+
+class TestRenderMessagesToJSON:
+    def test_produces_valid_json(self) -> None:
+        json.loads(render_messages_to_json([user_message("hello")]))  # no raise
+
+    def test_includes_version_1(self) -> None:
+        assert _parse([])["version"] == 1
+
+    def test_includes_format_json(self) -> None:
+        assert _parse([])["format"] == "json"
+
+    def test_includes_exported_at_as_iso_string(self) -> None:
+        assert re.match(r"^\d{4}-\d{2}-\d{2}T", _parse([])["exportedAt"])
+
+    def test_includes_message_count(self) -> None:
+        parsed = _parse([user_message("a"), assistant_message("b")])
+        assert parsed["messageCount"] == 2
+
+    def test_preserves_message_order(self) -> None:
+        parsed = _parse(
+            [user_message("first"), assistant_message("second"), user_message("third")]
+        )
+        assert parsed["messages"][0]["content"][0]["text"] == "first"
+        assert parsed["messages"][1]["content"][0]["text"] == "second"
+        assert parsed["messages"][2]["content"][0]["text"] == "third"
+
+    def test_includes_message_type_and_role(self) -> None:
+        parsed = _parse([user_message("hello")])
+        assert parsed["messages"][0]["type"] == "user"
+        assert parsed["messages"][0]["role"] == "user"
+
+    def test_handles_tool_use_content_blocks(self) -> None:
+        parsed = _parse([tool_use_message("Read", {"file_path": "/test.ts"})])
+        content = parsed["messages"][0]["content"][0]
+        assert content["type"] == "tool_use"
+        assert content["name"] == "Read"
+        assert content["input"]["file_path"] == "/test.ts"
+
+    def test_handles_tool_result_content_blocks(self) -> None:
+        parsed = _parse([tool_result_message("result text", True)])
+        assert parsed["messages"][0]["role"] == "tool"
+        content = parsed["messages"][0]["content"][0]
+        assert content["type"] == "tool_result"
+        assert content["content"] == "result text"
+        assert content["isError"] is True
+
+    def test_exports_runtime_tool_result_as_semantic_tool_message(self) -> None:
+        runtime_tool_result = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "tu-1", "content": "output"}],
+            },
+        }
+        parsed = _parse([runtime_tool_result])
+        msg = parsed["messages"][0]
+        assert msg["type"] == "tool"
+        assert msg["role"] == "tool"
+        assert "internalType" not in msg
+        assert "rawType" not in msg
+        assert msg["content"][0]["type"] == "tool_result"
+
+    def test_keeps_mixed_human_text_and_tool_result_as_user_message(self) -> None:
+        mixed_message = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tu-1", "content": "tool output"},
+                    {"type": "text", "text": "human follow-up"},
+                ],
+            },
+        }
+        parsed = _parse([mixed_message])
+        msg = parsed["messages"][0]
+        assert msg["type"] == "user"
+        assert msg["role"] == "user"
+        assert "internalType" not in msg
+        assert [block["type"] for block in msg["content"]] == ["tool_result", "text"]
+
+    def test_keeps_mixed_non_text_and_tool_result_as_user_message(self) -> None:
+        mixed_message = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tu-1", "content": "tool output"},
+                    {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "abc"}},
+                ],
+            },
+        }
+        parsed = _parse([mixed_message])
+        msg = parsed["messages"][0]
+        assert msg["type"] == "user"
+        assert msg["role"] == "user"
+        assert [block["type"] for block in msg["content"]] == ["tool_result", "image"]
+
+    def test_exports_system_reminder_siblings_as_semantic_tool_messages(self) -> None:
+        runtime_tool_result = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tu-1", "content": "tool output"},
+                    {"type": "text", "text": "<system-reminder>note</system-reminder>"},
+                ],
+            },
+        }
+        parsed = _parse([runtime_tool_result])
+        msg = parsed["messages"][0]
+        assert msg["type"] == "tool"
+        assert msg["role"] == "tool"
+        assert "internalType" not in msg
+        assert "rawType" not in msg
+        assert len(msg["content"]) == 1
+
+    def test_safely_handles_non_serializable_content(self) -> None:
+        cyclic: Dict[str, Any] = {"a": 1}
+        cyclic["self"] = cyclic
+        msg = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "tool-1", "name": "Cyclic", "input": cyclic}],
+            },
+        }
+        parsed = _parse([msg])
+        assert parsed["messages"][0]["content"][0]["input"] == {"a": 1, "self": "[Circular]"}
+
+    def test_safely_handles_throwing_getters_in_json_content(self) -> None:
+        # Python analog of the TS throwing-getter fixture: a Mapping whose item
+        # access raises. safe_json_value reaches the per-key guard -> sentinel.
+        class _ThrowingGetterMapping(dict):
+            def __getitem__(self, key: Any) -> Any:
+                if key == "boom":
+                    raise RuntimeError("getter exploded")
+                return super().__getitem__(key)
+
+        hostile = _ThrowingGetterMapping(boom=None)
+        msg = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "tool-1", "name": "Hostile", "input": hostile}],
+            },
+        }
+        parsed = _parse([msg])
+        assert parsed["messages"][0]["content"][0]["input"] == {"boom": "[Unserializable]"}
+
+    def test_exports_unknown_message_types_with_stable_public_type_and_raw_type(self) -> None:
+        parsed = _parse([{"type": "custom"}])
+        msg = parsed["messages"][0]
+        assert msg["type"] == "unknown"
+        assert msg["role"] == "unknown"
+        assert msg["rawType"] == "custom"
+
+    def test_does_not_emit_empty_raw_type_for_messages_without_a_type(self) -> None:
+        parsed = _parse([{}])
+        msg = parsed["messages"][0]
+        assert msg["type"] == "unknown"
+        assert msg["role"] == "unknown"
+        assert "rawType" not in msg
+
+    def test_normalizes_camel_case_tool_result_ids(self) -> None:
+        parsed = _parse(
+            [
+                {
+                    "type": "tool",
+                    "message": {
+                        "role": "tool",
+                        "content": [
+                            {"type": "tool_result", "toolUseId": "camel-id", "content": "ok", "isError": False}
+                        ],
+                    },
+                }
+            ]
+        )
+        content = parsed["messages"][0]["content"][0]
+        assert content["toolUseId"] == "camel-id"
+        assert content["isError"] is False
+
+    def test_preserves_timestamp_when_present(self) -> None:
+        parsed = _parse([user_message("hello")])
+        assert parsed["messages"][0]["timestamp"] == "2026-05-13T12:00:00Z"
+
+    def test_uses_2_space_indentation(self) -> None:
+        rendered = render_messages_to_json([user_message("hello")])
+        assert '  "version"' in rendered
+
+    def test_filters_out_progress_messages(self) -> None:
+        progress_msg = {
+            "type": "progress",
+            "message": {"role": "user", "content": [{"type": "text", "text": "Loading..."}]},
+        }
+        parsed = _parse([progress_msg, user_message("hello")])
+        assert parsed["messageCount"] == 1
+        assert parsed["messages"][0]["type"] == "user"
+
+    def test_filters_out_attachment_messages(self) -> None:
+        att_msg = {"type": "attachment", "attachment": {"type": "file"}}
+        parsed = _parse([att_msg, user_message("hello")])
+        assert parsed["messageCount"] == 1
+
+    def test_skips_thinking_content_blocks(self) -> None:
+        msg = {
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "thinking", "thinking": "inner thoughts"}]},
+        }
+        assert _parse([msg])["messageCount"] == 0
+
+    def test_skips_redacted_thinking_content_blocks(self) -> None:
+        msg = {
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "redacted_thinking"}]},
+        }
+        assert _parse([msg])["messageCount"] == 0
+
+    def test_preserves_top_level_system_message_content(self) -> None:
+        parsed = _parse(
+            [
+                {
+                    "type": "system",
+                    "subtype": "local_command",
+                    "content": "local command output",
+                    "timestamp": "2026-05-13T12:00:04Z",
+                }
+            ]
+        )
+        assert parsed["messageCount"] == 1
+        msg = parsed["messages"][0]
+        assert msg["type"] == "system"
+        assert msg["subtype"] == "local_command"
+        assert msg["content"][0] == {"type": "text", "text": "local command output"}
+
+    def test_strips_system_reminders_embedded_in_visible_json_text(self) -> None:
+        parsed = _parse(
+            [user_message("visible before <system-reminder>hidden</system-reminder> visible after")]
+        )
+        assert parsed["messages"][0]["content"][0]["text"] == "visible before  visible after"
+
+    def test_strips_system_reminders_nested_inside_tool_result_content(self) -> None:
+        parsed = _parse(
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "tu-1",
+                                "content": [
+                                    {"type": "text", "text": "visible <system-reminder>hidden</system-reminder>"}
+                                ],
+                            }
+                        ],
+                    },
+                }
+            ]
+        )
+        assert parsed["messages"][0]["content"][0]["content"][0]["text"] == "visible"
+        serialized = json.dumps(parsed)
+        assert "system-reminder" not in serialized
+        assert "hidden" not in serialized
+
+    def test_preserves_source_index_when_internal_messages_filtered(self) -> None:
+        parsed = _parse(
+            [
+                {"type": "progress", "message": {"role": "user", "content": [{"type": "text", "text": "loading"}]}},
+                user_message("visible"),
+            ]
+        )
+        assert parsed["messages"][0]["index"] == 0
+        assert parsed["messages"][0]["sourceIndex"] == 1
+
+    def test_skips_synthetic_missing_tool_result_placeholders(self) -> None:
+        parsed = _parse(
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "missing",
+                                "content": SYNTHETIC_TOOL_RESULT_PLACEHOLDER,
+                                "is_error": True,
+                            }
+                        ],
+                    },
+                },
+                user_message("visible"),
+            ]
+        )
+        assert parsed["messageCount"] == 1
+        assert parsed["messages"][0]["content"][0]["text"] == "visible"
+
+    def test_skips_synthetic_missing_tool_result_placeholders_with_internal_siblings(self) -> None:
+        parsed = _parse(
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "missing",
+                                "content": SYNTHETIC_TOOL_RESULT_PLACEHOLDER,
+                                "is_error": True,
+                            },
+                            {"type": "text", "text": "<system-reminder>hidden metadata</system-reminder>"},
+                        ],
+                    },
+                },
+                user_message("visible"),
+            ]
+        )
+        assert parsed["messageCount"] == 1
+        assert parsed["messages"][0]["content"][0]["text"] == "visible"
+
+    def test_skips_synthetic_first_text_bracketed_literals(self) -> None:
+        # Pins the corrected ``_SYNTHETIC_FIRST_TEXTS`` contract: TS
+        # ``isSyntheticContent`` filters on five *bracketed display literals*.
+        # Three of them have no Python constant but must still be filtered so the
+        # synthetic-message filter stays byte-identical to TS.
+        for literal in ("[Request cancelled]", "[Tool use rejected]", "[No response requested]"):
+            parsed = _parse(
+                [
+                    {
+                        "type": "user",
+                        "message": {"role": "user", "content": [{"type": "text", "text": literal}]},
+                    },
+                    user_message("visible"),
+                ]
+            )
+            assert parsed["messageCount"] == 1, literal
+            assert parsed["messages"][0]["content"][0]["text"] == "visible"
+
+    def test_does_not_skip_semantic_cancel_message_sentence(self) -> None:
+        # The flip side of the contract: Python's ``CANCEL_MESSAGE`` is a full
+        # sentence, NOT the bracketed literal TS keys on, so it must remain
+        # exportable. Filtering on it instead would over-filter relative to TS.
+        parsed = _parse(
+            [
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": [{"type": "text", "text": CANCEL_MESSAGE}]},
+                },
+                user_message("visible"),
+            ]
+        )
+        assert parsed["messageCount"] == 2
+        assert parsed["messages"][0]["content"][0]["text"] == CANCEL_MESSAGE
+
+    def test_preserves_unknown_content_block_type_while_sanitizing_value(self) -> None:
+        parsed = _parse(
+            [
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "server_tool_use", "id": "srv-1", "name": "web_search"}],
+                    },
+                }
+            ]
+        )
+        content = parsed["messages"][0]["content"][0]
+        assert content["type"] == "server_tool_use"
+        assert content["value"] == {"type": "server_tool_use", "id": "srv-1", "name": "web_search"}
+
+    def test_skips_internal_meta_and_breadcrumb_messages(self) -> None:
+        # Adaptation: <command-name> -> <task-notification> (see module docstring).
+        parsed = _parse(
+            [
+                {
+                    "type": "user",
+                    "isMeta": True,
+                    "message": {"role": "user", "content": [{"type": "text", "text": "internal caveat"}]},
+                },
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "<task-notification>note</task-notification>"},
+                },
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "<system-reminder>hidden</system-reminder>"},
+                },
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "<system-reminder>hidden array</system-reminder>"}],
+                    },
+                },
+                user_message("visible user text"),
+            ]
+        )
+        assert parsed["messageCount"] == 1
+        assert parsed["messages"][0]["content"][0]["text"] == "visible user text"
+
+    def test_filters_internal_text_blocks_preserving_mixed_real_content(self) -> None:
+        parsed = _parse(
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "<task-notification>note</task-notification>"},
+                            {"type": "text", "text": "real user content"},
+                        ],
+                    },
+                }
+            ]
+        )
+        assert parsed["messageCount"] == 1
+        assert parsed["messages"][0]["content"] == [{"type": "text", "text": "real user content"}]
+
+    def test_does_not_drop_visible_text_containing_internal_tag_wrappers(self) -> None:
+        parsed = _parse(
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "visible before <task-notification>x</task-notification> visible after",
+                            }
+                        ],
+                    },
+                }
+            ]
+        )
+        assert parsed["messageCount"] == 1
+        assert parsed["messages"][0]["type"] == "user"
+        assert parsed["messages"][0]["content"][0]["text"] == "visible before  visible after"
+
+
+# --------------------------------------------------------------------------- #
+# render_messages_to_plain_text  (no TS reference — Python-only transcript)
+# --------------------------------------------------------------------------- #
+
+
+class TestRenderMessagesToPlainText:
+    def test_includes_header(self) -> None:
+        text = render_messages_to_plain_text([user_message("hello")])
+        assert "Conversation Export" in text
+        assert "Format: Text" in text
+
+    def test_includes_exported_timestamp(self) -> None:
+        text = render_messages_to_plain_text([])
+        assert re.search(r"Exported: \d{4}-\d{2}-\d{2}T", text)
+
+    def test_renders_plain_user_and_assistant_headings(self) -> None:
+        text = render_messages_to_plain_text([user_message("hello"), assistant_message("world")])
+        lines = text.splitlines()
+        assert "User" in lines
+        assert "Assistant" in lines
+        # No markdown heading syntax in the plain-text format.
+        assert "## User" not in text
+
+    def test_preserves_text_content(self) -> None:
+        text = render_messages_to_plain_text([user_message("hello world")])
+        assert "hello world" in text
+
+    def test_renders_tool_use_blocks(self) -> None:
+        text = render_messages_to_plain_text([tool_use_message("Bash", {"command": "ls -la"})])
+        assert "Tool Use: Bash" in text
+        assert "ls -la" in text
+
+    def test_renders_tool_result_blocks(self) -> None:
+        text = render_messages_to_plain_text([tool_result_message("file1.txt\nfile2.txt")])
+        assert "Tool Result" in text.splitlines()
+        assert "file1.txt" in text
+
+    def test_marks_errored_tool_results(self) -> None:
+        text = render_messages_to_plain_text([tool_result_message("failure output", True)])
+        assert "failure output" in text
+        assert "(Error)" in text
+
+    def test_renders_image_placeholder(self) -> None:
+        msg = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "image", "source": {"type": "base64", "media_type": "image/png"}}],
+            },
+        }
+        text = render_messages_to_plain_text([msg])
+        assert "[Image attachment]" in text
+
+    def test_strips_system_reminders_in_visible_text(self) -> None:
+        text = render_messages_to_plain_text(
+            [user_message("visible before <system-reminder>hidden</system-reminder> visible after")]
+        )
+        assert "visible before  visible after" in text
+        assert "<system-reminder>" not in text
+        assert "hidden" not in text
+
+    def test_skips_progress_messages(self) -> None:
+        progress_msg = {
+            "type": "progress",
+            "message": {"role": "user", "content": [{"type": "text", "text": "Loading..."}]},
+        }
+        text = render_messages_to_plain_text([progress_msg, user_message("hello")])
+        assert "Loading..." not in text
+        assert "User" in text.splitlines()
+
+    def test_skips_thinking_blocks(self) -> None:
+        msg = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "thinking", "thinking": "Let me think about this..."}],
+            },
+        }
+        text = render_messages_to_plain_text([msg])
+        assert "Let me think about this..." not in text
+        assert "Assistant" not in text.splitlines()
+
+    def test_skips_synthetic_first_text_messages(self) -> None:
+        synthetic = {
+            "type": "user",
+            "message": {"role": "user", "content": [{"type": "text", "text": INTERRUPT_MESSAGE}]},
+        }
+        text = render_messages_to_plain_text([synthetic, user_message("visible")])
+        assert INTERRUPT_MESSAGE not in text
+        assert "visible" in text
+
+    def test_skips_synthetic_tool_result_placeholder_messages(self) -> None:
+        synthetic = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "missing",
+                        "content": SYNTHETIC_TOOL_RESULT_PLACEHOLDER,
+                        "is_error": True,
+                    }
+                ],
+            },
+        }
+        text = render_messages_to_plain_text([synthetic, user_message("visible")])
+        assert SYNTHETIC_TOOL_RESULT_PLACEHOLDER not in text
+        assert "visible" in text
+
+    def test_empty_messages_has_header_only(self) -> None:
+        text = render_messages_to_plain_text([])
+        assert "Conversation Export" in text
+        assert "User" not in text.splitlines()
+
+    def test_dispatcher_routes_each_format(self) -> None:
+        from src.utils.export_renderer import render_messages_for_export
+
+        msgs = [user_message("hello")]
+        assert "Format: Text" in render_messages_for_export(msgs, format="text")
+        assert "Format: Markdown" in render_messages_for_export(msgs, format="markdown")
+        assert '"format": "json"' in render_messages_for_export(msgs, format="json")
+
+    def test_dispatcher_rejects_unknown_format(self) -> None:
+        import pytest
+
+        from src.utils.export_renderer import render_messages_for_export
+
+        with pytest.raises(ValueError):
+            render_messages_for_export([], format="xml")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Phase 4 **P2** of the `/export` port (P1 = prompt_text primitive, merged in #243). Ports the *pure*, surface-agnostic export logic from `typescript/src/utils/`:

- **`src/utils/export_formats.py`** — port of `exportFormats.ts`: format normalization (`text`/`markdown`/`json`), `/export` argument parsing (`parse_export_args`), filename/extension and filepath helpers.
- **`src/utils/export_renderer.py`** — port of the *pure* renderers in `exportRenderer.tsx`: the markdown renderer, the JSON renderer (camelCase, wire-compatible with TS), a from-scratch plain-text transcriber, and the `render_messages_for_export` dispatcher.

### Deliberate, documented divergences from TS
- **No Ink/terminal `text` renderer.** TS streams the React/Ink UI through `renderToAnsiString` — surface-coupled and not line-portable. Python's `text` format is a standalone plain-text transcript over the same structured content.
- **Bash-output envelope parser scoped out.** Python `src/` never emits `<bash-stdout>`/`<local-command-stdout>`/`<bash-input>` (grep-confirmed), so those branches are dead and omitted.
- **Internal-text tags.** Only `<task-notification>` (plus `<system-reminder>`) is live in Python, so the top-level internal-text stripper targets just those.
- **Synthetic-message filter.** `_SYNTHETIC_FIRST_TEXTS` mirrors TS `isSyntheticContent`'s five **bracketed display literals** verbatim (not Python's semantic sentence-constants), for byte-identical export output.

### Review
- Critic: **APPROVE** — fix for the synthetic-literals finding verified via mutation testing; exact-membership semantics confirmed against TS.

## Test plan
- [x] `tests/test_export_formats.py` — 43 tests (verbatim port of `exportFormats.test.ts`)
- [x] `tests/test_export_renderer.py` — 82 tests (markdown + JSON ports + new plain-text suite + synthetic-literal pinning tests)
- [x] Full suite: 7039 passed; the 6 failures are pre-existing and unrelated to this change (workspace-boundary parity, advisor default-property, environmental `python`-not-found MCP tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)