### PR TITLE
fix(tui+server): /clear resets the backend conversation, not just the screen

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -228,6 +228,21 @@ class _AgentSession:
         if subtype == "rewind":
             self._do_rewind(request_id, inner.get("turns", 1))
             return
+        if subtype == "clear":
+            # Reset the conversation so /clear actually starts a fresh context
+            # (not just the client screen). Idle-only.
+            with self._lock:
+                active = self._current_abort is not None
+            if active:
+                self._reply(request_id, {"ok": False, "error": "cannot clear during an active turn"})
+                return
+            try:
+                if self.session is not None:
+                    self.session.conversation.clear()
+                self._reply(request_id, {"ok": True, "count": 0})
+            except Exception as exc:  # noqa: BLE001
+                self._reply(request_id, {"ok": False, "error": str(exc)})
+            return
         # Unknown subtype — error back so a correlating client doesn't hang.
         if isinstance(request_id, str):
             self._emit({

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -575,6 +575,9 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         // Static output is flushed to scrollback; reclaim the screen too.
         process.stdout.write('\x1b[2J\x1b[3J\x1b[H')
         setEntries([])
+        setSessionCost(0)
+        setContextUsage(null)
+        client?.sendControl('clear') // reset the backend conversation, not just the screen
         return true
       case 'help':
         addEntry({ kind: 'system', text: HELP })


### PR DESCRIPTION
## Summary
Real functional gap: `/clear` only wiped the client transcript — the agent-server kept the full conversation, so the **model still saw all prior context**. Now `/clear` starts a fresh context (matching the original).

- **Backend**: a `clear` control request (idle-guarded) calls `conversation.clear()`.
- **Client**: `/clear` sends it and also resets the session cost + context indicator.

## Verification
Server suite **80 pass** (additive). Client **interactively verified**: `/clear` sends the `clear` control request (in addition to wiping the screen/entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)