### PR TITLE
feat(tui+server): live subagent progress (AgentProgressLine)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -248,6 +248,11 @@ class _AgentSession:
             },
         })
 
+    def _emit_agent_progress(self, ev: dict) -> None:
+        """Forward a spawned subagent's progress to the client (the original's
+        AgentProgressLine). Wired onto tool_context.agent_progress_emit."""
+        self._emit({"type": "agent_progress", "session_id": self.session_id, **ev})
+
     def _system_prompt_text(self) -> str:
         """The active system prompt as a plain string (it may be a block list —
         build_effective_system_prompt returns the full base block list)."""
@@ -611,6 +616,7 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
         sess.provider_name = provider_name
         sess.tool_registry = registry
         sess.tool_context = tool_context
+        tool_context.agent_progress_emit = sess._emit_agent_progress  # stream subagent progress
         sess.session = Session.create(provider_name, getattr(provider, "model", model or ""))
         sess.system_prompt = system_prompt
     except Exception as exc:  # noqa: BLE001

--- a/src/tool_system/context.py
+++ b/src/tool_system/context.py
@@ -170,6 +170,11 @@ class ToolContext:
     messages: list[Any] = field(default_factory=list)
     set_response_length: Callable[[Callable[[int], int]], None] | None = None
     set_in_progress_tool_use_ids: Callable[[Callable[[set[str]], set[str]]], None] | None = None
+    # Optional hook to stream a spawned subagent's live progress to the UI
+    # (the Agent tool sets run_params.on_message → this). Wired only by the
+    # agent-server (forwards an ``agent_progress`` message to the client); SDK /
+    # REPL / unit-test paths leave it ``None`` and emit nothing.
+    agent_progress_emit: Callable[[dict[str, Any]], None] | None = None
     # Mirrors TS Tool.ts:231
     # ``setHasInterruptibleToolInProgress?: (v: boolean) => void``.
     # Optional callback wired only in interactive (REPL/TUI) contexts; SDK

--- a/src/tool_system/tools/agent.py
+++ b/src/tool_system/tools/agent.py
@@ -320,6 +320,43 @@ def make_agent_tool(
             parent_system_prompt=fork_parent_system_prompt,
         )
 
+        # Stream the subagent's live progress to the UI when the host wired a
+        # hook (agent-server only). run_agent calls on_message per message, so
+        # this covers both the sync and background paths. Purely additive — no
+        # hook means no behavior change.
+        _emit_progress = getattr(context, "agent_progress_emit", None)
+        if _emit_progress is not None:
+            from src.tasks.progress import (
+                ProgressTracker,
+                total_tokens_from_tracker,
+                update_progress_from_message,
+            )
+
+            _tracker = ProgressTracker()
+
+            def _on_subagent_message(message: Any) -> None:
+                try:
+                    update_progress_from_message(_tracker, message)
+                    acts = _tracker.recent_activities
+                    activity = None
+                    if acts:
+                        last = acts[-1]
+                        activity = last.activity_description or last.tool_name
+                    _emit_progress({
+                        "agent_id": agent_id,
+                        "name": agent_name,
+                        "description": description,
+                        "subagent_type": subagent_type,
+                        "activity": activity,
+                        "tool_use_count": _tracker.tool_use_count,
+                        "tokens": total_tokens_from_tracker(_tracker),
+                        "status": "running",
+                    })
+                except Exception:
+                    logger.debug("subagent progress emit failed", exc_info=True)
+
+            run_params.on_message = _on_subagent_message
+
         if is_async:
             return _launch_async_agent(
                 run_params=run_params,

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -19,6 +19,7 @@ import { searchFiles } from './fileIndex.js'
 import { Spinner } from './components/Spinner.js'
 import { StatusBar } from './components/StatusBar.js'
 import { LiveTools, type LiveGroup } from './components/LiveTools.js'
+import { AgentProgressLine, type AgentLine } from './components/AgentProgressLine.js'
 import { READ_LIKE, TOOL_VERB, toolActivityLabel } from './toolMeta.js'
 import { messageToEntries, streamDeltaText, type TranscriptEntry } from './sdkMessageAdapter.js'
 import { matchSlash, resolveSlash } from './slashCommands.js'
@@ -91,6 +92,8 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const [liveTools, setLiveTools] = useState<LiveGroup[]>([])
   const liveRef = useRef<LiveGroup[]>([])
   const collapsedIds = useRef<Set<string>>(new Set())
+  // Live subagent progress lines, keyed by agent_id; cleared at turn end.
+  const [agentLines, setAgentLines] = useState<AgentLine[]>([])
 
   const slashMatches = !input.includes(' ') ? matchSlash(input) : []
   const slashOpen = slashMatches.length > 0 && permissions.length === 0
@@ -196,10 +199,38 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
           return
         }
         const type = (msg as { type?: string }).type
