### PR TITLE
feat(ui-tui): /debug-tool-call — inspect the last tool call

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -1260,6 +1260,21 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         }
         return true
       }
+      case 'debugToolCall': {
+        // Inspect the last tool call (the original's debug-tool-call): raw input +
+        // matching result, for debugging tool behavior.
+        const tools = entries.filter((e) => e.kind === 'tool' && e.toolName)
+        const last = tools[tools.length - 1]
+        if (!last) {
+          addEntry({ kind: 'system', text: 'no tool calls in this session yet' })
+          return true
+        }
+        const res = entries.find((e) => e.kind === 'toolResult' && (e.forToolUseIds ?? []).includes(last.toolUseId ?? ''))
+        const input = JSON.stringify(last.input ?? {}, null, 2)
+        const result = res?.text ? res.text.slice(0, 600) : '(no result captured)'
+        addEntry({ kind: 'system', text: `debug ${last.toolName}\ninput:\n${input}\nresult:\n${result}` })
+        return true
+      }
       case 'env': {
         // Curated runtime environment (the original's `env`, adapted — no secret
         // env vars, only non-sensitive runtime facts).

--- a/ui-tui/src/slashCommands.ts
+++ b/ui-tui/src/slashCommands.ts
@@ -67,6 +67,7 @@ export interface SlashCommand {
     | 'timestamps'
     | 'diagnostics'
     | 'env'
+    | 'debugToolCall'
     | 'diff'
     | 'stats'
     | 'prompt'
@@ -112,6 +113,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/timestamps', description: 'Toggle message timestamps', kind: 'timestamps' },
   { name: '/diagnostics', description: 'Run the project typecheck/lint and show issues', kind: 'diagnostics' },
   { name: '/env', description: 'Show the runtime environment (platform, node, terminal, shell)', kind: 'env' },
+  { name: '/debug-tool-call', description: 'Show the last tool call (raw input + result) for debugging', kind: 'debugToolCall' },
   { name: '/permissions', description: 'Show active permission mode and rules', kind: 'permissions' },
   { name: '/agents', description: 'List available subagent types', kind: 'agents' },
   { name: '/skills', description: 'List available skills', kind: 'skills' },


### PR DESCRIPTION
## Summary
Ports the original's disabled `debug-tool-call`: `/debug-tool-call` shows the most recent tool call's name, raw input (pretty JSON), and matching result — for debugging tool behavior. Reads from transcript entries; safe (no execution), client-side.

## Verification
With no tool calls it reports so; after a Bash `tool_use` it shows "debug Bash" with the input (`ls -la`). typecheck + build clean. 74 commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)