### PR TITLE
Dispatchable saved /<name> workflows + the ultracode authoring keyword

### DIFF
--- a/docs/workflow-commands-and-ultracode-plan.md
+++ b/docs/workflow-commands-and-ultracode-plan.md
@@ -1,0 +1,78 @@
+# Plan: dynamic workflow slash commands + the `ultracode` authoring keyword
+
+> Closes the two gaps the user flagged against [`workflow-engine.md`](./workflow-engine.md)
+> §4.1 (ultracode authoring) and §4.5/§4.7 (saved `/<name>` workflows). Status from an
+> audit of the current tree, then a concrete build.
+
+## Audit — what exists vs. what's missing
+
+### Feature 1 — `ultracode` authoring keyword (§4.1, §4.8): **NOT IMPLEMENTED**
+`grep -ri ultracode src/` → **0 hits.** None of the three pieces exist:
+- the `ultracode` keyword in a prompt injecting a `<system-reminder>` that nudges the model to author/launch a workflow via the Workflow tool;
+- `/effort ultracode` enabling a session-long auto-orchestration mode;
+- the §4.8 gate (keyword no-ops + `ultracode` removed from the `/effort` menu when workflows are disabled).
+
+> Note: Python's effort pipeline is **inert** (`effort_command.py` docstring: `settings.effort`
+> reaches no request builder; there is no `xhigh`). So the faithfully-implementable half of
+> `/effort ultracode` is the **session orchestration mode** (a standing reminder), not a reasoning level.
+
+### Feature 2 — dynamic `/<name>` workflow commands (§4.5, §4.7): **PARTIAL**
+- ✅ Bundled `/deep-research` + `/workflows` register into the global registry via
+  `get_builtin_commands()` → dispatch + autocomplete work (fixed in #267).
+- ✅ Discovery logic exists: `workflows_integration.load_workflow_commands(cwd)` finds project
+  `.claude/workflows/*.py` + personal `~/.claude/workflows/*.py`, project-wins-personal.
+- ❌ **Gap:** that discovery is wired only into the aggregator's `get_commands()`, which has
+  **no real REPL consumers**. Saved workflows never reach the global command registry that
+  dispatch + suggestions read. **Confirmed empirically:** a saved `.claude/workflows/triage_issues.py`
+  → `global registry (dispatch): False`, `aggregator get_commands: True`. So `/triage-issues`
+  does not dispatch or autocomplete in the REPL.
+
+The fix model already exists for skills: `load_and_register_skills(registry=None)` is called at
+startup from REPL `_init_command_system` (`core.py:1073`) and TUI `app.py:1486`. Workflows need the
+identical treatment — they have no `load_and_register_workflows`.
+
+## Build
+
+### Part A — register saved workflows into the command registry
+- **`src/command_system/workflows_integration.py`**: add
+  `load_and_register_workflows(project_root=None, registry=None) -> list[PromptCommand]`, mirroring
+  `load_and_register_skills`:
+  - reuse `_discover_dir` for project `.claude/workflows/` + personal `~/.claude/workflows/`
+    (project enumerated first → wins on clash);
+  - **shadowing guard**: skip any name colliding with an already-registered command or alias
+    (builtins/bundled win — same rule skills use);
+  - gated by `is_workflows_enabled()` → returns `[]` when disabled;
+  - registers ONLY the discovered project/personal commands (bundled `/deep-research` + `/workflows`
+    are already registered by `register_builtin_commands`).
+- **Call it at startup** after skills: REPL `core.py::_init_command_system` and TUI
+  `app.py` (next to the existing `load_and_register_skills(registry=None)`).
+- **Tests** (`tests/test_workflow_dynamic_commands.py`): a saved project workflow resolves in the
+  global registry + carries the Workflow-tool directive; project-wins-personal; builtin-wins-over-
+  workflow on a name clash; disabled ⇒ not registered.
+
+### Part B — the `ultracode` authoring keyword + session mode
+- **New `src/workflow/ultracode.py`** (pure + process-global session flag, like
+  `message_queue_manager`):
+  - `prompt_requests_ultracode(text) -> bool` — case-insensitive `\bultracode\b`, gated by
+    `is_workflows_enabled()`;
+  - session flag: `set_ultracode_session(bool)` / `is_ultracode_session()` / `reset_ultracode()`;
+  - `ultracode_reminder_for(text) -> str | None` — the single decision used by the chat seam:
+    returns the keyword `<system-reminder>` when the keyword is present, else the standing
+    session reminder when session mode is on, else `None`; always `None` when workflows are disabled;
+  - reminder texts: confirm ultracode and instruct the model to **author/launch a workflow via the
+    Workflow tool** for this task (keyword = this turn; session = every substantive task this session).
+- **REPL `chat()` wiring**: after the existing at-mention/companion-intro attachment block, append
+  `ultracode_reminder_for(user_input)` to `user_input` when non-None (mirrors the companion-intro append).
+- **`/effort ultracode`** (`effort_command.py`): an `ultracode` branch (gated by
+  `is_workflows_enabled()`) that calls `set_ultracode_session(True)` and confirms; selecting any real
+  level or `auto` calls `set_ultracode_session(False)` (reset per "reset with /effort high"). Add an
+  `ultracode` picker option **only when workflows are enabled** (§4.8 removal when disabled).
+- **Tests** (`tests/test_ultracode.py`): keyword detection (positive / negative / word-boundary /
+  case); `ultracode_reminder_for` precedence + gating (None when disabled); session set/clear/reset;
+  `/effort ultracode` enables session mode and is gated; a real `/effort` level clears it.
+
+## Out of scope (call it out, don't half-build)
+- Wiring the keyword into the **TUI** chat path (different submission seam); the detection/reminder
+  logic is a reusable pure module so the TUI can adopt it in a follow-up. REPL is the user's surface.
+- `Option+W` keyword-highlight dismissal and the editor "View raw script" affordance (UI polish).
+- Making the effort *reasoning level* actually reach inference (a separate, already-deferred phase).

--- a/docs/workflow-engine-port-plan.md
+++ b/docs/workflow-engine-port-plan.md
@@ -334,3 +334,18 @@ dispatch loop — with a production-topology regression test; schema subagents n
 `resolve_agent_tools` (firewall + scoping, `Workflow` stripped — no recursion) before the injected
 `StructuredOutput` tool, instead of receiving the full base pool; and `run_agent` now honors
 `permission_mode_override`, so the `acceptEdits` guarantee for workflow subagents is actually applied.
+
+**Addendum — §4.1 ultracode + §4.7 dynamic-command registration (closed two gaps).** The Phase-7
+row above overstated discovery: saved `.claude/workflows/*.py` were produced by `load_workflow_commands`
+but only fed the aggregator's `get_commands()`, which has **no real REPL consumers**, so `/<name>`
+never reached the global registry that dispatch + suggestions read (the same orphaning that hid
+`/deep-research` until #267). And the `ultracode` authoring keyword (§4.1) was never built (0 hits in
+`src/`). Both are now done (see `workflow-commands-and-ultracode-plan.md`):
+- **Dynamic commands** — `load_and_register_workflows(registry=None)` (mirrors `load_and_register_skills`,
+  same shadowing guard: builtins/bundled win, project beats personal) is called at REPL + TUI startup, so
+  saved workflows dispatch **and** autocomplete (with a `workflow` tag). ✅ `test_workflow_dynamic_commands.py`
+- **ultracode** — `src/workflow/ultracode.py`: the `\bultracode\b` keyword in a prompt (one-shot) and
+  `/effort ultracode` (session-long mode) append a `<system-reminder>` nudging the model to author a
+  workflow via the Workflow tool. Gated by `is_workflows_enabled()` (§4.8: keyword no-ops, the option
+  leaves the `/effort` menu when off). Note: Python's effort pipeline is inert, so `/effort ultracode`
+  contributes the orchestration mode only, not a reasoning level. ✅ `test_ultracode.py`

--- a/src/command_system/effort_command.py
+++ b/src/command_system/effort_command.py
@@ -76,6 +76,26 @@ _DESCRIPTIONS: dict[str, str] = {
 # TS effort.tsx:213: picker auto-pick description when effort is undefined.
 _AUTO_PICKER_DESC = "Use default effort level for your model"
 
+# workflow-engine §4.1: `/effort ultracode` enables the session-long workflow
+# auto-orchestration mode (not a persisted effort level — Python's effort
+# pipeline is inert, so this contributes the orchestration mode only).
+_ULTRACODE_ON_MSG = (
+    "Ultracode on: I'll plan and run a workflow (fan out subagents + verify) for "
+    "substantive tasks this session, instead of working turn by turn. "
+    "Reset with /effort high."
+)
+
+
+def _valid_options_str() -> str:
+    base = "low, medium, high, max, auto"
+    from src.workflow.gating import is_workflows_enabled
+
+    return f"{base}, ultracode" if is_workflows_enabled() else base
+
+
+def _invalid_msg(raw: str) -> str:
+    return f"Invalid argument: {raw}. Valid options are: {_valid_options_str()}"
+
 # TS effort.tsx:179 help text, minus the xhigh line (no OpenAI-effort path in Python).
 _USAGE = (
     "Usage: /effort [low|medium|high|max|auto]\n\n"
@@ -131,6 +151,19 @@ def _effort_options(current: str) -> list[UIOption]:
                 description="current" if level == current else None,
             )
         )
+    # Ultracode (workflow-engine §4.1) — workflow auto-orchestration mode. Only in
+    # the menu when workflows are enabled (§4.8: removed when off).
+    from src.workflow.gating import is_workflows_enabled
+    from src.workflow.ultracode import is_ultracode_session
+
+    if is_workflows_enabled():
+        options.append(
+            UIOption(
+                value="ultracode",
+                label="ultracode",
+                description="on" if is_ultracode_session() else "workflow auto-orchestration",
+            )
+        )
     return options
 
 
@@ -171,6 +204,13 @@ class EffortCommand(InteractiveCommand):
             )
             if picked is None:  # TS handleCancel -> onDone('Cancelled') (no options -> user).
                 return InteractiveOutcome(message="Cancelled", display="user")
