### PR TITLE
fix(ui-tui): redraw cleanly on terminal resize (no stacked input boxes)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -310,6 +310,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   }) // /buddy companion sprite (opt-in)
   const [txFind, setTxFind] = useState<string | null>(null) // fullscreen Ctrl+F find query (null = closed)
   const [vimMode, setVimMode] = useState(false) // /vim modal editing
+  const [resizeKey, setResizeKey] = useState(0) // bumped on terminal resize to remount <Static> (inline)
 
   // Fullscreen uses the terminal's alternate screen so the bounded transcript
   // viewport renders in place (no scrollback spam). Enter on mount, restore on exit.
@@ -318,6 +319,30 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
     process.stdout.write('\x1b[?1049h')
     return () => {
       process.stdout.write('\x1b[?1049l')
+    }
+  }, [])
+
+  // Terminal resize (inline mode): standard Ink's incremental erase miscounts a
+  // line's wrapped height after a width change, so the live region (the input
+  // box) leaves stacked copies in the scrollback on resize. Mirror the original's
+  // full-reset-on-resize — clear the screen + scrollback and remount <Static> so
+  // the transcript re-emits at the new width and the live region redraws clean.
+  // Debounced so dragging the window border triggers a single reset, not one per
+  // intermediate size.
+  useEffect(() => {
+    if (FULLSCREEN) return // alt-screen redraws cleanly; only inline stacks
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const onResize = (): void => {
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
+        process.stdout.write('\x1b[2J\x1b[3J\x1b[H')
+        setResizeKey((k) => k + 1)
+      }, 80)
+    }
+    process.stdout.on('resize', onResize)
+    return () => {
+      if (timer) clearTimeout(timer)
+      process.stdout.off('resize', onResize)
     }
   }, [])
   const [slashSel, setSlashSel] = useState(0)
@@ -2483,7 +2508,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
           {visibleEntries.map(renderEntry)}
         </Box>
       ) : (
-        <Static items={entries}>{renderEntry}</Static>
+        <Static key={resizeKey} items={entries}>{renderEntry}</Static>
       )}
 
       {streaming ? (

--- a/ui-tui/test/features.test.mjs
+++ b/ui-tui/test/features.test.mjs
@@ -156,3 +156,26 @@ test('/exit runs the quit handler (closes the connection and exits)', async () =
   assert.ok(closed, '/exit should close the connection via the quit handler')
   try { r.unmount() } catch { /* exit() may have already torn down */ }
 })
+
+test('terminal resize triggers a full reset (no stacked input boxes)', async () => {
+  const writes = []
+  const orig = process.stdout.write.bind(process.stdout)
+  process.stdout.write = (chunk, ...rest) => {
+    const s = String(chunk)
+    writes.push(s)
+    if (s.includes('\x1b[2J')) return true // swallow the clear so this test run isn't wiped
+    return orig(chunk, ...rest)
+  }
+  try {
+    mount()
+    await wait(150)
+    process.stdout.emit('resize')
+    await wait(160) // > 80ms debounce
+  } finally {
+    process.stdout.write = orig
+  }
+  assert.ok(
+    writes.some((w) => w.includes('\x1b[2J') && w.includes('\x1b[3J') && w.includes('\x1b[H')),
+    'resize should clear screen + scrollback + home (full reset), not leave stacked frames',
+  )
+})


### PR DESCRIPTION
## Summary
Resizing the terminal left the input box (and live region) stacked many times in the scrollback (see screenshot in the report). Standard Ink's inline renderer erases the previous frame by its line count at the **old** width; after a width change those lines re-wrap to a different number of rows, so the erase miscounts and stale copies pile up.

## Fix
Mirror the original's vendored-Ink behavior (full reset on resize): on a debounced terminal `resize`, clear the screen + scrollback + home the cursor and remount `<Static>` (via a key bump) so the transcript re-emits at the new width and the live region redraws from a clean slate.
- **Inline-mode only** — fullscreen uses the alternate screen and redraws cleanly already.
- **Debounced (80ms)** so dragging the window border triggers one reset, not one per intermediate size.

## Verification
Committed test (`ui-tui/test/features.test.mjs`): emitting `resize` attaches the handler and writes the full-reset sequence (`ESC[2J ESC[3J ESC[H`). `npm test` **15/15**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)