### PR TITLE
docs(readme): make DeepSeek the default provider across all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ The configuration file is saved at `~/.clawcodex/config.json`. Minimal example:
 
 ```json
 {
-  "default_provider": "zai",
+  "default_provider": "deepseek",
   "providers": {
-    "zai": {
+    "deepseek": {
       "api_key": "xxx-xxx",
-      "base_url": "https://api.z.ai/api/coding/paas/v4",
-      "default_model": "glm-5.2"
+      "base_url": "https://api.deepseek.com",
+      "default_model": "deepseek-v4-pro"
     }
   },
   "env": {
@@ -63,6 +63,7 @@ The `session`, `settings`, and `env` blocks are optional — sensible defaults a
 
 ## 📰 News
 
+- **2026-06-18:** **DeepSeek prefix-cache exploitation — a HUGE token-cost win (#363)** — ClawCodex now keeps its request prefix **byte-stable** across turns so DeepSeek's automatic prompt-prefix cache covers the entire `system + tools + history` span. Per-request-volatile sections (env, the mutable `MEMORY.md` body, plan-mode, etc.) are relocated to a trailing `<system-reminder>` *after* the conversation history, so the cached prefix never breaks even when memory/env change. We also register DeepSeek's **1M-token context window**, map its prompt-cache usage onto the Anthropic `cache_read_input_tokens` convention, and surface a per-model **prompt-cache hit-rate** + cost in `/cost`. **Why this is enormous — the token economics:** Claude Fable 5 runs **$10 / $50** per 1M input/output tokens, while **DeepSeek-V4-Pro is just $0.435 / $0.87** — already **~23× cheaper on input** and **~57× cheaper on output**. And because **cache-hit input is billed at only 10%** of the normal input rate, the long, context-heavy sessions that agentic coding actually produces pay just **~$0.0435 per 1M input tokens** — roughly **230× cheaper than Fable 5 input**. The token efficiency ClawCodex unlocks here is **HUGE**. Everything is gated to the `deepseek` provider — every other provider's request is byte-for-byte unchanged. Follow-up: truncated tool-call argument JSON is now best-effort recovered in the shared OpenAI-compatible layer, so an interrupted DeepSeek stream keeps its partial tool args instead of dropping them to `{}` (#364).
 - **2026-06-16:** **Z.ai GLM-5.2 support (#343)** — new `zai` provider for Z.ai's OpenAI-compatible GLM Coding Plan (`https://api.z.ai/api/coding/paas/v4`), shipping `GLM-5.1` and the `GLM-5.2` preview; GLM-5.2 delivers coding capability comparable to Claude Opus 4.7. First app built end-to-end with GLM-5.2 — a [FIFA World Cup 2026 intro page](demos/wc26-intro/index.html) (animated hero + live countdown, three host nations, 16 stadiums, tournament format, and record-breaking facts).
 - **2026-06-11:** **Codebase stats** — Total Python files: 1,093 files; Total Lines of Python Code: **233,520 lines** (up from 213,777 lines on 2026-05-29; ~+19.7k lines from the interactive command-system batch, the dynamic workflow engine + `/deep-research`, and the Tavily web-tooling refresh).
 - **2026-06-10 to 2026-06-11:** **Dynamic workflow engine + `/deep-research` (#262–#264, #266–#271)** — Python workflow engine core (`agent()`/`parallel()`/`pipeline()`/`phase()`, journaling, resume) wired end-to-end: Workflow tool, `/workflows` TUI dialog + status-line pill, per-agent retry, worktree isolation, result delivery, and the bundled `/deep-research` harness registered as a slash command. Reliability: LLM read timeout applied centrally to all openai-compatible providers (#269), parallel agents no longer serialize on the event loop (#270), and the deep-research synthesize step forbids tools so the report-writer can't loop (#271). Follow-ups: workflow max-turns cap fix (#272), deep-research verdict-enum fix (#273), rich `/workflows` live monitor with phase progress + per-agent stats (#287).

--- a/docs/i18n/README_AR.md
+++ b/docs/i18n/README_AR.md
@@ -135,12 +135,12 @@ uv pip install -r requirements.txt
 
 ```json
 {
-  "default_provider": "zai",
+  "default_provider": "deepseek",
   "providers": {
-    "zai": {
+    "deepseek": {
       "api_key": "xxx-xxx",
-      "base_url": "https://api.z.ai/api/coding/paas/v4",
-      "default_model": "glm-5.2"
+      "base_url": "https://api.deepseek.com",
+      "default_model": "deepseek-v4-pro"
     }
   },
   "env": {
@@ -163,7 +163,7 @@ python -m src.cli login
 
 هذه العملية ستقوم بـ:
 
-1. مطالبتك باختيار مزود: anthropic / openai / zai
+1. مطالبتك باختيار مزود: anthropic / openai / zai / minimax / openrouter / deepseek
 2. مطالبتك بمفتاح API الخاص بذلك المزود
 3. حفظ عنوان URL أساسي مخصص اختياريًا
 4. حفظ نموذج افتراضي اختياريًا
@@ -173,23 +173,51 @@ python -m src.cli login
 
 ```json
 {
-  "default_provider": "zai",
+  "default_provider": "deepseek",
   "providers": {
     "anthropic": {
       "api_key": "your-api-key",
       "base_url": "https://api.anthropic.com",
-      "default_model": "claude-sonnet-4-20250514"
+      "default_model": "claude-sonnet-4-6"
     },
     "openai": {
       "api_key": "your-api-key",
       "base_url": "https://api.openai.com/v1",
-      "default_model": "gpt-4"
+      "default_model": "gpt-5.4"
     },
     "zai": {
       "api_key": "your-api-key",
       "base_url": "https://api.z.ai/api/coding/paas/v4",
       "default_model": "glm-5.2"
+    },
+    "minimax": {
+      "api_key": "your-api-key",
+      "base_url": "https://api.minimaxi.com/anthropic",
+      "default_model": "MiniMax-M2.7"
+    },
+    "openrouter": {
+      "api_key": "your-api-key",
+      "base_url": "https://openrouter.ai/api/v1",
+      "default_model": "deepseek/deepseek-v4-pro"
+    },
+    "deepseek": {
+      "api_key": "your-api-key",
+      "base_url": "https://api.deepseek.com",
+      "default_model": "deepseek-v4-pro"
     }
+  },
+  "session": {
+    "auto_save": true,
+    "max_history": 100
+  },
+  "settings": {
+    "advisor_enabled": false,
+    "advisor_model": "claude-sonnet-4-6",
+    "advisor_client_mode": false,
+    "advisor_provider": "openai"
+  },
+  "env": {
+    "TAVILY_API_KEY": "tvly-YOUR-TAVILY-API-KEY"
   }
 }
 ```

--- a/docs/i18n/README_FR.md
+++ b/docs/i18n/README_FR.md
@@ -135,12 +135,12 @@ Le fichier de configuration est enregistré dans `~/.clawcodex/config.json`. Exe
 
 ```json
 {
-  "default_provider": "zai",
+  "default_provider": "deepseek",
   "providers": {
-    "zai": {
+    "deepseek": {
       "api_key": "xxx-xxx",
-      "base_url": "https://api.z.ai/api/coding/paas/v4",
-      "default_model": "glm-5.2"
+      "base_url": "https://api.deepseek.com",
+      "default_model": "deepseek-v4-pro"
     }
   },
   "env": {
@@ -163,7 +163,7 @@ python -m src.cli login
 
 Ce processus va :
 
-1. vous demander de choisir un fournisseur : anthropic / openai / zai
+1. vous demander de choisir un fournisseur : anthropic / openai / zai / minimax / openrouter / deepseek
 2. vous demander la clé API de ce fournisseur
 3. enregistrer optionnellement une URL de base personnalisée
 4. enregistrer optionnellement un modèle par défaut
@@ -173,23 +173,51 @@ Le fichier de configuration est enregistré dans `~/.clawcodex/config.json`. Exe
 
 ```json
 {
-  "default_provider": "zai",
+  "default_provider": "deepseek",
   "providers": {
     "anthropic": {
       "api_key": "your-api-key",
       "base_url": "https://api.anthropic.com",
-      "default_model": "claude-sonnet-4-20250514"
+      "default_model": "claude-sonnet-4-6"
     },
     "openai": {
       "api_key": "your-api-key",
       "base_url": "https://api.openai.com/v1",
-      "default_model": "gpt-4"
+      "default_model": "gpt-5.4"
     },
     "zai": {
       "api_key": "your-api-key",
       "base_url": "https://api.z.ai/api/coding/paas/v4",
       "default_model": "glm-5.2"
+    },
+    "minimax": {
+      "api_key": "your-api-key",
+      "base_url": "https://api.minimaxi.com/anthropic",
+      "default_model": "MiniMax-M2.7"
+    },
+    "openrouter": {
+      "api_key": "your-api-key",
+      "base_url": "https://openrouter.ai/api/v1",
+      "default_model": "deepseek/deepseek-v4-pro"
+    },
+    "deepseek": {
+      "api_key": "your-api-key",
+      "base_url": "https://api.deepseek.com",
+      "default_model": "deepseek-v4-pro"
     }
+  },
+  "session": {
+    "auto_save": true,
+    "max_history": 100
+  },
+  "settings": {
+    "advisor_enabled": false,
+    "advisor_model": "claude-sonnet-4-6",
+    "advisor_client_mode": false,
+    "advisor_provider": "openai"
+  },
+  "env": {
+    "TAVILY_API_KEY": "tvly-YOUR-TAVILY-API-KEY"
   }
 }
 ```

--- a/docs/i18n/README_HI.md
+++ b/docs/i18n/README_HI.md
@@ -135,12 +135,12 @@ uv pip install -r requirements.txt
 
 ```json
 {
-  "default_provider": "zai",
+  "default_provider": "deepseek",
   "providers": {
-    "zai": {
+    "deepseek": {
       "api_key": "xxx-xxx",
-      "base_url": "https://api.z.ai/api/coding/paas/v4",
-      "default_model": "glm-5.2"
+      "base_url": "https://api.deepseek.com",
+      "default_model": "deepseek-v4-pro"
     }
   },
   "env": {
@@ -163,7 +163,7 @@ python -m src.cli login
 
 यह प्रक्रिया:
 
-1. आपको एक प्रदाता चुनने के लिए कहेगी: anthropic / openai / zai
+1. आपको एक प्रदाता चुनने के लिए कहेगी: anthropic / openai / zai / minimax / openrouter / deepseek
 2. उस प्रदाता की API कुंजी मांगेगी
 3. वैकल्पिक रूप से एक कस्टम base URL सहेजेगी
 4. वैकल्पिक रूप से एक डिफ़ॉल्ट मॉडल सहेजेगी
@@ -173,23 +173,51 @@ python -m src.cli login
 
 ```json
 {
-  "default_provider": "zai",
+  "default_provider": "deepseek",
   "providers": {
     "anthropic": {
       "api_key": "your-api-key",
       "base_url": "https://api.anthropic.com",
-      "default_model": "claude-sonnet-4-20250514"
+      "default_model": "claude-sonnet-4-6"
     },
     "openai": {
       "api_key": "your-api-key",
       "base_url": "https://api.openai.com/v1",
-      "default_model": "gpt-4"
+      "default_model": "gpt-5.4"
     },
     "zai": {
       "api_key": "your-api-key",
       "base_url": "https://api.z.ai/api/coding/paas/v4",
       "default_model": "glm-5.2"
+    },
+    "minimax": {
+      "api_key": "your-api-key",
+      "base_url": "https://api.minimaxi.com/anthropic",
+      "default_model": "MiniMax-M2.7"
+    },
+    "openrouter": {
+      "api_key": "your-api-key",
+      "base_url": "https://openrouter.ai/api/v1",
+      "default_model": "deepseek/deepseek-v4-pro"
+    },
+    "deepseek": {
+      "api_key": "your-api-key",
+      "base_url": "https://api.deepseek.com",
+      "default_model": "deepseek-v4-pro"
     }
+  },
+  "session": {
+    "auto_save": true,
+    "max_history": 100
+  },
+  "settings": {
+    "advisor_enabled": false,
+    "advisor_model": "claude-sonnet-4-6",
+    "advisor_client_mode": false,
+    "advisor_provider": "openai"
+  },
+  "env": {
+    "TAVILY_API_KEY": "tvly-YOUR-TAVILY-API-KEY"
   }
 }
 ```

--- a/docs/i18n/README_PT.md
+++ b/docs/i18n/README_PT.md
@@ -135,12 +135,12 @@ O arquivo de configuração é salvo em `~/.clawcodex/config.json`. Exemplo mín
 
 ```json
 {
-  "default_provider": "zai",
+  "default_provider": "deepseek",
   "providers": {
-    "zai": {
+    "deepseek": {
       "api_key": "xxx-xxx",
-      "base_url": "https://api.z.ai/api/coding/paas/v4",
-      "default_model": "glm-5.2"
+      "base_url": "https://api.deepseek.com",
+      "default_model": "deepseek-v4-pro"
     }
   },
   "env": {
@@ -163,7 +163,7 @@ python -m src.cli login
 
 Este processo irá:
 
-1. pedir que você escolha um provedor: anthropic / openai / zai
+1. pedir que você escolha um provedor: anthropic / openai / zai / minimax / openrouter / deepseek
 2. pedir a chave API desse provedor
 3. salvar opcionalmente uma URL base personalizada
 4. salvar opcionalmente um modelo padrão
@@ -173,23 +173,51 @@ O arquivo de configuração é salvo em `~/.clawcodex/config.json`. Exemplo de e
 
 ```json
 {
-  "default_provider": "zai",
+  "default_provider": "deepseek",
   "providers": {
     "anthropic": {
       "api_key": "your-api-key",
       "base_url": "https://api.anthropic.com",
-      "default_model": "claude-sonnet-4-20250514"
+      "default_model": "claude-sonnet-4-6"
     },
     "openai": {
       "api_key": "your-api-key",
       "base_url": "https://api.openai.com/v1",
-      "default_model": "gpt-4"
+      "default_model": "gpt-5.4"
     },
     "zai": {
       "api_key": "your-api-key",
       "base_url": "https://api.z.ai/api/coding/paas/v4",
       "default_model": "glm-5.2"
+    },
+    "minimax": {
+      "api_key": "your-api-key",
+      "base_url": "https://api.minimaxi.com/anthropic",
+      "default_model": "MiniMax-M2.7"
+    },
+    "openrouter": {
+      "api_key": "your-api-key",
+      "base_url": "https://openrouter.ai/api/v1",
+      "default_model": "deepseek/deepseek-v4-pro"
+    },
+    "deepseek": {
+      "api_key": "your-api-key",
+      "base_url": "https://api.deepseek.com",
+      "default_model": "deepseek-v4-pro"
     }
+  },
+  "session": {
+    "auto_save": true,
+    "max_history": 100
+  },
+  "settings": {
+    "advisor_enabled": false,
+    "advisor_model": "claude-sonnet-4-6",
+    "advisor_client_mode": false,
+    "advisor_provider": "openai"
+  },
+  "env": {
+    "TAVILY_API_KEY": "tvly-YOUR-TAVILY-API-KEY"
   }
 }
 ```

--- a/docs/i18n/README_RU.md
+++ b/docs/i18n/README_RU.md
@@ -135,12 +135,12 @@ uv pip install -r requirements.txt
 
 ```json
 {
-  "default_provider": "zai",
+  "default_provider": "deepseek",
   "providers": {
-    "zai": {
+    "deepseek": {
       "api_key": "xxx-xxx",
-      "base_url": "https://api.z.ai/api/coding/paas/v4",
-      "default_model": "glm-5.2"
+      "base_url": "https://api.deepseek.com",
+      "default_model": "deepseek-v4-pro"
     }
   },
   "env": {
@@ -163,7 +163,7 @@ python -m src.cli login
 
 Этот процесс:
 
-1. попросит вас выбрать провайдера: anthropic / openai / zai
+1. попросит вас выбрать провайдера: anthropic / openai / zai / minimax / openrouter / deepseek
 2. попросит ввести API ключ этого провайдера
 3. при необходимости сохранит пользовательский base URL
 4. при необходимости сохранит модель по умолчанию
@@ -173,23 +173,51 @@ python -m src.cli login
 
 ```json
 {
-  "default_provider": "zai",
+  "default_provider": "deepseek",
   "providers": {
     "anthropic": {
       "api_key": "your-api-key",
       "base_url": "https://api.anthropic.com",
-      "default_model": "claude-sonnet-4-20250514"
+      "default_model": "claude-sonnet-4-6"
     },
     "openai": {
       "api_key": "your-api-key",
       "base_url": "https://api.openai.com/v1",
-      "default_model": "gpt-4"
+      "default_model": "gpt-5.4"
     },
     "zai": {
       "api_key": "your-api-key",
       "base_url": "https://api.z.ai/api/coding/paas/v4",
       "default_model": "glm-5.2"
+    },
+    "minimax": {
+      "api_key": "your-api-key",
+      "base_url": "https://api.minimaxi.com/anthropic",
+      "default_model": "MiniMax-M2.7"
+    },
+    "openrouter": {
+      "api_key": "your-api-key",
+      "base_url": "https://openrouter.ai/api/v1",
+      "default_model": "deepseek/deepseek-v4-pro"
+    },
+    "deepseek": {
+      "api_key": "your-api-key",
+      "base_url": "https://api.deepseek.com",
+      "default_model": "deepseek-v4-pro"
     }
+  },
+  "session": {
+    "auto_save": true,
+    "max_history": 100
+  },
+  "settings": {
+    "advisor_enabled": false,
+    "advisor_model": "claude-sonnet-4-6",
+    "advisor_client_mode": false,
+    "advisor_provider": "openai"
+  },
+  "env": {
+    "TAVILY_API_KEY": "tvly-YOUR-TAVILY-API-KEY"
   }
 }
 ```

--- a/docs/i18n/README_ZH.md
+++ b/docs/i18n/README_ZH.md
@@ -41,12 +41,12 @@ python -m src.cli --dangerously-skip-permissions   # 启动 REPL
 
 ```json
 {
-  "default_provider": "zai",
+  "default_provider": "deepseek",
   "providers": {
-    "zai": {
+    "deepseek": {
       "api_key": "xxx-xxx",
-      "base_url": "https://api.z.ai/api/coding/paas/v4",
-      "default_model": "glm-5.2"
+      "base_url": "https://api.deepseek.com",
+      "default_model": "deepseek-v4-pro"
     }
   },
   "env": {


### PR DESCRIPTION
## Summary

Positions **DeepSeek** as ClawCodex's focus provider/model across every README and surfaces its token-efficiency story.

- **News (English):** new entry for the DeepSeek prefix-cache exploitation feature (#363) + the tool-arg-recovery follow-up (#364), emphasizing the token economics — Claude Fable 5 at **\$10/\$50** per Mtok vs **DeepSeek-V4-Pro \$0.435/\$0.87**, and **~\$0.0435/M** on cache-hit input (~**230×** cheaper than Fable 5 input) for long sessions.
- **Quick Install (all 7 READMEs):** minimal config now defaults to `deepseek` (`api.deepseek.com` / `deepseek-v4-pro`).
- **i18n Configure (AR/FR/HI/PT/RU):** `default_provider` → `deepseek` and refreshed to match the English README — all **6 providers**, current model IDs (`claude-sonnet-4-6`, `gpt-5.4`), plus `session`/`settings`/`env` blocks. Stale IDs (`claude-sonnet-4-20250514`, `gpt-4`) removed.
- **i18n interactive-login list:** expanded from `anthropic / openai / zai` to all six providers.

## Scope notes

- English & ZH **Configure** examples intentionally still default to `anthropic` (canonical full-structure reference). Quick Install in those files already defaults to `deepseek`. Happy to flip the English/ZH Configure default to `deepseek` too if we want DeepSeek end-to-end.

## Verification

- Every \`\`\`json block across all 7 READMEs parses cleanly (validated with `json.loads`).
- No stale model IDs remain.

| Section | English / ZH | AR / FR / HI / PT / RU |
|---|---|---|
| Quick Install (minimal) | `deepseek` | `deepseek` |
| Configure (full structure) | `anthropic` (6 providers) | `deepseek` (6 providers) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)