### PR TITLE
feat(tui): context-aware prompt footer hints (interrupt / bash / grammar)

### DIFF
--- a/src/tui/screens/repl.py
+++ b/src/tui/screens/repl.py
@@ -143,6 +143,9 @@ class REPLScreen(Screen):
         app: "ClawCodexTUI" = self.app  # type: ignore[assignment]
         if hasattr(app, "app_state"):
             self.status_bar.bind_state(app.app_state)
+        # Drive the footer's "esc to interrupt" hint off the same busy
+        # signal as the spinner (single source of truth).
+        self.status_bar.bind_footer(self.prompt_input.footer)
         # Attach the live region to the app's announcer so every
         # cross-screen announcement mirrors into this REPL.
         if hasattr(app, "announcer"):

--- a/src/tui/widgets/prompt_input.py
+++ b/src/tui/widgets/prompt_input.py
@@ -283,12 +283,19 @@ class PromptInput(Vertical):
     def vim_state(self) -> VimState:  # exposed for tests / status line
         return self._vim
 
+    @property
+    def footer(self) -> PromptInputFooter:
+        """The hint footer (so the status line can drive its loading state)."""
+        return self._footer
+
     # ---- input events ----
     def on_input_changed(self, event: Input.Changed) -> None:
         # C4 bash-mode affordance (TS inputModes getModeFromInput): a `!`
         # prefix accents the input border. lstrip matches the dispatch
         # predicate (the submit layer strips before routing).
-        self.set_class(event.value.lstrip().startswith("!"), "-bash-mode")
+        bash_mode = event.value.lstrip().startswith("!")
+        self.set_class(bash_mode, "-bash-mode")
+        self._footer.set_bash_mode(bash_mode)
         self._refresh_suggestions(event.value, event.input.cursor_position)
 
     async def on_input_submitted(self, event: Input.Submitted) -> None:

--- a/src/tui/widgets/prompt_input_footer.py
+++ b/src/tui/widgets/prompt_input_footer.py
@@ -71,6 +71,11 @@ class PromptInputFooter(Static):
         super().__init__(Text(""), markup=False)
         self._vim = vim_state
         self._hints_provider = hints_provider
+        # Context flags that swap the hint set (TS PromptInputFooterLeftSide):
+        # while a run is in flight the footer collapses to "esc to interrupt";
+        # in bash mode it shows "! for bash mode".
+        self._loading: bool = False
+        self._bash_mode: bool = False
         # Track the most recent rendered line as a test seam — same
         # pattern :class:`PromptInputModeIndicator` uses.
         self._last_line: str = ""
@@ -90,6 +95,27 @@ class PromptInputFooter(Static):
 
         self._redraw()
 
+    def set_loading(self, loading: bool) -> None:
+        """Toggle the in-flight state (footer → ``esc to interrupt``).
+
+        Driven by :class:`~src.tui.widgets.status_line.StatusLine` so the
+        footer tracks the same ``is_thinking`` signal as the spinner — see
+        ``StatusLine.bind_footer``.
+        """
+
+        if loading == self._loading:
+            return
+        self._loading = loading
+        self._redraw()
+
+    def set_bash_mode(self, bash_mode: bool) -> None:
+        """Toggle bash mode (footer → ``! for bash mode``)."""
+
+        if bash_mode == self._bash_mode:
+            return
+        self._bash_mode = bash_mode
+        self._redraw()
+
     @property
     def last_line(self) -> str:
         """Most recently rendered hint line (test seam)."""
@@ -106,16 +132,23 @@ class PromptInputFooter(Static):
         return self._default_hints()
 
     def _default_hints(self) -> list[FooterHint]:
-        """Curated default hints — small enough to fit on one line.
+        """Context-aware default hints (TS ``PromptInputFooterLeftSide``).
 
