### PR TITLE
feat(tui+server): /rename session label

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -111,6 +111,7 @@ class _AgentSession:
     session: Any = None
     system_prompt: Any = "You are a helpful assistant."
     init_error: str | None = None
+    _session_name: str | None = None  # user-set label (/rename) shown in /resume
 
     # Worker + cross-thread coordination.
     _inbox: _queue.Queue = field(default_factory=_queue.Queue)
@@ -232,6 +233,12 @@ class _AgentSession:
         if subtype == "list_sessions":
             self._reply(request_id, {"sessions": _list_saved_sessions()})
             return
+        if subtype == "rename":
+            name = inner.get("name")
+            self._session_name = str(name).strip() if isinstance(name, str) and name.strip() else None
+            self._save_session()
+            self._reply(request_id, {"ok": True, "name": self._session_name or ""})
+            return
         if subtype == "resume":
             self._do_resume(request_id, inner.get("session_id"))
             return
@@ -311,6 +318,7 @@ class _AgentSession:
                 "updated_at": time.time(),
                 "message_count": len(msgs),
                 "preview": _first_prompt_preview(msgs),
+                "name": self._session_name,
                 "conversation": self.session.conversation.to_dict(),
             }
             (d / f"{self.session_id}.json").write_text(json.dumps(payload), encoding="utf-8")
@@ -901,6 +909,7 @@ def _list_saved_sessions(limit: int = 20) -> list[dict]:
                 "session_id": data.get("session_id", f.stem),
                 "updated_at": data.get("updated_at", 0),
                 "preview": data.get("preview", ""),
+                "name": data.get("name") or "",
                 "message_count": data.get("message_count", 0),
                 "model": data.get("model", ""),
             })

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -607,6 +607,19 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         client?.close()
         exit()
         return true
+      case 'rename': {
+        if (!arg) {
+          addEntry({ kind: 'system', text: 'usage: /rename <name>' })
+        } else if (client) {
+          void client.requestControl('rename', { name: arg }).then((r) => {
+            addEntry({
+              kind: r && r['ok'] ? 'system' : 'error',
+              text: r && r['ok'] ? `session renamed → ${arg}` : 'rename failed',
+            })
+          })
+        }
+        return true
+      }
       case 'resume': {
         if (client) {
           void client.requestControl('list_sessions').then((r) => {
@@ -616,7 +629,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
               return
             }
             const options = sessions.map((s) => {
-              const prev = String(s['preview'] || '(no preview)').slice(0, 50)
+              const prev = String(s['name'] || s['preview'] || '(no preview)').slice(0, 50)
               const age = relAge(Number(s['updated_at']) || 0)
               return `${prev}  ·  ${Number(s['message_count']) || 0} msgs${age ? `  ·  ${age}` : ''}`
             })

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -16,6 +16,7 @@ export interface SlashCommand {
     | 'compact'
     | 'rewind'
     | 'resume'
+    | 'rename'
     | 'theme'
     | 'export'
     | 'copy'
@@ -39,6 +40,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/compact', description: 'Summarize & compact the conversation: /compact [instructions]', kind: 'compact' },
   { name: '/rewind', description: 'Undo the last turn(s): /rewind [N]', kind: 'rewind' },
   { name: '/resume', description: 'Resume a saved session', kind: 'resume' },
+  { name: '/rename', description: 'Name the current session: /rename <name>', kind: 'rename' },
   { name: '/theme', description: 'Switch color theme: /theme <dark|light>', kind: 'theme' },
   { name: '/export', description: 'Save the transcript to a markdown file', kind: 'export' },
   { name: '/copy', description: "Copy the last response to the clipboard", kind: 'copy' },


### PR DESCRIPTION
## Summary
Rounds out the session chapter. A `rename` control sets a user label on the current session, persisted in the session file and shown in the `/resume` picker (name preferred over the auto-generated preview).

- **Backend**: `_session_name` field + `rename` control → set + re-save; `list_sessions` returns `name`.
- **Client**: `/rename <name>` → `rename` control; `/resume` labels use the name when set.

## Verification
Backend: rename → save → `list_sessions` returns `name: 'auth refactor'`. Server suite **80 pass**. Client **interactively verified**: `/rename auth work` sends `rename: {name:'auth work'}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)