### PR TITLE
feat(tui+server): /agents — list available subagent types

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -246,6 +246,21 @@ class _AgentSession:
         if subtype == "branch":
             self._do_branch(request_id)
             return
+        if subtype == "list_agents":
+            agents: list[dict] = []
+            try:
+                from src.agent.load_agents_dir import get_agent_definitions_with_overrides
+
+                for a in get_agent_definitions_with_overrides(self.cwd):
+                    agents.append({
+                        "type": a.agent_type,
+                        "source": getattr(a, "source", "built-in"),
+                        "when": getattr(a, "when_to_use", "") or "",
+                    })
+            except Exception:  # noqa: BLE001
+                logger.debug("[agent-server] list_agents failed", exc_info=True)
+            self._reply(request_id, {"agents": agents})
+            return
         if subtype == "list_permissions":
             ctx = self.tool_context.permission_context if self.tool_context else None
             mode, allow, deny = "default", [], []

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -804,6 +804,23 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         })
         return true
       }
+      case 'agents': {
+        if (client) {
+          void client.requestControl('list_agents').then((r) => {
+            const agents = Array.isArray(r?.['agents']) ? (r['agents'] as Record<string, unknown>[]) : []
+            if (!agents.length) {
+              addEntry({ kind: 'system', text: 'no agents available' })
+              return
+            }
+            const lines = agents.map((a) => {
+              const when = String(a['when'] || '').replace(/\s+/g, ' ').slice(0, 60)
+              return `● ${String(a['type'])} (${String(a['source'])})${when ? ` — ${when}` : ''}`
+            })
+            addEntry({ kind: 'system', text: `Agents (${agents.length}):\n${lines.join('\n')}` })
+          })
+        }
+        return true
+      }
       case 'permissions': {
         if (client) {
           void client.requestControl('list_permissions').then((r) => {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -25,6 +25,7 @@ export interface SlashCommand {
     | 'init'
     | 'permissions'
     | 'memory'
+    | 'agents'
     | 'export'
     | 'copy'
     | 'doctor'
@@ -57,6 +58,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/copy', description: "Copy the last response to the clipboard", kind: 'copy' },
   { name: '/mcp', description: 'List connected MCP servers and their tools', kind: 'mcp' },
   { name: '/permissions', description: 'Show active permission mode and rules', kind: 'permissions' },
+  { name: '/agents', description: 'List available subagent types', kind: 'agents' },
   { name: '/init', description: 'Analyze the codebase and create/improve CLAUDE.md', kind: 'init' },
   { name: '/memory', description: 'Show the loaded CLAUDE.md memory files', kind: 'memory' },
   { name: '/doctor', description: 'Show connection + session diagnostics', kind: 'doctor' },


### PR DESCRIPTION
## Summary
Ports the original's `/agents` (inventory §2). A `list_agents` control returns the merged agent definitions (`get_agent_definitions_with_overrides`) — type, source (built-in/project/user), when-to-use; the client `/agents` command renders them.

## Verification
Backend returns 4 built-ins (general-purpose/Explore/Plan/critic); client → `Agents (N): ● general-purpose (built-in) — …`. Server suite **83 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)