+        if (type === 'agent_progress') {
+          // Live subagent progress (the original's AgentProgressLine). Upsert
+          // by agent_id; lines clear at turn end.
+          const m = msg as {
+            agent_id?: string
+            name?: string
+            description?: string
+            activity?: string
+            tool_use_count?: number
+            tokens?: number
+          }
+          if (m.agent_id) {
+            const id = m.agent_id
+            setAgentLines((prev) => [
+              ...prev.filter((l) => l.agentId !== id),
+              {
+                agentId: id,
+                name: m.name ?? '',
+                description: m.description ?? '',
+                activity: m.activity ?? '',
+                toolUseCount: Number(m.tool_use_count) || 0,
+                tokens: Number(m.tokens) || 0,
+              },
+            ])
+          }
+          return
+        }
         if (type === 'assistant') setStream('') // final assistant replaces the live stream
         if (type === 'result') {
           setBusy(false)
           setToolActivity(null)
+          setAgentLines([]) // subagents are done when the turn ends
           flushStream() // commit a partial left over by interrupt/error (no-op on success)
           void c.requestControl('get_context_usage').then(applyContextUsage) // refresh after each turn
         }
@@ -444,6 +475,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     liveRef.current = []
     collapsedIds.current.clear()
     setLiveTools([])
+    setAgentLines([])
     setTurnStartedAt(Date.now())
     setInput('')
     setSlashSel(0)
@@ -482,6 +514,14 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       ) : null}
 
       {liveTools.length > 0 ? <LiveTools groups={liveTools} /> : null}
+
+      {agentLines.length > 0 ? (
+        <Box flexDirection="column">
+          {agentLines.map((l) => (
+            <AgentProgressLine key={l.agentId} line={l} />
+          ))}
+        </Box>
+      ) : null}
 
       {busy && permissions.length === 0 ? (
         <Box>

--- a/ui-tui/src/components/AgentProgressLine.tsx
+++ b/ui-tui/src/components/AgentProgressLine.tsx
@@ -1,0 +1,43 @@
+/**
+ * Live progress line for a running subagent (the original's AgentProgressLine),
+ * driven by `agent_progress` messages the agent-server streams from the Agent
+ * tool's run_agent on_message hook. Shows the task, its current activity, and a
+ * running tool/token count — in the subagent blue-purple.
+ */
+import { Box, Text } from 'ink'
+import React from 'react'
+import { theme } from '../theme.js'
+
+export interface AgentLine {
+  agentId: string
+  name: string
+  description: string
+  activity: string
+  toolUseCount: number
+  tokens: number
+}
+
+function fmtK(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n)
+}
+
+export function AgentProgressLine({ line }: { line: AgentLine }): React.ReactElement {
+  const label = line.name ? `${line.description} (@${line.name})` : line.description || 'Task'
+  const stats: string[] = []
+  if (line.toolUseCount > 0) stats.push(`${line.toolUseCount} tool${line.toolUseCount === 1 ? '' : 's'}`)
+  if (line.tokens > 0) stats.push(`${fmtK(line.tokens)} tokens`)
+  return (
+    <Box>
+      <Box width={2}>
+        <Text color={theme.suggestion}>⏺</Text>
+      </Box>
+      <Box flexGrow={1}>
+        <Text>
+          <Text bold>{label}</Text>
+          {line.activity ? <Text color={theme.dim}>{`  ${line.activity}`}</Text> : null}
+          {stats.length ? <Text color={theme.dim}>{`  · ${stats.join(' · ')}`}</Text> : null}
+        </Text>
+      </Box>
+    </Box>
+  )
+}


### PR DESCRIPTION
## Summary
End-to-end port of the original's **live subagent progress** (`AgentProgressLine`). When the agent spawns subagents (the `Agent` tool), each running subagent now shows a live line with its task, current activity, and tool/token counts.

### Backend (additive + defensive — no hook ⇒ no behavior change)
- `ToolContext.agent_progress_emit` optional hook.
- agent-server wires it (`_emit_agent_progress`) to forward an `agent_progress` message to the client.
- the `Agent` tool sets `run_params.on_message` — `run_agent` already calls this per subagent message (covers **sync + background** paths) — folding each message into a `ProgressTracker` and emitting `{agent_id, name, description, subagent_type, activity, tool_use_count, tokens, status}`.

### Client
- `App` handles `agent_progress`: upsert one live line per `agent_id`, cleared at turn end / new prompt.
- `AgentProgressLine`: `⏺ task · activity · N tools · K tokens` (subagent blue-purple, `@name` for named agents), in the dynamic region alongside the spinner.

## Verification
- **80 server + 170 agent/tool-system tests pass** — backend is purely additive (optional hook).
- Client rendering **screenshot-verified** with synthetic `agent_progress` events (two concurrent subagents).
- Live end-to-end requires a model-backed run (the app loop) — message shape matches between backend emit and client handler by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)