### PR TITLE
feat(ui-tui): fullscreen sticky prompt header

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -994,7 +994,12 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       {FULLSCREEN ? (
         <Box flexGrow={1} flexDirection="column" overflow="hidden">
           {scrollOffset > 0 ? (
-            <Text color={theme.dim}>{`↑ ${scrollOffset} newer — PgDn to follow`}</Text>
+            <Text color={theme.dim} wrap="truncate-end">
+              {(() => {
+                const lastPrompt = [...entries].reverse().find((e) => e.kind === 'user')?.text
+                return `┊ ${lastPrompt ? lastPrompt : ''}  · ↑ ${scrollOffset} newer — PgDn to follow`
+              })()}
+            </Text>
           ) : null}
           {visibleEntries.map(renderEntry)}
         </Box>


### PR DESCRIPTION
## Summary
Fullscreen-chapter follow-up (inventory §7 "sticky prompt header"). When scrolled up in fullscreen, the top line pins the current task (most recent user prompt) + the `↑ N newer — PgDn to follow` indicator, so you keep context while browsing history. Double-gated (fullscreen only) → no effect on inline mode.

## Verification
`tsc` + build clean. Interactively verified: after submitting `implement the parser` + 12 steps, PgUp shows top line `┊ implement the parser  · ↑ 5 newer — PgDn to follow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)