### PR TITLE
feat: /btw — side question without polluting history (§1/§2)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -176,7 +176,10 @@ class _AgentSession:
         """Route one client → server message. Runs on the main asyncio loop."""
         msg_type = msg.get("type")
         if msg_type == "user":
-            self._inbox.put(_extract_prompt_content(msg))  # str, or blocks for multimodal
+            content = _extract_prompt_content(msg)  # str, or blocks for multimodal
+            mm = msg.get("message")
+            ephemeral = bool(msg.get("ephemeral") or (isinstance(mm, dict) and mm.get("ephemeral")))
+            self._inbox.put({"__btw__": True, "content": content} if ephemeral else content)
             return
         if msg_type == "control_response":
             self._resolve_permission(msg)
@@ -1064,12 +1067,17 @@ class _AgentSession:
             item = self._inbox.get()
             if item is _SHUTDOWN or self._stop.is_set():
                 break
+            if isinstance(item, dict) and item.get("__btw__"):  # side question (/btw)
+                self._run_turn(item.get("content"), btw=True)
+                continue
             if not isinstance(item, (str, list)):  # str prompt, or multimodal blocks
                 continue
             self._run_turn(item)
         self._close_stream()
 
-    def _run_turn(self, prompt) -> None:  # prompt: str | list[ContentBlock] (multimodal)
+    def _run_turn(self, prompt, btw: bool = False) -> None:  # prompt: str | list[ContentBlock]
+        # btw=True → a "side question" (the original's /btw): run with full context
+        # but DON'T persist the Q&A, so the main conversation isn't interrupted.
         from src.query.agent_loop_compat import run_query_as_agent_loop
 
         if self.init_error is not None:
@@ -1089,6 +1097,9 @@ class _AgentSession:
         if self.tool_context is not None:
             self.tool_context.abort_controller = abort
 
+        # Snapshot history for a side-question turn so we can restore it after
+        # (drops the ephemeral Q + A on every exit path via the finally below).
+        _btw_snapshot = list(self.session.conversation.messages) if btw else None
         self.session.conversation.add_user_message(prompt)
         start = time.monotonic()
 
@@ -1159,6 +1170,10 @@ class _AgentSession:
         finally:
             with self._lock:
                 self._current_abort = None
+            if btw and _btw_snapshot is not None:
+                msgs = self.session.conversation.messages
+                msgs.clear()
+                msgs.extend(_btw_snapshot)
 
         _usage = result.usage if result.num_turns > 0 else None
         _cost = 0.0

--- a/src/server/direct_connect_manager.py
+++ b/src/server/direct_connect_manager.py
@@ -125,21 +125,24 @@ class DirectConnectSessionManager:
     def is_connected(self) -> bool:
         return self._ws is not None and not self._closed
 
-    async def send_message(self, content: object) -> bool:
+    async def send_message(self, content: object, ephemeral: bool = False) -> bool:
         """Send a user prompt over the WS.
 
         Mirrors ``directConnectManager.ts:125-142``. The wire shape
         matches what the agent's stream-json input format expects.
-        Returns False if the WS is not open.
+        ``ephemeral=True`` marks a /btw side question (answered with context but
+        not persisted to history). Returns False if the WS is not open.
         """
         if self._ws is None or self._closed:
             return False
-        envelope = {
+        envelope: dict = {
             'type': 'user',
             'message': {'role': 'user', 'content': content},
             'parent_tool_use_id': None,
             'session_id': '',
         }
+        if ephemeral:
+            envelope['ephemeral'] = True
         try:
             await self._ws.send(json.dumps(envelope))
         except (websockets.exceptions.ConnectionClosed, OSError):

--- a/tests/server/test_agent_server_e2e.py
+++ b/tests/server/test_agent_server_e2e.py
@@ -119,6 +119,27 @@ class _ThinkingProvider:
         )
 
 
+_RECORDED_TURNS: list[str] = []
+
+
+class _RecordingProvider:
+    """Records the messages it receives per turn (to assert btw non-persistence)."""
+
+    def __init__(self, api_key=None, base_url=None, model=None):
+        self.model = model or "fake"
+
+    def chat(self, messages, tools=None, **kw):
+        _RECORDED_TURNS.append(" || ".join(str(m) for m in messages))
+        return ChatResponse(
+            content="ok", model=self.model,
+            usage={"input_tokens": 2, "output_tokens": 1},
+            finish_reason="stop", tool_uses=None,
+        )
+
+    def chat_stream_response(self, *a, **kw):
+        raise NotImplementedError
+
+
 def _free_port() -> int:
     import socket
 
@@ -268,6 +289,39 @@ async def test_turn_streams_thinking_delta(tmp_path):
             ]
             assert thinking, "no thinking_delta stream_event emitted"
             assert thinking[0]["event"]["delta"]["thinking"] == "let me think "
