### PR TITLE
feat(ui-tui): configurable keybindings (§8)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -17,6 +17,7 @@ import { PermissionDialog } from './components/PermissionDialog.js'
 import { SlashMenu } from './components/SlashMenu.js'
 import { editInEditor } from './editor.js'
 import { isTrusted, trustFolder, untrustFolder } from './trust.js'
+import { matchesBinding } from './keybindings.js'
 import { exec } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
@@ -722,19 +723,19 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     }
     // Ctrl+O: toggle expand of collapsed tool results / thinking (fully re-renders
     // in fullscreen; affects subsequent entries in inline <Static> mode).
-    if (key.ctrl && ch === 'o') {
+    if (matchesBinding('expand', ch, key)) {
       setExpanded((e) => !e)
       return
     }
     // Ctrl+L: redraw. In fullscreen, clear the alt-screen and force a repaint;
     // in inline mode a repaint is harmless (Static stays in scrollback).
-    if (key.ctrl && ch === 'l') {
+    if (matchesBinding('redraw', ch, key)) {
       if (FULLSCREEN) process.stdout.write('\x1b[2J\x1b[3J\x1b[H')
       setThemeVersion((v) => v + 1) // force a re-render
       return
     }
     // Ctrl+G: edit the current prompt in $EDITOR (the original's external editor).
-    if (key.ctrl && ch === 'g') {
+    if (matchesBinding('external-editor', ch, key)) {
       const sin = process.stdin as unknown as { setRawMode?: (m: boolean) => void }
       const canRaw = typeof sin.setRawMode === 'function'
       try {
@@ -776,7 +777,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       }
       return // find mode swallows other keys
     }
-    if (FULLSCREEN && key.ctrl && ch === 'f') {
+    if (FULLSCREEN && matchesBinding('transcript-find', ch, key)) {
       setTxFind('')
       return
     }
@@ -803,7 +804,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       return // picker swallows all other keys
     }
     // Ctrl+R: open reverse history search, or cycle to the next older match.
-    if (key.ctrl && ch === 'r') {
+    if (matchesBinding('history-search', ch, key)) {
       if (!searchMode) {
         setSearchMode(true)
         setSearchQuery('')
@@ -843,7 +844,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     }
     // Ctrl+E: jump to the oldest message (show-previous, the original's §8); a
     // second press (already at top) jumps back to the bottom.
-    if (FULLSCREEN && key.ctrl && ch === 'e') {
+    if (FULLSCREEN && matchesBinding('jump-oldest', ch, key)) {
       setScrollOffset((o) => (o >= Math.max(0, entries.length - 1) ? 0 : Math.max(0, entries.length - 1)))
       return
     }

--- a/ui-tui/src/keybindings.ts
+++ b/ui-tui/src/keybindings.ts
@@ -1,0 +1,63 @@
+/**
+ * Configurable keybindings (the original's keybindings/loadUserBindings, §8).
+ * Maps named actions → key combos, overridable via ~/.clawcodex/keybindings.json
+ * (e.g. {"external-editor": "ctrl+x"}). Unset actions fall back to defaults, so
+ * behavior is unchanged when no config exists (regression-safe).
+ */
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+const DEFAULTS: Record<string, string> = {
+  'external-editor': 'ctrl+g',
+  redraw: 'ctrl+l',
+  expand: 'ctrl+o',
+  'transcript-find': 'ctrl+f',
+  'history-search': 'ctrl+r',
+  'jump-oldest': 'ctrl+e',
+}
+
+let _bindings: Record<string, string> | null = null
+
+function load(): Record<string, string> {
+  if (_bindings) return _bindings
+  let custom: Record<string, unknown> = {}
+  try {
+    const raw = JSON.parse(readFileSync(join(homedir(), '.clawcodex', 'keybindings.json'), 'utf8'))
+    if (raw && typeof raw === 'object') custom = raw as Record<string, unknown>
+  } catch {
+    /* no config — defaults only */
+  }
+  const merged: Record<string, string> = { ...DEFAULTS }
+  for (const [k, v] of Object.entries(custom)) {
+    if (typeof v === 'string' && v.trim()) merged[k] = v.trim().toLowerCase()
+  }
+  _bindings = merged
+  return merged
+}
+
+interface KeyState {
+  ctrl?: boolean
+  shift?: boolean
+  meta?: boolean
+}
+
+/** True if the pressed key (ch + modifiers) matches the combo bound to `action`. */
+export function matchesBinding(action: string, ch: string, key: KeyState): boolean {
+  const combo = load()[action]
+  if (!combo) return false
+  const parts = combo.split('+')
+  const k = parts[parts.length - 1] ?? ''
+  const needCtrl = parts.includes('ctrl')
+  const needShift = parts.includes('shift')
+  const needAlt = parts.includes('alt') || parts.includes('meta') || parts.includes('option')
+  if (needCtrl !== !!key.ctrl) return false
+  if (needShift !== !!key.shift) return false
+  if (needAlt !== !!key.meta) return false
+  return (ch || '').toLowerCase() === k
+}
+
+/** Test seam: reset the cached config (so a freshly-written file is re-read). */
+export function _resetBindingsCache(): void {
+  _bindings = null
+}


### PR DESCRIPTION
## Summary
Ports the original's `loadUserBindings` (inventory §8). `src/keybindings.ts` maps named actions → key combos, overridable via `~/.clawcodex/keybindings.json` (e.g. `{"external-editor":"ctrl+x"}`); unset actions fall back to defaults so behavior is unchanged with no config (**regression-safe**). The global ctrl binds — expand, redraw, external-editor, transcript-find, history-search, jump-oldest — now route through `matchesBinding(action, ch, key)`.

This was the "risky refactor" deferred earlier — done **safely** via default-fallback (no config = no change), not a wholesale input rewrite.

## Verification
`matchesBinding` maps `ctrl+g`→external-editor by default and `ctrl+x` after a remap; in-app `Ctrl+R` still opens history search with no config. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)