### PR TITLE
query: restore the base system prompt on the live TUI/headless path

### DIFF
--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -307,7 +307,9 @@ def run_headless(options: HeadlessOptions) -> int:
                             getattr(tool_context, "output_style_dir", None),
                         ).prompt
                         effective_system_prompt = (
-                            build_effective_system_prompt(_style_prompt, tool_context)
+                            build_effective_system_prompt(
+                                _style_prompt, tool_context, provider=provider,
+                            )
                         )
 
                         def _persist(msg: Any) -> None:

--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -94,7 +94,7 @@ def run_query_as_agent_loop_sync(
         getattr(tool_context, "output_style_dir", None),
     ).prompt
     effective_system_prompt = build_effective_system_prompt(
-        style_prompt, tool_context,
+        style_prompt, tool_context, provider=provider,
     )
 
     def _persist(msg: Any) -> None:
@@ -139,22 +139,77 @@ def run_query_as_agent_loop_sync(
     )
 
 
-def build_effective_system_prompt(style_prompt: str, tool_context: ToolContext) -> str:
-    """Assemble the cold-start system prompt for headless+TUI cutover.
+def build_effective_system_prompt(
+    style_prompt: str,
+    tool_context: ToolContext,
+    *,
+    provider: Any | None = None,
+    mcp_servers: list[Any] | None = None,
+    query_source: str = "main",
+) -> list[dict[str, Any]]:
+    """Assemble the cold-start system prompt for the headless+TUI cutover.
 