+        finally:
+            await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_btw_side_question_not_persisted(tmp_path):
+    """A /btw turn answers with context but is dropped from history afterward."""
+    from src.tool_system.registry import ToolRegistry
+
+    _RECORDED_TURNS.clear()
+    async with _running_server(tmp_path, _RecordingProvider, ToolRegistry([])) as config:
+        cfg, _ = await create_direct_connect_session(
+            server_url=f"http://127.0.0.1:{config.port}", cwd=str(tmp_path)
+        )
+        received: list[dict] = []
+        callbacks = DirectConnectCallbacks(
+            on_message=lambda m: received.append(m),
+            on_permission_request=lambda req, rid: None,
+        )
+        client = DirectConnectSessionManager(cfg, callbacks)
+        await client.connect()
+        try:
+            # 1) side question (ephemeral)
+            await client.send_message("SIDEQ_TANGENT", ephemeral=True)
+            assert await _wait_for(lambda: len([m for m in received if m.get("type") == "result"]) == 1)
+            # 2) normal question — its context must NOT include the btw Q&A
+            await client.send_message("NORMALQ_MAIN")
+            assert await _wait_for(lambda: len([m for m in received if m.get("type") == "result"]) == 2)
+
+            assert any("SIDEQ_TANGENT" in t for t in _RECORDED_TURNS), "btw turn never ran with its question"
+            normal_turn = _RECORDED_TURNS[-1]
+            assert "NORMALQ_MAIN" in normal_turn, "normal turn missing its own message"
+            assert "SIDEQ_TANGENT" not in normal_turn, "btw question leaked into the next turn's context"
         finally:
             await client.disconnect()
 

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -1230,6 +1230,17 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         })
         return true
       }
+      case 'btw': {
+        const q = arg.trim()
+        if (!q) {
+          addEntry({ kind: 'system', text: 'usage: /btw <question>' })
+        } else if (busy) {
+          addEntry({ kind: 'system', text: 'busy — wait for the current turn before a side question' })
+        } else {
+          dispatchPrompt(q, true) // ephemeral
+        }
+        return true
+      }
       case 'lang': {
         const lang = arg.trim()
         if (client) {
@@ -1946,10 +1957,13 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   }
 
   /** Send a prompt now and start a turn (shared by submit + queue drain). */
-  const dispatchPrompt = (text: string): void => {
+  const dispatchPrompt = (text: string, ephemeral = false): void => {
     if (!client) return
     const img = pendingImageRef.current
-    if (img) {
+    if (ephemeral) {
+      // Side question (/btw): answered with context but not saved to history.
+      client.sendEphemeralPrompt(expandPastes(text))
+    } else if (img) {
       // Multimodal: send text + image as a content-block list (inventory §1).
       pendingImageRef.current = null
       client.sendPromptBlocks([
@@ -1960,6 +1974,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       client.sendPrompt(expandPastes(text)) // model gets the full paste; transcript shows the placeholder
     }
     if (historyRef.current[historyRef.current.length - 1] !== text) historyRef.current.push(text)
+    if (ephemeral) addEntry({ kind: 'system', text: '↪ side question — not saved to history' })
     addEntry({ kind: 'user', text })
     setStream('')
     setBusy(true)

--- a/ui-tui/src/client.ts
+++ b/ui-tui/src/client.ts
@@ -145,6 +145,18 @@ export class DirectConnectClient {
     });
   }
 
+  /** Send a side question (the original's /btw): answered with full context but
+   *  not persisted to the conversation history (ephemeral). */
+  sendEphemeralPrompt(content: string): void {
+    this.send({
+      type: 'user',
+      message: { role: 'user', content },
+      ephemeral: true,
+      parent_tool_use_id: null,
+      session_id: '',
+    });
+  }
+
   /** Send a user turn whose content is a block list (text + image blocks) for
    *  multimodal input. The server preserves non-text blocks (image-paste, §1). */
   sendPromptBlocks(content: Array<Record<string, unknown>>): void {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -61,6 +61,7 @@ export interface SlashCommand {
     | 'mcpTrust'
     | 'rtl'
     | 'lang'
+    | 'btw'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -100,6 +101,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/mcp-trust', description: 'Approve the connected MCP servers', kind: 'mcpTrust' },
   { name: '/rtl', description: 'Toggle right-to-left text shaping (Hebrew/Arabic)', kind: 'rtl' },
   { name: '/lang', description: 'Set preferred response language: /lang <language> (or clear)', kind: 'lang' },
+  { name: '/btw', description: 'Ask a side question without saving it to history: /btw <question>', kind: 'btw' },
   { name: '/permissions', description: 'Show active permission mode and rules', kind: 'permissions' },
   { name: '/agents', description: 'List available subagent types', kind: 'agents' },
   { name: '/skills', description: 'List available skills', kind: 'skills' },


### PR DESCRIPTION
## Summary
Ports the original's `/btw` ("ask a quick side question without interrupting the main conversation"). A `/btw` turn runs with the full conversation context but is **ephemeral**: the agent-server snapshots history, runs the turn, and restores the snapshot in a `finally` (covers success/abort/error) so the Q&A is dropped — the next turn's context is unaffected.

- **agent-server**: `_run_turn(prompt, btw)` snapshot+restore; inbox routes `{__btw__}` for `{type:user, ephemeral:true}`; worker unpacks it.
- **direct_connect_manager**: `send_message(content, ephemeral=)`.
- **TUI**: `client.sendEphemeralPrompt`; `dispatchPrompt(text, ephemeral)`; `/btw` command with a "↪ side question — not saved to history" note.

Found via a systematic audit of the original's 102 commands (most unported ones are disabled/external/N-A; `/btw` was a genuine enabled miss).

## Verification
e2e `test_btw_side_question_not_persisted`: a `/btw` turn runs with its question, but the following normal turn's context does NOT contain it. TUI sends ephemeral + shows the note. Agent-server suite green (15 passed). typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)