### PR TITLE
docs: retranslate Chinese README (README_ZH) to match current English README

### DIFF
--- a/docs/i18n/README_ZH.md
+++ b/docs/i18n/README_ZH.md
@@ -4,9 +4,9 @@
 
 # ClawCodex
 
-**面向真实使用的 Claude Code Python 重构版 — 真实架构、可运行的 CLI Agent**
+**面向生产使用的 Claude Code Python 重写版 —— 真实架构、可靠的 CLI Agent**
 
-*从 TypeScript 参考实现移植，并在 Python 侧扩展了完整的运行时能力*
+*从 TypeScript 参考实现移植而来，并扩展了 Python 原生运行时*
 
 ***
 
@@ -15,28 +15,76 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/downloads/)
 
+
 **🔥 活跃开发中 • 每周更新新功能 🔥**
 
-## FLEXIBLE SKILL SYSTEMS
-
-**基于 Markdown 的斜杠技能系统，支持参数替换、工具限制，以及项目级 / 用户级技能加载。**
+![ClawCodex 截图](../../assets/clawcodex-screenshot-1.png)
 
 </div>
 
 ***
 
+## ⚡ 快速安装
+
+```bash
+git clone https://github.com/agentforce314/clawcodex.git
+cd clawcodex
+python3 -m venv .venv && source .venv/bin/activate   # Python 3.10+
+pip install -r requirements.txt
+
+python -m src.cli login   # 配置写入 ~/.clawcodex/config.json
+
+python -m src.cli         # 启动 REPL
+```
+
+***
+
+## 📰 新闻
+
+- **2026-06-11：** **代码库统计** —— Python 文件总数：1,093 个；Python 代码总行数：**233,520 行**（高于 2026-05-29 的 213,777 行；新增约 1.97 万行，主要来自交互式命令系统批次、动态 workflow 引擎 + `/deep-research`，以及 Tavily 网络工具链更新）。
+- **2026-06-10 至 2026-06-11：** **动态 workflow 引擎 + `/deep-research`（#262–#264、#266–#271）** —— Python workflow 引擎核心（`agent()`/`parallel()`/`pipeline()`/`phase()`、运行日志、断点恢复）完成端到端接线：Workflow 工具、`/workflows` TUI 对话框 + 状态栏指示、按 agent 重试、worktree 隔离、结果投递，以及注册为斜杠命令的内置 `/deep-research` 研究工作流。可靠性方面：LLM 读取超时统一应用到所有 openai 兼容 provider（#269），并行 agent 不再在事件循环上串行执行（#270），deep-research 的 synthesize 步骤禁用工具、避免报告撰写 agent 陷入循环（#271）。后续修复：workflow max-turns 上限修复（#272）、deep-research verdict 枚举修复（#273）、带阶段进度与各 agent 统计的 `/workflows` 实时监控（#287）。
+- **2026-06-10：** **Web 工具链更新（#265）** —— 用基于 Tavily 的 WebSearch 取代已失效的 DuckDuckGo 抓取，并新增基于配置文件的密钥存储；WebFetch 重写为确定性的 markdown/text/html 提取（借鉴 opencode）。
+- **2026-05-30 至 2026-06-09：** **交互式命令系统对齐（#230–#261）** —— 交互式移植 `/theme`、`/effort`、`/model`、`/logo`、`/mcp`、`/tasks`、`/diff`、`/export`、`/output-style`、`/statusline`、`/release-notes`、`/copy`、`/vim`、`/memory`、`/stickers` 与 `/rename`，构建于新的 prompt-text 原语与交互式命令桥之上；技能注册与模型工具暴露接线；会话持久化生产者（`SessionPersister` + agent-bridge 接线）；外加扩展思考支持（#249）与模型错误吞噬修复（#250）。
+- **2026-05-29：** **代码库统计** —— Python 文件总数：977 个；Python 代码总行数：**213,777 行**（高于 2026-05-21 的 183,768 行；新增约 3 万行，来自远程桥接对齐移植（阶段 0–18）、`/buddy` 虚拟伙伴子系统与 CLI 传输层）。
+- **2026-05-29：** **远程桥接对齐 + CLI 传输（#200–#226）** —— 完成远程控制桥接阶段 0–18 的完整移植：bridge API 客户端、子 CLI 会话运行器、免环境变量的 v2 编排器、多会话守护进程、worktree 启动、原地重连、带崩溃恢复的常驻模式、JWT 刷新，以及 v1 `WebSocketTransport` / `SerialBatchEventUploader` 写路径与混合分发。另含 CLI 传输工厂、合并式 worker 状态上传器与 `RemoteIO` 桥（#226）；新增 `/buddy` 虚拟伙伴命令——孵化 / 抚摸 / 状态 / 静音（#225）。
+- **2026-05-21：** **代码库统计** —— Python 文件总数：890 个；Python 代码总行数：**183,768 行**（高于 2026-05-16 的 177,428 行；因 `src/tool_system/agent_loop.py` 合并进 `src/query/query.py`，文件数净减 4 个）。
+- **2026-05-21：** **`/advisor` 省 token 编码模式（#181–#193）** —— 让低成本 worker 模型（`haiku-4-5`，每 Mtok $1/$5）与高成本 reviewer（`opus-4-7`，$5/$25）搭档，仅在关键决策点咨询后者；典型会话比纯 opus 便宜约 6 倍。支持显式 `<provider>:<model>` 语法、跨 provider 路由（例如经 litellm 使用 `deepseek/deepseek-v4-pro` worker + `claude-opus-4-7` advisor），并在状态栏实时显示 worker/advisor 的 token 数与美元成本。
+- **2026-05-16：** **代码库统计** —— Python 文件总数：894 个；Python 代码总行数：**177,428 行**（高于 2026-05-14 的 167,034 行；两天新增约 1.04 万行，主要是 ESC 取消加固与图像处理对齐）。
+- **2026-05-16：** **图像处理对齐（Tier C，#149/#154/#155/#156）** —— Read 工具复刻 TS 图像管线（魔数嗅探、缩放/压缩、base64 上限）；`@image.png` 提及内联为真正的 `ImageBlock` 而非乱码；跨 provider 的 Anthropic `image`/`document` → OpenAI `image_url`/`file` 转换；`BaseProvider` 中调用 API 前的 base64 大小校验。
+
+📚 更早的条目已移至完整的 **[News 归档](../NEWS.md)**。
+
+***
+
 ## 🎯 为什么是 ClawCodex？
 
