### PR TITLE
commands: port /copy response/code-block copier (Phase 13)

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -83,6 +83,7 @@ from .mcp_command import MCP_COMMAND, McpCommand
 from .tasks_command import TASKS_COMMAND, TasksCommand
 from .diff_command import DIFF_COMMAND, DiffCommand
 from .release_notes_command import RELEASE_NOTES_COMMAND
+from .copy_command import COPY_COMMAND, CopyCommand
 from .types import (
     Command,
     CommandAvailability,
@@ -173,6 +174,8 @@ __all__ = [
     "DIFF_COMMAND",
     "DiffCommand",
     "RELEASE_NOTES_COMMAND",
+    "COPY_COMMAND",
+    "CopyCommand",
     "get_builtin_commands",
     "register_builtin_commands",
     # Moved-to-plugin factory + shell-at-prompt-build

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -36,6 +36,7 @@ from .mcp_command import MCP_COMMAND
 from .tasks_command import TASKS_COMMAND
 from .diff_command import DIFF_COMMAND
 from .release_notes_command import RELEASE_NOTES_COMMAND
+from .copy_command import COPY_COMMAND
 from .types import Command, CommandType, CompactionResult, LocalCommand, PromptCommand
 
 
@@ -1250,6 +1251,7 @@ def get_builtin_commands() -> list[Command]:
         TASKS_COMMAND,
         DIFF_COMMAND,
         RELEASE_NOTES_COMMAND,
+        COPY_COMMAND,
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)

--- a/src/command_system/copy_command.py
+++ b/src/command_system/copy_command.py
@@ -1,0 +1,319 @@
+"""copy — ``/copy`` copy-assistant-response command (port of TS local-jsx).
+
+Port of ``typescript/src/commands/copy/`` (``copy.tsx`` + ``index.ts``). Copies the
+latest (or Nth-latest, ``/copy N``) assistant response — or one of its fenced code
+blocks via a picker — to the clipboard, always also writing a temp-file fallback.
+
+**Headless keystone:** the *direct* path (no code blocks in the message, or the
+``copyFullResponse`` config opt-out, including via ``/copy N``) never touches
+``ctx.ui`` → works on every surface incl. ``NullUIHost``. Only the code-block picker
+needs a surface. Coexistence: **fall-through** (no TUI dialog for ``/copy``).
+
+Deliberate divergences (documented for parity review):
+  * **Clipboard via subprocess** (pbcopy / xclip / xsel / clip), not TS's OSC 52
+    escape (which is fire-and-forget and therefore always *claims* success). A failed
+    subprocess copy must not lie: clipboard-fail + file-ok reports
+    ``"Written to {path} (…)"`` instead of "Copied to clipboard".
+  * **Line-based fence parser**, not the marked lexer — indented code blocks and
+    ``~~~`` fences are not recognized (fenced ``` blocks are what assistants emit).
+  * **``COPY_DIR`` = ``{tmpdir}/clawcodex``** (TS uses ``{tmpdir}/claude``).
+  * **Codepoint-based label truncation** (TS uses display-width ``stringWidth``).
+  * **No ``isApiErrorMessage`` flag** on Python messages — empty texts are skipped,
+    which is the practical effect.
+  * **``w`` write-only keyboard shortcut dropped** (no keyboard primitive on the
+    ``select`` bridge).
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from .types import (
+    CommandContext,
+    InteractiveCommand,
+    InteractiveOutcome,
+    UIOption,
+)
+
+MAX_LOOKBACK = 20  # TS copy.tsx:25
+RESPONSE_FILENAME = "response.md"
+
+# Verbatim port of TS STRIPPED_TAGS_RE (messages.ts:2764-2765).
+_STRIPPED_TAGS_RE = re.compile(
+    r"<(commit_analysis|context|function_analysis|pr_analysis)>.*?</\1>\n?",
+    re.DOTALL,
+)
+
+
+def _strip_prompt_xml_tags(content: str) -> str:
+    """TS ``stripPromptXMLTags`` (messages.ts:2767-2769)."""
+    return _STRIPPED_TAGS_RE.sub("", content).strip()
+
+
+def _copy_dir() -> Path:
+    return Path(tempfile.gettempdir()) / "clawcodex"
+
+
+@dataclass(frozen=True)
+class CodeBlock:
+    code: str
+    lang: str | None
+
+
+def _extract_code_blocks(markdown: str) -> list[CodeBlock]:
+    """Fenced ``` code blocks from the (XML-stripped) markdown. Line-based parser
+    (see module divergences): an opening ``` captures the language token; lines are
+    collected until the closing ```; an unclosed fence yields no block."""
+    blocks: list[CodeBlock] = []
+    in_fence = False
+    lang: str | None = None
+    buf: list[str] = []
+    for line in _strip_prompt_xml_tags(markdown).split("\n"):
+        stripped = line.strip()
+        if not in_fence and stripped.startswith("```"):
+            in_fence = True
+            token = stripped[3:].strip()
+            lang = token.split()[0] if token else None
+            buf = []
+            continue
+        if in_fence and stripped.startswith("```") and not stripped[3:].strip():
+            # CommonMark: a CLOSING fence may not carry an info string — a ```js
+            # line inside an open fence is content, not a close.
+            blocks.append(CodeBlock(code="\n".join(buf), lang=lang))
+            in_fence = False
+            lang = None
+            buf = []
+            continue
+        if in_fence:
+            buf.append(line)
+    return blocks
+
+
+def _message_role(msg: Any) -> Any:
+    if isinstance(msg, Mapping):
+        return msg.get("role") or msg.get("type")
+    return getattr(msg, "role", None) or getattr(msg, "type", None)
+
+
+def _message_text(msg: Any) -> str:
+    """Assistant text joined with '\\n\\n' (TS extractTextContent(content, '\\n\\n'))."""
+    from src.utils.export_renderer import extract_message_content
+
+    content = extract_message_content(msg)
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, Mapping):
+                if block.get("type") in (None, "text") and block.get("text"):
+                    parts.append(str(block["text"]))
+            else:
+                text = getattr(block, "text", None)
+                if text and getattr(block, "type", "text") in (None, "text"):
+                    parts.append(str(text))
+        return "\n\n".join(parts).strip()
+    return ""
+
+
+def collect_recent_assistant_texts(messages: Any) -> list[str]:
+    """TS ``collectRecentAssistantTexts`` (copy.tsx:50-61): newest-first assistant
+    texts that actually said something, capped at ``MAX_LOOKBACK``."""
+    texts: list[str] = []
+    for msg in reversed(list(messages or [])):
+        if len(texts) >= MAX_LOOKBACK:
+            break
+        if _message_role(msg) != "assistant":
+            continue
+        text = _message_text(msg)
+        if text:
+            texts.append(text)
+    return texts
+
+
+def _file_extension(lang: str | None) -> str:
+    """TS ``fileExtension`` (copy.tsx:62-72) — sanitized to prevent path traversal."""
+    if lang:
+        sanitized = re.sub(r"[^a-zA-Z0-9]", "", lang)
+        if sanitized and sanitized != "plaintext":
+            return f".{sanitized}"
+    return ".txt"
+
+
+def _truncate_line(text: str, max_len: int) -> str:
+    """First line, codepoint-truncated to ``max_len`` with ``…`` (TS truncateLine,
+    minus display-width awareness — module divergences)."""
+    first = text.split("\n")[0]
+    if len(first) <= max_len:
+        return first
+    return first[: max_len - 1] + "…"
+
+
+def _set_clipboard(text: str) -> bool:
+    """Best-effort OS clipboard via subprocess; True on success."""
+    if sys.platform == "darwin":
+        candidates = [["pbcopy"]]
+    elif sys.platform.startswith("win"):
+        candidates = [["clip"]]
+    else:
+        candidates = [["xclip", "-selection", "clipboard"], ["xsel", "--clipboard", "--input"]]
+    for cmd in candidates:
+        try:
+            proc = subprocess.run(
+                cmd, input=text.encode("utf-8"), capture_output=True, timeout=5
+            )
+            if proc.returncode == 0:
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def _write_to_file(text: str, filename: str) -> str:
+    copy_dir = _copy_dir()
+    copy_dir.mkdir(parents=True, exist_ok=True)
+    path = copy_dir / filename
+    path.write_text(text, encoding="utf-8")
+    return str(path)
+
+
+def _copy_or_write(text: str, filename: str) -> str:
+    """TS ``copyOrWriteToFile`` (copy.tsx:81-94), with the honest clipboard-failure
+    divergence (module docstring). ``char_count`` is Python codepoints; TS
+    ``text.length`` is UTF-16 code units (astral chars differ by one)."""
+    copied = _set_clipboard(text)
+    line_count = text.count("\n") + 1
+    char_count = len(text)
+    try:
+        path = _write_to_file(text, filename)
+    except Exception as exc:
+        if copied:
+            return f"Copied to clipboard ({char_count} characters, {line_count} lines)"
+        return f"Failed to copy: {exc}"
+    if copied:
+        return (
+            f"Copied to clipboard ({char_count} characters, {line_count} lines)\n"
+            f"Also written to {path}"
+        )
+    return f"Written to {path} ({char_count} characters, {line_count} lines)"
+
+
+def _copy_full_response_enabled() -> bool:
+    from src.config import load_config
+
+    return bool(load_config().get("copyFullResponse"))
+
+
+def _persist_copy_full_response() -> None:
+    from src.config import _get_default_manager, load_config
+
+    if not load_config().get("copyFullResponse"):
+        _get_default_manager().set_global("copyFullResponse", True)
+
+
+@dataclass(frozen=True)
+class CopyCommand(InteractiveCommand):
+    """Copy the latest assistant response (or a code block) to the clipboard."""
+
+    async def run(self, args: str, context: CommandContext) -> InteractiveOutcome:
+        messages = getattr(context.conversation, "messages", None) or []
+        texts = collect_recent_assistant_texts(messages)
+        if not texts:
+            return InteractiveOutcome(message="No assistant message to copy", display="user")
+
+        # /copy N reaches back N-1 messages (TS copy.tsx:341-355).
+        age = 0
+        arg = (args or "").strip()
+        if arg:
+            # int(arg) mirrors TS Number()+isInteger: accepts "+2"/"02", rejects
+            # floats and non-numerics.
+            try:
+                n = int(arg)
+                is_int = True
+            except ValueError:
+                n, is_int = 0, False
+            if not is_int or n < 1:
+                return InteractiveOutcome(
+                    message=(
+                        "Usage: /copy [N] where N is 1 (latest), 2, 3, … "
+                        f"Got: {arg}"
+                    ),
+                    display="user",
+                )
+            if n > len(texts):
+                noun = "message" if len(texts) == 1 else "messages"
+                return InteractiveOutcome(
+                    message=f"Only {len(texts)} assistant {noun} available to copy",
+                    display="user",
+                )
+            age = n - 1
+
+        text = texts[age]
+        code_blocks = _extract_code_blocks(text)
+
+        if not code_blocks or _copy_full_response_enabled():
+            return InteractiveOutcome(
+                message=_copy_or_write(text, RESPONSE_FILENAME), display="user"
+            )
+
+        return await self._pick(context, text, code_blocks)
+
+    async def _pick(
+        self, context: CommandContext, full_text: str, code_blocks: list[CodeBlock]
+    ) -> InteractiveOutcome:
+        options: list[UIOption] = [
+            UIOption(
+                value="full",
+                label="Full response",
+                description=(
+                    f"{len(full_text)} chars, {full_text.count(chr(10)) + 1} lines"
+                ),
+            )
+        ]
+        for i, block in enumerate(code_blocks):
+            lines = block.code.count("\n") + 1
+            desc_parts = [p for p in (block.lang, f"{lines} lines" if lines > 1 else None) if p]
+            options.append(
+                UIOption(
+                    value=str(i),
+                    label=_truncate_line(block.code, 60),
+                    description=", ".join(desc_parts) or None,
+                )
+            )
+        options.append(
+            UIOption(
+                value="always",
+                label="Always copy full response",
+                description="Skip this picker in the future (revert via /config)",
+            )
+        )
+
+        picked = await context.ui.select("Select content to copy:", options)
+        if picked is None:
+            return InteractiveOutcome(message="Copy cancelled", display="system")
+
+        if picked in ("full", "always"):
+            result = _copy_or_write(full_text, RESPONSE_FILENAME)
+            if picked == "always":
+                _persist_copy_full_response()
+                result += "\nPreference saved. Use /config to change copyFullResponse"
+            return InteractiveOutcome(message=result, display="user")
+
+        block = code_blocks[int(picked)]
+        result = _copy_or_write(block.code, f"copy{_file_extension(block.lang)}")
+        return InteractiveOutcome(message=result, display="user")
+
+
+COPY_COMMAND = CopyCommand(
+    name="copy",
+    # Verbatim TS index.ts.
+    description="Copy Claude's last response to clipboard (or /copy N for the Nth-latest)",
+)
+
+
+__all__ = ["COPY_COMMAND", "CopyCommand", "collect_recent_assistant_texts"]

