### PR TITLE
commands: port faithful /logo command + startup-banner palettes (Phase 8)

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -78,6 +78,7 @@ from .export_command import EXPORT_COMMAND, ExportCommand
 from .theme_command import THEME_COMMAND, ThemeCommand
 from .effort_command import EFFORT_COMMAND, EffortCommand
 from .model_command import MODEL_COMMAND, ModelCommand
+from .logo_command import LOGO_COMMAND, LogoCommand
 from .types import (
     Command,
     CommandAvailability,
@@ -159,6 +160,8 @@ __all__ = [
     "EffortCommand",
     "MODEL_COMMAND",
     "ModelCommand",
+    "LOGO_COMMAND",
+    "LogoCommand",
     "get_builtin_commands",
     "register_builtin_commands",
     # Moved-to-plugin factory + shell-at-prompt-build

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -31,6 +31,7 @@ from .statusline import STATUSLINE_COMMAND
 from .theme_command import THEME_COMMAND
 from .effort_command import EFFORT_COMMAND
 from .model_command import MODEL_COMMAND
+from .logo_command import LOGO_COMMAND
 from .types import Command, CommandType, CompactionResult, LocalCommand, PromptCommand
 
 
@@ -1240,6 +1241,7 @@ def get_builtin_commands() -> list[Command]:
         THEME_COMMAND,
         EFFORT_COMMAND,
         MODEL_COMMAND,
+        LOGO_COMMAND,
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)

--- a/src/command_system/logo_command.py
+++ b/src/command_system/logo_command.py
@@ -1,0 +1,101 @@
+"""logo — interactive ``/logo`` command (port of TS local-jsx).
+
+Port of ``typescript/src/commands/logo/`` (``logo.tsx`` + ``index.ts``). Picks the
+startup-banner color palette and persists it to the global config ``logoColor`` key;
+the two startup banners (REPL + TUI) resolve and render it on next launch.
+
+Coexistence: **fall-through** (the ``/export`` pattern, NOT the ``/theme``/``/effort``/
+``/model`` inversion). There is **no TUI dialog** for ``/logo`` (it is not in the TUI's
+``LOCAL_BUILTINS``/``open_dialog`` map), so the dispatch falls through and this
+``InteractiveCommand`` serves every surface via the ``UIHost`` port — TUI
+(``TextualUIHost.select``), REPL (``ReplUIHost.select``), SDK (``NullUIHost`` → clean
+error), and the help/aggregator listings.
+
+Faithfulness to TS (``logo.tsx``):
+  * ``call(onDone, _context)`` **ignores args** — the picker is the only path; no
+    headless keystone (on ``NullUIHost`` the ``select`` raises → engine clean error).
+  * **Success → ``display="user"``** (TS ``onDone("Startup logo set to …")`` with no
+    options → model-visible ``createUserMessage``).
+  * **Cancel → "Logo picker dismissed" / ``display="system"``** (verbatim TS).
+
+Deliberate divergences (documented for parity review):
+  * **No swatch preview** in the picker — TS ``LogoPicker`` shows an ANSI gradient
+    swatch per option, but the ``select`` primitive has plain labels. Labels are the
+    friendly ``LOGO_PALETTE_LABELS`` (TS shows labels too).
+  * **Static description** ("Change the startup logo color scheme"); TS's is dynamic
+    ``…(current: {label})`` — a frozen ``CommandBase.description`` can't be a getter.
+    The current palette is the picker's ``current=`` marker.
+  * **Persist via config ``logoColor``** (top-level key, like ``/theme``).
+
+``logo_palettes`` / ``set_logo_color`` are imported lazily (the ``theme``/``app.py``
+discipline).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .types import (
+    CommandContext,
+    InteractiveCommand,
+    InteractiveOutcome,
+    UIOption,
+)
+
+
+def _current_logo() -> str:
+    """The persisted palette name, or the default — mirrors TS index.ts:13-14 /
+    logo.tsx:20-23 (validate via ``is_logo_palette_name``)."""
+    from src.config import load_config
+    from src.utils.logo_palettes import DEFAULT_LOGO_PALETTE, is_logo_palette_name
+
+    current = load_config().get("logoColor")
+    return current if is_logo_palette_name(current) else DEFAULT_LOGO_PALETTE
+
+
+def _logo_options(current: str) -> list[UIOption]:
+    """Picker options: friendly labels, marking the current palette. Lazy import."""
+    from src.utils.logo_palettes import LOGO_PALETTE_LABELS, LOGO_PALETTE_NAMES
+
+    return [
+        UIOption(
+            value=name,
+            label=LOGO_PALETTE_LABELS[name],
+            description="current" if name == current else None,
+        )
+        for name in LOGO_PALETTE_NAMES
+    ]
+
+
+@dataclass(frozen=True)
+class LogoCommand(InteractiveCommand):
+    """Pick the startup logo color palette and persist it. Frozen + no new fields
+    (the ``ThemeCommand`` pattern); behavior lives in :meth:`run`."""
+
+    async def run(self, args: str, context: CommandContext) -> InteractiveOutcome:
+        # TS call ignores args — the picker is the only path. No headless keystone;
+        # on NullUIHost the select below raises -> the engine returns a clean error.
+        from src.config import set_logo_color
+        from src.utils.logo_palettes import LOGO_PALETTE_LABELS
+
+        current = _current_logo()
+        picked = await context.ui.select(
+            "Select startup logo color:", _logo_options(current), current=current
+        )
+        if picked is None:
+            # TS cancel: onDone("Logo picker dismissed", {display:"system"}).
+            return InteractiveOutcome(message="Logo picker dismissed", display="system")
+        set_logo_color(picked)  # persist (TS saveGlobalConfig logoColor)
+        # TS success: onDone("Startup logo set to …") with NO options => model-visible.
+        return InteractiveOutcome(
+            message=f"Startup logo set to {LOGO_PALETTE_LABELS[picked]}. Visible on next launch.",
+            display="user",
+        )
+
+
+LOGO_COMMAND = LogoCommand(
+    name="logo",
+    description="Change the startup logo color scheme",  # static (TS dynamic — see docstring)
+)
+
+
+__all__ = ["LOGO_COMMAND", "LogoCommand"]

--- a/src/config.py
+++ b/src/config.py
@@ -341,6 +341,17 @@ def set_theme(name: str) -> None:
     _get_default_manager().set_global("theme", name)
 
 
+def set_logo_color(name: str) -> None:
+    """Persist the startup logo color palette to the global config.
+
+    Mirrors TS ``/logo`` (``saveGlobalConfig(c => ({...c, logoColor: chosen}))``). A
+    top-level config key (like :func:`set_theme`), read via
+    ``load_config().get("logoColor")`` by the startup banners — NOT a nested settings
+    field.
+    """
+    _get_default_manager().set_global("logoColor", name)
+
+
 def set_effort(value: Optional[str]) -> None:
     """Persist the reasoning-effort choice to user settings (``settings.effort``)
     and invalidate the settings read-cache.

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -2090,16 +2090,35 @@ class ClawcodexREPL:
 
         width = getattr(self.console, "width", 80)
         content_width = max(28, min(width - 12, 72))
-        table = Table.grid(padding=(0, 1))
-        table.add_column(style="bright_black", justify="right", no_wrap=True)
-        table.add_column(style="white", ratio=1)
-        table.add_row("Version", Text.assemble(("ClawCodex", "bold white"), ("  ", ""), (f"v{__version__}", "bold cyan")))
-        table.add_row("Model", Text(model_label, style="bold magenta"))
-        table.add_row("Provider", Text(provider_label, style="bold green"))
-        table.add_row("Workspace", Text(self._truncate_middle(display_path, content_width - 12), style="bold blue"))
 
-        footer = Text("/help  •  /tools  •  /tui  •  /stream  •  /exit", style="dim")
-        mascot_block = Text(mascot_ascii, style="bold orange3", no_wrap=True)
+        # /logo: resolve the persisted palette (best-effort — fall back to the
+        # original hardcoded styles so the banner never fails to render).
+        try:
+            from src.config import load_config
+            from src.utils.logo_palettes import banner_palette, mascot_gradient_text
+
+            _logo = load_config().get("logoColor")
+            _st = banner_palette(_logo)
+            mascot_block = mascot_gradient_text(_logo, mascot_ascii.split("\n"))
+            border, title_st, accent, value, label, dim = (
+                _st.border, _st.title, _st.accent, _st.value, _st.label, _st.dim,
+            )
+        except Exception:
+            border, title_st, accent, value, label, dim = (
+                "bright_black", "bold bright_cyan", "bold white", "bold magenta",
+                "bright_black", "dim",
+            )
+            mascot_block = Text(mascot_ascii, style="bold orange3", no_wrap=True)
+
+        table = Table.grid(padding=(0, 1))
+        table.add_column(style=label, justify="right", no_wrap=True)
+        table.add_column(style="white", ratio=1)
+        table.add_row("Version", Text.assemble(("ClawCodex", accent), ("  ", ""), (f"v{__version__}", accent)))
+        table.add_row("Model", Text(model_label, style=value))
+        table.add_row("Provider", Text(provider_label, style=value))
+        table.add_row("Workspace", Text(self._truncate_middle(display_path, content_width - 12), style=value))
+
+        footer = Text("/help  •  /tools  •  /tui  •  /stream  •  /exit", style=dim)
         body = Group(
             Columns([mascot_block, table], align="center", expand=False),
             Text(""),
@@ -2107,9 +2126,9 @@ class ClawcodexREPL:
         )
         header = Panel(
             body,
-            border_style="bright_black",
-            title="[bold bright_cyan] CLAWCODEX [/bold bright_cyan]",
-            subtitle="[dim]interactive terminal[/dim]",
+            border_style=border,
+            title=f"[{title_st}] CLAWCODEX [/{title_st}]",
+            subtitle=f"[{dim}]interactive terminal[/{dim}]",
             padding=(1, 2),
         )
         self.console.print(header)

--- a/src/tui/widgets/header.py
+++ b/src/tui/widgets/header.py
@@ -93,29 +93,48 @@ class StartupHeader(Static):
         display_path = _display_cwd(self._workspace_root)
         width = self._width_hint or 80
         content_width = max(28, min(width - 12, 72))
+
+        # /logo: resolve the persisted palette (best-effort — fall back to the
+        # original hardcoded styles so the banner never fails to render).
+        try:
+            from src.config import load_config
+            from src.utils.logo_palettes import banner_palette, mascot_gradient_text
+
+            _logo = load_config().get("logoColor")
+            _st = banner_palette(_logo)
+            mascot_block = mascot_gradient_text(_logo, _MASCOT.split("\n"))
+            border, title_st, accent, value, label, dim = (
+                _st.border, _st.title, _st.accent, _st.value, _st.label, _st.dim,
+            )
+        except Exception:
+            border, title_st, accent, value, label, dim = (
+                "bright_black", "bold bright_cyan", "bold white", "bold magenta",
+                "bright_black", "dim",
+            )
+            mascot_block = Text(_MASCOT, style="bold orange3", no_wrap=True)
+
         table = Table.grid(padding=(0, 1))
-        table.add_column(style="bright_black", justify="right", no_wrap=True)
+        table.add_column(style=label, justify="right", no_wrap=True)
         table.add_column(style="white", ratio=1)
         table.add_row(
             "Version",
             Text.assemble(
-                ("ClawCodex", "bold white"),
+                ("ClawCodex", accent),
                 ("  ", ""),
-                (f"v{self._version}", "bold cyan"),
+                (f"v{self._version}", accent),
             ),
         )
-        table.add_row("Model", Text(self._model or "unknown", style="bold magenta"))
+        table.add_row("Model", Text(self._model or "unknown", style=value))
         table.add_row(
             "Provider",
-            Text(f"{self._provider.upper()} Provider", style="bold green"),
+            Text(f"{self._provider.upper()} Provider", style=value),
         )
         table.add_row(
             "Workspace",
-            Text(_truncate_middle(display_path, content_width - 12), style="bold blue"),
+            Text(_truncate_middle(display_path, content_width - 12), style=value),
         )
 
-        footer = Text(self._slash_hints, style="dim")
-        mascot_block = Text(_MASCOT, style="bold orange3", no_wrap=True)
+        footer = Text(self._slash_hints, style=dim)
         body = Group(
             Columns([mascot_block, table], align="center", expand=False),
             Text(""),
@@ -123,8 +142,8 @@ class StartupHeader(Static):
         )
         return Panel(
             body,
-            border_style="bright_black",
-            title="[bold bright_cyan] CLAWCODEX [/bold bright_cyan]",
-            subtitle="[dim]interactive terminal[/dim]",
+            border_style=border,
+            title=f"[{title_st}] CLAWCODEX [/{title_st}]",
+            subtitle=f"[{dim}]interactive terminal[/{dim}]",
             padding=(0, 2),
         )

--- a/src/utils/logo_palettes.py
+++ b/src/utils/logo_palettes.py
@@ -1,0 +1,181 @@
+"""Color palettes for the startup banner logo.
+
+Port of ``typescript/src/components/StartupScreen.palettes.ts``. Selected via the
+``/logo`` command, persisted in the global config ``logoColor`` key, and applied by
+the two startup banners (``src/repl/core.py::_print_startup_header`` and
+``src/tui/widgets/header.py::StartupHeader._render_banner``).
+
+Imports only ``rich`` + stdlib (NO Textual) so the REPL banner can import it. The
+palette ROLES (gradient / accent / cream / dim / border) are mapped onto Python's
+mascot+table+Panel banner (which differs from TS's gradient ASCII logo) via
+:func:`banner_palette` + :func:`mascot_gradient_text`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from rich.text import Text
+
+RGB = tuple[int, int, int]
+
+
+@dataclass(frozen=True)
+class LogoPalette:
+    gradient: tuple[RGB, ...]  # top→bottom stops painted across the mascot rows
+    accent: RGB  # title / version highlight
+    cream: RGB  # soft body text (table values)
+    dim: RGB  # label names / footer
+    border: RGB  # Panel border
+
+
+# Verbatim from StartupScreen.palettes.ts:21-78.
+LOGO_PALETTES: dict[str, LogoPalette] = {
+    "sunset": LogoPalette(
+        gradient=(
+            (255, 180, 100),
+            (240, 140, 80),
+            (217, 119, 87),
+            (193, 95, 60),
+            (160, 75, 55),
+            (130, 60, 50),
+        ),
+        accent=(240, 148, 100),
+        cream=(220, 195, 170),
+        dim=(120, 100, 82),
+        border=(100, 80, 65),
+    ),
+    "forest": LogoPalette(
+        gradient=(
+            (180, 240, 170),
+            (130, 215, 130),
+            (85, 180, 95),
+            (55, 145, 75),
+            (40, 110, 60),
+            (25, 80, 45),
+        ),
+        accent=(120, 200, 120),
+        cream=(200, 220, 190),
+        dim=(90, 120, 90),
+        border=(70, 95, 70),
+    ),
+    "ocean": LogoPalette(
+        gradient=(
+            (170, 220, 255),
+            (125, 185, 240),
+            (80, 150, 220),
+            (55, 115, 190),
+            (40, 85, 150),
+            (25, 55, 110),
+        ),
+        accent=(110, 180, 230),
+        cream=(195, 215, 235),
+        dim=(90, 115, 145),
+        border=(70, 90, 115),
+    ),
+    "monochrome": LogoPalette(
+        gradient=(
+            (225, 225, 225),
+            (195, 195, 195),
+            (160, 160, 160),
+            (125, 125, 125),
+            (95, 95, 95),
+            (70, 70, 70),
+        ),
+        accent=(200, 200, 200),
+        cream=(210, 210, 210),
+        dim=(120, 120, 120),
+        border=(95, 95, 95),
+    ),
+}
+
+LOGO_PALETTE_NAMES: list[str] = list(LOGO_PALETTES.keys())
+
+DEFAULT_LOGO_PALETTE = "sunset"
+
+# Verbatim from StartupScreen.palettes.ts:86-91.
+LOGO_PALETTE_LABELS: dict[str, str] = {
+    "sunset": "Sunset (default)",
+    "forest": "Forest green",
+    "ocean": "Ocean blue",
+    "monochrome": "Monochrome",
+}
+
+
+def is_logo_palette_name(value: object) -> bool:
+    """True iff ``value`` is a known palette name."""
+    return isinstance(value, str) and value in LOGO_PALETTES
+
+
+def resolve_logo_palette(name: str | None) -> LogoPalette:
+    """The palette for ``name``, or the default (``sunset``) for unknown/None."""
+    if is_logo_palette_name(name):
+        return LOGO_PALETTES[name]  # type: ignore[index]
+    return LOGO_PALETTES[DEFAULT_LOGO_PALETTE]
+
+
+def rgb_hex(rgb: RGB) -> str:
+    """``(r,g,b)`` → ``"#rrggbb"`` (Rich truecolor style)."""
+    r, g, b = rgb
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+@dataclass(frozen=True)
+class BannerStyles:
+    """Resolved Rich style strings for the banner elements. ``bold`` weight is
+    preserved where the original hardcoded styles were bold (so ``/logo`` changes
+    only hue, not weight)."""
+
+    border: str  # Panel border_style (current "bright_black" — not bold)
+    title: str  # Panel title (current "bold bright_cyan")
+    accent: str  # version row (current "bold white"/"bold cyan")
+    value: str  # table values (current "bold magenta"/"green"/"blue")
+    label: str  # label column (current "bright_black" — not bold)
+    dim: str  # footer / subtitle (current "dim" — not bold)
+
+
+def banner_palette(name: str | None) -> BannerStyles:
+    """Resolve ``name`` → the banner style strings. Never raises (unknown/None →
+    default ``sunset``)."""
+    p = resolve_logo_palette(name)
+    return BannerStyles(
+        border=rgb_hex(p.border),
+        title=f"bold {rgb_hex(p.accent)}",
+        accent=f"bold {rgb_hex(p.accent)}",
+        value=f"bold {rgb_hex(p.cream)}",
+        label=rgb_hex(p.dim),
+        dim=rgb_hex(p.dim),
+    )
+
+
+def mascot_gradient_text(name: str | None, mascot_lines: list[str]) -> Text:
+    """Build the mascot as a Rich ``Text`` with a vertical gradient: each line gets a
+    gradient stop sampled across the palette (bold, matching the original
+    ``bold orange3``). Never raises."""
+    palette = resolve_logo_palette(name)
+    gradient = palette.gradient
+    n = len(mascot_lines)
+    text = Text(no_wrap=True)
+    for i, line in enumerate(mascot_lines):
+        if n <= 1:
+            stop = gradient[0]
+        else:
+            stop = gradient[round(i * (len(gradient) - 1) / (n - 1))]
+        suffix = "\n" if i < n - 1 else ""
+        text.append(line + suffix, style=f"bold {rgb_hex(stop)}")
+    return text
+
+
+__all__ = [
+    "RGB",
+    "LogoPalette",
+    "LOGO_PALETTES",
+    "LOGO_PALETTE_NAMES",
+    "DEFAULT_LOGO_PALETTE",
+    "LOGO_PALETTE_LABELS",
+    "is_logo_palette_name",
+    "resolve_logo_palette",
+    "rgb_hex",
+    "BannerStyles",
+    "banner_palette",
+    "mascot_gradient_text",
+]

--- a/tests/test_logo_command.py
+++ b/tests/test_logo_command.py
@@ -1,0 +1,255 @@
+"""Tests for the ``/logo`` command (Phase 8 — port of TS local-jsx).
+
+Mirrors the ``/theme`` test layout. ``/logo`` differs in ONE structural way: it has NO
+TUI dialog, so its dispatch **falls through** (the ``/export`` pattern) rather than
+being intercepted (the theme/effort/model inversion). Also includes lightweight
+banner-wiring assertions (both startup banners resolve+apply the palette).
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+import src.config as cfg
+from src.command_system import (
+    LOGO_COMMAND,
+    LogoCommand,
+    create_command_context,
+    get_builtin_commands,
+    get_commands,
+    is_bridge_safe_command,
+)
+from src.command_system.engine import CommandEngine
+from src.command_system.registry import CommandRegistry
+from src.command_system.types import (
+    CommandType,
+    InteractiveOutcome,
+    InteractiveUnavailableError,
+    NullUIHost,
+)
+from src.utils.logo_palettes import (
+    DEFAULT_LOGO_PALETTE,
+    LOGO_PALETTE_LABELS,
+    LOGO_PALETTE_NAMES,
+    banner_palette,
+)
+
+
+class FakeUIHost:
+    def __init__(self, *, pick=None):
+        self._pick = pick
+        self.select_calls: list[dict] = []
+
+    async def select(self, title, options, *, current=None):
+        self.select_calls.append(
+            {
+                "title": title,
+                "values": [o.value for o in options],
+                "labels": [o.label for o in options],
+                "descriptions": [o.description for o in options],
+                "current": current,
+            }
+        )
+        return self._pick
+
+    async def prompt_text(self, title, *, default="", placeholder=None):
+        return None
+
+    async def display(self, title, body):
+        return None
+
+
+@pytest.fixture
+def isolated_config(tmp_path, monkeypatch):
+    """Point the global config at a tmp file + a fresh manager rooted at a non-git
+    tmp cwd (logo reads via ``load_config()``/``ConfigManager``, like ``/theme``)."""
+    monkeypatch.setattr(cfg, "GLOBAL_CONFIG_FILE", tmp_path / "config.json")
+    monkeypatch.setattr(cfg, "_default_manager", cfg.ConfigManager(cwd=tmp_path))
+    return tmp_path
+
+
+def _ctx(tmp_path: Path, *, ui=None):
+    return create_command_context(workspace_root=tmp_path, cwd=tmp_path, ui=ui)
+
+
+def _registry_with(*commands) -> CommandRegistry:
+    reg = CommandRegistry()
+    for c in commands:
+        reg.register(c)
+    return reg
+
+
+def _persisted_logo(tmp_path: Path):
+    return cfg.ConfigManager(cwd=tmp_path).get("logoColor")
+
+
+# --------------------------------------------------------------------------- #
+# A. Metadata + registration
+# --------------------------------------------------------------------------- #
+def test_logo_registered_in_builtins_and_aggregator():
+    assert "logo" in {c.name for c in get_builtin_commands()}
+    assert "logo" in {c.name for c in get_commands(cwd=str(Path.cwd()))}
+
+
+def test_logo_metadata_mirrors_ts():
+    assert isinstance(LOGO_COMMAND, LogoCommand)
+    assert LOGO_COMMAND.name == "logo"
+    assert LOGO_COMMAND.description == "Change the startup logo color scheme"
+    assert LOGO_COMMAND.argument_hint is None  # TS sets none
+    assert LOGO_COMMAND.command_type == CommandType.INTERACTIVE
+    assert LOGO_COMMAND.is_hidden is False
+    assert LOGO_COMMAND.disable_model_invocation is False
+    assert LOGO_COMMAND.user_invocable is True
+
+
+# --------------------------------------------------------------------------- #
+# B. Bridge-safety + dispatch FALL-THROUGH (the /export pattern)
+# --------------------------------------------------------------------------- #
+def test_logo_blocked_from_bridge_by_type():
+    assert is_bridge_safe_command(LOGO_COMMAND) is False
+
+
+def test_dispatch_local_command_falls_through_for_logo():
+    # THE DIFFERENCE vs theme/effort/model: /logo has NO TUI dialog, so dispatch
+    # falls through (handled=False) and the registry command runs on every surface.
+    from src.tui.commands import dispatch_local_command
+
+    res = dispatch_local_command(
+        "/logo", session=None, workspace_root=Path("."), tool_registry=None
+    )
+    assert res.handled is False
+    assert res.open_dialog is None
+
+
+# --------------------------------------------------------------------------- #
+# C. Picker happy path
+# --------------------------------------------------------------------------- #
+async def test_picker_persists_and_reports(isolated_config):
+    tmp_path = isolated_config
+    ui = FakeUIHost(pick="ocean")
+    out = await LOGO_COMMAND.run("", _ctx(tmp_path, ui=ui))
+
+    assert isinstance(out, InteractiveOutcome)
+    assert out.message == "Startup logo set to Ocean blue. Visible on next launch."
+    assert out.display == "user"  # TS no-options onDone -> model-visible
+    assert _persisted_logo(tmp_path) == "ocean"
+    call = ui.select_calls[0]
+    assert call["values"] == LOGO_PALETTE_NAMES
+    assert call["labels"] == [LOGO_PALETTE_LABELS[n] for n in LOGO_PALETTE_NAMES]
+
+
+# --------------------------------------------------------------------------- #
+# D. Cancel
+# --------------------------------------------------------------------------- #
+async def test_cancel_returns_system_dismissed(isolated_config):
+    tmp_path = isolated_config
+    ui = FakeUIHost(pick=None)
+    out = await LOGO_COMMAND.run("", _ctx(tmp_path, ui=ui))
+
+    assert out.message == "Logo picker dismissed"
+    assert out.display == "system"
+    assert out.display != "skip"
+    assert _persisted_logo(tmp_path) is None  # cancel does not persist
+
+
+# --------------------------------------------------------------------------- #
+# E. Null surface + args ignored
+# --------------------------------------------------------------------------- #
+async def test_run_raises_on_null_surface(isolated_config):
+    tmp_path = isolated_config
+    with pytest.raises(InteractiveUnavailableError):
+        await LOGO_COMMAND.run("", _ctx(tmp_path, ui=NullUIHost()))
+    assert _persisted_logo(tmp_path) is None
+
+
+async def test_engine_errors_cleanly_on_null_surface(isolated_config):
+    tmp_path = isolated_config
+    reg = _registry_with(LOGO_COMMAND)
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+    assert ctx.ui is None  # engine substitutes NullUIHost
+    eng = CommandEngine(registry=reg, workspace_root=tmp_path, context=ctx)
+
+    result = await eng.execute("/logo")
+
+    assert result.success is False
+    assert result.error is not None
+    assert "interactive surface" in result.error
+
+
+async def test_args_are_ignored(isolated_config):
+    tmp_path = isolated_config
+    ui = FakeUIHost(pick="forest")
+    out = await LOGO_COMMAND.run("ocean extra args", _ctx(tmp_path, ui=ui))
+    assert out.message == "Startup logo set to Forest green. Visible on next launch."
+    assert _persisted_logo(tmp_path) == "forest"  # the PICK wins, not the args
+    assert len(ui.select_calls) == 1
+
+
+# --------------------------------------------------------------------------- #
+# F. Seed current from persisted palette
+# --------------------------------------------------------------------------- #
+async def test_picker_current_defaults_when_unset(isolated_config):
+    tmp_path = isolated_config
+    ui = FakeUIHost(pick="ocean")
+    await LOGO_COMMAND.run("", _ctx(tmp_path, ui=ui))
+    assert ui.select_calls[0]["current"] == DEFAULT_LOGO_PALETTE  # "sunset"
+
+
+async def test_picker_seeds_current_from_persisted(isolated_config):
+    tmp_path = isolated_config
+    cfg.set_logo_color("ocean")
+    ui = FakeUIHost(pick="forest")
+    await LOGO_COMMAND.run("", _ctx(tmp_path, ui=ui))
+
+    call = ui.select_calls[0]
+    assert call["current"] == "ocean"
+    # Exactly the current option carries the "current" marker.
+    for value, desc in zip(call["values"], call["descriptions"]):
+        assert desc == ("current" if value == "ocean" else None)
+
+
+# --------------------------------------------------------------------------- #
+# G. Banner wiring (both startup banners resolve + apply the palette)
+# --------------------------------------------------------------------------- #
+def test_repl_banner_wires_palette():
+    from src.repl.core import ClawcodexREPL
+
+    src_text = inspect.getsource(ClawcodexREPL._print_startup_header)
+    assert "banner_palette" in src_text
+    assert "mascot_gradient_text" in src_text
+
+
+def test_tui_header_wires_palette_and_applies_border(isolated_config):
+    tmp_path = isolated_config
+    cfg.set_logo_color("forest")
+
+    from src.tui.widgets.header import StartupHeader
+
+    header = StartupHeader(
+        version="1.2.3",
+        model="claude-sonnet-4-6",
+        provider="anthropic",
+        workspace_root=tmp_path,
+    )
+    panel = header._render_banner()
+    # The Panel border is the forest palette's border hex (best-effort wiring applied).
+    assert panel.border_style == banner_palette("forest").border
+
+
+def test_tui_header_falls_back_on_bogus_logo(isolated_config, monkeypatch):
+    tmp_path = isolated_config
+    cfg.set_logo_color("not-a-real-palette")
+
+    from src.tui.widgets.header import StartupHeader
+
+    # Bogus name resolves to the default palette (no crash).
+    header = StartupHeader(
+        version="1.2.3",
+        model="m",
+        provider="anthropic",
+        workspace_root=tmp_path,
+    )
+    panel = header._render_banner()
+    assert panel.border_style == banner_palette(None).border  # default sunset

--- a/tests/test_logo_palettes.py
+++ b/tests/test_logo_palettes.py
@@ -1,0 +1,100 @@
+"""Tests for the logo color-palette module (Phase 8).
+
+Guards the direct data port of ``StartupScreen.palettes.ts`` and the banner-style
+helpers (``banner_palette``, ``mascot_gradient_text``, ``rgb_hex``).
+"""
+from __future__ import annotations
+
+from src.utils.logo_palettes import (
+    DEFAULT_LOGO_PALETTE,
+    LOGO_PALETTE_LABELS,
+    LOGO_PALETTE_NAMES,
+    LOGO_PALETTES,
+    banner_palette,
+    is_logo_palette_name,
+    mascot_gradient_text,
+    resolve_logo_palette,
+    rgb_hex,
+)
+
+
+def test_palette_names_and_default():
+    assert LOGO_PALETTE_NAMES == ["sunset", "forest", "ocean", "monochrome"]
+    assert DEFAULT_LOGO_PALETTE == "sunset"
+    assert LOGO_PALETTE_LABELS == {
+        "sunset": "Sunset (default)",
+        "forest": "Forest green",
+        "ocean": "Ocean blue",
+        "monochrome": "Monochrome",
+    }
+
+
+def test_palette_data_verbatim_spotcheck():
+    # Guards the RGB data against StartupScreen.palettes.ts.
+    sunset = LOGO_PALETTES["sunset"]
+    assert sunset.gradient[0] == (255, 180, 100)
+    assert sunset.gradient[5] == (130, 60, 50)
+    assert sunset.accent == (240, 148, 100)
+    assert sunset.cream == (220, 195, 170)
+    assert sunset.dim == (120, 100, 82)
+    assert sunset.border == (100, 80, 65)
+    assert len(sunset.gradient) == 6
+    # Each palette has a 6-stop gradient.
+    for name in LOGO_PALETTE_NAMES:
+        assert len(LOGO_PALETTES[name].gradient) == 6
+    assert LOGO_PALETTES["ocean"].gradient[0] == (170, 220, 255)
+    assert LOGO_PALETTES["monochrome"].accent == (200, 200, 200)
+
+
+def test_is_logo_palette_name():
+    assert is_logo_palette_name("sunset") is True
+    assert is_logo_palette_name("ocean") is True
+    assert is_logo_palette_name("bogus") is False
+    assert is_logo_palette_name(None) is False
+    assert is_logo_palette_name(123) is False
+
+
+def test_resolve_logo_palette_falls_back_to_default():
+    assert resolve_logo_palette("ocean") is LOGO_PALETTES["ocean"]
+    assert resolve_logo_palette("bogus") is LOGO_PALETTES["sunset"]
+    assert resolve_logo_palette(None) is LOGO_PALETTES["sunset"]
+
+
+def test_rgb_hex():
+    assert rgb_hex((255, 180, 100)) == "#ffb464"
+    assert rgb_hex((0, 0, 0)) == "#000000"
+    assert rgb_hex((100, 80, 65)) == "#645041"
+
+
+def test_banner_palette_styles():
+    st = banner_palette("ocean")
+    p = LOGO_PALETTES["ocean"]
+    assert st.border == rgb_hex(p.border)  # not bold (Panel border)
+    assert st.title == f"bold {rgb_hex(p.accent)}"
+    assert st.accent == f"bold {rgb_hex(p.accent)}"
+    assert st.value == f"bold {rgb_hex(p.cream)}"  # bold preserved
+    assert st.label == rgb_hex(p.dim)  # not bold
+    assert st.dim == rgb_hex(p.dim)
+
+
+def test_banner_palette_default_on_unset():
+    assert banner_palette(None) == banner_palette("sunset")
+    assert banner_palette("bogus") == banner_palette("sunset")
+
+
+def test_mascot_gradient_text_per_line():
+    lines = ["a", "b", "c", "d"]  # the 4-line mascot shape
+    text = mascot_gradient_text("sunset", lines)
+    assert text.plain == "a\nb\nc\nd"
+    grad = LOGO_PALETTES["sunset"].gradient
+    # 4 lines sample stops [0, 2, 3, 5].
+    expected = [grad[0], grad[2], grad[3], grad[5]]
+    styles = [span.style for span in text.spans]
+    assert styles == [f"bold {rgb_hex(s)}" for s in expected]
+
+
+def test_mascot_gradient_text_single_line_guard():
+    # N<=1 must not divide-by-zero.
+    text = mascot_gradient_text("forest", ["only"])
+    assert text.plain == "only"
+    assert text.spans[0].style == f"bold {rgb_hex(LOGO_PALETTES['forest'].gradient[0])}"


### PR DESCRIPTION
## Summary
- Port TS local-jsx `/logo` (`typescript/src/commands/logo/`) as a Class-B `InteractiveCommand`, **and build the logo color-palette subsystem it needs** — Python had none. Unlike `/theme`/`/effort`/`/model` (which wrapped existing dialogs/state), this phase introduces the whole feature.
- **`src/utils/logo_palettes.py`** — byte-exact port of `StartupScreen.palettes.ts`: 4 palettes (sunset/forest/ocean/monochrome; gradient + accent/cream/dim/border), `DEFAULT=sunset`, labels, `is_logo_palette_name`, `resolve_logo_palette`, plus `rgb_hex`/`banner_palette`/`mascot_gradient_text` (rich+stdlib only, no Textual).
- **`src/command_system/logo_command.py`** — picker-only (ignores args, like TS), persists `config.logoColor` via `set_logo_color`, success "Startup logo set to {LABEL}. Visible on next launch." (`display="user"`), cancel "Logo picker dismissed" (`display="system"`). Coexistence is **fall-through** (the `/export` pattern): `/logo` has no TUI dialog, so the registry command serves every surface — no inversion.
- **Banner wiring:** both `src/repl/core.py::_print_startup_header` and `src/tui/widgets/header.py::_render_banner` resolve `logoColor` → palette and apply it (mascot vertical gradient, Panel border, accent title/version, cream values, dim labels), **bold preserved**, best-effort `try/except` → original styles so the banner never fails. **The default (unset) banner now renders the sunset palette** (matching TS's default).

**Divergences:** no swatch preview (the `select` primitive has plain labels), static description (frozen `CommandBase` can't be a getter), and the palette is mapped onto Python's mascot+table+Panel banner (not TS's gradient ASCII logo).

## Test plan
- [x] `tests/test_logo_palettes.py` — byte-exact palette-data guard + `banner_palette`/`mascot_gradient_text` (incl. the N≤1 div-by-zero guard).
- [x] `tests/test_logo_command.py` — metadata/registration, bridge-safety + **fall-through** dispatch, picker/cancel/null-surface/args-ignored, current-seed, and banner wiring (TUI `border_style == banner_palette(...).border`, bogus→default fallback; REPL source-guard).
- [x] Full suite: **7158 passed**; only the 6 pre-existing baseline failures. The startup-banner change preserves text content (existing `test_repl.py` startup test green).
- [x] Plan + implementation both critic-approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)