### PR TITLE
fix(ui-tui): diff wrap long lines + true file line numbers + tight gutter

### DIFF
--- a/ui-tui/src/components/DiffView.tsx
+++ b/ui-tui/src/components/DiffView.tsx
@@ -1,32 +1,67 @@
 /**
- * Renders a line diff (from diff.ts) Claude-Code style: a line-number gutter +
- * marker, added lines on a green background, removed lines on a red background,
- * context lines dim. Mirrors StructuredDiff's gutter (marker + line number).
+ * Renders a line diff (from diff.ts) the way the original StructuredDiff does:
+ * a NON-colored line-number gutter column + a colored content column (green
+ * added / red removed / dim context). Long lines WRAP — each wrapped row keeps
+ * the marker and the background color, and the line number shows only on the
+ * first row — instead of being truncated off the right edge. Topped with an
+ * "⎿ Added N, removed M lines" summary.
+ *
+ * Line numbers are relative to the edited region: the tool input gives us
+ * old_string/new_string, not absolute file positions.
  */
 import { Box, Text } from 'ink'
 import React from 'react'
 import { theme } from '../theme.js'
 import type { DiffLine } from '../diff.js'
 
-const MAX_LINES = 40
+const MAX_LINES = 80
+
+/** Hard-wrap into <=width segments (code wraps mid-token, like the original). */
+function wrapSegs(s: string, width: number): string[] {
+  if (width < 1 || s.length <= width) return [s || ' ']
+  const out: string[] = []
+  for (let i = 0; i < s.length; i += width) out.push(s.slice(i, i + width))
+  return out
+}
 
 export function DiffView({ lines }: { lines: DiffLine[] }): React.ReactElement {
   const shown = lines.slice(0, MAX_LINES)
   const extra = lines.length - shown.length
-  const width = Math.max(1, ...lines.map((l) => String(l.oldNo ?? l.newNo ?? 0).length))
+  const numW = Math.max(1, ...lines.map((l) => String(l.oldNo ?? l.newNo ?? 0).length))
+  const cols = process.stdout.columns ?? 80
+  const gutterW = numW + 1
+  const contentW = Math.max(8, cols - gutterW - 1) // content column fills the rest of the row
+  const segW = Math.max(4, contentW - 2) // room for "<marker> "
+  const added = lines.filter((l) => l.type === 'add').length
+  const removed = lines.filter((l) => l.type === 'del').length
+
   return (
     <Box flexDirection="column">
+      <Text color={theme.dim}>
+        {`  ⎿ Added ${added} line${added === 1 ? '' : 's'}, removed ${removed} line${removed === 1 ? '' : 's'}`}
+      </Text>
       {shown.map((l, i) => {
         const no = l.type === 'del' ? l.oldNo : l.newNo
         const marker = l.type === 'add' ? '+' : l.type === 'del' ? '-' : ' '
         const bg = l.type === 'add' ? theme.diffAddBg : l.type === 'del' ? theme.diffDelBg : undefined
+        const fg = l.type === 'ctx' ? theme.dim : undefined
+        const segs = wrapSegs(l.text, segW)
         return (
-          <Text key={i} backgroundColor={bg} color={l.type === 'ctx' ? theme.dim : undefined} wrap="truncate-end">
-            {`${marker} ${String(no ?? '').padStart(width)} ${l.text || ' '}`}
-          </Text>
+          <Box key={i}>
+            <Box width={gutterW} flexShrink={0}>
+              <Text color={theme.dim}>{String(no ?? '').padStart(numW)}</Text>
+            </Box>
+            <Box flexDirection="column">
+              {segs.map((seg, j) => (
+                <Text key={j} backgroundColor={bg} color={fg}>
+                  {`${marker} ${seg}`.padEnd(contentW)}
+                </Text>
+              ))}
+            </Box>
+          </Box>
         )
       })}
-      {extra > 0 ? <Text color={theme.dim}>{`    … +${extra} more line${extra === 1 ? '' : 's'}`}</Text> : null}
+      {extra > 0 ? <Text color={theme.dim}>{`    … +${extra} more lines`}</Text> : null}
     </Box>
   )
 }

