### PR TITLE
feat(ui-tui): /context command (context-window breakdown)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -360,6 +360,34 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         client?.close()
         exit()
         return true
+      case 'context': {
+        // Pull a fresh usage snapshot, then render the category breakdown.
+        if (client) {
+          void client.requestControl('get_context_usage').then((r) => {
+            applyContextUsage(r)
+            if (r && typeof r['percentage'] === 'number') {
+              addEntry({
+                kind: 'context',
+                text: '',
+                contextData: {
+                  percentage: r['percentage'] as number,
+                  totalTokens: Number(r['total_tokens']) || 0,
+                  maxTokens: Number(r['max_tokens']) || 0,
+                  categories: Array.isArray(r['categories'])
+                    ? (r['categories'] as { name?: unknown; tokens?: unknown }[]).map((c) => ({
+                        name: String(c.name ?? ''),
+                        tokens: Number(c.tokens) || 0,
+                      }))
+                    : [],
+                },
+              })
+            } else {
+              addEntry({ kind: 'system', text: 'context usage unavailable' })
+            }
+          })
+        }
+        return true
+      }
       case 'control': {
         if (!arg) {
           addEntry({ kind: 'system', text: `usage: ${cmd.name} <value>` })

--- a/ui-tui/src/components/Message.tsx
+++ b/ui-tui/src/components/Message.tsx
@@ -89,6 +89,45 @@ function TodoList({ todos }: { todos: NonNullable<TranscriptEntry['todos']> }): 
   )
 }
 
+function fmtTok(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(n >= 100_000 ? 0 : 1)}k` : String(n)
+}
+
+/** Context-window usage breakdown (the original's /context ContextVisualization):
+ *  a total bar colored by headroom + per-category token bars. */
+function ContextView({ data }: { data: NonNullable<TranscriptEntry['contextData']> }): React.ReactElement {
+  const { percentage, totalTokens, maxTokens, categories } = data
+  const W = 28
+  const filled = Math.max(0, Math.min(W, Math.round((percentage / 100) * W)))
+  const barColor = percentage >= 90 ? theme.error : percentage >= 70 ? theme.warn : theme.success
+  const nameW = Math.max(8, ...categories.map((c) => c.name.length))
+  return (
+    <Box flexDirection="column">
+      <Text>
+        <Text color={theme.success}>⏺ </Text>
+        <Text bold>Context</Text>
+      </Text>
+      <Box>
+        <Text color={theme.dim}>{'  ⎿ '}</Text>
+        <Text color={barColor}>{'█'.repeat(filled)}</Text>
+        <Text color={theme.subtle}>{'░'.repeat(W - filled)}</Text>
+        <Text color={theme.dim}>{`  ${Math.round(percentage)}% · ${fmtTok(totalTokens)}/${fmtTok(maxTokens)} tokens`}</Text>
+      </Box>
+      {categories.map((c, i) => {
+        const seg = Math.max(1, Math.min(W, Math.round((c.tokens / Math.max(1, maxTokens)) * W)))
+        return (
+          <Box key={i}>
+            <Text color={theme.dim}>{'     '}</Text>
+            <Text>{c.name.padEnd(nameW)}</Text>
+            <Text color={theme.accent}>{`  ${'▪'.repeat(seg)}`}</Text>
+            <Text color={theme.dim}>{`  ${fmtTok(c.tokens)}`}</Text>
+          </Box>
+        )
+      })}
+    </Box>
+  )
+}
+
 export function Message({ entry }: { entry: TranscriptEntry }): React.ReactElement | null {
   switch (entry.kind) {
     case 'banner':
@@ -153,6 +192,8 @@ export function Message({ entry }: { entry: TranscriptEntry }): React.ReactEleme
     }
     case 'toolResult':
       return <ToolResult text={entry.text} isError={entry.isError} />
+    case 'context':
+      return entry.contextData ? <ContextView data={entry.contextData} /> : null
     case 'result':
       return <Text color={theme.success}>{`✓ ${entry.text}`}</Text>
     case 'error':

--- a/ui-tui/src/sdkMessageAdapter.ts
+++ b/ui-tui/src/sdkMessageAdapter.ts
@@ -31,6 +31,13 @@ export interface TodoItem {
   activeForm?: string
 }
 
+export interface ContextData {
+  percentage: number
+  totalTokens: number
+  maxTokens: number
+  categories: { name: string; tokens: number }[]
+}
+
 export type EntryKind =
   | 'banner'
   | 'user'
@@ -40,6 +47,7 @@ export type EntryKind =
   | 'system'
   | 'result'
   | 'error'
+  | 'context'
 
 export interface TranscriptEntry {
   id: string
@@ -62,6 +70,8 @@ export interface TranscriptEntry {
   count?: number
   /** TodoWrite tool calls: the todo list to render as a checklist. */
   todos?: TodoItem[]
+  /** /context entries: the context-window usage breakdown to visualize. */
+  contextData?: ContextData
   /** banner only: the session info snapshot, captured once at init. */
   bannerData?: { model: string; mode: string; tools: number; cwd?: string }
 }

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -7,7 +7,7 @@ export interface SlashCommand {
   name: string
   description: string
   /** how the command is handled when submitted. */
-  kind: 'clear' | 'help' | 'quit' | 'control' | 'send'
+  kind: 'clear' | 'help' | 'quit' | 'control' | 'context' | 'send'
   /** for kind:'control' — the control_request subtype. */
   control?: string
 }
@@ -22,6 +22,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
     kind: 'control',
     control: 'set_permission_mode',
   },
+  { name: '/context', description: 'Show context-window usage by category', kind: 'context' },
   { name: '/quit', description: 'Exit the TUI', kind: 'quit' },
 ]
 


### PR DESCRIPTION
## Summary
Adds the original's `/context` (ContextVisualization), built on the `get_context_usage` backend pull from the previous PR — so it's end-to-end.

- `/context` pulls a fresh usage snapshot and renders a breakdown entry.
- `ContextView`: total bar colored by headroom (green <70 / amber <90 / red), `NN% · used/max tokens`, then per-category proportional bars + token counts.

## Verification
`tsc` + build clean; rendered a 42% / 83k-of-200k snapshot with System prompt / System tools / Messages categories via ink-testing-library — bars + counts correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)