### PR TITLE
feat(ui-tui): /memory — show loaded CLAUDE.md files

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -17,6 +17,8 @@ import { Message } from './components/Message.js'
 import { PermissionDialog } from './components/PermissionDialog.js'
 import { SlashMenu } from './components/SlashMenu.js'
 import { exec } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
 import { FileMenu } from './components/FileMenu.js'
 import { VimInput } from './components/VimInput.js'
 import { searchFiles } from './fileIndex.js'
@@ -759,6 +761,22 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
             })
           })
         }
+        return true
+      }
+      case 'memory': {
+        const files = [
+          { label: 'project', path: join(process.cwd(), 'CLAUDE.md') },
+          { label: 'global', path: join(homedir(), '.claude', 'CLAUDE.md') },
+        ]
+        const lines = files.map((f) => {
+          try {
+            const n = readFileSync(f.path, 'utf8').split('\n').length
+            return `${f.label}: ${f.path} (${n} lines)`
+          } catch {
+            return `${f.label}: ${f.path} (not found)`
+          }
+        })
+        addEntry({ kind: 'system', text: `Memory files:\n${lines.join('\n')}` })
         return true
       }
       case 'init': {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -24,6 +24,7 @@ export interface SlashCommand {
     | 'cost'
     | 'init'
     | 'permissions'
+    | 'memory'
     | 'export'
     | 'copy'
     | 'doctor'
@@ -57,6 +58,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/mcp', description: 'List connected MCP servers and their tools', kind: 'mcp' },
   { name: '/permissions', description: 'Show active permission mode and rules', kind: 'permissions' },
   { name: '/init', description: 'Analyze the codebase and create/improve CLAUDE.md', kind: 'init' },
+  { name: '/memory', description: 'Show the loaded CLAUDE.md memory files', kind: 'memory' },
   { name: '/doctor', description: 'Show connection + session diagnostics', kind: 'doctor' },
   { name: '/quit', description: 'Exit the TUI', kind: 'quit' },
 ]


### PR DESCRIPTION
## Summary
Ports the original's `/memory` (inventory §2). Lists the project (`./CLAUDE.md`) and global (`~/.claude/CLAUDE.md`) memory files with paths + line counts (or "not found"). Pure client-side.

## Verification
`/memory` → `project: …/CLAUDE.md (not found) · global: ~/.claude/CLAUDE.md (33 lines)`. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)