### PR TITLE
commands: port faithful /export command (Phase 4 P3)

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -74,6 +74,7 @@ from .skills_integration import (
 )
 from .permissions_command import PERMISSIONS_COMMAND, PermissionsCommand
 from .output_style_command import OUTPUT_STYLE_COMMAND, OutputStyleCommand
+from .export_command import EXPORT_COMMAND, ExportCommand
 from .types import (
     Command,
     CommandAvailability,
@@ -147,6 +148,8 @@ __all__ = [
     "PermissionsCommand",
     "OUTPUT_STYLE_COMMAND",
     "OutputStyleCommand",
+    "EXPORT_COMMAND",
+    "ExportCommand",
     "get_builtin_commands",
     "register_builtin_commands",
     # Moved-to-plugin factory + shell-at-prompt-build

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -23,6 +23,7 @@ from ..history import HistoryLog
 from ..providers.base import BaseProvider
 from .engine import CommandContext, CommandResult, LocalCommandResult
 from .registry import CommandRegistry, get_command_registry, list_commands
+from .export_command import EXPORT_COMMAND
 from .output_style_command import OUTPUT_STYLE_COMMAND
 from .permissions_command import PERMISSIONS_COMMAND
 from .security_review import SECURITY_REVIEW_COMMAND
@@ -1232,6 +1233,7 @@ def get_builtin_commands() -> list[Command]:
         STATUSLINE_COMMAND,
         PERMISSIONS_COMMAND,
         OUTPUT_STYLE_COMMAND,
+        EXPORT_COMMAND,
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)

--- a/src/command_system/export_command.py
+++ b/src/command_system/export_command.py
@@ -1,0 +1,269 @@
+"""export — interactive ``/export`` command (port of TS local-jsx).
+
+Port of ``typescript/src/commands/export/`` (``export.tsx`` + ``index.ts``). A
+``local-jsx`` command becomes an :class:`InteractiveCommand` (blocked remotely by
+type), with two paths mirroring the TS command:
+
+  * **Args path** (``/export <filename>``): render + write the file *headlessly*,
+    never touching ``ctx.ui`` — so it works on the SDK / ``NullUIHost`` surface
+    where ``select`` would raise (the headless keystone, like /output-style's
+    text result).
+  * **Wizard path** (no args): drive ``ctx.ui`` — ``select`` the format, then
+    ``prompt_text`` the filename. So one consumer exercises *both* bridge
+    primitives.
+
+Deliberate divergences from TS (documented for parity review):
+
+  * **Clipboard deferred** (plan §4.5). TS's wizard offers a "method" step
+    (clipboard vs file); a faithful clipboard write needs ``osc.ts`` ported,
+    which is out of scope this phase. The wizard ships file-only, so the
+    one-option "method" select is dropped (dead UI) and returns when clipboard
+    lands as its own PR. The command ``description`` keeps TS's "to a file or
+    clipboard" verbatim so it doesn't churn when that follow-up lands.
+  * **Esc cancels the whole export.** TS ``ExportDialog`` Esc navigates to the
+    previous step; the linear ``await select``/``await prompt_text`` shape can't
+    express back-navigation, so Esc at any step cancels the export →
+    :meth:`InteractiveOutcome.skip` (the /permissions cancel convention). TS
+    shows an "Export cancelled" toast at the format step; the skip path is
+    silent. Acceptable — the steps are cheap to re-invoke.
+"""
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Optional
+
+from src.utils.export_formats import (
+    ExportFormat,
+    ensure_export_filename_extension,
+    infer_export_format_from_filename,
+    parse_export_args,
+    resolve_export_filepath,
+)
+from src.utils.export_renderer import (
+    extract_message_content,
+    is_text_block,
+    render_messages_for_export,
+)
+
+from .types import (
+    CommandContext,
+    InteractiveCommand,
+    InteractiveOutcome,
+    UIOption,
+)
+
+# Wizard format options — labels/descriptions mirror ExportDialog.tsx:136-148.
+_FORMAT_OPTIONS: list[UIOption] = [
+    UIOption(
+        value="text",
+        label="Plain Text (.txt)",
+        description="Plain text format",
+    ),
+    UIOption(
+        value="markdown",
+        label="Markdown (.md)",
+        description="Markdown format for readable archives",
+    ),
+    UIOption(
+        value="json",
+        label="JSON (.json)",
+        description="Structured JSON for programmatic use",
+    ),
+]
+
+
+def format_timestamp(date: datetime) -> str:
+    """``YYYY-MM-DD-HHMMSS`` in local time (port of export.tsx:11-19)."""
+    return date.strftime("%Y-%m-%d-%H%M%S")
+
+
+def _message_type(msg: Any) -> Any:
+    if isinstance(msg, Mapping):
+        return msg.get("type")
+    return getattr(msg, "type", None)
+
+
+def _block_text(block: Any) -> str:
+    if isinstance(block, Mapping):
+        return block.get("text") or ""
+    return getattr(block, "text", "") or ""
+
+
+def extract_first_prompt(messages: Any) -> str:
+    """First user message's first line, truncated to 50 chars (export.tsx:20-42).
+
+    Mirrors TS ``msg.message?.content`` reads via the renderer's
+    :func:`extract_message_content` accessor so flat dataclasses and wire-shaped
+    dicts both resolve.
+    """
+    first_user = None
+    for msg in messages or []:
+        if _message_type(msg) == "user":
+            first_user = msg
+            break
+    if first_user is None:
+        return ""
+
+    content = extract_message_content(first_user)
+    result = ""
+    if isinstance(content, str):
+        result = content.strip()
+    elif isinstance(content, list):
+        # TS uses ``find(b => b.type === 'text')`` and reads ``.text`` off the
+        # match; a malformed first text block (no ``text`` key) yields ``''``.
+        # ``is_text_block`` additionally requires a string ``text``, so a
+        # malformed block is skipped and scanning continues — a negligible
+        # divergence (TextBlock.text is typed ``str = ""``, so unreachable in
+        # practice) that fails no worse than TS.
+        for item in content:
+            if is_text_block(item):
+                result = _block_text(item).strip()
+                break
+
+    result = result.split("\n")[0]
+    if len(result) > 50:
+        result = result[:49] + "…"
+    return result
+
+
+def sanitize_filename(text: str) -> str:
+    """Lowercase + hyphenate into a filesystem-safe slug (export.tsx:43-49)."""
+    s = text.lower()
+    s = re.sub(r"[^a-z0-9\s-]", "", s)  # drop special chars
+    s = re.sub(r"\s+", "-", s)  # spaces -> hyphens
+    s = re.sub(r"-+", "-", s)  # collapse repeated hyphens
+    s = re.sub(r"^-|-$", "", s)  # trim leading/trailing hyphens
+    return s
+
+
+def _default_filename(messages: Any) -> str:
+    """``<ts>-<slug>.txt`` or ``conversation-<ts>.txt`` (export.tsx:85-91)."""
+    first_prompt = extract_first_prompt(messages)
+    timestamp = format_timestamp(datetime.now())
+    sanitized = sanitize_filename(first_prompt) if first_prompt else ""
+    if sanitized:
+        return f"{timestamp}-{sanitized}.txt"
+    return f"conversation-{timestamp}.txt"
+
+
+@dataclass(frozen=True)
+class ExportCommand(InteractiveCommand):
+    """Render the conversation and write it to a file.
+
+    Args path is headless (never reaches ``ctx.ui``); the no-args path drives
+    the file-only wizard. Frozen + no new fields (the ``StatuslineCommand``
+    pattern); behavior lives entirely in :meth:`run`.
+    """
+
+    async def run(self, args: str, context: CommandContext) -> InteractiveOutcome:
+        parsed = parse_export_args(args)
+        if parsed.error:
+            return InteractiveOutcome(message=parsed.error, display="system")
+
+        # Resolve the conversation with the existing no-conversation idiom
+        # (builtins.py:381). Covers a None conversation too — hasattr(None, …)
+        # is False — so SDK/listing callers degrade gracefully instead of
+        # raising.
+        conversation = context.conversation
+        if not hasattr(conversation, "messages"):
+            return InteractiveOutcome(
+                message="No conversation to export.", display="system"
+            )
+        messages = conversation.messages
+
+        # Format: --format flag > filename extension > text default
+        # (export.tsx:60-63).
+        fmt: Optional[ExportFormat] = parsed.format
+        if fmt is None and parsed.filename:
+            fmt = infer_export_format_from_filename(parsed.filename)
+        if fmt is None:
+            fmt = "text"
+
+        cwd = str(context.cwd or context.workspace_root)
+
+        # --- Args path: headless render + write, never touches ctx.ui. ---
+        if parsed.filename:
+            # TS preserves a ``.markdown`` extension only when the user did not
+            # pass an explicit --format flag (export.tsx:69-71).
+            return self._write_export(
+                messages,
+                fmt,
+                parsed.filename,
+                cwd,
+                preserve_markdown_extension=parsed.format is None,
+            )
+
+        # --- Wizard path: select format, then prompt for filename. ---
+        picked = await context.ui.select(
+            "Select export format:", _FORMAT_OPTIONS, current=fmt
+        )
+        if picked is None:
+            return InteractiveOutcome.skip()  # Esc -> cancel the whole export.
+        chosen: ExportFormat = picked  # type: ignore[assignment]
+
+        # Default filename carries the chosen format's extension (ExportDialog
+        # recomputes it when the format changes, ExportDialog.tsx:37-66).
+        default_name = ensure_export_filename_extension(
+            _default_filename(messages), chosen, preserve_markdown_extension=True
+        )
+        name = await context.ui.prompt_text("Enter filename:", default=default_name)
+        if name is None:
+            return InteractiveOutcome.skip()
+
+        # The wizard submit always preserves a ``.markdown`` extension
+        # (ExportDialog.tsx:99-101).
+        return self._write_export(
+            messages, chosen, name, cwd, preserve_markdown_extension=True
+        )
+
+    @staticmethod
+    def _write_export(
+        messages: Any,
+        fmt: ExportFormat,
+        filename: str,
+        cwd: str,
+        *,
+        preserve_markdown_extension: bool,
+    ) -> InteractiveOutcome:
+        """Render + write the export; never raises (export.tsx:67-82,
+        ExportDialog.tsx:95-121 both wrap the write in a try/catch and report a
+        failure message rather than throwing out of the command)."""
+        try:
+            content = render_messages_for_export(messages, format=fmt)
+            final_filename = ensure_export_filename_extension(
+                filename,
+                fmt,
+                preserve_markdown_extension=preserve_markdown_extension,
+            )
+            filepath = resolve_export_filepath(cwd, final_filename)
+            with open(filepath, "w", encoding="utf-8") as fh:
+                fh.write(content)
+            return InteractiveOutcome(
+                message=f"Conversation exported to: {filepath}", display="system"
+            )
+        except Exception as exc:  # mirror TS catch-all (export.tsx:79)
+            return InteractiveOutcome(
+                message=f"Failed to export conversation: {exc}", display="system"
+            )
+
+
+EXPORT_COMMAND = ExportCommand(
+    name="export",
+    # Verbatim from index.ts. Mentions clipboard, which is deferred this phase
+    # (plan §4.5); kept as-is so the description doesn't churn when the
+    # clipboard follow-up reintroduces that delivery method.
+    description="Export the current conversation to a file or clipboard",
+    argument_hint="[filename]",
+)
+
+
+__all__ = [
+    "EXPORT_COMMAND",
+    "ExportCommand",
+    "extract_first_prompt",
+    "format_timestamp",
+    "sanitize_filename",
+]

--- a/tests/test_export_command.py
+++ b/tests/test_export_command.py
@@ -1,0 +1,411 @@
+"""Tests for the ``/export`` command (Phase 4 P3 — port of TS local-jsx).
+
+Ports the behavior of ``typescript/src/commands/export/`` (``export.tsx`` +
+``ExportDialog.tsx``) onto the interactive-command bridge. Mirrors the
+permissions/output-style test layout (``tests/test_interactive_bridge.py``,
+``tests/test_output_style_command.py``):
+
+  * Registration in builtins + aggregator; metadata (INTERACTIVE, name, desc).
+  * Bridge-safety **by type** (``is_bridge_safe_command`` False) + the TUI
+    direct-dispatch table falling through to the async registry arm.
+  * **Args path on ``NullUIHost``** — the headless keystone: ``/export out.json``
+    renders + writes the file and returns success *without ever touching*
+    ``ctx.ui`` (proven by using ``NullUIHost``, whose ``select``/``prompt_text``
+    raise).
+  * **Wizard path** via a scripted ``FakeUIHost`` — ``select`` format then
+    ``prompt_text`` filename: happy path writes the file; cancel at either step
+    → ``skip``. (No clipboard/method step this phase — plan §4.5.)
+  * Empty/absent conversation → graceful "No conversation to export." (no raise).
+  * Error path (unwritable target) → failure message (no raise).
+  * Port-fidelity unit tests for the private helpers (``format_timestamp`` /
+    ``extract_first_prompt`` / ``sanitize_filename``).
+"""
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src.command_system import (
+    EXPORT_COMMAND,
+    ExportCommand,
+    create_command_context,
+    get_builtin_commands,
+    get_commands,
+    is_bridge_safe_command,
+)
+from src.command_system.engine import CommandEngine
+from src.command_system.export_command import (
+    extract_first_prompt,
+    format_timestamp,
+    sanitize_filename,
+)
+from src.command_system.registry import CommandRegistry
+from src.command_system.types import (
+    CommandType,
+    InteractiveOutcome,
+    InteractiveUnavailableError,
+    NullUIHost,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fakes / fixtures
+# --------------------------------------------------------------------------- #
+class FakeUIHost:
+    """Scripted UI surface recording ``select`` / ``prompt_text`` calls.
+
+    ``pick`` is returned by ``select`` (``None`` = cancel); ``text`` by
+    ``prompt_text`` (``None`` = cancel, ``''`` = empty-but-valid submit).
+    """
+
+    def __init__(self, *, pick: str | None = None, text: str | None = None) -> None:
+        self._pick = pick
+        self._text = text
+        self.select_calls: list[dict] = []
+        self.prompt_calls: list[dict] = []
+        self.display_calls: list[tuple[str, str]] = []
+
+    async def select(self, title, options, *, current=None):
+        self.select_calls.append(
+            {"title": title, "values": [o.value for o in options], "current": current}
+        )
+        return self._pick
+
+    async def prompt_text(self, title, *, default="", placeholder=None):
+        self.prompt_calls.append(
+            {"title": title, "default": default, "placeholder": placeholder}
+        )
+        return self._text
+
+    async def display(self, title, body):
+        self.display_calls.append((title, body))
+
+
+def _conversation(*messages):
+    """A minimal conversation object exposing ``.messages`` (the only attr the
+    command reads)."""
+    return SimpleNamespace(messages=list(messages))
+
+
+def _user_msg(text: str) -> dict:
+    return {"type": "user", "message": {"role": "user", "content": text}}
+
+
+def _ctx(tmp_path: Path, *, conversation=None, ui=None):
+    return create_command_context(
+        workspace_root=tmp_path, cwd=tmp_path, conversation=conversation, ui=ui
+    )
+
+
+def _registry_with(*commands) -> CommandRegistry:
+    reg = CommandRegistry()
+    for c in commands:
+        reg.register(c)
+    return reg
+
+
+# --------------------------------------------------------------------------- #
+# A. Metadata + registration
+# --------------------------------------------------------------------------- #
+def test_export_registered_in_builtins_and_aggregator():
+    assert "export" in {c.name for c in get_builtin_commands()}
+    assert "export" in {c.name for c in get_commands(cwd=str(Path.cwd()))}
+
+
+def test_export_metadata_mirrors_ts():
+    assert isinstance(EXPORT_COMMAND, ExportCommand)
+    assert EXPORT_COMMAND.name == "export"
+    # Verbatim from typescript/src/commands/export/index.ts.
+    assert EXPORT_COMMAND.description == (
+        "Export the current conversation to a file or clipboard"
+    )
+    assert EXPORT_COMMAND.argument_hint == "[filename]"
+    # local-jsx -> INTERACTIVE (so the remote-safety gate blocks it by type).
+    assert EXPORT_COMMAND.command_type == CommandType.INTERACTIVE
+    # TS sets only type/name/description/argumentHint; everything else defaults.
+    assert EXPORT_COMMAND.is_hidden is False
+    assert EXPORT_COMMAND.disable_model_invocation is False
+    assert EXPORT_COMMAND.user_invocable is True
+
+
+# --------------------------------------------------------------------------- #
+# B. Bridge-safety BY TYPE + TUI dispatch fall-through
+# --------------------------------------------------------------------------- #
+def test_export_blocked_from_remote_by_type():
+    # INTERACTIVE commands are never bridge-safe (mirrors TS local-jsx).
+    assert is_bridge_safe_command(EXPORT_COMMAND) is False
+
+
+def test_dispatch_local_command_falls_through_for_export():
+    # The TUI's direct-dispatch table must NOT claim /export; it has to fall
+    # through to the async registry path where the INTERACTIVE arm lives.
+    from src.tui.commands import dispatch_local_command
+
+    res = dispatch_local_command(
+        "/export", session=None, workspace_root=Path("."), tool_registry=None
+    )
+    assert res.handled is False
+
+
+# --------------------------------------------------------------------------- #
+# C. Args path — headless render + write, never touches ctx.ui
+# --------------------------------------------------------------------------- #
+async def test_args_path_writes_file_on_null_surface(tmp_path):
+    # The headless keystone: NullUIHost.select/prompt_text raise, so a green
+    # write here proves the args path never reaches for ctx.ui.
+    conv = _conversation(_user_msg("hello world"))
+    outcome = await EXPORT_COMMAND.run("out.json", _ctx(tmp_path, conversation=conv, ui=NullUIHost()))
+
+    assert isinstance(outcome, InteractiveOutcome)
+    assert outcome.display == "system"
+    target = tmp_path / "out.json"
+    assert outcome.message == f"Conversation exported to: {target}"
+    assert target.exists()
+    data = json.loads(target.read_text(encoding="utf-8"))
+    assert data["format"] == "json"
+    assert data["messageCount"] == 1
+
+
+async def test_args_path_infers_format_from_extension(tmp_path):
+    conv = _conversation(_user_msg("hi"))
+    outcome = await EXPORT_COMMAND.run("notes.md", _ctx(tmp_path, conversation=conv, ui=NullUIHost()))
+
+    target = tmp_path / "notes.md"
+    assert target.exists()
+    assert outcome.message == f"Conversation exported to: {target}"
+    # Markdown render, not JSON.
+    assert not target.read_text(encoding="utf-8").lstrip().startswith("{")
+
+
+async def test_args_path_format_flag_overrides_extension(tmp_path):
+    # --format json wins over the .txt extension; the file is rewritten to .json.
+    conv = _conversation(_user_msg("hi"))
+    outcome = await EXPORT_COMMAND.run("transcript.txt --format json", _ctx(tmp_path, conversation=conv, ui=NullUIHost()))
+
+    target = tmp_path / "transcript.json"
+    assert target.exists()
+    assert not (tmp_path / "transcript.txt").exists()
+    assert outcome.message == f"Conversation exported to: {target}"
+    json.loads(target.read_text(encoding="utf-8"))  # valid JSON
+
+
+async def test_args_path_parse_error_is_reported(tmp_path):
+    conv = _conversation(_user_msg("hi"))
+    outcome = await EXPORT_COMMAND.run("--format xml out", _ctx(tmp_path, conversation=conv, ui=NullUIHost()))
+
+    assert outcome.display == "system"
+    assert outcome.message is not None
+    assert "Unsupported export format: xml" in outcome.message
+
+
+async def test_args_path_write_failure_returns_message_no_raise(tmp_path):
+    # Unwritable target (parent dir doesn't exist) -> failure outcome, no raise.
+    conv = _conversation(_user_msg("hi"))
+    bad = tmp_path / "missing" / "sub" / "out.json"
+    outcome = await EXPORT_COMMAND.run(str(bad), _ctx(tmp_path, conversation=conv, ui=NullUIHost()))
+
+    assert outcome.display == "system"
+    assert outcome.message is not None
+    assert outcome.message.startswith("Failed to export conversation:")
+    assert not bad.exists()
+
+
+# --------------------------------------------------------------------------- #
+# D. Wizard path — select format -> prompt_text filename
+# --------------------------------------------------------------------------- #
+async def test_wizard_happy_path_writes_file(tmp_path):
+    conv = _conversation(_user_msg("Hi there"))
+    ui = FakeUIHost(pick="markdown", text="mychat")
+    outcome = await EXPORT_COMMAND.run("", _ctx(tmp_path, conversation=conv, ui=ui))
+
+    target = tmp_path / "mychat.md"
+    assert target.exists()
+    assert outcome.message == f"Conversation exported to: {target}"
+    assert outcome.display == "system"
+
+    # The format select offered the three formats and seeded current=text.
+    assert ui.select_calls[0]["values"] == ["text", "markdown", "json"]
+    assert ui.select_calls[0]["current"] == "text"
+    # The filename prompt's default carried the chosen (.md) extension and the
+    # sanitized first-prompt slug + a timestamp.
+    default = ui.prompt_calls[0]["default"]
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}-\d{6}-hi-there\.md", default)
+
+
+async def test_wizard_format_flag_seeds_select_current(tmp_path):
+    # --format with no filename runs the wizard, but the resolved format seeds
+    # the select's `current` (export.tsx:60-63 feeds the dialog's initial
+    # format). Proves the flag isn't silently dropped on the no-filename path.
+    conv = _conversation(_user_msg("hi"))
+    ui = FakeUIHost(pick="markdown", text="out")
+    await EXPORT_COMMAND.run("--format markdown", _ctx(tmp_path, conversation=conv, ui=ui))
+
+    assert ui.select_calls[0]["current"] == "markdown"
+
+
+async def test_wizard_default_filename_falls_back_to_conversation_prefix(tmp_path):
+    # No extractable first prompt -> conversation-<ts>.<ext> default.
+    conv = _conversation({"type": "assistant", "message": {"role": "assistant", "content": "hi"}})
+    ui = FakeUIHost(pick="json", text="dump")
+    await EXPORT_COMMAND.run("", _ctx(tmp_path, conversation=conv, ui=ui))
+
+    default = ui.prompt_calls[0]["default"]
+    assert re.fullmatch(r"conversation-\d{4}-\d{2}-\d{2}-\d{6}\.json", default)
+
+
+async def test_wizard_cancel_at_format_returns_skip(tmp_path):
+    conv = _conversation(_user_msg("hi"))
+    ui = FakeUIHost(pick=None)
+    outcome = await EXPORT_COMMAND.run("", _ctx(tmp_path, conversation=conv, ui=ui))
+
+    assert outcome.display == "skip"
+    assert outcome.message is None
+    # Cancelled before reaching the filename prompt; no file written.
+    assert ui.prompt_calls == []
+    assert list(tmp_path.iterdir()) == []
+
+
+async def test_wizard_cancel_at_filename_returns_skip(tmp_path):
+    conv = _conversation(_user_msg("hi"))
+    ui = FakeUIHost(pick="json", text=None)  # Esc at the filename prompt
+    outcome = await EXPORT_COMMAND.run("", _ctx(tmp_path, conversation=conv, ui=ui))
+
+    assert outcome.display == "skip"
+    assert outcome.message is None
+    assert list(tmp_path.iterdir()) == []
+
+
+# --------------------------------------------------------------------------- #
+# E. No-conversation graceful degradation
+# --------------------------------------------------------------------------- #
+async def test_no_conversation_is_graceful(tmp_path):
+    # conversation=None -> hasattr(None, "messages") is False -> graceful.
+    outcome = await EXPORT_COMMAND.run("out.json", _ctx(tmp_path, conversation=None, ui=NullUIHost()))
+    assert outcome.display == "system"
+    assert outcome.message == "No conversation to export."
+    assert not (tmp_path / "out.json").exists()
+
+
+async def test_no_conversation_graceful_even_in_wizard(tmp_path):
+    # Absent messages short-circuits before the wizard touches ctx.ui.
+    ui = FakeUIHost(pick="json", text="x")
+    outcome = await EXPORT_COMMAND.run("", _ctx(tmp_path, conversation=None, ui=ui))
+    assert outcome.message == "No conversation to export."
+    assert ui.select_calls == []
+
+
+# --------------------------------------------------------------------------- #
+# F. Engine INTERACTIVE arm — args path reachable on a null surface
+# --------------------------------------------------------------------------- #
+async def test_engine_routes_args_path_to_text_on_null_surface(tmp_path):
+    # /export <file> with no UI wired: the engine substitutes NullUIHost, but
+    # the args path never calls it -> clean text result (mirrors output-style).
+    conv = _conversation(_user_msg("hi"))
+    reg = _registry_with(EXPORT_COMMAND)
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path, conversation=conv)
+    assert ctx.ui is None
+    eng = CommandEngine(registry=reg, workspace_root=tmp_path, context=ctx)
+
+    result = await eng.execute("/export out.json")
+
+    assert result.success is True
+    assert result.result_type == "text"
+    assert result.display == "system"
+    assert (tmp_path / "out.json").exists()
+
+
+async def test_engine_wizard_errors_cleanly_on_null_surface(tmp_path):
+    # No-args wizard with no UI wired: the engine's NullUIHost makes select
+    # raise InteractiveUnavailableError, which the engine turns into a clean
+    # error result (not a crash).
+    conv = _conversation(_user_msg("hi"))
+    reg = _registry_with(EXPORT_COMMAND)
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path, conversation=conv)
+    eng = CommandEngine(registry=reg, workspace_root=tmp_path, context=ctx)
+
+    result = await eng.execute("/export")
+
+    assert result.success is False
+    assert result.error is not None
+
+
+async def test_run_directly_raises_on_null_surface_for_wizard(tmp_path):
+    # Calling run() directly (no engine substitution) with NullUIHost: the
+    # wizard's select must raise rather than fake a pick.
+    conv = _conversation(_user_msg("hi"))
+    with pytest.raises(InteractiveUnavailableError):
+        await EXPORT_COMMAND.run("", _ctx(tmp_path, conversation=conv, ui=NullUIHost()))
+
+
+# --------------------------------------------------------------------------- #
+# G. Helper port-fidelity (export.tsx:11-49)
+# --------------------------------------------------------------------------- #
+class TestFormatTimestamp:
+    def test_zero_pads_all_fields(self):
+        assert format_timestamp(datetime(2026, 1, 2, 3, 4, 5)) == "2026-01-02-030405"
+
+    def test_full_width_fields(self):
+        assert format_timestamp(datetime(2026, 12, 31, 23, 59, 59)) == "2026-12-31-235959"
+
+
+class TestExtractFirstPrompt:
+    def test_string_content_first_line_trimmed(self):
+        # TS trims the *whole* string first, then takes the first line
+        # (export.tsx:27-37): leading whitespace and a trailing tail are
+        # stripped, leaving the first line clean.
+        msgs = [{"type": "user", "message": {"role": "user", "content": "  first line\nsecond  "}}]
+        assert extract_first_prompt(msgs) == "first line"
+
+    def test_array_content_uses_first_text_block(self):
+        msgs = [
+            {
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {"type": "image", "source": {}},
+                        {"type": "text", "text": "  hello there  "},
+                    ],
+                },
+            }
+        ]
+        assert extract_first_prompt(msgs) == "hello there"
+
+    def test_skips_non_user_messages(self):
+        msgs = [
+            {"type": "assistant", "message": {"role": "assistant", "content": "ignored"}},
+            {"type": "user", "message": {"role": "user", "content": "the prompt"}},
+        ]
+        assert extract_first_prompt(msgs) == "the prompt"
+
+    def test_returns_empty_when_no_user_message(self):
+        assert extract_first_prompt([]) == ""
+        assert extract_first_prompt([{"type": "assistant", "message": {"role": "assistant", "content": "x"}}]) == ""
+
+    def test_truncates_to_50_chars_with_ellipsis(self):
+        long = "x" * 60
+        result = extract_first_prompt([{"type": "user", "message": {"role": "user", "content": long}}])
+        assert result == "x" * 49 + "…"
+        assert len(result) == 50
+
+
+class TestSanitizeFilename:
+    def test_lowercases_and_hyphenates(self):
+        assert sanitize_filename("Hello World") == "hello-world"
+
+    def test_strips_special_characters(self):
+        assert sanitize_filename("Hello, World!!") == "hello-world"
+
+    def test_collapses_repeated_hyphens_and_whitespace(self):
+        assert sanitize_filename("a   b---c") == "a-b-c"
+
+    def test_trims_leading_and_trailing_hyphens(self):
+        assert sanitize_filename("  -leading and trailing-  ") == "leading-and-trailing"
+
+    def test_empty_after_sanitize(self):
+        assert sanitize_filename("!!!") == ""


