### PR TITLE
feat(ui-tui): /doctor diagnostics command

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -583,6 +583,23 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         client?.close()
         exit()
         return true
+      case 'doctor': {
+        addEntry({
+          kind: 'system',
+          text: [
+            'clawcodex diagnostics',
+            `  connection  ${connected ? 'connected' : 'disconnected'}`,
+            `  server      ${serverLabel}`,
+            `  model       ${model}`,
+            `  mode        ${mode}`,
+            `  tools       ${tools}`,
+            `  protocol    v${SUPPORTED_PROTOCOL_MAJOR}.x`,
+            `  theme       ${currentThemeName()}`,
+            `  cwd         ${process.cwd()}`,
+          ].join('\n'),
+        })
+        return true
+      }
       case 'copy': {
         // Copy the last assistant response via OSC 52 (terminal clipboard; works
         // in iTerm2/kitty/wezterm/… without a clipboard library).

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -7,7 +7,7 @@ export interface SlashCommand {
   name: string
   description: string
   /** how the command is handled when submitted. */
-  kind: 'clear' | 'help' | 'quit' | 'control' | 'context' | 'compact' | 'theme' | 'export' | 'copy' | 'send'
+  kind: 'clear' | 'help' | 'quit' | 'control' | 'context' | 'compact' | 'theme' | 'export' | 'copy' | 'doctor' | 'send'
   /** for kind:'control' — the control_request subtype. */
   control?: string
 }
@@ -27,6 +27,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/theme', description: 'Switch color theme: /theme <dark|light>', kind: 'theme' },
   { name: '/export', description: 'Save the transcript to a markdown file', kind: 'export' },
   { name: '/copy', description: "Copy the last response to the clipboard", kind: 'copy' },
+  { name: '/doctor', description: 'Show connection + session diagnostics', kind: 'doctor' },
   { name: '/quit', description: 'Exit the TUI', kind: 'quit' },
 ]
 


### PR DESCRIPTION
## Summary
Ports the original's Doctor (inventory §5). `/doctor` shows a quick diagnostics panel: connection, server label, model, permission mode, tool count, protocol version, theme, and cwd — from client state (no backend round-trip).

## Verification
`tsc` + build clean; `resolveSlash('/doctor')` → `doctor`. Rendered the diagnostics entry via ink-testing-library (screenshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)