### PR TITLE
Fix event-loop deadlock from missing LLM client timeout (+ workflow schema-repair retry)

### DIFF
--- a/src/providers/openai_provider.py
+++ b/src/providers/openai_provider.py
@@ -33,14 +33,32 @@ class OpenAIProvider(OpenAICompatibleProvider):
             raise ModuleNotFoundError(
                 "openai package is not installed. Install optional dependencies to use OpenAIProvider."
             )
-        kwargs: dict[str, Any] = {"api_key": self.api_key}
+        import os
+
+        import httpx
+
+        # Bound how long a request may stall with NO bytes from the server.
+        # Without this the SDK's sync streaming read blocks forever when an
+        # endpoint accepts the request but never replies (observed with a
+        # LiteLLM proxy on streaming + tool calls) — which freezes the asyncio
+        # event loop the agent loop runs on, deadlocking every concurrent agent.
+        # ``read`` is the max gap *between* bytes, so legitimate long streams are
+        # fine as long as data keeps flowing. All tunable via env.
+        read_timeout = float(os.environ.get("CLAWCODEX_LLM_READ_TIMEOUT", "120"))
+        connect_timeout = float(os.environ.get("CLAWCODEX_LLM_CONNECT_TIMEOUT", "15"))
+        timeout = httpx.Timeout(connect=connect_timeout, read=read_timeout, write=30.0, pool=15.0)
+        max_retries = int(os.environ.get("CLAWCODEX_LLM_MAX_RETRIES", "1"))
+
+        kwargs: dict[str, Any] = {
+            "api_key": self.api_key,
+            "timeout": timeout,
+            "max_retries": max_retries,
+        }
         if self.base_url:
             kwargs["base_url"] = self.base_url
-        # Support SSL verification bypass for corporate/internal endpoints
-        import os
+        # Support SSL verification bypass for corporate/internal endpoints.
         if os.environ.get("CLAWCODEX_SSL_VERIFY", "").lower() in ("0", "false", "no"):
-            import httpx
-            kwargs["http_client"] = httpx.Client(verify=False)
+            kwargs["http_client"] = httpx.Client(verify=False, timeout=timeout)
         return OpenAI(**kwargs)
 
     def get_available_models(self) -> list[str]:

--- a/src/workflow/bundled/deep_research.py
+++ b/src/workflow/bundled/deep_research.py
@@ -83,7 +83,18 @@ for result in searches:
 
 if not claims:
     raise RuntimeError("No claims were gathered — the question may be too narrow or WebSearch is unavailable.")
-log(f"Gathered {len(claims)} distinct claims; cross-checking each.")
+
+# Cap the verify fan-out: the Verify phase spawns one agent per claim, so a very
+# thorough search model (opus gathered 32) would otherwise launch dozens of
+# concurrent agents — slow, costly, and prone to overrunning a flaky endpoint.
+# Keep the first N distinct claims (search angles are ordered most-authoritative
+# first). Logged, never silent.
+MAX_VERIFY_CLAIMS = 10
+if len(claims) > MAX_VERIFY_CLAIMS:
+    log(f"Gathered {len(claims)} claims; verifying the first {MAX_VERIFY_CLAIMS} to bound the fan-out.")
+    claims = claims[:MAX_VERIFY_CLAIMS]
+else:
+    log(f"Gathered {len(claims)} distinct claims; cross-checking each.")
 
 # ── Phase 2: cross-check every claim independently ───────────────────────────
 phase("Verify")

--- a/src/workflow/runner.py
+++ b/src/workflow/runner.py
@@ -17,6 +17,7 @@ testing (it needs a real provider) and is intentionally thin.
 
 from __future__ import annotations
 
+import json
 from typing import Any, Callable, Optional
 
 from src.utils.abort_controller import AbortController, AbortError
@@ -35,6 +36,34 @@ _SCHEMA_NUDGE = (
 )
 
 
