### PR TITLE
docs(readme): default the Configure example to DeepSeek (EN + ZH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ The configuration file is saved in `~/.clawcodex/config.json`. Example structure
 
 ```json
 {
-  "default_provider": "anthropic",
+  "default_provider": "deepseek",
   "providers": {
     "anthropic": {
       "api_key": "your-api-key",

--- a/docs/i18n/README_ZH.md
+++ b/docs/i18n/README_ZH.md
@@ -297,7 +297,7 @@ clawcodex login
 
 ```json
 {
-  "default_provider": "anthropic",
+  "default_provider": "deepseek",
   "providers": {
     "anthropic": {
       "api_key": "your-api-key",


### PR DESCRIPTION
Quick Install already defaults to deepseek (merged in #365); flip the full-structure Configure example to match so every README defaults to DeepSeek end-to-end. The example still lists all six providers — only default_provider changes (anthropic -> deepseek) in README.md and docs/i18n/README_ZH.md.