### PR TITLE
feat(ui-tui): external editor (Ctrl+G)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -15,6 +15,7 @@ import type { Transport } from './transport.js'
 import { Message } from './components/Message.js'
 import { PermissionDialog } from './components/PermissionDialog.js'
 import { SlashMenu } from './components/SlashMenu.js'
+import { editInEditor } from './editor.js'
 import { exec } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
@@ -659,6 +660,21 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     if (key.ctrl && ch === 'l') {
       if (FULLSCREEN) process.stdout.write('\x1b[2J\x1b[3J\x1b[H')
       setThemeVersion((v) => v + 1) // force a re-render
+      return
+    }
+    // Ctrl+G: edit the current prompt in $EDITOR (the original's external editor).
+    if (key.ctrl && ch === 'g') {
+      const sin = process.stdin as unknown as { setRawMode?: (m: boolean) => void }
+      const canRaw = typeof sin.setRawMode === 'function'
+      try {
+        if (canRaw) sin.setRawMode?.(false)
+        setInput(editInEditor(input))
+      } catch (e) {
+        addEntry({ kind: 'error', text: `editor failed: ${(e as Error).message}` })
+      } finally {
+        if (canRaw) sin.setRawMode?.(true)
+        setThemeVersion((v) => v + 1) // repaint after the editor released the screen
+      }
       return
     }
     // Shift+Tab: cycle permission mode (the original's mode cycle, §5/§8).

--- a/ui-tui/src/editor.ts
+++ b/ui-tui/src/editor.ts
@@ -1,0 +1,28 @@
+/**
+ * External-editor support (the original's Ctrl+G / Ctrl+X Ctrl+E, inventory §8):
+ * open the current prompt in $VISUAL/$EDITOR, then read the edited text back.
+ * Synchronous (execSync) so the editor owns the terminal while it runs — callers
+ * drop raw mode around the call. Kept as a pure helper so it's unit-testable with
+ * a non-interactive $EDITOR script.
+ */
+import { execSync } from 'node:child_process'
+import { writeFileSync, readFileSync, unlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+export function editInEditor(text: string): string {
+  const editor = process.env['VISUAL'] || process.env['EDITOR'] || 'vi'
+  const file = join(tmpdir(), `clawcodex-edit-${process.pid}.txt`)
+  writeFileSync(file, text, 'utf8')
+  try {
+    execSync(`${editor} ${JSON.stringify(file)}`, { stdio: 'inherit' })
+    // Editors conventionally leave a trailing newline; drop a single one.
+    return readFileSync(file, 'utf8').replace(/\n$/, '')
+  } finally {
+    try {
+      unlinkSync(file)
+    } catch {
+      /* ignore */
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Ports the original's external-editor keybinding (inventory §8). `Ctrl+G` writes the current prompt to a temp file, opens it in `$VISUAL`/`$EDITOR` (default `vi`), and reads the edited text back into the input. Raw mode is dropped around the editor (with a `finally` to always restore it) so the editor owns the terminal; a repaint follows. `editInEditor()` is a pure helper for testability.

## Verification
`editInEditor("hello world")` with a non-interactive uppercasing `$EDITOR` → "HELLO WORLD"; in-app `Ctrl+G` on "edit me" → "EDIT ME". typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)