### PR TITLE
Web tooling for deep-research: Tavily search, config-backed secrets, deterministic WebFetch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,11 @@ dependencies = [
     # for all platforms and covers PNG/JPEG/GIF/WebP and palette quantization.
     # Without this, oversized images get rejected instead of downscaled.
     "Pillow>=10.0",
+    # HTML -> Markdown conversion for the WebFetch tool (port of TS Turndown).
+    # Preserves headings/lists/links so fetched pages are usable for research;
+    # without it WebFetch falls back to a flat regex tag-strip (no structure).
+    # Pulls in beautifulsoup4 (pure-Python).
+    "markdownify>=0.11",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ textual>=0.79
 PyYAML>=6.0
 pathspec>=0.11
 mcp>=1.27.0
+markdownify>=0.11
 
 # Development Dependencies
 build>=1.0.0

--- a/src/cli.py
+++ b/src/cli.py
@@ -532,6 +532,18 @@ def show_config():
             console.print(f"    Base URL: {provider_config.get('base_url', 'Not set')}")
             console.print(f"    Default Model: {provider_config.get('default_model', 'Not set')}")
 
+        # Stored API keys (config "env" block, e.g. TAVILY_API_KEY). Values are
+        # masked — only the name and a hint are shown.
+        from src.secret_store import get_secret, list_secret_names
+
+        stored_names = list_secret_names()
+        if stored_names:
+            console.print("\n[cyan]Stored Keys (env):[/cyan]")
+            for name in stored_names:
+                value = get_secret(name) or ""
+                masked = f"{value[:4]}...{value[-4:]}" if len(value) > 10 else "Set"
+                console.print(f"    {name}: {masked}")
+
         console.print()
 
     except Exception as e:

--- a/src/init.py
+++ b/src/init.py
@@ -91,6 +91,15 @@ def init() -> None:
     apply_safe_config_environment_variables(extra_env=mdm_safe_env)
     profile_checkpoint("init_safe_env_vars_applied")
 
+    # Stored API keys: copy the config ``env`` block (e.g. TAVILY_API_KEY in
+    # ~/.clawcodex/config.json) into os.environ so every os.environ[...] reader
+    # sees them. override=False -> a real exported var and the managed/MDM safe
+    # env applied just above both win over the user's stored value.
+    _logger.info("init: applying stored config env (API keys)")
+    from src.secret_store import apply_config_env_to_environ
+    apply_config_env_to_environ()
+    profile_checkpoint("init_config_env_applied")
+
     _logger.info("init: setting up graceful shutdown")
     setup_graceful_shutdown()
     profile_checkpoint("init_after_graceful_shutdown")

--- a/src/secret_store.py
+++ b/src/secret_store.py
@@ -1,0 +1,162 @@
+"""Secret / API-key storage for Claw Codex.
+
+Keys live in the single config file (``~/.clawcodex/config.json``) under a
+top-level ``"env"`` object — one place for all configuration, no scattered
+``.env`` files::
+
+    {
+      "default_provider": "...",
+      "providers": { ... },
+      "env": {
+        "TAVILY_API_KEY": "tvly-xxxxxxxx"
+      }
+    }
+
+Because the config hierarchy is global < project < local (deep-merged), an
+``env`` block may appear at any level; later levels override earlier ones.
+
+Resolution order for a single key (highest precedence first):
+
+  1. the real process environment (an explicit ``export NAME=...``)
+  2. the merged config ``env`` block
+
+So an exported shell variable always wins over the stored value (handy for
+temporary overrides and CI), while the config file is the durable store.
+
+At startup :func:`apply_config_env_to_environ` copies the config ``env`` block
+into ``os.environ`` (without clobbering already-set variables) so every existing
+``os.environ[...]`` reader — tools, subprocesses, MCP servers — transparently
+sees the stored keys. :func:`get_secret` additionally falls back to reading the
+config directly, so it resolves correctly even on code paths that never ran
+startup ``init()`` (standalone scripts, tests).
+
+Values are never logged; the global config file is written ``0600`` by
+``src.config._atomic_write_json``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Top-level config key holding the NAME -> value secret map.
+CONFIG_ENV_KEY = "env"
+
+
+def _coerce_env_map(section: Any) -> dict[str, str]:
+    """Return a clean ``{NAME: str}`` map from a config ``env`` section.
+
+    Non-dict sections, empty/non-string names, and ``bool``/``None``/container
+    values are skipped (``bool`` is excluded deliberately — ``True`` is not a
+    credential). Numbers are coerced to their string form.
+    """
+    if not isinstance(section, dict):
+        return {}
+    out: dict[str, str] = {}
+    for name, value in section.items():
+        if not isinstance(name, str) or not name:
+            continue
+        if isinstance(value, bool) or value is None:
+            continue
+        if isinstance(value, (str, int, float)):
+            out[name] = str(value)
+    return out
+
+
+def _config_env() -> dict[str, str]:
+    """The merged config ``env`` block as a ``{NAME: value}`` map (may be empty)."""
+    try:
+        from src.config import load_config
+
+        return _coerce_env_map(load_config().get(CONFIG_ENV_KEY))
+    except Exception as exc:  # config unreadable -> behave as if unset
+        logger.debug("secret_store: could not read config env: %s", exc)
+        return {}
+
+
+def get_secret(name: str, default: str | None = None) -> str | None:
+    """Resolve a single secret / API key.
+
+    Order: real ``os.environ`` (non-empty) -> config ``env`` block -> *default*.
+    Empty / whitespace-only values are treated as unset.
+    """
+    env_val = os.environ.get(name)
+    if env_val and env_val.strip():
+        return env_val
+    cfg_val = _config_env().get(name)
+    if cfg_val and cfg_val.strip():
+        return cfg_val
+    return default
+
+
+def apply_config_env_to_environ(*, override: bool = False) -> list[str]:
+    """Copy the config ``env`` block into ``os.environ``.
+
+    Called once at startup (from :func:`src.init.init`). With ``override=False``
+    (the default) an already-set, non-empty environment variable is left
+    untouched, so an explicit ``export`` wins over the stored value. Returns the
+    list of variable NAMES applied (never values) for diagnostics.
+    """
+    applied: list[str] = []
+    for name, value in _config_env().items():
+        if not override and (os.environ.get(name) or "").strip():
+            continue
+        os.environ[name] = value
+        applied.append(name)
+    if applied:
+        logger.debug(
+            "secret_store: applied %d config env var(s): %s",
+            len(applied),
+            ", ".join(sorted(applied)),
+        )
+    return applied
+
+
+def list_secret_names() -> list[str]:
+    """Sorted NAMES of keys stored in the config ``env`` block (no values)."""
+    return sorted(_config_env().keys())
+
+
+def set_secret(name: str, value: str) -> None:
+    """Store a secret / API key in the **global** config ``env`` block.
+
+    Writes ``~/.clawcodex/config.json`` atomically (``0600``) and refreshes the
+    live process environment so the new value is visible immediately in-session.
+    """
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("secret name must be a non-empty string")
+    from src.config import _get_default_manager
+
+    mgr = _get_default_manager()
+    cfg = mgr.load_global()
+    section = cfg.get(CONFIG_ENV_KEY)
+    if not isinstance(section, dict):
+        section = {}
+    section[name] = value
+    cfg[CONFIG_ENV_KEY] = section
+    mgr.save_global(cfg)
+    # Reflect immediately for the current process (explicit set overrides live).
+    os.environ[name] = value
+
+
+def delete_secret(name: str) -> bool:
+    """Remove a secret from the global config ``env`` block.
+
+    Returns ``True`` if a stored key was removed, ``False`` if it was absent.
+    Also clears the live ``os.environ`` mirror.
+    """
+    from src.config import _get_default_manager
+
+    mgr = _get_default_manager()
+    cfg = mgr.load_global()
+    section = cfg.get(CONFIG_ENV_KEY)
+    if not isinstance(section, dict) or name not in section:
+        return False
+    del section[name]
+    cfg[CONFIG_ENV_KEY] = section
+    mgr.save_global(cfg)
+    os.environ.pop(name, None)
+    return True

--- a/src/tool_system/tools/web_fetch.py
+++ b/src/tool_system/tools/web_fetch.py
@@ -11,14 +11,17 @@ Features:
 
 from __future__ import annotations
 
+import gzip
 import html
 import http.client
 import ipaddress
 import re
 import socket
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
+import zlib
 from typing import Any
 
 from ..build_tool import Tool, build_tool
@@ -34,21 +37,80 @@ from src.permissions.types import (
 # -- HTML to Markdown ----------------------------------------------------------
 
 _TAG_RE = re.compile(r"<[^>]+>")
+# Blocks whose *contents* are noise (script/style code, inline SVG paths, etc.).
+# Removed before conversion so they never leak into the extracted text — markdownify
+# strips the tags but can otherwise surface their text nodes.
+_NOISE_BLOCK_RE = re.compile(
+    r"<(script|style|noscript|svg|template)\b[^>]*>.*?</\1>",
+    flags=re.DOTALL | re.IGNORECASE,
+)
+
+
+def _strip_noise_blocks(raw: str) -> str:
+    return _NOISE_BLOCK_RE.sub(" ", raw)
+
 
 try:
     import markdownify as _md
 
     def _html_to_markdown(raw: str) -> str:
-        return _md.markdownify(raw, strip=["img", "script", "style"])
+        # Structured markdown: headings, lists, and links are preserved (so the
+        # model can cite sources and follow structure), unlike the flat regex
+        # fallback below.
+        text = _md.markdownify(_strip_noise_blocks(raw), strip=["img", "script", "style"])
+        return re.sub(r"\n{3,}", "\n\n", text).strip()  # collapse blank-line runs
 except ImportError:
     _md = None  # type: ignore[assignment]
 
     def _html_to_markdown(raw: str) -> str:
-        text = re.sub(r"<script[^>]*>.*?</script>", "", raw, flags=re.DOTALL | re.IGNORECASE)
-        text = re.sub(r"<style[^>]*>.*?</style>", "", text, flags=re.DOTALL | re.IGNORECASE)
-        text = _TAG_RE.sub(" ", text)
+        text = _TAG_RE.sub(" ", _strip_noise_blocks(raw))
         text = re.sub(r"\s+", " ", text).strip()
         return html.unescape(text)
+
+
+# Tags whose subtrees carry no readable content (ported from opencode's
+# extractTextFromHTML skip-list, plus svg/template).
+_NOISE_TAGS = ["script", "style", "noscript", "iframe", "object", "embed", "svg", "template"]
+
+try:
+    import bs4 as _bs4  # provided by markdownify's beautifulsoup4 dependency
+
+    def _html_to_text(raw: str) -> str:
+        """Plain-text extraction: drop noise subtrees, collect text nodes.
+
+        DOM-aware (BeautifulSoup), so it won't mangle text the way a flat regex
+        tag-strip can. Mirrors opencode's htmlparser2-based ``extractTextFromHTML``.
+        """
+        soup = _bs4.BeautifulSoup(raw, "html.parser")
+        for tag in soup(_NOISE_TAGS):
+            tag.decompose()
+        text = soup.get_text(separator="\n")
+        return re.sub(r"\n{3,}", "\n\n", text).strip()
+except ImportError:
+    _bs4 = None  # type: ignore[assignment]
+
+    def _html_to_text(raw: str) -> str:
+        text = _TAG_RE.sub(" ", _strip_noise_blocks(raw))
+        return html.unescape(re.sub(r"\s+", " ", text).strip())
+
+
+def _convert(content: str, content_type: str, fmt: str) -> str:
+    """Convert a fetched body to the requested ``fmt`` (markdown/text/html).
+
+    Non-HTML bodies (json, plain text, already-markdown) pass through unchanged;
+    binary image types return a short placeholder instead of decoded garbage.
+    Mirrors opencode's deterministic ``convert`` — no model involved.
+    """
+    mime = content_type.split(";", 1)[0].strip().lower()
+    if mime.startswith("image/") and mime != "image/svg+xml":
+        return f"[non-text content: {mime}]"
+    if "html" not in mime:
+        return content  # text/markdown/json/xml/etc — already usable
+    if fmt == "markdown":
+        return _html_to_markdown(content)
+    if fmt == "text":
+        return _html_to_text(content)
+    return content  # fmt == "html": return the raw HTML the caller asked for
 
 
 # -- URL Validation ------------------------------------------------------------
@@ -128,17 +190,92 @@ class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
         return None
 
 
-def _fetch_with_redirect_handling(url: str, timeout: float = 15) -> tuple[str, str, int]:
+# Many sites (Cloudflare and friends) answer 403 to non-browser User-Agents, so a
+# generic "claw-codex/0.1" UA silently failed on a large slice of the real web.
+# When a site instead challenges the *browser* UA (Cloudflare bot-fight), we retry
+# once with a plain bot UA — some WAFs pass bots while challenging browsers. Both
+# behaviours are borrowed from opencode's webfetch tool.
+_BROWSER_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+_FALLBACK_UA = "claw-codex"
+
+_MAX_FETCH_BYTES = 2_000_000
+
+
+def _accept_header(fmt: str) -> str:
+    """Content-negotiation Accept header preferring the requested format."""
+    if fmt == "markdown":
+        return "text/markdown;q=1.0, text/x-markdown;q=0.9, text/plain;q=0.8, text/html;q=0.7, */*;q=0.1"
+    if fmt == "text":
+        return "text/plain;q=1.0, text/markdown;q=0.9, text/html;q=0.8, */*;q=0.1"
+    if fmt == "html":
+        return "text/html;q=1.0, application/xhtml+xml;q=0.9, text/plain;q=0.8, text/markdown;q=0.7, */*;q=0.1"
+    return "*/*"
+
+
+def _request_headers(fmt: str, user_agent: str) -> dict[str, str]:
+    return {
+        "User-Agent": user_agent,
+        "Accept": _accept_header(fmt),
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept-Encoding": "gzip, deflate",
+    }
+
+
+def _charset_from_content_type(content_type: str) -> str | None:
+    match = re.search(r"charset=([^\s;]+)", content_type or "", flags=re.IGNORECASE)
+    return match.group(1).strip().strip('"\'') if match else None
+
+
+def _read_response_body(resp) -> str:
+    """Read, transparently decompress (gzip/deflate), and decode a response body."""
+    raw = resp.read(_MAX_FETCH_BYTES)
+    encoding = (resp.headers.get("Content-Encoding") or "").lower()
+    if "gzip" in encoding:
+        try:
+            raw = gzip.decompress(raw)
+        except Exception:
+            pass  # not actually gzipped -> use bytes as-is
+    elif "deflate" in encoding:
+        try:
+            raw = zlib.decompress(raw)
+        except zlib.error:
+            try:
+                raw = zlib.decompress(raw, -zlib.MAX_WBITS)  # raw deflate, no header
+            except Exception:
+                pass
+    charset = _charset_from_content_type(resp.headers.get("Content-Type", "")) or "utf-8"
+    try:
+        return raw.decode(charset, errors="replace")
+    except LookupError:  # unknown charset label
+        return raw.decode("utf-8", errors="replace")
+
+
+def _is_cloudflare_challenge(e: urllib.error.HTTPError) -> bool:
+    """403 with a Cloudflare bot-fight challenge marker."""
+    try:
+        return e.code == 403 and (e.headers.get("cf-mitigated") or "").lower() == "challenge"
+    except Exception:
+        return False
+
+
+def _fetch_with_redirect_handling(
+    url: str, timeout: float = 15, fmt: str = "markdown", user_agent: str = _BROWSER_UA
+) -> tuple[str, str, int]:
     opener = urllib.request.build_opener(_NoRedirectHandler)
     current_url = url
     for _ in range(_MAX_REDIRECTS):
-        req = urllib.request.Request(current_url, headers={"User-Agent": "claw-codex/0.1"})
+        req = urllib.request.Request(current_url, headers=_request_headers(fmt, user_agent))
         try:
             resp = opener.open(req, timeout=timeout)
-            raw_bytes = resp.read(1_000_000)
             content_type = resp.headers.get("Content-Type", "")
-            return raw_bytes.decode("utf-8", errors="replace"), content_type, resp.status
+            return _read_response_body(resp), content_type, resp.status
         except urllib.error.HTTPError as e:
+            # Cloudflare challenged the browser UA -> retry once with a bot UA.
+            if _is_cloudflare_challenge(e) and user_agent != _FALLBACK_UA:
+                return _fetch_with_redirect_handling(url, timeout, fmt, _FALLBACK_UA)
             if e.code in (301, 302, 303, 307, 308):
                 redirect_url = e.headers.get("Location", "")
                 if not redirect_url:
@@ -304,9 +441,15 @@ def _map_result_to_api(result: Any, tool_use_id: str) -> dict[str, Any]:
 
 # -- Main Call -----------------------------------------------------------------
 
+_VALID_FORMATS = ("markdown", "text", "html")
+
+
 def _web_fetch_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
     url = tool_input.get("url", "")
     prompt = tool_input.get("prompt", "")
+    fmt = tool_input.get("format") or "markdown"
+    if fmt not in _VALID_FORMATS:
+        fmt = "markdown"
 
     if not isinstance(url, str) or not url:
         raise ToolInputError("url must be a non-empty string")
@@ -315,14 +458,16 @@ def _web_fetch_call(tool_input: dict[str, Any], context: ToolContext) -> ToolRes
 
     start_time = time.time()
 
-    cached = _cache_get(url)
+    # Cache the *converted* content; key by format so a markdown fetch and a text
+    # fetch of the same URL don't collide.
+    cache_key = f"{fmt}:{url}"
+    cached = _cache_get(cache_key)
     if cached:
         content, content_type, status = cached
     else:
-        content, content_type, status = _fetch_with_redirect_handling(url)
-        if "text/html" in content_type:
-            content = _html_to_markdown(content)
-        _cache_set(url, content, content_type, status)
+        raw, content_type, status = _fetch_with_redirect_handling(url, fmt=fmt)
+        content = _convert(raw, content_type, fmt)
+        _cache_set(cache_key, content, content_type, status)
 
     if len(content) > 100_000:
         content = content[:100_000] + "\n\n... [truncated] ..."
@@ -350,20 +495,20 @@ def _web_fetch_call(tool_input: dict[str, Any], context: ToolContext) -> ToolRes
 
 _WEB_FETCH_PROMPT = """IMPORTANT: WebFetch WILL FAIL for authenticated or private URLs. Before using this tool, check if the URL points to an authenticated service (e.g. Google Docs, Confluence, Jira, GitHub). If so, look for a specialized MCP tool that provides authenticated access.
 
-- Fetches content from a specified URL and processes it using an AI model
-- Takes a URL and a prompt as input
-- Fetches the URL content, converts HTML to markdown
-- Processes the content with the prompt using a small, fast model
-- Returns the model's response about the content
-- Use this tool when you need to retrieve and analyze web content
+- Fetches content from a specified URL and returns it as text
+- Takes a URL and an optional `format` (markdown | text | html; default markdown)
+- Fetches the URL content and converts HTML deterministically (no model call):
+  `markdown` preserves headings/lists/links, `text` is clean plain text, `html` is raw
+- Use this tool when you need to retrieve and read web content
 
 Usage notes:
   - IMPORTANT: If an MCP-provided web fetch tool is available, prefer using that tool instead of this one, as it may have fewer restrictions.
   - The URL must be a fully-formed valid URL
   - HTTP URLs will be automatically upgraded to HTTPS
-  - The prompt should describe what information you want to extract from the page
+  - Use `format: "markdown"` (default) for reading; `format: "text"` to strip all structure; `format: "html"` for the raw page
+  - The `prompt` (optional) is passed through as context for what you're looking for; it does not trigger a separate model call
   - This tool is read-only and does not modify any files
-  - Results may be summarized if the content is very large
+  - Large results may be truncated
   - Includes a self-cleaning 15-minute cache for faster responses when repeatedly accessing the same URL
   - When a URL redirects to a different host, the tool will inform you and provide the redirect URL in a special format. You should then make a new WebFetch request with the redirect URL to fetch the content.
   - For GitHub URLs, prefer using the gh CLI via Bash instead (e.g., gh pr view, gh issue view, gh api)."""
@@ -396,7 +541,12 @@ WebFetchTool: Tool = build_tool(
             },
             "prompt": {
                 "type": "string",
-                "description": "The prompt to run on the fetched content",
+                "description": "Optional. What you're looking for on the page (passed through as context; does not trigger a separate model call)",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["text", "markdown", "html"],
+                "description": "Format to return the content in. Defaults to markdown.",
             },
         },
         "required": ["url"],

--- a/src/tool_system/tools/web_search.py
+++ b/src/tool_system/tools/web_search.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import html
 import json
-import re
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
 from datetime import datetime
@@ -106,75 +105,78 @@ def _normalize_hit(raw: Any) -> dict[str, str] | None:
 
 
 # ---------------------------------------------------------------------------
-# DuckDuckGo search (HTML scraping fallback)
+# Tavily Search API — https://api.tavily.com/search
 # ---------------------------------------------------------------------------
+# Replaces the legacy DuckDuckGo backend (which scraped HTML and no longer
+# returns results). Configure with the TAVILY_API_KEY environment variable (a
+# key starting with ``tvly-``). Mirrors the TS adapter at
+# ``typescript/src/tools/WebSearchTool/providers/tavily.ts``.
 
-_RESULT_RE = re.compile(
-    r'<a[^>]+class="result__a"[^>]+href="(?P<url>[^"]+)"[^>]*>(?P<title>.*?)</a>.*?'
-    r'<a[^>]+class="result__snippet"[^>]*>(?P<snippet>.*?)</a>',
-    re.DOTALL,
-)
-
-
-def _strip_tags(s: str) -> str:
-    return html.unescape(re.sub(r"<[^>]+>", "", s)).strip()
+_TAVILY_URL = "https://api.tavily.com/search"
 
 
-def _ddg_html_search(query: str, num: int = 10) -> list[dict[str, str]]:
-    """Search DuckDuckGo via HTML scraping (legacy fallback)."""
-    url = "https://duckduckgo.com/html/?" + urllib.parse.urlencode({"q": query})
-    req = urllib.request.Request(url, headers={"User-Agent": "claw-codex/0.1"})
-    with urllib.request.urlopen(req, timeout=15) as resp:
-        raw = resp.read(1_000_000).decode("utf-8", errors="replace")
+def _tavily_api_key() -> str | None:
+    # Resolved via the secret store: an exported TAVILY_API_KEY wins, otherwise
+    # the value stored in ~/.clawcodex/config.json under "env". Lazy import keeps
+    # the tool module free of a config dependency at import time.
+    from src.secret_store import get_secret
 
-    results: list[dict[str, str]] = []
-    for match in _RESULT_RE.finditer(raw):
-        results.append(
-            {
-                "title": _strip_tags(match.group("title")),
-                "url": html.unescape(match.group("url")),
-                "snippet": _strip_tags(match.group("snippet")),
-            }
-        )
-        if len(results) >= num:
-            break
-    return results
+    key = (get_secret("TAVILY_API_KEY") or "").strip()
+    return key or None
 
 
-# ---------------------------------------------------------------------------
-# DuckDuckGo search (via duckduckgo-search package, preferred)
-# ---------------------------------------------------------------------------
+def is_web_search_configured() -> bool:
+    """Whether a web-search backend is configured (a Tavily API key is set)."""
+    return _tavily_api_key() is not None
 
-def _ddg_package_search(query: str, num: int = 10) -> list[dict[str, str]] | None:
-    """Search DuckDuckGo via the duckduckgo-search package.
 
-    Returns None if the package is not installed, so caller can fall back.
+def _tavily_search(query: str, num: int = 15) -> list[dict[str, str]]:
+    """Search the web via Tavily.
+
+    Raises ``ToolInputError`` when ``TAVILY_API_KEY`` is unset (so the model and
+    user get a clear "configure search" signal rather than silent empty results)
+    or when the API call fails.
     """
+    key = _tavily_api_key()
+    if not key:
+        raise ToolInputError(
+            "Web search is not configured. Set the TAVILY_API_KEY environment "
+            "variable (get a free key at https://app.tavily.com)."
+        )
+
+    body = json.dumps(
+        {"query": query, "max_results": max(1, min(num, 20)), "include_answer": False}
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        _TAVILY_URL,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {key}"},
+    )
     try:
-        from duckduckgo_search import DDGS  # type: ignore[import-untyped]
-    except ImportError:
-        return None
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            raw = resp.read(2_000_000).decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            detail = exc.read(2000).decode("utf-8", errors="replace")
+        except Exception:
+            pass
+        raise ToolInputError(f"Tavily search error {exc.code}: {detail[:300]}") from exc
+    except urllib.error.URLError as exc:
+        raise ToolInputError(f"Tavily search failed: {exc.reason}") from exc
 
     try:
-        with DDGS() as ddgs:
-            raw_results = list(ddgs.text(query, max_results=num, safesearch="on"))
-    except Exception:
-        return None
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ToolInputError("Tavily returned a non-JSON response.") from exc
 
-    results: list[dict[str, str]] = []
-    for raw in raw_results:
-        hit = _normalize_hit(raw)
+    hits: list[dict[str, str]] = []
+    for raw_hit in data.get("results") or []:
+        hit = _normalize_hit(raw_hit)  # maps title/url/content via field aliases
         if hit:
-            results.append(hit)
-    return results
-
-
-def _search_duckduckgo(query: str, num: int = 10) -> list[dict[str, str]]:
-    """Search DuckDuckGo, preferring the package API over HTML scraping."""
-    pkg_results = _ddg_package_search(query, num)
-    if pkg_results is not None:
-        return pkg_results
-    return _ddg_html_search(query, num)
+            hits.append(hit)
+    return hits
 
 
 # ---------------------------------------------------------------------------
@@ -302,7 +304,7 @@ def _format_output(
     # Structured links
     if hits:
         results.append({
-            "tool_use_id": "ddg-search",
+            "tool_use_id": "tavily-search",
             "content": [{"title": h["title"], "url": h["url"]} for h in hits],
         })
 
@@ -330,8 +332,8 @@ def _web_search_call(tool_input: dict[str, Any], context: ToolContext) -> ToolRe
 
     start_time = time.monotonic()
 
-    # Search using DuckDuckGo (package preferred, HTML fallback)
-    results = _search_duckduckgo(query, num=10)
+    # Search via Tavily (requires TAVILY_API_KEY).
+    results = _tavily_search(query, num=15)
 
     # Apply domain filters
     results = _apply_domain_filters(

--- a/tests/test_secret_store.py
+++ b/tests/test_secret_store.py
@@ -1,0 +1,149 @@
+"""Tests for src/secret_store.py — config-backed secret/API-key storage."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import src.config as config_module
+import src.secret_store as ss
+
+
+# --- pure helpers ---------------------------------------------------------
+
+
+def test_coerce_env_map_filters_non_strings():
+    src = {
+        "TAVILY_API_KEY": "tvly-x",
+        "PORT": 8080,            # int -> str
+        "RATIO": 1.5,            # float -> str
+        "ENABLED": True,         # bool -> skipped (not a credential)
+        "MISSING": None,         # None -> skipped
+        "NESTED": {"a": 1},      # container -> skipped
+        "": "noname",            # empty name -> skipped
+    }
+    out = ss._coerce_env_map(src)
+    assert out == {"TAVILY_API_KEY": "tvly-x", "PORT": "8080", "RATIO": "1.5"}
+
+
+def test_coerce_env_map_non_dict():
+    assert ss._coerce_env_map(None) == {}
+    assert ss._coerce_env_map(["x"]) == {}
+
+
+# --- get_secret resolution order -----------------------------------------
+
+
+def test_get_secret_env_wins_over_config(monkeypatch):
+    monkeypatch.setenv("MYKEY", "from-env")
+    monkeypatch.setattr(ss, "_config_env", lambda: {"MYKEY": "from-config"})
+    assert ss.get_secret("MYKEY") == "from-env"
+
+
+def test_get_secret_falls_back_to_config(monkeypatch):
+    monkeypatch.delenv("MYKEY", raising=False)
+    monkeypatch.setattr(ss, "_config_env", lambda: {"MYKEY": "from-config"})
+    assert ss.get_secret("MYKEY") == "from-config"
+
+
+def test_get_secret_empty_env_uses_config(monkeypatch):
+    monkeypatch.setenv("MYKEY", "   ")  # whitespace == unset
+    monkeypatch.setattr(ss, "_config_env", lambda: {"MYKEY": "from-config"})
+    assert ss.get_secret("MYKEY") == "from-config"
+
+
+def test_get_secret_default_when_missing(monkeypatch):
+    monkeypatch.delenv("MYKEY", raising=False)
+    monkeypatch.setattr(ss, "_config_env", lambda: {})
+    assert ss.get_secret("MYKEY") is None
+    assert ss.get_secret("MYKEY", "fallback") == "fallback"
+
+
+# --- apply_config_env_to_environ -----------------------------------------
+
+
+def test_apply_no_override_preserves_real_env(monkeypatch):
+    monkeypatch.setattr(ss, "_config_env", lambda: {"A_REAL": "cfg-a", "B_NEW": "cfg-b"})
+    monkeypatch.setenv("A_REAL", "exported-a")
+    monkeypatch.delenv("B_NEW", raising=False)
+    try:
+        applied = ss.apply_config_env_to_environ()
+        assert applied == ["B_NEW"]            # only the unset one
+        import os
+
+        assert os.environ["A_REAL"] == "exported-a"  # export preserved
+        assert os.environ["B_NEW"] == "cfg-b"         # filled from config
+    finally:
+        import os
+
+        os.environ.pop("B_NEW", None)
+
+
+def test_apply_override_true_replaces(monkeypatch):
+    monkeypatch.setattr(ss, "_config_env", lambda: {"A_REAL": "cfg-a"})
+    monkeypatch.setenv("A_REAL", "exported-a")
+    applied = ss.apply_config_env_to_environ(override=True)
+    assert applied == ["A_REAL"]
+    import os
+
+    assert os.environ["A_REAL"] == "cfg-a"
+
+
+def test_list_secret_names(monkeypatch):
+    monkeypatch.setattr(ss, "_config_env", lambda: {"Z": "1", "A": "2"})
+    assert ss.list_secret_names() == ["A", "Z"]  # sorted
+
+
+# --- set_secret / delete_secret round-trip through the global config ------
+
+
+@pytest.fixture
+def isolated_global_config(tmp_path, monkeypatch):
+    """Point the global config at a tmp file; no project/local bleed."""
+    cfg = tmp_path / ".clawcodex" / "config.json"
+    monkeypatch.setattr(config_module, "GLOBAL_CONFIG_FILE", cfg)
+    monkeypatch.setattr(config_module, "_default_manager", None)
+    # Neutralize project/local discovery so the real repo's .claude/config.json
+    # doesn't leak into the merged view.
+    monkeypatch.setattr(config_module, "_find_git_root", lambda *a, **k: None)
+    return cfg
+
+
+def test_set_secret_writes_config_and_resolves(isolated_global_config, monkeypatch):
+    monkeypatch.delenv("ROUNDTRIP_KEY", raising=False)
+    ss.set_secret("ROUNDTRIP_KEY", "s3cret-value")
+
+    # 1. persisted to the single config file under "env"
+    data = json.loads(isolated_global_config.read_text(encoding="utf-8"))
+    assert data["env"]["ROUNDTRIP_KEY"] == "s3cret-value"
+
+    # 2. mirrored into the live process immediately
+    import os
+
+    assert os.environ["ROUNDTRIP_KEY"] == "s3cret-value"
+
+    # 3. resolves from config even after the live mirror is cleared
+    monkeypatch.delenv("ROUNDTRIP_KEY", raising=False)
+    monkeypatch.setattr(config_module, "_default_manager", None)  # drop cache
+    assert ss.get_secret("ROUNDTRIP_KEY") == "s3cret-value"
+    assert "ROUNDTRIP_KEY" in ss.list_secret_names()
+
+
+def test_set_secret_rejects_empty_name(isolated_global_config):
+    with pytest.raises(ValueError):
+        ss.set_secret("  ", "x")
+
+
+def test_delete_secret(isolated_global_config, monkeypatch):
+    monkeypatch.delenv("TO_DELETE", raising=False)
+    ss.set_secret("TO_DELETE", "v")
+    monkeypatch.setattr(config_module, "_default_manager", None)
+    assert ss.delete_secret("TO_DELETE") is True
+
+    monkeypatch.setattr(config_module, "_default_manager", None)
+    data = json.loads(isolated_global_config.read_text(encoding="utf-8"))
+    assert "TO_DELETE" not in data.get("env", {})
+    # deleting an absent key is a no-op returning False
+    monkeypatch.setattr(config_module, "_default_manager", None)
+    assert ss.delete_secret("NEVER_EXISTED") is False

--- a/tests/test_tool_system_tools.py
+++ b/tests/test_tool_system_tools.py
@@ -289,24 +289,21 @@ class TestWebFetchTool(ToolSystemTests):
 
 
 class TestWebSearchTool(ToolSystemTests):
-    """Tests for the refactored WebSearchTool.
+    """Tests for the Tavily-backed WebSearchTool.
 
-    All tests that exercise DuckDuckGo search patch both the package-based
-    search (``_ddg_package_search``) and ``urllib.request.urlopen`` to ensure
-    the HTML-scraping fallback path is taken with controlled data, regardless
-    of whether ``duckduckgo-search`` is installed in the test environment.
+    The HTTP boundary (``urllib.request.urlopen``) is patched to return canned
+    Tavily JSON and ``TAVILY_API_KEY`` is set, so the tests exercise the real
+    ``_tavily_search`` parsing + domain filtering + output formatting without
+    any network access.
     """
 
-    _DDG_PKG_PATCH = "src.tool_system.tools.web_search._ddg_package_search"
-
-    def test_web_search_parses_results(self) -> None:
-        html_doc = """
-        <a class="result__a" href="https://example.com/">Example</a>
-        <a class="result__snippet">Snippet</a>
-        """
+    @staticmethod
+    def _tavily_resp(results: list[dict[str, str]]):
+        """Build a fake urlopen response carrying a Tavily ``{"results": [...]}`` body."""
+        payload = json.dumps({"results": results}).encode("utf-8")
 
         class _Resp(io.BytesIO):
-            headers = {"Content-Type": "text/html"}
+            headers = {"Content-Type": "application/json"}
 
             def __enter__(self):
                 return self
@@ -314,8 +311,19 @@ class TestWebSearchTool(ToolSystemTests):
             def __exit__(self, exc_type, exc, tb):
                 return False
 
-        with patch(self._DDG_PKG_PATCH, return_value=None), \
-             patch.object(urllib.request, "urlopen", return_value=_Resp(html_doc.encode("utf-8"))):
+        return _Resp(payload)
+
+    def _patch_tavily(self, results: list[dict[str, str]]):
+        """Context: a configured key + urlopen returning the given Tavily results."""
+        return patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}), patch.object(
+            urllib.request, "urlopen", return_value=self._tavily_resp(results)
+        )
+
+    def test_web_search_parses_results(self) -> None:
+        env, net = self._patch_tavily(
+            [{"title": "Example", "url": "https://example.com/", "content": "Snippet"}]
+        )
+        with env, net:
             out = WebSearchTool.call({"query": "example"}, self.ctx).output
             self.assertEqual(out["query"], "example")
             self.assertIn("duration_seconds", out)
@@ -332,24 +340,11 @@ class TestWebSearchTool(ToolSystemTests):
 
     def test_web_search_domain_filtering_blocked(self) -> None:
         """blocked_domains filters out matching results."""
-        html_doc = """
-        <a class="result__a" href="https://example.com/">Example</a>
-        <a class="result__snippet">Snippet one</a>
-        <a class="result__a" href="https://other.org/">Other</a>
-        <a class="result__snippet">Snippet two</a>
-        """
-
-        class _Resp(io.BytesIO):
-            headers = {"Content-Type": "text/html"}
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-        with patch(self._DDG_PKG_PATCH, return_value=None), \
-             patch.object(urllib.request, "urlopen", return_value=_Resp(html_doc.encode("utf-8"))):
+        env, net = self._patch_tavily([
+            {"title": "Example", "url": "https://example.com/", "content": "Snippet one"},
+            {"title": "Other", "url": "https://other.org/", "content": "Snippet two"},
+        ])
+        with env, net:
             out = WebSearchTool.call(
                 {"query": "test", "blocked_domains": ["example.com"]}, self.ctx
             ).output
@@ -360,24 +355,11 @@ class TestWebSearchTool(ToolSystemTests):
 
     def test_web_search_domain_filtering_allowed(self) -> None:
         """allowed_domains keeps only matching results."""
-        html_doc = """
-        <a class="result__a" href="https://example.com/">Example</a>
-        <a class="result__snippet">Snippet one</a>
-        <a class="result__a" href="https://other.org/">Other</a>
-        <a class="result__snippet">Snippet two</a>
-        """
-
-        class _Resp(io.BytesIO):
-            headers = {"Content-Type": "text/html"}
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-        with patch(self._DDG_PKG_PATCH, return_value=None), \
-             patch.object(urllib.request, "urlopen", return_value=_Resp(html_doc.encode("utf-8"))):
+        env, net = self._patch_tavily([
+            {"title": "Example", "url": "https://example.com/", "content": "Snippet one"},
+            {"title": "Other", "url": "https://other.org/", "content": "Snippet two"},
+        ])
+        with env, net:
             out = WebSearchTool.call(
                 {"query": "test", "allowed_domains": ["example.com"]}, self.ctx
             ).output
@@ -387,24 +369,11 @@ class TestWebSearchTool(ToolSystemTests):
 
     def test_web_search_subdomain_matching(self) -> None:
         """Subdomain matching: sub.example.com matches example.com."""
-        html_doc = """
-        <a class="result__a" href="https://sub.example.com/page">Sub Example</a>
-        <a class="result__snippet">Sub snippet</a>
-        <a class="result__a" href="https://badexample.com/">Bad Example</a>
-        <a class="result__snippet">Bad snippet</a>
-        """
-
-        class _Resp(io.BytesIO):
-            headers = {"Content-Type": "text/html"}
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-        with patch(self._DDG_PKG_PATCH, return_value=None), \
-             patch.object(urllib.request, "urlopen", return_value=_Resp(html_doc.encode("utf-8"))):
+        env, net = self._patch_tavily([
+            {"title": "Sub Example", "url": "https://sub.example.com/page", "content": "Sub snippet"},
+            {"title": "Bad Example", "url": "https://badexample.com/", "content": "Bad snippet"},
+        ])
+        with env, net:
             out = WebSearchTool.call(
                 {"query": "test", "allowed_domains": ["example.com"]}, self.ctx
             ).output
@@ -435,7 +404,7 @@ class TestWebSearchTool(ToolSystemTests):
             "query": "python docs",
             "results": [
                 "**Python** -- The official docs (https://python.org)",
-                {"tool_use_id": "ddg-search", "content": [{"title": "Python", "url": "https://python.org"}]},
+                {"tool_use_id": "tavily-search", "content": [{"title": "Python", "url": "https://python.org"}]},
             ],
             "duration_seconds": 0.5,
         }
