### PR TITLE
commands: port /release-notes changelog viewer (Phase 12)

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -82,6 +82,7 @@ from .logo_command import LOGO_COMMAND, LogoCommand
 from .mcp_command import MCP_COMMAND, McpCommand
 from .tasks_command import TASKS_COMMAND, TasksCommand
 from .diff_command import DIFF_COMMAND, DiffCommand
+from .release_notes_command import RELEASE_NOTES_COMMAND
 from .types import (
     Command,
     CommandAvailability,
@@ -171,6 +172,7 @@ __all__ = [
     "TasksCommand",
     "DIFF_COMMAND",
     "DiffCommand",
+    "RELEASE_NOTES_COMMAND",
     "get_builtin_commands",
     "register_builtin_commands",
     # Moved-to-plugin factory + shell-at-prompt-build

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -35,6 +35,7 @@ from .logo_command import LOGO_COMMAND
 from .mcp_command import MCP_COMMAND
 from .tasks_command import TASKS_COMMAND
 from .diff_command import DIFF_COMMAND
+from .release_notes_command import RELEASE_NOTES_COMMAND
 from .types import Command, CommandType, CompactionResult, LocalCommand, PromptCommand
 
 
@@ -1248,6 +1249,7 @@ def get_builtin_commands() -> list[Command]:
         MCP_COMMAND,
         TASKS_COMMAND,
         DIFF_COMMAND,
+        RELEASE_NOTES_COMMAND,
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)

--- a/src/command_system/release_notes_command.py
+++ b/src/command_system/release_notes_command.py
@@ -1,0 +1,56 @@
+"""release-notes — ``/release-notes`` changelog viewer (port of TS ``type:'local'``).
+
+Port of ``typescript/src/commands/release-notes/``. TS tries a GitHub-releases fetch and
+falls back to the **stored changelog**; Python reads the project's local ``CHANGELOG.md``
+(exactly the stored-changelog path) and **drops the network fetch/cache** (the same
+unported-subsystem boundary as ``/mcp``/``/model``). When the current version has no
+section (or the changelog is absent, e.g. pip installs), the output degrades to the
+release-page URL — faithful to TS's notes-empty case.
+
+Maps to :class:`LocalCommand` (the first ``type:'local'`` single-command port of this
+batch — prior ports were ``local-jsx`` → ``InteractiveCommand``), using the established
+``set_call`` pattern from builtins (help/clear/…). Sync impl: the only async part of TS
+was the dropped fetch.
+"""
+from __future__ import annotations
+
+from .types import CommandContext, LocalCommand, LocalCommandResult
+
+
+def release_notes_call(args: str, context: CommandContext) -> LocalCommandResult:
+    # Lazy imports keep `import src.command_system` light (the established discipline).
+    from src import __version__
+    from src.utils.release_notes import (
+        format_release_notes_for_display,
+        get_release_notes_for_version,
+        get_release_tag_url,
+        normalize_public_version,
+        read_local_changelog,
+    )
+
+    # Normalize once and reuse for header + URL (TS interpolates the already-public
+    # build version; getReleaseTagUrl normalizes internally — identical result).
+    version = normalize_public_version(__version__)
+    notes = get_release_notes_for_version(version, read_local_changelog())
+    url = get_release_tag_url(version)
+    if notes:
+        return LocalCommandResult(
+            type="text",
+            value=(
+                f"Release notes for {version}:\n"
+                f"{format_release_notes_for_display(notes)}\n\n"
+                f"Full release page: {url}"
+            ),
+        )
+    return LocalCommandResult(type="text", value=f"Release notes: {url}")
+
+
+RELEASE_NOTES_COMMAND = LocalCommand(
+    name="release-notes",
+    description="View release notes",  # verbatim TS index.ts
+    supports_non_interactive=True,  # verbatim TS index.ts
+)
+RELEASE_NOTES_COMMAND.set_call(release_notes_call)
+
+
+__all__ = ["RELEASE_NOTES_COMMAND", "release_notes_call"]

--- a/src/utils/release_notes.py
+++ b/src/utils/release_notes.py
@@ -1,0 +1,133 @@
+"""Release-notes parsing for the ``/release-notes`` command.
+
+Port of the *stored-changelog* half of ``typescript/src/utils/releaseNotes.ts`` (+ the
+URL/version helpers from ``utils/version.ts``). The TS GitHub-releases **fetch/cache**
+path (``fetchAndStoreChangelog`` etc.) is dropped — Python reads the project's local
+``CHANGELOG.md`` instead, which is exactly the content TS's stored-changelog fallback
+parses. The startup "what's new" banner consumers (``getRecentReleaseNotes`` /
+``sliceReleaseNotesForDisplay``) are out of scope.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# The Python project's analog of TS OPENCLAUDE_RELEASES_URL (version.ts:6).
+RELEASES_URL = "https://github.com/agentforce314/clawcodex/releases"
+
+# Encoded section-header marker — verbatim TS SECTION_HEADER_PREFIX. Only the
+# (dropped) GitHub-release parser *produces* these; the formatter still renders them
+# for parity.
+_SECTION_HEADER_PREFIX = "__section__:"  # verbatim TS (releaseNotes.ts:21)
+
+_VERSION_RE = re.compile(r"(\d+)(?:\.(\d+))?(?:\.(\d+))?")
+
+
+def normalize_public_version(version: str) -> str:
+    """Mirror of TS ``normalizePublicVersion`` (version.ts:9-16): semver-``coerce`` the
+    string (the FIRST version-ish number found, padded to ``maj.min.patch``) — handles
+    ``[0.1.0] - 2026-04-19``, ``v0.5.0``, and release-please link headings — else strip
+    a leading ``v``."""
+    trimmed = version.strip()
+    m = _VERSION_RE.search(trimmed)
+    if m:
+        # Matched digits kept VERBATIM (no int-normalization): semver coerce rejects
+        # leading-zero components (-> TS falls back to the strip-^v path, returning
+        # them unchanged), so "01.02.03" must stay "01.02.03" here too.
+        major, minor, patch = m.group(1), m.group(2) or "0", m.group(3) or "0"
+        return f"{major}.{minor}.{patch}"
+    return re.sub(r"^v", "", trimmed, flags=re.IGNORECASE)  # /^v/i — case-insensitive like TS
+
+
+def parse_changelog(content: str) -> dict[str, list[str]]:
+    """Faithful port of TS ``parseChangelog`` (releaseNotes.ts:316-358): split on
+    ``^## `` headings (the first chunk — the preamble — is skipped), key each section by
+    the normalized version from its heading line, collect only ``- ``/``* `` bullet
+    lines (``###``/``####`` sub-headers are ignored), and keep sections with ≥1 bullet."""
+    if not content:
+        return {}
+    release_notes: dict[str, list[str]] = {}
+    sections = re.split(r"^## ", content, flags=re.MULTILINE)[1:]
+    for section in sections:
+        lines = section.strip().split("\n")
+        if not lines:
+            continue
+        version_line = lines[0]
+        if not version_line:
+            continue
+        version = normalize_public_version(version_line)
+        if not version:
+            continue
+        notes = []
+        for line in lines[1:]:
+            t = line.strip()
+            if t.startswith("- ") or t.startswith("* "):
+                note = t[2:].strip()
+                if note:
+                    notes.append(note)
+        if notes:
+            release_notes[version] = notes
+    return release_notes
+
+
+def get_release_notes_for_version(version: str, content: str) -> list[str]:
+    """TS ``getReleaseNotesForVersion`` (releaseNotes.ts:415-426)."""
+    try:
+        return parse_changelog(content).get(normalize_public_version(version), [])
+    except Exception:
+        return []
+
+
+def is_release_section_header(note: str) -> bool:
+    return note.startswith(_SECTION_HEADER_PREFIX)
+
+
+def get_release_section_header_title(note: str) -> str:
+    return note[len(_SECTION_HEADER_PREFIX):] if is_release_section_header(note) else note
+
+
+def format_release_notes_for_display(notes: list[str]) -> str:
+    """TS ``formatReleaseNotesForDisplay`` (releaseNotes.ts:428-444): encoded section
+    headers render as ``"{Title}:"`` preceded by a blank line when not first; plain
+    notes render as ``"- {note}"``."""
+    lines: list[str] = []
+    for note in notes:
+        if is_release_section_header(note):
+            if lines:
+                lines.append("")
+            lines.append(f"{get_release_section_header_title(note)}:")
+            continue
+        lines.append(f"- {note}")
+    return "\n".join(lines)
+
+
+def get_release_tag_url(version: str) -> str:
+    """TS ``getReleaseTagUrl`` (version.ts:54-56)."""
+    return f"{RELEASES_URL}/tag/v{normalize_public_version(version)}"
+
+
+def read_local_changelog() -> str:
+    """Best-effort read of the project's ``CHANGELOG.md`` (the stored-changelog analog).
+    Resolved relative to the ``src`` package (repo root in dev checkouts); absent (e.g.
+    pip installs) or unreadable → ``""`` (the command then falls back to the URL line,
+    matching TS's notes-empty case)."""
+    try:
+        import src
+
+        path = Path(src.__file__).resolve().parent.parent / "CHANGELOG.md"
+        return path.read_text(encoding="utf-8")
+    except Exception:
+        return ""
+
+
+__all__ = [
+    "RELEASES_URL",
+    "normalize_public_version",
+    "parse_changelog",
+    "get_release_notes_for_version",
+    "is_release_section_header",
+    "get_release_section_header_title",
+    "format_release_notes_for_display",
+    "get_release_tag_url",
+    "read_local_changelog",
+]

--- a/tests/test_release_notes_command.py
+++ b/tests/test_release_notes_command.py
@@ -1,0 +1,212 @@
+"""Tests for the ``/release-notes`` command (Phase 12 — port of TS ``type:'local'``).
+
+Reads the project's local ``CHANGELOG.md`` (the TS stored-changelog fallback path; the
+GitHub fetch/cache is dropped). First ``local``-type port of the batch → maps to
+``LocalCommand`` + ``set_call``; NOTE it is in ``BRIDGE_SAFE_COMMANDS`` (mirroring TS),
+so — unlike the interactive ports — ``is_bridge_safe_command`` is **True**.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src import __version__
+from src.command_system import (
+    RELEASE_NOTES_COMMAND,
+    create_command_context,
+    get_builtin_commands,
+    get_commands,
+    is_bridge_safe_command,
+)
+from src.command_system.engine import CommandEngine
+from src.command_system.registry import CommandRegistry
+from src.command_system.types import CommandType
+from src.utils.release_notes import (
+    RELEASES_URL,
+    format_release_notes_for_display,
+    get_release_notes_for_version,
+    get_release_tag_url,
+    normalize_public_version,
+    parse_changelog,
+    read_local_changelog,
+)
+
+_CHANGELOG = """# Changelog
+
+Preamble text with a list:
+- this preamble bullet must be skipped
+
+## [0.5.0] - 2026-06-01
+
+### Added
+- new thing one
+* new thing two
+- 
+
+### Fixed
+- a bug fix
+
+## v0.4.0
+
+No bullets here, just prose.
+
+## [0.1.0] - 2026-04-19
+
+- initial release
+"""
+
+
+# --------------------------------------------------------------------------- #
+# A. normalize_public_version (the semver-coerce mirror)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("[0.1.0] - 2026-04-19", "0.1.0"),  # FIRST match wins (not the date)
+        ("v0.5.0", "0.5.0"),
+        ("v2.3", "2.3.0"),  # padded like semver coerce
+        ("1", "1.0.0"),
+        ("  0.5.0  ", "0.5.0"),
+        ("2026-04-19", "2026.0.0"),  # coerce behavior on a bare date
+        ("vNext", "Next"),  # no digits -> strip leading v
+        ("VNext", "Next"),  # /^v/i — case-insensitive strip
+        ("01.02.03", "01.02.03"),  # leading zeros kept VERBATIM (coerce rejects -> TS fallback)
+    ],
+)
+def test_normalize_public_version(raw, expected):
+    assert normalize_public_version(raw) == expected
+
+
+# --------------------------------------------------------------------------- #
+# B. parse_changelog / get_release_notes_for_version
+# --------------------------------------------------------------------------- #
+def test_parse_changelog():
+    parsed = parse_changelog(_CHANGELOG)
+    # Preamble (before the first ## heading) is skipped — its bullet must not leak.
+    assert all("preamble" not in n for notes in parsed.values() for n in notes)
+    # Keep-a-Changelog heading normalizes to the bare version key.
+    assert parsed["0.5.0"] == ["new thing one", "new thing two", "a bug fix"]
+    # ### sub-headers are ignored (bullets collected flat); '* ' bullets accepted.
+    # Bullet-less sections are dropped entirely.
+    assert "0.4.0" not in parsed
+    assert parsed["0.1.0"] == ["initial release"]
+    assert parse_changelog("") == {}
+
+
+def test_get_release_notes_for_version():
+    assert get_release_notes_for_version("v0.5.0", _CHANGELOG) == [
+        "new thing one",
+        "new thing two",
+        "a bug fix",
+    ]
+    assert get_release_notes_for_version("9.9.9", _CHANGELOG) == []
+
+
+# --------------------------------------------------------------------------- #
+# C. format_release_notes_for_display
+# --------------------------------------------------------------------------- #
+def test_format_plain_notes():
+    assert format_release_notes_for_display(["one", "two"]) == "- one\n- two"
+
+
+def test_format_with_encoded_section_headers():
+    notes = ["__section__:Added", "one", "__section__:Fixed", "two"]
+    # Header first -> no leading blank; later headers preceded by a blank line.
+    assert (
+        format_release_notes_for_display(notes)
+        == "Added:\n- one\n\nFixed:\n- two"
+    )
+
+
+def test_release_tag_url():
+    assert get_release_tag_url("0.5.0") == f"{RELEASES_URL}/tag/v0.5.0"
+    assert get_release_tag_url("v0.5.0") == f"{RELEASES_URL}/tag/v0.5.0"
+
+
+def test_read_local_changelog_reads_repo_file():
+    # Dev checkouts have CHANGELOG.md at the package root.
+    content = read_local_changelog()
+    assert content.startswith("# Changelog")
+
+
+# --------------------------------------------------------------------------- #
+# D. Command behavior (changelog source monkeypatched)
+# --------------------------------------------------------------------------- #
+def _ctx(tmp_path: Path):
+    return create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+
+
+async def test_command_with_notes(tmp_path, monkeypatch):
+    changelog = f"# Changelog\n\n## [{__version__}] - 2026-06-09\n\n- ported things\n"
+    monkeypatch.setattr(
+        "src.utils.release_notes.read_local_changelog", lambda: changelog
+    )
+    result = await RELEASE_NOTES_COMMAND.call("", _ctx(tmp_path))
+    assert result.type == "text"
+    assert result.value == (
+        f"Release notes for {__version__}:\n- ported things\n\n"
+        f"Full release page: {RELEASES_URL}/tag/v{__version__}"
+    )
+
+
+async def test_command_url_fallback_when_version_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "src.utils.release_notes.read_local_changelog",
+        lambda: "# Changelog\n\n## [0.0.1]\n\n- ancient\n",
+    )
+    result = await RELEASE_NOTES_COMMAND.call("", _ctx(tmp_path))
+    assert result.value == f"Release notes: {RELEASES_URL}/tag/v{__version__}"
+
+
+async def test_command_url_fallback_when_changelog_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr("src.utils.release_notes.read_local_changelog", lambda: "")
+    result = await RELEASE_NOTES_COMMAND.call("ignored args", _ctx(tmp_path))
+    assert result.value == f"Release notes: {RELEASES_URL}/tag/v{__version__}"
+
+
+# --------------------------------------------------------------------------- #
+# E. Registration + type + bridge-safety + dispatch fall-through
+# --------------------------------------------------------------------------- #
+def test_registered():
+    assert "release-notes" in {c.name for c in get_builtin_commands()}
+    assert "release-notes" in {c.name for c in get_commands(cwd=str(Path.cwd()))}
+
+
+def test_metadata_mirrors_ts():
+    assert RELEASE_NOTES_COMMAND.name == "release-notes"
+    assert RELEASE_NOTES_COMMAND.description == "View release notes"
+    assert RELEASE_NOTES_COMMAND.command_type == CommandType.LOCAL
+    assert RELEASE_NOTES_COMMAND.supports_non_interactive is True
+
+
+def test_bridge_safe_by_allowlist():
+    # UNLIKE the interactive ports: release-notes is a LOCAL command listed in
+    # BRIDGE_SAFE_COMMANDS (mirroring TS commands.ts) -> bridge-safe.
+    assert is_bridge_safe_command(RELEASE_NOTES_COMMAND) is True
+
+
+def test_dispatch_falls_through():
+    from src.tui.commands import dispatch_local_command
+
+    res = dispatch_local_command(
+        "/release-notes", session=None, workspace_root=Path("."), tool_registry=None
+    )
+    assert res.handled is False
+    assert res.open_dialog is None
+
+
+# --------------------------------------------------------------------------- #
+# F. Engine end-to-end (headless)
+# --------------------------------------------------------------------------- #
+async def test_engine_succeeds_headless(tmp_path, monkeypatch):
+    monkeypatch.setattr("src.utils.release_notes.read_local_changelog", lambda: "")
+    reg = CommandRegistry()
+    reg.register(RELEASE_NOTES_COMMAND)
+    ctx = create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+    eng = CommandEngine(registry=reg, workspace_root=tmp_path, context=ctx)
+
+    result = await eng.execute("/release-notes")
+
+    assert result.success is True
+    assert result.text.startswith("Release notes")


### PR DESCRIPTION
## Summary
- Port TS `type:'local'` `/release-notes` (`typescript/src/commands/release-notes/`) as a `LocalCommand` — the **first local-type** single-command port of the batch. TS tries a GitHub-releases fetch and falls back to the **stored changelog**; Python reads the project's local `CHANGELOG.md` (exactly that stored-changelog path) and **drops the network fetch/cache** (the `/mcp`-style subsystem boundary).
- **`src/utils/release_notes.py`** — faithful ports of `parseChangelog` (preamble skip, version-line normalize, bullets only, ≥1-bullet sections), `getReleaseNotesForVersion`, `formatReleaseNotesForDisplay` (incl. the `__section__:` header branch, verbatim TS prefix), `normalizePublicVersion` (regex coerce — first version-ish match, digits kept **verbatim**; `/^v/i` fallback strip), `get_release_tag_url`.
- Output strings **byte-exact** to `release-notes.ts:42-51`; URL-only fallback when the version has no section / changelog absent (pip installs). **Bridge-safety:** `release-notes` is allowlisted in `BRIDGE_SAFE_COMMANDS` in both codebases → the first **bridge-safe** command of the batch. Dispatch falls through (no TUI dialog).

## Test plan
- [x] `tests/test_release_notes_command.py` (23 tests): normalize parametrized vs real-semver-coerce ground truth (incl. verbatim leading zeros + `/^v/i`), parser (preamble leak, `* ` bullets, bullet-less sections, empty input), formatter branches (exact strings), tag URL, real-repo changelog read, command notes/fallback paths (byte-exact), registration/LOCAL/`supports_non_interactive`, bridge-safe **True**, dispatch fall-through, engine headless.
- [x] Full suite: **7224 passed**; only the 6 pre-existing baseline failures.
- [x] Plan + implementation critic-approved (critic verified the parser against the real CHANGELOG — 53 notes for 0.1.0 — and caught a plan-text bridge-safety inversion + two normalize edge-case pins, all fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)