### PR TITLE
feat(tui+server): /model interactive picker (provider model list)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -216,6 +216,7 @@ class _AgentSession:
                 "permission_mode": _current_mode(self.tool_context, self.config.permission_mode),
                 "model": getattr(self.provider, "model", None),
                 "provider": self.provider_name,
+                "available_models": self._available_models(),
             })
             return
         if subtype == "get_context_usage":
@@ -250,6 +251,17 @@ class _AgentSession:
                 "response": response,
             },
         })
+
+    def _available_models(self) -> list[str]:
+        """Provider's selectable models (for the /model picker). Best-effort."""
+        try:
+            fn = getattr(self.provider, "get_available_models", None)
+            if callable(fn):
+                models = fn()
+                return [str(m) for m in models] if models else []
+        except Exception:  # noqa: BLE001
+            pass
+        return []
 
     def _emit_agent_progress(self, ev: dict) -> None:
         """Forward a spawned subagent's progress to the client (the original's

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -96,7 +96,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const draftRef = useRef('')
   // Interactive select picker (the original's CustomSelect) for /mode, /theme.
   const [picker, setPicker] = useState<{
-    kind: 'mode' | 'theme'
+    kind: 'mode' | 'theme' | 'model'
     title: string
     options: string[]
     sel: number
@@ -150,13 +150,17 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     setAtSel(0)
   }
 
-  /** Apply an interactive-picker selection (/mode, /theme). */
-  const applyPick = (kind: 'mode' | 'theme', value: string): void => {
+  /** Apply an interactive-picker selection (/mode, /theme, /model). */
+  const applyPick = (kind: 'mode' | 'theme' | 'model', value: string): void => {
     if (!value) return
     if (kind === 'mode') {
       client?.sendControl('set_permission_mode', { mode: value })
       setMode(value)
       addEntry({ kind: 'system', text: `mode → ${value}` })
+    } else if (kind === 'model') {
+      client?.sendControl('set_model', { model: value })
+      setModel(value)
+      addEntry({ kind: 'system', text: `model → ${value}` })
     } else if (applyTheme(value)) {
       setThemeVersion((v) => v + 1)
       addEntry({ kind: 'system', text: `theme → ${value}` })
@@ -593,6 +597,25 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
               title: 'Select permission mode',
               options,
               sel: Math.max(0, options.indexOf(mode)),
+            })
+            return true
+          }
+          if (cmd.control === 'set_model' && client) {
+            // Pull the provider's model list, then open the picker.
+            void client.requestControl('get_settings').then((r) => {
+              const models = Array.isArray(r?.['available_models'])
+                ? (r['available_models'] as unknown[]).map(String).filter(Boolean)
+                : []
+              if (models.length) {
+                setPicker({
+                  kind: 'model',
+                  title: 'Select model',
+                  options: models,
+                  sel: Math.max(0, models.indexOf(model)),
+                })
+              } else {
+                addEntry({ kind: 'system', text: `usage: ${cmd.name} <name>  (no model list available)` })
+              }
             })
             return true
           }


### PR DESCRIPTION
## Summary
Extends the select-picker to `/model`, end-to-end.

- **Backend**: `get_settings` now includes `available_models` from `provider.get_available_models()` (best-effort; empty list if unsupported).
- **Client**: `/model` with no arg pulls `get_settings` and opens the picker with the provider's models, pre-selected to the current one; `Enter` → `set_model`. Falls back to the `usage` hint when no list is available. (`/model <name>` still works directly.)

## Verification
Server suite **80 pass** (additive). **Interactively verified**: `/model` opens `Select model` with `DeepSeek-V4-Pro / -Flash / mimo-v2.5-pro`; `↓`+`Enter` sends `set_model: DeepSeek-V4-Flash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)