### PR TITLE
Add a discoverable /ultracode <task> command

### DIFF
--- a/docs/workflow-commands-and-ultracode-plan.md
+++ b/docs/workflow-commands-and-ultracode-plan.md
@@ -71,6 +71,17 @@ identical treatment — they have no `load_and_register_workflows`.
   case); `ultracode_reminder_for` precedence + gating (None when disabled); session set/clear/reset;
   `/effort ultracode` enables session mode and is gated; a real `/effort` level clears it.
 
+### Part B.2 — the `/ultracode` slash command (added from user feedback)
+The doc specifies only the bare `ultracode` keyword, but users naturally type `/ultracode` (like every
+other command) and got no autocomplete and no dispatch — the keyword fires only on non-slash input via
+`chat()`, so `/ultracode` hit `handle_command` as an unknown command. Add a discoverable, autocompleting
+**`/ultracode <task>`** command (bundled `PromptCommand`, `kind="workflow"`, gated by
+`is_workflows_enabled()`) whose directive tells the model to **author** a fresh workflow script for the
+task and launch it via the Workflow tool — vs. `/deep-research` / saved `/<name>`, which run an
+*existing* script. Lives in `workflows_integration.py::_ultracode_command`, registered through
+`bundled_workflow_commands()` (same path that makes `/deep-research` dispatch + autocomplete).
+The bare keyword + `/effort ultracode` session mode are unchanged.
+
 ## Out of scope (call it out, don't half-build)
 - Wiring the keyword into the **TUI** chat path (different submission seam); the detection/reminder
   logic is a reusable pure module so the TUI can adopt it in a follow-up. REPL is the user's surface.

--- a/src/command_system/workflows_integration.py
+++ b/src/command_system/workflows_integration.py
@@ -62,6 +62,42 @@ def _workflow_to_command(path: Path, loaded_from: str) -> Optional[PromptCommand
     )
 
 
+_ULTRACODE_DIRECTIVE = (
+    "The user invoked /ultracode — they are explicitly opting into multi-agent "
+    'workflow orchestration and want you to AUTHOR and run a workflow (a "pipeline") '
+    "for the task below, instead of doing it turn by turn.\n\n"
+    "Design a workflow script for the task: decompose it into phases, fan out "
+    "subagents for the independent parts (parallel/pipeline), and adversarially verify "
+    "findings before synthesizing. Then launch it by calling the Workflow tool with "
+    "your script passed inline as `script` (see the Workflow tool's own description for "
+    "the script shape — it begins with `export const meta = {...}`). If the task below "
+    "is empty, ask the user what they want the workflow to do instead of guessing.\n\n"
+    "The Workflow tool launches the run in the BACKGROUND and returns a `run_id` "
+    "immediately. As soon as it returns, STOP: reply with one short sentence confirming "
+    "the workflow started (mention the run_id) and END YOUR TURN. Do NOT wait for it, "
+    "poll it, call another tool, or do the work yourself — the finished result is "
+    "delivered automatically when the run completes.\n\n"
+    "Task:\n$ARGUMENTS"
+)
+
+
+def _ultracode_command() -> PromptCommand:
+    """The ``/ultracode`` command: a discoverable, autocompleting slash form of the
+    ``ultracode`` authoring keyword. ``/ultracode <task>`` directs the model to
+    author a fresh workflow script for the task and launch it via the Workflow tool
+    (vs. ``/deep-research`` / saved ``/<name>``, which run an *existing* script)."""
+    return PromptCommand(
+        name="ultracode",
+        description="Author and run a multi-agent workflow (pipeline) for a task",
+        kind="workflow",
+        loaded_from="bundled",
+        source="bundled",
+        is_enabled=is_workflows_enabled,
+        argument_hint="<task>",
+        markdown_content=_ULTRACODE_DIRECTIVE,
+    )
+
+
 def _deep_research_command() -> Optional[PromptCommand]:
     path = bundled_workflow_path("deep_research")
     try:
