### PR TITLE
feat(ui-tui): /export transcript to markdown

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -8,6 +8,8 @@
  */
 import { Box, Static, Text, useApp, useInput } from 'ink'
 import TextInput from 'ink-text-input'
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import React, { useEffect, useRef, useState } from 'react'
 import { DirectConnectClient } from './client.js'
 import type { Transport } from './transport.js'
@@ -54,6 +56,59 @@ const HELP = [
  * (non-Static) region inside the viewport so Ink can erase it cleanly instead of
  * leaking re-rendered copies into scrollback.
  */
+/** Serialize the transcript to readable Markdown (for /export). */
+function transcriptToMarkdown(entries: TranscriptEntry[]): string {
+  const out: string[] = ['# clawcodex transcript', '']
+  for (const e of entries) {
+    switch (e.kind) {
+      case 'user':
+        out.push(`### › ${e.text}`, '')
+        break
+      case 'assistant':
+        out.push(e.text, '')
+        break
+      case 'thinking':
+        out.push(`> ∴ _${e.text.replace(/\n/g, ' ')}_`, '')
+        break
+      case 'tool': {
+        if (e.todos) {
+          out.push('**Todos:**')
+          for (const t of e.todos) out.push(`- [${t.status === 'completed' ? 'x' : ' '}] ${t.content}`)
+          out.push('')
+        } else if (e.agent) {
+          out.push(`\`Task(${e.agent.description})\`${e.agent.subagentType ? ` · ${e.agent.subagentType}` : ''}`, '')
+        } else {
+          const name = e.diff ? e.diff.displayName : e.toolName
+          out.push(`\`${name}(${e.argsText ?? ''})\``)
+          if (e.diff) {
+            out.push('```diff')
+            if (e.diff.kind === 'write' && e.diff.content) out.push(...e.diff.content.split('\n').map((l) => `+${l}`))
+            else for (const h of e.diff.hunks) out.push(...h.lines)
+            out.push('```')
+          }
+          out.push('')
+        }
+        break
+      }
+      case 'toolResult':
+        out.push('```', e.text, '```', '')
+        break
+      case 'result':
+        out.push(`_${e.text}_`, '')
+        break
+      case 'error':
+        out.push(`**Error:** ${e.text}`, '')
+        break
+      case 'system':
+        out.push(`_${e.text}_`, '')
+        break
+      default:
+        break
+    }
+  }
+  return out.join('\n')
+}
+
 /** The chunk inserted between `oldV` and `newV` (common prefix/suffix diff). */
 function diffInsert(oldV: string, newV: string): { ins: string; p: number; s: number } {
   let p = 0
@@ -528,6 +583,18 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         client?.close()
         exit()
         return true
+      case 'export': {
+        try {
+          const md = transcriptToMarkdown(entries)
+          const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+          const file = join(process.cwd(), `clawcodex-transcript-${ts}.md`)
+          writeFileSync(file, md, 'utf8')
+          addEntry({ kind: 'system', text: `exported transcript → ${file}` })
+        } catch (e) {
+          addEntry({ kind: 'error', text: `export failed: ${String((e as Error).message)}` })
+        }
+        return true
+      }
       case 'theme': {
         if (!arg) {
           const options = ['dark', 'light']

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -7,7 +7,7 @@ export interface SlashCommand {
   name: string
   description: string
   /** how the command is handled when submitted. */
-  kind: 'clear' | 'help' | 'quit' | 'control' | 'context' | 'compact' | 'theme' | 'send'
+  kind: 'clear' | 'help' | 'quit' | 'control' | 'context' | 'compact' | 'theme' | 'export' | 'send'
   /** for kind:'control' — the control_request subtype. */
   control?: string
 }
@@ -25,6 +25,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/context', description: 'Show context-window usage by category', kind: 'context' },
   { name: '/compact', description: 'Summarize & compact the conversation: /compact [instructions]', kind: 'compact' },
   { name: '/theme', description: 'Switch color theme: /theme <dark|light>', kind: 'theme' },
+  { name: '/export', description: 'Save the transcript to a markdown file', kind: 'export' },
   { name: '/quit', description: 'Exit the TUI', kind: 'quit' },
 ]
 


### PR DESCRIPTION
## Summary
Ports the original's `/export` (inventory §2). Serializes the transcript to a readable Markdown file (`clawcodex-transcript-<ts>.md` in the cwd):

- user prompts (`### › …`), assistant text, thinking (`> ∴ …`)
- tool calls — diffs as ` ```diff ` fences, TodoWrite as a `- [ ]` checklist, subagent tasks
- tool results (fenced), the result line
- reports the written path; failures surface as an error entry.

## Verification
`tsc` + build clean. **Interactively verified**: after a turn, `/export` wrote `clawcodex-transcript-2026-…md` containing the assistant text, user prompt, and result line in Markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)