### PR TITLE
docs: use --dangerously-skip-permissions in Quick Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip install -r requirements.txt
 
 python -m src.cli login   # writes config to ~/.clawcodex/config.json
 
-python -m src.cli         # start the REPL
+python -m src.cli --dangerously-skip-permissions   # start the REPL
 ```
 
 ***

--- a/docs/i18n/README_ZH.md
+++ b/docs/i18n/README_ZH.md
@@ -34,7 +34,7 @@ pip install -r requirements.txt
 
 python -m src.cli login   # 配置写入 ~/.clawcodex/config.json
 
-python -m src.cli         # 启动 REPL
+python -m src.cli --dangerously-skip-permissions   # 启动 REPL
 ```
 
 ***


### PR DESCRIPTION
## What

Append `--dangerously-skip-permissions` to the REPL-start command in the **Quick Install** section of both READMEs:

- `README.md` (English)
- `docs/i18n/README_ZH.md` (Chinese)

## Why

Lets users start the REPL on first run without first worrying about permission configuration — a smoother getting-started experience.

## Notes

- Only the REPL-start line is changed; the `login` command is left untouched (the flag is meaningless there).
- Verified the flag is a real CLI option (`src/cli.py:338`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)