+            from src.workflow.ultracode import set_ultracode_session
+
+            if picked == "ultracode":
+                set_ultracode_session(True)
+                return InteractiveOutcome(message=_ULTRACODE_ON_MSG, display="user")
+            # Any real effort choice exits ultracode mode (spec: "reset with /effort high").
+            set_ultracode_session(False)
             if picked == "auto":
                 set_effort(None)
                 # TS effort.tsx:213 (effort=undefined).
@@ -185,21 +225,28 @@ class EffortCommand(InteractiveCommand):
             )
 
         # 4. explicit arg (headless — TS executeEffort :108-123).
+        from src.workflow.ultracode import set_ultracode_session
+
+        if a == "ultracode":
+            # workflow-engine §4.1 / §4.8: only valid when workflows are enabled.
+            from src.workflow.gating import is_workflows_enabled
+
+            if not is_workflows_enabled():
+                return InteractiveOutcome(message=_invalid_msg(raw), display="user")
+            set_ultracode_session(True)
+            return InteractiveOutcome(message=_ULTRACODE_ON_MSG, display="user")
         if a in ("auto", "unset"):
             set_effort(None)  # TS unsetEffortLevel.
+            set_ultracode_session(False)
             return InteractiveOutcome(message="Effort level set to auto", display="user")
         if a in _levels():
             set_effort(a)  # TS setEffortValue (env-override / session-only branches dropped).
