### PR TITLE
deep_research: forbid tools in the synthesize step (fixes 'stuck at Synthesize')

### DIFF
--- a/src/workflow/bundled/deep_research.py
+++ b/src/workflow/bundled/deep_research.py
@@ -121,7 +121,9 @@ phase("Synthesize")
 bullet_lines = "\n".join(f"- {c['claim']} (source: {c['source']})" for c in survivors)
 report = await agent(
     f'Write a clear, well-organized report answering: "{question}".\n\n'
-    f"Use ONLY these cross-checked claims, citing the source for each point:\n\n{bullet_lines}\n\n"
+    f"You already have everything you need below — do NOT use any tools (no web search, "
+    f"no web fetch, no retrieving anything). Write the report DIRECTLY from these "
+    f"cross-checked claims, citing the source for each point:\n\n{bullet_lines}\n\n"
     f"Structure it with a short summary followed by the details. Note any open questions.",
     label="synthesize",
     phase="Synthesize",


### PR DESCRIPTION
## Bug

After the parallelism fix (#270), `/deep-research` reached the **Synthesize** stage and then sat there for a very long time (888k tokens).

Reproduced the synthesize step in isolation on deepseek: it returned a **58-char fragment** — `"Let me try alternative approaches to retrieve the content."` — not a report. The Synthesize agent has all the cross-checked claims in its prompt, but with the full tool pool available, deepseek **ignores "use ONLY these claims" and tries to WebFetch the source URLs**, looping through its turns. With higher `max_turns` that loop runs for minutes.

## Fix

Tell the synthesize agent explicitly **not to use any tools** and to write directly from the claims it was given.

### Verified on deepseek
| | Before | After |
|---|---|---|
| `tool_uses` | 4+ (looping) | **0** |
| output | 58-char fragment | **1623-char cited report** |
| time | 24s of looping → nothing | ~13s → real report |

```
# Core Product Advantage of Micron HBM
## Summary  Micron's HBM3E ... >1.2 TB/s bandwidth ... ~30% lower power ...
## Details  ### 1. Industry-Leading Bandwidth ...
```

## Note
This unblocks Synthesize. Separately, deepseek's overall verbosity (the 888k tokens across Search+Verify) is a model characteristic, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)