### PR TITLE
feat(tui+server): /plugin — list installed plugins

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -258,6 +258,24 @@ class _AgentSession:
         if subtype == "branch":
             self._do_branch(request_id)
             return
+        if subtype == "list_plugins":
+            plugins: list[dict] = []
+            try:
+                from src.plugins.loader import load_plugins_from_directories
+
+                dirs = [
+                    str(Path.home() / ".claude" / "plugins"),
+                    str(Path(self.cwd) / ".claude" / "plugins"),
+                ]
+                res = load_plugins_from_directories(dirs)
+                plugins = [
+                    {"name": p.name, "enabled": bool(p.enabled), "source": getattr(p, "source", "")}
+                    for p in res.plugins
+                ]
+            except Exception:  # noqa: BLE001
+                logger.debug("[agent-server] list_plugins failed", exc_info=True)
+            self._reply(request_id, {"plugins": plugins})
+            return
         if subtype == "list_skills":
             skills: list[dict] = []
             total = 0

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -862,6 +862,20 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         }
         return true
       }
+      case 'plugin': {
+        if (client) {
+          void client.requestControl('list_plugins').then((r) => {
+            const plugins = Array.isArray(r?.['plugins']) ? (r['plugins'] as Record<string, unknown>[]) : []
+            if (!plugins.length) {
+              addEntry({ kind: 'system', text: 'no plugins installed (~/.claude/plugins or .claude/plugins)' })
+              return
+            }
+            const lines = plugins.map((p) => `● ${String(p['name'])}${p['enabled'] ? '' : ' (disabled)'}`)
+            addEntry({ kind: 'system', text: `Plugins (${plugins.length}):\n${lines.join('\n')}` })
+          })
+        }
+        return true
+      }
       case 'effort': {
         if (client) {
           void client.requestControl('set_effort', { effort: arg }).then((r) => {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -39,6 +39,7 @@ export interface SlashCommand {
     | 'upgrade'
     | 'provider'
     | 'effort'
+    | 'plugin'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -89,6 +90,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/upgrade', description: 'How to update clawcodex', kind: 'upgrade' },
   { name: '/provider', description: 'Switch LLM provider: /provider <name>', kind: 'provider' },
   { name: '/effort', description: 'Set reasoning effort: /effort <low|medium|high> (or clear)', kind: 'effort' },
+  { name: '/plugin', description: 'List installed plugins', kind: 'plugin' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports the original's `/plugin` (inventory §2). A `list_plugins` control discovers plugins under `~/.claude/plugins` and `<cwd>/.claude/plugins` (`load_plugins_from_directories`) and returns name/enabled/source; the client `/plugin` command lists them (or "no plugins installed").

## Verification
Empty-safe (`no plugins installed`). Server suite **83 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)