### PR TITLE
feat(ui-tui): /history — recall a past prompt (HistorySearchDialog)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -293,7 +293,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const pasteCounter = useRef(0)
   // Interactive select picker (the original's CustomSelect) for /mode, /theme.
   const [picker, setPicker] = useState<{
-    kind: 'mode' | 'theme' | 'model' | 'resume' | 'rewindpick'
+    kind: 'mode' | 'theme' | 'model' | 'resume' | 'rewindpick' | 'historyrecall'
     title: string
     options: string[]
     /** Optional value per option (e.g. session_id); falls back to the label. */
@@ -399,12 +399,17 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   }
 
   const applyPick = (
-    kind: 'mode' | 'theme' | 'model' | 'resume' | 'rewindpick',
+    kind: 'mode' | 'theme' | 'model' | 'resume' | 'rewindpick' | 'historyrecall',
     value: string,
   ): void => {
     if (!value) return
     if (kind === 'rewindpick') {
       requestRewind(Number(value) || 1)
+      return
+    }
+    if (kind === 'historyrecall') {
+      setInput(value)
+      setHistIdx(-1)
       return
     }
     if (kind === 'mode') {
@@ -938,6 +943,21 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       }
       case 'stickers': {
         addEntry({ kind: 'system', text: 'Claude Code stickers: https://www.stickermule.com/claudecode' })
+        return true
+      }
+      case 'history': {
+        const h = historyRef.current
+        if (!h.length) {
+          addEntry({ kind: 'system', text: 'no history yet' })
+          return true
+        }
+        const opts: string[] = []
+        const vals: string[] = []
+        for (let i = h.length - 1; i >= 0; i--) {
+          opts.push((h[i] || '').replace(/\s+/g, ' ').slice(0, 60))
+          vals.push(h[i] as string)
+        }
+        setPicker({ kind: 'historyrecall', title: 'History (recall a prompt)', options: opts, values: vals, sel: 0 })
         return true
       }
       case 'search': {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -44,6 +44,7 @@ export interface SlashCommand {
     | 'buddy'
     | 'stickers'
     | 'search'
+    | 'history'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -99,6 +100,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/buddy', description: 'Toggle the companion sprite: /buddy [cat|duck|blob|off]', kind: 'buddy' },
   { name: '/stickers', description: 'Where to get Claude Code stickers', kind: 'stickers' },
   { name: '/search', description: 'Search file contents (ripgrep): /search <query>', kind: 'search' },
+  { name: '/history', description: 'Pick a past prompt to recall', kind: 'history' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports the original's `HistorySearchDialog` (inventory §6) as `/history`: opens a list-picker of submitted prompts (newest first) → recalls the chosen one into the input. **Distinct** from `Ctrl+R` (inline cycle) — a browsable list view. Reuses the picker (kind `historyrecall`).

## Verification
After 2 prompts, `/history` lists them; selecting "beta query" recalls it to the input. typecheck + build clean. 50 commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)