### PR TITLE
permissions: generalize Bash "don't ask again" to a safe first-word prefix

### DIFF
--- a/src/permissions/bash_suggestions.py
+++ b/src/permissions/bash_suggestions.py
@@ -177,6 +177,82 @@ def get_simple_command_prefix(command: str) -> str | None:
     return " ".join(remaining[:2])
 
 
+# Commands safe to generalize to a first-word ``Bash(<cmd>:*)`` rule: each is
+# read-only with respect to its OWN arguments — it cannot write a file, exec
+# another program, or mutate system state via any flag/positional, regardless of
+# arguments. This is the deterministic stand-in for TS's ``getFirstWordPrefix``
+# (bashPermissions.ts:222), which TS surfaces as an *editable* dialog default the
+# user can narrow; this port has no such field, so it must never auto-grant a
+# generalization the user can't take back — hence the allowlist rather than
+# "any first word".
+#
+# DELIBERATELY EXCLUDED (would be unsafe to generalize — and, crucially, a
+# rule-matched ``Bash(<cmd>:*)`` allow is NOT re-screened by the bash safety
+# check at match time, so the allowlist is the entire boundary): find / fd
+# (``-exec`` / ``-delete`` / ``-x``), sort / uniq / tee / xxd / base64 / info
+# (write via an output-file arg or flag — ``xxd in out``, ``base64 -o``,
+# ``info --output``), cp / mv / dd / install / ln / truncate (write), command /
+# env / xargs / shells (exec their args — also in BARE_SHELL_PREFIXES), sed / awk
+# (``-i`` in-place / ``system()``), git / npm / make (mutating subcommands —
+# read-only ``git`` subcommands still get the 2-word ``git status:*`` prefix),
+# and ``date`` (``-s`` sets the clock).
+#
+# KNOWN LIMITATION (pre-existing for ALL Bash prefix rules — including the
+# existing 2-word ``git status:*`` form — and shared with TS): an output
+# redirect like ``ls > FILE`` is matched by ``Bash(ls:*)`` and can clobber FILE.
+# Closing that needs a change to the rule MATCHER (refuse redirected commands),
+# which applies to every prefix rule and is out of scope for this UX fix.
+SAFE_PREFIX_COMMANDS: frozenset[str] = frozenset({
+    # listing / navigation / fs metadata
+    "ls", "pwd", "tree", "stat", "file", "basename", "dirname", "realpath",
+    "readlink", "du", "df", "free",
+    # file contents → stdout (no in-place / output-file arg). NB: xxd is
+    # EXCLUDED — ``xxd in out`` / ``xxd -r in out`` writes the second positional.
+    "cat", "head", "tail", "nl", "tac", "rev", "wc", "od", "hexdump",
+    "strings",
+    # text transforms: stdin/args → stdout (no output-file arg). NB: base64 is
+    # EXCLUDED — BSD/macOS ``base64 -o out`` writes a file.
+    "cut", "paste", "column", "fold", "expand", "unexpand", "fmt", "numfmt",
+    "tr", "comm", "cmp", "diff", "jq",
+    # read-only search (NO find/fd — they exec/delete)
+    "grep", "egrep", "fgrep", "rg", "locate",
+    # system / process / network info
+    "whoami", "hostname", "uname", "arch", "id", "groups", "nproc", "uptime",
+    "cal", "locale", "getconf", "printenv",
+    "ps", "pgrep", "lsof", "netstat", "ss", "which", "type",
+    # hashing (read → digest on stdout)
+    "sha256sum", "sha1sum", "md5sum", "cksum",
+    # pure / trivial. NB: info is EXCLUDED — GNU texinfo ``info --output=FILE``
+    # writes a file; ``man`` has no such flag (and the pager shell-escape is
+    # neutralized by the Bash tool's stdin=DEVNULL), so man stays.
+    "echo", "printf", "seq", "expr", "test", "true", "false", "sleep",
+    "man", "help", "tput",
+})
+
+
+def get_safe_first_word_prefix(command: str) -> str | None:
+    """``'ls demos/'`` → ``'ls'``; ``None`` unless the first word is read-only
+    w.r.t. its arguments (:data:`SAFE_PREFIX_COMMANDS`).
+
+    Lets a single ``Bash(ls:*)`` grant cover ``ls`` of any path instead of a
+    path-specific exact rule that re-prompts for every directory. The safe-set
+    restriction is the security control — see the set's comment for why a bare
+    ``getFirstWordPrefix`` port (TS) would be unsafe here.
+    """
+    tokens = [t for t in command.strip().split() if t]
+    remaining = _skip_safe_env_assignments(tokens)
+    if not remaining:
+        return None
+    cmd = remaining[0]
+    # Same shape gate as the subcommand regex: reject paths (./x, /usr/bin/ls),
+    # flags, and numbers — only a bare command name may generalize.
+    if not _SUBCOMMAND_RE.match(cmd):
+        return None
+    if cmd not in SAFE_PREFIX_COMMANDS:
+        return None
+    return cmd
+
+
 def _extract_prefix_before_heredoc(command: str) -> str | None:
     """Stable prefix before a ``<<`` heredoc (TS :285-316)."""
 
