### PR TITLE
feat(ui-tui): config validation (§6 InvalidConfigDialog/ValidationErrorsList)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -18,6 +18,7 @@ import { SlashMenu } from './components/SlashMenu.js'
 import { editInEditor } from './editor.js'
 import { isTrusted, trustFolder, untrustFolder, isMcpTrusted, trustMcp } from './trust.js'
 import { matchesBinding, bindingConflicts } from './keybindings.js'
+import { configErrors } from './configCheck.js'
 import { shapeRtl } from './bidi.js'
 import { exec } from 'node:child_process'
 import { readFileSync } from 'node:fs'
@@ -2123,6 +2124,11 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       const conflicts = bindingConflicts()
       if (conflicts.length) {
         addEntry({ kind: 'system', text: `⚠ keybinding conflict(s): ${conflicts.join('; ')}` })
+      }
+      // Config validation (§6): surface malformed config files (else silently ignored).
+      const cfgErrs = configErrors()
+      if (cfgErrs.length) {
+        addEntry({ kind: 'error', text: `invalid config:\n  ${cfgErrs.join('\n  ')}` })
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/ui-tui/src/configCheck.ts
+++ b/ui-tui/src/configCheck.ts
@@ -1,0 +1,26 @@
+/**
+ * Config validation (the original's InvalidConfigDialog / InvalidSettingsDialog /
+ * ValidationErrorsList, §6): the per-feature loaders silently ignore malformed
+ * JSON (so a typo'd config just stops working with no clue). This validates the
+ * known config files up front and returns human-readable errors to surface.
+ */
+import { readFileSync, existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+const CONFIG_FILES = ['keybindings.json', 'logo.json', 'trusted.json', 'trusted-mcp.json']
+
+/** Parse errors for any present-but-malformed config file (empty = all valid). */
+export function configErrors(): string[] {
+  const errors: string[] = []
+  for (const name of CONFIG_FILES) {
+    const path = join(homedir(), '.clawcodex', name)
+    if (!existsSync(path)) continue
+    try {
+      JSON.parse(readFileSync(path, 'utf8'))
+    } catch (e) {
+      errors.push(`${name}: ${(e as Error).message}`)
+    }
+  }
+  return errors
+}


### PR DESCRIPTION
## Summary
Ports the original's invalid-config surfacing. `configErrors()` parses the known `~/.clawcodex` config files (keybindings/logo/trusted/trusted-mcp) up front; on startup, malformed JSON is reported ("invalid config: <file>: <error>") instead of being silently ignored by the per-feature loaders. Found via the component audit.

## Verification
A malformed `logo.json` surfaces "invalid config: logo.json: …". typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)