### PR TITLE
feat(repl): bracket the ❯ input with top/bottom border rules

### DIFF
--- a/src/repl/core.py
+++ b/src/repl/core.py
@@ -734,6 +734,15 @@ class ClawcodexREPL:
                 # background highlight.
                 'prompt': 'bold fg:ansiblue bg:#262626',
                 'bottom-toolbar': 'fg:#888888 bg:default',
+                # Top/bottom rules that bracket the input row, mirroring
+                # Claude Code's bordered input box (PromptInput.tsx renders
+                # it with ``borderStyle="round"`` + ``borderLeft/Right=
+                # {false}`` — i.e. horizontal rules only, no sides). The
+                # ``❯`` marker carries ``class:prompt`` (dim bg), so the
+                # rule must reset ``bg:default`` to escape that highlight;
+                # ``bold`` keeps the top rule (which inherits class:prompt)
+                # and the bottom rule (in the toolbar) the same weight.
+                'input-rule': 'bold fg:#585858 bg:default',
                 # Slash-command completion menu (two-column layout:
                 # /name on the left, [tag] + description on the right).
                 # Mirrors the TS reference where unselected rows are dim
@@ -753,6 +762,71 @@ class ClawcodexREPL:
             prompt_continuation=self._prompt_continuation,
             bottom_toolbar=self._bottom_toolbar,
         )
