### PR TITLE
feat(ui-tui): render TodoWrite as a checklist (TaskListV2 look)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -264,6 +264,11 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
             ) {
               // Result for collapsed reads → drop (kept collapsed, like the original).
             } else {
+              // TodoWrite's "Todos modified" result is noise — the checklist IS
+              // the output; collapse its result like a read.
+              if (e.kind === 'tool' && e.toolName === 'TodoWrite' && e.toolUseId) {
+                collapsedIds.current.add(e.toolUseId)
+              }
               // Preserve order: freeze the live read-group before this entry.
               toCommit.push(...takeLive(), e)
             }

--- a/ui-tui/src/components/Message.tsx
+++ b/ui-tui/src/components/Message.tsx
@@ -58,6 +58,37 @@ function ToolResult({ text, isError }: { text: string; isError?: boolean }): Rea
   )
 }
 
+/** TodoWrite checklist — matches the original TaskListV2: ✔ completed (green,
+ *  struck through, dim), ◼ in-progress (orange, bold), ◻ pending. */
+function TodoList({ todos }: { todos: NonNullable<TranscriptEntry['todos']> }): React.ReactElement {
+  const icon = (s: string): { glyph: string; color: string | undefined } =>
+    s === 'completed'
+      ? { glyph: '✔', color: theme.success }
+      : s === 'in_progress'
+        ? { glyph: '◼', color: theme.accent }
+        : { glyph: '◻', color: undefined }
+  return (
+    <Box flexDirection="column">
+      <Text>
+        <Text color={theme.success}>⏺ </Text>
+        <Text bold>Update Todos</Text>
+      </Text>
+      {todos.map((t, i) => {
+        const { glyph, color } = icon(t.status)
+        const done = t.status === 'completed'
+        return (
+          <Box key={i}>
+            <Text color={color}>{`  ${glyph} `}</Text>
+            <Text bold={t.status === 'in_progress'} strikethrough={done} dimColor={done}>
+              {t.content}
+            </Text>
+          </Box>
+        )
+      })}
+    </Box>
+  )
+}
+
 export function Message({ entry }: { entry: TranscriptEntry }): React.ReactElement | null {
   switch (entry.kind) {
     case 'banner':
@@ -87,6 +118,10 @@ export function Message({ entry }: { entry: TranscriptEntry }): React.ReactEleme
         </Box>
       )
     case 'tool': {
+      // TodoWrite renders as a checklist (the original's TaskListV2 look).
+      if (entry.todos) {
+        return <TodoList todos={entry.todos} />
+      }
       // Collapsed summary of several same-kind calls (e.g. "Read 4 files").
       if (entry.count && entry.count > 1) {
         const noun = TOOL_VERB[entry.toolName ?? '']?.noun || 'files'

--- a/ui-tui/src/sdkMessageAdapter.ts
+++ b/ui-tui/src/sdkMessageAdapter.ts
@@ -25,6 +25,12 @@ function readFileSafe(p: unknown): string | undefined {
   }
 }
 
+export interface TodoItem {
+  content: string
+  status: 'pending' | 'in_progress' | 'completed'
+  activeForm?: string
+}
+
 export type EntryKind =
   | 'banner'
   | 'user'
@@ -54,6 +60,8 @@ export interface TranscriptEntry {
   isError?: boolean
   /** collapsed tool summary: how many same-kind calls this entry represents. */
   count?: number
+  /** TodoWrite tool calls: the todo list to render as a checklist. */
+  todos?: TodoItem[]
   /** banner only: the session info snapshot, captured once at init. */
   bannerData?: { model: string; mode: string; tools: number; cwd?: string }
 }
@@ -153,6 +161,18 @@ export function messageToEntries(msg: ServerMessage): TranscriptEntry[] {
             string,
             unknown
           >
+          // TodoWrite renders as a checklist, not a generic tool call.
+          if (toolName === 'TodoWrite' && Array.isArray(tinput['todos'])) {
+            out.push({
+              id: nextId(),
+              kind: 'tool',
+              text: '',
+              toolName,
+              todos: tinput['todos'] as TodoItem[],
+              toolUseId: String((block as { id?: string }).id ?? ''),
+            })
+            continue
+          }
           const diff =
             toolName === 'Edit' || toolName === 'Write' || toolName === 'MultiEdit'
               ? (buildToolDiff(toolName, tinput, readFileSafe(tinput['file_path'])) ?? undefined)


### PR DESCRIPTION
## Summary
The agent's `TodoWrite` calls now render as the original Claude Code checklist instead of a generic `⏺ TodoWrite(...)` line. The data already flows end-to-end (`TodoWrite` is in the agent-server's tool registry — verified 44 tools incl. TodoWrite), so this is the client rendering.

- `⏺ Update Todos` header
- `✔` completed (green, struck through, dim), `◼` in-progress (orange, bold), `◻` pending — matching `TaskListV2`'s `getTaskIcon` + `bold/strikethrough/dimColor` styling.
- The noisy "Todos have been modified…" tool result is dropped (the checklist *is* the output).

## Verification
`tsc` + build clean; rendered a 4-item list (2 completed/struck, 1 in-progress/bold, 1 pending) via ink-testing-library — matches the original. Confirmed TodoWrite is registered in the agent-server so tool_use reaches the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)