@@ -445,16 +414,14 @@ class TestWebSearchTool(ToolSystemTests):
         self.assertIn("REMINDER", api_result["content"])
         self.assertIn("sources", api_result["content"].lower())
 
-    def test_web_search_ddg_package_path(self) -> None:
-        """When duckduckgo-search package is available, use it instead of HTML scraping."""
-        mock_results = [
-            {"title": "Pkg Result", "url": "https://pkg.example.com/", "snippet": "From package"},
-        ]
-        with patch(self._DDG_PKG_PATCH, return_value=mock_results):
-            out = WebSearchTool.call({"query": "package test"}, self.ctx).output
-            self.assertEqual(out["query"], "package test")
-            links = out["results"][-1]
-            self.assertEqual(links["content"][0]["url"], "https://pkg.example.com/")
+    def test_web_search_unconfigured_raises(self) -> None:
+        """With no TAVILY_API_KEY set, search raises a clear 'configure' error."""
+        # Empty env var + empty config "env" block (isolate from real config).
+        with patch.dict(os.environ, {"TAVILY_API_KEY": ""}), \
+             patch("src.secret_store._config_env", return_value={}):
+            with self.assertRaises(Exception) as cm:
+                WebSearchTool.call({"query": "anything"}, self.ctx)
+            self.assertIn("TAVILY_API_KEY", str(cm.exception))
 
 
 class TestSleepTool(ToolSystemTests):

