### PR TITLE
fix(context): deepseek-v4 & glm-5.2 report their 1M context window

### DIFF
--- a/src/context_system/context_analyzer.py
+++ b/src/context_system/context_analyzer.py
@@ -33,6 +33,9 @@ MODEL_CONTEXT_WINDOWS: dict[str, int] = {
     "glm-5.2": 1_000_000,
     "glm-5.1": 202_752,
     "glm-4": 128_000,  # legacy GLM-4.x fallback
+    # DeepSeek V4 ships a 1M context window, like glm-5.2 (legacy deepseek-chat/
+    # -reasoner are intentionally NOT matched here — see src/models/configs.py).
+    "deepseek-v4": 1_000_000,
     # Minimax defaults
     "minimax": 128_000,
     "abab": 128_000,
@@ -66,11 +69,31 @@ class ContextData:
 
 
 def get_context_window_for_model(model: str) -> int:
-    """Get the context window size for a model."""
+    """Get the context window size for a model.
+
+    Checks the local table first (back-compat), then defers to the canonical
+    per-model registry (``src/models/configs.py`` via ``src/models/context.py``)
+    so models registered there — e.g. DeepSeek V4's 1M window — are reflected in
+    the context display without maintaining a second table. This closes the drift
+    that made the agent-server status bar report 200K for deepseek-v4-pro: the
+    registry had 1M but this table didn't, and the display reads this function.
+    """
     model_lower = model.lower()
     for name, window in MODEL_CONTEXT_WINDOWS.items():
         if name in model_lower:
             return window
+    # Defer to the canonical model registry for ids not in the local table.
+    try:
+        from ..models.context import (
+            DEFAULT_CONTEXT_WINDOW as _REGISTRY_DEFAULT,
+            get_context_window_for_model as _registry_window,
+        )
+
+        win = _registry_window(model)
+        if win and win != _REGISTRY_DEFAULT:
+            return win
+    except Exception:
+        pass
     # Try to extract a numeric window from model name (e.g., "gpt-4-32k")
     match = re.search(r'(\d+)k', model_lower)
     if match:

--- a/src/models/configs.py
+++ b/src/models/configs.py
@@ -162,6 +162,31 @@ MODEL_CONFIGS: dict[str, ModelConfig] = {
         max_output_tokens=8_192,
         supports_cache=True,
     ),
+    # Z.ai GLM Coding Plan. glm-5.2 ships a 1M context window (like DeepSeek V4);
+    # glm-5.1 is 202_752 and legacy glm-4.x is 128K. Registered here so the
+    # canonical window/threshold path agrees with the context display — both
+    # exact keys, so glm-4 never prefix-matches glm-5.2's 1M.
+    "glm-5.2": ModelConfig(
+        model_id="glm-5.2",
+        display_name="GLM-5.2",
+        context_window=1_000_000,
+        max_output_tokens=8_192,
+        supports_cache=True,
+    ),
+    "glm-5.1": ModelConfig(
+        model_id="glm-5.1",
+        display_name="GLM-5.1",
+        context_window=202_752,
+        max_output_tokens=8_192,
+        supports_cache=True,
+    ),
+    "glm-4": ModelConfig(
+        model_id="glm-4",
+        display_name="GLM-4",
+        context_window=128_000,
+        max_output_tokens=8_192,
+        supports_cache=True,
+    ),
 }
 
 

--- a/tests/test_context_window_1m.py
+++ b/tests/test_context_window_1m.py
@@ -1,0 +1,38 @@
+"""Context-window sizes for 1M-context models (deepseek-v4, glm-5.2).
+
+Regression guard for the agent-server status bar reporting 200K for models that
+ship a 1M window. The display reads ``context_analyzer``; autocompact reads the
+canonical registry (``src/models/configs.py``) — both must agree.
+"""
+
+from src.context_system.context_analyzer import (
+    get_context_window_for_model as display_window,
+)
+from src.models.context import get_context_window_for_model as canonical_window
+
+
+def test_deepseek_v4_is_1m_in_display_and_canonical():
+    assert display_window("deepseek-v4-pro") == 1_000_000
+    assert canonical_window("deepseek-v4-pro") == 1_000_000
+
+
+def test_glm_5_2_is_1m_in_display_and_canonical():
+    assert display_window("glm-5.2") == 1_000_000
+    assert canonical_window("glm-5.2") == 1_000_000
+
+
+def test_glm_4_legacy_not_promoted_to_1m():
+    # glm-4 must not prefix-match glm-5.2's 1M window (both are exact keys).
+    assert display_window("glm-4") == 128_000
+    assert canonical_window("glm-4") == 128_000
+
+
+def test_legacy_deepseek_chat_not_promoted_to_1m():
+    # Only deepseek-v4* gets 1M; legacy deepseek-chat/-reasoner do not.
+    assert display_window("deepseek-chat") != 1_000_000
+
+
+def test_display_defers_to_canonical_for_registered_models():
+    # A model registered in the canonical table is reflected in the display via
+    # the registry fallback, so the two never drift again.
+    assert display_window("deepseek-v4-pro") == canonical_window("deepseek-v4-pro")


### PR DESCRIPTION
## Summary
The agent-server status bar showed `114k/200k` for **deepseek-v4-pro**, which ships a **1M** context window. Two model→window tables had drifted: the canonical registry (`src/models/configs.py`) had deepseek at 1M, but the display path (`context_analyzer.py`) defaulted unknown models to 200K; glm-5.2 was the mirror case (1M in the display table, missing from the registry).

## Changes
- `context_analyzer.get_context_window_for_model` now **defers to the canonical registry** for ids not in its local table — the display can't drift from the registry again.
- Register **glm-5.2 (1M)**, glm-5.1 (202_752), glm-4 (128K) in `configs.py` as exact keys (glm-4 never prefix-matches glm-5.2's 1M).
- Drop the over-broad local `deepseek` key so legacy deepseek-chat/-reasoner aren't promoted to 1M (only `deepseek-v4*`).

## Verification
Display and canonical agree: deepseek-v4-pro/glm-5.2 = 1M, glm-5.1 = 202_752, glm-4 = 128K, deepseek-chat ≠ 1M. New regression test (`tests/test_context_window_1m.py`) + 55 model/context/autocompact tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)