### PR TITLE
constants: port SPINNER_VERBS pool + spinnerVerbs setting (parity)

### DIFF
--- a/src/constants/spinner_verbs.py
+++ b/src/constants/spinner_verbs.py
@@ -1,0 +1,119 @@
+"""Spinner verbs for the busy/thinking status line.
+
+Mirrors ``typescript/src/constants/spinnerVerbs.ts``. The TUI status line
+shows one of these gerunds while the agent is working (e.g. ``Cogitating…``,
+``Frolicking…``). TS picks a fresh verb per spinner mount via
+``sample(getSpinnerVerbs())``; the Python port samples once per thinking
+session in :meth:`src.tui.state.AppState.set_thinking`.
+
+The list is kept byte-identical to the TS source (including ``Beboppin'``
+and the accented ``Flambéing`` / ``Sautéing``) so the two implementations
+draw from the same pool.
+"""
+from __future__ import annotations
+
+import random
+from typing import Final
+
+# Verbatim from typescript/src/constants/spinnerVerbs.ts:16-204 (187 entries).
+SPINNER_VERBS: Final[tuple[str, ...]] = (
+    "Accomplishing", "Actioning", "Actualizing", "Architecting",
+    "Baking", "Beaming", "Beboppin'", "Befuddling",
+    "Billowing", "Blanching", "Bloviating", "Boogieing",
+    "Boondoggling", "Booping", "Bootstrapping", "Brewing",
+    "Bunning", "Burrowing", "Calculating", "Canoodling",
+    "Caramelizing", "Cascading", "Catapulting", "Cerebrating",
+    "Channeling", "Channelling", "Choreographing", "Churning",
+    "Clauding", "Coalescing", "Cogitating", "Combobulating",
+    "Composing", "Computing", "Concocting", "Considering",
+    "Contemplating", "Cooking", "Crafting", "Creating",
+    "Crunching", "Crystallizing", "Cultivating", "Deciphering",
+    "Deliberating", "Determining", "Dilly-dallying", "Discombobulating",
+    "Doing", "Doodling", "Drizzling", "Ebbing",
+    "Effecting", "Elucidating", "Embellishing", "Enchanting",
+    "Envisioning", "Evaporating", "Fermenting", "Fiddle-faddling",
+    "Finagling", "Flambéing", "Flibbertigibbeting", "Flowing",
+    "Flummoxing", "Fluttering", "Forging", "Forming",
+    "Frolicking", "Frosting", "Gallivanting", "Galloping",
+    "Garnishing", "Generating", "Gesticulating", "Germinating",
+    "Gitifying", "Grooving", "Gusting", "Harmonizing",
+    "Hashing", "Hatching", "Herding", "Honking",
+    "Hullaballooing", "Hyperspacing", "Ideating", "Imagining",
+    "Improvising", "Incubating", "Inferring", "Infusing",
+    "Ionizing", "Jitterbugging", "Julienning", "Kneading",
+    "Leavening", "Levitating", "Lollygagging", "Manifesting",
+    "Marinating", "Meandering", "Metamorphosing", "Misting",
+    "Moonwalking", "Moseying", "Mulling", "Mustering",
+    "Musing", "Nebulizing", "Nesting", "Newspapering",
+    "Noodling", "Nucleating", "Orbiting", "Orchestrating",
+    "Osmosing", "Perambulating", "Percolating", "Perusing",
+    "Philosophising", "Photosynthesizing", "Pollinating", "Pondering",
+    "Pontificating", "Pouncing", "Precipitating", "Prestidigitating",
+    "Processing", "Proofing", "Propagating", "Puttering",
+    "Puzzling", "Quantumizing", "Razzle-dazzling", "Razzmatazzing",
+    "Recombobulating", "Reticulating", "Roosting", "Ruminating",
+    "Sautéing", "Scampering", "Schlepping", "Scurrying",
+    "Seasoning", "Shenaniganing", "Shimmying", "Simmering",
+    "Skedaddling", "Sketching", "Slithering", "Smooshing",
+    "Sock-hopping", "Spelunking", "Spinning", "Sprouting",
+    "Stewing", "Sublimating", "Swirling", "Swooping",
+    "Symbioting", "Synthesizing", "Tempering", "Thinking",
+    "Thundering", "Tinkering", "Tomfoolering", "Topsy-turvying",
+    "Transfiguring", "Transmuting", "Twisting", "Undulating",
+    "Unfurling", "Unravelling", "Vibing", "Waddling",
+    "Wandering", "Warping", "Whatchamacalliting", "Whirlpooling",
+    "Whirring", "Whisking", "Wibbling", "Working",
+    "Wrangling", "Zesting", "Zigzagging",
+)
+
+# TS fallback when the pool is somehow empty (Spinner.tsx:449).
+_FALLBACK_VERB: Final[str] = "Working"
+
+
+def get_spinner_verbs() -> list[str]:
+    """Return the active spinner-verb pool, honoring the user setting.
+
+    Mirrors TS ``getSpinnerVerbs`` (spinnerVerbs.ts:3-13):
+
+    * no ``spinner_verbs`` setting → the built-in defaults;
+    * ``mode="replace"`` → the user's verbs (or defaults if the user list
+      is empty — TS guards the empty-replace case the same way);
+    * ``mode="append"`` → defaults followed by the user's verbs.
+
+    Settings are read lazily so this module stays import-light and the
+    TUI never has to be on the path.
+    """
+    try:
+        from src.settings.settings import get_settings
+
+        config = get_settings().spinner_verbs
+    except Exception:
+        config = None
+
+    if config is None:
+        return list(SPINNER_VERBS)
+
+    # Guard a malformed setting (e.g. ``verbs: "Vibing"`` as a bare string):
+    # iterate-as-list would char-explode it into single letters. Treat any
+    # non-list as "no custom verbs" rather than producing junk verbs.
+    user_verbs = list(config.verbs) if isinstance(config.verbs, list) else []
+    if config.mode == "replace":
+        return user_verbs if user_verbs else list(SPINNER_VERBS)
+    # "append" (and any unexpected mode) → defaults + user verbs.
+    return list(SPINNER_VERBS) + user_verbs
+
+
+def pick_spinner_verb() -> str:
+    """Pick a random spinner verb from the active pool.
+
+    Single indirection point for randomness so tests can monkeypatch it
+    deterministically. Falls back to ``"Working"`` if the pool is empty
+    (matches TS ``sample(getSpinnerVerbs()) ?? "Working"``).
+    """
+    verbs = get_spinner_verbs()
+    if not verbs:
+        return _FALLBACK_VERB
+    return random.choice(verbs)
+
+
+__all__ = ["SPINNER_VERBS", "get_spinner_verbs", "pick_spinner_verb"]

