### PR TITLE
feat(ch06/round3): tool pipeline — skip-set aggregate, call-input discipline, fail-closed permissions

### DIFF
--- a/src/query/query.py
+++ b/src/query/query.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import os
 import re
 import sys
@@ -1078,8 +1079,11 @@ def _dispatch_single_tool(
                 # Update the running aggregate AFTER the block is
                 # finalized (post-persistence, so the wrapper message
                 # size is what counts toward the budget — not the
-                # original 200K output).
-                tool_use_context.tool_result_chars_so_far += compute_block_chars(api_block)
+                # original 200K output). Non-finite-threshold tools
+                # (Read) don't count — TS skip-set semantics
+                # (query.ts:419-423, toolResultStorage.ts:841-851).
+                if math.isfinite(tool.max_result_size_chars):
+                    tool_use_context.tool_result_chars_so_far += compute_block_chars(api_block)
             raw_content = api_block.get("content", "")
             # Preserve list-of-content-blocks shape so multimodal tool_results
             # (e.g. Read's image content blocks, bash data:image/... captures)

--- a/src/services/tool_execution/tool_execution.py
+++ b/src/services/tool_execution/tool_execution.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable
@@ -50,16 +51,21 @@ async def run_tool_use(
     tool_use_context: ToolContext,
 ) -> AsyncGenerator[MessageUpdateLazy, None]:
     from src.tool_system.build_tool import find_tool_by_name
-    from src.tool_system.registry import get_all_base_tools
 
     tool_name = tool_use.name
     tool = find_tool_by_name(tool_use_context.options.tools, tool_name)
 
     if tool is None:
+        # Old-transcript names and pool-hidden tools resolve through the
+        # FULL base-tool list (TS toolExecution.ts:335-341:
+        # findToolByName(getAllBaseTools(), toolName)). Not a permission
+        # bypass: resolution still runs downstream for the resolved tool.
         try:
-            from src.tool_system.registry import ToolRegistry
-            fallback_registry = ToolRegistry(tool_use_context.options.tools)
-            tool = fallback_registry.get(tool_name)
+            from src.tool_system.defaults import build_default_registry
+
+            tool = find_tool_by_name(
+                build_default_registry().list_tools(), tool_name
+            )
         except Exception:
             pass
 
@@ -205,13 +211,18 @@ async def _check_permissions_and_call_tool(
             logger.debug("Validation error for %s: %s", tool.name, e)
 
     # ----- Step 6 — Input Backfill (clone, not mutate).
-    # The original API-bound input is preserved (preserves prompt cache);
-    # the cloned, backfilled input is what hooks and permissions see.
-    # Mirrors typescript/src/services/tools/toolExecution.ts backfill step.
+    # call() receives the MODEL-ORIGINAL input: tool results embed input
+    # fields verbatim (e.g. "File created successfully at: {path}"), and
+    # changing them alters the serialized transcript. The cloned,
+    # backfilled input is the hooks/permissions audience only.
+    # Mirrors typescript/src/services/tools/toolExecution.ts:838-853.
+    call_input = processed_input
+    backfilled_clone: dict[str, Any] | None = None
     if tool.backfill_observable_input is not None:
         try:
             backfilled = dict(processed_input)
             tool.backfill_observable_input(backfilled)
+            backfilled_clone = backfilled
             processed_input = backfilled
         except Exception as e:
             logger.debug("backfill_observable_input error for %s: %s", tool.name, e)
@@ -295,7 +306,30 @@ async def _check_permissions_and_call_tool(
         call_context.tool_use_id = tool_use_id
         call_context.user_modified = permission_decision.get("userModified", False)
 
-        result = await _call_tool(tool, processed_input, call_context)
+        # If processed_input still points at the backfill clone, no
+        # hook/permission replaced it — pass the pre-backfill call_input so
+        # call() sees the model's original field values. Hook/permission
+        # flows may return a fresh object derived from the backfilled clone
+        # (e.g. via schema re-parse): if its file_path matches the
+        # backfill-expanded value, restore the model's original so the tool
+        # result string embeds the path the model emitted. Other
+        # modifications flow through unchanged. Mirrors
+        # typescript/src/services/tools/toolExecution.ts:1212-1237.
+        if (
+            backfilled_clone is not None
+            and processed_input is not call_input
+            and isinstance(processed_input, dict)
+            and "file_path" in processed_input
+            and isinstance(call_input, dict)
+            and "file_path" in call_input
+            and processed_input.get("file_path")
+            == backfilled_clone.get("file_path")
+        ):
+            call_input = {**processed_input, "file_path": call_input["file_path"]}
+        elif processed_input is not backfilled_clone:
+            call_input = processed_input
+
+        result = await _call_tool(tool, call_input, call_context)
 
         duration_ms = int((time.monotonic() - start_time) * 1000)
 
@@ -325,9 +359,15 @@ async def _check_permissions_and_call_tool(
             tool_results_dir=tool_results_dir,
             aggregate_chars_so_far=tool_use_context.tool_result_chars_so_far,
         )
-        tool_use_context.tool_result_chars_so_far += compute_block_chars(
-            tool_result_block,
-        )
+        # Non-finite-threshold tools (Read) are excluded from the aggregate
+        # — TS skip-set semantics (query.ts:419-423,
+        # toolResultStorage.ts:841-851): skipped tools neither get replaced
+        # nor count toward the budget. process_tool_result_block still runs
+        # for them (empty-content marker applies to ALL tools).
+        if math.isfinite(tool.max_result_size_chars):
+            tool_use_context.tool_result_chars_so_far += compute_block_chars(
+                tool_result_block,
+            )
 
         resulting_messages.append(MessageUpdateLazy(
             message=create_user_message(

--- a/src/services/tool_execution/tool_hooks.py
+++ b/src/services/tool_execution/tool_hooks.py
@@ -293,9 +293,30 @@ async def resolve_hook_permission_decision(
                     return decision
                 if hasattr(decision, "behavior"):
                     return {"behavior": decision.behavior, "message": getattr(decision, "message", None)}
+                return {
+                    "behavior": "deny",
+                    "message": (
+                        "Permission handler returned an unrecognized "
+                        f"decision for {tool.name}"
+                    ),
+                }
             except Exception as e:
                 logger.debug("can_use_tool error: %s", e)
-        return {"behavior": "allow"}
+                return {
+                    "behavior": "deny",
+                    "message": f"Permission handler failed for {tool.name}",
+                }
+        # FAIL CLOSED. TS cannot express a missing handler (canUseTool is a
+        # required field, query.ts:191), and the production lane's
+        # handlerless ask path denies the same way (handler.py:42-51) — an
+        # allow here would make every tool call permitted the moment a
+        # future caller forgets to wire can_use_tool.
+        return {
+            "behavior": "deny",
+            "message": (
+                f"Permission required but no handler available for {tool.name}"
+            ),
+        }
 
     if isinstance(hook_permission_result, dict):
         behavior = hook_permission_result.get("behavior")

--- a/src/services/tool_execution/tool_result_persistence.py
+++ b/src/services/tool_execution/tool_result_persistence.py
@@ -383,8 +383,12 @@ def maybe_persist_large_tool_result(
     # WI-5.1: per-message aggregate gate. Even when this block alone is
     # under ``threshold``, if adding it would push the running total
     # over ``aggregate_cap`` we persist it to disk to keep the message
-    # within budget. The TS reference checks the aggregate at the same
-    # point per ``toolLimits.ts:49`` semantics.
+    # within budget. DEVIATION: the TS reference enforces the aggregate
+    # ONLY at the wire (enforceToolResultBudget, with non-finite tools
+    # excluded from replacement AND counting via skipToolNames); the
+    # port decides at result-creation time instead — see
+    # my-docs/ch06-tools-round3-gap-analysis.md §3. Same 200K constant
+    # (toolLimits.ts:49); callers skip the counter for non-finite tools.
     aggregate_would_exceed = (aggregate_chars_so_far + size) > aggregate_cap
     if size <= threshold and not aggregate_would_exceed:
         return tool_result_block

--- a/src/tool_system/build_tool.py
+++ b/src/tool_system/build_tool.py
@@ -99,7 +99,6 @@ TOOL_DEFAULTS: dict[str, Any] = {
     "is_destructive": lambda _input: False,
     "check_permissions": lambda _input, _ctx: PermissionPassthroughResult(),
     "to_auto_classifier_input": lambda _input: "",
-    "user_facing_name": None,
 }
 
 

--- a/src/tool_system/tools/write.py
+++ b/src/tool_system/tools/write.py
@@ -220,7 +220,8 @@ def _write_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
     if not isinstance(content, str):
         raise ToolInputError("content must be a string")
 
-    # Path is already expanded by backfill_observable_input
+    # call() receives the MODEL-ORIGINAL path (backfill is the
+    # hooks/permissions audience only); both branches below self-expand.
     if _is_auto_memory_write(file_path):
         # Memory dir is outside the workspace allowlist; bypass it. The
         # auto-memory subsystem owns this path namespace and its own
@@ -262,7 +263,10 @@ def _write_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
         name="Write",
         output={
             "type": "update" if original_file is not None else "create",
-            "filePath": str(path),
+            # MODEL-ORIGINAL path, not the resolved one: tool results embed
+            # input fields verbatim (TS FileWriteTool.ts:377/:400 uses
+            # file_path for data.filePath; fullFilePath is fs/logging only).
+            "filePath": file_path,
             "content": content,
             "structuredPatch": hunks,
             "originalFile": original_file,

--- a/tests/test_tool_hooks.py
+++ b/tests/test_tool_hooks.py
@@ -33,13 +33,18 @@ def _make_assistant_msg() -> AssistantMessage:
 
 class TestResolveHookPermissionDecision:
     @pytest.mark.asyncio
-    async def test_no_hook_result_no_can_use_tool(self):
+    async def test_no_hook_result_no_can_use_tool_fails_closed(self):
+        # ch06 round-3: a missing permission handler DENIES. TS cannot
+        # express this state (canUseTool is required, query.ts:191); the
+        # old allow fallback made every tool call permitted whenever a
+        # caller forgot to wire can_use_tool.
         tool = _make_tool()
         ctx = _make_context()
         decision = await resolve_hook_permission_decision(
             None, tool, {}, ctx, None, _make_assistant_msg(), "tu_1"
         )
-        assert decision["behavior"] == "allow"
+        assert decision["behavior"] == "deny"
+        assert "no handler available" in decision["message"]
 
     @pytest.mark.asyncio
     async def test_hook_allow(self):

--- a/tests/test_tool_pipeline_round3.py
+++ b/tests/test_tool_pipeline_round3.py
@@ -1,0 +1,454 @@
+"""ch06 round-3 pipeline tests: aggregate skip-set (WI-1), call-input
+discipline (WI-2), base-tool lookup fallback (WI-3).
+
+Plan: my-docs/python-port-improvement-round-3/ch06-tools-round3-plan.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest import mock
+
+from src.services.tool_execution.tool_execution import run_tool_use
+from src.services.tool_execution.tool_result_persistence import (
+    MAX_TOOL_RESULTS_PER_MESSAGE_CHARS,
+    PERSISTED_OUTPUT_TAG,
+)
+from src.tool_system.build_tool import build_tool
+from src.tool_system.context import ToolContext, ToolUseOptions
+from src.tool_system.protocol import ToolResult
+from src.types.messages import AssistantMessage
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _ToolUse:
+    def __init__(self, name: str, input_: dict, id_: str = "toolu_r3_1"):
+        self.name = name
+        self.input = input_
+        self.id = id_
+
+
+_SCHEMA = {"type": "object", "properties": {}, "additionalProperties": True}
+
+
+def _stub_tool(name: str, call_fn, *, max_chars: float = 30_000, backfill=None):
+    return build_tool(
+        name=name,
+        input_schema=_SCHEMA,
+        call=call_fn,
+        prompt="stub",
+        description="stub",
+        max_result_size_chars=max_chars,
+        backfill_observable_input=backfill,
+    )
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _context(self, tools: list, mode: str = "bypassPermissions") -> ToolContext:
+        ctx = ToolContext(
+            workspace_root=self.workspace,
+            options=ToolUseOptions(tools=tools),
+        )
+        ctx.permission_context.mode = mode
+        return ctx
+
+    def _execute(self, ctx: ToolContext, tool_use: _ToolUse, can_use_tool=None) -> list:
+        # The services lane fails CLOSED without a permission handler, so
+        # tests that want execution must say so explicitly.
+        if can_use_tool is None:
+            def can_use_tool(*_a, **_k):
+                return {"behavior": "allow"}
+
+        async def drive():
+            updates = []
+            async for update in run_tool_use(
+                tool_use,
+                AssistantMessage(content="using a tool"),
+                can_use_tool,
+                ctx,
+            ):
+                updates.append(update)
+            return updates
+
+        return _run(drive())
+
+    @staticmethod
+    def _result_blocks(updates: list) -> list[dict]:
+        # Services lane yields dict blocks; the production lane wraps
+        # ToolResultBlock dataclass instances — normalize both to dicts.
+        blocks = []
+        for u in updates:
+            msg = getattr(u, "message", u)
+            content = getattr(msg, "content", None)
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "tool_result":
+                        blocks.append(block)
+                    elif hasattr(block, "tool_use_id") and hasattr(block, "content"):
+                        blocks.append({
+                            "type": "tool_result",
+                            "tool_use_id": block.tool_use_id,
+                            "content": block.content,
+                            "is_error": getattr(block, "is_error", False),
+                        })
+        return blocks
+
+
+# ---------------------------------------------------------------------------
+# WI-1 — aggregate counter skips non-finite-threshold tools
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateSkipSet(_Base):
+    def test_inf_tool_does_not_count_and_does_not_push_later_results(self):
+        big = "x" * (MAX_TOOL_RESULTS_PER_MESSAGE_CHARS + 50_000)
+        read_like = _stub_tool(
+            "ReadLike",
+            lambda _inp, _ctx: ToolResult(name="ReadLike", output=big),
+            max_chars=float("inf"),
+        )
+        small_tool = _stub_tool(
+            "SmallTool",
+            lambda _inp, _ctx: ToolResult(name="SmallTool", output="y" * 1_000),
+        )
+        ctx = self._context([read_like, small_tool])
+
+        updates = self._execute(ctx, _ToolUse("ReadLike", {}, "toolu_inf"))
+        blocks = self._result_blocks(updates)
+        self.assertEqual(len(blocks), 1)
+        # inf opt-out: content intact (pre-existing ad7e026 behavior)...
+        self.assertNotIn(PERSISTED_OUTPUT_TAG, str(blocks[0].get("content", "")))
+        # ...and (round-3) it does NOT count toward the aggregate.
+        self.assertEqual(ctx.tool_result_chars_so_far, 0)
+
+        updates2 = self._execute(ctx, _ToolUse("SmallTool", {}, "toolu_small"))
+        blocks2 = self._result_blocks(updates2)
+        self.assertEqual(len(blocks2), 1)
+        # The Read fan-out must not force-persist a later small result.
+        self.assertNotIn(PERSISTED_OUTPUT_TAG, str(blocks2[0].get("content", "")))
+        self.assertEqual(ctx.tool_result_chars_so_far, 1_000)
+
+    def test_finite_tool_still_force_persisted_at_cap_boundary(self):
+        small_tool = _stub_tool(
+            "SmallTool",
+            lambda _inp, _ctx: ToolResult(name="SmallTool", output="y" * 1_000),
+        )
+        ctx = self._context([small_tool])
+        ctx.tool_result_chars_so_far = MAX_TOOL_RESULTS_PER_MESSAGE_CHARS - 100
+
+        updates = self._execute(ctx, _ToolUse("SmallTool", {}, "toolu_cap"))
+        blocks = self._result_blocks(updates)
+        self.assertEqual(len(blocks), 1)
+        self.assertIn(PERSISTED_OUTPUT_TAG, str(blocks[0].get("content", "")))
+        # Counter grows by the wrapper size (~header + preview), not an
+        # unbounded original.
+        self.assertLess(
+            ctx.tool_result_chars_so_far,
+            MAX_TOOL_RESULTS_PER_MESSAGE_CHARS + 2_500,
+        )
+
+
+class TestProductionLaneAggregate(_Base):
+    def test_production_dispatch_skips_inf_tool_counting(self):
+        # The PRODUCTION lane (query._dispatch_single_tool -> registry
+        # dispatch) has its own counter site — pin its skip-set gate too.
+        from src.query.query import _dispatch_single_tool
+        from src.tool_system.registry import ToolRegistry
+
+        big = "x" * (MAX_TOOL_RESULTS_PER_MESSAGE_CHARS + 50_000)
+        read_like = _stub_tool(
+            "ReadLike",
+            lambda _i, _c: ToolResult(name="ReadLike", output=big),
+            max_chars=float("inf"),
+        )
+        small_tool = _stub_tool(
+            "SmallTool",
+            lambda _i, _c: ToolResult(name="SmallTool", output="y" * 1_000),
+        )
+        registry = ToolRegistry([read_like, small_tool])
+        ctx = self._context([read_like, small_tool])
+
+        primary, _extras = _dispatch_single_tool(
+            SimpleNamespace(name="ReadLike", input={}, id="toolu_prod_inf"),
+            registry,
+            ctx,
+            [read_like, small_tool],
+        )
+        self.assertEqual(ctx.tool_result_chars_so_far, 0)
+        blocks = self._result_blocks([primary])
+        self.assertEqual(len(blocks), 1)
+        self.assertNotIn(PERSISTED_OUTPUT_TAG, str(blocks[0].get("content", "")))
+
+        primary2, _ = _dispatch_single_tool(
+            SimpleNamespace(name="SmallTool", input={}, id="toolu_prod_small"),
+            registry,
+            ctx,
+            [read_like, small_tool],
+        )
+        blocks2 = self._result_blocks([primary2])
+        self.assertNotIn(PERSISTED_OUTPUT_TAG, str(blocks2[0].get("content", "")))
+        self.assertEqual(ctx.tool_result_chars_so_far, 1_000)
+
+
+# ---------------------------------------------------------------------------
+# WI-2 — call() input discipline (TS toolExecution.ts:838-853, 1212-1237)
+# ---------------------------------------------------------------------------
+
+
+def _backfill_expand(inp: dict[str, Any]) -> None:
+    fp = inp.get("file_path")
+    if isinstance(fp, str):
+        inp["file_path"] = "/abs/expanded/" + fp.lstrip("~/")
+    inp["_resolved"] = True
+
+
+class TestCallInputDiscipline(_Base):
+    def _seen_call_input(self, hook_results=None) -> dict:
+        seen: dict[str, Any] = {}
+
+        def call(inp, _ctx):
+            seen.update({"input": inp})
+            return ToolResult(name="BackfillTool", output="ok")
+
+        tool = _stub_tool("BackfillTool", call, backfill=_backfill_expand)
+        ctx = self._context([tool])
+
+        if hook_results is None:
+            self._execute(ctx, _ToolUse("BackfillTool", {"file_path": "~/orig.txt"}))
+        else:
+            async def fake_hooks(_ctx, _tool, processed_input, _tid):
+                for r in hook_results(processed_input):
+                    yield r
+
+            with mock.patch(
+                "src.services.tool_execution.tool_hooks.run_pre_tool_use_hooks",
+                fake_hooks,
+            ):
+                self._execute(
+                    ctx, _ToolUse("BackfillTool", {"file_path": "~/orig.txt"})
+                )
+        return seen["input"]
+
+    def test_no_hook_call_sees_model_original_file_path(self):
+        got = self._seen_call_input()
+        # Branch 1 (no-hook): {**clone, file_path: original} — original
+        # path restored, other backfilled keys flow through.
+        self.assertEqual(got["file_path"], "~/orig.txt")
+        self.assertTrue(got.get("_resolved"))
+
+    def test_hook_echoing_clone_restores_original_file_path(self):
+        def echo_with_marker(processed_input):
+            fresh = dict(processed_input)  # fresh object, same file_path
+            fresh["_hook_marker"] = True
+            return [{"type": "hookUpdatedInput", "updatedInput": fresh}]
+
+        got = self._seen_call_input(echo_with_marker)
+        self.assertEqual(got["file_path"], "~/orig.txt")   # restored
+        self.assertTrue(got.get("_hook_marker"))           # hook change kept
+
+    def test_hook_with_different_file_path_converges_fully(self):
+        def rewrite(_processed_input):
+            return [{
+                "type": "hookUpdatedInput",
+                "updatedInput": {"file_path": "/hook/chose/this.txt"},
+            }]
+
+        got = self._seen_call_input(rewrite)
+        self.assertEqual(got["file_path"], "/hook/chose/this.txt")
+
+    def test_write_relative_path_e2e_result_embeds_model_original(self):
+        from src.tool_system.defaults import build_default_registry
+
+        registry = build_default_registry()
+        write_tool = next(
+            t for t in registry.list_tools() if t.name == "Write"
+        )
+        target_name = "ch06_r3_e2e_target.txt"
+        ctx = self._context([write_tool])
+        updates = self._execute(
+            ctx,
+            _ToolUse(
+                "Write",
+                {"file_path": target_name, "content": "hello round 3"},
+            ),
+        )
+        target = self.workspace / target_name
+        self.assertTrue(target.exists())
+        self.assertEqual(target.read_text(), "hello round 3")
+        # A cwd regression must fail loudly, not litter the repo root.
+        self.assertFalse((Path.cwd() / target_name).exists())
+        blocks = self._result_blocks(updates)
+        text = str(blocks[0].get("content", "")) if blocks else ""
+        joined = text + "".join(
+            str(getattr(getattr(u, "message", u), "toolUseResult", ""))
+            for u in updates
+        )
+        # TS parity: the result embeds the MODEL-ORIGINAL path, not the
+        # backfill-expanded absolute path.
+        self.assertIn(target_name, joined)
+        self.assertNotIn(str(self.workspace / target_name), joined)
+
+
+# ---------------------------------------------------------------------------
+# WI-3 — base-tool lookup fallback (TS toolExecution.ts:335-341)
+# ---------------------------------------------------------------------------
+
+
+class TestBaseToolFallback(_Base):
+    def test_pool_hidden_tool_resolves_via_base_list(self):
+        ran: list = []
+
+        def call(_inp, _ctx):
+            ran.append(True)
+            return ToolResult(name="HiddenTool", output="ran")
+
+        hidden = _stub_tool("HiddenTool", call)
+        fake_registry = SimpleNamespace(list_tools=lambda: [hidden])
+
+        ctx = self._context([])  # NOT in the active pool
+        with mock.patch(
+            "src.tool_system.defaults.build_default_registry",
+            return_value=fake_registry,
+        ):
+            updates = self._execute(ctx, _ToolUse("HiddenTool", {}))
+        self.assertTrue(ran)
+        blocks = self._result_blocks(updates)
+        self.assertFalse(blocks[0].get("is_error", False))
+
+    def test_unknown_name_still_errors(self):
+        ctx = self._context([])
+        updates = self._execute(ctx, _ToolUse("NoSuchToolEver", {}))
+        blocks = self._result_blocks(updates)
+        self.assertEqual(len(blocks), 1)
+        self.assertTrue(blocks[0].get("is_error"))
+        self.assertIn("No such tool available", str(blocks[0].get("content", "")))
+
+    def test_fallback_resolved_tool_still_goes_through_permissions(self):
+        # The fallback is not a permission bypass: in the services lane,
+        # permission resolution (can_use_tool) still runs for a
+        # fallback-resolved tool, and a deny stops call().
+        ran: list = []
+
+        def call(_inp, _ctx):
+            ran.append(True)
+            return ToolResult(name="HiddenTool", output="ran")
+
+        hidden = _stub_tool("HiddenTool", call)
+        fake_registry = SimpleNamespace(list_tools=lambda: [hidden])
+
+        def deny_all(*_a, **_k):
+            return {"behavior": "deny", "message": "denied by policy"}
+
+        ctx = self._context([])
+        with mock.patch(
+            "src.tool_system.defaults.build_default_registry",
+            return_value=fake_registry,
+        ):
+            async def drive():
+                updates = []
+                async for update in run_tool_use(
+                    _ToolUse("HiddenTool", {}),
+                    AssistantMessage(content="using a tool"),
+                    deny_all,
+                    ctx,
+                ):
+                    updates.append(update)
+                return updates
+
+            updates = _run(drive())
+        self.assertFalse(ran)
+        blocks = self._result_blocks(updates)
+        self.assertEqual(len(blocks), 1)
+        self.assertTrue(blocks[0].get("is_error"))
+        self.assertIn("denied by policy", str(blocks[0].get("content", "")))
+
+    def test_services_lane_fails_closed_without_handler(self):
+        # No can_use_tool → deny, call() never runs (TS cannot express a
+        # missing handler; the production lane's handlerless ask path
+        # denies the same way).
+        ran: list = []
+
+        def call(_inp, _ctx):
+            ran.append(True)
+            return ToolResult(name="NoHandlerTool", output="ran")
+
+        tool = _stub_tool("NoHandlerTool", call)
+        ctx = self._context([tool])
+
+        async def drive():
+            updates = []
+            async for update in run_tool_use(
+                _ToolUse("NoHandlerTool", {}),
+                AssistantMessage(content="using a tool"),
+                None,
+                ctx,
+            ):
+                updates.append(update)
+            return updates
+
+        updates = _run(drive())
+        self.assertFalse(ran)
+        blocks = self._result_blocks(updates)
+        self.assertTrue(blocks[0].get("is_error"))
+        self.assertIn("no handler available", str(blocks[0].get("content", "")))
+
+    def test_services_lane_fails_closed_on_throwing_handler(self):
+        ran: list = []
+
+        def call(_inp, _ctx):
+            ran.append(True)
+            return ToolResult(name="ThrowTool", output="ran")
+
+        def exploding_handler(*_a, **_k):
+            raise RuntimeError("handler crashed")
+
+        tool = _stub_tool("ThrowTool", call)
+        ctx = self._context([tool])
+        updates = self._execute(
+            ctx, _ToolUse("ThrowTool", {}), can_use_tool=exploding_handler
+        )
+        self.assertFalse(ran)
+        blocks = self._result_blocks(updates)
+        self.assertTrue(blocks[0].get("is_error"))
+        self.assertIn("Permission handler failed", str(blocks[0].get("content", "")))
+
+    def test_production_lane_plan_mode_denies_write_tool_handlerless(self):
+        # PRODUCTION lane (registry.dispatch): plan mode without a
+        # bypass grant resolves a write-ish tool to ask; with no
+        # permission handler the ask fails CLOSED and call() never runs.
+        from src.tool_system.registry import ToolRegistry, ToolCall
+
+        ran: list = []
+
+        def call(_inp, _ctx):
+            ran.append(True)
+            return ToolResult(name="PlanWrite", output="ran")
+
+        tool = _stub_tool("PlanWrite", call)
+        registry = ToolRegistry([tool])
+        ctx = self._context([tool], mode="plan")
+        result = registry.dispatch(
+            ToolCall(name="PlanWrite", input={}, tool_use_id="toolu_plan"),
+            ctx,
+        )
+        self.assertTrue(result.is_error)
+        self.assertFalse(ran)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Round-3 chapter-6 (tools) PR. A small-scope chapter by design — round 2 landed most of the tool system (per-tool limits, pool ordering, bash classification, grep pagination, edit staleness all verified at parity) — so this PR closes the verified residue plus two findings discovered during implementation.

- **Aggregate skip-set (TS `query.ts:419-423`, `toolResultStorage.ts:841-851`)**: Read (∞-threshold) results no longer count toward the 200K per-message tool-result budget at either counter site (services pipeline + production in-loop). Heavy Read fan-outs were prematurely force-persisting later small results. The persistence half of the opt-out was already fixed by `ad7e026`; this completes the counting half and corrects a false TS-parity comment (TS enforces the aggregate only at the wire, with non-finite tools excluded from both replacement and counting).
- **call() input discipline (TS `toolExecution.ts:838-853`, `:1212-1237`, ported literally)**: `call()` receives the model-original input; the backfilled clone is the hooks/permissions audience only; a hook that echoes the clone gets the original `file_path` restored. Tool results embed input fields verbatim — this keeps transcripts stable. **Write's structured `filePath` now carries the input value** (TS `FileWriteTool.ts:377/:400`; `fullFilePath` is fs/logging only). Guard noted in the gap doc: Edit/Read keep resolved paths on purpose (TS `absoluteFilePath`).
- **Base-tool lookup fallback made real (TS `toolExecution.ts:335-341`)**: old-transcript names and pool-hidden tools resolve through `build_default_registry()`; the previous "fallback" re-indexed the same active list. Permission resolution still runs for fallback-resolved tools (pinned).
- **Fail-closed permission default (behavioral change, services lane)**: `resolve_hook_permission_decision` now denies on all three no-decision prongs (missing / throwing / unrecognized-shape handler) instead of allowing. TS cannot express these states (`canUseTool` is a required field, `query.ts:191`); the production lane's handlerless ask path already denied identically (`handler.py:42-51`). Any future direct caller of `run_tool_use` must supply `can_use_tool` to execute tools. One legacy test pinning the old fail-open updated with rationale.

## Architecture finding recorded (no code change): the two-lane pipeline

The gap analysis (my-docs, G6) documents that production dispatch (`query._dispatch_single_tool` → `registry.dispatch`) is a slim lane — PreToolUse/PostToolUse hooks and input backfill never run on it today; the full 14-step lane (`run_tool_use`) is consumed only by the ch07-unwired streaming executor. **ch07 inherits lane unification** with a precise wiring contract (including passing the loop's real `can_use_tool`). Other deferrals: PermissionDenied firing + speculative classifier + hook `if`-condition evaluation/matchers → ch12; sed simulation → ch13/14; replacement-record resume → ch16; wire-level ContentReplacementState kept as a documented deviation (creation-time budgeting is prefix-stable and resume is unported).

## Test plan

- [x] 13 new tests in `tests/test_tool_pipeline_round3.py`: aggregate gates on BOTH lanes, cap-boundary force-persist pin, three convergence branches, Write `~`/relative-path e2e (asserts the result embeds the model-original path; includes a cwd-regression tripwire), fallback resolve/error/permission pins, fail-closed handler pins (production plan-mode + services-lane missing/throwing handler)
- [x] Guard-class fixes mutation-tested — each reverted fix fails its pin (including one mutation that initially SURVIVED, which exposed the production-lane counter site as uncovered and produced its test)
- [x] Broad selection (tool/pipeline/registry/permission/write/budget/persist/hook/orchestr/streaming): 2,050+ passed, failures = baseline subset only (`test_write_outside_workspace_blocked` re-verified identical under git stash on the clean tree)
- [x] Full suite: 7,888 passed / 9 failed = the documented pre-existing env baseline
- [x] Critic-reviewed: gap-doc REVISE → rev-2 APPROVE; plan REVISE (4 corrections) applied; implementation REVISE (5 items incl. the fail-closed flip) → delta APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)