### PR TITLE
docs(i18n): list all 25 providers in the login-flow step

### DIFF
--- a/docs/i18n/README_AR.md
+++ b/docs/i18n/README_AR.md
@@ -172,7 +172,7 @@ python -m src.cli login
 
 هذه العملية ستقوم بـ:
 
-1. مطالبتك باختيار مزود: anthropic / openai / zai / minimax / openrouter / deepseek
+1. مطالبتك باختيار مزود: anthropic / openai / gemini / zai / minimax / openrouter / deepseek، أو أي مزود متوافق مع OpenAI (together, novita, fireworks, moonshot, nvidia-nim, siliconflow, deepinfra, huggingface, …) وخوادم محلية (ollama / vllm / sglang)
 2. مطالبتك بمفتاح API الخاص بذلك المزود
 3. حفظ عنوان URL أساسي مخصص اختياريًا
 4. حفظ نموذج افتراضي اختياريًا

--- a/docs/i18n/README_FR.md
+++ b/docs/i18n/README_FR.md
@@ -172,7 +172,7 @@ python -m src.cli login
 
 Ce processus va :
 
-1. vous demander de choisir un fournisseur : anthropic / openai / zai / minimax / openrouter / deepseek
+1. vous demander de choisir un fournisseur : anthropic / openai / gemini / zai / minimax / openrouter / deepseek, ou tout fournisseur compatible OpenAI (together, novita, fireworks, moonshot, nvidia-nim, siliconflow, deepinfra, huggingface, …) et serveurs locaux (ollama / vllm / sglang)
 2. vous demander la clé API de ce fournisseur
 3. enregistrer optionnellement une URL de base personnalisée
 4. enregistrer optionnellement un modèle par défaut

--- a/docs/i18n/README_HI.md
+++ b/docs/i18n/README_HI.md
@@ -172,7 +172,7 @@ python -m src.cli login
 
 यह प्रक्रिया:
 
-1. आपको एक प्रदाता चुनने के लिए कहेगी: anthropic / openai / zai / minimax / openrouter / deepseek
+1. आपको एक प्रदाता चुनने के लिए कहेगी: anthropic / openai / gemini / zai / minimax / openrouter / deepseek, या कोई भी OpenAI-संगत वेंडर (together, novita, fireworks, moonshot, nvidia-nim, siliconflow, deepinfra, huggingface, …) और स्थानीय सर्वर (ollama / vllm / sglang)
 2. उस प्रदाता की API कुंजी मांगेगी
 3. वैकल्पिक रूप से एक कस्टम base URL सहेजेगी
 4. वैकल्पिक रूप से एक डिफ़ॉल्ट मॉडल सहेजेगी

--- a/docs/i18n/README_PT.md
+++ b/docs/i18n/README_PT.md
@@ -172,7 +172,7 @@ python -m src.cli login
 
 Este processo irá:
 
-1. pedir que você escolha um provedor: anthropic / openai / zai / minimax / openrouter / deepseek
+1. pedir que você escolha um provedor: anthropic / openai / gemini / zai / minimax / openrouter / deepseek, ou qualquer provedor compatível com OpenAI (together, novita, fireworks, moonshot, nvidia-nim, siliconflow, deepinfra, huggingface, …) e servidores locais (ollama / vllm / sglang)
 2. pedir a chave API desse provedor
 3. salvar opcionalmente uma URL base personalizada
 4. salvar opcionalmente um modelo padrão

--- a/docs/i18n/README_RU.md
+++ b/docs/i18n/README_RU.md
@@ -172,7 +172,7 @@ python -m src.cli login
 
 Этот процесс:
 
-1. попросит вас выбрать провайдера: anthropic / openai / zai / minimax / openrouter / deepseek
+1. попросит вас выбрать провайдера: anthropic / openai / gemini / zai / minimax / openrouter / deepseek, либо любой OpenAI-совместимый провайдер (together, novita, fireworks, moonshot, nvidia-nim, siliconflow, deepinfra, huggingface, …) и локальные серверы (ollama / vllm / sglang)
 2. попросит ввести API ключ этого провайдера
 3. при необходимости сохранит пользовательский base URL
 4. при необходимости сохранит модель по умолчанию


### PR DESCRIPTION
The AR/FR/HI/PT/RU READMEs' "choose a provider" login step still listed only 6 providers — missing **gemini**, the OpenAI-compatible gateways, and the local servers. The English and Chinese READMEs already list them fully (and every README's provider section + feature table already documents all 25). This brings the five translations in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)