### PR TITLE
feat(ui-tui): collapse large pastes to [Pasted text #N]

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -54,6 +54,16 @@ const HELP = [
  * (non-Static) region inside the viewport so Ink can erase it cleanly instead of
  * leaking re-rendered copies into scrollback.
  */
+/** The chunk inserted between `oldV` and `newV` (common prefix/suffix diff). */
+function diffInsert(oldV: string, newV: string): { ins: string; p: number; s: number } {
+  let p = 0
+  const max = Math.min(oldV.length, newV.length)
+  while (p < max && oldV[p] === newV[p]) p++
+  let s = 0
+  while (s < oldV.length - p && s < newV.length - p && oldV[oldV.length - 1 - s] === newV[newV.length - 1 - s]) s++
+  return { ins: newV.slice(p, newV.length - s), p, s }
+}
+
 function streamTail(text: string, cols: number, maxLines: number): string {
   if (maxLines < 1) maxLines = 1
   const width = cols < 8 ? 8 : cols
@@ -94,6 +104,9 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const historyRef = useRef<string[]>([])
   const [histIdx, setHistIdx] = useState(-1)
   const draftRef = useRef('')
+  // Large pastes collapse to a `[Pasted text #N]` placeholder (token → real text).
+  const pasteStore = useRef<Map<string, string>>(new Map())
+  const pasteCounter = useRef(0)
   // Interactive select picker (the original's CustomSelect) for /mode, /theme.
   const [picker, setPicker] = useState<{
     kind: 'mode' | 'theme' | 'model'
@@ -637,10 +650,19 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     }
   }
 
+  /** Replace `[Pasted text #N]` placeholders with their real text for the model. */
+  const expandPastes = (t: string): string => {
+    let e = t
+    for (const [token, real] of pasteStore.current) {
+      if (e.includes(token)) e = e.split(token).join(real)
+    }
+    return e
+  }
+
   /** Send a prompt now and start a turn (shared by submit + queue drain). */
   const dispatchPrompt = (text: string): void => {
     if (!client) return
-    client.sendPrompt(text)
+    client.sendPrompt(expandPastes(text)) // model gets the full paste; transcript shows the placeholder
     if (historyRef.current[historyRef.current.length - 1] !== text) historyRef.current.push(text)
     addEntry({ kind: 'user', text })
     setStream('')
@@ -819,7 +841,19 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
             <TextInput
               value={input}
               onChange={(v) => {
-                setInput(v)
+                // Collapse a large paste to a placeholder so it doesn't flood
+                // the input (the original's [Pasted text #N]). Normal typing
+                // inserts one char at a time, so this only fires on paste.
+                const { ins, p, s } = diffInsert(input, v)
+                const nLines = ins ? ins.split('\n').length : 0
+                if (ins && (ins.length > 200 || nLines >= 4)) {
+                  const n = (pasteCounter.current += 1)
+                  const token = `[Pasted text #${n}${nLines > 1 ? ` +${nLines} lines` : ''}]`
+                  pasteStore.current.set(token, ins)
+                  setInput(v.slice(0, p) + token + (s ? v.slice(v.length - s) : ''))
+                } else {
+                  setInput(v)
+                }
                 setSlashSel(0)
                 setAtSel(0)
                 setHistIdx(-1)


### PR DESCRIPTION
## Summary
Ports the original's paste placeholder (inventory §1) — correcting an earlier "blocked" assessment (ink-text-input v6 handles multi-line paste cleanly, no premature submit).

- A large multi-line paste (`>200` chars or `≥4` lines), detected via a prefix/suffix diff in `onChange` (normal typing inserts one char, so it never triggers), collapses to a `[Pasted text #N +K lines]` token instead of flooding the input.
- The token **expands to the real text when sent** — the model gets the full paste; the transcript shows the placeholder. Works for queued/recalled prompts (token store persists for the session).

## Verification
`tsc` + build clean. Interactively verified: pasting a 5-line block shows `[Pasted text #1 +5 lines]`; submitting after appending text sends the full expanded text to the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)