### PR TITLE
feat(ui-tui): /summary — summarize the conversation (adapts the disabled summary)

### DIFF
--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -173,6 +173,14 @@ export const SLASH_COMMANDS: SlashCommand[] = [
       'Run `git diff --staged` (fall back to `git diff`) and draft a concise Conventional Commits ' +
       'message for the changes. Output only the commit message.',
   },
+  {
+    name: '/summary',
+    description: 'Summarize the conversation so far',
+    kind: 'prompt',
+    promptText:
+      'Summarize our conversation so far, concisely: the key decisions made, the current state, ' +
+      'and any open items or next steps.',
+  },
   { name: '/memory', description: 'Show the loaded CLAUDE.md memory files', kind: 'memory' },
   { name: '/doctor', description: 'Show connection + session diagnostics', kind: 'doctor' },
   { name: '/quit', description: 'Exit the TUI', kind: 'quit' },


### PR DESCRIPTION
## Summary
Ports the original's `summary` command (disabled there) as a prompt command: expands to "summarize our conversation so far concisely — key decisions, current state, open items". Distinct from `/insights` (analysis) and `/compact` (summarize + replace history). Client-side `promptText`, no backend change.

## Verification
`/summary` resolves to `kind:'prompt'` with `promptText`. typecheck + build clean. 73 commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)