### PR TITLE
components C4: bash-mode (!) input

### DIFF
--- a/src/services/bash_mode.py
+++ b/src/services/bash_mode.py
@@ -1,0 +1,102 @@
+"""Bash-mode (`!` prefix) execution (components C4).
+
+Port of TS ``utils/processUserInput/processBashCommand.tsx``: the user's
+``!command`` runs DIRECTLY through the Bash tool's call function —
+structurally bypassing the registry's permission flow (user-typed
+commands are not model-initiated actions; ``bash_tool.py``'s
+defense-in-depth dangerous-pattern guard still applies) — produces NO
+agent turn (TS ``shouldQuery: false``), and feeds TWO user messages into
+the conversation so the model sees what happened on its next turn:
+
+    <bash-input>command</bash-input>
+    <bash-stdout>…</bash-stdout><bash-stderr>…</bash-stderr>
+
+Divergences (documented): the TS synthetic caveat message
+(``createSyntheticUserCaveatMessage``) has no Python analog and is
+skipped; stdout AND stderr are both XML-escaped (TS escapes stderr
+always and stdout only on some paths); the PowerShell branch is not
+ported (no PowerShell tool registration in Python); commands run
+SEQUENTIALLY and are refused while one is in flight (TS queues); no
+live progress streaming or ESC cancel yet — the echo row shows
+"running…" until completion (follow-up); texts arriving while an agent
+run is in flight DEFER via ``AgentBridge.append_user_texts`` and land
+after the run (conversation-integrity guard).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from xml.sax.saxutils import escape
+
+BASH_INPUT_TAG = "bash-input"  # TS constants/xml.ts:8-10
+BASH_STDOUT_TAG = "bash-stdout"
+BASH_STDERR_TAG = "bash-stderr"
+
+
+@dataclass(frozen=True)
+class BashModeOutcome:
+    command: str
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = 0
+    ok: bool = True
+    error: str | None = None
+    # The user messages to append to the conversation (TS parity).
+    conversation_texts: tuple[str, ...] = field(default_factory=tuple)
+
+
+def run_bash_mode_command(command: str, tool_context: Any) -> BashModeOutcome:
+    """Execute ``command`` via the direct Bash path; never raises."""
+
+    command = (command or "").strip()
+    if not command:
+        return BashModeOutcome(
+            command="", ok=False, error="Usage: !<shell command>"
+        )
+
+    input_text = f"<{BASH_INPUT_TAG}>{command}</{BASH_INPUT_TAG}>"
+    try:
+        from src.tool_system.tools.bash.bash_tool import _bash_call
+
+        result = _bash_call({"command": command}, tool_context)
+        output = result.output if isinstance(result.output, dict) else {}
+        stdout = str(output.get("stdout", "") or "")
+        stderr = str(output.get("stderr", "") or "")
+        exit_code = int(output.get("exit_code", 0) or 0)
+        ok = not bool(result.is_error) and exit_code == 0
+        out_text = (
+            f"<{BASH_STDOUT_TAG}>{escape(stdout)}</{BASH_STDOUT_TAG}>"
+            f"<{BASH_STDERR_TAG}>{escape(stderr)}</{BASH_STDERR_TAG}>"
+        )
+        return BashModeOutcome(
+            command=command,
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=exit_code,
+            ok=ok,
+            conversation_texts=(input_text, out_text),
+        )
+    except Exception as exc:
+        # TS error path: `<bash-stderr>Command failed: …</bash-stderr>`.
+        message = f"Command failed: {exc}"
+        out_text = (
+            f"<{BASH_STDERR_TAG}>{escape(message)}</{BASH_STDERR_TAG}>"
+        )
+        return BashModeOutcome(
+            command=command,
+            stderr=message,
+            exit_code=-1,
+            ok=False,
+            error=str(exc),
+            conversation_texts=(input_text, out_text),
+        )
+
+
+__all__ = [
+    "BASH_INPUT_TAG",
+    "BASH_STDERR_TAG",
+    "BASH_STDOUT_TAG",
+    "BashModeOutcome",
+    "run_bash_mode_command",
+]

--- a/src/tui/agent_bridge.py
+++ b/src/tui/agent_bridge.py
@@ -120,6 +120,12 @@ class AgentBridge:
         # model support); True/False = explicit user toggle (TS
         # ThinkingToggle: "Enable or disable thinking for this session").
         self.extended_thinking: bool | None = None
+        # C4 bash-mode: user texts that arrived while a run was in flight.
+        # Appending mid-run can interleave between a tool_use and its
+        # tool_result in the conversation (durably, via the persister) —
+        # so they defer and drain in _finish() after the run's appends
+        # are over.
+        self._deferred_user_texts: list[str] = []
 
     def reset_advisor_dedup(self) -> None:
         """Drop the advisor-dedup state.
