### PR TITLE
commands: port faithful /model interactive command (Phase 7)

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -77,6 +77,7 @@ from .output_style_command import OUTPUT_STYLE_COMMAND, OutputStyleCommand
 from .export_command import EXPORT_COMMAND, ExportCommand
 from .theme_command import THEME_COMMAND, ThemeCommand
 from .effort_command import EFFORT_COMMAND, EffortCommand
+from .model_command import MODEL_COMMAND, ModelCommand
 from .types import (
     Command,
     CommandAvailability,
@@ -156,6 +157,8 @@ __all__ = [
     "ThemeCommand",
     "EFFORT_COMMAND",
     "EffortCommand",
+    "MODEL_COMMAND",
+    "ModelCommand",
     "get_builtin_commands",
     "register_builtin_commands",
     # Moved-to-plugin factory + shell-at-prompt-build

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -30,6 +30,7 @@ from .security_review import SECURITY_REVIEW_COMMAND
 from .statusline import STATUSLINE_COMMAND
 from .theme_command import THEME_COMMAND
 from .effort_command import EFFORT_COMMAND
+from .model_command import MODEL_COMMAND
 from .types import Command, CommandType, CompactionResult, LocalCommand, PromptCommand
 
 
@@ -1238,6 +1239,7 @@ def get_builtin_commands() -> list[Command]:
         EXPORT_COMMAND,
         THEME_COMMAND,
         EFFORT_COMMAND,
+        MODEL_COMMAND,
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)

--- a/src/command_system/model_command.py
+++ b/src/command_system/model_command.py
@@ -1,0 +1,189 @@
+"""model — interactive ``/model`` command (port of TS local-jsx).
+
+Port of ``typescript/src/commands/model/`` (``model.tsx`` + ``index.ts``). Like
+``/theme`` and ``/effort``, this is the **inverse** of ``/export`` at the TUI dispatch
+layer: the TUI keeps intercepting ``/model`` (+ ``/models``) → ``open_dialog="model"`` to
+preserve its ``ModelPickerScreen``; this command serves the registry-consulting surfaces
+(REPL numbered-menu ``select``, SDK, help/aggregator listings) where ``/model`` was
+previously invisible (it lived only in the TUI's private ``LOCAL_BUILTINS``).
+
+**Functional** (unlike ``/effort``): the live model channel in Python is
+``provider.model`` — providers resolve the request model via ``_get_model`` =
+``kwargs.get("model", self.model)`` and neither the main loop nor the fast path passes a
+``model=`` override, so the held provider's ``.model`` decides the next query's model. So
+this command sets **``ctx.provider.model``** (the channel inference reads), reachable on the
+REPL because Phase 7 also wires ``provider`` into the REPL command context. It is the **only**
+write: the reactive ``AppState.main_loop_model`` has no production reader (its
+``set_main_loop_model_override`` mirror is dead), and TS ``/model`` never writes disk — so
+this is session-only, no settings write.
+
+**Headless keystone:** the arg paths (``/model <name>``, ``current``/``status``/…, ``help``)
+need no UI; only the no-args picker needs a surface (``NullUIHost.select`` raises there).
+
+**Deliberate divergences (documented for parity review):**
+  * **Dropped** (need unported subsystems): network discovery/``refresh`` (→ "not supported"),
+    org-allowlist, 1M-context gates, fast-mode, extra-usage billing, network model-validation,
+    and TS ``'default'``-reset (no provider-default reachable from ``CommandContext``).
+  * **Validation = alias-resolve + membership** in ``provider.get_available_models()`` (the
+    list the picker uses), not TS's network ``validateModel``. Makes "Model 'x' not found"
+    reachable. ``MODEL_ALIASES`` is Claude-only, so on non-Anthropic providers (incl. GLM —
+    the REPL default, whose ``get_available_models()`` lists ``zai/glm-5``) set-by-name needs
+    the **exact listed id**; the picker is the ergonomic path there.
+  * **Static description** ("Set the AI model"); TS's is dynamic ``…(currently {model})`` — a
+    frozen ``CommandBase.description: str`` can't be a getter. ``current`` shows the live model.
+  * **``provider.model`` is the sole write** (Python reads it, not AppState — an architectural
+    divergence from TS, which writes ``AppState.mainLoopModel``).
+  * **Effort suffix in ``current``** reads ``settings.effort`` (the Phase 6 channel), not
+    AppState ``effortValue``.
+  * **Label = ``display_name``** (drops TS ``renderModelLabel``'s ``(default)``/alias decoration).
+
+``disable_model_invocation=True`` — model selection is user-driven (the ``/permissions``
+stance); a model must not switch its own model via the SlashCommand tool. ``src.models`` /
+``get_settings`` are imported lazily (the ``app.py``/advisor discipline).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .types import (
+    CommandContext,
+    InteractiveCommand,
+    InteractiveOutcome,
+    UIOption,
+)
+
+COMMON_HELP_ARGS = frozenset({"help", "-h", "--help"})
+# Verbatim from TS COMMON_INFO_ARGS (model.tsx).
+COMMON_INFO_ARGS = frozenset({
+    "list", "show", "display", "current", "view", "get", "check",
+    "describe", "print", "version", "about", "status", "?",
+})
+
+_NO_PROVIDER = "Model unavailable (no active provider)."
+# TS help text (model.tsx:792), minus the dropped `refresh` clause.
+_USAGE = "Run /model to open the model selection menu, or /model [modelName] to set the model."
+
+
+def _canonical(name: str) -> str:
+    """Resolve an alias to its canonical id (``sonnet`` → ``claude-sonnet-4-...``);
+    returns the input unchanged for non-aliases. Lazy import — see module docstring."""
+    from src.models.model import canonical_model_name
+
+    return canonical_model_name(name)
+
+
+def _label(model: str | None) -> str:
+    if not model:
+        return "(none)"
+    from src.models.model import display_name
+
+    return display_name(model)
+
+
+def _list_models(provider) -> list[str]:
+    """The provider's available model ids (the source the picker uses + the validation
+    set). ``get_available_models`` is the real provider method (``list_models`` does not
+    exist on providers)."""
+    try:
+        return [str(m) for m in (provider.get_available_models() or [])]
+    except Exception:
+        return []
+
+
+def _options(models: list[str], current: str | None) -> list[UIOption]:
+    return [
+        UIOption(value=m, label=m, description="current" if m == current else None)
+        for m in models
+    ]
+
+
+def _effort_suffix() -> str:
+    """`` (effort: X)`` when an effort is persisted (Phase 6 ``settings.effort``), else ``""``."""
+    try:
+        from src.settings.settings import get_settings
+
+        eff = get_settings().effort
+    except Exception:
+        eff = ""
+    return f" (effort: {eff})" if eff else ""
+
+
+def _show_current(context: CommandContext) -> str:
+    prov = context.provider
+    cur = getattr(prov, "model", None) if prov is not None else None
+    if not cur:
+        return "Current model: (none)"
+    return f"Current model: {_label(cur)}{_effort_suffix()}"
+
+
+def _apply(provider, model: str) -> None:
+    """Set the live model. ``provider.model`` is the channel inference reads; guarded
+    exactly like the TUI's ``_open_model_picker`` (app.py)."""
+    try:
+        provider.model = model
+    except Exception:
+        pass
+
+
+@dataclass(frozen=True)
+class ModelCommand(InteractiveCommand):
+    """Pick or set the active model. Frozen + no new fields (the ``ThemeCommand`` pattern);
+    behavior lives in :meth:`run`."""
+
+    async def run(self, args: str, context: CommandContext) -> InteractiveOutcome:
+        a = (args or "").strip()
+        low = a.lower()
+
+        if low in COMMON_HELP_ARGS:  # TS help => display:'system' (model.tsx:792)
+            return InteractiveOutcome(message=_USAGE, display="system")
+        if low in COMMON_INFO_ARGS:  # ShowModelAndClose
+            return InteractiveOutcome(message=_show_current(context), display="user")
+        if low == "refresh":  # TS network discovery — dropped
+            return InteractiveOutcome(
+                message="Model refresh is not supported.", display="system"
+            )
+        if not a:  # ModelPickerWrapper
+            return await self._pick(context)
+        return self._set(context, a)  # SetModelAndClose (headless)
+
+    async def _pick(self, context: CommandContext) -> InteractiveOutcome:
+        prov = context.provider
+        if prov is None:
+            return InteractiveOutcome(message=_NO_PROVIDER, display="system")
+        models = _list_models(prov)
+        if not models:
+            return InteractiveOutcome(message="No models available.", display="system")
+        current = getattr(prov, "model", None)
+        picked = await context.ui.select(
+            "Select model:", _options(models, current), current=current
+        )
+        if picked is None:  # TS cancel: "Kept model as …" (model.tsx:376), NOT skip
+            return InteractiveOutcome(
+                message=f"Kept model as {_label(current)}", display="system"
+            )
+        _apply(prov, picked)
+        return InteractiveOutcome(message=f"Set model to {_label(picked)}", display="user")
+
+    def _set(self, context: CommandContext, arg: str) -> InteractiveOutcome:
+        prov = context.provider
+        if prov is None or not hasattr(prov, "model"):
+            return InteractiveOutcome(message=_NO_PROVIDER, display="system")
+        canon = _canonical(arg)
+        models = _list_models(prov)
+        # Membership validation (TS network validate dropped). Permissive when the
+        # provider lists nothing (unknown provider) so a valid id still goes through.
+        if models and canon not in models:
+            return InteractiveOutcome(message=f"Model '{arg}' not found", display="system")
+        _apply(prov, canon)
+        return InteractiveOutcome(message=f"Set model to {_label(canon)}", display="user")
+
+
+MODEL_COMMAND = ModelCommand(
+    name="model",
+    description="Set the AI model",   # static (TS is dynamic — see module docstring)
+    argument_hint="[model]",          # verbatim TS index.ts
+    disable_model_invocation=True,    # user-driven only (the /permissions stance)
+)
+
+
+__all__ = ["MODEL_COMMAND", "ModelCommand"]

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -1051,6 +1051,10 @@ class ClawcodexREPL:
             cost_tracker=self.cost_tracker,
             history=self.history_log,
             app_state_store=self.app_state_store,
