### PR TITLE
feat(ui-tui): /init — scaffold CLAUDE.md

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -761,6 +761,18 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         }
         return true
       }
+      case 'init': {
+        if (client && ready && !busy && permissions.length === 0) {
+          dispatchPrompt(
+            'Analyze this codebase and create a CLAUDE.md file capturing: the build, lint, and ' +
+              'test commands; the high-level architecture; and any conventions a new contributor ' +
+              'should know. If a CLAUDE.md already exists, improve it rather than duplicating it.',
+          )
+        } else {
+          addEntry({ kind: 'system', text: 'cannot /init right now (agent busy or not ready)' })
+        }
+        return true
+      }
       case 'cost': {
         const cost = `$${(sessionCost || 0).toFixed(4)}`
         const cu = contextUsage

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -22,6 +22,7 @@ export interface SlashCommand {
     | 'vim'
     | 'mcp'
     | 'cost'
+    | 'init'
     | 'export'
     | 'copy'
     | 'doctor'
@@ -53,6 +54,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/export', description: 'Save the transcript to a markdown file', kind: 'export' },
   { name: '/copy', description: "Copy the last response to the clipboard", kind: 'copy' },
   { name: '/mcp', description: 'List connected MCP servers and their tools', kind: 'mcp' },
+  { name: '/init', description: 'Analyze the codebase and create/improve CLAUDE.md', kind: 'init' },
   { name: '/doctor', description: 'Show connection + session diagnostics', kind: 'doctor' },
   { name: '/quit', description: 'Exit the TUI', kind: 'quit' },
 ]


### PR DESCRIPTION
## Summary
Ports the original's `/init` (inventory §2). Dispatches a codebase-analysis prompt asking the agent to create or improve `CLAUDE.md` (build/lint/test commands, architecture, conventions). Guarded when the agent is busy/not-ready.

## Verification
`/init` dispatches the CLAUDE.md prompt to the backend (1 user message, contains "CLAUDE.md"). typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)