### PR TITLE
commands: port /rename on the persistence producer (Phase 18)

### DIFF
--- a/src/command_system/__init__.py
+++ b/src/command_system/__init__.py
@@ -87,6 +87,7 @@ from .copy_command import COPY_COMMAND, CopyCommand
 from .vim_command import VIM_COMMAND
 from .memory_command import MEMORY_COMMAND, MemoryCommand
 from .stickers_command import STICKERS_COMMAND
+from .rename_command import RENAME_COMMAND, RenameCommand
 from .types import (
     Command,
     CommandAvailability,
@@ -183,6 +184,8 @@ __all__ = [
     "MEMORY_COMMAND",
     "MemoryCommand",
     "STICKERS_COMMAND",
+    "RENAME_COMMAND",
+    "RenameCommand",
     "get_builtin_commands",
     "register_builtin_commands",
     # Moved-to-plugin factory + shell-at-prompt-build

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -40,6 +40,7 @@ from .copy_command import COPY_COMMAND
 from .vim_command import VIM_COMMAND
 from .memory_command import MEMORY_COMMAND
 from .stickers_command import STICKERS_COMMAND
+from .rename_command import RENAME_COMMAND
 from .types import Command, CommandType, CompactionResult, LocalCommand, PromptCommand
 
 
@@ -1258,6 +1259,7 @@ def get_builtin_commands() -> list[Command]:
         VIM_COMMAND,
         MEMORY_COMMAND,
         STICKERS_COMMAND,
+        RENAME_COMMAND,
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)

--- a/src/command_system/rename_command.py
+++ b/src/command_system/rename_command.py
@@ -1,0 +1,141 @@
+"""rename — ``/rename`` rename the current conversation (port of TS local-jsx).
+
+Port of ``typescript/src/commands/rename/`` (``rename.ts`` + ``generateSessionName.ts``).
+``/rename <name>`` sets the name directly; bare ``/rename`` generates a short
+kebab-case name from the conversation (Haiku side-call, best-effort).
+
+**Persist channel (now genuinely live):** ``SessionStorage`` metadata ``title`` — the
+session-persistence producer (``services/session_persistence.SessionPersister``,
+driven by ``agent_bridge``) writes metadata + transcripts in normal TUI operation,
+and the resume screen lists sessions labeled by ``meta.title`` first. The id channel
+is unified by construction (``Session.create`` reads bootstrap ``get_session_id()``,
+guarded by ``test_session_id_unified_with_bootstrap``), so this command provably
+targets the same session directory the producer writes. When metadata is absent
+(e.g. headless surfaces where no producer ran) the command falls back to
+``init_metadata(title=…)`` — the session then appears in the resume list.
+
+Output-style pattern: ``run()`` never touches ``ctx.ui`` (TS has no picker) → works
+headless on every surface.
+
+Deliberate divergences (documented for parity review):
+  * **DROPPED:** the teammate guard (no ``isTeammate`` analog), ``saveAgentName`` +
+    AppState ``standaloneAgentContext.name`` (no analog), the best-effort bridge
+    title sync (only a protocol ``set_session_title`` exists — no concrete client),
+    and the compact-boundary message filter (messages used as-is).
+  * **Name generation** is anthropic-direct best-effort (the ``generate_llm_title``
+    sibling pattern); ANY failure (no key/network/parse) → the no-context message
+    (TS distinguishes only null-generation; merged — honest).
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .types import (
+    CommandContext,
+    InteractiveCommand,
+    InteractiveOutcome,
+)
+
+# Verbatim TS generateSessionName.ts:22-24 system prompt.
+_NAME_PROMPT = (
+    "Generate a short kebab-case name (2-4 words) that captures the main topic of "
+    'this conversation. Use lowercase words separated by hyphens. Examples: '
+    '"fix-login-bug", "add-auth-feature", "refactor-api-client", '
+    '"debug-test-failures". Return JSON with a "name" field.'
+)
+
+_NO_CONTEXT_MSG = (
+    "Could not generate a name: no conversation context yet. Usage: /rename <name>"
+)
+
+
+def _conversation_text(messages: Any) -> str:
+    """Flatten user/assistant texts (the TS extractConversationText reduction)."""
+    parts: list[str] = []
+    for msg in list(messages or [])[:20]:
+        role = (
+            msg.get("role") or msg.get("type")
+            if isinstance(msg, Mapping)
+            else getattr(msg, "role", None) or getattr(msg, "type", None)
+        )
+        if role not in ("user", "assistant"):
+            continue
+        content = msg.get("content") if isinstance(msg, Mapping) else getattr(msg, "content", None)
+        if isinstance(content, str) and content.strip():
+            parts.append(f"{role}: {content.strip()}")
+        elif isinstance(content, list):
+            for block in content:
+                text = (
+                    block.get("text")
+                    if isinstance(block, Mapping)
+                    else getattr(block, "text", None)
+                )
+                if text and str(text).strip():
+                    parts.append(f"{role}: {str(text).strip()}")
+    return "\n".join(parts)
+
+
+async def _generate_session_name(messages: Any) -> str | None:
+    """Port of TS ``generateSessionName`` — kebab-case 2-4 words via a Haiku
+    side-call; best-effort ``None`` on any failure (the ``generate_llm_title``
+    sibling pattern)."""
+    text = _conversation_text(messages)
+    if not text:
+        return None
+    try:
+        import anthropic
+
+        client = anthropic.Anthropic()
+        result = client.messages.create(
+            model="claude-3-5-haiku-20241022",
+            max_tokens=100,
+            system=_NAME_PROMPT,
+            messages=[{"role": "user", "content": text[:4000]}],
+        )
+        raw = "".join(
+            getattr(b, "text", "") or "" for b in (result.content or [])
+        ).strip()
+        m = re.search(r"\{.*\}", raw, re.DOTALL)
+        if not m:
+            return None
+        name = json.loads(m.group(0)).get("name")
+        return name.strip() if isinstance(name, str) and name.strip() else None
+    except Exception:
+        return None
+
+
+@dataclass(frozen=True)
+class RenameCommand(InteractiveCommand):
+    """Rename the current conversation (SessionStorage metadata title)."""
+
+    async def run(self, args: str, context: CommandContext) -> InteractiveOutcome:
+        name = (args or "").strip()
+        if not name:
+            messages = getattr(context.conversation, "messages", None) or []
+            generated = await _generate_session_name(messages)
+            if not generated:
+                return InteractiveOutcome(message=_NO_CONTEXT_MSG, display="system")
+            name = generated
+
+        from src.bootstrap.state import get_session_id
+        from src.services.session_storage import SessionStorage
+
+        storage = SessionStorage(session_id=str(get_session_id()))
+        if storage.get_metadata() is None:
+            storage.init_metadata(title=name)
+        else:
+            storage.update_metadata(title=name)
+        # Verbatim TS rename.ts:85 (display:'system').
+        return InteractiveOutcome(message=f"Session renamed to: {name}", display="system")
+
+
+RENAME_COMMAND = RenameCommand(
+    name="rename",
+    description="Rename the current conversation",  # verbatim TS index.ts
+)
+
+
+__all__ = ["RENAME_COMMAND", "RenameCommand"]

--- a/tests/test_rename_command.py
+++ b/tests/test_rename_command.py
@@ -1,0 +1,179 @@
+"""Tests for the ``/rename`` command (Phase 18 — re-landed on the persistence producer).
+
+The persist channel is genuinely live now: the producer (PR #260) writes
+SessionStorage metadata/transcripts in normal TUI operation, and the id channel is
+unified (``Session.create`` reads bootstrap ``get_session_id()``).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import src.services.session_storage as ss
+from src.command_system import (
+    RENAME_COMMAND,
+    RenameCommand,
+    create_command_context,
+    get_builtin_commands,
+    is_bridge_safe_command,
+)
+from src.command_system.engine import CommandEngine
+from src.command_system.registry import CommandRegistry
+from src.command_system.rename_command import _conversation_text, _generate_session_name
+from src.command_system.types import CommandType, InteractiveOutcome, NullUIHost
+
+_NO_CONTEXT = (
+    "Could not generate a name: no conversation context yet. Usage: /rename <name>"
+)
+_SID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture
+def rename_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(ss, "SESSIONS_DIR", tmp_path / "sessions")
+    monkeypatch.setattr("src.bootstrap.state.get_session_id", lambda: _SID)
+    return tmp_path
+
+
+def _ctx(tmp_path, messages=None, *, ui=None):
+    conversation = SimpleNamespace(messages=messages or [])
+    return create_command_context(
+        workspace_root=tmp_path, cwd=tmp_path, conversation=conversation, ui=ui
+    )
+
+
+def _title(tmp_path):
+    meta = ss.SessionStorage(session_id=_SID, sessions_dir=tmp_path / "sessions").get_metadata()
+    return meta.title if meta else None
+
+
+# --------------------------------------------------------------------------- #
+# A. Args path (init-when-absent + update-when-present)
+# --------------------------------------------------------------------------- #
+async def test_rename_with_args_inits_metadata(rename_env):
+    out = await RENAME_COMMAND.run("my-session", _ctx(rename_env, ui=NullUIHost()))
+    assert isinstance(out, InteractiveOutcome)
+    assert out.message == "Session renamed to: my-session"
+    assert out.display == "system"
+    assert _title(rename_env) == "my-session"
+
+
+async def test_rename_updates_existing_metadata(rename_env):
+    # The producer-initialized case: metadata exists (model/cwd from the run).
+    storage = ss.SessionStorage(session_id=_SID, sessions_dir=rename_env / "sessions")
+    storage.init_metadata(model="m", cwd="/x", title="old")
+    out = await RENAME_COMMAND.run("new-name", _ctx(rename_env, ui=NullUIHost()))
+    assert out.message == "Session renamed to: new-name"
+    meta = ss.SessionStorage(session_id=_SID, sessions_dir=rename_env / "sessions").get_metadata()
+    assert meta.title == "new-name"
+    assert meta.model == "m"  # other fields preserved by update
+
+
+# --------------------------------------------------------------------------- #
+# B. No-args generation path
+# --------------------------------------------------------------------------- #
+async def test_rename_generates_name(rename_env, monkeypatch):
+    async def _gen(messages):
+        return "fix-login-bug"
+
+    monkeypatch.setattr(
+        "src.command_system.rename_command._generate_session_name", _gen
+    )
+    out = await RENAME_COMMAND.run("", _ctx(rename_env, ui=NullUIHost()))
+    assert out.message == "Session renamed to: fix-login-bug"
+    assert _title(rename_env) == "fix-login-bug"
+
+
+async def test_rename_no_context_message(rename_env, monkeypatch):
+    async def _gen(messages):
+        return None
+
+    monkeypatch.setattr(
+        "src.command_system.rename_command._generate_session_name", _gen
+    )
+    out = await RENAME_COMMAND.run("", _ctx(rename_env, ui=NullUIHost()))
+    assert out.message == _NO_CONTEXT
+    assert out.display == "system"
+    assert _title(rename_env) is None  # nothing persisted
+
+
+# --------------------------------------------------------------------------- #
+# C. Generator unit
+# --------------------------------------------------------------------------- #
+def test_conversation_text_flattens_roles():
+    msgs = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+        {"role": "system", "content": "skip me"},
+    ]
+    text = _conversation_text(msgs)
+    assert "user: hello" in text and "assistant: hi" in text
+    assert "skip me" not in text
+
+
+async def test_generate_session_name_empty_messages_no_api():
+    assert await _generate_session_name([]) is None
+
+
+async def test_generate_session_name_failure_is_none(monkeypatch):
+    import sys
+    from types import ModuleType
+
+    fake = ModuleType("anthropic")
+
+    class _Boom:
+        def __init__(self, *a, **k):
+            raise RuntimeError("no key")
+
+    fake.Anthropic = _Boom
+    monkeypatch.setitem(sys.modules, "anthropic", fake)
+    assert await _generate_session_name([{"role": "user", "content": "x"}]) is None
+
+
+# --------------------------------------------------------------------------- #
+# D. End-to-end with the PRODUCER (the re-land integration lock)
+# --------------------------------------------------------------------------- #
+async def test_rename_after_producer_session_appears_in_resume_list(rename_env):
+    from src.services.session_persistence import SessionPersister
+
+    p = SessionPersister(_SID, sessions_dir=rename_env / "sessions")
+    p.start(model="m", cwd="/w")
+    p.record_user("hello")
+    p.flush()
+
+    out = await RENAME_COMMAND.run("better-name", _ctx(rename_env, ui=NullUIHost()))
+    assert out.message == "Session renamed to: better-name"
+
+    metas = ss.SessionStorage.list_sessions(sessions_dir=rename_env / "sessions")
+    by_id = {m.session_id: m for m in metas}
+    assert by_id[_SID].title == "better-name"  # the resume list shows the new title
+    assert by_id[_SID].message_count == 1  # producer data intact
+
+
+# --------------------------------------------------------------------------- #
+# E. Headless + registration + safety + dispatch
+# --------------------------------------------------------------------------- #
+async def test_engine_headless_success(rename_env):
+    reg = CommandRegistry()
+    reg.register(RENAME_COMMAND)
+    ctx = _ctx(rename_env)  # ui=None -> NullUIHost; never touched
+    eng = CommandEngine(registry=reg, workspace_root=rename_env, context=ctx)
+    result = await eng.execute("/rename cool-name")
+    assert result.success is True
+    assert result.text == "Session renamed to: cool-name"
+
+
+def test_registered_metadata_safety_dispatch():
+    assert "rename" in {c.name for c in get_builtin_commands()}
+    assert isinstance(RENAME_COMMAND, RenameCommand)
+    assert RENAME_COMMAND.description == "Rename the current conversation"
+    assert RENAME_COMMAND.command_type == CommandType.INTERACTIVE
+    assert is_bridge_safe_command(RENAME_COMMAND) is False
+    from src.tui.commands import dispatch_local_command
+
+    res = dispatch_local_command(
+        "/rename", session=None, workspace_root=Path("."), tool_registry=None
+    )
+    assert res.handled is False


### PR DESCRIPTION
## Summary
- Port TS local-jsx `/rename` as an `InteractiveCommand` — **re-landed on a true premise**: the persistence producer (#260) writes the `SessionStorage` channel in normal TUI operation, and the id is unified by construction (guard-tested). The first attempt was critic-rejected + reverted (hollow store → ghost entries).
- `/rename <name>` direct; bare `/rename` generates a kebab-case name (TS prompt verbatim, Haiku best-effort → verbatim no-context message on failure). `update_metadata` in normal TUI (preserves producer counters); `init_metadata` fallback only on producer-less headless surfaces (documented edge, inherited by the `/resume` phase gate). Headless everywhere (never touches `ctx.ui`); messages verbatim. Drops documented (teammate guard / agent-name / bridge sync / compact filter — no analogs).

## Test plan
- [x] `tests/test_rename_command.py` (10): init/update paths, generation + no-context, generator unit (mocked anthropic), **produce→rename→list integration lock** (title updated AND `message_count` intact), engine headless, registration/safety/fall-through.
- [x] Full suite: **7304 passed**, only the 6 known baseline failures.
- [x] Plan-critic (caught the original false premise), producer phase, and the re-land all critic-approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)