### PR TITLE
feat(ch05/round3): agent loop — stop hooks, token budget, nudge, post-compact wires

### DIFF
--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -162,6 +162,20 @@ def clear_command_call(args: str, context: CommandContext) -> LocalCommandResult
     if hasattr(context.history, "events"):
         context.history.events.clear()
 
+    # ch05 round-3 G3: a cleared conversation restarts the cache epoch —
+    # reset memoized prompt sections + beta-header latches (TS
+    # clearSystemPromptSections via /clear, commands/clear/caches.ts:74).
+    # Direct call, NOT run_post_compact_cleanup: /clear must not register
+    # as a compaction (pending_post_compaction telemetry).
+    try:
+        from src.context_system.system_prompt_cache import (
+            clear_system_prompt_sections,
+        )
+
+        clear_system_prompt_sections()
+    except Exception:
+        pass
+
     return LocalCommandResult(
         type="text",
         value="Conversation cleared.",

--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -578,3 +578,48 @@ async def execute_stop_hooks(
         timeout_ms=timeout_ms,
     ):
         yield result
+
+
+async def execute_stop_failure_hooks(
+    last_message: Any,
+    tool_use_context: Any,
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Run StopFailure hooks (ch05 round-3 G1).
+
+    Fired when the loop ends a turn on an API-error response — the
+    death-spiral guard path where Stop hooks must NOT run (TS
+    query.ts:1346-1349 + the PTL/media surfacing exits :1256/:1263).
+    TS dispatches fire-and-forget; the port awaits at the (terminal)
+    exit paths — latency bounded by the hook timeout.
+    """
+    stdin_data = {
+        "hook_event": "StopFailure",
+        "error": _flatten_text(getattr(last_message, "content", "")) or "",
+    }
+    abort_signal = None
+    abort_ctrl = getattr(tool_use_context, "abort_controller", None)
+    if abort_ctrl:
+        abort_signal = abort_ctrl.signal
+    async for result in _run_hooks_for_event(
+        "StopFailure",
+        None,
+        stdin_data,
+        tool_use_context,
+        abort_signal=abort_signal,
+    ):
+        yield result
+
+
+def _flatten_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            text = getattr(block, "text", None)
+            if text is None and isinstance(block, dict):
+                text = block.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+        return " ".join(parts)
+    return str(content or "")

--- a/src/query/continuation_nudge.py
+++ b/src/query/continuation_nudge.py
@@ -1,0 +1,75 @@
+"""Continuation-nudge detection — port of TS query.ts:1443-1512.
+
+Detects when the model SIGNALS intent to continue ("so now I need to
+edit…", "let me run…") but returned no tool calls, so the loop can
+inject a nudge instead of ending the turn prematurely. Capped at
+``MAX_CONTINUATION_NUDGES`` per turn-chain (query.ts:169) — this cap
+belongs HERE, not to the token-budget continuation (a separate
+mechanism bounded by its own 90%/diminishing rules).
+"""
+
+from __future__ import annotations
+
+import re
+
+MAX_CONTINUATION_NUDGES = 3
+
+NUDGE_MESSAGE = "Continue with the task. Use the appropriate tools to proceed."
+
+# Don't nudge when the model signaled completion (query.ts:1487).
+_COMPLETION_MARKERS = re.compile(
+    r"\b(done|finished|completed|complete|summary|that's all|that is all"
+    r"|all set|hope this helps|let me know if)\b"
+)
+
+_ACTION = (
+    r"(do|create|write|edit|update|fix|implement|add|run|check|make|build"
+    r"|set up)"
+)
+
+# Always-on signal patterns (query.ts:1466-1481).
+_SIGNALS = [
+    re.compile(
+        r"\bso now (i|let me|we) (need to|have to|should|must|will) "
+        + _ACTION + r"\b"
+    ),
+    re.compile(
+        r"\bnow i('ll| will) "
+        r"(do|create|write|edit|update|fix|implement|add|run|check|make"
+        r"|build|set up|go|proceed)\b"
+    ),
+    re.compile(
+        r"\blet me (go ahead and |now )?"
+        r"(do|create|write|edit|update|fix|implement|add|run|check|make"
+        r"|build|set up|proceed)\b"
+    ),
+    re.compile(
+        r"\btime to (do|create|write|edit|update|fix|implement|add|run"
+        r"|check|make|build|get started|begin)\b"
+    ),
+]
+
+# Short-message-only patterns (< 80 chars; query.ts:1472-1475, 1478-1481).
+_SHORT_SIGNALS = [
+    re.compile(
+        r"\b(i('ll| will| need to| have to| must) (now )?" + _ACTION + r")\b"
+    ),
+    re.compile(
+        r"\bnext,?\s+(i('ll| will)|let me|i need to) "
+        r"(do|create|write|edit|update|fix|implement|add|run|check|make"
+        r"|build)\b"
+    ),
+]
+
+
+def detect_continuation_signal(last_text: str) -> bool:
+    """True iff the (lowercased) final assistant text signals continuation
+    intent without a completion marker."""
+    text = last_text.lower()
+    if _COMPLETION_MARKERS.search(text):
+        return False
+    if any(p.search(text) for p in _SIGNALS):
+        return True
+    if len(text) < 80 and any(p.search(text) for p in _SHORT_SIGNALS):
+        return True
+    return False

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -28,6 +28,17 @@ from ..utils.image_validation import ImageSizeError
 from ..providers.base import BaseProvider, ChatResponse
 
 from .config import QueryConfig, build_query_config
+from .continuation_nudge import (
+    MAX_CONTINUATION_NUDGES,
+    NUDGE_MESSAGE,
+    detect_continuation_signal,
+)
+from .stop_hooks import StopHookResult, handle_stop_hooks_streaming
+from .token_budget import (
+    ContinueDecision,
+    check_token_budget,
+    create_budget_tracker,
+)
 from .tool_failure_loop_guard import (
     create_tool_failure_loop_guard_state,
     update_tool_failure_loop_guard,
@@ -86,6 +97,10 @@ class QueryParams:
     provider: BaseProvider
     abort_controller: AbortController
     query_source: str = "repl_main_thread"
+    # ch05 round-3 G2: the +500k turn budget. Deliberate deviation from
+    # TS's ambient bootstrap-global design — params is the carrier; the
+    # bootstrap globals remain the mechanism (snapshot at query() entry).
+    token_budget: int | None = None
     max_output_tokens_override: int | None = None
     max_turns: int | None = None
     user_context: dict[str, str] | None = None
@@ -361,6 +376,24 @@ def _retry_after_seconds(e: Exception, default: float) -> float:
             except (TypeError, ValueError):
                 pass
     return default
+
+
+async def _fire_stop_failure_hooks(last_message: Any, tool_use_context: Any) -> None:
+    """Dispatch StopFailure hooks at the error-exit paths (ch05 G1).
+
+    TS fires fire-and-forget at query.ts:1256/:1263/:1347; the port
+    awaits (terminal paths; latency bounded by the hook timeout) and
+    never raises.
+    """
+    try:
+        from ..hooks.hook_executor import execute_stop_failure_hooks
+
+        async for _result in execute_stop_failure_hooks(
+            last_message, tool_use_context
+        ):
+            pass
+    except Exception:
+        logger.debug("StopFailure hook dispatch failed", exc_info=True)
 
 
 async def _call_model_sync(
@@ -1262,6 +1295,26 @@ async def query(
     # query.ts:311 (state built before the while(true) at :327). Any
     # successful tool result resets the counters inside the guard.
     tool_failure_guard_state = create_tool_failure_loop_guard_state()
+    # ch05 round-3 G2: snapshot the turn-token baseline + budget into the
+    # bootstrap globals (zero callers before this — without the snapshot,
+    # get_turn_output_tokens() returns SESSION-cumulative tokens and the
+    # budget check is silently wrong after any prior output). Tracker is
+    # once-per-query (TS query.ts:299) — per-iteration construction would
+    # disable diminishing-returns detection.
+    from ..bootstrap.state import snapshot_output_tokens_for_turn
+
+    # Top-level queries only: a nested subagent query() (Agent tool runs
+    # inside the main turn's tool phase) or a sidechannel must NOT
+    # re-snapshot — it would null the budget, re-baseline the turn counter,
+    # and zero the continuation count mid-turn. TS snapshots only at the
+    # REPL surface (REPL.tsx:2944); agent_id mirrors check_token_budget's
+    # own subagent discriminator.
+    if (
+        getattr(params.tool_use_context, "agent_id", None) is None
+        and params.query_source not in ("compact", "session_memory")
+    ):
+        snapshot_output_tokens_for_turn(params.token_budget)
+    budget_tracker = create_budget_tracker()
 
     while True:
         messages = state.messages
@@ -1609,6 +1662,8 @@ async def query(
             ):
                 if last_message is not None:
                     yield last_message
+                # ch05 G1: StopFailure fires on error exits (TS :1256).
+                await _fire_stop_failure_hooks(last_message, tool_use_context)
                 set_terminal(
                     holder,
                     natural_termination,
@@ -1701,6 +1756,8 @@ async def query(
                 # must remain.
                 if last_message is not None:
                     yield last_message
+                # ch05 G1: StopFailure fires on error exits (TS :1263).
+                await _fire_stop_failure_hooks(last_message, tool_use_context)
                 set_terminal(
                     holder,
                     natural_termination,
@@ -1712,9 +1769,179 @@ async def query(
                 )
                 return
 
-            if last_message and getattr(last_message, "isApiErrorMessage", False):
+            if last_message and (
+                getattr(last_message, "isApiErrorMessage", False)
+                or _is_withheld_max_output_tokens(last_message)
+            ):
+                # Death-spiral guard (TS query.ts:1346-1349): NO Stop hooks
+                # on an API-error response ("error -> hook blocking ->
+                # retry -> error -> ... the hook injects more tokens each
+                # cycle"); StopFailure hooks fire instead. The recovery-
+                # exhausted max-output-tokens message is included explicitly:
+                # the port tags it isApiErrorMessage=False (it carries real
+                # partial content), while TS's equivalent is a synthetic
+                # error message with isApiErrorMessage=true
+                # (claude.ts:2289-2295) — without this clause a blocking
+                # Stop hook re-opens the truncation spiral the recovery
+                # counter just closed.
+                await _fire_stop_failure_hooks(last_message, tool_use_context)
                 set_terminal(holder, natural_termination, Terminal(reason="completed"))
                 return
+
+            # ch05 round-3 G1 — Stop hooks at the clean no-tool-use exit
+            # (TS query.ts:1351-1391 via query/stopHooks.ts). The handler
+            # streams its own progress/system messages, then yields the
+            # final StopHookResult.
+            stop_result = StopHookResult()
+            try:
+                async for item in handle_stop_hooks_streaming(
+                    messages,
+                    assistant_messages,
+                    # The system-prompt param is signature-parity only —
+                    # _handle_stop_hooks_generator never reads it, so ""
+                    # for block-list prompts is deliberate.
+                    params.system_prompt
+                    if isinstance(params.system_prompt, str)
+                    else "",
+                    tool_use_context,
+                    params.query_source,
+                    state.stop_hook_active,
+                ):
+                    if isinstance(item, StopHookResult):
+                        stop_result = item
+                    else:
+                        yield item
+            except Exception:
+                logger.exception("stop hooks failed; continuing to exit")
+
+            if stop_result.prevent_continuation:
+                set_terminal(
+                    holder,
+                    natural_termination,
+                    Terminal(reason="stop_hook_prevented"),
+                )
+                return
+
+            if stop_result.blocking_errors:
+                # Stop hook says "not done" — retry with the blocking
+                # errors appended. PRESERVE has_attempted_reactive_compact:
+                # if compact already ran and couldn't recover, retrying
+                # after a stop-hook blocking error will produce the same
+                # result; resetting to False here caused an infinite loop
+                # burning thousands of API calls (TS query.ts:1375-1381).
+                state = QueryState(
+                    messages=[
+                        *messages,
+                        *assistant_messages,
+                        *stop_result.blocking_errors,
+                    ],
+                    tool_use_context=tool_use_context,
+                    auto_compact_tracking=state.auto_compact_tracking,
+                    max_output_tokens_recovery_count=0,
+                    has_attempted_reactive_compact=has_attempted_reactive_compact,
+                    max_output_tokens_override=None,
+                    stop_hook_active=True,
+                    turn_count=turn_count,
+                    pending_tool_use_summary=None,
+                    continuation_nudge_count=state.continuation_nudge_count,
+                    transition=Transition(reason="stop_hook_blocking"),
+                )
+                continue
+
+            # ch05 round-3 G2 — token budget (TS query.ts:1393-1441).
+            # No MAX_CONTINUATION_NUDGES interaction: budget continuations
+            # are bounded only by check_token_budget's 90%/diminishing
+            # rules (the nudge cap below is a SEPARATE mechanism).
+            from ..bootstrap.state import (
+                get_current_turn_token_budget,
+                get_turn_output_tokens,
+                increment_budget_continuation_count,
+            )
+
+            budget_decision = check_token_budget(
+                budget_tracker,
+                getattr(tool_use_context, "agent_id", None),
+                get_current_turn_token_budget(),
+                get_turn_output_tokens(),
+            )
+            if isinstance(budget_decision, ContinueDecision):
+                increment_budget_continuation_count()
+                logger.debug(
+                    "Token budget continuation #%d: %d%% (%d/%d)",
+                    budget_decision.continuation_count,
+                    budget_decision.pct,
+                    budget_decision.turn_tokens,
+                    budget_decision.budget,
+                )
+                state = QueryState(
+                    messages=[
+                        *messages,
+                        *assistant_messages,
+                        UserMessage(
+                            content=budget_decision.nudge_message,
+                            isMeta=True,
+                        ),
+                    ],
+                    tool_use_context=tool_use_context,
+                    auto_compact_tracking=state.auto_compact_tracking,
+                    max_output_tokens_recovery_count=0,
+                    has_attempted_reactive_compact=False,
+                    max_output_tokens_override=None,
+                    stop_hook_active=None,
+                    turn_count=turn_count,
+                    pending_tool_use_summary=None,
+                    continuation_nudge_count=state.continuation_nudge_count,
+                    transition=Transition(reason="token_budget_continuation"),
+                )
+                continue
+            if getattr(budget_decision, "completion_event", None):
+                logger.debug(
+                    "token budget completed: %s",
+                    budget_decision.completion_event,
+                )
+
+            # ch05 round-3 G5 — continuation nudge (TS query.ts:1443-1512):
+            # the model SAID it would act but called no tools. Capped at
+            # MAX_CONTINUATION_NUDGES per turn-chain.
+            if (
+                assistant_messages
+                and (params.max_turns is None or turn_count < params.max_turns)
+                and state.continuation_nudge_count < MAX_CONTINUATION_NUDGES
+            ):
+                last_assistant = assistant_messages[-1]
+                content = getattr(last_assistant, "content", "")
+                if isinstance(content, str):
+                    last_text = content
+                else:
+                    last_text = " ".join(
+                        getattr(b, "text", "")
+                        for b in content
+                        if getattr(b, "type", None) == "text"
+                    )
+                if last_text and detect_continuation_signal(last_text):
+                    logger.debug(
+                        "Continuation nudge triggered (%d/%d)",
+                        state.continuation_nudge_count + 1,
+                        MAX_CONTINUATION_NUDGES,
+                    )
+                    state = QueryState(
+                        messages=[
+                            *messages,
+                            *assistant_messages,
+                            UserMessage(content=NUDGE_MESSAGE, isMeta=True),
+                        ],
+                        tool_use_context=tool_use_context,
+                        auto_compact_tracking=state.auto_compact_tracking,
+                        max_output_tokens_recovery_count=0,
+                        has_attempted_reactive_compact=False,
+                        max_output_tokens_override=None,
+                        stop_hook_active=None,
+                        turn_count=turn_count,
+                        pending_tool_use_summary=None,
+                        continuation_nudge_count=state.continuation_nudge_count + 1,
+                        transition=Transition(reason="continuation_nudge"),
+                    )
+                    continue
 
             set_terminal(holder, natural_termination, Terminal(reason="completed"))
             return

--- a/src/query/stop_hooks.py
+++ b/src/query/stop_hooks.py
@@ -106,7 +106,12 @@ async def _handle_stop_hooks_generator(
         agent_id = getattr(tool_use_context, "agent_id", None)
         agent_type = getattr(tool_use_context, "agent_type", None)
 
-        if not has_hook_for_event("Stop", tool_use_context):
+        # Gate on the SAME event the executor will dispatch (SubagentStop
+        # when agent_id is set, hook_executor.py:561) — gating on "Stop"
+        # alone silently disables SubagentStop-only configurations.
+        if not has_hook_for_event(
+            "SubagentStop" if agent_id else "Stop", tool_use_context
+        ):
             return
 
         blocking_errors: list[Message] = []

--- a/src/services/compact/compact.py
+++ b/src/services/compact/compact.py
@@ -176,6 +176,20 @@ def _is_prompt_too_long_error(error_str: str) -> bool:
     )
 
 
+def _mark_post_compaction_state() -> None:
+    """Set the bootstrap pending_post_compaction flag (ch05 round-3 G4).
+
+    Consume side is OTel cache-miss telemetry (TS consumePostCompaction,
+    services/api/logging.ts) — deferred; the mark keeps the state real.
+    Never raises."""
+    try:
+        from src.bootstrap.state import mark_post_compaction
+
+        mark_post_compaction()
+    except Exception:
+        logger.debug("mark_post_compaction failed", exc_info=True)
+
+
 def _record_compaction_usage(context: "CompactContext", usage: Any) -> None:
     """Record a summarize call's usage into the bootstrap cost totals
     (ch04 round-3 G1 — TS counts every API call via addToTotalSessionCost
@@ -372,6 +386,11 @@ async def compact_conversation(
             # loop's (critic-found). Distinct API call from any
             # query_source="compact" loop turn, so no double count.
             _record_compaction_usage(context, response.usage)
+            # ch05 round-3 G4: mark the post-compaction cache state at the
+            # SUCCESS site (TS compact.ts:73 / autoCompact.ts:350) — never
+            # in run_post_compact_cleanup, which /clear-adjacent paths may
+            # share; /clear must not register as a compaction.
+            _mark_post_compaction_state()
             break
         except Exception as e:
             error_str = str(e)
@@ -416,6 +435,7 @@ async def compact_conversation(
                 if response.usage:
                     compaction_usage = dict(response.usage)
                 _record_compaction_usage(context, response.usage)
+                _mark_post_compaction_state()
                 break
             except Exception as e2:
                 logger.warning(
@@ -568,6 +588,11 @@ async def partial_compact_conversation(
             # loop's (critic-found). Distinct API call from any
             # query_source="compact" loop turn, so no double count.
             _record_compaction_usage(context, response.usage)
+            # ch05 round-3 G4: mark the post-compaction cache state at the
+            # SUCCESS site (TS compact.ts:73 / autoCompact.ts:350) — never
+            # in run_post_compact_cleanup, which /clear-adjacent paths may
+            # share; /clear must not register as a compaction.
+            _mark_post_compaction_state()
             break
         except Exception as e:
             error_str = str(e)

--- a/src/services/compact/post_compact_cleanup.py
+++ b/src/services/compact/post_compact_cleanup.py
@@ -34,6 +34,20 @@ def run_post_compact_cleanup(
     """
     cleared: list[str] = []
 
+    # ch05 round-3 G3: every compaction restarts the cache epoch — reset
+    # memoized prompt sections + beta-header latches (TS
+    # clearSystemPromptSections, constants/systemPromptSections.ts:65-68).
+    # Runs even with a None context (the reset is global state).
+    try:
+        from src.context_system.system_prompt_cache import (
+            clear_system_prompt_sections,
+        )
+
+        clear_system_prompt_sections()
+        cleared.append("system_prompt_sections")
+    except Exception:
+        pass
+
     if context is None:
         return cleared
 

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -727,6 +727,16 @@ class ClawCodexTUI(App):
             # C3a: the context-% segment must not keep showing the
             # pre-clear context (TS shows nothing for an empty list).
             self.app_state.last_turn_input_tokens = 0
+            # ch05 round-3 G3: this TUI-local path bypasses the registry
+            # /clear builtin — reset prompt sections + latches here too.
+            try:
+                from src.context_system.system_prompt_cache import (
+                    clear_system_prompt_sections,
+                )
+
+                clear_system_prompt_sections()
+            except Exception:
+                pass
             return
         if result.system_text == "__thinking__":
             # C3b /thinking: flip the bridge's session override. First use

--- a/tests/test_post_compact_cleanup.py
+++ b/tests/test_post_compact_cleanup.py
@@ -16,9 +16,10 @@ class TestRunPostCompactCleanup(unittest.TestCase):
     """Tests for run_post_compact_cleanup()."""
 
     def test_none_context(self):
-        """No-op when context is None."""
+        """ch05 round-3 G3: the section/latch reset is GLOBAL state and
+        runs even with a None context; nothing else does."""
         result = run_post_compact_cleanup(None)
-        self.assertEqual(result, [])
+        self.assertEqual(result, ["system_prompt_sections"])
 
     def test_clears_registered_caches(self):
         """Clears all registered caches."""
@@ -67,10 +68,11 @@ class TestRunPostCompactCleanup(unittest.TestCase):
         self.assertIn("good_cache", result)
 
     def test_empty_context(self):
-        """Empty context returns empty list."""
+        """Empty context clears only the global section/latch state
+        (ch05 round-3 G3)."""
         ctx = PostCompactContext()
         result = run_post_compact_cleanup(ctx)
-        self.assertEqual(result, [])
+        self.assertEqual(result, ["system_prompt_sections"])
 
 
 if __name__ == "__main__":

--- a/tests/test_query_loop_wires_round3.py
+++ b/tests/test_query_loop_wires_round3.py
@@ -1,0 +1,645 @@
+"""ch05 round-3 acceptance tests: the five loop wires.
+
+Stop hooks at the clean exit (G1), token budget (G2), /clear+compact
+section resets (G3), post-compaction mark (G4), continuation nudge (G5).
+Plan: my-docs/python-port-improvement-round-3/ch05-agent-loop-round3-plan.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from src.bootstrap.state import (
+    consume_post_compaction,
+    get_budget_continuation_count,
+    reset_state_for_tests,
+)
+
+
+def get_pending_post_compaction() -> bool:
+    # Read the module attribute dynamically: reset_state_for_tests REBINDS
+    # _STATE, so an imported reference goes stale.
+    from src.bootstrap import state as _bs
+
+    return _bs._STATE.pending_post_compaction
+from src.providers.base import ChatResponse
+from src.query.continuation_nudge import (
+    MAX_CONTINUATION_NUDGES,
+    detect_continuation_signal,
+)
+from src.query.query import QueryParams, run_query
+from src.query.stop_hooks import StopHookResult
+from src.state.cache_state import (
+    get_beta_header_latches,
+    reset_for_test_only as reset_cache_state_for_tests,
+)
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.types.messages import UserMessage
+from src.utils.abort_controller import AbortController
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_state_for_tests()
+    try:
+        reset_cache_state_for_tests()
+    except Exception:
+        pass
+    yield
+    reset_state_for_tests()
+    try:
+        reset_cache_state_for_tests()
+    except Exception:
+        pass
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _completion(content="Done. The task is complete.") -> ChatResponse:
+    return ChatResponse(
+        content=content,
+        model="claude-test",
+        usage={"input_tokens": 7, "output_tokens": 3},
+        finish_reason="end_turn",
+        tool_uses=None,
+    )
+
+
+def _provider(responses):
+    provider = mock.MagicMock()
+    provider.model = "claude-test"
+    provider.chat_stream_response.side_effect = NotImplementedError()
+    seq = list(responses)
+
+    def chat(*a, **k):
+        return seq.pop(0) if len(seq) > 1 else seq[0]
+
+    provider.chat.side_effect = chat
+    return provider
+
+
+def _params(workspace: Path, provider, **kw) -> QueryParams:
+    registry = build_default_registry()
+    return QueryParams(
+        messages=[UserMessage(content="Hi")],
+        system_prompt="You are helpful.",
+        tools=registry.list_tools(),
+        tool_registry=registry,
+        tool_use_context=kw.pop(
+            "tool_use_context", ToolContext(workspace_root=workspace)
+        ),
+        provider=provider,
+        abort_controller=AbortController(),
+        max_turns=8,
+        **kw,
+    )
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# G1 — stop hooks
+# ---------------------------------------------------------------------------
+
+
+class TestStopHooks(_Base):
+    def test_prevent_continuation_terminal(self):
+        async def fake_stream(*a, **k):
+            yield StopHookResult(prevent_continuation=True)
+
+        with mock.patch(
+            "src.query.query.handle_stop_hooks_streaming", fake_stream
+        ):
+            _msgs, terminal = _run(
+                run_query(_params(self.workspace, _provider([_completion()])))
+            )
+        self.assertEqual(terminal.reason, "stop_hook_prevented")
+
+    def test_blocking_errors_retry_once_with_flag(self):
+        calls: list = []
+
+        async def fake_stream(messages, assistants, sp, ctx, source, active, *a, **k):
+            calls.append(active)
+            if len(calls) == 1:
+                yield StopHookResult(
+                    blocking_errors=[
+                        UserMessage(content="Linter found 3 errors", isMeta=True)
+                    ]
+                )
+            else:
+                yield StopHookResult()
+
+        with mock.patch(
+            "src.query.query.handle_stop_hooks_streaming", fake_stream
+        ):
+            _msgs, terminal = _run(
+                run_query(_params(self.workspace, _provider([_completion()])))
+            )
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(len(calls), 2)          # one retry
+        self.assertIsNone(calls[0])              # first run: not active
+        self.assertTrue(calls[1])                # retry: stop_hook_active=True
+
+    def test_api_error_skips_stop_hooks_fires_stop_failure(self):
+        provider = mock.MagicMock()
+        provider.model = "claude-test"
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        err = _completion("")
+        provider.chat.return_value = err
+
+        stop_called = []
+        failure_called = []
+
+        async def fake_stream(*a, **k):
+            stop_called.append(True)
+            yield StopHookResult()
+
+        async def fake_failure(*a, **k):
+            failure_called.append(True)
+
+        with mock.patch(
+            "src.query.query.handle_stop_hooks_streaming", fake_stream
+        ), mock.patch(
+            "src.query.query._fire_stop_failure_hooks", fake_failure
+        ), mock.patch(
+            "src.query.query._call_model_sync",
+            side_effect=_fake_api_error_response,
+        ):
+            _msgs, terminal = _run(
+                run_query(_params(self.workspace, provider))
+            )
+        self.assertEqual(terminal.reason, "completed")
+        self.assertFalse(stop_called)            # Stop hooks skipped
+        self.assertTrue(failure_called)          # StopFailure fired
+
+    def test_no_hooks_plain_completed_regression(self):
+        _msgs, terminal = _run(
+            run_query(_params(self.workspace, _provider([_completion()])))
+        )
+        self.assertEqual(terminal.reason, "completed")
+
+    def test_max_tokens_exhausted_skips_stop_hooks(self):
+        # Recovery-exhausted max-output-tokens message carries
+        # isApiErrorMessage=False (real partial content) — the guard must
+        # treat it as an error exit anyway, or a blocking Stop hook
+        # re-opens the truncation spiral (escalate + 3 recoveries + hook
+        # exec per cycle, unbounded).
+        async def fake_model(**kwargs):
+            from src.types.messages import AssistantMessage
+
+            msg = AssistantMessage(content="partial answer, cut off mid-")
+            msg._api_error = "max_output_tokens"
+            return [msg], []
+
+        stop_called: list = []
+        failure_called: list = []
+
+        async def fake_stream(*a, **k):
+            # Block only on the first call so a future guard regression
+            # FAILS at the asserts instead of hanging in the spiral.
+            stop_called.append(True)
+            if len(stop_called) == 1:
+                yield StopHookResult(
+                    blocking_errors=[
+                        UserMessage(content="keep going", isMeta=True)
+                    ]
+                )
+            else:
+                yield StopHookResult()
+
+        async def fake_failure(*a, **k):
+            failure_called.append(True)
+
+        with mock.patch(
+            "src.query.query.handle_stop_hooks_streaming", fake_stream
+        ), mock.patch(
+            "src.query.query._fire_stop_failure_hooks", fake_failure
+        ), mock.patch(
+            "src.query.query._call_model_sync", side_effect=fake_model
+        ):
+            _msgs, terminal = _run(
+                run_query(_params(self.workspace, _provider([_completion()])))
+            )
+        self.assertEqual(terminal.reason, "completed")
+        self.assertFalse(stop_called)            # Stop hooks skipped
+        self.assertTrue(failure_called)          # StopFailure fired
+
+    def test_blocking_preserves_reactive_compact_guard(self):
+        # Guard-5 pin: PTL → reactive compact → clean response → hook
+        # blocks → PTL again must terminate prompt_too_long WITHOUT a
+        # second compact attempt. If the stop_hook_blocking reconstruct
+        # reset has_attempted_reactive_compact, this loops compacting
+        # forever (TS query.ts:1375-1381 production incident).
+        from src.services.compact.reactive_compact import ReactiveCompactResult
+
+        seq = {"n": 0}
+
+        async def fake_model(**kwargs):
+            from src.types.messages import AssistantMessage
+
+            seq["n"] += 1
+            if seq["n"] in (1, 3):
+                msg = AssistantMessage(content="")
+                msg.isApiErrorMessage = True
+                msg._api_error = "prompt_too_long"
+                return [msg], []
+            return [AssistantMessage(content="Here is my answer.")], []
+
+        compact_calls: list = []
+
+        async def fake_compact(**kwargs):
+            compact_calls.append(True)
+            return ReactiveCompactResult(
+                compacted=True,
+                messages=[UserMessage(content="compacted summary", isMeta=True)],
+                tokens_before=100,
+                tokens_after=10,
+            )
+
+        hook_calls: list = []
+
+        async def fake_stream(messages, assistants, sp, ctx, source, active, *a, **k):
+            hook_calls.append(active)
+            if len(hook_calls) == 1:
+                yield StopHookResult(
+                    blocking_errors=[
+                        UserMessage(content="not done yet", isMeta=True)
+                    ]
+                )
+            else:
+                yield StopHookResult()
+
+        with mock.patch(
+            "src.query.query.handle_stop_hooks_streaming", fake_stream
+        ), mock.patch(
+            "src.services.compact.reactive_compact.reactive_compact",
+            side_effect=fake_compact,
+        ), mock.patch(
+            "src.query.query._call_model_sync", side_effect=fake_model
+        ):
+            _msgs, terminal = _run(
+                run_query(_params(self.workspace, _provider([_completion()])))
+            )
+        self.assertEqual(terminal.reason, "prompt_too_long")
+        self.assertEqual(len(compact_calls), 1)  # no second compact
+        self.assertEqual(len(hook_calls), 1)     # blocked once, then PTL exit
+
+
+async def _fake_api_error_response(**kwargs):
+    from src.types.messages import AssistantMessage
+
+    msg = AssistantMessage(content="API error: boom")
+    msg.isApiErrorMessage = True
+    return [msg], []
+
+
+# ---------------------------------------------------------------------------
+# G2 — token budget
+# ---------------------------------------------------------------------------
+
+
+class TestTokenBudget(_Base):
+    def _budgeted_params(self, provider, budget=10_000, **kw):
+        return _params(self.workspace, provider, token_budget=budget, **kw)
+
+    def _bump_output_tokens(self, n):
+        # record_api_usage MERGES into the per-model accumulator;
+        # add_to_total_cost_state REPLACES (its callers pre-merge).
+        from src.cost_tracker import record_api_usage
+
+        record_api_usage("claude-test", {"output_tokens": n})
+
+    def test_snapshot_at_entry_makes_turn_tokens_turn_scoped(self):
+        # Session already produced output BEFORE this query — without the
+        # entry snapshot the budget math would see session-cumulative.
+        self._bump_output_tokens(9_999)
+        provider = _provider([_completion()])
+        responses = {"n": 0}
+
+        def chat(*a, **k):
+            responses["n"] += 1
+            # Each call produces tiny output; under 90% of budget the loop
+            # would continue if turn tokens were computed correctly small,
+            # but diminishing-returns will not trigger (deltas tiny but
+            # continuation_count < 3 initially).
+            self._bump_output_tokens(10)
+            return _completion()
+
+        provider.chat.side_effect = chat
+        _msgs, terminal = _run(
+            run_query(self._budgeted_params(provider, budget=100))
+        )
+        # turn tokens start at 0 (snapshot) and grow by ~10/turn; budget
+        # 100 → continues until diminishing-returns stops it (3+ small
+        # deltas) — NOT an instant stop from the 9,999 session tokens.
+        self.assertEqual(terminal.reason, "completed")
+        self.assertGreaterEqual(get_budget_continuation_count(), 3)
+
+    def test_continues_past_three_while_under_threshold(self):
+        # Anti-conflation: budget continuations are NOT capped at 3.
+        provider = _provider([_completion()])
+        turn = {"n": 0}
+
+        def chat(*a, **k):
+            turn["n"] += 1
+            self._bump_output_tokens(1_000)   # healthy deltas, no diminishing
+            return _completion()
+
+        provider.chat.side_effect = chat
+        _msgs, terminal = _run(
+            run_query(
+                self._budgeted_params(provider, budget=8_000)
+            )
+        )
+        self.assertEqual(terminal.reason, "completed")
+        # 1000/turn vs 8000 budget → 90% at 7200 → 7 turns continue
+        self.assertGreater(get_budget_continuation_count(), 3)
+
+    def test_nudge_appended_not_yielded(self):
+        provider = _provider([_completion()])
+        turn = {"n": 0}
+
+        def chat(*a, **k):
+            turn["n"] += 1
+            self._bump_output_tokens(1_000)
+            return _completion()
+
+        provider.chat.side_effect = chat
+        msgs, _terminal = _run(
+            run_query(self._budgeted_params(provider, budget=3_000))
+        )
+        # Non-vacuity: the budget-continuation path actually ran.
+        self.assertGreaterEqual(get_budget_continuation_count(), 1)
+        # The nudge is appended to next-state messages, never yielded:
+        # no isMeta UserMessage in the stream (this scenario yields no
+        # legitimate user messages), and no nudge text (token_budget.py
+        # phrasing: "token target" / "Keep working").
+        for m in msgs:
+            if isinstance(m, UserMessage):
+                self.assertFalse(
+                    getattr(m, "isMeta", False),
+                    f"isMeta UserMessage leaked into the yield stream: {m}",
+                )
+        yielded_texts = [str(getattr(m, "content", "")).lower() for m in msgs]
+        self.assertFalse(
+            any(
+                "token target" in t or "keep working" in t
+                for t in yielded_texts
+            ),
+            f"budget nudge leaked into the yield stream: {yielded_texts}",
+        )
+
+    def test_subagent_stops_immediately(self):
+        provider = _provider([_completion()])
+        ctx = ToolContext(workspace_root=self.workspace)
+        ctx.agent_id = "agent-123"
+        _msgs, terminal = _run(
+            run_query(
+                self._budgeted_params(
+                    provider, budget=1_000_000, tool_use_context=ctx
+                )
+            )
+        )
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(get_budget_continuation_count(), 0)
+
+    def test_no_budget_untouched_path(self):
+        provider = _provider([_completion()])
+        _msgs, terminal = _run(run_query(_params(self.workspace, provider)))
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(get_budget_continuation_count(), 0)
+
+    def test_subagent_query_preserves_turn_snapshot(self):
+        # A nested subagent query() (the Agent tool runs inside the main
+        # turn's tool phase) must NOT re-snapshot — that would null the
+        # main turn's budget, re-baseline the counter, and zero the
+        # continuation count mid-turn.
+        from src.bootstrap.state import (
+            get_current_turn_token_budget,
+            get_turn_output_tokens,
+            increment_budget_continuation_count,
+            snapshot_output_tokens_for_turn,
+        )
+
+        snapshot_output_tokens_for_turn(5_000)   # the main turn's snapshot
+        increment_budget_continuation_count()
+        self._bump_output_tokens(1_234)          # main-turn progress
+
+        ctx = ToolContext(workspace_root=self.workspace)
+        ctx.agent_id = "agent-nested"
+        _msgs, terminal = _run(
+            run_query(
+                _params(self.workspace, _provider([_completion()]),
+                        tool_use_context=ctx)
+            )
+        )
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(get_current_turn_token_budget(), 5_000)
+        self.assertEqual(get_budget_continuation_count(), 1)
+        self.assertGreaterEqual(get_turn_output_tokens(), 1_234)
+
+    def test_sidechannel_source_preserves_turn_snapshot(self):
+        from src.bootstrap.state import (
+            get_current_turn_token_budget,
+            snapshot_output_tokens_for_turn,
+        )
+
+        snapshot_output_tokens_for_turn(5_000)
+        _msgs, terminal = _run(
+            run_query(
+                _params(self.workspace, _provider([_completion()]),
+                        query_source="compact")
+            )
+        )
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(get_current_turn_token_budget(), 5_000)
+
+
+# ---------------------------------------------------------------------------
+# G1 — SubagentStop gate (stop_hooks.py)
+# ---------------------------------------------------------------------------
+
+
+class TestSubagentStopGate(_Base):
+    def _drive(self, ctx):
+        from src.query.stop_hooks import handle_stop_hooks_streaming
+
+        async def run():
+            items = []
+            async for item in handle_stop_hooks_streaming(
+                [], [], "", ctx, "agent", None
+            ):
+                items.append(item)
+            return items
+
+        return _run(run())
+
+    def test_subagent_context_gates_on_subagent_stop(self):
+        # A SubagentStop-only config must fire for subagent contexts —
+        # gating on "Stop" alone silently disabled it (the executor
+        # dispatches SubagentStop when subagent_id is set).
+        gated_events: list = []
+        ran: list = []
+
+        def fake_has_hook(event, ctx):
+            gated_events.append(event)
+            return event == "SubagentStop"
+
+        async def fake_execute(**kw):
+            ran.append(kw.get("subagent_id"))
+            if False:
+                yield  # async generator
+
+        with mock.patch(
+            "src.hooks.hook_executor.has_hook_for_event", fake_has_hook
+        ), mock.patch(
+            "src.hooks.hook_executor.execute_stop_hooks", fake_execute
+        ):
+            ctx = ToolContext(workspace_root=self.workspace)
+            ctx.agent_id = "agent-9"
+            items = self._drive(ctx)
+        self.assertEqual(gated_events, ["SubagentStop"])
+        self.assertEqual(ran, ["agent-9"])
+        self.assertIsInstance(items[-1], StopHookResult)
+
+    def test_top_level_context_gates_on_stop(self):
+        gated_events: list = []
+
+        def fake_has_hook(event, ctx):
+            gated_events.append(event)
+            return False
+
+        with mock.patch(
+            "src.hooks.hook_executor.has_hook_for_event", fake_has_hook
+        ):
+            items = self._drive(ToolContext(workspace_root=self.workspace))
+        self.assertEqual(gated_events, ["Stop"])
+        self.assertIsInstance(items[-1], StopHookResult)
+
+
+# ---------------------------------------------------------------------------
+# G5 — continuation nudge
+# ---------------------------------------------------------------------------
+
+
+class TestContinuationNudge(_Base):
+    def test_detector_matrix(self):
+        self.assertTrue(
+            detect_continuation_signal("So now I need to edit the file")
+        )
+        self.assertTrue(detect_continuation_signal("Let me run the tests"))
+        self.assertTrue(detect_continuation_signal("Time to fix the bug"))
+        # Completion markers win.
+        self.assertFalse(
+            detect_continuation_signal(
+                "Let me run through what we did — the task is complete."
+            )
+        )
+        # Short-only pattern: long "I'll ..." text does NOT match.
+        long_text = (
+            "I'll update the documentation later if needed, but for the "
+            "moment here is a detailed explanation of the architecture "
+            "and how the pieces fit together in this design."
+        )
+        self.assertFalse(detect_continuation_signal(long_text))
+        self.assertTrue(detect_continuation_signal("I'll update the file"))
+
+    def test_nudges_then_caps(self):
+        provider = _provider([_completion("So now I need to edit the file")])
+        msgs, terminal = _run(run_query(_params(self.workspace, provider)))
+        self.assertEqual(terminal.reason, "completed")
+        # The loop nudged MAX times (model kept signaling, never used tools)
+        # then completed; assistant yields = MAX+1 model calls.
+        from src.types.messages import AssistantMessage
+
+        assistant_count = sum(
+            1 for m in msgs if isinstance(m, AssistantMessage)
+        )
+        self.assertEqual(assistant_count, MAX_CONTINUATION_NUDGES + 1)
+
+    def test_completion_text_no_nudge(self):
+        provider = _provider([_completion("Done. Everything is complete.")])
+        msgs, terminal = _run(run_query(_params(self.workspace, provider)))
+        from src.types.messages import AssistantMessage
+
+        self.assertEqual(
+            sum(1 for m in msgs if isinstance(m, AssistantMessage)), 1
+        )
+
+
+# ---------------------------------------------------------------------------
+# G3 + G4 — /clear resets; compaction marks
+# ---------------------------------------------------------------------------
+
+
+class TestClearAndCompactionState(_Base):
+    def _latch_something(self):
+        # get_beta_header_latches returns the LIVE latches object (the
+        # fast_mode producer mutates it the same way, fast_mode.py:62-63).
+        get_beta_header_latches().fast_mode_header_latched = True
+        self.assertTrue(get_beta_header_latches().fast_mode_header_latched)
+
+    def test_registry_clear_resets_sections_and_latches(self):
+        from src.command_system.builtins import clear_command_call
+
+        self._latch_something()
+        context = mock.MagicMock()
+        clear_command_call("", context)
+        self.assertFalse(get_beta_header_latches().fast_mode_header_latched)
+        self.assertFalse(get_pending_post_compaction())  # /clear ≠ compaction
+
+    def test_compaction_success_marks_and_resets(self):
+        from src.services.compact.compact import (
+            CompactContext,
+            compact_conversation,
+        )
+        from src.types.messages import AssistantMessage
+
+        provider = mock.MagicMock()
+        provider.model = "main"
+
+        async def chat_async(*a, **k):
+            return ChatResponse(
+                content="A perfectly valid summary of the conversation.",
+                model="summarize-model",
+                usage={"input_tokens": 5, "output_tokens": 2},
+                finish_reason="end_turn",
+                tool_uses=None,
+            )
+
+        provider.chat_async = chat_async
+        context = CompactContext(
+            provider=provider,
+            model="summarize-model",
+            messages=[
+                UserMessage(content="hello " * 60),
+                AssistantMessage(content="world " * 60),
+                UserMessage(content="more " * 60),
+                AssistantMessage(content="words " * 60),
+            ],
+        )
+        result = _run(compact_conversation(context))
+        self.assertIsNotNone(result)
+        self.assertTrue(get_pending_post_compaction())
+        self.assertTrue(consume_post_compaction())  # consume-once works
+        self.assertFalse(get_pending_post_compaction())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Round-3 chapter-5 (agent loop) PR. The stop-hooks, token-budget, and post-compact libraries existed but were never integrated into the production `query()` loop — five previously never-produced loop outcomes now have producing paths and tests, in TS done-branch order (API-error guard → Stop hooks → token budget → continuation nudge → completed).

- **Stop/SubagentStop hooks at the clean exit** (`query.ts:1346-1391`): `prevent_continuation` → `stop_hook_prevented`; blocking errors → one retry with `stop_hook_active=True`, recovery counter reset, and `has_attempted_reactive_compact` **preserved** (the TS production incident: resetting it looped compacting forever). StopFailure hooks fire on all three error exits.
- **Death-spiral guard widened**: the recovery-exhausted max-output-tokens message carries `isApiErrorMessage=False` in the port (real partial content; TS's equivalent is synthetic with `true`, `claude.ts:2289-2295`) — it is now treated as an error exit so a blocking Stop hook cannot re-open the truncation spiral.
- **Token budget** (`query.ts:1393-1441`): `QueryParams.token_budget` + entry snapshot, gated to **top-level queries only** — a nested Agent-tool `query()` or a compact/session_memory sidechannel no longer clobbers the main turn's budget globals (TS snapshots only at the REPL surface, `REPL.tsx:2944`). Budget continuations append an isMeta nudge (never yielded) and are deliberately NOT capped by `MAX_CONTINUATION_NUDGES` — separate mechanisms.
- **Continuation nudge** (`query.ts:1443-1512`): exact regex port (completion markers first; 4 always-on + 2 short-only(<80) patterns), capped at 3.
- **Post-compaction state**: compaction success marks `pending_post_compaction` (consume-once; consumer is telemetry, deferred); `run_post_compact_cleanup` + both `/clear` surfaces reset system-prompt sections + beta-header latches; `/clear` does NOT mark. Two legacy cleanup tests updated: the section/latch reset is global state and now runs even with a None context.
- **`stop_hooks` gate fix**: gates on the same event the executor dispatches (`SubagentStop` when `agent_id` set) — SubagentStop-only configs previously never fired.

## Notes for future chapters

- A `query_source="compact"`/`"session_memory"` top-level query skips the snapshot but the done-branch budget *check* still reads the main turn's globals. No production caller hits this today (compact calls the provider directly; `run_agent` always sets `agent_id`); the ch13/14 `+500k` surface-parse work inherits the question.
- `pending_post_compaction` is marked at summarize-success (beside usage recording), slightly earlier than TS's commit-point marks — consume is unwired so impact is nil; revisit if a consumer lands.
- The TUI `__clear__` block is covered indirectly (it calls the same helpers as the registry `/clear` builtin, which is tested); a direct TUI test would pull Textual app construction into this suite.

## Test plan

- [x] 20 tests in `tests/test_query_loop_wires_round3.py` (stop-hook prevent/blocking-retry/regression, budget snapshot-scoping + anti-conflation + subagent/sidechannel preservation, nudge matrix + cap, /clear vs compaction marking, SubagentStop gate)
- [x] Guard-class fixes mutation-tested: each fix individually reverted → its pin fails (snapshot ungated 2F; guard narrowed 1F; reactive flag reset 1F; gate hardcoded "Stop" 1F)
- [x] Guard-5 production sequence pinned end-to-end: PTL → reactive compact → clean → hook blocks → PTL → terminal `prompt_too_long`, exactly one compact
- [x] Full suite: 7,875 passed / 9 failed = the documented pre-existing env baseline (parity e2e ×4, test_providers ×5)
- [x] Critic-reviewed: REVISE round (5 required items) addressed, then APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)