### PR TITLE
Rich /workflows monitor: phase progress + per-agent stats (tokens/tools/duration)

### DIFF
--- a/src/command_system/workflows_command.py
+++ b/src/command_system/workflows_command.py
@@ -48,8 +48,16 @@ class WorkflowsCommand(InteractiveCommand):
                 message="No workflow runs. Start one with /deep-research or by asking for a workflow.",
                 display="system",
             )
-        lines = [f"• {_format_workflow(t)}" for t in runs]
-        return InteractiveOutcome(message="Workflows:\n" + "\n".join(lines), display="system")
+        from src.workflow.progress import render_run_lines
+
+        blocks: list[str] = []
+        for t in runs:
+            lines = render_run_lines(t)
+            run_id = getattr(t, "run_id", "") or ""
+            if run_id and lines:
+                lines[0] = f"{lines[0]}  (run: {run_id})"
+            blocks.append("\n".join(lines))
+        return InteractiveOutcome(message="\n\n".join(blocks), display="system")
 
 
 WORKFLOWS_COMMAND = WorkflowsCommand(

--- a/src/tui/screens/workflow_dialog.py
+++ b/src/tui/screens/workflow_dialog.py
@@ -26,34 +26,33 @@ from .dialog_base import DialogScreen
 
 
 def format_workflow_detail(state: Any) -> list[str]:
-    """Render a workflow run's phases → agents tree as display lines."""
-    lines = [f"{getattr(state, 'workflow_name', 'workflow')}  [{getattr(state, 'status', '?')}]"]
-    summary = getattr(state, "summary", None)
-    if summary:
-        lines.append(summary)
-    progress = getattr(state, "progress", None)
-    phases = getattr(progress, "phases", None) or []
-    if not phases:
-        lines.append("(no phases yet)")
-    for phase in phases:
-        agents = getattr(phase, "agents", []) or []
-        lines.append(f"▸ {phase.title}  ({len(agents)} agents · {phase.token_total} tokens)")
-        for agent in agents:
-            lines.append(f"    • [{agent.status}] {agent.label}  ({agent.tokens} tok)")
-    return lines
+    """Render a workflow run's header + phases → agents tree as display lines.
+
+    Delegates to the shared :func:`src.workflow.progress.render_run_lines` so the
+    REPL ``/workflows`` command and this TUI dialog show identical rich detail
+    (status icons, agent type, tokens, tool count, duration, phase progress).
+    """
+    from src.workflow.progress import render_run_lines
+
+    return render_run_lines(state)
 
 
 def _agent_options(state: Any) -> list[SelectOption]:
+    from src.workflow.progress import format_tokens
+
     progress = getattr(state, "progress", None)
     phases = getattr(progress, "phases", None) or []
     options: list[SelectOption] = []
     for phase in phases:
         for agent in getattr(phase, "agents", []) or []:
+            stats = f"{format_tokens(agent.tokens)} tok"
+            if agent.tool_count:
+                stats += f" · {agent.tool_count} tools"
             options.append(
                 SelectOption(
-                    label=f"[{agent.status}] {agent.label}",
+                    label=f"{agent.icon} {agent.label}",
                     value=agent.key or "",
-                    description=f"{agent.tokens} tok · {phase.title}",
+                    description=f"{stats} · {phase.title}",
                     disabled=not agent.key,
                 )
             )

--- a/src/workflow/progress.py
+++ b/src/workflow/progress.py
@@ -9,10 +9,20 @@ optional ``on_change`` callback so the TUI can repaint.
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass, field
 from typing import Callable, Literal, Optional
 
 AgentStatus = Literal["running", "completed", "failed", "skipped", "cached"]
+
+#: Status glyphs for the /workflows monitor (mirrors the Claude Code view).
+_STATUS_ICON = {
+    "running": "●",
+    "completed": "✔",
+    "failed": "✗",
+    "skipped": "⊘",
+    "cached": "⚡",
+}
 
 
 @dataclass
@@ -26,6 +36,15 @@ class AgentRecord:
     #: The agent's deterministic call-path key (e.g. "0.1") — lets the UI/task
     #: layer target this specific agent for skip/retry.
     key: str = ""
+    #: Display metadata surfaced in the /workflows monitor.
+    agent_type: str = ""
+    tool_count: int = 0
+    started_at: Optional[float] = None  # time.monotonic() at start (display only)
+    elapsed: Optional[float] = None     # seconds, set on finish
+
+    @property
+    def icon(self) -> str:
+        return _STATUS_ICON.get(self.status, "•")
 
 
 @dataclass
@@ -37,6 +56,11 @@ class PhaseRecord:
     @property
     def token_total(self) -> int:
         return sum(a.tokens for a in self.agents)
+
+    @property
+    def done_count(self) -> int:
+        """Agents that have finished (any non-running status)."""
+        return sum(1 for a in self.agents if a.status != "running")
 
 
 class WorkflowProgress:
@@ -68,9 +92,19 @@ class WorkflowProgress:
         self._logs.append(message)
         self._changed()
 
-    def agent_started(self, index: int, label: str, phase: Optional[str], key: str = "") -> AgentRecord:
+    def agent_started(
+        self,
+        index: int,
+        label: str,
+        phase: Optional[str],
+        key: str = "",
+        agent_type: str = "",
+    ) -> AgentRecord:
         phase = phase or self._current_phase
-        record = AgentRecord(index=index, label=label, phase=phase, key=key)
+        record = AgentRecord(
+            index=index, label=label, phase=phase, key=key,
+            agent_type=agent_type, started_at=time.monotonic(),
+        )
         self._phase_for(phase).agents.append(record)
         self._changed()
         return record
@@ -82,10 +116,14 @@ class WorkflowProgress:
         status: AgentStatus,
         tokens: int = 0,
         error: Optional[str] = None,
+        tool_count: int = 0,
     ) -> None:
         record.status = status
         record.tokens = tokens
         record.error = error
