### PR TITLE
feat(ui-tui): OSC 8 clickable refs (file paths + URLs)

### DIFF
--- a/ui-tui/src/components/Message.tsx
+++ b/ui-tui/src/components/Message.tsx
@@ -12,6 +12,7 @@ import { Markdown } from '../markdown.js'
 import { theme } from '../theme.js'
 import { Banner } from './Banner.js'
 import { DiffView } from './DiffView.js'
+import { hyperlink } from '../hyperlink.js'
 import { TOOL_VERB } from '../toolMeta.js'
 import type { TranscriptEntry } from '../sdkMessageAdapter.js'
 
@@ -207,13 +208,22 @@ export function Message({
       // File-edit tools display as Update/Create/Write (the original's
       // userFacingName), not the raw tool id.
       const name = diff ? diff.displayName : entry.toolName
+      // Clickable refs (OSC 8, inventory §8): web args are URLs; file-op args are
+      // paths → file:// links. No-op on terminals that don't support hyperlinks.
+      const args = entry.argsText ?? ''
+      const isFileOp = ['Read', 'Edit', 'Write', 'MultiEdit', 'NotebookEdit'].includes(entry.toolName ?? '')
+      const linkedArgs = isWeb
+        ? hyperlink(args, args)
+        : isFileOp && args
+          ? hyperlink(args, `file://${args.startsWith('/') ? args : `${process.cwd()}/${args}`}`)
+          : args
       return (
         <Box flexDirection="column">
           <Text>
             <Text color={theme.success}>⏺ </Text>
             <Text bold>{name}</Text>
             <Text color={theme.dim}>(</Text>
-            <Text color={isWeb ? theme.link : theme.dim}>{entry.argsText}</Text>
+            <Text color={isWeb ? theme.link : theme.dim}>{linkedArgs}</Text>
             <Text color={theme.dim}>)</Text>
           </Text>
           {diff ? <DiffView diff={diff} /> : null}

--- a/ui-tui/src/hyperlink.ts
+++ b/ui-tui/src/hyperlink.ts
@@ -1,0 +1,26 @@
+/**
+ * OSC 8 terminal hyperlinks (the original's clickable refs, inventory §8) with
+ * capability detection — emit the escape only on terminals known to render it,
+ * otherwise return the text unchanged so unsupported terminals show no garbage.
+ */
+const OSC = '\x1b]8;;'
+const ST = '\x1b\\'
+
+let _supported: boolean | null = null
+export function supportsHyperlinks(): boolean {
+  if (_supported !== null) return _supported
+  const tp = process.env['TERM_PROGRAM'] ?? ''
+  const term = process.env['TERM'] ?? ''
+  _supported =
+    ['iTerm.app', 'WezTerm', 'ghostty', 'vscode', 'Hyper', 'rio'].includes(tp) ||
+    term === 'xterm-kitty' ||
+    !!process.env['VTE_VERSION'] ||
+    !!process.env['KITTY_WINDOW_ID']
+  return _supported
+}
+
+/** Wrap `text` in an OSC 8 hyperlink to `url` (no-op on unsupported terminals). */
+export function hyperlink(text: string, url: string): string {
+  if (!url || !supportsHyperlinks()) return text
+  return `${OSC}${url}${ST}${text}${OSC}${ST}`
+}


### PR DESCRIPTION
## Summary
Ports the original's clickable refs (inventory §8). `hyperlink()` wraps **known** refs in OSC 8 escapes with terminal **capability detection** (iTerm2/WezTerm/kitty/ghostty/vscode/Hyper/rio/VTE) — no-op elsewhere so unsupported terminals show no garbage. Tool entries now link web args (URL) and file-op args (`file://` resolved to cwd).

Reverses my "fiddly-marginal" call — the clean version wraps *known* refs (not heuristic detection) and gates on capability.

## Verification
Supported terminal wraps `file.ts` in OSC 8; unsupported returns plain text. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)