### PR TITLE
feat(ui-tui): close Claude-Code look-and-feel gaps (banner, user box, code highlighting, …)

### DIFF
--- a/ui-tui/bun.lock
+++ b/ui-tui/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "clawcodex-tui",
       "dependencies": {
+        "cli-highlight": "^2.1.11",
         "ink": "^5.0.1",
         "ink-text-input": "^6.0.0",
         "react": "^18.3.1",
@@ -35,17 +36,27 @@
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
-    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
 
     "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
 
+    "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
+
     "cli-truncate": ["cli-truncate@4.0.0", "", { "dependencies": { "slice-ansi": "^5.0.0", "string-width": "^7.0.0" } }, "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA=="],
 
+    "cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
+
     "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
@@ -57,9 +68,17 @@
 
     "es-toolkit": ["es-toolkit@1.48.1", "", {}, "sha512-wfnXlwd5I75eXRtdD2vuEs50xHHESECDsGD7yiQnfFVNoa5522NwXEbmgo98LfiukSQHs+mBM7/YG3qKJB9/mQ=="],
 
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
     "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
@@ -77,13 +96,23 @@
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
+    "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
+
+    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
 
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
     "react-reconciler": ["react-reconciler@0.29.2", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
@@ -99,6 +128,12 @@
 
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -111,10 +146,48 @@
 
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yargs": ["yargs@16.2.2", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w=="],
+
+    "yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
+
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
+
+    "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "cli-truncate/slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
 
+    "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "ink/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "ink-text-input/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
+
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "cliui/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -14,6 +14,7 @@
     "dev": "bun run src/cli.tsx"
   },
   "dependencies": {
+    "cli-highlight": "^2.1.11",
     "ink": "^5.0.1",
     "ink-text-input": "^6.0.0",
     "react": "^18.3.1",

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -11,6 +11,7 @@ import TextInput from 'ink-text-input'
 import React, { useEffect, useRef, useState } from 'react'
 import { DirectConnectClient, type SessionInfo } from './client.js'
 import { Markdown } from './markdown.js'
+import { Banner } from './components/Banner.js'
 import { Message } from './components/Message.js'
 import { PermissionDialog } from './components/PermissionDialog.js'
 import { SlashMenu } from './components/SlashMenu.js'
@@ -49,6 +50,7 @@ export function App({ info, serverLabel }: Props): React.ReactElement {
   const [turnStartedAt, setTurnStartedAt] = useState(0)
   const [model, setModel] = useState('?')
   const [mode, setMode] = useState('?')
+  const [tools, setTools] = useState(0)
   const [connected, setConnected] = useState(false)
   const [client, setClient] = useState<DirectConnectClient | null>(null)
   const [slashSel, setSlashSel] = useState(0)
@@ -108,9 +110,10 @@ export function App({ info, serverLabel }: Props): React.ReactElement {
           flushStream() // commit a partial left over by interrupt/error (no-op on success)
         }
         if (type === 'system' && (msg as { subtype?: string }).subtype === 'init') {
-          const m = msg as { model?: string; permission_mode?: string; protocol_version?: string }
+          const m = msg as { model?: string; permission_mode?: string; protocol_version?: string; tools?: unknown[] }
           setModel(m.model ?? '?')
           setMode(m.permission_mode ?? '?')
+          setTools(Array.isArray(m.tools) ? m.tools.length : 0)
           const major = parseProtocolMajor(m.protocol_version)
           if (major !== null && major !== SUPPORTED_PROTOCOL_MAJOR) {
             addEntry({
@@ -242,7 +245,17 @@ export function App({ info, serverLabel }: Props): React.ReactElement {
 
   return (
     <Box flexDirection="column">
-      <Static items={entries}>{(entry) => <Message key={entry.id} entry={entry} />}</Static>
+      {entries.length === 0 && streaming === '' ? (
+        <Banner model={model} mode={mode} tools={tools} cwd={info.workDir} />
+      ) : null}
+
+      <Static items={entries}>
+        {(entry) => (
+          <Box key={entry.id} marginTop={entry.kind === 'tool' || entry.kind === 'toolResult' ? 0 : 1}>
+            <Message entry={entry} />
+          </Box>
+        )}
+      </Static>
 
       {streaming ? (
         <Box>
@@ -266,8 +279,8 @@ export function App({ info, serverLabel }: Props): React.ReactElement {
       ) : (
         <>
           {slashOpen ? <SlashMenu matches={slashMatches} selected={sel} /> : null}
-          <Box>
-            <Text color={connected ? theme.user : theme.dim}>{busy ? '… ' : '❯ '}</Text>
+          <Box borderStyle="round" borderColor={theme.dim} paddingX={1}>
+            <Text color={connected ? theme.accent : theme.dim}>{busy ? '… ' : '❯ '}</Text>
             <TextInput
               value={input}
               onChange={(v) => {
@@ -278,6 +291,7 @@ export function App({ info, serverLabel }: Props): React.ReactElement {
               placeholder={connected ? 'Type a message, or / for commands…' : 'connecting…'}
             />
           </Box>
+          <Text color={theme.dim}>{'  enter send · / commands · esc interrupt · ^C quit'}</Text>
         </>
       )}
 

--- a/ui-tui/src/cli.tsx
+++ b/ui-tui/src/cli.tsx
@@ -78,7 +78,7 @@ async function main(): Promise<void> {
     }
     connectUrl = backend.ccUrl
     connectToken = backend.token
-    serverLabel = backend.ccUrl
+    serverLabel = 'local' // spawn mode: the backend is internal — don't show the ephemeral URL
     dispose = backend.dispose
     // Make sure the child dies with us, however we exit.
     const cleanup = () => dispose?.()

--- a/ui-tui/src/components/Banner.tsx
+++ b/ui-tui/src/components/Banner.tsx
@@ -1,0 +1,65 @@
+/**
+ * Welcome / session panel shown before the first message — the clawcodex
+ * analogue of Claude Code's intro banner + provider box. Carries the
+ * connection info (model · mode · tools · cwd) so it doesn't clutter the
+ * transcript, plus a one-line tip.
+ */
+import { Box, Text } from 'ink'
+import React from 'react'
+import { theme } from '../theme.js'
+
+interface Props {
+  model: string
+  mode: string
+  tools: number
+  cwd?: string
+}
+
+function shorten(cwd?: string): string | undefined {
+  if (!cwd) return undefined
+  const home = process.env['HOME']
+  return home && cwd.startsWith(home) ? `~${cwd.slice(home.length)}` : cwd
+}
+
+function Row({ label, value }: { label: string; value: string }): React.ReactElement {
+  return (
+    <Text>
+      <Text color={theme.dim}>{label.padEnd(7)}</Text>
+      {value}
+    </Text>
+  )
+}
+
+export function Banner({ model, mode, tools, cwd }: Props): React.ReactElement {
+  const dir = shorten(cwd)
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={theme.accent}
+      paddingX={2}
+      paddingY={1}
+      marginBottom={1}
+    >
+      <Text>
+        <Text bold color={theme.accent}>
+          clawcodex
+        </Text>
+        <Text color={theme.dim}>{'  ·  a Claude-Code-style TUI on the Python backend'}</Text>
+      </Text>
+      <Box marginTop={1} flexDirection="column">
+        <Row label="model" value={model} />
+        <Row label="mode" value={mode} />
+        <Row label="tools" value={String(tools)} />
+        {dir ? <Row label="cwd" value={dir} /> : null}
+      </Box>
+      <Box marginTop={1}>
+        <Text color={theme.dim}>{'Type a message · '}</Text>
+        <Text color={theme.accent}>/help</Text>
+        <Text color={theme.dim}>{' for commands · '}</Text>
+        <Text color={theme.accent}>^C</Text>
+        <Text color={theme.dim}>{' to quit'}</Text>
+      </Box>
+    </Box>
+  )
+}

--- a/ui-tui/src/components/Message.tsx
+++ b/ui-tui/src/components/Message.tsx
@@ -35,9 +35,15 @@ export function Message({ entry }: { entry: TranscriptEntry }): React.ReactEleme
   switch (entry.kind) {
     case 'user':
       return (
-        <Box>
-          <Text color={theme.user} bold>{'› '}</Text>
-          <Text color={theme.user}>{entry.text}</Text>
+        <Box borderStyle="round" borderColor={theme.dim} paddingX={1}>
+          <Box width={2}>
+            <Text color={theme.user} bold>
+              ›
+            </Text>
+          </Box>
+          <Box flexGrow={1}>
+            <Text color={theme.user}>{entry.text}</Text>
+          </Box>
         </Box>
       )
     case 'assistant':

--- a/ui-tui/src/markdown.tsx
+++ b/ui-tui/src/markdown.tsx
@@ -8,9 +8,19 @@
  * can render a live streaming buffer mid-token. Not a spec-complete parser —
  * a focused port of the Claude-Code look, full control, zero deps.
  */
+import { highlight } from 'cli-highlight'
 import { Box, Text } from 'ink'
 import React from 'react'
 import { theme } from './theme.js'
+
+/** Syntax-highlight a code block to an ANSI string (Ink Text passes ANSI through). */
+function highlightCode(code: string, lang?: string): string[] {
+  try {
+    return highlight(code, { language: lang, ignoreIllegals: true }).split('\n')
+  } catch {
+    return code.split('\n')
+  }
+}
 
 // ── inline spans ──────────────────────────────────────────────────────────
 
@@ -162,18 +172,16 @@ export function Markdown({ text }: { text: string }): React.ReactElement {
     <Box flexDirection="column">
       {blocks.map((b, idx) => {
         if (b.type === 'code') {
+          // Borderless, syntax-highlighted, with a dim left gutter — matches
+          // the Claude Code look (no box; cli-highlight colors the code).
+          const lines = highlightCode(b.lines.join('\n'), b.lang)
           return (
-            <Box
-              key={idx}
-              flexDirection="column"
-              borderStyle="round"
-              borderColor={theme.border}
-              paddingX={1}
-            >
-              {(b.lines.length ? b.lines : ['']).map((ln, j) => (
-                <Text key={j} color={theme.code}>
-                  {ln || ' '}
-                </Text>
+            <Box key={idx} flexDirection="column" marginY={0}>
+              {(lines.length ? lines : [' ']).map((ln, j) => (
+                <Box key={j}>
+                  <Text color={theme.dim}>{'  │ '}</Text>
+                  <Text>{ln || ' '}</Text>
+                </Box>
               ))}
             </Box>
           )
@@ -209,7 +217,7 @@ export function Markdown({ text }: { text: string }): React.ReactElement {
             <Box key={idx} flexDirection="column">
               {b.items.map((it, j) => {
                 const num = parseInt(it.marker, 10)
-                const bullet = it.ordered ? `${Number.isFinite(num) ? num : j + 1}. ` : '• '
+                const bullet = it.ordered ? `${Number.isFinite(num) ? num : j + 1}. ` : '- '
                 return (
                   <Box key={j}>
                     <Text color={theme.accent}>{`  ${bullet}`}</Text>

--- a/ui-tui/src/sdkMessageAdapter.ts
+++ b/ui-tui/src/sdkMessageAdapter.ts
@@ -69,6 +69,10 @@ function truncate(s: string, max = 100): string {
   return one.length > max ? `${one.slice(0, max - 1)}…` : one
 }
 
+function fmtK(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n)
+}
+
 function toolResultText(content: string | ContentBlock[] | undefined): string {
   if (typeof content === 'string') return content
   if (!Array.isArray(content)) return ''
@@ -99,14 +103,8 @@ export function messageToEntries(msg: ServerMessage): TranscriptEntry[] {
       level?: string
     }
     if (m.subtype === 'init') {
-      const tools = Array.isArray(m.tools) ? m.tools.length : 0
-      return [
-        {
-          id: nextId(),
-          kind: 'system',
-          text: `connected · ${m.model ?? '?'} · ${m.permission_mode ?? '?'} · ${tools} tools · v${m.protocol_version ?? '?'}`,
-        },
-      ]
+      // Connection info is shown in the welcome Banner, not the transcript.
+      return []
     }
     if (m.message) {
       return [{ id: nextId(), kind: m.level === 'error' ? 'error' : 'system', text: m.message }]
@@ -155,12 +153,13 @@ export function messageToEntries(msg: ServerMessage): TranscriptEntry[] {
     if (m.subtype === 'cancelled') {
       return [{ id: nextId(), kind: 'system', text: 'interrupted' }]
     }
-    const usage = m.usage
-      ? ` · ${Object.entries(m.usage)
-          .map(([k, v]) => `${k}=${v}`)
-          .join(' ')}`
-      : ''
-    return [{ id: nextId(), kind: 'result', text: `done (${m.num_turns ?? 0} turns)${usage}` }]
+    const u = (m.usage ?? {}) as Record<string, number>
+    const inTok = u['input_tokens'] ?? u['input'] ?? 0
+    const outTok = u['output_tokens'] ?? u['output'] ?? 0
+    const total = inTok + outTok
+    const tok = total > 0 ? ` · ${fmtK(total)} tokens` : ''
+    const turns = m.num_turns ?? 0
+    return [{ id: nextId(), kind: 'result', text: `done · ${turns} turn${turns === 1 ? '' : 's'}${tok}` }]
   }
 
   return []


### PR DESCRIPTION
## Close Claude-Code look-and-feel gaps in the Ink TUI

QA-driven polish: I captured **both** the original Claude Code TUI (`typescript/dist/cli.mjs`) and the clawcodex TUI on the same query (via a `pyte`+Pillow screenshot harness — no terminal-screenshot tools were installed), compared them, and closed the visible gaps.

### Before → after
| Gap | Before (clawcodex) | After |
|---|---|---|
| **Welcome** | nothing on startup | bordered **session banner** (model · mode · tools · cwd + `/help` tip) |
| **User message** | raw cyan text, wrapped mid-word | **bordered box** with `›`, clean wrapping |
| **Code blocks** | plain green, rounded border | **syntax-highlighted** (`cli-highlight`, e.g. `echo` in cyan), borderless + dim gutter |
| **Result line** | `… input_tokens=… last_cache_read_…` dump | compact `✓ done · 1 turn · 15.2k tokens` |
| **Input** | bare `›` + placeholder | **bordered input box** + key-hints line |
| **Status** | internal `cc://127.0.0.1:62368` | `local` in spawn mode |
| **Lists / spacing** | `•`, dense | `-` bullets + inter-message spacing |

### Notes
- Connection info moved into the banner (no more inline `· connected ·` transcript line).
- `cli-highlight` ANSI renders correctly through Ink `<Text>` (verified in the re-captured screenshot).
- A full port of the original `utils/markdown.js` renderer wasn't possible — that file is **absent** from the local `typescript/` checkout (it's an incomplete subset), and the original user box uses `backgroundColor` (a forked-ink feature npm-ink lacks). The look is matched with npm-ink equivalents + `cli-highlight` (the same highlighter the original uses).

typecheck + build green. Branches off `main` (which already has the TUI migration, #395).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
