### PR TITLE
feat(ui-tui): MCP server approval/trust (§6)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -16,7 +16,7 @@ import { Message } from './components/Message.js'
 import { PermissionDialog } from './components/PermissionDialog.js'
 import { SlashMenu } from './components/SlashMenu.js'
 import { editInEditor } from './editor.js'
-import { isTrusted, trustFolder, untrustFolder } from './trust.js'
+import { isTrusted, trustFolder, untrustFolder, isMcpTrusted, trustMcp } from './trust.js'
 import { matchesBinding } from './keybindings.js'
 import { exec } from 'node:child_process'
 import { readFileSync } from 'node:fs'
@@ -1592,9 +1592,28 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
             }
             const lines = servers.map((s) => {
               const tools = Array.isArray(s['tools']) ? (s['tools'] as string[]) : []
-              return `● ${String(s['name'])} — ${tools.length} tool${tools.length === 1 ? '' : 's'}: ${tools.join(', ')}`
+              const nm = String(s['name'])
+              const mark = isMcpTrusted(nm) ? '✓' : '⚠'
+              return `${mark} ${nm} — ${tools.length} tool${tools.length === 1 ? '' : 's'}: ${tools.join(', ')}`
             })
-            addEntry({ kind: 'system', text: `MCP servers:\n${lines.join('\n')}` })
+            const anyUntrusted = servers.some((s) => !isMcpTrusted(String(s['name'])))
+            const hint = anyUntrusted ? '\n⚠ unapproved server(s) — /mcp-trust to approve' : ''
+            addEntry({ kind: 'system', text: `MCP servers:\n${lines.join('\n')}${hint}` })
+          })
+        }
+        return true
+      }
+      case 'mcpTrust': {
+        if (client) {
+          void client.requestControl('list_mcp').then((r) => {
+            const servers = Array.isArray(r?.['servers']) ? (r['servers'] as Record<string, unknown>[]) : []
+            if (!servers.length) {
+              addEntry({ kind: 'system', text: 'no MCP servers to approve' })
+              return
+            }
+            const names = servers.map((s) => String(s['name']))
+            names.forEach(trustMcp)
+            addEntry({ kind: 'system', text: `✓ approved MCP server(s): ${names.join(', ')}` })
           })
         }
         return true

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -58,6 +58,7 @@ export interface SlashCommand {
     | 'fast'
     | 'open'
     | 'trust'
+    | 'mcpTrust'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -94,6 +95,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/export', description: 'Save the transcript to a markdown file', kind: 'export' },
   { name: '/copy', description: "Copy the last response to the clipboard", kind: 'copy' },
   { name: '/mcp', description: 'List connected MCP servers and their tools', kind: 'mcp' },
+  { name: '/mcp-trust', description: 'Approve the connected MCP servers', kind: 'mcpTrust' },
   { name: '/permissions', description: 'Show active permission mode and rules', kind: 'permissions' },
   { name: '/agents', description: 'List available subagent types', kind: 'agents' },
   { name: '/skills', description: 'List available skills', kind: 'skills' },

--- a/ui-tui/src/trust.ts
+++ b/ui-tui/src/trust.ts
@@ -43,3 +43,35 @@ export function trustFolder(cwd: string): void {
 export function untrustFolder(cwd: string): void {
   save(load().filter((p) => p !== cwd))
 }
+
+/**
+ * MCP server approval (the original's MCP server-trust dialog, §6): remember which
+ * MCP servers the user has approved. Stored at ~/.clawcodex/trusted-mcp.json.
+ */
+const MCP_TRUST_FILE = join(homedir(), '.clawcodex', 'trusted-mcp.json')
+
+function loadMcp(): string[] {
+  try {
+    const v = JSON.parse(readFileSync(MCP_TRUST_FILE, 'utf8'))
+    return Array.isArray(v) ? v.map(String) : []
+  } catch {
+    return []
+  }
+}
+
+export function isMcpTrusted(name: string): boolean {
+  return loadMcp().includes(name)
+}
+
+export function trustMcp(name: string): void {
+  const list = loadMcp()
+  if (!list.includes(name)) {
+    list.push(name)
+    try {
+      mkdirSync(dirname(MCP_TRUST_FILE), { recursive: true })
+      writeFileSync(MCP_TRUST_FILE, JSON.stringify(list), 'utf8')
+    } catch {
+      /* best-effort */
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Ports the original's MCP server-trust as a soft approval (analogous to folder-trust, #518). `/mcp` marks each server ✓ approved / ⚠ not-approved and hints when any are unapproved; `/mcp-trust` approves the connected servers, persisted in `~/.clawcodex/trusted-mcp.json`. Soft surface — the backend still gates tool use.

## Verification
`/mcp` shows ⚠ + hint for an unapproved server; `/mcp-trust` persists the approval; `/mcp` then shows ✓. typecheck + build clean. 64 commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)