### PR TITLE
feat(tui+backend): /insights — model-based session analysis

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -234,6 +234,9 @@ class _AgentSession:
         if subtype in ("bg_run", "bg_list", "bg_kill", "bg_agent"):
             self._do_bgtask(request_id, subtype, inner.get("command"), inner.get("id"))
             return
+        if subtype == "insights":
+            self._do_insights(request_id)
+            return
         if subtype == "set_effort":
             effort = inner.get("effort")
             if isinstance(effort, str) and effort in ("minimal", "low", "medium", "high"):
@@ -577,6 +580,33 @@ class _AgentSession:
         except Exception as exc:  # noqa: BLE001
             logger.exception("[agent-server] set_provider failed")
             self._reply(request_id, {"ok": False, "error": str(exc)})
+
+    def _do_insights(self, request_id: object) -> None:
+        """/insights: a model-based analysis of the session (the original's
+        Insights). Runs the model call in a daemon thread (_emit is thread-safe)
+        so it never blocks the control loop; replies when the narrative is ready."""
+        if self.session is None or self.provider is None:
+            self._reply(request_id, {"ok": False, "error": "no active session"})
+            return
+        msgs = list(self.session.conversation.messages)
+        if not msgs:
+            self._reply(request_id, {"ok": False, "error": "no conversation yet"})
+            return
+        text = "\n".join(f"{getattr(m, 'role', '?')}: {self._message_text(m)[:400]}" for m in msgs[-12:])
+
+        def _work() -> None:
+            try:
+                prompt = (
+                    "Analyze this coding session and give 3-5 concise insights: what was "
+                    "accomplished, notable patterns, and one suggestion for next steps. "
+                    "Be brief — short bullet points.\n\nSESSION:\n" + text
+                )
+                resp = self.provider.chat([{"role": "user", "content": prompt}])
+                self._reply(request_id, {"ok": True, "insights": (getattr(resp, "content", "") or "").strip()})
+            except Exception as exc:  # noqa: BLE001
+                self._reply(request_id, {"ok": False, "error": str(exc)})
+
+        threading.Thread(target=_work, name=f"insights-{self.session_id}", daemon=True).start()
 
     def _do_bgtask(self, request_id: object, subtype: str, command: object, tid: object) -> None:
         """Background tasks (the original's Ctrl+B runs): bg_run starts a detached

--- a/tests/server/test_agent_server_e2e.py
+++ b/tests/server/test_agent_server_e2e.py
@@ -633,6 +633,47 @@ async def test_control_background_task(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_control_insights(tmp_path):
+    """insights guards an empty session, then returns a model-based narrative."""
+    from src.tool_system.registry import ToolRegistry
+
+    with contextlib.ExitStack() as stack:
+        for p in _patches(_TextProvider, ToolRegistry([])):
+            stack.enter_context(p)
+        spawn = make_spawn_agent(AgentServerConfig(permission_mode="default"))
+        handle = await spawn("ds_test", str(tmp_path), None)
+        gen = handle.messages_from_agent()
+        try:
+            init = await asyncio.wait_for(gen.__anext__(), timeout=5)
+            assert init["subtype"] == "init"
+
+            async def _reply_for(rid, req):
+                await handle.send_to_agent({"type": "control_request", "request_id": rid, "request": req})
+                for _ in range(30):
+                    msg = await asyncio.wait_for(gen.__anext__(), timeout=5)
+                    if msg.get("type") == "control_response" and msg["response"].get("request_id") == rid:
+                        return msg["response"]["response"]
+                raise AssertionError(f"no reply for {rid}")
+
+            empty = await _reply_for("i0", {"subtype": "insights"})
+            assert empty["ok"] is False  # no conversation yet
+
+            # run a turn so there is conversation to analyze
+            await handle.send_to_agent({"type": "user", "message": {"role": "user", "content": "hello"}})
+            for _ in range(30):
+                msg = await asyncio.wait_for(gen.__anext__(), timeout=5)
+                if msg.get("type") == "result":
+                    break
+
+            ins = await _reply_for("i1", {"subtype": "insights"})
+            assert ins["ok"] is True and ins["insights"]  # _TextProvider returns a narrative
+        finally:
+            await handle.shutdown()
+            with contextlib.suppress(Exception):
+                await gen.aclose()
+
+
+@pytest.mark.asyncio
 async def test_interrupt_trips_abort(tmp_path):
     """An interrupt control_request must trip the in-flight turn's abort."""
     from src.permissions.types import PermissionPassthroughResult

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -1101,6 +1101,17 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         })
         return true
       }
+      case 'insights': {
+        addEntry({ kind: 'system', text: '∴ analyzing session…' })
+        void client?.requestControl('insights', {}, 120_000).then((r) => {
+          if (r && r['ok']) {
+            addEntry({ kind: 'assistant', text: `**Session insights**\n\n${String(r['insights'] || '(none)')}` })
+          } else {
+            addEntry({ kind: 'error', text: `insights failed: ${r && r['error'] ? String(r['error']) : 'no response'}` })
+          }
+        })
+        return true
+      }
       case 'image': {
         const p = arg.trim()
         if (!p) {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -53,6 +53,7 @@ export interface SlashCommand {
     | 'bg'
     | 'bgAgent'
     | 'image'
+    | 'insights'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -117,6 +118,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/bg', description: 'Run a shell command in the background: /bg <cmd> (or /bg kill <id>)', kind: 'bg' },
   { name: '/bg-agent', description: 'Run an agent query in the background: /bg-agent <prompt>', kind: 'bgAgent' },
   { name: '/image', description: 'Attach an image to your next message: /image <path>', kind: 'image' },
+  { name: '/insights', description: 'Model-based analysis of this session', kind: 'insights' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports the original's `/insights` (inventory §2) as a model-based session analysis. The backend `insights` control runs the model on the recent conversation (in a daemon thread — `_emit` is thread-safe, so it never blocks the async control loop) and replies with a short narrative. TUI: `/insights` shows "analyzing session…" then renders it.

Checked the original source to port faithfully: `/insights` **is** model-based (not a `/cost` duplicate); `/extra-usage` is claude.ai-org-account specific (N/A); `/fast` needs a dedicated fast-model tier (no clawcodex concept); `/plan` views a plan file (no concept) — so `/insights` is the portable one of that group.

## Verification
Backend e2e (empty-session guard, then model-based narrative after a turn); TUI `/insights` renders the analysis. Full server suite green (91).

🤖 Generated with [Claude Code](https://claude.com/claude-code)