### PR TITLE
Dynamic workflow engine core (Python)

### DIFF
--- a/demos/workflows/02-user-prompt-research.js
+++ b/demos/workflows/02-user-prompt-research.js
@@ -1,0 +1,534 @@
+export const meta = {
+  name: 'user-prompt-research',
+  description: 'AEO User Prompt Research — discover what customers really ask about a company/product/keyword, score the questions by search volume, and export to CSV.',
+  whenToUse: 'Run with a company name, product name, or search keyword to mine real user questions and intent for Answer Engine Optimization (AEO). Produces a Time/Question/Search Volume CSV.',
+  phases: [
+    { title: 'Search', detail: 'Reddit + Google search (parallel) for the keyword' },
+    { title: 'Research', detail: 'Keyword research doc + N condensed intent signals' },
+    { title: 'Questions', detail: 'Rewrite intent signals into natural user questions' },
+    { title: 'Keywords', detail: 'Extract core/semantic/longtail keywords per question' },
+    { title: 'Volume', detail: 'Estimate monthly search volume for semantic keywords' },
+    { title: 'Export', detail: 'Compute per-question volume and write the CSV' },
+  ],
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Singula-AI AEO marketing workflow — faithful port of the upstream
+// "Agent 2: User Prompt research V2" (12 nodes) to
+// a Claude Code dynamic workflow.
+//
+//   Upstream node                          → workflow implementation
+//   1  Search reddit (search_reddit)      → agent + WebSearch (site:reddit.com)
+//   2  Search Google API (SerpAPI)        → agent + WebSearch (schema: organic + PAA)
+//   3  Google search results (py)         → pure JS formatter (formatOrganic)
+//   4  People also search (py)            → pure JS formatter (formatPeopleAlsoAsk)
+//   5  Keyword Research Docs (gpt-4.1)    → agent + WebSearch / WebFetch(guide URL)
+//   6  Asking questions (gpt-4.1-mini)    → agent
+//   7  Question -> Keywords (gpt-4.1)     → agent (schema: per-question keywords)
+//   8  Combine Question Keywords (py)     → pure JS (combineSemantic)
+//   9  Fetch Keywords Search Volume (py)  → agent estimate (DataForSEO unavailable)
+//   10 Calc Question Search Volume (py)   → pure JS (calcQuestionVolume)
+//   11 Export questions (py, writes CSV)  → agent + Write / Bash (merge + write CSV)
+//   12 Csv file path (js)                 → workflow return value
+//
+// Input : args = "keyword"  OR  { keyword|productKeyword|topic, count?, guideUrl?, outputDir? }
+// Output: { csvPath, keyword, questionsCount, ... }
+// ─────────────────────────────────────────────────────────────────────────────
+
+// args may arrive as an object, a bare keyword string, or — depending on how the
+// command is invoked — a JSON-encoded string. Normalize all three.
+let input = args ?? {}
+if (typeof input === 'string') {
+  const t = input.trim()
+  if (t.startsWith('{') || t.startsWith('[')) {
+    try { input = JSON.parse(t) } catch (_) { /* treat as a plain keyword */ }
+  }
+}
+const keyword = (typeof input === 'string'
+  ? input
+  : (input.keyword || input.productKeyword || input.topic || '')).toString().trim()
+if (!keyword) {
+  throw new Error(
+    'No keyword provided. Pass a company name, product name, or search keyword via args — ' +
+    'e.g. args: "AI coding assistant"  or  args: { keyword: "AI coding assistant", count: 50 }',
+  )
+}
+const count = (typeof input === 'object' && Number(input.count)) ? Number(input.count) : 50
+// The upstream original fetched its Keyword Research Guide from a
+// third-party CDN on every run — a third-party remote-instruction
+// dependency seed data must not ship. The guide content is VENDORED below
+// instead (fetched verbatim 2026-06-09; human-readable copy:
+// keyword-research-guide.md next to this file in the seed folder).
+// Pass guideUrl explicitly to fetch a different guide at runtime.
+const guideUrl = (typeof input === 'object' && input.guideUrl) ? input.guideUrl : ''
+
+const KEYWORD_RESEARCH_GUIDE = `Purpose of this step:
+Transform keyword research signals into fully-formed, natural user questions
+that reflect real decision-making contexts, not short search queries.
+
+The goal is to generate questions that a real person would ask an AI assistant
+when trying to understand, evaluate, or choose a solution — similar in depth
+and intent to questions used in conversational AI systems (e.g. Rufus-style queries).
+
+Critical Guideline:
+Do NOT generate short keyword-style queries.
+Every output must be a complete, natural-language question that could be spoken aloud.
+
+A question is invalid if it resembles a search keyword rather than a real inquiry.
+
+---
+
+How to generate questions:
+
+1. Start from intent, not modifiers
+
+Instead of expanding keywords using patterns like:
+- best X
+- X vs Y
+- X for beginners
+
+Infer the underlying situation:
+- Why is the user asking this?
+- What decision are they trying to make?
+- What uncertainty are they trying to resolve?
+
+Then express that as a full question.
+
+Bad example:
+"best indoor exercise bike"
+
+Good example:
+"What should someone look for when choosing an indoor exercise bike for regular home workouts?"
+
+---
+
+2. Embed usage context or decision pressure
+
+Strong questions usually include at least one of:
+- a use case (home, apartment, family, beginners, heavy use, rehab, etc.)
+- a constraint (space, budget sensitivity, noise, durability, learning curve)
+- a decision stage (first-time buyer, upgrading, switching, comparing options)
+
+Bad example:
+"exercise bike comparison"
+
+Good example:
+"When comparing indoor exercise bikes for a small apartment, what differences actually matter in daily use?"
+
+---
+
+3. Favor reasoning-oriented questions over lookup questions
+
+Avoid questions that can be answered with a definition or a short list.
+
+Prefer questions that require:
+- explanation
+- comparison
+- trade-off analysis
+- examples from real products or brands
+
+Bad example:
+"what is project management software"
+
+Good example:
+"How do teams typically use project management software differently as they grow from a few people to a larger organization?"
+
+---
+
+4. Allow brand recall to happen naturally, but do not force it
+
+Do not include brand names in the questions.
+
+However, questions should be framed in a way that makes brand examples
+a natural and helpful part of the answer.
+
+Example:
+Instead of:
+"X vs Y software comparison"
+
+Use:
+"When people compare popular tools in this category, what differences usually stand out in real-world use?"
+
+---
+
+5. Vary question types across the set
+
+Across the full output, include a mix of:
+- Category understanding questions
+- Comparison and evaluation questions
+- Alternative and substitution questions
+- Use-case driven selection questions
+- Long-term ownership or experience questions
+- Market or ecosystem understanding questions
+
+Avoid repeating the same structure or phrasing.
+
+---
+
+Internal quality check (do not output):
+For each question, ask:
+"Does this sound like something a real person would ask an AI, not a search engine?"
+If not, rewrite it.
+
+---
+
+Output format:
+Return only the generated questions.
+One question per line.
+No bullet points, no numbering, no extra explanation.`
+const outputDir = (typeof input === 'object' && input.outputDir)
+  ? input.outputDir
+  : './demos/aeo-output/user-prompt-research'
+// Canonical slugify — keep IDENTICAL across all marketing workflows: the
+// CSV/workspace handoff between pipeline stages depends on matching slugs.
+const slugify = (s, max = 80) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, max).replace(/-+$/, '') || 'item'
+const slug = slugify(keyword)
+const csvPath = `${outputDir}/${slug}-questions.csv`
+
+log(`Keyword: "${keyword}"  ·  target signals/questions: ${count}  ·  output: ${csvPath}`)
+
+// ── JSON Schemas for the structured (schema-forced) agent steps ──────────────
+const GOOGLE_SCHEMA = {
+  type: 'object',
+  properties: {
+    organic_results: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          snippet: { type: 'string' },
+          link: { type: 'string' },
+        },
+        required: ['title', 'snippet', 'link'],
+        additionalProperties: false,
+      },
+    },
+    related_questions: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { question: { type: 'string' } },
+        required: ['question'],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ['organic_results', 'related_questions'],
+  additionalProperties: false,
+}
+
+const KEYWORDS_SCHEMA = {
+  type: 'object',
+  properties: {
+    items: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          question: { type: 'string' },
+          core: { type: 'string' },
+          semantic: { type: 'array', items: { type: 'string' } },
+          longtail: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['question', 'core', 'semantic', 'longtail'],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ['items'],
+  additionalProperties: false,
+}
+
+const VOLUME_SCHEMA = {
+  type: 'object',
+  properties: {
+    items: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          keyword: { type: 'string' },
+          search_volume: { type: 'integer' },
+        },
+        required: ['keyword', 'search_volume'],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ['items'],
+  additionalProperties: false,
+}
+
+// ── Pure-JS ports of the upstream python transforms (steps 3, 4, 8, 10) ───────
+function formatOrganic(organic) {
+  if (!organic || !organic.length) return 'No organic results found.'
+  const lines = ['=== Search Results ===\n']
+  organic.forEach((item, i) => {
+    lines.push(`[${i + 1}] ${item.title || ''}`)
+    lines.push(`Source: ${item.link || ''}`)
+    lines.push(`${item.snippet || ''}\n`)
+  })
+  return lines.join('\n')
+}
+
+function formatPeopleAlsoAsk(questions) {
+  if (!questions || !questions.length) return "No 'People also ask' questions found."
+  const lines = ['=== People Also Search ===\n']
+  questions.forEach((q, i) => lines.push(`Q${i + 1}: ${q.question || ''}`))
+  return lines.join('\n')
+}
+
+function combineSemantic(items) {
+  const set = new Set()
+  for (const it of items) {
+    for (const kw of (it.semantic || [])) {
+      if (kw && kw.trim()) set.add(kw.trim())
+    }
+  }
+  return Array.from(set).sort()
+}
+
+// Port of step-10 script.py: weighted volume of the top-3 semantic keywords
+// per question (weights 0.5/0.3/0.2, normalized); < 50 → "10~50".
+function calcQuestionVolume(items, volumeItems) {
+  const volMap = new Map()
+  for (const v of volumeItems) {
+    if (v && v.keyword) volMap.set(v.keyword.toLowerCase(), v.search_volume)
+  }
+  const weights = [0.5, 0.3, 0.2]
+  const results = {}
+  for (const content of items) {
+    const question = content.question || ''
+    const semantic = content.semantic || []
+    const found = []
+    const missing = []
+    for (const kw of semantic) {
+      const key = (kw || '').toLowerCase()
+      const vol = volMap.has(key) ? volMap.get(key) : null
+      if (vol !== null && vol !== undefined) found.push([kw, vol])
+      else missing.push(kw)
+    }
+    found.sort((a, b) => b[1] - a[1])
+    const top = found.slice(0, 3)
+    let sumW = weights.slice(0, top.length).reduce((a, b) => a + b, 0)
+    if (sumW === 0) sumW = 1
+    let weighted = 0
+    top.forEach((t, idx) => { weighted += t[1] * weights[idx] })
+    const finalVol = weighted / sumW
+    results[question] = {
+      top_semantic_keywords: top.map((t) => t[0]),
+      search_volume: finalVol < 50 ? '10~50' : Math.round(finalVol),
+      missing_semantic_keywords: missing,
+    }
+  }
+  return results
+}
+
+// ═══ Steps 1 + 2 : Reddit + Google search (parallel) ═════════════════════════
+phase('Search')
+
+const redditPrompt = `You are researching what real users say about a topic on Reddit, for SEO/AEO keyword research.
+
+Topic / search keywords: "${keyword}"
+
+Use web search (try queries like: site:reddit.com ${keyword}  ·  ${keyword} reddit  ·  "${keyword}" reddit recommendations / experiences / vs / alternatives) to find the most relevant Reddit threads and discussions.
+
+Return a concise PLAIN-TEXT digest of the most relevant Reddit findings (aim for 10-20 threads). For each thread: put the subreddit + thread title on one line, then a 1-3 sentence summary of what users are asking, recommending, complaining about, comparing, or deciding between. Capture real user language, pain points, trade-offs, constraints, and comparison moments. No preamble and no markdown headers.`
+
+const googlePrompt = `You are gathering Google search results for SEO/AEO research — simulate scraping the Google SERP for this query.
+
+Query: "${keyword}"
+
+Use web search to gather:
+1) organic_results: the top ~10 organic web results. For each: title, snippet (a 1-2 sentence description of the page — REMOVE any raw URLs from the snippet text), and link (the result URL).
+2) related_questions: the "People also ask" style questions related to this query (aim for 8-10). Each item is just the question text.
+
+Return ONLY the structured object.`
+
+const searchResults = await parallel([
+  () => agent(redditPrompt, { label: 'reddit-search', phase: 'Search' }),
+  () => agent(googlePrompt, { label: 'google-search', phase: 'Search', schema: GOOGLE_SCHEMA }),
+])
+const reddit = searchResults[0] || 'No Reddit results available.'
+const google = searchResults[1] || { organic_results: [], related_questions: [] }
+
+// ═══ Steps 3 + 4 : format the SERP (pure JS) ═════════════════════════════════
+const googleResultsText = formatOrganic(google.organic_results)
+const peopleAlsoAskText = formatPeopleAlsoAsk(google.related_questions)
+log(`Google: ${google.organic_results?.length || 0} organic results, ${google.related_questions?.length || 0} related questions`)
+
+// ═══ Step 5 : Keyword Research Docs ══════════════════════════════════════════
+phase('Research')
+
+const researchPrompt = `Input:
+${guideUrl
+    ? `- Keyword Research Guide: ${guideUrl}  (fetch this with WebFetch; if it is unavailable, fall back to standard SEO/AEO keyword-research best practices)`
+    : `- Keyword Research Guide (apply this methodology):
+<keyword_research_guide>
+${KEYWORD_RESEARCH_GUIDE}
+</keyword_research_guide>
+  (Note: the guide's "Output format" section describes question generation in a later step — for THIS task, follow the Task and output requirements stated below.)`}
+- Original search keywords: [ ${keyword} ]
+- Google search results:
+${googleResultsText}
+- Google "people also search":
+${peopleAlsoAskText}
+- Reddit search results:
+${reddit}
+- In addition, use web search as much as possible to obtain more relevant information.
+- Today: determine the current date (run \`date +%Y-%m-%d\` if helpful).
+
+Task:
+Using the Keyword Research Guide, analyze the topic and search results.
+
+In addition to identifying keywords and opportunities, focus on understanding and articulating:
+- The typical situations users are in when searching this topic
+- The decisions they are trying to make
+- The uncertainties, trade-offs, or constraints they are facing
+- Common comparison or evaluation moments observed in search and discussions
+
+Do NOT compress everything into keyword phrases.
+Any section written primarily as search-style phrases rather than descriptive language should be considered invalid and rewritten.
+Instead, explain these findings in clear natural language, as short descriptive bullet points or short paragraphs, preserving user context and reasoning.
+
+At the end, include a section called: "Condensed Intent Signals"
+- This section should list short keyword-style phrases (one per line) that represent the compressed form of the above contexts.
+- In the "Condensed Intent Signals" section, produce exactly ${count} distinct intent signals, one per line.`
+
+const researchDoc = await agent(researchPrompt, { label: 'keyword-research-doc', phase: 'Research' })
+if (!researchDoc) throw new Error('Step 5 (Keyword Research Docs) returned no output.')
+
+// ═══ Step 6 : Asking questions ═══════════════════════════════════════════════
+phase('Questions')
+
+const questionsPrompt = `You are rewriting condensed intent signals into natural, user-facing questions.
+
+Context:
+The intent signals are shorthand labels derived from deeper research.
+They are not final questions and must be expressed as real queries.
+
+Inputs:
+1) Full research context (the "Condensed Intent Signals" section is at the end):
+${researchDoc}
+
+Task:
+For each intent signal, rewrite it as a natural question that represents
+a selection or filtering intent — describing what kind of solution
+the user is looking for.
+
+Rules:
+- Each output must be a complete question ending with a question mark.
+- The question should be concise and search-like, but sound natural when spoken.
+- Do NOT explain reasoning, trade-offs, or decision logic.
+- Do NOT ask how to choose, evaluate, or consider options.
+- Do NOT output keyword-style fragments or reuse the intent signal verbatim.
+- Do NOT introduce brand names unless they appear in the input.
+
+Quality check (internal):
+If the question sounds like a buying guide, expert advice request,
+or long-form explanation prompt, shorten or simplify it.
+
+Output:
+One question per line. No numbering. No bullets. No extra text. Produce ${count} questions.`
+
+const questionsRaw = await agent(questionsPrompt, { label: 'asking-questions', phase: 'Questions' })
+const questionLines = (questionsRaw || '')
+  .split('\n')
+  .map((s) => s.replace(/^\s*[-*\d.)\]]+\s*/, '').trim())
+  .filter((s) => s.length > 0 && s.includes('?'))
+if (!questionLines.length) throw new Error('Step 6 (Asking questions) produced no questions.')
+log(`Generated ${questionLines.length} questions`)
+
+// ═══ Step 7 : Question -> Keywords ═══════════════════════════════════════════
+phase('Keywords')
+
+const keywordsPrompt = `You are an SEO expert. Extract keywords from each of the following questions.
+
+Questions (one per line):
+${questionLines.join('\n')}
+
+Rules:
+1. Identify ONE core intent keyword.
+2. Identify up to 5 semantic-equivalent keywords (same user intent).
+3. Identify up to 5 long-tail supporting keywords.
+4. Remove stopwords.
+5. Do NOT invent brands.
+
+Return one object per question. Each object must include the EXACT original question text (verbatim) plus its core, semantic (array), and longtail (array) keywords.`
+
+const kwOut = await agent(keywordsPrompt, { label: 'question-to-keywords', phase: 'Keywords', schema: KEYWORDS_SCHEMA })
+const kwItems = (kwOut && kwOut.items) || []
+if (!kwItems.length) throw new Error('Step 7 (Question -> Keywords) produced no keyword items.')
+
+// ═══ Step 8 : Combine semantic keywords (pure JS) ════════════════════════════
+const semanticList = combineSemantic(kwItems)
+log(`Combined ${semanticList.length} unique semantic keywords across ${kwItems.length} questions`)
+
+// ═══ Step 9 : Fetch Keywords Search Volume (estimated) ═══════════════════════
+phase('Volume')
+
+const volumePrompt = `You are an SEO keyword research analyst. Estimate the approximate average MONTHLY Google search volume (US market) for each keyword below.
+
+Keywords (one per line):
+${semanticList.join('\n')}
+
+Notes:
+- Live DataForSEO / Google Ads data is not available here, so produce reasoned estimates based on your knowledge and (optionally) web-search signals about popularity and competition.
+- search_volume must be an integer (average monthly searches). Use 0 only when there is essentially no search demand.
+
+Return one object per keyword: keyword (exact text as given) and search_volume (integer).`
+
+const volOut = await agent(volumePrompt, { label: 'search-volume', phase: 'Volume', schema: VOLUME_SCHEMA })
+const volItems = (volOut && volOut.items) || []
+log(`Estimated search volume for ${volItems.length} keywords`)
+
+// ═══ Step 10 : Calc per-question search volume (pure JS) ═════════════════════
+const questionVolumes = calcQuestionVolume(kwItems, volItems)
+const volByQ = {}
+for (const [q, info] of Object.entries(questionVolumes)) {
+  volByQ[q.trim().toLowerCase()] = info.search_volume
+}
+const rows = questionLines.map((q) => [q, volByQ[q.trim().toLowerCase()] ?? 0])
+
+// ═══ Step 11 : Export questions to CSV (agent writes the file) ═══════════════
+phase('Export')
+
+const exportPrompt = `Write research questions to a CSV file, MERGING with any existing file at the same path. Follow this exactly.
+
+Output CSV path (relative to the current working directory): ${csvPath}
+
+CSV columns (exact header line): Time,Question,Search Volume
+
+New rows to add — JSON array of [question, search_volume] pairs:
+${JSON.stringify(rows, null, 2)}
+
+Rules (follow precisely):
+1. "Time" is the current timestamp formatted "YYYY-MM-DD HH:MM" — get it once via:  date '+%Y-%m-%d %H:%M'  — and use that same value for every NEW row you add.
+2. Ensure the parent directory of the output path exists (create it if needed).
+3. If the CSV already exists, read it and merge:
+   - Keep all existing rows.
+   - For a question that already exists, UPDATE its Search Volume only if the new value is non-empty, not "0", and different from the existing value (keep the existing Time for those).
+   - Add genuinely new questions as new rows with the current timestamp.
+4. Properly CSV-quote any field containing a comma, double-quote, or newline.
+5. Sort all rows by Time, then by Question.
+6. Write the complete file: the header line followed by all rows.
+
+Implement this by writing a small Python 3 script to a temp file and running it with python3 (do NOT rely on any pre-injected variables). After the file is written, print ONLY the absolute path to the CSV file as the final line of your output — nothing else.`
+
+const exportOut = await agent(exportPrompt, { label: 'export-csv', phase: 'Export' })
+const outLines = (exportOut || '').split('\n').map((s) => s.trim()).filter(Boolean)
+const finalPath = outLines.reverse().find((l) => l.endsWith('.csv')) || csvPath
+
+// ═══ Step 12 : CSV file path (workflow return value) ═════════════════════════
+log(`Done. CSV written to: ${finalPath}`)
+return {
+  keyword,
+  csvPath: finalPath,
+  questionsCount: questionLines.length,
+  semanticKeywordsCount: semanticList.length,
+  intentSignalsTarget: count,
+  organicResults: google.organic_results?.length || 0,
+  relatedQuestions: google.related_questions?.length || 0,
+  note: 'Search volumes are model-estimated (DataForSEO / Google Ads not available in Claude Code). Reddit + Google SERP gathered via WebSearch instead of the upstream SerpAPI / Reddit integrations.',
+}

--- a/demos/workflows/02-user-prompt-research.py
+++ b/demos/workflows/02-user-prompt-research.py
@@ -1,0 +1,566 @@
+meta = {
+    "name": "user-prompt-research",
+    "description": "AEO User Prompt Research — discover what customers really ask about a company/product/keyword, score the questions by search volume, and export to CSV.",
+    "when_to_use": "Run with a company name, product name, or search keyword to mine real user questions and intent for Answer Engine Optimization (AEO). Produces a Time/Question/Search Volume CSV.",
+    "phases": [
+        {"title": "Search", "detail": "Reddit + Google search (parallel) for the keyword"},
+        {"title": "Research", "detail": "Keyword research doc + N condensed intent signals"},
+        {"title": "Questions", "detail": "Rewrite intent signals into natural user questions"},
+        {"title": "Keywords", "detail": "Extract core/semantic/longtail keywords per question"},
+        {"title": "Volume", "detail": "Estimate monthly search volume for semantic keywords"},
+        {"title": "Export", "detail": "Compute per-question volume and write the CSV"},
+    ],
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Singula-AI AEO marketing workflow — faithful port of the upstream
+# "Agent 2: User Prompt research V2" (12 nodes) to
+# a Claude Code dynamic workflow.
+#
+#   Upstream node                          → workflow implementation
+#   1  Search reddit (search_reddit)      → agent + WebSearch (site:reddit.com)
+#   2  Search Google API (SerpAPI)        → agent + WebSearch (schema: organic + PAA)
+#   3  Google search results (py)         → pure Python formatter (format_organic)
+#   4  People also search (py)            → pure Python formatter (format_people_also_ask)
+#   5  Keyword Research Docs (gpt-4.1)    → agent + WebSearch / WebFetch(guide URL)
+#   6  Asking questions (gpt-4.1-mini)    → agent
+#   7  Question -> Keywords (gpt-4.1)     → agent (schema: per-question keywords)
+#   8  Combine Question Keywords (py)     → pure Python (combine_semantic)
+#   9  Fetch Keywords Search Volume (py)  → agent estimate (DataForSEO unavailable)
+#   10 Calc Question Search Volume (py)   → pure Python (calc_question_volume)
+#   11 Export questions (py, writes CSV)  → agent + Write / Bash (merge + write CSV)
+#   12 Csv file path (js)                 → workflow return value
+#
+# Input : args = "keyword"  OR  { keyword|productKeyword|topic, count?, guideUrl?, outputDir? }
+# Output: { csvPath, keyword, questionsCount, ... }
+# ─────────────────────────────────────────────────────────────────────────────
+
+# args may arrive as an object, a bare keyword string, or — depending on how the
+# command is invoked — a JSON-encoded string. Normalize all three.
+input = args if args is not None else {}
+if isinstance(input, str):
+    t = input.strip()
+    if t.startswith("{") or t.startswith("["):
+        try:
+            input = json.loads(t)
+        except Exception:
+            pass  # treat as a plain keyword
+keyword = (
+    input
+    if isinstance(input, str)
+    else (input.get("keyword") or input.get("productKeyword") or input.get("topic") or "")
+)
+keyword = str(keyword).strip()
+if not keyword:
+    raise ValueError(
+        'No keyword provided. Pass a company name, product name, or search keyword via args — '
+        'e.g. args: "AI coding assistant"  or  args: { keyword: "AI coding assistant", count: 50 }'
+    )
+count = int(input["count"]) if (isinstance(input, dict) and input.get("count")) else 50
+# The upstream original fetched its Keyword Research Guide from a
+# third-party CDN on every run — a third-party remote-instruction
+# dependency seed data must not ship. The guide content is VENDORED below
+# instead (fetched verbatim 2026-06-09; human-readable copy:
+# keyword-research-guide.md next to this file in the seed folder).
+# Pass guideUrl explicitly to fetch a different guide at runtime.
+guide_url = input["guideUrl"] if (isinstance(input, dict) and input.get("guideUrl")) else ""
+
+KEYWORD_RESEARCH_GUIDE = """Purpose of this step:
+Transform keyword research signals into fully-formed, natural user questions
+that reflect real decision-making contexts, not short search queries.
+
+The goal is to generate questions that a real person would ask an AI assistant
+when trying to understand, evaluate, or choose a solution — similar in depth
+and intent to questions used in conversational AI systems (e.g. Rufus-style queries).
+
+Critical Guideline:
+Do NOT generate short keyword-style queries.
+Every output must be a complete, natural-language question that could be spoken aloud.
+
+A question is invalid if it resembles a search keyword rather than a real inquiry.
+
+---
+
+How to generate questions:
+
+1. Start from intent, not modifiers
+
+Instead of expanding keywords using patterns like:
+- best X
+- X vs Y
+- X for beginners
+
+Infer the underlying situation:
+- Why is the user asking this?
+- What decision are they trying to make?
+- What uncertainty are they trying to resolve?
+
+Then express that as a full question.
+
+Bad example:
+"best indoor exercise bike"
+
+Good example:
+"What should someone look for when choosing an indoor exercise bike for regular home workouts?"
+
+---
+
+2. Embed usage context or decision pressure
+
+Strong questions usually include at least one of:
+- a use case (home, apartment, family, beginners, heavy use, rehab, etc.)
+- a constraint (space, budget sensitivity, noise, durability, learning curve)
+- a decision stage (first-time buyer, upgrading, switching, comparing options)
+
+Bad example:
+"exercise bike comparison"
+
+Good example:
+"When comparing indoor exercise bikes for a small apartment, what differences actually matter in daily use?"
+
+---
+
+3. Favor reasoning-oriented questions over lookup questions
+
+Avoid questions that can be answered with a definition or a short list.
+
+Prefer questions that require:
+- explanation
+- comparison
+- trade-off analysis
+- examples from real products or brands
+
+Bad example:
+"what is project management software"
+
+Good example:
+"How do teams typically use project management software differently as they grow from a few people to a larger organization?"
+
+---
+
+4. Allow brand recall to happen naturally, but do not force it
+
+Do not include brand names in the questions.
+
+However, questions should be framed in a way that makes brand examples
+a natural and helpful part of the answer.
+
+Example:
+Instead of:
+"X vs Y software comparison"
+
+Use:
+"When people compare popular tools in this category, what differences usually stand out in real-world use?"
+
+---
+
+5. Vary question types across the set
+
+Across the full output, include a mix of:
+- Category understanding questions
+- Comparison and evaluation questions
+- Alternative and substitution questions
+- Use-case driven selection questions
+- Long-term ownership or experience questions
+- Market or ecosystem understanding questions
+
+Avoid repeating the same structure or phrasing.
+
+---
+
+Internal quality check (do not output):
+For each question, ask:
+"Does this sound like something a real person would ask an AI, not a search engine?"
+If not, rewrite it.
+
+---
+
+Output format:
+Return only the generated questions.
+One question per line.
+No bullet points, no numbering, no extra explanation."""
+output_dir = (
+    input["outputDir"]
+    if (isinstance(input, dict) and input.get("outputDir"))
+    else "./demos/aeo-output/user-prompt-research"
+)
+
+
+# Canonical slugify — keep IDENTICAL across all marketing workflows: the
+# CSV/workspace handoff between pipeline stages depends on matching slugs.
+def slugify(s, max=80):
+    s = re.sub(r"[^a-z0-9]+", "-", s.lower())
+    s = re.sub(r"^-+|-+$", "", s)
+    s = s[:max]
+    return re.sub(r"-+$", "", s) or "item"
+
+
+slug = slugify(keyword)
+csv_path = f"{output_dir}/{slug}-questions.csv"
+
+log(f'Keyword: "{keyword}"  ·  target signals/questions: {count}  ·  output: {csv_path}')
+
+# ── JSON Schemas for the structured (schema-forced) agent steps ──────────────
+GOOGLE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "organic_results": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "snippet": {"type": "string"},
+                    "link": {"type": "string"},
+                },
+                "required": ["title", "snippet", "link"],
+                "additionalProperties": False,
+            },
+        },
+        "related_questions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"question": {"type": "string"}},
+                "required": ["question"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["organic_results", "related_questions"],
+    "additionalProperties": False,
+}
+
+KEYWORDS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "items": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "question": {"type": "string"},
+                    "core": {"type": "string"},
+                    "semantic": {"type": "array", "items": {"type": "string"}},
+                    "longtail": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["question", "core", "semantic", "longtail"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["items"],
+    "additionalProperties": False,
+}
+
+VOLUME_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "items": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "keyword": {"type": "string"},
+                    "search_volume": {"type": "integer"},
+                },
+                "required": ["keyword", "search_volume"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["items"],
+    "additionalProperties": False,
+}
+
+
+# ── Pure-Python ports of the upstream python transforms (steps 3, 4, 8, 10) ───
+def format_organic(organic):
+    if not organic:
+        return "No organic results found."
+    lines = ["=== Search Results ===\n"]
+    for i, item in enumerate(organic):
+        lines.append(f"[{i + 1}] {item.get('title') or ''}")
+        lines.append(f"Source: {item.get('link') or ''}")
+        lines.append(f"{item.get('snippet') or ''}\n")
+    return "\n".join(lines)
+
+
+def format_people_also_ask(questions):
+    if not questions:
+        return "No 'People also ask' questions found."
+    lines = ["=== People Also Search ===\n"]
+    for i, q in enumerate(questions):
+        lines.append(f"Q{i + 1}: {q.get('question') or ''}")
+    return "\n".join(lines)
+
+
+def combine_semantic(items):
+    s = set()
+    for it in items:
+        for kw in (it.get("semantic") or []):
+            if kw and kw.strip():
+                s.add(kw.strip())
+    return sorted(s)
+
+
+# Port of step-10 script.py: weighted volume of the top-3 semantic keywords
+# per question (weights 0.5/0.3/0.2, normalized); < 50 → "10~50".
+def calc_question_volume(items, volume_items):
+    vol_map = {}
+    for v in volume_items:
+        if v and v.get("keyword"):
+            vol_map[v["keyword"].lower()] = v["search_volume"]
+    weights = [0.5, 0.3, 0.2]
+    results = {}
+    for content in items:
+        question = content.get("question") or ""
+        semantic = content.get("semantic") or []
+        found = []
+        missing = []
+        for kw in semantic:
+            key = (kw or "").lower()
+            vol = vol_map.get(key)
+            if vol is not None:
+                found.append([kw, vol])
+            else:
+                missing.append(kw)
+        found.sort(key=lambda a: a[1], reverse=True)
+        top = found[:3]
+        sum_w = sum(weights[: len(top)])
+        if sum_w == 0:
+            sum_w = 1
+        weighted = 0
+        for idx, t in enumerate(top):
+            weighted += t[1] * weights[idx]
+        final_vol = weighted / sum_w
+        results[question] = {
+            "top_semantic_keywords": [t[0] for t in top],
+            "search_volume": "10~50" if final_vol < 50 else round(final_vol),
+            "missing_semantic_keywords": missing,
+        }
+    return results
+
+
+# ═══ Steps 1 + 2 : Reddit + Google search (parallel) ═════════════════════════
+phase("Search")
+
+reddit_prompt = f"""You are researching what real users say about a topic on Reddit, for SEO/AEO keyword research.
+
+Topic / search keywords: "{keyword}"
+
+Use web search (try queries like: site:reddit.com {keyword}  ·  {keyword} reddit  ·  "{keyword}" reddit recommendations / experiences / vs / alternatives) to find the most relevant Reddit threads and discussions.
+
+Return a concise PLAIN-TEXT digest of the most relevant Reddit findings (aim for 10-20 threads). For each thread: put the subreddit + thread title on one line, then a 1-3 sentence summary of what users are asking, recommending, complaining about, comparing, or deciding between. Capture real user language, pain points, trade-offs, constraints, and comparison moments. No preamble and no markdown headers."""
+
+google_prompt = f"""You are gathering Google search results for SEO/AEO research — simulate scraping the Google SERP for this query.
+
+Query: "{keyword}"
+
+Use web search to gather:
+1) organic_results: the top ~10 organic web results. For each: title, snippet (a 1-2 sentence description of the page — REMOVE any raw URLs from the snippet text), and link (the result URL).
+2) related_questions: the "People also ask" style questions related to this query (aim for 8-10). Each item is just the question text.
+
+Return ONLY the structured object."""
+
+search_results = await parallel([
+    lambda: agent(reddit_prompt, label="reddit-search", phase="Search"),
+    lambda: agent(google_prompt, label="google-search", phase="Search", schema=GOOGLE_SCHEMA),
+])
+reddit = search_results[0] or "No Reddit results available."
+google = search_results[1] or {"organic_results": [], "related_questions": []}
+
+# ═══ Steps 3 + 4 : format the SERP (pure Python) ═════════════════════════════
+google_results_text = format_organic(google.get("organic_results"))
+people_also_ask_text = format_people_also_ask(google.get("related_questions"))
+log(
+    f"Google: {len(google.get('organic_results') or [])} organic results, "
+    f"{len(google.get('related_questions') or [])} related questions"
+)
+
+# ═══ Step 5 : Keyword Research Docs ══════════════════════════════════════════
+phase("Research")
+
+if guide_url:
+    _guide_block = (
+        f"- Keyword Research Guide: {guide_url}  (fetch this with WebFetch; if it is unavailable, "
+        f"fall back to standard SEO/AEO keyword-research best practices)"
+    )
+else:
+    _guide_block = f"""- Keyword Research Guide (apply this methodology):
+<keyword_research_guide>
+{KEYWORD_RESEARCH_GUIDE}
+</keyword_research_guide>
+  (Note: the guide's "Output format" section describes question generation in a later step — for THIS task, follow the Task and output requirements stated below.)"""
+
+research_prompt = f"""Input:
+{_guide_block}
+- Original search keywords: [ {keyword} ]
+- Google search results:
+{google_results_text}
+- Google "people also search":
+{people_also_ask_text}
+- Reddit search results:
+{reddit}
+- In addition, use web search as much as possible to obtain more relevant information.
+- Today: determine the current date (run `date +%Y-%m-%d` if helpful).
+
+Task:
+Using the Keyword Research Guide, analyze the topic and search results.
+
+In addition to identifying keywords and opportunities, focus on understanding and articulating:
+- The typical situations users are in when searching this topic
+- The decisions they are trying to make
+- The uncertainties, trade-offs, or constraints they are facing
+- Common comparison or evaluation moments observed in search and discussions
+
+Do NOT compress everything into keyword phrases.
+Any section written primarily as search-style phrases rather than descriptive language should be considered invalid and rewritten.
+Instead, explain these findings in clear natural language, as short descriptive bullet points or short paragraphs, preserving user context and reasoning.
+
+At the end, include a section called: "Condensed Intent Signals"
+- This section should list short keyword-style phrases (one per line) that represent the compressed form of the above contexts.
+- In the "Condensed Intent Signals" section, produce exactly {count} distinct intent signals, one per line."""
+
+research_doc = await agent(research_prompt, label="keyword-research-doc", phase="Research")
+if not research_doc:
+    raise RuntimeError("Step 5 (Keyword Research Docs) returned no output.")
+
+# ═══ Step 6 : Asking questions ═══════════════════════════════════════════════
+phase("Questions")
+
+questions_prompt = f"""You are rewriting condensed intent signals into natural, user-facing questions.
+
+Context:
+The intent signals are shorthand labels derived from deeper research.
+They are not final questions and must be expressed as real queries.
+
+Inputs:
+1) Full research context (the "Condensed Intent Signals" section is at the end):
+{research_doc}
+
+Task:
+For each intent signal, rewrite it as a natural question that represents
+a selection or filtering intent — describing what kind of solution
+the user is looking for.
+
+Rules:
+- Each output must be a complete question ending with a question mark.
+- The question should be concise and search-like, but sound natural when spoken.
+- Do NOT explain reasoning, trade-offs, or decision logic.
+- Do NOT ask how to choose, evaluate, or consider options.
+- Do NOT output keyword-style fragments or reuse the intent signal verbatim.
+- Do NOT introduce brand names unless they appear in the input.
+
+Quality check (internal):
+If the question sounds like a buying guide, expert advice request,
+or long-form explanation prompt, shorten or simplify it.
+
+Output:
+One question per line. No numbering. No bullets. No extra text. Produce {count} questions."""
+
+questions_raw = await agent(questions_prompt, label="asking-questions", phase="Questions")
+question_lines = [
+    line
+    for line in (
+        re.sub(r"^\s*[-*\d.)\]]+\s*", "", s).strip()
+        for s in (questions_raw or "").split("\n")
+    )
+    if len(line) > 0 and "?" in line
+]
+if not question_lines:
+    raise RuntimeError("Step 6 (Asking questions) produced no questions.")
+log(f"Generated {len(question_lines)} questions")
+
+# ═══ Step 7 : Question -> Keywords ═══════════════════════════════════════════
+phase("Keywords")
+
+keywords_prompt = f"""You are an SEO expert. Extract keywords from each of the following questions.
+
+Questions (one per line):
+{chr(10).join(question_lines)}
+
+Rules:
+1. Identify ONE core intent keyword.
+2. Identify up to 5 semantic-equivalent keywords (same user intent).
+3. Identify up to 5 long-tail supporting keywords.
+4. Remove stopwords.
+5. Do NOT invent brands.
+
+Return one object per question. Each object must include the EXACT original question text (verbatim) plus its core, semantic (array), and longtail (array) keywords."""
+
+kw_out = await agent(keywords_prompt, label="question-to-keywords", phase="Keywords", schema=KEYWORDS_SCHEMA)
+kw_items = (kw_out and kw_out.get("items")) or []
+if not kw_items:
+    raise RuntimeError("Step 7 (Question -> Keywords) produced no keyword items.")
+
+# ═══ Step 8 : Combine semantic keywords (pure Python) ════════════════════════
+semantic_list = combine_semantic(kw_items)
+log(f"Combined {len(semantic_list)} unique semantic keywords across {len(kw_items)} questions")
+
+# ═══ Step 9 : Fetch Keywords Search Volume (estimated) ═══════════════════════
+phase("Volume")
+
+volume_prompt = f"""You are an SEO keyword research analyst. Estimate the approximate average MONTHLY Google search volume (US market) for each keyword below.
+
+Keywords (one per line):
+{chr(10).join(semantic_list)}
+
+Notes:
+- Live DataForSEO / Google Ads data is not available here, so produce reasoned estimates based on your knowledge and (optionally) web-search signals about popularity and competition.
+- search_volume must be an integer (average monthly searches). Use 0 only when there is essentially no search demand.
+
+Return one object per keyword: keyword (exact text as given) and search_volume (integer)."""
+
+vol_out = await agent(volume_prompt, label="search-volume", phase="Volume", schema=VOLUME_SCHEMA)
+vol_items = (vol_out and vol_out.get("items")) or []
+log(f"Estimated search volume for {len(vol_items)} keywords")
+
+# ═══ Step 10 : Calc per-question search volume (pure Python) ══════════════════
+question_volumes = calc_question_volume(kw_items, vol_items)
+vol_by_q = {}
+for q, info in question_volumes.items():
+    vol_by_q[q.strip().lower()] = info["search_volume"]
+rows = [[q, vol_by_q.get(q.strip().lower(), 0)] for q in question_lines]
+
+# ═══ Step 11 : Export questions to CSV (agent writes the file) ═══════════════
+phase("Export")
+
+export_prompt = f"""Write research questions to a CSV file, MERGING with any existing file at the same path. Follow this exactly.
+
+Output CSV path (relative to the current working directory): {csv_path}
+
+CSV columns (exact header line): Time,Question,Search Volume
+
+New rows to add — JSON array of [question, search_volume] pairs:
+{json.dumps(rows, indent=2)}
+
+Rules (follow precisely):
+1. "Time" is the current timestamp formatted "YYYY-MM-DD HH:MM" — get it once via:  date '+%Y-%m-%d %H:%M'  — and use that same value for every NEW row you add.
+2. Ensure the parent directory of the output path exists (create it if needed).
+3. If the CSV already exists, read it and merge:
+   - Keep all existing rows.
+   - For a question that already exists, UPDATE its Search Volume only if the new value is non-empty, not "0", and different from the existing value (keep the existing Time for those).
+   - Add genuinely new questions as new rows with the current timestamp.
+4. Properly CSV-quote any field containing a comma, double-quote, or newline.
+5. Sort all rows by Time, then by Question.
+6. Write the complete file: the header line followed by all rows.
+
+Implement this by writing a small Python 3 script to a temp file and running it with python3 (do NOT rely on any pre-injected variables). After the file is written, print ONLY the absolute path to the CSV file as the final line of your output — nothing else."""
+
+export_out = await agent(export_prompt, label="export-csv", phase="Export")
+out_lines = [s.strip() for s in (export_out or "").split("\n") if s.strip()]
+final_path = next((line for line in reversed(out_lines) if line.endswith(".csv")), csv_path)
+
+# ═══ Step 12 : CSV file path (workflow return value) ═════════════════════════
+log(f"Done. CSV written to: {final_path}")
+return {
+    "keyword": keyword,
+    "csvPath": final_path,
+    "questionsCount": len(question_lines),
+    "semanticKeywordsCount": len(semantic_list),
+    "intentSignalsTarget": count,
+    "organicResults": len(google.get("organic_results") or []),
+    "relatedQuestions": len(google.get("related_questions") or []),
+    "note": "Search volumes are model-estimated (DataForSEO / Google Ads not available in Claude Code). Reddit + Google SERP gathered via WebSearch instead of the upstream SerpAPI / Reddit integrations.",
+}

--- a/demos/workflows/03-aeo-data-scientist.js
+++ b/demos/workflows/03-aeo-data-scientist.js
@@ -1,0 +1,1095 @@
+export const meta = {
+  name: 'aeo-data-scientist',
+  description: 'AEO Full-Stack Data Scientist — ask research questions on ChatGPT, Google AI and Perplexity (cookie-less browser), measure brand visibility vs competitors, analyze cited domains, and write an AEO report.',
+  whenToUse: 'Run with a brand name plus research questions (or the CSV produced by /user-prompt-research) to measure how often the brand appears in AI-engine answers, who the competitors are, and which domains get cited. Designed for small daily batches: each run scrapes a few uncovered questions and recomputes scores/report over ALL accumulated data.',
+  phases: [
+    { title: 'Init', detail: 'Load questions (args or CSV) + scan workspace coverage' },
+    { title: 'Scrape', detail: 'Ask each pending question on ChatGPT / Google AI / Perplexity, no login' },
+    { title: 'Competitors', detail: 'Extract + clean competitor brands from AI answers' },
+    { title: 'Visibility', detail: 'Brand/competitor visibility scores (pure JS port)' },
+    { title: 'Domains', detail: 'Citation domain matrix, URL mapping, LLM categorization' },
+    { title: 'Report', detail: 'Write the AEO report + run log' },
+  ],
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Singula-AI AEO marketing workflow — faithful port of the upstream
+// "Agent 3: AEO Full-Stack Data Scientist" (27 nodes)
+// to a Claude Code dynamic workflow.
+//
+//   Upstream node                              → workflow implementation
+//   1  Generate job id (py)                   → init agent (date-based id; no RNG in script)
+//   2  Workspace path (py, /tmp/<job>)        → persistent ./demos/aeo-output/aeo-data-scientist/<brand-slug>/
+//   3  Initialization (py, metadata.json)     → run log appended to metadata.json (export agent)
+//   4  Question list (py passthrough)         → args.questions OR /user-prompt-research CSV (closes the
+//                                               team-bus seam the upstream left manual)
+//   5  Extension scraping (chrome_extension)  → per-question agent + gstack /browse, NO COOKIES
+//   6  Save Extension Result (py)             → same agent writes canonical answer JSONs
+//   7  1-Gather AI results (loop, Playwright) → same agents (sequential loop, small batch per run)
+//   8  Select Data Retrieval Mode (js)        → not needed (always cookie-less browse path)
+//   9  1-Write questions to txt (py)          → questions.txt via export agent
+//   10 1-Save raw data S3 (py)                → SKIPPED: no upstream S3 — everything stays on local fs
+//   11 Submit Query thru API (py)             → SKIPPED (upstream vendor backend)
+//   12 2-Parse answers (py, random sample)    → pure JS, DETERMINISTIC sample (no RNG allowed here)
+//   13 2-Find all competitors (gpt-4.1)       → agent (faithful prompt)
+//   14 2-Reformat competitor list (gpt-4.1)   → agent (faithful prompt, schema-forced list)
+//   15 2-Pull competitors from API (py)       → SKIPPED (upstream vendor backend); LLM list is sole source
+//   16 2-Calculate Visibility Score (py)      → pure JS port (same math, same output keys)
+//   17 2-Submit score thru API (py)           → SKIPPED (upstream vendor backend); saved locally instead
+//   18 3-Parse reference to csv (py)          → pure JS port (zero-count rows omitted — step 22
+//                                               filtered them out anyway)
+//   19 3-Parse domain relations (py)          → pure JS port (url normalization, reuse stats)
+//   20 3-Analyze domain categories (ai)       → agent (faithful prompt, schema-forced)
+//   21 3-Domain categories 3D CSV (py)        → pure JS builds domain_summary.csv (export agent writes)
+//   22 3-Combine ref data (py)                → pure JS port (full analysis JSON shape)
+//   23 3-Domain reference list (py→HTML+S3)   → pure JS HTML (condensed), saved locally, no S3/API
+//   24 3-Write ref domain report (ai)         → agent (faithful prompt; hardcoded "blood pressure
+//                                               monitors" example genericized to args topic)
+//   25 3-Save report to file (py)             → export agent
+//   26 Upload to S3 (py)                      → SKIPPED: local fs only (user decision)
+//   27 Collect results (py)                   → workflow return value
+//
+// Cookie-less + incremental design (user decision): the browser runs logged
+// out (fresh profile, no cookies), and ChatGPT / Google / Perplexity tolerate
+// only a few anonymous queries at a time. So each run scrapes at most
+// `maxQuestions` not-yet-covered questions (default 3), records per-platform
+// success/blocked status, and recomputes all analysis over the FULL
+// accumulated corpus. Schedule the workflow daily to grow coverage gradually;
+// failed/blocked (platform, question) pairs are retried on later runs.
+//
+// Browser prerequisites (empirical, 2026-06-09):
+//   - The browse daemon must be STARTED FROM THE MAIN SESSION — Claude Code's
+//     command sandbox blocks workflow subagents from cold-starting it (hangs
+//     on "[browse] Starting server...").
+//   - It must run in HEADED stealth mode (/connect-chrome): headless mode is
+//     bot-blocked by all three platforms on the very first anonymous query;
+//     headed stealth passes all three without any login.
+//
+// Input : args = { brand (required), brandLink?, topic?, questions?: string[]|string,
+//                  questionsCsv?: path, maxQuestions?: 3, platforms?: subset of
+//                  ['chatgpt','google-ai','perplexity'], outputDir? }
+//   - questions source precedence: args.questions > args.questionsCsv >
+//     derived ./demos/aeo-output/user-prompt-research/<topic-slug>-questions.csv
+// Output: { jobId, visibility, topCompetitors, topDomains, reportPath, ... }
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ── args normalization ───────────────────────────────────────────────────────
+let input = args ?? {}
+if (typeof input === 'string') {
+  const t = input.trim()
+  if (t.startsWith('{')) {
+    try { input = JSON.parse(t) } catch (_) { input = { brand: t } }
+  } else {
+    input = { brand: t }
+  }
+}
+const brand = (input.brand || '').toString().trim()
+if (!brand) {
+  throw new Error(
+    'No brand provided. Pass args like { brand: "Cursor", topic: "ai coding assistant" } ' +
+    'or { brand: "Cursor", questions: ["...", "..."] }.',
+  )
+}
+const brandLink = (input.brandLink || '').toString().trim()
+const topic = (input.topic || '').toString().trim()
+// Canonical slugify — keep IDENTICAL across all marketing workflows: the
+// CSV/workspace handoff between pipeline stages depends on matching slugs.
+const slugify = (s, max = 80) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, max).replace(/-+$/, '') || 'item'
+const brandSlug = slugify(brand, 40)
+const workspace = (input.outputDir || `./demos/aeo-output/aeo-data-scientist/${brandSlug}`).replace(/\/+$/, '')
+const maxQuestions = Number(input.maxQuestions) > 0 ? Math.floor(Number(input.maxQuestions)) : 3
+const ALL_PLATFORMS = ['chatgpt', 'google-ai', 'perplexity']
+const platforms = Array.isArray(input.platforms) && input.platforms.length
+  ? input.platforms.filter((p) => ALL_PLATFORMS.includes(p))
+  : ALL_PLATFORMS
+if (!platforms.length) throw new Error(`platforms must be a subset of ${ALL_PLATFORMS.join(', ')}`)
+
+// explicit questions (array or newline string), else CSV path
+let explicitQuestions = []
+if (Array.isArray(input.questions)) explicitQuestions = input.questions
+else if (typeof input.questions === 'string') explicitQuestions = input.questions.split('\n')
+explicitQuestions = explicitQuestions.map((q) => q.toString().trim()).filter((q) => q.length > 0)
+
+let csvPath = (input.questionsCsv || '').toString().trim()
+if (!explicitQuestions.length && !csvPath && topic) {
+  csvPath = `./demos/aeo-output/user-prompt-research/${slugify(topic)}-questions.csv`
+}
+if (!explicitQuestions.length && !csvPath) {
+  throw new Error(
+    'No questions provided. Pass questions: [...], questionsCsv: "<path>", or topic: "<keyword>" ' +
+    '(topic derives the CSV written by /user-prompt-research). Run /user-prompt-research first if needed.',
+  )
+}
+const topicLabel = topic || `${brand}-related products/services`
+
+log(`Brand: "${brand}"  ·  workspace: ${workspace}  ·  batch: up to ${maxQuestions} question(s) × [${platforms.join(', ')}]  ·  no-login browser mode`)
+
+// ── JSON Schemas for schema-forced agent steps ───────────────────────────────
+const INIT_SCHEMA = {
+  type: 'object',
+  properties: {
+    runTime: { type: 'string' },        // "YYYY-MM-DD HH:MM:SS"
+    runStamp: { type: 'string' },       // "YYYY_MM_DD_HH_MM_SS"
+    daemonHealthy: { type: 'boolean' }, // gstack browse daemon reachable?
+    daemonMode: { type: 'string' },     // 'headed' | 'launched' (headless) | 'none'
+    csvQuestions: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { question: { type: 'string' }, volume: { type: 'string' } },
+        required: ['question', 'volume'],
+        additionalProperties: false,
+      },
+    },
+    covered: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          platform: { type: 'string' },
+          file: { type: 'string' },
+          question: { type: 'string' },
+          status: { type: 'string' },
+        },
+        required: ['platform', 'file', 'question', 'status'],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ['runTime', 'runStamp', 'daemonHealthy', 'daemonMode', 'csvQuestions', 'covered'],
+  additionalProperties: false,
+}
+
+// Sandboxed subagents CANNOT cold-start the browse daemon (the sandbox blocks
+// the server bind and the CLI hangs on "[browse] Starting server..."). They can
+// only talk to an ALREADY-RUNNING daemon. Every browse call therefore goes
+// through this hang-proof wrapper, and Init verifies the daemon up-front.
+const BROWSE_WRAPPER = `Run every browse command through this hang-proof wrapper (NEVER call the browse binary directly — a cold daemon start hangs forever in this sandbox):
+python3 -c "import subprocess,os,sys; r=subprocess.run([os.path.expanduser('~/.claude/skills/gstack/browse/dist/browse')]+sys.argv[1:],capture_output=True,text=True,timeout=90); print(r.stdout); print(r.stderr,file=sys.stderr)" <command> <args...>
+If a call raises TimeoutExpired twice in a row, stop using the browser and mark the affected platform(s) failed with note "browse timeout". Never let any single Bash call run longer than ~120 seconds.`
+
+const SCRAPE_SCHEMA = {
+  type: 'object',
+  properties: {
+    results: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          platform: { type: 'string', enum: ALL_PLATFORMS },
+          status: { type: 'string', enum: ['completed', 'failed'] },
+          answerChars: { type: 'integer' },
+          sourcesCount: { type: 'integer' },
+          note: { type: 'string' },     // '' when fine; 'blocked: login wall', 'captcha', etc.
+        },
+        required: ['platform', 'status', 'answerChars', 'sourcesCount', 'note'],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ['results'],
+  additionalProperties: false,
+}
+
+const CORPUS_SCHEMA = {
+  type: 'object',
+  properties: {
+    answers: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          platform: { type: 'string' },
+          question: { type: 'string' },
+          status: { type: 'string' },
+          answer: { type: 'string' },
+          sources: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: { url: { type: 'string' }, title: { type: 'string' } },
+              required: ['url', 'title'],
+              additionalProperties: false,
+            },
+          },
+        },
+        required: ['platform', 'question', 'status', 'answer', 'sources'],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ['answers'],
+  additionalProperties: false,
+}
+
+const COMPETITORS_SCHEMA = {
+  type: 'object',
+  properties: { competitors: { type: 'array', items: { type: 'string' } } },
+  required: ['competitors'],
+  additionalProperties: false,
+}
+
+const DOMCAT_SCHEMA = {
+  type: 'object',
+  properties: {
+    items: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          domain: { type: 'string' },
+          total_citations: { type: 'integer' },
+          category: { type: 'string' },
+          category_name: { type: 'string' },
+        },
+        required: ['domain', 'total_citations', 'category', 'category_name'],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ['items'],
+  additionalProperties: false,
+}
+
+const EXPORT_SCHEMA = {
+  type: 'object',
+  properties: { files: { type: 'array', items: { type: 'string' } } },
+  required: ['files'],
+  additionalProperties: false,
+}
+
+// ── pure-JS ports of the upstream python transforms ───────────────────────────
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// step-16 get_domain_from_url / step-18 extract_domain_from_url
+function domainFromUrl(url) {
+  if (!url) return ''
+  let u = url.trim()
+  if (!/^https?:\/\//i.test(u)) u = 'https://' + u
+  const m = u.match(/^https?:\/\/([^/?#]+)/i)
+  let domain = (m ? m[1] : '').toLowerCase()
+  domain = domain.replace(/^www\./, '').replace(/:\d+$/, '')
+  return domain
+}
+
+// step-19 normalize_url
+function normalizeUrl(url) {
+  let base = url.split('?')[0].split('#')[0]
+  if (base.endsWith('/')) base = base.slice(0, -1)
+  return base
+}
+
+function csvField(v) {
+  const s = String(v ?? '')
+  return /[",\n]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s
+}
+
+// "10~50" → 30 midpoint for sorting; plain ints pass through
+function volumeToNumber(v) {
+  const s = String(v ?? '').trim()
+  const range = s.match(/^(\d+)\s*~\s*(\d+)$/)
+  if (range) return (Number(range[1]) + Number(range[2])) / 2
+  const n = Number(s)
+  return Number.isFinite(n) ? n : 0
+}
+
+// step-12 port: per-platform sample of completed answers, joined as one text.
+// Original used random.sample(n/3, max 10); RNG is banned in workflow scripts,
+// so we take an evenly-spaced deterministic sample of the same size.
+function sampleAnswerText(corpus) {
+  const texts = []
+  for (const platform of ALL_PLATFORMS) {
+    const entries = corpus
+      .filter((a) => a.platform === platform && a.status === 'completed' && a.answer.trim())
+      .sort((x, y) => x.question.localeCompare(y.question))
+    if (!entries.length) continue
+    const n = entries.length
+    const size = Math.min(Math.max(1, Math.floor(n / 3)), 10, n)
+    for (let k = 0; k < size; k++) {
+      const idx = Math.floor((k * n) / size)
+      texts.push(entries[idx].answer.replace(/[\r\n]+/g, ' '))
+    }
+  }
+  return texts.join('\n')
+}
+
+// step-16 extract_ai_content equivalent over our canonical answer entries
+function answerContent(entry) {
+  const sourceText = entry.sources
+    .map((s) => `${domainFromUrl(s.url)} ${s.title || ''}`)
+    .join(' ')
+  return `${entry.answer} ${sourceText}`
+}
+
+function mentionCount(name, content) {
+  if (!name || !content) return 0
+  const re = new RegExp(`\\b${escapeRegex(name)}\\b`, 'gi')
+  return (content.match(re) || []).length
+}
+
+// step-16 analyze_brand_visibility port (same output keys)
+function analyzeBrandVisibility(corpus, brandName, link) {
+  const valid = corpus.filter((a) => a.status === 'completed' && a.answer.trim())
+  if (!valid.length) {
+    return {
+      brand_name: brandName, brand_link: link, brand_logo: '',
+      brand_visibility_score_percentage: 0.0,
+      brand_link_visibility_score_percentage: 0.0,
+      brand_mentions: 0, brand_link_mentions: 0,
+      platform_visibility_score_percentage_list: [],
+    }
+  }
+  const linkDomain = domainFromUrl(link)
+  let totalScore = 0, totalLinkScore = 0, totalMentions = 0, totalLinkMentions = 0
+  const platformStats = {}
+  for (const entry of valid) {
+    const content = answerContent(entry)
+    const mentions = mentionCount(brandName, content)
+    const linkMentions = linkDomain ? mentionCount(linkDomain, content) : 0
+    totalScore += mentions > 0 ? 1 : 0
+    totalLinkScore += linkMentions > 0 ? 1 : 0
+    totalMentions += mentions
+    totalLinkMentions += linkMentions
+    const p = entry.platform
+    if (!platformStats[p]) platformStats[p] = { total: 0, withBrand: 0, mentions: 0, withLink: 0, linkMentions: 0 }
+    platformStats[p].total += 1
+    if (mentions > 0) platformStats[p].withBrand += 1
+    platformStats[p].mentions += mentions
+    if (linkMentions > 0) platformStats[p].withLink += 1
+    platformStats[p].linkMentions += linkMentions
+  }
+  const round2 = (x) => Math.round(x * 100) / 100
+  const platformList = Object.entries(platformStats).map(([name, s]) => ({
+    platform_name: name,
+    platform_logo: '',
+    platform_visibility_score_percentage: round2((s.withBrand / s.total) * 100),
+    platform_brand_link_visibility_score_percentage: round2((s.withLink / s.total) * 100),
+    platform_brand_mentions: s.mentions,
+    platform_brand_link_mentions: s.linkMentions,
+  }))
+  return {
+    brand_name: brandName, brand_link: link, brand_logo: '',
+    brand_visibility_score_percentage: round2((totalScore / valid.length) * 100),
+    brand_link_visibility_score_percentage: round2((totalLinkScore / valid.length) * 100),
+    brand_mentions: totalMentions, brand_link_mentions: totalLinkMentions,
+    platform_visibility_score_percentage_list: platformList,
+  }
+}
+
+// step-18 port: platform×question×domain citation matrix + domain summary.
+// Deviation: long-format rows with citation_count === 0 are omitted (step-22
+// filtered count>0 anyway, and zero rows explode the CSV as coverage grows).
+function buildCitationMatrix(corpus) {
+  const matrix = {}
+  const allDomains = new Set()
+  for (const entry of corpus) {
+    if (entry.status !== 'completed') continue
+    let q = entry.question
+    if (q.length > 100) q = q.slice(0, 97) + '...'
+    if (!q) continue
+    const domains = entry.sources.map((s) => domainFromUrl(s.url)).filter(Boolean)
+    if (!domains.length) continue
+    const p = entry.platform
+    matrix[p] = matrix[p] || {}
+    matrix[p][q] = matrix[p][q] || {}
+    for (const d of domains) {
+      matrix[p][q][d] = (matrix[p][q][d] || 0) + 1
+      allDomains.add(d)
+    }
+  }
+  const rows = []
+  for (const p of Object.keys(matrix).sort()) {
+    for (const q of Object.keys(matrix[p]).sort()) {
+      for (const d of Object.keys(matrix[p][q]).sort()) {
+        rows.push({ platform: p, question: q, domain: d, citation_count: matrix[p][q][d] })
+      }
+    }
+  }
+  const totals = {}
+  for (const r of rows) totals[r.domain] = (totals[r.domain] || 0) + r.citation_count
+  const domainSummary = Array.from(allDomains)
+    .sort()
+    .map((d) => ({ domain: d, total_citations: totals[d] || 0, category: '' }))
+    .sort((a, b) => b.total_citations - a.total_citations)
+  return { rows, domainSummary, matrix }
+}
+
+// step-19 port: domain → url/platform/question mapping with reuse stats
+function buildUrlMapping(corpus) {
+  const mapping = {}
+  for (const entry of corpus) {
+    if (entry.status !== 'completed') continue
+    let q = entry.question
+    if (q.length > 100) q = q.slice(0, 97) + '...'
+    if (!q) continue
+    for (const s of entry.sources) {
+      const url = (s.url || '').trim()
+      const domain = domainFromUrl(url)
+      if (!domain) continue
+      const norm = normalizeUrl(url)
+      const m = mapping[domain] = mapping[domain] || { citations: {}, urlUsage: {}, platforms: new Set(), urls: new Set() }
+      m.urlUsage[norm] = m.urlUsage[norm] || []
+      if (!m.urlUsage[norm].includes(q)) m.urlUsage[norm].push(q)
+      const key = `${norm}\u0000${q}`
+      if (m.citations[key]) {
+        if (!m.citations[key].platforms.includes(entry.platform)) m.citations[key].platforms.push(entry.platform)
+      } else {
+        m.citations[key] = { url, platform: entry.platform, platforms: [entry.platform], question: q }
+      }
+      m.platforms.add(entry.platform)
+      m.urls.add(norm)
+    }
+  }
+  const final = {}
+  for (const domain of Object.keys(mapping).sort()) {
+    const m = mapping[domain]
+    const citations = Object.values(m.citations).map((c) => ({
+      url: c.url,
+      platform: c.platforms.length > 1 ? c.platforms.slice().sort().join(', ') : c.platform,
+      question: c.question,
+    }))
+    const reuse = Object.values(m.urlUsage).filter((qs) => qs.length > 1)
+    final[domain] = {
+      url_citations: citations,
+      total_platform_question_unique_citations: citations.length,
+      unique_urls: m.urls.size,
+      platforms: Array.from(m.platforms).sort(),
+      url_reuse: reuse.length,
+      max_url_reuse: reuse.length ? Math.max(...reuse.map((qs) => qs.length)) : 0,
+    }
+  }
+  return final
+}
+
+// step-22 port: combine matrix + category map into the report-input JSON
+function combineRefData(rows, categoryMap) {
+  const overall = {}, platformDomains = {}, questionDomains = {}, pqDomains = {}, totals = {}
+  const platforms2 = new Set(), questions = new Set(), domains = new Set()
+  for (const r of rows) {
+    if (r.citation_count <= 0) continue
+    platforms2.add(r.platform); questions.add(r.question); domains.add(r.domain)
+    totals[r.domain] = (totals[r.domain] || 0) + r.citation_count
+    overall[r.domain] = (overall[r.domain] || 0) + 1
+    ;(platformDomains[r.platform] = platformDomains[r.platform] || {})[r.domain] =
+      (platformDomains[r.platform]?.[r.domain] || 0) + 1
+    ;(questionDomains[r.question] = questionDomains[r.question] || {})[r.domain] =
+      (questionDomains[r.question]?.[r.domain] || 0) + 1
+    const pq = (pqDomains[r.platform] = pqDomains[r.platform] || {})
+    ;(pq[r.question] = pq[r.question] || {})[r.domain] = (pq[r.question]?.[r.domain] || 0) + 1
+  }
+  const cat = (d) => categoryMap[d] || 'unknown'
+  const result = {
+    summary: {
+      total_platforms: platforms2.size,
+      total_questions: questions.size,
+      total_unique_domains: domains.size,
+      total_platform_question_pairs: Object.values(overall).reduce((a, b) => a + b, 0),
+      total_actual_citations: Object.values(totals).reduce((a, b) => a + b, 0),
+    },
+    overall: {
+      description: 'Domain occurrence frequency across platform-question combinations',
+      all_domains: Object.entries(overall)
+        .map(([d, c]) => ({ domain: d, category: cat(d), platform_question_occurrences: c, actual_citation_total: totals[d] }))
+        .sort((a, b) => b.platform_question_occurrences - a.platform_question_occurrences),
+    },
+    by_platform: {},
+    by_question: {},
+    platform_question_breakdown: {},
+  }
+  for (const p of Array.from(platforms2).sort()) {
+    const pd = platformDomains[p]
+    result.by_platform[p] = {
+      total_question_occurrences: Object.values(pd).reduce((a, b) => a + b, 0),
+      unique_domains: Object.keys(pd).length,
+      all_domains: Object.entries(pd)
+        .map(([d, c]) => ({ domain: d, category: cat(d), question_occurrences: c }))
+        .sort((a, b) => b.question_occurrences - a.question_occurrences),
+    }
+  }
+  for (const q of Array.from(questions).sort()) {
+    const qd = questionDomains[q]
+    const display = q.length > 100 ? q.slice(0, 100) + '...' : q
+    result.by_question[display] = {
+      full_question: q,
+      total_platform_occurrences: Object.values(qd).reduce((a, b) => a + b, 0),
+      unique_domains: Object.keys(qd).length,
+      all_domains: Object.entries(qd)
+        .map(([d, c]) => ({ domain: d, category: cat(d), platform_occurrences: c }))
+        .sort((a, b) => b.platform_occurrences - a.platform_occurrences),
+    }
+  }
+  for (const p of Array.from(platforms2).sort()) {
+    const list = []
+    for (const [q, dd] of Object.entries(pqDomains[p] || {})) {
+      const display = q.length > 80 ? q.slice(0, 80) + '...' : q
+      list.push({
+        question: display,
+        total_domain_occurrences: Object.values(dd).reduce((a, b) => a + b, 0),
+        all_domains: Object.entries(dd)
+          .map(([d, c]) => ({ domain: d, category: cat(d), occurrences: c }))
+          .sort((a, b) => b.occurrences - a.occurrences),
+      })
+    }
+    if (list.length) result.platform_question_breakdown[p] = list
+  }
+  // comparative analysis
+  const domainPlatforms = {}
+  for (const [p, pd] of Object.entries(platformDomains)) {
+    for (const d of Object.keys(pd)) (domainPlatforms[d] = domainPlatforms[d] || new Set()).add(p)
+  }
+  const universal = Object.entries(domainPlatforms)
+    .filter(([, ps]) => ps.size === platforms2.size)
+    .map(([d, ps]) => ({
+      domain: d, category: cat(d), platforms: Array.from(ps).sort(),
+      total_platform_question_occurrences: overall[d], actual_citation_total: totals[d],
+    }))
+    .sort((a, b) => b.total_platform_question_occurrences - a.total_platform_question_occurrences)
+  const specific = {}
+  for (const [d, ps] of Object.entries(domainPlatforms)) {
+    if (ps.size === 1) {
+      const p = Array.from(ps)[0]
+      ;(specific[p] = specific[p] || []).push({ domain: d, category: cat(d), question_occurrences: platformDomains[p][d] })
+    }
+  }
+  for (const p of Object.keys(specific)) specific[p].sort((a, b) => b.question_occurrences - a.question_occurrences)
+  result.comparative_analysis = {
+    universal_domains: universal,
+    platform_specific_domains: specific,
+    domain_coverage: {
+      domains_in_all_platforms: universal.length,
+      domains_in_single_platform: Object.values(specific).reduce((a, l) => a + l.length, 0),
+    },
+  }
+  return result
+}
+
+// step-23 port (condensed): static HTML reference list, grouped by category
+function buildReferenceHtml(urlMapping, catNameMap, brandName, runTime) {
+  const byCategory = {}
+  for (const [domain, info] of Object.entries(urlMapping)) {
+    const catName = catNameMap[domain] || 'Other'
+    ;(byCategory[catName] = byCategory[catName] || []).push({ domain, info })
+  }
+  const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+  const parts = [
+    '<!DOCTYPE html><html><head><meta charset="utf-8"><title>Domain Reference List</title>',
+    '<style>body{font-family:Georgia,serif;max-width:960px;margin:2rem auto;padding:0 1rem;color:#222}',
+    'h2{border-bottom:2px solid #b5651d;padding-bottom:4px}h3{margin-bottom:2px}',
+    '.meta{color:#666;font-size:0.9em}li{margin:2px 0}</style></head><body>',
+    `<h1>Domain Reference List</h1><p class="meta">Brand: ${esc(brandName)} · Generated: ${esc(runTime)} · AI-engine citations grouped by domain category</p>`,
+  ]
+  for (const catName of Object.keys(byCategory).sort()) {
+    parts.push(`<h2>${esc(catName)}</h2>`)
+    for (const { domain, info } of byCategory[catName].sort((a, b) => b.info.total_platform_question_unique_citations - a.info.total_platform_question_unique_citations)) {
+      parts.push(`<h3>${esc(domain)}</h3>`)
+      parts.push(`<p class="meta">${info.total_platform_question_unique_citations} citation(s) · ${info.unique_urls} unique URL(s) · platforms: ${esc(info.platforms.join(', '))} · url_reuse: ${info.url_reuse} (max ${info.max_url_reuse})</p>`)
+      parts.push('<ul>')
+      for (const c of info.url_citations) {
+        // citations come from scraped web data — only hyperlink http(s) schemes
+        parts.push(/^https?:\/\//i.test(c.url)
+          ? `<li><a href="${esc(c.url)}">${esc(normalizeUrl(c.url))}</a> — <em>${esc(c.platform)}</em> — ${esc(c.question)}</li>`
+          : `<li>${esc(c.url)} — <em>${esc(c.platform)}</em> — ${esc(c.question)}</li>`)
+      }
+      parts.push('</ul>')
+    }
+  }
+  parts.push('</body></html>')
+  return parts.join('\n')
+}
+
+// ═══ Phase: Init — timestamps, dirs, question CSV, coverage scan ═════════════
+phase('Init')
+
+const initPrompt = `You are initializing a local AEO research workspace. Do these steps exactly; everything is on the local filesystem relative to the current working directory.
+
+1. Run \`date '+%Y-%m-%d %H:%M:%S'\` → return as runTime. Run \`date '+%Y_%m_%d_%H_%M_%S'\` → return as runStamp.
+2. Ensure these directories exist (mkdir -p): ${platforms.map((p) => `${workspace}/answers/${p}`).join('  ')}
+3. ${csvPath
+    ? `Read the CSV file at "${csvPath}" (columns: Time,Question,Search Volume). Return every row as {question, volume} (volume as the raw string, e.g. "140" or "10~50"). If the file does not exist, return an empty csvQuestions array.`
+    : 'No CSV to read — return an empty csvQuestions array.'}
+4. Scan ${workspace}/answers/*/*.json — for EACH json file found, parse it and return {platform: <parent dir name>, file: <basename>, question: <result.question or "">, status: <its "status" field or "failed">}. If the directory is empty or missing, return an empty covered array.
+5. Check the gstack browse daemon WITHOUT risking a hang — run exactly:
+python3 -c "import subprocess,os; r=subprocess.run([os.path.expanduser('~/.claude/skills/gstack/browse/dist/browse'),'status'],capture_output=True,text=True,timeout=20); print(r.stdout)"
+→ daemonHealthy = true only if it prints "Status: healthy" within the timeout. On TimeoutExpired, any exception, or other output: daemonHealthy = false (do NOT retry, do NOT try to start the daemon).
+→ daemonMode = "headed" if the output contains "Mode: headed", "launched" if it contains "Mode: launched", otherwise "none".
+
+Use bash (ls/date/mkdir) and python3 for parsing. Return ONLY the structured object.`
+
+const init = await agent(initPrompt, { label: 'init-workspace', phase: 'Init', schema: INIT_SCHEMA })
+if (!init) throw new Error('Init agent failed — cannot determine workspace state.')
+const runTime = init.runTime.trim()
+const runStamp = init.runStamp.trim()
+const jobId = `AEO_${brandSlug}_${runStamp}`
+
+// Build the master question list (explicit > CSV sorted by volume desc)
+let allQuestions
+if (explicitQuestions.length) {
+  allQuestions = explicitQuestions
+} else {
+  allQuestions = init.csvQuestions
+    .map((r) => ({ q: r.question.trim(), v: volumeToNumber(r.volume) }))
+    .filter((r) => r.q.length > 0 && r.q.includes('?'))
+    .sort((a, b) => b.v - a.v)
+    .map((r) => r.q)
+  // CSV merge keeps duplicates across runs — dedupe, keeping highest-volume order
+  allQuestions = Array.from(new Set(allQuestions))
+}
+if (!allQuestions.length) {
+  throw new Error(`No usable questions found${csvPath ? ` in ${csvPath}` : ''}. Run /user-prompt-research "${topic || brand}" first, or pass questions explicitly.`)
+}
+
+// Coverage: (platform → set of covered question slugs with status completed)
+const coveredSet = new Set(
+  init.covered
+    .filter((c) => c.status === 'completed')
+    .map((c) => `${c.platform}\u0000${slugify(c.question)}`),
+)
+const pending = []   // [{question, slug, missingPlatforms}]
+for (const q of allQuestions) {
+  const slug = slugify(q)
+  const missing = platforms.filter((p) => !coveredSet.has(`${p}\u0000${slug}`))
+  if (missing.length) pending.push({ question: q, slug, missingPlatforms: missing })
+}
+let batch = pending.slice(0, maxQuestions)
+if (!init.daemonHealthy && batch.length) {
+  log('⚠ gstack browse daemon is NOT running — skipping scraping this run (sandboxed agents cannot start it). Start it from the main session (e.g. run `browse status` via the /browse skill), then re-run.')
+  batch = []
+} else if (batch.length && init.daemonMode !== 'headed' && !input.allowHeadless) {
+  // Empirical (2026-06-09): in HEADLESS mode all three platforms hard-block the
+  // anonymous browser on the first query (ChatGPT/Perplexity: Cloudflare loop,
+  // Google: sorry-page captcha). Headed stealth mode (/connect-chrome) passes.
+  log('⚠ browse daemon is running HEADLESS — all 3 platforms bot-block anonymous headless browsers, so scraping is skipped. Run /connect-chrome in the main session for headed stealth mode (or pass allowHeadless: true to force).')
+  batch = []
+}
+log(`Questions: ${allQuestions.length} total · ${pending.length} with missing platform coverage · scraping ${batch.length} this run (job ${jobId})`)
+
+// ═══ Phase: Scrape — sequential, one agent per question, no cookies ══════════
+phase('Scrape')
+
+const scrapeStatus = []  // [{question, results: [{platform, status, note}]}]
+for (const item of batch) {
+  const scrapePrompt = `You are collecting AI-answer-engine responses for AEO (Answer Engine Optimization) research. You operate a headless browser WITHOUT any login cookies (sandbox environment). Work gently: one question, ${item.missingPlatforms.length} platform(s), at most ONE retry per platform. If a platform shows a login wall, captcha, or bot block, mark it failed — do NOT fight it.
+
+QUESTION: ${item.question}
+
+PLATFORMS TO QUERY (only these): ${item.missingPlatforms.join(', ')}
+
+Browser: the gstack browse daemon is ALREADY RUNNING (verified). ${BROWSE_WRAPPER}
+Useful commands: goto <url> · text · snapshot -i · click <sel|@ref> · fill <sel> <val> · type <text> · press Enter · wait --networkidle · links · reload. Take a fresh "text" or "snapshot -i" after each wait to check streaming progress; poll with short waits instead of one long one.
+
+Bot-block handling: if a page shows a Cloudflare/"verify you are human" challenge or a hard login wall, wait ~10s, reload ONCE; if still blocked, mark that platform failed with note "blocked: <reason>" and move on.
+
+Per-platform instructions:
+${item.missingPlatforms.includes('chatgpt') ? `- chatgpt: goto https://chatgpt.com — dismiss any consent/"stay logged out" dialogs. Fill the prompt box with the question, submit, then poll (wait a few seconds + re-read text) until the response stops growing. Extract the assistant's full answer as plain text, plus any cited/linked source URLs in the answer.\n` : ''}${item.missingPlatforms.includes('google-ai') ? `- google-ai: goto https://www.google.com/search?udm=50&q=<url-encoded question> (Google AI Mode). If AI Mode is unavailable without login, fall back to a regular search https://www.google.com/search?q=... and use the "AI Overview" block (click "Show more" if present). Extract the AI-generated answer text and the cited source links (url + title). If there is NO AI-generated answer at all, mark failed with note "no AI answer".\n` : ''}${item.missingPlatforms.includes('perplexity') ? `- perplexity: goto https://www.perplexity.ai/search?q=<url-encoded question> (or the homepage search box). Poll until the answer finishes. Extract the answer text and the numbered source citations (url + title).\n` : ''}
+After scraping, write ONE json file per platform (including failed ones) using a python3 script. Path: ${workspace}/answers/<platform>/${item.slug}.json (overwrite if present). Get TS_MS via python3 int(time.time()*1000). Exact JSON shape:
+{
+  "scriptName": "search-<platform>",
+  "status": "completed" | "failed",
+  "timestamp": TS_MS,
+  "result": {
+    "question": <the question>,
+    "answer": <full plain-text answer, or "" if failed>,
+    "answerLength": <len of answer>,
+    "sources": [{"url": "...", "title": "..."}],
+    "sourcesCount": <len of sources>
+  },
+  "error": null | "<short reason>"
+}
+Rules: status "completed" requires a non-empty real answer actually scraped from the platform. NEVER fabricate an answer or sources from your own knowledge — if scraping failed, status is "failed". Keep answer text as-is (do not summarize it).
+
+Return ONLY the structured object: results = one entry per platform with {platform, status, answerChars, sourcesCount, note} (note "" when fine).`
+
+  const out = await agent(scrapePrompt, { label: `ask:${item.slug.slice(0, 40)}`, phase: 'Scrape', schema: SCRAPE_SCHEMA })
+  const results = (out && out.results) || item.missingPlatforms.map((p) => ({ platform: p, status: 'failed', answerChars: 0, sourcesCount: 0, note: 'scrape agent failed' }))
+  scrapeStatus.push({ question: item.question, results })
+  const lineSummary = results.map((r) => `${r.platform}:${r.status === 'completed' ? 'ok' : 'FAIL'}`).join(' ')
+  log(`"${item.question.slice(0, 60)}..." → ${lineSummary}`)
+}
+
+// per-platform health for this run
+const platformHealth = {}
+for (const p of platforms) {
+  const rs = scrapeStatus.flatMap((s) => s.results).filter((r) => r.platform === p)
+  platformHealth[p] = {
+    attempted: rs.length,
+    completed: rs.filter((r) => r.status === 'completed').length,
+    notes: Array.from(new Set(rs.filter((r) => r.note).map((r) => r.note))),
+  }
+}
+
+// ═══ Load full accumulated corpus (previous runs + this run) ═════════════════
+const corpusPrompt = `Read ALL json files under ${workspace}/answers/*/*.json on the local filesystem (use python3; the answers/<platform>/ dir name is the platform). For each file return one entry:
+{platform, question: result.question, status: <"status" field>, answer: <result.answer, or result.aiGenerated.formattedContent if answer is missing/empty; truncate to 6000 chars>, sources: [{url, title}] from result.sources (use "" for a missing title; for source items that are plain strings, treat the string as the url)}.
+Skip unparseable files. Return ONLY the structured object. If there are no files, return {"answers": []}.`
+
+const corpusOut = await agent(corpusPrompt, { label: 'load-corpus', phase: 'Scrape', schema: CORPUS_SCHEMA })
+const corpus = ((corpusOut && corpusOut.answers) || []).filter((a) => a.question && a.question.trim())
+const validCorpus = corpus.filter((a) => a.status === 'completed' && a.answer.trim())
+log(`Corpus: ${corpus.length} answer files, ${validCorpus.length} valid (completed) answers`)
+if (!validCorpus.length) {
+  throw new Error(
+    `No successful answers in the corpus (platform status: ${JSON.stringify(platformHealth)}; browse daemon healthy: ${init.daemonHealthy}). ` +
+    'Nothing to analyze. If the daemon was down, start it from the main session (any /browse command) and re-run. ' +
+    'If platforms blocked the anonymous browser, try again later, reduce maxQuestions, or import cookies via /setup-browser-cookies.',
+  )
+}
+
+// ═══ Phase: Competitors — steps 12/13/14 (15 skipped: upstream API) ═══════════
+phase('Competitors')
+
+const sampledAnswers = sampleAnswerText(corpus)
+const questionsJoined = allQuestions.join('\n')
+
+// step-13 prompt, faithful
+const findCompetitorsPrompt = `Task: Extract competitor brand names from the AI response.
+
+Variables:
+QUESTIONS = ${questionsJoined}
+AI_ANSWER = ${sampledAnswers}
+
+Context: Based on QUESTIONS, determine the product/service category and usage context being discussed.
+
+Definition - A competitor is a brand/product line that:
+- Offers products/services in the same primary category as discussed in QUESTIONS
+- Targets similar usage context and customer segment
+- Is explicitly mentioned in the AI response
+
+Inclusion rules (ALL required):
+- Name appears verbatim in the AI response
+- Represents a brand or product line name (no model numbers)
+- Relevant to the category implied by QUESTIONS
+- When uncertain, omit
+
+Exclusion rules:
+- Generic terms, technologies, categories (non-proper nouns)
+- Parent companies without specific product lines mentioned
+- Marketplaces/platforms unless they ARE the product category
+- Accessories or complementary items (unless that's your category)
+- Products/services outside the usage context of QUESTIONS
+
+Output format:
+Return only valid competitor names, comma-separated, no extra formatting.
+If none found, return empty string.`
+
+const rawCompetitors = (await agent(findCompetitorsPrompt, { label: 'find-competitors', phase: 'Competitors' })) || ''
+
+// step-14 prompt, faithful (output schema-forced instead of one-per-line text)
+const reformatPrompt = `Inputs
+RAW_LIST = ${rawCompetitors}
+MY_BRAND = ${brand}
+
+IMPORTANT:
+RAW_LIST is the ONLY allowed source of brand names.
+Do NOT generate, infer, explain, or fabricate any names.
+If RAW_LIST is empty or contains no valid brands return an empty list.
+
+Goal
+Clean and deduplicate RAW_LIST, exclude anything that equals MY_BRAND, exclude any empty strings.
+Rules (apply in this order):
+Parse & trim: Split on commas and line breaks; trim whitespace. Remove surrounding quotes/brackets/hashtags and trailing punctuation.
+Canonicalization for matching (not for inventing new names):
+Case-insensitive comparison.
+Ignore common legal suffixes for equality checks (e.g., Inc., LLC, Ltd., Co., GmbH, S.A., S.r.l., Pvt. Ltd., Co., Ltd., PLC, LLP, BV, NV, AB, AG, KK).
+Treat minor punctuation/spacing variants as the same (hyphens, extra spaces, periods).
+Exclude self: Remove any entry that equals MY_BRAND under the canonicalization above, or is an obvious alias/house style of MY_BRAND present in RAW_LIST.
+Scope guard: Keep only brand or product-line names (proper nouns). Discard generic descriptors, categories, feature terms, model numbers/SKUs, and non-brand entities.
+Deduplicate: Preserve the first appearance order from RAW_LIST.
+Use the original surface form from RAW_LIST (except trimming/quote removal).
+
+Return ONLY the structured object: {competitors: [...]}.`
+
+const compOut = await agent(reformatPrompt, { label: 'clean-competitors', phase: 'Competitors', schema: COMPETITORS_SCHEMA })
+const competitors = Array.from(new Set(((compOut && compOut.competitors) || []).map((c) => c.trim()).filter((c) => c && c.toLowerCase() !== brand.toLowerCase())))
+log(`Competitors found in AI answers: ${competitors.length ? competitors.join(', ') : '(none)'}`)
+
+// ═══ Phase: Visibility — step 16 pure-JS port (step 17 skipped) ══════════════
+phase('Visibility')
+
+const visibility = analyzeBrandVisibility(corpus, brand, brandLink)
+visibility.competitors = competitors.map((c) => {
+  const r = analyzeBrandVisibility(corpus, c, '')
+  return {
+    brand_name: c,
+    brand_logo: '',
+    brand_visibility_score_percentage: r.brand_visibility_score_percentage,
+    platform_visibility_score_percentage_list: r.platform_visibility_score_percentage_list,
+  }
+})
+log(`Brand visibility: ${visibility.brand_visibility_score_percentage}% of ${validCorpus.length} valid answers mention "${brand}"`)
+
+// visibility_history.csv row (trend across scheduled runs)
+const platPct = (p) => {
+  const e = visibility.platform_visibility_score_percentage_list.find((x) => x.platform_name === p)
+  return e ? e.platform_visibility_score_percentage : ''
+}
+const historyHeader = 'Time,Job,Valid Answers,Brand %,Link %,chatgpt %,google-ai %,perplexity %'
+const historyRow = [runTime, jobId, validCorpus.length, visibility.brand_visibility_score_percentage, visibility.brand_link_visibility_score_percentage, platPct('chatgpt'), platPct('google-ai'), platPct('perplexity')].map(csvField).join(',')
+
+const exportVisibilityPrompt = `Write these local files using a python3 script (create parent dirs; overwrite unless told to append). Return the structured object {files: [<paths written>]}.
+
+1. WRITE ${workspace}/visibility_score.json with EXACTLY this JSON content:
+${JSON.stringify(visibility, null, 2)}
+
+2. APPEND to ${workspace}/visibility_history.csv: if the file does not exist, first write the header line "${historyHeader}". Then append this row:
+${historyRow}
+
+3. WRITE ${workspace}/questions.txt — one question per line:
+${allQuestions.join('\n')}`
+
+const visExport = await agent(exportVisibilityPrompt, { label: 'export-visibility', phase: 'Visibility', schema: EXPORT_SCHEMA })
+
+// ═══ Phase: Domains — steps 18-23 (pure JS + one LLM categorization) ═════════
+phase('Domains')
+
+const { rows: matrixRows, domainSummary } = buildCitationMatrix(corpus)
+const urlMapping = buildUrlMapping(corpus)
+log(`Citations: ${matrixRows.length} (platform,question,domain) rows across ${domainSummary.length} unique domains`)
+
+// step-20 prompt, faithful (input = step-18 domain_summary), schema-forced
+let categoryMap = {}, catNameMap = {}, domcatItems = []
+if (domainSummary.length) {
+  const domcatPrompt = `From the json input:
+${JSON.stringify({ domain_summary: { description: 'Unique domains with total citation counts', total_unique_domains: domainSummary.length, data: domainSummary } }, null, 2)}
+
+parse the key "domain_summary" and categorize every domain. For each domain produce:
+
+1. domain - the website domain (e.g., "amazon.com")
+2. total_citations - the citation count number
+3. category - snake_case category identifier
+4. category_name - human-readable category name
+
+Category mapping rules:
+- Use these predefined categories when applicable:
+  * "ecommerce" → "E-commerce"
+  * "social_media" → "Social Media"
+  * "news" → "News & Media"
+  * "review_websites" → "Review & Consumer Sites"
+  * "technology" → "Technology Platforms"
+  * "healthcare" → "Healthcare Organizations"
+  * "medical_devices" → "Medical Device Companies"
+  * "health_news" → "Health News & Media"
+  * "research" → "Research & Academic"
+  * "nonprofit" → "Nonprofit Organizations"
+  * "blogs" → "Blogs"
+  * "sports" → "Sports & Fitness"
+  * "government" → "Government & Public Services"
+  * "education" → "Educational Resources"
+
+For domains not fitting above categories, create appropriate snake_case category and corresponding human-readable name.
+Every domain must have both category and category_name filled. Return ONLY the structured object with one item per domain.`
+
+  const domcatOut = await agent(domcatPrompt, { label: 'categorize-domains', phase: 'Domains', schema: DOMCAT_SCHEMA })
+  domcatItems = (domcatOut && domcatOut.items) || []
+  for (const it of domcatItems) {
+    categoryMap[it.domain] = it.category
+    catNameMap[it.domain] = it.category_name
+  }
+}
+
+const analysis = combineRefData(matrixRows, categoryMap)
+const referenceHtml = buildReferenceHtml(urlMapping, catNameMap, brand, runTime)
+
+// CSV strings (steps 18 + 21)
+const matrixCsv = ['platform,question,domain,citation_count']
+  .concat(matrixRows.map((r) => [r.platform, r.question, r.domain, r.citation_count].map(csvField).join(',')))
+  .join('\n')
+const summaryCsv = ['domain,total_citations,category,category_name']
+  .concat(domcatItems.map((it) => [it.domain, it.total_citations, it.category, it.category_name].map(csvField).join(',')))
+  .join('\n')
+
+// Exports are split across two parallel agents to bound per-prompt payload —
+// the corpus (and these artifacts) grow with every scheduled run.
+const exportHeader = 'Write these local files using a python3 script (create parent dirs, overwrite). The payloads below must be written EXACTLY as given. Return the structured object {files: [<paths written>]}.'
+const exportDomainsPromptA = `${exportHeader}
+
+1. WRITE ${workspace}/domain_citation_matrix.csv :
+${matrixCsv}
+
+2. WRITE ${workspace}/domain_summary.csv :
+${summaryCsv}
+
+3. WRITE ${workspace}/domain_reference.html :
+${referenceHtml}`
+
+const exportDomainsPromptB = `${exportHeader}
+
+1. WRITE ${workspace}/domain_url_platform_mapping.json :
+${JSON.stringify(urlMapping, null, 2)}
+
+2. WRITE ${workspace}/domain_analysis_result.json :
+${JSON.stringify(analysis, null, 2)}`
+
+const payloadBytes = exportDomainsPromptA.length + exportDomainsPromptB.length
+if (payloadBytes > 300000) {
+  log(`⚠ domain export payload is ${Math.round(payloadBytes / 1000)}KB and grows with corpus size — consider archiving ${workspace} and starting a fresh question set.`)
+}
+const domExports = await parallel([
+  () => agent(exportDomainsPromptA, { label: 'export-domains-csv-html', phase: 'Domains', schema: EXPORT_SCHEMA }),
+  () => agent(exportDomainsPromptB, { label: 'export-domains-json', phase: 'Domains', schema: EXPORT_SCHEMA }),
+])
+const domExport = { files: domExports.filter(Boolean).flatMap((e) => e.files || []) }
+
+// ═══ Phase: Report — step 24 (faithful, genericized) + 25/27 ═════════════════
+phase('Report')
+
+// keep the report-agent prompt bounded: drop the bulkiest sections if huge
+let reportInput = analysis
+if (JSON.stringify(analysis).length > 150000) {
+  reportInput = { ...analysis, by_question: '(omitted for size)', platform_question_breakdown: '(omitted for size)' }
+  log('Analysis JSON > 150KB — report input reduced (by_question + breakdown omitted)')
+}
+
+const reportPrompt = `${JSON.stringify(reportInput, null, 2)}
+
+Generate a comprehensive AEO (Answer Engine Optimization) report based on the domain analysis JSON data provided. This analysis examines how different domains are cited by AI platforms (ChatGPT, Google AI Mode, and Perplexity) when responding to consumer queries about ${topicLabel}.
+
+## Report Requirements:
+
+### Structure:
+1. Executive Summary
+2. Domain Performance Rankings
+3. Platform-Specific Insights
+4. Comprehensive AEO Optimization Strategy
+
+### Section 1 - Executive Summary:
+Display these metrics with brief explanations:
+- Total platforms: [number] (explain what platforms are analyzed)
+- Total questions: [number] (explain these are unique test queries)
+- Unique domains: [number] (explain these are distinct websites cited)
+- Total platform_question_pairs: [number] (explain this counts unique platform-question combinations where domains appear)
+- Total actual_citations: [number] (explain this is the sum of all citation_count values)
+
+**Important**: Add a note explaining the difference between platform_question_occurrences (how many platform-question combinations a domain appears in) and actual_citation_total (the sum of citation counts).
+
+### Section 2 - Domain Performance Rankings:
+Create table with these columns:
+- Rank
+- Domain
+- Category
+- Platform-Question Occurrences (from platform_question_occurrences field)
+- Actual Citations Total (from actual_citation_total field)
+- Platform Count (how many different platforms cite this domain)
+
+Show top 15 domains sorted by platform_question_occurrences (highest first).
+
+**Add caption below table**: "Platform-Question Occurrences shows in how many unique (platform, question) pairs the domain was cited. Actual Citations Total shows the cumulative citation count when a domain appears multiple times for the same query."
+
+### Section 3 - Platform Coverage Analysis:
+
+#### 3a. Platform Distribution Table:
+Add caption: "*Domains sorted by platform coverage count (high to low)*"
+
+Create table with these columns:
+- Domain
+- ChatGPT (use ✓ or leave blank)
+- Google AI (use ✓ or leave blank)
+- Perplexity (use ✓ or leave blank)
+- Platform Count (number)
+- Platform-Question Occurrences
+
+Sort by platform count (most to least), then by occurrences.
+
+#### 3b. Platform-Specific Metrics:
+For each platform, show:
+- Total question_occurrences (explain this counts unique questions where domains appear)
+- Unique domains cited
+- Top 5 domains by question_occurrences
+
+### Section 4 - AEO Optimization Strategy:
+Include four tiers:
+- Tier 1: Foundation Building (explain citation frequency patterns)
+- Tier 2: Platform-Specific Optimization (reference platform_specific_domains data)
+- Tier 3: Content Distribution Framework (mention url_reuse patterns)
+- Tier 4: Technical Implementation
+Each tier must have specific tactics, KPIs based on the metrics, and timelines.
+
+Rules about Key Metrics to Explain:
+When using these metrics, always clarify their meaning at the beginning or end of the section in caption, but do not use the raw key name:
+- platform_question_occurrences: Number of unique (platform, question) combinations
+- actual_citation_total: Sum of all citation_count values for the domain
+- question_occurrences: Number of different questions where domain appears (within a platform)
+- platform_occurrences: Number of different platforms where domain appears (for a question)
+- url_reuse: How many URLs are used for multiple questions
+- max_url_reuse: Maximum times a single URL answered different questions
+
+### Writing Rules:
+1. No dates/years in titles
+2. Use metrics exactly as named in the JSON (platform_question_occurrences, not "citations")
+3. Explain what each metric means when first introduced
+4. Professional tone for business strategy
+5. Pure markdown output without code blocks
+6. When showing numbers, add brief inline explanations for clarity
+
+The goal is to help brands understand not just the numbers, but what they mean for optimization strategy. Output ONLY the report markdown — no preamble.`
+
+const reportMd = (await agent(reportPrompt, { label: 'write-aeo-report', phase: 'Report' })) || ''
+if (!reportMd.trim()) throw new Error('Report agent returned no output.')
+
+const runLogEntry = {
+  job_id: jobId,
+  brand,
+  run_time: runTime,
+  questions_total: allQuestions.length,
+  scraped_this_run: scrapeStatus.map((s) => ({
+    question: s.question,
+    platforms: Object.fromEntries(s.results.map((r) => [r.platform, r.status === 'completed' ? 'ok' : `failed${r.note ? `: ${r.note}` : ''}`])),
+  })),
+  platform_health: platformHealth,
+  valid_answers_in_corpus: validCorpus.length,
+}
+
+const exportReportPrompt = `Write these local files using a python3 script (create parent dirs). Return the structured object {files: [<paths written>]}.
+
+1. WRITE ${workspace}/aeo-report.md with EXACTLY this markdown content:
+${reportMd}
+
+2. UPDATE ${workspace}/metadata.json — read it if it exists (shape {"brand": ..., "runs": [...]}); if missing or unparseable start from {"brand": ${JSON.stringify(brand)}, "runs": []}. Append this run entry to "runs" and write back pretty-printed:
+${JSON.stringify(runLogEntry, null, 2)}
+
+After writing, print the ABSOLUTE path of the report file and include it in files.`
+
+const repExport = await agent(exportReportPrompt, { label: 'export-report', phase: 'Report', schema: EXPORT_SCHEMA })
+const writtenFiles = [
+  ...((visExport && visExport.files) || []),
+  ...((domExport && domExport.files) || []),
+  ...((repExport && repExport.files) || []),
+]
+const reportPath = writtenFiles.find((f) => f.endsWith('aeo-report.md')) || `${workspace}/aeo-report.md`
+
+// ═══ Result (upstream step 27 equivalent) ═════════════════════════════════════
+const remaining = pending.length - batch.filter((b) => {
+  const s = scrapeStatus.find((x) => x.question === b.question)
+  return s && s.results.every((r) => r.status === 'completed')
+}).length
+log(`Done. Report: ${reportPath} · coverage ${allQuestions.length - remaining}/${allQuestions.length} questions · ${remaining} still pending`)
+
+return {
+  jobId,
+  brand,
+  brandLink,
+  workspace,
+  questionsTotal: allQuestions.length,
+  pendingBeforeRun: pending.length,
+  scrapedThisRun: runLogEntry.scraped_this_run,
+  platformHealth,
+  validAnswersInCorpus: validCorpus.length,
+  visibility: {
+    brand_visibility_score_percentage: visibility.brand_visibility_score_percentage,
+    brand_link_visibility_score_percentage: visibility.brand_link_visibility_score_percentage,
+    per_platform: visibility.platform_visibility_score_percentage_list,
+  },
+  topCompetitors: visibility.competitors
+    .slice()
+    .sort((a, b) => b.brand_visibility_score_percentage - a.brand_visibility_score_percentage)
+    .slice(0, 5)
+    .map((c) => ({ brand: c.brand_name, visibility: c.brand_visibility_score_percentage })),
+  topDomains: analysis.overall.all_domains.slice(0, 5),
+  reportPath,
+  files: writtenFiles,
+  note:
+    'Cookie-less mode: platforms may block anonymous queries (see platformHealth). Failed (platform,question) pairs are retried on the next run — schedule this workflow daily to grow coverage. ' +
+    'REQUIREMENT: the gstack browse daemon must already be running in HEADED stealth mode (run /connect-chrome in the main session first) — sandboxed workflow agents cannot start it, and headless mode gets bot-blocked by all three platforms; when the daemon is down or headless the run skips scraping and only recomputes analysis. ' +
+    'Skipped vs the upstream original: S3 uploads and proprietary vendor backend APIs (query log, server competitor list, score submission) — everything is saved to the local workspace instead.',
+}

--- a/demos/workflows/03-aeo-data-scientist.py
+++ b/demos/workflows/03-aeo-data-scientist.py
@@ -1,0 +1,1188 @@
+meta = {
+    "name": "aeo-data-scientist",
+    "description": "AEO Full-Stack Data Scientist — ask research questions on ChatGPT, Google AI and Perplexity (cookie-less browser), measure brand visibility vs competitors, analyze cited domains, and write an AEO report.",
+    "when_to_use": "Run with a brand name plus research questions (or the CSV produced by /user-prompt-research) to measure how often the brand appears in AI-engine answers, who the competitors are, and which domains get cited. Designed for small daily batches: each run scrapes a few uncovered questions and recomputes scores/report over ALL accumulated data.",
+    "phases": [
+        {"title": "Init", "detail": "Load questions (args or CSV) + scan workspace coverage"},
+        {"title": "Scrape", "detail": "Ask each pending question on ChatGPT / Google AI / Perplexity, no login"},
+        {"title": "Competitors", "detail": "Extract + clean competitor brands from AI answers"},
+        {"title": "Visibility", "detail": "Brand/competitor visibility scores (pure port)"},
+        {"title": "Domains", "detail": "Citation domain matrix, URL mapping, LLM categorization"},
+        {"title": "Report", "detail": "Write the AEO report + run log"},
+    ],
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Singula-AI AEO marketing workflow — faithful port of the upstream
+# "Agent 3: AEO Full-Stack Data Scientist" (27 nodes)
+# to a Claude Code dynamic workflow.
+#
+#   Upstream node                              → workflow implementation
+#   1  Generate job id (py)                   → init agent (date-based id; no RNG in script)
+#   2  Workspace path (py, /tmp/<job>)        → persistent ./demos/aeo-output/aeo-data-scientist/<brand-slug>/
+#   3  Initialization (py, metadata.json)     → run log appended to metadata.json (export agent)
+#   4  Question list (py passthrough)         → args.questions OR /user-prompt-research CSV (closes the
+#                                               team-bus seam the upstream left manual)
+#   5  Extension scraping (chrome_extension)  → per-question agent + gstack /browse, NO COOKIES
+#   6  Save Extension Result (py)             → same agent writes canonical answer JSONs
+#   7  1-Gather AI results (loop, Playwright) → same agents (sequential loop, small batch per run)
+#   8  Select Data Retrieval Mode (js)        → not needed (always cookie-less browse path)
+#   9  1-Write questions to txt (py)          → questions.txt via export agent
+#   10 1-Save raw data S3 (py)                → SKIPPED: no upstream S3 — everything stays on local fs
+#   11 Submit Query thru API (py)             → SKIPPED (upstream vendor backend)
+#   12 2-Parse answers (py, random sample)    → pure code, DETERMINISTIC sample (no RNG allowed here)
+#   13 2-Find all competitors (gpt-4.1)       → agent (faithful prompt)
+#   14 2-Reformat competitor list (gpt-4.1)   → agent (faithful prompt, schema-forced list)
+#   15 2-Pull competitors from API (py)       → SKIPPED (upstream vendor backend); LLM list is sole source
+#   16 2-Calculate Visibility Score (py)      → pure port (same math, same output keys)
+#   17 2-Submit score thru API (py)           → SKIPPED (upstream vendor backend); saved locally instead
+#   18 3-Parse reference to csv (py)          → pure port (zero-count rows omitted — step 22
+#                                               filtered them out anyway)
+#   19 3-Parse domain relations (py)          → pure port (url normalization, reuse stats)
+#   20 3-Analyze domain categories (ai)       → agent (faithful prompt, schema-forced)
+#   21 3-Domain categories 3D CSV (py)        → pure code builds domain_summary.csv (export agent writes)
+#   22 3-Combine ref data (py)                → pure port (full analysis JSON shape)
+#   23 3-Domain reference list (py→HTML+S3)   → pure code HTML (condensed), saved locally, no S3/API
+#   24 3-Write ref domain report (ai)         → agent (faithful prompt; hardcoded "blood pressure
+#                                               monitors" example genericized to args topic)
+#   25 3-Save report to file (py)             → export agent
+#   26 Upload to S3 (py)                      → SKIPPED: local fs only (user decision)
+#   27 Collect results (py)                   → workflow return value
+#
+# Cookie-less + incremental design (user decision): the browser runs logged
+# out (fresh profile, no cookies), and ChatGPT / Google / Perplexity tolerate
+# only a few anonymous queries at a time. So each run scrapes at most
+# `max_questions` not-yet-covered questions (default 3), records per-platform
+# success/blocked status, and recomputes all analysis over the FULL
+# accumulated corpus. Schedule the workflow daily to grow coverage gradually;
+# failed/blocked (platform, question) pairs are retried on later runs.
+#
+# Browser prerequisites (empirical, 2026-06-09):
+#   - The browse daemon must be STARTED FROM THE MAIN SESSION — Claude Code's
+#     command sandbox blocks workflow subagents from cold-starting it (hangs
+#     on "[browse] Starting server...").
+#   - It must run in HEADED stealth mode (/connect-chrome): headless mode is
+#     bot-blocked by all three platforms on the very first anonymous query;
+#     headed stealth passes all three without any login.
+#
+# Input : args = { brand (required), brandLink?, topic?, questions?: list[str]|str,
+#                  questionsCsv?: path, maxQuestions?: 3, platforms?: subset of
+#                  ['chatgpt','google-ai','perplexity'], outputDir? }
+#   - questions source precedence: args.questions > args.questionsCsv >
+#     derived ./demos/aeo-output/user-prompt-research/<topic-slug>-questions.csv
+# Output: { jobId, visibility, topCompetitors, topDomains, reportPath, ... }
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── args normalization ───────────────────────────────────────────────────────
+input = args if args is not None else {}
+if isinstance(input, str):
+    t = input.strip()
+    if t.startswith("{"):
+        try:
+            input = json.loads(t)
+        except Exception:
+            input = {"brand": t}
+    else:
+        input = {"brand": t}
+brand = str(input.get("brand") or "").strip()
+if not brand:
+    raise RuntimeError(
+        'No brand provided. Pass args like { brand: "Cursor", topic: "ai coding assistant" } '
+        'or { brand: "Cursor", questions: ["...", "..."] }.'
+    )
+brand_link = str(input.get("brandLink") or "").strip()
+topic = str(input.get("topic") or "").strip()
+
+
+# Canonical slugify — keep IDENTICAL across all marketing workflows: the
+# CSV/workspace handoff between pipeline stages depends on matching slugs.
+def slugify(s, max=80):
+    out = re.sub(r"[^a-z0-9]+", "-", s.lower())
+    out = re.sub(r"^-+|-+$", "", out)[:max]
+    out = re.sub(r"-+$", "", out)
+    return out or "item"
+
+
+brand_slug = slugify(brand, 40)
+workspace = re.sub(r"/+$", "", input.get("outputDir") or f"./demos/aeo-output/aeo-data-scientist/{brand_slug}")
+max_questions = math.floor(float(input.get("maxQuestions"))) if (input.get("maxQuestions") is not None and float(input.get("maxQuestions")) > 0) else 3
+ALL_PLATFORMS = ["chatgpt", "google-ai", "perplexity"]
+platforms = (
+    [p for p in input["platforms"] if p in ALL_PLATFORMS]
+    if isinstance(input.get("platforms"), list) and len(input["platforms"])
+    else ALL_PLATFORMS
+)
+if not platforms:
+    raise RuntimeError(f"platforms must be a subset of {', '.join(ALL_PLATFORMS)}")
+
+# explicit questions (array or newline string), else CSV path
+explicit_questions = []
+if isinstance(input.get("questions"), list):
+    explicit_questions = input["questions"]
+elif isinstance(input.get("questions"), str):
+    explicit_questions = input["questions"].split("\n")
+explicit_questions = [q2 for q2 in (str(q).strip() for q in explicit_questions) if len(q2) > 0]
+
+csv_path = str(input.get("questionsCsv") or "").strip()
+if not explicit_questions and not csv_path and topic:
+    csv_path = f"./demos/aeo-output/user-prompt-research/{slugify(topic)}-questions.csv"
+if not explicit_questions and not csv_path:
+    raise RuntimeError(
+        'No questions provided. Pass questions: [...], questionsCsv: "<path>", or topic: "<keyword>" '
+        "(topic derives the CSV written by /user-prompt-research). Run /user-prompt-research first if needed."
+    )
+topic_label = topic or f"{brand}-related products/services"
+
+log(f"Brand: \"{brand}\"  ·  workspace: {workspace}  ·  batch: up to {max_questions} question(s) × [{', '.join(platforms)}]  ·  no-login browser mode")
+
+# ── JSON Schemas for schema-forced agent steps ───────────────────────────────
+INIT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "runTime": {"type": "string"},        # "YYYY-MM-DD HH:MM:SS"
+        "runStamp": {"type": "string"},       # "YYYY_MM_DD_HH_MM_SS"
+        "daemonHealthy": {"type": "boolean"},  # gstack browse daemon reachable?
+        "daemonMode": {"type": "string"},     # 'headed' | 'launched' (headless) | 'none'
+        "csvQuestions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"question": {"type": "string"}, "volume": {"type": "string"}},
+                "required": ["question", "volume"],
+                "additionalProperties": False,
+            },
+        },
+        "covered": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "platform": {"type": "string"},
+                    "file": {"type": "string"},
+                    "question": {"type": "string"},
+                    "status": {"type": "string"},
+                },
+                "required": ["platform", "file", "question", "status"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["runTime", "runStamp", "daemonHealthy", "daemonMode", "csvQuestions", "covered"],
+    "additionalProperties": False,
+}
+
+# Sandboxed subagents CANNOT cold-start the browse daemon (the sandbox blocks
+# the server bind and the CLI hangs on "[browse] Starting server..."). They can
+# only talk to an ALREADY-RUNNING daemon. Every browse call therefore goes
+# through this hang-proof wrapper, and Init verifies the daemon up-front.
+BROWSE_WRAPPER = """Run every browse command through this hang-proof wrapper (NEVER call the browse binary directly — a cold daemon start hangs forever in this sandbox):
+python3 -c "import subprocess,os,sys; r=subprocess.run([os.path.expanduser('~/.claude/skills/gstack/browse/dist/browse')]+sys.argv[1:],capture_output=True,text=True,timeout=90); print(r.stdout); print(r.stderr,file=sys.stderr)" <command> <args...>
+If a call raises TimeoutExpired twice in a row, stop using the browser and mark the affected platform(s) failed with note "browse timeout". Never let any single Bash call run longer than ~120 seconds."""
+
+SCRAPE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "results": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "platform": {"type": "string", "enum": ALL_PLATFORMS},
+                    "status": {"type": "string", "enum": ["completed", "failed"]},
+                    "answerChars": {"type": "integer"},
+                    "sourcesCount": {"type": "integer"},
+                    "note": {"type": "string"},     # '' when fine; 'blocked: login wall', 'captcha', etc.
+                },
+                "required": ["platform", "status", "answerChars", "sourcesCount", "note"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["results"],
+    "additionalProperties": False,
+}
+
+CORPUS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "answers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "platform": {"type": "string"},
+                    "question": {"type": "string"},
+                    "status": {"type": "string"},
+                    "answer": {"type": "string"},
+                    "sources": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {"url": {"type": "string"}, "title": {"type": "string"}},
+                            "required": ["url", "title"],
+                            "additionalProperties": False,
+                        },
+                    },
+                },
+                "required": ["platform", "question", "status", "answer", "sources"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["answers"],
+    "additionalProperties": False,
+}
+
+COMPETITORS_SCHEMA = {
+    "type": "object",
+    "properties": {"competitors": {"type": "array", "items": {"type": "string"}}},
+    "required": ["competitors"],
+    "additionalProperties": False,
+}
+
+DOMCAT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "items": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "domain": {"type": "string"},
+                    "total_citations": {"type": "integer"},
+                    "category": {"type": "string"},
+                    "category_name": {"type": "string"},
+                },
+                "required": ["domain", "total_citations", "category", "category_name"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["items"],
+    "additionalProperties": False,
+}
+
+EXPORT_SCHEMA = {
+    "type": "object",
+    "properties": {"files": {"type": "array", "items": {"type": "string"}}},
+    "required": ["files"],
+    "additionalProperties": False,
+}
+
+
+# ── pure-code ports of the upstream python transforms ─────────────────────────
+def escape_regex(s):
+    return re.sub(r"[.*+?^${}()|[\]\\]", lambda m: "\\" + m.group(0), s)
+
+
+# step-16 get_domain_from_url / step-18 extract_domain_from_url
+def domain_from_url(url):
+    if not url:
+        return ""
+    u = url.strip()
+    if not re.match(r"^https?://", u, re.IGNORECASE):
+        u = "https://" + u
+    m = re.match(r"^https?://([^/?#]+)", u, re.IGNORECASE)
+    domain = (m.group(1) if m else "").lower()
+    domain = re.sub(r"^www\.", "", domain)
+    domain = re.sub(r":\d+$", "", domain)
+    return domain
+
+
+# step-19 normalize_url
+def normalize_url(url):
+    base = url.split("?")[0].split("#")[0]
+    if base.endswith("/"):
+        base = base[:-1]
+    return base
+
+
+def csv_field(v):
+    s = str("" if v is None else v)
+    return '"' + s.replace('"', '""') + '"' if re.search(r"[\",\n]", s) else s
+
+
+# "10~50" → 30 midpoint for sorting; plain ints pass through
+def volume_to_number(v):
+    s = str("" if v is None else v).strip()
+    rng = re.match(r"^(\d+)\s*~\s*(\d+)$", s)
+    if rng:
+        return (int(rng.group(1)) + int(rng.group(2))) / 2
+    try:
+        n = float(s)
+    except (ValueError, TypeError):
+        return 0
+    return n if math.isfinite(n) else 0
+
+
+# step-12 port: per-platform sample of completed answers, joined as one text.
+# Original used random.sample(n/3, max 10); RNG is banned in workflow scripts,
+# so we take an evenly-spaced deterministic sample of the same size.
+def sample_answer_text(corpus):
+    texts = []
+    for platform in ALL_PLATFORMS:
+        entries = sorted(
+            (a for a in corpus if a["platform"] == platform and a["status"] == "completed" and a["answer"].strip()),
+            key=lambda x: x["question"],
+        )
+        if not entries:
+            continue
+        n = len(entries)
+        size = min(max(1, math.floor(n / 3)), 10, n)
+        for k in range(size):
+            idx = math.floor((k * n) / size)
+            texts.append(re.sub(r"[\r\n]+", " ", entries[idx]["answer"]))
+    return "\n".join(texts)
+
+
+# step-16 extract_ai_content equivalent over our canonical answer entries
+def answer_content(entry):
+    source_text = " ".join(f"{domain_from_url(s['url'])} {s.get('title') or ''}" for s in entry["sources"])
+    return f"{entry['answer']} {source_text}"
+
+
+def mention_count(name, content):
+    if not name or not content:
+        return 0
+    rx = re.compile(rf"\b{escape_regex(name)}\b", re.IGNORECASE)
+    return len(rx.findall(content))
+
+
+# step-16 analyze_brand_visibility port (same output keys)
+def analyze_brand_visibility(corpus, brand_name, link):
+    valid = [a for a in corpus if a["status"] == "completed" and a["answer"].strip()]
+    if not valid:
+        return {
+            "brand_name": brand_name, "brand_link": link, "brand_logo": "",
+            "brand_visibility_score_percentage": 0.0,
+            "brand_link_visibility_score_percentage": 0.0,
+            "brand_mentions": 0, "brand_link_mentions": 0,
+            "platform_visibility_score_percentage_list": [],
+        }
+    link_domain = domain_from_url(link)
+    total_score = 0
+    total_link_score = 0
+    total_mentions = 0
+    total_link_mentions = 0
+    platform_stats = {}
+    for entry in valid:
+        content = answer_content(entry)
+        mentions = mention_count(brand_name, content)
+        link_mentions = mention_count(link_domain, content) if link_domain else 0
+        total_score += 1 if mentions > 0 else 0
+        total_link_score += 1 if link_mentions > 0 else 0
+        total_mentions += mentions
+        total_link_mentions += link_mentions
+        p = entry["platform"]
+        if p not in platform_stats:
+            platform_stats[p] = {"total": 0, "withBrand": 0, "mentions": 0, "withLink": 0, "linkMentions": 0}
+        platform_stats[p]["total"] += 1
+        if mentions > 0:
+            platform_stats[p]["withBrand"] += 1
+        platform_stats[p]["mentions"] += mentions
+        if link_mentions > 0:
+            platform_stats[p]["withLink"] += 1
+        platform_stats[p]["linkMentions"] += link_mentions
+
+    def round2(x):
+        # Faithful to JS Math.round (round half AWAY from zero); Python's round()
+        # is banker's rounding and would differ on exact .5 ties (e.g. 3.125).
+        # All inputs here are non-negative percentages, so floor(x + 0.5) suffices.
+        return math.floor(x * 100 + 0.5) / 100
+
+    platform_list = [
+        {
+            "platform_name": name,
+            "platform_logo": "",
+            "platform_visibility_score_percentage": round2((s["withBrand"] / s["total"]) * 100),
+            "platform_brand_link_visibility_score_percentage": round2((s["withLink"] / s["total"]) * 100),
+            "platform_brand_mentions": s["mentions"],
+            "platform_brand_link_mentions": s["linkMentions"],
+        }
+        for name, s in platform_stats.items()
+    ]
+    return {
+        "brand_name": brand_name, "brand_link": link, "brand_logo": "",
+        "brand_visibility_score_percentage": round2((total_score / len(valid)) * 100),
+        "brand_link_visibility_score_percentage": round2((total_link_score / len(valid)) * 100),
+        "brand_mentions": total_mentions, "brand_link_mentions": total_link_mentions,
+        "platform_visibility_score_percentage_list": platform_list,
+    }
+
+
+# step-18 port: platform×question×domain citation matrix + domain summary.
+# Deviation: long-format rows with citation_count === 0 are omitted (step-22
+# filtered count>0 anyway, and zero rows explode the CSV as coverage grows).
+def build_citation_matrix(corpus):
+    matrix = {}
+    all_domains = set()
+    for entry in corpus:
+        if entry["status"] != "completed":
+            continue
+        q = entry["question"]
+        if len(q) > 100:
+            q = q[:97] + "..."
+        if not q:
+            continue
+        domains = [d for d in (domain_from_url(s["url"]) for s in entry["sources"]) if d]
+        if not domains:
+            continue
+        p = entry["platform"]
+        matrix[p] = matrix.get(p) or {}
+        matrix[p][q] = matrix[p].get(q) or {}
+        for d in domains:
+            matrix[p][q][d] = matrix[p][q].get(d, 0) + 1
+            all_domains.add(d)
+    rows = []
+    for p in sorted(matrix.keys()):
+        for q in sorted(matrix[p].keys()):
+            for d in sorted(matrix[p][q].keys()):
+                rows.append({"platform": p, "question": q, "domain": d, "citation_count": matrix[p][q][d]})
+    totals = {}
+    for r in rows:
+        totals[r["domain"]] = totals.get(r["domain"], 0) + r["citation_count"]
+    domain_summary = sorted(
+        ({"domain": d, "total_citations": totals.get(d, 0), "category": ""} for d in sorted(all_domains)),
+        key=lambda a: a["total_citations"],
+        reverse=True,
+    )
+    return {"rows": rows, "domainSummary": domain_summary, "matrix": matrix}
+
+
+# step-19 port: domain → url/platform/question mapping with reuse stats
+def build_url_mapping(corpus):
+    mapping = {}
+    for entry in corpus:
+        if entry["status"] != "completed":
+            continue
+        q = entry["question"]
+        if len(q) > 100:
+            q = q[:97] + "..."
+        if not q:
+            continue
+        for s in entry["sources"]:
+            url = (s.get("url") or "").strip()
+            domain = domain_from_url(url)
+            if not domain:
+                continue
+            norm = normalize_url(url)
+            m = mapping.get(domain) or {"citations": {}, "urlUsage": {}, "platforms": set(), "urls": set()}
+            mapping[domain] = m
+            m["urlUsage"][norm] = m["urlUsage"].get(norm) or []
+            if q not in m["urlUsage"][norm]:
+                m["urlUsage"][norm].append(q)
+            key = f"{norm}\x00{q}"
+            if m["citations"].get(key):
+                if entry["platform"] not in m["citations"][key]["platforms"]:
+                    m["citations"][key]["platforms"].append(entry["platform"])
+            else:
+                m["citations"][key] = {"url": url, "platform": entry["platform"], "platforms": [entry["platform"]], "question": q}
+            m["platforms"].add(entry["platform"])
+            m["urls"].add(norm)
+    final = {}
+    for domain in sorted(mapping.keys()):
+        m = mapping[domain]
+        citations = [
+            {
+                "url": c["url"],
+                "platform": ", ".join(sorted(c["platforms"])) if len(c["platforms"]) > 1 else c["platform"],
+                "question": c["question"],
+            }
+            for c in m["citations"].values()
+        ]
+        reuse = [qs for qs in m["urlUsage"].values() if len(qs) > 1]
+        final[domain] = {
+            "url_citations": citations,
+            "total_platform_question_unique_citations": len(citations),
+            "unique_urls": len(m["urls"]),
+            "platforms": sorted(m["platforms"]),
+            "url_reuse": len(reuse),
+            "max_url_reuse": max((len(qs) for qs in reuse)) if reuse else 0,
+        }
+    return final
+
+
+# step-22 port: combine matrix + category map into the report-input JSON
+def combine_ref_data(rows, category_map):
+    overall = {}
+    platform_domains = {}
+    question_domains = {}
+    pq_domains = {}
+    totals = {}
+    platforms2 = set()
+    questions = set()
+    domains = set()
+    for r in rows:
+        if r["citation_count"] <= 0:
+            continue
+        platforms2.add(r["platform"])
+        questions.add(r["question"])
+        domains.add(r["domain"])
+        totals[r["domain"]] = totals.get(r["domain"], 0) + r["citation_count"]
+        overall[r["domain"]] = overall.get(r["domain"], 0) + 1
+        platform_domains[r["platform"]] = platform_domains.get(r["platform"]) or {}
+        platform_domains[r["platform"]][r["domain"]] = platform_domains[r["platform"]].get(r["domain"], 0) + 1
+        question_domains[r["question"]] = question_domains.get(r["question"]) or {}
+        question_domains[r["question"]][r["domain"]] = question_domains[r["question"]].get(r["domain"], 0) + 1
+        pq = pq_domains.get(r["platform"]) or {}
+        pq_domains[r["platform"]] = pq
+        pq[r["question"]] = pq.get(r["question"]) or {}
+        pq[r["question"]][r["domain"]] = pq[r["question"]].get(r["domain"], 0) + 1
+
+    def cat(d):
+        return category_map.get(d) or "unknown"
+
+    result = {
+        "summary": {
+            "total_platforms": len(platforms2),
+            "total_questions": len(questions),
+            "total_unique_domains": len(domains),
+            "total_platform_question_pairs": sum(overall.values()),
+            "total_actual_citations": sum(totals.values()),
+        },
+        "overall": {
+            "description": "Domain occurrence frequency across platform-question combinations",
+            "all_domains": sorted(
+                (
+                    {"domain": d, "category": cat(d), "platform_question_occurrences": c, "actual_citation_total": totals[d]}
+                    for d, c in overall.items()
+                ),
+                key=lambda a: a["platform_question_occurrences"],
+                reverse=True,
+            ),
+        },
+        "by_platform": {},
+        "by_question": {},
+        "platform_question_breakdown": {},
+    }
+    for p in sorted(platforms2):
+        pd = platform_domains[p]
+        result["by_platform"][p] = {
+            "total_question_occurrences": sum(pd.values()),
+            "unique_domains": len(pd.keys()),
+            "all_domains": sorted(
+                ({"domain": d, "category": cat(d), "question_occurrences": c} for d, c in pd.items()),
+                key=lambda a: a["question_occurrences"],
+                reverse=True,
+            ),
+        }
+    for q in sorted(questions):
+        qd = question_domains[q]
+        display = q[:100] + "..." if len(q) > 100 else q
+        result["by_question"][display] = {
+            "full_question": q,
+            "total_platform_occurrences": sum(qd.values()),
+            "unique_domains": len(qd.keys()),
+            "all_domains": sorted(
+                ({"domain": d, "category": cat(d), "platform_occurrences": c} for d, c in qd.items()),
+                key=lambda a: a["platform_occurrences"],
+                reverse=True,
+            ),
+        }
+    for p in sorted(platforms2):
+        list_ = []
+        for q, dd in (pq_domains.get(p) or {}).items():
+            display = q[:80] + "..." if len(q) > 80 else q
+            list_.append({
+                "question": display,
+                "total_domain_occurrences": sum(dd.values()),
+                "all_domains": sorted(
+                    ({"domain": d, "category": cat(d), "occurrences": c} for d, c in dd.items()),
+                    key=lambda a: a["occurrences"],
+                    reverse=True,
+                ),
+            })
+        if list_:
+            result["platform_question_breakdown"][p] = list_
+    # comparative analysis
+    domain_platforms = {}
+    for p, pd in platform_domains.items():
+        for d in pd.keys():
+            domain_platforms[d] = domain_platforms.get(d) or set()
+            domain_platforms[d].add(p)
+    universal = sorted(
+        (
+            {
+                "domain": d, "category": cat(d), "platforms": sorted(ps),
+                "total_platform_question_occurrences": overall[d], "actual_citation_total": totals[d],
+            }
+            for d, ps in domain_platforms.items()
+            if len(ps) == len(platforms2)
+        ),
+        key=lambda a: a["total_platform_question_occurrences"],
+        reverse=True,
+    )
+    specific = {}
+    for d, ps in domain_platforms.items():
+        if len(ps) == 1:
+            p = next(iter(ps))
+            specific[p] = specific.get(p) or []
+            specific[p].append({"domain": d, "category": cat(d), "question_occurrences": platform_domains[p][d]})
+    for p in specific.keys():
+        specific[p].sort(key=lambda a: a["question_occurrences"], reverse=True)
+    result["comparative_analysis"] = {
+        "universal_domains": universal,
+        "platform_specific_domains": specific,
+        "domain_coverage": {
+            "domains_in_all_platforms": len(universal),
+            "domains_in_single_platform": sum(len(l) for l in specific.values()),
+        },
+    }
+    return result
+
+
+# step-23 port (condensed): static HTML reference list, grouped by category
+def build_reference_html(url_mapping, cat_name_map, brand_name, run_time):
+    by_category = {}
+    for domain, info in url_mapping.items():
+        cat_name = cat_name_map.get(domain) or "Other"
+        by_category[cat_name] = by_category.get(cat_name) or []
+        by_category[cat_name].append({"domain": domain, "info": info})
+
+    def esc(s):
+        return (
+            str(s)
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;")
+        )
+
+    parts = [
+        '<!DOCTYPE html><html><head><meta charset="utf-8"><title>Domain Reference List</title>',
+        "<style>body{font-family:Georgia,serif;max-width:960px;margin:2rem auto;padding:0 1rem;color:#222}",
+        "h2{border-bottom:2px solid #b5651d;padding-bottom:4px}h3{margin-bottom:2px}",
+        ".meta{color:#666;font-size:0.9em}li{margin:2px 0}</style></head><body>",
+        f'<h1>Domain Reference List</h1><p class="meta">Brand: {esc(brand_name)} · Generated: {esc(run_time)} · AI-engine citations grouped by domain category</p>',
+    ]
+    for cat_name in sorted(by_category.keys()):
+        parts.append(f"<h2>{esc(cat_name)}</h2>")
+        for item in sorted(by_category[cat_name], key=lambda a: a["info"]["total_platform_question_unique_citations"], reverse=True):
+            domain = item["domain"]
+            info = item["info"]
+            parts.append(f"<h3>{esc(domain)}</h3>")
+            parts.append(f'<p class="meta">{info["total_platform_question_unique_citations"]} citation(s) · {info["unique_urls"]} unique URL(s) · platforms: {esc(", ".join(info["platforms"]))} · url_reuse: {info["url_reuse"]} (max {info["max_url_reuse"]})</p>')
+            parts.append("<ul>")
+            for c in info["url_citations"]:
+                # citations come from scraped web data — only hyperlink http(s) schemes
+                if re.match(r"^https?://", c["url"], re.IGNORECASE):
+                    parts.append(f'<li><a href="{esc(c["url"])}">{esc(normalize_url(c["url"]))}</a> — <em>{esc(c["platform"])}</em> — {esc(c["question"])}</li>')
+                else:
+                    parts.append(f'<li>{esc(c["url"])} — <em>{esc(c["platform"])}</em> — {esc(c["question"])}</li>')
+            parts.append("</ul>")
+    parts.append("</body></html>")
+    return "\n".join(parts)
+
+
+# ═══ Phase: Init — timestamps, dirs, question CSV, coverage scan ═════════════
+phase("Init")
+
+init_prompt = f"""You are initializing a local AEO research workspace. Do these steps exactly; everything is on the local filesystem relative to the current working directory.
+
+1. Run `date '+%Y-%m-%d %H:%M:%S'` → return as runTime. Run `date '+%Y_%m_%d_%H_%M_%S'` → return as runStamp.
+2. Ensure these directories exist (mkdir -p): {"  ".join(f"{workspace}/answers/{p}" for p in platforms)}
+3. {
+    f'Read the CSV file at "{csv_path}" (columns: Time,Question,Search Volume). Return every row as {{question, volume}} (volume as the raw string, e.g. "140" or "10~50"). If the file does not exist, return an empty csvQuestions array.'
+    if csv_path
+    else "No CSV to read — return an empty csvQuestions array."
+}
+4. Scan {workspace}/answers/*/*.json — for EACH json file found, parse it and return {{platform: <parent dir name>, file: <basename>, question: <result.question or "">, status: <its "status" field or "failed">}}. If the directory is empty or missing, return an empty covered array.
+5. Check the gstack browse daemon WITHOUT risking a hang — run exactly:
+python3 -c "import subprocess,os; r=subprocess.run([os.path.expanduser('~/.claude/skills/gstack/browse/dist/browse'),'status'],capture_output=True,text=True,timeout=20); print(r.stdout)"
+→ daemonHealthy = true only if it prints "Status: healthy" within the timeout. On TimeoutExpired, any exception, or other output: daemonHealthy = false (do NOT retry, do NOT try to start the daemon).
+→ daemonMode = "headed" if the output contains "Mode: headed", "launched" if it contains "Mode: launched", otherwise "none".
+
+Use bash (ls/date/mkdir) and python3 for parsing. Return ONLY the structured object."""
+
+init = await agent(init_prompt, label="init-workspace", phase="Init", schema=INIT_SCHEMA)
+if not init:
+    raise RuntimeError("Init agent failed — cannot determine workspace state.")
+run_time = init["runTime"].strip()
+run_stamp = init["runStamp"].strip()
+job_id = f"AEO_{brand_slug}_{run_stamp}"
+
+# Build the master question list (explicit > CSV sorted by volume desc)
+if explicit_questions:
+    all_questions = explicit_questions
+else:
+    all_questions = [
+        r["q"]
+        for r in sorted(
+            (
+                {"q": r["question"].strip(), "v": volume_to_number(r["volume"])}
+                for r in init["csvQuestions"]
+            ),
+            key=lambda a: a["v"],
+            reverse=True,
+        )
+        if len(r["q"]) > 0 and "?" in r["q"]
+    ]
+    # CSV merge keeps duplicates across runs — dedupe, keeping highest-volume order
+    all_questions = list(dict.fromkeys(all_questions))
+if not all_questions:
+    raise RuntimeError(f'No usable questions found{f" in {csv_path}" if csv_path else ""}. Run /user-prompt-research "{topic or brand}" first, or pass questions explicitly.')
+
+# Coverage: (platform → set of covered question slugs with status completed)
+covered_set = set(
+    f"{c['platform']}\x00{slugify(c['question'])}"
+    for c in init["covered"]
+    if c["status"] == "completed"
+)
+pending = []   # [{question, slug, missingPlatforms}]
+for q in all_questions:
+    slug = slugify(q)
+    missing = [p for p in platforms if f"{p}\x00{slug}" not in covered_set]
+    if missing:
+        pending.append({"question": q, "slug": slug, "missingPlatforms": missing})
+batch = pending[:max_questions]
+if not init["daemonHealthy"] and batch:
+    log("⚠ gstack browse daemon is NOT running — skipping scraping this run (sandboxed agents cannot start it). Start it from the main session (e.g. run `browse status` via the /browse skill), then re-run.")
+    batch = []
+elif batch and init["daemonMode"] != "headed" and not input.get("allowHeadless"):
+    # Empirical (2026-06-09): in HEADLESS mode all three platforms hard-block the
+    # anonymous browser on the first query (ChatGPT/Perplexity: Cloudflare loop,
+    # Google: sorry-page captcha). Headed stealth mode (/connect-chrome) passes.
+    log("⚠ browse daemon is running HEADLESS — all 3 platforms bot-block anonymous headless browsers, so scraping is skipped. Run /connect-chrome in the main session for headed stealth mode (or pass allowHeadless: true to force).")
+    batch = []
+log(f"Questions: {len(all_questions)} total · {len(pending)} with missing platform coverage · scraping {len(batch)} this run (job {job_id})")
+
+# ═══ Phase: Scrape — sequential, one agent per question, no cookies ══════════
+phase("Scrape")
+
+scrape_status = []  # [{question, results: [{platform, status, note}]}]
+for item in batch:
+    scrape_prompt = f"""You are collecting AI-answer-engine responses for AEO (Answer Engine Optimization) research. You operate a headless browser WITHOUT any login cookies (sandbox environment). Work gently: one question, {len(item["missingPlatforms"])} platform(s), at most ONE retry per platform. If a platform shows a login wall, captcha, or bot block, mark it failed — do NOT fight it.
+
+QUESTION: {item["question"]}
+
+PLATFORMS TO QUERY (only these): {", ".join(item["missingPlatforms"])}
+
+Browser: the gstack browse daemon is ALREADY RUNNING (verified). {BROWSE_WRAPPER}
+Useful commands: goto <url> · text · snapshot -i · click <sel|@ref> · fill <sel> <val> · type <text> · press Enter · wait --networkidle · links · reload. Take a fresh "text" or "snapshot -i" after each wait to check streaming progress; poll with short waits instead of one long one.
+
+Bot-block handling: if a page shows a Cloudflare/"verify you are human" challenge or a hard login wall, wait ~10s, reload ONCE; if still blocked, mark that platform failed with note "blocked: <reason>" and move on.
+
+Per-platform instructions:
+{"- chatgpt: goto https://chatgpt.com — dismiss any consent/" + chr(34) + "stay logged out" + chr(34) + " dialogs. Fill the prompt box with the question, submit, then poll (wait a few seconds + re-read text) until the response stops growing. Extract the assistant's full answer as plain text, plus any cited/linked source URLs in the answer." + chr(10) if "chatgpt" in item["missingPlatforms"] else ""}{"- google-ai: goto https://www.google.com/search?udm=50&q=<url-encoded question> (Google AI Mode). If AI Mode is unavailable without login, fall back to a regular search https://www.google.com/search?q=... and use the " + chr(34) + "AI Overview" + chr(34) + " block (click " + chr(34) + "Show more" + chr(34) + " if present). Extract the AI-generated answer text and the cited source links (url + title). If there is NO AI-generated answer at all, mark failed with note " + chr(34) + "no AI answer" + chr(34) + "." + chr(10) if "google-ai" in item["missingPlatforms"] else ""}{"- perplexity: goto https://www.perplexity.ai/search?q=<url-encoded question> (or the homepage search box). Poll until the answer finishes. Extract the answer text and the numbered source citations (url + title)." + chr(10) if "perplexity" in item["missingPlatforms"] else ""}
+After scraping, write ONE json file per platform (including failed ones) using a python3 script. Path: {workspace}/answers/<platform>/{item["slug"]}.json (overwrite if present). Get TS_MS via python3 int(time.time()*1000). Exact JSON shape:
+{{
+  "scriptName": "search-<platform>",
+  "status": "completed" | "failed",
+  "timestamp": TS_MS,
+  "result": {{
+    "question": <the question>,
+    "answer": <full plain-text answer, or "" if failed>,
+    "answerLength": <len of answer>,
+    "sources": [{{"url": "...", "title": "..."}}],
+    "sourcesCount": <len of sources>
+  }},
+  "error": null | "<short reason>"
+}}
+Rules: status "completed" requires a non-empty real answer actually scraped from the platform. NEVER fabricate an answer or sources from your own knowledge — if scraping failed, status is "failed". Keep answer text as-is (do not summarize it).
+
+Return ONLY the structured object: results = one entry per platform with {{platform, status, answerChars, sourcesCount, note}} (note "" when fine)."""
+
+    out = await agent(scrape_prompt, label=f"ask:{item['slug'][:40]}", phase="Scrape", schema=SCRAPE_SCHEMA)
+    results = (out and out.get("results")) or [
+        {"platform": p, "status": "failed", "answerChars": 0, "sourcesCount": 0, "note": "scrape agent failed"}
+        for p in item["missingPlatforms"]
+    ]
+    scrape_status.append({"question": item["question"], "results": results})
+    line_summary = " ".join(f"{r['platform']}:{'ok' if r['status'] == 'completed' else 'FAIL'}" for r in results)
+    log(f'"{item["question"][:60]}..." → {line_summary}')
+
+# per-platform health for this run
+platform_health = {}
+for p in platforms:
+    rs = [r for s in scrape_status for r in s["results"] if r["platform"] == p]
+    platform_health[p] = {
+        "attempted": len(rs),
+        "completed": len([r for r in rs if r["status"] == "completed"]),
+        "notes": list(dict.fromkeys(r["note"] for r in rs if r["note"])),
+    }
+
+# ═══ Load full accumulated corpus (previous runs + this run) ═════════════════
+corpus_prompt = f"""Read ALL json files under {workspace}/answers/*/*.json on the local filesystem (use python3; the answers/<platform>/ dir name is the platform). For each file return one entry:
+{{platform, question: result.question, status: <"status" field>, answer: <result.answer, or result.aiGenerated.formattedContent if answer is missing/empty; truncate to 6000 chars>, sources: [{{url, title}}] from result.sources (use "" for a missing title; for source items that are plain strings, treat the string as the url)}}.
+Skip unparseable files. Return ONLY the structured object. If there are no files, return {{"answers": []}}."""
+
+corpus_out = await agent(corpus_prompt, label="load-corpus", phase="Scrape", schema=CORPUS_SCHEMA)
+corpus = [a for a in ((corpus_out and corpus_out.get("answers")) or []) if a["question"] and a["question"].strip()]
+valid_corpus = [a for a in corpus if a["status"] == "completed" and a["answer"].strip()]
+log(f"Corpus: {len(corpus)} answer files, {len(valid_corpus)} valid (completed) answers")
+if not valid_corpus:
+    raise RuntimeError(
+        f"No successful answers in the corpus (platform status: {json.dumps(platform_health)}; browse daemon healthy: {init['daemonHealthy']}). "
+        "Nothing to analyze. If the daemon was down, start it from the main session (any /browse command) and re-run. "
+        "If platforms blocked the anonymous browser, try again later, reduce maxQuestions, or import cookies via /setup-browser-cookies."
+    )
+
+# ═══ Phase: Competitors — steps 12/13/14 (15 skipped: upstream API) ═══════════
+phase("Competitors")
+
+sampled_answers = sample_answer_text(corpus)
+questions_joined = "\n".join(all_questions)
+
+# step-13 prompt, faithful
+find_competitors_prompt = f"""Task: Extract competitor brand names from the AI response.
+
+Variables:
+QUESTIONS = {questions_joined}
+AI_ANSWER = {sampled_answers}
+
+Context: Based on QUESTIONS, determine the product/service category and usage context being discussed.
+
+Definition - A competitor is a brand/product line that:
+- Offers products/services in the same primary category as discussed in QUESTIONS
+- Targets similar usage context and customer segment
+- Is explicitly mentioned in the AI response
+
+Inclusion rules (ALL required):
+- Name appears verbatim in the AI response
+- Represents a brand or product line name (no model numbers)
+- Relevant to the category implied by QUESTIONS
+- When uncertain, omit
+
+Exclusion rules:
+- Generic terms, technologies, categories (non-proper nouns)
+- Parent companies without specific product lines mentioned
+- Marketplaces/platforms unless they ARE the product category
+- Accessories or complementary items (unless that's your category)
+- Products/services outside the usage context of QUESTIONS
+
+Output format:
+Return only valid competitor names, comma-separated, no extra formatting.
+If none found, return empty string."""
+
+raw_competitors = (await agent(find_competitors_prompt, label="find-competitors", phase="Competitors")) or ""
+
+# step-14 prompt, faithful (output schema-forced instead of one-per-line text)
+reformat_prompt = f"""Inputs
+RAW_LIST = {raw_competitors}
+MY_BRAND = {brand}
+
+IMPORTANT:
+RAW_LIST is the ONLY allowed source of brand names.
+Do NOT generate, infer, explain, or fabricate any names.
+If RAW_LIST is empty or contains no valid brands return an empty list.
+
+Goal
+Clean and deduplicate RAW_LIST, exclude anything that equals MY_BRAND, exclude any empty strings.
+Rules (apply in this order):
+Parse & trim: Split on commas and line breaks; trim whitespace. Remove surrounding quotes/brackets/hashtags and trailing punctuation.
+Canonicalization for matching (not for inventing new names):
+Case-insensitive comparison.
+Ignore common legal suffixes for equality checks (e.g., Inc., LLC, Ltd., Co., GmbH, S.A., S.r.l., Pvt. Ltd., Co., Ltd., PLC, LLP, BV, NV, AB, AG, KK).
+Treat minor punctuation/spacing variants as the same (hyphens, extra spaces, periods).
+Exclude self: Remove any entry that equals MY_BRAND under the canonicalization above, or is an obvious alias/house style of MY_BRAND present in RAW_LIST.
+Scope guard: Keep only brand or product-line names (proper nouns). Discard generic descriptors, categories, feature terms, model numbers/SKUs, and non-brand entities.
+Deduplicate: Preserve the first appearance order from RAW_LIST.
+Use the original surface form from RAW_LIST (except trimming/quote removal).
+
+Return ONLY the structured object: {{competitors: [...]}}."""
+
+comp_out = await agent(reformat_prompt, label="clean-competitors", phase="Competitors", schema=COMPETITORS_SCHEMA)
+competitors = list(dict.fromkeys(
+    c2 for c2 in (c.strip() for c in ((comp_out and comp_out.get("competitors")) or []))
+    if c2 and c2.lower() != brand.lower()
+))
+log(f"Competitors found in AI answers: {', '.join(competitors) if competitors else '(none)'}")
+
+# ═══ Phase: Visibility — step 16 pure-code port (step 17 skipped) ════════════
+phase("Visibility")
+
+visibility = analyze_brand_visibility(corpus, brand, brand_link)
+visibility["competitors"] = [
+    {
+        "brand_name": c,
+        "brand_logo": "",
+        "brand_visibility_score_percentage": r["brand_visibility_score_percentage"],
+        "platform_visibility_score_percentage_list": r["platform_visibility_score_percentage_list"],
+    }
+    for c, r in ((c, analyze_brand_visibility(corpus, c, "")) for c in competitors)
+]
+log(f'Brand visibility: {visibility["brand_visibility_score_percentage"]}% of {len(valid_corpus)} valid answers mention "{brand}"')
+
+
+# visibility_history.csv row (trend across scheduled runs)
+def plat_pct(p):
+    e = next((x for x in visibility["platform_visibility_score_percentage_list"] if x["platform_name"] == p), None)
+    return e["platform_visibility_score_percentage"] if e else ""
+
+
+history_header = "Time,Job,Valid Answers,Brand %,Link %,chatgpt %,google-ai %,perplexity %"
+history_row = ",".join(csv_field(v) for v in [run_time, job_id, len(valid_corpus), visibility["brand_visibility_score_percentage"], visibility["brand_link_visibility_score_percentage"], plat_pct("chatgpt"), plat_pct("google-ai"), plat_pct("perplexity")])
+
+export_visibility_prompt = f"""Write these local files using a python3 script (create parent dirs; overwrite unless told to append). Return the structured object {{files: [<paths written>]}}.
+
+1. WRITE {workspace}/visibility_score.json with EXACTLY this JSON content:
+{json.dumps(visibility, indent=2)}
+
+2. APPEND to {workspace}/visibility_history.csv: if the file does not exist, first write the header line "{history_header}". Then append this row:
+{history_row}
+
+3. WRITE {workspace}/questions.txt — one question per line:
+{chr(10).join(all_questions)}"""
+
+vis_export = await agent(export_visibility_prompt, label="export-visibility", phase="Visibility", schema=EXPORT_SCHEMA)
+
+# ═══ Phase: Domains — steps 18-23 (pure code + one LLM categorization) ════════
+phase("Domains")
+
+_matrix = build_citation_matrix(corpus)
+matrix_rows = _matrix["rows"]
+domain_summary = _matrix["domainSummary"]
+url_mapping = build_url_mapping(corpus)
+log(f"Citations: {len(matrix_rows)} (platform,question,domain) rows across {len(domain_summary)} unique domains")
+
+# step-20 prompt, faithful (input = step-18 domain_summary), schema-forced
+category_map = {}
+cat_name_map = {}
+domcat_items = []
+if domain_summary:
+    domcat_prompt = f"""From the json input:
+{json.dumps({"domain_summary": {"description": "Unique domains with total citation counts", "total_unique_domains": len(domain_summary), "data": domain_summary}}, indent=2)}
+
+parse the key "domain_summary" and categorize every domain. For each domain produce:
+
+1. domain - the website domain (e.g., "amazon.com")
+2. total_citations - the citation count number
+3. category - snake_case category identifier
+4. category_name - human-readable category name
+
+Category mapping rules:
+- Use these predefined categories when applicable:
+  * "ecommerce" → "E-commerce"
+  * "social_media" → "Social Media"
+  * "news" → "News & Media"
+  * "review_websites" → "Review & Consumer Sites"
+  * "technology" → "Technology Platforms"
+  * "healthcare" → "Healthcare Organizations"
+  * "medical_devices" → "Medical Device Companies"
+  * "health_news" → "Health News & Media"
+  * "research" → "Research & Academic"
+  * "nonprofit" → "Nonprofit Organizations"
+  * "blogs" → "Blogs"
+  * "sports" → "Sports & Fitness"
+  * "government" → "Government & Public Services"
+  * "education" → "Educational Resources"
+
+For domains not fitting above categories, create appropriate snake_case category and corresponding human-readable name.
+Every domain must have both category and category_name filled. Return ONLY the structured object with one item per domain."""
+
+    domcat_out = await agent(domcat_prompt, label="categorize-domains", phase="Domains", schema=DOMCAT_SCHEMA)
+    domcat_items = (domcat_out and domcat_out.get("items")) or []
+    for it in domcat_items:
+        category_map[it["domain"]] = it["category"]
+        cat_name_map[it["domain"]] = it["category_name"]
+
+analysis = combine_ref_data(matrix_rows, category_map)
+reference_html = build_reference_html(url_mapping, cat_name_map, brand, run_time)
+
+# CSV strings (steps 18 + 21)
+matrix_csv = "\n".join(
+    ["platform,question,domain,citation_count"]
+    + [",".join(csv_field(v) for v in [r["platform"], r["question"], r["domain"], r["citation_count"]]) for r in matrix_rows]
+)
+summary_csv = "\n".join(
+    ["domain,total_citations,category,category_name"]
+    + [",".join(csv_field(v) for v in [it["domain"], it["total_citations"], it["category"], it["category_name"]]) for it in domcat_items]
+)
+
+# Exports are split across two parallel agents to bound per-prompt payload —
+# the corpus (and these artifacts) grow with every scheduled run.
+export_header = "Write these local files using a python3 script (create parent dirs, overwrite). The payloads below must be written EXACTLY as given. Return the structured object {files: [<paths written>]}."
+export_domains_prompt_a = f"""{export_header}
+
+1. WRITE {workspace}/domain_citation_matrix.csv :
+{matrix_csv}
+
+2. WRITE {workspace}/domain_summary.csv :
+{summary_csv}
+
+3. WRITE {workspace}/domain_reference.html :
+{reference_html}"""
+
+export_domains_prompt_b = f"""{export_header}
+
+1. WRITE {workspace}/domain_url_platform_mapping.json :
+{json.dumps(url_mapping, indent=2)}
+
+2. WRITE {workspace}/domain_analysis_result.json :
+{json.dumps(analysis, indent=2)}"""
+
+payload_bytes = len(export_domains_prompt_a) + len(export_domains_prompt_b)
+if payload_bytes > 300000:
+    log(f"⚠ domain export payload is {math.floor(payload_bytes / 1000 + 0.5)}KB and grows with corpus size — consider archiving {workspace} and starting a fresh question set.")
+dom_exports = await parallel([
+    agent(export_domains_prompt_a, label="export-domains-csv-html", phase="Domains", schema=EXPORT_SCHEMA),
+    agent(export_domains_prompt_b, label="export-domains-json", phase="Domains", schema=EXPORT_SCHEMA),
+])
+dom_export = {"files": [f for e in dom_exports if e for f in (e.get("files") or [])]}
+
+# ═══ Phase: Report — step 24 (faithful, genericized) + 25/27 ═════════════════
+phase("Report")
+
+# keep the report-agent prompt bounded: drop the bulkiest sections if huge
+report_input = analysis
+if len(json.dumps(analysis)) > 150000:
+    report_input = {**analysis, "by_question": "(omitted for size)", "platform_question_breakdown": "(omitted for size)"}
+    log("Analysis JSON > 150KB — report input reduced (by_question + breakdown omitted)")
+
+report_prompt = f"""{json.dumps(report_input, indent=2)}
+
+Generate a comprehensive AEO (Answer Engine Optimization) report based on the domain analysis JSON data provided. This analysis examines how different domains are cited by AI platforms (ChatGPT, Google AI Mode, and Perplexity) when responding to consumer queries about {topic_label}.
+
+## Report Requirements:
+
+### Structure:
+1. Executive Summary
+2. Domain Performance Rankings
+3. Platform-Specific Insights
+4. Comprehensive AEO Optimization Strategy
+
+### Section 1 - Executive Summary:
+Display these metrics with brief explanations:
+- Total platforms: [number] (explain what platforms are analyzed)
+- Total questions: [number] (explain these are unique test queries)
+- Unique domains: [number] (explain these are distinct websites cited)
+- Total platform_question_pairs: [number] (explain this counts unique platform-question combinations where domains appear)
+- Total actual_citations: [number] (explain this is the sum of all citation_count values)
+
+**Important**: Add a note explaining the difference between platform_question_occurrences (how many platform-question combinations a domain appears in) and actual_citation_total (the sum of citation counts).
+
+### Section 2 - Domain Performance Rankings:
+Create table with these columns:
+- Rank
+- Domain
+- Category
+- Platform-Question Occurrences (from platform_question_occurrences field)
+- Actual Citations Total (from actual_citation_total field)
+- Platform Count (how many different platforms cite this domain)
+
+Show top 15 domains sorted by platform_question_occurrences (highest first).
+
+**Add caption below table**: "Platform-Question Occurrences shows in how many unique (platform, question) pairs the domain was cited. Actual Citations Total shows the cumulative citation count when a domain appears multiple times for the same query."
+
+### Section 3 - Platform Coverage Analysis:
+
+#### 3a. Platform Distribution Table:
+Add caption: "*Domains sorted by platform coverage count (high to low)*"
+
+Create table with these columns:
+- Domain
+- ChatGPT (use ✓ or leave blank)
+- Google AI (use ✓ or leave blank)
+- Perplexity (use ✓ or leave blank)
+- Platform Count (number)
+- Platform-Question Occurrences
+
+Sort by platform count (most to least), then by occurrences.
+
+#### 3b. Platform-Specific Metrics:
+For each platform, show:
+- Total question_occurrences (explain this counts unique questions where domains appear)
+- Unique domains cited
+- Top 5 domains by question_occurrences
+
+### Section 4 - AEO Optimization Strategy:
+Include four tiers:
+- Tier 1: Foundation Building (explain citation frequency patterns)
+- Tier 2: Platform-Specific Optimization (reference platform_specific_domains data)
+- Tier 3: Content Distribution Framework (mention url_reuse patterns)
+- Tier 4: Technical Implementation
+Each tier must have specific tactics, KPIs based on the metrics, and timelines.
+
+Rules about Key Metrics to Explain:
+When using these metrics, always clarify their meaning at the beginning or end of the section in caption, but do not use the raw key name:
+- platform_question_occurrences: Number of unique (platform, question) combinations
+- actual_citation_total: Sum of all citation_count values for the domain
+- question_occurrences: Number of different questions where domain appears (within a platform)
+- platform_occurrences: Number of different platforms where domain appears (for a question)
+- url_reuse: How many URLs are used for multiple questions
+- max_url_reuse: Maximum times a single URL answered different questions
+
+### Writing Rules:
+1. No dates/years in titles
+2. Use metrics exactly as named in the JSON (platform_question_occurrences, not "citations")
+3. Explain what each metric means when first introduced
+4. Professional tone for business strategy
+5. Pure markdown output without code blocks
+6. When showing numbers, add brief inline explanations for clarity
+
+The goal is to help brands understand not just the numbers, but what they mean for optimization strategy. Output ONLY the report markdown — no preamble."""
+
+report_md = (await agent(report_prompt, label="write-aeo-report", phase="Report")) or ""
+if not report_md.strip():
+    raise RuntimeError("Report agent returned no output.")
+
+run_log_entry = {
+    "job_id": job_id,
+    "brand": brand,
+    "run_time": run_time,
+    "questions_total": len(all_questions),
+    "scraped_this_run": [
+        {
+            "question": s["question"],
+            "platforms": {r["platform"]: ("ok" if r["status"] == "completed" else ("failed: " + str(r["note"]) if r.get("note") else "failed")) for r in s["results"]},
+        }
+        for s in scrape_status
+    ],
+    "platform_health": platform_health,
+    "valid_answers_in_corpus": len(valid_corpus),
+}
+
+export_report_prompt = f"""Write these local files using a python3 script (create parent dirs). Return the structured object {{files: [<paths written>]}}.
+
+1. WRITE {workspace}/aeo-report.md with EXACTLY this markdown content:
+{report_md}
+
+2. UPDATE {workspace}/metadata.json — read it if it exists (shape {{"brand": ..., "runs": [...]}}); if missing or unparseable start from {{"brand": {json.dumps(brand)}, "runs": []}}. Append this run entry to "runs" and write back pretty-printed:
+{json.dumps(run_log_entry, indent=2)}
+
+After writing, print the ABSOLUTE path of the report file and include it in files."""
+
+rep_export = await agent(export_report_prompt, label="export-report", phase="Report", schema=EXPORT_SCHEMA)
+written_files = [
+    *((vis_export and vis_export.get("files")) or []),
+    *(dom_export.get("files") or []),
+    *((rep_export and rep_export.get("files")) or []),
+]
+report_path = next((f for f in written_files if f.endswith("aeo-report.md")), f"{workspace}/aeo-report.md")
+
+# ═══ Result (upstream step 27 equivalent) ═════════════════════════════════════
+remaining = len(pending) - len([
+    b for b in batch
+    if (lambda s: s and all(r["status"] == "completed" for r in s["results"]))(
+        next((x for x in scrape_status if x["question"] == b["question"]), None)
+    )
+])
+log(f"Done. Report: {report_path} · coverage {len(all_questions) - remaining}/{len(all_questions)} questions · {remaining} still pending")
+
+return {
+    "jobId": job_id,
+    "brand": brand,
+    "brandLink": brand_link,
+    "workspace": workspace,
+    "questionsTotal": len(all_questions),
+    "pendingBeforeRun": len(pending),
+    "scrapedThisRun": run_log_entry["scraped_this_run"],
+    "platformHealth": platform_health,
+    "validAnswersInCorpus": len(valid_corpus),
+    "visibility": {
+        "brand_visibility_score_percentage": visibility["brand_visibility_score_percentage"],
+        "brand_link_visibility_score_percentage": visibility["brand_link_visibility_score_percentage"],
+        "per_platform": visibility["platform_visibility_score_percentage_list"],
+    },
+    "topCompetitors": [
+        {"brand": c["brand_name"], "visibility": c["brand_visibility_score_percentage"]}
+        for c in sorted(visibility["competitors"], key=lambda a: a["brand_visibility_score_percentage"], reverse=True)[:5]
+    ],
+    "topDomains": analysis["overall"]["all_domains"][:5],
+    "reportPath": report_path,
+    "files": written_files,
+    "note":
+        "Cookie-less mode: platforms may block anonymous queries (see platformHealth). Failed (platform,question) pairs are retried on the next run — schedule this workflow daily to grow coverage. "
+        "REQUIREMENT: the gstack browse daemon must already be running in HEADED stealth mode (run /connect-chrome in the main session first) — sandboxed workflow agents cannot start it, and headless mode gets bot-blocked by all three platforms; when the daemon is down or headless the run skips scraping and only recomputes analysis. "
+        "Skipped vs the upstream original: S3 uploads and proprietary vendor backend APIs (query log, server competitor list, score submission) — everything is saved to the local workspace instead.",
+}

--- a/demos/workflows/04-aeo-content-advisor.js
+++ b/demos/workflows/04-aeo-content-advisor.js
@@ -1,0 +1,340 @@
+export const meta = {
+  name: 'aeo-content-advisor',
+  description: 'AEO Content Advisor — analyze the AI-answer corpus collected by /aeo-data-scientist to find brand content gaps and generate a strategic content roadmap.',
+  whenToUse: 'Run with a brand name after /aeo-data-scientist has collected answers. Computes brand visibility / recommendation rates per platform, identifies the questions where the brand is missing, cross-references the domains AI engines trust, and writes an AEO Strategic Audit Report with concrete content ideas.',
+  phases: [
+    { title: 'Load', detail: 'Read the accumulated AI-answer corpus from the local workspace' },
+    { title: 'Audit', detail: 'Mention depth, recommendation rate, top authorities, content gaps (pure JS)' },
+    { title: 'Report', detail: 'AEO Strategic Audit Report (faithful upstream prompt)' },
+    { title: 'Export', detail: 'Write report + audit JSON to the workspace' },
+  ],
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Singula-AI AEO marketing workflow — faithful port of the upstream
+// "Agent 4: AEO Content Advisor" (5 nodes) to a
+// Claude Code dynamic workflow.
+//
+//   Upstream node                          → workflow implementation
+//   1  Retrive AEO data (py, S3 by job)   → SKIPPED: no upstream S3 — we read agent 3's
+//   2  Retrieve AEO - Debug (py)            LOCAL workspace directly (answers/<platform>/*.json),
+//   3  Workspace path (py)                  which closes the team.context.job_id seam
+//   4  Python script (py, audit builder)  → pure JS port (mention depth, recommend keywords,
+//                                            ref blacklist, platform stats, content gaps)
+//   5  Create text (gpt-4.1)              → agent (faithful prompt; @Builtin-Today → `date`)
+//
+// Team-bus seam closed: the original took `team.context.job_id` (published by
+// agent 3) and re-downloaded that job's files from the upstream S3. Our agent 3
+// port accumulates answers in a persistent per-brand workspace, so this
+// workflow just points at the same directory — no job ID, no download.
+//
+// Input : args = "brand"  OR  { brand, brandLink?, workspace?, outputPath? }
+//         workspace defaults to ./demos/aeo-output/aeo-data-scientist/<brand-slug>
+//         (must contain answers/<platform>/*.json from /aeo-data-scientist)
+// Output: { brand, reportPath, auditPath, overallVisibility, topAuthorities, ... }
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ── args normalization ───────────────────────────────────────────────────────
+let input = args ?? {}
+if (typeof input === 'string') {
+  const t = input.trim()
+  if (t.startsWith('{')) {
+    try { input = JSON.parse(t) } catch (_) { input = { brand: t } }
+  } else {
+    input = { brand: t }
+  }
+}
+const brand = (input.brand || '').toString().trim()
+if (!brand) {
+  throw new Error('No brand provided. Pass args like "Cursor" or { brand: "Cursor" } — must match the brand used with /aeo-data-scientist.')
+}
+// Canonical slugify — keep IDENTICAL across all marketing workflows: the
+// CSV/workspace handoff between pipeline stages depends on matching slugs.
+const slugify = (s, max = 80) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, max).replace(/-+$/, '') || 'item'
+const brandSlug = slugify(brand, 40)
+const workspace = (input.workspace || `./demos/aeo-output/aeo-data-scientist/${brandSlug}`).replace(/\/+$/, '')
+const reportPath = input.outputPath || `${workspace}/aeo-content-advisor-report.md`
+const auditPath = `${workspace}/aeo-content-audit.json`
+
+log(`Brand: "${brand}"  ·  corpus: ${workspace}/answers/  ·  report → ${reportPath}`)
+
+// ── Schemas ──────────────────────────────────────────────────────────────────
+const CORPUS_SCHEMA = {
+  type: 'object',
+  properties: {
+    runDate: { type: 'string' },   // YYYY-MM-DD
+    answers: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          platform: { type: 'string' },
+          question: { type: 'string' },
+          status: { type: 'string' },
+          answer: { type: 'string' },
+          sources: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: { url: { type: 'string' }, title: { type: 'string' } },
+              required: ['url', 'title'],
+              additionalProperties: false,
+            },
+          },
+        },
+        required: ['platform', 'question', 'status', 'answer', 'sources'],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ['runDate', 'answers'],
+  additionalProperties: false,
+}
+
+const EXPORT_SCHEMA = {
+  type: 'object',
+  properties: { files: { type: 'array', items: { type: 'string' } } },
+  required: ['files'],
+  additionalProperties: false,
+}
+
+// ── pure-JS port of step-4 (audit builder) ───────────────────────────────────
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function domainFromUrl(url) {
+  if (!url) return ''
+  let u = url.trim()
+  if (!/^https?:\/\//i.test(u)) u = 'https://' + u
+  const m = u.match(/^https?:\/\/([^/?#]+)/i)
+  let domain = (m ? m[1] : '').toLowerCase()
+  return domain.replace(/^www\./, '').replace(/:\d+$/, '')
+}
+
+// step-4 analyze_mention_depth: count \b-bounded mentions; "recommended" when
+// any endorsement keyword appears in a text that mentions the brand
+const RECOMMEND_KEYWORDS = ['best', 'top', 'recommend', 'reliable', 'superior', 'choice', 'winner', 'excellent']
+function analyzeMentionDepth(text, brandName) {
+  if (!text || !brandName) return { count: 0, is_recommended: false }
+  const lower = text.toLowerCase()
+  const mentions = (lower.match(new RegExp(`\\b${escapeRegex(brandName.toLowerCase())}\\b`, 'g')) || []).length
+  const isRecommended = mentions > 0 && RECOMMEND_KEYWORDS.some((kw) => lower.includes(kw))
+  return { count: mentions, is_recommended: isRecommended }
+}
+
+// step-4 extract_detailed_sources (blacklist preserved; domain derived from url
+// since our canonical answer files store sources as {url, title})
+const REF_BLACKLIST = ['policies.google.com', 'support.google.com', 'blog.google', 'youtube.com/ads']
+function extractDetailedSources(sources) {
+  const refs = []
+  for (const s of sources || []) {
+    const domain = domainFromUrl(s.url)
+    if (domain && !REF_BLACKLIST.includes(domain)) {
+      refs.push({ domain, title: (s.title || '').slice(0, 100), url: s.url || '' })
+    }
+  }
+  return refs
+}
+
+// step-4 process_json_file equivalent over a canonical corpus entry
+function processEntry(entry, brandName) {
+  const brandIntel = analyzeMentionDepth(entry.answer, brandName)
+  const refList = extractDetailedSources(entry.sources)
+  const brandInCitations = refList.some((ref) => JSON.stringify(ref).toLowerCase().includes(brandName.toLowerCase()))
+  return {
+    question: entry.question || 'Unknown Question',
+    source: entry.platform,
+    include_brand: brandIntel.count > 0,
+    mention_count: brandIntel.count,
+    is_recommended: brandIntel.is_recommended,
+    brand_in_citations: brandInCitations,
+    ref_list: refList,
+  }
+}
+
+// step-4 calculate_advanced_stats (same output keys and formatting)
+function calculateAdvancedStats(allResults) {
+  const platformData = {}
+  const domainCounter = {}
+  const questionMap = {}
+  for (const r of allResults) {
+    const p = r.source, q = r.question
+    platformData[p] = platformData[p] || { tested: 0, found: 0, recommendations: 0, total_mentions: 0 }
+    platformData[p].tested += 1
+    if (r.include_brand) {
+      platformData[p].found += 1
+      platformData[p].total_mentions += r.mention_count
+      if (r.is_recommended) platformData[p].recommendations += 1
+    }
+    ;(questionMap[q] = questionMap[q] || {})[p] = r.include_brand
+    for (const ref of r.ref_list) domainCounter[ref.domain] = (domainCounter[ref.domain] || 0) + 1
+  }
+  const pct = (x) => `${(x * 100).toFixed(1)}%`
+  const byPlatform = {}
+  for (const [p, s] of Object.entries(platformData)) {
+    byPlatform[p] = {
+      visibility: pct(s.found / s.tested),
+      recommend_rate: pct(s.found > 0 ? s.recommendations / s.found : 0),
+      avg_mentions: s.found > 0 ? Math.round((s.total_mentions / s.found) * 100) / 100 : 0,
+    }
+  }
+  const completelyMissing = [], partiallyMissing = []
+  for (const [q, pStatus] of Object.entries(questionMap)) {
+    const foundIn = Object.entries(pStatus).filter(([, v]) => v).map(([p]) => p)
+    const missingIn = Object.entries(pStatus).filter(([, v]) => !v).map(([p]) => p)
+    if (!foundIn.length) completelyMissing.push({ question: q, missing: missingIn })
+    else if (missingIn.length) partiallyMissing.push({ question: q, found: foundIn, missing: missingIn })
+  }
+  const totalTested = Object.values(platformData).reduce((a, s) => a + s.tested, 0)
+  const totalFound = Object.values(platformData).reduce((a, s) => a + s.found, 0)
+  return {
+    brand_health: {
+      overall_visibility: pct(totalTested > 0 ? totalFound / totalTested : 0),
+      top_authorities: Object.entries(domainCounter).sort((a, b) => b[1] - a[1]).slice(0, 10).map(([d]) => d),
+    },
+    platform_deep_dive: byPlatform,
+    content_gaps: {
+      high_priority_missing: completelyMissing,
+      opportunity_count: completelyMissing.length + partiallyMissing.length,
+    },
+  }
+}
+
+// ═══ Phase: Load — read corpus + current date ════════════════════════════════
+phase('Load')
+
+const corpusPrompt = `Read ALL json files under ${workspace}/answers/*/*.json on the local filesystem (use python3; the answers/<platform>/ dir name is the platform). For each file return one entry:
+{platform, question: result.question, status: <"status" field>, answer: <result.answer, or result.aiGenerated.formattedContent if answer is missing/empty; truncate to 6000 chars>, sources: [{url, title}] from result.sources (use "" for a missing title; for source items that are plain strings, treat the string as the url)}.
+Skip unparseable files. Also run \`date '+%Y-%m-%d'\` and return it as runDate.
+Return ONLY the structured object. If there are no files, return {"runDate": <date>, "answers": []}.`
+
+const corpusOut = await agent(corpusPrompt, { label: 'load-corpus', phase: 'Load', schema: CORPUS_SCHEMA })
+if (!corpusOut) throw new Error('Corpus loader agent failed.')
+const corpus = (corpusOut.answers || []).filter((a) => a.status === 'completed' && a.answer.trim() && a.question.trim())
+if (!corpus.length) {
+  throw new Error(
+    `No completed AI answers found under ${workspace}/answers/. ` +
+    `Run /aeo-data-scientist for brand "${brand}" first (it collects the corpus this advisor analyzes), or pass workspace: "<path>" if the data lives elsewhere.`,
+  )
+}
+log(`Corpus: ${corpus.length} completed answers across ${new Set(corpus.map((a) => a.platform)).size} platform(s)`)
+
+// ═══ Phase: Audit — step-4 pure JS ═══════════════════════════════════════════
+phase('Audit')
+
+const allResults = corpus.map((entry) => processEntry(entry, brand))
+const auditSummary = calculateAdvancedStats(allResults)
+const auditJson = {
+  success: true,
+  brand_name: brand,
+  audit_summary: auditSummary,
+  raw_results: allResults,
+}
+log(`Audit: visibility ${auditSummary.brand_health.overall_visibility} · ${auditSummary.content_gaps.high_priority_missing.length} questions with brand fully missing · top authority: ${auditSummary.brand_health.top_authorities[0] || '(none)'}`)
+
+// keep the report prompt bounded: drop per-result ref_list details if huge
+let reportInput = auditJson
+if (JSON.stringify(auditJson).length > 150000) {
+  reportInput = {
+    ...auditJson,
+    raw_results: allResults.map((r) => ({ ...r, ref_list: r.ref_list.slice(0, 3) })),
+  }
+  log('Audit JSON > 150KB — ref lists trimmed to 3 per result for the report prompt')
+}
+
+// ═══ Phase: Report — step-5 prompt, faithful ═════════════════════════════════
+phase('Report')
+
+const reportPrompt = `# AEO Strategy & Content Intelligence - Expert Prompt
+
+## Role
+You are a senior AEO (Answer Engine Optimization) Strategist. Your goal is to analyze brand audit data and create a content roadmap that forces AI models (ChatGPT, Google AI, Perplexity) to recognize and recommend ${brand}.
+
+## Task
+1. Analyze the provided JSON to identify "Brand Gaps" where ${brand} is missing or not recommended.
+2. Cross-reference the "Top Authorities" (domains AI trust) with the missing questions.
+3. For each high-priority missing question, generate a strategic content plan.
+
+## Input Data Breakdown
+You will receive a JSON containing:
+- \`audit_summary\`: Brand health, visibility rates, and \`top_authorities\` (the domains AI currently cites).
+- \`raw_results\`: Detailed question-by-question performance including \`is_recommended\` and \`brand_in_citations\`.
+
+## Output Format (Markdown)
+
+# AEO Strategic Audit Report: ${brand}
+
+## 1. Brand Visibility Scorecard
+- **Overall Visibility:** [Overall % from audit_summary]
+- **Platform Performance:** - ChatGPT: [Visibility %] (Avg Mentions: [X])
+  - Google AI: [Visibility %] (Avg Mentions: [X])
+  - Perplexity: [Visibility %] (Avg Mentions: [X])
+- **Recommendation Rate:** [Overall Recommend Rate]% (How often AI actually "endorses" the brand)
+
+## 2. Competitive Citation Intelligence
+- **Dominant Authorities:** [List Top 5 domains from top_authorities]
+- **Strategic Insight:** [Briefly explain if the brand is missing from these top cited domains and what it means for AEO].
+
+## 3. High-Priority Content Solutions
+For each question in \`high_priority_missing\` (or grouped by topic):
+
+### Topic/Question: [Question Text]
+- **The Gap:** [Why is the brand missing? e.g., "AI relies on site X which doesn't list us."]
+- **Recommended Content Pieces (3-5 ideas):**
+  * **Title:** [SEO Optimized: 50-60 chars]
+  * **Description:** [Brief, mentioning brand name and a key USP]
+  * **AEO Pivot:** [Explain how this specific piece targets the "Top Authorities" or fills a technical data gap for AI models].
+
+## 4. Immediate Action Items
+- [List 3 concrete steps, e.g., "Publish a comparison guide vs Competitor X", "Update technical schema on the site"].
+
+## Instructions:
+1. **Be Data-Driven:** Use the exact percentages and counts from the JSON.
+2. **Be Specific:** Content titles must include the ${brand}.
+3. **Focus on "Influence":** Don't just suggest blogs; suggest content that provides the *data points* AI models are currently missing.
+4. **Tone:** Professional, analytical, and action-oriented.
+5. **Time Accuracy**: Today's date is ${corpusOut.runDate} , for any context that implies current date/year, you must use the correct date.
+
+JSON Data:
+${JSON.stringify(reportInput, null, 2)}
+
+Output ONLY the report markdown — no preamble.`
+
+const reportMd = (await agent(reportPrompt, { label: 'aeo-strategy-report', phase: 'Report' })) || ''
+if (!reportMd.trim()) throw new Error('Report agent returned no output.')
+
+// ═══ Phase: Export ═══════════════════════════════════════════════════════════
+phase('Export')
+
+// Split across two parallel agents to bound per-prompt payload — the audit
+// JSON grows with the corpus across scheduled runs.
+const exportHeader = 'Write this local file using a python3 script (create parent dirs, overwrite). The payload must be written EXACTLY as given. Return the structured object {files: [<ABSOLUTE path written>]}.'
+const exps = await parallel([
+  () => agent(`${exportHeader}
+
+WRITE ${reportPath} with this markdown content:
+${reportMd}`, { label: 'export-report-md', phase: 'Export', schema: EXPORT_SCHEMA }),
+  () => agent(`${exportHeader}
+
+WRITE ${auditPath} with this JSON content:
+${JSON.stringify(auditJson, null, 2)}`, { label: 'export-audit-json', phase: 'Export', schema: EXPORT_SCHEMA }),
+])
+const files = exps.filter(Boolean).flatMap((e) => e.files || [])
+if (!files.length) files.push(reportPath, auditPath)
+
+log(`Done. Report: ${files.find((f) => f.endsWith('.md')) || reportPath}`)
+return {
+  brand,
+  reportPath: files.find((f) => f.endsWith('.md')) || reportPath,
+  auditPath: files.find((f) => f.endsWith('.json')) || auditPath,
+  answersAnalyzed: corpus.length,
+  overallVisibility: auditSummary.brand_health.overall_visibility,
+  platformDeepDive: auditSummary.platform_deep_dive,
+  topAuthorities: auditSummary.brand_health.top_authorities.slice(0, 5),
+  highPriorityMissing: auditSummary.content_gaps.high_priority_missing.length,
+  opportunityCount: auditSummary.content_gaps.opportunity_count,
+  note:
+    'Reads the local corpus accumulated by /aeo-data-scientist (replaces the upstream S3 job download — team.context.job_id seam closed). ' +
+    'The audit improves as the corpus grows: schedule /aeo-data-scientist daily, re-run this advisor whenever you want a fresh roadmap.',
+}

--- a/demos/workflows/04-aeo-content-advisor.py
+++ b/demos/workflows/04-aeo-content-advisor.py
@@ -1,0 +1,357 @@
+meta = {
+    "name": "aeo-content-advisor",
+    "description": "AEO Content Advisor — analyze the AI-answer corpus collected by /aeo-data-scientist to find brand content gaps and generate a strategic content roadmap.",
+    "when_to_use": "Run with a brand name after /aeo-data-scientist has collected answers. Computes brand visibility / recommendation rates per platform, identifies the questions where the brand is missing, cross-references the domains AI engines trust, and writes an AEO Strategic Audit Report with concrete content ideas.",
+    "phases": [
+        {"title": "Load", "detail": "Read the accumulated AI-answer corpus from the local workspace"},
+        {"title": "Audit", "detail": "Mention depth, recommendation rate, top authorities, content gaps (pure Python)"},
+        {"title": "Report", "detail": "AEO Strategic Audit Report (faithful upstream prompt)"},
+        {"title": "Export", "detail": "Write report + audit JSON to the workspace"},
+    ],
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Singula-AI AEO marketing workflow — faithful port of the upstream
+# "Agent 4: AEO Content Advisor" (5 nodes) to a
+# Claude Code dynamic workflow.
+#
+#   Upstream node                          → workflow implementation
+#   1  Retrive AEO data (py, S3 by job)   → SKIPPED: no upstream S3 — we read agent 3's
+#   2  Retrieve AEO - Debug (py)            LOCAL workspace directly (answers/<platform>/*.json),
+#   3  Workspace path (py)                  which closes the team.context.job_id seam
+#   4  Python script (py, audit builder)  → pure Python port (mention depth, recommend keywords,
+#                                            ref blacklist, platform stats, content gaps)
+#   5  Create text (gpt-4.1)              → agent (faithful prompt; @Builtin-Today → `date`)
+#
+# Team-bus seam closed: the original took `team.context.job_id` (published by
+# agent 3) and re-downloaded that job's files from the upstream S3. Our agent 3
+# port accumulates answers in a persistent per-brand workspace, so this
+# workflow just points at the same directory — no job ID, no download.
+#
+# Input : args = "brand"  OR  { brand, brandLink?, workspace?, outputPath? }
+#         workspace defaults to ./demos/aeo-output/aeo-data-scientist/<brand-slug>
+#         (must contain answers/<platform>/*.json from /aeo-data-scientist)
+# Output: { brand, reportPath, auditPath, overallVisibility, topAuthorities, ... }
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── args normalization ───────────────────────────────────────────────────────
+input = args if args is not None else {}
+if isinstance(input, str):
+    t = input.strip()
+    if t.startswith("{"):
+        try:
+            input = json.loads(t)
+        except Exception:
+            input = {"brand": t}
+    else:
+        input = {"brand": t}
+brand = str(input.get("brand") or "").strip()
+if not brand:
+    raise RuntimeError('No brand provided. Pass args like "Cursor" or { brand: "Cursor" } — must match the brand used with /aeo-data-scientist.')
+
+
+# Canonical slugify — keep IDENTICAL across all marketing workflows: the
+# CSV/workspace handoff between pipeline stages depends on matching slugs.
+def slugify(s, max=80):
+    out = re.sub(r"-+$", "", re.sub(r"^-+|-+$", "", re.sub(r"[^a-z0-9]+", "-", s.lower()))[:max])
+    return out or "item"
+
+
+brandSlug = slugify(brand, 40)
+workspace = re.sub(r"/+$", "", input.get("workspace") or f"./demos/aeo-output/aeo-data-scientist/{brandSlug}")
+reportPath = input.get("outputPath") or f"{workspace}/aeo-content-advisor-report.md"
+auditPath = f"{workspace}/aeo-content-audit.json"
+
+log(f'Brand: "{brand}"  ·  corpus: {workspace}/answers/  ·  report → {reportPath}')
+
+# ── Schemas ──────────────────────────────────────────────────────────────────
+CORPUS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "runDate": {"type": "string"},   # YYYY-MM-DD
+        "answers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "platform": {"type": "string"},
+                    "question": {"type": "string"},
+                    "status": {"type": "string"},
+                    "answer": {"type": "string"},
+                    "sources": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {"url": {"type": "string"}, "title": {"type": "string"}},
+                            "required": ["url", "title"],
+                            "additionalProperties": False,
+                        },
+                    },
+                },
+                "required": ["platform", "question", "status", "answer", "sources"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["runDate", "answers"],
+    "additionalProperties": False,
+}
+
+EXPORT_SCHEMA = {
+    "type": "object",
+    "properties": {"files": {"type": "array", "items": {"type": "string"}}},
+    "required": ["files"],
+    "additionalProperties": False,
+}
+
+
+# ── pure-Python port of step-4 (audit builder) ───────────────────────────────
+def escapeRegex(s):
+    return re.sub(r"[.*+?^${}()|[\]\\]", r"\\\g<0>", s)
+
+
+def domainFromUrl(url):
+    if not url:
+        return ""
+    u = url.strip()
+    if not re.match(r"^https?://", u, re.IGNORECASE):
+        u = "https://" + u
+    m = re.match(r"^https?://([^/?#]+)", u, re.IGNORECASE)
+    domain = (m.group(1) if m else "").lower()
+    return re.sub(r":\d+$", "", re.sub(r"^www\.", "", domain))
+
+
+# step-4 analyze_mention_depth: count \b-bounded mentions; "recommended" when
+# any endorsement keyword appears in a text that mentions the brand
+RECOMMEND_KEYWORDS = ["best", "top", "recommend", "reliable", "superior", "choice", "winner", "excellent"]
+
+
+def analyzeMentionDepth(text, brandName):
+    if not text or not brandName:
+        return {"count": 0, "is_recommended": False}
+    lower = text.lower()
+    mentions = len(re.findall(rf"\b{escapeRegex(brandName.lower())}\b", lower))
+    isRecommended = mentions > 0 and any(kw in lower for kw in RECOMMEND_KEYWORDS)
+    return {"count": mentions, "is_recommended": isRecommended}
+
+
+# step-4 extract_detailed_sources (blacklist preserved; domain derived from url
+# since our canonical answer files store sources as {url, title})
+REF_BLACKLIST = ["policies.google.com", "support.google.com", "blog.google", "youtube.com/ads"]
+
+
+def extractDetailedSources(sources):
+    refs = []
+    for s in sources or []:
+        domain = domainFromUrl(s.get("url"))
+        if domain and domain not in REF_BLACKLIST:
+            refs.append({"domain": domain, "title": (s.get("title") or "")[:100], "url": s.get("url") or ""})
+    return refs
+
+
+# step-4 process_json_file equivalent over a canonical corpus entry
+def processEntry(entry, brandName):
+    brandIntel = analyzeMentionDepth(entry.get("answer"), brandName)
+    refList = extractDetailedSources(entry.get("sources"))
+    brandInCitations = any(brandName.lower() in json.dumps(ref).lower() for ref in refList)
+    return {
+        "question": entry.get("question") or "Unknown Question",
+        "source": entry.get("platform"),
+        "include_brand": brandIntel["count"] > 0,
+        "mention_count": brandIntel["count"],
+        "is_recommended": brandIntel["is_recommended"],
+        "brand_in_citations": brandInCitations,
+        "ref_list": refList,
+    }
+
+
+# step-4 calculate_advanced_stats (same output keys and formatting)
+def calculateAdvancedStats(allResults):
+    platformData = {}
+    domainCounter = {}
+    questionMap = {}
+    for r in allResults:
+        p, q = r["source"], r["question"]
+        platformData[p] = platformData.get(p) or {"tested": 0, "found": 0, "recommendations": 0, "total_mentions": 0}
+        platformData[p]["tested"] += 1
+        if r["include_brand"]:
+            platformData[p]["found"] += 1
+            platformData[p]["total_mentions"] += r["mention_count"]
+            if r["is_recommended"]:
+                platformData[p]["recommendations"] += 1
+        questionMap[q] = questionMap.get(q) or {}
+        questionMap[q][p] = r["include_brand"]
+        for ref in r["ref_list"]:
+            domainCounter[ref["domain"]] = domainCounter.get(ref["domain"], 0) + 1
+
+    def pct(x):
+        return f"{x * 100:.1f}%"
+
+    byPlatform = {}
+    for p, s in platformData.items():
+        byPlatform[p] = {
+            "visibility": pct(s["found"] / s["tested"]),
+            "recommend_rate": pct(s["recommendations"] / s["found"] if s["found"] > 0 else 0),
+            "avg_mentions": round((s["total_mentions"] / s["found"]) * 100) / 100 if s["found"] > 0 else 0,
+        }
+    completelyMissing, partiallyMissing = [], []
+    for q, pStatus in questionMap.items():
+        foundIn = [p for p, v in pStatus.items() if v]
+        missingIn = [p for p, v in pStatus.items() if not v]
+        if not foundIn:
+            completelyMissing.append({"question": q, "missing": missingIn})
+        elif missingIn:
+            partiallyMissing.append({"question": q, "found": foundIn, "missing": missingIn})
+    totalTested = sum(s["tested"] for s in platformData.values())
+    totalFound = sum(s["found"] for s in platformData.values())
+    return {
+        "brand_health": {
+            "overall_visibility": pct(totalFound / totalTested if totalTested > 0 else 0),
+            "top_authorities": [d for d, _ in sorted(domainCounter.items(), key=lambda kv: kv[1], reverse=True)[:10]],
+        },
+        "platform_deep_dive": byPlatform,
+        "content_gaps": {
+            "high_priority_missing": completelyMissing,
+            "opportunity_count": len(completelyMissing) + len(partiallyMissing),
+        },
+    }
+
+
+# ═══ Phase: Load — read corpus + current date ════════════════════════════════
+phase("Load")
+
+corpusPrompt = f"""Read ALL json files under {workspace}/answers/*/*.json on the local filesystem (use python3; the answers/<platform>/ dir name is the platform). For each file return one entry:
+{{platform, question: result.question, status: <"status" field>, answer: <result.answer, or result.aiGenerated.formattedContent if answer is missing/empty; truncate to 6000 chars>, sources: [{{url, title}}] from result.sources (use "" for a missing title; for source items that are plain strings, treat the string as the url)}}.
+Skip unparseable files. Also run `date '+%Y-%m-%d'` and return it as runDate.
+Return ONLY the structured object. If there are no files, return {{"runDate": <date>, "answers": []}}."""
+
+corpusOut = await agent(corpusPrompt, label="load-corpus", phase="Load", schema=CORPUS_SCHEMA)
+if not corpusOut:
+    raise RuntimeError("Corpus loader agent failed.")
+corpus = [a for a in (corpusOut.get("answers") or []) if a["status"] == "completed" and a["answer"].strip() and a["question"].strip()]
+if not corpus:
+    raise RuntimeError(
+        f"No completed AI answers found under {workspace}/answers/. "
+        f'Run /aeo-data-scientist for brand "{brand}" first (it collects the corpus this advisor analyzes), or pass workspace: "<path>" if the data lives elsewhere.'
+    )
+log(f"Corpus: {len(corpus)} completed answers across {len(set(a['platform'] for a in corpus))} platform(s)")
+
+# ═══ Phase: Audit — step-4 pure Python ═══════════════════════════════════════
+phase("Audit")
+
+allResults = [processEntry(entry, brand) for entry in corpus]
+auditSummary = calculateAdvancedStats(allResults)
+auditJson = {
+    "success": True,
+    "brand_name": brand,
+    "audit_summary": auditSummary,
+    "raw_results": allResults,
+}
+log(f"Audit: visibility {auditSummary['brand_health']['overall_visibility']} · {len(auditSummary['content_gaps']['high_priority_missing'])} questions with brand fully missing · top authority: {(auditSummary['brand_health']['top_authorities'][0] if auditSummary['brand_health']['top_authorities'] else '(none)')}")
+
+# keep the report prompt bounded: drop per-result ref_list details if huge
+reportInput = auditJson
+if len(json.dumps(auditJson)) > 150000:
+    reportInput = {
+        **auditJson,
+        "raw_results": [{**r, "ref_list": r["ref_list"][:3]} for r in allResults],
+    }
+    log("Audit JSON > 150KB — ref lists trimmed to 3 per result for the report prompt")
+
+# ═══ Phase: Report — step-5 prompt, faithful ═════════════════════════════════
+phase("Report")
+
+reportPrompt = f"""# AEO Strategy & Content Intelligence - Expert Prompt
+
+## Role
+You are a senior AEO (Answer Engine Optimization) Strategist. Your goal is to analyze brand audit data and create a content roadmap that forces AI models (ChatGPT, Google AI, Perplexity) to recognize and recommend {brand}.
+
+## Task
+1. Analyze the provided JSON to identify "Brand Gaps" where {brand} is missing or not recommended.
+2. Cross-reference the "Top Authorities" (domains AI trust) with the missing questions.
+3. For each high-priority missing question, generate a strategic content plan.
+
+## Input Data Breakdown
+You will receive a JSON containing:
+- `audit_summary`: Brand health, visibility rates, and `top_authorities` (the domains AI currently cites).
+- `raw_results`: Detailed question-by-question performance including `is_recommended` and `brand_in_citations`.
+
+## Output Format (Markdown)
+
+# AEO Strategic Audit Report: {brand}
+
+## 1. Brand Visibility Scorecard
+- **Overall Visibility:** [Overall % from audit_summary]
+- **Platform Performance:** - ChatGPT: [Visibility %] (Avg Mentions: [X])
+  - Google AI: [Visibility %] (Avg Mentions: [X])
+  - Perplexity: [Visibility %] (Avg Mentions: [X])
+- **Recommendation Rate:** [Overall Recommend Rate]% (How often AI actually "endorses" the brand)
+
+## 2. Competitive Citation Intelligence
+- **Dominant Authorities:** [List Top 5 domains from top_authorities]
+- **Strategic Insight:** [Briefly explain if the brand is missing from these top cited domains and what it means for AEO].
+
+## 3. High-Priority Content Solutions
+For each question in `high_priority_missing` (or grouped by topic):
+
+### Topic/Question: [Question Text]
+- **The Gap:** [Why is the brand missing? e.g., "AI relies on site X which doesn't list us."]
+- **Recommended Content Pieces (3-5 ideas):**
+  * **Title:** [SEO Optimized: 50-60 chars]
+  * **Description:** [Brief, mentioning brand name and a key USP]
+  * **AEO Pivot:** [Explain how this specific piece targets the "Top Authorities" or fills a technical data gap for AI models].
+
+## 4. Immediate Action Items
+- [List 3 concrete steps, e.g., "Publish a comparison guide vs Competitor X", "Update technical schema on the site"].
+
+## Instructions:
+1. **Be Data-Driven:** Use the exact percentages and counts from the JSON.
+2. **Be Specific:** Content titles must include the {brand}.
+3. **Focus on "Influence":** Don't just suggest blogs; suggest content that provides the *data points* AI models are currently missing.
+4. **Tone:** Professional, analytical, and action-oriented.
+5. **Time Accuracy**: Today's date is {corpusOut["runDate"]} , for any context that implies current date/year, you must use the correct date.
+
+JSON Data:
+{json.dumps(reportInput, indent=2)}
+
+Output ONLY the report markdown — no preamble."""
+
+reportMd = (await agent(reportPrompt, label="aeo-strategy-report", phase="Report")) or ""
+if not reportMd.strip():
+    raise RuntimeError("Report agent returned no output.")
+
+# ═══ Phase: Export ═══════════════════════════════════════════════════════════
+phase("Export")
+
+# Split across two parallel agents to bound per-prompt payload — the audit
+# JSON grows with the corpus across scheduled runs.
+exportHeader = "Write this local file using a python3 script (create parent dirs, overwrite). The payload must be written EXACTLY as given. Return the structured object {files: [<ABSOLUTE path written>]}."
+exps = await parallel([
+    agent(f"""{exportHeader}
+
+WRITE {reportPath} with this markdown content:
+{reportMd}""", label="export-report-md", phase="Export", schema=EXPORT_SCHEMA),
+    agent(f"""{exportHeader}
+
+WRITE {auditPath} with this JSON content:
+{json.dumps(auditJson, indent=2)}""", label="export-audit-json", phase="Export", schema=EXPORT_SCHEMA),
+])
+files = [f for e in exps if e for f in (e.get("files") or [])]
+if not files:
+    files.extend([reportPath, auditPath])
+
+log(f"Done. Report: {next((f for f in files if f.endswith('.md')), reportPath)}")
+return {
+    "brand": brand,
+    "reportPath": next((f for f in files if f.endswith(".md")), reportPath),
+    "auditPath": next((f for f in files if f.endswith(".json")), auditPath),
+    "answersAnalyzed": len(corpus),
+    "overallVisibility": auditSummary["brand_health"]["overall_visibility"],
+    "platformDeepDive": auditSummary["platform_deep_dive"],
+    "topAuthorities": auditSummary["brand_health"]["top_authorities"][:5],
+    "highPriorityMissing": len(auditSummary["content_gaps"]["high_priority_missing"]),
+    "opportunityCount": auditSummary["content_gaps"]["opportunity_count"],
+    "note":
+        "Reads the local corpus accumulated by /aeo-data-scientist (replaces the upstream S3 job download — team.context.job_id seam closed). "
+        "The audit improves as the corpus grows: schedule /aeo-data-scientist daily, re-run this advisor whenever you want a fresh roadmap.",
+}

--- a/demos/workflows/05-article-writer.js
+++ b/demos/workflows/05-article-writer.js
@@ -1,0 +1,187 @@
+export const meta = {
+  name: 'article-writer',
+  description: 'Article Writing Team — write an AEO-optimized blog article from a title + your product URL, then refine it into a natural, engaging post (two-pass: draft → polish).',
+  whenToUse: 'Run with a blog article title and a product URL (plus an optional content guide) to produce a publish-ready markdown article that weaves the product context in subtly. Pairs with /aeo-content-advisor: feed it the content ideas/titles from the advisor report.',
+  phases: [
+    { title: 'Context', detail: 'Fetch the product URL and extract product context' },
+    { title: 'Draft', detail: 'Write the full-length blog article (faithful upstream prompt)' },
+    { title: 'Polish', detail: 'Editorial refinement pass (faithful upstream prompt)' },
+    { title: 'Export', detail: 'Save the article as markdown' },
+  ],
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Singula-AI AEO marketing workflow — faithful port of the upstream
+// "Agent 5: Article Writing Team Version" (3 nodes)
+// to a Claude Code dynamic workflow.
+//
+//   Upstream node                          → workflow implementation
+//   1  Product context (fetch_web)        → agent + WebFetch (WebSearch fallback) — the
+//                                            original drove a Playwright Chrome page
+//   2  Blog generator (gpt-5.1)           → agent (faithful prompt; @Builtin-Today → `date`)
+//   3  Improve writing (gpt-5.1)          → agent (faithful prompt; one genericization:
+//                                            "lifestyle or fitness blogger" was a client
+//                                            leftover → blogger in the product's niche,
+//                                            overridable via args.tone)
+//   —  Output html (medium-article-template) → markdown file (the HTML render was a
+//                                            upstream app template; .md is the portable artifact)
+//
+// Team-bus seam: team.input.productLink → args.productUrl.
+//
+// Input : args = { productUrl (required), title (required), contentGuide?, tone?, outputDir? }
+//         (bare string starting with http → productUrl; you'll be asked for a title)
+// Output: { articlePath, title, productUrl, words }
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ── args normalization ───────────────────────────────────────────────────────
+let input = args ?? {}
+if (typeof input === 'string') {
+  const t = input.trim()
+  if (t.startsWith('{')) {
+    try { input = JSON.parse(t) } catch (_) { input = {} }
+  } else if (/^https?:\/\//i.test(t)) {
+    input = { productUrl: t }
+  } else {
+    input = { title: t }
+  }
+}
+const productUrl = (input.productUrl || input.url || '').toString().trim()
+const title = (input.title || '').toString().trim()
+const contentGuide = (input.contentGuide || input.guide || '').toString().trim()
+const tone = (input.tone || '').toString().trim()
+if (!productUrl || !title) {
+  throw new Error(
+    'Need both a product URL and an article title. Pass args like ' +
+    '{ productUrl: "https://cursor.com", title: "Why AI Coding Assistants Beat Autocomplete", contentGuide?: "...", tone?: "..." }. ' +
+    'Tip: take titles from the /aeo-content-advisor report ("Recommended Content Pieces").',
+  )
+}
+// Canonical slugify — keep IDENTICAL across all marketing workflows.
+const slugify = (s, max = 80) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, max).replace(/-+$/, '') || 'item'
+const outputDir = (input.outputDir || './demos/aeo-output/articles').replace(/\/+$/, '')
+const articlePath = `${outputDir}/${slugify(title)}.md`
+
+log(`Article: "${title}"  ·  product: ${productUrl}  ·  output: ${articlePath}`)
+
+// ── Schemas ──────────────────────────────────────────────────────────────────
+const CONTEXT_SCHEMA = {
+  type: 'object',
+  properties: {
+    today: { type: 'string' },          // YYYY-MM-DD
+    productContext: { type: 'string' }, // extracted page content
+    fetchNote: { type: 'string' },      // '' or how the fallback was used
+  },
+  required: ['today', 'productContext', 'fetchNote'],
+  additionalProperties: false,
+}
+
+const EXPORT_SCHEMA = {
+  type: 'object',
+  properties: { files: { type: 'array', items: { type: 'string' } } },
+  required: ['files'],
+  additionalProperties: false,
+}
+
+// ═══ Step 1: Product context (fetch_web → WebFetch) ══════════════════════════
+phase('Context')
+
+const contextPrompt = `You are extracting product context from a company's website for a content writer.
+
+1. Run \`date '+%Y-%m-%d'\` and return it as today.
+2. Fetch ${productUrl} with WebFetch and extract the page's substantive content as plain text: what the product is, who it's for, key features and capabilities, pricing signals, positioning/tagline, and any notable proof points (customers, numbers). Preserve concrete facts verbatim where possible; skip navigation/footer boilerplate. Aim for 300-800 words of faithful extraction — this stands in for the raw page content, so do not editorialize or add outside knowledge.
+3. If WebFetch fails or returns no useful content (JS-only page, block page), use WebSearch for the product/site and reconstruct the same context from search results — and say so in fetchNote (e.g. "WebFetch blocked; built from search results"). Otherwise fetchNote is "".
+
+Return ONLY the structured object {today, productContext, fetchNote}.`
+
+const ctx = await agent(contextPrompt, { label: 'product-context', phase: 'Context', schema: CONTEXT_SCHEMA })
+if (!ctx || !ctx.productContext.trim()) throw new Error(`Could not extract product context from ${productUrl}.`)
+if (ctx.fetchNote) log(`Product context note: ${ctx.fetchNote}`)
+
+// ═══ Step 2: Blog generator (faithful prompt) ════════════════════════════════
+phase('Draft')
+
+const draftPrompt = `You are a skilled blog writer and content strategist. Write a full-length blog article in Markdown format based on the following inputs:
+
+Product Context (from Product URL extraction):
+${ctx.productContext}
+
+Blog article title:
+${title}
+
+Content Guide: ${contentGuide || '(empty)'}
+(Note: This field may be empty. If provided, follow the user's guide closely, but do not break the required Markdown formatting rules.)
+
+Today's date is: ${ctx.today}
+
+Writing Guidelines:
+1. Analyze all the Topic options and choose the strongest perspective to guide the article. You may blend elements of multiple Topics if it strengthens the narrative.
+2. Write in an engaging blog style — conversational yet professional, with smooth transitions, storytelling elements, and practical insights.
+3. Use Markdown headings (##, ###) for clear structure.
+4. Start with a strong **hook in the introduction** that makes readers want to keep reading.
+5. Include examples, metaphors, or short anecdotes to make abstract ideas relatable.
+6. Naturally integrate both Original + Researched Keywords for SEO, but never make it feel forced.
+7. Weave the Product Context into the narrative subtly — highlight relevance without hard-selling.
+8. Break down the body into scannable sections (Executive Summary, Introduction, Market Insights, Product Relevance, Actionable Tips, Conclusion).
+9. End with a clear **conclusion and call-to-action** aligned with the Blog Intent.
+10. Keep the tone aligned with the Content Guide (authoritative, friendly, inspirational, technical, etc.).
+11. If any context in title and body implies current time, you must use the correct date/year as of today: ${ctx.today}
+
+Output:
+Return only the final blog article in **Markdown format**, with headings, subheadings, bullet points, and short paragraphs for readability.
+Do not wrap the output in \`\`\`markdown code block markers`
+
+const draft = (await agent(draftPrompt, { label: 'blog-generator', phase: 'Draft' })) || ''
+if (!draft.trim()) throw new Error('Blog generator returned no output.')
+log(`Draft: ~${draft.split(/\s+/).length} words`)
+
+// ═══ Step 3: Improve writing (faithful prompt; persona genericized) ══════════
+phase('Polish')
+
+const personaLine = tone
+  ? `Make the tone conversational and relatable, matching this voice: ${tone}.`
+  : 'Make the tone conversational and relatable, as if written by an experienced blogger in this product\'s niche.'
+
+const polishPrompt = `You are a professional blog editor. Take the draft blog article below and refine it into a natural, engaging blog post while keeping all the essential information intact.
+
+Draft Blog Article:
+${draft}
+
+Refinement Guidelines:
+1. ${personaLine}
+2. Keep the Markdown structure (headings, lists, formatting) but smooth out stiff or report-like phrasing.
+3. Add storytelling elements, anecdotes, or examples that make the article feel more personal and vivid.
+4. Replace technical specs or numbers with reader-friendly comparisons or metaphors (unless specs are critical).
+5. Weave in a sense of personality: rhetorical questions, casual expressions, light humor, or emojis where appropriate.
+6. Ensure flow between sections feels natural, with smooth transitions rather than abrupt bullet points.
+7. Preserve SEO keywords, but integrate them subtly so they feel organic.
+8. Always end with a warm, motivating conclusion and a call-to-action that feels human and encouraging.
+
+Output:
+Return only the refined blog article in **Markdown format**, keeping headings and formatting consistent.`
+
+const article = (await agent(polishPrompt, { label: 'improve-writing', phase: 'Polish' })) || ''
+if (!article.trim()) throw new Error('Improve-writing agent returned no output.')
+
+// ═══ Export ══════════════════════════════════════════════════════════════════
+phase('Export')
+
+const exportPrompt = `Write this local file using a python3 script (create parent dirs, overwrite). Return the structured object {files: [<absolute path written>]}.
+
+WRITE ${articlePath} with EXACTLY this markdown content:
+${article}`
+
+const exp = await agent(exportPrompt, { label: 'export-article', phase: 'Export', schema: EXPORT_SCHEMA })
+const finalPath = ((exp && exp.files) || []).find((f) => f.endsWith('.md')) || articlePath
+
+log(`Done. Article: ${finalPath}`)
+return {
+  title,
+  productUrl,
+  articlePath: finalPath,
+  words: article.split(/\s+/).length,
+  contextNote: ctx.fetchNote || 'product context fetched from URL',
+  note:
+    'Two-pass output (draft → editorial polish), faithful to the upstream agent. ' +
+    'Deviation: saved as markdown instead of the upstream medium-article-template HTML render; ' +
+    'the step-3 "lifestyle or fitness blogger" persona (a client leftover) is genericized to the product\'s niche — override with args.tone.',
+}

--- a/demos/workflows/05-article-writer.py
+++ b/demos/workflows/05-article-writer.py
@@ -1,0 +1,204 @@
+meta = {
+    "name": "article-writer",
+    "description": "Article Writing Team — write an AEO-optimized blog article from a title + your product URL, then refine it into a natural, engaging post (two-pass: draft → polish).",
+    "when_to_use": "Run with a blog article title and a product URL (plus an optional content guide) to produce a publish-ready markdown article that weaves the product context in subtly. Pairs with /aeo-content-advisor: feed it the content ideas/titles from the advisor report.",
+    "phases": [
+        {"title": "Context", "detail": "Fetch the product URL and extract product context"},
+        {"title": "Draft", "detail": "Write the full-length blog article (faithful upstream prompt)"},
+        {"title": "Polish", "detail": "Editorial refinement pass (faithful upstream prompt)"},
+        {"title": "Export", "detail": "Save the article as markdown"},
+    ],
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Singula-AI AEO marketing workflow — faithful port of the upstream
+# "Agent 5: Article Writing Team Version" (3 nodes)
+# to a Claude Code dynamic workflow.
+#
+#   Upstream node                          → workflow implementation
+#   1  Product context (fetch_web)        → agent + WebFetch (WebSearch fallback) — the
+#                                            original drove a Playwright Chrome page
+#   2  Blog generator (gpt-5.1)           → agent (faithful prompt; @Builtin-Today → `date`)
+#   3  Improve writing (gpt-5.1)          → agent (faithful prompt; one genericization:
+#                                            "lifestyle or fitness blogger" was a client
+#                                            leftover → blogger in the product's niche,
+#                                            overridable via args.tone)
+#   —  Output html (medium-article-template) → markdown file (the HTML render was a
+#                                            upstream app template; .md is the portable artifact)
+#
+# Team-bus seam: team.input.productLink → args.productUrl.
+#
+# Input : args = { productUrl (required), title (required), contentGuide?, tone?, outputDir? }
+#         (bare string starting with http → productUrl; you'll be asked for a title)
+# Output: { articlePath, title, productUrl, words }
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── args normalization ───────────────────────────────────────────────────────
+data = args if args is not None else {}
+if isinstance(data, str):
+    t = data.strip()
+    if t.startswith("{"):
+        try:
+            data = json.loads(t)
+        except Exception:
+            data = {}
+    elif re.match(r"^https?://", t, re.IGNORECASE):
+        data = {"productUrl": t}
+    else:
+        data = {"title": t}
+product_url = str(data.get("productUrl") or data.get("url") or "").strip()
+title = str(data.get("title") or "").strip()
+content_guide = str(data.get("contentGuide") or data.get("guide") or "").strip()
+tone = str(data.get("tone") or "").strip()
+if not product_url or not title:
+    raise RuntimeError(
+        "Need both a product URL and an article title. Pass args like "
+        '{ productUrl: "https://cursor.com", title: "Why AI Coding Assistants Beat Autocomplete", contentGuide?: "...", tone?: "..." }. '
+        'Tip: take titles from the /aeo-content-advisor report ("Recommended Content Pieces").'
+    )
+
+
+# Canonical slugify — keep IDENTICAL across all marketing workflows.
+def slugify(s, max=80):
+    s = re.sub(r"[^a-z0-9]+", "-", s.lower())
+    s = re.sub(r"^-+|-+$", "", s)
+    s = s[:max]
+    s = re.sub(r"-+$", "", s)
+    return s or "item"
+
+
+output_dir = re.sub(r"/+$", "", str(data.get("outputDir") or "./demos/aeo-output/articles"))
+article_path = f"{output_dir}/{slugify(title)}.md"
+
+log(f'Article: "{title}"  ·  product: {product_url}  ·  output: {article_path}')
+
+# ── Schemas ──────────────────────────────────────────────────────────────────
+CONTEXT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "today": {"type": "string"},          # YYYY-MM-DD
+        "productContext": {"type": "string"},  # extracted page content
+        "fetchNote": {"type": "string"},        # '' or how the fallback was used
+    },
+    "required": ["today", "productContext", "fetchNote"],
+    "additionalProperties": False,
+}
+
+EXPORT_SCHEMA = {
+    "type": "object",
+    "properties": {"files": {"type": "array", "items": {"type": "string"}}},
+    "required": ["files"],
+    "additionalProperties": False,
+}
+
+# ═══ Step 1: Product context (fetch_web → WebFetch) ══════════════════════════
+phase("Context")
+
+context_prompt = f"""You are extracting product context from a company's website for a content writer.
+
+1. Run `date '+%Y-%m-%d'` and return it as today.
+2. Fetch {product_url} with WebFetch and extract the page's substantive content as plain text: what the product is, who it's for, key features and capabilities, pricing signals, positioning/tagline, and any notable proof points (customers, numbers). Preserve concrete facts verbatim where possible; skip navigation/footer boilerplate. Aim for 300-800 words of faithful extraction — this stands in for the raw page content, so do not editorialize or add outside knowledge.
+3. If WebFetch fails or returns no useful content (JS-only page, block page), use WebSearch for the product/site and reconstruct the same context from search results — and say so in fetchNote (e.g. "WebFetch blocked; built from search results"). Otherwise fetchNote is "".
+
+Return ONLY the structured object {{today, productContext, fetchNote}}."""
+
+ctx = await agent(context_prompt, label="product-context", phase="Context", schema=CONTEXT_SCHEMA)
+if not ctx or not ctx["productContext"].strip():
+    raise RuntimeError(f"Could not extract product context from {product_url}.")
+if ctx["fetchNote"]:
+    log(f"Product context note: {ctx['fetchNote']}")
+
+# ═══ Step 2: Blog generator (faithful prompt) ════════════════════════════════
+phase("Draft")
+
+draft_prompt = f"""You are a skilled blog writer and content strategist. Write a full-length blog article in Markdown format based on the following inputs:
+
+Product Context (from Product URL extraction):
+{ctx["productContext"]}
+
+Blog article title:
+{title}
+
+Content Guide: {content_guide or "(empty)"}
+(Note: This field may be empty. If provided, follow the user's guide closely, but do not break the required Markdown formatting rules.)
+
+Today's date is: {ctx["today"]}
+
+Writing Guidelines:
+1. Analyze all the Topic options and choose the strongest perspective to guide the article. You may blend elements of multiple Topics if it strengthens the narrative.
+2. Write in an engaging blog style — conversational yet professional, with smooth transitions, storytelling elements, and practical insights.
+3. Use Markdown headings (##, ###) for clear structure.
+4. Start with a strong **hook in the introduction** that makes readers want to keep reading.
+5. Include examples, metaphors, or short anecdotes to make abstract ideas relatable.
+6. Naturally integrate both Original + Researched Keywords for SEO, but never make it feel forced.
+7. Weave the Product Context into the narrative subtly — highlight relevance without hard-selling.
+8. Break down the body into scannable sections (Executive Summary, Introduction, Market Insights, Product Relevance, Actionable Tips, Conclusion).
+9. End with a clear **conclusion and call-to-action** aligned with the Blog Intent.
+10. Keep the tone aligned with the Content Guide (authoritative, friendly, inspirational, technical, etc.).
+11. If any context in title and body implies current time, you must use the correct date/year as of today: {ctx["today"]}
+
+Output:
+Return only the final blog article in **Markdown format**, with headings, subheadings, bullet points, and short paragraphs for readability.
+Do not wrap the output in ```markdown code block markers"""
+
+draft = (await agent(draft_prompt, label="blog-generator", phase="Draft")) or ""
+if not draft.strip():
+    raise RuntimeError("Blog generator returned no output.")
+draft_words = len(re.split(r"\s+", draft))
+log(f"Draft: ~{draft_words} words")
+
+# ═══ Step 3: Improve writing (faithful prompt; persona genericized) ══════════
+phase("Polish")
+
+persona_line = (
+    f"Make the tone conversational and relatable, matching this voice: {tone}."
+    if tone
+    else "Make the tone conversational and relatable, as if written by an experienced blogger in this product's niche."
+)
+
+polish_prompt = f"""You are a professional blog editor. Take the draft blog article below and refine it into a natural, engaging blog post while keeping all the essential information intact.
+
+Draft Blog Article:
+{draft}
+
+Refinement Guidelines:
+1. {persona_line}
+2. Keep the Markdown structure (headings, lists, formatting) but smooth out stiff or report-like phrasing.
+3. Add storytelling elements, anecdotes, or examples that make the article feel more personal and vivid.
+4. Replace technical specs or numbers with reader-friendly comparisons or metaphors (unless specs are critical).
+5. Weave in a sense of personality: rhetorical questions, casual expressions, light humor, or emojis where appropriate.
+6. Ensure flow between sections feels natural, with smooth transitions rather than abrupt bullet points.
+7. Preserve SEO keywords, but integrate them subtly so they feel organic.
+8. Always end with a warm, motivating conclusion and a call-to-action that feels human and encouraging.
+
+Output:
+Return only the refined blog article in **Markdown format**, keeping headings and formatting consistent."""
+
+article = (await agent(polish_prompt, label="improve-writing", phase="Polish")) or ""
+if not article.strip():
+    raise RuntimeError("Improve-writing agent returned no output.")
+
+# ═══ Export ══════════════════════════════════════════════════════════════════
+phase("Export")
+
+export_prompt = f"""Write this local file using a python3 script (create parent dirs, overwrite). Return the structured object {{files: [<absolute path written>]}}.
+
+WRITE {article_path} with EXACTLY this markdown content:
+{article}"""
+
+exp = await agent(export_prompt, label="export-article", phase="Export", schema=EXPORT_SCHEMA)
+final_path = next((f for f in ((exp and exp.get("files")) or []) if f.endswith(".md")), article_path)
+
+log(f"Done. Article: {final_path}")
+return {
+    "title": title,
+    "productUrl": product_url,
+    "articlePath": final_path,
+    "words": len(re.split(r"\s+", article)),
+    "contextNote": ctx["fetchNote"] or "product context fetched from URL",
+    "note": (
+        "Two-pass output (draft → editorial polish), faithful to the upstream agent. "
+        "Deviation: saved as markdown instead of the upstream medium-article-template HTML render; "
+        "the step-3 \"lifestyle or fitness blogger\" persona (a client leftover) is genericized to the product's niche — override with args.tone."
+    ),
+}

--- a/docs/workflow-engine-port-plan.md
+++ b/docs/workflow-engine-port-plan.md
@@ -1,0 +1,307 @@
+# Faithful Port Plan: The Workflow Engine → clawcodex (Python)
+
+> **Goal.** Port Claude Code's *dynamic workflows* subsystem into the clawcodex Python rebuild
+> (`src/` at the repo root). "Faithful" = behaviourally and structurally faithful to the official
+> spec and the TypeScript integration surface, expressed idiomatically in Python. See
+> [`workflow-engine.md`](./workflow-engine.md) for the feature behaviour this plan implements.
+>
+> **Decided:** workflow scripts are **Python** (executed by an in-process sandbox that injects async
+> orchestration globals), not JavaScript. The behaviour, API shape, and semantics are preserved;
+> only the surface syntax the model authors changes.
+
+**Anchor conventions.** Python anchors are `src/...` (repo root). TypeScript anchors are
+`typescript/src/...` and appear only as the parity/Rosetta reference. All anchors verified against
+the tree at the time of writing.
+
+---
+
+## 1. Current state in the Python tree
+
+The port was **anticipated** — two scaffold points already exist, declared but unimplemented:
+
+| Scaffold | Anchor | State |
+|---|---|---|
+| `"local_workflow"` task-type discriminant | `src/tasks_core.py:36` | Declared in `TaskType`; comment: "declared so the discriminator is byte-aligned with TS, but no Task implementation" |
+| Workflow task-id prefix `"w"` | `src/tasks_core.py:73` (`_TASK_ID_PREFIXES`) | `generate_task_id("local_workflow")` already yields `w########` |
+| `CommandBase.kind = "workflow"` badge field | `src/command_system/types.py:113` | Field present (`# "workflow" or None`); no producer yet |
+
+Everything else is greenfield. Note two **stubs to be aware of** (not blockers, but adjacent):
+- The TUI background-task panel is **broken**: `/tasks` calls `REPLScreen.focus_task_panel()` which **does not exist** (`src/tui/app.py:716-729`), so it always degrades to "Task panel focus is not available." The workflow port introduces the first working background-task UI.
+- `StructuredOutputTool` exists but is an **unvalidated no-op** whose result never returns to a caller (§4.3).
+
+---
+
+## 2. Reuse map
+
+### 2.1 Reusable as-is (the substrate)
+
+| Concern | Reuse | Anchor |
+|---|---|---|
+| Run one subagent (stream messages) | `run_agent(params)` → `AsyncGenerator[Message]` | `src/agent/run_agent.py:218` (params dataclass `:36-66`) |
+| One-shot subagent convenience | `run_query(params)` → `(messages, terminal)` | `src/query/query.py:1694` |
+| Final text + usage from a finished run | `finalize_agent_tool(messages, agent_id, metadata)` | `src/agent/agent_tool_utils.py:200` (`AgentToolResult` `:176`); partial: `extract_partial_result` `:315` |
+| Agent-type resolution + default | `get_agent_definitions_with_overrides(cwd)`, `find_agent_by_type`, `GENERAL_PURPOSE_AGENT` | `src/agent/load_agents_dir.py:115`; `src/agent/agent_definitions.py:88,248,265` |
+| JSON-Schema validation (only validator in tree) | `validate_json_schema(value, schema, root)` | `src/tool_system/schema_validation.py:37` |
+| Bounded-concurrency fan-out **pattern** | `asyncio.Semaphore + ensure_future + Queue` | `src/services/tool_execution/orchestrator.py:213-282` |
+| Cancellation | `AbortController` / `AbortSignal`, `create_child_abort_controller(parent)` | `src/utils/abort_controller.py` (child `:88`) |
+| Background-task model + store | `TaskStateBase`, `RuntimeTaskRegistry`, `Task` protocol | `src/tasks_core.py:104-158`; `src/task_registry.py:45-175` |
+| Task lifecycle template | `LocalAgentTask` (state, register, progress, terminal, eviction) | `src/tasks/local_agent.py:35-405`; eviction `src/tasks/eviction.py:41-179` |
+| Progress accounting | `AgentProgress`, `ProgressTracker`, `total_tokens_from_tracker` | `src/tasks/progress.py:67-114` |
+| Tool construction + registration | `build_tool(...)`, `ToolRegistry`, `ALL_STATIC_TOOLS` | `src/tool_system/build_tool.py:122`; `src/tool_system/registry.py:20`; `src/tool_system/tools/__init__.py:43` |
+| Command base + aggregation | `PromptCommand`/`InteractiveCommand`, `get_commands(cwd)`, builtins append-gate | `src/command_system/types.py:96-412`; `src/command_system/aggregator.py:71-118`; `src/command_system/builtins.py:1226-1266` |
+| Disk→dynamic command precedent | `skills_integration.skill_to_prompt_command` + `src/skills/loader.py` disk walk | `src/command_system/skills_integration.py:28-73`; `src/skills/loader.py:600-737` |
+| Permission decision + dialog | `has_permissions_to_use_tool`, `PermissionModal`, `auto_mode_classify` | `src/permissions/check.py:104-206,451-489`; `src/tui/screens/permission_modal.py:36-186` |
+| Permission-rule persistence ("don't ask again for X in Y") | `PermissionUpdateAddRules`, `persist_permission_update`, `create_read_rule_suggestion` | `src/permissions/types.py:141-148`; `src/permissions/updates.py:267-345,366-391` |
+| Settings/env gating pattern | advisor gate (`is_advisor_enabled`, `_env_truthy`) + `SettingsSchema` | `src/utils/advisor.py:73-133`; `src/settings/types.py:66-151`; `src/settings/settings.py:25-67` |
+| Modal/list TUI primitives | `DialogScreen(ModalScreen)`, `SelectList`, master/detail exemplar | `src/tui/screens/dialog_base.py:33`; `src/tui/widgets/select_list.py:50-77`; `src/tui/screens/mcp_dialogs.py:40` |
+| Cross-thread UI updates | `App.post_message` of `Message` subclasses via the bridge | `src/tui/messages.py`; `src/tui/agent_bridge.py:72` |
+| Cost computation + accumulator | `compute_cost`, `add_to_total_cost_state`, `get_total_cost_usd` | `src/services/pricing.py`; `src/bootstrap/state.py:534,595` |
+| Token-target budget semantics | `BudgetTracker`, `check_token_budget`, `parse_token_budget` | `src/query/token_budget.py:29,59,117` |
+
+### 2.2 Net-new (the engine and its gaps)
+
+1. **Python script sandbox** — there is **no `exec`/`eval`/`compile` of model code anywhere** (`ast` appears only in tests). Build: async-wrap + `compile` + `exec` into a curated namespace; `ast.parse` + `ast.literal_eval` for `meta`; frozen/absent `time`/`random`/`datetime`.
+2. **Schema-validated structured output with return + retry** — the biggest gap. `StructuredOutputTool` (`src/tool_system/tools/structured_output.py`) does **not** validate (schema is `additionalProperties:True`), writes to `context.outbox`, and its result **is never read back** (only `SendUserMessage` outbox entries are consumed, `agent_loop_compat.py:411-421`); `finalize_agent_tool` extracts **text only**. Build: per-call schema injection, validation via `validate_json_schema`, retrieval from a dedicated channel, and the retry cap.
+3. **Bounded subagent fan-out** — no `gather`-over-subagents exists; the Agent tool is **not concurrency-safe** (`is_destructive=True`, no `is_concurrency_safe`), so it runs serially today. Build the `parallel()`/`pipeline()` scheduler by cloning the `orchestrator.py` Semaphore/Queue pattern over `run_agent` coroutines.
+4. **Per-run caps** — ≤16 concurrent, 1000/run, 4096/call have **no precedent**.
+5. **Production-path budget predicate** — `max_budget_usd` is threaded (`src/tool_system/context.py:40`) but **inert**; the only predicate (`is_over_budget`) lives on the **deprecated** tracker (`src/services/cost_tracker.py:241`). Build a run-wide predicate over `get_total_cost_usd()` / token accounting.
+6. **Per-agent abort map** — siblings track one `asyncio.Event`; workflows need a `dict[agent_id → abort handle]` plus a run-level abort (for `x` stop-agent-vs-stop-run and `r` retry).
+7. **Background-task UI** — the pill (`get_pill_label`) and the `/workflows` progress/detail dialog do not exist; the `/tasks` panel is a broken stub.
+8. **Progress channel** — no background-task progress `Message` exists; add one or poll the registry.
+9. **Journaling + resume** — per-`runId` journal under the session dir; same-session prefix replay.
+10. **Worktree-per-agent** — `wf_<runId>-<idx>` creation/cleanup.
+
+---
+
+## 3. The Python script engine (net-new core)
+
+A new package, suggested `src/workflow/`:
+
+```
+src/workflow/
+  runtime.py      # run_workflow(...) entry; owns the asyncio loop, journal, progress
+  sandbox.py      # meta extraction + curated exec of the Python script
+  scheduler.py    # Semaphore(≤16) + ensure_future + Queue; 1000/run + 4096/call caps
+  primitives.py   # agent / pipeline / parallel / phase / log / workflow / budget impls
+  structured.py   # schema-injected StructuredOutput + validate + retrieve + retry
+  journal.py      # per-runId (call_index → result) persistence for resume
+  registry.py     # bundled + disk-discovered workflows (name → script source)
+  budget.py       # run-wide token/USD ceiling over the production accounting
+```
+
+**Verified API-usage profile** (from `demos/workflows/*.js`, four real workflows): `log` (27×),
+`args` (27×), `agent` (20×), `phase` (20×), **`schema` structured output (19×)**, `parallel` (3×);
+`pipeline`, `workflow`, `budget`, `isolation`, `model`, and `agentType` appear in the API but in
+none of these demos. So the engine's **common path** — `agent` + `parallel` + `phase`/`log` + script
+helpers + `return`, with **schema-validated structured output** — carries essentially all real
+usage and must be the most robust part; the rarer primitives can land later (Phase 4+).
+
+### 3.1 `runtime.run_workflow(...)`
+
+`async def run_workflow(source: str, *, args, run_id, tool_context, on_progress, resume_from=None) -> WorkflowResult`.
+Because the engine **owns its own async entry** (preferred over being driven by sync tool dispatch — see §6 trap), it can `await` natively. Steps: `parse_meta` → build the sandbox namespace (injected primitives bound to this run) → `exec` the wrapped script → `await __workflow_main__()` → collect the return value → finalize.
+
+### 3.2 `sandbox.py` — meta extraction + curated exec
+
+- **`extract_meta(source) -> dict`**: `tree = ast.parse(source)`; find the top-level `meta = {...}` (`ast.Assign`/`ast.AnnAssign`); `ast.literal_eval(node.value)` (rejects anything but literals — no execution); validate `name`/`description`/`phases`.
+- **Curated execution** (idiomatic Python, the only viable approach — no precedent exists):
+  ```
+  wrapped = "async def __workflow_main__():\n" + textwrap.indent(source, "    ")
+  code = compile(wrapped, "<workflow>", "exec")
+  ns = {"__builtins__": CURATED_BUILTINS, "agent": ..., "pipeline": ..., "parallel": ...,
+        "phase": ..., "log": ..., "workflow": ..., "args": args, "budget": budget}
+  exec(code, ns)
+  result = await ns["__workflow_main__"]()
+  ```
+- **Namespace contents — corrected against the real demo corpus.** The demos (`demos/workflows/*.js`) lean heavily on JSON, regex, and math (`JSON.parse`/`JSON.stringify`/`Math.round` are everywhere), so the sandbox must expose those, not strip all imports. Provide:
+  - Safe builtins: `len`, `range`, `enumerate`, `sorted`, `min`, `max`, `sum`, `round`, `abs`, `any`, `all`, `dict`, `list`, `set`, `tuple`, `str`, `int`, `float`, `bool`, `zip`, `map`, `filter`, `reversed`, `isinstance`, `print`→`log`, `True/False/None`.
+  - Exception types the scripts raise: `Exception`, `ValueError`, `RuntimeError`, `KeyError`, `TypeError`, `IndexError`.
+  - The **deterministic** stdlib real workflows need: `json`, `re`, `math`, `collections`, `itertools`, `functools`, `string`, `textwrap`. Expose these **either** as pre-bound globals **or** via a **whitelisted `__import__`** (so the model can write `import json` / `import re` naturally) that permits only this set. (Decision §8.)
+  - **Block**: `os`, `sys`, `subprocess`, `socket`, `pathlib`, `open`, `exec`, `eval`, `compile`, `input`, `globals`, and dunder-escape attributes. Removing the dangerous `__import__` targets (not `__import__` wholesale) keeps `import json` working while denying `os`/`subprocess`/`sys`.
+  - **Exclude `time` / `random` / `datetime`** — non-determinism breaks resume (JS parity: `Date.now`/`Math.random` are unavailable; they appear **zero** times across the demos). A workflow needing a timestamp passes one via `args` or has an agent run `date` (demo 02 does exactly this in its CSV-export step).
+  - **Define-before-use:** the script defines its own helper functions/classes (`slugify`, `formatOrganic`, …); Python does not hoist `def`, so a faithful JS→Python port must order helper definitions before their first call.
+- **Security posture:** the script is **model-authored, not adversarial** — the goal is determinism + ergonomics, not a hard boundary (this matches clawcodex, which already runs tools in `bypassPermissions` mode by default, `src/tool_system/context.py:70`). `exec` with curated builtins removes fs/shell/import reach and forces all side effects through the injected agent primitives. A harder boundary (subprocess `-I`/`-S`, WASM) is out of scope.
+
+### 3.3 `scheduler.py` — bounded concurrency + caps
+
+Clone the canonical pattern (`src/services/tool_execution/orchestrator.py:213-282`): `asyncio.Semaphore(max_concurrent)`, workers via `asyncio.ensure_future`, results via `asyncio.Queue`, cancel outstanding tasks on early exit. Parameterize over `run_agent` coroutines instead of tool calls. Enforce:
+- `WORKFLOW_MAX_CONCURRENT_AGENTS` — default **16**. House style uses fixed env/config ints (`os.cpu_count()` is used nowhere in `src/`), but the official spec reduces on low-core machines, so the faithful value is `min(16, max(1, (os.cpu_count() or 3) - 2))` with a `CLAUDE_CODE_WORKFLOW_MAX_AGENTS` override. (Decision §8.)
+- `WORKFLOW_MAX_AGENTS_PER_RUN = 1000` (raise when exceeded).
+- Per-call item cap **4096** for `pipeline`/`parallel` (explicit error).
+
+### 3.4 `primitives.py` — the injected API
+
+- **`agent(prompt, opts=None)`** — the core. Resolve `agent_type` (default `general-purpose`) via `find_agent_by_type`; build `RunAgentParams` (prompt, agent definition, model, a **child** `AbortController` from the run controller, `acceptEdits` permission mode, the inherited allowlist); acquire a scheduler slot; drive `run_agent(...)` to completion; `finalize_agent_tool(...)` → final text. If `opts.schema`, route through `structured.py` (§4.3). Record `(prompt, opts) → result` to the journal; update the task's per-agent state. Return `None` on skip/death.
+- **`parallel(items)`** — barrier. `items` is an iterable of **coroutines** (`agent(...)`, the idiomatic Python form the demos' `await parallel([...])` maps to) **or** zero-arg callables returning coroutines (thunks, faithful to the JS `() => agent(...)` surface). Gather all under the concurrency cap; a raised item → `None`; the call itself never raises; results returned in input order (so `a, b = await parallel([...])` unpacking works).
+- **`pipeline(items, *stages)`** — per-item independent stage chains, **no barrier**. Stages are async callables: the first is `stage(item)`, each later stage is `stage(prev, original_item, index)`; a raised stage drops that item to `None`. (Not used by the four demos, but part of the API surface.)
+- The wrapped body's top-level **`return` value is the workflow result** (demo 02 returns `{"keyword", "csv_path", ...}`); a top-level **`raise`** aborts the run with that error.
+- **`phase(title)` / `log(msg)`** — update the task's phase tree / emit a narrator line via the progress channel (§5.4).
+- **`workflow(name_or_ref, args=None)`** — resolve from `registry.py`, run inline via `run_workflow`, one nesting level (raise if already nested).
+- **`budget`** — a small object over `budget.py` (§4.4).
+
+---
+
+## 4. Module-by-module integration
+
+### 4.1 The Workflow tool — `src/tool_system/tools/workflow.py`
+
+`build_tool(name=WORKFLOW_TOOL_NAME, ...)` (template: the Agent tool's async-launch path,
+`src/tool_system/tools/agent.py:395-614`, and `tasks_v2.py` TaskOutput poller). Contract:
+- `input_schema` (plain JSON-Schema dict): one of `script` / `name` / `script_path`, optional `args`, `resume_from_run_id`.
+- `call(input, context) -> ToolResult` — **`Tool.call` does not stream** (`src/tool_system/build_tool.py:43`); it may be `async def` (the registry bridges coroutines, `registry.py:134-188`). Generate a `w########` id (`generate_task_id("local_workflow")`), register a `LocalWorkflowTaskState`, launch `run_workflow(...)` as a background task (mirror `_launch_async_agent`), and **return a handle immediately** (`{"status":"workflow_launched","run_id":...,"task_output_key":...}`). Progress reaches the TUI via the task registry/progress channel (§5.4), **not** via `call`.
+- `is_enabled` → gated on `disable_workflows` (§4.6). `is_read_only=True` (subagents carry their own permissions). `is_destructive` left default (False). Register in `ALL_STATIC_TOOLS` (`src/tool_system/tools/__init__.py:43`) — keep it a stable prefix entry.
+- `WORKFLOW_TOOL_NAME = "Workflow"` in `src/agent/constants.py` (alongside `AGENT_TOOL_NAME`), and **added to `ALL_AGENT_DISALLOWED_TOOLS`** (`src/agent/constants.py:26-34`) so subagents can't recursively spawn workflows.
+
+### 4.2 Subagent reuse for `agent()`
+
+Use `run_agent` + `finalize_agent_tool` directly (NOT the `Agent` tool, which adds JSON-serialization, a sync/async bridge, and its own background-task registration — overhead the engine doesn't want). `_collect_agent_messages` (`src/tool_system/tools/agent.py:802`) is the reference for collect-and-track-progress.
+
+### 4.3 Structured output — `src/workflow/structured.py` (largest gap)
+
+`StructuredOutputTool` today: `call` appends raw input to `context.outbox` and returns a fixed string; schema is `additionalProperties:True`; result never returns; it's filtered out of worker tool sets (`src/coordinator/mode.py:97`). Build:
+1. **Per-call schema tool**: construct a `StructuredOutput`-named tool whose `input_schema = opts.schema` and whose `call` runs `validate_json_schema(input, schema, "StructuredOutput")` (`src/tool_system/schema_validation.py:37`); on success, surface the validated object on a **dedicated channel** the engine reads (a fresh field on the subagent's `ToolContext`, or a sentinel in `outbox` the engine consumes — do not rely on the text-only `finalize_agent_tool`).
+2. **Steer + retry**: inject a prompt instruction ("call StructuredOutput once at the end"); count `StructuredOutput` calls and cap retries (`MAX_STRUCTURED_OUTPUT_RETRIES`, default 5 — upstream parity; the existing loop only has `MAX_OUTPUT_TOKENS_RECOVERY_LIMIT=3` for a different purpose). On exhaustion, resolve `agent()` to `None`.
+3. Add the per-call tool to the subagent's `available_tools` for that run only.
+
+### 4.4 Budget — `src/workflow/budget.py`
+
+`budget.total` from the turn's token directive (parse via `parse_token_budget`, `src/query/token_budget.py:117`); `budget.spent()` reads the production accumulator `get_total_cost_usd()` / model-usage (`src/bootstrap/state.py:595`) — **a run-wide ceiling predicate must be added on the production path** (only `is_over_budget` exists, on the deprecated tracker `src/services/cost_tracker.py:241`). `remaining()` = `max(0, total - spent())`. Exceeding `total` makes `agent()` raise.
+
+### 4.5 Background task — `src/tasks/local_workflow.py`
+
+Mirror `src/tasks/local_agent.py`. Register in `src/tasks/__init__.py:42-44` and re-export in `__all__`.
+- **`LocalWorkflowTaskState(TaskStateBase)`** with `type: Literal["local_workflow"] = "local_workflow"`, plus: `run_id`, `summary: str | None`, a **phase/agent tree** (`phases: list[WorkflowPhaseState]`, each phase → `agents: dict[str, WorkflowAgentState]`), a **per-agent abort map** (each `WorkflowAgentState` carries an `abort_event: asyncio.Event` + `AgentProgress`), a **run-level `abort_event`** (stop-all), `is_paused`, and the usual `error`/`result`/`evict_after`. Aggregate agent count / token total / elapsed by summing `AgentProgress` + `total_tokens_from_tracker` upward.
+- All mutations go through `registry.update(task_id, mutator)` with a **synchronous pure mutator** using `dataclasses.replace` (hard contract — `update` rejects coroutine mutators before taking the lock; `src/task_registry.py:128-168`).
+- **`class LocalWorkflowTask`**: `name`, `type="local_workflow"`, `async def kill` (run-level stop). Auto-reachable from `stop_task` (`src/tasks/stop_task.py:82`) once registered — no edit there.
+- **Named API** (the TS `killWorkflowTask`/`skipWorkflowAgent`/`retryWorkflowAgent` equivalents): `kill_workflow_task(task_id, registry)`, `skip_workflow_agent(task_id, agent_id, registry)`, `retry_workflow_agent(task_id, agent_id, registry)` — these set the relevant `abort_event`(s) and re-enqueue work. Reuse `_terminal_replace` + `schedule_eviction` (`PANEL_GRACE_SECONDS=30`, `src/tasks/eviction.py:41`).
+
+### 4.6 TUI — pill + `/workflows` dialog
+
+- **Pill** (`get_pill_label`, port of `typescript/src/tasks/pillLabel.ts:60-61`): `"1 background workflow"` / `"N background workflows"`. New `src/tasks/pill_label.py`; consume in `StatusLine` (`src/tui/widgets/status_line.py`, which already polls `AppState` every 100ms — `:77`) or a footer segment. **`AppState` does not hold the registry today** — thread `runtime_tasks` (or a running-task snapshot) onto it.
+- **`/workflows` progress view** — new `src/tui/screens/workflow_dialog.py` extending `DialogScreen(ModalScreen)` (`src/tui/screens/dialog_base.py:33`), using `SelectList` (`src/tui/widgets/select_list.py:50` — already binds `j/k`, `enter`, `esc`). Master/detail exemplar: `McpListScreen` (`src/tui/screens/mcp_dialogs.py:40`). Detail analog: `typescript/src/components/tasks/AsyncAgentDetailDialog.tsx`. Wire bindings to the §4.5 named API: `p`=pause/resume run, `x`=`skip_workflow_agent` (or `kill_workflow_task` when focused on the run), `r`=`retry_workflow_agent`, `s`=save script (§4.7), `Enter/→`=drill phase→agent, `Esc/←`=back, `j/k`=scroll.
+- **Wire the command**: add `/workflows` to the TUI local builtins (`src/tui/commands.py:32-55`, dispatch `:272-291`) and an opener in `src/tui/app.py` (`_open_phase2_dialog` `:389-418`, opener pattern `_open_mcp_list` `:677-690`). (Optionally fix the broken `/tasks` `focus_task_panel` at the same time.)
+- **Progress channel** (§5.4): lowest-friction faithful fit is **poll-on-interval** — the dialog reads `runtime_tasks.get(run_id)` on a Textual `set_interval` tick (the registry is RLock-guarded, safe from the UI thread), matching the `StatusLine` precedent. Alternatively add a `WorkflowProgress(Message)` to `src/tui/messages.py` posted via `agent_bridge` for push updates.
+
+### 4.7 Commands — discovery, static, and bundled
+
+- **Dynamic per-workflow commands**: new `src/command_system/workflows_integration.py` (clone of `skills_integration.py`) + a disk walker modeled on `src/skills/loader.py` retargeted to `.claude/workflows/` (project) and `~/.claude/workflows/` (personal). Each file → a `PromptCommand`-style command with `kind="workflow"` (`src/command_system/types.py:113`) and `loaded_from="project"|"user"`, whose `get_prompt_for_command` emits a Workflow tool call with the chosen `name`/`script_path`. Splice into `get_commands` (`src/command_system/aggregator.py:89-92`); **project-wins-over-personal** falls out of enumeration order + the existing name-dedupe. Add a `_load_workflow_commands_cached` and clear it in `clear_commands_cache()` (`aggregator.py:212`).
+- **Static `/workflows` + bundled `/deep-research`**: module-level command singletons appended in `get_builtin_commands()` behind the `disable_workflows` gate (precedent: `if is_buddy_command_enabled(): cmds.append(...)`, `src/command_system/builtins.py:1264`). `/deep-research` is a markdown-bodied prompt command with a declared tool allowlist — template: `security_review.py` + `create_moved_to_plugin_command` (`src/command_system/moved_to_plugin.py:71`).
+- **Save (`s` in `/workflows`)**: write the run's script to the chosen `.claude/workflows/` location; it becomes `/<name>` next session via the discovery loader above.
+
+### 4.8 Permission
+
+- **Approval dialog**: extend `PermissionModal` (`src/tui/screens/permission_modal.py:36-186`). Add a `"Workflow"` entry to `_TOOL_RENDERERS` (`:361-372`) rendering the planned phases + a "View raw script" body, and add the extra options ("Yes, and don't ask again for `<name>` in `<path>`") via the existing `enable_setting` channel (`:138-151`) → a `PermissionUpdateAddRules` scoped to name+path (`create_read_rule_suggestion` pattern, `src/permissions/updates.py:366`) persisted by `persist_permission_update` (`:267-345`).
+- **Auto-mode pre-allowlist**: add a `"Workflow"` branch to `auto_mode_classify` returning `allow=True` (next to the existing `"Agent"` branch, `src/permissions/check.py:483-484`).
+- **Subagents → `acceptEdits` + inherited allowlist**: in `_build_permission_context` (`src/agent/run_agent.py:108-161`) force `effective_mode="acceptEdits"` for workflow-spawned agents and ensure `always_allow_rules` are copied (already at `:155`); the allowlist is the agent's resolved tools (`resolve_agent_tools`, `src/agent/agent_tool_utils.py:83`).
+
+### 4.9 Gating — settings + env + `/config`
+
+No central feature-flag system exists; use the advisor pattern (`src/utils/advisor.py:73-133`):
+- Add `disable_workflows: bool = False` to `SettingsSchema` (`src/settings/types.py:66-151`) and `DEFAULT_SETTINGS` (`src/settings/constants.py`). (If keeping the literal JSON key `disableWorkflows`, it is also readable via `SettingsSchema.extra`, the pattern used for `permissions.allowBypassPermissionsMode` at `src/permissions/modes.py:137`.)
+- Env `CLAUDE_CODE_DISABLE_WORKFLOWS` via `_env_truthy` (`src/utils/advisor.py:73`); **add it to the honored-env allowlist** in `src/permissions/trust_boundary.py:75-96`.
+- `/config` toggle writes through `ConfigManager.set_global/set_project` (`src/config.py:218-226`, as `set_effort` does `:355`).
+- A gate helper `is_workflows_enabled()` (env shortcut beats settings) gates: the static/bundled command appends, the dynamic loader (returns `[]`), and the Workflow tool's `is_enabled`.
+
+---
+
+## 5. Cross-cutting design notes
+
+### 5.1 The engine owns its loop
+Launch the runtime as its own async entry (like `QueryEngine.submit_message`, `src/query/engine.py:203`) so `await agent(...)` and the bounded fan-out are native asyncio. Avoid driving it from synchronous tool dispatch; if the Workflow tool's `call` must kick it off, schedule the runtime as a background task on the running loop (mirror `agent.py:356-372`) rather than blocking dispatch.
+
+### 5.2 Cancellation tree
+One run-level `AbortController`; each `agent()` derives a child via `create_child_abort_controller` (`src/utils/abort_controller.py:88`) so ESC/`x`-on-run cascades to all subagents, while `x`-on-agent / `r` set only that agent's `abort_event`. Cancellation is **cooperative** — `run_agent` must observe the abort at yield points (today only the parent controller propagates; the per-agent `abort_event` check is part of the workflow wrapper). Tear down outstanding asyncio tasks with `task.cancel()` as the orchestrator does (`orchestrator.py:280-282`).
+
+### 5.3 Journaling + resume — `src/workflow/journal.py`
+Persist `(call_index → result)` per `runId` under the session dir (`~/.claude/projects/<session>/` — the official script-file location). On `resume_from_run_id`, the `agent()` primitive returns the cached result for unchanged `(prompt, opts)` at the same index and runs live from the first divergence. **Same-session only** (per spec); a fresh session restarts the run.
+
+### 5.4 Progress channel
+Each `phase()`/`log()`/agent-state change updates `LocalWorkflowTaskState` via `registry.update`. The TUI surfaces it by **polling** the registry on an interval (faithful, low-friction, matches `StatusLine`) or via a new `WorkflowProgress(Message)` posted through `agent_bridge` (`src/tui/agent_bridge.py:72`) for push updates. (Decision §8.)
+
+---
+
+## 6. Known traps / divergences from the TS source
+
+- **`Tool.call` does not stream** (Python diverges from TS's async-generator `call`). Progress must flow through the background-task registry + progress channel, never `call` yields.
+- **`StructuredOutputTool` is an unvalidated no-op** whose result never returns — must be upgraded, not merely reused (§4.3).
+- **The Agent tool is serial** (`is_destructive=True`, not concurrency-safe). The fan-out limiter is genuinely net-new; reuse `run_agent`, not the Agent tool.
+- **`RuntimeTaskRegistry.update` mutators must be synchronous pure functions** — never `await` under its lock (deadlocks asyncio vs. worker threads).
+- **No `os.cpu_count()` in `src/`** — the ≤16 cap should be a constant/env per house style; the low-core reduction is an explicit deviation to add (§3.3, §8).
+- **The `/tasks` background-task panel is a broken stub** — the workflow port is the first working background-task UI; budget for building it, not extending it.
+- **Cost recording is a consumer concern**, not in the loop — the budget predicate must be added on the production path (`get_total_cost_usd`), not the deprecated tracker.
+- **`src/constants/` is a placeholder**; tool-name/disallowed constants live in `src/agent/constants.py`.
+
+---
+
+## 7. Suggested sequencing
+
+Each phase is independently testable; the feature is usable behind the gate after Phase 5.
+
+| Phase | Deliverable | Gate / test |
+|---|---|---|
+| **0. Scaffold + gate** | `src/workflow/` package skeleton; `WORKFLOW_TOOL_NAME`; `disable_workflows` setting + env + `is_workflows_enabled()`; register tool (disabled by default). | Tree imports with the gate on/off; tool absent when disabled. |
+| **1. Sandbox + meta** | `extract_meta` (ast) + curated `exec` async-wrap. | A trivial script's `meta` validates; body runs; `import`/`open` raise inside it. |
+| **2. Core `agent()`** | `agent()` (text) over `run_agent` + `finalize_agent_tool`; serial scheduler. | A single-`agent()` script returns text end-to-end. |
+| **3. Structured output** | schema-injected `StructuredOutput` + `validate_json_schema` + return channel + retry cap. | A script gets a validated object; malformed output retries then `None` at the cap. |
+| **4. Concurrency + budget** | `parallel`/`pipeline`, `Semaphore(≤16)`, 1000/run + 4096/call caps, `budget`. | Fan-out respects the cap; `budget.remaining()` drives a loop; ceiling raises. |
+| **5. Background task** | `LocalWorkflowTask` (+ state, named API, abort map), registration, pill. | A run shows in the pill; `stop_task` kills it; completes within the grace window. |
+| **6. `/workflows` UI** | progress/detail dialog with `p/x/r/s/Enter/Esc/j/k`; progress channel. | Drill phase→agent; pause/stop/retry/save work live. |
+| **7. Commands** | dynamic `.claude/workflows` discovery + static `/workflows` + bundled `/deep-research`. | `/<name>` runs a saved workflow; `/deep-research` works; project wins on clash. |
+| **8. Permission** | approval renderer + don't-ask-again rule + auto-mode allowlist + subagent acceptEdits. | Default mode prompts per run; auto pre-allowlists; subagents auto-approve edits. |
+| **9. Resume + worktree** | per-`runId` journal + `resume_from_run_id`; `wf_<runId>-<idx>` worktrees. | Same script+args ⇒ cache hit; edited call N re-runs from N; parallel file-mutating agents don't collide. |
+
+---
+
+## 8. Open decisions
+
+1. **Concurrency cap source** — fixed `16` (house style) vs. `min(16, cpu_count−2)` (faithful low-core reduction). Recommend the latter with a `CLAUDE_CODE_WORKFLOW_MAX_AGENTS` override. (§3.3)
+2. **Structured-output return channel** — a new `ToolContext` field vs. a typed sentinel in `outbox`. Pick one explicit channel; do not overload the text path. (§4.3)
+3. **Progress delivery** — poll-on-interval (simplest, matches `StatusLine`) vs. a `WorkflowProgress` Textual message (push). (§5.4)
+4. **Budget unit** — token-target (parity with `token_budget.py`) vs. USD cap (parity with TS `maxBudgetUsd`). Spec leans token; implement the predicate on the production accumulator either way. (§4.4)
+5. **Save UX** — reuse `InteractiveCommand`/`ctx.ui.select` (like `copy_command.py`) for the two-location save picker, or a Textual modal. (§4.7)
+6. **Fixing `/tasks`** — implement `REPLScreen.focus_task_panel` as part of this work, or scope the workflow dialog independently and leave `/tasks` broken.
+7. **Settings key casing** — typed `disable_workflows` field vs. literal `disableWorkflows` via `SettingsSchema.extra`. (§4.9)
+8. **Sandbox stdlib exposure** — pre-bound globals vs. a whitelisted `__import__` for the deterministic modules workflows need (`json`/`re`/`math`/`collections`/…). The demos write JSON/regex/math constantly, so one of these is mandatory; pick the one that reads most naturally for model-authored scripts. (§3.2)
+
+---
+
+## 9. Effort note
+
+The integration glue (modules §4.1, §4.5–§4.9) is mechanical — every one has a sibling template in
+the tree and a contract pinned by an existing consumer or the official spec. The genuine
+engineering is **§3 (the script engine)** and **§4.3 (validated structured output with return +
+retry)**: neither has any precedent in the codebase (no `exec` of model code exists; the structured
+tool is a no-op), and they are where the upstream engine's complexity lived. Budget the bulk of the
+effort there; the rest is faithful wiring against the anchors above. The two scaffold points already
+in the tree (`local_workflow` task type, `CommandBase.kind="workflow"`) confirm the architecture was
+designed to accept this port.
+
+---
+
+## 10. Implementation status
+
+**Built (plan Phases 1–4: the engine core, `src/workflow/`) — 90 unit/integration tests passing.**
+
+| Module | What it does | Tested |
+|---|---|---|
+| `sandbox.py` | `ast` `meta` extraction; curated `exec` async-wrap; whitelisted stdlib (`json`/`re`/`math`/…) with `time`/`random`/`datetime`/host access withheld | ✅ `test_sandbox.py` |
+| `scheduler.py` | `asyncio.Semaphore` concurrency cap + per-run 1000 cap | ✅ `test_scheduler.py` |
+| `budget.py` | token ceiling (`total`/`spent()`/`remaining()`), shared-pool via `base_spent` | ✅ `test_budget.py` |
+| `callpath.py` + `journal.py` | **deterministic call-path keys** (fixes the multi-round fan-out resume bug) + per-key fingerprint matching | ✅ `test_journal.py`, `test_runtime.py::…multiround…` |
+| `primitives.py` / `runtime.py` | `agent`/`parallel`/`pipeline`/`phase`/`log`/`workflow`/`budget`; failure→`None`; item cap; per-agent abort handles | ✅ `test_primitives.py`, `test_runtime.py` |
+| `structured.py` | schema validation + retry collector + the injected `StructuredOutput` tool (built on the real `build_tool`) | ✅ `test_structured.py` |
+| `runner.py` (`LiveAgentRunner`) | production seam: `run_agent` + `finalize_agent_tool` + structured tool | ⚠️ structured tool unit-tested; `run_agent` composition needs **live integration test** |
+| `demos/workflows/*.py` | the four JS demos ported to Python; run end-to-end against the engine | ✅ `test_demos.py` |
+
+**Deferred (plan Phases 5–9: integration — not yet built).** None of these exist yet, so the feature
+is not user-reachable: the Workflow tool (`src/tool_system/tools/workflow.py`), `LocalWorkflowTask`,
+the `/workflows` TUI + pill, command discovery + `/deep-research`, the permission renderer +
+auto-mode allowlist, the `disable_workflows` gating, **journal disk-persistence** (`Journal.to_json`/
+`load` exist and are tested but no caller writes them to the session dir yet — so resume currently
+works only in-process), and worktree-per-agent. `LiveAgentRunner` is constructed nowhere yet.
+
+**Known integration wiring (when Phases 5–9 land):** pass `Budget(base_spent=get_total_cost_usd)` so
+the ceiling counts the shared pool (§4.4); pass a `ProgressTracker` to `finalize_agent_tool` for
+token parity; expose each run's per-agent controllers (already reachable via `WorkflowRun.abort_agent`)
+to the task layer for `x`/`r`; add the live structured-output integration test (schema agent returns a
+validated object; malformed → retry → `None` at the cap).

--- a/docs/workflow-engine.md
+++ b/docs/workflow-engine.md
@@ -1,0 +1,321 @@
+# The Workflow Engine — Feature Deep Dive
+
+> **Purpose.** This document is the authoritative behavioural specification of Claude Code's
+> *dynamic workflows* feature, written to drive a faithful port into the **clawcodex Python
+> implementation** (`src/` at the repo root). It is implementation-neutral: it describes *what the
+> feature does* and *how a user experiences it*. The companion
+> [`workflow-engine-port-plan.md`](./workflow-engine-port-plan.md) maps every piece onto the Python
+> architecture with `file:line` anchors.
+>
+> **Sources of truth.** (1) The official documentation —
+> <https://code.claude.com/docs/en/workflows> (feature requires Claude Code v2.1.154+). (2) The
+> public Workflow tool contract (the script API the model is taught). (3) The surviving TypeScript
+> integration surface under `typescript/src/`, which carries the real signatures of the
+> closed-source engine and is used as a Rosetta stone. Where these disagree, the official docs win.
+
+---
+
+## 1. What a workflow is
+
+A **dynamic workflow is a JavaScript script that orchestrates [subagents](https://code.claude.com/docs/en/sub-agents) at scale.** Claude writes the script for the task you describe, and a runtime executes it **in the background** while your session stays responsive. Intermediate results live in **script variables**, not in Claude's context window — so Claude's context holds only the final answer.
+
+Reach for a workflow when a task needs more agents than one conversation can coordinate, or when you want the orchestration codified as a script you can read and rerun. Canonical uses: a codebase-wide bug sweep, a 500-file migration, a research question whose sources must be cross-checked against each other, and a hard plan worth drafting from several independent angles before committing.
+
+Crucially, moving the plan into code lets a workflow apply a **repeatable quality pattern**, not just run more agents: independent agents can adversarially review each other's findings before anything is reported, or draft a plan from several angles and weigh them — yielding a more trustworthy result than a single pass.
+
+> **Port note.** In a Python host the script language is **Python**, not JavaScript (decided —
+> see the port plan). The *behaviour*, *API shape*, and *semantics* below are preserved; only the
+> surface syntax the model authors changes. Every JS signature in this document has a direct
+> Python equivalent (`await agent(...)`, `await pipeline(...)`, `meta = {...}`).
+
+### 1.1 Workflows vs. subagents, skills, and agent teams
+
+All four can run a multi-step task; the difference is **who holds the plan** (from the official docs):
+
+| | Subagents | Skills | Agent teams | **Workflows** |
+|---|---|---|---|---|
+| What it is | A worker Claude spawns | Instructions Claude follows | A lead supervising peer sessions | **A script the runtime executes** |
+| Who decides what runs next | Claude, turn by turn | Claude, per the prompt | The lead, turn by turn | **The script** |
+| Where intermediate results live | Claude's context | Claude's context | A shared task list | **Script variables** |
+| What's repeatable | The worker definition | The instructions | The team definition | **The orchestration itself** |
+| Scale | A few per turn | A few per turn | A handful of peers | **Dozens to hundreds per run** |
+| Interruption | Restarts the turn | Restarts the turn | Teammates keep running | **Resumable in the same session** |
+
+---
+
+## 2. The programming model
+
+A workflow script (Python in the port; JavaScript upstream) runs in an **async context** with a small set of orchestration primitives injected as globals. It must begin with a `meta` declaration.
+
+### 2.1 The `meta` block
+
+`meta` is a **pure literal** — no variables, calls, spreads, or interpolation — because the runtime extracts and validates it by **static analysis before executing the script**. (In the Python port this is an `ast.literal_eval` over the `meta = {...}` assignment node.)
+
+```python
+# Python-native form (port)
+meta = {
+    "name": "find-flaky-tests",
+    "description": "Find flaky tests and propose fixes",   # shown in the approval prompt
+    "when_to_use": "...",                                   # optional; shown in the workflow list
+    "phases": [                                             # optional; one entry per phase() call
+        {"title": "Scan", "detail": "grep test logs for retries"},
+        {"title": "Fix",  "detail": "one agent per flaky test"},
+    ],
+    "model": "sonnet",                                      # optional default/per-phase model
+}
+```
+
+Required: `name`, `description`. `phases[].title` values are matched **exactly** against `phase()` calls in the body to drive the progress display.
+
+### 2.2 Injected globals (the orchestration API)
+
+| Primitive | Signature | Behaviour |
+|---|---|---|
+| `agent` | `await agent(prompt, opts=None) -> Any` | Spawn one subagent. Without `schema`, resolves to its final text. With `schema`, the subagent is forced to emit a **validated** object. Resolves to `None` if the agent is skipped or dies after retries. |
+| `pipeline` | `await pipeline(items, stage1, stage2, ...) -> list` | Run each item through all stages **independently — no barrier between stages** (item A may be in stage 3 while item B is still in stage 1). The default for multi-stage work. Each later stage receives `(prev_result, original_item, index)`. A stage that raises drops that item to `None`. |
+| `parallel` | `await parallel(thunks) -> list` | Run thunks concurrently and **await all** (a barrier). A thunk that raises resolves to `None`; the call itself never raises. Use only when you genuinely need all results together. |
+| `phase` | `phase(title) -> None` | Start a new progress phase; subsequent `agent()` calls group under it. |
+| `log` | `log(message) -> None` | Emit a narrator progress line to the user. |
+| `workflow` | `await workflow(name_or_ref, args=None) -> Any` | Run another workflow inline as a sub-step. **One level of nesting only** — `workflow()` inside a child raises. |
+| `args` | value | The `args` input passed at invocation, verbatim (structured data — lists/dicts usable directly). `None`/`undefined` if omitted. |
+| `budget` | `{ total, spent(), remaining() }` | The turn's token target. `total` is `None` if unset; `spent()` is the shared output-token total across the main loop **and** all workflows; reaching `total` is a **hard ceiling** that makes further `agent()` calls raise. Scripts scale depth with `while budget.total and budget.remaining() > N: ...`. |
+
+`agent()` options (`opts`): `label`, `phase`, `schema`, `model`, `isolation="worktree"`, `agent_type`.
+- `schema` — a JSON Schema; forces schema-validated structured output (see §2.3).
+- `label` — overrides the display label; `phase` — explicitly assigns this call to a progress group (use inside `pipeline`/`parallel` stages to avoid racing the global `phase()` state).
+- `model` — per-call model override (omit to inherit the session model — almost always correct).
+- `isolation="worktree"` — run the agent in a fresh git worktree (expensive; only when parallel agents mutate files and would conflict).
+- `agent_type` — use a named subagent type (e.g. `Explore`) instead of the default general agent; composes with `schema`.
+
+### 2.3 Structured output
+
+`agent(prompt, {schema})` gives the subagent a `StructuredOutput` tool compiled from the JSON Schema. The subagent is steered (by the tool's prompt, not by a forced API `tool_choice`) to call it once at the end; the call's input is **validated against the schema**, and the validated object flows back to the script as the resolved value. Validation failures become an error the model sees and retries, up to a retry cap (upstream default 5). A schema reused across many `agent()` calls is compiled once (identity-cached upstream via `WeakMap`).
+
+### 2.4 Canonical composition patterns
+
+These are conventions the model is taught, not separate API:
+
+- **Pipeline by default** — multi-stage work with no cross-item barrier.
+- **Barrier only when stage N needs all of stage N−1** — dedup/merge across the full set, early-exit on zero, or cross-item comparison. Otherwise the transform goes *inside* a pipeline stage.
+- **Adversarial verify** — N independent skeptics per finding, each prompted to refute; drop on majority-refute.
+- **Perspective-diverse verify** — give each verifier a distinct lens (correctness, security, perf, reproducibility) rather than N identical refuters.
+- **Judge panel** — generate N independent attempts from different angles, score with parallel judges, synthesize from the winner.
+- **Loop-until-dry** — keep spawning finders until K consecutive rounds surface nothing new.
+- **Multi-modal sweep / completeness critic** — parallel searches each blind to the others, then a final agent asking "what's missing?".
+
+### 2.5 The runtime environment (Python port)
+
+The script runs inside an **async sandbox**. Available: the *deterministic* parts of the standard
+library that real workflows rely on — `json`, `re`, `math`, `collections`, `itertools`,
+`functools`, `string`, `textwrap` — plus the safe builtins and exception types. The script may
+define and call its own helper functions and classes (**define before use** — Python does not hoist
+`def`). Top-level `await`, `return` (whose value becomes the workflow's result), and `raise` all
+work. **Not** available: any filesystem, shell, or network access from the script itself (agents do
+all I/O), and the non-deterministic primitives `time`, `random`, and `datetime.now()` — they would
+break deterministic resume, so pass timestamps via `args` or have an agent run `date`. `parallel`
+and `pipeline` accept either coroutines (`agent(...)`, idiomatic) or zero-arg callables returning
+them.
+
+### 2.6 A worked example (Python)
+
+A faithful Python translation of the basic structure used by the real demo corpus
+(`demos/workflows/*.js`) — `meta`, `args` handling, a pure helper, `phase`/`log`, a parallel pair of
+a text agent and a schema agent, and a `return` value:
+
+```python
+meta = {
+    "name": "user-prompt-research",
+    "description": "Discover what customers ask about a keyword; score questions by search volume.",
+    "when_to_use": "Run with a company, product, or keyword to mine real user questions for AEO.",
+    "phases": [
+        {"title": "Search",    "detail": "Reddit + Google search in parallel"},
+        {"title": "Questions", "detail": "Rewrite intent signals into natural user questions"},
+    ],
+}
+
+# args may be a bare keyword string or a dict; normalize both.
+data = args if isinstance(args, dict) else {}
+keyword = (args if isinstance(args, str) else data.get("keyword", "")).strip()
+if not keyword:
+    raise ValueError('Pass a keyword via args — e.g. args="AI coding assistant"')
+count = int(data.get("count", 50))
+
+def slugify(s, maxlen=80):  # plain helper, defined before use (Python does not hoist)
+    return re.sub(r"-+$", "", re.sub(r"[^a-z0-9]+", "-", s.lower()).strip("-")[:maxlen]) or "item"
+
+GOOGLE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "organic_results": {"type": "array", "items": {
+            "type": "object",
+            "properties": {"title": {"type": "string"}, "link": {"type": "string"}},
+            "required": ["title", "link"],
+        }},
+        "related_questions": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["organic_results", "related_questions"],
+}
+
+log(f'Keyword: "{keyword}" · target questions: {count}')
+
+phase("Search")
+reddit, google = await parallel([
+    agent(f'Summarize real Reddit discussion about "{keyword}" for SEO research ...', label="reddit"),
+    agent(f'Gather the Google SERP for "{keyword}" ...', label="google", schema=GOOGLE_SCHEMA),
+])
+google = google or {"organic_results": [], "related_questions": []}
+log(f'Google: {len(google["organic_results"])} organic results')
+
+phase("Questions")
+raw = await agent(
+    f"Using this research, write {count} natural user questions, one per line:\n"
+    f"{reddit}\n{json.dumps(google)}",
+    label="questions",
+)
+questions = [q.strip() for q in (raw or "").splitlines() if "?" in q]
+if not questions:
+    raise RuntimeError("No questions produced.")
+
+return {                                   # the returned value is the workflow's result
+    "keyword": keyword,
+    "questions": questions,
+    "csv_path": f"./out/{slugify(keyword)}-questions.csv",
+}
+```
+
+The original JavaScript form of this workflow is `demos/workflows/02-user-prompt-research.js`; the
+Python ports of the demo corpus should live alongside it (e.g. `demos/workflows/*.py`).
+
+---
+
+## 3. Execution semantics
+
+| Aspect | Behaviour (authoritative) |
+|---|---|
+| **Concurrency cap** | **Up to 16 concurrent agents, fewer on machines with limited CPU cores.** Excess `agent()` calls queue and run as slots free. (Upstream cap: `min(16, cpu_cores − 2)`.) |
+| **Lifetime agent cap** | **1,000 agents total per run** — a runaway-loop backstop. |
+| **Per-call item cap** | A single `pipeline()`/`parallel()` call accepts at most 4,096 items; more is an explicit error, not silent truncation. |
+| **No mid-run user input** | Only agent permission prompts can pause a run. For sign-off between stages, run each stage as its own workflow. |
+| **No direct fs/shell from the script** | The script coordinates; **agents** read, write, and run commands. The workflow body has no filesystem or shell access. |
+| **Budget** | A turn-level token target acts as a hard ceiling. `budget.spent()` is shared across the main loop and all workflows; once it reaches `budget.total`, `agent()` raises. The agent caps also bound the cost of a runaway script. |
+| **Worktree isolation** | `agent(..., {isolation:"worktree"})` runs the agent in a fresh git worktree, auto-removed if unchanged. Per-agent worktrees are named `wf_<runId>-<idx>`. |
+| **Sandbox restrictions** | No filesystem/host access from the script. Non-deterministic primitives (`Date.now`/`Math.random` upstream; `time`/`random`/`datetime.now` in the Python port) are unavailable or frozen — they would break deterministic resume. Timestamps come in via `args`; randomness varies by agent index. |
+| **Resume / journaling** | Every run has a `runId`. Each `agent()` call's inputs and result are journaled. Resuming replays the **longest unchanged prefix** from cache and runs the rest live; same script + same args ⇒ 100% cache hit. **Resume works only within the same session** — exiting Claude Code restarts a running workflow fresh next session. |
+| **Model** | Every agent uses the **session's model** unless the script routes a stage elsewhere via `agent(..., {model})`. |
+| **MCP access** | Workflow agents reach session-connected MCP tools (schemas load on demand). Interactively-authenticated MCP servers may be absent in headless/cron runs. |
+
+---
+
+## 4. The user experience and surfaces
+
+### 4.1 Authoring a workflow
+
+- **Ask in your prompt.** Include the keyword `ultracode` (pre-v2.1.160 it was `workflow`), or just ask in your own words ("use a workflow", "run a workflow"). Claude writes a script for the task instead of working turn by turn. `Option+W` / `Alt+W` dismisses the keyword highlight for one prompt.
+- **`/effort ultracode`.** Combines `xhigh` reasoning with automatic workflow orchestration: Claude plans a workflow for *every* substantive task in the session (often several in a row — understand, change, verify). Lasts the session; reset with `/effort high`. Only on models that support `xhigh` effort.
+
+### 4.2 Bundled workflow: `/deep-research`
+
+The one built-in workflow. `/deep-research <question>` fans out web searches across several angles, fetches and cross-checks sources, **votes on each claim**, and returns a cited report with claims that didn't survive cross-checking filtered out. Requires the WebSearch tool. Saved workflows become `/<name>` commands the same way and appear in `/` autocomplete alongside it.
+
+### 4.3 Watching a run: `/workflows`
+
+Workflows run in the background. `/workflows` lists running and completed runs; select one to open the **progress view** showing each phase with its **agent count, token total, and elapsed time**. A one-line summary also appears in the task panel below the input box. Key bindings in the progress view:
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` | Select a phase or agent |
+| `Enter` / `→` | Drill into the phase, then into an agent (read its prompt, recent tool calls, result) |
+| `Esc` | Back out one level |
+| `j` / `k` | Scroll within agent detail on overflow |
+| `p` | **Pause or resume** the run |
+| `x` | **Stop** the selected agent, or the whole workflow when focus is on the run |
+| `r` | **Restart** the selected running agent |
+| `s` | **Save** the run's script as a command |
+
+### 4.4 Approval and permission model
+
+The per-run prompt shows the planned phases and: **Yes, run it** / **Yes, and don't ask again for `<name>` in `<path>`** / **View raw script** / **No**. `Ctrl+G` opens the script in your editor; `Tab` lets you adjust the prompt before the run starts.
+
+Whether you're prompted depends on permission mode:
+
+| Permission mode | When you're prompted |
+|---|---|
+| Default, accept edits | Every run, unless you chose "don't ask again" for that workflow in this project |
+| Auto | First launch only; any **Yes** records consent in user settings; skipped entirely when ultracode is on |
+| Bypass / `claude -p` / Agent SDK | Never — the run starts immediately |
+
+**Critically:** the subagents a workflow spawns **always run in `acceptEdits` mode and inherit your tool allowlist, regardless of your session's mode.** File edits are auto-approved; shell/web/MCP calls *not* in your allowlist can still prompt mid-run. Your session's permission mode controls only the launch prompt.
+
+### 4.5 Saving, discovery, and `args`
+
+- **Save:** in `/workflows`, select a run and press `s`. `Tab` toggles two locations: `.claude/workflows/` (project, shared via the repo) or `~/.claude/workflows/` (personal, all projects). Saved workflows run as `/<name>`. **A project workflow wins over a personal one** on name clash.
+- **`args`:** a saved workflow reads invocation input from the `args` global, passed as **structured data** (lists/dicts usable without parsing); `undefined`/`None` if omitted. Example: `Run /triage-issues on issues 1024, 1025, and 1030`.
+
+### 4.6 Persistence and resume
+
+Every run writes its script to a file under the session's directory in `~/.claude/projects/<session>/`; Claude receives the path when the run starts (you can ask for it, diff it against a prior run, or edit it and relaunch). The runtime tracks each agent's result, which is what makes a run **resumable within the same session** (`p` in `/workflows`, or ask Claude to relaunch with the same script). Exiting Claude Code mid-run restarts it fresh next session.
+
+### 4.7 Cost
+
+A workflow spawns many agents, so one run can use meaningfully more tokens than the same task in conversation; runs count toward plan usage and rate limits. The agent caps bound a runaway script. The `/workflows` view shows each agent's token usage live, and you can stop a run there without losing completed work. To gauge spend, run on a small slice first.
+
+### 4.8 Turning workflows off
+
+- `/config` → toggle **Dynamic workflows** off (persists).
+- `"disableWorkflows": true` in `~/.claude/settings.json` (persists), or in managed settings for an org.
+- `CLAUDE_CODE_DISABLE_WORKFLOWS=1` (read at startup).
+
+When disabled: bundled workflow commands are unavailable, the `ultracode` keyword no longer triggers a run, and `ultracode` is removed from the `/effort` menu.
+
+---
+
+## 5. Reference architecture (implementation-neutral)
+
+The engine is a constellation of seams, not one module. The port maps each onto a clawcodex subsystem; see the port plan for exact targets.
+
+```
+   user / model invokes a workflow
+   (ultracode keyword · /deep-research · /<saved-name>)
+                    │
+                    ▼
+        ┌───────────────────────┐   spawns + streams
+        │   Workflow tool        │──────────────────────────────┐
+        │   (one tool-use call)  │                              │
+        └───────────┬───────────┘                              ▼
+                    │ runs the script           ┌───────────────────────────┐
+                    ▼                            │  per-agent() call:        │
+        ┌───────────────────────┐  agent()      │   subagent runner         │
+        │   Workflow runtime    │──────────────►│   + finalize → text       │
+        │   · sandbox (script)  │◄──────────────│   + schema → validated obj │
+        │   · scheduler (≤16)   │   result      │   + child abort controller │
+        │   · budget · journal  │               └───────────────────────────┘
+        └───────────┬───────────┘
+                    │ surfaces as a background task
+                    ▼
+   ┌───────────────────────────┐    ┌─────────────────────────────────────┐
+   │  Workflow background task │───►│  task-panel pill ("N background      │
+   │  (phases → agents tree,   │    │  workflows") · /workflows progress   │
+   │   per-agent abort map)    │    │  view · per-agent detail (p/x/r/s)   │
+   └───────────────────────────┘    └─────────────────────────────────────┘
+
+   discovery   ──►  /workflows (static) · /deep-research (bundled) ·
+                    /<name> per file in .claude/workflows + ~/.claude/workflows
+   approval    ──►  per-run permission prompt; subagents run acceptEdits + inherit allowlist
+   gating      ──►  disableWorkflows setting · CLAUDE_CODE_DISABLE_WORKFLOWS · /config
+```
+
+The subsystems involved:
+
+1. **The Workflow tool** — a single tool-use the model calls; it launches the run and returns a handle/result.
+2. **The runtime** — executes the script in a sandbox, injects the primitives, schedules bounded-concurrency `agent()` fan-out, accounts budget, and journals for resume.
+3. **The subagent path** — each `agent()` reuses the host's existing subagent runner and result-finalization, plus a schema-validated structured-output mechanism.
+4. **The background task** — a phase/agent tree with per-agent abort handles, surfaced as a pill and a `/workflows` progress/detail view.
+5. **Commands** — a static `/workflows`, the bundled `/deep-research`, and one dynamic `/<name>` command per saved workflow file.
+6. **Permission** — a per-run approval dialog with "don't ask again for `<name>` in `<path>`"; auto-mode pre-allowlisting; subagents forced to `acceptEdits` with the inherited allowlist.
+7. **Gating** — a settings key + env var + `/config` toggle.
+
+---
+
+## 6. Provenance — why there is no source to copy
+
+The upstream engine is gated behind the internal-only build flag `WORKFLOW_SCRIPTS`. In the bundled `typescript/` snapshot its implementation files were stripped (only the stub `typescript/src/tools/WorkflowTool/constants.ts` remains), and the compiled `dist/cli.mjs` was built with the flag off, so every workflow symbol was dead-code-eliminated to `null`. The canonical public repo `Gitlawb/openclaude` ships the identical stub. What survives is the **integration surface** — the flag-gated call sites — which carries the real signatures and is the Rosetta stone the port plan uses. There is therefore nothing to extract; the engine must be **reconstructed** against this spec. The reconstruction targets the **Python** implementation; see [`workflow-engine-port-plan.md`](./workflow-engine-port-plan.md).

--- a/src/workflow/__init__.py
+++ b/src/workflow/__init__.py
@@ -1,0 +1,72 @@
+"""The clawcodex workflow engine — a deterministic multi-agent orchestrator.
+
+Executes a model-authored *Python* workflow script in a sandbox, injecting the
+async orchestration primitives (``agent`` / ``parallel`` / ``pipeline`` /
+``phase`` / ``log`` / ``workflow`` / ``args`` / ``budget``) and fanning out
+bounded-concurrency subagent calls through an injectable :class:`AgentRunner`.
+
+See ``docs/workflow-engine.md`` (feature) and
+``docs/workflow-engine-port-plan.md`` (architecture).
+"""
+
+from __future__ import annotations
+
+from .budget import Budget
+from .constants import (
+    MAX_AGENTS_PER_RUN,
+    MAX_ITEMS_PER_CALL,
+    MAX_STRUCTURED_OUTPUT_RETRIES,
+    max_concurrent_agents,
+)
+from .errors import (
+    WorkflowBudgetExceeded,
+    WorkflowError,
+    WorkflowLimitError,
+    WorkflowMetaError,
+)
+from .journal import Journal, JournalRecord, fingerprint
+from .progress import AgentRecord, PhaseRecord, WorkflowProgress
+from .runner import LiveAgentRunner
+from .runtime import WorkflowResult, WorkflowRun, run_workflow
+from .sandbox import build_namespace, compile_workflow, execute_workflow, extract_meta
+from .scheduler import Scheduler
+from .structured import (
+    StructuredOutputCollector,
+    make_structured_output_tool,
+    validate_structured,
+)
+from .types import AgentOutcome, AgentRunner, AgentSpec, WorkflowMeta
+
+__all__ = [
+    "run_workflow",
+    "WorkflowRun",
+    "WorkflowResult",
+    "AgentRunner",
+    "LiveAgentRunner",
+    "AgentSpec",
+    "AgentOutcome",
+    "WorkflowMeta",
+    "WorkflowProgress",
+    "PhaseRecord",
+    "AgentRecord",
+    "Budget",
+    "Scheduler",
+    "Journal",
+    "JournalRecord",
+    "fingerprint",
+    "StructuredOutputCollector",
+    "make_structured_output_tool",
+    "validate_structured",
+    "extract_meta",
+    "compile_workflow",
+    "build_namespace",
+    "execute_workflow",
+    "WorkflowError",
+    "WorkflowMetaError",
+    "WorkflowLimitError",
+    "WorkflowBudgetExceeded",
+    "MAX_AGENTS_PER_RUN",
+    "MAX_ITEMS_PER_CALL",
+    "MAX_STRUCTURED_OUTPUT_RETRIES",
+    "max_concurrent_agents",
+]

--- a/src/workflow/budget.py
+++ b/src/workflow/budget.py
@@ -1,0 +1,61 @@
+"""The ``budget`` primitive — a token target that acts as a hard ceiling.
+
+Exposes ``budget.total`` / ``budget.spent()`` / ``budget.remaining()`` to the
+script. The engine adds each agent's token usage via :meth:`Budget.add`; once
+``spent`` reaches ``total`` the next ``agent()`` call raises
+:class:`WorkflowBudgetExceeded`.
+
+Scripts scale depth with::
+
+    while budget.total and budget.remaining() > 50_000:
+        ...
+
+``total`` is ``None`` when no target was set, in which case ``remaining()`` is
+``math.inf`` and the ceiling never trips.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Callable, Optional
+
+from .errors import WorkflowBudgetExceeded
+
+
+class Budget:
+    def __init__(
+        self,
+        total: Optional[int] = None,
+        *,
+        base_spent: Callable[[], int] | None = None,
+    ) -> None:
+        """``base_spent`` optionally reports tokens already spent outside the
+        workflow (the main loop), so ``spent()`` is a shared pool as the spec
+        requires; it defaults to zero for a standalone run."""
+        self._total = total
+        self._own_spent = 0
+        self._base_spent = base_spent
+
+    @property
+    def total(self) -> Optional[int]:
+        return self._total
+
+    def spent(self) -> int:
+        base = self._base_spent() if self._base_spent is not None else 0
+        return base + self._own_spent
+
+    def remaining(self) -> float:
+        if self._total is None:
+            return math.inf
+        return max(0, self._total - self.spent())
+
+    def add(self, tokens: int) -> None:
+        if tokens > 0:
+            self._own_spent += tokens
+
+    def check(self) -> None:
+        """Raise if the ceiling has been reached. Called before each ``agent()``."""
+        if self._total is not None and self.spent() >= self._total:
+            raise WorkflowBudgetExceeded(
+                f"workflow budget exhausted: spent {self.spent()} of {self._total} tokens"
+            )

--- a/src/workflow/callpath.py
+++ b/src/workflow/callpath.py
@@ -1,0 +1,61 @@
+"""Deterministic call-path keys for resume (fixes the spawn-order bug).
+
+The journal must key each ``agent()`` result by *where the call is in the
+orchestration tree*, NOT by the order subagents happen to start — otherwise a
+second round of fan-out whose timing depends on the first round (adversarial
+verify, judge panels, loop-until-dry) assigns indices by completion order,
+which is non-deterministic, breaking resume and risking returning a sibling's
+cached result.
+
+Each *branch* of execution carries a ``path`` (a tuple of ints) and a private
+counter. Within a branch, ``agent`` / ``parallel`` / ``pipeline`` are awaited
+sequentially, so each takes the next counter slot deterministically. ``parallel``
+and ``pipeline`` give every item its own child branch (``path + (slot, item)``)
+with a fresh counter, so concurrency only ever happens *across* branches — never
+on a shared counter. The current branch is held in a ``ContextVar``, which
+asyncio copies per task, so sibling fan-out branches stay isolated.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from dataclasses import dataclass
+
+CallKey = tuple[int, ...]
+
+
+@dataclass
+class Branch:
+    path: CallKey = ()
+    _counter: int = 0
+
+    def next_slot(self) -> int:
+        slot = self._counter
+        self._counter += 1
+        return slot
+
+
+_current: contextvars.ContextVar[Branch] = contextvars.ContextVar("workflow_branch")
+
+
+def current_branch() -> Branch:
+    """The branch for the running task. ``run_workflow`` always sets a base
+    branch before executing the script, so this is defined during a run."""
+    return _current.get()
+
+
+def use_branch(path: CallKey):
+    """Enter a child branch (with a fresh counter); returns a reset token."""
+    return _current.set(Branch(path))
+
+
+def reset_branch(token) -> None:
+    _current.reset(token)
+
+
+def key_to_str(key: CallKey) -> str:
+    return ".".join(str(part) for part in key)
+
+
+def key_from_str(text: str) -> CallKey:
+    return tuple(int(part) for part in text.split(".")) if text else ()

--- a/src/workflow/constants.py
+++ b/src/workflow/constants.py
@@ -1,0 +1,44 @@
+"""Runtime caps for the workflow engine.
+
+Authoritative values from the official spec
+(<https://code.claude.com/docs/en/workflows>): up to 16 concurrent agents
+(fewer on low-core machines), 1,000 agents per run, and a per-call item
+cap. The upstream concurrency cap is ``min(16, cpu_cores - 2)``; we honor
+that (with a ``CLAUDE_CODE_WORKFLOW_MAX_AGENTS`` override) rather than the
+house-style fixed integer, because the spec explicitly reduces parallelism
+on small machines.
+"""
+
+from __future__ import annotations
+
+import os
+
+#: Hard backstop on total ``agent()`` calls across a run's whole lifetime.
+MAX_AGENTS_PER_RUN = 1000
+
+#: Maximum items accepted by a single ``parallel()`` / ``pipeline()`` call.
+MAX_ITEMS_PER_CALL = 4096
+
+#: Retry cap for schema-validated structured output (upstream parity).
+MAX_STRUCTURED_OUTPUT_RETRIES = 5
+
+#: Hard ceiling on the concurrency cap regardless of core count.
+_CONCURRENCY_HARD_MAX = 16
+
+_ENV_MAX_AGENTS = "CLAUDE_CODE_WORKFLOW_MAX_AGENTS"
+
+
+def max_concurrent_agents() -> int:
+    """Resolve the per-run concurrency cap.
+
+    ``CLAUDE_CODE_WORKFLOW_MAX_AGENTS`` overrides everything when set to a
+    positive integer; otherwise ``min(16, cpu_count - 2)`` with a floor of 1.
+    """
+    override = os.environ.get(_ENV_MAX_AGENTS, "").strip()
+    if override:
+        try:
+            return max(1, int(override))
+        except ValueError:
+            pass
+    cores = os.cpu_count() or 3
+    return max(1, min(_CONCURRENCY_HARD_MAX, cores - 2))

--- a/src/workflow/errors.py
+++ b/src/workflow/errors.py
@@ -1,0 +1,31 @@
+"""Exception hierarchy for the workflow engine.
+
+The split mirrors the two failure surfaces described in
+``docs/workflow-engine-port-plan.md``: pre-flight validation errors (bad
+``meta``, compile failure) are raised *before* a run starts, while
+limit/budget errors are raised *inside* the running script from a
+primitive (``agent``/``parallel``/``pipeline``) so the script may catch
+them or let them abort the run.
+"""
+
+from __future__ import annotations
+
+
+class WorkflowError(Exception):
+    """Base class for all workflow-engine errors."""
+
+
+class WorkflowMetaError(WorkflowError):
+    """The script's ``meta`` block is missing, non-literal, or invalid, or
+    the script failed to parse/compile. Raised pre-flight; the run never
+    starts."""
+
+
+class WorkflowLimitError(WorkflowError):
+    """A hard runtime cap was exceeded (per-call item cap or per-run agent
+    cap). Raised from inside a primitive."""
+
+
+class WorkflowBudgetExceeded(WorkflowError):
+    """The run reached its token ``budget`` ceiling. Raised from ``agent()``
+    so the script stops spawning work."""

--- a/src/workflow/journal.py
+++ b/src/workflow/journal.py
@@ -1,0 +1,83 @@
+"""Per-run journal enabling same-session resume.
+
+Each ``agent()`` call is keyed by its **deterministic call-path** (see
+:mod:`src.workflow.callpath`) plus a fingerprint of its ``(prompt, opts)``. On
+resume a call is served from cache iff both its path and fingerprint match the
+prior run. Because the path is structural (not spawn-order), an unchanged script
++ args produces identical keys regardless of subagent timing, and a changed
+call only invalidates calls whose *inputs* therefore change (their fingerprints
+differ) — independent branches stay cached.
+
+The on-disk form is a JSON file under the session directory (wired by the
+Workflow tool); the in-memory form (``dict[CallKey, JournalRecord]``) is what
+the engine reads/writes during a run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from .callpath import CallKey, key_from_str, key_to_str
+from .types import AgentSpec
+
+_MISS = object()
+#: Sentinel returned by :meth:`Journal.lookup` for a cache miss.
+MISS = _MISS
+
+
+@dataclass(frozen=True)
+class JournalRecord:
+    fingerprint: str
+    result: Any
+
+
+def fingerprint(spec: AgentSpec) -> str:
+    """Stable hash of the parts of a call that determine its result."""
+    payload = json.dumps(
+        {
+            "prompt": spec.prompt,
+            "schema": spec.schema,
+            "model": spec.model,
+            "agent_type": spec.agent_type,
+            "isolation": spec.isolation,
+        },
+        sort_keys=True,
+        default=str,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+class Journal:
+    def __init__(self, prior: Optional[Mapping[CallKey, JournalRecord]] = None) -> None:
+        self._prior = dict(prior or {})
+        self._records: dict[CallKey, JournalRecord] = {}
+
+    def lookup(self, key: CallKey, spec: AgentSpec):
+        """Return the cached result for an unchanged call at ``key``, else MISS."""
+        prior = self._prior.get(key)
+        if prior is not None and prior.fingerprint == fingerprint(spec):
+            return prior.result
+        return _MISS
+
+    def record(self, key: CallKey, spec: AgentSpec, result: Any) -> None:
+        self._records[key] = JournalRecord(fingerprint(spec), result)
+
+    @property
+    def records(self) -> dict[CallKey, JournalRecord]:
+        return dict(self._records)
+
+    # ── persistence (string-keyed for JSON) ───────────────────────────────────
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {key_to_str(k): {"fingerprint": r.fingerprint, "result": r.result} for k, r in self._records.items()},
+            default=str,
+        )
+
+    @staticmethod
+    def load(text: str) -> dict[CallKey, JournalRecord]:
+        raw = json.loads(text)
+        return {key_from_str(k): JournalRecord(v["fingerprint"], v["result"]) for k, v in raw.items()}

--- a/src/workflow/primitives.py
+++ b/src/workflow/primitives.py
@@ -1,0 +1,59 @@
+"""Pure helpers for the ``parallel`` / ``pipeline`` primitives.
+
+Kept separate from :mod:`src.workflow.runtime` so the argument-resolution rules
+(coroutine vs. thunk; stage arity) are unit-testable in isolation. The
+stateful primitive bodies live on ``WorkflowRun``.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable, Sequence
+
+from .errors import WorkflowError
+
+
+async def await_item(item: Any) -> Any:
+    """Resolve a ``parallel()`` item.
+
+    Accepts a coroutine / awaitable (idiomatic ``agent(...)``) or a zero-arg
+    callable returning one (a thunk, faithful to the JS ``() => agent(...)``
+    surface).
+    """
+    if inspect.isawaitable(item):
+        return await item
+    if callable(item):
+        result = item()
+        return await result if inspect.isawaitable(result) else result
+    raise WorkflowError("parallel() items must be coroutines or zero-arg callables")
+
+
+def fit_args(fn: Callable[..., Any], args: Sequence[Any]) -> tuple[Any, ...]:
+    """Trim ``args`` to the number of positional params ``fn`` declares.
+
+    Mirrors JavaScript's "extra arguments are ignored": a ``pipeline`` stage
+    written as ``lambda prev: ...`` receives only ``prev``, while
+    ``def stage(prev, item, index)`` receives all three. Callables with
+    ``*args`` (or whose signature can't be introspected, e.g. some builtins)
+    receive everything.
+    """
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return tuple(args)
+    positional = 0
+    for param in sig.parameters.values():
+        if param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD):
+            positional += 1
+        elif param.kind == param.VAR_POSITIONAL:
+            return tuple(args)
+    # Trim to the declared arity (a 0-arg stage is called with no args, like JS).
+    return tuple(args[:positional])
+
+
+async def run_stage(stage: Callable[..., Any], prev: Any, item: Any, index: int) -> Any:
+    """Invoke one ``pipeline`` stage with ``(prev, item, index)`` arity-fitted."""
+    if not callable(stage):
+        raise WorkflowError("pipeline() stages must be callables")
+    result = stage(*fit_args(stage, (prev, item, index)))
+    return await result if inspect.isawaitable(result) else result

--- a/src/workflow/progress.py
+++ b/src/workflow/progress.py
@@ -1,0 +1,125 @@
+"""Progress model for a running workflow.
+
+This is the in-memory tree the ``LocalWorkflowTask`` / ``/workflows`` view will
+render: ordered **phases**, each holding the **agents** that ran under it
+(label, status, tokens), plus narrator **log** lines. Every ``phase()``,
+``log()``, and ``agent()`` lifecycle transition updates it and fires the
+optional ``on_change`` callback so the TUI can repaint.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Literal, Optional
+
+AgentStatus = Literal["running", "completed", "failed", "skipped", "cached"]
+
+
+@dataclass
+class AgentRecord:
+    index: int
+    label: str
+    phase: Optional[str]
+    status: AgentStatus = "running"
+    tokens: int = 0
+    error: Optional[str] = None
+
+
+@dataclass
+class PhaseRecord:
+    title: str
+    detail: Optional[str] = None
+    agents: list[AgentRecord] = field(default_factory=list)
+
+    @property
+    def token_total(self) -> int:
+        return sum(a.tokens for a in self.agents)
+
+
+class WorkflowProgress:
+    def __init__(
+        self,
+        phases_meta: Optional[list[dict]] = None,
+        *,
+        on_change: Callable[["WorkflowProgress"], None] | None = None,
+    ) -> None:
+        # Seed declared phases (from meta.phases) so the tree shows them before
+        # any agent runs; phase() started later by title reuses the same record.
+        self._phases: list[PhaseRecord] = [
+            PhaseRecord(title=p.get("title", ""), detail=p.get("detail"))
+            for p in (phases_meta or [])
+            if isinstance(p, dict) and p.get("title")
+        ]
+        self._logs: list[str] = []
+        self._current_phase: Optional[str] = None
+        self._on_change = on_change
+
+    # ── mutations ──────────────────────────────────────────────────────────
+    def start_phase(self, title: str) -> None:
+        self._current_phase = title
+        if not any(p.title == title for p in self._phases):
+            self._phases.append(PhaseRecord(title=title))
+        self._changed()
+
+    def log(self, message: str) -> None:
+        self._logs.append(message)
+        self._changed()
+
+    def agent_started(self, index: int, label: str, phase: Optional[str]) -> AgentRecord:
+        phase = phase or self._current_phase
+        record = AgentRecord(index=index, label=label, phase=phase)
+        self._phase_for(phase).agents.append(record)
+        self._changed()
+        return record
+
+    def agent_finished(
+        self,
+        record: AgentRecord,
+        *,
+        status: AgentStatus,
+        tokens: int = 0,
+        error: Optional[str] = None,
+    ) -> None:
+        record.status = status
+        record.tokens = tokens
+        record.error = error
+        self._changed()
+
+    # ── reads ──────────────────────────────────────────────────────────────
+    @property
+    def phases(self) -> list[PhaseRecord]:
+        return self._phases
+
+    @property
+    def logs(self) -> list[str]:
+        return list(self._logs)
+
+    @property
+    def current_phase(self) -> Optional[str]:
+        return self._current_phase
+
+    @property
+    def agent_count(self) -> int:
+        return sum(len(p.agents) for p in self._phases)
+
+    @property
+    def token_total(self) -> int:
+        return sum(p.token_total for p in self._phases)
+
+    def summary(self) -> str:
+        phase = self._current_phase or (self._phases[-1].title if self._phases else "starting")
+        return f"{phase} · {self.agent_count} agents · {self.token_total} tokens"
+
+    # ── internals ──────────────────────────────────────────────────────────
+    def _phase_for(self, phase: Optional[str]) -> PhaseRecord:
+        title = phase or "main"
+        for record in self._phases:
+            if record.title == title:
+                return record
+        record = PhaseRecord(title=title)
+        self._phases.append(record)
+        return record
+
+    def _changed(self) -> None:
+        if self._on_change is not None:
+            self._on_change(self)

--- a/src/workflow/runner.py
+++ b/src/workflow/runner.py
@@ -1,0 +1,122 @@
+"""Production ``AgentRunner`` — the bridge from ``agent()`` to a real subagent.
+
+This is the integration seam. The engine core (sandbox / scheduler / budget /
+journal / primitives) is fully unit-tested against the in-memory ``FakeRunner``;
+``LiveAgentRunner`` wires the same ``AgentRunner`` protocol to the real
+``src.agent.run_agent`` loop, ``finalize_agent_tool`` (final text + token usage),
+and the schema-validated ``StructuredOutput`` tool from
+:mod:`src.workflow.structured`.
+
+Its app-specific dependencies (provider, tool registry, parent context, the
+base worker tool pool, and agent-type resolution) are injected by the caller —
+in production, the Workflow tool builds them from its ``ToolContext``. The
+structured-output path here is exercised by the ``make_structured_output_tool``
+unit tests; the ``run_agent`` composition is validated by live integration
+testing (it needs a real provider) and is intentionally thin.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from src.utils.abort_controller import AbortController, AbortError
+
+from .structured import (
+    SYNTHETIC_OUTPUT_TOOL_NAME,
+    StructuredOutputCollector,
+    make_structured_output_tool,
+)
+from .types import AgentOutcome, AgentSpec
+
+#: Appended to a schema call's prompt so the model emits via the injected tool.
+_SCHEMA_NUDGE = (
+    "\n\nWhen you are finished, call the StructuredOutput tool exactly once with "
+    "your final answer as its arguments. Do not put the answer anywhere else."
+)
+
+
+class LiveAgentRunner:
+    def __init__(
+        self,
+        *,
+        provider: Any,
+        tool_registry: Any,
+        parent_context: Any,
+        base_tools: list,
+        resolve_agent: Callable[[str], Any],
+        default_agent_type: str = "general-purpose",
+        run_id: str = "wf",
+        max_turns: Optional[int] = None,
+    ) -> None:
+        self._provider = provider
+        self._tool_registry = tool_registry
+        self._parent_context = parent_context
+        self._base_tools = list(base_tools)
+        self._resolve_agent = resolve_agent
+        self._default_agent_type = default_agent_type
+        self._run_id = run_id
+        self._max_turns = max_turns
+
+    async def run(self, spec: AgentSpec, *, abort: AbortController, index: int) -> AgentOutcome:
+        # Imported lazily: ``src.agent`` pulls in the whole agent stack, which
+        # the engine core deliberately never imports.
+        from src.agent.agent_tool_utils import finalize_agent_tool
+        from src.agent.run_agent import RunAgentParams, run_agent
+
+        agent_type = spec.agent_type or self._default_agent_type
+        agent_definition = self._resolve_agent(agent_type)
+        agent_id = f"wf_{self._run_id}-{index}"
+
+        # isolation="worktree" is not yet wired (run_agent worktree support is a
+        # later phase); a worktree request currently runs in-place.
+        collector: Optional[StructuredOutputCollector] = None
+        available_tools = list(self._base_tools)
+        prompt = spec.prompt
+        if spec.schema is not None:
+            collector = StructuredOutputCollector(schema=spec.schema)
+            available_tools = [
+                t for t in available_tools if getattr(t, "name", None) != SYNTHETIC_OUTPUT_TOOL_NAME
+            ]
+            available_tools.append(make_structured_output_tool(collector))
+            prompt = spec.prompt + _SCHEMA_NUDGE
+
+        params = RunAgentParams(
+            parent_context=self._parent_context,
+            agent_definition=agent_definition,
+            prompt=prompt,
+            available_tools=available_tools,
+            tool_registry=self._tool_registry,
+            provider=self._provider,
+            model=spec.model,
+            agent_id=agent_id,
+            abort_controller=abort,
+            max_turns=self._max_turns,
+            # Keep the injected StructuredOutput tool in the pool verbatim.
+            use_exact_tools=spec.schema is not None,
+        )
+
+        messages: list = []
+        try:
+            async for message in run_agent(params):
+                messages.append(message)
+        except AbortError:
+            raise  # cancellation unwinds; the engine marks the agent aborted
+
+        # finalize_agent_tool raises if the run produced no assistant message;
+        # the engine catches that and resolves agent() to None (a "death").
+        result = finalize_agent_tool(messages, agent_id, {"agent_type": agent_type})
+        tokens = result.total_tokens
+        tool_uses = result.total_tool_use_count
+
+        if spec.schema is not None:
+            assert collector is not None
+            if collector.succeeded:
+                return AgentOutcome(structured=collector.value, tokens=tokens, tool_use_count=tool_uses)
+            return AgentOutcome(
+                error=f"structured output not produced (last error: {collector.last_error})",
+                tokens=tokens,
+                tool_use_count=tool_uses,
+            )
+
+        text = "".join(block.get("text", "") for block in result.content)
+        return AgentOutcome(text=text, tokens=tokens, tool_use_count=tool_uses)

--- a/src/workflow/runtime.py
+++ b/src/workflow/runtime.py
@@ -1,0 +1,329 @@
+"""The workflow runtime: binds the orchestration primitives to per-run state
+and executes a script end-to-end.
+
+``run_workflow`` is the public entry point. It extracts ``meta`` (pre-flight),
+builds a :class:`WorkflowRun` holding the scheduler / budget / journal /
+progress / abort controller, injects the primitives into the sandbox namespace,
+and runs the script. A script-level exception is captured into
+``WorkflowResult.error`` (the run ends); a bad ``meta`` raises before the run
+starts.
+
+Resume keys come from :mod:`src.workflow.callpath` (deterministic call-paths),
+so caching is correct even under concurrent multi-round fan-out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Optional
+
+from src.utils.abort_controller import (
+    AbortController,
+    AbortError,
+    create_abort_controller,
+    create_child_abort_controller,
+)
+
+from .budget import Budget
+from .callpath import CallKey, current_branch, key_to_str, reset_branch, use_branch
+from .constants import MAX_ITEMS_PER_CALL
+from .errors import WorkflowError, WorkflowMetaError
+from .journal import MISS, Journal, JournalRecord
+from .primitives import await_item, run_stage
+from .progress import WorkflowProgress
+from .sandbox import execute_workflow, extract_meta
+from .scheduler import Scheduler
+from .types import AgentOutcome, AgentRunner, AgentSpec, WorkflowMeta
+
+
+@dataclass
+class WorkflowResult:
+    meta: WorkflowMeta
+    value: Any = None
+    error: Optional[str] = None
+    progress: Optional[WorkflowProgress] = None
+    journal: dict[CallKey, JournalRecord] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+
+class WorkflowRun:
+    """Owns the state for one running script and implements the primitives."""
+
+    def __init__(
+        self,
+        *,
+        meta: WorkflowMeta,
+        runner: AgentRunner,
+        args: Any,
+        run_id: str,
+        scheduler: Scheduler,
+        budget: Budget,
+        journal: Journal,
+        progress: WorkflowProgress,
+        controller: AbortController,
+        base_path: CallKey = (),
+        resolve_workflow: Optional[Callable[[str], str]] = None,
+        depth: int = 0,
+    ) -> None:
+        self._meta = meta
+        self._runner = runner
+        self._args = args
+        self._run_id = run_id
+        self._scheduler = scheduler
+        self._budget = budget
+        self._journal = journal
+        self._progress = progress
+        self._controller = controller
+        self._base_path = base_path
+        self._resolve_workflow = resolve_workflow
+        self._depth = depth
+        self._display = 0
+        # S2: per-agent child controllers, keyed by call-path, reachable so the
+        # task layer can stop/retry one agent without aborting the whole run.
+        self._agent_controllers: dict[CallKey, AbortController] = {}
+
+    @property
+    def controller(self) -> AbortController:
+        return self._controller
+
+    def abort_agent(self, key: CallKey) -> bool:
+        """Abort one in-flight agent by its call-path key. Returns whether a
+        live controller was found."""
+        controller = self._agent_controllers.get(key)
+        if controller is None:
+            return False
+        controller.abort("agent_stopped")
+        return True
+
+    def namespace(self) -> dict[str, Any]:
+        return {
+            "agent": self.agent,
+            "parallel": self.parallel,
+            "pipeline": self.pipeline,
+            "phase": self.phase,
+            "log": self.log,
+            "workflow": self.workflow,
+            "budget": self._budget,
+        }
+
+    # ── primitives ───────────────────────────────────────────────────────────
+
+    async def agent(
+        self,
+        prompt: Any,
+        *,
+        label: Optional[str] = None,
+        phase: Optional[str] = None,
+        schema: Optional[Mapping[str, Any]] = None,
+        model: Optional[str] = None,
+        agent_type: Optional[str] = None,
+        isolation: Optional[str] = None,
+    ) -> Any:
+        # Deterministic call-path key (taken synchronously, so it is stable
+        # across runs regardless of fan-out timing).
+        key = current_branch().path + (current_branch().next_slot(),)
+        spec = AgentSpec(
+            prompt=str(prompt),
+            label=label,
+            phase=phase,
+            schema=schema,
+            model=model,
+            agent_type=agent_type,
+            isolation=isolation,
+        )
+        eff_label = label or agent_type or "agent"
+        eff_phase = phase or self._progress.current_phase
+
+        cached = self._journal.lookup(key, spec)
+        if cached is not MISS:
+            record = self._progress.agent_started(self._next_display(), eff_label, eff_phase)
+            self._progress.agent_finished(record, status="cached")
+            return cached
+
+        # Live calls only: count toward the per-run cap and the budget ceiling.
+        self._controller.signal.throw_if_aborted()
+        self._scheduler.reserve()
+        self._budget.check()
+
+        record = self._progress.agent_started(self._next_display(), eff_label, eff_phase)
+        child = create_child_abort_controller(self._controller)
+        self._agent_controllers[key] = child
+        try:
+            async with self._scheduler.slot():
+                try:
+                    outcome = await self._runner.run(spec, abort=child, index=key_to_str(key))
+                except AbortError:
+                    self._progress.agent_finished(record, status="failed", error="aborted")
+                    raise
+                except Exception as exc:  # noqa: BLE001 — a subagent death -> None
+                    outcome = AgentOutcome(error=f"{type(exc).__name__}: {exc}")
+        finally:
+            self._agent_controllers.pop(key, None)
+
+        self._budget.add(outcome.tokens)
+        if outcome.error is not None:
+            self._progress.agent_finished(record, status="failed", tokens=outcome.tokens, error=outcome.error)
+            result: Any = None
+        elif outcome.skipped:
+            self._progress.agent_finished(record, status="skipped", tokens=outcome.tokens)
+            result = None
+        else:
+            result = outcome.structured if schema is not None else outcome.text
+            self._progress.agent_finished(record, status="completed", tokens=outcome.tokens)
+
+        self._journal.record(key, spec, result)
+        return result
+
+    async def parallel(self, items) -> list:
+        items = list(items)
+        if len(items) > MAX_ITEMS_PER_CALL:
+            self._close_coroutines(items)
+            raise WorkflowError(
+                f"parallel() received {len(items)} items; the per-call cap is {MAX_ITEMS_PER_CALL}"
+            )
+        base = current_branch().path + (current_branch().next_slot(),)
+
+        async def guarded(index: int, item):
+            token = use_branch(base + (index,))
+            try:
+                return await await_item(item)
+            except Exception:
+                return None  # the barrier never rejects
+            finally:
+                reset_branch(token)
+
+        return list(await asyncio.gather(*(guarded(i, it) for i, it in enumerate(items))))
+
+    async def pipeline(self, items, *stages) -> list:
+        items = list(items)
+        if len(items) > MAX_ITEMS_PER_CALL:
+            self._close_coroutines(items)
+            raise WorkflowError(
+                f"pipeline() received {len(items)} items; the per-call cap is {MAX_ITEMS_PER_CALL}"
+            )
+        base = current_branch().path + (current_branch().next_slot(),)
+
+        async def run_item(index: int, item):
+            token = use_branch(base + (index,))
+            try:
+                prev = item
+                for stage in stages:
+                    try:
+                        prev = await run_stage(stage, prev, item, index)
+                    except Exception:
+                        return None  # drop this item; siblings continue
+                return prev
+            finally:
+                reset_branch(token)
+
+        return list(await asyncio.gather(*(run_item(i, it) for i, it in enumerate(items))))
+
+    def phase(self, title: str) -> None:
+        self._progress.start_phase(str(title))
+
+    def log(self, message: Any) -> None:
+        self._progress.log(str(message))
+
+    async def workflow(self, name_or_ref: str, args: Any = None) -> Any:
+        if self._depth >= 1:
+            raise WorkflowError("workflow() nesting is one level only")
+        if self._resolve_workflow is None:
+            raise WorkflowError("nested workflows are not available in this run")
+        # Consume a slot so the nested run's keys don't collide with siblings.
+        slot = current_branch().next_slot()
+        source = self._resolve_workflow(name_or_ref)
+        sub = await run_workflow(
+            source,
+            runner=self._runner,
+            args=args,
+            run_id=f"{self._run_id}/{name_or_ref}",
+            resolve_workflow=self._resolve_workflow,
+            scheduler=self._scheduler,  # share the concurrency cap
+            budget=self._budget,        # share the budget pool
+            controller=self._controller,
+            base_path=current_branch().path + (slot,),
+            _depth=self._depth + 1,
+        )
+        if not sub.ok:
+            raise WorkflowError(f"nested workflow '{name_or_ref}' failed: {sub.error}")
+        return sub.value
+
+    # ── internals ──────────────────────────────────────────────────────────
+    def _next_display(self) -> int:
+        n = self._display
+        self._display += 1
+        return n
+
+    @staticmethod
+    def _close_coroutines(items) -> None:
+        for item in items:
+            if inspect.iscoroutine(item):
+                item.close()
+
+
+async def run_workflow(
+    source: str,
+    *,
+    runner: AgentRunner,
+    args: Any = None,
+    run_id: str = "wf",
+    on_progress: Optional[Callable[[WorkflowProgress], None]] = None,
+    resume: Optional[Mapping[CallKey, JournalRecord]] = None,
+    resolve_workflow: Optional[Callable[[str], str]] = None,
+    budget_total: Optional[int] = None,
+    max_concurrent: Optional[int] = None,
+    controller: Optional[AbortController] = None,
+    scheduler: Optional[Scheduler] = None,
+    budget: Optional[Budget] = None,
+    base_path: CallKey = (),
+    _depth: int = 0,
+) -> WorkflowResult:
+    """Run a Python workflow ``source`` to completion.
+
+    Raises :class:`WorkflowMetaError` if the ``meta`` block is missing/invalid
+    (pre-flight). A script *runtime* exception is captured into
+    ``WorkflowResult.error`` and ends the run gracefully.
+    """
+    meta = extract_meta(source)
+
+    scheduler = scheduler if scheduler is not None else Scheduler(max_concurrent)
+    budget = budget if budget is not None else Budget(budget_total)
+    journal = Journal(resume)
+    progress = WorkflowProgress(meta.phases, on_change=on_progress)
+    controller = controller if controller is not None else create_abort_controller()
+
+    run = WorkflowRun(
+        meta=meta,
+        runner=runner,
+        args=args,
+        run_id=run_id,
+        scheduler=scheduler,
+        budget=budget,
+        journal=journal,
+        progress=progress,
+        controller=controller,
+        base_path=base_path,
+        resolve_workflow=resolve_workflow,
+        depth=_depth,
+    )
+
+    # Establish this run's base branch for deterministic call-path keys, and
+    # restore the caller's branch afterwards (matters for nested workflow()).
+    token = use_branch(base_path)
+    value: Any = None
+    error: Optional[str] = None
+    try:
+        value = await execute_workflow(source, run.namespace(), args)
+    except WorkflowMetaError:
+        raise  # compile error surfaced during exec — treat as pre-flight
+    except Exception as exc:  # noqa: BLE001 — any script error ends the run
+        error = f"{type(exc).__name__}: {exc}"
+    finally:
+        reset_branch(token)
+
+    return WorkflowResult(meta=meta, value=value, error=error, progress=progress, journal=journal.records)

--- a/src/workflow/sandbox.py
+++ b/src/workflow/sandbox.py
@@ -1,0 +1,185 @@
+"""Sandboxed execution of a model-authored Python workflow script.
+
+Two responsibilities:
+
+1. **Static ``meta`` extraction** — parse the script with ``ast`` and
+   ``ast.literal_eval`` the top-level ``meta = {...}`` assignment *without
+   executing the script* (a non-literal ``meta`` is rejected).
+2. **Curated execution** — wrap the body in ``async def __workflow_main__()``,
+   compile it, and run it against a namespace that injects the orchestration
+   primitives + a deterministic, whitelisted standard library while denying
+   filesystem / shell / network reach.
+
+Security posture (per ``docs/workflow-engine-port-plan.md`` §3.2): the script
+is *model-authored, not adversarial*, so the goal is determinism + ergonomics,
+not a hard sandbox. ``exec`` with curated builtins removes ``os``/``subprocess``
+/``open`` reach and forces all I/O through the injected ``agent`` primitive,
+while ``time``/``random``/``datetime`` are withheld so a run is deterministic
+and therefore resumable.
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins as _builtins
+import collections
+import functools
+import importlib
+import itertools
+import json
+import math
+import re
+import string
+import textwrap
+from typing import Any, Mapping
+
+from .errors import WorkflowMetaError
+from .types import WorkflowMeta
+
+_REQUIRED_META = ("name", "description")
+_WRAPPER_NAME = "__workflow_main__"
+
+# Deterministic stdlib modules real workflows lean on (the demo corpus uses
+# json/re/math constantly). Injected as globals AND importable. Deliberately
+# excludes time/random/datetime (non-determinism breaks resume) and anything
+# touching the host (os/sys/subprocess/socket/pathlib).
+_MODULE_WHITELIST: dict[str, Any] = {
+    "json": json,
+    "re": re,
+    "math": math,
+    "collections": collections,
+    "itertools": itertools,
+    "functools": functools,
+    "string": string,
+    "textwrap": textwrap,
+}
+
+# Builtins that are safe and commonly needed. Notably absent: __import__
+# (provided separately, whitelisted), open, eval, exec, compile, input,
+# globals, locals, vars, breakpoint, exit, quit, help.
+_SAFE_BUILTIN_NAMES = (
+    "abs", "all", "any", "bool", "bytes", "chr", "dict", "divmod",
+    "enumerate", "filter", "float", "format", "frozenset", "getattr",
+    "hasattr", "hash", "int", "isinstance", "issubclass", "iter", "len",
+    "list", "map", "max", "min", "next", "ord", "range", "repr", "reversed",
+    "round", "set", "slice", "sorted", "str", "sum", "tuple", "zip",
+    # exception types the scripts raise / catch
+    "Exception", "ValueError", "RuntimeError", "KeyError", "TypeError",
+    "IndexError", "StopIteration", "ZeroDivisionError", "ArithmeticError",
+    "AttributeError", "NotImplementedError", "AssertionError",
+)
+
+
+def _safe_import(name, globals=None, locals=None, fromlist=(), level=0):  # noqa: A002
+    """A restricted ``__import__`` permitting only the whitelisted modules.
+
+    Lets the model write idiomatic ``import json`` / ``from re import sub``
+    while denying ``import os`` (and relative imports). The whitelisted
+    modules are also pre-bound as globals, so either style works.
+    """
+    if level != 0:
+        raise ImportError("relative imports are not allowed in workflow scripts")
+    root = name.split(".")[0]
+    if root not in _MODULE_WHITELIST:
+        raise ImportError(f"import of '{name}' is not allowed in workflow scripts")
+    return importlib.__import__(name, globals, locals, fromlist, level)
+
+
+def _safe_builtins() -> dict[str, Any]:
+    d: dict[str, Any] = {name: getattr(_builtins, name) for name in _SAFE_BUILTIN_NAMES}
+    d["__import__"] = _safe_import
+    d["True"] = True
+    d["False"] = False
+    d["None"] = None
+    return d
+
+
+# ── meta extraction ──────────────────────────────────────────────────────────
+
+
+def extract_meta(source: str) -> WorkflowMeta:
+    """Statically extract and validate the ``meta`` literal (no execution)."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        raise WorkflowMetaError(f"workflow script has a syntax error: {exc}") from exc
+
+    node = _find_meta_node(tree)
+    if node is None:
+        raise WorkflowMetaError(
+            "workflow script must define a top-level `meta = {...}` dict literal"
+        )
+    try:
+        raw = ast.literal_eval(node)
+    except (ValueError, SyntaxError, TypeError) as exc:
+        raise WorkflowMetaError(
+            "`meta` must be a pure literal (no variables, calls, f-strings, or comprehensions)"
+        ) from exc
+    if not isinstance(raw, dict):
+        raise WorkflowMetaError("`meta` must be a dict")
+
+    for key in _REQUIRED_META:
+        val = raw.get(key)
+        if not isinstance(val, str) or not val.strip():
+            raise WorkflowMetaError(f"`meta` requires a non-empty string `{key}`")
+
+    phases = raw.get("phases", []) or []
+    if not isinstance(phases, list):
+        raise WorkflowMetaError("`meta.phases` must be a list")
+
+    return WorkflowMeta(
+        name=raw["name"],
+        description=raw["description"],
+        when_to_use=raw.get("when_to_use"),
+        phases=phases,
+        model=raw.get("model"),
+        raw=raw,
+    )
+
+
+def _find_meta_node(tree: ast.Module) -> ast.expr | None:
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Assign):
+            targets, value = stmt.targets, stmt.value
+        elif isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
+            targets, value = [stmt.target], stmt.value
+        else:
+            continue
+        for target in targets:
+            if isinstance(target, ast.Name) and target.id == "meta":
+                return value
+    return None
+
+
+# ── execution ────────────────────────────────────────────────────────────────
+
+
+def compile_workflow(source: str):
+    """Compile the script body as the body of ``async def __workflow_main__()``.
+
+    Wrapping in an async function makes top-level ``await``, ``return`` (the
+    workflow's result), and ``raise`` all valid.
+    """
+    body = source if source.strip() else "pass"
+    wrapped = f"async def {_WRAPPER_NAME}():\n" + textwrap.indent(body, "    ")
+    try:
+        return compile(wrapped, "<workflow>", "exec")
+    except SyntaxError as exc:
+        raise WorkflowMetaError(f"workflow script failed to compile: {exc}") from exc
+
+
+def build_namespace(primitives: Mapping[str, Any], args: Any) -> dict[str, Any]:
+    """Assemble the global namespace the script executes in."""
+    ns: dict[str, Any] = {"__builtins__": _safe_builtins()}
+    ns.update(_MODULE_WHITELIST)  # json/re/math/... available without import too
+    ns.update(primitives)         # agent/parallel/pipeline/phase/log/workflow/budget
+    ns["args"] = args
+    return ns
+
+
+async def execute_workflow(source: str, primitives: Mapping[str, Any], args: Any) -> Any:
+    """Compile + run the script, returning its top-level ``return`` value."""
+    code = compile_workflow(source)
+    namespace = build_namespace(primitives, args)
+    exec(code, namespace)  # noqa: S102 — curated namespace; see module docstring
+    return await namespace[_WRAPPER_NAME]()

--- a/src/workflow/scheduler.py
+++ b/src/workflow/scheduler.py
@@ -1,0 +1,63 @@
+"""Bounded-concurrency scheduling for ``agent()`` fan-out.
+
+A thin wrapper over ``asyncio.Semaphore`` (the canonical limiter pattern in
+``src/services/tool_execution/orchestrator.py``). Each ``agent()`` call acquires
+a :meth:`Scheduler.slot` for the duration of its subagent run, so no more than
+``max_concurrent`` subagents run at once even when ``parallel()`` hands the
+scheduler hundreds of coroutines. The per-run lifetime cap (1,000 agents) is
+also enforced here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+
+from .constants import MAX_AGENTS_PER_RUN, max_concurrent_agents
+from .errors import WorkflowLimitError
+
+
+class Scheduler:
+    def __init__(self, max_concurrent: int | None = None) -> None:
+        self._max_concurrent = max_concurrent if max_concurrent is not None else max_concurrent_agents()
+        self._sem = asyncio.Semaphore(self._max_concurrent)
+        self._launched = 0
+        self._peak = 0
+        self._active = 0
+
+    @property
+    def max_concurrent(self) -> int:
+        return self._max_concurrent
+
+    @property
+    def launched(self) -> int:
+        return self._launched
+
+    @property
+    def peak_concurrency(self) -> int:
+        return self._peak
+
+    def reserve(self) -> int:
+        """Claim a lifetime slot and return this call's 0-based index.
+
+        Raises once the per-run agent cap is hit. Called synchronously at
+        ``agent()`` entry (before any ``await``) so indices are deterministic.
+        """
+        if self._launched >= MAX_AGENTS_PER_RUN:
+            raise WorkflowLimitError(
+                f"workflow exceeded the per-run agent cap of {MAX_AGENTS_PER_RUN}"
+            )
+        index = self._launched
+        self._launched += 1
+        return index
+
+    @asynccontextmanager
+    async def slot(self):
+        """Hold a concurrency slot for the duration of one subagent run."""
+        async with self._sem:
+            self._active += 1
+            self._peak = max(self._peak, self._active)
+            try:
+                yield
+            finally:
+                self._active -= 1

--- a/src/workflow/structured.py
+++ b/src/workflow/structured.py
@@ -1,0 +1,121 @@
+"""Schema-validated structured output for ``agent(prompt, schema=...)``.
+
+The clawcodex ``StructuredOutputTool`` is currently an unvalidated no-op whose
+result never returns to a caller, so the workflow engine must own validation
+itself. The pure pieces live here (and are unit-tested directly); the
+production ``AgentRunner`` wires :class:`StructuredOutputCollector` into the
+injected ``StructuredOutput`` tool given to a schema subagent.
+
+Validation reuses the repository's only JSON-Schema validator,
+``src.tool_system.schema_validation.validate_json_schema`` (raises
+``ToolInputError`` on mismatch).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from src.tool_system.build_tool import Tool, build_tool
+from src.tool_system.errors import ToolInputError
+from src.tool_system.protocol import ToolResult
+from src.tool_system.schema_validation import validate_json_schema
+
+from .constants import MAX_STRUCTURED_OUTPUT_RETRIES
+
+#: The name the model is told to call. Matches the stock ``StructuredOutputTool``
+#: so the per-call schema tool shadows it in the subagent's tool pool.
+SYNTHETIC_OUTPUT_TOOL_NAME = "StructuredOutput"
+
+
+def validate_structured(obj: Any, schema: Mapping[str, Any]) -> tuple[bool, Optional[str]]:
+    """Validate ``obj`` against ``schema``; return ``(ok, error_message)``."""
+    try:
+        validate_json_schema(obj, schema, root_name="output")
+        return True, None
+    except ToolInputError as exc:
+        return False, str(exc)
+
+
+@dataclass
+class StructuredOutputCollector:
+    """Accumulates a schema subagent's ``StructuredOutput`` emissions.
+
+    The injected tool calls :meth:`offer` for each emission. A valid object is
+    captured and ends the run; an invalid one returns the validation error (fed
+    back to the model as a tool error so it retries) until the retry cap is hit.
+    """
+
+    schema: Mapping[str, Any]
+    max_retries: int = MAX_STRUCTURED_OUTPUT_RETRIES
+    attempts: int = 0
+    value: Any = None
+    succeeded: bool = False
+    last_error: Optional[str] = None
+
+    def offer(self, obj: Any) -> tuple[bool, Optional[str]]:
+        """Validate one emission. Returns ``(accepted, error_message)``."""
+        if self.succeeded:
+            return True, None
+        self.attempts += 1
+        ok, error = validate_structured(obj, self.schema)
+        if ok:
+            self.value = obj
+            self.succeeded = True
+            return True, None
+        self.last_error = error
+        return False, error
+
+    @property
+    def exhausted(self) -> bool:
+        """True once retries are spent without a valid object."""
+        return not self.succeeded and self.attempts >= self.max_retries
+
+
+def make_structured_output_tool(collector: StructuredOutputCollector) -> Tool:
+    """Build the per-call ``StructuredOutput`` tool injected into a schema subagent.
+
+    Unlike the stock ``StructuredOutputTool`` (which neither validates nor
+    returns its payload), this tool drives ``collector``: a valid emission is
+    captured and acknowledged; an invalid one is returned as a tool *error*
+    carrying the validation message so the model corrects and retries, until the
+    retry cap is reached. The input schema is left permissive so the model's
+    raw object reaches :meth:`StructuredOutputCollector.offer` for validation
+    here (rather than being rejected earlier by dispatch-level validation).
+    """
+
+    def _call(tool_input: dict, context: Any) -> ToolResult:
+        accepted, error = collector.offer(tool_input)
+        if accepted:
+            outbox = getattr(context, "outbox", None)
+            if outbox is not None:
+                outbox.append({"tool": SYNTHETIC_OUTPUT_TOOL_NAME, "structured_output": tool_input})
+            return ToolResult(
+                name=SYNTHETIC_OUTPUT_TOOL_NAME,
+                output={"data": "Structured output accepted.", "structured_output": tool_input},
+            )
+        if collector.exhausted:
+            return ToolResult(
+                name=SYNTHETIC_OUTPUT_TOOL_NAME,
+                output={"data": f"Structured output failed validation after {collector.attempts} attempts: {error}"},
+                is_error=True,
+            )
+        return ToolResult(
+            name=SYNTHETIC_OUTPUT_TOOL_NAME,
+            output={"data": f"Output did not match the schema: {error}. Fix the fields and call StructuredOutput again."},
+            is_error=True,
+        )
+
+    return build_tool(
+        name=SYNTHETIC_OUTPUT_TOOL_NAME,
+        input_schema={"type": "object", "additionalProperties": True},
+        call=_call,
+        prompt=(
+            "Return your final answer by calling this tool exactly once at the end, "
+            "with arguments matching the requested schema."
+        ),
+        description="Return a final response as schema-validated structured JSON.",
+        max_result_size_chars=100_000,
+        is_read_only=lambda _input: True,
+        is_concurrency_safe=lambda _input: True,
+    )

--- a/src/workflow/types.py
+++ b/src/workflow/types.py
@@ -1,0 +1,73 @@
+"""Core data types and the subagent-runner seam for the workflow engine.
+
+``AgentRunner`` is the dependency-injection boundary: in production it wraps
+``src.agent.run_agent`` + ``finalize_agent_tool`` + schema-validated
+structured output (see ``src/workflow/runner.py``); in tests it is a fake
+that returns canned ``AgentOutcome``s. The engine itself never imports the
+agent stack, which keeps the orchestration logic unit-testable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Protocol
+
+from src.utils.abort_controller import AbortController
+
+
+@dataclass(frozen=True)
+class WorkflowMeta:
+    """The validated ``meta`` block extracted statically from a script."""
+
+    name: str
+    description: str
+    when_to_use: Optional[str] = None
+    phases: list[dict[str, Any]] = field(default_factory=list)
+    model: Optional[str] = None
+    raw: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    """A single ``agent(prompt, **opts)`` request from the script."""
+
+    prompt: str
+    label: Optional[str] = None
+    phase: Optional[str] = None
+    schema: Optional[Mapping[str, Any]] = None
+    model: Optional[str] = None
+    agent_type: Optional[str] = None
+    isolation: Optional[str] = None
+
+
+@dataclass
+class AgentOutcome:
+    """The result of running one subagent.
+
+    For a plain call the engine returns ``text``; for a ``schema`` call it
+    returns ``structured``. ``skipped``/``error`` cause ``agent()`` to
+    resolve to ``None``. ``tokens`` feeds the run-wide ``budget``.
+    """
+
+    text: Optional[str] = None
+    structured: Any = None
+    tokens: int = 0
+    tool_use_count: int = 0
+    error: Optional[str] = None
+    skipped: bool = False
+
+
+class AgentRunner(Protocol):
+    """The subagent-spawning seam the workflow ``agent()`` primitive calls."""
+
+    async def run(
+        self,
+        spec: AgentSpec,
+        *,
+        abort: AbortController,
+        index: str,
+    ) -> AgentOutcome:
+        """``index`` is the call's deterministic call-path key as a string
+        (e.g. ``"0"``, ``"1.0"``) — stable across runs, suitable as an
+        agent id suffix."""
+        ...

--- a/tests/workflow/conftest.py
+++ b/tests/workflow/conftest.py
@@ -1,0 +1,109 @@
+"""Shared fixtures for the workflow-engine tests.
+
+``FakeRunner`` stands in for the production ``AgentRunner`` so the engine can be
+exercised end-to-end without a live model: it records every ``AgentSpec``, can
+delay (for concurrency tests), honors the abort signal, and either uses a
+caller-supplied ``handler`` or a sensible default (text → ``r{index}``, schema →
+``{"echo": prompt}``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+import pytest
+
+from src.workflow.types import AgentOutcome, AgentSpec
+
+
+@dataclass
+class FakeRunner:
+    handler: Optional[Callable[[AgentSpec, int], Any]] = None
+    delay: float = 0.0
+    calls: list[AgentSpec] = field(default_factory=list)
+    peak: int = 0
+    _active: int = 0
+
+    async def run(self, spec: AgentSpec, *, abort, index: str) -> AgentOutcome:
+        self.calls.append(spec)
+        self._active += 1
+        self.peak = max(self.peak, self._active)
+        try:
+            if self.delay:
+                await asyncio.sleep(self.delay)
+            if abort.signal.aborted:
+                return AgentOutcome(skipped=True)
+            if self.handler is not None:
+                out = self.handler(spec, index)
+                if inspect.isawaitable(out):
+                    out = await out
+                return out
+            if spec.schema is not None:
+                return AgentOutcome(structured={"echo": spec.prompt}, tokens=10)
+            return AgentOutcome(text=f"r{index}", tokens=5)
+        finally:
+            self._active -= 1
+
+    @property
+    def call_count(self) -> int:
+        return len(self.calls)
+
+
+@pytest.fixture
+def runner() -> FakeRunner:
+    return FakeRunner()
+
+
+@pytest.fixture
+def make_runner():
+    def _make(handler=None, delay: float = 0.0) -> FakeRunner:
+        return FakeRunner(handler=handler, delay=delay)
+
+    return _make
+
+
+def instance_from_schema(schema: Any) -> Any:
+    """Build a minimal value satisfying a JSON Schema (for driving demos)."""
+    if not isinstance(schema, dict):
+        return "x"
+    if "enum" in schema and schema["enum"]:
+        return schema["enum"][0]
+    stype = schema.get("type")
+    if stype == "object":
+        props = schema.get("properties", {})
+        return {key: instance_from_schema(sub) for key, sub in props.items()}
+    if stype == "array":
+        items = schema.get("items")
+        return [instance_from_schema(items)] if isinstance(items, dict) else []
+    if stype == "integer":
+        return 1
+    if stype == "number":
+        return 1.0
+    if stype == "boolean":
+        return True
+    return "x"
+
+
+@dataclass
+class SchemaFakeRunner:
+    """A runner that returns schema-derived stubs and content-bearing text, so a
+    real demo script can run end-to-end without a model."""
+
+    calls: list[AgentSpec] = field(default_factory=list)
+
+    async def run(self, spec: AgentSpec, *, abort, index: str) -> AgentOutcome:
+        self.calls.append(spec)
+        if spec.schema is not None:
+            return AgentOutcome(structured=instance_from_schema(spec.schema), tokens=10)
+        # Text with a question mark + multiple lines so line/`?`-filtering demos
+        # produce non-empty output.
+        text = "What should a buyer consider?\nFirst point\nSecond point?\nThird point?"
+        return AgentOutcome(text=text, tokens=5)
+
+
+@pytest.fixture
+def schema_runner() -> SchemaFakeRunner:
+    return SchemaFakeRunner()

--- a/tests/workflow/test_budget.py
+++ b/tests/workflow/test_budget.py
@@ -1,0 +1,54 @@
+"""Tests for the ``budget`` primitive."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from src.workflow.budget import Budget
+from src.workflow.errors import WorkflowBudgetExceeded
+
+
+def test_no_target_is_unbounded():
+    b = Budget(None)
+    assert b.total is None
+    assert b.remaining() == math.inf
+    b.add(1_000_000)
+    b.check()  # never raises
+
+
+def test_spent_and_remaining():
+    b = Budget(100)
+    assert b.spent() == 0
+    assert b.remaining() == 100
+    b.add(60)
+    assert b.spent() == 60
+    assert b.remaining() == 40
+
+
+def test_check_raises_at_ceiling():
+    b = Budget(100)
+    b.add(60)
+    b.check()  # 60 < 100, ok
+    b.add(50)  # now 110 >= 100
+    with pytest.raises(WorkflowBudgetExceeded):
+        b.check()
+
+
+def test_remaining_floors_at_zero():
+    b = Budget(50)
+    b.add(80)
+    assert b.remaining() == 0
+
+
+def test_base_spent_is_shared_pool():
+    external = {"v": 30}
+    b = Budget(100, base_spent=lambda: external["v"])
+    assert b.spent() == 30
+    b.add(50)
+    assert b.spent() == 80
+    external["v"] = 60
+    assert b.spent() == 110
+    with pytest.raises(WorkflowBudgetExceeded):
+        b.check()

--- a/tests/workflow/test_demos.py
+++ b/tests/workflow/test_demos.py
@@ -1,0 +1,80 @@
+"""Integration guard: the shipped Python demo workflows are valid against the
+engine.
+
+Every file in ``demos/workflows/*.py`` must (1) define an extractable ``meta``
+block and (2) compile as a workflow body (i.e. parse + wrap in the
+``async def __workflow_main__`` envelope). This catches regressions in the demo
+corpus and confirms the converted scripts conform to the sandbox's expectations
+without needing a live model.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from src.workflow.runtime import run_workflow
+from src.workflow.sandbox import compile_workflow, extract_meta
+
+# Exception types that indicate a *port/API* bug (vs. a demo's own input guard).
+_API_MISUSE_PREFIXES = ("TypeError", "NameError", "AttributeError", "SyntaxError", "WorkflowError")
+
+# Generous args superset so each demo finds the keys it needs and proceeds past
+# its input guards into actually spawning agents.
+_DEMO_ARGS = {
+    "keyword": "wireless earbuds",
+    "productKeyword": "wireless earbuds",
+    "topic": "wireless earbuds",
+    "brand": "Acme",
+    "productUrl": "https://example.com/product",
+    "product_url": "https://example.com/product",
+    "title": "Why Wireless Earbuds Beat Wired",
+    "count": 3,
+    "maxQuestions": 3,
+    "question": "Which wireless earbuds are best for running?",
+}
+
+_DEMO_DIR = pathlib.Path(__file__).resolve().parents[2] / "demos" / "workflows"
+_DEMO_FILES = sorted(_DEMO_DIR.glob("*.py"))
+
+
+def test_demo_corpus_present():
+    # The four converted demos (02-05) should exist.
+    names = {p.name for p in _DEMO_FILES}
+    assert _DEMO_FILES, f"no Python demos found in {_DEMO_DIR}"
+    assert any(n.startswith("02-") for n in names)
+    assert any(n.startswith("05-") for n in names)
+
+
+@pytest.mark.parametrize("path", _DEMO_FILES, ids=lambda p: p.name)
+def test_demo_has_valid_meta(path: pathlib.Path):
+    meta = extract_meta(path.read_text())
+    assert meta.name
+    assert meta.description
+    # phases, when used, are a list of dicts with titles
+    for phase in meta.phases:
+        assert isinstance(phase, dict)
+        assert phase.get("title")
+
+
+@pytest.mark.parametrize("path", _DEMO_FILES, ids=lambda p: p.name)
+def test_demo_compiles_as_workflow(path: pathlib.Path):
+    # Raises on syntax/compile error; the wrapper makes top-level await/return valid.
+    compile_workflow(path.read_text())
+
+
+@pytest.mark.parametrize("path", _DEMO_FILES, ids=lambda p: p.name)
+async def test_demo_runs_against_the_engine(path: pathlib.Path, schema_runner):
+    # Actually execute each demo through the real engine with a schema-aware
+    # fake. A genuine API-misuse / port bug (positional opts, undefined name,
+    # bad await) surfaces as a TypeError/NameError; a demo's own input guard
+    # (RuntimeError/ValueError) is acceptable. This is what compile-only can't catch.
+    runner = schema_runner
+    result = await run_workflow(path.read_text(), runner=runner, args=dict(_DEMO_ARGS), max_concurrent=4)
+    if result.error is not None:
+        prefix = result.error.split(":", 1)[0]
+        assert prefix not in _API_MISUSE_PREFIXES, f"{path.name} hit a port/API bug: {result.error}"
+    # The engine must have driven the script into execution: either it spawned
+    # agents, or it raised its own input guard — never a silent no-op.
+    assert runner.calls or result.error is not None, f"{path.name} silently did nothing"

--- a/tests/workflow/test_journal.py
+++ b/tests/workflow/test_journal.py
@@ -1,0 +1,61 @@
+"""Tests for the resume journal (call-path keying + per-key matching)."""
+
+from __future__ import annotations
+
+from src.workflow.journal import MISS, Journal, JournalRecord, fingerprint
+from src.workflow.types import AgentSpec
+
+
+def _spec(prompt="p", **kw):
+    return AgentSpec(prompt=prompt, **kw)
+
+
+def test_fingerprint_is_stable_and_distinguishing():
+    a = _spec("hello")
+    assert fingerprint(a) == fingerprint(_spec("hello"))
+    assert fingerprint(a) != fingerprint(_spec("world"))
+    assert fingerprint(_spec("p", model="opus")) != fingerprint(_spec("p", model="haiku"))
+    assert fingerprint(_spec("p", schema={"type": "object"})) != fingerprint(_spec("p"))
+
+
+def test_lookup_hit_returns_cached_result():
+    spec = _spec("x")
+    j = Journal({(0,): JournalRecord(fingerprint(spec), "cached-value")})
+    assert j.lookup((0,), spec) == "cached-value"
+
+
+def test_lookup_miss_when_fingerprint_differs():
+    j = Journal({(0,): JournalRecord(fingerprint(_spec("old")), "v")})
+    assert j.lookup((0,), _spec("new")) is MISS
+
+
+def test_per_key_independence():
+    # Path-based keys: changing one call does NOT invalidate an independent
+    # sibling at a different path (more precise than linear-prefix divergence).
+    prior = {
+        (0,): JournalRecord(fingerprint(_spec("a")), "ra"),
+        (1,): JournalRecord(fingerprint(_spec("b")), "rb"),
+        (2,): JournalRecord(fingerprint(_spec("c")), "rc"),
+    }
+    j = Journal(prior)
+    assert j.lookup((0,), _spec("a")) == "ra"        # hit
+    assert j.lookup((1,), _spec("CHANGED")) is MISS  # changed -> miss
+    assert j.lookup((2,), _spec("c")) == "rc"        # independent -> still hit
+
+
+def test_nested_path_keys_are_distinct():
+    spec = _spec("x")
+    j = Journal({(0, 1, 0): JournalRecord(fingerprint(spec), "deep")})
+    assert j.lookup((0, 1, 0), spec) == "deep"
+    assert j.lookup((0, 1, 1), spec) is MISS
+
+
+def test_record_and_roundtrip():
+    j = Journal()
+    j.record((0,), _spec("a"), {"r": 1})
+    j.record((1, 0), _spec("b"), "text")
+    assert set(j.records.keys()) == {(0,), (1, 0)}
+    restored = Journal.load(j.to_json())
+    assert restored[(0,)].result == {"r": 1}
+    assert restored[(1, 0)].result == "text"
+    assert restored[(0,)].fingerprint == fingerprint(_spec("a"))

--- a/tests/workflow/test_primitives.py
+++ b/tests/workflow/test_primitives.py
@@ -1,0 +1,64 @@
+"""Tests for the pure parallel/pipeline argument helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.workflow.errors import WorkflowError
+from src.workflow.primitives import await_item, fit_args, run_stage
+
+
+async def test_await_item_coroutine():
+    async def coro():
+        return 7
+
+    assert await await_item(coro()) == 7
+
+
+async def test_await_item_thunk_returning_coroutine():
+    async def coro():
+        return 9
+
+    assert await await_item(lambda: coro()) == 9
+
+
+async def test_await_item_thunk_returning_value():
+    assert await await_item(lambda: 5) == 5
+
+
+async def test_await_item_rejects_plain_value():
+    with pytest.raises(WorkflowError):
+        await await_item(42)
+
+
+def test_fit_args_trims_to_declared_arity():
+    assert fit_args(lambda a: a, (1, 2, 3)) == (1,)
+    assert fit_args(lambda a, b: a, (1, 2, 3)) == (1, 2)
+    assert fit_args(lambda a, b, c: a, (1, 2, 3)) == (1, 2, 3)
+
+
+def test_fit_args_varargs_gets_everything():
+    assert fit_args(lambda *xs: xs, (1, 2, 3)) == (1, 2, 3)
+
+
+def test_fit_args_zero_arg_callable_gets_nothing():
+    assert fit_args(lambda: 1, (1, 2, 3)) == ()
+
+
+def test_fit_args_uninspectable_gets_everything():
+    # Some builtins can't be signature-introspected; pass all args.
+    assert fit_args(map, (1, 2, 3)) == (1, 2, 3)
+
+
+async def test_run_stage_sync_and_async():
+    assert await run_stage(lambda prev, item, index: prev + 1, 10, 99, 0) == 11
+
+    async def astage(prev):
+        return prev * 2
+
+    assert await run_stage(astage, 4, 99, 0) == 8
+
+
+async def test_run_stage_rejects_non_callable():
+    with pytest.raises(WorkflowError):
+        await run_stage("not callable", 1, 1, 0)

--- a/tests/workflow/test_runtime.py
+++ b/tests/workflow/test_runtime.py
@@ -1,0 +1,301 @@
+"""End-to-end tests for the workflow runtime, driven by the FakeRunner."""
+
+from __future__ import annotations
+
+import src.workflow.runtime as runtime_mod
+import src.workflow.scheduler as scheduler_mod
+from src.workflow.runtime import run_workflow
+from src.workflow.types import AgentOutcome
+
+META = 'meta = {"name": "t", "description": "d"}\n'
+
+
+# ── basics ───────────────────────────────────────────────────────────────────
+
+
+async def test_basic_run_returns_value(runner):
+    res = await run_workflow(META + 'return await agent("hi")', runner=runner)
+    assert res.ok
+    assert res.value == "r0"
+    assert runner.call_count == 1
+
+
+async def test_meta_is_parsed_and_exposed(runner):
+    res = await run_workflow(
+        'meta = {"name": "named", "description": "d", "phases": [{"title": "A"}]}\nreturn 1',
+        runner=runner,
+    )
+    assert res.meta.name == "named"
+    assert res.meta.phases == [{"title": "A"}]
+
+
+async def test_bad_meta_raises_preflight(runner):
+    import pytest
+
+    from src.workflow.errors import WorkflowMetaError
+
+    with pytest.raises(WorkflowMetaError):
+        await run_workflow("return 1", runner=runner)
+
+
+async def test_script_runtime_error_is_captured(runner):
+    res = await run_workflow(META + 'raise ValueError("nope")', runner=runner)
+    assert not res.ok
+    assert "ValueError" in res.error
+    assert "nope" in res.error
+
+
+# ── agent: text vs schema, failure -> None ───────────────────────────────────
+
+
+async def test_schema_agent_returns_structured(runner):
+    res = await run_workflow(
+        META + 'return await agent("x", schema={"type": "object"})', runner=runner
+    )
+    assert res.value == {"echo": "x"}
+
+
+async def test_failed_subagent_resolves_to_none(make_runner):
+    def handler(spec, index):
+        if "boom" in spec.prompt:
+            raise RuntimeError("subagent died")
+        return AgentOutcome(text=f"ok{index}")
+
+    runner = make_runner(handler=handler)
+    res = await run_workflow(META + 'return await agent("boom")', runner=runner)
+    assert res.ok  # the run does not crash...
+    assert res.value is None  # ...the agent just resolves to None
+
+
+async def test_error_outcome_resolves_to_none(make_runner):
+    runner = make_runner(handler=lambda s, i: AgentOutcome(error="terminal"))
+    res = await run_workflow(META + 'return await agent("x")', runner=runner)
+    assert res.value is None
+
+
+# ── parallel ─────────────────────────────────────────────────────────────────
+
+
+async def test_parallel_preserves_order_and_nulls_failures(make_runner):
+    def handler(spec, index):
+        if spec.prompt == "boom":
+            raise RuntimeError("x")
+        return AgentOutcome(text=spec.prompt.upper())
+
+    runner = make_runner(handler=handler)
+    script = META + 'return await parallel([agent("a"), agent("boom"), agent("c")])'
+    res = await run_workflow(script, runner=runner)
+    assert res.value == ["A", None, "C"]
+
+
+async def test_parallel_respects_concurrency_cap(make_runner):
+    runner = make_runner(delay=0.02)
+    script = META + "return await parallel([agent(str(i)) for i in range(12)])"
+    res = await run_workflow(script, runner=runner, max_concurrent=3)
+    assert len(res.value) == 12
+    assert runner.peak <= 3
+
+
+# ── pipeline ─────────────────────────────────────────────────────────────────
+
+
+async def test_pipeline_runs_stages_per_item(runner):
+    script = META + (
+        "return await pipeline([1, 2, 3],\n"
+        "    lambda prev, item, index: prev + 1,\n"
+        "    lambda prev, item, index: prev * 10)\n"
+    )
+    res = await run_workflow(script, runner=runner)
+    assert res.value == [20, 30, 40]
+
+
+async def test_pipeline_drops_failing_item(runner):
+    script = META + (
+        "def stage(prev, item, index):\n"
+        "    if item == 2:\n"
+        "        raise ValueError('bad')\n"
+        "    return prev * 100\n"
+        "return await pipeline([1, 2, 3], stage)\n"
+    )
+    res = await run_workflow(script, runner=runner)
+    assert res.value == [100, None, 300]
+
+
+# ── caps & budget ────────────────────────────────────────────────────────────
+
+
+async def test_budget_ceiling_stops_the_run(runner):
+    # Each agent costs 5 tokens; total 8 -> the third call trips the ceiling.
+    script = META + (
+        'a = await agent("1")\n'
+        'b = await agent("2")\n'
+        'c = await agent("3")\n'
+        "return [a, b, c]\n"
+    )
+    res = await run_workflow(script, runner=runner, budget_total=8)
+    assert not res.ok
+    assert "budget" in res.error.lower()
+    assert runner.call_count == 2  # third never reached the runner
+
+
+async def test_per_call_item_cap(monkeypatch, runner):
+    monkeypatch.setattr(runtime_mod, "MAX_ITEMS_PER_CALL", 3)
+    script = META + "return await parallel([agent(str(i)) for i in range(4)])"
+    res = await run_workflow(script, runner=runner)
+    assert not res.ok
+    assert "per-call cap" in res.error
+
+
+async def test_per_run_agent_cap(monkeypatch, runner):
+    monkeypatch.setattr(scheduler_mod, "MAX_AGENTS_PER_RUN", 2)
+    script = META + (
+        'await agent("1")\n'
+        'await agent("2")\n'
+        'await agent("3")\n'
+        "return 'done'\n"
+    )
+    res = await run_workflow(script, runner=runner)
+    assert not res.ok
+    assert "per-run agent cap" in res.error
+
+
+# ── abort ────────────────────────────────────────────────────────────────────
+
+
+async def test_pre_aborted_run_stops(runner):
+    from src.utils.abort_controller import create_abort_controller
+
+    controller = create_abort_controller()
+    controller.abort("user")
+    res = await run_workflow(META + 'return await agent("x")', runner=runner, controller=controller)
+    assert not res.ok
+    assert "abort" in res.error.lower()
+    assert runner.call_count == 0  # never spawned
+
+
+# ── resume ───────────────────────────────────────────────────────────────────
+
+
+async def test_resume_replays_cached_results(make_runner):
+    script = META + (
+        'a = await agent("one")\n'
+        'b = await agent("two")\n'
+        "return [a, b]\n"
+    )
+    first = make_runner()
+    run1 = await run_workflow(script, runner=first)
+    assert first.call_count == 2
+
+    second = make_runner()
+    run2 = await run_workflow(script, runner=second, resume=run1.journal)
+    assert run2.value == run1.value
+    assert second.call_count == 0  # everything served from the journal
+
+
+async def test_resume_keys_are_deterministic_under_multiround_fanout(make_runner):
+    # Two concurrent branches, each doing a SECOND-round agent that depends on
+    # its first-round result. Regression for the spawn-order keying bug: the
+    # call-path key for "branch X's round-2 agent" must be the same no matter
+    # which branch's round-1 finished first.
+    import asyncio
+
+    script = META + (
+        "async def branch(tag):\n"
+        "    r1 = await agent('r1-' + tag)\n"
+        "    r2 = await agent('r2-' + tag + '-' + str(r1))\n"
+        "    return r2\n"
+        "return await parallel([branch('A'), branch('B')])\n"
+    )
+
+    def slow(tag):
+        async def handler(spec, index):
+            if spec.prompt.startswith("r1-") and tag in spec.prompt:
+                await asyncio.sleep(0.02)  # make this branch's round 1 finish last
+            return AgentOutcome(text="ok", tokens=1)
+
+        return handler
+
+    run_a = await run_workflow(script, runner=make_runner(handler=slow("A")))
+    run_b = await run_workflow(script, runner=make_runner(handler=slow("B")))
+
+    # Each call-path key must map to the SAME logical call (same fingerprint)
+    # regardless of which branch was slow — the heart of the fix.
+    fp_a = {k: r.fingerprint for k, r in run_a.journal.items()}
+    fp_b = {k: r.fingerprint for k, r in run_b.journal.items()}
+    assert fp_a == fp_b
+
+    # And resuming across the two timings is a full cache hit.
+    third = make_runner(handler=slow("A"))
+    run_c = await run_workflow(script, runner=third, resume=run_b.journal)
+    assert third.call_count == 0
+
+
+async def test_resume_reruns_after_divergence(make_runner):
+    base = META + 'a = await agent("one")\nb = await agent("SECOND")\nreturn [a, b]\n'
+    first = make_runner()
+    run1 = await run_workflow(base.replace("SECOND", "two"), runner=first)
+
+    second = make_runner()
+    run2 = await run_workflow(base.replace("SECOND", "CHANGED"), runner=second, resume=run1.journal)
+    # index 0 cached, index 1 changed -> exactly one live call.
+    assert second.call_count == 1
+    assert run2.value[0] == run1.value[0]  # prefix preserved
+
+
+# ── nested workflow ──────────────────────────────────────────────────────────
+
+
+async def test_nested_workflow(runner):
+    sub = 'meta = {"name": "sub", "description": "d"}\nreturn await agent("inner:" + args["q"])'
+
+    def resolve(name):
+        assert name == "sub"
+        return sub
+
+    script = META + 'return await workflow("sub", args={"q": "hello"})'
+    res = await run_workflow(script, runner=runner, resolve_workflow=resolve)
+    assert res.ok
+    # The nested run's agent sits under the parent's consumed slot -> key "0.0".
+    assert res.value == "r0.0"
+    assert runner.calls[0].prompt == "inner:hello"
+
+
+async def test_nested_workflow_depth_guard(runner):
+    inner = 'meta = {"name": "i", "description": "d"}\nreturn await workflow("x")'
+
+    def resolve(name):
+        return inner
+
+    script = META + 'return await workflow("i")'
+    res = await run_workflow(script, runner=runner, resolve_workflow=resolve)
+    assert not res.ok
+    assert "nesting is one level" in res.error
+
+
+# ── progress ─────────────────────────────────────────────────────────────────
+
+
+async def test_progress_tracks_phases_agents_and_statuses(make_runner):
+    def handler(spec, index):
+        if spec.prompt == "fail":
+            return AgentOutcome(error="x")
+        return AgentOutcome(text="ok", tokens=7)
+
+    runner = make_runner(handler=handler)
+    script = (
+        'meta = {"name": "p", "description": "d", "phases": [{"title": "One"}]}\n'
+        'phase("One")\n'
+        'log("hello")\n'
+        'await agent("ok", label="good")\n'
+        'await agent("fail", label="bad")\n'
+        "return 1\n"
+    )
+    res = await run_workflow(script, runner=runner)
+    prog = res.progress
+    assert prog.agent_count == 2
+    assert prog.token_total == 7
+    assert "hello" in prog.logs
+    statuses = {a.label: a.status for p in prog.phases for a in p.agents}
+    assert statuses["good"] == "completed"
+    assert statuses["bad"] == "failed"
+    assert any(p.title == "One" for p in prog.phases)

--- a/tests/workflow/test_sandbox.py
+++ b/tests/workflow/test_sandbox.py
@@ -1,0 +1,138 @@
+"""Tests for static ``meta`` extraction and the curated execution sandbox."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.workflow.errors import WorkflowMetaError
+from src.workflow.sandbox import execute_workflow, extract_meta
+
+
+# ── meta extraction ──────────────────────────────────────────────────────────
+
+
+def test_extract_meta_valid():
+    meta = extract_meta(
+        'meta = {"name": "x", "description": "d", '
+        '"when_to_use": "u", "phases": [{"title": "P", "detail": "dd"}], "model": "sonnet"}'
+    )
+    assert meta.name == "x"
+    assert meta.description == "d"
+    assert meta.when_to_use == "u"
+    assert meta.phases == [{"title": "P", "detail": "dd"}]
+    assert meta.model == "sonnet"
+
+
+def test_extract_meta_annotated_assignment():
+    meta = extract_meta('meta: dict = {"name": "x", "description": "d"}')
+    assert meta.name == "x"
+    assert meta.phases == []
+
+
+def test_extract_meta_missing_block():
+    with pytest.raises(WorkflowMetaError):
+        extract_meta("x = 1\n")
+
+
+def test_extract_meta_non_literal_rejected():
+    # A computed value in `meta` must not be silently executed.
+    with pytest.raises(WorkflowMetaError):
+        extract_meta('name = "n"\nmeta = {"name": name, "description": "d"}')
+
+
+def test_extract_meta_missing_required_key():
+    with pytest.raises(WorkflowMetaError):
+        extract_meta('meta = {"name": "x"}')
+
+
+def test_extract_meta_empty_required_key():
+    with pytest.raises(WorkflowMetaError):
+        extract_meta('meta = {"name": "", "description": "d"}')
+
+
+def test_extract_meta_bad_phases_type():
+    with pytest.raises(WorkflowMetaError):
+        extract_meta('meta = {"name": "x", "description": "d", "phases": "nope"}')
+
+
+def test_extract_meta_syntax_error():
+    with pytest.raises(WorkflowMetaError):
+        extract_meta("meta = {")
+
+
+# ── execution: return / raise / helpers / await ──────────────────────────────
+
+
+async def test_top_level_return_value():
+    assert await execute_workflow("return 1 + 2", {}, None) == 3
+
+
+async def test_falls_off_end_returns_none():
+    assert await execute_workflow("x = 5", {}, None) is None
+
+
+async def test_top_level_raise_propagates():
+    with pytest.raises(ValueError):
+        await execute_workflow('raise ValueError("boom")', {}, None)
+
+
+async def test_helper_def_and_await_injected_primitive():
+    async def ping(value):
+        return value * 2
+
+    body = "def double(n):\n    return n * 2\nreturn await ping(double(3))"
+    assert await execute_workflow(body, {"ping": ping}, None) == 12
+
+
+async def test_args_is_injected():
+    assert await execute_workflow("return args['k']", {}, {"k": 42}) == 42
+
+
+# ── sandbox restrictions ─────────────────────────────────────────────────────
+
+
+async def test_json_available_as_global_without_import():
+    assert await execute_workflow('return json.dumps({"a": 1})', {}, None) == '{"a": 1}'
+
+
+async def test_math_and_re_available():
+    assert await execute_workflow("return math.floor(3.9)", {}, None) == 3
+    assert await execute_workflow('return re.sub(r"a", "b", "aaa")', {}, None) == "bbb"
+
+
+async def test_import_json_allowed():
+    assert await execute_workflow("import json\nreturn json.dumps([1, 2])", {}, None) == "[1, 2]"
+
+
+async def test_import_os_blocked():
+    with pytest.raises(ImportError):
+        await execute_workflow("import os\nreturn os.getcwd()", {}, None)
+
+
+async def test_import_subprocess_blocked():
+    with pytest.raises(ImportError):
+        await execute_workflow("import subprocess\nreturn 1", {}, None)
+
+
+async def test_open_is_unavailable():
+    with pytest.raises(NameError):
+        await execute_workflow('return open("/etc/passwd")', {}, None)
+
+
+async def test_eval_is_unavailable():
+    with pytest.raises(NameError):
+        await execute_workflow('return eval("1+1")', {}, None)
+
+
+async def test_time_excluded_for_determinism():
+    # Not importable...
+    with pytest.raises(ImportError):
+        await execute_workflow("import time\nreturn time.time()", {}, None)
+    # ...and not a pre-bound global either.
+    with pytest.raises(NameError):
+        await execute_workflow("return time.time()", {}, None)
+
+
+async def test_random_excluded_for_determinism():
+    with pytest.raises(ImportError):
+        await execute_workflow("import random\nreturn random.random()", {}, None)

--- a/tests/workflow/test_scheduler.py
+++ b/tests/workflow/test_scheduler.py
@@ -1,0 +1,58 @@
+"""Tests for the bounded-concurrency scheduler and per-run agent cap."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import src.workflow.scheduler as scheduler_mod
+from src.workflow.errors import WorkflowLimitError
+from src.workflow.scheduler import Scheduler
+
+
+def test_reserve_assigns_sequential_indices():
+    sched = Scheduler(max_concurrent=4)
+    assert [sched.reserve() for _ in range(3)] == [0, 1, 2]
+    assert sched.launched == 3
+
+
+def test_reserve_enforces_per_run_cap(monkeypatch):
+    monkeypatch.setattr(scheduler_mod, "MAX_AGENTS_PER_RUN", 2)
+    sched = Scheduler(max_concurrent=4)
+    sched.reserve()
+    sched.reserve()
+    with pytest.raises(WorkflowLimitError):
+        sched.reserve()
+
+
+async def test_slot_caps_concurrency():
+    sched = Scheduler(max_concurrent=3)
+    active = 0
+    peak = 0
+
+    async def worker():
+        nonlocal active, peak
+        async with sched.slot():
+            active += 1
+            peak = max(peak, active)
+            await asyncio.sleep(0.01)
+            active -= 1
+
+    await asyncio.gather(*(worker() for _ in range(20)))
+    assert peak <= 3
+    assert sched.peak_concurrency <= 3
+
+
+async def test_slot_releases_on_exception():
+    sched = Scheduler(max_concurrent=1)
+
+    async def boom():
+        async with sched.slot():
+            raise RuntimeError("x")
+
+    with pytest.raises(RuntimeError):
+        await boom()
+    # The single slot must be free again afterwards.
+    async with sched.slot():
+        pass

--- a/tests/workflow/test_structured.py
+++ b/tests/workflow/test_structured.py
@@ -1,0 +1,102 @@
+"""Tests for schema-validated structured output."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.workflow.structured import (
+    StructuredOutputCollector,
+    make_structured_output_tool,
+    validate_structured,
+)
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+    "required": ["name", "age"],
+    "additionalProperties": False,
+}
+
+
+def test_validate_structured_ok():
+    ok, err = validate_structured({"name": "x", "age": 3}, _SCHEMA)
+    assert ok is True
+    assert err is None
+
+
+def test_validate_structured_missing_required():
+    ok, err = validate_structured({"name": "x"}, _SCHEMA)
+    assert ok is False
+    assert "age" in err
+
+
+def test_validate_structured_wrong_type():
+    ok, err = validate_structured({"name": "x", "age": "old"}, _SCHEMA)
+    assert ok is False
+    assert "age" in err
+
+
+def test_collector_accepts_valid():
+    c = StructuredOutputCollector(schema=_SCHEMA)
+    accepted, err = c.offer({"name": "x", "age": 3})
+    assert accepted is True
+    assert err is None
+    assert c.succeeded is True
+    assert c.value == {"name": "x", "age": 3}
+    assert c.exhausted is False
+
+
+def test_collector_retries_then_exhausts():
+    c = StructuredOutputCollector(schema=_SCHEMA, max_retries=2)
+    accepted, err = c.offer({"name": "x"})  # attempt 1 — invalid
+    assert accepted is False and err is not None
+    assert c.succeeded is False
+    assert c.exhausted is False
+    c.offer({"name": "x"})  # attempt 2 — invalid -> now exhausted
+    assert c.attempts == 2
+    assert c.exhausted is True
+    assert c.succeeded is False
+
+
+def test_collector_recovers_before_exhaustion():
+    c = StructuredOutputCollector(schema=_SCHEMA, max_retries=3)
+    c.offer({"bad": 1})  # invalid
+    accepted, _ = c.offer({"name": "ok", "age": 1})  # valid
+    assert accepted is True
+    assert c.succeeded is True
+    assert c.exhausted is False
+
+
+# ── the injected StructuredOutput tool (bridges to the real tool system) ──────
+
+
+def test_structured_tool_accepts_valid_and_captures():
+    collector = StructuredOutputCollector(schema=_SCHEMA)
+    tool = make_structured_output_tool(collector)
+    ctx = SimpleNamespace(outbox=[])
+    result = tool.call({"name": "x", "age": 5}, ctx)
+    assert not result.is_error
+    assert collector.value == {"name": "x", "age": 5}
+    assert ctx.outbox == [{"tool": "StructuredOutput", "structured_output": {"name": "x", "age": 5}}]
+
+
+def test_structured_tool_rejects_invalid_as_error():
+    collector = StructuredOutputCollector(schema=_SCHEMA)
+    tool = make_structured_output_tool(collector)
+    ctx = SimpleNamespace(outbox=[])
+    result = tool.call({"name": "x"}, ctx)  # missing age
+    assert result.is_error
+    assert "schema" in result.output["data"].lower()
+    assert collector.attempts == 1
+    assert collector.succeeded is False
+    assert ctx.outbox == []  # nothing captured on failure
+
+
+def test_structured_tool_reports_exhaustion():
+    collector = StructuredOutputCollector(schema=_SCHEMA, max_retries=1)
+    tool = make_structured_output_tool(collector)
+    ctx = SimpleNamespace(outbox=[])
+    result = tool.call({"name": "x"}, ctx)  # invalid, and max_retries=1 -> exhausted
+    assert result.is_error
+    assert "after 1 attempts" in result.output["data"]
+    assert collector.exhausted is True


### PR DESCRIPTION
## Summary

Adds the **dynamic workflow engine core** — a deterministic multi-agent orchestrator that runs a model-authored **Python** workflow script in a sandbox, fanning out bounded-concurrency subagent calls. Implements the spec in `docs/workflow-engine.md`.

This is **port-plan Phases 1–4 (the engine core)** plus the `LiveAgentRunner` production seam. It is intentionally **not yet user-reachable**: the integration half (Workflow tool, `LocalWorkflowTask`, `/workflows` TUI, command discovery + `/deep-research`, permission wiring, `disable_workflows` gating, journal disk-persistence, worktrees = Phases 5–9) is a follow-up. Full status table: `docs/workflow-engine-port-plan.md` §10.

## What's included

- **`src/workflow/`** (13 modules) — `ast` `meta` extraction + curated `exec` sandbox (exposes `json`/`re`/`math`; withholds `time`/`random`/`datetime` for resume determinism); `asyncio.Semaphore` scheduler with ≤16-concurrent / 1000-per-run / 4096-per-call caps; token `budget` ceiling; `agent`/`parallel`/`pipeline`/`phase`/`log`/`workflow` primitives; schema-validated structured output built on the real `build_tool`; a deterministic call-path resume journal; and the `LiveAgentRunner` seam over `run_agent` + `finalize_agent_tool`.
- **`demos/workflows/*.py`** — the four upstream JS demos ported to Python (the real-usage corpus the API targets), alongside their `.js` originals.
- **`tests/workflow/`** — 90 tests.
- **`docs/`** — feature spec + Python port plan.

## Design notes

- Workflow scripts are **Python** (not JS) — executed via curated `exec` with injected async globals; the behaviorally-faithful, idiomatic choice for a Python host.
- Resume is keyed by **deterministic structural call-paths**, not spawn order, so caching is correct even under concurrent multi-round fan-out (adversarial-verify / judge-panel patterns). This was a critical bug surfaced by an adversarial review and fixed here, with a regression test.
- The subagent-spawning seam (`AgentRunner`) is dependency-injected — which is what makes the engine unit-testable without a live model.

## Testing

`.venv/bin/python -m pytest tests/workflow/ -q` → **90 passed**. Covers sandbox, scheduler, budget, journal (incl. multi-round resume determinism), structured-output validation/retry, primitives, end-to-end runtime, and all four demos executed through the engine.

## Review

An adversarial critic pass found and (in this PR) fixed a critical resume-keying bug. Remaining items — live integration testing of `LiveAgentRunner`, budget shared-pool wiring — are documented as part of the Phase 5–9 integration follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
