### PR TITLE
fix(ui-tui): diff syntax highlighting (force color) + cap tint width on wide terminals

### DIFF
--- a/ui-tui/src/cli.tsx
+++ b/ui-tui/src/cli.tsx
@@ -14,6 +14,7 @@
  *   clawcodex-tui [--cwd DIR]                                # spawn + own a backend
  *   clawcodex-tui <cc://host:port> [--token T] [--cwd DIR]   # attach
  */
+import './forceColor.js' // MUST be first — sets FORCE_COLOR before chalk/Ink load
 import { render } from 'ink'
 import React from 'react'
 import { App } from './App.js'

--- a/ui-tui/src/components/DiffView.tsx
+++ b/ui-tui/src/components/DiffView.tsx
@@ -21,6 +21,7 @@ import { theme } from '../theme.js'
 import type { DiffLine } from '../diff.js'
 
 const MAX_LINES = 80
+const MAX_DIFF_WIDTH = 120 // readable cap so wide terminals don't stretch the tint
 const RESET = '\x1b[0m'
 const ADD_BG: [number, number, number] = [34, 92, 43]
 const DEL_BG: [number, number, number] = [122, 41, 54]
@@ -70,9 +71,12 @@ export function DiffView({ lines, filePath }: { lines: DiffLine[]; filePath?: st
   const cols = process.stdout.columns ?? 80
   const indent = 2 // sit under the "⎿" summary
   const gutterW = indent + numW + 1 // indent + right-aligned number + a space
-  const contentMax = Math.max(8, cols - gutterW - 1)
+  // Cap the content column at a readable width so a very wide terminal (or one
+  // long line) doesn't stretch the tint across the whole screen — a no-op on
+  // normal terminals, it just bounds the worst case.
+  const contentMax = Math.max(8, Math.min(cols - gutterW - 1, MAX_DIFF_WIDTH))
   // Tint width = the longest line in the hunk (marker + code), capped at the
-  // terminal — a tight block for short hunks instead of a full-width bar.
+  // content column — a tight block for short hunks instead of a full-width bar.
   const longest = Math.max(2, ...shown.map((l) => 1 + (l.text?.length ?? 0)))
   const blockW = Math.min(contentMax, longest)
   const segW = Math.max(4, blockW) // wrap target (marker is counted in bgRow)

--- a/ui-tui/src/forceColor.ts
+++ b/ui-tui/src/forceColor.ts
@@ -1,0 +1,16 @@
+/**
+ * Force color ON before any color library (chalk via cli-highlight, and Ink)
+ * loads — this MUST be imported first.
+ *
+ * The launcher spawns this process with stdout inherited, but in that spawned
+ * context cli-highlight's `supports-color` can resolve to "no color" (level 0),
+ * so syntax highlighting silently drops to plain text — which then sits on the
+ * diff's hardcoded rgb tint as flat, unreadable text. The TUI always renders to
+ * a terminal (Ink itself emits truecolor), so advertise truecolor — unless the
+ * user explicitly opted out via NO_COLOR or their own FORCE_COLOR.
+ */
+if (process.env['FORCE_COLOR'] === undefined && process.env['NO_COLOR'] === undefined) {
+  process.env['FORCE_COLOR'] = '3'
+}
+
+export {}


### PR DESCRIPTION
Two diff-rendering issues that showed up only in the **real** terminal (my pyte captures masked both — a PTY always reports a TTY, and the test edit had short lines):

1. **No syntax highlighting.** cli-highlight (chalk) only colors when it detects color support; in the launcher-spawned TUI that resolved to *no color*, so the highlighted code dropped to plain text — flat and unreadable on the diff's hardcoded rgb tint. **Fix:** new `forceColor.ts` sets `FORCE_COLOR=3` before chalk/Ink load (imported first in `cli.tsx`), respecting an explicit `NO_COLOR`/`FORCE_COLOR`. The TUI always renders to a terminal and Ink already emits truecolor.
2. **Full-width tint on wide terminals.** The tint is padded to the longest line in the hunk; one long line (or a 200-col terminal) stretched it across the whole screen, giving short lines giant bars. **Fix:** cap the content column at `MAX_DIFF_WIDTH=120` — a no-op on normal terminals, it bounds the worst case so long lines wrap and there's a real right margin.

Verified at COLS=200 with a long-line edit: highlighted code, blocks bounded to ~120 with a right margin, long body wraps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)