### PR TITLE
Run model calls off the event loop so parallel workflow agents don't serialize

### DIFF
--- a/src/query/query.py
+++ b/src/query/query.py
@@ -590,50 +590,49 @@ async def _call_model_sync(
     # synchronous chat() if the provider doesn't support structured streaming.
     if _diag:
         logger.warning("[DIAG] _call_model_sync: calling provider (streaming)...")
-    try:
+    def _do_provider_call():
+        # ``abort_signal`` reaches the provider so a tripped controller can close
+        # the streaming HTTP response immediately. ``on_text_chunk`` (when set)
+        # fires chunks live; falls back to a kwargless call if the provider's
+        # signature doesn't accept it, and to plain ``chat()`` if the provider
+        # has no streaming at all (emulating chunks from the final text).
         try:
-            # ``abort_signal`` reaches the provider so a tripped controller
-            # can close the streaming HTTP response immediately rather than
-            # waiting for the model to finish generating. Without this
-            # plumb, ESC during a tool-use-only response (no intermediate
-            # text chunks for an ``on_text_chunk`` to observe) waits the
-            # full model latency before the outer query loop bails.
-            # Forward on_text_chunk so the SDK fires chunks live (and
-            # the chunk callback can raise AbortError to tear down the
-            # stream mid-flight). Falls back to a kwargless call if
-            # the provider's signature doesn't accept on_text_chunk.
             if on_text_chunk is not None:
                 try:
-                    response = provider.chat_stream_response(
+                    return provider.chat_stream_response(
                         api_messages,
                         on_text_chunk=on_text_chunk,
                         abort_signal=abort_signal,
                         **call_kwargs,
                     )
                 except TypeError:
-                    response = provider.chat_stream_response(
+                    return provider.chat_stream_response(
                         api_messages, abort_signal=abort_signal, **call_kwargs,
                     )
-            else:
-                response = provider.chat_stream_response(
-                    api_messages, abort_signal=abort_signal, **call_kwargs,
-                )
+            return provider.chat_stream_response(
+                api_messages, abort_signal=abort_signal, **call_kwargs,
+            )
         except (NotImplementedError, AttributeError):
             if _diag:
                 logger.warning("[DIAG] _call_model_sync: streaming not supported, falling back to chat()")
-            response = provider.chat(api_messages, **call_kwargs)
-            # Emulate streaming chunks from the final text when the
-            # caller asked for live streaming (on_text_chunk set) but
-            # the provider only supports plain chat(). Legacy
-            # ``agent_loop._emit_text_chunks`` did this so the headless
-            # ``--include-partial-messages`` flag and CLI live-text UX
-            # work uniformly across providers — without it, a
-            # ``stream=True`` caller paired with a non-streaming
-            # provider would see the entire response materialize at
-            # once after the model finishes.
-            if on_text_chunk is not None and response.content:
+            resp = provider.chat(api_messages, **call_kwargs)
+            if on_text_chunk is not None and resp.content:
                 from ..tool_system.renderers import _emit_text_chunks
-                _emit_text_chunks(on_text_chunk, response.content)
+                _emit_text_chunks(on_text_chunk, resp.content)
+            return resp
+
+    try:
+        # The provider call is a BLOCKING sync call (streaming read on a worker
+        # thread + a poll loop). Running it directly on the event loop blocks it,
+        # so concurrent agents (e.g. a workflow's parallel() fan-out) serialize —
+        # one model call at a time. When there's no live-UI streaming callback
+        # (background/workflow agents have on_text_chunk=None), run it OFF the
+        # loop via to_thread so those agents truly run in parallel. The
+        # interactive path keeps its callbacks firing on the event-loop thread.
+        if on_text_chunk is None:
+            response = await asyncio.to_thread(_do_provider_call)
+        else:
+            response = _do_provider_call()
     except AbortError:
         # User-initiated cancel — propagate so the query loop's
         # ``except AbortError: pass`` boundary unwinds to the

--- a/tests/workflow/test_agent_concurrency.py
+++ b/tests/workflow/test_agent_concurrency.py
@@ -1,0 +1,70 @@
+"""Concurrent workflow agents must run their model calls in PARALLEL.
+
+Regression: the sync provider call ran on the asyncio event loop, so a workflow's
+parallel() fan-out serialized — each agent's model call blocked the loop until it
+finished (observed live: search agents stuck at "0 tokens"). The provider call now
+runs off-loop (to_thread) when there's no live-UI callback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from src.providers.base import ChatResponse
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.agent.agent_definitions import GENERAL_PURPOSE_AGENT
+from src.utils.abort_controller import create_abort_controller
+from src.workflow.runner import LiveAgentRunner
+from src.workflow.types import AgentSpec
+
+_SLEEP = 0.4
+
+
+class _SleepProvider:
+    """Each model call blocks for _SLEEP seconds (simulates real latency)."""
+
+    model = "fake"
+
+    def _resp(self):
+        return ChatResponse(
+            content="ok", model="fake",
+            usage={"input_tokens": 1, "output_tokens": 1},
+            finish_reason="stop", tool_uses=None,
+        )
+
+    def chat_stream_response(self, messages, tools=None, on_text_chunk=None, abort_signal=None, **kw):
+        time.sleep(_SLEEP)
+        return self._resp()
+
+    def chat(self, messages, tools=None, **kw):
+        time.sleep(_SLEEP)
+        return self._resp()
+
+
+def _runner(provider, tmp_path):
+    registry = build_default_registry(provider=provider)
+    return LiveAgentRunner(
+        provider=provider, tool_registry=registry,
+        parent_context=ToolContext(workspace_root=tmp_path),
+        base_tools=list(registry.list_tools()),
+        resolve_agent=lambda _t: GENERAL_PURPOSE_AGENT, run_id="conc", max_turns=2,
+    )
+
+
+async def test_concurrent_agents_run_in_parallel(tmp_path):
+    runner = _runner(_SleepProvider(), tmp_path)
+
+    async def one(i):
+        return await runner.run(
+            AgentSpec(prompt=f"reply {i}"), abort=create_abort_controller(), index=str(i),
+        )
+
+    t0 = time.monotonic()
+    outs = await asyncio.gather(*[one(i) for i in range(4)])
+    dt = time.monotonic() - t0
+
+    assert all(o is not None for o in outs)
+    # 4 agents x 0.4s: serialized -> ~1.6s; parallel -> ~0.4s. Generous bound.
+    assert dt < 1.0, f"agents serialized ({dt:.2f}s) — off-loop model call regressed"


### PR DESCRIPTION
## Bug (user-reported, then proven)

A single WebSearch is fast, but a workflow's **parallel agents** sit at "0 tokens" for minutes. The user's hypothesis — parallel WebSearch/WebFetch agents have an issue — was exactly right.

`_call_model_sync` is `async` but invokes the provider's **synchronous** streaming call (`chat_stream_response` + its poll loop) **directly on the asyncio event loop**. That blocks the loop for the entire model call, so a workflow's `parallel()` fan-out runs **one model call at a time**.

### Proof (instrumented timing test, openrouter/deepseek)

Before:
```
[6.24s] START → [8.82s] END    agent 1
[8.82s] START → [11.67s] END   agent 2   ← starts exactly when agent 1 ends
[11.67s] START → [15.49s] END  agent 3
[15.50s] START → [19.13s] END  agent 4
MAX concurrent model calls in flight: 1  → SERIALIZED (event loop blocked)
```

## Fix

When there is **no live-UI streaming callback** (background/workflow agents have `on_text_chunk=None`), run the blocking provider call via `asyncio.to_thread`, so the event loop stays free and concurrent agents truly run in parallel. The interactive path (`on_text_chunk` set) is **unchanged** — its callbacks keep firing on the event-loop thread, so no UI thread-safety risk.

After:
```
SINGLE agent:        4.28s
4 CONCURRENT agents: 4.07s   (1.0x — same as one)
[4.29s] START asyncio_0/1/2/3   ← all four overlap, on worker threads
MAX concurrent model calls in flight: 4  → TRULY PARALLEL
```

4 agents in **~4s instead of ~17s**. This is a core fix — it helps every `parallel()` workflow.

## Tests
`tests/workflow/test_agent_concurrency.py` asserts 4 concurrent agents finish well under the serialized time. Existing query/agent-loop/runner tests (57) + workflow tests (151) pass.

## Scope note
This fixes the *parallelism/"stuck"* problem. It does **not** fix the separate issue that some non-Claude models (glm, deepseek) don't reliably emit `StructuredOutput` after a web search (0 claims) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)