### PR TITLE
ch02/round3: wire the config trust boundary end-to-end

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -149,12 +150,72 @@ def main():
         return _run_tui_mode(args)
 
     profile_checkpoint("mode_dispatch_repl")
+    # ch02 round-3: the legacy REPL is the DEFAULT interactive surface but
+    # had no folder-trust gate (C8 shipped one only for the opt-in TUI).
+    # Port hardening, consistent with C8 and stricter than TS (which gates
+    # only Anthropic-account setups, interactiveHelpers.tsx:139): ask
+    # before the full project env applies. Already-trusted sessions
+    # (including non-interactive ones seeded by run_pre_action) skip this.
+    from src.services.startup_gates import check_trust_accepted
+
+    if not check_trust_accepted():
+        if sys.stdin.isatty():
+            if not _prompt_folder_trust():
+                return 1
+        else:
+            # Piped-stdin REPL (scripted use) ≈ -p mode: implicit trust,
+            # matching the non-interactive branch of run_pre_action. The
+            # single documented asymmetry of the trust seeding matrix.
+            from src.permissions.trust_boundary import establish_session_trust
+
+            establish_session_trust()
     profile_checkpoint("phase4_dispatch")
     return start_repl(
         stream=args.stream,
         permission_mode=args._resolved_permission_mode,
         is_bypass_permissions_mode_available=args._resolved_is_bypass_available,
     )
+
+
+def _prompt_folder_trust() -> bool:
+    """Plain-text port of the C8 TrustFolderScreen for the legacy REPL.
+
+    Accept → persist (``record_trust_accepted``) + grant session trust +
+    apply the full env. Decline/EOF → False (caller exits 1, mirroring TS
+    TrustDialog's "No, exit" → gracefulShutdownSync(1)).
+    """
+    from src.permissions.trust_boundary import establish_session_trust
+    from src.services.startup_gates import (
+        collect_trust_warnings,
+        record_trust_accepted,
+    )
+
+    cwd = os.getcwd()
+    print("Do you trust the files in this folder?")
+    print(f"  {cwd}")
+    try:
+        warnings = collect_trust_warnings()
+    except Exception:
+        warnings = []
+    if warnings:
+        print()
+        for warning in warnings:
+            print(f"  ! {warning}")
+    print()
+    print(
+        "ClawCodex may read, execute, and modify files here. Accept only if "
+        "you trust this folder's contents and configuration."
+    )
+    try:
+        answer = input("Trust this folder? [y/N] ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return False
+    if answer not in ("y", "yes"):
+        return False
+    record_trust_accepted()
+    establish_session_trust()
+    return True
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/src/config.py
+++ b/src/config.py
@@ -151,6 +151,35 @@ def get_default_config() -> dict[str, Any]:
     }
 
 
+# Keys a committable project/local config tier may NOT contribute while the
+# session is untrusted. ``providers``/``default_provider`` would redirect API
+# traffic to a config-controlled host while the user's global credentials
+# remain attached; ``env`` is owned by permissions.trust_boundary's gated
+# passes. (TS has no analogue: its project files contribute settings only.)
+_UNTRUSTED_TIER_BLOCKED_KEYS: frozenset[str] = frozenset(
+    {"env", "providers", "default_provider"}
+)
+
+
+def _session_trusted() -> bool:
+    try:
+        from src.bootstrap.state import get_session_trust_accepted
+
+        return get_session_trust_accepted()
+    except Exception:
+        # Bootstrap state unavailable (early import, standalone script):
+        # fail toward the pre-round-3 behavior rather than breaking reads.
+        return True
+
+
+def _strip_untrusted_keys(tier: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in tier.items()
+        if key not in _UNTRUSTED_TIER_BLOCKED_KEYS
+    }
+
+
 # ---------------------------------------------------------------------------
 # ConfigManager — three-level loading + merge
 # ---------------------------------------------------------------------------
@@ -191,10 +220,26 @@ class ConfigManager:
         return dict(self._local_cache)
 
     def get_merged(self) -> dict[str, Any]:
-        """Return fully merged config: global < project < local."""
+        """Return fully merged config: global < project < local.
+
+        While the session is untrusted, the project/local tiers are
+        stripped of trust-sensitive keys before merging (ch02 round-3
+        gap A5): a committable ``.claude/config.json`` must not be able
+        to redirect API traffic (``providers.*.base_url`` riding the
+        user's global ``api_key``) or inject env before the folder-trust
+        gate. Checked at merge time so a mid-session trust grant takes
+        effect on the next read. Env application is separately owned by
+        ``permissions.trust_boundary``; the ``env`` strip here is
+        defense in depth for direct ``get_merged()["env"]`` readers.
+        """
         merged = self.load_global()
-        merged = _deep_merge(merged, self.load_project())
-        merged = _deep_merge(merged, self.load_local())
+        project = self.load_project()
+        local = self.load_local()
+        if not _session_trusted():
+            project = _strip_untrusted_keys(project)
+            local = _strip_untrusted_keys(local)
+        merged = _deep_merge(merged, project)
+        merged = _deep_merge(merged, local)
         return merged
 
     # --- writers ---

--- a/src/init.py
+++ b/src/init.py
@@ -32,7 +32,8 @@ from functools import cache
 
 from src.permissions.trust_boundary import (
     apply_safe_config_environment_variables,
-    extract_mdm_safe_env,
+    establish_session_trust,
+    extract_mdm_env,
 )
 from src.prefetch import (
     get_or_start_keychain_prefetch,
@@ -84,21 +85,19 @@ def init() -> None:
         wait_and_read_keychain(get_or_start_keychain_prefetch(), timeout=5.0)
     )
     mdm_payload = wait_and_read_mdm(get_or_start_mdm_raw_read(), timeout=2.0)
-    mdm_safe_env = extract_mdm_safe_env(mdm_payload)
+    mdm_env = extract_mdm_env(mdm_payload)
     profile_checkpoint("init_after_prefetch_consumption")
 
-    _logger.info("init: applying safe env vars")
-    apply_safe_config_environment_variables(extra_env=mdm_safe_env)
+    # ch02 round-3: the pre-trust pass applies the TRUSTED tiers in full
+    # (global config env — including stored API keys like TAVILY_API_KEY —
+    # and user settings env), the SAFE subset of the project-scoped tiers,
+    # and the MDM policy env last. Project/local tiers apply in full only
+    # after trust (run_pre_action seeding or a trust-gate accept). The old
+    # secret_store startup applier is gone — it copied the MERGED env
+    # (committable project tiers included) with no trust gate.
+    _logger.info("init: applying pre-trust env (trusted tiers + safe subset)")
+    apply_safe_config_environment_variables(extra_env=mdm_env)
     profile_checkpoint("init_safe_env_vars_applied")
-
-    # Stored API keys: copy the config ``env`` block (e.g. TAVILY_API_KEY in
-    # ~/.clawcodex/config.json) into os.environ so every os.environ[...] reader
-    # sees them. override=False -> a real exported var and the managed/MDM safe
-    # env applied just above both win over the user's stored value.
-    _logger.info("init: applying stored config env (API keys)")
-    from src.secret_store import apply_config_env_to_environ
-    apply_config_env_to_environ()
-    profile_checkpoint("init_config_env_applied")
 
     _logger.info("init: setting up graceful shutdown")
     setup_graceful_shutdown()
@@ -149,26 +148,27 @@ def run_pre_action(args: object) -> None:
     from src.bootstrap.state import (
         set_client_type,
         set_is_interactive,
-        set_session_trust_accepted,
     )
 
-    set_is_interactive(_determine_is_interactive(args))
+    is_interactive = _determine_is_interactive(args)
+    set_is_interactive(is_interactive)
     set_client_type(_determine_client_type())
 
-    # The trust dialog SHIPPED (components C8:
-    # ``services/startup_gates.check_trust_accepted`` + the TUI's
-    # TrustFolderScreen), but this placeholder must outlive it: the TUI
-    # is the only surface with a dialog — headless / -p / legacy-REPL
-    # sessions have no way to ask, and flipping the default to
-    # untrusted would hard-block their ``hooks/trust_gate.py`` and
-    # ``tool_system/context.py:workspace_trusted`` consumers with no
-    # way to consent. The dialog's accept path syncs this same flag via
-    # ``record_trust_accepted``, so narrowing this later only requires
-    # seeding interactive sessions from check_trust_accepted() here.
-    # TODO(components-C8 follow-up): seed from
-    # ``startup_gates.check_trust_accepted()`` for interactive sessions
-    # instead of unconditionally trusting.
-    set_session_trust_accepted(True)
+    # ch02 round-3 trust seeding (closes the C8 follow-up TODO). TS mapping
+    # (main.tsx:1955-1967, interactiveHelpers.tsx:139-194):
+    #   * non-interactive (-p / non-TTY stdout): trust is implicit — grant
+    #     it and apply the full env immediately so git spawns and tools see
+    #     project PATH/GIT_DIR etc.
+    #   * interactive + previously accepted for this folder (parent-walk in
+    #     check_trust_accepted): same.
+    #   * interactive + not yet accepted: stay untrusted (bootstrap default
+    #     is False); the surface's gate decides — the TUI TrustFolderScreen
+    #     (C8) or the legacy REPL's text prompt (cli.py) — and its accept
+    #     path calls establish_session_trust().
+    from src.services.startup_gates import check_trust_accepted
+
+    if not is_interactive or check_trust_accepted():
+        establish_session_trust()
 
     profile_checkpoint("pre_action_end")
 

--- a/src/permissions/trust_boundary.py
+++ b/src/permissions/trust_boundary.py
@@ -1,27 +1,56 @@
 """Two-stage env-var trust boundary — chapter 2 §"The Trust Boundary".
 
 Mirrors TS ``applySafeConfigEnvironmentVariables`` /
-``applyConfigEnvironmentVariables`` from
-``typescript/src/utils/managedEnv.ts``. The architectural insight: env
-vars from project-level config can be poisoned by a malicious clone, so
-we read them in two passes — only a *safe subset* applies pre-trust.
+``applyConfigEnvironmentVariables`` (``typescript/src/utils/managedEnv.ts``).
+The TS model is **source-class based**, not key-class based:
 
-The safe subset is a *verbatim port* of TS's ``SAFE_ENV_VARS`` set from
-``typescript/src/utils/managedEnvConstants.ts:109-194``. Default-deny:
-anything not in ``SAFE_ENV_KEYS`` is treated as unsafe.
+* **Trusted sources** (user-owned): the global config
+  (``~/.clawcodex/config.json``) and the user settings file. Their ``env``
+  blocks apply IN FULL before the trust dialog (TS managedEnv.ts:125-159 —
+  a user's own ``HTTPS_PROXY`` or ``NODE_EXTRA_CA_CERTS`` is legitimate;
+  see ``caCertsConfig.ts:59-66`` for the same source distinction).
+* **Project-scoped sources** (a clone could ship them): project/local
+  config and settings files. Pre-trust, only the ``SAFE_ENV_KEYS`` subset
+  of their ``env`` blocks applies (TS managedEnv.ts:173-178); the rest
+  waits for :func:`apply_full_config_environment_variables` after the
+  user accepts the trust gate.
+* **Policy source** (root-owned MDM managed preferences): applies in full,
+  last, and — uniquely — may override the inherited shell environment
+  (TS applies policySettings last among trusted sources,
+  managedEnv.ts:160-172; IT must win).
+
+This module is the **sole writer** of config-sourced environment
+variables (ch02 round-3: it absorbed ``secret_store``'s startup applier,
+which used to copy the merged — project tiers included — env block into
+``os.environ`` with no trust gating).
+
+Precedence — the shell-wins customization
+------------------------------------------
+TS overwrites ``process.env`` with settings env (``Object.assign``). This
+port intentionally diverges for user-owned and project tiers: variables
+present in the ORIGINAL process environment (with non-empty values) are
+never overridden by config sources, so ``export TAVILY_API_KEY=...``
+stays a temporary override (documented contract, see ``secret_store``).
+Mechanically this is TS's CCD spawn-env-keys filter
+(managedEnv.ts:62-80) promoted to always-on. The MDM/policy tier is the
+one exception and overrides everything — that is parity with TS's
+*non-CCD* policy precedence (in CCD mode TS strips spawn keys from
+policy too, managedEnv.ts:160-163; this port has no CCD host).
 
 The ``UNSAFE_ENV_KEYS`` set is technically redundant with default-deny
 but exists for auditability — security reviewers should be able to grep
 for ``PATH`` / ``LD_PRELOAD`` / ``NODE_EXTRA_CA_CERTS`` and see them
-explicitly excluded.
-
-Plan reference: ``my-docs/ch02-bootstrap-refactoring-plan.md`` P1.1.
+explicitly excluded **from the project-scoped pre-trust pass**. Trusted
+tiers may legitimately set these keys (the classification is
+project-source-relative, not absolute).
 """
 
 from __future__ import annotations
 
