### PR TITLE
feat(ui-tui): live tool-progress (collapsed activity spinner + compact reads)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -55,6 +55,29 @@ function streamTail(text: string, cols: number, maxLines: number): string {
   return visual.slice(-maxLines).join('\n')
 }
 
+const TOOL_VERB: Record<string, { verb: string; noun: string }> = {
+  Read: { verb: 'Reading', noun: 'files' },
+  Edit: { verb: 'Editing', noun: 'files' },
+  Write: { verb: 'Writing', noun: 'files' },
+  MultiEdit: { verb: 'Editing', noun: 'files' },
+  Bash: { verb: 'Running', noun: 'commands' },
+  Grep: { verb: 'Searching', noun: '' },
+  Glob: { verb: 'Globbing', noun: '' },
+  WebFetch: { verb: 'Fetching', noun: '' },
+  WebSearch: { verb: 'Searching', noun: '' },
+}
+
+/** Live spinner label, e.g. "Reading 3 files" (collapsed count) or "Running git status". */
+function toolActivityLabel(name: string | undefined, args: string | undefined, count: number): string {
+  const { verb, noun } = (name && TOOL_VERB[name]) || {
+    verb: name ? `Using ${name}` : 'Working',
+    noun: '',
+  }
+  if (count > 1 && noun) return `${verb} ${count} ${noun}`
+  const target = (args || '').split(/[\\/]/).pop() || args || ''
+  return target ? `${verb} ${target}` : verb
+}
+
 export function App({ transport, serverLabel }: Props): React.ReactElement {
   const { exit } = useApp()
   const [entries, setEntries] = useState<TranscriptEntry[]>([])
@@ -73,6 +96,8 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const [slashSel, setSlashSel] = useState(0)
   const localSeq = useRef(0)
   const bannerAdded = useRef(false)
+  const [toolActivity, setToolActivity] = useState<string | null>(null)
+  const turnToolCounts = useRef<Record<string, number>>({})
 
   const slashMatches = !input.includes(' ') ? matchSlash(input) : []
   const slashOpen = slashMatches.length > 0 && permissions.length === 0
@@ -126,6 +151,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         if (type === 'assistant') setStream('') // final assistant replaces the live stream
         if (type === 'result') {
           setBusy(false)
+          setToolActivity(null)
           flushStream() // commit a partial left over by interrupt/error (no-op on success)
         }
         if (type === 'system' && (msg as { subtype?: string }).subtype === 'init') {
@@ -169,7 +195,18 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
           }
         }
         const newEntries = messageToEntries(msg)
-        if (newEntries.length) setEntries((e) => [...e, ...newEntries])
+        if (newEntries.length) {
+          // Update the live tool-progress label (collapses repeated tools, e.g.
+          // "Reading 3 files") as each tool call streams in.
+          for (const e of newEntries) {
+            if (e.kind === 'tool') {
+              const verb = (e.toolName && TOOL_VERB[e.toolName]?.verb) || e.toolName || 'tool'
+              const n = (turnToolCounts.current[verb] = (turnToolCounts.current[verb] ?? 0) + 1)
+              setToolActivity(toolActivityLabel(e.toolName, e.argsText, n))
+            }
+          }
+          setEntries((prev) => [...prev, ...newEntries])
+        }
       },
     })
     setClient(c)
@@ -284,6 +321,8 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     addEntry({ kind: 'user', text })
     setStream('')
     setBusy(true)
+    turnToolCounts.current = {}
+    setToolActivity(null)
     setTurnStartedAt(Date.now())
     setInput('')
     setSlashSel(0)
@@ -323,7 +362,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
 
       {busy && permissions.length === 0 ? (
         <Box>
-          <Spinner startedAt={turnStartedAt} />
+          <Spinner startedAt={turnStartedAt} activity={toolActivity} />
         </Box>
       ) : null}
 

--- a/ui-tui/src/components/Message.tsx
+++ b/ui-tui/src/components/Message.tsx
@@ -18,6 +18,13 @@ const RESULT_MAX_LINES = 8
 
 function ToolResult({ text }: { text: string }): React.ReactElement {
   const lines = text.replace(/\s+$/, '').split('\n')
+  // Collapse a long line-numbered file dump (Read / cat -n) to a single line —
+  // several Reads otherwise bury the transcript under hundreds of content lines.
+  // The original keeps these collapsed (ctrl+o to expand).
+  const numbered = lines.filter((l) => /^\s*\d+[\t |→]/.test(l)).length
+  if (lines.length > 6 && numbered >= lines.length * 0.6) {
+    return <Text color={theme.dim}>{`  ⎿ Read ${lines.length} lines`}</Text>
+  }
   const shown = lines.slice(0, RESULT_MAX_LINES)
   const extra = lines.length - shown.length
   return (

--- a/ui-tui/src/components/Spinner.tsx
+++ b/ui-tui/src/components/Spinner.tsx
@@ -20,7 +20,14 @@ const VERBS = [
   'Conjuring',
 ]
 
-export function Spinner({ startedAt }: { startedAt: number }): React.ReactElement {
+export function Spinner({
+  startedAt,
+  activity,
+}: {
+  startedAt: number
+  /** Live tool activity (e.g. "Reading 3 files") — shown instead of the verb. */
+  activity?: string | null
+}): React.ReactElement {
   const [frame, setFrame] = useState(0)
   const [verb] = useState(() => VERBS[Math.floor(Math.random() * VERBS.length)])
   const [elapsed, setElapsed] = useState(0)
@@ -36,10 +43,8 @@ export function Spinner({ startedAt }: { startedAt: number }): React.ReactElemen
 
   return (
     <Text color={theme.spinner}>
-      {FRAMES[frame]} {verb}…{' '}
-      <Text color={theme.dim}>
-        ({elapsed}s · esc to interrupt)
-      </Text>
+      {FRAMES[frame]} {activity || verb}…{' '}
+      <Text color={theme.dim}>({elapsed}s · esc to interrupt)</Text>
     </Text>
   )
 }


### PR DESCRIPTION
## Live tool-progress: collapsed activity + compact reads

Studied the original Claude Code TUI via a **multi-tool filmstrip** (snapshots over time during a several-Read task). The original:
- collapses repeated tools into a **live `● Reading N files…` summary** whose count updates in place (1→3), showing only the current file, with a working spinner;
- keeps file reads collapsed (ctrl+o to expand) rather than dumping content.

clawcodex showed **each Read as a separate block dumping ~8 lines of file content**, with only a static random-verb spinner. Two changes bring it in line:

### 1. Live tool-progress in the spinner
The working indicator now reflects the **current tool activity** — `Reading README.md` for one, `Reading 4 files` (collapsed count) for several — updating as each tool call streams in, instead of a static "Working…". App tracks per-turn tool counts by verb (Read→Reading, Bash→Running, …); cleared on result / new turn. `Spinner` gains an `activity` prop.

### 2. Compact tool results
A long line-numbered file dump (Read / `cat -n`) collapses to **`⎿ Read N lines`** instead of dumping 8 lines per call, so several reads no longer bury the transcript.

### Verified (filmstrips)
- Spinner progresses `Working…` → `Reading 4 files…` as the parallel reads execute.
- A single big read renders `● Read(README.md)` → `⎿ Read 651 lines` + spinner `Reading README.md…`.

`typecheck` + `build` green. Branches off `main`.

> Note: I also spotted a minor UX wart while testing — if you type+Enter during the backend's startup (before `system/init`), the `ready` gate drops that Enter (the text stays). Tangential to this PR; easy follow-up to queue the pending submit.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
