### PR TITLE
feat(ui-tui): /diff and /stats

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -814,6 +814,25 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         })
         return true
       }
+      case 'diff': {
+        runBang('git --no-pager diff')
+        return true
+      }
+      case 'stats': {
+        const prompts = entries.filter((e) => e.kind === 'user').length
+        const tools = entries.filter((e) => e.kind === 'tool').length
+        const cu = contextUsage
+        const lines = [
+          `prompts: ${prompts}`,
+          `tool calls: ${tools}`,
+          `cost: $${(sessionCost || 0).toFixed(4)}`,
+        ]
+        if (cu) {
+          lines.push(`context: ${Math.round(cu.percentage)}% (${cu.totalTokens.toLocaleString()}/${cu.maxTokens.toLocaleString()})`)
+        }
+        addEntry({ kind: 'system', text: `Session stats:\n${lines.join('\n')}` })
+        return true
+      }
       case 'config': {
         if (client) {
           void client.requestControl('get_settings').then((r) => {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -27,6 +27,8 @@ export interface SlashCommand {
     | 'memory'
     | 'agents'
     | 'config'
+    | 'diff'
+    | 'stats'
     | 'prompt'
     | 'export'
     | 'copy'
@@ -64,6 +66,8 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/permissions', description: 'Show active permission mode and rules', kind: 'permissions' },
   { name: '/agents', description: 'List available subagent types', kind: 'agents' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
+  { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
+  { name: '/stats', description: 'Show session statistics', kind: 'stats' },
   { name: '/init', description: 'Analyze the codebase and create/improve CLAUDE.md', kind: 'init' },
   {
     name: '/review',


### PR DESCRIPTION
## Summary
Two more inventory §2 commands:
- `/diff` — shows the working-tree `git diff` (via the bash-mode runner).
- `/stats` — session statistics: prompt count, tool calls, cost USD, context-window % + tokens.

## Verification
`/stats` → `prompts: N · tool calls: N · cost: $X · context: …`; `/diff` runs `git diff`. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)