### PR TITLE
components C1: multi-option permission flow wired to the rule engine

### DIFF
--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -160,8 +160,6 @@ def run_headless(options: HeadlessOptions) -> int:
     # round-5 fields. When skip_permissions wins, force bypass mode + bypass
     # availability so the registry's ``has_permissions_to_use_tool`` check
     # short-circuits to ``allow``.
-    from src.permissions.types import ToolPermissionContext
-
     if options.skip_permissions:
         effective_mode: str = "bypassPermissions"
         bypass_available = True
@@ -176,12 +174,21 @@ def run_headless(options: HeadlessOptions) -> int:
     # the next safe boundary — which can be several minutes for a
     # subprocess.wait() or an in-flight subagent.
     abort_controller = AbortController()
+    # C1: load persisted permission rules (settings files) at startup so
+    # "always allow" rules saved in interactive sessions auto-allow here
+    # too. Setup warnings intentionally unsurfaced until phase C6.
+    from src.permissions.settings_paths import default_setup_paths
+    from src.permissions.setup import setup_permissions
+
+    _perm_setup = setup_permissions(
+        cwd=str(workspace_root),
+        mode=effective_mode,  # type: ignore[arg-type]
+        is_bypass_available=bypass_available,
+        **default_setup_paths(str(workspace_root)),
+    )
     tool_context = ToolContext(
         workspace_root=workspace_root,
-        permission_context=ToolPermissionContext(
-            mode=effective_mode,  # type: ignore[arg-type]
-            is_bypass_permissions_mode_available=bypass_available,
-        ),
+        permission_context=_perm_setup.context,
         abort_controller=abort_controller,
     )
     tool_context.options.is_non_interactive_session = True
@@ -587,16 +594,19 @@ def _filter_registry(registry, *, keep) -> None:
 
 
 def _auto_deny_permission_handler(stderr: IO[str]):
-    def handler(tool_name: str, message: str, suggestion: Optional[str]):
+    from src.permissions.types import PermissionAskReply, PermissionAskRequest
+
+    def handler(request: PermissionAskRequest) -> PermissionAskReply:
         stderr.write(
-            f"[headless] denying permission for {tool_name}: {message}"
+            f"[headless] denying permission for {request.tool_name}: "
+            f"{request.message}"
             " (pass --dangerously-skip-permissions to bypass)\n"
         )
         try:
             stderr.flush()
         except Exception:
             pass
-        return False, False
+        return PermissionAskReply(behavior="deny")
 
     return handler
 

--- a/src/entrypoints/tui.py
+++ b/src/entrypoints/tui.py
@@ -108,16 +108,23 @@ def run_tui(options: TUIOptions) -> int:
     # or ``--permission-mode``). When bypass is in effect we also flip
     # ``allow_docs`` so the doc-write gate in write.py / edit.py doesn't
     # second-guess the user's explicit opt-in.
-    from src.permissions.types import ToolPermissionContext
+    # C1: load persisted permission rules (settings files) at startup so
+    # "always allow" rules from prior sessions are live — the rule engine
+    # ran against empty rule sets before this. Setup warnings (dangerous /
+    # shadowed rules) intentionally unsurfaced until phase C6.
+    from src.permissions.settings_paths import default_setup_paths
+    from src.permissions.setup import setup_permissions
+
+    _perm_setup = setup_permissions(
+        cwd=str(workspace_root),
+        mode=options.permission_mode or "default",  # type: ignore[arg-type]
+        is_bypass_available=bool(options.is_bypass_permissions_mode_available),
+        **default_setup_paths(str(workspace_root)),
+    )
 
     tool_context = ToolContext(
         workspace_root=workspace_root,
-        permission_context=ToolPermissionContext(
-            mode=options.permission_mode or "default",  # type: ignore[arg-type]
-            is_bypass_permissions_mode_available=bool(
-                options.is_bypass_permissions_mode_available
-            ),
-        ),
+        permission_context=_perm_setup.context,
     )
     if options.permission_mode == "bypassPermissions":
         tool_context.allow_docs = True

--- a/src/permissions/__init__.py
+++ b/src/permissions/__init__.py
@@ -19,7 +19,7 @@ from .filesystem import (
     check_write_permission_for_path,
     normalize_case_for_comparison,
 )