+        record.tool_count = tool_count
+        if record.started_at is not None:
+            record.elapsed = time.monotonic() - record.started_at
         self._changed()
 
     # ── reads ──────────────────────────────────────────────────────────────
@@ -126,3 +164,76 @@ class WorkflowProgress:
     def _changed(self) -> None:
         if self._on_change is not None:
             self._on_change(self)
+
+
+# ---------------------------------------------------------------------------
+# Rendering for the /workflows monitor (shared by the REPL command + TUI dialog)
+# ---------------------------------------------------------------------------
+
+def format_tokens(n: int) -> str:
+    """Compact token count: 79600 -> '79.6k', 950 -> '950'."""
+    try:
+        n = int(n)
+    except (TypeError, ValueError):
+        return "0"
+    if n >= 1000:
+        return f"{n / 1000:.1f}k"
+    return str(n)
+
+
+def format_duration(seconds: Optional[float]) -> str:
+    """Compact duration: 75 -> '1m 15s', 45 -> '45s', None -> ''."""
+    if seconds is None:
+        return ""
+    s = int(seconds)
+    if s >= 60:
+        return f"{s // 60}m {s % 60:02d}s"
+    return f"{s}s"
+
+
+def format_agent_line(agent: AgentRecord, *, indent: str = "      ") -> str:
+    """One rich agent row: '✔ label  type   12.3k tok · 5 tools · 1m 15s'."""
+    parts = [f"{format_tokens(agent.tokens)} tok"]
+    if agent.tool_count:
+        parts.append(f"{agent.tool_count} tools")
+    dur = format_duration(agent.elapsed)
+    if dur:
+        parts.append(dur)
+    typ = f"  {agent.agent_type}" if agent.agent_type else ""
+    line = f"{indent}{agent.icon} {agent.label}{typ}   {' · '.join(parts)}"
+    if agent.error:
+        line += f"  — {agent.error[:60]}"
+    return line
+
+
+def render_run_lines(state: object) -> list[str]:
+    """Render a workflow run's header + phases -> agents tree as display lines.
+
+    Mirrors the Claude Code /workflows monitor: per-phase progress (done/total)
+    and per-agent status icon, type, tokens, tool count, and duration. ``state``
+    is duck-typed (a LocalWorkflowTask or any object exposing ``workflow_name``,
+    ``status``, and ``progress``) so the REPL command and the TUI dialog share it.
+    """
+    name = getattr(state, "workflow_name", None) or "workflow"
+    status = getattr(state, "status", "?") or "?"
+    progress = getattr(state, "progress", None)
+    phases = list(getattr(progress, "phases", None) or [])
+
+    total = sum(len(p.agents) for p in phases)
+    done = sum(p.done_count for p in phases)
+    header = f"{name}  [{status}]"
+    if total:
+        tok = getattr(progress, "token_total", 0)
+        header += f"  ·  {done}/{total} agents · {format_tokens(tok)} tok"
+    lines = [header]
+
+    if not phases:
+        lines.append("  (no phases yet)")
+        return lines
+
+    for p in phases:
+        prog = f"{p.done_count}/{len(p.agents)}" if p.agents else "—"
+        lines.append(f"  ▸ {p.title}  ({prog} · {format_tokens(p.token_total)} tok)")
+        for a in p.agents:
+            lines.append(format_agent_line(a))
+    return lines

