### PR TITLE
components C3b: transcript polish + /thinking toggle

### DIFF
--- a/src/command_system/engine.py
+++ b/src/command_system/engine.py
@@ -178,6 +178,18 @@ class CommandEngine:
                 return CommandResult.skip(command.name)
 
             display_text = local_result.display_text or local_result.value
+            if local_result.type == "compact":
+                # C3b: preserve the compact result type so UI surfaces can
+                # render a boundary row (TS CompactBoundaryMessage) instead
+                # of a plain system line. text still carries the
+                # user_display_message for surfaces that don't special-case.
+                return CommandResult(
+                    success=True,
+                    command_name=command.name,
+                    result_type="compact",
+                    text=display_text,
+                    display="system",
+                )
             return CommandResult.success_text(
                 command.name,
                 display_text,

--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -193,6 +193,7 @@ async def run_query_as_agent_loop(
     on_message: Callable[[Message], None] | None = None,
     cancel_signal: AbortSignal | None = None,
     abort_controller: AbortController | None = None,
+    extended_thinking: bool | None = None,
 ) -> AgentLoopRunResult:
     """Drive the canonical query() loop and adapt to AgentLoopResult.
 
@@ -252,6 +253,9 @@ async def run_query_as_agent_loop(
         provider=provider,
         abort_controller=abort_controller,
         max_turns=max_turns,
+        # C3b /thinking: None = auto (model-gated default), True/False =
+        # explicit session override (TS ThinkingToggle semantics).
+        extended_thinking=extended_thinking,
         # Critic-flagged: forward on_text_chunk into QueryParams so
         # the provider's chat_stream_response fires chunks LIVE. The
         # adapter must NOT call on_text_chunk(full_text) once at the

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -1189,6 +1189,15 @@ class ClawcodexREPL:
                 self.chat(prompt_text)
             return True
 
+        elif result.result_type == "compact":
+            # C3b: the engine now emits a typed compact result. The
+            # conversation was ALREADY mutated — falling through to the
+            # legacy chain would re-handle an executed command.
+            if result.text:
+                self.console.print("\n" + result.text)
+                self.console.print()
+            return True
+
         elif result.result_type == "skip":
             # Command handled silently
             return True

--- a/src/tui/agent_bridge.py
+++ b/src/tui/agent_bridge.py
@@ -116,6 +116,10 @@ class AgentBridge:
         # truncated or replaced.
         self._emitted_advisor_ids: set[str] = set()
         self._last_scanned_msg_index: int = 0
+        # C3b /thinking session override. None = auto (query gates on
+        # model support); True/False = explicit user toggle (TS
+        # ThinkingToggle: "Enable or disable thinking for this session").
+        self.extended_thinking: bool | None = None
 
     def reset_advisor_dedup(self) -> None:
         """Drop the advisor-dedup state.
@@ -350,6 +354,8 @@ class AgentBridge:
                     # its signal) so the provider sees the same signal
                     # ESC trips. See same fix in headless.py for why.
                     abort_controller=controller,
+                    # C3b /thinking session override (None = auto).
+                    extended_thinking=self.extended_thinking,
                 ))
             finally:
                 _loop.close()

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -382,6 +382,52 @@ class ClawCodexTUI(App):
             # pre-clear context (TS shows nothing for an empty list).
             self.app_state.last_turn_input_tokens = 0
             return
