### PR TITLE
feat(tui): @ file-mention dropdown with in-place splice

### DIFF
--- a/src/tui/screens/repl.py
+++ b/src/tui/screens/repl.py
@@ -109,6 +109,7 @@ class REPLScreen(Screen):
         self.prompt_input = PromptInput(
             words_provider=words_provider,
             suggestions_provider=suggestions_provider,
+            files_provider=self._workspace_files,
             vim_mode=initial_vim_mode(),
         )
         # Dim preview of prompts queued while a run is in flight (parity
@@ -127,6 +128,30 @@ class REPLScreen(Screen):
 
     def compose(self) -> ComposeResult:
         yield self._fullscreen
+
+    def _workspace_files(self) -> list[str]:
+        """Cached workspace file list for the ``@``-mention dropdown.
+
+        ``rg --files`` is run once per session and reused (same snapshot
+        strategy as the ``/open`` quick-open dialog) so typing ``@`` never
+        spawns ripgrep per keystroke. Failures degrade to an empty list.
+        """
+
+        cached = getattr(self, "_workspace_files_cache", None)
+        if cached is not None:
+            return cached
+        try:
+            from src.services.workspace_search import list_workspace_files
+
+            files, _truncated = list_workspace_files(str(self._workspace_root))
+        except Exception:
+            # Transient ripgrep failure — don't cache, so the next `@`
+            # keystroke retries (TS resets its file-list promise on error).
+            return []
+        # Cache successful results (including a legitimately empty repo) so
+        # `@` typing never re-spawns ripgrep per keystroke.
+        self._workspace_files_cache = files
+        return files
 
     def on_mount(self) -> None:
         self._fullscreen.scroll_region().mount(self.header_widget)

--- a/src/tui/widgets/prompt_input.py
+++ b/src/tui/widgets/prompt_input.py
@@ -145,11 +145,18 @@ class PromptInput(Vertical):
         *,
         words_provider: Callable[[], list[str]],
         suggestions_provider: Callable[[], list[CommandSuggestion]] | None = None,
+        files_provider: Callable[[], list[str]] | None = None,
         vim_mode: bool = False,
     ) -> None:
         super().__init__()
         self._words_provider = words_provider
         self._suggestions_provider = suggestions_provider
+        # Returns the (host-cached) workspace file list for the `@`-mention
+        # dropdown. None disables @-completion (legacy/embedded callers).
+        self._files_provider = files_provider
+        # Which popup is showing: "slash" command palette or "at" file list.
+        # Drives how an accepted row is applied (execute/fill vs splice).
+        self._suggest_mode = "slash"
         self._history: list[str] = []
         self._history_pos: int | None = None
         self._input = _PasteAwareInput(placeholder="Type a prompt, or / for commands")
@@ -380,13 +387,14 @@ class PromptInput(Vertical):
         execute: bool,
         option: Option | None = None,
     ) -> bool:
-        """Accept the highlighted (or given) slash suggestion.
+        """Accept the highlighted (or given) suggestion row.
 
