### PR TITLE
Notify on background-workflow completion (banner + agent summary)

### DIFF
--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -497,6 +497,13 @@ class ClawcodexREPL:
         # reference's "type while it's still thinking" affordance.
         self._queued_prompts: list[str] = []
         self._queued_prompts_lock = threading.Lock()
+        # True only while the main run() loop is blocked on the idle
+        # ``❯`` prompt. The background notification watcher reads this to
+        # decide whether it may wake the prompt (so a finished workflow's
+        # banner + summary surface without a keystroke); it never wakes a
+        # permission dialog or an in-progress chat turn.
+        self._at_prompt = False
+        self._notif_stop: threading.Event | None = None
         # Permission dialogs can be requested from different worker paths
         # (e.g. subagents/tools). Serialize interactive prompts so we never
         # mount competing prompt_toolkit applications at once.
@@ -1857,6 +1864,107 @@ class ClawcodexREPL:
         with self._queued_prompts_lock:
             return len(self._queued_prompts)
 
+    # ── background-task completion notifications ───────────────────────────────
+    def _deliver_pending_task_notifications(self) -> bool:
+        """Drain finished-task ``<task-notification>`` envelopes, print a
+        completion banner for each, then hand them to the agent as one turn so it
+        summarizes the result and points to where the output lives.
+
+        Returns whether anything was delivered (the run loop ``continue``s when
+        so, to re-read fresh input afterwards). Safe to call every turn — a empty
+        queue is a cheap no-op.
+        """
+        try:
+            from src.utils.message_queue_manager import drain_pending_notifications
+        except Exception:
+            return False
+        drained = drain_pending_notifications(mode="task-notification")
+        if not drained:
+            return False
+
+        from src.repl.task_notifications import build_notification_turn, parse_task_id, render_banner
+
+        registry = getattr(getattr(self, "tool_context", None), "runtime_tasks", None)
+        envelopes = [n.value for n in drained]
+        self.console.print()
+        for xml in envelopes:
+            state = None
+            if registry is not None:
+                task_id = parse_task_id(xml)
+                if task_id:
+                    try:
+                        state = registry.get(task_id)
+                    except Exception:
+                        state = None
+            for line in render_banner(xml, state):
+                self.console.print(line)
+
+        # Let the agent read the results and report conversationally.
+        self.chat(build_notification_turn(envelopes))
+        return True
+
+    def _wake_idle_prompt(self) -> None:
+        """Unblock the idle ``❯`` prompt from another thread so a freshly
+        finished workflow surfaces without a keystroke.
+
+        Only fires when the prompt is genuinely idle (running with an empty
+        buffer); a half-typed line is left untouched. Verified against
+        prompt_toolkit 3.0.x: ``app.exit(result="")`` makes ``prompt()`` return
+        ``""``, which the run loop treats as a no-op turn that then delivers.
+        """
+        session = getattr(self, "prompt_session", None)
+        app = getattr(session, "app", None)
+        loop = getattr(app, "loop", None)
+        if app is None or loop is None:
+            return
+        try:
+            if loop.is_closed():
+                return
+        except Exception:
+            return
+
+        def _exit_if_idle() -> None:
+            try:
+                if app.is_running and not app.current_buffer.text:
+                    app.exit(result="")
+            except Exception:
+                pass
+
+        try:
+            loop.call_soon_threadsafe(_exit_if_idle)
+        except Exception:
+            pass
+
+    def _notification_watcher(self, stop: threading.Event) -> None:
+        """Daemon loop: while the user idles at the prompt, wake it as soon as a
+        background task posts a completion notification."""
+        from src.utils.message_queue_manager import peek_pending_notifications
+
+        while not stop.is_set():
+            try:
+                if self._at_prompt and peek_pending_notifications():
+                    self._wake_idle_prompt()
+            except Exception:
+                pass
+            stop.wait(0.4)
+
+    def _start_notification_watcher(self) -> None:
+        if self._notif_stop is not None:
+            return
+        stop = threading.Event()
+        self._notif_stop = stop
+        threading.Thread(
+            target=self._notification_watcher,
+            args=(stop,),
+            name="repl-task-notifications",
+            daemon=True,
+        ).start()
+
+    def _stop_notification_watcher(self) -> None:
+        if self._notif_stop is not None:
+            self._notif_stop.set()
+            self._notif_stop = None
+
     def _status_message(self) -> str:
         """Spinner status text. Includes queued-prompt count when non-zero."""
 
