### PR TITLE
sessions: add the persistence producer (SessionPersister + agent_bridge wiring)

### DIFF
--- a/src/services/session_persistence.py
+++ b/src/services/session_persistence.py
@@ -1,0 +1,90 @@
+"""Session-persistence producer — the writer side of ``SessionStorage``.
+
+Until this phase, the session-persistence subsystem was consumer-complete but
+producer-less: ``SessionStorage`` (metadata + JSONL transcript), ``resume_session``,
+``SessionStorage.list_sessions`` and the TUI resume screen all existed, but **nothing
+in production wrote** metadata or transcripts. :class:`SessionPersister` is that
+producer; the TUI agent bridge drives it (user message at submit, assistant/tool
+messages as the loop drains them, flush at the end of every run incl. abort/error).
+
+Properties:
+  * **Never raises.** Persistence must never break the live session — every method
+    swallows exceptions, logging a single warning the first time (latched).
+  * **Title-preserving.** ``start()`` initializes metadata only when absent, so a
+    ``/rename``-set title (or any prior metadata) survives restarts; ``model``/``cwd``
+    reflect the first run (``last_updated``/``message_count`` bump on every flush).
+  * **Thread-safe.** Records arrive from the agent worker thread; an internal lock
+    serializes buffer appends and flushes.
+  * **Privacy note:** conversation content lands under ``~/.clawcodex/sessions/{id}/``
+    — the same always-on persistence TS ships (``utils/sessionStorage.ts``); large
+    tool results are file-ref-replaced by ``SessionStorage`` before writing.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class SessionPersister:
+    """Best-effort, never-raising producer for ``SessionStorage``."""
+
+    def __init__(self, session_id: str, sessions_dir: Path | None = None) -> None:
+        self._lock = threading.RLock()
+        self._warned = False
+        self._storage: Any = None
+        try:
+            from src.services.session_storage import SessionStorage
+
+            self._storage = SessionStorage(
+                session_id=str(session_id), sessions_dir=sessions_dir
+            )
+        except Exception as exc:  # pragma: no cover — import/ctor failure
+            self._warn(exc)
+
+    # ---- internal -------------------------------------------------------
+    def _warn(self, exc: Exception) -> None:
+        if not self._warned:
+            self._warned = True
+            logger.warning("Session persistence disabled for this session: %s", exc)
+
+    # ---- producer API ---------------------------------------------------
+    def start(self, *, model: str = "", cwd: str = "") -> None:
+        """Initialize metadata — only when absent (never clobbers a title)."""
+        try:
+            with self._lock:
+                if self._storage is None:
+                    return
+                if self._storage.get_metadata() is None:
+                    self._storage.init_metadata(model=model, cwd=cwd)
+        except Exception as exc:
+            self._warn(exc)
+
+    def record(self, message: Any) -> None:
+        """Buffer one message (attr- or Mapping-shaped role/content)."""
+        try:
+            with self._lock:
+                if self._storage is None:
+                    return
+                self._storage.write_message(message)
+        except Exception as exc:
+            self._warn(exc)
+
+    def record_user(self, prompt: str) -> None:
+        self.record({"role": "user", "content": prompt})
+
+    def flush(self) -> None:
+        """Flush the buffer to disk (also bumps metadata counters)."""
+        try:
+            with self._lock:
+                if self._storage is None:
+                    return
+                self._storage.flush()
+        except Exception as exc:
+            self._warn(exc)
+
+
+__all__ = ["SessionPersister"]

--- a/src/tui/agent_bridge.py
+++ b/src/tui/agent_bridge.py
@@ -18,11 +18,14 @@ events back to the Textual screen:
 
 Keeping this logic out of :class:`src.tui.app.ClawCodexTUI` lets unit
 tests drive :class:`AgentBridge` with a fake agent loop (see
-``tests/tui/test_agent_bridge.py``).
+``tests/test_esc_cancel_propagation.py`` and
+``tests/test_session_persistence.py``, which construct the bridge with
+stub dependencies).
 """
 
 from __future__ import annotations
 
+import os
 import threading
 import uuid
 from pathlib import Path
@@ -83,6 +86,16 @@ class AgentBridge:
         # callback also raises :class:`AbortError` on the worker thread
         # to tear down an in-flight HTTP stream cleanly.
         self._abort_controller: AbortController | None = None
+        # Session-persistence producer: writes the metadata + JSONL transcript
+        # that resume_session / the resume screen consume. Best-effort (never
+        # raises); start() initializes metadata only when absent so a
+        # /rename-set title survives restarts.
+        from src.services.session_persistence import SessionPersister
+
+        self._persister = SessionPersister(session_id=session.session_id)
+        self._persister.start(
+            model=getattr(provider, "model", "") or "", cwd=os.getcwd()
+        )
         # Wire permission handler: the tool dispatcher calls this from
         # the worker thread, we post to the UI and block on an Event.
         tool_context.permission_handler = self._permission_handler
