### PR TITLE
feat(providers): add 18 OpenAI-compatible LLM providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,23 @@ Explain the code in $path. Start with an analogy, then draw a diagram.
 ClawCodex’s main advantage is **multi-provider support**: while Claude Code targets **Claude** models, we aim to support **every major LLM provider** behind the same agent runtime—so you can swap vendors, regions, and price tiers without giving up tools, skills, or the coding loop. That flexibility is what makes agentic coding practical at scale.
 
 ```python
-providers = ["anthropic", "openai", "zai", "minimax", "openrouter", "deepseek"]  # OpenAI-compatible & GLM APIs; more can be added
+providers = [
+    # Native / bespoke wire formats
+    "anthropic", "minimax", "deepseek", "zai", "openrouter", "openai", "gemini",
+    # OpenAI-compatible vendors (ported from CodeWhale's provider registry)
+    "nvidia-nim", "atlascloud", "wanjie-ark", "volcengine", "xiaomi-mimo",
+    "novita", "fireworks", "siliconflow", "siliconflow-cn", "arcee", "moonshot",
+    "huggingface", "together", "stepfun", "deepinfra",
+    # Local servers (no API key required)
+    "ollama", "vllm", "sglang",
+]  # 25 providers; aliases like `nim`, `kimi`, `hf` resolve automatically
 ```
+
+Any new OpenAI-compatible vendor is a one-row addition to
+`src/providers/openai_compatible_specs.py` (base URL + default model + API-key
+env vars). API keys resolve from config **or** the provider's standard env var
+(e.g. `TOGETHER_API_KEY`, `MOONSHOT_API_KEY`), so most providers work without
+editing `config.json`.
 
 ### Interactive REPL (default) and Textual TUI (opt-in)
 
@@ -239,7 +254,7 @@ clawcodex --allow-dangerously-skip-permissions         # allow /permission-mode 
 |--------|--------|-------------|
 | CLI Entry | ✅ | `clawcodex`, `login`, `config`, `-p` / `--print`, `--tui`, `--stream`, `--version` |
 | Interactive REPL | ✅ | Default inline REPL; optional Textual TUI; history, tab completion, multiline |
-| Multi-Provider | ✅ | Anthropic, OpenAI, Z.ai GLM, Minimax, OpenRouter, DeepSeek — including Anthropic→OpenAI image / document block translation for vision-capable OpenAI-compat backends |
+| Multi-Provider | ✅ | 25 providers — Anthropic, OpenAI, Gemini, Z.ai GLM, Minimax, OpenRouter, DeepSeek, plus a CodeWhale-parity OpenAI-compatible registry (NVIDIA NIM, Together, Novita, Fireworks, SiliconFlow, Moonshot/Kimi, DeepInfra, Hugging Face, Volcengine, StepFun, Arcee, AtlasCloud, Xiaomi MiMo, Wanjie Ark) and local servers (Ollama, vLLM, SGLang). Anthropic→OpenAI image / document block translation for vision-capable OpenAI-compat backends; per-provider API-key env-var fallback |
 | Session Persistence | ✅ | Save/load sessions locally |
 | Agent Loop | ✅ | Tool calling loop with streaming and headless mode |
 | Skill System | ✅ | SKILL.md-based slash-command skills with args + tool limits |
@@ -304,7 +319,7 @@ clawcodex login
 
 This flow will:
 
-1. ask you to choose a provider: anthropic / openai / zai / minimax / openrouter / deepseek
+1. ask you to choose a provider: anthropic / openai / gemini / zai / minimax / openrouter / deepseek, or any OpenAI-compatible vendor (together, novita, fireworks, moonshot, nvidia-nim, siliconflow, deepinfra, huggingface, …) and local servers (ollama / vllm / sglang)
 2. ask for that provider's API key
 3. optionally save a custom base URL
 4. optionally save a default model
@@ -521,7 +536,7 @@ clawcodex/
 │   ├── entrypoints/        # Headless (-p) and TUI bootstraps
 │   ├── repl/               # Inline REPL (prompt_toolkit + Rich)
 │   ├── tui/                # Textual UI (--tui, /tui)
-│   ├── providers/          # Anthropic, OpenAI, GLM, Minimax, OpenRouter, DeepSeek
+│   ├── providers/          # Anthropic, OpenAI, Gemini, Z.ai GLM, Minimax, OpenRouter, DeepSeek + OpenAI-compatible registry (openai_compatible_specs.py)
 │   ├── agent/              # Conversation, session, prompts
 │   ├── tool_system/        # Agent loop, tools, schemas
 │   ├── skills/             # SKILL.md loading and skill tool

--- a/docs/i18n/README_AR.md
+++ b/docs/i18n/README_AR.md
@@ -72,7 +72,16 @@
 ### دعم متعدد المزودين
 
 ```python
-providers = ["Anthropic Claude", "OpenAI GPT", "Z.ai GLM"]  # + سهل التوسيع
+providers = [
+    # بروتوكولات أصلية / مخصصة
+    "anthropic", "minimax", "deepseek", "zai", "openrouter", "openai", "gemini",
+    # مزودون متوافقون مع OpenAI (منقولون من سجل CodeWhale)
+    "nvidia-nim", "atlascloud", "wanjie-ark", "volcengine", "xiaomi-mimo",
+    "novita", "fireworks", "siliconflow", "siliconflow-cn", "arcee", "moonshot",
+    "huggingface", "together", "stepfun", "deepinfra",
+    # خوادم محلية (لا تتطلب مفتاح API)
+    "ollama", "vllm", "sglang",
+]  # 25 مزوداً؛ الأسماء المستعارة مثل nim و kimi و hf تُحلّ تلقائياً
 ```
 
 ### REPL تفاعلي

--- a/docs/i18n/README_FR.md
+++ b/docs/i18n/README_FR.md
@@ -72,7 +72,16 @@
 ### Support multi-fournisseurs
 
 ```python
-providers = ["Anthropic Claude", "OpenAI GPT", "Z.ai GLM"]  # + facile à étendre
+providers = [
+    # Protocoles natifs / spécifiques
+    "anthropic", "minimax", "deepseek", "zai", "openrouter", "openai", "gemini",
+    # Fournisseurs compatibles OpenAI (portés du registre de CodeWhale)
+    "nvidia-nim", "atlascloud", "wanjie-ark", "volcengine", "xiaomi-mimo",
+    "novita", "fireworks", "siliconflow", "siliconflow-cn", "arcee", "moonshot",
+    "huggingface", "together", "stepfun", "deepinfra",
+    # Serveurs locaux (aucune clé API requise)
+    "ollama", "vllm", "sglang",
+]  # 25 fournisseurs ; les alias comme nim, kimi, hf sont résolus automatiquement
 ```
 
 ### REPL interactif

