### PR TITLE
docs: document session, settings, and env config.json blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,9 +328,25 @@ The configuration file is saved in in `~/.clawcodex/config.json`. Example struct
       "base_url": "https://api.deepseek.com",
       "default_model": "deepseek-v4-pro"
     }
+  },
+  "session": {
+    "auto_save": true,
+    "max_history": 100
+  },
+  "settings": {
+    "advisor_model": "claude-sonnet-4-6",
+    "advisor_client_mode": false,
+    "advisor_provider": "openai"
+  },
+  "env": {
+    "TAVILY_API_KEY": "tvly-YOUR-TAVILY-API-KEY"
   }
 }
 ```
+
+- **`session`** — REPL session persistence: `auto_save` writes each session automatically; `max_history` caps retained turns.
+- **`settings`** — the advisor model used for background helpers (`advisor_provider` / `advisor_model`, and `advisor_client_mode` to route via the client).
+- **`env`** — secrets and environment values injected at startup (e.g. `TAVILY_API_KEY` for web search). Managed via `clawcodex config`; keys here are exported into the process environment without overriding anything you already set in your shell.
 
 ### Run
 


### PR DESCRIPTION
## What

The README's `config.json` example (under **Configuration**) only documented `default_provider` and `providers`. This adds the three blocks users actually need to configure runtime behavior and secrets:

```json
  "session": {
    "auto_save": true,
    "max_history": 100
  },
  "settings": {
    "advisor_model": "claude-sonnet-4-6",
    "advisor_client_mode": false,
    "advisor_provider": "openai"
  },
  "env": {
    "TAVILY_API_KEY": "tvly-YOUR-TAVILY-API-KEY"
  }
```

Each gets a one-line explainer:
- **`session`** — REPL session persistence (`auto_save`, `max_history`).
- **`settings`** — advisor model for background helpers (`advisor_provider` / `advisor_model` / `advisor_client_mode`).
- **`env`** — secrets injected into the environment at startup (e.g. `TAVILY_API_KEY` for web search), managed via `clawcodex config`, non-overriding of existing shell env.

## Security
The Tavily key in the example is a **placeholder** (`tvly-YOUR-TAVILY-API-KEY`) — no real secret is committed. Real keys live only in `~/.clawcodex/config.json` on disk.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)