### PR TITLE
docs: migrate GLM provider docs to canonical `zai`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ python -m src.cli login   # writes config to ~/.clawcodex/config.json
 python -m src.cli --dangerously-skip-permissions   # start the REPL
 ```
 
+The configuration file is saved at `~/.clawcodex/config.json`. Minimal example:
+
+```json
+{
+  "default_provider": "zai",
+  "providers": {
+    "zai": {
+      "api_key": "xxx-xxx",
+      "base_url": "https://api.z.ai/api/coding/paas/v4",
+      "default_model": "glm-5.2"
+    }
+  }
+}
+```
+
+The `session`, `settings`, and `env` blocks are optional — sensible defaults apply when they're omitted. See [Configure](#configure) for the full structure.
+
 ***
 
 ## 📰 News
@@ -132,7 +149,7 @@ Explain the code in $path. Start with an analogy, then draw a diagram.
 ClawCodex’s main advantage is **multi-provider support**: while Claude Code targets **Claude** models, we aim to support **every major LLM provider** behind the same agent runtime—so you can swap vendors, regions, and price tiers without giving up tools, skills, or the coding loop. That flexibility is what makes agentic coding practical at scale.
 
 ```python
-providers = ["anthropic", "openai", "glm", "minimax", "openrouter", "deepseek"]  # OpenAI-compatible & GLM APIs; more can be added
+providers = ["anthropic", "openai", "zai", "minimax", "openrouter", "deepseek"]  # OpenAI-compatible & GLM APIs; more can be added
 ```
 
 ### Interactive REPL (default) and Textual TUI (opt-in)
@@ -201,7 +218,7 @@ clawcodex --allow-dangerously-skip-permissions         # allow /permission-mode 
 |--------|--------|-------------|
 | CLI Entry | ✅ | `clawcodex`, `login`, `config`, `-p` / `--print`, `--tui`, `--stream`, `--version` |
 | Interactive REPL | ✅ | Default inline REPL; optional Textual TUI; history, tab completion, multiline |
-| Multi-Provider | ✅ | Anthropic, OpenAI, Zhipu GLM, Minimax, OpenRouter, DeepSeek — including Anthropic→OpenAI image / document block translation for vision-capable OpenAI-compat backends |
+| Multi-Provider | ✅ | Anthropic, OpenAI, Z.ai GLM, Minimax, OpenRouter, DeepSeek — including Anthropic→OpenAI image / document block translation for vision-capable OpenAI-compat backends |
 | Session Persistence | ✅ | Save/load sessions locally |
 | Agent Loop | ✅ | Tool calling loop with streaming and headless mode |
 | Skill System | ✅ | SKILL.md-based slash-command skills with args + tool limits |
@@ -266,13 +283,13 @@ clawcodex login
 
 This flow will:
 
-1. ask you to choose a provider: anthropic / openai / glm / minimax / openrouter / deepseek
+1. ask you to choose a provider: anthropic / openai / zai / minimax / openrouter / deepseek
 2. ask for that provider's API key
 3. optionally save a custom base URL
 4. optionally save a default model
 5. set the selected provider as default
 
-The configuration file is saved in in `~/.clawcodex/config.json`. Example structure:
+The configuration file is saved in `~/.clawcodex/config.json`. Example structure:
 
 ```json
 {
@@ -288,10 +305,10 @@ The configuration file is saved in in `~/.clawcodex/config.json`. Example struct
       "base_url": "https://api.openai.com/v1",
       "default_model": "gpt-5.4"
     },
