### PR TITLE
feat(ui-tui): /color, /tag, /session command aliases

### DIFF
--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -102,6 +102,10 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/memory', description: 'Show the loaded CLAUDE.md memory files', kind: 'memory' },
   { name: '/doctor', description: 'Show connection + session diagnostics', kind: 'doctor' },
   { name: '/quit', description: 'Exit the TUI', kind: 'quit' },
+  // Aliases for inventory §2 command names that map to existing functionality.
+  { name: '/color', description: 'Switch color theme (alias of /theme)', kind: 'theme' },
+  { name: '/tag', description: 'Label the current session: /tag <name>', kind: 'rename' },
+  { name: '/session', description: 'Show session + connection diagnostics', kind: 'doctor' },
 ]
 
 /** Commands whose name starts with the typed token (case-insensitive). */


### PR DESCRIPTION
## Summary
Maps three more inventory §2 command names to existing functionality: `/color` → theme switcher, `/tag <name>` → session rename, `/session` → diagnostics. Pure command-table aliases, no new logic.

## Verification
`/color`→theme, `/tag`→rename, `/session`→doctor resolve correctly. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)