### PR TITLE
feat(tui+backend): multimodal image input (/image <path>)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -174,7 +174,7 @@ class _AgentSession:
         """Route one client → server message. Runs on the main asyncio loop."""
         msg_type = msg.get("type")
         if msg_type == "user":
-            self._inbox.put(_extract_prompt_text(msg))
+            self._inbox.put(_extract_prompt_content(msg))  # str, or blocks for multimodal
             return
         if msg_type == "control_response":
             self._resolve_permission(msg)
@@ -966,11 +966,12 @@ class _AgentSession:
             item = self._inbox.get()
             if item is _SHUTDOWN or self._stop.is_set():
                 break
-            assert isinstance(item, str)
+            if not isinstance(item, (str, list)):  # str prompt, or multimodal blocks
+                continue
             self._run_turn(item)
         self._close_stream()
 
-    def _run_turn(self, prompt: str) -> None:
+    def _run_turn(self, prompt) -> None:  # prompt: str | list[ContentBlock] (multimodal)
         from src.query.agent_loop_compat import run_query_as_agent_loop
 
         if self.init_error is not None:
@@ -1436,6 +1437,22 @@ def _extract_prompt_text(msg: dict) -> str:
                 parts.append(block)
         return "".join(parts)
     return str(content) if content is not None else ""
+
+
+def _extract_prompt_content(msg: dict):
+    """Like ``_extract_prompt_text`` but PRESERVES a content-block list when it
+    carries non-text blocks (e.g. images) so multimodal input flows through to
+    ``add_user_message`` (MessageContent = str | list[ContentBlock]). Text-only
+    content still collapses to a plain string (the common path)."""
+    message = msg.get("message")
+    content = message.get("content") if isinstance(message, dict) else msg.get("content")
+    if isinstance(content, list):
+        has_nontext = any(
+            isinstance(b, dict) and b.get("type") not in (None, "text") for b in content
+        )
+        if has_nontext:
+            return content  # keep blocks intact (images, etc.)
+    return _extract_prompt_text(msg)
 
 
 def _tool_schemas(registry: Any) -> list[dict[str, Any]]:

--- a/tests/server/test_prompt_content.py
+++ b/tests/server/test_prompt_content.py
@@ -1,0 +1,21 @@
+"""_extract_prompt_content preserves image blocks (multimodal) but flattens text."""
+
+from src.server.agent_server import _extract_prompt_content
+
+
+def test_string_content():
+    assert _extract_prompt_content({"message": {"role": "user", "content": "hi"}}) == "hi"
+
+
+def test_text_only_list_flattens():
+    msg = {"message": {"role": "user", "content": [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]}}
+    assert _extract_prompt_content(msg) == "ab"
+
+
+def test_image_block_preserved():
+    img = {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "x"}}
+    msg = {"message": {"role": "user", "content": [{"type": "text", "text": "look"}, img]}}
+    out = _extract_prompt_content(msg)
+    assert isinstance(out, list)
+    assert any(b.get("type") == "image" for b in out)
+    assert any(b.get("type") == "text" for b in out)

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -247,6 +247,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const streamRef = useRef('') // source of truth for the live buffer (no stale closures)
   const [permissions, setPermissions] = useState<PendingPermission[]>([]) // FIFO queue
   const alwaysAllowRef = useRef<Set<string>>(new Set()) // tools the user said "don't ask again"
+  const pendingImageRef = useRef<{ data: string; media_type: string; name: string } | null>(null) // /image attachment
   const [permFeedback, setPermFeedback] = useState<string | null>(null) // Tab-to-amend feedback field
   const [input, setInput] = useState('')
   const [busy, setBusy] = useState(false)
@@ -1100,6 +1101,34 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         })
         return true
       }