--- a/docs/i18n/README_HI.md
+++ b/docs/i18n/README_HI.md
@@ -72,7 +72,16 @@
 ### बहु-प्रदाता समर्थन
 
 ```python
-providers = ["Anthropic Claude", "OpenAI GPT", "Z.ai GLM"]  # + आसानी से विस्तारणीय
+providers = [
+    # नेटिव / विशिष्ट प्रोटोकॉल
+    "anthropic", "minimax", "deepseek", "zai", "openrouter", "openai", "gemini",
+    # OpenAI-संगत प्रदाता (CodeWhale की रजिस्ट्री से पोर्ट किए गए)
+    "nvidia-nim", "atlascloud", "wanjie-ark", "volcengine", "xiaomi-mimo",
+    "novita", "fireworks", "siliconflow", "siliconflow-cn", "arcee", "moonshot",
+    "huggingface", "together", "stepfun", "deepinfra",
+    # लोकल सर्वर (कोई API key आवश्यक नहीं)
+    "ollama", "vllm", "sglang",
+]  # 25 प्रदाता; nim, kimi, hf जैसे उपनाम स्वतः हल हो जाते हैं
 ```
 
 ### इंटरैक्टिव REPL

--- a/docs/i18n/README_PT.md
+++ b/docs/i18n/README_PT.md
@@ -72,7 +72,16 @@
 ### Suporte Multi-Provedor
 
 ```python
-providers = ["Anthropic Claude", "OpenAI GPT", "Z.ai GLM"]  # + fácil de estender
+providers = [
+    # Protocolos nativos / específicos
+    "anthropic", "minimax", "deepseek", "zai", "openrouter", "openai", "gemini",
+    # Provedores compatíveis com OpenAI (portados do registro do CodeWhale)
+    "nvidia-nim", "atlascloud", "wanjie-ark", "volcengine", "xiaomi-mimo",
+    "novita", "fireworks", "siliconflow", "siliconflow-cn", "arcee", "moonshot",
+    "huggingface", "together", "stepfun", "deepinfra",
+    # Servidores locais (nenhuma chave de API necessária)
+    "ollama", "vllm", "sglang",
+]  # 25 provedores; aliases como nim, kimi, hf são resolvidos automaticamente
 ```
 
 ### REPL Interativo

--- a/docs/i18n/README_RU.md
+++ b/docs/i18n/README_RU.md
@@ -72,7 +72,16 @@
 ### Поддержка нескольких провайдеров
 
 ```python
-providers = ["Anthropic Claude", "OpenAI GPT", "Z.ai GLM"]  # + легко расширить
+providers = [
+    # Нативные / специфичные протоколы
+    "anthropic", "minimax", "deepseek", "zai", "openrouter", "openai", "gemini",
+    # OpenAI-совместимые провайдеры (перенесены из реестра CodeWhale)
+    "nvidia-nim", "atlascloud", "wanjie-ark", "volcengine", "xiaomi-mimo",
+    "novita", "fireworks", "siliconflow", "siliconflow-cn", "arcee", "moonshot",
+    "huggingface", "together", "stepfun", "deepinfra",
+    # Локальные серверы (ключ API не требуется)
+    "ollama", "vllm", "sglang",
+]  # 25 провайдеров; псевдонимы вроде nim, kimi, hf разрешаются автоматически
 ```
 
 ### Интерактивный REPL

--- a/docs/i18n/README_ZH.md
+++ b/docs/i18n/README_ZH.md
@@ -154,8 +154,22 @@ arguments: [path]
 ClawCodex 的核心优势是**多提供商支持**：Claude Code 以 **Claude** 系列模型为目标，而我们希望在同一套 Agent 运行时之上支持**所有主流 LLM 提供商**——你可以自由切换厂商、区域与价位，而不必放弃工具、技能与编码闭环。正是这种灵活性，让 agentic 编程在规模化使用时真正可行。
 
 ```python
-providers = ["anthropic", "openai", "zai", "minimax", "openrouter", "deepseek"]  # OpenAI 兼容与 GLM API；可继续扩展
+providers = [
+    # 原生 / 专用协议
+    "anthropic", "minimax", "deepseek", "zai", "openrouter", "openai", "gemini",
+    # OpenAI 兼容厂商（移植自 CodeWhale 的 provider 注册表）
+    "nvidia-nim", "atlascloud", "wanjie-ark", "volcengine", "xiaomi-mimo",
+    "novita", "fireworks", "siliconflow", "siliconflow-cn", "arcee", "moonshot",
+    "huggingface", "together", "stepfun", "deepinfra",
+    # 本地服务（无需 API Key）
+    "ollama", "vllm", "sglang",
+]  # 共 25 个 provider；nim、kimi、hf 等别名自动解析
 ```
+
+新增任意 OpenAI 兼容厂商，只需在 `src/providers/openai_compatible_specs.py`
+中加一行（base URL + 默认模型 + API Key 环境变量）。API Key 既可来自配置文件，
+也可来自该 provider 的标准环境变量（如 `TOGETHER_API_KEY`、`MOONSHOT_API_KEY`），
+因此大多数 provider 无需手动编辑 `config.json` 即可使用。
 
 ### 交互式 REPL（默认）与 Textual TUI（可选）
 
@@ -222,7 +236,7 @@ clawcodex --allow-dangerously-skip-permissions         # 允许之后通过 /per
 |------|------|------|
 | CLI 入口 | ✅ | `clawcodex`、`login`、`config`、`-p` / `--print`、`--tui`、`--stream`、`--version` |
 | 交互式 REPL | ✅ | 默认行内 REPL；可选 Textual TUI；历史、Tab 补全、多行输入 |
-| 多提供商支持 | ✅ | Anthropic、OpenAI、智谱 GLM、Minimax、OpenRouter、DeepSeek——含 Anthropic→OpenAI 的 image / document 块转换，适配具备视觉能力的 OpenAI 兼容后端 |
+| 多提供商支持 | ✅ | 25 个 provider —— Anthropic、OpenAI、Gemini、智谱 GLM、Minimax、OpenRouter、DeepSeek，外加与 CodeWhale 对齐的 OpenAI 兼容注册表（NVIDIA NIM、Together、Novita、Fireworks、SiliconFlow、Moonshot/Kimi、DeepInfra、Hugging Face、火山引擎、StepFun、Arcee、AtlasCloud、小米 MiMo、万捷 Ark）以及本地服务（Ollama、vLLM、SGLang）。含 Anthropic→OpenAI 的 image / document 块转换，适配具备视觉能力的 OpenAI 兼容后端；每个 provider 均支持 API Key 环境变量回退 |
 | 会话持久化 | ✅ | 本地保存/加载会话 |
 | Agent Loop | ✅ | 工具调用循环；支持流式与无头模式 |
 | Skill 系统 | ✅ | 基于 SKILL.md 的斜杠技能：参数与工具白名单 |
@@ -287,7 +301,7 @@ clawcodex login
 
 这个流程会：
 
-1. 让你选择 provider：anthropic / openai / zai / minimax / openrouter / deepseek
+1. 让你选择 provider：anthropic / openai / gemini / zai / minimax / openrouter / deepseek，或任意 OpenAI 兼容厂商（together、novita、fireworks、moonshot、nvidia-nim、siliconflow、deepinfra、huggingface 等）以及本地服务（ollama / vllm / sglang）
 2. 让你输入该 provider 的 API key
 3. 可选：保存自定义 base URL
 4. 可选：保存默认 model
@@ -500,7 +514,7 @@ clawcodex/
 │   ├── entrypoints/        # 无头（-p）与 TUI 启动
 │   ├── repl/               # 行内 REPL（prompt_toolkit + Rich）
 │   ├── tui/                # Textual UI（--tui、/tui）
