### PR TITLE
fix(ui-tui): faithful diffs via upstream TypeScript implementation's exact ColorDiff (word-level)

### DIFF
--- a/ui-tui/package-lock.json
+++ b/ui-tui/package-lock.json
@@ -9,9 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "cli-highlight": "^2.1.11",
+        "diff": "^8.0.3",
+        "highlight.js": "^11.11.1",
         "ink": "^5.0.1",
         "ink-text-input": "^6.0.0",
         "react": "^18.3.1",
+        "string-width": "^7.2.0",
         "wrap-ansi": "^9.0.2",
         "ws": "^8.18.0"
       },
@@ -22,6 +25,7 @@
         "@types/node": "^22.5.0",
         "@types/react": "^18.3.5",
         "@types/ws": "^8.5.12",
+        "ink-testing-library": "^4.0.0",
         "typescript": "^5.6.2"
       },
       "engines": {
@@ -185,6 +189,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cli-highlight/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/cli-truncate": {
       "version": "4.0.0",
       "license": "MIT",
@@ -326,6 +339,15 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/diff": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "license": "MIT"
@@ -387,10 +409,12 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "10.7.3",
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
       "engines": {
-        "node": "*"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/indent-string": {
@@ -445,6 +469,24 @@
           "optional": true
         },
         "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink-testing-library": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz",
+      "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -674,6 +716,8 @@
     },
     "node_modules/string-width": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^10.3.0",

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -15,9 +15,12 @@
   },
   "dependencies": {
     "cli-highlight": "^2.1.11",
+    "diff": "^8.0.3",
+    "highlight.js": "^11.11.1",
     "ink": "^5.0.1",
     "ink-text-input": "^6.0.0",
     "react": "^18.3.1",
+    "string-width": "^7.2.0",
     "wrap-ansi": "^9.0.2",
     "ws": "^8.18.0"
   },
@@ -25,6 +28,7 @@
     "@types/node": "^22.5.0",
     "@types/react": "^18.3.5",
     "@types/ws": "^8.5.12",
