### PR TITLE
feat(tui): ? shortcuts help panel (PromptInputHelpMenu parity)

### DIFF
--- a/src/tui/commands.py
+++ b/src/tui/commands.py
@@ -279,11 +279,16 @@ def dispatch_local_command(
     if name == "/clear":
         return CommandDispatchResult(handled=True, system_text="__clear__")
     if name == "/help":
+        from .widgets.shortcuts_help import shortcut_lines
+
         lines = [
             "Slash commands:",
             "  " + "  ".join(LOCAL_BUILTINS),
             "Tip: press `/` in the prompt to open the palette.",
             "Exit with /exit or Ctrl+D. /repl is an alias kept for parity.",
+            "",
+            "Keyboard shortcuts (press ? in the prompt to toggle):",
+            *("  " + line for line in shortcut_lines(vim_enabled=False)),
         ]
         return CommandDispatchResult(handled=True, system_text="\n".join(lines))
     if name == "/tools":

--- a/src/tui/widgets/prompt_input.py
+++ b/src/tui/widgets/prompt_input.py
@@ -37,6 +37,7 @@ from ..paste import PasteInfo, classify_paste
 from ..vim import VimState
 from .prompt_input_footer import PromptInputFooter
 from .prompt_input_mode_indicator import PromptInputModeIndicator
+from .shortcuts_help import ShortcutsHelp
 
 
 @dataclass
@@ -167,12 +168,20 @@ class PromptInput(Vertical):
         # siblings of the existing ``Input`` + ``OptionList`` pair.
         self._mode_indicator = PromptInputModeIndicator(vim_state=self._vim)
         self._footer = PromptInputFooter(vim_state=self._vim)
+        # `?`-toggled shortcuts panel (TS PromptInputHelpMenu). Hidden until
+        # `?` is typed into an empty prompt; replaces the footer while open.
+        self._help = ShortcutsHelp(vim_state=self._vim, classes="-hidden")
+        self._help_open = False
+        # Guards the programmatic input reset when `?` toggles help, so the
+        # resulting Input.Changed doesn't immediately close the panel.
+        self._suppress_change = False
 
     def compose(self) -> ComposeResult:
         yield self._mode_indicator
         yield self._input
         yield self._suggestions
         yield self._footer
+        yield self._help
 
     def on_mount(self) -> None:
         self._input.focus()
@@ -290,6 +299,20 @@ class PromptInput(Vertical):
 
     # ---- input events ----
     def on_input_changed(self, event: Input.Changed) -> None:
+        # Swallow the echo from our own programmatic reset (the `?` toggle).
+        if self._suppress_change:
+            self._suppress_change = False
+            return
+        # `?` into an empty prompt toggles the shortcuts panel and is
+        # consumed (TS PromptInput.onChange: value === '?' → toggle, return).
+        if event.value == "?":
+            self._toggle_help()
+            self._suppress_change = True
+            self._input.value = ""
+            return
+        # Any other change closes the panel (TS: setHelpOpen(false)).
+        if self._help_open:
+            self._set_help(False)
         # C4 bash-mode affordance (TS inputModes getModeFromInput): a `!`
         # prefix accents the input border. lstrip matches the dispatch
         # predicate (the submit layer strips before routing).
@@ -297,6 +320,26 @@ class PromptInput(Vertical):
         self.set_class(bash_mode, "-bash-mode")
         self._footer.set_bash_mode(bash_mode)
         self._refresh_suggestions(event.value, event.input.cursor_position)
+
+    # ---- shortcuts help panel ----
+    def _toggle_help(self) -> None:
+        self._set_help(not self._help_open)
+
+    def _set_help(self, show: bool) -> None:
+        """Show/hide the `?` shortcuts panel, swapping it for the footer."""
+        self._help_open = show
+        if show:
+            self._help.refresh_content()
+            self._help.remove_class("-hidden")
+        else:
+            self._help.add_class("-hidden")
+        # Footer owns its own visibility — suppress it while the panel shows
+        # so a run starting mid-help can't render "esc to interrupt" beneath.
+        self._footer.set_suppressed(show)
+
+    @property
+    def help_open(self) -> bool:  # test seam
+        return self._help_open
 
     async def on_input_submitted(self, event: Input.Submitted) -> None:
         # If the palette is open and a row is highlighted, accept the
@@ -387,6 +430,10 @@ class PromptInput(Vertical):
                 event.stop()
                 return
 
+        if key == "escape" and self._help_open:
+            self._set_help(False)
+            event.stop()
+            return
         if key == "tab" and not self._suggestions.has_class("-hidden"):
             # Tab completes the highlighted command without running it
             # (TS handleTab → applyCommandSuggestion(shouldExecute=false)).

--- a/src/tui/widgets/prompt_input_footer.py
+++ b/src/tui/widgets/prompt_input_footer.py
@@ -76,6 +76,12 @@ class PromptInputFooter(Static):
         # in bash mode it shows "! for bash mode".
         self._loading: bool = False
         self._bash_mode: bool = False
+        # When the `?` shortcuts panel is open it replaces the footer (TS
+        # PromptInputFooter.tsx:135 `if (helpOpen) return <HelpMenu>`). The
+        # footer owns its own `-hidden` class — `_set_help` toggles this flag
+        # rather than poking the class, so a run starting while help is open
+        # can't un-hide the footer underneath the panel.
+        self._suppressed: bool = False
         # Track the most recent rendered line as a test seam — same
         # pattern :class:`PromptInputModeIndicator` uses.
         self._last_line: str = ""
@@ -114,6 +120,14 @@ class PromptInputFooter(Static):
         if bash_mode == self._bash_mode:
             return
         self._bash_mode = bash_mode
+        self._redraw()
+
+    def set_suppressed(self, suppressed: bool) -> None:
+        """Hide the footer entirely (the ``?`` panel takes its place)."""
+
+        if suppressed == self._suppressed:
+            return
+        self._suppressed = suppressed
         self._redraw()
 
     @property
@@ -155,13 +169,22 @@ class PromptInputFooter(Static):
         def vim_active() -> bool:
             return vim is not None and vim.enabled
 
+        # TS idle footer is just "? for shortcuts" — the full key list lives
+        # in the `?` panel (ShortcutsHelp). Keep the vim chord hint visible
+        # when vim is on since it's not in the idle panel's default view.
         return [
-            FooterHint(keys="/", label="for commands"),
-            FooterHint(keys="ctrl+l", label="to clear"),
+            FooterHint(keys="?", label="for shortcuts"),
             FooterHint(keys="i/esc", label="vim", when=vim_active),
         ]
 
     def _redraw(self) -> None:
+        # Suppressed → fully hidden, regardless of hint content (the `?`
+        # panel is showing in its place). Single owner of -hidden.
+        if self._suppressed:
+            self._last_line = ""
+            self.add_class("-hidden")
+            self.update(Text(""))
+            return
         hints = self._resolve_hints()
         visible: list[FooterHint] = []
         for hint in hints:

--- a/src/tui/widgets/shortcuts_help.py
+++ b/src/tui/widgets/shortcuts_help.py
@@ -1,0 +1,102 @@
+"""The ``?`` shortcuts help panel.
+
+Port of the ink ``PromptInputHelpMenu`` (``components/PromptInput/
+PromptInputHelpMenu.tsx``): typing ``?`` into an empty prompt toggles a
+muted panel listing the keyboard shortcuts. ``?`` is muscle memory for
+Claude Code users; before this the key did nothing.
+
+This panel lists **only the shortcuts actually wired in this port** — the
+TS menu advertises many more (``& for background``, ``ctrl+t`` tasks,
+model picker, stash, ``$EDITOR``, …) that are gated on subsystems the
+Python TUI hasn't ported. Advertising an unimplemented key is worse than
+omitting it, so :data:`_BASE_SHORTCUTS` is the honest subset. The same
+list feeds the ``/help`` output (single source of truth).
+"""
+
+from __future__ import annotations
+
+from rich.table import Table
+from rich.text import Text
+from textual.widgets import Static
+
+from ..vim import VimState
+
+# (key, action) pairs — every entry maps to a binding the TUI wires today.
+# ``@ for file paths`` is intentionally absent until the @-mention dropdown
+# lands; ``double-tap esc`` / ``shift+tab`` / ``ctrl+r`` likewise wait for
+# their wiring PRs.
+_BASE_SHORTCUTS: list[tuple[str, str]] = [
+    ("/", "for commands"),
+    ("!", "for bash mode"),
+    ("#", "to add a memory"),
+    ("tab", "to complete a command"),
+    ("↑ ↓", "to navigate history"),
+    ("ctrl+l", "to clear the draft"),
+    ("ctrl+o", "to expand last output"),
+    ("esc", "to interrupt"),
+    ("?", "for shortcuts"),
+    ("/exit", "to quit"),
+]
+_VIM_SHORTCUTS: list[tuple[str, str]] = [
+    ("i / esc", "vim insert / normal"),
+]
+
+
+def wired_shortcuts(vim_enabled: bool) -> list[tuple[str, str]]:
+    """The (key, action) pairs to advertise, vim chords appended when on."""
+    pairs = list(_BASE_SHORTCUTS)
+    if vim_enabled:
+        pairs.extend(_VIM_SHORTCUTS)
+    return pairs
+
+
+def shortcut_lines(vim_enabled: bool) -> list[str]:
+    """``["/ for commands", …]`` — used by ``/help`` (plain text)."""
+    return [f"{key} {action}" for key, action in wired_shortcuts(vim_enabled)]
+
+
+class ShortcutsHelp(Static):
+    """Muted two-column shortcut grid, shown while ``?`` is toggled on."""
+
+    DEFAULT_CSS = """
+    ShortcutsHelp {
+        height: auto;
+        padding: 0 2;
+        color: $text-muted;
+    }
+    ShortcutsHelp.-hidden {
+        display: none;
+    }
+    """
+
+    def __init__(
+        self, *, vim_state: VimState | None = None, classes: str | None = None
+    ) -> None:
+        super().__init__("", markup=False, classes=classes)
+        self._vim = vim_state
+
+    def on_mount(self) -> None:
+        self.refresh_content()
+
+    def refresh_content(self) -> None:
+        """Rebuild the grid (call when vim mode toggles before showing)."""
+        vim_on = self._vim is not None and self._vim.enabled
+        pairs = wired_shortcuts(vim_on)
+        grid = Table.grid(padding=(0, 3))
+        grid.add_column()
+        grid.add_column()
+        mid = (len(pairs) + 1) // 2
+        left, right = pairs[:mid], pairs[mid:]
+        for i in range(mid):
+            lk, la = left[i]
+            cells = [Text(f"{lk} {la}", style="dim")]
+            if i < len(right):
+                rk, ra = right[i]
+                cells.append(Text(f"{rk} {ra}", style="dim"))
+            else:
+                cells.append(Text(""))
+            grid.add_row(*cells)
+        self.update(grid)
+
+
+__all__ = ["ShortcutsHelp", "wired_shortcuts", "shortcut_lines"]

--- a/tests/tui/test_prompt_input_footer.py
+++ b/tests/tui/test_prompt_input_footer.py
@@ -57,9 +57,8 @@ async def test_default_hints_rendered_with_vim_off():
     async with _Host(footer).run_test() as pilot:
         await pilot.pause()
         line = footer.last_line
-        # Idle set with the TS "key to/for action" grammar, lowercase keys.
-        assert "/ for commands" in line
-        assert "ctrl+l to clear" in line
+        # TS idle footer is just "? for shortcuts" (full list in the ? panel).
+        assert "? for shortcuts" in line
         assert "i/esc vim" not in line  # vim hint filtered when vim off
         assert "esc to interrupt" not in line  # not loading
 
@@ -98,10 +97,10 @@ async def test_loading_collapses_to_interrupt_hint():
         await pilot.pause()
         line = footer.last_line
         assert line == "esc to interrupt"
-        assert "for commands" not in line  # idle hints hidden while busy
+        assert "shortcuts" not in line  # idle hints hidden while busy
         footer.set_loading(False)
         await pilot.pause()
-        assert "/ for commands" in footer.last_line
+        assert "? for shortcuts" in footer.last_line
 
 
 @pytest.mark.asyncio
@@ -154,7 +153,7 @@ async def test_status_line_drives_footer_loading(monkeypatch):
         assert footer.last_line == "esc to interrupt"
         status.set_idle()
         await pilot.pause()
-        assert "/ for commands" in footer.last_line
+        assert "? for shortcuts" in footer.last_line
 
 
 @pytest.mark.asyncio

--- a/tests/tui/test_shortcuts_help_pr4.py
+++ b/tests/tui/test_shortcuts_help_pr4.py
@@ -1,0 +1,147 @@
+"""`?` shortcuts help panel (TUI UX PR 4).
+
+Ports the ink ``PromptInputHelpMenu``: typing ``?`` into an empty prompt
+toggles a muted shortcut panel (previously ``?`` did nothing). The panel
+lists only wired bindings; the same list feeds ``/help``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("textual")
+
+from textual.app import App, ComposeResult
+
+from src.tui.widgets.prompt_input import PromptInput
+from src.tui.widgets.shortcuts_help import (
+    ShortcutsHelp,
+    shortcut_lines,
+    wired_shortcuts,
+)
+
+
+# ---- pure data ------------------------------------------------------------
+
+
+def test_wired_shortcuts_lists_real_bindings_only():
+    keys = {k for k, _ in wired_shortcuts(vim_enabled=False)}
+    # Wired today:
+    assert {"/", "!", "#", "tab", "ctrl+l", "ctrl+o", "esc", "?", "/exit"} <= keys
+    # NOT wired yet — must not be advertised:
+    assert "@" not in keys  # @-mention dropdown is a later PR
+    assert "shift+tab" not in keys
+    assert "ctrl+r" not in keys
+
+
+def test_vim_shortcuts_appended_only_when_vim_on():
+    off = wired_shortcuts(vim_enabled=False)
+    on = wired_shortcuts(vim_enabled=True)
+    assert len(on) == len(off) + 1
+    assert any("vim" in action for _, action in on)
+    assert all("vim" not in action for _, action in off)
+
+
+def test_shortcut_lines_are_key_space_action():
+    assert "/ for commands" in shortcut_lines(vim_enabled=False)
+    assert "! for bash mode" in shortcut_lines(vim_enabled=False)
+
+
+# ---- widget harness -------------------------------------------------------
+
+
+class _Host(App):
+    def __init__(self, prompt: PromptInput) -> None:
+        super().__init__()
+        self._prompt = prompt
+
+    def compose(self) -> ComposeResult:
+        yield self._prompt
+
+
+def _make_prompt(vim_mode: bool = False) -> PromptInput:
+    return PromptInput(words_provider=lambda: [], vim_mode=vim_mode)
+
+
+@pytest.mark.asyncio
+async def test_question_mark_toggles_help_and_is_consumed():
+    prompt = _make_prompt()
+    async with _Host(prompt).run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("?")
+        await pilot.pause()
+        assert prompt.help_open is True
+        # The `?` is consumed — it never lands in the draft.
+        assert prompt.current_text() == ""
+        # Panel visible, footer hidden while open.
+        assert not prompt._help.has_class("-hidden")
+        assert prompt._footer.has_class("-hidden")
+        # `?` again toggles it back off.
+        await pilot.press("?")
+        await pilot.pause()
+        assert prompt.help_open is False
+        assert prompt._help.has_class("-hidden")
+        assert not prompt._footer.has_class("-hidden")
+
+
+@pytest.mark.asyncio
+async def test_escape_closes_help():
+    prompt = _make_prompt()
+    async with _Host(prompt).run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("?")
+        await pilot.pause()
+        assert prompt.help_open is True
+        await pilot.press("escape")
+        await pilot.pause()
+        assert prompt.help_open is False
+
+
+@pytest.mark.asyncio
+async def test_typing_after_help_closes_it_and_inserts():
+    prompt = _make_prompt()
+    async with _Host(prompt).run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("?")
+        await pilot.pause()
+        assert prompt.help_open is True
+        await pilot.press("h", "i")
+        await pilot.pause()
+        # Help closed and the keystrokes landed in the draft.
+        assert prompt.help_open is False
+        assert prompt.current_text() == "hi"
+
+
+@pytest.mark.asyncio
+async def test_footer_stays_hidden_when_loading_starts_during_help():
+    """A run starting while the `?` panel is open must not render the
+    footer's "esc to interrupt" beneath the panel (TS short-circuits the
+    footer entirely while helpOpen)."""
+    prompt = _make_prompt()
+    async with _Host(prompt).run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("?")
+        await pilot.pause()
+        assert prompt.help_open is True
+        # Simulate the agent going busy while help is open.
+        prompt._footer.set_loading(True)
+        await pilot.pause()
+        assert prompt._footer.has_class("-hidden")  # still suppressed
+        assert not prompt._help.has_class("-hidden")  # panel still shown
+        # Closing help restores the footer, now showing the interrupt hint.
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not prompt._footer.has_class("-hidden")
+        assert prompt._footer.last_line == "esc to interrupt"
+
+
+@pytest.mark.asyncio
+async def test_question_mark_mid_text_is_literal_not_a_toggle():
+    prompt = _make_prompt()
+    async with _Host(prompt).run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("a", "b", "?")
+        await pilot.pause()
+        # `?` after text is a normal character; no toggle.
+        assert prompt.help_open is False
+        assert prompt.current_text() == "ab?"


### PR DESCRIPTION
## What

PR 4 of the TUI UX parity pass. `?` is muscle memory in Claude Code but did **nothing** in this port. Now typing `?` into an empty prompt toggles a muted two-column panel of keyboard shortcuts (TS `PromptInputHelpMenu`), replacing the footer while open.

```
  / for commands              ctrl+l to clear the draft
  ! for bash mode             ctrl+o to expand last output
  # to add a memory           esc to interrupt
  tab to complete a command   ? for shortcuts
  ↑ ↓ to navigate history     /exit to quit
```

### Behavior (TS-faithful — `PromptInput.tsx:866-872`)
- `?` into an empty prompt toggles the panel and is **consumed** (never lands in the draft).
- Any other change closes it; `?` mid-text (`ab?`) is a literal char.
- Escape closes it.

### Honest binding list
`src/tui/widgets/shortcuts_help.py` lists **only shortcuts actually wired in this port**. Unported keys (`@`, `shift+tab`, `ctrl+r`, double-esc) are deliberately omitted — advertising a dead key is worse than omitting it. The `ctrl+o` label says "to expand last output" (what this port does) rather than TS's persistent-verbose wording.

### Also
- The same `_BASE_SHORTCUTS` list feeds `/help`'s new **Keyboard shortcuts** section (single source of truth).
- Idle footer → just `? for shortcuts` (TS `PromptInputFooterLeftSide.tsx:411`); the full list now lives in the panel.
- The footer owns its own visibility via `set_suppressed()`, so a run starting while the panel is open can't render `esc to interrupt` beneath it (matches TS's `if (helpOpen) return <HelpMenu>` short-circuit).

## Tests
- New `tests/tui/test_shortcuts_help_pr4.py`: toggle, `?` consumed, escape-closes, type-after-closes-and-inserts, mid-text literal, honest binding list, **loading-during-help regression**.
- Full `tests/tui/` suite: **718 passed, 2 skipped**.

## Review
Critic two rounds (REQUEST-CHANGES on a footer-under-panel render bug → fixed with single-owner `set_suppressed` → APPROVE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)