### PR TITLE
Register bundled /deep-research into the REPL/TUI command surface

### DIFF
--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -1263,6 +1263,19 @@ def get_builtin_commands() -> list[Command]:
     ]
     if is_buddy_command_enabled():
         cmds.append(BUDDY_COMMAND)
+    # Bundled dynamic-workflow slash commands (e.g. /deep-research). Registering
+    # them here (gated) surfaces them in BOTH command suggestions and dispatch —
+    # which read the global registry this populates — instead of only the
+    # aggregator's get_commands(), which has no real consumers.
+    try:
+        from src.workflow.gating import is_workflows_enabled
+
+        if is_workflows_enabled():
+            from .workflows_integration import bundled_workflow_commands
+
+            cmds.extend(bundled_workflow_commands())
+    except Exception:  # noqa: BLE001 — never break command listing on a bad file
+        pass
     return cmds
 
 

--- a/src/command_system/workflows_integration.py
+++ b/src/command_system/workflows_integration.py
@@ -80,8 +80,14 @@ def bundled_workflow_commands() -> list[Command]:
     command registry that both command suggestions and dispatch read — the
     aggregator's :func:`get_commands` that also lists them has no real consumers.
     Project/personal workflows are cwd-dependent and remain the aggregator's job.
+
+    Includes the ``/workflows`` viewer so the Rich REPL can dispatch it (the TUI
+    has its own ``open_dialog`` fast-path, which runs before registry dispatch,
+    so registering here doesn't disturb it).
     """
-    out: list[Command] = []
+    from .workflows_command import WORKFLOWS_COMMAND
+
+    out: list[Command] = [WORKFLOWS_COMMAND]
     deep = _deep_research_command()
     if deep is not None:
         out.append(deep)

--- a/src/command_system/workflows_integration.py
+++ b/src/command_system/workflows_integration.py
@@ -72,6 +72,22 @@ def _deep_research_command() -> Optional[PromptCommand]:
     )
 
 
+def bundled_workflow_commands() -> list[Command]:
+    """The cwd-independent bundled workflow slash commands (currently
+    ``/deep-research``).
+
+    Surfaced via ``get_builtin_commands()`` so they register into the global
+    command registry that both command suggestions and dispatch read — the
+    aggregator's :func:`get_commands` that also lists them has no real consumers.
+    Project/personal workflows are cwd-dependent and remain the aggregator's job.
+    """
+    out: list[Command] = []
+    deep = _deep_research_command()
+    if deep is not None:
+        out.append(deep)
+    return out
+
+
 def _discover_dir(directory: Path, loaded_from: str) -> list[PromptCommand]:
     commands: list[PromptCommand] = []
     try:

--- a/tests/test_workflow_command_registration.py
+++ b/tests/test_workflow_command_registration.py
@@ -34,3 +34,30 @@ def test_global_registry_resolves_deep_research(monkeypatch):
     assert getattr(cmd, "kind", None) == "workflow"
     # the dispatched prompt is the Workflow-tool directive, not raw text
     assert "Workflow tool" in getattr(cmd, "markdown_content", "")
+
+
+def test_global_registry_resolves_workflows_viewer(monkeypatch):
+    """``/workflows`` must dispatch in the Rich REPL (reads runtime_tasks)."""
+    monkeypatch.delenv("CLAUDE_CODE_DISABLE_WORKFLOWS", raising=False)
+    register_builtin_commands(None)
+    assert get_command_registry().get("workflows") is not None
+    assert "workflows" in _names(get_builtin_commands())
+
+
+def test_workflows_viewer_lists_runs():
+    """Given a runtime_tasks registry with a local_workflow task, it lists it."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from src.command_system.workflows_command import WORKFLOWS_COMMAND
+
+    task = SimpleNamespace(
+        type="local_workflow", status="running", workflow_name="deep-research",
+        run_id="wf_abc123", summary="Search · 4 agents",
+    )
+    ctx = SimpleNamespace(tool_context=SimpleNamespace(runtime_tasks=SimpleNamespace(all=lambda: [task])))
+    out = asyncio.run(WORKFLOWS_COMMAND.run("", ctx))
+    assert "deep-research" in out.message and "wf_abc123" in out.message
+
+    empty = SimpleNamespace(tool_context=SimpleNamespace(runtime_tasks=SimpleNamespace(all=lambda: [])))
+    assert "No workflow runs" in asyncio.run(WORKFLOWS_COMMAND.run("", empty)).message

--- a/tests/test_workflow_command_registration.py
+++ b/tests/test_workflow_command_registration.py
@@ -1,0 +1,36 @@
+"""The bundled /deep-research workflow must reach the command surface.
+
+Regression guard: the workflow PromptCommands were produced by the aggregator's
+``get_commands()`` but never registered into the global command registry that
+suggestions + dispatch actually read, so ``/deep-research`` had no autocomplete
+and dispatched as raw text. They are now surfaced via ``get_builtin_commands()``.
+"""
+
+from __future__ import annotations
+
+from src.command_system.builtins import get_builtin_commands, register_builtin_commands
+from src.command_system.registry import get_command_registry
+
+
+def _names(cmds):
+    return {getattr(c, "name", None) for c in cmds}
+
+
+def test_deep_research_in_builtin_commands_when_enabled(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_DISABLE_WORKFLOWS", raising=False)
+    assert "deep-research" in _names(get_builtin_commands())
+
+
+def test_deep_research_absent_when_workflows_disabled(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")
+    assert "deep-research" not in _names(get_builtin_commands())
+
+
+def test_global_registry_resolves_deep_research(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_DISABLE_WORKFLOWS", raising=False)
+    register_builtin_commands(None)  # populates the global registry
+    cmd = get_command_registry().get("deep-research")
+    assert cmd is not None
+    assert getattr(cmd, "kind", None) == "workflow"
+    # the dispatched prompt is the Workflow-tool directive, not raw text
+    assert "Workflow tool" in getattr(cmd, "markdown_content", "")


### PR DESCRIPTION
## Bug

Typing `/deep-research …` in a session did nothing useful: **no autocomplete** for `/deep-`, and the command "ran" as a bogus `Skill` call with the model narrating fake progress. `/workflows` likewise showed only a help listing.

## Root cause

The workflow slash commands (`/deep-research`, `/workflows`) are produced by the command **aggregator** (`get_commands()`), but **nothing consumes `get_commands()`** for the actual command surface:
- **Suggestions** (`build_command_suggestions`) source from a hardcoded builtin list + the **global command registry** + skills.
- **Dispatch** (`execute_command_async`) reads the **global command registry**.

Both read the global registry, which `register_builtin_commands` populates — and the workflow commands were never registered there. So `/deep-research` was invisible to autocomplete and fell through to the model as **raw text** (which improvised a `Skill` call), and `/workflows` fell through to the help listing.

(All prior workflow testing drove `run_workflow` directly, never the slash-command path — so this gap wasn't caught.)

## Fix

Surface the cwd-independent **bundled** workflow commands through `get_builtin_commands()`, gated by `is_workflows_enabled()` (mirrors the `BUDDY_COMMAND` pattern). They now register into the global registry that both suggestions and dispatch read:

- **`/deep-research`** autocompletes and injects the *"Call the Workflow tool with `script_path`…"* directive (verified working end-to-end: the model launches the Workflow tool).
- **`/workflows`** dispatches in the Rich REPL, reading `runtime_tasks` via the command context's `tool_context` to list running/recent runs. The TUI keeps its `open_dialog` fast-path (runs before registry dispatch); suggestions dedupe by name so `/workflows` isn't doubled.

## Tests
`tests/test_workflow_command_registration.py` — present/absent by gate, both commands resolved by the global registry, the deep-research directive, and the `/workflows` viewer listing a run. 68 command-system tests pass.

## Known follow-up (out of scope)
**cwd-dependent** project/personal workflows (`.claude/workflows/*.py`) still only live in the aggregator — a global singleton can't hold per-cwd commands; wiring those into the session needs a cwd-aware step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)