### PR TITLE
feat(tui): wire Ctrl+R history search and double-Esc clear-draft

### DIFF
--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -164,6 +164,10 @@ class ClawCodexTUI(App):
         # first 0.8s would treat 0.0 as "armed" and exit on a single press —
         # TS useDoublePress guards on an explicit timer flag too.)
         self._pending_exit_at: float | None = None
+        # Double-Esc draft clear (TS handleEscape): first idle Esc on a
+        # non-empty draft warns, a second within the window clears + saves
+        # to history. None = not armed (same boot-monotonic reasoning).
+        self._pending_clear_at: float | None = None
         # Persistent prompt history used by the PromptInput (↑/↓) and
         # the /history slash-command dialog. The store is append-only
         # per turn and auto-rotates past ``max_entries``.
@@ -1719,6 +1723,38 @@ class ClawCodexTUI(App):
             return
         if self.app_state.queued_prompts and self._repl_screen is not None:
             self._repl_screen.pop_queue_into_input()
+            return
+        # Priority 3: idle Esc on a non-empty draft → double-press to clear
+        # (TS handleEscape: first press warns, second clears + saves to
+        # history so ↑ can recover it).
+        self._handle_double_esc()
+
+    def _handle_double_esc(self) -> None:
+        prompt = self._active_prompt()
+        if prompt is None:
+            return
+        draft = prompt.current_text()
+        if not draft:
+            return  # nothing to clear; idle Esc on an empty prompt is a no-op
+        now = time.monotonic()
+        armed = (
+            self._pending_clear_at is not None
+            and (now - self._pending_clear_at) <= self._DOUBLE_PRESS_SECONDS
+        )
+        if armed:
+            self._pending_clear_at = None
+            try:
+                prompt.record_history(draft)
+                self.history_store.append(draft)
+            except Exception:
+                pass
+            prompt.clear()
+            return
+        self._pending_clear_at = now
+        try:
+            self.notify("Press Esc again to clear", timeout=self._DOUBLE_PRESS_SECONDS)
+        except Exception:
+            pass
 
     # ---- helpers ----
     def _build_default_tool_context(self) -> ToolContext:

--- a/src/tui/screens/repl.py
+++ b/src/tui/screens/repl.py
@@ -60,6 +60,9 @@ class REPLScreen(Screen):
         # C3b: legacy-REPL parity — re-print the most recent truncated
         # block in full (CtrlOToExpand).
         ("ctrl+o", "expand_last", "Expand last truncated"),
+        # TS history:search (defaultBindings ctrl+r) — opens the existing
+        # reverse-history-search dialog (was reachable only via /history).
+        ("ctrl+r", "history_search", "Search history"),
     ]
 
     DEFAULT_CSS = """
@@ -187,6 +190,12 @@ class REPLScreen(Screen):
 
     def action_expand_last(self) -> None:
         self.transcript.expand_last()
+
+    def action_history_search(self) -> None:
+        app = self.app
+        opener = getattr(app, "_open_history_search", None)
+        if callable(opener):
+            opener(self.transcript)
 
     # ---- prompt submission ----
     def on_prompt_submitted(self, message: PromptSubmitted) -> None:

--- a/src/tui/widgets/prompt_input.py
+++ b/src/tui/widgets/prompt_input.py
@@ -239,6 +239,17 @@ class PromptInput(Vertical):
 
         return self._input.value or ""
 
+    def record_history(self, text: str) -> None:
+        """Append ``text`` to the in-session ↑/↓ history.
+
+        Used by the double-Esc clear so a discarded draft is recoverable
+        with ↑ (TS handleEscape → addToHistory on the second press).
+        """
+
+        if text:
+            self._history.append(text)
+            self._history_pos = None
+
     # ---- bracketed paste ----
     def handle_paste(self, text: str) -> PasteInfo:
         """Insert a bracketed-paste payload as a single atomic operation.

--- a/src/tui/widgets/shortcuts_help.py
+++ b/src/tui/widgets/shortcuts_help.py
@@ -22,8 +22,8 @@ from textual.widgets import Static
 from ..vim import VimState
 
 # (key, action) pairs — every entry maps to a binding the TUI wires today.