-    "glm": {
+    "zai": {
       "api_key": "your-api-key",
-      "base_url": "https://open.bigmodel.cn/api/paas/v4",
-      "default_model": "zai/glm-5"
+      "base_url": "https://api.z.ai/api/coding/paas/v4",
+      "default_model": "glm-5.2"
     },
     "minimax": {
       "api_key": "your-api-key",

--- a/docs/guide/SETUP_GUIDE.md
+++ b/docs/guide/SETUP_GUIDE.md
@@ -1,124 +1,113 @@
-# 环境配置指南
+# Setup Guide
 
-## 1. 激活虚拟环境
+Detailed installation and configuration for **clawcodex**. For a quick overview, see the [Quick Start](../../README.md#-quick-start) in the main README — this guide expands on each step and adds a provider reference and troubleshooting.
 
-```bash
-# 进入项目目录
-cd /root/Claw-Codex
+## Prerequisites
 
-# 激活虚拟环境
-source .venv/bin/activate
+- **Python 3.10+** (3.11 recommended)
+- **git**
+- **[uv](https://github.com/astral-sh/uv)** (recommended) or `pip`
+- An API key for at least one supported provider: Anthropic, OpenAI, Z.ai (GLM), MiniMax, OpenRouter, or DeepSeek
 
-# 确认 Python 版本
-python --version  # 应该显示 Python 3.11.x
-```
-
-## 2. 配置 GLM API Key
-
-### 方式一：环境变量（推荐用于测试）
+## 1. Clone and install
 
 ```bash
-# 临时设置（当前会话有效）
-export GLM_API_KEY="your_api_key_here"
+git clone https://github.com/agentforce314/clawcodex.git
+cd clawcodex
 
-# 永久设置（添加到 ~/.bashrc）
-echo 'export GLM_API_KEY="your_api_key_here"' >> ~/.bashrc
-source ~/.bashrc
+# Create and activate a virtual environment (uv recommended)
+uv venv --python 3.11
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+
+# Install the package with its entry point
+uv pip install -e ".[dev]"
 ```
 
-### 方式二：.env 文件（推荐用于开发）
+Confirm the CLI is available:
 
 ```bash
-# 在项目根目录创建 .env 文件
-cat > .env << 'EOF'
-# GLM API Configuration
-GLM_API_KEY=your_api_key_here
-GLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4
-GLM_DEFAULT_MODEL=glm-4
-
-# Optional: Other APIs
-# ANTHROPIC_API_KEY=your_anthropic_key
-# OPENAI_API_KEY=your_openai_key
-EOF
-
-# .env 文件已在 .gitignore 中，不会被提交到 Git
+clawcodex --help
 ```
 
-## 3. GLM API 信息
+If you'd rather not install the entry point, you can always run `python -m src.cli` in place of `clawcodex`.
 
-### API 端点
-- **Base URL**: `https://open.bigmodel.cn/api/paas/v4`
-- **认证方式**: Bearer Token (API Key)
-- **文档**: https://open.bigmodel.cn/dev/api
+## 2. Configure a provider
 
-### 可用模型
-- `glm-4` - 最新的 GLM-4 模型（推荐）
-- `glm-4-flash` - 快速版本
-- `glm-3-turbo` - GLM-3 Turbo
+clawcodex reads its configuration from `~/.clawcodex/config.json`. Create it interactively or by hand.
 
-### API 调用示例（Python）
-```python
-from zhipuai import ZhipuAI
+### Option A — Interactive (recommended)
 
-client = ZhipuAI(api_key="your_api_key")
-
-response = client.chat.completions.create(
-    model="glm-4",
-    messages=[
-        {"role": "user", "content": "你好"}
-    ]
-)
-print(response.choices[0].message.content)
-```
-
-## 4. 验证配置
-
-### 测试环境变量
 ```bash
-# 检查环境变量是否设置
-echo $GLM_API_KEY
-
-# 如果使用 .env 文件，Python 会自动加载
-python -c "from dotenv import load_dotenv; import os; load_dotenv(); print(os.getenv('GLM_API_KEY'))"
+clawcodex login
 ```
 
-## 5. 后续步骤
+This walks you through:
 
-配置完成后，我会：
-1. 创建 `requirements.txt` 和 `setup.py`
-2. 安装依赖：`uv pip install -e .`
-3. 创建配置文件：`~/.clawcodex/config.json`
-4. 测试 GLM API 连接
+1. choosing a provider — `anthropic` / `openai` / `zai` / `minimax` / `openrouter` / `deepseek`
+2. entering that provider's API key
+3. optionally setting a custom base URL
+4. optionally setting a default model
+5. setting the chosen provider as the default
+
+### Option B — Edit the config file directly
+
+Create `~/.clawcodex/config.json` (only the providers you actually use are required):
+
+```json
+{
+  "default_provider": "zai",
+  "providers": {
+    "anthropic": {
+      "api_key": "your-api-key",
+      "base_url": "https://api.anthropic.com",
+      "default_model": "claude-sonnet-4-6"
+    },
+    "zai": {
+      "api_key": "your-api-key",
+      "base_url": "https://api.z.ai/api/coding/paas/v4",
+      "default_model": "glm-5.2"
+    }
+  },
+  "env": {
+    "TAVILY_API_KEY": "tvly-YOUR-TAVILY-API-KEY"
+  }
+}
+```
+
+- **`default_provider`** — which provider block to use unless overridden with `--provider`.
+- **`providers`** — one block per provider (`api_key`, `base_url`, `default_model`).
+- **`env`** — secrets and environment values injected at startup (e.g. `TAVILY_API_KEY` for web search). Manage these with `clawcodex config`.
+
+> **Secrets live in this single config file** (the `env` block and each provider's `api_key`) — clawcodex does **not** read `.env` files.
+
+## 3. Provider reference
+
+| Provider key | Base URL | Example model |
+|---|---|---|
+| `anthropic` | `https://api.anthropic.com` | `claude-sonnet-4-6` |
+| `openai` | `https://api.openai.com/v1` | `gpt-5.4` |
+| `zai` | `https://api.z.ai/api/coding/paas/v4` | `glm-5.2` (also `glm-5.1`) |
+| `minimax` | `https://api.minimaxi.com/anthropic` | `MiniMax-M2.7` |
+| `openrouter` | `https://openrouter.ai/api/v1` | `deepseek/deepseek-v4-pro` |
+| `deepseek` | `https://api.deepseek.com` | `deepseek-v4-pro` |
+
+> **Z.ai (GLM):** clawcodex uses Z.ai's OpenAI-compatible GLM Coding Plan at `https://api.z.ai/api/coding/paas/v4`, serving `GLM-5.1` (stable) and `GLM-5.2` (preview). The legacy provider name `glm` is still accepted as an alias for `zai`. Get a key at <https://z.ai/>.
+
+## 4. Run
+
+```bash
+clawcodex                  # start the inline REPL (same as: python -m src.cli)
+clawcodex --help           # all flags: --tui, -p, --provider, --model, …
+clawcodex --provider zai   # start this session with a specific provider
+```
+
+## Troubleshooting
+
+- **`clawcodex: command not found`** — activate your virtualenv (`source .venv/bin/activate`), or run `python -m src.cli`.
+- **`Unknown provider` / auth errors** — make sure the provider key in `~/.clawcodex/config.json` matches a block under `providers`, and that its `api_key` is set.
+- **Wrong Python version** — clawcodex needs Python 3.10+. Check with `python --version`; recreate the venv with `uv venv --python 3.11` if needed.
+- **Web search not working** — set `TAVILY_API_KEY` in the `env` block of the config (see above).
 
 ---
 
-## 常见问题
-
-### Q: API Key 在哪里获取？
-A: 访问 https://open.bigmodel.cn/ 注册账号后获取
-
-### Q: 如何获取 API Key？
-A:
-1. 登录智谱开放平台
-2. 进入「API 密钥」页面
-3. 创建新的 API Key
-
-### Q: 有免费额度吗？
-A: 新用户通常有免费试用额度，具体查看官网说明
-
----
-
-## 下一步
-
-请按以下步骤操作：
-
-1. ✅ **激活虚拟环境**：
-   ```bash
-   source .venv/bin/activate
-   ```
-
-2. ✅ **配置 API Key**（二选一）：
-   - 方式一：`export GLM_API_KEY="your_key"`
-   - 方式二：创建 `.env` 文件并写入
-
-3. ✅ **告诉我已完成**，我会继续后续步骤
+For full provider/model details and feature status, see the [main README](../../README.md) and [FEATURE_LIST.md](../../FEATURE_LIST.md).

--- a/docs/i18n/README_AR.md
+++ b/docs/i18n/README_AR.md
@@ -72,7 +72,7 @@
 ### دعم متعدد المزودين
 
 ```python
-providers = ["Anthropic Claude", "OpenAI GPT", "Zhipu GLM"]  # + سهل التوسيع
+providers = ["Anthropic Claude", "OpenAI GPT", "Z.ai GLM"]  # + سهل التوسيع
 ```
 
 ### REPL تفاعلي
@@ -131,6 +131,23 @@ source .venv/bin/activate
 uv pip install -r requirements.txt
 ```
 
+يتم حفظ ملف التكوين في `~/.clawcodex/config.json`. مثال مبسّط:
+
+```json
+{
+  "default_provider": "zai",
+  "providers": {
+    "zai": {
+      "api_key": "xxx-xxx",
+      "base_url": "https://api.z.ai/api/coding/paas/v4",
+      "default_model": "glm-5.2"
+    }
+  }
+}
+```
+
+كتل `session` و`settings` و`env` اختيارية — تُطبَّق قيم افتراضية معقولة عند حذفها (الهيكل الكامل أدناه).
+
 ### التكوين
 
 #### الخيار 1: تفاعلي (مُوصى به)
@@ -141,7 +158,7 @@ python -m src.cli login
 
 هذه العملية ستقوم بـ:
 
-1. مطالبتك باختيار مزود: anthropic / openai / glm
+1. مطالبتك باختيار مزود: anthropic / openai / zai
 2. مطالبتك بمفتاح API الخاص بذلك المزود
 3. حفظ عنوان URL أساسي مخصص اختياريًا
 4. حفظ نموذج افتراضي اختياريًا
@@ -151,7 +168,7 @@ python -m src.cli login
 
 ```json
 {
-  "default_provider": "glm",
+  "default_provider": "zai",
   "providers": {
     "anthropic": {
       "api_key": "your-api-key",
@@ -163,10 +180,10 @@ python -m src.cli login
       "base_url": "https://api.openai.com/v1",
       "default_model": "gpt-4"
     },
-    "glm": {
+    "zai": {
       "api_key": "your-api-key",
-      "base_url": "https://open.bigmodel.cn/api/paas/v4",
-      "default_model": "glm-4.5"
+      "base_url": "https://api.z.ai/api/coding/paas/v4",
+      "default_model": "glm-5.2"
     }
   }
 }

--- a/docs/i18n/README_FR.md
+++ b/docs/i18n/README_FR.md
@@ -72,7 +72,7 @@
 ### Support multi-fournisseurs
 
 ```python
-providers = ["Anthropic Claude", "OpenAI GPT", "Zhipu GLM"]  # + facile à étendre
+providers = ["Anthropic Claude", "OpenAI GPT", "Z.ai GLM"]  # + facile à étendre
 ```
 
 ### REPL interactif
@@ -131,6 +131,23 @@ source .venv/bin/activate
 uv pip install -r requirements.txt
 ```
 
+Le fichier de configuration est enregistré dans `~/.clawcodex/config.json`. Exemple minimal :
+
+```json
+{
+  "default_provider": "zai",
+  "providers": {
+    "zai": {
+      "api_key": "xxx-xxx",
+      "base_url": "https://api.z.ai/api/coding/paas/v4",
+      "default_model": "glm-5.2"
+    }
+  }
+}
+```
+
+Les blocs `session`, `settings` et `env` sont optionnels — des valeurs par défaut raisonnables s'appliquent s'ils sont omis (structure complète ci-dessous).
+
 ### Configuration
 
 #### Option 1 : Interactif (Recommandé)
@@ -141,7 +158,7 @@ python -m src.cli login
 
 Ce processus va :
 
-1. vous demander de choisir un fournisseur : anthropic / openai / glm
+1. vous demander de choisir un fournisseur : anthropic / openai / zai
 2. vous demander la clé API de ce fournisseur
 3. enregistrer optionnellement une URL de base personnalisée
 4. enregistrer optionnellement un modèle par défaut
@@ -151,7 +168,7 @@ Le fichier de configuration est enregistré dans `~/.clawcodex/config.json`. Exe
 
 ```json
 {
-  "default_provider": "glm",
+  "default_provider": "zai",
   "providers": {
     "anthropic": {
       "api_key": "your-api-key",
@@ -163,10 +180,10 @@ Le fichier de configuration est enregistré dans `~/.clawcodex/config.json`. Exe
       "base_url": "https://api.openai.com/v1",
       "default_model": "gpt-4"
     },
-    "glm": {
+    "zai": {
       "api_key": "your-api-key",
-      "base_url": "https://open.bigmodel.cn/api/paas/v4",
-      "default_model": "glm-4.5"
+      "base_url": "https://api.z.ai/api/coding/paas/v4",
+      "default_model": "glm-5.2"
     }
   }
 }

--- a/docs/i18n/README_HI.md
+++ b/docs/i18n/README_HI.md
@@ -72,7 +72,7 @@
 ### बहु-प्रदाता समर्थन
 
 ```python
-providers = ["Anthropic Claude", "OpenAI GPT", "Zhipu GLM"]  # + आसानी से विस्तारणीय
+providers = ["Anthropic Claude", "OpenAI GPT", "Z.ai GLM"]  # + आसानी से विस्तारणीय
 ```
 
 ### इंटरैक्टिव REPL
@@ -131,6 +131,23 @@ source .venv/bin/activate
 uv pip install -r requirements.txt
 ```
 
+कॉन्फ़िगरेशन फ़ाइल `~/.clawcodex/config.json` में सहेजी जाती है। न्यूनतम उदाहरण:
+
+```json
+{
+  "default_provider": "zai",
+  "providers": {
+    "zai": {
+      "api_key": "xxx-xxx",
+      "base_url": "https://api.z.ai/api/coding/paas/v4",
+      "default_model": "glm-5.2"
+    }
+  }
+}
+```
+
+`session`, `settings` और `env` ब्लॉक वैकल्पिक हैं — इन्हें छोड़ने पर उचित डिफ़ॉल्ट मान लागू होते हैं (पूरी संरचना नीचे)।
+
 ### कॉन्फ़िगर करें
 
 #### विकल्प 1: इंटरैक्टिव (अनुशंसित)
@@ -141,7 +158,7 @@ python -m src.cli login
 
 यह प्रक्रिया:
 
-1. आपको एक प्रदाता चुनने के लिए कहेगी: anthropic / openai / glm
+1. आपको एक प्रदाता चुनने के लिए कहेगी: anthropic / openai / zai
 2. उस प्रदाता की API कुंजी मांगेगी
 3. वैकल्पिक रूप से एक कस्टम base URL सहेजेगी
 4. वैकल्पिक रूप से एक डिफ़ॉल्ट मॉडल सहेजेगी
@@ -151,7 +168,7 @@ python -m src.cli login
 
 ```json
 {
-  "default_provider": "glm",
+  "default_provider": "zai",
   "providers": {
     "anthropic": {
       "api_key": "your-api-key",
@@ -163,10 +180,10 @@ python -m src.cli login
       "base_url": "https://api.openai.com/v1",
       "default_model": "gpt-4"
     },
-    "glm": {
+    "zai": {
       "api_key": "your-api-key",
-      "base_url": "https://open.bigmodel.cn/api/paas/v4",
-      "default_model": "glm-4.5"
+      "base_url": "https://api.z.ai/api/coding/paas/v4",
+      "default_model": "glm-5.2"
     }
   }
 }

--- a/docs/i18n/README_PT.md
+++ b/docs/i18n/README_PT.md
@@ -72,7 +72,7 @@
 ### Suporte Multi-Provedor
 
 ```python
-providers = ["Anthropic Claude", "OpenAI GPT", "Zhipu GLM"]  # + fácil de estender
+providers = ["Anthropic Claude", "OpenAI GPT", "Z.ai GLM"]  # + fácil de estender
 ```
 
 ### REPL Interativo
@@ -131,6 +131,23 @@ source .venv/bin/activate
 uv pip install -r requirements.txt
 ```
 
+O arquivo de configuração é salvo em `~/.clawcodex/config.json`. Exemplo mínimo:
+
+```json
+{
+  "default_provider": "zai",
+  "providers": {
+    "zai": {
+      "api_key": "xxx-xxx",
+      "base_url": "https://api.z.ai/api/coding/paas/v4",
+      "default_model": "glm-5.2"
+    }
+  }
+}
+```
+
+Os blocos `session`, `settings` e `env` são opcionais — valores padrão razoáveis se aplicam quando omitidos (estrutura completa abaixo).
+
 ### Configurar
 
 #### Opção 1: Interativo (Recomendado)
@@ -141,7 +158,7 @@ python -m src.cli login
 
 Este processo irá:
 
-1. pedir que você escolha um provedor: anthropic / openai / glm
+1. pedir que você escolha um provedor: anthropic / openai / zai
 2. pedir a chave API desse provedor
 3. salvar opcionalmente uma URL base personalizada
 4. salvar opcionalmente um modelo padrão
@@ -151,7 +168,7 @@ O arquivo de configuração é salvo em `~/.clawcodex/config.json`. Exemplo de e
 
 ```json
 {
-  "default_provider": "glm",
+  "default_provider": "zai",
   "providers": {
     "anthropic": {
       "api_key": "your-api-key",
@@ -163,10 +180,10 @@ O arquivo de configuração é salvo em `~/.clawcodex/config.json`. Exemplo de e
       "base_url": "https://api.openai.com/v1",
       "default_model": "gpt-4"
     },
-    "glm": {
+    "zai": {
       "api_key": "your-api-key",
-      "base_url": "https://open.bigmodel.cn/api/paas/v4",
-      "default_model": "glm-4.5"
+      "base_url": "https://api.z.ai/api/coding/paas/v4",
+      "default_model": "glm-5.2"
     }
   }
 }

--- a/docs/i18n/README_RU.md
+++ b/docs/i18n/README_RU.md
@@ -72,7 +72,7 @@
 ### Поддержка нескольких провайдеров
 
 ```python
-providers = ["Anthropic Claude", "OpenAI GPT", "Zhipu GLM"]  # + легко расширить
+providers = ["Anthropic Claude", "OpenAI GPT", "Z.ai GLM"]  # + легко расширить
 ```
 
 ### Интерактивный REPL
@@ -131,6 +131,23 @@ source .venv/bin/activate
 uv pip install -r requirements.txt
 ```
 
+Файл конфигурации сохраняется в `~/.clawcodex/config.json`. Минимальный пример:
+
+```json
+{
+  "default_provider": "zai",
+  "providers": {
+    "zai": {
+      "api_key": "xxx-xxx",
+      "base_url": "https://api.z.ai/api/coding/paas/v4",
+      "default_model": "glm-5.2"
+    }
+  }
+}
+```
+
+Блоки `session`, `settings` и `env` необязательны — при их отсутствии применяются разумные значения по умолчанию (полная структура ниже).
+
 ### Настройка
 
 #### Вариант 1: Интерактивный (Рекомендуется)
@@ -141,7 +158,7 @@ python -m src.cli login
 
 Этот процесс:
 
-1. попросит вас выбрать провайдера: anthropic / openai / glm
+1. попросит вас выбрать провайдера: anthropic / openai / zai
 2. попросит ввести API ключ этого провайдера
 3. при необходимости сохранит пользовательский base URL
 4. при необходимости сохранит модель по умолчанию
@@ -151,7 +168,7 @@ python -m src.cli login
 
 ```json
 {
-  "default_provider": "glm",
+  "default_provider": "zai",
   "providers": {
     "anthropic": {
       "api_key": "your-api-key",
@@ -163,10 +180,10 @@ python -m src.cli login
       "base_url": "https://api.openai.com/v1",
       "default_model": "gpt-4"
     },
-    "glm": {
+    "zai": {
       "api_key": "your-api-key",
-      "base_url": "https://open.bigmodel.cn/api/paas/v4",
-      "default_model": "glm-4.5"
+      "base_url": "https://api.z.ai/api/coding/paas/v4",
+      "default_model": "glm-5.2"
     }
   }
 }

--- a/docs/i18n/README_ZH.md
+++ b/docs/i18n/README_ZH.md
@@ -37,6 +37,23 @@ python -m src.cli login   # 配置写入 ~/.clawcodex/config.json
 python -m src.cli --dangerously-skip-permissions   # 启动 REPL
 ```
 
+配置文件保存在 `~/.clawcodex/config.json`。最小示例：
+
+```json
+{
+  "default_provider": "zai",
+  "providers": {
+    "zai": {
+      "api_key": "xxx-xxx",
+      "base_url": "https://api.z.ai/api/coding/paas/v4",
+      "default_model": "glm-5.2"
+    }
+  }
+}
+```
+
+`session`、`settings` 和 `env` 块均为可选——省略时会使用合理的默认值。完整结构见 [配置](#配置)。
+
 ***
 
 ## 📰 新闻
@@ -132,7 +149,7 @@ arguments: [path]
 ClawCodex 的核心优势是**多提供商支持**：Claude Code 以 **Claude** 系列模型为目标，而我们希望在同一套 Agent 运行时之上支持**所有主流 LLM 提供商**——你可以自由切换厂商、区域与价位，而不必放弃工具、技能与编码闭环。正是这种灵活性，让 agentic 编程在规模化使用时真正可行。
 
 ```python
-providers = ["anthropic", "openai", "glm", "minimax", "openrouter", "deepseek"]  # OpenAI 兼容与 GLM API；可继续扩展
+providers = ["anthropic", "openai", "zai", "minimax", "openrouter", "deepseek"]  # OpenAI 兼容与 GLM API；可继续扩展
 ```
 
 ### 交互式 REPL（默认）与 Textual TUI（可选）
@@ -265,7 +282,7 @@ clawcodex login
 
 这个流程会：
 
-1. 让你选择 provider：anthropic / openai / glm / minimax / openrouter / deepseek
+1. 让你选择 provider：anthropic / openai / zai / minimax / openrouter / deepseek
 2. 让你输入该 provider 的 API key
 3. 可选：保存自定义 base URL
 4. 可选：保存默认 model
@@ -287,10 +304,10 @@ clawcodex login
       "base_url": "https://api.openai.com/v1",
       "default_model": "gpt-5.4"
     },
-    "glm": {
+    "zai": {
       "api_key": "your-api-key",
-      "base_url": "https://open.bigmodel.cn/api/paas/v4",
-      "default_model": "zai/glm-5"
+      "base_url": "https://api.z.ai/api/coding/paas/v4",
+      "default_model": "glm-5.2"
     },
     "minimax": {
       "api_key": "your-api-key",

--- a/eval/README.md
+++ b/eval/README.md
@@ -189,7 +189,7 @@ flag. Available presets:
 | `openai` (default) | `gpt-4o` | `--provider openai` | OpenAI native |
 | `deepseek` | `deepseek-v4-pro` | `--provider deepseek` | OpenAI-compatible (`https://api.deepseek.com/v1`) |
 | `anthropic` | `claude-sonnet-4-6` | `--provider anthropic` | Anthropic native |
-| `glm` | `zai/glm-5` | `--provider glm` | OpenAI-compatible (`https://open.bigmodel.cn/api/paas/v4`) |
+| `zai` | `glm-5.2` | `--provider zai` | OpenAI-compatible (`https://api.z.ai/api/coding/paas/v4`) |
 
 Examples:
 
@@ -252,7 +252,7 @@ python eval/compare_results.py \
 | Flag | Default | Notes |
 |---|---|---|
 | `--scope` | `smoke` | `smoke` / `instances` / `all` (full split) |
-| `--provider` | `openai` | Preset: `openai` / `deepseek` / `anthropic` / `glm` |
+| `--provider` | `openai` | Preset: `openai` / `deepseek` / `anthropic` / `zai` |
 | `--model` | (preset's default) | Override the preset's model name |
 | `--clawcodex-provider` | (preset) | Override clawcodex `--provider` flag |
 | `--openclaude-provider` | (preset) | Override openclaude routing hint |

--- a/eval/run_compare.py
+++ b/eval/run_compare.py
@@ -114,13 +114,13 @@ PROVIDER_PRESETS: dict[str, ProviderPreset] = {
         openclaude_base_url="",
         description="Anthropic Claude on both agents (uses native Claude path).",
     ),
-    "glm": ProviderPreset(
-        name="glm",
-        model="zai/glm-5",
-        clawcodex_provider="glm",
+    "zai": ProviderPreset(
+        name="zai",
+        model="glm-5.2",
+        clawcodex_provider="zai",
         openclaude_provider="openai",
-        openclaude_base_url="https://open.bigmodel.cn/api/paas/v4",
-        description="Zhipu GLM-5: clawcodex via 'glm' provider, openclaude via OpenAI-compatible API.",
+        openclaude_base_url="https://api.z.ai/api/coding/paas/v4",
+        description="Z.ai GLM-5.2: clawcodex via 'zai' provider, openclaude via OpenAI-compatible API.",
     ),
     "gemini": ProviderPreset(
         name="gemini",


### PR DESCRIPTION
## Summary

`zai` is the canonical provider (Z.ai GLM Coding Plan, `https://api.z.ai/api/coding/paas/v4`, models `GLM-5.1`/`GLM-5.2`); `glm` is now a **legacy alias** for it (`PROVIDER_ALIASES` in `src/providers/__init__.py`). The docs still showed the old `glm` / `open.bigmodel.cn` setup in several places. This brings all user-facing docs in line and cleans up two stale doc surfaces.

## Changes

**READMEs (EN + 6 i18n: ZH, RU, AR, FR, PT, HI)**
- Provider config block → `zai` / `https://api.z.ai/api/coding/paas/v4` / `glm-5.2`
- Fixed `default_provider`, the `providers` list, the multi-provider feature row, and the interactive-login provider list (all still referenced `glm`)
- Added a **minimal `config.json` example** under Quick Install / Install. `session`, `settings`, and `env` are omitted because they have defaults (`get_default_config()` + deep-merge); the example is valid JSON (the original snippet had an unclosed `providers` object)

**`docs/guide/SETUP_GUIDE.md`** (linked from all 7 READMEs as "Detailed installation")
- Rewrote the obsolete Chinese scratch-note (taught `.env` files + the `zhipuai` SDK + `glm-4` + a hardcoded path — a workflow the project abandoned) as a current English install guide grounded in the real flow (`uv` install, `clawcodex login`, `~/.clawcodex/config.json`, provider reference, troubleshooting)

**Eval harness**
- Migrated the `glm` preset to `zai` in `eval/run_compare.py` and `eval/README.md`. The model was doubly stale (`zai/glm-5`) — corrected to bare `glm-5.2`, since the same string is sent to both the clawcodex `zai` provider and upstream TypeScript implementation's Z.ai OpenAI-compatible endpoint. `upstream TypeScript implementation_base_url` → `api.z.ai/api/coding/paas/v4`

## Intentionally left as-is
- `src/providers/__init__.py` `"glm": "zai"` alias + `glm_provider.py` legacy docstring (the back-compat machinery)
- `tests/**` and the `CONTRIBUTING.md` / `docs/guide/TESTING.md` snippets that mirror them — they deliberately exercise the `glm` alias (e.g. `get_provider_class("glm") == ZaiProvider`)

## Verification
- All inserted/edited JSON blocks parse as valid JSON
- `eval/run_compare.py` compiles (`py_compile`); the preset rename is isolated (nothing imports those presets)
- No stale `glm` / `bigmodel.cn` references remain in any user-facing doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)