### PR TITLE
feat(providers): thinking-aware streaming + Claude 4.x max_tokens default

### DIFF
--- a/src/providers/anthropic_provider.py
+++ b/src/providers/anthropic_provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import sys
 from typing import Generator, Optional, Any, TYPE_CHECKING
 from urllib.parse import urlparse
@@ -101,6 +102,43 @@ def _extract_usage_dict(usage: Any) -> dict[str, Any]:
         }
 
     return result
+
+
+# Claude 4.x and newer models support a much larger ``max_tokens`` ceiling
+# than the SDK's historical 4096 default — opus-4.x and sonnet-4.x accept
+# up to 32K (and up to 64K with the larger-output beta header). The legacy
+# 4096 default routinely truncated long completions on these models, which
+# in turn caused agent loops to either re-prompt to finish a half-written
+# patch or accept the truncated body verbatim. Bumping to 32K matches
+# Anthropic's documented standard ceiling for 4.x without requiring a
+# beta opt-in.
+#
+# Older Claude 3.x snapshots cap at 4K-8K depending on tier; pulling the
+# default up to 32K would make the API reject those requests with a 400.
+# Detection is by model-name pattern so newer 4.x point releases
+# (e.g. ``claude-opus-4-7-20260201``) opt in automatically.
+_LARGE_MAX_TOKENS_MODEL_PATTERN = re.compile(
+    r"claude-(?:sonnet|opus|haiku)-(?:4-\d+|[5-9]\b|\d{2,})",
+    re.IGNORECASE,
+)
+
+DEFAULT_MAX_OUTPUT_TOKENS_4X = 32000
+DEFAULT_MAX_OUTPUT_TOKENS_LEGACY = 4096
+
+
+def _default_max_tokens(model: str | None) -> int:
+    """Pick a sensible ``max_tokens`` ceiling for the given model.
+
+    Returns 32K for the Claude 4.x family (which is what the API allows
+    without beta opt-ins), and 4096 for everything else (preserves the
+    legacy ceiling on 3.x where the API rejects higher values).
+
+    A caller can always override via ``kwargs["max_tokens"]``; this only
+    affects the default when no value is supplied.
+    """
+    if model and _LARGE_MAX_TOKENS_MODEL_PATTERN.search(model):
+        return DEFAULT_MAX_OUTPUT_TOKENS_4X
+    return DEFAULT_MAX_OUTPUT_TOKENS_LEGACY
 
 
 class AnthropicProvider(BaseProvider):
@@ -304,7 +342,7 @@ class AnthropicProvider(BaseProvider):
             Chat response
         """
         model = self._get_model(**kwargs)
-        max_tokens = kwargs.get("max_tokens", 4096)
+        max_tokens = kwargs.get("max_tokens", _default_max_tokens(model))
 
         system = kwargs.pop("system", None)
 
@@ -346,7 +384,7 @@ class AnthropicProvider(BaseProvider):
             Chunks of response content
         """
         model = self._get_model(**kwargs)
-        max_tokens = kwargs.get("max_tokens", 4096)
+        max_tokens = kwargs.get("max_tokens", _default_max_tokens(model))
 
         # Convert messages
         anthropic_messages = self._prepare_messages(messages)
@@ -404,7 +442,7 @@ class AnthropicProvider(BaseProvider):
         guard.raise_if_pre_aborted()
 
         model = self._get_model(**kwargs)
-        max_tokens = kwargs.get("max_tokens", 4096)
+        max_tokens = kwargs.get("max_tokens", _default_max_tokens(model))
         system = kwargs.pop("system", None)
         anthropic_messages = self._prepare_messages(messages)
 
@@ -459,9 +497,41 @@ class AnthropicProvider(BaseProvider):
                 watchdog = StreamWatchdog(stream)
                 watchdog.arm()
                 try:
