### PR TITLE
feat(ui-tui): terminal focus tracking (§8) — notify when unfocused

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -255,6 +255,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const [busy, setBusy] = useState(false)
   const [turnStartedAt, setTurnStartedAt] = useState(0)
   const turnStartRef = useRef(0) // closure-safe turn-start time for the completion notification
+  const focusedRef = useRef(true) // terminal focus (DECSET 1004) — for notify-when-unfocused
   const [model, setModel] = useState('?')
   const [mode, setMode] = useState('?')
   const [tools, setTools] = useState(0)
@@ -604,7 +605,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
           // Completion notification (the original's terminal notifications, §8):
           // ring the bell + OSC 9 desktop notice for long turns the user may have
           // stepped away from. Quick turns stay silent (threshold 10s).
-          if (turnStartRef.current && Date.now() - turnStartRef.current > 10_000) {
+          if (turnStartRef.current && (!focusedRef.current || Date.now() - turnStartRef.current > 10_000)) {
             try {
               process.stdout.write('\x07') // bell — flags the tab/taskbar
               process.stdout.write('\x1b]9;clawcodex — response ready\x07') // OSC 9 (iTerm/Ghostty/kitty)
@@ -696,6 +697,15 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   }, [transport])
 
   useInput((ch, key) => {
+    // Terminal focus events (DECSET 1004) arrive as "[I" / "[O" — track + swallow.
+    if (ch === '[I') {
+      focusedRef.current = true
+      return
+    }
+    if (ch === '[O') {
+      focusedRef.current = false
+      return
+    }
     if (key.ctrl && ch === 'c') {
       client?.close()
       exit()
@@ -1857,6 +1867,23 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [entries.length])
+
+  // Terminal focus tracking (DECSET 1004, §8): enable focus reporting so the
+  // completion notification can fire when the user is away (unfocused).
+  useEffect(() => {
+    try {
+      process.stdout.write('\x1b[?1004h')
+    } catch {
+      /* non-tty */
+    }
+    return () => {
+      try {
+        process.stdout.write('\x1b[?1004l')
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [])
 
   // Folder-trust first-run notice (the original's TrustDialog, §6): once ready,
   // if this folder hasn't been acknowledged, surface a one-line notice. The

--- a/ui-tui/src/components/VimInput.tsx
+++ b/ui-tui/src/components/VimInput.tsx
@@ -235,6 +235,7 @@ export function VimInput({
   useInput(
     (input, key) => {
       if (!active) return
+      if (input === '[I' || input === '[O') return // terminal focus events — ignore
       const wasYank = yankActive.current // was the previous key a yank? (for Meta+Y)
       yankActive.current = false
       if (readlineEdit(input, key, wasYank)) return // Ctrl+A/E/W/U/K/Y, Meta+Y in either mode


### PR DESCRIPTION
## Summary
Ports focus tracking (inventory §8). Enables DECSET 1004 so the terminal reports focus; ink delivers the events as `"[I"`/`"[O"`, which App tracks (`focusedRef`) and both input handlers swallow (no garbage in the prompt). The completion notification (#517) now fires when the user is **unfocused** (any duration), not just for >10s turns.

## Verification
A quick turn while unfocused now notifies; focus escapes never appear in the input line. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)