### PR TITLE
feat(ui-tui): theme support (dark/light) + /theme

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -24,7 +24,7 @@ import { READ_LIKE, TOOL_VERB, toolActivityLabel } from './toolMeta.js'
 import { messageToEntries, streamDeltaText, type TranscriptEntry } from './sdkMessageAdapter.js'
 import { matchSlash, resolveSlash } from './slashCommands.js'
 import { parseProtocolMajor, SUPPORTED_PROTOCOL_MAJOR } from './protocol.js'
-import { theme } from './theme.js'
+import { applyTheme, theme } from './theme.js'
 
 interface Props {
   transport: Transport
@@ -82,6 +82,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     maxTokens: number
   } | null>(null)
   const [sessionCost, setSessionCost] = useState(0) // cumulative USD across turns
+  const [, setThemeVersion] = useState(0) // bumped on /theme to repaint the dynamic UI
   const [slashSel, setSlashSel] = useState(0)
   const [atSel, setAtSel] = useState(0)
   // Submitted-prompt history for ↑/↓ recall (readline-style; -1 = live draft).
@@ -464,6 +465,15 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         client?.close()
         exit()
         return true
+      case 'theme': {
+        if (applyTheme(arg)) {
+          setThemeVersion((v) => v + 1) // repaint dynamic UI; new output uses the theme
+          addEntry({ kind: 'system', text: `theme → ${arg}` })
+        } else {
+          addEntry({ kind: 'system', text: `usage: ${cmd.name} <dark|light>` })
+        }
+        return true
+      }
       case 'context': {
         // Pull a fresh usage snapshot, then render the category breakdown.
         if (client) {

--- a/ui-tui/src/components/DiffView.tsx
+++ b/ui-tui/src/components/DiffView.tsx
@@ -18,10 +18,7 @@ import React from 'react'
 import { ColorDiff, ColorFile } from '../colorDiff.js'
 import { countPatchLines } from '../patch.js'
 import type { ToolDiff } from '../diff.js'
-import { theme } from '../theme.js'
-
-// CC's default dark theme — Monokai syntax colors + dark add/del tints.
-const THEME_NAME = 'dark'
+import { currentThemeName, theme } from '../theme.js'
 // Original truncates created-file previews to the first 10 lines.
 const WRITE_MAX_LINES = 10
 // Safety cap so a giant edit can't flood the live viewport.
@@ -51,7 +48,7 @@ export function DiffView({ diff }: { diff: ToolDiff }): React.ReactElement | nul
     const content = diff.content ?? ''
     const all = content.split('\n')
     const shown = all.slice(0, WRITE_MAX_LINES).join('\n')
-    const lines = new ColorFile(shown, diff.filePath).render(THEME_NAME, width, false) ?? []
+    const lines = new ColorFile(shown, diff.filePath).render(currentThemeName(), width, false) ?? []
     for (const l of lines) bodyRows.push({ text: l })
     const extra = all.length - WRITE_MAX_LINES
     if (extra > 0) hint = `… +${extra} ${extra === 1 ? 'line' : 'lines'}`
@@ -63,7 +60,7 @@ export function DiffView({ diff }: { diff: ToolDiff }): React.ReactElement | nul
       if (i > 0) bodyRows.push({ text: '...', sep: true })
       const lines =
         new ColorDiff(hunk, diff.firstLine, diff.filePath, diff.fileContent ?? null).render(
-          THEME_NAME,
+          currentThemeName(),
           width,
           false,
         ) ?? []

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -7,7 +7,7 @@ export interface SlashCommand {
   name: string
   description: string
   /** how the command is handled when submitted. */
-  kind: 'clear' | 'help' | 'quit' | 'control' | 'context' | 'compact' | 'send'
+  kind: 'clear' | 'help' | 'quit' | 'control' | 'context' | 'compact' | 'theme' | 'send'
   /** for kind:'control' — the control_request subtype. */
   control?: string
 }
@@ -24,6 +24,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   },
   { name: '/context', description: 'Show context-window usage by category', kind: 'context' },
   { name: '/compact', description: 'Summarize & compact the conversation: /compact [instructions]', kind: 'compact' },
+  { name: '/theme', description: 'Switch color theme: /theme <dark|light>', kind: 'theme' },
   { name: '/quit', description: 'Exit the TUI', kind: 'quit' },
 ]
 

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -1,34 +1,123 @@
 /**
- * Color palette — the EXACT Claude Code dark theme, ported from
- * typescript/src/utils/theme.ts (`darkTheme`). Ink accepts `rgb(r,g,b)` for
- * truecolor, so we use the real brand values rather than approximate ANSI
- * names. The signature element is Claude orange `rgb(215,119,87)`.
+ * Color palette — ported from typescript/src/utils/theme.ts (darkTheme +
+ * lightTheme). Ink accepts `rgb(r,g,b)` for truecolor, so we use the real brand
+ * values. The signature element is Claude orange `rgb(215,119,87)`.
+ *
+ * `theme` is a MUTABLE live object: every component reads `theme.*` at render
+ * time, so `applyTheme(name)` (from /theme or $CLAWCODEX_THEME) swaps the
+ * palette in place and a top-level re-render repaints the dynamic UI + all new
+ * output. Already-printed scrollback keeps its colors — like a real terminal.
  */