+        if result.system_text == "__thinking__":
+            # C3b /thinking: flip the bridge's session override. First use
+            # DISABLES (auto → off, matching the TS toggle's "respond
+            # without extended thinking" default action), then alternates.
+            bridge = self._agent_bridge
+            new_value = bridge.extended_thinking is False
+            if new_value:
+                # Honest enable (review M4): an explicit True bypasses the
+                # query layer's model gate and a non-Anthropic provider
+                # ignores it silently — refuse instead of lying.
+                try:
+                    from src.providers.anthropic_provider import (
+                        AnthropicProvider,
+                    )
+                    from src.providers.minimax_provider import MinimaxProvider
+                    from src.query.query import (
+                        _model_supports_extended_thinking,
+                    )
+
+                    provider_obj = bridge._provider
+                    supported = isinstance(
+                        provider_obj, (AnthropicProvider, MinimaxProvider)
+                    ) and _model_supports_extended_thinking(
+                        getattr(provider_obj, "model", None)
+                    )
+                except Exception:
+                    supported = False
+                if not supported:
+                    transcript.append_system(
+                        "Extended thinking is not supported by the current "
+                        "model/provider — leaving it disabled.",
+                        style="muted",
+                    )
+                    return
+            bridge.extended_thinking = new_value
+            transcript.append_system(
+                "Extended thinking enabled for this session."
+                if new_value
+                else "Extended thinking disabled for this session — "
+                "the model will respond without extended thinking.",
+                style="muted",
+            )
+            return
+        if result.compact and result.system_text:
+            transcript.append_compact_boundary(result.system_text)
+            return
         if result.system_text:
             transcript.append_system(result.system_text, style="muted")
         if result.prompt_text:

--- a/src/tui/commands.py
+++ b/src/tui/commands.py
@@ -55,6 +55,8 @@ LOCAL_BUILTINS: tuple[str, ...] = (
     "/rewind",
     # components C2:
     "/resume",
+    # components C3b:
+    "/thinking",
 )
 
 
@@ -79,6 +81,8 @@ class CommandDispatchResult:
     system_text: str | None = None
     open_dialog: str | None = None
     error: str | None = None
+    # C3b: system_text is a compaction notice — render as a boundary row.
+    compact: bool = False
 
 
 @dataclass(frozen=True)
@@ -124,6 +128,7 @@ _LOCAL_BUILTIN_DESCRIPTIONS: dict[str, str] = {
     "/tasks": "Browse background tasks",
     "/rewind": "Rewind conversation to an earlier turn",
     "/resume": "Resume a previous conversation",
+    "/thinking": "Toggle extended thinking for this session",
 }
 
 
