### PR TITLE
feat(ui-tui): FastIcon + EffortCallout footer indicators (§7)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -271,6 +271,8 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const bashAllowPrefixRef = useRef<Set<string>>(new Set()) // Bash command prefixes auto-allowed (granular)
   const pendingImageRef = useRef<{ data: string; media_type: string; name: string } | null>(null) // /image attachment
   const fastModeRef = useRef<string | null>(null) // /fast: prev model while fast mode is on
+  const [fastMode, setFastMode] = useState(false) // FastIcon (§7) — ⚡ in the footer
+  const [effort, setEffort] = useState('') // EffortCallout (§7) — reasoning effort in the footer
   const [permFeedback, setPermFeedback] = useState<string | null>(null) // Tab-to-amend feedback field
   const [input, setInput] = useState('')
   const [busy, setBusy] = useState(false)
@@ -1410,6 +1412,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
           if (fastModeRef.current) {
             const prev = fastModeRef.current
             fastModeRef.current = null
+            setFastMode(false)
             client?.sendControl('set_model', { model: prev })
             setModel(prev)
             addEntry({ kind: 'system', text: `fast mode off — model → ${prev}` })
@@ -1421,6 +1424,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
             return
           }
           fastModeRef.current = cur
+          setFastMode(true)
           client?.sendControl('set_model', { model: fast })
           setModel(fast)
           addEntry({ kind: 'system', text: `⚡ fast mode on — model → ${fast}` })
@@ -1634,10 +1638,9 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       case 'effort': {
         if (client) {
           void client.requestControl('set_effort', { effort: arg }).then((r) => {
-            addEntry({
-              kind: 'system',
-              text: `reasoning effort → ${r && r['effort'] ? String(r['effort']) : 'default'}`,
-            })
+            const lvl = r && r['effort'] ? String(r['effort']) : ''
+            setEffort(lvl && lvl !== 'default' ? `effort:${lvl}` : '') // EffortCallout (§7)
+            addEntry({ kind: 'system', text: `reasoning effort → ${lvl || 'default'}` })
           })
         }
         return true
@@ -2612,6 +2615,8 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         busy={busy}
         context={contextUsage}
         cost={sessionCost}
+        fast={fastMode}
+        effort={effort}
       />
     </Box>
   )

--- a/ui-tui/src/components/StatusBar.tsx
+++ b/ui-tui/src/components/StatusBar.tsx
@@ -21,6 +21,8 @@ interface Props {
   busy: boolean
   context?: ContextUsage | null
   cost?: number
+  fast?: boolean // FastIcon (§7): ⚡ when fast mode is on
+  effort?: string // EffortCallout (§7): reasoning effort level when set
 }
 
 const MODE_COLOR: Record<string, string | undefined> = {
@@ -43,7 +45,7 @@ function ctxColor(pct: number): string {
   return theme.dim
 }
 
-export function StatusBar({ connected, model, mode, busy, context, cost }: Props): React.ReactElement {
+export function StatusBar({ connected, model, mode, busy, context, cost, fast, effort }: Props): React.ReactElement {
   const dot = !connected ? theme.dim : busy ? theme.warn : theme.success
   const modeColor = MODE_COLOR[mode] ?? theme.dim
   return (
@@ -59,10 +61,12 @@ export function StatusBar({ connected, model, mode, busy, context, cost }: Props
             <Text color={theme.dim}>{` (${fmtK(context.totalTokens)}/${fmtK(context.maxTokens)}) · `}</Text>
           </>
         ) : null}
+        {fast ? <Text color={theme.accent}>{'⚡ '}</Text> : null}
         <Text color={dot}>{'● '}</Text>
         <Text color={theme.dim}>{model}</Text>
         <Text color={theme.dim}>{' · '}</Text>
         <Text color={modeColor}>{mode}</Text>
+        {effort ? <Text color={theme.dim}>{` · ${effort}`}</Text> : null}
       </Box>
     </Box>
   )


### PR DESCRIPTION
## Summary
Ports the original's FastIcon and EffortCallout as footer status indicators: ⚡ shows when fast mode is on (tracked on `/fast`), and `effort:<level>` shows when a reasoning effort is set (tracked on `/effort`, cleared on default). The `/fast` and `/effort` backends existed; these surface their state.

## Verification
`/effort high` → `effort:high` in the footer; `/fast` → `⚡` in the footer. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)