### PR TITLE
ch02/round3: wire the deferred context-prefetch lane (GAP B)

### DIFF
--- a/scripts/audit/setup.py
+++ b/scripts/audit/setup.py
@@ -5,13 +5,43 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from src.deferred_init import DeferredInitResult, run_deferred_init
 from src.prefetch import (
     PrefetchResult,
     get_or_start_keychain_prefetch,
     get_or_start_mdm_raw_read,
     start_project_scan,
 )
+
+
+# ch02 round-3: relocated from src/deferred_init.py — this flags
+# snapshot is audit-manifest scaffolding; the production module now
+# implements the real deferred-prefetch lane (start_deferred_prefetches).
+@dataclass(frozen=True)
+class DeferredInitResult:
+    trusted: bool
+    plugin_init: bool
+    skill_init: bool
+    mcp_prefetch: bool
+    session_hooks: bool
+
+    def as_lines(self) -> tuple[str, ...]:
+        return (
+            f'- plugin_init={self.plugin_init}',
+            f'- skill_init={self.skill_init}',
+            f'- mcp_prefetch={self.mcp_prefetch}',
+            f'- session_hooks={self.session_hooks}',
+        )
+
+
+def run_deferred_init(trusted: bool) -> DeferredInitResult:
+    enabled = bool(trusted)
+    return DeferredInitResult(
+        trusted=trusted,
+        plugin_init=enabled,
+        skill_init=enabled,
+        mcp_prefetch=enabled,
+        session_hooks=enabled,
+    )
 
 
 @dataclass(frozen=True)

--- a/src/cli.py
+++ b/src/cli.py
@@ -627,6 +627,15 @@ def start_repl(
     the in-process tool registry will short-circuit permission checks
     for the user (when ``--dangerously-skip-permissions`` is set).
     """
+    # ch02 round-3 GAP B: warm the context memos while the (heavy)
+    # src.repl import and REPL constructor run and the user types the
+    # first prompt. The dispatch-level trust gate already ran, so the
+    # system-context lane self-gates correctly. Mirrors TS
+    # startDeferredPrefetches (main.tsx:392-439) post-render kick.
+    from src.deferred_init import start_deferred_prefetches
+
+    start_deferred_prefetches()
+
     from src.config import get_default_provider
     from src.repl import ClawcodexREPL
 

--- a/src/context_system/claude_md.py
+++ b/src/context_system/claude_md.py
@@ -39,8 +39,12 @@ logger = logging.getLogger(__name__)
 # Module-level memoize cache for get_memory_files
 # ---------------------------------------------------------------------------
 
-_memory_files_cache: list[MemoryFileInfo] | None = None
-_memory_files_cache_key: str | None = None
+# (key, files) as ONE atomic reference — the deferred-prefetch lane
+# (ch02 round-3) made this cache cross-thread; two separate globals
+# could tear (reader matches an old key against new-key data). A single
+# tuple assignment is GIL-atomic: readers snapshot one reference and
+# check its own key.
+_memory_files_cache: tuple[str, list[MemoryFileInfo]] | None = None
 # Per-cwd memo of the C8 external-includes approval. The lookup behind
 # it shells out (git rev-parse) and reads the global config — far too
 # heavy per get_memory_files call. record_external_includes_choice
@@ -50,9 +54,8 @@ _external_includes_approval_cache: dict[str, bool] = {}
 
 def clear_memory_file_caches() -> None:
     """Clear the memoized memory files cache (call after compact)."""
-    global _memory_files_cache, _memory_files_cache_key
+    global _memory_files_cache
     _memory_files_cache = None
-    _memory_files_cache_key = None
     _external_includes_approval_cache.clear()
 
 
@@ -393,7 +396,7 @@ async def get_memory_files(
 
     Results are cached; call clear_memory_file_caches() to invalidate.
     """
-    global _memory_files_cache, _memory_files_cache_key
+    global _memory_files_cache
 
     original_cwd = cwd or _get_original_cwd()
     # TS claudemd.ts:812-815: externals load when forced (the gate's
@@ -406,8 +409,9 @@ async def get_memory_files(
     )
     cache_key = f"{original_cwd}:{include_external}"
 
-    if _memory_files_cache is not None and _memory_files_cache_key == cache_key:
-        return list(_memory_files_cache)
+    cached = _memory_files_cache  # one-reference snapshot (thread-safe)
+    if cached is not None and cached[0] == cache_key:
+        return list(cached[1])
 
     result: list[MemoryFileInfo] = []
     processed_paths: set[str] = set()
@@ -490,8 +494,7 @@ async def get_memory_files(
             conditional_rule=False,
         ))
 