--- a/tests/test_web_fetch_extract.py
+++ b/tests/test_web_fetch_extract.py
@@ -1,0 +1,220 @@
+"""Tests for WebFetch parse/extract improvements: structured markdown,
+noise stripping, browser headers, and transparent gzip/deflate decoding."""
+
+from __future__ import annotations
+
+import gzip
+import urllib.error
+import zlib
+from pathlib import Path
+
+from src.tool_system.context import ToolContext
+from src.tool_system.tools import web_fetch
+from src.tool_system.tools.web_fetch import (
+    WebFetchTool,
+    _accept_header,
+    _charset_from_content_type,
+    _convert,
+    _fetch_with_redirect_handling,
+    _html_to_markdown,
+    _html_to_text,
+    _read_response_body,
+    _strip_noise_blocks,
+)
+
+
+class _Resp:
+    """Minimal urlopen-style response: .read(n), .headers, .status."""
+
+    def __init__(self, raw: bytes, headers: dict, status: int = 200):
+        self._raw = raw
+        self.headers = headers
+        self.status = status
+
+    def read(self, _n=None):
+        return self._raw
+
+
+# --- HTML -> markdown -----------------------------------------------------
+
+
+def test_strip_noise_blocks_removes_script_and_style():
+    html = '<p>keep</p><script>var s="drop-js"</script><style>.x{color:red}</style>'
+    out = _strip_noise_blocks(html)
+    assert "drop-js" not in out
+    assert "color:red" not in out
+    assert "keep" in out
+
+
+def test_html_to_markdown_preserves_structure_and_drops_noise():
+    html = (
+        '<html><body><h1>Title</h1>'
+        '<script>alert("secret-js")</script>'
+        '<p>Read <a href="https://example.org/doc">the docs</a> now.</p>'
+        '<style>.z{color:red}</style></body></html>'
+    )
+    md = _html_to_markdown(html)
+    assert "secret-js" not in md          # script contents dropped
+    assert "color:red" not in md          # style contents dropped
+    assert "Title" in md
+    if web_fetch._md is not None:          # markdownify installed -> link kept
+        assert "[the docs](https://example.org/doc)" in md
+    else:                                  # regex fallback -> text only
+        assert "the docs" in md
+
+
+# --- body decoding: gzip / deflate / charset ------------------------------
+
+
+def test_read_response_body_gzip():
+    body = b"<h1>Hello</h1>"
+    resp = _Resp(gzip.compress(body), {"Content-Encoding": "gzip", "Content-Type": "text/html"})
+    assert "<h1>Hello</h1>" in _read_response_body(resp)
+
+
+def test_read_response_body_deflate():
+    body = b"<p>deflated</p>"
+    resp = _Resp(zlib.compress(body), {"Content-Encoding": "deflate", "Content-Type": "text/html"})
+    assert "deflated" in _read_response_body(resp)
+
+
+def test_read_response_body_plain_identity():
+    resp = _Resp(b"<p>plain</p>", {"Content-Type": "text/html"})
+    assert "plain" in _read_response_body(resp)
+
+
+def test_read_response_body_respects_charset():
+    body = "Café".encode("latin-1")
+    resp = _Resp(body, {"Content-Type": "text/html; charset=latin-1"})
+    assert "Café" in _read_response_body(resp)
+
+
+def test_charset_from_content_type():
+    assert _charset_from_content_type("text/html; charset=ISO-8859-1") == "ISO-8859-1"
+    assert _charset_from_content_type('text/html; charset="utf-8"') == "utf-8"
+    assert _charset_from_content_type("text/html") is None
+    assert _charset_from_content_type("") is None
+
+
+# --- fetch sends browser-like headers -------------------------------------
+
+
+def test_fetch_sends_browser_headers(monkeypatch):
+    captured: dict = {}
+
+    def fake_open(self, req, timeout=None):
+        captured["ua"] = req.get_header("User-agent")
+        captured["accept_encoding"] = req.get_header("Accept-encoding")
+        return _Resp(b"<p>ok</p>", {"Content-Type": "text/html"})
+
+    monkeypatch.setattr("urllib.request.OpenerDirector.open", fake_open)
+    text, content_type, status = _fetch_with_redirect_handling("https://example.com/")
+
+    assert "Mozilla/5.0" in (captured["ua"] or "")     # not "claw-codex/0.1"
+    assert "gzip" in (captured["accept_encoding"] or "")
+    assert status == 200
+    assert "ok" in text
+
+
+# --- format dispatch (borrowed from opencode) -----------------------------
+
+_HTML = (
+    '<html><body><h1>Heading</h1>'
+    '<script>track("x")</script>'
+    '<p>Visit <a href="https://ex.org/d">the docs</a>.</p></body></html>'
+)
+
+
+def test_convert_markdown_preserves_links():
+    out = _convert(_HTML, "text/html", "markdown")
+    assert "Heading" in out
+    assert 'track("x")' not in out
+    if web_fetch._md is not None:
+        assert "[the docs](https://ex.org/d)" in out
+
+
+def test_convert_text_is_plain_no_markdown_syntax():
+    out = _convert(_HTML, "text/html", "text")
+    assert "Heading" in out and "the docs" in out
+    assert 'track("x")' not in out      # script subtree dropped
+    assert "](https://" not in out      # plain text, not markdown links
+
+
+def test_convert_html_returns_raw():
+    assert _convert("<p>raw</p>", "text/html", "html") == "<p>raw</p>"
+
+
+def test_convert_non_html_passthrough():
+    body = '{"k": 1}'
+    assert _convert(body, "application/json", "markdown") == body
+
+
+def test_convert_image_guard():
+    out = _convert("\x89PNG\x0d", "image/png", "markdown")
+    assert "non-text content" in out and "image/png" in out
+
+
+def test_html_to_text_drops_noise_tags():
+    out = _html_to_text('<div>keep<iframe>frame</iframe><style>.a{}</style></div>')
+    assert "keep" in out
+    assert "frame" not in out and ".a{}" not in out
+
+
+def test_accept_header_per_format():
+    assert "text/markdown" in _accept_header("markdown")
+    assert _accept_header("text").startswith("text/plain")
+    assert _accept_header("html").startswith("text/html")
+
+
+# --- Cloudflare challenge retry (borrowed from opencode) ------------------
+
+
+def test_cloudflare_challenge_retry(monkeypatch):
+    seen_uas: list = []
+
+    def fake_open(self, req, timeout=None):
+        seen_uas.append(req.get_header("User-agent"))
+        if len(seen_uas) == 1:
+            raise urllib.error.HTTPError(
+                req.full_url, 403, "Forbidden", {"cf-mitigated": "challenge"}, None
+            )
+        return _Resp(b"<p>passed</p>", {"Content-Type": "text/html"})
+
+    monkeypatch.setattr("urllib.request.OpenerDirector.open", fake_open)
+    text, content_type, status = _fetch_with_redirect_handling("https://example.com/")
+
+    assert len(seen_uas) == 2                 # retried once
+    assert seen_uas[0] != seen_uas[1]         # with a different UA
+    assert "Mozilla/5.0" in seen_uas[0]       # first try: browser UA
+    assert "passed" in text
+
+
+def test_plain_403_not_retried(monkeypatch):
+    seen = []
+
+    def fake_open(self, req, timeout=None):
+        seen.append(1)
+        raise urllib.error.HTTPError(req.full_url, 403, "Forbidden", {}, None)
+
+    monkeypatch.setattr("urllib.request.OpenerDirector.open", fake_open)
+    try:
+        _fetch_with_redirect_handling("https://example.com/")
+    except urllib.error.HTTPError:
+        pass
+    assert len(seen) == 1                      # no challenge marker -> no retry
+
+
+# --- end-to-end format param through WebFetchTool.call --------------------
+
+
+def test_format_param_end_to_end(monkeypatch):
+    html = b'<html><body><h1>T</h1><p>Body</p></body></html>'
+
+    def fake_open(self, req, timeout=None):
+        return _Resp(html, {"Content-Type": "text/html"})
+
+    monkeypatch.setattr("urllib.request.OpenerDirector.open", fake_open)
+    ctx = ToolContext(workspace_root=Path("/tmp"))
+    out = WebFetchTool.call({"url": "https://example.com/x", "format": "text"}, ctx).output
+    assert "Body" in out["result"]
+    assert "](https://" not in out["result"]   # text format, not markdown

