### PR TITLE
feat(ch07/round3): unify production tool execution onto the orchestrator lane

### DIFF
--- a/src/query/config.py
+++ b/src/query/config.py
@@ -14,7 +14,10 @@ class QueryConfig:
     effort: str = "high"
     temperature: float | None = None
     stop_sequences: list[str] | None = None
-    streaming_tool_execution: bool = True
+    # ch07 round-3: default False — PR-1 lands the TS UNGATED path
+    # (batch orchestrator); PR-2 owns wiring the streaming executor and
+    # any flip to True (TS gates via Statsig tengu_streaming_tool_execution2).
+    streaming_tool_execution: bool = False
     reactive_compact_enabled: bool = True
     context_collapse_enabled: bool = False
     token_budget_enabled: bool = True
@@ -42,7 +45,10 @@ class FrozenQueryConfig:
     effort: str = "high"
     temperature: float | None = None
     stop_sequences: tuple[str, ...] | None = None
-    streaming_tool_execution: bool = True
+    # ch07 round-3: default False — PR-1 lands the TS UNGATED path
+    # (batch orchestrator); PR-2 owns wiring the streaming executor and
+    # any flip to True (TS gates via Statsig tengu_streaming_tool_execution2).
+    streaming_tool_execution: bool = False
     reactive_compact_enabled: bool = True
     context_collapse_enabled: bool = False
     token_budget_enabled: bool = True

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -20,7 +20,7 @@ from ..types.messages import (
     create_assistant_api_error_message,
 )
 from ..types.content_blocks import TextBlock, ToolResultBlock, ToolUseBlock
-from ..tool_system.build_tool import Tool, Tools, find_tool_by_name
+from ..tool_system.build_tool import Tool, Tools
 from ..tool_system.context import ToolContext
 from ..tool_system.protocol import ToolCall, ToolResult
 from ..tool_system.registry import ToolRegistry
@@ -308,14 +308,13 @@ def _is_hook_stopped_continuation(msg: Message | None) -> bool:
     next turn — mirroring TS at query.ts:1698-1701.
 
     The attachment is produced by ``PreToolUse`` / ``PostToolUse`` hooks
-    that set ``prevent_continuation`` — see
-    ``src/services/tool_execution/tool_execution.py:362-372`` and
-    ``src/services/tool_execution/tool_hooks.py:185-195``. The current
-    production dispatch path (``_run_tools_partitioned`` → registry
-    dispatch) does NOT route through those producers — that wiring is
-    the C7 architectural-unification gap, deferred. Landing the terminal
-    mapping here means the contract is in place the moment any future
-    change wires hook-aware dispatch into the loop.
+    that set ``prevent_continuation`` (see
+    ``src/services/tool_execution/tool_execution.py`` and
+    ``tool_hooks.py``). WIRED at ch07 round-3 PR-1: the production loop
+    consumes orchestrator.run_tools, which routes through those
+    producers; detection happens IN the consumption loop (the attachment
+    never reaches the collected tool_results under raw user-role
+    collection).
 
     Local import of ``AttachmentMessage`` matches the pattern at
     ``_drain_pending_user_messages`` — keeps the top-level import list
