### PR TITLE
feat(tui+backend): project wiki (/wiki init|status|ingest)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -226,6 +226,9 @@ class _AgentSession:
         if subtype == "knowledge":
             self._do_knowledge(request_id, inner.get("action"))
             return
+        if subtype == "wiki":
+            self._do_wiki(request_id, inner.get("action"), inner.get("path"))
+            return
         if subtype == "set_effort":
             effort = inner.get("effort")
             if isinstance(effort, str) and effort in ("minimal", "low", "medium", "high"):
@@ -558,6 +561,26 @@ class _AgentSession:
             self._reply(request_id, {"ok": True, "provider": name, "model": model or ""})
         except Exception as exc:  # noqa: BLE001
             logger.exception("[agent-server] set_provider failed")
+            self._reply(request_id, {"ok": False, "error": str(exc)})
+
+    def _do_wiki(self, request_id: object, action: object, path: object) -> None:
+        """/wiki: init | status | ingest <path>. File-based project wiki under
+        .clawcodex/wiki (the original's /wiki)."""
+        try:
+            from src.wiki import ingest_source, init_wiki, wiki_status
+
+            act = str(action or "status").strip().lower()
+            if act == "init":
+                self._reply(request_id, {"ok": True, **init_wiki(self.cwd)})
+            elif act == "ingest":
+                if not isinstance(path, str) or not path.strip():
+                    self._reply(request_id, {"ok": False, "error": "usage: /wiki ingest <path>"})
+                    return
+                self._reply(request_id, ingest_source(self.cwd, path.strip()))
+            else:
+                self._reply(request_id, {"ok": True, **wiki_status(self.cwd)})
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[agent-server] wiki failed")
             self._reply(request_id, {"ok": False, "error": str(exc)})
 
     def _do_knowledge(self, request_id: object, action: object) -> None:

--- a/src/wiki/__init__.py
+++ b/src/wiki/__init__.py
@@ -1,0 +1,9 @@
+"""Project wiki (the original's /wiki) — a file-based knowledge area under
+``.clawcodex/wiki`` with pages/, sources/, and top-level index/log/schema files.
+Supports init (create structure), status (counts), and ingest (copy a file into
+sources/). Mirrors typescript/src/services/wiki.
+"""
+
+from .wiki import get_wiki_paths, ingest_source, init_wiki, wiki_status
+
+__all__ = ["get_wiki_paths", "init_wiki", "wiki_status", "ingest_source"]