@@ -141,6 +147,55 @@ class AgentBridge:
     @property
     def busy(self) -> bool:
         return self._busy
+
+    def append_user_texts(self, texts: tuple[str, ...] | list[str]) -> None:
+        """Append plain user texts to the conversation + session store.
+
+        Safe at any time: while a run is in flight the texts DEFER and
+        drain in ``_finish()`` after the run's own appends — appending
+        mid-run could land between an assistant ``tool_use`` and its
+        ``tool_result``, making the next turn's pairing repair tell the
+        model a successful tool failed (C4 review B1). Idle → immediate
+        append + persist.
+        """
+
+        texts = [t for t in texts if t]
+        if not texts:
+            return
+        with self._busy_lock:
+            if self._busy:
+                self._deferred_user_texts.extend(texts)
+                return
+        for text in texts:
+            try:
+                self._session.conversation.add_user_message(text)
+                self._persister.record({"role": "user", "content": text})
+            except Exception:
+                pass
+        try:
+            self._persister.flush()
+        except Exception:
+            pass
+
+    def _drain_deferred_user_texts(self) -> None:
+        """Append parked texts (call only while no run is appending).
+
+        Residual window (C4 review note 1): a bash completion landing
+        while ``_finish`` is mid-drain/flush still defers — busy cannot
+        clear earlier without re-opening the interleave hazard for a
+        racing ``submit`` (its appends + controller swap). Those parked
+        texts land via the ``submit()`` drain below, BEFORE the next
+        prompt, so they are never lost and order stays correct.
+        """
+
+        with self._busy_lock:
+            pending, self._deferred_user_texts = self._deferred_user_texts, []
+        for text in pending:
+            try:
+                self._session.conversation.add_user_message(text)
+                self._persister.record({"role": "user", "content": text})
+            except Exception:
+                pass
 
     def resume_session(self, session_id: str) -> list[Any] | None:
         """Swap the live conversation to a persisted session (C2 /resume).
@@ -237,6 +292,11 @@ class AgentBridge:
             # controller that is never tripped by ESC.
             self._tool_context.abort_controller = self._abort_controller
 
+        # C4: texts parked during a previous run's teardown land BEFORE
+        # this prompt. We hold the run slot (busy=True) so new bash
+        # completions defer rather than racing this append; the worker
+        # hasn't spawned yet, so nothing else writes the conversation.
+        self._drain_deferred_user_texts()
         self._session.conversation.add_user_message(prompt)
         self._persister.record_user(prompt)
         self._post(AgentRunStarted(prompt=prompt))
@@ -468,6 +528,10 @@ class AgentBridge:
         self._finish()
 
     def _finish(self) -> None:
+        # C4: user texts that arrived mid-run append AFTER the run's own
+        # conversation writes are over (and before the durable flush
+        # below carries them to disk in the correct order).
+        self._drain_deferred_user_texts()
         # Durable persistence at the end of EVERY run (completion, abort, error).
         self._persister.flush()
         self._state.set_thinking(False)

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -15,7 +15,10 @@ screen then materialises as a modal.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from src.services.bash_mode import BashModeOutcome
 
 from textual.app import App
 
@@ -433,6 +436,91 @@ class ClawCodexTUI(App):
         if result.prompt_text:
             transcript.append_user(f"(from slash command) {result.prompt_text[:80]}…")
             self.submit_to_agent(result.prompt_text)
+
+    # ---- C4 bash-mode (`!` prefix) --------------------------------------
+    def run_bash_mode(self, command: str, transcript: Transcript) -> None:
+        """Execute a user-typed ``!command`` directly (no agent turn).
+
+        Divergences from TS (documented; see services/bash_mode):
+        sequential only (a second ``!`` while one runs is refused — TS
+        queues), and no live progress streaming / ESC cancel yet (the
+        echo row shows "running…" until completion; cancel is a
+        follow-up). If the agent starts mid-flight, the conversation
+        texts DEFER via the bridge and land after the run (review B1).
+        """
+
+        command = (command or "").strip()
+        if not command:
+            transcript.append_system("Usage: !<shell command>", style="muted")
+            return
+        # History first: TS records queued/refused commands too (m11).
+        self.history_store.append(f"!{command}")
+        if getattr(self, "_bash_inflight", False):
+            transcript.append_system(
+                "A bash command is already running — wait for it to finish.",
+                style="muted",
+            )
+            return
+        if self._agent_bridge.busy:
+            transcript.append_system(
+                "Agent is working — bash mode is unavailable until idle.",
+                style="muted",
+            )
+            return
+        self._bash_inflight = True
+        row = transcript.append_bash_running(command)
+
+        def _work() -> None:
+            from src.services.bash_mode import run_bash_mode_command
+
+            try:
+                outcome = run_bash_mode_command(command, self.tool_context)
+            except Exception as exc:  # service contract: never raises
+                try:
+                    self.call_from_thread(
+                        self._bash_mode_error, command, str(exc), transcript
+                    )
+                except Exception:
+                    pass
+                return
+            try:
+                self.call_from_thread(
+                    self._finish_bash_mode, outcome, row, transcript
+                )
+            except Exception:
+                # App shutting down mid-flight; nothing to render.
+                self._bash_inflight = False
+
+        self.run_worker(
+            _work, thread=True, exit_on_error=False, group="bash-mode"
+        )
+
+    def _bash_mode_error(
+        self, command: str, error: str, transcript: Transcript
+    ) -> None:
+        self._bash_inflight = False
+        transcript.append_system(f"!{command}: {error}", style="error")
+
+    def _finish_bash_mode(
+        self,
+        outcome: "BashModeOutcome",
+        row: Any,
+        transcript: Transcript,
+    ) -> None:
+        self._bash_inflight = False
+        transcript.finish_bash_io(
+            row,
+            command=outcome.command,
+            stdout=outcome.stdout,
+            stderr=outcome.stderr,
+            exit_code=outcome.exit_code,
+            ok=outcome.ok,
+        )
+        # TS parity: both messages enter the CONVERSATION (the model sees
+        # them next turn) — via the bridge, which defers while a run is
+        # in flight so the texts can never interleave a tool_use/result
+        # pair (review B1); no agent turn fires (shouldQuery: false).
+        self._agent_bridge.append_user_texts(outcome.conversation_texts)
 
     # ---- Phase 2 dialog dispatcher -------------------------------------
     def _open_phase2_dialog(self, name: str, transcript: Transcript) -> None:

--- a/src/tui/screens/repl.py
+++ b/src/tui/screens/repl.py
@@ -156,6 +156,12 @@ class REPLScreen(Screen):
         if text.startswith("/"):
             if app.handle_local_slash_command(text, self.transcript):
                 return
+        if text.startswith("!"):
+            # C4 bash-mode: direct execution, no agent turn, no busy
+            # spinner (the echo row mounts synchronously; the worker
+            # fills in the output when the command finishes).
+            app.run_bash_mode(text[1:], self.transcript)
+            return
         self.transcript.append_user(text)
         self.status_bar.set_busy()
         self.status_bar.bump_turn()

--- a/src/tui/widgets/prompt_input.py
+++ b/src/tui/widgets/prompt_input.py
@@ -126,6 +126,9 @@ class PromptInput(Vertical):
         border: round $primary-darken-2;
         padding: 0 1;
     }
+    PromptInput.-bash-mode > Input {
+        border: round magenta;
+    }
     """
 
     BINDINGS = [
@@ -256,6 +259,10 @@ class PromptInput(Vertical):
 
     # ---- input events ----
     def on_input_changed(self, event: Input.Changed) -> None:
+        # C4 bash-mode affordance (TS inputModes getModeFromInput): a `!`
+        # prefix accents the input border. lstrip matches the dispatch
+        # predicate (the submit layer strips before routing).
+        self.set_class(event.value.lstrip().startswith("!"), "-bash-mode")
         self._refresh_suggestions(event.value, event.input.cursor_position)
 
     async def on_input_submitted(self, event: Input.Submitted) -> None:

--- a/src/tui/widgets/tool_activity/base.py
+++ b/src/tui/widgets/tool_activity/base.py
@@ -90,11 +90,12 @@ _BODY_MAX_CHARS = 1500
 _BODY_MAX_LINES = 20
 
 
-def truncated_panel(text: str, *, style: str = "green") -> Panel:
-    """Render ``text`` in a bordered panel with stable truncation limits.
+def truncate_body(text: str) -> tuple[str, bool]:
+    """``(shown, truncated)`` under the shared panel limits.
 
-    Extracted from ``src.tui.widgets.transcript._truncated_panel`` so
-    individual tool-activity widgets render output consistently.
+    THE single truncation implementation — ``truncated_panel`` and the
+    transcript's bash/expandable paths all use it so the limits (and the
+    trailing-newline rstrip) can never drift apart (C4 review m5).
     """
 
     s = (text or "").rstrip("\n")
@@ -107,6 +108,17 @@ def truncated_panel(text: str, *, style: str = "green") -> Panel:
     if len(s) > _BODY_MAX_CHARS:
         s = s[:_BODY_MAX_CHARS]
         truncated = True
+    return s, truncated
+
+
+def truncated_panel(text: str, *, style: str = "green") -> Panel:
+    """Render ``text`` in a bordered panel with stable truncation limits.
+
+    Extracted from ``src.tui.widgets.transcript._truncated_panel`` so
+    individual tool-activity widgets render output consistently.
+    """
+
+    s, truncated = truncate_body(text)
     if truncated:
         s = f"{s}\n… (truncated)"
     return Panel(Text(s), border_style=style, padding=(0, 1))

--- a/src/tui/widgets/transcript_view.py
+++ b/src/tui/widgets/transcript_view.py
@@ -257,19 +257,14 @@ class TranscriptView(VerticalScroll):
                     getattr(row, "tool_name", "") or tool_name or ""
                 )
                 # C3b ctrl+o: stash full output for anything the row's
-                # panel will truncate (limits mirror
-                # tool_activity.base.truncated_panel). Matched rows only
-                # — the standalone fallback below renders untruncated.
+                # panel will truncate (THE shared limit implementation —
+                # tool_activity.base.truncate_body). Matched rows only —
+                # the standalone fallback below renders untruncated.
                 if isinstance(tool_output, str) and tool_output:
-                    from .tool_activity.base import (
-                        _BODY_MAX_CHARS,
-                        _BODY_MAX_LINES,
-                    )
+                    from .tool_activity.base import truncate_body
 
-                    if (
-                        len(tool_output) > _BODY_MAX_CHARS
-                        or tool_output.count("\n") + 1 > _BODY_MAX_LINES
-                    ):
+                    _shown, was_truncated = truncate_body(tool_output)
+                    if was_truncated:
                         self.note_expandable(
                             f"{effective_name or 'tool'} result", tool_output
                         )
@@ -403,6 +398,80 @@ class TranscriptView(VerticalScroll):
             markup=False,
         )
         self.mount(row)
+        self._scroll_end()
+
+    def append_bash_running(self, command: str) -> Widget:
+        """Mount the bash-mode echo row IMMEDIATELY (synchronous with the
+        submit — TS mounts BashModeProgress before awaiting); the returned
+        row is later completed via :meth:`finish_bash_io`."""
+
+        self._retire_active_assistant()
+        self._break_read_group()
+        header = Text("! ", style="bold magenta")
+        header.append(command, style="bold")
+        from rich.console import Group as _Group
+
+        row = _SnapshotStatic(
+            Panel(
+                _Group(header, Text("running…", style="dim")),
+                border_style="magenta",
+                padding=(0, 1),
+                title="bash",
+            ),
+            classes="bash-io",
+            markup=False,
+        )
+        self.mount(row)
+        self._scroll_end()
+        return row
+
+    def finish_bash_io(
+        self,
+        row: Widget,
+        *,
+        command: str,
+        stdout: str,
+        stderr: str,
+        exit_code: int,
+        ok: bool,
+    ) -> None:
+        """Fill the echo row with the command's output (TS
+        UserBashOutputMessage). BOTH streams render — git/npm/pip write
+        normal output to stderr with exit 0 (review M2); stderr is styled
+        red regardless. Truncation shares the tool-panel limits and the
+        full text is ctrl+o-expandable."""
+
+        from .tool_activity.base import truncate_body
+
+        header = Text("! ", style="bold magenta")
+        header.append(command, style="bold")
+        body_parts: list[Text] = [header]
+        combined = "\n".join(p for p in (stdout.rstrip("\n"), stderr.rstrip("\n")) if p)
+        out_shown, out_trunc = truncate_body(stdout)
+        err_shown, err_trunc = truncate_body(stderr)
+        if out_shown:
+            body_parts.append(Text(out_shown))
+        if err_shown:
+            body_parts.append(Text(err_shown, style="red"))
+        if out_trunc or err_trunc:
+            body_parts.append(Text("… (ctrl+o to expand)", style="dim"))
+            self.note_expandable(f"! {command}", combined)
+        if not ok:
+            body_parts.append(Text(f"exit {exit_code}", style="bold red"))
+        from rich.console import Group as _Group
+
+        renderable = Panel(
+            _Group(*body_parts),
+            border_style="magenta" if ok else "red",
+            padding=(0, 1),
+            title="bash",
+        )
+        try:
+            row.update(renderable)  # type: ignore[attr-defined]
+        except Exception:
+            self.mount(
+                _SnapshotStatic(renderable, classes="bash-io", markup=False)
+            )
         self._scroll_end()
 
     # ---- C3b ctrl+o expandables ------------------------------------

--- a/tests/tui/test_bash_mode_c4.py
+++ b/tests/tui/test_bash_mode_c4.py
@@ -1,0 +1,298 @@
+"""C4 bash-mode tests: direct execution, conversation parity, UI rows."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.services.bash_mode import (
+    BASH_INPUT_TAG,
+    BASH_STDERR_TAG,
+    BASH_STDOUT_TAG,
+    run_bash_mode_command,
+)
+from src.tool_system.context import ToolContext
+
+
+def _ctx(tmp: str) -> ToolContext:
+    ctx = ToolContext(workspace_root=Path(tmp))
+    # The ask path must NEVER be consulted for user-typed commands.
+    ctx.permission_handler = MagicMock(
+        side_effect=AssertionError("permission prompt fired in bash mode")
+    )
+    return ctx
+
+
+class TestRunBashModeCommand:
+    def test_success_captures_stdout_and_messages(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            outcome = run_bash_mode_command("echo hello", _ctx(tmp))
+        assert outcome.ok
+        assert outcome.exit_code == 0
+        assert "hello" in outcome.stdout
+        assert len(outcome.conversation_texts) == 2
+        assert (
+            outcome.conversation_texts[0]
+            == f"<{BASH_INPUT_TAG}>echo hello</{BASH_INPUT_TAG}>"
+        )
+        assert f"<{BASH_STDOUT_TAG}>" in outcome.conversation_texts[1]
+        assert f"<{BASH_STDERR_TAG}>" in outcome.conversation_texts[1]
+
+    def test_no_permission_prompt_fires(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = _ctx(tmp)
+            outcome = run_bash_mode_command("echo guarded", ctx)
+        assert outcome.ok
+        ctx.permission_handler.assert_not_called()
+
+    def test_cd_persists_tool_context_cwd(self) -> None:
+        # Deliberate TS parity (persistent-shell cwd writeback): a
+        # user-typed `!cd <dir>` changes the shared tool cwd. Pinned so a
+        # future pass doesn't "fix" it (review note).
+        with tempfile.TemporaryDirectory() as tmp:
+            sub = Path(tmp) / "subdir"
+            sub.mkdir()
+            ctx = _ctx(tmp)
+            outcome = run_bash_mode_command("cd subdir", ctx)
+            assert outcome.ok
+            assert Path(ctx.cwd) == sub.resolve()
+
+    def test_timeout_path(self, monkeypatch) -> None:
+        monkeypatch.setenv("BASH_DEFAULT_TIMEOUT_MS", "1000")
+        with tempfile.TemporaryDirectory() as tmp:
+            outcome = run_bash_mode_command("sleep 2", _ctx(tmp))
+        assert not outcome.ok
+        assert outcome.exit_code == 143
+        assert "timed out" in outcome.stderr
+
+    def test_failure_exit_code_and_stderr(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            outcome = run_bash_mode_command(
+                "sh -c 'echo oops >&2; exit 3'", _ctx(tmp)
+            )
+        assert not outcome.ok
+        assert outcome.exit_code == 3
+        assert "oops" in outcome.stderr
+        out_msg = outcome.conversation_texts[1]
+        assert f"<{BASH_STDERR_TAG}>" in out_msg
+        assert "oops" in out_msg.split(f"<{BASH_STDERR_TAG}>", 1)[1]
+
+    def test_dangerous_command_refused_honestly(self) -> None:
+        # bash_tool's defense-in-depth guard raises; the service converts
+        # it to the TS error-path message shape, never raising.
+        with tempfile.TemporaryDirectory() as tmp:
+            outcome = run_bash_mode_command("rm -rf /", _ctx(tmp))
+        assert not outcome.ok
+        assert outcome.error
+        assert "Command failed:" in outcome.conversation_texts[1]
+
+    def test_empty_command_usage(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            outcome = run_bash_mode_command("   ", _ctx(tmp))
+        assert not outcome.ok
+        assert outcome.conversation_texts == ()
+        assert "Usage" in (outcome.error or "")
+
+    def test_xml_special_chars_escaped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            outcome = run_bash_mode_command("echo '<tag> & co'", _ctx(tmp))
+        assert outcome.ok
+        out_msg = outcome.conversation_texts[1]
+        assert "&lt;tag&gt; &amp; co" in out_msg
+        assert "<tag> & co" not in out_msg
+
+
+class TestFinishBashMode:
+    def test_fills_row_and_routes_texts_through_bridge(self) -> None:
+        from src.services.bash_mode import BashModeOutcome
+        from src.tui.app import ClawCodexTUI
+
+        rows: list[tuple[str, dict]] = []
+        appended: list[tuple] = []
+
+        transcript = SimpleNamespace(
+            finish_bash_io=lambda row, **kw: rows.append(("finish", kw)),
+            append_system=lambda text, style="muted": rows.append(
+                ("system", {"text": text})
+            ),
+        )
+        fake = SimpleNamespace(
+            _bash_inflight=True,
+            _agent_bridge=SimpleNamespace(
+                append_user_texts=lambda texts: appended.append(tuple(texts))
+            ),
+        )
+        outcome = BashModeOutcome(
+            command="echo hi",
+            stdout="hi\n",
+            ok=True,
+            conversation_texts=(
+                "<bash-input>echo hi</bash-input>",
+                "<bash-stdout>hi\n</bash-stdout><bash-stderr></bash-stderr>",
+            ),
+        )
+        ClawCodexTUI._finish_bash_mode(fake, outcome, object(), transcript)
+
+        assert fake._bash_inflight is False
+        assert rows[0][0] == "finish"
+        assert rows[0][1]["command"] == "echo hi"
+        assert appended == [outcome.conversation_texts]
+
+
+class TestBridgeDeferral:
+    """Review B1: texts arriving mid-run defer and drain in _finish."""
+
+    def _bridge(self, tmp_path, monkeypatch):
+        import src.services.session_storage as storage_mod
+        from src.agent.session import Session
+        from src.tool_system.context import ToolContext
+        from src.tool_system.registry import ToolRegistry
+        from src.tui.agent_bridge import AgentBridge
+        from src.tui.state import AppState
+
+        # Keep the real persister off the developer's ~/.clawcodex/sessions
+        # (review note 2 — the established isolation pattern).
+        monkeypatch.setattr(storage_mod, "SESSIONS_DIR", tmp_path / "sessions")
+
+        session = Session.create("test", "test-model")
+        bridge = AgentBridge(
+            post_message=lambda _m: None,
+            session=session,
+            provider=MagicMock(model="m"),
+            tool_registry=ToolRegistry(),
+            tool_context=ToolContext(workspace_root=tmp_path),
+            app_state=AppState(),
+            run_worker=lambda *a, **k: None,
+        )
+        return bridge, session
+
+    def test_idle_appends_immediately(self, tmp_path, monkeypatch) -> None:
+        bridge, session = self._bridge(tmp_path, monkeypatch)
+        before = len(session.conversation.messages)
+        bridge.append_user_texts(("<bash-input>x</bash-input>",))
+        assert len(session.conversation.messages) == before + 1
+
+    def test_busy_defers_until_finish(self, tmp_path, monkeypatch) -> None:
+        bridge, session = self._bridge(tmp_path, monkeypatch)
+        before = len(session.conversation.messages)
+        bridge._busy = True
+        bridge.append_user_texts(
+            ("<bash-input>x</bash-input>", "<bash-stdout></bash-stdout>")
+        )
+        # Nothing lands mid-run…
+        assert len(session.conversation.messages) == before
+        # …and the run's terminal path drains them in order.
+        bridge._finish()
+        msgs = session.conversation.messages
+        assert len(msgs) == before + 2
+        assert "<bash-input>" in str(msgs[-2].content)
+
+
+@pytest.mark.asyncio
+async def test_transcript_bash_rows_running_then_finish() -> None:
+    pytest.importorskip("textual")
+    from textual.app import App, ComposeResult
+
+    from src.tui.widgets.transcript_view import TranscriptView
+
+    class _Host(App):
+        def compose(self) -> ComposeResult:
+            yield TranscriptView()
+
+    app = _Host()
+    async with app.run_test() as pilot:
+        view = app.query_one(TranscriptView)
+        long_out = "\n".join(f"l{i}" for i in range(50))
+        row = view.append_bash_running("seq 50")
+        await pilot.pause()
+        assert len(view.query(".bash-io")) == 1  # echo row is synchronous
+        view.finish_bash_io(
+            row,
+            command="seq 50",
+            stdout=long_out,
+            stderr="",
+            exit_code=0,
+            ok=True,
+        )
+        await pilot.pause()
+        assert len(view.query(".bash-io")) == 1  # updated in place
+        label, full = view._expandables[-1]
+        assert label == "! seq 50"
+        assert "l49" in full
+
+
+@pytest.mark.asyncio
+async def test_transcript_bash_stderr_shown_even_on_success() -> None:
+    """git/npm write normal output to stderr with exit 0 (review M2)."""
+
+    pytest.importorskip("textual")
+    from textual.app import App, ComposeResult
+
+    from src.tui.widgets.transcript_view import TranscriptView
+
+    class _Host(App):
+        def compose(self) -> ComposeResult:
+            yield TranscriptView()
+
+    app = _Host()
+    async with app.run_test() as pilot:
+        view = app.query_one(TranscriptView)
+        row = view.append_bash_running("git push")
+        view.finish_bash_io(
+            row,
+            command="git push",
+            stdout="",
+            stderr="Everything up-to-date\n",
+            exit_code=0,
+            ok=True,
+        )
+        await pilot.pause()
+        from tests.tui.test_transcript_c3b import _rendered
+
+        assert "Everything up-to-date" in _rendered(view.snapshot())
+
+
+class TestReplDispatch:
+    def test_bang_routes_to_bash_mode_not_agent(self) -> None:
+        from src.tui.screens.repl import REPLScreen
+
+        calls: list[tuple[str, object]] = []
+        fake = SimpleNamespace(
+            app=SimpleNamespace(
+                handle_local_slash_command=lambda text, t: False,
+                run_bash_mode=lambda cmd, t: calls.append(("bash", cmd)),
+                submit_to_agent=lambda text: calls.append(("agent", text)),
+            ),
+            transcript=SimpleNamespace(
+                append_user=lambda text: calls.append(("user", text))
+            ),
+            status_bar=SimpleNamespace(
+                set_busy=lambda: None, bump_turn=lambda: None
+            ),
+        )
+        REPLScreen.on_prompt_submitted(
+            fake, SimpleNamespace(text="!git status")
+        )
+        assert calls == [("bash", "git status")]
+
+    def test_busy_refusal_row(self) -> None:
+        from src.tui.app import ClawCodexTUI
+
+        rows: list[str] = []
+        history: list[str] = []
+        fake = SimpleNamespace(
+            history_store=SimpleNamespace(append=history.append),
+            _bash_inflight=False,
+            _agent_bridge=SimpleNamespace(busy=True),
+        )
+        transcript = SimpleNamespace(
+            append_system=lambda text, style="muted": rows.append(text)
+        )
+        ClawCodexTUI.run_bash_mode(fake, "ls", transcript)
+        assert any("Agent is working" in r for r in rows)
+        # Refused commands still reach history (m11).
+        assert history == ["!ls"]


### PR DESCRIPTION
## Summary
- `!command` runs directly through the Bash tool (no permission prompt — pinned by test; the tool's own dangerous-pattern guard still applies), no agent turn, and `<bash-input>`/`<bash-stdout|stderr>` user messages reach the conversation (TS `processBashCommand` parity)
- Conversation integrity: new `AgentBridge.append_user_texts` defers mid-run texts and drains them at run end + before the next prompt — a bash completion can never interleave a `tool_use`/`tool_result` pair (review blocking find)
- Synchronous echo row + in-place output fill; both streams rendered; shared `truncate_body`; sequential-only with honest refusals; `!` input accent
- Documented divergences: no caveat message, both streams XML-escaped, no PowerShell, no live progress/ESC cancel yet (follow-up)

## Test plan
- [x] 15 tests: no-permission-prompt pin, dangerous-command refusal, deferral via a real bridge, timeout (exit 143), `!cd` cwd parity pin, stderr-on-success render, repl dispatch, busy refusal + history
- [x] Full suite BASELINE-IDENTICAL (diff-verified)
- [x] Impl-critic: REQUEST CHANGES (conversation interleave, stderr drop, no in-flight feedback) → all fixed → **APPROVE**

🤖 Generated with [Claude Code](https://claude.com/claude-code)