### PR TITLE
providers: port Z.ai (GLM) provider from CodeWhale, replace legacy glm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 dependencies = [
     "anthropic",
     "openai",
-    "zhipuai",
     "python-dotenv",
     "rich",
     "prompt-toolkit",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # Core Dependencies
 anthropic>=0.18.0
 openai>=1.0.0
-zhipuai>=2.0.0
 python-dotenv>=1.0.0
 rich>=13.0.0
 prompt-toolkit>=3.0.0

--- a/src/cli.py
+++ b/src/cli.py
@@ -308,7 +308,7 @@ Examples:
         '--provider',
         type=str,
         default=None,
-        help='Override the provider (anthropic, openai, glm, minimax, openrouter, deepseek)',
+        help='Override the provider (anthropic, openai, zai, minimax, openrouter, deepseek)',
     )
     noninteractive.add_argument(
         '--allowed-tools',

--- a/src/command_system/model_command.py
+++ b/src/command_system/model_command.py
@@ -26,8 +26,8 @@ need no UI; only the no-args picker needs a surface (``NullUIHost.select`` raise
     and TS ``'default'``-reset (no provider-default reachable from ``CommandContext``).
   * **Validation = alias-resolve + membership** in ``provider.get_available_models()`` (the
     list the picker uses), not TS's network ``validateModel``. Makes "Model 'x' not found"
-    reachable. ``MODEL_ALIASES`` is Claude-only, so on non-Anthropic providers (incl. GLM —
-    the REPL default, whose ``get_available_models()`` lists ``zai/glm-5``) set-by-name needs
+    reachable. ``MODEL_ALIASES`` is Claude-only, so on non-Anthropic providers (incl. Z.ai —
+    the REPL default, whose ``get_available_models()`` lists ``GLM-5.1``/``GLM-5.2``) set-by-name needs
     the **exact listed id**; the picker is the ergonomic path there.
   * **Static description** ("Set the AI model"); TS's is dynamic ``…(currently {model})`` — a
     frozen ``CommandBase.description: str`` can't be a getter. ``current`` shows the live model.

--- a/src/context_system/context_analyzer.py
+++ b/src/context_system/context_analyzer.py
@@ -29,9 +29,11 @@ MODEL_CONTEXT_WINDOWS: dict[str, int] = {
     "gpt-4o-mini": 128_000,
     "gpt-4-turbo": 128_000,
     "gpt-4": 128_000,
-    # GLM / Minimax defaults
-    "glm-4": 128_000,
-    "glm-4-flash": 128_000,
+    # Z.ai GLM Coding Plan
+    "glm-5.2": 1_000_000,
+    "glm-5.1": 202_752,
+    "glm-4": 128_000,  # legacy GLM-4.x fallback
+    # Minimax defaults
     "minimax": 128_000,
     "abab": 128_000,
 }

--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -69,24 +69,14 @@ PROVIDER_INFO: dict[str, ProviderInfo] = {
             "gpt-3.5-turbo",
         ],
     },
-    "glm": {
-        "label": "Zhipu GLM (z.ai)",
-        "default_base_url": "https://open.bigmodel.cn/api/paas/v4",
-        "default_model": "zai/glm-5",
+    "zai": {
+        "label": "Z.ai (GLM Coding)",
+        "default_base_url": "https://api.z.ai/api/coding/paas/v4",
+        "default_model": "GLM-5.1",
         "available_models": [
-            # GLM-5 series (latest, requires zai/ prefix)
-            "zai/glm-5",
-            "zai/glm-5-turbo",
-            # GLM-4 series (standard, zai/ prefix)
-            "zai/glm-4",
-            "zai/glm-4-plus",
-            "zai/glm-4-air",
-            "zai/glm-4-flash",
-            "zai/glm-4.5",
-            "zai/glm-4.6",
-            "zai/glm-4.7",
-            # GLM-3 series (legacy)
-            "zai/glm-3-turbo",
+            # GLM Coding Plan (Z.ai direct, OpenAI-compatible)
+            "GLM-5.1",  # stable default
+            "GLM-5.2",  # opt-in preview
         ],
     },
     "minimax": {
@@ -173,15 +163,36 @@ PROVIDER_INFO: dict[str, ProviderInfo] = {
 }
 
 
+# Legacy / alternate provider names accepted during resolution. ``glm`` is the
+# pre-rename id for Z.ai (Zhipu rebranded as z.ai); ``z-ai`` / ``z_ai`` /
+# ``z.ai`` mirror CodeWhale's accepted spellings. Aliases are normalized in
+# ``get_provider_class`` / ``get_provider_info`` only — config lookups
+# (``get_provider_config``) stay literal so a ``[providers.glm]`` block written
+# before the rename still resolves by its own key.
+PROVIDER_ALIASES: dict[str, str] = {
+    "glm": "zai",
+    "z-ai": "zai",
+    "z_ai": "zai",
+    "z.ai": "zai",
+}
+
+
+def _canonical_provider_name(provider_name: str) -> str:
+    """Resolve a legacy/alternate provider spelling to its canonical id."""
+    return PROVIDER_ALIASES.get(provider_name, provider_name)
+
+
 def get_provider_info(provider_name: str) -> ProviderInfo:
-    """Get provider info by name."""
-    if provider_name not in PROVIDER_INFO:
+    """Get provider info by name (legacy aliases accepted)."""
+    canonical = _canonical_provider_name(provider_name)
+    if canonical not in PROVIDER_INFO:
         raise ValueError(f"Unknown provider: {provider_name}")
-    return PROVIDER_INFO[provider_name]
+    return PROVIDER_INFO[canonical]
 
 
 def get_provider_class(provider_name: str):
-    """Get provider class by name."""
+    """Get provider class by name (legacy aliases accepted)."""
+    provider_name = _canonical_provider_name(provider_name)
     if provider_name == "anthropic":
         from .anthropic_provider import AnthropicProvider
 
@@ -190,10 +201,10 @@ def get_provider_class(provider_name: str):
         from .openai_provider import OpenAIProvider
 
         return OpenAIProvider
-    if provider_name == "glm":
-        from .glm_provider import GLMProvider
+    if provider_name == "zai":
+        from .zai_provider import ZaiProvider
 
-        return GLMProvider
+        return ZaiProvider
     if provider_name == "minimax":
         from .minimax_provider import MinimaxProvider
 

--- a/src/providers/glm_provider.py
+++ b/src/providers/glm_provider.py
@@ -1,61 +1,19 @@
-"""GLM (Zhipu AI) provider implementation."""
+"""Backward-compatible shim for the renamed Z.ai (GLM) provider.
+
+The legacy ``glm`` provider — which spoke to Zhipu's ``open.bigmodel.cn``
+endpoint through the ``zhipuai`` SDK with ``zai/``-prefixed model names — has
+been replaced by :class:`~src.providers.zai_provider.ZaiProvider`, which
+targets Z.ai's OpenAI-compatible GLM Coding Plan endpoint. The ``glm``
+provider id still resolves to the new provider (see
+``src.providers.get_provider_class``); this module only preserves the old
+``from src.providers.glm_provider import GLMProvider`` import path.
+"""
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from .zai_provider import ZaiProvider
 
-try:
-    from zhipuai import ZhipuAI  # type: ignore
-except ImportError:  # catches both ModuleNotFoundError and bare ImportError (e.g. zhipuai<2.0 where ZhipuAI symbol moved)
-    ZhipuAI = None
+# Legacy alias: ``GLMProvider`` now IS ``ZaiProvider``.
+GLMProvider = ZaiProvider
 
-from .openai_compatible import OpenAICompatibleProvider
-
-
-class GLMProvider(OpenAICompatibleProvider):
-    """GLM (Zhipu AI) provider using Zhipu SDK.
-
-    GLM models on z.ai require the 'zai/' prefix in model names.
-    """
-
-    def __init__(
-        self, api_key: str, base_url: Optional[str] = None, model: Optional[str] = None
-    ):
-        """Initialize GLM provider.
-
-        Args:
-            api_key: Zhipu AI API key
-            base_url: Base URL (optional)
-            model: Default model (default: zai/glm-5)
-        """
-        super().__init__(api_key, base_url, model or "zai/glm-5")
-
-    def _create_client(self) -> Any:
-        """Create Zhipu AI SDK client."""
-        if ZhipuAI is None:  # pragma: no cover
-            raise ModuleNotFoundError(
-                "zhipuai package is not installed. Install optional dependencies to use GLMProvider."
-            )
-        return ZhipuAI(api_key=self.api_key)
-
-    def get_available_models(self) -> list[str]:
-        """Get list of available GLM models.
-
-        Returns:
-            List of model names (with zai/ prefix for z.ai API)
-        """
-        return [
-            # GLM-5 series (latest, requires zai/ prefix)
-            "zai/glm-5",
-            "zai/glm-5-turbo",
-            # GLM-4 series (standard, zai/ prefix)
-            "zai/glm-4",
-            "zai/glm-4-plus",
-            "zai/glm-4-air",
-            "zai/glm-4-flash",
-            "zai/glm-4.5",
-            "zai/glm-4.6",
-            "zai/glm-4.7",
-            # GLM-3 series (legacy)
-            "zai/glm-3-turbo",
-        ]
+__all__ = ["GLMProvider", "ZaiProvider"]

--- a/src/providers/zai_provider.py
+++ b/src/providers/zai_provider.py
@@ -1,0 +1,114 @@
+"""Z.ai (GLM) provider implementation.
+
+Z.ai serves the GLM Coding Plan over an OpenAI-compatible
+``/chat/completions`` API at ``https://api.z.ai/api/coding/paas/v4`` (the
+general API lives at ``https://api.z.ai/api/paas/v4``). The provider therefore
+reuses the OpenAI SDK pointed at the Z.ai base URL — the same shape as
+:class:`~src.providers.deepseek_provider.DeepSeekProvider` — rather than a
+vendor-specific SDK.
+
+Ported from the CodeWhale ``zai`` provider: canonical id ``zai`` (aliases
+``z-ai`` / ``z_ai`` / ``z.ai``, plus the pre-rename ``glm``), default model
+``GLM-5.1`` with ``GLM-5.2`` as an opt-in preview. GLM models stream their
+chain-of-thought through ``reasoning_content``, which the shared
+``OpenAICompatibleProvider`` already surfaces.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+try:
+    from openai import OpenAI  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    OpenAI = None
+
+from .openai_compatible import OpenAICompatibleProvider
+
+
+# Canonical Z.ai GLM model ids, keyed by accepted lowercase aliases. Ported
+# from CodeWhale's ``canonical_zai_model_id``: the Z.ai endpoint expects the
+# capitalized ``GLM-5.x`` ids, so a config value like ``glm-5.2`` (or the
+# OpenRouter-style ``zai-glm-5-2``) is normalized before the request. Unknown /
+# custom model ids pass through unchanged.
+_GLM_MODEL_ALIASES: dict[str, str] = {
+    "glm-5.1": "GLM-5.1",
+    "glm-5-1": "GLM-5.1",
+    "zai-glm-5.1": "GLM-5.1",
+    "zai-glm-5-1": "GLM-5.1",
+    "glm-5.2": "GLM-5.2",
+    "glm-5-2": "GLM-5.2",
+    "zai-glm-5.2": "GLM-5.2",
+    "zai-glm-5-2": "GLM-5.2",
+}
+
+
+def _canonical_glm_model(model: str) -> str:
+    """Map an accepted GLM alias to its canonical Z.ai id; pass others through."""
+    return _GLM_MODEL_ALIASES.get(model.strip().lower(), model)
+
+
+class ZaiProvider(OpenAICompatibleProvider):
+    """Z.ai GLM Coding Plan provider using the OpenAI SDK against the Z.ai base URL."""
+
+    DEFAULT_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
+    DEFAULT_MODEL = "GLM-5.1"
+
+    def __init__(
+        self, api_key: str, base_url: Optional[str] = None, model: Optional[str] = None
+    ):
+        """Initialize the Z.ai provider.
+
+        Args:
+            api_key: Z.ai API key (``ZAI_API_KEY`` / ``Z_AI_API_KEY``).
+            base_url: Base URL (optional, defaults to the GLM Coding Plan endpoint).
+            model: Default model (default: ``GLM-5.1``; ``GLM-5.2`` is an opt-in preview).
+        """
+        super().__init__(
+            api_key,
+            base_url or self.DEFAULT_BASE_URL,
+            model or self.DEFAULT_MODEL,
+        )
+
+    def _get_model(self, **kwargs) -> str:
+        """Resolve the model id, normalizing known GLM aliases to canonical ids.
+
+        ``OpenAICompatibleProvider`` sends ``_get_model(...)`` verbatim to the
+        endpoint, so this is where ``glm-5.2`` becomes ``GLM-5.2``. The base
+        implementation still strips the ``[1m]`` context-opt-in suffix first.
+        """
+        model = super()._get_model(**kwargs)
+        return _canonical_glm_model(model) if model else model
+
+    def _create_client(self) -> Any:
+        """Create an OpenAI SDK client pointed at Z.ai.
+
+        The read timeout that prevents a stalled stream from freezing the event
+        loop is applied centrally by ``OpenAICompatibleProvider.client`` (via
+        ``_apply_client_timeout``) for every provider, so it isn't set here.
+        """
+        if OpenAI is None:  # pragma: no cover
+            raise ModuleNotFoundError(
+                "openai package is not installed. Install optional dependencies to use ZaiProvider."
+            )
+        kwargs: dict[str, Any] = {
+            "api_key": self.api_key,
+            "base_url": self.base_url or self.DEFAULT_BASE_URL,
+        }
+        # Support SSL verification bypass for corporate/internal endpoints.
+        import os
+        if os.environ.get("CLAWCODEX_SSL_VERIFY", "").lower() in ("0", "false", "no"):
+            import httpx
+            kwargs["http_client"] = httpx.Client(verify=False)
+        return OpenAI(**kwargs)
+
+    def get_available_models(self) -> list[str]:
+        """Return Z.ai's GLM Coding Plan models.
+
+        ``GLM-5.1`` is the stable default; ``GLM-5.2`` is an opt-in preview
+        (set ``model = "GLM-5.2"`` to try it).
+        """
+        return [
+            "GLM-5.1",
+            "GLM-5.2",
+        ]

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -383,7 +383,7 @@ class ClawcodexREPL:
 
     def __init__(
         self,
-        provider_name: str = "glm",
+        provider_name: str = "zai",
         stream: bool = False,
         *,
         permission_mode: str = "default",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,7 +63,7 @@ class TestDefaultConfig(unittest.TestCase):
         self.assertIn("providers", config)
         self.assertIn("anthropic", config["providers"])
         self.assertIn("openai", config["providers"])
-        self.assertIn("glm", config["providers"])
+        self.assertIn("zai", config["providers"])
 
     def test_default_provider_is_anthropic(self):
         """Test that default provider is Anthropic."""
@@ -82,8 +82,8 @@ class TestDefaultConfig(unittest.TestCase):
             "gpt-5.4"
         )
         self.assertEqual(
-            config["providers"]["glm"]["default_model"],
-            "zai/glm-5"
+            config["providers"]["zai"]["default_model"],
+            "GLM-5.1"
         )
 
 
@@ -156,11 +156,11 @@ class TestProviderConfig(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             with _patch_global_config(temp_dir):
                 _reset_manager()
-                glm_config = get_provider_config("glm")
+                zai_config = get_provider_config("zai")
 
-                self.assertIn("api_key", glm_config)
-                self.assertIn("base_url", glm_config)
-                self.assertIn("default_model", glm_config)
+                self.assertIn("api_key", zai_config)
+                self.assertIn("base_url", zai_config)
+                self.assertIn("default_model", zai_config)
 
     def test_get_unknown_provider(self):
         """Test getting unknown provider."""

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -7,7 +7,8 @@ from unittest.mock import MagicMock, patch
 
 from src.providers import get_provider_class
 from src.providers.anthropic_provider import AnthropicProvider
-from src.providers.glm_provider import GLMProvider
+from src.providers.glm_provider import GLMProvider  # legacy back-compat alias
+from src.providers.zai_provider import ZaiProvider
 from src.providers.openai_compatible import _convert_anthropic_messages_to_openai
 from src.providers.openai_provider import OpenAIProvider
 from src.providers.base import ChatMessage, ChatResponse
@@ -48,7 +49,7 @@ class TestChatResponse(unittest.TestCase):
         """Test response with reasoning content."""
         response = ChatResponse(
             content="Answer",
-            model="glm-4.5",
+            model="GLM-5.1",
             usage={"input_tokens": 10, "output_tokens": 5},
             finish_reason="stop",
             reasoning_content="Reasoning process...",
@@ -422,28 +423,66 @@ class TestOpenAIProvider(unittest.TestCase):
         self.assertEqual(response.usage["total_tokens"], 15)
 
 
-class TestGLMProvider(unittest.TestCase):
-    """Test GLM provider."""
+class TestZaiProvider(unittest.TestCase):
+    """Test Z.ai (GLM) provider.
+
+    Z.ai's GLM Coding Plan is OpenAI-compatible, so the provider uses the
+    OpenAI SDK pointed at the Z.ai base URL (mirrors DeepSeek/OpenAI).
+    """
 
     def test_initialization(self):
-        """Test provider initialization."""
-        provider = GLMProvider(api_key="test_key")
-        self.assertEqual(provider.model, "zai/glm-5")
+        """Default model is the stable GLM-5.1, default base URL is the GLM Coding Plan."""
+        provider = ZaiProvider(api_key="test_key")
+        self.assertEqual(provider.model, "GLM-5.1")
+        self.assertEqual(provider.base_url, "https://api.z.ai/api/coding/paas/v4")
 
     def test_custom_model(self):
-        """Test provider with custom model."""
-        provider = GLMProvider(api_key="test_key", model="glm-4")
-        self.assertEqual(provider.model, "glm-4")
+        """Test provider with custom model (e.g. the GLM-5.2 preview)."""
+        provider = ZaiProvider(api_key="test_key", model="GLM-5.2")
+        self.assertEqual(provider.model, "GLM-5.2")
+
+    def test_custom_base_url(self):
+        """A configured base URL (e.g. the general API) overrides the default."""
+        provider = ZaiProvider(
+            api_key="test_key", base_url="https://api.z.ai/api/paas/v4"
+        )
+        self.assertEqual(provider.base_url, "https://api.z.ai/api/paas/v4")
 
     def test_get_available_models(self):
         """Test getting available models."""
-        provider = GLMProvider(api_key="test_key")
+        provider = ZaiProvider(api_key="test_key")
         models = provider.get_available_models()
-        self.assertIn("zai/glm-4.5", models)
-        self.assertIn("zai/glm-4", models)
+        self.assertIn("GLM-5.1", models)
+        self.assertIn("GLM-5.2", models)
 
-    @patch("src.providers.glm_provider.ZhipuAI")
-    def test_chat(self, mock_zhipu):
+    def test_legacy_glm_alias(self):
+        """``GLMProvider`` is preserved as a back-compat alias of ``ZaiProvider``."""
+        self.assertIs(GLMProvider, ZaiProvider)
+
+    def test_model_alias_canonicalization(self):
+        """Lowercase/aliased GLM ids are normalized to canonical ids on send.
+
+        The Z.ai endpoint expects ``GLM-5.x``; a config value like ``glm-5.2``
+        (the shape Z.ai users commonly write) must reach the API canonicalized.
+        ``provider.model`` keeps the user's spelling for display.
+        """
+        provider = ZaiProvider(api_key="test_key", model="glm-5.2")
+        self.assertEqual(provider.model, "glm-5.2")
+        self.assertEqual(provider._get_model(), "GLM-5.2")
+        # OpenRouter-style alias and the [1m] context suffix both resolve.
+        self.assertEqual(
+            ZaiProvider(api_key="k", model="zai-glm-5-1")._get_model(), "GLM-5.1"
+        )
+        self.assertEqual(
+            ZaiProvider(api_key="k", model="glm-5.2[1m]")._get_model(), "GLM-5.2"
+        )
+        # Unknown / custom ids pass through untouched.
+        self.assertEqual(
+            ZaiProvider(api_key="k", model="custom-model")._get_model(), "custom-model"
+        )
+
+    @patch("src.providers.zai_provider.OpenAI")
+    def test_chat(self, mock_openai):
         """Test synchronous chat."""
         # Setup mock
         mock_client = MagicMock()
@@ -451,42 +490,47 @@ class TestGLMProvider(unittest.TestCase):
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = "Hello!"
         mock_response.choices[0].message.reasoning_content = None
-        mock_response.model = "glm-4.5"
+        mock_response.model = "GLM-5.1"
         mock_response.usage = MagicMock(
             prompt_tokens=10, completion_tokens=5, total_tokens=15
         )
         mock_response.choices[0].finish_reason = "stop"
         mock_client.chat.completions.create.return_value = mock_response
-        mock_zhipu.return_value = mock_client
+        # ``OpenAICompatibleProvider.client`` wraps the SDK client with
+        # ``with_options(...)`` (bounded read timeout); return the same mock so
+        # the configured ``create`` stub is the one actually exercised.
+        mock_client.with_options.return_value = mock_client
+        mock_openai.return_value = mock_client
 
         # Test
-        provider = GLMProvider(api_key="test_key")
+        provider = ZaiProvider(api_key="test_key")
         messages = [ChatMessage(role="user", content="Hi")]
         response = provider.chat(messages)
 
         self.assertEqual(response.content, "Hello!")
-        self.assertEqual(response.model, "glm-4.5")
+        self.assertEqual(response.model, "GLM-5.1")
         self.assertIsNone(response.reasoning_content)
 
-    @patch("src.providers.glm_provider.ZhipuAI")
-    def test_chat_with_reasoning(self, mock_zhipu):
-        """Test chat with reasoning content."""
+    @patch("src.providers.zai_provider.OpenAI")
+    def test_chat_with_reasoning(self, mock_openai):
+        """GLM reasoning streams through ``reasoning_content`` and is surfaced."""
         # Setup mock
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = "Answer"
         mock_response.choices[0].message.reasoning_content = "Thinking..."
-        mock_response.model = "glm-4.5"
+        mock_response.model = "GLM-5.1"
         mock_response.usage = MagicMock(
             prompt_tokens=10, completion_tokens=5, total_tokens=15
         )
         mock_response.choices[0].finish_reason = "stop"
         mock_client.chat.completions.create.return_value = mock_response
-        mock_zhipu.return_value = mock_client
+        mock_client.with_options.return_value = mock_client
+        mock_openai.return_value = mock_client
 
         # Test
-        provider = GLMProvider(api_key="test_key")
+        provider = ZaiProvider(api_key="test_key")
         messages = [ChatMessage(role="user", content="Complex question")]
         response = provider.chat(messages)
 
@@ -507,10 +551,19 @@ class TestGetProviderClass(unittest.TestCase):
         cls = get_provider_class("openai")
         self.assertEqual(cls, OpenAIProvider)
 
-    def test_get_glm_provider(self):
-        """Test getting GLM provider class."""
-        cls = get_provider_class("glm")
-        self.assertEqual(cls, GLMProvider)
+    def test_get_zai_provider(self):
+        """Test getting the Z.ai provider class by canonical id."""
+        cls = get_provider_class("zai")
+        self.assertEqual(cls, ZaiProvider)
+
+    def test_get_zai_provider_via_legacy_glm_alias(self):
+        """The pre-rename ``glm`` id still resolves to the Z.ai provider."""
+        self.assertEqual(get_provider_class("glm"), ZaiProvider)
+
+    def test_get_zai_provider_via_dotted_alias(self):
+        """CodeWhale's ``z.ai`` / ``z-ai`` spellings resolve to the Z.ai provider."""
+        self.assertEqual(get_provider_class("z.ai"), ZaiProvider)
+        self.assertEqual(get_provider_class("z-ai"), ZaiProvider)
 
     def test_get_unknown_provider(self):
         """Test getting unknown provider."""


### PR DESCRIPTION
## Summary

Fixes a startup crash — `ValueError: Unknown provider: zai` — for any config using the post-rename provider name. The provider was renamed **glm → zai** (Zhipu's z.ai rebrand), but the code only knew `glm`.

Ported CodeWhale's `zai` provider, which is **OpenAI-compatible** (`ChatCompletions` wire format) rather than the legacy Zhipu SDK path. The old `GLMProvider` forced the `zhipuai` SDK, **ignored `base_url`**, and used `zai/`-prefixed model names — so it could not have reached the z.ai GLM Coding Plan endpoint a `zai` config points at.

## Changes

- **`src/providers/zai_provider.py`** (new) — `ZaiProvider`, OpenAI SDK + z.ai base URL (same shape as `DeepSeekProvider`). Endpoint `https://api.z.ai/api/coding/paas/v4`, models `GLM-5.1` (default) / `GLM-5.2` (preview). Includes GLM model-id canonicalization (`glm-5.2` → `GLM-5.2`), ported from CodeWhale's `canonical_zai_model_id`, so existing lowercase config values reach the API in the expected form.
- **`src/providers/glm_provider.py`** — legacy Zhipu impl replaced with a back-compat shim (`GLMProvider = ZaiProvider`) preserving the old import path.
- **`src/providers/__init__.py`** — `zai` is now canonical in `PROVIDER_INFO` (label *Z.ai (GLM Coding)*); legacy/alternate names (`glm`, `z-ai`, `z_ai`, `z.ai`) resolve via an alias map in `get_provider_class` / `get_provider_info`. Config lookups stay literal, so a pre-rename `[providers.glm]` block still resolves by its own key.
- Updated REPL default provider, CLI `--provider` help, GLM context windows (`GLM-5.1`=202,752, `GLM-5.2`=1,000,000), and a stale model-command comment.
- Removed the now-unused **`zhipuai`** dependency.

## Tests

- Legacy GLM tests rewritten as `TestZaiProvider` (OpenAI-SDK mocks + alias/canonicalization coverage); default-config and provider-resolution tests updated.
- **48 passed** in `test_providers` + `test_config`; **107 passed** across repl/integration/model-command/query suites.
- Reproduced the original crash path (`config → get_provider_class("zai") → instantiate`) — now resolves to `ZaiProvider` and constructs correctly.

## Note on pre-existing failures

4 failures remain in `TestOpenAIProvider` (×3) and `TestAnthropicProvider` (×1). These **fail on a clean tree too** (verified via `git stash`) — an unrelated mock gap where the tests don't stub `client.with_options(...)` from `_apply_client_timeout`. The new Zai tests handle it correctly; these four are out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)