--- a/tests/test_copy_command.py
+++ b/tests/test_copy_command.py
@@ -1,0 +1,349 @@
+"""Tests for the ``/copy`` command (Phase 13 — port of TS local-jsx).
+
+Headless keystone = the direct path (no code blocks / ``copyFullResponse`` / ``/copy N``
+to a block-less message) — never touches ``ctx.ui``. The code-block picker needs a
+surface. Clipboard + copy-dir are monkeypatched; config isolated for ``copyFullResponse``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import src.command_system.copy_command as cc
+import src.config as cfg
+from src.command_system import (
+    COPY_COMMAND,
+    CopyCommand,
+    create_command_context,
+    get_builtin_commands,
+    is_bridge_safe_command,
+)
+from src.command_system.copy_command import (
+    CodeBlock,
+    _extract_code_blocks,
+    _file_extension,
+    _strip_prompt_xml_tags,
+    _truncate_line,
+    collect_recent_assistant_texts,
+)
+from src.command_system.engine import CommandEngine
+from src.command_system.registry import CommandRegistry
+from src.command_system.safe_commands import REMOTE_SAFE_COMMANDS
+from src.command_system.types import CommandType, InteractiveOutcome, NullUIHost
+
+
+class FakeUIHost:
+    def __init__(self, *, pick=None):
+        self._pick = pick
+        self.select_calls: list[dict] = []
+
+    async def select(self, title, options, *, current=None):
+        self.select_calls.append(
+            {
+                "title": title,
+                "values": [o.value for o in options],
+                "labels": [o.label for o in options],
+                "descriptions": [o.description for o in options],
+            }
+        )
+        return self._pick
+
+    async def prompt_text(self, title, *, default="", placeholder=None):
+        return None
+
+    async def display(self, title, body):
+        return None
+
+
+@pytest.fixture
+def copy_env(tmp_path, monkeypatch):
+    """Clipboard succeeds by default; copy-dir redirected into tmp; config isolated."""
+    monkeypatch.setattr(cc, "_set_clipboard", lambda text: True)
+    copy_dir = tmp_path / "copydir"
+    monkeypatch.setattr(cc, "_copy_dir", lambda: copy_dir)
+    monkeypatch.setattr(cfg, "GLOBAL_CONFIG_FILE", tmp_path / "config.json")
+    monkeypatch.setattr(cfg, "_default_manager", cfg.ConfigManager(cwd=tmp_path))
+    return SimpleNamespace(tmp=tmp_path, copy_dir=copy_dir, monkeypatch=monkeypatch)
+
+
+def _msg(role, content):
+    return {"role": role, "content": content}
+
+
+def _ctx(tmp_path, messages, *, ui=None):
+    conversation = SimpleNamespace(messages=messages)
+    return create_command_context(
+        workspace_root=tmp_path, cwd=tmp_path, conversation=conversation, ui=ui
+    )
+
+
+# --------------------------------------------------------------------------- #
+# A. Helpers
+# --------------------------------------------------------------------------- #
+def test_collect_recent_assistant_texts_order_skip_cap():
+    messages = [_msg("user", "q1"), _msg("assistant", "a1"), _msg("system", "s")]
+    messages += [_msg("assistant", f"a{i}") for i in range(2, 30)]
+    texts = collect_recent_assistant_texts(messages)
+    assert len(texts) == 20  # MAX_LOOKBACK cap
+    assert texts[0] == "a29"  # newest first
+    assert "q1" not in texts and "s" not in texts
+
+
+def test_collect_joins_text_parts_and_skips_empty():
+    messages = [
+        _msg("assistant", [{"type": "text", "text": "part1"}, {"type": "text", "text": "part2"}]),
+        _msg("assistant", [{"type": "tool_use", "name": "X"}]),  # tool-only -> skipped
+    ]
+    texts = collect_recent_assistant_texts(messages)
+    assert texts == ["part1\n\npart2"]
+
+
+def test_strip_prompt_xml_tags():
+    s = "before\n<commit_analysis>secret</commit_analysis>\nafter"
+    # The TS regex consumes the tag block AND its trailing newline (`\n?`).
+    assert _strip_prompt_xml_tags(s) == "before\nafter"
+    assert _strip_prompt_xml_tags("<context>a\nb</context>x").strip() == "x"
+
+
+def test_extract_code_blocks():
+    md = "intro\n```python\nprint(1)\nprint(2)\n```\nmid\n```\nplain\n```\n```js"
+    blocks = _extract_code_blocks(md)
+    assert blocks == [
+        CodeBlock(code="print(1)\nprint(2)", lang="python"),
+        CodeBlock(code="plain", lang=None),
+    ]  # the unclosed ```js fence yields no block (documented divergence vs marked)
+    assert _extract_code_blocks("no fences here") == []
+
+
+def test_extract_code_blocks_lang_is_first_info_token():
+    md = "```python title=x.py linenums\ncode\n```"
+    assert _extract_code_blocks(md) == [CodeBlock(code="code", lang="python")]
+
+
+def test_extract_code_blocks_close_fence_carries_no_info_string():
+    # CommonMark: a ```js line INSIDE an open fence is content, not a close.
+    md = "```md\nexample:\n```js\ncode\n```"
+    assert _extract_code_blocks(md) == [
+        CodeBlock(code="example:\n```js\ncode", lang="md")
+    ]
+
+
+async def test_copy_or_write_file_fail_branches(copy_env):
+    def _boom(text, filename):
+        raise OSError("disk full")
+
+    copy_env.monkeypatch.setattr(cc, "_write_to_file", _boom)
+    out = await COPY_COMMAND.run(
+        "", _ctx(copy_env.tmp, [_msg("assistant", "hi")], ui=NullUIHost())
+    )
+    # clipboard ok + file-fail -> first line ONLY (TS catch behavior).
+    assert out.message == "Copied to clipboard (2 characters, 1 lines)"
+
+    copy_env.monkeypatch.setattr(cc, "_set_clipboard", lambda text: False)
+    out = await COPY_COMMAND.run(
+        "", _ctx(copy_env.tmp, [_msg("assistant", "hi")], ui=NullUIHost())
+    )
+    assert out.message == "Failed to copy: disk full"
+
+
+@pytest.mark.parametrize(
+    "lang,ext",
+    [
+        ("python", ".python"),
+        ("tsx", ".tsx"),
+        ("../../etc/passwd", ".etcpasswd"),  # traversal sanitized
+        ("plaintext", ".txt"),
+        (None, ".txt"),
+        ("!!!", ".txt"),
+    ],
+)
+def test_file_extension(lang, ext):
+    assert _file_extension(lang) == ext
+
+
+def test_truncate_line():
+    assert _truncate_line("short", 60) == "short"
+    assert _truncate_line("x" * 80, 60) == "x" * 59 + "…"
+    assert _truncate_line("first\nsecond", 60) == "first"
+
+
+# --------------------------------------------------------------------------- #
+# B. Direct path (no code blocks) — the headless keystone
+# --------------------------------------------------------------------------- #
+async def test_direct_copy_clipboard_ok(copy_env):
+    out = await COPY_COMMAND.run(
+        "", _ctx(copy_env.tmp, [_msg("assistant", "hello world")], ui=NullUIHost())
+    )
+    assert isinstance(out, InteractiveOutcome)
+    path = copy_env.copy_dir / "response.md"
+    assert out.message == (
+        f"Copied to clipboard (11 characters, 1 lines)\nAlso written to {path}"
+    )
+    assert out.display == "user"
+    assert path.read_text() == "hello world"
+
+
+async def test_direct_copy_clipboard_fail_is_honest(copy_env):
+    copy_env.monkeypatch.setattr(cc, "_set_clipboard", lambda text: False)
+    out = await COPY_COMMAND.run(
+        "", _ctx(copy_env.tmp, [_msg("assistant", "hi")], ui=NullUIHost())
+    )
+    path = copy_env.copy_dir / "response.md"
+    assert out.message == f"Written to {path} (2 characters, 1 lines)"
+
+
+# --------------------------------------------------------------------------- #
+# C. /copy N
+# --------------------------------------------------------------------------- #
+async def test_copy_n_picks_nth_latest(copy_env):
+    msgs = [_msg("assistant", "older"), _msg("assistant", "newest")]
+    out = await COPY_COMMAND.run("2", _ctx(copy_env.tmp, msgs, ui=NullUIHost()))
+    assert out.message.startswith("Copied to clipboard")
+    assert (copy_env.copy_dir / "response.md").read_text() == "older"
+
+
+@pytest.mark.parametrize("bad", ["x", "0", "-1", "1.5"])
+async def test_copy_n_invalid(copy_env, bad):
+    out = await COPY_COMMAND.run(
+        bad, _ctx(copy_env.tmp, [_msg("assistant", "a")], ui=NullUIHost())
+    )
+    assert out.message == (
+        f"Usage: /copy [N] where N is 1 (latest), 2, 3, … Got: {bad}"
+    )
+
+
+async def test_copy_n_too_large_singular(copy_env):
+    out = await COPY_COMMAND.run(
+        "5", _ctx(copy_env.tmp, [_msg("assistant", "a")], ui=NullUIHost())
+    )
+    assert out.message == "Only 1 assistant message available to copy"
+
+
+async def test_copy_n_too_large_plural(copy_env):
+    msgs = [_msg("assistant", "a"), _msg("assistant", "b")]
+    out = await COPY_COMMAND.run("5", _ctx(copy_env.tmp, msgs, ui=NullUIHost()))
+    assert out.message == "Only 2 assistant messages available to copy"
+
+
+async def test_no_assistant_message(copy_env):
+    out = await COPY_COMMAND.run("", _ctx(copy_env.tmp, [_msg("user", "q")], ui=NullUIHost()))
+    assert out.message == "No assistant message to copy"
+    assert out.display == "user"
+
+
+# --------------------------------------------------------------------------- #
+# D. copyFullResponse skips the picker
+# --------------------------------------------------------------------------- #
+_BLOCKY = "text\n```python\ncode_here\n```\ntail"
+
+
+async def test_copy_full_response_pref_skips_picker(copy_env):
+    cfg._get_default_manager().set_global("copyFullResponse", True)
+    ui = FakeUIHost(pick="full")
+    out = await COPY_COMMAND.run("", _ctx(copy_env.tmp, [_msg("assistant", _BLOCKY)], ui=ui))
+    assert ui.select_calls == []  # no picker
+    assert out.message.startswith("Copied to clipboard")
+    assert (copy_env.copy_dir / "response.md").read_text() == _BLOCKY
+
+
+# --------------------------------------------------------------------------- #
+# E. Picker
+# --------------------------------------------------------------------------- #
+async def test_picker_options_shape(copy_env):
+    ui = FakeUIHost(pick="full")
+    await COPY_COMMAND.run("", _ctx(copy_env.tmp, [_msg("assistant", _BLOCKY)], ui=ui))
+    call = ui.select_calls[0]
+    assert call["values"] == ["full", "0", "always"]
+    assert call["labels"][0] == "Full response"
+    # Full desc format: "{chars} chars, {lines} lines" over the whole message text.
+    assert call["descriptions"][0] == f"{len(_BLOCKY)} chars, {_BLOCKY.count(chr(10)) + 1} lines"
+    assert call["labels"][1] == "code_here"
+    assert call["descriptions"][1] == "python"  # 1-line block: no "N lines" part
+    assert call["labels"][2] == "Always copy full response"
+    assert call["descriptions"][2] == "Skip this picker in the future (revert via /config)"
+
+
+async def test_picker_block_description_matrix(copy_env):
+    # All four TS desc shapes: lang+multi, no-lang+multi, lang+1-line, no-lang+1-line (None).
+    md = (
+        "```python\na\nb\nc\n```\n"  # python, 3 lines
+        "```\nx\ny\nz\n```\n"  # 3 lines
+        "```js\none\n```\n"  # js
+        "```\nlone\n```"  # -> description None (TS `|| undefined`)
+    )
+    ui = FakeUIHost(pick="full")
+    await COPY_COMMAND.run("", _ctx(copy_env.tmp, [_msg("assistant", md)], ui=ui))
+    descs = ui.select_calls[0]["descriptions"][1:-1]  # block options only
+    assert descs == ["python, 3 lines", "3 lines", "js", None]
+
+
+async def test_picker_block_copy(copy_env):
+    ui = FakeUIHost(pick="0")
+    out = await COPY_COMMAND.run("", _ctx(copy_env.tmp, [_msg("assistant", _BLOCKY)], ui=ui))
+    assert out.message.startswith("Copied to clipboard")
+    assert (copy_env.copy_dir / "copy.python").read_text() == "code_here"
+
+
+async def test_picker_always_persists_pref(copy_env):
+    ui = FakeUIHost(pick="always")
+    out = await COPY_COMMAND.run("", _ctx(copy_env.tmp, [_msg("assistant", _BLOCKY)], ui=ui))
+    assert out.message.endswith(
+        "\nPreference saved. Use /config to change copyFullResponse"
+    )
+    assert cfg.ConfigManager(cwd=copy_env.tmp).get("copyFullResponse") is True
+
+
+async def test_picker_cancel(copy_env):
+    ui = FakeUIHost(pick=None)
+    out = await COPY_COMMAND.run("", _ctx(copy_env.tmp, [_msg("assistant", _BLOCKY)], ui=ui))
+    assert out.message == "Copy cancelled"
+    assert out.display == "system"
+
+
+# --------------------------------------------------------------------------- #
+# F. Engine end-to-end
+# --------------------------------------------------------------------------- #
+async def test_engine_picker_errors_on_null_surface(copy_env):
+    reg = CommandRegistry()
+    reg.register(COPY_COMMAND)
+    ctx = _ctx(copy_env.tmp, [_msg("assistant", _BLOCKY)])  # ui=None -> NullUIHost
+    eng = CommandEngine(registry=reg, workspace_root=copy_env.tmp, context=ctx)
+    result = await eng.execute("/copy")
+    assert result.success is False
+    assert "interactive surface" in result.error
+
+
+async def test_engine_direct_path_succeeds_headless(copy_env):
+    reg = CommandRegistry()
+    reg.register(COPY_COMMAND)
+    ctx = _ctx(copy_env.tmp, [_msg("assistant", "plain text")])
+    eng = CommandEngine(registry=reg, workspace_root=copy_env.tmp, context=ctx)
+    result = await eng.execute("/copy")
+    assert result.success is True
+    assert result.text.startswith("Copied to clipboard")
+
+
+# --------------------------------------------------------------------------- #
+# G. Registration + metadata + safety + dispatch
+# --------------------------------------------------------------------------- #
+def test_registered_and_metadata():
+    assert "copy" in {c.name for c in get_builtin_commands()}
+    assert isinstance(COPY_COMMAND, CopyCommand)
+    assert COPY_COMMAND.description == (
+        "Copy Claude's last response to clipboard (or /copy N for the Nth-latest)"
+    )
+    assert COPY_COMMAND.command_type == CommandType.INTERACTIVE
+
+
+def test_safety_and_dispatch():
+    assert is_bridge_safe_command(COPY_COMMAND) is False  # INTERACTIVE by type
+    assert "copy" in REMOTE_SAFE_COMMANDS  # the orthogonal name-based remote filter
+    from src.tui.commands import dispatch_local_command
+
+    res = dispatch_local_command(
+        "/copy", session=None, workspace_root=Path("."), tool_registry=None
+    )
+    assert res.handled is False
+    assert res.open_dialog is None


### PR DESCRIPTION
## Summary
- Port TS local-jsx `/copy` (`typescript/src/commands/copy/`) as an `InteractiveCommand`: copies the latest (or `/copy N`) assistant response — or a fenced code block via a `select` picker — to the clipboard, always writing a `{tmpdir}/clawcodex/` file fallback.
- **Headless keystone:** the direct path (no code blocks / `copyFullResponse` opt-out) never touches `ctx.ui`. **Both content shapes handled** (`str | list` — the REPL appends plain strings; a literal port of TS's Array-guard would have shipped a dead command; plan-critic M1, tests use plain-string as the primary case).
- Message strings **byte-exact** (usage with U+2026, singular/plural, picker desc shapes incl. the `|| undefined`→`None` collapse, always-persist guard + suffix, file-fail→first-line-only). **Honest divergence:** subprocess clipboard; a failed copy reports `Written to {path} (…)` rather than TS's fire-and-forget OSC52 claim.
- Fence parser: first-info-token lang; closing fence may not carry an info string (CommonMark); unclosed fence yields no block — documented vs marked.

## Test plan
- [x] `tests/test_copy_command.py` (34): helpers (collect order/skip/cap/join, strip-tags, fence matrix incl. info-string close + unclosed, file-extension sanitize, truncate), direct path (clipboard ok/fail/file-fail/both-fail), `/copy N` (valid/invalid/too-large sing+plural), `copyFullResponse` skip, picker (options matrix, block, always-persist, cancel), engine (picker null-surface error / direct headless success), registration + REMOTE_SAFE membership + bridge-by-type + fall-through.
- [x] Full suite: **7258 passed**, only the 6 known baseline failures. (A transient 7th was diagnosed as a **pre-existing flake** — `test_prompt_assembly` byte-identity vs the hh:mm:ss env timestamp, ch17 `4b2f469`; reproduced via second-boundary straddle; unrelated to this PR.)
- [x] Plan + implementation critic-approved (byte-level string verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)