### PR TITLE
feat(tui+server): /branch — fork the current session

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -242,6 +242,9 @@ class _AgentSession:
         if subtype == "resume":
             self._do_resume(request_id, inner.get("session_id"))
             return
+        if subtype == "branch":
+            self._do_branch(request_id)
+            return
         if subtype == "clear":
             # Reset the conversation so /clear actually starts a fresh context
             # (not just the client screen). Idle-only.
@@ -324,6 +327,35 @@ class _AgentSession:
             (d / f"{self.session_id}.json").write_text(json.dumps(payload), encoding="utf-8")
         except Exception:  # noqa: BLE001 — persistence must never break a turn
             logger.debug("[agent-server] session save failed", exc_info=True)
+
+    def _do_branch(self, request_id: object) -> None:
+        """Fork the current conversation to a new saved session (the original's
+        /branch). Read-only on the live session — just writes a copy under a new
+        id so /resume can switch to it later."""
+        try:
+            if self.session is None or not self.session.conversation.messages:
+                self._reply(request_id, {"ok": False, "error": "nothing to branch"})
+                return
+            msgs = self.session.conversation.messages
+            new_id = f"{self.session_id}-b{_uuid.uuid4().hex[:6]}"
+            base = self._session_name or _first_prompt_preview(msgs) or self.session_id
+            d = _sessions_dir()
+            d.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "session_id": new_id,
+                "model": getattr(self.provider, "model", None) or self.config.model or "",
+                "cwd": self.cwd,
+                "updated_at": time.time(),
+                "message_count": len(msgs),
+                "preview": _first_prompt_preview(msgs),
+                "name": f"branch of {base}",
+                "conversation": self.session.conversation.to_dict(),
+            }
+            (d / f"{new_id}.json").write_text(json.dumps(payload), encoding="utf-8")
+            self._reply(request_id, {"ok": True, "session_id": new_id})
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[agent-server] branch failed")
+            self._reply(request_id, {"ok": False, "error": str(exc)})
 
     def _do_resume(self, request_id: object, session_id: object) -> None:
         """Load a saved conversation into this session (the original's /resume).

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -760,6 +760,20 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         }
         return true
       }
+      case 'branch': {
+        if (client) {
+          void client.requestControl('branch').then((r) => {
+            addEntry({
+              kind: r && r['ok'] ? 'system' : 'error',
+              text:
+                r && r['ok']
+                  ? `⎇ branched to ${String(r['session_id'])} — /resume to switch`
+                  : `branch failed: ${r && r['error'] ? String(r['error']) : 'no response'}`,
+            })
+          })
+        }
+        return true
+      }
       case 'resume': {
         if (client) {
           void client.requestControl('list_sessions').then((r) => {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -16,6 +16,7 @@ export interface SlashCommand {
     | 'compact'
     | 'rewind'
     | 'resume'
+    | 'branch'
     | 'rename'
     | 'theme'
     | 'vim'
@@ -41,6 +42,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/compact', description: 'Summarize & compact the conversation: /compact [instructions]', kind: 'compact' },
   { name: '/rewind', description: 'Undo the last turn(s): /rewind [N]', kind: 'rewind' },
   { name: '/resume', description: 'Resume a saved session', kind: 'resume' },
+  { name: '/branch', description: 'Fork the current session to a new one', kind: 'branch' },
   { name: '/rename', description: 'Name the current session: /rename <name>', kind: 'rename' },
   { name: '/theme', description: 'Switch color theme: /theme <dark|light>', kind: 'theme' },
   { name: '/vim', description: 'Toggle vim editing mode', kind: 'vim' },


### PR DESCRIPTION
## Summary
Completes the session-persistence chapter (inventory §2 session branching). A `branch` control writes a copy of the current conversation under a new id (name `branch of <…>`), **read-only** on the live session; `/resume` can switch to it later.

- **Backend**: `_do_branch` → new `<id>-b<hex>.json` with the current conversation.
- **Client**: `/branch` → confirms the new session id.

## Verification
`_do_branch` writes the fork (shows in `list_sessions` as `branch of build the thing`); server suite **80 pass**; client **interactively verified** (`/branch` sends `branch`, shows `⎇ branched to …`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)