+            # Phase 7 (/model): the active provider, so registry commands can read/set
+            # the live model (provider.model) on the REPL. /advisor also benefits
+            # (decide_advisor_mode gets a real provider instead of None).
+            provider=self.provider,
             ui=ReplUIHost(self._safe_input, self.console),
             # P0-6 Option B: lets a SkillPromptCommand render via the same
             # _run_markdown_skill path the Skill tool uses (session id +

--- a/tests/test_model_command.py
+++ b/tests/test_model_command.py
@@ -1,0 +1,301 @@
+"""Tests for the ``/model`` command (Phase 7 — port of TS local-jsx).
+
+Mirrors the ``/theme``/``/effort`` test layout. ``/model`` is the **inverse** of
+``/export`` at the TUI dispatch layer: the TUI keeps intercepting ``/model`` (+ ``/models``)
+→ ``open_dialog="model"``; the ``ModelCommand`` serves the registry-consulting surfaces.
+It is **functional** — it sets the live ``provider.model`` (the channel inference reads) via
+``ctx.provider`` — so the tests drive a ``FakeProvider`` with a settable ``.model`` and a
+``get_available_models()`` list.
+
+Sections:
+  * A — metadata + registration.
+  * B — bridge-safety by type + TUI dispatch inversion (``/model`` AND ``/models``).
+  * C — set-by-name (headless): alias-resolve + membership; not-found; honest-failure; empty-list.
+  * D — picker: set / cancel ("Kept model as …") / no-models.
+  * E — info / help / refresh (+ effort suffix from settings).
+  * F — null surface: no-args picker raises; engine clean error; arg path works headless.
+  * G — D1: the REPL wires ``provider`` into its command context.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.command_system import (
+    MODEL_COMMAND,
+    ModelCommand,
+    create_command_context,
+    get_builtin_commands,
+    get_commands,
+    is_bridge_safe_command,
+)
+from src.command_system.engine import CommandEngine
+from src.command_system.registry import CommandRegistry
+from src.command_system.types import (
+    CommandType,
+    InteractiveOutcome,
+    InteractiveUnavailableError,
+    NullUIHost,
+)
+from src.models.model import canonical_model_name, display_name
+
+_SONNET = "claude-sonnet-4-20250514"
+_OPUS = "claude-opus-4-20250514"
+
+
+# --------------------------------------------------------------------------- #
+# Fakes / helpers
+# --------------------------------------------------------------------------- #
+class FakeUIHost:
+    def __init__(self, *, pick=None):
+        self._pick = pick
+        self.select_calls: list[dict] = []
+
+    async def select(self, title, options, *, current=None):
+        self.select_calls.append(
+            {
+                "title": title,
+                "values": [o.value for o in options],
+                "labels": [o.label for o in options],
+                "descriptions": [o.description for o in options],
+                "current": current,
+            }
+        )
+        return self._pick
+
+    async def prompt_text(self, title, *, default="", placeholder=None):
+        return None
+
+    async def display(self, title, body):
+        return None
+
+
+class FakeProvider:
+    def __init__(self, model=_SONNET, models=None):
+        self.model = model
+        self._models = [_SONNET, _OPUS] if models is None else list(models)
+
+    def get_available_models(self):
+        return list(self._models)
+
+
+def _ctx(tmp_path: Path, *, ui=None, provider=None):
+    return create_command_context(
+        workspace_root=tmp_path, cwd=tmp_path, ui=ui, provider=provider
+    )
+
+
+def _registry_with(*commands) -> CommandRegistry:
+    reg = CommandRegistry()
+    for c in commands:
+        reg.register(c)
+    return reg
+
+
+@pytest.fixture(autouse=True)
+def _no_effort(monkeypatch):
+    """Default: no persisted effort, so ``current`` has no effort suffix unless a test
+    overrides it (the suffix reads ``settings.effort`` via ``get_settings``)."""
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        "src.settings.settings.get_settings",
+        lambda *a, **k: SimpleNamespace(effort=""),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# A. Metadata + registration
+# --------------------------------------------------------------------------- #
+def test_model_registered_in_builtins_and_aggregator():
+    assert "model" in {c.name for c in get_builtin_commands()}
+    assert "model" in {c.name for c in get_commands(cwd=str(Path.cwd()))}
+
+
+def test_model_metadata_mirrors_ts():
+    assert isinstance(MODEL_COMMAND, ModelCommand)
+    assert MODEL_COMMAND.name == "model"
+    assert MODEL_COMMAND.description == "Set the AI model"
+    assert MODEL_COMMAND.argument_hint == "[model]"
+    assert MODEL_COMMAND.command_type == CommandType.INTERACTIVE
+    assert MODEL_COMMAND.disable_model_invocation is True
+    assert MODEL_COMMAND.is_hidden is False
+
+
+# --------------------------------------------------------------------------- #
+# B. Bridge-safety + TUI dispatch inversion
+# --------------------------------------------------------------------------- #
+def test_model_blocked_from_bridge_by_type():
+    assert is_bridge_safe_command(MODEL_COMMAND) is False
+
+
+@pytest.mark.parametrize("name", ["/model", "/models"])
+def test_dispatch_local_command_intercepts_model(name):
+    from src.tui.commands import dispatch_local_command
+
+    res = dispatch_local_command(
+        name, session=None, workspace_root=Path("."), tool_registry=None
+    )
+    assert res.handled is True
+    assert res.open_dialog == "model"
+
+
+# --------------------------------------------------------------------------- #
+# C. Set-by-name (headless)
+# --------------------------------------------------------------------------- #
+async def test_set_by_alias_resolves_and_sets(tmp_path):
+    prov = FakeProvider(model=_SONNET)
+    out = await MODEL_COMMAND.run("opus", _ctx(tmp_path, provider=prov))
+    assert isinstance(out, InteractiveOutcome)
+    assert prov.model == canonical_model_name("opus") == _OPUS
+    assert out.message == f"Set model to {display_name(_OPUS)}"
+    assert out.display == "user"
+
+
+async def test_set_full_id(tmp_path):
+    prov = FakeProvider(model=_OPUS)
+    out = await MODEL_COMMAND.run(_SONNET, _ctx(tmp_path, provider=prov))
+    assert prov.model == _SONNET
+    assert out.message == f"Set model to {display_name(_SONNET)}"
+
+
+async def test_set_unknown_is_not_found_and_does_not_change(tmp_path):
+    prov = FakeProvider(model=_SONNET)
+    out = await MODEL_COMMAND.run("bogus", _ctx(tmp_path, provider=prov))
+    assert out.message == "Model 'bogus' not found"
+    assert out.display == "system"
+    assert prov.model == _SONNET  # unchanged
+
+
+async def test_set_without_provider_is_honest_failure(tmp_path):
+    out = await MODEL_COMMAND.run("opus", _ctx(tmp_path, provider=None))
+    assert out.message == "Model unavailable (no active provider)."
+    assert out.display == "system"
+
+
+async def test_set_permissive_when_provider_lists_nothing(tmp_path):
+    # Unknown provider (empty list) => membership skipped => the id is set.
+    prov = FakeProvider(model=_SONNET, models=[])
+    out = await MODEL_COMMAND.run("zai/glm-5", _ctx(tmp_path, provider=prov))
+    assert prov.model == "zai/glm-5"  # actually changed (not tautological)
+    assert out.message == f"Set model to {display_name('zai/glm-5')}"
+
+
+# --------------------------------------------------------------------------- #
+# D. Picker
+# --------------------------------------------------------------------------- #
+async def test_picker_sets_model(tmp_path):
+    prov = FakeProvider(model=_SONNET)
+    ui = FakeUIHost(pick=_OPUS)
+    out = await MODEL_COMMAND.run("", _ctx(tmp_path, ui=ui, provider=prov))
+    assert prov.model == _OPUS
+    assert out.message == f"Set model to {display_name(_OPUS)}"
+    assert out.display == "user"
+    call = ui.select_calls[0]
+    assert call["values"] == prov.get_available_models()
+    assert call["current"] == _SONNET  # seeded from provider.model
+
+
+async def test_picker_cancel_keeps_model(tmp_path):
+    prov = FakeProvider(model=_SONNET)
+    ui = FakeUIHost(pick=None)
+    out = await MODEL_COMMAND.run("", _ctx(tmp_path, ui=ui, provider=prov))
+    assert out.message == f"Kept model as {display_name(_SONNET)}"
+    assert out.display == "system"
+    assert prov.model == _SONNET  # unchanged
+
+
+async def test_picker_no_models(tmp_path):
+    prov = FakeProvider(model=_SONNET, models=[])
+    ui = FakeUIHost(pick=_OPUS)
+    out = await MODEL_COMMAND.run("", _ctx(tmp_path, ui=ui, provider=prov))
+    assert out.message == "No models available."
+    assert out.display == "system"
+
+
+# --------------------------------------------------------------------------- #
+# E. Info / help / refresh
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("arg", ["current", "status", "show", "?"])
+async def test_info_shows_current(tmp_path, arg):
+    prov = FakeProvider(model=_OPUS)
+    out = await MODEL_COMMAND.run(arg, _ctx(tmp_path, provider=prov))
+    assert out.message == f"Current model: {display_name(_OPUS)}"
+    assert out.display == "user"
+
+
+async def test_info_includes_effort_suffix(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        "src.settings.settings.get_settings",
+        lambda *a, **k: SimpleNamespace(effort="high"),
+    )
+    prov = FakeProvider(model=_OPUS)
+    out = await MODEL_COMMAND.run("current", _ctx(tmp_path, provider=prov))
+    assert out.message == f"Current model: {display_name(_OPUS)} (effort: high)"
+
+
+@pytest.mark.parametrize("arg", ["help", "-h", "--help"])
+async def test_help(tmp_path, arg):
+    prov = FakeProvider()
+    before = prov.model
+    out = await MODEL_COMMAND.run(arg, _ctx(tmp_path, provider=prov))
+    assert out.message.startswith("Run /model to open the model selection menu")
+    assert out.display == "system"
+    assert prov.model == before  # no change
+
+
+async def test_refresh_not_supported(tmp_path):
+    prov = FakeProvider()
+    out = await MODEL_COMMAND.run("refresh", _ctx(tmp_path, provider=prov))
+    assert out.message == "Model refresh is not supported."
+    assert out.display == "system"
+
+
+# --------------------------------------------------------------------------- #
+# F. Null surface (only the no-args picker needs a UI)
+# --------------------------------------------------------------------------- #
+async def test_picker_raises_on_null_surface(tmp_path):
+    prov = FakeProvider()
+    with pytest.raises(InteractiveUnavailableError):
+        await MODEL_COMMAND.run("", _ctx(tmp_path, ui=NullUIHost(), provider=prov))
+
+
+async def test_engine_errors_cleanly_on_null_surface(tmp_path):
+    prov = FakeProvider()
+    reg = _registry_with(MODEL_COMMAND)
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path, provider=prov)
+    assert ctx.ui is None  # engine substitutes NullUIHost
+    eng = CommandEngine(registry=reg, workspace_root=tmp_path, context=ctx)
+
+    result = await eng.execute("/model")  # no args => picker => needs a surface
+
+    assert result.success is False
+    assert result.error is not None
+    assert "interactive surface" in result.error
+
+
+async def test_engine_arg_path_succeeds_headless(tmp_path):
+    prov = FakeProvider(model=_SONNET)
+    reg = _registry_with(MODEL_COMMAND)
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path, provider=prov)
+    eng = CommandEngine(registry=reg, workspace_root=tmp_path, context=ctx)
+
+    result = await eng.execute("/model opus")
+
+    assert result.success is True
+    assert prov.model == _OPUS
+
+
+# --------------------------------------------------------------------------- #
+# G. D1 — the REPL wires provider into its command context
+# --------------------------------------------------------------------------- #
+def test_repl_wires_provider_into_command_context():
+    import inspect
+
+    from src.repl.core import ClawcodexREPL
+
+    src_text = inspect.getsource(ClawcodexREPL._init_command_system)
+    assert "provider=self.provider" in src_text


### PR DESCRIPTION
## Summary
- Port TS local-jsx `/model` (`typescript/src/commands/model/`) as a Class-B `InteractiveCommand` (`src/command_system/model_command.py`), surfacing it on registry-consulting surfaces (REPL, SDK, help/aggregator) where it was previously invisible (TUI-only).
- **Functional** (unlike `/effort`): sets the **live** model channel `provider.model` — the channel inference actually reads (`_get_model` = `kwargs.get("model", self.model)`; no `model=` override on the main or fast path). Reachable on the REPL because this phase also wires `provider` into the REPL command context (**D1**, 1 line; `/advisor` also benefits — `decide_advisor_mode` gets a real provider instead of `None`).
- Branches mirror `model.tsx call()`: no-args **picker** (`select` over `provider.get_available_models()`), **set-by-name** (alias-resolve via `canonical_model_name` + membership validation → `Model 'x' not found`), **current/status/info** (`COMMON_INFO_ARGS`), **help**, and **refresh → "not supported"**. Messages verbatim from TS (`Set model to {label}`, cancel `Kept model as {label}`); display mapping faithful.
- Dispatch **inversion** (same as `/theme`,`/effort`): the TUI keeps intercepting `/model` (+ `/models`) → `open_dialog="model"`; the TUI dialog is **unchanged**. `disable_model_invocation=True` (user-driven, the `/permissions` stance).
- Session-only, **no disk write** (TS `/model` never persists either); the inert `AppState.main_loop_model` mirror is intentionally not written (no reader).

**Dropped (need unported subsystems):** network discovery/refresh, org-allowlist, 1M-context gates, fast-mode, extra-usage, network model-validation, `'default'`-reset. Validation is local; on non-Anthropic providers (incl. GLM, the REPL default) set-by-name needs the exact listed id (aliases are Claude-only) — the picker is the ergonomic path.

## Test plan
- [x] New `tests/test_model_command.py` (26 tests): metadata/registration, bridge-safety + dispatch inversion (`/model` AND `/models`), set-by-name (alias-resolve, not-found, honest-failure, empty-list permissive), picker (set/cancel/no-models), info/help/refresh (+ effort suffix), null-surface error + headless arg success via the engine, and a D1 wiring guard.
- [x] Full suite: **7135 passed**; only the 6 pre-existing baseline failures (workspace-boundary, tool-parity, two mcp `test_valid_command`) — unrelated to model.
- [x] Plan + implementation both critic-approved (the plan round caught — and fixed before any code — a two-`AppState`-classes conflation and a nonexistent `list_models()` assumption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)