-                    for text in stream.text_stream:
-                        # Each chunk pushes the deadline forward.
+                    # Iterate the FULL event stream rather than the
+                    # text-only ``stream.text_stream`` view. With extended
+                    # thinking enabled (Anthropic Claude 4.x), the model
+                    # often emits 60–120s+ of ``thinking_delta`` events
+                    # with no intervening ``text_delta``s while it works
+                    # through a hard prompt. ``text_stream`` only yields
+                    # on text deltas, so the watchdog (default 90s idle)
+                    # would fire and close the stream mid-thinking — the
+                    # provider then falls back to non-streaming ``chat()``
+                    # which the Anthropic SDK rejects with
+                    # "Streaming is required for operations that may take
+                    # longer than 10 minutes."
+                    #
+                    # Resetting the watchdog on EVERY event type
+                    # (thinking deltas, input_json deltas, message_start /
+                    # _stop, content_block_start / _stop, message_delta)
+                    # keeps the stream alive as long as the model is
+                    # genuinely producing output. We still only accumulate
+                    # text into ``streamed_text`` and fire ``on_text_chunk``
+                    # for ``text_delta`` events — thinking is private and
+                    # must not be surfaced to the visible output channel.
+                    for event in stream:
+                        # Each event — text, thinking, tool, snapshot —
+                        # is liveness; push the deadline forward.
                         watchdog.reset()
+                        delta = getattr(event, "delta", None)
+                        if delta is None:
+                            continue
+                        # Only ``TextDelta`` carries a ``text`` field.
+                        # ``ThinkingDelta`` has ``thinking`` (deliberately
+                        # not surfaced — it's the private scratchpad).
+                        # ``InputJSONDelta`` has ``partial_json`` (handled
+                        # by the SDK's final-message accumulation, no
+                        # need to track here).
+                        text = getattr(delta, "text", None)
                         if not text:
                             continue
                         streamed_text += text