+import json
 import os
-from typing import Mapping
+from pathlib import Path
+from typing import Any, Mapping
 
 __all__ = [
     "SAFE_ENV_KEYS",
@@ -30,17 +59,17 @@ __all__ = [
     "is_safe_env_key",
     "apply_safe_config_environment_variables",
     "apply_full_config_environment_variables",
-    "extract_mdm_safe_env",
+    "establish_session_trust",
+    "extract_mdm_env",
+    "reset_trust_boundary_for_test_only",
 ]
 
 
 # Allow-list ported verbatim from
-# ``typescript/src/utils/managedEnvConstants.ts:109-194``. The exclusions
-# (NODE_EXTRA_CA_CERTS, ANTHROPIC_BASE_URL, HTTP_PROXY, etc.) are
-# intentional security controls — DO NOT add them here. If a key needs
-# to be set pre-trust, port the corresponding TS entry; if it isn't on
-# the TS list, it goes through the post-trust
-# ``apply_full_config_environment_variables`` instead.
+# ``typescript/src/utils/managedEnvConstants.ts:109-194``. Pre-trust,
+# project-scoped sources may only set these. If a key needs to apply
+# pre-trust from a project file, port the corresponding TS entry; if it
+# isn't on the TS list, it waits for the post-trust full pass.
 SAFE_ENV_KEYS: frozenset[str] = frozenset({
     # Model selection (Anthropic + Vertex + Bedrock)
     "ANTHROPIC_CUSTOM_HEADERS",
@@ -135,11 +164,10 @@ SAFE_ENV_KEYS: frozenset[str] = frozenset({
 
 
 # Explicit unsafe set. Redundant with default-deny (anything not in
-# SAFE_ENV_KEYS is unsafe) but exists for auditability — security
-# reviewers should be able to grep for these names and see them
-# explicitly excluded. Anchored to chapter §"The Trust Boundary" and
-# TS managedEnvConstants.ts:92-103 ("TRUST ATTACKER-CONTROLLED SERVER"
-# / "REDIRECT TO ATTACKER-CONTROLLED SERVER" comment blocks).
+# SAFE_ENV_KEYS is unsafe FOR PROJECT-SCOPED SOURCES) but exists for
+# auditability. Anchored to chapter §"The Trust Boundary" and TS
+# managedEnvConstants.ts:92-103. NB: trusted tiers (global config, user
+# settings, MDM) may legitimately set these keys — see module docstring.
 UNSAFE_ENV_PREFIXES: tuple[str, ...] = ("LD_", "DYLD_")
 UNSAFE_ENV_KEYS: frozenset[str] = frozenset({
     # PATH hijacking / shared-library injection
@@ -171,81 +199,249 @@ UNSAFE_ENV_KEYS: frozenset[str] = frozenset({
 })
 
 
+# --- module state -----------------------------------------------------------
+
+# Keys present (with non-empty values) in the process environment before the
+# first config application. Config tiers never override these; only the MDM
+# policy tier may. Mirrors TS ccdSpawnEnvKeys (managedEnv.ts:62-80) promoted
+# to always-on. Empty/whitespace-only shell values do NOT reserve a key —
+# carries over secret_store's "empty env var counts as unset" semantics.
+_shell_env_keys: frozenset[str] | None = None
+
+# MDM env stashed by the safe pass so the full pass can re-assert policy
+# precedence without re-reading the plist payload.
+_last_mdm_env: dict[str, str] = {}
+
+
+def reset_trust_boundary_for_test_only() -> None:
+    """Reset module state. Test-only (PYTEST_CURRENT_TEST-gated)."""
+    if os.environ.get("PYTEST_CURRENT_TEST") is None:
+        raise RuntimeError(
+            "reset_trust_boundary_for_test_only can only be called in tests"
+        )
+    global _shell_env_keys, _last_mdm_env
+    _shell_env_keys = None
+    _last_mdm_env = {}
+
+
+def _capture_shell_env_keys() -> frozenset[str]:
+    global _shell_env_keys
+    if _shell_env_keys is None:
+        _shell_env_keys = frozenset(
+            key for key, value in os.environ.items() if value.strip()
+        )
+    return _shell_env_keys
+
+
 def is_safe_env_key(key: str) -> bool:
-    """True iff this key is safe to apply pre-trust.
+    """True iff a PROJECT-SCOPED source may set this key pre-trust.
 
     Match priority: explicit unsafe set > unsafe prefix match > safe
-    allow-list. Anything that doesn't match the safe list returns
-    False (default-deny).
+    allow-list (case-insensitive, TS managedEnv.ts:175
+    ``key.toUpperCase()``). Default-deny.
     """
     if key in UNSAFE_ENV_KEYS:
         return False
     if any(key.startswith(prefix) for prefix in UNSAFE_ENV_PREFIXES):
         return False
-    return key in SAFE_ENV_KEYS
+    return key.upper() in SAFE_ENV_KEYS
+
+
+# --- application core --------------------------------------------------------
+
+
+def _apply(env: Mapping[str, str], *, override_shell: bool = False) -> None:
+    shell_keys = _capture_shell_env_keys()
+    for key, value in env.items():
+        if not override_shell and key in shell_keys:
+            continue
+        os.environ[key] = value
+
+
+def _coerce_env_block(block: Any) -> dict[str, str]:
+    """Coerce a raw config/settings ``env`` value into ``{str: str}``.
+
+    Same rules as the retired ``secret_store._coerce_env_map``: str/int/float
+    values stringify; bool/None are skipped (booleans are config flags, not
+    env text).
+    """
+    if not isinstance(block, Mapping):
+        return {}
+    out: dict[str, str] = {}
+    for name, value in block.items():
+        if not isinstance(name, str) or not name:
+            continue
+        if isinstance(value, bool) or value is None:
+            continue
+        if isinstance(value, (str, int, float)):
+            out[name] = str(value)
+    return out
+
+
+# --- source loaders (S1..S6 in the round-3 plan) ------------------------------
+
+
+def _load_global_config_env() -> dict[str, str]:
+    """S1: ``env`` from the user's global config. Trusted tier."""
+    from src.config import ConfigManager  # lazy: avoid early-cycle risk
+
+    return _coerce_env_block(ConfigManager().load_global().get("env"))
+
+
+def _read_settings_env(path: str) -> dict[str, str]:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return _coerce_env_block(data.get("env"))
+
+
+def _user_settings_enabled() -> bool:
+    # TS gates trusted-source env on isSettingSourceEnabled
+    # (managedEnv.ts:145, gh#217 SDK isolation).
+    try:
+        from src.bootstrap.state import get_allowed_setting_sources
+
+        return "userSettings" in get_allowed_setting_sources()
+    except Exception:
+        return True
+
+
+def _load_user_settings_env() -> dict[str, str]:
+    """S2: ``env`` from the user settings file. Trusted tier."""
+    if not _user_settings_enabled():
+        return {}
+    from src.permissions import settings_paths
+
+    return _read_settings_env(settings_paths.user_settings_path())
+
+
+def _load_project_scoped_env(cwd: str | Path | None = None) -> dict[str, str]:
+    """S3<S4<S5<S6 merged: project config, project settings, local config,
+    local settings (later wins). The committable, untrusted tier family.
+    """
+    from src import config as config_mod
+    from src.permissions import settings_paths
+
+    cwd_str = str(cwd) if cwd is not None else None
+    merged: dict[str, str] = {}
+
+    cm = config_mod.ConfigManager()
+    merged.update(_coerce_env_block(cm.load_project().get("env")))          # S3
+    merged.update(
+        _read_settings_env(settings_paths.project_settings_path(cwd_str))   # S4
+    )
+    merged.update(_coerce_env_block(cm.load_local().get("env")))            # S5
+    merged.update(
+        _read_settings_env(settings_paths.local_settings_path(cwd_str))     # S6
+    )
+    return merged
+
+
+# --- the two passes -----------------------------------------------------------
 
 
 def apply_safe_config_environment_variables(
     config_env: Mapping[str, str] | None = None,
     extra_env: Mapping[str, str] | None = None,
 ) -> None:
-    """Apply only the safe subset of config.env to os.environ.
+    """Pre-trust pass. Mirrors TS ``applySafeConfigEnvironmentVariables``
+    (managedEnv.ts:125-186).
 
-    Called from ``init()`` before the trust dialog. Mirrors TS
-    ``applySafeConfigEnvironmentVariables``. Uses ``setdefault`` — does
-    NOT overwrite pre-existing process env (matches TS behavior at
-    managedEnv.ts:60-65 which checks ``process.env[key] === undefined``
-    before writing).
+    Order (later wins, subject to the shell-wins rule — see module
+    docstring): trusted tiers IN FULL (global config, then user settings),
+    then the SAFE subset of the merged project-scoped tiers, then the MDM
+    policy env IN FULL (which alone may override the shell). TS literally
+    applies its merged-safe loop after policySettings and relies on merge
+    priority for policy survival; applying MDM last is net-equivalent and
+    simpler (critic-verified for all key-collision cases).
 
-    ``extra_env`` carries managed-config (MDM) values; ch02 round-2 PR-1
-    (G1) consumes the MDM prefetch this way. Order matters: MDM values
-    apply FIRST (lowest precedence — they are defaults), then config-file
-    values via ``setdefault`` so any prior environment OR earlier MDM
-    value wins over a later config-file write. This matches TS where the
-    union is built before any single application.
+    ``config_env`` overrides the S1 global-config tier (test seam).
+    ``extra_env`` is the MDM payload env from :func:`extract_mdm_env`.
     """
+    _apply(
+        _load_global_config_env() if config_env is None else dict(config_env)
+    )
+    _apply(_load_user_settings_env())
+    _apply({
+        key: value
+        for key, value in _load_project_scoped_env().items()
+        if is_safe_env_key(key)
+    })
     if extra_env:
-        for key, value in extra_env.items():
-            if is_safe_env_key(key):
-                os.environ.setdefault(key, value)
-    if config_env is None:
-        config_env = _load_config_env()
-    for key, value in config_env.items():
-        if is_safe_env_key(key):
-            os.environ.setdefault(key, value)
+        global _last_mdm_env
+        _last_mdm_env = dict(extra_env)
+        _apply(_last_mdm_env, override_shell=True)
 
 
 def apply_full_config_environment_variables(
     config_env: Mapping[str, str] | None = None,
 ) -> None:
-    """Apply the full config.env to os.environ, including unsafe.
+    """Post-trust pass. Mirrors TS ``applyConfigEnvironmentVariables``
+    (managedEnv.ts:192-208): every tier in full, MDM policy last.
 
-    Called ONLY after the trust dialog has been accepted. Mirrors TS
-    ``applyConfigEnvironmentVariables``. Overwrites pre-existing values
-    (full apply: unsafe-vars-from-config win over inherited).
+    Idempotent and callable repeatedly (TS re-applies at main.tsx:2591 and
+    on settings change, onChangeAppState.ts:173). Call sites: implicit
+    trust for non-interactive sessions (run_pre_action), previously-trusted
+    interactive sessions, and every trust-gate accept path via
+    :func:`establish_session_trust`.
+
+    Known divergence (documented): TS follows the full apply with CA/mTLS/
+    proxy cache clears + global agent reconfiguration (managedEnv.ts:201-207).
+    The port has no global agent layer — already-constructed HTTP clients
+    (the opt-in TUI builds one before its gates) keep their construction-time
+    proxy/CA settings until next launch; everything reading ``os.environ``
+    at call time picks the new values up immediately. Client
+    rebuild-on-accept is ch04 (API-layer) follow-up work.
     """
-    if config_env is None:
-        config_env = _load_config_env()
-    for key, value in config_env.items():
-        os.environ[key] = value  # full apply: overwrites
+    _apply(
+        _load_global_config_env() if config_env is None else dict(config_env)
+    )
+    _apply(_load_user_settings_env())
+    _apply(_load_project_scoped_env())
+    if _last_mdm_env:
+        _apply(_last_mdm_env, override_shell=True)
 
 
-def extract_mdm_safe_env(payload: str | None) -> dict[str, str]:
-    """Parse an MDM plist-as-JSON payload and return the safe env subset.
+def establish_session_trust() -> None:
+    """Grant session trust and apply the full environment.
+
+    The single helper every accept path uses (TS pairs
+    ``setSessionTrustAccepted(true)`` at interactiveHelpers.tsx:150 with
+    ``applyConfigEnvironmentVariables()`` at :194): non-interactive
+    implicit trust, previously-accepted interactive sessions, the TUI
+    TrustFolderScreen accept, and the legacy-REPL text prompt accept.
+
+    Sets BOTH session-trust flags (bootstrap state + startup_gates) via
+    ``grant_session_trust`` — without the sync, a piped-stdout session
+    (classified non-interactive, dispatched to the REPL) would be asked
+    to trust AFTER its env was already applied.
+    """
+    from src.services.startup_gates import grant_session_trust  # lazy
+
+    grant_session_trust()
+    apply_full_config_environment_variables()
+
+
+def extract_mdm_env(payload: str | None) -> dict[str, str]:
+    """Parse an MDM plist-as-JSON payload and return its env block.
 
     ``payload`` is the stdout from ``plutil -convert json -o -
     /Library/Managed Preferences/com.anthropic.claude-code.plist`` (see
     ``src/prefetch.py:start_mdm_raw_read``). Failure modes (None, empty,
-    malformed JSON, missing ``env`` key, non-dict ``env``) all silently
-    return ``{}`` — init() must never raise due to MDM failures.
+    malformed JSON, missing/non-dict ``env``) silently return ``{}`` —
+    init() must never raise due to MDM failures.
 
-    Only keys passing ``is_safe_env_key`` survive; values are coerced
-    to strings (matching the env-var contract).
+    UNFILTERED (ch02 round-3): the managed-preferences plist is root-owned
+    — it is the port's policy tier, which TS applies without a safe-key
+    filter (managedEnv.ts:160-172). The previous safe-filtering broke the
+    enterprise-proxy use case policy env exists for.
     """
     if not payload:
         return {}
-    import json
-
     try:
         parsed = json.loads(payload)
     except (json.JSONDecodeError, ValueError):
@@ -255,31 +451,4 @@ def extract_mdm_safe_env(payload: str | None) -> dict[str, str]:
     env = parsed.get("env")
     if not isinstance(env, dict):
         return {}
-    return {
-        str(k): str(v)
-        for k, v in env.items()
-        if v is not None and is_safe_env_key(str(k))
-    }
-
-
-def _load_config_env() -> dict[str, str]:
-    """Load the ``env`` subkey from the user's global config.
-
-    Reads from ``ConfigManager.load_global()`` only. TS reads from
-    user/policy/flag sources pre-trust (`managedEnv.ts:106-110`);
-    project/local sources are attacker-controllable (a malicious clone
-    could ship a ``.claude/config.json``) and must be deferred to the
-    post-trust ``apply_full_config_environment_variables``.
-
-    Returns ``{}`` when no ``env`` is configured. The lazy import of
-    ``ConfigManager`` avoids a circular import at module-load.
-    """
-    from src.config import ConfigManager  # lazy: avoid early-cycle risk
-
-    cm = ConfigManager()
-    global_env = cm.load_global().get("env") or {}
-    return {
-        str(k): str(v)
-        for k, v in global_env.items()
-        if v is not None
-    }
+    return _coerce_env_block(env)

--- a/src/secret_store.py
+++ b/src/secret_store.py
@@ -12,23 +12,20 @@ top-level ``"env"`` object — one place for all configuration, no scattered
       }
     }
 
-Because the config hierarchy is global < project < local (deep-merged), an
-``env`` block may appear at any level; later levels override earlier ones.
-
 Resolution order for a single key (highest precedence first):
 
   1. the real process environment (an explicit ``export NAME=...``)
-  2. the merged config ``env`` block
+  2. the GLOBAL config ``env`` block
 
 So an exported shell variable always wins over the stored value (handy for
-temporary overrides and CI), while the config file is the durable store.
+temporary overrides and CI), while the global config file is the durable store.
 
-At startup :func:`apply_config_env_to_environ` copies the config ``env`` block
-into ``os.environ`` (without clobbering already-set variables) so every existing
-``os.environ[...]`` reader — tools, subprocesses, MCP servers — transparently
-sees the stored keys. :func:`get_secret` additionally falls back to reading the
-config directly, so it resolves correctly even on code paths that never ran
-startup ``init()`` (standalone scripts, tests).
+Environment APPLICATION is owned by ``src.permissions.trust_boundary`` (ch02
+round-3): the trusted tiers' env applies at ``init()``, project/local tiers
+only after the folder-trust gate. This module deliberately reads the GLOBAL
+tier only — its fallback exists for code paths that never ran startup
+``init()`` (standalone scripts, tests), and must not become a side door for
+untrusted project-tier values.
 
 Values are never logged; the global config file is written ``0600`` by
 ``src.config._atomic_write_json``.
@@ -67,11 +64,17 @@ def _coerce_env_map(section: Any) -> dict[str, str]:
 
 
 def _config_env() -> dict[str, str]:
-    """The merged config ``env`` block as a ``{NAME: value}`` map (may be empty)."""
-    try:
-        from src.config import load_config
+    """The GLOBAL config ``env`` block as a ``{NAME: value}`` map.
 
-        return _coerce_env_map(load_config().get(CONFIG_ENV_KEY))
+    Global tier only — project/local config env is trust-gated and applied
+    to ``os.environ`` by ``permissions.trust_boundary``; reading the merged
+    view here would leak untrusted project values into ``get_secret``
+    consumers before the trust gate runs.
+    """
+    try:
+        from src.config import ConfigManager
+
+        return _coerce_env_map(ConfigManager().load_global().get(CONFIG_ENV_KEY))
     except Exception as exc:  # config unreadable -> behave as if unset
         logger.debug("secret_store: could not read config env: %s", exc)
         return {}
@@ -90,29 +93,6 @@ def get_secret(name: str, default: str | None = None) -> str | None:
     if cfg_val and cfg_val.strip():
         return cfg_val
     return default
-
-
-def apply_config_env_to_environ(*, override: bool = False) -> list[str]:
-    """Copy the config ``env`` block into ``os.environ``.
-
-    Called once at startup (from :func:`src.init.init`). With ``override=False``
-    (the default) an already-set, non-empty environment variable is left
-    untouched, so an explicit ``export`` wins over the stored value. Returns the
-    list of variable NAMES applied (never values) for diagnostics.
-    """
-    applied: list[str] = []
-    for name, value in _config_env().items():
-        if not override and (os.environ.get(name) or "").strip():
-            continue
-        os.environ[name] = value
-        applied.append(name)
-    if applied:
-        logger.debug(
-            "secret_store: applied %d config env var(s): %s",
-            len(applied),
-            ", ".join(sorted(applied)),
-        )
-    return applied
 
 
 def list_secret_names() -> list[str]:

--- a/src/services/startup_gates.py
+++ b/src/services/startup_gates.py
@@ -87,23 +87,32 @@ def check_trust_accepted(cwd: str | Path | None = None) -> bool:
         current = parent
 
 
-def record_trust_accepted(cwd: str | Path | None = None) -> bool:
-    """Persist acceptance (TS TrustDialog.tsx:172-178). Home directory
-    → session-only; everything else → ``projects[path]`` entry."""
+def grant_session_trust() -> None:
+    """Set BOTH session-trust flags (this module's + bootstrap state's),
+    with no persistence.
 
+    The two flags exist because ``check_trust_accepted`` predates the
+    bootstrap port; they must never desync — e.g. a piped-stdout session
+    is classified non-interactive (implicit trust, full env applied in
+    ``run_pre_action``) yet still dispatches to the REPL, whose gate
+    consults ``check_trust_accepted``; without the sync it would prompt
+    AFTER the env was already applied.
+    """
     global _session_trust_accepted
     _session_trust_accepted = True
-    # Keep the BOOTSTRAP session-trust flag (the port of the same TS
-    # symbol, consumed by hooks/trust_gate.py and
-    # tool_system/context.workspace_trusted) in sync — today init.py
-    # pre-sets it True for every entrypoint, but once that placeholder
-    # narrows, an accepted dialog must still propagate trust there.
     try:
         from src.bootstrap.state import set_session_trust_accepted
 
         set_session_trust_accepted(True)
     except Exception:
         pass
+
+
+def record_trust_accepted(cwd: str | Path | None = None) -> bool:
+    """Persist acceptance (TS TrustDialog.tsx:172-178). Home directory
+    → session-only; everything else → ``projects[path]`` entry."""
+
+    grant_session_trust()
 
     from src import config as config_mod
 
@@ -280,6 +289,7 @@ __all__ = [
     "check_trust_accepted",
     "collect_trust_warnings",
     "get_external_includes_state",
+    "grant_session_trust",
     "has_skip_dangerous_mode_permission_prompt",
     "list_external_includes",
     "record_bypass_accepted",

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -270,6 +270,19 @@ class ClawCodexTUI(App):
             persisted = record_trust_accepted()
         except Exception:
             persisted = False
+        # Apply the full (project/local tiers included) env now that trust
+        # is granted — TS pairs the dialog accept with
+        # applyConfigEnvironmentVariables (interactiveHelpers.tsx:150+194).
+        # The provider client constructed before this screen keeps its
+        # construction-time proxy/CA settings until next launch (no global
+        # agent layer to reconfigure — ch04 follow-up); everything reading
+        # os.environ at call time sees the new values immediately.
+        try:
+            from src.permissions.trust_boundary import establish_session_trust
+
+            establish_session_trust()
+        except Exception:
+            pass
         if not persisted and self._repl_screen is not None:
             self._repl_screen.transcript.append_system(
                 "Folder trusted for this session only — could not write "

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -105,34 +105,50 @@ class TestResetClearsCache(unittest.TestCase):
                 os.environ["PYTEST_CURRENT_TEST"] = saved
 
 
-class TestInitDoesNotApplyUnsafeEnv(unittest.TestCase):
-    """End-to-end: init() must NOT touch PATH or other unsafe vars."""
+class TestInitDoesNotClobberShellEnv(unittest.TestCase):
+    """End-to-end: init() must NOT touch vars the shell already set.
+
+    Round-3 framing: the GLOBAL config is a trusted tier and its env
+    applies in full (TS managedEnv.ts:137) — even keys like PATH — BUT
+    the port's shell-wins rule protects any variable already present in
+    the original process environment. PATH is always in the shell env,
+    so a config PATH never lands. (Project-tier unsafe keys are blocked
+    by classification — covered in test_trust_boundary.py.)"""
 
     def test_path_is_not_modified_by_init(self) -> None:
-        # Setup: pretend the user's global config has both safe and
-        # unsafe keys. apply_safe_config_environment_variables (real,
-        # not mocked) should only apply the safe one.
+        from src.permissions.trust_boundary import (
+            reset_trust_boundary_for_test_only,
+        )
+
         config_env = {
-            "PATH": "/opt/evil/bin",
+            "PATH": "/opt/somewhere/bin",
             "ANTHROPIC_MODEL": "claude-sonnet-4-6",
         }
         original_path = os.environ.get("PATH", "")
+        reset_trust_boundary_for_test_only()
 
         with mock.patch(
-            "src.permissions.trust_boundary._load_config_env",
+            "src.permissions.trust_boundary._load_global_config_env",
             return_value=config_env,
+        ), mock.patch(
+            "src.permissions.trust_boundary._load_user_settings_env",
+            return_value={},
+        ), mock.patch(
+            "src.permissions.trust_boundary._load_project_scoped_env",
+            return_value={},
         ), mock.patch.object(init_module, "setup_graceful_shutdown"), \
                 mock.patch.object(init_module, "start_api_preconnect"):
             os.environ.pop("ANTHROPIC_MODEL", None)
             init_module.init()
 
         try:
-            # PATH unchanged.
+            # PATH unchanged (shell-wins).
             self.assertEqual(os.environ.get("PATH", ""), original_path)
-            # ANTHROPIC_MODEL was applied (safe).
+            # ANTHROPIC_MODEL was applied (not in the shell snapshot).
             self.assertEqual(os.environ.get("ANTHROPIC_MODEL"), "claude-sonnet-4-6")
         finally:
             os.environ.pop("ANTHROPIC_MODEL", None)
+            reset_trust_boundary_for_test_only()
 
 
 class TestRunPreActionCallsInit(unittest.TestCase):
@@ -146,21 +162,29 @@ class TestRunPreActionCallsInit(unittest.TestCase):
 class TestRunPreActionSetsInteractive(unittest.TestCase):
     def test_default_args_interactive_true_when_tty(self) -> None:
         # We can't make sys.stdout a real TTY in unittest, so patch
-        # isatty to return True.
+        # isatty to return True. Trust seeding is exercised separately —
+        # stub establish + the persisted-trust check here.
         with mock.patch.object(init_module, "init"), \
+                mock.patch.object(init_module, "establish_session_trust"), \
+                mock.patch(
+                    "src.services.startup_gates.check_trust_accepted",
+                    return_value=False,
+                ), \
                 mock.patch.object(sys.stdout, "isatty", return_value=True):
             args = types.SimpleNamespace(print=False)
             init_module.run_pre_action(args)
             self.assertTrue(get_is_interactive())
 
     def test_print_mode_sets_interactive_false(self) -> None:
-        with mock.patch.object(init_module, "init"):
+        with mock.patch.object(init_module, "init"), \
+                mock.patch.object(init_module, "establish_session_trust"):
             args = types.SimpleNamespace(print=True)
             init_module.run_pre_action(args)
             self.assertFalse(get_is_interactive())
 
     def test_non_tty_stdout_sets_interactive_false(self) -> None:
         with mock.patch.object(init_module, "init"), \
+                mock.patch.object(init_module, "establish_session_trust"), \
                 mock.patch.object(sys.stdout, "isatty", return_value=False):
             args = types.SimpleNamespace(print=False)
             init_module.run_pre_action(args)
@@ -170,6 +194,7 @@ class TestRunPreActionSetsInteractive(unittest.TestCase):
 class TestRunPreActionSetsClientType(unittest.TestCase):
     def test_default_when_env_unset(self) -> None:
         with mock.patch.object(init_module, "init"), \
+                mock.patch.object(init_module, "establish_session_trust"), \
                 mock.patch.dict(os.environ, {}, clear=False):
             os.environ.pop("CLAUDE_CODE_ENTRYPOINT", None)
             args = types.SimpleNamespace(print=False)
@@ -178,6 +203,7 @@ class TestRunPreActionSetsClientType(unittest.TestCase):
 
     def test_sdk_py_override(self) -> None:
         with mock.patch.object(init_module, "init"), \
+                mock.patch.object(init_module, "establish_session_trust"), \
                 mock.patch.dict(os.environ, {"CLAUDE_CODE_ENTRYPOINT": "sdk-py"}):
             args = types.SimpleNamespace(print=False)
             init_module.run_pre_action(args)
@@ -187,23 +213,52 @@ class TestRunPreActionSetsClientType(unittest.TestCase):
         # Defensive default: an attacker setting this env var to a
         # random string shouldn't change behavior.
         with mock.patch.object(init_module, "init"), \
+                mock.patch.object(init_module, "establish_session_trust"), \
                 mock.patch.dict(os.environ, {"CLAUDE_CODE_ENTRYPOINT": "totally-random"}):
             args = types.SimpleNamespace(print=False)
             init_module.run_pre_action(args)
             self.assertEqual(get_client_type(), "cli")
 
 
-class TestRunPreActionSetsTrustAccepted(unittest.TestCase):
-    """A6 / P1.6: plan-phase-1 default is `set_session_trust_accepted(True)`
-    so existing trust-gate consumers behave correctly."""
+class TestRunPreActionTrustSeeding(unittest.TestCase):
+    """ch02 round-3 trust matrix (replaces the plan-phase-1 unconditional
+    `set_session_trust_accepted(True)`):
 
-    def test_pre_action_sets_trust_accepted_true(self) -> None:
-        # Pre-state: default False.
-        self.assertFalse(get_session_trust_accepted())
-        with mock.patch.object(init_module, "init"):
+    * non-interactive  → implicit trust (TS main.tsx:1955-1967);
+    * interactive + previously accepted → trusted;
+    * interactive + not accepted → stays untrusted (the surface's gate
+      decides later).
+    """
+
+    def _run(self, *, interactive: bool, persisted_trust: bool) -> mock.MagicMock:
+        establish = mock.MagicMock()
+        with mock.patch.object(init_module, "init"), \
+                mock.patch.object(
+                    init_module, "establish_session_trust", establish
+                ), \
+                mock.patch(
+                    "src.services.startup_gates.check_trust_accepted",
+                    return_value=persisted_trust,
+                ), \
+                mock.patch.object(
+                    sys.stdout, "isatty", return_value=interactive
+                ):
             args = types.SimpleNamespace(print=False)
             init_module.run_pre_action(args)
-        self.assertTrue(get_session_trust_accepted())
+        return establish
+
+    def test_non_interactive_gets_implicit_trust(self) -> None:
+        establish = self._run(interactive=False, persisted_trust=False)
+        establish.assert_called_once()
+
+    def test_interactive_previously_trusted_establishes(self) -> None:
+        establish = self._run(interactive=True, persisted_trust=True)
+        establish.assert_called_once()
+
+    def test_interactive_untrusted_stays_untrusted(self) -> None:
+        establish = self._run(interactive=True, persisted_trust=False)
+        establish.assert_not_called()
+        self.assertFalse(get_session_trust_accepted())
 
 
 if __name__ == "__main__":

--- a/tests/test_init_integration.py
+++ b/tests/test_init_integration.py
@@ -143,8 +143,14 @@ class TestPreActionRunsForDefaultInvocation(unittest.TestCase):
         # We patch the actual REPL launcher so the test doesn't drag
         # in the full provider/registry/etc. stack. _resolve_permission_state
         # is allowed to run because cli.start_repl reads args._resolved_*.
+        # check_trust_accepted is patched True so the round-3 REPL trust
+        # gate (exercised in test_trust_wiring_round3.py) stays inert here.
         with mock.patch("src.init.run_pre_action") as mock_pre, \
                 mock.patch("src.cli.start_repl", return_value=0), \
+                mock.patch(
+                    "src.services.startup_gates.check_trust_accepted",
+                    return_value=True,
+                ), \
                 mock.patch("src.entrypoints.tui.should_use_tui", return_value=False), \
                 mock.patch.object(sys, "argv", ["clawcodex"]):
             from src import cli
@@ -158,15 +164,30 @@ class TestPreActionRunsForDefaultInvocation(unittest.TestCase):
 
 
 class TestInitSafeEnvApplyBeforeUnsafe(unittest.TestCase):
-    def test_safe_applied_unsafe_skipped(self) -> None:
+    def test_safe_applied_shell_path_preserved(self) -> None:
+        # Round-3: the global tier applies in full, but PATH is always
+        # in the original shell environment, so the shell-wins rule
+        # preserves it. Project-tier unsafe-key exclusion is covered in
+        # test_trust_boundary.py.
+        from src.permissions.trust_boundary import (
+            reset_trust_boundary_for_test_only,
+        )
+
         config_env = {
-            "ANTHROPIC_MODEL": "claude-sonnet-4-6",  # safe
-            "PATH": "/opt/evil/bin",                 # unsafe
+            "ANTHROPIC_MODEL": "claude-sonnet-4-6",
+            "PATH": "/opt/somewhere/bin",
         }
         original_path = os.environ.get("PATH", "")
+        reset_trust_boundary_for_test_only()
         with mock.patch(
-            "src.permissions.trust_boundary._load_config_env",
+            "src.permissions.trust_boundary._load_global_config_env",
             return_value=config_env,
+        ), mock.patch(
+            "src.permissions.trust_boundary._load_user_settings_env",
+            return_value={},
+        ), mock.patch(
+            "src.permissions.trust_boundary._load_project_scoped_env",
+            return_value={},
         ), mock.patch.object(init_module, "setup_graceful_shutdown"), \
                 mock.patch.object(init_module, "start_api_preconnect"):
             os.environ.pop("ANTHROPIC_MODEL", None)
@@ -176,6 +197,7 @@ class TestInitSafeEnvApplyBeforeUnsafe(unittest.TestCase):
                 self.assertEqual(os.environ.get("PATH", ""), original_path)
             finally:
                 os.environ.pop("ANTHROPIC_MODEL", None)
+                reset_trust_boundary_for_test_only()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_init_prefetch_consumption.py
+++ b/tests/test_init_prefetch_consumption.py
@@ -1,12 +1,15 @@
-"""Tests for ch02 round-2 PR-1 (G1): init() consumes prefetch results.
+"""Tests for init() prefetch consumption (ch02 round-2 G1 + round-3).
 
 Covers:
-- MDM payload parsing (extract_mdm_safe_env) — safe vs unsafe keys,
-  malformed inputs, missing fields, None / empty.
+- MDM payload parsing (extract_mdm_env) — UNFILTERED extraction (round-3:
+  the root-owned managed-prefs plist is the policy tier, TS applies
+  policySettings without a safe-key filter), malformed inputs, missing
+  fields, None / empty.
 - Keychain stash semantics — set/read, idempotence, None handling.
 - init() integration — MDM payload threaded into
   apply_safe_config_environment_variables(extra_env=...).
-- Precedence — config-file values still win over MDM extras (setdefault).
+- Precedence — the MDM policy tier applies LAST and overrides every other
+  tier AND the inherited shell env (round-3; TS policy precedence).
 """
 
 from __future__ import annotations
@@ -18,7 +21,8 @@ from unittest import mock
 from src.init import init, reset_init_for_test_only
 from src.permissions.trust_boundary import (
     apply_safe_config_environment_variables,
-    extract_mdm_safe_env,
+    extract_mdm_env,
+    reset_trust_boundary_for_test_only,
 )
 from src.utils.keychain_stash import (
     read_stashed_keychain,
@@ -27,44 +31,68 @@ from src.utils.keychain_stash import (
 )
 
 
+def _hermetic_tier_patches() -> list:
+    """Patch the disk-backed tier loaders so tests never read the real
+    user/global/project config or settings files."""
+    return [
+        mock.patch(
+            "src.permissions.trust_boundary._load_global_config_env",
+            return_value={},
+        ),
+        mock.patch(
+            "src.permissions.trust_boundary._load_user_settings_env",
+            return_value={},
+        ),
+        mock.patch(
+            "src.permissions.trust_boundary._load_project_scoped_env",
+            return_value={},
+        ),
+    ]
+
+
 _SAFE_KEY = "ANTHROPIC_MODEL"
 _UNSAFE_KEY = "ANTHROPIC_API_KEY"
 
 
-class ExtractMdmSafeEnvTests(unittest.TestCase):
-    def test_filters_to_safe_keys_only(self) -> None:
+class ExtractMdmEnvTests(unittest.TestCase):
+    def test_extraction_is_unfiltered(self) -> None:
+        # Round-3: MDM is the policy tier — no safe-key filter (TS
+        # applies policySettings unfiltered, managedEnv.ts:160-172).
         payload = (
             '{"env": {"' + _SAFE_KEY + '": "claude-opus-4-7", '
             '"' + _UNSAFE_KEY + '": "sk-secret"}}'
         )
-        result = extract_mdm_safe_env(payload)
-        self.assertEqual(result, {_SAFE_KEY: "claude-opus-4-7"})
+        result = extract_mdm_env(payload)
+        self.assertEqual(
+            result,
+            {_SAFE_KEY: "claude-opus-4-7", _UNSAFE_KEY: "sk-secret"},
+        )
 
     def test_returns_empty_dict_for_none_payload(self) -> None:
-        self.assertEqual(extract_mdm_safe_env(None), {})
+        self.assertEqual(extract_mdm_env(None), {})
 
     def test_returns_empty_dict_for_empty_payload(self) -> None:
-        self.assertEqual(extract_mdm_safe_env(""), {})
+        self.assertEqual(extract_mdm_env(""), {})
 
     def test_returns_empty_dict_for_malformed_json(self) -> None:
-        self.assertEqual(extract_mdm_safe_env('{not valid json'), {})
+        self.assertEqual(extract_mdm_env('{not valid json'), {})
 
     def test_returns_empty_dict_for_missing_env_key(self) -> None:
-        self.assertEqual(extract_mdm_safe_env('{"other": 1}'), {})
+        self.assertEqual(extract_mdm_env('{"other": 1}'), {})
 
     def test_returns_empty_dict_for_non_dict_env(self) -> None:
-        self.assertEqual(extract_mdm_safe_env('{"env": "not a dict"}'), {})
+        self.assertEqual(extract_mdm_env('{"env": "not a dict"}'), {})
 
     def test_returns_empty_dict_for_non_dict_root(self) -> None:
-        self.assertEqual(extract_mdm_safe_env('["a", "b"]'), {})
+        self.assertEqual(extract_mdm_env('["a", "b"]'), {})
 
     def test_skips_none_values(self) -> None:
         payload = '{"env": {"' + _SAFE_KEY + '": null}}'
-        self.assertEqual(extract_mdm_safe_env(payload), {})
+        self.assertEqual(extract_mdm_env(payload), {})
 
     def test_coerces_non_string_values(self) -> None:
         payload = '{"env": {"' + _SAFE_KEY + '": 42}}'
-        self.assertEqual(extract_mdm_safe_env(payload), {_SAFE_KEY: "42"})
+        self.assertEqual(extract_mdm_env(payload), {_SAFE_KEY: "42"})
 
 
 class KeychainStashTests(unittest.TestCase):
@@ -98,14 +126,27 @@ class KeychainStashTests(unittest.TestCase):
 
 class ApplySafeEnvExtraTests(unittest.TestCase):
     def setUp(self) -> None:
+        reset_trust_boundary_for_test_only()
         self._original = os.environ.get(_SAFE_KEY)
+        self._original_unsafe = os.environ.get(_UNSAFE_KEY)
         os.environ.pop(_SAFE_KEY, None)
+        os.environ.pop(_UNSAFE_KEY, None)
+        self._patches = _hermetic_tier_patches()
+        for p in self._patches:
+            p.start()
 
     def tearDown(self) -> None:
-        if self._original is None:
-            os.environ.pop(_SAFE_KEY, None)
-        else:
-            os.environ[_SAFE_KEY] = self._original
+        for p in self._patches:
+            p.stop()
+        for key, original in (
+            (_SAFE_KEY, self._original),
+            (_UNSAFE_KEY, self._original_unsafe),
+        ):
+            if original is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = original
+        reset_trust_boundary_for_test_only()
 
     def test_extra_env_applies_safe_keys(self) -> None:
         apply_safe_config_environment_variables(
@@ -113,25 +154,28 @@ class ApplySafeEnvExtraTests(unittest.TestCase):
         )
         self.assertEqual(os.environ.get(_SAFE_KEY), "from-mdm")
 
-    def test_extra_env_ignores_unsafe_keys(self) -> None:
+    def test_extra_env_applies_unsafe_keys_too(self) -> None:
+        # Round-3: the policy tier is unfiltered — an IT-managed API key
+        # or proxy is the use case managed preferences exist for.
         apply_safe_config_environment_variables(
             config_env={},
-            extra_env={_UNSAFE_KEY: "sk-leaked"},
+            extra_env={_UNSAFE_KEY: "sk-managed"},
         )
-        self.assertIsNone(os.environ.get(_UNSAFE_KEY))
+        self.assertEqual(os.environ.get(_UNSAFE_KEY), "sk-managed")
 
-    def test_extra_env_loses_to_existing_environ(self) -> None:
+    def test_extra_env_overrides_existing_environ(self) -> None:
+        # Round-3: MDM/policy alone overrides the inherited shell env
+        # (TS applies policySettings last; IT must win).
         os.environ[_SAFE_KEY] = "from-env"
+        reset_trust_boundary_for_test_only()  # snapshot includes the export
         apply_safe_config_environment_variables(
             config_env={}, extra_env={_SAFE_KEY: "from-mdm"}
         )
-        # setdefault: pre-existing wins
-        self.assertEqual(os.environ.get(_SAFE_KEY), "from-env")
+        self.assertEqual(os.environ.get(_SAFE_KEY), "from-mdm")
 
-    def test_config_env_overrides_extra_env_via_setdefault_ordering(self) -> None:
-        # extra_env applies FIRST via setdefault, then config_env via
-        # setdefault. So if both target the same key with no pre-existing
-        # env, extra_env wins (first writer to setdefault).
+    def test_extra_env_beats_config_env(self) -> None:
+        # MDM applies LAST (policy precedence) — it overwrites the
+        # global-config tier value.
         apply_safe_config_environment_variables(
             config_env={_SAFE_KEY: "from-config"},
             extra_env={_SAFE_KEY: "from-mdm"},
@@ -145,12 +189,19 @@ class InitConsumesPrefetchesTests(unittest.TestCase):
     def setUp(self) -> None:
         reset_init_for_test_only()
         reset_stashed_keychain_for_test_only()
+        reset_trust_boundary_for_test_only()
         self._original_safe = os.environ.get(_SAFE_KEY)
         os.environ.pop(_SAFE_KEY, None)
+        self._tier_patches = _hermetic_tier_patches()
+        for p in self._tier_patches:
+            p.start()
 
     def tearDown(self) -> None:
+        for p in self._tier_patches:
+            p.stop()
         reset_init_for_test_only()
         reset_stashed_keychain_for_test_only()
+        reset_trust_boundary_for_test_only()
         if self._original_safe is None:
             os.environ.pop(_SAFE_KEY, None)
         else:

--- a/tests/test_secret_store.py
+++ b/tests/test_secret_store.py
@@ -60,34 +60,27 @@ def test_get_secret_default_when_missing(monkeypatch):
     assert ss.get_secret("MYKEY", "fallback") == "fallback"
 
 
-# --- apply_config_env_to_environ -----------------------------------------
+# --- global-tier scoping (ch02 round-3) -----------------------------------
+# Env APPLICATION moved to permissions.trust_boundary; the read fallback
+# here must see ONLY the global tier so untrusted project config can never
+# feed get_secret consumers before the trust gate.
 
 
-def test_apply_no_override_preserves_real_env(monkeypatch):
-    monkeypatch.setattr(ss, "_config_env", lambda: {"A_REAL": "cfg-a", "B_NEW": "cfg-b"})
-    monkeypatch.setenv("A_REAL", "exported-a")
-    monkeypatch.delenv("B_NEW", raising=False)
-    try:
-        applied = ss.apply_config_env_to_environ()
-        assert applied == ["B_NEW"]            # only the unset one
-        import os
+def test_config_env_reads_global_tier_only(monkeypatch):
+    from unittest import mock
 
-        assert os.environ["A_REAL"] == "exported-a"  # export preserved
-        assert os.environ["B_NEW"] == "cfg-b"         # filled from config
-    finally:
-        import os
-
-        os.environ.pop("B_NEW", None)
-
-
-def test_apply_override_true_replaces(monkeypatch):
-    monkeypatch.setattr(ss, "_config_env", lambda: {"A_REAL": "cfg-a"})
-    monkeypatch.setenv("A_REAL", "exported-a")
-    applied = ss.apply_config_env_to_environ(override=True)
-    assert applied == ["A_REAL"]
-    import os
-
-    assert os.environ["A_REAL"] == "cfg-a"
+    monkeypatch.delenv("MYKEY", raising=False)
+    monkeypatch.delenv("EVIL", raising=False)
+    with mock.patch(
+        "src.config.ConfigManager.load_global",
+        return_value={"env": {"MYKEY": "from-global"}},
+    ), mock.patch(
+        "src.config.ConfigManager.load_project",
+        return_value={"env": {"MYKEY": "from-project", "EVIL": "x"}},
+    ) as mock_project:
+        assert ss.get_secret("MYKEY") == "from-global"
+        assert ss.get_secret("EVIL") is None
+        mock_project.assert_not_called()
 
 
 def test_list_secret_names(monkeypatch):

--- a/tests/test_trust_boundary.py
+++ b/tests/test_trust_boundary.py
@@ -1,9 +1,14 @@
-"""Unit tests for ``src/permissions/trust_boundary.py`` (P1.1).
+"""Unit tests for ``src/permissions/trust_boundary.py`` (ch02 round-3).
 
-Mirrors the chapter §"The Trust Boundary" semantic: only the safe env-
-var subset applies pre-trust; everything else (PATH, LD_PRELOAD,
-NODE_EXTRA_CA_CERTS, proxies, base URLs, API keys) is excluded by
-default-deny.
+The boundary is SOURCE-class based (TS managedEnv.ts:106-110):
+
+* trusted tiers (global config, user settings) apply IN FULL pre-trust;
+* project-scoped tiers apply only the ``SAFE_ENV_KEYS`` subset pre-trust
+  and in full post-trust;
+* the MDM policy tier applies in full, last, and alone may override the
+  inherited shell environment;
+* original (non-empty) shell env keys are never overridden by config
+  tiers — the port's documented shell-wins customization.
 """
 
 from __future__ import annotations
@@ -12,8 +17,6 @@ import os
 import unittest
 from unittest import mock
 
-import pytest
-
 from src.permissions.trust_boundary import (
     SAFE_ENV_KEYS,
     UNSAFE_ENV_KEYS,
@@ -21,14 +24,12 @@ from src.permissions.trust_boundary import (
     apply_full_config_environment_variables,
     apply_safe_config_environment_variables,
     is_safe_env_key,
+    reset_trust_boundary_for_test_only,
 )
 
 
 class TestSafeKeyAllowList(unittest.TestCase):
     def test_every_entry_in_safe_env_keys_is_safe(self) -> None:
-        # Every key in the allow-list must classify as safe — round-trip
-        # verifies no entry is shadowed by UNSAFE_ENV_KEYS or by a
-        # prefix match.
         for key in SAFE_ENV_KEYS:
             with self.subTest(key=key):
                 self.assertTrue(
@@ -38,17 +39,28 @@ class TestSafeKeyAllowList(unittest.TestCase):
 
     def test_set_size_matches_ts_port(self) -> None:
         # Sanity check: TS managedEnvConstants.ts:109-194 has 82 entries
-        # in SAFE_ENV_VARS. Our port should match exactly. If a future
-        # WI legitimately changes the count, update both this number
-        # and the corresponding TS comment.
+        # in SAFE_ENV_VARS. Our port should match exactly.
         self.assertEqual(
             len(SAFE_ENV_KEYS),
             82,
             "SAFE_ENV_KEYS count drifted from the TS port",
         )
 
+    def test_membership_is_case_insensitive(self) -> None:
+        # TS tests key.toUpperCase() (managedEnv.ts:175) — a project
+        # settings file may write `anthropic_model` and it still counts
+        # as the safe key.
+        self.assertTrue(is_safe_env_key("anthropic_model"))
+        self.assertTrue(is_safe_env_key("Disable_Telemetry"))
+
 
 class TestUnsafeKeysBlocked(unittest.TestCase):
+    """``is_safe_env_key`` is the PROJECT-TIER gate. These keys may
+    never apply pre-trust **from a project-scoped source**; trusted
+    tiers (global config, user settings, MDM) may legitimately set
+    them — see TS caCertsConfig.ts:59-66 for the same source-relative
+    distinction on NODE_EXTRA_CA_CERTS."""
+
     def test_path_returns_false(self) -> None:
         self.assertFalse(is_safe_env_key("PATH"))
 
@@ -59,9 +71,10 @@ class TestUnsafeKeysBlocked(unittest.TestCase):
         self.assertFalse(is_safe_env_key("NODE_OPTIONS"))
 
     def test_node_extra_ca_certs_returns_false(self) -> None:
-        # The round-1 critic-blocking-issue case: TS explicitly flags
-        # NODE_EXTRA_CA_CERTS as "TRUST ATTACKER-CONTROLLED SERVER"
-        # (managedEnvConstants.ts:99-103).
+        # TS flags NODE_EXTRA_CA_CERTS as "TRUST ATTACKER-CONTROLLED
+        # SERVER" for PROJECT sources (managedEnvConstants.ts:99-103);
+        # the same key from global config/user settings applies
+        # pre-trust via the trusted-tier pass (caCertsConfig.ts:59-66).
         self.assertFalse(is_safe_env_key("NODE_EXTRA_CA_CERTS"))
 
     def test_anthropic_base_url_returns_false(self) -> None:
@@ -88,139 +101,234 @@ class TestUnsafePrefixesBlocked(unittest.TestCase):
 
 class TestUnknownKeyDefaultDeny(unittest.TestCase):
     def test_random_key_returns_false(self) -> None:
-        # Default-deny: anything not in the allow-list returns False.
         self.assertFalse(is_safe_env_key("FOO_BAR_BAZ"))
 
     def test_empty_string_returns_false(self) -> None:
         self.assertFalse(is_safe_env_key(""))
 
 
-class TestApplySafeDoesNotApplyUnsafe(unittest.TestCase):
-    def test_unsafe_keys_excluded_from_safe_apply(self, *, monkeypatch=None):
-        # Use a synthetic config_env so we don't depend on real disk
-        # state. Pass it explicitly to bypass _load_config_env.
-        config_env = {
-            "ANTHROPIC_MODEL": "claude-sonnet-4-6",  # safe
-            "PATH": "/opt/evil/bin",                 # unsafe
-            "NODE_EXTRA_CA_CERTS": "/opt/evil.crt",  # unsafe
-            "LD_PRELOAD": "/opt/evil.so",            # unsafe (prefix)
-            "DISABLE_TELEMETRY": "1",                # safe
+class _HermeticEnvCase(unittest.TestCase):
+    """Base for application-semantics tests: resets the module's
+    shell-env snapshot, patches all tier loaders to empty (tests opt in
+    per tier), and restores every env key it touches."""
+
+    TOUCHED_KEYS: tuple[str, ...] = ()
+
+    def setUp(self) -> None:
+        reset_trust_boundary_for_test_only()
+        self._saved = {k: os.environ.get(k) for k in self.TOUCHED_KEYS}
+        for key in self.TOUCHED_KEYS:
+            os.environ.pop(key, None)
+        self._patches = [
+            mock.patch(
+                "src.permissions.trust_boundary._load_global_config_env",
+                return_value={},
+            ),
+            mock.patch(
+                "src.permissions.trust_boundary._load_user_settings_env",
+                return_value={},
+            ),
+            mock.patch(
+                "src.permissions.trust_boundary._load_project_scoped_env",
+                return_value={},
+            ),
+        ]
+        self.mock_global, self.mock_user, self.mock_project = [
+            p.start() for p in self._patches
+        ]
+
+    def tearDown(self) -> None:
+        for p in self._patches:
+            p.stop()
+        for key, value in self._saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        reset_trust_boundary_for_test_only()
+
+
+class TestTrustedTiersApplyFully(_HermeticEnvCase):
+    """TS applies trusted-source env IN FULL pre-trust
+    (managedEnv.ts:137-159) — including keys on the project-unsafe list."""
+
+    TOUCHED_KEYS = ("NODE_TLS_REJECT_UNAUTHORIZED", "ANTHROPIC_MODEL")
+
+    def test_global_config_unsafe_class_key_applies_pre_trust(self) -> None:
+        apply_safe_config_environment_variables(
+            config_env={"NODE_TLS_REJECT_UNAUTHORIZED": "0"}
+        )
+        self.assertEqual(os.environ.get("NODE_TLS_REJECT_UNAUTHORIZED"), "0")
+
+    def test_user_settings_env_applies_pre_trust(self) -> None:
+        self.mock_user.return_value = {"ANTHROPIC_MODEL": "from-user-settings"}
+        apply_safe_config_environment_variables(config_env={})
+        self.assertEqual(
+            os.environ.get("ANTHROPIC_MODEL"), "from-user-settings"
+        )
+
+    def test_user_settings_beat_global(self) -> None:
+        self.mock_user.return_value = {"ANTHROPIC_MODEL": "from-user-settings"}
+        apply_safe_config_environment_variables(
+            config_env={"ANTHROPIC_MODEL": "from-global"}
+        )
+        self.assertEqual(
+            os.environ.get("ANTHROPIC_MODEL"), "from-user-settings"
+        )
+
+
+class TestProjectTierSafeSubset(_HermeticEnvCase):
+    """Project-scoped sources: SAFE subset pre-trust (managedEnv.ts:173-178),
+    everything post-trust."""
+
+    TOUCHED_KEYS = (
+        "ANTHROPIC_MODEL",
+        "NODE_EXTRA_CA_CERTS",
+        "LD_PRELOAD",
+        "GIT_WORK_TREE_TEST_TB",
+    )
+
+    def test_project_safe_key_applies_pre_trust(self) -> None:
+        self.mock_project.return_value = {"ANTHROPIC_MODEL": "from-project"}
+        apply_safe_config_environment_variables(config_env={})
+        self.assertEqual(os.environ.get("ANTHROPIC_MODEL"), "from-project")
+
+    def test_project_safe_key_lowercase_applies_pre_trust(self) -> None:
+        self.mock_project.return_value = {"anthropic_model": "from-project"}
+        apply_safe_config_environment_variables(config_env={})
+        self.assertEqual(os.environ.get("anthropic_model"), "from-project")
+
+    def test_project_unsafe_keys_never_apply_pre_trust(self) -> None:
+        self.mock_project.return_value = {
+            "NODE_EXTRA_CA_CERTS": "/opt/evil.crt",
+            "LD_PRELOAD": "/opt/evil.so",
         }
-        with mock.patch.dict(os.environ, {}, clear=False):
-            # Remove any pre-existing keys to make the test deterministic
-            for k in ("ANTHROPIC_MODEL", "DISABLE_TELEMETRY", "PATH",
-                      "NODE_EXTRA_CA_CERTS", "LD_PRELOAD"):
-                os.environ.pop(k, None)
-            apply_safe_config_environment_variables(config_env)
+        apply_safe_config_environment_variables(config_env={})
+        self.assertIsNone(os.environ.get("NODE_EXTRA_CA_CERTS"))
+        self.assertIsNone(os.environ.get("LD_PRELOAD"))
 
-            self.assertEqual(os.environ.get("ANTHROPIC_MODEL"), "claude-sonnet-4-6")
-            self.assertEqual(os.environ.get("DISABLE_TELEMETRY"), "1")
-            # Unsafe keys: NOT applied.
-            self.assertNotEqual(os.environ.get("PATH"), "/opt/evil/bin")
-            self.assertIsNone(os.environ.get("NODE_EXTRA_CA_CERTS"))
-            self.assertIsNone(os.environ.get("LD_PRELOAD"))
+    def test_full_pass_applies_project_unsafe_keys(self) -> None:
+        # Post-trust the project tier applies in full — for keys not
+        # reserved by the shell snapshot (GIT_WORK_TREE-style keys are
+        # the TS-cited motivation, main.tsx:1955-1961).
+        self.mock_project.return_value = {
+            "GIT_WORK_TREE_TEST_TB": "/repo/worktree"
+        }
+        apply_full_config_environment_variables(config_env={})
+        self.assertEqual(
+            os.environ.get("GIT_WORK_TREE_TEST_TB"), "/repo/worktree"
+        )
+
+    def test_full_pass_project_beats_global(self) -> None:
+        self.mock_project.return_value = {"ANTHROPIC_MODEL": "from-project"}
+        apply_full_config_environment_variables(
+            config_env={"ANTHROPIC_MODEL": "from-global"}
+        )
+        self.assertEqual(os.environ.get("ANTHROPIC_MODEL"), "from-project")
 
 
-class TestApplySafeDoesNotOverwriteExisting(unittest.TestCase):
-    def test_setdefault_semantics(self) -> None:
-        # Pre-existing process env wins; setdefault doesn't clobber.
-        config_env = {"ANTHROPIC_MODEL": "from-config"}
-        with mock.patch.dict(os.environ, {"ANTHROPIC_MODEL": "from-shell"}, clear=False):
-            apply_safe_config_environment_variables(config_env)
-            self.assertEqual(os.environ["ANTHROPIC_MODEL"], "from-shell")
+class TestShellWinsCustomization(_HermeticEnvCase):
+    """Documented port divergence from TS Object.assign: variables
+    present (non-empty) in the ORIGINAL process environment are never
+    overridden by config tiers — only by the MDM policy tier. Mechanism:
+    TS's CCD spawn-env-keys filter (managedEnv.ts:62-80) always-on."""
+
+    TOUCHED_KEYS = ("ANTHROPIC_MODEL",)
+
+    def test_shell_var_survives_safe_and_full_pass(self) -> None:
+        os.environ["ANTHROPIC_MODEL"] = "from-shell"
+        reset_trust_boundary_for_test_only()  # snapshot AFTER the export
+        apply_safe_config_environment_variables(
+            config_env={"ANTHROPIC_MODEL": "from-config"}
+        )
+        self.assertEqual(os.environ["ANTHROPIC_MODEL"], "from-shell")
+        apply_full_config_environment_variables(
+            config_env={"ANTHROPIC_MODEL": "from-config"}
+        )
+        self.assertEqual(os.environ["ANTHROPIC_MODEL"], "from-shell")
+
+    def test_empty_shell_var_does_not_reserve_the_key(self) -> None:
+        # Carry-over from the retired secret_store applier: an empty env
+        # var counts as unset (`export FOO=` should not mask config).
+        os.environ["ANTHROPIC_MODEL"] = "   "
+        reset_trust_boundary_for_test_only()
+        apply_safe_config_environment_variables(
+            config_env={"ANTHROPIC_MODEL": "from-config"}
+        )
+        self.assertEqual(os.environ["ANTHROPIC_MODEL"], "from-config")
+
+    def test_mdm_overrides_shell(self) -> None:
+        # The policy tier is the single exception (TS applies
+        # policySettings last among trusted sources; IT must win).
+        os.environ["ANTHROPIC_MODEL"] = "from-shell"
+        reset_trust_boundary_for_test_only()
+        apply_safe_config_environment_variables(
+            config_env={}, extra_env={"ANTHROPIC_MODEL": "from-mdm"}
+        )
+        self.assertEqual(os.environ["ANTHROPIC_MODEL"], "from-mdm")
 
 
-class TestApplyFullOverwritesUnsafe(unittest.TestCase):
-    def test_full_apply_writes_unsafe_keys(self) -> None:
-        # Post-trust: the full apply writes everything, including
-        # explicitly-unsafe keys.
-        config_env = {"PATH": "/opt/safe/bin", "ANTHROPIC_MODEL": "claude-4"}
-        with mock.patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("PATH", None)
-            os.environ.pop("ANTHROPIC_MODEL", None)
-            apply_full_config_environment_variables(config_env)
-            self.assertEqual(os.environ.get("PATH"), "/opt/safe/bin")
-            self.assertEqual(os.environ.get("ANTHROPIC_MODEL"), "claude-4")
+class TestMdmPolicyTier(_HermeticEnvCase):
+    TOUCHED_KEYS = ("ANTHROPIC_MODEL", "HTTPS_PROXY")
 
-    def test_full_apply_overwrites_existing(self) -> None:
-        # Full apply uses assignment, not setdefault — so a config value
-        # wins over the shell value, mirroring TS's post-trust behavior.
-        config_env = {"ANTHROPIC_MODEL": "from-config"}
-        with mock.patch.dict(os.environ, {"ANTHROPIC_MODEL": "from-shell"}, clear=False):
-            apply_full_config_environment_variables(config_env)
-            self.assertEqual(os.environ["ANTHROPIC_MODEL"], "from-config")
+    def test_mdm_applies_last_over_other_tiers(self) -> None:
+        self.mock_project.return_value = {"ANTHROPIC_MODEL": "from-project"}
+        apply_safe_config_environment_variables(
+            config_env={"ANTHROPIC_MODEL": "from-global"},
+            extra_env={"ANTHROPIC_MODEL": "from-mdm"},
+        )
+        self.assertEqual(os.environ["ANTHROPIC_MODEL"], "from-mdm")
+
+    def test_mdm_unsafe_class_keys_apply(self) -> None:
+        # Root-owned policy tier is unfiltered (TS applies policySettings
+        # without a safe-key filter, managedEnv.ts:160-172) — the
+        # enterprise-proxy use case.
+        apply_safe_config_environment_variables(
+            config_env={}, extra_env={"HTTPS_PROXY": "http://corp-proxy:3128"}
+        )
+        self.assertEqual(
+            os.environ.get("HTTPS_PROXY"), "http://corp-proxy:3128"
+        )
+
+    def test_full_pass_reasserts_mdm_last(self) -> None:
+        # The safe pass stashes the MDM env; the full pass re-applies it
+        # after the project tier so policy survives post-trust too.
+        apply_safe_config_environment_variables(
+            config_env={}, extra_env={"ANTHROPIC_MODEL": "from-mdm"}
+        )
+        self.mock_project.return_value = {"ANTHROPIC_MODEL": "from-project"}
+        apply_full_config_environment_variables(config_env={})
+        self.assertEqual(os.environ["ANTHROPIC_MODEL"], "from-mdm")
 
 
 class TestLoadConfigEnvFallthrough(unittest.TestCase):
-    """Risk-register row 3: load_global must fall through cleanly
-    when no global config exists.
-    """
-
     def test_no_global_config_does_not_raise(self) -> None:
-        # apply_safe_config_environment_variables() with no arg loads
-        # from disk. On a fresh test machine without ~/.clawcodex/config.json
-        # this should succeed and apply nothing (returns empty dict).
-        # Mock ConfigManager.load_global to return {} (no env subkey)
-        # so the test doesn't depend on user-local config.
-        with mock.patch("src.config.ConfigManager.load_global", return_value={}):
+        reset_trust_boundary_for_test_only()
+        with mock.patch(
+            "src.config.ConfigManager.load_global", return_value={}
+        ), mock.patch(
+            "src.config.ConfigManager.load_project", return_value={}
+        ), mock.patch(
+            "src.config.ConfigManager.load_local", return_value={}
+        ), mock.patch(
+            "src.permissions.trust_boundary._read_settings_env",
+            return_value={},
+        ):
             apply_safe_config_environment_variables()  # must not raise
 
 
-class TestLoadConfigEnvOnlyReadsGlobal(unittest.TestCase):
-    """Security invariant: _load_config_env reads ONLY load_global,
-    never load_project / load_local. A malicious project clone
-    shipping ``.claude/config.json`` with ``env: {PATH: /opt/evil}``
-    must NOT poison the pre-trust env.
-
-    Per the chapter §"The Trust Boundary" and the TS reference
-    (managedEnv.ts:106-110, which reads from user/policy/flag sources
-    only). The plan's risk-register row 3 committed to this test.
-    """
-
-    def test_project_env_not_applied_pre_trust(self) -> None:
-        # Simulate the attack: global config has no env, but project
-        # config has a malicious PATH.
-        attacker_env = {"PATH": "/opt/evil/bin"}
-        original_path = os.environ.get("PATH", "")
-
-        # The implementation should only read load_global. If it
-        # reads load_project / load_local, the attacker's PATH would
-        # be in config_env and then is_safe_env_key("PATH") returns
-        # False so it's still not applied — but the security goal is
-        # to never even read the project config in the first place.
-        # We assert both: load_project is NOT called, and PATH stays
-        # unchanged.
-        with mock.patch(
-            "src.config.ConfigManager.load_global", return_value={"env": {}}
-        ) as mock_global, mock.patch(
-            "src.config.ConfigManager.load_project", return_value={"env": attacker_env}
-        ) as mock_project, mock.patch(
-            "src.config.ConfigManager.load_local", return_value={"env": attacker_env}
-        ) as mock_local:
-            apply_safe_config_environment_variables()
-            # PATH unchanged — defense-in-depth from is_safe_env_key.
-            self.assertEqual(os.environ.get("PATH", ""), original_path)
-            # _load_config_env reads only the global source.
-            mock_global.assert_called_once()
-            mock_project.assert_not_called()
-            mock_local.assert_not_called()
-
-
 class TestUnsafeKeySetIsAuditable(unittest.TestCase):
-    """Documented audit guarantees: the explicit unsafe set has
-    every name the chapter / TS reference calls out by name."""
+    """Documented audit guarantees: the explicit unsafe set has every
+    name the chapter / TS reference calls out by name. NB these are
+    PROJECT-TIER exclusions; trusted tiers may set them (the
+    classification is source-relative — caCertsConfig.ts:59-66)."""
 
     def test_chapter_mentioned_keys_are_explicitly_unsafe(self) -> None:
-        # Chapter §"The Trust Boundary": "PATH, LD_PRELOAD, NODE_OPTIONS".
-        # All three must be explicitly enumerated (PATH/NODE_OPTIONS in
-        # the set; LD_PRELOAD via UNSAFE_ENV_PREFIXES).
         self.assertIn("PATH", UNSAFE_ENV_KEYS)
         self.assertIn("NODE_OPTIONS", UNSAFE_ENV_KEYS)
         self.assertIn("LD_", UNSAFE_ENV_PREFIXES)
 
     def test_ts_attack_category_keys_explicitly_unsafe(self) -> None:
-        # TS managedEnvConstants.ts:92-103 comment block enumerates the
-        # explicit "DANGEROUS" categories. Audit that we keep them all.
         for expected in (
             "NODE_EXTRA_CA_CERTS",
             "NODE_TLS_REJECT_UNAUTHORIZED",

--- a/tests/test_trust_wiring_round3.py
+++ b/tests/test_trust_wiring_round3.py
@@ -1,0 +1,252 @@
+"""ch02 round-3 acceptance tests: trust boundary wired end-to-end.
+
+Covers the gap-analysis work items (my-docs/ch02-bootstrap-round3-gap-analysis.md):
+A0 — project config env no longer applies pre-trust (the secret_store
+bypass is closed); A5 — project/local `providers`/`default_provider`
+are stripped from the merged config while untrusted; A3 — trust seeding
+matrix + both-flags sync + the legacy-REPL text gate.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import src.config as config_module
+from src.bootstrap.state import (
+    get_session_trust_accepted,
+    reset_state_for_tests,
+)
+from src.permissions.trust_boundary import (
+    apply_safe_config_environment_variables,
+    establish_session_trust,
+    reset_trust_boundary_for_test_only,
+    _load_project_scoped_env,
+)
+from src.services.startup_gates import (
+    check_trust_accepted,
+    record_trust_accepted,
+    reset_session_trust_for_testing,
+)
+
+
+@pytest.fixture
+def isolated_repo(tmp_path, monkeypatch):
+    """A fake 'clone': global config in one tmp dir, a repo dir whose
+    .claude/config.json is the committable project tier."""
+    global_cfg = tmp_path / "home" / ".clawcodex" / "config.json"
+    repo = tmp_path / "repo"
+    (repo / ".claude").mkdir(parents=True)
+    monkeypatch.setattr(config_module, "GLOBAL_CONFIG_FILE", global_cfg)
+    monkeypatch.setattr(config_module, "_default_manager", None, raising=False)
+    monkeypatch.setattr(config_module, "_find_git_root", lambda *a, **k: repo)
+    return repo
+
+
+def _write_project_config(repo: Path, data: dict) -> None:
+    (repo / ".claude" / "config.json").write_text(json.dumps(data))
+
+
+@pytest.fixture(autouse=True)
+def _reset_trust_state():
+    reset_trust_boundary_for_test_only()
+    reset_state_for_tests()
+    reset_session_trust_for_testing()
+    yield
+    reset_trust_boundary_for_test_only()
+    reset_state_for_tests()
+    reset_session_trust_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# A0 — the env bypass is closed
+# ---------------------------------------------------------------------------
+
+
+def test_a0_project_unsafe_env_gated_on_trust(isolated_repo, monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    _write_project_config(
+        isolated_repo,
+        {"env": {"ANTHROPIC_BASE_URL": "https://project-host.example"}},
+    )
+    reset_trust_boundary_for_test_only()  # snapshot without the key
+
+    # Pre-trust: the safe pass must NOT apply the project tier's
+    # unsafe-class key (this used to leak via secret_store's applier).
+    with mock.patch(
+        "src.permissions.trust_boundary._load_user_settings_env",
+        return_value={},
+    ), mock.patch(
+        "src.permissions.trust_boundary._read_settings_env",
+        return_value={},
+    ):
+        apply_safe_config_environment_variables()
+        assert os.environ.get("ANTHROPIC_BASE_URL") is None
+
+        # Post-trust: the full pass applies it.
+        establish_session_trust()
+        assert (
+            os.environ.get("ANTHROPIC_BASE_URL")
+            == "https://project-host.example"
+        )
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+
+
+def test_a0_project_safe_env_applies_pre_trust(isolated_repo, monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_MODEL", raising=False)
+    _write_project_config(
+        isolated_repo, {"env": {"ANTHROPIC_MODEL": "project-model"}}
+    )
+    reset_trust_boundary_for_test_only()
+    with mock.patch(
+        "src.permissions.trust_boundary._load_user_settings_env",
+        return_value={},
+    ), mock.patch(
+        "src.permissions.trust_boundary._read_settings_env",
+        return_value={},
+    ):
+        apply_safe_config_environment_variables()
+        assert os.environ.get("ANTHROPIC_MODEL") == "project-model"
+    monkeypatch.delenv("ANTHROPIC_MODEL", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# A5 — providers/default_provider strip while untrusted
+# ---------------------------------------------------------------------------
+
+
+def test_a5_project_providers_stripped_until_trusted(isolated_repo):
+    _write_project_config(
+        isolated_repo,
+        {
+            "providers": {
+                "anthropic": {"base_url": "https://project-host.example"}
+            },
+            "default_provider": "project-provider",
+            "session": {"max_history": 7},
+        },
+    )
+    cm = config_module.ConfigManager()
+
+    merged = cm.get_merged()
+    providers = merged.get("providers") or {}
+    assert "anthropic" not in providers or (
+        providers["anthropic"].get("base_url")
+        != "https://project-host.example"
+    )
+    assert merged.get("default_provider") != "project-provider"
+    # Non-sensitive project keys still merge (the strip is surgical).
+    assert merged.get("session", {}).get("max_history") == 7
+
+    # Mid-session trust grant is honored at the next merge.
+    with mock.patch(
+        "src.permissions.trust_boundary.apply_full_config_environment_variables"
+    ):
+        establish_session_trust()
+    merged_after = cm.get_merged()
+    assert (
+        merged_after["providers"]["anthropic"]["base_url"]
+        == "https://project-host.example"
+    )
+    assert merged_after["default_provider"] == "project-provider"
+
+
+# ---------------------------------------------------------------------------
+# A3 — flags sync + gates
+# ---------------------------------------------------------------------------
+
+
+def test_establish_session_trust_syncs_both_flags(isolated_repo):
+    with mock.patch(
+        "src.permissions.trust_boundary.apply_full_config_environment_variables"
+    ) as mock_full:
+        establish_session_trust()
+        establish_session_trust()  # idempotent
+    assert get_session_trust_accepted() is True
+    # check_trust_accepted consults the OTHER flag — the piped-stdout
+    # REPL case must not re-prompt after implicit trust.
+    assert check_trust_accepted() is True
+    assert mock_full.call_count == 2  # re-apply is safe/idempotent
+
+
+def test_record_trust_accepted_grants_session_trust(isolated_repo):
+    record_trust_accepted(cwd=isolated_repo)
+    assert get_session_trust_accepted() is True
+    assert check_trust_accepted(cwd=isolated_repo) is True
+
+
+class TestReplTrustPrompt(unittest.TestCase):
+    """The legacy-REPL text gate (cli._prompt_folder_trust)."""
+
+    def _call(self, answer: str | None):
+        from src import cli
+
+        record = mock.MagicMock(return_value=True)
+        establish = mock.MagicMock()
+        if answer is None:
+            input_patch = mock.patch(
+                "builtins.input", side_effect=EOFError
+            )
+        else:
+            input_patch = mock.patch("builtins.input", return_value=answer)
+        with mock.patch(
+            "src.services.startup_gates.record_trust_accepted", record
+        ), mock.patch(
+            "src.permissions.trust_boundary.establish_session_trust",
+            establish,
+        ), mock.patch(
+            "src.services.startup_gates.collect_trust_warnings",
+            return_value=["example warning"],
+        ), input_patch:
+            result = cli._prompt_folder_trust()
+        return result, record, establish
+
+    def test_accept_records_and_establishes(self) -> None:
+        result, record, establish = self._call("y")
+        self.assertTrue(result)
+        record.assert_called_once()
+        establish.assert_called_once()
+
+    def test_decline_returns_false(self) -> None:
+        result, record, establish = self._call("n")
+        self.assertFalse(result)
+        record.assert_not_called()
+        establish.assert_not_called()
+
+    def test_default_empty_answer_declines(self) -> None:
+        result, _, _ = self._call("")
+        self.assertFalse(result)
+
+    def test_eof_declines(self) -> None:
+        result, _, _ = self._call(None)
+        self.assertFalse(result)
+
+
+# ---------------------------------------------------------------------------
+# Cross-family precedence (plan §1.0): settings beat config within a scope
+# ---------------------------------------------------------------------------
+
+
+def test_project_settings_env_beats_project_config_env(
+    isolated_repo, monkeypatch
+):
+    _write_project_config(
+        isolated_repo, {"env": {"ANTHROPIC_MODEL": "from-project-config"}}
+    )
+    settings_dir = isolated_repo / ".clawcodex"
+    settings_dir.mkdir()
+    (settings_dir / "settings.json").write_text(
+        json.dumps({"env": {"ANTHROPIC_MODEL": "from-project-settings"}})
+    )
+    monkeypatch.chdir(isolated_repo)
+    merged = _load_project_scoped_env(cwd=isolated_repo)
+    assert merged["ANTHROPIC_MODEL"] == "from-project-settings"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Round-3 improvement pass for book chapter 2 (Bootstrap). Fresh gap analysis found that the chapter's central security mechanism — the two-stage config trust boundary — was **bypassed, misported, and unwired** in the port:

- **A0 (the live bypass):** `init.py` copied the *merged* config env (including the committable `<git-root>/.claude/config.json` project tier) into `os.environ` unfiltered, pre-trust, on every entrypoint, via `secret_store.apply_config_env_to_environ`.
- **A1/A2:** the pre-trust pass safe-filtered the wrong axis (the trusted global config) and never read project tiers; the post-trust full pass had zero callers and a global-only loader.
- **A3:** `set_session_trust_accepted(True)` was hard-coded, so the C8 trust gates' outcome fed nothing — and the *default* interactive surface (legacy REPL) had no gate at all.
- **A5 (critic-found):** the `providers`/`default_provider` deep-merge channel let a committable project config redirect API traffic while the user's global `api_key` stayed attached — unreachable by env-gating.

### Changes
- `permissions/trust_boundary.py` rewritten as the **sole env-writer** on the TS source-class model (`managedEnv.ts:106-186`): trusted tiers full pre-trust; project tiers SAFE-subset (uppercase membership) until trust; MDM policy tier unfiltered, last, shell-overriding. Documented shell-wins customization (TS CCD spawn-env-keys pattern, always-on).
- Trust wiring: implicit trust + full apply for non-interactive (TS `main.tsx:1955-1967`); seeding from persisted per-folder acceptance; TUI accept applies full env (`interactiveHelpers.tsx:150+194` pairing); **new legacy-REPL text trust gate** (C8-consistent hardening, stricter than TS — documented). Both session-trust flags synced (`grant_session_trust`), fixing the piped-stdout double-gate.
- `get_merged()` strips `env`/`providers`/`default_provider` from project/local config tiers while untrusted (merge-time check; mid-session grants honored). `get_secret` fallback rescoped to the global tier.

### Known limits (documented in-code + gap analysis)
- TUI one-launch client lag (client built before gates; rebuild = ch04 follow-up).
- Fast paths (`config`/`login`) see the stripped merged view even in trusted dirs (fail-safe, display-only).
- Config-tool write-back laundering deferred to ch15/ch16.

Gap analysis: `my-docs/ch02-bootstrap-round3-gap-analysis.md`; plan: `my-docs/python-port-improvement-round-3/ch02-bootstrap-round3-plan.md` (local, gitignored). Three critic review cycles; plan + gap analysis APPROVE; implementation review resolved all code-level items (snapshot-poisoning trace, strip-layer correctness, TUI provider-build ordering, hermetic tests, both grep DoDs).

## Test plan
- [x] New `tests/test_trust_wiring_round3.py`: A0 regression (project env gated → applied on trust), A5 strip + mid-session restore, both-flags sync + idempotency, REPL prompt accept/decline/EOF/empty, cross-family precedence
- [x] Reworked `test_trust_boundary.py` (hermetic tier loaders; trusted-tier-full; project safe-subset incl. lowercase; shell-wins incl. empty-string pin; MDM tier incl. full-pass re-assert), `test_secret_store.py`, `test_init*.py`
- [x] Full suite: 7,805 passed; the 9 failures are the pre-existing environment set documented in PR #321 (verified identical via stash on clean main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)