+            set_ultracode_session(False)  # selecting a real level exits ultracode
             return InteractiveOutcome(
                 message=f"Set effort level to {a}: {_DESCRIPTIONS[a]}", display="user"
             )
         # TS :120-122 (minus xhigh). Use the trimmed original-case arg in the message.
-        return InteractiveOutcome(
-            message=(
-                f"Invalid argument: {raw}. Valid options are: low, medium, high, max, auto"
-            ),
-            display="user",
-        )
+        return InteractiveOutcome(message=_invalid_msg(raw), display="user")
 
 
 EFFORT_COMMAND = EffortCommand(

--- a/src/command_system/workflows_integration.py
+++ b/src/command_system/workflows_integration.py
@@ -13,13 +13,16 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from src.workflow.bundled import bundled_workflow_path
 from src.workflow.gating import is_workflows_enabled
 from src.workflow.sandbox import extract_meta
 
 from .types import Command, PromptCommand
+
+if TYPE_CHECKING:
+    from .registry import CommandRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -135,3 +138,44 @@ def load_workflow_commands(cwd: str) -> list[Command]:
         seen.add(cmd.name)
         commands.append(cmd)
     return commands
+
+
+def load_and_register_workflows(
+    project_root: str | Path | None = None,
+    registry: "CommandRegistry | None" = None,
+) -> list[PromptCommand]:
+    """Discover saved project/personal workflows and register them as ``/<name>``
+    commands into the command registry (global if ``registry`` is ``None``).
+
+    This is the workflow analogue of :func:`load_and_register_skills`, and exists
+    for the same reason: the aggregator's ``get_commands()`` lists these but has
+    no real consumers, so dispatch + suggestions (which read the GLOBAL registry)
+    never saw saved workflows. The REPL/TUI call this at startup, right after
+    ``load_and_register_skills``.
+
+    Precedence, all via the shadowing guard (a name already in the target wins):
+    builtins/bundled (registered first) beat saved workflows; **project beats
+    personal** (project is enumerated first); workflow-vs-workflow ties are
+    first-wins. Only the discovered project/personal commands are registered —
+    bundled ``/deep-research`` + ``/workflows`` already come from
+    ``register_builtin_commands``.
+
+    Gated by :func:`is_workflows_enabled`; returns ``[]`` when workflows are off.
+    """
+    if not is_workflows_enabled():
+        return []
+
+    from .registry import get_command_registry
+
+    cwd = Path(project_root) if project_root is not None else Path.cwd()
+    project = _discover_dir(cwd / ".claude" / "workflows", "project")
+    personal = _discover_dir(Path.home() / ".claude" / "workflows", "user")
+
+    target = registry if registry is not None else get_command_registry()
+    registered: list[PromptCommand] = []
+    for cmd in [*project, *personal]:  # project first → wins on a name clash
+        if target.get(cmd.name) is not None:
+            continue  # builtin / bundled / earlier workflow already owns the name
+        target.register(cmd)
+        registered.append(cmd)
+    return registered

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -1075,6 +1075,20 @@ class ClawcodexREPL:
             # Skill discovery must never block REPL startup; builtins still work.
             pass
 
+        # Saved workflows (.claude/workflows/*.py — project + personal) as
+        # /<name> commands, registered global-only after skills so builtins/
+        # bundled win on a name clash (same shadowing guard as skills). Without
+        # this, discovery lived only in the orphaned aggregator and /<name>
+        # never dispatched.
+        try:
+            from src.command_system.workflows_integration import (
+                load_and_register_workflows,
+            )
+
+            load_and_register_workflows(registry=None)
+        except Exception:
+            pass
+
         # Create command registry and register built-ins
         self.command_registry = CommandRegistry()
         register_builtin_commands(self.command_registry)
@@ -2939,6 +2953,17 @@ class ClawcodexREPL:
                         f"{user_input}\n\n{intro_text}"
                         if user_input else intro_text
                     )