-from .handler import PermissionHandlerCallback, handle_permission_ask
+from .handler import handle_permission_ask
 from .loader import apply_rules_to_context, settings_to_rules
 from .modes import (
     is_default_mode,
@@ -59,6 +59,9 @@ from .types import (
     OtherDecisionReason,
     PermissionAllowDecision,
     PermissionAskDecision,
+    PermissionAskHandler,
+    PermissionAskReply,
+    PermissionAskRequest,
     PermissionBehavior,
     PermissionDecision,
     PermissionDecisionReason,
@@ -116,11 +119,13 @@ __all__ = [
     "OtherDecisionReason",
     "PermissionAllowDecision",
     "PermissionAskDecision",
+    "PermissionAskHandler",
+    "PermissionAskReply",
+    "PermissionAskRequest",
     "PermissionBehavior",
     "PermissionDecision",
     "PermissionDecisionReason",
     "PermissionDenyDecision",
-    "PermissionHandlerCallback",
     "PermissionMode",
     "PermissionPassthroughResult",
     "PermissionPromptToolDecisionReason",

--- a/src/permissions/bash_suggestions.py
+++ b/src/permissions/bash_suggestions.py
@@ -1,0 +1,280 @@
+"""Heuristic "don't ask again" rule suggestions for Bash permission asks.
+
+Port of the non-LLM derivation in typescript/src/tools/BashTool/
+bashPermissions.ts (suggestionForExactCommand :245-273,
+getSimpleCommandPrefix :140-168, extractPrefixBeforeHeredoc :285-316,
+BARE_SHELL_PREFIXES :171-205, SAFE_ENV_VARS :357-410) and the shared
+builders in utils/permissions/shellRuleMatching.ts (suggestionForPrefix
+:211-227, suggestionForExactCommand :189-205 — both emit a single
+``addRules``/``allow`` update destined for ``localSettings``).
+
+Deliberate divergence: the TS Haiku-based prefix extractor
+(utils/shell/prefix.ts ``getCommandSubcommandPrefix``) is NOT ported —
+it is an LLM classifier call; C1 ships the deterministic heuristics only.
+ANT_ONLY_SAFE_ENV_VARS is dropped (no ant user-type in Python).
+"""
+
+from __future__ import annotations
+
+import re
+
+from .types import (
+    PermissionRuleValue,
+    PermissionUpdate,
+    PermissionUpdateAddRules,
+)
+
+BASH_TOOL_NAME = "Bash"
+
+# TS bashPermissions.ts:93
+_ENV_VAR_ASSIGN_RE = re.compile(r"^[A-Za-z_]\w*=")
+
+# TS bashPermissions.ts:165 — second token must look like a subcommand
+# ("commit", "run"), not a flag (-rf), filename (a.txt), path, or number.
+_SUBCOMMAND_RE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
+
+# TS bashPermissions.ts:171-205 — never suggest bare shells/wrappers as
+# prefixes: `Bash(bash:*)` ≈ `Bash(*)` via `-c`; sudo/env/xargs likewise.
+BARE_SHELL_PREFIXES = frozenset(
+    {
+        "sh",
+        "bash",
+        "zsh",
+        "fish",
+        "csh",
+        "tcsh",
+        "ksh",
+        "dash",
+        "cmd",
+        "powershell",
+        "pwsh",
+        "env",
+        "xargs",
+        "nice",
+        "stdbuf",
+        "nohup",
+        "timeout",
+        "time",
+        "sudo",
+        "doas",
+        "pkexec",
+    }
+)
+
+# TS bashPermissions.ts:357-410 — env vars that CANNOT execute code or load
+# libraries; safe to skip when extracting the command name. PATH/LD_*/
+# PYTHONPATH/NODE_OPTIONS etc. must never be added here.
+SAFE_ENV_VARS = frozenset(
+    {
+        "GOEXPERIMENT",
+        "GOOS",
+        "GOARCH",
+        "CGO_ENABLED",
+        "GO111MODULE",
+        "RUST_BACKTRACE",
+        "RUST_LOG",
+        "NODE_ENV",
+        "PYTHONUNBUFFERED",
+        "PYTHONDONTWRITEBYTECODE",
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD",
+        "PYTEST_DEBUG",
+        "ANTHROPIC_API_KEY",
+        "LANG",
+        "LANGUAGE",
+        "LC_ALL",
+        "LC_CTYPE",
+        "LC_TIME",
+        "CHARSET",
+        "TERM",
+        "COLORTERM",
+        "NO_COLOR",
+        "FORCE_COLOR",
+        "TZ",
+        "LS_COLORS",
+        "LSCOLORS",
+        "GREP_COLOR",
+        "GREP_COLORS",
+        "GCC_COLORS",
+        "TIME_STYLE",
+        "BLOCK_SIZE",
+        "BLOCKSIZE",
+    }
+)
+
+
+def contains_unquoted_chaining(command: str) -> bool:
+    """True when ``command`` chains multiple commands outside quotes.
+
+    Detects ``&&``, ``||``, ``;``, ``|`` and newlines that are not inside
+    single or double quotes. Used to (a) refuse PREFIX rule derivation for
+    compound commands (a prefix of the first sub-command would later
+    blanket-match the whole family) and (b) stop prefix rules from
+    auto-allowing compound commands at match time. Command substitution
+    (``$(…)``/backticks) is deliberately NOT treated as chaining here —
+    the per-sub-command safety screen rates it before any allow rule can
+    short-circuit.
+    """
+
+    in_single = False
+    in_double = False
+    i = 0
+    n = len(command)
+    while i < n:
+        ch = command[i]
+        if ch == "\\" and not in_single and i + 1 < n:
+            i += 2
+            continue
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif not in_single and not in_double:
+            if ch in (";", "|", "\n"):
+                return True
+            if ch == "&" and i + 1 < n and command[i + 1] == "&":
+                return True
+        i += 1
+    return False
+
+
+def _skip_safe_env_assignments(tokens: list[str]) -> list[str] | None:
+    """Drop leading VAR=value tokens; ``None`` if a non-safe var appears.
+
+    Returning ``None`` (instead of skipping anyway) prevents suggesting
+    prefix rules that can never match at allow-rule check time, because
+    the rule matcher only strips SAFE env vars (TS :146-159 rationale).
+    """
+
+    i = 0
+    while i < len(tokens) and _ENV_VAR_ASSIGN_RE.match(tokens[i]):
+        var_name = tokens[i].split("=", 1)[0]
+        if var_name not in SAFE_ENV_VARS:
+            return None
+        i += 1
+    return tokens[i:]
+
+
+def get_simple_command_prefix(command: str) -> str | None:
+    """``'git commit -m "x"'`` → ``'git commit'``; None when no safe 2-word
+    prefix exists (TS getSimpleCommandPrefix :140-168)."""
+
+    tokens = [t for t in command.strip().split() if t]
+    if not tokens:
+        return None
+    remaining = _skip_safe_env_assignments(tokens)
+    if remaining is None or len(remaining) < 2:
+        return None
+    if not _SUBCOMMAND_RE.match(remaining[1]):
+        return None
+    return " ".join(remaining[:2])
+
+
+def _extract_prefix_before_heredoc(command: str) -> str | None:
+    """Stable prefix before a ``<<`` heredoc (TS :285-316)."""
+
+    idx = command.find("<<")
+    if idx <= 0:
+        return None
+    before = command[:idx].strip()
+    if not before:
+        return None
+    prefix = get_simple_command_prefix(before)
+    if prefix:
+        return prefix
+    tokens = [t for t in before.split() if t]
+    remaining = _skip_safe_env_assignments(tokens)
+    if not remaining:
+        return None
+    # Deliberate divergence from TS (which has no guard here): a bare shell
+    # before a heredoc (`bash <<EOF`) would yield Bash(bash:*) ≈ Bash(*).
+    if remaining[0] in BARE_SHELL_PREFIXES:
+        return None
+    return " ".join(remaining[:2]) or None
+
+
+def suggestion_for_prefix(prefix: str) -> list[PermissionUpdate]:
+    """``prefix`` → ``[addRules Bash(prefix:*) → localSettings]``
+    (TS shellRuleMatching.ts:211-227)."""
+
+    return [
+        PermissionUpdateAddRules(
+            destination="localSettings",
+            behavior="allow",
+            rules=(
+                PermissionRuleValue(
+                    tool_name=BASH_TOOL_NAME, rule_content=f"{prefix}:*"
+                ),
+            ),
+        )
+    ]
+
+
+def suggestion_for_exact_command(command: str) -> list[PermissionUpdate]:
+    """``command`` → ``[addRules Bash(command) → localSettings]``
+    (TS shellRuleMatching.ts:189-205)."""
+
+    return [
+        PermissionUpdateAddRules(
+            destination="localSettings",
+            behavior="allow",
+            rules=(
+                PermissionRuleValue(
+                    tool_name=BASH_TOOL_NAME, rule_content=command
+                ),
+            ),
+        )
+    ]
+
+
+def suggestions_for_bash_command(command: str) -> list[PermissionUpdate]:
+    """Best "don't ask again" rule for ``command``
+    (TS suggestionForExactCommand :245-273).
+
+    Order: heredoc prefix → first line of a multiline command → 2-word
+    prefix → exact command. Callers should pass commands that already
+    failed allow-rule matching; dangerous-command asks should NOT call
+    this (TS passes ``suggestions: []`` there).
+    """
+
+    command = command.strip()
+    if not command:
+        return []
+
+    if "<<" in command and command.index("<<") > 0:
+        # Heredoc: either a stable prefix before the operator, or nothing —
+        # never fall through to the multiline first-line branch (that would
+        # bake the heredoc operator into the rule, e.g. "bash <<EOF:*").
+        before = command[: command.index("<<")]
+        if contains_unquoted_chaining(before):
+            return []
+        heredoc_prefix = _extract_prefix_before_heredoc(command)
+        if heredoc_prefix:
+            return suggestion_for_prefix(heredoc_prefix)
+        return []
+
+    # Compound commands still get the first sub-command's prefix (a SUBSET
+    # of TS's per-sub-command suggestions): safe because the match-time
+    # guard in prepare_permission_matcher refuses to auto-allow any
+    # chained command, so a prefix rule can only ever skip prompts for
+    # SIMPLE commands.
+    if "\n" in command:
+        first_line = command.split("\n", 1)[0].strip()
+        if first_line:
+            return suggestion_for_prefix(first_line)
+        return []
+
+    prefix = get_simple_command_prefix(command)
+    if prefix:
+        return suggestion_for_prefix(prefix)
+
+    return suggestion_for_exact_command(command)
+
+
+__all__ = [
+    "BARE_SHELL_PREFIXES",
+    "SAFE_ENV_VARS",
+    "get_simple_command_prefix",
+    "suggestion_for_prefix",
+    "suggestion_for_exact_command",
+    "suggestions_for_bash_command",
+]

--- a/src/permissions/bash_suggestions.py
+++ b/src/permissions/bash_suggestions.py
@@ -26,8 +26,8 @@ from .types import (
 
 BASH_TOOL_NAME = "Bash"
 
-# TS bashPermissions.ts:93
-_ENV_VAR_ASSIGN_RE = re.compile(r"^[A-Za-z_]\w*=")
+# TS bashPermissions.ts:93 — re.ASCII matches JS \w (ASCII-only).
+_ENV_VAR_ASSIGN_RE = re.compile(r"^[A-Za-z_]\w*=", re.ASCII)
 
 # TS bashPermissions.ts:165 — second token must look like a subcommand
 # ("commit", "run"), not a flag (-rf), filename (a.txt), path, or number.
@@ -105,14 +105,14 @@ SAFE_ENV_VARS = frozenset(
 def contains_unquoted_chaining(command: str) -> bool:
     """True when ``command`` chains multiple commands outside quotes.
 
-    Detects ``&&``, ``||``, ``;``, ``|`` and newlines that are not inside
-    single or double quotes. Used to (a) refuse PREFIX rule derivation for
-    compound commands (a prefix of the first sub-command would later
-    blanket-match the whole family) and (b) stop prefix rules from
-    auto-allowing compound commands at match time. Command substitution
-    (``$(…)``/backticks) is deliberately NOT treated as chaining here —
-    the per-sub-command safety screen rates it before any allow rule can
-    short-circuit.
+    Detects ``&&``, ``||``, ``;``, ``|``, newlines, and lone ``&``
+    (separator/background — both sides execute, same as ``;``) that are
+    not inside single or double quotes. ``>&``, ``<&`` and ``&>`` are
+    redirections, not chaining, and are skipped. Known non-goals,
+    accepted because the per-sub-command safety screen rates every
+    command before any allow rule can short-circuit: command
+    substitution (``$(…)``/backticks) and ANSI-C quoting (``$'…'`` —
+    an escaped quote inside it inverts this scanner's quote state).
     """
 
     in_single = False
@@ -131,8 +131,16 @@ def contains_unquoted_chaining(command: str) -> bool:
         elif not in_single and not in_double:
             if ch in (";", "|", "\n"):
                 return True
-            if ch == "&" and i + 1 < n and command[i + 1] == "&":
-                return True
+            if ch == "&":
+                if i + 1 < n and command[i + 1] == "&":
+                    return True
+                if i > 0 and command[i - 1] in "<>":
+                    i += 1
+                    continue  # 2>&1-style redirection
+                if i + 1 < n and command[i + 1] == ">":
+                    i += 2
+                    continue  # &> redirection
+                return True  # lone & — separator or backgrounding
         i += 1
     return False
 
@@ -189,7 +197,7 @@ def _extract_prefix_before_heredoc(command: str) -> str | None:
     # before a heredoc (`bash <<EOF`) would yield Bash(bash:*) ≈ Bash(*).
     if remaining[0] in BARE_SHELL_PREFIXES:
         return None
-    return " ".join(remaining[:2]) or None
+    return " ".join(remaining[:2])
 
 
 def suggestion_for_prefix(prefix: str) -> list[PermissionUpdate]:
@@ -240,11 +248,14 @@ def suggestions_for_bash_command(command: str) -> list[PermissionUpdate]:
     if not command:
         return []
 
-    if "<<" in command and command.index("<<") > 0:
+    heredoc_idx = command.find("<<")
+    if heredoc_idx != -1:
         # Heredoc: either a stable prefix before the operator, or nothing —
         # never fall through to the multiline first-line branch (that would
         # bake the heredoc operator into the rule, e.g. "bash <<EOF:*").
-        before = command[: command.index("<<")]
+        if heredoc_idx == 0:
+            return []
+        before = command[:heredoc_idx]
         if contains_unquoted_chaining(before):
             return []
         heredoc_prefix = _extract_prefix_before_heredoc(command)
@@ -252,16 +263,32 @@ def suggestions_for_bash_command(command: str) -> list[PermissionUpdate]:
             return suggestion_for_prefix(heredoc_prefix)
         return []
 
-    # Compound commands still get the first sub-command's prefix (a SUBSET
-    # of TS's per-sub-command suggestions): safe because the match-time
-    # guard in prepare_permission_matcher refuses to auto-allow any
-    # chained command, so a prefix rule can only ever skip prompts for
-    # SIMPLE commands.
     if "\n" in command:
+        # TS takes the first line verbatim as a prefix rule. Two Python
+        # adjustments (both consequences of the D3 whole-string matcher):
+        # a compound first line would mint a rule the chaining guard can
+        # never match (the user would be re-prompted forever), so derive
+        # the first sub-command's 2-word prefix instead; and a bare-shell
+        # first line is suppressed for the same reason as the heredoc D1
+        # guard.
         first_line = command.split("\n", 1)[0].strip()
-        if first_line:
-            return suggestion_for_prefix(first_line)
-        return []
+        if contains_unquoted_chaining(first_line):
+            prefix = get_simple_command_prefix(first_line)
+            return suggestion_for_prefix(prefix) if prefix else []
+        tokens = first_line.split()
+        if len(tokens) == 1 and tokens[0] in BARE_SHELL_PREFIXES:
+            return []
+        return suggestion_for_prefix(first_line)
+
+    if contains_unquoted_chaining(command):
+        # Single-line compound: the first sub-command's 2-word prefix (a
+        # SUBSET of TS's per-sub-command suggestions) — safe because the
+        # match-time guard refuses to auto-allow chained commands, so the
+        # rule only ever skips prompts for SIMPLE commands. No derivable
+        # prefix → no suggestion (an exact rule containing chaining would
+        # be unmatchable: dead).
+        prefix = get_simple_command_prefix(command)
+        return suggestion_for_prefix(prefix) if prefix else []
 
     prefix = get_simple_command_prefix(command)
     if prefix:
@@ -272,7 +299,9 @@ def suggestions_for_bash_command(command: str) -> list[PermissionUpdate]:
 
 __all__ = [
     "BARE_SHELL_PREFIXES",
+    "BASH_TOOL_NAME",
     "SAFE_ENV_VARS",
+    "contains_unquoted_chaining",
     "get_simple_command_prefix",
     "suggestion_for_prefix",
     "suggestion_for_exact_command",

--- a/src/permissions/check.py
+++ b/src/permissions/check.py
@@ -308,14 +308,18 @@ def has_permissions_to_use_tool_inner(
                     )
 
     if tool_permission_result.behavior == "passthrough":
-        return PermissionAskDecision(
-            behavior="ask",
-            message=create_permission_request_message(
-                tool.name,
-                getattr(tool_permission_result, "decision_reason", None),
+        return _with_default_suggestions(
+            PermissionAskDecision(
+                behavior="ask",
+                message=create_permission_request_message(
+                    tool.name,
+                    getattr(tool_permission_result, "decision_reason", None),
+                ),
+                decision_reason=getattr(tool_permission_result, "decision_reason", None),
+                suggestions=getattr(tool_permission_result, "suggestions", None),
             ),
-            decision_reason=getattr(tool_permission_result, "decision_reason", None),
-            suggestions=getattr(tool_permission_result, "suggestions", None),
+            tool.name,
+            tool_input,
         )
 
     if tool_permission_result.behavior == "allow":
@@ -327,21 +331,78 @@ def has_permissions_to_use_tool_inner(
             decision_reason=getattr(tool_permission_result, "decision_reason", None),
         )
 
-    return _coerce_to_ask_decision(tool_permission_result, tool.name)
+    return _coerce_to_ask_decision(tool_permission_result, tool.name, tool_input)
 
 
 def _coerce_to_ask_decision(
     result: PermissionResult,
     tool_name: str,
+    tool_input: dict[str, Any] | None = None,
 ) -> PermissionAskDecision:
     if isinstance(result, PermissionAskDecision):
-        return result
-    return PermissionAskDecision(
-        behavior="ask",
-        message=getattr(result, "message", create_permission_request_message(tool_name)),
-        decision_reason=getattr(result, "decision_reason", None),
-        suggestions=getattr(result, "suggestions", None),
+        return _with_default_suggestions(result, tool_name, tool_input)
+    return _with_default_suggestions(
+        PermissionAskDecision(
+            behavior="ask",
+            message=getattr(result, "message", create_permission_request_message(tool_name)),
+            decision_reason=getattr(result, "decision_reason", None),
+            suggestions=getattr(result, "suggestions", None),
+        ),
+        tool_name,
+        tool_input,
     )
+
+
+def _with_default_suggestions(
+    ask: PermissionAskDecision,
+    tool_name: str,
+    tool_input: dict[str, Any] | None,
+) -> PermissionAskDecision:
+    """Fill ``ask.suggestions`` with derived "don't ask again" rules.
+
+    Mirrors TS bashPermissions.ts:1234-1236 (step 5: "Suggest prefix if
+    available, otherwise exact command"). Two deliberate exclusions:
+
+    * safety-flagged asks keep an empty list — TS :1219 ("Don't suggest
+      saving a potentially dangerous command");
+    * asks that already carry suggestions (a tool supplied its own) are
+      left untouched.
+
+    Read asks get the ``Read(<dir>/**)`` rule via the previously-orphaned
+    :func:`create_read_rule_suggestion`.
+    """
+
+    if ask.suggestions:
+        return ask
+    if isinstance(ask.decision_reason, SafetyCheckDecisionReason):
+        return ask
+    if not tool_input:
+        return ask
+
+    suggestions: list[Any] | None = None
+    if tool_name == "Bash":
+        command = tool_input.get("command", "")
+        if isinstance(command, str) and command.strip():
+            from .bash_suggestions import suggestions_for_bash_command
+
+            suggestions = suggestions_for_bash_command(command)
+    elif tool_name == "Read":
+        file_path = tool_input.get("file_path") or tool_input.get("path")
+        if isinstance(file_path, str) and file_path:
+            import os as _os
+
+            from .updates import create_read_rule_suggestion
+
+            suggestion = create_read_rule_suggestion(
+                _os.path.dirname(file_path) or file_path,
+                destination="localSettings",
+            )
+            suggestions = [suggestion] if suggestion else None
+
+    if not suggestions:
+        return ask
+    ask.suggestions = suggestions
+    return ask
 
 
 def check_rule_based_permissions(
@@ -407,6 +468,18 @@ def check_rule_based_permissions(
 
 
 def prepare_permission_matcher(rule_content: str) -> Callable[[str], bool]:
+    # Chaining guard (C1): every non-explicit-wildcard rule refuses to
+    # auto-allow a command that chains further commands (&&, ||, ;, |,
+    # newline outside quotes). Without this, a rule like "git diff:*" (or
+    # the legacy single-word "git:*", or even an exact "ls -la" rule via
+    # the startswith fallback) would blanket-allow "<match> && anything"
+    # whenever the trailing command happens to rate benign in the safety
+    # screen. Deliberately stricter than TS, whose matcher runs
+    # per-AST-sub-command; Python matches whole strings, so chained
+    # commands must simply re-prompt. ("" and "*" rules are explicit
+    # allow-alls and stay unguarded.)
+    from .bash_suggestions import contains_unquoted_chaining
+
     if not rule_content:
         return lambda _: True
 
@@ -418,14 +491,29 @@ def prepare_permission_matcher(rule_content: str) -> Callable[[str], bool]:
         suffix = rule_content.split(":", 1)[1]
         if suffix == "*":
             def _prefix_matcher(command: str) -> bool:
+                # TS semantics (bashPermissions.ts:879-882): exact match or
+                # prefix followed by a space — which makes MULTI-WORD
+                # prefixes ("git diff:*") work. The previous version
+                # compared only the command's first token against the whole
+                # prefix, so multi-word prefix rules could never match
+                # (latent until C1 un-starved the rule engine). The
+                # path-basename normalization of the first token
+                # (`/usr/bin/git` → `git`) is a deliberate Python nicety.
+                if contains_unquoted_chaining(command):
+                    return False
                 parts = command.strip().split(None, 1)
                 if not parts:
                     return False
-                cmd_name = parts[0].rsplit("/", 1)[-1]
-                return cmd_name == prefix
+                head = parts[0].rsplit("/", 1)[-1]
+                normalized = (
+                    head if len(parts) == 1 else f"{head} {parts[1]}"
+                )
+                return normalized == prefix or normalized.startswith(prefix + " ")
             return _prefix_matcher
         else:
             def _exact_prefix_matcher(command: str) -> bool:
+                if contains_unquoted_chaining(command):
+                    return False
                 parts = command.strip().split(None, 1)
                 if not parts:
                     return False
@@ -437,9 +525,15 @@ def prepare_permission_matcher(rule_content: str) -> Callable[[str], bool]:
             return _exact_prefix_matcher
 
     if "*" in rule_content or "?" in rule_content:
-        return lambda command: fnmatch.fnmatch(command.strip(), rule_content)
+        return lambda command: (
+            not contains_unquoted_chaining(command)
+            and fnmatch.fnmatch(command.strip(), rule_content)
+        )
 
-    return lambda command: command.strip().startswith(rule_content)
+    return lambda command: (
+        not contains_unquoted_chaining(command)
+        and command.strip().startswith(rule_content)
+    )
 
 
 @dataclass(frozen=True)

--- a/src/permissions/check.py
+++ b/src/permissions/check.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Protocol, runtime_checkable
 
 from .bash_security import analyze_bash_command
+from .bash_suggestions import contains_unquoted_chaining
 from .rules import (
     get_ask_rule_for_tool,
     get_deny_rule_for_tool,
@@ -478,8 +479,6 @@ def prepare_permission_matcher(rule_content: str) -> Callable[[str], bool]:
     # per-AST-sub-command; Python matches whole strings, so chained
     # commands must simply re-prompt. ("" and "*" rules are explicit
     # allow-alls and stay unguarded.)
-    from .bash_suggestions import contains_unquoted_chaining
-
     if not rule_content:
         return lambda _: True
 
@@ -512,6 +511,11 @@ def prepare_permission_matcher(rule_content: str) -> Callable[[str], bool]:
             return _prefix_matcher
         else:
             def _exact_prefix_matcher(command: str) -> bool:
+                # Known limitation: like the pre-C1 code, this branch only
+                # matches single-word rule prefixes (the first token is
+                # compared to the whole prefix), so a user-written
+                # "git diff:--stat*" rule cannot match. No producer mints
+                # such rules today; fix alongside a real consumer.
                 if contains_unquoted_chaining(command):
                     return False
                 parts = command.strip().split(None, 1)
@@ -530,10 +534,21 @@ def prepare_permission_matcher(rule_content: str) -> Callable[[str], bool]:
             and fnmatch.fnmatch(command.strip(), rule_content)
         )
 
-    return lambda command: (
-        not contains_unquoted_chaining(command)
-        and command.strip().startswith(rule_content)
-    )
+    def _exact_or_word_prefix_matcher(command: str) -> bool:
+        # Rules without ":*" or wildcards: exact match, or the rule
+        # followed by a SPACE (word boundary). Bare startswith would let
+        # a stored rule match last-token elongations (a rule for one
+        # flag cluster matching a longer one) — meaningful since C1's
+        # suggestion layer started minting exact-command rules into this
+        # branch. The +space prefix form (vs TS pure equality) is kept
+        # for the pre-existing locked behavior of word-prefix rules like
+        # "npm run".
+        if contains_unquoted_chaining(command):
+            return False
+        cmd = command.strip()
+        return cmd == rule_content or cmd.startswith(rule_content + " ")
+
+    return _exact_or_word_prefix_matcher
 
 
 @dataclass(frozen=True)

--- a/src/permissions/check.py
+++ b/src/permissions/check.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import fnmatch
 import logging
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Callable, Protocol, runtime_checkable
 
 from .bash_security import analyze_bash_command
@@ -359,7 +359,7 @@ def _with_default_suggestions(
     tool_name: str,
     tool_input: dict[str, Any] | None,
 ) -> PermissionAskDecision:
-    """Fill ``ask.suggestions`` with derived "don't ask again" rules.
+    """Return ``ask`` with derived "don't ask again" rules filled in.
 
     Mirrors TS bashPermissions.ts:1234-1236 (step 5: "Suggest prefix if
     available, otherwise exact command"). Two deliberate exclusions:
@@ -369,8 +369,15 @@ def _with_default_suggestions(
     * asks that already carry suggestions (a tool supplied its own) are
       left untouched.
 
-    Read asks get the ``Read(<dir>/**)`` rule via the previously-orphaned
-    :func:`create_read_rule_suggestion`.
+    Bash-only for now: the engine's content-rule matching is consulted
+    only for Bash commands (:298), and ``tool_always_allowed_rule``
+    requires content-less rules — a suggested ``Read(<dir>/**)`` rule
+    would persist but never match (review-A H1), so Read suggestions are
+    deliberately NOT derived until a path-rule matcher exists
+    (follow-up noted in the C1 plan).
+
+    Returns a copy (``dataclasses.replace``) rather than mutating —
+    the input can be a tool-owned decision object.
     """
 
     if ask.suggestions:
@@ -380,29 +387,15 @@ def _with_default_suggestions(
     if not tool_input:
         return ask
 
-    suggestions: list[Any] | None = None
     if tool_name == "Bash":
         command = tool_input.get("command", "")
         if isinstance(command, str) and command.strip():
             from .bash_suggestions import suggestions_for_bash_command
 
             suggestions = suggestions_for_bash_command(command)
-    elif tool_name == "Read":
-        file_path = tool_input.get("file_path") or tool_input.get("path")
-        if isinstance(file_path, str) and file_path:
-            import os as _os
+            if suggestions:
+                return replace(ask, suggestions=suggestions)
 
-            from .updates import create_read_rule_suggestion
-
-            suggestion = create_read_rule_suggestion(
-                _os.path.dirname(file_path) or file_path,
-                destination="localSettings",
-            )
-            suggestions = [suggestion] if suggestion else None
-
-    if not suggestions:
-        return ask
-    ask.suggestions = suggestions
     return ask
 
 

--- a/src/permissions/handler.py
+++ b/src/permissions/handler.py
@@ -66,7 +66,7 @@ def handle_permission_ask(
                 updated_input=reply.updated_input or decision.updated_input,
                 decision_reason=decision.decision_reason,
             ),
-            tuple(reply.chosen_updates),
+            tuple(reply.chosen_updates or ()),
         )
 
     feedback = (reply.message or "").strip()

--- a/src/permissions/handler.py
+++ b/src/permissions/handler.py
@@ -1,48 +1,88 @@
+"""Bridge between an ``ask`` decision and an interactive surface.
+
+C1 (components-folder parity) replaced the legacy 3-arg callback
+``(tool_name, message, suggestion_str) -> (allowed, enable)`` with the
+request/reply shape mirroring TS ``PermissionResult``: the surface
+receives the full :class:`PermissionAskRequest` (tool input drives
+per-tool previews; suggestions drive the "always allow" option) and
+answers with a :class:`PermissionAskReply` (which may carry the chosen
+"don't ask again" updates and deny feedback).
+"""
+
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Any
 
 from .types import (
     PermissionAllowDecision,
     PermissionAskDecision,
+    PermissionAskHandler,
+    PermissionAskRequest,
     PermissionDecision,
     PermissionDenyDecision,
     PermissionUpdate,
 )
 
 
-PermissionHandlerCallback = Callable[
-    [str, str, list[PermissionUpdate] | None],
-    tuple[bool, dict[str, Any] | None],
-]
-
-
 def handle_permission_ask(
     tool_name: str,
     decision: PermissionAskDecision,
-    handler: PermissionHandlerCallback | None = None,
-) -> PermissionDecision:
+    handler: PermissionAskHandler | None = None,
+    tool_input: dict[str, Any] | None = None,
+) -> tuple[PermissionDecision, tuple[PermissionUpdate, ...]]:
+    """Resolve an ``ask`` decision through ``handler``.
+
+    Returns ``(final_decision, chosen_updates)``. ``chosen_updates`` are
+    the "don't ask again" rules the user accepted (empty on deny / plain
+    allow); the caller applies them to the live context and persists the
+    persistable destinations — mirroring how TS applies
+    ``updatedPermissions`` from the dialog's ``PermissionResult``.
+    """
+
     if handler is None:
-        return PermissionDenyDecision(
-            behavior="deny",
-            message=decision.message or f"Permission required but no handler available for {tool_name}",
-            decision_reason=decision.decision_reason,
+        return (
+            PermissionDenyDecision(
+                behavior="deny",
+                message=decision.message
+                or f"Permission required but no handler available for {tool_name}",
+                decision_reason=decision.decision_reason,
+            ),
+            (),
         )
 
-    allowed, updated_input = handler(
-        tool_name,
-        decision.message or f"Tool '{tool_name}' requires permission",
-        decision.suggestions,
-    )
-
-    if allowed:
-        return PermissionAllowDecision(
-            behavior="allow",
-            updated_input=updated_input or decision.updated_input,
-            decision_reason=decision.decision_reason,
-        )
-    return PermissionDenyDecision(
-        behavior="deny",
-        message="Permission denied by user.",
+    request = PermissionAskRequest(
+        tool_name=tool_name,
+        message=decision.message or f"Tool '{tool_name}' requires permission",
+        tool_input=tool_input,
+        suggestions=tuple(decision.suggestions or ()),
         decision_reason=decision.decision_reason,
     )
+    reply = handler(request)
+
+    if reply.behavior == "allow":
+        return (
+            PermissionAllowDecision(
+                behavior="allow",
+                updated_input=reply.updated_input or decision.updated_input,
+                decision_reason=decision.decision_reason,
+            ),
+            tuple(reply.chosen_updates),
+        )
+
+    feedback = (reply.message or "").strip()
+    message = "Permission denied by user."
+    if feedback:
+        # TS deny-with-feedback: the user's note reaches the model via the
+        # tool error so it can change course.
+        message = f"Permission denied by user: {feedback}"
+    return (
+        PermissionDenyDecision(
+            behavior="deny",
+            message=message,
+            decision_reason=decision.decision_reason,
+        ),
+        (),
+    )
+
+
+__all__ = ["handle_permission_ask"]

--- a/src/permissions/settings_paths.py
+++ b/src/permissions/settings_paths.py
@@ -1,0 +1,81 @@
+"""Canonical settings-file paths for permission persistence.
+
+Port of the TS destination→file mapping used by ``persistPermissionUpdate``
+(typescript/src/utils/permissions/permissionSetup.ts) onto the established
+Python split (src/config.py:4-6): global state under ``~/.clawcodex/``,
+project state under ``<cwd>/.claude/``.
+
+Permissions deliberately live in STANDALONE settings files with a top-level
+``permissions`` key (the layout ``setup.py``/``updates.py`` share, same as
+TS ``.claude/settings.json``) — NOT in the config manager's ``"settings"``
+sub-key layer and NOT in ``~/.clawcodex/config.json``.
+"""
+
+from __future__ import annotations
+
+import os
+
+from .types import PermissionUpdateDestination
+
+USER_SETTINGS_FILENAME = os.path.join("~", ".clawcodex", "settings.json")
+PROJECT_SETTINGS_DIRNAME = ".claude"
+
+
+def user_settings_path() -> str:
+    return os.path.expanduser(USER_SETTINGS_FILENAME)
+
+
+def project_settings_path(cwd: str | None = None) -> str:
+    base = cwd or os.getcwd()
+    return os.path.join(base, PROJECT_SETTINGS_DIRNAME, "settings.json")
+
+
+def local_settings_path(cwd: str | None = None) -> str:
+    base = cwd or os.getcwd()
+    return os.path.join(base, PROJECT_SETTINGS_DIRNAME, "settings.local.json")
+
+
+def settings_path_for_destination(
+    destination: PermissionUpdateDestination,
+    cwd: str | None = None,
+) -> str | None:
+    """``SettingsPathResolver`` for :func:`persist_permission_update`.
+
+    ``session`` and ``cliArg`` are in-memory only → ``None`` (the persist
+    helpers treat ``None`` as non-persistable, matching TS).
+    """
+
+    if destination == "userSettings":
+        return user_settings_path()
+    if destination == "projectSettings":
+        return project_settings_path(cwd)
+    if destination == "localSettings":
+        return local_settings_path(cwd)
+    return None
+
+
+def default_setup_paths(cwd: str | None = None) -> dict[str, str | None]:
+    """Keyword arguments for :func:`src.permissions.setup.setup_permissions`.
+
+    ``setup_permissions`` has no default paths of its own — every caller
+    must supply them. This is the one canonical place they come from.
+    """
+
+    from src.settings.managed_path import resolve_managed_settings_path
+
+    managed = resolve_managed_settings_path()
+    return {
+        "user_settings_path": user_settings_path(),
+        "project_settings_path": project_settings_path(cwd),
+        "local_settings_path": local_settings_path(cwd),
+        "managed_settings_path": str(managed) if managed else None,
+    }
+
+
+__all__ = [
+    "settings_path_for_destination",
+    "default_setup_paths",
+    "user_settings_path",
+    "project_settings_path",
+    "local_settings_path",
+]

--- a/src/permissions/settings_paths.py
+++ b/src/permissions/settings_paths.py
@@ -1,14 +1,14 @@
 """Canonical settings-file paths for permission persistence.
 
 Port of the TS destination→file mapping used by ``persistPermissionUpdate``
-(typescript/src/utils/permissions/permissionSetup.ts) onto the established
-Python split (src/config.py:4-6): global state under ``~/.clawcodex/``,
-project state under ``<cwd>/.claude/``.
-
-Permissions deliberately live in STANDALONE settings files with a top-level
-``permissions`` key (the layout ``setup.py``/``updates.py`` share, same as
-TS ``.claude/settings.json``) — NOT in the config manager's ``"settings"``
-sub-key layer and NOT in ``~/.clawcodex/config.json``.
+(typescript/src/utils/permissions/permissionSetup.ts), with the project tier
+namespaced under ``.clawcodex/`` rather than TS's ``.claude/``: the real
+Claude Code harness owns ``<project>/.claude/settings{,.local}.json``, and a
+second tool reading/writing the SAME files would inherit and mutate the
+harness's live permission rules (review-A finding, C1). The file LAYOUT is
+still TS-parity — standalone settings files with a top-level ``permissions``
+key (the shape ``setup.py``/``updates.py`` share) — NOT the config manager's
+``"settings"`` sub-key layer and NOT ``~/.clawcodex/config.json``.
 """
 
 from __future__ import annotations
@@ -18,7 +18,7 @@ import os
 from .types import PermissionUpdateDestination
 
 USER_SETTINGS_FILENAME = os.path.join("~", ".clawcodex", "settings.json")
-PROJECT_SETTINGS_DIRNAME = ".claude"
+PROJECT_SETTINGS_DIRNAME = ".clawcodex"
 
 
 def user_settings_path() -> str:

--- a/src/permissions/types.py
+++ b/src/permissions/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Literal, Union
+from typing import Any, Callable, Literal, Union
 
 
 # Mirrors typescript/src/types/permissions.ts:16-38.
@@ -308,6 +308,41 @@ PermissionResult = Union[
     PermissionDecision,
     PermissionPassthroughResult,
 ]
+
+
+@dataclass(frozen=True)
+class PermissionAskRequest:
+    """Everything an interactive surface needs to render a permission ask.
+
+    Mirrors what TS hands ``PermissionRequest.tsx`` via ``toolUseConfirm``:
+    the tool, the human message, the raw input (drives per-tool previews),
+    and the rule suggestions an "always allow" option would persist.
+    """
+
+    tool_name: str
+    message: str
+    tool_input: dict[str, Any] | None = None
+    suggestions: tuple[PermissionUpdate, ...] = ()
+    decision_reason: PermissionDecisionReason | None = None
+
+
+@dataclass(frozen=True)
+class PermissionAskReply:
+    """A surface's answer to a :class:`PermissionAskRequest`.
+
+    Mirrors TS ``PermissionResult``: allow may carry ``chosen_updates``
+    (the accepted "don't ask again" rules — TS ``updatedPermissions``) and
+    deny may carry ``message`` (the user's feedback, which reaches the
+    model in the tool error — TS deny-with-feedback).
+    """
+
+    behavior: Literal["allow", "deny"] = "deny"
+    updated_input: dict[str, Any] | None = None
+    chosen_updates: tuple[PermissionUpdate, ...] = ()
+    message: str | None = None
+
+
+PermissionAskHandler = Callable[[PermissionAskRequest], PermissionAskReply]
 
 
 def _empty_rules_by_source() -> ToolPermissionRulesBySource:

--- a/src/permissions/updates.py
+++ b/src/permissions/updates.py
@@ -72,6 +72,29 @@ def extract_rules(updates: list[PermissionUpdate] | None) -> list[PermissionRule
     return out
 
 
+def suggestions_label(updates: tuple[PermissionUpdate, ...] | list[PermissionUpdate]) -> str | None:
+    """Human label for an "always allow" option, naming the rule(s).
+
+    Mirrors the intent of TS ``generateShellSuggestionsLabel``
+    (components/permissions/shellPermissionHelpers.tsx:65): name the
+    rules the user is about to save, e.g.
+    ``don't ask again for Bash(git diff:*)``.
+    """
+
+    rule_strings: list[str] = []
+    for rule_value in extract_rules(list(updates)):
+        try:
+            rule_strings.append(permission_rule_value_to_string(rule_value))
+        except Exception:
+            continue
+    if not rule_strings:
+        return None
+    shown = ", ".join(rule_strings[:3])
+    if len(rule_strings) > 3:
+        shown += ", …"
+    return f"don't ask again for {shown}"
+
+
 def has_rules(updates: list[PermissionUpdate] | None) -> bool:
     """True if ``updates`` contains at least one ``addRules`` rule."""
     return len(extract_rules(updates)) > 0

--- a/src/permissions/updates.py
+++ b/src/permissions/updates.py
@@ -363,6 +363,9 @@ def persist_permission_update(
         permissions["additionalDirectories"] = [d for d in existing if d not in target]
 
     elif isinstance(update, PermissionUpdateSetMode):
+        # Write-only today: setup_permissions does not read defaultMode
+        # back at startup (mode comes from CLI/config). Asymmetry noted in
+        # the C1 review; wire the read side with the C8 mode-gate work.
         permissions["defaultMode"] = update.mode
 
     return _write_json(path, settings)

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -442,16 +442,24 @@ class ClawcodexREPL:
             get_available_mcp_servers=_get_mcp_servers_for_prompt,
         )
         self._engine_messages: list[Any] = []
-        from src.permissions.types import ToolPermissionContext
+        # C1: build the permission context through the settings loader so
+        # rules persisted by "always allow" (and hand-written settings
+        # files) are live in every session — previously this was a bare
+        # ruleless ToolPermissionContext. Setup warnings (dangerous rules,
+        # shadowed rules) are intentionally not surfaced yet — phase C6.
+        from src.permissions.settings_paths import default_setup_paths
+        from src.permissions.setup import setup_permissions
+
+        _perm_setup = setup_permissions(
+            cwd=str(Path.cwd()),
+            mode=self._permission_mode,  # type: ignore[arg-type]
+            is_bypass_available=self._is_bypass_permissions_mode_available,
+            **default_setup_paths(str(Path.cwd())),
+        )
 
         self.tool_context = ToolContext(
             workspace_root=Path.cwd(),
-            permission_context=ToolPermissionContext(
-                mode=self._permission_mode,  # type: ignore[arg-type]
-                is_bypass_permissions_mode_available=(
-                    self._is_bypass_permissions_mode_available
-                ),
-            ),
+            permission_context=_perm_setup.context,
         )
         self.tool_context.ask_user = self._ask_user_questions
         # Permission handler with status control for proper input handling
@@ -461,9 +469,11 @@ class ClawcodexREPL:
             # before the handler is ever consulted, but a few tools call the
             # handler directly (e.g. the doc-write gate). Auto-allow there
             # too so the user's explicit opt-in is honored end-to-end.
+            from src.permissions.types import PermissionAskReply
+
             self.tool_context.allow_docs = True
             self.tool_context.permission_handler = (
-                lambda _tn, _msg, _sug: (True, False)
+                lambda _request: PermissionAskReply(behavior="allow")
             )
         else:
             self.tool_context.permission_handler = self._handle_permission_request
@@ -908,28 +918,28 @@ class ClawcodexREPL:
 
         return answers
 
-    def _handle_permission_request(
-        self,
-        tool_name: str,
-        message: str,
-        suggestion: str | None,
-    ) -> tuple[bool, bool]:
+    def _handle_permission_request(self, request: Any) -> Any:
         """Handle interactive permission requests from tools.
 
-        Args:
-            tool_name: Name of the tool requesting permission.
-            message: Message explaining what permission is needed.
-            suggestion: Optional suggestion for enabling the setting.
-
-        Returns:
-            Tuple of (allowed: bool, continue_without_caching: bool).
-            continue_without_caching is always False since we don't cache in REPL.
+        C1: receives a :class:`src.permissions.types.PermissionAskRequest`
+        and returns a :class:`~src.permissions.types.PermissionAskReply`.
+        The console menu mirrors the TUI modal's option set: allow once /
+        allow always (when rule suggestions exist) / deny / deny with
+        feedback — plus the REPL-only ``allow_docs`` enable shortcut.
         """
+        from src.permissions.types import PermissionAskReply
+
+        tool_name = request.tool_name
+        message = request.message
+        suggestions = tuple(getattr(request, "suggestions", ()) or ())
+
         with self._permission_prompt_lock:
             cache_key = tool_name.strip().lower()
             cached = self._permission_decision_cache.get(cache_key)
             if cached is not None:
-                return cached, False
+                return PermissionAskReply(
+                    behavior="allow" if cached else "deny"
+                )
 
             # Stop the Rich status spinner if running, so we can get clean input
             if self._current_status is not None:
@@ -953,16 +963,29 @@ class ClawcodexREPL:
                     can_enable_setting = True
                     setting_to_enable = "allow_docs"
 
-            # Build options
-            options: list[tuple[str, str]] = [
-                ("y", "Yes, allow this action"),
-                ("n", "No, deny this action"),
-            ]
+            always_label: str | None = None
+            if suggestions:
+                from src.permissions.updates import suggestions_label
+
+                always_label = suggestions_label(suggestions)
+
+            # Build options as (key, description, action) rows so the
+            # numeric choices always match what was displayed.
+            options: list[tuple[str, str, str]] = []
             if can_enable_setting:
-                options.insert(0, ("e", f"Enable {setting_to_enable} and allow"))
+                options.append(
+                    ("e", f"Enable {setting_to_enable} and allow", "enable")
+                )
+            options.append(("y", "Yes, allow this action", "allow"))
+            if always_label:
+                options.append(("a", f"Yes, and {always_label}", "always"))
+            options.append(("n", "No, deny this action", "deny"))
+            options.append(
+                ("d", "No, and tell Claude what to do differently", "feedback")
+            )
 
             self.console.print("[bold]Options:[/bold]")
-            for i, (key, desc) in enumerate(options, start=1):
+            for i, (key, desc, _action) in enumerate(options, start=1):
                 self.console.print(f"  {i}. [{key}] {desc}")
             self.console.print("")
 
@@ -970,31 +993,42 @@ class ClawcodexREPL:
             # and the LiveStatus bottom region.
             choice = self._safe_input("Select option> ").strip().lower()
 
-            # Parse choice based on the actual displayed options
-            if can_enable_setting:
-                # Menu: 1=Enable, 2=Yes, 3=No
-                if choice in ("1", "e", "enable"):
-                    self._enable_permission_setting(setting_to_enable)
-                    self._permission_decision_cache[cache_key] = True
-                    return True, False
-                elif choice in ("2", "y", "yes", ""):
-                    self._permission_decision_cache[cache_key] = True
-                    return True, False
-                elif choice in ("3", "n", "no"):
-                    self._permission_decision_cache[cache_key] = False
-                    return False, False
+            action: str | None = None
+            if choice == "":
+                action = "allow"
             else:
-                # Menu: 1=Yes, 2=No
-                if choice in ("1", "y", "yes", ""):
-                    self._permission_decision_cache[cache_key] = True
-                    return True, False
-                elif choice in ("2", "n", "no"):
-                    self._permission_decision_cache[cache_key] = False
-                    return False, False
+                for i, (key, _desc, opt_action) in enumerate(options, start=1):
+                    if choice == str(i) or choice == key:
+                        action = opt_action
+                        break
+                if action is None and choice in ("yes",):
+                    action = "allow"
+                elif action is None and choice in ("no",):
+                    action = "deny"
+
+            if action == "enable":
+                self._enable_permission_setting(setting_to_enable)
+                self._permission_decision_cache[cache_key] = True
+                return PermissionAskReply(behavior="allow")
+            if action == "allow":
+                self._permission_decision_cache[cache_key] = True
+                return PermissionAskReply(behavior="allow")
+            if action == "always":
+                # Don't poison the cache with a plain allow — the rule
+                # itself now auto-allows future matching calls.
+                return PermissionAskReply(
+                    behavior="allow", chosen_updates=suggestions
+                )
+            if action == "deny":
+                self._permission_decision_cache[cache_key] = False
+                return PermissionAskReply(behavior="deny")
+            if action == "feedback":
+                note = self._safe_input("What should Claude do instead? > ").strip()
+                return PermissionAskReply(behavior="deny", message=note or None)
 
             # Default to deny for invalid input
             self.console.print("[dim]Invalid choice, defaulting to deny.[/dim]")
-            return False, False
+            return PermissionAskReply(behavior="deny")
 
     def _enable_permission_setting(self, setting_name: str | None) -> None:
         """Enable a permission setting in the tool context."""

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -303,7 +303,10 @@ import json
 import threading
 import time
 from collections import deque
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from src.permissions.types import PermissionAskReply, PermissionAskRequest
 
 from src.agent import Session
 from src.config import get_provider_config
@@ -466,9 +469,10 @@ class ClawcodexREPL:
         self._current_status = None
         if self._permission_mode == "bypassPermissions":
             # The bypass mode short-circuits the registry's permission check
-            # before the handler is ever consulted, but a few tools call the
-            # handler directly (e.g. the doc-write gate). Auto-allow there
-            # too so the user's explicit opt-in is honored end-to-end.
+            # before the handler is ever consulted; the allow-reply lambda is
+            # belt-and-braces for any future direct handler caller. (The old
+            # claim that the doc-write gate calls the handler directly was
+            # wrong — it flows through check_permissions → registry.)
             from src.permissions.types import PermissionAskReply
 
             self.tool_context.allow_docs = True
@@ -918,7 +922,9 @@ class ClawcodexREPL:
 
         return answers
 
-    def _handle_permission_request(self, request: Any) -> Any:
+    def _handle_permission_request(
+        self, request: "PermissionAskRequest"
+    ) -> "PermissionAskReply":
         """Handle interactive permission requests from tools.
 
         C1: receives a :class:`src.permissions.types.PermissionAskRequest`

--- a/src/tool_system/context.py
+++ b/src/tool_system/context.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Optional
 
 from .errors import ToolPermissionError
 from .task_manager import TaskManager
-from src.permissions.types import ToolPermissionContext
+from src.permissions.types import PermissionAskHandler, ToolPermissionContext
 from src.services.swarm.agent_name_registry import AgentNameRegistry
 from src.task_registry import RuntimeTaskRegistry
 from src.utils.abort_controller import AbortController
@@ -150,7 +150,12 @@ class ToolContext:
     additional_working_directories: tuple[Path, ...] = ()
     allow_docs: bool = False
 
-    permission_handler: Callable[[str, str, Optional[str]], tuple[bool, bool]] | None = None
+    # C1 (components parity): request/reply protocol — the surface gets the
+    # full PermissionAskRequest (tool_input → previews, suggestions →
+    # "always allow") and answers with a PermissionAskReply (chosen_updates,
+    # deny feedback). Replaced the legacy (tool_name, message, suggestion)
+    # -> (allowed, enable) shape end-to-end; no shim.
+    permission_handler: PermissionAskHandler | None = None
 
     options: ToolUseOptions = field(default_factory=ToolUseOptions)
     # Always present; callers that own the per-run cancellation lifecycle

--- a/src/tool_system/registry.py
+++ b/src/tool_system/registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import logging
 import threading
 from typing import Any, Iterable
 
@@ -17,23 +18,33 @@ from src.permissions.types import (
     ToolPermissionContext,
 )
 
+log = logging.getLogger(__name__)
+
 
 def _apply_and_persist_updates(
     context: ToolContext, updates: tuple[PermissionUpdate, ...]
 ) -> None:
     """Apply accepted "don't ask again" updates and persist them.
 
-    In-memory application makes the rule effective for the rest of the
-    session; persistence (for userSettings/projectSettings/localSettings
-    destinations) makes it survive restarts, read back at startup via
-    ``setup_permissions``. Both halves are best-effort: a failed settings
-    write must never fail the already-approved tool call.
+    In-memory application makes the rule effective for later dispatches
+    through THIS ToolContext (note: a subagent created earlier holds a
+    reference to the PREVIOUS permission_context object — sharing is
+    by-reference at creation, `agent/subagent_context.py` — so an
+    "always" accepted mid-session does not reach already-running
+    subagents until restart; they fail safe by re-prompting. TS shares
+    one live context — documented divergence). Persistence (for
+    userSettings/projectSettings/localSettings destinations) makes it
+    survive restarts, read back at startup via ``setup_permissions``.
+    Both halves are best-effort: a failed settings write must never fail
+    the already-approved tool call — but it is logged, since the user
+    was just promised "don't ask again".
     """
 
     from src.permissions.settings_paths import settings_path_for_destination
     from src.permissions.updates import (
         apply_permission_updates,
         persist_permission_updates,
+        supports_persistence,
     )
 
     try:
@@ -43,17 +54,24 @@ def _apply_and_persist_updates(
             context.permission_context, list(updates)
         )
     except Exception:
-        pass
+        log.exception("failed to apply accepted permission updates in-memory")
     try:
         cwd = str(context.workspace_root) if context.workspace_root else None
-        persist_permission_updates(
+        results = persist_permission_updates(
             list(updates),
             settings_path_for_destination=lambda destination: (
                 settings_path_for_destination(destination, cwd)
             ),
         )
+        for update, ok in zip(updates, results):
+            if not ok and supports_persistence(update.destination):
+                log.warning(
+                    "permission update not persisted (destination=%s); "
+                    "the rule applies this session only",
+                    update.destination,
+                )
     except Exception:
-        pass
+        log.exception("failed to persist accepted permission updates")
 
 
 class ToolRegistry:

--- a/src/tool_system/registry.py
+++ b/src/tool_system/registry.py
@@ -13,8 +13,47 @@ from src.permissions.check import has_permissions_to_use_tool
 from src.permissions.handler import handle_permission_ask
 from src.permissions.types import (
     PermissionAskDecision,
+    PermissionUpdate,
     ToolPermissionContext,
 )
+
+
+def _apply_and_persist_updates(
+    context: ToolContext, updates: tuple[PermissionUpdate, ...]
+) -> None:
+    """Apply accepted "don't ask again" updates and persist them.
+
+    In-memory application makes the rule effective for the rest of the
+    session; persistence (for userSettings/projectSettings/localSettings
+    destinations) makes it survive restarts, read back at startup via
+    ``setup_permissions``. Both halves are best-effort: a failed settings
+    write must never fail the already-approved tool call.
+    """
+
+    from src.permissions.settings_paths import settings_path_for_destination
+    from src.permissions.updates import (
+        apply_permission_updates,
+        persist_permission_updates,
+    )
+
+    try:
+        # apply_permission_updates returns a FRESH context (input unchanged)
+        # — rebind it so every later dispatch sees the new rules.
+        context.permission_context = apply_permission_updates(
+            context.permission_context, list(updates)
+        )
+    except Exception:
+        pass
+    try:
+        cwd = str(context.workspace_root) if context.workspace_root else None
+        persist_permission_updates(
+            list(updates),
+            settings_path_for_destination=lambda destination: (
+                settings_path_for_destination(destination, cwd)
+            ),
+        )
+    except Exception:
+        pass
 
 
 class ToolRegistry:
@@ -80,19 +119,12 @@ class ToolRegistry:
 
         if decision.behavior == "ask":
             assert isinstance(decision, PermissionAskDecision)
-            handler_cb = None
-            if context.permission_handler is not None:
-                raw_handler = context.permission_handler
-
-                def _adapted_handler(
-                    tn: str, msg: str, suggestions: Any,
-                ) -> tuple[bool, dict[str, Any] | None]:
-                    allowed, _ = raw_handler(tn, msg, None)
-                    return allowed, None
-
-                handler_cb = _adapted_handler
-
-            final = handle_permission_ask(tool.name, decision, handler_cb)
+            final, chosen_updates = handle_permission_ask(
+                tool.name,
+                decision,
+                context.permission_handler,
+                tool_input=call.input,
+            )
 
             if final.behavior == "deny":
                 return ToolResult(
@@ -101,6 +133,9 @@ class ToolRegistry:
                     is_error=True,
                     tool_use_id=call.tool_use_id,
                 )
+
+            if chosen_updates:
+                _apply_and_persist_updates(context, chosen_updates)
 
             if hasattr(final, "updated_input") and final.updated_input:
                 call = ToolCall(

--- a/src/tui/agent_bridge.py
+++ b/src/tui/agent_bridge.py
@@ -29,7 +29,10 @@ import os
 import threading
 import uuid
 from pathlib import Path
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from src.permissions.types import PermissionAskReply, PermissionAskRequest
 
 from src.agent import Session
 from src.tool_system.renderers import AgentLoopResult, ToolEvent
@@ -573,7 +576,9 @@ class AgentBridge:
         self._last_scanned_msg_index = len(messages)
 
     # ---- permission bridge ----
-    def _permission_handler(self, request: Any) -> Any:
+    def _permission_handler(
+        self, request: "PermissionAskRequest"
+    ) -> "PermissionAskReply":
         """Called from the worker thread whenever the tool dispatcher
         wants user approval.
 

--- a/src/tui/agent_bridge.py
+++ b/src/tui/agent_bridge.py
@@ -573,42 +573,43 @@ class AgentBridge:
         self._last_scanned_msg_index = len(messages)
 
     # ---- permission bridge ----
-    def _permission_handler(
-        self,
-        tool_name: str,
-        message: str,
-        suggestion: str | None,
-    ) -> tuple[bool, bool]:
+    def _permission_handler(self, request: Any) -> Any:
         """Called from the worker thread whenever the tool dispatcher
         wants user approval.
 
-        Posts a :class:`PermissionRequested` to the UI, which pushes a
-        modal; blocks the worker until the modal resolves via
+        Receives a :class:`src.permissions.types.PermissionAskRequest`
+        and returns a :class:`~src.permissions.types.PermissionAskReply`.
+        Posts a :class:`PermissionRequested` to the UI (with the REAL
+        ``tool_input`` so the modal's per-tool previews render, and the
+        derived rule ``suggestions`` so the always-allow option shows);
+        blocks the worker until the modal resolves via
         :class:`PermissionResolved`.
         """
 
-        done = threading.Event()
-        outcome: dict[str, bool] = {"allowed": False, "enable": False}
+        from src.permissions.types import PermissionAskReply
 
-        def _decide(allowed: bool, enable: bool) -> None:
-            outcome["allowed"] = allowed
-            outcome["enable"] = enable
+        done = threading.Event()
+        outcome: dict[str, Any] = {"reply": PermissionAskReply(behavior="deny")}
+
+        def _decide(reply: Any) -> None:
+            outcome["reply"] = reply
             done.set()
 
+        tool_input = _safe_copy(request.tool_input)
         pending = self._state.enqueue_permission(
-            tool_name=tool_name,
-            message=message,
-            suggestion=suggestion,
-            tool_input=None,
+            tool_name=request.tool_name,
+            message=request.message,
+            suggestions=tuple(request.suggestions),
+            tool_input=tool_input,
             decide=_decide,
         )
         self._post(
             PermissionRequested(
                 request_id=pending.request_id,
-                tool_name=tool_name,
-                message=message,
-                suggestion=suggestion,
-                tool_input=None,
+                tool_name=request.tool_name,
+                message=request.message,
+                suggestions=tuple(request.suggestions),
+                tool_input=tool_input,
             )
         )
         # Wait for the UI to call ``_decide``. No timeout — the UI is
@@ -620,7 +621,7 @@ class AgentBridge:
         # Remove the entry from the state queue; the modal already
         # dismissed itself and emitted ``PermissionResolved``.
         self._state.resolve_permission(pending.request_id)
-        return outcome["allowed"], outcome["enable"]
+        return outcome["reply"]
 
 
 def _safe_copy(value: Any) -> Any:

--- a/src/tui/messages.py
+++ b/src/tui/messages.py
@@ -27,7 +27,10 @@ Naming conventions mirror the React side:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from src.permissions.types import PermissionUpdate
 
 from textual.message import Message
 
@@ -131,7 +134,7 @@ class PermissionRequested(Message):
     request_id: str
     tool_name: str
     message: str
-    suggestions: tuple[Any, ...] = ()
+    suggestions: tuple["PermissionUpdate", ...] = ()
     tool_input: dict[str, Any] | None = None
 
 

--- a/src/tui/messages.py
+++ b/src/tui/messages.py
@@ -131,7 +131,7 @@ class PermissionRequested(Message):
     request_id: str
     tool_name: str
     message: str
-    suggestion: str | None = None
+    suggestions: tuple[Any, ...] = ()
     tool_input: dict[str, Any] | None = None
 
 
@@ -141,11 +141,14 @@ class PermissionResolved(Message):
 
     Always paired with a call to :meth:`AppState.resolve_permission` so
     the worker thread is unblocked *before* this message is posted.
+    ``always`` means the user accepted the suggested "don't ask again"
+    rules; ``feedback`` is the optional deny-with-feedback note.
     """
 
     request_id: str
     allowed: bool
-    enable_setting: bool = False
+    always: bool = False
+    feedback: str | None = None
 
 
 @dataclass

--- a/src/tui/screens/permission_modal.py
+++ b/src/tui/screens/permission_modal.py
@@ -6,13 +6,28 @@ unified preview and chapter
 routes to a per-tool body (Bash → command + matched rule; Edit →
 inline diff; Write → file path + content preview; etc.).
 
+C1 (components-folder parity) upgraded the decision surface from binary
+Allow/Deny to the TS ``PermissionPrompt.tsx`` option list:
+
+* **Allow once** (``y``)
+* **Allow always** (``a``, only when the ask carries rule suggestions) —
+  accepts the derived "don't ask again" rules; the registry applies them
+  to the live context and persists them (TS "Yes, and don't ask again")
+* **Deny** (``n`` / ``Esc``)
+* **Deny with feedback** (``d``) — opens a one-line input; the note
+  reaches the model in the tool error (TS "No, and tell Claude what to
+  do differently")
+
+The modal resolves by calling ``request.decide`` with a
+:class:`src.permissions.types.PermissionAskReply`.
+
 Architecture per refactoring-plan A9: a single :class:`PermissionModal`
 screen with a tool-name-keyed dispatcher to specialized render
 functions. Avoids a class-per-tool hierarchy that would make adding
 tools verbose. Per the ``mouse=False`` design constraint (gap analysis
 §1 read #2 (c)), all interactive elements are reachable via keyboard
 only; the buttons are decorative — the actual decisions fire from the
-``y`` / ``n`` / ``Esc`` keybindings registered on the modal.
+keybindings registered on the modal.
 """
 
 from __future__ import annotations
@@ -27,7 +42,9 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Center, Middle, Vertical
 from textual.screen import ModalScreen
-from textual.widgets import Button, Static
+from textual.widgets import Button, Input, Static
+
+from src.permissions.updates import suggestions_label
 
 from ..messages import PermissionResolved
 from ..state import PendingPermission
@@ -37,8 +54,10 @@ class PermissionModal(ModalScreen[bool]):
     """Modal that blocks input until the user decides on a tool call."""
 
     BINDINGS = [
-        Binding("y", "allow", "Allow", show=False),
+        Binding("y", "allow", "Allow once", show=False),
+        Binding("a", "allow_always", "Allow always", show=False),
         Binding("n", "deny", "Deny", show=False),
+        Binding("d", "deny_feedback", "Deny with feedback", show=False),
         Binding("escape", "deny", "Deny", show=False),
     ]
 
@@ -79,6 +98,11 @@ class PermissionModal(ModalScreen[bool]):
     def __init__(self, request: PendingPermission) -> None:
         super().__init__()
         self._request = request
+        self._always_label = suggestions_label(
+            getattr(request, "suggestions", ()) or ()
+        )
+        self._feedback_open = False
+        self._resolved = False
 
     # ---- composition ----
     def compose(self) -> ComposeResult:
@@ -109,35 +133,98 @@ class PermissionModal(ModalScreen[bool]):
         )
         if input_preview is not None:
             panel.mount(Static(input_preview, markup=False))
-        if self._request.suggestion:
-            panel.mount(
-                Static(
-                    Text(self._request.suggestion, style="italic dim"),
-                    markup=False,
-                )
-            )
         buttons = Vertical(id="buttons")
         panel.mount(buttons)
-        buttons.mount(Button("Allow (y)", id="allow", classes="-allow"))
-        buttons.mount(Button("Deny  (n)", id="deny", classes="-deny"))
+        buttons.mount(Button("Allow once (y)", id="allow", classes="-allow"))
+        if self._always_label:
+            buttons.mount(
+                Button(
+                    f"Allow always (a) — {self._always_label}",
+                    id="allow-always",
+                    classes="-allow",
+                )
+            )
+        buttons.mount(Button("Deny (n / esc)", id="deny", classes="-deny"))
+        buttons.mount(
+            Button(
+                "Deny, tell Claude what to do differently (d)",
+                id="deny-feedback",
+                classes="-deny",
+            )
+        )
+        feedback = Input(
+            placeholder="Tell Claude what to do differently… (enter to send)",
+            id="feedback-input",
+        )
+        feedback.display = False
+        panel.mount(feedback)
 
     # ---- events ----
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "allow":
             self.action_allow()
+        elif event.button.id == "allow-always":
+            self.action_allow_always()
         elif event.button.id == "deny":
             self.action_deny()
+        elif event.button.id == "deny-feedback":
+            self.action_deny_feedback()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id == "feedback-input":
+            self._resolve(allowed=False, feedback=event.value.strip() or None)
 
     def action_allow(self) -> None:
-        self._resolve(True)
+        if self._feedback_open:
+            return
+        self._resolve(allowed=True)
+
+    def action_allow_always(self) -> None:
+        if self._feedback_open or not self._always_label:
+            return
+        self._resolve(allowed=True, always=True)
 
     def action_deny(self) -> None:
-        self._resolve(False)
+        # Esc while the feedback input is open backs out to plain deny —
+        # same end state, so just resolve.
+        self._resolve(allowed=False)
+
+    def action_deny_feedback(self) -> None:
+        if self._feedback_open:
+            return
+        self._feedback_open = True
+        try:
+            feedback = self.query_one("#feedback-input", Input)
+        except Exception:
+            self._resolve(allowed=False)
+            return
+        feedback.display = True
+        feedback.focus()
 
     # ---- internals ----
-    def _resolve(self, allowed: bool) -> None:
+    def _resolve(
+        self,
+        *,
+        allowed: bool,
+        always: bool = False,
+        feedback: str | None = None,
+    ) -> None:
+        if self._resolved:
+            return
+        self._resolved = True
+        from src.permissions.types import PermissionAskReply
+
+        if allowed:
+            chosen = (
+                tuple(getattr(self._request, "suggestions", ()) or ())
+                if always
+                else ()
+            )
+            reply = PermissionAskReply(behavior="allow", chosen_updates=chosen)
+        else:
+            reply = PermissionAskReply(behavior="deny", message=feedback)
         try:
-            self._request.decide(allowed, False)
+            self._request.decide(reply)
         except Exception:
             pass
         # Post the decision to the app so status-line / state observers
@@ -146,7 +233,8 @@ class PermissionModal(ModalScreen[bool]):
             PermissionResolved(
                 request_id=self._request.request_id,
                 allowed=allowed,
-                enable_setting=False,
+                always=always,
+                feedback=feedback,
             )
         )
         self.dismiss(allowed)

--- a/src/tui/screens/permission_modal.py
+++ b/src/tui/screens/permission_modal.py
@@ -240,17 +240,6 @@ class PermissionModal(ModalScreen[bool]):
         self.dismiss(allowed)
 
 
-def _preview_tool_input(tool_input: Any) -> RenderableType | None:
-    """Dispatch to a tool-name-keyed renderer, falling back to generic.
-
-    The original signature is preserved so :class:`PermissionModal` keeps
-    the same call site. The dispatcher is the new behavior — Phase 7's
-    specialization happens through this single entry point.
-    """
-
-    return preview_for_tool(None, tool_input)
-
-
 def preview_for_tool(
     tool_name: str | None, tool_input: Any
 ) -> RenderableType | None:

--- a/src/tui/state.py
+++ b/src/tui/state.py
@@ -64,16 +64,19 @@ def priority_of(dialog: FocusedDialog) -> int:
 class PendingPermission:
     """A tool-permission request awaiting user decision.
 
-    ``decide`` is called from the permission modal with the user's choice;
-    it is safe to invoke from either thread.
+    ``decide`` is called from the permission modal with the user's
+    :class:`src.permissions.types.PermissionAskReply`; it is safe to
+    invoke from either thread. ``suggestions`` carries the derived
+    "don't ask again" :class:`~src.permissions.types.PermissionUpdate`
+    rules behind the modal's always-allow option (C1).
     """
 
     request_id: str
     tool_name: str
     message: str
-    suggestion: str | None
+    suggestions: tuple[Any, ...]
     tool_input: dict[str, Any] | None
-    decide: Callable[[bool, bool], None]
+    decide: Callable[[Any], None]
     created_at: float = field(default_factory=time.time)
 
 
@@ -121,16 +124,16 @@ class AppState:
         self,
         tool_name: str,
         message: str,
-        suggestion: str | None,
+        suggestions: tuple[Any, ...],
         tool_input: dict[str, Any] | None,
-        decide: Callable[[bool, bool], None],
+        decide: Callable[[Any], None],
     ) -> PendingPermission:
         with self._lock:
             request = PendingPermission(
                 request_id=f"perm-{next(self._ids)}",
                 tool_name=tool_name,
                 message=message,
-                suggestion=suggestion,
+                suggestions=suggestions,
                 tool_input=tool_input,
                 decide=decide,
             )

--- a/src/tui/state.py
+++ b/src/tui/state.py
@@ -18,7 +18,10 @@ import threading
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from src.permissions.types import PermissionAskReply, PermissionUpdate
 
 
 class FocusedDialog(str, Enum):
@@ -74,9 +77,9 @@ class PendingPermission:
     request_id: str
     tool_name: str
     message: str
-    suggestions: tuple[Any, ...]
+    suggestions: tuple["PermissionUpdate", ...]
     tool_input: dict[str, Any] | None
-    decide: Callable[[Any], None]
+    decide: Callable[["PermissionAskReply"], None]
     created_at: float = field(default_factory=time.time)
 
 
@@ -124,9 +127,9 @@ class AppState:
         self,
         tool_name: str,
         message: str,
-        suggestions: tuple[Any, ...],
+        suggestions: tuple["PermissionUpdate", ...],
         tool_input: dict[str, Any] | None,
-        decide: Callable[[Any], None],
+        decide: Callable[["PermissionAskReply"], None],
     ) -> PendingPermission:
         with self._lock:
             request = PendingPermission(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,26 @@ class _InMemoryKeyringBackend:
 
 
 @pytest.fixture(autouse=True)
+def _isolate_user_permission_settings(tmp_path, monkeypatch):
+    """Point the USER permission-settings file at an empty per-test path.
+
+    C1 wired ``setup_permissions`` into the REPL/TUI/headless startup
+    paths, which would otherwise read the developer's real
+    ``~/.clawcodex/settings.json`` during tests — machine-dependent allow
+    rules could then flip dispatch assertions (review-A finding 6). The
+    project/local tiers resolve from each test's cwd/workspace and the
+    repo intentionally has no ``.clawcodex/`` dir, so only the user tier
+    needs pinning.
+    """
+
+    from src.permissions import settings_paths
+
+    isolated = str(tmp_path / "isolated-user-settings.json")
+    monkeypatch.setattr(settings_paths, "user_settings_path", lambda: isolated)
+    yield
+
+
+@pytest.fixture(autouse=True)
 def _isolate_mcp_keyring(request, monkeypatch):
     """Swap ``keyring.get_keyring()`` to a per-test in-memory backend so
     MCP token-storage tests don't leak into the real OS keychain.

--- a/tests/test_bash_suggestions.py
+++ b/tests/test_bash_suggestions.py
@@ -1,0 +1,158 @@
+"""Tests for src/permissions/bash_suggestions.py (C1).
+
+Mirrors the TS behavior of tools/BashTool/bashPermissions.ts
+``suggestionForExactCommand`` / ``getSimpleCommandPrefix`` and the shared
+builders in utils/permissions/shellRuleMatching.ts.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.permissions.bash_suggestions import (
+    get_simple_command_prefix,
+    suggestions_for_bash_command,
+)
+from src.permissions.types import PermissionUpdateAddRules
+
+
+def _only_rule(updates):
+    assert len(updates) == 1, updates
+    update = updates[0]
+    assert isinstance(update, PermissionUpdateAddRules)
+    assert update.behavior == "allow"
+    assert update.destination == "localSettings"
+    assert len(update.rules) == 1
+    return update.rules[0]
+
+
+class TestGetSimpleCommandPrefix(unittest.TestCase):
+    def test_two_word_prefix(self) -> None:
+        self.assertEqual(
+            get_simple_command_prefix('git commit -m "fix typo"'), "git commit"
+        )
+
+    def test_safe_env_var_skipped(self) -> None:
+        self.assertEqual(
+            get_simple_command_prefix("NODE_ENV=prod npm run build"), "npm run"
+        )
+
+    def test_unsafe_env_var_returns_none(self) -> None:
+        self.assertIsNone(get_simple_command_prefix("MY_VAR=val npm run build"))
+
+    def test_flag_second_token_returns_none(self) -> None:
+        self.assertIsNone(get_simple_command_prefix("ls -la"))
+
+    def test_filename_second_token_returns_none(self) -> None:
+        self.assertIsNone(get_simple_command_prefix("cat file.txt"))
+
+    def test_number_second_token_returns_none(self) -> None:
+        self.assertIsNone(get_simple_command_prefix("chmod 755 file"))
+
+    def test_single_word_returns_none(self) -> None:
+        self.assertIsNone(get_simple_command_prefix("ls"))
+
+
+class TestSuggestionsForBashCommand(unittest.TestCase):
+    def test_prefix_rule_for_subcommand(self) -> None:
+        rule = _only_rule(suggestions_for_bash_command("git diff --stat"))
+        self.assertEqual(rule.tool_name, "Bash")
+        self.assertEqual(rule.rule_content, "git diff:*")
+
+    def test_exact_rule_when_no_prefix(self) -> None:
+        rule = _only_rule(suggestions_for_bash_command("ls -la"))
+        self.assertEqual(rule.rule_content, "ls -la")
+
+    def test_heredoc_uses_prefix_before_operator(self) -> None:
+        cmd = 'git commit -m "$(cat <<\'EOF\'\nmsg\nEOF\n)"'
+        rule = _only_rule(suggestions_for_bash_command(cmd))
+        self.assertEqual(rule.rule_content, "git commit:*")
+
+    def test_heredoc_bare_shell_yields_nothing(self) -> None:
+        # Deliberate divergence from TS: Bash(bash:*) ≈ Bash(*).
+        self.assertEqual(suggestions_for_bash_command("bash <<EOF\nevil\nEOF"), [])
+
+    def test_multiline_uses_first_line_prefix(self) -> None:
+        cmd = "git status\ngit diff"
+        rule = _only_rule(suggestions_for_bash_command(cmd))
+        self.assertEqual(rule.rule_content, "git status:*")
+
+    def test_empty_command_yields_nothing(self) -> None:
+        self.assertEqual(suggestions_for_bash_command("   "), [])
+
+    def test_compound_command_still_gets_first_prefix(self) -> None:
+        # Safe because the matcher refuses chained commands at match time.
+        rule = _only_rule(suggestions_for_bash_command("git diff && echo hi"))
+        self.assertEqual(rule.rule_content, "git diff:*")
+
+
+class TestContainsUnquotedChaining(unittest.TestCase):
+    def test_operators_detected(self) -> None:
+        from src.permissions.bash_suggestions import contains_unquoted_chaining
+
+        for cmd in (
+            "a && b",
+            "a || b",
+            "a; b",
+            "a | b",
+            "a\nb",
+        ):
+            self.assertTrue(contains_unquoted_chaining(cmd), cmd)
+
+    def test_quoted_operators_ignored(self) -> None:
+        from src.permissions.bash_suggestions import contains_unquoted_chaining
+
+        for cmd in (
+            'echo "a && b"',
+            "echo 'a; b'",
+            'grep "x|y" file',
+            "git commit -m 'one; two'",
+        ):
+            self.assertFalse(contains_unquoted_chaining(cmd), cmd)
+
+    def test_simple_commands_clean(self) -> None:
+        from src.permissions.bash_suggestions import contains_unquoted_chaining
+
+        self.assertFalse(contains_unquoted_chaining("git diff --stat"))
+        self.assertFalse(contains_unquoted_chaining("ls -la /tmp"))
+
+
+class TestMatcherChainingGuard(unittest.TestCase):
+    def test_prefix_rule_rejects_chained_commands(self) -> None:
+        from src.permissions.check import prepare_permission_matcher
+
+        matcher = prepare_permission_matcher("git diff:*")
+        self.assertTrue(matcher("git diff --cached"))
+        self.assertFalse(matcher("git diff && echo hi"))
+        self.assertFalse(matcher("git diff | tee out.txt"))
+        self.assertFalse(matcher("git diff; echo hi"))
+
+    def test_single_word_prefix_rule_rejects_chained(self) -> None:
+        from src.permissions.check import prepare_permission_matcher
+
+        matcher = prepare_permission_matcher("git:*")
+        self.assertTrue(matcher("git status"))
+        self.assertFalse(matcher("git status && git push"))
+
+    def test_plain_prefix_rule_rejects_chained(self) -> None:
+        from src.permissions.check import prepare_permission_matcher
+
+        matcher = prepare_permission_matcher("npm run")
+        self.assertTrue(matcher("npm run build"))
+        self.assertFalse(matcher("npm run build && npm publish"))
+
+    def test_quoted_operator_still_matches(self) -> None:
+        from src.permissions.check import prepare_permission_matcher
+
+        matcher = prepare_permission_matcher("git commit:*")
+        self.assertTrue(matcher("git commit -m 'one; two'"))
+
+    def test_explicit_allow_all_unguarded(self) -> None:
+        from src.permissions.check import prepare_permission_matcher
+
+        self.assertTrue(prepare_permission_matcher("*")("a && b"))
+        self.assertTrue(prepare_permission_matcher("")("a && b"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bash_suggestions.py
+++ b/tests/test_bash_suggestions.py
@@ -85,6 +85,34 @@ class TestSuggestionsForBashCommand(unittest.TestCase):
         rule = _only_rule(suggestions_for_bash_command("git diff && echo hi"))
         self.assertEqual(rule.rule_content, "git diff:*")
 
+    def test_compound_without_derivable_prefix_yields_nothing(self) -> None:
+        # An exact rule containing chaining would be unmatchable (dead).
+        self.assertEqual(suggestions_for_bash_command("ls && pwd"), [])
+
+    def test_multiline_compound_first_line_derives_prefix(self) -> None:
+        # A verbatim compound first line would mint a dead rule.
+        rule = _only_rule(
+            suggestions_for_bash_command("git fetch && git rebase\ngit push")
+        )
+        self.assertEqual(rule.rule_content, "git fetch:*")
+
+    def test_multiline_bare_shell_first_line_yields_nothing(self) -> None:
+        self.assertEqual(suggestions_for_bash_command("bash\necho hi"), [])
+
+    def test_heredoc_at_index_zero_yields_nothing(self) -> None:
+        self.assertEqual(suggestions_for_bash_command("<<EOF\nhi\nEOF"), [])
+
+    def test_heredoc_with_chained_before_segment_yields_nothing(self) -> None:
+        self.assertEqual(
+            suggestions_for_bash_command("true && cat <<EOF\nhi\nEOF"), []
+        )
+
+    def test_env_assignment_then_compound(self) -> None:
+        rule = _only_rule(
+            suggestions_for_bash_command("NODE_ENV=test npm run lint && npm test")
+        )
+        self.assertEqual(rule.rule_content, "npm run:*")
+
 
 class TestContainsUnquotedChaining(unittest.TestCase):
     def test_operators_detected(self) -> None:
@@ -115,6 +143,24 @@ class TestContainsUnquotedChaining(unittest.TestCase):
 
         self.assertFalse(contains_unquoted_chaining("git diff --stat"))
         self.assertFalse(contains_unquoted_chaining("ls -la /tmp"))
+
+    def test_lone_ampersand_detected_redirections_skipped(self) -> None:
+        from src.permissions.bash_suggestions import contains_unquoted_chaining
+
+        self.assertTrue(contains_unquoted_chaining("a & b"))
+        self.assertTrue(contains_unquoted_chaining("a&b"))
+        self.assertTrue(contains_unquoted_chaining("sleep 5 &"))
+        self.assertFalse(contains_unquoted_chaining("cmd 2>&1"))
+        self.assertFalse(contains_unquoted_chaining("cmd <&3"))
+        self.assertFalse(contains_unquoted_chaining("cmd &> out.log"))
+
+    def test_escaped_operators(self) -> None:
+        from src.permissions.bash_suggestions import contains_unquoted_chaining
+
+        self.assertFalse(contains_unquoted_chaining(r"echo a\;b"))
+        self.assertFalse(contains_unquoted_chaining(r"echo a\|b"))
+        # Double backslash = literal backslash, then a REAL separator.
+        self.assertTrue(contains_unquoted_chaining("echo a\\\\; rm x"))
 
 
 class TestMatcherChainingGuard(unittest.TestCase):
@@ -152,6 +198,42 @@ class TestMatcherChainingGuard(unittest.TestCase):
 
         self.assertTrue(prepare_permission_matcher("*")("a && b"))
         self.assertTrue(prepare_permission_matcher("")("a && b"))
+
+    def test_prefix_rule_word_boundary(self) -> None:
+        from src.permissions.check import prepare_permission_matcher
+
+        matcher = prepare_permission_matcher("git diff:*")
+        self.assertTrue(matcher("git diff"))
+        self.assertFalse(matcher("git diffx"))
+
+    def test_exact_rule_rejects_elongation(self) -> None:
+        from src.permissions.check import prepare_permission_matcher
+
+        matcher = prepare_permission_matcher("ls -la")
+        self.assertTrue(matcher("ls -la"))
+        self.assertTrue(matcher("ls -la /tmp"))
+        self.assertFalse(matcher("ls -lah"))
+        run = prepare_permission_matcher("npm run")
+        self.assertFalse(run("npm runabc"))
+
+    def test_basename_normalization_both_directions(self) -> None:
+        from src.permissions.check import prepare_permission_matcher
+
+        matcher = prepare_permission_matcher("git status:*")
+        # Intended direction: path-qualified executable matches.
+        self.assertTrue(matcher("/usr/bin/git status"))
+        # Accepted trade-off (locked deliberately): a same-named
+        # executable at ANY path also matches — the safety screen runs
+        # first on every command, which bounds the exposure.
+        self.assertTrue(matcher("/somewhere/else/git status"))
+
+    def test_exact_prefix_suffix_branch(self) -> None:
+        from src.permissions.check import prepare_permission_matcher
+
+        matcher = prepare_permission_matcher("git:status*")
+        self.assertTrue(matcher("git status --short"))
+        self.assertFalse(matcher("git push"))
+        self.assertFalse(matcher("git status && git push"))
 
 
 if __name__ == "__main__":

--- a/tests/test_dangerous_skip_permissions.py
+++ b/tests/test_dangerous_skip_permissions.py
@@ -295,8 +295,12 @@ def test_headless_run_default_mode_keeps_auto_deny_handler(tmp_path, monkeypatch
     # Default mode keeps the auto-deny handler.
     assert ctx.permission_context.mode == "default"
     assert ctx.permission_handler is not None
-    allowed, _ = ctx.permission_handler("Bash", "needs approval", None)
-    assert allowed is False
+    from src.permissions.types import PermissionAskRequest
+
+    reply = ctx.permission_handler(
+        PermissionAskRequest(tool_name="Bash", message="needs approval")
+    )
+    assert reply.behavior == "deny"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_headless_cli.py
+++ b/tests/test_headless_cli.py
@@ -267,9 +267,13 @@ def test_headless_without_skip_permissions_installs_auto_deny_handler(fake_wirin
     assert code == 0
     ctx = captured["tool_context"]
     assert ctx.options.is_non_interactive_session is True
-    # Non-interactive mode installs an auto-deny handler that returns (False, False).
-    allowed, _ = ctx.permission_handler("Bash", "needs approval", None)
-    assert allowed is False
+    # Non-interactive mode installs an auto-deny handler that replies deny.
+    from src.permissions.types import PermissionAskRequest
+
+    reply = ctx.permission_handler(
+        PermissionAskRequest(tool_name="Bash", message="needs approval")
+    )
+    assert reply.behavior == "deny"
 
 
 def test_headless_with_skip_permissions_clears_handler(fake_wiring, tmp_path):

--- a/tests/test_integration_permission_system.py
+++ b/tests/test_integration_permission_system.py
@@ -257,26 +257,72 @@ class TestSettingsLoader(unittest.TestCase):
 class TestHandlePermissionAsk(unittest.TestCase):
     def test_no_handler_returns_deny(self) -> None:
         decision = PermissionAskDecision(message="confirm?")
-        result = handle_permission_ask("TestTool", decision)
+        result, chosen = handle_permission_ask("TestTool", decision)
         self.assertEqual(result.behavior, "deny")
+        self.assertEqual(chosen, ())
 
     def test_handler_allows(self) -> None:
+        from src.permissions.types import PermissionAskReply, PermissionAskRequest
+
         decision = PermissionAskDecision(message="confirm?")
 
-        def handler(name: str, msg: str, suggestions: Any) -> tuple[bool, Any]:
-            return True, None
+        def handler(request: PermissionAskRequest) -> PermissionAskReply:
+            assert request.tool_name == "TestTool"
+            assert request.message == "confirm?"
+            return PermissionAskReply(behavior="allow")
 
-        result = handle_permission_ask("TestTool", decision, handler)
+        result, chosen = handle_permission_ask("TestTool", decision, handler)
         self.assertEqual(result.behavior, "allow")
+        self.assertEqual(chosen, ())
 
     def test_handler_denies(self) -> None:
+        from src.permissions.types import PermissionAskReply, PermissionAskRequest
+
         decision = PermissionAskDecision(message="confirm?")
 
-        def handler(name: str, msg: str, suggestions: Any) -> tuple[bool, Any]:
-            return False, None
+        def handler(request: PermissionAskRequest) -> PermissionAskReply:
+            return PermissionAskReply(behavior="deny")
 
-        result = handle_permission_ask("TestTool", decision, handler)
+        result, chosen = handle_permission_ask("TestTool", decision, handler)
         self.assertEqual(result.behavior, "deny")
+        self.assertEqual(chosen, ())
+
+    def test_handler_deny_feedback_reaches_message(self) -> None:
+        from src.permissions.types import PermissionAskReply, PermissionAskRequest
+
+        decision = PermissionAskDecision(message="confirm?")
+
+        def handler(request: PermissionAskRequest) -> PermissionAskReply:
+            return PermissionAskReply(behavior="deny", message="use rg instead")
+
+        result, _ = handle_permission_ask("TestTool", decision, handler)
+        self.assertEqual(result.behavior, "deny")
+        self.assertIn("use rg instead", result.message)
+
+    def test_handler_always_returns_chosen_updates(self) -> None:
+        from src.permissions.types import (
+            PermissionAskReply,
+            PermissionAskRequest,
+            PermissionRuleValue,
+            PermissionUpdateAddRules,
+        )
+
+        update = PermissionUpdateAddRules(
+            destination="localSettings",
+            behavior="allow",
+            rules=(PermissionRuleValue(tool_name="Bash", rule_content="git diff:*"),),
+        )
+        decision = PermissionAskDecision(message="confirm?", suggestions=[update])
+
+        def handler(request: PermissionAskRequest) -> PermissionAskReply:
+            assert request.suggestions == (update,)
+            return PermissionAskReply(
+                behavior="allow", chosen_updates=tuple(request.suggestions)
+            )
+
+        result, chosen = handle_permission_ask("TestTool", decision, handler)
+        self.assertEqual(result.behavior, "allow")
+        self.assertEqual(chosen, (update,))
 
 
 class TestBuildAppSmoke(unittest.TestCase):

--- a/tests/test_permission_ask_flow.py
+++ b/tests/test_permission_ask_flow.py
@@ -43,18 +43,26 @@ def _make_ask_tool(name: str = "Bash"):
 
 class TestSettingsPaths(unittest.TestCase):
     def test_destination_mapping(self) -> None:
+        # Project tier is .clawcodex/ — NOT .claude/, which the real
+        # Claude Code harness owns (cross-tool interference otherwise).
         self.assertEqual(
             settings_path_for_destination("localSettings", "/tmp/p"),
-            "/tmp/p/.claude/settings.local.json",
+            "/tmp/p/.clawcodex/settings.local.json",
         )
         self.assertEqual(
             settings_path_for_destination("projectSettings", "/tmp/p"),
-            "/tmp/p/.claude/settings.json",
+            "/tmp/p/.clawcodex/settings.json",
         )
-        self.assertTrue(
-            settings_path_for_destination("userSettings").endswith(
-                "/.clawcodex/settings.json"
-            )
+        # The live user_settings_path() is conftest-isolated in tests
+        # (_isolate_user_permission_settings), so lock the canonical user
+        # tier via the constant it derives from.
+        import os
+
+        from src.permissions import settings_paths as sp_mod
+
+        self.assertEqual(
+            sp_mod.USER_SETTINGS_FILENAME,
+            os.path.join("~", ".clawcodex", "settings.json"),
         )
         self.assertIsNone(settings_path_for_destination("session"))
         self.assertIsNone(settings_path_for_destination("cliArg"))
@@ -70,7 +78,9 @@ class TestSettingsPaths(unittest.TestCase):
                 "managed_settings_path",
             },
         )
-        self.assertEqual(paths["local_settings_path"], "/tmp/p/.claude/settings.local.json")
+        self.assertEqual(
+            paths["local_settings_path"], "/tmp/p/.clawcodex/settings.local.json"
+        )
 
 
 class TestRegistryAskFlow(unittest.TestCase):
@@ -87,7 +97,7 @@ class TestRegistryAskFlow(unittest.TestCase):
         self.tmp.cleanup()
 
     def _local_settings(self) -> Path:
-        return self.root / ".claude" / "settings.local.json"
+        return self.root / ".clawcodex" / "settings.local.json"
 
     def _dispatch(self, command: str):
         return self.registry.dispatch(
@@ -168,7 +178,7 @@ class TestRegistryAskFlow(unittest.TestCase):
             cwd=str(self.root),
             mode="default",
             user_settings_path=str(self.root / "nonexistent-user-settings.json"),
-            project_settings_path=str(self.root / ".claude" / "settings.json"),
+            project_settings_path=str(self.root / ".clawcodex" / "settings.json"),
             local_settings_path=str(self._local_settings()),
         )
         tool = _make_ask_tool()
@@ -182,6 +192,85 @@ class TestRegistryAskFlow(unittest.TestCase):
             tool, {"command": "rm -r build"}, setup.context
         )
         self.assertEqual(other.behavior, "ask")
+
+
+class TestHeadlessStartupLoadsPersistedRules(unittest.TestCase):
+    """Executes the PRODUCTION headless setup block (not an inline copy):
+    a rule persisted in the workspace's local settings must be live in the
+    tool_context that run_headless constructs (review-A finding 5b)."""
+
+    def test_headless_setup_block_loads_rules(self) -> None:
+        import io
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from src.entrypoints import headless as headless_mod
+        from src.entrypoints.headless import HeadlessOptions, run_headless
+        from src.providers.base import ChatResponse
+
+        class _FakeProvider:
+            def __init__(self, api_key, base_url=None, model=None):
+                self.model = model or "fake"
+
+            def chat(self, messages, tools=None, **kw):
+                return ChatResponse(
+                    content="ok",
+                    model="fake",
+                    usage={"input_tokens": 1, "output_tokens": 1},
+                    finish_reason="end_turn",
+                    tool_uses=None,
+                )
+
+        class _FakeRegistry:
+            def list_tools(self):
+                return []
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            local = root / ".clawcodex" / "settings.local.json"
+            local.parent.mkdir(parents=True)
+            local.write_text(
+                json.dumps({"permissions": {"allow": ["Bash(git diff:*)"]}})
+            )
+
+            captured: dict = {}
+            original = headless_mod.run_query_as_agent_loop
+
+            async def _capture(*args, **kw):
+                captured["tool_context"] = kw["tool_context"]
+                return await original(*args, **kw)
+
+            with patch.object(
+                headless_mod, "get_provider_class", lambda n: _FakeProvider
+            ), patch.object(
+                headless_mod,
+                "get_provider_config",
+                lambda n: {"api_key": "x", "default_model": "fake"},
+            ), patch.object(
+                headless_mod, "get_default_provider", lambda: "anthropic"
+            ), patch.object(
+                headless_mod,
+                "build_default_registry",
+                lambda provider=None: _FakeRegistry(),
+            ), patch.object(
+                headless_mod, "run_query_as_agent_loop", _capture
+            ):
+                code = run_headless(
+                    HeadlessOptions(
+                        prompt="hi",
+                        output_format="text",
+                        stdout=io.StringIO(),
+                        stderr=io.StringIO(),
+                        workspace_root=root,
+                    )
+                )
+            self.assertEqual(code, 0)
+            ctx = captured["tool_context"]
+            self.assertIn(
+                "Bash(git diff:*)",
+                ctx.permission_context.always_allow_rules.get("localSettings", []),
+            )
 
 
 class TestHeadlessNoHandlerStillDenies(unittest.TestCase):

--- a/tests/test_permission_ask_flow.py
+++ b/tests/test_permission_ask_flow.py
@@ -1,0 +1,242 @@
+"""C1 end-to-end tests: ask → multi-option reply → apply + persist → reload.
+
+Covers the previously-severed last mile (registry adapter / tool_input /
+suggestions) and the read side (rules loaded at startup). The restart
+round-trip is the test that would have caught the persist-into-a-void bug
+the plan critic flagged.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.permissions.check import has_permissions_to_use_tool
+from src.permissions.settings_paths import (
+    default_setup_paths,
+    settings_path_for_destination,
+)
+from src.permissions.setup import setup_permissions
+from src.permissions.types import (
+    PermissionAskDecision,
+    PermissionAskReply,
+    PermissionPassthroughResult,
+    ToolPermissionContext,
+)
+from src.tool_system.build_tool import build_tool
+from src.tool_system.context import ToolContext
+from src.tool_system.protocol import ToolCall, ToolResult
+from src.tool_system.registry import ToolRegistry
+
+
+def _make_ask_tool(name: str = "Bash"):
+    return build_tool(
+        name=name,
+        description="test tool",
+        input_schema={"type": "object", "properties": {"command": {"type": "string"}}},
+        call=lambda tool_input, context: ToolResult(name=name, output={"ok": True}),
+        check_permissions=lambda tool_input, context: PermissionPassthroughResult(),
+    )
+
+
+class TestSettingsPaths(unittest.TestCase):
+    def test_destination_mapping(self) -> None:
+        self.assertEqual(
+            settings_path_for_destination("localSettings", "/tmp/p"),
+            "/tmp/p/.claude/settings.local.json",
+        )
+        self.assertEqual(
+            settings_path_for_destination("projectSettings", "/tmp/p"),
+            "/tmp/p/.claude/settings.json",
+        )
+        self.assertTrue(
+            settings_path_for_destination("userSettings").endswith(
+                "/.clawcodex/settings.json"
+            )
+        )
+        self.assertIsNone(settings_path_for_destination("session"))
+        self.assertIsNone(settings_path_for_destination("cliArg"))
+
+    def test_default_setup_paths_keys(self) -> None:
+        paths = default_setup_paths("/tmp/p")
+        self.assertEqual(
+            set(paths),
+            {
+                "user_settings_path",
+                "project_settings_path",
+                "local_settings_path",
+                "managed_settings_path",
+            },
+        )
+        self.assertEqual(paths["local_settings_path"], "/tmp/p/.claude/settings.local.json")
+
+
+class TestRegistryAskFlow(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name).resolve()
+        self.registry = ToolRegistry([_make_ask_tool()])
+        self.ctx = ToolContext(
+            workspace_root=self.root,
+            permission_context=ToolPermissionContext(mode="default"),
+        )
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _local_settings(self) -> Path:
+        return self.root / ".claude" / "settings.local.json"
+
+    def _dispatch(self, command: str):
+        return self.registry.dispatch(
+            ToolCall(name="Bash", input={"command": command}), self.ctx
+        )
+
+    def test_request_carries_tool_input_and_suggestions(self) -> None:
+        captured = {}
+
+        def handler(request):
+            captured["request"] = request
+            return PermissionAskReply(behavior="allow")
+
+        self.ctx.permission_handler = handler
+        result = self._dispatch("git diff --stat")
+        self.assertFalse(result.is_error)
+        request = captured["request"]
+        self.assertEqual(request.tool_name, "Bash")
+        self.assertEqual(request.tool_input, {"command": "git diff --stat"})
+        self.assertTrue(request.suggestions)
+        rule = request.suggestions[0].rules[0]
+        self.assertEqual(rule.rule_content, "git diff:*")
+
+    def test_allow_once_does_not_persist(self) -> None:
+        self.ctx.permission_handler = lambda request: PermissionAskReply(
+            behavior="allow"
+        )
+        result = self._dispatch("git diff --stat")
+        self.assertFalse(result.is_error)
+        self.assertFalse(self._local_settings().exists())
+        # And the in-memory context gained no rules either.
+        self.assertEqual(self.ctx.permission_context.always_allow_rules, {})
+
+    def test_allow_always_applies_in_memory_and_persists(self) -> None:
+        calls = {"n": 0}
+
+        def handler(request):
+            calls["n"] += 1
+            return PermissionAskReply(
+                behavior="allow", chosen_updates=tuple(request.suggestions)
+            )
+
+        self.ctx.permission_handler = handler
+
+        first = self._dispatch("git diff --stat")
+        self.assertFalse(first.is_error)
+        self.assertEqual(calls["n"], 1)
+
+        # Persisted: rule string under permissions.allow in localSettings.
+        settings = json.loads(self._local_settings().read_text())
+        self.assertIn("Bash(git diff:*)", settings["permissions"]["allow"])
+
+        # In-memory: a second matching call must NOT re-prompt.
+        second = self._dispatch("git diff HEAD~1")
+        self.assertFalse(second.is_error)
+        self.assertEqual(calls["n"], 1, "rule should auto-allow without re-asking")
+
+    def test_deny_feedback_reaches_tool_error(self) -> None:
+        self.ctx.permission_handler = lambda request: PermissionAskReply(
+            behavior="deny", message="use git log instead"
+        )
+        result = self._dispatch("git diff --stat")
+        self.assertTrue(result.is_error)
+        self.assertIn("use git log instead", result.output["error"])
+
+    def test_restart_round_trip_rule_auto_allows(self) -> None:
+        """Persist via "always" → rebuild context via the STARTUP loader →
+        the rule auto-allows with no handler involved at all."""
+
+        self.ctx.permission_handler = lambda request: PermissionAskReply(
+            behavior="allow", chosen_updates=tuple(request.suggestions)
+        )
+        self.assertFalse(self._dispatch("git diff --stat").is_error)
+        self.assertTrue(self._local_settings().exists())
+
+        # "Restart": fresh context built exactly like the entrypoints do.
+        setup = setup_permissions(
+            cwd=str(self.root),
+            mode="default",
+            user_settings_path=str(self.root / "nonexistent-user-settings.json"),
+            project_settings_path=str(self.root / ".claude" / "settings.json"),
+            local_settings_path=str(self._local_settings()),
+        )
+        tool = _make_ask_tool()
+        decision = has_permissions_to_use_tool(
+            tool, {"command": "git diff --cached"}, setup.context
+        )
+        self.assertEqual(decision.behavior, "allow")
+
+        # A non-matching command still asks.
+        other = has_permissions_to_use_tool(
+            tool, {"command": "rm -r build"}, setup.context
+        )
+        self.assertEqual(other.behavior, "ask")
+
+
+class TestHeadlessNoHandlerStillDenies(unittest.TestCase):
+    def test_ask_without_handler_denies(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        try:
+            registry = ToolRegistry([_make_ask_tool()])
+            ctx = ToolContext(
+                workspace_root=Path(tmp.name),
+                permission_context=ToolPermissionContext(mode="default"),
+            )
+            ctx.permission_handler = None
+            result = registry.dispatch(
+                ToolCall(name="Bash", input={"command": "git diff"}), ctx
+            )
+            self.assertTrue(result.is_error)
+        finally:
+            tmp.cleanup()
+
+
+class TestSafetyAsksCarryNoSuggestions(unittest.TestCase):
+    def test_dangerous_command_ask_has_no_suggestions(self) -> None:
+        from src.permissions.check import has_permissions_to_use_tool
+        from src.tool_system.tools.bash.bash_tool import _bash_check_permissions
+
+        tool = build_tool(
+            name="Bash",
+            description="bash",
+            input_schema={
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+            },
+            call=lambda tool_input, context: ToolResult(name="Bash", output={"ok": True}),
+            check_permissions=_bash_check_permissions,
+        )
+        tmp = tempfile.TemporaryDirectory()
+        try:
+            ctx = ToolContext(
+                workspace_root=Path(tmp.name),
+                permission_context=ToolPermissionContext(mode="default"),
+            )
+            decision = has_permissions_to_use_tool(
+                tool,
+                {"command": "rm -rf /tmp/whatever"},
+                ctx.permission_context,
+                tool_use_context=ctx,
+            )
+            self.assertEqual(decision.behavior, "ask")
+            self.assertFalse(
+                decision.suggestions,
+                "safety-flagged asks must not suggest saving the command",
+            )
+        finally:
+            tmp.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -135,7 +135,11 @@ class TestToolRegistryDispatchPermissions(unittest.TestCase):
         self.tmp.cleanup()
 
     def test_dispatch_allows_regular_file_with_handler(self) -> None:
-        self.ctx.permission_handler = lambda name, msg, sug: (True, False)
+        from src.permissions.types import PermissionAskReply
+
+        self.ctx.permission_handler = lambda request: PermissionAskReply(
+            behavior="allow"
+        )
         result = self.registry.dispatch(
             ToolCall(name="Write", input={"file_path": str(self.root / "test.txt"), "content": "hello"}),
             self.ctx,
@@ -156,14 +160,16 @@ class TestToolRegistryDispatchPermissions(unittest.TestCase):
         )
 
     def test_dispatch_calls_permission_handler_for_ask(self) -> None:
-        call_count = 0
-        captured_args = None
+        from src.permissions.types import PermissionAskReply
 
-        def mock_handler(tool_name: str, message: str, suggestion: str | None):
-            nonlocal call_count, captured_args
+        call_count = 0
+        captured_request = None
+
+        def mock_handler(request):
+            nonlocal call_count, captured_request
             call_count += 1
-            captured_args = (tool_name, message, suggestion)
-            return True, False
+            captured_request = request
+            return PermissionAskReply(behavior="allow")
 
         self.ctx.permission_handler = mock_handler
 
@@ -173,12 +179,19 @@ class TestToolRegistryDispatchPermissions(unittest.TestCase):
         )
 
         self.assertEqual(call_count, 1)
-        self.assertEqual(captured_args[0], "Write")
+        self.assertEqual(captured_request.tool_name, "Write")
+        # C1: the registry forwards the REAL tool input to the surface.
+        self.assertEqual(
+            captured_request.tool_input.get("file_path"),
+            str(self.root / "test.md"),
+        )
         self.assertFalse(result.is_error)
 
     def test_dispatch_respects_handler_deny(self) -> None:
-        def mock_handler(tool_name: str, message: str, suggestion: str | None):
-            return False, False
+        from src.permissions.types import PermissionAskReply
+
+        def mock_handler(request):
+            return PermissionAskReply(behavior="deny")
 
         self.ctx.permission_handler = mock_handler
 
@@ -190,10 +203,28 @@ class TestToolRegistryDispatchPermissions(unittest.TestCase):
         self.assertTrue(result.is_error)
         self.assertIn("denied", result.output.get("error", "").lower())
 
+    def test_dispatch_deny_feedback_reaches_error(self) -> None:
+        from src.permissions.types import PermissionAskReply
+
+        def mock_handler(request):
+            return PermissionAskReply(behavior="deny", message="write it in /tmp")
+
+        self.ctx.permission_handler = mock_handler
+
+        result = self.registry.dispatch(
+            ToolCall(name="Write", input={"file_path": str(self.root / "test.md"), "content": "hello"}),
+            self.ctx,
+        )
+
+        self.assertTrue(result.is_error)
+        self.assertIn("write it in /tmp", result.output.get("error", ""))
+
     def test_dispatch_allows_after_handler_enables_setting(self) -> None:
-        def mock_handler(tool_name: str, message: str, suggestion: str | None):
+        from src.permissions.types import PermissionAskReply
+
+        def mock_handler(request):
             self.ctx.allow_docs = True
-            return True, False
+            return PermissionAskReply(behavior="allow")
 
         self.ctx.permission_handler = mock_handler
 

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -631,6 +631,121 @@ class TestREPL(unittest.TestCase):
                     self.assertEqual(second.behavior, "allow")
                     self.assertEqual(prompt_calls, 1)
 
+    def _make_repl_for_menu(self):
+        with patch('src.repl.core.get_provider_config', return_value={
+            "api_key": "test_api_key_12345678",
+            "base_url": "https://open.bigmodel.cn/api/paas/v4",
+            "default_model": "glm-4.5",
+        }), patch('src.repl.core.PromptSession') as mock_prompt_session:
+            mock_prompt_session.return_value = Mock(prompt=Mock(return_value=""))
+            with patch('src.repl.core.Session.create'):
+                with patch('src.repl.core.get_provider_class') as mock_provider_class:
+                    mock_provider = Mock()
+                    mock_provider.model = "glm-4.5"
+                    mock_provider_class.return_value = mock_provider
+                    repl = ClawcodexREPL(provider_name="glm")
+                    repl.console.print = Mock()
+                    return repl
+
+    def _suggestion(self):
+        from src.permissions.types import (
+            PermissionRuleValue,
+            PermissionUpdateAddRules,
+        )
+
+        return PermissionUpdateAddRules(
+            destination="localSettings",
+            behavior="allow",
+            rules=(
+                PermissionRuleValue(tool_name="Bash", rule_content="git diff:*"),
+            ),
+        )
+
+    def test_permission_menu_always_option(self):
+        """With suggestions: row 2 = always; both '2' and 'a' choose it,
+        the reply carries chosen_updates, and the decision is NOT cached."""
+        from src.permissions.types import PermissionAskRequest
+
+        suggestion = self._suggestion()
+        for choice in ("2", "a"):
+            repl = self._make_repl_for_menu()
+            repl._safe_input = Mock(return_value=choice)
+            reply = repl._handle_permission_request(
+                PermissionAskRequest(
+                    tool_name="Bash",
+                    message="Run?",
+                    suggestions=(suggestion,),
+                )
+            )
+            self.assertEqual(reply.behavior, "allow")
+            self.assertEqual(reply.chosen_updates, (suggestion,))
+            self.assertEqual(repl._permission_decision_cache, {})
+
+    def test_permission_menu_numbering_with_suggestions(self):
+        """Without an enable row: 1=allow, 2=always, 3=deny, 4=feedback."""
+        from src.permissions.types import PermissionAskRequest
+
+        suggestion = self._suggestion()
+        repl = self._make_repl_for_menu()
+        repl._safe_input = Mock(return_value="3")
+        reply = repl._handle_permission_request(
+            PermissionAskRequest(
+                tool_name="Bash", message="Run?", suggestions=(suggestion,)
+            )
+        )
+        self.assertEqual(reply.behavior, "deny")
+        self.assertIsNone(reply.message)
+
+    def test_permission_menu_feedback_option(self):
+        """'d' (or the last row number) opens the feedback sub-prompt and
+        the note lands on the deny reply."""
+        from src.permissions.types import PermissionAskRequest
+
+        repl = self._make_repl_for_menu()
+        repl._safe_input = Mock(side_effect=["d", "try /tmp instead"])
+        reply = repl._handle_permission_request(
+            PermissionAskRequest(tool_name="Bash", message="Run?")
+        )
+        self.assertEqual(reply.behavior, "deny")
+        self.assertEqual(reply.message, "try /tmp instead")
+
+    def test_permission_menu_enable_row_shifts_numbering(self):
+        """allow_docs asks prepend the enable row: 1=enable, 2=allow,
+        3=deny, 4=feedback (no suggestions case)."""
+        from src.permissions.types import PermissionAskRequest
+
+        repl = self._make_repl_for_menu()
+        repl.tool_context.allow_docs = False
+        repl._safe_input = Mock(return_value="1")
+        reply = repl._handle_permission_request(
+            PermissionAskRequest(
+                tool_name="Write",
+                message="Writing documentation files is blocked unless "
+                "allow_docs is enabled",
+            )
+        )
+        self.assertEqual(reply.behavior, "allow")
+        self.assertTrue(repl.tool_context.allow_docs)
+
+    def test_repl_tool_context_is_registry_rebind_target(self):
+        """The REPL holds ONE ToolContext; an in-session applied rule
+        (registry rebinds permission_context on it) is visible to the
+        next dispatch through the same object."""
+        from src.permissions.types import PermissionRuleValue, PermissionUpdateAddRules
+        from src.permissions.updates import apply_permission_updates
+
+        repl = self._make_repl_for_menu()
+        before = repl.tool_context.permission_context
+        repl.tool_context.permission_context = apply_permission_updates(
+            before, [self._suggestion()]
+        )
+        self.assertIn(
+            "Bash(git diff:*)",
+            repl.tool_context.permission_context.always_allow_rules.get(
+                "localSettings", []
+            ),
+        )
+
 
 class TestConversation(unittest.TestCase):
     """Test conversation management."""

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -560,13 +560,25 @@ class TestREPL(unittest.TestCase):
 
                     repl._safe_input = fake_input  # type: ignore[assignment]
 
+                    from src.permissions.types import PermissionAskRequest
+
                     t1 = threading.Thread(
                         target=repl._handle_permission_request,
-                        args=("Grep", "Claude wants to use Grep. Allow?", None),
+                        args=(
+                            PermissionAskRequest(
+                                tool_name="Grep",
+                                message="Claude wants to use Grep. Allow?",
+                            ),
+                        ),
                     )
                     t2 = threading.Thread(
                         target=repl._handle_permission_request,
-                        args=("Read", "Claude wants to use Read. Allow?", None),
+                        args=(
+                            PermissionAskRequest(
+                                tool_name="Read",
+                                message="Claude wants to use Read. Allow?",
+                            ),
+                        ),
                     )
                     t1.start()
                     t2.start()
@@ -600,19 +612,23 @@ class TestREPL(unittest.TestCase):
 
                     repl._safe_input = fake_input  # type: ignore[assignment]
 
+                    from src.permissions.types import PermissionAskRequest
+
                     first = repl._handle_permission_request(
-                        "Grep",
-                        "Claude wants to use Grep. Allow?",
-                        None,
+                        PermissionAskRequest(
+                            tool_name="Grep",
+                            message="Claude wants to use Grep. Allow?",
+                        )
                     )
                     second = repl._handle_permission_request(
-                        "Grep",
-                        "Claude wants to use Grep. Allow?",
-                        None,
+                        PermissionAskRequest(
+                            tool_name="Grep",
+                            message="Claude wants to use Grep. Allow?",
+                        )
                     )
 
-                    self.assertEqual(first, (True, False))
-                    self.assertEqual(second, (True, False))
+                    self.assertEqual(first.behavior, "allow")
+                    self.assertEqual(second.behavior, "allow")
                     self.assertEqual(prompt_calls, 1)
 
 

--- a/tests/test_tool_registry_pipeline.py
+++ b/tests/test_tool_registry_pipeline.py
@@ -160,7 +160,7 @@ class TestRegistryDispatch(unittest.TestCase):
         self.assertFalse(result.is_error)
 
     def test_dispatch_checks_permissions_ask_with_handler_deny(self) -> None:
-        from src.permissions.types import PermissionAskDecision
+        from src.permissions.types import PermissionAskDecision, PermissionAskReply
 
         def _ask(inp: dict, ctx: ToolContext):
             return PermissionAskDecision(message="confirm?")
@@ -171,7 +171,7 @@ class TestRegistryDispatch(unittest.TestCase):
             workspace_root=Path(self.tmp.name),
             permission_context=ToolPermissionContext(mode="default"),
         )
-        ctx.permission_handler = lambda name, msg, sug: (False, False)
+        ctx.permission_handler = lambda request: PermissionAskReply(behavior="deny")
         result = reg.dispatch(ToolCall(name="NeedApproval", input={}), ctx)
         self.assertTrue(result.is_error)
         self.assertIn("denied", result.output["error"])

--- a/tests/tui/test_permission_modal_options.py
+++ b/tests/tui/test_permission_modal_options.py
@@ -1,0 +1,123 @@
+"""Pilot tests for the C1 multi-option permission modal."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("textual")
+
+from textual.app import App, ComposeResult
+from textual.screen import Screen
+from textual.widgets import Static
+
+from src.permissions.types import (
+    PermissionAskReply,
+    PermissionRuleValue,
+    PermissionUpdateAddRules,
+)
+from src.tui.screens.permission_modal import PermissionModal
+from src.tui.state import PendingPermission
+
+
+class _Host(Screen):
+    def compose(self) -> ComposeResult:
+        yield Static("host")
+
+
+class _DialogHost(App):
+    def on_mount(self) -> None:
+        self.push_screen(_Host())
+
+
+_SUGGESTION = PermissionUpdateAddRules(
+    destination="localSettings",
+    behavior="allow",
+    rules=(PermissionRuleValue(tool_name="Bash", rule_content="git diff:*"),),
+)
+
+
+def _pending(replies: list, suggestions=()) -> PendingPermission:
+    return PendingPermission(
+        request_id="perm-test",
+        tool_name="Bash",
+        message="Claude wants to run a command",
+        suggestions=tuple(suggestions),
+        tool_input={"command": "git diff --stat"},
+        decide=replies.append,
+    )
+
+
+@pytest.mark.asyncio
+async def test_allow_once_reply() -> None:
+    replies: list[PermissionAskReply] = []
+    app = _DialogHost()
+    async with app.run_test() as pilot:
+        app.push_screen(PermissionModal(_pending(replies, [_SUGGESTION])))
+        await pilot.pause()
+        await pilot.press("y")
+        await pilot.pause()
+    assert len(replies) == 1
+    assert replies[0].behavior == "allow"
+    assert replies[0].chosen_updates == ()
+
+
+@pytest.mark.asyncio
+async def test_allow_always_carries_suggestions() -> None:
+    replies: list[PermissionAskReply] = []
+    app = _DialogHost()
+    async with app.run_test() as pilot:
+        app.push_screen(PermissionModal(_pending(replies, [_SUGGESTION])))
+        await pilot.pause()
+        await pilot.press("a")
+        await pilot.pause()
+    assert len(replies) == 1
+    assert replies[0].behavior == "allow"
+    assert replies[0].chosen_updates == (_SUGGESTION,)
+
+
+@pytest.mark.asyncio
+async def test_allow_always_unavailable_without_suggestions() -> None:
+    replies: list[PermissionAskReply] = []
+    app = _DialogHost()
+    async with app.run_test() as pilot:
+        app.push_screen(PermissionModal(_pending(replies, [])))
+        await pilot.pause()
+        await pilot.press("a")  # no suggestions → ignored
+        await pilot.pause()
+        assert replies == []
+        await pilot.press("escape")
+        await pilot.pause()
+    assert len(replies) == 1
+    assert replies[0].behavior == "deny"
+
+
+@pytest.mark.asyncio
+async def test_deny_with_feedback_flow() -> None:
+    replies: list[PermissionAskReply] = []
+    app = _DialogHost()
+    async with app.run_test() as pilot:
+        app.push_screen(PermissionModal(_pending(replies, [_SUGGESTION])))
+        await pilot.pause()
+        await pilot.press("d")
+        await pilot.pause()
+        for ch in "use rg":
+            await pilot.press(ch if ch != " " else "space")
+        await pilot.press("enter")
+        await pilot.pause()
+    assert len(replies) == 1
+    assert replies[0].behavior == "deny"
+    assert replies[0].message == "use rg"
+
+
+@pytest.mark.asyncio
+async def test_escape_denies() -> None:
+    replies: list[PermissionAskReply] = []
+    app = _DialogHost()
+    async with app.run_test() as pilot:
+        app.push_screen(PermissionModal(_pending(replies, [_SUGGESTION])))
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+    assert len(replies) == 1
+    assert replies[0].behavior == "deny"
+    assert replies[0].message is None

--- a/tests/tui/test_permission_modal_options.py
+++ b/tests/tui/test_permission_modal_options.py
@@ -110,6 +110,29 @@ async def test_deny_with_feedback_flow() -> None:
 
 
 @pytest.mark.asyncio
+async def test_feedback_input_consumes_binding_letters() -> None:
+    """Typing y/n/a/d into the focused feedback Input must not trigger the
+    screen bindings (Textual routes printable keys to the focused widget)."""
+
+    replies: list[PermissionAskReply] = []
+    app = _DialogHost()
+    async with app.run_test() as pilot:
+        app.push_screen(PermissionModal(_pending(replies, [_SUGGESTION])))
+        await pilot.pause()
+        await pilot.press("d")
+        await pilot.pause()
+        for ch in "dany":
+            await pilot.press(ch)
+        await pilot.pause()
+        assert replies == [], "screen bindings stole keys mid-typing"
+        await pilot.press("enter")
+        await pilot.pause()
+    assert len(replies) == 1
+    assert replies[0].behavior == "deny"
+    assert replies[0].message == "dany"
+
+
+@pytest.mark.asyncio
 async def test_escape_denies() -> None:
     replies: list[PermissionAskReply] = []
     app = _DialogHost()


### PR DESCRIPTION
## Summary
- Phase C1 of the components/ folder parity plan (gap analysis + plan critic-approved; impl critic-approved in two scoped reviews after 2 REQUEST CHANGES rounds)
- Permission prompts upgrade from binary Allow/Deny to the TS PermissionPrompt option set: **allow once / allow always (persisted rule) / deny / deny with feedback** — on the TUI modal AND the legacy REPL console menu
- Un-severs the existing `src/permissions/` engine end-to-end:
  - new `PermissionAskRequest/Reply` protocol replaces the legacy 3-arg handler on all four producers (TUI bridge, REPL, headless auto-deny, subagent share); real `tool_input` now reaches the modal so per-tool previews render
  - registry applies accepted rules to the live context and persists them via the new `.clawcodex/` settings resolver; `setup_permissions` wired into all three entrypoints so persisted rules **load at startup** (restart round-trip tested)
  - bash "don't ask again" suggestions ported from TS heuristics (2-word prefix / heredoc / safe-env-vars; no LLM extractor)
- Engine fixes found en route: multi-word prefix rules never matched (first-token-only comparison); new quote-aware **chaining guard** — prefix/wildcard rules decline compound commands (re-prompt) since Python matches whole strings where TS matches per-AST-sub-command (documented divergence)
- Review-driven hardening: Read suggestions removed (would persist rules nothing matches — parked on a path-rule matcher), project settings namespaced `.clawcodex/` (`.claude/settings*.json` is the real harness's file — cross-tool collision), word-boundary matching for exact rules, lone-`&` detection, persist-failure logging, typed protocol, hermetic test fixture

## Test plan
- [x] 36 new tests: derivation table, chaining-guard matrix, registry ask-flow (allow-once no-persist / always applies+persists / deny-feedback reaches model / restart round-trip via the production loader), REPL menu mapping (always+feedback rows, enable-row numbering), headless production setup block, 6 Textual pilot tests (incl. binding letters while feedback input focused)
- [x] Full suite: 12 failed / 7564 passed — failure set name-for-name identical to the verified clean-main(0fa986f) baseline (each stash-run-verified pre-existing)
- [x] Critic reviews: plan APPROVE; impl Review A (protocol/UX/wiring) APPROVE; impl Review B (string heuristics parity) APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)