### PR TITLE
commands: port /vim editor-mode toggle + seed the TUI (Phase 14)

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -84,6 +84,7 @@ from .tasks_command import TASKS_COMMAND, TasksCommand
 from .diff_command import DIFF_COMMAND, DiffCommand
 from .release_notes_command import RELEASE_NOTES_COMMAND
 from .copy_command import COPY_COMMAND, CopyCommand
+from .vim_command import VIM_COMMAND
 from .types import (
     Command,
     CommandAvailability,
@@ -176,6 +177,7 @@ __all__ = [
     "RELEASE_NOTES_COMMAND",
     "COPY_COMMAND",
     "CopyCommand",
+    "VIM_COMMAND",
     "get_builtin_commands",
     "register_builtin_commands",
     # Moved-to-plugin factory + shell-at-prompt-build

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -37,6 +37,7 @@ from .tasks_command import TASKS_COMMAND
 from .diff_command import DIFF_COMMAND
 from .release_notes_command import RELEASE_NOTES_COMMAND
 from .copy_command import COPY_COMMAND
+from .vim_command import VIM_COMMAND
 from .types import Command, CommandType, CompactionResult, LocalCommand, PromptCommand
 
 
@@ -1252,6 +1253,7 @@ def get_builtin_commands() -> list[Command]:
         DIFF_COMMAND,
         RELEASE_NOTES_COMMAND,
         COPY_COMMAND,
+        VIM_COMMAND,
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)

--- a/src/command_system/vim_command.py
+++ b/src/command_system/vim_command.py
@@ -1,0 +1,61 @@
+"""vim — ``/vim`` editor-mode toggle (port of TS ``type:'local'``).
+
+Port of ``typescript/src/commands/vim/``. Toggles ``editorMode`` between ``"vim"`` and
+``"normal"`` in the global config (the TS ``saveGlobalConfig`` channel; legacy
+``"emacs"`` reads as ``"normal"``) and reports the new mode verbatim.
+
+**Functional half:** the TUI seeds ``PromptInput(vim_mode=...)`` from this config key at
+construction (``src/tui/screens/repl.py``) — so the persisted mode genuinely enables the
+existing vim subsystem (``VimState`` et al.) on the next TUI launch. Divergences:
+TS applies the toggle live (Ink re-reads config); the registry command has no widget
+handle and the TUI has no non-dialog intercept mechanism, so Python applies on the
+**next TUI launch** (``PromptInput.set_vim_mode`` exists for a future live intercept).
+The prompt-toolkit REPL has no vim editing implementation — the mode takes effect in
+the TUI.
+"""
+from __future__ import annotations
+
+from .types import CommandContext, LocalCommand, LocalCommandResult
+
+
+def initial_vim_mode() -> bool:
+    """Best-effort seed for ``PromptInput(vim_mode=...)``: True iff the persisted
+    ``editorMode`` is ``"vim"`` (False on unset/normal/legacy-emacs/any error)."""
+    try:
+        from src.config import load_config
+
+        return load_config().get("editorMode") == "vim"
+    except Exception:
+        return False
+
+
+def vim_command_call(args: str, context: CommandContext) -> LocalCommandResult:
+    from src.config import _get_default_manager, load_config
+
+    current = load_config().get("editorMode") or "normal"
+    if current == "emacs":  # TS back-compat: treat 'emacs' as 'normal'
+        current = "normal"
+    new_mode = "vim" if current == "normal" else "normal"
+    _get_default_manager().set_global("editorMode", new_mode)
+
+    if new_mode == "vim":
+        suffix = "Use Escape key to toggle between INSERT and NORMAL modes."
+    else:
+        suffix = "Using standard (readline) keyboard bindings."
+    # Divergence from TS (which applies the toggle live): the trailing note keeps the
+    # mid-session instruction honest — the seed is read at PromptInput construction.
+    return LocalCommandResult(
+        type="text",
+        value=f"Editor mode set to {new_mode}. {suffix} Takes effect on next TUI launch.",
+    )
+
+
+VIM_COMMAND = LocalCommand(
+    name="vim",
+    description="Toggle between Vim and Normal editing modes",  # verbatim TS index.ts
+    supports_non_interactive=False,  # verbatim TS index.ts
+)
+VIM_COMMAND.set_call(vim_command_call)
+
+
+__all__ = ["VIM_COMMAND", "vim_command_call", "initial_vim_mode"]

--- a/src/tui/screens/repl.py
+++ b/src/tui/screens/repl.py
@@ -95,9 +95,14 @@ class REPLScreen(Screen):
             workspace_root=self._workspace_root,
             provider_instance=provider_instance,
         )
