### PR TITLE
chore(release): bump version to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clawcodex"
-version = "0.5.0"
+version = "0.6.0"
 description = "A production-oriented Python rebuild of Claude Code — real architecture, reliable CLI agent"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Claw Codex - Claude Code Python Implementation."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 __author__ = "Claw Codex Team"
 
 from .config import load_config, get_provider_config


### PR DESCRIPTION
Bumps the package version **0.5.0 → 0.6.0**.

- `pyproject.toml` `version = "0.6.0"`
- `src/__init__.py` `__version__ = "0.6.0"`

`clawcodex --version` now reports `claw-codex version 0.6.0 (Python)`. The version-coupled release-notes tests (which derive their expectations from `__version__`) pass (23/23). A `v0.6.0` git tag is pushed alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)