### PR TITLE
feat(tui+backend): background tasks (/bg, /tasks) — §9 Ctrl+B runs

### DIFF
--- a/src/background/__init__.py
+++ b/src/background/__init__.py
@@ -1,0 +1,8 @@
+"""Background tasks (the original's §9 backgroundable runs / Ctrl+B). A registry
+of detached shell commands running concurrently in subprocesses — no conversation
+race (each task is its own process). Surfaced via /bg and /tasks.
+"""
+
+from .tasks import BackgroundTasks, BgTask
+
+__all__ = ["BackgroundTasks", "BgTask"]

--- a/src/background/tasks.py
+++ b/src/background/tasks.py
@@ -1,0 +1,88 @@
+"""Background task registry: detached shell commands in subprocesses."""
+
+from __future__ import annotations
+
+import subprocess
+import threading
+import uuid
+from dataclasses import dataclass
+
+_MAX_OUTPUT = 8000
+
+
+@dataclass
+class BgTask:
+    id: str
+    command: str
+    status: str = "running"  # running | done | failed | killed
+    output: str = ""
+    exit_code: int | None = None
+    started: float = 0.0
+
+
+class BackgroundTasks:
+    """Thread-safe registry of background subprocess tasks."""
+
+    def __init__(self) -> None:
+        self._tasks: dict[str, BgTask] = {}
+        self._procs: dict[str, subprocess.Popen] = {}
+        self._lock = threading.Lock()
+
+    def start(self, command: str, cwd: str, now: float = 0.0) -> BgTask:
+        tid = uuid.uuid4().hex[:8]
+        task = BgTask(id=tid, command=command, status="running", started=now)
+        proc = subprocess.Popen(  # noqa: S602 - intentional shell task, user-initiated
+            command,
+            shell=True,
+            cwd=cwd or None,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        with self._lock:
+            self._tasks[tid] = task
+            self._procs[tid] = proc
+        threading.Thread(target=self._wait, args=(tid, proc), daemon=True).start()
+        return task
+
+    def _wait(self, tid: str, proc: subprocess.Popen) -> None:
+        out = ""
+        try:
+            out, _ = proc.communicate()
+        except Exception:  # noqa: BLE001
+            pass
+        with self._lock:
+            t = self._tasks.get(tid)
+            if t is not None:
+                t.output = (out or "")[-_MAX_OUTPUT:]
+                t.exit_code = proc.returncode
+                if t.status != "killed":
+                    t.status = "done" if proc.returncode == 0 else "failed"
+            self._procs.pop(tid, None)
+
+    def list(self) -> list[BgTask]:
+        with self._lock:
+            return list(self._tasks.values())
+
+    def get(self, tid: str) -> BgTask | None:
+        with self._lock:
+            return self._tasks.get(tid)
+
+    def output(self, tid: str) -> str | None:
+        with self._lock:
+            t = self._tasks.get(tid)
+            return t.output if t is not None else None
+
+    def kill(self, tid: str) -> bool:
+        with self._lock:
+            proc = self._procs.get(tid)
+            t = self._tasks.get(tid)
+            if t is not None and t.status == "running":
+                t.status = "killed"
+        if proc is not None:
+            try:
+                proc.terminate()
+                return True
+            except Exception:  # noqa: BLE001
+                return False
+        return False

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -117,6 +117,7 @@ class _AgentSession:
     _knowledge: Any = None  # KnowledgeGraph (lazy-loaded), populated at each turn end
     _knowledge_enabled: bool = True  # the original's knowledgeGraphEnabled (default on)
     _knowledge_semantic: bool = False  # opt-in model-based extraction (vs heuristic)
+    _bgtasks: Any = None  # BackgroundTasks registry (lazy), the original's Ctrl+B runs
 
     # Worker + cross-thread coordination.
     _inbox: _queue.Queue = field(default_factory=_queue.Queue)
@@ -229,6 +230,9 @@ class _AgentSession:
             return
         if subtype == "wiki":
             self._do_wiki(request_id, inner.get("action"), inner.get("path"))
+            return
+        if subtype in ("bg_run", "bg_list", "bg_kill"):
+            self._do_bgtask(request_id, subtype, inner.get("command"), inner.get("id"))
             return
         if subtype == "set_effort":
             effort = inner.get("effort")
@@ -572,6 +576,41 @@ class _AgentSession:
             self._reply(request_id, {"ok": True, "provider": name, "model": model or ""})
         except Exception as exc:  # noqa: BLE001
             logger.exception("[agent-server] set_provider failed")
+            self._reply(request_id, {"ok": False, "error": str(exc)})
+
+    def _do_bgtask(self, request_id: object, subtype: str, command: object, tid: object) -> None:
+        """Background tasks (the original's Ctrl+B runs): bg_run starts a detached
+        shell command, bg_list lists them, bg_kill terminates one."""
+        try:
+            from src.background import BackgroundTasks
+
+            if self._bgtasks is None:
+                self._bgtasks = BackgroundTasks()
+            if subtype == "bg_run":
+                if not isinstance(command, str) or not command.strip():
+                    self._reply(request_id, {"ok": False, "error": "usage: /bg <command>"})
+                    return
+                t = self._bgtasks.start(command.strip(), self.cwd, now=time.time())
+                self._reply(request_id, {"ok": True, "id": t.id, "command": t.command})
+                return
+            if subtype == "bg_kill":
+                ok = self._bgtasks.kill(str(tid or ""))
+                self._reply(request_id, {"ok": ok})
+                return
+            # bg_list
+            tasks = [
+                {
+                    "id": t.id,
+                    "command": t.command,
+                    "status": t.status,
+                    "exit_code": t.exit_code,
+                    "output": (t.output or "")[-400:],
+                }
+                for t in self._bgtasks.list()
+            ]
+            self._reply(request_id, {"ok": True, "tasks": tasks})
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[agent-server] bgtask failed")
             self._reply(request_id, {"ok": False, "error": str(exc)})
 
     def _do_wiki(self, request_id: object, action: object, path: object) -> None:

--- a/tests/background/test_tasks.py
+++ b/tests/background/test_tasks.py
@@ -1,0 +1,49 @@
+"""Background task registry tests."""
+
+import time
+
+from src.background import BackgroundTasks
+
+
+def _wait_done(reg, tid, timeout=5.0):
+    end = time.time() + timeout
+    while time.time() < end:
+        t = reg.get(tid)
+        if t and t.status != "running":
+            return t
+        time.sleep(0.02)
+    raise AssertionError("task did not finish")
+
+
+def test_start_and_complete(tmp_path):
+    reg = BackgroundTasks()
+    t = reg.start("echo hello", str(tmp_path))
+    assert t.status == "running"
+    done = _wait_done(reg, t.id)
+    assert done.status == "done"
+    assert done.exit_code == 0
+    assert "hello" in done.output
+
+
+def test_failed_exit_code(tmp_path):
+    reg = BackgroundTasks()
+    t = reg.start("exit 3", str(tmp_path))
+    done = _wait_done(reg, t.id)
+    assert done.status == "failed"
+    assert done.exit_code == 3
+
+
+def test_list_and_output(tmp_path):
+    reg = BackgroundTasks()
+    t = reg.start("echo abc", str(tmp_path))
+    _wait_done(reg, t.id)
+    assert any(x.id == t.id for x in reg.list())
+    assert "abc" in (reg.output(t.id) or "")
+
+
+def test_kill(tmp_path):
+    reg = BackgroundTasks()
+    t = reg.start("sleep 10", str(tmp_path))
+    assert reg.kill(t.id) is True
+    done = _wait_done(reg, t.id)
+    assert done.status == "killed"

--- a/tests/server/test_agent_server_e2e.py
+++ b/tests/server/test_agent_server_e2e.py
@@ -583,6 +583,50 @@ async def test_control_wiki(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_control_background_task(tmp_path):
+    """bg_run starts a detached command; bg_list reports it completing."""
+    from src.tool_system.registry import ToolRegistry
+
+    with contextlib.ExitStack() as stack:
+        for p in _patches(_TextProvider, ToolRegistry([])):
+            stack.enter_context(p)
+        spawn = make_spawn_agent(AgentServerConfig(permission_mode="default"))
+        handle = await spawn("ds_test", str(tmp_path), None)
+        gen = handle.messages_from_agent()
+        try:
+            init = await asyncio.wait_for(gen.__anext__(), timeout=5)
+            assert init["subtype"] == "init"
+
+            async def _reply_for(rid, req):
+                await handle.send_to_agent({"type": "control_request", "request_id": rid, "request": req})
+                for _ in range(12):
+                    msg = await asyncio.wait_for(gen.__anext__(), timeout=5)
+                    if msg.get("type") == "control_response" and msg["response"].get("request_id") == rid:
+                        return msg["response"]["response"]
+                raise AssertionError(f"no reply for {rid}")
+
+            run = await _reply_for("b1", {"subtype": "bg_run", "command": "echo hi"})
+            assert run["ok"] is True and run["id"]
+            tid = run["id"]
+
+            # poll until the task completes
+            done = None
+            for i in range(20):
+                lst = await _reply_for(f"bl{i}", {"subtype": "bg_list"})
+                match = [t for t in lst["tasks"] if t["id"] == tid]
+                if match and match[0]["status"] != "running":
+                    done = match[0]
+                    break
+                await asyncio.sleep(0.1)
+            assert done is not None and done["status"] == "done"
+            assert "hi" in done["output"]
+        finally:
+            await handle.shutdown()
+            with contextlib.suppress(Exception):
+                await gen.aclose()
+
+
+@pytest.mark.asyncio
 async def test_interrupt_trips_abort(tmp_path):
     """An interrupt control_request must trip the in-flight turn's abort."""
     from src.permissions.types import PermissionPassthroughResult

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -1100,12 +1100,38 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         })
         return true
       }
