### PR TITLE
feat(ui-tui): PrBadge — current branch's PR in the footer (§7)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -276,6 +276,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const resumeFilterRef = useRef('') // LogSelector (§6): session search filter
   const [fastMode, setFastMode] = useState(false) // FastIcon (§7) — ⚡ in the footer
   const [effort, setEffort] = useState('') // EffortCallout (§7) — reasoning effort in the footer
+  const [prBadge, setPrBadge] = useState('') // PrBadge (§7) — current branch's PR, via gh
   const [permFeedback, setPermFeedback] = useState<string | null>(null) // Tab-to-amend feedback field
   const [input, setInput] = useState('')
   const [busy, setBusy] = useState(false)
@@ -2220,6 +2221,16 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         const externals = Array.isArray(r?.['externals']) ? (r['externals'] as string[]) : []
         if (r && r['state'] === 'unset' && externals.length) setExternalIncludes(externals)
       })
+      // PrBadge (§7): show the current branch's PR in the footer, via gh.
+      exec('gh pr view --json number,state', { cwd: process.cwd(), timeout: 8000 }, (err, out) => {
+        if (err) return
+        try {
+          const pr = JSON.parse(`${out}`) as { number?: number; state?: string }
+          if (pr.number) setPrBadge(`#${pr.number}${pr.state && pr.state !== 'OPEN' ? ` ${pr.state.toLowerCase()}` : ''}`)
+        } catch {
+          /* no PR / bad json */
+        }
+      })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ready])
@@ -2661,6 +2672,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         cost={sessionCost}
         fast={fastMode}
         effort={effort}
+        prBadge={prBadge}
       />
     </Box>
   )

--- a/ui-tui/src/components/StatusBar.tsx
+++ b/ui-tui/src/components/StatusBar.tsx
@@ -23,6 +23,7 @@ interface Props {
   cost?: number
   fast?: boolean // FastIcon (§7): ⚡ when fast mode is on
   effort?: string // EffortCallout (§7): reasoning effort level when set
+  prBadge?: string // PrBadge (§7): current branch's PR (e.g. "#42")
 }
 
 const MODE_COLOR: Record<string, string | undefined> = {
@@ -45,7 +46,7 @@ function ctxColor(pct: number): string {
   return theme.dim
 }
 
-export function StatusBar({ connected, model, mode, busy, context, cost, fast, effort }: Props): React.ReactElement {
+export function StatusBar({ connected, model, mode, busy, context, cost, fast, effort, prBadge }: Props): React.ReactElement {
   const dot = !connected ? theme.dim : busy ? theme.warn : theme.success
   const modeColor = MODE_COLOR[mode] ?? theme.dim
   return (
@@ -61,6 +62,7 @@ export function StatusBar({ connected, model, mode, busy, context, cost, fast, e
             <Text color={theme.dim}>{` (${fmtK(context.totalTokens)}/${fmtK(context.maxTokens)}) · `}</Text>
           </>
         ) : null}
+        {prBadge ? <Text color={theme.dim}>{`⊟ ${prBadge} · `}</Text> : null}
         {fast ? <Text color={theme.accent}>{'⚡ '}</Text> : null}
         <Text color={dot}>{'● '}</Text>
         <Text color={theme.dim}>{model}</Text>


### PR DESCRIPTION
## Summary
Re-examined the "external" classification: **PrBadge is buildable via the `gh` CLI** (already used by `/pr-comments`), not external. On startup, `gh pr view --json number,state` populates a footer badge (e.g. `⊟ #42`, or `⊟ #42 merged`); absent when there's no PR or `gh` isn't available.

## Verification
StatusBar renders `⊟ #42` when a PR badge is set. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)