--- a/src/settings/constants.py
+++ b/src/settings/constants.py
@@ -51,5 +51,8 @@ VALID_EFFORT_VALUES = ("", "low", "medium", "high", "max")
 # Known valid output styles
 VALID_OUTPUT_STYLES = ("default", "concise", "verbose", "markdown")
 
+# Known valid spinner-verb merge modes (TS settings/types.ts:696)
+VALID_SPINNER_VERB_MODES = ("append", "replace")
+
 # Known valid permission modes
 VALID_PERMISSION_MODES = ("default", "plan", "bypassPermissions")

--- a/src/settings/types.py
+++ b/src/settings/types.py
@@ -38,6 +38,18 @@ class OutputStyleSettings:
 
 
 @dataclass
+class SpinnerVerbsSettings:
+    """Custom spinner-verb configuration.
+
+    Mirrors TS ``settings/types.ts:695`` (``spinnerVerbs``). ``mode``:
+    ``"append"`` adds ``verbs`` to the built-in defaults; ``"replace"``
+    uses only ``verbs``. See :mod:`src.constants.spinner_verbs`.
+    """
+    mode: str = "append"  # "append" | "replace"
+    verbs: list[str] = field(default_factory=list)
+
+
+@dataclass
 class CompactSettings:
     """Compaction settings."""
     auto_compact: bool = True
@@ -123,6 +135,9 @@ class SettingsSchema:
     # Output
     output_style: OutputStyleSettings = field(default_factory=OutputStyleSettings)
 
+    # Spinner verbs (None = built-in defaults)
+    spinner_verbs: SpinnerVerbsSettings | None = None
+
     # Compact
     compact: CompactSettings = field(default_factory=CompactSettings)
 
@@ -201,6 +216,8 @@ class SettingsSchema:
             ]
         if "output_style" in known and isinstance(known["output_style"], dict):
             known["output_style"] = OutputStyleSettings(**known["output_style"])
+        if "spinner_verbs" in known and isinstance(known["spinner_verbs"], dict):
+            known["spinner_verbs"] = SpinnerVerbsSettings(**known["spinner_verbs"])
         if "compact" in known and isinstance(known["compact"], dict):
             known["compact"] = CompactSettings(**known["compact"])
         if "hooks" in known and isinstance(known["hooks"], dict):

