### PR TITLE
workflow: default concurrency to 4 (gentle on the rate-limit window)

### DIFF
--- a/docs/workflow-engine-port-plan.md
+++ b/docs/workflow-engine-port-plan.md
@@ -254,7 +254,7 @@ Each phase is independently testable; the feature is usable behind the gate afte
 
 ## 8. Open decisions
 
-1. **Concurrency cap source** — fixed `16` (house style) vs. `min(16, cpu_count−2)` (faithful low-core reduction). Recommend the latter with a `CLAUDE_CODE_WORKFLOW_MAX_AGENTS` override. (§3.3)
+1. **Concurrency cap source** — ~~fixed `16` vs. `min(16, cpu_count−2)`~~ **RESOLVED:** defaults to a gentle **`4`** (`DEFAULT_MAX_CONCURRENT_AGENTS`, `CLAUDE_CODE_WORKFLOW_MAX_AGENTS` override). The `min(16, cpu−2)` heuristic was dropped — workflow agents are network/LLM-bound, so the real limiter is the provider rate-limit / token window, not core count, and 16-wide fan-out can exhaust a plan's 5-hour budget in one burst. (§3.3)
 2. **Structured-output return channel** — a new `ToolContext` field vs. a typed sentinel in `outbox`. Pick one explicit channel; do not overload the text path. (§4.3)
 3. **Progress delivery** — poll-on-interval (simplest, matches `StatusLine`) vs. a `WorkflowProgress` Textual message (push). (§5.4)
 4. **Budget unit** — token-target (parity with `token_budget.py`) vs. USD cap (parity with TS `maxBudgetUsd`). Spec leans token; implement the predicate on the production accumulator either way. (§4.4)

