### PR TITLE
feat(ui-tui): memory usage in /doctor (§7 MemoryUsageIndicator)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -1862,6 +1862,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
             `  tools       ${tools}`,
             `  protocol    v${SUPPORTED_PROTOCOL_MAJOR}.x`,
             `  theme       ${currentThemeName()}`,
+            `  memory      ${(process.memoryUsage().rss / 1048576).toFixed(0)} MB rss · uptime ${Math.floor(process.uptime())}s`,
             `  cwd         ${process.cwd()}`,
           ].join('\n'),
         })


### PR DESCRIPTION
## Summary
Ports the original's MemoryUsageIndicator: `/doctor` now reports process RSS and uptime (e.g. "memory 84 MB rss · uptime 312s") alongside the other diagnostics. Found via the systematic component audit.

## Verification
`/doctor` renders the memory line with MB rss + uptime. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)