### PR TITLE
feat(tui+backend): /bg-agent — background agent runs (§9 async-agent)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -231,7 +231,7 @@ class _AgentSession:
         if subtype == "wiki":
             self._do_wiki(request_id, inner.get("action"), inner.get("path"))
             return
-        if subtype in ("bg_run", "bg_list", "bg_kill"):
+        if subtype in ("bg_run", "bg_list", "bg_kill", "bg_agent"):
             self._do_bgtask(request_id, subtype, inner.get("command"), inner.get("id"))
             return
         if subtype == "set_effort":
@@ -592,6 +592,18 @@ class _AgentSession:
                     return
                 t = self._bgtasks.start(command.strip(), self.cwd, now=time.time())
                 self._reply(request_id, {"ok": True, "id": t.id, "command": t.command})
+                return
+            if subtype == "bg_agent":
+                # Background agent run: a detached `clawcodex -p <prompt>` subprocess
+                # (the §9 async-agent variant) — fully isolated, concurrent, tracked.
+                if not isinstance(command, str) or not command.strip():
+                    self._reply(request_id, {"ok": False, "error": "usage: /bg-agent <prompt>"})
+                    return
+                import shlex
+
+                cmd = f"clawcodex -p {shlex.quote(command.strip())}"
+                t = self._bgtasks.start(cmd, self.cwd, now=time.time())
+                self._reply(request_id, {"ok": True, "id": t.id, "command": cmd})
                 return
             if subtype == "bg_kill":
                 ok = self._bgtasks.kill(str(tid or ""))

--- a/tests/server/test_agent_server_e2e.py
+++ b/tests/server/test_agent_server_e2e.py
@@ -620,6 +620,12 @@ async def test_control_background_task(tmp_path):
                 await asyncio.sleep(0.1)
             assert done is not None and done["status"] == "done"
             assert "hi" in done["output"]
+
+            # bg_agent builds a detached `clawcodex -p <prompt>` task.
+            ag = await _reply_for("a1", {"subtype": "bg_agent", "command": "hello"})
+            assert ag["ok"] is True and ag["id"]
+            assert ag["command"] == "clawcodex -p hello"
+            await _reply_for("ak", {"subtype": "bg_kill", "id": ag["id"]})  # clean up
         finally:
             await handle.shutdown()
             with contextlib.suppress(Exception):

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -1129,6 +1129,18 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         }
         return true
       }
+      case 'bgAgent': {
+        const p = arg.trim()
+        if (!p) {
+          addEntry({ kind: 'system', text: 'usage: /bg-agent <prompt>' })
+          return true
+        }
+        void client?.requestControl('bg_agent', { command: p }).then((r) => {
+          if (r && r['ok']) addEntry({ kind: 'system', text: `▶ background agent ${String(r['id'])}: ${p}` })
+          else addEntry({ kind: 'error', text: `bg-agent failed: ${r && r['error'] ? String(r['error']) : 'no response'}` })
+        })
+        return true
+      }
       case 'bg': {
         const a = arg.trim()
         if (a.toLowerCase().startsWith('kill ')) {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -51,6 +51,7 @@ export interface SlashCommand {
     | 'knowledge'
     | 'wiki'
     | 'bg'
+    | 'bgAgent'
     | 'image'
     | 'diff'
     | 'stats'
@@ -114,6 +115,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/knowledge', description: 'Knowledge graph: /knowledge [list|clear|enable|disable]', kind: 'knowledge' },
   { name: '/wiki', description: 'Project wiki: /wiki [init|status|ingest <path>]', kind: 'wiki' },
   { name: '/bg', description: 'Run a shell command in the background: /bg <cmd> (or /bg kill <id>)', kind: 'bg' },
+  { name: '/bg-agent', description: 'Run an agent query in the background: /bg-agent <prompt>', kind: 'bgAgent' },
   { name: '/image', description: 'Attach an image to your next message: /image <path>', kind: 'image' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },


### PR DESCRIPTION
## Summary
Makes background **agent** runs first-class (inventory §9 async-agent variant). The `bg_agent` control builds a detached `clawcodex -p <prompt>` subprocess via the existing `BackgroundTasks` registry — **fully isolated** (own process/conversation), concurrent, **no shared-state race**, tracked in `/tasks`. TUI: `/bg-agent <prompt>`.

This is the safe, process-isolated form of §9 backgroundable agent runs. Backgrounding the *current in-flight* turn (Ctrl+B) remains the larger in-process multi-session piece.

## Verification
Backend e2e (`bg_agent` builds `clawcodex -p hello`, returns id, `bg_kill` cleans up); TUI `/bg-agent` forwards the prompt and shows the task id. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)