+def _schema_repair_prompt(schema: Any, last_error: Optional[str]) -> str:
+    """A corrective user turn appended to the SAME conversation on retry.
+
+    The agent already has the data it gathered (search results, etc.) in context;
+    this turn quotes the exact validation failure and asks it to re-emit via the
+    tool — explicitly WITHOUT searching again. Cheap models that lapse into prose
+    or the wrong shape on the first pass reliably correct here, since they only
+    need to reformat data they already have.
+    """
+    reason = last_error or "you did not call the StructuredOutput tool at all"
+    try:
+        schema_json = json.dumps(schema, ensure_ascii=False)
+    except Exception:  # noqa: BLE001 — non-serializable schema: fall back to repr
+        schema_json = str(schema)
+    if len(schema_json) > 1500:
+        schema_json = schema_json[:1500] + " …"
+    return (
+        "Your previous response did not produce valid structured output. "
+        f"Reason: {reason}. "
+        "You already have everything you need from the conversation above — do NOT "
+        "search or fetch again. Now call the StructuredOutput tool exactly once, with "
+        f"arguments that exactly match this JSON Schema:\n{schema_json}\n"
+        "Every required field must be present with the correct type (an array must be a "
+        "JSON array, not a string), add no extra fields, and put your entire answer in "
+        "that single tool call."
+    )
+
+
 class LiveAgentRunner:
     def __init__(
         self,
@@ -47,6 +76,7 @@ class LiveAgentRunner:
         default_agent_type: str = "general-purpose",
         run_id: str = "wf",
         max_turns: Optional[int] = None,
+        schema_max_attempts: int = 3,
     ) -> None:
         self._provider = provider
         self._tool_registry = tool_registry
@@ -56,6 +86,10 @@ class LiveAgentRunner:
         self._default_agent_type = default_agent_type
         self._run_id = run_id
         self._max_turns = max_turns
+        # A schema agent that fails validation (or skips the tool) is re-run with
+        # a corrective prompt, up to this many TOTAL attempts. Retries cost extra
+        # only on failure — a model that gets it right first time pays nothing.
+        self._schema_max_attempts = max(1, schema_max_attempts)
 
     async def run(self, spec: AgentSpec, *, abort: AbortController, index: str) -> AgentOutcome:
         # isolation="worktree": run the agent in a throwaway git worktree so
@@ -87,7 +121,7 @@ class LiveAgentRunner:
         from src.agent.run_agent import RunAgentParams, run_agent
         from src.tasks.progress import ProgressTracker, update_progress_from_message
         from src.tool_system.registry import ToolRegistry
-        from src.types.messages import AssistantMessage
+        from src.types.messages import AssistantMessage, UserMessage
 
         agent_type = spec.agent_type or self._default_agent_type
         agent_definition = self._resolve_agent(agent_type)
@@ -96,91 +130,130 @@ class LiveAgentRunner:
         # Resolve the agent's *scoped, firewalled* toolset (applies
         # ALL_AGENT_DISALLOWED_TOOLS — including Workflow, so a subagent can't
         # recurse into another workflow — plus the agent definition's own tool
-        # scoping). We then pass it with use_exact_tools=True so run_agent keeps
-        # the injected StructuredOutput tool verbatim instead of re-resolving and
-        # dropping it. Belt-and-braces: strip Workflow even if it slips through.
+        # scoping). use_exact_tools=True (below) keeps the injected StructuredOutput
+        # tool verbatim. Belt-and-braces: strip Workflow even if it slips through.
         resolved = resolve_agent_tools(agent_definition, self._base_tools, is_async=False)
-        worker_tools = [t for t in resolved.resolved_tools if getattr(t, "name", "") != WORKFLOW_TOOL_NAME]
+        base_worker_tools = [
+            t for t in resolved.resolved_tools if getattr(t, "name", "") != WORKFLOW_TOOL_NAME
+        ]
 
-        collector: Optional[StructuredOutputCollector] = None
-        prompt = spec.prompt
-        structured_tool = None
-        if spec.schema is not None:
-            collector = StructuredOutputCollector(schema=spec.schema)
-            structured_tool = make_structured_output_tool(collector)
-            worker_tools = [t for t in worker_tools if getattr(t, "name", "") != SYNTHETIC_OUTPUT_TOOL_NAME]
-            worker_tools.append(structured_tool)
-            prompt = spec.prompt + _SCHEMA_NUDGE
-        available_tools = worker_tools
+        def _name(t: Any) -> str:
+            return getattr(t, "name", "")
 
