### PR TITLE
workflow: honor --dangerously-skip-permissions for subagents + allow reading the tool-results spill dir

### DIFF
--- a/src/tool_system/context.py
+++ b/src/tool_system/context.py
@@ -275,6 +275,19 @@ class ToolContext:
     def allowed_roots(self) -> tuple[Path, ...]:
         roots: list[Path] = [self.workspace_root]
         roots.extend(self.additional_working_directories)
+        # The session's tool-results spill dir is an internal path the runtime
+        # writes large tool results to and then points the model back at (e.g. a
+        # workflow subagent told to Read the offloaded result). Reading it back
+        # must be allowed even though it sits outside workspace_root. Resolved so
+        # the /tmp → /private/tmp (macOS) match holds against the resolved path.
+        try:
+            from src.services.tool_execution.tool_result_persistence import (
+                resolve_tool_results_dir,
+            )
+
+            roots.append(resolve_tool_results_dir(self).resolve())
+        except Exception:
+            pass
         return tuple(roots)
 
     def ensure_allowed_path(self, path: str | Path) -> Path:

--- a/src/workflow/runner.py
+++ b/src/workflow/runner.py
@@ -64,6 +64,27 @@ def _schema_repair_prompt(schema: Any, last_error: Optional[str]) -> str:
     )
 
 