-**ClawCodex** 是一个面向真实使用的 **Claude Code Python 重构版**：它基于**真实 TypeScript 架构**移植而来，并且交付的是一个**可运行的 CLI Agent**，而不只是源码镜像。
+**ClawCodex** 是一个**面向生产使用的 Claude Code Python 重写版**：从**真实的 TypeScript 架构**移植而来，并以**可用的 CLI Agent** 形式交付，而不只是一份源码镜像。
 
-- **真实 Agent Runtime** — 具备工具调用循环、流式 REPL、会话历史与多轮执行能力
-- **高保真移植** — 尽可能保留 Claude Code 的原始架构，同时做符合 Python 风格的实现
-- **适合继续开发** — 代码可读、测试完善，并支持基于 Markdown 的技能扩展
-- **多 LLM 提供商** — 相对上游最大的进展之一：Claude Code 主要面向 **Claude 系列模型**，而 ClawCodex 致力于接入**各大主流 LLM 提供商**，在保持 Agent 能力的前提下，为用户提供更**灵活**、更**具性价比**的 agentic 编程体验
+- **真实 Agent Runtime** —— 工具调用循环、流式 REPL、会话历史与多轮执行
+- **高保真移植** —— 保留 Claude Code 的原始架构，同时做符合 Python 风格的实现
+- **适合二次开发** —— 可读的 Python 代码、丰富的测试，以及基于 Markdown 的技能扩展
+- **多 LLM 提供商** —— 相对上游最大的进展：Claude Code 仅围绕 Claude 系列模型构建，而 ClawCodex 致力于接入**所有主流 LLM 提供商**，让你为 agentic 编程选择最**灵活**、最**具性价比**的技术栈
 
