### PR TITLE
feat(tui+backend): /plan — a plan the agent follows

### DIFF
--- a/src/plan/__init__.py
+++ b/src/plan/__init__.py
@@ -1,0 +1,8 @@
+"""Project plan (the original's /plan) — a persisted plan the agent follows,
+stored at ``.clawcodex/plan.md`` and injected as a system-prompt section so the
+running agent honors it. Set/view/clear via /plan.
+"""
+
+from .plan import clear_plan, get_plan, plan_path, set_plan
+
+__all__ = ["get_plan", "set_plan", "clear_plan", "plan_path"]

--- a/src/plan/plan.py
+++ b/src/plan/plan.py
@@ -1,0 +1,31 @@
+"""Plan file storage (.clawcodex/plan.md)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def plan_path(cwd: str | Path) -> Path:
+    return Path(cwd) / ".clawcodex" / "plan.md"
+
+
+def get_plan(cwd: str | Path) -> str:
+    try:
+        return plan_path(cwd).read_text(encoding="utf-8").strip()
+    except Exception:  # noqa: BLE001 - missing/unreadable → no plan
+        return ""
+
+
+def set_plan(cwd: str | Path, text: str) -> None:
+    p = plan_path(cwd)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text.strip() + "\n", encoding="utf-8")
+
+
+def clear_plan(cwd: str | Path) -> bool:
+    p = plan_path(cwd)
+    try:
+        p.unlink()
+        return True
+    except Exception:  # noqa: BLE001 - already absent
+        return False

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -110,6 +110,7 @@ class _AgentSession:
     tool_context: Any = None
     session: Any = None
     system_prompt: Any = "You are a helpful assistant."
+    _base_system_prompt: Any = None  # system prompt before the /plan section is composed in
     init_error: str | None = None
     _session_name: str | None = None  # user-set label (/rename) shown in /resume
     _mcp_runtime: Any = None  # McpRuntime (connected MCP servers) when configured
@@ -236,6 +237,9 @@ class _AgentSession:
             return
         if subtype == "insights":
             self._do_insights(request_id)
+            return
+        if subtype == "plan":
+            self._do_plan(request_id, inner.get("action"), inner.get("text"))
             return
         if subtype == "set_effort":
             effort = inner.get("effort")
@@ -581,6 +585,40 @@ class _AgentSession:
             logger.exception("[agent-server] set_provider failed")
             self._reply(request_id, {"ok": False, "error": str(exc)})
 
+    def _compose_with_plan(self, base: Any) -> Any:
+        """Append the active /plan as a system-prompt section so the agent follows
+        it. No plan → returns base unchanged (regression-safe)."""
+        try:
+            from src.plan import get_plan
+
+            plan = get_plan(self.cwd)
+            if plan and isinstance(base, list):
+                return base + [{"type": "text", "text": f"# Current Plan\nFollow this plan set by the user:\n\n{plan}"}]
+        except Exception:  # noqa: BLE001
+            logger.debug("[agent-server] plan compose failed", exc_info=True)
+        return base
+
+    def _do_plan(self, request_id: object, action: object, text: object) -> None:
+        """/plan: view (default) | set <text> | clear. The plan is injected into
+        the system prompt (the original's /plan)."""
+        try:
+            from src.plan import clear_plan, get_plan, set_plan
+
+            act = str(action or "view").strip().lower()
+            if act == "set":
+                if not isinstance(text, str) or not text.strip():
+                    self._reply(request_id, {"ok": False, "error": "usage: /plan <text>"})
+                    return
+                set_plan(self.cwd, text)
+            elif act == "clear":
+                clear_plan(self.cwd)
+            if act in ("set", "clear") and self._base_system_prompt is not None:
+                self.system_prompt = self._compose_with_plan(self._base_system_prompt)
+            self._reply(request_id, {"ok": True, "plan": get_plan(self.cwd)})
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[agent-server] plan failed")
+            self._reply(request_id, {"ok": False, "error": str(exc)})
+
     def _do_insights(self, request_id: object) -> None:
         """/insights: a model-based analysis of the session (the original's
         Insights). Runs the model call in a daemon thread (_emit is thread-safe)
@@ -748,7 +786,8 @@ class _AgentSession:
                 from src.query.agent_loop_compat import build_effective_system_prompt
 
                 style_prompt = resolve_output_style(style, getattr(tc, "output_style_dir", None)).prompt
-                self.system_prompt = build_effective_system_prompt(style_prompt, tc, provider=self.provider)
+                self._base_system_prompt = build_effective_system_prompt(style_prompt, tc, provider=self.provider)
+                self.system_prompt = self._compose_with_plan(self._base_system_prompt)
             except Exception:  # noqa: BLE001 - keep the style set even if rebuild is unavailable
                 logger.debug("[agent-server] system prompt rebuild after set_output_style failed", exc_info=True)
             self._reply(request_id, {"ok": True, "style": style})
@@ -1296,7 +1335,8 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
         sess.tool_context = tool_context
         tool_context.agent_progress_emit = sess._emit_agent_progress  # stream subagent progress
         sess.session = Session.create(provider_name, getattr(provider, "model", model or ""))
-        sess.system_prompt = system_prompt
+        sess._base_system_prompt = system_prompt
+        sess.system_prompt = sess._compose_with_plan(system_prompt)  # honor an existing /plan
     except Exception as exc:  # noqa: BLE001
         logger.exception("[agent-server] runtime build failed")
         sess.init_error = f"agent-server failed to start: {exc}"

--- a/tests/plan/test_plan.py
+++ b/tests/plan/test_plan.py
@@ -1,0 +1,28 @@
+"""Plan file storage + system-prompt compose tests."""
+
+from src.plan import clear_plan, get_plan, plan_path, set_plan
+
+
+def test_set_get_clear(tmp_path):
+    assert get_plan(tmp_path) == ""
+    set_plan(tmp_path, "1. do X\n2. do Y")
+    assert "do X" in get_plan(tmp_path)
+    assert plan_path(tmp_path).exists()
+    assert clear_plan(tmp_path) is True
+    assert get_plan(tmp_path) == ""
+
+
+def test_compose_with_plan_appends_only_when_present(tmp_path):
+    from src.server.agent_server import _AgentSession
+
+    sess = _AgentSession.__new__(_AgentSession)
+    sess.cwd = str(tmp_path)
+    base = [{"type": "text", "text": "base"}]
+    # no plan → unchanged (regression-safe)
+    assert sess._compose_with_plan(base) == base
+    # with plan → appends a "# Current Plan" block
+    set_plan(tmp_path, "ship it")
+    composed = sess._compose_with_plan(base)
+    assert len(composed) == len(base) + 1
+    assert "Current Plan" in composed[-1]["text"]
+    assert "ship it" in composed[-1]["text"]

--- a/tests/server/test_agent_server_e2e.py
+++ b/tests/server/test_agent_server_e2e.py
@@ -674,6 +674,43 @@ async def test_control_insights(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_control_plan(tmp_path):
+    """plan set/view/clear round-trips and injects into the system prompt."""
+    from src.tool_system.registry import ToolRegistry
+
+    with contextlib.ExitStack() as stack:
+        for p in _patches(_TextProvider, ToolRegistry([])):
+            stack.enter_context(p)
+        spawn = make_spawn_agent(AgentServerConfig(permission_mode="default"))
+        handle = await spawn("ds_test", str(tmp_path), None)
+        gen = handle.messages_from_agent()
+        try:
+            init = await asyncio.wait_for(gen.__anext__(), timeout=5)
+            assert init["subtype"] == "init"
+
+            async def _reply_for(rid, req):
+                await handle.send_to_agent({"type": "control_request", "request_id": rid, "request": req})
+                for _ in range(12):
+                    msg = await asyncio.wait_for(gen.__anext__(), timeout=5)
+                    if msg.get("type") == "control_response" and msg["response"].get("request_id") == rid:
+                        return msg["response"]["response"]
+                raise AssertionError(f"no reply for {rid}")
+
+            empty = await _reply_for("p0", {"subtype": "plan", "action": "view"})
+            assert empty["plan"] == ""
+            setr = await _reply_for("p1", {"subtype": "plan", "action": "set", "text": "ship v2"})
+            assert setr["ok"] is True and "ship v2" in setr["plan"]
+            view = await _reply_for("p2", {"subtype": "plan", "action": "view"})
+            assert "ship v2" in view["plan"]
+            cleared = await _reply_for("p3", {"subtype": "plan", "action": "clear"})
+            assert cleared["plan"] == ""
+        finally:
+            await handle.shutdown()
+            with contextlib.suppress(Exception):
+                await gen.aclose()
+
+
+@pytest.mark.asyncio
 async def test_interrupt_trips_abort(tmp_path):
     """An interrupt control_request must trip the in-flight turn's abort."""
     from src.permissions.types import PermissionPassthroughResult

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -1101,6 +1101,46 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         })
         return true
       }