-    _memory_files_cache = result
-    _memory_files_cache_key = cache_key
+    _memory_files_cache = (cache_key, result)
 
     return list(result)
 

--- a/src/deferred_init.py
+++ b/src/deferred_init.py
@@ -1,31 +1,128 @@
+"""Deferred post-render prefetches — chapter 2 §"Post-render deferred
+prefetches" (ch02 round-3 GAP B).
+
+Mirrors the minimal core of TS ``startDeferredPrefetches``
+(main.tsx:392-439) and the non-interactive early kicks
+(main.tsx:1973-1990): warm the memoized user context (CLAUDE.md walk)
+and — when the session is trusted — the system context (git status
+probes) so the first turn's ``fetch_system_prompt_parts`` hits warm
+caches instead of paying the cold filesystem/subprocess cost inside the
+user's first request.
+
+Trust gating mirrors TS ``prefetchSystemContextIfSafe``: system context
+(git subprocess execution in the workspace) only runs when
+``bootstrap.state.get_session_trust_accepted()`` is True. Post ch02
+round-3 PR-1 that flag covers both TS conditions (explicit trust OR
+non-interactive implicit trust). Deliberately NOT gated on
+``ToolContext.workspace_trusted`` — that field has no production
+setters yet (ch12 follow-up).
+
+Two execution modes, because the port's entrypoints split by loop
+ownership:
+
+* **Running asyncio loop** (Textual TUI): tasks are scheduled on it.
+* **No loop** (headless / legacy REPL, which call ``asyncio.run`` per
+  query): a daemon thread drives its own short-lived loop. The memo
+  caches in ``context_system.prompt_assembly`` are plain module-level
+  dict assignments — atomic under the GIL; a race with the first query
+  recomputes the same value at worst (same tolerance TS accepts for its
+  fire-and-forget ``void`` kicks).
+
+Failures never propagate: prefetching is purely advisory.
+"""
+
 from __future__ import annotations
 
-from dataclasses import dataclass
+import asyncio
+import logging
+import threading
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
-class DeferredInitResult:
-    trusted: bool
-    plugin_init: bool
-    skill_init: bool
-    mcp_prefetch: bool
-    session_hooks: bool
+@dataclass
+class DeferredPrefetchHandle:
+    """Handle for tests/observability. ``join()`` blocks until the
+    thread-mode warmup finishes; ``tasks`` carries loop-mode tasks."""
 