-    Combines the user's output-style prompt with the workspace
-    context block (CLAUDE.md, git status, cwd) produced by
-    ``build_context_prompt``. Lives here because the only callers are
-    the F.2/F.3 cutover code in ``src/entrypoints/headless.py`` and
-    ``src/tui/agent_bridge.py``; the canonical query() loop expects
-    the system_prompt pre-built (per its QueryParams.system_prompt
-    contract) so the cutover code uses this helper to match what
-    the legacy ``run_agent_loop`` did internally.
+    Returns the FULL system prompt as a **block list** (``list[dict]``) so the
+    ``query()`` loop still engages prompt caching: the canonical base sections
+    (``build_full_system_prompt_blocks`` — intro / # Doing tasks / # Executing
+    actions / # Using your tools / # Tone / output-efficiency / env / memory /
+    skills / …) with the resolved output-style prompt **appended**, then the
+    existing workspace + git + CLAUDE.md context preserved as a trailing
+    (uncached) block.
+
+    Why this exists: the TUI (``tui/agent_bridge.py``) and headless
+    (``entrypoints/headless.py``) cutover routes through ``query()``, which
+    passes ``params.system_prompt`` **verbatim** to the model — it has no base
+    build of its own. The engine/REPL path (``engine.py:124-188``) does the
+    canonical build when ``system_prompt`` is unset, but the cutover pre-sets
+    it, so before this fix the live TUI/headless agent received **no base
+    instructions** at all (only the style line + context). This helper restores
+    them, mirroring the engine's ``build_full_system_prompt_blocks`` +
+    ``append_system_prompt`` shape.
+
+    CLAUDE.md note: ``build_full_system_prompt_blocks``' memory section is
+    *auto-memory* (``MEMORY.md`` via ``load_memory_prompt``), **not** CLAUDE.md.
+    On the engine path CLAUDE.md is injected into the *messages* via
+    ``prepend_user_context``; the cutover does not do that, so we keep
+    ``build_context_prompt`` (which emits ``## Project Instructions``) to
+    preserve CLAUDE.md — option (b) in
+    ``my-docs/get-parity-by-folder/live-base-system-prompt-gap-analysis.md``.
+    This overlaps the base ``# Environment`` section on CWD/date (a benign,
+    documented duplication).
+
+    ``tools``/``tool_registry`` are deliberately NOT passed to
+    ``build_full_system_prompt_blocks`` (matching ``engine.py:167``): tool
+    schemas reach the model via the API ``tools=`` param, so emitting a prose
+    tool-docs section here would double-send them. ``provider``/``mcp_servers``
+    feed only the global cache-scope gate; ``None`` is safe (disables the
+    cross-user global scope, which TUI/headless should not use).
     """
-    # Local import — context_system is a heavier dep; only the cutover
-    # callers need it, no need to drag it into agent_loop_compat's
-    # import time.
+    # Local imports — context_system is a heavier dep; only the cutover
+    # callers need it, no need to drag it into agent_loop_compat's import time.
     from ..context_system import build_context_prompt
+    from ..context_system.prompt_assembly import build_full_system_prompt_blocks
+
+    cwd = str(tool_context.cwd or tool_context.workspace_root)
+
+    # Skills listing (best-effort; mirrors engine.py:183).
+    try:
+        from ..command_system import get_skill_tool_commands
+        skills = get_skill_tool_commands(cwd)
+    except Exception:
+        skills = None
+
+    blocks = build_full_system_prompt_blocks(
+        cwd=cwd,
+        output_style="default",          # style is appended below (mirror engine.py:169)
+        append_system_prompt=style_prompt,
+        query_source=query_source,
+        provider=provider,
+        mcp_servers=mcp_servers,
+        skills=skills,
+    )
+
+    # Preserve the existing workspace + git + CLAUDE.md context verbatim as a
+    # trailing uncached block (CLAUDE.md is NOT in the base blocks above).
     try:
         context_prompt = build_context_prompt(
             tool_context.workspace_root,
@@ -162,9 +217,10 @@ def build_effective_system_prompt(style_prompt: str, tool_context: ToolContext) 
         )
     except Exception:
         context_prompt = ""
-    if not context_prompt.strip():
-        return style_prompt
-    return f"{style_prompt}\n\n{context_prompt}"
+    if context_prompt.strip():
+        blocks = blocks + [{"type": "text", "text": context_prompt}]
+
+    return blocks
 
 
 @dataclass(frozen=True)

--- a/src/tui/agent_bridge.py
+++ b/src/tui/agent_bridge.py
@@ -376,7 +376,7 @@ class AgentBridge:
                 getattr(self._tool_context, "output_style_dir", None),
             ).prompt
             effective_system_prompt = build_effective_system_prompt(
-                _style_prompt, self._tool_context,
+                _style_prompt, self._tool_context, provider=self._provider,
             )
 
             def _persist(msg: Any) -> None:

--- a/tests/test_clear_system_prompt_sections.py
+++ b/tests/test_clear_system_prompt_sections.py
@@ -13,9 +13,17 @@ from src.state import cache_state as cs
 class TestClearSystemPromptSections(unittest.TestCase):
     def setUp(self) -> None:
         cs.reset_for_test_only()
+        # Isolate the process-global prompt-section cache: other tests that
+        # exercise the TUI/headless cutover (build_effective_system_prompt →
+        # build_full_system_prompt_blocks) populate it, and this test asserts
+        # exact cache sizes. Clear it so collection order can't leak in.
+        from src.context_system.prompt_assembly import get_system_prompt_cache
+        get_system_prompt_cache().invalidate_all()
 
     def tearDown(self) -> None:
         cs.reset_for_test_only()
+        from src.context_system.prompt_assembly import get_system_prompt_cache
+        get_system_prompt_cache().invalidate_all()
 
     def test_clear_resets_all_toggle_latches(self) -> None:
         latches = cs.get_beta_header_latches()

--- a/tests/test_live_base_system_prompt.py
+++ b/tests/test_live_base_system_prompt.py
@@ -1,0 +1,112 @@
+"""Regression test for the live TUI/headless base-system-prompt fix.
+
+Before the fix, the cutover's ``build_effective_system_prompt`` returned only
+``{style}\n\n{context}`` (no base sections), so the live TUI/headless agent
+received NO operating instructions. The fix makes it return the full base
+prompt as a block list (mirroring the engine/REPL canonical path), with the
+style appended and the workspace/git/CLAUDE.md context preserved.
+
+See ``my-docs/get-parity-by-folder/live-base-system-prompt-gap-analysis.md``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.query.agent_loop_compat import build_effective_system_prompt
+from src.tool_system.context import ToolContext
+
+
+_SENTINEL_STYLE = "ZZZ_OUTPUT_STYLE_SENTINEL_marker_42"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_prompt_cache():
+    """build_effective_system_prompt populates the process-global prompt
+    cache (intended in production). Clear it before+after each test here so
+    this file never leaks cached sections into other tests (e.g.
+    test_clear_system_prompt_sections asserts exact cache sizes)."""
+    from src.context_system.prompt_assembly import get_system_prompt_cache
+
+    get_system_prompt_cache().invalidate_all()
+    yield
+    get_system_prompt_cache().invalidate_all()
+
+
+def _joined(blocks) -> str:
+    assert isinstance(blocks, list), f"expected block list, got {type(blocks)}"
+    assert all(isinstance(b, dict) and "text" in b for b in blocks), blocks
+    return "\n".join(b.get("text", "") for b in blocks)
+
+
+def test_returns_block_list_with_cache_control(tmp_path: Path):
+    """The helper returns the block-list shape so query() engages caching."""
+    ctx = ToolContext(workspace_root=tmp_path)
+    blocks = build_effective_system_prompt(_SENTINEL_STYLE, ctx)
+    assert isinstance(blocks, list) and len(blocks) >= 1
+    # At least one block carries a cache_control marker (cached base prefix).
+    assert any("cache_control" in b for b in blocks), (
+        "no cache_control marker — caching not engaged"
+    )
+
+
+def test_includes_base_sections(tmp_path: Path):
+    """The base operating instructions are present (the bug: they were absent)."""
+    ctx = ToolContext(workspace_root=tmp_path)
+    text = _joined(build_effective_system_prompt(_SENTINEL_STYLE, ctx))
+    for marker in (
+        "# Doing tasks",
+        "# Executing actions with care",
+        "# Using your tools",
+        "# Tone and style",
+        "# Environment",
+    ):
+        assert marker in text, f"base section missing: {marker!r}"
+
+
+def test_appends_the_resolved_style(tmp_path: Path):
+    """The resolved output-style prompt is appended (style still applied)."""
+    ctx = ToolContext(workspace_root=tmp_path)
+    text = _joined(build_effective_system_prompt(_SENTINEL_STYLE, ctx))
+    assert _SENTINEL_STYLE in text
+
+
+def test_does_not_emit_prose_tool_docs(tmp_path: Path):
+    """tools/tool_registry are NOT passed (mirrors engine.py:167) so no prose
+    tool-docs section is emitted — tool schemas go via the API tools= param.
+    The general '# Using your tools' guidance is still present (asserted above);
+    here we guard against a per-tool prose docs block sneaking in."""
+    ctx = ToolContext(workspace_root=tmp_path)
+    text = _joined(build_effective_system_prompt(_SENTINEL_STYLE, ctx))
+    # The prose tool-docs section header (_build_tool_docs_section emits
+    # "# Available Tools" only when tools/tool_registry are passed). It must
+    # be absent — distinct from "# Available Skills", which IS expected.
+    assert "# Available Tools" not in text
+
+
+def test_preserves_claude_md_project_instructions(tmp_path: Path, monkeypatch):
+    """CLAUDE.md must NOT be dropped (critic B1): it is kept via the trailing
+    build_context_prompt block (## Project Instructions), since the base
+    blocks' memory section is MEMORY.md auto-memory, not CLAUDE.md."""
+    # Isolate HOME so global ~/.claude/CLAUDE.md doesn't mask the test file.
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+    marker = "PROJECT_CLAUDE_MD_SENTINEL_xyz"
+    (tmp_path / "CLAUDE.md").write_text(f"# Project rules\n{marker}\n", encoding="utf-8")
+
+    ctx = ToolContext(workspace_root=tmp_path)
+    text = _joined(build_effective_system_prompt(_SENTINEL_STYLE, ctx))
+    assert marker in text, "CLAUDE.md project instructions were dropped"
+
+
+def test_provider_none_is_safe(tmp_path: Path):
+    """provider/mcp_servers default to None (disables global cache scope) and
+    the helper still produces a valid full prompt."""
+    ctx = ToolContext(workspace_root=tmp_path)
+    blocks = build_effective_system_prompt(
+        _SENTINEL_STYLE, ctx, provider=None, mcp_servers=None,
+    )
+    text = _joined(blocks)
+    assert "# Doing tasks" in text and _SENTINEL_STYLE in text


