### PR TITLE
feat(ui-tui): /files — list working-directory files

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -845,6 +845,17 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         }
         return true
       }
+      case 'files': {
+        const files = searchFiles(process.cwd(), '', Date.now())
+        if (!files.length) {
+          addEntry({ kind: 'system', text: 'no files found' })
+          return true
+        }
+        const shown = files.slice(0, 30)
+        const more = files.length > shown.length ? ` (showing 30)` : ''
+        addEntry({ kind: 'system', text: `Files${more}:\n${shown.join('\n')}` })
+        return true
+      }
       case 'skills': {
         if (client) {
           void client.requestControl('list_skills').then((r) => {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -28,6 +28,7 @@ export interface SlashCommand {
     | 'agents'
     | 'config'
     | 'skills'
+    | 'files'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -67,6 +68,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/permissions', description: 'Show active permission mode and rules', kind: 'permissions' },
   { name: '/agents', description: 'List available subagent types', kind: 'agents' },
   { name: '/skills', description: 'List available skills', kind: 'skills' },
+  { name: '/files', description: 'List files in the working directory', kind: 'files' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports the original's `/files` (inventory §2). Lists the cwd files from the cached bounded walk (`searchFiles`), capped at 30 with a "showing 30" hint.

## Verification
`/files` → `Files: package.json · scripts/smoke.ts · …`. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)