-**这是一个真正可跑的 Claude Code 风格 Python 终端工作流：能流式回答、调工具、抓外部上下文，并通过 skills 扩展行为。**
+**一个真正可跑的 Claude Code 风格 Python 终端工作流：流式回答、调用工具、抓取上下文，并通过 skills 扩展行为。**
 
 **🚀 立即试用！Fork 它、修改它、让它成为你的！欢迎提交 Pull Request！**
+
+***
+
+## 🏆 SWE-bench Verified —— 相同模型下 `clawcodex` 超越 `openclaude`
+
+![SWE-bench Verified —— clawcodex vs openclaude on Gemini 2.5 Pro](../../assets/swebench-verified-gemini.png)
+
+在完整的 **SWE-bench Verified** 数据集（499 个实例，公开的 agent 编码榜单）上，两个 agent 均由 **Gemini 2.5 Pro** 驱动，运行在我们的标准化评测框架中：
+
+| Agent | 已解决 | 未解决 | 错误 |
+|---|---:|---:|---:|
+| **clawcodex** | **291 / 499（58.2%）** | 124 | 84 |
+| openclaude | 265 / 499（53.0%） | 144 | 90 |
+
+- ✅ **两者都解决**：241 &nbsp;&nbsp; 🟢 **仅 clawcodex 解决**：50 &nbsp;&nbsp; 🔵 **仅 openclaude 解决**：24 &nbsp;&nbsp; ❌ **均未解决**：184
+
+本地复现 —— 完整流程（累积分批、`--predict-workers N`、`--capture-traces`）见 [`eval/README.md`](../../eval/README.md)。
 
 ***
 
@@ -46,7 +94,7 @@
 
 ## ✨ 特性
 
-### Streaming Agent Experience
+### 流式 Agent 体验
 
 ```text
 >>> /stream on
@@ -81,15 +129,15 @@ arguments: [path]
 
 ### 多提供商支持
 
-ClawCodex 的核心优势之一是**多模型 / 多提供商**：Claude Code 以 **Claude** 为主线，我们则希望在同一套 Agent 运行时上覆盖**各大主流 LLM 提供商**，便于按场景切换厂商、区域与价位，而不牺牲工具、技能与编码闭环——这也是让 agentic 编程在成本与灵活性上真正可用的基础。
+ClawCodex 的核心优势是**多提供商支持**：Claude Code 以 **Claude** 系列模型为目标，而我们希望在同一套 Agent 运行时之上支持**所有主流 LLM 提供商**——你可以自由切换厂商、区域与价位，而不必放弃工具、技能与编码闭环。正是这种灵活性，让 agentic 编程在规模化使用时真正可行。
 
 ```python
-providers = ["anthropic", "openai", "glm", "minimax"]  # 可继续扩展
+providers = ["anthropic", "openai", "glm", "minimax", "openrouter", "deepseek"]  # OpenAI 兼容与 GLM API；可继续扩展
 ```
 
 ### 交互式 REPL（默认）与 Textual TUI（可选）
 
-**默认**为 **prompt_toolkit + Rich** 行内 REPL（滚动区 + 状态行）。使用 **`clawcodex --tui`** 或 REPL 内的 **`/tui`** 可进入 **Textual** 全屏界面。
+**默认**交互界面为 **prompt_toolkit + Rich** 行内 REPL（对话记录保留在终端滚动区，外加感知工具状态的状态行）。需要时，使用 **`clawcodex --tui`** 或 REPL 内的 **`/tui`** 斜杠命令进入 **Textual** 全屏界面。
 
 ```text
 >>> 你好！
@@ -103,7 +151,7 @@ Assistant: 嗨！我是 ClawCodex，一个 Python 重实现...
 >>> Tab            # 自动补全
 >>> /explain-code qsort.py   # 运行 SKILL.md 技能（或 /skill …）
 
