### PR TITLE
chore(install): bump installer version to 0.6.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,7 @@ trap 'log_err "Installer crash at line $LINENO: $BASH_COMMAND"' ERR
 # ============================================================================
 #  Config (read-only defaults)
 # ============================================================================
-readonly INSTALLER_VERSION="0.5.0"
+readonly INSTALLER_VERSION="0.6.0"
 # REPO_REF is intentionally NOT readonly — it gets reassigned when the user
 # passes --ref. We have no version tags, so the default is the main branch;
 # --ref is the escape hatch for installing a specific commit/tag/branch.


### PR DESCRIPTION
Bumps `install.sh` `INSTALLER_VERSION` 0.5.0 → 0.6.0 to track the 0.6.0 release (shown in the installer banner and `install.sh --version`). The hosted copy at clawcodex.app/install.sh is re-synced to match in the website repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)