### PR TITLE
fix(ui-tui): stream dup, diff indent, and persistent welcome banner

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -10,7 +10,6 @@ import { Box, Static, Text, useApp, useInput } from 'ink'
 import TextInput from 'ink-text-input'
 import React, { useEffect, useRef, useState } from 'react'
 import { DirectConnectClient, type SessionInfo } from './client.js'
-import { Banner } from './components/Banner.js'
 import { Message } from './components/Message.js'
 import { PermissionDialog } from './components/PermissionDialog.js'
 import { SlashMenu } from './components/SlashMenu.js'
@@ -68,9 +67,11 @@ export function App({ info, serverLabel }: Props): React.ReactElement {
   const [mode, setMode] = useState('?')
   const [tools, setTools] = useState(0)
   const [connected, setConnected] = useState(false)
+  const [ready, setReady] = useState(false) // system/init received — banner committed, submit allowed
   const [client, setClient] = useState<DirectConnectClient | null>(null)
   const [slashSel, setSlashSel] = useState(0)
   const localSeq = useRef(0)
+  const bannerAdded = useRef(false)
 
   const slashMatches = !input.includes(' ') ? matchSlash(input) : []
   const slashOpen = slashMatches.length > 0 && permissions.length === 0
@@ -127,9 +128,30 @@ export function App({ info, serverLabel }: Props): React.ReactElement {
         }
         if (type === 'system' && (msg as { subtype?: string }).subtype === 'init') {
           const m = msg as { model?: string; permission_mode?: string; protocol_version?: string; tools?: unknown[] }
+          const toolCount = Array.isArray(m.tools) ? m.tools.length : 0
           setModel(m.model ?? '?')
           setMode(m.permission_mode ?? '?')
-          setTools(Array.isArray(m.tools) ? m.tools.length : 0)
+          setTools(toolCount)
+          // Commit the welcome banner as the FIRST Static entry so it stays in
+          // scrollback as the conversation grows (the original keeps its logo).
+          // It must be APPENDED before any other entry — <Static> is append-only
+          // and tracks by index, so prepending would skip the banner and
+          // duplicate the next row. Submit is gated on `ready` (set here) so a
+          // user message can never beat the banner into the list.
+          setReady(true)
+          if (!bannerAdded.current) {
+            bannerAdded.current = true
+            addEntry({
+              kind: 'banner',
+              text: '',
+              bannerData: {
+                model: m.model ?? '?',
+                mode: m.permission_mode ?? '?',
+                tools: toolCount,
+                cwd: info.workDir,
+              },
+            })
+          }
           const major = parseProtocolMajor(m.protocol_version)
           if (major !== null && major !== SUPPORTED_PROTOCOL_MAJOR) {
             addEntry({
@@ -249,7 +271,7 @@ export function App({ info, serverLabel }: Props): React.ReactElement {
         return
       }
     }
-    if (!client || !connected || busy || permissions.length > 0) return
+    if (!client || !ready || busy || permissions.length > 0) return
     client.sendPrompt(text)
     addEntry({ kind: 'user', text })
     setStream('')
@@ -261,13 +283,12 @@ export function App({ info, serverLabel }: Props): React.ReactElement {
 
   return (
     <Box flexDirection="column">
-      {entries.length === 0 && streaming === '' ? (
-        <Banner model={model} mode={mode} tools={tools} cwd={info.workDir} />
-      ) : null}
-
       <Static items={entries}>
         {(entry) => (
-          <Box key={entry.id} marginTop={entry.kind === 'tool' || entry.kind === 'toolResult' ? 0 : 1}>
+          <Box
+            key={entry.id}
+            marginTop={['tool', 'toolResult', 'banner'].includes(entry.kind) ? 0 : 1}
+          >
             <Message entry={entry} />
           </Box>
         )}
@@ -311,7 +332,7 @@ export function App({ info, serverLabel }: Props): React.ReactElement {
             paddingX={1}
             width="100%"
           >
-            <Text color={connected ? theme.accent : theme.dim}>{busy ? '… ' : '❯ '}</Text>
+            <Text color={ready ? theme.accent : theme.dim}>{busy ? '… ' : '❯ '}</Text>
             <TextInput
               value={input}
               onChange={(v) => {
@@ -319,7 +340,7 @@ export function App({ info, serverLabel }: Props): React.ReactElement {
                 setSlashSel(0)
               }}
               onSubmit={onSubmit}
-              placeholder={connected ? 'Type a message, or / for commands…' : 'connecting…'}
+              placeholder={ready ? 'Type a message, or / for commands…' : 'starting agent-server…'}
             />
           </Box>
         </>

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -10,7 +10,6 @@ import { Box, Static, Text, useApp, useInput } from 'ink'
 import TextInput from 'ink-text-input'
 import React, { useEffect, useRef, useState } from 'react'
 import { DirectConnectClient, type SessionInfo } from './client.js'
-import { Markdown } from './markdown.js'
 import { Banner } from './components/Banner.js'
 import { Message } from './components/Message.js'
 import { PermissionDialog } from './components/PermissionDialog.js'
@@ -38,6 +37,23 @@ const HELP = [
   '/help /clear /model <m> /mode <m> /quit',
   '↑↓ — slash menu · tab — complete',
 ].join('\n')
+
+/**
+ * Tail of a live buffer that fits `maxLines` visual rows at `cols` width — hard-
+ * wraps each logical line, then keeps the last `maxLines`. Keeps the streaming
+ * (non-Static) region inside the viewport so Ink can erase it cleanly instead of
+ * leaking re-rendered copies into scrollback.
+ */
+function streamTail(text: string, cols: number, maxLines: number): string {
+  if (maxLines < 1) maxLines = 1
+  const width = cols < 8 ? 8 : cols
+  const visual: string[] = []
+  for (const ln of text.split('\n')) {
+    if (ln.length <= width) visual.push(ln)
+    else for (let i = 0; i < ln.length; i += width) visual.push(ln.slice(i, i + width))
+  }
+  return visual.slice(-maxLines).join('\n')
+}
 
 export function App({ info, serverLabel }: Props): React.ReactElement {
   const { exit } = useApp()
@@ -262,8 +278,16 @@ export function App({ info, serverLabel }: Props): React.ReactElement {
           <Box width={2}>
             <Text color={theme.accent}>⏺</Text>
           </Box>
-          <Box flexDirection="column" flexGrow={1}>
-            <Markdown text={streaming} />
+          <Box flexGrow={1}>
+            {/* The live stream is the only UNBOUNDED part of the dynamic (non-
+                Static) region. If it overflows the viewport Ink can't erase the
+                scrolled-off rows, so each re-render (the spinner ticks ~10×/s)
+                leaves a stale copy in scrollback → the message appears dozens of
+                times. Cap it to a viewport-fitting tail (plain text); the full
+                markdown commits to <Static> when the assistant message lands. */}
+            <Text>
+              {streamTail(streaming, (process.stdout.columns ?? 80) - 4, (process.stdout.rows ?? 24) - 10)}
+            </Text>
           </Box>
         </Box>
       ) : null}

--- a/ui-tui/src/components/DiffView.tsx
+++ b/ui-tui/src/components/DiffView.tsx
@@ -15,14 +15,14 @@ export function DiffView({ lines }: { lines: DiffLine[] }): React.ReactElement {
   const extra = lines.length - shown.length
   const width = Math.max(1, ...lines.map((l) => String(l.oldNo ?? l.newNo ?? 0).length))
   return (
-    <Box flexDirection="column" marginLeft={2}>
+    <Box flexDirection="column">
       {shown.map((l, i) => {
         const no = l.type === 'del' ? l.oldNo : l.newNo
         const marker = l.type === 'add' ? '+' : l.type === 'del' ? '-' : ' '
         const bg = l.type === 'add' ? theme.diffAddBg : l.type === 'del' ? theme.diffDelBg : undefined
         return (
           <Text key={i} backgroundColor={bg} color={l.type === 'ctx' ? theme.dim : undefined} wrap="truncate-end">
-            {` ${marker} ${String(no ?? '').padStart(width)} ${l.text || ' '} `}
+            {`${marker} ${String(no ?? '').padStart(width)} ${l.text || ' '}`}
           </Text>
         )
       })}

--- a/ui-tui/src/components/Message.tsx
+++ b/ui-tui/src/components/Message.tsx
@@ -10,6 +10,7 @@ import { Box, Text } from 'ink'
 import React from 'react'
 import { Markdown } from '../markdown.js'
 import { theme } from '../theme.js'
+import { Banner } from './Banner.js'
 import { DiffView } from './DiffView.js'
 import { toolDiff } from '../diff.js'
 import type { TranscriptEntry } from '../sdkMessageAdapter.js'
@@ -35,6 +36,8 @@ function ToolResult({ text }: { text: string }): React.ReactElement {
 
 export function Message({ entry }: { entry: TranscriptEntry }): React.ReactElement | null {
   switch (entry.kind) {
+    case 'banner':
+      return entry.bannerData ? <Banner {...entry.bannerData} /> : null
     case 'user':
       return (
         <Box>

--- a/ui-tui/src/markdown.tsx
+++ b/ui-tui/src/markdown.tsx
@@ -172,8 +172,7 @@ export function Markdown({ text }: { text: string }): React.ReactElement {
     <Box flexDirection="column">
       {blocks.map((b, idx) => {
         if (b.type === 'code') {
-          // Borderless, syntax-highlighted, with a dim left gutter — matches
-          // the Claude Code look (no box; cli-highlight colors the code).
+          // Borderless, indented, syntax-highlighted via cli-highlight.
           const lines = highlightCode(b.lines.join('\n'), b.lang)
           return (
             <Box key={idx} flexDirection="column" marginY={0} paddingLeft={2}>

--- a/ui-tui/src/sdkMessageAdapter.ts
+++ b/ui-tui/src/sdkMessageAdapter.ts
@@ -14,6 +14,7 @@ import {
 } from './protocol.js'
 
 export type EntryKind =
+  | 'banner'
   | 'user'
   | 'assistant'
   | 'tool'
@@ -31,6 +32,8 @@ export interface TranscriptEntry {
   argsText?: string
   /** tool calls only: the raw input (used to render Edit/Write diffs). */
   input?: Record<string, unknown>
+  /** banner only: the session info snapshot, captured once at init. */
+  bannerData?: { model: string; mode: string; tools: number; cwd?: string }
 }
 
 let _seq = 0


### PR DESCRIPTION
## Fix three TUI rendering bugs found in terminal testing

### 1. Duplicated lines (many copies of a streamed message)
The live streaming region is the only **unbounded** part of Ink's dynamic (non-`Static`) tree. When a streamed response is taller than the viewport, Ink can't erase the rows that scrolled off — so every re-render (the spinner ticks ~10×/s) leaves a stale copy in scrollback, and a long message ends up printed dozens of times.
**Fix:** cap the live stream to a viewport-fitting tail (`streamTail`, plain text); the full syntax-highlighted markdown still commits to `<Static>` when the message lands. Verified with a pyte `HistoryScreen` A/B (pre-fix: 2+ copies; post-fix: exactly one).

### 2. Edit/Write diffs rendered too far right
Dropped `DiffView`'s `marginLeft` + leading gutter space so deeply-indented code (nested JSX/SVG) isn't pushed off the right edge. Diffs are flush-left: `- 1  const cls = "btn"` / `+ 1  …`.

### 3. Welcome banner vanished on the first task
The banner was a conditional render (`entries.length === 0 ? <Banner/> : null`), so it disappeared the moment the first message landed; the original keeps its logo in scrollback.
**Fix:** commit the banner as the **first `<Static>` entry** (new `banner` entry kind) so it's written to scrollback once and stays. Since `<Static>` is append-only/indexed, the banner must be appended before any other entry — so submit is gated on a `ready` flag set when `system/init` arrives. This also fixes a **cold-start race** where a message sent during the ~20s startup beat the banner into the list (prepending it duplicated the first row). Input shows "starting agent-server…" until ready.

`typecheck` + `build` green; server suite **79 passed** (client-only). Branches off `main`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