-# 多行输入：Shift+Enter、Meta/Alt+Enter，或 `\` 后 Enter；单独 Enter 提交。
+# 多行输入：Shift+Enter、Meta/Alt+Enter，或 `\` 后 Enter 换行；单独 Enter 提交。
 ```
 
 ### 完整的 CLI
@@ -112,17 +160,28 @@ Assistant: 嗨！我是 ClawCodex，一个 Python 重实现...
 clawcodex                       # 行内 REPL（默认）
 clawcodex --tui                 # Textual TUI
 clawcodex --stream              # 开启实时渲染的 REPL
-clawcodex login                 # 交互式配置 API
-clawcodex config                # 查看配置
+clawcodex login                 # 交互式配置 API key
+clawcodex config                # 查看 ~/.clawcodex/config.json 中的配置
 clawcodex --version             # 版本信息
 
-# 非交互 / 脚本（管道、CI、自动化）
-clawcodex -p "用中文总结 src/cli.py"
+# 非交互 / 脚本化（管道、CI、自动化 agent）
+clawcodex -p "总结 src/cli.py"
 clawcodex -p "Hello" --output-format json
+clawcodex -p --output-format stream-json --input-format stream-json < events.ndjson
 
+# 单次运行覆盖配置
 clawcodex --provider anthropic --model claude-sonnet-4-6 -p "Hi"
 clawcodex --max-turns 10 --allowed-tools Read,Grep -p "查找 TODO"
+
+# 权限控制（REPL、TUI 与 -p 均生效）
+clawcodex --permission-mode plan                       # plan / acceptEdits / dontAsk
+clawcodex --dangerously-skip-permissions -p "ls"       # 跳过所有权限检查
+clawcodex --allow-dangerously-skip-permissions         # 允许之后通过 /permission-mode 切换为 bypass
 ```
+
+> **`--dangerously-skip-permissions`** 会在整个会话期间禁用所有工具权限检查。
+> 仅建议在无互联网访问的沙箱容器/虚拟机中使用。当进程以 root/sudo
+> 运行时该参数会被拒绝，除非设置了 `IS_SANDBOX=1` 或 `CLAUDE_CODE_BUBBLEWRAP=1`。
 
 ***
 
@@ -132,19 +191,21 @@ clawcodex --max-turns 10 --allowed-tools Read,Grep -p "查找 TODO"
 | ----- | ------ | ------ |
 | REPL 命令 | ✅ 完成   | 内置命令 + `/tools`、`/stream`、`/context`、`/compact`、技能等 |
 | 工具系统 | ✅ 完成   | 30+ 工具 |
-| 自动化测试 | ✅ 已覆盖  | 工具、agent loop、providers、parity、REPL 等 |
+| 自动化测试 | ✅ 已覆盖  | 工具、agent loop、providers、parity、REPL、认证等 |
 | 文档    | ✅ 完成   | 指南、多语言 README、[FEATURE_LIST.md](../../FEATURE_LIST.md) |
 
 ### 核心系统
 
 | 系统 | 状态 | 描述 |
 |------|------|------|
-| CLI 入口 | ✅ | `clawcodex`、`login`、`config`、`-p`、`--tui`、`--stream`、`--version` |
-| 交互式 REPL | ✅ | 默认行内 REPL；可选 Textual；历史、Tab、多行输入 |
-| 多提供商支持 | ✅ | Anthropic、OpenAI、智谱 GLM、Minimax |
+| CLI 入口 | ✅ | `clawcodex`、`login`、`config`、`-p` / `--print`、`--tui`、`--stream`、`--version` |
+| 交互式 REPL | ✅ | 默认行内 REPL；可选 Textual TUI；历史、Tab 补全、多行输入 |
+| 多提供商支持 | ✅ | Anthropic、OpenAI、智谱 GLM、Minimax、OpenRouter、DeepSeek——含 Anthropic→OpenAI 的 image / document 块转换，适配具备视觉能力的 OpenAI 兼容后端 |
 | 会话持久化 | ✅ | 本地保存/加载会话 |
 | Agent Loop | ✅ | 工具调用循环；支持流式与无头模式 |
