### PR TITLE
feat(ui-tui): render tool-result errors in red

### DIFF
--- a/ui-tui/src/components/Message.tsx
+++ b/ui-tui/src/components/Message.tsx
@@ -17,8 +17,25 @@ import type { TranscriptEntry } from '../sdkMessageAdapter.js'
 
 const RESULT_MAX_LINES = 8
 
-function ToolResult({ text }: { text: string }): React.ReactElement {
+function ToolResult({ text, isError }: { text: string; isError?: boolean }): React.ReactElement {
   const lines = text.replace(/\s+$/, '').split('\n')
+  // Errors render in red (the original's error tool-result variant) and aren't
+  // collapsed — the message is what the user needs to see.
+  if (isError) {
+    const shown = lines.slice(0, RESULT_MAX_LINES)
+    const extra = lines.length - shown.length
+    return (
+      <Box flexDirection="column">
+        {shown.map((ln, i) => (
+          <Box key={i}>
+            <Text color={theme.error}>{i === 0 ? '  ⎿ ' : '    '}</Text>
+            <Text color={theme.error}>{ln || ' '}</Text>
+          </Box>
+        ))}
+        {extra > 0 ? <Text color={theme.error}>{`    … +${extra} more line${extra === 1 ? '' : 's'}`}</Text> : null}
+      </Box>
+    )
+  }
   // Collapse a long line-numbered file dump (Read / cat -n) to a single line —
   // several Reads otherwise bury the transcript under hundreds of content lines.
   // The original keeps these collapsed (ctrl+o to expand).
@@ -100,7 +117,7 @@ export function Message({ entry }: { entry: TranscriptEntry }): React.ReactEleme
       )
     }
     case 'toolResult':
-      return <ToolResult text={entry.text} />
+      return <ToolResult text={entry.text} isError={entry.isError} />
     case 'result':
       return <Text color={theme.success}>{`✓ ${entry.text}`}</Text>
     case 'error':

--- a/ui-tui/src/sdkMessageAdapter.ts
+++ b/ui-tui/src/sdkMessageAdapter.ts
@@ -50,6 +50,8 @@ export interface TranscriptEntry {
   toolUseId?: string
   /** tool results: the tool_use ids they answer (to drop collapsed-read results). */
   forToolUseIds?: string[]
+  /** tool results: the tool reported an error (rendered in red). */
+  isError?: boolean
   /** collapsed tool summary: how many same-kind calls this entry represents. */
   count?: number
   /** banner only: the session info snapshot, captured once at init. */
@@ -180,7 +182,10 @@ export function messageToEntries(msg: ServerMessage): TranscriptEntry[] {
           .filter((b) => b && b.type === 'tool_result')
           .map((b) => String((b as { tool_use_id?: string }).tool_use_id ?? ''))
       : []
-    return text ? [{ id: nextId(), kind: 'toolResult', text, forToolUseIds }] : []
+    const isError =
+      Array.isArray(content) &&
+      content.some((b) => b && b.type === 'tool_result' && (b as { is_error?: boolean }).is_error === true)
+    return text ? [{ id: nextId(), kind: 'toolResult', text, forToolUseIds, isError }] : []
   }
 
   if (type === 'result') {


### PR DESCRIPTION
## Summary
Tool results that report an error now render in the error color (red), matching the original's success/error tool-result variants. Previously every result rendered dim, so failures were easy to miss.

- `sdkMessageAdapter.ts` — extract `is_error` from `tool_result` blocks onto the entry.
- `Message.tsx` — error results render red and are not collapsed.

## Verification
`tsc` + `npm run build` clean; rendered an errored `cat missing.ts` (red `⎿ Error: ENOENT…`) next to a successful result (dim) via ink-testing-library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)