+
+    def _input_border_width(self) -> int:
+        """Column count for the input box's top/bottom rule lines.
+
+        Prefers the live prompt_toolkit output size (so the rules re-flow
+        on terminal resize) and falls back to ``shutil`` when no app is
+        running (e.g. unit tests calling these helpers directly).
+        """
+
+        try:
+            from prompt_toolkit.application import get_app
+            cols = get_app().output.get_size().columns
+            if cols and cols > 0:
+                return int(cols)
+        except Exception:
+            pass
+        try:
+            import shutil
+            return shutil.get_terminal_size((100, 24)).columns
+        except Exception:
+            return 80
+
+    def _prompt_message(self):
+        """Prompt rendered each turn: a full-width rule above the ``❯``
+        marker — the top edge of Claude Code's bordered input box.
+
+        ``PromptInput.tsx`` draws the input row with ``borderStyle="round"``
+        and ``borderLeft/Right={false}``, leaving just horizontal rules top
+        and bottom. prompt_toolkit splits a multi-line message at the last
+        ``\\n`` (see ``_split_multiline_prompt``): everything before it is
+        rendered on the line(s) above the input, so the rule sits directly
+        over ``❯``. The matching bottom rule is emitted by
+        :meth:`_bottom_toolbar`. Returned as a callable so the width tracks
+        terminal resizes between redraws.
+        """
+
+        from prompt_toolkit.formatted_text import FormattedText
+
+        rule = "─" * self._input_border_width()
+        return FormattedText([
+            ("class:input-rule", rule + "\n"),
+            ("class:prompt", "❯ "),
+        ])
+
+    def _with_bottom_rule(self, status: str):
+        """Wrap the footer ``status`` with the bottom edge of the input box:
+        a full-width rule directly beneath the input, above the status row.
+
+        The bottom rule lives in the ``bottom_toolbar`` (rather than the
+        prompt message) so it is filtered out once the prompt is accepted —
+        the box visually collapses on submit, matching the reference, while
+        the top rule from :meth:`_prompt_message` stays as a per-turn
+        divider in scrollback.
+        """
+
+        try:
+            from prompt_toolkit.formatted_text import FormattedText
+
+            rule = "─" * self._input_border_width()
+            return FormattedText([
+                ("class:input-rule", rule + "\n"),
+                ("", status),
+            ])
+        except Exception:
+            return status
 
     def _bottom_toolbar(self):
         """Single-line status footer for the input prompt.
@@ -822,7 +896,7 @@ class ClawcodexREPL:
                 f" · cost {format_cost_usd(total_cost)}"
                 if total_cost > 0 else ""
             )
-            return (
+            status = (
                 f" {provider} · {model} · {cwd} ·{advisor_part} "
                 f"turns: {self._stats_turns} · "
                 f"tokens: {self._stats_input_tokens} in / "
@@ -830,6 +904,7 @@ class ClawcodexREPL:
                 f"{advisor_tokens}"
                 f"{cost_part} "
             )
+            return self._with_bottom_rule(status)
         except Exception:
             # Never let the toolbar break the input prompt.
             return ""
@@ -2433,7 +2508,9 @@ class ClawcodexREPL:
                     # wake returns "" (handled as a no-op turn below).
                     self._at_prompt = True
                     try:
-                        user_input = self.prompt_session.prompt('❯ ')
+                        user_input = self.prompt_session.prompt(
+                            self._prompt_message
+                        )
                     finally:
                         self._at_prompt = False
 

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -1137,5 +1137,83 @@ class TestREPLConversationSanitization(unittest.TestCase):
         )
 
 
+class TestInputBoxBorder(unittest.TestCase):
+    """The legacy REPL brackets the ``❯`` input with top/bottom rules,
+    mirroring Claude Code's bordered input box (``PromptInput.tsx`` renders
+    the row with ``borderStyle="round"`` + ``borderLeft/Right={false}``, i.e.
+    horizontal rules only). These helpers build that box without needing a
+    full REPL instance — bind the real methods to a stand-in.
+    """
+
+    WIDTH = 40
+
+    def _stub(self):
+        stub = types.SimpleNamespace()
+        stub._input_border_width = lambda: self.WIDTH
+        stub._prompt_message = ClawcodexREPL._prompt_message.__get__(stub)
+        stub._with_bottom_rule = ClawcodexREPL._with_bottom_rule.__get__(stub)
+        return stub
+
+    def test_prompt_message_is_rule_above_marker(self):
+        from prompt_toolkit.formatted_text import to_formatted_text
+        from prompt_toolkit.shortcuts.prompt import _split_multiline_prompt
+
+        stub = self._stub()
+        msg = stub._prompt_message()
+        get_prompt = lambda: to_formatted_text(msg, style="class:prompt")
+        has_before, before, first_line = _split_multiline_prompt(get_prompt)
+
+        # Multi-line: the rule renders above, ``❯`` is the input line.
+        self.assertTrue(has_before())
+        self.assertEqual("".join(c for _s, c in before()), "─" * self.WIDTH)
+        self.assertEqual("".join(c for _s, c in first_line()), "❯ ")
+        # Rule escapes the dim prompt bg; the marker keeps class:prompt.
+        self.assertIn("class:input-rule", before()[0][0])
+        self.assertIn("class:prompt", first_line()[-1][0])
+
+    def test_bottom_rule_wraps_status(self):
+        stub = self._stub()
+        frags = list(stub._with_bottom_rule(" provider · model "))
+        self.assertEqual(frags[0], ("class:input-rule", "─" * self.WIDTH + "\n"))
+        self.assertEqual(frags[1], ("", " provider · model "))
+
+    def test_renders_through_prompt_toolkit(self):
+        """End-to-end: the rules, marker, and footer actually paint."""
+        import io
+
+        try:
+            from prompt_toolkit import PromptSession
+            from prompt_toolkit.styles import Style
+            from prompt_toolkit.output.plain_text import PlainTextOutput
+            from prompt_toolkit.input.defaults import create_pipe_input
+        except Exception as exc:  # pragma: no cover - env without pt extras
+            self.skipTest(f"prompt_toolkit render harness unavailable: {exc}")
+
+        stub = self._stub()
+        style = Style.from_dict({
+            "prompt": "bold fg:ansiblue bg:#262626",
+            "bottom-toolbar": "fg:#888888 bg:default",
+            "input-rule": "bold fg:#585858 bg:default",
+        })
+        buf = io.StringIO()
+        with create_pipe_input() as inp:
+            session = PromptSession(
+                message=stub._prompt_message,
+                bottom_toolbar=lambda: stub._with_bottom_rule(" footer-here "),
+                style=style,
+                input=inp,
+                output=PlainTextOutput(buf),
+                multiline=False,
+            )
+            inp.send_text("hi\r")
+            result = session.prompt()
+
+        rendered = buf.getvalue()
+        self.assertEqual(result, "hi")
+        self.assertIn("─" * self.WIDTH, rendered)  # top + bottom rules painted
+        self.assertIn("❯", rendered)
+        self.assertIn("footer-here", rendered)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## What

The default `prompt_toolkit` REPL (`src/repl/core.py`) drew a bare `❯ ` with no border, unlike Claude Code's bordered input box. The reference `PromptInput.tsx` renders that row with `borderStyle="round"` + `borderLeft/Right={false}` — i.e. **top + bottom rules only, no vertical sides**. This mirrors that.

(The opt-in `--tui` already had its own border; this only touches the default REPL.)

## How

- **Top rule** — a callable prompt `message` returning `─────\n❯ `. prompt_toolkit's `_split_multiline_prompt` renders everything before the last `\n` on the line above the input, so the rule sits directly over `❯`. Callable ⇒ width re-flows on terminal resize.
- **Bottom rule** — prepended to the existing `bottom_toolbar` (provider/model/cost footer). The toolbar is filtered by `~is_done`, so on submit the bottom rule + footer collapse, matching how the reference box collapses — leaving `──── / ❯ your message` as a clean per-turn divider in scrollback.
- **Style** — new `input-rule` class (`bold fg:#585858 bg:default`); `bg:default` is required to escape the `❯` marker's dim `bg:#262626` highlight that prompt_toolkit applies as the message base style.

## Live appearance

```
────────────────────────────────────────
❯ hi
────────────────────────────────────────
 provider · model · cwd · turns: 1 · tokens: …
```
…collapses to `──── / ❯ hi` on submit.

## Tests

`TestInputBoxBorder` in `tests/test_repl.py`: FormattedText structure, the multiline split (rule above / `❯` as input line), and an **end-to-end prompt_toolkit render** through a pipe input + plain-text capture asserting the rules, marker, and footer all paint. Full `test_repl.py` green (41 passed); 80 more across other `repl.core` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)