--- a/docs/workflow-engine.md
+++ b/docs/workflow-engine.md
@@ -192,7 +192,7 @@ Python ports of the demo corpus should live alongside it (e.g. `demos/workflows/
 
 | Aspect | Behaviour (authoritative) |
 |---|---|
-| **Concurrency cap** | **Up to 16 concurrent agents, fewer on machines with limited CPU cores.** Excess `agent()` calls queue and run as slots free. (Upstream cap: `min(16, cpu_cores − 2)`.) |
+| **Concurrency cap** | Excess `agent()` calls queue and run as slots free. Upstream allows **up to 16** (`min(16, cpu_cores − 2)`). **ClawCodex defaults to a gentler `4`** — workflow agents are rate-limit-bound, not CPU-bound, so a big fan-out can burn a plan's window in one burst; raise it with `CLAUDE_CODE_WORKFLOW_MAX_AGENTS`. |
 | **Lifetime agent cap** | **1,000 agents total per run** — a runaway-loop backstop. |
 | **Per-call item cap** | A single `pipeline()`/`parallel()` call accepts at most 4,096 items; more is an explicit error, not silent truncation. |
 | **No mid-run user input** | Only agent permission prompts can pause a run. For sign-off between stages, run each stage as its own workflow. |

--- a/src/workflow/constants.py
+++ b/src/workflow/constants.py
@@ -1,12 +1,14 @@
 """Runtime caps for the workflow engine.
 
-Authoritative values from the official spec
-(<https://code.claude.com/docs/en/workflows>): up to 16 concurrent agents
-(fewer on low-core machines), 1,000 agents per run, and a per-call item
-cap. The upstream concurrency cap is ``min(16, cpu_cores - 2)``; we honor
-that (with a ``CLAUDE_CODE_WORKFLOW_MAX_AGENTS`` override) rather than the
-house-style fixed integer, because the spec explicitly reduces parallelism
-on small machines.
+Caps from the official spec (<https://code.claude.com/docs/en/workflows>):
+1,000 agents per run and a per-call item cap. The spec allows *up to* 16
+concurrent agents, but workflow agents are network/LLM-bound, not CPU-bound —
+so the real limiter is your provider's rate-limit / token window, not core
+count. Fanning out 16 at once can burn a plan's 5-hour window fast, so we
+default to a deliberately gentle **4** concurrent and let heavy users opt up
+via ``CLAUDE_CODE_WORKFLOW_MAX_AGENTS``. (This is a conscious deviation from the
+upstream ``min(16, cpu_cores - 2)`` heuristic, which over-parallelizes on
+big-core machines.)
 """
 
 from __future__ import annotations
@@ -25,8 +27,10 @@ MAX_STRUCTURED_OUTPUT_RETRIES = 5
 #: How many times a single agent may be re-spawned via the `r` (retry) action.
 MAX_AGENT_RETRIES = 3
 
-#: Hard ceiling on the concurrency cap regardless of core count.
-_CONCURRENCY_HARD_MAX = 16
+#: Default per-run concurrency cap. Small on purpose — see the module docstring:
+#: the limiter is the rate-limit window, not CPU, and 4 keeps a run from eating a
+#: plan's budget in one burst. Raise via ``CLAUDE_CODE_WORKFLOW_MAX_AGENTS``.
+DEFAULT_MAX_CONCURRENT_AGENTS = 4
 
 _ENV_MAX_AGENTS = "CLAUDE_CODE_WORKFLOW_MAX_AGENTS"
 
@@ -35,7 +39,10 @@ def max_concurrent_agents() -> int:
     """Resolve the per-run concurrency cap.
 
     ``CLAUDE_CODE_WORKFLOW_MAX_AGENTS`` overrides everything when set to a
-    positive integer; otherwise ``min(16, cpu_count - 2)`` with a floor of 1.
+    positive integer; otherwise the gentle :data:`DEFAULT_MAX_CONCURRENT_AGENTS`
+    (4). Note: this caps how many agents run *at once* (the burst), not the
+    total token spend of a run — that is governed by the workflow's own fan-out
+    breadth and the ``budget`` ceiling.
     """
     override = os.environ.get(_ENV_MAX_AGENTS, "").strip()
     if override:
@@ -43,5 +50,4 @@ def max_concurrent_agents() -> int:
             return max(1, int(override))
         except ValueError:
             pass
-    cores = os.cpu_count() or 3
-    return max(1, min(_CONCURRENCY_HARD_MAX, cores - 2))
+    return DEFAULT_MAX_CONCURRENT_AGENTS

--- a/tests/workflow/test_scheduler.py
+++ b/tests/workflow/test_scheduler.py
@@ -17,6 +17,29 @@ def test_reserve_assigns_sequential_indices():
     assert sched.launched == 3
 
 
+def test_default_concurrency_is_gentle(monkeypatch):
+    """Default cap is a gentle 4 (rate-limit friendly), not the old min(16, cpu-2).
+    A run is network/LLM-bound, so the limiter is the token window, not cores."""
+    from src.workflow.constants import DEFAULT_MAX_CONCURRENT_AGENTS, max_concurrent_agents
+
+    monkeypatch.delenv("CLAUDE_CODE_WORKFLOW_MAX_AGENTS", raising=False)
+    assert DEFAULT_MAX_CONCURRENT_AGENTS == 4
+    assert max_concurrent_agents() == 4
+    # a default-constructed Scheduler (what every workflow run gets) uses it
+    assert Scheduler().max_concurrent == 4
+
+
+def test_concurrency_env_override(monkeypatch):
+    from src.workflow.constants import max_concurrent_agents
+
+    monkeypatch.setenv("CLAUDE_CODE_WORKFLOW_MAX_AGENTS", "12")
+    assert max_concurrent_agents() == 12
+    assert Scheduler().max_concurrent == 12
+    # garbage falls back to the gentle default
+    monkeypatch.setenv("CLAUDE_CODE_WORKFLOW_MAX_AGENTS", "not-a-number")
+    assert max_concurrent_agents() == 4
+
+
 def test_reserve_enforces_per_run_cap(monkeypatch):
     monkeypatch.setattr(scheduler_mod, "MAX_AGENTS_PER_RUN", 2)
     sched = Scheduler(max_concurrent=4)


### PR DESCRIPTION
## Why
Reviewer feedback on a `/deep-research` run:
> the engineering is clean but fanning out to **16 concurrent agents** will eat your 5-hour window alive on a max plan. that deep-research run you showed burned 847.7k tokens in one go.

Workflow agents are **network/LLM-bound, not CPU-bound**, so scaling concurrency by core count (`min(16, cpu_count − 2)`) is the wrong heuristic — the real limiter is the provider's rate-limit / token window, and a 16-wide burst can exhaust a plan's budget fast.

## Change
- `DEFAULT_MAX_CONCURRENT_AGENTS = 4` — the per-run cap now defaults to a gentle **4** instead of `min(16, cpu_count − 2)`.
- `CLAUDE_CODE_WORKFLOW_MAX_AGENTS` override is **unchanged** — heavy users can still opt up (`export CLAUDE_CODE_WORKFLOW_MAX_AGENTS=12`).
- Applies to **every** workflow run (deep-research, `ultracode`-authored, demos), since a default `Scheduler()` reads this value.

```
default:      4
override 8:   8   (CLAUDE_CODE_WORKFLOW_MAX_AGENTS)
```

## Honest scope note
This caps the **burst** (how many agents run at once), which is what hammers the rate-limit window. It does **not** by itself reduce a run's **total** token spend (the 847.7k) — that's a function of the workflow's own fan-out breadth (`/deep-research` uses ~4 search angles + up to 10 verify claims) and the `budget` ceiling. If you also want lower total spend, the levers are fewer search angles / verify claims (happy to do that as a follow-up).

## Tests / docs
New `test_default_concurrency_is_gentle` + `test_concurrency_env_override`; 160 workflow tests pass. Docs updated (`workflow-engine.md` cap row + port-plan open-decision #1 marked resolved). The local social-media showcase was updated to say "4 concurrent by default" too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)