### PR TITLE
Wire dynamic workflows end-to-end (Phases 5-9)

### DIFF
--- a/docs/workflow-engine-port-plan.md
+++ b/docs/workflow-engine-port-plan.md
@@ -293,15 +293,42 @@ designed to accept this port.
 | `runner.py` (`LiveAgentRunner`) | production seam: `run_agent` + `finalize_agent_tool` + structured tool | ⚠️ structured tool unit-tested; `run_agent` composition needs **live integration test** |
 | `demos/workflows/*.py` | the four JS demos ported to Python; run end-to-end against the engine | ✅ `test_demos.py` |
 
-**Deferred (plan Phases 5–9: integration — not yet built).** None of these exist yet, so the feature
-is not user-reachable: the Workflow tool (`src/tool_system/tools/workflow.py`), `LocalWorkflowTask`,
-the `/workflows` TUI + pill, command discovery + `/deep-research`, the permission renderer +
-auto-mode allowlist, the `disable_workflows` gating, **journal disk-persistence** (`Journal.to_json`/
-`load` exist and are tested but no caller writes them to the session dir yet — so resume currently
-works only in-process), and worktree-per-agent. `LiveAgentRunner` is constructed nowhere yet.
+**Built (plan Phases 5–9: integration) — the feature is now user-reachable behind the gate.**
 
-**Known integration wiring (when Phases 5–9 land):** pass `Budget(base_spent=get_total_cost_usd)` so
-the ceiling counts the shared pool (§4.4); pass a `ProgressTracker` to `finalize_agent_tool` for
-token parity; expose each run's per-agent controllers (already reachable via `WorkflowRun.abort_agent`)
-to the task layer for `x`/`r`; add the live structured-output integration test (schema agent returns a
-validated object; malformed → retry → `None` at the cap).
+| Piece | Module | Tested |
+|---|---|---|
+| Gating + constants | `src/workflow/gating.py`, `disable_workflows` setting, `CLAUDE_CODE_DISABLE_WORKFLOWS`, `WORKFLOW_TOOL_NAME` (+ recursion guard) | ✅ |
+| Background task (Phase 5) | `src/tasks/local_workflow.py` (state, lifecycle, `kill`/`skip`/`retry` API), registered; pill `src/tasks/pill_label.py` | ✅ |
+| Workflow tool (entry) | `src/tool_system/tools/workflow.py` + `src/workflow/launch.py`; registered (gated) in `defaults.py` | ✅ |
+| Commands (Phase 7) | `src/command_system/workflows_integration.py` (discovery + `/deep-research`) + `workflows_command.py` (`/workflows`), spliced into the aggregator | ✅ |
+| Permissions (Phase 8) | `auto_mode_classify` Workflow branch; subagents forced `acceptEdits` in `LiveAgentRunner` | ✅ (classify) |
+| Resume persistence (Phase 9) | `Journal` persisted to the run's file; `resume_from_run_id` reloads it | ✅ |
+| Bundled workflow | `src/workflow/bundled/deep_research.py` (real fan-out → cross-check → cited report) | ✅ |
+
+**Remaining polish (not blocking; documented honestly):**
+- **Rich `/workflows` TUI dialog** — the headless `/workflows` list + the pill label are built and
+  tested; the Textual phases→agents drill-down with the `p`/`x`/`r`/`s` bindings is not (it builds on
+  the `/tasks` panel, which is itself a broken stub — `REPLScreen.focus_task_panel` is missing). The
+  per-run/agent control API it needs already exists (`kill_workflow_task`/`skip_workflow_agent`).
+- **Live pill wiring** — `workflow_pill_label` is tested; threading `runtime_tasks` onto the live
+  `StatusLine` is a small TUI edit not yet made.
+- **`retry_workflow_agent`** reports "unsupported" — re-spawning one agent mid-run needs engine support.
+- **Budget shared-pool / ProgressTracker** — `LiveAgentRunner` builds `RunAgentParams` correctly but
+  isn't wired to `Budget(base_spent=get_total_cost_usd)` / a `ProgressTracker`; do this when the tool
+  constructs the run with the real provider.
+- **Worktree-per-agent** (`wf_<runId>-<idx>`) — `isolation="worktree"` currently runs in-place.
+- **Live integration test** — `LiveAgentRunner`'s `run_agent` composition needs a real/recorded model
+  (the structured-output tool and the whole engine + launcher are unit-tested with a fake runner).
+- **Result delivery** — the final result is captured on the task (`complete_workflow_task`) and shown
+  by `/workflows`; auto-injecting the report back into the conversation on completion (the
+  async-agent `enqueue_*_notification` path) is a follow-up.
+- **Run-file location** — run journals are written under `<cwd>/.clawcodex/workflows/<run_id>.json`
+  (resume reads the same path; internally consistent). The spec's location is
+  `~/.claude/projects/<session>/`; aligning to the session dir is a deliberate, deferred change.
+
+**Hardening (post adversarial review).** Fixed before merge: the background launch now runs on a
+dedicated daemon thread (`task_manager.start`) so the run outlives the throwaway `asyncio.run`
+dispatch loop — with a production-topology regression test; schema subagents now go through
+`resolve_agent_tools` (firewall + scoping, `Workflow` stripped — no recursion) before the injected
+`StructuredOutput` tool, instead of receiving the full base pool; and `run_agent` now honors
+`permission_mode_override`, so the `acceptEdits` guarantee for workflow subagents is actually applied.

--- a/src/agent/constants.py
+++ b/src/agent/constants.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 # --- Tool name constants ---
 AGENT_TOOL_NAME = "Agent"
 LEGACY_AGENT_TOOL_NAME = "Task"
+WORKFLOW_TOOL_NAME = "Workflow"
 
 # --- Built-in agent type identifiers ---
 VERIFICATION_AGENT_TYPE = "verification"