-│   ├── providers/          # Anthropic、OpenAI、GLM、Minimax、OpenRouter、DeepSeek
+│   ├── providers/          # Anthropic、OpenAI、Gemini、智谱 GLM、Minimax、OpenRouter、DeepSeek + OpenAI 兼容注册表（openai_compatible_specs.py）
 │   ├── agent/              # 对话、会话、提示词
 │   ├── tool_system/        # Agent loop、工具与 schema
 │   ├── skills/             # SKILL.md 加载与 Skill 工具

--- a/src/config.py
+++ b/src/config.py
@@ -409,12 +409,27 @@ def save_config(config: dict[str, Any]) -> None:
 
 
 def get_provider_config(provider: str) -> dict[str, Any]:
-    """Get configuration for a specific provider."""
+    """Get configuration for a specific provider.
+
+    The literal ``provider`` key is tried first, so a pre-rename block such as
+    ``[providers.glm]`` still resolves by its own key. When the literal name is
+    absent, fall back to the canonical id so an alias (``nim`` -> ``nvidia-nim``,
+    ``glm`` -> ``zai``, ``kimi`` -> ``moonshot`` …) passed via ``--provider``
+    resolves to the provider's default config block.
+    """
     config = load_config()
     providers = config.get("providers", {})
-    if provider not in providers:
-        raise ValueError(f"Unknown provider: {provider}")
-    return providers[provider]
+    if provider in providers:
+        return providers[provider]
+    try:
+        from src.providers import canonical_provider_name
+
+        canonical = canonical_provider_name(provider)
+    except Exception:
+        canonical = provider
+    if canonical != provider and canonical in providers:
+        return providers[canonical]
+    raise ValueError(f"Unknown provider: {provider}")
 
 
 def set_api_key(

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -49,7 +49,11 @@ from src.cli_core import (
     ndjson_safe_dumps,
 )
 from src.config import get_default_provider, get_provider_config
-from src.providers import get_provider_class
+from src.providers import (
+    get_provider_class,
+    provider_requires_api_key,
+    resolve_api_key,
+)
 from src.tool_system.renderers import AgentLoopResult, ToolEvent
 from src.query.agent_loop_compat import (
     build_effective_system_prompt,
@@ -140,7 +144,11 @@ def run_headless(options: HeadlessOptions) -> int:
         provider_cfg = get_provider_config(provider_name)
     except Exception as exc:
         cli_error(f"error: unable to load provider config: {exc}", 2)
-    if not provider_cfg.get("api_key"):
+    # Config api_key wins; fall back to the provider's known env vars (e.g.
+    # ``DEEPSEEK_API_KEY``) so a freshly-added provider works without ``login``.
+    # Local providers (Ollama / vLLM / SGLang) need no key.
+    api_key = resolve_api_key(provider_name, provider_cfg)
+    if not api_key and provider_requires_api_key(provider_name):
         cli_error(
             f"error: API key for provider '{provider_name}' is not configured. "
             "Run `clawcodex login` to set it up.",
@@ -150,7 +158,7 @@ def run_headless(options: HeadlessOptions) -> int:
     provider_cls = get_provider_class(provider_name)
     model = options.model or provider_cfg.get("default_model")
     provider = provider_cls(
-        api_key=provider_cfg["api_key"],
+        api_key=api_key,
         base_url=provider_cfg.get("base_url"),
         model=model,
     )

--- a/src/entrypoints/tui.py
+++ b/src/entrypoints/tui.py
@@ -21,7 +21,11 @@ from typing import Callable
 
 from src.cli_core.exit import cli_error
 from src.config import get_default_provider, get_provider_config
-from src.providers import get_provider_class
+from src.providers import (
+    get_provider_class,
+    provider_requires_api_key,
+    resolve_api_key,
+)
 
 
 @dataclass
@@ -83,7 +87,11 @@ def run_tui(options: TUIOptions) -> int:
             provider_cfg = get_provider_config(provider_name)
         except Exception as exc:
             cli_error(f"error: unable to load provider config: {exc}", 2)
-        if not provider_cfg.get("api_key"):
+        # Config api_key wins; fall back to the provider's known env vars so a
+        # freshly-added provider works without ``login``. Local providers
+        # (Ollama / vLLM / SGLang) need no key.
+        api_key = resolve_api_key(provider_name, provider_cfg)
+        if not api_key and provider_requires_api_key(provider_name):
             cli_error(
                 f"error: API key for provider '{provider_name}' is not configured. "
                 "Run `clawcodex login` to set it up.",
@@ -92,7 +100,7 @@ def run_tui(options: TUIOptions) -> int:
         provider_cls = get_provider_class(provider_name)
         model = options.model or provider_cfg.get("default_model")
         provider = provider_cls(
-            api_key=provider_cfg["api_key"],
+            api_key=api_key,
             base_url=provider_cfg.get("base_url"),
             model=model,
         )

--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from .base import BaseProvider, ChatMessage, ChatResponse
 
@@ -163,6 +163,26 @@ PROVIDER_INFO: dict[str, ProviderInfo] = {
 }
 
 
+# --- Data-driven OpenAI-compatible providers (CodeWhale parity) ------------
+# The bulk of LLM vendors speak the OpenAI ``/chat/completions`` wire format and
+# differ only in base URL / default model / API-key env vars. Those live in a
+# spec registry (``src/providers/openai_compatible_specs.py``, ported from
+# CodeWhale's ``crates/config/src/provider.rs``) and are merged in here so they
+# appear in ``login``, default config, model pickers, and the defaults table
+# exactly like the hand-written providers. Hand-written entries above win on any
+# id collision (there are none today — the registry holds only the providers
+# ClawCodex previously lacked).
+from .openai_compatible_specs import (  # noqa: E402
+    SPECS_BY_ID as _SPECS_BY_ID,
+    build_provider_class as _build_spec_provider_class,
+    spec_aliases as _spec_aliases,
+    spec_provider_info as _spec_provider_info,
+)
+
+for _spec_id, _spec_info in _spec_provider_info().items():
+    PROVIDER_INFO.setdefault(_spec_id, _spec_info)  # type: ignore[arg-type]
+
+
 # Legacy / alternate provider names accepted during resolution. ``glm`` is the
 # pre-rename id for Z.ai (Zhipu rebranded as z.ai); ``z-ai`` / ``z_ai`` /
 # ``z.ai`` mirror CodeWhale's accepted spellings. Aliases are normalized in
@@ -176,10 +196,26 @@ PROVIDER_ALIASES: dict[str, str] = {
     "z.ai": "zai",
 }
 
+# Merge registry aliases (e.g. ``nim`` -> ``nvidia-nim``, ``kimi`` ->
+# ``moonshot``). Literal entries above win on collision.
+for _alias, _canonical in _spec_aliases().items():
+    PROVIDER_ALIASES.setdefault(_alias, _canonical)
+
 
 def _canonical_provider_name(provider_name: str) -> str:
     """Resolve a legacy/alternate provider spelling to its canonical id."""
     return PROVIDER_ALIASES.get(provider_name, provider_name)
+
+
+def canonical_provider_name(provider_name: str) -> str:
+    """Public alias for :func:`_canonical_provider_name`.
+
+    Resolves a legacy/alternate spelling (``glm``, ``z.ai``, ``nim``,
+    ``kimi`` …) to its canonical provider id. Used by ``src.config`` so
+    ``--provider <alias>`` resolves a config block, and by the entrypoints'
+    API-key resolution.
+    """
+    return _canonical_provider_name(provider_name)
 
 
 def get_provider_info(provider_name: str) -> ProviderInfo:
@@ -221,7 +257,83 @@ def get_provider_class(provider_name: str):
         from .gemini_provider import GeminiProvider
 
         return GeminiProvider
+    # Data-driven OpenAI-compatible providers (nvidia-nim, together, novita,
+    # moonshot, ollama, …). The class is synthesized from the provider's spec.
+    if provider_name in _SPECS_BY_ID:
+        return _build_spec_provider_class(provider_name)
     raise ValueError(f"Unknown provider: {provider_name}")
+
+
+# API-key env-var candidates for the hand-written providers. The registry
+# providers carry their own ``env_vars`` (see ``openai_compatible_specs``);
+# these cover the classes that predate the registry so env-var resolution
+# (:func:`resolve_api_key`) is uniform across every provider. Mirrors
+# CodeWhale's per-provider ``env_vars`` lists.
+_BUILTIN_ENV_VARS: dict[str, tuple[str, ...]] = {
+    "anthropic": ("ANTHROPIC_API_KEY",),
+    "openai": ("OPENAI_API_KEY",),
+    "deepseek": ("DEEPSEEK_API_KEY",),
+    "openrouter": ("OPENROUTER_API_KEY",),
+    "zai": ("ZAI_API_KEY", "Z_AI_API_KEY"),
+    "minimax": ("MINIMAX_API_KEY",),
+    "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+}
+
+
+def provider_env_vars(provider_name: str) -> tuple[str, ...]:
+    """API-key environment-variable candidates for a provider (highest first)."""
+    canonical = _canonical_provider_name(provider_name)
+    if canonical in _BUILTIN_ENV_VARS:
+        return _BUILTIN_ENV_VARS[canonical]
+    spec = _SPECS_BY_ID.get(canonical)
+    return spec.env_vars if spec else ()
+
+
+def provider_requires_api_key(provider_name: str) -> bool:
+    """Whether a provider needs an API key.
+
+    ``False`` for local servers (Ollama / vLLM / SGLang) that accept any/no
+    token, so they stay usable without running ``login``. Every other provider
+    requires a key.
+    """
+    canonical = _canonical_provider_name(provider_name)
+    spec = _SPECS_BY_ID.get(canonical)
+    return spec.requires_api_key if spec else True
+
+
+def resolve_api_key(
+    provider_name: str, provider_cfg: dict[str, Any] | None = None
+) -> str:
+    """Resolve a provider's API key: configured value first, then env vars.
+
+    The configured ``providers.<name>.api_key`` always wins. When it is empty
+    (the common case for a freshly-added provider the user hasn't run ``login``
+    for), fall back to the provider's known env-var candidates via
+    :func:`src.secret_store.get_secret` — which itself checks the real process
+    environment, then the global config ``env`` block. This makes every
+    provider, including the registry additions, usable by simply exporting e.g.
+    ``TOGETHER_API_KEY`` (CodeWhale parity) without hand-editing ``config.json``.
+
+    Returns ``""`` when no key is found; callers gate fatality on
+    :func:`provider_requires_api_key`.
+    """
+    if provider_cfg is None:
+        try:
+            from src.config import get_provider_config
+
+            provider_cfg = get_provider_config(provider_name)
+        except Exception:
+            provider_cfg = {}
+    configured = (provider_cfg or {}).get("api_key")
+    if isinstance(configured, str) and configured.strip():
+        return configured
+    from src.secret_store import get_secret
+
+    for env_name in provider_env_vars(provider_name):
+        value = get_secret(env_name)
+        if value and value.strip():
+            return value
+    return ""
 
 
 # Legacy registry for display purposes
@@ -234,6 +346,11 @@ __all__ = [
     "ChatResponse",
     "get_provider_class",
     "get_provider_info",
+    "canonical_provider_name",
+    "provider_env_vars",
+    "provider_requires_api_key",
+    "resolve_api_key",
     "PROVIDER_INFO",
+    "PROVIDER_ALIASES",
     "AVAILABLE_PROVIDERS",
 ]

--- a/src/providers/openai_compatible_specs.py
+++ b/src/providers/openai_compatible_specs.py
@@ -1,0 +1,431 @@
+"""Data-driven registry of OpenAI-compatible LLM providers.
+
+Most LLM vendors expose an OpenAI-style ``/v1/chat/completions`` API, so they
+differ only in their default base URL, default model, accepted API-key env
+vars, and display label — not in request/response handling. Rather than ship a
+near-identical hand-written class per vendor, this module captures that
+metadata as :class:`ProviderSpec` rows and synthesizes a concrete
+:class:`~src.providers.openai_compatible.OpenAICompatibleProvider` subclass for
+each one on demand.
+
+This mirrors the CodeWhale reference's ``crates/config/src/provider.rs``
+registry (the ``provider!`` macro table), porting the providers CodeWhale
+supports that ClawCodex previously lacked. Base URLs, default models, env-var
+candidates, and aliases are copied verbatim from CodeWhale's
+``crates/config/src/lib.rs`` constants so a user migrating between the two sees
+identical behaviour.
+
+Providers with bespoke behaviour are intentionally NOT in this table and keep
+their hand-written classes:
+
+* ``anthropic`` / ``minimax`` — native Anthropic Messages wire format.
+* ``deepseek`` — prompt-prefix-cache usage re-mapping (``is_deepseek``).
+* ``zai`` — GLM model-id canonicalization.
+* ``openrouter`` — optional ranking/attribution headers.
+* ``openai`` / ``gemini`` — kept as explicit classes (stable test import paths).
+
+CodeWhale's ``openai-codex`` provider is also intentionally excluded: it speaks
+the OpenAI *Responses* API over a ChatGPT OAuth token, which is a separate wire
+format ClawCodex's OpenAI-compatible layer does not implement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, ClassVar, Optional
+
+try:
+    from openai import OpenAI  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    OpenAI = None
+
+from .openai_compatible import OpenAICompatibleProvider
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    """Static metadata describing one OpenAI-compatible provider.
+
+    Mirrors a row of CodeWhale's ``provider!`` macro table.
+    """
+
+    #: Canonical provider id — the value users pass to ``--provider`` and the
+    #: key under ``config.json`` ``providers.<id>``. Lowercase, hyphenated.
+    id: str
+    #: Human-readable label for login prompts / tables.
+    label: str
+    #: Default API base URL when config/CLI supplies none.
+    default_base_url: str
+    #: Default model when config/CLI supplies none.
+    default_model: str
+    #: Models surfaced in the login flow / pickers. Free-text model ids are
+    #: always accepted regardless of this list; it is a convenience only.
+    available_models: tuple[str, ...]
+    #: API-key environment-variable candidates, highest precedence first.
+    #: Used by ``src.providers.resolve_api_key`` to source a key when the
+    #: provider's ``config.json`` ``api_key`` is empty (CodeWhale parity).
+    env_vars: tuple[str, ...]
+    #: Alternate spellings accepted during provider resolution.
+    aliases: tuple[str, ...] = ()
+    #: Whether a key is mandatory. ``False`` for local servers (Ollama, vLLM,
+    #: SGLang) that accept any/no token — these stay usable without ``login``.
+    requires_api_key: bool = True
+    #: Generated subclass name (for repr / debugging). Derived from ``id`` when
+    #: omitted.
+    class_name: str = ""
+
+    def resolved_class_name(self) -> str:
+        if self.class_name:
+            return self.class_name
+        parts = [p for p in self.id.replace("-", "_").split("_") if p]
+        return "".join(p.capitalize() for p in parts) + "Provider"
+
+
+# DeepSeek model ids served by the various OpenAI-compatible gateways, in the
+# id spelling each gateway expects. CodeWhale defaults most of these providers
+# to DeepSeek models (it is DeepSeek-focused, as is ClawCodex), so the defaults
+# below match CodeWhale's ``crates/config/src/lib.rs`` constants exactly.
+_SPECS: tuple[ProviderSpec, ...] = (
+    ProviderSpec(
+        id="nvidia-nim",
+        label="NVIDIA NIM",
+        default_base_url="https://integrate.api.nvidia.com/v1",
+        default_model="deepseek-ai/deepseek-v4-pro",
+        available_models=(
+            "deepseek-ai/deepseek-v4-pro",
+            "deepseek-ai/deepseek-v4-flash",
+        ),
+        env_vars=("NVIDIA_API_KEY", "NVIDIA_NIM_API_KEY", "DEEPSEEK_API_KEY"),
+        aliases=("nvidia", "nvidia_nim", "nim"),
+    ),
+    ProviderSpec(
+        id="atlascloud",
+        label="AtlasCloud",
+        default_base_url="https://api.atlascloud.ai/v1",
+        default_model="deepseek-ai/deepseek-v4-flash",
+        available_models=(
+            "deepseek-ai/deepseek-v4-flash",
+            "deepseek-ai/deepseek-v4-pro",
+        ),
+        env_vars=("ATLASCLOUD_API_KEY",),
+        aliases=("atlas-cloud", "atlas_cloud", "atlas"),
+    ),
+    ProviderSpec(
+        id="wanjie-ark",
+        label="Wanjie Ark",
+        default_base_url="https://maas-openapi.wanjiedata.com/api/v1",
+        default_model="deepseek-reasoner",
+        available_models=("deepseek-reasoner", "deepseek-chat"),
+        env_vars=("WANJIE_ARK_API_KEY", "WANJIE_API_KEY", "WANJIE_MAAS_API_KEY"),
+        aliases=(
+            "wanjie",
+            "wanjie_ark",
+            "ark-wanjie",
+            "ark_wanjie",
+            "wanjieark",
+            "wanjie-maas",
+            "wanjie_maas",
+            "wanjiemaas",
+        ),
+    ),
+    ProviderSpec(
+        id="volcengine",
+        label="Volcengine Ark",
+        default_base_url="https://ark.cn-beijing.volces.com/api/coding/v3",
+        default_model="DeepSeek-V4-Pro",
+        available_models=("DeepSeek-V4-Pro", "DeepSeek-V4-Flash"),
+        env_vars=("VOLCENGINE_API_KEY", "VOLCENGINE_ARK_API_KEY", "ARK_API_KEY"),
+        aliases=(
+            "volcengine-ark",
+            "volcengine_ark",
+            "ark",
+            "volc-ark",
+            "volcengineark",
+        ),
+    ),
+    ProviderSpec(
+        id="xiaomi-mimo",
+        label="Xiaomi MiMo",
+        default_base_url="https://token-plan-sgp.xiaomimimo.com/v1",
+        default_model="mimo-v2.5-pro",
+        available_models=("mimo-v2.5-pro",),
+        env_vars=(
+            "XIAOMI_MIMO_TOKEN_PLAN_API_KEY",
+            "MIMO_TOKEN_PLAN_API_KEY",
+            "XIAOMI_MIMO_API_KEY",
+            "XIAOMI_API_KEY",
+            "MIMO_API_KEY",
+        ),
+        aliases=("xiaomi_mimo", "xiaomimimo", "mimo", "xiaomi"),
+    ),
+    ProviderSpec(
+        id="novita",
+        label="Novita AI",
+        default_base_url="https://api.novita.ai/openai/v1",
+        default_model="deepseek/deepseek-v4-pro",
+        available_models=(
+            "deepseek/deepseek-v4-pro",
+            "deepseek/deepseek-v4-flash",
+        ),
+        env_vars=("NOVITA_API_KEY",),
+    ),
+    ProviderSpec(
+        id="fireworks",
+        label="Fireworks AI",
+        default_base_url="https://api.fireworks.ai/inference/v1",
+        default_model="accounts/fireworks/models/deepseek-v4-pro",
+        available_models=("accounts/fireworks/models/deepseek-v4-pro",),
+        env_vars=("FIREWORKS_API_KEY",),
+        aliases=("fireworks-ai",),
+    ),
+    ProviderSpec(
+        id="siliconflow",
+        label="SiliconFlow",
+        default_base_url="https://api.siliconflow.com/v1",
+        default_model="deepseek-ai/DeepSeek-V4-Pro",
+        available_models=(
+            "deepseek-ai/DeepSeek-V4-Pro",
+            "deepseek-ai/DeepSeek-V4-Flash",
+        ),
+        env_vars=("SILICONFLOW_API_KEY",),
+        aliases=("silicon-flow", "silicon_flow"),
+    ),
+    ProviderSpec(
+        id="siliconflow-cn",
+        label="SiliconFlow (China)",
+        default_base_url="https://api.siliconflow.cn/v1",
+        default_model="deepseek-ai/DeepSeek-V4-Pro",
+        available_models=(
+            "deepseek-ai/DeepSeek-V4-Pro",
+            "deepseek-ai/DeepSeek-V4-Flash",
+        ),
+        env_vars=("SILICONFLOW_API_KEY",),
+        aliases=(
+            "siliconflow-CN",
+            "silicon-flow-cn",
+            "silicon-flow-CN",
+            "silicon_flow_cn",
+            "silicon_flow_CN",
+            "siliconflow-china",
+        ),
+    ),
+    ProviderSpec(
+        id="arcee",
+        label="Arcee AI",
+        default_base_url="https://api.arcee.ai/api/v1",
+        default_model="trinity-large-thinking",
+        available_models=("trinity-large-thinking",),
+        env_vars=("ARCEE_API_KEY",),
+        aliases=("arcee-ai", "arcee_ai"),
+    ),
+    ProviderSpec(
+        id="moonshot",
+        label="Moonshot / Kimi",
+        default_base_url="https://api.moonshot.ai/v1",
+        default_model="kimi-k2.7-code",
+        available_models=("kimi-k2.7-code",),
+        env_vars=("MOONSHOT_API_KEY", "KIMI_API_KEY"),
+        aliases=("moonshot-ai", "kimi", "kimi-k2"),
+    ),
+    ProviderSpec(
+        id="sglang",
+        label="SGLang (local)",
+        default_base_url="http://localhost:30000/v1",
+        default_model="deepseek-ai/DeepSeek-V4-Pro",
+        available_models=(
+            "deepseek-ai/DeepSeek-V4-Pro",
+            "deepseek-ai/DeepSeek-V4-Flash",
+        ),
+        env_vars=("SGLANG_API_KEY",),
+        aliases=("sg-lang",),
+        requires_api_key=False,
+    ),
+    ProviderSpec(
+        id="vllm",
+        label="vLLM (local)",
+        default_base_url="http://localhost:8000/v1",
+        default_model="deepseek-ai/DeepSeek-V4-Pro",
+        available_models=(
+            "deepseek-ai/DeepSeek-V4-Pro",
+            "deepseek-ai/DeepSeek-V4-Flash",
+        ),
+        env_vars=("VLLM_API_KEY",),
+        aliases=("v-llm",),
+        requires_api_key=False,
+    ),
+    ProviderSpec(
+        id="ollama",
+        label="Ollama (local)",
+        default_base_url="http://localhost:11434/v1",
+        default_model="deepseek-coder:1.3b",
+        available_models=("deepseek-coder:1.3b",),
+        env_vars=("OLLAMA_API_KEY",),
+        aliases=("ollama-local",),
+        requires_api_key=False,
+    ),
+    ProviderSpec(
+        id="huggingface",
+        label="Hugging Face",
+        default_base_url="https://router.huggingface.co/v1",
+        default_model="deepseek-ai/DeepSeek-V4-Pro",
+        available_models=(
+            "deepseek-ai/DeepSeek-V4-Pro",
+            "deepseek-ai/DeepSeek-V4-Flash",
+        ),
+        env_vars=("HUGGINGFACE_API_KEY", "HF_TOKEN"),
+        aliases=("hugging-face", "hugging_face", "hf"),
+    ),
+    ProviderSpec(
+        id="together",
+        label="Together AI",
+        default_base_url="https://api.together.xyz/v1",
+        default_model="deepseek-ai/DeepSeek-V4-Pro",
+        available_models=(
+            "deepseek-ai/DeepSeek-V4-Pro",
+            "deepseek-ai/DeepSeek-V4-Flash",
+        ),
+        env_vars=("TOGETHER_API_KEY",),
+        aliases=("together-ai", "together_ai"),
+    ),
+    ProviderSpec(
+        id="stepfun",
+        label="StepFun / StepFlash",
+        default_base_url="https://api.stepfun.ai/v1",
+        default_model="step-3.7-flash",
+        available_models=("step-3.7-flash",),
+        env_vars=("STEPFUN_API_KEY", "STEP_API_KEY"),
+        aliases=("step-fun", "step_fun", "stepflash", "step-flash", "step_flash"),
+    ),
+    ProviderSpec(
+        id="deepinfra",
+        label="DeepInfra",
+        default_base_url="https://api.deepinfra.com/v1/openai",
+        default_model="deepseek-ai/DeepSeek-V4-Pro",
+        available_models=(
+            "deepseek-ai/DeepSeek-V4-Pro",
+            "deepseek-ai/DeepSeek-V4-Flash",
+        ),
+        env_vars=("DEEPINFRA_API_KEY", "DEEPINFRA_TOKEN"),
+        aliases=("deep-infra", "deep_infra"),
+    ),
+)
+
+
+#: Canonical id -> spec.
+SPECS_BY_ID: dict[str, ProviderSpec] = {spec.id: spec for spec in _SPECS}
+
+
+class _SpecOpenAICompatibleProvider(OpenAICompatibleProvider):
+    """Base for registry-generated providers; ``SPEC`` is set per subclass.
+
+    All request/response handling (message translation, tool-call rebuild,
+    streaming + ESC abort, bounded read timeout) is inherited unchanged from
+    :class:`OpenAICompatibleProvider`; only the SDK client construction and the
+    model list vary, and both read from ``SPEC``.
+    """
+
+    SPEC: ClassVar[ProviderSpec]
+
+    def __init__(
+        self, api_key: str, base_url: Optional[str] = None, model: Optional[str] = None
+    ):
+        spec = self.SPEC
+        super().__init__(
+            api_key,
+            base_url or spec.default_base_url,
+            model or spec.default_model,
+        )
+
+    def _create_client(self) -> Any:
+        """Create an OpenAI SDK client pointed at this provider's base URL.
+
+        Mirrors the hand-written providers (DeepSeek / OpenRouter / Z.ai): the
+        bounded read timeout is applied centrally by
+        ``OpenAICompatibleProvider.client``; the optional ``CLAWCODEX_SSL_VERIFY``
+        bypass is honoured here for corporate/self-hosted endpoints.
+        """
+        if OpenAI is None:  # pragma: no cover
+            raise ModuleNotFoundError(
+                "openai package is not installed. Install optional dependencies "
+                f"to use {type(self).__name__}."
+            )
+        import os
+
+        # Local servers (Ollama / vLLM / SGLang) accept any token; pass a
+        # placeholder rather than letting an empty key fall through to the SDK's
+        # OPENAI_API_KEY env lookup (which would silently target the wrong host).
+        api_key = self.api_key or "EMPTY"
+        kwargs: dict[str, Any] = {
+            "api_key": api_key,
+            "base_url": self.base_url or self.SPEC.default_base_url,
+        }
+        if os.environ.get("CLAWCODEX_SSL_VERIFY", "").lower() in ("0", "false", "no"):
+            import httpx
+
+            kwargs["http_client"] = httpx.Client(verify=False)
+        return OpenAI(**kwargs)
+
+    def get_available_models(self) -> list[str]:
+        return list(self.SPEC.available_models)
+
+
+# Generated subclasses are cached so repeated lookups return the same class
+# object (stable identity for ``is`` checks / isinstance and cheaper repeats).
+_CLASS_CACHE: dict[str, type[_SpecOpenAICompatibleProvider]] = {}
+
+
+def build_provider_class(provider_id: str) -> type[_SpecOpenAICompatibleProvider]:
+    """Return the generated provider class for ``provider_id`` (canonical id).
+
+    Raises ``KeyError`` if ``provider_id`` is not a registry provider.
+    """
+    spec = SPECS_BY_ID[provider_id]
+    cached = _CLASS_CACHE.get(provider_id)
+    if cached is not None:
+        return cached
+    cls = type(
+        spec.resolved_class_name(),
+        (_SpecOpenAICompatibleProvider,),
+        {
+            "SPEC": spec,
+            "DEFAULT_BASE_URL": spec.default_base_url,
+            "DEFAULT_MODEL": spec.default_model,
+            "__doc__": (
+                f"{spec.label} provider (OpenAI-compatible). Generated from "
+                "ProviderSpec; see src/providers/openai_compatible_specs.py."
+            ),
+        },
+    )
+    _CLASS_CACHE[provider_id] = cls
+    return cls
+
+
+def spec_provider_info() -> dict[str, dict[str, Any]]:
+    """Registry rows as ``PROVIDER_INFO``-shaped metadata dicts."""
+    return {
+        spec.id: {
+            "label": spec.label,
+            "default_base_url": spec.default_base_url,
+            "default_model": spec.default_model,
+            "available_models": list(spec.available_models),
+        }
+        for spec in _SPECS
+    }
+
+
+def spec_aliases() -> dict[str, str]:
+    """Alias spelling -> canonical id, for every registry provider."""
+    aliases: dict[str, str] = {}
+    for spec in _SPECS:
+        for alias in spec.aliases:
+            aliases[alias] = spec.id
+    return aliases
+
+
+__all__ = [
+    "ProviderSpec",
+    "SPECS_BY_ID",
+    "build_provider_class",
+    "spec_provider_info",
+    "spec_aliases",
+]

--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -311,7 +311,11 @@ if TYPE_CHECKING:
 from src.agent import Session
 from src.config import get_provider_config
 from src.outputStyles import resolve_output_style
-from src.providers import get_provider_class
+from src.providers import (
+    get_provider_class,
+    provider_requires_api_key,
+    resolve_api_key,
+)
 from src.providers.anthropic_provider import AnthropicProvider
 from src.providers.base import ChatMessage
 from src.providers.minimax_provider import MinimaxProvider
@@ -409,9 +413,12 @@ class ClawcodexREPL:
         self.provider_name = provider_name
         self.stream = stream
 
-        # Load configuration
+        # Load configuration. Config api_key wins; fall back to the provider's
+        # known env vars so a freshly-added provider works without ``login``.
+        # Local providers (Ollama / vLLM / SGLang) need no key.
         config = get_provider_config(provider_name)
-        if not config.get("api_key"):
+        api_key = resolve_api_key(provider_name, config)
+        if not api_key and provider_requires_api_key(provider_name):
             self.console.print("[red]Error: API key not configured.[/red]")
             self.console.print("Run [bold]clawcodex login[/bold] to configure.")
             sys.exit(1)
@@ -419,7 +426,7 @@ class ClawcodexREPL:
         # Initialize provider
         provider_class = get_provider_class(provider_name)
         self.provider = provider_class(
-            api_key=config["api_key"],
+            api_key=api_key,
             base_url=config.get("base_url"),
             model=config.get("default_model")
         )
@@ -3521,13 +3528,13 @@ class ClawcodexREPL:
 
         # Reinitialize provider
         from src.config import get_provider_config
-        from src.providers import get_provider_class
+        from src.providers import get_provider_class, resolve_api_key
 
         config = get_provider_config(provider)
         provider_class = get_provider_class(provider)
 
         self.provider = provider_class(
-            api_key=config["api_key"],
+            api_key=resolve_api_key(provider, config),
             base_url=config.get("base_url"),
             model=config.get("default_model")
         )

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -1,0 +1,230 @@
+"""Tests for the data-driven OpenAI-compatible provider registry.
+
+Covers the providers ported from CodeWhale's ``crates/config/src/provider.rs``
+into ``src/providers/openai_compatible_specs.py``: registry completeness,
+generated-class defaults, alias resolution, API-key env-var fallback, and the
+keyless-local-provider path.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from src.providers import (
+    PROVIDER_INFO,
+    canonical_provider_name,
+    get_provider_class,
+    get_provider_info,
+    provider_env_vars,
+    provider_requires_api_key,
+    resolve_api_key,
+)
+from src.providers.base import ChatMessage
+from src.providers.openai_compatible import OpenAICompatibleProvider
+from src.providers.openai_compatible_specs import (
+    SPECS_BY_ID,
+    build_provider_class,
+)
+
+# The 18 providers ClawCodex previously lacked, ported from CodeWhale.
+EXPECTED_NEW_PROVIDERS = {
+    "nvidia-nim",
+    "atlascloud",
+    "wanjie-ark",
+    "volcengine",
+    "xiaomi-mimo",
+    "novita",
+    "fireworks",
+    "siliconflow",
+    "siliconflow-cn",
+    "arcee",
+    "moonshot",
+    "sglang",
+    "vllm",
+    "ollama",
+    "huggingface",
+    "together",
+    "stepfun",
+    "deepinfra",
+}
+
+# A sample of (id -> (base_url, default_model)) copied verbatim from CodeWhale's
+# ``crates/config/src/lib.rs`` constants — a regression guard that our ports did
+# not drift from the reference.
+CODEWHALE_DEFAULTS = {
+    "nvidia-nim": ("https://integrate.api.nvidia.com/v1", "deepseek-ai/deepseek-v4-pro"),
+    "together": ("https://api.together.xyz/v1", "deepseek-ai/DeepSeek-V4-Pro"),
+    "moonshot": ("https://api.moonshot.ai/v1", "kimi-k2.7-code"),
+    "ollama": ("http://localhost:11434/v1", "deepseek-coder:1.3b"),
+    "deepinfra": ("https://api.deepinfra.com/v1/openai", "deepseek-ai/DeepSeek-V4-Pro"),
+    "stepfun": ("https://api.stepfun.ai/v1", "step-3.7-flash"),
+    "siliconflow-cn": ("https://api.siliconflow.cn/v1", "deepseek-ai/DeepSeek-V4-Pro"),
+}
+
+
+class TestRegistryCompleteness(unittest.TestCase):
+    def test_all_new_providers_registered(self):
+        self.assertEqual(EXPECTED_NEW_PROVIDERS, set(SPECS_BY_ID.keys()))
+
+    def test_new_providers_surface_in_provider_info(self):
+        for pid in EXPECTED_NEW_PROVIDERS:
+            self.assertIn(pid, PROVIDER_INFO, f"{pid} missing from PROVIDER_INFO")
+            info = PROVIDER_INFO[pid]
+            self.assertTrue(info["label"])
+            self.assertTrue(info["default_base_url"])
+            self.assertTrue(info["default_model"])
+            self.assertTrue(info["available_models"])
+
+    def test_defaults_match_codewhale(self):
+        for pid, (base_url, model) in CODEWHALE_DEFAULTS.items():
+            spec = SPECS_BY_ID[pid]
+            self.assertEqual(spec.default_base_url, base_url, pid)
+            self.assertEqual(spec.default_model, model, pid)
+
+    def test_default_model_is_in_available_models(self):
+        for spec in SPECS_BY_ID.values():
+            self.assertIn(spec.default_model, spec.available_models, spec.id)
+
+    def test_hand_written_providers_not_shadowed(self):
+        # The registry must hold only the *new* providers — never override the
+        # bespoke hand-written ones (deepseek cache logic, zai GLM aliasing …).
+        for pid in ("anthropic", "openai", "deepseek", "zai", "minimax", "openrouter", "gemini"):
+            self.assertNotIn(pid, SPECS_BY_ID, f"{pid} should keep its hand-written class")
+
+
+class TestGeneratedClass(unittest.TestCase):
+    def test_build_returns_openai_compatible_subclass(self):
+        cls = build_provider_class("together")
+        self.assertTrue(issubclass(cls, OpenAICompatibleProvider))
+
+    def test_defaults_applied(self):
+        provider = build_provider_class("together")(api_key="k")
+        self.assertEqual(provider.base_url, "https://api.together.xyz/v1")
+        self.assertEqual(provider.model, "deepseek-ai/DeepSeek-V4-Pro")
+
+    def test_explicit_overrides_win(self):
+        provider = build_provider_class("together")(
+            api_key="k", base_url="http://proxy/v1", model="custom-model"
+        )
+        self.assertEqual(provider.base_url, "http://proxy/v1")
+        self.assertEqual(provider.model, "custom-model")
+
+    def test_available_models(self):
+        provider = build_provider_class("nvidia-nim")(api_key="k")
+        self.assertEqual(
+            provider.get_available_models(),
+            ["deepseek-ai/deepseek-v4-pro", "deepseek-ai/deepseek-v4-flash"],
+        )
+
+    def test_class_identity_is_cached(self):
+        self.assertIs(build_provider_class("together"), build_provider_class("together"))
+        self.assertIs(get_provider_class("together"), build_provider_class("together"))
+
+    def test_generated_class_name(self):
+        self.assertEqual(build_provider_class("nvidia-nim").__name__, "NvidiaNimProvider")
+
+
+class TestProviderResolution(unittest.TestCase):
+    def test_get_provider_class_by_canonical_id(self):
+        self.assertEqual(get_provider_class("moonshot").__name__, "MoonshotProvider")
+
+    def test_get_provider_class_via_alias(self):
+        # CodeWhale aliases resolve to the canonical provider class.
+        self.assertIs(get_provider_class("nim"), get_provider_class("nvidia-nim"))
+        self.assertIs(get_provider_class("kimi"), get_provider_class("moonshot"))
+        self.assertIs(get_provider_class("hf"), get_provider_class("huggingface"))
+        self.assertIs(get_provider_class("deep-infra"), get_provider_class("deepinfra"))
+
+    def test_canonical_provider_name(self):
+        self.assertEqual(canonical_provider_name("nim"), "nvidia-nim")
+        self.assertEqual(canonical_provider_name("together-ai"), "together")
+        self.assertEqual(canonical_provider_name("together"), "together")  # passthrough
+
+    def test_get_provider_info_via_alias(self):
+        info = get_provider_info("kimi")
+        self.assertEqual(info["default_model"], "kimi-k2.7-code")
+
+
+class TestApiKeyResolution(unittest.TestCase):
+    def test_config_key_wins(self):
+        self.assertEqual(
+            resolve_api_key("together", {"api_key": "sk-config"}), "sk-config"
+        )
+
+    def test_env_fallback_when_config_empty(self):
+        with patch.dict("os.environ", {"TOGETHER_API_KEY": "sk-env"}, clear=False):
+            self.assertEqual(resolve_api_key("together", {"api_key": ""}), "sk-env")
+
+    def test_env_fallback_respects_candidate_order(self):
+        # nvidia-nim accepts DEEPSEEK_API_KEY as a fallback candidate.
+        with patch.dict("os.environ", {"DEEPSEEK_API_KEY": "sk-ds"}, clear=False):
+            self.assertEqual(resolve_api_key("nvidia-nim", {"api_key": ""}), "sk-ds")
+
+    def test_returns_empty_when_nothing_found(self):
+        with patch("src.secret_store.get_secret", return_value=None):
+            self.assertEqual(resolve_api_key("together", {"api_key": ""}), "")
+
+    def test_builtin_provider_env_vars(self):
+        self.assertEqual(provider_env_vars("anthropic"), ("ANTHROPIC_API_KEY",))
+        self.assertEqual(provider_env_vars("zai"), ("ZAI_API_KEY", "Z_AI_API_KEY"))
+
+    def test_spec_provider_env_vars(self):
+        self.assertEqual(
+            provider_env_vars("nvidia-nim"),
+            ("NVIDIA_API_KEY", "NVIDIA_NIM_API_KEY", "DEEPSEEK_API_KEY"),
+        )
+
+
+class TestKeylessLocalProviders(unittest.TestCase):
+    def test_local_providers_do_not_require_key(self):
+        for pid in ("ollama", "vllm", "sglang"):
+            self.assertFalse(provider_requires_api_key(pid), pid)
+
+    def test_remote_providers_require_key(self):
+        for pid in ("together", "moonshot", "nvidia-nim"):
+            self.assertTrue(provider_requires_api_key(pid), pid)
+
+    @patch("src.providers.openai_compatible_specs.OpenAI")
+    def test_empty_key_becomes_placeholder(self, mock_openai):
+        # A keyless local provider must not pass an empty key to the SDK (which
+        # would silently fall through to the OPENAI_API_KEY env lookup).
+        provider = build_provider_class("ollama")(api_key="")
+        provider._create_client()
+        kwargs = mock_openai.call_args.kwargs
+        self.assertEqual(kwargs["api_key"], "EMPTY")
+        self.assertEqual(kwargs["base_url"], "http://localhost:11434/v1")
+
+
+class TestSpecProviderChat(unittest.TestCase):
+    @patch("src.providers.openai_compatible_specs.OpenAI")
+    def test_chat_uses_openai_compatible_path(self, mock_openai):
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Hi from Together!"
+        mock_response.choices[0].message.reasoning_content = None
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.model = "deepseek-ai/DeepSeek-V4-Pro"
+        mock_response.usage = MagicMock(
+            prompt_tokens=7, completion_tokens=3, total_tokens=10
+        )
+        mock_response.choices[0].finish_reason = "stop"
+        mock_client.chat.completions.create.return_value = mock_response
+        # OpenAICompatibleProvider.client wraps the SDK client via with_options().
+        mock_client.with_options.return_value = mock_client
+        mock_openai.return_value = mock_client
+
+        provider = build_provider_class("together")(api_key="sk-test")
+        response = provider.chat([ChatMessage(role="user", content="Hi")])
+
+        self.assertEqual(response.content, "Hi from Together!")
+        self.assertEqual(response.usage["total_tokens"], 10)
+        # The configured base URL reached the SDK client.
+        self.assertEqual(
+            mock_openai.call_args.kwargs["base_url"], "https://api.together.xyz/v1"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Expand provider support from **7 to 25**. This adds the 18 missing OpenAI-compatible providers via a data-driven registry, alongside the existing hand-written ones.

**New providers:** `nvidia-nim`, `atlascloud`, `wanjie-ark`, `volcengine`, `xiaomi-mimo`, `novita`, `fireworks`, `siliconflow`, `siliconflow-cn`, `arcee`, `moonshot` (Kimi), `huggingface`, `together`, `stepfun`, `deepinfra`, and local servers `ollama`, `vllm`, `sglang`.

## Design — data-driven registry

Rather than 18 near-identical hand-written classes, this adds **`src/providers/openai_compatible_specs.py`**: a `ProviderSpec` table (base URL + default model + API-key env vars + aliases — each vendor's published defaults) plus a factory that synthesizes an `OpenAICompatibleProvider` subclass per spec. Adding a future vendor is a one-row change.

Hand-written providers with bespoke logic are **untouched**: `deepseek` (prefix-cache re-mapping), `zai` (GLM aliasing), `openrouter` (headers), `anthropic`/`minimax` (native wire formats).

## Wiring

- Specs merge into `PROVIDER_INFO` (login, default config, pickers, tables) and `PROVIDER_ALIASES` (`nim`→`nvidia-nim`, `kimi`→`moonshot`, `hf`→`huggingface`, …).
- `get_provider_class` falls back to the registry; `get_provider_config` is now alias-aware (a literal config key still wins, preserving `[providers.glm]` back-compat).
- `resolve_api_key()` falls back to a provider's standard env var (e.g. `TOGETHER_API_KEY`) when config has none; `provider_requires_api_key()` lets local servers (Ollama/vLLM/SGLang) run **without** a key — wired into the headless, TUI, and REPL entrypoints.

So `clawcodex --provider together` (with `TOGETHER_API_KEY` exported) or `clawcodex --provider ollama` (no key) work out of the box.

## Tests

- **25 new tests** in `tests/test_provider_registry.py` — completeness, generated-class defaults, alias resolution, env-var fallback, keyless local providers, mocked chat. All pass.
- Regression sweep across provider/config/entrypoint/advisor suites: **209 passed**.

## Docs

`README.md` and all 6 `docs/i18n/` translations (ZH, FR, PT, RU, HI, AR) updated for the expanded provider set.

## Excluded

An OpenAI Codex / ChatGPT provider — it speaks the OpenAI **Responses API** over a **ChatGPT OAuth** token, a wire format ClawCodex's OpenAI-compatible layer doesn't implement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)