### PR TITLE
feat(ui-tui): /fast — toggle a faster model

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -248,6 +248,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const [permissions, setPermissions] = useState<PendingPermission[]>([]) // FIFO queue
   const alwaysAllowRef = useRef<Set<string>>(new Set()) // tools the user said "don't ask again"
   const pendingImageRef = useRef<{ data: string; media_type: string; name: string } | null>(null) // /image attachment
+  const fastModeRef = useRef<string | null>(null) // /fast: prev model while fast mode is on
   const [permFeedback, setPermFeedback] = useState<string | null>(null) // Tab-to-amend feedback field
   const [input, setInput] = useState('')
   const [busy, setBusy] = useState(false)
@@ -1098,6 +1099,32 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
           const ents = (r['entities'] as Array<{ name: string; type: string; count: number }>) || []
           const lines = ents.map((e) => `  ${e.type === 'file' ? '📄' : e.type === 'url' ? '🔗' : '◆'} ${e.name} ·${e.count}`)
           addEntry({ kind: 'system', text: lines.length ? `${head}\n${lines.join('\n')}` : head })
+        })
+        return true
+      }
+      case 'fast': {
+        // Toggle a faster model (the original's /fast). Heuristic: pick a model
+        // whose name reads "fast" from the provider's available list.
+        void client?.requestControl('get_settings', {}).then((r) => {
+          const models = ((r && (r['available_models'] as string[])) || []).filter(Boolean)
+          const cur = String((r && r['model']) || model)
+          if (fastModeRef.current) {
+            const prev = fastModeRef.current
+            fastModeRef.current = null
+            client?.sendControl('set_model', { model: prev })
+            setModel(prev)
+            addEntry({ kind: 'system', text: `fast mode off — model → ${prev}` })
+            return
+          }
+          const fast = models.find((m) => /haiku|mini|flash|turbo|lite|small|fast/i.test(m) && m !== cur)
+          if (!fast) {
+            addEntry({ kind: 'system', text: 'no faster model available in this provider' })
+            return
+          }
+          fastModeRef.current = cur
+          client?.sendControl('set_model', { model: fast })
+          setModel(fast)
+          addEntry({ kind: 'system', text: `⚡ fast mode on — model → ${fast}` })
         })
         return true
       }

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -55,6 +55,7 @@ export interface SlashCommand {
     | 'image'
     | 'insights'
     | 'plan'
+    | 'fast'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -121,6 +122,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/image', description: 'Attach an image to your next message: /image <path>', kind: 'image' },
   { name: '/insights', description: 'Model-based analysis of this session', kind: 'insights' },
   { name: '/plan', description: 'Set a plan the agent follows: /plan [<text>|edit|clear]', kind: 'plan' },
+  { name: '/fast', description: 'Toggle fast mode (switch to a faster model)', kind: 'fast' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports the original's `/fast` (inventory §2/§7) **client-side**. `/fast` switches to a faster model from the provider's available list (heuristic: name matches `haiku|mini|flash|turbo|lite|small|fast`) and remembers the previous model; toggling again restores it. Reuses `get_settings` + `set_model` — no backend change. (clawcodex has no single fixed fast-model tier, so it picks the provider's fast model by name; informs if none exists.)

## Verification
With opus/sonnet/haiku available: `/fast` → `set_model(haiku)` "fast mode on"; `/fast` again → `set_model(opus)` "fast mode off". typecheck + build clean. 61 commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)