### PR TITLE
feat(ui-tui): MCP elicitation form (§6) — completes functional elicitation

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -248,6 +248,8 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const [streaming, setStreaming] = useState('')
   const streamRef = useRef('') // source of truth for the live buffer (no stale closures)
   const [permissions, setPermissions] = useState<PendingPermission[]>([]) // FIFO queue
+  // MCP elicitation form (a server requested user input, §6).
+  const [elicit, setElicit] = useState<{ requestId: string; message: string; field: string; value: string } | null>(null)
   const alwaysAllowRef = useRef<Set<string>>(new Set()) // tools the user said "don't ask again"
   const bashAllowPrefixRef = useRef<Set<string>>(new Set()) // Bash command prefixes auto-allowed (granular)
   const pendingImageRef = useRef<{ data: string; media_type: string; name: string } | null>(null) // /image attachment
@@ -566,6 +568,12 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
             input: (req as { input?: Record<string, unknown> }).input ?? {},
           },
         ]),
+      onElicitation: (params, requestId) => {
+        const message = String((params as { message?: unknown }).message ?? 'The MCP server requests input')
+        const schema = (params as { requestedSchema?: { properties?: Record<string, unknown> } }).requestedSchema
+        const field = schema?.properties ? Object.keys(schema.properties)[0] || 'value' : 'value'
+        setElicit({ requestId, message, field, value: '' })
+      },
       onMessage: (msg) => {
         const delta = streamDeltaText(msg)
         if (delta !== null) {
@@ -715,6 +723,30 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       focusedRef.current = false
       blurAtRef.current = Date.now()
       return
+    }
+    // MCP elicitation form: capture input → respond accept/decline (§6).
+    if (elicit) {
+      if (key.escape) {
+        client?.respondControl(elicit.requestId, { action: 'decline' })
+        setElicit(null)
+        return
+      }
+      if (key.return) {
+        client?.respondControl(elicit.requestId, {
+          action: 'accept',
+          content: { [elicit.field]: elicit.value },
+        })
+        setElicit(null)
+        return
+      }
+      if (key.backspace || key.delete) {
+        setElicit((e) => (e ? { ...e, value: e.value.slice(0, -1) } : e))
+        return
+      }
+      if (ch && !key.ctrl && !key.meta && ch.length === 1 && ch >= ' ') {
+        setElicit((e) => (e ? { ...e, value: e.value + ch } : e))
+      }
+      return // elicitation swallows other keys
     }
     if (key.ctrl && ch === 'c') {
       client?.close()
@@ -2158,7 +2190,28 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         </Box>
       ) : null}
 
-      {permission ? (
+      {elicit ? (
+        <Box
+          flexDirection="column"
+          borderStyle="round"
+          borderColor={theme.suggestion}
+          borderLeft={false}
+          borderRight={false}
+          paddingX={1}
+          marginTop={1}
+        >
+          <Text color={theme.accent} bold>
+            {'⌯ MCP server requests input'}
+          </Text>
+          <Text>{elicit.message}</Text>
+          <Box>
+            <Text color={theme.dim}>{`${elicit.field}: `}</Text>
+            <Text>{elicit.value}</Text>
+            <Text inverse> </Text>
+          </Box>
+          <Text color={theme.dim}>{'  enter to send · esc to decline'}</Text>
+        </Box>
+      ) : permission ? (
         <Box flexDirection="column">
           <PermissionDialog toolName={permission.toolName} input={permission.input} />
           {permFeedback !== null ? (
@@ -2254,7 +2307,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
               vimEnabled={vimMode}
               onChange={handleInputChange}
               onSubmit={onSubmit}
-              active
+              active={!elicit}
               placeholder={ready ? 'Type a message, or / for commands…' : 'starting agent-server…'}
             />
             {/* Inline ghost-text completion for slash commands (inventory §1):

--- a/ui-tui/src/client.ts
+++ b/ui-tui/src/client.ts
@@ -49,6 +49,8 @@ export async function createSession(
 export interface ClientCallbacks {
   onMessage: (msg: ServerMessage) => void;
   onPermissionRequest: (req: ControlRequestMessage['request'], requestId: string) => void;
+  /** An MCP server requested user input (elicitation/create, §6). */
+  onElicitation?: (params: Record<string, unknown>, requestId: string) => void;
   onConnected?: () => void;
   onDisconnected?: () => void;
   onError?: (err: Error) => void;
@@ -107,6 +109,9 @@ export class DirectConnectClient {
       const subtype = cr.request?.subtype;
       if (subtype === 'can_use_tool' && typeof cr.request_id === 'string') {
         this.cb.onPermissionRequest(cr.request, cr.request_id);
+      } else if (subtype === 'mcp_elicitation' && typeof cr.request_id === 'string' && this.cb.onElicitation) {
+        const params = (cr.request as { params?: Record<string, unknown> })?.params ?? {};
+        this.cb.onElicitation(params, cr.request_id);
       } else if (typeof cr.request_id === 'string') {
         this.sendErrorResponse(cr.request_id, `unsupported control subtype: ${subtype}`);
       }
@@ -160,6 +165,14 @@ export class DirectConnectClient {
       behavior === 'allow'
         ? { behavior: 'allow', updatedInput: opts.updatedInput ?? {} }
         : { behavior: 'deny', message: opts.message ?? '' };
+    this.send({
+      type: 'control_response',
+      response: { subtype: 'success', request_id: requestId, response },
+    });
+  }
+
+  /** Send a raw control_response payload (e.g. an MCP elicitation result). */
+  respondControl(requestId: string, response: Record<string, unknown>): void {
     this.send({
       type: 'control_response',
       response: { subtype: 'success', request_id: requestId, response },


### PR DESCRIPTION
## Summary
The TUI half of MCP elicitation. The client routes `mcp_elicitation` control_requests to a new `onElicitation` callback; App shows a form (server message + a field from the `requestedSchema`), captures input, and replies via a new `client.respondControl`: Enter → `{action:'accept', content:{<field>: value}}`, Esc → `{action:'decline'}`. VimInput is gated (`active={!elicit}`) so keystrokes go to the form, not the prompt.

With #526 (client protocol) + #527 (agent-server bridge), **MCP elicitation now works end-to-end**: a server's `elicitation/create` → TUI form → response back to the server.

## Verification
ink-testing-library e2e: form renders message+field; typing shows in the form (not the prompt); Enter sends `{action:accept, content:{name:Ada}}`; Esc declines; normal prompt typing unaffected. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)