### PR TITLE
query: enable Anthropic extended thinking on Claude 4.x

### DIFF
--- a/src/query/query.py
+++ b/src/query/query.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import sys
 import time
 from dataclasses import dataclass, field
@@ -80,6 +81,19 @@ class QueryParams:
     # raise AbortError from inside the SDK's stream context to tear
     # down the HTTP socket on ESC.
     on_text_chunk: Callable[[str], None] | None = None
+
+    # Extended thinking ("adaptive" mode) — opt the model into a private
+    # reasoning scratchpad before producing its visible answer. Defaults
+    # to ``None`` which auto-enables on Anthropic Claude 4.x models
+    # (the only family the API supports it on) and stays off elsewhere.
+    # Pass ``False`` to force-disable (e.g. for determinism in tests).
+    # Mirrors the TS reference which always passes
+    # ``thinking: {type: "adaptive"}`` on these models.
+    extended_thinking: bool | None = None
+    # Output-effort hint forwarded as ``output_config.effort``. Anthropic
+    # accepts ``"low" | "medium" | "high"``. Only sent when extended
+    # thinking is active.
+    thinking_effort: str = "medium"
 
 
 @dataclass
@@ -285,6 +299,25 @@ def _is_hook_stopped_continuation(msg: Message | None) -> bool:
     return False
 
 
