### PR TITLE
docs(ui-tui): refresh /help with all commands + shortcuts

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -38,9 +38,14 @@ interface PendingPermission {
 }
 
 const HELP = [
-  'enter — send · esc — interrupt · ^C — quit',
-  '/help /clear /model <m> /mode <m> /quit',
-  '↑↓ — slash menu · tab — complete',
+  'Commands:',
+  '  /help   /clear   /quit',
+  '  /model <m>   /mode <default|acceptEdits|plan|…>   /theme <dark|light>',
+  '  /context   (window usage)        /compact [instructions]   (summarize)',
+  'Keys:',
+  '  enter — send        esc — interrupt        ^C / ^D — quit',
+  '  ↑↓ — history        ^R — reverse-search    tab — complete',
+  '  @ — file mention    / — command menu       (type while busy → queued)',
 ].join('\n')
 
 /**


### PR DESCRIPTION
## Summary
`/help` was stale after this session's 19 feature PRs (it listed only the original 5 commands). Refreshed to document the full set: `/context`, `/compact`, `/theme`, plus the `↑↓` history, `^R` reverse-search, `@` file-mention, and queue-while-busy behaviors.

## Verification
`tsc` + build clean. Pure text/content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)