### PR DESCRIPTION
## Problem (verified)

The live **TUI** (`tui/agent_bridge.py`) and **headless** (`entrypoints/headless.py`) surfaces were sending the model a system prompt with **no base operating instructions** — no identity intro, `# Doing tasks`, `# Executing actions`, tool guidance, `# Tone and style`, output-efficiency, or cyber-risk. They sent only the resolved output-style line + workspace/git/CLAUDE.md context.

**Root cause:** these surfaces route through `query()`, which passes `QueryParams.system_prompt` **verbatim** to the model (it has no base build). The cutover pre-built that prompt via `build_effective_system_prompt`, which returned only `{style}\n\n{context}`. The REPL was unaffected — it uses `QueryEngine`'s canonical build (`engine.py:124-188`), which the `query()` cutover bypasses.

Empirically confirmed before the fix: `build_effective_system_prompt("default-style", ctx)` → 0 base-prompt markers.

## Fix

Rewrite `build_effective_system_prompt` to return the full base prompt as a **block list** (so `query()` keeps prompt caching), mirroring the engine/REPL canonical path:

- `build_full_system_prompt_blocks(cwd, output_style="default", append_system_prompt=style_prompt, query_source="main", provider, mcp_servers, skills)` — full base sections + the resolved style appended. **No `tools`/`tool_registry`** (matching `engine.py:167`): tool schemas reach the model via the API `tools=` param, so a prose tool-docs section would double-send them.
- The existing workspace + git + **CLAUDE.md** context is preserved verbatim as a trailing uncached block. (`build_full_system_prompt_blocks`' memory section is auto-memory/`MEMORY.md`, **not** CLAUDE.md — so dropping `build_context_prompt` would silently drop CLAUDE.md.)
- All three callers thread `provider=` for the global cache-scope gate (`None` is safe).

**Known benign duplication (documented in the docstring):** the base `# Environment` section overlaps the retained `## Runtime Context` on CWD/date. A future loop-unification (CLAUDE.md → messages via `prepend_user_context`, mirroring the engine exactly) removes it.

## Test isolation

`tests/test_clear_system_prompt_sections.py::test_clear_invalidates_prompt_cache` asserts exact prompt-cache sizes but assumed an empty process-global `_prompt_cache` it never enforced. This change makes cutover-exercising tests populate that cache, exposing the latent gap; `setUp`/`tearDown` now `invalidate_all()` it (matching the pre-existing `test_system_prompt_full.py` pattern).

## Verification

- New `tests/test_live_base_system_prompt.py`: proves the base sections (`# Doing tasks`, `# Executing actions with care`, `# Using your tools`, `# Tone and style`, `# Environment`) + appended style + **CLAUDE.md** (`## Project Instructions`) now appear, the result is a `list[dict]` with `cache_control`, and no prose `# Available Tools` block is double-sent.
- Full suite: **7935 passed**, 12 failed = pre-existing baseline (advisor ×2, parity e2e ×2, tool_parity ×2, providers ×6) — verified reproducing on clean `origin/main`, **zero regressions**.

Design + analysis (critic-approved through two rounds): `my-docs/get-parity-by-folder/live-base-system-prompt-gap-analysis.md`. This follow-on came out of the `constants/` parity sweep (gap doc §3.5 — the output-style subsystem was found non-functional because of this base-prompt gap).

Gap analysis, design, and implementation each passed an independent Critic review loop to APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)