### PR TITLE
feat(ui-tui): /keybindings — show keyboard shortcuts

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -845,6 +845,29 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         }
         return true
       }
+      case 'keybindings': {
+        const keys = [
+          'Enter         submit',
+          'Ctrl+C        interrupt / exit',
+          'Ctrl+D        exit (empty input)',
+          'Ctrl+R        reverse history search',
+          '↑ / ↓         input history',
+          'Ctrl+W/U/K    kill word / to start / to end',
+          'Ctrl+A / E    line start / end',
+          'Ctrl+Y        yank (paste killed text)',
+          'Alt+← / →     word motion',
+          'Tab           accept completion',
+          '! …           bash mode',
+          '@             file mention',
+          '/             slash command',
+          'Esc           cancel (vim: normal mode)',
+          'PgUp / PgDn   scroll transcript (fullscreen)',
+          'Ctrl+F        find in transcript (fullscreen)',
+          '?             shortcuts overlay',
+        ]
+        addEntry({ kind: 'system', text: `Keybindings:\n${keys.map((k) => '  ' + k).join('\n')}` })
+        return true
+      }
       case 'files': {
         const files = searchFiles(process.cwd(), '', Date.now())
         if (!files.length) {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -29,6 +29,7 @@ export interface SlashCommand {
     | 'config'
     | 'skills'
     | 'files'
+    | 'keybindings'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -69,6 +70,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/agents', description: 'List available subagent types', kind: 'agents' },
   { name: '/skills', description: 'List available skills', kind: 'skills' },
   { name: '/files', description: 'List files in the working directory', kind: 'files' },
+  { name: '/keybindings', description: 'Show keyboard shortcuts', kind: 'keybindings' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports the original's `/keybindings` (inventory §2/§8). Lists the implemented shortcuts (submit, interrupt, history, `Ctrl+R` search, readline kill-ring/yank, word motion, bash/`@`/slash modes, fullscreen scroll/find, `?` overlay).

## Verification
`/keybindings` → `Keybindings: … Ctrl+R reverse history search …`. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)