### PR TITLE
docs(readme): start the REPL with --dangerously-skip-permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Then configure a provider and start coding:
 
 ```bash
 clawcodex login   # interactive provider + API key setup → ~/.clawcodex/config.json
-clawcodex         # start the REPL in any project
+clawcodex --dangerously-skip-permissions         # start the REPL in any project
 ```
 
 The installer also ships `clawcodex` lifecycle helpers — `doctor` (diagnose your

--- a/docs/i18n/README_AR.md
+++ b/docs/i18n/README_AR.md
@@ -105,7 +105,7 @@ See [README.md](../../README.md#skills-slash-commands) for a quick tutorial on c
 ### CLI كامل
 
 ```bash
-clawcodex              # بدء REPL
+clawcodex --dangerously-skip-permissions              # بدء REPL
 clawcodex login        # تكوين API
 clawcodex --version    # التحقق من الإصدار
 clawcodex config       # عرض الإعدادات

--- a/docs/i18n/README_FR.md
+++ b/docs/i18n/README_FR.md
@@ -105,7 +105,7 @@ See [README.md](../../README.md#skills-slash-commands) for a quick tutorial on c
 ### CLI complet
 
 ```bash
-clawcodex              # Démarrer le REPL
+clawcodex --dangerously-skip-permissions              # Démarrer le REPL
 clawcodex login        # Configurer l'API
 clawcodex --version    # Vérifier la version
 clawcodex config       # Voir les paramètres

--- a/docs/i18n/README_HI.md
+++ b/docs/i18n/README_HI.md
@@ -105,7 +105,7 @@ See [README.md](../../README.md#skills-slash-commands) for a quick tutorial on c
 ### पूर्ण CLI
 
 ```bash
-clawcodex              # REPL प्रारंभ करें
+clawcodex --dangerously-skip-permissions              # REPL प्रारंभ करें
 clawcodex login        # API कॉन्फ़िगर करें
 clawcodex --version    # संस्करण जांचें
 clawcodex config       # सेटिंग्स देखें

--- a/docs/i18n/README_PT.md
+++ b/docs/i18n/README_PT.md
@@ -105,7 +105,7 @@ See [README.md](../../README.md#skills-slash-commands) for a quick tutorial on c
 ### CLI Completo
 
 ```bash
-clawcodex              # Iniciar REPL
+clawcodex --dangerously-skip-permissions              # Iniciar REPL
 clawcodex login        # Configurar API
 clawcodex --version    # Verificar versão
 clawcodex config       # Ver configurações

--- a/docs/i18n/README_RU.md
+++ b/docs/i18n/README_RU.md
@@ -105,7 +105,7 @@ See [README.md](../../README.md#skills-slash-commands) for a quick tutorial on c
 ### Полный CLI
 
 ```bash
-clawcodex              # Запустить REPL
+clawcodex --dangerously-skip-permissions              # Запустить REPL
 clawcodex login        # Настроить API
 clawcodex --version    # Проверить версию
 clawcodex config       # Просмотреть настройки


### PR DESCRIPTION
Show `clawcodex --dangerously-skip-permissions` as the REPL-start command in the English quick-start and in each translation's REPL-start line (AR/FR/HI/PT/RU). ZH already uses the flag in its quick-start. The CLI reference rows that document the plain `clawcodex` command are left as-is.