### PR TITLE
feat(tui+server): /permissions — show active mode + rules

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -246,6 +246,20 @@ class _AgentSession:
         if subtype == "branch":
             self._do_branch(request_id)
             return
+        if subtype == "list_permissions":
+            ctx = self.tool_context.permission_context if self.tool_context else None
+            mode, allow, deny = "default", [], []
+            if ctx is not None:
+                try:
+                    from src.permissions import get_allow_rules, get_deny_rules
+
+                    mode = getattr(ctx, "mode", "default") or "default"
+                    allow = [_fmt_rule(r) for r in get_allow_rules(ctx)]
+                    deny = [_fmt_rule(r) for r in get_deny_rules(ctx)]
+                except Exception:  # noqa: BLE001
+                    logger.debug("[agent-server] list_permissions failed", exc_info=True)
+            self._reply(request_id, {"mode": mode, "allow": allow, "deny": deny})
+            return
         if subtype == "list_mcp":
             rt = self._mcp_runtime
             servers = (
@@ -941,6 +955,14 @@ def _result_message(
     if error is not None:
         payload["error"] = error
     return payload
+
+
+def _fmt_rule(rule: Any) -> str:
+    """Render a PermissionRule as e.g. ``Bash(ls:*)`` or ``Read`` (for /permissions)."""
+    v = getattr(rule, "rule_value", None)
+    tool = getattr(v, "tool_name", "") or "?"
+    content = getattr(v, "rule_content", None)
+    return f"{tool}({content})" if content else tool
 
 
 def _sessions_dir() -> Path:

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -786,6 +786,21 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         })
         return true
       }
+      case 'permissions': {
+        if (client) {
+          void client.requestControl('list_permissions').then((r) => {
+            const mode = String(r?.['mode'] ?? 'default')
+            const allow = Array.isArray(r?.['allow']) ? (r['allow'] as string[]) : []
+            const deny = Array.isArray(r?.['deny']) ? (r['deny'] as string[]) : []
+            const lines = [`mode: ${mode}`]
+            if (allow.length) lines.push(`allow: ${allow.join(', ')}`)
+            if (deny.length) lines.push(`deny: ${deny.join(', ')}`)
+            if (!allow.length && !deny.length) lines.push('(no explicit allow/deny rules)')
+            addEntry({ kind: 'system', text: `Permissions:\n${lines.join('\n')}` })
+          })
+        }
+        return true
+      }
       case 'mcp': {
         if (client) {
           void client.requestControl('list_mcp').then((r) => {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -23,6 +23,7 @@ export interface SlashCommand {
     | 'mcp'
     | 'cost'
     | 'init'
+    | 'permissions'
     | 'export'
     | 'copy'
     | 'doctor'
@@ -54,6 +55,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/export', description: 'Save the transcript to a markdown file', kind: 'export' },
   { name: '/copy', description: "Copy the last response to the clipboard", kind: 'copy' },
   { name: '/mcp', description: 'List connected MCP servers and their tools', kind: 'mcp' },
+  { name: '/permissions', description: 'Show active permission mode and rules', kind: 'permissions' },
   { name: '/init', description: 'Analyze the codebase and create/improve CLAUDE.md', kind: 'init' },
   { name: '/doctor', description: 'Show connection + session diagnostics', kind: 'doctor' },
   { name: '/quit', description: 'Exit the TUI', kind: 'quit' },


### PR DESCRIPTION
## Summary
Ports the original's `/permissions` (inventory §2). A `list_permissions` control returns the current permission mode + allow/deny rules (via `get_allow_rules`/`get_deny_rules`), formatted as e.g. `Bash(ls:*)` / `Read`; the client `/permissions` command renders them.

## Verification
`/permissions` → `mode: acceptEdits · allow: Bash(ls:*), Read · deny: Bash(rm:*)`. Server suite **83 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)