### PR TITLE
feat(ui-tui): CoordinatorAgentStatus — multi-agent summary (§9)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -2462,6 +2462,12 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
 
       {agentLines.length > 0 ? (
         <Box flexDirection="column">
+          {agentLines.length > 1 ? (
+            // CoordinatorAgentStatus (§9): summary over concurrently-running subagents.
+            <Text color={theme.accent}>
+              {`⛬ coordinating ${agentLines.length} agents · ${agentLines.reduce((a, l) => a + (l.toolUseCount || 0), 0)} tools`}
+            </Text>
+          ) : null}
           {agentLines.map((l) => (
             <AgentProgressLine key={l.agentId} line={l} />
           ))}


### PR DESCRIPTION
## Summary
Re-examined the "different architecture" classification: a coordinator summary **is** buildable over the existing `AgentProgressLine`/`agentLines`. When ≥2 subagents run concurrently, show "⛬ coordinating N agents · T tools" above the per-agent lines (aggregated from `agentLines`); single-agent runs are unchanged.

## Verification
1 agent shows no summary; 2 agents show "coordinating 2 agents · 5 tools". typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)