### PR TITLE
components C8: startup security gates (trust / includes / bypass)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -234,6 +234,76 @@ class ConfigManager:
 
 
 # ---------------------------------------------------------------------------
+# Per-project state in the GLOBAL config (TS config.projects[path])
+# ---------------------------------------------------------------------------
+# TS keeps per-project security state (hasTrustDialogAccepted,
+# hasClaudeMdExternalIncludesApproved, ...) in the USER-owned global
+# config keyed by project path — deliberately NOT in the committable
+# project config, so a checked-out repo can never pre-accept its own
+# trust prompts. Same here: ``~/.clawcodex/config.json`` → "projects".
+
+_PROJECTS_KEY = "projects"
+
+
+def _global_config_file() -> Path:
+    # Resolve through the module attribute at call time so test
+    # isolation that re-points GLOBAL_CONFIG_DIR covers these helpers.
+    return Path(GLOBAL_CONFIG_DIR) / "config.json"
+
+
+def normalize_path_for_config_key(path: str | Path) -> str:
+    """Canonical absolute path used as a ``projects`` map key."""
+
+    return str(Path(path).resolve())
+
+
+def get_project_path_for_config(cwd: str | Path | None = None) -> str:
+    """Where per-project state is keyed: git root if in a repo, else cwd
+    (TS ``getProjectPathForConfig``)."""
+
+    root = _find_git_root(cwd)
+    if root is not None:
+        return normalize_path_for_config_key(root)
+    return normalize_path_for_config_key(cwd or Path.cwd())
+
+
+def get_project_entry(project_path: str | Path) -> dict[str, Any]:
+    """The global-config ``projects[path]`` entry ({} if absent)."""
+
+    config = _read_json(_global_config_file())
+    projects = config.get(_PROJECTS_KEY)
+    if not isinstance(projects, dict):
+        return {}
+    entry = projects.get(normalize_path_for_config_key(project_path))
+    return entry if isinstance(entry, dict) else {}
+
+
+def update_project_entry(
+    project_path: str | Path, updates: dict[str, Any]
+) -> bool:
+    """Merge *updates* into ``projects[path]`` in the global config."""
+
+    path = _global_config_file()
+    config = _read_json(path)
+    projects = config.get(_PROJECTS_KEY)
+    if not isinstance(projects, dict):
+        projects = {}
+    key = normalize_path_for_config_key(project_path)
+    entry = projects.get(key)
+    if not isinstance(entry, dict):
+        entry = {}
+    entry.update(updates)
+    projects[key] = entry
+    config[_PROJECTS_KEY] = projects
+    try:
+        _atomic_write_json(path, config)
+    except OSError:
+        return False
+    _get_default_manager().invalidate()
+    return True
+
+
+# ---------------------------------------------------------------------------
 # History (JSONL paste history)
 # ---------------------------------------------------------------------------
 

--- a/src/context_system/claude_md.py
+++ b/src/context_system/claude_md.py
@@ -41,6 +41,11 @@ logger = logging.getLogger(__name__)
 
 _memory_files_cache: list[MemoryFileInfo] | None = None
 _memory_files_cache_key: str | None = None
+# Per-cwd memo of the C8 external-includes approval. The lookup behind
+# it shells out (git rev-parse) and reads the global config — far too
+# heavy per get_memory_files call. record_external_includes_choice
+# clears all caches, so in-process flips are still picked up.
+_external_includes_approval_cache: dict[str, bool] = {}
 
 
 def clear_memory_file_caches() -> None:
@@ -48,6 +53,7 @@ def clear_memory_file_caches() -> None:
     global _memory_files_cache, _memory_files_cache_key
     _memory_files_cache = None
     _memory_files_cache_key = None
+    _external_includes_approval_cache.clear()
 
 
 def reset_get_memory_files_cache() -> None:
@@ -336,6 +342,40 @@ def _path_in_working_path(path: str, working_path: str) -> bool:
         return False
 
 
+def _external_includes_approved(original_cwd: str) -> bool:
+    """C8: ``projects[path].hasClaudeMdExternalIncludesApproved`` from
+    the user-owned global config (TS getCurrentProjectConfig)."""
+
+    cached = _external_includes_approval_cache.get(original_cwd)
+    if cached is not None:
+        return cached
+    try:
+        from src import config as config_mod
+
+        entry = config_mod.get_project_entry(
+            config_mod.get_project_path_for_config(original_cwd)
+        )
+        approved = bool(entry.get("hasClaudeMdExternalIncludesApproved"))
+    except Exception:
+        approved = False
+    _external_includes_approval_cache[original_cwd] = approved
+    return approved
+
+
+def is_external_memory_file(
+    info: MemoryFileInfo, cwd: str | None = None
+) -> bool:
+    """TS getExternalClaudeMdIncludes predicate (claudemd.ts:1427-1437):
+    a non-User-tier INCLUDED file (has a parent) living outside the
+    original cwd. The User tier is excluded — the user's own
+    ~/CLAUDE.md may include anything without triggering the project
+    gate."""
+
+    if info.type == "User" or not info.parent:
+        return False
+    return not _path_in_working_path(info.path, cwd or _get_original_cwd())
+
+
 # ---------------------------------------------------------------------------
 # get_memory_files — main entry point (mirrors TS getMemoryFiles)
 # ---------------------------------------------------------------------------
@@ -356,14 +396,21 @@ async def get_memory_files(
     global _memory_files_cache, _memory_files_cache_key
 
     original_cwd = cwd or _get_original_cwd()
-    cache_key = f"{original_cwd}:{force_include_external}"
+    # TS claudemd.ts:812-815: externals load when forced (the gate's
+    # detection pass) OR when this project approved them via the C8
+    # external-includes dialog. The cache keys on the EFFECTIVE value
+    # so an approval recorded mid-session isn't masked by a stale
+    # pre-approval entry.
+    include_external = force_include_external or _external_includes_approved(
+        original_cwd
+    )
+    cache_key = f"{original_cwd}:{include_external}"
 
     if _memory_files_cache is not None and _memory_files_cache_key == cache_key:
         return list(_memory_files_cache)
 
     result: list[MemoryFileInfo] = []
     processed_paths: set[str] = set()
-    include_external = force_include_external
 
     home = str(Path.home())
 

--- a/src/entrypoints/tui.py
+++ b/src/entrypoints/tui.py
@@ -58,12 +58,17 @@ def run_tui(options: TUIOptions) -> int:
             2,
         )
 
-    # ``is_interactive`` is set during bootstrap phase 2 by
+    # ``is_interactive`` is normally set during bootstrap phase 2 by
     # ``src.init.run_pre_action`` (called from ``cli.main``) before any
-    # entry point runs. Previously we set it here too, but that was the
-    # M7.1 gap closed in plan phase 1 of ch02-bootstrap. The TUI
-    # entrypoint can rely on ``get_is_interactive()`` already being
-    # ``True`` by the time this function runs.
+    # entry point runs. C8 re-asserts it here defensively: the bootstrap
+    # DEFAULT is non-interactive, and since the .mcp.json approval gate
+    # auto-approves non-interactive sessions (TS utils.ts:399-403), a
+    # future caller booting run_tui without the CLI bootstrap would
+    # otherwise silently auto-approve repo MCP servers inside an
+    # interactive UI.
+    from src.bootstrap.state import set_is_interactive
+
+    set_is_interactive(True)
     workspace_root = options.workspace_root or Path.cwd()
 
     # Build provider ------------------------------------------------------
