### PR TITLE
feat(ui-tui): /release-notes and /feedback

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -862,6 +862,20 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         }
         return true
       }
+      case 'releaseNotes': {
+        addEntry({
+          kind: 'system',
+          text: 'Release notes are published on the clawcodex GitHub releases page.',
+        })
+        return true
+      }
+      case 'feedback': {
+        addEntry({
+          kind: 'system',
+          text: 'Report bugs or share feedback on the clawcodex GitHub issues page.',
+        })
+        return true
+      }
       case 'logo': {
         addEntry({
           kind: 'banner',

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -32,6 +32,8 @@ export interface SlashCommand {
     | 'keybindings'
     | 'statusline'
     | 'logo'
+    | 'releaseNotes'
+    | 'feedback'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -75,6 +77,8 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/keybindings', description: 'Show keyboard shortcuts', kind: 'keybindings' },
   { name: '/statusline', description: 'Set a status-line shell command: /statusline <cmd> (or clear)', kind: 'statusline' },
   { name: '/logo', description: 'Re-show the startup banner', kind: 'logo' },
+  { name: '/release-notes', description: 'Where to find release notes', kind: 'releaseNotes' },
+  { name: '/feedback', description: 'How to report bugs or feedback', kind: 'feedback' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Two more inventory §2 commands as info pointers: `/release-notes` (GitHub releases) and `/feedback` (GitHub issues).

## Verification
Both resolve to their handlers and print the pointer; 39 commands total. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)