@@ -294,6 +370,14 @@ def suggestions_for_bash_command(command: str) -> list[PermissionUpdate]:
     if prefix:
         return suggestion_for_prefix(prefix)
 
+    # No 2-word prefix (e.g. ``ls demos/`` — second token is a path, not a
+    # subcommand). For a command that is read-only w.r.t. its arguments, offer a
+    # reusable first-word prefix (``Bash(ls:*)``) so the grant covers any path,
+    # instead of a path-specific exact rule that re-prompts every directory.
+    first_word = get_safe_first_word_prefix(command)
+    if first_word:
+        return suggestion_for_prefix(first_word)
+
     return suggestion_for_exact_command(command)
 
 
@@ -301,7 +385,9 @@ __all__ = [
     "BARE_SHELL_PREFIXES",
     "BASH_TOOL_NAME",
     "SAFE_ENV_VARS",
+    "SAFE_PREFIX_COMMANDS",
     "contains_unquoted_chaining",
+    "get_safe_first_word_prefix",
     "get_simple_command_prefix",
     "suggestion_for_prefix",
     "suggestion_for_exact_command",

--- a/tests/test_bash_suggestions.py
+++ b/tests/test_bash_suggestions.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import unittest
 
 from src.permissions.bash_suggestions import (
+    SAFE_PREFIX_COMMANDS,
+    get_safe_first_word_prefix,
     get_simple_command_prefix,
     suggestions_for_bash_command,
 )
@@ -60,8 +62,11 @@ class TestSuggestionsForBashCommand(unittest.TestCase):
         self.assertEqual(rule.rule_content, "git diff:*")
 
     def test_exact_rule_when_no_prefix(self) -> None:
-        rule = _only_rule(suggestions_for_bash_command("ls -la"))
-        self.assertEqual(rule.rule_content, "ls -la")
+        # No 2-word prefix and not a safe-to-generalize command → exact rule.
+        # (NB: a safe read-only command like `ls -la` now yields `ls:*` — see
+        # TestFirstWordPrefixSuggestion.)
+        rule = _only_rule(suggestions_for_bash_command("mv old.txt new.txt"))
+        self.assertEqual(rule.rule_content, "mv old.txt new.txt")
 
     def test_heredoc_uses_prefix_before_operator(self) -> None:
         cmd = 'git commit -m "$(cat <<\'EOF\'\nmsg\nEOF\n)"'
@@ -234,6 +239,75 @@ class TestMatcherChainingGuard(unittest.TestCase):
         self.assertTrue(matcher("git status --short"))
         self.assertFalse(matcher("git push"))
         self.assertFalse(matcher("git status && git push"))
+
+
+class TestGetSafeFirstWordPrefix(unittest.TestCase):
+    def test_safe_command_returns_first_word(self) -> None:
+        self.assertEqual(get_safe_first_word_prefix("ls demos/"), "ls")
+        self.assertEqual(get_safe_first_word_prefix("cat a/b/c.txt"), "cat")
+        self.assertEqual(get_safe_first_word_prefix("grep -r foo ."), "grep")
+
+    def test_unsafe_command_returns_none(self) -> None:
+        # Commands that write/exec via their own args — must NOT generalize.
+        # Includes the write-via-output-arg trio (xxd/base64/info) a reviewer
+        # caught in the first cut.
+        for cmd in ("find . -name x", "sort -o /etc/x f", "tee /etc/x",
+                    "cp a /b", "mv a /b", "dd if=/dev/zero of=/x", "rm x",
+                    "xxd -r p.hex /victim", "base64 -d -i x -o /victim",
+                    "info --output=/victim coreutils"):
+            self.assertIsNone(get_safe_first_word_prefix(cmd), cmd)
+
+    def test_path_or_flag_first_token_returns_none(self) -> None:
+        self.assertIsNone(get_safe_first_word_prefix("./script.sh"))
+        self.assertIsNone(get_safe_first_word_prefix("/usr/bin/ls x"))
+        self.assertIsNone(get_safe_first_word_prefix("-rf x"))
+
+    def test_unsafe_env_var_returns_none(self) -> None:
+        self.assertIsNone(get_safe_first_word_prefix("LD_PRELOAD=x ls /"))
+
+    def test_safe_env_var_skipped(self) -> None:
+        self.assertEqual(get_safe_first_word_prefix("NO_COLOR=1 ls /"), "ls")
+
+    def test_no_shells_or_wrappers_in_safe_set(self) -> None:
+        for bad in ("bash", "sh", "env", "xargs", "sudo", "find", "fd",
+                    "sort", "uniq", "tee", "cp", "mv", "rm", "dd", "git",
+                    "sed", "awk", "command", "date", "npm", "curl",
+                    "xxd", "base64", "info"):
+            self.assertNotIn(bad, SAFE_PREFIX_COMMANDS, bad)
+
+
+class TestFirstWordPrefixSuggestion(unittest.TestCase):
+    def _rule(self, command: str):
+        updates = suggestions_for_bash_command(command)
+        return _only_rule(updates).rule_content if updates else None
+
+    def test_ls_path_generalizes_to_prefix(self) -> None:
+        self.assertEqual(self._rule("ls demos/"), "ls:*")
+        self.assertEqual(self._rule("cat foo.txt"), "cat:*")
+        self.assertEqual(self._rule("grep -r foo ."), "grep:*")
+
+    def test_reported_bug_one_grant_covers_sibling_paths(self) -> None:
+        # Approving `ls .../demos/` must cover `ls .../demos/elon-blog/`.
+        from src.permissions.check import prepare_permission_matcher
+
+        rule = self._rule("ls /Users/x/workspace/demos/")
+        self.assertEqual(rule, "ls:*")
+        matcher = prepare_permission_matcher(rule)
+        self.assertTrue(matcher("ls /Users/x/workspace/demos/elon-blog/"))
+
+    def test_dangerous_command_not_generalized_to_bare_prefix(self) -> None:
+        # Must never auto-suggest Bash(find:*)/Bash(sort:*)/Bash(xxd:*)/etc.
+        for cmd in ("find . -name x", "sort -o /etc/x f", "tee /etc/x",
+                    "xxd -r p.hex /victim", "base64 -d -i x -o /victim",
+                    "info --output=/victim coreutils"):
+            self.assertNotEqual(self._rule(cmd), f"{cmd.split()[0]}:*", cmd)
+
+    def test_two_word_prefix_still_wins(self) -> None:
+        # The 2-word prefix path is unchanged (takes precedence).
+        self.assertEqual(self._rule("git status"), "git status:*")
+
+    def test_unsafe_command_falls_back_to_exact(self) -> None:
+        self.assertEqual(self._rule("find . -name x"), "find . -name x")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem (user-reported)

Running `ls demos/` prompts with **"Yes, and don't ask again for `Bash(ls /Users/.../demos/)`"** — the *exact, path-specific* command. After approving it, `ls demos/elon-blog/` prompts **again** (the exact rule can't match a different path). So the Bash session grant is useless for read-only commands that take a path argument — the agent re-asks for every directory.

**Root cause:** the port faithfully ported TS's *deterministic* `suggestionForExactCommand` (heredoc → first-line → 2-word prefix → exact). For `ls demos/` the 2-word prefix declines (2nd token is a path, not a subcommand) → falls to the exact command. TS additionally has `getFirstWordPrefix` (`bashPermissions.ts:222` → `ls`) which it surfaces as an **editable dialog default** + an async LLM refinement — both dropped in this port.

## Fix

When the 2-word prefix declines, suggest a reusable first-word prefix `Bash(ls:*)` — but **only** for a hand-audited `SAFE_PREFIX_COMMANDS` allowlist.

**Why an allowlist, not a straight port of `getFirstWordPrefix`:** TS's any-first-word default is safe only because it's *editable* — the user narrows it before granting. This port has no such field, so an auto-suggested generalization is un-take-back-able. And critically, **a rule-matched `Bash(<cmd>:*)` allow is NOT re-screened by the bash safety check at match time** (verified) — so the allowlist is the *entire* security boundary. The set is restricted to commands that are read-only w.r.t. their **own** arguments (`ls`, `cat`, `grep`, `head`, `tail`, `wc`, `pwd`, `echo`, …). Excluded: `find`/`fd` (`-exec`/`-delete`), `sort`/`uniq`/`tee`/`xxd`/`base64`/`info` (write via an output arg/flag), `cp`/`mv`/`dd` (write), shells/`env`/`xargs` (exec), `sed`/`awk`, `git`/`npm`/`make`, `date -s`.

- `ls demos/` → `Bash(ls:*)` → now matches `ls .../demos/elon-blog/` ✅
- `git status` → `Bash(git status:*)` (2-word, unchanged); `find . -name x` / `sort -o x` / `xxd -r in out` → **exact** (not generalized)

## Tests
`tests/test_bash_suggestions.py` — added `TestGetSafeFirstWordPrefix` + `TestFirstWordPrefixSuggestion` (incl. the reported-bug end-to-end matcher check and negative tests for every excluded write/exec command); updated one existing test that used `ls -la` (now `ls:*`). 45 in-file tests pass; broad `-k "bash or permission or suggestion or session_option"` = 839 passed.

## Review
Critic loop: **REQUEST CHANGES → fixed → APPROVE.** The review caught `xxd`/`base64`/`info` as write-via-output-arg primitives in my first cut (an auto-granted `Bash(xxd:*)` would be an arbitrary-file-write); they were removed and pinned with regression tests.

## Deferred follow-up (out of scope)
Output redirects (`ls > FILE`) are matched by `Bash(ls:*)` — pre-existing for **all** prefix rules including the long-shipped `git status:*`. Closing it needs a rule-*matcher* change (refuse redirected commands), which hardens every prefix rule at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)