### PR TITLE
commands: port faithful /theme interactive command (Phase 5)

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -75,6 +75,7 @@ from .skills_integration import (
 from .permissions_command import PERMISSIONS_COMMAND, PermissionsCommand
 from .output_style_command import OUTPUT_STYLE_COMMAND, OutputStyleCommand
 from .export_command import EXPORT_COMMAND, ExportCommand
+from .theme_command import THEME_COMMAND, ThemeCommand
 from .types import (
     Command,
     CommandAvailability,
@@ -150,6 +151,8 @@ __all__ = [
     "OutputStyleCommand",
     "EXPORT_COMMAND",
     "ExportCommand",
+    "THEME_COMMAND",
+    "ThemeCommand",
     "get_builtin_commands",
     "register_builtin_commands",
     # Moved-to-plugin factory + shell-at-prompt-build

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -28,6 +28,7 @@ from .output_style_command import OUTPUT_STYLE_COMMAND
 from .permissions_command import PERMISSIONS_COMMAND
 from .security_review import SECURITY_REVIEW_COMMAND
 from .statusline import STATUSLINE_COMMAND
+from .theme_command import THEME_COMMAND
 from .types import Command, CommandType, CompactionResult, LocalCommand, PromptCommand
 
 
@@ -1234,6 +1235,7 @@ def get_builtin_commands() -> list[Command]:
         PERMISSIONS_COMMAND,
         OUTPUT_STYLE_COMMAND,
         EXPORT_COMMAND,
+        THEME_COMMAND,
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)

--- a/src/command_system/theme_command.py
+++ b/src/command_system/theme_command.py
@@ -1,0 +1,131 @@
+"""theme — interactive ``/theme`` command (port of TS local-jsx).
+
+Port of ``typescript/src/commands/theme/`` (``theme.tsx`` + ``index.ts``). A
+``local-jsx`` command becomes an :class:`InteractiveCommand` (blocked remotely by
+type). Unlike ``/export`` — which proves its bridge wiring by *falling through* the
+TUI dispatch so the registry arm runs — ``/theme`` is the **inverse**: the TUI keeps
+intercepting ``/theme`` (``commands.py`` → ``open_dialog="theme"``) to preserve its
+rich **live-preview** ``ThemePickerScreen``. This command therefore serves only the
+surfaces that *consult the registry*: the REPL (numbered-menu ``select``), the SDK
+(``NullUIHost`` → clean error), and the help/aggregator listings — where ``/theme``
+was previously invisible because it lived only in the TUI's private ``LOCAL_BUILTINS``.
+
+Faithfulness to TS (``theme.tsx``):
+
+  * ``call(onDone, _context)`` **ignores args** — the picker is the only path. We do
+    not parse args and add no headless write path; on ``NullUIHost`` (SDK) the
+    ``select`` below raises → the engine returns a clean "needs an interactive
+    surface" error. There is no ``/export``-style headless keystone because TS
+    ``/theme`` has none.
+  * **Success → ``display="user"``.** TS ``onDone(f"Theme set to {setting}")`` passes
+    **no** options, so ``processSlashCommand`` routes it through ``createUserMessage``
+    (model-visible) with ``shouldQuery ?? false``. Python's faithful equivalent is
+    ``display="user"`` — the engine's own value for model-visible content
+    (``CommandResult.success_prompt``) — with the default ``should_query=False``.
+  * **Cancel → "Theme picker dismissed" / ``display="system"``**, **not** ``skip()``.
+    Faithful to TS ``onDone("Theme picker dismissed", {display:"system"})`` (a
+    user-visible system line). Cancel does **not** persist.
+
+Deliberate divergences (documented for parity review):
+
+  * **Python's own theme set.** Options come from :func:`list_theme_names`
+    (``auto``/``dark``/``light``/``claude``) — the same source the TUI
+    ``ThemePickerScreen`` uses, so both surfaces stay in lockstep — not TS's
+    ``light-daltonized``/``*-ansi`` variants (no Python ``Palette`` exists for them)
+    nor TS's flag-gated ``auto`` (Python offers ``auto`` unconditionally). Labels are
+    the **raw** theme names, mirroring ``ThemePickerScreen``'s ``SelectOption(label=
+    name…)``, not TS's friendly labels.
+  * **Persist-only, no live hot-swap.** The command_system surface has no ``App``
+    handle (``CommandContext`` carries workspace_root/cwd/conversation/ui, not the
+    Textual app), so "Theme set to {name}" means *persisted; applies on next launch*
+    on non-TUI surfaces. The live hot-swap stays the TUI dialog's job (``apply_theme``).
+
+``list_theme_names`` is imported **lazily** inside :func:`_theme_options` (not at
+module top) so a bare ``import src.command_system`` does not pull the heavy
+``src.tui`` package — ``src/tui/__init__.py`` eagerly imports the Textual app. This
+mirrors the local-import discipline already used in ``builtins.py`` (buddy) and
+``app.py`` (config).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.config import load_config, set_theme
+
+from .types import (
+    CommandContext,
+    InteractiveCommand,
+    InteractiveOutcome,
+    UIOption,
+)
+
+_DEFAULT_THEME = "dark"
+
+
+def _current_theme() -> str:
+    """The persisted theme, or ``"dark"`` — the same happy-path read as
+    ``app._resolve_theme_name()`` (``load_config().get("theme") or "dark"``).
+    ``_resolve_theme_name`` additionally wraps the read in ``try/except → "dark"``;
+    here we intentionally let a ``load_config()`` failure propagate, because the
+    engine wraps :meth:`ThemeCommand.run` and converts any exception into a clean
+    error ``CommandResult`` (whereas the TUI swallows it to keep rendering). The
+    *merged* read is correct here: we only need the *effective* current value to seed
+    the picker, not a write."""
+    return load_config().get("theme") or _DEFAULT_THEME
+
+
+def _theme_options(current: str) -> list[UIOption]:
+    """Build picker options from :func:`list_theme_names`, marking the option equal to
+    ``current`` with ``description="current"`` (the same marker the TUI
+    ``ThemePickerScreen`` shows). Labels are the raw theme names.
+
+    Imported lazily — see the module docstring."""
+    from src.tui.theme import list_theme_names
+
+    options: list[UIOption] = []
+    for name in list_theme_names():
+        desc = "current" if name == current else None
+        options.append(UIOption(value=name, label=name, description=desc))
+    return options
+
+
+@dataclass(frozen=True)
+class ThemeCommand(InteractiveCommand):
+    """Pick a color theme and persist it.
+
+    Frozen + no new fields (the ``ExportCommand``/``StatuslineCommand`` pattern);
+    behavior lives entirely in :meth:`run`.
+    """
+
+    async def run(self, args: str, context: CommandContext) -> InteractiveOutcome:
+        # TS `call(onDone, _context)` ignores args — the picker is the only path.
+        # No args path => no headless keystone (unlike /export); on NullUIHost the
+        # select below raises -> the engine returns a clean error.
+        current = _current_theme()
+        options = _theme_options(current)
+        picked = await context.ui.select("Select theme:", options, current=current)
+        if picked is None:
+            # TS cancel: onDone("Theme picker dismissed", {display:"system"}).
+            # A visible system line — NOT skip() (which /export uses for Esc).
+            return InteractiveOutcome(
+                message="Theme picker dismissed", display="system"
+            )
+        set_theme(picked)  # persist (TS setTheme -> setThemeSetting -> saveGlobalConfig)
+        # TS success: onDone("Theme set to …") with NO options => createUserMessage
+        # (model-visible, shouldQuery=false). Faithful map = display="user".
+        return InteractiveOutcome(message=f"Theme set to {picked}", display="user")
+
+
+THEME_COMMAND = ThemeCommand(
+    name="theme",
+    # Verbatim from typescript/src/commands/theme/index.ts. (The TUI popup shows
+    # "Change the color theme" from _LOCAL_BUILTIN_DESCRIPTIONS, which wins the
+    # suggestion dedup; this TS-verbatim text surfaces on the registry/SDK listings.)
+    description="Change the theme",
+)
+
+
+__all__ = [
+    "THEME_COMMAND",
+    "ThemeCommand",
+]

--- a/src/config.py
+++ b/src/config.py
@@ -327,3 +327,15 @@ def set_default_provider(provider: str) -> None:
 def get_default_provider() -> str:
     """Get the default provider."""
     return load_config().get("default_provider", "anthropic")
+
+
+def set_theme(name: str) -> None:
+    """Persist the selected theme to the global config.
+
+    Mirrors TS ``setThemeSetting`` (``components/design-system/ThemeProvider.tsx``:
+    ``saveGlobalConfig(c => ({...c, theme: setting}))``). Uses ``set_global``
+    (global-only) — **not** ``load_config()`` + ``save_config()``, which would
+    serialize the *merged* (global+project+local) config back into the global file.
+    Matches the ``set_api_key`` / ``set_default_provider`` convention above.
+    """
+    _get_default_manager().set_global("theme", name)

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -547,10 +547,18 @@ class ClawCodexTUI(App):
             self.apply_theme(name, transcript=transcript)
 
         self.announcer.announce("Opened theme picker.", notify=False)
+        # D2: persist the pick like TS (setTheme always saves to the global config).
+        # The screen fires on_persist only on selection, not on cancel
+        # (theme_picker.py:76-93), so Esc leaves the saved theme untouched — matching
+        # TS (cancel ⇒ no setTheme). The live hot-swap still runs via _on_selected;
+        # persistence (disk) and apply_theme (live palette) are complementary.
+        from src.config import set_theme
+
         self.push_screen(
             ThemePickerScreen(
                 themes=list_theme_names(),
                 current=self._theme_name,
+                on_persist=set_theme,
                 on_preview=_on_preview,
             ),
             callback=_on_selected,

--- a/tests/test_theme_command.py
+++ b/tests/test_theme_command.py
@@ -1,0 +1,314 @@
+"""Tests for the ``/theme`` command (Phase 5 — port of TS local-jsx).
+
+Ports the behavior of ``typescript/src/commands/theme/`` (``theme.tsx`` +
+``index.ts``) onto the interactive-command bridge, mirroring the ``/export`` test
+layout (``tests/test_export_command.py``). ``/theme`` is the **inverse** of
+``/export`` at the TUI dispatch layer: ``/export`` proves it *falls through* so the
+registry arm runs, while ``/theme`` must keep the TUI **intercepting** (``handled=
+True``, ``open_dialog="theme"``) so the rich live-preview ``ThemePickerScreen`` is
+preserved. The ``ThemeCommand`` is therefore exercised only on registry-consulting
+surfaces (REPL/SDK/listings).
+
+Sections:
+  * A — metadata + registration (INTERACTIVE, name, verbatim TS description, no hint).
+  * B — bridge-safety **by type** + the TUI dispatch **inversion** (the anti-regression
+    assertion: ``/theme`` stays intercepted, NOT fall-through).
+  * C — picker happy path: success → ``display="user"`` (TS no-options ``onDone`` →
+    model-visible ``createUserMessage``), the pick is persisted, and ``select`` is
+    seeded from config with the full theme list.
+  * D — cancel path: ``"Theme picker dismissed"`` / ``display="system"`` (NOT ``skip``),
+    config unchanged.
+  * E — null surface: ``select`` raises → engine returns a clean error (no headless
+    keystone); args are ignored (TS ignores ``_context``).
+  * F — options shape: values == ``list_theme_names()``; the current option carries
+    ``description="current"``; labels are the raw theme names.
+  * G — D2 wiring: ``_open_theme_picker`` passes ``on_persist=set_theme`` to the screen.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import src.config as cfg
+from src.command_system import (
+    THEME_COMMAND,
+    ThemeCommand,
+    create_command_context,
+    get_builtin_commands,
+    get_commands,
+    is_bridge_safe_command,
+)
+from src.command_system.engine import CommandEngine
+from src.command_system.registry import CommandRegistry
+from src.command_system.types import (
+    CommandType,
+    InteractiveOutcome,
+    InteractiveUnavailableError,
+    NullUIHost,
+)
+from src.tui.theme import list_theme_names
+
+
+# --------------------------------------------------------------------------- #
+# Fakes / fixtures
+# --------------------------------------------------------------------------- #
+class FakeUIHost:
+    """Scripted UI surface recording ``select`` calls. ``pick`` is returned by
+    ``select`` (``None`` = cancel). ``prompt_text``/``display`` round out the
+    Protocol (``/theme`` only uses ``select``)."""
+
+    def __init__(self, *, pick: str | None = None, text: str | None = None) -> None:
+        self._pick = pick
+        self._text = text
+        self.select_calls: list[dict] = []
+        self.prompt_calls: list[dict] = []
+        self.display_calls: list[tuple[str, str]] = []
+
+    async def select(self, title, options, *, current=None):
+        self.select_calls.append(
+            {
+                "title": title,
+                "values": [o.value for o in options],
+                "labels": [o.label for o in options],
+                "descriptions": [o.description for o in options],
+                "current": current,
+            }
+        )
+        return self._pick
+
+    async def prompt_text(self, title, *, default="", placeholder=None):
+        self.prompt_calls.append(
+            {"title": title, "default": default, "placeholder": placeholder}
+        )
+        return self._text
+
+    async def display(self, title, body):
+        self.display_calls.append((title, body))
+
+
+@pytest.fixture
+def isolated_config(tmp_path, monkeypatch):
+    """Point the global config at a tmp file and give the singleton a fresh manager
+    rooted at a non-git tmp cwd, so tests never touch ``~/.clawcodex/config.json`` and
+    project/local configs resolve empty (``_find_git_root(tmp_path)`` is ``None``).
+
+    N2: the theme value is read via ``load_config()`` / ``ConfigManager`` (not the
+    settings cache), so the only state to reset is the manager singleton + its backing
+    file. ``monkeypatch`` auto-restores both attrs after the test.
+    """
+    monkeypatch.setattr(cfg, "GLOBAL_CONFIG_FILE", tmp_path / "config.json")
+    monkeypatch.setattr(cfg, "_default_manager", cfg.ConfigManager(cwd=tmp_path))
+    return tmp_path
+
+
+def _ctx(tmp_path: Path, *, ui=None):
+    # /theme ignores the conversation entirely (picker-only), so we don't wire one.
+    return create_command_context(workspace_root=tmp_path, cwd=tmp_path, ui=ui)
+
+
+def _registry_with(*commands) -> CommandRegistry:
+    reg = CommandRegistry()
+    for c in commands:
+        reg.register(c)
+    return reg
+
+
+def _persisted_theme(tmp_path: Path):
+    """Read ``theme`` back through a FRESH manager (true on-disk round-trip)."""
+    return cfg.ConfigManager(cwd=tmp_path).get("theme")
+
+
+# --------------------------------------------------------------------------- #
+# A. Metadata + registration
+# --------------------------------------------------------------------------- #
+def test_theme_registered_in_builtins_and_aggregator():
+    assert "theme" in {c.name for c in get_builtin_commands()}
+    assert "theme" in {c.name for c in get_commands(cwd=str(Path.cwd()))}
+
+
+def test_theme_metadata_mirrors_ts():
+    assert isinstance(THEME_COMMAND, ThemeCommand)
+    assert THEME_COMMAND.name == "theme"
+    # Verbatim from typescript/src/commands/theme/index.ts.
+    assert THEME_COMMAND.description == "Change the theme"
+    # TS sets no argumentHint (the command ignores args).
+    assert THEME_COMMAND.argument_hint is None
+    # local-jsx -> INTERACTIVE (so the remote/bridge gate blocks it by type).
+    assert THEME_COMMAND.command_type == CommandType.INTERACTIVE
+    # TS sets only type/name/description; everything else defaults.
+    assert THEME_COMMAND.is_hidden is False
+    assert THEME_COMMAND.disable_model_invocation is False
+    assert THEME_COMMAND.user_invocable is True
+
+
+# --------------------------------------------------------------------------- #
+# B. Bridge-safety BY TYPE + TUI dispatch inversion
+# --------------------------------------------------------------------------- #
+def test_theme_blocked_from_bridge_by_type():
+    # INTERACTIVE commands are never bridge-safe (mirrors TS local-jsx). Note this
+    # is orthogonal to REMOTE_SAFE_COMMANDS (a name-based --remote filter that also
+    # lists "theme"): the type gate still blocks the bridge.
+    assert is_bridge_safe_command(THEME_COMMAND) is False
+
+
+def test_dispatch_local_command_intercepts_theme():
+    # THE INVERSION vs /export: the TUI's direct-dispatch table MUST claim /theme
+    # (handled=True, open_dialog="theme") so the rich live-preview ThemePickerScreen
+    # is preserved. Do NOT assert fall-through here — that was /export's rule. This
+    # is the explicit anti-regression guarantee for the TUI dialog.
+    from src.tui.commands import dispatch_local_command
+
+    res = dispatch_local_command(
+        "/theme", session=None, workspace_root=Path("."), tool_registry=None
+    )
+    assert res.handled is True
+    assert res.open_dialog == "theme"
+
+
+# --------------------------------------------------------------------------- #
+# C. Picker happy path
+# --------------------------------------------------------------------------- #
+async def test_picker_happy_path_persists_and_reports(isolated_config):
+    tmp_path = isolated_config
+    ui = FakeUIHost(pick="light")
+    outcome = await THEME_COMMAND.run("", _ctx(tmp_path, ui=ui))
+
+    assert isinstance(outcome, InteractiveOutcome)
+    assert outcome.message == "Theme set to light"
+    # B1: success is model-visible in TS (no-options onDone -> createUserMessage),
+    # so display="user", NOT "system".
+    assert outcome.display == "user"
+    assert outcome.should_query is False
+    # The pick is persisted to the (isolated) global config.
+    assert _persisted_theme(tmp_path) == "light"
+    # select offered the full theme list and seeded current from config.
+    assert ui.select_calls[0]["values"] == list_theme_names()
+
+
+async def test_picker_seeds_current_from_persisted_theme(isolated_config):
+    tmp_path = isolated_config
+    cfg.set_theme("claude")  # pre-persist a non-default theme
+    ui = FakeUIHost(pick="dark")
+    await THEME_COMMAND.run("", _ctx(tmp_path, ui=ui))
+
+    # current= reflects the persisted theme, so the picker pre-highlights it.
+    assert ui.select_calls[0]["current"] == "claude"
+
+
+async def test_picker_current_defaults_to_dark_when_unset(isolated_config):
+    tmp_path = isolated_config  # no theme persisted
+    ui = FakeUIHost(pick="light")
+    await THEME_COMMAND.run("", _ctx(tmp_path, ui=ui))
+
+    # _current_theme() falls back to "dark" (identical to app._resolve_theme_name()).
+    assert ui.select_calls[0]["current"] == "dark"
+
+
+# --------------------------------------------------------------------------- #
+# D. Cancel path
+# --------------------------------------------------------------------------- #
+async def test_cancel_returns_system_dismissed_not_skip(isolated_config):
+    tmp_path = isolated_config
+    ui = FakeUIHost(pick=None)  # Esc
+    outcome = await THEME_COMMAND.run("", _ctx(tmp_path, ui=ui))
+
+    # Faithful to TS onDone("Theme picker dismissed", {display:"system"}) — a visible
+    # system line, NOT skip (which would be display="skip").
+    assert outcome.message == "Theme picker dismissed"
+    assert outcome.display == "system"
+    assert outcome.display != "skip"
+    # Cancel does not persist.
+    assert _persisted_theme(tmp_path) is None
+
+
+# --------------------------------------------------------------------------- #
+# E. Null surface (always needs a UI) + args ignored
+# --------------------------------------------------------------------------- #
+async def test_run_raises_on_null_surface(isolated_config):
+    tmp_path = isolated_config
+    # No args path => the picker is the only path => select must raise on NullUIHost
+    # (proves there is no /export-style headless keystone).
+    with pytest.raises(InteractiveUnavailableError):
+        await THEME_COMMAND.run("", _ctx(tmp_path, ui=NullUIHost()))
+    assert _persisted_theme(tmp_path) is None
+
+
+async def test_engine_errors_cleanly_on_null_surface(isolated_config):
+    tmp_path = isolated_config
+    reg = _registry_with(THEME_COMMAND)
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+    assert ctx.ui is None  # engine substitutes NullUIHost
+    eng = CommandEngine(registry=reg, workspace_root=tmp_path, context=ctx)
+
+    result = await eng.execute("/theme")
+
+    assert result.success is False
+    assert result.error is not None
+    # The clean "needs an interactive surface" message, not a stack trace.
+    assert "interactive surface" in result.error
+
+
+async def test_args_are_ignored(isolated_config):
+    tmp_path = isolated_config
+    # TS call(onDone, _context) ignores args: extra args don't shortcut the picker.
+    ui = FakeUIHost(pick="dark")
+    outcome = await THEME_COMMAND.run("light extra args", _ctx(tmp_path, ui=ui))
+
+    assert outcome.message == "Theme set to dark"  # the PICK wins, not the args
+    assert _persisted_theme(tmp_path) == "dark"
+    assert len(ui.select_calls) == 1  # the picker still ran
+
+
+# --------------------------------------------------------------------------- #
+# F. Options shape
+# --------------------------------------------------------------------------- #
+async def test_options_shape_marks_current_and_uses_raw_labels(isolated_config):
+    tmp_path = isolated_config
+    cfg.set_theme("light")
+    ui = FakeUIHost(pick="light")
+    await THEME_COMMAND.run("", _ctx(tmp_path, ui=ui))
+
+    call = ui.select_calls[0]
+    names = list_theme_names()
+    assert call["values"] == names
+    # Labels are the raw theme names (mirrors ThemePickerScreen), not friendly labels.
+    assert call["labels"] == names
+    # Exactly the current option carries the "current" marker.
+    for name, desc in zip(call["values"], call["descriptions"]):
+        assert desc == ("current" if name == "light" else None)
+
+
+# --------------------------------------------------------------------------- #
+# G. D2 — _open_theme_picker wires on_persist=set_theme
+# --------------------------------------------------------------------------- #
+def test_open_theme_picker_wires_on_persist(monkeypatch):
+    # Assert the wiring (not a live Textual render): _open_theme_picker must pass
+    # on_persist=set_theme so the TUI persists like TS. The screen fires on_persist
+    # only on selection, not on cancel (theme_picker.py:76-93), so Esc won't persist.
+    from src.tui import app as app_mod
+    from src.config import set_theme
+
+    captured: dict = {}
+
+    class _FakeScreen:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(app_mod, "ThemePickerScreen", _FakeScreen)
+
+    fake_self = SimpleNamespace(
+        _theme_name="dark",
+        announcer=SimpleNamespace(announce=lambda *a, **k: None),
+        push_screen=lambda screen, callback=None: None,
+        apply_theme=lambda *a, **k: None,
+        _restore_prompt_focus=lambda: None,
+    )
+
+    app_mod.ClawCodexTUI._open_theme_picker(fake_self, transcript=None)
+
+    assert captured.get("on_persist") is set_theme
+    # And the picker is still seeded the same way (no regression of preview wiring).
+    assert callable(captured.get("on_preview"))
+    assert captured.get("current") == "dark"


### PR DESCRIPTION
## Summary
Phase 5 of the command_system parity port: ports TS `local-jsx` `/theme` (`typescript/src/commands/theme/`) as a Class-B `InteractiveCommand`.

- **Surfaces it where it was invisible.** `/theme` previously lived only in the TUI's private builtins. As an `InteractiveCommand` it now appears on registry-consulting surfaces (REPL numbered-menu, SDK clean-error, help/aggregator listings).
- **Dispatch inversion vs `/export`.** The TUI **keeps intercepting** `/theme` (`dispatch_local_command` → `open_dialog="theme"`) to preserve the rich live-preview `ThemePickerScreen`; the registry command serves the other surfaces. (Anti-regression test guards this.)
- **Faithful `display` mapping.** Success → `display="user"` (TS no-options `onDone` → model-visible `createUserMessage`, `shouldQuery=false`); cancel → `display="system"` `"Theme picker dismissed"` (not `skip`).
- **Persistence.** New `config.set_theme()` writes global-only via `set_global` (matching `set_api_key` / `set_default_provider`), faithful to TS `saveGlobalConfig`.
- **D2 wiring.** The TUI picker now also passes `on_persist=set_theme`, so a selection persists like TS while Esc leaves the saved theme untouched (`theme_picker.py` fires `on_persist` only on select).
- **Import safety.** `list_theme_names` is imported lazily so `import src.command_system` does not pull the heavy Textual stack.

Documented deliberate divergences: Python's own theme set (`auto`/`dark`/`light`/`claude`) with raw-name labels; persist-only (no live hot-swap) on non-TUI surfaces.

## Test plan
- [x] 13 new tests in `tests/test_theme_command.py` (sections A–G) pass
- [x] Broader command_system + config suites green (138 tests)
- [x] Critic review: APPROVE (no BLOCKER/MAJOR; one MINOR docstring fix applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)