@@ -96,7 +132,7 @@ def bundled_workflow_commands() -> list[Command]:
     """
     from .workflows_command import WORKFLOWS_COMMAND
 
-    out: list[Command] = [WORKFLOWS_COMMAND]
+    out: list[Command] = [WORKFLOWS_COMMAND, _ultracode_command()]
     deep = _deep_research_command()
     if deep is not None:
         out.append(deep)
@@ -122,7 +158,7 @@ def load_workflow_commands(cwd: str) -> list[Command]:
     (project wins over personal on a name clash)."""
     from .workflows_command import WORKFLOWS_COMMAND
 
-    commands: list[Command] = [WORKFLOWS_COMMAND]
+    commands: list[Command] = [WORKFLOWS_COMMAND, _ultracode_command()]
     deep = _deep_research_command()
     if deep is not None:
         commands.append(deep)

--- a/tests/test_ultracode.py
+++ b/tests/test_ultracode.py
@@ -142,3 +142,38 @@ def test_picker_includes_ultracode_when_enabled():
 def test_picker_excludes_ultracode_when_disabled(monkeypatch):
     monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")
     assert "ultracode" not in [o.value for o in _effort_options("auto")]
+
+
+# ── /ultracode slash command (discoverable authoring form) ────────────────────
+
+
+def _names(cmds):
+    return {getattr(c, "name", None) for c in cmds}
+
+
+def test_ultracode_is_a_registered_command():
+    from src.command_system.builtins import get_builtin_commands, register_builtin_commands
+    from src.command_system.registry import get_command_registry
+
+    assert "ultracode" in _names(get_builtin_commands())  # autocompletes + dispatches
+    register_builtin_commands(None)
+    cmd = get_command_registry().get("ultracode")
+    assert cmd is not None
+    assert getattr(cmd, "kind", None) == "workflow"
+
+
+def test_ultracode_command_directive_authors_and_launches():
+    from src.command_system.workflows_integration import _ultracode_command
+
+    directive = _ultracode_command().markdown_content or ""
+    assert "AUTHOR" in directive            # author a fresh workflow…
+    assert "Workflow tool" in directive     # …and launch it via the tool
+    assert "$ARGUMENTS" in directive        # the task is substituted in
+    assert "END YOUR TURN" in directive     # background run → don't block
+
+
+def test_ultracode_command_absent_when_workflows_disabled(monkeypatch):
+    from src.command_system.builtins import get_builtin_commands
+
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")
+    assert "ultracode" not in _names(get_builtin_commands())


### PR DESCRIPTION
## Why
Follow-up to #303. The `ultracode` authoring trigger shipped as a bare **keyword** (the design doc's literal wording: "include the keyword `ultracode`"). But typing **`/ultracode`** — the natural thing, since everything else is a slash command — gave **no autocomplete** and dispatched as an *unknown* command: the keyword only fires on non-slash input through `chat()`, so `/ultracode` hit `handle_command` and fell through to the slash palette.

(Reported: "when I type `/ultracode` there is no auto completion. Are you sure `/ultracode` functions correctly for creating a pipeline?" — it didn't.)

## What
Add a real **`/ultracode <task>`** command: a bundled `PromptCommand` (`kind="workflow"`, gated by `is_workflows_enabled()`) whose directive tells the model to **author** a fresh workflow script for the task and launch it via the Workflow tool, then stop (background run). Registered through `bundled_workflow_commands()` — the same path that makes `/deep-research` dispatch + autocomplete.

- `/ultracode` now appears in `/` completion with a **`workflow`** tag and the description "Author and run a multi-agent workflow (pipeline) for a task".
- `/ultracode build a web scraper for hacker news` renders the directive with the task substituted into `Task:\n…` (verified end-to-end through `execute_command_async`).
- Distinct from `/deep-research` and saved `/<name>`, which run an **existing** script. The bare `ultracode` keyword and `/effort ultracode` session mode are unchanged.

## Verified
```
1. /ultracode registered:      True | kind: workflow
2. /ultracode autocompletes:   True
3. suggestion tag/desc:        ('workflow', 'Author and run a multi-agent workflow (pipeline) for a task')
4. directive authors+launches: True
5. gated off when disabled:    True
```

## Honest caveat
This wires the command → directive → model turn (the same proven path as `/deep-research`, which you've run). Whether the model then authors a *valid* script that the Workflow tool runs to completion is model behavior on that same path — not something this PR can guarantee. The plumbing (registration, autocomplete, dispatch, task substitution) is tested + verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)