+      case 'image': {
+        const p = arg.trim()
+        if (!p) {
+          addEntry({ kind: 'system', text: 'usage: /image <path>' })
+          return true
+        }
+        try {
+          const buf = readFileSync(p)
+          const ext = (p.toLowerCase().split('.').pop() || '').trim()
+          const media =
+            ext === 'png'
+              ? 'image/png'
+              : ext === 'gif'
+                ? 'image/gif'
+                : ext === 'webp'
+                  ? 'image/webp'
+                  : 'image/jpeg'
+          const name = p.split('/').pop() || p
+          pendingImageRef.current = { data: buf.toString('base64'), media_type: media, name }
+          addEntry({
+            kind: 'system',
+            text: `📎 image attached: ${name} (${Math.round(buf.length / 1024)} KB) — sent with your next message`,
+          })
+        } catch (e) {
+          addEntry({ kind: 'error', text: `image read failed: ${(e as Error).message}` })
+        }
+        return true
+      }
       case 'bg': {
         const a = arg.trim()
         if (a.toLowerCase().startsWith('kill ')) {
@@ -1628,7 +1657,17 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   /** Send a prompt now and start a turn (shared by submit + queue drain). */
   const dispatchPrompt = (text: string): void => {
     if (!client) return
-    client.sendPrompt(expandPastes(text)) // model gets the full paste; transcript shows the placeholder
+    const img = pendingImageRef.current
+    if (img) {
+      // Multimodal: send text + image as a content-block list (inventory §1).
+      pendingImageRef.current = null
+      client.sendPromptBlocks([
+        { type: 'text', text: expandPastes(text) },
+        { type: 'image', source: { type: 'base64', media_type: img.media_type, data: img.data } },
+      ])
+    } else {
+      client.sendPrompt(expandPastes(text)) // model gets the full paste; transcript shows the placeholder
+    }
     if (historyRef.current[historyRef.current.length - 1] !== text) historyRef.current.push(text)
     addEntry({ kind: 'user', text })
     setStream('')

--- a/ui-tui/src/client.ts
+++ b/ui-tui/src/client.ts
@@ -140,6 +140,17 @@ export class DirectConnectClient {
     });
   }
 
+  /** Send a user turn whose content is a block list (text + image blocks) for
+   *  multimodal input. The server preserves non-text blocks (image-paste, §1). */
+  sendPromptBlocks(content: Array<Record<string, unknown>>): void {
+    this.send({
+      type: 'user',
+      message: { role: 'user', content },
+      parent_tool_use_id: null,
+      session_id: '',
+    });
+  }
+
   respondPermission(
     requestId: string,
     behavior: 'allow' | 'deny',

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -51,6 +51,7 @@ export interface SlashCommand {
     | 'knowledge'
     | 'wiki'
     | 'bg'
+    | 'image'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -113,6 +114,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/knowledge', description: 'Knowledge graph: /knowledge [list|clear|enable|disable]', kind: 'knowledge' },
   { name: '/wiki', description: 'Project wiki: /wiki [init|status|ingest <path>]', kind: 'wiki' },
   { name: '/bg', description: 'Run a shell command in the background: /bg <cmd> (or /bg kill <id>)', kind: 'bg' },
+  { name: '/image', description: 'Attach an image to your next message: /image <path>', kind: 'image' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports **image input** (inventory §1) via `/image`, sidestepping the clipboard-tool blocker.

**Backend**: `_extract_prompt_content` preserves a content-block list when it carries non-text blocks (images); the worker accepts `str | blocks`; `_run_turn` feeds them to `add_user_message` (`MessageContent = str | list[ContentBlock]`). The text path is unchanged (additive).

**Client**: `sendPromptBlocks` sends a block list. **TUI**: `/image <path>` reads the file → base64 (media type by extension) → attaches it to the next message, sent as `[text, image]` blocks.

Model *vision* depends on the configured model (env-dependent); the **plumbing is verified end-to-end**. Clipboard-paste capture still needs an external tool (`pngpaste`).

## Verification
`_extract_prompt_content` unit tests (str / text-list-flatten / image-preserved); full server suite green; TUI `/image` attaches a PNG and the next message is sent as text+image blocks with base64 data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)