### PR TITLE
feat(deepseek): exploit prefix cache for token efficiency (DeepSeek-scoped)

### DIFF
--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -285,19 +285,39 @@ def cost_command_call(args: str, context: CommandContext) -> LocalCommandResult:
     Returns:
         LocalCommandResult
     """
-    tracker = context.cost_tracker
-    if tracker is None:
-        return LocalCommandResult(
-            type="text",
-            value="Cost tracking not available.",
+    from src.bootstrap.state import get_model_usage, get_total_cost_usd
+    from src.services.pricing import format_cost_usd
+
+    lines: list[str] = ["Session Cost:", ""]
+    lines.append(f"  Total: {format_cost_usd(get_total_cost_usd())}")
+
+    # Per-model token usage + prompt-cache hit-rate. ``cache_read_input_tokens``
+    # is the cached portion of the prompt (DeepSeek hits, Anthropic cache
+    # reads); ``input_tokens`` + ``cache_creation_input_tokens`` is the
+    # uncached portion. Surfacing the hit-rate is what makes the DeepSeek
+    # prefix-cache savings visible.
+    model_usage = get_model_usage()
+    for model, u in sorted(model_usage.items()):
+        cached = int(getattr(u, "cache_read_input_tokens", 0) or 0)
+        uncached = int(
+            (getattr(u, "input_tokens", 0) or 0)
+            + (getattr(u, "cache_creation_input_tokens", 0) or 0)
+        )
+        prompt_total = cached + uncached
+        hit_pct = (100.0 * cached / prompt_total) if prompt_total else 0.0
+        lines.append("")
+        lines.append(f"  {model}  {format_cost_usd(u.cost_usd)}")
+        lines.append(
+            f"    prompt {prompt_total:,} tok "
+            f"({cached:,} cached, {hit_pct:.0f}% hit) · "
+            f"output {int(getattr(u, 'output_tokens', 0) or 0):,} tok"
         )
 
-    lines = ["Session Cost:", ""]
-    lines.append(f"  Total units: {tracker.total_units}")
-
-    if tracker.events:
+    # Legacy free-form units/events (costHook ``/cost`` event log).
+    tracker = context.cost_tracker
+    if tracker is not None and (tracker.total_units or tracker.events):
         lines.append("")
-        lines.append("  Recent events:")
+        lines.append(f"  Recorded units: {tracker.total_units}")
         for event in tracker.events[-10:]:
             lines.append(f"    - {event}")
 

--- a/src/context_system/prompt_assembly.py
+++ b/src/context_system/prompt_assembly.py
@@ -728,6 +728,12 @@ def build_full_system_prompt_blocks(
     ) -> None:
         for idx, section in enumerate(group):
             block: dict[str, Any] = {"type": "text", "text": section.content}
+            # Inert metadata for the query layer: routes per-request-volatile
+            # (REQUEST-scope) sections to the request tail for DeepSeek
+            # prefix-cache stability. Stripped before the wire for Anthropic;
+            # other OpenAI-compatible providers flatten only ``text`` and
+            # ignore it. See ``query._split_system_prompt_blocks``.
+            block["_cache_scope"] = scope.value
             if idx == len(group) - 1:
                 # Last block in this scope group → mark for caching.
                 cache_control: dict[str, Any] = {

--- a/src/models/configs.py
+++ b/src/models/configs.py
@@ -129,6 +129,39 @@ MODEL_CONFIGS: dict[str, ModelConfig] = {
         cost_cache_create_per_mtok=0.30,
         cost_cache_read_per_mtok=0.03,
     ),
+
+    # DeepSeek V4 series (OpenAI-compatible; api.deepseek.com). Registered so
+    # context-window-aware logic (compaction triggers, token warnings) uses
+    # DeepSeek's real ~1M window instead of the 200K default. Keys are the
+    # bare model ids used ONLY by the ``deepseek`` provider; OpenRouter's
+    # ``deepseek/…`` ids do not prefix-match ``deepseek-v4``, so OpenRouter is
+    # intentionally unaffected. Legacy ``deepseek-chat`` / ``deepseek-reasoner``
+    # are deliberately NOT registered: their prefix-match base would be the
+    # broad ``deepseek`` and could capture other ids.
+    #
+    # NOTE: ``get_model_config``'s prefix fallback bases these on
+    # ``deepseek-v4`` and ``pro`` precedes ``flash``, so a FUTURE
+    # dated/suffixed variant (e.g. ``deepseek-v4-flash-0701``) would fall back
+    # to ``pro``'s row — register such variants explicitly.
+    #
+    # Cost/pricing is intentionally NOT set here: DeepSeek's USD rates live in
+    # ``services/pricing.py`` (the single source the cost path reads). The
+    # ``ModelConfig.cost_*`` defaults are unread for these models — duplicating
+    # the rates here only invites 10× decimal drift between the two tables.
+    "deepseek-v4-pro": ModelConfig(
+        model_id="deepseek-v4-pro",
+        display_name="DeepSeek V4 Pro",
+        context_window=1_000_000,
+        max_output_tokens=8_192,
+        supports_cache=True,
+    ),
+    "deepseek-v4-flash": ModelConfig(
+        model_id="deepseek-v4-flash",
+        display_name="DeepSeek V4 Flash",
+        context_window=1_000_000,
+        max_output_tokens=8_192,
+        supports_cache=True,
+    ),
 }
 
 

--- a/src/providers/base.py
+++ b/src/providers/base.py
@@ -49,6 +49,14 @@ TextChunkCallback: TypeAlias = Callable[[str], None]
 class BaseProvider(ABC):
     """Base class for LLM providers."""
 
+    #: Whether this provider talks to DeepSeek's API. Overridden to ``True``
+    #: in :class:`~src.providers.deepseek_provider.DeepSeekProvider`. Gates
+    #: DeepSeek-only token-efficiency behaviour (prompt-prefix-cache
+    #: stability) without affecting any other provider. Scope is the
+    #: ``deepseek`` provider class ONLY — a DeepSeek model served via
+    #: OpenRouter is intentionally NOT covered.
+    is_deepseek: bool = False
+
     def __init__(
         self, api_key: str, base_url: Optional[str] = None, model: Optional[str] = None
     ):

--- a/src/providers/deepseek_provider.py
+++ b/src/providers/deepseek_provider.py
@@ -24,6 +24,12 @@ class DeepSeekProvider(OpenAICompatibleProvider):
 
     DEFAULT_BASE_URL = "https://api.deepseek.com"
 
+    #: Marks this provider as DeepSeek so the query layer relocates the
+    #: per-request-volatile (REQUEST-scope) system sections to a trailing tail,
+    #: keeping the request prefix byte-stable for DeepSeek's automatic prefix
+    #: cache (see ``query._split_system_prompt_blocks``).
+    is_deepseek = True
+
     def __init__(
         self, api_key: str, base_url: Optional[str] = None, model: Optional[str] = None
     ):
@@ -55,6 +61,82 @@ class DeepSeekProvider(OpenAICompatibleProvider):
             import httpx
             kwargs["http_client"] = httpx.Client(verify=False)
         return OpenAI(**kwargs)
+
+    def _build_usage_dict(self, usage: Any) -> dict[str, Any]:
+        """Add DeepSeek prompt-cache accounting onto the base usage dict.
+
+        DeepSeek reports automatic prefix-cache utilisation in its ``usage``
+        object — either as top-level ``prompt_cache_hit_tokens`` /
+        ``prompt_cache_miss_tokens`` (DeepSeek's native shape) or, on some
+        OpenAI-compatible gateways, nested under
+        ``prompt_tokens_details.cached_tokens``. The base
+        :meth:`OpenAICompatibleProvider._build_usage_dict` reports
+        ``input_tokens`` as the FULL prompt (hit + miss) and drops the cache
+        split, so cache hit-rate is invisible and cost cannot credit the hit.
+
+        When a cache hit is present we re-map onto the **Anthropic
+        convention** that ``cost_tracker.record_api_usage`` /
+        ``services.pricing.compute_cost`` already understand:
+
+        * ``input_tokens``            → cache MISS (uncached), priced at input
+        * ``cache_read_input_tokens`` → cache HIT, priced at the cheap cache rate
+        * ``cache_creation_input_tokens`` → 0 (DeepSeek has no cache-write charge)
+
+        ``total_tokens`` and ``output_tokens`` are left untouched (still the
+        full counts), and ``reasoning_tokens`` is surfaced when present. With
+        no cache hit, the dict is identical to the base (all prompt tokens are
+        uncached input). This override runs only for the DeepSeek provider;
+        every other provider keeps the base behaviour.
+        """
+        result = super()._build_usage_dict(usage)
+        if usage is None:
+            return result
+
+        def _field(name: str) -> int:
+            value = getattr(usage, name, None)
+            if value is None:
+                extra = getattr(usage, "model_extra", None)
+                if isinstance(extra, dict):
+                    value = extra.get(name)
+            try:
+                return int(value or 0)
+            except (TypeError, ValueError):
+                return 0
+
+        hit = _field("prompt_cache_hit_tokens")
+        miss = _field("prompt_cache_miss_tokens")
+
+        # OpenAI-compatible nested shape: prompt_tokens_details.cached_tokens.
+        details = getattr(usage, "prompt_tokens_details", None)
+        nested_cached = (
+            getattr(details, "cached_tokens", None) if details is not None else None
+        )
+        if not hit and nested_cached:
+            try:
+                hit = int(nested_cached)
+            except (TypeError, ValueError):
+                hit = 0
+
+        prompt_tokens = int(result.get("input_tokens", 0) or 0)
+        if hit > 0:
+            # Only an explicit/derivable cache hit triggers the re-map; with no
+            # hit, the base dict (input_tokens = full prompt) is already correct.
+            if not miss:
+                miss = max(prompt_tokens - hit, 0)
+            result["input_tokens"] = miss
+            result["cache_read_input_tokens"] = hit
+            result["cache_creation_input_tokens"] = 0
+
+        cdetails = getattr(usage, "completion_tokens_details", None)
+        reasoning = (
+            getattr(cdetails, "reasoning_tokens", None) if cdetails is not None else None
+        )
+        if reasoning:
+            try:
+                result["reasoning_tokens"] = int(reasoning)
+            except (TypeError, ValueError):
+                pass
+        return result
 
     def get_available_models(self) -> list[str]:
         """Return DeepSeek's current production models.

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -396,6 +396,99 @@ async def _fire_stop_failure_hooks(last_message: Any, tool_use_context: Any) -> 
         logger.debug("StopFailure hook dispatch failed", exc_info=True)
 
 
+def _strip_block_metadata(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return copies of ``blocks`` with the internal ``_cache_scope`` key
+    removed, so it never reaches a provider's wire payload.
+
+    The Anthropic provider forwards system blocks verbatim to its SDK
+    (``call_kwargs["system"] = system_prompt``), so the inert ``_cache_scope``
+    tag emitted by the prompt assembler must be stripped before it lands on a
+    1P request. Non-Anthropic providers flatten only ``text`` and never see it.
+    """
+    cleaned: list[dict[str, Any]] = []
+    for blk in blocks:
+        if isinstance(blk, dict) and "_cache_scope" in blk:
+            blk = {k: v for k, v in blk.items() if k != "_cache_scope"}
+        cleaned.append(blk)
+    return cleaned
+
+
+def _split_system_prompt_blocks(
+    blocks: list[dict[str, Any]], *, relocate_request_scope: bool
+) -> tuple[str, str]:
+    """Flatten system-prompt blocks for an OpenAI-compatible provider.
+
+    Returns ``(system_text, volatile_tail_text)``.
+
+    The ``__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__`` marker is always dropped (it is
+    an Anthropic cache-only signal that would be unintelligible prose to other
+    models).
+
+    When ``relocate_request_scope`` is True (DeepSeek only), blocks tagged
+    ``_cache_scope == "request"`` — the env section, the auto-memory section
+    (which embeds the mutable ``MEMORY.md`` body), plan-mode / non-interactive
+    / tool-restriction sections — are routed into ``volatile_tail_text`` so the
+    caller can place them AFTER the conversation history. That keeps the
+    ``system + tools + history`` prefix byte-stable across turns, so DeepSeek's
+    automatic prefix cache covers it even when memory or the environment
+    changes mid-session.
+
+    When False (every other provider), the tail is empty and all non-boundary
+    text is concatenated into ``system_text`` — byte-for-byte the prior
+    behaviour.
+    """
+    from ..context_system.cache_boundary import SYSTEM_PROMPT_DYNAMIC_BOUNDARY
+
+    stable: list[str] = []
+    volatile: list[str] = []
+    for blk in blocks:
+        if not isinstance(blk, dict):
+            continue
+        text = blk.get("text")
+        if not text or text == SYSTEM_PROMPT_DYNAMIC_BOUNDARY:
+            continue
+        if relocate_request_scope and blk.get("_cache_scope") == "request":
+            volatile.append(str(text))
+        else:
+            stable.append(str(text))
+    return "\n\n".join(stable), "\n\n".join(volatile)
+
+
+def _append_session_context_tail(
+    api_messages: list[dict[str, Any]], tail_text: str
+) -> list[dict[str, Any]]:
+    """Place the DeepSeek relocated-volatile sections AFTER the conversation.
+
+    Wrapped as ambient ``<system-reminder>`` context. Merged into the trailing
+    user message when that is a plain user turn (string content, or a
+    content-block list with no ``tool_result``) so the wire keeps strict
+    user/assistant alternation. Otherwise — e.g. the turn ends in a tool result
+    (which converts to ``role:tool`` on the wire) — appended as a standalone
+    trailing user message, which lands correctly after the tool messages.
+    Returns a new list; ``api_messages`` is not mutated.
+    """
+    reminder = (
+        "<system-reminder>\n"
+        "Current session/environment context (ambient — not a new user request):\n"
+        f"{tail_text}\n"
+        "</system-reminder>"
+    )
+    last = api_messages[-1] if api_messages else None
+    if isinstance(last, dict) and last.get("role") == "user":
+        content = last.get("content")
+        if isinstance(content, str):
+            merged = dict(last)
+            merged["content"] = f"{content}\n\n{reminder}" if content else reminder
+            return [*api_messages[:-1], merged]
+        if isinstance(content, list) and not any(
+            isinstance(b, dict) and b.get("type") == "tool_result" for b in content
+        ):
+            merged = dict(last)
+            merged["content"] = [*content, {"type": "text", "text": reminder}]
+            return [*api_messages[:-1], merged]
+    return [*api_messages, {"role": "user", "content": reminder}]
+
+
 async def _call_model_sync(
     *,
     provider: BaseProvider,
@@ -617,6 +710,11 @@ async def _call_model_sync(
                     "%s — ADVISOR_TOOL_INSTRUCTIONS NOT injected",
                     type(system_prompt).__name__,
                 )
+        # Strip the inert ``_cache_scope`` metadata the assembler tags onto
+        # blocks; Anthropic forwards the system list verbatim to its SDK, so
+        # the tag must not reach the 1P wire.
+        if isinstance(system_prompt, list):
+            system_prompt = _strip_block_metadata(system_prompt)
         call_kwargs["system"] = system_prompt
     else:
         # Non-Anthropic providers (OpenAI-compat, GLM, etc.) consume the
@@ -629,14 +727,18 @@ async def _call_model_sync(
         # signal for the Anthropic backend; emitting it as raw text into
         # a non-Anthropic system prompt embeds an unintelligible token in
         # the prose that may confuse those models.
+        #
+        # DeepSeek-only: route the per-request-volatile (REQUEST-scope)
+        # sections to a trailing tail so the system prefix stays byte-stable
+        # for DeepSeek's automatic prefix cache. ``relocate_request_scope`` is
+        # False for every other provider, so ``flattened`` keeps every
+        # non-boundary block (byte-for-byte the prior behaviour) and
+        # ``volatile_tail`` is "".
+        is_deepseek = bool(getattr(provider, "is_deepseek", False))
+        volatile_tail = ""
         if isinstance(system_prompt, list):
-            from ..context_system.cache_boundary import SYSTEM_PROMPT_DYNAMIC_BOUNDARY
-            flattened = "\n\n".join(
-                str(blk.get("text", ""))
-                for blk in system_prompt
-                if isinstance(blk, dict)
-                and blk.get("text")
-                and blk.get("text") != SYSTEM_PROMPT_DYNAMIC_BOUNDARY
+            flattened, volatile_tail = _split_system_prompt_blocks(
+                system_prompt, relocate_request_scope=is_deepseek
             )
         else:
             flattened = system_prompt
@@ -650,6 +752,15 @@ async def _call_model_sync(
             else:
                 flattened = ADVISOR_TOOL_INSTRUCTIONS
         api_messages = [{"role": "system", "content": flattened}, *api_messages]
+        # DeepSeek: the relocated REQUEST-scope sections (env, auto-memory,
+        # plan-mode, …) ride a trailing <system-reminder> user message so they
+        # sit AFTER the conversation history. The system + tools + history
+        # prefix then stays byte-stable turn-over-turn and hits DeepSeek's
+        # automatic prefix cache even when memory or the environment changes
+        # mid-session. ``volatile_tail`` is always "" for other providers, so
+        # this is a strict no-op for them.
+        if volatile_tail:
+            api_messages = _append_session_context_tail(api_messages, volatile_tail)
 
     if is_anthropic and sdk_max_retries is not None:
         # ch04 round-3 G3(c): the loop's manual 529 lane passes 0 here so

--- a/src/services/pricing.py
+++ b/src/services/pricing.py
@@ -59,6 +59,25 @@ _TIER_HAIKU_3 = {
     "cache_creation": 0.30 / 1_000_000,
     "cache_read": 0.03 / 1_000_000,
 }
+# DeepSeek V4 (USD per million tokens). DeepSeek's automatic prefix cache
+# bills cache HITS at the low ``cache_read`` rate and cache MISSES at the
+# normal input rate; there is no separate cache-write charge, so
+# ``cache_creation`` mirrors ``input`` (a non-cached token is just input).
+# DeepSeekProvider maps its usage onto the Anthropic convention
+# (``input_tokens`` = miss, ``cache_read_input_tokens`` = hit), so these tiers
+# price correctly through the generic ``compute_cost``.
+_TIER_DEEPSEEK_FLASH = {
+    "input": 0.14 / 1_000_000,
+    "output": 0.28 / 1_000_000,
+    "cache_creation": 0.14 / 1_000_000,
+    "cache_read": 0.0028 / 1_000_000,
+}
+_TIER_DEEPSEEK_PRO = {
+    "input": 0.435 / 1_000_000,
+    "output": 0.87 / 1_000_000,
+    "cache_creation": 0.435 / 1_000_000,
+    "cache_read": 0.003625 / 1_000_000,
+}
 
 
 # Exact-match table — keyed by canonical model name. Order DOESN'T matter
@@ -82,6 +101,11 @@ PRICING: dict[str, dict[str, float]] = {
     "claude-opus-4-5": _TIER_5_25,
     "claude-opus-4-1": _TIER_15_75,
     "claude-opus-4-20250514": _TIER_15_75,
+    # DeepSeek V4 (api.deepseek.com). OpenRouter's ``deepseek/…`` ids resolve
+    # here too via get_pricing's vendor-prefix strip — consistent with how
+    # every proxied model is priced at its upstream rate.
+    "deepseek-v4-flash": _TIER_DEEPSEEK_FLASH,
+    "deepseek-v4-pro": _TIER_DEEPSEEK_PRO,
 }
 
 
@@ -126,10 +150,10 @@ def get_pricing(model: str) -> dict[str, float] | None:
          (legacy cost-tracker facade).
 
     Critic C1: returning ``None`` instead of a generic Sonnet-tier
-    fallback prevents silently mispricing non-Claude models by 10×
-    (DeepSeek $0.27/$1.10 vs sonnet $3/$15) or 3-5× (Gemini, GPT-5).
-    The user picks "no number" over "wrong number" for status-bar
-    honesty; per-provider tier tables are a future PR.
+    fallback prevents silently mispricing unknown non-Claude models by
+    3-10× (e.g. Gemini, GPT-5 vs sonnet $3/$15). The user picks "no
+    number" over "wrong number" for status-bar honesty. DeepSeek V4 is
+    now tabled above; other per-provider tiers remain a future PR.
     """
     if not model:
         return None

--- a/tests/test_deepseek_prefix_cache.py
+++ b/tests/test_deepseek_prefix_cache.py
@@ -1,0 +1,393 @@
+"""Tests for the DeepSeek prefix-cache token-efficiency work.
+
+All behaviour is scoped to the ``deepseek`` provider so other providers/models
+are provably unaffected. Covers:
+
+* ``BaseProvider.is_deepseek`` capability flag (gate).
+* DeepSeek context-window registry rows (and that OpenRouter-DeepSeek and
+  other providers keep the default).
+* DeepSeek cache-token telemetry in ``_build_usage_dict`` (both wire shapes),
+  and that the base/other providers do NOT gain cache keys.
+* The system-prompt cache-scope metadata + the query-layer relocation that
+  moves per-request-volatile (REQUEST-scope) sections to a trailing tail for
+  DeepSeek, keeping the system+history prefix byte-stable even when volatile
+  sections (e.g. the mutable MEMORY.md body) change — while leaving every
+  other provider's request bytes identical.
+"""
+
+from __future__ import annotations
+
+from src.context_system.prompt_assembly import build_full_system_prompt_blocks
+from src.models import get_context_window_for_model, get_model_max_output_tokens
+from src.providers.base import BaseProvider
+from src.providers.deepseek_provider import DeepSeekProvider
+from src.providers.openai_provider import OpenAIProvider
+from src.query.query import (
+    _append_session_context_tail,
+    _split_system_prompt_blocks,
+    _strip_block_metadata,
+)
+
+
+_KEY = "sk-" + "x" * 24
+
+
+# --------------------------------------------------------------------------- #
+# is_deepseek flag (scope gate)
+# --------------------------------------------------------------------------- #
+
+def test_is_deepseek_flag_scoped_to_deepseek_provider():
+    assert BaseProvider.is_deepseek is False
+    assert DeepSeekProvider(api_key=_KEY).is_deepseek is True
+    assert OpenAIProvider(api_key=_KEY).is_deepseek is False
+
+
+# --------------------------------------------------------------------------- #
+# Context-window registry
+# --------------------------------------------------------------------------- #
+
+def test_deepseek_v4_context_windows_registered():
+    assert get_context_window_for_model("deepseek-v4-pro") == 1_000_000
+    assert get_context_window_for_model("deepseek-v4-flash") == 1_000_000
+    assert get_model_max_output_tokens("deepseek-v4-pro") == 8_192
+
+
+def test_other_providers_context_window_unchanged():
+    # OpenRouter-DeepSeek (decision #1: out of scope) keeps the 200K default.
+    assert get_context_window_for_model("deepseek/deepseek-v4-pro") == 200_000
+    assert get_context_window_for_model("gpt-5.4") == 200_000
+    assert get_context_window_for_model("some-unknown-model") == 200_000
+    # Legacy aliases intentionally NOT registered (broad prefix-match risk).
+    assert get_context_window_for_model("deepseek-chat") == 200_000
+
+
+# --------------------------------------------------------------------------- #
+# Cache-token telemetry
+# --------------------------------------------------------------------------- #
+
+class _Usage:
+    """Minimal stand-in for the OpenAI SDK usage object."""
+
+    def __init__(self, **kw):
+        self.prompt_tokens = kw.get("prompt_tokens", 0)
+        self.completion_tokens = kw.get("completion_tokens", 0)
+        self.total_tokens = kw.get("total_tokens", 0)
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+def test_deepseek_usage_maps_native_cache_shape_to_anthropic_convention():
+    ds = DeepSeekProvider(api_key=_KEY)
+    out = ds._build_usage_dict(_Usage(
+        prompt_tokens=1000, completion_tokens=50, total_tokens=1050,
+        prompt_cache_hit_tokens=800, prompt_cache_miss_tokens=200,
+    ))
+    # input_tokens = uncached (miss); cache_read = cached (hit); no cache-write.
+    assert out["input_tokens"] == 200
+    assert out["cache_read_input_tokens"] == 800
+    assert out["cache_creation_input_tokens"] == 0
+    assert out["output_tokens"] == 50
+    assert out["total_tokens"] == 1050
+
+
+def test_deepseek_usage_nested_openai_cache_shape_derives_miss():
+    ds = DeepSeekProvider(api_key=_KEY)
+
+    class _Details:
+        cached_tokens = 700
+
+    usage = _Usage(prompt_tokens=1000, completion_tokens=10, total_tokens=1010)
+    usage.prompt_tokens_details = _Details()
+    out = ds._build_usage_dict(usage)
+    assert out["cache_read_input_tokens"] == 700
+    assert out["input_tokens"] == 300  # derived: prompt - hit
+
+
+def test_deepseek_usage_model_extra_dict():
+    ds = DeepSeekProvider(api_key=_KEY)
+    usage = _Usage(prompt_tokens=500, completion_tokens=5, total_tokens=505)
+    usage.model_extra = {"prompt_cache_hit_tokens": 400}
+    out = ds._build_usage_dict(usage)
+    assert out["cache_read_input_tokens"] == 400
+    assert out["input_tokens"] == 100
+
+
+def test_deepseek_usage_no_cache_hit_leaves_input_full():
+    """No cache hit → no re-map: all prompt tokens stay as uncached input."""
+    ds = DeepSeekProvider(api_key=_KEY)
+    out = ds._build_usage_dict(
+        _Usage(prompt_tokens=300, completion_tokens=20, total_tokens=320)
+    )
+    assert out["input_tokens"] == 300
+    assert "cache_read_input_tokens" not in out
+
+
+def test_deepseek_usage_reads_reasoning_tokens():
+    ds = DeepSeekProvider(api_key=_KEY)
+
+    class _CDetails:
+        reasoning_tokens = 42
+
+    usage = _Usage(prompt_tokens=10, completion_tokens=100, total_tokens=110)
+    usage.completion_tokens_details = _CDetails()
+    assert ds._build_usage_dict(usage)["reasoning_tokens"] == 42
+
+
+def test_deepseek_usage_none_is_safe():
+    assert DeepSeekProvider(api_key=_KEY)._build_usage_dict(None) == {}
+
+
+def test_other_provider_usage_unchanged_by_cache_fields():
+    """Isolation: the base OpenAI-compatible usage dict is untouched even if a
+    usage object carries DeepSeek-style cache fields."""
+    out = OpenAIProvider(api_key=_KEY)._build_usage_dict(_Usage(
+        prompt_tokens=1000, completion_tokens=50, total_tokens=1050,
+        prompt_cache_hit_tokens=800,
+    ))
+    assert "cache_read_input_tokens" not in out
+    assert out == {"input_tokens": 1000, "output_tokens": 50, "total_tokens": 1050}
+
+
+# --------------------------------------------------------------------------- #
+# Cost wiring (services/pricing.py)
+# --------------------------------------------------------------------------- #
+
+def test_deepseek_pricing_registered():
+    from src.services.pricing import get_pricing
+
+    flash = get_pricing("deepseek-v4-flash")
+    pro = get_pricing("deepseek-v4-pro")
+    assert flash is not None and pro is not None
+    assert flash["input"] == 0.14 / 1_000_000
+    assert flash["cache_read"] == 0.0028 / 1_000_000
+    assert pro["input"] == 0.435 / 1_000_000
+    assert pro["output"] == 0.87 / 1_000_000
+
+
+def test_openrouter_deepseek_pricing_via_vendor_strip():
+    """Consistent with how all proxied models are priced at the upstream rate
+    (get_pricing strips the ``deepseek/`` vendor prefix)."""
+    from src.services.pricing import get_pricing
+
+    assert get_pricing("deepseek/deepseek-v4-pro") == get_pricing("deepseek-v4-pro")
+
+
+def test_deepseek_cost_credits_cache_hit_end_to_end():
+    """A DeepSeek response mapped through the provider then priced charges the
+    cheap cache-hit rate for the cached portion — the whole point of the
+    prefix-cache work."""
+    from src.services.pricing import compute_cost
+
+    ds = DeepSeekProvider(api_key=_KEY)
+    usage = ds._build_usage_dict(_Usage(
+        prompt_tokens=1_000_000, completion_tokens=0, total_tokens=1_000_000,
+        prompt_cache_hit_tokens=900_000, prompt_cache_miss_tokens=100_000,
+    ))
+    cost = compute_cost("deepseek-v4-flash", usage)
+    expected = 100_000 * 0.14 / 1_000_000 + 900_000 * 0.0028 / 1_000_000
+    assert abs(cost - expected) < 1e-12
+    # ~9x cheaper than pricing the whole prompt as uncached input.
+    full = 1_000_000 * 0.14 / 1_000_000
+    assert cost < full / 5
+
+
+def test_cost_command_surfaces_cache_hit_rate():
+    """End-to-end: a recorded DeepSeek usage appears in /cost with the
+    prompt-cache hit-rate and a cache-credited cost."""
+    from pathlib import Path
+
+    from src.bootstrap.state import reset_cost_state
+    from src.command_system.builtins import cost_command_call
+    from src.command_system.types import CommandContext
+    from src.cost_tracker import record_api_usage
+
+    reset_cost_state()
+    try:
+        ds = DeepSeekProvider(api_key=_KEY)
+        usage = ds._build_usage_dict(_Usage(
+            prompt_tokens=100_000, completion_tokens=500, total_tokens=100_500,
+            prompt_cache_hit_tokens=90_000, prompt_cache_miss_tokens=10_000,
+        ))
+        record_api_usage("deepseek-v4-pro", usage)
+        ctx = CommandContext(
+            workspace_root=Path("/tmp"), cwd=Path("/tmp"),
+            conversation=None, cost_tracker=None, history=None,
+        )
+        out = cost_command_call("", ctx).value
+        assert "deepseek-v4-pro" in out
+        assert "90,000 cached" in out
+        assert "90% hit" in out
+    finally:
+        reset_cost_state()
+
+
+# --------------------------------------------------------------------------- #
+# cache_scope metadata tagging (assembler)
+# --------------------------------------------------------------------------- #
+
+def _scope_of(blocks, needle):
+    for b in blocks:
+        if needle in b.get("text", ""):
+            return b.get("_cache_scope")
+    return None
+
+
+def test_assembler_tags_blocks_with_cache_scope():
+    blocks = build_full_system_prompt_blocks(cwd="/tmp")
+    # The env section is per-request volatile → REQUEST scope.
+    assert _scope_of(blocks, "# Environment") == "request"
+    # The intro/identity is globally cacheable → GLOBAL scope.
+    assert _scope_of(blocks, "software engineering tasks") == "global"
+    # Every text block except the boundary marker carries a scope tag.
+    from src.context_system.cache_boundary import SYSTEM_PROMPT_DYNAMIC_BOUNDARY
+    for b in blocks:
+        if b.get("text") == SYSTEM_PROMPT_DYNAMIC_BOUNDARY:
+            assert "_cache_scope" not in b
+        else:
+            assert b.get("_cache_scope") in {"global", "session", "request"}
+
+
+# --------------------------------------------------------------------------- #
+# _strip_block_metadata (Anthropic wire safety)
+# --------------------------------------------------------------------------- #
+
+def test_strip_block_metadata_removes_cache_scope_only():
+    blocks = [
+        {"type": "text", "text": "a", "_cache_scope": "global",
+         "cache_control": {"type": "ephemeral"}},
+        {"type": "text", "text": "b"},
+    ]
+    cleaned = _strip_block_metadata(blocks)
+    assert all("_cache_scope" not in b for b in cleaned)
+    # cache_control and other keys are preserved.
+    assert cleaned[0]["cache_control"] == {"type": "ephemeral"}
+    assert cleaned[0]["text"] == "a"
+    # Original is not mutated.
+    assert blocks[0]["_cache_scope"] == "global"
+
+
+# --------------------------------------------------------------------------- #
+# _split_system_prompt_blocks (the relocation core)
+# --------------------------------------------------------------------------- #
+
+def _sample_blocks():
+    from src.context_system.cache_boundary import SYSTEM_PROMPT_DYNAMIC_BOUNDARY
+    return [
+        {"type": "text", "text": "INTRO", "_cache_scope": "global"},
+        {"type": "text", "text": SYSTEM_PROMPT_DYNAMIC_BOUNDARY},
+        {"type": "text", "text": "TOOLS", "_cache_scope": "session"},
+        {"type": "text", "text": "ENV-and-MEMORY", "_cache_scope": "request"},
+    ]
+
+
+def test_split_relocates_request_scope_for_deepseek():
+    system, tail = _split_system_prompt_blocks(_sample_blocks(), relocate_request_scope=True)
+    # Stable prefix keeps GLOBAL + SESSION, drops the boundary marker.
+    assert "INTRO" in system and "TOOLS" in system
+    assert "__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__" not in system
+    # REQUEST-scope content is moved out of the prefix into the tail.
+    assert "ENV-and-MEMORY" not in system
+    assert tail == "ENV-and-MEMORY"
+
+
+def test_split_keeps_everything_in_system_for_other_providers():
+    system, tail = _split_system_prompt_blocks(_sample_blocks(), relocate_request_scope=False)
+    assert "INTRO" in system and "TOOLS" in system and "ENV-and-MEMORY" in system
+    assert "__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__" not in system
+    assert tail == ""  # no relocation → no tail for non-DeepSeek
+
+
+def test_deepseek_prefix_stable_when_request_scope_block_changes():
+    """The core guarantee: a mid-session change to a REQUEST-scope section
+    (e.g. a MEMORY.md write, or the live env timestamp) must NOT perturb the
+    DeepSeek system prefix — only the relocated tail changes."""
+    from src.context_system.cache_boundary import SYSTEM_PROMPT_DYNAMIC_BOUNDARY
+    turn1 = [
+        {"type": "text", "text": "INTRO", "_cache_scope": "global"},
+        {"type": "text", "text": SYSTEM_PROMPT_DYNAMIC_BOUNDARY},
+        {"type": "text", "text": "TOOLS", "_cache_scope": "session"},
+        {"type": "text", "text": "MEMORY v1", "_cache_scope": "request"},
+    ]
+    turn2 = [
+        {"type": "text", "text": "INTRO", "_cache_scope": "global"},
+        {"type": "text", "text": SYSTEM_PROMPT_DYNAMIC_BOUNDARY},
+        {"type": "text", "text": "TOOLS", "_cache_scope": "session"},
+        {"type": "text", "text": "MEMORY v2 (user added a note)", "_cache_scope": "request"},
+    ]
+    sys1, tail1 = _split_system_prompt_blocks(turn1, relocate_request_scope=True)
+    sys2, tail2 = _split_system_prompt_blocks(turn2, relocate_request_scope=True)
+    assert sys1 == sys2, "DeepSeek system prefix must be stable across a memory write"
+    assert tail1 != tail2, "the changed content rides the (uncached) tail"
+
+
+def test_non_deepseek_prefix_changes_when_request_scope_block_changes():
+    """Contrast: without relocation, the same change lands in the system
+    prefix (this is the current behaviour for non-DeepSeek providers — they
+    rely on Anthropic-style explicit cache_control, not byte-stability)."""
+    base = {"type": "text", "text": "INTRO", "_cache_scope": "global"}
+    sys1, _ = _split_system_prompt_blocks(
+        [base, {"type": "text", "text": "MEM v1", "_cache_scope": "request"}],
+        relocate_request_scope=False,
+    )
+    sys2, _ = _split_system_prompt_blocks(
+        [base, {"type": "text", "text": "MEM v2", "_cache_scope": "request"}],
+        relocate_request_scope=False,
+    )
+    assert sys1 != sys2
+
+
+def test_memory_section_is_request_scoped():
+    """Regression guard tying the relocation guarantee to the real section
+    taxonomy: the auto-memory section embeds the mutable MEMORY.md body, so it
+    MUST stay REQUEST-scoped (relocated to the tail for DeepSeek). If it's ever
+    retagged SESSION/GLOBAL it would sit in the cached prefix and a memory
+    write would bust the whole history cache. Skips when no memory section is
+    produced in the test environment."""
+    from src.context_system.prompt_assembly import _build_memory_section
+    from src.context_system.system_prompt_cache import CacheScope
+
+    section = _build_memory_section()
+    if section is not None:
+        assert section.cache_scope is CacheScope.REQUEST
+
+
+# --------------------------------------------------------------------------- #
+# _append_session_context_tail (placement / alternation hardening)
+# --------------------------------------------------------------------------- #
+
+def test_tail_merges_into_trailing_string_user_turn():
+    """Fresh turn ending in a string user prompt: merge the tail into it so the
+    wire keeps strict user/assistant alternation (no consecutive user msgs)."""
+    msgs = [{"role": "system", "content": "S"}, {"role": "user", "content": "hello"}]
+    out = _append_session_context_tail(msgs, "ENV+MEM")
+    assert len(out) == len(msgs)  # merged, not appended
+    assert out[-1]["role"] == "user"
+    assert out[-1]["content"].startswith("hello")
+    assert "ENV+MEM" in out[-1]["content"]
+    # input not mutated
+    assert msgs[-1]["content"] == "hello"
+
+
+def test_tail_is_standalone_message_after_tool_result():
+    """Mid-tool-loop: the turn ends in a tool_result (→ role:tool on the wire),
+    so the tail must be a NEW trailing user message to land after it."""
+    msgs = [
+        {"role": "assistant", "content": [{"type": "tool_use", "id": "t1", "name": "x", "input": {}}]},
+        {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]},
+    ]
+    out = _append_session_context_tail(msgs, "ENV+MEM")
+    assert len(out) == len(msgs) + 1
+    assert out[-1]["role"] == "user"
+    assert "ENV+MEM" in out[-1]["content"]
+    # the tool_result message is untouched (tail did not merge into it)
+    assert out[-2]["content"][0]["type"] == "tool_result"
+
+
+def test_tail_merges_into_multimodal_user_turn_without_tool_result():
+    """A fresh user turn with image/text blocks (no tool_result) merges the
+    tail as an extra text block, preserving a single user turn."""
+    msgs = [{"role": "user", "content": [{"type": "text", "text": "look"}]}]
+    out = _append_session_context_tail(msgs, "ENV")
+    assert len(out) == 1
+    assert out[-1]["content"][-1]["type"] == "text"
+    assert "ENV" in out[-1]["content"][-1]["text"]

--- a/tests/test_pricing_status_bar.py
+++ b/tests/test_pricing_status_bar.py
@@ -50,14 +50,19 @@ class TestGetPricing(unittest.TestCase):
         # model name was passed in.
         p = get_pricing("anthropic/claude-opus-4-7")
         self.assertEqual(p["input"], 5.0 / 1_000_000)
+        # The same strip prices DeepSeek-via-OpenRouter at the upstream
+        # DeepSeek rate (a directional estimate; the proxy may add markup).
+        d = get_pricing("deepseek/deepseek-v4-pro")
+        self.assertEqual(d["input"], 0.435 / 1_000_000)
 
     def test_unknown_model_returns_none(self) -> None:
         # Critic C1: unknowns return None instead of mispricing as
-        # Sonnet 3/15 (which would be ~10× off for DeepSeek-tier
-        # models the user actually runs).
+        # Sonnet 3/15 (which would be ~10× off for the cheap non-Claude
+        # models the user actually runs). DeepSeek V4 is now tabled, so the
+        # still-unpriced examples are Gemini / GPT-tier ids.
         self.assertIsNone(get_pricing("totally-unknown-model-xyz"))
-        self.assertIsNone(get_pricing("deepseek/deepseek-v4-pro"))
         self.assertIsNone(get_pricing("gpt-5.4"))
+        self.assertIsNone(get_pricing("google/gemini-2.5-pro"))
 
     def test_empty_model_returns_none(self) -> None:
         self.assertIsNone(get_pricing(""))


### PR DESCRIPTION
## What & why

DeepSeek bills cached prompt tokens at ~1/50th of uncached input, and its prefix cache is **automatic** (longest-common-prefix match) rather than Anthropic's explicit `cache_control` breakpoints. This PR makes clawcodex keep its request **prefix byte-stable** across turns so DeepSeek's cache covers the system prompt + accumulating history — keeping token cost low across long sessions — and wires DeepSeek cost + cache telemetry so the savings are visible.

**Everything is gated to the `deepseek` provider. Other providers' requests are byte-for-byte unchanged.**

## Changes

- **`is_deepseek` provider flag** — resolved once on the provider class; gates all DeepSeek-only behavior. (OpenRouter-DeepSeek is intentionally out of scope.)
- **Prefix-cache stability** — the system-prompt assembler tags each block with an inert `_cache_scope`; for DeepSeek the query layer relocates the per-request-volatile (REQUEST-scope) sections — env timestamp, the **mutable `MEMORY.md` body**, plan-mode, etc. — into a trailing `<system-reminder>` user message **after** the conversation history. The `system + tools + history` prefix then stays byte-stable turn-over-turn even when memory/env change mid-session. Metadata is stripped before the Anthropic wire (Anthropic forwards system blocks verbatim).
- **Context window** — registered `deepseek-v4-pro`/`-flash` at the real 1M window (was silently defaulting to 200K, mis-calibrating compaction triggers).
- **Cache telemetry + cost** — `_build_usage_dict` maps DeepSeek's cache split onto the Anthropic convention (`input_tokens`=miss, `cache_read_input_tokens`=hit) so the existing `compute_cost`/`record_api_usage` credit the cheap cache rate. Added DeepSeek pricing tiers in `services/pricing.py` (the single source of cost truth).
- **`/cost`** now shows per-model token usage + prompt-cache hit-rate + cost, e.g. `prompt 100,000 tok (90,000 cached, 90% hit)`.

## Scope-isolation guarantee

All byte-changing edits sit behind the resolved `is_deepseek` flag or are new no-op-by-default hooks. The Anthropic block-list/`cache_control` path and every other OpenAI-compatible provider's flatten are untouched; their snapshots don't move.

## Test plan

- New `tests/test_deepseek_prefix_cache.py` (23 tests): flag scoping, context-window registry (incl. OpenRouter-DeepSeek unaffected), cache-token mapping (native + nested + `model_extra` shapes), the **prefix-stability guarantee under a simulated MEMORY.md write**, tail-placement/alternation hardening, pricing, and an end-to-end cache-credited cost + `/cost` hit-rate render.
- Updated `tests/test_pricing_status_bar.py` for the now-tabled DeepSeek pricing.
- Broad sweep: **1115 passing**; the only failures (4 in `test_providers.py`) are **pre-existing** (confirmed on baseline, unrelated to this change).
- Reviewed across multiple rounds by an adversarial critic agent (caught and fixed: the original freeze-only approach was insufficient because the memory body is mutable → switched to relocation; a 10× cache-rate decimal typo → removed the duplicate dead pricing fields so cost lives in one place).

## Notes for reviewers

- **OpenRouter-DeepSeek cost display** now shows a DeepSeek-rate estimate instead of `$0`, via the existing vendor-prefix strip that already prices `anthropic/…` etc. — a directional upstream estimate (proxy markup not modeled), consistent with the module's documented proxy-pricing behavior.
- **Deferred (non-gating, pre-existing):** the live status-bar token count + cost under-report cache for *all* cache-using providers (reads `input_tokens` alone; passes `0` for `worker_cache_read_tokens`). The authoritative `/cost` is correct. Worth a separate general "status-bar cache accounting" fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
