### PR TITLE
feat(ui-tui): inline ghost-text slash completion

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -1853,6 +1853,22 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
               active
               placeholder={ready ? 'Type a message, or / for commands…' : 'starting agent-server…'}
             />
+            {/* Inline ghost-text completion for slash commands (inventory §1):
+                dim suffix of the top match; Tab/Enter accepts via the menu. */}
+            {(() => {
+              const top = slashMatches[0]
+              if (
+                !vimMode &&
+                top &&
+                input.startsWith('/') &&
+                !input.includes(' ') &&
+                top.name.startsWith(input) &&
+                top.name.length > input.length
+              ) {
+                return <Text color={theme.dim}>{top.name.slice(input.length)}</Text>
+              }
+              return null
+            })()}
           </Box>
         </>
       )}


### PR DESCRIPTION
## Summary
Ports the original's inline ghost-text (inventory §1): while typing a slash command, the dim suffix of the top match is shown inline after the cursor (e.g. "/sett" → "/sett" + dim "ings"). Tab/Enter accepts it via the existing menu. Shown only for a single partial `/token` in non-vim mode.

## Verification
Typing "/sett" renders dim "ings" on the input line (→ `/settings`). typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)