### PR TITLE
feat(ui-tui): /buddy — animated companion sprite

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -18,6 +18,7 @@ import { SlashMenu } from './components/SlashMenu.js'
 import { exec } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
+import { BUDDY_SPECIES, CompanionSprite } from './components/CompanionSprite.js'
 import { FileMenu } from './components/FileMenu.js'
 import { VimInput } from './components/VimInput.js'
 import { searchFiles } from './fileIndex.js'
@@ -265,6 +266,10 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const [, setThemeVersion] = useState(0) // bumped on /theme to repaint the dynamic UI
   const [scrollOffset, setScrollOffset] = useState(0) // fullscreen: entries hidden from the bottom
   const [expanded, setExpanded] = useState(false) // Ctrl+O: expand collapsed tool results / thinking
+  const [buddy, setBuddy] = useState<string | null>(() => {
+    const b = process.env['CLAWCODEX_BUDDY']
+    return b ? (BUDDY_SPECIES.includes(b) ? b : 'cat') : null
+  }) // /buddy companion sprite (opt-in)
   const [txFind, setTxFind] = useState<string | null>(null) // fullscreen Ctrl+F find query (null = closed)
   const [vimMode, setVimMode] = useState(false) // /vim modal editing
 
@@ -902,6 +907,20 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
           setStatusCmd(arg)
           runStatusline(arg)
           addEntry({ kind: 'system', text: `status line set: ${arg}` })
+        }
+        return true
+      }
+      case 'buddy': {
+        if (arg === 'off') {
+          setBuddy(null)
+          addEntry({ kind: 'system', text: 'buddy off' })
+        } else if (arg && BUDDY_SPECIES.includes(arg)) {
+          setBuddy(arg)
+          addEntry({ kind: 'system', text: `buddy → ${arg}` })
+        } else {
+          const next = buddy ? null : 'cat'
+          setBuddy(next)
+          addEntry({ kind: 'system', text: next ? `buddy → ${next} (try: ${BUDDY_SPECIES.join(' / ')})` : 'buddy off' })
         }
         return true
       }
@@ -1552,6 +1571,12 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
           <Text color={contextUsage.percentage >= 90 ? theme.error : theme.warn}>
             {`⚠ Context ${Math.round(contextUsage.percentage)}% used — run /compact to free space`}
           </Text>
+        </Box>
+      ) : null}
+
+      {buddy ? (
+        <Box marginTop={1}>
+          <CompanionSprite species={buddy} />
         </Box>
       ) : null}
 

--- a/ui-tui/src/components/CompanionSprite.tsx
+++ b/ui-tui/src/components/CompanionSprite.tsx
@@ -1,0 +1,60 @@
+/**
+ * Buddy — the animated companion sprite ported from openclaude's src/buddy/
+ * (sprites.ts). A small ASCII creature that idle-cycles its frames and blinks.
+ * Sprites are 5 lines × 12 wide with {E} eye slots (substituted per blink).
+ * Opt-in (the original is feature-gated); rendered above the input when on.
+ */
+import { Box, Text } from 'ink'
+import React, { useEffect, useState } from 'react'
+import { theme } from '../theme.js'
+
+// Verbatim frames from typescript/src/buddy/sprites.ts (idle fidget animation).
+const BODIES: Record<string, string[][]> = {
+  cat: [
+    ['            ', '   /\\_/\\    ', '  ( {E}   {E})  ', '  (  ω  )   ', '  (")_(")   '],
+    ['            ', '   /\\_/\\    ', '  ( {E}   {E})  ', '  (  ω  )   ', '  (")_(")~  '],
+    ['            ', '   /\\-/\\    ', '  ( {E}   {E})  ', '  (  ω  )   ', '  (")_(")   '],
+  ],
+  duck: [
+    ['            ', '    __      ', '  <({E} )___  ', '   (  ._>   ', '    `--´    '],
+    ['            ', '    __      ', '  <({E} )___  ', '   (  ._>   ', '    `--´~   '],
+    ['            ', '    __      ', '  <({E} )___  ', '   (  .__>  ', '    `--´    '],
+  ],
+  blob: [
+    ['            ', '   .----.   ', '  ( {E}  {E} )  ', '  (      )  ', '   `----´   '],
+    ['            ', '  .------.  ', ' (  {E}  {E}  ) ', ' (        ) ', '  `------´  '],
+    ['            ', '    .--.    ', '   ({E}  {E})   ', '   (    )   ', '    `--´    '],
+  ],
+}
+export const BUDDY_SPECIES = Object.keys(BODIES)
+
+export function CompanionSprite({ species }: { species?: string }): React.ReactElement {
+  const sp = species && BODIES[species] ? species : 'cat'
+  const frames = BODIES[sp] as string[][]
+  const [frame, setFrame] = useState(0)
+  const [blink, setBlink] = useState(false)
+
+  useEffect(() => {
+    const f = setInterval(() => setFrame((x) => (x + 1) % frames.length), 900)
+    const b = setInterval(() => {
+      setBlink(true)
+      setTimeout(() => setBlink(false), 160)
+    }, 4200)
+    return () => {
+      clearInterval(f)
+      clearInterval(b)
+    }
+  }, [frames.length])
+
+  const eye = blink ? '-' : '•'
+  const lines = (frames[frame] as string[]).map((l) => l.replace(/\{E\}/g, eye))
+  return (
+    <Box flexDirection="column">
+      {lines.map((l, i) => (
+        <Text key={i} color={theme.accent}>
+          {l}
+        </Text>
+      ))}
+    </Box>
+  )
+}

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -41,6 +41,7 @@ export interface SlashCommand {
     | 'effort'
     | 'plugin'
     | 'reloadPlugins'
+    | 'buddy'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -93,6 +94,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/effort', description: 'Set reasoning effort: /effort <low|medium|high> (or clear)', kind: 'effort' },
   { name: '/plugin', description: 'List installed plugins', kind: 'plugin' },
   { name: '/reload-plugins', description: 'Reload plugins from disk', kind: 'reloadPlugins' },
+  { name: '/buddy', description: 'Toggle the companion sprite: /buddy [cat|duck|blob|off]', kind: 'buddy' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports upstream TypeScript implementation's **buddy** (`typescript/src/buddy/`). `CompanionSprite` renders a 5-line ASCII creature with **verbatim idle-fidget frames** (cat/duck/blob from `sprites.ts`) that cycle + blink (`{E}` eye slot → `•`/`-`). Opt-in: `/buddy [cat|duck|blob|off]` or `CLAWCODEX_BUDDY=<species>`; default off.

Reverses my "out-of-scope" call — the goal said "all from the typescript implementation," and buddy's source is right there and portable.

## Verification
`/buddy cat` renders `/\_/\` … `(")_(")`; `/buddy off` hides it. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)