### PR TITLE
feat(ui-tui): /tasks — current turn + queued prompts

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -1000,6 +1000,14 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         addEntry({ kind: 'system', text: 'Claude Code stickers: https://www.stickermule.com/claudecode' })
         return true
       }
+      case 'tasks': {
+        const lines: string[] = []
+        if (busy) lines.push(`● running — ${toolActivity || 'agent turn in progress'}`)
+        if (queued.length) lines.push(`⏳ ${queued.length} queued prompt${queued.length === 1 ? '' : 's'}`)
+        if (!lines.length) lines.push('no active tasks')
+        addEntry({ kind: 'system', text: `Tasks:\n${lines.join('\n')}` })
+        return true
+      }
       case 'settings': {
         const opts = ['model', 'mode', 'theme', 'effort', 'provider']
         setPicker({ kind: 'settings', title: 'Settings (select to change)', options: opts, sel: 0 })

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -46,6 +46,7 @@ export interface SlashCommand {
     | 'search'
     | 'history'
     | 'settings'
+    | 'tasks'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -103,6 +104,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/search', description: 'Search file contents (ripgrep): /search <query>', kind: 'search' },
   { name: '/history', description: 'Pick a past prompt to recall', kind: 'history' },
   { name: '/settings', description: 'Open the settings menu', kind: 'settings' },
+  { name: '/tasks', description: 'Show the current turn + queued prompts', kind: 'tasks' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports the original's `/tasks` (inventory §2/§9) as a **safe status view**: shows the in-flight turn (with its current tool activity) + the count of queued prompts, or "no active tasks" when idle. Read-only snapshot of the async work the agent-server already does — no concurrency change (true `Ctrl+B` turn-backgrounding would need a multi-session backend, deferred as a careful effort).

## Verification
`/tasks` → "Tasks: no active tasks" when idle. typecheck + build clean. 52 commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)