### PR TITLE
feat(tui+backend): semantic knowledge extraction (/knowledge semantic)

### DIFF
--- a/src/knowledge/__init__.py
+++ b/src/knowledge/__init__.py
@@ -7,6 +7,7 @@ model-based semantic extraction + @orama search, which is a follow-up. The store
 persistence, and /knowledge command surface are functional end-to-end.
 """
 
+from .extract import extract_entities_semantic
 from .graph import Entity, KnowledgeGraph, default_graph_path
 
-__all__ = ["Entity", "KnowledgeGraph", "default_graph_path"]
+__all__ = ["Entity", "KnowledgeGraph", "default_graph_path", "extract_entities_semantic"]

--- a/src/knowledge/extract.py
+++ b/src/knowledge/extract.py
@@ -1,0 +1,41 @@
+"""Model-based semantic entity extraction for the knowledge graph (the original's
+mechanism, opt-in). Asks the provider for a JSON list of entities; falls back to
+[] on any error so the caller can use the heuristic instead.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+_PROMPT = (
+    "Extract the key technical entities discussed in the text below. "
+    'Return ONLY a JSON array of objects with "name" and "type" '
+    "(type one of: file, symbol, concept). At most 10 entities, most important first. "
+    "No prose, no code fences.\n\nTEXT:\n"
+)
+
+
+def extract_entities_semantic(text: str, provider: Any) -> list[tuple[str, str]]:
+    """Return [(name, type), …] extracted by the model; [] on any failure."""
+    if not text or provider is None:
+        return []
+    try:
+        # chat() accepts plain {role, content} dicts (MessageInput = ChatMessage | dict).
+        resp = provider.chat([{"role": "user", "content": _PROMPT + text[:4000]}])
+        raw = (getattr(resp, "content", "") or "").strip()
+        m = re.search(r"\[.*\]", raw, re.S)
+        if not m:
+            return []
+        items = json.loads(m.group(0))
+        out: list[tuple[str, str]] = []
+        for it in items:
+            if isinstance(it, dict) and str(it.get("name", "")).strip():
+                etype = str(it.get("type", "concept")).strip().lower()
+                if etype not in ("file", "symbol", "concept", "url"):
+                    etype = "concept"
+                out.append((str(it["name"]).strip(), etype))
+        return out[:10]
+    except Exception:  # noqa: BLE001 - extraction is best-effort
+        return []

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -116,6 +116,7 @@ class _AgentSession:
     _effort: str | None = None  # /effort reasoning level, injected via extra_body when set
     _knowledge: Any = None  # KnowledgeGraph (lazy-loaded), populated at each turn end
     _knowledge_enabled: bool = True  # the original's knowledgeGraphEnabled (default on)
+    _knowledge_semantic: bool = False  # opt-in model-based extraction (vs heuristic)
 
     # Worker + cross-thread coordination.
     _inbox: _queue.Queue = field(default_factory=_queue.Queue)
@@ -510,7 +511,17 @@ class _AgentSession:
                 self._knowledge = KnowledgeGraph.load()
             msgs = self.session.conversation.messages
             text = "\n".join(self._message_text(m) for m in msgs[-2:])  # last user+assistant
-            if self._knowledge.record_from_text(text, now=time.time()):
+            recorded = False
+            if self._knowledge_semantic and self.provider is not None:
+                from src.knowledge import extract_entities_semantic
+
+                ents = extract_entities_semantic(text, self.provider)
+                for name, etype in ents:
+                    self._knowledge.add(name, etype, now=time.time())
+                recorded = bool(ents)
+            if not recorded:  # heuristic (default, and fallback if semantic yields nothing)
+                recorded = bool(self._knowledge.record_from_text(text, now=time.time()))
+            if recorded:
                 self._knowledge.save()
         except Exception:  # noqa: BLE001 — knowledge must never break a turn
             logger.debug("[agent-server] knowledge record failed", exc_info=True)
@@ -601,6 +612,13 @@ class _AgentSession:
                 self._knowledge_enabled = act == "enable"
                 self._reply(request_id, {"ok": True, "enabled": self._knowledge_enabled, "stats": self._knowledge.stats()})
                 return
