### PR TITLE
components C5: workspace search dialogs + ripgrep drain fix

### DIFF
--- a/src/command_system/input_processing.py
+++ b/src/command_system/input_processing.py
@@ -516,6 +516,17 @@ def expand_at_mentions(
         ):
             continue
 
+        # C5: the search dialog inserts ``@file#Lline`` (TS
+        # attachments.ts:2859-2861 parses the ``#L10-20`` fragment).
+        # Degraded port: strip the fragment so the FILE attaches — the
+        # line reference stays visible to the model in the prompt text;
+        # range slicing is a noted follow-up.
+        fragment_match = re.search(r"#L\d+(?:-\d+)?$", raw)
+        if fragment_match:
+            raw = raw[: fragment_match.start()]
+            if not raw:
+                continue
+
         expanded = os.path.expanduser(raw)
         if not os.path.isabs(expanded):
             expanded = os.path.abspath(os.path.join(cwd, expanded))

--- a/src/services/fuzzy_match.py
+++ b/src/services/fuzzy_match.py
@@ -1,0 +1,45 @@
+"""UI-neutral fuzzy scorer (components C5).
+
+Moved verbatim from ``src.tui.screens.history_search`` (which now
+re-exports it) so service-layer consumers — ``workspace_search`` and any
+headless surface — never import a Textual module for a pure function
+(the dependency-direction rule from the C2/C4 reviews).
+"""
+
+from __future__ import annotations
+
+
+def fuzzy_score(text: str, query: str) -> tuple[bool, int]:
+    """Return ``(matched, score)``; higher score = better match.
+
+    Matching rules:
+      * Empty query matches everything with score 0.
+      * Case-insensitive substring match scores ``1000 - position``.
+      * Subsequence match scores ``500 - gap_penalty``.
+      * Anything else returns ``(False, 0)``.
+    """
+
+    if not query:
+        return True, 0
+    text_lower = text.lower()
+    q_lower = query.lower()
+    pos = text_lower.find(q_lower)
+    if pos >= 0:
+        return True, 1000 - pos
+    # Subsequence scan.
+    ti = 0
+    last_match = -1
+    gap = 0
+    for qc in q_lower:
+        while ti < len(text_lower) and text_lower[ti] != qc:
+            ti += 1
+        if ti >= len(text_lower):
+            return False, 0
+        if last_match >= 0:
+            gap += ti - last_match - 1
+        last_match = ti
+        ti += 1
+    return True, max(0, 500 - gap)
+
+
+__all__ = ["fuzzy_score"]