+        # /vim: seed the editor mode from the persisted editorMode config key
+        # (best-effort; the command toggles it, effective on next launch).
+        from src.command_system.vim_command import initial_vim_mode
+
         self.prompt_input = PromptInput(
             words_provider=words_provider,
             suggestions_provider=suggestions_provider,
+            vim_mode=initial_vim_mode(),
         )
         # ARIA live region — stays height: 1 and only announces the
         # most recent status change. Mounted just above the status

--- a/tests/test_vim_command.py
+++ b/tests/test_vim_command.py
@@ -1,0 +1,150 @@
+"""Tests for the ``/vim`` command (Phase 14 — port of TS ``type:'local'``).
+
+Toggles the persisted ``editorMode`` (vim ↔ normal, legacy emacs reads as normal) and
+the TUI seeds ``PromptInput(vim_mode=...)`` from it at construction — the functional
+half that keeps this from being effort-style inert.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+import src.config as cfg
+from src.command_system import (
+    VIM_COMMAND,
+    create_command_context,
+    get_builtin_commands,
+    is_bridge_safe_command,
+)
+from src.command_system.engine import CommandEngine
+from src.command_system.registry import CommandRegistry
+from src.command_system.safe_commands import (
+    BRIDGE_SAFE_COMMANDS,
+    REMOTE_SAFE_COMMANDS,
+)
+from src.command_system.types import CommandType
+from src.command_system.vim_command import initial_vim_mode
+
+_VIM_MSG = (
+    "Editor mode set to vim. Use Escape key to toggle between INSERT and NORMAL "
+    "modes. Takes effect on next TUI launch."
+)
+_NORMAL_MSG = (
+    "Editor mode set to normal. Using standard (readline) keyboard bindings. "
+    "Takes effect on next TUI launch."
+)
+
+
+@pytest.fixture
+def isolated_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(cfg, "GLOBAL_CONFIG_FILE", tmp_path / "config.json")
+    monkeypatch.setattr(cfg, "_default_manager", cfg.ConfigManager(cwd=tmp_path))
+    return tmp_path
+
+
+def _ctx(tmp_path: Path):
+    return create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+
+
+def _persisted(tmp_path: Path):
+    return cfg.ConfigManager(cwd=tmp_path).get("editorMode")
+
+
+# --------------------------------------------------------------------------- #
+# A. Toggle matrix (messages verbatim TS vim.ts)
+# --------------------------------------------------------------------------- #
+async def test_unset_toggles_to_vim(isolated_config):
+    result = await VIM_COMMAND.call("", _ctx(isolated_config))
+    assert result.type == "text"
+    assert result.value == _VIM_MSG
+    assert _persisted(isolated_config) == "vim"
+
+
+async def test_vim_toggles_to_normal(isolated_config):
+    cfg._get_default_manager().set_global("editorMode", "vim")
+    result = await VIM_COMMAND.call("", _ctx(isolated_config))
+    assert result.value == _NORMAL_MSG
+    assert _persisted(isolated_config) == "normal"
+
+
+async def test_normal_toggles_to_vim(isolated_config):
+    cfg._get_default_manager().set_global("editorMode", "normal")
+    result = await VIM_COMMAND.call("", _ctx(isolated_config))
+    assert result.value == _VIM_MSG
+    assert _persisted(isolated_config) == "vim"
+
+
+async def test_legacy_emacs_reads_as_normal_toggles_to_vim(isolated_config):
+    cfg._get_default_manager().set_global("editorMode", "emacs")
+    result = await VIM_COMMAND.call("", _ctx(isolated_config))
+    assert result.value == _VIM_MSG
+    assert _persisted(isolated_config) == "vim"
+
+
+# --------------------------------------------------------------------------- #
+# B. The consumer seed (the functional half)
+# --------------------------------------------------------------------------- #
+def test_initial_vim_mode(isolated_config):
+    assert initial_vim_mode() is False  # unset
+    cfg._get_default_manager().set_global("editorMode", "vim")
+    assert initial_vim_mode() is True
+    cfg._get_default_manager().set_global("editorMode", "normal")
+    assert initial_vim_mode() is False
+    cfg._get_default_manager().set_global("editorMode", "emacs")
+    assert initial_vim_mode() is False
+
+
+def test_initial_vim_mode_safe_on_error(monkeypatch):
+    monkeypatch.setattr(
+        "src.config.load_config", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    assert initial_vim_mode() is False
+
+
+def test_repl_screen_seeds_vim_mode():
+    # Wiring guard: the sole PromptInput construction site passes vim_mode=.
+    from src.tui.screens import repl as repl_mod
+
+    src_text = inspect.getsource(repl_mod)
+    assert "vim_mode=initial_vim_mode()" in src_text
+
+
+# --------------------------------------------------------------------------- #
+# C. Registration + metadata + safety + dispatch
+# --------------------------------------------------------------------------- #
+def test_registered_and_metadata():
+    assert "vim" in {c.name for c in get_builtin_commands()}
+    assert VIM_COMMAND.name == "vim"
+    assert VIM_COMMAND.description == "Toggle between Vim and Normal editing modes"
+    assert VIM_COMMAND.command_type == CommandType.LOCAL
+    assert VIM_COMMAND.supports_non_interactive is False
+
+
+def test_safety_and_dispatch():
+    assert "vim" in REMOTE_SAFE_COMMANDS  # name-based remote filter (matches TS)
+    assert "vim" not in BRIDGE_SAFE_COMMANDS
+    assert is_bridge_safe_command(VIM_COMMAND) is False  # LOCAL, not allowlisted
+    from src.tui.commands import dispatch_local_command
+
+    res = dispatch_local_command(
+        "/vim", session=None, workspace_root=Path("."), tool_registry=None
+    )
+    assert res.handled is False
+
+
+# --------------------------------------------------------------------------- #
+# D. Engine end-to-end (headless)
+# --------------------------------------------------------------------------- #
+async def test_engine_toggles_headless(isolated_config):
+    reg = CommandRegistry()
+    reg.register(VIM_COMMAND)
+    ctx = _ctx(isolated_config)
+    eng = CommandEngine(registry=reg, workspace_root=isolated_config, context=ctx)
+
+    result = await eng.execute("/vim")
+
+    assert result.success is True
+    assert result.text == _VIM_MSG
+    assert _persisted(isolated_config) == "vim"


### PR DESCRIPTION
## Summary
- Port TS `type:'local'` `/vim` as a `LocalCommand`: toggles `editorMode` vim↔normal in the global config (legacy `emacs` reads as `normal`, TS back-compat), persisted via `set_global`.
- **The functional half:** Python's vim subsystem existed but was **unwired** — `PromptInput(vim_mode=)` defaulted False at its sole construction site. `src/tui/screens/repl.py` now seeds `vim_mode=initial_vim_mode()` from the persisted `editorMode`, so the toggle genuinely enables vim on the next TUI launch (the effort-inertness guard).
- **Divergence (critic-recommended):** messages append `" Takes effect on next TUI launch."` — TS applies the toggle live; the registry command has no widget handle, so the TS-verbatim "Use Escape key…" instruction would be premature mid-session. `PromptInput.set_vim_mode` is ready for a future live intercept.
- `vim` in `REMOTE_SAFE_COMMANDS` (both codebases), not in BRIDGE_SAFE (LOCAL → bridge-blocked, matches TS); dispatch falls through.

## Test plan
- [x] `tests/test_vim_command.py` (10): toggle matrix (unset/vim/normal/emacs, persisted value asserted each direction), seed helper (+error-safe), `vim_mode=initial_vim_mode()` wiring guard, registration/metadata/safety/dispatch, engine headless. Existing vim-state suite green.
- [x] Full suite: **7270 passed**, only the 6 known baseline failures.
- [x] Plan + implementation critic-approved (the message suffix was the critic's own recommended fix, pre-authorized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)