### PR TITLE
Apply LLM read timeout to ALL openai-compatible providers (not just OpenAI)

### DIFF
--- a/src/providers/openai_compatible.py
+++ b/src/providers/openai_compatible.py
@@ -13,6 +13,32 @@ from typing import Any, Generator, Optional
 from .base import BaseProvider, ChatResponse, MessageInput, TextChunkCallback
 
 
+def _apply_client_timeout(client: Any) -> Any:
+    """Bound an OpenAI-SDK client's read timeout + retries (env-tunable).
+
+    Without this, a streaming request to an endpoint that accepts the connection
+    but stalls mid-read blocks the *synchronous* SDK read for the SDK's 600s
+    default — and that read runs on the asyncio event loop the agent loop drives,
+    so one stalled stream freezes every concurrent workflow agent. ``read`` is
+    the max gap BETWEEN bytes, so legitimate long streams keep working as long as
+    data keeps flowing. Applied centrally (base ``client`` property) so every
+    subclass is covered. Tunable via CLAWCODEX_LLM_READ_TIMEOUT /
+    CLAWCODEX_LLM_CONNECT_TIMEOUT / CLAWCODEX_LLM_MAX_RETRIES.
+    """
+    try:
+        import os
+
+        import httpx
+
+        read = float(os.environ.get("CLAWCODEX_LLM_READ_TIMEOUT", "120"))
+        connect = float(os.environ.get("CLAWCODEX_LLM_CONNECT_TIMEOUT", "15"))
+        max_retries = int(os.environ.get("CLAWCODEX_LLM_MAX_RETRIES", "1"))
+        timeout = httpx.Timeout(connect=connect, read=read, write=30.0, pool=15.0)
+        return client.with_options(timeout=timeout, max_retries=max_retries)
+    except Exception:  # noqa: BLE001 — never break client creation over timeout cfg
+        return client
+
+
 def _anthropic_image_block_to_openai(block: dict[str, Any]) -> dict[str, Any] | None:
     """Translate an Anthropic image content block to OpenAI's
     ``image_url`` shape.
@@ -394,9 +420,16 @@ class OpenAICompatibleProvider(BaseProvider):
 
     @property
     def client(self) -> Any:
-        """Get or create the SDK client (lazy initialization)."""
+        """Get or create the SDK client (lazy initialization).
+
+        A bounded read timeout is applied centrally here so EVERY
+        openai-compatible provider (openai, openrouter, deepseek, glm, …) is
+        protected from a stalled streaming read blocking the asyncio event loop
+        — not just OpenAIProvider. The SDK default is read=600s, which freezes
+        concurrent workflow agents for up to 10 minutes on a stalled stream.
+        """
         if self._client is None:
-            self._client = self._create_client()
+            self._client = _apply_client_timeout(self._create_client())
         return self._client
 
     def _prepare_messages(self, messages: list[MessageInput]) -> list[dict[str, Any]]:

--- a/src/providers/openai_provider.py
+++ b/src/providers/openai_provider.py
@@ -28,37 +28,24 @@ class OpenAIProvider(OpenAICompatibleProvider):
         super().__init__(api_key, base_url, model or "gpt-5.4")
 
     def _create_client(self) -> Any:
-        """Create OpenAI SDK client."""
+        """Create OpenAI SDK client.
+
+        The read timeout that prevents a stalled stream from freezing the event
+        loop is applied centrally by ``OpenAICompatibleProvider.client`` (via
+        ``_apply_client_timeout``) for every provider, so it isn't set here.
+        """
         if OpenAI is None:  # pragma: no cover
             raise ModuleNotFoundError(
                 "openai package is not installed. Install optional dependencies to use OpenAIProvider."
             )
-        import os
-
-        import httpx
-
-        # Bound how long a request may stall with NO bytes from the server.
-        # Without this the SDK's sync streaming read blocks forever when an
-        # endpoint accepts the request but never replies (observed with a
-        # LiteLLM proxy on streaming + tool calls) — which freezes the asyncio
-        # event loop the agent loop runs on, deadlocking every concurrent agent.
-        # ``read`` is the max gap *between* bytes, so legitimate long streams are
-        # fine as long as data keeps flowing. All tunable via env.
-        read_timeout = float(os.environ.get("CLAWCODEX_LLM_READ_TIMEOUT", "120"))
-        connect_timeout = float(os.environ.get("CLAWCODEX_LLM_CONNECT_TIMEOUT", "15"))
-        timeout = httpx.Timeout(connect=connect_timeout, read=read_timeout, write=30.0, pool=15.0)
-        max_retries = int(os.environ.get("CLAWCODEX_LLM_MAX_RETRIES", "1"))
-
-        kwargs: dict[str, Any] = {
-            "api_key": self.api_key,
-            "timeout": timeout,
-            "max_retries": max_retries,
-        }
+        kwargs: dict[str, Any] = {"api_key": self.api_key}
         if self.base_url:
             kwargs["base_url"] = self.base_url
         # Support SSL verification bypass for corporate/internal endpoints.
+        import os
         if os.environ.get("CLAWCODEX_SSL_VERIFY", "").lower() in ("0", "false", "no"):
-            kwargs["http_client"] = httpx.Client(verify=False, timeout=timeout)
+            import httpx
+            kwargs["http_client"] = httpx.Client(verify=False)
         return OpenAI(**kwargs)
 
     def get_available_models(self) -> list[str]:

--- a/tests/test_provider_timeout.py
+++ b/tests/test_provider_timeout.py
@@ -1,0 +1,31 @@
+"""Every OpenAI-SDK-based provider must get a bounded read timeout.
+
+Regression: the read timeout that stops a stalled stream from blocking the event
+loop was added only to OpenAIProvider, so openrouter/deepseek/glm inherited the
+SDK's 600s default and froze workflow agents. It is now applied centrally in the
+base ``OpenAICompatibleProvider.client`` property.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.providers.deepseek_provider import DeepSeekProvider
+from src.providers.openai_provider import OpenAIProvider
+from src.providers.openrouter_provider import OpenRouterProvider
+
+_OPENAI_SDK_PROVIDERS = (OpenAIProvider, OpenRouterProvider, DeepSeekProvider)
+
+
+@pytest.mark.parametrize("cls", _OPENAI_SDK_PROVIDERS)
+def test_provider_has_bounded_read_timeout(cls):
+    p = cls(api_key="x", base_url="https://example.com/v1", model="m")
+    # default 120s — far below the openai SDK's 600s default
+    assert p.client.timeout.read <= 120.0
+    assert p.client.max_retries == 1
+
+
+def test_read_timeout_is_env_tunable(monkeypatch):
+    monkeypatch.setenv("CLAWCODEX_LLM_READ_TIMEOUT", "45")
+    p = OpenRouterProvider(api_key="x", base_url="https://x/v1", model="m")
+    assert p.client.timeout.read == 45.0


