### PR TITLE
feat(ui-tui): Ctrl+O — expand collapsed tool results / thinking

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -235,6 +235,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const statusCmdRef = useRef<string | null>(null) // guards async output against a later clear
   const [, setThemeVersion] = useState(0) // bumped on /theme to repaint the dynamic UI
   const [scrollOffset, setScrollOffset] = useState(0) // fullscreen: entries hidden from the bottom
+  const [expanded, setExpanded] = useState(false) // Ctrl+O: expand collapsed tool results / thinking
   const [txFind, setTxFind] = useState<string | null>(null) // fullscreen Ctrl+F find query (null = closed)
   const [vimMode, setVimMode] = useState(false) // /vim modal editing
 
@@ -570,6 +571,12 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     if (key.ctrl && ch === 'c') {
       client?.close()
       exit()
+      return
+    }
+    // Ctrl+O: toggle expand of collapsed tool results / thinking (fully re-renders
+    // in fullscreen; affects subsequent entries in inline <Static> mode).
+    if (key.ctrl && ch === 'o') {
+      setExpanded((e) => !e)
       return
     }
     // Fullscreen Ctrl+F transcript find.
@@ -1443,7 +1450,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     : entries
   const renderEntry = (entry: TranscriptEntry): React.ReactElement => (
     <Box key={entry.id} marginTop={['tool', 'toolResult', 'banner'].includes(entry.kind) ? 0 : 1}>
-      <Message entry={entry} />
+      <Message entry={entry} expanded={expanded} />
     </Box>
   )
 

--- a/ui-tui/src/components/Message.tsx
+++ b/ui-tui/src/components/Message.tsx
@@ -17,12 +17,21 @@ import type { TranscriptEntry } from '../sdkMessageAdapter.js'
 
 const RESULT_MAX_LINES = 8
 
-function ToolResult({ text, isError }: { text: string; isError?: boolean }): React.ReactElement {
+function ToolResult({
+  text,
+  isError,
+  expanded,
+}: {
+  text: string
+  isError?: boolean
+  expanded?: boolean
+}): React.ReactElement {
   const lines = text.replace(/\s+$/, '').split('\n')
+  const max = expanded ? lines.length : RESULT_MAX_LINES
   // Errors render in red (the original's error tool-result variant) and aren't
   // collapsed — the message is what the user needs to see.
   if (isError) {
-    const shown = lines.slice(0, RESULT_MAX_LINES)
+    const shown = lines.slice(0, max)
     const extra = lines.length - shown.length
     return (
       <Box flexDirection="column">
@@ -40,10 +49,10 @@ function ToolResult({ text, isError }: { text: string; isError?: boolean }): Rea
   // several Reads otherwise bury the transcript under hundreds of content lines.
   // The original keeps these collapsed (ctrl+o to expand).
   const numbered = lines.filter((l) => /^\s*\d+[\t |→]/.test(l)).length
-  if (lines.length > 6 && numbered >= lines.length * 0.6) {
-    return <Text color={theme.dim}>{`  ⎿ Read ${lines.length} lines`}</Text>
+  if (!expanded && lines.length > 6 && numbered >= lines.length * 0.6) {
+    return <Text color={theme.dim}>{`  ⎿ Read ${lines.length} lines (ctrl+o to expand)`}</Text>
   }
-  const shown = lines.slice(0, RESULT_MAX_LINES)
+  const shown = lines.slice(0, max)
   const extra = lines.length - shown.length
   return (
     <Box flexDirection="column">
@@ -128,7 +137,13 @@ function ContextView({ data }: { data: NonNullable<TranscriptEntry['contextData'
   )
 }
 
-export function Message({ entry }: { entry: TranscriptEntry }): React.ReactElement | null {
+export function Message({
+  entry,
+  expanded,
+}: {
+  entry: TranscriptEntry
+  expanded?: boolean
+}): React.ReactElement | null {
   switch (entry.kind) {
     case 'banner':
       return entry.bannerData ? <Banner {...entry.bannerData} /> : null
@@ -206,12 +221,12 @@ export function Message({ entry }: { entry: TranscriptEntry }): React.ReactEleme
       )
     }
     case 'toolResult':
-      return <ToolResult text={entry.text} isError={entry.isError} />
+      return <ToolResult text={entry.text} isError={entry.isError} expanded={expanded} />
     case 'thinking': {
       // ∴ Thinking (dim italic) + the reasoning, capped (the original's
       // AssistantThinkingMessage; full text lives in scrollback).
       const lines = entry.text.split('\n')
-      const MAX = 14
+      const MAX = expanded ? lines.length : 14
       const shown = lines.slice(0, MAX)
       const extra = lines.length - shown.length
       return (


### PR DESCRIPTION
## Summary
Ports the original's `Ctrl+O` expand (inventory §8). A global `expanded` flag (toggled by `Ctrl+O`) is threaded into `Message` → `ToolResult`/thinking, which then show **full** content instead of the 8-line / "Read N lines" / 14-line collapse. The full text was already stored on the entry — only the render truncated. **Fully effective in fullscreen** (re-renders); affects subsequent entries in inline `<Static>` mode.

Reverses my "Static-constrained" claim for `Ctrl+O` — fullscreen re-renders, so expand IS possible there.

## Verification
Fullscreen: `Read 20 lines (ctrl+o to expand)` → `Ctrl+O` → all 20 lines → `Ctrl+O` → collapsed again. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)