### PR TITLE
commands: port /mcp server list (Phase 9)

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -79,6 +79,7 @@ from .theme_command import THEME_COMMAND, ThemeCommand
 from .effort_command import EFFORT_COMMAND, EffortCommand
 from .model_command import MODEL_COMMAND, ModelCommand
 from .logo_command import LOGO_COMMAND, LogoCommand
+from .mcp_command import MCP_COMMAND, McpCommand
 from .types import (
     Command,
     CommandAvailability,
@@ -162,6 +163,8 @@ __all__ = [
     "ModelCommand",
     "LOGO_COMMAND",
     "LogoCommand",
+    "MCP_COMMAND",
+    "McpCommand",
     "get_builtin_commands",
     "register_builtin_commands",
     # Moved-to-plugin factory + shell-at-prompt-build

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -32,6 +32,7 @@ from .theme_command import THEME_COMMAND
 from .effort_command import EFFORT_COMMAND
 from .model_command import MODEL_COMMAND
 from .logo_command import LOGO_COMMAND
+from .mcp_command import MCP_COMMAND
 from .types import Command, CommandType, CompactionResult, LocalCommand, PromptCommand
 
 
@@ -1242,6 +1243,7 @@ def get_builtin_commands() -> list[Command]:
         EFFORT_COMMAND,
         MODEL_COMMAND,
         LOGO_COMMAND,
+        MCP_COMMAND,
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)

--- a/src/command_system/mcp_command.py
+++ b/src/command_system/mcp_command.py
@@ -1,0 +1,111 @@
+"""mcp — ``/mcp`` MCP-server list (port of TS local-jsx).
+
+TS ``/mcp`` (``commands/mcp/``) is a *manager* — a settings panel + enable/disable +
+reconnect, all driven by the MCP connection-manager subsystem. Python's ``/mcp`` is
+**display-only** (``McpListScreen`` lists the configured servers; the dialog has no
+enable/disable action). So this port lists the servers and treats the management verbs
+as unsupported (the same subsystem boundary ``/model`` hit with discovery).
+
+Follows the **output-style precedent**: a ``local-jsx`` → :class:`InteractiveCommand`
+whose ``run()`` returns text **without touching ``ctx.ui``**, so it behaves identically
+on every surface (REPL, Textual, and ``NullUIHost`` headless — no raise).
+
+Coexistence: **inversion** — the TUI keeps intercepting ``/mcp``
+(``commands.py`` → ``open_dialog="mcp"`` → ``McpListScreen``); this registry command
+serves the non-TUI surfaces (REPL/SDK) + the help/aggregator listings.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .types import (
+    CommandContext,
+    InteractiveCommand,
+    InteractiveOutcome,
+)
+
+# TS management verbs (mcp.tsx call): enable/disable -> MCPToggle, reconnect ->
+# MCPReconnect, no-redirect -> MCPSettings. All need the MCP connection-manager.
+_MGMT_ARGS = frozenset({"enable", "disable", "reconnect", "no-redirect"})
+_NOT_SUPPORTED = (
+    "MCP server management (enable/disable/reconnect/settings) is not supported in "
+    "this build."
+)
+
+
+def _collect_mcp_servers() -> list[dict[str, Any]]:
+    """Read configured MCP servers from the SAME config keys as the TUI's
+    ``_collect_mcp_servers`` (app.py) — ``mcp_servers`` / ``mcpServers`` — PLUS
+    ``error`` (which the TUI helper leaves unset but ``_status_summary`` renders).
+    Runtime ``status``/``tools`` aren't in the config schema, so real servers come
+    back ``disconnected`` (see module note); the richer branches are synthetic-only."""
+    from src.config import load_config
+
+    try:
+        cfg = load_config() or {}
+        raw = cfg.get("mcp_servers") or cfg.get("mcpServers") or {}
+    except Exception:
+        raw = {}
+    servers: list[dict[str, Any]] = []
+    if isinstance(raw, dict):
+        for server_id, entry in raw.items():
+            e = entry if isinstance(entry, dict) else {}
+            tools = e.get("tools")
+            servers.append(
+                {
+                    "id": str(server_id),
+                    "name": str(e.get("name", server_id)),
+                    "status": e.get("status", "disconnected"),
+                    "tools": list(tools) if isinstance(tools, list) else [],
+                    "error": e.get("error"),
+                }
+            )
+    return servers
+
+
+def _status_summary(server: dict[str, Any]) -> str:
+    """Verbatim port of ``_mcp_status_summary`` (mcp_dialogs.py:94-101), quirks intact:
+    ``tool_suffix`` is always-plural (``"1 tools"``) and appears ONLY on ``connected``."""
+    tools = server.get("tools") or []
+    tool_suffix = f" ({len(tools)} tools)" if tools else ""
+    status = server.get("status")
+    if status == "error":
+        err = server.get("error")
+        return f"error: {err}" if err else "error"
+    if status == "connected":
+        return f"connected{tool_suffix}"
+    return "disconnected"
+
+
+@dataclass(frozen=True)
+class McpCommand(InteractiveCommand):
+    """List the configured MCP servers. Frozen + no new fields (the
+    ``OutputStyleCommand`` pattern); ``run()`` returns text without touching ``ctx.ui``."""
+
+    async def run(self, args: str, context: CommandContext) -> InteractiveOutcome:
+        parts = (args or "").strip().split()
+        if parts and parts[0].lower() in _MGMT_ARGS:
+            # TS enable/disable/reconnect/settings — need the unported MCP
+            # connection-manager subsystem.
+            return InteractiveOutcome(message=_NOT_SUPPORTED, display="system")
+
+        servers = _collect_mcp_servers()
+        if not servers:
+            return InteractiveOutcome(
+                message="No MCP servers configured.", display="system"
+            )
+        lines = [f"• {s['name']} — {_status_summary(s)}" for s in servers]
+        return InteractiveOutcome(
+            message="MCP servers:\n" + "\n".join(lines), display="system"
+        )
+
+
+MCP_COMMAND = McpCommand(
+    name="mcp",
+    description="Manage MCP servers",  # verbatim TS index.ts
+    argument_hint="[enable|disable [server-name]]",  # verbatim TS index.ts
+)
+
+
+__all__ = ["MCP_COMMAND", "McpCommand"]

--- a/tests/test_mcp_command.py
+++ b/tests/test_mcp_command.py
@@ -1,0 +1,146 @@
+"""Tests for the ``/mcp`` command (Phase 9 — port of TS local-jsx, display-only).
+
+``/mcp`` lists the configured MCP servers (Python's dialog is display-only). It follows
+the output-style precedent: an ``InteractiveCommand`` whose ``run()`` returns text WITHOUT
+touching ``ctx.ui`` (so it works on every surface incl. ``NullUIHost``). Coexistence is
+**inversion** (the TUI keeps its ``McpListScreen`` via ``open_dialog="mcp"``).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import src.config as cfg
+from src.command_system import (
+    MCP_COMMAND,
+    McpCommand,
+    create_command_context,
+    get_builtin_commands,
+    get_commands,
+    is_bridge_safe_command,
+)
+from src.command_system.engine import CommandEngine
+from src.command_system.registry import CommandRegistry
+from src.command_system.types import CommandType, InteractiveOutcome, NullUIHost
+
+
+@pytest.fixture
+def isolated_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(cfg, "GLOBAL_CONFIG_FILE", tmp_path / "config.json")
+    monkeypatch.setattr(cfg, "_default_manager", cfg.ConfigManager(cwd=tmp_path))
+    return tmp_path
+
+
+def _set_servers(servers: dict) -> None:
+    cfg._get_default_manager().set_global("mcp_servers", servers)
+
+
+def _ctx(tmp_path: Path, *, ui=None):
+    return create_command_context(workspace_root=tmp_path, cwd=tmp_path, ui=ui)
+
+
+# --------------------------------------------------------------------------- #
+# A. Metadata + registration
+# --------------------------------------------------------------------------- #
+def test_mcp_registered_in_builtins_and_aggregator():
+    assert "mcp" in {c.name for c in get_builtin_commands()}
+    assert "mcp" in {c.name for c in get_commands(cwd=str(Path.cwd()))}
+
+
+def test_mcp_metadata_mirrors_ts():
+    assert isinstance(MCP_COMMAND, McpCommand)
+    assert MCP_COMMAND.name == "mcp"
+    assert MCP_COMMAND.description == "Manage MCP servers"
+    assert MCP_COMMAND.argument_hint == "[enable|disable [server-name]]"
+    assert MCP_COMMAND.command_type == CommandType.INTERACTIVE
+    assert MCP_COMMAND.is_hidden is False
+
+
+# --------------------------------------------------------------------------- #
+# B. Bridge-safety + dispatch inversion
+# --------------------------------------------------------------------------- #
+def test_mcp_blocked_from_bridge_by_type():
+    assert is_bridge_safe_command(MCP_COMMAND) is False
+
+
+def test_dispatch_local_command_intercepts_mcp():
+    from src.tui.commands import dispatch_local_command
+
+    res = dispatch_local_command(
+        "/mcp", session=None, workspace_root=Path("."), tool_registry=None
+    )
+    assert res.handled is True
+    assert res.open_dialog == "mcp"
+
+
+# --------------------------------------------------------------------------- #
+# C. List output — synthetic config exercising the ported _status_summary.
+#    (status/tools/error aren't in the real config schema; this locks the
+#    verbatim quirks: always-plural "1 tools", suffix only on connected.)
+# --------------------------------------------------------------------------- #
+async def test_list_output_synthetic(isolated_config):
+    tmp = isolated_config
+    _set_servers(
+        {
+            "a": {"name": "alpha", "status": "connected", "tools": ["t1"]},
+            "b": {"name": "beta", "status": "error", "error": "boom"},
+        }
+    )
+    out = await MCP_COMMAND.run("", _ctx(tmp, ui=NullUIHost()))  # no raise: never touches ui
+    assert isinstance(out, InteractiveOutcome)
+    assert out.message == (
+        "MCP servers:\n"
+        "• alpha — connected (1 tools)\n"  # always-plural quirk
+        "• beta — error: boom"  # no tool suffix on error
+    )
+    assert out.display == "system"
+
+
+async def test_list_output_realistic_renders_disconnected(isolated_config):
+    tmp = isolated_config
+    # Real config schema (command/args, no runtime status) → "disconnected".
+    _set_servers({"x": {"command": "foo", "args": ["bar"]}})
+    out = await MCP_COMMAND.run("", _ctx(tmp, ui=NullUIHost()))
+    assert out.message == "MCP servers:\n• x — disconnected"  # name defaults to id
+
+
+# --------------------------------------------------------------------------- #
+# D. Empty
+# --------------------------------------------------------------------------- #
+async def test_empty(isolated_config):
+    out = await MCP_COMMAND.run("", _ctx(isolated_config, ui=NullUIHost()))
+    assert out.message == "No MCP servers configured."
+    assert out.display == "system"
+
+
+# --------------------------------------------------------------------------- #
+# E. Management args → not supported
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "arg", ["enable foo", "disable", "reconnect x", "no-redirect", "ENABLE all"]
+)
+async def test_management_args_not_supported(isolated_config, arg):
+    _set_servers({"a": {"name": "alpha"}})
+    out = await MCP_COMMAND.run(arg, _ctx(isolated_config, ui=NullUIHost()))
+    assert out.message.startswith("MCP server management")
+    assert "not supported" in out.message
+    assert out.display == "system"
+
+
+# --------------------------------------------------------------------------- #
+# F. Engine end-to-end on a NullUIHost surface — no headless error (unlike pickers)
+# --------------------------------------------------------------------------- #
+async def test_engine_succeeds_headless(isolated_config):
+    tmp = isolated_config
+    _set_servers({"a": {"name": "alpha"}})
+    reg = CommandRegistry()
+    reg.register(MCP_COMMAND)
+    ctx = create_command_context(workspace_root=tmp, cwd=tmp)  # ui=None → engine subs NullUIHost
+    eng = CommandEngine(registry=reg, workspace_root=tmp, context=ctx)
+
+    result = await eng.execute("/mcp")
+
+    assert result.success is True
+    assert result.result_type == "text"
+    assert result.text.startswith("MCP servers:")


### PR DESCRIPTION
## Summary
- Port TS local-jsx `/mcp` (`typescript/src/commands/mcp/`) as an `InteractiveCommand`. TS `/mcp` is a manager (settings panel + enable/disable + reconnect); Python's `/mcp` dialog is **display-only** (`McpListScreen` lists configured servers), so this port lists the servers and treats management verbs as **not supported** (the MCP connection-manager subsystem is unported — the same boundary `/model` hit with discovery).
- Follows the **output-style precedent**: `run()` returns text **without touching `ctx.ui`**, so it works on every surface incl. `NullUIHost` (no raise). Coexistence is **inversion**: the TUI keeps intercepting `/mcp` (`open_dialog="mcp"` → `McpListScreen`); the registry command serves REPL/SDK + listings.
- `_status_summary` is a **behaviorally-verbatim** port of `_mcp_status_summary` (quirks intact: always-plural `"N tools"`, suffix only on `connected`). The config schema has no `status`/`tools`/`error`, so real servers render `"disconnected"` until the connection manager lands; the connected/error branches are ported for parity.

## Test plan
- [x] `tests/test_mcp_command.py` (13 tests): metadata/registration, bridge-safety + inversion dispatch, list output (synthetic config locks the verbatim quirks; realistic config → `disconnected`), empty, management-args not-supported, engine-headless success.
- [x] Full suite: **7183 passed**; only the 6 pre-existing baseline failures.
- [x] Plan + implementation both critic-approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)