### PR TITLE
ch03/round3: state persistence end-to-end + git lock flag + CLAUDE.md cache producer

### DIFF
--- a/src/bootstrap/state.py
+++ b/src/bootstrap/state.py
@@ -1088,7 +1088,7 @@ def reset_state_for_tests() -> None:
 
     Gated by the ``PYTEST_CURRENT_TEST`` environment variable, which pytest
     sets during test execution. Production calls raise ``RuntimeError``.
-    Mirrors TS ``resetStateForTests`` (``bootstrap/state.ts:993``).
+    Mirrors TS ``resetStateForTests`` (``bootstrap/state.ts:951``).
 
     Resets:
       * the ``_STATE`` dataclass singleton (all dataclass fields zero out)

--- a/src/context_system/git_context.py
+++ b/src/context_system/git_context.py
@@ -151,10 +151,14 @@ async def collect_git_context(
         None, _get_default_branch, target,
     )
     status_fut = loop.run_in_executor(
-        None, _git_cmd, ["status", "--short"], target,
+        # --no-optional-locks: don't take index write locks for the
+        # status probe — a concurrent `git` in the user's other terminal
+        # must never block on ours (TS context.ts:63-72; the flag rides
+        # only status + log there — TS-exact, ch03 round-3 G2).
+        None, _git_cmd, ["--no-optional-locks", "status", "--short"], target,
     )
     commits_fut = loop.run_in_executor(
-        None, _git_cmd, ["log", "--oneline", "-n", "5"], target,
+        None, _git_cmd, ["--no-optional-locks", "log", "--oneline", "-n", "5"], target,
     )
     user_fut = loop.run_in_executor(
         None, _git_cmd, ["config", "user.name"], target,

--- a/src/context_system/prompt_assembly.py
+++ b/src/context_system/prompt_assembly.py
@@ -84,6 +84,7 @@ async def get_user_context(
     context["currentDate"] = _get_session_start_date_iso()
 
     # CLAUDE.md content (skip in --bare mode unless --add-dir used)
+    claude_md_content = ""
     if not _should_disable_claude_md():
         try:
             memory_files = await get_memory_files(cwd=cwd)
@@ -92,6 +93,18 @@ async def get_user_context(
                 context["claudeMd"] = claude_md_content
         except Exception:
             pass
+
+    # Cache CLAUDE.md into the bootstrap singleton (TS context.ts:173-176):
+    # the DAG-leaf cache exists to break the classifier→filesystem→
+    # permissions→classifier import cycle. The TS consumer (yoloClassifier,
+    # the auto-mode transcript classifier) is unported — this is forward
+    # provisioning so the cache is real when ch06/ch12 land the consumer.
+    try:
+        from ..bootstrap.state import set_cached_claude_md_content
+
+        set_cached_claude_md_content(claude_md_content or None)
+    except Exception:
+        pass
 
     _user_context_cache = context
     return dict(context)

--- a/src/entrypoints/tui.py
+++ b/src/entrypoints/tui.py
@@ -96,6 +96,14 @@ def run_tui(options: TUIOptions) -> int:
             base_url=provider_cfg.get("base_url"),
             model=model,
         )
+        # ch03 round-3 G1 read-side: a persisted /model choice survives
+        # restart — but override-first precedence (TS model.ts:109-135):
+        # an explicit options.model wins, and the provider_factory branch
+        # above is skipped entirely (the factory chose its model).
+        if options.model is None:
+            from src.settings.settings import apply_persisted_model
+
+            apply_persisted_model(provider, provider_name)
 
     # Build tool registry + context --------------------------------------
     from src.tool_system.context import ToolContext

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -423,6 +423,15 @@ class ClawcodexREPL:
             base_url=config.get("base_url"),
             model=config.get("default_model")
         )
+        # ch03 round-3 G1 read-side: persisted /model survives restart.
+        # No explicit model parameter exists on this path, so the call is
+        # unconditional; the (model, provider) pair guard inside ignores
+        # cross-provider stale values. NB the mid-session provider-reinit
+        # flow rebuilds with default_model and deliberately does NOT
+        # re-apply the pair — restart-scoped parity is the boundary.
+        from src.settings.settings import apply_persisted_model
+
+        apply_persisted_model(self.provider, provider_name)
 
         # Create session
         self.session = Session.create(
@@ -1099,11 +1108,22 @@ class ClawcodexREPL:
 
         # Reactive AppState store backing interactive commands like
         # /permissions; held on self so the chosen mode persists for the
-        # REPL session.
-        from src.state.app_state import create_app_state_store
+        # REPL session. ch03 round-3 G1: seeded from persisted settings
+        # (model gated on the active provider) + the LIVE provider-name
+        # supplier so /model persistence records the provider that is
+        # active AT WRITE TIME (the provider-reinit flow reassigns
+        # self.provider_name mid-session — a captured string would
+        # poison the (model, provider) pair guard).
+        from src.state.app_state import (
+            create_app_state_store,
+            set_active_provider_supplier,
+        )
         from src.repl.ui_host import ReplUIHost
 
-        self.app_state_store = create_app_state_store()
+        self.app_state_store = create_app_state_store(
+            active_provider=self.provider_name
+        )
+        set_active_provider_supplier(lambda: self.provider_name)
 
         # Create command context
         self.command_context = create_command_context(

--- a/src/services/cost_restore.py
+++ b/src/services/cost_restore.py
@@ -45,11 +45,10 @@ def restore_cost_state_for_session(session_id: SessionId | str) -> bool:
     can call restore-then-switch or switch-then-restore.
 
     The on-disk location is ``~/.clawcodex/sessions/<sid>.json`` —
-    the same place ``Session.save`` writes. Today the Python
-    ``Session.save`` does NOT persist a ``cost`` block — this function
-    reads whatever cost fields are present and tolerates missing ones,
-    so it works correctly once persistence catches up (Phase-2.4
-    follow-up).
+    the same place ``Session.save`` writes. ``Session.save`` persists a
+    ``cost`` block since ch03 round-2 R2.1 (``agent/session.py:50-73``);
+    the missing-field tolerance below remains for snapshots written by
+    pre-R2.1 builds.
     """
     target = str(session_id)
     session_file = _sessions_dir() / f"{target}.json"

--- a/src/settings/settings.py
+++ b/src/settings/settings.py
@@ -65,3 +65,29 @@ def get_settings(
     if _settings_cache is None:
         _settings_cache = load_settings(config_manager=config_manager, cwd=cwd)
     return _settings_cache
+
+
+def apply_persisted_model(provider: Any, provider_name: str) -> bool:
+    """Apply the persisted ``(model, model_provider)`` pair to a provider.
+
+    The effective read-side of the ch03 round-3 model persistence: the
+    port's live model channel is ``provider.model``, so a persisted
+    `/model` choice must reach the constructed provider to survive a
+    restart. Mirrors ``getUserSpecifiedModelSetting``
+    (TS ``utils/model/model.ts:109-135``) including its provider-match
+    guard — a model persisted under another provider is ignored (the
+    cross-provider staleness failure documented there). Callers gate on
+    explicit overrides: an explicit ``--model``-style choice made at
+    construction wins (override-first precedence), so call this only when
+    no explicit model was supplied.
+
+    Returns True iff the persisted model was applied.
+    """
+    try:
+        s = get_settings()
+    except Exception:
+        return False
+    if s.model and s.model_provider == provider_name:
+        provider.model = s.model
+        return True
+    return False

--- a/src/settings/types.py
+++ b/src/settings/types.py
@@ -68,6 +68,17 @@ class SettingsSchema:
 
     # Model
     model: str = ""
+    # Provider key that ``model`` was chosen under (ch03 round-3 G1).
+    # Multi-provider port: a persisted model is meaningful only with the
+    # provider that served it — TS utils/model/model.ts:109-135 documents
+    # the cross-provider staleness failure (a stale settings.model kept
+    # firing at the wrong endpoint and 400ing after a provider switch).
+    # Same pairing rationale as advisor_model/advisor_provider below.
+    # Read-side guard: the persisted model applies ONLY when this matches
+    # the session's active provider. Distinct from ``provider`` (the
+    # active-provider selection) — reusing that key would make the guard
+    # vacuous and let /model mutate provider selection.
+    model_provider: str = ""
     small_fast_model: str = ""
     # Advisor — reviewer tool. Empty string = unset (no /advisor).
     # Persisted analogue of TS appState.advisorModel; the /advisor slash

--- a/src/state/app_state.py
+++ b/src/state/app_state.py
@@ -134,18 +134,64 @@ def get_default_app_state() -> AppState:
 # ---------------------------------------------------------------------------
 
 
+# Active-provider supplier slot (ch03 round-3 G1). Pattern matches the
+# listener slots below: entrypoints register a LIVE attribute read
+# (``lambda: self.provider_name``) so a mid-session provider reinit
+# (repl/core.py provider-switch flow) is reflected at persist time —
+# a captured string would persist /model choices under a stale provider
+# and defeat the (model, provider) pair guard.
+_active_provider_supplier: Callable[[], str | None] | None = None
+
+
+def set_active_provider_supplier(
+    cb: Callable[[], str | None] | None,
+) -> None:
+    global _active_provider_supplier
+    _active_provider_supplier = cb
+
+
+def _active_provider_name() -> str:
+    if _active_provider_supplier is None:
+        return ""
+    try:
+        return _active_provider_supplier() or ""
+    except Exception:
+        return ""
+
+
+def _persist_settings_keys(**keys: Any) -> None:
+    """Write keys into the global config's ``settings`` sub-key.
+
+    The advisor write idiom (shared default ConfigManager → save_global →
+    invalidate_settings_cache) hoisted for reuse by the model handler.
+    Raises on failure — CALLERS swallow and log, so the in-memory change
+    still works for the current process.
+    """
+    from src import config as cfg_mod
+    from src.settings.settings import invalidate_settings_cache
+
+    mgr = cfg_mod._get_default_manager()
+    cfg = mgr.load_global()
+    settings_section = cfg.get("settings")
+    if not isinstance(settings_section, dict):
+        settings_section = {}
+    settings_section.update(keys)
+    cfg["settings"] = settings_section
+    mgr.save_global(cfg)
+    invalidate_settings_cache()
+
+
 def _on_main_loop_model_change(old: AppState, new: AppState) -> None:
-    """Mirror model choice into bootstrap singleton.
+    """Mirror model choice into bootstrap + persist the (model, provider)
+    pair to settings.
 
-    Matches TS at ``onChangeAppState.ts:97-120`` — when the user changes
-    the model (via /model slash command or the model picker), the
-    bootstrap-state override must update so the next API call reads the
-    new value, and settings persistence happens as a side effect.
-
-    Settings persistence is currently no-op — the settings.json layering
-    lives in ``src.settings`` and the writer is not yet wired through
-    a single chokepoint. Plan §P2.1 left this stub here as the wiring
-    target.
+    Matches TS at ``onChangeAppState.ts:97-120`` (persist to user settings
+    + ``setMainLoopModelOverride``; TS also syncs the active provider
+    profile at ``:117-119`` — provider-profile sync is ch04 client
+    territory here). Unset convention: ``None`` model writes ``""`` for
+    BOTH keys — idiom consistency with the advisor handlers (NOT TS's
+    ``model: undefined`` key-removal; read-equivalent through the
+    defaults merge in ``load_settings``).
     """
     if old.main_loop_model == new.main_loop_model:
         return
@@ -155,18 +201,65 @@ def _on_main_loop_model_change(old: AppState, new: AppState) -> None:
         old.main_loop_model,
         new.main_loop_model,
     )
-    # TODO: persist to user settings via ``src.settings`` once the
-    # writer-side has a single chokepoint.
+    try:
+        _persist_settings_keys(
+            model=new.main_loop_model or "",
+            model_provider=(
+                _active_provider_name() if new.main_loop_model else ""
+            ),
+        )
+    except Exception:
+        logger.exception(
+            "Failed to persist model to settings; in-memory value still active"
+        )
+
+
+def _persist_config_keys(**keys: Any) -> None:
+    """Write top-level global-config keys (TS global config, not settings)."""
+    from src import config as cfg_mod
+
+    mgr = cfg_mod._get_default_manager()
+    cfg = mgr.load_global()
+    cfg.update(keys)
+    mgr.save_global(cfg)
 
 
 def _on_verbose_change(old: AppState, new: AppState) -> None:
+    """Persist ``verbose`` to the global config top level (TS
+    ``onChangeAppState.ts:144-148`` — config, not settings)."""
     if old.verbose == new.verbose:
         return
     logger.debug("AppState.verbose %s -> %s", old.verbose, new.verbose)
-    # TODO: persist to global config.
+    try:
+        _persist_config_keys(verbose=bool(new.verbose))
+    except Exception:
+        logger.exception("Failed to persist verbose to global config")
+
+
+# expanded_view domain is 'none' | 'tasks' | 'teammates' (AppStateStore.ts:96).
+# On-disk form is TS's legacy boolean pair; read-back priority is TS-exact
+# (main.tsx:2932): showSpinnerTree ? 'teammates' : showExpandedTodos ?
+# 'tasks' : 'none' — a (True, True) disk state reads as 'teammates'.
+_EXPANDED_VIEW_TO_BOOLS: dict[str, tuple[bool, bool]] = {
+    "none": (False, False),
+    "tasks": (True, False),
+    "teammates": (False, True),
+}
+
+
+def expanded_view_from_config_bools(
+    show_expanded_todos: bool, show_spinner_tree: bool
+) -> str:
+    if show_spinner_tree:
+        return "teammates"
+    if show_expanded_todos:
+        return "tasks"
+    return "none"
 
 
 def _on_expanded_view_change(old: AppState, new: AppState) -> None:
+    """Persist ``expanded_view`` to the global config as the legacy
+    showExpandedTodos + showSpinnerTree pair (TS onChangeAppState.ts:123-136)."""
     if old.expanded_view == new.expanded_view:
         return
     logger.debug(
@@ -174,8 +267,15 @@ def _on_expanded_view_change(old: AppState, new: AppState) -> None:
         old.expanded_view,
         new.expanded_view,
     )
-    # TODO: persist to global config as showExpandedTodos +
-    # showSpinnerTree (TS: onChangeAppState.ts:123-136).
+    todos, spinner = _EXPANDED_VIEW_TO_BOOLS.get(
+        new.expanded_view, (False, False)
+    )
+    try:
+        _persist_config_keys(
+            showExpandedTodos=todos, showSpinnerTree=spinner
+        )
+    except Exception:
+        logger.exception("Failed to persist expanded_view to global config")
 
 
 # Permission-mode notification hooks. Real listeners (CCR bridge, SDK
@@ -395,26 +495,83 @@ def on_change_app_state(old_state: AppState, new_state: AppState) -> None:
 # ---------------------------------------------------------------------------
 
 
+def seed_app_state_from_settings(active_provider: str | None) -> AppState:
+    """Read-side of the §3.4 persistence (ch03 round-3 G1).
+
+    TS seeds ``verbose`` from global config (``main.tsx:1129``, ``:2928``)
+    and ``expandedView`` from the showSpinnerTree/showExpandedTodos pair
+    (``:2932``); the model read mechanism is ``getUserSpecifiedModelSetting``
+    (``utils/model/model.ts:109-135``) whose provider-match guard this
+    mirrors: the persisted model applies ONLY when it was persisted under
+    the session's active provider — a stale cross-provider model must
+    never fire at the wrong endpoint.
+
+    NB ``get_settings()`` merges project/local "settings" sub-keys, so a
+    repo could shadow ``model`` — bounded by the provider-match guard and
+    by model choice being non-credential-bearing (the settings-tier trust
+    policy is ch15/16 work; ch02's untrusted strip covers
+    env/providers/default_provider).
+    """
+    from src import config as cfg_mod
+    from src.settings.settings import get_settings
+
+    try:
+        settings = get_settings()
+        cfg = cfg_mod._get_default_manager().load_global()
+    except Exception:
+        logger.exception("settings seed failed; starting from defaults")
+        return get_default_app_state()
+
+    model: str | None = settings.model or None
+    # Provider-mismatch guard: the persisted provider must be truthy AND
+    # match — a pair persisted with model_provider="" (unregistered
+    # supplier) is never applied, honoring the fail-safe contract.
+    if model and (
+        not settings.model_provider
+        or settings.model_provider != (active_provider or "")
+    ):
+        model = None
+    if model:
+        # Keep the bootstrap mirror consistent from the first read.
+        set_main_loop_model_override(model)
+
+    return AppState(
+        main_loop_model=model,
+        verbose=bool(cfg.get("verbose", False)),
+        expanded_view=expanded_view_from_config_bools(
+            bool(cfg.get("showExpandedTodos", False)),
+            bool(cfg.get("showSpinnerTree", False)),
+        ),
+    )
+
+
 def create_app_state_store(
     initial: AppState | None = None,
+    *,
+    active_provider: str | None = None,
 ) -> Store[AppState]:
     """Construct an AppState store with the centralized side-effect router.
 
     Equivalent to TS:
-    ``createStore(getDefaultAppState(), onChangeAppState)``.
+    ``createStore(getDefaultAppState(), onChangeAppState)`` — plus the
+    settings read-side: when ``initial`` is not supplied, the state is
+    seeded from persisted settings/config (model gated on
+    ``active_provider``; see :func:`seed_app_state_from_settings`).
     """
-    return create_store(
-        initial if initial is not None else get_default_app_state(),
-        on_change=on_change_app_state,
-    )
+    if initial is None:
+        initial = seed_app_state_from_settings(active_provider)
+    return create_store(initial, on_change=on_change_app_state)
 
 
 __all__ = [
     "AppState",
     "create_app_state_store",
+    "expanded_view_from_config_bools",
     "get_default_app_state",
     "on_change_app_state",
     "replace_state",
+    "seed_app_state_from_settings",
+    "set_active_provider_supplier",
     "set_permission_mode_listener",
     "set_session_metadata_listener",
 ]

--- a/src/state/cache_state.py
+++ b/src/state/cache_state.py
@@ -165,9 +165,10 @@ def evaluate_prompt_cache_1h_eligibility(
     keeps 1h caching dormant. When the porting WI for these inputs lands,
     1h caching activates without requiring code changes here.
 
-    **Status (Phase 2):** this primitive is implemented but has NO
-    production caller today. ``grep -rn "evaluate_prompt_cache_1h_eligibility"
-    src/`` returns only the definition. The 1h cache path is therefore
+    **Status (ch03 round-3 refresh):** this primitive IS called by
+    ``initialize_prompt_cache_eligibility``
+    (``src/state/session_start.py:77``), but that session-start shim
+    itself has zero callers. The 1h cache path is therefore still
     end-to-end dormant: ``prompt_cache_1h_eligible`` stays at ``None``,
     ``should_1h_cache_ttl`` always returns False, every cache_control
     emits ``ttl: '5m'``. Activating 1h requires (a) porting the user-type

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -1132,6 +1132,26 @@ class ClawCodexTUI(App):
             except Exception:
                 pass
             self.app_state.model = model_id
+            # ch03 round-3 (plan-critic major-3): route through the
+            # reactive store so the §3.4 chokepoint fires — persistence
+            # (settings model + model_provider pair) and the bootstrap
+            # mirror. Without this, picker switches were the exact
+            # scattered-mutation disease the chapter narrates.
+            try:
+                from src.state.app_state import replace_state
+
+                self._ensure_command_context()
+                if self._app_state_store is not None:
+                    self._app_state_store.set_state(
+                        lambda s: replace_state(s, main_loop_model=model_id)
+                    )
+            except Exception:
+                # Render-state already switched; only persistence/mirror
+                # was lost — make that diagnosable.
+                logger.debug(
+                    "model picker: store routing failed; switch not persisted",
+                    exc_info=True,
+                )
             transcript.append_system(f"Model switched to {model_id}.", style="muted")
             if self._repl_screen is not None:
                 self._repl_screen.status_bar.refresh_identity(model=model_id)
@@ -1553,11 +1573,23 @@ class ClawCodexTUI(App):
             from src.command_system.engine import create_command_context
             from src.cost_tracker import CostTracker
             from src.history import HistoryLog
-            from src.state.app_state import create_app_state_store
+            from src.state.app_state import (
+                create_app_state_store,
+                set_active_provider_supplier,
+            )
             from src.tui.ui_host import TextualUIHost
 
             if self._app_state_store is None:
-                self._app_state_store = create_app_state_store()
+                # ch03 round-3 G1: seeded from persisted settings (model
+                # gated on the active provider). NB this store is LAZY —
+                # seeding fires at first command use, not app start
+                # (harmless: the TUI renders from tui/state.py). Anyone
+                # making this eager must re-check ordering vs provider
+                # construction in entrypoints/tui.py.
+                self._app_state_store = create_app_state_store(
+                    active_provider=self.provider_name
+                )
+                set_active_provider_supplier(lambda: self.provider_name)
 
             self._command_context = create_command_context(
                 workspace_root=self.workspace_root,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,35 @@ def _isolate_user_permission_settings(tmp_path, monkeypatch):
         )
     except Exception:
         pass  # textual not installed in this environment
+    # ch03 round-3: the active-provider supplier is a module-level slot;
+    # tests need it deterministically EMPTY (the "persists '' when
+    # unregistered" case) and must not leak a registration across tests.
+    # The shared default ConfigManager and the settings cache must reset
+    # too: store creation now SEEDS from them (seed_app_state_from_settings),
+    # so a test that populates either cache would otherwise bleed into
+    # every later store-creating test's seeds (critic major-1 on the ch03
+    # round-3 review).
+    def _reset_state_seams() -> None:
+        try:
+            from src.state.app_state import set_active_provider_supplier
+
+            set_active_provider_supplier(None)
+        except Exception:
+            pass
+        try:
+            config_mod._default_manager = None
+        except Exception:
+            pass
+        try:
+            from src.settings.settings import invalidate_settings_cache
+
+            invalidate_settings_cache()
+        except Exception:
+            pass
+
+    _reset_state_seams()
     yield
+    _reset_state_seams()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_app_state_persistence_round3.py
+++ b/tests/test_app_state_persistence_round3.py
@@ -1,0 +1,268 @@
+"""ch03 round-3 G1: AppState handler persistence + read-side seeding.
+
+The §3.4 chokepoint made real: model/verbose/expanded_view changes persist
+on diff (TS onChangeAppState.ts:97-148), and store creation seeds back from
+the persisted values — with the (model, model_provider) pair guard
+(TS utils/model/model.ts:109-135) so a stale cross-provider model never
+applies.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from unittest import mock
+
+import pytest
+
+import src.config as config_module
+from src.bootstrap.state import (
+    get_main_loop_model_override,
+    reset_state_for_tests,
+)
+from src.settings.settings import (
+    apply_persisted_model,
+    get_settings,
+    invalidate_settings_cache,
+)
+from src.state.app_state import (
+    AppState,
+    create_app_state_store,
+    expanded_view_from_config_bools,
+    replace_state,
+    seed_app_state_from_settings,
+    set_active_provider_supplier,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(tmp_path, monkeypatch):
+    global_cfg = tmp_path / ".clawcodex" / "config.json"
+    monkeypatch.setattr(config_module, "GLOBAL_CONFIG_FILE", global_cfg)
+    monkeypatch.setattr(config_module, "GLOBAL_CONFIG_DIR", global_cfg.parent)
+    monkeypatch.setattr(config_module, "_default_manager", None, raising=False)
+    monkeypatch.setattr(config_module, "_find_git_root", lambda *a, **k: None)
+    invalidate_settings_cache()
+    reset_state_for_tests()
+    set_active_provider_supplier(None)
+    yield global_cfg
+    invalidate_settings_cache()
+    reset_state_for_tests()
+    set_active_provider_supplier(None)
+
+
+def _read_global(path) -> dict:
+    return json.loads(path.read_text()) if path.exists() else {}
+
+
+# ---------------------------------------------------------------------------
+# Write side — handler persistence
+# ---------------------------------------------------------------------------
+
+
+def test_model_change_persists_pair_and_mirrors_bootstrap(_isolated_state):
+    set_active_provider_supplier(lambda: "openrouter")
+    store = create_app_state_store(AppState())
+    store.set_state(lambda s: replace_state(s, main_loop_model="kimi-k3"))
+
+    assert get_main_loop_model_override() == "kimi-k3"
+    invalidate_settings_cache()
+    s = get_settings()
+    assert s.model == "kimi-k3"
+    assert s.model_provider == "openrouter"
+
+
+def test_model_none_writes_empty_strings(_isolated_state):
+    set_active_provider_supplier(lambda: "openrouter")
+    store = create_app_state_store(AppState(main_loop_model="kimi-k3"))
+    store.set_state(lambda s: replace_state(s, main_loop_model=None))
+
+    invalidate_settings_cache()
+    s = get_settings()
+    assert s.model == ""
+    assert s.model_provider == ""
+
+
+def test_model_persists_empty_provider_when_supplier_unregistered(
+    _isolated_state,
+):
+    store = create_app_state_store(AppState())
+    store.set_state(lambda s: replace_state(s, main_loop_model="kimi-k3"))
+    invalidate_settings_cache()
+    s = get_settings()
+    assert s.model == "kimi-k3"
+    assert s.model_provider == ""
+
+
+def test_model_write_does_not_touch_provider_selection(_isolated_state):
+    # Critic note-1: /model must not mutate the active-provider selection.
+    global_cfg = _isolated_state
+    global_cfg.parent.mkdir(parents=True, exist_ok=True)
+    global_cfg.write_text(json.dumps({"default_provider": "anthropic"}))
+    config_module._default_manager = None
+
+    set_active_provider_supplier(lambda: "openrouter")
+    store = create_app_state_store(AppState())
+    store.set_state(lambda s: replace_state(s, main_loop_model="kimi-k3"))
+
+    data = _read_global(global_cfg)
+    assert data.get("default_provider") == "anthropic"
+    assert "provider" not in data.get("settings", {})
+
+
+def test_verbose_persists_to_config_top_level(_isolated_state):
+    store = create_app_state_store(AppState())
+    store.set_state(lambda s: replace_state(s, verbose=True))
+    data = _read_global(_isolated_state)
+    assert data.get("verbose") is True
+
+
+def test_expanded_view_persists_as_legacy_boolean_pair(_isolated_state):
+    store = create_app_state_store(AppState())
+    store.set_state(lambda s: replace_state(s, expanded_view="tasks"))
+    data = _read_global(_isolated_state)
+    assert data.get("showExpandedTodos") is True
+    assert data.get("showSpinnerTree") is False
+
+    store.set_state(lambda s: replace_state(s, expanded_view="teammates"))
+    data = _read_global(_isolated_state)
+    assert data.get("showExpandedTodos") is False
+    assert data.get("showSpinnerTree") is True
+
+    store.set_state(lambda s: replace_state(s, expanded_view="none"))
+    data = _read_global(_isolated_state)
+    assert data.get("showExpandedTodos") is False
+    assert data.get("showSpinnerTree") is False
+
+
+# ---------------------------------------------------------------------------
+# Read side — seeding + the pair guard
+# ---------------------------------------------------------------------------
+
+
+def _persist(global_cfg, *, settings=None, **top):
+    data = dict(top)
+    if settings:
+        data["settings"] = settings
+    global_cfg.parent.mkdir(parents=True, exist_ok=True)
+    global_cfg.write_text(json.dumps(data))
+    config_module._default_manager = None
+    invalidate_settings_cache()
+
+
+def test_seed_applies_model_when_provider_matches(_isolated_state):
+    _persist(
+        _isolated_state,
+        settings={"model": "kimi-k3", "model_provider": "openrouter"},
+    )
+    state = seed_app_state_from_settings("openrouter")
+    assert state.main_loop_model == "kimi-k3"
+    assert get_main_loop_model_override() == "kimi-k3"
+
+
+def test_seed_ignores_model_on_provider_mismatch(_isolated_state):
+    # Critic note-1 vacuous-guard case: pair persisted under provider A,
+    # session active under provider B -> model ignored, selection untouched.
+    _persist(
+        _isolated_state,
+        default_provider="anthropic",
+        settings={"model": "kimi-k3", "model_provider": "openrouter"},
+    )
+    state = seed_app_state_from_settings("anthropic")
+    assert state.main_loop_model is None
+    assert get_main_loop_model_override() is None
+    assert _read_global(_isolated_state).get("default_provider") == "anthropic"
+
+
+def test_seed_reads_verbose_and_expanded_view(_isolated_state):
+    _persist(
+        _isolated_state,
+        verbose=True,
+        showExpandedTodos=False,
+        showSpinnerTree=True,
+    )
+    state = seed_app_state_from_settings(None)
+    assert state.verbose is True
+    assert state.expanded_view == "teammates"
+
+
+def test_expanded_view_read_priority_spinner_wins_ties(_isolated_state):
+    # (True, True) on disk reads as 'teammates' (TS main.tsx:2932 priority).
+    assert expanded_view_from_config_bools(True, True) == "teammates"
+    assert expanded_view_from_config_bools(True, False) == "tasks"
+    assert expanded_view_from_config_bools(False, False) == "none"
+
+
+def test_store_factory_seeds_when_initial_omitted(_isolated_state):
+    _persist(
+        _isolated_state,
+        verbose=True,
+        settings={"model": "kimi-k3", "model_provider": "openrouter"},
+    )
+    store = create_app_state_store(active_provider="openrouter")
+    assert store.get_state().main_loop_model == "kimi-k3"
+    assert store.get_state().verbose is True
+
+
+# ---------------------------------------------------------------------------
+# Effective read side — apply_persisted_model
+# ---------------------------------------------------------------------------
+
+
+class _FakeProvider:
+    def __init__(self) -> None:
+        self.model = "default-model"
+
+
+def test_apply_persisted_model_match(_isolated_state):
+    _persist(
+        _isolated_state,
+        settings={"model": "kimi-k3", "model_provider": "openrouter"},
+    )
+    provider = _FakeProvider()
+    assert apply_persisted_model(provider, "openrouter") is True
+    assert provider.model == "kimi-k3"
+
+
+def test_apply_persisted_model_mismatch_or_unset(_isolated_state):
+    _persist(
+        _isolated_state,
+        settings={"model": "kimi-k3", "model_provider": "openrouter"},
+    )
+    provider = _FakeProvider()
+    assert apply_persisted_model(provider, "anthropic") is False
+    assert provider.model == "default-model"
+
+    _persist(_isolated_state, settings={})
+    provider2 = _FakeProvider()
+    assert apply_persisted_model(provider2, "openrouter") is False
+    assert provider2.model == "default-model"
+
+
+def test_restart_round_trip_same_provider(_isolated_state):
+    """DoD-2: a /model choice survives 'restart' on the same provider and
+    is ignored after a provider switch."""
+    set_active_provider_supplier(lambda: "openrouter")
+    store = create_app_state_store(AppState())
+    store.set_state(lambda s: replace_state(s, main_loop_model="kimi-k3"))
+
+    # "Restart": fresh seed + fresh provider, same provider name.
+    reset_state_for_tests()
+    set_active_provider_supplier(None)
+    invalidate_settings_cache()
+    config_module._default_manager = None
+    provider = _FakeProvider()
+    assert apply_persisted_model(provider, "openrouter") is True
+    assert provider.model == "kimi-k3"
+    state = seed_app_state_from_settings("openrouter")
+    assert state.main_loop_model == "kimi-k3"
+
+    # Provider switch: persisted pair ignored everywhere.
+    provider_b = _FakeProvider()
+    assert apply_persisted_model(provider_b, "anthropic") is False
+    state_b = seed_app_state_from_settings("anthropic")
+    assert state_b.main_loop_model is None
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_git_context.py
+++ b/tests/test_git_context.py
@@ -181,3 +181,41 @@ class TestFormatGitStatus(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestNoOptionalLocksFlag(unittest.TestCase):
+    """ch03 round-3 G2: the status and log probes must pass
+    --no-optional-locks (TS context.ts:63-72 — those two commands only)
+    so a concurrent git in the user's other terminal never blocks on our
+    read probes."""
+
+    def test_status_and_log_carry_the_flag_exactly(self):
+        calls: list[list[str]] = []
+
+        def fake_git_cmd(args, cwd, timeout=5.0):
+            calls.append(list(args))
+            # The is-git gate must pass or collect_git_context returns
+            # before running any probe.
+            if args == ["rev-parse", "--is-inside-work-tree"]:
+                return "true"
+            return ""
+
+        clear_git_caches()
+        with tempfile.TemporaryDirectory() as tmp:
+            _init_git_repo(tmp)
+            with patch(
+                "src.context_system.git_context._git_cmd",
+                side_effect=fake_git_cmd,
+            ):
+                _run(collect_git_context(tmp))
+        clear_git_caches()
+
+        flagged = [c for c in calls if c and c[0] == "--no-optional-locks"]
+        flagged_tails = {tuple(c[1:3]) for c in flagged}
+        self.assertIn(("status", "--short"), flagged_tails)
+        self.assertIn(("log", "--oneline"), flagged_tails)
+        # TS-exact: ONLY status + log get the flag.
+        self.assertEqual(len(flagged), 2, f"unexpected flagged calls: {flagged}")
+        unflagged = [c for c in calls if c and c[0] != "--no-optional-locks"]
+        for cmd in unflagged:
+            self.assertNotIn("--no-optional-locks", cmd)

--- a/tests/test_prompt_assembly.py
+++ b/tests/test_prompt_assembly.py
@@ -636,3 +636,49 @@ class TestClearContextCaches(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestUserContextBootstrapCache(unittest.TestCase):
+    """ch03 round-3 G3: get_user_context must populate the bootstrap
+    cached_claude_md_content (TS context.ts:173-176 — the DAG-leaf cache
+    that breaks the classifier->filesystem->permissions->classifier
+    cycle; consumer unported, cache is forward provisioning)."""
+
+    def setUp(self):
+        from src.bootstrap.state import reset_state_for_tests
+
+        clear_context_caches()
+        reset_state_for_tests()
+
+    tearDown = setUp
+
+    def test_user_context_populates_cache(self):
+        from unittest import mock
+
+        from src.bootstrap.state import get_cached_claude_md_content
+        from src.context_system import prompt_assembly as pa
+
+        fake_files = [object()]
+        with mock.patch.object(
+            pa, "get_memory_files", new=mock.AsyncMock(return_value=fake_files)
+        ), mock.patch.object(
+            pa, "get_claude_mds", return_value="# Project notes"
+        ):
+            asyncio.run(pa.get_user_context())
+        self.assertEqual(get_cached_claude_md_content(), "# Project notes")
+
+    def test_absent_claude_md_caches_none_not_stale(self):
+        from unittest import mock
+
+        from src.bootstrap.state import (
+            get_cached_claude_md_content,
+            set_cached_claude_md_content,
+        )
+        from src.context_system import prompt_assembly as pa
+
+        set_cached_claude_md_content("stale")
+        with mock.patch.object(
+            pa, "get_memory_files", new=mock.AsyncMock(return_value=[])
+        ), mock.patch.object(pa, "get_claude_mds", return_value=""):
+            asyncio.run(pa.get_user_context())
+        self.assertIsNone(get_cached_claude_md_content())


### PR DESCRIPTION
## Summary

Round-3 improvement pass for book chapter 3 (State — the two-tier architecture). Gap analysis + plan critic-reviewed (two cycles each); implementation APPROVED. Docs: `my-docs/ch03-state-round3-gap-analysis.md`, `my-docs/python-port-improvement-round-3/ch03-state-round3-plan.md` (local, gitignored).

**WI-1 — the §3.4 persistence chokepoint made real** (all three handler TODOs, TS `onChangeAppState.ts:97-148`):
- `/model` persists a **(model, model_provider) pair**; the read-side applies it only when the persisted provider matches the active one (TS `model.ts:109-135` — the documented cross-provider staleness bug a multi-provider port must not reintroduce). Override-first precedence: an explicit `options.model` at the TUI entrypoint wins; the provider_factory branch is skipped.
- `verbose` / `expanded_view` persist to the global config as `verbose` + `showExpandedTodos`/`showSpinnerTree` (domain `'none'|'tasks'|'teammates'`; TS-exact spinner-wins read priority).
- Read-side seeding at store creation + `apply_persisted_model` carrying the choice to the live `provider.model` channel; live active-provider supplier (survives mid-session provider reinit); **TUI model picker routed through the reactive store**, closing the one mutation path that bypassed the chokepoint.
- conftest now resets the shared ConfigManager/settings cache/supplier per test (store creation seeds from them — critic catch preventing suite-wide order coupling).

**WI-2** — git probes pass `--no-optional-locks` on `status`+`log` (TS-exact, `context.ts:63-72`).

**WI-3** — `get_user_context` populates the bootstrap `cached_claude_md_content` (TS `context.ts:173-176` cycle-breaking cache; consumer unported — forward provisioning), overwriting stale values with None; three stale-comment refreshes.

**Deferred with named owners:** latch/beta-header consumption, dead cost-accumulation head, provider-profile model sync, settings-watcher → ch04; `/clear` → `clear_system_prompt_sections` wire, `pending_post_compaction` consumption → ch05.

## Test plan
- [x] 17 new tests: persistence round-trips (incl. the vacuous-guard case and a DoD restart round-trip), expanded_view both directions, git argv exactness (exactly-two-flagged), cache-producer overwrite semantics
- [x] Affected selections: 1,113 + 176 passed post-fix
- [x] Full suite ×2: 7,830 passed; 9 failures = the documented pre-existing environment set (PR #321)

🤖 Generated with [Claude Code](https://claude.com/claude-code)