### PR DESCRIPTION
## Bug

PR #266 added a bounded read timeout to stop a stalled stream from blocking the asyncio event loop — but **only on `OpenAIProvider`**. `openrouter`, `deepseek`, and `glm` are separate subclasses with their own `_create_client`, so they kept the openai SDK's **600s** default read timeout.

Observed live on `openrouter` / `deepseek-v4-pro`: `/deep-research` search agents sat at **"0 tokens"** because each model call could block the (event-loop-bound) sync read for up to 10 minutes, and the calls serialize.

## Fix

Apply the timeout **centrally** in `OpenAICompatibleProvider.client` via `_apply_client_timeout` (`client.with_options(timeout=…, max_retries=…)`), so every subclass — present and future — is covered. Removed the now-redundant per-provider block from `OpenAIProvider`.

Verified: `OpenAIProvider`, `OpenRouterProvider`, `DeepSeekProvider` all report `read=120s, max_retries=1`; env-tunable via `CLAWCODEX_LLM_READ_TIMEOUT` / `_CONNECT_TIMEOUT` / `_MAX_RETRIES`. (GLM uses the zhipuai SDK, not the openai SDK; `_apply_client_timeout` degrades gracefully there.)

## Tests
`tests/test_provider_timeout.py` — bounded timeout across all three openai-SDK providers + env-tunability. 13 tests pass.

## Important: this is necessary but NOT sufficient for deep-research on these models
A live end-to-end test (openrouter/deepseek) showed the timeout now applies, but the **search agent still failed**: 133s, then `structured output not produced (last error: None)` — deepseek does the web search but **never calls the `StructuredOutput` tool**, so 0 claims (same failure mode as glm/haiku). Plus the sync calls block the loop, so agents run serially. Those are separate, deeper issues (forced `tool_choice` for structured output; off-loop model calls for concurrency) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)