### PR TITLE
feat(ui-tui): @-mention file autocomplete

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -14,6 +14,8 @@ import type { Transport } from './transport.js'
 import { Message } from './components/Message.js'
 import { PermissionDialog } from './components/PermissionDialog.js'
 import { SlashMenu } from './components/SlashMenu.js'
+import { FileMenu } from './components/FileMenu.js'
+import { searchFiles } from './fileIndex.js'
 import { Spinner } from './components/Spinner.js'
 import { StatusBar } from './components/StatusBar.js'
 import { LiveTools, type LiveGroup } from './components/LiveTools.js'
@@ -74,6 +76,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const [ready, setReady] = useState(false) // system/init received — banner committed, submit allowed
   const [client, setClient] = useState<DirectConnectClient | null>(null)
   const [slashSel, setSlashSel] = useState(0)
+  const [atSel, setAtSel] = useState(0)
   const localSeq = useRef(0)
   const bannerAdded = useRef(false)
   const [toolActivity, setToolActivity] = useState<string | null>(null)
@@ -88,6 +91,22 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const slashOpen = slashMatches.length > 0 && permissions.length === 0
   const sel = Math.min(slashSel, Math.max(0, slashMatches.length - 1))
   const permission = permissions[0] ?? null
+
+  // `@`-mention file autocomplete: an @token at the end of the input (after
+  // start or whitespace) opens a file-suggestion dropdown (the original's
+  // @-typeahead). Mutually exclusive with the slash menu.
+  const atToken = (() => {
+    if (slashOpen || input.startsWith('/')) return null
+    const m = /(?:^|\s)@([^\s]*)$/.exec(input)
+    return m ? (m[1] as string) : null
+  })()
+  const atMatches = atToken !== null ? searchFiles(process.cwd(), atToken, Date.now()) : []
+  const atOpen = atMatches.length > 0 && permissions.length === 0
+  const atSelClamped = Math.min(atSel, Math.max(0, atMatches.length - 1))
+  const completeAt = (pick: string): void => {
+    setInput(input.replace(/@([^\s]*)$/, `@${pick} `))
+    setAtSel(0)
+  }
 
   const addEntry = (e: Omit<TranscriptEntry, 'id'>) =>
     setEntries((prev) => [...prev, { ...e, id: `l${localSeq.current++}` }])
@@ -279,6 +298,21 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         return
       }
     }
+    if (atOpen) {
+      if (key.upArrow) {
+        setAtSel((s) => (s - 1 + atMatches.length) % atMatches.length)
+        return
+      }
+      if (key.downArrow) {
+        setAtSel((s) => (s + 1) % atMatches.length)
+        return
+      }
+      if (key.tab) {
+        const pick = atMatches[atSelClamped]
+        if (pick) completeAt(pick)
+        return
+      }
+    }
     if (key.escape && busy) {
       client?.interrupt()
     }
