### PR TITLE
fix(tui): double-press Ctrl+C / Ctrl+D to exit (stop instant-quit + dead Ctrl+D)

### DIFF
--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -15,6 +15,7 @@ screen then materialises as a modal.
 from __future__ import annotations
 
 import logging
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -42,7 +43,7 @@ from .commands import (
     dispatch_registry_command,
 )
 from .history_store import HistoryStore  # noqa: F401 (re-exported for tests)
-from .messages import CancelRequested, QueuedPromptsChanged
+from .messages import CancelRequested, ExitRequested, QueuedPromptsChanged
 from .screens.cost_threshold import CostThresholdScreen
 from .screens.diff_dialog import DiffDialogScreen, FileDiff
 from .screens.effort_picker import EffortPickerScreen
@@ -102,9 +103,14 @@ class ClawCodexTUI(App):
     TITLE = "ClawCodex"
     SUB_TITLE = "interactive terminal"
 
+    # NOTE: Ctrl+C/Ctrl+D reach these app actions only on the REPL screen
+    # (Textual's screen-level ctrl+c=copy SkipActions through to the app when
+    # nothing is selected). While a ModalScreen is open it captures these
+    # keys, so the double-press exit does NOT fire inside dialogs — every
+    # modal uses Esc to dismiss, which is the intended escape hatch.
     BINDINGS = [
         ("ctrl+c", "cancel_or_quit", "Cancel / Quit"),
-        ("ctrl+d", "quit", "Quit"),
+        ("ctrl+d", "request_quit", "Quit"),
     ]
 
     def __init__(
@@ -151,6 +157,13 @@ class ClawCodexTUI(App):
         # alt-screen tears down. Mirrors the TS ink behaviour where the
         # conversation the user saw stays on-screen after ``/exit``.
         self.exit_snapshot: list[Any] = []
+        # Double-press exit (Ctrl+C / Ctrl+D): first press arms + warns,
+        # a second press within the window exits. monotonic timestamp of
+        # the last arming press; None = not armed. (Must NOT default to 0.0:
+        # Linux CLOCK_MONOTONIC starts at boot, so a process launched in the
+        # first 0.8s would treat 0.0 as "armed" and exit on a single press —
+        # TS useDoublePress guards on an explicit timer flag too.)
+        self._pending_exit_at: float | None = None
         # Persistent prompt history used by the PromptInput (↑/↓) and
         # the /history slash-command dialog. The store is append-only
         # per turn and auto-rotates past ``max_entries``.
@@ -655,11 +668,56 @@ class ClawCodexTUI(App):
             pass
 
     # ---- bindings ----
+    _DOUBLE_PRESS_SECONDS = 0.8
+
     def action_cancel_or_quit(self) -> None:
-        # Phase 1 keeps Ctrl+C as exit. Real cancellation (interrupt the
-        # in-flight agent loop) lands in Phase 2 alongside the cost /
-        # idle dialogs.
-        self.exit()
+        # Ctrl+C: double-press to exit (TS handleCtrlC). A lone Ctrl+C no
+        # longer kills the app + discards the draft; the first press clears
+        # a non-empty draft (shell idiom) and warns, the second exits.
+        self._request_exit("ctrl-c")
+
+    def action_request_quit(self) -> None:
+        # Ctrl+D when the prompt input isn't focused (e.g. a modal). The
+        # focused-input case is handled by _PasteAwareInput → ExitRequested.
+        self._request_exit("ctrl-d")
+
+    def on_exit_requested(self, message: "ExitRequested") -> None:
+        self._request_exit(getattr(message, "source", "ctrl-d"))
+
+    def _active_prompt(self) -> Any | None:
+        screen = self._repl_screen
+        return getattr(screen, "prompt_input", None) if screen is not None else None
+
+    def _request_exit(self, source: str) -> None:
+        """Shared double-press exit for Ctrl+C / Ctrl+D."""
+        now = time.monotonic()
+        armed = (
+            self._pending_exit_at is not None
+            and (now - self._pending_exit_at) <= self._DOUBLE_PRESS_SECONDS
+        )
+        if armed:
+            self.exit()
+            return
+        label = "Ctrl-C" if source == "ctrl-c" else "Ctrl-D"
+        # Ctrl+C clears a non-empty draft on the first press (shell idiom);
+        # Ctrl+D only reaches here on an empty buffer.
+        if source == "ctrl-c":
+            prompt = self._active_prompt()
+            if prompt is not None and prompt.current_text():
+                try:
+                    prompt.clear()
+                except Exception:
+                    pass
+        self._pending_exit_at = now
+        try:
+            # Match the toast lifetime to the double-press window so the
+            # affordance disappears exactly when a press would re-arm.
+            self.notify(
+                f"Press {label} again to exit",
+                timeout=self._DOUBLE_PRESS_SECONDS,
+            )
+        except Exception:
+            pass
 
     # ---- local command dispatcher ----
     def handle_local_slash_command(self, text: str, transcript: Transcript) -> bool:

--- a/src/tui/messages.py
+++ b/src/tui/messages.py
@@ -180,6 +180,19 @@ class CancelRequested(Message):
 
 
 @dataclass
+class ExitRequested(Message):
+    """User pressed Ctrl+D on an empty prompt.
+
+    The stock ``Input`` swallows Ctrl+D (delete-forward), which is a no-op
+    on an empty buffer — so the app's quit binding never fires. The
+    paste-aware input posts this instead, and the app runs the same
+    double-press exit flow as Ctrl+C (``ClawCodexTUI._request_exit``).
+    """
+
+    source: str = "ctrl-d"
+
+
+@dataclass
 class QueuedPromptReady(Message):
     """A queued prompt may be drained now that the bridge is idle.
 

--- a/src/tui/screens/exit_flow.py
+++ b/src/tui/screens/exit_flow.py
@@ -21,7 +21,10 @@ ExitAction = Literal["quit", "quit-clear", "cancel"]
 
 
 class ExitFlowScreen(DialogScreen["ExitAction"]):
-    """Confirm-exit dialog pushed when the user hits Ctrl+D / ``/exit``.
+    """Confirm-exit dialog pushed by ``/exit``.
+
+    (Ctrl+C / Ctrl+D exit directly via the double-press flow in
+    ``ClawCodexTUI._request_exit`` and do NOT push this dialog.)
 
     Resolves with:
       * ``"quit"``       — leave, keep conversation in session history.

--- a/src/tui/widgets/prompt_input.py
+++ b/src/tui/widgets/prompt_input.py
@@ -3,18 +3,19 @@
 Port of ``typescript/src/components/PromptInput/PromptInput.tsx`` at the
 fidelity required to feel like the ink reference:
 
-* Multi-line editing via ``Shift+Enter`` / ``Ctrl+J`` (Textual's default)
-  with plain ``Enter`` submitting the prompt.
+* Plain ``Enter`` submits the prompt.
 * Slash-command palette opens when the current token starts with ``/``
-  and fuzzy-filters as the user types.
+  and fuzzy-filters as the user types; ``@`` opens the file-mention list.
 * Up / Down navigate the in-session history when the palette is closed;
   when it is open, arrow keys drive the option list.
 * ``Escape`` closes the palette without losing the draft.
 * ``Ctrl+L`` clears the draft.
 
-Phase 1 deliberately keeps the implementation single-line-in-practice
-(using Textual's ``Input``) but exposes :meth:`set_multiline` for
-Phase 2 to swap in a ``TextArea`` without changing the public surface.
+The implementation is single-line in practice (Textual's ``Input``).
+Multi-line editing (``Shift+Enter`` / ``Ctrl+J`` newline insertion) needs
+a ``TextArea`` swap — a deliberately-deferred future change — so those
+keys are NOT yet wired (the earlier docstring claiming they worked was
+inaccurate).
 """
 
 from __future__ import annotations
@@ -28,11 +29,12 @@ from textual import events
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.message import Message
+from textual.binding import Binding
 from textual.widgets import Input, OptionList
 from textual.widgets.option_list import Option
 
 from ..commands import CommandSuggestion
-from ..messages import CancelRequested, PromptPasted
+from ..messages import CancelRequested, ExitRequested, PromptPasted
 from ..paste import PasteInfo, classify_paste
 from ..vim import VimState
 from .prompt_input_footer import PromptInputFooter
@@ -63,6 +65,17 @@ class _PasteAwareInput(Input):
     the host owns the buffer mutation so vim-mode shims, slash-popup
     suppression, and history-pointer hygiene all happen in one place.
     """
+
+    # Override the stock ``delete,ctrl+d → delete_right`` so Ctrl+D on an
+    # EMPTY buffer requests exit (TS handleEmptyCtrlD) instead of no-op'ing.
+    # The plain ``delete`` key keeps deleting forward (inherited binding).
+    BINDINGS = [Binding("ctrl+d", "smart_ctrl_d", "", show=False)]
+
+    def action_smart_ctrl_d(self) -> None:
+        if self.value:
+            self.action_delete_right()  # non-empty: normal forward-delete
+        else:
+            self.post_message(ExitRequested(source="ctrl-d"))
 
     def _on_paste(self, event: events.Paste) -> None:  # type: ignore[override]
         # Walk up the widget tree looking for a parent that knows how

--- a/tests/tui/test_exit_fundamentals_pr6.py
+++ b/tests/tui/test_exit_fundamentals_pr6.py
@@ -1,0 +1,130 @@
+"""Ctrl+C / Ctrl+D exit fundamentals (TUI UX PR 6).
+
+Before this, a single Ctrl+C instantly killed the app and discarded the
+draft, and Ctrl+D on an empty prompt did nothing (the stock Input swallows
+it). Now both use a double-press exit (TS handleCtrlC / handleEmptyCtrlD):
+first press arms + warns (Ctrl+C also clears a non-empty draft), a second
+press within the window exits. Ctrl+D on a non-empty buffer still deletes
+forward.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("textual")
+
+from src.tui.app import ClawCodexTUI
+from src.tui.widgets import PromptInput
+from src.tool_system.context import ToolContext
+from src.tool_system.registry import ToolRegistry
+
+
+class _FakeProvider:
+    provider_name = "fake"
+    model = "claude-opus-4-8"
+
+
+def _make_app(root: Path) -> ClawCodexTUI:
+    return ClawCodexTUI(
+        provider=_FakeProvider(),
+        provider_name="fake",
+        workspace_root=root,
+        tool_registry=ToolRegistry(),
+        tool_context=ToolContext(workspace_root=root),
+        stream=False,
+    )
+
+
+async def _boot(app: ClawCodexTUI, pilot) -> list:
+    """Dismiss the bypass gate and stub exit; return the exit-call sink."""
+    await pilot.pause()
+    await pilot.press("down")  # → "Yes, I accept"
+    await pilot.press("enter")
+    await pilot.pause()
+    exited: list = []
+    app.exit = lambda *a, **k: exited.append(True)  # type: ignore[method-assign]
+    return exited
+
+
+@pytest.mark.asyncio
+async def test_single_ctrl_c_does_not_exit(tmp_path):
+    app = _make_app(tmp_path)
+    async with app.run_test(size=(100, 30)) as pilot:
+        exited = await _boot(app, pilot)
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+        assert exited == []  # armed, not exited
+        assert app._pending_exit_at != 0.0
+
+
+@pytest.mark.asyncio
+async def test_double_ctrl_c_exits(tmp_path):
+    app = _make_app(tmp_path)
+    async with app.run_test(size=(100, 30)) as pilot:
+        exited = await _boot(app, pilot)
+        await pilot.press("ctrl+c")
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+        assert exited == [True]
+
+
+@pytest.mark.asyncio
+async def test_ctrl_c_clears_nonempty_draft_first(tmp_path):
+    app = _make_app(tmp_path)
+    async with app.run_test(size=(100, 30)) as pilot:
+        exited = await _boot(app, pilot)
+        prompt = app.screen.query_one(PromptInput)
+        for ch in "hello":
+            await pilot.press(ch)
+        await pilot.pause()
+        assert prompt.current_text() == "hello"
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+        # First press cleared the draft and armed; did not exit.
+        assert prompt.current_text() == ""
+        assert exited == []
+
+
+@pytest.mark.asyncio
+async def test_pending_exit_uses_none_sentinel_not_zero(tmp_path):
+    # Regression: Linux CLOCK_MONOTONIC starts at boot, so a 0.0 default would
+    # read as "armed" (now - 0.0 <= 0.8) within the first 0.8s of uptime and
+    # exit on a SINGLE press. The unarmed state must be an explicit None
+    # sentinel, and the armed check must guard it (see _request_exit).
+    app = _make_app(tmp_path)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(app, pilot)
+        assert app._pending_exit_at is None  # not 0.0
+
+
+@pytest.mark.asyncio
+async def test_ctrl_d_on_empty_arms_then_exits(tmp_path):
+    app = _make_app(tmp_path)
+    async with app.run_test(size=(100, 30)) as pilot:
+        exited = await _boot(app, pilot)
+        await pilot.press("ctrl+d")
+        await pilot.pause()
+        assert exited == []  # armed
+        await pilot.press("ctrl+d")
+        await pilot.pause()
+        assert exited == [True]
+
+
+@pytest.mark.asyncio
+async def test_ctrl_d_on_nonempty_deletes_forward(tmp_path):
+    app = _make_app(tmp_path)
+    async with app.run_test(size=(100, 30)) as pilot:
+        exited = await _boot(app, pilot)
+        prompt = app.screen.query_one(PromptInput)
+        for ch in "abc":
+            await pilot.press(ch)
+        # Move cursor to start so ctrl+d (delete-forward) has something to eat.
+        prompt._input.cursor_position = 0
+        await pilot.pause()
+        await pilot.press("ctrl+d")
+        await pilot.pause()
+        assert prompt.current_text() == "bc"  # deleted 'a' forward
+        assert exited == []  # not an exit while buffer non-empty


### PR DESCRIPTION
## What

PR 6 of the TUI UX parity pass. Two exit-key bugs, matching the ink REPL (TS `handleCtrlC` / `handleEmptyCtrlD`):

- **Ctrl+C instantly killed the app** and discarded the draft. Now it's a double-press: the first press clears a non-empty draft (shell idiom) and warns "Press Ctrl-C again to exit"; a second press within 0.8s exits. (ESC still interrupts a running agent — Ctrl+C is exit-only, consistent with the `esc to interrupt` hint.)
- **Ctrl+D on an empty prompt did nothing** — Textual's `Input` binds `delete,ctrl+d → delete_right` (a no-op on empty), shadowing the app quit, which contradicts the on-screen "Ctrl+D to leave" text. `_PasteAwareInput` now overrides `ctrl+d`: non-empty → forward-delete (unchanged); empty → posts `ExitRequested` → same double-press exit. The plain `delete` key is untouched.

### Robustness
`_request_exit()` shares the double-press machine. The armed state uses a **None sentinel, not 0.0** — Linux `CLOCK_MONOTONIC` starts at boot, so a `0.0` default would read as "armed" in the first 0.8s of uptime and exit on a *single* press (TS `useDoublePress` guards on an explicit timer flag too). A regression test pins this.

### Also
- Removed the false "Multi-line via Shift+Enter / Ctrl+J" docstring claim in `prompt_input.py` (newline insertion needs a `TextArea` swap — a separate deferred change; those keys are NOT wired).
- Fixed `exit_flow.py` docstring (Ctrl+D no longer pushes that dialog; only `/exit` does).

## Tests
- New `tests/tui/test_exit_fundamentals_pr6.py`: single-Ctrl+C arms (no exit), double exits, Ctrl+C clears non-empty draft first, Ctrl+D empty arms→exits, Ctrl+D non-empty forward-deletes, None-sentinel boot regression.
- Full `tests/tui/` suite: **732 passed, 2 skipped**.

## Review
Critic two rounds (REQUEST-CHANGES on the boot-time `monotonic` sentinel bug + a modal-capture doc correction → fixed → APPROVE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)