--- a/src/settings/validation.py
+++ b/src/settings/validation.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from .constants import VALID_EFFORT_VALUES, VALID_OUTPUT_STYLES, VALID_PERMISSION_MODES
+from .constants import (
+    VALID_EFFORT_VALUES,
+    VALID_OUTPUT_STYLES,
+    VALID_PERMISSION_MODES,
+    VALID_SPINNER_VERB_MODES,
+)
 from .types import SettingsSchema
 
 
@@ -51,6 +56,17 @@ def validate_settings(settings: SettingsSchema) -> list[ValidationError]:
             field="output_style.max_width",
             message="max_width must be >= 40",
             value=settings.output_style.max_width,
+        ))
+
+    # Spinner verbs (optional; only the merge mode is constrained)
+    if settings.spinner_verbs is not None and (
+        settings.spinner_verbs.mode not in VALID_SPINNER_VERB_MODES
+    ):
+        errors.append(ValidationError(
+            field="spinner_verbs.mode",
+            message=f"Invalid spinner verbs mode: {settings.spinner_verbs.mode!r}. "
+                    f"Must be one of {VALID_SPINNER_VERB_MODES}",
+            value=settings.spinner_verbs.mode,
         ))
 
     # Max turns (0 = unlimited, otherwise must be positive)

--- a/src/tui/agent_bridge.py
+++ b/src/tui/agent_bridge.py
@@ -300,7 +300,9 @@ class AgentBridge:
         self._session.conversation.add_user_message(prompt)
         self._persister.record_user(prompt)
         self._post(AgentRunStarted(prompt=prompt))
