### PR TITLE
feat(tui+backend): knowledge graph (/knowledge), functional first version

### DIFF
--- a/src/knowledge/__init__.py
+++ b/src/knowledge/__init__.py
@@ -1,0 +1,12 @@
+"""Knowledge graph — a lightweight, auto-populated store of entities the agent has
+encountered (files, symbols, URLs), the foundation of the original's /knowledge.
+
+This is the heuristic first version: entities are extracted from conversation text
+by pattern (file paths, `backtick` symbols, URLs) rather than the original's
+model-based semantic extraction + @orama search, which is a follow-up. The store,
+persistence, and /knowledge command surface are functional end-to-end.
+"""
+
+from .graph import Entity, KnowledgeGraph, default_graph_path
+
+__all__ = ["Entity", "KnowledgeGraph", "default_graph_path"]

--- a/src/knowledge/graph.py
+++ b/src/knowledge/graph.py
@@ -1,0 +1,118 @@
+"""Knowledge graph store + heuristic entity extraction.
+
+Entities are keyed by (type, name); each tracks how many times it's been seen and
+when last seen. ``record_from_text`` extracts entities by pattern. Persistence is a
+single JSON file (default ``~/.clawcodex/knowledge/graph.json``).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+
+def default_graph_path() -> Path:
+    return Path.home() / ".clawcodex" / "knowledge" / "graph.json"
+
+
+@dataclass
+class Entity:
+    name: str
+    type: str  # "file" | "symbol" | "url"
+    count: int = 1
+    last_seen: float = 0.0
+    attributes: dict[str, str] = field(default_factory=dict)
+
+
+# Extraction patterns (heuristic). Kept deliberately low-noise.
+_FILE_RE = re.compile(r"(?<![\w/])([\w./-]+\.(?:py|ts|tsx|js|jsx|md|json|toml|yaml|yml|rs|go|sh|txt))\b")
+_SYMBOL_RE = re.compile(r"`([A-Za-z_][\w./]{1,60})`")
+_URL_RE = re.compile(r"https?://[^\s)\]>'\"]+")
+
+
+class KnowledgeGraph:
+    """In-memory entity store with heuristic extraction + JSON persistence."""
+
+    def __init__(self) -> None:
+        self.entities: dict[str, Entity] = {}  # key: f"{type}:{name}"
+
+    @staticmethod
+    def _key(name: str, etype: str) -> str:
+        return f"{etype}:{name}"
+
+    def add(self, name: str, etype: str, now: float = 0.0) -> None:
+        name = name.strip()
+        if not name:
+            return
+        key = self._key(name, etype)
+        ent = self.entities.get(key)
+        if ent is None:
+            self.entities[key] = Entity(name=name, type=etype, count=1, last_seen=now)
+        else:
+            ent.count += 1
+            if now:
+                ent.last_seen = now
+
+    def record_from_text(self, text: str, now: float = 0.0) -> int:
+        """Extract entities from ``text``; returns the number of mentions recorded."""
+        if not text:
+            return 0
+        n = 0
+        for m in _FILE_RE.finditer(text):
+            self.add(m.group(1), "file", now)
+            n += 1
+        for m in _SYMBOL_RE.finditer(text):
+            self.add(m.group(1), "symbol", now)
+            n += 1
+        for m in _URL_RE.finditer(text):
+            self.add(m.group(0), "url", now)
+            n += 1
+        return n
+
+    def stats(self) -> dict[str, int]:
+        by_type: dict[str, int] = {}
+        for ent in self.entities.values():
+            by_type[ent.type] = by_type.get(ent.type, 0) + 1
+        return {"total": len(self.entities), **by_type}
+
+    def top(self, limit: int = 20) -> list[Entity]:
+        return sorted(self.entities.values(), key=lambda e: (-e.count, -e.last_seen, e.name))[:limit]
+
+    def clear(self) -> None:
+        self.entities.clear()
+
+    # — persistence —
+    def to_dict(self) -> dict:
+        return {"entities": [asdict(e) for e in self.entities.values()]}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "KnowledgeGraph":
+        g = cls()
+        for e in data.get("entities", []) or []:
+            try:
+                ent = Entity(
+                    name=str(e["name"]),
+                    type=str(e.get("type", "")),
+                    count=int(e.get("count", 1)),
+                    last_seen=float(e.get("last_seen", 0.0)),
+                    attributes=dict(e.get("attributes", {})),
+                )
+                g.entities[cls._key(ent.name, ent.type)] = ent
+            except Exception:  # noqa: BLE001 - skip malformed entries
+                continue
+        return g
+
+    def save(self, path: Path | None = None) -> None:
+        p = path or default_graph_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(self.to_dict()), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: Path | None = None) -> "KnowledgeGraph":
+        p = path or default_graph_path()
+        try:
+            return cls.from_dict(json.loads(p.read_text(encoding="utf-8")))
+        except Exception:  # noqa: BLE001 - missing/corrupt → empty graph
+            return cls()

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -114,6 +114,8 @@ class _AgentSession:
     _session_name: str | None = None  # user-set label (/rename) shown in /resume
     _mcp_runtime: Any = None  # McpRuntime (connected MCP servers) when configured
     _effort: str | None = None  # /effort reasoning level, injected via extra_body when set
+    _knowledge: Any = None  # KnowledgeGraph (lazy-loaded), populated at each turn end
+    _knowledge_enabled: bool = True  # the original's knowledgeGraphEnabled (default on)
 
     # Worker + cross-thread coordination.
     _inbox: _queue.Queue = field(default_factory=_queue.Queue)
@@ -220,6 +222,9 @@ class _AgentSession:
             return
         if subtype == "set_output_style":
             self._do_set_output_style(request_id, inner.get("style"))
+            return
+        if subtype == "knowledge":
+            self._do_knowledge(request_id, inner.get("action"))
             return
         if subtype == "set_effort":
             effort = inner.get("effort")
@@ -469,6 +474,43 @@ class _AgentSession:
             (d / f"{self.session_id}.json").write_text(json.dumps(payload), encoding="utf-8")
         except Exception:  # noqa: BLE001 — persistence must never break a turn
             logger.debug("[agent-server] session save failed", exc_info=True)
+        self._record_knowledge()
+
+    @staticmethod
+    def _message_text(msg: object) -> str:
+        """Best-effort text of a conversation message (str content or text blocks)."""
+        content = getattr(msg, "content", None)
+        if content is None and isinstance(msg, dict):
+            content = msg.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for b in content:
+                t = getattr(b, "text", None)
+                if t is None and isinstance(b, dict):
+                    t = b.get("text")
+                if isinstance(t, str):
+                    parts.append(t)
+            return "\n".join(parts)
+        return ""
+
+    def _record_knowledge(self) -> None:
+        """Extract entities from the latest exchange into the knowledge graph
+        (the original's /knowledge auto-learning). Best-effort; gated by the flag."""
+        if not self._knowledge_enabled or self.session is None:
+            return
+        try:
+            from src.knowledge import KnowledgeGraph
+
+            if self._knowledge is None:
+                self._knowledge = KnowledgeGraph.load()
+            msgs = self.session.conversation.messages
+            text = "\n".join(self._message_text(m) for m in msgs[-2:])  # last user+assistant
+            if self._knowledge.record_from_text(text, now=time.time()):
+                self._knowledge.save()
+        except Exception:  # noqa: BLE001 — knowledge must never break a turn
+            logger.debug("[agent-server] knowledge record failed", exc_info=True)
 
     def _do_set_provider(self, request_id: object, name: object) -> None:
         """Switch the LLM provider mid-session (the original's /provider). Rebuilds
@@ -516,6 +558,37 @@ class _AgentSession:
             self._reply(request_id, {"ok": True, "provider": name, "model": model or ""})
         except Exception as exc:  # noqa: BLE001
             logger.exception("[agent-server] set_provider failed")
+            self._reply(request_id, {"ok": False, "error": str(exc)})
+
+    def _do_knowledge(self, request_id: object, action: object) -> None:
+        """/knowledge: status (default) | list | clear | enable | disable. Surfaces
+        the auto-populated knowledge graph (the original's Knowledge Graph engine)."""
+        try:
+            from src.knowledge import KnowledgeGraph
+
+            if self._knowledge is None:
+                self._knowledge = KnowledgeGraph.load()
+            act = str(action or "status").strip().lower()
+            if act == "clear":
+                self._knowledge.clear()
+                self._knowledge.save()
+                self._reply(request_id, {"ok": True, "enabled": self._knowledge_enabled, "stats": self._knowledge.stats()})
+                return
+            if act in ("enable", "disable"):
+                self._knowledge_enabled = act == "enable"
+                self._reply(request_id, {"ok": True, "enabled": self._knowledge_enabled, "stats": self._knowledge.stats()})
+                return
+            entities = (
+                [{"name": e.name, "type": e.type, "count": e.count} for e in self._knowledge.top(20)]
+                if act == "list"
+                else []
+            )
+            self._reply(
+                request_id,
+                {"ok": True, "enabled": self._knowledge_enabled, "stats": self._knowledge.stats(), "entities": entities},
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[agent-server] knowledge failed")
             self._reply(request_id, {"ok": False, "error": str(exc)})
 
     def _do_set_output_style(self, request_id: object, style: object) -> None:

--- a/tests/knowledge/test_graph.py
+++ b/tests/knowledge/test_graph.py
@@ -1,0 +1,42 @@
+"""Knowledge graph store + heuristic extraction tests."""
+
+from src.knowledge import KnowledgeGraph
+
+
+def test_record_extracts_files_symbols_urls():
+    g = KnowledgeGraph()
+    g.record_from_text("Edited src/app.py and `build_registry`; see https://example.com/docs", now=1.0)
+    stats = g.stats()
+    assert stats["file"] == 1
+    assert stats["symbol"] == 1
+    assert stats["url"] == 1
+    assert stats["total"] == 3
+
+
+def test_count_and_top():
+    g = KnowledgeGraph()
+    g.record_from_text("a.py a.py b.py", now=1.0)  # a.py twice, b.py once
+    top = g.top()
+    assert top[0].name == "a.py" and top[0].count == 2
+    assert any(e.name == "b.py" for e in top)
+
+
+def test_persistence_roundtrip(tmp_path):
+    p = tmp_path / "graph.json"
+    g = KnowledgeGraph()
+    g.record_from_text("module main.ts has `Foo`", now=2.0)
+    g.save(p)
+    g2 = KnowledgeGraph.load(p)
+    assert g2.stats()["total"] == g.stats()["total"]
+    assert any(e.name == "main.ts" for e in g2.entities.values())
+
+
+def test_clear():
+    g = KnowledgeGraph()
+    g.record_from_text("x.py", now=1.0)
+    g.clear()
+    assert g.stats()["total"] == 0
+
+
+def test_load_missing_is_empty(tmp_path):
+    assert KnowledgeGraph.load(tmp_path / "nope.json").stats()["total"] == 0

--- a/tests/server/test_agent_server_e2e.py
+++ b/tests/server/test_agent_server_e2e.py
@@ -509,6 +509,43 @@ async def test_control_set_output_style(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_control_knowledge(tmp_path):
+    """knowledge control returns stats and toggles enable/disable."""
+    from src.tool_system.registry import ToolRegistry
+
+    with contextlib.ExitStack() as stack:
+        for p in _patches(_TextProvider, ToolRegistry([])):
+            stack.enter_context(p)
+        spawn = make_spawn_agent(AgentServerConfig(permission_mode="default"))
+        handle = await spawn("ds_test", str(tmp_path), None)
+        gen = handle.messages_from_agent()
+        try:
+            init = await asyncio.wait_for(gen.__anext__(), timeout=5)
+            assert init["subtype"] == "init"
+
+            async def _reply_for(rid, req):
+                await handle.send_to_agent({"type": "control_request", "request_id": rid, "request": req})
+                for _ in range(12):
+                    msg = await asyncio.wait_for(gen.__anext__(), timeout=5)
+                    if msg.get("type") == "control_response" and msg["response"].get("request_id") == rid:
+                        return msg["response"]["response"]
+                raise AssertionError(f"no reply for {rid}")
+
+            st = await _reply_for("k1", {"subtype": "knowledge", "action": "status"})
+            assert st["ok"] is True and "total" in st["stats"] and st["enabled"] is True
+
+            off = await _reply_for("k2", {"subtype": "knowledge", "action": "disable"})
+            assert off["enabled"] is False
+
+            lst = await _reply_for("k3", {"subtype": "knowledge", "action": "list"})
+            assert lst["ok"] is True and isinstance(lst["entities"], list)
+        finally:
+            await handle.shutdown()
+            with contextlib.suppress(Exception):
+                await gen.aclose()
+
+
+@pytest.mark.asyncio
 async def test_interrupt_trips_abort(tmp_path):
     """An interrupt control_request must trip the in-flight turn's abort."""
     from src.permissions.types import PermissionPassthroughResult

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -1053,6 +1053,22 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         })
         return true
       }
+      case 'knowledge': {
+        const action = (arg || 'status').trim().toLowerCase()
+        void client?.requestControl('knowledge', { action }).then((r) => {
+          if (!r || !r['ok']) {
+            addEntry({ kind: 'error', text: `knowledge failed: ${r && r['error'] ? String(r['error']) : 'no response'}` })
+            return
+          }
+          const st = (r['stats'] as Record<string, number>) || {}
+          const en = r['enabled'] ? 'enabled' : 'disabled'
+          const head = `Knowledge graph: ${en} · ${st['total'] || 0} entities (${st['file'] || 0} files, ${st['symbol'] || 0} symbols, ${st['url'] || 0} urls)`
+          const ents = (r['entities'] as Array<{ name: string; type: string; count: number }>) || []
+          const lines = ents.map((e) => `  ${e.type === 'file' ? '📄' : e.type === 'url' ? '🔗' : '◆'} ${e.name} ·${e.count}`)
+          addEntry({ kind: 'system', text: lines.length ? `${head}\n${lines.join('\n')}` : head })
+        })
+        return true
+      }
       case 'tasks': {
         const lines: string[] = []
         if (busy) lines.push(`● running — ${toolActivity || 'agent turn in progress'}`)

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -48,6 +48,7 @@ export interface SlashCommand {
     | 'settings'
     | 'tasks'
     | 'outputStyle'
+    | 'knowledge'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -107,6 +108,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/settings', description: 'Open the settings menu', kind: 'settings' },
   { name: '/tasks', description: 'Show the current turn + queued prompts', kind: 'tasks' },
   { name: '/output-style', description: 'Set the response output style', kind: 'outputStyle' },
+  { name: '/knowledge', description: 'Knowledge graph: /knowledge [list|clear|enable|disable]', kind: 'knowledge' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports the original's Knowledge Graph engine (`/knowledge`) as a **functional store** (the first big-backend subsystem from the remaining frontier).

**Backend** (`src/knowledge/`): `KnowledgeGraph` — entities keyed by `type:name` with count/last_seen, heuristic `record_from_text` (files, `` `symbols` ``, urls), JSON persistence at `~/.clawcodex/knowledge/graph.json`. The agent-server **auto-records from the latest exchange at each turn end** (gated by `_knowledge_enabled`, default on) and exposes a `knowledge` control (status/list/clear/enable/disable).

**TUI**: `/knowledge [list|clear|enable|disable]` shows counts + top entities.

Heuristic extraction now; the original's model-based semantic extraction + `@orama` search is a follow-up. Store, persistence, recording, control, and command are functional + tested.

## Verification
Store unit tests (extract/count/persist/clear/missing); backend e2e (status/disable/list round-trip); TUI `/knowledge list` renders counts + entities. Full server suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)