### PR TITLE
feat(ui-tui): vim modal input (/vim)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -17,6 +17,7 @@ import { Message } from './components/Message.js'
 import { PermissionDialog } from './components/PermissionDialog.js'
 import { SlashMenu } from './components/SlashMenu.js'
 import { FileMenu } from './components/FileMenu.js'
+import { VimInput } from './components/VimInput.js'
 import { searchFiles } from './fileIndex.js'
 import { Spinner } from './components/Spinner.js'
 import { StatusBar } from './components/StatusBar.js'
@@ -230,6 +231,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const [, setThemeVersion] = useState(0) // bumped on /theme to repaint the dynamic UI
   const [scrollOffset, setScrollOffset] = useState(0) // fullscreen: entries hidden from the bottom
   const [txFind, setTxFind] = useState<string | null>(null) // fullscreen Ctrl+F find query (null = closed)
+  const [vimMode, setVimMode] = useState(false) // /vim modal editing
 
   // Fullscreen uses the terminal's alternate screen so the bounded transcript
   // viewport renders in place (no scrollback spam). Enter on mount, restore on exit.
@@ -695,8 +697,8 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         return
       }
     }
-    // Input history recall with ↑/↓ when no menu is open (readline-style).
-    if (!slashOpen && !atOpen) {
+    // Input history recall with ↑/↓ when no menu is open (vim owns its own keys).
+    if (!slashOpen && !atOpen && !vimMode) {
       const h = historyRef.current
       if (key.upArrow && h.length > 0) {
         if (histIdx === -1) draftRef.current = input
@@ -739,6 +741,12 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         client?.close()
         exit()
         return true
+      case 'vim': {
+        const next = !vimMode
+        setVimMode(next)
+        addEntry({ kind: 'system', text: `vim mode ${next ? 'on' : 'off'}` })
+        return true
+      }
       case 'rename': {
         if (!arg) {
           addEntry({ kind: 'system', text: 'usage: /rename <name>' })
@@ -1181,30 +1189,51 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
             paddingX={1}
             width="100%"
           >
-            <Text color={ready ? theme.accent : theme.dim}>{busy ? '… ' : '❯ '}</Text>
-            <TextInput
-              value={input}
-              onChange={(v) => {
-                // Collapse a large paste to a placeholder so it doesn't flood
-                // the input (the original's [Pasted text #N]). Normal typing
-                // inserts one char at a time, so this only fires on paste.
-                const { ins, p, s } = diffInsert(input, v)
-                const nLines = ins ? ins.split('\n').length : 0
-                if (ins && (ins.length > 200 || nLines >= 4)) {
-                  const n = (pasteCounter.current += 1)
-                  const token = `[Pasted text #${n}${nLines > 1 ? ` +${nLines} lines` : ''}]`
-                  pasteStore.current.set(token, ins)
-                  setInput(v.slice(0, p) + token + (s ? v.slice(v.length - s) : ''))
-                } else {
+            {vimMode ? (
+              <VimInput
+                value={input}
+                onChange={(v) => {
                   setInput(v)
-                }
-                setSlashSel(0)
-                setAtSel(0)
-                setHistIdx(-1)
-              }}
-              onSubmit={onSubmit}
-              placeholder={ready ? 'Type a message, or / for commands…' : 'starting agent-server…'}
-            />
+                  setSlashSel(0)
+                  setAtSel(0)
+                  setHistIdx(-1)
+                }}
+                onSubmit={onSubmit}
+                // Stay active during slash/@ menus: VimInput ignores nav keys
+                // (App handles ↑/↓/Tab) and its Enter routes through onSubmit,
+                // which performs menu completion. Gating it off here would strand
+                // typing after the first "/" or "@".
+                active
+                placeholder={ready ? 'Type a message, or / for commands…' : 'starting agent-server…'}
+              />
+            ) : (
+              <>
+                <Text color={ready ? theme.accent : theme.dim}>{busy ? '… ' : '❯ '}</Text>
+                <TextInput
+                  value={input}
+                  onChange={(v) => {
+                    // Collapse a large paste to a placeholder so it doesn't flood
+                    // the input (the original's [Pasted text #N]). Normal typing
+                    // inserts one char at a time, so this only fires on paste.
+                    const { ins, p, s } = diffInsert(input, v)
+                    const nLines = ins ? ins.split('\n').length : 0
+                    if (ins && (ins.length > 200 || nLines >= 4)) {
+                      const n = (pasteCounter.current += 1)
+                      const token = `[Pasted text #${n}${nLines > 1 ? ` +${nLines} lines` : ''}]`
+                      pasteStore.current.set(token, ins)
+                      setInput(v.slice(0, p) + token + (s ? v.slice(v.length - s) : ''))
+                    } else {
+                      setInput(v)
+                    }
+                    setSlashSel(0)
+                    setAtSel(0)
+                    setHistIdx(-1)
+                  }}
+                  onSubmit={onSubmit}
+                  placeholder={ready ? 'Type a message, or / for commands…' : 'starting agent-server…'}
+                />
+              </>
+            )}
           </Box>
         </>
       )}

--- a/ui-tui/src/components/VimInput.tsx
+++ b/ui-tui/src/components/VimInput.tsx
@@ -1,0 +1,124 @@
+/**
+ * Minimal vim modal input (the original's /vim), used in place of ink-text-input
+ * only when vim mode is on — so the default input path is untouched. Edits the
+ * shared `value` (so the slash/@ menus + history still work off it) and owns a
+ * cursor + normal/insert mode via its own useInput (active only when no menu /
+ * dialog is up, so App's menu navigation keeps working).
+ *
+ * Normal: h/l/0/$ move · w/b word · i/a/I/A insert · x delete · D kill-to-end ·
+ *   Enter submit.  Insert: type · ←/→ · Backspace · Esc→normal · Enter submit.
+ */
+import { Text, useInput } from 'ink'
+import React, { useState } from 'react'
+import { theme } from '../theme.js'
+
+interface Props {
+  value: string
+  onChange: (v: string) => void
+  onSubmit: (v: string) => void
+  active: boolean
+  placeholder?: string
+}
+
+const WORD = /[\p{L}\p{N}_]/u
+function nextWord(s: string, c: number): number {
+  let i = c
+  while (i < s.length && WORD.test(s[i] ?? '')) i++ // end current word
+  while (i < s.length && !WORD.test(s[i] ?? '')) i++ // skip gap
+  return i
+}
+function prevWord(s: string, c: number): number {
+  let i = c - 1
+  while (i > 0 && !WORD.test(s[i] ?? '')) i-- // skip gap
+  while (i > 0 && WORD.test(s[i - 1] ?? '')) i-- // to word start
+  return Math.max(0, i)
+}
+
+export function VimInput({ value, onChange, onSubmit, active, placeholder }: Props): React.ReactElement {
+  const [normal, setNormal] = useState(false) // start in insert (like the original entering /vim)
+  const [cursor, setCursor] = useState(value.length)
+  const clamp = (c: number, max = value.length): number => Math.max(0, Math.min(max, c))
+
+  useInput(
+    (input, key) => {
+      if (!active) return
+      if (normal) {
+        if (input === 'i') return setNormal(false)
+        if (input === 'a') {
+          setCursor((c) => clamp(c + 1))
+          return setNormal(false)
+        }
+        if (input === 'A') {
+          setCursor(value.length)
+          return setNormal(false)
+        }
+        if (input === 'I') {
+          setCursor(0)
+          return setNormal(false)
+        }
+        if (input === 'h' || key.leftArrow) return setCursor((c) => clamp(c - 1))
+        if (input === 'l' || key.rightArrow) return setCursor((c) => clamp(c + 1))
+        if (input === '0') return setCursor(0)
+        if (input === '$') return setCursor(Math.max(0, value.length - 1))
+        if (input === 'w') return setCursor(nextWord(value, cursor))
+        if (input === 'b') return setCursor(prevWord(value, cursor))
+        if (input === 'x') {
+          if (value) {
+            onChange(value.slice(0, cursor) + value.slice(cursor + 1))
+            setCursor((c) => clamp(c, Math.max(0, value.length - 2)))
+          }
+          return
+        }
+        if (input === 'D') return onChange(value.slice(0, cursor))
+        if (key.return) return onSubmit(value)
+        return // normal mode swallows everything else
+      }
+      // insert mode
+      if (key.escape) {
+        setNormal(true)
+        setCursor((c) => Math.max(0, c - 1))
+        return
+      }
+      if (key.return) return onSubmit(value)
+      if (key.leftArrow) return setCursor((c) => clamp(c - 1))
+      if (key.rightArrow) return setCursor((c) => clamp(c + 1))
+      if (key.backspace || key.delete) {
+        if (cursor > 0) {
+          onChange(value.slice(0, cursor - 1) + value.slice(cursor))
+          setCursor((c) => c - 1)
+        }
+        return
+      }
+      if (input && !key.ctrl && !key.meta) {
+        onChange(value.slice(0, cursor) + input + value.slice(cursor))
+        setCursor((c) => c + input.length)
+      }
+    },
+    { isActive: active },
+  )
+
+  // Render: mode tag + text with a block cursor (reverse video).
+  const cur = clamp(cursor)
+  const empty = value.length === 0
+  const tag = normal ? '[N] ' : '[I] '
+  if (empty && placeholder) {
+    return (
+      <Text>
+        <Text color={normal ? theme.warn : theme.accent}>{tag}</Text>
+        <Text inverse> </Text>
+        <Text color={theme.dim}>{placeholder}</Text>
+      </Text>
+    )
+  }
+  const before = value.slice(0, cur)
+  const at = value.slice(cur, cur + 1) || ' '
+  const after = value.slice(cur + 1)
+  return (
+    <Text>
+      <Text color={normal ? theme.warn : theme.accent}>{tag}</Text>
+      <Text>{before}</Text>
+      <Text inverse>{at}</Text>
+      <Text>{after}</Text>
+    </Text>
+  )
+}

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -18,6 +18,7 @@ export interface SlashCommand {
     | 'resume'
     | 'rename'
     | 'theme'
+    | 'vim'
     | 'export'
     | 'copy'
     | 'doctor'
@@ -42,6 +43,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/resume', description: 'Resume a saved session', kind: 'resume' },
   { name: '/rename', description: 'Name the current session: /rename <name>', kind: 'rename' },
   { name: '/theme', description: 'Switch color theme: /theme <dark|light>', kind: 'theme' },
+  { name: '/vim', description: 'Toggle vim editing mode', kind: 'vim' },
   { name: '/export', description: 'Save the transcript to a markdown file', kind: 'export' },
   { name: '/copy', description: "Copy the last response to the clipboard", kind: 'copy' },
   { name: '/doctor', description: 'Show connection + session diagnostics', kind: 'doctor' },


### PR DESCRIPTION
## Summary
Ports the original's **vim editing mode**. Gated behind `/vim` — the default keeps `ink-text-input` untouched (**zero regression** to the 11 shipped input behaviors). This was the last "multi-day-only" item I'd deferred; testing made it tractable.

`VimInput` is a self-contained modal input with its own `useInput`:
- **insert**: type · ←/→ · Backspace · Esc→normal · Enter submit
- **normal**: `h`/`l`/`0`/`$` move · `w`/`b` word · `i`/`a`/`I`/`A` insert · `x` delete · `D` kill-to-end · Enter submit
- block cursor (reverse video) + `[N]`/`[I]` mode tag

### Integration (no regression to the input system)
- Edits the shared `input` state → slash/`@` menus keep filtering.
- Stays active during menus: ignores ↑/↓/Tab (App handles nav), routes Enter through `onSubmit` (which does menu completion) — so you can type a command through the menu in vim.
- App's ↑/↓ history is gated off in vim so VimInput owns its keys.

## Verification
Interactively verified: insert→`hello`, Esc→`[N]`, `0`+`x`→`ello`, `A`+` world`→submit `"ello world"`; typing `/vim` through the menu in vim then toggling off; **default input + slash menu unaffected** (`"hi there"` submits normally after toggle-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)