### PR TITLE
fix(query): propagate upstream model errors instead of silent empty s…

### DIFF
--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -370,6 +370,25 @@ async def run_query_as_agent_loop(
                 or reason
                 or "user_interrupt"
             )
+        # Same pattern for upstream model failures (connection errors, 4xx,
+        # 5xx, prompt_too_long, etc.). ``query.py`` catches the SDK
+        # exception, yields ``_create_assistant_api_error_message`` into
+        # the message stream (so the TUI can render "API error: ..." in
+        # the transcript), and sets ``Terminal(reason="model_error",
+        # error=<original_exception>)``. Without re-raising here the
+        # adapter returns ``response_text=""`` with a happy
+        # ``AgentLoopRunResult`` and headless ships ``is_error: false,
+        # num_turns: 0, result: ""`` — a silent success that downstream
+        # eval scripts (SWE-bench, batch runners) cannot distinguish
+        # from a legitimately empty completion. Re-raising the original
+        # exception routes it into headless's ``except Exception``
+        # branch which sets ``exit_code=1`` and emits subtype:error /
+        # is_error:true with the error string as ``result``.
+        if reason == "model_error":
+            original_error = getattr(terminal, "error", None)
+            if isinstance(original_error, BaseException):
+                raise original_error
+            raise RuntimeError(str(original_error) if original_error else "model_error")
 
     # When the loop exited because of max_turns, surface the legacy
     # ``[Max tool turns reached]`` sentinel as response_text so callers

