### PR TITLE
feat(tui+server): /add-dir — add a working directory

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -278,6 +278,30 @@ class _AgentSession:
                 logger.debug("[agent-server] list_agents failed", exc_info=True)
             self._reply(request_id, {"agents": agents})
             return
+        if subtype == "add_dir":
+            path = inner.get("path")
+            try:
+                if not isinstance(path, str) or not path:
+                    self._reply(request_id, {"ok": False, "error": "missing path"})
+                    return
+                p = Path(path)
+                abspath = str((p if p.is_absolute() else Path(self.cwd) / p).resolve())
+                if not Path(abspath).is_dir():
+                    self._reply(request_id, {"ok": False, "error": "not a directory"})
+                    return
+                ctx = self.tool_context.permission_context if self.tool_context else None
+                if ctx is None:
+                    self._reply(request_id, {"ok": False, "error": "no permission context"})
+                    return
+                from src.permissions.types import AdditionalWorkingDirectory
+
+                ctx.additional_working_directories[abspath] = AdditionalWorkingDirectory(
+                    path=abspath, source="session"
+                )
+                self._reply(request_id, {"ok": True, "path": abspath})
+            except Exception as exc:  # noqa: BLE001
+                self._reply(request_id, {"ok": False, "error": str(exc)})
+            return
         if subtype == "list_permissions":
             ctx = self.tool_context.permission_context if self.tool_context else None
             mode, allow, deny = "default", [], []

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -862,6 +862,19 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         }
         return true
       }
+      case 'addDir': {
+        if (!arg) {
+          addEntry({ kind: 'system', text: 'usage: /add-dir <path>' })
+        } else if (client) {
+          void client.requestControl('add_dir', { path: arg }).then((r) => {
+            addEntry({
+              kind: r && r['ok'] ? 'system' : 'error',
+              text: r && r['ok'] ? `added working dir: ${String(r['path'])}` : `add-dir failed: ${r && r['error'] ? String(r['error']) : 'no response'}`,
+            })
+          })
+        }
+        return true
+      }
       case 'releaseNotes': {
         addEntry({
           kind: 'system',

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -34,6 +34,7 @@ export interface SlashCommand {
     | 'logo'
     | 'releaseNotes'
     | 'feedback'
+    | 'addDir'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -79,6 +80,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/logo', description: 'Re-show the startup banner', kind: 'logo' },
   { name: '/release-notes', description: 'Where to find release notes', kind: 'releaseNotes' },
   { name: '/feedback', description: 'How to report bugs or feedback', kind: 'feedback' },
+  { name: '/add-dir', description: 'Add a working directory: /add-dir <path>', kind: 'addDir' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports the original's `/add-dir` (inventory §2). An `add_dir` control resolves the path (relative to cwd), validates it's a directory, and adds it to the session's `permission_context.additional_working_directories` (source=session) so the agent can access it. Client: `/add-dir <path>` → confirms the resolved path.

## Verification
Adding populates `additional_working_directories`; client sends `add_dir` + shows confirmation. Server suite **83 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)