### PR TITLE
commands: port /stickers (Phase 17)

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -86,6 +86,7 @@ from .release_notes_command import RELEASE_NOTES_COMMAND
 from .copy_command import COPY_COMMAND, CopyCommand
 from .vim_command import VIM_COMMAND
 from .memory_command import MEMORY_COMMAND, MemoryCommand
+from .stickers_command import STICKERS_COMMAND
 from .types import (
     Command,
     CommandAvailability,
@@ -181,6 +182,7 @@ __all__ = [
     "VIM_COMMAND",
     "MEMORY_COMMAND",
     "MemoryCommand",
+    "STICKERS_COMMAND",
     "get_builtin_commands",
     "register_builtin_commands",
     # Moved-to-plugin factory + shell-at-prompt-build

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -39,6 +39,7 @@ from .release_notes_command import RELEASE_NOTES_COMMAND
 from .copy_command import COPY_COMMAND
 from .vim_command import VIM_COMMAND
 from .memory_command import MEMORY_COMMAND
+from .stickers_command import STICKERS_COMMAND
 from .types import Command, CommandType, CompactionResult, LocalCommand, PromptCommand
 
 
@@ -1256,6 +1257,7 @@ def get_builtin_commands() -> list[Command]:
         COPY_COMMAND,
         VIM_COMMAND,
         MEMORY_COMMAND,
+        STICKERS_COMMAND,
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)

--- a/src/command_system/stickers_command.py
+++ b/src/command_system/stickers_command.py
@@ -1,0 +1,34 @@
+"""stickers — ``/stickers`` open the sticker page (port of TS ``type:'local'``).
+
+Port of ``typescript/src/commands/stickers/``. Opens the sticker-order page in the
+default browser via stdlib :mod:`webbrowser` (the ``openBrowser`` analog); on failure
+falls back to printing the URL. Messages verbatim from ``stickers.ts``.
+"""
+from __future__ import annotations
+
+from .types import CommandContext, LocalCommand, LocalCommandResult
+
+_URL = "https://www.stickermule.com/claudecode"
+
+
+def stickers_command_call(args: str, context: CommandContext) -> LocalCommandResult:
+    try:
+        import webbrowser
+
+        success = webbrowser.open(_URL)
+    except Exception:
+        success = False
+    if success:
+        return LocalCommandResult(type="text", value="Opening sticker page in browser…")
+    return LocalCommandResult(type="text", value=f"Failed to open browser. Visit: {_URL}")
+
+
+STICKERS_COMMAND = LocalCommand(
+    name="stickers",
+    description="Order OpenClaude stickers",  # verbatim TS index.ts
+    supports_non_interactive=False,  # verbatim TS index.ts
+)
+STICKERS_COMMAND.set_call(stickers_command_call)
+
+
+__all__ = ["STICKERS_COMMAND", "stickers_command_call"]

--- a/tests/test_stickers_command.py
+++ b/tests/test_stickers_command.py
@@ -1,0 +1,73 @@
+"""Tests for the ``/stickers`` command (Phase 17 — port of TS ``type:'local'``)."""
+from __future__ import annotations
+
+import webbrowser
+from pathlib import Path
+
+import pytest
+
+from src.command_system import (
+    STICKERS_COMMAND,
+    create_command_context,
+    get_builtin_commands,
+    is_bridge_safe_command,
+)
+from src.command_system.engine import CommandEngine
+from src.command_system.registry import CommandRegistry
+from src.command_system.safe_commands import REMOTE_SAFE_COMMANDS
+from src.command_system.types import CommandType
+
+_URL = "https://www.stickermule.com/claudecode"
+
+
+def _ctx(tmp_path: Path):
+    return create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+
+
+async def test_success_message(tmp_path, monkeypatch):
+    opened: list[str] = []
+    monkeypatch.setattr(webbrowser, "open", lambda url: opened.append(url) or True)
+    result = await STICKERS_COMMAND.call("", _ctx(tmp_path))
+    assert result.value == "Opening sticker page in browser…"  # verbatim, U+2026
+    assert opened == [_URL]
+
+
+async def test_failure_falls_back_to_url(tmp_path, monkeypatch):
+    monkeypatch.setattr(webbrowser, "open", lambda url: False)
+    result = await STICKERS_COMMAND.call("", _ctx(tmp_path))
+    assert result.value == f"Failed to open browser. Visit: {_URL}"
+
+
+async def test_exception_falls_back_to_url(tmp_path, monkeypatch):
+    def _boom(url):
+        raise RuntimeError("no display")
+
+    monkeypatch.setattr(webbrowser, "open", _boom)
+    result = await STICKERS_COMMAND.call("", _ctx(tmp_path))
+    assert result.value == f"Failed to open browser. Visit: {_URL}"
+
+
+async def test_engine_headless(tmp_path, monkeypatch):
+    monkeypatch.setattr(webbrowser, "open", lambda url: True)
+    reg = CommandRegistry()
+    reg.register(STICKERS_COMMAND)
+    ctx = _ctx(tmp_path)
+    eng = CommandEngine(registry=reg, workspace_root=tmp_path, context=ctx)
+    result = await eng.execute("/stickers")
+    assert result.success is True
+    assert result.text.startswith("Opening sticker page")
+
+
+def test_registered_metadata_safety_dispatch():
+    assert "stickers" in {c.name for c in get_builtin_commands()}
+    assert STICKERS_COMMAND.description == "Order OpenClaude stickers"
+    assert STICKERS_COMMAND.command_type == CommandType.LOCAL
+    assert STICKERS_COMMAND.supports_non_interactive is False
+    assert "stickers" in REMOTE_SAFE_COMMANDS  # matches TS
+    assert is_bridge_safe_command(STICKERS_COMMAND) is False  # LOCAL, not allowlisted
+    from src.tui.commands import dispatch_local_command
+
+    res = dispatch_local_command(
+        "/stickers", session=None, workspace_root=Path("."), tool_registry=None
+    )
+    assert res.handled is False


### PR DESCRIPTION
## Summary
- Port TS `type:'local'` `/stickers` as a `LocalCommand`: opens the sticker page via stdlib `webbrowser` (the `openBrowser` analog — genuinely functional, spawn-success semantics symmetric with TS); failure/exception → `Failed to open browser. Visit: {url}`. Messages **byte-exact** (incl. U+2026). `stickers` in REMOTE_SAFE both codebases; not BRIDGE_SAFE (LOCAL → bridge-blocked, matches TS); fall-through dispatch.
- **Queue closure:** `/rename` was reverted un-merged after the plan-critic proved the `SessionStorage` store is **hollow** (no production writer; stale docstring) — shipping would have created unresumable ghost entries. `/rename`, `/tag`, `/resume` are deferred on a "session-persistence producer" phase (a runtime-behavior decision needing user sign-off).

## Test plan
- [x] `tests/test_stickers_command.py` (5): success exact-string + exact URL captured, False fallback, exception fallback, engine headless, registration/REMOTE_SAFE/bridge/fall-through.
- [x] Full suite: **7287 passed**, only the 6 known baseline failures.
- [x] Combined plan+impl critic-approved (byte-level verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)