### PR TITLE
diag(ui-tui): opt-in event-loop stall logger to locate the input freeze

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -27,6 +27,7 @@ import { BUDDY_SPECIES, CompanionSprite } from './components/CompanionSprite.js'
 import { FileMenu } from './components/FileMenu.js'
 import { VimInput } from './components/VimInput.js'
 import { searchFiles, prewarmFileIndex } from './fileIndex.js'
+import { note as perfNote, bumpRender as perfBumpRender } from './perfDebug.js'
 import { Spinner } from './components/Spinner.js'
 import { StatusBar } from './components/StatusBar.js'
 import { DevBar } from './components/DevBar.js'
@@ -247,6 +248,7 @@ function streamTail(text: string, cols: number, maxLines: number): string {
 
 
 export function App({ transport, serverLabel }: Props): React.ReactElement {
+  perfBumpRender() // perf diagnostics (CLAWCODEX_DEBUG_PERF=1): count renders
   const { exit } = useApp()
   const [entries, setEntries] = useState<TranscriptEntry[]>([])
   const [streaming, setStreaming] = useState('')
@@ -700,6 +702,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
         setElicit({ requestId, message, field, value: '' })
       },
       onMessage: (msg) => {
+        perfNote(`msg:${(msg as { type?: string }).type ?? '?'}`)
         const think = streamThinkingDelta(msg)
         if (think !== null) {
           appendThinkingStream(think)
@@ -842,6 +845,7 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   }, [transport])
 
   useInput((ch, key) => {
+    perfNote(`key:${key.backspace ? 'backspace' : key.delete ? 'delete' : key.return ? 'return' : ch ? JSON.stringify(ch).slice(0, 8) : 'special'}`)
     // Terminal focus events (DECSET 1004) arrive as "[I" / "[O" — track + swallow.
     if (ch === '[I') {
       focusedRef.current = true

--- a/ui-tui/src/cli.tsx
+++ b/ui-tui/src/cli.tsx
@@ -19,6 +19,7 @@ import { render } from 'ink'
 import React from 'react'
 import { App } from './App.js'
 import { createSession } from './client.js'
+import { startStallDetector } from './perfDebug.js'
 import { StdioTransport, WsTransport, type Transport } from './transport.js'
 
 interface Args {
@@ -101,6 +102,7 @@ async function main(): Promise<void> {
     })
   }
 
+  startStallDetector() // opt-in (CLAWCODEX_DEBUG_PERF=1): logs event-loop stalls
   const { waitUntilExit } = render(<App transport={transport} serverLabel={serverLabel} />)
   await waitUntilExit()
   dispose?.()

--- a/ui-tui/src/perfDebug.ts
+++ b/ui-tui/src/perfDebug.ts
@@ -1,0 +1,60 @@
+/**
+ * Opt-in performance diagnostics (CLAWCODEX_DEBUG_PERF=1).
+ *
+ * Logs event-loop stalls — periods where the Node event loop was blocked longer
+ * than a threshold — to ~/.clawcodex/perf.log, tagged with the last "activity"
+ * breadcrumb (a render, a backend message, or a keypress). When input feels
+ * stuck, the log pinpoints WHERE the block is: JS render/processing (a stall
+ * appears) vs. terminal/backend (no stall appears). No-ops unless enabled.
+ */
+import { appendFileSync, mkdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export const PERF_DEBUG = process.env['CLAWCODEX_DEBUG_PERF'] === '1'
+const LOG_PATH = join(homedir(), '.clawcodex', 'perf.log')
+
+let lastActivity = 'startup'
+let activityAt = Date.now()
+let renderCount = 0
+
+function write(line: string): void {
+  try {
+    mkdirSync(join(homedir(), '.clawcodex'), { recursive: true })
+    appendFileSync(LOG_PATH, line + '\n')
+  } catch {
+    /* best effort */
+  }
+}
+
+/** Record what the app is doing right now (cheap; only when enabled). */
+export function note(activity: string): void {
+  if (!PERF_DEBUG) return
+  lastActivity = activity
+  activityAt = Date.now()
+}
+
+/** Count a React render (helps tell render-storms from single blocks). */
+export function bumpRender(): void {
+  if (PERF_DEBUG) renderCount++
+}
+
+/** Start the stall detector. Call once at startup. */
+export function startStallDetector(): void {
+  if (!PERF_DEBUG) return
+  write(`\n=== clawcodex perf session ${new Date().toISOString()} (log: ${LOG_PATH}) ===`)
+  const INTERVAL = 100
+  const THRESHOLD = 300 // report blocks longer than this
+  let last = Date.now()
+  const timer = setInterval(() => {
+    const now = Date.now()
+    const gap = now - last - INTERVAL
+    if (gap > THRESHOLD) {
+      write(
+        `${new Date().toISOString()} STALL ${gap}ms · lastActivity="${lastActivity}" (${now - activityAt}ms ago) · renders=${renderCount}`,
+      )
+    }
+    last = now
+  }, INTERVAL)
+  timer.unref?.()
+}


### PR DESCRIPTION
## Correction + diagnostic
Investigating the "second-query backspace freezes 5–10s" report.

**Correcting an earlier wrong diagnosis:** the "~27 KB re-emit per keystroke" I measured was a **test-harness artifact** — Python's `pty.fork` defaults to a 0×0 winsize, which makes Ink unable to compute layout and re-emit everything. With a **real** terminal winsize (verified 24×80 and 50×120), Ink writes **~25 bytes/keystroke** even with 500 `<Static>` lines. A real-TUI PTY repro (real winsize + a realistic turn) shows second-query backspace latency of **0–7ms**. So the renderer is **not** the cause, and the freeze doesn't reproduce headless — it depends on the real backend's post-turn work or the user's terminal.

## What this adds
`CLAWCODEX_DEBUG_PERF=1` → logs event-loop stalls (>300ms) to `~/.clawcodex/perf.log`, tagged with the last activity breadcrumb (render / backend message / keypress). This localizes the freeze: a logged stall ⇒ a JS block (and which activity caused it); **no** stall during the freeze ⇒ terminal/backend, not JS. No-op unless enabled.

## Verification
Logs a synthetic 1.2s block correctly; `npm test` **17/17** (breadcrumbs are no-ops without the env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)