--- a/src/workflow/runtime.py
+++ b/src/workflow/runtime.py
@@ -158,12 +158,15 @@ class WorkflowRun:
             isolation=isolation,
         )
         eff_label = label or agent_type or "agent"
+        eff_agent_type = agent_type or "general-purpose"
         eff_phase = phase or self._progress.current_phase
 
         key_str = key_to_str(key)
         cached = self._journal.lookup(key, spec)
         if cached is not MISS:
-            record = self._progress.agent_started(self._next_display(), eff_label, eff_phase, key_str)
+            record = self._progress.agent_started(
+                self._next_display(), eff_label, eff_phase, key_str, agent_type=eff_agent_type
+            )
             self._progress.agent_finished(record, status="cached")
             return cached
 
@@ -172,7 +175,9 @@ class WorkflowRun:
         self._scheduler.reserve()
         self._budget.check()
 
-        record = self._progress.agent_started(self._next_display(), eff_label, eff_phase, key_str)
+        record = self._progress.agent_started(
+            self._next_display(), eff_label, eff_phase, key_str, agent_type=eff_agent_type
+        )
         attempts = 0
         while True:
             child = create_child_abort_controller(self._controller)
@@ -202,14 +207,21 @@ class WorkflowRun:
 
         self._budget.add(outcome.tokens)
         if outcome.error is not None:
-            self._progress.agent_finished(record, status="failed", tokens=outcome.tokens, error=outcome.error)
+            self._progress.agent_finished(
+                record, status="failed", tokens=outcome.tokens,
+                error=outcome.error, tool_count=outcome.tool_use_count,
+            )
             result: Any = None
         elif outcome.skipped:
-            self._progress.agent_finished(record, status="skipped", tokens=outcome.tokens)
+            self._progress.agent_finished(
+                record, status="skipped", tokens=outcome.tokens, tool_count=outcome.tool_use_count,
+            )
             result = None
         else:
             result = outcome.structured if schema is not None else outcome.text
-            self._progress.agent_finished(record, status="completed", tokens=outcome.tokens)
+            self._progress.agent_finished(
+                record, status="completed", tokens=outcome.tokens, tool_count=outcome.tool_use_count,
+            )
 
         self._journal.record(key, spec, result)
         return result

--- a/tests/tui/test_workflow_dialog.py
+++ b/tests/tui/test_workflow_dialog.py
@@ -57,7 +57,10 @@ def test_format_workflow_detail_renders_phases_and_agents():
     assert "demo" in blob
     assert "Search" in blob
     assert "finder" in blob
-    assert "completed" in blob
+    # the completed agent renders with the ✔ status icon + token stats + phase progress
+    assert "✔" in blob
+    assert "tok" in blob
+    assert "1/1" in blob
 
 
 def test_format_workflow_detail_handles_no_phases():