+            if act in ("semantic", "heuristic"):
+                self._knowledge_semantic = act == "semantic"
+                self._reply(
+                    request_id,
+                    {"ok": True, "enabled": self._knowledge_enabled, "semantic": self._knowledge_semantic, "stats": self._knowledge.stats()},
+                )
+                return
             entities = (
                 [{"name": e.name, "type": e.type, "count": e.count} for e in self._knowledge.top(20)]
                 if act == "list"
@@ -608,7 +626,13 @@ class _AgentSession:
             )
             self._reply(
                 request_id,
-                {"ok": True, "enabled": self._knowledge_enabled, "stats": self._knowledge.stats(), "entities": entities},
+                {
+                    "ok": True,
+                    "enabled": self._knowledge_enabled,
+                    "semantic": self._knowledge_semantic,
+                    "stats": self._knowledge.stats(),
+                    "entities": entities,
+                },
             )
         except Exception as exc:  # noqa: BLE001
             logger.exception("[agent-server] knowledge failed")

--- a/tests/knowledge/test_extract.py
+++ b/tests/knowledge/test_extract.py
@@ -1,0 +1,41 @@
+"""Semantic entity extraction tests (mock provider)."""
+
+from src.knowledge import extract_entities_semantic
+
+
+class _Resp:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _Provider:
+    def __init__(self, content: str) -> None:
+        self._content = content
+
+    def chat(self, messages, tools=None, **kw):  # noqa: ANN001
+        return _Resp(self._content)
+
+
+def test_parses_json_array():
+    p = _Provider('[{"name":"app.py","type":"file"},{"name":"Foo","type":"symbol"}]')
+    ents = extract_entities_semantic("blah", p)
+    assert ("app.py", "file") in ents
+    assert ("Foo", "symbol") in ents
+
+
+def test_handles_fences_and_prose():
+    p = _Provider('Sure:\n```json\n[{"name":"Caching","type":"concept"}]\n```')
+    assert ("Caching", "concept") in extract_entities_semantic("t", p)
+
+
+def test_unknown_type_defaults_concept():
+    p = _Provider('[{"name":"thing","type":"weird"}]')
+    assert ("thing", "concept") in extract_entities_semantic("t", p)
+
+
+def test_bad_json_returns_empty():
+    assert extract_entities_semantic("t", _Provider("not json")) == []
+
+
+def test_none_provider():
+    assert extract_entities_semantic("t", None) == []

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -1092,7 +1092,8 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
           }
           const st = (r['stats'] as Record<string, number>) || {}
           const en = r['enabled'] ? 'enabled' : 'disabled'
-          const head = `Knowledge graph: ${en} · ${st['total'] || 0} entities (${st['file'] || 0} files, ${st['symbol'] || 0} symbols, ${st['url'] || 0} urls)`
+          const mode = r['semantic'] ? ' · semantic' : ''
+          const head = `Knowledge graph: ${en}${mode} · ${st['total'] || 0} entities (${st['file'] || 0} files, ${st['symbol'] || 0} symbols, ${st['url'] || 0} urls)`
           const ents = (r['entities'] as Array<{ name: string; type: string; count: number }>) || []
           const lines = ents.map((e) => `  ${e.type === 'file' ? '📄' : e.type === 'url' ? '🔗' : '◆'} ${e.name} ·${e.count}`)
           addEntry({ kind: 'system', text: lines.length ? `${head}\n${lines.join('\n')}` : head })


### PR DESCRIPTION
## Summary
Makes the knowledge graph faithful to the original's **model-based extraction**, opt-in. `src/knowledge/extract.py` asks the provider for a JSON entity list (`[{name,type}]`, fenced/prose tolerant, `[]`-on-error). The agent-server gains `_knowledge_semantic` (default off); when on, `_record_knowledge` uses model extraction and falls back to the heuristic if it yields nothing. `/knowledge semantic|heuristic` toggles it; status/list report the mode and the TUI shows "· semantic".

## Verification
Extract unit tests (json/fences/unknown-type/bad-json/none-provider); full knowledge+wiki+server suite (101) green; TUI `/knowledge semantic` shows the mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)