### PR DESCRIPTION
## Summary

Phase 4 **P3** (final of three): port the `/export` command, the first consumer of the `prompt_text` UIHost primitive (P1, #243) and the multi-format export renderers (P2, #244).

Faithful port of `typescript/src/commands/export/` (`export.tsx` + `index.ts` + `ExportDialog.tsx`) onto the interactive-command bridge.

- **Args path** (`/export <filename>`): renders + writes the file **headlessly**, never touching `ctx.ui` — so it works on the SDK / `NullUIHost` surface (the headless keystone).
- **Wizard path** (no args): drives `ctx.ui` — `select` the format, then `prompt_text` the filename. One consumer exercises *both* bridge primitives.
- **Blocked from remote/bridge by type**: `InteractiveCommand` ⇒ `is_bridge_safe_command` is `False` structurally (mirrors TS `local-jsx`).

### Documented divergences from TS (in the module docstring)
- **Clipboard deferred** (plan §4.5): the wizard ships file-only; the one-option "method" select is dropped as dead UI and returns when `osc.ts` is ported. The `description` keeps TS's "to a file or clipboard" verbatim so it doesn't churn on the follow-up.
- **Esc cancels the whole export** → `InteractiveOutcome.skip()` (the `/permissions` cancel convention). TS's `ExportDialog` Esc navigates to the previous step; the linear `await select`/`await prompt_text` shape can't express back-navigation.

## Test plan
- [x] `tests/test_export_command.py` — 31 tests: metadata/registration, bridge-safety by type + TUI dispatch fall-through, args path on `NullUIHost` (headless keystone), wizard happy/cancel paths, format-flag seeds the wizard select, no-conversation graceful degradation, engine INTERACTIVE arm, and helper port-fidelity (`format_timestamp`/`extract_first_prompt`/`sanitize_filename`).
- [x] Full suite: **7070 passed, 5 skipped**, 6 pre-existing failures (workspace-boundary / tool-parity / MCP-config — unrelated to this change). Zero new failures.
- [x] Critic review loop: **APPROVE** (no Critical/Major). Two recommended Minor fixes applied (wizard `--format`-seeding test; comment on the `extract_first_prompt` array-scan divergence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)