-export const theme = {
-  user: undefined as string | undefined, // user text: default (white)
-  assistant: undefined as string | undefined, // assistant text + ⏺ dot: default white ("text")
-  tool: 'rgb(215,119,87)', // tool name — claude orange
-  toolResult: 'rgb(153,153,153)', // inactive (secondary text)
+
+export interface ThemeTokens {
+  user: string | undefined
+  assistant: string | undefined
+  tool: string
+  toolResult: string
+  system: string
+  error: string
+  success: string
+  warn: string
+  dim: string
+  subtle: string
+  accent: string
+  brand: string
+  heading: string | undefined
+  code: string
+  link: string
+  suggestion: string
+  border: string
+  promptBorder: string
+  userBg: string
+  spinner: string
+  spinnerShimmer: string
+  diffAddBg: string
+  diffDelBg: string
+}
+
+const DARK: ThemeTokens = {
+  user: undefined,
+  assistant: undefined,
+  tool: 'rgb(215,119,87)',
+  toolResult: 'rgb(153,153,153)',
   system: 'rgb(153,153,153)',
-  error: 'rgb(255,107,128)', // bright red
-  success: 'rgb(78,186,101)', // bright green
-  warn: 'rgb(255,193,7)', // bright amber
-  dim: 'rgb(153,153,153)', // inactive — secondary text
-  subtle: 'rgb(80,80,80)', // very dim — gutters / faint borders
-  accent: 'rgb(215,119,87)', // claude orange (brand)
+  error: 'rgb(255,107,128)',
+  success: 'rgb(78,186,101)',
+  warn: 'rgb(255,193,7)',
+  dim: 'rgb(153,153,153)',
+  subtle: 'rgb(80,80,80)',
+  accent: 'rgb(215,119,87)',
   brand: 'rgb(215,119,87)',
-  heading: undefined as string | undefined, // headings: bold, default color
-  code: 'rgb(78,186,101)', // fallback code color (cli-highlight overrides)
-  link: 'rgb(177,185,249)', // light blue-purple
+  heading: undefined,
+  code: 'rgb(78,186,101)',
+  link: 'rgb(177,185,249)',
   suggestion: 'rgb(177,185,249)',
-  border: 'rgb(80,80,80)', // subtle box borders
-  promptBorder: 'rgb(136,136,136)', // input rule
-  userBg: 'rgb(55,55,55)', // user message background
-  spinner: 'rgb(215,119,87)', // claude orange
-  spinnerShimmer: 'rgb(235,159,127)', // lighter claude orange — spinner glimmer sweep
-  diffAddBg: 'rgb(34,92,43)', // dark green — added lines
-  diffDelBg: 'rgb(122,41,54)', // dark red — removed lines
-} as const
+  border: 'rgb(80,80,80)',
+  promptBorder: 'rgb(136,136,136)',
+  userBg: 'rgb(55,55,55)',
+  spinner: 'rgb(215,119,87)',
+  spinnerShimmer: 'rgb(235,159,127)',
+  diffAddBg: 'rgb(34,92,43)',
+  diffDelBg: 'rgb(122,41,54)',
+}
+
+const LIGHT: ThemeTokens = {
+  user: undefined,
+  assistant: undefined,
+  tool: 'rgb(215,119,87)',
+  toolResult: 'rgb(102,102,102)',
+  system: 'rgb(102,102,102)',
+  error: 'rgb(171,43,63)',
+  success: 'rgb(44,122,57)',
+  warn: 'rgb(150,108,30)',
+  dim: 'rgb(102,102,102)',
+  subtle: 'rgb(175,175,175)',
+  accent: 'rgb(215,119,87)',
+  brand: 'rgb(215,119,87)',
+  heading: undefined,
+  code: 'rgb(44,122,57)',
+  link: 'rgb(87,105,247)',
+  suggestion: 'rgb(87,105,247)',
+  border: 'rgb(175,175,175)',
+  promptBorder: 'rgb(153,153,153)',
+  userBg: 'rgb(240,240,240)',
+  spinner: 'rgb(215,119,87)',
+  spinnerShimmer: 'rgb(245,149,117)',
+  diffAddBg: 'rgb(105,219,124)',
+  diffDelBg: 'rgb(255,168,180)',
+}
+
+/** Theme palettes by name. The name also drives ColorDiff (it builds its own
+ *  RGB from a theme name: `dark` → Monokai + dark tints, light → GitHub). */
+export const THEMES: Record<string, ThemeTokens> = {
+  dark: DARK,
+  light: LIGHT,
+  'dark-ansi': DARK,
+  'light-ansi': LIGHT,
+}
+
+/** Mutable live palette — components read this each render. */
+export const theme: ThemeTokens = { ...DARK }
+
+let _current = 'dark'
+
+/** Current theme name (passed to ColorDiff so diffs follow the theme). */
+export function currentThemeName(): string {
+  return _current
+}
+
+/** Swap the live palette in place. Returns false for an unknown name. */
+export function applyTheme(name: string): boolean {
+  const t = THEMES[name]
+  if (!t) return false
+  Object.assign(theme, t)
+  _current = name
+  return true
+}
+
+// Honor $CLAWCODEX_THEME at startup (e.g. CLAWCODEX_THEME=light).
+const envTheme = process.env['CLAWCODEX_THEME']
+if (envTheme && THEMES[envTheme]) applyTheme(envTheme)
 
 /** Leading glyphs for each message kind (Claude-Code figures). */
 export const glyph = {


### PR DESCRIPTION
## Summary
Ports the original's theming (dark + light palettes from `utils/theme.ts`).

- `theme` is now a **mutable live object**; `applyTheme(name)` swaps the palette in place and a top-level re-render repaints the dynamic UI + all new output. Printed scrollback keeps its colors (like a real terminal).
- `/theme <dark|light>` switches live; `$CLAWCODEX_THEME` sets it at startup.
- `DiffView` passes `currentThemeName()` to `ColorDiff`/`ColorFile`, so **diffs follow the theme** (light → GitHub syntax + light pastel tints; dark → Monokai + dark tints).

## Verification
`tsc` + build clean. Rendered the same transcript (assistant + edit diff + result) under **dark vs light** via ink-testing-library — diff tints + syntax + accent colors switch correctly (screenshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)