### PR TITLE
fix(ui-tui): collapse web-search results to a one-line summary

### DIFF
--- a/ui-tui/src/components/Message.tsx
+++ b/ui-tui/src/components/Message.tsx
@@ -53,6 +53,14 @@ function ToolResult({
   if (!expanded && lines.length > 6 && numbered >= lines.length * 0.6) {
     return <Text color={theme.dim}>{`  ⎿ Read ${lines.length} lines (ctrl+o to expand)`}</Text>
   }
+  // Web search results are a few very long lines (result JSON) that wrap to
+  // dozens of rows. Collapse to a one-line summary — the original's WebSearch
+  // renderToolResultMessage shows only chrome, never the results. Full text
+  // stays available via ctrl+o (and the model always receives the full result).
+  if (!expanded && lines[0]?.startsWith('Web search results for query:')) {
+    const q = (lines[0].match(/"(.*)"/)?.[1] ?? '').slice(0, 60)
+    return <Text color={theme.dim}>{`  ⎿ 🔍 web search${q ? `: ${q}` : ''} (ctrl+o to expand)`}</Text>
+  }
   const shown = lines.slice(0, max)
   const extra = lines.length - shown.length
   return (

--- a/ui-tui/test/features.test.mjs
+++ b/ui-tui/test/features.test.mjs
@@ -116,3 +116,15 @@ test('normal typing reaches the prompt', async () => {
   await wait(40)
   assert.match(strip(lastFrame()), /hello world/)
 })
+
+test('web search results collapse to a one-line summary (not a content dump)', async () => {
+  const { cb, lastFrame } = mount()
+  await wait(150)
+  const huge = 'Links: ' + JSON.stringify(Array.from({ length: 40 }, (_, i) => ({ title: 'R' + i, url: 'https://e.com/' + i, content: 'Lorem ipsum '.repeat(20) })))
+  const content = `Web search results for query: "obama achievements"\n\n${huge}\n\nREMINDER: include sources.`
+  cb().onData(JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content }] } }) + '\n')
+  await wait(100)
+  const f = strip(lastFrame())
+  assert.match(f, /🔍 web search: obama achievements \(ctrl\+o to expand\)/)
+  assert.ok(!f.includes('Lorem ipsum'), 'raw web-search content must not be dumped into the transcript')
+})


### PR DESCRIPTION
## Summary
WebSearch results are a few very long lines (the result JSON), so they wrapped to dozens of rows and buried the transcript — even though tool results cap at 8 *logical* lines, each wrapped hugely (see screenshot in the report). The original's WebSearch `renderToolResultMessage` shows only chrome ("Did N searches"), never the results content.

## Change
Collapse a tool result whose first line is `Web search results for query:` to `🔍 web search: <query> (ctrl+o to expand)`, mirroring the existing Read-dump collapse. Full text stays available via ctrl+o, and the **model always receives the complete result** — this only changes the on-screen display.

## Verification
Committed test (`ui-tui/test/features.test.mjs`): a 40-result web-search `tool_result` renders the one-line summary and does **not** dump the raw content. `npm test` 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)