### PR TITLE
feat(ui-tui): DevBar — env-gated internal-state overlay (§7)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -29,6 +29,7 @@ import { VimInput } from './components/VimInput.js'
 import { searchFiles } from './fileIndex.js'
 import { Spinner } from './components/Spinner.js'
 import { StatusBar } from './components/StatusBar.js'
+import { DevBar } from './components/DevBar.js'
 import { LiveTools, type LiveGroup } from './components/LiveTools.js'
 import { AgentProgressLine, type AgentLine } from './components/AgentProgressLine.js'
 import { READ_LIKE, TOOL_VERB, toolActivityLabel } from './toolMeta.js'
@@ -2728,6 +2729,14 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       )}
 
       {statusText ? <Text color={theme.dim}>{statusText}</Text> : null}
+      <DevBar
+        entries={entries.length}
+        agents={agentLines.length}
+        busy={busy}
+        stream={streaming.length}
+        scroll={scrollOffset}
+        fullscreen={FULLSCREEN}
+      />
       <StatusBar
         connected={connected}
         model={model}

--- a/ui-tui/src/components/DevBar.tsx
+++ b/ui-tui/src/components/DevBar.tsx
@@ -1,0 +1,26 @@
+/**
+ * DevBar (the original's dev-build status bar, §7) — adapted: a compact internal-
+ * state line for debugging the TUI, shown only when CLAWCODEX_DEV=1 so it never
+ * clutters normal use. Renders nothing otherwise.
+ */
+import { Text } from 'ink'
+import React from 'react'
+import { theme } from '../theme.js'
+
+interface Props {
+  entries: number
+  agents: number
+  busy: boolean
+  stream: number
+  scroll: number
+  fullscreen: boolean
+}
+
+export function DevBar({ entries, agents, busy, stream, scroll, fullscreen }: Props): React.ReactElement | null {
+  if (process.env['CLAWCODEX_DEV'] !== '1') return null
+  return (
+    <Text color={theme.dim}>
+      {`[dev] entries:${entries} agents:${agents} busy:${busy ? 1 : 0} stream:${stream} scroll:${scroll} ${fullscreen ? 'fs' : 'inline'}`}
+    </Text>
+  )
+}


### PR DESCRIPTION
## Summary
Ports the original's DevBar, adapted: a compact internal-state line (entries, agents, busy, stream length, scroll, layout) shown only when `CLAWCODEX_DEV=1`, so it never clutters normal use. Real dev tooling for debugging the TUI.

## Verification
Hidden by default; renders "[dev] entries:… agents:… busy:…" with `CLAWCODEX_DEV=1`. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)