### PR TITLE
feat(ui-tui): /stickers

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -910,6 +910,10 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         }
         return true
       }
+      case 'stickers': {
+        addEntry({ kind: 'system', text: 'Claude Code stickers: https://www.stickermule.com/claudecode' })
+        return true
+      }
       case 'buddy': {
         if (arg === 'off') {
           setBuddy(null)

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -42,6 +42,7 @@ export interface SlashCommand {
     | 'plugin'
     | 'reloadPlugins'
     | 'buddy'
+    | 'stickers'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -95,6 +96,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/plugin', description: 'List installed plugins', kind: 'plugin' },
   { name: '/reload-plugins', description: 'Reload plugins from disk', kind: 'reloadPlugins' },
   { name: '/buddy', description: 'Toggle the companion sprite: /buddy [cat|duck|blob|off]', kind: 'buddy' },
+  { name: '/stickers', description: 'Where to get Claude Code stickers', kind: 'stickers' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports upstream TypeScript implementation's `/stickers` (`typescript/src/commands/stickers` — opens `stickermule.com/claudecode`). Shows the sticker URL.

## Verification
Resolves to its handler; 48 commands. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)