+      case 'bg': {
+        const a = arg.trim()
+        if (a.toLowerCase().startsWith('kill ')) {
+          const id = a.slice(5).trim()
+          void client?.requestControl('bg_kill', { id }).then((r) => {
+            addEntry({ kind: 'system', text: r && r['ok'] ? `killed bg task ${id}` : `no such task ${id}` })
+          })
+          return true
+        }
+        if (!a) {
+          addEntry({ kind: 'system', text: 'usage: /bg <command>  (or /bg kill <id>)' })
+          return true
+        }
+        void client?.requestControl('bg_run', { command: a }).then((r) => {
+          if (r && r['ok']) addEntry({ kind: 'system', text: `▶ background task ${String(r['id'])}: ${a}` })
+          else addEntry({ kind: 'error', text: `bg failed: ${r && r['error'] ? String(r['error']) : 'no response'}` })
+        })
+        return true
+      }
       case 'tasks': {
         const lines: string[] = []
         if (busy) lines.push(`● running — ${toolActivity || 'agent turn in progress'}`)
         if (queued.length) lines.push(`⏳ ${queued.length} queued prompt${queued.length === 1 ? '' : 's'}`)
-        if (!lines.length) lines.push('no active tasks')
-        addEntry({ kind: 'system', text: `Tasks:\n${lines.join('\n')}` })
+        void client?.requestControl('bg_list', {}).then((r) => {
+          const tasks = (r && (r['tasks'] as Array<{ id: string; command: string; status: string }>)) || []
+          for (const t of tasks) {
+            const icon = t.status === 'running' ? '●' : t.status === 'done' ? '✓' : t.status === 'killed' ? '⊘' : '✗'
+            lines.push(`${icon} bg ${t.id} [${t.status}] — ${t.command}`)
+          }
+          if (!lines.length) lines.push('no active tasks')
+          addEntry({ kind: 'system', text: `Tasks:\n${lines.join('\n')}` })
+        })
         return true
       }
       case 'settings': {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -50,6 +50,7 @@ export interface SlashCommand {
     | 'outputStyle'
     | 'knowledge'
     | 'wiki'
+    | 'bg'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -111,6 +112,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/output-style', description: 'Set the response output style', kind: 'outputStyle' },
   { name: '/knowledge', description: 'Knowledge graph: /knowledge [list|clear|enable|disable]', kind: 'knowledge' },
   { name: '/wiki', description: 'Project wiki: /wiki [init|status|ingest <path>]', kind: 'wiki' },
+  { name: '/bg', description: 'Run a shell command in the background: /bg <cmd> (or /bg kill <id>)', kind: 'bg' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports the **concurrent core** of the original's backgroundable runs (inventory §9).

**Backend** (`src/background/`): `BackgroundTasks` — thread-safe registry of detached shell commands in subprocesses (start/list/output/kill, captured output, **no conversation race** — each task is its own process). agent-server `bg_run`/`bg_list`/`bg_kill` controls.

**TUI**: `/bg <cmd>` starts a background task, `/bg kill <id>` terminates, and `/tasks` now lists live background tasks (icon + status + command) alongside the running turn + queue.

Full turn/agent backgrounding (concurrent *conversations*) remains a larger multi-session effort; this lands the concurrent **bash-task** variant end-to-end.

## Verification
Registry unit tests (complete/failed/list/output/kill); backend e2e (`bg_run` → poll `bg_list` → done + output captured); TUI `/bg` + `/tasks` render. Full server/knowledge/wiki/background suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)