### PR TITLE
docs(readme): add TAVILY_API_KEY env block to Quick Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,14 @@ The configuration file is saved at `~/.clawcodex/config.json`. Minimal example:
       "base_url": "https://api.z.ai/api/coding/paas/v4",
       "default_model": "glm-5.2"
     }
+  },
+  "env": {
+    "TAVILY_API_KEY": "tvly-YOUR-TAVILY-API-KEY"
   }
 }
 ```
+
+> **Note:** `TAVILY_API_KEY` is required for the WebSearch tool — get a key at [tavily.com](https://tavily.com).
 
 The `session`, `settings`, and `env` blocks are optional — sensible defaults apply when they're omitted. See [Configure](#configure) for the full structure.
 

--- a/docs/i18n/README_AR.md
+++ b/docs/i18n/README_AR.md
@@ -142,9 +142,14 @@ uv pip install -r requirements.txt
       "base_url": "https://api.z.ai/api/coding/paas/v4",
       "default_model": "glm-5.2"
     }
+  },
+  "env": {
+    "TAVILY_API_KEY": "tvly-YOUR-TAVILY-API-KEY"
   }
 }
 ```
+
+> **ملاحظة:** مفتاح `TAVILY_API_KEY` مطلوب لأداة WebSearch — احصل على مفتاح من [tavily.com](https://tavily.com).
 
 كتل `session` و`settings` و`env` اختيارية — تُطبَّق قيم افتراضية معقولة عند حذفها (الهيكل الكامل أدناه).
 

--- a/docs/i18n/README_FR.md
+++ b/docs/i18n/README_FR.md
@@ -142,9 +142,14 @@ Le fichier de configuration est enregistré dans `~/.clawcodex/config.json`. Exe
       "base_url": "https://api.z.ai/api/coding/paas/v4",
       "default_model": "glm-5.2"
     }
+  },
+  "env": {
+    "TAVILY_API_KEY": "tvly-YOUR-TAVILY-API-KEY"
   }
 }
 ```
+
+> **Remarque :** `TAVILY_API_KEY` est requis pour l'outil WebSearch — obtenez une clé sur [tavily.com](https://tavily.com).
 
 Les blocs `session`, `settings` et `env` sont optionnels — des valeurs par défaut raisonnables s'appliquent s'ils sont omis (structure complète ci-dessous).
 

--- a/docs/i18n/README_HI.md
+++ b/docs/i18n/README_HI.md
@@ -142,9 +142,14 @@ uv pip install -r requirements.txt
       "base_url": "https://api.z.ai/api/coding/paas/v4",
       "default_model": "glm-5.2"
     }
+  },
+  "env": {
+    "TAVILY_API_KEY": "tvly-YOUR-TAVILY-API-KEY"
   }
 }
 ```
+
+> **नोट:** WebSearch टूल के लिए `TAVILY_API_KEY` आवश्यक है — [tavily.com](https://tavily.com) पर कुंजी प्राप्त करें।
 
 `session`, `settings` और `env` ब्लॉक वैकल्पिक हैं — इन्हें छोड़ने पर उचित डिफ़ॉल्ट मान लागू होते हैं (पूरी संरचना नीचे)।
 

--- a/docs/i18n/README_PT.md
+++ b/docs/i18n/README_PT.md
@@ -142,9 +142,14 @@ O arquivo de configuração é salvo em `~/.clawcodex/config.json`. Exemplo mín
       "base_url": "https://api.z.ai/api/coding/paas/v4",
       "default_model": "glm-5.2"
     }
+  },
+  "env": {
+    "TAVILY_API_KEY": "tvly-YOUR-TAVILY-API-KEY"
   }
 }
 ```
+
+> **Nota:** `TAVILY_API_KEY` é necessário para a ferramenta WebSearch — obtenha uma chave em [tavily.com](https://tavily.com).
 
 Os blocos `session`, `settings` e `env` são opcionais — valores padrão razoáveis se aplicam quando omitidos (estrutura completa abaixo).
 

--- a/docs/i18n/README_RU.md
+++ b/docs/i18n/README_RU.md
@@ -142,9 +142,14 @@ uv pip install -r requirements.txt
       "base_url": "https://api.z.ai/api/coding/paas/v4",
       "default_model": "glm-5.2"
     }
+  },
+  "env": {
+    "TAVILY_API_KEY": "tvly-YOUR-TAVILY-API-KEY"
   }
 }
 ```
+
+> **Примечание:** `TAVILY_API_KEY` требуется для инструмента WebSearch — получите ключ на [tavily.com](https://tavily.com).
 
 Блоки `session`, `settings` и `env` необязательны — при их отсутствии применяются разумные значения по умолчанию (полная структура ниже).
 

--- a/docs/i18n/README_ZH.md
+++ b/docs/i18n/README_ZH.md
@@ -48,9 +48,14 @@ python -m src.cli --dangerously-skip-permissions   # 启动 REPL
       "base_url": "https://api.z.ai/api/coding/paas/v4",
       "default_model": "glm-5.2"
     }
+  },
+  "env": {
+    "TAVILY_API_KEY": "tvly-YOUR-TAVILY-API-KEY"
   }
 }
 ```
+
+> **注意：** WebSearch 工具需要 `TAVILY_API_KEY`——可在 [tavily.com](https://tavily.com) 获取密钥。
 
 `session`、`settings` 和 `env` 块均为可选——省略时会使用合理的默认值。完整结构见 [配置](#配置)。
 


### PR DESCRIPTION
## Summary
- Adds the `env` block with `TAVILY_API_KEY` to the **Quick Install** minimal config example so users see it without scrolling to the full Configure section.
- Adds a note that `TAVILY_API_KEY` is required for the **WebSearch** tool, with a link to tavily.com to get a key.
- Applied consistently to the English README and all i18n translations: AR, FR, HI, PT, RU, ZH.

## Why
The WebSearch tool fails silently without a Tavily key. The full Configure section already documents this, but the Quick Install example (what most people copy) omitted it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)