--- a/src/services/workspace_search.py
+++ b/src/services/workspace_search.py
@@ -1,0 +1,145 @@
+"""Workspace search backends (components C5).
+
+UI-neutral helpers behind the TUI's global-search and quick-open dialogs
+(TS ``components/GlobalSearchDialog.tsx`` / ``QuickOpenDialog.tsx``),
+both ripgrep-backed via the shared ``tool_system.utils.ripgrep`` runner.
+
+Insertion formats are TS-verbatim:
+
+* content match → ``@{file}#L{line} `` (GlobalSearchDialog.tsx:178)
+* file → ``@{path} `` (QuickOpenDialog.tsx:152)
+
+Divergences (documented): no live preview pane and no open-in-editor
+action (no editor-spawn analog exists — same decision as `/memory`);
+dialogs are reached via ``/search`` and ``/open`` instead of the TS
+ctrl+shift chords (terminals commonly swallow them; revisit with the
+keybindings phase).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from typing import Any
+
+# TS GlobalSearchDialog.tsx:31-32: MAX_MATCHES_PER_FILE=10 (rg -m),
+# MAX_TOTAL_MATCHES=500 parsed total.
+_PER_FILE_MATCH_CAP = 10
+_MAX_RESULTS = 500
+
+# TS GlobalSearchDialog.tsx:325-332: "a simple split on the first colon
+# would mangle the path [Windows drive letters] — use a regex".
+_LINE_RE = re.compile(r"^(.*?):(\d+):(.*)$")
+
+
+def _to_posix_rel(path: str, cwd: str) -> str:
+    rel = os.path.relpath(path, cwd) if os.path.isabs(path) else path
+    # TS quick-open normalizes to forward slashes for the mention text.
+    return rel.replace(os.sep, "/") if os.sep != "/" else rel
+
+
+@dataclass(frozen=True)
+class ContentMatch:
+    file: str  # relative to the search root
+    line: int
+    text: str
+
+    def insertion(self) -> str:
+        return f"@{self.file}#L{self.line} "
+
+    def label(self) -> str:
+        return f"{self.file}:{self.line}"
+
+
+def file_insertion(path: str) -> str:
+    return f"@{path} "
+
+
+def search_content(
+    query: str,
+    cwd: str,
+    *,
+    max_results: int = _MAX_RESULTS,
+    abort_signal: Any | None = None,
+) -> tuple[list[ContentMatch], bool]:
+    """Fixed-string, case-insensitive content search (TS rg args:
+    GlobalSearchDialog.tsx:268 ``-i -F``). Returns ``(matches,
+    truncated)`` — truncated=True when the parse hit ``max_results``."""
+
+    query = (query or "").strip()
+    if not query:
+        return [], False
+    from src.tool_system.utils.ripgrep import ripgrep
+
+    lines = ripgrep(
+        [
+            "-n",
+            "--no-heading",
+            "-i",
+            "--fixed-strings",
+            "-m",
+            str(_PER_FILE_MATCH_CAP),
+            "--",
+            query,
+        ],
+        cwd,
+        abort_signal=abort_signal,
+    )
+    matches: list[ContentMatch] = []
+    truncated = False
+    for raw in lines:
+        if len(matches) >= max_results:
+            truncated = True
+            break
+        parsed = _LINE_RE.match(raw)
+        if not parsed:
+            continue
+        file_part, line_part, text = parsed.groups()
+        matches.append(
+            ContentMatch(
+                file=_to_posix_rel(file_part, cwd),
+                line=int(line_part),
+                text=text.strip()[:200],
+            )
+        )
+    return matches, truncated
+
+
+def list_workspace_files(
+    cwd: str, *, max_files: int = 5000, abort_signal: Any | None = None
+) -> tuple[list[str], bool]:
+    """All tracked-ish files (``rg --files`` honors .gitignore), POSIX-
+    relative. Returns ``(files, truncated)``."""
+
+    from src.tool_system.utils.ripgrep import ripgrep
+
+    lines = ripgrep(["--files"], cwd, abort_signal=abort_signal)
+    truncated = len(lines) > max_files
+    return [_to_posix_rel(raw, cwd) for raw in lines[:max_files]], truncated
+
+
+def filter_files(files: list[str], query: str, *, limit: int = 50) -> list[str]:
+    """Fuzzy-ranked filter (same scorer as the history search)."""
+
+    query = (query or "").strip()
+    if not query:
+        return files[:limit]
+    from src.services.fuzzy_match import fuzzy_score
+
+    scored: list[tuple[int, str]] = []
+    for path in files:
+        matched, score = fuzzy_score(path, query)
+        if matched:
+            scored.append((score, path))
+    scored.sort(key=lambda pair: (-pair[0], pair[1]))
+    return [path for _score, path in scored[:limit]]
+
+
+__all__ = [
+    "ContentMatch",
+    "file_insertion",
+    "filter_files",
+    "list_workspace_files",
+    "search_content",
+]

--- a/src/tool_system/utils/ripgrep.py
+++ b/src/tool_system/utils/ripgrep.py
@@ -8,6 +8,7 @@ import shutil
 import signal as _signal_mod
 import subprocess
 import sys
+import threading as _threading
 import time as _time_mod
 from typing import Any
 
@@ -124,6 +125,11 @@ def _run_rg_with_abort(
         "stdout": subprocess.PIPE,
         "stderr": subprocess.PIPE,
         "text": True,
+        # Strict decoding inside the drain threads would convert one
+        # non-UTF8 matched line anywhere into silent truncation (the
+        # drain dies, the pipe refills, the child stalls to timeout) —
+        # rg emits matched content in the file's original bytes.
+        "errors": "replace",
     }
     if sys.platform == "win32":
         popen_kwargs["creationflags"] = getattr(
@@ -133,6 +139,28 @@ def _run_rg_with_abort(
         popen_kwargs["start_new_session"] = True
 
     proc = subprocess.Popen(argv, **popen_kwargs)
+
+    # Drain both pipes CONCURRENTLY with the poll loop (C5 fix): the loop
+    # below never read the pipes, so output beyond the OS pipe buffer
+    # (~64KB) blocked ripgrep on write and the call sat until the full
+    # timeout. `rg --files` on a normal repo was the first caller to trip
+    # it; large content searches had the same latent stall.
+    out_chunks: list[str] = []
+    err_chunks: list[str] = []
+
+    def _drain(stream: Any, buf: list[str]) -> None:
+        try:
+            for chunk in iter(lambda: stream.read(8192), ""):
+                buf.append(chunk)
+        except Exception:
+            pass
+
+    drains = []
+    for stream, buf in ((proc.stdout, out_chunks), (proc.stderr, err_chunks)):
+        thread = _threading.Thread(target=_drain, args=(stream, buf), daemon=True)
+        thread.start()
+        drains.append(thread)
+
     deadline = _time_mod.monotonic() + timeout_s
     aborted = False
     timed_out = False
@@ -160,14 +188,16 @@ def _run_rg_with_abort(
                 pass
 
     try:
-        stdout, stderr = proc.communicate(timeout=_KILL_GRACE_S)
+        proc.wait(timeout=_KILL_GRACE_S)
     except subprocess.TimeoutExpired:
-        stdout, stderr = "", ""
+        pass
+    for thread in drains:
+        thread.join(timeout=_KILL_GRACE_S)
 
     return (
         proc.returncode if proc.returncode is not None else -1,
-        stdout or "",
-        stderr or "",
+        "".join(out_chunks),
+        "".join(err_chunks),
         aborted,
         timed_out,
     )

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -555,8 +555,41 @@ class ClawCodexTUI(App):
             self._open_workflows_dialog(transcript)
         elif name == "resume":
             self._open_resume_picker(transcript)
+        elif name == "search" or name.startswith("search:"):
+            self._open_global_search(
+                transcript, name.partition(":")[2] if ":" in name else ""
+            )
+        elif name == "quickopen":
+            self._open_quick_open(transcript)
         else:
             transcript.append_system(f"Dialog '{name}' not available.", style="muted")
+
+    # ---- C5 workspace search dialogs -----------------------------------
+    def _insert_into_prompt(self, insertion: str | None) -> None:
+        if not insertion:
+            return
+        if self._repl_screen is not None:
+            self._repl_screen.prompt_input.append_value(insertion)
+
+    def _open_global_search(
+        self, transcript: Transcript, initial_query: str = ""
+    ) -> None:
+        from src.tui.screens.workspace_search import GlobalSearchScreen
+
+        self.push_screen(
+            GlobalSearchScreen(
+                cwd=str(self.workspace_root), initial_query=initial_query
+            ),
+            callback=self._insert_into_prompt,
+        )
+
+    def _open_quick_open(self, transcript: Transcript) -> None:
+        from src.tui.screens.workspace_search import QuickOpenScreen
+
+        self.push_screen(
+            QuickOpenScreen(cwd=str(self.workspace_root)),
+            callback=self._insert_into_prompt,
+        )
 
     def _open_resume_picker(self, transcript: Transcript) -> None:
         """C2: list persisted sessions; selection swaps the live session.

