### PR TITLE
feat(ui-tui): /env — curated runtime environment (adapts the disabled env)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -1260,6 +1260,21 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         }
         return true
       }
+      case 'env': {
+        // Curated runtime environment (the original's `env`, adapted — no secret
+        // env vars, only non-sensitive runtime facts).
+        const e = process.env
+        const lines = [
+          `platform   ${process.platform} (${process.arch})`,
+          `node       ${process.version}`,
+          `terminal   ${e['TERM_PROGRAM'] || e['TERM'] || 'unknown'}`,
+          `shell      ${e['SHELL'] || 'unknown'}`,
+          `locale     ${e['LANG'] || e['LC_ALL'] || 'unknown'}`,
+          `cwd        ${process.cwd()}`,
+        ]
+        addEntry({ kind: 'system', text: `environment:\n  ${lines.join('\n  ')}` })
+        return true
+      }
       case 'diagnostics': {
         // DiagnosticsDisplay (§3), adapted to no-LSP: run the project's typecheck/
         // lint and show issues. Auto-detects the checker.

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -66,6 +66,7 @@ export interface SlashCommand {
     | 'thinking'
     | 'timestamps'
     | 'diagnostics'
+    | 'env'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -110,6 +111,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/thinking', description: 'Toggle extended thinking: /thinking [on|off]', kind: 'thinking' },
   { name: '/timestamps', description: 'Toggle message timestamps', kind: 'timestamps' },
   { name: '/diagnostics', description: 'Run the project typecheck/lint and show issues', kind: 'diagnostics' },
+  { name: '/env', description: 'Show the runtime environment (platform, node, terminal, shell)', kind: 'env' },
   { name: '/permissions', description: 'Show active permission mode and rules', kind: 'permissions' },
   { name: '/agents', description: 'List available subagent types', kind: 'agents' },
   { name: '/skills', description: 'List available skills', kind: 'skills' },


### PR DESCRIPTION
## Summary
Ports the original's `env` command (disabled there), adapted to a **safe curated form**: `/env` shows platform/arch, node version, terminal, shell, locale, and cwd — deliberately excluding raw env vars so no secrets are surfaced. Shows disabled-in-original commands get ported when they can be made safe.

## Verification
`/env` renders platform + node version + terminal; contains no API_KEY/TOKEN/SECRET. typecheck + build clean. 72 commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)