### PR TITLE
feat(tui+backend): functional output styles (/output-style)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -218,6 +218,9 @@ class _AgentSession:
         if subtype == "set_provider":
             self._do_set_provider(request_id, inner.get("provider"))
             return
+        if subtype == "set_output_style":
+            self._do_set_output_style(request_id, inner.get("style"))
+            return
         if subtype == "set_effort":
             effort = inner.get("effort")
             if isinstance(effort, str) and effort in ("minimal", "low", "medium", "high"):
@@ -513,6 +516,43 @@ class _AgentSession:
             self._reply(request_id, {"ok": True, "provider": name, "model": model or ""})
         except Exception as exc:  # noqa: BLE001
             logger.exception("[agent-server] set_provider failed")
+            self._reply(request_id, {"ok": False, "error": str(exc)})
+
+    def _do_set_output_style(self, request_id: object, style: object) -> None:
+        """Switch the output style mid-session (the original's /output-style).
+        Sets tool_context.output_style_name + rebuilds the system prompt so the
+        style's section is appended on the next turn. Idle-only."""
+        with self._lock:
+            active = self._current_abort is not None
+        if active:
+            self._reply(request_id, {"ok": False, "error": "cannot change output style during an active turn"})
+            return
+        try:
+            from src.settings.constants import VALID_OUTPUT_STYLES
+
+            if not isinstance(style, str) or style not in VALID_OUTPUT_STYLES:
+                self._reply(
+                    request_id,
+                    {"ok": False, "error": f"invalid style (valid: {', '.join(VALID_OUTPUT_STYLES)})"},
+                )
+                return
+            tc = self.tool_context
+            if tc is None:
+                self._reply(request_id, {"ok": False, "error": "session not ready"})
+                return
+            tc.output_style_name = style
+            # Rebuild the system prompt so the style section takes effect next turn.
+            try:
+                from src.outputStyles import resolve_output_style
+                from src.query.agent_loop_compat import build_effective_system_prompt
+
+                style_prompt = resolve_output_style(style, getattr(tc, "output_style_dir", None)).prompt
+                self.system_prompt = build_effective_system_prompt(style_prompt, tc, provider=self.provider)
+            except Exception:  # noqa: BLE001 - keep the style set even if rebuild is unavailable
+                logger.debug("[agent-server] system prompt rebuild after set_output_style failed", exc_info=True)
+            self._reply(request_id, {"ok": True, "style": style})
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[agent-server] set_output_style failed")
             self._reply(request_id, {"ok": False, "error": str(exc)})
 
     def _do_branch(self, request_id: object) -> None:

