### PR TITLE
feat(ui-tui): folder trust (/trust + first-run notice) — §6 TrustDialog

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -16,6 +16,7 @@ import { Message } from './components/Message.js'
 import { PermissionDialog } from './components/PermissionDialog.js'
 import { SlashMenu } from './components/SlashMenu.js'
 import { editInEditor } from './editor.js'
+import { isTrusted, trustFolder, untrustFolder } from './trust.js'
 import { exec } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
@@ -1129,6 +1130,20 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         })
         return true
       }
+      case 'trust': {
+        const a = arg.trim().toLowerCase()
+        const cwd = process.cwd()
+        if (a === 'add' || a === 'yes' || a === '') {
+          trustFolder(cwd)
+          addEntry({ kind: 'system', text: `✓ folder trusted: ${cwd}` })
+        } else if (a === 'remove' || a === 'no') {
+          untrustFolder(cwd)
+          addEntry({ kind: 'system', text: `folder untrusted: ${cwd}` })
+        } else {
+          addEntry({ kind: 'system', text: `folder ${isTrusted(cwd) ? 'is trusted' : 'is NOT trusted'}: ${cwd}` })
+        }
+        return true
+      }
       case 'open': {
         const q = arg.trim()
         if (!q) {
@@ -1842,6 +1857,20 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [entries.length])
+
+  // Folder-trust first-run notice (the original's TrustDialog, §6): once ready,
+  // if this folder hasn't been acknowledged, surface a one-line notice. The
+  // backend permission system still gates every action; /trust records consent.
+  const trustNotedRef = useRef(false)
+  useEffect(() => {
+    if (ready && !trustNotedRef.current) {
+      trustNotedRef.current = true
+      if (!isTrusted(process.cwd())) {
+        addEntry({ kind: 'system', text: '⚠ new folder — files/commands run here; /trust to acknowledge' })
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ready])
 
   // Auto-allow tools the user marked "don't ask again" (skip the prompt).
   useEffect(() => {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -57,6 +57,7 @@ export interface SlashCommand {
     | 'plan'
     | 'fast'
     | 'open'
+    | 'trust'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -125,6 +126,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/plan', description: 'Set a plan the agent follows: /plan [<text>|edit|clear]', kind: 'plan' },
   { name: '/fast', description: 'Toggle fast mode (switch to a faster model)', kind: 'fast' },
   { name: '/open', description: 'Fuzzy-find a file to @-mention: /open <query>', kind: 'open' },
+  { name: '/trust', description: 'Folder trust: /trust [status|add|remove]', kind: 'trust' },
   { name: '/config', description: 'Show model, mode, and available models', kind: 'config' },
   { name: '/diff', description: 'Show the working-tree git diff', kind: 'diff' },
   { name: '/stats', description: 'Show session statistics', kind: 'stats' },

--- a/ui-tui/src/trust.ts
+++ b/ui-tui/src/trust.ts
@@ -1,0 +1,45 @@
+/**
+ * Folder trust (the original's TrustDialog, inventory §6): remember which folders
+ * the user has acknowledged as safe to operate in. Soft surface — the backend's
+ * permission system still gates every action; this records consent + the first-run
+ * notice. Stored at ~/.clawcodex/trusted.json.
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join, dirname } from 'node:path'
+
+const TRUST_FILE = join(homedir(), '.clawcodex', 'trusted.json')
+
+function load(): string[] {
+  try {
+    const v = JSON.parse(readFileSync(TRUST_FILE, 'utf8'))
+    return Array.isArray(v) ? v.map(String) : []
+  } catch {
+    return []
+  }
+}
+
+function save(list: string[]): void {
+  try {
+    mkdirSync(dirname(TRUST_FILE), { recursive: true })
+    writeFileSync(TRUST_FILE, JSON.stringify(list), 'utf8')
+  } catch {
+    /* best-effort */
+  }
+}
+
+export function isTrusted(cwd: string): boolean {
+  return load().includes(cwd)
+}
+
+export function trustFolder(cwd: string): void {
+  const list = load()
+  if (!list.includes(cwd)) {
+    list.push(cwd)
+    save(list)
+  }
+}
+
+export function untrustFolder(cwd: string): void {
+  save(load().filter((p) => p !== cwd))
+}


### PR DESCRIPTION
## Summary
Ports the original's TrustDialog (inventory §6) as a soft folder-trust. On first run in an unacknowledged folder, surface "⚠ new folder — /trust to acknowledge"; `/trust [status|add|remove]` records consent in `~/.clawcodex/trusted.json`. The backend permission system still gates every action — this surfaces the trust state + records acknowledgment (no hard restriction).

Found via the component audit — a genuine §6 gap.

## Verification
Untrusted folder shows the first-run notice; `/trust add` marks it trusted (persisted) and clears the notice next run. typecheck + build clean. 63 commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)