@@ -156,7 +161,10 @@ def run_tui(options: TUIOptions) -> int:
         app.run(inline=True, inline_no_clear=True, mouse=False)
     except KeyboardInterrupt:
         return 130
-    return 0
+    # C8: startup gates exit via app.exit(return_code=...) — declining
+    # the trust or bypass dialog must propagate a non-zero exit code to
+    # the shell (TS gracefulShutdownSync(1)).
+    return app.return_code or 0
 
 
 def _replay_transcript_to_host(app) -> None:

--- a/src/init.py
+++ b/src/init.py
@@ -155,14 +155,19 @@ def run_pre_action(args: object) -> None:
     set_is_interactive(_determine_is_interactive(args))
     set_client_type(_determine_client_type())
 
-    # Plan phase 1 default: trust the current directory until the
-    # trust-dialog ships in plan phase 2/3 (see A4 working assumption).
-    # Propagating the implicit "trusted" decision through the existing
-    # state setter keeps ``hooks/trust_gate.py`` and
-    # ``tool_system/context.py:workspace_trusted`` consumers behaving
-    # correctly.
-    # TODO(plan-phase-2): replace with checkHasTrustDialogAccepted()
-    # analog once the trust dialog ships.
+    # The trust dialog SHIPPED (components C8:
+    # ``services/startup_gates.check_trust_accepted`` + the TUI's
+    # TrustFolderScreen), but this placeholder must outlive it: the TUI
+    # is the only surface with a dialog — headless / -p / legacy-REPL
+    # sessions have no way to ask, and flipping the default to
+    # untrusted would hard-block their ``hooks/trust_gate.py`` and
+    # ``tool_system/context.py:workspace_trusted`` consumers with no
+    # way to consent. The dialog's accept path syncs this same flag via
+    # ``record_trust_accepted``, so narrowing this later only requires
+    # seeding interactive sessions from check_trust_accepted() here.
+    # TODO(components-C8 follow-up): seed from
+    # ``startup_gates.check_trust_accepted()`` for interactive sessions
+    # instead of unconditionally trusting.
     set_session_trust_accepted(True)
 
     profile_checkpoint("pre_action_end")

--- a/src/services/mcp_approval.py
+++ b/src/services/mcp_approval.py
@@ -40,9 +40,11 @@ Both gates sit on the choke points every current and future consumer
 (doctor, /mcp, the eventual runtime mount) reads through; non-TUI
 sessions get warning notices for pending servers instead of a prompt.
 