--- a/src/wiki/wiki.py
+++ b/src/wiki/wiki.py
@@ -1,0 +1,112 @@
+"""Project wiki file management: init / status / ingest."""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+CLAWCODEX_DIRNAME = ".clawcodex"
+WIKI_DIRNAME = "wiki"
+
+
+@dataclass
+class WikiPaths:
+    root: Path
+    pages_dir: Path
+    sources_dir: Path
+    schema_file: Path
+    index_file: Path
+    log_file: Path
+
+
+def get_wiki_paths(cwd: str | Path) -> WikiPaths:
+    root = Path(cwd) / CLAWCODEX_DIRNAME / WIKI_DIRNAME
+    return WikiPaths(
+        root=root,
+        pages_dir=root / "pages",
+        sources_dir=root / "sources",
+        schema_file=root / "schema.md",
+        index_file=root / "index.md",
+        log_file=root / "log.md",
+    )
+
+
+def _schema_template(project: str) -> str:
+    return (
+        f"# {project} Wiki — Schema\n\n"
+        "How this wiki is organized:\n\n"
+        "- `index.md`: top-level navigation and major topics\n"
+        "- `log.md`: append-only update log\n"
+        "- `pages/`: durable topic and architecture pages\n"
+        "- `sources/`: ingested source notes and summaries\n\n"
+        "Keep pages focused on one topic.\n"
+    )
+
+
+def _index_template(project: str) -> str:
+    return (
+        f"# {project} Wiki\n\n"
+        "## Pages\n\n- [Architecture](./pages/architecture.md)\n\n"
+        "## Sources\n\nSource notes live in [sources/](./sources/)\n\n"
+        "## Log\n\nSee [log.md](./log.md)\n"
+    )
+
+
+def _log_template() -> str:
+    return "# Update Log\n\n- wiki initialized\n"
+
+
+def _architecture_template(project: str) -> str:
+    return f"# Architecture\n\n_Describe {project}'s architecture here._\n"
+
+
+def _ensure_file(path: Path, content: str, created: list[str]) -> None:
+    if not path.exists():
+        path.write_text(content, encoding="utf-8")
+        created.append(str(path))
+
+
+def init_wiki(cwd: str | Path) -> dict:
+    paths = get_wiki_paths(cwd)
+    already = paths.index_file.exists()
+    created: list[str] = []
+    for d in (paths.root, paths.pages_dir, paths.sources_dir):
+        d.mkdir(parents=True, exist_ok=True)
+    project = Path(cwd).name or "project"
+    _ensure_file(paths.schema_file, _schema_template(project), created)
+    _ensure_file(paths.index_file, _index_template(project), created)
+    _ensure_file(paths.log_file, _log_template(), created)
+    _ensure_file(paths.pages_dir / "architecture.md", _architecture_template(project), created)
+    return {"root": str(paths.root), "created_files": created, "already_existed": already}
+
+
+def wiki_status(cwd: str | Path) -> dict:
+    paths = get_wiki_paths(cwd)
+    if not paths.index_file.exists():
+        return {"initialized": False, "root": str(paths.root), "page_count": 0, "source_count": 0}
+    pages = len(list(paths.pages_dir.glob("*.md"))) if paths.pages_dir.exists() else 0
+    sources = len(list(paths.sources_dir.glob("*"))) if paths.sources_dir.exists() else 0
+    return {"initialized": True, "root": str(paths.root), "page_count": pages, "source_count": sources}
+
+
+def ingest_source(cwd: str | Path, src: str) -> dict:
+    paths = get_wiki_paths(cwd)
+    if not paths.index_file.exists():
+        return {"ok": False, "error": "wiki not initialized — run /wiki init first"}
+    src_path = Path(src)
+    if not src_path.is_absolute():
+        src_path = Path(cwd) / src
+    if not src_path.is_file():
+        return {"ok": False, "error": f"not a file: {src}"}
+    dest = paths.sources_dir / src_path.name
+    try:
+        shutil.copyfile(src_path, dest)
+    except Exception as exc:  # noqa: BLE001
+        return {"ok": False, "error": str(exc)}
+    try:  # append to the log (best-effort)
+        with paths.log_file.open("a", encoding="utf-8") as f:
+            f.write(f"- ingested source: {src_path.name}\n")
+    except Exception:  # noqa: BLE001
+        pass
+    return {"ok": True, "dest": str(dest)}

--- a/tests/server/test_agent_server_e2e.py
+++ b/tests/server/test_agent_server_e2e.py
@@ -546,6 +546,43 @@ async def test_control_knowledge(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_control_wiki(tmp_path):
+    """wiki control inits the structure and reports status."""
+    from src.tool_system.registry import ToolRegistry
+
+    with contextlib.ExitStack() as stack:
+        for p in _patches(_TextProvider, ToolRegistry([])):
+            stack.enter_context(p)
+        spawn = make_spawn_agent(AgentServerConfig(permission_mode="default"))
+        handle = await spawn("ds_test", str(tmp_path), None)
+        gen = handle.messages_from_agent()
+        try:
+            init = await asyncio.wait_for(gen.__anext__(), timeout=5)
+            assert init["subtype"] == "init"
+
+            async def _reply_for(rid, req):
+                await handle.send_to_agent({"type": "control_request", "request_id": rid, "request": req})
+                for _ in range(12):
+                    msg = await asyncio.wait_for(gen.__anext__(), timeout=5)
+                    if msg.get("type") == "control_response" and msg["response"].get("request_id") == rid:
+                        return msg["response"]["response"]
+                raise AssertionError(f"no reply for {rid}")
+
+            before = await _reply_for("w0", {"subtype": "wiki", "action": "status"})
+            assert before["initialized"] is False
+
+            ini = await _reply_for("w1", {"subtype": "wiki", "action": "init"})
+            assert ini["ok"] is True and len(ini["created_files"]) >= 4
+
+            after = await _reply_for("w2", {"subtype": "wiki", "action": "status"})
+            assert after["initialized"] is True and after["page_count"] == 1
+        finally:
+            await handle.shutdown()
+            with contextlib.suppress(Exception):
+                await gen.aclose()
+
+
+@pytest.mark.asyncio
 async def test_interrupt_trips_abort(tmp_path):
     """An interrupt control_request must trip the in-flight turn's abort."""
     from src.permissions.types import PermissionPassthroughResult

--- a/tests/wiki/test_wiki.py
+++ b/tests/wiki/test_wiki.py
@@ -1,0 +1,43 @@
+"""Project wiki init/status/ingest tests."""
+
+from src.wiki import get_wiki_paths, ingest_source, init_wiki, wiki_status
+
+
+def test_init_creates_structure(tmp_path):
+    res = init_wiki(tmp_path)
+    assert res["already_existed"] is False
+    assert len(res["created_files"]) >= 4  # schema, index, log, architecture
+    paths = get_wiki_paths(tmp_path)
+    assert paths.index_file.exists()
+    assert paths.pages_dir.is_dir() and paths.sources_dir.is_dir()
+    assert (paths.pages_dir / "architecture.md").exists()
+
+
+def test_init_idempotent(tmp_path):
+    init_wiki(tmp_path)
+    res2 = init_wiki(tmp_path)
+    assert res2["already_existed"] is True
+    assert res2["created_files"] == []
+
+
+def test_status_before_and_after(tmp_path):
+    assert wiki_status(tmp_path)["initialized"] is False
+    init_wiki(tmp_path)
+    st = wiki_status(tmp_path)
+    assert st["initialized"] is True
+    assert st["page_count"] == 1  # architecture.md
+
+
+def test_ingest_copies_into_sources(tmp_path):
+    (tmp_path / "README.md").write_text("# Readme", encoding="utf-8")
+    assert ingest_source(tmp_path, "README.md")["ok"] is False  # not initialized yet
+    init_wiki(tmp_path)
+    res = ingest_source(tmp_path, "README.md")
+    assert res["ok"] is True
+    assert (get_wiki_paths(tmp_path).sources_dir / "README.md").exists()
+    assert wiki_status(tmp_path)["source_count"] == 1
+
+
+def test_ingest_missing_file(tmp_path):
+    init_wiki(tmp_path)
+    assert ingest_source(tmp_path, "nope.md")["ok"] is False

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -1053,6 +1053,36 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         })
         return true
       }