-        # Tool DISPATCH resolves by name from the registry, not from
-        # ``available_tools`` — so the schema agent needs a per-call registry in
-        # which ``StructuredOutput`` is *our* validating tool (not the stock
-        # no-op) and ``Workflow`` is absent. Built per call so concurrent schema
-        # agents don't share a collector.
-        agent_registry = ToolRegistry()
-        for t in self._tool_registry.list_tools():
-            # Same firewall as the advertised pool: no Agent/Workflow/TaskStop/...
-            # so a subagent can't recurse or escalate via a by-name dispatch.
-            if getattr(t, "name", "") in ALL_AGENT_DISALLOWED_TOOLS:
-                continue
-            if structured_tool is not None and getattr(t, "name", "") == SYNTHETIC_OUTPUT_TOOL_NAME:
-                continue
-            agent_registry.register(t)
-        if structured_tool is not None:
-            agent_registry.register(structured_tool)
+        async def _attempt(prompt_text, collector, context_messages=None):
+            """Run the agent once. Returns (result, tokens, tool_use_count, messages).
 
-        params = RunAgentParams(
-            parent_context=parent_context,
-            agent_definition=agent_definition,
-            prompt=prompt,
-            available_tools=available_tools,
-            tool_registry=agent_registry,
-            provider=self._provider,
-            model=spec.model,
-            agent_id=agent_id,
-            abort_controller=abort,
-            max_turns=self._max_turns,
-            # Workflow subagents always run acceptEdits (file edits auto-approved)
-            # regardless of the session's mode — per the official spec. run_agent
-            # honors this override ahead of the inheritance rules.
-            permission_mode_override="acceptEdits",
-            # We already resolved + firewalled + injected; don't let run_agent
-            # re-resolve (which would drop the injected StructuredOutput tool).
-            use_exact_tools=True,
-        )
+            ``context_messages`` carries the prior conversation on a retry so the
+            agent keeps the data it already gathered. A fresh collector + registry
+            per attempt avoids cross-attempt contamination of the validating tool.
+            """
+            structured_tool = make_structured_output_tool(collector) if collector is not None else None
+            worker_tools = list(base_worker_tools)
+            if structured_tool is not None:
+                worker_tools = [t for t in worker_tools if _name(t) != SYNTHETIC_OUTPUT_TOOL_NAME]
+                worker_tools.append(structured_tool)
 
-        # Feed a ProgressTracker so finalize_agent_tool reports chapter-correct
-        # token totals (latest input + cumulative output) rather than the
-        # message.usage fallback — these tokens drive the workflow budget.
-        tracker = ProgressTracker()
-        messages: list = []
-        try:
-            async for message in run_agent(params):
-                messages.append(message)
-                if isinstance(message, AssistantMessage):
-                    try:
-                        update_progress_from_message(tracker, message)
-                    except Exception:  # noqa: BLE001 — progress is best-effort
-                        pass
-        except AbortError:
-            raise  # cancellation unwinds; the engine marks the agent aborted
+            # Tool DISPATCH resolves by name from a per-call registry in which
+            # StructuredOutput is *our* validating tool (not the stock no-op) and
+            # the disallowed tools (Agent/Workflow/TaskStop/...) are absent — so a
+            # subagent can't recurse or escalate via a by-name dispatch.
+            agent_registry = ToolRegistry()
+            for t in self._tool_registry.list_tools():
+                if _name(t) in ALL_AGENT_DISALLOWED_TOOLS:
+                    continue
+                if structured_tool is not None and _name(t) == SYNTHETIC_OUTPUT_TOOL_NAME:
+                    continue
+                agent_registry.register(t)
+            if structured_tool is not None:
+                agent_registry.register(structured_tool)
 