--- a/ui-tui/src/components/DiffView.tsx
+++ b/ui-tui/src/components/DiffView.tsx
@@ -29,9 +29,9 @@ export function DiffView({ lines }: { lines: DiffLine[] }): React.ReactElement {
   const extra = lines.length - shown.length
   const numW = Math.max(1, ...lines.map((l) => String(l.oldNo ?? l.newNo ?? 0).length))
   const cols = process.stdout.columns ?? 80
-  const gutterW = numW + 1
+  const gutterW = numW + 1 // right-aligned line number + a single space
   const contentW = Math.max(8, cols - gutterW - 1) // content column fills the rest of the row
-  const segW = Math.max(4, contentW - 2) // room for "<marker> "
+  const segW = Math.max(4, contentW - 1) // room for the 1-char marker (no space — it hugs the code)
   const added = lines.filter((l) => l.type === 'add').length
   const removed = lines.filter((l) => l.type === 'del').length
 
@@ -54,7 +54,7 @@ export function DiffView({ lines }: { lines: DiffLine[] }): React.ReactElement {
             <Box flexDirection="column">
               {segs.map((seg, j) => (
                 <Text key={j} backgroundColor={bg} color={fg}>
-                  {`${marker} ${seg}`.padEnd(contentW)}
+                  {`${marker}${seg}`.padEnd(contentW)}
                 </Text>
               ))}
             </Box>

--- a/ui-tui/src/components/Message.tsx
+++ b/ui-tui/src/components/Message.tsx
@@ -12,7 +12,6 @@ import { Markdown } from '../markdown.js'
 import { theme } from '../theme.js'
 import { Banner } from './Banner.js'
 import { DiffView } from './DiffView.js'
-import { toolDiff } from '../diff.js'
 import type { TranscriptEntry } from '../sdkMessageAdapter.js'
 
 const RESULT_MAX_LINES = 8
@@ -63,7 +62,7 @@ export function Message({ entry }: { entry: TranscriptEntry }): React.ReactEleme
         </Box>
       )
     case 'tool': {
-      const diff = entry.toolName ? toolDiff(entry.toolName, entry.input ?? {}) : null
+      const diff = entry.diff
       const isWeb = entry.toolName === 'WebFetch' || entry.toolName === 'WebSearch'
       return (
         <Box flexDirection="column">

--- a/ui-tui/src/diff.ts
+++ b/ui-tui/src/diff.ts
@@ -30,8 +30,33 @@ export function lineDiff(oldStr: string, newStr: string, startLine = 1): DiffLin
   return out
 }
 
-/** Build a diff for an Edit/Write/MultiEdit tool call from its raw input. */
-export function toolDiff(toolName: string, input: Record<string, unknown>): DiffLine[] | null {
+/**
+ * File line number where `probe` begins in `fileContent` (1-based). The original
+ * computes this from the patch hunk's oldStart; we locate the changed region
+ * directly. Tries old_string (pre-edit file) then new_string (post-edit file),
+ * so it works whether or not the edit has already been applied on disk.
+ */
+function startLineOf(fileContent: string | undefined, oldS: string, newS: string): number {
+  if (!fileContent) return 1
+  const probe = oldS && fileContent.includes(oldS) ? oldS : newS && fileContent.includes(newS) ? newS : null
+  if (!probe) return 1
+  const idx = fileContent.indexOf(probe)
+  if (idx <= 0) return 1
+  let line = 1
+  for (let i = 0; i < idx; i++) if (fileContent[i] === '\n') line++
+  return line
+}
+
+/**
+ * Build a diff for an Edit/Write/MultiEdit tool call from its raw input.
+ * `fileContent` (the on-disk file) lets us emit true file line numbers; without
+ * it we fall back to region-relative (1-based) numbering.
+ */
+export function toolDiff(
+  toolName: string,
+  input: Record<string, unknown>,
+  fileContent?: string,
+): DiffLine[] | null {
   if (toolName === 'Write') {
     const content = typeof input['content'] === 'string' ? (input['content'] as string) : ''
     if (!content) return null
@@ -41,7 +66,7 @@ export function toolDiff(toolName: string, input: Record<string, unknown>): Diff
     const oldS = typeof input['old_string'] === 'string' ? (input['old_string'] as string) : ''
     const newS = typeof input['new_string'] === 'string' ? (input['new_string'] as string) : ''
     if (!oldS && !newS) return null
-    return lineDiff(oldS, newS)
+    return lineDiff(oldS, newS, startLineOf(fileContent, oldS, newS))
   }
   if (toolName === 'MultiEdit') {
     const edits = Array.isArray(input['edits']) ? (input['edits'] as Record<string, unknown>[]) : []
@@ -49,7 +74,7 @@ export function toolDiff(toolName: string, input: Record<string, unknown>): Diff
     for (const e of edits) {
       const oldS = typeof e['old_string'] === 'string' ? (e['old_string'] as string) : ''
       const newS = typeof e['new_string'] === 'string' ? (e['new_string'] as string) : ''
-      out.push(...lineDiff(oldS, newS))
+      out.push(...lineDiff(oldS, newS, startLineOf(fileContent, oldS, newS)))
     }
     return out.length ? out : null
   }

--- a/ui-tui/src/sdkMessageAdapter.ts
+++ b/ui-tui/src/sdkMessageAdapter.ts
@@ -7,11 +7,23 @@
  * tool_use blocks (rendered as Claude-Code-style tool calls) and tool_result
  * blocks (the indented ⎿ output).
  */
+import { readFileSync } from 'node:fs'
 import {
   blocksToText,
   type ContentBlock,
   type ServerMessage,
 } from './protocol.js'
+import { toolDiff, type DiffLine } from './diff.js'
+
+/** Best-effort read of the edited file (local in spawn mode) for true line numbers. */
+function readFileSafe(p: unknown): string | undefined {
+  if (typeof p !== 'string' || !p) return undefined
+  try {
+    return readFileSync(p, 'utf8')
+  } catch {
+    return undefined
+  }
+}
 
 export type EntryKind =
   | 'banner'
@@ -32,6 +44,8 @@ export interface TranscriptEntry {
   argsText?: string
   /** tool calls only: the raw input (used to render Edit/Write diffs). */
   input?: Record<string, unknown>
+  /** Edit/Write tool calls: precomputed diff (with true file line numbers). */
+  diff?: DiffLine[]
   /** banner only: the session info snapshot, captured once at init. */
   bannerData?: { model: string; mode: string; tools: number; cwd?: string }
 }
@@ -126,13 +140,23 @@ export function messageToEntries(msg: ServerMessage): TranscriptEntry[] {
     if (Array.isArray(content)) {
       for (const block of content) {
         if (block && block.type === 'tool_use') {
+          const toolName = String((block as { name?: string }).name ?? 'tool')
+          const tinput = ((block as { input?: Record<string, unknown> }).input ?? {}) as Record<
+            string,
+            unknown
+          >
+          const diff =
+            toolName === 'Edit' || toolName === 'Write' || toolName === 'MultiEdit'
+              ? (toolDiff(toolName, tinput, readFileSafe(tinput['file_path'])) ?? undefined)
+              : undefined
           out.push({
             id: nextId(),
             kind: 'tool',
             text: '',
-            toolName: String((block as { name?: string }).name ?? 'tool'),
-            argsText: formatToolArgs((block as { input?: unknown }).input),
-            input: ((block as { input?: Record<string, unknown> }).input ?? {}) as Record<string, unknown>,
+            toolName,
+            argsText: formatToolArgs(tinput),
+            input: tinput,
+            diff,
           })
         }
       }


### PR DESCRIPTION
## Fix diff rendering: wrap long lines, true file line numbers, tight gutter

Grounded in the original `StructuredDiff` / `FileEditToolDiff` (`typescript/src/components/`).

### 1. Wrap long lines (don't truncate)
The renderer used `wrap="truncate-end"`, cutting long edited lines (minified config, SVG paths) off the right edge. Now: a **non-colored line-number gutter column** + a **colored content column** where long lines **wrap** across visual rows — each wrapped row keeps the `+`/`-` marker and the green/red background; the line number shows only on the first row. Rows fill the full width, with an `⎿ Added N, removed M lines` summary.

### 2. True file line numbers
The original reads the on-disk file (`loadDiffData(file_path)` → `structuredPatch` → `oldStart`/`newStart`). We do the same: the adapter reads the edited file (best-effort, local in spawn mode) and offsets the diff line numbers to where `old_string`/`new_string` actually sits — instead of region-relative 1-based numbers. Falls back to relative if the file can't be read (e.g. attach mode). Verified: editing line 4 now shows **4**, not 1.

### 3. Marker hugs the content
Dropped the extra space after `+`/`-` so the code's own indentation lines up (`4 -const target`, `+  if (…)`), matching the original gutter exactly.

Verified end-to-end: a mid-file edit shows the correct file line number, the marker against the code, and long added lines wrapping (not truncating).

`typecheck` + `build` green. Branches off `main`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
