### PR TITLE
feat(ui-tui): readline transpose (Ctrl+T) + kill-word-forward (Alt+D)

### DIFF
--- a/ui-tui/src/components/VimInput.tsx
+++ b/ui-tui/src/components/VimInput.tsx
@@ -93,6 +93,25 @@ export function VimInput({
       }
       return true
     }
+    // Alt+D — kill word forward (readline).
+    if (key.meta && input === 'd') {
+      const end = nextWord(value, cursor)
+      killRing.current = value.slice(cursor, end)
+      onChange(value.slice(0, cursor) + value.slice(end))
+      return true
+    }
+    // Ctrl+T (\x14) — transpose the two chars around the cursor (readline).
+    if (input === '\x14' || (key.ctrl && input === 't')) {
+      const n = value.length
+      if (n >= 2) {
+        const i = cursor >= n ? n - 1 : cursor
+        if (i >= 1) {
+          onChange(value.slice(0, i - 1) + value[i] + value[i - 1] + value.slice(i + 1))
+          setCursor(Math.min(n, i + 1))
+        }
+      }
+      return true
+    }
     if (!key.ctrl) return false
     if (input === 'a') return (setCursor(0), true)
     if (input === 'e') return (setCursor(value.length), true)


### PR DESCRIPTION
## Summary
Completes the readline op set (inventory §1/§8). `Ctrl+T` transposes the two chars around the cursor; `Alt+D` kills from the cursor to the next word end (into the kill-ring, yankable with `Ctrl+Y`). Joins the existing `Ctrl+A/E/W/U/K/Y` + word-motion + undo.

## Verification
"ab" + `Ctrl+T` → "ba"; "foo bar" at col 0 + `Alt+D` → "bar". typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)