### PR TITLE
components C9: '#' memory-append shortcut

### DIFF
--- a/src/command_system/memory_command.py
+++ b/src/command_system/memory_command.py
@@ -68,7 +68,9 @@ def _resolve_project_memory_path(files: list, cwd: str) -> str:
     return str(Path(cwd) / "CLAUDE.md")
 
 
-async def _build_options(cwd: str) -> list[UIOption]:
+async def build_memory_options(cwd: str) -> list[UIOption]:
+    """Public: the memory-target hierarchy, shared by ``/memory`` and
+    the C9 ``#`` shortcut so the two pickers can never drift."""
     from src.context_system.claude_md import (
         clear_memory_file_caches,
         get_memory_files,
@@ -150,7 +152,7 @@ class MemoryCommand(InteractiveCommand):
 
     async def run(self, args: str, context: CommandContext) -> InteractiveOutcome:
         cwd = str(context.cwd)
-        options = await _build_options(cwd)
+        options = await build_memory_options(cwd)
         picked = await context.ui.select("Memory", options)
         if picked is None:
             # Verbatim TS (memory.tsx:65).
@@ -179,4 +181,4 @@ MEMORY_COMMAND = MemoryCommand(
 )
 
 
-__all__ = ["MEMORY_COMMAND", "MemoryCommand"]
+__all__ = ["MEMORY_COMMAND", "MemoryCommand", "build_memory_options"]

--- a/src/services/memory_append.py
+++ b/src/services/memory_append.py
@@ -1,0 +1,76 @@
+"""``#`` memory-note append (components C9) — UI-neutral file layer.
+
+Port note (honesty over invention): the vendored TS snapshot ships the
+RENDERER for saved notes (``UserMemoryInputMessage.tsx`` — the
+``<user-memory-input>`` row plus a random "Got it. / Good to know. /
+Noted." acknowledgement) and the target selector
+(``MemoryFileSelector.tsx``, already ported as ``/memory``), but NOT
+the trigger glue: no ``#`` detection or append function exists in the
+snapshot. This module supplies that glue with a documented discipline:
+
+* ensure the file exists (ensure-create via append-mode open, plus the
+  same ``~/.claude`` mkdir rule as the ``/memory`` port);
+* separate from existing content with a single newline (adding one to
+  a file that doesn't end in ``\\n`` first);
+* write the note as a ``- `` bullet line unless the user already
+  supplied list/heading punctuation — matching the bulleted style the
+  product writes to CLAUDE.md memory files.
+"""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+SAVING_MESSAGES = ("Got it.", "Good to know.", "Noted.")
+
+
+def pick_saving_message() -> str:
+    """TS UserMemoryInputMessage.tsx:9 — lodash ``sample`` of the trio."""
+
+    return random.choice(SAVING_MESSAGES)
+
+
+def format_note_line(note: str) -> str:
+    stripped = note.strip()
+    if stripped.startswith(("-", "*", "#")):
+        return stripped
+    return f"- {stripped}"
+
+
+def append_memory_note(path: str, note: str) -> bool:
+    """Append *note* to the memory file at *path*. Returns success."""
+
+    stripped = note.strip()
+    if not stripped:
+        return False
+    try:
+        target = Path(path)
+        claude_home = Path.home() / ".claude"
+        try:
+            if target.resolve().is_relative_to(claude_home.resolve()):
+                claude_home.mkdir(parents=True, exist_ok=True)
+        except (OSError, ValueError):
+            pass
+        target.parent.mkdir(parents=True, exist_ok=True)
+        existing = ""
+        if target.exists():
+            existing = target.read_text(encoding="utf-8")
+        prefix = ""
+        if existing and not existing.endswith("\n"):
+            prefix = "\n"
+        with open(target, "a", encoding="utf-8") as f:
+            f.write(f"{prefix}{format_note_line(stripped)}\n")
+        return True
+    except (OSError, ValueError):
+        # ValueError covers UnicodeDecodeError from a non-UTF8 file —
+        # the bool contract must hold without caller help.
+        return False
+
+
+__all__ = [
+    "SAVING_MESSAGES",
+    "append_memory_note",
+    "format_note_line",
+    "pick_saving_message",
+]

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -730,6 +730,75 @@ class ClawCodexTUI(App):
             self.submit_to_agent(result.prompt_text)
 
     # ---- C4 bash-mode (`!` prefix) --------------------------------------
+    # ---- C9 `#` memory-append shortcut -----------------------------------
+    def run_memory_shortcut(self, note: str, transcript: Transcript) -> None:
+        # History first, like bash-mode does for `!` — a saved (or
+        # cancelled) note must stay reachable via up-arrow.
+        try:
+            self.history_store.append(f"#{note}")
+        except Exception:
+            pass
+        self.run_worker(
+            self._memory_shortcut_flow(note, transcript),
+            exclusive=False,
+            name="c9-memory-shortcut",
+        )
+
+    async def _memory_shortcut_flow(
+        self, note: str, transcript: Transcript
+    ) -> None:
+        try:
+            from src.command_system.memory_command import build_memory_options
+
+            options = await build_memory_options(str(self.workspace_root))
+        except Exception:
+            options = []
+        if not options:
+            transcript.append_system(
+                "Could not enumerate memory files — note not saved.",
+                style="muted",
+            )
+            self._insert_into_prompt(f"#{note}")
+            return
+        from src.tui.screens.memory_save import MemorySaveScreen
+
+        self.push_screen(
+            MemorySaveScreen(note, options),
+            callback=lambda path, _n=note, _t=transcript: (
+                self._on_memory_target(_n, path, _t)
+            ),
+        )
+
+    def _on_memory_target(
+        self, note: str, path: str | None, transcript: Transcript
+    ) -> None:
+        from src.services.memory_append import (
+            append_memory_note,
+            pick_saving_message,
+        )
+
+        if path is None:
+            # Verbatim TS cancel string (memory.tsx:65); the note goes
+            # back into the prompt so nothing typed is lost.
+            transcript.append_system("Cancelled memory editing", style="muted")
+            self._insert_into_prompt(f"#{note}")
+            return
+        ok = False
+        try:
+            ok = append_memory_note(path, note)
+        except Exception:
+            ok = False
+        if not ok:
+            transcript.append_system(
+                f"Could not write {path} — memory not saved.", style="muted"
+            )
+            self._insert_into_prompt(f"#{note}")
+            return
+        # TS UserMemoryInputMessage: the `#`-styled note row plus a
+        # random acknowledgement line.
+        transcript.append_system(f"# {note.strip()}", style="muted")
+        transcript.append_system(pick_saving_message(), style="muted")
+
     def run_bash_mode(self, command: str, transcript: Transcript) -> None:
         """Execute a user-typed ``!command`` directly (no agent turn).
 

--- a/src/tui/screens/__init__.py
+++ b/src/tui/screens/__init__.py
@@ -14,6 +14,7 @@ from .mcp_dialogs import (
     McpServer,
     McpToolListScreen,
 )
+from .memory_save import MemorySaveScreen
 from .message_selector import MessageSelectorScreen, TranscriptMessage
 from .model_picker import ModelPickerScreen
 from .permission_modal import PermissionModal
@@ -49,6 +50,7 @@ __all__ = [
     "McpListScreen",
     "McpServer",
     "McpToolListScreen",
+    "MemorySaveScreen",
     "MessageSelectorScreen",
     "ModelPickerScreen",
     "PermissionModal",

--- a/src/tui/screens/memory_save.py
+++ b/src/tui/screens/memory_save.py
@@ -1,0 +1,70 @@
+"""``#`` memory-note target picker (components C9).
+
+Reuses the ``/memory`` hierarchy options (TS ``MemoryFileSelector`` —
+User memory / Project memory / enumerated files). Dismisses with the
+chosen file path, or ``None`` on Esc (= cancel; the note returns to the
+prompt so nothing is lost). Title phrasing is port-chosen — the
+vendored TS snapshot has no ``#`` dialog to quote.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator, Sequence
+
+from rich.text import Text
+from textual.widget import Widget
+from textual.widgets import Static
+
+from src.command_system.types import UIOption
+from src.tui.widgets.select_list import SelectList, SelectOption
+
+from .dialog_base import DialogScreen
+
+
+class MemorySaveScreen(DialogScreen[str | None]):
+    """Pick which memory file a ``#`` note should be appended to."""
+
+    title_text = "Save memory to:"
+    footer_hint = "Enter selects · Esc cancels"
+    border_variant = "primary"
+
+    def __init__(self, note: str, options: Sequence[UIOption]) -> None:
+        super().__init__()
+        self._note = note
+        self._options = list(options)
+        self._select: SelectList | None = None
+
+    def build_body(self) -> Iterator[Widget]:
+        preview = self._note if len(self._note) <= 120 else (
+            self._note[:117] + "..."
+        )
+        yield Static(Text(f"# {preview}", style="bold"), markup=False)
+        self._select = SelectList(
+            [
+                SelectOption(
+                    label=str(opt.label),
+                    value=str(opt.value),
+                    description=getattr(opt, "description", None),
+                )
+                for opt in self._options
+            ],
+            allow_cancel=True,
+        )
+        yield self._select
+
+    def _post_mount(self) -> None:
+        if self._select is not None:
+            self._select.focus()
+
+    def on_select_list_option_selected(
+        self, event: SelectList.OptionSelected
+    ) -> None:
+        self.dismiss(str(event.option.value))
+
+    def on_select_list_selection_cancelled(
+        self, _: SelectList.SelectionCancelled
+    ) -> None:
+        self.dismiss(None)
+
+
+__all__ = ["MemorySaveScreen"]

--- a/src/tui/screens/repl.py
+++ b/src/tui/screens/repl.py
@@ -162,6 +162,11 @@ class REPLScreen(Screen):
             # fills in the output when the command finishes).
             app.run_bash_mode(text[1:], self.transcript)
             return
+        if text.startswith("#") and text[1:].strip():
+            # C9 memory shortcut: pick a memory file, append the note,
+            # no agent turn. A bare "#" falls through to the agent.
+            app.run_memory_shortcut(text[1:], self.transcript)
+            return
         self.transcript.append_user(text)
         self.status_bar.set_busy()
         self.status_bar.bump_turn()

--- a/tests/tui/test_memory_shortcut_c9.py
+++ b/tests/tui/test_memory_shortcut_c9.py
@@ -1,0 +1,233 @@
+"""C9 tests: `#` memory-append shortcut (service, screen, routing)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.services.memory_append import (
+    SAVING_MESSAGES,
+    append_memory_note,
+    format_note_line,
+    pick_saving_message,
+)
+
+
+class TestAppendService:
+    def test_creates_file_and_bullets_note(self, tmp_path) -> None:
+        target = tmp_path / "CLAUDE.md"
+        assert append_memory_note(str(target), "prefer tabs")
+        assert target.read_text() == "- prefer tabs\n"
+
+    def test_appends_with_newline_discipline(self, tmp_path) -> None:
+        target = tmp_path / "CLAUDE.md"
+        target.write_text("# Existing\n\n- old note")  # no trailing newline
+        assert append_memory_note(str(target), "new note")
+        assert target.read_text() == "# Existing\n\n- old note\n- new note\n"
+
+    def test_existing_punctuation_not_double_bulleted(self, tmp_path) -> None:
+        assert format_note_line("- already a bullet") == "- already a bullet"
+        assert format_note_line("# heading note") == "# heading note"
+        assert format_note_line("plain") == "- plain"
+        target = tmp_path / "m.md"
+        assert append_memory_note(str(target), "  - spaced bullet  ")
+        assert target.read_text() == "- spaced bullet\n"
+
+    def test_empty_note_rejected(self, tmp_path) -> None:
+        target = tmp_path / "m.md"
+        assert not append_memory_note(str(target), "   ")
+        assert not target.exists()
+
+    def test_write_failure_returns_false(self, tmp_path) -> None:
+        # A directory at the target path makes open() fail with OSError.
+        target = tmp_path / "CLAUDE.md"
+        target.mkdir()
+        assert not append_memory_note(str(target), "note")
+
+    def test_creates_missing_parent_dirs(self, tmp_path) -> None:
+        target = tmp_path / "deep" / "nested" / "MEMORY.md"
+        assert append_memory_note(str(target), "note")
+        assert target.read_text() == "- note\n"
+
+    def test_saving_message_pool(self) -> None:
+        assert pick_saving_message() in SAVING_MESSAGES
+
+
+@pytest.mark.asyncio
+async def test_memory_save_screen_outcomes() -> None:
+    pytest.importorskip("textual")
+    import asyncio
+
+    from textual.app import App, ComposeResult
+    from textual.screen import Screen
+    from textual.widgets import Static
+
+    from src.command_system.types import UIOption
+    from src.tui.screens.memory_save import MemorySaveScreen
+
+    class _Host(Screen):
+        def compose(self) -> ComposeResult:
+            yield Static("host")
+
+    class _App(App):
+        def on_mount(self) -> None:
+            self.push_screen(_Host())
+
+    options = [
+        UIOption(value="/u/CLAUDE.md", label="User memory", description="~"),
+        UIOption(value="/p/CLAUDE.md", label="Project memory", description="./"),
+    ]
+    for presses, expected in (
+        (("enter",), "/u/CLAUDE.md"),
+        (("down", "enter"), "/p/CLAUDE.md"),
+        (("escape",), None),
+    ):
+        app = _App()
+        async with app.run_test() as pilot:
+            loop = asyncio.get_running_loop()
+            future: asyncio.Future = loop.create_future()
+            app.push_screen(
+                MemorySaveScreen("remember this", options),
+                callback=lambda r: future.set_result(r),
+            )
+            await pilot.pause()
+            for key in presses:
+                await pilot.press(key)
+            result = await asyncio.wait_for(future, timeout=5)
+        assert result == expected, (presses, result)
+
+
+class TestReplRouting:
+    def _fake_screen(self):
+        from src.tui.screens.repl import REPLScreen
+
+        calls: dict[str, list] = {
+            "bash": [],
+            "memory": [],
+            "agent": [],
+            "user_rows": [],
+        }
+        fake = SimpleNamespace(
+            app=SimpleNamespace(
+                handle_local_slash_command=lambda text, t: False,
+                run_bash_mode=lambda cmd, t: calls["bash"].append(cmd),
+                run_memory_shortcut=lambda note, t: calls["memory"].append(note),
+                submit_to_agent=lambda text: calls["agent"].append(text),
+            ),
+            transcript=SimpleNamespace(
+                append_user=lambda text: calls["user_rows"].append(text)
+            ),
+            status_bar=SimpleNamespace(
+                set_busy=lambda: None, bump_turn=lambda: None
+            ),
+        )
+        on_submit = REPLScreen.on_prompt_submitted
+        return fake, calls, on_submit
+
+    def _msg(self, text: str):
+        return SimpleNamespace(text=text)
+
+    def test_hash_prefix_routes_to_memory_shortcut(self) -> None:
+        fake, calls, on_submit = self._fake_screen()
+        on_submit(fake, self._msg("# remember to run lint"))
+        assert calls["memory"] == [" remember to run lint"]
+        assert calls["agent"] == []
+
+    def test_bare_hash_falls_through_to_agent(self) -> None:
+        fake, calls, on_submit = self._fake_screen()
+        on_submit(fake, self._msg("#"))
+        assert calls["memory"] == []
+        assert calls["agent"] == ["#"]
+
+    def test_bang_still_routes_to_bash(self) -> None:
+        fake, calls, on_submit = self._fake_screen()
+        on_submit(fake, self._msg("!ls"))
+        assert calls["bash"] == ["ls"]
+
+
+class TestAppMemoryFlow:
+    def _fake(self):
+        from src.tui.app import ClawCodexTUI
+
+        rows: list[str] = []
+        inserted: list[str] = []
+        fake = SimpleNamespace(
+            _insert_into_prompt=lambda text: inserted.append(text),
+        )
+        transcript = SimpleNamespace(
+            append_system=lambda text, style="muted": rows.append(text)
+        )
+        on_target = (
+            lambda note, path: ClawCodexTUI._on_memory_target(
+                fake, note, path, transcript
+            )
+        )
+        return on_target, rows, inserted
+
+    def test_cancel_row_and_note_restored(self) -> None:
+        on_target, rows, inserted = self._fake()
+        on_target(" my note", None)
+        assert rows == ["Cancelled memory editing"]
+        assert inserted == ["# my note"]
+
+    def test_success_rows(self, tmp_path) -> None:
+        on_target, rows, inserted = self._fake()
+        target = tmp_path / "CLAUDE.md"
+        on_target(" my note", str(target))
+        assert target.read_text() == "- my note\n"
+        assert rows[0] == "# my note"
+        assert rows[1] in SAVING_MESSAGES
+        assert inserted == []
+
+    def test_write_failure_row_and_restore(self, tmp_path) -> None:
+        on_target, rows, inserted = self._fake()
+        target = tmp_path / "CLAUDE.md"
+        target.mkdir()  # forces the append to fail
+        on_target("note", str(target))
+        assert any("memory not saved" in r for r in rows)
+        assert inserted == ["#note"]
+
+    def test_enumeration_failure_row_and_restore(self, monkeypatch) -> None:
+        import asyncio
+
+        import src.command_system.memory_command as memory_command_mod
+        from src.tui.app import ClawCodexTUI
+
+        async def boom(cwd):
+            raise RuntimeError("no memory files")
+
+        monkeypatch.setattr(memory_command_mod, "build_memory_options", boom)
+        rows: list[str] = []
+        inserted: list[str] = []
+        fake = SimpleNamespace(
+            workspace_root="/tmp",
+            _insert_into_prompt=lambda text: inserted.append(text),
+        )
+        transcript = SimpleNamespace(
+            append_system=lambda text, style="muted": rows.append(text)
+        )
+        asyncio.run(ClawCodexTUI._memory_shortcut_flow(fake, "note", transcript))
+        assert any("Could not enumerate" in r for r in rows)
+        assert inserted == ["#note"]
+
+    def test_note_recorded_in_history(self) -> None:
+        from src.tui.app import ClawCodexTUI
+
+        history: list[str] = []
+        workers: list = []
+        fake = SimpleNamespace(
+            history_store=SimpleNamespace(
+                append=lambda text: history.append(text)
+            ),
+            run_worker=lambda coro, **kw: workers.append(coro),
+            _memory_shortcut_flow=lambda note, transcript: _coro(),
+        )
+        ClawCodexTUI.run_memory_shortcut(fake, " my note", None)
+        assert history == ["# my note"]
+        for w in workers:
+            w.close()
+
+
+async def _coro():
+    return None


### PR DESCRIPTION
## Summary
- A prompt starting with `#` saves a note to a chosen memory file instead of starting an agent turn: repl routing (precedence `/`, `!`, `#`; bare `#` falls through to the agent) → `MemorySaveScreen` over the `/memory` target hierarchy (`build_memory_options` promoted to a public shared API so the two pickers can never drift) → `services/memory_append.py`.
- **Honesty note** (recorded in plan §9, gap-doc T7, and the module docstring): the vendored TS snapshot ships only the renderer (`UserMemoryInputMessage.tsx` — `#` row + random "Got it. / Good to know. / Noted.") and the selector — no `#` detection or append exists in it. TS-verbatim pieces are ported verbatim (acknowledgement trio, "Cancelled memory editing", target hierarchy); the connective glue is explicitly port-derived: ensure-create, single-newline separation, `- ` bullet unless the note supplies its own punctuation.
- Every failure/cancel path restores `#note` into the prompt (nothing typed is lost — deliberate, don't revert as "extra"); notes are recorded in prompt history like `!` commands; no agent turn consumed.

## Test plan
- [x] 17 tests: append discipline (create+bullet, newline handling, no double-bulleting, empty rejected, OSError/ValueError → False, parent-dir creation), screen pilot (enter/down-enter/escape), repl routing via the real handler (`#` intercepts stripped, bare `#` falls through, `!` unaffected), app flow (cancel/success/write-failure/enumeration-failure rows + restore, history recording)
- [x] TUI + services + memory suites: 762 passed, 0 new failures
- [x] Full suite BASELINE-IDENTICAL vs the 12 known pre-existing failures
- [x] Critic: APPROVE (independently re-verified the snapshot claims; 3 MINOR / 4 NIT all applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)