+      case 'plan': {
+        const a = arg.trim()
+        if (!a) {
+          void client?.requestControl('plan', { action: 'view' }).then((r) => {
+            const plan = String((r && r['plan']) || '')
+            addEntry({ kind: 'system', text: plan ? `Current plan:\n${plan}` : 'no plan set — /plan <text> to set one' })
+          })
+          return true
+        }
+        if (a.toLowerCase() === 'clear') {
+          void client?.requestControl('plan', { action: 'clear' }).then(() => addEntry({ kind: 'system', text: 'plan cleared' }))
+          return true
+        }
+        if (a.toLowerCase() === 'edit') {
+          void client?.requestControl('plan', { action: 'view' }).then((r) => {
+            const cur = String((r && r['plan']) || '')
+            const sin = process.stdin as unknown as { setRawMode?: (m: boolean) => void }
+            const canRaw = typeof sin.setRawMode === 'function'
+            let next = cur
+            try {
+              if (canRaw) sin.setRawMode?.(false)
+              next = editInEditor(cur)
+            } catch (e) {
+              addEntry({ kind: 'error', text: `editor failed: ${(e as Error).message}` })
+              return
+            } finally {
+              if (canRaw) sin.setRawMode?.(true)
+              setThemeVersion((v) => v + 1)
+            }
+            void client
+              ?.requestControl('plan', { action: 'set', text: next })
+              .then(() => addEntry({ kind: 'system', text: 'plan updated' }))
+          })
+          return true
+        }
+        void client?.requestControl('plan', { action: 'set', text: a }).then((r) => {
+          addEntry({ kind: 'system', text: r && r['ok'] ? 'plan set — the agent will follow it' : 'plan failed' })
+        })
+        return true
+      }
       case 'insights': {
         addEntry({ kind: 'system', text: '∴ analyzing session…' })
         void client?.requestControl('insights', {}, 120_000).then((r) => {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -54,6 +54,7 @@ export interface SlashCommand {
     | 'bgAgent'
     | 'image'
     | 'insights'
+    | 'plan'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -119,6 +120,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/bg-agent', description: 'Run an agent query in the background: /bg-agent <prompt>', kind: 'bgAgent' },
   { name: '/image', description: 'Attach an image to your next message: /image <path>', kind: 'image' },
   { name: '/insights', description: 'Model-based analysis of this session', kind: 'insights' },
+  { name: '/plan', description: 'Set a plan the agent follows: /plan [<text>|edit|clear]', kind: 'plan' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports the original's `/plan` (inventory §2) **functionally**. `src/plan` stores a plan at `.clawcodex/plan.md`; the agent-server **composes it into the system prompt** as a "# Current Plan" section (`_base_system_prompt` + `_compose_with_plan`, applied at setup, on `/plan` change, and on output-style change so they compose). No plan → prompt unchanged (regression-safe). `plan` control: view/set/clear. TUI: `/plan` (view), `/plan <text>` (set), `/plan edit` (`$EDITOR`), `/plan clear`.

## Verification
Plan unit tests (store + compose appends only when present); backend e2e (view→set→view→clear); TUI `/plan` set + view; full backend suite green (no-plan path unchanged → regression-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)