### PR TITLE
feat: /lang — preferred response language (§6 LanguagePicker)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -111,6 +111,7 @@ class _AgentSession:
     session: Any = None
     system_prompt: Any = "You are a helpful assistant."
     _base_system_prompt: Any = None  # system prompt before the /plan section is composed in
+    _language: Any = None  # preferred response language (the original's LanguagePicker, §6)
     init_error: str | None = None
     _session_name: str | None = None  # user-set label (/rename) shown in /resume
     _mcp_runtime: Any = None  # McpRuntime (connected MCP servers) when configured
@@ -240,6 +241,9 @@ class _AgentSession:
             return
         if subtype == "plan":
             self._do_plan(request_id, inner.get("action"), inner.get("text"))
+            return
+        if subtype == "set_language":
+            self._do_set_language(request_id, inner.get("language"))
             return
         if subtype == "set_effort":
             effort = inner.get("effort")
@@ -593,10 +597,23 @@ class _AgentSession:
 
             plan = get_plan(self.cwd)
             if plan and isinstance(base, list):
-                return base + [{"type": "text", "text": f"# Current Plan\nFollow this plan set by the user:\n\n{plan}"}]
+                base = base + [{"type": "text", "text": f"# Current Plan\nFollow this plan set by the user:\n\n{plan}"}]
         except Exception:  # noqa: BLE001
             logger.debug("[agent-server] plan compose failed", exc_info=True)
+        # Response language (the original's LanguagePicker, §6).
+        lang = getattr(self, "_language", None)
+        if lang and isinstance(base, list):
+            base = base + [{"type": "text", "text": f"# Response Language\nRespond in {lang} unless the user writes in another language."}]
         return base
+
+    def _do_set_language(self, request_id: object, language: object) -> None:
+        """Set the preferred response language (LanguagePicker, §6) and recompose
+        the system prompt so the agent honors it. Empty clears it."""
+        lang = str(language or "").strip()
+        self._language = lang or None
+        if self._base_system_prompt is not None:
+            self.system_prompt = self._compose_with_plan(self._base_system_prompt)
+        self._reply(request_id, {"ok": True, "language": self._language or ""})
 
     def _do_plan(self, request_id: object, action: object, text: object) -> None:
         """/plan: view (default) | set <text> | clear. The plan is injected into

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -1193,6 +1193,16 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         })
         return true
       }
+      case 'lang': {
+        const lang = arg.trim()
+        if (client) {
+          void client.requestControl('set_language', { language: lang === 'clear' ? '' : lang }).then((r) => {
+            const set = r && r['language'] ? String(r['language']) : ''
+            addEntry({ kind: 'system', text: set ? `responses will be in ${set}` : 'response language cleared' })
+          })
+        }
+        return true
+      }
       case 'rtl': {
         setRtlMode((on) => {
           const next = !on

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -60,6 +60,7 @@ export interface SlashCommand {
     | 'trust'
     | 'mcpTrust'
     | 'rtl'
+    | 'lang'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -98,6 +99,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/mcp', description: 'List connected MCP servers and their tools', kind: 'mcp' },
   { name: '/mcp-trust', description: 'Approve the connected MCP servers', kind: 'mcpTrust' },
   { name: '/rtl', description: 'Toggle right-to-left text shaping (Hebrew/Arabic)', kind: 'rtl' },
+  { name: '/lang', description: 'Set preferred response language: /lang <language> (or clear)', kind: 'lang' },
   { name: '/permissions', description: 'Show active permission mode and rules', kind: 'permissions' },
   { name: '/agents', description: 'List available subagent types', kind: 'agents' },
   { name: '/skills', description: 'List available skills', kind: 'skills' },


### PR DESCRIPTION
## Summary
Ports the original's LanguagePicker. `/lang <language>` sets a preferred response language; the agent-server stores it and composes a `# Response Language\nRespond in <language>…` section into the system prompt (alongside `/plan`), recomposed live; `/lang clear` removes it. Backend `set_language` control + TUI command.

The original also sets a *voice* language; TTS is external/out-of-scope here — this ports the response-language half, which is what affects the agent.

## Verification
Backend injects "Respond in French" into the system prompt and clears it; TUI `/lang French` sends `set_language` and confirms. Agent-server + plan suites green (15 passed). typecheck + build clean. 66 commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)