### PR TITLE
commands: port /memory memory-file picker (Phase 15, no-spawn)

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -85,6 +85,7 @@ from .diff_command import DIFF_COMMAND, DiffCommand
 from .release_notes_command import RELEASE_NOTES_COMMAND
 from .copy_command import COPY_COMMAND, CopyCommand
 from .vim_command import VIM_COMMAND
+from .memory_command import MEMORY_COMMAND, MemoryCommand
 from .types import (
     Command,
     CommandAvailability,
@@ -178,6 +179,8 @@ __all__ = [
     "COPY_COMMAND",
     "CopyCommand",
     "VIM_COMMAND",
+    "MEMORY_COMMAND",
+    "MemoryCommand",
     "get_builtin_commands",
     "register_builtin_commands",
     # Moved-to-plugin factory + shell-at-prompt-build

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -38,6 +38,7 @@ from .diff_command import DIFF_COMMAND
 from .release_notes_command import RELEASE_NOTES_COMMAND
 from .copy_command import COPY_COMMAND
 from .vim_command import VIM_COMMAND
+from .memory_command import MEMORY_COMMAND
 from .types import Command, CommandType, CompactionResult, LocalCommand, PromptCommand
 
 
@@ -1254,6 +1255,7 @@ def get_builtin_commands() -> list[Command]:
         RELEASE_NOTES_COMMAND,
         COPY_COMMAND,
         VIM_COMMAND,
+        MEMORY_COMMAND,
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)

--- a/src/command_system/memory_command.py
+++ b/src/command_system/memory_command.py
@@ -1,0 +1,182 @@
+"""memory — ``/memory`` memory-file picker (port of TS local-jsx, degraded no-spawn).
+
+Port of ``typescript/src/commands/memory/`` + the core of ``MemoryFileSelector``.
+Presents the CLAUDE.md memory hierarchy — the synthetic **User memory**
+(``~/.claude/CLAUDE.md``) and **Project memory** (nearest loaded ancestor
+``CLAUDE.md``, falling back to ``{cwd}/CLAUDE.md``) candidates, differentiated via
+option *descriptions* (the TS selector's real channel), plus the existing files
+enumerated by the ``claude_md`` port — ensure-creates the selected file
+(exclusive-create; existing content preserved), and reports its path with an editor
+hint.
+
+Deliberate divergences (documented for parity review):
+  * **No ``$EDITOR`` spawn.** TS ``editFileInEditor`` suspends the Ink app; Python has
+    no suspend-aware helper, and spawning an editor inside the Textual TUI corrupts the
+    screen. The success message is adapted accordingly (an "Opened … in your editor"
+    claim would be false — the ``/copy`` clipboard standard); the cancel/error strings
+    stay TS-verbatim.
+  * **Folder-open extras dropped** (auto-memory / team / agent folders — need the
+    open-folder mechanism and those subsystems).
+  * Rules files are listed flat (the ``select`` primitive has flat labels; TS indents).
+
+Picker-only (TS ignores args) → no headless keystone; ``NullUIHost`` gets a clean
+engine error.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from .types import (
+    CommandContext,
+    InteractiveCommand,
+    InteractiveOutcome,
+    UIOption,
+)
+
+
+def _display_path(path: str, cwd: str) -> str:
+    """``~``-abbreviated, else cwd-relative, else absolute (the TS
+    ``getRelativeMemoryPath`` shape)."""
+    home = str(Path.home())
+    real = os.path.realpath(path)
+    try:
+        rel = os.path.relpath(real, os.path.realpath(cwd))
+        if not rel.startswith(".."):
+            return rel
+    except ValueError:
+        pass
+    if real.startswith(home + os.sep) or real == home:
+        return "~" + real[len(home):]
+    return real
+
+
+def _resolve_project_memory_path(files: list, cwd: str) -> str:
+    """TS ``getProjectMemoryPathForSelector``: prefer the **nearest** already-loaded
+    root-level Project CLAUDE.md (TS walks cwd upward; ``get_memory_files`` enumerates
+    root→cwd, so iterate reversed — last match = nearest); fall back to
+    ``{cwd}/CLAUDE.md`` only when none exists — so a repo subdirectory still points at
+    the real project memory."""
+    for info in reversed(files):
+        if (
+            getattr(info, "parent", None) is None
+            and getattr(info, "type", None) == "Project"
+            and os.path.basename(info.path) == "CLAUDE.md"
+        ):
+            return info.path
+    return str(Path(cwd) / "CLAUDE.md")
+
+
+async def _build_options(cwd: str) -> list[UIOption]:
+    from src.context_system.claude_md import (
+        clear_memory_file_caches,
+        get_memory_files,
+    )
+
+    try:
+        clear_memory_file_caches()  # TS primes fresh per open (memory.tsx:86-87)
+        files = list(await get_memory_files(cwd=cwd))
+    except Exception:
+        files = []
+
+    home = Path.home()
+    user_path = str(home / ".claude" / "CLAUDE.md")
+    project_path = _resolve_project_memory_path(files, cwd)
+
+    # Git-aware project description (TS: `${isGit ? 'Checked in at' : 'Saved in'} ./…`).
+    try:
+        from src.utils.git import get_repo_root
+
+        in_git = get_repo_root(cwd) is not None
+    except Exception:
+        in_git = False
+    project_desc = (
+        f"{'Checked in at' if in_git else 'Saved in'} ./{os.path.basename(project_path)}"
+    )
+
+    # NOTE: TS's `" (new)"` suffix is DEAD CODE (only interpolated in the depth>0
+    # branch, where exists is always true) — the real differentiation is the
+    # description column, ported here. Labels stay plain.
+    options: list[UIOption] = [
+        UIOption(
+            value=user_path,
+            label="User memory",
+            description="Saved in ~/.claude/CLAUDE.md",  # verbatim TS (hardcoded tilde)
+        ),
+        UIOption(value=project_path, label="Project memory", description=project_desc),
+    ]
+    seen: set[str] = {os.path.realpath(user_path), os.path.realpath(project_path)}
+
+    # Remaining enumerated files (managed/user/project + rules), deduped by realpath
+    # (stronger than TS's exact-path dedup — deliberate). Parented files were
+    # @-imported (TS desc); others get no description.
+    for info in files:
+        real = os.path.realpath(info.path)
+        if real in seen:
+            continue
+        seen.add(real)
+        options.append(
+            UIOption(
+                value=info.path,
+                label=_display_path(info.path, cwd),
+                description="@-imported" if getattr(info, "parent", None) else None,
+            )
+        )
+    return options
+
+
+def _ensure_file(path: str) -> None:
+    """TS parity: mkdir the claude home when the path is under it, then
+    exclusive-create an empty file (existing content preserved)."""
+    claude_home = str(Path.home() / ".claude")
+    if path.startswith(claude_home):
+        Path(claude_home).mkdir(parents=True, exist_ok=True)
+    try:
+        with open(path, "x", encoding="utf-8"):
+            pass
+    except FileExistsError:
+        pass
+
+
+_EDITOR_HINT = (
+    "> To choose an editor, set the $EDITOR or $VISUAL environment variable."
+)
+
+
+@dataclass(frozen=True)
+class MemoryCommand(InteractiveCommand):
+    """Pick a memory file, ensure it exists, and report its path."""
+
+    async def run(self, args: str, context: CommandContext) -> InteractiveOutcome:
+        cwd = str(context.cwd)
+        options = await _build_options(cwd)
+        picked = await context.ui.select("Memory", options)
+        if picked is None:
+            # Verbatim TS (memory.tsx:65).
+            return InteractiveOutcome(
+                message="Cancelled memory editing", display="system"
+            )
+        try:
+            _ensure_file(picked)
+        except Exception as exc:
+            # Verbatim TS catch shape (memory.tsx:61) — onDone without options.
+            return InteractiveOutcome(
+                message=f"Error opening memory file: {exc}", display="user"
+            )
+        return InteractiveOutcome(
+            message=(
+                f"Memory file at {_display_path(picked, cwd)}. "
+                f"Open it in your editor.\n\n{_EDITOR_HINT}"
+            ),
+            display="system",  # TS uses display:'system' for the success line
+        )
+
+
+MEMORY_COMMAND = MemoryCommand(
+    name="memory",
+    description="Edit Claude memory files",  # verbatim TS index.ts
+)
+
+
+__all__ = ["MEMORY_COMMAND", "MemoryCommand"]

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -1,0 +1,244 @@
+"""Tests for the ``/memory`` command (Phase 15 — port of TS local-jsx, no-spawn)."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from src.command_system import (
+    MEMORY_COMMAND,
+    MemoryCommand,
+    create_command_context,
+    get_builtin_commands,
+    is_bridge_safe_command,
+)
+from src.command_system.engine import CommandEngine
+from src.command_system.memory_command import _display_path
+from src.command_system.registry import CommandRegistry
+from src.command_system.types import CommandType, InteractiveOutcome, NullUIHost
+
+
+class FakeUIHost:
+    def __init__(self, *, pick=None):
+        self._pick = pick
+        self.select_calls: list[dict] = []
+
+    async def select(self, title, options, *, current=None):
+        self.select_calls.append(
+            {
+                "title": title,
+                "values": [o.value for o in options],
+                "labels": [o.label for o in options],
+                "descriptions": [o.description for o in options],
+            }
+        )
+        return self._pick
+
+    async def prompt_text(self, title, *, default="", placeholder=None):
+        return None
+
+    async def display(self, title, body):
+        return None
+
+
+@pytest.fixture
+def mem_env(tmp_path, monkeypatch):
+    """Fake HOME (so ~/.claude lives in tmp) + empty get_memory_files."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+    async def _no_files(cwd=None, **kwargs):
+        return []
+
+    monkeypatch.setattr(
+        "src.context_system.claude_md.get_memory_files", _no_files
+    )
+    cwd = tmp_path / "proj"
+    cwd.mkdir()
+    return home, cwd
+
+
+def _ctx(cwd: Path, *, ui=None):
+    return create_command_context(workspace_root=cwd, cwd=cwd, ui=ui)
+
+
+class _Info:
+    def __init__(self, path, type="Project", parent=None):
+        self.path = path
+        self.type = type
+        self.parent = parent
+
+
+# --------------------------------------------------------------------------- #
+# A. Options (plain labels; TS differentiates via DESCRIPTIONS — " (new)" is
+#    dead code in TS and is not ported)
+# --------------------------------------------------------------------------- #
+async def test_options_synthetic_candidates_with_descriptions(mem_env):
+    home, cwd = mem_env  # no git repo, no enumerated files
+    ui = FakeUIHost(pick=None)
+    await MEMORY_COMMAND.run("", _ctx(cwd, ui=ui))
+    call = ui.select_calls[0]
+    assert call["labels"][0] == "User memory"
+    assert call["labels"][1] == "Project memory"
+    assert call["descriptions"][0] == "Saved in ~/.claude/CLAUDE.md"  # verbatim TS
+    assert call["descriptions"][1] == "Saved in ./CLAUDE.md"  # non-git branch
+    assert call["values"][0] == str(home / ".claude" / "CLAUDE.md")
+    assert call["values"][1] == str(cwd / "CLAUDE.md")  # fallback (no loaded ancestor)
+
+
+async def test_project_memory_resolved_from_ancestor_walk(mem_env, monkeypatch):
+    # From a repo SUBDIRECTORY the Project entry must point at the loaded
+    # root-level CLAUDE.md, not {cwd}/CLAUDE.md (critic M2).
+    home, cwd = mem_env
+    root_claude = cwd / "CLAUDE.md"
+    root_claude.write_text("root project mem")
+    subdir = cwd / "sub"
+    subdir.mkdir()
+
+    async def _files(cwd=None, **kwargs):
+        return [_Info(str(root_claude), type="Project", parent=None)]
+
+    monkeypatch.setattr("src.context_system.claude_md.get_memory_files", _files)
+    ui = FakeUIHost(pick=None)
+    await MEMORY_COMMAND.run("", _ctx(subdir, ui=ui))
+    call = ui.select_calls[0]
+    assert call["values"][1] == str(root_claude)  # ancestor-resolved, not sub/CLAUDE.md
+    assert call["values"].count(str(root_claude)) == 1  # deduped from the enumeration
+    assert "Project memory" in call["labels"]
+
+
+async def test_project_memory_prefers_nearest_ancestor(mem_env, monkeypatch):
+    # Monorepo: /repo/CLAUDE.md + /repo/sub/CLAUDE.md, cwd=/repo/sub/deep ->
+    # the NEAREST loaded ancestor wins (TS walks cwd upward).
+    home, cwd = mem_env
+    (cwd / "CLAUDE.md").write_text("root")
+    sub = cwd / "sub"
+    deep = sub / "deep"
+    deep.mkdir(parents=True)
+    (sub / "CLAUDE.md").write_text("nearer")
+
+    async def _files(cwd=None, **kwargs):
+        return [  # enumeration order is root -> cwd
+            _Info(str(mem_env[1] / "CLAUDE.md"), type="Project", parent=None),
+            _Info(str(sub / "CLAUDE.md"), type="Project", parent=None),
+        ]
+
+    monkeypatch.setattr("src.context_system.claude_md.get_memory_files", _files)
+    ui = FakeUIHost(pick=None)
+    await MEMORY_COMMAND.run("", _ctx(deep, ui=ui))
+    assert ui.select_calls[0]["values"][1] == str(sub / "CLAUDE.md")
+
+
+async def test_project_desc_git_branch(mem_env, monkeypatch):
+    home, cwd = mem_env
+    monkeypatch.setattr("src.utils.git.get_repo_root", lambda *a, **k: str(cwd))
+    ui = FakeUIHost(pick=None)
+    await MEMORY_COMMAND.run("", _ctx(cwd, ui=ui))
+    assert ui.select_calls[0]["descriptions"][1] == "Checked in at ./CLAUDE.md"
+
+
+async def test_options_extra_files_and_imported_desc(mem_env, monkeypatch):
+    home, cwd = mem_env
+
+    async def _files(cwd=None, **kwargs):
+        return [
+            _Info(str(home / "extra.md"), type="User", parent=None),
+            _Info(str(home / "imported.md"), type="User", parent=str(home / "extra.md")),
+        ]
+
+    monkeypatch.setattr("src.context_system.claude_md.get_memory_files", _files)
+    ui = FakeUIHost(pick=None)
+    await MEMORY_COMMAND.run("", _ctx(cwd, ui=ui))
+    call = ui.select_calls[0]
+    i_extra = call["values"].index(str(home / "extra.md"))
+    i_imp = call["values"].index(str(home / "imported.md"))
+    assert call["labels"][i_extra] == "~/extra.md"
+    assert call["descriptions"][i_extra] is None
+    assert call["descriptions"][i_imp] == "@-imported"  # parented -> TS desc
+
+
+# --------------------------------------------------------------------------- #
+# B. Select: ensure-create + preservation + message
+# --------------------------------------------------------------------------- #
+async def test_select_user_memory_creates_dir_and_file(mem_env):
+    home, cwd = mem_env
+    target = str(home / ".claude" / "CLAUDE.md")
+    ui = FakeUIHost(pick=target)
+    out = await MEMORY_COMMAND.run("", _ctx(cwd, ui=ui))
+    assert isinstance(out, InteractiveOutcome)
+    assert (home / ".claude" / "CLAUDE.md").exists()
+    assert out.message.startswith("Memory file at ~/.claude/CLAUDE.md. Open it in your editor.")
+    assert "> To choose an editor, set the $EDITOR or $VISUAL environment variable." in out.message
+    assert out.display == "system"
+
+
+async def test_select_preserves_existing_content(mem_env):
+    home, cwd = mem_env
+    target = cwd / "CLAUDE.md"
+    target.write_text("precious")
+    ui = FakeUIHost(pick=str(target))
+    await MEMORY_COMMAND.run("", _ctx(cwd, ui=ui))
+    assert target.read_text() == "precious"  # exclusive-create swallowed
+
+
+async def test_select_create_failure(mem_env, monkeypatch):
+    home, cwd = mem_env
+    monkeypatch.setattr(
+        "src.command_system.memory_command._ensure_file",
+        lambda path: (_ for _ in ()).throw(OSError("nope")),
+    )
+    ui = FakeUIHost(pick=str(cwd / "CLAUDE.md"))
+    out = await MEMORY_COMMAND.run("", _ctx(cwd, ui=ui))
+    assert out.message == "Error opening memory file: nope"
+    assert out.display == "user"
+
+
+async def test_cancel(mem_env):
+    home, cwd = mem_env
+    ui = FakeUIHost(pick=None)
+    out = await MEMORY_COMMAND.run("", _ctx(cwd, ui=ui))
+    assert out.message == "Cancelled memory editing"  # verbatim TS
+    assert out.display == "system"
+
+
+# --------------------------------------------------------------------------- #
+# C. Display-path helper
+# --------------------------------------------------------------------------- #
+def test_display_path(tmp_path, monkeypatch):
+    home = tmp_path / "h"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    cwd = tmp_path / "w"
+    cwd.mkdir()
+    assert _display_path(str(cwd / "CLAUDE.md"), str(cwd)) == "CLAUDE.md"
+    assert _display_path(str(home / "x.md"), str(cwd)) == "~/x.md"
+
+
+# --------------------------------------------------------------------------- #
+# D. Null surface + registration + safety + dispatch
+# --------------------------------------------------------------------------- #
+async def test_engine_errors_on_null_surface(mem_env):
+    home, cwd = mem_env
+    reg = CommandRegistry()
+    reg.register(MEMORY_COMMAND)
+    ctx = create_command_context(workspace_root=cwd, cwd=cwd)
+    eng = CommandEngine(registry=reg, workspace_root=cwd, context=ctx)
+    result = await eng.execute("/memory")
+    assert result.success is False
+    assert "interactive surface" in result.error
+
+
+def test_registered_metadata_safety_dispatch():
+    assert "memory" in {c.name for c in get_builtin_commands()}
+    assert isinstance(MEMORY_COMMAND, MemoryCommand)
+    assert MEMORY_COMMAND.description == "Edit Claude memory files"
+    assert MEMORY_COMMAND.command_type == CommandType.INTERACTIVE
+    assert is_bridge_safe_command(MEMORY_COMMAND) is False
+    from src.tui.commands import dispatch_local_command
+
+    res = dispatch_local_command(
+        "/memory", session=None, workspace_root=Path("."), tool_registry=None
+    )
+    assert res.handled is False


### PR DESCRIPTION
## Summary
- Port TS local-jsx `/memory` (+ `MemoryFileSelector` core) as an `InteractiveCommand`: picker over the CLAUDE.md hierarchy — synthetic **User/Project memory** candidates differentiated via option **descriptions** (the TS selector's real channel; TS's `" (new)"` suffix is dead code and is not ported — plan-critic M1), plus the existing files from the `claude_md` port, deduped by realpath.
- **Project memory resolves to the nearest loaded root-level ancestor `CLAUDE.md`** (TS walks cwd upward), falling back to `{cwd}/CLAUDE.md` — a repo subdirectory points at the real project memory, not a spurious new subdir file (plan-critic M2).
- On select: mkdir `~/.claude` when under it → **exclusive-create** (existing content preserved) → **honest no-spawn message** (no `editFileInEditor` analog exists; spawning `$EDITOR` inside Textual corrupts the screen; claiming "Opened … in your editor" would be false — the `/copy` standard). Cancel/error strings verbatim with TS display mappings.
- `/keybindings` (next in queue) **deferred after verification**: Python's TUI keybindings are code-only (no user-file loader) — the port would be inert.

## Test plan
- [x] `tests/test_memory_command.py` (12): synthetic candidates + verbatim descriptions (git + non-git branches), ancestor-walk resolution (subdir + nearest-of-two monorepo cases), dedup, `@-imported` desc, ensure-create + preservation, cancel/error verbatim, null-surface engine error, registration/safety/fall-through.
- [x] Fresh full suite post-fix: **7282 passed**, only the 6 known baseline failures.
- [x] Plan + implementation critic-approved (M1/M2 fixed; nearest-ancestor + docstring one-liners applied pre-merge as authorized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)