### PR TITLE
feat(mcp): handle incoming server→client requests (elicitation) in McpClient

### DIFF
--- a/src/services/mcp/client.py
+++ b/src/services/mcp/client.py
@@ -128,6 +128,20 @@ class McpClient:
         # that want OAuth-protected MCP servers to work end-to-end;
         # legacy callers (stdio / open HTTP) pass None.
         self._auth_provider: Any = None
+        # MCP elicitation (server→client input requests, §6): optional async
+        # handler that presents the request to the user and returns the result
+        # ({"action": "accept"|"decline"|"cancel", "content": {...}}). Default
+        # (None) declines — a valid response, so elicitation-capable servers no
+        # longer hang on an ignored request.
+        self._elicitation_handler: Any = None
+
+    def set_elicitation_handler(self, handler: Any) -> None:
+        """Inject the async elicitation handler (params dict -> result dict).
+
+        Wired in by the runtime to bridge an MCP server's input request to the
+        TUI. When unset, elicitation requests are declined.
+        """
+        self._elicitation_handler = handler
 
     def set_auth_provider(self, provider: Any) -> None:
         """Inject the McpAuthProvider used for HTTP/SSE/WS auth flows.
@@ -196,7 +210,7 @@ class McpClient:
                 "initialize",
                 {
                     "protocolVersion": "2024-11-05",
-                    "capabilities": {"roots": {}},
+                    "capabilities": {"roots": {}, "elicitation": {}},
                     "clientInfo": {
                         "name": "claude-code",
                         "version": "1.0.0",
@@ -344,12 +358,60 @@ class McpClient:
                         )
                     else:
                         future.set_result(msg.result)
+                elif msg.method is not None and msg.id is not None:
+                    # Incoming server→client REQUEST (e.g. elicitation/create).
+                    # Handle out-of-band so the loop keeps draining, then reply.
+                    asyncio.get_event_loop().create_task(
+                        self._handle_incoming_request(msg)
+                    )
         except Exception as e:
             logger.debug("MCP receive loop error: %s", e)
             for future in self._pending_requests.values():
                 if not future.done():
                     future.set_exception(e)
             self._pending_requests.clear()
+
+    async def _handle_incoming_request(self, msg: JsonRpcMessage) -> None:
+        """Reply to a server→client request (elicitation/create, etc.)."""
+        try:
+            if msg.method == "elicitation/create":
+                result = await self._run_elicitation(msg.params or {})
+                await self._send_response(msg.id, result=result)
+            else:
+                await self._send_response(
+                    msg.id,
+                    error={"code": -32601, "message": f"Method not found: {msg.method}"},
+                )
+        except Exception as e:  # never let a handler crash the receive loop
+            try:
+                await self._send_response(
+                    msg.id, error={"code": -32603, "message": str(e)}
+                )
+            except Exception:
+                pass
+
+    async def _run_elicitation(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Run the injected elicitation handler, or decline if none is set."""
+        handler = self._elicitation_handler
+        if handler is None:
+            return {"action": "decline"}
+        try:
+            res = await handler(params)
+            return res if isinstance(res, dict) and res.get("action") else {"action": "decline"}
+        except Exception:
+            return {"action": "decline"}
+
+    async def _send_response(
+        self,
+        request_id: int | str | None,
+        result: Any = None,
+        error: dict[str, Any] | None = None,
+    ) -> None:
+        if self._transport is None or request_id is None:
+            return
+        await self._transport.send(
+            JsonRpcMessage(id=request_id, result=result, error=error)
+        )
 
     async def _send_request(
         self,

--- a/tests/test_mcp_elicitation.py
+++ b/tests/test_mcp_elicitation.py
@@ -1,0 +1,77 @@
+"""MCP elicitation handling (server→client requests) in McpClient."""
+import asyncio
+
+from src.services.mcp.client import McpClient
+from src.services.mcp.transport import JsonRpcMessage, McpTransport
+
+
+class _FakeTransport(McpTransport):
+    def __init__(self, incoming):
+        self._incoming = list(incoming)
+        self.sent = []
+        self._open = True
+
+    async def start(self): ...
+
+    async def send(self, message):
+        self.sent.append(message)
+
+    async def receive(self):
+        if self._incoming:
+            return self._incoming.pop(0)
+        # one short tick, then signal close so the loop exits
+        await asyncio.sleep(0.02)
+        self._open = False
+        return None
+
+    async def close(self):
+        self._open = False
+
+    @property
+    def is_connected(self):
+        return self._open
+
+
+def _run(client, transport):
+    async def go():
+        client._transport = transport
+        await client._receive_loop()
+        # let any out-of-band handler task finish + send its reply
+        await asyncio.sleep(0.05)
+    asyncio.run(go())
+
+
+def test_elicitation_default_declines():
+    req = JsonRpcMessage(method="elicitation/create", id=7, params={"message": "Name?"})
+    tx = _FakeTransport([req])
+    c = McpClient()
+    _run(c, tx)
+    replies = [m for m in tx.sent if m.id == 7]
+    assert replies, "no reply sent to elicitation/create"
+    assert replies[0].result == {"action": "decline"}
+
+
+def test_elicitation_uses_handler():
+    captured = {}
+
+    async def handler(params):
+        captured.update(params)
+        return {"action": "accept", "content": {"name": "Ada"}}
+
+    req = JsonRpcMessage(method="elicitation/create", id=9, params={"message": "Name?"})
+    tx = _FakeTransport([req])
+    c = McpClient()
+    c.set_elicitation_handler(handler)
+    _run(c, tx)
+    replies = [m for m in tx.sent if m.id == 9]
+    assert replies and replies[0].result == {"action": "accept", "content": {"name": "Ada"}}
+    assert captured.get("message") == "Name?"
+
+
+def test_unknown_request_method_errors():
+    req = JsonRpcMessage(method="sampling/createMessage", id=11, params={})
+    tx = _FakeTransport([req])
+    c = McpClient()
+    _run(c, tx)
+    replies = [m for m in tx.sent if m.id == 11]
+    assert replies and replies[0].error and replies[0].error["code"] == -32601


### PR DESCRIPTION
## Summary
The McpClient receive loop matched only responses (by id) and **silently dropped incoming server→client requests** — so an elicitation-capable server's `elicitation/create` would hang forever. Now the client:
- advertises the `elicitation` capability on `initialize`,
- dispatches incoming requests out-of-band (loop keeps draining), and
- replies: `elicitation/create` → an injectable async handler (`set_elicitation_handler`), defaulting to `{"action":"decline"}` when none is wired; unknown methods → JSON-RPC `-32601`.

This is the **backend protocol layer** for MCP elicitation (inventory §6); the handler hook is the seam for bridging to a TUI form (follow-up). Foundational + safe: elicitation servers no longer hang, behavior unchanged when no handler is set.

## Verification
`tests/test_mcp_elicitation.py` — default-decline, handler-used, unknown-method `-32601`. Full MCP suite green (68 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)