-        # finalize_agent_tool raises if the run produced no assistant message;
-        # the engine catches that and resolves agent() to None (a "death").
-        result = finalize_agent_tool(messages, agent_id, {"agent_type": agent_type}, progress=tracker)
-        tokens = result.total_tokens
-        tool_uses = result.total_tool_use_count
-
-        if spec.schema is not None:
-            assert collector is not None
-            if collector.succeeded:
-                return AgentOutcome(structured=collector.value, tokens=tokens, tool_use_count=tool_uses)
-            return AgentOutcome(
-                error=f"structured output not produced (last error: {collector.last_error})",
-                tokens=tokens,
-                tool_use_count=tool_uses,
+            params = RunAgentParams(
+                parent_context=parent_context,
+                agent_definition=agent_definition,
+                prompt=prompt_text,
+                context_messages=context_messages,
+                available_tools=worker_tools,
+                tool_registry=agent_registry,
+                provider=self._provider,
+                model=spec.model,
+                agent_id=agent_id,
+                abort_controller=abort,
+                max_turns=self._max_turns,
+                # Workflow subagents always run acceptEdits (file edits auto-approved)
+                # regardless of the session's mode — per the official spec.
+                permission_mode_override="acceptEdits",
+                # Already resolved + firewalled + injected; don't let run_agent
+                # re-resolve (which would drop the injected StructuredOutput tool).
+                use_exact_tools=True,
             )
 
-        text = "".join(block.get("text", "") for block in result.content)
-        return AgentOutcome(text=text, tokens=tokens, tool_use_count=tool_uses)
+            # ProgressTracker so finalize_agent_tool reports chapter-correct token
+            # totals (latest input + cumulative output) — these drive the budget.
+            tracker = ProgressTracker()
+            messages: list = []
+            try:
+                async for message in run_agent(params):
+                    messages.append(message)
+                    if isinstance(message, AssistantMessage):
+                        try:
+                            update_progress_from_message(tracker, message)
+                        except Exception:  # noqa: BLE001 — progress is best-effort
+                            pass
+            except AbortError:
+                raise  # cancellation unwinds; the engine marks the agent aborted
+
+            # finalize_agent_tool raises if the run produced no assistant message;
+            # the engine catches that and resolves agent() to None (a "death").
+            result = finalize_agent_tool(messages, agent_id, {"agent_type": agent_type}, progress=tracker)
+            return result, result.total_tokens, result.total_tool_use_count, messages
+
+        # ── text agent: single shot ──────────────────────────────────────────
+        if spec.schema is None:
+            result, tokens, tool_uses, _ = await _attempt(spec.prompt, None)
+            text = "".join(block.get("text", "") for block in result.content)
+            return AgentOutcome(text=text, tokens=tokens, tool_use_count=tool_uses)
+
+        # ── schema agent: emit-or-repair retry loop (context-preserving) ──────
+        # Cheap/weak models often return the wrong shape (a string where an array
+        # is required, a renamed/missing field) or skip the tool entirely — yet
+        # reliably reformat correctly once told exactly what's wrong. So on a miss
+        # we CONTINUE the same conversation (the agent keeps its gathered search
+        # results) with a corrective turn, rather than re-running from scratch:
+        # faster (no re-search) and higher-converging. Retries fire ONLY on
+        # failure, so a model that nails it first time (e.g. opus) pays nothing
+        # extra. Tokens accumulate across attempts to keep the budget accurate.
+        total_tokens = 0
+        total_tool_uses = 0
+        last_error: Optional[str] = None
+        convo: list = []
+        attempts = self._schema_max_attempts
+        for attempt in range(attempts):
+            collector = StructuredOutputCollector(schema=spec.schema)
+            if attempt == 0:
+                prompt_text = spec.prompt + _SCHEMA_NUDGE
+                context_messages = None
+            else:
+                prompt_text = _schema_repair_prompt(spec.schema, last_error)
+                context_messages = convo
+            result, tokens, tool_uses, produced = await _attempt(
+                prompt_text, collector, context_messages
+            )
+            total_tokens += tokens
+            total_tool_uses += tool_uses
+            if collector.succeeded:
+                return AgentOutcome(
+                    structured=collector.value,
+                    tokens=total_tokens,
+                    tool_use_count=total_tool_uses,
+                )
+            last_error = collector.last_error
+            # Carry the full conversation forward: prior context + this attempt's
+            # user turn (run_agent appends ``prompt`` as a user message but does
+            # not re-yield it) + the messages it produced.
+            convo = (context_messages or []) + [UserMessage(content=prompt_text)] + produced
+
+        return AgentOutcome(
+            error=f"structured output not produced after {attempts} attempt(s) (last error: {last_error})",
+            tokens=total_tokens,
+            tool_use_count=total_tool_uses,
+        )

--- a/tests/workflow/test_runner_integration.py
+++ b/tests/workflow/test_runner_integration.py
@@ -96,3 +96,57 @@ async def test_schema_not_produced_resolves_to_none(tmp_path):
     assert out.structured is None
     assert out.error is not None
     assert "structured output not produced" in out.error  # the schema-miss path, not an incidental error
+
+
+async def test_schema_repair_retry_succeeds_on_second_attempt(tmp_path):
+    """A weak model that skips the tool on attempt 1 is re-prompted and succeeds."""
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "integer"}},
+        "required": ["answer"],
+        "additionalProperties": False,
+    }
+    provider = _ScriptedProvider([
+        _resp("Here is my answer in prose: 7"),  # attempt 1: no tool call -> fails
+        _resp(tool_uses=[{"id": "s1", "name": "StructuredOutput", "input": {"answer": 7}}], finish="tool_use"),
+        _resp("done"),  # attempt 2 wrap-up turn
+    ])
+    runner = _runner(provider, tmp_path)
+    out = await runner.run(AgentSpec(prompt="produce", schema=schema), abort=create_abort_controller(), index="0")
+    assert out.structured == {"answer": 7}
+    assert out.error is None
+    assert len(provider.tools_seen) >= 3  # a 2nd attempt ran after the 1st failed
+
+
+async def test_schema_repair_exhausts_attempts(tmp_path):
+    """When every attempt fails, the error names the attempt count; tokens summed."""
+    schema = {"type": "object", "properties": {"answer": {"type": "integer"}}, "required": ["answer"]}
+    provider = _ScriptedProvider([_resp("never uses the tool")])
+    registry = build_default_registry(provider=provider)
+    runner = LiveAgentRunner(
+        provider=provider,
+        tool_registry=registry,
+        parent_context=ToolContext(workspace_root=tmp_path),
+        base_tools=list(registry.list_tools()),
+        resolve_agent=lambda _t: GENERAL_PURPOSE_AGENT,
+        run_id="wf_itest",
+        max_turns=4,
+        schema_max_attempts=2,
+    )
+    out = await runner.run(AgentSpec(prompt="produce", schema=schema), abort=create_abort_controller(), index="0")
+    assert out.structured is None
+    assert "after 2 attempt(s)" in out.error
+    assert provider._turn >= 2  # both attempts actually ran
+
+
+def test_schema_repair_prompt_quotes_error_and_schema():
+    from src.workflow.runner import _schema_repair_prompt
+
+    schema = {"type": "object", "properties": {"x": {"type": "integer"}}, "required": ["x"]}
+    s = _schema_repair_prompt(schema, "output.x: expected integer, got string")
+    assert "expected integer, got string" in s
+    assert "StructuredOutput" in s
+    assert '"required"' in s  # the schema JSON is embedded
+    assert "do NOT" in s and "search" in s  # tells the model not to re-search
+    # a None error (model skipped the tool) gets explanatory phrasing
+    assert "did not call the StructuredOutput tool" in _schema_repair_prompt(schema, None)