@@ -2186,10 +2294,17 @@ class ClawcodexREPL:
     def run(self):
         """Run the REPL."""
         self._print_startup_header()
+        self._start_notification_watcher()
 
         while True:
             try:
                 self._refresh_completer()
+                # Surface any background task (workflow/agent) that finished
+                # since the last turn: print its banner and let the agent
+                # summarize it. Delivered work counts as a turn, so loop back
+                # to read fresh input afterwards.
+                if self._deliver_pending_task_notifications():
+                    continue
                 queued = self._pop_queued_prompt()
                 if queued is not None:
                     # Echo queued submissions with a dim background so
@@ -2209,7 +2324,15 @@ class ClawcodexREPL:
                     # up front so that newlines (via Shift+Enter / Meta+Enter
                     # / ``\`` + Enter) can live in the buffer. Plain Enter
                     # still submits via our custom ``c-m`` binding.
-                    user_input = self.prompt_session.prompt('❯ ')
+                    #
+                    # ``_at_prompt`` lets the notification watcher wake this
+                    # blocking read when a background workflow finishes; the
+                    # wake returns "" (handled as a no-op turn below).
+                    self._at_prompt = True
+                    try:
+                        user_input = self.prompt_session.prompt('❯ ')
+                    finally:
+                        self._at_prompt = False
 
                 if not user_input.strip():
                     continue
@@ -2226,6 +2349,8 @@ class ClawcodexREPL:
             except EOFError:
                 self.console.print("\n[blue]Goodbye![/blue]")
                 break
+
+        self._stop_notification_watcher()
 
     def handle_command(self, command: str):
         """Handle slash commands."""

