### PR TITLE
feat(ui-tui): queued-prompt priorities now/next/later (§1)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -2013,8 +2013,17 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     setSlashSel(0)
     if (busy) {
       // Queue prompts typed while the agent is working (the original's queued
-      // commands); the drain effect sends the next one when the turn ends.
-      queuedRef.current.push(text)
+      // commands) with now/next/later priority (inventory §1): a leading "now:"
+      // interrupts the current turn and runs next; "next:" jumps the queue;
+      // otherwise it's appended (later). The drain effect sends the front item
+      // when the turn ends.
+      const pri = text.match(/^(now|next)\s*:\s*([\s\S]+)$/i)
+      if (pri) {
+        queuedRef.current.unshift(pri[2] as string) // front of the queue
+        if ((pri[1] as string).toLowerCase() === 'now') client?.interrupt() // run it immediately
+      } else {
+        queuedRef.current.push(text) // later (default, FIFO)
+      }
       setQueued([...queuedRef.current])
       return
     }


### PR DESCRIPTION
## Summary
Ports the original's queued-command priorities (inventory §1). While the agent is busy, a queued prompt prefixed `now:` interrupts the current turn and runs next; `next:` jumps to the front of the queue; anything else is appended (later, FIFO — unchanged default). The prefix is stripped before queueing.

Found via the component audit — a genuine §1 gap.

## Verification
`next: X` lands at the front ahead of an earlier appended item (prefix stripped); `now: X` triggers an interrupt. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)