### PR TITLE
feat(tui): large-paste placeholder ([Pasted text #N +K lines])

### DIFF
--- a/src/tui/widgets/prompt_input.py
+++ b/src/tui/widgets/prompt_input.py
@@ -105,6 +105,17 @@ class _PasteAwareInput(Input):
 
 
 _NAME_COLUMN_WIDTH = 22  # left column reserved for "/name (alias)"
+# A "large" paste is replaced in the buffer by a "[Pasted text #id +N lines]"
+# placeholder (TS PromptInput.tsx:1240-1265 / history.ts formatPastedText) and
+# expanded back to the real text on submit, so a multi-thousand-line/char paste
+# doesn't flood the input. Char threshold matches TS (imagePaste.ts:30, 800).
+# Line trigger: TS placeholders at >2 newlines (4+ visual lines); we use >=2
+# newlines (3+ lines) — DELIBERATELY one line more aggressive because this
+# port's input is single-line and renders embedded newlines flat, so even a
+# 3-line paste is unreadable inline.
+_PASTE_CHARS_THRESHOLD = 800
+_PASTE_NEWLINES_THRESHOLD = 2  # placeholder when newline count >= this
+_PASTE_PLACEHOLDER_RE = re.compile(r"\[Pasted text #(\d+)(?: \+\d+ lines)?\]")
 # TS shows 6 rows in the non-overlay slash menu
 # (PromptInputFooterSuggestions.tsx:175 → ``Math.min(6, …)``). The full
 # candidate set is still ranked; only the display is capped.
@@ -182,6 +193,10 @@ class PromptInput(Vertical):
         # Round 2 / WI-R2.5: most-recent bracketed paste classification.
         # Test seam — the host reads :class:`PromptPasted` instead.
         self._last_paste: PasteInfo | None = None
+        # Large-paste placeholders: id → full pasted text. The buffer shows
+        # "[Pasted text #id +N lines]"; expand_pastes() restores it at submit.
+        self._pasted_blobs: dict[int, str] = {}
+        self._paste_counter: int = 0
         # Round 2 / WI-R2.4: passive status surfaces around the input.
         # The mode indicator subscribes to ``VimState`` directly; the
         # footer reads ``VimState.enabled`` lazily. Both mounted as
@@ -212,6 +227,7 @@ class PromptInput(Vertical):
 
     def clear(self) -> None:
         self._input.value = ""
+        self._pasted_blobs.clear()
         self._hide_suggestions()
 
     def append_value(self, text: str) -> None:
@@ -272,9 +288,10 @@ class PromptInput(Vertical):
             inp = self._input
             value = inp.value or ""
             pos = max(0, min(inp.cursor_position, len(value)))
-            new_value = value[:pos] + info.text + value[pos:]
+            insert = self._paste_insert_text(info)
+            new_value = value[:pos] + insert + value[pos:]
             inp.value = new_value
-            inp.cursor_position = pos + info.length
+            inp.cursor_position = pos + len(insert)
         # Pasted content must never reopen the slash palette; the user
         # paste-bombed the prompt and likely wants to keep typing or
         # submit. Same rationale as the TS ``usePasteHandler`` reset.
@@ -283,6 +300,41 @@ class PromptInput(Vertical):
         # ``_history_pos`` untouched here is the explicit contract.
         self.post_message(PromptPasted(info=info))
         return info
+
+    def _paste_insert_text(self, info: PasteInfo) -> str:
+        """Raw text for small pastes; a placeholder for large ones.
+
+        A large paste (> _PASTE_CHARS_THRESHOLD chars or >=
+        _PASTE_NEWLINES_THRESHOLD newlines) is stashed under an id and shown
+        as "[Pasted text #id +N lines]" so it doesn't flood the single-line
+        input; ``expand_pastes`` restores it at submit.
+        """
+
+        newlines = info.line_count - 1
+        big = (
+            info.length > _PASTE_CHARS_THRESHOLD
+            or newlines >= _PASTE_NEWLINES_THRESHOLD
+        )
+        if not big:
+            return info.text
+        self._paste_counter += 1
+        pid = self._paste_counter
+        self._pasted_blobs[pid] = info.text
+        if newlines > 0:
+            return f"[Pasted text #{pid} +{newlines} lines]"
+        return f"[Pasted text #{pid}]"
+
+    def expand_pastes(self, text: str) -> str:
+        """Replace any "[Pasted text #id …]" placeholders with real text."""
+
+        if not self._pasted_blobs:
+            return text
+
+        def _repl(match: "re.Match[str]") -> str:
+            pid = int(match.group(1))
+            return self._pasted_blobs.get(pid, match.group(0))
+
+        return _PASTE_PLACEHOLDER_RE.sub(_repl, text)
 
     @property
     def last_paste(self) -> PasteInfo | None:
@@ -383,10 +435,12 @@ class PromptInput(Vertical):
         text = (event.value or "").strip()
         if not text:
             return
+        text = self.expand_pastes(text)  # restore large-paste placeholders
         self._history.append(text)
         self._history_pos = None
         self._hide_suggestions()
         self._input.value = ""
+        self._pasted_blobs.clear()
         self.post_message(PromptSubmitted(text=text))
 
     def on_option_list_option_selected(
@@ -574,9 +628,11 @@ class PromptInput(Vertical):
         elif action == "submit":
             text = value.strip()
             if text:
+                text = self.expand_pastes(text)
                 self._history.append(text)
                 self._history_pos = None
                 inp.value = ""
+                self._pasted_blobs.clear()
                 self.post_message(PromptSubmitted(text=text))
 
     # ---- suggestion plumbing ----

--- a/tests/tui/test_paste_handling.py
+++ b/tests/tui/test_paste_handling.py
@@ -180,9 +180,13 @@ async def test_handle_paste_multiline_preserved():
         await pilot.pause()
         prompt.handle_paste("line1\nline2\nline3")
         await pilot.pause()
-        # Stock Input._on_paste would have kept only "line1"; verify the
-        # whole multi-line payload survives.
-        assert prompt._input.value == "line1\nline2\nline3"
+        # Stock Input._on_paste would have kept only "line1". A 3-line paste
+        # now shows a placeholder in the (single-line) buffer, but the whole
+        # multi-line payload survives intact in the blob store and is
+        # restored by expand_pastes — i.e. it is NOT truncated.
+        assert prompt._input.value == "[Pasted text #1 +2 lines]"
+        assert prompt._pasted_blobs[1] == "line1\nline2\nline3"
+        assert prompt.expand_pastes(prompt._input.value) == "line1\nline2\nline3"
         assert prompt.last_paste is not None
         assert prompt.last_paste.line_count == 3
 
@@ -296,11 +300,13 @@ async def test_paste_routes_through_subclassed_input():
         prompt._input.focus()
         # Fire the Paste event directly at the input. The custom
         # _on_paste handler should walk up to PromptInput and route
-        # through handle_paste; the buffer should contain the *full*
-        # multi-line payload (stock Input truncates to first line).
+        # through handle_paste. A 3-line paste shows a placeholder, but the
+        # full payload is preserved in the blob (stock Input would truncate
+        # to the first line — verify routing happened and nothing was lost).
         prompt._input.post_message(events.Paste(text="multi\nline\npaste"))
         await pilot.pause()
-        assert prompt._input.value == "multi\nline\npaste"
+        assert prompt._input.value == "[Pasted text #1 +2 lines]"
+        assert prompt._pasted_blobs[1] == "multi\nline\npaste"
         assert prompt.last_paste is not None
         assert prompt.last_paste.line_count == 3
         # And the host received the bubbled-up message.

--- a/tests/tui/test_paste_placeholder_pr8.py
+++ b/tests/tui/test_paste_placeholder_pr8.py
@@ -1,0 +1,145 @@
+"""Large-paste placeholder (TUI UX PR 8).
+
+A big paste (> 800 chars or >= 2 newlines / 3+ lines) is replaced in the
+single-line input by a "[Pasted text #id +N lines]" placeholder (TS format)
+and expanded back to the real text on submit, so a multi-thousand-line/char
+paste doesn't flood the buffer. Small pastes are still inserted literally.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("textual")
+
+from textual.app import App, ComposeResult
+
+from src.tui.widgets.prompt_input import PromptInput, PromptSubmitted
+
+
+class _Host(App):
+    def __init__(self, prompt: PromptInput) -> None:
+        super().__init__()
+        self._prompt = prompt
+        self.submitted: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        yield self._prompt
+
+    def on_prompt_submitted(self, message: PromptSubmitted) -> None:
+        self.submitted.append(message.text)
+
+
+def _make_prompt() -> PromptInput:
+    return PromptInput(words_provider=lambda: [])
+
+
+@pytest.mark.asyncio
+async def test_small_paste_inserted_literally():
+    prompt = _make_prompt()
+    async with _Host(prompt).run_test() as pilot:
+        await pilot.pause()
+        prompt.handle_paste("short paste")
+        await pilot.pause()
+        assert prompt.current_text() == "short paste"
+        assert prompt._pasted_blobs == {}
+
+
+@pytest.mark.asyncio
+async def test_two_line_paste_not_placeholdered():
+    # A trailing-newline / 2-line paste stays literal (1 newline < threshold).
+    prompt = _make_prompt()
+    async with _Host(prompt).run_test() as pilot:
+        await pilot.pause()
+        prompt.handle_paste("one\n")  # 1 newline
+        await pilot.pause()
+        assert "Pasted text" not in prompt.current_text()
+        assert prompt._pasted_blobs == {}
+
+
+@pytest.mark.asyncio
+async def test_multiline_paste_becomes_placeholder():
+    prompt = _make_prompt()
+    async with _Host(prompt).run_test() as pilot:
+        await pilot.pause()
+        prompt.handle_paste("a\nb\nc\nd")  # 3 newlines
+        await pilot.pause()
+        # TS label: "+N lines" where N = newline count.
+        assert prompt.current_text() == "[Pasted text #1 +3 lines]"
+        assert prompt._pasted_blobs[1] == "a\nb\nc\nd"
+
+
+@pytest.mark.asyncio
+async def test_long_single_line_paste_becomes_placeholder():
+    prompt = _make_prompt()
+    blob = "x" * 900  # > 800 chars, 0 newlines
+    async with _Host(prompt).run_test() as pilot:
+        await pilot.pause()
+        prompt.handle_paste(blob)
+        await pilot.pause()
+        # Single-line large paste → no "+lines" suffix (TS format).
+        assert prompt.current_text() == "[Pasted text #1]"
+        assert prompt._pasted_blobs[1] == blob
+
+
+@pytest.mark.asyncio
+async def test_moderate_single_line_paste_stays_literal():
+    # 100 chars is below the 800-char threshold → inserted literally
+    # (matches TS, which keeps single-line pastes inline until 800).
+    prompt = _make_prompt()
+    blob = "x" * 100
+    async with _Host(prompt).run_test() as pilot:
+        await pilot.pause()
+        prompt.handle_paste(blob)
+        await pilot.pause()
+        assert prompt.current_text() == blob
+        assert prompt._pasted_blobs == {}
+
+
+@pytest.mark.asyncio
+async def test_submit_expands_placeholder_to_real_text():
+    prompt = _make_prompt()
+    host = _Host(prompt)
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        prompt.handle_paste("a\nb\nc\nd")
+        await pilot.pause()
+        assert "[Pasted text #1 +3 lines]" in prompt.current_text()
+        await pilot.press("enter")
+        await pilot.pause()
+        # The agent receives the real multi-line text, not the placeholder.
+        assert host.submitted == ["a\nb\nc\nd"]
+        assert prompt.current_text() == ""
+        assert prompt._pasted_blobs == {}  # cleared after submit
+
+
+@pytest.mark.asyncio
+async def test_placeholder_spliced_midline_and_expanded():
+    prompt = _make_prompt()
+    host = _Host(prompt)
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        for ch in "see ":
+            await pilot.press("space" if ch == " " else ch)
+        prompt.handle_paste("L1\nL2\nL3")  # 2 newlines
+        await pilot.pause()
+        assert prompt.current_text() == "see [Pasted text #1 +2 lines]"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert host.submitted == ["see L1\nL2\nL3"]
+
+
+@pytest.mark.asyncio
+async def test_vim_submit_also_expands_placeholder():
+    # The vim-mode submit action shares the expand+clear logic.
+    prompt = PromptInput(words_provider=lambda: [], vim_mode=True)
+    host = _Host(prompt)
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        prompt.handle_paste("v1\nv2\nv3")
+        await pilot.pause()
+        assert "[Pasted text #1 +2 lines]" in prompt.current_text()
+        prompt._apply_vim_action("submit")  # vim Enter in normal mode
+        await pilot.pause()
+        assert host.submitted == ["v1\nv2\nv3"]
+        assert prompt._pasted_blobs == {}


### PR DESCRIPTION
## What

PR 8 of the TUI UX parity pass. The prompt is a single-line `Input`, so a big/multi-line bracketed paste used to dump raw into the buffer and flood it. Now a **large paste** — > 800 chars (TS `imagePaste.ts` threshold) or ≥ 2 newlines (3+ lines) — is stashed under an id and the buffer shows a **`[Pasted text #N +K lines]`** placeholder (TS `history.ts` format; `[Pasted text #N]` for a long single line). On submit, `expand_pastes()` restores the real text before posting, so the agent always receives the full content.

### Correctness
- **Expansion happens before queueing** — a paste submitted while the agent is busy enqueues the expanded text, not an orphaned placeholder.
- `re.sub` doesn't re-scan replacements → a blob containing placeholder-like text can't double-expand; an unknown/edited id stays literal.
- Both Enter and vim-submit expand + clear the blob store; `clear()` resets it too. History stores the expanded text (↑ recovers real content).

### Deliberate divergence
Line trigger is one line more aggressive than TS (`>=2` vs `>2` newlines): the single-line `Input` renders embedded newlines flat, so even a 3-line paste is unreadable inline. The char threshold (800) matches TS exactly.

## Tests
- New `tests/tui/test_paste_placeholder_pr8.py` (8): small-stays-literal, 2-line-literal, multiline→placeholder, 800-char boundary, mid-line splice + expand, submit-expands, **vim-submit expands**.
- Updated the two `test_paste_handling` no-truncation tests to assert the blob preserves the full payload.
- Full `tests/tui/` suite: **745 passed, 2 skipped**.

## Review
Critic two rounds — it read the real TS source and corrected my thresholds (800 not 64) + label format; aligned and re-verified → APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)