### PR TITLE
fix(repl): eliminate prompt_toolkit un-awaited-coroutine warnings

### DIFF
--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -2048,8 +2048,11 @@ class ClawcodexREPL:
 
         Tries ``prompt_toolkit.prompt`` first because it cooperates with
         :func:`prompt_toolkit.patch_stdout.patch_stdout`. Falls back to
-        bare ``input()`` if prompt_toolkit isn't available or the runtime
-        can't open a TTY (e.g. piped stdin).
+        bare ``input()`` if prompt_toolkit isn't available, an asyncio
+        event loop is already running in this thread (the sync prompt
+        can't nest inside one — it would leak an un-awaited
+        ``Application.run_async`` coroutine), or the runtime can't open a
+        TTY (e.g. piped stdin).
 
         If a :class:`~src.repl.live_status.LiveStatus` is currently
         mounted (we're inside ``chat()``), pause it for the duration of
@@ -2061,7 +2064,25 @@ class ClawcodexREPL:
         live = self._active_live_status
 
         def _do_read() -> str:
-            if _HAS_PROMPT_TOOLKIT:
+            # ``prompt_toolkit.prompt`` (sync) internally drives a fresh
+            # ``Application`` via ``loop.run_until_complete``, which can't
+            # nest inside an already-running loop: it builds an
+            # ``Application.run_async`` coroutine, the nested run raises, and
+            # the coroutine is GC'd un-awaited -> RuntimeWarning. We can't
+            # assume a fixed thread per caller — the permission handler runs
+            # on the agent's loop thread, while sync tools like
+            # AskUserQuestion are offloaded to a worker thread via
+            # ``asyncio.to_thread`` — so we detect a running loop at read
+            # time. If one is running, skip prompt_toolkit and use blocking
+            # ``input()`` (it could not have worked anyway); otherwise — the
+            # idle ``❯`` prompt and the ``ui_host`` worker-thread read — keep
+            # the rich prompt_toolkit editor.
+            loop_running = True
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                loop_running = False
+            if _HAS_PROMPT_TOOLKIT and not loop_running:
                 try:
                     from prompt_toolkit import prompt as pt_prompt
 
@@ -2743,7 +2764,7 @@ class ClawcodexREPL:
 - Use Tab for command completion
 - Press Ctrl+C to interrupt current operation
 - Press Ctrl+D to exit
-- Multi-line input: Shift+Enter, Meta/Alt+Enter, or `\` + Enter inserts a newline; plain Enter submits
+- Multi-line input: Shift+Enter, Meta/Alt+Enter, or `\\` + Enter inserts a newline; plain Enter submits
 """
         self.console.print(Markdown(help_text))
 

--- a/src/repl/live_status.py
+++ b/src/repl/live_status.py
@@ -404,6 +404,24 @@ class LiveStatus:
         except Exception:
             pass
         finally:
+            # Cancel anything still pending before closing the loop. If an
+            # exception ever reaches the loop's handler while the app is up,
+            # prompt_toolkit schedules ``Application._handle_exception``'s
+            # ``in_term`` error-printer via ``ensure_future``; left pending at
+            # ``loop.close()`` it leaks as an un-awaited-coroutine
+            # RuntimeWarning. Draining (cancel + gather) awaits each task via
+            # its CancelledError instead. ``_stop``'s guarded exit prevents the
+            # usual trigger; this is defense-in-depth for any other straggler.
+            try:
+                pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    loop.run_until_complete(
+                        asyncio.gather(*pending, return_exceptions=True)
+                    )
+            except Exception:
+                pass
             try:
                 loop.close()
             except Exception:
@@ -457,8 +475,29 @@ class LiveStatus:
         app = self._app
         loop = self._loop
         if app is not None and loop is not None and not loop.is_closed():
+
+            def _exit_if_running() -> None:
+                # Guard against a double-exit. In a non-TTY context (piped or
+                # closed stdin) the app can already have exited on its own via
+                # EOF; calling ``exit()`` again raises "Return value already
+                # set", which prompt_toolkit routes to the loop exception
+                # handler -> ``ensure_future(in_term())``. That ``in_term`` task
+                # is then destroyed pending when the loop closes, leaking an
+                # un-awaited coroutine (and printing the traceback). Reading the
+                # future state on the loop thread keeps the check from racing
+                # the app's own exit. ``app.future`` is per-Application and
+                # reset to None between runs on this same loop thread, so it is
+                # always this app's current-or-None future — never a stale
+                # sibling run's, despite prompt_toolkit's general exit() caveat.
+                try:
+                    fut = app.future
+                    if fut is not None and not fut.done():
+                        app.exit()
+                except Exception:
+                    pass
+
             try:
-                loop.call_soon_threadsafe(app.exit)
+                loop.call_soon_threadsafe(_exit_if_running)
             except RuntimeError:
                 pass
         if self._thread is not None:

--- a/tests/test_live_status.py
+++ b/tests/test_live_status.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import threading
 import time
+from unittest.mock import patch
 
 import pytest
 
@@ -114,6 +115,53 @@ def test_on_expand_callback_wired() -> None:
         assert cb is not None
         cb()
     assert called == ["ok"]
+
+
+def test_lifecycle_does_not_trigger_loop_exception_handler() -> None:
+    """Regression: a start -> update -> paused -> stop cycle must not push any
+    exception onto the prompt_toolkit Application's loop exception handler.
+
+    In a non-TTY context (headless pytest) the Application exits on its own
+    (EOF) before ``_stop`` runs. The old ``_stop`` then called ``app.exit()``
+    unconditionally, hitting "Return value already set". prompt_toolkit routes
+    that to the loop exception handler (``Application._handle_exception``),
+    which does ``ensure_future(in_term())`` to print the traceback — and that
+    ``in_term`` task is destroyed pending at ``loop.close()``, leaking
+    ``RuntimeWarning: coroutine '...in_term' was never awaited`` (the symptom
+    is GC-timed, so we assert on its deterministic root cause instead). The
+    guarded exit in ``_stop`` must keep the handler from ever firing.
+    """
+    import prompt_toolkit.application.application as appmod
+
+    fired: list[object] = []
+    # Record (and swallow) anything reaching the handler so a regression
+    # surfaces as captured context here rather than as a GC-timed warning at
+    # some unrelated test's teardown. Not delegating to the real handler keeps
+    # this test from itself scheduling the leaking in_term task.
+    def recording_handler(self, loop, context):  # noqa: ANN001
+        fired.append(context.get("exception") or context.get("message"))
+
+    with patch.object(appmod.Application, "_handle_exception", recording_handler):
+        for i in range(6):
+            status = LiveStatus(f"working {i}")
+            with status:
+                time.sleep(0.02)
+                status.update(f"step {i}")
+                with status.paused():
+                    pass
+
+    assert fired == [], (
+        "prompt_toolkit's loop exception handler fired during a normal "
+        f"LiveStatus lifecycle (it schedules a leaking in_term task): {fired}"
+    )
+    # The guard must not strand the background thread: a skipped exit() only
+    # happens when the app already finished, so every cycle still tears down.
+    live = [
+        t
+        for t in threading.enumerate()
+        if t.name == "clawcodex-live-status" and t.is_alive()
+    ]
+    assert live == [], f"LiveStatus threads stranded after teardown: {live}"
 
 
 def test_paused_context_releases_and_restores_application() -> None:

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 import unittest
 from unittest.mock import Mock, patch, MagicMock
 from pathlib import Path
+import asyncio
+import gc
+import sys
 import tempfile
 import json
 import threading
 import time
+import types
+import warnings
 from rich.markdown import Markdown
 
 import src.config as config_module
@@ -745,6 +750,72 @@ class TestREPL(unittest.TestCase):
                 "localSettings", []
             ),
         )
+
+
+class TestSafeInputLoopGuard(unittest.TestCase):
+    """``_safe_input`` must not invoke the synchronous ``prompt_toolkit.prompt``
+    while an asyncio event loop is running in the calling thread.
+
+    The sync prompt drives ``loop.run_until_complete(Application.run_async())``
+    internally; nested inside an already-running loop it raises and leaks the
+    ``Application.run_async`` coroutine un-awaited -> a ``RuntimeWarning``. Off
+    the loop it must still reach the rich prompt_toolkit editor. A fake
+    ``prompt_toolkit`` module makes the test deterministic regardless of whether
+    the package (or a TTY) is available in the test environment.
+    """
+
+    def _make_repl(self):
+        # Skip the heavy __init__; _do_read only reads _active_live_status.
+        repl = ClawcodexREPL.__new__(ClawcodexREPL)
+        repl._active_live_status = None
+        return repl
+
+    @staticmethod
+    def _fake_pt(calls):
+        mod = types.ModuleType("prompt_toolkit")
+
+        def fake_prompt(prompt):  # mirrors prompt_toolkit.prompt's signature
+            calls.append(prompt)
+            return "from-pt"
+
+        mod.prompt = fake_prompt
+        return mod
+
+    def test_off_loop_uses_prompt_toolkit(self):
+        """No running loop -> the rich prompt_toolkit editor is used."""
+        calls: list[str] = []
+        repl = self._make_repl()
+        with patch.dict(sys.modules, {"prompt_toolkit": self._fake_pt(calls)}), \
+                patch("src.repl.core._HAS_PROMPT_TOOLKIT", True):
+            result = repl._safe_input("Q> ")
+        self.assertEqual(result, "from-pt")
+        self.assertEqual(calls, ["Q> "])
+
+    def test_on_loop_skips_prompt_toolkit_and_does_not_leak(self):
+        """Running loop -> prompt_toolkit is skipped (it would leak an
+        un-awaited ``Application.run_async`` coroutine); ``input()`` is used
+        and no RuntimeWarning escapes."""
+        calls: list[str] = []
+        repl = self._make_repl()
+
+        async def run():
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                with patch.dict(
+                    sys.modules, {"prompt_toolkit": self._fake_pt(calls)}
+                ), patch("src.repl.core._HAS_PROMPT_TOOLKIT", True), patch(
+                    "builtins.input", return_value="typed"
+                ):
+                    val = repl._safe_input("Q> ")
+                gc.collect()
+                gc.collect()
+            leaks = [w for w in caught if "never awaited" in str(w.message)]
+            return val, leaks
+
+        val, leaks = asyncio.run(run())
+        self.assertEqual(val, "typed")  # input() fallback, not prompt_toolkit
+        self.assertEqual(calls, [])  # prompt_toolkit never attempted
+        self.assertEqual(leaks, [])  # no un-awaited-coroutine RuntimeWarning
 
 
 class TestConversation(unittest.TestCase):


### PR DESCRIPTION
## Summary

Running `python -m src.cli` surfaced two `RuntimeWarning: ... was never awaited` leaks (and one `SyntaxWarning`). All three are fixed here, each with a red-green regression test.

### 1. `coroutine 'Application.run_async' was never awaited`
`ClawcodexREPL._safe_input` called the **synchronous** `prompt_toolkit.prompt()` from interactive handlers (permission prompt, ask-user) that can run *inside* the async agent loop. The sync prompt drives `loop.run_until_complete(Application.run_async())` internally — which can't nest in an already-running loop: it constructs the `run_async` coroutine, the nested run raises, the surrounding `except Exception: pass` swallows it, and the coroutine is GC'd un-awaited.

**Fix:** detect a running loop via `asyncio.get_running_loop()` and fall straight to `input()` (prompt_toolkit could not have worked there anyway). Off-loop paths — the idle `❯` prompt and the `ui_host` worker-thread read — still get the rich prompt_toolkit editor.

### 2. `coroutine 'Application._handle_exception.<locals>.in_term' was never awaited`
`LiveStatus._stop` signalled `app.exit()` unconditionally. In a non-TTY context (piped/closed stdin) the prompt_toolkit `Application` self-exits via EOF first, so the second `exit()` hits `"Return value already set"` (`application.py:1292`). prompt_toolkit routes that to its loop exception handler → `ensure_future(in_term())`, and the `in_term` task is destroyed pending when `loop.close()` runs → the leak (it also printed an "Unhandled exception in event loop" traceback).

**Fix:** guard the exit — only call `app.exit()` when `app.future is not None and not app.future.done()`, checked on the loop thread to avoid racing the app's own EOF-exit. Defense-in-depth: `_run_thread` now cancels + `gather`s pending tasks before `loop.close()`.

### 3. `SyntaxWarning: invalid escape sequence "\`"`
Escaped the backslash in the `/help` multi-line-input line (renders identically).

## Testing
- New red-green regression tests (verified to FAIL without each fix, PASS with it):
  - `tests/test_repl.py::TestSafeInputLoopGuard` (on-loop → `input()` fallback, no leak; off-loop → prompt_toolkit still used)
  - `tests/test_live_status.py::test_lifecycle_does_not_trigger_loop_exception_handler` (+ thread-not-stranded assertion)
- `tests/test_repl.py tests/test_live_status.py`: **46 passed** under `-W error::RuntimeWarning`, zero "never awaited".
- Reviewed by the `critic` agent (APPROVE) for both fixes; root causes verified against the vendored prompt_toolkit 3.x source.
- Pre-existing `tests/test_providers.py` failures (mock/impl mismatch on `ZhipuAI().with_options()`) are unrelated — present identically on clean `main`; this diff touches neither providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)