### PR TITLE
feat(ui-tui): /copy last response to clipboard (OSC 52)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -583,6 +583,19 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         client?.close()
         exit()
         return true
+      case 'copy': {
+        // Copy the last assistant response via OSC 52 (terminal clipboard; works
+        // in iTerm2/kitty/wezterm/… without a clipboard library).
+        const last = [...entries].reverse().find((e) => e.kind === 'assistant' && e.text.trim())
+        if (last) {
+          const b64 = Buffer.from(last.text, 'utf8').toString('base64')
+          process.stdout.write(`\x1b]52;c;${b64}\x07`)
+          addEntry({ kind: 'system', text: 'copied last response to clipboard' })
+        } else {
+          addEntry({ kind: 'system', text: 'nothing to copy' })
+        }
+        return true
+      }
       case 'export': {
         try {
           const md = transcriptToMarkdown(entries)

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -7,7 +7,7 @@ export interface SlashCommand {
   name: string
   description: string
   /** how the command is handled when submitted. */
-  kind: 'clear' | 'help' | 'quit' | 'control' | 'context' | 'compact' | 'theme' | 'export' | 'send'
+  kind: 'clear' | 'help' | 'quit' | 'control' | 'context' | 'compact' | 'theme' | 'export' | 'copy' | 'send'
   /** for kind:'control' — the control_request subtype. */
   control?: string
 }
@@ -26,6 +26,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/compact', description: 'Summarize & compact the conversation: /compact [instructions]', kind: 'compact' },
   { name: '/theme', description: 'Switch color theme: /theme <dark|light>', kind: 'theme' },
   { name: '/export', description: 'Save the transcript to a markdown file', kind: 'export' },
+  { name: '/copy', description: "Copy the last response to the clipboard", kind: 'copy' },
   { name: '/quit', description: 'Exit the TUI', kind: 'quit' },
 ]
 


### PR DESCRIPTION
## Summary
Ports the original's `/copy` (inventory §2). Copies the last assistant response to the system clipboard via the **OSC 52** terminal escape — works in iTerm2/kitty/wezterm/… without a clipboard library. Reports success or `nothing to copy`.

## Verification
`tsc` + build clean. **Interactively verified** (spying on `process.stdout`): after an assistant turn, `/copy` writes `\x1b]52;c;<base64>` containing the correct base64 of the last response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)