### PR TITLE
feat(ui-tui): keybinding-conflict warnings (§8 KeybindingWarnings)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -17,7 +17,7 @@ import { PermissionDialog } from './components/PermissionDialog.js'
 import { SlashMenu } from './components/SlashMenu.js'
 import { editInEditor } from './editor.js'
 import { isTrusted, trustFolder, untrustFolder, isMcpTrusted, trustMcp } from './trust.js'
-import { matchesBinding } from './keybindings.js'
+import { matchesBinding, bindingConflicts } from './keybindings.js'
 import { shapeRtl } from './bidi.js'
 import { exec } from 'node:child_process'
 import { readFileSync } from 'node:fs'
@@ -2118,6 +2118,11 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       trustNotedRef.current = true
       if (!isTrusted(process.cwd())) {
         addEntry({ kind: 'system', text: '⚠ new folder — files/commands run here; /trust to acknowledge' })
+      }
+      // KeybindingWarnings (§8): flag combos bound to more than one action.
+      const conflicts = bindingConflicts()
+      if (conflicts.length) {
+        addEntry({ kind: 'system', text: `⚠ keybinding conflict(s): ${conflicts.join('; ')}` })
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/ui-tui/src/keybindings.ts
+++ b/ui-tui/src/keybindings.ts
@@ -57,6 +57,20 @@ export function matchesBinding(action: string, ch: string, key: KeyState): boole
   return (ch || '').toLowerCase() === k
 }
 
+/**
+ * Conflicting bindings (the original's KeybindingWarnings, §8): combos bound to
+ * more than one action. Returns "combo → actionA, actionB" strings (empty = none).
+ */
+export function bindingConflicts(): string[] {
+  const byCombo: Record<string, string[]> = {}
+  for (const [action, combo] of Object.entries(load())) {
+    ;(byCombo[combo] ||= []).push(action)
+  }
+  return Object.entries(byCombo)
+    .filter(([, acts]) => acts.length > 1)
+    .map(([combo, acts]) => `${combo} → ${acts.join(', ')}`)
+}
+
 /** Test seam: reset the cached config (so a freshly-written file is re-read). */
 export function _resetBindingsCache(): void {
   _bindings = null


### PR DESCRIPTION
## Summary
Ports the original's KeybindingWarnings: `bindingConflicts()` flags any key combo bound to more than one action (defaults + `~/.clawcodex/keybindings.json` overrides); on startup a "⚠ keybinding conflict(s): <combo> → actionA, actionB" notice is surfaced. Found via the component audit.

## Verification
Mapping `external-editor`→`ctrl+r` (history-search's default) is detected; a clean config reports no conflicts. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)