### PR TITLE
feat(ui-tui): /review, /security-review, /commit-message (prompt commands)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -779,6 +779,16 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         addEntry({ kind: 'system', text: `Memory files:\n${lines.join('\n')}` })
         return true
       }
+      case 'prompt': {
+        if (cmd.promptText) {
+          if (client && ready && !busy && permissions.length === 0) {
+            dispatchPrompt(cmd.promptText)
+          } else {
+            addEntry({ kind: 'system', text: `cannot run ${cmd.name} now (agent busy or not ready)` })
+          }
+        }
+        return true
+      }
       case 'init': {
         if (client && ready && !busy && permissions.length === 0) {
           dispatchPrompt(

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -26,12 +26,15 @@ export interface SlashCommand {
     | 'permissions'
     | 'memory'
     | 'agents'
+    | 'prompt'
     | 'export'
     | 'copy'
     | 'doctor'
     | 'send'
   /** for kind:'control' — the control_request subtype. */
   control?: string
+  /** for kind:'prompt' — the LLM-visible text the command expands to. */
+  promptText?: string
 }
 
 export const SLASH_COMMANDS: SlashCommand[] = [
@@ -60,6 +63,30 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/permissions', description: 'Show active permission mode and rules', kind: 'permissions' },
   { name: '/agents', description: 'List available subagent types', kind: 'agents' },
   { name: '/init', description: 'Analyze the codebase and create/improve CLAUDE.md', kind: 'init' },
+  {
+    name: '/review',
+    description: 'Review the current changes for bugs and quality',
+    kind: 'prompt',
+    promptText:
+      'Review the current changes (run `git diff`) for bugs, edge cases, and quality issues. ' +
+      'Be specific with file:line references and suggest concrete fixes.',
+  },
+  {
+    name: '/security-review',
+    description: 'Security review of the current changes',
+    kind: 'prompt',
+    promptText:
+      'Perform a security review of the current changes (run `git diff`), focusing on injection, ' +
+      'auth/authz, secrets, SSRF, and unsafe deserialization. Report findings with severity and fixes.',
+  },
+  {
+    name: '/commit-message',
+    description: 'Draft a commit message for the current changes',
+    kind: 'prompt',
+    promptText:
+      'Run `git diff --staged` (fall back to `git diff`) and draft a concise Conventional Commits ' +
+      'message for the changes. Output only the commit message.',
+  },
   { name: '/memory', description: 'Show the loaded CLAUDE.md memory files', kind: 'memory' },
   { name: '/doctor', description: 'Show connection + session diagnostics', kind: 'doctor' },
   { name: '/quit', description: 'Exit the TUI', kind: 'quit' },


### PR DESCRIPTION
## Summary
Ports the original's prompt-type commands (inventory §2). Adds a generic `kind:'prompt'` (with `promptText`) that expands to an LLM-visible prompt:
- `/review` — bug/quality review of `git diff`
- `/security-review` — OWASP-focused security review
- `/commit-message` — Conventional Commits draft

Guarded when the agent is busy/not-ready.

## Verification
`/security-review` dispatches its prompt to the backend (1 user message containing "security review"). typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)