### PR DESCRIPTION
## The bug: a workflow that hung at 0% CPU for 35+ minutes

Running the bundled deep-research workflow against an OpenAI-compatible endpoint (a LiteLLM proxy serving `glm-5-maas`) would **deadlock** — frozen at 0% CPU, no network activity, no progress, indefinitely.

### Root cause (found via a linear, timeout-bounded diagnostic + `faulthandler` stack dump)

The OpenAI-compatible client (`src/providers/openai_provider.py`) was built with **no timeout**. A **streaming** request to an endpoint that accepts the connection but stalls mid-read blocks the synchronous SDK socket read **forever**:

```
ssl.read  ← blocked, no timeout
httpcore _receive_response_*
openai completions.create(stream=True)
openai_compatible.chat_stream_response
query._call_model_sync          ← runs ON the asyncio event loop
run_agent → LiveAgentRunner
```

Because that sync read runs **on the event loop** the agent loop drives, one hung stream freezes *every* "concurrent" workflow agent. `asyncio.wait_for` can't save it — the loop itself is blocked inside a sync C call, so the timeout never fires. (Non-streaming `chat` was unaffected, which is why direct tests passed and only the agent path hung — and intermittently, so some runs slipped through.)

## Fixes

**1. Provider read timeout (the deadlock fix).** Give the client a bounded `read` timeout — the max gap *between* bytes, so legitimate long streams keep working as long as data flows — plus connect timeout and `max_retries`. All env-tunable: `CLAWCODEX_LLM_READ_TIMEOUT` (120s), `CLAWCODEX_LLM_CONNECT_TIMEOUT` (15s), `CLAWCODEX_LLM_MAX_RETRIES` (1).

**2. Context-preserving schema-repair retry.** When a schema agent yields no valid structured output (wrong shape, missing field, or no tool call), `LiveAgentRunner` now **continues the same conversation** with a corrective turn quoting the exact validation error + schema, asking it to re-emit *without* re-searching. Preserves gathered data; retries fire only on failure. `schema_max_attempts` (default 3) is configurable.

**3. Bounded verify fan-out.** `deep_research` caps the Verify phase to the first 10 claims (one agent per claim, so a thorough model could otherwise launch dozens). Logged, never silent.

## Validation (same diagnostic, after the fix)

| Layer | Before | After |
|---|---|---|
| Single schema agent | **hung forever** | completes in ~60–106s |
| **Two concurrent agents** | froze the workflow | ✅ **2.8s** (`['A','B']`) |
| Tools (WebSearch/WebFetch) | ✅ | ✅ |

156 tests pass (`tests/workflow/` + `tests/test_provider_config.py`), incl. new retry tests (succeeds-on-2nd-attempt, exhausts-attempts, repair-prompt contents).

## Known follow-ups (not deadlock-related)
- **Type strictness:** weak models (glm) return JSON types as strings (`"42"`, an array as a string). Strict schema validation rejects these even after retries — needs lenient coercion in the `StructuredOutput` validator.
- **`glm-5-maas` streaming is slow** (~35s/call via this proxy) — functional but sluggish; the deeper sync-call-blocks-the-loop architecture (true concurrency) is a separate, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)