+
+        # ultracode (workflow-engine §4.1): the `ultracode` keyword in this
+        # message, or the session-long `/effort ultracode` mode, appends a
+        # <system-reminder> nudging the model to author a workflow via the
+        # Workflow tool rather than working turn by turn. No-op (None) when
+        # workflows are disabled.
+        from src.workflow.ultracode import ultracode_reminder_for
+
+        ultra_reminder = ultracode_reminder_for(user_input)
+        if ultra_reminder:
+            user_input = f"{user_input}\n\n{ultra_reminder}" if user_input else ultra_reminder
 
         # Image @-mentions become real image content blocks on the user
         # message so the model sees the image directly (matches TS's

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -1484,6 +1484,13 @@ class ClawCodexTUI(App):
 
             register_builtin_commands(None)
             load_and_register_skills(registry=None)
+            # Saved workflows (.claude/workflows/*.py) as /<name> commands —
+            # same global-only registration + shadowing guard as skills.
+            from src.command_system.workflows_integration import (
+                load_and_register_workflows,
+            )
+
+            load_and_register_workflows(registry=None)
         except Exception:
             pass
         self._skills_registered = True

--- a/src/workflow/ultracode.py
+++ b/src/workflow/ultracode.py
@@ -1,0 +1,105 @@
+"""The ``ultracode`` workflow-authoring trigger (workflow-engine §4.1).
+
+Two entry points nudge the model to **author a workflow** (via the Workflow
+tool) instead of working turn by turn:
+
+* the keyword ``ultracode`` in a prompt — this turn only, and
+* ``/effort ultracode`` — a session-long auto-orchestration mode.
+
+Both are gated by :func:`is_workflows_enabled` (§4.8: the keyword no-ops and the
+``/effort`` option disappears when workflows are off). Session state is
+process-global — the same shape as :mod:`src.utils.message_queue_manager` — so
+the REPL chat seam and the ``/effort`` command share it without plumbing.
+
+This module is pure (no console, no model call); the REPL appends
+:func:`ultracode_reminder_for` to the user turn, and the model decides whether to
+launch a workflow. Python's effort pipeline is inert, so ``/effort ultracode``
+contributes the **orchestration mode**, not a reasoning level.
+"""
+
+from __future__ import annotations
+
+import re
+
+from src.workflow.gating import is_workflows_enabled
+
+# Standalone, case-insensitive keyword (won't fire on substrings like "ultracoder").
+_KEYWORD_RE = re.compile(r"\bultracode\b", re.IGNORECASE)
+
+# Process-global session toggle (set by ``/effort ultracode``).
+_session_on = False
+
+
+def prompt_requests_ultracode(text: str) -> bool:
+    """Whether ``text`` contains the standalone ``ultracode`` keyword. Always
+    ``False`` when workflows are disabled (§4.8)."""
+    if not text or not is_workflows_enabled():
+        return False
+    return bool(_KEYWORD_RE.search(text))
+
+
+def set_ultracode_session(on: bool) -> None:
+    """Turn the session-long auto-orchestration mode on/off."""
+    global _session_on
+    _session_on = bool(on)
+
+
+def is_ultracode_session() -> bool:
+    """Whether session mode is on **and** workflows are enabled."""
+    return _session_on and is_workflows_enabled()
+
+
+def reset_ultracode() -> None:
+    """Clear the session flag (test/teardown helper)."""
+    global _session_on
+    _session_on = False
+
+
+_KEYWORD_REMINDER = (
+    "<system-reminder>\n"
+    'The user included the keyword "ultracode" in their message — they are '
+    "explicitly opting into multi-agent workflow orchestration for THIS task. "
+    "Instead of working turn by turn, design and launch a workflow via the "
+    "Workflow tool: decompose the task, fan out subagents for the independent "
+    "parts, and adversarially verify findings before synthesizing. If the task "
+    "is genuinely trivial or purely conversational, you may handle it directly "
+    "and briefly say why. This reminder is injected by the harness, not typed by "
+    "the user.\n"
+    "</system-reminder>"
+)
+
+_SESSION_REMINDER = (
+    "<system-reminder>\n"
+    "Ultracode is on for this session: author and run a workflow (via the "
+    "Workflow tool) for every substantive task by default — decompose, fan out "
+    "subagents for independent work, and adversarially verify before "
+    "synthesizing. For multi-phase work, run several workflows in sequence so "
+    "you stay in the loop between phases. Solo only on conversational turns or "
+    "trivial mechanical edits. Reset with /effort high.\n"
+    "</system-reminder>"
+)
+
+
+def ultracode_reminder_for(text: str) -> str | None:
+    """The ultracode ``<system-reminder>`` to append to a user turn, or ``None``.
+
+    Precedence: the keyword in THIS message wins (one-shot keyword reminder);
+    otherwise, if session mode is on, the standing session reminder; otherwise
+    ``None``. Always ``None`` when workflows are disabled.
+    """
+    if not is_workflows_enabled():
+        return None
+    if prompt_requests_ultracode(text):
+        return _KEYWORD_REMINDER
+    if is_ultracode_session():
+        return _SESSION_REMINDER
+    return None
+
+
+__all__ = [
+    "prompt_requests_ultracode",
+    "set_ultracode_session",
+    "is_ultracode_session",
+    "reset_ultracode",
+    "ultracode_reminder_for",
+]

