### PR TITLE
feat(ui-tui): /search — content search (ripgrep)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -914,6 +914,29 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         addEntry({ kind: 'system', text: 'Claude Code stickers: https://www.stickermule.com/claudecode' })
         return true
       }
+      case 'search': {
+        if (!arg) {
+          addEntry({ kind: 'system', text: 'usage: /search <query>' })
+          return true
+        }
+        const q = arg.replace(/'/g, "'\\''") // safe single-quote for the shell
+        addEntry({ kind: 'system', text: `/search ${arg}` })
+        exec(
+          `rg -n -S --max-count=50 --max-columns=200 -- '${q}'`,
+          { cwd: process.cwd(), timeout: 15_000, maxBuffer: 512 * 1024 },
+          (err, stdout, stderr) => {
+            const out = `${stdout || ''}`.trim()
+            if (out) {
+              addEntry({ kind: 'toolResult', text: out.split('\n').slice(0, 40).join('\n') })
+            } else if (err && (err as { code?: number }).code === 1) {
+              addEntry({ kind: 'system', text: 'no matches' })
+            } else {
+              addEntry({ kind: 'error', text: stderr ? String(stderr).split('\n')[0] : 'search failed' })
+            }
+          },
+        )
+        return true
+      }
       case 'buddy': {
         if (arg === 'off') {
           setBuddy(null)

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -43,6 +43,7 @@ export interface SlashCommand {
     | 'reloadPlugins'
     | 'buddy'
     | 'stickers'
+    | 'search'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -97,6 +98,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/reload-plugins', description: 'Reload plugins from disk', kind: 'reloadPlugins' },
   { name: '/buddy', description: 'Toggle the companion sprite: /buddy [cat|duck|blob|off]', kind: 'buddy' },
   { name: '/stickers', description: 'Where to get Claude Code stickers', kind: 'stickers' },
+  { name: '/search', description: 'Search file contents (ripgrep): /search <query>', kind: 'search' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports the original's global content search (inventory §6 `GlobalSearchDialog`) as a `/search <query>` command: runs ripgrep in cwd (smart-case, capped) and shows matching `file:line` results. Distinct from `@` (filenames) and `Ctrl+R` (history). Query is single-quoted for shell safety.

## Verification
`/search CompanionSprite` returns the `.tsx` matches. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)