### PR TITLE
feat(tui+server): session persistence + /resume

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -47,6 +47,7 @@ loop with ``loop.call_soon_threadsafe`` (asyncio.Queue is not thread-safe).
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import queue as _queue
 import threading
@@ -228,6 +229,12 @@ class _AgentSession:
         if subtype == "rewind":
             self._do_rewind(request_id, inner.get("turns", 1))
             return
+        if subtype == "list_sessions":
+            self._reply(request_id, {"sessions": _list_saved_sessions()})
+            return
+        if subtype == "resume":
+            self._do_resume(request_id, inner.get("session_id"))
+            return
         if subtype == "clear":
             # Reset the conversation so /clear actually starts a fresh context
             # (not just the client screen). Idle-only.
@@ -285,6 +292,60 @@ class _AgentSession:
         """Forward a spawned subagent's progress to the client (the original's
         AgentProgressLine). Wired onto tool_context.agent_progress_emit."""
         self._emit({"type": "agent_progress", "session_id": self.session_id, **ev})
+
+    def _save_session(self) -> None:
+        """Persist the conversation to disk so it can be /resume'd. Best-effort,
+        called at each turn end."""
+        try:
+            if self.session is None:
+                return
+            msgs = self.session.conversation.messages
+            if not msgs:
+                return
+            d = _sessions_dir()
+            d.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "session_id": self.session_id,
+                "model": getattr(self.provider, "model", None) or self.config.model or "",
+                "cwd": self.cwd,
+                "updated_at": time.time(),
+                "message_count": len(msgs),
+                "preview": _first_prompt_preview(msgs),
+                "conversation": self.session.conversation.to_dict(),
+            }
+            (d / f"{self.session_id}.json").write_text(json.dumps(payload), encoding="utf-8")
+        except Exception:  # noqa: BLE001 — persistence must never break a turn
+            logger.debug("[agent-server] session save failed", exc_info=True)
+
+    def _do_resume(self, request_id: object, session_id: object) -> None:
+        """Load a saved conversation into this session (the original's /resume).
+        Idle-only — replacing the conversation mid-turn would race the worker."""
+        with self._lock:
+            active = self._current_abort is not None
+        if active:
+            self._reply(request_id, {"ok": False, "error": "cannot resume during an active turn"})
+            return
+        try:
+            if not isinstance(session_id, str) or not session_id:
+                self._reply(request_id, {"ok": False, "error": "missing session_id"})
+                return
+            f = _sessions_dir() / f"{session_id}.json"
+            if not f.exists():
+                self._reply(request_id, {"ok": False, "error": "session not found"})
+                return
+            from src.agent.conversation import Conversation
+
+            data = json.loads(f.read_text(encoding="utf-8"))
+            conv = Conversation.from_dict(data.get("conversation", {"messages": []}))
+            self.session.conversation = conv
+            self._reply(request_id, {
+                "ok": True,
+                "count": len(conv.messages),
+                "preview": data.get("preview", ""),
+            })
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[agent-server] resume failed")
+            self._reply(request_id, {"ok": False, "error": str(exc)})
 
     def _do_rewind(self, request_id: object, turns: object) -> None:
         """Drop the last N prompt-turns from the conversation (the original's
@@ -577,6 +638,7 @@ class _AgentSession:
             duration_ms=int((time.monotonic() - start) * 1000),
             total_cost_usd=_cost,
         ))
+        self._save_session()  # persist for /resume
 
     async def shutdown(self) -> None:
         self._stop.set()
@@ -799,6 +861,53 @@ def _result_message(
     if error is not None:
         payload["error"] = error
     return payload
+
+
+def _sessions_dir() -> Path:
+    return Path.home() / ".clawcodex" / "sessions"
+
+
+def _first_prompt_preview(msgs: list) -> str:
+    """First real user prompt text (for the /resume session list)."""
+    for m in msgs:
+        if getattr(m, "role", None) != "user":
+            continue
+        c = getattr(m, "content", None)
+        if isinstance(c, str):
+            return c[:80]
+        if isinstance(c, list):
+            for b in c:
+                t = b.get("type") if isinstance(b, dict) else getattr(b, "type", None)
+                if t == "text":
+                    txt = b.get("text") if isinstance(b, dict) else getattr(b, "text", "")
+                    if txt:
+                        return str(txt)[:80]
+    return ""
+
+
+def _list_saved_sessions(limit: int = 20) -> list[dict]:
+    """Saved sessions, newest first (for /resume)."""
+    out: list[dict] = []
+    try:
+        d = _sessions_dir()
+        if not d.exists():
+            return []
+        for f in d.glob("*.json"):
+            try:
+                data = json.loads(f.read_text(encoding="utf-8"))
+            except Exception:  # noqa: BLE001
+                continue
+            out.append({
+                "session_id": data.get("session_id", f.stem),
+                "updated_at": data.get("updated_at", 0),
+                "preview": data.get("preview", ""),
+                "message_count": data.get("message_count", 0),
+                "model": data.get("model", ""),
+            })
+        out.sort(key=lambda s: s.get("updated_at", 0), reverse=True)
+    except Exception:  # noqa: BLE001
+        pass
+    return out[:limit]
 
 
 def _system_message(session_id: str, text: str, *, level: str = "info") -> dict:

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -109,6 +109,16 @@ function transcriptToMarkdown(entries: TranscriptEntry[]): string {
   return out.join('\n')
 }
 
+/** Compact relative age for the /resume list (updated_at in epoch seconds). */
+function relAge(sec: number): string {
+  if (!sec) return ''
+  const diff = Date.now() / 1000 - sec
+  if (diff < 60) return 'just now'
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}
+
 /** The chunk inserted between `oldV` and `newV` (common prefix/suffix diff). */
 function diffInsert(oldV: string, newV: string): { ins: string; p: number; s: number } {
   let p = 0
@@ -164,9 +174,11 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const pasteCounter = useRef(0)
   // Interactive select picker (the original's CustomSelect) for /mode, /theme.
   const [picker, setPicker] = useState<{
-    kind: 'mode' | 'theme' | 'model'
+    kind: 'mode' | 'theme' | 'model' | 'resume'
     title: string
     options: string[]
+    /** Optional value per option (e.g. session_id); falls back to the label. */
+    values?: string[]
     sel: number
   } | null>(null)
   // Ctrl+R reverse history search.
@@ -218,8 +230,8 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     setAtSel(0)
   }
 
-  /** Apply an interactive-picker selection (/mode, /theme, /model). */
-  const applyPick = (kind: 'mode' | 'theme' | 'model', value: string): void => {
+  /** Apply an interactive-picker selection (/mode, /theme, /model, /resume). */
+  const applyPick = (kind: 'mode' | 'theme' | 'model' | 'resume', value: string): void => {
     if (!value) return
     if (kind === 'mode') {
       client?.sendControl('set_permission_mode', { mode: value })
@@ -229,6 +241,15 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       client?.sendControl('set_model', { model: value })
       setModel(value)
       addEntry({ kind: 'system', text: `model → ${value}` })
+    } else if (kind === 'resume') {
+      void client?.requestControl('resume', { session_id: value }).then((r) => {
+        if (r && r['ok']) {
+          addEntry({ kind: 'system', text: `↻ resumed session — ${Number(r['count']) || 0} messages restored` })
+          void client?.requestControl('get_context_usage').then(applyContextUsage)
+        } else {
+          addEntry({ kind: 'error', text: `resume failed: ${r && r['error'] ? String(r['error']) : 'no response'}` })
+        }
+      })
     } else if (applyTheme(value)) {
       setThemeVersion((v) => v + 1)
       addEntry({ kind: 'system', text: `theme → ${value}` })
@@ -452,7 +473,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         return
       }
       if (key.return) {
-        applyPick(picker.kind, picker.options[picker.sel] ?? '')
+        applyPick(picker.kind, (picker.values ?? picker.options)[picker.sel] ?? '')
         setPicker(null)
         return
       }
@@ -586,6 +607,25 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         client?.close()
         exit()
         return true
+      case 'resume': {
+        if (client) {
+          void client.requestControl('list_sessions').then((r) => {
+            const sessions = Array.isArray(r?.['sessions']) ? (r['sessions'] as Record<string, unknown>[]) : []
+            if (!sessions.length) {
+              addEntry({ kind: 'system', text: 'no saved sessions' })
+              return
+            }
+            const options = sessions.map((s) => {
+              const prev = String(s['preview'] || '(no preview)').slice(0, 50)
+              const age = relAge(Number(s['updated_at']) || 0)
+              return `${prev}  ·  ${Number(s['message_count']) || 0} msgs${age ? `  ·  ${age}` : ''}`
+            })
+            const values = sessions.map((s) => String(s['session_id']))
+            setPicker({ kind: 'resume', title: 'Resume session', options, values, sel: 0 })
+          })
+        }
+        return true
+      }
       case 'rewind': {
         const n = Math.max(1, parseInt(arg, 10) || 1)
         if (client) {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -15,6 +15,7 @@ export interface SlashCommand {
     | 'context'
     | 'compact'
     | 'rewind'
+    | 'resume'
     | 'theme'
     | 'export'
     | 'copy'
@@ -37,6 +38,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/context', description: 'Show context-window usage by category', kind: 'context' },
   { name: '/compact', description: 'Summarize & compact the conversation: /compact [instructions]', kind: 'compact' },
   { name: '/rewind', description: 'Undo the last turn(s): /rewind [N]', kind: 'rewind' },
+  { name: '/resume', description: 'Resume a saved session', kind: 'resume' },
   { name: '/theme', description: 'Switch color theme: /theme <dark|light>', kind: 'theme' },
   { name: '/export', description: 'Save the transcript to a markdown file', kind: 'export' },
   { name: '/copy', description: "Copy the last response to the clipboard", kind: 'copy' },


### PR DESCRIPTION
## Summary
End-to-end port of the original's **session resume** — the core of the disk-persistence chapter.

### Backend (`agent_server.py`)
- **Auto-save** the conversation to `~/.clawcodex/sessions/<id>.json` at each turn end (best-effort), with a first-prompt preview + message count.
- New controls: **`list_sessions`** (newest first) and **`resume {session_id}`** (loads `Conversation.from_dict` in place; idle-guarded).

### Client
- `/resume` → `list_sessions` → **interactive picker** (`preview · N msgs · age`) → `resume` → restores the conversation + refreshes context. The picker now carries a value-per-option (session_id) distinct from the label.

## Verification
- save → list → resume cycle on synthetic sessions: preview + restore correct (2 msgs loaded into a fresh session). Server suite **80 pass**.
- Client **interactively verified**: `/resume` lists sessions, opens the picker, and selecting sends `resume: sess-A`; screenshot of the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)