### PR TITLE
feat(server): wire MCP servers into the agent-server (functional MCP)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -112,6 +112,7 @@ class _AgentSession:
     system_prompt: Any = "You are a helpful assistant."
     init_error: str | None = None
     _session_name: str | None = None  # user-set label (/rename) shown in /resume
+    _mcp_runtime: Any = None  # McpRuntime (connected MCP servers) when configured
 
     # Worker + cross-thread coordination.
     _inbox: _queue.Queue = field(default_factory=_queue.Queue)
@@ -703,6 +704,12 @@ class _AgentSession:
             await asyncio.get_running_loop().run_in_executor(
                 None, lambda: worker.join(timeout=5.0)
             )
+        if self._mcp_runtime is not None:
+            try:
+                self._mcp_runtime.shutdown()  # disconnect MCP servers + stop their loop
+            except Exception:  # noqa: BLE001
+                logger.debug("[agent-server] MCP shutdown failed", exc_info=True)
+            self._mcp_runtime = None
 
 
 def make_spawn_agent(config: AgentServerConfig | None = None):
@@ -797,6 +804,28 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
             deny = {n.lower() for n in cfg.disallowed_tools}
             _filter_registry(registry, keep=lambda n: n.lower() not in deny)
 
+        # Connect configured MCP servers (guarded: no servers ⇒ no-op). Their
+        # tools run on McpRuntime's dedicated loop so they survive the per-turn
+        # asyncio.run. Registered after allow/deny filtering so an MCP-enabling
+        # user always gets them.
+        try:
+            from src.server.mcp_runtime import McpRuntime
+
+            mcp_rt = McpRuntime()
+            if mcp_rt.start():
+                for mtool in mcp_rt.tools:
+                    try:
+                        registry.register(mtool)
+                    except Exception:  # noqa: BLE001
+                        logger.debug("[mcp] register failed: %s", getattr(mtool, "name", "?"), exc_info=True)
+                sess._mcp_runtime = mcp_rt
+                logger.info(
+                    "[agent-server] MCP: %d tool(s) from %d server(s)",
+                    len(mcp_rt.tools), len(mcp_rt.servers),
+                )
+        except Exception:  # noqa: BLE001 — MCP must never break startup
+            logger.debug("[agent-server] MCP bootstrap skipped", exc_info=True)
+
         workspace_root = Path(sess.cwd)
         mode = perm_mode or cfg.permission_mode or "default"
         bypass = mode == "bypassPermissions"
@@ -812,6 +841,8 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
             abort_controller=AbortController(),
         )
         tool_context.options.is_non_interactive_session = True
+        if sess._mcp_runtime is not None:
+            tool_context.mcp_clients = sess._mcp_runtime.clients  # server-name catalog for the agent tool
 
         try:
             from src.outputStyles import resolve_output_style

--- a/tests/server/test_mcp_runtime.py
+++ b/tests/server/test_mcp_runtime.py
@@ -50,6 +50,32 @@ def test_runtime_connects_lists_and_calls(monkeypatch, tmp_path: Path) -> None:
         rt.shutdown()
 
 
+def test_mcp_tools_register_into_default_registry(monkeypatch, tmp_path: Path) -> None:
+    """The agent-server wiring: MCP tools register into a build_default_registry
+    and are callable by name (what the model's tool dispatch does)."""
+    _configure(monkeypatch, tmp_path)
+    from src.tool_system.build_tool import find_tool_by_name
+    from src.tool_system.defaults import build_default_registry
+
+    class _StubProvider:
+        model = "stub"
+
+    registry = build_default_registry(provider=_StubProvider())
+    rt = McpRuntime()
+    try:
+        assert rt.start() is True
+        for mtool in rt.tools:
+            registry.register(mtool)
+        tools = list(registry.list_tools())
+        tool = find_tool_by_name(tools, "mcp__test-server__echo")
+        assert tool is not None
+        res = tool.call({"message": "via registry"}, ToolContext(workspace_root="."))
+        assert res.is_error is False
+        assert "via registry" in res.output
+    finally:
+        rt.shutdown()
+
+
 def test_runtime_no_servers_is_noop(monkeypatch) -> None:
     import src.services.mcp.config as mcpconfig
 


### PR DESCRIPTION
## Summary
Second step of the MCP chapter — **MCP is now functional end-to-end in clawcodex** (it was unwired *and* bridge-broken before).

`_build_runtime` now:
- starts `McpRuntime` (**guarded**: no configured servers ⇒ no-op),
- registers each connected server's tools into the registry so the model sees `mcp__<server>__<tool>` and can call them (dispatched through McpRuntime's loop-correct bridge),
- sets `tool_context.mcp_clients` (server-name catalog for the agent tool),
- shuts the runtime down on session close.

## Verification
With the repo's stdio mock server configured, the MCP tool **registers into a real `build_default_registry` and is callable by name** (`via registry`, no error). No-MCP path unchanged — **83 server tests** (was 82).

## Next
`/mcp` client command to list connected servers/tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)