### PR TITLE
permissions: port per-tool "allow for the whole session" prompt option (parity)

### DIFF
--- a/src/permissions/check.py
+++ b/src/permissions/check.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import fnmatch
 import logging
+import os
 import re
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Callable, Protocol, runtime_checkable
@@ -100,6 +101,58 @@ def _get_updated_input_or_fallback(
     if hasattr(permission_result, "updated_input") and permission_result.updated_input is not None:
         return permission_result.updated_input
     return fallback
+
+
+# File-editing tools whose "allow all edits during this session" option maps to
+# acceptEdits mode, and which acceptEdits mode auto-allows inside the working
+# roots (parity with typescript/src/utils/permissions/filesystem.ts:1382-1397).
+_FILE_EDIT_TOOLS: tuple[str, ...] = ("Write", "Edit", "MultiEdit", "NotebookEdit")
+
+
+def _allowed_roots_for_check(
+    context: ToolPermissionContext, tool_use_context: Any | None
+) -> list[str]:
+    """Working-directory roots used for acceptEdits path checks.
+
+    Prefers the live ``ToolContext.allowed_roots()`` (workspace + additional
+    dirs + internal paths); falls back to the cwd, and always folds in the
+    session-granted ``additional_working_directories`` from the permission
+    context so a just-accepted directory grant is honored.
+    """
+    roots: list[str] = []
+    if tool_use_context is not None:
+        try:
+            roots.extend(str(r) for r in tool_use_context.allowed_roots())
+        except Exception:
+            pass
+    if not roots:
+        roots.append(os.getcwd())
+    try:
+        roots.extend(context.additional_working_directories.keys())
+    except Exception:
+        pass
+    return roots
+
+
+def _path_in_working_roots(
+    file_path: str,
+    context: ToolPermissionContext,
+    tool_use_context: Any | None,
+) -> bool:
+    from pathlib import Path
+
+    abs_path = os.path.abspath(os.path.expanduser(file_path))
+    try:
+        target = Path(abs_path).resolve()
+    except OSError:
+        target = Path(abs_path)
+    for root in _allowed_roots_for_check(context, tool_use_context):
+        try:
+            target.relative_to(Path(root).resolve())
+            return True
+        except (ValueError, OSError):
+            continue
+    return False
 
 
 def has_permissions_to_use_tool(
@@ -253,7 +306,12 @@ def has_permissions_to_use_tool_inner(
         and tool.requires_user_interaction()
         and tool_permission_result.behavior == "ask"
     ):
-        return _coerce_to_ask_decision(tool_permission_result, tool.name)
+        return _coerce_to_ask_decision(
+            tool_permission_result,
+            tool.name,
+            context=context,
+            tool_use_context=tool_use_context,
+        )
 
     if (
         tool_permission_result.behavior == "ask"
@@ -263,7 +321,12 @@ def has_permissions_to_use_tool_inner(
         and hasattr(tool_permission_result.decision_reason, "rule")
         and tool_permission_result.decision_reason.rule.rule_behavior == "ask"
     ):
-        return _coerce_to_ask_decision(tool_permission_result, tool.name)
+        return _coerce_to_ask_decision(
+            tool_permission_result,
+            tool.name,
+            context=context,
+            tool_use_context=tool_use_context,
+        )
 
     if (
         tool_permission_result.behavior == "ask"
@@ -271,7 +334,12 @@ def has_permissions_to_use_tool_inner(
         and tool_permission_result.decision_reason is not None
         and tool_permission_result.decision_reason.type == "safetyCheck"
     ):
-        return _coerce_to_ask_decision(tool_permission_result, tool.name)
+        return _coerce_to_ask_decision(
+            tool_permission_result,
+            tool.name,
+            context=context,
+            tool_use_context=tool_use_context,
+        )
 
     should_bypass = (
         context.mode == "bypassPermissions"
@@ -286,6 +354,35 @@ def has_permissions_to_use_tool_inner(
             updated_input=_get_updated_input_or_fallback(tool_permission_result, tool_input),
             decision_reason=ModeDecisionReason(mode=context.mode),
         )
+
+    # acceptEdits mode: auto-allow file edits whose target is inside the working
+    # roots and is not a protected/dangerous path (parity with
+    # typescript/src/utils/permissions/filesystem.ts:1382-1397). This is what
+    # makes the file-edit "allow all edits during this session" option
+    # (setMode:acceptEdits) and the shift+tab "Accept edits" mode actually
+    # suppress later edit prompts. Gated on a passthrough tool result so an
+    # explicit tool ask (e.g. the docs gate) is still respected.
+    if (
+        context.mode == "acceptEdits"
+        and tool_permission_result.behavior == "passthrough"
+        and tool.name in _FILE_EDIT_TOOLS
+    ):
+        edit_path = tool_input.get("file_path") or tool_input.get("notebook_path")
+        if (
+            isinstance(edit_path, str)
+            and edit_path
+            and _path_in_working_roots(edit_path, context, tool_use_context)
+        ):
+            from .filesystem import check_path_safety_for_auto_edit
+
+            if check_path_safety_for_auto_edit(edit_path) is None:
+                return PermissionAllowDecision(
+                    behavior="allow",
+                    updated_input=_get_updated_input_or_fallback(
+                        tool_permission_result, tool_input
+                    ),
+                    decision_reason=ModeDecisionReason(mode="acceptEdits"),
+                )
 
     always_allowed = tool_always_allowed_rule(context, tool)
     if always_allowed:
@@ -321,6 +418,9 @@ def has_permissions_to_use_tool_inner(
             ),
             tool.name,
             tool_input,
+            context=context,
+            tool_use_context=tool_use_context,
+            from_passthrough=True,
         )
 
     if tool_permission_result.behavior == "allow":
@@ -332,16 +432,27 @@ def has_permissions_to_use_tool_inner(
             decision_reason=getattr(tool_permission_result, "decision_reason", None),
         )
 
-    return _coerce_to_ask_decision(tool_permission_result, tool.name, tool_input)
+    return _coerce_to_ask_decision(
+        tool_permission_result,
+        tool.name,
+        tool_input,
+        context=context,
+        tool_use_context=tool_use_context,
+    )
 
 
 def _coerce_to_ask_decision(
     result: PermissionResult,
     tool_name: str,
     tool_input: dict[str, Any] | None = None,
+    *,
+    context: ToolPermissionContext | None = None,
+    tool_use_context: Any | None = None,
 ) -> PermissionAskDecision:
     if isinstance(result, PermissionAskDecision):
-        return _with_default_suggestions(result, tool_name, tool_input)
+        return _with_default_suggestions(
+            result, tool_name, tool_input, context, tool_use_context
+        )
     return _with_default_suggestions(
         PermissionAskDecision(
             behavior="ask",
@@ -351,6 +462,8 @@ def _coerce_to_ask_decision(
         ),
         tool_name,
         tool_input,
+        context,
+        tool_use_context,
     )
 
 
@@ -358,44 +471,60 @@ def _with_default_suggestions(
     ask: PermissionAskDecision,
     tool_name: str,
     tool_input: dict[str, Any] | None,
+    context: ToolPermissionContext | None = None,
+    tool_use_context: Any | None = None,
+    *,
+    from_passthrough: bool = False,
 ) -> PermissionAskDecision:
-    """Return ``ask`` with derived "don't ask again" rules filled in.
+    """Return ``ask`` with the "allow for the whole session" updates filled in.
 
-    Mirrors TS bashPermissions.ts:1234-1236 (step 5: "Suggest prefix if
-    available, otherwise exact command"). Two deliberate exclusions:
+    These updates drive the middle "Yes, …" option every interactive surface
+    renders. The per-tool shape (Bash command-prefix rule, file-edit
+    ``setMode:acceptEdits``, content-less rule for other tools, plus a
+    directory grant for out-of-roots paths) lives in
+    :func:`src.permissions.updates.default_session_suggestions`, so both the
+    console and TUI prompts stay in sync from one source.
 
-    * safety-flagged asks keep an empty list — TS :1219 ("Don't suggest
-      saving a potentially dangerous command");
-    * asks that already carry suggestions (a tool supplied its own) are
-      left untouched.
+    Three deliberate exclusions are preserved:
 
-    Bash-only for now: the engine's content-rule matching is consulted
-    only for Bash commands (:298), and ``tool_always_allowed_rule``
-    requires content-less rules — a suggested ``Read(<dir>/**)`` rule
-    would persist but never match (review-A H1), so Read suggestions are
-    deliberately NOT derived until a path-rule matcher exists
-    (follow-up noted in the C1 plan).
+    * safety-flagged asks keep an empty list — TS ("Don't suggest saving a
+      potentially dangerous command");
+    * asks that already carry suggestions (a tool supplied its own) are left
+      untouched;
+    * only an ask the matcher manufactured from a ``passthrough`` tool result
+      (``from_passthrough``) gets a session option. An ask a tool raised
+      explicitly — e.g. the docs gate (``write.py``/``edit.py`` block ``.md``
+      edits unless ``allow_docs``) — or a configured ask-rule owns its own
+      gating, which a mode flip / blanket rule would not satisfy: the
+      acceptEdits auto-allow is itself ``passthrough``-gated, so "allow all
+      edits this session" would re-prompt the very file it was offered on
+      while silently widening session scope. So those asks keep Yes/No only.
 
-    Returns a copy (``dataclasses.replace``) rather than mutating —
-    the input can be a tool-owned decision object.
+    Returns a copy (``dataclasses.replace``) rather than mutating — the input
+    can be a tool-owned decision object.
     """
 
     if ask.suggestions:
         return ask
     if isinstance(ask.decision_reason, SafetyCheckDecisionReason):
         return ask
-    if not tool_input:
+    if not from_passthrough:
         return ask
 
-    if tool_name == "Bash":
-        command = tool_input.get("command", "")
-        if isinstance(command, str) and command.strip():
-            from .bash_suggestions import suggestions_for_bash_command
+    from .updates import default_session_suggestions
 
-            suggestions = suggestions_for_bash_command(command)
-            if suggestions:
-                return replace(ask, suggestions=suggestions)
+    allowed_roots: tuple[str, ...] | None = None
+    if tool_use_context is not None:
+        try:
+            allowed_roots = tuple(str(r) for r in tool_use_context.allowed_roots())
+        except Exception:
+            allowed_roots = None
 
+    suggestions = default_session_suggestions(
+        tool_name, tool_input, context, allowed_roots=allowed_roots
+    )
+    if suggestions:
+        return replace(ask, suggestions=tuple(suggestions))
     return ask
 
 
@@ -448,7 +577,12 @@ def check_rule_based_permissions(
         and hasattr(tool_permission_result.decision_reason, "rule")
         and tool_permission_result.decision_reason.rule.rule_behavior == "ask"
     ):
-        return _coerce_to_ask_decision(tool_permission_result, tool.name)
+        return _coerce_to_ask_decision(
+            tool_permission_result,
+            tool.name,
+            context=context,
+            tool_use_context=tool_use_context,
+        )
 
     if (
         tool_permission_result.behavior == "ask"
@@ -456,7 +590,12 @@ def check_rule_based_permissions(
         and tool_permission_result.decision_reason is not None
         and tool_permission_result.decision_reason.type == "safetyCheck"
     ):
-        return _coerce_to_ask_decision(tool_permission_result, tool.name)
+        return _coerce_to_ask_decision(
+            tool_permission_result,
+            tool.name,
+            context=context,
+            tool_use_context=tool_use_context,
+        )
 
     return None
 

--- a/src/permissions/updates.py
+++ b/src/permissions/updates.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any, Callable
 
 from .rule_parser import (
@@ -415,3 +415,238 @@ def create_read_rule_suggestion(
         behavior="allow",
         destination=destination,
     )
+
+
+# ---------------------------------------------------------------------------
+# Per-tool "allow for the whole session" suggestions + labels
+# ---------------------------------------------------------------------------
+#
+# Mirrors the original Claude Code per-tool permission option set:
+#   typescript/src/components/permissions/FilePermissionDialog/permissionOptions.tsx
+#   typescript/src/utils/permissions/filesystem.ts:generateSuggestions (1436)
+#   typescript/src/components/permissions/FallbackPermissionRequest.tsx
+#
+# Adapted to the mechanisms the Python matcher (check.py) actually honors:
+#   * a file edit's "allow all edits during this session" maps to
+#     ``setMode:acceptEdits`` (honored by ``has_permissions_to_use_tool_inner``),
+#   * edits/reads whose target is outside the working roots also grant the
+#     directory (``addDirectories``, bridged into ``ToolContext.allowed_roots``),
+#   * Bash keeps its command-prefix rule (``suggestions_for_bash_command``),
+#   * every other tool gets a content-less allow rule (matched by
+#     ``tool_always_allowed_rule`` for any tool).
+#
+# Persistence destinations match the original exactly: file edits/reads apply
+# in-memory (``session``); Bash and other tools persist (``localSettings``).
+
+FILE_EDIT_TOOL_NAMES: tuple[str, ...] = ("Write", "Edit", "MultiEdit", "NotebookEdit")
+FILE_READ_TOOL_NAMES: tuple[str, ...] = ("Read", "Glob", "Grep")
+
+# Interaction / meta tools render their own dialogs in the original and never
+# carry a "don't ask again" option — never mint a session rule for them.
+_NO_SESSION_OPTION_TOOLS: frozenset[str] = frozenset(
+    {"AskUserQuestion", "EnterPlanMode", "ExitPlanMode"}
+)
+
+# NB: the original surfaces this option with a "(shift+tab)" hint, because there
+# the key cycles permission modes. This port has the cycle *logic*
+# (``src.permissions.cycle.cycle_permission_mode``) but no keybinding wired to
+# it — mode changes go through the ``/permissions`` command — so advertising the
+# shortcut would promise a keypress that does nothing. The hint is intentionally
+# omitted until a shift+tab binding exists.
+
+_PATH_INPUT_KEYS: tuple[str, ...] = ("file_path", "notebook_path", "path")
+
+
+def _tool_input_path(tool_input: dict[str, Any] | None) -> str | None:
+    if not tool_input:
+        return None
+    for key in _PATH_INPUT_KEYS:
+        value = tool_input.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _abs_path(file_path: str) -> str:
+    return os.path.abspath(os.path.expanduser(file_path))
+
+
+def _resolve(path: str) -> Path:
+    try:
+        return Path(path).resolve()
+    except OSError:
+        return Path(_abs_path(path))
+
+
+def _path_within_roots(
+    file_path: str, allowed_roots: tuple[str, ...] | None
+) -> bool:
+    """Whether ``file_path`` lives under one of ``allowed_roots``.
+
+    ``allowed_roots is None`` means "unknown" — assume inside so we do not
+    suggest a directory grant the matcher would never need. The real matcher
+    still gates access; this only shapes the suggestion/label.
+    """
+    if not allowed_roots:
+        return True
+    target = _resolve(file_path)
+    for root in allowed_roots:
+        try:
+            target.relative_to(_resolve(root))
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _grant_directory(tool_name: str, path: str) -> str | None:
+    """The directory to grant for an out-of-roots access.
+
+    Search tools (Glob/Grep) pass a directory as their target; file tools pass
+    a file, so we grant its parent. Mirrors TS ``getDirectoryForPath``.
+
+    Returns ``None`` for a filesystem-root grant (``/``) so we never register
+    the whole filesystem as a session working directory — same guard
+    :func:`create_read_rule_suggestion` already applies.
+    """
+    if tool_name in ("Glob", "Grep"):
+        directory = _abs_path(path)
+    else:
+        directory = os.path.dirname(_abs_path(path))
+    if not directory or directory == "/":
+        return None
+    return directory
+
+
+def default_session_suggestions(
+    tool_name: str,
+    tool_input: dict[str, Any] | None,
+    perm_context: ToolPermissionContext | None = None,
+    *,
+    allowed_roots: tuple[str, ...] | None = None,
+) -> list[PermissionUpdate]:
+    """Build the "allow for the whole session" updates for ``tool_name``.
+
+    Returns the :class:`PermissionUpdate` list an "always allow" choice would
+    apply. Empty list = no session option for this ask.
+    """
+    if tool_name in _NO_SESSION_OPTION_TOOLS:
+        return []
+    tool_input = tool_input or {}
+    mode = getattr(perm_context, "mode", "default")
+
+    # Bash: command-prefix rule, persisted (unchanged behavior).
+    if tool_name == "Bash":
+        command = tool_input.get("command", "")
+        if isinstance(command, str) and command.strip():
+            from .bash_suggestions import suggestions_for_bash_command
+
+            return suggestions_for_bash_command(command)
+        return []
+
+    # File edits: setMode acceptEdits (+ addDirectories when outside roots).
+    if tool_name in FILE_EDIT_TOOL_NAMES:
+        updates: list[PermissionUpdate] = []
+        if mode in ("default", "plan"):
+            updates.append(
+                PermissionUpdateSetMode(destination="session", mode="acceptEdits")
+            )
+        path = _tool_input_path(tool_input)
+        if path and not _path_within_roots(path, allowed_roots):
+            grant = _grant_directory(tool_name, path)
+            if grant is not None:
+                updates.append(
+                    PermissionUpdateAddDirectories(
+                        destination="session",
+                        directories=(grant,),
+                    )
+                )
+        return updates
+
+    # File reads/search: content-less session rule for the tool (+ a directory
+    # grant when the target is outside roots so execution is permitted too).
+    if tool_name in FILE_READ_TOOL_NAMES:
+        updates = [
+            PermissionUpdateAddRules(
+                destination="session",
+                behavior="allow",
+                rules=(PermissionRuleValue(tool_name=tool_name),),
+            )
+        ]
+        path = _tool_input_path(tool_input)
+        if path and not _path_within_roots(path, allowed_roots):
+            grant = _grant_directory(tool_name, path)
+            if grant is not None:
+                updates.append(
+                    PermissionUpdateAddDirectories(
+                        destination="session",
+                        directories=(grant,),
+                    )
+                )
+        return updates
+
+    # Every other tool (WebFetch, Skill, MCP, …): persisted content-less rule.
+    if tool_name:
+        return [
+            PermissionUpdateAddRules(
+                destination="localSettings",
+                behavior="allow",
+                rules=(PermissionRuleValue(tool_name=tool_name),),
+            )
+        ]
+    return []
+
+
+def _directory_label(directories: tuple[str, ...]) -> str:
+    if not directories:
+        return "this directory"
+    return os.path.basename(directories[0].rstrip("/")) or "this directory"
+
+
+def session_option_label(
+    suggestions: tuple[PermissionUpdate, ...] | list[PermissionUpdate],
+    tool_name: str | None = None,
+    tool_input: dict[str, Any] | None = None,
+) -> str | None:
+    """Human label for the session option, rendered as ``f"Yes, {label}"``.
+
+    Mirrors the per-tool option text in the original (permissionOptions.tsx /
+    FallbackPermissionRequest.tsx). Returns ``None`` when there is nothing to
+    offer (the caller then omits the option).
+    """
+    suggestions = tuple(suggestions or ())
+    if not suggestions:
+        return None
+
+    dir_update = next(
+        (
+            u
+            for u in suggestions
+            if isinstance(u, PermissionUpdateAddDirectories) and u.directories
+        ),
+        None,
+    )
+    has_accept_edits = any(
+        isinstance(u, PermissionUpdateSetMode) and u.mode == "acceptEdits"
+        for u in suggestions
+    )
+
+    # File edits — "allow all edits [in <dir>/] during this session".
+    if has_accept_edits or tool_name in FILE_EDIT_TOOL_NAMES:
+        if dir_update:
+            name = _directory_label(dir_update.directories)
+            return f"allow all edits in {name}/ during this session"
+        return "allow all edits during this session"
+
+    # File reads — "allow reading from <dir>/ during this session" / generic.
+    if tool_name in FILE_READ_TOOL_NAMES:
+        if dir_update:
+            name = _directory_label(dir_update.directories)
+            return f"allow reading from {name}/ during this session"
+        return "allow reading during this session"
+
+    # Bash and every other tool — "and don't ask again for <rule(s)>".
+    base = suggestions_label(suggestions)
+    if base:
+        return f"and {base}"
+    return None

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -991,9 +991,11 @@ class ClawcodexREPL:
 
             always_label: str | None = None
             if suggestions:
-                from src.permissions.updates import suggestions_label
+                from src.permissions.updates import session_option_label
 
-                always_label = suggestions_label(suggestions)
+                always_label = session_option_label(
+                    suggestions, tool_name, getattr(request, "tool_input", None)
+                )
 
             # Build options as (key, description, action) rows so the
             # numeric choices always match what was displayed.
@@ -1004,7 +1006,7 @@ class ClawcodexREPL:
                 )
             options.append(("y", "Yes, allow this action", "allow"))
             if always_label:
-                options.append(("a", f"Yes, and {always_label}", "always"))
+                options.append(("a", f"Yes, {always_label}", "always"))
             options.append(("n", "No, deny this action", "deny"))
             options.append(
                 ("d", "No, and tell Claude what to do differently", "feedback")

--- a/src/tool_system/context.py
+++ b/src/tool_system/context.py
@@ -275,6 +275,21 @@ class ToolContext:
     def allowed_roots(self) -> tuple[Path, ...]:
         roots: list[Path] = [self.workspace_root]
         roots.extend(self.additional_working_directories)
+        # Session-granted directories from accepted permission updates.
+        # `PermissionUpdateAddDirectories` (e.g. the user choosing "allow all
+        # edits in <dir>/ during this session" for an out-of-cwd file) writes
+        # `ToolPermissionContext.additional_working_directories`; without folding
+        # those in here the grant never reaches `ensure_allowed_path` and the
+        # next edit/read in that directory still fails. Resolved so the
+        # /tmp → /private/tmp (macOS) match holds.
+        try:
+            for dir_path in self.permission_context.additional_working_directories.keys():
+                try:
+                    roots.append(Path(dir_path).resolve())
+                except OSError:
+                    roots.append(Path(dir_path))
+        except Exception:
+            pass
         # The session's tool-results spill dir is an internal path the runtime
         # writes large tool results to and then points the model back at (e.g. a
         # workflow subagent told to Read the offloaded result). Reading it back

--- a/src/tui/screens/permission_modal.py
+++ b/src/tui/screens/permission_modal.py
@@ -10,9 +10,13 @@ C1 (components-folder parity) upgraded the decision surface from binary
 Allow/Deny to the TS ``PermissionPrompt.tsx`` option list:
 
 * **Allow once** (``y``)
-* **Allow always** (``a``, only when the ask carries rule suggestions) —
-  accepts the derived "don't ask again" rules; the registry applies them
-  to the live context and persists them (TS "Yes, and don't ask again")
+* **Allow for the whole session** (``a``) — the per-tool option mirroring the
+  original (``allow all edits in <dir>/ during this session`` for file edits,
+  ``allow reading from <dir>/ …`` for reads, ``don't ask again for <rule>`` for
+  bash/other tools). The accepted updates (``setMode:acceptEdits`` /
+  ``addDirectories`` / ``addRules``) are applied to the live context and the
+  persistable ones saved; label text comes from
+  :func:`src.permissions.updates.session_option_label`.
 * **Deny** (``n`` / ``Esc``)
 * **Deny with feedback** (``d``) — opens a one-line input; the note
   reaches the model in the tool error (TS "No, and tell Claude what to
@@ -44,7 +48,7 @@ from textual.containers import Center, Middle, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Static
 
-from src.permissions.updates import suggestions_label
+from src.permissions.updates import session_option_label
 
 from ..messages import PermissionResolved
 from ..state import PendingPermission
@@ -98,8 +102,10 @@ class PermissionModal(ModalScreen[bool]):
     def __init__(self, request: PendingPermission) -> None:
         super().__init__()
         self._request = request
-        self._always_label = suggestions_label(
-            getattr(request, "suggestions", ()) or ()
+        self._always_label = session_option_label(
+            getattr(request, "suggestions", ()) or (),
+            getattr(request, "tool_name", None),
+            getattr(request, "tool_input", None),
         )
         self._feedback_open = False
         self._resolved = False
@@ -139,7 +145,7 @@ class PermissionModal(ModalScreen[bool]):
         if self._always_label:
             buttons.mount(
                 Button(
-                    f"Allow always (a) — {self._always_label}",
+                    f"Yes, {self._always_label} (a)",
                     id="allow-always",
                     classes="-allow",
                 )

--- a/tests/test_permission_session_options.py
+++ b/tests/test_permission_session_options.py
@@ -1,0 +1,632 @@
+"""Tests for the per-tool "allow for the whole session" permission option.
+
+Covers the parity work that upgrades the middle permission choice from a
+binary "Allow always" (Bash-only "don't ask again") to the original
+per-tool option set:
+
+* :func:`src.permissions.updates.default_session_suggestions` — the
+  ``PermissionUpdate`` list each tool category contributes (Bash prefix
+  rule, file-edit ``setMode:acceptEdits`` + out-of-roots ``addDirectories``,
+  read content-less rule, other-tool content-less rule).
+* :func:`src.permissions.updates.session_option_label` — the human label.
+* The ``acceptEdits``-mode auto-allow added to
+  :func:`src.permissions.check.has_permissions_to_use_tool` — the half that
+  makes the file-edit session option actually suppress later prompts.
+* :meth:`src.tool_system.context.ToolContext.allowed_roots` folding in the
+  session-granted directories.
+* End-to-end (registry-driven): ask → "always" → apply → a later matching
+  call is not re-prompted.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from src.permissions.check import has_permissions_to_use_tool
+from src.permissions.types import (
+    AdditionalWorkingDirectory,
+    ModeDecisionReason,
+    PermissionAskDecision,
+    PermissionAskReply,
+    PermissionPassthroughResult,
+    PermissionResult,
+    PermissionRuleValue,
+    PermissionUpdateAddDirectories,
+    PermissionUpdateAddRules,
+    PermissionUpdateSetMode,
+    SafetyCheckDecisionReason,
+    ToolPermissionContext,
+)
+from src.permissions.updates import (
+    default_session_suggestions,
+    session_option_label,
+)
+from src.tool_system.build_tool import build_tool
+from src.tool_system.context import ToolContext
+from src.tool_system.protocol import ToolCall, ToolResult
+from src.tool_system.registry import ToolRegistry
+
+
+# --------------------------------------------------------------------------
+# Lightweight test doubles
+# --------------------------------------------------------------------------
+class _MockTool:
+    def __init__(
+        self, name: str = "Write", perm_result: PermissionResult | None = None
+    ) -> None:
+        self._name = name
+        self._perm_result = perm_result
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def is_mcp(self) -> bool:
+        return False
+
+    def check_permissions(
+        self, tool_input: dict[str, Any], context: Any
+    ) -> PermissionResult:
+        if self._perm_result is not None:
+            return self._perm_result
+        return PermissionPassthroughResult()
+
+
+class _FakeToolUseContext:
+    """Stands in for ToolContext where only ``allowed_roots()`` is exercised."""
+
+    def __init__(self, roots: tuple[str, ...]) -> None:
+        self._roots = tuple(Path(r) for r in roots)
+
+    def allowed_roots(self) -> tuple[Path, ...]:
+        return self._roots
+
+
+# --------------------------------------------------------------------------
+# default_session_suggestions
+# --------------------------------------------------------------------------
+class TestDefaultSessionSuggestions(unittest.TestCase):
+    def test_bash_yields_command_prefix_rule(self) -> None:
+        updates = default_session_suggestions("Bash", {"command": "git diff --stat"})
+        self.assertTrue(updates)
+        first = updates[0]
+        self.assertIsInstance(first, PermissionUpdateAddRules)
+        self.assertEqual(first.destination, "localSettings")
+        self.assertEqual(first.behavior, "allow")
+        self.assertEqual(first.rules[0].tool_name, "Bash")
+        self.assertEqual(first.rules[0].rule_content, "git diff:*")
+
+    def test_bash_empty_command_yields_nothing(self) -> None:
+        self.assertEqual(default_session_suggestions("Bash", {"command": "   "}), [])
+        self.assertEqual(default_session_suggestions("Bash", {"command": ""}), [])
+        self.assertEqual(default_session_suggestions("Bash", {}), [])
+
+    def test_file_edit_within_roots_sets_accept_edits_only(self) -> None:
+        updates = default_session_suggestions(
+            "Write",
+            {"file_path": "/ws/a.py"},
+            ToolPermissionContext(mode="default"),
+            allowed_roots=("/ws",),
+        )
+        self.assertEqual(len(updates), 1)
+        self.assertIsInstance(updates[0], PermissionUpdateSetMode)
+        self.assertEqual(updates[0].mode, "acceptEdits")
+        self.assertEqual(updates[0].destination, "session")
+
+    def test_file_edit_outside_roots_grants_parent_directory(self) -> None:
+        updates = default_session_suggestions(
+            "Edit",
+            {"file_path": "/other/place/a.py"},
+            ToolPermissionContext(mode="default"),
+            allowed_roots=("/ws",),
+        )
+        self.assertEqual(len(updates), 2)
+        self.assertIsInstance(updates[0], PermissionUpdateSetMode)
+        self.assertIsInstance(updates[1], PermissionUpdateAddDirectories)
+        # File tools grant the file's *parent* directory.
+        self.assertEqual(updates[1].directories, ("/other/place",))
+        self.assertEqual(updates[1].destination, "session")
+
+    def test_file_edit_plan_mode_still_sets_accept_edits(self) -> None:
+        updates = default_session_suggestions(
+            "Write",
+            {"file_path": "/ws/a.py"},
+            ToolPermissionContext(mode="plan"),
+            allowed_roots=("/ws",),
+        )
+        self.assertEqual(len(updates), 1)
+        self.assertIsInstance(updates[0], PermissionUpdateSetMode)
+
+    def test_file_edit_already_accept_edits_within_roots_yields_nothing(self) -> None:
+        # Already in acceptEdits + inside roots: the matcher auto-allows, so
+        # there is no session option to offer.
+        updates = default_session_suggestions(
+            "Write",
+            {"file_path": "/ws/a.py"},
+            ToolPermissionContext(mode="acceptEdits"),
+            allowed_roots=("/ws",),
+        )
+        self.assertEqual(updates, [])
+
+    def test_file_edit_already_accept_edits_outside_roots_grants_dir_only(self) -> None:
+        updates = default_session_suggestions(
+            "Write",
+            {"file_path": "/other/a.py"},
+            ToolPermissionContext(mode="acceptEdits"),
+            allowed_roots=("/ws",),
+        )
+        self.assertEqual(len(updates), 1)
+        self.assertIsInstance(updates[0], PermissionUpdateAddDirectories)
+        self.assertEqual(updates[0].directories, ("/other",))
+
+    def test_read_within_roots_yields_content_less_session_rule(self) -> None:
+        updates = default_session_suggestions(
+            "Read", {"file_path": "/ws/a.py"}, allowed_roots=("/ws",)
+        )
+        self.assertEqual(len(updates), 1)
+        self.assertIsInstance(updates[0], PermissionUpdateAddRules)
+        self.assertEqual(updates[0].destination, "session")
+        self.assertEqual(updates[0].behavior, "allow")
+        self.assertEqual(updates[0].rules[0].tool_name, "Read")
+        self.assertIsNone(updates[0].rules[0].rule_content)
+
+    def test_read_outside_roots_grants_parent_directory(self) -> None:
+        updates = default_session_suggestions(
+            "Read", {"file_path": "/other/a.py"}, allowed_roots=("/ws",)
+        )
+        self.assertEqual(len(updates), 2)
+        self.assertIsInstance(updates[0], PermissionUpdateAddRules)
+        self.assertIsInstance(updates[1], PermissionUpdateAddDirectories)
+        self.assertEqual(updates[1].directories, ("/other",))
+
+    def test_grep_outside_roots_grants_the_path_itself(self) -> None:
+        # Search tools target a directory, so the grant is the path verbatim
+        # (not its parent).
+        updates = default_session_suggestions(
+            "Grep", {"path": "/other/sub"}, allowed_roots=("/ws",)
+        )
+        self.assertEqual(len(updates), 2)
+        self.assertEqual(updates[0].rules[0].tool_name, "Grep")
+        self.assertEqual(updates[1].directories, ("/other/sub",))
+
+    def test_other_tool_yields_persisted_content_less_rule(self) -> None:
+        updates = default_session_suggestions("WebFetch", {"url": "https://x"})
+        self.assertEqual(len(updates), 1)
+        self.assertIsInstance(updates[0], PermissionUpdateAddRules)
+        self.assertEqual(updates[0].destination, "localSettings")
+        self.assertEqual(updates[0].rules[0].tool_name, "WebFetch")
+        self.assertIsNone(updates[0].rules[0].rule_content)
+
+    def test_interaction_tools_have_no_session_option(self) -> None:
+        for name in ("AskUserQuestion", "EnterPlanMode", "ExitPlanMode"):
+            self.assertEqual(default_session_suggestions(name, {}), [], name)
+
+    def test_empty_tool_name_yields_nothing(self) -> None:
+        self.assertEqual(default_session_suggestions("", {}), [])
+
+    def test_filesystem_root_edit_does_not_grant_root(self) -> None:
+        # A file at "/" would make the grant directory "/" — never register the
+        # whole filesystem as a session working root.
+        updates = default_session_suggestions(
+            "Write",
+            {"file_path": "/a.py"},
+            ToolPermissionContext(mode="default"),
+            allowed_roots=("/ws",),
+        )
+        self.assertEqual(len(updates), 1)
+        self.assertIsInstance(updates[0], PermissionUpdateSetMode)
+        self.assertFalse(
+            any(isinstance(u, PermissionUpdateAddDirectories) for u in updates)
+        )
+
+    def test_unknown_roots_assumed_inside_so_no_dir_grant(self) -> None:
+        # allowed_roots=None means "unknown" — don't mint a directory grant.
+        updates = default_session_suggestions(
+            "Write",
+            {"file_path": "/anywhere/a.py"},
+            ToolPermissionContext(mode="default"),
+            allowed_roots=None,
+        )
+        self.assertEqual(len(updates), 1)
+        self.assertIsInstance(updates[0], PermissionUpdateSetMode)
+
+
+# --------------------------------------------------------------------------
+# session_option_label
+# --------------------------------------------------------------------------
+class TestSessionOptionLabel(unittest.TestCase):
+    def test_empty_suggestions_returns_none(self) -> None:
+        self.assertIsNone(session_option_label(()))
+        self.assertIsNone(session_option_label((), "Write", {}))
+
+    def test_file_edit_within_roots_label(self) -> None:
+        label = session_option_label(
+            (PermissionUpdateSetMode(destination="session", mode="acceptEdits"),),
+            "Write",
+        )
+        # No "(shift+tab)" hint: that key is not wired to mode-cycling in this
+        # port (mode changes go through /permissions).
+        self.assertEqual(label, "allow all edits during this session")
+        # Rendered form the surfaces show:
+        self.assertEqual(
+            f"Yes, {label}", "Yes, allow all edits during this session"
+        )
+
+    def test_file_edit_outside_roots_names_directory(self) -> None:
+        label = session_option_label(
+            (
+                PermissionUpdateSetMode(destination="session", mode="acceptEdits"),
+                PermissionUpdateAddDirectories(
+                    destination="session", directories=("/foo/bar",)
+                ),
+            ),
+            "Write",
+        )
+        self.assertEqual(label, "allow all edits in bar/ during this session")
+
+    def test_file_edit_detected_via_accept_edits_without_tool_name(self) -> None:
+        # Even when the caller cannot supply tool_name, the setMode update
+        # identifies the ask as a file edit.
+        label = session_option_label(
+            (PermissionUpdateSetMode(destination="session", mode="acceptEdits"),),
+            None,
+        )
+        self.assertEqual(label, "allow all edits during this session")
+
+    def test_read_within_roots_label_is_a_complete_phrase(self) -> None:
+        label = session_option_label(
+            (
+                PermissionUpdateAddRules(
+                    destination="session",
+                    behavior="allow",
+                    rules=(PermissionRuleValue(tool_name="Read"),),
+                ),
+            ),
+            "Read",
+        )
+        self.assertEqual(label, "allow reading during this session")
+        # Must read as a sentence once prefixed (regression: bare
+        # "during this session" rendered "Yes, during this session").
+        self.assertEqual(f"Yes, {label}", "Yes, allow reading during this session")
+
+    def test_read_outside_roots_names_directory(self) -> None:
+        label = session_option_label(
+            (
+                PermissionUpdateAddRules(
+                    destination="session",
+                    behavior="allow",
+                    rules=(PermissionRuleValue(tool_name="Read"),),
+                ),
+                PermissionUpdateAddDirectories(
+                    destination="session", directories=("/foo/proj",)
+                ),
+            ),
+            "Read",
+        )
+        self.assertEqual(label, "allow reading from proj/ during this session")
+
+    def test_bash_label_uses_dont_ask_again(self) -> None:
+        suggestions = default_session_suggestions("Bash", {"command": "git diff"})
+        label = session_option_label(tuple(suggestions), "Bash")
+        self.assertIsNotNone(label)
+        assert label is not None
+        self.assertTrue(label.startswith("and don't ask again for"))
+        self.assertIn("Bash(git diff", label)
+
+    def test_other_tool_label_uses_dont_ask_again(self) -> None:
+        suggestions = default_session_suggestions("WebFetch", {"url": "https://x"})
+        label = session_option_label(tuple(suggestions), "WebFetch")
+        self.assertEqual(label, "and don't ask again for WebFetch")
+
+
+# --------------------------------------------------------------------------
+# acceptEdits-mode auto-allow (check.py)
+# --------------------------------------------------------------------------
+class TestAcceptEditsAutoAllow(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = os.path.realpath(self.tmp.name)
+        self.ctx = ToolPermissionContext(mode="acceptEdits")
+        self.tuc = _FakeToolUseContext((self.root,))
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _check(self, tool, tool_input):
+        return has_permissions_to_use_tool(
+            tool, tool_input, self.ctx, tool_use_context=self.tuc
+        )
+
+    def test_edit_inside_roots_is_auto_allowed(self) -> None:
+        decision = self._check(
+            _MockTool(name="Write"),
+            {"file_path": os.path.join(self.root, "a.py"), "content": "x"},
+        )
+        self.assertEqual(decision.behavior, "allow")
+        self.assertIsInstance(decision.decision_reason, ModeDecisionReason)
+        self.assertEqual(decision.decision_reason.mode, "acceptEdits")
+
+    def test_notebook_edit_path_key_is_honored(self) -> None:
+        decision = self._check(
+            _MockTool(name="NotebookEdit"),
+            {"notebook_path": os.path.join(self.root, "nb.ipynb")},
+        )
+        self.assertEqual(decision.behavior, "allow")
+
+    def test_dangerous_file_inside_roots_still_asks(self) -> None:
+        decision = self._check(
+            _MockTool(name="Write"),
+            {"file_path": os.path.join(self.root, ".env"), "content": "x"},
+        )
+        self.assertEqual(decision.behavior, "ask")
+
+    def test_edit_outside_roots_still_asks(self) -> None:
+        decision = self._check(
+            _MockTool(name="Write"),
+            {"file_path": "/somewhere/else/a.py", "content": "x"},
+        )
+        self.assertEqual(decision.behavior, "ask")
+
+    def test_non_edit_tool_not_auto_allowed_in_accept_edits(self) -> None:
+        decision = self._check(
+            _MockTool(name="Read"),
+            {"file_path": os.path.join(self.root, "a.py")},
+        )
+        self.assertEqual(decision.behavior, "ask")
+
+    def test_explicit_tool_ask_is_not_swallowed_by_accept_edits(self) -> None:
+        # A tool that explicitly asks (behavior != passthrough) must keep
+        # asking even for an in-roots edit in acceptEdits mode.
+        explicit = PermissionAskDecision(
+            behavior="ask", message="the docs gate wants confirmation"
+        )
+        decision = self._check(
+            _MockTool(name="Write", perm_result=explicit),
+            {"file_path": os.path.join(self.root, "a.py"), "content": "x"},
+        )
+        self.assertEqual(decision.behavior, "ask")
+
+    def test_default_mode_does_not_auto_allow(self) -> None:
+        self.ctx = ToolPermissionContext(mode="default")
+        decision = self._check(
+            _MockTool(name="Write"),
+            {"file_path": os.path.join(self.root, "a.py"), "content": "x"},
+        )
+        self.assertEqual(decision.behavior, "ask")
+
+
+# --------------------------------------------------------------------------
+# The session option is offered only for passthrough-derived asks
+# --------------------------------------------------------------------------
+class TestSessionOptionOnlyForPassthroughAsks(unittest.TestCase):
+    """An ask a tool raised *explicitly* (e.g. the docs gate) must not be given
+    a ``setMode:acceptEdits`` suggestion: flipping mode would not unblock it
+    (the auto-allow is passthrough-gated) and would silently widen session
+    scope. Only matcher-manufactured (passthrough) asks get the option."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = os.path.realpath(self.tmp.name)
+        self.ctx = ToolPermissionContext(mode="default")
+        self.tuc = _FakeToolUseContext((self.root,))
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _check(self, tool, tool_input):
+        return has_permissions_to_use_tool(
+            tool, tool_input, self.ctx, tool_use_context=self.tuc
+        )
+
+    def test_passthrough_edit_ask_offers_session_option(self) -> None:
+        decision = self._check(
+            _MockTool(name="Write"),
+            {"file_path": os.path.join(self.root, "a.py"), "content": "x"},
+        )
+        self.assertEqual(decision.behavior, "ask")
+        self.assertTrue(decision.suggestions)
+        self.assertTrue(
+            any(isinstance(u, PermissionUpdateSetMode) for u in decision.suggestions)
+        )
+
+    def test_explicit_docs_gate_ask_offers_no_session_option(self) -> None:
+        # Mirrors write.py/edit.py: an explicit ask, no decision_reason.
+        explicit = PermissionAskDecision(
+            behavior="ask",
+            message="Writing documentation files is blocked unless allow_docs is enabled",
+        )
+        decision = self._check(
+            _MockTool(name="Write", perm_result=explicit),
+            {"file_path": os.path.join(self.root, "README.md"), "content": "x"},
+        )
+        self.assertEqual(decision.behavior, "ask")
+        self.assertFalse(decision.suggestions)
+
+
+# --------------------------------------------------------------------------
+# ToolContext.allowed_roots folds in session-granted directories
+# --------------------------------------------------------------------------
+class TestAllowedRootsFolding(unittest.TestCase):
+    def test_session_granted_directory_reaches_allowed_roots(self) -> None:
+        with tempfile.TemporaryDirectory() as ws, tempfile.TemporaryDirectory() as extra:
+            ws_r, extra_r = os.path.realpath(ws), os.path.realpath(extra)
+            ctx = ToolContext(
+                workspace_root=Path(ws_r),
+                permission_context=ToolPermissionContext(
+                    additional_working_directories={
+                        extra_r: AdditionalWorkingDirectory(
+                            path=extra_r, source="session"
+                        )
+                    }
+                ),
+            )
+            roots = {str(r) for r in ctx.allowed_roots()}
+            self.assertIn(str(Path(ws_r).resolve()), roots)
+            self.assertIn(str(Path(extra_r).resolve()), roots)
+
+
+# --------------------------------------------------------------------------
+# End-to-end: ask → "always" → apply → no re-prompt
+# --------------------------------------------------------------------------
+def _passthrough_tool(name: str, schema_props: dict[str, Any]):
+    return build_tool(
+        name=name,
+        description="test tool",
+        input_schema={"type": "object", "properties": schema_props},
+        call=lambda tool_input, context: ToolResult(name=name, output={"ok": True}),
+        check_permissions=lambda tool_input, context: PermissionPassthroughResult(),
+    )
+
+
+class TestSessionOptionEndToEnd(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(os.path.realpath(self.tmp.name))
+        self.registry = ToolRegistry(
+            [
+                _passthrough_tool(
+                    "Write", {"file_path": {"type": "string"}, "content": {"type": "string"}}
+                ),
+                _passthrough_tool("Read", {"file_path": {"type": "string"}}),
+            ]
+        )
+        self.ctx = ToolContext(
+            workspace_root=self.root,
+            permission_context=ToolPermissionContext(mode="default"),
+        )
+        self.calls = {"n": 0}
+
+        def always_handler(request):
+            self.calls["n"] += 1
+            return PermissionAskReply(
+                behavior="allow", chosen_updates=tuple(request.suggestions)
+            )
+
+        self.ctx.permission_handler = always_handler
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _write(self, path: str):
+        return self.registry.dispatch(
+            ToolCall(name="Write", input={"file_path": path, "content": "x"}), self.ctx
+        )
+
+    def _read(self, path: str):
+        return self.registry.dispatch(
+            ToolCall(name="Read", input={"file_path": path}), self.ctx
+        )
+
+    def test_allow_all_edits_session_stops_reprompting(self) -> None:
+        first = self._write(str(self.root / "a.py"))
+        self.assertFalse(first.is_error)
+        self.assertEqual(self.calls["n"], 1)
+        # The accepted setMode flipped the live context into acceptEdits.
+        self.assertEqual(self.ctx.permission_context.mode, "acceptEdits")
+        # A second edit to a *different* in-roots file is not re-prompted.
+        second = self._write(str(self.root / "b.py"))
+        self.assertFalse(second.is_error)
+        self.assertEqual(self.calls["n"], 1, "second edit should auto-allow")
+
+    def test_allow_reading_session_stops_reprompting(self) -> None:
+        first = self._read(str(self.root / "a.py"))
+        self.assertFalse(first.is_error)
+        self.assertEqual(self.calls["n"], 1)
+        self.assertIn("Read", self.ctx.permission_context.always_allow_rules["session"])
+        second = self._read(str(self.root / "b.py"))
+        self.assertFalse(second.is_error)
+        self.assertEqual(self.calls["n"], 1, "second read should auto-allow")
+
+    def test_out_of_roots_edit_grants_directory_for_session(self) -> None:
+        with tempfile.TemporaryDirectory() as outside:
+            outside_r = os.path.realpath(outside)
+            first = self._write(os.path.join(outside_r, "a.py"))
+            self.assertFalse(first.is_error)
+            self.assertEqual(self.calls["n"], 1)
+            self.assertEqual(self.ctx.permission_context.mode, "acceptEdits")
+            self.assertIn(
+                outside_r, self.ctx.permission_context.additional_working_directories
+            )
+            # A later edit elsewhere in the granted directory is auto-allowed.
+            second = self._write(os.path.join(outside_r, "b.py"))
+            self.assertFalse(second.is_error)
+            self.assertEqual(self.calls["n"], 1, "granted dir should auto-allow")
+
+
+class TestDocsGateEndToEnd(unittest.TestCase):
+    """End-to-end: a docs-gated ``.md`` write (explicit tool ask) offers no
+    session option, so accepting it cannot silently flip the session into
+    acceptEdits, and the same file re-prompts (the gate, not a dead-end mode)."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(os.path.realpath(self.tmp.name))
+
+        def check(tool_input, context):
+            p = tool_input.get("file_path", "")
+            if Path(p).suffix.lower() in {".md", ".markdown"}:
+                return PermissionAskDecision(
+                    behavior="ask", message="docs blocked unless allow_docs"
+                )
+            return PermissionPassthroughResult()
+
+        write_tool = build_tool(
+            name="Write",
+            description="docs-gated write",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "file_path": {"type": "string"},
+                    "content": {"type": "string"},
+                },
+            },
+            call=lambda tool_input, context: ToolResult(name="Write", output={"ok": True}),
+            check_permissions=check,
+        )
+        self.registry = ToolRegistry([write_tool])
+        self.ctx = ToolContext(
+            workspace_root=self.root,
+            permission_context=ToolPermissionContext(mode="default"),
+        )
+        self.captured: list[Any] = []
+
+        def always_handler(request):
+            self.captured.append(request)
+            return PermissionAskReply(
+                behavior="allow", chosen_updates=tuple(request.suggestions)
+            )
+
+        self.ctx.permission_handler = always_handler
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _write_md(self):
+        return self.registry.dispatch(
+            ToolCall(
+                name="Write",
+                input={"file_path": str(self.root / "README.md"), "content": "x"},
+            ),
+            self.ctx,
+        )
+
+    def test_docs_gate_offers_no_session_option_and_does_not_escalate(self) -> None:
+        first = self._write_md()
+        self.assertFalse(first.is_error)
+        self.assertEqual(len(self.captured), 1)
+        # No middle option offered for the explicit docs-gate ask.
+        self.assertFalse(self.captured[0].suggestions)
+        # The session was NOT flipped into acceptEdits.
+        self.assertEqual(self.ctx.permission_context.mode, "default")
+        # The same file re-prompts (the gate stands; not a dead-end mode flip).
+        self._write_md()
+        self.assertEqual(len(self.captured), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Ports Claude Code's per-tool **"allow for the whole session"** middle permission option. Previously the Python port offered only a binary Bash-only "don't ask again"; now every interactive ask renders the original per-tool option as `Yes, <label>`:

| Tool class | Session update | Persistence |
|---|---|---|
| File edits (`Write`/`Edit`/`MultiEdit`/`NotebookEdit`) | `setMode:acceptEdits` (+ `addDirectories` when outside roots) | session |
| File reads (`Read`/`Glob`/`Grep`) | content-less allow rule (+ `addDirectories` when outside roots) | session |
| `Bash` | command-prefix rule (unchanged) | localSettings |
| Every other tool (WebFetch/Skill/MCP/…) | content-less allow rule | localSettings |
| `AskUserQuestion`/`EnterPlanMode`/`ExitPlanMode` | — (no option) | — |

`default_session_suggestions()` builds the `PermissionUpdate` list; `session_option_label()` renders the label. The console (`repl/core.py`) and TUI (`permission_modal.py`) prompts both render from this single source.

## How it takes effect

- `has_permissions_to_use_tool_inner` gains an **acceptEdits-mode auto-allow**: a `passthrough` file edit whose path is inside the working roots and passes `check_path_safety_for_auto_edit` is allowed without re-prompting (so the file-edit option, and the Accept-edits mode generally, actually suppress later prompts).
- `ToolContext.allowed_roots()` folds in session-granted `additional_working_directories`, so an accepted out-of-roots directory grant reaches the matcher (this was the original bug: the grant was written but never consulted).

## Safety / correctness notes

- **Suggestions are synthesized only for asks the matcher manufactures from a `passthrough` result.** An ask a tool raises *explicitly* — e.g. the docs gate that blocks `.md` edits unless `allow_docs` — or a configured ask-rule keeps **Yes/No only**. Offering "allow all edits this session" there would be a dead-end (the auto-allow is itself `passthrough`-gated, so the gate would re-prompt the same file) **and** would silently flip the whole session into `acceptEdits`. This was caught in review and explicitly gated against.
- Dangerous paths stay protected *inside* a session-granted directory: every auto-allow runs `check_path_safety_for_auto_edit` (`.env`, lockfiles, `.git/`, `.ssh/`, …), and `_path_in_working_roots` resolves symlinks so an in-roots symlink pointing outside the roots is not auto-allowed.
- `_grant_directory` returns `None` for a filesystem-root (`/`) grant so we never register the whole filesystem as a session working directory.
- The original's `(shift+tab)` hint is **omitted**: this port has the mode-cycle logic (`permissions/cycle.py`) but no keybinding wired to it (mode changes go through `/permissions`), so advertising the shortcut would promise a keypress that does nothing. Wiring shift+tab is a sensible follow-up.

## Test plan

- New `tests/test_permission_session_options.py` (37 tests): suggestion shapes per tool class, label rendering, the acceptEdits auto-allow (in-roots allow / dangerous-file ask / out-of-roots ask / non-edit-tool ask / explicit-ask-not-swallowed), `allowed_roots` folding, the passthrough gating (incl. the docs-gate **no-escalation** end-to-end case), and end-to-end `ask → always → no-reprompt` cycles for edits, reads, and out-of-roots directory grants.
- Full permission + TUI sweep: **777 passed**, 1 skipped.
- Full suite: the 12 failures are pre-existing on `main` (6 provider/network, 2 advisor, 2 tool-property parity, 2 `*_outside_workspace_blocked` parity) — reproduced on a clean checkout; **zero** new failures from this change.
- Reviewed by the `critic` subagent; all BLOCKING/MAJOR/MINOR findings from the first pass were fixed and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
