### PR TITLE
feat(ui-tui): unified ControlledInput with readline editing

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -7,7 +7,6 @@
  * line, over the Direct Connect protocol.
  */
 import { Box, Static, Text, useApp, useInput } from 'ink'
-import TextInput from 'ink-text-input'
 import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import React, { useEffect, useRef, useState } from 'react'
@@ -1171,6 +1170,24 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     }
   }
 
+  // Shared input onChange: collapse a large paste to a placeholder (the
+  // original's [Pasted text #N]) and reset menu/history selection.
+  const handleInputChange = (v: string): void => {
+    const { ins, p, s } = diffInsert(input, v)
+    const nLines = ins ? ins.split('\n').length : 0
+    if (ins && (ins.length > 200 || nLines >= 4)) {
+      const n = (pasteCounter.current += 1)
+      const token = `[Pasted text #${n}${nLines > 1 ? ` +${nLines} lines` : ''}]`
+      pasteStore.current.set(token, ins)
+      setInput(v.slice(0, p) + token + (s ? v.slice(v.length - s) : ''))
+    } else {
+      setInput(v)
+    }
+    setSlashSel(0)
+    setAtSel(0)
+    setHistIdx(-1)
+  }
+
   const onSubmit = (value: string): void => {
     const text = value.trim()
     if (!text) return
@@ -1368,53 +1385,23 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
             paddingX={1}
             width="100%"
           >
-            {vimMode ? (
-              <VimInput
-                value={input}
-                onChange={(v) => {
-                  setInput(v)
-                  setSlashSel(0)
-                  setAtSel(0)
-                  setHistIdx(-1)
-                }}
-                onSubmit={onSubmit}
-                // Stay active during slash/@ menus: VimInput ignores nav keys
-                // (App handles ↑/↓/Tab) and its Enter routes through onSubmit,
-                // which performs menu completion. Gating it off here would strand
-                // typing after the first "/" or "@".
-                active
-                placeholder={ready ? 'Type a message, or / for commands…' : 'starting agent-server…'}
-              />
-            ) : (
-              <>
-                <Text color={input.startsWith('!') ? theme.error : ready ? theme.accent : theme.dim}>
-                  {busy ? '… ' : input.startsWith('!') ? '! ' : '❯ '}
-                </Text>
-                <TextInput
-                  value={input}
-                  onChange={(v) => {
-                    // Collapse a large paste to a placeholder so it doesn't flood
-                    // the input (the original's [Pasted text #N]). Normal typing
-                    // inserts one char at a time, so this only fires on paste.
-                    const { ins, p, s } = diffInsert(input, v)
-                    const nLines = ins ? ins.split('\n').length : 0
-                    if (ins && (ins.length > 200 || nLines >= 4)) {
-                      const n = (pasteCounter.current += 1)
-                      const token = `[Pasted text #${n}${nLines > 1 ? ` +${nLines} lines` : ''}]`
-                      pasteStore.current.set(token, ins)
-                      setInput(v.slice(0, p) + token + (s ? v.slice(v.length - s) : ''))
-                    } else {
-                      setInput(v)
-                    }
-                    setSlashSel(0)
-                    setAtSel(0)
-                    setHistIdx(-1)
-                  }}
-                  onSubmit={onSubmit}
-                  placeholder={ready ? 'Type a message, or / for commands…' : 'starting agent-server…'}
-                />
-              </>
-            )}
+            {!vimMode ? (
+              <Text color={input.startsWith('!') ? theme.error : ready ? theme.accent : theme.dim}>
+                {busy ? '… ' : input.startsWith('!') ? '! ' : '❯ '}
+              </Text>
+            ) : null}
+            {/* One controlled input for both modes: readline editing (Ctrl+A/E/W/U/K,
+                arrows) always; /vim adds the normal/insert keymap. Stays active during
+                slash/@ menus (it ignores ↑/↓/Tab — App handles nav — and routes Enter
+                through onSubmit, which does menu completion). */}
+            <VimInput
+              value={input}
+              vimEnabled={vimMode}
+              onChange={handleInputChange}
+              onSubmit={onSubmit}
+              active
+              placeholder={ready ? 'Type a message, or / for commands…' : 'starting agent-server…'}
+            />
           </Box>
         </>
       )}