-| Skill 系统 | ✅ | SKILL.md 斜杠技能：参数与工具白名单 |
+| Skill 系统 | ✅ | 基于 SKILL.md 的斜杠技能：参数与工具白名单 |
+| 取消 / 中止 | ✅ | ESC 可在约 50ms 内中止进行中的 Bash、Grep/Glob 以及所有 provider 的流式 HTTP；子 agent 拥有隔离的 `AbortController`；`Bash` 的 `tool_result` 区分超时与 ESC 中止 |
+| 图像处理 | ✅ | 与 TS 对齐的 Read 管线（魔数嗅探、按 API 限制缩放/压缩）；`@image.png` @-提及内联为 `ImageBlock`；`BaseProvider._prepare_messages` 中调用 API 前的 base64 大小校验；二进制 @-提及（PDF/zip/docx/…）转为 Read 工具提示而非乱码 |
 | 上下文构建 | 🟡 | workspace / git / `CLAUDE.md` 注入；更丰富的摘要与 memory 仍在演进 |
 | 权限系统 | 🟡 | 框架与检查逻辑已有；全面集成进行中 |
 | MCP | 🟡 | MCP 相关工具与接线已有；协议层/运行时仍在完善 |
@@ -161,7 +222,7 @@ clawcodex --max-turns 10 --allowed-tools Read,Grep -p "查找 TODO"
 | Agent 工具 | Agent, Brief, Team | ✅ 完成 |
 | 配置 | Config, PlanMode, Cron | ✅ 完成 |
 | MCP | MCP 工具与资源 | 🟡 工具已接线；完整 client/runtime 仍在演进 |
-| 其他 | LSP, Worktree, Skill（SKILL.md）, ToolSearch | ✅ 完成 |
+| 其他 | LSP, Worktree, Skill, ToolSearch | ✅ 完成 |
 
 ### 路线图进度
 
@@ -169,7 +230,7 @@ clawcodex --max-turns 10 --allowed-tools Read,Grep -p "查找 TODO"
 - ✅ **阶段 1**：Claude Code 核心 MVP 体验
 - ✅ **阶段 2**：真实工具调用闭环
 - 🟡 **阶段 3**：上下文深度、权限集成、类 `/resume` 的恢复能力（进行中）
-- 🟡 **阶段 4**：MCP 运行时、插件与扩展（工具已有，平台能力持续推进）
+- 🟡 **阶段 4**：MCP 运行时深化、插件与可扩展性（工具已有，平台能力持续推进）
 - ⏳ **阶段 5**：Python 原生差异化特性
 
 **详细功能状态和 PR 指南请查看 [FEATURE_LIST.md](../../FEATURE_LIST.md)。**
@@ -189,7 +250,7 @@ source .venv/bin/activate
 # 安装包与 console 入口（推荐）
 uv pip install -e ".[dev]"
 
