### PR TITLE
fix(tui): prefer built node dist over bun to launch the Ink TUI (fixes react resolution error)

### DIFF
--- a/src/entrypoints/tui_launcher.py
+++ b/src/entrypoints/tui_launcher.py
@@ -82,19 +82,26 @@ def _resolve_tui_dir(explicit: str | None) -> Path | None:
 
 
 def _resolve_tui_command(tui_dir: Path | None) -> list[str] | None:
-    """The base command (without connection args) that runs the Ink TUI."""
+    """The base command (without connection args) that runs the Ink TUI.
+
+    Prefer the built ``dist`` on node: it uses standard node module resolution.
+    ``bun run src/cli.tsx`` (no build) is the fallback — but bun can mis-resolve
+    ``react/jsx-dev-runtime`` from its global auto-install cache ("Cannot find
+    package 'react' from …/.bun/install/cache/…"), so it's no longer the default
+    when a dist exists.
+    """
     override = os.environ.get("CLAWCODEX_TUI_CMD")
     if override:
         return override.split()
     if tui_dir is None:
         return None
-    bun = shutil.which("bun")
-    if bun:
-        return [bun, "run", str(tui_dir / "src" / "cli.tsx")]
     node = shutil.which("node")
     dist = tui_dir / "dist" / "cli.js"
     if node and dist.exists():
         return [node, str(dist)]
+    bun = shutil.which("bun")
+    if bun:
+        return [bun, "run", str(tui_dir / "src" / "cli.tsx")]
     return None
 
 


### PR DESCRIPTION
`clawcodex tui` crashed at launch:
```
error: Cannot find package 'react' from '.../.bun/install/cache/react@18.3.1@@@1/cjs/react-jsx-dev-runtime.development.js'
```
The launcher preferred `bun run src/cli.tsx`, and bun mis-resolves `react/jsx-dev-runtime` from its global auto-install cache. The install path already builds the `dist`, and `node ui-tui/dist/cli.js` runs cleanly (standard node resolution). So `_resolve_tui_command` now prefers **node + built dist**, falling back to `bun run src` only when there's no dist (no-build dev).

Verified: `_resolve_tui_command` returns `node …/dist/cli.js`; launcher tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)