-    def as_lines(self) -> tuple[str, ...]:
-        return (
-            f'- plugin_init={self.plugin_init}',
-            f'- skill_init={self.skill_init}',
-            f'- mcp_prefetch={self.mcp_prefetch}',
-            f'- session_hooks={self.session_hooks}',
+    mode: str  # "loop" | "thread" | "noop"
+    tasks: list[asyncio.Task] = field(default_factory=list)
+    thread: threading.Thread | None = None
+
+    def join(self, timeout: float | None = 5.0) -> None:
+        if self.thread is not None:
+            self.thread.join(timeout=timeout)
+
+
+def _system_context_allowed() -> bool:
+    try:
+        from src.bootstrap.state import get_session_trust_accepted
+
+        return get_session_trust_accepted()
+    except Exception:
+        return False
+
+
+async def _warm(cwd: str | None, include_system_context: bool) -> None:
+    # The whole body is guarded: in loop mode a failure outside the
+    # gather (e.g. the import) would otherwise surface as an unretrieved
+    # task exception — prefetching is advisory and must never propagate.
+    try:
+        from src.context_system.prompt_assembly import (
+            get_system_context,
+            get_user_context,
         )
 
+        coros = [get_user_context(cwd)]
+        if include_system_context:
+            coros.append(get_system_context(cwd))
+        results = await asyncio.gather(*coros, return_exceptions=True)
+        for result in results:
+            if isinstance(result, Exception):
+                logger.debug("deferred prefetch lane failed: %r", result)
+    except Exception as exc:
+        logger.debug("deferred prefetch failed: %r", exc)
 
-def run_deferred_init(trusted: bool) -> DeferredInitResult:
-    enabled = bool(trusted)
-    return DeferredInitResult(
-        trusted=trusted,
-        plugin_init=enabled,
-        skill_init=enabled,
-        mcp_prefetch=enabled,
-        session_hooks=enabled,
+
+def start_deferred_prefetches(
+    cwd: str | None = None,
+    *,
+    include_system_context: bool | None = None,
+) -> DeferredPrefetchHandle:
+    """Fire-and-forget warmup of the per-session context memos.
+
+    ``include_system_context=None`` resolves the trust gate itself
+    (TS ``prefetchSystemContextIfSafe``); pass ``True`` from a
+    just-accepted trust gate (TS ``interactiveHelpers.tsx:159`` kicks
+    ``getSystemContext`` right after trust is established).
+
+    Idempotent: the underlying context functions are memoized, so
+    re-kicking (e.g. once at mount, again after the trust gate) only
+    fills lanes that are still cold.
+    """
+    if include_system_context is None:
+        include_system_context = _system_context_allowed()
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is not None:
+        task = loop.create_task(_warm(cwd, include_system_context))
+        return DeferredPrefetchHandle(mode="loop", tasks=[task])
+
+    def _run_in_thread() -> None:
+        try:
+            asyncio.run(_warm(cwd, include_system_context))
+        except Exception as exc:
+            logger.debug("deferred prefetch thread failed: %r", exc)
+
+    thread = threading.Thread(
+        target=_run_in_thread,
+        name="clawcodex-deferred-prefetch",
+        daemon=True,
     )
+    thread.start()
+    return DeferredPrefetchHandle(mode="thread", thread=thread)

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -122,6 +122,19 @@ def run_headless(options: HeadlessOptions) -> int:
     stderr = options.stderr or sys.stderr
     stdin = options.stdin or sys.stdin
 
+    # ch02 round-3 GAP B: warm the user/system context memos now so the
+    # CLAUDE.md walk and git probes overlap with provider + registry
+    # construction below instead of running inside the first turn.
+    # Mirrors TS main.tsx:1973-1990 (non-interactive early kicks; trust
+    # is implicit in -p mode and was granted by run_pre_action).
+    # MUST use the resolved workspace_root, not the process cwd — the
+    # memos are key-less and first-writer pins the content the query
+    # path (which passes workspace_root) will read.
+    workspace_root = options.workspace_root or Path.cwd()
+    from src.deferred_init import start_deferred_prefetches
+
+    start_deferred_prefetches(cwd=str(workspace_root))
+
     provider_name = options.provider_name or get_default_provider()
     try:
         provider_cfg = get_provider_config(provider_name)
@@ -152,7 +165,7 @@ def run_headless(options: HeadlessOptions) -> int:
         deny = {name.lower() for name in options.disallowed_tools}
         _filter_registry(tool_registry, keep=lambda n: n.lower() not in deny)
 
-    workspace_root = options.workspace_root or Path.cwd()
+    # (workspace_root already resolved above, before the prefetch kick.)
 
     # Compute the effective permission context. ``skip_permissions=True`` is
     # the legacy alias and means "user passed --dangerously-skip-permissions";

--- a/src/permissions/trust_boundary.py
+++ b/src/permissions/trust_boundary.py
@@ -329,7 +329,7 @@ def _load_project_scoped_env(cwd: str | Path | None = None) -> dict[str, str]:
     cwd_str = str(cwd) if cwd is not None else None
     merged: dict[str, str] = {}
 
-    cm = config_mod.ConfigManager()
+    cm = config_mod.ConfigManager(cwd=cwd)
     merged.update(_coerce_env_block(cm.load_project().get("env")))          # S3
     merged.update(
         _read_settings_env(settings_paths.project_settings_path(cwd_str))   # S4

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -14,6 +14,7 @@ screen then materialises as a modal.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -21,6 +22,8 @@ if TYPE_CHECKING:
     from src.services.bash_mode import BashModeOutcome
 
 from textual.app import App
+
+logger = logging.getLogger(__name__)
 
 from src import __version__ as CLAW_VERSION
 from src.agent import Session
@@ -222,6 +225,19 @@ class ClawCodexTUI(App):
         except Exception:
             pass
         self._state_unsub = self.app_state.subscribe(self._on_state_change)
+        # ch02 round-3 GAP B: post-render context warmup (TS
+        # startDeferredPrefetches, main.tsx:392-439). The system-context
+        # lane self-gates on session trust — already seeded by
+        # run_pre_action for previously-trusted folders; untrusted
+        # sessions warm only the user-context lane here and the
+        # system-context lane re-kicks after the trust gate accepts
+        # (_finish_startup_gates, TS interactiveHelpers.tsx:159).
+        try:
+            from src.deferred_init import start_deferred_prefetches
+
+            start_deferred_prefetches(cwd=str(self.workspace_root))
+        except Exception:
+            pass
         # C8 → C6 → C7 boot chain, strictly sequential: the security
         # gates (trust → external includes → bypass acceptance; TS
         # interactiveHelpers order) must resolve BEFORE the .mcp.json
@@ -282,7 +298,12 @@ class ClawCodexTUI(App):
 
             establish_session_trust()
         except Exception:
-            pass
+            # Loaders are tolerant so this is unlikely; silent partial
+            # state after an accepted dialog deserves at least a log.
+            logger.warning(
+                "trust accepted but full env application failed",
+                exc_info=True,
+            )
         if not persisted and self._repl_screen is not None:
             self._repl_screen.transcript.append_system(
                 "Folder trusted for this session only — could not write "
@@ -407,6 +428,22 @@ class ClawCodexTUI(App):
         self.exit(return_code=1 if choice == "decline" else 0)
 
     def _finish_startup_gates(self) -> None:
+        # ch02 round-3 GAP B: the gates are resolved — if the session is
+        # now trusted (pre-seeded or just accepted), warm the
+        # system-context lane that the on_mount kick had to skip while
+        # untrusted (TS interactiveHelpers.tsx:159 post-trust
+        # getSystemContext kick). Memoized → no-op when already warm.
+        try:
+            from src.bootstrap.state import get_session_trust_accepted
+            from src.deferred_init import start_deferred_prefetches
+
+            if get_session_trust_accepted():
+                start_deferred_prefetches(
+                    cwd=str(self.workspace_root),
+                    include_system_context=True,
+                )
+        except Exception:
+            pass
         # C6: surface ignored/malformed config files as startup rows
         # (TS StatusNotices / InvalidSettingsDialog family — Python's
         # loader silently falls back to {}, so warn honestly instead).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,8 +57,20 @@ def _isolate_user_permission_settings(tmp_path, monkeypatch):
     # assertions.
     import src.config as config_mod
 
+    # The isolated dir mirrors the prod layout (~/.clawcodex) so tests
+    # asserting on the path shape (test_config_path_is_in_home) hold.
+    _isolated_global_dir = tmp_path / "isolated-home" / ".clawcodex"
+    monkeypatch.setattr(config_mod, "GLOBAL_CONFIG_DIR", _isolated_global_dir)
+    # ch02 round-3: GLOBAL_CONFIG_FILE is read independently of the DIR
+    # constant (get_global_config_path) — isolate it too so the tier
+    # loaders (_load_global_config_env, get_secret's global fallback)
+    # never read the developer's real ~/.clawcodex/config.json. Before
+    # this, only the DIR was patched and FILE silently kept pointing at
+    # the developer's real config (critic nit 4 on PR #322).
     monkeypatch.setattr(
-        config_mod, "GLOBAL_CONFIG_DIR", tmp_path / "isolated-global"
+        config_mod,
+        "GLOBAL_CONFIG_FILE",
+        _isolated_global_dir / "config.json",
     )
     # C8: skip the startup security gates (trust / external includes /
     # bypass acceptance) in full-app tests — every app test would

--- a/tests/test_deferred_prefetch.py
+++ b/tests/test_deferred_prefetch.py
@@ -1,0 +1,133 @@
+"""ch02 round-3 GAP B: deferred context prefetch lane.
+
+The lane warms the memoized user/system context
+(``context_system.prompt_assembly``) so the first turn's
+``fetch_system_prompt_parts`` hits warm caches. System context is
+trust-gated via ``bootstrap.state.get_session_trust_accepted`` (TS
+``prefetchSystemContextIfSafe``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest import mock
+
+import pytest
+
+import src.context_system.prompt_assembly as pa
+from src.bootstrap.state import (
+    reset_state_for_tests,
+    set_session_trust_accepted,
+)
+from src.deferred_init import start_deferred_prefetches
+
+
+@pytest.fixture(autouse=True)
+def _clean_context_state():
+    pa.clear_context_caches()
+    reset_state_for_tests()
+    yield
+    pa.clear_context_caches()
+    reset_state_for_tests()
+
+
+def _user_cache_warm() -> bool:
+    return pa._user_context_cache is not None
+
+
+def _system_cache_warm() -> bool:
+    return pa._system_context_cache is not None
+
+
+def test_thread_mode_warms_user_context_untrusted(tmp_path):
+    handle = start_deferred_prefetches(cwd=str(tmp_path))
+    assert handle.mode == "thread"
+    handle.join()
+    assert _user_cache_warm()
+    # Untrusted session: the git-probe lane must not have run.
+    assert not _system_cache_warm()
+
+
+def test_thread_mode_warms_both_when_trusted(tmp_path):
+    set_session_trust_accepted(True)
+    handle = start_deferred_prefetches(cwd=str(tmp_path))
+    handle.join()
+    assert _user_cache_warm()
+    assert _system_cache_warm()
+
+
+def test_explicit_include_system_context_overrides_gate(tmp_path):
+    # The post-trust-gate re-kick passes True explicitly (the caller just
+    # established trust; the flag read would also succeed, but the
+    # explicit form documents intent at the call site).
+    handle = start_deferred_prefetches(
+        cwd=str(tmp_path), include_system_context=True
+    )
+    handle.join()
+    assert _system_cache_warm()
+
+
+def test_loop_mode_schedules_tasks(tmp_path):
+    async def scenario():
+        handle = start_deferred_prefetches(cwd=str(tmp_path))
+        assert handle.mode == "loop"
+        assert handle.tasks
+        await asyncio.gather(*handle.tasks)
+
+    asyncio.run(scenario())
+    assert _user_cache_warm()
+
+
+def test_rekick_is_idempotent(tmp_path):
+    handle1 = start_deferred_prefetches(cwd=str(tmp_path))
+    handle1.join()
+    sentinel = pa._user_context_cache
+    handle2 = start_deferred_prefetches(
+        cwd=str(tmp_path), include_system_context=True
+    )
+    handle2.join()
+    # Memoized: the user-context lane did not recompute.
+    assert pa._user_context_cache is sentinel
+    assert _system_cache_warm()
+
+
+def test_prefetch_failure_never_propagates(tmp_path):
+    with mock.patch(
+        "src.context_system.prompt_assembly.get_user_context",
+        side_effect=RuntimeError("boom"),
+    ):
+        handle = start_deferred_prefetches(cwd=str(tmp_path))
+        handle.join()  # must not raise
+
+
+class TestEntrypointWiring(unittest.TestCase):
+    def test_headless_kicks_prefetch_before_provider_load(self) -> None:
+        from src.entrypoints import headless
+
+        options = headless.HeadlessOptions(prompt="hi")
+        with mock.patch(
+            "src.deferred_init.start_deferred_prefetches"
+        ) as kick, mock.patch.object(
+            headless, "get_default_provider", side_effect=SystemExit(2)
+        ):
+            # SystemExit right after the kick point keeps the test cheap.
+            with self.assertRaises(SystemExit):
+                headless.run_headless(options)
+            kick.assert_called_once()
+
+    def test_start_repl_kicks_prefetch(self) -> None:
+        from src import cli
+
+        with mock.patch(
+            "src.deferred_init.start_deferred_prefetches"
+        ) as kick, mock.patch(
+            "src.config.get_default_provider", side_effect=SystemExit(2)
+        ):
+            with self.assertRaises(SystemExit):
+                cli.start_repl()
+            kick.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR-2 of the ch02 (bootstrap) round-3 iteration — closes GAP B from `my-docs/ch02-bootstrap-round3-gap-analysis.md` (PR-1 was #322).

- `run_deferred_init()` was dead code; every session paid the CLAUDE.md walk + git probes cold inside the first turn. `src/deferred_init.py` is now the real lane (`start_deferred_prefetches`), mirroring TS `startDeferredPrefetches` (main.tsx:392-439) and the non-interactive early kicks (:1973-1990); the audit-only flags stub moved to its sole consumer, `scripts/audit/setup.py`.
- System-context lane (git subprocesses) gates on `get_session_trust_accepted` (TS `prefetchSystemContextIfSafe`) — meaningful since #322; deliberately not the setter-less `workspace_trusted` (ch12 follow-up).
- Loop mode (TUI `create_task` at mount + post-trust-gate re-kick, TS interactiveHelpers.tsx:159) and thread mode (headless/legacy-REPL, which `asyncio.run` per query).
- Cross-thread hardening: the `claude_md` memo collapsed to one atomic `(key, files)` tuple (two globals could tear against the new prefetch thread).
- Critic catch: headless kick must use the resolved `workspace_root`, not the process cwd — the key-less memos pin first-writer content.
- Carries #322's approved-with-nits items: `ConfigManager(cwd=cwd)` coherence, TUI logs failed env application on trust accept, conftest isolates `GLOBAL_CONFIG_FILE` (exposed + fixed a latent dev-config test leak; `HISTORY_FILE` is the named same-class follow-up).

Critic: REVISE (1 major, 3 minors) → all applied → **APPROVE**.

## Test plan
- [x] New `tests/test_deferred_prefetch.py`: thread/loop modes, trust gating, explicit override, idempotent re-kick (memo identity), failure tolerance, headless + start_repl wiring
- [x] Affected suites (claude_md / context_system / headless / trust wiring): green
- [x] Full suite: 7,813 passed; the 9 failures are the documented pre-existing environment set (PR #321), verified identical via --lf collect

🤖 Generated with [Claude Code](https://claude.com/claude-code)