--- a/tests/test_web_search_tavily.py
+++ b/tests/test_web_search_tavily.py
@@ -1,0 +1,122 @@
+"""Tests for the Tavily web-search backend (replaces DuckDuckGo)."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+
+import pytest
+
+from src.tool_system.context import ToolContext
+from src.tool_system.errors import ToolInputError
+from src.tool_system.tools.web_search import (
+    WebSearchTool,
+    _tavily_search,
+    _web_search_call,
+    is_web_search_configured,
+)
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._d = json.dumps(payload).encode("utf-8")
+
+    def read(self, _n=None):
+        return self._d
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_unconfigured_raises_clear_error(monkeypatch):
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    # Isolate from the developer's real ~/.clawcodex/config.json "env" block.
+    monkeypatch.setattr("src.secret_store._config_env", lambda: {})
+    assert is_web_search_configured() is False
+    with pytest.raises(ToolInputError) as exc:
+        _tavily_search("python")
+    assert "TAVILY_API_KEY" in str(exc.value)
+
+
+def test_configured_via_config_env(monkeypatch):
+    """A key stored in config.json's 'env' block configures search (no export)."""
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "src.secret_store._config_env", lambda: {"TAVILY_API_KEY": "tvly-from-config"}
+    )
+    assert is_web_search_configured() is True
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["auth"] = req.headers.get("Authorization")
+        return _FakeResp({"results": []})
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    _tavily_search("python")
+    assert captured["auth"] == "Bearer tvly-from-config"
+
+
+def test_parses_results_and_request_shape(monkeypatch):
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-test123")
+    assert is_web_search_configured() is True
+    payload = {
+        "results": [
+            {"title": "Python", "url": "https://python.org", "content": "The official site"},
+            {"title": "Docs", "url": "https://docs.python.org", "content": "Documentation"},
+        ]
+    }
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["auth"] = req.headers.get("Authorization")
+        captured["body"] = json.loads(req.data)
+        return _FakeResp(payload)
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    hits = _tavily_search("python", num=5)
+
+    assert len(hits) == 2
+    assert hits[0]["title"] == "Python"
+    assert hits[0]["url"] == "https://python.org"
+    assert hits[0]["snippet"] == "The official site"  # content -> snippet alias
+    assert captured["url"] == "https://api.tavily.com/search"
+    assert captured["method"] == "POST"
+    assert captured["auth"] == "Bearer tvly-test123"
+    assert captured["body"]["query"] == "python"
+    assert captured["body"]["max_results"] == 5
+    assert captured["body"]["include_answer"] is False
+
+
+def test_http_error_is_surfaced(monkeypatch):
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-bad")
+
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.HTTPError(req.full_url, 401, "Unauthorized", {}, None)
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    with pytest.raises(ToolInputError) as exc:
+        _tavily_search("python")
+    assert "401" in str(exc.value)
+
+
+def test_full_call_returns_tool_result(monkeypatch, tmp_path):
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-test")
+    payload = {"results": [{"title": "T", "url": "https://t.example", "content": "snippet here"}]}
+    monkeypatch.setattr("urllib.request.urlopen", lambda req, timeout=None: _FakeResp(payload))
+
+    result = _web_search_call({"query": "test query"}, ToolContext(workspace_root=tmp_path))
+    assert result.name == "WebSearch"
+    assert result.output["query"] == "test query"
+    # the structured links block carries the hit
+    blocks = result.output["results"]
+    assert any(isinstance(b, dict) and b.get("tool_use_id") == "tavily-search" for b in blocks)
+
+
+def test_tool_is_still_registered_and_named():
+    assert WebSearchTool.name == "WebSearch"
+    assert WebSearchTool.is_read_only({}) is True


