### PR TITLE
feat(ui-tui): /cost + /usage session summary

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -761,6 +761,19 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         }
         return true
       }
+      case 'cost': {
+        const cost = `$${(sessionCost || 0).toFixed(4)}`
+        const cu = contextUsage
+        const ctxPart = cu
+          ? ` · ${Math.round(cu.percentage)}% context (${cu.totalTokens.toLocaleString()}/${cu.maxTokens.toLocaleString()} tokens)`
+          : ''
+        const prompts = entries.filter((e) => e.kind === 'user').length
+        addEntry({
+          kind: 'system',
+          text: `Session: ${prompts} prompt${prompts === 1 ? '' : 's'} · ${cost}${ctxPart}`,
+        })
+        return true
+      }
       case 'mcp': {
         if (client) {
           void client.requestControl('list_mcp').then((r) => {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -21,6 +21,7 @@ export interface SlashCommand {
     | 'theme'
     | 'vim'
     | 'mcp'
+    | 'cost'
     | 'export'
     | 'copy'
     | 'doctor'
@@ -40,6 +41,8 @@ export const SLASH_COMMANDS: SlashCommand[] = [
     control: 'set_permission_mode',
   },
   { name: '/context', description: 'Show context-window usage by category', kind: 'context' },
+  { name: '/cost', description: 'Show session cost and token usage', kind: 'cost' },
+  { name: '/usage', description: 'Show token usage and context window', kind: 'cost' },
   { name: '/compact', description: 'Summarize & compact the conversation: /compact [instructions]', kind: 'compact' },
   { name: '/rewind', description: 'Undo the last turn(s): /rewind [N]', kind: 'rewind' },
   { name: '/resume', description: 'Resume a saved session', kind: 'resume' },


### PR DESCRIPTION
## Summary
Ports the original's cost/usage commands (inventory §2). `/cost` and `/usage` show a one-line session summary: prompt count · cumulative cost (USD) · context-window % with token counts (used/max), from the `sessionCost` + `get_context_usage` data already tracked.

## Verification
`/cost` → `Session: N prompts · $X · 42% context (84,000/200,000 tokens)`. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)