### PR TITLE
feat: external CLAUDE.md imports dialog (§6 ClaudeMdExternalIncludesDialog)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -255,6 +255,26 @@ class _AgentSession:
         if subtype == "set_mcp_enabled":
             self._do_set_mcp_enabled(request_id, inner.get("server"), inner.get("enabled"))
             return
+        if subtype == "external_includes":
+            # External CLAUDE.md @-imports (ClaudeMdExternalIncludesDialog, §6).
+            try:
+                from src.services.startup_gates import get_external_includes_state, list_external_includes
+
+                externals = await list_external_includes(self.cwd)
+                state = get_external_includes_state(self.cwd)
+            except Exception:  # noqa: BLE001
+                externals, state = [], "unset"
+            self._reply(request_id, {"state": state, "externals": externals})
+            return
+        if subtype == "set_external_includes":
+            try:
+                from src.services.startup_gates import record_external_includes_choice
+
+                ok = record_external_includes_choice(bool(inner.get("approved")), self.cwd)
+            except Exception:  # noqa: BLE001
+                ok = False
+            self._reply(request_id, {"ok": ok})
+            return
         if subtype == "set_effort":
             effort = inner.get("effort")
             if isinstance(effort, str) and effort in ("minimal", "low", "medium", "high"):

--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -257,6 +257,8 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const [elicit, setElicit] = useState<{ requestId: string; message: string; field: string; value: string } | null>(null)
   // MCP server multiselect (§6 MCPServerMultiselectDialog) — toggle servers on/off.
   const [mcpToggle, setMcpToggle] = useState<{ servers: { name: string; enabled: boolean; tools: string[] }[]; sel: number } | null>(null)
+  // External CLAUDE.md imports confirm (§6 ClaudeMdExternalIncludesDialog).
+  const [externalIncludes, setExternalIncludes] = useState<string[] | null>(null)
   // RTL display shaping (§8) — opt-in (terminals with native bidi shouldn't use it).
   const [rtlMode, setRtlMode] = useState<boolean>(process.env['CLAWCODEX_RTL'] === '1')
   // Message timestamps (§3) — opt-in via /timestamps.
@@ -785,6 +787,17 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     if (ch === '[O') {
       focusedRef.current = false
       blurAtRef.current = Date.now()
+      return
+    }
+    // External CLAUDE.md imports (§6): y allows, anything else disables them.
+    if (externalIncludes) {
+      const approved = ch === 'y' || ch === 'Y'
+      client?.requestControl('set_external_includes', { approved })
+      addEntry({
+        kind: 'system',
+        text: approved ? 'external CLAUDE.md imports allowed' : 'external CLAUDE.md imports disabled',
+      })
+      setExternalIncludes(null)
       return
     }
     // MCP server multiselect (§6): ↑/↓ navigate, space toggles + persists, esc closes.
@@ -2154,6 +2167,12 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       if (cfgErrs.length) {
         addEntry({ kind: 'error', text: `invalid config:\n  ${cfgErrs.join('\n  ')}` })
       }
+      // External CLAUDE.md imports (§6 ClaudeMdExternalIncludesDialog): if any are
+      // pending approval, prompt before they're loaded into the system prompt.
+      void client?.requestControl('external_includes').then((r) => {
+        const externals = Array.isArray(r?.['externals']) ? (r['externals'] as string[]) : []
+        if (r && r['state'] === 'unset' && externals.length) setExternalIncludes(externals)
+      })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ready])
@@ -2413,7 +2432,18 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         </Box>
       ) : null}
 
-      {mcpToggle ? (
+      {externalIncludes ? (
+        <Box flexDirection="column" borderStyle="round" borderColor={theme.error} borderLeft={false} borderRight={false} paddingX={1} marginTop={1}>
+          <Text color={theme.error} bold>
+            {'⚠ Allow external CLAUDE.md file imports?'}
+          </Text>
+          <Text color={theme.dim}>{'Your CLAUDE.md @-imports files outside this project:'}</Text>
+          {externalIncludes.slice(0, 6).map((p) => (
+            <Text key={p} color={theme.dim}>{`  • ${p}`}</Text>
+          ))}
+          <Text color={theme.dim}>{'  y to allow · any other key to disable'}</Text>
+        </Box>
+      ) : mcpToggle ? (
         <Box flexDirection="column" borderStyle="round" borderColor={theme.suggestion} borderLeft={false} borderRight={false} paddingX={1} marginTop={1}>
           <Text color={theme.dim}>{'MCP servers — space to toggle, esc to close'}</Text>
           {mcpToggle.servers.map((s, i) => (
@@ -2551,7 +2581,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
               vimEnabled={vimMode}
               onChange={handleInputChange}
               onSubmit={onSubmit}
-              active={!elicit && !pendingMode && !mcpToggle}
+              active={!elicit && !pendingMode && !mcpToggle && !externalIncludes}
               placeholder={ready ? 'Type a message, or / for commands…' : 'starting agent-server…'}
             />
             {/* Inline ghost-text completion for slash commands (inventory §1):


### PR DESCRIPTION
## Summary
Wires the existing backend external-includes approval (`src/services/startup_gates` + `context_system/claude_md`, already used by the Python TUI) to the **Node TUI**:
- **agent-server**: `external_includes` control → `{state, externals}` (await `list_external_includes` + `get_external_includes_state`); `set_external_includes {approved}` → `record_external_includes_choice` (persists + clears memo caches).
- **TUI**: on startup, if external `@`-imports are pending (state `unset`), show a confirm listing the external paths — `y` allows, any other key disables them (prompt-injection guard for content pulled into the system prompt).

## Verification
Dialog lists external paths; `n` records `approved=false` ("disabled"); agent-server suite green (15 passed). typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)