### PR TITLE
feat(tui): sparkle spinner + live token/elapsed busy row

### DIFF
--- a/src/tui/widgets/status_line.py
+++ b/src/tui/widgets/status_line.py
@@ -27,7 +27,33 @@ from textual.widgets import Static
 from ..state import AppState
 
 
-_SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+# The signature Claude Code "sparkle" spinner: a density ramp of the six
+# glyphs (darwin set; other platforms swap ✽→*), animated as a ping-pong —
+# base frames followed by their reverse, advanced one step per tick. This
+# replaces the old generic braille spinner with the recognizable ink look.
+_SPINNER_BASE = ["·", "✢", "✳", "✶", "✻", "✽"]
+_SPINNER_FRAMES = _SPINNER_BASE + list(reversed(_SPINNER_BASE))
+
+
+def _format_elapsed(secs: int) -> str:
+    """``Ns`` under a minute, else ``Nm Ns`` (TS ``formatDuration``)."""
+    if secs < 60:
+        return f"{secs}s"
+    return f"{secs // 60}m {secs % 60}s"
+
+
+def _format_token_count(n: int) -> str:
+    """Compact count approximating TS ``formatNumber`` (``1321`` → ``1.3k``).
+
+    A deliberate approximation of ``Intl`` compact notation, not a faithful
+    port. The ``< 999_950`` bound keeps the ``k`` branch from rounding up to
+    ``1000.0k`` at one decimal — that boundary rolls into ``m`` instead.
+    """
+    if n < 1000:
+        return str(n)
+    if n < 999_950:
+        return f"{n / 1000:.1f}k"
+    return f"{n / 1_000_000:.1f}m"
 
 
 class StatusLine(Static):
@@ -237,24 +263,52 @@ class StatusLine(Static):
         self._redraw()
 
     def _redraw(self) -> None:
-        spinner = _SPINNER_FRAMES[self._frame] if self.is_thinking else " "
+        spinner = (
+            _SPINNER_FRAMES[self._frame % len(_SPINNER_FRAMES)]
+            if self.is_thinking
+            else " "
+        )
         self.update(self._compose_text(spinner=spinner))
+
+    def _busy_middle(self, spinner: str, verb: str) -> str:
+        """Render the working indicator: ``✶ Synthesizing… (5s · ↓ 1.2k tokens)``.
+
+        Ports the ink ``SpinnerAnimationRow`` look: glyph + verb + ``…`` +
+        a parenthesized status group with elapsed time and a live token
+        estimate (``round(chars/4)`` from the streamed response, the same
+        ``leaderTokens`` heuristic TS uses). Divergence from TS
+        ``SHOW_TOKENS_AFTER_MS`` (30s gate): TS hides this group on its
+        separate floating spinner row for the first 30s; the Python
+        status-line middle is the ONLY spinner surface and already showed
+        elapsed from 1s, so we keep live feedback from the start (tokens
+        appear once output streams). Token feedback is naturally absent
+        when ``/stream`` is off (no deltas arrive).
+        """
+
+        state = self._app_state
+        parts: list[str] = []
+        if state and state.verb_started_at:
+            secs = int(time.time() - state.verb_started_at)
+            if secs >= 1:
+                parts.append(_format_elapsed(secs))
+        if state and state.streaming_text:
+            # TS leaderTokens = round(responseChars / 4) (SpinnerAnimationRow).
+            tok = round(len(state.streaming_text) / 4)
+            if tok > 0:
+                parts.append(f"↓ {_format_token_count(tok)} tokens")
+        tail = f" ({' · '.join(parts)})" if parts else ""
+        return f"{spinner} {verb}…{tail}"
 
     def _compose_text(self, *, spinner: str) -> Text:
         state = self._app_state
         verb = state.verb if state else ("thinking" if self.is_thinking else "ready")
-        elapsed = ""
-        if state and state.is_thinking and state.verb_started_at:
-            secs = int(time.time() - state.verb_started_at)
-            if secs > 0:
-                elapsed = f" {secs}s"
 
         # TS parity: a configured statusLine command REPLACES the default
         # row content; activity feedback (spinner + verb) is kept so the
         # user still sees that the agent is working.
         if self._custom_status:
             if self.is_thinking:
-                return Text(f"{spinner} {verb}{elapsed}    {self._custom_status}")
+                return Text(f"{self._busy_middle(spinner, verb)}    {self._custom_status}")
             return Text(self._custom_status)
 
         left_parts = [f"{self._provider} · {self._model}"]
@@ -279,7 +333,7 @@ class StatusLine(Static):
             left_parts.append(advisor_seg)
         left = " · ".join(left_parts)
         cwd = self._display_cwd()
-        middle = f"{spinner} {verb}{elapsed}" if self.is_thinking else verb
+        middle = self._busy_middle(spinner, verb) if self.is_thinking else verb
         right_bits: list[str] = [f"turn {self.turns}"]
         if self.queued:
             right_bits.append(f"queued {self.queued}")

