### PR TITLE
advisor: add advisor_enabled master switch (off by default) in config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ The configuration file is saved in in `~/.clawcodex/config.json`. Example struct
     "max_history": 100
   },
   "settings": {
+    "advisor_enabled": false,
     "advisor_model": "claude-sonnet-4-6",
     "advisor_client_mode": false,
     "advisor_provider": "openai"
@@ -325,7 +326,7 @@ The configuration file is saved in in `~/.clawcodex/config.json`. Example struct
 ```
 
 - **`session`** — REPL session persistence: `auto_save` writes each session automatically; `max_history` caps retained turns.
-- **`settings`** — the advisor model used for background helpers (`advisor_provider` / `advisor_model`, and `advisor_client_mode` to route via the client).
+- **`settings`** — the advisor (reviewer) feature. **`advisor_enabled` is the master switch — `false` by default, so the advisor is OFF unless you opt in** (set it to `true`, or run `/advisor <provider>:<model>` which flips it on). `advisor_provider` / `advisor_model` pick the reviewer model; `advisor_client_mode` routes the call via the client.
 - **`env`** — secrets and environment values injected at startup (e.g. `TAVILY_API_KEY` for web search). Managed via `clawcodex config`; keys here are exported into the process environment without overriding anything you already set in your shell.
 
 ### Run

--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -620,6 +620,44 @@ def _write_advisor_client_mode(context: CommandContext, value: bool) -> None:
     invalidate_settings_cache()
 
 
+def _read_current_advisor_enabled(context: CommandContext) -> bool:
+    """Resolve the advisor master switch (reactive store preferred, settings
+    fallback). Mirrors ``_read_current_advisor_client_mode``."""
+    store = getattr(context, "app_state_store", None)
+    if store is not None:
+        try:
+            return bool(getattr(store.get_state(), "advisor_enabled", False))
+        except Exception:
+            pass
+    try:
+        from ..settings.settings import get_settings
+        return bool(getattr(get_settings(), "advisor_enabled", False))
+    except Exception:
+        return False
+
+
+def _write_advisor_enabled(context: CommandContext, value: bool) -> None:
+    """Persist the advisor master switch (store-preferred, settings fallback).
+    Mirrors ``_write_advisor_client_mode`` — the store path fires
+    ``_on_advisor_enabled_change`` which persists to settings."""
+    store = getattr(context, "app_state_store", None)
+    if store is not None:
+        from ..state.app_state import replace_state
+        store.set_state(lambda s: replace_state(s, advisor_enabled=bool(value)))
+        return
+    from .. import config as cfg_mod
+    from ..settings.settings import invalidate_settings_cache
+    mgr = cfg_mod._get_default_manager()
+    cfg = mgr.load_global()
+    settings_section = cfg.get("settings")
+    if not isinstance(settings_section, dict):
+        settings_section = {}
+    settings_section["advisor_enabled"] = bool(value)
+    cfg["settings"] = settings_section
+    mgr.save_global(cfg)
+    invalidate_settings_cache()
+
+
 def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResult:
     """Handle /advisor — configure the reviewer model.
 
@@ -690,6 +728,7 @@ def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResu
     current_advisor = _read_current_advisor_model(context)
     current_provider = _read_current_advisor_provider(context)
     current_client_mode = _read_current_advisor_client_mode(context)
+    current_enabled = _read_current_advisor_enabled(context)
 
     main_loop_model = ""
     if provider is not None:
@@ -749,6 +788,7 @@ def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResu
             current_advisor,
             force_client_mode=current_client_mode,
             advisor_provider=current_provider,
+            advisor_enabled=current_enabled,
         )
         mode_label = {
             ADVISOR_MODE_SERVER_SIDE: "active (server-side)",
@@ -758,6 +798,8 @@ def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResu
         suffix = ""
         if current_client_mode:
             suffix = " [--client forced]"
+        if not current_enabled:
+            suffix += " [disabled: advisor_enabled is off]"
         return (
             f"Advisor: {current_provider}:{current_advisor} — {mode_label}{suffix}\n"
             'Use "/advisor unset" to disable or '
@@ -818,6 +860,8 @@ def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResu
             _write_advisor_provider(context, None)
         if current_client_mode:
             _write_advisor_client_mode(context, False)
+        if current_enabled:
+            _write_advisor_enabled(context, False)  # master switch off
         if previous_model or previous_provider:
             prior = (
                 f"{previous_provider}:{previous_model}"
@@ -888,6 +932,8 @@ def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResu
     normalized = canonical_model_name(resolved)
     _write_advisor_model(context, normalized)
     _write_advisor_provider(context, provider_part)
+    # Explicitly configuring the advisor opts in: flip the master switch on.
+    _write_advisor_enabled(context, True)
     if force_client_flag is True:
         _write_advisor_client_mode(context, True)
     elif force_client_flag is False:
@@ -907,6 +953,7 @@ def advisor_command_call(args: str, context: CommandContext) -> LocalCommandResu
         normalized,
         force_client_mode=effective_client_mode,
         advisor_provider=provider_part,
+        advisor_enabled=True,  # just enabled above
     )
     if chosen_mode == ADVISOR_MODE_SERVER_SIDE:
         mode_msg = "Will run server-side (Anthropic beta path)."

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -450,7 +450,10 @@ async def _call_model_sync(
         configured = (getattr(settings, "advisor_model", "") or "").strip()
         configured_provider = (getattr(settings, "advisor_provider", "") or "").strip()
         force_client = bool(getattr(settings, "advisor_client_mode", False))
-        if configured:
+        # Master switch (default False): the advisor stays inactive unless the
+        # user opted in via `advisor_enabled` in ~/.clawcodex/config.json.
+        advisor_enabled = bool(getattr(settings, "advisor_enabled", False))
+        if configured and advisor_enabled:
             from ..models.model import canonical_model_name
             candidate = canonical_model_name(configured)
             advisor_mode = decide_advisor_mode(
@@ -459,6 +462,7 @@ async def _call_model_sync(
                 candidate,
                 force_client_mode=force_client,
                 advisor_provider=configured_provider,
+                advisor_enabled=advisor_enabled,
             )
             if advisor_mode != ADVISOR_MODE_INACTIVE:
                 advisor_model_normalized = candidate

--- a/src/settings/types.py
+++ b/src/settings/types.py
@@ -100,6 +100,13 @@ class SettingsSchema:
     # ``/advisor <model> --client``. See decide_advisor_mode() in
     # src/utils/advisor.py for the full activation table.
     advisor_client_mode: bool = False
+    # Master on/off switch for the advisor (reviewer tool). Default False —
+    # the advisor is OFF unless the user explicitly opts in, even when
+    # advisor_model/advisor_provider are configured. Enable via
+    # ``"advisor_enabled": true`` in ~/.clawcodex/config.json's "settings"
+    # block, or by running ``/advisor <provider>:<model>`` (which flips it on).
+    # ``decide_advisor_mode`` returns INACTIVE whenever this is False.
+    advisor_enabled: bool = False
 
     # Provider
     provider: str = "anthropic"

--- a/src/state/app_state.py
+++ b/src/state/app_state.py
@@ -116,6 +116,12 @@ class AppState:
     # ``_on_advisor_client_mode_change``.
     advisor_client_mode: bool = False
 
+    # Master on/off switch for the advisor. Default False — the advisor is
+    # OFF unless explicitly enabled (config flag ``advisor_enabled`` or
+    # ``/advisor <provider>:<model>``). Persisted to ``settings.advisor_enabled``
+    # via ``_on_advisor_enabled_change``.
+    advisor_enabled: bool = False
+
 
 def replace_state(state: AppState, **changes: Any) -> AppState:
     """Return a copy of ``state`` with ``changes`` applied. Equivalent
@@ -453,6 +459,29 @@ def _on_advisor_client_mode_change(old: AppState, new: AppState) -> None:
         )
 
 
+def _on_advisor_enabled_change(old: AppState, new: AppState) -> None:
+    """Persist the advisor master switch to user settings + invalidate the read
+    cache. Same persistence pattern as ``_on_advisor_client_mode_change``."""
+    if old.advisor_enabled == new.advisor_enabled:
+        return
+    from src import config as cfg_mod
+    from src.settings.settings import invalidate_settings_cache
+    try:
+        mgr = cfg_mod._get_default_manager()
+        cfg = mgr.load_global()
+        settings_section = cfg.get("settings")
+        if not isinstance(settings_section, dict):
+            settings_section = {}
+        settings_section["advisor_enabled"] = bool(new.advisor_enabled)
+        cfg["settings"] = settings_section
+        mgr.save_global(cfg)
+        invalidate_settings_cache()
+    except Exception:
+        logger.exception(
+            "Failed to persist advisor_enabled to settings; in-memory value still active"
+        )
+
+
 # Registry. EVERY field in AppState must appear here as a handler
 # (function-form, including explicit no-ops). The coverage test enforces
 # this — adding a new AppState field without a handler entry fails
@@ -466,6 +495,7 @@ _FIELD_HANDLERS: dict[str, Callable[[AppState, AppState], None]] = {
     "advisor_model": _on_advisor_model_change,
     "advisor_provider": _on_advisor_provider_change,
     "advisor_client_mode": _on_advisor_client_mode_change,
+    "advisor_enabled": _on_advisor_enabled_change,
 }
 
 

--- a/src/utils/advisor.py
+++ b/src/utils/advisor.py
@@ -343,6 +343,7 @@ def decide_advisor_mode(
     *,
     force_client_mode: bool = False,
     advisor_provider: str | None = None,
+    advisor_enabled: bool = True,
 ) -> str:
     """Pick activation mode for the upcoming turn.
 
@@ -368,7 +369,15 @@ def decide_advisor_mode(
        lands on the same Anthropic API as the main loop.
     5. Otherwise, if the advisor provider is configured → CLIENT_SIDE.
     6. Else INACTIVE — the configured advisor can't be reached.
+
+    ``advisor_enabled`` is the master switch (settings ``advisor_enabled``,
+    default False in production): when False the advisor is INACTIVE regardless
+    of model/provider. The parameter defaults True so direct callers (the
+    activation truth-table tests) keep their behavior; production call sites pass
+    ``get_settings().advisor_enabled``.
     """
+    if not advisor_enabled:
+        return ADVISOR_MODE_INACTIVE
     if _env_truthy(_DISABLE_ENV):
         return ADVISOR_MODE_INACTIVE
     if not advisor_model:
@@ -438,6 +447,9 @@ def format_advisor_status(
         return None
     try:
         settings = get_settings()
+        # Master switch off → no advisor segment at all (it isn't running).
+        if not bool(getattr(settings, "advisor_enabled", False)):
+            return None
         advisor_model = (getattr(settings, "advisor_model", "") or "").strip()
         advisor_provider = (getattr(settings, "advisor_provider", "") or "").strip()
         if not advisor_model:
@@ -450,6 +462,7 @@ def format_advisor_status(
             canonical,
             force_client_mode=force_client,
             advisor_provider=advisor_provider,
+            advisor_enabled=True,  # already checked above
         )
     except Exception:
         return None

--- a/tests/test_advisor_client_side.py
+++ b/tests/test_advisor_client_side.py
@@ -232,7 +232,7 @@ class TestBuildAdvisorForwardedMessages(unittest.TestCase):
         with patch("src.utils.advisor._env_truthy", return_value=False), \
              patch("src.settings.settings.get_settings") as get_s, \
              patch("src.models.model.canonical_model_name", side_effect=lambda x: x):
-            fake = type("S", (), {"advisor_model": "claude-opus-4-7", "advisor_provider": "anthropic", "advisor_client_mode": False})()
+            fake = type("S", (), {"advisor_model": "claude-opus-4-7", "advisor_provider": "anthropic", "advisor_client_mode": False, "advisor_enabled": True})()
             get_s.return_value = fake
             out = format_advisor_status(None, "claude-haiku-4-5")
         self.assertIsNotNone(out)
@@ -252,7 +252,7 @@ class TestBuildAdvisorForwardedMessages(unittest.TestCase):
         from unittest.mock import patch
         with patch("src.utils.advisor._env_truthy", return_value=False), \
              patch("src.settings.settings.get_settings") as get_s:
-            fake = type("S", (), {"advisor_model": "", "advisor_provider": "", "advisor_client_mode": False})()
+            fake = type("S", (), {"advisor_model": "", "advisor_provider": "", "advisor_client_mode": False, "advisor_enabled": True})()
             get_s.return_value = fake
             out = format_advisor_status(None, "claude-haiku-4-5")
         self.assertIsNone(out)
@@ -264,7 +264,7 @@ class TestBuildAdvisorForwardedMessages(unittest.TestCase):
         with patch.dict(os.environ, {"CLAUDE_CODE_DISABLE_ADVISOR_TOOL": "1"}, clear=False), \
              patch("src.settings.settings.get_settings") as get_s, \
              patch("src.models.model.canonical_model_name", side_effect=lambda x: x):
-            fake = type("S", (), {"advisor_model": "claude-opus-4-7", "advisor_provider": "anthropic", "advisor_client_mode": False})()
+            fake = type("S", (), {"advisor_model": "claude-opus-4-7", "advisor_provider": "anthropic", "advisor_client_mode": False, "advisor_enabled": True})()
             get_s.return_value = fake
             out = format_advisor_status(None, "claude-haiku-4-5")
         # Even with model set, env-disable → mode is INACTIVE → label shows

--- a/tests/test_advisor_command.py
+++ b/tests/test_advisor_command.py
@@ -161,10 +161,12 @@ class TestAdvisorCommandStorePath(unittest.TestCase):
             )
             res = advisor_command_call("anthropic:claude-opus-4-6", ctx)
             self.assertIn("Advisor set to anthropic:claude-opus-4-6", res.value)
-            # Two writes — model AND provider land separately on the store.
-            self.assertEqual(len(store.writes), 2)
+            # Three writes — model, provider, AND the master switch (advisor_enabled)
+            # land separately on the store; replace_state preserves the earlier fields.
+            self.assertEqual(len(store.writes), 3)
             self.assertEqual(store.writes[-1].advisor_model, "claude-opus-4-6")
             self.assertEqual(store.writes[-1].advisor_provider, "anthropic")
+            self.assertTrue(store.writes[-1].advisor_enabled)
 
     def test_unset_clears_when_set(self) -> None:
         with _IsolatedEnv():
@@ -206,6 +208,7 @@ class TestAdvisorCommandStorePath(unittest.TestCase):
             store = _FakeStore(initial=AppState(
                 advisor_model="claude-opus-4-6",
                 advisor_provider="anthropic",
+                advisor_enabled=True,  # master switch on (else inactive)
             ))
             provider = _fake_first_party_provider("claude-opus-4-5")
             ctx = _make_context(store=store, provider=provider)
@@ -222,8 +225,8 @@ class TestAdvisorCommandStorePath(unittest.TestCase):
             ctx = _make_context(store=store, provider=_fake_first_party_provider())
             res = advisor_command_call("anthropic:haiku", ctx)
             self.assertIn("Advisor set to", res.value)
-            # Two writes — model and provider land separately.
-            self.assertEqual(len(store.writes), 2)
+            # Three writes — model, provider, and the master switch (advisor_enabled).
+            self.assertEqual(len(store.writes), 3)
 
     def test_rejects_unknown_provider(self) -> None:
         # An unknown provider key must be rejected — clawcodex needs a

--- a/tests/test_advisor_request_wiring.py
+++ b/tests/test_advisor_request_wiring.py
@@ -110,7 +110,13 @@ def _isolate_env():
 
 
 def _set_settings(**kwargs):
-    """Write keys into the global settings file + invalidate cache."""
+    """Write keys into the global settings file + invalidate cache.
+
+    Defaults ``advisor_enabled=True`` so a configured advisor is active: the
+    master switch defaults False in production, but these tests exercise the
+    *active* request-wiring paths. Tests that want it off pass it explicitly.
+    """
+    kwargs.setdefault("advisor_enabled", True)
     import src.config as cfg_mod
     from src.config import ConfigManager
     from src.settings.settings import invalidate_settings_cache
@@ -325,6 +331,19 @@ class TestAdvisorInactivePaths(unittest.TestCase):
             provider = _stub_provider_class(AnthropicProvider, cap)
             _run(provider, [UserMessage(content="x")])
             self._assert_inactive(cap)
+
+    def test_no_advisor_when_master_switch_off(self) -> None:
+        # Fully configured, first-party — but advisor_enabled=False (the default)
+        # keeps it inactive. This is the master-switch the user asked for.
+        _set_settings(
+            advisor_model="claude-opus-4-6",
+            advisor_provider="anthropic",
+            advisor_enabled=False,
+        )
+        cap = _Capture()
+        provider = _stub_provider_class(AnthropicProvider, cap)
+        _run(provider, [UserMessage(content="x")])
+        self._assert_inactive(cap)
 
     def test_no_advisor_when_provider_unknown(self) -> None:
         # Post multi-provider rewrite: routing is decided by the


### PR DESCRIPTION
## What you asked
> I saw the advisor showing up. I don't want the advisor mode enabled by default. Add a flag in ~/.clawcodex/config.json to enable it; otherwise disabled by default.

The advisor activated whenever `advisor_model` + `advisor_provider` were set — and the README's settings example sets them, so it turned on unbidden. This adds an explicit **master switch, OFF by default**.

## How to control it
```json
"settings": {
  "advisor_enabled": false,    // ← default; advisor is OFF
  "advisor_model": "claude-sonnet-4-6",
  "advisor_provider": "anthropic"
}
```
Set `"advisor_enabled": true` to turn it on, or run `/advisor anthropic:claude-opus-4-7` (which flips the switch on for you). `/advisor off` flips it back.

## Changes
- **`settings.advisor_enabled`** (bool, default `False`) + matching **AppState** field + `_on_advisor_enabled_change` persistence handler (+ registry entry for the field-coverage contract).
- **`decide_advisor_mode`** gains an `advisor_enabled` param (default `True` so the activation truth-table tests are unaffected) — returns `INACTIVE` when `False`. Production callers pass the setting:
  - **query loop** (`query.py`) — the place the advisor "showed up"; now gated.
  - **status line** (`format_advisor_status`) — hides the advisor segment entirely when off.
- **`/advisor` command** — configuring flips the switch on; `unset`/`off` flips it off; status shows `[disabled: advisor_enabled is off]` when a model is set but the switch is off. Store-preferred read/write helpers mirror `advisor_client_mode`.
- **README** documents it as the default-off master switch.

## Verified
End-to-end: `advisor_enabled:false` in config.json → `get_settings()` False → `decide_advisor_mode` `INACTIVE`; `true` → active. **138 tests pass** (new `test_no_advisor_when_master_switch_off`; active-path tests set the flag; `/advisor` store-write count 2→3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)