### PR TITLE
deep-research: trim to 3 search angles + 6 verify claims (~1/3 less token spend)

### DIFF
--- a/src/workflow/bundled/deep_research.py
+++ b/src/workflow/bundled/deep_research.py
@@ -17,11 +17,15 @@ question = (args if isinstance(args, str) else (args or {}).get("question", ""))
 if not question:
     raise ValueError('Provide a research question via args — e.g. /deep-research "what changed in X?"')
 
+# Search angles, ordered most-authoritative first. Kept deliberately lean (3,
+# not "every angle"): each angle is one web-searching subagent and the Search
+# phase is the single biggest cost driver of a run, so a fourth angle buys
+# breadth at a steep token price. The three here already span primary sources,
+# what's new, and outside scrutiny.
 ANGLES = [
     "official documentation and primary sources",
     "recent news, changelogs, and release notes",
     "expert analysis, comparisons, and critiques",
-    "community discussion and real-world reports",
 ]
 
 CLAIMS_SCHEMA = {
@@ -87,12 +91,13 @@ for result in searches:
 if not claims:
     raise RuntimeError("No claims were gathered — the question may be too narrow or WebSearch is unavailable.")
 
-# Cap the verify fan-out: the Verify phase spawns one agent per claim, so a very
-# thorough search model (opus gathered 32) would otherwise launch dozens of
-# concurrent agents — slow, costly, and prone to overrunning a flaky endpoint.
-# Keep the first N distinct claims (search angles are ordered most-authoritative
-# first). Logged, never silent.
-MAX_VERIFY_CLAIMS = 10
+# Cap the verify fan-out: the Verify phase spawns one web-searching agent per
+# claim, and (with Search) it dominates a run's token spend — a thorough search
+# model can gather 30+ claims, which would otherwise launch dozens of agents.
+# 6 keeps the report well-sourced while holding the cost down; raise it if you
+# want exhaustive cross-checking. Claims are ordered most-authoritative first
+# (by search angle), so the first 6 are the strongest. Logged, never silent.
+MAX_VERIFY_CLAIMS = 6
 if len(claims) > MAX_VERIFY_CLAIMS:
     log(f"Gathered {len(claims)} claims; verifying the first {MAX_VERIFY_CLAIMS} to bound the fan-out.")
     claims = claims[:MAX_VERIFY_CLAIMS]


### PR DESCRIPTION
## Why
Companion to #336 (concurrency → 4). Concurrency caps the **burst**; this cuts the **total work** the reviewer flagged ("847.7k tokens in one go"). Search + Verify dominate a run's spend — each search angle is a web-searching subagent (Search was the single biggest cost), and Verify spawns one agent per claim.

## Change (`src/workflow/bundled/deep_research.py`)
- **Search angles 4 → 3** — drop "community discussion & real-world reports"; keep primary sources, what's-new, and outside scrutiny.
- **`MAX_VERIFY_CLAIMS` 10 → 6.**

A run now fans out **3 search + ≤6 verify + 1 synthesize ≈ 10 agents** (was ~15), and the heaviest (search) agents drop 4 → 3.

## Impact
On the shown run's per-agent averages (Search ≈ 90k/agent, Verify ≈ 47k/agent):

| | before | after |
|---|---|---|
| Search | 4 agents · ~360k | 3 agents · ~270k |
| Verify | 10 agents · ~473k | 6 agents · ~283k |
| Synthesize | ~16k | ~16k |
| **Total** | **~847k** | **~570k** (~⅓ off) |

…while keeping the report well-sourced. Both numbers are right at the top of the bundled script for anyone who wants exhaustive runs.

## Verified
End-to-end through the engine with a fake runner: **3 search agents; 12 claims gathered → capped to 6 verified; ok=True**. 189 workflow/command tests pass.

> Note: the gitignored social-media showcase still shows the *old* run's monitor (4 search / 10 verify / 847.7k) — that was a real run, so I didn't fabricate new numbers. Happy to refresh it after a fresh trimmed run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)