### PR TITLE
feat(tui+server): live context-window usage in the status bar

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -219,7 +219,7 @@ class _AgentSession:
             })
             return
         if subtype == "get_context_usage":
-            self._reply(request_id, {"protocol_version": PROTOCOL_VERSION})
+            self._reply(request_id, self._context_usage())
             return
         # Unknown subtype — error back so a correlating client doesn't hang.
         if isinstance(request_id, str):
@@ -247,6 +247,55 @@ class _AgentSession:
                 "response": response,
             },
         })
+
+    def _system_prompt_text(self) -> str:
+        """The active system prompt as a plain string (it may be a block list —
+        build_effective_system_prompt returns the full base block list)."""
+        sp = self.system_prompt
+        if isinstance(sp, str):
+            return sp
+        if isinstance(sp, list):
+            parts: list[str] = []
+            for b in sp:
+                if isinstance(b, dict):
+                    parts.append(str(b.get("text", "")))
+                else:
+                    parts.append(str(getattr(b, "text", b)))
+            return "\n".join(parts)
+        return str(sp)
+
+    def _context_usage(self) -> dict:
+        """Live context-window usage for the status bar (the original's
+        get_context_usage). Best-effort — any failure degrades to just the
+        protocol version so the client never hangs or crashes."""
+        out: dict = {"protocol_version": PROTOCOL_VERSION}
+        try:
+            from src.context_system.context_analyzer import analyze_context
+
+            model = getattr(self.provider, "model", None) or self.config.model or ""
+            messages = (
+                self.session.conversation.get_messages() if self.session is not None else []
+            )
+            data = analyze_context(
+                conversation_api_messages=messages,
+                model=model,
+                system_prompt=self._system_prompt_text(),
+                tool_schemas=_tool_schemas(self.tool_registry),
+                claude_md_content="",
+            )
+            out.update({
+                "total_tokens": data.total_tokens,
+                "max_tokens": data.max_tokens,
+                "percentage": round(data.percentage, 1),
+                "categories": [
+                    {"name": c.name, "tokens": c.tokens}
+                    for c in data.categories
+                    if not c.is_deferred and c.name != "Free space"
+                ],
+            })
+        except Exception as exc:  # noqa: BLE001 — never let a usage pull break the session
+            out["error"] = str(exc)
+        return out
 
     def _resolve_permission(self, msg: dict) -> None:
         response = msg.get("response")

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -75,6 +75,11 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const [connected, setConnected] = useState(false)
   const [ready, setReady] = useState(false) // system/init received — banner committed, submit allowed
   const [client, setClient] = useState<DirectConnectClient | null>(null)
+  const [contextUsage, setContextUsage] = useState<{
+    percentage: number
+    totalTokens: number
+    maxTokens: number
+  } | null>(null)
   const [slashSel, setSlashSel] = useState(0)
   const [atSel, setAtSel] = useState(0)
   const localSeq = useRef(0)
@@ -154,6 +159,17 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     }))
   }
 
