### PR TITLE
fix(permissions): auto-allow Skill invocations instead of prompting

### DIFF
--- a/src/permissions/check.py
+++ b/src/permissions/check.py
@@ -137,10 +137,17 @@ _FILE_EDIT_TOOLS: tuple[str, ...] = ("Write", "Edit", "MultiEdit", "NotebookEdit
 #   * file mutation: Write/Edit/MultiEdit/NotebookEdit
 #   * code execution: Bash
 #   * arbitrary network egress: WebFetch
-#   * input/path-conditional (carry their own check_permissions): Config (write),
-#     Glob, Grep, SendMessage (cross-machine bridge:/uds: recipients), and Skill
-#     (TS allows only skills with safe properties — and this port's skill
-#     executor runs embedded shell directly, so the invocation must stay gated).
+#   * input/conditional (carry their own check_permissions): Config (write),
+#     Glob, Grep, SendMessage (cross-machine bridge:/uds: recipients), and Skill.
+#     Skill's own check (``tools/skill.py:_skill_check_permissions``) AUTO-ALLOWS
+#     the invocation — in this port a skill grants no ungated capability: its
+#     embedded ``!`` shell is permission-checked in ``_make_shell_executor`` and
+#     the model's own tool calls are gated normally — while still honoring
+#     per-skill ``Skill(<name>)`` deny/ask content rules. (TS instead gates
+#     skills that declare ``allowed-tools``; we diverge because that
+#     pre-authorization is not wired through here, so there's nothing extra to
+#     gate. It lives here rather than in NO_PERMISSION_TOOLS because that
+#     content-rule handling is input-conditional, like Config/Grep.)
 #   * MCP server access: MCP / ListMcpResourcesTool / ReadMcpResourceTool and
 #     dynamic ``mcp__*`` (external/untrusted boundary).
 #   * plan-mode meta tools: EnterPlanMode / ExitPlanMode (ExitPlanMode is the

--- a/src/tool_system/tools/skill.py
+++ b/src/tool_system/tools/skill.py
@@ -110,6 +110,75 @@ def _validate_skill_input(tool_input: dict[str, Any], context: ToolContext) -> V
 
 
 # ---------------------------------------------------------------------------
+# Permission check (adapted from TS SkillTool/SkillTool.ts checkPermissions)
+# ---------------------------------------------------------------------------
+
+def _skill_check_permissions(tool_input: dict[str, Any], context: ToolContext) -> Any:
+    """Resolve permission for a skill invocation.
+
+    Policy (see ``src/permissions/check.py`` NO_PERMISSION_TOOLS comment): the
+    invocation AUTO-ALLOWS. In this port a skill grants no ungated capability —
+    its embedded ``!`` shell is permission-checked in :func:`_make_shell_executor`
+    and the model's own tool calls are gated normally — so the invocation itself
+    need not prompt. This deliberately diverges from TS, which gates skills that
+    declare ``allowed-tools``; that pre-authorization is not wired through this
+    port, so there is nothing extra to gate.
+
+    Explicit rules still win. Blanket ``Skill`` deny/ask rules are honored
+    upstream in ``has_permissions_to_use_tool_inner`` (which runs before this);
+    this function additionally honors per-skill *content* rules — ``Skill(<name>)``
+    and ``Skill(<prefix>:*)`` — for both ``deny`` (security-critical: never
+    auto-allow a denied skill) and ``ask``. Rule matching mirrors TS'
+    ``ruleMatches`` (strip leading slash, then exact or ``<prefix>:*``).
+    """
+    from src.permissions.rules import get_rule_by_contents_for_tool
+    from src.permissions.types import (
+        PermissionAllowDecision,
+        PermissionAskDecision,
+        PermissionDenyDecision,
+        RuleDecisionReason,
+    )
+
+    raw = tool_input.get("skill")
+    command_name = raw.strip().lstrip("/") if isinstance(raw, str) else ""
+
+    perm_ctx = getattr(context, "permission_context", None)
+    if perm_ctx is None or not command_name:
+        # No rule context in scope (or malformed input — validate_input rejects
+        # that separately). Auto-allow per policy; a blanket ``Skill`` deny is
+        # still caught upstream from the real permission context.
+        return PermissionAllowDecision(behavior="allow", updated_input=tool_input)
+
+    def _rule_matches(rule_content: str) -> bool:
+        normalized = rule_content.lstrip("/")
+        if normalized == command_name:
+            return True
+        if normalized.endswith(":*"):
+            return command_name.startswith(normalized[:-2])
+        return False
+
+    # Per-skill deny rules first — an explicit deny must never be auto-allowed.
+    for rule_content, rule in get_rule_by_contents_for_tool(perm_ctx, "Skill", "deny").items():
+        if _rule_matches(rule_content):
+            return PermissionDenyDecision(
+                behavior="deny",
+                message="Skill execution blocked by permission rules",
+                decision_reason=RuleDecisionReason(rule=rule),
+            )
+
+    # Per-skill ask rules: honor an explicit "prompt me for this skill".
+    for rule_content, rule in get_rule_by_contents_for_tool(perm_ctx, "Skill", "ask").items():
+        if _rule_matches(rule_content):
+            return PermissionAskDecision(
+                behavior="ask",
+                message=f"Execute skill: {command_name}",
+                decision_reason=RuleDecisionReason(rule=rule),
+            )
+
+    return PermissionAllowDecision(behavior="allow", updated_input=tool_input)
+
+
+# ---------------------------------------------------------------------------
 # mapResultToApi (ported from TS SkillTool/SkillTool.ts
 #     mapToolResultToToolResultBlockParam)
 # ---------------------------------------------------------------------------
@@ -439,6 +508,7 @@ SkillTool: Tool = build_tool(
     description="Execute a skill within the main conversation",
     map_result_to_api=_skill_map_result_to_api,
     validate_input=_validate_skill_input,
+    check_permissions=_skill_check_permissions,
     max_result_size_chars=100_000,
     is_read_only=lambda _input: True,
     is_concurrency_safe=lambda _input: True,

--- a/tests/test_tool_permission_parity.py
+++ b/tests/test_tool_permission_parity.py
@@ -27,7 +27,6 @@ _GATED = {
     "Edit", "Write", "MultiEdit", "NotebookEdit",  # file mutation
     "Bash",                                          # code execution
     "WebFetch",                                      # arbitrary network egress
-    "Skill",                                         # runs embedded shell / skill cmds
     "MCP", "ListMcpResourcesTool", "ReadMcpResourceTool",  # MCP boundary
     "EnterPlanMode", "ExitPlanMode",                 # plan-mode meta
 }
@@ -92,7 +91,6 @@ class TestGatedToolsStillAsk(_Base):
             "NotebookEdit": {"notebook_path": str(self.ws / "n.ipynb"), "new_source": "x"},
             "Bash": {"command": "echo hi"},
             "WebFetch": {"url": "https://example.com", "prompt": "x"},
-            "Skill": {"skill": "some-skill"},
             "MCP": {"server": "s", "tool": "t"},
             "ListMcpResourcesTool": {},
             "ReadMcpResourceTool": {"server": "s", "uri": "u"},
@@ -176,10 +174,47 @@ class TestSendMessageGate(_Base):
             "ask",
         )
 
-    def test_skill_is_gated(self) -> None:
-        # Skill runs embedded shell / declared tools — the invocation stays gated.
-        ctx = _ctx("default", self.ws)
-        self.assertEqual(_behavior(self.reg, "Skill", {"skill": "some-skill"}, ctx), "ask")
+
+class TestSkillAutoAllows(_Base):
+    """Skill invocations auto-allow, but explicit per-skill rules still win.
+
+    The invocation grants no ungated capability in this port — a skill's
+    embedded ``!`` shell is permission-checked (see TestSkillEmbeddedShellGated)
+    and the model's own tool calls are gated normally — so it need not prompt.
+    """
+
+    def test_skill_auto_allows(self) -> None:
+        # The skill INVOCATION auto-allows (it grants no ungated capability in
+        # this port — embedded shell + the model's tool calls are checked
+        # separately; see TestSkillEmbeddedShellGated). True in default and auto.
+        for mode in ("default", "auto"):
+            ctx = _ctx(mode, self.ws)
+            self.assertEqual(
+                _behavior(self.reg, "Skill", {"skill": "some-skill"}, ctx), "allow",
+                f"Skill should auto-allow in {mode} mode",
+            )
+
+    def test_skill_blanket_deny_rule_wins(self) -> None:
+        # A content-less ``Skill`` deny rule (honored upstream) beats auto-allow.
+        pc = ToolPermissionContext.from_iterables(deny_names=["Skill"])
+        ctx = ToolContext(workspace_root=self.ws, permission_context=pc)
+        self.assertEqual(_behavior(self.reg, "Skill", {"skill": "browse"}, ctx), "deny")
+
+    def test_skill_per_skill_deny_rule_wins(self) -> None:
+        # A per-skill ``Skill(browse)`` deny rule is honored by the tool's own
+        # check_permissions; an unrelated skill still auto-allows.
+        pc = ToolPermissionContext.from_iterables(deny_names=["Skill(browse)"])
+        ctx = ToolContext(workspace_root=self.ws, permission_context=pc)
+        self.assertEqual(_behavior(self.reg, "Skill", {"skill": "browse"}, ctx), "deny")
+        self.assertEqual(_behavior(self.reg, "Skill", {"skill": "/browse"}, ctx), "deny")
+        self.assertEqual(_behavior(self.reg, "Skill", {"skill": "qa"}, ctx), "allow")
+
+    def test_skill_prefix_deny_rule_matches(self) -> None:
+        # ``Skill(review:*)`` matches ``review-pr`` (TS ruleMatches prefix form).
+        pc = ToolPermissionContext.from_iterables(deny_names=["Skill(review:*)"])
+        ctx = ToolContext(workspace_root=self.ws, permission_context=pc)
+        self.assertEqual(_behavior(self.reg, "Skill", {"skill": "review-pr"}, ctx), "deny")
+        self.assertEqual(_behavior(self.reg, "Skill", {"skill": "browse"}, ctx), "allow")
 
 
 class TestConfigInputDependent(_Base):


### PR DESCRIPTION
## Problem

Using ClawCodex, invoking any skill triggered a permission prompt:

```
⚠ Permission Required
  Claude wants to use Skill. Allow?
```

In the Python port, the `Skill` tool had **no** `check_permissions` and wasn't in `NO_PERMISSION_TOOLS`, so it fell through to the default `passthrough → ask`. That prompted on **every** skill invocation — even plain skills the TypeScript reference auto-allows.

(Investigation note: the TS reference only auto-allows skills with no "special" properties. Skills that declare `allowed-tools` — like `browse` and nearly every gstack skill — are gated in literal TS too, so a faithful TS port wouldn't have fixed the UX.)

## Fix

Give `Skill` its own `check_permissions` (`_skill_check_permissions`) that **auto-allows** the invocation, while still honoring explicit per-skill `Skill(<name>)` / `Skill(<prefix>:*)` **deny** and **ask** content rules. Blanket `Skill` deny/ask rules were already honored upstream in `has_permissions_to_use_tool_inner`.

This is safe because, in this port, a skill invocation grants **no ungated capability**:
- a skill's embedded `` ! `` shell is permission-checked in `_make_shell_executor`, and
- the model's own tool calls are gated normally.

It deliberately diverges from TS (which gates skills declaring `allowed-tools`) because that pre-authorization isn't wired through this port — there's nothing extra to gate. It lives in the tool's own check (like `Config`/`Grep`/`SendMessage`) rather than `NO_PERMISSION_TOOLS` because the content-rule handling is input-conditional.

## Changes

- **`src/tool_system/tools/skill.py`** — add `_skill_check_permissions`, wire into `build_tool`
- **`src/permissions/check.py`** — replace the stale "Skill must stay gated" comment with the new policy + TS-divergence rationale
- **`tests/test_tool_permission_parity.py`** — flip Skill `ask`→`allow` (default + auto mode), add per-skill / prefix deny-rule coverage in a dedicated `TestSkillAutoAllows`; keep `TestSkillEmbeddedShellGated` (the safety net)

## Verification

- 1445 tests pass across the skills/permission/command suites (1 pre-existing skip)
- End-to-end: `browse` now resolves to **`allow`** in default mode (was `ask`); a `Skill(browse)` deny rule still **denies** browse while an unrelated `qa` skill still **allows**

🤖 Generated with [Claude Code](https://claude.com/claude-code)