### PR TITLE
components C7: .mcp.json server approval gate

### DIFF
--- a/src/services/mcp/config.py
+++ b/src/services/mcp/config.py
@@ -374,9 +374,11 @@ def get_mcp_configs_by_scope(
 
     Scope semantics (Phase 7 WI-7.1, gap #9):
       - ``local``: ``.mcp.json`` in the current working directory only.
-        Per the chapter, this scope requires user approval — currently
-        loaded unconditionally; future work can gate behind a workspace-
-        trust check (out of scope here).
+        Requires user approval — enforced downstream (C7) in
+        ``get_all_mcp_configs`` (pre-merge per-scope filter) and
+        ``get_mcp_config_by_name`` (per-name gate); this per-scope
+        loader stays unfiltered so the approval flow itself can
+        enumerate pending servers.
       - ``project``: ``.mcp.json`` files in **parent** directories of the
         cwd, walked toward the filesystem root. Closest-parent-wins.
         The cwd itself is intentionally excluded so it can be tagged
@@ -502,6 +504,17 @@ def get_mcp_config_by_name(name: str) -> ScopedMcpServerConfig | None:
     for scope in ("enterprise", "user", "project", "local"):
         servers, _ = get_mcp_configs_by_scope(scope)  # type: ignore[arg-type]
         if name in servers:
+            # C7: per-name resolves (reconnect_mcp_server, OAuth flows)
+            # must honor the same .mcp.json approval gate as the
+            # aggregate path — otherwise this is a side door that
+            # connects a pending/rejected repo server by name.
+            if scope in ("project", "local"):
+                from src.services.mcp_approval import (
+                    get_mcpjson_server_status,
+                )
+
+                if get_mcpjson_server_status(name) != "approved":
+                    continue
             return servers[name]
     # Also check managed (plugin) and dynamic (SDK-injected) servers.
     managed = get_managed_mcp_configs()
@@ -608,6 +621,24 @@ def get_all_mcp_configs() -> tuple[dict[str, ScopedMcpServerConfig], list[Valida
     user_servers, user_errors = get_mcp_configs_by_scope("user")
     project_servers, project_errors = get_mcp_configs_by_scope("project")
     local_servers, local_errors = get_mcp_configs_by_scope("local")
+
+    # C7: .mcp.json-derived servers (project/local scope) are untrusted
+    # until approved — a checked-out repo must not launch arbitrary MCP
+    # processes on its own say-so (TS getProjectMcpServerStatus gate).
+    # Filtered PRE-merge, per scope: filtering the merged map instead
+    # would let an unapproved repo server name-collide with (shadow) a
+    # user-scope server and then be dropped, knocking out BOTH.
+    from src.services.mcp_approval import filter_unapproved_mcpjson_servers
+
+    project_servers, project_pending = filter_unapproved_mcpjson_servers(
+        project_servers
+    )
+    local_servers, local_pending = filter_unapproved_mcpjson_servers(
+        local_servers
+    )
+    # Same name pending in both scopes → identical notice text; dedup.
+    approval_notices = list(dict.fromkeys(project_pending + local_pending))
+
     managed_servers = get_managed_mcp_configs()
     dynamic_servers = get_dynamic_mcp_configs()
     # Phase 7 WI-7.3: pick up any Claude.ai connectors that the agent's
@@ -661,6 +692,7 @@ def get_all_mcp_configs() -> tuple[dict[str, ScopedMcpServerConfig], list[Valida
     all_errors = (
         enterprise_errors + user_errors + project_errors + local_errors
         + _notices_to_validation_errors(notices)
+        + _notices_to_validation_errors(approval_notices)
         + _notices_to_validation_errors(dedup_notice_strings)
     )
     return filtered, all_errors

--- a/src/services/mcp_approval.py
+++ b/src/services/mcp_approval.py
@@ -1,0 +1,224 @@
+"""Project ``.mcp.json`` server approval (components C7).
+
+Port of TS ``MCPServerApprovalDialog.tsx`` +
+``services/mcp/utils.ts getProjectMcpServerStatus`` (:351-390): servers
+configured by a repo's ``.mcp.json`` are UNTRUSTED until the user
+approves them — a checked-out repository must not get to launch
+arbitrary MCP processes on its own say-so.
+
+Status precedence (TS-faithful):
+``disabledMcpjsonServers`` (name-normalized) → rejected;
+``enabledMcpjsonServers`` → approved; ``enableAllProjectMcpServers`` →
+approved; else **pending**.
+
+Settings layering: TS reads these keys from MERGED settings
+(``getSettings_DEPRECATED`` → user → project → local; list values are
+unioned by ``settingsMergeCustomizer``, scalars last-writer-wins). This
+port reads the **user and local** tiers only — the project tier
+(``<cwd>/.clawcodex/settings.json``, committable) is DELIBERATELY
+excluded so a repo cannot self-approve its own ``.mcp.json`` servers
+by also committing settings. This also ignores a repo-committed
+``disabledMcpjsonServers`` — accepted: the failure mode is fail-safe
+(server stays pending → user is prompted). Deviation from TS,
+strictly safer.
+Choices persist to the local tier (TS MCPServerApprovalDialog.tsx:31-48
+writes localSettings) — ``<cwd>/.clawcodex/settings.local.json``.
+
+Enforcement has exactly two gates in ``services/mcp/config``, applied
+to the ``.mcp.json``-derived scopes only (Python ``local`` = cwd
+``.mcp.json``, ``project`` = parent-dir ``.mcp.json``; other scopes are
+the user's or operator's own configuration and pass untouched):
+
+* ``get_all_mcp_configs`` filters each ``.mcp.json`` scope BEFORE the
+  cross-scope merge — pre-merge so a repo server name-colliding with a
+  user-scope server can never shadow-then-drop it;
+* ``get_mcp_config_by_name`` returns ``None`` for a non-approved
+  ``.mcp.json`` server, closing the per-name resolve path
+  (``reconnect_mcp_server`` etc.).
+
+Both gates sit on the choke points every current and future consumer
+(doctor, /mcp, the eventual runtime mount) reads through; non-TUI
+sessions get warning notices for pending servers instead of a prompt.
+
+Deferred (documented): the TS bypass-mode auto-approve branch reads
+``skipDangerousModePermissionPrompt`` — that key lands with the C8
+bypass gate; until then bypass sessions see the same skip-with-warning.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from src.services.mcp.normalization import normalize_name_for_mcp
+
+ENABLED_KEY = "enabledMcpjsonServers"
+DISABLED_KEY = "disabledMcpjsonServers"
+ENABLE_ALL_KEY = "enableAllProjectMcpServers"
+
+_MCPJSON_SCOPES = frozenset({"project", "local"})
+
+
+def _local_settings_path(cwd: str | None = None) -> str:
+    from src.permissions import settings_paths
+
+    return settings_paths.local_settings_path(cwd)
+
+
+def _read_json_dict(path: str) -> dict[str, Any]:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _read_merged_settings(cwd: str | None = None) -> dict[str, Any]:
+    """User tier then local tier (TS merge order; project tier excluded
+    on purpose — see module docstring). Lists union, scalars last-win."""
+
+    from src.permissions import settings_paths
+
+    merged: dict[str, Any] = {}
+    for path in (
+        settings_paths.user_settings_path(),
+        _local_settings_path(cwd),
+    ):
+        layer = _read_json_dict(path)
+        for key in (ENABLED_KEY, DISABLED_KEY):
+            value = layer.get(key)
+            if isinstance(value, list):
+                names = [str(n) for n in value]
+                existing = merged.get(key, [])
+                merged[key] = existing + [
+                    n for n in names if n not in existing
+                ]
+        if ENABLE_ALL_KEY in layer:
+            merged[ENABLE_ALL_KEY] = layer.get(ENABLE_ALL_KEY)
+    return merged
+
+
+def _write_local_settings(data: dict[str, Any], cwd: str | None = None) -> bool:
+    path = _local_settings_path(cwd)
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        return True
+    except OSError:
+        return False
+
+
+def get_mcpjson_server_status(
+    server_name: str, *, cwd: str | None = None
+) -> str:
+    """``approved`` | ``rejected`` | ``pending`` (TS utils.ts:351)."""
+
+    settings = _read_merged_settings(cwd)
+    normalized = normalize_name_for_mcp(server_name)
+    disabled = settings.get(DISABLED_KEY) or []
+    if any(normalize_name_for_mcp(str(n)) == normalized for n in disabled):
+        return "rejected"
+    enabled = settings.get(ENABLED_KEY) or []
+    if any(normalize_name_for_mcp(str(n)) == normalized for n in enabled):
+        return "approved"
+    if settings.get(ENABLE_ALL_KEY) is True:
+        return "approved"
+    return "pending"
+
+
+def list_pending_mcpjson_servers(cwd: str | None = None) -> list[str]:
+    """Names of ``.mcp.json`` servers awaiting a decision."""
+
+    from src.services.mcp.config import get_mcp_configs_by_scope
+
+    names: list[str] = []
+    for scope in ("project", "local"):
+        try:
+            servers, _errors = get_mcp_configs_by_scope(scope)  # type: ignore[arg-type]
+        except Exception:
+            continue
+        for name in servers:
+            if name in names:
+                continue
+            if get_mcpjson_server_status(name, cwd=cwd) == "pending":
+                names.append(name)
+    return sorted(names)
+
+
+def record_mcpjson_choice(
+    server_name: str, choice: str, *, cwd: str | None = None
+) -> bool:
+    """Persist one decision: ``enable`` | ``enable_all`` | ``disable``."""
+
+    settings = _read_json_dict(_local_settings_path(cwd))
+
+    def _names(key: str) -> list[str]:
+        value = settings.get(key)
+        return [str(n) for n in value] if isinstance(value, list) else []
+
+    if choice == "enable":
+        enabled = _names(ENABLED_KEY)
+        if server_name not in enabled:
+            enabled.append(server_name)
+        settings[ENABLED_KEY] = enabled
+    elif choice == "enable_all":
+        settings[ENABLE_ALL_KEY] = True
+    elif choice == "disable":
+        disabled = _names(DISABLED_KEY)
+        if server_name not in disabled:
+            disabled.append(server_name)
+        settings[DISABLED_KEY] = disabled
+    else:
+        return False
+    return _write_local_settings(settings, cwd)
+
+
+def is_mcpjson_scope(scope: Any) -> bool:
+    return str(scope) in _MCPJSON_SCOPES
+
+
+def filter_unapproved_mcpjson_servers(
+    servers: dict[str, Any], *, cwd: str | None = None
+) -> tuple[dict[str, Any], list[str]]:
+    """Drop non-approved ``.mcp.json``-scoped servers from a scope map.
+
+    Returns ``(kept, pending_notices)``. Non-``.mcp.json`` scopes pass
+    through untouched. Rejected servers are dropped SILENTLY — an
+    explicit user decision is not a health problem (TS likewise loads
+    nothing and warns nothing for disabled servers); only still-pending
+    servers get an actionable notice.
+    """
+
+    kept: dict[str, Any] = {}
+    notices: list[str] = []
+    for name, scoped in servers.items():
+        scope = getattr(scoped, "scope", None)
+        if not is_mcpjson_scope(scope):
+            kept[name] = scoped
+            continue
+        status = get_mcpjson_server_status(name, cwd=cwd)
+        if status == "approved":
+            kept[name] = scoped
+        elif status == "pending":
+            notices.append(
+                f"MCP server '{name}' from .mcp.json is awaiting approval "
+                "— open the TUI to approve, or add it to "
+                f"{ENABLED_KEY} in .clawcodex/settings.local.json"
+            )
+    return kept, notices
+
+
+__all__ = [
+    "DISABLED_KEY",
+    "ENABLED_KEY",
+    "ENABLE_ALL_KEY",
+    "filter_unapproved_mcpjson_servers",
+    "get_mcpjson_server_status",
+    "is_mcpjson_scope",
+    "list_pending_mcpjson_servers",
+    "record_mcpjson_choice",
+]

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -226,6 +226,96 @@ class ClawCodexTUI(App):
         # (TS StatusNotices / InvalidSettingsDialog family — Python's
         # loader silently falls back to {}, so warn honestly instead).
         self.call_after_refresh(self._show_config_warnings)
+        # C7: prompt for any pending .mcp.json servers (TS
+        # handleMcpjsonServerApprovals — gated like TS: only after a
+        # clean settings read, which C6's warnings have just reported).
+        self.call_after_refresh(self._run_mcp_approvals)
+
+    # ---- C7 .mcp.json server approvals ----------------------------------
+    # cwd note: approvals deliberately key off the process cwd (the
+    # default of every mcp_approval call), NOT self.workspace_root —
+    # enumeration and enforcement in services/mcp/config both resolve
+    # from the process cwd, and splitting the two would persist
+    # approvals to a file enforcement never reads.
+    def _run_mcp_approvals(self) -> None:
+        try:
+            from src.services.mcp_approval import list_pending_mcpjson_servers
+
+            pending = list_pending_mcpjson_servers()
+        except Exception:
+            return
+        if pending:
+            self._prompt_next_mcp_approval(list(pending))
+
+    def _prompt_next_mcp_approval(self, queue: list[str]) -> None:
+        from src.services.mcp_approval import get_mcpjson_server_status
+        from src.tui.screens.mcp_approval import McpApprovalScreen
+
+        while queue:
+            name = queue.pop(0)
+            try:
+                still_pending = get_mcpjson_server_status(name) == "pending"
+            except Exception:
+                still_pending = False
+            if not still_pending:
+                # An earlier answer (enable_all, or a normalization-equal
+                # name) already decided this one — don't re-ask.
+                continue
+            self.push_screen(
+                McpApprovalScreen(name),
+                callback=lambda choice, _n=name, _q=queue: (
+                    self._on_mcp_approval(_n, choice, _q)
+                ),
+            )
+            return
+
+    def _on_mcp_approval(
+        self, name: str, choice: str | None, queue: list[str]
+    ) -> None:
+        transcript = (
+            self._repl_screen.transcript if self._repl_screen else None
+        )
+        if choice:
+            persisted = False
+            try:
+                from src.services.mcp_approval import record_mcpjson_choice
+
+                persisted = record_mcpjson_choice(name, choice)
+            except Exception:
+                persisted = False
+            if not persisted:
+                if transcript is not None:
+                    transcript.append_system(
+                        f"Could not save the choice for MCP server "
+                        f"'{name}' (settings file not writable) — it "
+                        "stays pending.",
+                        style="muted",
+                    )
+                self._prompt_next_mcp_approval(queue)
+                return
+        if transcript is not None:
+            if choice == "enable":
+                transcript.append_system(
+                    f"MCP server '{name}' enabled.", style="muted"
+                )
+            elif choice == "enable_all":
+                transcript.append_system(
+                    "All .mcp.json servers from this project enabled.",
+                    style="muted",
+                )
+            elif choice == "disable":
+                transcript.append_system(
+                    f"MCP server '{name}' disabled.", style="muted"
+                )
+            else:
+                transcript.append_system(
+                    f"MCP server '{name}' left pending — you'll be asked "
+                    "again next launch.",
+                    style="muted",
+                )
+        if choice == "enable_all":
+            queue.clear()  # everything else is now approved too
+        self._prompt_next_mcp_approval(queue)
 
     def _show_config_warnings(self) -> None:
         if self._repl_screen is None:

--- a/src/tui/screens/__init__.py
+++ b/src/tui/screens/__init__.py
@@ -7,6 +7,7 @@ from .effort_picker import EffortPickerScreen
 from .exit_flow import ExitFlowScreen
 from .history_search import HistoryEntry, HistorySearchScreen, fuzzy_score
 from .idle_return import IdleReturnScreen
+from .mcp_approval import McpApprovalScreen
 from .mcp_dialogs import (
     McpElicitationScreen,
     McpListScreen,
@@ -36,6 +37,7 @@ __all__ = [
     "HistoryEntry",
     "HistorySearchScreen",
     "IdleReturnScreen",
+    "McpApprovalScreen",
     "McpElicitationScreen",
     "McpListScreen",
     "McpServer",

--- a/src/tui/screens/mcp_approval.py
+++ b/src/tui/screens/mcp_approval.py
@@ -1,0 +1,82 @@
+"""Project ``.mcp.json`` server approval dialog (components C7).
+
+Port of TS ``MCPServerApprovalDialog.tsx`` (single pending server; the
+multi-server case iterates this same dialog rather than porting the
+separate multiselect — degraded scope, documented). Dismisses with the
+chosen action (``enable`` / ``enable_all`` / ``disable``) or ``None``
+on Esc (= remain pending; asked again next launch, exactly TS's
+behavior for an unanswered dialog).
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+from rich.text import Text
+from textual.widget import Widget
+from textual.widgets import Static
+
+from src.tui.widgets.select_list import SelectList, SelectOption
+
+from .dialog_base import DialogScreen
+
+
+class McpApprovalScreen(DialogScreen[str | None]):
+    """One pending ``.mcp.json`` server → enable / enable-all / disable."""
+
+    title_text = "New MCP server found in .mcp.json"
+    footer_hint = "Enter selects · Esc decides later"
+    border_variant = "warning"
+
+    def __init__(self, server_name: str) -> None:
+        super().__init__()
+        self._server_name = server_name
+        self._select: SelectList | None = None
+
+    def build_body(self) -> Iterator[Widget]:
+        yield Static(
+            Text(
+                f"This project's .mcp.json configures the server "
+                f"'{self._server_name}'. MCP servers run as local "
+                "processes — only enable servers you trust.",
+                style="dim",
+            ),
+            markup=False,
+        )
+        self._select = SelectList(
+            [
+                SelectOption(
+                    label=f"Yes, enable '{self._server_name}'",
+                    value="enable",
+                ),
+                SelectOption(
+                    label="Yes, and enable ALL servers this project's "
+                    ".mcp.json configures (now and in the future)",
+                    value="enable_all",
+                ),
+                SelectOption(
+                    label=f"No, disable '{self._server_name}'",
+                    value="disable",
+                ),
+            ],
+            allow_cancel=True,
+        )
+        yield self._select
+
+    def _post_mount(self) -> None:
+        if self._select is not None:
+            self._select.focus()
+
+    def on_select_list_option_selected(
+        self, event: SelectList.OptionSelected
+    ) -> None:
+        self.dismiss(str(event.option.value))
+
+    def on_select_list_selection_cancelled(
+        self, _: SelectList.SelectionCancelled
+    ) -> None:
+        # Esc = decide later: stays pending, asked again next launch.
+        self.dismiss(None)
+
+
+__all__ = ["McpApprovalScreen"]

--- a/tests/tui/test_mcp_approval_c7.py
+++ b/tests/tui/test_mcp_approval_c7.py
@@ -1,0 +1,319 @@
+"""C7 tests: .mcp.json approval status, persistence, enforcement, UI."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from src.services.mcp_approval import (
+    DISABLED_KEY,
+    ENABLE_ALL_KEY,
+    ENABLED_KEY,
+    filter_unapproved_mcpjson_servers,
+    get_mcpjson_server_status,
+    list_pending_mcpjson_servers,
+    record_mcpjson_choice,
+)
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    """Isolated cwd with a local .mcp.json declaring two servers."""
+
+    import src.services.mcp.config as mcp_config_mod
+
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "alpha": {"command": "alpha-server"},
+                    "beta": {"command": "beta-server"},
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(mcp_config_mod, "_get_cwd", lambda: str(tmp_path))
+    # Approval reads/writes default to the process cwd — pin it too so
+    # the no-cwd production call paths resolve to this project.
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _settings(tmp_path) -> dict:
+    path = tmp_path / ".clawcodex" / "settings.local.json"
+    return json.loads(path.read_text()) if path.exists() else {}
+
+
+class TestStatusAndPersistence:
+    def test_default_is_pending(self, project) -> None:
+        assert get_mcpjson_server_status("alpha", cwd=str(project)) == "pending"
+
+    def test_enable_round_trip(self, project) -> None:
+        assert record_mcpjson_choice("alpha", "enable", cwd=str(project))
+        assert get_mcpjson_server_status("alpha", cwd=str(project)) == "approved"
+        assert _settings(project)[ENABLED_KEY] == ["alpha"]
+
+    def test_disable_beats_enable(self, project) -> None:
+        record_mcpjson_choice("alpha", "enable", cwd=str(project))
+        record_mcpjson_choice("alpha", "disable", cwd=str(project))
+        # TS precedence: disabled list is checked FIRST.
+        assert get_mcpjson_server_status("alpha", cwd=str(project)) == "rejected"
+        data = _settings(project)
+        assert "alpha" in data[ENABLED_KEY] and "alpha" in data[DISABLED_KEY]
+
+    def test_enable_all(self, project) -> None:
+        record_mcpjson_choice("beta", "enable_all", cwd=str(project))
+        assert _settings(project)[ENABLE_ALL_KEY] is True
+        assert get_mcpjson_server_status("alpha", cwd=str(project)) == "approved"
+        assert get_mcpjson_server_status("never-seen", cwd=str(project)) == "approved"
+
+    def test_name_normalization(self, project) -> None:
+        # normalize_name_for_mcp maps non-[a-zA-Z0-9_-] chars to "_",
+        # so "alpha server" and "alpha_server" are the same identity.
+        record_mcpjson_choice("alpha server", "enable", cwd=str(project))
+        assert (
+            get_mcpjson_server_status("alpha_server", cwd=str(project))
+            == "approved"
+        )
+
+    def test_invalid_choice_rejected(self, project) -> None:
+        assert not record_mcpjson_choice("alpha", "bogus", cwd=str(project))
+
+
+class TestPendingListing:
+    def test_lists_both_until_decided(self, project) -> None:
+        pending = list_pending_mcpjson_servers(str(project))
+        assert pending == ["alpha", "beta"]
+        record_mcpjson_choice("alpha", "enable", cwd=str(project))
+        assert list_pending_mcpjson_servers(str(project)) == ["beta"]
+        record_mcpjson_choice("beta", "disable", cwd=str(project))
+        assert list_pending_mcpjson_servers(str(project)) == []
+
+
+class TestEnforcement:
+    def _scoped(self, scope: str):
+        return SimpleNamespace(scope=scope)
+
+    def test_pending_mcpjson_scope_dropped_with_notice(self, project) -> None:
+        servers = {
+            "alpha": self._scoped("local"),
+            "userserver": self._scoped("user"),
+        }
+        kept, notices = filter_unapproved_mcpjson_servers(
+            servers, cwd=str(project)
+        )
+        assert "alpha" not in kept
+        assert "userserver" in kept  # non-.mcp.json scopes untouched
+        assert any("awaiting approval" in n for n in notices)
+
+    def test_approved_kept_rejected_silently_dropped(self, project) -> None:
+        record_mcpjson_choice("alpha", "enable", cwd=str(project))
+        record_mcpjson_choice("beta", "disable", cwd=str(project))
+        servers = {
+            "alpha": self._scoped("local"),
+            "beta": self._scoped("project"),
+        }
+        kept, notices = filter_unapproved_mcpjson_servers(
+            servers, cwd=str(project)
+        )
+        assert list(kept) == ["alpha"]
+        # An explicit rejection is a decision, not a health problem —
+        # no perpetual warning.
+        assert notices == []
+
+    def test_get_all_mcp_configs_excludes_pending(self, project) -> None:
+        """End-to-end through the REAL aggregator: a pending .mcp.json
+        server never reaches the merged set (headless enforcement)."""
+
+        from src.services.mcp.config import get_all_mcp_configs
+
+        configs, errors = get_all_mcp_configs()
+        assert "alpha" not in configs and "beta" not in configs
+        assert any(
+            "awaiting approval" in (e.message or "") for e in errors
+        )
+        record_mcpjson_choice("alpha", "enable", cwd=str(project))
+        configs2, _errors2 = get_all_mcp_configs()
+        assert "alpha" in configs2
+        assert "beta" not in configs2
+
+    def test_repo_name_collision_cannot_shadow_user_server(
+        self, project, tmp_path, monkeypatch
+    ) -> None:
+        """Regression (critic finding 1): an unapproved/rejected repo
+        .mcp.json server name-colliding with a user-scope server must
+        not knock the user's own server out of the merged set."""
+
+        from src.services.mcp.config import get_all_mcp_configs
+
+        user_dir = tmp_path / "user-config"
+        user_dir.mkdir()
+        (user_dir / "config.json").write_text(
+            json.dumps(
+                {"mcpServers": {"alpha": {"command": "user-alpha"}}}
+            )
+        )
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(user_dir))
+
+        configs, _errors = get_all_mcp_configs()
+        assert "alpha" in configs  # user's own server survives
+        assert configs["alpha"].scope == "user"
+
+        record_mcpjson_choice("alpha", "disable", cwd=str(project))
+        configs2, _errors2 = get_all_mcp_configs()
+        assert "alpha" in configs2  # explicit rejection of the repo's
+        assert configs2["alpha"].scope == "user"  # copy keeps the user's
+
+    def test_get_mcp_config_by_name_gates_mcpjson_scopes(
+        self, project
+    ) -> None:
+        """The per-name resolve path (reconnect etc.) honors the gate."""
+
+        from src.services.mcp.config import get_mcp_config_by_name
+
+        assert get_mcp_config_by_name("alpha") is None  # pending
+        record_mcpjson_choice("beta", "disable", cwd=str(project))
+        assert get_mcp_config_by_name("beta") is None  # rejected
+        record_mcpjson_choice("alpha", "enable", cwd=str(project))
+        resolved = get_mcp_config_by_name("alpha")
+        assert resolved is not None and resolved.scope == "local"
+
+    def test_user_tier_enable_all_is_honored(self, project) -> None:
+        """TS reads these keys from merged settings (user→local). A
+        user-level enableAllProjectMcpServers opt-in approves repo
+        servers; the project settings tier is deliberately excluded."""
+
+        from src.permissions import settings_paths
+
+        with open(settings_paths.user_settings_path(), "w") as f:
+            json.dump({ENABLE_ALL_KEY: True}, f)
+        assert get_mcpjson_server_status("alpha", cwd=str(project)) == "approved"
+        # Local disable still beats the user-tier blanket enable.
+        record_mcpjson_choice("alpha", "disable", cwd=str(project))
+        assert get_mcpjson_server_status("alpha", cwd=str(project)) == "rejected"
+
+    def test_non_list_settings_values_ignored_not_mangled(
+        self, project
+    ) -> None:
+        path = project / ".clawcodex" / "settings.local.json"
+        path.parent.mkdir(exist_ok=True)
+        path.write_text(json.dumps({ENABLED_KEY: "alpha"}))
+        # A string value must not be iterated as characters.
+        assert get_mcpjson_server_status("a", cwd=str(project)) == "pending"
+        record_mcpjson_choice("beta", "enable", cwd=str(project))
+        assert json.loads(path.read_text())[ENABLED_KEY] == ["beta"]
+
+
+@pytest.mark.asyncio
+async def test_approval_screen_choices() -> None:
+    pytest.importorskip("textual")
+    import asyncio
+
+    from textual.app import App, ComposeResult
+    from textual.screen import Screen
+    from textual.widgets import Static
+
+    from src.tui.screens.mcp_approval import McpApprovalScreen
+
+    class _Host(Screen):
+        def compose(self) -> ComposeResult:
+            yield Static("host")
+
+    class _App(App):
+        def on_mount(self) -> None:
+            self.push_screen(_Host())
+
+    for presses, expected in (
+        (("enter",), "enable"),
+        (("down", "enter"), "enable_all"),
+        (("down", "down", "enter"), "disable"),
+        (("escape",), None),
+    ):
+        app = _App()
+        async with app.run_test() as pilot:
+            loop = asyncio.get_running_loop()
+            future: asyncio.Future = loop.create_future()
+            app.push_screen(
+                McpApprovalScreen("alpha"),
+                callback=lambda r: future.set_result(r),
+            )
+            await pilot.pause()
+            for key in presses:
+                await pilot.press(key)
+            result = await asyncio.wait_for(future, timeout=5)
+        assert result == expected, (presses, result)
+
+
+class TestAppApprovalChain:
+    def _fake(self, tmp_path):
+        from src.tui.app import ClawCodexTUI
+
+        rows: list[str] = []
+        pushes: list[tuple] = []
+        fake = SimpleNamespace(
+            workspace_root=tmp_path,
+            _repl_screen=SimpleNamespace(
+                transcript=SimpleNamespace(
+                    append_system=lambda text, style="muted": rows.append(text)
+                )
+            ),
+            push_screen=lambda screen, callback=None: pushes.append(
+                (screen, callback)
+            ),
+        )
+        # Wire the real chain methods onto the fake so _on_mcp_approval's
+        # tail call exercises production control flow.
+        fake._prompt_next_mcp_approval = (
+            lambda queue: ClawCodexTUI._prompt_next_mcp_approval(fake, queue)
+        )
+        fake._on_mcp_approval = (
+            lambda name, choice, queue: ClawCodexTUI._on_mcp_approval(
+                fake, name, choice, queue
+            )
+        )
+        return fake, rows, pushes
+
+    def test_enable_persists_and_chains_to_next(self, project) -> None:
+        fake, rows, pushes = self._fake(project)
+        fake._on_mcp_approval("alpha", "enable", ["beta"])
+        assert get_mcpjson_server_status("alpha", cwd=str(project)) == "approved"
+        assert len(pushes) == 1  # beta prompted next
+        assert any("'alpha' enabled" in r for r in rows)
+
+    def test_enable_all_clears_queue(self, project) -> None:
+        fake, rows, pushes = self._fake(project)
+        queue = ["beta", "gamma"]
+        fake._on_mcp_approval("alpha", "enable_all", queue)
+        assert queue == []
+        assert len(pushes) == 0  # nothing further prompted
+        assert _settings(project)[ENABLE_ALL_KEY] is True
+        assert any("All .mcp.json servers" in r for r in rows)
+
+    def test_pending_row_on_escape(self, project) -> None:
+        fake, rows, pushes = self._fake(project)
+        fake._on_mcp_approval("alpha", None, [])
+        assert get_mcpjson_server_status("alpha", cwd=str(project)) == "pending"
+        assert any("left pending" in r for r in rows)
+
+    def test_already_decided_queue_entry_skipped(self, project) -> None:
+        fake, rows, pushes = self._fake(project)
+        record_mcpjson_choice("beta", "enable", cwd=str(project))
+        fake._prompt_next_mcp_approval(["beta", "alpha"])
+        # beta was decided out-of-band — only alpha gets a dialog.
+        assert len(pushes) == 1
+        assert pushes[0][0]._server_name == "alpha"
+
+    def test_write_failure_reports_honestly(self, project, monkeypatch) -> None:
+        import src.services.mcp_approval as approval_mod
+
+        monkeypatch.setattr(
+            approval_mod, "_write_local_settings", lambda *a, **k: False
+        )
+        fake, rows, pushes = self._fake(project)
+        fake._on_mcp_approval("alpha", "enable_all", ["beta"])
+        assert not any("enabled" in r for r in rows)
+        assert any("Could not save" in r for r in rows)
+        # The failed enable_all must NOT clear the queue — beta still asked.
+        assert len(pushes) == 1


### PR DESCRIPTION
## Summary
- Ports the TS `.mcp.json` approval feature (`MCPServerApprovalDialog.tsx` + `getProjectMcpServerStatus`, utils.ts:351-390): repo-declared MCP servers (scopes `project`+`local`) are untrusted until the user approves, with status precedence disabled→rejected, enabled→approved, enableAll→approved, else pending; decisions persist to `.clawcodex/settings.local.json`.
- Enforcement at both choke points in `services/mcp/config`: `get_all_mcp_configs` filters `.mcp.json` scopes **pre-merge** (fixes a critic-reproduced bug where an unapproved repo server name-colliding with a user-scope server knocked both out), and `get_mcp_config_by_name` gates per-name resolves (reconnect/OAuth path). Pending → warning notice via the ValidationError channel (/doctor); rejected → silent drop.
- TUI: `McpApprovalScreen` chained at boot per pending server (enable / enable all / disable; Esc = decide later, re-asked next launch); `enable_all` short-circuits the queue; settings-write failures report honestly and keep servers pending.
- Settings read is merged user→local per TS semantics (lists unioned, scalars last-win); the **project tier is deliberately excluded** so a repo cannot self-approve via committed settings — documented safer-than-TS deviation.
- Elicitation declared GATED (MCP client has no server→client request support); gap doc T12 corrected, plan §7 updated.

## Test plan
- [x] 20 new tests: status precedence + persistence round-trips, normalization identity, pending enumeration, pre-merge enforcement end-to-end through the real `get_all_mcp_configs`, cross-scope shadowing regression, by-name gate, user-tier enableAll, non-list value guards, screen pilot (all four outcomes via real key presses), boot-chain behaviors incl. write-failure honesty
- [x] TUI + services + MCP suites: 893 passed (2 pre-existing PATH-dependent failures, stash-verified on base)
- [x] Full suite BASELINE-IDENTICAL vs the 12 known pre-existing failures
- [x] Critic loop: REQUEST CHANGES (3 MAJOR / 5 MINOR / 2 NIT) → all fixed → APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)