### PR TITLE
feat(ui-tui): right-to-left text shaping (§8 bidi)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -18,6 +18,7 @@ import { SlashMenu } from './components/SlashMenu.js'
 import { editInEditor } from './editor.js'
 import { isTrusted, trustFolder, untrustFolder, isMcpTrusted, trustMcp } from './trust.js'
 import { matchesBinding } from './keybindings.js'
+import { shapeRtl } from './bidi.js'
 import { exec } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
@@ -250,6 +251,8 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const [permissions, setPermissions] = useState<PendingPermission[]>([]) // FIFO queue
   // MCP elicitation form (a server requested user input, §6).
   const [elicit, setElicit] = useState<{ requestId: string; message: string; field: string; value: string } | null>(null)
+  // RTL display shaping (§8) — opt-in (terminals with native bidi shouldn't use it).
+  const [rtlMode, setRtlMode] = useState<boolean>(process.env['CLAWCODEX_RTL'] === '1')
   const alwaysAllowRef = useRef<Set<string>>(new Set()) // tools the user said "don't ask again"
   const bashAllowPrefixRef = useRef<Set<string>>(new Set()) // Bash command prefixes auto-allowed (granular)
   const pendingImageRef = useRef<{ data: string; media_type: string; name: string } | null>(null) // /image attachment
@@ -1190,6 +1193,17 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         })
         return true
       }