-        self._state.set_thinking(True, verb="Synthesizing")
+        # Empty verb → AppState.set_thinking samples a random SPINNER_VERBS
+        # entry (TS Spinner.tsx:166), instead of a fixed "Synthesizing".
+        self._state.set_thinking(True)
         self._run_worker(
             self._run_agent_in_thread,
             thread=True,

--- a/src/tui/state.py
+++ b/src/tui/state.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable
 
+from src.constants.spinner_verbs import pick_spinner_verb
+
 if TYPE_CHECKING:
     from src.permissions.types import PermissionAskReply, PermissionUpdate
 
@@ -197,7 +199,10 @@ class AppState:
         with self._lock:
             self.is_thinking = thinking
             if thinking:
-                self.verb = verb or "Synthesizing"
+                # TS picks a fresh random verb per spinner mount
+                # (Spinner.tsx:166). When no explicit verb is given, sample
+                # from the SPINNER_VERBS pool instead of a fixed string.
+                self.verb = verb or pick_spinner_verb()
                 self.verb_started_at = time.time()
             else:
                 self.verb = "Ready"

--- a/src/tui/widgets/status_line.py
+++ b/src/tui/widgets/status_line.py
@@ -211,7 +211,9 @@ class StatusLine(Static):
     def bump_turn(self) -> None:
         self.turns += 1
 
-    def set_busy(self, verb: str = "Synthesizing") -> None:
+    def set_busy(self, verb: str = "") -> None:
+        # Empty verb → AppState.set_thinking samples a random SPINNER_VERBS
+        # entry (TS Spinner.tsx:166), instead of a fixed "Synthesizing".
         self.is_thinking = True
         if self._app_state is not None:
             self._app_state.set_thinking(True, verb=verb)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -12,6 +12,7 @@ from src.settings.types import (
     OutputStyleSettings,
     PermissionRule,
     SettingsSchema,
+    SpinnerVerbsSettings,
     ToolSettings,
 )
 from src.settings.constants import DEFAULT_SETTINGS
@@ -54,6 +55,17 @@ class TestSettingsSchema:
         assert len(s.permissions) == 1
         assert s.permissions[0].tool == "Bash"
 
+    def test_from_dict_spinner_verbs(self):
+        data = {"spinner_verbs": {"mode": "replace", "verbs": ["Vibing", "Whirring"]}}
+        s = SettingsSchema.from_dict(data)
+        assert isinstance(s.spinner_verbs, SpinnerVerbsSettings)
+        assert s.spinner_verbs.mode == "replace"
+        assert s.spinner_verbs.verbs == ["Vibing", "Whirring"]
+
+    def test_spinner_verbs_defaults_none(self):
+        # Absent key → None (built-in defaults used at read time).
+        assert SettingsSchema.from_dict({}).spinner_verbs is None
+
 
 class TestValidation:
     def test_valid_settings(self):
@@ -79,6 +91,22 @@ class TestValidation:
         s = SettingsSchema(output_style=OutputStyleSettings(max_width=10))
         errors = validate_settings(s)
         assert any(e.field == "output_style.max_width" for e in errors)
+
+    def test_invalid_spinner_verbs_mode(self):
+        s = SettingsSchema(spinner_verbs=SpinnerVerbsSettings(mode="bogus"))
+        errors = validate_settings(s)
+        assert any(e.field == "spinner_verbs.mode" for e in errors)
+
+    def test_valid_spinner_verbs_modes(self):
+        for mode in ("append", "replace"):
+            s = SettingsSchema(spinner_verbs=SpinnerVerbsSettings(mode=mode))
+            assert not any(e.field == "spinner_verbs.mode"
+                           for e in validate_settings(s))
+
+    def test_spinner_verbs_none_is_valid(self):
+        # Default (no override) must not produce a spinner_verbs error.
+        assert not any(e.field == "spinner_verbs.mode"
+                       for e in validate_settings(DEFAULT_SETTINGS))
 
     def test_negative_max_turns(self):
         s = SettingsSchema(max_turns=-1)

--- a/tests/test_spinner_verbs.py
+++ b/tests/test_spinner_verbs.py
@@ -1,0 +1,148 @@
+"""Tests for the spinner-verb pool and its wiring into the status verb.
+
+Covers the port of ``typescript/src/constants/spinnerVerbs.ts``:
+* the verbatim ``SPINNER_VERBS`` pool,
+* ``get_spinner_verbs`` settings-merge semantics (``append`` / ``replace``),
+* ``pick_spinner_verb`` (pool member + empty-pool fallback),
+* and the live wiring: ``AppState.set_thinking`` samples the pool when no
+  explicit verb is supplied (replacing the old hardcoded ``"Synthesizing"``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.constants.spinner_verbs import (
+    SPINNER_VERBS,
+    get_spinner_verbs,
+    pick_spinner_verb,
+)
+from src.settings.types import SettingsSchema, SpinnerVerbsSettings
+
+
+# --------------------------------------------------------------------------
+# SPINNER_VERBS pool
+# --------------------------------------------------------------------------
+
+def test_pool_is_nonempty_and_verbatim_anchors():
+    # 187 entries ported verbatim from spinnerVerbs.ts:16-204.
+    assert len(SPINNER_VERBS) == 187
+    # Anchors spanning the list, incl. the apostrophe + accented entries.
+    for anchor in ("Accomplishing", "Cogitating", "Synthesizing",
+                   "Working", "Zigzagging", "Beboppin'",
+                   "Flambéing", "Sautéing"):
+        assert anchor in SPINNER_VERBS, anchor
+
+
+def test_pool_has_no_duplicates():
+    assert len(set(SPINNER_VERBS)) == len(SPINNER_VERBS)
+
+
+# --------------------------------------------------------------------------
+# get_spinner_verbs — settings merge
+# --------------------------------------------------------------------------
+
+def _patch_settings(monkeypatch, spinner_verbs):
+    """Point get_spinner_verbs' lazy ``get_settings`` at a stub schema."""
+    schema = SettingsSchema(spinner_verbs=spinner_verbs)
+    monkeypatch.setattr(
+        "src.settings.settings.get_settings", lambda *a, **k: schema
+    )
+
+
+def test_get_spinner_verbs_defaults_when_unset(monkeypatch):
+    _patch_settings(monkeypatch, None)
+    assert get_spinner_verbs() == list(SPINNER_VERBS)
+
+
+def test_get_spinner_verbs_append(monkeypatch):
+    _patch_settings(
+        monkeypatch, SpinnerVerbsSettings(mode="append", verbs=["Frobnicating"])
+    )
+    result = get_spinner_verbs()
+    assert result[: len(SPINNER_VERBS)] == list(SPINNER_VERBS)
+    assert result[-1] == "Frobnicating"
+    assert len(result) == len(SPINNER_VERBS) + 1
+
+
+def test_get_spinner_verbs_replace(monkeypatch):
+    _patch_settings(
+        monkeypatch,
+        SpinnerVerbsSettings(mode="replace", verbs=["Frobnicating", "Wibbling"]),
+    )
+    assert get_spinner_verbs() == ["Frobnicating", "Wibbling"]
+
+
+def test_get_spinner_verbs_replace_empty_falls_back(monkeypatch):
+    # TS guards empty-replace by returning defaults.
+    _patch_settings(monkeypatch, SpinnerVerbsSettings(mode="replace", verbs=[]))
+    assert get_spinner_verbs() == list(SPINNER_VERBS)
+
+
+def test_get_spinner_verbs_ignores_malformed_non_list_verbs(monkeypatch):
+    # A bare string (not a list) must not char-explode into single letters.
+    _patch_settings(
+        monkeypatch, SpinnerVerbsSettings(mode="append", verbs="Vibing")  # type: ignore[arg-type]
+    )
+    assert get_spinner_verbs() == list(SPINNER_VERBS)
+
+
+def test_get_spinner_verbs_survives_settings_failure(monkeypatch):
+    def _boom(*a, **k):
+        raise RuntimeError("settings unavailable")
+
+    monkeypatch.setattr("src.settings.settings.get_settings", _boom)
+    # Never raises into the render path — defaults stand.
+    assert get_spinner_verbs() == list(SPINNER_VERBS)
+
+
+# --------------------------------------------------------------------------
+# pick_spinner_verb
+# --------------------------------------------------------------------------
+
+def test_pick_returns_pool_member(monkeypatch):
+    _patch_settings(monkeypatch, None)
+    for _ in range(20):
+        assert pick_spinner_verb() in SPINNER_VERBS
+
+
+def test_pick_empty_pool_falls_back_to_working(monkeypatch):
+    monkeypatch.setattr(
+        "src.constants.spinner_verbs.get_spinner_verbs", lambda: []
+    )
+    assert pick_spinner_verb() == "Working"
+
+
+# --------------------------------------------------------------------------
+# Wiring: AppState.set_thinking samples the pool
+# --------------------------------------------------------------------------
+
+def test_set_thinking_samples_pool_when_no_verb(monkeypatch):
+    from src.tui.state import AppState
+
+    monkeypatch.setattr(
+        "src.tui.state.pick_spinner_verb", lambda: "Frolicking"
+    )
+    state = AppState()
+    state.set_thinking(True)
+    assert state.verb == "Frolicking"
+
+
+def test_set_thinking_explicit_verb_still_wins(monkeypatch):
+    from src.tui.state import AppState
+
+    monkeypatch.setattr(
+        "src.tui.state.pick_spinner_verb", lambda: "Frolicking"
+    )
+    state = AppState()
+    state.set_thinking(True, verb="Compiling")
+    assert state.verb == "Compiling"
+
+
+def test_set_thinking_false_resets_to_ready():
+    from src.tui.state import AppState
+
+    state = AppState()
+    state.set_thinking(True, verb="Compiling")
+    state.set_thinking(False)
+    assert state.verb == "Ready"


### PR DESCRIPTION
## What

Ports `typescript/src/constants/spinnerVerbs.ts` — the **only** self-contained, in-scope, functional gap found in the `constants/` parity sweep (gap analysis + plan in `my-docs/get-parity-by-folder/constants-*.md`).

The TUI status line showed a single hardcoded `"Synthesizing"`. TS samples a random verb per spinner mount from a ~190-verb pool, with a user settings override. This restores that behavior.

## Changes

- **`src/constants/spinner_verbs.py`** (new): `SPINNER_VERBS` (187 entries, verified **byte- and order-identical** to the TS source, incl. `Beboppin'`, `Flambéing`, `Sautéing`) + `get_spinner_verbs()` (append/replace settings merge; empty-replace → defaults; never raises into the render path) + `pick_spinner_verb()` (`random.choice` + `"Working"` fallback, single indirection point for test determinism).
- **settings**: `SpinnerVerbsSettings {mode, verbs}` + `from_dict` coercion (mirrors `output_style`), `VALID_SPINNER_VERB_MODES`, and `spinner_verbs.mode` validation (gated on the setting being present).
- **wiring**: `pick_spinner_verb()` feeds `AppState.set_thinking`; the hardcoded `"Synthesizing"` is dropped at `agent_bridge.py:303` and `status_line.py:214` (transitive arg-less `set_busy` callers sample via the default). The `_app_state is None` branch is untouched.

## Scope note — output styles deferred

The round-3 fresh analysis found output styles are **non-functional end-to-end**: nothing assigns `tool_context.output_style_name` from `settings.output_style.style` (the producer is unwired), and the injection registries are split live/dead. A functional fix is a subsystem repair (producer wiring across 3 entry points + registry unification + TS built-ins), flagged for a dedicated phase rather than shipped as dead-code data here. Full write-up in gap doc §3.5.

## Tests

- New `tests/test_spinner_verbs.py` (pool fidelity, append/replace/empty/malformed-input merge, pick + fallback, `set_thinking` wiring via monkeypatched pick) + `spinner_verbs` cases in `tests/test_settings.py` (parse + validation).
- Full suite: **7928 passed**. The 12 failures are pre-existing baseline (advisor_smoke ×2, parity e2e ×2, tool_parity ×2, test_providers ×6) — verified reproducing identically on clean `origin/main` via `git stash`.

Gap analysis, refactoring plan, and implementation each passed an independent Critic review loop to APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)