### PR TITLE
feat(tui+server): /mcp — list connected MCP servers + tools

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -246,6 +246,15 @@ class _AgentSession:
         if subtype == "branch":
             self._do_branch(request_id)
             return
+        if subtype == "list_mcp":
+            rt = self._mcp_runtime
+            servers = (
+                [{"name": n, "tools": tools} for n, tools in rt.servers.items()]
+                if rt is not None
+                else []
+            )
+            self._reply(request_id, {"servers": servers})
+            return
         if subtype == "clear":
             # Reset the conversation so /clear actually starts a fresh context
             # (not just the client screen). Idle-only.

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -760,6 +760,23 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         }
         return true
       }
+      case 'mcp': {
+        if (client) {
+          void client.requestControl('list_mcp').then((r) => {
+            const servers = Array.isArray(r?.['servers']) ? (r['servers'] as Record<string, unknown>[]) : []
+            if (!servers.length) {
+              addEntry({ kind: 'system', text: 'no MCP servers connected (configure servers in .mcp.json / config.json)' })
+              return
+            }
+            const lines = servers.map((s) => {
+              const tools = Array.isArray(s['tools']) ? (s['tools'] as string[]) : []
+              return `● ${String(s['name'])} — ${tools.length} tool${tools.length === 1 ? '' : 's'}: ${tools.join(', ')}`
+            })
+            addEntry({ kind: 'system', text: `MCP servers:\n${lines.join('\n')}` })
+          })
+        }
+        return true
+      }
       case 'branch': {
         if (client) {
           void client.requestControl('branch').then((r) => {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -20,6 +20,7 @@ export interface SlashCommand {
     | 'rename'
     | 'theme'
     | 'vim'
+    | 'mcp'
     | 'export'
     | 'copy'
     | 'doctor'
@@ -48,6 +49,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/vim', description: 'Toggle vim editing mode', kind: 'vim' },
   { name: '/export', description: 'Save the transcript to a markdown file', kind: 'export' },
   { name: '/copy', description: "Copy the last response to the clipboard", kind: 'copy' },
+  { name: '/mcp', description: 'List connected MCP servers and their tools', kind: 'mcp' },
   { name: '/doctor', description: 'Show connection + session diagnostics', kind: 'doctor' },
   { name: '/quit', description: 'Exit the TUI', kind: 'quit' },
 ]


### PR DESCRIPTION
## Summary
Final piece of the MCP chapter. A `list_mcp` control reports connected servers + tool names from `McpRuntime`; the client `/mcp` command renders them (or a hint to configure `.mcp.json` when none are connected).

**MCP is now functional end-to-end in clawcodex**: connect (`McpRuntime`, loop-correct) → register into the registry (model calls `mcp__server__tool`) → `/mcp` to inspect.

## Verification
Populated → `● test-server — 2 tools: echo, add`; empty → config hint. Server suite **83 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)