+      case 'rtl': {
+        setRtlMode((on) => {
+          const next = !on
+          addEntry({
+            kind: 'system',
+            text: `right-to-left shaping ${next ? 'on' : 'off'}${next ? ' (best in fullscreen / for new messages)' : ''}`,
+          })
+          return next
+        })
+        return true
+      }
       case 'trust': {
         const a = arg.trim().toLowerCase()
         const cwd = process.cwd()
@@ -2115,9 +2129,11 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const visibleEntries = FULLSCREEN
     ? windowFromBottom(fsEntries, process.stdout.columns ?? 80, Math.max(4, termRows - 4), scrollOffset)
     : entries
+  const shapeEntry = (e: TranscriptEntry): TranscriptEntry =>
+    rtlMode && e.text ? { ...e, text: e.text.split('\n').map(shapeRtl).join('\n') } : e
   const renderEntry = (entry: TranscriptEntry): React.ReactElement => (
     <Box key={entry.id} marginTop={['tool', 'toolResult', 'banner'].includes(entry.kind) ? 0 : 1}>
-      <Message entry={entry} expanded={expanded} />
+      <Message entry={shapeEntry(entry)} expanded={expanded} />
     </Box>
   )
 

--- a/ui-tui/src/bidi.ts
+++ b/ui-tui/src/bidi.ts
@@ -1,0 +1,99 @@
+/**
+ * RTL run shaping (the original's bidi handling, inventory §8) — pure TS, no deps.
+ *
+ * Scope: reorders right-to-left runs (Hebrew/Arabic) into visual order within
+ * LTR-base text, for terminals that don't apply the Unicode Bidirectional
+ * Algorithm themselves. This covers the common case — RTL words embedded in
+ * otherwise-LTR content — correctly and verifiably. It is intentionally NOT a
+ * full UAX #9 implementation (no base-RTL paragraph resolution, no nested
+ * embedding levels); it's opt-in (/rtl) precisely because terminals that DO
+ * their own bidi would otherwise double-reorder.
+ */
+
+type CharType = 'R' | 'EN' | 'L' | 'N'
+
+function classify(cp: number): CharType {
+  // Right-to-left scripts (Hebrew, Arabic, and their presentation forms).
+  if (
+    (cp >= 0x0590 && cp <= 0x05ff) || // Hebrew
+    (cp >= 0xfb1d && cp <= 0xfb4f) || // Hebrew presentation forms
+    (cp >= 0x0600 && cp <= 0x06ff) || // Arabic
+    (cp >= 0x0750 && cp <= 0x077f) || // Arabic supplement
+    (cp >= 0x08a0 && cp <= 0x08ff) || // Arabic extended-A
+    (cp >= 0xfb50 && cp <= 0xfdff) || // Arabic presentation forms-A
+    (cp >= 0xfe70 && cp <= 0xfeff) //   Arabic presentation forms-B
+  ) {
+    return 'R'
+  }
+  if (cp >= 0x0030 && cp <= 0x0039) return 'EN' // ASCII digits (stay LTR inside RTL)
+  if (cp >= 0x0660 && cp <= 0x0669) return 'EN' // Arabic-Indic digits (kept LTR-order)
+  return 'L' // everything else treated as LTR/neutral for run boundaries
+  // (N is folded into L here; interior-neutral handling is done in shapeRtl)
+}
+
+/** True if the string contains any RTL characters (cheap pre-check). */
+export function hasRtl(s: string): boolean {
+  for (const ch of s) {
+    if (classify(ch.codePointAt(0) ?? 0) === 'R') return true
+  }
+  return false
+}
+
+/**
+ * Reverse maximal RTL runs (including interior spaces/punctuation between two
+ * RTL chars) so they read correctly on a non-bidi terminal. Digit sub-runs
+ * inside an RTL run keep their logical order (numbers are read LTR).
+ */
+export function shapeRtl(s: string): string {
+  if (!hasRtl(s)) return s
+  const chars = [...s]
+  const n = chars.length
+  const isR = chars.map((c) => classify(c.codePointAt(0) ?? 0) === 'R')
+  const isSpace = chars.map((c) => {
+    const cp = c.codePointAt(0) ?? 0
+    return cp === 0x20 || (cp >= 0x21 && cp <= 0x2f) || (cp >= 0x3a && cp <= 0x40) // space + ASCII punct
+  })
+  const isDigit = chars.map((c) => classify(c.codePointAt(0) ?? 0) === 'EN')
+  const out = chars.slice()
+
+  const reverse = (lo: number, hi: number) => {
+    for (let a = lo, b = hi - 1; a < b; a++, b--) {
+      const t = out[a]!
+      out[a] = out[b]!
+      out[b] = t
+    }
+  }
+
+  let i = 0
+  while (i < n) {
+    if (!isR[i]) {
+      i++
+      continue
+    }
+    // Extend the run over RTL chars, interior spaces/punct, and digits.
+    let j = i + 1
+    while (j < n && (isR[j] || isDigit[j] || (isSpace[j] && j + 1 < n && (isR[j + 1] || isDigit[j + 1])))) {
+      j++
+    }
+    reverse(i, j)
+    // Restore logical order of digit sub-runs (they were reversed above).
+    for (let k = i; k < j; ) {
+      // after reversal, find digit sub-runs in `out` and un-reverse them
+      const origIdx = i + (j - 1 - k)
+      if (isDigit[origIdx]) {
+        let m = k
+        while (m < j) {
+          const oi = i + (j - 1 - m)
+          if (!isDigit[oi]) break
+          m++
+        }
+        reverse(k, m)
+        k = m
+      } else {
+        k++
+      }
+    }
+    i = j
+  }
+  return out.join('')
+}

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -59,6 +59,7 @@ export interface SlashCommand {
     | 'open'
     | 'trust'
     | 'mcpTrust'
+    | 'rtl'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -96,6 +97,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/copy', description: "Copy the last response to the clipboard", kind: 'copy' },
   { name: '/mcp', description: 'List connected MCP servers and their tools', kind: 'mcp' },
   { name: '/mcp-trust', description: 'Approve the connected MCP servers', kind: 'mcpTrust' },
+  { name: '/rtl', description: 'Toggle right-to-left text shaping (Hebrew/Arabic)', kind: 'rtl' },
   { name: '/permissions', description: 'Show active permission mode and rules', kind: 'permissions' },
   { name: '/agents', description: 'List available subagent types', kind: 'agents' },
   { name: '/skills', description: 'List available skills', kind: 'skills' },


### PR DESCRIPTION
## Summary
Ports RTL/bidi handling as a pure-TS shaper (no deps). `src/bidi.ts` reverses RTL runs (Hebrew/Arabic, incl. presentation forms) into visual order within LTR-base text, keeping digit sub-runs in logical order — the common case (RTL words in otherwise-LTR content) on terminals without native bidi. Opt-in via `/rtl` (and `CLAWCODEX_RTL=1`) since bidi-capable terminals would otherwise double-reorder.

Scoped honestly: **not** full UAX #9 (no base-RTL paragraph resolution / nested levels). Display-only — stored entry text stays logical, so `/export` and `/copy` are unaffected.

## Verification
bidi unit cases (RTL word reversed, spaced run, digits keep order, no-RTL untouched); in-app `/rtl` toggles and a Hebrew assistant line renders reversed while the logical form is not shown. typecheck + build clean. 65 commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)