-        Chosen for maximum discoverability of the actions a new user
-        hits within their first session: open a slash command, cancel
-        an in-flight request / dismiss the popup, clear the draft, and
-        (when relevant) vim mode chord. Every hint here corresponds to
-        a binding the host currently wires (``PromptInput.BINDINGS`` +
-        ``REPLScreen.BINDINGS``); future rounds replace this static set
-        with resolver output via ``hints_provider``.
+        Mode precedence mirrors the ink footer: bash mode wins first —
+        ``ModeIndicator`` returns ``! for bash mode`` before any loading
+        logic (PromptInputFooterLeftSide.tsx:317-319, ahead of the
+        ``getSpinnerHintParts(isLoading…)`` at :375). Then, while a run is
+        in flight, the only hint is ``esc to interrupt``; otherwise the
+        idle discoverability set. Keys are lowercased; ``to``-actions match
+        the TS ``KeyboardShortcutHint`` grammar (``esc to interrupt``),
+        while ``for``-hints (``/ for commands``, ``! for bash mode``) are
+        raw TS strings. Every idle hint maps to a wired binding.
         """
+
+        if self._bash_mode:
+            return [FooterHint(keys="!", label="for bash mode")]
+        if self._loading:
+            return [FooterHint(keys="esc", label="to interrupt")]
 
         vim = self._vim
 
@@ -123,10 +156,9 @@ class PromptInputFooter(Static):
             return vim is not None and vim.enabled
 
         return [
-            FooterHint(keys="/", label="command"),
-            FooterHint(keys="Esc", label="cancel"),
-            FooterHint(keys="Ctrl+L", label="clear"),
-            FooterHint(keys="i/Esc", label="vim", when=vim_active),
+            FooterHint(keys="/", label="for commands"),
+            FooterHint(keys="ctrl+l", label="to clear"),
+            FooterHint(keys="i/esc", label="vim", when=vim_active),
         ]
 
     def _redraw(self) -> None:

--- a/src/tui/widgets/status_line.py
+++ b/src/tui/widgets/status_line.py
@@ -19,12 +19,16 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from rich.text import Text
 from textual.reactive import reactive
 from textual.widgets import Static
 
 from ..state import AppState
+
+if TYPE_CHECKING:
+    from .prompt_input_footer import PromptInputFooter
 
 
 # The signature Claude Code "sparkle" spinner: a density ramp of the six
@@ -96,6 +100,11 @@ class StatusLine(Static):
         self._provider_instance = provider_instance
         self._frame = 0
         self._timer = None
+        # Optional hint footer driven off the same is_thinking signal, so
+        # "esc to interrupt" appears exactly while the spinner animates
+        # (single source of truth — see bind_footer / watch_is_thinking).
+        self._footer: "PromptInputFooter | None" = None
+        self._footer_loading = False
         # C3a: output of the user's settings ``statusLine.command`` hook
         # (TS StatusLine.tsx). None = unconfigured/failed → default row.
         self._custom_status: str | None = None
@@ -222,6 +231,30 @@ class StatusLine(Static):
         self._app_state = state
         self._redraw()
 
+    def bind_footer(self, footer: "PromptInputFooter") -> None:
+        """Attach the prompt hint footer so it tracks ``is_thinking``.
+
+        The footer's "esc to interrupt" hint must appear exactly while the
+        agent is busy. Rather than re-derive busy in the REPL screen, the
+        footer rides the same reactive the spinner does (``watch_is_thinking``
+        fires from the tick that polls ``AppState.is_thinking`` and from the
+        explicit ``set_busy``/``set_idle`` setters).
+        """
+
+        self._footer = footer
+        self._sync_footer_loading()
+
+    def _sync_footer_loading(self) -> None:
+        if self._footer is None:
+            return
+        if self.is_thinking == self._footer_loading:
+            return
+        self._footer_loading = self.is_thinking
+        try:
+            self._footer.set_loading(self.is_thinking)
+        except Exception:
+            pass
+
     def refresh_identity(
         self,
         *,
@@ -251,6 +284,7 @@ class StatusLine(Static):
 
     # ---- render ----
     def watch_is_thinking(self, _: bool) -> None:
+        self._sync_footer_loading()
         self._redraw()
 
     def watch_turns(self, _: int) -> None:

--- a/tests/tui/test_prompt_input_footer.py
+++ b/tests/tui/test_prompt_input_footer.py
@@ -57,11 +57,11 @@ async def test_default_hints_rendered_with_vim_off():
     async with _Host(footer).run_test() as pilot:
         await pilot.pause()
         line = footer.last_line
-        # Three hints visible when vim is off — vim hint is filtered.
-        assert "/ command" in line
-        assert "Esc cancel" in line
-        assert "Ctrl+L clear" in line
-        assert "i/Esc vim" not in line
+        # Idle set with the TS "key to/for action" grammar, lowercase keys.
+        assert "/ for commands" in line
+        assert "ctrl+l to clear" in line
+        assert "i/esc vim" not in line  # vim hint filtered when vim off
+        assert "esc to interrupt" not in line  # not loading
 
 
 @pytest.mark.asyncio
@@ -71,7 +71,7 @@ async def test_vim_hint_appears_when_vim_on():
     async with _Host(footer).run_test() as pilot:
         await pilot.pause()
         line = footer.last_line
-        assert "i/Esc vim" in line
+        assert "i/esc vim" in line
 
 
 @pytest.mark.asyncio
@@ -81,11 +81,80 @@ async def test_refresh_hints_picks_up_vim_toggle():
     footer = PromptInputFooter(vim_state=vim)
     async with _Host(footer).run_test() as pilot:
         await pilot.pause()
-        assert "i/Esc vim" not in footer.last_line
+        assert "i/esc vim" not in footer.last_line
         vim.set_enabled(True)
         footer.refresh_hints()
         await pilot.pause()
-        assert "i/Esc vim" in footer.last_line
+        assert "i/esc vim" in footer.last_line
+
+
+@pytest.mark.asyncio
+async def test_loading_collapses_to_interrupt_hint():
+    """While a run is in flight the footer shows only 'esc to interrupt'."""
+    footer = PromptInputFooter(vim_state=VimState(enabled=False))
+    async with _Host(footer).run_test() as pilot:
+        await pilot.pause()
+        footer.set_loading(True)
+        await pilot.pause()
+        line = footer.last_line
+        assert line == "esc to interrupt"
+        assert "for commands" not in line  # idle hints hidden while busy
+        footer.set_loading(False)
+        await pilot.pause()
+        assert "/ for commands" in footer.last_line
+
+
+@pytest.mark.asyncio
+async def test_bash_mode_shows_bash_hint():
+    footer = PromptInputFooter(vim_state=VimState(enabled=False))
+    async with _Host(footer).run_test() as pilot:
+        await pilot.pause()
+        footer.set_bash_mode(True)
+        await pilot.pause()
+        assert footer.last_line == "! for bash mode"
+
+
+@pytest.mark.asyncio
+async def test_bash_mode_takes_precedence_over_loading():
+    # TS parity: ModeIndicator returns "! for bash mode" before any
+    # loading logic (PromptInputFooterLeftSide.tsx:317-319 ahead of :375).
+    footer = PromptInputFooter(vim_state=VimState(enabled=False))
+    async with _Host(footer).run_test() as pilot:
+        await pilot.pause()
+        footer.set_loading(True)
+        footer.set_bash_mode(True)
+        await pilot.pause()
+        assert footer.last_line == "! for bash mode"
+
+
+@pytest.mark.asyncio
+async def test_status_line_drives_footer_loading(monkeypatch):
+    """The footer's loading state rides the StatusLine's is_thinking signal."""
+    from pathlib import Path
+
+    from src.tui.state import AppState
+    from src.tui.widgets.status_line import StatusLine
+
+    monkeypatch.setattr(StatusLine, "refresh_custom_status", lambda self: None)
+    footer = PromptInputFooter(vim_state=VimState(enabled=False))
+    status = StatusLine(
+        provider="p", model="m", workspace_root=Path("/tmp"), app_state=AppState()
+    )
+
+    class _Host2(App):
+        def compose(self) -> ComposeResult:
+            yield status
+            yield footer
+
+    async with _Host2().run_test() as pilot:
+        await pilot.pause()
+        status.bind_footer(footer)
+        status.set_busy()  # is_thinking True → footer shows interrupt hint
+        await pilot.pause()
+        assert footer.last_line == "esc to interrupt"
+        status.set_idle()
+        await pilot.pause()
+        assert "/ for commands" in footer.last_line
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

PR 3 of the TUI UX parity pass. The prompt footer was static (`/ command · Esc cancel · Ctrl+L clear`) regardless of state. Now it's context-aware, matching the ink REPL:

- **While a run is in flight** → `esc to interrupt` (TS `getSpinnerHintParts`). This was the single most-missing hint — the interrupt affordance was absent on every turn.
- **Bash mode** (`!` prefix) → `! for bash mode`. Bash takes precedence over loading, matching TS (`PromptInputFooterLeftSide.tsx:317-319` returns the bash hint ahead of the loading logic at `:375`).
- **Idle** → `/ for commands · ctrl+l to clear` (+ `i/esc vim` when vim on).
- **Grammar**: lowercase keys, `key to/for action` phrasing.

## Single source of truth

The loading hint rides the **same `is_thinking` signal as the spinner**: `StatusLine.bind_footer()` toggles the footer from `watch_is_thinking` (fired by both the tick that polls `AppState.is_thinking` and the explicit `set_busy`/`set_idle` setters), so the `esc to interrupt` hint and the animated spinner can never drift. Bash mode is driven from `PromptInput.on_input_changed`. `repl.py` adds one `bind_footer` line at mount.

The idle `esc` hint is dropped — TS itself removed it as misleading when idle (`PromptInputFooterLeftSide.tsx:416-418`); `esc to interrupt` now shows only while busy.

## Tests
- `tests/tui/test_prompt_input_footer.py` (+6): new grammar, loading→interrupt, bash hint, **bash > loading precedence**, and a `StatusLine → footer` integration test (mutation-checked non-vacuous).
- Full `tests/tui/` suite: **710 passed, 2 skipped**.

## Review
Critic two rounds (REQUEST-CHANGES on a precedence inversion → fixed to TS-faithful bash>loading → APPROVE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)