@@ -295,6 +300,12 @@ def dispatch_local_command(
         return CommandDispatchResult(handled=True, open_dialog="workflows")
     if name == "/rewind":
         return CommandDispatchResult(handled=True, open_dialog="rewind")
+    if name == "/thinking":
+        # TS mounts ThinkingToggle from the prompt-input footer; Python's
+        # surface is this command (documented divergence). The app flips
+        # the bridge's session override on the sentinel (the __clear__
+        # pattern — this module stays UI-state-free).
+        return CommandDispatchResult(handled=True, system_text="__thinking__")
     if name in ("/resume", "/continue"):
         # /continue = TS alias (commands/resume/index.ts:7). Intercepted
         # here too so the TUI opens the picker instead of falling through
@@ -337,6 +348,12 @@ async def dispatch_registry_command(
 
     if result.result_type == "text":
         return CommandDispatchResult(handled=True, system_text=result.text or "")
+
+    if result.result_type == "compact":
+        # C3b: typed so the app renders a boundary row, not a plain line.
+        return CommandDispatchResult(
+            handled=True, system_text=result.text or "", compact=True
+        )
 
     if result.result_type == "prompt":
         prompt_text = ""

--- a/src/tui/screens/repl.py
+++ b/src/tui/screens/repl.py
@@ -54,6 +54,9 @@ class REPLScreen(Screen):
 
     BINDINGS = [
         ("ctrl+l", "clear_transcript", "Clear transcript"),
+        # C3b: legacy-REPL parity — re-print the most recent truncated
+        # block in full (CtrlOToExpand).
+        ("ctrl+o", "expand_last", "Expand last truncated"),
     ]
 
     DEFAULT_CSS = """
@@ -142,6 +145,9 @@ class REPLScreen(Screen):
     # ---- actions ----
     def action_clear_transcript(self) -> None:
         self.transcript.clear_transcript()
+
+    def action_expand_last(self) -> None:
+        self.transcript.expand_last()
 
     # ---- prompt submission ----
     def on_prompt_submitted(self, message: PromptSubmitted) -> None:

--- a/src/tui/widgets/transcript_view.py
+++ b/src/tui/widgets/transcript_view.py
@@ -17,12 +17,43 @@ the visual output matches the new transcript regardless of entry point.
 
 from __future__ import annotations
 
+from collections import deque
 from typing import Any
 
+from rich.panel import Panel
 from rich.text import Text
 from textual.containers import VerticalScroll
 from textual.widget import Widget
 from textual.widgets import Static
+
+# Read/search tools whose consecutive DONE rows collapse into one summary
+# row (TS CollapsedReadSearchContent / GroupedToolUseContent scope).
+# ("ls" deliberately absent: no LS tool registration exists in
+# src/tool_system today.)
+_READ_GROUP_TOOLS = frozenset({"read", "grep", "glob"})
+# Collapse only once a run reaches this many rows (2 keeps short pairs
+# visible-but-compact; TS groups any consecutive run in transcript mode).
+_READ_GROUP_MIN = 3
+
+
+class _SnapshotStatic(Static):
+    """Static row that participates in the post-exit scrollback dump.
+
+    ``TranscriptView.snapshot()`` skips rows without a ``snapshot``
+    attribute — the C3b rows (compact boundary, read-group summary,
+    expanded panels) must not vanish from the dump (review M3).
+    """
+
+    def __init__(self, renderable: Any, **kwargs: Any) -> None:
+        super().__init__(renderable, **kwargs)
+        self._snapshot_renderable = renderable
+
+    def snapshot(self) -> Any:
+        return self._snapshot_renderable
+
+    def update(self, renderable: Any = "") -> None:  # type: ignore[override]
+        self._snapshot_renderable = renderable
+        super().update(renderable)
 
 from .messages import (
     AssistantAdvisorMessage,
@@ -74,6 +105,22 @@ class TranscriptView(VerticalScroll):
         # ``shouldRenderStatically`` with a snapshot of the message
         # list for the same reason).
         self._mounted_rows: list[Widget] = []
+        # C3b ctrl+o: bounded stash of (label, full_content) for rows whose
+        # body rendered truncated — mirrors the legacy REPL's
+        # ``_expandable_blocks`` (repl/core.py) including the maxlen.
+        self._expandables: deque[tuple[str, str]] = deque(maxlen=20)
+        # C3b read-group collapse state: rows + labels of the current run
+        # of consecutive completed read/search rows, and the summary row
+        # that replaces them once the run reaches _READ_GROUP_MIN.
+        self._read_rows: list[Widget] = []
+        self._read_labels: list[str] = []
+        self._read_group_row: Static | None = None
+        # Identity of this group's ctrl+o stash entry. Per-read CONTENT
+        # stashes land between folds (real Read outputs exceed the
+        # truncation limits), so position-based "is it newest?" checks
+        # miss — the entry is found by identity wherever it sits
+        # (review M2 residual).
+        self._read_group_entry: tuple[str, str] | None = None
         if max_messages is not None:
             self.max_messages = max(1, int(max_messages))
 
@@ -92,6 +139,7 @@ class TranscriptView(VerticalScroll):
     # ---- public API (Phase 0 compatibility) -----------------------
     def append_user(self, text: str) -> None:
         self._retire_active_assistant()
+        self._break_read_group()
         row = UserTextMessage(text)
         self.mount(row)
         self._scroll_end()
@@ -108,6 +156,7 @@ class TranscriptView(VerticalScroll):
         if active is not None and not isinstance(active, AssistantTextMessage):
             self._retire_active_assistant()
         if self._active_assistant is None:
+            self._break_read_group()
             self._active_assistant = AssistantTextMessage()
             self.mount(self._active_assistant)
         self._active_assistant.append_chunk(chunk)
@@ -138,6 +187,7 @@ class TranscriptView(VerticalScroll):
             active.has_class("-redacted") != redacted
         ):
             self._retire_active_assistant()
+            self._break_read_group()
             row = AssistantThinkingMessage(redacted=redacted)
             self._active_assistant = row  # type: ignore[assignment]
             self.mount(row)
@@ -151,6 +201,7 @@ class TranscriptView(VerticalScroll):
             active.finalise(text)
             self._active_assistant = None
         elif (text or "").strip():
+            self._break_read_group()
             row = AssistantThinkingMessage(redacted=redacted)
             self.mount(row)
             row.finalise(text)
@@ -161,6 +212,7 @@ class TranscriptView(VerticalScroll):
             self._active_assistant.finalise(text)
             self._active_assistant = None
         elif (text or "").strip():
+            self._break_read_group()
             row = AssistantTextMessage()
             self.mount(row)
             row.finalise(text)
@@ -181,6 +233,8 @@ class TranscriptView(VerticalScroll):
         key = tool_use_id or _synthetic_id(tool_name, tool_input)
 
         if kind == "tool_use":
+            if (tool_name or "").lower() not in _READ_GROUP_TOOLS:
+                self._break_read_group()
             row = AssistantToolUseMessage(
                 tool_use_id=key,
                 tool_name=tool_name,
@@ -195,10 +249,37 @@ class TranscriptView(VerticalScroll):
         if kind == "tool_result":
             row = self._tool_rows.pop(key, None)
             if row is not None:
+                # PRODUCTION SHAPE: result events arrive with
+                # tool_name="" (agent_loop_compat.py builds them without
+                # a name) — the row, captured at tool_use time, is the
+                # authoritative source (review B1).
+                effective_name = (
+                    getattr(row, "tool_name", "") or tool_name or ""
+                )
+                # C3b ctrl+o: stash full output for anything the row's
+                # panel will truncate (limits mirror
+                # tool_activity.base.truncated_panel). Matched rows only
+                # — the standalone fallback below renders untruncated.
+                if isinstance(tool_output, str) and tool_output:
+                    from .tool_activity.base import (
+                        _BODY_MAX_CHARS,
+                        _BODY_MAX_LINES,
+                    )
+
+                    if (
+                        len(tool_output) > _BODY_MAX_CHARS
+                        or tool_output.count("\n") + 1 > _BODY_MAX_LINES
+                    ):
+                        self.note_expandable(
+                            f"{effective_name or 'tool'} result", tool_output
+                        )
                 if is_error:
                     row.mark_error(tool_output)
+                    self._break_read_group()
                 else:
                     row.mark_done(tool_output)
+                    if effective_name.lower() in _READ_GROUP_TOOLS:
+                        self._on_read_tool_done(row, effective_name)
                 self._scroll_end()
                 return
             # No matching tool_use row; emit a standalone result row so
@@ -224,6 +305,7 @@ class TranscriptView(VerticalScroll):
             return
 
         if kind == "tool_error":
+            self._break_read_group()
             row = self._tool_rows.pop(key, None)
             if row is not None:
                 row.mark_error(tool_output, error=error)
@@ -264,6 +346,7 @@ class TranscriptView(VerticalScroll):
         silently dropped.
         """
         self._retire_active_assistant()
+        self._break_read_group()
         if kind == "start":
             if tool_use_id in self._advisor_rows:
                 return
@@ -303,8 +386,131 @@ class TranscriptView(VerticalScroll):
         """
 
         self._retire_active_assistant()
+        self._break_read_group()
         canonical = _canonical_system_style(style)
         self.mount(SystemMessage(text, style=canonical))
+        self._scroll_end()
+
+    def append_compact_boundary(self, text: str) -> None:
+        """Distinct rule-style row marking a conversation compaction
+        (TS CompactBoundaryMessage / CompactSummary)."""
+
+        self._retire_active_assistant()
+        self._break_read_group()
+        row = _SnapshotStatic(
+            Text(f"── ✻ {text} ──", style="bold dim"),
+            classes="compact-boundary",
+            markup=False,
+        )
+        self.mount(row)
+        self._scroll_end()
+
+    # ---- C3b ctrl+o expandables ------------------------------------
+    def note_expandable(self, label: str, full_text: str) -> None:
+        """Stash full content for a row that rendered truncated."""
+
+        if full_text:
+            self._expandables.append((label, full_text))
+
+    def expand_last(self) -> None:
+        """Re-print the most recent truncated block in full, as a fresh
+        row below (legacy-REPL ``_do_expand_last`` parity — the entry is
+        NOT popped, so repeated ctrl+o re-prints the same newest block
+        until a newer truncated row arrives)."""
+
+        if not self._expandables:
+            self.append_system("Nothing to expand.", style="muted")
+            return
+        label, full_text = self._expandables[-1]
+        self._retire_active_assistant()
+        self._break_read_group()
+        self.mount(
+            _SnapshotStatic(
+                Panel(
+                    Text(full_text),
+                    title=f"expanded: {label}",
+                    border_style="bright_black",
+                    padding=(0, 1),
+                ),
+                markup=False,
+            )
+        )
+        self._scroll_end()
+
+    # ---- C3b read-group collapse -------------------------------------
+    def _break_read_group(self) -> None:
+        self._read_rows = []
+        self._read_labels = []
+        self._read_group_row = None
+        self._read_group_entry = None
+
+    def _read_label(self, row: Widget, fallback_name: str) -> str:
+        tool_input = getattr(row, "tool_input", None) or {}
+        arg = (
+            tool_input.get("file_path")
+            or tool_input.get("pattern")
+            or tool_input.get("path")
+            or ""
+        )
+        name = getattr(row, "tool_name", "") or fallback_name or "tool"
+        return f"{name}({arg})" if arg else str(name)
+
+    def _remove_row(self, row: Widget) -> None:
+        try:
+            self._mounted_rows.remove(row)
+        except ValueError:
+            pass
+        try:
+            row.remove()
+        except Exception:
+            pass
+
+    def _on_read_tool_done(self, row: Widget, tool_name: str) -> None:
+        """Fold runs of completed read/search rows into one summary row.
+
+        The run accumulates silently until ``_READ_GROUP_MIN``; from then
+        on the individual rows are removed and a single summary row shows
+        the aggregated labels (full list reachable via ctrl+o — ONE stash
+        entry per group, updated in place across folds).
+        """
+
+        self._read_rows.append(row)
+        self._read_labels.append(self._read_label(row, tool_name))
+        if len(self._read_labels) < _READ_GROUP_MIN:
+            return
+        labels = self._read_labels
+        shown = labels[-4:]
+        prefix = "… , " if len(labels) > 4 else ""
+        summary = Text(
+            f"⌕ {len(labels)} reads/searches · "
+            + prefix
+            + ", ".join(shown)
+            + "  (ctrl+o for the full list)",
+            style="dim",
+        )
+        if self._read_group_row is None:
+            group = _SnapshotStatic(summary, classes="read-group", markup=False)
+            self.mount(group)
+            self._read_group_row = group
+        else:
+            self._read_group_row.update(summary)
+        for run_row in self._read_rows:
+            self._remove_row(run_row)
+        self._read_rows = []
+        stash_entry = ("collapsed reads/searches", "\n".join(labels))
+        # Replace THIS group's previous entry by identity, wherever it
+        # sits — per-read content stashes interleave between folds, so the
+        # entry is rarely the newest. Evicted (not found) → append fresh.
+        replaced = False
+        if self._read_group_entry is not None:
+            for i in range(len(self._expandables) - 1, -1, -1):
+                if self._expandables[i] is self._read_group_entry:
+                    self._expandables[i] = stash_entry
+                    replaced = True
+                    break
+        if not replaced:
+            self._expandables.append(stash_entry)
+        self._read_group_entry = stash_entry
         self._scroll_end()
 
     def clear_transcript(self) -> None:
@@ -312,6 +518,8 @@ class TranscriptView(VerticalScroll):
         self._tool_rows.clear()
         self._advisor_rows.clear()
         self._mounted_rows.clear()
+        self._expandables.clear()
+        self._break_read_group()
         try:
             for child in list(self.children):
                 child.remove()

--- a/tests/tui/test_transcript_c3b.py
+++ b/tests/tui/test_transcript_c3b.py
@@ -1,0 +1,309 @@
+"""C3b tests: compact boundary, ctrl+o expand, read-group collapse, /thinking.
+
+Tool RESULT events deliberately use the PRODUCTION shape — ``tool_name=""``
+(agent_loop_compat.py builds result ToolEvents without a name) — the C3b
+review's B1: name-carrying result events masked an inert collapse feature.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("textual")
+
+from textual.app import App, ComposeResult
+
+from src.tui.widgets.transcript_view import (
+    _READ_GROUP_MIN,
+    TranscriptView,
+)
+
+
+class _Host(App):
+    def compose(self) -> ComposeResult:
+        yield TranscriptView()
+
+
+def _rendered(pieces) -> str:
+    """Plain-text rendering of snapshot pieces (Panels etc.)."""
+
+    import io
+
+    from rich.console import Console
+
+    console = Console(record=True, width=120, file=io.StringIO())
+    for piece in pieces:
+        try:
+            console.print(piece)
+        except Exception:
+            console.print(str(piece))
+    return console.export_text()
+
+
+def _result_event(view: TranscriptView, key: str, output: str = "ok"):
+    # PRODUCTION SHAPE: tool_name is EMPTY on result events.
+    view.append_tool_event(
+        kind="tool_result",
+        tool_name="",
+        tool_input=None,
+        tool_output=output,
+        is_error=False,
+        error=None,
+        tool_use_id=key,
+    )
+
+
+def _use_event(view: TranscriptView, tool: str, key: str, tool_input=None):
+    view.append_tool_event(
+        kind="tool_use",
+        tool_name=tool,
+        tool_input=tool_input or {},
+        tool_output=None,
+        is_error=False,
+        error=None,
+        tool_use_id=key,
+    )
+
+
+@pytest.mark.asyncio
+async def test_compact_boundary_row_and_snapshot() -> None:
+    app = _Host()
+    async with app.run_test() as pilot:
+        view = app.query_one(TranscriptView)
+        view.append_compact_boundary("Conversation compacted (saved 1234 tokens)")
+        await pilot.pause()
+        assert len(view.query(".compact-boundary")) == 1
+        # Post-exit dump must include it (review M3).
+        pieces = view.snapshot()
+        assert "compacted" in _rendered(pieces)
+
+
+@pytest.mark.asyncio
+async def test_expand_last_empty_is_honest() -> None:
+    app = _Host()
+    async with app.run_test() as pilot:
+        view = app.query_one(TranscriptView)
+        view.expand_last()
+        await pilot.pause()
+        assert view.message_count == 1  # the "Nothing to expand." row
+
+
+@pytest.mark.asyncio
+async def test_truncated_result_is_expandable_with_real_name() -> None:
+    app = _Host()
+    async with app.run_test() as pilot:
+        view = app.query_one(TranscriptView)
+        long_output = "\n".join(f"line {i}" for i in range(60))
+        _use_event(view, "Bash", "t1", {"command": "x"})
+        _result_event(view, "t1", long_output)
+        await pilot.pause()
+        assert len(view._expandables) == 1
+        label, full = view._expandables[-1]
+        # Label derives from the ROW's name, not the empty event name (B1).
+        assert label == "Bash result"
+        assert "line 59" in full
+        before = view.message_count
+        view.expand_last()
+        await pilot.pause()
+        assert view.message_count == before + 1
+        # Not popped: repeat re-prints (legacy REPL parity), and the
+        # expanded panel participates in the snapshot (M3).
+        view.expand_last()
+        await pilot.pause()
+        assert view.message_count == before + 2
+        assert "line 59" in _rendered(view.snapshot())
+
+
+@pytest.mark.asyncio
+async def test_short_result_not_expandable() -> None:
+    app = _Host()
+    async with app.run_test() as pilot:
+        view = app.query_one(TranscriptView)
+        _use_event(view, "Bash", "t1", {"command": "x"})
+        _result_event(view, "t1", "short")
+        await pilot.pause()
+        assert len(view._expandables) == 0
+
+
+@pytest.mark.asyncio
+async def test_read_group_collapses_with_production_events() -> None:
+    app = _Host()
+    async with app.run_test() as pilot:
+        view = app.query_one(TranscriptView)
+        for i in range(_READ_GROUP_MIN):
+            key = f"r{i}"
+            _use_event(view, "Read", key, {"file_path": f"/f{i}.py"})
+            _result_event(view, key)
+        await pilot.pause()
+        groups = view.query(".read-group")
+        assert len(groups) == 1
+        from src.tui.widgets.messages import AssistantToolUseMessage
+
+        assert len(view.query(AssistantToolUseMessage)) == 0
+        label, full = view._expandables[-1]
+        assert label == "collapsed reads/searches"
+        assert "Read(/f0.py)" in full
+        # The group row participates in the post-exit snapshot (M3).
+        assert "reads/searches" in _rendered(view.snapshot())
+
+
+@pytest.mark.asyncio
+async def test_multi_fold_updates_single_stash_entry() -> None:
+    """Folding N reads must not flood the ctrl+o deque (review M2) — with
+    PRODUCTION-SIZED outputs, whose per-read content stashes interleave
+    between folds (the residual the [-1]-only guard missed)."""
+
+    app = _Host()
+    async with app.run_test() as pilot:
+        view = app.query_one(TranscriptView)
+        n = _READ_GROUP_MIN + 5
+        big = "x" * 2000  # > _BODY_MAX_CHARS → every read stashes content
+        for i in range(n):
+            key = f"r{i}"
+            _use_event(view, "Read", key, {"file_path": f"/f{i}.py"})
+            _result_event(view, key, big)
+        await pilot.pause()
+        entries = [e for e in view._expandables if e[0] == "collapsed reads/searches"]
+        assert len(entries) == 1
+        assert f"Read(/f{n-1}.py)" in entries[0][1]
+        assert len(entries[0][1].splitlines()) == n
+        # The per-read CONTENT entries survive alongside the single
+        # collapsed entry (they are the removed rows' only remnant).
+        content_entries = [e for e in view._expandables if e[0] == "Read result"]
+        assert len(content_entries) == n
+
+
+@pytest.mark.asyncio
+async def test_read_group_breaks_on_thinking_and_nonread() -> None:
+    app = _Host()
+    async with app.run_test() as pilot:
+        view = app.query_one(TranscriptView)
+        for i in range(2):
+            key = f"r{i}"
+            _use_event(view, "Read", key, {"file_path": f"/f{i}.py"})
+            _result_event(view, key)
+        view.append_thinking("pondering…")
+        for i in range(2, 4):
+            key = f"r{i}"
+            _use_event(view, "Read", key, {"file_path": f"/f{i}.py"})
+            _result_event(view, key)
+        _use_event(view, "Bash", "b1", {"command": "x"})
+        _result_event(view, "b1")
+        _use_event(view, "Read", "r9", {"file_path": "/f9.py"})
+        _result_event(view, "r9")
+        await pilot.pause()
+        # Three separate short runs — none reached the threshold.
+        assert len(view.query(".read-group")) == 0
+
+
+class TestThinkingToggle:
+    def _fake_app(self, provider, current=None):
+        from src.tui.state import AppState
+
+        rows: list[tuple[str, str]] = []
+        bridge = SimpleNamespace(extended_thinking=current, _provider=provider)
+        fake = SimpleNamespace(
+            _agent_bridge=bridge,
+            app_state=AppState(),
+        )
+        transcript = SimpleNamespace(
+            append_system=lambda text, style="muted": rows.append((style, text)),
+            append_compact_boundary=lambda text: rows.append(("boundary", text)),
+            append_user=lambda text: rows.append(("user", text)),
+            clear_transcript=lambda: rows.append(("clear", "")),
+        )
+        return fake, bridge, transcript, rows
+
+    def _apply(self, fake, transcript, **kwargs):
+        from src.tui.app import ClawCodexTUI
+        from src.tui.commands import CommandDispatchResult
+
+        ClawCodexTUI._apply_command_result(
+            fake, CommandDispatchResult(handled=True, **kwargs), transcript
+        )
+
+    def test_first_use_disables(self) -> None:
+        fake, bridge, transcript, rows = self._fake_app(MagicMock())
+        self._apply(fake, transcript, system_text="__thinking__")
+        assert bridge.extended_thinking is False
+        assert "disabled" in rows[-1][1]
+
+    def test_enable_refused_on_unsupported_provider(self) -> None:
+        fake, bridge, transcript, rows = self._fake_app(
+            MagicMock(), current=False
+        )
+        self._apply(fake, transcript, system_text="__thinking__")
+        assert bridge.extended_thinking is False  # unchanged
+        assert "not supported" in rows[-1][1]
+
+    def test_enable_allowed_on_supporting_anthropic_model(self) -> None:
+        from src.providers.anthropic_provider import AnthropicProvider
+
+        provider = MagicMock(spec=AnthropicProvider)
+        provider.model = "claude-opus-4-7"
+        fake, bridge, transcript, rows = self._fake_app(provider, current=False)
+        self._apply(fake, transcript, system_text="__thinking__")
+        assert bridge.extended_thinking is True
+        assert "enabled" in rows[-1][1]
+
+    def test_compact_result_renders_boundary(self) -> None:
+        fake, bridge, transcript, rows = self._fake_app(MagicMock())
+        self._apply(
+            fake, transcript, system_text="compacted!", compact=True
+        )
+        assert rows[-1] == ("boundary", "compacted!")
+
+
+class TestCompactResultPlumb:
+    def test_engine_preserves_compact_type(self) -> None:
+        import asyncio
+        from pathlib import Path
+
+        from src.command_system.engine import CommandEngine
+        from src.command_system.types import (
+            LocalCommand,
+            LocalCommandResult,
+        )
+
+        class _FakeCompact(LocalCommand):
+            async def call(self, args, context):
+                return LocalCommandResult(type="compact", value="compacted!")
+
+        cmd = _FakeCompact(name="compact", description="d")
+        engine = CommandEngine(
+            registry=MagicMock(),
+            workspace_root=Path("."),
+            context=MagicMock(),
+        )
+        result = asyncio.run(engine._execute_local(cmd, ""))
+        assert result.result_type == "compact"
+        assert result.text == "compacted!"
+        assert result.success
+
+    @pytest.mark.asyncio
+    async def test_dispatch_maps_compact_flag(self, monkeypatch) -> None:
+        from src.tui import commands as commands_mod
+
+        async def _fake_execute(name, args, context):
+            from src.command_system.engine import CommandResult
+
+            return CommandResult(
+                success=True,
+                command_name="compact",
+                result_type="compact",
+                text="compacted!",
+            )
+
+        import src.command_system.builtins as builtins_mod
+
+        monkeypatch.setattr(
+            builtins_mod, "execute_command_async", _fake_execute
+        )
+        result = await commands_mod.dispatch_registry_command(
+            "/compact", command_context=MagicMock()
+        )
+        assert result.handled and result.compact
+        assert result.system_text == "compacted!"


### PR DESCRIPTION
## Summary
- Completes plan §3 (C3a = #294): compact boundary row (typed end-to-end plumb incl. the legacy-REPL compact branch), ctrl+o expand-last-truncated (legacy `_expandable_blocks` parity), read-group collapse (≥3 consecutive Read/Grep/Glob rows → one summary row, identity-tracked single ctrl+o stash entry), and a REAL `/thinking` session toggle (bridge → compat → `QueryParams.extended_thinking`, honest refusal on unsupported provider/model)
- Review-driven hardening: result events carry `tool_name=""` in production — names now derive from the row (the tests use production shapes); boundary/group/expanded rows participate in the post-exit scrollback dump; break-set covers thinking/advisor/assistant/error paths
- Known cosmetic (QA note): after the first fold the group summary row stays pinned while subsequent running read rows flash below it briefly — closest achievable to TS static-region grouping

## Test plan
- [x] 14 new tests on production-shaped events incl. multi-fold with >limit outputs (one collapsed entry + N surviving content entries), snapshot participation, real `_apply_command_result` thinking/compact branches, dispatch mapping
- [x] Full suite BASELINE-IDENTICAL (one transient delta re-verified as the documented prompt-assembly second-boundary flake — 3/3 isolated passes)
- [x] Impl-critic: two REQUEST CHANGES rounds (inert-in-production collapse, stash flooding, snapshot regression, dishonest thinking enable, break-set gaps) → all fixed → **APPROVE**

🤖 Generated with [Claude Code](https://claude.com/claude-code)