### PR TITLE
docs(readme): add big DeepSeek prefix-cache headline above Quick Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@
 
 ***
 
+<div align="center">
+
+# 🐋🔥 DeepSeek Prefix Cache
+
+# Run long agentic coding sessions for *pennies*
+
+### Cache-hit input bills at **`~$0.0435` / 1M tokens** — about **230× cheaper** than Claude Fable 5 (`$10` / 1M).
+
+ClawCodex keeps your request prefix **byte-stable**, so DeepSeek's prompt cache covers your whole
+`system + tools + history` span across turns. **The longer you code, the more you save.**
+
+</div>
+
+***
+
 ## ⚡ Quick Install
 
 ```bash


### PR DESCRIPTION
Centered H1 banner spotlighting the DeepSeek prefix-cache token-efficiency story (cache-hit input ~$0.0435/1M, ~230x cheaper than Claude Fable 5), placed just before Quick Install. H1 is the largest text GitHub renders for Markdown — style/font tags are stripped by its sanitizer.