### PR TITLE
feat(ui-tui): /open — fuzzy file finder (QuickOpen)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -309,6 +309,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       | 'settings'
       | 'difffile'
       | 'outputstyle'
+      | 'openfile'
     title: string
     options: string[]
     /** Optional value per option (e.g. session_id); falls back to the label. */
@@ -423,10 +424,16 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       | 'historyrecall'
       | 'settings'
       | 'difffile'
-      | 'outputstyle',
+      | 'outputstyle'
+      | 'openfile',
     value: string,
   ): void => {
     if (!value) return
+    if (kind === 'openfile') {
+      // Insert the chosen file as an @-mention (the original's QuickOpen).
+      setInput((prev) => (prev ? `${prev}@${value} ` : `@${value} `))
+      return
+    }
     if (kind === 'outputstyle') {
       void client?.requestControl('set_output_style', { style: value }).then((r) => {
         if (r && r['ok']) {
@@ -1107,6 +1114,20 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
           const lines = ents.map((e) => `  ${e.type === 'file' ? '📄' : e.type === 'url' ? '🔗' : '◆'} ${e.name} ·${e.count}`)
           addEntry({ kind: 'system', text: lines.length ? `${head}\n${lines.join('\n')}` : head })
         })
+        return true
+      }
+      case 'open': {
+        const q = arg.trim()
+        if (!q) {
+          addEntry({ kind: 'system', text: 'usage: /open <query>' })
+          return true
+        }
+        const files = searchFiles(process.cwd(), q, Date.now())
+        if (!files.length) {
+          addEntry({ kind: 'system', text: `no files match "${q}"` })
+          return true
+        }
+        setPicker({ kind: 'openfile', title: `Open file (${files.length})`, options: files, sel: 0 })
         return true
       }
       case 'fast': {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -56,6 +56,7 @@ export interface SlashCommand {
     | 'insights'
     | 'plan'
     | 'fast'
+    | 'open'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -123,6 +124,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/insights', description: 'Model-based analysis of this session', kind: 'insights' },
   { name: '/plan', description: 'Set a plan the agent follows: /plan [<text>|edit|clear]', kind: 'plan' },
   { name: '/fast', description: 'Toggle fast mode (switch to a faster model)', kind: 'fast' },
+  { name: '/open', description: 'Fuzzy-find a file to @-mention: /open <query>', kind: 'open' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },


### PR DESCRIPTION
## Summary
Ports the original's QuickOpen (inventory §6) as `/open`: fuzzy-find a file by query (reuses the `@` file index, `searchFiles`) in a picker, then insert it as an `@`-mention. A command-triggered standalone file finder, distinct from the inline `@` dropdown — the same way `/history` (list) complements `Ctrl+R` (cycle). Client-side, reuses the existing picker + `searchFiles` (no backend change).

## Verification
`/open App` lists `App.tsx` in the picker; selecting inserts `@<path>`. typecheck + build clean. 62 commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)