-        ``execute=True`` (Enter): run a zero-arg command immediately; for
-        an arg-taking command, fall back to filling ``/<name> `` so the
-        user can type the argument. ``execute=False`` (Tab): always fill
-        ``/<name> `` without running. Returns ``True`` if a row was
-        accepted.
+        In ``@``-mention mode the row is a file path → delegate to
+        ``_insert_file_mention`` (splice in place; ``execute`` ignored).
+        In slash mode: ``execute=True`` (Enter) runs a zero-arg command
+        immediately, or fills ``/<name> `` for an arg-taking one so the user
+        can type the argument; ``execute=False`` (Tab) always fills without
+        running. Returns ``True`` if a row was accepted.
         """
 
         if option is None:
@@ -399,6 +407,11 @@ class PromptInput(Vertical):
                 return False
         if option is None or not option.id:
             return False
+        # File mention: splice "@<path> " in place (mid-line safe) — never
+        # execute, never overwrite the whole draft. Both Enter and Tab fill.
+        if self._suggest_mode == "at":
+            self._insert_file_mention(str(option.id))
+            return True
         slash = str(option.id)
         run_now = execute and not self._arg_lookup.get(slash, False)
         if run_now:
@@ -417,6 +430,32 @@ class PromptInput(Vertical):
             self._hide_suggestions()
             self._input.focus()
         return True
+
+    def _insert_file_mention(self, path: str) -> None:
+        """Replace the ``@partial`` token under the cursor with ``@<path> ``.
+
+        Splices in place so surrounding text is preserved (TS
+        applyFileSuggestion), unlike the whole-line slash accept. Recomputes
+        the token from the live buffer so it's robust to cursor movement.
+        """
+
+        value = self._input.value or ""
+        cursor = self._input.cursor_position
+        token, start = _current_at_token(value[:cursor])
+        if token is None:
+            self._hide_suggestions()
+            return
+        from src.services.workspace_search import file_insertion
+
+        replacement = file_insertion(path)  # "@<path> "
+        new_value = value[:start] + replacement + value[cursor:]
+        self._input.value = new_value
+        try:
+            self._input.cursor_position = start + len(replacement)
+        except Exception:
+            pass
+        self._hide_suggestions()
+        self._input.focus()
 
     async def on_key(self, event: events.Key) -> None:
         key = event.key
@@ -518,13 +557,20 @@ class PromptInput(Vertical):
 
     # ---- suggestion plumbing ----
     def _refresh_suggestions(self, text: str, cursor: int) -> None:
-        token, _ = _current_slash_token(text[:cursor])
-        if token is None:
+        before = text[:cursor]
+        # Slash command palette takes precedence over @-mentions.
+        slash_token, _ = _current_slash_token(before)
+        if slash_token is not None:
+            self._suggest_mode = "slash"
+            options = self._build_suggestion_options(slash_token[1:].lower())
+        elif self._files_provider is not None and (
+            (at_token := _current_at_token(before)[0]) is not None
+        ):
+            self._suggest_mode = "at"
+            options = self._build_file_options(at_token[1:])
+        else:
             self._hide_suggestions()
             return
-        partial = token[1:].lower()
-
-        options = self._build_suggestion_options(partial)
         if not options:
             self._hide_suggestions()
             return
@@ -532,6 +578,22 @@ class PromptInput(Vertical):
         self._suggestions.add_options(options)
         self._suggestions.highlighted = 0
         self._suggestions.remove_class("-hidden")
+
+    def _build_file_options(self, partial: str) -> list[Option]:
+        """File rows for the ``@``-mention dropdown (reuses /search infra)."""
+        try:
+            files = self._files_provider() or []
+        except Exception:
+            files = []
+        if not files:
+            return []
+        from src.services.workspace_search import filter_files
+
+        matches = filter_files(files, partial, limit=_MAX_VISIBLE_SUGGESTIONS)
+        return [
+            Option(Text(path, no_wrap=True, overflow="ellipsis"), id=path)
+            for path in matches
+        ]
 
     def _build_suggestion_options(self, partial: str) -> list[Option]:
         """Return the rich Option rows to show under the prompt.
@@ -774,25 +836,27 @@ def _prev_word(text: str, pos: int) -> int:
     return pos
 
 
-def _current_slash_token(text_before_cursor: str) -> tuple[str | None, int]:
-    """Return ``(token, start_idx)`` for the slash command under the cursor.
+def _current_prefix_token(
+    text_before_cursor: str, sigil: str
+) -> tuple[str | None, int]:
+    """Return ``(token, start_idx)`` for a ``<sigil>word`` under the cursor.
 