+  /** Apply a get_context_usage control-response payload to the status bar. */
+  const applyContextUsage = (r: Record<string, unknown> | null): void => {
+    if (r && typeof r['percentage'] === 'number') {
+      setContextUsage({
+        percentage: r['percentage'] as number,
+        totalTokens: Number(r['total_tokens']) || 0,
+        maxTokens: Number(r['max_tokens']) || 0,
+      })
+    }
+  }
+
   useEffect(() => {
     const c = new DirectConnectClient(transport, {
       onConnected: () => setConnected(true),
@@ -185,6 +201,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
           setBusy(false)
           setToolActivity(null)
           flushStream() // commit a partial left over by interrupt/error (no-op on success)
+          void c.requestControl('get_context_usage').then(applyContextUsage) // refresh after each turn
         }
         if (type === 'system' && (msg as { subtype?: string }).subtype === 'init') {
           const m = msg as {
@@ -205,6 +222,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
           // duplicate the next row. Submit is gated on `ready` (set here) so a
           // user message can never beat the banner into the list.
           setReady(true)
+          void c.requestControl('get_context_usage').then(applyContextUsage) // seed the status bar
           if (!bannerAdded.current) {
             bannerAdded.current = true
             addEntry({
@@ -469,7 +487,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         </>
       )}
 
-      <StatusBar connected={connected} model={model} mode={mode} busy={busy} />
+      <StatusBar connected={connected} model={model} mode={mode} busy={busy} context={contextUsage} />
     </Box>
   )
 }

--- a/ui-tui/src/client.ts
+++ b/ui-tui/src/client.ts
@@ -65,6 +65,8 @@ const FILTERED = new Set([
 
 export class DirectConnectClient {
   private closed = false;
+  // request_id → resolver, for control pulls (get_context_usage, get_settings).
+  private pending = new Map<string, (response: Record<string, unknown> | null) => void>();
 
   constructor(
     private readonly transport: Transport,
@@ -107,6 +109,18 @@ export class DirectConnectClient {
         this.cb.onPermissionRequest(cr.request, cr.request_id);
       } else if (typeof cr.request_id === 'string') {
         this.sendErrorResponse(cr.request_id, `unsupported control subtype: ${subtype}`);
+      }
+      return;
+    }
+    if (type === 'control_response') {
+      // Resolve a correlated control pull (get_context_usage, …). Unmatched
+      // responses (e.g. permission acks) fall through and are ignored.
+      const cr = msg as { response?: { request_id?: string; response?: unknown } };
+      const rid = cr.response?.request_id;
+      if (rid && this.pending.has(rid)) {
+        const resolve = this.pending.get(rid) as (r: Record<string, unknown> | null) => void;
+        this.pending.delete(rid);
+        resolve((cr.response?.response as Record<string, unknown>) ?? null);
       }
       return;
     }
@@ -155,6 +169,29 @@ export class DirectConnectClient {
       type: 'control_request',
       request_id: randomUUID(),
       request: { subtype, ...fields },
+    });
+  }
+
+  /**
+   * Fire a control_request and resolve with the server's control_response
+   * payload (e.g. get_context_usage, get_settings). Resolves null on timeout so
+   * a slow/closed link never hangs the caller.
+   */
+  requestControl(
+    subtype: string,
+    fields: Record<string, unknown> = {},
+    timeoutMs = 5000,
+  ): Promise<Record<string, unknown> | null> {
+    const requestId = randomUUID();
+    return new Promise((resolve) => {
+      this.pending.set(requestId, resolve);
+      this.send({ type: 'control_request', request_id: requestId, request: { subtype, ...fields } });
+      setTimeout(() => {
+        if (this.pending.has(requestId)) {
+          this.pending.delete(requestId);
+          resolve(null);
+        }
+      }, timeoutMs);
     });
   }
 

--- a/ui-tui/src/components/StatusBar.tsx
+++ b/ui-tui/src/components/StatusBar.tsx
@@ -1,17 +1,25 @@
 /**
  * Bottom footer — matches the original PromptInputFooter: left side shows a
- * hint ("? for shortcuts"), right side shows status (a connection dot + model ·
- * mode, with the mode colored when it's non-default, like getModeColor).
+ * hint ("? for shortcuts"), right side shows status — context-window usage (the
+ * original's StatusLine context %), a connection dot, and model · mode (mode
+ * colored when non-default, like getModeColor).
  */
 import { Box, Text } from 'ink'
 import React from 'react'
 import { theme } from '../theme.js'
+
+interface ContextUsage {
+  percentage: number
+  totalTokens: number
+  maxTokens: number
+}
 
 interface Props {
   connected: boolean
   model: string
   mode: string
   busy: boolean
+  context?: ContextUsage | null
 }
 
 const MODE_COLOR: Record<string, string | undefined> = {
@@ -21,13 +29,32 @@ const MODE_COLOR: Record<string, string | undefined> = {
   plan: 'rgb(72,150,140)', // sage (planMode)
 }
 
-export function StatusBar({ connected, model, mode, busy }: Props): React.ReactElement {
+/** Compact token count: 1234 → "1.2k", 200000 → "200k". */
+function fmtK(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(n >= 100_000 ? 0 : 1)}k`
+  return String(n)
+}
+
+/** Context % colored by headroom: dim plenty, amber tightening, red low. */
+function ctxColor(pct: number): string {
+  if (pct >= 90) return theme.error
+  if (pct >= 70) return theme.warn
+  return theme.dim
+}
+
+export function StatusBar({ connected, model, mode, busy, context }: Props): React.ReactElement {
   const dot = !connected ? theme.dim : busy ? theme.warn : theme.success
   const modeColor = MODE_COLOR[mode] ?? theme.dim
   return (
     <Box marginTop={1} justifyContent="space-between">
       <Text color={theme.dim}>? for shortcuts</Text>
       <Box>
+        {context ? (
+          <>
+            <Text color={ctxColor(context.percentage)}>{`${Math.round(context.percentage)}%`}</Text>
+            <Text color={theme.dim}>{` (${fmtK(context.totalTokens)}/${fmtK(context.maxTokens)}) · `}</Text>
+          </>
+        ) : null}
         <Text color={dot}>{'● '}</Text>
         <Text color={theme.dim}>{model}</Text>
         <Text color={theme.dim}>{' · '}</Text>


### PR DESCRIPTION
## Summary
First **end-to-end** (backend + client) feature of the port: the original's StatusLine context-window %.

### Backend (`src/server/agent_server.py`)
- Implement the `get_context_usage` control request (was a stub returning only the protocol version).
- Compute real usage via `context_system.analyze_context` over the session's conversation + system prompt + tool schemas → `total_tokens`, `max_tokens`, `percentage`, `categories`.
- Best-effort: any failure degrades to just the protocol version, so a usage pull can never hang or crash the session. Handles a block-list system prompt and an absent tool registry.

### Client (`ui-tui`)
- `client.ts` — request/response **correlation** (`requestControl`) so the client can *pull* a `control_response` (these were previously filtered).
- `App.tsx` — pull `get_context_usage` on init and after each turn; store usage.
- `StatusBar.tsx` — render `NN% (used/max)` colored by headroom (dim <70, amber 70–90, red ≥90), before `model · mode`.

## Verification
- `analyze_context` + `_context_usage` exercised with a real `Conversation` → `{total_tokens, max_tokens, percentage, categories}` (handles no-registry/string-prompt).
- Server suite: **80 passed** (no regressions).
- ui-tui `tsc` + build clean; StatusBar rendered at 8% / 74% / 93% — color thresholds verified by screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)