--- a/src/tui/commands.py
+++ b/src/tui/commands.py
@@ -57,6 +57,9 @@ LOCAL_BUILTINS: tuple[str, ...] = (
     "/resume",
     # components C3b:
     "/thinking",
+    # components C5:
+    "/search",
+    "/open",
 )
 
 
@@ -69,10 +72,11 @@ class CommandDispatchResult:
       that should be forwarded to the agent as a user turn.
     * ``system_text`` — text to append to the transcript as a system
       message (from commands that emit a textual response).
-    * ``open_dialog`` — name of a Phase 2 dialog screen to push
-      (``model``, ``effort``, ``history``, ``cost``, ``idle``, ``exit``,
-      ``theme``). The app resolves the name to a concrete
-      :class:`DialogScreen` subclass.
+    * ``open_dialog`` — name of a dialog screen to push (``model``,
+      ``effort``, ``history``, ``cost``, ``idle``, ``exit``, ``theme``,
+      ``diff``, ``mcp``, ``tasks``, ``workflows``, ``rewind``,
+      ``resume``, ``search[:seed]``, ``quickopen``). The app resolves
+      the name to a concrete screen.
     * ``error`` — surfaced to the user as a red system line.
     """
 
@@ -129,6 +133,8 @@ _LOCAL_BUILTIN_DESCRIPTIONS: dict[str, str] = {
     "/rewind": "Rewind conversation to an earlier turn",
     "/resume": "Resume a previous conversation",
     "/thinking": "Toggle extended thinking for this session",
+    "/search": "Search the workspace (insert @file#Lline)",
+    "/open": "Quick-open a file (insert @path)",
 }
 
 
@@ -306,6 +312,15 @@ def dispatch_local_command(
         # the bridge's session override on the sentinel (the __clear__
         # pattern — this module stays UI-state-free).
         return CommandDispatchResult(handled=True, system_text="__thinking__")
+    if name == "/search":
+        # C5: the dialog has its own query input; any argument seeds it.
+        search_args = raw.split(" ", 1)[1].strip() if " " in raw else ""
+        return CommandDispatchResult(
+            handled=True,
+            open_dialog=f"search:{search_args}" if search_args else "search",
+        )
+    if name == "/open":
+        return CommandDispatchResult(handled=True, open_dialog="quickopen")
     if name in ("/resume", "/continue"):
         # /continue = TS alias (commands/resume/index.ts:7). Intercepted
         # here too so the TUI opens the picker instead of falling through

--- a/src/tui/screens/__init__.py
+++ b/src/tui/screens/__init__.py
@@ -23,6 +23,7 @@ from .resume_conversation import (
     build_resume_entries,
 )
 from .theme_picker import ThemePickerScreen
+from .workspace_search import GlobalSearchScreen, QuickOpenScreen
 
 __all__ = [
     "CostThresholdScreen",
@@ -31,6 +32,7 @@ __all__ = [
     "EffortPickerScreen",
     "ExitFlowScreen",
     "FileDiff",
+    "GlobalSearchScreen",
     "HistoryEntry",
     "HistorySearchScreen",
     "IdleReturnScreen",
@@ -41,6 +43,7 @@ __all__ = [
     "MessageSelectorScreen",
     "ModelPickerScreen",
     "PermissionModal",
+    "QuickOpenScreen",
     "REPLScreen",
     "ResumeConversation",
     "ResumeEntry",

--- a/src/tui/screens/history_search.py
+++ b/src/tui/screens/history_search.py
@@ -155,37 +155,10 @@ class HistorySearchScreen(DialogScreen[str | None]):
 # --------------------------------------------------------------------
 
 
-def fuzzy_score(text: str, query: str) -> tuple[bool, int]:
-    """Return ``(matched, score)``; higher score = better match.
-
-    Matching rules:
-      * Empty query matches everything with score 0.
-      * Case-insensitive substring match scores ``1000 - position``.
-      * Subsequence match scores ``500 - gap_penalty``.
-      * Anything else returns ``(False, 0)``.
-    """
-
-    if not query:
-        return True, 0
-    text_lower = text.lower()
-    q_lower = query.lower()
-    pos = text_lower.find(q_lower)
-    if pos >= 0:
-        return True, 1000 - pos
-    # Subsequence scan.
-    ti = 0
-    last_match = -1
-    gap = 0
-    for qc in q_lower:
-        while ti < len(text_lower) and text_lower[ti] != qc:
-            ti += 1
-        if ti >= len(text_lower):
-            return False, 0
-        if last_match >= 0:
-            gap += ti - last_match - 1
-        last_match = ti
-        ti += 1
-    return True, max(0, 500 - gap)
+# C5: moved to the UI-neutral services layer (services/fuzzy_match) so
+# headless consumers never import this Textual module for a pure
+# function; re-exported here for all existing callers.
+from src.services.fuzzy_match import fuzzy_score  # noqa: E402
 
 
 def _rank_entries(

--- a/src/tui/screens/workspace_search.py
+++ b/src/tui/screens/workspace_search.py
@@ -1,0 +1,308 @@
+"""Global-search and quick-open modal screens (components C5).
+
+Degraded ports of TS ``components/GlobalSearchDialog.tsx`` (ripgrep
+content search → pick a match) and ``QuickOpenDialog.tsx`` (fuzzy file
+open). Selection dismisses with the TS-verbatim PROMPT INSERTION string
+(``@file#Lline `` / ``@path ``) — the app appends it to the composer
+draft. The ``@file#Lline`` mention attaches the FILE downstream
+(``expand_at_mentions`` strips the fragment; range slicing is a noted
+follow-up). Esc dismisses with ``None``.
+
+Keyboard model = the house ``HistorySearchScreen`` idiom: the Input
+keeps focus the whole time; up/down/ctrl+p/n route to the
+:class:`SelectList`; Enter selects the highlighted row.
+
+Divergences (documented): no preview pane and no open-in-editor action
+(no editor-spawn analog — the `/memory` decision); reached via
+``/search`` and ``/open`` rather than the TS ctrl+shift chords
+(terminals commonly swallow them; revisit with the keybindings phase);
+content search re-queries on Enter rather than per-keystroke streaming
+(bounded subprocess churn).
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+from rich.text import Text
+from textual import work
+from textual.binding import Binding
+from textual.widget import Widget
+from textual.widgets import Input, Static
+
+from src.services.workspace_search import (
+    ContentMatch,
+    file_insertion,
+    filter_files,
+    list_workspace_files,
+    search_content,
+)
+from src.tui.widgets.select_list import SelectList, SelectOption
+from src.utils.abort_controller import AbortController
+
+from .dialog_base import DialogScreen
+
+
+class GlobalSearchScreen(DialogScreen[str | None]):
+    """Workspace content search; dismisses with a prompt insertion."""
+
+    title_text = "Search workspace"
+    footer_hint = "Enter searches / selects · ↑↓ navigate · Esc closes"
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel", show=False),
+        Binding("up", "move(-1)", "Previous", show=False),
+        Binding("down", "move(1)", "Next", show=False),
+        Binding("ctrl+p", "move(-1)", "Previous", show=False),
+        Binding("ctrl+n", "move(1)", "Next", show=False),
+    ]
+
+    def __init__(self, cwd: str, initial_query: str = "") -> None:
+        super().__init__()
+        self._cwd = cwd
+        self._initial_query = initial_query
+        self._matches: list[ContentMatch] = []
+        self._last_query: str | None = None
+        self._abort: AbortController | None = None
+        self._input: Input | None = None
+        self._list: SelectList | None = None
+        self._count_label: Static | None = None
+
+    def build_body(self) -> Iterator[Widget]:
+        self._input = Input(
+            value=self._initial_query,
+            placeholder="Search text… (enter to run)",
+        )
+        yield self._input
+        self._count_label = Static(Text(""), markup=False)
+        yield self._count_label
+        self._list = SelectList([])
+        yield self._list
+
+    def _post_mount(self) -> None:
+        if self._input is not None:
+            self._input.focus()
+        if self._initial_query.strip():
+            self._run_search(self._initial_query)
+
+    # ---- input handling ----
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        query = event.value.strip()
+        if not query:
+            return  # stay idle on empty Enter (review m12)
+        # Enter on an UNCHANGED query selects the highlighted match (the
+        # HistorySearch flow); a changed query re-runs the search.
+        if query == self._last_query and self._matches:
+            self.action_select_current()
+            return
+        self._run_search(query)
+
+    def action_move(self, delta: int) -> None:
+        if self._list is not None:
+            self._list.action_move(delta)
+
+    def action_select_current(self) -> None:
+        if self._list is None or self._list.current is None:
+            return
+        try:
+            index = int(self._list.current.value)
+            match = self._matches[index]
+        except (TypeError, ValueError, IndexError):
+            return
+        self.dismiss(match.insertion())
+
+    # ---- search ----
+    def _run_search(self, query: str) -> None:
+        # Stale-result guard (review B1): drop the previous matches NOW
+        # so Enter-during-flight cannot select results of an older query.
+        self._matches = []
+        self._last_query = query.strip()
+        if self._abort is not None:
+            self._abort.abort("superseded")
+        self._abort = AbortController()
+        self._set_placeholder("searching…")
+        self._search_worker(query.strip(), self._abort)
+
+    @work(thread=True, group="global-search", exit_on_error=False)
+    def _search_worker(self, query: str, abort: AbortController) -> None:
+        from src.tool_system.utils.ripgrep import RipgrepAbortedError
+
+        try:
+            matches, truncated = search_content(
+                query, self._cwd, abort_signal=abort.signal
+            )
+            error: str | None = None
+        except RipgrepAbortedError:
+            # Superseded or dialog-closed search: never report (a
+            # same-query restart would otherwise flash "search failed:
+            # …cancelled…" — review note).
+            return
+        except Exception as exc:
+            matches, truncated, error = [], False, str(exc)
+        try:
+            self.app.call_from_thread(
+                self._apply_results, query, matches, truncated, error
+            )
+        except Exception:
+            pass  # app/screen tearing down
+
+    def _apply_results(
+        self,
+        query: str,
+        matches: list[ContentMatch],
+        truncated: bool,
+        error: str | None,
+    ) -> None:
+        if not self.is_attached:
+            return
+        if query != self._last_query:
+            return  # superseded (review B1 second variant)
+        if error:
+            self._matches = []
+            self._set_placeholder(f"search failed: {error}")
+            return
+        self._matches = matches
+        if self._list is None:
+            return
+        options = [
+            SelectOption(
+                label=match.label(),
+                value=str(i),
+                description=match.text[:80],
+            )
+            for i, match in enumerate(matches)
+        ]
+        self._list.set_options(options)
+        if self._count_label is not None:
+            if not matches:
+                note = "no matches"
+            else:
+                note = f"{len(matches)} match{'es' if len(matches) != 1 else ''}"
+                if truncated:
+                    note += "+ (truncated — refine the query)"
+            self._count_label.update(Text(f"  {note}", style="dim"))
+
+    def _set_placeholder(self, text: str) -> None:
+        if self._list is not None:
+            self._list.set_options([])
+        if self._count_label is not None:
+            self._count_label.update(Text(f"  {text}", style="dim"))
+
+    def on_unmount(self) -> None:
+        if self._abort is not None:
+            self._abort.abort("dialog closed")
+
+
+class QuickOpenScreen(DialogScreen[str | None]):
+    """Fuzzy file finder; dismisses with an ``@path `` insertion."""
+
+    title_text = "Quick open"
+    footer_hint = "Enter inserts @path · ↑↓ navigate · Esc closes"
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel", show=False),
+        Binding("up", "move(-1)", "Previous", show=False),
+        Binding("down", "move(1)", "Next", show=False),
+        Binding("ctrl+p", "move(-1)", "Previous", show=False),
+        Binding("ctrl+n", "move(1)", "Next", show=False),
+    ]
+
+    def __init__(self, cwd: str) -> None:
+        super().__init__()
+        self._cwd = cwd
+        self._all_files: list[str] = []
+        self._files_truncated = False
+        self._shown: list[str] = []
+        self._abort: AbortController | None = None
+        self._input: Input | None = None
+        self._list: SelectList | None = None
+        self._count_label: Static | None = None
+
+    def build_body(self) -> Iterator[Widget]:
+        self._input = Input(placeholder="Type to search files…")
+        yield self._input
+        self._count_label = Static(Text("  loading files…", style="dim"), markup=False)
+        yield self._count_label
+        self._list = SelectList([])
+        yield self._list
+
+    def _post_mount(self) -> None:
+        if self._input is not None:
+            self._input.focus()
+        self._abort = AbortController()
+        self._load_files_worker(self._abort)
+
+    @work(thread=True, exclusive=True, group="quick-open", exit_on_error=False)
+    def _load_files_worker(self, abort: AbortController) -> None:
+        try:
+            files, truncated = list_workspace_files(
+                self._cwd, abort_signal=abort.signal
+            )
+            error: str | None = None
+        except Exception as exc:
+            files, truncated, error = [], False, str(exc)
+        try:
+            self.app.call_from_thread(self._files_loaded, files, truncated, error)
+        except Exception:
+            pass
+
+    def _files_loaded(
+        self, files: list[str], truncated: bool, error: str | None
+    ) -> None:
+        if not self.is_attached:
+            return
+        if error:
+            if self._count_label is not None:
+                self._count_label.update(
+                    Text(f"  file listing failed: {error}", style="dim")
+                )
+            return
+        self._all_files = files
+        self._files_truncated = truncated
+        self._refilter(self._input.value if self._input else "")
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if self._all_files:
+            self._refilter(event.value)
+
+    def _refilter(self, query: str) -> None:
+        self._shown = filter_files(self._all_files, query)
+        if self._list is not None:
+            self._list.set_options(
+                [
+                    SelectOption(label=path, value=str(i))
+                    for i, path in enumerate(self._shown)
+                ]
+            )
+        if self._count_label is not None:
+            note = (
+                f"{len(self._shown)} / {len(self._all_files)} files"
+                if self._shown
+                else "no files"
+            )
+            if self._files_truncated:
+                note += " (file list truncated at 5000)"
+            self._count_label.update(Text(f"  {note}", style="dim"))
+
+    def on_input_submitted(self, _: Input.Submitted) -> None:
+        self.action_select_current()
+
+    def action_move(self, delta: int) -> None:
+        if self._list is not None:
+            self._list.action_move(delta)
+
+    def action_select_current(self) -> None:
+        if self._list is None or self._list.current is None:
+            return
+        try:
+            path = self._shown[int(self._list.current.value)]
+        except (TypeError, ValueError, IndexError):
+            return
+        self.dismiss(file_insertion(path))
+
+    def on_unmount(self) -> None:
+        if self._abort is not None:
+            self._abort.abort("dialog closed")
+
+
+__all__ = ["GlobalSearchScreen", "QuickOpenScreen"]

