### PR TITLE
feat: /thinking — toggle extended thinking (§1 ThinkingToggle)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -112,6 +112,7 @@ class _AgentSession:
     system_prompt: Any = "You are a helpful assistant."
     _base_system_prompt: Any = None  # system prompt before the /plan section is composed in
     _language: Any = None  # preferred response language (the original's LanguagePicker, §6)
+    _thinking: Any = None  # extended-thinking override (ThinkingToggle); None = model default
     init_error: str | None = None
     _session_name: str | None = None  # user-set label (/rename) shown in /resume
     _mcp_runtime: Any = None  # McpRuntime (connected MCP servers) when configured
@@ -247,6 +248,9 @@ class _AgentSession:
             return
         if subtype == "set_language":
             self._do_set_language(request_id, inner.get("language"))
+            return
+        if subtype == "set_thinking":
+            self._do_set_thinking(request_id, inner.get("action"))
             return
         if subtype == "set_effort":
             effort = inner.get("effort")
@@ -608,6 +612,18 @@ class _AgentSession:
         if lang and isinstance(base, list):
             base = base + [{"type": "text", "text": f"# Response Language\nRespond in {lang} unless the user writes in another language."}]
         return base
+
+    def _do_set_thinking(self, request_id: object, action: object) -> None:
+        """Toggle/set extended thinking (the original's ThinkingToggle). action:
+        'on'|'off' set explicitly; anything else toggles. Applies next turn."""
+        act = str(action or "").lower()
+        if act == "on":
+            self._thinking = True
+        elif act == "off":
+            self._thinking = False
+        else:
+            self._thinking = not bool(self._thinking)
+        self._reply(request_id, {"ok": True, "thinking": bool(self._thinking)})
 
     def _do_set_language(self, request_id: object, language: object) -> None:
         """Set the preferred response language (LanguagePicker, §6) and recompose
@@ -1151,6 +1167,7 @@ class _AgentSession:
                 on_thinking_chunk=on_thinking_chunk,
                 on_message=on_message,
                 abort_controller=abort,
+                extended_thinking=self._thinking,  # None = model default; True/False = ThinkingToggle
             ))
         except AbortError:
             self._emit(_result_message(

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -1114,6 +1114,17 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         })
         return true
       }
+      case 'thinking': {
+        const a = arg.trim().toLowerCase()
+        const action = a === 'on' || a === 'off' ? a : 'toggle'
+        if (client) {
+          void client.requestControl('set_thinking', { action }).then((r) => {
+            const on = !!(r && r['thinking'])
+            addEntry({ kind: 'system', text: `extended thinking ${on ? 'on' : 'off'}` })
+          })
+        }
+        return true
+      }
       case 'prComments': {
         // Show the current branch's PR + comments via gh (the original's pr_comments).
         exec('gh pr view --comments', { cwd: process.cwd(), timeout: 15_000, maxBuffer: 512 * 1024 }, (err, stdout) => {

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -63,6 +63,7 @@ export interface SlashCommand {
     | 'lang'
     | 'btw'
     | 'prComments'
+    | 'thinking'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -104,6 +105,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/lang', description: 'Set preferred response language: /lang <language> (or clear)', kind: 'lang' },
   { name: '/btw', description: 'Ask a side question without saving it to history: /btw <question>', kind: 'btw' },
   { name: '/pr-comments', description: "Show the current branch's PR comments (via gh)", kind: 'prComments' },
+  { name: '/thinking', description: 'Toggle extended thinking: /thinking [on|off]', kind: 'thinking' },
   { name: '/permissions', description: 'Show active permission mode and rules', kind: 'permissions' },
   { name: '/agents', description: 'List available subagent types', kind: 'agents' },
   { name: '/skills', description: 'List available skills', kind: 'skills' },


### PR DESCRIPTION
## Summary
Ports the original's ThinkingToggle. `/thinking [on|off]` (or bare toggle) sets a per-session extended-thinking override; the agent-server stores it (`_thinking`) and passes `extended_thinking` to the agent loop each turn (None = model default).

Found via a **systematic component audit** (`typescript/src/components`, 120 components) — the same rigor as the command audit.

## Verification
Backend on/off/toggle flips `_thinking` + replies correctly; TUI `/thinking on` sends `set_thinking` and shows "extended thinking on". Agent-server suite green (15 passed). typecheck + build clean. 69 commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)