### PR TITLE
Stop the model from running away after launching a workflow

### DIFF
--- a/src/command_system/workflows_integration.py
+++ b/src/command_system/workflows_integration.py
@@ -29,7 +29,13 @@ def _directive(name: str, path: str) -> str:
         f'Launch the dynamic workflow "{name}" — do NOT do the work yourself. '
         f"Call the Workflow tool with `script_path` set to \"{path}\" and pass the "
         f"user's input as `args` (parse it as JSON if it looks structured, otherwise "
-        f"pass it as a string):\n\n$ARGUMENTS"
+        f"pass it as a string).\n\n"
+        f"The Workflow tool launches the run in the BACKGROUND and returns a `run_id` "
+        f"immediately. As soon as it returns, STOP: reply with one short sentence "
+        f"confirming the workflow started (mention the run_id) and END YOUR TURN. Do "
+        f"NOT wait for it, poll it, call any tool again, or write the report yourself — "
+        f"the finished report is delivered automatically when the run completes.\n\n"
+        f"$ARGUMENTS"
     )
 
 

--- a/tests/test_workflow_command_registration.py
+++ b/tests/test_workflow_command_registration.py
@@ -33,7 +33,12 @@ def test_global_registry_resolves_deep_research(monkeypatch):
     assert cmd is not None
     assert getattr(cmd, "kind", None) == "workflow"
     # the dispatched prompt is the Workflow-tool directive, not raw text
-    assert "Workflow tool" in getattr(cmd, "markdown_content", "")
+    directive = getattr(cmd, "markdown_content", "")
+    assert "Workflow tool" in directive
+    # ...and it tells the model to STOP after launching (background run), so the
+    # main turn doesn't run away "waiting" for the result.
+    assert "END YOUR TURN" in directive
+    assert "background" in directive.lower()
 
 
 def test_global_registry_resolves_workflows_viewer(monkeypatch):


### PR DESCRIPTION
## Bug

After `/deep-research` launches the Workflow tool (which returns a `run_id` immediately and runs in the **background**), the main assistant turn **runs away** — observed: `Thinking… 2m+ · ↓150–170k tokens`, on multiple models including a fast/smart one (deepseek-v4-pro via OpenRouter). The model says *"let me wait for the results"* and keeps generating instead of ending its turn.

## Root cause

The `/deep-research` directive told the model to **launch** the workflow but said nothing about what to do **after**. With no instruction, the model improvises — "waiting" or writing the report itself — and generates until it nears the context limit. A background workflow returns immediately and delivers its result via a later notification, so the model should just confirm and stop.

> Note: this commit (`4ad2999`) was authored against PR #267 but #267 merged at an earlier commit, so the fix never reached `main`. This PR lands it.

## Fix

Spell out the async contract in the directive: *the Workflow tool launches in the background and returns a `run_id` immediately; after it returns, confirm the run_id in one sentence and **END YOUR TURN** — do not wait, poll, re-call tools, or write the report yourself; the result arrives automatically when the run finishes.*

## Tests
`tests/test_workflow_command_registration.py` asserts the directive contains `END YOUR TURN` and mentions the background contract. 5 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)