--- a/src/tui/widgets/prompt_input.py
+++ b/src/tui/widgets/prompt_input.py
@@ -178,6 +178,20 @@ class PromptInput(Vertical):
         self._input.value = ""
         self._hide_suggestions()
 
+    def append_value(self, text: str) -> None:
+        """Append ``text`` to the draft (C5 search/open insertions) and
+        put the cursor at the end."""
+
+        if not text:
+            return
+        new_value = (self._input.value or "") + text
+        self._input.value = new_value
+        try:
+            self._input.cursor_position = len(new_value)
+        except Exception:
+            pass
+        self.focus_input()
+
     def set_value(self, value: str) -> None:
         """Replace the draft text in the prompt (used by /history)."""
 

--- a/tests/tui/test_workspace_search_c5.py
+++ b/tests/tui/test_workspace_search_c5.py
@@ -1,0 +1,269 @@
+"""C5 tests: workspace-search service, dialogs, dispatch, insertion."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from src.services.workspace_search import (
+    ContentMatch,
+    file_insertion,
+    filter_files,
+    list_workspace_files,
+    search_content,
+)
+
+
+@pytest.fixture
+def workspace(tmp_path) -> Path:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "alpha.py").write_text(
+        "def needle_function():\n    return 1\n"
+    )
+    (tmp_path / "src" / "beta.py").write_text("x = 'no match here'\n")
+    (tmp_path / "README.md").write_text("needle_function docs\n")
+    return tmp_path
+
+
+class TestService:
+    def test_search_content_parses_and_relativizes(self, workspace) -> None:
+        matches, truncated = search_content("needle_function", str(workspace))
+        assert not truncated
+        files = {m.file for m in matches}
+        assert "src/alpha.py" in files and "README.md" in files
+        alpha = next(m for m in matches if m.file == "src/alpha.py")
+        assert alpha.line == 1
+        assert "needle_function" in alpha.text
+
+    def test_search_is_case_insensitive(self, workspace) -> None:
+        # TS uses rg -i (GlobalSearchDialog.tsx:268) — an uppercase query
+        # must still match.
+        matches, _ = search_content("NEEDLE_FUNCTION", str(workspace))
+        assert matches
+
+    def test_truncation_flag(self, workspace) -> None:
+        big = workspace / "many.txt"
+        big.write_text("hit\n" * 40)
+        matches, truncated = search_content(
+            "hit", str(workspace), max_results=3
+        )
+        assert len(matches) == 3
+        assert truncated
+
+    def test_insertion_formats_are_ts_verbatim(self) -> None:
+        match = ContentMatch(file="src/a.py", line=12, text="x")
+        assert match.insertion() == "@src/a.py#L12 "
+        assert file_insertion("src/a.py") == "@src/a.py "
+
+    def test_list_and_filter_files(self, workspace) -> None:
+        files, truncated = list_workspace_files(str(workspace))
+        assert not truncated
+        assert "src/alpha.py" in files
+        ranked = filter_files(files, "alpha")
+        assert ranked[0] == "src/alpha.py"
+        # Substring beats subsequence.
+        ranked2 = filter_files(["zzz_ap.py", "alpha.py"], "alp")
+        assert ranked2[0] == "alpha.py"
+
+    def test_empty_query_returns_nothing(self, workspace) -> None:
+        assert search_content("   ", str(workspace)) == ([], False)
+
+    def test_mention_fragment_attaches_file(self, workspace) -> None:
+        # The @file#Lline insertion must be FUNCTIONAL downstream
+        # (review M4): expand_at_mentions strips the fragment and
+        # attaches the file.
+        from src.command_system.input_processing import expand_at_mentions
+
+        _text, attachments = expand_at_mentions(
+            "look at @src/alpha.py#L1 please", cwd=str(workspace)
+        )
+        assert any(
+            "alpha.py" in str(a.get("path", "")) for a in attachments
+        ), attachments
+
+    def test_large_output_does_not_stall(self, tmp_path) -> None:
+        """Regression for the pipe-buffer deadlock: >64KB of rg output
+        previously blocked until the 20s timeout."""
+
+        from src.tool_system.utils.ripgrep import ripgrep
+
+        big = tmp_path / "big.txt"
+        big.write_text("needle padding padding padding\n" * 5000)  # ~150KB
+        start = time.monotonic()
+        lines = ripgrep(["-n", "--fixed-strings", "needle"], str(big))
+        elapsed = time.monotonic() - start
+        assert len(lines) == 5000
+        assert elapsed < 5, f"rg stalled: {elapsed:.1f}s"
+
+
+class TestDispatch:
+    def _dispatch(self, text: str):
+        from src.tui.commands import dispatch_local_command
+
+        return dispatch_local_command(
+            text, session=None, workspace_root=Path("."), tool_registry=None
+        )
+
+    def test_search_plain_and_seeded(self) -> None:
+        assert self._dispatch("/search").open_dialog == "search"
+        assert self._dispatch("/search foo bar").open_dialog == "search:foo bar"
+
+    def test_open(self) -> None:
+        assert self._dispatch("/open").open_dialog == "quickopen"
+
+
+@pytest.mark.asyncio
+async def test_global_search_screen_selection(workspace) -> None:
+    pytest.importorskip("textual")
+    import asyncio
+
+    from textual.app import App, ComposeResult
+    from textual.screen import Screen
+    from textual.widgets import Static
+
+    from src.tui.screens.workspace_search import GlobalSearchScreen
+
+    class _Host(Screen):
+        def compose(self) -> ComposeResult:
+            yield Static("host")
+
+    class _App(App):
+        def on_mount(self) -> None:
+            self.push_screen(_Host())
+
+    app = _App()
+    async with app.run_test() as pilot:
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future = loop.create_future()
+        app.push_screen(
+            GlobalSearchScreen(
+                cwd=str(workspace), initial_query="needle_function"
+            ),
+            callback=lambda r: future.set_result(r),
+        )
+        # Let the worker run + results land.
+        for _ in range(20):
+            await pilot.pause(0.05)
+            screen = app.screen
+            if getattr(screen, "_matches", None):
+                break
+        assert getattr(app.screen, "_matches", [])
+        # Input kept focus (no theft); Enter on the unchanged query
+        # selects the highlighted (top) match.
+        await pilot.press("enter")
+        result = await asyncio.wait_for(future, timeout=5)
+    assert result is not None
+    assert result.startswith("@") and "#L" in result and result.endswith(" ")
+
+
+@pytest.mark.asyncio
+async def test_global_search_stale_enter_does_not_select_old_query(
+    workspace,
+) -> None:
+    """Review B1: Enter while a NEW query's search is in flight must not
+    insert the OLD query's top match."""
+
+    pytest.importorskip("textual")
+    import asyncio
+
+    from textual.app import App, ComposeResult
+    from textual.screen import Screen
+    from textual.widgets import Static
+
+    from src.tui.screens.workspace_search import GlobalSearchScreen
+
+    class _Host(Screen):
+        def compose(self) -> ComposeResult:
+            yield Static("host")
+
+    class _App(App):
+        def on_mount(self) -> None:
+            self.push_screen(_Host())
+
+    app = _App()
+    async with app.run_test() as pilot:
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future = loop.create_future()
+        app.push_screen(
+            GlobalSearchScreen(
+                cwd=str(workspace), initial_query="needle_function"
+            ),
+            callback=lambda r: future.set_result(r),
+        )
+        for _ in range(20):
+            await pilot.pause(0.05)
+            if getattr(app.screen, "_matches", None):
+                break
+        screen = app.screen
+        # Simulate the user editing the query and re-running the search:
+        # _run_search must clear matches IMMEDIATELY.
+        screen._run_search("something else entirely")
+        assert screen._matches == []
+        # Enter now (unchanged-new-query + no matches) selects nothing.
+        await pilot.press("enter")
+        await pilot.pause()
+        assert not future.done()
+        await pilot.press("escape")
+        result = await asyncio.wait_for(future, timeout=5)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_quick_open_screen_enter_picks_top(workspace) -> None:
+    pytest.importorskip("textual")
+    import asyncio
+
+    from textual.app import App, ComposeResult
+    from textual.screen import Screen
+    from textual.widgets import Static
+
+    from src.tui.screens.workspace_search import QuickOpenScreen
+
+    class _Host(Screen):
+        def compose(self) -> ComposeResult:
+            yield Static("host")
+
+    class _App(App):
+        def on_mount(self) -> None:
+            self.push_screen(_Host())
+
+    app = _App()
+    async with app.run_test() as pilot:
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future = loop.create_future()
+        app.push_screen(
+            QuickOpenScreen(cwd=str(workspace)),
+            callback=lambda r: future.set_result(r),
+        )
+        for _ in range(20):
+            await pilot.pause(0.05)
+            if getattr(app.screen, "_all_files", None):
+                break
+        for ch in "alpha":
+            await pilot.press(ch)
+        await pilot.pause()
+        await pilot.press("enter")
+        result = await asyncio.wait_for(future, timeout=5)
+    assert result == "@src/alpha.py "
+
+
+@pytest.mark.asyncio
+async def test_prompt_append_value() -> None:
+    pytest.importorskip("textual")
+    from textual.app import App, ComposeResult
+
+    from src.tui.widgets.prompt_input import PromptInput
+
+    class _Host(App):
+        def compose(self) -> ComposeResult:
+            yield PromptInput(words_provider=lambda: [])
+
+    app = _Host()
+    async with app.run_test() as pilot:
+        prompt = app.query_one(PromptInput)
+        prompt.set_value("look at ")
+        prompt.append_value("@src/a.py#L12 ")
+        await pilot.pause()
+        assert prompt._input.value == "look at @src/a.py#L12 "


### PR DESCRIPTION
## Summary
- `/search` + `/open` dialogs (TS GlobalSearch/QuickOpen, degraded scope) inserting TS-verbatim `@file#Lline ` / `@path ` mentions — now functional downstream (`expand_at_mentions` strips the `#L` fragment and attaches the file)
- Shared-engine fix: the ripgrep runner deadlocked on >64KB output (pipes never drained during the abort-poll loop) and strict decoding could silently truncate Grep/Glob results — drained concurrently + `errors="replace"`
- UI-neutral `workspace_search`/`fuzzy_match` services (TS-cited caps/flags, Windows-safe parse, POSIX insertions); screens on the house DialogScreen+SelectList idiom with the stale-result race closed in depth

## Test plan
- [x] 14 tests: >64KB no-stall regression, stale-enter pilot, case-insensitivity, truncation flags, functional-mention pin, dispatch seeding
- [x] 636 TUI/REPL + 56 grep/glob/ripgrep engine tests green; full suite BASELINE-IDENTICAL
- [x] Impl-critic: REQUEST CHANGES (stale race, Windows parse, decode truncation, inert mentions, keyboard model) → all fixed → **APPROVE**

🤖 Generated with [Claude Code](https://claude.com/claude-code)