@@ -326,6 +360,13 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const onSubmit = (value: string): void => {
     const text = value.trim()
     if (!text) return
+    // Enter while the @-file menu is open completes the highlighted path
+    // instead of submitting.
+    if (atOpen) {
+      const pick = atMatches[atSelClamped]
+      if (pick) completeAt(pick)
+      return
+    }
     // Never send a partial slash to the model: run an exact command, else
     // complete to the highlighted match.
     if (text.startsWith('/')) {
@@ -404,6 +445,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       ) : (
         <>
           {slashOpen ? <SlashMenu matches={slashMatches} selected={sel} /> : null}
+          {atOpen ? <FileMenu matches={atMatches} selected={atSelClamped} /> : null}
           <Box
             borderStyle="round"
             borderColor={theme.promptBorder}
@@ -418,6 +460,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
               onChange={(v) => {
                 setInput(v)
                 setSlashSel(0)
+                setAtSel(0)
               }}
               onSubmit={onSubmit}
               placeholder={ready ? 'Type a message, or / for commands…' : 'starting agent-server…'}

--- a/ui-tui/src/components/FileMenu.tsx
+++ b/ui-tui/src/components/FileMenu.tsx
@@ -1,0 +1,45 @@
+/**
+ * `@`-mention file suggestions shown above the input — mirrors SlashMenu and the
+ * original's @-typeahead: a borderless list, the selected row a full-width
+ * highlighted bar. The basename is emphasized; the directory is dimmed.
+ */
+import { Box, Text } from 'ink'
+import React from 'react'
+import { theme } from '../theme.js'
+
+interface Props {
+  matches: string[]
+  selected: number
+}
+
+function split(path: string): { dir: string; base: string } {
+  const i = path.lastIndexOf('/')
+  return i >= 0 ? { dir: path.slice(0, i + 1), base: path.slice(i + 1) } : { dir: '', base: path }
+}
+
+export function FileMenu({ matches, selected }: Props): React.ReactElement | null {
+  if (matches.length === 0) return null
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      {matches.map((path, i) => {
+        const { dir, base } = split(path)
+        if (i === selected) {
+          return (
+            <Box key={path} width="100%">
+              <Text backgroundColor={theme.suggestion} color="black" bold wrap="truncate">
+                {`› ${path} `}
+              </Text>
+            </Box>
+          )
+        }
+        return (
+          <Box key={path}>
+            <Text color={theme.dim}>{'  '}</Text>
+            <Text color={theme.dim}>{dir}</Text>
+            <Text>{base}</Text>
+          </Box>
+        )
+      })}
+    </Box>
+  )
+}

--- a/ui-tui/src/fileIndex.ts
+++ b/ui-tui/src/fileIndex.ts
@@ -1,0 +1,94 @@
+/**
+ * Lightweight file index for `@`-mention autocomplete (the original's
+ * @-typeahead over files). A bounded recursive walk of the cwd, cached and
+ * filtered in-memory so keystrokes stay responsive — heavy/vendor dirs are
+ * skipped, results are capped.
+ */
+import { readdirSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const IGNORE_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  'out',
+  'coverage',
+  'target',
+  '__pycache__',
+  '.next',
+  '.cache',
+  '.port_sessions',
+  'venv',
+  '.venv',
+])
+const MAX_FILES = 12_000
+const STALE_MS = 15_000
+const MAX_RESULTS = 10
+
+interface Cache {
+  cwd: string
+  at: number
+  files: string[]
+}
+let cache: Cache | null = null
+
+function walk(root: string): string[] {
+  const out: string[] = []
+  const stack: string[] = [root]
+  while (stack.length > 0 && out.length < MAX_FILES) {
+    const dir = stack.pop() as string
+    let entries
+    try {
+      entries = readdirSync(dir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const e of entries) {
+      if (e.isDirectory()) {
+        if (e.name.startsWith('.') || IGNORE_DIRS.has(e.name)) continue
+        stack.push(join(dir, e.name))
+      } else if (e.isFile()) {
+        out.push(relative(root, join(dir, e.name)))
+        if (out.length >= MAX_FILES) break
+      }
+    }
+  }
+  return out
+}
+
+function getFiles(cwd: string, now: number): string[] {
+  if (cache && cache.cwd === cwd && now - cache.at < STALE_MS) return cache.files
+  const files = walk(cwd).sort()
+  cache = { cwd, at: now, files }
+  return files
+}
+
+function basename(p: string): string {
+  const i = p.lastIndexOf('/')
+  return i >= 0 ? p.slice(i + 1) : p
+}
+
+/**
+ * Files matching `query` (case-insensitive), ranked: basename prefix >
+ * basename substring > path substring, then by path length (shorter first).
+ * Empty query returns the first results in sorted order.
+ *
+ * `now` is passed in (callers stamp Date.now()) so this stays pure for tests.
+ */
+export function searchFiles(cwd: string, query: string, now: number): string[] {
+  const files = getFiles(cwd, now)
+  const q = query.toLowerCase()
+  if (!q) return files.slice(0, MAX_RESULTS)
+  const scored: { path: string; rank: number }[] = []
+  for (const path of files) {
+    const lp = path.toLowerCase()
+    const base = basename(lp)
+    let rank = -1
+    if (base.startsWith(q)) rank = 0
+    else if (base.includes(q)) rank = 1
+    else if (lp.includes(q)) rank = 2
+    if (rank >= 0) scored.push({ path, rank })
+  }
+  scored.sort((a, b) => a.rank - b.rank || a.path.length - b.path.length || a.path.localeCompare(b.path))
+  return scored.slice(0, MAX_RESULTS).map((s) => s.path)
+}


### PR DESCRIPTION
## Summary
Adds the original Claude Code `@`-typeahead, which the TS client was missing entirely. Typing `@<partial>` at the end of the input opens a file-suggestion dropdown.

- **fileIndex.ts** — bounded, cached recursive walk of the cwd (skips `node_modules`, `dist`, `.git`, `.venv`, … ; capped at 12k; 15s cache). `searchFiles` ranks basename-prefix > basename-substring > path-substring, then shortest path.
- **FileMenu.tsx** — dropdown mirroring `SlashMenu`: directory dimmed, basename emphasized, selected row a full-width highlighted bar.
- **App.tsx** — detects the `@`token (after start/space), `↑/↓` navigate, `Tab`/`Enter` complete to `@path `. Mutually exclusive with the slash menu; resets on input change.

## Verification
`tsc` + `npm run build` clean. `searchFiles` ranking verified (diff → `src/diff.ts` first; Spinner → `spinnerVerbs.ts`/`Spinner.tsx`). Dropdown rendered via ink-testing-library — dir/basename styling + selection bar correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)