### PR TITLE
feat(ui-tui): permission flow, edit diffs, WebFetch, slash menu, status bar

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -298,11 +298,10 @@ export function App({ info, serverLabel }: Props): React.ReactElement {
               placeholder={connected ? 'Type a message, or / for commands…' : 'connecting…'}
             />
           </Box>
-          <Text color={theme.dim}>{'  enter send · / commands · esc interrupt · ^C quit'}</Text>
         </>
       )}
 
-      <StatusBar connected={connected} serverLabel={serverLabel} model={model} mode={mode} busy={busy} />
+      <StatusBar connected={connected} model={model} mode={mode} busy={busy} />
     </Box>
   )
 }

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -141,10 +141,10 @@ export function App({ info, serverLabel }: Props): React.ReactElement {
     const head = permissions[0]
     if (head) {
       const c = ch.toLowerCase()
-      if (c === 'y') {
+      if (c === 'y' || ch === '1') {
         client?.respondPermission(head.requestId, 'allow')
         setPermissions((q) => q.slice(1))
-      } else if (c === 'n' || c === 'd') {
+      } else if (c === 'n' || c === 'd' || ch === '2') {
         client?.respondPermission(head.requestId, 'deny', { message: 'denied by user' })
         setPermissions((q) => q.slice(1))
       } else if (key.escape) {
@@ -268,7 +268,7 @@ export function App({ info, serverLabel }: Props): React.ReactElement {
         </Box>
       ) : null}
 
-      {busy ? (
+      {busy && permissions.length === 0 ? (
         <Box>
           <Spinner startedAt={turnStartedAt} />
         </Box>

--- a/ui-tui/src/components/DiffView.tsx
+++ b/ui-tui/src/components/DiffView.tsx
@@ -1,0 +1,32 @@
+/**
+ * Renders a line diff (from diff.ts) Claude-Code style: a line-number gutter +
+ * marker, added lines on a green background, removed lines on a red background,
+ * context lines dim. Mirrors StructuredDiff's gutter (marker + line number).
+ */
+import { Box, Text } from 'ink'
+import React from 'react'
+import { theme } from '../theme.js'
+import type { DiffLine } from '../diff.js'
+
+const MAX_LINES = 40
+
+export function DiffView({ lines }: { lines: DiffLine[] }): React.ReactElement {
+  const shown = lines.slice(0, MAX_LINES)
+  const extra = lines.length - shown.length
+  const width = Math.max(1, ...lines.map((l) => String(l.oldNo ?? l.newNo ?? 0).length))
+  return (
+    <Box flexDirection="column" marginLeft={2}>
+      {shown.map((l, i) => {
+        const no = l.type === 'del' ? l.oldNo : l.newNo
+        const marker = l.type === 'add' ? '+' : l.type === 'del' ? '-' : ' '
+        const bg = l.type === 'add' ? theme.diffAddBg : l.type === 'del' ? theme.diffDelBg : undefined
+        return (
+          <Text key={i} backgroundColor={bg} color={l.type === 'ctx' ? theme.dim : undefined} wrap="truncate-end">
+            {` ${marker} ${String(no ?? '').padStart(width)} ${l.text || ' '} `}
+          </Text>
+        )
+      })}
+      {extra > 0 ? <Text color={theme.dim}>{`    … +${extra} more line${extra === 1 ? '' : 's'}`}</Text> : null}
+    </Box>
+  )
+}

--- a/ui-tui/src/components/Message.tsx
+++ b/ui-tui/src/components/Message.tsx
@@ -61,12 +61,15 @@ export function Message({ entry }: { entry: TranscriptEntry }): React.ReactEleme
       )
     case 'tool': {
       const diff = entry.toolName ? toolDiff(entry.toolName, entry.input ?? {}) : null
+      const isWeb = entry.toolName === 'WebFetch' || entry.toolName === 'WebSearch'
       return (
         <Box flexDirection="column">
           <Text>
             <Text color={theme.success}>⏺ </Text>
             <Text bold>{entry.toolName}</Text>
-            <Text color={theme.dim}>{`(${entry.argsText})`}</Text>
+            <Text color={theme.dim}>(</Text>
+            <Text color={isWeb ? theme.link : theme.dim}>{entry.argsText}</Text>
+            <Text color={theme.dim}>)</Text>
           </Text>
           {diff ? <DiffView lines={diff} /> : null}
         </Box>

--- a/ui-tui/src/components/Message.tsx
+++ b/ui-tui/src/components/Message.tsx
@@ -10,6 +10,8 @@ import { Box, Text } from 'ink'
 import React from 'react'
 import { Markdown } from '../markdown.js'
 import { theme } from '../theme.js'
+import { DiffView } from './DiffView.js'
+import { toolDiff } from '../diff.js'
 import type { TranscriptEntry } from '../sdkMessageAdapter.js'
 
 const RESULT_MAX_LINES = 8
@@ -57,14 +59,19 @@ export function Message({ entry }: { entry: TranscriptEntry }): React.ReactEleme
           </Box>
         </Box>
       )
-    case 'tool':
+    case 'tool': {
+      const diff = entry.toolName ? toolDiff(entry.toolName, entry.input ?? {}) : null
       return (
-        <Text>
-          <Text color={theme.success}>⏺ </Text>
-          <Text bold>{entry.toolName}</Text>
-          <Text color={theme.dim}>{`(${entry.argsText})`}</Text>
-        </Text>
+        <Box flexDirection="column">
+          <Text>
+            <Text color={theme.success}>⏺ </Text>
+            <Text bold>{entry.toolName}</Text>
+            <Text color={theme.dim}>{`(${entry.argsText})`}</Text>
+          </Text>
+          {diff ? <DiffView lines={diff} /> : null}
+        </Box>
       )
+    }
     case 'toolResult':
       return <ToolResult text={entry.text} />
     case 'result':

--- a/ui-tui/src/components/Message.tsx
+++ b/ui-tui/src/components/Message.tsx
@@ -60,7 +60,7 @@ export function Message({ entry }: { entry: TranscriptEntry }): React.ReactEleme
     case 'tool':
       return (
         <Text>
-          <Text color={theme.assistant}>⏺ </Text>
+          <Text color={theme.success}>⏺ </Text>
           <Text bold>{entry.toolName}</Text>
           <Text color={theme.dim}>{`(${entry.argsText})`}</Text>
         </Text>

--- a/ui-tui/src/components/PermissionDialog.tsx
+++ b/ui-tui/src/components/PermissionDialog.tsx
@@ -1,7 +1,9 @@
 /**
- * Tool-permission prompt — a bordered Claude-Code-style dialog. The wire
- * protocol's control_response is allow/deny, so we offer (y) allow / (n) deny
- * (esc = deny). The args preview shows what the tool wants to do.
+ * Tool-permission prompt — matches the original Claude Code permission dialog
+ * (components/permissions/PermissionDialog.tsx): a top-rule-only frame in the
+ * permission blue-purple, the tool name + an args preview, then a numbered
+ * option list with "Yes" highlighted. The wire protocol is allow/deny, so the
+ * keys are 1/y = allow, 2/n = deny, esc = interrupt.
  */
 import { Box, Text } from 'ink'
 import React from 'react'
@@ -14,44 +16,48 @@ interface Props {
 
 export function PermissionDialog({ toolName, input }: Props): React.ReactElement {
   const keys = Object.keys(input ?? {})
-  const preview =
-    keys.length > 0
-      ? keys
-          .map((k) => {
-            const v = (input as Record<string, unknown>)[k]
-            const s = typeof v === 'string' ? v : JSON.stringify(v)
-            return `${k}: ${s.length > 120 ? `${s.slice(0, 119)}…` : s}`
-          })
-          .join('\n')
-      : null
+  const preview = keys.map((k) => {
+    const v = (input as Record<string, unknown>)[k]
+    const s = typeof v === 'string' ? v : JSON.stringify(v)
+    return `${k}: ${s.length > 120 ? `${s.slice(0, 119)}…` : s}`
+  })
 
   return (
-    <Box flexDirection="column" borderStyle="round" borderColor={theme.warn} paddingX={1}>
-      <Text color={theme.warn} bold>
-        ⏵ Permission required
-      </Text>
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={theme.suggestion}
+      borderBottom={false}
+      borderLeft={false}
+      borderRight={false}
+      paddingX={1}
+      marginTop={1}
+    >
       <Text>
-        Allow <Text bold color={theme.tool}>{toolName}</Text> to run?
+        <Text color={theme.suggestion} bold>
+          {toolName}
+        </Text>
+        <Text color={theme.dim}>{' wants to run'}</Text>
       </Text>
-      {preview ? (
+      {preview.length ? (
         <Box flexDirection="column" marginTop={1}>
-          {preview.split('\n').map((ln, i) => (
+          {preview.map((ln, i) => (
             <Text key={i} color={theme.dim}>
-              {ln}
+              {`  ${ln}`}
             </Text>
           ))}
         </Box>
       ) : null}
-      <Box marginTop={1}>
-        <Text color={theme.success} bold>
-          (y)
+      <Box marginTop={1} flexDirection="column">
+        <Text color={theme.dim}>Do you want to proceed?</Text>
+        <Text>
+          <Text color={theme.suggestion} bold>
+            {'❯ '}
+          </Text>
+          <Text bold>1. Yes</Text>
+          <Text color={theme.dim}>{'   (y)'}</Text>
         </Text>
-        <Text>{' allow   '}</Text>
-        <Text color={theme.error} bold>
-          (n)
-        </Text>
-        <Text>{' deny   '}</Text>
-        <Text color={theme.dim}>esc to deny</Text>
+        <Text color={theme.dim}>{'  2. No, and tell the agent what to do differently   (n / esc)'}</Text>
       </Box>
     </Box>
   )

--- a/ui-tui/src/components/SlashMenu.tsx
+++ b/ui-tui/src/components/SlashMenu.tsx
@@ -1,4 +1,9 @@
-/** Slash-command autocomplete dropdown shown above the input. */
+/**
+ * Slash-command suggestions shown above the input — matches the original
+ * PromptInputFooterSuggestions: a borderless list where the selected row is a
+ * full-width highlighted bar (background + inverse text), format
+ * "/name   description".
+ */
 import { Box, Text } from 'ink'
 import React from 'react'
 import { theme } from '../theme.js'
@@ -11,21 +16,28 @@ interface Props {
 
 export function SlashMenu({ matches, selected }: Props): React.ReactElement | null {
   if (matches.length === 0) return null
+  const nameW = Math.max(...matches.map((c) => c.name.length))
   return (
-    <Box flexDirection="column" borderStyle="round" borderColor={theme.border} paddingX={1}>
+    <Box flexDirection="column" marginBottom={1}>
       {matches.map((c, i) => {
         const on = i === selected
+        if (on) {
+          // Selected: full-width highlighted bar, › prefix, dark bold text.
+          return (
+            <Box key={c.name} width="100%">
+              <Text backgroundColor={theme.suggestion} color="black" bold wrap="truncate">
+                {`› ${c.name.padEnd(nameW)}   ${c.description} `}
+              </Text>
+            </Box>
+          )
+        }
         return (
           <Box key={c.name}>
-            <Text color={on ? theme.accent : theme.dim} bold={on}>
-              {on ? '❯ ' : '  '}
-              {c.name.padEnd(10)}
-            </Text>
-            <Text color={theme.dim}>{c.description}</Text>
+            <Text>{`  ${c.name.padEnd(nameW)}`}</Text>
+            <Text color={theme.dim}>{`   ${c.description}`}</Text>
           </Box>
         )
       })}
-      <Text color={theme.dim}>{'  ↑↓ select · tab complete · enter run'}</Text>
     </Box>
   )
 }

--- a/ui-tui/src/components/StatusBar.tsx
+++ b/ui-tui/src/components/StatusBar.tsx
@@ -1,24 +1,38 @@
-/** Bottom status line: connection dot · server · model · mode, and hints. */
+/**
+ * Bottom footer — matches the original PromptInputFooter: left side shows a
+ * hint ("? for shortcuts"), right side shows status (a connection dot + model ·
+ * mode, with the mode colored when it's non-default, like getModeColor).
+ */
 import { Box, Text } from 'ink'
 import React from 'react'
 import { theme } from '../theme.js'
 
 interface Props {
   connected: boolean
-  serverLabel: string
   model: string
   mode: string
   busy: boolean
 }
 
-export function StatusBar({ connected, serverLabel, model, mode, busy }: Props): React.ReactElement {
+const MODE_COLOR: Record<string, string | undefined> = {
+  default: undefined,
+  acceptEdits: theme.success,
+  bypassPermissions: theme.error,
+  plan: 'rgb(72,150,140)', // sage (planMode)
+}
+
+export function StatusBar({ connected, model, mode, busy }: Props): React.ReactElement {
+  const dot = !connected ? theme.dim : busy ? theme.warn : theme.success
+  const modeColor = MODE_COLOR[mode] ?? theme.dim
   return (
     <Box marginTop={1} justifyContent="space-between">
+      <Text color={theme.dim}>? for shortcuts</Text>
       <Box>
-        <Text color={connected ? theme.success : theme.error}>{connected ? '●' : '○'}</Text>
-        <Text color={theme.dim}>{` ${serverLabel} · ${model} · ${mode}`}</Text>
+        <Text color={dot}>{'● '}</Text>
+        <Text color={theme.dim}>{model}</Text>
+        <Text color={theme.dim}>{' · '}</Text>
+        <Text color={modeColor}>{mode}</Text>
       </Box>
-      <Text color={theme.dim}>{`${busy ? 'working' : 'ready'} · / commands · ^C quit`}</Text>
     </Box>
   )
 }

--- a/ui-tui/src/diff.ts
+++ b/ui-tui/src/diff.ts
@@ -1,0 +1,57 @@
+/**
+ * Minimal line diff for Edit/Write tool calls, rendered Claude-Code style
+ * (green added / red removed lines with a line-number gutter). Not a full Myers
+ * diff — it trims the common prefix/suffix and shows the changed middle, which
+ * is exactly right for an Edit's old_string→new_string region.
+ */
+export interface DiffLine {
+  type: 'add' | 'del' | 'ctx'
+  text: string
+  oldNo?: number
+  newNo?: number
+}
+
+export function lineDiff(oldStr: string, newStr: string, startLine = 1): DiffLine[] {
+  const o = oldStr.split('\n')
+  const n = newStr.split('\n')
+  let p = 0
+  while (p < o.length && p < n.length && o[p] === n[p]) p++
+  let s = 0
+  while (s < o.length - p && s < n.length - p && o[o.length - 1 - s] === n[n.length - 1 - s]) s++
+  const out: DiffLine[] = []
+  let oldNo = startLine
+  let newNo = startLine
+  for (let i = 0; i < p; i++) out.push({ type: 'ctx', text: o[i] ?? '', oldNo: oldNo++, newNo: newNo++ })
+  for (let i = p; i < o.length - s; i++) out.push({ type: 'del', text: o[i] ?? '', oldNo: oldNo++ })
+  for (let i = p; i < n.length - s; i++) out.push({ type: 'add', text: n[i] ?? '', newNo: newNo++ })
+  for (let i = 0; i < s; i++) {
+    out.push({ type: 'ctx', text: o[o.length - s + i] ?? '', oldNo: oldNo++, newNo: newNo++ })
+  }
+  return out
+}
+
+/** Build a diff for an Edit/Write/MultiEdit tool call from its raw input. */
+export function toolDiff(toolName: string, input: Record<string, unknown>): DiffLine[] | null {
+  if (toolName === 'Write') {
+    const content = typeof input['content'] === 'string' ? (input['content'] as string) : ''
+    if (!content) return null
+    return content.split('\n').map((text, i) => ({ type: 'add', text, newNo: i + 1 }))
+  }
+  if (toolName === 'Edit') {
+    const oldS = typeof input['old_string'] === 'string' ? (input['old_string'] as string) : ''
+    const newS = typeof input['new_string'] === 'string' ? (input['new_string'] as string) : ''
+    if (!oldS && !newS) return null
+    return lineDiff(oldS, newS)
+  }
+  if (toolName === 'MultiEdit') {
+    const edits = Array.isArray(input['edits']) ? (input['edits'] as Record<string, unknown>[]) : []
+    const out: DiffLine[] = []
+    for (const e of edits) {
+      const oldS = typeof e['old_string'] === 'string' ? (e['old_string'] as string) : ''
+      const newS = typeof e['new_string'] === 'string' ? (e['new_string'] as string) : ''
+      out.push(...lineDiff(oldS, newS))
+    }
+    return out.length ? out : null
+  }
+  return null
+}

--- a/ui-tui/src/sdkMessageAdapter.ts
+++ b/ui-tui/src/sdkMessageAdapter.ts
@@ -29,6 +29,8 @@ export interface TranscriptEntry {
   /** tool calls only: the tool name + a compact one-line args preview. */
   toolName?: string
   argsText?: string
+  /** tool calls only: the raw input (used to render Edit/Write diffs). */
+  input?: Record<string, unknown>
 }
 
 let _seq = 0
@@ -127,6 +129,7 @@ export function messageToEntries(msg: ServerMessage): TranscriptEntry[] {
             text: '',
             toolName: String((block as { name?: string }).name ?? 'tool'),
             argsText: formatToolArgs((block as { input?: unknown }).input),
+            input: ((block as { input?: Record<string, unknown> }).input ?? {}) as Record<string, unknown>,
           })
         }
       }

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -25,6 +25,8 @@ export const theme = {
   promptBorder: 'rgb(136,136,136)', // input rule
   userBg: 'rgb(55,55,55)', // user message background
   spinner: 'rgb(215,119,87)', // claude orange
+  diffAddBg: 'rgb(34,92,43)', // dark green — added lines
+  diffDelBg: 'rgb(122,41,54)', // dark red — removed lines
 } as const
 
 /** Leading glyphs for each message kind (Claude-Code figures). */


### PR DESCRIPTION
## TUI element pass: permission flow, edit diffs, WebFetch, slash menu, status bar

Continues the Claude Code look-and-feel work (after #395/#400/#401), grounding each element in the real `typescript/src` components and verifying with side-by-side screenshot captures.

### 1. Permission prompt (`PermissionDialog`)
Top-rule-only frame in the permission **blue-purple** (was a full amber box), `<tool> wants to run` + indented args preview + a numbered option list (`❯ 1. Yes (y)` / `2. No, and tell the agent what to do differently (n/esc)`) — mirrors `components/permissions/PermissionDialog.tsx`. Keys `1`/`2` added alongside `y`/`n`. Spinner hidden while a prompt is open.

### 2. Edit/Write diffs (`diff.ts`, `DiffView`)
New: Edit/Write/MultiEdit tool calls now render a real diff — **green added** (`rgb(34,92,43)`) / **red removed** (`rgb(122,41,54)`) lines with a line-number gutter + `+`/`-` markers, mirroring the original `StructuredDiff`. Verified on a live Edit (`- console.log("hi")` → `+ console.log("hello " + name)`).

### 3. WebFetch / WebSearch
URL/query argument now rendered in the **blue-purple link color** so it reads as a link.

### 4. Slash menu (`SlashMenu`)
Selected row is now a full-width **highlighted bar** (suggestion-blue bg, dark bold text, `›` prefix) with aligned name/description columns — matches `PromptInputFooterSuggestions`. Fixed a double-slash bug.

### 5. Status bar / footer (`StatusBar`)
Left **`? for shortcuts`** hint + right **`● model · mode`** status (mode colored when non-default, e.g. `bypassPermissions` in red) — matches `PromptInputFooter`'s left-hints / right-status layout. Dropped the redundant key-hint line + the internal `cc://` label.

### Bonus
Tool-call dot is now **green** (success), matching the original.

`typecheck` + `build` green. Branches off `main`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