@@ -143,6 +156,7 @@ class AgentBridge:
             self._tool_context.abort_controller = self._abort_controller
 
         self._session.conversation.add_user_message(prompt)
+        self._persister.record_user(prompt)
         self._post(AgentRunStarted(prompt=prompt))
         self._state.set_thinking(True, verb="Synthesizing")
         self._run_worker(
@@ -232,6 +246,8 @@ class AgentBridge:
                 # 400 at the API). Surface it now, not later.
                 try:
                     self._session.conversation.add_message(msg.role, msg.content)
+                    # Mirror into the session transcript (best-effort, never raises).
+                    self._persister.record(msg)
                 except Exception:
                     import logging
                     logging.getLogger(__name__).exception(
@@ -348,6 +364,8 @@ class AgentBridge:
         self._finish()
 
     def _finish(self) -> None:
+        # Durable persistence at the end of EVERY run (completion, abort, error).
+        self._persister.flush()
         self._state.set_thinking(False)
         self._state.clear_streaming_text()
         with self._busy_lock:

--- a/src/tui/screens/resume_conversation.py
+++ b/src/tui/screens/resume_conversation.py
@@ -105,10 +105,10 @@ class ResumeConversation(ModalScreen[str | None]):
     def _load_sessions(self) -> list[tuple[str, str]]:
         """Return ``(session_id, label)`` pairs to display.
 
-        Phase-8 close-out: ``SessionStorage.list_sessions()`` is now wired
-        from ``agent_bridge.py``; this method reads the metadata files
-        the agent loop writes during normal operation. Empty list when
-        no sessions exist (clean install, first run).
+        Reads the metadata files the session-persistence producer
+        (``services/session_persistence.SessionPersister``, driven by
+        ``agent_bridge``) writes during normal TUI operation. Empty list
+        when no sessions exist (clean install, first run).
         """
 
         try:

--- a/tests/test_session_persistence.py
+++ b/tests/test_session_persistence.py
@@ -1,0 +1,160 @@
+"""Tests for the session-persistence producer (SessionPersister + agent_bridge wiring).
+
+The bar (from the /rename review): a session produced by the persister must be
+genuinely resumable — ``resume_session`` round-trips it, ``list_sessions`` shows it
+with the right ``message_count`` — and persistence must NEVER break the live session.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import src.services.session_storage as ss
+from src.services.session_persistence import SessionPersister
+from src.services.session_resume import resume_session
+from src.services.session_storage import SessionStorage
+
+
+@pytest.fixture
+def sessions_dir(tmp_path, monkeypatch):
+    d = tmp_path / "sessions"
+    monkeypatch.setattr(ss, "SESSIONS_DIR", d)
+    return d
+
+
+# --------------------------------------------------------------------------- #
+# A. Persister unit
+# --------------------------------------------------------------------------- #
+def test_start_inits_metadata_once_and_preserves_title(sessions_dir):
+    p = SessionPersister("sid-1", sessions_dir=sessions_dir)
+    p.start(model="m1", cwd="/w")
+    meta = SessionStorage(session_id="sid-1", sessions_dir=sessions_dir).get_metadata()
+    assert meta is not None and meta.model == "m1" and meta.cwd == "/w"
+
+    # A /rename-style title set between runs must survive a second start().
+    SessionStorage(session_id="sid-1", sessions_dir=sessions_dir).update_metadata(
+        title="kept-title"
+    )
+    p2 = SessionPersister("sid-1", sessions_dir=sessions_dir)
+    p2.start(model="m2", cwd="/other")
+    meta = SessionStorage(session_id="sid-1", sessions_dir=sessions_dir).get_metadata()
+    assert meta.title == "kept-title"
+    assert meta.model == "m1"  # first-run value kept (documented)
+
+
+def test_record_and_flush_write_transcript_and_count(sessions_dir):
+    p = SessionPersister("sid-2", sessions_dir=sessions_dir)
+    p.start(model="m", cwd="/w")
+    p.record_user("hello")
+    p.record({"role": "assistant", "content": "world"})
+    p.flush()
+
+    storage = SessionStorage(session_id="sid-2", sessions_dir=sessions_dir)
+    entries = storage.read_transcript()
+    assert [e["role"] for e in entries] == ["user", "assistant"]
+    assert entries[0]["content"] == "hello"
+    assert storage.get_metadata().message_count == 2
+
+
+def test_persister_never_raises(sessions_dir, caplog):
+    p = SessionPersister("sid-3", sessions_dir=sessions_dir)
+    p.start(model="m", cwd="/w")
+    # Make every storage op explode — persister must swallow with ONE warning.
+    p._storage.write_message = MagicMock(side_effect=OSError("disk gone"))
+    p._storage.flush = MagicMock(side_effect=OSError("disk gone"))
+    with caplog.at_level("WARNING"):
+        p.record_user("x")
+        p.record_user("y")
+        p.flush()
+    warnings = [r for r in caplog.records if "persistence disabled" in r.message]
+    assert len(warnings) == 1  # latched
+
+
+def test_persister_survives_ctor_failure(monkeypatch, caplog):
+    monkeypatch.setattr(
+        "src.services.session_storage.SessionStorage",
+        MagicMock(side_effect=RuntimeError("boom")),
+    )
+    with caplog.at_level("WARNING"):
+        p = SessionPersister("sid-4")
+        p.start(model="m", cwd="/w")  # no-ops silently
+        p.record_user("x")
+        p.flush()
+    assert p._storage is None
+
+
+# --------------------------------------------------------------------------- #
+# B. Round-trip (the bar)
+# --------------------------------------------------------------------------- #
+def test_round_trip_resume_and_list(sessions_dir):
+    p = SessionPersister("sid-rt", sessions_dir=sessions_dir)
+    p.start(model="m", cwd="/w")
+    p.record_user("q1")
+    p.record({"role": "assistant", "content": "a1"})
+    p.record_user("q2")
+    p.flush()
+
+    result = resume_session("sid-rt", sessions_dir=sessions_dir)
+    assert result.success is True
+    assert len(result.messages) == 3
+    assert result.metadata is not None
+
+    metas = SessionStorage.list_sessions(sessions_dir=sessions_dir)
+    ids = {m.session_id: m for m in metas}
+    assert "sid-rt" in ids
+    assert ids["sid-rt"].message_count == 3
+
+
+# --------------------------------------------------------------------------- #
+# C. agent_bridge wiring (behavioral, via the esc-cancel harness pattern)
+# --------------------------------------------------------------------------- #
+def test_bridge_records_user_prompt_and_flushes(sessions_dir, tmp_path):
+    from src.agent.session import Session
+    from src.tool_system.context import ToolContext
+    from src.tool_system.registry import ToolRegistry
+    from src.tui.agent_bridge import AgentBridge
+    from src.tui.state import AppState
+
+    def _post(_msg: Any) -> None:
+        return None
+
+    def _no_run_worker(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    session = Session.create("test", "test-model")
+    bridge = AgentBridge(
+        post_message=_post,
+        session=session,
+        provider=MagicMock(model="test-model"),
+        tool_registry=ToolRegistry(),
+        tool_context=ToolContext(workspace_root=tmp_path),
+        app_state=AppState(),
+        run_worker=_no_run_worker,
+    )
+
+    # Metadata initialized at construction.
+    storage = SessionStorage(session_id=session.session_id, sessions_dir=sessions_dir)
+    meta = storage.get_metadata()
+    assert meta is not None and meta.model == "test-model"
+
+    assert bridge.submit("persist me") is True
+    bridge._finish()  # the durable flush point (runs on every terminal path)
+
+    entries = SessionStorage(
+        session_id=session.session_id, sessions_dir=sessions_dir
+    ).read_transcript()
+    assert any(e["role"] == "user" and e["content"] == "persist me" for e in entries)
+
+
+def test_session_id_unified_with_bootstrap(sessions_dir):
+    # Pin 2 (plan-critic): Session.create reads the bootstrap session id, so the
+    # producer's directory id equals get_session_id() — a re-landed /rename
+    # (which uses get_session_id()) provably targets the SAME session dir.
+    from src.agent.session import Session
+    from src.bootstrap.state import get_session_id
+
+    session = Session.create("test", "test-model")
+    assert str(session.session_id) == str(get_session_id())


### PR DESCRIPTION
## Summary
- **The producer half of session persistence** (user-authorized): the subsystem was consumer-complete but producer-less — nothing wrote `SessionStorage` metadata/transcripts (the Phase-16 `/rename` finding). New `SessionPersister` (never-raising, title-preserving `start`, buffered `record`, `flush`) wired into `agent_bridge`: metadata at construction, user prompt at `submit()`, assistant/tool messages in the drain (inside the existing try — transcript mirrors what the conversation actually holds), **`flush()` first-statement of `_finish()`** (durable on completion/abort/error; serialized ahead of the busy release).
- Id channel **unified by construction** (`Session.create` reads bootstrap `get_session_id()`) and guarded by test — the `/rename` re-land provably targets the same session dir. Both stale docstrings corrected.
- Privacy: transcripts under `~/.clawcodex/sessions/{id}/` — the same always-on persistence TS ships; large tool results file-ref-replaced; O(1) buffered appends.

## Test plan
- [x] `tests/test_session_persistence.py` (7): start-once + `/rename`-title survival, transcript + `message_count`, never-raises (latched warning) + ctor-failure no-op, **round-trip bar** (`resume_session` success, `list_sessions` count), behavioral bridge test (real `AgentBridge`, stub deps), id-equivalence guard.
- [x] Existing esc-cancel bridge suite green; full suite **7294 passed**, only the 6 known baseline failures.
- [x] Plan + implementation critic-approved (3 pins applied: flush-first, id guard, docstring fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)