--- a/src/repl/task_notifications.py
+++ b/src/repl/task_notifications.py
@@ -1,0 +1,158 @@
+"""REPL-side delivery of background-task completion notifications.
+
+Background workflows (and background agents) run on daemon threads. When one
+finishes it pushes a ``<task-notification>`` envelope onto the process-global
+queue in :mod:`src.utils.message_queue_manager` (see
+``src.tasks.local_workflow.enqueue_workflow_notification``). The chapter
+deferred the *consumer* side of that queue ("WI-3.3"); for the interactive REPL
+this module is it.
+
+The REPL drains the queue at each turn boundary and, for every drained envelope:
+
+* prints a deterministic completion **banner** (so the user learns a run
+  finished the moment it does, with a pointer to where the output lives), and
+* hands the envelope back to the agent as a **turn** so it can read the result
+  and summarize it conversationally — the Claude Code "the research is done…"
+  behavior.
+
+Everything here is pure and side-effect free (no console, no registry mutation,
+no queue access) so it unit-tests without a live REPL; the REPL glue in
+``src/repl/core.py`` is the thin part that wires it to the console and ``chat``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+from src.constants.xml import (
+    OUTPUT_FILE_TAG,
+    STATUS_TAG,
+    SUMMARY_TAG,
+    TASK_ID_TAG,
+)
+from src.workflow.progress import format_duration, format_tokens
+
+# Status → (icon, rich color, past-tense verb) for the banner head.
+_BANNER_STYLE: dict[str, tuple[str, str, str]] = {
+    "completed": ("✔", "green", "completed"),
+    "failed": ("✗", "red", "failed"),
+    "killed": ("⊘", "yellow", "stopped"),
+}
+
+
+def _field(xml: str, tag: str) -> Optional[str]:
+    m = re.search(rf"<{re.escape(tag)}>(.*?)</{re.escape(tag)}>", xml, re.DOTALL)
+    return m.group(1).strip() if m else None
+
+
+def parse_task_id(xml: str) -> Optional[str]:
+    """Pull the ``<task-id>`` out of a notification envelope (for registry
+    correlation), or ``None`` if absent."""
+    return _field(xml, TASK_ID_TAG)
+
+
+def _elapsed_seconds(state: Any) -> Optional[float]:
+    start = getattr(state, "start_time", None)
+    end = getattr(state, "end_time", None)
+    if isinstance(start, (int, float)) and isinstance(end, (int, float)) and end >= start:
+        return end - start
+    return None
+
+
+def _stat_bits(state: Any) -> list[str]:
+    progress = getattr(state, "progress", None)
+    bits: list[str] = []
+    try:
+        phases = list(getattr(progress, "phases", None) or [])
+        total = sum(len(p.agents) for p in phases)
+        if total:
+            bits.append(f"{total} agents")
+    except Exception:
+        pass
+    try:
+        tok = int(getattr(progress, "token_total", 0) or 0)
+        if tok:
+            bits.append(f"{format_tokens(tok)} tok")
+    except Exception:
+        pass
+    dur = format_duration(_elapsed_seconds(state))
+    if dur:
+        bits.append(dur)
+    return bits
+
+
+def format_completion_banner(state: Any) -> list[str]:
+    """Deterministic completion banner (rich-markup lines) from a terminal
+    ``local_workflow`` task state.
+
+    Never raises — every field degrades to a sensible default, because this runs
+    on the REPL's main loop where an exception would be disruptive.
+    """
+    status = (getattr(state, "status", "") or "").lower()
+    icon, color, verb = _BANNER_STYLE.get(status, ("•", "cyan", status or "finished"))
+    name = getattr(state, "workflow_name", None) or "workflow"
+
+    tail = (" · " + " · ".join(bits)) if (bits := _stat_bits(state)) else ""
+    lines = [f"[{color}]{icon}[/{color}] [bold]{name}[/bold] {verb}{tail}"]
+
+    if status == "failed":
+        err = getattr(state, "error", None)
+        if err:
+            lines.append(f"  [red]{err}[/red]")
+    out = getattr(state, "output_file", None)
+    if out:
+        lines.append(f"  [dim]run journal → {out}[/dim]")
+    return lines
+
+
+def format_completion_banner_xml(xml: str) -> list[str]:
+    """Fallback banner built straight from an envelope, for the rare case where
+    the task state has already been evicted by delivery time."""
+    status = (_field(xml, STATUS_TAG) or "").lower()
+    icon, color, _verb = _BANNER_STYLE.get(status, ("•", "cyan", status or "finished"))
+    summary = _field(xml, SUMMARY_TAG) or "Background task finished"
+    lines = [f"[{color}]{icon}[/{color}] {summary}"]
+    out = _field(xml, OUTPUT_FILE_TAG)
+    if out:
+        lines.append(f"  [dim]run journal → {out}[/dim]")
+    return lines
+
+
+def render_banner(xml: str, state: Any | None) -> list[str]:
+    """Prefer the rich registry-state banner; fall back to the envelope."""
+    if state is not None:
+        try:
+            return format_completion_banner(state)
+        except Exception:
+            pass
+    return format_completion_banner_xml(xml)
+
+
+_TURN_PREAMBLE = (
+    "<system-reminder>\n"
+    "One or more background tasks you launched have finished. Their results are "
+    "delivered below as <task-notification> envelopes — these are system events, "
+    "not a new request the user typed. For each finished task: briefly confirm "
+    "it's done, summarize the key findings or output for the user, and tell them "
+    "where the full result is saved (the <output-file>, or any file path named "
+    "inside the <result>). If the <result> points at a file you must read to "
+    "report it accurately (for example a CSV), read it first. Keep it concise.\n"
+    "</system-reminder>"
+)
+
+
+def build_notification_turn(notifications: list[str]) -> str:
+    """Assemble drained ``<task-notification>`` envelopes into a single agent
+    turn: a guiding preamble followed by the raw envelopes."""
+    body = "\n\n".join(n.strip() for n in notifications if n and n.strip())
+    return f"{_TURN_PREAMBLE}\n\n{body}"
+
+
+__all__ = [
+    "parse_task_id",
+    "format_completion_banner",
+    "format_completion_banner_xml",
+    "render_banner",
+    "build_notification_turn",
+]

--- a/tests/test_repl_task_notifications.py
+++ b/tests/test_repl_task_notifications.py
@@ -1,0 +1,314 @@
+"""Background-task completion notifications surfaced in the REPL.
+
+Covers the pure formatter/turn-builder (``src/repl/task_notifications.py``) and
+the thin REPL glue (``ClawcodexREPL._deliver_pending_task_notifications`` /
+``_wake_idle_prompt`` / ``_notification_watcher``), exercised on a bare instance
+(``__new__``) so the heavy constructor is skipped.
+"""
+
+from __future__ import annotations
+
+import io
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from src.repl.task_notifications import (
+    build_notification_turn,
+    format_completion_banner,
+    format_completion_banner_xml,
+    parse_task_id,
+    render_banner,
+)
+from src.tasks.local_workflow import (
+    complete_workflow_task,
+    fail_workflow_task,
+    register_workflow_task,
+)
+from src.task_registry import RuntimeTaskRegistry
+from src.utils.message_queue_manager import (
+    clear_pending_notifications,
+    peek_pending_notifications,
+)
+from src.workflow.progress import WorkflowProgress
+
+
+@pytest.fixture(autouse=True)
+def _clean_queue():
+    clear_pending_notifications()
+    yield
+    clear_pending_notifications()
+
+
+class _FakeRun:
+    controller = SimpleNamespace(abort=lambda *a, **k: None)
+
+
+def _completed_registry(*, task_id="t1", name="deep-research", result=None, tokens=5):
+    reg = RuntimeTaskRegistry()
+    prog = WorkflowProgress([{"title": "Search"}])
+    prog.start_phase("Search")
+    rec = prog.agent_started(0, "finder", "Search", "0")
+    prog.agent_finished(rec, status="completed", tokens=tokens)
+    register_workflow_task(
+        task_id=task_id, run_id="r1", workflow_name=name, description="d",
+        output_file="/tmp/journal.json", progress=prog, run=_FakeRun(), registry=reg,
+    )
+    complete_workflow_task(task_id, result=result or {"report": "Micron HBM edge"}, registry=reg)
+    return reg
+
+
+# ── pure helpers ──────────────────────────────────────────────────────────────
+
+
+def test_parse_task_id():
+    xml = "<task-notification>\n<task-id>w94sx230j</task-id>\n<status>completed</status>\n</task-notification>"
+    assert parse_task_id(xml) == "w94sx230j"
+    assert parse_task_id("<task-notification></task-notification>") is None
+
+
+def test_format_completion_banner_completed():
+    reg = _completed_registry(tokens=847_700)
+    lines = format_completion_banner(reg.get("t1"))
+    blob = "\n".join(lines)
+    assert "✔" in blob
+    assert "deep-research" in blob
+    assert "completed" in blob
+    assert "1 agents" in blob          # one finished agent
+    assert "847.7k tok" in blob        # compact tokens
+    assert "journal → /tmp/journal.json" in blob
+
+
+def test_format_completion_banner_failed_shows_error():
+    reg = RuntimeTaskRegistry()
+    register_workflow_task(
+        task_id="t2", run_id="r2", workflow_name="deep-research", description="d",
+        output_file="/tmp/j2.json", progress=WorkflowProgress([]), run=_FakeRun(), registry=reg,
+    )
+    fail_workflow_task("t2", error="synthesize: structured output not produced", registry=reg)
+    blob = "\n".join(format_completion_banner(reg.get("t2")))
+    assert "✗" in blob
+    assert "failed" in blob
+    assert "structured output not produced" in blob
+
+
+def test_format_completion_banner_xml_fallback():
+    xml = (
+        "<task-notification>\n<task-id>x</task-id>\n<output-file>/tmp/j.json</output-file>\n"
+        '<status>completed</status>\n<summary>Agent "deep-research" completed</summary>\n</task-notification>'
+    )
+    blob = "\n".join(format_completion_banner_xml(xml))
+    assert "✔" in blob
+    assert 'Agent "deep-research" completed' in blob
+    assert "journal → /tmp/j.json" in blob
+
+
+def test_render_banner_prefers_state_falls_back_to_xml():
+    reg = _completed_registry()
+    assert any("deep-research" in ln for ln in render_banner("<x/>", reg.get("t1")))
+    # no state -> fall back to the envelope's summary
+    xml = "<task-notification>\n<status>killed</status>\n<summary>Agent \"w\" was stopped</summary>\n</task-notification>"
+    assert any("stopped" in ln for ln in render_banner(xml, None))
+
+
+def test_build_notification_turn_wraps_envelopes():
+    turn = build_notification_turn(["<task-notification>A</task-notification>", "<task-notification>B</task-notification>"])
+    assert "<system-reminder>" in turn
+    assert "background tasks" in turn
+    assert "<task-notification>A</task-notification>" in turn
+    assert "<task-notification>B</task-notification>" in turn
+
+
+# ── REPL glue (bare instance via __new__) ─────────────────────────────────────
+
+
+def _bare_repl():
+    from rich.console import Console
+
+    from src.repl.core import ClawcodexREPL
+
+    repl = ClawcodexREPL.__new__(ClawcodexREPL)
+    buf = io.StringIO()
+    repl.console = Console(file=buf, width=100, force_terminal=False)
+    repl._at_prompt = False
+    repl._notif_stop = None
+    return repl, buf
+
+
+def test_deliver_prints_banner_and_feeds_agent():
+    reg = _completed_registry()
+    repl, buf = _bare_repl()
+    repl.tool_context = SimpleNamespace(runtime_tasks=reg)
+    turns: list[str] = []
+    repl.chat = lambda text: turns.append(text)
+
+    assert peek_pending_notifications()  # complete_workflow_task enqueued one
+    assert repl._deliver_pending_task_notifications() is True
+
+    out = buf.getvalue()
+    assert "✔" in out and "deep-research" in out         # banner printed
+    assert len(turns) == 1                                # exactly one agent turn
+    assert "<task-notification>" in turns[0]              # envelope handed to agent
+    assert "<system-reminder>" in turns[0]               # with the guiding preamble
+
+    # queue is now empty -> a second call is a no-op (no extra turn)
+    assert repl._deliver_pending_task_notifications() is False
+    assert len(turns) == 1
+
+
+def test_deliver_noop_on_empty_queue():
+    repl, _ = _bare_repl()
+    repl.tool_context = SimpleNamespace(runtime_tasks=RuntimeTaskRegistry())
+    repl.chat = lambda text: pytest.fail("chat must not run with an empty queue")
+    assert repl._deliver_pending_task_notifications() is False
+
+
+# ── idle-prompt wake guard ────────────────────────────────────────────────────
+
+
+class _FakeLoop:
+    def __init__(self):
+        self.closed = False
+
+    def is_closed(self):
+        return self.closed
+
+    def call_soon_threadsafe(self, fn):  # run inline so the test is deterministic
+        fn()
+
+
+class _FakeBuffer:
+    def __init__(self, text=""):
+        self.text = text
+
+
+class _FakeApp:
+    def __init__(self, *, is_running=True, text=""):
+        self.is_running = is_running
+        self.loop = _FakeLoop()
+        self.current_buffer = _FakeBuffer(text)
+        self.exited_with = "UNSET"
+
+    def exit(self, result=None):
+        self.exited_with = result
+
+
+def _wake_with(app):
+    repl, _ = _bare_repl()
+    repl.prompt_session = SimpleNamespace(app=app)
+    repl._wake_idle_prompt()
+    return app
+
+
+def test_wake_exits_when_idle_and_empty():
+    app = _wake_with(_FakeApp(is_running=True, text=""))
+    assert app.exited_with == ""  # prompt() will return "" -> no-op turn
+
+
+def test_wake_leaves_half_typed_input_untouched():
+    app = _wake_with(_FakeApp(is_running=True, text="git comm"))
+    assert app.exited_with == "UNSET"  # never clobber the user's buffer
+
+
+def test_wake_noop_when_app_not_running():
+    app = _wake_with(_FakeApp(is_running=False, text=""))
+    assert app.exited_with == "UNSET"
+
+
+def test_wake_noop_when_no_session():
+    repl, _ = _bare_repl()
+    repl.prompt_session = None
+    repl._wake_idle_prompt()  # must not raise
+
+
+# ── watcher wakes an idle prompt on a pending notification ────────────────────
+
+
+def test_watcher_wakes_prompt_when_idle_and_pending():
+    repl, _ = _bare_repl()
+    woke = threading.Event()
+    repl._wake_idle_prompt = woke.set  # type: ignore[method-assign]
+    repl._at_prompt = True
+
+    _completed_registry()  # enqueues a notification onto the global queue
+    stop = threading.Event()
+    t = threading.Thread(target=repl._notification_watcher, args=(stop,), daemon=True)
+    t.start()
+    try:
+        assert woke.wait(2.0), "watcher should wake the idle prompt within 2s"
+    finally:
+        stop.set()
+        t.join(timeout=1.0)
+
+
+def test_watcher_idle_false_does_not_wake():
+    repl, _ = _bare_repl()
+    woke = threading.Event()
+    repl._wake_idle_prompt = woke.set  # type: ignore[method-assign]
+    repl._at_prompt = False  # not at the prompt -> never wake
+
+    _completed_registry()
+    stop = threading.Event()
+    t = threading.Thread(target=repl._notification_watcher, args=(stop,), daemon=True)
+    t.start()
+    try:
+        assert not woke.wait(0.8)
+    finally:
+        stop.set()
+        t.join(timeout=1.0)
+
+
+# ── end-to-end: production launcher → enqueue → REPL delivery ──────────────────
+
+
+class _MiniRunner:
+    """Minimal AgentRunner — returns a structured result without a live model."""
+
+    async def run(self, spec, *, abort, index):
+        from src.workflow.types import AgentOutcome
+
+        if spec.schema is not None:
+            return AgentOutcome(structured={"echo": spec.prompt}, tokens=12)
+        return AgentOutcome(text="Micron's HBM edge is its 1-beta node.", tokens=12)
+
+
+def test_end_to_end_launch_to_repl_delivery(tmp_path):
+    import asyncio
+
+    from src.workflow.launch import run_workflow_task
+
+    reg = RuntimeTaskRegistry()
+    source = (
+        'meta = {"name": "deep-research", "description": "d", "phases": [{"title": "Go"}]}\n'
+        'phase("Go")\n'
+        'r = await agent("research micron hbm")\n'
+        'return {"report": r}\n'
+    )
+    result = asyncio.run(
+        run_workflow_task(
+            source=source,
+            runner=_MiniRunner(),
+            registry=reg,
+            task_id="we2e",
+            run_id="wf_e2e",
+            output_file=str(tmp_path / "journal.json"),
+        )
+    )
+    assert result.ok
+    assert reg.get("we2e").status == "completed"
+    # the launcher's completion path enqueued exactly one envelope
+    assert len(peek_pending_notifications()) == 1
+
+    # the REPL drains it: banner to console + one agent turn carrying the result
+    repl, buf = _bare_repl()
+    repl.tool_context = SimpleNamespace(runtime_tasks=reg)
+    turns: list[str] = []
+    repl.chat = lambda text: turns.append(text)
+    assert repl._deliver_pending_task_notifications() is True
+
+    out = buf.getvalue()
+    assert "✔" in out and "deep-research" in out
+    assert len(turns) == 1
+    assert "Micron's HBM edge" in turns[0]  # the workflow's result reached the agent


### PR DESCRIPTION
## Problem

You ran `/deep-research` end-to-end — all 15 agents finished, Synthesize completed — but the REPL **never told you**. The only way to see it was done was to keep polling `/workflows`, and even then there was no pointer to the results.

**Root cause:** on completion, `complete_workflow_task` → `enqueue_workflow_notification` dutifully builds a `<task-notification>` (result + output location + token/agent stats) and pushes it onto the `message_queue_manager` queue… and **nothing in the REPL ever drains that queue.** `drain_pending_notifications` had zero production callers — its own docstring admits the consumer side ("WI-3.3") was deferred. The notification was built and dropped on the floor.

## Fix

Wire the missing consumer, matching the Claude Code reference you showed (banner, then the agent reads + summarizes):

```
✔ deep-research completed · 15 agents · 847.7k tok · 6m 40s
  run journal → ~/.clawcodex/workflows/wf_1d92c718.json

● The research is done. Micron's HBM advantage comes down to its
  1-beta DRAM node (best perf-per-watt)… [agent summarizes the result]
```

- **`src/repl/task_notifications.py`** (new, pure + fully unit-tested): deterministic completion banner from the terminal task state (`✔`/`✗`/`⊘` · name · agents · tokens · duration · run journal), an envelope-only fallback, and `build_notification_turn()` that wraps drained envelopes in a guiding `<system-reminder>` for the agent.
- **REPL glue (`core.py`)**: `_deliver_pending_task_notifications()` drains the queue at the turn boundary, prints each banner, then hands the envelopes to the agent as **one turn** so it summarizes and points to where the output lives. A daemon watcher **wakes the idle `❯` prompt** the moment a run finishes — so it surfaces **without a keystroke** — and is careful to **never clobber a half-typed line or a permission dialog** (only wakes when the prompt is running with an empty buffer).

The cross-thread wake (`app.exit` via `loop.call_soon_threadsafe`) was verified against prompt_toolkit 3.0.52 under a PTY before building on it.

## Tests — 15, all green

Pure helpers; the REPL delivery method (banner + exactly one agent turn; no-op on empty queue); the wake guard (idle+empty exits; half-typed / not-running don't); the watcher (wakes when idle+pending, silent when not at prompt); and an **end-to-end** test driving the real production launcher (`run_workflow_task`) → enqueue → REPL delivery with a fake runner.

> Note: 7 pre-existing `tests/tui/test_workspace_search_c5.py` failures are a ripgrep/env issue on this machine (they fail on a clean tree too) — unrelated to this change.

## Scope note
Banner + agent-summary is the behavior you picked. `p` pause / `s` save and other surfaces are untouched. This consumer also covers background **agent** task notifications (same queue), not just workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)