--- a/tests/tui/test_spinner_row_pr2.py
+++ b/tests/tui/test_spinner_row_pr2.py
@@ -1,0 +1,121 @@
+"""Spinner / busy-row visual parity (TUI UX PR 2).
+
+Ports the ink ``SpinnerAnimationRow`` look into the Textual status line's
+middle segment (the de-facto spinner surface in this port):
+
+* the signature "sparkle" glyph set ``· ✢ ✳ ✶ ✻ ✽`` (12-frame ping-pong),
+* an ellipsis after the verb (``Synthesizing…``),
+* a parenthesized status group with elapsed time (minute rollover) and a
+  live token estimate (``round(chars/4)`` from the streamed response).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("textual")
+
+from textual.app import App
+
+from src.tui.state import AppState
+from src.tui.widgets.status_line import (
+    StatusLine,
+    _SPINNER_BASE,
+    _SPINNER_FRAMES,
+    _format_elapsed,
+    _format_token_count,
+)
+
+
+# ---- pure helpers ---------------------------------------------------------
+
+
+def test_spinner_frames_are_the_sparkle_set():
+    assert _SPINNER_BASE == ["·", "✢", "✳", "✶", "✻", "✽"]
+    # 12-frame ping-pong: base then reversed base (Spinner/SpinnerGlyph.tsx:7).
+    assert len(_SPINNER_FRAMES) == 12
+    assert _SPINNER_FRAMES[:6] == _SPINNER_BASE
+    assert _SPINNER_FRAMES[6:] == list(reversed(_SPINNER_BASE))
+    # No braille left over from the old set.
+    assert all(ch not in _SPINNER_FRAMES for ch in "⠋⠙⠹⠸")
+
+
+def test_format_elapsed_rolls_over_at_a_minute():
+    assert _format_elapsed(5) == "5s"
+    assert _format_elapsed(59) == "59s"
+    assert _format_elapsed(90) == "1m 30s"
+    assert _format_elapsed(125) == "2m 5s"
+
+
+def test_format_token_count_compacts_thousands():
+    assert _format_token_count(0) == "0"
+    assert _format_token_count(500) == "500"
+    assert _format_token_count(1321) == "1.3k"
+    assert _format_token_count(1_500_000) == "1.5m"
+    # boundary must roll k→m, not print "1000.0k"
+    assert _format_token_count(999_999) == "1.0m"
+
+
+# ---- widget render --------------------------------------------------------
+
+
+async def _widget(state, monkeypatch):
+    monkeypatch.setattr(StatusLine, "refresh_custom_status", lambda self: None)
+    widget = StatusLine(
+        provider="prov",
+        model="claude-opus-4-8",
+        workspace_root=Path("/tmp"),
+        app_state=state,
+    )
+
+    class _Host(App):
+        def compose(self):
+            yield widget
+
+    return _Host(), widget
+
+
+def _busy_state(*, elapsed_s: float = 5.0, streamed_chars: int = 0):
+    state = AppState()
+    state.is_thinking = True
+    state.verb = "Synthesizing"
+    state.verb_started_at = time.time() - elapsed_s
+    state.streaming_text = "x" * streamed_chars
+    return state
+
+
+@pytest.mark.asyncio
+async def test_busy_middle_has_glyph_ellipsis_and_elapsed(monkeypatch):
+    app, widget = await _widget(_busy_state(elapsed_s=5.0), monkeypatch)
+    async with app.run_test():
+        widget.is_thinking = True
+        text = widget._compose_text(spinner="✶").plain
+    assert "✶ Synthesizing…" in text
+    assert "(5s)" in text  # parenthesized elapsed, no tokens yet
+
+
+@pytest.mark.asyncio
+async def test_busy_middle_shows_live_token_estimate(monkeypatch):
+    # 480 streamed chars → round(480/4) = 120 tokens.
+    app, widget = await _widget(
+        _busy_state(elapsed_s=5.0, streamed_chars=480), monkeypatch
+    )
+    async with app.run_test():
+        widget.is_thinking = True
+        text = widget._compose_text(spinner="✶").plain
+    assert "↓ 120 tokens" in text
+    assert "(5s · ↓ 120 tokens)" in text
+
+
+@pytest.mark.asyncio
+async def test_idle_row_has_no_ellipsis_or_spinner(monkeypatch):
+    state = AppState()  # not thinking
+    app, widget = await _widget(state, monkeypatch)
+    async with app.run_test():
+        widget.is_thinking = False
+        text = widget._compose_text(spinner=" ").plain
+    assert "…" not in text
+    assert "Synthesizing" not in text


### PR DESCRIPTION
## What

PR 2 of the TUI UX parity pass. Brings the working/loading indicator up to the ink REPL's look.

The Python TUI shows the busy indicator in the **status-line's middle segment** (this port has no separate floating spinner row like TS), so that's where the work happens.

**Before:** `⠴ Whisking 1s` — generic braille glyph, no ellipsis, no token feedback.
**After:** `✶ Synthesizing… (5s · ↓ 1.2k tokens)`.

### Changes (`src/tui/widgets/status_line.py`)
- **Sparkle glyphs** `· ✢ ✳ ✶ ✻ ✽` as a 12-frame ping-pong (base + reverse), replacing braille — the signature Claude Code look.
- **Ellipsis** after the verb.
- **Parenthesized status group**: elapsed time with minute rollover (`_format_elapsed` → `1m 30s`) and a **live token estimate** `↓ N tokens` = `round(streamed_chars / 4)` (the TS `leaderTokens` heuristic), compacted via `_format_token_count` (`1.3k`/`1.5m`).

### Deliberate divergence (documented)
TS gates the elapsed+token group behind `SHOW_TOKENS_AFTER_MS` (30s) on its *floating* spinner. The Python status-line middle is the **only** spinner surface and already showed elapsed from 1s, so gating would *remove* feedback. We keep live feedback from the start; tokens appear once output streams (naturally absent when `/stream` is off).

## Tests
- New `tests/tui/test_spinner_row_pr2.py` (6): glyph set/ping-pong, elapsed rollover, token compaction (+ k→m boundary), busy-row render with/without tokens, idle row has no ellipsis.
- Full `tests/tui/` suite: **706 passed, 2 skipped**.

## Review
Critic APPROVE; applied its pre-merge fixes (`round` vs floor to match TS `Math.round`; k→m rollover boundary; softened glyph comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)