--- a/ui-tui/src/components/VimInput.tsx
+++ b/ui-tui/src/components/VimInput.tsx
@@ -18,6 +18,9 @@ interface Props {
   onSubmit: (v: string) => void
   active: boolean
   placeholder?: string
+  /** When false, this is the default readline input (insert-only): Esc does not
+   *  enter normal mode and no [N]/[I] tag is shown. When true, /vim is on. */
+  vimEnabled?: boolean
 }
 
 const WORD = /[\p{L}\p{N}_]/u
@@ -34,14 +37,40 @@ function prevWord(s: string, c: number): number {
   return Math.max(0, i)
 }
 
-export function VimInput({ value, onChange, onSubmit, active, placeholder }: Props): React.ReactElement {
+export function VimInput({
+  value,
+  onChange,
+  onSubmit,
+  active,
+  placeholder,
+  vimEnabled = true,
+}: Props): React.ReactElement {
   const [normal, setNormal] = useState(false) // start in insert (like the original entering /vim)
   const [cursor, setCursor] = useState(value.length)
   const clamp = (c: number, max = value.length): number => Math.max(0, Math.min(max, c))
 
+  // readline kill-ring / line edits shared by both modes' insert state.
+  const killWordBack = (): void => {
+    const left = value.slice(0, cursor).replace(/\s+$/, '')
+    const cut = Math.max(left.lastIndexOf(' '), left.lastIndexOf('/'), left.lastIndexOf('\t')) + 1
+    const newLeft = left.slice(0, cut)
+    onChange(newLeft + value.slice(cursor))
+    setCursor(newLeft.length)
+  }
+  const readlineEdit = (input: string, key: { ctrl?: boolean }): boolean => {
+    if (!key.ctrl) return false
+    if (input === 'a') return (setCursor(0), true)
+    if (input === 'e') return (setCursor(value.length), true)
+    if (input === 'w') return (killWordBack(), true)
+    if (input === 'u') return (onChange(value.slice(cursor)), setCursor(0), true) // kill to start
+    if (input === 'k') return (onChange(value.slice(0, cursor)), true) // kill to end
+    return false
+  }
+
   useInput(
     (input, key) => {
       if (!active) return
+      if (readlineEdit(input, key)) return // Ctrl+A/E/W/U/K in either mode
       if (normal) {
         if (input === 'i') return setNormal(false)
         if (input === 'a') {
@@ -75,9 +104,11 @@ export function VimInput({ value, onChange, onSubmit, active, placeholder }: Pro
       }
       // insert mode
       if (key.escape) {
-        setNormal(true)
-        setCursor((c) => Math.max(0, c - 1))
-        return
+        if (vimEnabled) {
+          setNormal(true)
+          setCursor((c) => Math.max(0, c - 1))
+        }
+        return // when vim is off, Esc is left for App (interrupt) — no normal mode
       }
       if (key.return) return onSubmit(value)
       if (key.leftArrow) return setCursor((c) => clamp(c - 1))
@@ -100,7 +131,7 @@ export function VimInput({ value, onChange, onSubmit, active, placeholder }: Pro
   // Render: mode tag + text with a block cursor (reverse video).
   const cur = clamp(cursor)
   const empty = value.length === 0
-  const tag = normal ? '[N] ' : '[I] '
+  const tag = vimEnabled ? (normal ? '[N] ' : '[I] ') : ''
   if (empty && placeholder) {
     return (
       <Text>


### PR DESCRIPTION
## Summary
The **foundational input refactor** (inventory §1 readline editing) — I'd flagged this "high-risk, do fresh," but `VimInput` had already proven the integration, so it was tractable. Replaces `ink-text-input` with **one controlled input** used in both modes:
- **readline always**: `Ctrl+A` home, `Ctrl+E` end, `Ctrl+W` kill-word, `Ctrl+U` kill-to-start, `Ctrl+K` kill-to-end, ←/→
- **`/vim`** adds the normal/insert keymap on top (`vimEnabled` gates `Esc`→normal + the `[N]`/`[I]` tag)

This unlocks the readline cluster in the **default** input — previously blocked because `ink-text-input` owns its cursor.

Integration preserved: shared paste-aware `onChange`; stays active during slash/`@` menus (App handles ↑/↓/Tab + history; Enter routes through `onSubmit` for completion). `ink-text-input` removed from the input box.

## Verification (exhaustive, ink-testing-library)
typing · `Ctrl+W` word-kill · `Ctrl+U` clear · slash menu · `@` menu · submit · ↑↓ history · `Ctrl+R` reverse-search · large-paste → `[Pasted text #N]` · `/vim` toggle + `[I]`/`[N]` + `0`/`x` motions. **No regressions.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)