### PR TITLE
feat(ui-tui): Ctrl+L redraw

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -608,6 +608,13 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       setExpanded((e) => !e)
       return
     }
+    // Ctrl+L: redraw. In fullscreen, clear the alt-screen and force a repaint;
+    // in inline mode a repaint is harmless (Static stays in scrollback).
+    if (key.ctrl && ch === 'l') {
+      if (FULLSCREEN) process.stdout.write('\x1b[2J\x1b[3J\x1b[H')
+      setThemeVersion((v) => v + 1) // force a re-render
+      return
+    }
     // Fullscreen Ctrl+F transcript find.
     if (FULLSCREEN && txFind !== null) {
       if (key.escape || key.return) {


### PR DESCRIPTION
## Summary
Ports the original's `Ctrl+L` redraw (inventory §8). In fullscreen it clears the alt-screen and forces a repaint; in inline mode it forces a harmless re-render (Static stays in scrollback). **Completes the Static cluster** (`Ctrl+O` #476, grouped-read #477, `Ctrl+L`) — all three initially mis-filed as "Static-constrained by design," all three reversed by testing.

## Verification
Fullscreen: `Ctrl+L` clears the alt-screen + keeps rendering. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)