### PR TITLE
feat(ui-tui): render thinking blocks (∴ Thinking)

### DIFF
--- a/ui-tui/src/components/Message.tsx
+++ b/ui-tui/src/components/Message.tsx
@@ -207,6 +207,31 @@ export function Message({ entry }: { entry: TranscriptEntry }): React.ReactEleme
     }
     case 'toolResult':
       return <ToolResult text={entry.text} isError={entry.isError} />
+    case 'thinking': {
+      // ∴ Thinking (dim italic) + the reasoning, capped (the original's
+      // AssistantThinkingMessage; full text lives in scrollback).
+      const lines = entry.text.split('\n')
+      const MAX = 14
+      const shown = lines.slice(0, MAX)
+      const extra = lines.length - shown.length
+      return (
+        <Box flexDirection="column">
+          <Text dimColor italic>
+            ∴ Thinking
+          </Text>
+          <Box flexDirection="column" paddingLeft={2}>
+            {shown.map((l, i) => (
+              <Text key={i} dimColor italic>
+                {l || ' '}
+              </Text>
+            ))}
+            {extra > 0 ? (
+              <Text dimColor italic>{`… +${extra} more lines`}</Text>
+            ) : null}
+          </Box>
+        </Box>
+      )
+    }
     case 'context':
       return entry.contextData ? <ContextView data={entry.contextData} /> : null
     case 'result':

--- a/ui-tui/src/sdkMessageAdapter.ts
+++ b/ui-tui/src/sdkMessageAdapter.ts
@@ -48,6 +48,7 @@ export type EntryKind =
   | 'result'
   | 'error'
   | 'context'
+  | 'thinking'
 
 export interface TranscriptEntry {
   id: string
@@ -168,6 +169,20 @@ export function messageToEntries(msg: ServerMessage): TranscriptEntry[] {
     const m = msg as { message: { content: string | ContentBlock[] } }
     const content = m.message?.content
     const out: TranscriptEntry[] = []
+    // Thinking blocks render first (the original's ∴ Thinking), before the
+    // assistant's spoken text.
+    if (Array.isArray(content)) {
+      const thinking = content
+        .filter((b) => b && (b.type === 'thinking' || b.type === 'redacted_thinking'))
+        .map((b) =>
+          b.type === 'redacted_thinking'
+            ? '[redacted thinking]'
+            : String((b as { thinking?: string }).thinking ?? ''),
+        )
+        .filter((t) => t.trim())
+        .join('\n')
+      if (thinking.trim()) out.push({ id: nextId(), kind: 'thinking', text: thinking })
+    }
     const text = blocksToText(content)
     if (text.trim()) out.push({ id: nextId(), kind: 'assistant', text })
     if (Array.isArray(content)) {


### PR DESCRIPTION
## Summary
Ports the original's `AssistantThinkingMessage`. The agent-server **already** passes `thinking` / `redacted_thinking` content blocks through (`message_to_dict` → `_sdk_envelope`), so this is the client rendering that was missing.

- Adapter extracts thinking blocks (before the spoken text) into a `thinking` entry.
- `Message` renders `∴ Thinking` (dim italic) + the reasoning (dim italic, indented, capped at 14 lines with `… +N more lines`). Redacted thinking → placeholder.
- Renders whenever the provider emits thinking (extended-thinking models with thinking enabled); no-op otherwise.

## Verification
`tsc` + build clean. Adapter verified to yield `["thinking","assistant"]` from an assistant message with a thinking block; rendered `∴ Thinking` + reasoning + the spoken line via ink-testing-library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)