+    "ink-testing-library": "^4.0.0",
     "typescript": "^5.6.2"
   },
   "engines": {

--- a/ui-tui/src/colorDiff.ts
+++ b/ui-tui/src/colorDiff.ts
@@ -1,0 +1,941 @@
+/**
+ * Pure TypeScript color-diff renderer — ported VERBATIM from openclaude's
+ * typescript/src/native-ts/color-diff/index.ts (itself a pure-TS port of the
+ * Rust `color-diff` NAPI module). This is the exact non-native path the
+ * original TUI uses, so our diffs render identically by construction.
+ *
+ * `ColorDiff(hunk, firstLine, filePath, fileContent).render(themeName, width, dim)`
+ * returns an array of fully ANSI-escaped lines (right-aligned line-number
+ * gutter, +/-/space markers, add/remove backgrounds that extend to the wrap
+ * width, highlight.js syntax colors, and word-level diff highlighting). The
+ * output is self-contained ANSI — it does NOT use Ink's theme system — so the
+ * React wrapper only has to print each line in a <Text>.
+ *
+ * Local deltas vs the upstream file (kept minimal for re-sync):
+ *   - stringWidth: the `string-width` package instead of the ink-fork helper.
+ *   - logError: silent no-op (writing to stderr would corrupt the TUI).
+ *   - highlight.js loaded via createRequire (ui-tui compiles to ESM).
+ *   - emitter access tolerates both `emitter` (hljs 10.x) and `_emitter`
+ *     (hljs 11.x); ui-tui ships 11.11.1.
+ */
+
+import { diffArrays } from 'diff'
+import type { HLJSApi } from 'highlight.js'
+import { basename, extname } from 'node:path'
+import { createRequire } from 'node:module'
+import stringWidth from 'string-width'
+
+const require = createRequire(import.meta.url)
+
+/** Silent in a TUI — stderr writes would punch through the Ink frame. */
+function logError(_e: unknown): void {
+  /* intentionally empty */
+}
+
+// Lazy: defers loading highlight.js until first render (registers 190+ grammars,
+// ~100-200ms). Matches the upstream lazy-require pattern.
+let cachedHljs: HLJSApi | null = null
+function hljs(): HLJSApi {
+  if (cachedHljs) return cachedHljs
+  const mod = require('highlight.js')
+  cachedHljs = ('default' in mod && mod.default ? mod.default : mod) as HLJSApi
+  return cachedHljs!
+}
+
+// ---------------------------------------------------------------------------
+// Public API types (match vendor/color-diff-src/index.d.ts)
+// ---------------------------------------------------------------------------
+
+export type Hunk = {
+  oldStart: number
+  oldLines: number
+  newStart: number
+  newLines: number
+  lines: string[]
+}
+
+export type SyntaxTheme = {
+  theme: string
+  source: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Color / ANSI escape helpers
+// ---------------------------------------------------------------------------
+
+type Color = { r: number; g: number; b: number; a: number }
+type Style = { foreground: Color; background: Color }
+type Block = [Style, string]
+type ColorMode = 'truecolor' | 'color256' | 'ansi'
+
+const RESET = '\x1b[0m'
+const DIM = '\x1b[2m'
+const UNDIM = '\x1b[22m'
+
+function rgb(r: number, g: number, b: number): Color {
+  return { r, g, b, a: 255 }
+}
+
+function ansiIdx(index: number): Color {
+  return { r: index, g: 0, b: 0, a: 0 }
+}
+
+// Sentinel: a=1 means "terminal default" (matches bat convention)
+const DEFAULT_BG: Color = { r: 0, g: 0, b: 0, a: 1 }
+
+function detectColorMode(theme: string): ColorMode {
+  if (theme.includes('ansi')) return 'ansi'
+  const ct = process.env.COLORTERM ?? ''
+  return ct === 'truecolor' || ct === '24bit' ? 'truecolor' : 'color256'
+}
+
+// Port of ansi_colours::ansi256_from_rgb — approximates RGB to the xterm-256
+// palette (6x6x6 cube + 24 greys).
+const CUBE_LEVELS = [0, 95, 135, 175, 215, 255]
+function ansi256FromRgb(r: number, g: number, b: number): number {
+  const q = (c: number) =>
+    c < 48 ? 0 : c < 115 ? 1 : c < 155 ? 2 : c < 195 ? 3 : c < 235 ? 4 : 5
+  const qr = q(r)
+  const qg = q(g)
+  const qb = q(b)
+  const cubeIdx = 16 + 36 * qr + 6 * qg + qb
+  const grey = Math.round((r + g + b) / 3)
+  if (grey < 5) return 16
+  if (grey > 244 && qr === qg && qg === qb) return cubeIdx
+  const greyLevel = Math.max(0, Math.min(23, Math.round((grey - 8) / 10)))
+  const greyIdx = 232 + greyLevel
+  const greyRgb = 8 + greyLevel * 10
+  const cr = CUBE_LEVELS[qr]!
+  const cg = CUBE_LEVELS[qg]!
+  const cb = CUBE_LEVELS[qb]!
+  const dCube = (r - cr) ** 2 + (g - cg) ** 2 + (b - cb) ** 2
+  const dGrey = (r - greyRgb) ** 2 + (g - greyRgb) ** 2 + (b - greyRgb) ** 2
+  return dGrey < dCube ? greyIdx : cubeIdx
+}
+
+function colorToEscape(c: Color, fg: boolean, mode: ColorMode): string {
+  // alpha=0: palette index encoded in .r (bat's ansi-theme convention)
+  if (c.a === 0) {
+    const idx = c.r
+    if (idx < 8) return `\x1b[${(fg ? 30 : 40) + idx}m`
+    if (idx < 16) return `\x1b[${(fg ? 90 : 100) + (idx - 8)}m`
+    return `\x1b[${fg ? 38 : 48};5;${idx}m`
+  }
+  // alpha=1: terminal default
+  if (c.a === 1) return fg ? '\x1b[39m' : '\x1b[49m'
+
+  const codeType = fg ? 38 : 48
+  if (mode === 'truecolor') {
+    return `\x1b[${codeType};2;${c.r};${c.g};${c.b}m`
+  }
+  return `\x1b[${codeType};5;${ansi256FromRgb(c.r, c.g, c.b)}m`
+}
+
+function asTerminalEscaped(
+  blocks: readonly Block[],
+  mode: ColorMode,
+  skipBackground: boolean,
+  dim: boolean,
+): string {
+  let out = dim ? RESET + DIM : RESET
+  for (const [style, text] of blocks) {
+    out += colorToEscape(style.foreground, true, mode)
+    if (!skipBackground) {
+      out += colorToEscape(style.background, false, mode)
+    }
+    out += text
+  }
+  return out + RESET
+}
+
+// ---------------------------------------------------------------------------
+// Theme
+// ---------------------------------------------------------------------------
+
+type Marker = '+' | '-' | ' '
+
+type Theme = {
+  addLine: Color
+  addWord: Color
+  addDecoration: Color
+  deleteLine: Color
+  deleteWord: Color
+  deleteDecoration: Color
+  foreground: Color
+  background: Color
+  scopes: Record<string, Color>
+}
+
+function defaultSyntaxThemeName(themeName: string): string {
+  if (themeName.includes('ansi')) return 'ansi'
+  if (themeName.includes('dark')) return 'Monokai Extended'
+  return 'GitHub'
+}
+
+// highlight.js scope → syntect Monokai Extended foreground (measured from the
+// Rust module's output so colors match the original exactly)
+const MONOKAI_SCOPES: Record<string, Color> = {
+  keyword: rgb(249, 38, 114),
+  _storage: rgb(102, 217, 239),
+  built_in: rgb(166, 226, 46),
+  type: rgb(166, 226, 46),
+  literal: rgb(190, 132, 255),
+  number: rgb(190, 132, 255),
+  string: rgb(230, 219, 116),
+  title: rgb(166, 226, 46),
+  'title.function': rgb(166, 226, 46),
+  'title.class': rgb(166, 226, 46),
+  'title.class.inherited': rgb(166, 226, 46),
+  params: rgb(253, 151, 31),
+  comment: rgb(117, 113, 94),
+  meta: rgb(117, 113, 94),
+  attr: rgb(166, 226, 46),
+  attribute: rgb(166, 226, 46),
+  variable: rgb(255, 255, 255),
+  'variable.language': rgb(255, 255, 255),
+  property: rgb(255, 255, 255),
+  operator: rgb(249, 38, 114),
+  punctuation: rgb(248, 248, 242),
+  symbol: rgb(190, 132, 255),
+  regexp: rgb(230, 219, 116),
+  subst: rgb(248, 248, 242),
+}
+
+// highlight.js scope → syntect GitHub-light foreground (measured from Rust)
+const GITHUB_SCOPES: Record<string, Color> = {
+  keyword: rgb(167, 29, 93),
+  _storage: rgb(167, 29, 93),
+  built_in: rgb(0, 134, 179),
+  type: rgb(0, 134, 179),
+  literal: rgb(0, 134, 179),
+  number: rgb(0, 134, 179),
+  string: rgb(24, 54, 145),
+  title: rgb(121, 93, 163),
+  'title.function': rgb(121, 93, 163),
+  'title.class': rgb(0, 0, 0),
+  'title.class.inherited': rgb(0, 0, 0),
+  params: rgb(0, 134, 179),
+  comment: rgb(150, 152, 150),
+  meta: rgb(150, 152, 150),
+  attr: rgb(0, 134, 179),
+  attribute: rgb(0, 134, 179),
+  variable: rgb(0, 134, 179),
+  'variable.language': rgb(0, 134, 179),
+  property: rgb(0, 134, 179),
+  operator: rgb(167, 29, 93),
+  punctuation: rgb(51, 51, 51),
+  symbol: rgb(0, 134, 179),
+  regexp: rgb(24, 54, 145),
+  subst: rgb(51, 51, 51),
+}
+
+// Keywords that syntect scopes as storage.type rather than keyword.control.
+const STORAGE_KEYWORDS = new Set([
+  'const',
+  'let',
+  'var',
+  'function',
+  'class',
+  'type',
+  'interface',
+  'enum',
+  'namespace',
+  'module',
+  'def',
+  'fn',
+  'func',
+  'struct',
+  'trait',
+  'impl',
+])
+
+const ANSI_SCOPES: Record<string, Color> = {
+  keyword: ansiIdx(13),
+  _storage: ansiIdx(14),
+  built_in: ansiIdx(14),
+  type: ansiIdx(14),
+  literal: ansiIdx(12),
+  number: ansiIdx(12),
+  string: ansiIdx(10),
+  title: ansiIdx(11),
+  'title.function': ansiIdx(11),
+  'title.class': ansiIdx(11),
+  comment: ansiIdx(8),
+  meta: ansiIdx(8),
+}
+
+function buildTheme(themeName: string, mode: ColorMode): Theme {
+  const isDark = themeName.includes('dark')
+  const isAnsi = themeName.includes('ansi')
+  const isDaltonized = themeName.includes('daltonized')
+  const tc = mode === 'truecolor'
+
+  if (isAnsi) {
+    return {
+      addLine: DEFAULT_BG,
+      addWord: DEFAULT_BG,
+      addDecoration: ansiIdx(10),
+      deleteLine: DEFAULT_BG,
+      deleteWord: DEFAULT_BG,
+      deleteDecoration: ansiIdx(9),
+      foreground: ansiIdx(7),
+      background: DEFAULT_BG,
+      scopes: ANSI_SCOPES,
+    }
+  }
+
+  if (isDark) {
+    const fg = rgb(248, 248, 242)
+    const deleteLine = rgb(61, 1, 0)
+    const deleteWord = rgb(92, 2, 0)
+    const deleteDecoration = rgb(220, 90, 90)
+    if (isDaltonized) {
+      return {
+        addLine: tc ? rgb(0, 27, 41) : ansiIdx(17),
+        addWord: tc ? rgb(0, 48, 71) : ansiIdx(24),
+        addDecoration: rgb(81, 160, 200),
+        deleteLine,
+        deleteWord,
+        deleteDecoration,
+        foreground: fg,
+        background: DEFAULT_BG,
+        scopes: MONOKAI_SCOPES,
+      }
+    }
+    return {
+      addLine: tc ? rgb(2, 40, 0) : ansiIdx(22),
+      addWord: tc ? rgb(4, 71, 0) : ansiIdx(28),
+      addDecoration: rgb(80, 200, 80),
+      deleteLine,
+      deleteWord,
+      deleteDecoration,
+      foreground: fg,
+      background: DEFAULT_BG,
+      scopes: MONOKAI_SCOPES,
+    }
+  }
+
+  // light
+  const fg = rgb(51, 51, 51)
+  const deleteLine = rgb(255, 220, 220)
+  const deleteWord = rgb(255, 199, 199)
+  const deleteDecoration = rgb(207, 34, 46)
+  if (isDaltonized) {
+    return {
+      addLine: rgb(219, 237, 255),
+      addWord: rgb(179, 217, 255),
+      addDecoration: rgb(36, 87, 138),
+      deleteLine,
+      deleteWord,
+      deleteDecoration,
+      foreground: fg,
+      background: DEFAULT_BG,
+      scopes: GITHUB_SCOPES,
+    }
+  }
+  return {
+    addLine: rgb(220, 255, 220),
+    addWord: rgb(178, 255, 178),
+    addDecoration: rgb(36, 138, 61),
+    deleteLine,
+    deleteWord,
+    deleteDecoration,
+    foreground: fg,
+    background: DEFAULT_BG,
+    scopes: GITHUB_SCOPES,
+  }
+}
+
+function defaultStyle(theme: Theme): Style {
+  return { foreground: theme.foreground, background: theme.background }
+}
+
+function lineBackground(marker: Marker, theme: Theme): Color {
+  switch (marker) {
+    case '+':
+      return theme.addLine
+    case '-':
+      return theme.deleteLine
+    case ' ':
+      return theme.background
+  }
+}
+
+function wordBackground(marker: Marker, theme: Theme): Color {
+  switch (marker) {
+    case '+':
+      return theme.addWord
+    case '-':
+      return theme.deleteWord
+    case ' ':
+      return theme.background
+  }
+}
+
+function decorationColor(marker: Marker, theme: Theme): Color {
+  switch (marker) {
+    case '+':
+      return theme.addDecoration
+    case '-':
+      return theme.deleteDecoration
+    case ' ':
+      return theme.foreground
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Syntax highlighting via highlight.js
+// ---------------------------------------------------------------------------
+
+// hljs 10.x uses `kind`; 11.x uses `scope`. Handle both.
+type HljsNode = {
+  scope?: string
+  kind?: string
+  children: (HljsNode | string)[]
+}
+
+const FILENAME_LANGS: Record<string, string> = {
+  Dockerfile: 'dockerfile',
+  Makefile: 'makefile',
+  Rakefile: 'ruby',
+  Gemfile: 'ruby',
+  CMakeLists: 'cmake',
+}
+
+function detectLanguage(
+  filePath: string,
+  firstLine: string | null,
+): string | null {
+  const base = basename(filePath)
+  const ext = extname(filePath).slice(1)
+
+  const stem = base.split('.')[0] ?? ''
+  const byName = FILENAME_LANGS[base] ?? FILENAME_LANGS[stem]
+  if (byName && hljs().getLanguage(byName)) return byName
+  if (ext) {
+    const lang = hljs().getLanguage(ext)
+    if (lang) return ext
+  }
+  if (firstLine) {
+    const line = firstLine.startsWith('﻿') ? firstLine.slice(1) : firstLine
+    if (line.startsWith('#!')) {
+      if (line.includes('bash') || line.includes('/sh')) return 'bash'
+      if (line.includes('python')) return 'python'
+      if (line.includes('node')) return 'javascript'
+      if (line.includes('ruby')) return 'ruby'
+      if (line.includes('perl')) return 'perl'
+    }
+    if (line.startsWith('<?php')) return 'php'
+    if (line.startsWith('<?xml')) return 'xml'
+  }
+  return null
+}
+
+function scopeColor(
+  scope: string | undefined,
+  text: string,
+  theme: Theme,
+): Color {
+  if (!scope) return theme.foreground
+  if (scope === 'keyword' && STORAGE_KEYWORDS.has(text.trim())) {
+    return theme.scopes['_storage'] ?? theme.foreground
+  }
+  return (
+    theme.scopes[scope] ??
+    theme.scopes[scope.split('.')[0]!] ??
+    theme.foreground
+  )
+}
+
+function flattenHljs(
+  node: HljsNode | string,
+  theme: Theme,
+  parentScope: string | undefined,
+  out: Block[],
+): void {
+  if (typeof node === 'string') {
+    const fg = scopeColor(parentScope, node, theme)
+    out.push([{ foreground: fg, background: theme.background }, node])
+    return
+  }
+  const scope = node.scope ?? node.kind ?? parentScope
+  for (const child of node.children) {
+    flattenHljs(child, theme, scope, out)
+  }
+}
+
+function hasRootNode(emitter: unknown): emitter is { rootNode: HljsNode } {
+  return (
+    typeof emitter === 'object' &&
+    emitter !== null &&
+    'rootNode' in emitter &&
+    typeof (emitter as { rootNode: unknown }).rootNode === 'object' &&
+    (emitter as { rootNode: unknown }).rootNode !== null &&
+    'children' in (emitter as { rootNode: object }).rootNode
+  )
+}
+
+let loggedEmitterShapeError = false
+
+function highlightLine(
+  state: { lang: string | null; stack: unknown },
+  line: string,
+  theme: Theme,
+): Block[] {
+  // syntect-parity: feed a trailing \n so line comments terminate, then strip
+  const code = line + '\n'
+  if (!state.lang) {
+    return [[defaultStyle(theme), code]]
+  }
+  let result
+  try {
+    result = hljs().highlight(code, {
+      language: state.lang,
+      ignoreIllegals: true,
+    })
+  } catch {
+    return [[defaultStyle(theme), code]]
+  }
+  // hljs 10.x exposes `.emitter`; 11.x renamed it to `._emitter`.
+  const emitter =
+    (result as { emitter?: unknown; _emitter?: unknown }).emitter ??
+    (result as { _emitter?: unknown })._emitter
+  if (!hasRootNode(emitter)) {
+    if (!loggedEmitterShapeError) {
+      loggedEmitterShapeError = true
+      logError(
+        new Error(
+          `color-diff: hljs emitter shape mismatch. Syntax highlighting disabled.`,
+        ),
+      )
+    }
+    return [[defaultStyle(theme), code]]
+  }
+  const blocks: Block[] = []
+  flattenHljs(emitter.rootNode, theme, undefined, blocks)
+  return blocks
+}
+
+// ---------------------------------------------------------------------------
+// Word diff
+// ---------------------------------------------------------------------------
+
+type Range = { start: number; end: number }
+
+const CHANGE_THRESHOLD = 0.4
+
+function tokenize(text: string): string[] {
+  const tokens: string[] = []
+  let i = 0
+  while (i < text.length) {
+    const ch = text[i]!
+    if (/[\p{L}\p{N}_]/u.test(ch)) {
+      let j = i + 1
+      while (j < text.length && /[\p{L}\p{N}_]/u.test(text[j]!)) j++
+      tokens.push(text.slice(i, j))
+      i = j
+    } else if (/\s/.test(ch)) {
+      let j = i + 1
+      while (j < text.length && /\s/.test(text[j]!)) j++
+      tokens.push(text.slice(i, j))
+      i = j
+    } else {
+      const cp = text.codePointAt(i)!
+      const len = cp > 0xffff ? 2 : 1
+      tokens.push(text.slice(i, i + len))
+      i += len
+    }
+  }
+  return tokens
+}
+
+function findAdjacentPairs(markers: Marker[]): [number, number][] {
+  const pairs: [number, number][] = []
+  let i = 0
+  while (i < markers.length) {
+    if (markers[i] === '-') {
+      const delStart = i
+      let delEnd = i
+      while (delEnd < markers.length && markers[delEnd] === '-') delEnd++
+      let addEnd = delEnd
+      while (addEnd < markers.length && markers[addEnd] === '+') addEnd++
+      const delCount = delEnd - delStart
+      const addCount = addEnd - delEnd
+      if (delCount > 0 && addCount > 0) {
+        const n = Math.min(delCount, addCount)
+        for (let k = 0; k < n; k++) {
+          pairs.push([delStart + k, delEnd + k])
+        }
+        i = addEnd
+      } else {
+        i = delEnd
+      }
+    } else {
+      i++
+    }
+  }
+  return pairs
+}
+
+function wordDiffStrings(oldStr: string, newStr: string): [Range[], Range[]] {
+  const oldTokens = tokenize(oldStr)
+  const newTokens = tokenize(newStr)
+  const ops = diffArrays(oldTokens, newTokens)
+
+  const totalLen = oldStr.length + newStr.length
+  let changedLen = 0
+  const oldRanges: Range[] = []
+  const newRanges: Range[] = []
+  let oldOff = 0
+  let newOff = 0
+
+  for (const op of ops) {
+    const len = op.value.reduce((s, t) => s + t.length, 0)
+    if (op.removed) {
+      changedLen += len
+      oldRanges.push({ start: oldOff, end: oldOff + len })
+      oldOff += len
+    } else if (op.added) {
+      changedLen += len
+      newRanges.push({ start: newOff, end: newOff + len })
+      newOff += len
+    } else {
+      oldOff += len
+      newOff += len
+    }
+  }
+
+  if (totalLen > 0 && changedLen / totalLen > CHANGE_THRESHOLD) {
+    return [[], []]
+  }
+  return [oldRanges, newRanges]
+}
+
+// ---------------------------------------------------------------------------
+// Highlight (per-line transform pipeline)
+// ---------------------------------------------------------------------------
+
+type Highlight = {
+  marker: Marker | null
+  lineNumber: number
+  lines: Block[][]
+}
+
+function removeNewlines(h: Highlight): void {
+  h.lines = h.lines.map(line =>
+    line.flatMap(([style, text]) =>
+      text
+        .split('\n')
+        .filter(p => p.length > 0)
+        .map((p): Block => [style, p]),
+    ),
+  )
+}
+
+function charWidth(ch: string): number {
+  return stringWidth(ch)
+}
+
+function wrapText(h: Highlight, width: number, theme: Theme): void {
+  const newLines: Block[][] = []
+  for (const line of h.lines) {
+    const queue: Block[] = line.slice()
+    let cur: Block[] = []
+    let curW = 0
+    while (queue.length > 0) {
+      const [style, text] = queue.shift()!
+      const tw = stringWidth(text)
+      if (curW + tw <= width) {
+        cur.push([style, text])
+        curW += tw
+      } else {
+        const remaining = width - curW
+        let bytePos = 0
+        let accW = 0
+        for (const ch of text) {
+          const cw = charWidth(ch)
+          if (accW + cw > remaining) break
+          accW += cw
+          bytePos += ch.length
+        }
+        if (bytePos === 0) {
+          if (curW === 0) {
+            const firstCp = text.codePointAt(0)!
+            bytePos = firstCp > 0xffff ? 2 : 1
+          } else {
+            newLines.push(cur)
+            queue.unshift([style, text])
+            cur = []
+            curW = 0
+            continue
+          }
+        }
+        cur.push([style, text.slice(0, bytePos)])
+        newLines.push(cur)
+        queue.unshift([style, text.slice(bytePos)])
+        cur = []
+        curW = 0
+      }
+    }
+    newLines.push(cur)
+  }
+  h.lines = newLines
+
+  // Pad changed lines so background extends to edge
+  if (h.marker && h.marker !== ' ') {
+    const bg = lineBackground(h.marker, theme)
+    const padStyle: Style = { foreground: theme.foreground, background: bg }
+    for (const line of h.lines) {
+      const curW = line.reduce((s, [, t]) => s + stringWidth(t), 0)
+      if (curW < width) {
+        line.push([padStyle, ' '.repeat(width - curW)])
+      }
+    }
+  }
+}
+
+function addLineNumber(
+  h: Highlight,
+  theme: Theme,
+  maxDigits: number,
+  fullDim: boolean,
+): void {
+  const style: Style = {
+    foreground: h.marker ? decorationColor(h.marker, theme) : theme.foreground,
+    background: h.marker ? lineBackground(h.marker, theme) : theme.background,
+  }
+  const shouldDim = h.marker === null || h.marker === ' '
+  for (let i = 0; i < h.lines.length; i++) {
+    const prefix =
+      i === 0
+        ? ` ${String(h.lineNumber).padStart(maxDigits)} `
+        : ' '.repeat(maxDigits + 2)
+    const wrapped = shouldDim && !fullDim ? `${DIM}${prefix}${UNDIM}` : prefix
+    h.lines[i]!.unshift([style, wrapped])
+  }
+}
+
+function addMarker(h: Highlight, theme: Theme): void {
+  if (!h.marker) return
+  const style: Style = {
+    foreground: decorationColor(h.marker, theme),
+    background: lineBackground(h.marker, theme),
+  }
+  for (const line of h.lines) {
+    line.unshift([style, h.marker])
+  }
+}
+
+function dimContent(h: Highlight): void {
+  for (const line of h.lines) {
+    if (line.length > 0) {
+      line[0]![1] = DIM + line[0]![1]
+      const last = line.length - 1
+      line[last]![1] = line[last]![1] + UNDIM
+    }
+  }
+}
+
+function applyBackground(h: Highlight, theme: Theme, ranges: Range[]): void {
+  if (!h.marker) return
+  const lineBg = lineBackground(h.marker, theme)
+  const wordBg = wordBackground(h.marker, theme)
+
+  let rangeIdx = 0
+  let byteOff = 0
+  for (let li = 0; li < h.lines.length; li++) {
+    const newLine: Block[] = []
+    for (const [style, text] of h.lines[li]!) {
+      const textStart = byteOff
+      const textEnd = byteOff + text.length
+
+      while (rangeIdx < ranges.length && ranges[rangeIdx]!.end <= textStart) {
+        rangeIdx++
+      }
+      if (rangeIdx >= ranges.length) {
+        newLine.push([{ ...style, background: lineBg }, text])
+        byteOff = textEnd
+        continue
+      }
+
+      let remaining = text
+      let pos = textStart
+      while (remaining.length > 0 && rangeIdx < ranges.length) {
+        const r = ranges[rangeIdx]!
+        const inRange = pos >= r.start && pos < r.end
+        let next: number
+        if (inRange) {
+          next = Math.min(r.end, textEnd)
+        } else if (r.start > pos && r.start < textEnd) {
+          next = r.start
+        } else {
+          next = textEnd
+        }
+        const segLen = next - pos
+        const seg = remaining.slice(0, segLen)
+        newLine.push([{ ...style, background: inRange ? wordBg : lineBg }, seg])
+        remaining = remaining.slice(segLen)
+        pos = next
+        if (pos >= r.end) rangeIdx++
+      }
+      if (remaining.length > 0) {
+        newLine.push([{ ...style, background: lineBg }, remaining])
+      }
+      byteOff = textEnd
+    }
+    h.lines[li] = newLine
+  }
+}
+
+function intoLines(
+  h: Highlight,
+  dim: boolean,
+  skipBg: boolean,
+  mode: ColorMode,
+): string[] {
+  return h.lines.map(line => asTerminalEscaped(line, mode, skipBg, dim))
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+function maxLineNumber(hunk: Hunk): number {
+  const oldEnd = Math.max(0, hunk.oldStart + hunk.oldLines - 1)
+  const newEnd = Math.max(0, hunk.newStart + hunk.newLines - 1)
+  return Math.max(oldEnd, newEnd)
+}
+
+function parseMarker(s: string): Marker {
+  return s === '+' || s === '-' ? s : ' '
+}
+
+export class ColorDiff {
+  private hunk: Hunk
+  private filePath: string
+  private firstLine: string | null
+  private prefixContent: string | null
+
+  constructor(
+    hunk: Hunk,
+    firstLine: string | null,
+    filePath: string,
+    prefixContent?: string | null,
+  ) {
+    this.hunk = hunk
+    this.filePath = filePath
+    this.firstLine = firstLine
+    this.prefixContent = prefixContent ?? null
+  }
+
+  render(themeName: string, width: number, dim: boolean): string[] | null {
+    const mode = detectColorMode(themeName)
+    const theme = buildTheme(themeName, mode)
+    const lang = detectLanguage(this.filePath, this.firstLine)
+    const hlState = { lang, stack: null }
+
+    void this.prefixContent
+
+    const maxDigits = String(maxLineNumber(this.hunk)).length
+    let oldLine = this.hunk.oldStart
+    let newLine = this.hunk.newStart
+
+    // First pass: assign markers + line numbers
+    type Entry = { lineNumber: number; marker: Marker; code: string }
+    const entries: Entry[] = this.hunk.lines.map(rawLine => {
+      const marker = parseMarker(rawLine.slice(0, 1))
+      const code = rawLine.slice(1)
+      let lineNumber: number
+      switch (marker) {
+        case '+':
+          lineNumber = newLine++
+          break
+        case '-':
+          lineNumber = oldLine++
+          break
+        case ' ':
+          lineNumber = newLine
+          oldLine++
+          newLine++
+          break
+      }
+      return { lineNumber, marker, code }
+    })
+
+    // Word-diff ranges (skip when dim — too loud)
+    const ranges: Range[][] = entries.map(() => [])
+    if (!dim) {
+      const markers = entries.map(e => e.marker)
+      for (const [delIdx, addIdx] of findAdjacentPairs(markers)) {
+        const [delR, addR] = wordDiffStrings(
+          entries[delIdx]!.code,
+          entries[addIdx]!.code,
+        )
+        ranges[delIdx] = delR
+        ranges[addIdx] = addR
+      }
+    }
+
+    const effectiveWidth = Math.max(1, width - maxDigits - 2 - 1)
+
+    // Second pass: highlight + transform pipeline
+    const out: string[] = []
+    for (let i = 0; i < entries.length; i++) {
+      const { lineNumber, marker, code } = entries[i]!
+      const tokens: Block[] =
+        marker === '-'
+          ? [[defaultStyle(theme), code]]
+          : highlightLine(hlState, code, theme)
+
+      const h: Highlight = { marker, lineNumber, lines: [tokens] }
+      removeNewlines(h)
+      applyBackground(h, theme, ranges[i]!)
+      wrapText(h, effectiveWidth, theme)
+      if (mode === 'ansi' && marker === '-') {
+        dimContent(h)
+      }
+      addMarker(h, theme)
+      addLineNumber(h, theme, maxDigits, dim)
+      out.push(...intoLines(h, dim, false, mode))
+    }
+    return out
+  }
+}
+
+export class ColorFile {
+  private code: string
+  private filePath: string
+
+  constructor(code: string, filePath: string) {
+    this.code = code
+    this.filePath = filePath
+  }
+
+  render(themeName: string, width: number, dim: boolean): string[] | null {
+    const mode = detectColorMode(themeName)
+    const theme = buildTheme(themeName, mode)
+    const lines = this.code.split('\n')
+    if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop()
+    const firstLine = lines[0] ?? null
+    const lang = detectLanguage(this.filePath, firstLine)
+    const hlState = { lang, stack: null }
+
+    const maxDigits = String(lines.length).length
+    const effectiveWidth = Math.max(1, width - maxDigits - 2)
+
+    const out: string[] = []
+    for (let i = 0; i < lines.length; i++) {
+      const tokens = highlightLine(hlState, lines[i]!, theme)
+      const h: Highlight = { marker: null, lineNumber: i + 1, lines: [tokens] }
+      removeNewlines(h)
+      wrapText(h, effectiveWidth, theme)
+      addLineNumber(h, theme, maxDigits, dim)
+      out.push(...intoLines(h, dim, true, mode))
+    }
+    return out
+  }
+}
+
+export function getSyntaxTheme(themeName: string): SyntaxTheme {
+  return { theme: defaultSyntaxThemeName(themeName), source: null }
+}

--- a/ui-tui/src/components/DiffView.tsx
+++ b/ui-tui/src/components/DiffView.tsx
@@ -1,116 +1,99 @@
 /**
- * Renders a line diff (from diff.ts) the way the original Claude Code does:
+ * Renders an Edit/MultiEdit/Write tool result the way the original Claude Code
+ * does, driving openclaude's pure-TS ColorDiff / ColorFile renderers (see
+ * ../colorDiff.ts). Layout mirrors MessageResponse + FileEditToolUpdatedMessage /
+ * FileWriteToolCreatedMessage:
  *
- *  - a NON-colored, right-aligned line-number gutter;
- *  - the code is SYNTAX-HIGHLIGHTED (via cli-highlight) on top of the add/del
- *    tint — the background is baked into the ANSI and re-applied after every
- *    syntax reset, so a `\x1b[0m` mid-line doesn't punch a hole in the tint;
- *  - the tint extends only to the LONGEST line in the hunk (capped at the
- *    terminal width), not the full terminal — short lines get a tight block,
- *    not a full-width bar;
- *  - long lines wrap (ANSI-aware) keeping the marker + tint on each row;
- *  - context lines (unchanged) render highlighted with no tint.
+ *   ⎿  Added N lines, removed M lines        (edit summary; omitted for writes)
+ *      <diff hunks | highlighted new content, width = columns - 12>
+ *      … +N lines                            (write truncation hint)
  *
- * Topped with an "⎿ Added N, removed M lines" summary.
+ * ColorDiff/ColorFile emit fully ANSI-escaped rows (dimmed line-number gutter,
+ * +/-/space markers, add/remove backgrounds, highlight.js syntax colors,
+ * word-level diff), so we just print each row in a <Text>. No dashed frame —
+ * that belongs to the permission preview, not the result message.
  */
-import { highlight } from 'cli-highlight'
 import { Box, Text } from 'ink'
 import React from 'react'
-import wrapAnsi from 'wrap-ansi'
+import { ColorDiff, ColorFile } from '../colorDiff.js'
+import { countPatchLines } from '../patch.js'
+import type { ToolDiff } from '../diff.js'
 import { theme } from '../theme.js'
-import type { DiffLine } from '../diff.js'
 
-const MAX_LINES = 80
-const MAX_DIFF_WIDTH = 120 // readable cap so wide terminals don't stretch the tint
-const RESET = '\x1b[0m'
-const ADD_BG: [number, number, number] = [34, 92, 43]
-const DEL_BG: [number, number, number] = [122, 41, 54]
+// CC's default dark theme — Monokai syntax colors + dark add/del tints.
+const THEME_NAME = 'dark'
+// Original truncates created-file previews to the first 10 lines.
+const WRITE_MAX_LINES = 10
+// Safety cap so a giant edit can't flood the live viewport.
+const EDIT_MAX_LINES = 240
 
-/** Visible width (ANSI codes don't count). */
-const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, '')
-
-const LANG: Record<string, string> = {
-  ts: 'typescript', tsx: 'typescript', mts: 'typescript', cts: 'typescript',
-  js: 'javascript', jsx: 'javascript', mjs: 'javascript', cjs: 'javascript',
-  py: 'python', rs: 'rust', go: 'go', rb: 'ruby', java: 'java', kt: 'kotlin',
-  c: 'c', h: 'c', cpp: 'cpp', cc: 'cpp', hpp: 'cpp', cs: 'csharp', swift: 'swift',
-  php: 'php', json: 'json', yml: 'yaml', yaml: 'yaml', toml: 'ini', ini: 'ini',
-  sh: 'bash', bash: 'bash', zsh: 'bash', md: 'markdown', css: 'css', scss: 'scss',
-  html: 'xml', xml: 'xml', sql: 'sql', lua: 'lua', dockerfile: 'dockerfile',
-}
-function langOf(path?: string): string | undefined {
-  const ext = (path || '').split(/[./\\]/).pop()?.toLowerCase()
-  return ext ? LANG[ext] : undefined
-}
-function hl(code: string, lang?: string): string {
-  if (!code) return ''
-  try {
-    return highlight(code, { language: lang, ignoreIllegals: true })
-  } catch {
-    return code
+/** "Added 3 lines, removed 2 lines" — exact phrasing/casing from upstream. */
+function editSummary(added: number, removed: number): string {
+  const parts: string[] = []
+  if (added > 0) parts.push(`Added ${added} ${added > 1 ? 'lines' : 'line'}`)
+  if (removed > 0) {
+    const verb = added === 0 ? 'Removed' : 'removed'
+    parts.push(`${verb} ${removed} ${removed > 1 ? 'lines' : 'line'}`)
   }
+  return parts.join(', ')
 }
 
-/**
- * Build one rendered row: marker + highlighted code, padded to `width`, with the
- * background re-applied after every syntax reset so the tint spans the full row.
- */
-function bgRow(ansi: string, bg: [number, number, number] | null, marker: string, width: number): string {
-  const pad = ' '.repeat(Math.max(0, width - 1 - stripAnsi(ansi).length)) // -1 for the marker
-  if (!bg) return `${marker}${ansi}${pad}`
-  const BG = `\x1b[48;2;${bg[0]};${bg[1]};${bg[2]}m`
-  const body = ansi.replace(/\x1b\[0m/g, RESET + BG) // keep the tint past each reset
-  return `${BG}${marker}${body}${pad}${RESET}`
-}
-
-export function DiffView({ lines, filePath }: { lines: DiffLine[]; filePath?: string }): React.ReactElement {
-  const shown = lines.slice(0, MAX_LINES)
-  const extra = lines.length - shown.length
-  const lang = langOf(filePath)
-  const numW = Math.max(1, ...lines.map((l) => String(l.oldNo ?? l.newNo ?? 0).length))
+export function DiffView({ diff }: { diff: ToolDiff }): React.ReactElement | null {
   const cols = process.stdout.columns ?? 80
-  const indent = 2 // sit under the "⎿" summary
-  const gutterW = indent + numW + 1 // indent + right-aligned number + a space
-  // Cap the content column at a readable width so a very wide terminal (or one
-  // long line) doesn't stretch the tint across the whole screen — a no-op on
-  // normal terminals, it just bounds the worst case.
-  const contentMax = Math.max(8, Math.min(cols - gutterW - 1, MAX_DIFF_WIDTH))
-  // Tint width = the longest line in the hunk (marker + code), capped at the
-  // content column — a tight block for short hunks instead of a full-width bar.
-  const longest = Math.max(2, ...shown.map((l) => 1 + (l.text?.length ?? 0)))
-  const blockW = Math.min(contentMax, longest)
-  const segW = Math.max(4, blockW) // wrap target (marker is counted in bgRow)
-  const added = lines.filter((l) => l.type === 'add').length
-  const removed = lines.filter((l) => l.type === 'del').length
+  // Exact width the original passes to its diff/code renderers.
+  const width = Math.max(20, cols - 12)
+
+  const bodyRows: { text: string; sep?: boolean }[] = []
+  let summary = ''
+  let hint = ''
+
+  if (diff.kind === 'write') {
+    const content = diff.content ?? ''
+    const all = content.split('\n')
+    const shown = all.slice(0, WRITE_MAX_LINES).join('\n')
+    const lines = new ColorFile(shown, diff.filePath).render(THEME_NAME, width, false) ?? []
+    for (const l of lines) bodyRows.push({ text: l })
+    const extra = all.length - WRITE_MAX_LINES
+    if (extra > 0) hint = `… +${extra} ${extra === 1 ? 'line' : 'lines'}`
+  } else {
+    if (!diff.hunks.length) return null
+    const { added, removed } = countPatchLines(diff.hunks)
+    summary = editSummary(added, removed)
+    diff.hunks.forEach((hunk, i) => {
+      if (i > 0) bodyRows.push({ text: '...', sep: true })
+      const lines =
+        new ColorDiff(hunk, diff.firstLine, diff.filePath, diff.fileContent ?? null).render(
+          THEME_NAME,
+          width,
+          false,
+        ) ?? []
+      for (const l of lines) bodyRows.push({ text: l })
+    })
+    const over = bodyRows.length - EDIT_MAX_LINES
+    if (over > 0) {
+      bodyRows.length = EDIT_MAX_LINES
+      hint = `… +${over} ${over === 1 ? 'line' : 'lines'}`
+    }
+  }
 
   return (
-    <Box flexDirection="column">
-      <Text color={theme.dim}>
-        {`  ⎿ Added ${added} line${added === 1 ? '' : 's'}, removed ${removed} line${removed === 1 ? '' : 's'}`}
-      </Text>
-      {shown.map((l, i) => {
-        const no = l.type === 'del' ? l.oldNo : l.newNo
-        const marker = l.type === 'add' ? '+' : l.type === 'del' ? '-' : ' '
-        const bg = l.type === 'add' ? ADD_BG : l.type === 'del' ? DEL_BG : null
-        const ansi = hl(l.text ?? '', lang)
-        const rows =
-          stripAnsi(ansi).length <= segW - 1
-            ? [ansi]
-            : wrapAnsi(ansi, segW - 1, { hard: true, trim: false }).split('\n')
-        return (
-          <Box key={i}>
-            <Box width={gutterW} flexShrink={0}>
-              <Text color={theme.dim}>{`  ${String(no ?? '').padStart(numW)} `}</Text>
-            </Box>
-            <Box flexDirection="column">
-              {rows.map((row, j) => (
-                <Text key={j}>{bgRow(row, bg, j === 0 ? marker : ' ', blockW)}</Text>
-              ))}
-            </Box>
-          </Box>
-        )
-      })}
-      {extra > 0 ? <Text color={theme.dim}>{`    … +${extra} more lines`}</Text> : null}
+    <Box flexDirection="row">
+      <Box flexShrink={0}>
+        <Text color={theme.dim}>{'  ⎿  '}</Text>
+      </Box>
+      <Box flexDirection="column" flexGrow={1}>
+        {summary ? <Text>{summary}</Text> : null}
+        {bodyRows.map((r, i) =>
+          r.sep ? (
+            <Text key={i} dimColor>
+              {'...'}
+            </Text>
+          ) : (
+            <Text key={i}>{r.text}</Text>
+          ),
+        )}
+        {hint ? <Text color={theme.dim}>{hint}</Text> : null}
+      </Box>
     </Box>
   )
 }

--- a/ui-tui/src/components/Message.tsx
+++ b/ui-tui/src/components/Message.tsx
@@ -83,23 +83,19 @@ export function Message({ entry }: { entry: TranscriptEntry }): React.ReactEleme
       }
       const diff = entry.diff
       const isWeb = entry.toolName === 'WebFetch' || entry.toolName === 'WebSearch'
+      // File-edit tools display as Update/Create/Write (the original's
+      // userFacingName), not the raw tool id.
+      const name = diff ? diff.displayName : entry.toolName
       return (
         <Box flexDirection="column">
           <Text>
             <Text color={theme.success}>⏺ </Text>
-            <Text bold>{entry.toolName}</Text>
+            <Text bold>{name}</Text>
             <Text color={theme.dim}>(</Text>
             <Text color={isWeb ? theme.link : theme.dim}>{entry.argsText}</Text>
             <Text color={theme.dim}>)</Text>
           </Text>
-          {diff ? (
-            <DiffView
-              lines={diff}
-              filePath={
-                typeof entry.input?.['file_path'] === 'string' ? (entry.input['file_path'] as string) : undefined
-              }
-            />
-          ) : null}
+          {diff ? <DiffView diff={diff} /> : null}
         </Box>
       )
     }

--- a/ui-tui/src/diff.ts
+++ b/ui-tui/src/diff.ts
@@ -1,115 +1,130 @@
 /**
- * Minimal line diff for Edit/Write tool calls, rendered Claude-Code style
- * (green added / red removed lines with a line-number gutter). Not a full Myers
- * diff — it trims the common prefix/suffix and shows the changed middle, which
- * is exactly right for an Edit's old_string→new_string region.
+ * Build the diff payload for an Edit/Write/MultiEdit tool call as
+ * StructuredPatchHunk[] — the exact shape openclaude's StructuredDiff renderer
+ * consumes. Mirrors typescript/src/components/FileEditToolDiff.tsx#loadDiffData:
+ *
+ *   - when the on-disk file is available, diff the WHOLE file with the edit(s)
+ *     applied → structuredPatch emits hunks with true file line numbers and 3
+ *     lines of surrounding context (no hand-rolled context window);
+ *   - otherwise fall back to diffing the tool inputs only (old_string as the
+ *     "file"), numbered from line 1, exactly like upstream diffToolInputsOnly.
  */
-export interface DiffLine {
-  type: 'add' | 'del' | 'ctx'
-  text: string
-  oldNo?: number
-  newNo?: number
+import {
+  getPatchForDisplay,
+  getPatchFromContents,
+  type FileEdit,
+  type StructuredPatchHunk,
+} from './patch.js'
+
+export interface ToolDiff {
+  /**
+   * 'edit'  → render a +/- StructuredDiff from `hunks` (Edit/MultiEdit, or a
+   *           Write that overwrites a file we can read pre-write).
+   * 'write' → render the full new `content` syntax-highlighted (ColorFile), the
+   *           way the original shows a created file (no +/- markers).
+   */
+  kind: 'edit' | 'write'
+  hunks: StructuredPatchHunk[]
+  /** kind==='write': the full new file content (rendered via ColorFile). */
+  content?: string
+  /** First line of the file (shebang detection for syntax highlighting). */
+  firstLine: string | null
+  /** Full file content, when available — passed to ColorDiff for context. */
+  fileContent?: string
+  filePath: string
+  /** Display verb for the tool-use line: Update / Create / Write. */
+  displayName: string
 }
 
-export function lineDiff(oldStr: string, newStr: string, startLine = 1): DiffLine[] {
-  const o = oldStr.split('\n')
-  const n = newStr.split('\n')
-  let p = 0
-  while (p < o.length && p < n.length && o[p] === n[p]) p++
-  let s = 0
-  while (s < o.length - p && s < n.length - p && o[o.length - 1 - s] === n[n.length - 1 - s]) s++
-  const out: DiffLine[] = []
-  let oldNo = startLine
-  let newNo = startLine
-  for (let i = 0; i < p; i++) out.push({ type: 'ctx', text: o[i] ?? '', oldNo: oldNo++, newNo: newNo++ })
-  for (let i = p; i < o.length - s; i++) out.push({ type: 'del', text: o[i] ?? '', oldNo: oldNo++ })
-  for (let i = p; i < n.length - s; i++) out.push({ type: 'add', text: n[i] ?? '', newNo: newNo++ })
-  for (let i = 0; i < s; i++) {
-    out.push({ type: 'ctx', text: o[o.length - s + i] ?? '', oldNo: oldNo++, newNo: newNo++ })
-  }
-  return out
+function firstLineOf(s: string): string | null {
+  return s.split('\n', 1)[0] ?? null
 }
 
-/**
- * File line number where `probe` begins in `fileContent` (1-based). The original
- * computes this from the patch hunk's oldStart; we locate the changed region
- * directly. Tries old_string (pre-edit file) then new_string (post-edit file),
- * so it works whether or not the edit has already been applied on disk.
- */
-function startLineOf(fileContent: string | undefined, oldS: string, newS: string): number {
-  if (!fileContent) return 1
-  const probe = oldS && fileContent.includes(oldS) ? oldS : newS && fileContent.includes(newS) ? newS : null
-  if (!probe) return 1
-  const idx = fileContent.indexOf(probe)
-  if (idx <= 0) return 1
-  let line = 1
-  for (let i = 0; i < idx; i++) if (fileContent[i] === '\n') line++
-  return line
-}
-
-/** Unchanged file lines shown above/below the change, for orientation. */
-const CONTEXT_LINES = 3
-
-/**
- * Surround the changed region with a few unchanged file lines (the original
- * shows ~3 above/below). Uses the on-disk file and the located start line; if
- * the file isn't available or the region can't be found, returns the diff as-is.
- */
-function withFileContext(
-  core: DiffLine[],
-  fileContent: string | undefined,
-  oldS: string,
-  newS: string,
-  start: number,
-): DiffLine[] {
-  if (!fileContent) return core
-  const fileLines = fileContent.split('\n')
-  const probe = oldS && fileContent.includes(oldS) ? oldS : newS && fileContent.includes(newS) ? newS : null
-  if (!probe) return core
-  const span = probe.split('\n').length
-  const before: DiffLine[] = []
-  for (let i = Math.max(0, start - 1 - CONTEXT_LINES); i < start - 1; i++) {
-    before.push({ type: 'ctx', text: fileLines[i] ?? '', oldNo: i + 1, newNo: i + 1 })
-  }
-  const afterStart = start - 1 + span // 0-based index just past the changed region
-  const after: DiffLine[] = []
-  for (let i = afterStart; i < Math.min(fileLines.length, afterStart + CONTEXT_LINES); i++) {
-    after.push({ type: 'ctx', text: fileLines[i] ?? '', oldNo: i + 1, newNo: i + 1 })
-  }
-  return [...before, ...core, ...after]
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : ''
 }
 
 /**
- * Build a diff for an Edit/Write/MultiEdit tool call from its raw input.
- * `fileContent` (the on-disk file) lets us emit true file line numbers; without
- * it we fall back to region-relative (1-based) numbering.
+ * Build a ToolDiff from a tool call's raw input. `fileContent` (the on-disk
+ * file, read best-effort by the caller) yields true file line numbers; without
+ * it we diff the inputs region-relative.
  */
-export function toolDiff(
+export function buildToolDiff(
   toolName: string,
   input: Record<string, unknown>,
   fileContent?: string,
-): DiffLine[] | null {
+): ToolDiff | null {
+  const filePath = str(input['file_path']) || str(input['path']) || ''
+
   if (toolName === 'Write') {
-    const content = typeof input['content'] === 'string' ? (input['content'] as string) : ''
-    if (!content) return null
-    return content.split('\n').map((text, i) => ({ type: 'add', text, newNo: i + 1 }))
-  }
-  if (toolName === 'Edit') {
-    const oldS = typeof input['old_string'] === 'string' ? (input['old_string'] as string) : ''
-    const newS = typeof input['new_string'] === 'string' ? (input['new_string'] as string) : ''
-    if (!oldS && !newS) return null
-    const start = startLineOf(fileContent, oldS, newS)
-    return withFileContext(lineDiff(oldS, newS, start), fileContent, oldS, newS, start)
-  }
-  if (toolName === 'MultiEdit') {
-    const edits = Array.isArray(input['edits']) ? (input['edits'] as Record<string, unknown>[]) : []
-    const out: DiffLine[] = []
-    for (const e of edits) {
-      const oldS = typeof e['old_string'] === 'string' ? (e['old_string'] as string) : ''
-      const newS = typeof e['new_string'] === 'string' ? (e['new_string'] as string) : ''
-      out.push(...lineDiff(oldS, newS, startLineOf(fileContent, oldS, newS)))
+    const content = str(input['content'])
+    // If we can read the pre-write file AND it differs, show a real diff
+    // (the original's "update" path); otherwise show the new content
+    // highlighted (the "create" path). The file-not-yet-written and
+    // file-unreadable cases both fall to 'write'.
+    if (fileContent !== undefined && fileContent !== content && content) {
+      const hunks = getPatchFromContents({ filePath, oldContent: fileContent, newContent: content })
+      if (hunks.length) {
+        return {
+          kind: 'edit',
+          hunks,
+          firstLine: firstLineOf(content),
+          fileContent: content,
+          filePath,
+          displayName: 'Update',
+        }
+      }
     }
-    return out.length ? out : null
+    if (!content) return null
+    return {
+      kind: 'write',
+      hunks: [],
+      content,
+      firstLine: firstLineOf(content),
+      filePath,
+      displayName: 'Write',
+    }
   }
+
+  if (toolName === 'Edit') {
+    const old_string = str(input['old_string'])
+    const new_string = str(input['new_string'])
+    if (!old_string && !new_string) return null
+    const replace_all = input['replace_all'] === true
+    const edit: FileEdit = { old_string, new_string, replace_all }
+    const displayName = old_string === '' ? 'Create' : 'Update'
+    if (fileContent && fileContent.includes(old_string)) {
+      const hunks = getPatchForDisplay({ filePath, fileContents: fileContent, edits: [edit] })
+      if (!hunks.length) return null
+      return { kind: 'edit', hunks, firstLine: firstLineOf(fileContent), fileContent, filePath, displayName }
+    }
+    // inputs-only: treat old_string as the whole "file"
+    const hunks = getPatchForDisplay({ filePath, fileContents: old_string, edits: [edit] })
+    if (!hunks.length) return null
+    return { kind: 'edit', hunks, firstLine: null, filePath, displayName }
+  }
+
+  if (toolName === 'MultiEdit') {
+    const raw = Array.isArray(input['edits']) ? (input['edits'] as Record<string, unknown>[]) : []
+    const edits: FileEdit[] = raw.map(e => ({
+      old_string: str(e['old_string']),
+      new_string: str(e['new_string']),
+      replace_all: e['replace_all'] === true,
+    }))
+    if (!edits.length) return null
+    if (fileContent) {
+      const hunks = getPatchForDisplay({ filePath, fileContents: fileContent, edits })
+      if (hunks.length) {
+        return { kind: 'edit', hunks, firstLine: firstLineOf(fileContent), fileContent, filePath, displayName: 'Update' }
+      }
+    }
+    // inputs-only: one patch per edit, old_string as its "file"
+    const hunks = edits.flatMap(e =>
+      getPatchForDisplay({ filePath, fileContents: e.old_string, edits: [e] }),
+    )
+    if (!hunks.length) return null
+    return { kind: 'edit', hunks, firstLine: null, filePath, displayName: 'Update' }
+  }
+
   return null
 }

--- a/ui-tui/src/patch.ts
+++ b/ui-tui/src/patch.ts
@@ -1,0 +1,141 @@
+/**
+ * Build display patches (StructuredPatchHunk[]) from Edit/Write/MultiEdit tool
+ * inputs — ported from openclaude's typescript/src/utils/diff.ts so our hunks
+ * match the original byte-for-byte before they reach the ColorDiff renderer.
+ *
+ * Dropped vs upstream: the analytics/cost-tracker side effects (logEvent,
+ * addToTotalLinesChanged) — the agent backend owns those; the client only
+ * renders.
+ */
+import { structuredPatch, type StructuredPatchHunk } from 'diff'
+
+export const CONTEXT_LINES = 3
+export const DIFF_TIMEOUT_MS = 5_000
+
+/** Leading tabs → 2 spaces each (display only), matching upstream. */
+export function convertLeadingTabsToSpaces(content: string): string {
+  if (!content.includes('\t')) return content
+  return content.replace(/^\t+/gm, m => '  '.repeat(m.length))
+}
+
+// `&` and `$` confuse the diff library's replace step; swap for tokens, then
+// restore after the patch is computed.
+const AMPERSAND_TOKEN = '<<:AMPERSAND_TOKEN:>>'
+const DOLLAR_TOKEN = '<<:DOLLAR_TOKEN:>>'
+
+function escapeForDiff(s: string): string {
+  return s.replaceAll('&', AMPERSAND_TOKEN).replaceAll('$', DOLLAR_TOKEN)
+}
+
+function unescapeFromDiff(s: string): string {
+  return s.replaceAll(AMPERSAND_TOKEN, '&').replaceAll(DOLLAR_TOKEN, '$')
+}
+
+export interface FileEdit {
+  old_string: string
+  new_string: string
+  replace_all?: boolean
+}
+
+/** Diff two whole contents (used for Write / new files). */
+export function getPatchFromContents({
+  filePath,
+  oldContent,
+  newContent,
+  ignoreWhitespace = false,
+  singleHunk = false,
+}: {
+  filePath: string
+  oldContent: string
+  newContent: string
+  ignoreWhitespace?: boolean
+  singleHunk?: boolean
+}): StructuredPatchHunk[] {
+  const result = structuredPatch(
+    filePath,
+    filePath,
+    escapeForDiff(oldContent),
+    escapeForDiff(newContent),
+    undefined,
+    undefined,
+    {
+      ignoreWhitespace,
+      context: singleHunk ? 100_000 : CONTEXT_LINES,
+      timeout: DIFF_TIMEOUT_MS,
+    },
+  )
+  if (!result) return []
+  return result.hunks.map(h => ({
+    ...h,
+    lines: h.lines.map(unescapeFromDiff),
+  }))
+}
+
+/**
+ * Patch for display with edits applied to `fileContents`. Leading tabs are
+ * rendered as spaces. Mirrors upstream getPatchForDisplay exactly.
+ */
+export function getPatchForDisplay({
+  filePath,
+  fileContents,
+  edits,
+  ignoreWhitespace = false,
+}: {
+  filePath: string
+  fileContents: string
+  edits: FileEdit[]
+  ignoreWhitespace?: boolean
+}): StructuredPatchHunk[] {
+  const preparedFileContents = escapeForDiff(
+    convertLeadingTabsToSpaces(fileContents),
+  )
+  const result = structuredPatch(
+    filePath,
+    filePath,
+    preparedFileContents,
+    edits.reduce((p, edit) => {
+      const { old_string, new_string } = edit
+      const replace_all = 'replace_all' in edit ? edit.replace_all : false
+      const escapedOldString = escapeForDiff(
+        convertLeadingTabsToSpaces(old_string),
+      )
+      const escapedNewString = escapeForDiff(
+        convertLeadingTabsToSpaces(new_string),
+      )
+      if (replace_all) {
+        return p.replaceAll(escapedOldString, () => escapedNewString)
+      }
+      return p.replace(escapedOldString, () => escapedNewString)
+    }, preparedFileContents),
+    undefined,
+    undefined,
+    {
+      context: CONTEXT_LINES,
+      ignoreWhitespace,
+      timeout: DIFF_TIMEOUT_MS,
+    },
+  )
+  if (!result) return []
+  return result.hunks.map(h => ({
+    ...h,
+    lines: h.lines.map(unescapeFromDiff),
+  }))
+}
+
+/** Count +/- lines across a patch (for the "N additions, M removals" header). */
+export function countPatchLines(patch: StructuredPatchHunk[]): {
+  added: number
+  removed: number
+} {
+  let added = 0
+  let removed = 0
+  for (const hunk of patch) {
+    for (const line of hunk.lines) {
+      if (line.startsWith('+')) added++
+      else if (line.startsWith('-')) removed++
+    }
+  }
+  return { added, removed }
+}
+
+export type { StructuredPatchHunk }

--- a/ui-tui/src/sdkMessageAdapter.ts
+++ b/ui-tui/src/sdkMessageAdapter.ts
@@ -13,7 +13,7 @@ import {
   type ContentBlock,
   type ServerMessage,
 } from './protocol.js'
-import { toolDiff, type DiffLine } from './diff.js'
+import { buildToolDiff, type ToolDiff } from './diff.js'
 
 /** Best-effort read of the edited file (local in spawn mode) for true line numbers. */
 function readFileSafe(p: unknown): string | undefined {
@@ -44,8 +44,8 @@ export interface TranscriptEntry {
   argsText?: string
   /** tool calls only: the raw input (used to render Edit/Write diffs). */
   input?: Record<string, unknown>
-  /** Edit/Write tool calls: precomputed diff (with true file line numbers). */
-  diff?: DiffLine[]
+  /** Edit/Write tool calls: precomputed diff hunks (with true file line numbers). */
+  diff?: ToolDiff
   /** tool calls: the tool_use id (used to correlate + collapse results). */
   toolUseId?: string
   /** tool results: the tool_use ids they answer (to drop collapsed-read results). */
@@ -153,7 +153,7 @@ export function messageToEntries(msg: ServerMessage): TranscriptEntry[] {
           >
           const diff =
             toolName === 'Edit' || toolName === 'Write' || toolName === 'MultiEdit'
-              ? (toolDiff(toolName, tinput, readFileSafe(tinput['file_path'])) ?? undefined)
+              ? (buildToolDiff(toolName, tinput, readFileSafe(tinput['file_path'])) ?? undefined)
               : undefined
           out.push({
             id: nextId(),


### PR DESCRIPTION
## Summary
Stops the diff whack-a-mole by **porting the exact renderer the original Claude Code TUI uses** instead of re-approximating it. `typescript/` (upstream TypeScript implementation) draws diffs with a pure-TS module, `native-ts/color-diff` (no native binary); this PR ports it verbatim, so the diff **body is faithful by construction**.

## What renders now
- Dimmed line-number gutter, `+/-/space` markers, red/green line tints
- highlight.js **Monokai** syntax colors on code
- **word-level diff** highlighting (changed tokens get a brighter tint)
- `Update`/`Create`/`Write` display names; Write shows highlighted new content (not an all-green diff)
- summary `Added N lines, removed M lines`, width `cols-12`, no dashed frame — matches `FileEditToolUpdatedMessage`

## Files
- `colorDiff.ts` — verbatim port (string-width, ESM `createRequire`, hljs 11 `_emitter`)
- `patch.ts` — `getPatchForDisplay`/`structuredPatch` (3 context lines, `&`/`$` escaping)
- `diff.ts` — `buildToolDiff` (Edit/MultiEdit/Write)
- `DiffView.tsx` / `Message.tsx` / `sdkMessageAdapter.ts` — wiring

## Verification
`tsc` + `npm run build` clean. Rendered via ink-testing-library (real Yoga layout, no re-wrap) and real-Ink truecolor; screenshot matches the original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)