### PR TITLE
feat(tui+server): /rewind — undo the last turn(s)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -225,6 +225,9 @@ class _AgentSession:
         if subtype == "compact":
             await self._do_compact(request_id, inner.get("instructions"))
             return
+        if subtype == "rewind":
+            self._do_rewind(request_id, inner.get("turns", 1))
+            return
         # Unknown subtype — error back so a correlating client doesn't hang.
         if isinstance(request_id, str):
             self._emit({
@@ -267,6 +270,46 @@ class _AgentSession:
         """Forward a spawned subagent's progress to the client (the original's
         AgentProgressLine). Wired onto tool_context.agent_progress_emit."""
         self._emit({"type": "agent_progress", "session_id": self.session_id, **ev})
+
+    def _do_rewind(self, request_id: object, turns: object) -> None:
+        """Drop the last N prompt-turns from the conversation (the original's
+        /rewind). A prompt-turn starts at a real user prompt (string/text
+        content — not a tool_result, which is also role 'user') and runs to the
+        end. Idle-only: the worker mutates the conversation during a turn."""
+        with self._lock:
+            active = self._current_abort is not None
+        if active:
+            self._reply(request_id, {"ok": False, "error": "cannot rewind during an active turn"})
+            return
+        try:
+            n = int(turns) if isinstance(turns, (int, float)) else 1
+            n = max(1, n)
+            msgs = self.session.conversation.messages if self.session is not None else []
+
+            def is_prompt(m: Any) -> bool:
+                if getattr(m, "role", None) != "user":
+                    return False
+                c = getattr(m, "content", None)
+                if isinstance(c, str):
+                    return True
+                if isinstance(c, list):
+                    for b in c:
+                        t = b.get("type") if isinstance(b, dict) else getattr(b, "type", None)
+                        if t == "text":
+                            return True
+                return False
+
+            prompt_idxs = [i for i, m in enumerate(msgs) if is_prompt(m)]
+            if not prompt_idxs:
+                self._reply(request_id, {"ok": True, "removed": 0, "count": len(msgs)})
+                return
+            target = prompt_idxs[max(0, len(prompt_idxs) - n)]
+            removed = len(msgs) - target
+            del msgs[target:]
+            self._reply(request_id, {"ok": True, "removed": removed, "count": len(msgs)})
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[agent-server] rewind failed")
+            self._reply(request_id, {"ok": False, "error": str(exc)})
 
     def _system_prompt_text(self) -> str:
         """The active system prompt as a plain string (it may be a block list —

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -583,6 +583,28 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         client?.close()
         exit()
         return true
+      case 'rewind': {
+        const n = Math.max(1, parseInt(arg, 10) || 1)
+        if (client) {
+          void client.requestControl('rewind', { turns: n }).then((r) => {
+            if (r && r['ok']) {
+              const removed = Number(r['removed']) || 0
+              const count = Number(r['count']) || 0
+              addEntry({
+                kind: 'system',
+                text: `↩ rewound — dropped ${removed} message${removed === 1 ? '' : 's'} (${count} remaining)`,
+              })
+              void client.requestControl('get_context_usage').then(applyContextUsage)
+            } else {
+              addEntry({
+                kind: 'error',
+                text: `rewind failed: ${r && r['error'] ? String(r['error']) : 'no response'}`,
+              })
+            }
+          })
+        }
+        return true
+      }
       case 'doctor': {
         addEntry({
           kind: 'system',

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -7,7 +7,19 @@ export interface SlashCommand {
   name: string
   description: string
   /** how the command is handled when submitted. */
-  kind: 'clear' | 'help' | 'quit' | 'control' | 'context' | 'compact' | 'theme' | 'export' | 'copy' | 'doctor' | 'send'
+  kind:
+    | 'clear'
+    | 'help'
+    | 'quit'
+    | 'control'
+    | 'context'
+    | 'compact'
+    | 'rewind'
+    | 'theme'
+    | 'export'
+    | 'copy'
+    | 'doctor'
+    | 'send'
   /** for kind:'control' — the control_request subtype. */
   control?: string
 }
@@ -24,6 +36,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   },
   { name: '/context', description: 'Show context-window usage by category', kind: 'context' },
   { name: '/compact', description: 'Summarize & compact the conversation: /compact [instructions]', kind: 'compact' },
+  { name: '/rewind', description: 'Undo the last turn(s): /rewind [N]', kind: 'rewind' },
   { name: '/theme', description: 'Switch color theme: /theme <dark|light>', kind: 'theme' },
   { name: '/export', description: 'Save the transcript to a markdown file', kind: 'export' },
   { name: '/copy', description: "Copy the last response to the clipboard", kind: 'copy' },


### PR DESCRIPTION
## Summary
End-to-end port of the original's **/rewind** (session rewind) — the first of the session-persistence chapter.

### Backend (`agent_server.py`)
- A `rewind` control request → `_do_rewind` drops the last **N prompt-turns** from the conversation in place. A prompt-turn starts at a real user prompt (string/text content — **not** a `tool_result`, which is also role `user`) and runs to the end. Idle-guarded (the worker mutates the conversation mid-turn). Replies `{removed, count}`.

### Client
- `/rewind [N]` → `requestControl('rewind', {turns:N})` → `↩ rewound — dropped K messages (M remaining)` + refreshes the context indicator; errors surface.

## Verification
- **Server suite 80 pass** (additive). `_do_rewind` verified on a synthetic 5-message / 2-turn conversation: rewind 1 → 3 messages (drops prompt2+answer2, keeps prompt1/answer1/toolresult); rewind again → 0. Correctly distinguishes prompts from tool-results.
- Client **interactively verified**: `/rewind` sends `rewind: {turns:1}` and follows with `get_context_usage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)