-# 或：先装依赖再 editable
+# 或：先装依赖再 editable 安装
 # uv pip install -r requirements.txt && uv pip install -e .
 ```
 
@@ -204,17 +265,17 @@ clawcodex login
 
 这个流程会：
 
-1. 让你选择 provider：anthropic / openai / glm / minimax
+1. 让你选择 provider：anthropic / openai / glm / minimax / openrouter / deepseek
 2. 让你输入该 provider 的 API key
 3. 可选：保存自定义 base URL
 4. 可选：保存默认 model
 5. 将该 provider 设为默认
 
-配置文件会保存在 `~/.clawcodex/config.json`。示例结构：
+配置文件保存在 `~/.clawcodex/config.json`。示例结构：
 
 ```json
 {
-  "default_provider": "openai",
+  "default_provider": "anthropic",
   "providers": {
     "anthropic": {
       "api_key": "your-api-key",
@@ -235,16 +296,42 @@ clawcodex login
       "api_key": "your-api-key",
       "base_url": "https://api.minimaxi.com/anthropic",
       "default_model": "MiniMax-M2.7"
+    },
+    "openrouter": {
+      "api_key": "your-api-key",
+      "base_url": "https://openrouter.ai/api/v1",
+      "default_model": "deepseek/deepseek-v4-pro"
+    },
+    "deepseek": {
+      "api_key": "your-api-key",
+      "base_url": "https://api.deepseek.com",
+      "default_model": "deepseek-v4-pro"
     }
+  },
+  "session": {
+    "auto_save": true,
+    "max_history": 100
+  },
+  "settings": {
+    "advisor_model": "claude-sonnet-4-6",
+    "advisor_client_mode": false,
+    "advisor_provider": "openai"
+  },
+  "env": {
+    "TAVILY_API_KEY": "tvly-YOUR-TAVILY-API-KEY"
   }
 }
 ```
+
+- **`session`** —— REPL 会话持久化：`auto_save` 自动保存每个会话；`max_history` 限制保留的对话轮数。
+- **`settings`** —— 后台辅助功能所用的 advisor 模型（`advisor_provider` / `advisor_model`，以及控制是否经由客户端路由的 `advisor_client_mode`）。
+- **`env`** —— 启动时注入的密钥与环境变量（例如用于 Web 搜索的 `TAVILY_API_KEY`）。通过 `clawcodex config` 管理；这里的键会被导出到进程环境，但不会覆盖你在 shell 中已设置的值。
 
 ### 运行
 
 ```bash
 clawcodex                  # 启动行内 REPL（等同于 python -m src.cli）
-clawcodex --help           # 含 --tui、-p、--provider、--model 等
+clawcodex --help           # 全部参数：--tui、-p、--provider、--model 等
 ```
 
 **就这样！** 配置密钥后即可使用 CLI 或 REPL。
@@ -271,7 +358,7 @@ clawcodex --help           # 含 --tui、-p、--provider、--model 等
 | `/compact` | 压缩或清空对话（不可用时回退为清空） |
 | `/exit`、`/quit`、`/q` | 退出 |
 
-### Skills（技能 / 斜杠命令）教程
+### Skills（技能 / 斜杠命令）
 
 技能是存放在 `.clawcodex/skills` 下的 Markdown 斜杠命令。每个技能对应一个目录，并且文件名固定为 `SKILL.md`。
 
@@ -288,7 +375,7 @@ clawcodex --help           # 含 --tui、-p、--provider、--model 等
 ```md
 ---
 description: 用类比 + 图示解释代码
-when_to_use: 当用户问“这段代码怎么工作？”时使用
+when_to_use: 在解释代码如何工作时使用
 allowed-tools:
   - Read
   - Grep
@@ -316,8 +403,30 @@ arguments: [path]
 
 - 用户级技能：`~/.clawcodex/skills/<skill-name>/SKILL.md`
 - 工具限制：`allowed-tools` 用于限制技能允许调用的工具集合
-- 参数替换：支持 `$ARGUMENTS`、`$0`、`$1`、以及命名参数（例如 `$path`，来自 `arguments`）
+- 参数替换：支持 `$ARGUMENTS`、`$0`、`$1`、以及命名参数（例如来自 `arguments` 的 `$path`）
 - 占位符写法：请使用 `$path`，不要写成 `${path}`
+
+
+
+***
+
+## 🎨 演示
+
+**[`demos/`](../../demos/) 目录下的每个应用都由 ClawCodex 自身端到端生成** —— 用的正是你刚安装的这个 CLI、同一个 agent loop、同一套工具。零人工修改 🙂
+
+| 演示 | 技术栈 | 描述 |
+| ---- | ----- | ----------- |
+| [`demos/crm-app`](../../demos/crm-app) | React 18 + Vite + Vitest | 迷你 CRM：联系人、商机、仪表盘与完整测试套件 |
+| [`demos/linkedin-app`](../../demos/linkedin-app) | React 18 + Vite + React Router | LinkedIn 风格信息流：个人主页、人脉、职位、私信 |
+| [`demos/minecraft-app`](../../demos/minecraft-app) | React + three.js + @react-three/fiber | 浏览器体素沙盒：地形、挖掘、HUD 与玩家控制 |
+
+```bash
+cd demos/crm-app   # 或 linkedin-app / minecraft-app
+npm install
+npm run dev        # vite 开发服务器
+```
+
+想看看它是怎么做到的？在任意空目录里打开 ClawCodex，让它构建点什么——上面这三个就是这样生成的。
 
 ***
 
