### PR TITLE
diag(ui-tui): CLAWCODEX_DEBUG_PERF=2 trace mode (per-event timeline)

### DIFF
--- a/ui-tui/src/markdown.tsx
+++ b/ui-tui/src/markdown.tsx
@@ -13,12 +13,16 @@ import { Box, Text } from 'ink'
 import React from 'react'
 import stringWidth from 'string-width'
 import wrapAnsi from 'wrap-ansi'
+import { note as perfNote } from './perfDebug.js'
 import { theme } from './theme.js'
 
 /** Syntax-highlight a code block to an ANSI string (Ink Text passes ANSI through). */
 function highlightCode(code: string, lang?: string): string[] {
   try {
-    return highlight(code, { language: lang, ignoreIllegals: true }).split('\n')
+    perfNote('md-highlight(cli-highlight)')
+    const r = highlight(code, { language: lang, ignoreIllegals: true }).split('\n')
+    perfNote('md-highlight-done')
+    return r
   } catch {
     return code.split('\n')
   }
@@ -290,6 +294,7 @@ function TableBlock({ block }: { block: Extract<Block, { type: 'table' }> }): Re
 }
 
 export function Markdown({ text }: { text: string }): React.ReactElement {
+  perfNote(`md-render(${text.length}b)`)
   const blocks = parseBlocks(text)
   return (
     <Box flexDirection="column">

--- a/ui-tui/src/perfDebug.ts
+++ b/ui-tui/src/perfDebug.ts
@@ -11,7 +11,10 @@ import { appendFileSync, mkdirSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
-export const PERF_DEBUG = process.env['CLAWCODEX_DEBUG_PERF'] === '1'
+// =1 → log event-loop stalls only. =2 → also TRACE every keypress/render/message
+// with timestamps (to locate input/render-delivery delays that aren't loop stalls).
+export const PERF_DEBUG = process.env['CLAWCODEX_DEBUG_PERF'] === '1' || process.env['CLAWCODEX_DEBUG_PERF'] === '2'
+const PERF_TRACE = process.env['CLAWCODEX_DEBUG_PERF'] === '2'
 const LOG_PATH = join(homedir(), '.clawcodex', 'perf.log')
 
 let lastActivity = 'startup'
@@ -32,11 +35,14 @@ export function note(activity: string): void {
   if (!PERF_DEBUG) return
   lastActivity = activity
   activityAt = Date.now()
+  if (PERF_TRACE) write(`${new Date().toISOString()} · ${activity}`)
 }
 
 /** Count a React render (helps tell render-storms from single blocks). */
 export function bumpRender(): void {
-  if (PERF_DEBUG) renderCount++
+  if (!PERF_DEBUG) return
+  renderCount++
+  if (PERF_TRACE) write(`${new Date().toISOString()} · render#${renderCount}`)
 }
 
 /** Start the stall detector. Call once at startup. */


### PR DESCRIPTION
## Summary
Extends the stall logger (#567) to diagnose **input-delivery delays that aren't event-loop blocks** — like the reported second-query backspace freeze, which logs **0 stalls** (so it's stdin/terminal-side, not JS compute).

`CLAWCODEX_DEBUG_PERF=2` logs every keypress, render, and backend message to `~/.clawcodex/perf.log` with timestamps. The timeline disambiguates a gap *before* a keypress (stdin delivery) vs *before* the next render (render/terminal). `=1` still logs stalls only. Adds `md-render`/`md-highlight` breadcrumbs to attribute render time.

All no-ops unless enabled. `npm test` **17/17**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)