### PR TITLE
commands: port /tasks background-task list (Phase 10, degraded)

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -80,6 +80,7 @@ from .effort_command import EFFORT_COMMAND, EffortCommand
 from .model_command import MODEL_COMMAND, ModelCommand
 from .logo_command import LOGO_COMMAND, LogoCommand
 from .mcp_command import MCP_COMMAND, McpCommand
+from .tasks_command import TASKS_COMMAND, TasksCommand
 from .types import (
     Command,
     CommandAvailability,
@@ -165,6 +166,8 @@ __all__ = [
     "LogoCommand",
     "MCP_COMMAND",
     "McpCommand",
+    "TASKS_COMMAND",
+    "TasksCommand",
     "get_builtin_commands",
     "register_builtin_commands",
     # Moved-to-plugin factory + shell-at-prompt-build

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -33,6 +33,7 @@ from .effort_command import EFFORT_COMMAND
 from .model_command import MODEL_COMMAND
 from .logo_command import LOGO_COMMAND
 from .mcp_command import MCP_COMMAND
+from .tasks_command import TASKS_COMMAND
 from .types import Command, CommandType, CompactionResult, LocalCommand, PromptCommand
 
 
@@ -1244,6 +1245,7 @@ def get_builtin_commands() -> list[Command]:
         MODEL_COMMAND,
         LOGO_COMMAND,
         MCP_COMMAND,
+        TASKS_COMMAND,
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)

--- a/src/command_system/tasks_command.py
+++ b/src/command_system/tasks_command.py
@@ -1,0 +1,72 @@
+"""tasks — ``/tasks`` background-task list (port of TS local-jsx, degraded).
+
+TS ``/tasks`` (``commands/tasks/``) renders ``BackgroundTasksDialog`` — it **lists and
+manages** (kill) background tasks. Python's TUI ``/tasks`` focuses a live task panel
+(app-bound). This registry port provides the **headless list** — the running tasks ARE
+reachable from the command surface via ``context.tool_context.runtime_tasks`` (the same
+``RuntimeTaskRegistry`` tools write to) — and **drops management** (kill needs the
+app/async ``Task.kill`` path). The TUI keeps its live panel (inversion).
+
+Follows the output-style/``/mcp`` precedent: ``run()`` returns text **without touching
+``ctx.ui``**, so it works on every surface; on the SDK (where ``tool_context`` is None)
+it reports the list is unavailable rather than raising.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .types import (
+    CommandContext,
+    InteractiveCommand,
+    InteractiveOutcome,
+)
+
+
+def _coerce(x: Any) -> Any:
+    """Defensive: a ``.value``-bearing object → its ``.value``, else the value unchanged.
+    ``TaskType``/``TaskStatus`` are ``Literal[str]`` today (already plain strings, so this
+    just passes them through) — this only future-proofs against an enum/wrapper."""
+    return getattr(x, "value", x)
+
+
+def _format_task(t: Any) -> str:
+    status = _coerce(getattr(t, "status", "")) or "?"
+    label = getattr(t, "description", "") or _coerce(getattr(t, "type", "")) or "(task)"
+    return f"[{status}] {label} (id: {getattr(t, 'id', '')})"
+
+
+@dataclass(frozen=True)
+class TasksCommand(InteractiveCommand):
+    """List the running background tasks. Frozen + no new fields (the ``McpCommand``
+    pattern); ``run()`` returns text without touching ``ctx.ui``."""
+
+    async def run(self, args: str, context: CommandContext) -> InteractiveOutcome:
+        tc = getattr(context, "tool_context", None)
+        registry = getattr(tc, "runtime_tasks", None) if tc is not None else None
+        if registry is None:
+            # SDK / listing surfaces have no live task registry.
+            return InteractiveOutcome(
+                message="Background tasks are unavailable on this surface.",
+                display="system",
+            )
+        try:
+            tasks = list(registry.all())
+        except Exception:
+            tasks = []
+        if not tasks:
+            return InteractiveOutcome(message="No background tasks.", display="system")
+        lines = [f"• {_format_task(t)}" for t in tasks]
+        return InteractiveOutcome(
+            message="Background tasks:\n" + "\n".join(lines), display="system"
+        )
+
+
+TASKS_COMMAND = TasksCommand(
+    name="tasks",
+    description="List and manage background tasks",  # verbatim TS (port only LISTS)
+    aliases=["bashes"],  # verbatim TS index.ts
+)
+
+
+__all__ = ["TASKS_COMMAND", "TasksCommand"]

--- a/tests/test_tasks_command.py
+++ b/tests/test_tasks_command.py
@@ -1,0 +1,126 @@
+"""Tests for the ``/tasks`` command (Phase 10 — degraded background-task list).
+
+Lists running tasks from ``context.tool_context.runtime_tasks`` (the live registry).
+Same output-style/``/mcp`` pattern (``run()`` returns text, no ``ctx.ui``). REPL-functional;
+SDK (``tool_context is None``) → "unavailable". Coexistence is inversion (TUI keeps panel).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src.command_system import (
+    TASKS_COMMAND,
+    TasksCommand,
+    create_command_context,
+    get_builtin_commands,
+    get_commands,
+    is_bridge_safe_command,
+)
+from src.command_system.engine import CommandEngine
+from src.command_system.registry import CommandRegistry
+from src.command_system.types import CommandType, InteractiveOutcome, NullUIHost
+
+
+def _task(id, type, status, description=""):
+    return SimpleNamespace(id=id, type=type, status=status, description=description)
+
+
+def _ctx(tmp_path, *, ui=None, tasks=None, tool_context="__default__"):
+    if tool_context == "__default__":
+        registry = SimpleNamespace(all=lambda: list(tasks or []))
+        tool_context = SimpleNamespace(runtime_tasks=registry)
+    return create_command_context(
+        workspace_root=tmp_path, cwd=tmp_path, ui=ui, tool_context=tool_context
+    )
+
+
+# --------------------------------------------------------------------------- #
+# A. Metadata + registration
+# --------------------------------------------------------------------------- #
+def test_tasks_registered():
+    assert "tasks" in {c.name for c in get_builtin_commands()}
+    assert "tasks" in {c.name for c in get_commands(cwd=str(Path.cwd()))}
+
+
+def test_tasks_metadata_mirrors_ts():
+    assert isinstance(TASKS_COMMAND, TasksCommand)
+    assert TASKS_COMMAND.name == "tasks"
+    assert TASKS_COMMAND.description == "List and manage background tasks"
+    assert TASKS_COMMAND.aliases == ["bashes"]
+    assert TASKS_COMMAND.command_type == CommandType.INTERACTIVE
+
+
+# --------------------------------------------------------------------------- #
+# B. Bridge-safety + dispatch inversion
+# --------------------------------------------------------------------------- #
+def test_tasks_blocked_from_bridge_by_type():
+    assert is_bridge_safe_command(TASKS_COMMAND) is False
+
+
+def test_dispatch_local_command_intercepts_tasks():
+    from src.tui.commands import dispatch_local_command
+
+    res = dispatch_local_command(
+        "/tasks", session=None, workspace_root=Path("."), tool_registry=None
+    )
+    assert res.handled is True
+    assert res.open_dialog == "tasks"
+
+
+# --------------------------------------------------------------------------- #
+# C. List output. t1 = realistic (Literal[str] type/status, the production shape);
+#    t2 = SYNTHETIC `.value`-bearing object to exercise the defensive _coerce branch.
+# --------------------------------------------------------------------------- #
+async def test_list_output(tmp_path):
+    tasks = [
+        _task("t1", "local_shell", "running", "build the thing"),
+        _task("t2", SimpleNamespace(value="agent"), SimpleNamespace(value="done"), ""),
+    ]
+    out = await TASKS_COMMAND.run("", _ctx(tmp_path, ui=NullUIHost(), tasks=tasks))
+    assert isinstance(out, InteractiveOutcome)
+    assert out.message == (
+        "Background tasks:\n"
+        "• [running] build the thing (id: t1)\n"
+        "• [done] agent (id: t2)"  # description empty → falls back to coerced type
+    )
+    assert out.display == "system"
+
+
+async def test_empty_registry(tmp_path):
+    out = await TASKS_COMMAND.run("", _ctx(tmp_path, ui=NullUIHost(), tasks=[]))
+    assert out.message == "No background tasks."
+    assert out.display == "system"
+
+
+# --------------------------------------------------------------------------- #
+# E. Unavailable when no tool_context / registry (SDK surface)
+# --------------------------------------------------------------------------- #
+async def test_unavailable_without_tool_context(tmp_path):
+    out = await TASKS_COMMAND.run("", _ctx(tmp_path, ui=NullUIHost(), tool_context=None))
+    assert out.message == "Background tasks are unavailable on this surface."
+    assert out.display == "system"
+
+
+async def test_unavailable_without_runtime_tasks(tmp_path):
+    tc = SimpleNamespace()  # has no runtime_tasks attr
+    out = await TASKS_COMMAND.run("", _ctx(tmp_path, ui=NullUIHost(), tool_context=tc))
+    assert out.message == "Background tasks are unavailable on this surface."
+
+
+# --------------------------------------------------------------------------- #
+# F. Engine end-to-end (headless, no raise — unlike pickers)
+# --------------------------------------------------------------------------- #
+async def test_engine_succeeds_headless(tmp_path):
+    tasks = [_task("t1", "local_shell", "running", "do it")]
+    reg = CommandRegistry()
+    reg.register(TASKS_COMMAND)
+    ctx = _ctx(tmp_path, tasks=tasks)  # ui=None → engine subs NullUIHost
+    eng = CommandEngine(registry=reg, workspace_root=tmp_path, context=ctx)
+
+    result = await eng.execute("/tasks")
+
+    assert result.success is True
+    assert result.text.startswith("Background tasks:")


### PR DESCRIPTION
## Summary
- Port TS local-jsx `/tasks` (`typescript/src/commands/tasks/`) as an `InteractiveCommand`. TS `/tasks` lists **and manages** (kill) background tasks; Python's TUI `/tasks` focuses a live panel (app-bound). This registry port provides the **headless list** — the running tasks are reachable via `context.tool_context.runtime_tasks` (the same `RuntimeTaskRegistry` tools write to) — and **drops management** (kill needs the app/async `Task.kill` path). The TUI keeps its live panel (**inversion**, `open_dialog="tasks"`).
- Follows the output-style/`/mcp` precedent: `run()` returns text **without touching `ctx.ui`**, so it works on every surface; on the SDK (`tool_context` None) it reports the list is **unavailable** rather than raising. REPL-functional, SDK-degraded (the user's "ship degraded-but-useful" choice).
- alias `bashes` (TS); `_format_task` = `[status] {description or type} (id)`, getattr-guarded.

## Test plan
- [x] `tests/test_tasks_command.py` (9 tests): metadata/registration (+ alias), bridge-safety + inversion dispatch, list output (realistic + synthetic `_coerce` task), empty, unavailable (both None-paths), engine-headless success.
- [x] Full suite: **7192 passed**; only the 6 pre-existing baseline failures.
- [x] Plan + implementation both critic-approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)