-    Semantics locked in by :mod:`tests.tui.test_slash_token_parser`: a
-    slash token is a ``/word`` that either starts at the beginning of
-    the buffer or is preceded by whitespace. A slash followed by a
-    space has already been "committed" and does not re-open the popup.
+    A token is a ``<sigil>word`` that starts at the beginning of the buffer
+    or is preceded by whitespace, with no space inside it (a space commits
+    it and closes the popup). Shared by the ``/`` command palette and the
+    ``@`` file-mention dropdown.
     """
 
     text = text_before_cursor
     if not text:
         return None, 0
-    if text.startswith("/"):
+    if text.startswith(sigil):
         if " " in text:
             return None, 0
         return text, 0
     for i in range(len(text) - 1, -1, -1):
         ch = text[i]
-        if ch == "/":
+        if ch == sigil:
             if i > 0 and not text[i - 1].isspace():
                 return None, 0
             token = text[i:]
@@ -802,3 +866,26 @@ def _current_slash_token(text_before_cursor: str) -> tuple[str | None, int]:
         if ch.isspace():
             return None, 0
     return None, 0
+
+
+def _current_slash_token(text_before_cursor: str) -> tuple[str | None, int]:
+    """Return ``(token, start_idx)`` for the slash command under the cursor.
+
+    Semantics locked in by :mod:`tests.tui.test_slash_token_parser`: a
+    slash token is a ``/word`` that either starts at the beginning of
+    the buffer or is preceded by whitespace. A slash followed by a
+    space has already been "committed" and does not re-open the popup.
+    """
+
+    return _current_prefix_token(text_before_cursor, "/")
+
+
+def _current_at_token(text_before_cursor: str) -> tuple[str | None, int]:
+    """Return ``(token, start_idx)`` for the ``@file`` mention under the cursor.
+
+    Same boundary rules as the slash token (start-of-buffer or after
+    whitespace; no internal space), so ``email@host`` does NOT trigger the
+    dropdown but ``explain @util`` does. The ``@`` is included in the token.
+    """
+
+    return _current_prefix_token(text_before_cursor, "@")

--- a/src/tui/widgets/shortcuts_help.py
+++ b/src/tui/widgets/shortcuts_help.py
@@ -22,12 +22,12 @@ from textual.widgets import Static
 from ..vim import VimState
 
 # (key, action) pairs — every entry maps to a binding the TUI wires today.
-# ``@ for file paths`` is intentionally absent until the @-mention dropdown
-# lands; ``double-tap esc`` / ``shift+tab`` / ``ctrl+r`` likewise wait for
-# their wiring PRs.
+# ``double-tap esc`` / ``shift+tab`` / ``ctrl+r`` are intentionally absent
+# until their wiring PRs land.
 _BASE_SHORTCUTS: list[tuple[str, str]] = [
     ("/", "for commands"),
     ("!", "for bash mode"),
+    ("@", "for file paths"),
     ("#", "to add a memory"),
     ("tab", "to complete a command"),
     ("↑ ↓", "to navigate history"),

--- a/tests/tui/test_at_mentions_pr5.py
+++ b/tests/tui/test_at_mentions_pr5.py
@@ -1,0 +1,144 @@
+"""`@` file-mention dropdown (TUI UX PR 5).
+
+Ports the ink file typeahead: typing ``@`` (at the start or after
+whitespace) opens an inline file-suggestion dropdown; accepting a row
+splices ``@<path> `` into the draft in place. Reuses the ``/search`` file
+infra (``workspace_search.list_workspace_files``/``filter_files``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("textual")
+
+from textual.app import App, ComposeResult
+
+from src.tui.widgets.prompt_input import (
+    PromptInput,
+    _current_at_token,
+    _current_slash_token,
+)
+
+_FILES = [
+    "src/app.py",
+    "src/tui/widgets/prompt_input.py",
+    "README.md",
+    "tests/test_app.py",
+]
+
+
+# ---- token parser ---------------------------------------------------------
+
+
+def test_at_token_triggers_at_start_and_after_space():
+    assert _current_at_token("@") == ("@", 0)
+    assert _current_at_token("@util") == ("@util", 0)
+    assert _current_at_token("explain @ut") == ("@ut", 8)
+
+
+def test_at_token_not_triggered_mid_word_or_after_space():
+    # An email-like @ (preceded by non-space) is not a mention trigger.
+    assert _current_at_token("email@host") == (None, 0)
+    # A committed mention (space after) closes the popup.
+    assert _current_at_token("@util ") == (None, 0)
+    assert _current_at_token("plain text") == (None, 0)
+
+
+def test_slash_token_unchanged_by_refactor():
+    # The shared parser must preserve slash semantics.
+    assert _current_slash_token("/he") == ("/he", 0)
+    assert _current_slash_token("echo /ex") == ("/ex", 5)
+    assert _current_slash_token("src/re") == (None, 0)
+
+
+# ---- widget harness -------------------------------------------------------
+
+
+class _Host(App):
+    def __init__(self, prompt: PromptInput) -> None:
+        super().__init__()
+        self._prompt = prompt
+
+    def compose(self) -> ComposeResult:
+        yield self._prompt
+
+
+def _make_prompt() -> PromptInput:
+    return PromptInput(
+        words_provider=lambda: [],
+        files_provider=lambda: list(_FILES),
+    )
+
+
+def _rows(prompt: PromptInput) -> list[str]:
+    sl = prompt._suggestions
+    if sl.has_class("-hidden"):
+        return []
+    return [sl.get_option_at_index(i).id for i in range(sl.option_count)]
+
+
+@pytest.mark.asyncio
+async def test_at_opens_file_dropdown():
+    prompt = _make_prompt()
+    async with _Host(prompt).run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("@")
+        await pilot.pause()
+        # Empty @ lists files (capped).
+        assert len(_rows(prompt)) > 0
+        assert "README.md" in _rows(prompt)
+
+
+@pytest.mark.asyncio
+async def test_at_filters_fuzzily():
+    prompt = _make_prompt()
+    async with _Host(prompt).run_test() as pilot:
+        await pilot.pause()
+        for ch in "@prompt":
+            await pilot.press(ch)
+        await pilot.pause()
+        rows = _rows(prompt)
+        assert "src/tui/widgets/prompt_input.py" in rows
+        assert "README.md" not in rows
+
+
+@pytest.mark.asyncio
+async def test_accept_splices_mention_in_place():
+    prompt = _make_prompt()
+    async with _Host(prompt).run_test() as pilot:
+        await pilot.pause()
+        for ch in "explain ":
+            await pilot.press("space" if ch == " " else ch)
+        for ch in "@read":
+            await pilot.press(ch)
+        await pilot.pause()
+        assert "README.md" in _rows(prompt)
+        await pilot.press("enter")  # accept highlighted
+        await pilot.pause()
+        # Spliced in place, surrounding text preserved, trailing space added.
+        assert prompt.current_text() == "explain @README.md "
+
+
+@pytest.mark.asyncio
+async def test_tab_also_splices_file():
+    prompt = _make_prompt()
+    async with _Host(prompt).run_test() as pilot:
+        await pilot.pause()
+        for ch in "@readme":
+            await pilot.press(ch)
+        await pilot.pause()
+        await pilot.press("tab")
+        await pilot.pause()
+        assert prompt.current_text() == "@README.md "
+
+
+@pytest.mark.asyncio
+async def test_at_disabled_without_files_provider():
+    prompt = PromptInput(words_provider=lambda: [])  # no files_provider
+    async with _Host(prompt).run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("@")
+        await pilot.pause()
+        assert _rows(prompt) == []  # no dropdown
+        assert prompt.current_text() == "@"  # @ is a literal char

--- a/tests/tui/test_shortcuts_help_pr4.py
+++ b/tests/tui/test_shortcuts_help_pr4.py
@@ -26,10 +26,9 @@ from src.tui.widgets.shortcuts_help import (
 
 def test_wired_shortcuts_lists_real_bindings_only():
     keys = {k for k, _ in wired_shortcuts(vim_enabled=False)}
-    # Wired today:
-    assert {"/", "!", "#", "tab", "ctrl+l", "ctrl+o", "esc", "?", "/exit"} <= keys
+    # Wired today (@ landed with the @-mention dropdown):
+    assert {"/", "!", "@", "#", "tab", "ctrl+l", "ctrl+o", "esc", "?", "/exit"} <= keys
     # NOT wired yet — must not be advertised:
-    assert "@" not in keys  # @-mention dropdown is a later PR
     assert "shift+tab" not in keys
     assert "ctrl+r" not in keys
 


### PR DESCRIPTION
## What

PR 5 of the TUI UX parity pass. Typing `@` (at the start or after whitespace) now opens an **inline file-suggestion dropdown** — before this, `@` had no live completion (only post-submit `expand_at_mentions`). Accepting a row splices `@<path> ` into the draft **in place** (TS `applyFileSuggestion`), preserving surrounding text.

```
 @
 src/main.py
 src/app.py
 README.md
```

### Implementation
- Generalized the slash-token parser into `_current_prefix_token(text, sigil)`; `_current_slash_token` now delegates to it (semantics **unchanged** — `test_slash_token_parser` still green) and a new `_current_at_token` uses `@`. `email@host` does NOT trigger (preceded by non-space); a committed `@path ` closes the popup.
- `PromptInput` gains `files_provider` (host-cached file list) + `_suggest_mode` (`"slash"`|`"at"`); **slash takes precedence** over `@`.
- Reuses the `/search` infra: `filter_files` (fuzzy) over `list_workspace_files` (`rg --files`, gitignore-aware), capped at 6.
- `repl.py` caches the file list **once per session** (no ripgrep per keystroke); a transient `rg` failure isn't cached so the next `@` retries (TS resets its file-list promise on error).
- Both Enter and Tab splice the file (files never execute / submit).
- Added `@ for file paths` to the `?` shortcuts panel now that it's wired.

### Deferred (intentional, out of scope)
agent-name `@`, MCP-resource `@`, `@~/` path traversal, quoted paths with spaces, drag-drop — all subsystem-gated.

## Tests
- New `tests/tui/test_at_mentions_pr5.py`: token boundaries, slash-unchanged regression, open/filter, **mid-line splice** (`explain @read` → `explain @README.md `), Tab splice, `files_provider=None` disabled path.
- Full `tests/tui/` suite: **726 passed, 2 skipped**.

## Review
Critic APPROVE — verified the parser refactor is non-regressing via a 22,627-case fuzz; applied its two recommended nits (docstring + don't-cache-failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)