--- a/tests/test_agent_loop_compat_model_error.py
+++ b/tests/test_agent_loop_compat_model_error.py
@@ -1,0 +1,146 @@
+"""Regression test for the model-error swallowing bug.
+
+Before this fix, when the inner ``query()`` loop caught an upstream API
+exception (e.g. connection refused, prompt_too_long, 5xx), it set
+``Terminal(reason="model_error", error=<exc>)`` and the adapter
+``run_query_as_agent_loop`` returned **normally** with empty
+``response_text``. Headless then shipped
+``{"is_error": false, "num_turns": 0, "result": ""}`` — indistinguishable
+from a legitimately empty completion. SWE-bench and other eval flows
+that key off ``is_error`` could not detect the failure.
+
+The fix re-raises the original exception so headless's
+``except Exception`` branch sets ``exit_code=1`` and emits
+``subtype:error / is_error:true``.
+
+This test pins the new behavior so the swallowing can't silently
+return.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from src.providers.base import ChatResponse
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.types.messages import UserMessage
+from src.utils.abort_controller import AbortController
+
+from src.query.agent_loop_compat import (
+    AgentLoopRunResult,
+    run_query_as_agent_loop,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestModelErrorPropagation(unittest.TestCase):
+    """When the provider raises, the adapter must re-raise."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+        self.registry = build_default_registry()
+        self.context = ToolContext(workspace_root=self.workspace)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _provider_that_raises(self, exc: Exception) -> MagicMock:
+        """A MagicMock provider whose ``chat`` raises ``exc``. Mirrors the
+        real anthropic_provider's behavior when the SDK raises a
+        ``ConnectionError`` / ``APIError`` from ``messages.create``."""
+        provider = MagicMock()
+        # Force fallback into ``chat()`` so the raise lands inside the
+        # inner query loop's ``except Exception`` (which converts it to
+        # terminal=model_error).
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = exc
+        return provider
+
+    def test_connection_error_re_raises(self):
+        """The exception that originally hit the provider must surface
+        to the caller — not get silently turned into an empty
+        AgentLoopRunResult."""
+
+        original = ConnectionError("Connection refused: localhost:4000")
+        provider = self._provider_that_raises(original)
+
+        with self.assertRaises(ConnectionError) as ctx:
+            _run(run_query_as_agent_loop(
+                initial_messages=[UserMessage(content="anything")],
+                provider=provider,
+                tool_registry=self.registry,
+                tool_context=self.context,
+                system_prompt="",
+                max_turns=5,
+            ))
+
+        # The exact instance round-trips (not a wrapping).
+        self.assertIs(ctx.exception, original)
+
+    def test_generic_runtime_error_re_raises(self):
+        """Generic upstream errors (not matched by query.py's special
+        handlers like prompt_too_long / max_output_tokens) propagate
+        through the adapter.
+
+        ``prompt_too_long`` and ``max_output_tokens`` are intentionally
+        handled differently by query.py — those get converted to
+        "withheld" messages and re-prompted internally rather than
+        terminating. So we use a generic message that won't trip the
+        keyword detectors at query.py:660 / line 622.
+        """
+
+        original = RuntimeError("upstream model returned 502 Bad Gateway")
+        provider = self._provider_that_raises(original)
+
+        with self.assertRaises(RuntimeError) as ctx:
+            _run(run_query_as_agent_loop(
+                initial_messages=[UserMessage(content="hi")],
+                provider=provider,
+                tool_registry=self.registry,
+                tool_context=self.context,
+                system_prompt="",
+                max_turns=5,
+            ))
+
+        self.assertIn("502", str(ctx.exception))
+
+    def test_successful_run_does_not_raise(self):
+        """The new branch only fires for ``terminal.reason == 'model_error'``.
+        A clean completion still returns normally — guards against the
+        re-raise condition matching too broadly."""
+
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="ok",
+            model="test-model",
+            usage={"input_tokens": 1, "output_tokens": 1},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+        result = _run(run_query_as_agent_loop(
+            initial_messages=[UserMessage(content="hi")],
+            provider=provider,
+            tool_registry=self.registry,
+            tool_context=self.context,
+            system_prompt="",
+            max_turns=5,
+        ))
+
+        self.assertIsInstance(result, AgentLoopRunResult)
+        self.assertEqual(result.terminal.reason, "completed")
+        self.assertEqual(result.response_text, "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…uccess

When the inner ``query()`` loop catches an upstream API exception (connection refused, 4xx, 5xx, anything from ``client.messages.create`` that isn't ``prompt_too_long`` or ``max_output_tokens`` — those still get the withheld-message recovery treatment), it yields an ``_create_assistant_api_error_message`` into the message stream and sets ``Terminal(reason="model_error", error=<original_exc>)``.

The Critic-C1 block at ``agent_loop_compat.py:357`` handled abort terminals (``aborted_streaming`` / ``aborted_tools`` / ``interrupted``) by raising ``AbortError`` so callers' exception handlers fire. It forgot ``model_error``. So the adapter returned a happy ``AgentLoopRunResult(response_text="", terminal=Terminal(reason= "model_error", ...))`` and headless shipped:

    {"type":"result","subtype":"success","is_error":false,
     "num_turns":0,"result":"","usage":null}

— indistinguishable from a legitimately empty completion.

Downstream eval scripts (SWE-bench wrappers, batch runners) that key off ``is_error`` or ``subtype`` could not detect the failure and would write empty patches to their predictions file, treating "connection died" the same as "the model genuinely had nothing to say". That made parity investigations against upstream TypeScript implementation impossible to attribute — was clawcodex actually generating a bad patch, or was the API call failing silently?

# Fix

Add a ``model_error`` branch next to the abort-error branch in ``run_query_as_agent_loop``: re-raise the original exception (rounded- tripped through ``Terminal.error``). The exception lands in ``headless.py:359`` ``except Exception`` which sets ``exit_code=1`` and emits ``subtype:error / is_error:true``. TUI sees the same exception via the same path.

The ``_create_assistant_api_error_message`` already yielded into the message stream still reaches the TUI transcript and the conversation history, so users still see "API error: ..." rendered above the re-raise — no regression in TUI presentation. The re-raise is purely additive on top of the existing yield behavior.

# Live behavior

clawcodex pointed at a dead endpoint:

Before:
  {"type":"result","subtype":"success","is_error":false,
   "num_turns":0,"result":""}

After:
  {"type":"result","subtype":"error","is_error":true,
   "num_turns":0,"result":""}

The flip from ``success → error`` and ``false → true`` is the only externally-visible behavior change. ``result`` stays empty (the error detail still lands in the assistant message stream / conversation history; surfacing it into the ``result`` text field is a separate question with its own tradeoffs — punting).

# Test surface

``tests/test_agent_loop_compat_model_error.py`` — 3 cases:

* ``test_connection_error_re_raises`` — a ``ConnectionError`` from the mock provider's ``chat()`` round-trips out of ``run_query_as_agent_loop`` as the same exception instance.
* ``test_generic_runtime_error_re_raises`` — a generic ``RuntimeError("502 Bad Gateway")`` propagates. Uses a message that doesn't trip query.py's ``prompt_too_long`` / ``max_output_tokens`` keyword detectors (those have their own withheld-message recovery paths and don't terminate the loop).
* ``test_successful_run_does_not_raise`` — guard against the re-raise branch matching too broadly; a clean completion still returns an ``AgentLoopRunResult`` normally.

Existing ``test_agent_loop_compat.py`` (6 cases) and ``test_query_*.py`` (35 cases) all still pass.

# What this PR does NOT do

* Does not change query.py's behavior. The ``_create_assistant_api_error_message`` yield + ``Terminal(reason="model_error", error=e)`` set is unchanged. The fix is purely in the adapter's terminal-translation block.
* Does not surface the error text into the ``result`` field. The detail lives in the assistant message stream / conversation history. Adding it to ``result`` would be a richer change with TUI display implications; not in scope for this PR.
* Does not touch ``prompt_too_long`` or ``max_output_tokens`` paths. Those have their own withheld-message recovery in query.py (lines 215-249, 660-665) and never reach the ``terminal=model_error`` branch.

# Why it matters for parity work

Without this fix, every SWE-bench validation round on long-prompt instances (pylint-4551, django-11206, etc.) where ~90KB requests sometimes drop at the proxy layer produced empty predictions with ``is_error:false``. We attributed those to "thinking exhaustion" and spent a round investigating prompt budgets — the real culprit was infrastructure flakiness combined with this silent-swallow bug.