### PR TITLE
feat(ui-tui): /config — show model, mode, available models

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -814,6 +814,19 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         })
         return true
       }
+      case 'config': {
+        if (client) {
+          void client.requestControl('get_settings').then((r) => {
+            const m = String(r?.['model'] ?? model)
+            const pm = String(r?.['permission_mode'] ?? mode)
+            const avail = Array.isArray(r?.['available_models']) ? (r['available_models'] as string[]) : []
+            const lines = [`model: ${m}`, `mode: ${pm}`, `server: ${serverLabel}`]
+            if (avail.length) lines.push(`available models: ${avail.slice(0, 12).join(', ')}`)
+            addEntry({ kind: 'system', text: `Config:\n${lines.join('\n')}` })
+          })
+        }
+        return true
+      }
       case 'agents': {
         if (client) {
           void client.requestControl('list_agents').then((r) => {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -26,6 +26,7 @@ export interface SlashCommand {
     | 'permissions'
     | 'memory'
     | 'agents'
+    | 'config'
     | 'prompt'
     | 'export'
     | 'copy'
@@ -62,6 +63,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/mcp', description: 'List connected MCP servers and their tools', kind: 'mcp' },
   { name: '/permissions', description: 'Show active permission mode and rules', kind: 'permissions' },
   { name: '/agents', description: 'List available subagent types', kind: 'agents' },
+  { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/init', description: 'Analyze the codebase and create/improve CLAUDE.md', kind: 'init' },
   {
     name: '/review',


### PR DESCRIPTION
## Summary
Ports the original's `/config` (inventory §2). Uses the existing `get_settings` control to show the current model, permission mode, server label, and available models.

## Verification
`/config` → `model: claude-opus-4-8 · mode: default · available models: …`. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)