--- a/tests/workflow/test_progress_render.py
+++ b/tests/workflow/test_progress_render.py
@@ -1,0 +1,86 @@
+"""Rich /workflows monitor rendering — icons, agent type, tokens, tools,
+duration, and phase progress (mirrors the Claude Code workflow view)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.workflow.progress import (
+    WorkflowProgress,
+    format_duration,
+    format_tokens,
+    render_run_lines,
+)
+
+
+def test_format_tokens():
+    assert format_tokens(950) == "950"
+    assert format_tokens(79600) == "79.6k"
+    assert format_tokens(0) == "0"
+    assert format_tokens(None) == "0"
+
+
+def test_format_duration():
+    assert format_duration(None) == ""
+    assert format_duration(45) == "45s"
+    assert format_duration(75) == "1m 15s"
+
+
+def test_agent_record_carries_metadata():
+    prog = WorkflowProgress([{"title": "S"}])
+    prog.start_phase("S")
+    rec = prog.agent_started(0, "finder", "S", "0", agent_type="researcher")
+    assert rec.agent_type == "researcher"
+    assert rec.started_at is not None
+    assert rec.icon == "●"  # running
+    prog.agent_finished(rec, status="completed", tokens=1200, tool_count=5)
+    assert rec.tool_count == 5
+    assert rec.elapsed is not None
+    assert rec.icon == "✔"
+
+
+def test_phase_done_count():
+    prog = WorkflowProgress([{"title": "S"}])
+    prog.start_phase("S")
+    r1 = prog.agent_started(0, "a", "S", "0")
+    prog.agent_finished(r1, status="completed", tokens=1)
+    prog.agent_started(1, "b", "S", "1")  # still running
+    assert prog.phases[0].done_count == 1
+    assert len(prog.phases[0].agents) == 2
+
+
+def test_render_run_lines_rich():
+    prog = WorkflowProgress([{"title": "Search"}, {"title": "Verify"}])
+    prog.start_phase("Search")
+    rec = prog.agent_started(0, "google-search", "Search", "0", agent_type="researcher")
+    prog.agent_finished(rec, status="completed", tokens=20300, tool_count=6)
+    prog.start_phase("Verify")
+    prog.agent_started(1, "verify", "Verify", "1")  # running
+    state = SimpleNamespace(workflow_name="deep-research", status="running", progress=prog)
+    blob = "\n".join(render_run_lines(state))
+
+    assert "deep-research" in blob
+    assert "1/2 agents" in blob        # overall progress
+    assert "✔ google-search" in blob   # completed icon + label
+    assert "researcher" in blob        # agent type
+    assert "20.3k tok" in blob         # compact tokens
+    assert "6 tools" in blob           # tool count
+    assert "● verify" in blob          # running icon
+    assert "▸ Search  (1/1" in blob    # per-phase progress
+    assert "▸ Verify  (0/1" in blob
+
+
+def test_render_run_lines_no_phases():
+    state = SimpleNamespace(workflow_name="x", status="running", progress=WorkflowProgress([]))
+    assert "no phases" in "\n".join(render_run_lines(state)).lower()
+
+
+def test_render_run_lines_shows_error():
+    prog = WorkflowProgress([{"title": "S"}])
+    prog.start_phase("S")
+    rec = prog.agent_started(0, "bad", "S", "0")
+    prog.agent_finished(rec, status="failed", tokens=10, error="structured output not produced")
+    state = SimpleNamespace(workflow_name="x", status="running", progress=prog)
+    blob = "\n".join(render_run_lines(state))
+    assert "✗ bad" in blob
+    assert "structured output not produced" in blob


### PR DESCRIPTION
## What

Bring the `/workflows` monitor up to the Claude Code workflow view. Before, it showed one flat line per agent:
```
deep-research  [running]
▸ Search  (4 agents · 75456 tokens)
    • [completed] search:official docs  (17132 tok)
```

After — per-phase progress (done/total) and, per agent, a **status icon**, **agent type**, **compact tokens**, **tool count**, and **duration**:
```
deep-research  [running]  ·  2/3 agents · 37.4k tok
  ▸ Search  (2/2 · 37.4k tok)
      ✔ search:official docs  general-purpose   17.1k tok · 6 tools · 41s
      ✔ search:recent news    general-purpose   20.3k tok · 43 tools · 1m 15s
  ▸ Verify  (0/1 · 0 tok)
      ● verify  general-purpose   0 tok
  ▸ Synthesize  (— · 0 tok)
```

Icons: `●` running · `✔` completed · `✗` failed · `⊘` skipped · `⚡` cached.

## How

- **`progress.py`** — `AgentRecord` gains `agent_type` / `tool_count` / `started_at` / `elapsed` + an `icon` property; `PhaseRecord` gains `done_count`. New shared formatters: `format_tokens`, `format_duration`, `format_agent_line`, `render_run_lines`.
- **`runtime.py`** — propagate `agent_type` (on start) and `tool_count` + wall-clock duration (on finish). The runner already computed `tool_use_count`; the engine was dropping it.
- **`workflows_command.py`** (Rich REPL) and **`workflow_dialog.py`** (Textual TUI) both render via the shared `render_run_lines`, so the two surfaces stay identical; the TUI agent select-list also shows the icon + tool count.

## Tests
`tests/workflow/test_progress_render.py` (formatters, agent metadata, rich render, error row, phase progress) + updated the dialog test for the icon format. **166 workflow/TUI/command tests pass.**

## Note
This is the data + formatting layer (shared by both surfaces). The full interactive two-pane TUI with arrow-key phase navigation + `p`/`s` (pause/save) bindings from the reference is a follow-up — the engine doesn't pause/save yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)