### PR TITLE
commands: port /diff git-diff text (Phase 11, degraded)

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -81,6 +81,7 @@ from .model_command import MODEL_COMMAND, ModelCommand
 from .logo_command import LOGO_COMMAND, LogoCommand
 from .mcp_command import MCP_COMMAND, McpCommand
 from .tasks_command import TASKS_COMMAND, TasksCommand
+from .diff_command import DIFF_COMMAND, DiffCommand
 from .types import (
     Command,
     CommandAvailability,
@@ -168,6 +169,8 @@ __all__ = [
     "McpCommand",
     "TASKS_COMMAND",
     "TasksCommand",
+    "DIFF_COMMAND",
+    "DiffCommand",
     "get_builtin_commands",
     "register_builtin_commands",
     # Moved-to-plugin factory + shell-at-prompt-build

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -34,6 +34,7 @@ from .model_command import MODEL_COMMAND
 from .logo_command import LOGO_COMMAND
 from .mcp_command import MCP_COMMAND
 from .tasks_command import TASKS_COMMAND
+from .diff_command import DIFF_COMMAND
 from .types import Command, CommandType, CompactionResult, LocalCommand, PromptCommand
 
 
@@ -1246,6 +1247,7 @@ def get_builtin_commands() -> list[Command]:
         LOGO_COMMAND,
         MCP_COMMAND,
         TASKS_COMMAND,
+        DIFF_COMMAND,
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)

--- a/src/command_system/diff_command.py
+++ b/src/command_system/diff_command.py
@@ -1,0 +1,87 @@
+"""diff — ``/diff`` uncommitted-changes view (port of TS local-jsx, degraded).
+
+TS ``/diff`` (``commands/diff/``) renders an interactive ``DiffDialog`` showing the
+uncommitted changes AND per-turn file edits (from tool results). Python's TUI ``/diff``
+reads ``app_state.pending_diffs`` (app-bound) and pushes ``DiffDialogScreen``. This
+registry port shows the **uncommitted changes (staged + unstaged) as ``git diff`` text**
+— the content TS shows via ``git diff HEAD``, reachable from ``CommandContext.cwd`` via
+the existing ``src/utils/git.py`` helpers — dropping the per-turn diffs (app-bound), the
+interactive viewer, and untracked files (TS's ``git diff HEAD`` omits those too). The TUI
+keeps its rich dialog (inversion).
+
+Follows the output-style/``/mcp``/``/tasks`` precedent: ``run()`` returns text WITHOUT
+touching ``ctx.ui``, so it works on every surface.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .types import (
+    CommandContext,
+    InteractiveCommand,
+    InteractiveOutcome,
+)
+
+# Cap so a huge diff doesn't flood a single REPL/SDK message; the TUI has the full view.
+_MAX_LINES = 500
+
+
+def _cap(text: str) -> str:
+    lines = text.split("\n")
+    if len(lines) <= _MAX_LINES:
+        return text
+    more = len(lines) - _MAX_LINES
+    head = "\n".join(lines[:_MAX_LINES])
+    return (
+        f"{head}\n… (diff truncated — {more} more line(s); use the TUI /diff for the "
+        "full interactive view)"
+    )
+
+
+def _section(label: str, result) -> str:
+    return (
+        f"{label} ({result.files_changed} file(s), +{result.insertions} "
+        f"-{result.deletions}):\n" + (result.diff_text or "").rstrip("\n")
+    )
+
+
+@dataclass(frozen=True)
+class DiffCommand(InteractiveCommand):
+    """Show the uncommitted changes (staged + unstaged) as ``git diff`` text. Frozen + no
+    new fields (the ``McpCommand`` pattern); ``run()`` returns text without touching
+    ``ctx.ui``."""
+
+    async def run(self, args: str, context: CommandContext) -> InteractiveOutcome:
+        # Lazy import so `import src.command_system` doesn't pull the git/utils stack.
+        from src.utils.git import get_repo_root, get_session_diff
+
+        cwd = str(context.cwd)
+        if get_repo_root(cwd) is None:
+            # get_repo_root distinguishes not-a-repo from no-changes (both give "" from
+            # the diff helper otherwise).
+            return InteractiveOutcome("Not a git repository.", display="system")
+
+        # Staged + unstaged = the "uncommitted changes" TS shows via `git diff HEAD`,
+        # rendered as two labeled sections (avoids double-counting and handles a repo
+        # with no commits, which a literal `git diff HEAD` can't). Untracked files are
+        # not shown — matching TS's `git diff HEAD`.
+        staged = get_session_diff(cwd, staged=True)
+        unstaged = get_session_diff(cwd)
+        sections: list[str] = []
+        if (staged.diff_text or "").strip():
+            sections.append(_section("Staged changes", staged))
+        if (unstaged.diff_text or "").strip():
+            sections.append(_section("Unstaged changes", unstaged))
+        if not sections:
+            return InteractiveOutcome("No uncommitted changes.", display="system")
+        return InteractiveOutcome(_cap("\n\n".join(sections)), display="system")
+
+
+DIFF_COMMAND = DiffCommand(
+    name="diff",
+    # Verbatim TS index.ts (the port shows the git working-tree diff only — see docstring).
+    description="View uncommitted changes and per-turn diffs",
+)
+
+
+__all__ = ["DIFF_COMMAND", "DiffCommand"]

--- a/tests/test_diff_command.py
+++ b/tests/test_diff_command.py
@@ -1,0 +1,154 @@
+"""Tests for the ``/diff`` command (Phase 11 — git-diff text, degraded).
+
+Shows the uncommitted working-tree changes as ``git diff`` text (via ``src/utils/git.py``).
+Same output-style/``/mcp`` pattern (``run()`` returns text, no ``ctx.ui``). Coexistence is
+inversion (the TUI keeps its rich ``DiffDialogScreen``). Tests use a REAL ``git init`` repo.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from src.command_system import (
+    DIFF_COMMAND,
+    DiffCommand,
+    create_command_context,
+    get_builtin_commands,
+    get_commands,
+    is_bridge_safe_command,
+)
+from src.command_system.engine import CommandEngine
+from src.command_system.registry import CommandRegistry
+from src.command_system.types import CommandType, InteractiveOutcome, NullUIHost
+
+
+def _git(tmp: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=tmp, check=True, capture_output=True)
+
+
+def _repo(tmp: Path) -> Path:
+    _git(tmp, "init")
+    _git(tmp, "config", "user.email", "t@example.com")
+    _git(tmp, "config", "user.name", "Test")
+    (tmp / "f.txt").write_text("line1\nline2\n")
+    _git(tmp, "add", "f.txt")
+    _git(tmp, "commit", "-m", "init")
+    return tmp
+
+
+def _ctx(tmp: Path, *, ui=None):
+    return create_command_context(workspace_root=tmp, cwd=tmp, ui=ui)
+
+
+# --------------------------------------------------------------------------- #
+# A. Metadata + registration
+# --------------------------------------------------------------------------- #
+def test_diff_registered():
+    assert "diff" in {c.name for c in get_builtin_commands()}
+    assert "diff" in {c.name for c in get_commands(cwd=str(Path.cwd()))}
+
+
+def test_diff_metadata_mirrors_ts():
+    assert isinstance(DIFF_COMMAND, DiffCommand)
+    assert DIFF_COMMAND.name == "diff"
+    assert DIFF_COMMAND.description == "View uncommitted changes and per-turn diffs"
+    assert DIFF_COMMAND.command_type == CommandType.INTERACTIVE
+
+
+# --------------------------------------------------------------------------- #
+# B. Bridge-safety + dispatch inversion
+# --------------------------------------------------------------------------- #
+def test_diff_blocked_from_bridge_by_type():
+    assert is_bridge_safe_command(DIFF_COMMAND) is False
+
+
+def test_dispatch_local_command_intercepts_diff():
+    from src.tui.commands import dispatch_local_command
+
+    res = dispatch_local_command(
+        "/diff", session=None, workspace_root=Path("."), tool_registry=None
+    )
+    assert res.handled is True
+    assert res.open_dialog == "diff"
+
+
+# --------------------------------------------------------------------------- #
+# C. Modified working tree → diff text
+# --------------------------------------------------------------------------- #
+async def test_modified_shows_diff(tmp_path):
+    _repo(tmp_path)
+    (tmp_path / "f.txt").write_text("line1\nline2\nnew line\n")  # unstaged change
+    out = await DIFF_COMMAND.run("", _ctx(tmp_path, ui=NullUIHost()))
+    assert isinstance(out, InteractiveOutcome)
+    assert out.message.startswith("Unstaged changes (")
+    assert "+new line" in out.message
+    assert out.display == "system"
+
+
+async def test_staged_shows_diff(tmp_path):
+    # Regression for the critic's false-negative: a STAGED change must not report
+    # "No uncommitted changes." (unstaged-only `git diff` would).
+    _repo(tmp_path)
+    (tmp_path / "f.txt").write_text("line1\nline2\nstaged line\n")
+    _git(tmp_path, "add", "f.txt")
+    out = await DIFF_COMMAND.run("", _ctx(tmp_path, ui=NullUIHost()))
+    assert out.message.startswith("Staged changes (")
+    assert "+staged line" in out.message
+
+
+async def test_staged_and_unstaged_sections(tmp_path):
+    _repo(tmp_path)
+    (tmp_path / "f.txt").write_text("line1\nline2\nstaged\n")
+    _git(tmp_path, "add", "f.txt")  # stage
+    (tmp_path / "f.txt").write_text("line1\nline2\nstaged\nunstaged\n")  # further unstaged
+    out = await DIFF_COMMAND.run("", _ctx(tmp_path, ui=NullUIHost()))
+    assert "Staged changes (" in out.message
+    assert "Unstaged changes (" in out.message
+
+
+async def test_clean_repo(tmp_path):
+    _repo(tmp_path)  # no modifications
+    out = await DIFF_COMMAND.run("", _ctx(tmp_path, ui=NullUIHost()))
+    assert out.message == "No uncommitted changes."
+    assert out.display == "system"
+
+
+# --------------------------------------------------------------------------- #
+# E. Not a git repository (deterministic via monkeypatch)
+# --------------------------------------------------------------------------- #
+async def test_not_a_repo(tmp_path, monkeypatch):
+    monkeypatch.setattr("src.utils.git.get_repo_root", lambda *a, **k: None)
+    out = await DIFF_COMMAND.run("", _ctx(tmp_path, ui=NullUIHost()))
+    assert out.message == "Not a git repository."
+    assert out.display == "system"
+
+
+# --------------------------------------------------------------------------- #
+# F. Truncation of a large diff
+# --------------------------------------------------------------------------- #
+async def test_large_diff_truncated(tmp_path):
+    _repo(tmp_path)
+    (tmp_path / "f.txt").write_text("\n".join(f"line {i}" for i in range(700)) + "\n")
+    out = await DIFF_COMMAND.run("", _ctx(tmp_path, ui=NullUIHost()))
+    assert "diff truncated" in out.message
+    # Capped near _MAX_LINES (+ header + truncation notice line).
+    assert len(out.message.split("\n")) <= 503
+
+
+# --------------------------------------------------------------------------- #
+# G. Engine end-to-end (headless)
+# --------------------------------------------------------------------------- #
+async def test_engine_succeeds_headless(tmp_path):
+    _repo(tmp_path)
+    (tmp_path / "f.txt").write_text("line1\nline2\nchanged\n")
+    reg = CommandRegistry()
+    reg.register(DIFF_COMMAND)
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+    eng = CommandEngine(registry=reg, workspace_root=tmp_path, context=ctx)
+
+    result = await eng.execute("/diff")
+
+    assert result.success is True
+    assert result.text.startswith("Unstaged changes (")


### PR DESCRIPTION
## Summary
- Port TS local-jsx `/diff` (`typescript/src/commands/diff/`) as an `InteractiveCommand`. TS `/diff` renders an interactive `DiffDialog` (uncommitted changes + per-turn diffs); Python's TUI `/diff` reads app-bound `app_state.pending_diffs`. This registry port shows the **uncommitted changes (staged + unstaged) as `git diff` text** — the content TS shows via `git diff HEAD` — reusing `src/utils/git.py` (`get_repo_root` + `get_session_diff`), dropping the per-turn diffs (app-bound), the interactive viewer, and untracked files (TS's `git diff HEAD` omits those too). The TUI keeps its rich dialog (**inversion**).
- Follows the output-style/`/mcp` precedent: `run()` returns text **without touching `ctx.ui`**. Renders **Staged + Unstaged** as two labeled sections (avoids double-counting + handles a no-commits repo, which a literal `git diff HEAD` can't); both empty → "No uncommitted changes."; not a repo → "Not a git repository."; capped at 500 lines with a notice pointing to the TUI.

## Test plan
- [x] `tests/test_diff_command.py` (11 tests, real `git init` repo): metadata/registration, bridge-safety + inversion dispatch, unstaged diff, **staged diff** (regression for the false-negative), staged+unstaged sections, clean, not-a-repo, truncation, engine-headless.
- [x] Full suite: **7203 passed**; only the 6 pre-existing baseline failures.
- [x] Plan + implementation both critic-approved (plan-critic caught the unstaged-only false-negative; fixed to staged+unstaged before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)