-Deferred (documented): the TS bypass-mode auto-approve branch reads
-``skipDangerousModePermissionPrompt`` — that key lands with the C8
-bypass gate; until then bypass sessions see the same skip-with-warning.
+C8 update (was deferred in C7): the TS auto-approve branches are now
+ported — ``skipDangerousModePermissionPrompt`` (the C8 bypass-dialog
+acceptance) and non-interactive sessions both resolve to ``approved``
+(TS utils.ts:377-403), so headless/SDK runs match TS instead of the
+C7 interim skip-with-warning.
 """
 
 from __future__ import annotations
@@ -52,6 +54,7 @@ import os
 from typing import Any
 
 from src.services.mcp.normalization import normalize_name_for_mcp
+from src.services.startup_gates import _read_json_dict
 
 ENABLED_KEY = "enabledMcpjsonServers"
 DISABLED_KEY = "disabledMcpjsonServers"
@@ -64,15 +67,6 @@ def _local_settings_path(cwd: str | None = None) -> str:
     from src.permissions import settings_paths
 
     return settings_paths.local_settings_path(cwd)
-
-
-def _read_json_dict(path: str) -> dict[str, Any]:
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-    except (OSError, ValueError):
-        return {}
-    return data if isinstance(data, dict) else {}
 
 
 def _read_merged_settings(cwd: str | None = None) -> dict[str, Any]:
@@ -127,6 +121,34 @@ def get_mcpjson_server_status(
         return "approved"
     if settings.get(ENABLE_ALL_KEY) is True:
         return "approved"
+    # TS utils.ts:377-403 (deferred from C7, unlocked by C8): two
+    # auto-approve branches where no approval popup can be shown.
+    # (1) The user accepted the bypass-permissions dialog at some point
+    #     (skipDangerousModePermissionPrompt — read from user/local
+    #     settings only; TS explicitly excludes the project tier so a
+    #     repo cannot accept on the user's behalf).
+    # (2) Non-interactive session (SDK / -p / piped input) — the user
+    #     explicitly chose that mode and its docs warn to use trusted
+    #     directories only.
+    # TS additionally gates both on isSettingSourceEnabled(
+    # 'projectSettings'); this port has no setting-source disabling, so
+    # that condition is always true here.
+    try:
+        from src.services.startup_gates import (
+            has_skip_dangerous_mode_permission_prompt,
+        )
+
+        if has_skip_dangerous_mode_permission_prompt(cwd):
+            return "approved"
+    except Exception:
+        pass
+    try:
+        from src.bootstrap.state import get_is_non_interactive_session
+
+        if get_is_non_interactive_session():
+            return "approved"
+    except Exception:
+        pass
     return "pending"
 
 

--- a/src/services/startup_gates.py
+++ b/src/services/startup_gates.py
@@ -1,0 +1,289 @@
+"""Startup security gates (components C8) — UI-neutral state layer.
+
+Three gates, ported from the TS startup flow (interactiveHelpers.tsx:
+trust :139-143, CLAUDE.md external includes :174-179, bypass
+acceptance :228-232), in that order:
+
+1. **Folder trust** (TS ``TrustDialog`` + ``config.ts
+   checkHasTrustDialogAccepted`` :771-817): per-project flag
+   ``hasTrustDialogAccepted`` in the USER-owned global config's
+   ``projects[path]`` map — never in a committable file, so a repo
+   cannot pre-trust itself. Trust at a directory implies trust for its
+   children (parent-walk on read). Home-directory sessions are trusted
+   for the SESSION only (TS ``setSessionTrustAccepted``) — persisting
+   trust for ``$HOME`` would blanket-trust everything under it.
+   Decline exits with code 1.
+
+2. **External CLAUDE.md includes** (TS
+   ``ClaudeMdExternalIncludesDialog`` :120-132): per-project boolean
+   pair — ``hasClaudeMdExternalIncludesApproved`` +
+   ``hasClaudeMdExternalIncludesWarningShown``. Asked once (yes/no both
+   set WarningShown); the loader (``context_system/claude_md.py``)
+   includes externals only when approved. Non-interactive sessions
+   never load unapproved externals (TS parity: silent skip — the
+   include flag simply stays false).
+
+3. **Bypass-permissions acceptance** (TS
+   ``BypassPermissionsModeDialog.tsx`` :31-40): shown when
+   bypassPermissions mode is requested and
+   ``skipDangerousModePermissionPrompt`` is not already true. Accept
+   persists ``skipDangerousModePermissionPrompt: true`` to the USER
+   settings file (TS ``updateSettingsForSource("userSettings", ...)``);
+   decline exits 1; Esc exits 0 (TS ``_temp2`` →
+   ``gracefulShutdownSync(0)``). TS reads the flag from
+   user/local/flag/policy settings sources — this port models the user
+   and local tiers (flag/policy sources don't exist here; the project
+   tier is excluded in TS too, explicitly: a repo must not accept the
+   bypass dialog on the user's behalf).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+TRUST_KEY = "hasTrustDialogAccepted"
+INCLUDES_APPROVED_KEY = "hasClaudeMdExternalIncludesApproved"
+INCLUDES_WARNING_SHOWN_KEY = "hasClaudeMdExternalIncludesWarningShown"
+SKIP_DANGEROUS_PROMPT_KEY = "skipDangerousModePermissionPrompt"
+
+# Session-only trust for the home-directory case (TS bootstrap/state
+# setSessionTrustAccepted). Module state: one process == one session.
+_session_trust_accepted = False
+
+
+def reset_session_trust_for_testing() -> None:
+    global _session_trust_accepted
+    _session_trust_accepted = False
+
+
+# ---------------------------------------------------------------------------
+# Gate 1: folder trust
+# ---------------------------------------------------------------------------
+
+def check_trust_accepted(cwd: str | Path | None = None) -> bool:
+    """TS ``computeTrustDialogAccepted``: session trust, then cwd and
+    every parent. (TS also pre-checks the projectPath key location, but
+    the git root is normally an ancestor-or-self of the resolved cwd,
+    so the parent walk subsumes it — and skipping it saves a git
+    subprocess per check. Known edge: GIT_WORK_TREE/GIT_DIR redirection
+    can yield a non-ancestor root; trust recorded there is then missed
+    and the dialog re-asks — fails safe, never silently trusts.)"""
+
+    if _session_trust_accepted:
+        return True
+
+    from src import config as config_mod
+
+    current = Path(config_mod.normalize_path_for_config_key(cwd or Path.cwd()))
+    while True:
+        if config_mod.get_project_entry(current).get(TRUST_KEY):
+            return True
+        parent = current.parent
+        if parent == current:
+            return False
+        current = parent
+
+
+def record_trust_accepted(cwd: str | Path | None = None) -> bool:
+    """Persist acceptance (TS TrustDialog.tsx:172-178). Home directory
+    → session-only; everything else → ``projects[path]`` entry."""
+
+    global _session_trust_accepted
+    _session_trust_accepted = True
+    # Keep the BOOTSTRAP session-trust flag (the port of the same TS
+    # symbol, consumed by hooks/trust_gate.py and
+    # tool_system/context.workspace_trusted) in sync — today init.py
+    # pre-sets it True for every entrypoint, but once that placeholder
+    # narrows, an accepted dialog must still propagate trust there.
+    try:
+        from src.bootstrap.state import set_session_trust_accepted
+
+        set_session_trust_accepted(True)
+    except Exception:
+        pass
+
+    from src import config as config_mod
+
+    resolved_cwd = Path(
+        config_mod.normalize_path_for_config_key(cwd or Path.cwd())
+    )
+    try:
+        home = Path.home().resolve()
+    except (OSError, RuntimeError):
+        home = None
+    if home is not None and resolved_cwd == home:
+        return True  # session-only, by design
+
+    project_path = config_mod.get_project_path_for_config(cwd)
+    return config_mod.update_project_entry(project_path, {TRUST_KEY: True})
+
+
+def collect_trust_warnings(cwd: str | Path | None = None) -> list[str]:
+    """Degraded port of the TS trust dialog's warning enumeration.
+
+    TS lists eight source kinds (hooks, bash allow rules, apiKeyHelper,
+    AWS/GCP commands, OTel headers, dangerous env vars, slash-command
+    bash). This port only models two of those subsystems today, so only
+    those two are checked — bash allow rules and statusLine commands in
+    the committable settings tiers. Never invent warnings for absent
+    subsystems.
+    """
+
+    from src.permissions import settings_paths
+
+    warnings: list[str] = []
+    cwd_str = str(cwd) if cwd is not None else None
+    for label, path in (
+        (".clawcodex/settings.json", settings_paths.project_settings_path(cwd_str)),
+        (
+            ".clawcodex/settings.local.json",
+            settings_paths.local_settings_path(cwd_str),
+        ),
+    ):
+        data = _read_json_dict(path)
+        if not data:
+            continue
+        permissions = data.get("permissions")
+        allow = (
+            permissions.get("allow") if isinstance(permissions, dict) else None
+        )
+        if isinstance(allow, list) and any(
+            isinstance(rule, str) and rule.startswith("Bash") for rule in allow
+        ):
+            warnings.append(f"{label} pre-allows Bash commands")
+        if data.get("statusLine"):
+            warnings.append(f"{label} configures a status-line command")
+    return warnings
+
+
+# ---------------------------------------------------------------------------
+# Gate 2: external CLAUDE.md includes
+# ---------------------------------------------------------------------------
+
+def get_external_includes_state(cwd: str | Path | None = None) -> str:
+    """``approved`` | ``declined`` | ``unset`` for this project."""
+
+    from src import config as config_mod
+
+    entry = config_mod.get_project_entry(
+        config_mod.get_project_path_for_config(cwd)
+    )
+    if entry.get(INCLUDES_APPROVED_KEY):
+        return "approved"
+    if entry.get(INCLUDES_WARNING_SHOWN_KEY):
+        return "declined"
+    return "unset"
+
+
+def record_external_includes_choice(
+    approved: bool, cwd: str | Path | None = None
+) -> bool:
+    """TS dialog updaters _temp2/_temp3: both choices mark the warning
+    shown; only "yes" approves."""
+
+    from src import config as config_mod
+
+    ok = config_mod.update_project_entry(
+        config_mod.get_project_path_for_config(cwd),
+        {
+            INCLUDES_APPROVED_KEY: bool(approved),
+            INCLUDES_WARNING_SHOWN_KEY: True,
+        },
+    )
+    if ok:
+        # The loader memo AND the assembled-context memo both embed the
+        # external-include decision; clear both so an approval recorded
+        # mid-session takes effect on the next prompt, not next launch.
+        from src.context_system.claude_md import clear_memory_file_caches
+
+        clear_memory_file_caches()
+        try:
+            from src.context_system.prompt_assembly import (
+                clear_context_caches,
+            )
+
+            clear_context_caches()
+        except Exception:
+            pass
+    return ok
+
+
+async def list_external_includes(cwd: str | Path | None = None) -> list[str]:
+    """Paths of external @includes that WOULD load if approved (TS
+    hasExternalClaudeMdIncludes over ``getMemoryFiles(true)``)."""
+
+    from src.context_system.claude_md import (
+        get_memory_files,
+        is_external_memory_file,
+    )
+
+    cwd_str = str(cwd) if cwd is not None else None
+    files = await get_memory_files(cwd=cwd_str, force_include_external=True)
+    return [f.path for f in files if is_external_memory_file(f, cwd=cwd_str)]
+
+
+# ---------------------------------------------------------------------------
+# Gate 3: bypass-permissions acceptance
+# ---------------------------------------------------------------------------
+
+def _read_json_dict(path: str) -> dict[str, Any]:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def has_skip_dangerous_mode_permission_prompt(
+    cwd: str | Path | None = None,
+) -> bool:
+    from src.permissions import settings_paths
+
+    cwd_str = str(cwd) if cwd is not None else None
+    for path in (
+        settings_paths.user_settings_path(),
+        settings_paths.local_settings_path(cwd_str),
+    ):
+        if _read_json_dict(path).get(SKIP_DANGEROUS_PROMPT_KEY) is True:
+            return True
+    return False
+
+
+def record_bypass_accepted() -> bool:
+    """Persist ``skipDangerousModePermissionPrompt: true`` to the USER
+    settings file (TS updateSettingsForSource("userSettings", ...))."""
+
+    from src.permissions import settings_paths
+
+    path = settings_paths.user_settings_path()
+    data = _read_json_dict(path)
+    data[SKIP_DANGEROUS_PROMPT_KEY] = True
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        return True
+    except OSError:
+        return False
+
+
+__all__ = [
+    "INCLUDES_APPROVED_KEY",
+    "INCLUDES_WARNING_SHOWN_KEY",
+    "SKIP_DANGEROUS_PROMPT_KEY",
+    "TRUST_KEY",
+    "check_trust_accepted",
+    "collect_trust_warnings",
+    "get_external_includes_state",
+    "has_skip_dangerous_mode_permission_prompt",
+    "list_external_includes",
+    "record_bypass_accepted",
+    "record_external_includes_choice",
+    "record_trust_accepted",
+    "reset_session_trust_for_testing",
+]

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -222,14 +222,185 @@ class ClawCodexTUI(App):
         except Exception:
             pass
         self._state_unsub = self.app_state.subscribe(self._on_state_change)
+        # C8 → C6 → C7 boot chain, strictly sequential: the security
+        # gates (trust → external includes → bypass acceptance; TS
+        # interactiveHelpers order) must resolve BEFORE the .mcp.json
+        # approval prompts — a user who hasn't trusted the folder yet
+        # must not be asked to enable its MCP servers first.
+        self.call_after_refresh(self._run_startup_chain)
+
+    # ---- C8 startup security gates ---------------------------------------
+    def _run_startup_chain(self) -> None:
+        self._startup_gate_trust()
+
+    def _startup_gate_trust(self) -> None:
+        try:
+            from src.services.startup_gates import check_trust_accepted
+
+            needed = not check_trust_accepted()
+        except Exception:
+            # Fail CLOSED: a consent gate that errors must ask, not
+            # silently wave the folder through.
+            needed = True
+        if not needed:
+            self._startup_gate_includes()
+            return
+        from src.tui.screens.startup_gates import TrustFolderScreen
+
+        try:
+            from src.services.startup_gates import collect_trust_warnings
+
+            warnings = collect_trust_warnings()
+        except Exception:
+            warnings = []
+        self.push_screen(
+            TrustFolderScreen(str(self.workspace_root), warnings),
+            callback=self._on_trust_choice,
+        )
+
+    def _on_trust_choice(self, choice: str | None) -> None:
+        if choice != "trust":
+            # TS TrustDialog "No, exit" → gracefulShutdownSync(1).
+            self.exit(return_code=1)
+            return
+        persisted = False
+        try:
+            from src.services.startup_gates import record_trust_accepted
+
+            persisted = record_trust_accepted()
+        except Exception:
+            persisted = False
+        if not persisted and self._repl_screen is not None:
+            self._repl_screen.transcript.append_system(
+                "Folder trusted for this session only — could not write "
+                "the global config; you'll be asked again next launch.",
+                style="muted",
+            )
+        self._startup_gate_includes()
+
+    def _startup_gate_includes(self) -> None:
+        try:
+            from src.services.startup_gates import (
+                get_external_includes_state,
+            )
+
+            state = get_external_includes_state()
+        except Exception:
+            state = "declined"  # fail safe: no prompt, no external load
+        if state != "unset":
+            self._startup_gate_bypass()
+            return
+        self.run_worker(
+            self._detect_external_includes(),
+            exclusive=False,
+            name="c8-external-includes",
+        )
+
+    async def _detect_external_includes(self) -> None:
+        try:
+            from src.services.startup_gates import list_external_includes
+
+            externals = await list_external_includes()
+        except Exception:
+            externals = []
+        if not externals:
+            # Nothing external to approve — the question never arises
+            # (TS shows the dialog only when externals exist).
+            self._startup_gate_bypass()
+            return
+        from src.tui.screens.startup_gates import ExternalIncludesScreen
+
+        self.push_screen(
+            ExternalIncludesScreen(externals),
+            callback=self._on_includes_choice,
+        )
+
+    def _on_includes_choice(self, choice: str | None) -> None:
+        approved = choice == "yes"
+        persisted = False
+        try:
+            from src.services.startup_gates import (
+                record_external_includes_choice,
+            )
+
+            persisted = record_external_includes_choice(approved)
+        except Exception:
+            persisted = False
+        if self._repl_screen is not None:
+            transcript = self._repl_screen.transcript
+            if not persisted:
+                transcript.append_system(
+                    "Could not save the external-imports choice — "
+                    "you'll be asked again next launch.",
+                    style="muted",
+                )
+            elif approved:
+                transcript.append_system(
+                    "External CLAUDE.md imports enabled for this project.",
+                    style="muted",
+                )
+            else:
+                transcript.append_system(
+                    "External CLAUDE.md imports disabled for this project.",
+                    style="muted",
+                )
+        self._startup_gate_bypass()
+
+    def _startup_gate_bypass(self) -> None:
+        mode = getattr(
+            getattr(self.tool_context, "permission_context", None),
+            "mode",
+            "default",
+        )
+        if mode != "bypassPermissions":
+            self._finish_startup_gates()
+            return
+        try:
+            from src.services.startup_gates import (
+                has_skip_dangerous_mode_permission_prompt,
+            )
+
+            already_accepted = has_skip_dangerous_mode_permission_prompt()
+        except Exception:
+            already_accepted = False
+        if already_accepted:
+            self._finish_startup_gates()
+            return
+        from src.tui.screens.startup_gates import BypassPermissionsScreen
+
+        self.push_screen(
+            BypassPermissionsScreen(), callback=self._on_bypass_choice
+        )
+
+    def _on_bypass_choice(self, choice: str | None) -> None:
+        if choice == "accept":
+            persisted = False
+            try:
+                from src.services.startup_gates import record_bypass_accepted
+
+                persisted = record_bypass_accepted()
+            except Exception:
+                persisted = False
+            if not persisted and self._repl_screen is not None:
+                self._repl_screen.transcript.append_system(
+                    "Could not persist the bypass acceptance — you'll be "
+                    "asked again next launch.",
+                    style="muted",
+                )
+            self._finish_startup_gates()
+            return
+        # TS: explicit "No, exit" → exit 1; Esc (or any non-answer
+        # dismissal) → exit 0.
+        self.exit(return_code=1 if choice == "decline" else 0)
+
+    def _finish_startup_gates(self) -> None:
         # C6: surface ignored/malformed config files as startup rows
         # (TS StatusNotices / InvalidSettingsDialog family — Python's
         # loader silently falls back to {}, so warn honestly instead).
-        self.call_after_refresh(self._show_config_warnings)
+        self._show_config_warnings()
         # C7: prompt for any pending .mcp.json servers (TS
-        # handleMcpjsonServerApprovals — gated like TS: only after a
-        # clean settings read, which C6's warnings have just reported).
-        self.call_after_refresh(self._run_mcp_approvals)
+        # handleMcpjsonServerApprovals).
+        self._run_mcp_approvals()
 
     # ---- C7 .mcp.json server approvals ----------------------------------
     # cwd note: approvals deliberately key off the process cwd (the

--- a/src/tui/screens/__init__.py
+++ b/src/tui/screens/__init__.py
@@ -23,15 +23,22 @@ from .resume_conversation import (
     ResumeEntry,
     build_resume_entries,
 )
+from .startup_gates import (
+    BypassPermissionsScreen,
+    ExternalIncludesScreen,
+    TrustFolderScreen,
+)
 from .theme_picker import ThemePickerScreen
 from .workspace_search import GlobalSearchScreen, QuickOpenScreen
 
 __all__ = [
+    "BypassPermissionsScreen",
     "CostThresholdScreen",
     "DialogScreen",
     "DiffDialogScreen",
     "EffortPickerScreen",
     "ExitFlowScreen",
+    "ExternalIncludesScreen",
     "FileDiff",
     "GlobalSearchScreen",
     "HistoryEntry",
@@ -51,6 +58,7 @@ __all__ = [
     "ResumeEntry",
     "ThemePickerScreen",
     "TranscriptMessage",
+    "TrustFolderScreen",
     "build_resume_entries",
     "fuzzy_score",
 ]

--- a/src/tui/screens/startup_gates.py
+++ b/src/tui/screens/startup_gates.py
@@ -1,0 +1,203 @@
+"""Startup security-gate dialogs (components C8).
+
+Three boot-time screens, TS-faithful copy and outcomes:
+
+* :class:`TrustFolderScreen` — TS ``TrustDialog.tsx``; dismisses
+  ``"trust"`` or ``"exit"`` (Esc = exit too: the gate cannot be
+  bypassed by closing the dialog).
+* :class:`ExternalIncludesScreen` — TS
+  ``ClaudeMdExternalIncludesDialog.tsx``; dismisses ``"yes"`` or
+  ``"no"``; Esc maps to ``"no"`` (TS handleEscape → selection "no").
+* :class:`BypassPermissionsScreen` — TS
+  ``BypassPermissionsModeDialog.tsx``; dismisses ``"accept"``,
+  ``"decline"`` (exit 1) or ``"escape"`` (TS _temp2 →
+  gracefulShutdownSync(0)).
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+from rich.text import Text
+from textual.widget import Widget
+from textual.widgets import Static
+
+from src.tui.widgets.select_list import SelectList, SelectOption
+
+from .dialog_base import DialogScreen
+
+
+class TrustFolderScreen(DialogScreen[str]):
+    """First-launch folder trust gate."""
+
+    title_text = "Accessing workspace:"
+    footer_hint = "Enter selects · Esc exits"
+    border_variant = "warning"
+
+    def __init__(self, folder: str, warnings: list[str] | None = None) -> None:
+        super().__init__()
+        self._folder = folder
+        self._warnings = list(warnings or [])
+        self._select: SelectList | None = None
+
+    def build_body(self) -> Iterator[Widget]:
+        yield Static(Text(self._folder, style="bold"), markup=False)
+        yield Static(
+            Text(
+                "Quick safety check: Is this a project you created or one "
+                "you trust? (Like your own code, a well-known open source "
+                "project, or work from your team). If not, take a moment "
+                "to review what's in this folder first.",
+                style="dim",
+            ),
+            markup=False,
+        )
+        for warning in self._warnings:
+            yield Static(Text(f"  ! {warning}", style="yellow"), markup=False)
+        self._select = SelectList(
+            [
+                SelectOption(label="Yes, I trust this folder", value="trust"),
+                SelectOption(label="No, exit", value="exit"),
+            ],
+            allow_cancel=True,
+        )
+        yield self._select
+
+    def _post_mount(self) -> None:
+        if self._select is not None:
+            self._select.focus()
+
+    def on_select_list_option_selected(
+        self, event: SelectList.OptionSelected
+    ) -> None:
+        self.dismiss(str(event.option.value))
+
+    def on_select_list_selection_cancelled(
+        self, _: SelectList.SelectionCancelled
+    ) -> None:
+        # Trust cannot be deferred — closing the dialog is declining.
+        self.dismiss("exit")
+
+
+class ExternalIncludesScreen(DialogScreen[str]):
+    """CLAUDE.md external @imports approval (asked once per project)."""
+
+    title_text = "Allow external CLAUDE.md file imports?"
+    footer_hint = "Enter selects · Esc disables"
+    border_variant = "warning"
+
+    def __init__(self, external_paths: list[str]) -> None:
+        super().__init__()
+        self._external_paths = list(external_paths)
+        self._select: SelectList | None = None
+
+    def build_body(self) -> Iterator[Widget]:
+        yield Static(
+            Text(
+                "This project's CLAUDE.md imports files outside the "
+                "current working directory. Never allow this for "
+                "third-party repositories.",
+                style="dim",
+            ),
+            markup=False,
+        )
+        if self._external_paths:
+            listing = Text("External imports:\n", style="dim")
+            for path in self._external_paths[:8]:
+                listing.append(f"  {path}\n", style="dim")
+            if len(self._external_paths) > 8:
+                listing.append(
+                    f"  … and {len(self._external_paths) - 8} more\n",
+                    style="dim",
+                )
+            yield Static(listing, markup=False)
+        self._select = SelectList(
+            [
+                SelectOption(
+                    label="Yes, allow external imports", value="yes"
+                ),
+                SelectOption(
+                    label="No, disable external imports", value="no"
+                ),
+            ],
+            allow_cancel=True,
+        )
+        yield self._select
+
+    def _post_mount(self) -> None:
+        if self._select is not None:
+            self._select.focus()
+
+    def on_select_list_option_selected(
+        self, event: SelectList.OptionSelected
+    ) -> None:
+        self.dismiss(str(event.option.value))
+
+    def on_select_list_selection_cancelled(
+        self, _: SelectList.SelectionCancelled
+    ) -> None:
+        # TS handleEscape selects "no" (persisted decline).
+        self.dismiss("no")
+
+
+class BypassPermissionsScreen(DialogScreen[str]):
+    """Bypass-permissions acceptance gate."""
+
+    title_text = "WARNING: running in Bypass Permissions mode"
+    footer_hint = "Enter selects · Esc exits"
+    border_variant = "error"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._select: SelectList | None = None
+
+    def build_body(self) -> Iterator[Widget]:
+        yield Static(
+            Text(
+                "In Bypass Permissions mode, the agent will not ask for "
+                "your approval before running potentially dangerous "
+                "commands.\nThis mode should only be used in a sandboxed "
+                "container/VM that has restricted internet access and can "
+                "easily be restored if damaged.",
+                style="dim",
+            ),
+            markup=False,
+        )
+        yield Static(
+            Text(
+                "By proceeding, you accept all responsibility for actions "
+                "taken while running in Bypass Permissions mode.",
+            ),
+            markup=False,
+        )
+        self._select = SelectList(
+            [
+                SelectOption(label="No, exit", value="decline"),
+                SelectOption(label="Yes, I accept", value="accept"),
+            ],
+            allow_cancel=True,
+        )
+        yield self._select
+
+    def _post_mount(self) -> None:
+        if self._select is not None:
+            self._select.focus()
+
+    def on_select_list_option_selected(
+        self, event: SelectList.OptionSelected
+    ) -> None:
+        self.dismiss(str(event.option.value))
+
+    def on_select_list_selection_cancelled(
+        self, _: SelectList.SelectionCancelled
+    ) -> None:
+        # TS: Esc on this dialog exits with code 0 (distinct from the
+        # explicit "No, exit" which exits 1).
+        self.dismiss("escape")
+
+
+__all__ = [
+    "BypassPermissionsScreen",
+    "ExternalIncludesScreen",
+    "TrustFolderScreen",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,23 @@ def _isolate_user_permission_settings(tmp_path, monkeypatch):
     monkeypatch.setattr(
         config_mod, "GLOBAL_CONFIG_DIR", tmp_path / "isolated-global"
     )
+    # C8: skip the startup security gates (trust / external includes /
+    # bypass acceptance) in full-app tests — every app test would
+    # otherwise boot into the trust or bypass dialog and block on input.
+    # The chain jumps straight to its tail (C6 warnings + C7 MCP
+    # approvals), which is exactly the pre-C8 boot behavior.
+    # test_startup_gates_c8.py exercises the real chain via methods
+    # captured at import time, before this patch applies.
+    try:
+        from src.tui.app import ClawCodexTUI
+
+        monkeypatch.setattr(
+            ClawCodexTUI,
+            "_run_startup_chain",
+            lambda self: self._finish_startup_gates(),
+        )
+    except Exception:
+        pass  # textual not installed in this environment
     yield
 
 

--- a/tests/tui/test_mcp_approval_c7.py
+++ b/tests/tui/test_mcp_approval_c7.py
@@ -38,6 +38,12 @@ def project(tmp_path, monkeypatch):
     # Approval reads/writes default to the process cwd — pin it too so
     # the no-cwd production call paths resolve to this project.
     monkeypatch.chdir(tmp_path)
+    # C8: non-interactive sessions auto-approve (TS utils.ts:399-403).
+    # The bootstrap default is non-interactive, so pin interactive mode
+    # to exercise the pending/approval flows these tests are about.
+    from src.bootstrap import state as bootstrap_state
+
+    monkeypatch.setattr(bootstrap_state._STATE, "is_interactive", True)
     return tmp_path
 
 
@@ -80,6 +86,30 @@ class TestStatusAndPersistence:
 
     def test_invalid_choice_rejected(self, project) -> None:
         assert not record_mcpjson_choice("alpha", "bogus", cwd=str(project))
+
+    def test_non_interactive_session_auto_approves(
+        self, project, monkeypatch
+    ) -> None:
+        """TS utils.ts:399-403: SDK / -p / piped sessions can't show a
+        popup; the mode itself is the consent."""
+
+        from src.bootstrap import state as bootstrap_state
+
+        monkeypatch.setattr(bootstrap_state._STATE, "is_interactive", False)
+        assert get_mcpjson_server_status("alpha", cwd=str(project)) == "approved"
+        # Explicit disable still wins.
+        record_mcpjson_choice("alpha", "disable", cwd=str(project))
+        assert get_mcpjson_server_status("alpha", cwd=str(project)) == "rejected"
+
+    def test_bypass_acceptance_auto_approves(self, project) -> None:
+        """TS utils.ts:377-390: a user who accepted the bypass dialog
+        (skipDangerousModePermissionPrompt) consents to repo servers."""
+
+        from src.services.startup_gates import record_bypass_accepted
+
+        assert get_mcpjson_server_status("alpha", cwd=str(project)) == "pending"
+        assert record_bypass_accepted()
+        assert get_mcpjson_server_status("alpha", cwd=str(project)) == "approved"
 
 
 class TestPendingListing:

--- a/tests/tui/test_startup_gates_c8.py
+++ b/tests/tui/test_startup_gates_c8.py
@@ -1,0 +1,400 @@
+"""C8 tests: trust / external-includes / bypass startup gates."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src.services.startup_gates import (
+    INCLUDES_APPROVED_KEY,
+    INCLUDES_WARNING_SHOWN_KEY,
+    SKIP_DANGEROUS_PROMPT_KEY,
+    TRUST_KEY,
+    check_trust_accepted,
+    collect_trust_warnings,
+    get_external_includes_state,
+    has_skip_dangerous_mode_permission_prompt,
+    list_external_includes,
+    record_bypass_accepted,
+    record_external_includes_choice,
+    record_trust_accepted,
+    reset_session_trust_for_testing,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_session_trust():
+    reset_session_trust_for_testing()
+    yield
+    reset_session_trust_for_testing()
+
+
+@pytest.fixture
+def proj(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    return project
+
+
+def _global_config(tmp_path) -> dict:
+    import src.config as config_mod
+
+    path = Path(config_mod.GLOBAL_CONFIG_DIR) / "config.json"
+    return json.loads(path.read_text()) if path.exists() else {}
+
+
+class TestTrustGate:
+    def test_untrusted_by_default_then_round_trip(self, proj, tmp_path) -> None:
+        assert not check_trust_accepted(proj)
+        assert record_trust_accepted(proj)
+        assert check_trust_accepted(proj)
+        entry = _global_config(tmp_path)["projects"][str(proj.resolve())]
+        assert entry[TRUST_KEY] is True
+
+    def test_parent_trust_covers_children(self, proj, tmp_path) -> None:
+        import src.config as config_mod
+
+        child = proj / "nested" / "deep"
+        child.mkdir(parents=True)
+        config_mod.update_project_entry(proj, {TRUST_KEY: True})
+        reset_session_trust_for_testing()
+        assert check_trust_accepted(child)
+
+    def test_home_directory_trust_is_session_only(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+        monkeypatch.chdir(fake_home)
+        assert record_trust_accepted(fake_home)
+        assert check_trust_accepted(fake_home)  # session flag
+        assert "projects" not in _global_config(tmp_path)  # nothing persisted
+        reset_session_trust_for_testing()
+        assert not check_trust_accepted(fake_home)  # asked again next launch
+
+    def test_trust_warnings_enumerate_modeled_subsystems(self, proj) -> None:
+        assert collect_trust_warnings(proj) == []
+        settings_dir = proj / ".clawcodex"
+        settings_dir.mkdir()
+        (settings_dir / "settings.json").write_text(
+            json.dumps(
+                {
+                    "permissions": {"allow": ["Bash(ls:*)"]},
+                    "statusLine": {"type": "command", "command": "echo hi"},
+                }
+            )
+        )
+        warnings = collect_trust_warnings(proj)
+        assert any("pre-allows Bash" in w for w in warnings)
+        assert any("status-line command" in w for w in warnings)
+
+
+class TestExternalIncludesGate:
+    def test_state_round_trips(self, proj, tmp_path) -> None:
+        assert get_external_includes_state(proj) == "unset"
+        assert record_external_includes_choice(False, proj)
+        assert get_external_includes_state(proj) == "declined"
+        assert record_external_includes_choice(True, proj)
+        assert get_external_includes_state(proj) == "approved"
+        entry = _global_config(tmp_path)["projects"][str(proj.resolve())]
+        assert entry[INCLUDES_APPROVED_KEY] is True
+        assert entry[INCLUDES_WARNING_SHOWN_KEY] is True
+
+    @pytest.mark.asyncio
+    async def test_loader_gates_external_includes(
+        self, proj, tmp_path, monkeypatch
+    ) -> None:
+        """End-to-end through the REAL loader: external @includes load
+        only after this project approved them."""
+
+        from src.context_system.claude_md import (
+            clear_memory_file_caches,
+            get_memory_files,
+        )
+
+        outside = tmp_path / "elsewhere"
+        outside.mkdir()
+        ext = outside / "ext-notes.md"
+        ext.write_text("external payload")
+        (proj / "CLAUDE.md").write_text(f"Main rules.\n@{ext}")
+        monkeypatch.setenv("CLAUDE_CODE_ORIGINAL_CWD", str(proj))
+        clear_memory_file_caches()
+        try:
+            files = await get_memory_files(cwd=str(proj))
+            assert not any(f.path == str(ext) for f in files)
+
+            externals = await list_external_includes(proj)
+            assert str(ext) in externals
+
+            assert record_external_includes_choice(True, proj)
+            files_after = await get_memory_files(cwd=str(proj))
+            assert any(f.path == str(ext) for f in files_after)
+        finally:
+            clear_memory_file_caches()
+
+    def test_is_external_predicate(self, proj, tmp_path, monkeypatch) -> None:
+        from src.context_system.claude_md import is_external_memory_file
+        from src.context_system.models import MemoryFileInfo
+
+        monkeypatch.setenv("CLAUDE_CODE_ORIGINAL_CWD", str(proj))
+        outside = str(tmp_path / "elsewhere" / "x.md")
+        inside = str(proj / "x.md")
+        make = lambda path, parent, mem_type="Project": MemoryFileInfo(
+            path=path, type=mem_type, content="c", parent=parent
+        )
+        assert is_external_memory_file(make(outside, str(proj / "CLAUDE.md")))
+        assert not is_external_memory_file(make(inside, str(proj / "CLAUDE.md")))
+        # A ROOT file outside cwd (e.g. the user's ~/CLAUDE.md) is not
+        # an "external include" — only included files count.
+        assert not is_external_memory_file(make(outside, None))
+        # TS claudemd.ts:1432 excludes the User tier entirely: the
+        # user's own ~/CLAUDE.md may @include anything without
+        # triggering this project's gate.
+        assert not is_external_memory_file(
+            make(outside, "~/CLAUDE.md", mem_type="User")
+        )
+
+
+class TestBypassGate:
+    def test_accept_round_trip_user_settings(self, proj) -> None:
+        from src.permissions import settings_paths
+
+        assert not has_skip_dangerous_mode_permission_prompt(proj)
+        assert record_bypass_accepted()
+        assert has_skip_dangerous_mode_permission_prompt(proj)
+        data = json.loads(Path(settings_paths.user_settings_path()).read_text())
+        assert data[SKIP_DANGEROUS_PROMPT_KEY] is True
+
+    def test_local_tier_flag_honored(self, proj) -> None:
+        settings_dir = proj / ".clawcodex"
+        settings_dir.mkdir()
+        (settings_dir / "settings.local.json").write_text(
+            json.dumps({SKIP_DANGEROUS_PROMPT_KEY: True})
+        )
+        assert has_skip_dangerous_mode_permission_prompt(proj)
+
+
+@pytest.mark.asyncio
+async def test_gate_screens_outcomes() -> None:
+    pytest.importorskip("textual")
+    import asyncio
+
+    from textual.app import App, ComposeResult
+    from textual.screen import Screen
+    from textual.widgets import Static
+
+    from src.tui.screens.startup_gates import (
+        BypassPermissionsScreen,
+        ExternalIncludesScreen,
+        TrustFolderScreen,
+    )
+
+    class _Host(Screen):
+        def compose(self) -> ComposeResult:
+            yield Static("host")
+
+    class _App(App):
+        def on_mount(self) -> None:
+            self.push_screen(_Host())
+
+    cases = [
+        (lambda: TrustFolderScreen("/tmp/x", ["warn"]), ("enter",), "trust"),
+        (lambda: TrustFolderScreen("/tmp/x"), ("down", "enter"), "exit"),
+        (lambda: TrustFolderScreen("/tmp/x"), ("escape",), "exit"),
+        (lambda: ExternalIncludesScreen(["/e/a.md"]), ("enter",), "yes"),
+        (lambda: ExternalIncludesScreen([]), ("down", "enter"), "no"),
+        (lambda: ExternalIncludesScreen(["/e/a.md"]), ("escape",), "no"),
+        (lambda: BypassPermissionsScreen(), ("enter",), "decline"),
+        (lambda: BypassPermissionsScreen(), ("down", "enter"), "accept"),
+        (lambda: BypassPermissionsScreen(), ("escape",), "escape"),
+    ]
+    for factory, presses, expected in cases:
+        app = _App()
+        async with app.run_test() as pilot:
+            loop = asyncio.get_running_loop()
+            future: asyncio.Future = loop.create_future()
+            app.push_screen(factory(), callback=lambda r: future.set_result(r))
+            await pilot.pause()
+            for key in presses:
+                await pilot.press(key)
+            result = await asyncio.wait_for(future, timeout=5)
+        assert result == expected, (presses, result)
+
+
+def _capture_real_chain_methods():
+    """Bind the chain methods at import time — tests/conftest.py patches
+    ``_run_startup_chain`` on the class to skip the gates in full-app
+    tests, and these tests must exercise the REAL chain."""
+
+    from src.tui.app import ClawCodexTUI
+
+    return {
+        name: getattr(ClawCodexTUI, name)
+        for name in (
+            "_run_startup_chain",
+            "_startup_gate_trust",
+            "_on_trust_choice",
+            "_startup_gate_includes",
+            "_detect_external_includes",
+            "_on_includes_choice",
+            "_startup_gate_bypass",
+            "_on_bypass_choice",
+            "_finish_startup_gates",
+        )
+    }
+
+
+_REAL_CHAIN = _capture_real_chain_methods()
+
+
+class TestAppGateChain:
+    def _fake(self, proj):
+        rows: list[str] = []
+        pushes: list[tuple] = []
+        exits: list[int] = []
+        finished: list[str] = []
+        fake = SimpleNamespace(
+            workspace_root=proj,
+            tool_context=SimpleNamespace(
+                permission_context=SimpleNamespace(mode="default")
+            ),
+            _repl_screen=SimpleNamespace(
+                transcript=SimpleNamespace(
+                    append_system=lambda text, style="muted": rows.append(text)
+                )
+            ),
+            push_screen=lambda screen, callback=None: pushes.append(
+                (screen, callback)
+            ),
+            exit=lambda return_code=0: exits.append(return_code),
+            _show_config_warnings=lambda: finished.append("warnings"),
+            _run_mcp_approvals=lambda: finished.append("mcp"),
+        )
+        for name, method in _REAL_CHAIN.items():
+            setattr(
+                fake, name, (lambda m: lambda *a, **k: m(fake, *a, **k))(method)
+            )
+        # The includes detection step spawns an async worker; for the
+        # sync chain tests, pre-decide includes so it short-circuits.
+        return fake, rows, pushes, exits, finished
+
+    def test_all_satisfied_chain_reaches_c6_and_c7(self, proj) -> None:
+        record_trust_accepted(proj)
+        record_external_includes_choice(False, proj)
+        fake, rows, pushes, exits, finished = self._fake(proj)
+        fake._run_startup_chain()
+        assert finished == ["warnings", "mcp"]
+        assert pushes == [] and exits == []
+
+    def test_untrusted_prompts_and_decline_exits_1(self, proj) -> None:
+        fake, rows, pushes, exits, finished = self._fake(proj)
+        fake._startup_gate_trust()
+        assert len(pushes) == 1  # trust dialog shown
+        fake._on_trust_choice("exit")
+        assert exits == [1]
+        assert finished == []
+
+    def test_trust_accept_persists_and_continues(self, proj) -> None:
+        record_external_includes_choice(False, proj)
+        fake, rows, pushes, exits, finished = self._fake(proj)
+        fake._on_trust_choice("trust")
+        assert check_trust_accepted(proj)
+        assert finished == ["warnings", "mcp"]
+
+    def test_bypass_gate_prompts_only_in_bypass_mode(self, proj) -> None:
+        fake, rows, pushes, exits, finished = self._fake(proj)
+        fake.tool_context.permission_context.mode = "bypassPermissions"
+        fake._startup_gate_bypass()
+        assert len(pushes) == 1
+        # Decline exits 1; Esc exits 0 (TS gracefulShutdownSync codes).
+        fake._on_bypass_choice("decline")
+        fake._on_bypass_choice("escape")
+        assert exits == [1, 0]
+
+    def test_bypass_accept_persists_and_continues(self, proj) -> None:
+        fake, rows, pushes, exits, finished = self._fake(proj)
+        fake._on_bypass_choice("accept")
+        assert has_skip_dangerous_mode_permission_prompt(proj)
+        assert finished == ["warnings", "mcp"]
+        assert exits == []
+
+    def test_bypass_already_accepted_skips_prompt(self, proj) -> None:
+        record_bypass_accepted()
+        fake, rows, pushes, exits, finished = self._fake(proj)
+        fake.tool_context.permission_context.mode = "bypassPermissions"
+        fake._startup_gate_bypass()
+        assert pushes == []
+        assert finished == ["warnings", "mcp"]
+
+    def test_includes_choice_rows_and_persistence(self, proj) -> None:
+        fake, rows, pushes, exits, finished = self._fake(proj)
+        fake._on_includes_choice("yes")
+        assert get_external_includes_state(proj) == "approved"
+        assert any("imports enabled" in r for r in rows)
+        fake._on_includes_choice("no")
+        assert get_external_includes_state(proj) == "declined"
+        assert any("imports disabled" in r for r in rows)
+
+    def test_write_failure_reports_honestly(self, proj, monkeypatch) -> None:
+        import src.services.startup_gates as gates_mod
+
+        monkeypatch.setattr(
+            gates_mod, "record_bypass_accepted", lambda: False
+        )
+        fake, rows, pushes, exits, finished = self._fake(proj)
+        fake._on_bypass_choice("accept")
+        assert any("Could not persist" in r for r in rows)
+        assert finished == ["warnings", "mcp"]  # accepted interactively
+
+    def test_unset_includes_schedules_detection_worker(
+        self, proj, monkeypatch
+    ) -> None:
+        import src.services.startup_gates as gates_mod
+
+        monkeypatch.setattr(
+            gates_mod, "get_external_includes_state", lambda cwd=None: "unset"
+        )
+        fake, rows, pushes, exits, finished = self._fake(proj)
+        workers: list = []
+        fake.run_worker = lambda coro, **kw: workers.append(coro)
+        fake._startup_gate_includes()
+        assert len(workers) == 1
+        workers[0].close()  # avoid un-awaited coroutine warning
+        assert finished == []  # chain paused until the worker decides
+
+    def test_detect_worker_pushes_dialog_when_externals(
+        self, proj, monkeypatch
+    ) -> None:
+        import asyncio
+
+        import src.services.startup_gates as gates_mod
+
+        async def fake_list(cwd=None):
+            return ["/elsewhere/a.md"]
+
+        monkeypatch.setattr(gates_mod, "list_external_includes", fake_list)
+        fake, rows, pushes, exits, finished = self._fake(proj)
+        asyncio.run(fake._detect_external_includes())
+        assert len(pushes) == 1  # includes dialog shown
+        assert finished == []
+
+    def test_detect_worker_continues_when_no_externals(
+        self, proj, monkeypatch
+    ) -> None:
+        import asyncio
+
+        import src.services.startup_gates as gates_mod
+
+        async def fake_list(cwd=None):
+            return []
+
+        monkeypatch.setattr(gates_mod, "list_external_includes", fake_list)
+        fake, rows, pushes, exits, finished = self._fake(proj)
+        asyncio.run(fake._detect_external_includes())
+        assert pushes == []
+        assert finished == ["warnings", "mcp"]  # chain continued


### PR DESCRIPTION
## Summary
- Ports the three TS startup gates as a strictly sequential boot chain (trust → external CLAUDE.md includes → bypass acceptance → C6 warnings → C7 MCP approvals), so no later dialog can stack above an unanswered trust prompt.
- **Trust** (TrustDialog.tsx + config.ts:771-817): per-project `hasTrustDialogAccepted` in the user-owned global config `projects[path]` map (repo can't pre-trust itself); parent trust covers children; home-dir = session-only; decline → exit 1; accept also syncs the bootstrap session-trust flag consumed by hooks/trust_gate.
- **External includes** (ClaudeMdExternalIncludesDialog.tsx + claudemd.ts:805-815/1427-1437): asked once per project (boolean pair); the loader derives `include_external` from the approval, keys its cache on the effective value, and the externals predicate excludes the User tier exactly like TS; Esc = "no".
- **Bypass acceptance** (BypassPermissionsModeDialog.tsx): decline → exit 1, Esc → exit 0 (distinct TS codes, now propagated — `run_tui` returns `app.return_code`); accept persists `skipDangerousModePermissionPrompt: true` to user settings.
- Closes the C7 deferred item: `get_mcpjson_server_status` ports TS's auto-approve branches (bypass-accepted flag; non-interactive session, utils.ts:377-403) — headless/SDK behavior now TS parity; `run_tui` defensively pins interactive mode so the branch fails safe.
- `init.py` trust placeholder comment rewritten (the TODO it carried pointed at this phase); plan §8 updated with all [FOUND DURING IMPL] decisions.

## Test plan
- [x] 22 new tests: trust round-trip/parent-walk/home-session-only/warnings, includes state + end-to-end through the REAL loader (excluded → approved → included), User-tier predicate guard, bypass round-trips, 9-case screen pilot matrix, app-chain tests via import-time-captured real methods (decline codes, write-failure honesty, worker branches)
- [x] TUI + services + context + MCP + init suites: 983 passed (2 known PATH-dependent pre-existing failures)
- [x] Full suite BASELINE-IDENTICAL vs the 12 known pre-existing failures
- [x] Critic loop: REQUEST CHANGES (1 MAJOR / 5 MINOR / 4 NIT) → all fixed incl. the TS User-tier verification → APPROVE ("ready to ship")

🤖 Generated with [Claude Code](https://claude.com/claude-code)