### PR DESCRIPTION
Makes the deep-research web pipeline actually work end-to-end: **find URLs → store the key → fetch & parse**. Three related changes, two commits.

## 1. WebSearch — Tavily backend (replaces dead DuckDuckGo)
The old backend scraped DuckDuckGo HTML and returned **zero** results (package not installed, scrape yields nothing), so deep-research had no search.
- Ports a Tavily provider: `POST https://api.tavily.com/search` with `Authorization: Bearer $TAVILY_API_KEY`.
- Clear "configure search" error when the key is unset (no silent empty results).
- Mirrors `typescript/src/tools/WebSearchTool/providers/tavily.ts`.

## 2. secret_store — store/read API keys in one config file
Per the "single config file" preference, keys live in `~/.clawcodex/config.json` under a top-level `"env"` block — no `.env` files.
- `get_secret` resolves **exported env var → config `env` → default**; `set_secret` persists atomically (`0600`).
- Startup `init()` copies the `env` block into `os.environ` (override=False, so real exports/MDM win).
- `clawcodex config` shows stored keys **masked**.

## 3. WebFetch — deterministic markdown/text/html extraction (borrowed from opencode)
opencode's webfetch uses `turndown` + `htmlparser2` with **no model call**; this mirrors that (avoids paying an LLM per fetch).
- HTML→Markdown via `markdownify` (headings/lists/links preserved) — replaces the flat regex tag-strip that dumped nav/footer boilerplate.
- HTML→Text via BeautifulSoup, dropping `script/style/noscript/iframe/object/embed`.
- New `format` param (`markdown` default / `text` / `html`); per-format Accept headers.
- Robustness: browser User-Agent, Cloudflare-challenge retry, gzip/deflate decode, charset detection, image MIME guard.

## Tests
New: `test_web_search_tavily.py`, `test_secret_store.py`, `test_web_fetch_extract.py`; `TestWebSearchTool` reworked to mock Tavily. **123 passing** across the touched suites. Adds dependency `markdownify>=0.11` (pulls pure-Python beautifulsoup4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)