@@ -325,25 +434,37 @@ arguments: [path]
 
 ### 基于真实源码
 
-- **不是克隆** — 从真实的 TypeScript 实现移植而来
-- **架构保真** — 保持经过验证的设计模式
-- **持续改进** — 更好的错误处理、更多测试、更清晰的代码
+- **不是克隆** —— 从真实的 TypeScript 实现移植而来
+- **架构保真** —— 保持经过验证的设计模式
+- **持续改进** —— 更好的错误处理、更多测试、更清晰的代码
 
 ### 原生 Python
 
-- **类型提示** — 完整的类型注解
-- **现代 Python** — 使用 3.10+ 特性
-- **符合习惯** — 干净的 Python 风格代码
+- **类型提示** —— 完整的类型注解
+- **现代 Python** —— 使用 3.10+ 特性
+- **符合习惯** —— 干净的 Python 风格代码
 
 ### 以用户为中心
 
-- **3 步设置** — 克隆、`clawcodex login` 配置、`clawcodex` 运行
-- **交互式配置** — 选择 provider、Base URL、默认模型
-- **行内或 TUI** — 默认终端原生 REPL；可选 Textual
-- **可脚本化** — `-p`、JSON、NDJSON 便于自动化
-- **会话持久化** — 保存与恢复对话
+- **3 步设置** —— 克隆、配置（`clawcodex login`）、运行（`clawcodex`）
+- **交互式配置** —— 一个流程内完成 provider、Base URL 与默认模型
+- **行内或 TUI** —— 默认终端原生 REPL；可选 Textual UI
+- **可脚本化** —— `-p` / JSON / NDJSON 便于自动化
+- **会话持久化** —— 保存与恢复对话
 
 ***
+
+## 架构
+
+关于六大核心抽象（query loop、tools、tasks、两级 state、memory、hooks），以及从用户输入到模型输出的黄金路径，请见
+[`docs/ARCHITECTURE.md`](../ARCHITECTURE.md)。推荐新贡献者从这里入手。
+
+原版 Claude Code 架构的参考资料位于
+`claude-code-from-source/book/ch01-architecture.md`；逐章的移植差距分析与重构计划存放在
+`my-docs/` 下。
+
+***
+
 
 ## 📦 项目结构
 
@@ -351,20 +472,20 @@ arguments: [path]
 clawcodex/
 ├── src/
 │   ├── cli.py              # CLI 入口（控制台命令 clawcodex）
-│   ├── entrypoints/        # 无头 (-p) 与 TUI 启动
-│   ├── repl/               # 行内 REPL
+│   ├── entrypoints/        # 无头（-p）与 TUI 启动
+│   ├── repl/               # 行内 REPL（prompt_toolkit + Rich）
 │   ├── tui/                # Textual UI（--tui、/tui）
-│   ├── providers/          # Anthropic、OpenAI、GLM、Minimax
-│   ├── agent/              # 会话、对话、提示
+│   ├── providers/          # Anthropic、OpenAI、GLM、Minimax、OpenRouter、DeepSeek
+│   ├── agent/              # 对话、会话、提示词
 │   ├── tool_system/        # Agent loop、工具与 schema
-│   ├── skills/             # SKILL.md 与 Skill 工具
-│   ├── services/           # MCP、compact、IDE、工具执行等
-│   ├── context_system/     # 工作区 / git / CLAUDE.md
+│   ├── skills/             # SKILL.md 加载与 Skill 工具
+│   ├── services/           # MCP、compact、IDE 桥、工具执行等
+│   ├── context_system/     # workspace / git / CLAUDE.md 上下文
 │   ├── permissions/        # 权限模式与 bash 解析
-│   ├── hooks/              # Hook 类型与执行
+│   ├── hooks/              # Hook 类型与执行辅助
 │   └── command_system/     # 斜杠命令与参数替换
 ├── typescript/             # 参考 / 对等源码（运行 Python CLI 非必需）