@@ -28,6 +29,8 @@ ALL_AGENT_DISALLOWED_TOOLS: frozenset[str] = frozenset([
     "ExitPlanMode",
     "EnterPlanMode",
     AGENT_TOOL_NAME,
+    # Prevent recursive workflow execution inside subagents.
+    WORKFLOW_TOOL_NAME,
     "AskUserQuestion",
     "TaskStop",
     "Brief",

--- a/src/agent/run_agent.py
+++ b/src/agent/run_agent.py
@@ -235,8 +235,10 @@ async def run_agent(params: RunAgentParams) -> AsyncGenerator[Message, None]:
     start_time = time.time()
     agent_messages: list[Message] = []
 
-    # Resolve permission mode
-    effective_mode = resolve_permission_mode(
+    # Resolve permission mode. An explicit ``permission_mode_override`` wins
+    # (used by the workflow engine to force ``acceptEdits`` for its subagents);
+    # otherwise fall back to the inheritance rules.
+    effective_mode = params.permission_mode_override or resolve_permission_mode(
         params.parent_context,
         agent_def,
         is_async=params.is_async,

--- a/src/command_system/aggregator.py
+++ b/src/command_system/aggregator.py
@@ -68,6 +68,21 @@ def _load_skill_commands_cached(cwd: str) -> tuple[Command, ...]:
         return ()
 
 
+@lru_cache(maxsize=32)
+def _load_workflow_commands_cached(cwd: str) -> tuple[Command, ...]:
+    """Bundled + discovered workflow commands for ``cwd`` (cached by cwd).
+
+    Commands carry ``is_enabled=is_workflows_enabled`` so they're filtered out
+    fresh by ``get_commands`` when workflows are disabled, without busting the
+    discovery cache. Failures degrade to an empty tuple (non-critical)."""
+    try:
+        from .workflows_integration import load_workflow_commands
+        return tuple(load_workflow_commands(cwd))
+    except Exception as exc:  # noqa: BLE001 — workflows are non-critical
+        logger.debug("workflow command loading failed for %s: %s", cwd, exc)
+        return ()
+
+
 def get_commands(
     cwd: str | Path | None = None,
     *,
@@ -88,6 +103,7 @@ def get_commands(
     # Builtins fresh (re-evaluates conditional appends); skills cached by cwd.
     all_commands: list[Command] = [
         *get_builtin_commands(),
+        *_load_workflow_commands_cached(cwd_key),
         *_load_skill_commands_cached(cwd_key),
     ]
 
@@ -223,5 +239,6 @@ def clear_commands_cache() -> None:
     purpose so the aggregator doesn't reach across into the prompt layer.
     """
     _load_skill_commands_cached.cache_clear()
+    _load_workflow_commands_cached.cache_clear()
     get_skill_tool_commands.cache_clear()
     get_slash_command_tool_skills.cache_clear()

--- a/src/command_system/workflows_command.py
+++ b/src/command_system/workflows_command.py
@@ -1,0 +1,63 @@
+"""``/workflows`` — list running and recent dynamic-workflow runs.
+
+The headless-capable core of the workflow view (mirrors ``/tasks``): reads the
+shared ``runtime_tasks`` registry and reports each ``local_workflow`` task with
+its status, name, and live progress summary. Works on every surface without
+touching ``ctx.ui``.
+
+The rich TUI drill-down (phases → agents with the ``p``/``x``/``r``/``s`` key
+bindings from the spec) is a follow-up; the per-run/per-agent control API it
+needs already exists (``kill_workflow_task`` / ``skip_workflow_agent`` /
+``retry_workflow_agent`` in ``src/tasks/local_workflow.py``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.workflow.gating import is_workflows_enabled
+
+from .types import CommandContext, InteractiveCommand, InteractiveOutcome
+
+
+def _format_workflow(t: Any) -> str:
+    status = getattr(t, "status", "?") or "?"
+    name = getattr(t, "workflow_name", "") or "workflow"
+    summary = getattr(t, "summary", None) or ""
+    run_id = getattr(t, "run_id", "") or ""
+    tail = f" — {summary}" if summary else ""
+    return f"[{status}] {name}{tail} (run: {run_id})"
+
+
+@dataclass(frozen=True)
+class WorkflowsCommand(InteractiveCommand):
+    async def run(self, args: str, context: CommandContext) -> InteractiveOutcome:
+        tc = getattr(context, "tool_context", None)
+        registry = getattr(tc, "runtime_tasks", None) if tc is not None else None
+        if registry is None:
+            return InteractiveOutcome(
+                message="Workflows are unavailable on this surface.", display="system"
+            )
+        try:
+            runs = [t for t in registry.all() if getattr(t, "type", None) == "local_workflow"]
+        except Exception:
+            runs = []
+        if not runs:
+            return InteractiveOutcome(
+                message="No workflow runs. Start one with /deep-research or by asking for a workflow.",
+                display="system",
+            )
+        lines = [f"• {_format_workflow(t)}" for t in runs]
+        return InteractiveOutcome(message="Workflows:\n" + "\n".join(lines), display="system")
+
+
+WORKFLOWS_COMMAND = WorkflowsCommand(
+    name="workflows",
+    description="List running and recent dynamic workflows",
+    is_enabled=is_workflows_enabled,
+    kind="workflow",
+)
+
+
+__all__ = ["WORKFLOWS_COMMAND", "WorkflowsCommand"]

--- a/src/command_system/workflows_integration.py
+++ b/src/command_system/workflows_integration.py
@@ -1,0 +1,109 @@
+"""Contribute saved + bundled workflows as slash commands.
+
+Discovers ``.claude/workflows/*.py`` (project) and ``~/.claude/workflows/*.py``
+(personal), plus the bundled ``/deep-research``, and turns each into a
+``PromptCommand`` (``kind="workflow"``) that directs the model to launch it via
+the Workflow tool. Project workflows win over personal ones on a name clash.
+
+Mirrors the skills-integration pattern (``skills_integration.py``); failures
+degrade to fewer commands rather than breaking command listing.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from src.workflow.bundled import bundled_workflow_path
+from src.workflow.gating import is_workflows_enabled
+from src.workflow.sandbox import extract_meta
+
+from .types import Command, PromptCommand
+
+logger = logging.getLogger(__name__)
+
+
+def _directive(name: str, path: str) -> str:
+    return (
+        f'Launch the dynamic workflow "{name}" — do NOT do the work yourself. '
+        f"Call the Workflow tool with `script_path` set to \"{path}\" and pass the "
+        f"user's input as `args` (parse it as JSON if it looks structured, otherwise "
+        f"pass it as a string):\n\n$ARGUMENTS"
+    )
+
+
+def _workflow_to_command(path: Path, loaded_from: str) -> Optional[PromptCommand]:
+    try:
+        meta = extract_meta(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 — a bad file shouldn't break listing
+        logger.debug("skipping invalid workflow %s: %s", path, exc)
+        return None
+    name = path.stem
+    return PromptCommand(
+        name=name,
+        description=meta.description,
+        kind="workflow",
+        loaded_from=loaded_from,
+        source=loaded_from,
+        is_enabled=is_workflows_enabled,
+        argument_hint="[args]",
+        when_to_use=meta.when_to_use or None,
+        markdown_content=_directive(name, str(path)),
+    )
+
+
+def _deep_research_command() -> Optional[PromptCommand]:
+    path = bundled_workflow_path("deep_research")
+    try:
+        meta = extract_meta(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("bundled deep-research unavailable: %s", exc)
+        return None
+    return PromptCommand(
+        name="deep-research",
+        description=meta.description,
+        kind="workflow",
+        loaded_from="bundled",
+        source="bundled",
+        is_enabled=is_workflows_enabled,
+        argument_hint="<question>",
+        markdown_content=_directive("deep-research", str(path)),
+    )
+
+
+def _discover_dir(directory: Path, loaded_from: str) -> list[PromptCommand]:
+    commands: list[PromptCommand] = []
+    try:
+        if not directory.is_dir():
+            return commands
+        for path in sorted(directory.glob("*.py")):
+            cmd = _workflow_to_command(path, loaded_from)
+            if cmd is not None:
+                commands.append(cmd)
+    except OSError as exc:
+        logger.debug("workflow discovery failed for %s: %s", directory, exc)
+    return commands
+
+
+def load_workflow_commands(cwd: str) -> list[Command]:
+    """The ``/workflows`` view + bundled + project + personal workflow commands
+    (project wins over personal on a name clash)."""
+    from .workflows_command import WORKFLOWS_COMMAND
+
+    commands: list[Command] = [WORKFLOWS_COMMAND]
+    deep = _deep_research_command()
+    if deep is not None:
+        commands.append(deep)
+
+    # Project first so it reserves the name before the personal copy.
+    project = _discover_dir(Path(cwd) / ".claude" / "workflows", "project")
+    personal = _discover_dir(Path.home() / ".claude" / "workflows", "user")
+
+    seen = {c.name for c in commands}
+    for cmd in [*project, *personal]:
+        if cmd.name in seen:
+            continue
+        seen.add(cmd.name)
+        commands.append(cmd)
+    return commands

--- a/src/permissions/check.py
+++ b/src/permissions/check.py
@@ -483,6 +483,11 @@ def auto_mode_classify(
     if tool_name == "Agent":
         return AutoModeDecision(allow=True, reason="agent tool")
 
+    if tool_name == "Workflow":
+        # Workflow orchestration is safe to auto-allow — each subagent it spawns
+        # goes through canUseTool individually.
+        return AutoModeDecision(allow=True, reason="workflow orchestrator")
+
     if tool_name.startswith("mcp__"):
         return AutoModeDecision(allow=False, reason="MCP tools require explicit approval")
 

--- a/src/reference_data/ts_agent_constants.json
+++ b/src/reference_data/ts_agent_constants.json
@@ -7,6 +7,7 @@
     "ExitPlanMode",
     "EnterPlanMode",
     "Agent",
+    "Workflow",
     "AskUserQuestion",
     "TaskStop",
     "Brief"

--- a/src/settings/types.py
+++ b/src/settings/types.py
@@ -144,6 +144,10 @@ class SettingsSchema:
     # Fast mode (use small model)
     fast_mode: bool = False
 
+    # Disable dynamic workflows (also honored via CLAUDE_CODE_DISABLE_WORKFLOWS
+    # and the camelCase ``disableWorkflows`` JSON key). See src/workflow/gating.py.
+    disable_workflows: bool = False
+
     # Session retention days
     session_retention_days: int = 30
 

--- a/src/tasks/__init__.py
+++ b/src/tasks/__init__.py
@@ -36,12 +36,14 @@ from src.tasks.in_process_teammate import (
 )
 from src.tasks.local_agent import LocalAgentTask, LocalAgentTaskState
 from src.tasks.local_shell import LocalShellTask, LocalShellTaskState
+from src.tasks.local_workflow import LocalWorkflowTask, LocalWorkflowTaskState
 
 # N1 (Chunk C) — centralized registration. Idempotent (``register_task``
 # rejects duplicates), so importing ``src.tasks`` multiple times is safe.
 register_task(LocalShellTask())
 register_task(LocalAgentTask())
 register_task(InProcessTeammateTask())
+register_task(LocalWorkflowTask())
 
 __all__ = [
     "InProcessTeammateTask",
@@ -50,4 +52,6 @@ __all__ = [
     "LocalAgentTaskState",
     "LocalShellTask",
     "LocalShellTaskState",
+    "LocalWorkflowTask",
+    "LocalWorkflowTaskState",
 ]

--- a/src/tasks/local_workflow.py
+++ b/src/tasks/local_workflow.py
@@ -1,0 +1,197 @@
+"""``local_workflow`` task type — surfaces a running workflow as a background task.
+
+Mirrors the ``local_agent`` lifecycle (``src/tasks/local_agent.py``) but for a
+whole workflow run. The state holds a live reference to the engine's
+``WorkflowRun`` (loose-typed to avoid an import cycle) and its
+``WorkflowProgress`` snapshot; the named API reaches through the run to stop the
+whole workflow (``kill_workflow_task``) or one in-flight agent
+(``skip_workflow_agent``) via the per-agent abort controllers the engine
+exposes. ``retry_workflow_agent`` is reserved — re-spawning a single agent
+mid-run needs engine support that does not exist yet, so it currently reports
+"unsupported" rather than silently doing nothing.
+
+All mutations route through ``registry.update`` with synchronous mutators
+(the A6/C5 contract: never await under the registry lock).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field, replace
+from typing import Any, Literal, TYPE_CHECKING
+
+from src.tasks_core import TaskStateBase, is_terminal_task_status
+
+if TYPE_CHECKING:
+    from src.task_registry import RuntimeTaskRegistry
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(kw_only=True)
+class LocalWorkflowTaskState(TaskStateBase):
+    type: Literal["local_workflow"] = "local_workflow"  # type: ignore[assignment]
+    run_id: str = ""
+    workflow_name: str = ""
+    summary: str | None = None
+    #: Live ``WorkflowProgress`` (mutated in place by the engine) — the TUI reads
+    #: phases/agents/tokens off it. Loose-typed to avoid importing the engine.
+    progress: Any = field(default=None, compare=False)
+    #: The live ``WorkflowRun``, used to reach per-agent / run abort controllers.
+    run: Any = field(default=None, repr=False, compare=False)
+    result: Any = None
+    error: str | None = None
+    is_backgrounded: bool = True
+    is_paused: bool = False
+    retain: bool = False
+    evict_after: float | None = None
+
+
+def is_local_workflow_task(state: Any) -> bool:
+    return isinstance(state, LocalWorkflowTaskState)
+
+
+# ── lifecycle ─────────────────────────────────────────────────────────────────
+
+
+def register_workflow_task(
+    *,
+    task_id: str,
+    run_id: str,
+    workflow_name: str,
+    description: str,
+    output_file: str,
+    progress: Any,
+    run: Any,
+    registry: "RuntimeTaskRegistry",
+    tool_use_id: str | None = None,
+) -> LocalWorkflowTaskState:
+    import time
+
+    state = LocalWorkflowTaskState(
+        id=task_id,
+        type="local_workflow",
+        status="running",
+        description=description,
+        start_time=time.time(),
+        output_file=output_file,
+        tool_use_id=tool_use_id,
+        run_id=run_id,
+        workflow_name=workflow_name,
+        progress=progress,
+        run=run,
+        summary=_safe_summary(progress),
+    )
+    registry.upsert(state)
+    return state
+
+
+def update_workflow_summary(task_id: str, registry: "RuntimeTaskRegistry") -> None:
+    """Refresh the cached one-line summary from the live progress snapshot."""
+
+    def _update(prev: TaskStateBase) -> TaskStateBase:
+        if not isinstance(prev, LocalWorkflowTaskState) or is_terminal_task_status(prev.status):
+            return prev
+        return replace(prev, summary=_safe_summary(prev.progress))
+
+    registry.update(task_id, _update)
+
+
+def _terminal_replace(prev: LocalWorkflowTaskState, *, status: str, **extras: Any) -> TaskStateBase:
+    import time
+
+    from src.tasks.eviction import PANEL_GRACE_SECONDS, schedule_eviction
+
+    moment = time.time()
+    transitioned = replace(prev, status=status, end_time=moment, **extras)
+    return schedule_eviction(transitioned, grace_seconds=PANEL_GRACE_SECONDS, now=moment)
+
+
+def complete_workflow_task(task_id: str, *, result: Any, registry: "RuntimeTaskRegistry") -> None:
+    def _complete(prev: TaskStateBase) -> TaskStateBase:
+        if not isinstance(prev, LocalWorkflowTaskState) or is_terminal_task_status(prev.status):
+            return prev
+        return _terminal_replace(prev, status="completed", result=result, summary=_safe_summary(prev.progress))
+
+    registry.update(task_id, _complete)
+
+
+def fail_workflow_task(task_id: str, *, error: str, registry: "RuntimeTaskRegistry") -> None:
+    def _fail(prev: TaskStateBase) -> TaskStateBase:
+        if not isinstance(prev, LocalWorkflowTaskState) or is_terminal_task_status(prev.status):
+            return prev
+        return _terminal_replace(prev, status="failed", error=error)
+
+    registry.update(task_id, _fail)
+
+
+def kill_workflow_task(task_id: str, registry: "RuntimeTaskRegistry") -> None:
+    """Abort the whole run (cascades to every subagent) and mark it killed."""
+    captured_run: Any = None
+
+    def _kill(prev: TaskStateBase) -> TaskStateBase:
+        nonlocal captured_run
+        if not isinstance(prev, LocalWorkflowTaskState) or is_terminal_task_status(prev.status):
+            return prev
+        captured_run = prev.run
+        return _terminal_replace(prev, status="killed")
+
+    registry.update(task_id, _kill)
+    # Abort OUTSIDE the registry lock (the controller fires listeners).
+    if captured_run is not None:
+        try:
+            captured_run.controller.abort("workflow_stopped")
+        except Exception:
+            logger.exception("failed to abort workflow run %s", task_id)
+
+
+def skip_workflow_agent(task_id: str, agent_key: str, registry: "RuntimeTaskRegistry") -> bool:
+    """Stop one in-flight agent by its call-path key; it resolves to ``None`` in
+    the script. Returns whether a live agent was found."""
+    state = registry.get(task_id)
+    if not isinstance(state, LocalWorkflowTaskState) or state.run is None:
+        return False
+    try:
+        return bool(state.run.abort_agent(agent_key))
+    except Exception:
+        logger.exception("failed to skip agent %s in workflow %s", agent_key, task_id)
+        return False
+
+
+def retry_workflow_agent(task_id: str, agent_key: str, registry: "RuntimeTaskRegistry") -> bool:
+    """Reserved: re-spawning a single agent mid-run needs engine support that
+    does not exist yet. Reports unsupported rather than silently no-op'ing."""
+    logger.info("retry_workflow_agent is not yet supported (task=%s agent=%s)", task_id, agent_key)
+    return False
+
+
+def _safe_summary(progress: Any) -> str | None:
+    try:
+        return progress.summary() if progress is not None else None
+    except Exception:
+        return None
+
+
+# ── Task adapter ──────────────────────────────────────────────────────────────
+
+
+class LocalWorkflowTask:
+    name: str = "LocalWorkflowTask"
+    type: Literal["local_workflow"] = "local_workflow"
+
+    async def kill(self, task_id: str, registry: "RuntimeTaskRegistry") -> None:
+        kill_workflow_task(task_id, registry)
+
+
+__all__ = [
+    "LocalWorkflowTaskState",
+    "LocalWorkflowTask",
+    "is_local_workflow_task",
+    "register_workflow_task",
+    "update_workflow_summary",
+    "complete_workflow_task",
+    "fail_workflow_task",
+    "kill_workflow_task",
+    "skip_workflow_agent",
+    "retry_workflow_agent",
+]

--- a/src/tasks/pill_label.py
+++ b/src/tasks/pill_label.py
@@ -1,0 +1,45 @@
+"""Footer/status pill label for running background tasks.
+
+Port of ``typescript/src/tasks/pillLabel.ts``. The TUI's status line uses this
+to render the "N background workflows" indicator. Kept dependency-free so any
+widget can import it without pulling the task graph.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from src.tasks_core import TaskStateBase, TaskType, is_terminal_task_status
+
+_RUNNING = ("running", "pending")
+
+
+def _running_counts(tasks: list[TaskStateBase]) -> Counter[TaskType]:
+    counts: Counter[TaskType] = Counter()
+    for task in tasks:
+        if not is_terminal_task_status(task.status) and task.status in _RUNNING:
+            if not getattr(task, "is_backgrounded", True):
+                continue
+            counts[task.type] += 1
+    return counts
+
+
+def workflow_pill_label(tasks: list[TaskStateBase]) -> str | None:
+    """The 'N background workflow(s)' pill, or None when none are running."""
+    n = _running_counts(tasks).get("local_workflow", 0)
+    if n == 0:
+        return None
+    return "1 background workflow" if n == 1 else f"{n} background workflows"
+
+
+def background_task_pill(tasks: list[TaskStateBase]) -> str | None:
+    """A combined pill across background task types (workflows first)."""
+    counts = _running_counts(tasks)
+    parts: list[str] = []
+    label = workflow_pill_label(tasks)
+    if label:
+        parts.append(label)
+    agents = counts.get("local_agent", 0)
+    if agents:
+        parts.append(f"{agents} background agent" + ("" if agents == 1 else "s"))
+    return " · ".join(parts) if parts else None

--- a/src/tool_system/defaults.py
+++ b/src/tool_system/defaults.py
@@ -23,4 +23,13 @@ def build_default_registry(
         )
     )
     registry.register(make_tool_search_tool(registry))
+
+    # Dynamic workflows. Registered unconditionally (like the Agent tool, which
+    # also needs the registry + provider); the tool's ``is_enabled`` is the
+    # single runtime gate (``get_tools`` filters by it fresh), so a ``/config``
+    # toggle of ``disable_workflows`` takes effect without rebuilding the registry.
+    from .tools.workflow import make_workflow_tool
+
+    registry.register(make_workflow_tool(registry, provider=provider))
+
     return registry

--- a/src/tool_system/tools/workflow.py
+++ b/src/tool_system/tools/workflow.py
@@ -1,0 +1,188 @@
+"""The Workflow tool — entry point for dynamic multi-agent workflows.
+
+A factory (like ``make_agent_tool``) that captures the tool ``registry`` and
+``provider`` so each ``agent()`` in a workflow can spawn a real subagent. The
+tool's ``call`` resolves the script, schedules :func:`run_workflow_task` in the
+background (the session stays responsive), and returns a handle immediately.
+
+``runner_factory`` is injectable so the engine path is unit-testable with a fake
+runner; the default builds a ``LiveAgentRunner`` from the call's ``ToolContext``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from src.agent.constants import WORKFLOW_TOOL_NAME
+from src.tasks_core import generate_task_id
+from src.workflow.gating import is_workflows_enabled
+from src.workflow.launch import run_workflow_task
+
+from ..build_tool import Tool, build_tool
+from ..context import ToolContext
+from ..protocol import ToolResult
+
+logger = logging.getLogger(__name__)
+
+_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "script": {"type": "string", "description": "An inline Python workflow script to run."},
+        "name": {"type": "string", "description": "Name of a saved workflow under .claude/workflows."},
+        "script_path": {"type": "string", "description": "Path to a workflow script file to run."},
+        "args": {"description": "Structured input passed to the script as the `args` global."},
+        "resume_from_run_id": {"type": "string", "description": "Resume a prior run by id (same session)."},
+    },
+    "additionalProperties": True,
+}
+
+_PROMPT = (
+    "Run a dynamic workflow: a Python script that orchestrates many subagents at "
+    "scale, executed in the background. The script defines a top-level `meta = "
+    "{'name','description','phases'}` dict and uses injected async globals: "
+    "`await agent(prompt, schema=?, label=?, phase=?, model=?)`, "
+    "`await parallel([...])`, `await pipeline(items, stage1, stage2, ...)`, `phase(title)`, "
+    "`log(msg)`, `args`, and `budget`. Top-level `return` is the result. The "
+    "script itself has no filesystem/shell access (agents do the I/O); json/re/math "
+    "are available. Pass `script` (inline) or `name`/`script_path`."
+)
+
+
+def resolve_named_workflow(name: str, cwd: Optional[Path]) -> Optional[str]:
+    """Resolve a saved workflow ``name`` to its source (project wins over home)."""
+    candidates = []
+    if cwd is not None:
+        candidates.append(Path(cwd) / ".claude" / "workflows" / f"{name}.py")
+    candidates.append(Path.home() / ".claude" / "workflows" / f"{name}.py")
+    for path in candidates:
+        try:
+            if path.is_file():
+                return path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+    return None
+
+
+def _resolve_source(tool_input: dict, cwd: Optional[Path]) -> tuple[Optional[str], Optional[str]]:
+    """Return ``(source, error)``."""
+    script = tool_input.get("script")
+    if isinstance(script, str) and script.strip():
+        return script, None
+    script_path = tool_input.get("script_path")
+    if isinstance(script_path, str) and script_path.strip():
+        try:
+            return Path(script_path).read_text(encoding="utf-8"), None
+        except OSError as exc:
+            return None, f"could not read script_path: {exc}"
+    name = tool_input.get("name")
+    if isinstance(name, str) and name.strip():
+        source = resolve_named_workflow(name, cwd)
+        if source is None:
+            return None, f"no saved workflow named '{name}' under .claude/workflows"
+        return source, None
+    return None, "provide one of: script, script_path, or name"
+
+
+def _default_runner_factory(registry: Any, provider: Any) -> Callable[[ToolContext, str], Any]:
+    def factory(context: ToolContext, run_id: str) -> Any:
+        from src.workflow.runner import LiveAgentRunner
+
+        def resolve(agent_type: str) -> Any:
+            from src.agent.agent_definitions import GENERAL_PURPOSE_AGENT
+            try:
+                from src.agent.agent_definitions import find_agent_by_type
+                from src.agent.load_agents_dir import get_agent_definitions_with_overrides
+
+                agents = get_agent_definitions_with_overrides(str(context.cwd or "."))
+                found = find_agent_by_type(agents, agent_type)
+                return found or GENERAL_PURPOSE_AGENT
+            except Exception:
+                logger.exception("agent resolution failed; falling back to general-purpose")
+                return GENERAL_PURPOSE_AGENT
+
+        return LiveAgentRunner(
+            provider=provider,
+            tool_registry=registry,
+            parent_context=context,
+            base_tools=list(registry.list_tools()),
+            resolve_agent=resolve,
+            run_id=run_id,
+        )
+
+    return factory
+
+
+def make_workflow_tool(
+    registry: Any,
+    provider: Any = None,
+    *,
+    runner_factory: Optional[Callable[[ToolContext, str], Any]] = None,
+) -> Tool:
+    factory = runner_factory or _default_runner_factory(registry, provider)
+
+    async def _call(tool_input: dict, context: ToolContext) -> ToolResult:
+        if not is_workflows_enabled():
+            return ToolResult(name=WORKFLOW_TOOL_NAME, output={"error": "dynamic workflows are disabled"}, is_error=True)
+
+        source, error = _resolve_source(tool_input, context.cwd)
+        if source is None:
+            return ToolResult(name=WORKFLOW_TOOL_NAME, output={"error": error}, is_error=True)
+
+        run_id = "wf_" + uuid.uuid4().hex[:12]
+        task_id = generate_task_id("local_workflow")
+        base = Path(context.cwd) if context.cwd else Path.cwd()
+        wf_dir = base / ".clawcodex" / "workflows"
+        output_file = str(wf_dir / f"{run_id}.json")
+        runner = factory(context, run_id)
+
+        # Same-session resume: replay the prior run's journal if asked.
+        resume = None
+        prior_run_id = tool_input.get("resume_from_run_id")
+        if isinstance(prior_run_id, str) and prior_run_id.strip():
+            from src.workflow.launch import load_journal
+
+            resume = load_journal(str(wf_dir / f"{prior_run_id}.json"))
+
+        coro = run_workflow_task(
+            source=source,
+            runner=runner,
+            registry=context.runtime_tasks,
+            task_id=task_id,
+            run_id=run_id,
+            output_file=output_file,
+            args=tool_input.get("args"),
+            resume=resume,
+            tool_use_id=context.agent_id,
+        )
+
+        # Launch on a dedicated daemon thread that owns the run to completion.
+        # The production dispatch path executes this tool's ``call`` inside a
+        # throwaway ``asyncio.run`` loop (on a worker thread), so scheduling on
+        # the *current* loop would be torn down the instant we return the handle
+        # — the background run must outlive this call. ``task_manager.start``
+        # invokes ``target(stop_event)``, hence the ``_stop`` parameter.
+        context.task_manager.start(
+            name=f"workflow:{run_id}",
+            target=lambda _stop: asyncio.run(coro),
+        )
+
+        return ToolResult(
+            name=WORKFLOW_TOOL_NAME,
+            output={"status": "workflow_launched", "run_id": run_id, "task_id": task_id},
+        )
+
+    return build_tool(
+        name=WORKFLOW_TOOL_NAME,
+        input_schema=_INPUT_SCHEMA,
+        call=_call,
+        prompt=_PROMPT,
+        description="Run a dynamic multi-agent workflow script in the background.",
+        is_enabled=is_workflows_enabled,
+        is_read_only=lambda _input: True,  # subagents carry their own permissions
+        is_concurrency_safe=lambda _input: True,
+        max_result_size_chars=10_000,
+    )

--- a/src/workflow/__init__.py
+++ b/src/workflow/__init__.py
@@ -24,6 +24,7 @@ from .errors import (
     WorkflowLimitError,
     WorkflowMetaError,
 )
+from .gating import is_workflows_enabled
 from .journal import Journal, JournalRecord, fingerprint
 from .progress import AgentRecord, PhaseRecord, WorkflowProgress
 from .runner import LiveAgentRunner
@@ -65,6 +66,7 @@ __all__ = [
     "WorkflowMetaError",
     "WorkflowLimitError",
     "WorkflowBudgetExceeded",
+    "is_workflows_enabled",
     "MAX_AGENTS_PER_RUN",
     "MAX_ITEMS_PER_CALL",
     "MAX_STRUCTURED_OUTPUT_RETRIES",

--- a/src/workflow/bundled/__init__.py
+++ b/src/workflow/bundled/__init__.py
@@ -1,0 +1,12 @@
+"""Bundled workflow scripts shipped with clawcodex (e.g. /deep-research)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_DIR = Path(__file__).resolve().parent
+
+
+def bundled_workflow_path(name: str) -> Path:
+    """Absolute path to a bundled workflow script (``<name>.py``)."""
+    return _DIR / f"{name}.py"

--- a/src/workflow/bundled/deep_research.py
+++ b/src/workflow/bundled/deep_research.py
@@ -1,0 +1,124 @@
+meta = {
+    "name": "deep-research",
+    "description": "Investigate a question across many sources: fan out web searches, fetch and cross-check the findings, vote on each claim, and return a cited report.",
+    "when_to_use": "Run with a research question that needs sources cross-checked against each other. Requires the WebSearch tool.",
+    "phases": [
+        {"title": "Search", "detail": "Fan out web searches across several angles"},
+        {"title": "Verify", "detail": "Cross-check each claim with independent agents"},
+        {"title": "Synthesize", "detail": "Write a cited report from surviving claims"},
+    ],
+}
+
+# Bundled deep-research workflow (port of the upstream /deep-research bundle).
+# Each agent uses WebSearch/WebFetch to do the actual I/O; the script only
+# coordinates the fan-out, cross-checking, and synthesis.
+
+question = (args if isinstance(args, str) else (args or {}).get("question", "")).strip()
+if not question:
+    raise ValueError('Provide a research question via args — e.g. /deep-research "what changed in X?"')
+
+ANGLES = [
+    "official documentation and primary sources",
+    "recent news, changelogs, and release notes",
+    "expert analysis, comparisons, and critiques",
+    "community discussion and real-world reports",
+]
+
+CLAIMS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "claims": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "claim": {"type": "string"},
+                    "source": {"type": "string"},
+                },
+                "required": ["claim", "source"],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["claims"],
+    "additionalProperties": False,
+}
+
+VERDICT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "supported": {"type": "boolean"},
+        "reason": {"type": "string"},
+    },
+    "required": ["supported", "reason"],
+    "additionalProperties": False,
+}
+
+log(f"Researching: {question}")
+
+# ── Phase 1: fan out searches across angles ──────────────────────────────────
+phase("Search")
+searches = await parallel([
+    agent(
+        f'Research the question "{question}" focusing on {angle}. Use web search and fetch the '
+        f"most relevant sources. Extract concrete, verifiable claims that answer the question, "
+        f"each with the URL it came from. Return the structured object.",
+        label=f"search:{angle.split(',')[0][:20]}",
+        phase="Search",
+        schema=CLAIMS_SCHEMA,
+    )
+    for angle in ANGLES
+])
+
+claims = []
+seen = set()
+for result in searches:
+    if not result:
+        continue
+    for item in result.get("claims", []):
+        key = item.get("claim", "").strip().lower()
+        if key and key not in seen:
+            seen.add(key)
+            claims.append(item)
+
+if not claims:
+    raise RuntimeError("No claims were gathered — the question may be too narrow or WebSearch is unavailable.")
+log(f"Gathered {len(claims)} distinct claims; cross-checking each.")
+
+# ── Phase 2: cross-check every claim independently ───────────────────────────
+phase("Verify")
+verdicts = await parallel([
+    agent(
+        f'Independently verify this claim about "{question}":\n\n  "{c["claim"]}"\n\n'
+        f"(originally cited from {c['source']}). Use web search to find corroborating or "
+        f"contradicting evidence from a DIFFERENT source. Decide whether it is supported.",
+        label="verify",
+        phase="Verify",
+        schema=VERDICT_SCHEMA,
+    )
+    for c in claims
+])
+
+survivors = [
+    c for c, v in zip(claims, verdicts)
+    if v and v.get("supported") is True
+]
+log(f"{len(survivors)} of {len(claims)} claims survived cross-checking.")
+
+# ── Phase 3: synthesize a cited report ───────────────────────────────────────
+phase("Synthesize")
+bullet_lines = "\n".join(f"- {c['claim']} (source: {c['source']})" for c in survivors)
+report = await agent(
+    f'Write a clear, well-organized report answering: "{question}".\n\n'
+    f"Use ONLY these cross-checked claims, citing the source for each point:\n\n{bullet_lines}\n\n"
+    f"Structure it with a short summary followed by the details. Note any open questions.",
+    label="synthesize",
+    phase="Synthesize",
+)
+
+return {
+    "question": question,
+    "report": report,
+    "claims_gathered": len(claims),
+    "claims_verified": len(survivors),
+}

--- a/src/workflow/gating.py
+++ b/src/workflow/gating.py
@@ -1,0 +1,42 @@
+"""Feature gating for dynamic workflows.
+
+There is no central feature-flag system in clawcodex; following the advisor
+precedent (``src/utils/advisor.py``), workflows are gated by an env kill-switch
+plus a settings key. ``is_workflows_enabled()`` is the single chokepoint the
+Workflow tool, command discovery, and the bundled commands consult.
+
+Disabled when any of:
+- ``CLAUDE_CODE_DISABLE_WORKFLOWS`` is truthy (read at call time);
+- the ``disable_workflows`` setting is true; or
+- the camelCase ``disableWorkflows`` JSON key is set (via ``SettingsSchema.extra``).
+"""
+
+from __future__ import annotations
+
+import os
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_DISABLE_ENV = "CLAUDE_CODE_DISABLE_WORKFLOWS"
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
+
+
+def is_workflows_enabled() -> bool:
+    if _env_truthy(_DISABLE_ENV):
+        return False
+    try:
+        from src.settings.settings import get_settings
+
+        settings = get_settings()
+    except Exception:
+        # Pre-startup / no settings available: default to enabled (the env
+        # kill-switch above still applies).
+        return True
+    if getattr(settings, "disable_workflows", False):
+        return False
+    extra = getattr(settings, "extra", None)
+    if isinstance(extra, dict) and extra.get("disableWorkflows"):
+        return False
+    return True

--- a/src/workflow/journal.py
+++ b/src/workflow/journal.py
@@ -72,12 +72,17 @@ class Journal:
     # ── persistence (string-keyed for JSON) ───────────────────────────────────
 
     def to_json(self) -> str:
-        return json.dumps(
-            {key_to_str(k): {"fingerprint": r.fingerprint, "result": r.result} for k, r in self._records.items()},
-            default=str,
-        )
+        return records_to_json(self._records)
 
     @staticmethod
     def load(text: str) -> dict[CallKey, JournalRecord]:
         raw = json.loads(text)
         return {key_from_str(k): JournalRecord(v["fingerprint"], v["result"]) for k, v in raw.items()}
+
+
+def records_to_json(records: Mapping[CallKey, JournalRecord]) -> str:
+    """Serialize a records map (e.g. ``WorkflowResult.journal``) to JSON."""
+    return json.dumps(
+        {key_to_str(k): {"fingerprint": r.fingerprint, "result": r.result} for k, r in records.items()},
+        default=str,
+    )

--- a/src/workflow/launch.py
+++ b/src/workflow/launch.py
@@ -1,0 +1,126 @@
+"""Background launcher that ties a workflow run to a ``local_workflow`` task.
+
+``run_workflow_task`` is the awaitable the Workflow tool schedules: it runs the
+engine, registers the background task (via the engine's ``on_start`` hook with
+the live ``WorkflowRun`` so the task can abort it), keeps the task's summary
+fresh, and records the terminal state. It is unit-testable end-to-end with a
+fake ``AgentRunner`` and a plain ``RuntimeTaskRegistry`` — no live model needed.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from src.utils.abort_controller import AbortController, create_abort_controller
+
+from .errors import WorkflowMetaError
+from .journal import Journal, JournalRecord, records_to_json
+from .progress import WorkflowProgress
+from .types import AgentRunner
+
+logger = logging.getLogger(__name__)
+
+
+def persist_journal(path: str, records: Mapping) -> None:
+    """Write a run's journal to disk (best-effort) so it can resume in-session."""
+    try:
+        file = Path(path)
+        file.parent.mkdir(parents=True, exist_ok=True)
+        file.write_text(records_to_json(records), encoding="utf-8")
+    except OSError as exc:
+        logger.debug("could not persist workflow journal to %s: %s", path, exc)
+
+
+def load_journal(path: str) -> Optional[dict]:
+    """Load a prior run's journal from disk, or None if absent/unreadable."""
+    try:
+        return Journal.load(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        logger.debug("could not load workflow journal from %s: %s", path, exc)
+        return None
+
+
+async def run_workflow_task(
+    *,
+    source: str,
+    runner: AgentRunner,
+    registry: Any,  # RuntimeTaskRegistry
+    task_id: str,
+    run_id: str,
+    output_file: str,
+    args: Any = None,
+    controller: Optional[AbortController] = None,
+    resume: Optional[Mapping] = None,
+    resolve_workflow: Optional[Any] = None,
+    tool_use_id: Optional[str] = None,
+    budget_total: Optional[int] = None,
+    max_concurrent: Optional[int] = None,
+):
+    from src.tasks.local_workflow import (
+        complete_workflow_task,
+        fail_workflow_task,
+        register_workflow_task,
+        update_workflow_summary,
+    )
+
+    from .runtime import run_workflow
+
+    controller = controller if controller is not None else create_abort_controller()
+
+    def _on_start(run) -> None:
+        register_workflow_task(
+            task_id=task_id,
+            run_id=run_id,
+            workflow_name=run.meta.name,
+            description=run.meta.description,
+            output_file=output_file,
+            progress=run.progress,
+            run=run,
+            registry=registry,
+            tool_use_id=tool_use_id,
+        )
+
+    def _on_progress(_progress: WorkflowProgress) -> None:
+        update_workflow_summary(task_id, registry)
+
+    try:
+        result = await run_workflow(
+            source,
+            runner=runner,
+            args=args,
+            run_id=run_id,
+            controller=controller,
+            on_start=_on_start,
+            on_progress=_on_progress,
+            resume=resume,
+            resolve_workflow=resolve_workflow,
+            budget_total=budget_total,
+            max_concurrent=max_concurrent,
+        )
+    except WorkflowMetaError as exc:
+        # meta failed before the task was registered — surface a failed task so
+        # the user sees what happened rather than a silent no-op.
+        register_workflow_task(
+            task_id=task_id,
+            run_id=run_id,
+            workflow_name="workflow",
+            description="workflow (invalid meta)",
+            output_file=output_file,
+            progress=WorkflowProgress(),
+            run=None,
+            registry=registry,
+            tool_use_id=tool_use_id,
+        )
+        fail_workflow_task(task_id, error=f"WorkflowMetaError: {exc}", registry=registry)
+        return None
+
+    # Persist the journal so a same-session resume can replay completed agents.
+    persist_journal(output_file, result.journal)
+
+    if result.ok:
+        complete_workflow_task(task_id, result=result.value, registry=registry)
+    else:
+        fail_workflow_task(task_id, error=result.error or "unknown error", registry=registry)
+    return result

--- a/src/workflow/progress.py
+++ b/src/workflow/progress.py
@@ -23,6 +23,9 @@ class AgentRecord:
     status: AgentStatus = "running"
     tokens: int = 0
     error: Optional[str] = None
+    #: The agent's deterministic call-path key (e.g. "0.1") — lets the UI/task
+    #: layer target this specific agent for skip/retry.
+    key: str = ""
 
 
 @dataclass
@@ -65,9 +68,9 @@ class WorkflowProgress:
         self._logs.append(message)
         self._changed()
 
-    def agent_started(self, index: int, label: str, phase: Optional[str]) -> AgentRecord:
+    def agent_started(self, index: int, label: str, phase: Optional[str], key: str = "") -> AgentRecord:
         phase = phase or self._current_phase
-        record = AgentRecord(index=index, label=label, phase=phase)
+        record = AgentRecord(index=index, label=label, phase=phase, key=key)
         self._phase_for(phase).agents.append(record)
         self._changed()
         return record

--- a/src/workflow/runner.py
+++ b/src/workflow/runner.py
@@ -60,25 +60,33 @@ class LiveAgentRunner:
     async def run(self, spec: AgentSpec, *, abort: AbortController, index: int) -> AgentOutcome:
         # Imported lazily: ``src.agent`` pulls in the whole agent stack, which
         # the engine core deliberately never imports.
-        from src.agent.agent_tool_utils import finalize_agent_tool
+        from src.agent.agent_tool_utils import finalize_agent_tool, resolve_agent_tools
+        from src.agent.constants import WORKFLOW_TOOL_NAME
         from src.agent.run_agent import RunAgentParams, run_agent
 
         agent_type = spec.agent_type or self._default_agent_type
         agent_definition = self._resolve_agent(agent_type)
         agent_id = f"wf_{self._run_id}-{index}"
 
+        # Resolve the agent's *scoped, firewalled* toolset (applies
+        # ALL_AGENT_DISALLOWED_TOOLS — including Workflow, so a subagent can't
+        # recurse into another workflow — plus the agent definition's own tool
+        # scoping). We then pass it with use_exact_tools=True so run_agent keeps
+        # the injected StructuredOutput tool verbatim instead of re-resolving and
+        # dropping it. Belt-and-braces: strip Workflow even if it slips through.
+        resolved = resolve_agent_tools(agent_definition, self._base_tools, is_async=False)
+        worker_tools = [t for t in resolved.resolved_tools if getattr(t, "name", "") != WORKFLOW_TOOL_NAME]
+
         # isolation="worktree" is not yet wired (run_agent worktree support is a
         # later phase); a worktree request currently runs in-place.
         collector: Optional[StructuredOutputCollector] = None
-        available_tools = list(self._base_tools)
         prompt = spec.prompt
         if spec.schema is not None:
             collector = StructuredOutputCollector(schema=spec.schema)
-            available_tools = [
-                t for t in available_tools if getattr(t, "name", None) != SYNTHETIC_OUTPUT_TOOL_NAME
-            ]
-            available_tools.append(make_structured_output_tool(collector))
+            worker_tools = [t for t in worker_tools if getattr(t, "name", "") != SYNTHETIC_OUTPUT_TOOL_NAME]
+            worker_tools.append(make_structured_output_tool(collector))
             prompt = spec.prompt + _SCHEMA_NUDGE
+        available_tools = worker_tools
 
         params = RunAgentParams(
             parent_context=self._parent_context,
@@ -91,8 +99,13 @@ class LiveAgentRunner:
             agent_id=agent_id,
             abort_controller=abort,
             max_turns=self._max_turns,
-            # Keep the injected StructuredOutput tool in the pool verbatim.
-            use_exact_tools=spec.schema is not None,
+            # Workflow subagents always run acceptEdits (file edits auto-approved)
+            # regardless of the session's mode — per the official spec. run_agent
+            # honors this override ahead of the inheritance rules.
+            permission_mode_override="acceptEdits",
+            # We already resolved + firewalled + injected; don't let run_agent
+            # re-resolve (which would drop the injected StructuredOutput tool).
+            use_exact_tools=True,
         )
 
         messages: list = []

--- a/src/workflow/runtime.py
+++ b/src/workflow/runtime.py
@@ -83,17 +83,26 @@ class WorkflowRun:
         self._resolve_workflow = resolve_workflow
         self._depth = depth
         self._display = 0
-        # S2: per-agent child controllers, keyed by call-path, reachable so the
-        # task layer can stop/retry one agent without aborting the whole run.
-        self._agent_controllers: dict[CallKey, AbortController] = {}
+        # S2: per-agent child controllers, keyed by the call-path *string* (the
+        # form the UI/task layer carries on each AgentRecord), reachable so the
+        # task layer can stop one agent without aborting the whole run.
+        self._agent_controllers: dict[str, AbortController] = {}
 
     @property
     def controller(self) -> AbortController:
         return self._controller
 
-    def abort_agent(self, key: CallKey) -> bool:
-        """Abort one in-flight agent by its call-path key. Returns whether a
-        live controller was found."""
+    @property
+    def meta(self) -> WorkflowMeta:
+        return self._meta
+
+    @property
+    def progress(self) -> WorkflowProgress:
+        return self._progress
+
+    def abort_agent(self, key: str) -> bool:
+        """Abort one in-flight agent by its call-path key string. Returns
+        whether a live controller was found."""
         controller = self._agent_controllers.get(key)
         if controller is None:
             return False
@@ -139,9 +148,10 @@ class WorkflowRun:
         eff_label = label or agent_type or "agent"
         eff_phase = phase or self._progress.current_phase
 
+        key_str = key_to_str(key)
         cached = self._journal.lookup(key, spec)
         if cached is not MISS:
-            record = self._progress.agent_started(self._next_display(), eff_label, eff_phase)
+            record = self._progress.agent_started(self._next_display(), eff_label, eff_phase, key_str)
             self._progress.agent_finished(record, status="cached")
             return cached
 
@@ -150,9 +160,9 @@ class WorkflowRun:
         self._scheduler.reserve()
         self._budget.check()
 
-        record = self._progress.agent_started(self._next_display(), eff_label, eff_phase)
+        record = self._progress.agent_started(self._next_display(), eff_label, eff_phase, key_str)
         child = create_child_abort_controller(self._controller)
-        self._agent_controllers[key] = child
+        self._agent_controllers[key_str] = child
         try:
             async with self._scheduler.slot():
                 try:
@@ -163,7 +173,7 @@ class WorkflowRun:
                 except Exception as exc:  # noqa: BLE001 — a subagent death -> None
                     outcome = AgentOutcome(error=f"{type(exc).__name__}: {exc}")
         finally:
-            self._agent_controllers.pop(key, None)
+            self._agent_controllers.pop(key_str, None)
 
         self._budget.add(outcome.tokens)
         if outcome.error is not None:
@@ -273,6 +283,7 @@ async def run_workflow(
     args: Any = None,
     run_id: str = "wf",
     on_progress: Optional[Callable[[WorkflowProgress], None]] = None,
+    on_start: Optional[Callable[["WorkflowRun"], None]] = None,
     resume: Optional[Mapping[CallKey, JournalRecord]] = None,
     resolve_workflow: Optional[Callable[[str], str]] = None,
     budget_total: Optional[int] = None,
@@ -311,6 +322,9 @@ async def run_workflow(
         resolve_workflow=resolve_workflow,
         depth=_depth,
     )
+
+    if on_start is not None:
+        on_start(run)  # e.g. register the background task with the live run
 
     # Establish this run's base branch for deterministic call-path keys, and
     # restore the caller's branch afterwards (matters for nested workflow()).

--- a/tests/test_task_registry.py
+++ b/tests/test_task_registry.py
@@ -195,15 +195,17 @@ def test_get_task_by_type_dispatches_correctly() -> None:
 
 def test_get_task_by_type_unknown_returns_none() -> None:
     """Out-of-scope chapter task types stay unregistered (per plan §3:
-    RemoteAgent / Workflow / Monitor / Dream are deferred). Chunk-F
-    registered ``in_process_teammate`` so it's no longer in this list.
+    RemoteAgent / Monitor / Dream are deferred). Chunk-F registered
+    ``in_process_teammate``; the workflow-engine integration registered
+    ``local_workflow`` — both are now implemented and no longer in this list.
     """
     # ``dream`` is out-of-scope (chapter §3 / plan §3 — deferred).
     assert get_task_by_type("dream") is None
-    # And so are remote_agent / monitor_mcp / local_workflow.
+    # And so are remote_agent / monitor_mcp.
     assert get_task_by_type("remote_agent") is None
     assert get_task_by_type("monitor_mcp") is None
-    assert get_task_by_type("local_workflow") is None
+    # ``local_workflow`` is now registered by the workflow-engine integration.
+    assert get_task_by_type("local_workflow") is not None
 
 
 def test_in_process_teammate_registered_post_chunk_f() -> None:

--- a/tests/workflow/test_commands.py
+++ b/tests/workflow/test_commands.py
@@ -1,0 +1,106 @@
+"""Tests for workflow slash-command contribution (Phase 7)."""
+
+from __future__ import annotations
+
+from src.command_system.workflows_integration import (
+    _deep_research_command,
+    load_workflow_commands,
+)
+
+_VALID = 'meta = {"name": "x", "description": "My saved workflow", "phases": []}\nreturn 1\n'
+
+
+def test_deep_research_bundled_command():
+    cmd = _deep_research_command()
+    assert cmd is not None
+    assert cmd.name == "deep-research"
+    assert cmd.kind == "workflow"
+    assert cmd.loaded_from == "bundled"
+    assert "deep_research.py" in cmd.markdown_content
+    assert "$ARGUMENTS" in cmd.markdown_content
+
+
+def test_discovers_project_workflow(tmp_path):
+    wf_dir = tmp_path / ".claude" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "triage.py").write_text(_VALID, encoding="utf-8")
+
+    cmds = load_workflow_commands(str(tmp_path))
+    by_name = {c.name: c for c in cmds}
+    assert "deep-research" in by_name  # bundled is always present
+    assert "triage" in by_name
+    triage = by_name["triage"]
+    assert triage.kind == "workflow"
+    assert triage.loaded_from == "project"
+    assert triage.description == "My saved workflow"
+    assert str(wf_dir / "triage.py") in triage.markdown_content
+
+
+def test_invalid_workflow_file_is_skipped(tmp_path):
+    wf_dir = tmp_path / ".claude" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "broken.py").write_text("x = 1  # no meta block\n", encoding="utf-8")
+    (wf_dir / "good.py").write_text(_VALID, encoding="utf-8")
+
+    names = {c.name for c in load_workflow_commands(str(tmp_path))}
+    assert "good" in names
+    assert "broken" not in names
+
+
+def test_command_gating(monkeypatch, tmp_path):
+    from src.settings.types import SettingsSchema
+
+    monkeypatch.setattr("src.settings.settings.get_settings", lambda **_: SettingsSchema())
+    cmd = _deep_research_command()
+    monkeypatch.delenv("CLAUDE_CODE_DISABLE_WORKFLOWS", raising=False)
+    assert cmd.is_enabled() is True
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")
+    assert cmd.is_enabled() is False
+
+
+async def test_workflows_command_lists_runs():
+    from types import SimpleNamespace
+
+    from src.command_system.workflows_command import WORKFLOWS_COMMAND
+    from src.task_registry import RuntimeTaskRegistry
+    from src.tasks.local_workflow import register_workflow_task
+    from src.workflow.progress import WorkflowProgress
+
+    reg = RuntimeTaskRegistry()
+    register_workflow_task(
+        task_id="wq", run_id="r1", workflow_name="demo", description="d",
+        output_file="/tmp/x", progress=WorkflowProgress(), run=None, registry=reg,
+    )
+    ctx = SimpleNamespace(tool_context=SimpleNamespace(runtime_tasks=reg))
+    out = await WORKFLOWS_COMMAND.run("", ctx)
+    assert "demo" in out.message and "r1" in out.message
+
+
+async def test_workflows_command_empty_and_unavailable():
+    from types import SimpleNamespace
+
+    from src.command_system.workflows_command import WORKFLOWS_COMMAND
+    from src.task_registry import RuntimeTaskRegistry
+
+    empty = await WORKFLOWS_COMMAND.run("", SimpleNamespace(tool_context=SimpleNamespace(runtime_tasks=RuntimeTaskRegistry())))
+    assert "No workflow runs" in empty.message
+    na = await WORKFLOWS_COMMAND.run("", SimpleNamespace(tool_context=None))
+    assert "unavailable" in na.message.lower()
+
+
+def test_aggregator_includes_workflow_commands(tmp_path, monkeypatch):
+    from src.command_system import aggregator
+    from src.settings.types import SettingsSchema
+
+    monkeypatch.delenv("CLAUDE_CODE_DISABLE_WORKFLOWS", raising=False)
+    monkeypatch.setattr("src.settings.settings.get_settings", lambda **_: SettingsSchema())
+    aggregator.clear_commands_cache()
+
+    wf_dir = tmp_path / ".claude" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "myflow.py").write_text(_VALID, encoding="utf-8")
+
+    names = {c.name for c in aggregator.get_commands(str(tmp_path))}
+    assert "deep-research" in names
+    assert "myflow" in names
+    aggregator.clear_commands_cache()

--- a/tests/workflow/test_gating.py
+++ b/tests/workflow/test_gating.py
@@ -1,0 +1,45 @@
+"""Tests for workflow feature gating + the recursion-guard constant."""
+
+from __future__ import annotations
+
+import src.workflow.gating as gating
+from src.agent.constants import ALL_AGENT_DISALLOWED_TOOLS, WORKFLOW_TOOL_NAME
+from src.settings.types import SettingsSchema
+
+
+def test_workflow_tool_is_disallowed_in_subagents():
+    # Recursion guard: subagents must not be able to launch workflows.
+    assert WORKFLOW_TOOL_NAME == "Workflow"
+    assert WORKFLOW_TOOL_NAME in ALL_AGENT_DISALLOWED_TOOLS
+
+
+def test_enabled_by_default(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_DISABLE_WORKFLOWS", raising=False)
+    monkeypatch.setattr("src.settings.settings.get_settings", lambda **_: SettingsSchema())
+    assert gating.is_workflows_enabled() is True
+
+
+def test_env_kill_switch(monkeypatch):
+    monkeypatch.setattr("src.settings.settings.get_settings", lambda **_: SettingsSchema())
+    for value in ("1", "true", "YES", "on"):
+        monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", value)
+        assert gating.is_workflows_enabled() is False
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "0")
+    assert gating.is_workflows_enabled() is True
+
+
+def test_disabled_via_typed_setting(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_DISABLE_WORKFLOWS", raising=False)
+    monkeypatch.setattr(
+        "src.settings.settings.get_settings", lambda **_: SettingsSchema(disable_workflows=True)
+    )
+    assert gating.is_workflows_enabled() is False
+
+
+def test_disabled_via_camelcase_extra(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_DISABLE_WORKFLOWS", raising=False)
+    monkeypatch.setattr(
+        "src.settings.settings.get_settings",
+        lambda **_: SettingsSchema(extra={"disableWorkflows": True}),
+    )
+    assert gating.is_workflows_enabled() is False

--- a/tests/workflow/test_local_workflow.py
+++ b/tests/workflow/test_local_workflow.py
@@ -1,0 +1,157 @@
+"""Tests for the local_workflow background task + pill label."""
+
+from __future__ import annotations
+
+import src.tasks  # noqa: F401 — triggers Task registration
+from src.task_registry import RuntimeTaskRegistry, get_task_by_type
+from src.tasks_core import generate_task_id
+from src.tasks.local_workflow import (
+    LocalWorkflowTask,
+    LocalWorkflowTaskState,
+    complete_workflow_task,
+    fail_workflow_task,
+    kill_workflow_task,
+    register_workflow_task,
+    retry_workflow_agent,
+    skip_workflow_agent,
+    update_workflow_summary,
+)
+from src.tasks.pill_label import background_task_pill, workflow_pill_label
+from src.workflow.progress import WorkflowProgress
+
+
+class _FakeController:
+    def __init__(self):
+        self.aborted_with = None
+
+    def abort(self, reason=None):
+        self.aborted_with = reason
+
+
+class _FakeRun:
+    def __init__(self):
+        self.controller = _FakeController()
+        self.skipped = []
+
+    def abort_agent(self, key):
+        self.skipped.append(key)
+        return key == "0"
+
+
+def _register(registry, run=None, progress=None):
+    progress = progress or WorkflowProgress([{"title": "P"}])
+    run = run or _FakeRun()
+    return register_workflow_task(
+        task_id=generate_task_id("local_workflow"),
+        run_id="wf123",
+        workflow_name="demo",
+        description="demo workflow",
+        output_file="/tmp/wf.jsonl",
+        progress=progress,
+        run=run,
+        registry=registry,
+    )
+
+
+def test_task_is_registered():
+    task = get_task_by_type("local_workflow")
+    assert task is not None
+    assert task.name == "LocalWorkflowTask"
+    assert task.type == "local_workflow"
+
+
+def test_task_id_prefix():
+    assert generate_task_id("local_workflow").startswith("w")
+
+
+def test_register_and_summary():
+    reg = RuntimeTaskRegistry()
+    state = _register(reg)
+    got = reg.get(state.id)
+    assert isinstance(got, LocalWorkflowTaskState)
+    assert got.status == "running"
+    assert got.type == "local_workflow"
+    assert got.workflow_name == "demo"
+    # summary derives from the live progress
+    got.progress.start_phase("P")
+    update_workflow_summary(state.id, reg)
+    assert "P" in reg.get(state.id).summary
+
+
+def test_complete_and_fail():
+    reg = RuntimeTaskRegistry()
+    s1 = _register(reg)
+    complete_workflow_task(s1.id, result={"ok": 1}, registry=reg)
+    done = reg.get(s1.id)
+    assert done.status == "completed"
+    assert done.result == {"ok": 1}
+    assert done.end_time is not None
+    assert done.evict_after is not None
+
+    s2 = _register(reg)
+    fail_workflow_task(s2.id, error="boom", registry=reg)
+    assert reg.get(s2.id).status == "failed"
+    assert reg.get(s2.id).error == "boom"
+
+
+def test_kill_aborts_the_run():
+    reg = RuntimeTaskRegistry()
+    run = _FakeRun()
+    state = _register(reg, run=run)
+    kill_workflow_task(state.id, reg)
+    assert reg.get(state.id).status == "killed"
+    assert run.controller.aborted_with == "workflow_stopped"
+
+
+def test_skip_agent_targets_one_controller():
+    reg = RuntimeTaskRegistry()
+    run = _FakeRun()
+    state = _register(reg, run=run)
+    assert skip_workflow_agent(state.id, "0", reg) is True
+    assert skip_workflow_agent(state.id, "9", reg) is False
+    assert run.skipped == ["0", "9"]
+
+
+def test_retry_is_unsupported_for_now():
+    reg = RuntimeTaskRegistry()
+    state = _register(reg)
+    assert retry_workflow_agent(state.id, "0", reg) is False
+
+
+async def test_task_adapter_kill():
+    reg = RuntimeTaskRegistry()
+    run = _FakeRun()
+    state = _register(reg, run=run)
+    await LocalWorkflowTask().kill(state.id, reg)
+    assert reg.get(state.id).status == "killed"
+    assert run.controller.aborted_with == "workflow_stopped"
+
+
+def test_terminal_transitions_are_idempotent():
+    reg = RuntimeTaskRegistry()
+    state = _register(reg)
+    complete_workflow_task(state.id, result="a", registry=reg)
+    # A later kill must not override the completed terminal state.
+    kill_workflow_task(state.id, reg)
+    assert reg.get(state.id).status == "completed"
+
+
+# ── pill label ────────────────────────────────────────────────────────────────
+
+
+def test_pill_label_counts_running_workflows():
+    reg = RuntimeTaskRegistry()
+    assert workflow_pill_label(reg.all()) is None
+    a = _register(reg)
+    assert workflow_pill_label(reg.all()) == "1 background workflow"
+    _register(reg)
+    assert workflow_pill_label(reg.all()) == "2 background workflows"
+    # a terminal workflow drops out of the count
+    complete_workflow_task(a.id, result=None, registry=reg)
+    assert workflow_pill_label(reg.all()) == "1 background workflow"
+
+
+def test_background_pill_combines_types():
+    reg = RuntimeTaskRegistry()
+    _register(reg)
+    assert background_task_pill(reg.all()) == "1 background workflow"

--- a/tests/workflow/test_resume_persistence.py
+++ b/tests/workflow/test_resume_persistence.py
@@ -1,0 +1,53 @@
+"""Tests for journal disk-persistence + same-session resume (Phase 9)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.task_registry import RuntimeTaskRegistry
+from src.workflow.launch import load_journal, run_workflow_task
+
+META = 'meta = {"name": "t", "description": "d"}\n'
+SCRIPT = META + 'a = await agent("one")\nb = await agent("two")\nreturn [a, b]\n'
+
+
+async def test_journal_is_persisted(make_runner, tmp_path):
+    out = str(tmp_path / "wf" / "run1.json")
+    reg = RuntimeTaskRegistry()
+    runner = make_runner()
+    await run_workflow_task(
+        source=SCRIPT, runner=runner, registry=reg, task_id="w1", run_id="run1", output_file=out
+    )
+    assert Path(out).is_file()
+    assert runner.call_count == 2
+    journal = load_journal(out)
+    assert journal is not None and len(journal) == 2
+
+
+async def test_resume_from_persisted_journal_is_full_cache(make_runner, tmp_path):
+    out1 = str(tmp_path / "wf" / "run1.json")
+    reg1 = RuntimeTaskRegistry()
+    first = make_runner()
+    res1 = await run_workflow_task(
+        source=SCRIPT, runner=first, registry=reg1, task_id="w1", run_id="run1", output_file=out1
+    )
+
+    # Fresh run, resuming from the persisted journal -> nothing re-runs live.
+    reg2 = RuntimeTaskRegistry()
+    second = make_runner()
+    res2 = await run_workflow_task(
+        source=SCRIPT,
+        runner=second,
+        registry=reg2,
+        task_id="w2",
+        run_id="run2",
+        output_file=str(tmp_path / "wf" / "run2.json"),
+        resume=load_journal(out1),
+    )
+    assert second.call_count == 0
+    assert res2.value == res1.value
+    assert reg2.get("w2").status == "completed"
+
+
+def test_load_journal_missing_file_is_none(tmp_path):
+    assert load_journal(str(tmp_path / "nope.json")) is None

--- a/tests/workflow/test_workflow_permissions.py
+++ b/tests/workflow/test_workflow_permissions.py
@@ -1,0 +1,25 @@
+"""Tests for workflow permission classification (auto mode)."""
+
+from __future__ import annotations
+
+from src.permissions.check import auto_mode_classify
+from src.permissions.types import ToolPermissionContext
+
+
+def _ctx():
+    return ToolPermissionContext(mode="auto")
+
+
+def test_workflow_is_auto_allowed():
+    decision = auto_mode_classify("Workflow", {"script": "..."}, _ctx())
+    assert decision.allow is True
+    assert "workflow" in decision.reason.lower()
+
+
+def test_agent_still_auto_allowed():
+    # Parity guard — the Workflow branch sits next to the Agent branch.
+    assert auto_mode_classify("Agent", {}, _ctx()).allow is True
+
+
+def test_unknown_tool_still_denied():
+    assert auto_mode_classify("mcp__server__do", {}, _ctx()).allow is False

--- a/tests/workflow/test_workflow_tool.py
+++ b/tests/workflow/test_workflow_tool.py
@@ -1,0 +1,169 @@
+"""Tests for the background launcher and the Workflow tool factory."""
+
+from __future__ import annotations
+
+import asyncio
+
+import src.tasks  # noqa: F401 — task registration
+from src.settings.types import SettingsSchema
+from src.task_registry import RuntimeTaskRegistry
+from src.tasks.local_workflow import LocalWorkflowTaskState
+from src.tool_system.context import ToolContext
+from src.tool_system.tools.workflow import _resolve_source, make_workflow_tool
+from src.workflow.launch import run_workflow_task
+
+META = 'meta = {"name": "t", "description": "d"}\n'
+
+
+def _enable(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_DISABLE_WORKFLOWS", raising=False)
+    monkeypatch.setattr("src.settings.settings.get_settings", lambda **_: SettingsSchema())
+
+
+# ── launcher ──────────────────────────────────────────────────────────────────
+
+
+async def test_run_workflow_task_completes(make_runner):
+    reg = RuntimeTaskRegistry()
+    result = await run_workflow_task(
+        source=META + 'return await agent("hi")',
+        runner=make_runner(),
+        registry=reg,
+        task_id="wabc",
+        run_id="wf_x",
+        output_file="/tmp/x.json",
+    )
+    assert result.ok
+    state = reg.get("wabc")
+    assert isinstance(state, LocalWorkflowTaskState)
+    assert state.status == "completed"
+    assert state.result == "r0"
+    assert state.workflow_name == "t"
+
+
+async def test_run_workflow_task_meta_error_surfaces_failed_task(make_runner):
+    reg = RuntimeTaskRegistry()
+    await run_workflow_task(
+        source="return 1",  # no meta
+        runner=make_runner(),
+        registry=reg,
+        task_id="wbad",
+        run_id="wf_y",
+        output_file="/tmp/y.json",
+    )
+    state = reg.get("wbad")
+    assert state is not None
+    assert state.status == "failed"
+    assert "Meta" in state.error
+
+
+async def test_run_workflow_task_script_error_fails(make_runner):
+    reg = RuntimeTaskRegistry()
+    await run_workflow_task(
+        source=META + 'raise ValueError("x")',
+        runner=make_runner(),
+        registry=reg,
+        task_id="werr",
+        run_id="wf_z",
+        output_file="/tmp/z.json",
+    )
+    assert reg.get("werr").status == "failed"
+    assert "ValueError" in reg.get("werr").error
+
+
+# ── source resolution ─────────────────────────────────────────────────────────
+
+
+def test_resolve_source_inline_script():
+    assert _resolve_source({"script": "hello"}, None) == ("hello", None)
+
+
+def test_resolve_source_script_path(tmp_path):
+    p = tmp_path / "wf.py"
+    p.write_text("body", encoding="utf-8")
+    assert _resolve_source({"script_path": str(p)}, None) == ("body", None)
+
+
+def test_resolve_source_named(tmp_path):
+    wf_dir = tmp_path / ".claude" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "demo.py").write_text("named body", encoding="utf-8")
+    assert _resolve_source({"name": "demo"}, tmp_path) == ("named body", None)
+
+
+def test_resolve_source_errors():
+    src, err = _resolve_source({}, None)
+    assert src is None and "provide one" in err
+    src, err = _resolve_source({"name": "nope"}, None)
+    assert src is None and "no saved workflow" in err
+
+
+# ── tool ──────────────────────────────────────────────────────────────────────
+
+
+def test_tool_metadata_and_gating(monkeypatch):
+    tool = make_workflow_tool(registry=object(), provider=None)
+    assert tool.name == "Workflow"
+    assert tool.is_read_only({}) is True
+    _enable(monkeypatch)
+    assert tool.is_enabled() is True
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")
+    assert tool.is_enabled() is False
+
+
+async def test_tool_call_disabled_returns_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")
+    tool = make_workflow_tool(registry=object(), provider=None, runner_factory=lambda ctx, rid: None)
+    res = await tool.call({"script": META}, ToolContext(workspace_root=tmp_path))
+    assert res.is_error
+    assert "disabled" in res.output["error"]
+
+
+async def test_tool_call_launches_and_completes(make_runner, monkeypatch, tmp_path):
+    _enable(monkeypatch)
+    runner = make_runner()
+    tool = make_workflow_tool(registry=object(), provider=None, runner_factory=lambda ctx, rid: runner)
+    ctx = ToolContext(workspace_root=tmp_path)
+    res = await tool.call({"script": META + 'return await agent("hi")'}, ctx)
+    assert not res.is_error
+    assert res.output["status"] == "workflow_launched"
+    task_id = res.output["task_id"]
+    assert task_id.startswith("w")
+
+    # Let the background task finish.
+    for _ in range(200):
+        state = ctx.runtime_tasks.get(task_id)
+        if state is not None and state.status == "completed":
+            break
+        await asyncio.sleep(0.01)
+    final = ctx.runtime_tasks.get(task_id)
+    assert final is not None and final.status == "completed"
+    assert final.result == "r0"
+
+
+def test_tool_call_survives_ephemeral_dispatch_loop(make_runner, monkeypatch, tmp_path):
+    # Production topology: tool dispatch drives an async `call` via `asyncio.run`
+    # on a worker thread — a throwaway loop destroyed the instant `call` returns
+    # the handle. The workflow must run to completion on its own daemon thread
+    # regardless. (Regression for the "loop torn down before the run executes"
+    # bug; this is a SYNC test on purpose so there is no live loop to lean on.)
+    import time
+
+    _enable(monkeypatch)
+    runner = make_runner()
+    tool = make_workflow_tool(registry=object(), provider=None, runner_factory=lambda ctx, rid: runner)
+    ctx = ToolContext(workspace_root=tmp_path)
+
+    res = asyncio.run(tool.call({"script": META + 'return await agent("hi")'}, ctx))
+    assert res.output["status"] == "workflow_launched"
+    task_id = res.output["task_id"]
+
+    # The ephemeral loop is gone now; the daemon-threaded run must still finish.
+    for _ in range(300):
+        state = ctx.runtime_tasks.get(task_id)
+        if state is not None and state.status in ("completed", "failed"):
+            break
+        time.sleep(0.01)
+    final = ctx.runtime_tasks.get(task_id)
+    assert final is not None and final.status == "completed"
+    assert final.result == "r0"


### PR DESCRIPTION
## Summary

Wires the **dynamic workflow engine** (merged earlier as the engine core, #262) end-to-end so it's reachable from the model — **port-plan Phases 5–9**. The model can now launch a workflow via the **Workflow tool**; it runs as a background task, surfaces in `/workflows` + a footer pill, is discoverable as saved `/<name>` commands and the bundled `/deep-research`, is gated by `disable_workflows`, and supports same-session resume.

## What's added
- **Gating + constants** — `src/workflow/gating.py` (`CLAUDE_CODE_DISABLE_WORKFLOWS` + `disable_workflows` setting); `Workflow` added to `ALL_AGENT_DISALLOWED_TOOLS` (recursion guard) + the parity snapshot.
- **Background task (Phase 5)** — `src/tasks/local_workflow.py` (`LocalWorkflowTask`, lifecycle, `kill`/`skip`/`retry`), registered; `src/tasks/pill_label.py`.
- **Workflow tool (entry)** — `src/tool_system/tools/workflow.py` + `src/workflow/launch.py` (`run_workflow_task`), registered in `defaults.py`; `LiveAgentRunner` wired to `run_agent` + `finalize_agent_tool` + the injected `StructuredOutput`.
- **Commands (Phase 7)** — `workflows_integration.py` (discover `.claude/workflows/*.py`, project wins; bundled `src/workflow/bundled/deep_research.py`) + `workflows_command.py` (`/workflows`), spliced into the aggregator.
- **Permissions (Phase 8)** — `auto_mode_classify` allows `Workflow`; subagents forced `acceptEdits`.
- **Resume (Phase 9)** — journal persisted per run; `resume_from_run_id` replays it.

## Reviewed + hardened
An adversarial critic pass found and (in this PR) fixed three real bugs before merge:
1. **Background launch broke on the production dispatch path** — `call` runs inside a throwaway `asyncio.run` loop, so the run is now launched on a dedicated **daemon thread** that outlives it (+ a production-topology regression test that drives `call` via `asyncio.run` and asserts completion after the loop is gone).
2. **Schema subagents bypassed the tool firewall** — they now go through `resolve_agent_tools` (disallowed-tools + agent scoping, `Workflow` stripped — no recursion) before the injected `StructuredOutput` tool, instead of receiving the full base pool.
3. **`acceptEdits` was a no-op** — `run_agent` now honors `permission_mode_override`.

## Remaining polish (documented in port-plan §10, not blocking)
Rich Textual `/workflows` drill-down (the headless list + pill are built/tested), live pill wiring, `retry_workflow_agent`, worktree-per-agent, budget shared-pool, result auto-delivery to the conversation, and a live-model integration test for `LiveAgentRunner`.

## Testing
The full workflow suite passes (`.venv/bin/python -m pytest tests/workflow -q`); impacted shared suites (tasks, agent, permissions, aggregator, tool_system, parity) green. The 11 remaining full-suite failures are pre-existing and environment-related (`mcp` module not installed, etc.) — confirmed failing on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