--- a/tests/test_effort_command.py
+++ b/tests/test_effort_command.py
@@ -219,7 +219,10 @@ async def test_arg_is_case_insensitive(isolated_settings):
     assert _persisted_effort() == "high"
 
 
-async def test_invalid_arg_does_not_persist(isolated_settings):
+async def test_invalid_arg_does_not_persist(isolated_settings, monkeypatch):
+    # Base effort contract (no workflow extension) — the `ultracode` menu option
+    # and valid-args entry are covered in test_ultracode.py.
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")
     tmp_path = isolated_settings
     out = await EFFORT_COMMAND.run("bogus", _ctx(tmp_path, ui=NullUIHost()))
     assert out.message == (
@@ -264,7 +267,8 @@ async def test_status_reports_persisted_level(isolated_settings):
 # --------------------------------------------------------------------------- #
 # D. Picker happy path
 # --------------------------------------------------------------------------- #
-async def test_picker_sets_level(isolated_settings):
+async def test_picker_sets_level(isolated_settings, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")  # base picker (no ultracode option)
     tmp_path = isolated_settings
     ui = FakeUIHost(pick="low")
     out = await EFFORT_COMMAND.run("", _ctx(tmp_path, ui=ui))
@@ -354,7 +358,8 @@ async def test_engine_arg_path_succeeds_headless(isolated_settings):
 # --------------------------------------------------------------------------- #
 # G. Options shape
 # --------------------------------------------------------------------------- #
-async def test_options_shape_marks_current_and_uses_raw_labels(isolated_settings):
+async def test_options_shape_marks_current_and_uses_raw_labels(isolated_settings, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")  # base picker (no ultracode option)
     tmp_path = isolated_settings
     await EFFORT_COMMAND.run("high", _ctx(tmp_path, ui=NullUIHost()))  # current=high
     ui = FakeUIHost(pick="high")

--- a/tests/test_ultracode.py
+++ b/tests/test_ultracode.py
@@ -1,0 +1,144 @@
+"""The ``ultracode`` workflow-authoring trigger (workflow-engine §4.1, §4.8).
+
+Covers the pure detection/reminder module (``src/workflow/ultracode.py``) and the
+``/effort ultracode`` session toggle wired into ``effort_command.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from src.command_system import create_command_context
+from src.command_system.effort_command import EFFORT_COMMAND, _effort_options
+from src.workflow import ultracode as uc
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_DISABLE_WORKFLOWS", raising=False)  # enabled by default
+    uc.reset_ultracode()
+    yield
+    uc.reset_ultracode()
+
+
+def _ctx(tmp_path: Path):
+    return create_command_context(workspace_root=tmp_path, cwd=tmp_path)
+
+
+# ── keyword detection ─────────────────────────────────────────────────────────
+
+
+def test_keyword_detection_positive():
+    assert uc.prompt_requests_ultracode("please ultracode this audit")
+    assert uc.prompt_requests_ultracode("ULTRACODE the repo")  # case-insensitive
+    assert uc.prompt_requests_ultracode("do it. ultracode.")    # punctuation boundary
+
+
+def test_keyword_detection_negative():
+    assert not uc.prompt_requests_ultracode("refactor the code")
+    assert not uc.prompt_requests_ultracode("ultracoder")  # word boundary, not a substring
+    assert not uc.prompt_requests_ultracode("supraultracode")
+    assert not uc.prompt_requests_ultracode("")
+
+
+def test_keyword_detection_disabled(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")
+    assert not uc.prompt_requests_ultracode("ultracode this")  # §4.8: no-op when off
+
+
+# ── reminder selection ────────────────────────────────────────────────────────
+
+
+def test_reminder_for_keyword():
+    r = uc.ultracode_reminder_for("ultracode: build X")
+    assert r is not None
+    assert "<system-reminder>" in r
+    assert '"ultracode"' in r
+    assert "Workflow tool" in r
+
+
+def test_reminder_none_when_idle():
+    assert uc.ultracode_reminder_for("just chatting about the weather") is None
+
+
+def test_reminder_for_session_mode():
+    uc.set_ultracode_session(True)
+    r = uc.ultracode_reminder_for("do a normal thing")
+    assert r is not None
+    assert "on for this session" in r
+
+
+def test_keyword_beats_session():
+    uc.set_ultracode_session(True)
+    r = uc.ultracode_reminder_for("ultracode it")
+    assert '"ultracode"' in r  # one-shot keyword reminder wins over the session one
+
+
+def test_reminder_none_when_disabled(monkeypatch):
+    uc.set_ultracode_session(True)
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")
+    assert uc.ultracode_reminder_for("ultracode it") is None
+
+
+# ── session flag ──────────────────────────────────────────────────────────────
+
+
+def test_session_flag_set_reset():
+    assert uc.is_ultracode_session() is False
+    uc.set_ultracode_session(True)
+    assert uc.is_ultracode_session() is True
+    uc.reset_ultracode()
+    assert uc.is_ultracode_session() is False
+
+
+def test_session_flag_gated_by_enablement(monkeypatch):
+    uc.set_ultracode_session(True)
+    assert uc.is_ultracode_session() is True
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")
+    assert uc.is_ultracode_session() is False  # gated even when the flag is set
+
+
+# ── /effort ultracode ─────────────────────────────────────────────────────────
+
+
+def test_effort_ultracode_enables_session(tmp_path, monkeypatch):
+    persisted: list = []
+    monkeypatch.setattr("src.command_system.effort_command.set_effort", lambda v: persisted.append(v))
+    out = asyncio.run(EFFORT_COMMAND.run("ultracode", _ctx(tmp_path)))
+    assert uc.is_ultracode_session() is True
+    assert "Ultracode on" in out.message
+    assert persisted == []  # ultracode is a mode, NOT a persisted effort level
+
+
+def test_effort_high_clears_ultracode(tmp_path, monkeypatch):
+    monkeypatch.setattr("src.command_system.effort_command.set_effort", lambda v: None)
+    uc.set_ultracode_session(True)
+    out = asyncio.run(EFFORT_COMMAND.run("high", _ctx(tmp_path)))
+    assert uc.is_ultracode_session() is False  # "reset with /effort high"
+    assert "high" in out.message
+
+
+def test_effort_auto_clears_ultracode(tmp_path, monkeypatch):
+    monkeypatch.setattr("src.command_system.effort_command.set_effort", lambda v: None)
+    uc.set_ultracode_session(True)
+    asyncio.run(EFFORT_COMMAND.run("auto", _ctx(tmp_path)))
+    assert uc.is_ultracode_session() is False
+
+
+def test_effort_ultracode_rejected_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")
+    out = asyncio.run(EFFORT_COMMAND.run("ultracode", _ctx(tmp_path)))
+    assert uc.is_ultracode_session() is False
+    assert "Invalid argument" in out.message  # §4.8
+
+
+def test_picker_includes_ultracode_when_enabled():
+    assert "ultracode" in [o.value for o in _effort_options("auto")]
+
+
+def test_picker_excludes_ultracode_when_disabled(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")
+    assert "ultracode" not in [o.value for o in _effort_options("auto")]

--- a/tests/test_workflow_dynamic_commands.py
+++ b/tests/test_workflow_dynamic_commands.py
@@ -1,0 +1,107 @@
+"""Saved ``.claude/workflows/*.py`` register as dispatchable ``/<name>`` commands.
+
+Regression guard for the gap audited in
+``docs/workflow-commands-and-ultracode-plan.md``: discovery existed only in the
+aggregator's orphaned ``get_commands()``, so saved workflows never reached the
+global registry that REPL dispatch + suggestions read. ``load_and_register_workflows``
+registers them with the same shadowing guard skills use.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.command_system.registry import CommandRegistry
+from src.command_system.workflows_integration import (
+    bundled_workflow_commands,
+    load_and_register_workflows,
+)
+
+_WF = 'meta = {{"name": "{name}", "description": "{desc}"}}\nreturn await agent("x")\n'
+
+
+def _write_wf(directory: Path, filename: str, name: str, desc: str = "d") -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / filename).write_text(_WF.format(name=name, desc=desc), encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _workflows_enabled(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_DISABLE_WORKFLOWS", raising=False)
+
+
+def test_saved_project_workflow_registers_and_dispatches(tmp_path):
+    _write_wf(tmp_path / ".claude" / "workflows", "triage-issues.py", "triage-issues", "Triage GH issues")
+    reg = CommandRegistry()
+    registered = load_and_register_workflows(project_root=tmp_path, registry=reg)
+
+    assert "triage-issues" in {c.name for c in registered}
+    cmd = reg.get("triage-issues")
+    assert cmd is not None
+    assert getattr(cmd, "kind", None) == "workflow"
+    assert getattr(cmd, "loaded_from", None) == "project"
+    assert cmd.description == "Triage GH issues"
+    # the dispatched prompt is the Workflow-tool directive pointing at the file
+    directive = getattr(cmd, "markdown_content", "")
+    assert "Workflow tool" in directive
+    assert "triage-issues.py" in directive
+
+
+def test_project_wins_over_personal(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", lambda: home)
+    proj = tmp_path / "proj"
+    _write_wf(proj / ".claude" / "workflows", "dup.py", "dup", "PROJECT version")
+    _write_wf(home / ".claude" / "workflows", "dup.py", "dup", "PERSONAL version")
+
+    reg = CommandRegistry()
+    load_and_register_workflows(project_root=proj, registry=reg)
+    cmd = reg.get("dup")
+    assert cmd is not None
+    assert cmd.description == "PROJECT version"
+    assert cmd.loaded_from == "project"
+
+
+def test_personal_workflow_registers_when_no_project_clash(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", lambda: home)
+    _write_wf(home / ".claude" / "workflows", "personal-only.py", "personal-only", "mine")
+    reg = CommandRegistry()
+    load_and_register_workflows(project_root=tmp_path / "proj", registry=reg)
+    cmd = reg.get("personal-only")
+    assert cmd is not None
+    assert cmd.loaded_from == "user"
+
+
+def test_builtin_wins_over_saved_workflow(tmp_path):
+    # A saved workflow that tries to shadow the bundled /deep-research is skipped.
+    _write_wf(tmp_path / ".claude" / "workflows", "deep-research.py", "deep-research", "shadow attempt")
+    reg = CommandRegistry()
+    for c in bundled_workflow_commands():  # registers /workflows + /deep-research first
+        reg.register(c)
+    before = reg.get("deep-research")
+
+    registered = load_and_register_workflows(project_root=tmp_path, registry=reg)
+    assert "deep-research" not in {c.name for c in registered}
+    assert reg.get("deep-research") is before  # bundled retained, not overwritten
+
+
+def test_disabled_registers_nothing(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")
+    _write_wf(tmp_path / ".claude" / "workflows", "x.py", "x")
+    reg = CommandRegistry()
+    assert load_and_register_workflows(project_root=tmp_path, registry=reg) == []
+    assert reg.get("x") is None
+
+
+def test_invalid_workflow_file_is_skipped(tmp_path):
+    d = tmp_path / ".claude" / "workflows"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "broken.py").write_text("this is not a valid meta block", encoding="utf-8")
+    _write_wf(d, "good.py", "good", "valid one")
+    reg = CommandRegistry()
+    names = {c.name for c in load_and_register_workflows(project_root=tmp_path, registry=reg)}
+    assert "good" in names
+    assert "broken" not in names  # a bad file degrades, never breaks the rest


### PR DESCRIPTION
Closes two gaps the design docs specify but the tree didn't have — audited + planned in `docs/workflow-commands-and-ultracode-plan.md`.

## 1. Saved `/<name>` workflows were discovered but never dispatchable (§4.5 / §4.7)

`load_workflow_commands` found `.claude/workflows/*.py` (project) + `~/.claude/workflows/*.py` (personal), but only fed the aggregator's `get_commands()` — which has **no real REPL consumers**. So saved workflows never reached the global registry that dispatch + suggestions read (the same orphaning that hid `/deep-research` until #267).

**Confirmed empirically before the fix:** a saved `.claude/workflows/triage_issues.py` → `global registry (dispatch): False`.

**Fix:** `load_and_register_workflows(registry=None)` — mirrors `load_and_register_skills` (same shadowing guard: builtins/bundled win, **project beats personal**) — called at REPL (`_init_command_system`) and TUI (`app.py`) startup. After: that same file **dispatches and autocompletes** with a `workflow` tag.

## 2. The `ultracode` authoring keyword was never built (§4.1, §4.8)

`grep -ri ultracode src/` → 0 hits. New `src/workflow/ultracode.py`:
- the standalone `\bultracode\b` keyword in a prompt (one-shot), and
- `/effort ultracode` (session-long mode)

…append a `<system-reminder>` nudging the model to **author a workflow via the Workflow tool** instead of working turn by turn. Wired into REPL `chat()` (beside the companion-intro append) and `effort_command.py`. Gated by `is_workflows_enabled()` — §4.8: the keyword no-ops and the option leaves the `/effort` menu when workflows are off.

> Note: Python's effort pipeline is **inert** (no `xhigh`; `settings.effort` reaches no request builder), so `/effort ultracode` faithfully contributes the **orchestration mode**, not a reasoning level. Called out in the plan's "out of scope" section along with TUI keyword wiring and `Option+W`.

## Tests — 48 new, full sweep 299 passed
- `test_workflow_dynamic_commands.py` — registration, project-wins-personal, builtin-wins, disabled-registers-nothing, bad-file-skipped.
- `test_ultracode.py` — keyword detection (boundary/case/disabled), reminder precedence + gating, session toggle, `/effort ultracode` enable + `/effort high` reset + disabled-rejected + picker option gating.
- Three base-effort picker tests gated to workflows-off so they keep asserting the bare option set (ultracode-in-menu covered separately).

Docs: saved plan + a status-correcting addendum to `workflow-engine-port-plan.md` §10 (the Phase-7 row overstated discovery as wired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)