--- a/tests/server/test_agent_server_e2e.py
+++ b/tests/server/test_agent_server_e2e.py
@@ -475,6 +475,40 @@ async def test_control_ops_set_mode_and_get_settings(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_control_set_output_style(tmp_path):
+    """set_output_style validates the style and accepts a valid one."""
+    from src.tool_system.registry import ToolRegistry
+
+    with contextlib.ExitStack() as stack:
+        for p in _patches(_TextProvider, ToolRegistry([])):
+            stack.enter_context(p)
+        spawn = make_spawn_agent(AgentServerConfig(permission_mode="default"))
+        handle = await spawn("ds_test", str(tmp_path), None)
+        gen = handle.messages_from_agent()
+        try:
+            init = await asyncio.wait_for(gen.__anext__(), timeout=5)
+            assert init["subtype"] == "init"
+
+            async def _reply_for(rid, req):
+                await handle.send_to_agent({"type": "control_request", "request_id": rid, "request": req})
+                for _ in range(12):
+                    msg = await asyncio.wait_for(gen.__anext__(), timeout=5)
+                    if msg.get("type") == "control_response" and msg["response"].get("request_id") == rid:
+                        return msg["response"]["response"]
+                raise AssertionError(f"no reply for {rid}")
+
+            ok = await _reply_for("s1", {"subtype": "set_output_style", "style": "concise"})
+            assert ok["ok"] is True and ok["style"] == "concise"
+
+            bad = await _reply_for("s2", {"subtype": "set_output_style", "style": "bogus"})
+            assert bad["ok"] is False and "valid" in bad["error"]
+        finally:
+            await handle.shutdown()
+            with contextlib.suppress(Exception):
+                await gen.aclose()
+
+
+@pytest.mark.asyncio
 async def test_interrupt_trips_abort(tmp_path):
     """An interrupt control_request must trip the in-flight turn's abort."""
     from src.permissions.types import PermissionPassthroughResult

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -296,7 +296,16 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const pasteCounter = useRef(0)
   // Interactive select picker (the original's CustomSelect) for /mode, /theme.
   const [picker, setPicker] = useState<{
-    kind: 'mode' | 'theme' | 'model' | 'resume' | 'rewindpick' | 'historyrecall' | 'settings' | 'difffile'
+    kind:
+      | 'mode'
+      | 'theme'
+      | 'model'
+      | 'resume'
+      | 'rewindpick'
+      | 'historyrecall'
+      | 'settings'
+      | 'difffile'
+      | 'outputstyle'
     title: string
     options: string[]
     /** Optional value per option (e.g. session_id); falls back to the label. */
@@ -402,10 +411,29 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   }
 
   const applyPick = (
-    kind: 'mode' | 'theme' | 'model' | 'resume' | 'rewindpick' | 'historyrecall' | 'settings' | 'difffile',
+    kind:
+      | 'mode'
+      | 'theme'
+      | 'model'
+      | 'resume'
+      | 'rewindpick'
+      | 'historyrecall'
+      | 'settings'
+      | 'difffile'
+      | 'outputstyle',
     value: string,
   ): void => {
     if (!value) return
+    if (kind === 'outputstyle') {
+      void client?.requestControl('set_output_style', { style: value }).then((r) => {
+        if (r && r['ok']) {
+          addEntry({ kind: 'system', text: `output style → ${value}` })
+        } else {
+          addEntry({ kind: 'error', text: `output style failed: ${r && r['error'] ? String(r['error']) : 'no response'}` })
+        }
+      })
+      return
+    }
     if (kind === 'rewindpick') {
       requestRewind(Number(value) || 1)
       return
@@ -1014,6 +1042,15 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       }
       case 'stickers': {
         addEntry({ kind: 'system', text: 'Claude Code stickers: https://www.stickermule.com/claudecode' })
+        return true
+      }
+      case 'outputStyle': {
+        setPicker({
+          kind: 'outputstyle',
+          title: 'Output style',
+          options: ['default', 'concise', 'verbose', 'markdown'],
+          sel: 0,
+        })
         return true
       }
       case 'tasks': {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -47,6 +47,7 @@ export interface SlashCommand {
     | 'history'
     | 'settings'
     | 'tasks'
+    | 'outputStyle'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -105,6 +106,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/history', description: 'Pick a past prompt to recall', kind: 'history' },
   { name: '/settings', description: 'Open the settings menu', kind: 'settings' },
   { name: '/tasks', description: 'Show the current turn + queued prompts', kind: 'tasks' },
+  { name: '/output-style', description: 'Set the response output style', kind: 'outputStyle' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Wires output styles **end-to-end** (inventory §2/§6) — previously the setting existed but was never applied. 

**Backend**: new `set_output_style` control sets `tool_context.output_style_name` and **rebuilds the session system prompt** (idle-guarded) so the style's "# Output Style" section is appended on the next turn; validates against `VALID_OUTPUT_STYLES`.

**TUI**: `/output-style` opens a picker (default/concise/verbose/markdown) → `set_output_style`.

## Verification
Backend e2e (new test): "concise" accepted, "bogus" rejected. TUI: picker → `set_output_style` sent → "output style → concise". Full server suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)