@@ -887,382 +886,6 @@ async def _call_model_sync(
 
 
 # Max tools to run in parallel (TS default: 10, configurable via env var).
-# Reads CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY (the name documented in
-# chapter 7 and used in the TS reference). Falls back to the legacy
-# CLAWCODEX_MAX_TOOL_USE_CONCURRENCY with a DeprecationWarning so
-# users learn to migrate.
-def _resolve_max_tool_use_concurrency() -> int:
-    canonical = os.environ.get("CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY")
-    if canonical is not None:
-        return int(canonical)
-    legacy = os.environ.get("CLAWCODEX_MAX_TOOL_USE_CONCURRENCY")
-    if legacy is not None:
-        import warnings
-        warnings.warn(
-            "CLAWCODEX_MAX_TOOL_USE_CONCURRENCY is deprecated; use "
-            "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return int(legacy)
-    return 10
-
-
-MAX_TOOL_USE_CONCURRENCY = _resolve_max_tool_use_concurrency()
-
-
-@dataclass
-class _ToolBatch:
-    """A batch of tool_use blocks with the same concurrency classification."""
-    is_concurrent_safe: bool
-    blocks: list[ToolUseBlock]
-
-
-def _partition_tool_calls(
-    tool_use_blocks: list[ToolUseBlock],
-    tools: Tools,
-) -> list[_ToolBatch]:
-    """Partition tool calls into batches per TS partitionToolCalls().
-
-    Consecutive ConcurrencySafe tools are grouped for parallel execution.
-    Non-safe tools each get their own exclusive batch.
-
-    Mirrors TS: evaluates isConcurrencySafe per-call with actual tool input
-    (not a static lookup), so e.g. read-only Bash commands can be parallel.
-    """
-    batches: list[_ToolBatch] = []
-    for block in tool_use_blocks:
-        tool = find_tool_by_name(tools, block.name)
-        try:
-            is_safe = bool(tool.is_concurrency_safe(block.input)) if tool else False
-        except Exception:
-            is_safe = False
-        if batches and is_safe and batches[-1].is_concurrent_safe:
-            batches[-1].blocks.append(block)
-        else:
-            batches.append(_ToolBatch(is_concurrent_safe=is_safe, blocks=[block]))
-    return batches
-
-
-def _is_user_cancelled_abort(tool_use_context: ToolContext) -> bool:
-    """True iff the abort signal fired with a user-initiated reason.
-
-    ``sibling_error`` is the streaming-executor's parallel-tool cascade
-    and is NOT a user-rejected signal — surfacing REJECT_MESSAGE for it
-    would mask the real underlying failure. Every other abort reason in
-    the Python runtime (``user_interrupt`` from ESC, ``interrupt`` held
-    in reserve for TS parity) is collapsed into the user-cancelled
-    bucket here.
-
-    Divergence vs TS: ``StreamingToolExecutor.ts:219-229`` treats
-    ``'interrupt'`` (user typed mid-stream) and ``'user_interrupted'``
-    (ESC) differently — for ``'interrupt'`` it only synthesizes
-    REJECT_MESSAGE on tools whose ``interruptBehavior() === 'cancel'``.
-    Python today emits neither ``'interrupt'`` nor any per-tool
-    ``interrupt_behavior`` override on the production path, so the
-    collapsed check is sound. If a future change wires up
-    ``'interrupt'`` as a real reason, the per-tool gate must land first.
-    """
-    ctrl = tool_use_context.abort_controller
-    if not ctrl.signal.aborted:
-        return False
-    return ctrl.signal.reason != "sibling_error"
-
-
-def _build_user_cancelled_result(tool_use_id: str) -> UserMessage:
-    """Synthetic tool_result returned when the user aborts mid-run.
-
-    The bash tool's interrupted path emits
-    ``<error>Command was aborted before completion</error>``, which the
-    model reads as a generic command failure — on the next turn it tends
-    to retry the command rather than honour the user's cancel. Replacing
-    the tool_result with REJECT_MESSAGE makes the cancellation
-    unambiguous. Mirrors
-    ``typescript/src/services/tools/StreamingToolExecutor.ts:153-205``
-    (``createSyntheticErrorMessage`` for ``user_interrupted``).
-    """
-    from ..types.messages import REJECT_MESSAGE
-    return UserMessage(
-        content=[
-            ToolResultBlock(
-                tool_use_id=tool_use_id,
-                content=REJECT_MESSAGE,
-                is_error=True,
-            )
-        ],
-    )
-
-
-def _dispatch_single_tool(
-    block: ToolUseBlock,
-    tool_registry: ToolRegistry,
-    tool_use_context: ToolContext,
-    tools: Tools | None = None,
-) -> tuple[UserMessage, list[UserMessage]]:
-    """Dispatch a single tool and return ``(primary, extras)``.
-
-    ``primary`` is always the tool_result UserMessage. ``extras`` is any
-    supplemental ``new_messages`` the tool returned (e.g. the image
-    dimensions metadata user message). Callers MUST emit all primaries
-    before any extras across a multi-tool batch — otherwise tool_result
-    pairing in ``ensure_tool_result_pairing`` mis-attributes the missing
-    pair and injects a synthetic error placeholder.
-
-    Routes through ``process_tool_result_block`` (mirrors TS Step 11 of
-    the execution pipeline at ``processToolResultBlock``) so the per-tool
-    persistence threshold AND the WI-5.1 per-message aggregate budget
-    both engage on the production path. The running aggregate is held on
-    ``tool_use_context.tool_result_chars_so_far`` (reset at the top of
-    each per-turn loop in :func:`query`).
-    """
-    # Pre-tool gate: ESC may trip after the model picked this tool but
-    # before we entered dispatch (e.g. between the post-streaming abort
-    # check and the head of the partition loop). Hand back the
-    # synthetic result instead of running the tool. Mirrors the initial-
-    # abort branch in ``StreamingToolExecutor.collectResults``
-    # (typescript/src/services/tools/StreamingToolExecutor.ts:278-292).
-    if _is_user_cancelled_abort(tool_use_context):
-        return _build_user_cancelled_result(block.id), []
-
-    try:
-        call = ToolCall(
-            name=block.name,
-            input=block.input,
-            tool_use_id=block.id,
-        )
-        result = tool_registry.dispatch(call, tool_use_context)
-
-        # Post-tool override: bash's interrupted payload reads as a
-        # generic failure; replace it so the resume turn sees an
-        # unambiguous "user rejected" signal. Mirrors TS at
-        # ``StreamingToolExecutor.ts:332-345``.
-        if _is_user_cancelled_abort(tool_use_context):
-            return _build_user_cancelled_result(block.id), []
-
-        tool = find_tool_by_name(tools, block.name) if tools else None
-        metadata: dict[str, Any] = {}
-        if isinstance(result.output, dict):
-            metadata["tool_output"] = result.output
-
-        if tool is not None:
-            # WI-5.1: route through ``process_tool_result_block`` so the
-            # 200K per-message aggregate cap is enforced. Without this
-            # call the production REPL ran ``map_result_to_api`` directly
-            # and never engaged the gate (critic B2).
-            #
-            # The read-decide-write on ``tool_result_chars_so_far`` is
-            # serialized via ``_aggregate_lock`` because ``_run_tools_partitioned``
-            # dispatches concurrency-safe tools (Read/Grep/Glob) via
-            # ``asyncio.to_thread`` (critic B6). The decision MUST be
-            # made on a fresh snapshot of the counter — otherwise N
-            # threads racing the read all see 0, all decide "under cap"
-            # and the cap is silently bypassed. ``process_tool_result_block``
-            # is called inside the critical section: for small blocks
-            # under threshold it just returns the block (no I/O); the
-            # rare persist-to-disk path runs while serialized but those
-            # are at most O(1) per turn (typically <5%).
-            from ..services.tool_execution.tool_result_persistence import (
-                compute_block_chars,
-                process_tool_result_block,
-                resolve_tool_results_dir,
-            )
-            tool_results_dir = resolve_tool_results_dir(tool_use_context)
-            with tool_use_context._aggregate_lock:
-                aggregate_so_far = tool_use_context.tool_result_chars_so_far
-                api_block = process_tool_result_block(
-                    tool,
-                    result.output,
-                    block.id,
-                    tool_results_dir=tool_results_dir,
-                    aggregate_chars_so_far=aggregate_so_far,
-                )
-                # Update the running aggregate AFTER the block is
-                # finalized (post-persistence, so the wrapper message
-                # size is what counts toward the budget — not the
-                # original 200K output). Non-finite-threshold tools
-                # (Read) don't count — TS skip-set semantics
-                # (query.ts:419-423, toolResultStorage.ts:841-851).
-                if math.isfinite(tool.max_result_size_chars):
-                    tool_use_context.tool_result_chars_so_far += compute_block_chars(api_block)
-            raw_content = api_block.get("content", "")
-            # Preserve list-of-content-blocks shape so multimodal tool_results
-            # (e.g. Read's image content blocks, bash data:image/... captures)
-            # reach the API as proper image/document blocks instead of being
-            # JSON-stringified into text. The Anthropic API rejects images
-            # delivered as text and the model just sees JSON gibberish in the
-            # tool_result content otherwise. ``ToolResultBlock.content`` and
-            # ``content_block_to_dict`` already handle list shape end-to-end
-            # (see content_blocks.py:159-173).
-            if isinstance(raw_content, (str, list)):
-                result_content: str | list[Any] = raw_content
-            else:
-                result_content = str(raw_content)
-        elif isinstance(result.output, str):
-            result_content = result.output
-        elif isinstance(result.output, dict):
-            result_content = json.dumps(result.output, ensure_ascii=False)
-        else:
-            result_content = str(result.output)
-
-        result_msg = UserMessage(
-            content=[
-                ToolResultBlock(
-                    tool_use_id=block.id,
-                    content=result_content,
-                    is_error=result.is_error,
-                    metadata=metadata,
-                )
-            ],
-        )
-        # Collect any supplemental messages the tool produced (e.g. the
-        # FileReadTool image-dimensions metadata user message and PDF
-        # page-image blocks). Mirrors TS messages flow where the Read
-        # tool's createUserMessage({isMeta:true}) returns are pushed
-        # into the conversation alongside the tool_result. Returned
-        # separately so callers can emit all primaries before any extras
-        # (see docstring).
-        extras: list[UserMessage] = []
-        if result.new_messages:
-            for msg in result.new_messages:
-                if isinstance(msg, UserMessage):
-                    extras.append(msg)
-                elif isinstance(msg, dict):
-                    # Defensive: accept the raw-dict form too.
-                    extras.append(UserMessage(
-                        content=msg.get("content", ""),
-                        isMeta=bool(msg.get("isMeta", False)),
-                    ))
-        return result_msg, extras
-    except AbortError as abort_err:
-        # Two contracts to satisfy at once:
-        #
-        # 1. **tool_use/tool_result pairing must stay intact** — every
-        #    emitted tool_use needs a paired tool_result or the next
-        #    API call 400s on the orphan. Returning a tool_result
-        #    (not raising) preserves the pair. Pinned by
-        #    ``tests/test_esc_reject_message_dispatch.py``.
-        # 2. **No follow-up API turn after AbortError** — the loop
-        #    must NOT issue another model call. Pinned by
-        #    ``test_agent_loop_does_not_swallow_abort_error_as_tool_error``.
-        #
-        # Reconcile both: when AbortError surfaces from a tool and
-        # the user-cancel signal isn't already tripped, trip it. The
-        # post-tool gate downstream sees the signal aborted, sets
-        # terminal=aborted_tools, and the adapter raises AbortError
-        # to the caller. The conversation ends well-formed (tool_use
-        # has its tool_result) AND the loop exits without another
-        # API turn. Critic-flagged on Stage 4 review.
-        if _is_user_cancelled_abort(tool_use_context):
-            return _build_user_cancelled_result(block.id), []
-        ctrl = getattr(tool_use_context, "abort_controller", None)
-        if ctrl is not None:
-            try:
-                ctrl.abort("tool_raised_abort_error")
-            except Exception:
-                pass
-        return UserMessage(
-            content=[
-                ToolResultBlock(
-                    tool_use_id=block.id,
-                    content=f"Error: Tool execution aborted ({abort_err})",
-                    is_error=True,
-                )
-            ],
-        ), []
-    except Exception as e:
-        # A late abort can still race the post-tool gate above (the
-        # signal trips between the post-tool check and the exception).
-        # Honour it here so a tool that raises an unrelated error AFTER
-        # ESC landed doesn't get reported as a tool bug when the user
-        # actually pressed ESC.
-        if _is_user_cancelled_abort(tool_use_context):
-            return _build_user_cancelled_result(block.id), []
-        error_str = f"Error: {e}"
-        return UserMessage(
-            content=[
-                ToolResultBlock(
-                    tool_use_id=block.id,
-                    content=error_str,
-                    is_error=True,
-                )
-            ],
-        ), []
-
-
-async def _run_tools_partitioned(
-    tool_use_blocks: list[ToolUseBlock],
-    tool_registry: ToolRegistry,
-    tool_use_context: ToolContext,
-    tools: Tools,
-) -> list[UserMessage]:
-    """Run tools with TS-matching concurrency: safe tools parallel, unsafe exclusive.
-
-    Mirrors typescript/src/tools/partitionToolCalls + runTools (Mode 2).
-    ConcurrencySafe tools (Read, Grep, Glob, etc.) run in parallel up to
-    MAX_TOOL_USE_CONCURRENCY.  Non-safe tools (Bash, Edit, Write) run
-    exclusively one at a time.
-    """
-    batches = _partition_tool_calls(tool_use_blocks, tools)
-    # Emit all primary tool_result messages first, then all supplemental
-    # (isMeta) messages. Interleaving (e.g. [a_result, a_meta, b_result])
-    # breaks ensure_tool_result_pairing because the merge guard refuses to
-    # combine tool_result-bearing user messages with text-only ones, so
-    # b_result becomes orphaned and the pairing logic injects a synthetic
-    # "[Tool result missing due to internal error]" placeholder.
-    primaries: list[UserMessage] = []
-    extras: list[UserMessage] = []
-
-    def _accumulate(pair: tuple[UserMessage, list[UserMessage]]) -> None:
-        primaries.append(pair[0])
-        extras.extend(pair[1])
-
-    for batch in batches:
-        if batch.is_concurrent_safe and len(batch.blocks) > 1:
-            coros = [
-                asyncio.to_thread(
-                    _dispatch_single_tool, block, tool_registry, tool_use_context, tools,
-                )
-                for block in batch.blocks[:MAX_TOOL_USE_CONCURRENCY]
-            ]
-            for pair in await asyncio.gather(*coros):
-                _accumulate(pair)
-            if len(batch.blocks) > MAX_TOOL_USE_CONCURRENCY:
-                overflow = [
-                    asyncio.to_thread(
-                        _dispatch_single_tool, block, tool_registry, tool_use_context, tools,
-                    )
-                    for block in batch.blocks[MAX_TOOL_USE_CONCURRENCY:]
-                ]
-                for pair in await asyncio.gather(*overflow):
-                    _accumulate(pair)
-        else:
-            for block in batch.blocks:
-                pair = await asyncio.to_thread(
-                    _dispatch_single_tool, block, tool_registry, tool_use_context, tools,
-                )
-                _accumulate(pair)
-
-    return [*primaries, *extras]
-
-
-def _run_tools_sync(
-    tool_use_blocks: list[ToolUseBlock],
-    tool_registry: ToolRegistry,
-    tool_use_context: ToolContext,
-) -> list[UserMessage]:
-    """Legacy synchronous tool execution (no partitioning).
-
-    Same primaries-first invariant as :func:`_run_tools_partitioned`.
-    """
-    primaries: list[UserMessage] = []
-    extras: list[UserMessage] = []
-    for block in tool_use_blocks:
-        primary, extras_for_block = _dispatch_single_tool(block, tool_registry, tool_use_context)
-        primaries.append(primary)
-        extras.extend(extras_for_block)
-    return [*primaries, *extras]
-
-
 async def query(
     params: QueryParams,
     *,
@@ -1319,6 +942,13 @@ async def query(
     ):
         snapshot_output_tokens_for_turn(params.token_budget)
     budget_tracker = create_budget_tracker()
+
+    # ch07 round-3 G1: the orchestrator lane sources tool lookup AND the
+    # concurrency partition from context.options.tools — production
+    # previously left it empty ([] default), which would silently route
+    # every tool through the base-list fallback and classify off
+    # defaults. Sync once per query.
+    params.tool_use_context.options.tools = list(params.tools)
 
     while True:
         messages = state.messages
@@ -1958,9 +1588,12 @@ async def query(
 
         if _diag:
             _tools_t0 = time.monotonic()
-            _batches = _partition_tool_calls(tool_use_blocks, params.tools)
+            from ..services.tool_execution.orchestrator import (
+                partition_tool_calls as _diag_partition,
+            )
+            _batches = _diag_partition(tool_use_blocks, tool_use_context)
             _batch_desc = ", ".join(
-                f"[{'parallel' if b.is_concurrent_safe else 'exclusive'}: {[bl.name for bl in b.blocks]}]"
+                f"[{'parallel' if b.is_concurrency_safe else 'exclusive'}: {[bl.name for bl in b.blocks]}]"
                 for b in _batches
             )
             logger.warning(
@@ -1985,12 +1618,56 @@ async def query(
         # to avoid touching ToolContext's public surface.
         setattr(tool_use_context, "_active_provider", params.provider)
 
-        tool_results = await _run_tools_partitioned(
-            tool_use_blocks,
-            params.tool_registry,
-            tool_use_context,
-            params.tools,
+        # ch07 round-3 G1 — the unified lane: TS's ungated runTools path
+        # (query.ts:1537-1539 else-branch), consumed per query.ts:1541-1565.
+        # run_tool_use brings hooks, input backfill (permissions see
+        # normalized input), call-input convergence, base-list fallback,
+        # error classification, and context modifiers to production.
+        from ..services.tool_execution.can_use_tool_adapter import (
+            build_can_use_tool,
         )
+        from ..services.tool_execution.orchestrator import run_tools
+
+        can_use_tool = build_can_use_tool(tool_use_context)
+        tool_results: list[UserMessage] = []
+        hook_stopped = False
+        async for update in run_tools(
+            tool_use_blocks,
+            assistant_messages,
+            can_use_tool,
+            tool_use_context,
+        ):
+            new_ctx = update.new_context
+            if new_ctx is not None and new_ctx is not tool_use_context:
+                # A context modifier produced a derived context — adopt
+                # it, re-imposing loop-managed state (dataclasses.replace
+                # does not carry dynamic attributes). Mirrors TS
+                # re-imposing queryTracking at query.ts:1559-1563.
+                setattr(new_ctx, "_active_provider", params.provider)
+                tool_use_context = new_ctx
+            msg = update.message
+            if msg is None:
+                continue  # batch-end context-only update
+            # In-loop hook-stop detection (TS query.ts:1545-1550): the
+            # marker rides an ATTACHMENT message, which is yielded to the
+            # surface but never collected into tool_results.
+            if _is_hook_stopped_continuation(msg):
+                hook_stopped = True
+            yield msg
+            # Collect RAW user-role Message objects (tool results + meta
+            # extras) for the next turn's history — normalization stays
+            # at API prep, where the unconditional merge + hoist handles
+            # the interleaved shape (ch07 G3). STRICT type check: TS
+            # filters collected toolResults to type=='user'
+            # (query.ts:1552-1557); AttachmentMessage SUBCLASSES
+            # UserMessage here (type='attachment') and must NOT enter
+            # next-turn history — attachment->history threading is the
+            # ch11/ch12 attachment-transformation surface.
+            if (
+                isinstance(msg, UserMessage)
+                and getattr(msg, "type", "user") == "user"
+            ):
+                tool_results.append(msg)
 
         if _diag:
             logger.warning(
@@ -2003,9 +1680,6 @@ async def query(
                         if hasattr(b, 'content'):
                             clen = len(b.content) if isinstance(b.content, str) else len(str(b.content))
                             logger.warning("[DIAG]   result: tool_use_id=%s  is_error=%s  content_len=%d", getattr(b, 'tool_use_id', '?'), getattr(b, 'is_error', False), clen)
-
-        for result_msg in tool_results:
-            yield result_msg
 
         if params.abort_controller.signal.aborted:
             if params.abort_controller.signal.reason != "interrupt":
@@ -2028,7 +1702,7 @@ async def query(
         #     for a different reason. Matches TS where the hook_stopped
         #     return at :1701 precedes the max_turns check at :1885.
         #   * BEFORE state reconstruction — no next iteration follows.
-        if any(_is_hook_stopped_continuation(msg) for msg in tool_results):
+        if hook_stopped:
             set_terminal(
                 holder, natural_termination, Terminal(reason="hook_stopped"),
             )

--- a/src/services/tool_execution/can_use_tool_adapter.py
+++ b/src/services/tool_execution/can_use_tool_adapter.py
@@ -1,0 +1,94 @@
+"""Shared can_use_tool adapter — ch07 round-3 G2.
+
+Packages the production permission semantics that ``registry.dispatch``
+implements inline (``registry.py:126-175``) as the ``can_use_tool``
+callable ``run_tool_use`` expects, so the orchestrator lane and any
+future caller resolve permissions identically:
+
+    has_permissions_to_use_tool -> allow / deny / ask
+    ask -> handle_permission_ask(context.permission_handler)
+           (fail-closed DENY when no handler)
+    accepted "don't ask again" updates -> _apply_and_persist_updates
+
+``userModified`` synthesis: ``registry.dispatch`` has no such concept;
+``run_tool_use`` reads ``permission_decision.get("userModified")`` and
+sets ``context.user_modified``. Rule (TS-parity groundwork): True iff the
+user accepted "don't ask again" updates OR the dialog returned a fresh
+``updated_input``. NOTE: zero ``context.user_modified`` readers exist
+today — the future consumer is dialog-modified-input display semantics;
+the rule is pinned now so it is already correct when it becomes
+load-bearing.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+def build_can_use_tool(context: Any) -> Callable[..., dict[str, Any]]:
+    """Build a ``can_use_tool`` callable bound to ``context``.
+
+    The returned callable matches ``resolve_hook_permission_decision``'s
+    invocation shape: ``(tool, tool_input, tool_use_context,
+    assistant_message, tool_use_id) -> dict``.
+    """
+
+    def can_use_tool(
+        tool: Any,
+        tool_input: dict[str, Any],
+        _tool_use_context: Any,
+        _assistant_message: Any,
+        _tool_use_id: str,
+    ) -> dict[str, Any]:
+        from src.permissions.check import has_permissions_to_use_tool
+        from src.permissions.handler import handle_permission_ask
+        from src.tool_system.registry import _apply_and_persist_updates
+
+        decision = has_permissions_to_use_tool(
+            tool,
+            tool_input,
+            context.permission_context,
+            tool_use_context=context,
+        )
+
+        if decision.behavior == "deny":
+            return {
+                "behavior": "deny",
+                "message": getattr(decision, "message", None)
+                or "permission denied",
+            }
+
+        if decision.behavior == "ask":
+            final, chosen_updates = handle_permission_ask(
+                tool.name,
+                decision,
+                context.permission_handler,
+                tool_input=tool_input,
+            )
+            if final.behavior == "deny":
+                return {
+                    "behavior": "deny",
+                    "message": getattr(final, "message", None)
+                    or "permission denied by user",
+                }
+            if chosen_updates:
+                _apply_and_persist_updates(context, chosen_updates)
+            final_updated = getattr(final, "updated_input", None)
+            return {
+                "behavior": "allow",
+                "updatedInput": final_updated
+                or getattr(decision, "updated_input", None),
+                "userModified": bool(chosen_updates)
+                or final_updated is not None,
+            }
+
+        return {
+            "behavior": "allow",
+            "updatedInput": getattr(decision, "updated_input", None),
+            "userModified": False,
+        }
+
+    return can_use_tool

--- a/src/services/tool_execution/orchestrator.py
+++ b/src/services/tool_execution/orchestrator.py
@@ -30,10 +30,27 @@ if TYPE_CHECKING:
 
 
 def _get_max_tool_use_concurrency() -> int:
+    # Reads CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY (chapter-7 name, used in
+    # the TS reference) with the legacy CLAWCODEX_ alias + deprecation
+    # warning (moved from query.py at ch07 unification).
     try:
-        return int(os.environ.get("CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY", "10"))
+        canonical = os.environ.get("CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY")
+        if canonical is not None:
+            return int(canonical)
+        legacy = os.environ.get("CLAWCODEX_MAX_TOOL_USE_CONCURRENCY")
+        if legacy is not None:
+            import warnings
+
+            warnings.warn(
+                "CLAWCODEX_MAX_TOOL_USE_CONCURRENCY is deprecated; use "
+                "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return int(legacy)
     except (ValueError, TypeError):
         return 10
+    return 10
 
 
 @dataclass

--- a/src/services/tool_execution/tool_execution.py
+++ b/src/services/tool_execution/tool_execution.py
@@ -91,6 +91,14 @@ async def run_tool_use(
         # historical ``if abort_ctrl and …`` guard masked the field-is-None
         # hazard class that broke ESC propagation into subagents.
         if tool_use_context.abort_controller.signal.aborted:
+            if _is_user_cancelled_abort(tool_use_context):
+                # ESC tripped before dispatch: REJECT_MESSAGE so the
+                # model sees an unambiguous "user rejected" signal (TS
+                # StreamingToolExecutor.ts:153-205 user_interrupted).
+                yield MessageUpdateLazy(
+                    message=_build_user_cancelled_message(tool_use.id),
+                )
+                return
             content = _create_tool_result_stop(tool_use.id)
             yield MessageUpdateLazy(
                 message=create_user_message(
@@ -331,6 +339,17 @@ async def _check_permissions_and_call_tool(
 
         result = await _call_tool(tool, call_input, call_context)
 
+        # Post-tool override: a tool that observed the abort and returned
+        # (e.g. bash's interrupted payload) reads as a generic failure;
+        # replace it so the resume turn sees an unambiguous "user
+        # rejected" signal. Mirrors TS StreamingToolExecutor.ts:332-345;
+        # ported from the retired slim lane (ch07 unification).
+        if _is_user_cancelled_abort(tool_use_context):
+            resulting_messages.append(MessageUpdateLazy(
+                message=_build_user_cancelled_message(tool_use_id),
+            ))
+            return resulting_messages
+
         duration_ms = int((time.monotonic() - start_time) * 1000)
 
         # Step 11 — Result Budgeting. Per-tool max_result_size_chars is
@@ -369,9 +388,30 @@ async def _check_permissions_and_call_tool(
                 tool_result_block,
             )
 
+        # Build the in-process ToolResultBlock (dataclass, not the raw
+        # dict): preserves multimodal list content end-to-end (images/PDF
+        # blocks reach the API as blocks, not JSON-stringified text) and
+        # carries dict outputs as metadata["tool_output"] for display
+        # consumers (repl/core._format_tool_result_preview). The wire
+        # serialization strips metadata via content_block_to_dict.
+        from src.types.content_blocks import ToolResultBlock
+
+        raw_block_content = tool_result_block.get("content", "")
+        if not isinstance(raw_block_content, (str, list)):
+            raw_block_content = str(raw_block_content)
+        block_metadata: dict[str, Any] = {}
+        if isinstance(result.output, dict):
+            block_metadata["tool_output"] = result.output
+        result_block_obj = ToolResultBlock(
+            tool_use_id=tool_use_id,
+            content=raw_block_content,
+            is_error=bool(getattr(result, "is_error", False)),
+            metadata=block_metadata,
+        )
+
         resulting_messages.append(MessageUpdateLazy(
             message=create_user_message(
-                content=[tool_result_block],
+                content=[result_block_obj],
                 toolUseResult=result.data if not tool_use_context.agent_id else None,
             ),
             context_modifier=ContextModifier(
@@ -415,12 +455,32 @@ async def _check_permissions_and_call_tool(
 
         return resulting_messages
 
-    except AbortError:
-        content = _create_tool_result_stop(tool_use_id)
+    except AbortError as abort_err:
+        # Two contracts at once (ported from the retired slim lane;
+        # pinned by tests/test_esc_reject_message_dispatch.py and
+        # test_agent_loop_does_not_swallow_abort_error_as_tool_error):
+        # 1. tool_use/tool_result pairing stays intact — return a
+        #    result, don't raise (an orphaned tool_use 400s next call).
+        # 2. No follow-up API turn — when the signal isn't already
+        #    tripped, trip it so the loop's post-tools abort gate exits.
+        if _is_user_cancelled_abort(tool_use_context):
+            resulting_messages.append(MessageUpdateLazy(
+                message=_build_user_cancelled_message(tool_use_id),
+            ))
+            return resulting_messages
+        try:
+            tool_use_context.abort_controller.abort("tool_raised_abort_error")
+        except Exception:
+            pass
         resulting_messages.append(MessageUpdateLazy(
             message=create_user_message(
-                content=[content],
-                toolUseResult=CANCEL_MESSAGE,
+                content=[{
+                    "type": "tool_result",
+                    "content": f"Error: Tool execution aborted ({abort_err})",
+                    "is_error": True,
+                    "tool_use_id": tool_use_id,
+                }],
+                toolUseResult=f"Error: Tool execution aborted ({abort_err})",
             ),
         ))
         return resulting_messages
@@ -513,6 +573,48 @@ async def _resolve_permission(
         can_use_tool,
         assistant_message,
         tool_use_id,
+    )
+
+
+def _is_user_cancelled_abort(tool_use_context: Any) -> bool:
+    """True iff the abort signal fired with a user-initiated reason.
+
+    ``sibling_error`` (streaming-executor parallel cascade) and
+    ``streaming_fallback`` (discarded executor) are NOT user-rejected
+    signals — surfacing REJECT_MESSAGE for them would mask the real
+    failure. Every other reason (``user_interrupt`` from ESC,
+    ``interrupt`` reserved for TS parity, ``tool_raised_abort_error``)
+    collapses into the user-cancelled bucket. Moved from the retired
+    query.py slim lane at ch07 unification; see that lane's docstring
+    history for the TS interruptBehavior divergence note.
+    """
+    ctrl = tool_use_context.abort_controller
+    if not ctrl.signal.aborted:
+        return False
+    return ctrl.signal.reason not in ("sibling_error", "streaming_fallback")
+
+
+def _build_user_cancelled_message(tool_use_id: str) -> Any:
+    """Synthetic REJECT_MESSAGE tool_result for a user abort.
+
+    The bash tool's interrupted path emits ``<error>Command was aborted
+    before completion</error>`` which the model reads as a generic
+    failure and retries; REJECT_MESSAGE makes the cancellation
+    unambiguous. Mirrors TS ``createSyntheticErrorMessage`` for
+    ``user_interrupted`` (StreamingToolExecutor.ts:153-205).
+    """
+    from src.types.content_blocks import ToolResultBlock
+    from src.types.messages import REJECT_MESSAGE
+
+    return create_user_message(
+        content=[
+            ToolResultBlock(
+                tool_use_id=tool_use_id,
+                content=REJECT_MESSAGE,
+                is_error=True,
+            )
+        ],
+        toolUseResult="User rejected tool use",
     )
 
 

--- a/src/tool_system/context.py
+++ b/src/tool_system/context.py
@@ -92,7 +92,7 @@ class ToolContext:
     # Reset to 0 between messages by the turn-loop dispatcher.
     #
     # ``_aggregate_lock`` synchronizes the read-decide-write across
-    # concurrent tool dispatches (critic B6). ``_run_tools_partitioned``
+    # concurrent tool dispatches (critic B6). The query loop's concurrent dispatch
     # uses ``asyncio.to_thread`` to fan out concurrency-safe tools (Read,
     # Grep, Glob) — without this lock, N threads would all read 0, all
     # decide their block is under the cap, and the per-message budget

--- a/src/types/messages.py
+++ b/src/types/messages.py
@@ -313,11 +313,16 @@ def normalize_messages_for_api(messages: list[MessageLike]) -> list[dict[str, An
     for message in messages:
         result = normalize_message_for_api(message)
         if result is not None:
+            # Consecutive user messages merge UNCONDITIONALLY — TS
+            # normalize user-case merge + mergeUserMessages' hoist+seam
+            # tail (messages.ts:2445-2455). Mixed tool_result + text
+            # merges are handled by the hoist + seam join inside
+            # _merge_user_api_messages; the old
+            # _should_merge_user_messages guard was port-invented (ch07
+            # round-3 G3) and forced callers into a primaries-first
+            # reorder to avoid orphaning results.
             if normalized and normalized[-1]["role"] == result["role"] == "user":
-                if _should_merge_user_messages(normalized[-1], result):
-                    normalized[-1] = _merge_user_api_messages(normalized[-1], result)
-                else:
-                    normalized.append(result)
+                normalized[-1] = _merge_user_api_messages(normalized[-1], result)
             else:
                 normalized.append(result)
     normalized = ensure_tool_result_pairing(normalized)
@@ -502,43 +507,36 @@ def ensure_tool_result_pairing(
     return result
 
 
-def _has_tool_result_blocks(msg: dict[str, Any]) -> bool:
-    content = msg.get("content", "")
-    if not isinstance(content, list):
-        return False
-    return any(
-        isinstance(block, dict) and block.get("type") == "tool_result"
-        for block in content
-    )
-
-
-def _has_non_tool_result_blocks(msg: dict[str, Any]) -> bool:
-    content = msg.get("content", "")
-    if isinstance(content, str):
-        return True
-    if not isinstance(content, list):
-        return False
-    return any(
-        not (isinstance(block, dict) and block.get("type") == "tool_result")
-        for block in content
-    )
-
-
-def _should_merge_user_messages(
-    existing: dict[str, Any],
-    new: dict[str, Any],
-) -> bool:
-    if _has_tool_result_blocks(existing) and _has_non_tool_result_blocks(new):
-        return False
-    if _has_tool_result_blocks(new) and _has_non_tool_result_blocks(existing):
-        return False
-    return True
-
-
 def _hoist_tool_results(content: list[dict[str, Any]]) -> list[dict[str, Any]]:
     tool_results = [b for b in content if isinstance(b, dict) and b.get("type") == "tool_result"]
     other_blocks = [b for b in content if not (isinstance(b, dict) and b.get("type") == "tool_result")]
     return tool_results + other_blocks
+
+
+def _join_text_at_seam(
+    a: list[dict[str, Any]],
+    b: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Mirror TS joinTextAtSeam (messages.ts:2511-2521).
+
+    Blocks stay SEPARATE; the "\\n" goes on a's side so no block's
+    startswith changes — system-reminder classification reads b's block
+    heads, and prepending to b would break it.
+    """
+    if a and b:
+        last_a, first_b = a[-1], b[0]
+        if (
+            isinstance(last_a, dict)
+            and last_a.get("type") == "text"
+            and isinstance(first_b, dict)
+            and first_b.get("type") == "text"
+        ):
+            return [
+                *a[:-1],
+                {**last_a, "text": last_a.get("text", "") + "\n"},
+                *b,
+            ]
+    return [*a, *b]
 
 
 def _merge_user_api_messages(
@@ -551,7 +549,10 @@ def _merge_user_api_messages(
         ec = [{"type": "text", "text": ec}]
     if isinstance(nc, str):
         nc = [{"type": "text", "text": nc}]
-    return {"role": "user", "content": _hoist_tool_results(ec + nc)}
+    return {
+        "role": "user",
+        "content": _hoist_tool_results(_join_text_at_seam(ec, nc)),
+    }
 
 
 def _is_system_local_command(message: MessageLike) -> bool:

--- a/tests/parity/test_e2e_file_read.py
+++ b/tests/parity/test_e2e_file_read.py
@@ -16,6 +16,47 @@ from src.tool_system.errors import ToolInputError, ToolPermissionError
 from src.tool_system.protocol import ToolCall
 
 
+def _drive_unified(ctx, registry, blocks):
+    """ch07 unification: drive the orchestrator lane (the production path
+    after PR-1; the slim ``_dispatch_single_tool`` lane was retired).
+    Returns the user-role messages run_tools yielded, in yield order."""
+    import asyncio as _asyncio
+
+    from src.services.tool_execution.orchestrator import run_tools
+    from src.tool_system.registry import get_all_base_tools
+    from src.types.messages import AssistantMessage, UserMessage
+
+    ctx.options.tools = get_all_base_tools(registry)
+    ctx.permission_context.mode = "bypassPermissions"
+
+    def _allow(*_a, **_k):
+        return {"behavior": "allow"}
+
+    async def _go():
+        out = []
+        async for u in run_tools(
+            blocks, [AssistantMessage(content="t")], _allow, ctx,
+        ):
+            if u.message is not None and isinstance(u.message, UserMessage):
+                out.append(u.message)
+        return out
+
+    return _asyncio.run(_go())
+
+
+def _split_primary_extras(msgs, tool_use_id):
+    """(primary, extras) shim over the unified lane's yield stream."""
+    primary = None
+    extras = []
+    for m in msgs:
+        c = getattr(m, "content", None)
+        if isinstance(c, list) and c and hasattr(c[0], "tool_use_id") and c[0].tool_use_id == tool_use_id:
+            primary = m
+        else:
+            extras.append(m)
+    return primary, extras
+
+
 class TestE2EFileRead(unittest.TestCase):
     """End-to-end file read flow."""
 
@@ -302,7 +343,7 @@ class TestE2EFileRead(unittest.TestCase):
         dimensions metadata reaches the model."""
         import io
         from PIL import Image
-        from src.query.query import _dispatch_single_tool
+        pass  # ch07: unified-lane driver (see _drive_unified above)
         from src.types.messages import UserMessage
         from src.types.content_blocks import ToolUseBlock
 
@@ -313,7 +354,8 @@ class TestE2EFileRead(unittest.TestCase):
         big.write_bytes(buf.getvalue())
 
         block = ToolUseBlock(id="tu_pd_1", name="Read", input={"file_path": str(big)})
-        primary, extras = _dispatch_single_tool(block, self.registry, self.ctx)
+        msgs = _drive_unified(self.ctx, self.registry, [block])
+        primary, extras = _split_primary_extras(msgs, block.id)
 
         # Primary is the tool_result carrying tu_pd_1.
         self.assertIsInstance(primary, UserMessage)
@@ -328,13 +370,14 @@ class TestE2EFileRead(unittest.TestCase):
 
     def test_production_dispatch_no_extras_for_text_read(self) -> None:
         """A plain text read produces a tool_result and no extras."""
-        from src.query.query import _dispatch_single_tool
+        pass  # ch07: unified-lane driver (see _drive_unified above)
         from src.types.content_blocks import ToolUseBlock
 
         text = self.root / "plain.txt"
         text.write_text("hello\nworld\n")
         block = ToolUseBlock(id="tu_pd_2", name="Read", input={"file_path": str(text)})
-        primary, extras = _dispatch_single_tool(block, self.registry, self.ctx)
+        msgs = _drive_unified(self.ctx, self.registry, [block])
+        primary, extras = _split_primary_extras(msgs, block.id)
         self.assertEqual(extras, [])
         # Verify the right tool_use_id and non-error status.
         self.assertEqual(primary.content[0].tool_use_id, "tu_pd_2")
@@ -350,14 +393,12 @@ class TestE2EFileRead(unittest.TestCase):
         a_meta (no tool_result for b), decided tu_b was missing, and injected
         a synthetic "[Tool result missing due to internal error]" placeholder.
 
-        Post-fix: primaries-first ordering yields ``[a_result, b_result, a_meta]``
-        so pairing succeeds for both. This test drives two image Reads
-        concurrently through ``_run_tools_partitioned`` and verifies both
-        tool_results survive the normalize+pairing pipeline."""
+        ch07 round-3: the fix moved into normalize itself (unconditional
+        merge + hoist + seam join, TS messages.ts:2445-2489); the unified
+        lane yields interleaved and pairing still holds."""
         import asyncio
         import io
         from PIL import Image
-        from src.query.query import _run_tools_partitioned
         from src.types.content_blocks import ToolUseBlock
         from src.types.messages import normalize_messages_for_api, AssistantMessage
 
@@ -374,15 +415,11 @@ class TestE2EFileRead(unittest.TestCase):
         block_a = ToolUseBlock(id="tu_a", name="Read", input={"file_path": str(path_a)})
         block_b = ToolUseBlock(id="tu_b", name="Read", input={"file_path": str(path_b)})
 
-        # Read is concurrency-safe so this exercises the parallel path.
-        from src.tool_system.registry import get_all_base_tools
-        tools = get_all_base_tools(self.registry)
-        results = asyncio.run(_run_tools_partitioned(
-            [block_a, block_b], self.registry, self.ctx, tools,
-        ))
+        # Read is concurrency-safe so this exercises the parallel path
+        # of the UNIFIED lane (interleaved yields; the merge+hoist in
+        # normalize handles pairing — no reordering shim).
+        results = _drive_unified(self.ctx, self.registry, [block_a, block_b])
 
-        # Primaries first, then extras: [a_result, b_result, a_meta, b_meta].
-        # Both tool_results land before any meta message.
         tool_result_msgs = [
             m for m in results
             if m.content and hasattr(m.content[0], "tool_use_id")
@@ -538,7 +575,7 @@ class TestE2EFileRead(unittest.TestCase):
         tool_result still arrives as a list of content blocks (not a
         ``<persisted-output>`` wrapper)."""
         from PIL import Image
-        from src.query.query import _dispatch_single_tool
+        pass  # ch07: unified-lane driver (see _drive_unified above)
         from src.services.tool_execution.tool_result_persistence import (
             MAX_TOOL_RESULTS_PER_MESSAGE_CHARS,
         )
@@ -557,7 +594,8 @@ class TestE2EFileRead(unittest.TestCase):
 
         tools = get_all_base_tools(self.registry)
         tu = ToolUseBlock(id="tu_agg", name="Read", input={"file_path": str(png)})
-        primary, _extras = _dispatch_single_tool(tu, self.registry, self.ctx, tools)
+        msgs = _drive_unified(self.ctx, self.registry, [tu])
+        primary, _extras = _split_primary_extras(msgs, tu.id)
 
         body = primary.content[0].content
         self.assertIsInstance(body, list,
@@ -594,7 +632,7 @@ class TestE2EFileRead(unittest.TestCase):
         full wire shape: the API payload's tool_result content must be
         a list whose first element is an ``image`` content block."""
         from PIL import Image
-        from src.query.query import _dispatch_single_tool
+        pass  # ch07: unified-lane driver (see _drive_unified above)
         from src.tool_system.registry import get_all_base_tools
         from src.types.content_blocks import ToolResultBlock, ToolUseBlock
         from src.types.messages import AssistantMessage, normalize_messages_for_api
@@ -609,7 +647,8 @@ class TestE2EFileRead(unittest.TestCase):
         # ``process_tool_result_block`` branch where Bug B lived.
         tools = get_all_base_tools(self.registry)
         tu = ToolUseBlock(id="tu_regress_b", name="Read", input={"file_path": str(png)})
-        primary, _extras = _dispatch_single_tool(tu, self.registry, self.ctx, tools)
+        msgs = _drive_unified(self.ctx, self.registry, [tu])
+        primary, _extras = _split_primary_extras(msgs, tu.id)
 
         # Direct check on the ToolResultBlock the dispatcher built.
         self.assertIsInstance(primary.content[0], ToolResultBlock)

--- a/tests/test_esc_reject_message_dispatch.py
+++ b/tests/test_esc_reject_message_dispatch.py
@@ -1,64 +1,91 @@
-"""Regression tests for ESC-cancelled tool_results in the production path.
+"""ESC / user-cancel contract pins — REJECT_MESSAGE dispatch semantics.
 
-When the user presses ESC mid-Bash, the bash tool's own ``interrupted``
-path emits ``<error>Command was aborted before completion</error>`` in the
-tool_result content. The model reads this as a generic command failure
-and, on the next turn (e.g. "please resume"), tends to retry the command
-as if it had hit a transient bug — exactly what the user does NOT want.
-
-The TS reference solves this in
-``typescript/src/services/tools/StreamingToolExecutor.ts:153-205`` by
-overriding the tool_result with ``REJECT_MESSAGE`` whenever the abort
-reason is ``user_interrupted``. The Python production REPL bypasses
-``StreamingToolExecutor`` and runs through ``query._dispatch_single_tool``
-directly, so this file pins the same override into that production path.
-
-Tests cover:
-
-* Pre-tool gate — ESC fires before the dispatch begins.
-* Post-tool override — ESC fires while the tool is running and the tool
-  returns its own ``interrupted`` payload.
-* ``AbortError`` raised by the tool — grep/glob style.
-* ``sibling_error`` reason — must NOT mask the real failure with
-  ``REJECT_MESSAGE`` (the cascade indicates a real parallel-tool error).
-* Normal completion — no abort, no override.
+Originally pinned the query.py slim lane (`_dispatch_single_tool`); ch07
+PR-1 retired that lane, so these pins now arbitrate the UNIFIED lane
+(`run_tool_use` / `_check_permissions_and_call_tool`), whose user-cancel
+classification + REJECT_MESSAGE overrides were ported verbatim. The
+contract (unchanged): pre-tool gate, post-tool override, AbortError
+funnel — all must surface REJECT_MESSAGE for user-initiated aborts so the
+resume turn sees an unambiguous "user rejected" signal (TS
+StreamingToolExecutor.ts:153-205), and tool_use/tool_result pairing must
+stay intact.
 """
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
 
-from src.query.query import (
-    _build_user_cancelled_result,
-    _dispatch_single_tool,
+from src.services.tool_execution.tool_execution import (
+    _build_user_cancelled_message,
     _is_user_cancelled_abort,
+    run_tool_use,
 )
-from src.tool_system.context import ToolContext
-from src.tool_system.protocol import ToolResult
-from src.tool_system.registry import ToolRegistry
 from src.tool_system.build_tool import build_tool
+from src.tool_system.context import ToolContext, ToolUseOptions
+from src.tool_system.protocol import ToolResult
 from src.types.content_blocks import ToolResultBlock, ToolUseBlock
-from src.types.messages import REJECT_MESSAGE
+from src.types.messages import AssistantMessage, REJECT_MESSAGE
 from src.utils.abort_controller import AbortController, AbortError
 
 
-def _make_ctx(workspace: Path) -> ToolContext:
-    ctx = ToolContext(workspace_root=workspace)
+def _make_ctx(workspace: Path, tools: list | None = None) -> ToolContext:
+    ctx = ToolContext(
+        workspace_root=workspace,
+        options=ToolUseOptions(tools=tools or []),
+    )
     ctx.abort_controller = AbortController()
+    ctx.permission_context.mode = "bypassPermissions"
     return ctx
 
 
-def _extract_tool_result(msg: Any) -> ToolResultBlock:
-    # _dispatch_single_tool returns (primary: UserMessage, extras: list[UserMessage]).
-    # Accept either the tuple form or a bare UserMessage for back-compat.
-    if isinstance(msg, tuple):
-        msg = msg[0]
-    assert isinstance(msg.content, list)
-    assert len(msg.content) == 1
-    block = msg.content[0]
-    assert isinstance(block, ToolResultBlock)
-    return block
+def _allow(*_a: Any, **_k: Any) -> dict[str, Any]:
+    return {"behavior": "allow"}
+
+
+def _run_tool(ctx: ToolContext, tool, name: str, input_: dict, tid: str):
+    block = ToolUseBlock(id=tid, name=name, input=input_)
+
+    async def drive():
+        updates = []
+        async for u in run_tool_use(
+            block, AssistantMessage(content="t"), _allow, ctx
+        ):
+            updates.append(u)
+        return updates
+
+    return asyncio.run(drive())
+
+
+def _extract_tool_result(updates: list) -> Any:
+    msgs = [getattr(u, "message", u) for u in updates]
+    blocks = []
+    for m in msgs:
+        content = getattr(m, "content", None)
+        if isinstance(content, list):
+            for b in content:
+                if isinstance(b, ToolResultBlock):
+                    blocks.append(b)
+                elif isinstance(b, dict) and b.get("type") == "tool_result":
+                    blocks.append(ToolResultBlock(
+                        tool_use_id=b.get("tool_use_id", ""),
+                        content=b.get("content", ""),
+                        is_error=bool(b.get("is_error")),
+                    ))
+    assert len(blocks) == 1, f"expected exactly one tool_result, got {blocks}"
+    return blocks[0]
+
+
+def _stub(name: str, call):
+    return build_tool(
+        name=name,
+        input_schema={
+            "type": "object", "properties": {}, "additionalProperties": True,
+        },
+        call=call,
+        prompt=name,
+        description=name,
+    )
 
 
 def test_is_user_cancelled_abort_false_when_signal_not_aborted(tmp_path: Path) -> None:
@@ -78,50 +105,47 @@ def test_is_user_cancelled_abort_false_on_sibling_error(tmp_path: Path) -> None:
     assert _is_user_cancelled_abort(ctx) is False
 
 
-def test_build_user_cancelled_result_uses_reject_message() -> None:
-    msg = _build_user_cancelled_result("call_42")
-    block = _extract_tool_result(msg)
+def test_is_user_cancelled_abort_false_on_streaming_fallback(tmp_path: Path) -> None:
+    # ch07: the discarded streaming executor's reason is not a user
+    # rejection either.
+    ctx = _make_ctx(tmp_path)
+    ctx.abort_controller.abort("streaming_fallback")
+    assert _is_user_cancelled_abort(ctx) is False
+
+
+def test_build_user_cancelled_message_uses_reject_message() -> None:
+    msg = _build_user_cancelled_message("call_42")
+    block = msg.content[0]
+    assert isinstance(block, ToolResultBlock)
     assert block.tool_use_id == "call_42"
     assert block.content == REJECT_MESSAGE
     assert block.is_error is True
 
 
-def test_dispatch_pre_tool_abort_returns_reject_message(tmp_path: Path) -> None:
-    """Pre-tool gate: ESC trips BEFORE the dispatch starts.
+def test_pre_tool_abort_returns_reject_message(tmp_path: Path) -> None:
+    """Pre-tool gate: ESC trips BEFORE dispatch — the tool must NOT run
+    and the synthetic REJECT_MESSAGE must come out of the gate."""
+    ran: list = []
 
-    The registry must NOT be invoked (the user has already said stop) and
-    the synthetic ``REJECT_MESSAGE`` must come out of the gate instead.
-    """
-    ctx = _make_ctx(tmp_path)
+    def _call(_input: dict[str, Any], _context: ToolContext) -> ToolResult:
+        ran.append(True)
+        return ToolResult(name="Bash", output="should not happen")
+
+    tool = _stub("Bash", _call)
+    ctx = _make_ctx(tmp_path, [tool])
     ctx.abort_controller.abort("user_interrupt")
 
-    registry = MagicMock()
-    registry.dispatch = MagicMock(
-        side_effect=AssertionError(
-            "registry must not be hit when abort is already tripped"
-        )
-    )
-
-    block = ToolUseBlock(id="call_1", name="Bash", input={"command": "ls"})
-    result = _dispatch_single_tool(block, registry, ctx, tools=None)
-
-    tool_result = _extract_tool_result(result)
+    updates = _run_tool(ctx, tool, "Bash", {"command": "ls"}, "call_1")
+    tool_result = _extract_tool_result(updates)
     assert tool_result.content == REJECT_MESSAGE
     assert tool_result.is_error is True
-    registry.dispatch.assert_not_called()
+    assert not ran
 
 
-def test_dispatch_post_tool_abort_overrides_bash_interrupted_output(
-    tmp_path: Path,
-) -> None:
-    """Post-tool override: bash returns the ``interrupted`` payload AND
-    the abort is set when the result lands. The override fires so the
-    model sees ``REJECT_MESSAGE`` instead of the bash tool's own
-    ``<error>Command was aborted before completion</error>`` string.
-    """
-    ctx = _make_ctx(tmp_path)
-
-    # Mirror the bash tool's interrupted return path (bash_tool.py:324-339).
+def test_post_tool_abort_overrides_bash_interrupted_output(tmp_path: Path) -> None:
+    """Post-tool override: bash returns its ``interrupted`` payload AND
+    the abort is set when the result lands — the model must see
+    REJECT_MESSAGE, not bash's generic aborted string."""
     bash_output = {
         "cwd": str(tmp_path),
         "exit_code": -1,
@@ -131,273 +155,61 @@ def test_dispatch_post_tool_abort_overrides_bash_interrupted_output(
     }
 
     def _call(_input: dict[str, Any], context: ToolContext) -> ToolResult:
-        # Simulate ESC firing mid-run: the bash supervisor would have
-        # observed the abort, killed the subprocess, and returned the
-        # interrupted payload by this point.
         context.abort_controller.abort("user_interrupt")
-        return ToolResult(
-            name="Bash", output=bash_output, is_error=True,
-        )
+        return ToolResult(name="Bash", output=bash_output, is_error=True)
 
-    bash_tool = build_tool(
-        name="Bash",
-        input_schema={"type": "object", "properties": {}, "additionalProperties": True},
-        call=_call,
-        prompt=lambda: "Bash",
-        description=lambda _i: "shell",
-    )
-    registry = ToolRegistry()
-    registry.register(bash_tool)
+    tool = _stub("Bash", _call)
+    ctx = _make_ctx(tmp_path, [tool])
+    updates = _run_tool(ctx, tool, "Bash", {"command": "npm install"}, "call_99")
 
-    block = ToolUseBlock(id="call_99", name="Bash", input={"command": "npm install"})
-    result = _dispatch_single_tool(block, registry, ctx, tools=[bash_tool])
-
-    tool_result = _extract_tool_result(result)
+    tool_result = _extract_tool_result(updates)
     assert tool_result.content == REJECT_MESSAGE, (
         "post-tool override must replace bash's interrupted payload with "
         "REJECT_MESSAGE so the next-turn resume sees a clear 'user "
         "rejected' signal"
     )
-    assert "<error>Command was aborted before completion</error>" not in (
+    assert "<error>Command was aborted before completion</error>" not in str(
         tool_result.content
     )
     assert tool_result.is_error is True
 
 
-def test_dispatch_tool_abort_error_returns_reject_message(tmp_path: Path) -> None:
-    """A tool that raises ``AbortError`` (grep/glob via the ripgrep guard)
-    AND has the abort signal tripped must funnel into ``REJECT_MESSAGE``.
-    Without this branch the bare ``except Exception`` would stringify
-    the error as a generic ``Error: ...`` payload and the resume turn
-    would still look like a transient bug to the model.
-    """
-    ctx = _make_ctx(tmp_path)
+def test_tool_abort_error_returns_reject_message(tmp_path: Path) -> None:
+    """A tool that raises AbortError with the signal tripped must funnel
+    into REJECT_MESSAGE (not a generic Error payload)."""
 
     def _call(_input: dict[str, Any], context: ToolContext) -> ToolResult:
         context.abort_controller.abort("user_interrupt")
         raise AbortError("user_interrupt")
 
-    tool = build_tool(
-        name="Grep",
-        input_schema={"type": "object", "properties": {}, "additionalProperties": True},
-        call=_call,
-        prompt=lambda: "Grep",
-        description=lambda _i: "search",
-    )
-    registry = ToolRegistry()
-    registry.register(tool)
+    tool = _stub("Grep", _call)
+    ctx = _make_ctx(tmp_path, [tool])
+    updates = _run_tool(ctx, tool, "Grep", {"pattern": "TODO"}, "call_5")
 
-    block = ToolUseBlock(id="call_5", name="Grep", input={"pattern": "TODO"})
-    result = _dispatch_single_tool(block, registry, ctx, tools=[tool])
-
-    tool_result = _extract_tool_result(result)
+    tool_result = _extract_tool_result(updates)
     assert tool_result.content == REJECT_MESSAGE
     assert tool_result.is_error is True
 
 
-def test_dispatch_abort_error_without_signal_aborted_does_not_use_reject_message(
+def test_abort_error_without_signal_does_not_use_reject_message(
     tmp_path: Path,
 ) -> None:
-    """Defensive: if a future tool raises ``AbortError`` WITHOUT having
-    tripped the abort signal first (e.g. repurposed for its own internal
-    cancellation), the dispatch must NOT silently relabel it as a user
-    rejection — the user has no idea anything went wrong otherwise.
-
-    Today every Python call site that raises ``AbortError`` does so only
-    when the signal is already aborted; this test pins the contract so a
-    future regression where that convention drifts is caught loudly.
-    """
-    ctx = _make_ctx(tmp_path)
-    # Note: NO ``ctx.abort_controller.abort(...)`` — the signal stays clean.
+    """Defensive: AbortError WITHOUT a tripped signal must NOT be
+    relabelled as a user rejection — and the dual contract requires the
+    signal be tripped (no follow-up API turn) with a PAIRED tool_result."""
 
     def _call(_input: dict[str, Any], _context: ToolContext) -> ToolResult:
         raise AbortError("internal cancellation by tool, not user")
 
-    tool = build_tool(
-        name="OddTool",
-        input_schema={"type": "object", "properties": {}, "additionalProperties": True},
-        call=_call,
-        prompt=lambda: "OddTool",
-        description=lambda _i: "odd",
-    )
-    registry = ToolRegistry()
-    registry.register(tool)
+    tool = _stub("OddTool", _call)
+    ctx = _make_ctx(tmp_path, [tool])
+    updates = _run_tool(ctx, tool, "OddTool", {}, "call_7")
 
-    block = ToolUseBlock(id="call_6", name="OddTool", input={})
-    result = _dispatch_single_tool(block, registry, ctx, tools=[tool])
-
-    tool_result = _extract_tool_result(result)
-    assert tool_result.content != REJECT_MESSAGE, (
-        "AbortError without an aborted signal must NOT be relabelled as "
-        "user rejection — the cancellation came from the tool, not ESC"
-    )
-    assert tool_result.is_error is True
-    assert "Tool execution aborted" in str(tool_result.content)
-    assert "internal cancellation by tool, not user" in str(tool_result.content)
-
-
-def test_sibling_error_does_not_override_with_reject_message(tmp_path: Path) -> None:
-    """``sibling_error`` is the streaming-executor's parallel-tool
-    cascade reason. The tool that actually failed must keep its real
-    error payload so the user (and the model) can see what broke —
-    relabelling it as "user rejected" would mask a real bug.
-
-    Test setup: signal aborted with reason ``sibling_error``; the tool
-    returns a recognizable error payload. The dispatch must NOT route
-    through ``_build_user_cancelled_result`` — the tool's real output
-    must come through.
-    """
-    ctx = _make_ctx(tmp_path)
-    ctx.abort_controller.abort("sibling_error")
-
-    sentinel = "real failure: parallel tool returned exit 2"
-
-    def _call(_input: dict[str, Any], _context: ToolContext) -> ToolResult:
-        return ToolResult(name="Read", output=sentinel, is_error=True)
-
-    tool = build_tool(
-        name="Read",
-        input_schema={"type": "object", "properties": {}, "additionalProperties": True},
-        call=_call,
-        prompt=lambda: "Read",
-        description=lambda _i: "read",
-    )
-    registry = ToolRegistry()
-    registry.register(tool)
-
-    block = ToolUseBlock(id="call_2", name="Read", input={"file_path": "x"})
-    result = _dispatch_single_tool(block, registry, ctx, tools=[tool])
-
-    tool_result = _extract_tool_result(result)
-    assert tool_result.content != REJECT_MESSAGE, (
-        "sibling_error must NOT be relabelled as 'user rejected' — the "
-        "model needs the underlying parallel-tool failure to diagnose "
-        "what went wrong"
-    )
-    assert sentinel in str(tool_result.content), (
-        "the real tool failure payload must reach the model unchanged"
-    )
-    assert tool_result.is_error is True
-
-
-def test_dispatch_normal_completion_does_not_override(tmp_path: Path) -> None:
-    """Sanity check: a tool that completes successfully without any abort
-    must NOT have its result rewritten to ``REJECT_MESSAGE``.
-    """
-    ctx = _make_ctx(tmp_path)
-
-    def _call(_input: dict[str, Any], _context: ToolContext) -> ToolResult:
-        return ToolResult(name="Read", output="hello world", is_error=False)
-
-    tool = build_tool(
-        name="Read",
-        input_schema={"type": "object", "properties": {}, "additionalProperties": True},
-        call=_call,
-        prompt=lambda: "Read",
-        description=lambda _i: "read",
-    )
-    registry = ToolRegistry()
-    registry.register(tool)
-
-    block = ToolUseBlock(id="call_7", name="Read", input={"file_path": "x"})
-    result = _dispatch_single_tool(block, registry, ctx, tools=[tool])
-
-    tool_result = _extract_tool_result(result)
+    tool_result = _extract_tool_result(updates)
     assert tool_result.content != REJECT_MESSAGE
-    assert "hello world" in str(tool_result.content)
-    assert tool_result.is_error is False
-
-
-def test_dispatch_post_tool_abort_after_normal_completion(tmp_path: Path) -> None:
-    """A tool that finishes successfully but the abort trips before the
-    result is returned to the caller must still get the override —
-    mirrors the TS per-iteration check at
-    ``StreamingToolExecutor.ts:335`` which fires BEFORE pushing the
-    update, regardless of whether the update was an error.
-    """
-    ctx = _make_ctx(tmp_path)
-
-    def _call(_input: dict[str, Any], context: ToolContext) -> ToolResult:
-        # The tool finished cleanly, then ESC fires before the dispatch
-        # function gets to package the result up for the model.
-        context.abort_controller.abort("user_interrupt")
-        return ToolResult(name="Read", output="ok", is_error=False)
-
-    tool = build_tool(
-        name="Read",
-        input_schema={"type": "object", "properties": {}, "additionalProperties": True},
-        call=_call,
-        prompt=lambda: "Read",
-        description=lambda _i: "read",
-    )
-    registry = ToolRegistry()
-    registry.register(tool)
-
-    block = ToolUseBlock(id="call_9", name="Read", input={"file_path": "x"})
-    result = _dispatch_single_tool(block, registry, ctx, tools=[tool])
-
-    tool_result = _extract_tool_result(result)
-    assert tool_result.content == REJECT_MESSAGE
+    assert "aborted" in str(tool_result.content).lower()
     assert tool_result.is_error is True
-
-
-def test_dispatch_unrelated_exception_with_abort_returns_reject_message(
-    tmp_path: Path,
-) -> None:
-    """A late abort that races a tool exception: the user pressed ESC
-    AND the tool also raised a non-AbortError. The user's intent wins —
-    REJECT_MESSAGE is the correct framing.
-    """
-    ctx = _make_ctx(tmp_path)
-
-    def _call(_input: dict[str, Any], context: ToolContext) -> ToolResult:
-        context.abort_controller.abort("user_interrupt")
-        raise RuntimeError("unrelated bug")
-
-    tool = build_tool(
-        name="Flaky",
-        input_schema={"type": "object", "properties": {}, "additionalProperties": True},
-        call=_call,
-        prompt=lambda: "Flaky",
-        description=lambda _i: "flaky",
-    )
-    registry = ToolRegistry()
-    registry.register(tool)
-
-    block = ToolUseBlock(id="call_3", name="Flaky", input={})
-    result = _dispatch_single_tool(block, registry, ctx, tools=[tool])
-
-    tool_result = _extract_tool_result(result)
-    assert tool_result.content == REJECT_MESSAGE
-
-
-def test_dispatch_unrelated_exception_no_abort_falls_through_to_error(
-    tmp_path: Path,
-) -> None:
-    """When no abort fires, a plain exception still produces the legacy
-    ``Error: ...`` stringification — REJECT_MESSAGE must not leak into
-    the non-cancel error path.
-    """
-    ctx = _make_ctx(tmp_path)
-
-    def _call(_input: dict[str, Any], _context: ToolContext) -> ToolResult:
-        raise RuntimeError("boom")
-
-    tool = build_tool(
-        name="Boom",
-        input_schema={"type": "object", "properties": {}, "additionalProperties": True},
-        call=_call,
-        prompt=lambda: "Boom",
-        description=lambda _i: "boom",
-    )
-    registry = ToolRegistry()
-    registry.register(tool)
-
-    block = ToolUseBlock(id="call_4", name="Boom", input={})
-    result = _dispatch_single_tool(block, registry, ctx, tools=[tool])
-
-    tool_result = _extract_tool_result(result)
-    assert tool_result.content != REJECT_MESSAGE
-    assert "Error" in str(tool_result.content)
-    assert "boom" in str(tool_result.content)
-    assert tool_result.is_error is True
+    # The loop's post-tools abort gate must see a tripped signal so no
+    # follow-up API turn happens.
+    assert ctx.abort_controller.signal.aborted
+    assert ctx.abort_controller.signal.reason == "tool_raised_abort_error"

--- a/tests/test_messages_utility.py
+++ b/tests/test_messages_utility.py
@@ -240,3 +240,79 @@ class TestCreateVariants:
     def test_create_assistant_compact_boundary(self):
         msg = create_assistant_compact_boundary_message("summary text")
         assert isinstance(msg, AssistantMessage)
+
+
+class TestUnconditionalUserMergeRound3:
+    """ch07 round-3 G3: TS merges consecutive user messages
+    UNCONDITIONALLY (messages.ts:2457-2469) with tool_result hoisting and
+    joinTextAtSeam — the old mixed-merge guard was port-invented."""
+
+    def test_interleaved_results_and_meta_merge_to_one_hoisted_message(self):
+        from src.types.messages import (
+            AssistantMessage,
+            UserMessage,
+            normalize_messages_for_api,
+        )
+
+        msgs = [
+            AssistantMessage(content=[
+                {"type": "tool_use", "id": "tu_a", "name": "Read", "input": {}},
+                {"type": "tool_use", "id": "tu_b", "name": "Read", "input": {}},
+            ]),
+            UserMessage(content=[{
+                "type": "tool_result", "tool_use_id": "tu_a", "content": "A",
+            }]),
+            UserMessage(content="meta note for a", isMeta=True),
+            UserMessage(content=[{
+                "type": "tool_result", "tool_use_id": "tu_b", "content": "B",
+            }]),
+        ]
+        out = normalize_messages_for_api(msgs)
+        users = [m for m in out if m["role"] == "user"]
+        assert len(users) == 1
+        content = users[0]["content"]
+        # Hoist: tool_results first (a then b — submission order), text last.
+        assert [b.get("type") for b in content] == [
+            "tool_result", "tool_result", "text",
+        ]
+        assert content[0]["tool_use_id"] == "tu_a"
+        assert content[1]["tool_use_id"] == "tu_b"
+        assert "meta note" in content[2]["text"]
+
+    def test_text_text_seam_gets_newline(self):
+        from src.types.messages import UserMessage, normalize_messages_for_api
+
+        out = normalize_messages_for_api(
+            [UserMessage(content="2 + 2"), UserMessage(content="3 + 3")]
+        )
+        users = [m for m in out if m["role"] == "user"]
+        assert len(users) == 1
+        texts = [b["text"] for b in users[0]["content"] if b.get("type") == "text"]
+        # Blocks stay separate; "\n" appended to the LEFT block
+        # (TS joinTextAtSeam, messages.ts:2511-2521).
+        assert texts == ["2 + 2\n", "3 + 3"]
+
+    def test_interleaved_shape_produces_no_orphan_repairs(self):
+        from src.types.messages import (
+            AssistantMessage,
+            UserMessage,
+            normalize_messages_for_api,
+        )
+
+        msgs = [
+            AssistantMessage(content=[
+                {"type": "tool_use", "id": "tu_a", "name": "Read", "input": {}},
+                {"type": "tool_use", "id": "tu_b", "name": "Read", "input": {}},
+            ]),
+            UserMessage(content=[{
+                "type": "tool_result", "tool_use_id": "tu_a", "content": "A",
+            }]),
+            UserMessage(content="supplemental", isMeta=True),
+            UserMessage(content=[{
+                "type": "tool_result", "tool_use_id": "tu_b", "content": "B",
+            }]),
+        ]
+        out = normalize_messages_for_api(msgs)
+        joined = str(out)
+        assert "Tool result missing" not in joined
+        assert "[Tool result missing due to internal error]" not in joined

--- a/tests/test_orchestrator_concurrency.py
+++ b/tests/test_orchestrator_concurrency.py
@@ -247,8 +247,13 @@ class TestSubmissionOrderInvariant(unittest.IsolatedAsyncioTestCase):
             for b in content:
                 if isinstance(b, dict) and b.get("type") == "tool_result":
                     tid = b.get("tool_use_id")
-                    if tid:
-                        ids_seen.add(tid)
+                elif hasattr(b, "tool_use_id"):
+                    # ch07: run_tool_use builds ToolResultBlock objects.
+                    tid = b.tool_use_id
+                else:
+                    tid = None
+                if tid:
+                    ids_seen.add(tid)
 
         # All three submitted ids saw a tool_result. Without G1 the
         # slow tool's result might race the fast tools' completion.

--- a/tests/test_query_hook_stopped.py
+++ b/tests/test_query_hook_stopped.py
@@ -124,6 +124,19 @@ def _make_hook_stopped_attachment(
     })
 
 
+def _as_run_tools_stub(messages_factory):
+    """Adapt a list-of-Messages factory to the orchestrator.run_tools
+    async-generator seam (ch07 unification: the loop consumes
+    MessageUpdate(message=..., new_context=...) updates)."""
+    from src.services.tool_execution.orchestrator import MessageUpdate
+
+    async def _stub(_blocks, _assistants, _can_use_tool, _ctx, *a, **k):
+        for m in messages_factory():
+            yield MessageUpdate(message=m, new_context=_ctx)
+
+    return _stub
+
+
 class TestIsHookStoppedContinuationPredicate(unittest.TestCase):
     """Unit-test the detection helper in isolation."""
 
@@ -181,15 +194,12 @@ class TestHookStoppedTerminal(unittest.TestCase):
 
         params = _make_params(workspace=self.workspace, provider=provider)
 
-        async def patched_run_tools(*args, **kwargs):
-            return [
+        with patch(
+            "src.services.tool_execution.orchestrator.run_tools",
+            new=_as_run_tools_stub(lambda: [
                 _make_tool_result("toolu_001"),
                 _make_hook_stopped_attachment(tool_use_id="toolu_001"),
-            ]
-
-        with patch(
-            "src.query.query._run_tools_partitioned",
-            side_effect=patched_run_tools,
+            ]),
         ):
             messages, terminal = _run(run_query(params))
 
@@ -210,12 +220,11 @@ class TestHookStoppedTerminal(unittest.TestCase):
         params = _make_params(workspace=self.workspace, provider=provider)
         attachment = _make_hook_stopped_attachment(tool_use_id="toolu_002")
 
-        async def patched_run_tools(*args, **kwargs):
-            return [_make_tool_result("toolu_002"), attachment]
-
         with patch(
-            "src.query.query._run_tools_partitioned",
-            side_effect=patched_run_tools,
+            "src.services.tool_execution.orchestrator.run_tools",
+            new=_as_run_tools_stub(
+                lambda: [_make_tool_result("toolu_002"), attachment]
+            ),
         ):
             messages, terminal = _run(run_query(params))
 
@@ -243,12 +252,11 @@ class TestHookStoppedTerminal(unittest.TestCase):
 
         params = _make_params(workspace=self.workspace, provider=provider)
 
-        async def patched_run_tools(*args, **kwargs):
-            return [_make_tool_result("toolu_003")]  # no attachment
-
         with patch(
-            "src.query.query._run_tools_partitioned",
-            side_effect=patched_run_tools,
+            "src.services.tool_execution.orchestrator.run_tools",
+            new=_as_run_tools_stub(
+                lambda: [_make_tool_result("toolu_003")]  # no attachment
+            ),
         ):
             messages, terminal = _run(run_query(params))
 
@@ -271,7 +279,7 @@ class TestHookStoppedTerminal(unittest.TestCase):
             workspace=self.workspace, provider=provider, abort=abort,
         )
 
-        async def patched_run_tools(*args, **kwargs):
+        def _factory():
             # Trip the abort signal AND emit a hook_stopped attachment.
             # The abort check sits between these and the hook_stopped
             # check, so it must win.
@@ -282,8 +290,8 @@ class TestHookStoppedTerminal(unittest.TestCase):
             ]
 
         with patch(
-            "src.query.query._run_tools_partitioned",
-            side_effect=patched_run_tools,
+            "src.services.tool_execution.orchestrator.run_tools",
+            new=_as_run_tools_stub(_factory),
         ):
             messages, terminal = _run(run_query(params))
 
@@ -320,15 +328,12 @@ class TestHookStoppedDoesNotEmitMaxTurnsAttachment(unittest.TestCase):
             workspace=self.workspace, provider=provider, max_turns=1,
         )
 
-        async def patched_run_tools(*args, **kwargs):
-            return [
+        with patch(
+            "src.services.tool_execution.orchestrator.run_tools",
+            new=_as_run_tools_stub(lambda: [
                 _make_tool_result("toolu_005"),
                 _make_hook_stopped_attachment(tool_use_id="toolu_005"),
-            ]
-
-        with patch(
-            "src.query.query._run_tools_partitioned",
-            side_effect=patched_run_tools,
+            ]),
         ):
             messages, terminal = _run(run_query(params))
 

--- a/tests/test_query_terminal.py
+++ b/tests/test_query_terminal.py
@@ -61,6 +61,19 @@ def _make_params(
     )
 
 
+def _as_run_tools_stub(messages_factory):
+    """Adapt a list-of-Messages factory to the orchestrator.run_tools
+    async-generator seam (ch07 unification: the loop consumes
+    MessageUpdate(message=..., new_context=...) updates)."""
+    from src.services.tool_execution.orchestrator import MessageUpdate
+
+    async def _stub(_blocks, _assistants, _can_use_tool, _ctx, *a, **k):
+        for m in messages_factory():
+            yield MessageUpdate(message=m, new_context=_ctx)
+
+    return _stub
+
+
 class TestTerminalCompleted(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
@@ -180,21 +193,23 @@ class TestTerminalAbortedTools(unittest.TestCase):
         params = _make_params(workspace=self.workspace, provider=provider, abort=abort)
 
         async def aborting_runner(*args, **kwargs):
+            from src.services.tool_execution.orchestrator import MessageUpdate
             from src.types.content_blocks import ToolResultBlock
             abort.abort("user_abort")
-            return [
-                UserMessage(content=[
+            yield MessageUpdate(
+                message=UserMessage(content=[
                     ToolResultBlock(
                         tool_use_id="toolu_001",
                         content="aborted",
                         is_error=True,
                     ),
                 ]),
-            ]
+                new_context=None,
+            )
 
         with patch(
-            "src.query.query._run_tools_partitioned",
-            side_effect=aborting_runner,
+            "src.services.tool_execution.orchestrator.run_tools",
+            new=aborting_runner,
         ):
             _, terminal = _run(run_query(params))
         self.assertEqual(terminal.reason, "aborted_tools")

--- a/tests/test_query_tool_failure_loop.py
+++ b/tests/test_query_tool_failure_loop.py
@@ -80,6 +80,19 @@ def _ok_result(tool_use_id: str) -> UserMessage:
     )
 
 
+def _as_run_tools_stub(messages_factory):
+    """Adapt a list-of-Messages factory to the orchestrator.run_tools
+    async-generator seam (ch07 unification: the loop consumes
+    MessageUpdate(message=..., new_context=...) updates)."""
+    from src.services.tool_execution.orchestrator import MessageUpdate
+
+    async def _stub(_blocks, _assistants, _can_use_tool, _ctx, *a, **k):
+        for m in messages_factory():
+            yield MessageUpdate(message=m, new_context=_ctx)
+
+    return _stub
+
+
 class _FailingToolHarness:
     """Provider + patched tool runner that fail identically every turn."""
 
@@ -94,7 +107,12 @@ class _FailingToolHarness:
         return _tool_use_response(f"toolu_{self.turn:03d}")
 
     async def run_tools(self, tool_use_blocks, *args, **kwargs):
-        return [_failing_result(block.id) for block in tool_use_blocks]
+        # ch07 seam: orchestrator.run_tools is an async generator
+        # yielding MessageUpdate objects.
+        from src.services.tool_execution.orchestrator import MessageUpdate
+
+        for block in tool_use_blocks:
+            yield MessageUpdate(message=_failing_result(block.id), new_context=None)
 
 
 def _make_params(*, workspace: Path, provider, max_turns: int = 10) -> QueryParams:
@@ -125,8 +143,8 @@ class TestToolFailureLoopTerminal(unittest.TestCase):
         params = _make_params(workspace=self.workspace, provider=harness.provider)
 
         with patch(
-            "src.query.query._run_tools_partitioned",
-            side_effect=harness.run_tools,
+            "src.services.tool_execution.orchestrator.run_tools",
+            new=harness.run_tools,
         ):
             messages, terminal = _run(run_query(params))
 
@@ -157,8 +175,8 @@ class TestToolFailureLoopTerminal(unittest.TestCase):
         with patch.dict(
             "os.environ", {"CLAUDE_CODE_TOOL_FAILURE_LOOP_THRESHOLD": "0"}
         ), patch(
-            "src.query.query._run_tools_partitioned",
-            side_effect=harness.run_tools,
+            "src.services.tool_execution.orchestrator.run_tools",
+            new=harness.run_tools,
         ):
             _messages, terminal = _run(run_query(params))
 
@@ -180,16 +198,18 @@ class TestToolFailureLoopTerminal(unittest.TestCase):
         provider.chat.side_effect = next_response
 
         async def run_tools(tool_use_blocks, *args, **kwargs):
+            from src.services.tool_execution.orchestrator import MessageUpdate
+
             # Turn 3 succeeds; the rest fail identically.
-            if turn_box["n"] == 3:
-                return [_ok_result(b.id) for b in tool_use_blocks]
-            return [_failing_result(b.id) for b in tool_use_blocks]
+            for b in tool_use_blocks:
+                msg = _ok_result(b.id) if turn_box["n"] == 3 else _failing_result(b.id)
+                yield MessageUpdate(message=msg, new_context=None)
 
         params = _make_params(workspace=self.workspace, provider=provider)
 
         with patch(
-            "src.query.query._run_tools_partitioned",
-            side_effect=run_tools,
+            "src.services.tool_execution.orchestrator.run_tools",
+            new=run_tools,
         ):
             _messages, terminal = _run(run_query(params))
 
@@ -215,8 +235,8 @@ class TestCompatPathSurfacing(unittest.TestCase):
         seen_messages = []
 
         with patch(
-            "src.query.query._run_tools_partitioned",
-            side_effect=harness.run_tools,
+            "src.services.tool_execution.orchestrator.run_tools",
+            new=harness.run_tools,
         ):
             result = _run(run_query_as_agent_loop(
                 initial_messages=[UserMessage(content="do the thing")],

--- a/tests/test_query_unification_round3.py
+++ b/tests/test_query_unification_round3.py
@@ -1,0 +1,307 @@
+"""ch07 round-3 PR-1 acceptance: the unified production tool lane.
+
+query() now consumes orchestrator.run_tools (TS query.ts:1537-1565
+ungated branch) — these pins prove production gained the 14-step
+pipeline: hooks fire, context modifiers apply, permissions fail closed,
+the pool sync routes pool-local tools, and the display feed survives.
+Plan: my-docs/python-port-improvement-round-3/ch07-concurrency-round3-plan.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from src.providers.base import ChatResponse
+from src.query.query import QueryParams, run_query
+from src.tool_system.build_tool import build_tool
+from src.tool_system.context import ToolContext
+from src.tool_system.protocol import ToolResult
+from src.tool_system.registry import ToolRegistry
+from src.types.messages import UserMessage
+from src.utils.abort_controller import AbortController
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+_SCHEMA = {"type": "object", "properties": {}, "additionalProperties": True}
+
+
+def _tool_use_response(name="StubTool", tid="toolu_u1"):
+    return ChatResponse(
+        content="using the tool",
+        model="claude-test",
+        usage={"input_tokens": 5, "output_tokens": 3},
+        finish_reason="tool_use",
+        tool_uses=[{"id": tid, "name": name, "input": {}}],
+    )
+
+
+def _completion():
+    return ChatResponse(
+        content="Done. The task is complete.",
+        model="claude-test",
+        usage={"input_tokens": 5, "output_tokens": 3},
+        finish_reason="end_turn",
+        tool_uses=None,
+    )
+
+
+def _provider(responses):
+    provider = mock.MagicMock()
+    provider.model = "claude-test"
+    provider.chat_stream_response.side_effect = NotImplementedError()
+    seq = list(responses)
+
+    def chat(*a, **k):
+        return seq.pop(0) if len(seq) > 1 else seq[0]
+
+    provider.chat.side_effect = chat
+    return provider
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _params(self, tools, provider, mode="bypassPermissions"):
+        registry = ToolRegistry(tools)
+        ctx = ToolContext(workspace_root=self.workspace)
+        ctx.permission_context.mode = mode
+        return QueryParams(
+            messages=[UserMessage(content="Hi")],
+            system_prompt="You are helpful.",
+            tools=tools,
+            tool_registry=registry,
+            tool_use_context=ctx,
+            provider=provider,
+            abort_controller=AbortController(),
+            max_turns=4,
+        )
+
+
+class TestUnifiedLane(_Base):
+    def test_pool_local_tool_executes_via_options_tools_sync(self):
+        # The stub is NOT in the default registry — execution proves the
+        # options.tools sync routes the ACTIVE pool (no sync would mean
+        # the base-list fallback misses it -> "No such tool" error).
+        ran: list = []
+
+        def call(_i, _c):
+            ran.append(True)
+            return ToolResult(name="StubTool", output="ok")
+
+        tool = build_tool(
+            name="StubTool", input_schema=_SCHEMA, call=call,
+            prompt="s", description="s",
+        )
+        provider = _provider([_tool_use_response(), _completion()])
+        _msgs, terminal = _run(run_query(self._params([tool], provider)))
+        self.assertEqual(terminal.reason, "completed")
+        self.assertTrue(ran)
+
+    def test_pre_tool_use_hooks_fire_in_production(self):
+        # The 14-step lane is the only caller of run_pre_tool_use_hooks —
+        # observing it during run_query proves production unification.
+        seen: list = []
+
+        async def fake_hooks(_ctx, tool, _inp, _tid):
+            seen.append(tool.name)
+            if False:
+                yield
+
+        tool = build_tool(
+            name="StubTool", input_schema=_SCHEMA,
+            call=lambda _i, _c: ToolResult(name="StubTool", output="ok"),
+            prompt="s", description="s",
+        )
+        provider = _provider([_tool_use_response(), _completion()])
+        with mock.patch(
+            "src.services.tool_execution.tool_hooks.run_pre_tool_use_hooks",
+            fake_hooks,
+        ):
+            _msgs, terminal = _run(run_query(self._params([tool], provider)))
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(seen, ["StubTool"])
+
+    def test_serial_context_modifier_visible_to_next_tool(self):
+        observed: list = []
+
+        def first_call(_i, ctx):
+            def modify(c):
+                # NOTE: user_modified is unsuitable as a marker — the
+                # pipeline reassigns it per call from the permission
+                # decision. cwd is a real, stable field.
+                derived = dataclasses.replace(c)
+                derived.cwd = "/modified/by/first"
+                return derived
+
+            return ToolResult(
+                name="First", output="one", context_modifier=modify,
+            )
+
+        def second_call(_i, ctx):
+            observed.append(str(ctx.cwd))
+            return ToolResult(name="Second", output="two")
+
+        first = build_tool(
+            name="First", input_schema=_SCHEMA, call=first_call,
+            prompt="f", description="f",
+        )
+        second = build_tool(
+            name="Second", input_schema=_SCHEMA, call=second_call,
+            prompt="s", description="s",
+        )
+        resp = ChatResponse(
+            content="two tools",
+            model="claude-test",
+            usage={"input_tokens": 5, "output_tokens": 3},
+            finish_reason="tool_use",
+            tool_uses=[
+                {"id": "toolu_m1", "name": "First", "input": {}},
+                {"id": "toolu_m2", "name": "Second", "input": {}},
+            ],
+        )
+        provider = _provider([resp, _completion()])
+        _msgs, terminal = _run(run_query(self._params([first, second], provider)))
+        self.assertEqual(terminal.reason, "completed")
+        # Serial batch (both default non-concurrency-safe): the second
+        # tool sees the first tool's modifier-derived context.
+        self.assertEqual(observed, ["/modified/by/first"])
+
+    def test_permission_deny_fails_closed_in_default_mode(self):
+        # default mode + no permission handler: ask -> fail-closed deny;
+        # call() never runs; the loop completes with an error result.
+        ran: list = []
+
+        def call(_i, _c):
+            ran.append(True)
+            return ToolResult(name="StubTool", output="nope")
+
+        tool = build_tool(
+            name="StubTool", input_schema=_SCHEMA, call=call,
+            prompt="s", description="s",
+        )
+        provider = _provider([_tool_use_response(), _completion()])
+        msgs, terminal = _run(
+            run_query(self._params([tool], provider, mode="default"))
+        )
+        self.assertEqual(terminal.reason, "completed")
+        self.assertFalse(ran)
+        # The ask resolved to a fail-closed DENY: an is_error tool_result
+        # went back to the model (its message text is the ask prompt).
+        error_blocks = [
+            b
+            for m in msgs
+            for b in (getattr(m, "content", None) or [])
+            if (isinstance(b, dict) and b.get("type") == "tool_result"
+                and b.get("is_error"))
+        ]
+        self.assertEqual(len(error_blocks), 1)
+
+    def test_display_feed_reads_metadata_tool_output(self):
+        # (j): run_tool_use's ToolResultBlock carries dict outputs as
+        # metadata["tool_output"] for the REPL preview extraction.
+        from src.services.tool_execution.tool_execution import run_tool_use
+        from src.types.content_blocks import ToolResultBlock
+        from src.types.messages import AssistantMessage
+
+        structured = {"filePath": "x.txt", "structuredPatch": []}
+
+        tool = build_tool(
+            name="DictTool", input_schema=_SCHEMA,
+            call=lambda _i, _c: ToolResult(name="DictTool", output=structured),
+            prompt="d", description="d",
+        )
+        ctx = ToolContext(workspace_root=self.workspace)
+        ctx.permission_context.mode = "bypassPermissions"
+        ctx.options.tools = [tool]
+
+        async def drive():
+            out = []
+            async for u in run_tool_use(
+                __import__("types").SimpleNamespace(
+                    name="DictTool", input={}, id="toolu_d1",
+                ),
+                AssistantMessage(content="t"),
+                lambda *a, **k: {"behavior": "allow"},
+                ctx,
+            ):
+                out.append(u)
+            return out
+
+        updates = _run(drive())
+        blocks = [
+            b
+            for u in updates
+            for b in (getattr(getattr(u, "message", u), "content", None) or [])
+            if isinstance(b, ToolResultBlock)
+        ]
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0].metadata.get("tool_output"), structured)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestCanUseToolAdapter(_Base):
+    def test_user_modified_synthesis_on_dialog_updates(self):
+        # ask -> handler allows WITH "don't ask again" updates and a fresh
+        # updated_input -> userModified True reaches the call context.
+        from src.services.tool_execution.can_use_tool_adapter import (
+            build_can_use_tool,
+        )
+        from types import SimpleNamespace
+
+        tool = build_tool(
+            name="AskTool", input_schema=_SCHEMA,
+            call=lambda _i, _c: ToolResult(name="AskTool", output="ok"),
+            prompt="a", description="a",
+        )
+        ctx = ToolContext(workspace_root=self.workspace)
+        ctx.permission_context.mode = "default"
+
+        def handler(_request):
+            # PermissionAskHandler reply contract (handler.py:60-70):
+            # behavior + updated_input + chosen_updates.
+            return SimpleNamespace(
+                behavior="allow",
+                updated_input={"answer": 42},
+                chosen_updates=(),
+                message="",
+            )
+
+        ctx.permission_handler = handler
+        adapter = build_can_use_tool(ctx)
+        decision = adapter(tool, {}, ctx, None, "toolu_um1")
+        self.assertEqual(decision["behavior"], "allow")
+        self.assertEqual(decision["updatedInput"], {"answer": 42})
+        self.assertTrue(decision["userModified"])
+
+    def test_user_modified_false_on_plain_allow(self):
+        from src.services.tool_execution.can_use_tool_adapter import (
+            build_can_use_tool,
+        )
+
+        tool = build_tool(
+            name="FreeTool", input_schema=_SCHEMA,
+            call=lambda _i, _c: ToolResult(name="FreeTool", output="ok"),
+            prompt="f", description="f",
+        )
+        ctx = ToolContext(workspace_root=self.workspace)
+        ctx.permission_context.mode = "bypassPermissions"
+        adapter = build_can_use_tool(ctx)
+        decision = adapter(tool, {}, ctx, None, "toolu_um2")
+        self.assertEqual(decision["behavior"], "allow")
+        self.assertFalse(decision["userModified"])

--- a/tests/test_tool_orchestration.py
+++ b/tests/test_tool_orchestration.py
@@ -98,34 +98,34 @@ class TestMaxToolUseConcurrencyEnvVar:
     """ch07 / M3: production path reads CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY,
     not CLAWCODEX_MAX_TOOL_USE_CONCURRENCY."""
 
-    def _reload_query(self):
-        # Use importlib.import_module so the module is keyed in
-        # sys.modules under its fully-qualified name, which
-        # importlib.reload requires.
-        query_mod = importlib.import_module("src.query.query")
-        return importlib.reload(query_mod)
+    # ch07 unification: the resolver moved to the orchestrator (the
+    # query.py module constant retired with the slim lane); it is read
+    # per-call, so no module reload is needed.
+
+    @staticmethod
+    def _resolve():
+        from src.services.tool_execution.orchestrator import (
+            _get_max_tool_use_concurrency,
+        )
+        return _get_max_tool_use_concurrency()
 
     def test_canonical_env_var_is_honoured(self, monkeypatch):
         monkeypatch.delenv("CLAWCODEX_MAX_TOOL_USE_CONCURRENCY", raising=False)
         monkeypatch.setenv("CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY", "3")
-        mod = self._reload_query()
-        assert mod.MAX_TOOL_USE_CONCURRENCY == 3
+        assert self._resolve() == 3
 
     def test_legacy_env_var_still_works_with_deprecation(self, monkeypatch):
         monkeypatch.delenv("CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY", raising=False)
         monkeypatch.setenv("CLAWCODEX_MAX_TOOL_USE_CONCURRENCY", "7")
         with pytest.warns(DeprecationWarning, match="CLAWCODEX_MAX_TOOL_USE_CONCURRENCY"):
-            mod = self._reload_query()
-        assert mod.MAX_TOOL_USE_CONCURRENCY == 7
+            assert self._resolve() == 7
 
     def test_canonical_takes_precedence_over_legacy(self, monkeypatch):
         monkeypatch.setenv("CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY", "5")
         monkeypatch.setenv("CLAWCODEX_MAX_TOOL_USE_CONCURRENCY", "99")
-        mod = self._reload_query()
-        assert mod.MAX_TOOL_USE_CONCURRENCY == 5
+        assert self._resolve() == 5
 
     def test_default_when_neither_set(self, monkeypatch):
         monkeypatch.delenv("CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY", raising=False)
         monkeypatch.delenv("CLAWCODEX_MAX_TOOL_USE_CONCURRENCY", raising=False)
-        mod = self._reload_query()
-        assert mod.MAX_TOOL_USE_CONCURRENCY == 10
+        assert self._resolve() == 10

--- a/tests/test_tool_pipeline_round3.py
+++ b/tests/test_tool_pipeline_round3.py
@@ -164,11 +164,12 @@ class TestAggregateSkipSet(_Base):
 
 
 class TestProductionLaneAggregate(_Base):
-    def test_production_dispatch_skips_inf_tool_counting(self):
-        # The PRODUCTION lane (query._dispatch_single_tool -> registry
-        # dispatch) has its own counter site — pin its skip-set gate too.
-        from src.query.query import _dispatch_single_tool
-        from src.tool_system.registry import ToolRegistry
+    def test_production_lane_skips_inf_tool_counting(self):
+        # ch07 unification: the production lane IS orchestrator.run_tools
+        # — pin the aggregate skip-set through it (the slim
+        # _dispatch_single_tool lane this test originally pinned was
+        # retired in ch07 PR-1).
+        from src.services.tool_execution.orchestrator import run_tools
 
         big = "x" * (MAX_TOOL_RESULTS_PER_MESSAGE_CHARS + 50_000)
         read_like = _stub_tool(
@@ -180,27 +181,31 @@ class TestProductionLaneAggregate(_Base):
             "SmallTool",
             lambda _i, _c: ToolResult(name="SmallTool", output="y" * 1_000),
         )
-        registry = ToolRegistry([read_like, small_tool])
         ctx = self._context([read_like, small_tool])
 
-        primary, _extras = _dispatch_single_tool(
-            SimpleNamespace(name="ReadLike", input={}, id="toolu_prod_inf"),
-            registry,
-            ctx,
-            [read_like, small_tool],
-        )
+        def allow(*_a, **_k):
+            return {"behavior": "allow"}
+
+        async def drive(name, tid):
+            updates = []
+            async for u in run_tools(
+                [SimpleNamespace(name=name, input={}, id=tid)],
+                [AssistantMessage(content="batch")],
+                allow,
+                ctx,
+            ):
+                if u.message is not None:
+                    updates.append(u.message)
+            return updates
+
+        msgs = _run(drive("ReadLike", "toolu_prod_inf"))
         self.assertEqual(ctx.tool_result_chars_so_far, 0)
-        blocks = self._result_blocks([primary])
+        blocks = self._result_blocks(msgs)
         self.assertEqual(len(blocks), 1)
         self.assertNotIn(PERSISTED_OUTPUT_TAG, str(blocks[0].get("content", "")))
 
-        primary2, _ = _dispatch_single_tool(
-            SimpleNamespace(name="SmallTool", input={}, id="toolu_prod_small"),
-            registry,
-            ctx,
-            [read_like, small_tool],
-        )
-        blocks2 = self._result_blocks([primary2])
+        msgs2 = _run(drive("SmallTool", "toolu_prod_small"))
+        blocks2 = self._result_blocks(msgs2)
         self.assertNotIn(PERSISTED_OUTPUT_TAG, str(blocks2[0].get("content", "")))
         self.assertEqual(ctx.tool_result_chars_so_far, 1_000)
 

--- a/tests/test_tool_result_budget.py
+++ b/tests/test_tool_result_budget.py
@@ -342,237 +342,86 @@ class TestPerMessageAggregateBudget(unittest.TestCase):
         )
 
 
-class TestProductionPathBudgetEnforcement(unittest.TestCase):
-    """WI-5.1 critic B2: the production REPL routes tool execution through
-    ``query._dispatch_single_tool``. That function MUST go through
-    ``process_tool_result_block`` so the aggregate gate engages — the
-    prior layout called ``tool.map_result_to_api()`` directly, leaving
-    the 200K cap unenforced in production.
+# ch07 unification note: TestProductionPathBudgetEnforcement (which drove
+# the retired query._dispatch_single_tool with MagicMock plumbing) was
+# replaced by unified-lane coverage — see
+# tests/test_tool_pipeline_round3.py (aggregate skip-set, cap boundary,
+# production-lane run_tools variants) and
+# TestUnifiedLaneConcurrentCap below.
+
+
+class TestUnifiedLaneConcurrentCap(unittest.TestCase):
+    """Concurrent batches must not bypass the 200K per-message cap.
+
+    The slim lane needed ``_aggregate_lock`` because dispatch ran in
+    ``asyncio.to_thread``; the orchestrator lane's step-11
+    read-decide-write runs await-free ON the event loop, so concurrent
+    tools serialize naturally. This pins the end state: five 60K
+    results through one concurrent batch stay within cap + wrapper
+    slack.
     """
 
     def setUp(self):
         self.tmpdir = tempfile.TemporaryDirectory()
-        self.tool_results_dir = Path(self.tmpdir.name)
+        self.workspace = Path(self.tmpdir.name)
 
     def tearDown(self):
         self.tmpdir.cleanup()
 
-    def test_dispatch_single_tool_increments_aggregate_counter(self):
-        """A successful tool dispatch must bump
-        ``tool_use_context.tool_result_chars_so_far``.
-        """
-        from unittest.mock import MagicMock, patch as _patch
-        from src.query.query import _dispatch_single_tool
-        from src.tool_system.context import ToolContext
-        from src.types.content_blocks import ToolUseBlock
-
-        # Fake tool that returns a 30K-char string.
-        big_output = "x" * 30_000
-        fake_tool = MagicMock()
-        fake_tool.name = "Read"
-        fake_tool.max_result_size_chars = 50_000
-        fake_tool.map_result_to_api = MagicMock(
-            return_value={
-                "type": "tool_result",
-                "tool_use_id": "block-1",
-                "content": big_output,
-            }
-        )
-
-        fake_registry = MagicMock()
-        result_obj = MagicMock()
-        result_obj.output = big_output
-        result_obj.is_error = False
-        fake_registry.dispatch = MagicMock(return_value=result_obj)
-
-        ctx = ToolContext(workspace_root=self.tool_results_dir)
-        ctx.tool_result_chars_so_far = 0
-
-        block = ToolUseBlock(id="block-1", name="Read", input={})
-
-        with _patch(
-            "src.services.tool_execution.tool_result_persistence.resolve_tool_results_dir",
-            return_value=self.tool_results_dir,
-        ):
-            _dispatch_single_tool(block, fake_registry, ctx, tools=[fake_tool])
-
-        # Counter must reflect the block we just processed.
-        self.assertGreater(
-            ctx.tool_result_chars_so_far, 0,
-            "WI-5.1 critic B2: production path didn't increment the aggregate counter",
-        )
-
-    def test_dispatch_concurrent_does_not_bypass_cap(self):
-        """Critic B6: under parallel ``asyncio.to_thread`` dispatch (the
-        production path for concurrency-safe tools like Read/Grep/Glob),
-        N threads racing the counter read MUST NOT all see 0 and all
-        decide their block is under the cap. The ``_aggregate_lock`` on
-        ``ToolContext`` serializes the read-modify-write.
-
-        Test design:
-        - 6 dispatches run via ``asyncio.to_thread``.
-        - A ``threading.Barrier`` aligns all threads at the start of the
-          WI-5.1 read-modify-write region so they ALL hit the counter
-          at the same moment.
-        - ``compute_block_chars`` is patched to ``time.sleep`` BETWEEN
-          the lock'd read and the lock'd write, forcing GIL releases
-          and widening the race window deterministically across CPython
-          versions.
-        - With 6 × 40K-char blocks (240K total > 200K cap), the test
-          asserts (a) every write reflects in the final counter (no
-          lost updates), and (b) at least one block was persisted.
-        """
+    def test_concurrent_batch_respects_cap(self):
         import asyncio
-        import threading
-        import time
-        from unittest.mock import MagicMock, patch as _patch
-        from src.query.query import _dispatch_single_tool
-        from src.tool_system.context import ToolContext
-        from src.types.content_blocks import ToolUseBlock
 
-        big_output = "x" * 40_000
-        barrier = threading.Barrier(6)
+        from src.services.tool_execution.orchestrator import run_tools
+        from src.services.tool_execution.tool_result_persistence import (
+            MAX_TOOL_RESULTS_PER_MESSAGE_CHARS,
+        )
+        from src.tool_system.build_tool import build_tool
+        from src.tool_system.context import ToolContext, ToolUseOptions
+        from src.tool_system.protocol import ToolResult
+        from src.types.messages import AssistantMessage
 
-        def synced_dispatch(call, ctx):
-            barrier.wait(timeout=5.0)
-            r = MagicMock()
-            r.output = big_output
-            r.is_error = False
-            return r
+        def call(_inp, _ctx):
+            return ToolResult(name="BigSafe", output="z" * 60_000)
 
-        fake_registry = MagicMock()
-        fake_registry.dispatch.side_effect = synced_dispatch
+        tool = build_tool(
+            name="BigSafe",
+            input_schema={"type": "object", "properties": {},
+                          "additionalProperties": True},
+            call=call,
+            prompt="b",
+            description="b",
+            is_concurrency_safe=lambda _i: True,
+            max_result_size_chars=100_000,
+        )
+        ctx = ToolContext(
+            workspace_root=self.workspace,
+            options=ToolUseOptions(tools=[tool]),
+        )
+        ctx.permission_context.mode = "bypassPermissions"
 
-        fake_tool = MagicMock()
-        fake_tool.name = "Read"
-        fake_tool.max_result_size_chars = 50_000
-
-        def fake_map(output, block_id):
-            return {
-                "type": "tool_result",
-                "tool_use_id": block_id,
-                "content": output,
-            }
-        fake_tool.map_result_to_api.side_effect = fake_map
-
-        ctx = ToolContext(workspace_root=self.tool_results_dir)
+        from types import SimpleNamespace
 
         blocks = [
-            ToolUseBlock(id=f"b{i}", name="Read", input={})
-            for i in range(6)
+            SimpleNamespace(name="BigSafe", input={}, id=f"toolu_cap_{i}")
+            for i in range(5)
         ]
 
-        # Patch ``compute_block_chars`` to sleep so the read-modify-write
-        # path releases the GIL and the race window opens
-        # deterministically. Importantly we patch the name as it's
-        # resolved in ``src.query.query`` (since that's how
-        # ``_dispatch_single_tool`` imports it).
-        from src.services.tool_execution import tool_result_persistence as _trp
+        def allow(*_a, **_k):
+            return {"behavior": "allow"}
 
-        original_compute = _trp.compute_block_chars
+        async def drive():
+            async for _u in run_tools(
+                blocks, [AssistantMessage(content="t")], allow, ctx,
+            ):
+                pass
 
-        def slow_compute(block):
-            time.sleep(0.02)  # 20 ms — far exceeds any GIL switch interval
-            return original_compute(block)
-
-        async def run_parallel():
-            async def dispatch_one(b):
-                return await asyncio.to_thread(
-                    _dispatch_single_tool, b, fake_registry, ctx, [fake_tool]
-                )
-            return await asyncio.gather(*(dispatch_one(b) for b in blocks))
-
-        with _patch(
-            "src.services.tool_execution.tool_result_persistence.resolve_tool_results_dir",
-            return_value=self.tool_results_dir,
-        ), _patch(
-            "src.services.tool_execution.tool_result_persistence.compute_block_chars",
-            side_effect=slow_compute,
-        ):
-            results = asyncio.run(run_parallel())
-
-        # After 6 × 40K = 240K of inline content, the final counter
-        # should reflect ALL writes (no lost updates). With the lock,
-        # every write goes through ``+=`` under serialization — so the
-        # sum equals the actual block sizes. Without the lock, races
-        # lose writes (every thread reads 0 → counter = ONE block's
-        # worth, not six).
-        # results is now list[(primary, extras)] tuples; sum the primary
-        # tool_result content lengths.
-        self.assertEqual(
+        asyncio.run(drive())
+        # 3x60K fit under 200K; the 4th/5th force-persist to wrappers.
+        self.assertLessEqual(
             ctx.tool_result_chars_so_far,
-            sum(len(pair[0].content[0].content) for pair in results),
-            "Concurrent writes lost updates — aggregate counter doesn't "
-            "reflect every block's contribution. Lock is missing or "
-            "broken.",
-        )
-        # And at least one block must be persisted: the 240K total
-        # exceeds the 200K cap by 40K.
-        persisted_count = sum(
-            1
-            for pair in results
-            if "<persisted-output>" in pair[0].content[0].content
-        )
-        self.assertGreater(
-            persisted_count, 0,
-            "Critic B6: concurrent dispatch bypassed the WI-5.1 cap — "
-            "240K of inline content reached the message instead of "
-            "persisting the over-budget tail to disk",
+            MAX_TOOL_RESULTS_PER_MESSAGE_CHARS + 6_000,
         )
 
-    def test_dispatch_aggregate_triggers_persistence_when_over_cap(self):
-        """When the running aggregate would push past 200K, the next block
-        is persisted to disk instead of returned inline.
-        """
-        from unittest.mock import MagicMock, patch as _patch
-        from src.query.query import _dispatch_single_tool
-        from src.tool_system.context import ToolContext
-        from src.types.content_blocks import ToolUseBlock
-
-        # 30K output that alone fits under per-tool 50K threshold.
-        big_output = "x" * 30_000
-        fake_tool = MagicMock()
-        fake_tool.name = "Read"
-        fake_tool.max_result_size_chars = 50_000
-        fake_tool.map_result_to_api = MagicMock(
-            return_value={
-                "type": "tool_result",
-                "tool_use_id": "block-2",
-                "content": big_output,
-            }
-        )
-
-        fake_registry = MagicMock()
-        result_obj = MagicMock()
-        result_obj.output = big_output
-        result_obj.is_error = False
-        fake_registry.dispatch = MagicMock(return_value=result_obj)
-
-        ctx = ToolContext(workspace_root=self.tool_results_dir)
-        # Running aggregate already at 190K — the new 30K block must
-        # trigger persistence to keep the message within budget.
-        ctx.tool_result_chars_so_far = 190_000
-
-        block = ToolUseBlock(id="block-2", name="Read", input={})
-
-        with _patch(
-            "src.services.tool_execution.tool_result_persistence.resolve_tool_results_dir",
-            return_value=self.tool_results_dir,
-        ):
-            primary, extras = _dispatch_single_tool(
-                block, fake_registry, ctx, tools=[fake_tool]
-            )
-
-        # No supplemental messages expected for this test.
-        self.assertEqual(extras, [])
-        # The returned UserMessage's tool_result content should be the
-        # ``<persisted-output>`` wrapper, NOT the raw 30K output.
-        content = primary.content[0].content
-        self.assertIn(
-            "<persisted-output>", content,
-            "WI-5.1 critic B2: aggregate gate didn't fire on production path "
-            "— large block returned inline instead of persisted",
-        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Round-3 chapter-7 PR-1 of 2. The port had TWO tool-execution systems: a slim inline lane in the production loop and a TS-faithful 14-step lane (`run_tool_use` + orchestrator + streaming executor) with zero production callers. This PR makes the orchestrator lane THE production path — exactly TS's ungated `runTools` branch (`query.ts:1537-1565`) — closing ch06's G6 hand-off.

**Behavioral changes:**
- PreToolUse/PostToolUse hooks, input backfill (permission rules now see normalized input), call-input convergence, base-list lookup fallback, error classification, and context modifiers now run **in production** for the first time.
- `QueryConfig.streaming_tool_execution` default flipped to `False` — the gate existed but was consumed by nothing; PR-2 owns wiring the streaming executor (provider block events, mid-stream `addTool`, `discard()` on both retry lanes) and any flip back.
- Normalize merge made TS-exact (`messages.ts:2445-2489`): the port-invented mixed-merge guard deleted; unconditional merge + tool_result hoist + `joinTextAtSeam` (fixes a live text-seam bug). The slim lane's primaries-first reorder existed only to compensate — retired.
- ESC contract ported to the unified lane: user-cancel classification (excl. `sibling_error`/`streaming_fallback`), pre-call REJECT gate, post-call override, dual-contract AbortError handling (paired result + no follow-up turn).
- `run_tool_use` builds `ToolResultBlock` objects with in-process `metadata["tool_output"]` (display feed + guard shape + multimodal preservation; metadata never serializes to the wire).
- Collected tool_results filtered to strict `type=="user"` (TS `:1552-1557`) — `AttachmentMessage` subclasses `UserMessage` and must not enter next-turn history; hook-stop detection moved in-loop accordingly.

## Test plan

- [x] 7 new acceptance pins (hooks fire in production; serial context-modifier visibility; fail-closed deny with call-not-run; pool-local tool via `options.tools` sync; display-feed carrier; userModified synthesis ×2)
- [x] ESC suite rewritten against the unified lane with NEW pins (streaming_fallback classification, abort-reason `tool_raised_abort_error`)
- [x] Seam-casualty suites retargeted (hook_stopped, failure-loop, terminal, e2e file-read incl. the interleaved-pairing e2e proving no reorder shim is needed, env-var resolver, concurrent budget cap)
- [x] DoD mutation checks all kill (merge-guard restore → 2F; userModified synthesis removal → 1F; in-loop→post-loop hook-stop → 3F) — two initially SURVIVED, which produced the strict-type filter fix and the adapter pins
- [x] Full suite: 7,892 passed / 9 failed = the documented pre-existing env baseline
- [x] Critic: gap-doc rev-2 APPROVE; plan REVISE (3 production-breaking corrections) applied; implementation APPROVE (nits applied: stale docstring, import prune)

🤖 Generated with [Claude Code](https://claude.com/claude-code)