### PR TITLE
feat(ui-tui): /logo — re-show the startup banner

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -274,6 +274,9 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const [queued, setQueued] = useState<string[]>([])
   const localSeq = useRef(0)
   const bannerAdded = useRef(false)
+  const bannerDataRef = useRef<{ model: string; mode: string; tools: number; cwd?: string } | null>(
+    null,
+  ) // for /logo re-show
   const [toolActivity, setToolActivity] = useState<string | null>(null)
   const turnToolCounts = useRef<Record<string, number>>({})
   // Live, in-place tool-progress block: Read-like calls collapse here (not into
@@ -508,16 +511,13 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
           void c.requestControl('get_context_usage').then(applyContextUsage) // seed the status bar
           if (!bannerAdded.current) {
             bannerAdded.current = true
-            addEntry({
-              kind: 'banner',
-              text: '',
-              bannerData: {
-                model: m.model ?? '?',
-                mode: m.permission_mode ?? '?',
-                tools: toolCount,
-                cwd: m.cwd,
-              },
-            })
+            bannerDataRef.current = {
+              model: m.model ?? '?',
+              mode: m.permission_mode ?? '?',
+              tools: toolCount,
+              cwd: m.cwd,
+            }
+            addEntry({ kind: 'banner', text: '', bannerData: bannerDataRef.current })
           }
           const major = parseProtocolMajor(m.protocol_version)
           if (major !== null && major !== SUPPORTED_PROTOCOL_MAJOR) {
@@ -860,6 +860,14 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
           runStatusline(arg)
           addEntry({ kind: 'system', text: `status line set: ${arg}` })
         }
+        return true
+      }
+      case 'logo': {
+        addEntry({
+          kind: 'banner',
+          text: '',
+          bannerData: bannerDataRef.current ?? { model, mode, tools: 0, cwd: process.cwd() },
+        })
         return true
       }
       case 'keybindings': {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -31,6 +31,7 @@ export interface SlashCommand {
     | 'files'
     | 'keybindings'
     | 'statusline'
+    | 'logo'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -73,6 +74,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/files', description: 'List files in the working directory', kind: 'files' },
   { name: '/keybindings', description: 'Show keyboard shortcuts', kind: 'keybindings' },
   { name: '/statusline', description: 'Set a status-line shell command: /statusline <cmd> (or clear)', kind: 'statusline' },
+  { name: '/logo', description: 'Re-show the startup banner', kind: 'logo' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports the original's `/logo` (inventory §2/§7). Re-renders the startup banner (model/mode/tools/cwd) on demand, reusing the init banner data (captured in a ref).

## Verification
`/logo` re-adds the banner entry (banner art + model shown). typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)