### PR TITLE
feat(ui-tui): multiline input (trailing-backslash continuation)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -1529,6 +1529,12 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   }
 
   const onSubmit = (value: string): void => {
+    // Trailing-backslash line continuation (the original's multiline input):
+    // a line ending in `\` + Enter inserts a newline instead of submitting.
+    if (value.endsWith('\\') && !slashOpen && !atOpen) {
+      setInput(`${value.slice(0, -1)}\n`)
+      return
+    }
     const text = value.trim()
     if (!text) return
     // Enter while the @-file menu is open completes the highlighted path


### PR DESCRIPTION
## Summary
Ports the original's multiline input (inventory §1). A line ending in `\` + Enter inserts a newline and keeps editing instead of submitting (terminal-independent, unlike Shift/Meta+Enter which terminals don't reliably distinguish). The next plain Enter submits the whole multiline value.

## Verification
`line1\` + Enter does not submit (becomes `line1\n`); `line2` + Enter submits `line1\nline2`. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)