### PR TITLE
feat(ui-tui): render Agent/Task (subagent) as a Task card

### DIFF
--- a/ui-tui/src/components/Message.tsx
+++ b/ui-tui/src/components/Message.tsx
@@ -161,6 +161,21 @@ export function Message({ entry }: { entry: TranscriptEntry }): React.ReactEleme
       if (entry.todos) {
         return <TodoList todos={entry.todos} />
       }
+      // Agent/Task (subagent spawn) renders as a Task card.
+      if (entry.agent) {
+        const a = entry.agent
+        const label = a.name ? `${a.description} (@${a.name})` : a.description
+        return (
+          <Text>
+            <Text color={theme.suggestion}>⏺ </Text>
+            <Text bold>Task</Text>
+            <Text color={theme.dim}>(</Text>
+            <Text color={theme.suggestion}>{label}</Text>
+            <Text color={theme.dim}>)</Text>
+            {a.subagentType ? <Text color={theme.dim}>{`  · ${a.subagentType}`}</Text> : null}
+          </Text>
+        )
+      }
       // Collapsed summary of several same-kind calls (e.g. "Read 4 files").
       if (entry.count && entry.count > 1) {
         const noun = TOOL_VERB[entry.toolName ?? '']?.noun || 'files'

--- a/ui-tui/src/sdkMessageAdapter.ts
+++ b/ui-tui/src/sdkMessageAdapter.ts
@@ -72,6 +72,8 @@ export interface TranscriptEntry {
   todos?: TodoItem[]
   /** /context entries: the context-window usage breakdown to visualize. */
   contextData?: ContextData
+  /** Agent/Task tool calls: the spawned subagent's task + type. */
+  agent?: { description: string; subagentType: string; name: string }
   /** banner only: the session info snapshot, captured once at init. */
   bannerData?: { model: string; mode: string; tools: number; cwd?: string }
 }
@@ -171,6 +173,22 @@ export function messageToEntries(msg: ServerMessage): TranscriptEntry[] {
             string,
             unknown
           >
+          // Agent/Task (subagent spawn) renders as a Task card.
+          if (toolName === 'Agent' || toolName === 'Task') {
+            out.push({
+              id: nextId(),
+              kind: 'tool',
+              text: '',
+              toolName,
+              agent: {
+                description: String(tinput['description'] ?? ''),
+                subagentType: String(tinput['subagent_type'] ?? ''),
+                name: String(tinput['name'] ?? ''),
+              },
+              toolUseId: String((block as { id?: string }).id ?? ''),
+            })
+            continue
+          }
           // TodoWrite renders as a checklist, not a generic tool call.
           if (toolName === 'TodoWrite' && Array.isArray(tinput['todos'])) {
             out.push({


### PR DESCRIPTION
## Summary
Subagent spawns (the `Agent` tool, legacy `Task` — registered in the agent-server by default) now render as a distinct **Task card** instead of a generic `⏺ Agent(...)` line.

- `⏺ Task(<description>)` in the subagent blue-purple, with the `subagent_type` as a dim badge and an optional `@name`.
- The subagent's final output flows as the normal tool result below.

### Scope note
This is the **static** representation (spawn + result), which flows reliably over the current protocol. **Live** subagent progress (the original's `AgentProgressLine`) requires the agent-server to stream nested-agent-loop progress events — a `ToolContext` progress hook + a new message type + client `AgentProgressLine`. That's the next backend chapter (deferred here to keep this PR bounded/verified).

## Verification
`tsc` + build clean; rendered `Task(Audit auth module for vulns) · opus` + its result via ink-testing-library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)