+_THINKING_ELIGIBLE_MODEL_PATTERN = re.compile(
+    r"claude-(?:sonnet|opus|haiku)-(?:4-\d+|[5-9]\b|\d{2,})",
+    re.IGNORECASE,
+)
+
+
+def _model_supports_extended_thinking(model: str | None) -> bool:
+    """True iff the model is on the Anthropic Claude 4.x or newer family.
+
+    Extended thinking (``thinking={"type": "adaptive"}``) was introduced
+    with the Claude 4 series — the Anthropic API rejects the parameter
+    on 3.x and earlier. Detection is by name pattern so unreleased model
+    snapshots (e.g. ``claude-opus-4-7-20260201``) opt in automatically.
+    """
+    if not model:
+        return False
+    return bool(_THINKING_ELIGIBLE_MODEL_PATTERN.search(model))
+
+
 async def _call_model_sync(
     *,
     provider: BaseProvider,
@@ -294,6 +327,8 @@ async def _call_model_sync(
     max_output_tokens_override: int | None = None,
     abort_signal: Any = None,
     on_text_chunk: Callable[[str], None] | None = None,
+    extended_thinking: bool | None = None,
+    thinking_effort: str = "medium",
 ) -> tuple[list[AssistantMessage], list[ToolUseBlock]]:
     from ..types.messages import normalize_messages_for_api
     from ..utils.advisor import (
@@ -535,6 +570,19 @@ async def _call_model_sync(
 
     if max_output_tokens_override is not None:
         call_kwargs["max_tokens"] = max_output_tokens_override
+
+    # Extended thinking (Claude 4.x family). Forwarded straight through
+    # the provider's kwargs pass-through to client.messages.stream(
+    # thinking=..., output_config=...). Off-API on older Claude versions
+    # and on non-Anthropic providers, so guarded by both. ``None`` =
+    # auto-enable; ``True`` / ``False`` = caller override. Mirrors the
+    # TS reference which sends ``thinking: {type: "adaptive"}`` and
+    # ``output_config: {effort: ...}`` on every Claude 4.x request.
+    if extended_thinking is not False and is_anthropic:
+        provider_model = getattr(provider, "model", None) or call_kwargs.get("model")
+        if extended_thinking is True or _model_supports_extended_thinking(provider_model):
+            call_kwargs["thinking"] = {"type": "adaptive"}
+            call_kwargs["output_config"] = {"effort": thinking_effort}
 
     # TS callModel() uses SSE streaming for faster first-byte latency and
     # progressive text display.  Use chat_stream_response() which streams
@@ -1289,6 +1337,8 @@ async def query(
                 max_output_tokens_override=max_output_tokens_override,
                 abort_signal=params.abort_controller.signal,
                 on_text_chunk=params.on_text_chunk,
+                extended_thinking=params.extended_thinking,
+                thinking_effort=params.thinking_effort,
             )
             assistant_messages = returned_assistants
             tool_use_blocks = returned_tool_blocks

--- a/tests/test_query_extended_thinking.py
+++ b/tests/test_query_extended_thinking.py
@@ -1,0 +1,165 @@
+"""Tests for the extended-thinking injection in ``_call_model_sync``.
+
+Mirrors the TS reference's behavior: when the active provider is the
+Anthropic SDK and the model is in the Claude 4.x family (or newer),
+``client.messages.create`` / ``messages.stream`` receives
+``thinking={"type": "adaptive"}`` and ``output_config={"effort": ...}``
+without any caller having to ask for it. Older Claude versions and
+non-Anthropic providers don't see the kwargs.
+
+The tests drive the agent loop through one turn against a ``MagicMock``
+Anthropic provider and assert the kwargs landed on the streaming-fallback
+``chat()`` call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from src.providers.anthropic_provider import AnthropicProvider
+from src.providers.base import ChatResponse
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.types.messages import AssistantMessage, UserMessage
+from src.utils.abort_controller import AbortController
+
+from src.query.query import (
+    QueryParams,
+    _model_supports_extended_thinking,
+    query,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_anthropic_mock(model: str) -> MagicMock:
+    """A MagicMock that passes ``isinstance(x, AnthropicProvider)``.
+
+    ``_call_model_sync`` discriminates by ``isinstance(provider,
+    AnthropicProvider)``, so a plain MagicMock would land in the non-
+    Anthropic branch and never see the thinking injection.
+    """
+    provider = MagicMock(spec=AnthropicProvider)
+    provider.model = model
+    # Force the streaming path into the chat() fallback so test assertions
+    # can read the kwargs straight off ``chat.call_args``.
+    provider.chat_stream_response.side_effect = NotImplementedError()
+    provider.chat.return_value = ChatResponse(
+        content="ok",
+        model=model,
+        usage={"input_tokens": 1, "output_tokens": 1},
+        finish_reason="end_turn",
+        tool_uses=None,
+    )
+    return provider
+
+
+class TestModelSupportsThinking(unittest.TestCase):
+    """The standalone gating helper."""
+
+    def test_claude_4_family(self):
+        for m in (
+            "claude-opus-4-6",
+            "claude-opus-4-7-20260201",
+            "claude-sonnet-4-5",
+            "claude-sonnet-4-5-20250929",
+            "claude-haiku-4-5",
+        ):
+            self.assertTrue(_model_supports_extended_thinking(m), m)
+
+    def test_legacy_models(self):
+        for m in (
+            "claude-3-5-sonnet-20241022",
+            "claude-3-opus-20240229",
+            "claude-3-haiku-20240307",
+        ):
+            self.assertFalse(_model_supports_extended_thinking(m), m)
+
+    def test_non_anthropic(self):
+        for m in ("gpt-4o", "deepseek-v4-pro", "gemini-2.5-pro", "", None):
+            self.assertFalse(_model_supports_extended_thinking(m), m)
+
+
+class TestExtendedThinkingInjection(unittest.TestCase):
+    """End-to-end: drive the loop and inspect kwargs the provider saw."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+        self.registry = build_default_registry()
+        self.context = ToolContext(workspace_root=self.workspace)
+        self.abort = AbortController()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _drive_one_turn(self, provider: MagicMock, **extra_params) -> dict:
+        """Run one ``query()`` turn and return the kwargs the provider
+        observed on its (mock) ``chat()`` call."""
+        params = QueryParams(
+            messages=[UserMessage(content="hi")],
+            system_prompt="hello",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=1,
+            **extra_params,
+        )
+
+        async def run():
+            async for _ in query(params):
+                pass
+
+        _run(run())
+        self.assertTrue(provider.chat.called, "provider.chat() should have been invoked")
+        return provider.chat.call_args.kwargs
+
+    def test_anthropic_opus_4_gets_thinking_by_default(self):
+        provider = _make_anthropic_mock("claude-opus-4-6")
+        kw = self._drive_one_turn(provider)
+        self.assertEqual(kw.get("thinking"), {"type": "adaptive"})
+        self.assertEqual(kw.get("output_config"), {"effort": "medium"})
+
+    def test_anthropic_sonnet_4_gets_thinking_by_default(self):
+        provider = _make_anthropic_mock("claude-sonnet-4-5")
+        kw = self._drive_one_turn(provider)
+        self.assertEqual(kw.get("thinking"), {"type": "adaptive"})
+
+    def test_anthropic_legacy_3x_does_NOT_get_thinking(self):
+        # 3.x models reject the parameter at the API layer — the helper
+        # must withhold it.
+        provider = _make_anthropic_mock("claude-3-5-sonnet-20241022")
+        kw = self._drive_one_turn(provider)
+        self.assertNotIn("thinking", kw)
+        self.assertNotIn("output_config", kw)
+
+    def test_explicit_opt_out_suppresses_thinking(self):
+        provider = _make_anthropic_mock("claude-opus-4-6")
+        kw = self._drive_one_turn(provider, extended_thinking=False)
+        self.assertNotIn("thinking", kw)
+        self.assertNotIn("output_config", kw)
+
+    def test_explicit_opt_in_overrides_unknown_model(self):
+        # An out-of-band model name (e.g. proxy alias) should still get
+        # thinking if the caller forces it. Lets users opt into thinking
+        # on a custom Claude alias the helper hasn't been taught about.
+        provider = _make_anthropic_mock("custom-proxy-claude-model")
+        kw = self._drive_one_turn(provider, extended_thinking=True)
+        self.assertEqual(kw.get("thinking"), {"type": "adaptive"})
+
+    def test_custom_effort_propagates(self):
+        provider = _make_anthropic_mock("claude-opus-4-6")
+        kw = self._drive_one_turn(provider, thinking_effort="high")
+        self.assertEqual(kw.get("output_config"), {"effort": "high"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Port the ``thinking={"type": "adaptive"}`` + ``output_config={"effort": "medium"}`` request shape from the TS reference (upstream TypeScript implementation). Both fields are forwarded straight through ``AnthropicProvider`` to ``client.messages .stream()`` via the existing kwargs pass-through at anthropic_provider.py:239/277/360 — no provider change needed; the injection lives in ``_call_model_sync`` where the per-turn ``call_kwargs`` dict is shaped, alongside the existing ``system`` / ``betas`` handling.

# Why

A proxy-capture diff against upstream TypeScript implementation on the same SWE-bench instance showed three differences in the ``/v1/messages`` envelope clawcodex was never controlling for:

* ``thinking`` — absent in clawcodex, ``{"type": "adaptive"}`` in upstream TypeScript implementation. Gives the model a private reasoning scratchpad before the visible answer, enabling "wait, does this apply to GET requests too?" reflection that doesn't pollute the final output.
* ``max_tokens=4096`` vs ``64000``. (Not in scope for this PR.)
* ``tools=[<38 tools>]`` even with ``--allowed-tools _none_``. (Bug for a separate PR.)

The thinking miss is the largest and cheapest to close. clawcodex's streaming layer already handles incoming ``thinking`` content blocks (``src/query/streaming.py:272``) — this PR finishes the half-done port by actually requesting them.

# Validation

Patched + ran SWE-bench Verified harness against four instances on the same proxy/model (claude-opus-4-6, localhost:4000):

  instance                  baseline  thinking on  delta
  psf__requests-1142        ✗         ✓            +RESOLVED
  sympy__sympy-12419        ✗         ✗            no change
  django__django-11066      ✓         ✓            held
  django__django-11099      ✓         ✓            held

* 1 of 2 known clawcodex-only gaps closed (psf-1142 — upstream TypeScript implementation resolved it in batch50v2; clawcodex now also does).
* 2 of 2 regression-positive baselines held.
* 0 regressions.
* Live proxy capture confirms ``thinking: {"type": "adaptive"}`` + ``output_config: {"effort": "medium"}`` land on the wire.

Sympy-12419 still misses — that bug needs the model to reason about ``isinstance(i, (int, Integer))`` checks; thinking helps but isn't enough alone. Likely needs higher effort or pairs with future fixes to ``max_tokens`` and the ``--allowed-tools`` leak (separate PRs).

# Behavior

* Auto-on for ``claude-(sonnet|opus|haiku)-(4-\d+|[5-9]|\d{2,})`` — every Claude 4.x snapshot opts in, including unreleased point versions like ``claude-opus-4-7-20260201``.
* Off for Claude 3.x (the API rejects ``thinking`` on those models).
* Off for non-Anthropic providers (only the Anthropic path forwards the kwarg).
* Caller can force-disable via ``QueryParams(extended_thinking=False)`` — needed for determinism in tests and for users who want the legacy no-thinking response shape.
* Caller can force-enable via ``QueryParams(extended_thinking=True)`` — needed when a custom proxy aliases a Claude model under a non-matching name (e.g. ``my-claude-alias``).
* Effort defaults to ``"medium"``; pass ``thinking_effort="high"`` (or "low") to override. Mirrors the upstream TypeScript implementation default.

# Test surface

``tests/test_query_extended_thinking.py`` — 9 cases:
* helper coverage: Claude 4.x family, legacy 3.x, non-Anthropic, empty
* end-to-end via MagicMock provider: default-on opus-4, default-on sonnet-4, default-OFF on 3.5-sonnet, explicit opt-out, explicit opt-in override, custom effort propagation
* Mock uses ``spec=AnthropicProvider`` so the ``isinstance`` check in ``_call_model_sync`` sees the right provider type.

Existing query-loop tests (35) all still pass.

# What this PR does NOT do

* Bump default ``max_tokens`` (still 4096 — separate PR).
* Fix the ``--allowed-tools`` leak that leaves 38 tool schemas in every API call (separate PR).
* Add a ``--no-thinking`` CLI flag. The opt-out is plumbed at the ``QueryParams`` layer but no headless / TUI surface for it yet — can be added when a user actually needs it.
* Touch token accounting for thinking-tokens. The existing ``_extract_usage_dict`` comment at anthropic_provider.py:67-72 still applies: the SDK didn't expose them as of 0.88; if 0.105 does, surface them in a follow-up.