### PR TITLE
fix(tui): slash-command menu executes, completes, and filters like the ink REPL

### DIFF
--- a/src/tui/commands.py
+++ b/src/tui/commands.py
@@ -106,10 +106,21 @@ class CommandSuggestion:
     aliases: tuple[str, ...] = ()
     tag: str | None = None
     source: str = "builtin"
+    # Names of inline arguments the command accepts (e.g. ``("name",)`` for
+    # ``/rename <name>``). Empty = zero-arg. Drives Enter-vs-Tab in the
+    # popup: Enter EXECUTES a zero-arg command but only FILLS ``/<name> ``
+    # for an arg-taking one so the user can type the argument — matching TS
+    # ``applyCommandSuggestion`` (commandSuggestions.ts: execute iff
+    # ``type !== 'prompt' || argNames.length === 0``).
+    arg_names: tuple[str, ...] = ()
 
     @property
     def slash(self) -> str:
         return f"/{self.name}"
+
+    @property
+    def takes_args(self) -> bool:
+        return bool(self.arg_names)
 
 
 _LOCAL_BUILTIN_DESCRIPTIONS: dict[str, str] = {
@@ -182,6 +193,11 @@ def build_command_suggestions(
                 continue
             aliases = tuple(getattr(cmd, "aliases", []) or [])
             tag = "workflow" if getattr(cmd, "kind", None) == "workflow" else None
+            # Only prompt-template commands carry inline arg names (TS
+            # ``type === 'prompt'``). Builtins/dialogs/skills are zero-arg
+            # from the popup's perspective — Enter executes them (they open
+            # their own dialog / show usage when an arg is actually needed).
+            arg_names = tuple(getattr(cmd, "arg_names", ()) or ())
             push(
                 CommandSuggestion(
                     name=cmd.name,
@@ -189,6 +205,7 @@ def build_command_suggestions(
                     aliases=aliases,
                     tag=tag,
                     source=getattr(cmd, "loaded_from", "builtin") or "builtin",
+                    arg_names=arg_names,
                 )
             )
     except Exception:

--- a/src/tui/widgets/prompt_input.py
+++ b/src/tui/widgets/prompt_input.py
@@ -19,6 +19,7 @@ Phase 2 to swap in a ``TextArea`` without changing the public surface.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -90,13 +91,16 @@ class _PasteAwareInput(Input):
 
 
 _NAME_COLUMN_WIDTH = 22  # left column reserved for "/name (alias)"
-_MAX_VISIBLE_SUGGESTIONS = 10
+# TS shows 6 rows in the non-overlay slash menu
+# (PromptInputFooterSuggestions.tsx:175 → ``Math.min(6, …)``). The full
+# candidate set is still ranked; only the display is capped.
+_MAX_VISIBLE_SUGGESTIONS = 6
 
 
 class _SlashSuggestions(OptionList):
     DEFAULT_CSS = """
     _SlashSuggestions {
-        max-height: 10;
+        max-height: 6;
         border: none;
         padding: 0;
         background: $background;
@@ -149,6 +153,9 @@ class PromptInput(Vertical):
         self._history_pos: int | None = None
         self._input = _PasteAwareInput(placeholder="Type a prompt, or / for commands")
         self._suggestions = _SlashSuggestions(classes="-hidden")
+        # slash → takes_args, for the currently-visible popup rows. Lets
+        # the accept path decide Enter=execute (zero-arg) vs fill (arg).
+        self._arg_lookup: dict[str, bool] = {}
         self._vim = VimState(enabled=vim_mode)
         self._yank_buffer: str = ""
         # Round 2 / WI-R2.5: most-recent bracketed paste classification.
@@ -285,25 +292,81 @@ class PromptInput(Vertical):
         self._refresh_suggestions(event.value, event.input.cursor_position)
 
     async def on_input_submitted(self, event: Input.Submitted) -> None:
+        # If the palette is open and a row is highlighted, accept the
+        # selection (execute zero-arg / fill arg-taking) instead of
+        # submitting the partial prompt. Mirrors TS handleEnter →
+        # applyCommandSuggestion(shouldExecute=true).
+        if not self._suggestions.has_class("-hidden"):
+            if self._accept_suggestion(execute=True):
+                return
         text = (event.value or "").strip()
         if not text:
             return
-        # If the palette is open and a row is highlighted, accept the
-        # selection instead of submitting the partial prompt.
-        if not self._suggestions.has_class("-hidden"):
-            idx = self._suggestions.highlighted
-            if idx is not None:
-                option = self._suggestions.get_option_at_index(idx)
-                if option is not None and option.id:
-                    self._input.value = option.id
-                    self._input.cursor_position = len(option.id)
-                    self._hide_suggestions()
-                    return
         self._history.append(text)
         self._history_pos = None
         self._hide_suggestions()
         self._input.value = ""
         self.post_message(PromptSubmitted(text=text))
+
+    def on_option_list_option_selected(
+        self, event: OptionList.OptionSelected
+    ) -> None:
+        """Enter on the popup after arrow-navigation.
+
+        Up/Down moves focus onto the ``OptionList`` (see ``on_key``), so a
+        subsequent Enter is delivered as ``OptionSelected`` here — NOT as
+        ``Input.Submitted``. Without this handler that Enter was a no-op
+        (the headline slash-menu bug). Accept + execute, then return
+        focus to the input.
+        """
+
+        event.stop()
+        self._accept_suggestion(execute=True, option=event.option)
+        self._input.focus()
+
+    def _accept_suggestion(
+        self,
+        *,
+        execute: bool,
+        option: Option | None = None,
+    ) -> bool:
+        """Accept the highlighted (or given) slash suggestion.
+
+        ``execute=True`` (Enter): run a zero-arg command immediately; for
+        an arg-taking command, fall back to filling ``/<name> `` so the
+        user can type the argument. ``execute=False`` (Tab): always fill
+        ``/<name> `` without running. Returns ``True`` if a row was
+        accepted.
+        """
+
+        if option is None:
+            idx = self._suggestions.highlighted
+            if idx is None:
+                return False
+            try:
+                option = self._suggestions.get_option_at_index(idx)
+            except Exception:
+                return False
+        if option is None or not option.id:
+            return False
+        slash = str(option.id)
+        run_now = execute and not self._arg_lookup.get(slash, False)
+        if run_now:
+            self._hide_suggestions()
+            self._history.append(slash)
+            self._history_pos = None
+            self._input.value = ""
+            self.post_message(PromptSubmitted(text=slash))
+        else:
+            filled = f"{slash} "
+            self._input.value = filled
+            try:
+                self._input.cursor_position = len(filled)
+            except Exception:
+                pass
+            self._hide_suggestions()
+            self._input.focus()
+        return True
 
     async def on_key(self, event: events.Key) -> None:
         key = event.key
@@ -317,8 +380,17 @@ class PromptInput(Vertical):
                 event.stop()
                 return
 
+        if key == "tab" and not self._suggestions.has_class("-hidden"):
+            # Tab completes the highlighted command without running it
+            # (TS handleTab → applyCommandSuggestion(shouldExecute=false)).
+            if self._accept_suggestion(execute=False):
+                event.stop()
+                return
         if key == "escape" and not self._suggestions.has_class("-hidden"):
             self._hide_suggestions()
+            # Arrow-nav may have moved focus onto the popup; bring it back
+            # so the next keystroke lands in the draft, not a hidden list.
+            self._input.focus()
             event.stop()
             return
         if key == "escape":
@@ -421,8 +493,14 @@ class PromptInput(Vertical):
                 suggestions = self._suggestions_provider() or []
             except Exception:
                 suggestions = []
+            self._arg_lookup = {
+                s.slash: s.takes_args
+                for s in suggestions
+                if isinstance(s, CommandSuggestion)
+            }
             return _options_from_suggestions(suggestions, partial)
 
+        self._arg_lookup = {}
         words = self._words_provider() or []
         return _options_from_words(words, partial)
 
@@ -458,11 +536,18 @@ def _options_from_suggestions(
 ) -> list[Option]:
     """Filter + rank rich command suggestions, then render two-column rows.
 
-    Sort order matches the TS ranking spirit: exact name → exact alias
-    → prefix name → prefix alias → fuzzy subsequence. Duplicates (same
-    name) are collapsed; aliases are surfaced only when the user typed
-    them so an unmatched ``/com<TAB>`` does not get polluted with the
-    full alias list.
+    Sort order: exact name → exact alias → prefix name → prefix alias →
+    name-part prefix. Matching is anchored to a word boundary: a prefix of
+    the whole name/alias, or a prefix of any ``[:_-]``-delimited part of
+    the name (TS Fuse's ``partKey``, ``commandSuggestions.ts:12,39``) — so
+    ``/notes`` surfaces ``/release-notes`` and ``/ceo`` surfaces
+    ``/plan-ceo-review``. This is a deliberate *narrowing* of the TS Fuse
+    config (which also fuzzy-matches descriptions at low weight); the
+    earlier port instead used an unbounded subsequence test, which produced
+    false matches like ``/st`` → ``/cost``/``/history`` and ``/co`` →
+    ``/doctor`` — those stay dropped (no ``-``/``:`` part begins with the
+    query). Duplicates (same name) are collapsed; aliases/parts are
+    surfaced only when the user typed their prefix.
     """
 
     scored: list[tuple[int, int, CommandSuggestion, str | None]] = []
@@ -499,16 +584,16 @@ def _options_from_suggestions(
                 if alias_prefix:
                     rank = 3
                     matched_alias = alias_prefix
-                elif _fuzzy_match(name_lc, partial):
-                    rank = 5
-                else:
-                    alias_fuzzy = next(
-                        (a for a in sugg.aliases if _fuzzy_match(a.lower(), partial)),
-                        None,
-                    )
-                    if alias_fuzzy:
-                        rank = 6
-                        matched_alias = alias_fuzzy
+                elif any(
+                    part.startswith(partial)
+                    for part in re.split(r"[:_-]", name_lc)
+                    if part
+                ):
+                    # Word-boundary part prefix (TS Fuse partKey): lets
+                    # ``/notes`` match ``release-notes`` and ``/ceo`` match
+                    # ``plan-ceo-review`` without unbounded subsequence.
+                    rank = 4
+                # else: no match (no subsequence fallback — see docstring).
         if rank is None:
             continue
         seen.add(name_lc)
@@ -584,10 +669,12 @@ def _render_suggestion_row(
 def _fuzzy_match(name: str, partial: str) -> bool:
     """Lightweight fuzzy matcher: prefix wins, subsequence falls back.
 
-    Matches the behavior of ``useTypeahead`` in
-    ``typescript/src/components/PromptInput/useTypeahead.ts`` at a
-    reduced fidelity (no scoring, no MRU). Prefix matches are always
-    preferred so the most common ``/ex<Tab>`` workflow feels snappy.
+    LEGACY: only the ``_options_from_words`` fallback path (no rich
+    ``suggestions_provider`` — tests / embedded callers) still uses this.
+    The production rich path (``_options_from_suggestions``) deliberately
+    uses prefix/part-prefix matching instead (no subsequence), so the two
+    paths intentionally differ; do not "unify" them without re-checking the
+    ``/st`` → ``/cost`` regression this guards against.
     """
 
     if name.startswith(partial):

--- a/tests/tui/test_slash_menu_pr1.py
+++ b/tests/tui/test_slash_menu_pr1.py
@@ -1,0 +1,194 @@
+"""Slash-command menu parity fixes (TUI UX PR 1).
+
+Locks in four behaviors ported from the ink reference's command typeahead
+(``commandSuggestions.ts`` / ``useTypeahead.tsx``):
+
+* **Enter executes** the highlighted command — both when the ``Input`` is
+  focused and after arrow-navigation moved focus onto the popup
+  (``OptionList.OptionSelected``). Previously Enter either filled the text
+  (needing a second Enter) or did nothing at all after arrow-nav.
+* **Enter fills, not executes, arg-taking commands** (``/<name> ``) so the
+  user can type the argument — matching TS ``applyCommandSuggestion`` which
+  executes iff ``type !== 'prompt' || argNames.length === 0``.
+* **Tab completes without executing** (``/<name> ``).
+* **Prefix-only filtering** — no loose subsequence matches
+  (``/st`` must not surface ``/cost``/``/history``; ``/co`` not ``/doctor``).
+* **Display capped at 6 rows** (TS ``Math.min(6, …)``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("textual")
+
+from textual.app import App, ComposeResult
+
+from src.tui.commands import CommandSuggestion
+from src.tui.widgets.prompt_input import (
+    PromptInput,
+    PromptSubmitted,
+    _MAX_VISIBLE_SUGGESTIONS,
+    _options_from_suggestions,
+)
+
+
+# ---- fixtures: a deterministic rich suggestion set ------------------------
+
+_SUGGESTIONS: list[CommandSuggestion] = [
+    CommandSuggestion(name="help", description="Show help"),
+    CommandSuggestion(name="stream", description="Toggle streaming"),
+    CommandSuggestion(name="cost", description="Show cost"),
+    CommandSuggestion(name="history", description="Open history"),
+    CommandSuggestion(name="compact", description="Compact context"),
+    CommandSuggestion(name="doctor", description="Diagnose"),
+    CommandSuggestion(name="model", description="Pick model"),
+    CommandSuggestion(name="memory", description="Edit memory"),
+    CommandSuggestion(name="clear", description="Clear transcript"),
+    # arg-taking command (prompt-style): Enter should FILL, not execute.
+    CommandSuggestion(name="greet", description="Greet", arg_names=("name",)),
+    # alias-only prefix: name has no "bg" prefix, alias does.
+    CommandSuggestion(name="tasks", description="Tasks", aliases=("bg",)),
+    # hyphenated / namespaced names — TS Fuse matches on name parts split
+    # by ``[:_-]``, so ``/notes`` and ``/ceo`` must surface these.
+    CommandSuggestion(name="release-notes", description="Release notes"),
+    CommandSuggestion(name="plan-ceo-review", description="CEO review"),
+]
+
+
+def _ids(partial: str) -> list[str]:
+    return [opt.id for opt in _options_from_suggestions(_SUGGESTIONS, partial)]
+
+
+# ---- pure-function filtering tests (no app) -------------------------------
+
+
+def test_prefix_only_excludes_subsequence_matches():
+    rows = _ids("st")
+    assert "/stream" in rows
+    # "st" appears mid-word in cost/history but is NOT a prefix → excluded.
+    assert "/cost" not in rows
+    assert "/history" not in rows
+
+
+def test_prefix_co_excludes_doctor():
+    rows = _ids("co")
+    assert set(rows) == {"/cost", "/compact"}
+    assert "/doctor" not in rows  # subsequence "c..o" must not match
+
+
+def test_prefix_m_matches_only_prefixes():
+    rows = _ids("m")
+    assert "/model" in rows and "/memory" in rows
+    # stream/compact contain 'm' but not as a prefix.
+    assert "/stream" not in rows
+    assert "/compact" not in rows
+
+
+def test_alias_prefix_still_matches():
+    assert "/tasks" in _ids("bg")
+
+
+def test_part_prefix_matches_namespaced_commands():
+    # TS Fuse partKey: a prefix of any [:_-] part matches.
+    assert "/release-notes" in _ids("notes")
+    assert "/plan-ceo-review" in _ids("ceo")
+    # ...but only at a part boundary — "eo" is mid-part in "ceo", not a
+    # part prefix, so it must NOT match (no unbounded subsequence).
+    assert "/plan-ceo-review" not in _ids("eo")
+
+
+def test_exact_name_ranks_first():
+    # "/co" → cost (4) sorts before compact (7) by length tiebreak.
+    assert _ids("co")[0] == "/cost"
+
+
+def test_display_capped_at_six():
+    assert _MAX_VISIBLE_SUGGESTIONS == 6
+    # Empty partial returns every command, but display is capped.
+    assert len(_ids("")) <= 6
+
+
+# ---- widget harness -------------------------------------------------------
+
+
+class _Host(App):
+    def __init__(self, prompt: PromptInput) -> None:
+        super().__init__()
+        self._prompt = prompt
+        self.submitted: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        yield self._prompt
+
+    def on_prompt_submitted(self, message: PromptSubmitted) -> None:
+        self.submitted.append(message.text)
+
+
+def _make_prompt() -> PromptInput:
+    return PromptInput(
+        words_provider=lambda: [],
+        suggestions_provider=lambda: list(_SUGGESTIONS),
+    )
+
+
+async def _type(pilot, text: str) -> None:
+    for ch in text:
+        await pilot.press("/" if ch == "/" else ch)
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_enter_executes_zero_arg_command_without_navigation():
+    prompt = _make_prompt()
+    host = _Host(prompt)
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        await _type(pilot, "/he")  # only /help matches
+        await pilot.press("enter")
+        await pilot.pause()
+        assert host.submitted == ["/help"]
+        assert prompt.current_text() == ""  # input cleared on execute
+
+
+@pytest.mark.asyncio
+async def test_enter_after_arrow_nav_executes_highlighted():
+    prompt = _make_prompt()
+    host = _Host(prompt)
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        await _type(pilot, "/")  # empty partial → insertion order
+        await pilot.press("down")  # move highlight to index 1 = /stream
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        # The headline bug: this used to be a no-op (OptionSelected unhandled).
+        assert host.submitted == ["/stream"]
+        assert prompt.current_text() == ""
+
+
+@pytest.mark.asyncio
+async def test_tab_fills_without_executing():
+    prompt = _make_prompt()
+    host = _Host(prompt)
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        await _type(pilot, "/mod")  # only /model
+        await pilot.press("tab")
+        await pilot.pause()
+        assert host.submitted == []  # Tab never runs the command
+        assert prompt.current_text() == "/model "  # filled with trailing space
+
+
+@pytest.mark.asyncio
+async def test_enter_fills_arg_taking_command():
+    prompt = _make_prompt()
+    host = _Host(prompt)
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        await _type(pilot, "/gr")  # /greet, arg_names=("name",)
+        await pilot.press("enter")
+        await pilot.pause()
+        # Arg-taking command fills so the user can type the argument.
+        assert host.submitted == []
+        assert prompt.current_text() == "/greet "


### PR DESCRIPTION
## What

First PR of a TUI UX parity pass (`/tui` vs the original ink REPL). Fixes the slash-command autocomplete menu, which had a verified, high-frequency bug.

### The bug (reproduced)
- Pressing **Enter on an arrow-highlighted command did nothing** — after Up/Down moved focus to the popup, the `OptionList.OptionSelected` message was unhandled.
- Without arrow-nav, Enter only **filled** the text, needing a *second* Enter to run.

### Fixes (ported from the ink typeahead)
- **Enter executes** the highlighted command — both the `Input.Submitted` and the post-arrow-nav `OptionSelected` paths, routed through one `_accept_suggestion` helper. Arg-taking commands instead **fill** `/<name> ` so the user can type the argument (matches TS `applyCommandSuggestion`: execute iff `type !== 'prompt' || argNames` empty). `CommandSuggestion` now carries `arg_names`/`takes_args`, populated from the registry.
- **Tab completes** without executing (`/<name> `).
- **Filtering anchored to word boundaries**: prefix of the name/alias, or a prefix of any `[:_-]`-split name part (TS Fuse `partKey`). So `/notes` → `/release-notes`, `/ceo` → `/gstack:plan-ceo-review`, `/research` → `/deep-research` — while the old unbounded-subsequence false matches (`/st` → `/cost`, `/co` → `/doctor`) stay dropped.
- **Display capped at 6 rows** (TS `Math.min(6, …)`); the full candidate set is still ranked.
- **Escape restores focus** to the input after arrow-nav.

## Tests
- New `tests/tui/test_slash_menu_pr1.py` (11 tests): prefix exclusion, alias prefix, part-prefix (incl. mid-part negative), arg-fill vs execute, Enter-after-arrow-nav, Tab-fill, 6-row cap.
- Full `tests/tui/` suite: **700 passed, 2 skipped**.

## Review
Two critic rounds (REQUEST-CHANGES → APPROVE). Verified against the real 586-command registry and TS `commandSuggestions.ts` semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)