### PR TITLE
perf(backend): defer the openai import to cut agent-server cold-start

### DIFF
--- a/src/providers/openai_compatible_specs.py
+++ b/src/providers/openai_compatible_specs.py
@@ -31,11 +31,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, ClassVar, Optional
 
-try:
-    from openai import OpenAI  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover
-    OpenAI = None
-
+# NOTE: `openai` is imported lazily inside `_create_client` (not at module top).
+# The SDK pulls in hundreds of submodules (~370ms warm, and a lot of cold-cache
+# disk I/O on first launch); keeping it off the module-import path makes the
+# agent-server cold-start — and the first keystrokes after launch — noticeably
+# snappier. It's loaded on first client creation (the first turn), where it's
+# actually needed.
 from .openai_compatible import OpenAICompatibleProvider
 
 
@@ -338,7 +339,9 @@ class _SpecOpenAICompatibleProvider(OpenAICompatibleProvider):
         ``OpenAICompatibleProvider.client``; the optional ``CLAWCODEX_SSL_VERIFY``
         bypass is honoured here for corporate/self-hosted endpoints.
         """
-        if OpenAI is None:  # pragma: no cover
+        try:
+            from openai import OpenAI  # deferred — see module note above
+        except ModuleNotFoundError:  # pragma: no cover
             raise ModuleNotFoundError(
                 "openai package is not installed. Install optional dependencies "
                 f"to use {type(self).__name__}."

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -183,7 +183,7 @@ class TestKeylessLocalProviders(unittest.TestCase):
         for pid in ("together", "moonshot", "nvidia-nim"):
             self.assertTrue(provider_requires_api_key(pid), pid)
 
-    @patch("src.providers.openai_compatible_specs.OpenAI")
+    @patch("openai.OpenAI")  # deferred import in _create_client → patch at source
     def test_empty_key_becomes_placeholder(self, mock_openai):
         # A keyless local provider must not pass an empty key to the SDK (which
         # would silently fall through to the OPENAI_API_KEY env lookup).
@@ -195,7 +195,7 @@ class TestKeylessLocalProviders(unittest.TestCase):
 
 
 class TestSpecProviderChat(unittest.TestCase):
-    @patch("src.providers.openai_compatible_specs.OpenAI")
+    @patch("openai.OpenAI")  # deferred import in _create_client → patch at source
     def test_chat_uses_openai_compatible_path(self, mock_openai):
         mock_client = MagicMock()
         mock_response = MagicMock()
@@ -221,6 +221,28 @@ class TestSpecProviderChat(unittest.TestCase):
         # The configured base URL reached the SDK client.
         self.assertEqual(
             mock_openai.call_args.kwargs["base_url"], "https://api.together.xyz/v1"
+        )
+
+
+class TestColdStartImports(unittest.TestCase):
+    def test_openai_not_imported_at_cold_start(self):
+        """`openai` (hundreds of submodules) must stay OFF the agent-server
+        cold-start import path — it's deferred to first client creation in
+        ``openai_compatible_specs._create_client``. Eagerly importing it again
+        would re-add ~300ms (and a lot of cold-cache disk I/O) to launch, which
+        is the window users feel as first-keystroke lag.
+        """
+        import os
+        import subprocess
+        import sys
+
+        repo = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        code = "import sys; import src.cli; raise SystemExit(1 if 'openai' in sys.modules else 0)"
+        result = subprocess.run([sys.executable, "-c", code], cwd=repo, capture_output=True)
+        self.assertEqual(
+            result.returncode,
+            0,
+            "openai must not be imported when src.cli loads (keep it lazy)",
         )
 
 


### PR DESCRIPTION
## Summary
Investigating the "first query after launch is sticky for ~5–10s" report: the agent-server cold-start **eagerly imported `openai`** via the provider registry (`providers/__init__` → `openai_compatible_specs`). The openai SDK pulls in hundreds of submodules — ~370ms warm, and a lot of cold-cache disk I/O on first launch (the window users feel as first-keystroke lag, since the Python child's startup competes with the Node TUI for CPU/disk).

`OpenAI` is only used in `_create_client`, so it's now imported there (on first client creation / first turn), not at module load.

## Measured
- `import src.cli`: **322ms → 70ms (78% faster)**; `openai` no longer in `sys.modules` at cold-start.
- deepseek + spec-based OpenAI-compatible providers still work (openai loads on demand).
- Regression guard added (`TestColdStartImports`); two tests updated to patch `openai.OpenAI` at source. **26 provider tests + 250 provider/server tests pass.**

## Note
This removes one significant chunk of cold-start; the remaining first-launch time is Python interpreter startup + cold disk cache reading the codebase, which is partly environmental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)