### PR TITLE
fix(ui-tui): pre-warm the file index so @/open never freezes input

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -26,7 +26,7 @@ import { homedir } from 'node:os'
 import { BUDDY_SPECIES, CompanionSprite } from './components/CompanionSprite.js'
 import { FileMenu } from './components/FileMenu.js'
 import { VimInput } from './components/VimInput.js'
-import { searchFiles } from './fileIndex.js'
+import { searchFiles, prewarmFileIndex } from './fileIndex.js'
 import { Spinner } from './components/Spinner.js'
 import { StatusBar } from './components/StatusBar.js'
 import { DevBar } from './components/DevBar.js'
@@ -311,6 +311,12 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const [txFind, setTxFind] = useState<string | null>(null) // fullscreen Ctrl+F find query (null = closed)
   const [vimMode, setVimMode] = useState(false) // /vim modal editing
   const [resizeKey, setResizeKey] = useState(0) // bumped on terminal resize to remount <Static> (inline)
+
+  // Warm the @-mention / file index off the render path so the first @, /open, or
+  // /files doesn't freeze input on a cold synchronous filesystem walk.
+  useEffect(() => {
+    void prewarmFileIndex(process.cwd())
+  }, [])
 
   // Fullscreen uses the terminal's alternate screen so the bounded transcript
   // viewport renders in place (no scrollback spam). Enter on mount, restore on exit.

--- a/ui-tui/src/fileIndex.ts
+++ b/ui-tui/src/fileIndex.ts
@@ -5,6 +5,7 @@
  * skipped, results are capped.
  */
 import { readdirSync } from 'node:fs'
+import { readdir } from 'node:fs/promises'
 import { join, relative } from 'node:path'
 
 const IGNORE_DIRS = new Set([
@@ -56,8 +57,74 @@ function walk(root: string): string[] {
   return out
 }
 
+/** Async variant of `walk` — yields on each readdir so a large tree never blocks
+ *  the event loop (used by prewarm + background refresh). */
+async function walkAsync(root: string): Promise<string[]> {
+  const out: string[] = []
+  const stack: string[] = [root]
+  while (stack.length > 0 && out.length < MAX_FILES) {
+    const dir = stack.pop() as string
+    let entries
+    try {
+      entries = await readdir(dir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const e of entries) {
+      if (e.isDirectory()) {
+        if (e.name.startsWith('.') || IGNORE_DIRS.has(e.name)) continue
+        stack.push(join(dir, e.name))
+      } else if (e.isFile()) {
+        out.push(relative(root, join(dir, e.name)))
+        if (out.length >= MAX_FILES) break
+      }
+    }
+  }
+  return out
+}
+
+let refreshing = false
+
+/** Rebuild the cache in the background (non-blocking); keep the stale cache on error. */
+function refreshAsync(cwd: string): void {
+  if (refreshing) return
+  refreshing = true
+  void walkAsync(cwd)
+    .then((files) => {
+      cache = { cwd, at: Date.now(), files: files.sort() }
+    })
+    .catch(() => {
+      /* keep the stale cache */
+    })
+    .finally(() => {
+      refreshing = false
+    })
+}
+
+/**
+ * Warm the index off the render path (call once at startup). Without this, the
+ * first `@`/`/open`/`/files` triggers a synchronous walk of up to MAX_FILES files,
+ * freezing input for a beat ("sticky, then normal"). Async so it never blocks.
+ */
+export async function prewarmFileIndex(cwd: string): Promise<void> {
+  if (cache && cache.cwd === cwd) return
+  try {
+    const files = (await walkAsync(cwd)).sort()
+    if (!cache || cache.cwd !== cwd) cache = { cwd, at: Date.now(), files }
+  } catch {
+    /* best effort — searchFiles falls back to a synchronous walk */
+  }
+}
+
 function getFiles(cwd: string, now: number): string[] {
-  if (cache && cache.cwd === cwd && now - cache.at < STALE_MS) return cache.files
+  if (cache && cache.cwd === cwd) {
+    // Serve the cache immediately; if stale, refresh in the background so a
+    // keystroke never blocks on a filesystem walk.
+    if (now - cache.at >= STALE_MS) refreshAsync(cwd)
+    return cache.files
+  }
+  // Truly cold (prewarm hasn't filled it yet) — one synchronous walk so this
+  // render returns results.
   const files = walk(cwd).sort()
   cache = { cwd, at: now, files }
   return files

--- a/ui-tui/test/features.test.mjs
+++ b/ui-tui/test/features.test.mjs
@@ -179,3 +179,13 @@ test('terminal resize triggers a full reset (no stacked input boxes)', async () 
     'resize should clear screen + scrollback + home (full reset), not leave stacked frames',
   )
 })
+
+test('file index pre-warms async so file search never blocks input', async () => {
+  const { prewarmFileIndex, searchFiles } = await import('../dist/fileIndex.js')
+  await prewarmFileIndex(process.cwd()) // async walk off the render path
+  const t0 = performance.now()
+  const files = searchFiles(process.cwd(), 'App', Date.now())
+  const dt = performance.now() - t0
+  assert.ok(files.length > 0, 'should find files after prewarm')
+  assert.ok(dt < 50, `cached file search must be instant (no cold walk on the keystroke), took ${dt.toFixed(1)}ms`)
+})


### PR DESCRIPTION
## Summary
The first `@`-mention, `/open`, or `/files` triggered a **synchronous walk of up to 12k files** on the render/keystroke path — input froze for a beat, then recovered once the result cached ("sticky, then normal"). Same first-time-cold class as the slash-menu and resize bugs.

## Changes
- `prewarmFileIndex()`: async walk (`fs/promises`) that warms the cache off the render path; called once at startup.
- `getFiles()`: serve the cache immediately and **refresh in the background** when stale, so a keystroke never blocks on a filesystem walk (only a truly cold cache, before prewarm finishes, still does one sync walk).

## Verification
Committed test: after prewarm, a file search returns results in **<50ms (0.1ms measured)** instead of a cold multi-thousand-file walk. `npm test` **16/16**.

## Note on the reported slash lag
The slash-prefix+backspace lag specifically is the ~70-row slash-menu render, already capped to 10 rows in #560 — a **rebuild** picks that up. This PR fixes the same first-time-cold freeze on the file paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)