+# Parent modes that already auto-approve at least as much as acceptEdits — never
+# downgrade these for a workflow subagent (matches resolve_permission_mode's
+# "permissive parent takes precedence" rule in src/agent/run_agent.py).
+_PERMISSIVE_PARENT_MODES = ("bypassPermissions", "acceptEdits", "dontAsk")
+
+
+def _subagent_permission_override(parent_context: Any) -> Optional[str]:
+    """Permission mode to force on a workflow subagent, or ``None`` to inherit.
+
+    Forces ``acceptEdits`` (auto-approve file edits) for restrictive sessions
+    (default/plan), but returns ``None`` for an already-permissive session so
+    ``resolve_permission_mode`` carries the parent mode through — crucially,
+    ``bypassPermissions`` from ``--dangerously-skip-permissions`` is inherited
+    rather than silently downgraded to the more-restrictive ``acceptEdits``.
+    """
+    mode = getattr(getattr(parent_context, "permission_context", None), "mode", None)
+    if mode in _PERMISSIVE_PARENT_MODES:
+        return None
+    return "acceptEdits"
+
+
 class LiveAgentRunner:
     def __init__(
         self,
@@ -179,9 +200,14 @@ class LiveAgentRunner:
                 agent_id=agent_id,
                 abort_controller=abort,
                 max_turns=self._max_turns,
-                # Workflow subagents always run acceptEdits (file edits auto-approved)
-                # regardless of the session's mode — per the official spec.
-                permission_mode_override="acceptEdits",
+                # Workflow subagents auto-approve file edits (acceptEdits) regardless
+                # of the session's mode — per the spec — but NEVER downgrade an
+                # already-permissive session. If the user launched with
+                # --dangerously-skip-permissions (bypassPermissions), or any other
+                # permissive parent mode, inherit it (override=None lets
+                # resolve_permission_mode carry the parent mode through); otherwise
+                # elevate restrictive modes (default/plan) to acceptEdits.
+                permission_mode_override=_subagent_permission_override(parent_context),
                 # Already resolved + firewalled + injected; don't let run_agent
                 # re-resolve (which would drop the injected StructuredOutput tool).
                 use_exact_tools=True,

--- a/tests/test_workflow_permission_fixes.py
+++ b/tests/test_workflow_permission_fixes.py
@@ -1,0 +1,81 @@
+"""Workflow permission fixes.
+
+A) ``--dangerously-skip-permissions`` (bypassPermissions) is inherited by
+   workflow subagents, not silently downgraded to acceptEdits — so a subagent is
+   never *more* restricted than the session that launched it.
+B) The internal tool-results spill dir is readable in any mode: the runtime
+   offloads large tool results there and points the model back at them (a
+   workflow subagent told to ``Read`` the offloaded result), so reading it must
+   not trip the workspace allowlist.
+
+Repro for both: ``/wc26-watch-guide`` under ``--dangerously-skip-permissions``
+failed with ``ToolPermissionError: path is outside allowed working directories:
+/private/tmp/claude_tool_results/<pid>/tool-results/toolu_*.txt``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.permissions.types import ToolPermissionContext
+from src.services.tool_execution.tool_result_persistence import resolve_tool_results_dir
+from src.tool_system.context import ToolContext
+from src.tool_system.errors import ToolPermissionError
+from src.workflow.runner import _subagent_permission_override
+
+
+def _parent(mode):
+    return SimpleNamespace(permission_context=SimpleNamespace(mode=mode))
+
+
+# ── Fix A: don't downgrade a permissive session ───────────────────────────────
+
+
+def test_permissive_session_inherited_by_workflow_subagent():
+    # None == "inherit via resolve_permission_mode" → parent mode carries through.
+    assert _subagent_permission_override(_parent("bypassPermissions")) is None
+    assert _subagent_permission_override(_parent("acceptEdits")) is None
+    assert _subagent_permission_override(_parent("dontAsk")) is None
+
+
+def test_restrictive_session_elevated_to_acceptedits():
+    assert _subagent_permission_override(_parent("default")) == "acceptEdits"
+    assert _subagent_permission_override(_parent("plan")) == "acceptEdits"
+    # Missing / unknown mode → safe default of acceptEdits (auto-approve edits).
+    assert _subagent_permission_override(_parent(None)) == "acceptEdits"
+    assert _subagent_permission_override(SimpleNamespace()) == "acceptEdits"
+
+
+# ── Fix B: the tool-results spill dir is readable outside the workspace ────────
+
+
+def _acceptedits_ctx(workspace):
+    # acceptEdits is NOT bypass, so ensure_allowed_path enforces the allowlist —
+    # exactly the mode a workflow subagent runs in for a normal session.
+    return ToolContext(
+        workspace_root=workspace,
+        permission_context=ToolPermissionContext(mode="acceptEdits"),
+    )
+
+
+def test_tool_results_spill_dir_allowed_in_non_bypass_mode(tmp_path):
+    ctx = _acceptedits_ctx(tmp_path)
+    target = resolve_tool_results_dir(ctx) / "toolu_vrtx_01CniSDiu45h5JZN2vUGFaTo.txt"
+    out = ctx.ensure_allowed_path(str(target))
+    assert str(out).endswith("toolu_vrtx_01CniSDiu45h5JZN2vUGFaTo.txt")
+    # the spill dir is among the allowed roots
+    assert any("claude" in str(r).lower() and "tool-results" in str(r) for r in ctx.allowed_roots())
+
+
+def test_unrelated_outside_path_still_blocked(tmp_path):
+    ctx = _acceptedits_ctx(tmp_path)
+    with pytest.raises(ToolPermissionError):
+        ctx.ensure_allowed_path("/etc/passwd")
+
+
+def test_workspace_path_still_allowed(tmp_path):
+    ctx = _acceptedits_ctx(tmp_path)
+    inside = tmp_path / "src" / "x.py"
+    assert ctx.ensure_allowed_path(str(inside)) == inside.resolve()


### PR DESCRIPTION
## Repro
`clawcodex --dangerously-skip-permissions`, then run a saved workflow `/wc26-watch-guide`:
```
Tool Read failed classified=ToolPermissionError: path is outside allowed working
directories: /private/tmp/claude_tool_results/73681/tool-results/toolu_vrtx_*.txt
(allowed: /Users/ericlee2/workspace/clawcodex)
```

## Two independent bugs

### A) Workflow subagents ignored `--dangerously-skip-permissions`
The runner forced **every** subagent to `permission_mode_override="acceptEdits"` "regardless of the session's mode." But `acceptEdits` is *more* restrictive than `bypassPermissions` — so a bypass session was silently **downgraded** for its workflow subagents, re-enabling the working-directory allowlist that bypass is supposed to short-circuit.

**Fix:** `_subagent_permission_override(parent_context)` returns `None` (inherit) when the parent is already permissive (`bypassPermissions` / `acceptEdits` / `dontAsk`), and only elevates restrictive modes (`default` / `plan`) to `acceptEdits`. Subagents are never *more* restricted than the session that launched them — matching `resolve_permission_mode`'s own "permissive parent wins" rule.

### B) The tool-results spill dir wasn't readable (hits non-bypass users too)
That path is the runtime's **own** offload dir — large tool results are written to `…/tool-results/<tool_use_id>.txt` and the model is pointed back at them to `Read`. It lives outside `workspace_root`, so in any non-bypass mode the read tripped the allowlist — so this breaks normal (non-bypass) workflows as well.

**Fix:** `allowed_roots()` now includes the resolved `resolve_tool_results_dir(self)`, so reading offloaded results is allowed while unrelated outside paths stay blocked. (Resolved so the macOS `/tmp` → `/private/tmp` match holds.)

Either fix alone resolves the reported case; together they cover **both** bypass and non-bypass sessions.

## Verified + tests (5)
- `bypassPermissions`/`acceptEdits`/`dontAsk` → inherit; `default`/`plan`/missing → `acceptEdits`.
- Spill-dir path **allowed** in `acceptEdits` (non-bypass); `/etc/passwd` still **blocked**; workspace paths still allowed.
- 231 tests pass across runner / context / persistence / tool-execution suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)