### PR TITLE
feat(tui+server): USD cost in result line + status bar

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -488,14 +488,24 @@ class _AgentSession:
             with self._lock:
                 self._current_abort = None
 
+        _usage = result.usage if result.num_turns > 0 else None
+        _cost = 0.0
+        if _usage:
+            try:
+                from src.services.pricing import compute_cost
+
+                _cost = compute_cost(getattr(self.provider, "model", None) or self.config.model or "", _usage)
+            except Exception:  # noqa: BLE001 — cost is best-effort, never break the turn
+                _cost = 0.0
         self._emit(_result_message(
             self.session_id,
             subtype="success",
             num_turns=result.num_turns,
             result=result.response_text,
             is_error=False,
-            usage=result.usage if result.num_turns > 0 else None,
+            usage=_usage,
             duration_ms=int((time.monotonic() - start) * 1000),
+            total_cost_usd=_cost,
         ))
 
     async def shutdown(self) -> None:
@@ -703,6 +713,7 @@ def _result_message(
     usage: dict | None = None,
     error: str | None = None,
     duration_ms: int = 0,
+    total_cost_usd: float = 0.0,
 ) -> dict:
     payload: dict[str, Any] = {
         "type": "result",
@@ -713,6 +724,7 @@ def _result_message(
         "duration_ms": duration_ms,
         "is_error": is_error,
         "usage": usage or None,
+        "total_cost_usd": total_cost_usd,
     }
     if error is not None:
         payload["error"] = error

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -81,6 +81,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     totalTokens: number
     maxTokens: number
   } | null>(null)
+  const [sessionCost, setSessionCost] = useState(0) // cumulative USD across turns
   const [slashSel, setSlashSel] = useState(0)
   const [atSel, setAtSel] = useState(0)
   // Submitted-prompt history for ↑/↓ recall (readline-style; -1 = live draft).
@@ -251,6 +252,8 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
           setBusy(false)
           setToolActivity(null)
           setAgentLines([]) // subagents are done when the turn ends
+          const turnCost = Number((msg as { total_cost_usd?: number }).total_cost_usd) || 0
+          if (turnCost > 0) setSessionCost((c) => c + turnCost)
           flushStream() // commit a partial left over by interrupt/error (no-op on success)
           void c.requestControl('get_context_usage').then(applyContextUsage) // refresh after each turn
         }
@@ -704,7 +707,14 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         </>
       )}
 
-      <StatusBar connected={connected} model={model} mode={mode} busy={busy} context={contextUsage} />
+      <StatusBar
+        connected={connected}
+        model={model}
+        mode={mode}
+        busy={busy}
+        context={contextUsage}
+        cost={sessionCost}
+      />
     </Box>
   )
 }

--- a/ui-tui/src/components/StatusBar.tsx
+++ b/ui-tui/src/components/StatusBar.tsx
@@ -20,6 +20,7 @@ interface Props {
   mode: string
   busy: boolean
   context?: ContextUsage | null
+  cost?: number
 }
 
 const MODE_COLOR: Record<string, string | undefined> = {
@@ -42,13 +43,16 @@ function ctxColor(pct: number): string {
   return theme.dim
 }
 
-export function StatusBar({ connected, model, mode, busy, context }: Props): React.ReactElement {
+export function StatusBar({ connected, model, mode, busy, context, cost }: Props): React.ReactElement {
   const dot = !connected ? theme.dim : busy ? theme.warn : theme.success
   const modeColor = MODE_COLOR[mode] ?? theme.dim
   return (
     <Box marginTop={1} justifyContent="space-between">
       <Text color={theme.dim}>? for shortcuts</Text>
       <Box>
+        {cost && cost > 0 ? (
+          <Text color={theme.dim}>{`${cost < 0.01 ? `$${cost.toFixed(4)}` : `$${cost.toFixed(2)}`} · `}</Text>
+        ) : null}
         {context ? (
           <>
             <Text color={ctxColor(context.percentage)}>{`${Math.round(context.percentage)}%`}</Text>

--- a/ui-tui/src/sdkMessageAdapter.ts
+++ b/ui-tui/src/sdkMessageAdapter.ts
@@ -120,6 +120,11 @@ function fmtK(n: number): string {
   return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n)
 }
 
+/** USD cost: sub-cent shows 4 decimals ($0.0042), else 2 ($1.23). */
+export function fmtCost(c: number): string {
+  return c < 0.01 ? `$${c.toFixed(4)}` : `$${c.toFixed(2)}`
+}
+
 function toolResultText(content: string | ContentBlock[] | undefined): string {
   if (typeof content === 'string') return content
   if (!Array.isArray(content)) return ''
@@ -242,6 +247,7 @@ export function messageToEntries(msg: ServerMessage): TranscriptEntry[] {
       num_turns?: number
       usage?: Record<string, number> | null
       error?: string
+      total_cost_usd?: number
     }
     if (m.subtype === 'error') {
       return [{ id: nextId(), kind: 'error', text: `error: ${m.error ?? 'unknown'}` }]
@@ -254,8 +260,10 @@ export function messageToEntries(msg: ServerMessage): TranscriptEntry[] {
     const outTok = u['output_tokens'] ?? u['output'] ?? 0
     const total = inTok + outTok
     const tok = total > 0 ? ` · ${fmtK(total)} tokens` : ''
+    const cost = typeof m.total_cost_usd === 'number' ? m.total_cost_usd : 0
+    const costStr = cost > 0 ? ` · ${fmtCost(cost)}` : ''
     const turns = m.num_turns ?? 0
-    return [{ id: nextId(), kind: 'result', text: `done · ${turns} turn${turns === 1 ? '' : 's'}${tok}` }]
+    return [{ id: nextId(), kind: 'result', text: `done · ${turns} turn${turns === 1 ? '' : 's'}${tok}${costStr}` }]
   }
 
   return []


### PR DESCRIPTION
## Summary
End-to-end port of the original's cost display.

### Backend (`agent_server.py`)
- Compute per-turn USD via `src.services.pricing.compute_cost(model, usage)` and add `total_cost_usd` to the `result` message. Best-effort; `0.0` for models with no pricing entry (no guessing).

### Client
- Result line shows `· $X.XX` when cost > 0.
- `App` accumulates a **session total**; `StatusBar` shows it (`$X.XX · NN% (used/max) · model · mode`). Sub-cent renders 4 decimals.
- Hidden entirely for unpriced models (never a misleading `$0`).

## Verification
- Pricing confirmed: `compute_cost('claude-3-5-sonnet…', 10k/2k)` = `$0.06`; unknown model → `0.0`. Server suite **80 pass** (additive).
- `tsc` + build clean; result line + status-bar cost rendered via ink-testing-library (`done · 3 turns · 18.2k tokens · $0.07`; footer `$0.07 · 12% …`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)