### PR TITLE
feat(mcp): bridge MCP elicitation to the TUI (agent-server round-trip)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -1229,6 +1229,38 @@ def make_spawn_agent(config: AgentServerConfig | None = None):
 # ─── runtime construction (mirrors entrypoints/headless.py) ───────────────────
 
 
+def _make_elicitation_handler(sess: "_AgentSession") -> Any:
+    """Async MCP elicitation handler that bridges a server's input request to the
+    TUI via the session's control-request round-trip (reusing the permission
+    ``_pending`` mechanism). Runs on the McpRuntime loop; ``_emit`` is thread-safe
+    and the main loop's control_response handler sets the pending event.
+    """
+
+    async def _elicit(params: dict[str, Any]) -> dict[str, Any]:
+        request_id = str(_uuid.uuid4())
+        pending = _Pending(event=threading.Event())
+        with sess._lock:
+            sess._pending[request_id] = pending
+        sess._emit({
+            "type": "control_request",
+            "request_id": request_id,
+            "request": {"subtype": "mcp_elicitation", "params": params},
+        })
+        loop = asyncio.get_event_loop()
+        try:
+            got = await loop.run_in_executor(
+                None, pending.event.wait, sess.config.permission_timeout_s
+            )
+        finally:
+            with sess._lock:
+                sess._pending.pop(request_id, None)
+        if not got:
+            return {"action": "cancel"}
+        return pending.reply or {"action": "decline"}
+
+    return _elicit
+
+
 def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
     """Construct provider, registry, session, tool_context for ``sess``.
 
@@ -1289,6 +1321,13 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
                     except Exception:  # noqa: BLE001
                         logger.debug("[mcp] register failed: %s", getattr(mtool, "name", "?"), exc_info=True)
                 sess._mcp_runtime = mcp_rt
+                # Wire MCP elicitation → TUI form (servers can request user input).
+                _eh = _make_elicitation_handler(sess)
+                for _cl in mcp_rt.clients.values():
+                    try:
+                        _cl.set_elicitation_handler(_eh)
+                    except Exception:  # noqa: BLE001
+                        pass
                 logger.info(
                     "[agent-server] MCP: %d tool(s) from %d server(s)",
                     len(mcp_rt.tools), len(mcp_rt.servers),

--- a/tests/test_mcp_elicitation.py
+++ b/tests/test_mcp_elicitation.py
@@ -75,3 +75,52 @@ def test_unknown_request_method_errors():
     _run(c, tx)
     replies = [m for m in tx.sent if m.id == 11]
     assert replies and replies[0].error and replies[0].error["code"] == -32601
+
+
+def test_agent_server_elicitation_bridge_round_trip():
+    """_make_elicitation_handler emits mcp_elicitation + returns the TUI reply."""
+    import threading as _t
+    from types import SimpleNamespace
+    from src.server.agent_server import _make_elicitation_handler
+
+    sess = SimpleNamespace(
+        _lock=_t.Lock(),
+        _pending={},
+        emitted=[],
+        config=SimpleNamespace(permission_timeout_s=2.0),
+    )
+    sess._emit = lambda m: sess.emitted.append(m)
+    handler = _make_elicitation_handler(sess)
+
+    async def go():
+        task = asyncio.create_task(handler({"message": "Name?"}))
+        for _ in range(100):
+            if sess.emitted:
+                break
+            await asyncio.sleep(0.01)
+        rid = sess.emitted[0]["request_id"]
+        with sess._lock:
+            sess._pending[rid].reply = {"action": "accept", "content": {"name": "Ada"}}
+            sess._pending[rid].event.set()
+        return await task
+
+    result = asyncio.run(go())
+    assert sess.emitted[0]["request"]["subtype"] == "mcp_elicitation"
+    assert result == {"action": "accept", "content": {"name": "Ada"}}
+
+
+def test_agent_server_elicitation_bridge_timeout_cancels():
+    import threading as _t
+    from types import SimpleNamespace
+    from src.server.agent_server import _make_elicitation_handler
+
+    sess = SimpleNamespace(
+        _lock=_t.Lock(),
+        _pending={},
+        emitted=[],
+        config=SimpleNamespace(permission_timeout_s=0.05),  # times out fast
+    )
+    sess._emit = lambda m: sess.emitted.append(m)
+    handler = _make_elicitation_handler(sess)
+    result = asyncio.run(handler({"message": "Name?"}))
+    assert result == {"action": "cancel"}


### PR DESCRIPTION
## Summary
Wires each connected MCP client's elicitation handler (#526) to the TUI: when a server sends `elicitation/create`, the agent-server emits `control_request {subtype:'mcp_elicitation', params}` and awaits the reply, **reusing the permission `_pending` mechanism** (thread-safe `_emit`; the main loop's control_response handler sets the pending event). The handler runs on the McpRuntime loop and awaits the `threading.Event` via `run_in_executor`; timeout → `{action:'cancel'}`.

Backend half of functional MCP elicitation (inventory §6); the TUI form lands next.

## Verification
`tests/test_mcp_elicitation.py` — round-trip (emits `mcp_elicitation`, returns the TUI reply) + timeout→cancel. Agent-server e2e + MCP suites green (18 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)