-├── tests/                  # pytest
+├── tests/                  # pytest 测试套件
 ├── docs/                   # 指南、多语言 README、重构笔记
 ├── .clawcodex/skills/      # 项目级技能（可选）
 ├── FEATURE_LIST.md         # 能力矩阵与路线图
@@ -372,6 +493,7 @@ clawcodex/
 ```
 
 ***
+
 
 ## 🤝 贡献
 
@@ -389,10 +511,10 @@ python -m pytest tests/ -v
 
 ## 📖 文档
 
-- **[SETUP_GUIDE.md](../guide/SETUP_GUIDE.md)** — 详细安装说明
-- **[CONTRIBUTING.md](../../CONTRIBUTING.md)** — 开发指南
-- **[TESTING.md](../guide/TESTING.md)** — 测试指南
-- **[CHANGELOG.md](../../CHANGELOG.md)** — 版本历史
+- **[SETUP_GUIDE.md](../guide/SETUP_GUIDE.md)** —— 详细安装说明
+- **[CONTRIBUTING.md](../../CONTRIBUTING.md)** —— 开发指南
+- **[TESTING.md](../guide/TESTING.md)** —— 测试指南
+- **[CHANGELOG.md](../../CHANGELOG.md)** —— 版本历史
 
 ***
 
@@ -400,7 +522,7 @@ python -m pytest tests/ -v
 
 - **启动时间**：< 1 秒
 - **内存占用**：< 50MB
-- **响应**：回合式输出，支持 Rich Markdown 渲染
+- **响应**：回合式助手输出，支持 Rich Markdown 渲染
 
 ***
 
@@ -409,7 +531,7 @@ python -m pytest tests/ -v
 ✅ **基础本地安全实践**
 
 - Git 中无敏感数据
-- API 密钥在配置中做了基础混淆
+- API 密钥在配置中已做混淆
 - `.env` 文件被忽略
 - 适合本地开发工作流
 
@@ -417,7 +539,7 @@ python -m pytest tests/ -v
 
 ## 📄 许可证
 
-MIT 许可证 — 查看 [LICENSE](../../LICENSE)
+MIT 许可证 —— 查看 [LICENSE](../../LICENSE)
 
 ***
 
@@ -435,8 +557,12 @@ MIT 许可证 — 查看 [LICENSE](../../LICENSE)
 
 如果你觉得这个项目有用，请给个 **star** ⭐！
 
-**用 ❤️ 制作 by ClawCodex 团队**
+**由 ClawCodex 团队用 ❤️ 打造**
 
 [⬆ 回到顶部](#clawcodex)
 
 </div>
+
+***
+
+***


### PR DESCRIPTION
## Summary
- The Chinese README (`docs/i18n/README_ZH.md`) had drifted far behind the English `README.md`; with heavy traffic from China, it was missing most of the current story.
- Retranslated the full file from the current English README, adding the previously missing sections: ⚡ Quick Install, 📰 News (all 10 items), 🏆 SWE-bench Verified results, 🎨 Demos, and Architecture, plus the screenshot.
- Synced all stale content: OpenRouter/DeepSeek providers, permission-control CLI flags (`--permission-mode`, `--dangerously-skip-permissions`), the expanded `config.json` example (`session` / `settings` / `env`), and the new Cancellation/Abort and Image Handling status rows.
- All links rewritten relative to `docs/i18n/` (`../../assets/...`, `../NEWS.md`, `../ARCHITECTURE.md`, `../../demos/...`, etc.); every target verified to exist.
- Removed the stale "FLEXIBLE SKILL SYSTEMS" banner that no longer exists in the English README.

## Test plan
- [x] Section-by-section diff against English README: 48 headings, 10 news items, and 17 code blocks pair 1:1 in order; JSON config block byte-identical
- [x] Verified every number, date, PR reference, model name, and flag matches English exactly
- [x] Verified all 20 relative link targets exist on disk from `docs/i18n/`
- [ ] Spot-check GitHub rendering of the markdown after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)