--- a/tests/test_anthropic_max_tokens_default.py
+++ b/tests/test_anthropic_max_tokens_default.py
@@ -1,0 +1,147 @@
+"""Tests for the model-aware ``max_tokens`` default in AnthropicProvider.
+
+The legacy SDK default of 4096 truncated long completions on Claude 4.x
+models, which accept up to 32K out of the box (and 64K with a beta opt-
+in). This module covers two surfaces:
+
+  1. ``_default_max_tokens`` — the standalone helper that maps a model
+     name to a sensible ceiling. Returns 32K for the Claude 4.x family,
+     4096 for everything else (the API rejects higher values on 3.x).
+
+  2. The wired call sites — ``chat``, ``chat_stream``, and
+     ``chat_stream_response``. Each must use the helper when the caller
+     doesn't pass an explicit ``max_tokens`` kwarg, and must honor a
+     caller-supplied override unchanged.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from src.providers.anthropic_provider import (
+    AnthropicProvider,
+    _default_max_tokens,
+    DEFAULT_MAX_OUTPUT_TOKENS_4X,
+    DEFAULT_MAX_OUTPUT_TOKENS_LEGACY,
+)
+
+
+class TestDefaultMaxTokensHelper(unittest.TestCase):
+    """Standalone helper coverage."""
+
+    def test_claude_4_family_gets_32k(self):
+        for m in (
+            "claude-opus-4-6",
+            "claude-opus-4-7-20260201",
+            "claude-sonnet-4-5",
+            "claude-sonnet-4-5-20250929",
+            "claude-haiku-4-5",
+        ):
+            self.assertEqual(_default_max_tokens(m), DEFAULT_MAX_OUTPUT_TOKENS_4X, m)
+
+    def test_legacy_3x_stays_at_4096(self):
+        # The Anthropic API rejects larger ``max_tokens`` on 3.x snapshots,
+        # so the helper MUST preserve the legacy ceiling on these.
+        for m in (
+            "claude-3-5-sonnet-20241022",
+            "claude-3-opus-20240229",
+            "claude-3-haiku-20240307",
+        ):
+            self.assertEqual(_default_max_tokens(m), DEFAULT_MAX_OUTPUT_TOKENS_LEGACY, m)
+
+    def test_empty_or_none_model_keeps_legacy_default(self):
+        for m in ("", None):
+            self.assertEqual(_default_max_tokens(m), DEFAULT_MAX_OUTPUT_TOKENS_LEGACY, m)
+
+    def test_unknown_model_name_keeps_legacy_default(self):
+        # If a user runs against a proxy alias the helper doesn't recognize
+        # we default conservatively rather than send 32K and get a 400.
+        for m in ("custom-proxy-model", "my-corp/llm-v3", "gpt-4o"):
+            self.assertEqual(_default_max_tokens(m), DEFAULT_MAX_OUTPUT_TOKENS_LEGACY, m)
+
+
+def _make_provider_with_mock_client(model: str):
+    """Construct an AnthropicProvider whose ``_ensure_client`` returns a
+    MagicMock so we can read off the kwargs passed to ``messages.create``.
+    """
+    provider = AnthropicProvider(api_key="sk-test", model=model)
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = []
+    mock_response.model = model
+    mock_response.usage = None
+    mock_response.stop_reason = "end_turn"
+    mock_client.messages.create.return_value = mock_response
+    provider._ensure_client = MagicMock(return_value=mock_client)
+    return provider, mock_client
+
+
+class TestChatUsesDefault(unittest.TestCase):
+    """End-to-end: confirm the right ``max_tokens`` lands on the SDK call."""
+
+    def test_chat_default_for_opus_4(self):
+        provider, mc = _make_provider_with_mock_client("claude-opus-4-6")
+        provider.chat([{"role": "user", "content": "hi"}])
+        kw = mc.messages.create.call_args.kwargs
+        self.assertEqual(kw["max_tokens"], DEFAULT_MAX_OUTPUT_TOKENS_4X)
+
+    def test_chat_default_for_legacy_35_sonnet(self):
+        provider, mc = _make_provider_with_mock_client("claude-3-5-sonnet-20241022")
+        provider.chat([{"role": "user", "content": "hi"}])
+        kw = mc.messages.create.call_args.kwargs
+        self.assertEqual(kw["max_tokens"], DEFAULT_MAX_OUTPUT_TOKENS_LEGACY)
+
+    def test_chat_explicit_override_wins(self):
+        provider, mc = _make_provider_with_mock_client("claude-opus-4-6")
+        provider.chat([{"role": "user", "content": "hi"}], max_tokens=1024)
+        kw = mc.messages.create.call_args.kwargs
+        self.assertEqual(kw["max_tokens"], 1024)
+
+    def test_chat_explicit_override_lifts_legacy_too(self):
+        provider, mc = _make_provider_with_mock_client("claude-3-5-sonnet-20241022")
+        provider.chat([{"role": "user", "content": "hi"}], max_tokens=8192)
+        kw = mc.messages.create.call_args.kwargs
+        self.assertEqual(kw["max_tokens"], 8192)
+
+
+def _patch_messages_stream(provider: AnthropicProvider):
+    """Patch ``client.messages.stream`` to return a no-op context manager
+    so the streaming tests can read off the kwargs without driving a real
+    stream."""
+    mock_client = MagicMock()
+
+    class _NoopStream:
+        def __enter__(self_inner):
+            stream_obj = MagicMock()
+            stream_obj.text_stream = iter([])
+            return stream_obj
+
+        def __exit__(self_inner, *exc):
+            return False
+
+    mock_client.messages.stream.return_value = _NoopStream()
+    provider._ensure_client = MagicMock(return_value=mock_client)
+    return mock_client
+
+
+class TestChatStreamUsesDefault(unittest.TestCase):
+    """The streaming generator path picks the same default."""
+
+    def test_chat_stream_default_for_opus_4(self):
+        provider = AnthropicProvider(api_key="sk-test", model="claude-opus-4-6")
+        mc = _patch_messages_stream(provider)
+        list(provider.chat_stream([{"role": "user", "content": "hi"}]))
+        kw = mc.messages.stream.call_args.kwargs
+        self.assertEqual(kw["max_tokens"], DEFAULT_MAX_OUTPUT_TOKENS_4X)
+
+    def test_chat_stream_default_for_legacy_3x(self):
+        provider = AnthropicProvider(api_key="sk-test", model="claude-3-opus-20240229")
+        mc = _patch_messages_stream(provider)
+        list(provider.chat_stream([{"role": "user", "content": "hi"}]))
+        kw = mc.messages.stream.call_args.kwargs
+        self.assertEqual(kw["max_tokens"], DEFAULT_MAX_OUTPUT_TOKENS_LEGACY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_anthropic_thinking_keeps_stream_alive.py
+++ b/tests/test_anthropic_thinking_keeps_stream_alive.py
@@ -1,0 +1,162 @@
+"""Regression test for the thinking-aware streaming liveness fix.
+
+Before this fix, ``chat_stream_response`` iterated ``stream.text_stream``
+which only yields on ``text_delta`` events. When extended thinking is
+enabled (Claude 4.x), the model often emits 60-120s+ of ``thinking_delta``
+events with no text in between while it works through a hard prompt.
+The watchdog (default 90s idle) would interpret that as a hung stream,
+close it, and fall back to non-streaming ``chat()`` — which the Anthropic
+SDK rejects with "Streaming is required for operations that may take
+longer than 10 minutes." So every long-prompt + thinking request looked
+empty downstream.
+
+This module pins the fixed behavior: the watchdog now resets on every
+event from the full stream (including thinking deltas), and only
+``text_delta`` events contribute to the visible output.
+"""
+
+from __future__ import annotations
+
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+from src.providers.anthropic_provider import AnthropicProvider
+
+
+class _MockEvent:
+    """Minimal stand-in for an Anthropic streaming event with a delta.
+
+    The provider reads only ``getattr(event, "delta", None)`` and
+    ``getattr(delta, "text", None)``, so we don't need the full SDK
+    types — just the duck-typed shape.
+    """
+
+    def __init__(self, delta=None):
+        self.delta = delta
+
+
+class _TextDelta:
+    type = "text_delta"
+
+    def __init__(self, text: str):
+        self.text = text
+
+
+class _ThinkingDelta:
+    type = "thinking_delta"
+
+    def __init__(self, thinking: str):
+        self.thinking = thinking
+        # No ``text`` attribute — that's the point.
+
+
+def _build_provider_with_fake_stream(events: list) -> tuple[AnthropicProvider, MagicMock, MagicMock]:
+    """Wire a provider whose ``client.messages.stream`` yields ``events``."""
+
+    fake_response = MagicMock()
+    fake_response.close = MagicMock()
+
+    fake_stream = MagicMock()
+    fake_stream.__iter__ = MagicMock(return_value=iter(events))
+    fake_stream.response = fake_response
+
+    # Force the post-stream code path to fall back to ``streamed_text``
+    # by making ``get_final_message`` raise. ``_build_chat_response`` only
+    # runs when ``final_message`` is non-None, so we steer past it for the
+    # tests that care about the streamed-text accumulation path.
+    fake_stream.get_final_message = MagicMock(
+        side_effect=RuntimeError("final message unavailable")
+    )
+
+    stream_cm = MagicMock()
+    stream_cm.__enter__ = MagicMock(return_value=fake_stream)
+    stream_cm.__exit__ = MagicMock(return_value=False)
+
+    fake_client = MagicMock()
+    fake_client.messages.stream.return_value = stream_cm
+
+    provider = AnthropicProvider(api_key="test", model="claude-opus-4-6")
+    provider.client = fake_client
+    return provider, fake_stream, fake_response
+
+
+class TestThinkingDeltasKeepStreamAlive(unittest.TestCase):
+    """When thinking events flow without text, the watchdog must not fire."""
+
+    def test_long_thinking_burst_does_not_trigger_fallback(self):
+        """Stream emits a burst of thinking events spread across more time
+        than the watchdog's idle deadline, then a few text deltas, then
+        completes. The watchdog must NOT fire and the wrapper must NOT
+        fall back to ``chat()`` — the visible output is the concatenation
+        of the text deltas, thinking is never surfaced."""
+
+        captured_text_chunks: list[str] = []
+
+        def slow_thinking_then_text():
+            # Five thinking events spaced ~30ms apart — totalling ~150ms,
+            # well past the 50ms watchdog deadline we'll configure. With
+            # the old text_stream iteration, this would fire the
+            # watchdog because no text deltas arrive during this window.
+            for chunk in ("step 1", "step 2", "step 3", "step 4", "step 5"):
+                time.sleep(0.03)
+                yield _MockEvent(delta=_ThinkingDelta(chunk))
+            # Then two text deltas — the only events that should populate
+            # streamed_text and fire on_text_chunk.
+            yield _MockEvent(delta=_TextDelta("hello "))
+            yield _MockEvent(delta=_TextDelta("world"))
+
+        provider, fake_stream, fake_response = _build_provider_with_fake_stream(
+            list(slow_thinking_then_text())
+        )
+
+        with patch.dict("os.environ", {"CLAUDE_STREAM_IDLE_TIMEOUT_MS": "50"}), \
+             patch.object(provider, "chat") as mock_chat_fallback:
+            result = provider.chat_stream_response(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=None,
+                on_text_chunk=captured_text_chunks.append,
+            )
+
+        # Fallback must NOT have been invoked — the thinking events kept
+        # the stream alive past the would-have-fired-under-text_stream
+        # watchdog deadline.
+        mock_chat_fallback.assert_not_called()
+        # Watchdog must NOT have closed the underlying response.
+        fake_response.close.assert_not_called()
+        # Visible output is the concatenated text-delta payload — thinking
+        # text is deliberately excluded.
+        self.assertEqual(result.content, "hello world")
+        # ``on_text_chunk`` fires once per text delta, not once per event.
+        self.assertEqual(captured_text_chunks, ["hello ", "world"])
+
+
+class TestEventsWithoutDeltasAreSafe(unittest.TestCase):
+    """Events with no ``delta`` attribute (message_start / message_stop /
+    content_block_start / content_block_stop) reset the watchdog but
+    don't populate text. The wrapper must not crash on them."""
+
+    def test_iteration_over_no_delta_events_completes(self):
+        events = [
+            _MockEvent(delta=None),  # MessageStartEvent shape
+            _MockEvent(delta=None),  # ContentBlockStartEvent shape
+            _MockEvent(delta=_TextDelta("ok")),
+            _MockEvent(delta=None),  # ContentBlockStopEvent shape
+            _MockEvent(delta=None),  # MessageStopEvent shape
+        ]
+
+        provider, _, _ = _build_provider_with_fake_stream(events)
+        captured: list[str] = []
+        with patch.object(provider, "chat") as mock_chat_fallback:
+            result = provider.chat_stream_response(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=None,
+                on_text_chunk=captured.append,
+            )
+        mock_chat_fallback.assert_not_called()
+        self.assertEqual(result.content, "ok")
+        self.assertEqual(captured, ["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provider_abort_signal.py
+++ b/tests/test_provider_abort_signal.py
@@ -36,11 +36,30 @@ from src.providers.anthropic_provider import AnthropicProvider
 from src.utils.abort_controller import AbortController, AbortError
 
 
+class _FakeTextDelta:
+    """Duck-typed ``TextDelta`` — the provider reads ``delta.text``."""
+
+    type = "text_delta"
+
+    def __init__(self, text: str):
+        self.text = text
+
+
+class _FakeStreamEvent:
+    """Duck-typed Anthropic stream event with a ``delta`` attribute."""
+
+    def __init__(self, delta=None):
+        self.delta = delta
+
+
 class _FakeStream:
     """Minimal stand-in for the Anthropic SDK's ``messages.stream`` ctx manager.
 
     Yields text chunks one at a time with a configurable delay so we can
-    simulate a slow streaming response that ESC needs to cancel.
+    simulate a slow streaming response that ESC needs to cancel. The
+    provider iterates the full event stream (post thinking-aware fix),
+    so this exposes ``__iter__`` yielding events whose ``delta.text``
+    matches each chunk.
     """
 
     def __init__(self, chunks: list[str], per_chunk_delay_s: float = 0.0):
@@ -57,8 +76,7 @@ class _FakeStream:
     def __exit__(self, exc_type, exc, tb):
         return False
 
-    @property
-    def text_stream(self):
+    def _yield_chunks_with_closure_check(self):
         for chunk in self._chunks:
             if self._closed.is_set():
                 # SDK's iterator would raise once the underlying HTTP
@@ -74,6 +92,17 @@ class _FakeStream:
                         raise ConnectionError("response closed mid-stream")
                     time.sleep(0.005)
             yield chunk
+
+    @property
+    def text_stream(self):
+        # Kept for backward-compat in case any other test still consumes
+        # the text-only view directly. The provider itself now iterates
+        # the full event stream below.
+        yield from self._yield_chunks_with_closure_check()
+
+    def __iter__(self):
+        for chunk in self._yield_chunks_with_closure_check():
+            yield _FakeStreamEvent(delta=_FakeTextDelta(chunk))
 
     def get_final_message(self):
         # Build a minimal "final message" shape the provider's

--- a/tests/test_stream_watchdog.py
+++ b/tests/test_stream_watchdog.py
@@ -127,20 +127,24 @@ class TestWatchdogIntegrationWithProvider(unittest.TestCase):
         from unittest.mock import patch as _patch
         from src.providers.anthropic_provider import AnthropicProvider
 
-        # Build a fake stream whose ``text_stream`` yields nothing for
+        # Build a fake stream whose full event iteration yields nothing for
         # long enough that the watchdog fires, then raises (mirrors
-        # ``close()`` interrupting the iterator).
+        # ``close()`` interrupting the iterator). The provider now drives
+        # the watchdog from the full event stream (``for event in stream``)
+        # rather than the text-only ``stream.text_stream`` view — see the
+        # thinking-aware liveness rework — so the stall has to happen on
+        # ``__iter__`` for the watchdog branch to be exercised.
         fake_response = MagicMock()
         fake_response.close = MagicMock()
 
-        def slow_text_stream():
+        def slow_event_stream():
             time.sleep(0.3)
             # After watchdog fires + closes response, iteration should raise.
             raise RuntimeError("stream closed by watchdog")
             yield  # unreachable; makes this a generator
 
         fake_stream = MagicMock()
-        fake_stream.text_stream = slow_text_stream()
+        fake_stream.__iter__ = MagicMock(return_value=slow_event_stream())
         fake_stream.response = fake_response
 
         # The context manager returns our fake stream.


### PR DESCRIPTION
## Summary
- Bumps the Anthropic provider's default `max_tokens` from `4096` to `32000` for Claude 4.x models (via `_default_max_tokens(model)` regex-detected helper). 3.x callers stay at `4096` — the API rejects higher on those tiers. Callers passing an explicit `max_tokens` are unaffected.
- Reworks `chat_stream_response` to drive the streaming idle-watchdog from the **full event stream** (`for event in stream`) instead of the text-only view. Extended-thinking content blocks now keep `watchdog.reset()` ticking, so the 90s idle deadline no longer fires during long reasoning preludes. This is the regression we hit on SWE-bench Verified once Feat 1 (`thinking: adaptive`) was enabled.

## Why it matters
On localhost:4000 / `claude-opus-4-6`, the prior `4096` cap routinely truncated long patches; the prior watchdog firing during thinking surfaced as "is_error: false, content empty" in headless mode. After this PR, the SWE-bench harness produces non-truncated diffs and the watchdog falls back to non-streaming only on genuine stalls.

## Test plan
- [x] `tests/test_anthropic_max_tokens_default.py` (10 cases) — regex coverage + per-callsite defaulting
- [x] `tests/test_anthropic_thinking_keeps_stream_alive.py` (2 cases) — watchdog stays armed across pure-thinking events
- [x] `tests/test_stream_watchdog.py` — integration test updated to the event-stream shape
- [x] `tests/test_provider_abort_signal.py` — `_FakeStream.__iter__` updated to the event-stream shape
- [x] Live smoke against `localhost:4000` with `claude-opus-4-6`: 9.7s, 87 chunks, 685 chars, no watchdog fire
- [x] End-to-end `clawcodex -p` CLI run: 46s headless agent loop with extended thinking, correct output, no spurious watchdog
- [x] Rebased onto `origin/main` (97 upstream commits — including ch04/round3's `_effective_base_url` / `_is_first_party` / `_request_id_headers` first-party detection and per-request UUID — co-existing cleanly with our changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
