### PR TITLE
feat(ui-tui): permission "don't ask again" (session allow-list)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -245,6 +245,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const [streaming, setStreaming] = useState('')
   const streamRef = useRef('') // source of truth for the live buffer (no stale closures)
   const [permissions, setPermissions] = useState<PendingPermission[]>([]) // FIFO queue
+  const alwaysAllowRef = useRef<Set<string>>(new Set()) // tools the user said "don't ask again"
   const [input, setInput] = useState('')
   const [busy, setBusy] = useState(false)
   const [turnStartedAt, setTurnStartedAt] = useState(0)
@@ -754,7 +755,13 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       if (c === 'y' || ch === '1') {
         client?.respondPermission(head.requestId, 'allow')
         setPermissions((q) => q.slice(1))
-      } else if (c === 'n' || c === 'd' || ch === '2') {
+      } else if (c === 'a' || ch === '2') {
+        // "Yes, and don't ask again" — remember the tool + auto-allow future asks.
+        alwaysAllowRef.current.add(head.toolName)
+        client?.respondPermission(head.requestId, 'allow')
+        setPermissions((q) => q.slice(1))
+        addEntry({ kind: 'system', text: `always allowing ${head.toolName} this session` })
+      } else if (c === 'n' || c === 'd' || ch === '3') {
         client?.respondPermission(head.requestId, 'deny', { message: 'denied by user' })
         setPermissions((q) => q.slice(1))
       } else if (key.escape) {
@@ -1481,6 +1488,16 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     if (statusCmd && !busy) runStatusline(statusCmd)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [busy, statusCmd])
+
+  // Auto-allow tools the user marked "don't ask again" (skip the prompt).
+  useEffect(() => {
+    const head = permissions[0]
+    if (head && alwaysAllowRef.current.has(head.toolName)) {
+      client?.respondPermission(head.requestId, 'allow')
+      setPermissions((q) => q.slice(1))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [permissions])
 
   // Bash mode (`!cmd`): run a shell command client-side and show its output,
   // without involving the model. The TUI runs in the same cwd as the

--- a/ui-tui/src/components/PermissionDialog.tsx
+++ b/ui-tui/src/components/PermissionDialog.tsx
@@ -134,7 +134,8 @@ export function PermissionDialog({ toolName, input }: Props): React.ReactElement
           <Text bold>1. Yes</Text>
           <Text color={theme.dim}>{'   (y)'}</Text>
         </Text>
-        <Text color={theme.dim}>{'  2. No, and tell the agent what to do differently   (n / esc)'}</Text>
+        <Text color={theme.dim}>{'  2. Yes, and don’t ask again this session   (a)'}</Text>
+        <Text color={theme.dim}>{'  3. No, and tell the agent what to do differently   (n / esc)'}</Text>
       </Box>
     </Box>
   )


### PR DESCRIPTION
## Summary
Ports the original's "Yes, and don't ask again" permission option (inventory §5). Pressing `a` (option 2) at a prompt remembers the tool in a session allow-set and allows it; future requests for that tool are **auto-allowed** (an effect responds + dequeues without showing the dialog). Client-side — no backend protocol change. Dialog now lists Yes / Yes-don't-ask-again / No.

## Verification
`a` allows + remembers Bash; a second Bash request **auto-allows with no keypress and no dialog**. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)