### PR TITLE
feat(ui-tui): context-low warning (TokenWarning)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -952,6 +952,14 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         </Box>
       ) : null}
 
+      {contextUsage && contextUsage.percentage >= 80 ? (
+        <Box marginTop={1}>
+          <Text color={contextUsage.percentage >= 90 ? theme.error : theme.warn}>
+            {`⚠ Context ${Math.round(contextUsage.percentage)}% used — run /compact to free space`}
+          </Text>
+        </Box>
+      ) : null}
+
       {permission ? (
         <PermissionDialog toolName={permission.toolName} input={permission.input} />
       ) : picker ? (


### PR DESCRIPTION
## Summary
Ports the original's `TokenWarning` (inventory §7). When context usage (from the `get_context_usage` pull) reaches **≥80%**, a warning shows above the input — **amber** at 80–89%, **red** at ≥90% — nudging `/compact`.

## Verification
`tsc` + build clean. Interactively verified at 60% (no warning), 88% (`⚠ Context 88% used — run /compact to free space`, amber), 94% (red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)