-# ``double-tap esc`` / ``shift+tab`` / ``ctrl+r`` are intentionally absent
-# until their wiring PRs land.
+# ``shift+tab`` (permission-mode cycle) is intentionally absent until the
+# permission-mode→gating wiring lands (a cosmetic toggle would mislead).
 _BASE_SHORTCUTS: list[tuple[str, str]] = [
     ("/", "for commands"),
     ("!", "for bash mode"),
@@ -31,9 +31,11 @@ _BASE_SHORTCUTS: list[tuple[str, str]] = [
     ("#", "to add a memory"),
     ("tab", "to complete a command"),
     ("↑ ↓", "to navigate history"),
+    ("ctrl+r", "to search history"),
     ("ctrl+l", "to clear the draft"),
     ("ctrl+o", "to expand last output"),
     ("esc", "to interrupt"),
+    ("esc esc", "to clear input"),
     ("?", "for shortcuts"),
     ("/exit", "to quit"),
 ]

--- a/tests/tui/test_dormant_keybindings_pr7.py
+++ b/tests/tui/test_dormant_keybindings_pr7.py
@@ -1,0 +1,123 @@
+"""Wire two dormant keybindings (TUI UX PR 7).
+
+* Ctrl+R opens the existing reverse-history-search dialog (was reachable
+  only via /history; TS defaultBindings history:search = ctrl+r).
+* Double-Esc on an idle, non-empty draft clears it and saves it to history
+  (TS handleEscape). The existing Esc priorities — interrupt a running
+  agent, then pop a queued prompt back into the input — still win first.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("textual")
+
+from src.tui.app import ClawCodexTUI
+from src.tui.widgets import PromptInput
+from src.tool_system.context import ToolContext
+from src.tool_system.registry import ToolRegistry
+
+
+class _FakeProvider:
+    provider_name = "fake"
+    model = "claude-opus-4-8"
+
+
+def _make_app(root: Path) -> ClawCodexTUI:
+    return ClawCodexTUI(
+        provider=_FakeProvider(),
+        provider_name="fake",
+        workspace_root=root,
+        tool_registry=ToolRegistry(),
+        tool_context=ToolContext(workspace_root=root),
+        stream=False,
+    )
+
+
+async def _boot(app: ClawCodexTUI, pilot) -> None:
+    await pilot.pause()
+    await pilot.press("down")  # → "Yes, I accept"
+    await pilot.press("enter")
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_ctrl_r_opens_history_search(tmp_path):
+    app = _make_app(tmp_path)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(app, pilot)
+        app.history_store.append("an earlier prompt")  # non-empty history
+        await pilot.press("ctrl+r")
+        await pilot.pause()
+        assert app.screen.__class__.__name__ == "HistorySearchScreen"
+
+
+@pytest.mark.asyncio
+async def test_double_esc_clears_nonempty_draft_and_saves(tmp_path):
+    app = _make_app(tmp_path)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(app, pilot)
+        prompt = app.screen.query_one(PromptInput)
+        for ch in "draft":
+            await pilot.press(ch)
+        await pilot.pause()
+        # First Esc: armed, draft intact.
+        await pilot.press("escape")
+        await pilot.pause()
+        assert prompt.current_text() == "draft"
+        assert app._pending_clear_at is not None
+        # Second Esc: cleared + saved to history.
+        await pilot.press("escape")
+        await pilot.pause()
+        assert prompt.current_text() == ""
+        # Saved to BOTH the persistent store (ctrl+r dialog) and the
+        # in-session ↑/↓ history (recoverable by pressing Up).
+        assert any(r.prompt == "draft" for r in app.history_store.recent())
+        assert "draft" in prompt._history
+
+
+@pytest.mark.asyncio
+async def test_single_esc_on_empty_draft_is_noop(tmp_path):
+    app = _make_app(tmp_path)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(app, pilot)
+        await pilot.press("escape")
+        await pilot.pause()
+        # Nothing to clear → not armed, no crash.
+        assert app._pending_clear_at is None
+
+
+@pytest.mark.asyncio
+async def test_esc_with_queued_prompt_pops_does_not_arm_clear(tmp_path):
+    # Priority 2 (pop queue) must return before Priority 3 — the merged
+    # draft must NOT arm the clear toast. Guards the `return` after pop.
+    app = _make_app(tmp_path)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(app, pilot)
+        # Simulate an idle non-empty queue.
+        app.app_state.queued_prompts.append("queued one")
+        await pilot.press("escape")
+        await pilot.pause()
+        prompt = app.screen.query_one(PromptInput)
+        assert "queued one" in prompt.current_text()  # popped into the input
+        assert app._pending_clear_at is None  # Priority 3 did NOT run
+
+
+@pytest.mark.asyncio
+async def test_esc_while_busy_interrupts_does_not_clear(tmp_path):
+    app = _make_app(tmp_path)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(app, pilot)
+        prompt = app.screen.query_one(PromptInput)
+        for ch in "keep":
+            await pilot.press(ch)
+        # Simulate a run in flight: cancel() returns True (interrupt path).
+        app._agent_bridge.cancel = lambda: True  # type: ignore[method-assign]
+        await pilot.press("escape")
+        await pilot.pause()
+        # Priority 1 interrupt won — the draft is NOT touched by double-esc.
+        assert prompt.current_text() == "keep"
+        assert app._pending_clear_at is None

--- a/tests/tui/test_shortcuts_help_pr4.py
+++ b/tests/tui/test_shortcuts_help_pr4.py
@@ -26,11 +26,13 @@ from src.tui.widgets.shortcuts_help import (
 
 def test_wired_shortcuts_lists_real_bindings_only():
     keys = {k for k, _ in wired_shortcuts(vim_enabled=False)}
-    # Wired today (@ landed with the @-mention dropdown):
-    assert {"/", "!", "@", "#", "tab", "ctrl+l", "ctrl+o", "esc", "?", "/exit"} <= keys
-    # NOT wired yet — must not be advertised:
+    # Wired today (@ + ctrl+r + double-esc landed in later PRs):
+    assert {
+        "/", "!", "@", "#", "tab", "ctrl+r", "ctrl+l", "ctrl+o",
+        "esc", "esc esc", "?", "/exit",
+    } <= keys
+    # NOT wired yet — must not be advertised (cosmetic toggle would mislead):
     assert "shift+tab" not in keys
-    assert "ctrl+r" not in keys
 
 
 def test_vim_shortcuts_appended_only_when_vim_on():


### PR DESCRIPTION
## What

PR 7 of the TUI UX parity pass — wires two dormant keybindings from the ink REPL.

- **Ctrl+R** opens the existing reverse-history-search dialog (was reachable only via `/history`; TS `defaultBindings` `history:search = ctrl+r`).
- **Double-Esc** on an idle, non-empty draft clears it and saves it to history (TS `handleEscape`): first press warns "Press Esc again to clear", a second within 0.8s clears + records to both the ↑/↓ in-session history (so **Up recovers it**) and the persistent store.

### Esc priority (unchanged ordering)
Double-esc is **Priority 3** in `on_cancel_requested`, after Priority 1 (interrupt a running agent) and Priority 2 (pop a queued prompt). A `return` after the queue-pop keeps the merged draft from arming the clear toast. Uses a `None` sentinel (not `0.0`) for the same boot-`monotonic` reason as PR 6's Ctrl+C/D.

The `?` shortcuts panel now lists `ctrl+r` and `esc esc`.

### Deferred: shift+tab (permission-mode cycle)
The reactive `AppState.permission_mode` is **not** wired to real tool gating (gating reads `tool_context.permission_context.mode`; `/permissions` only updates the reactive store), so a `shift+tab` cycle would be cosmetic and misleading ("accept edits" toast while the agent still asks). Deferred until the permission-mode→gating wiring lands.

## Tests
- New `tests/tui/test_dormant_keybindings_pr7.py`: ctrl+r opens dialog; double-esc clears + saves + ↑-recall; empty-esc no-op; **queue-pop-doesn't-arm** (guards the new `return`); busy-esc interrupts-not-clears.
- Full `tests/tui/` suite: **737 passed, 2 skipped**.

## Review
Critic APPROVE; folded in its three polish items (panel discoverability for the new keys, ↑-recall assertion, queue-pop regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)