### PR TITLE
feat(ui-tui): bypass-permissions confirm (§5 BypassPermissionsModeDialog)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -258,6 +258,8 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const [rtlMode, setRtlMode] = useState<boolean>(process.env['CLAWCODEX_RTL'] === '1')
   // Message timestamps (§3) — opt-in via /timestamps.
   const [timestampsOn, setTimestampsOn] = useState<boolean>(false)
+  // Bypass-permissions confirm (§5 BypassPermissionsModeDialog).
+  const [bypassConfirm, setBypassConfirm] = useState<boolean>(false)
   const alwaysAllowRef = useRef<Set<string>>(new Set()) // tools the user said "don't ask again"
   const bashAllowPrefixRef = useRef<Set<string>>(new Set()) // Bash command prefixes auto-allowed (granular)
   const pendingImageRef = useRef<{ data: string; media_type: string; name: string } | null>(null) // /image attachment
@@ -491,6 +493,10 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       return
     }
     if (kind === 'mode') {
+      if (value === 'bypassPermissions') {
+        setBypassConfirm(true)
+        return
+      }
       client?.sendControl('set_permission_mode', { mode: value })
       setMode(value)
       addEntry({ kind: 'system', text: `mode → ${value}` })
@@ -515,6 +521,17 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
 
   const addEntry = (e: Omit<TranscriptEntry, 'id'>) =>
     setEntries((prev) => [...prev, { ts: Date.now(), ...e, id: `l${localSeq.current++}` }])
+
+  // Set the permission mode, but gate bypassPermissions behind a confirm
+  // (the original's BypassPermissionsModeDialog, §5).
+  const setPermMode = (mode: string): void => {
+    if (mode === 'bypassPermissions') {
+      setBypassConfirm(true)
+      return
+    }
+    client?.sendControl('set_permission_mode', { mode })
+    addEntry({ kind: 'system', text: `mode → ${mode}` })
+  }
 
   const setStream = (s: string) => {
     streamRef.current = s
@@ -769,6 +786,18 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       blurAtRef.current = Date.now()
       return
     }
+    // Bypass-permissions confirm (§5): y enables it, anything else cancels.
+    if (bypassConfirm) {
+      if (ch === 'y' || ch === 'Y') {
+        client?.sendControl('set_permission_mode', { mode: 'bypassPermissions' })
+        setMode('bypassPermissions')
+        addEntry({ kind: 'system', text: 'mode → bypassPermissions (all prompts disabled)' })
+      } else {
+        addEntry({ kind: 'system', text: 'bypass cancelled' })
+      }
+      setBypassConfirm(false)
+      return
+    }
     // MCP elicitation form: capture input → respond accept/decline (§6).
     if (elicit) {
       if (key.escape) {
@@ -830,6 +859,10 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     if (key.tab && key.shift) {
       const modes = ['default', 'acceptEdits', 'plan', 'bypassPermissions']
       const next = modes[(modes.indexOf(mode) + 1) % modes.length] as string
+      if (next === 'bypassPermissions') {
+        setBypassConfirm(true) // confirm before disabling all prompts (§5)
+        return
+      }
       client?.sendControl('set_permission_mode', { mode: next })
       setMode(next)
       addEntry({ kind: 'system', text: `mode → ${next}` })
@@ -1972,6 +2005,10 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
           client?.sendControl('set_model', { model: arg })
           setModel(arg)
         } else if (cmd.control === 'set_permission_mode') {
+          if (arg === 'bypassPermissions') {
+            setBypassConfirm(true) // confirm before disabling all prompts (§5)
+            return true
+          }
           client?.sendControl('set_permission_mode', { mode: arg })
           setMode(arg)
         }
@@ -2340,7 +2377,15 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         </Box>
       ) : null}
 
-      {elicit ? (
+      {bypassConfirm ? (
+        <Box flexDirection="column" borderStyle="round" borderColor={theme.error} borderLeft={false} borderRight={false} paddingX={1} marginTop={1}>
+          <Text color={theme.error} bold>
+            {'⚠ Enable bypass-permissions mode?'}
+          </Text>
+          <Text color={theme.dim}>{'This disables ALL permission prompts — every tool runs without asking.'}</Text>
+          <Text color={theme.dim}>{'  y to enable · any other key to cancel'}</Text>
+        </Box>
+      ) : elicit ? (
         <Box
           flexDirection="column"
           borderStyle="round"
@@ -2457,7 +2502,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
               vimEnabled={vimMode}
               onChange={handleInputChange}
               onSubmit={onSubmit}
-              active={!elicit}
+              active={!elicit && !bypassConfirm}
               placeholder={ready ? 'Type a message, or / for commands…' : 'starting agent-server…'}
             />
             {/* Inline ghost-text completion for slash commands (inventory §1):


### PR DESCRIPTION
## Summary
Ports the original's BypassPermissionsModeDialog. Entering `bypassPermissions` (via Shift+Tab cycle, the `/mode` picker, or `/mode bypassPermissions`) now requires a confirm — "⚠ Enable bypass-permissions mode? This disables ALL permission prompts" — since it disables every tool gate. `y` enables; any other key cancels. Found via the systematic component audit.

## Verification
`/mode bypassPermissions` shows the confirm without setting the mode; `n` cancels (mode unchanged); `y` sends `set_permission_mode bypassPermissions`. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)