### PR TITLE
feat(tui+server): /hooks and /upgrade

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -278,6 +278,21 @@ class _AgentSession:
                 logger.debug("[agent-server] list_agents failed", exc_info=True)
             self._reply(request_id, {"agents": agents})
             return
+        if subtype == "list_hooks":
+            info: dict = {}
+            try:
+                from src.settings.settings import load_settings
+
+                h = load_settings(cwd=self.cwd).hooks
+                info = {
+                    "enabled": bool(getattr(h, "enabled", True)),
+                    "timeout_ms": int(getattr(h, "timeout_ms", 0)),
+                    "max_concurrent": int(getattr(h, "max_concurrent", 0)),
+                }
+            except Exception:  # noqa: BLE001
+                logger.debug("[agent-server] list_hooks failed", exc_info=True)
+            self._reply(request_id, {"hooks": info})
+            return
         if subtype == "add_dir":
             path = inner.get("path")
             try:

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -862,6 +862,29 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         }
         return true
       }
+      case 'hooks': {
+        if (client) {
+          void client.requestControl('list_hooks').then((r) => {
+            const h = (r?.['hooks'] as Record<string, unknown>) || {}
+            if (!Object.keys(h).length) {
+              addEntry({ kind: 'system', text: 'no hook configuration' })
+              return
+            }
+            addEntry({
+              kind: 'system',
+              text: `Hooks: ${h['enabled'] ? 'enabled' : 'disabled'} · timeout ${Number(h['timeout_ms']) || 0}ms · max ${Number(h['max_concurrent']) || 0} concurrent`,
+            })
+          })
+        }
+        return true
+      }
+      case 'upgrade': {
+        addEntry({
+          kind: 'system',
+          text: 'Update clawcodex: re-run the install script (curl … | bash) or `pip install -U clawcodex`.',
+        })
+        return true
+      }
       case 'addDir': {
         if (!arg) {
           addEntry({ kind: 'system', text: 'usage: /add-dir <path>' })

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -35,6 +35,8 @@ export interface SlashCommand {
     | 'releaseNotes'
     | 'feedback'
     | 'addDir'
+    | 'hooks'
+    | 'upgrade'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -81,6 +83,8 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/release-notes', description: 'Where to find release notes', kind: 'releaseNotes' },
   { name: '/feedback', description: 'How to report bugs or feedback', kind: 'feedback' },
   { name: '/add-dir', description: 'Add a working directory: /add-dir <path>', kind: 'addDir' },
+  { name: '/hooks', description: 'Show hook configuration', kind: 'hooks' },
+  { name: '/upgrade', description: 'How to update clawcodex', kind: 'upgrade' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Two more inventory §2 commands. `/hooks` (`list_hooks` control → `load_settings().hooks`) shows the hook config (enabled · timeout · max concurrent). `/upgrade` prints update instructions.

## Verification
`/hooks` → `Hooks: enabled · timeout 30000ms · max 5 concurrent`; `/upgrade` shows the pointer. Server suite **83 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)