### PR TITLE
feat(tui+server): /skills — list available skills

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -246,6 +246,23 @@ class _AgentSession:
         if subtype == "branch":
             self._do_branch(request_id)
             return
+        if subtype == "list_skills":
+            skills: list[dict] = []
+            total = 0
+            try:
+                from src.skills.loader import get_all_skills
+
+                all_s = list(get_all_skills(project_root=self.cwd))
+                total = len(all_s)
+                for s in all_s[:120]:
+                    skills.append({
+                        "name": getattr(s, "name", "") or "",
+                        "description": str(getattr(s, "description", "") or "")[:80],
+                    })
+            except Exception:  # noqa: BLE001
+                logger.debug("[agent-server] list_skills failed", exc_info=True)
+            self._reply(request_id, {"skills": skills, "total": total})
+            return
         if subtype == "list_agents":
             agents: list[dict] = []
             try:

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -845,6 +845,22 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         }
         return true
       }
+      case 'skills': {
+        if (client) {
+          void client.requestControl('list_skills').then((r) => {
+            const skills = Array.isArray(r?.['skills']) ? (r['skills'] as Record<string, unknown>[]) : []
+            const total = Number(r?.['total']) || skills.length
+            if (!total) {
+              addEntry({ kind: 'system', text: 'no skills available' })
+              return
+            }
+            const shown = skills.slice(0, 24).map((s) => `● ${String(s['name'])}`)
+            const more = total > shown.length ? `\n…and ${total - shown.length} more` : ''
+            addEntry({ kind: 'system', text: `Skills (${total}):\n${shown.join('\n')}${more}` })
+          })
+        }
+        return true
+      }
       case 'agents': {
         if (client) {
           void client.requestControl('list_agents').then((r) => {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -27,6 +27,7 @@ export interface SlashCommand {
     | 'memory'
     | 'agents'
     | 'config'
+    | 'skills'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -65,6 +66,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/mcp', description: 'List connected MCP servers and their tools', kind: 'mcp' },
   { name: '/permissions', description: 'Show active permission mode and rules', kind: 'permissions' },
   { name: '/agents', description: 'List available subagent types', kind: 'agents' },
+  { name: '/skills', description: 'List available skills', kind: 'skills' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports the original's `/skills` (inventory §2). A `list_skills` control returns the unified skill set (`get_all_skills`, capped at 120) + total count; the client `/skills` command shows the count + first 24 names (`…and N more`).

## Verification
`/skills` → `Skills (541): ● qa … …and N more`. Server suite **83 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)