### PR TITLE
permissions: stop over-prompting for safe tools (match TS per-tool allow)

### DIFF
--- a/src/permissions/check.py
+++ b/src/permissions/check.py
@@ -108,6 +108,61 @@ def _get_updated_input_or_fallback(
 # roots (parity with typescript/src/utils/permissions/filesystem.ts:1382-1397).
 _FILE_EDIT_TOOLS: tuple[str, ...] = ("Write", "Edit", "MultiEdit", "NotebookEdit")
 
+# Tools that are NOT necessarily gated — they never need a permission prompt.
+# This port centralizes the always-allow set here (one auditable surface)
+# instead of scattering identical ``check_permissions=allow`` across ~20 tool
+# files. The decision is mode-independent, matching how TS resolves these tools.
+#
+# Two membership rationales (kept distinct on purpose):
+#   * TS-DEFAULT-ALLOW — the base ``TOOL_DEFAULTS.checkPermissions`` returns
+#     ``{behavior:'allow'}`` (typescript/src/Tool.ts:777), so every TS tool with
+#     no override auto-allows. The Python base default is ``passthrough → ask``
+#     (build_tool.py), so these need to be named explicitly. Covers TodoWrite,
+#     ToolSearch, Sleep, Agent (AgentTool.tsx:1309), and the Python-only
+#     bookkeeping/coordination tools with no TS analog (Tasks, Team, Cron,
+#     worktree, Status, Brief, advisor, Clipboard*).
+#   * DELIBERATE UX DIVERGENCE — TS gates these but the project guideline
+#     ("allow if it is not necessarily gated; favor UX while keeping safety")
+#     says not to: WebSearch (TS WebSearchTool.ts:645 returns passthrough → ask;
+#     low-risk read-only, no arbitrary URL unlike WebFetch), AskUserQuestion
+#     (TS returns ask+requiresUserInteraction — the questions ARE the gate;
+#     Python's ``call`` collects answers via ``context.ask_user`` so a separate
+#     permission prompt is redundant), SendUserMessage, StructuredOutput.
+#
+# The check (in :func:`has_permissions_to_use_tool_inner`) is gated on a
+# ``passthrough`` tool result and runs AFTER deny/ask RULES, so a user-configured
+# ``deny``/``ask`` rule (and any explicit tool ``ask``) still wins.
+#
+# DELIBERATELY EXCLUDED (kept gated — these ARE necessarily gated):
+#   * file mutation: Write/Edit/MultiEdit/NotebookEdit
+#   * code execution: Bash
+#   * arbitrary network egress: WebFetch
+#   * input/path-conditional (carry their own check_permissions): Config (write),
+#     Glob, Grep, SendMessage (cross-machine bridge:/uds: recipients), and Skill
+#     (TS allows only skills with safe properties — and this port's skill
+#     executor runs embedded shell directly, so the invocation must stay gated).
+#   * MCP server access: MCP / ListMcpResourcesTool / ReadMcpResourceTool and
+#     dynamic ``mcp__*`` (external/untrusted boundary).
+#   * plan-mode meta tools: EnterPlanMode / ExitPlanMode (ExitPlanMode is the
+#     plan-confirmation gate).
+NO_PERMISSION_TOOLS: frozenset[str] = frozenset({
+    # Interactive / output (the interaction or output IS the action)
+    "AskUserQuestion", "SendUserMessage", "StructuredOutput",
+    # Read-only / introspection
+    "WebSearch", "ToolSearch", "LSP", "advisor", "Brief", "Status",
+    "ClipboardRead",
+    # Bookkeeping / harness state (no external side effects)
+    "TodoWrite", "ClipboardWrite", "Sleep",
+    "TaskCreate", "TaskGet", "TaskList", "TaskUpdate", "TaskOutput", "TaskStop",
+    # Orchestration / coordination — every sub-action they spawn is itself
+    # permission-checked, so the spawn is not the gate.
+    "Agent", "Workflow", "TeamCreate", "TeamDelete",
+    # Scheduling — the scheduled run is permission-checked when it fires.
+    "CronCreate", "CronList", "CronDelete",
+    # Local, reversible git-worktree management.
+    "EnterWorktree", "ExitWorktree",
+})
+
 
 def _allowed_roots_for_check(
     context: ToolPermissionContext, tool_use_context: Any | None
@@ -299,6 +354,23 @@ def has_permissions_to_use_tool_inner(
             behavior="deny",
             message=getattr(tool_permission_result, "message", f"Permission denied for {tool.name}"),
             decision_reason=getattr(tool_permission_result, "decision_reason", None),
+        )
+
+    # Not-necessarily-gated tools auto-allow (see NO_PERMISSION_TOOLS). Gated on
+    # ``passthrough`` so a tool that explicitly returns ``ask``/``deny`` is still
+    # honored, and placed AFTER the deny/ask RULE checks above so configured
+    # rules win. Mode-independent — matching TS, where these tools' own
+    # checkPermissions returns allow regardless of permission mode.
+    if (
+        tool_permission_result.behavior == "passthrough"
+        and tool.name in NO_PERMISSION_TOOLS
+    ):
+        return PermissionAllowDecision(
+            behavior="allow",
+            updated_input=_get_updated_input_or_fallback(tool_permission_result, tool_input),
+            decision_reason=OtherDecisionReason(
+                reason="auto-allow: tool is not necessarily gated (NO_PERMISSION_TOOLS)",
+            ),
         )
 
     if (

--- a/src/tool_system/tools/config.py
+++ b/src/tool_system/tools/config.py
@@ -75,8 +75,23 @@ def _config_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult
     )
 
 
+def _config_check_permissions(tool_input: dict, _context):
+    """Mirror TS ``ConfigTool.checkPermissions`` (ConfigTool.ts:98-107): reading
+    a config value (no ``value`` provided) is auto-allowed; setting one falls
+    through to the normal ask flow (which still surfaces a session option)."""
+    from src.permissions.types import (
+        PermissionAllowDecision,
+        PermissionPassthroughResult,
+    )
+
+    if "value" not in (tool_input or {}):
+        return PermissionAllowDecision(behavior="allow", updated_input=tool_input)
+    return PermissionPassthroughResult()
+
+
 ConfigTool: Tool = build_tool(
     name="Config",
+    check_permissions=_config_check_permissions,
     input_schema={
         "type": "object",
         "additionalProperties": False,

--- a/src/tool_system/tools/glob.py
+++ b/src/tool_system/tools/glob.py
@@ -140,8 +140,31 @@ _GLOB_PROMPT = """- Fast file pattern matching tool that works with any codebase
 - When you are doing an open ended search that may require multiple rounds of globbing and grepping, use the Agent tool instead"""
 
 
+def _glob_check_permissions(tool_input: dict, context):
+    """Path-based read permission, mirroring TS ``GlobTool.checkPermissions`` →
+    ``checkReadPermissionForTool``. The default search dir (cwd) and any path
+    inside the workspace are allowed silently; an explicit ``path`` outside the
+    workspace falls through to the read ``ask``.
+
+    A relative ``path`` is resolved against ``context.cwd`` (the same base the
+    executor uses), not the process cwd, so the check and the run agree."""
+    import os
+    from pathlib import Path
+
+    from src.permissions.filesystem import check_read_permission_for_tool
+
+    base = context.cwd or context.workspace_root
+    path = (tool_input or {}).get("path")
+    if not path:
+        path = str(base)
+    elif not os.path.isabs(os.path.expanduser(path)):
+        path = str(Path(base) / path)
+    return check_read_permission_for_tool(path, context)
+
+
 GlobTool: Tool = build_tool(
     name="Glob",
+    check_permissions=_glob_check_permissions,
     input_schema={
         "type": "object",
         "additionalProperties": False,

--- a/src/tool_system/tools/grep.py
+++ b/src/tool_system/tools/grep.py
@@ -597,8 +597,32 @@ _GREP_PROMPT = """A powerful search tool built on ripgrep
 
 # -- Tool definition -----------------------------------------------------------
 
+def _grep_check_permissions(tool_input: dict, context):
+    """Path-based read permission, mirroring TS ``GrepTool.checkPermissions`` →
+    ``checkReadPermissionForTool``. The default search dir (cwd) and any path
+    inside the workspace are allowed silently; an explicit ``path`` outside the
+    workspace falls through to the read ``ask`` (Grep reads file *contents*, so
+    out-of-workspace targets stay gated).
+
+    A relative ``path`` is resolved against ``context.cwd`` (the same base the
+    executor uses), not the process cwd, so the check and the run agree."""
+    import os
+    from pathlib import Path
+
+    from src.permissions.filesystem import check_read_permission_for_tool
+
+    base = context.cwd or context.workspace_root
+    path = (tool_input or {}).get("path")
+    if not path:
+        path = str(base)
+    elif not os.path.isabs(os.path.expanduser(path)):
+        path = str(Path(base) / path)
+    return check_read_permission_for_tool(path, context)
+
+
 GrepTool: Tool = build_tool(
     name="Grep",
+    check_permissions=_grep_check_permissions,
     input_schema={
         "type": "object",
         "additionalProperties": False,

--- a/src/tool_system/tools/send_message.py
+++ b/src/tool_system/tools/send_message.py
@@ -531,10 +531,40 @@ def _send_message_classifier_input(input_data: dict) -> str:
     return f"to {to}"
 
 
+def _send_message_check_permissions(tool_input: dict, _context):
+    """Mirror TS ``SendMessageTool.checkPermissions`` (SendMessageTool.ts:585).
+
+    Local / team-mailbox / broadcast sends are allowed silently (coordination
+    traffic must not prompt). A cross-machine ``bridge:`` / ``uds:`` recipient
+    returns a non-classifier-approvable safety ``ask`` — bypass- and auto-mode
+    immune — because it is cross-trust-boundary prompt injection. (Those
+    transports are NotImplementedError stubs in this build, but the gate is
+    wired now so it cannot be forgotten when they land.)
+    """
+    from src.permissions.types import (
+        PermissionAllowDecision,
+        PermissionAskDecision,
+        SafetyCheckDecisionReason,
+    )
+
+    to = (tool_input or {}).get("to")
+    if isinstance(to, str) and (to.startswith("bridge:") or to.startswith("uds:")):
+        return PermissionAskDecision(
+            behavior="ask",
+            message=f"Send a message to cross-machine recipient {to}?",
+            decision_reason=SafetyCheckDecisionReason(
+                reason="Cross-machine message recipient requires confirmation",
+                classifier_approvable=False,
+            ),
+        )
+    return PermissionAllowDecision(behavior="allow", updated_input=tool_input)
+
+
 SendMessageTool: Tool = build_tool(
     name=SEND_MESSAGE_TOOL_NAME,
     input_schema=SEND_MESSAGE_INPUT_SCHEMA,
     call=_send_message_call,
+    check_permissions=_send_message_check_permissions,
     prompt=(
         "Send a message to a teammate, a remote peer, or broadcast to "
         "the team. The 'to' field accepts a teammate name, '*' for "

--- a/tests/test_tool_permission_parity.py
+++ b/tests/test_tool_permission_parity.py
@@ -1,0 +1,207 @@
+"""Per-tool permission parity with TS: don't over-prompt for safe tools.
+
+The Python port only defined ``check_permissions`` for the mutating/network
+tools; every other tool fell through to the build_tool default
+(``PermissionPassthroughResult``) which the flow turns into ``ask`` — so ~20
+safe/interactive/bookkeeping tools prompted in ``default`` mode (and were
+wrongly denied as "unknown tool" in ``auto`` mode). TS gives each such tool an
+``allow`` (or, for filesystem readers, a path-based read check). These tests pin
+the ported behavior: safe tools never prompt, genuinely-gated tools still do,
+and configured rules still win.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.permissions.check import NO_PERMISSION_TOOLS, has_permissions_to_use_tool
+from src.permissions.types import ToolPermissionContext
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+
+# Tools that MUST keep prompting (necessarily gated).
+_GATED = {
+    "Edit", "Write", "MultiEdit", "NotebookEdit",  # file mutation
+    "Bash",                                          # code execution
+    "WebFetch",                                      # arbitrary network egress
+    "Skill",                                         # runs embedded shell / skill cmds
+    "MCP", "ListMcpResourcesTool", "ReadMcpResourceTool",  # MCP boundary
+    "EnterPlanMode", "ExitPlanMode",                 # plan-mode meta
+}
+
+
+def _ctx(mode: str, ws: Path) -> ToolContext:
+    return ToolContext(
+        workspace_root=ws, permission_context=ToolPermissionContext(mode=mode)
+    )
+
+
+def _behavior(reg, name, tool_input, ctx) -> str:
+    tool = reg.get(name)
+    return has_permissions_to_use_tool(
+        tool, tool_input, ctx.permission_context, tool_use_context=ctx
+    ).behavior
+
+
+class _Base(unittest.TestCase):
+    def setUp(self) -> None:
+        self.ws = Path(tempfile.mkdtemp()).resolve()
+        (self.ws / "a.txt").write_text("hi\n")
+        self.reg = build_default_registry(include_user_tools=False)
+
+
+class TestSafeToolsAllow(_Base):
+    def test_no_permission_tools_allow_in_default(self) -> None:
+        ctx = _ctx("default", self.ws)
+        for name in sorted(NO_PERMISSION_TOOLS):
+            if self.reg.get(name) is None:
+                continue  # tool not registered in this build
+            self.assertEqual(
+                _behavior(self.reg, name, {}, ctx), "allow",
+                f"{name} should auto-allow in default mode",
+            )
+
+    def test_no_permission_tools_allow_in_auto(self) -> None:
+        # auto mode previously denied these as "unknown tool"; now allow.
+        ctx = _ctx("auto", self.ws)
+        for name in sorted(NO_PERMISSION_TOOLS):
+            if self.reg.get(name) is None:
+                continue
+            self.assertEqual(
+                _behavior(self.reg, name, {}, ctx), "allow",
+                f"{name} should auto-allow in auto mode",
+            )
+
+    def test_ask_user_question_does_not_prompt(self) -> None:
+        ctx = _ctx("default", self.ws)
+        self.assertEqual(
+            _behavior(self.reg, "AskUserQuestion", {"questions": [{"question": "q?"}]}, ctx),
+            "allow",
+        )
+
+
+class TestGatedToolsStillAsk(_Base):
+    def test_gated_tools_ask_in_default(self) -> None:
+        ctx = _ctx("default", self.ws)
+        inputs = {
+            "Edit": {"file_path": str(self.ws / "a.txt"), "old_string": "hi", "new_string": "yo"},
+            "Write": {"file_path": str(self.ws / "b.txt"), "content": "x"},
+            "NotebookEdit": {"notebook_path": str(self.ws / "n.ipynb"), "new_source": "x"},
+            "Bash": {"command": "echo hi"},
+            "WebFetch": {"url": "https://example.com", "prompt": "x"},
+            "Skill": {"skill": "some-skill"},
+            "MCP": {"server": "s", "tool": "t"},
+            "ListMcpResourcesTool": {},
+            "ReadMcpResourceTool": {"server": "s", "uri": "u"},
+            "EnterPlanMode": {},
+            "ExitPlanMode": {},
+        }
+        for name, inp in inputs.items():
+            if self.reg.get(name) is None:
+                continue
+            self.assertEqual(
+                _behavior(self.reg, name, inp, ctx), "ask",
+                f"{name} must remain gated (ask) in default mode",
+            )
+
+    def test_gated_tools_not_in_allow_set(self) -> None:
+        # Guard against accidentally adding a gated tool to the allow-set.
+        for name in _GATED:
+            self.assertNotIn(name, NO_PERMISSION_TOOLS)
+
+
+class TestSearchToolsPathBased(_Base):
+    def test_glob_grep_cwd_allow(self) -> None:
+        ctx = _ctx("default", self.ws)
+        self.assertEqual(_behavior(self.reg, "Glob", {"pattern": "*.py"}, ctx), "allow")
+        self.assertEqual(_behavior(self.reg, "Grep", {"pattern": "x"}, ctx), "allow")
+
+    def test_glob_grep_in_workspace_path_allow(self) -> None:
+        ctx = _ctx("default", self.ws)
+        self.assertEqual(
+            _behavior(self.reg, "Grep", {"pattern": "x", "path": str(self.ws)}, ctx), "allow"
+        )
+
+    def test_glob_grep_outside_workspace_ask(self) -> None:
+        ctx = _ctx("default", self.ws)
+        self.assertEqual(
+            _behavior(self.reg, "Glob", {"pattern": "*", "path": "/etc"}, ctx), "ask"
+        )
+        self.assertEqual(
+            _behavior(self.reg, "Grep", {"pattern": "x", "path": "/etc"}, ctx), "ask"
+        )
+
+    def test_relative_path_resolved_against_context_cwd(self) -> None:
+        # A relative path must resolve against context.cwd (the executor's base),
+        # not the process cwd — so an in-workspace relative dir still allows.
+        (self.ws / "sub").mkdir()
+        ctx = _ctx("default", self.ws)
+        self.assertEqual(_behavior(self.reg, "Grep", {"pattern": "x", "path": "."}, ctx), "allow")
+        self.assertEqual(_behavior(self.reg, "Glob", {"pattern": "*", "path": "sub"}, ctx), "allow")
+
+
+class TestSendMessageGate(_Base):
+    def test_local_recipient_allows(self) -> None:
+        ctx = _ctx("default", self.ws)
+        self.assertEqual(
+            _behavior(self.reg, "SendMessage", {"to": "teammate", "message": "hi"}, ctx),
+            "allow",
+        )
+        self.assertEqual(
+            _behavior(self.reg, "SendMessage", {"to": "*", "message": "hi"}, ctx), "allow"
+        )
+
+    def test_cross_machine_recipient_asks(self) -> None:
+        # bridge:/uds: recipients are a cross-trust boundary → must prompt,
+        # even though those transports are stubs today.
+        ctx = _ctx("default", self.ws)
+        self.assertEqual(
+            _behavior(self.reg, "SendMessage", {"to": "bridge:abc", "message": "hi"}, ctx),
+            "ask",
+        )
+        self.assertEqual(
+            _behavior(self.reg, "SendMessage", {"to": "uds:/tmp/s.sock", "message": "hi"}, ctx),
+            "ask",
+        )
+
+    def test_cross_machine_ask_is_bypass_immune(self) -> None:
+        # The safetyCheck ask is non-classifier-approvable, so even auto mode
+        # surfaces it rather than auto-allowing.
+        ctx = _ctx("auto", self.ws)
+        self.assertEqual(
+            _behavior(self.reg, "SendMessage", {"to": "bridge:abc", "message": "hi"}, ctx),
+            "ask",
+        )
+
+    def test_skill_is_gated(self) -> None:
+        # Skill runs embedded shell / declared tools — the invocation stays gated.
+        ctx = _ctx("default", self.ws)
+        self.assertEqual(_behavior(self.reg, "Skill", {"skill": "some-skill"}, ctx), "ask")
+
+
+class TestConfigInputDependent(_Base):
+    def test_config_read_allows(self) -> None:
+        ctx = _ctx("default", self.ws)
+        self.assertEqual(_behavior(self.reg, "Config", {"setting": "theme"}, ctx), "allow")
+
+    def test_config_write_asks(self) -> None:
+        ctx = _ctx("default", self.ws)
+        self.assertEqual(
+            _behavior(self.reg, "Config", {"setting": "theme", "value": "dark"}, ctx), "ask"
+        )
+
+
+class TestRulesStillWin(_Base):
+    def test_deny_rule_beats_central_allow(self) -> None:
+        # A configured deny rule for an otherwise-allowed tool must still deny —
+        # the central allow is gated on passthrough and runs after rule checks.
+        pc = ToolPermissionContext.from_iterables(deny_names=["TodoWrite"])
+        ctx = ToolContext(workspace_root=self.ws, permission_context=pc)
+        self.assertEqual(_behavior(self.reg, "TodoWrite", {}, ctx), "deny")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The Python port only defined `check_permissions` for the 6 mutating/network tools (Edit, Write, NotebookEdit, Bash, WebFetch, Read). **Every other tool fell through to the build_tool default (`PermissionPassthroughResult`)**, which the permission flow turns into `ask`. So ~20 safe/interactive/bookkeeping tools over-prompted:

- **`default` mode** → `ask` for `AskUserQuestion`, `TodoWrite`, `Glob`, `Grep`, `Task*`, `WebSearch`, `Workflow`, … (the reported "Claude wants to use AskUserQuestion. Allow?")
- **`auto` mode** → worse: `auto_mode_classify` returned `"unknown tool"` → **deny**

TS gives each safe tool an explicit `{behavior:'allow'}` — the base `TOOL_DEFAULTS.checkPermissions` (`Tool.ts:777`) — and filesystem readers (Glob/Grep) delegate to `checkReadPermissionForTool`.

**Guideline followed:** *allow actions that are not necessarily gated; optimize UX while keeping safety.*

## Change

- **`check.py`** — `NO_PERMISSION_TOOLS` frozenset + a `passthrough`→`allow` check in `has_permissions_to_use_tool_inner`, gated on `passthrough` and placed **after** the deny/ask RULE checks so configured rules (and explicit tool asks) still win. Mode-independent, like TS.
- **`glob.py` / `grep.py`** — `check_permissions` delegates to `check_read_permission_for_tool` (cwd / in-workspace → allow; out-of-workspace path → ask). Relative paths resolved against `context.cwd` so the check matches the executor.
- **`config.py`** — read (no `value`) → allow; write → ask (`ConfigTool.ts:98-107`).
- **`send_message.py`** — cross-machine `bridge:`/`uds:` recipients → **bypass-immune** safety ask; local/team/broadcast → allow (`SendMessageTool.ts:585`).

### Kept gated (necessarily gated)
File mutation (Edit/Write/MultiEdit/NotebookEdit), code execution (Bash), arbitrary network egress (WebFetch), **Skill** (its executor runs embedded shell), all MCP access (MCP/ListMcpResources/ReadMcpResource + dynamic `mcp__*`), and the plan-mode meta tools.

### Deliberate, documented UX divergences from TS
`WebSearch` (TS `passthrough`→ask; kept allowed — low-risk read-only, no arbitrary URL unlike WebFetch) and `AskUserQuestion` (TS `ask`+`requiresUserInteraction` — the questions *are* the interaction; Python's `call` collects answers, so a separate prompt is redundant).

## "Allow all edits this session" / session options
Verified as part of this work: the `acceptEdits` session option (**"Yes, allow all edits during this session"**) already exists and is functional, and every still-gated tool offers a session/always option (the only no-option cases are the plan-mode meta tools and dangerous Bash — both correct).

## Tests
- New `tests/test_tool_permission_parity.py` (**16 tests**): safe tools → allow (default + auto); gated tools → ask; Glob/Grep cwd/in-workspace → allow, out-of-workspace → ask, relative path resolved vs cwd; Config read→allow/write→ask; SendMessage local→allow / `bridge:`→bypass-immune ask; Skill gated; configured deny rule still wins.
- Broad suite: **2447 passed**; 7 failures are pre-existing baseline (identical on `main` — `test_*_outside_workspace_blocked`, two `tool_parity` snapshots, provider stream tests). Zero new regressions.
- Reviewed via the Critic loop (REQUEST CHANGES → fixed → **APPROVE**); the review closed two latent security gaps (Skill embedded-shell, SendMessage cross-machine).

## Follow-up (out of scope)
`skill.py:_make_shell_executor` runs embedded skill shell ungated (pre-existing; now fronted by Skill staying gated). It should eventually honor the bash permission path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)