### PR TITLE
fix(openai-compat): drop orphan tool_results with no matching tool_call

### DIFF
--- a/src/providers/openai_compatible.py
+++ b/src/providers/openai_compatible.py
@@ -7,10 +7,13 @@ OpenAI-style /chat/completions API (OpenAI, GLM, Minimax, etc.).
 from __future__ import annotations
 
 import json
+import logging
 from abc import abstractmethod
 from typing import Any, Generator, Optional
 
 from .base import BaseProvider, ChatResponse, MessageInput, TextChunkCallback
+
+logger = logging.getLogger(__name__)
 
 
 def _apply_client_timeout(client: Any) -> Any:
@@ -160,6 +163,43 @@ def _convert_anthropic_messages_to_openai(
        passing through as an unrecognised Anthropic block.
     """
     result: list[dict[str, Any]] = []
+
+    # Pre-scan every assistant message for the tool_use ids it declares.
+    # An OpenAI ``role=tool`` message is only valid as a response to a
+    # ``tool_call`` that was actually emitted; a tool_result whose
+    # tool_use_id never appears in any assistant ``tool_use`` is an ORPHAN
+    # and the API rejects it ("messages with role 'tool' must be a
+    # response to a preceding message with 'tool_calls'"). The tool_result
+    # branch below drops such orphans. ``ensure_tool_result_pairing``
+    # (src/types/messages.py) is the upstream backstop but its reverse-
+    # strip only fires when the previous message is NOT an assistant, so
+    # an orphan trailing a text-only assistant turn (a stale id after
+    # compaction/resume) slips through to here. Mirrors TS
+    # openaiShim.ts:498/548 ``knownToolCallIds``. (The symmetric assistant-
+    # side guard — dropping a tool_use that has no result — is NOT ported;
+    # ``ensure_tool_result_pairing`` backfills synthetic results for every
+    # tool_use upstream, so no orphan tool_call reaches the converter.)
+    #
+    # Intentionally ``tool_use``-only — NOT ``server_tool_use`` /
+    # ``mcp_tool_use`` (which ``ensure_tool_result_pairing`` does recognize,
+    # messages.py). Those server-side shapes never reach THIS converter:
+    # the Anthropic server-advisor path strips them before non-Anthropic
+    # providers (query.py strip_advisor_blocks), and client-side MCP
+    # surfaces as a plain ``tool_use``. Matches TS, which builds
+    # knownToolCallIds only from converted tool_use (openaiShim.ts:638).
+    # Do not widen this to server/mcp shapes without re-checking that path,
+    # or you risk un-dropping genuine orphans.
+    known_tool_call_ids: set[str] = set()
+    for scan_msg in messages:
+        if scan_msg.get("role") != "assistant":
+            continue
+        scan_content = scan_msg.get("content")
+        if not isinstance(scan_content, list):
+            continue
+        for scan_block in scan_content:
+            if isinstance(scan_block, dict) and scan_block.get("type") == "tool_use":
+                known_tool_call_ids.add(scan_block.get("id", ""))
+
     for msg in messages:
         role = msg.get("role", "user")
         content = msg.get("content", "")
@@ -264,6 +304,18 @@ def _convert_anthropic_messages_to_openai(
             deferred_multimodal_user_messages: list[dict[str, Any]] = []
             # Emit each tool_result as a separate role=tool message
             for tr in tool_results:
+                tool_use_id = tr.get("tool_use_id", "")
+                # Orphan guard: drop a tool_result whose id was never
+                # emitted as a tool_call (see the pre-scan note above).
+                # With no preceding ``tool_calls`` entry the API rejects
+                # the ``role=tool`` message. Mirrors TS openaiShim.ts:548.
+                if tool_use_id not in known_tool_call_ids:
+                    logger.debug(
+                        "Dropping orphan tool_result for tool_use_id=%r "
+                        "(no matching tool_call in history)",
+                        tool_use_id,
+                    )
+                    continue
                 raw_content = tr.get("content", "")
                 # Collect any image blocks separately. OpenAI's ``role=tool``
                 # message only accepts a text ``content`` string -- it
@@ -326,7 +378,6 @@ def _convert_anthropic_messages_to_openai(
                 # On Anthropic the equivalent stays a single
                 # multimodal tool_result with no split; there is no
                 # equivalent Anthropic-side limitation.
-                tool_use_id = tr.get("tool_use_id", "")
                 if multimodal_blocks_from_tool:
                     correlation = (
                         f"[multimodal content for tool_use_id={tool_use_id} "

--- a/tests/test_openai_compat_tool_result_ordering.py
+++ b/tests/test_openai_compat_tool_result_ordering.py
@@ -209,5 +209,93 @@ class TestToolResultOrdering(unittest.TestCase):
         _assert_tool_calls_immediately_followed(self, out)
 
 
+class TestOrphanToolResultGuard(unittest.TestCase):
+    """An OpenAI ``role=tool`` message is only valid as a response to a
+    ``tool_call`` that was actually emitted. A tool_result whose
+    tool_use_id never appears in any assistant ``tool_use`` is an ORPHAN;
+    the API rejects it with "messages with role 'tool' must be a response
+    to a preceding message with 'tool_calls'". The converter drops such
+    orphans (mirrors TS openaiShim.ts:548). ``ensure_tool_result_pairing``
+    is the upstream backstop, but its reverse-strip only fires when the
+    previous message is NOT an assistant, so an orphan trailing a
+    text-only assistant turn (a stale id after compaction/resume) reaches
+    the converter and must be dropped here."""
+
+    def test_orphan_tool_result_dropped(self) -> None:
+        """A tool_result with no matching assistant tool_use is dropped,
+        not emitted as a (illegal) standalone ``role=tool`` message."""
+        messages = [
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "ghost", "content": "stale"},
+                {"type": "text", "text": "hello"},
+            ]},
+        ]
+        out = _convert_anthropic_messages_to_openai(messages)
+        self.assertNotIn("tool", [m["role"] for m in out])
+        # The genuine user text survives.
+        self.assertEqual(out[-1]["role"], "user")
+        self.assertEqual(out[-1]["content"][0]["text"], "hello")
+
+    def test_valid_tool_result_still_emitted(self) -> None:
+        """Guard must NOT over-drop: a tool_result whose id WAS emitted as
+        a tool_call is still converted to a ``role=tool`` message."""
+        messages = [
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "call_ok", "name": "Read", "input": {}},
+            ]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "call_ok", "content": "ok"},
+            ]},
+        ]
+        out = _convert_anthropic_messages_to_openai(messages)
+        self.assertEqual([m["role"] for m in out], ["assistant", "tool"])
+        self.assertEqual(out[1]["tool_call_id"], "call_ok")
+        _assert_tool_calls_immediately_followed(self, out)
+
+    def test_orphan_after_text_only_assistant_end_to_end(self) -> None:
+        """The exact gap: a stale orphan tool_result trails a TEXT-ONLY
+        assistant turn, so ``ensure_tool_result_pairing`` does NOT strip
+        it. Run the real prep pipeline + converter and assert the result
+        is a VALID payload (orphan dropped, every ``role=tool`` backed by
+        a preceding ``tool_calls``, the user's text preserved)."""
+        conversation = [
+            AssistantMessage(content=[
+                ToolUseBlock(id="call_x", name="Read", input={"file_path": "/x"}),
+            ]),
+            UserMessage(content=[
+                ToolResultBlock(tool_use_id="call_x", content="ok", is_error=False),
+            ]),
+            AssistantMessage(content=[TextBlock(text="done — what next?")]),
+            UserMessage(content=[
+                ToolResultBlock(tool_use_id="call_ghost", content="stale", is_error=True),
+                TextBlock(text="please continue"),
+            ]),
+        ]
+        api_messages = normalize_messages_for_api(conversation)
+        out = _convert_anthropic_messages_to_openai(api_messages)
+
+        tool_ids = [m["tool_call_id"] for m in out if m["role"] == "tool"]
+        self.assertIn("call_x", tool_ids)
+        self.assertNotIn("call_ghost", tool_ids)
+        # Every emitted role=tool must be backed by a tool_call somewhere
+        # before it (no dangling tool message).
+        emitted_calls: set[str] = set()
+        for m in out:
+            if m["role"] == "assistant":
+                for tc in m.get("tool_calls", []):
+                    emitted_calls.add(tc["id"])
+            elif m["role"] == "tool":
+                self.assertIn(m["tool_call_id"], emitted_calls)
+        # The user's genuine text survived the drop.
+        self.assertTrue(
+            any(
+                m["role"] == "user"
+                and isinstance(m["content"], list)
+                and any(b.get("text") == "please continue" for b in m["content"])
+                for m in out
+            )
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-up to #393. Closes the deferred sibling defect (Major #2 from that PR's review).

## Problem

A `tool_result` whose `tool_use_id` was never emitted as a `tool_call` is an **orphan**. The OpenAI-compatible converter emitted it anyway as a standalone `role=tool` message, which the API rejects:

> messages with role 'tool' must be a response to a preceding message with 'tool_calls'

`ensure_tool_result_pairing` is the upstream backstop, but its reverse-strip only fires when the previous message is **not** an assistant — so an orphan trailing a **text-only assistant** turn (a stale id after compaction/resume) reaches the converter.

## Fix (`src/providers/openai_compatible.py`)

- Pre-scan every assistant message for the `tool_use` ids it declares → `known_tool_call_ids`.
- In the tool-result branch, **drop** (with `logger.debug`) any `tool_result` whose `tool_use_id` isn't known.
- `tool_use`-only by design: `server_tool_use`/`mcp_tool_use` shapes are stripped upstream for non-Anthropic providers, and client-side MCP surfaces as plain `tool_use`. Matches TS `openaiShim.ts:498/548/638`.
- The symmetric assistant-side guard (drop an orphan `tool_call`) is **not** ported — `ensure_tool_result_pairing` backfills a synthetic result for every `tool_use` upstream, so no orphan `tool_call` reaches the converter.

## Tests

`TestOrphanToolResultGuard` in `tests/test_openai_compat_tool_result_ordering.py`: direct drop, sanity (valid tool_result still emitted, no over-drop), and end-to-end through `normalize_messages_for_api` (the exact orphan-after-text-assistant gap). The two drop tests fail without the guard and pass with it.

Broad sweep: 1513 passed, 0 regressions (4 failures are pre-existing baseline env tests on `main` — 2 MCP `python not in PATH`, 2 advisor beta-header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)