### PR TITLE
feat(ui-tui): /pr-comments — show the branch's PR comments via gh (§2)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -1114,6 +1114,18 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         })
         return true
       }
+      case 'prComments': {
+        // Show the current branch's PR + comments via gh (the original's pr_comments).
+        exec('gh pr view --comments', { cwd: process.cwd(), timeout: 15_000, maxBuffer: 512 * 1024 }, (err, stdout) => {
+          const out = `${stdout || ''}`.trim()
+          if (err || !out) {
+            addEntry({ kind: 'system', text: 'no open PR for this branch (or gh not installed / not authenticated)' })
+          } else {
+            addEntry({ kind: 'system', text: out })
+          }
+        })
+        return true
+      }
       case 'diff': {
         // DiffDialog (§4): with >1 changed file, pick one to view; else dump.
         exec('git diff --name-only', { cwd: process.cwd(), timeout: 10_000, maxBuffer: 256 * 1024 }, (err, stdout) => {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -62,6 +62,7 @@ export interface SlashCommand {
     | 'rtl'
     | 'lang'
     | 'btw'
+    | 'prComments'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -102,6 +103,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/rtl', description: 'Toggle right-to-left text shaping (Hebrew/Arabic)', kind: 'rtl' },
   { name: '/lang', description: 'Set preferred response language: /lang <language> (or clear)', kind: 'lang' },
   { name: '/btw', description: 'Ask a side question without saving it to history: /btw <question>', kind: 'btw' },
+  { name: '/pr-comments', description: "Show the current branch's PR comments (via gh)", kind: 'prComments' },
   { name: '/permissions', description: 'Show active permission mode and rules', kind: 'permissions' },
   { name: '/agents', description: 'List available subagent types', kind: 'agents' },
   { name: '/skills', description: 'List available skills', kind: 'skills' },


### PR DESCRIPTION
## Summary
Ports the original's `pr_comments`. `/pr-comments` shells to `gh pr view --comments` (like `/diff` uses git) and prints the current branch's PR + comments; gracefully reports when there's no open PR or `gh` isn't installed/authenticated.

Found via the systematic audit of the original's 102 commands — `pr_comments` is enabled and buildable via the `gh` CLI clawcodex already uses for git.

## Verification
On a branch with no open PR it shows the graceful note; the PR-output path is the same `exec`→`addEntry` as `/diff`. typecheck + build clean. 68 commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)