### PR TITLE
fix(ui-tui): drop "No newline at end of file" markers from diffs

### DIFF
--- a/ui-tui/src/patch.ts
+++ b/ui-tui/src/patch.ts
@@ -67,7 +67,10 @@ export function getPatchFromContents({
   if (!result) return []
   return result.hunks.map(h => ({
     ...h,
-    lines: h.lines.map(unescapeFromDiff),
+    // Drop the `\ No newline at end of file` markers the diff library emits for
+    // non-newline-terminated content — real code lines are prefixed +/-/space,
+    // so only these markers start with a literal backslash.
+    lines: h.lines.filter(l => l[0] !== '\\').map(unescapeFromDiff),
   }))
 }
 
@@ -118,7 +121,10 @@ export function getPatchForDisplay({
   if (!result) return []
   return result.hunks.map(h => ({
     ...h,
-    lines: h.lines.map(unescapeFromDiff),
+    // Drop the `\ No newline at end of file` markers the diff library emits for
+    // non-newline-terminated content — real code lines are prefixed +/-/space,
+    // so only these markers start with a literal backslash.
+    lines: h.lines.filter(l => l[0] !== '\\').map(unescapeFromDiff),
   }))
 }
 


### PR DESCRIPTION
## Summary
Inputs-only edit diffs (from `old_string`/`new_string` snippets without a trailing newline) showed spurious `No newline at end of file` lines rendered as context — which also corrupted the line numbering.

Root cause: the `diff` package's `structuredPatch` includes a literal `\ No newline at end of file` entry in `hunk.lines`; `ColorDiff` rendered it as a normal (space-marker) line.

Fix: filter lines starting with a literal backslash in `getPatchForDisplay`/`getPatchFromContents`. Real code lines are always prefixed `+`/`-`/space, so this only removes the markers.

## Before / After
Before: `1 -…`, `1 No newline…`, `2 +…`, `3 No newline…`
After: `1 -…`, `1 +…` (clean, correct numbers, word-diff intact)

## Verification
`npm run build` clean; re-rendered an inputs-only edit diff via ink-testing-library — markers gone, numbering correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)