+      case 'wiki': {
+        const parts = arg.trim().split(/\s+/).filter(Boolean)
+        const action = (parts[0] || 'status').toLowerCase()
+        const path = parts.slice(1).join(' ')
+        void client?.requestControl('wiki', { action, path }).then((r) => {
+          if (!r || r['ok'] === false) {
+            addEntry({ kind: 'error', text: `wiki: ${r && r['error'] ? String(r['error']) : 'no response'}` })
+            return
+          }
+          if (action === 'init') {
+            const created = (r['created_files'] as string[]) || []
+            addEntry({
+              kind: 'system',
+              text: r['already_existed']
+                ? `wiki already exists at ${String(r['root'])}`
+                : `✓ wiki initialized at ${String(r['root'])} (${created.length} files)`,
+            })
+          } else if (action === 'ingest') {
+            addEntry({ kind: 'system', text: `✓ ingested → ${String(r['dest'])}` })
+          } else {
+            addEntry({
+              kind: 'system',
+              text: r['initialized']
+                ? `Wiki: initialized · ${Number(r['page_count']) || 0} pages, ${Number(r['source_count']) || 0} sources`
+                : `Wiki not initialized — run /wiki init (${String(r['root'])})`,
+            })
+          }
+        })
+        return true
+      }
       case 'knowledge': {
         const action = (arg || 'status').trim().toLowerCase()
         void client?.requestControl('knowledge', { action }).then((r) => {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -49,6 +49,7 @@ export interface SlashCommand {
     | 'tasks'
     | 'outputStyle'
     | 'knowledge'
+    | 'wiki'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -109,6 +110,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/tasks', description: 'Show the current turn + queued prompts', kind: 'tasks' },
   { name: '/output-style', description: 'Set the response output style', kind: 'outputStyle' },
   { name: '/knowledge', description: 'Knowledge graph: /knowledge [list|clear|enable|disable]', kind: 'knowledge' },
+  { name: '/wiki', description: 'Project wiki: /wiki [init|status|ingest <path>]', kind: 'wiki' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports the original's `/wiki` as a file-based project wiki under `.clawcodex/wiki` (second big-backend subsystem).

**Backend** (`src/wiki/`): `init` creates `pages/`, `sources/`, `index.md`, `log.md`, `schema.md` + a starter `architecture.md`; `status` counts pages/sources; `ingest` copies a file into `sources/` and logs it. agent-server `wiki` control routes init/status/ingest.

**TUI**: `/wiki [init|status|ingest <path>]`.

## Verification
Wiki unit tests (init/idempotent/status/ingest/missing); backend e2e (status→init→status); TUI `/wiki init` + `status` render. Full server suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)