### PR TITLE
fix(ui-tui): throttle live-stream renders (fixes post-turn input lag)

### DIFF
--- a/ui-tui/src/App.tsx
+++ b/ui-tui/src/App.tsx
@@ -253,6 +253,13 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   const [entries, setEntries] = useState<TranscriptEntry[]>([])
   const [streaming, setStreaming] = useState('')
   const streamRef = useRef('') // source of truth for the live buffer (no stale closures)
+  // Throttle live-stream renders: the backend emits one stream_event per token
+  // (very bursty — ~18 in 83ms observed), and one render+stdout-write per delta
+  // floods a slower terminal (Terminal.app), backing the render pipeline up for
+  // seconds and making subsequent keystrokes lag. Coalesce to ~20fps; a trailing
+  // timer guarantees the final delta is shown. (The original throttles too.)
+  const streamTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const streamLastRef = useRef(0)
   const [thinkingStream, setThinkingStream] = useState('') // live reasoning deltas (§3)
   const thinkingRef = useRef('')
   const [permissions, setPermissions] = useState<PendingPermission[]>([]) // FIFO queue
@@ -608,7 +615,14 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
   }
 
   const setStream = (s: string) => {
+    // Any explicit set (incl. the turn-end commit to '') cancels a pending
+    // throttled render so a stale buffer can't paint after the commit.
+    if (streamTimerRef.current) {
+      clearTimeout(streamTimerRef.current)
+      streamTimerRef.current = null
+    }
     streamRef.current = s
+    streamLastRef.current = Date.now()
     setStreaming(s)
   }
   const appendStream = (delta: string) => {
@@ -618,7 +632,26 @@ export function App({ transport, serverLabel }: Props): React.ReactElement {
       setThinkingStream('')
     }
     streamRef.current += delta
-    setStreaming(streamRef.current)
+    // Throttle to ~20fps: render now if enough time has passed, else schedule a
+    // single trailing render. Collapses bursty per-token deltas into far fewer
+    // renders/writes so the terminal pipeline doesn't back up.
+    const MIN_MS = 50
+    const now = Date.now()
+    const elapsed = now - streamLastRef.current
+    if (elapsed >= MIN_MS) {
+      if (streamTimerRef.current) {
+        clearTimeout(streamTimerRef.current)
+        streamTimerRef.current = null
+      }
+      streamLastRef.current = now
+      setStreaming(streamRef.current)
+    } else if (!streamTimerRef.current) {
+      streamTimerRef.current = setTimeout(() => {
+        streamTimerRef.current = null
+        streamLastRef.current = Date.now()
+        setStreaming(streamRef.current)
+      }, MIN_MS - elapsed)
+    }
   }
   const appendThinkingStream = (delta: string) => {
     thinkingRef.current += delta


### PR DESCRIPTION
## Root cause (from a real-terminal `CLAWCODEX_DEBUG_PERF=2` trace)
The "second-query backspace freezes 5–10s" bug is **not** a JS block (0 event-loop stalls) and **not** markdown (0 `md-render`). The backend emits **one `stream_event` per token** — extremely bursty (~18 deltas in 83ms) — and `appendStream` did one `setStreaming` → render → **stdout write per delta**. That's ~87 renders/writes for one short turn, flooding a slower terminal (Terminal.app); the pipeline backs up and drains over ~10s afterward, so the next query's keystrokes lag (key→render latency grew to ~5s, with a 7.2s gap — all with 0 stalls).

## Fix
Throttle `appendStream` to ~20fps (render immediately if ≥50ms elapsed, else a single trailing render so the last delta still shows). `setStream` (incl. the turn-end commit to `''`) cancels any pending render. The turn-end flush commits the **full** buffer — no content lost, only the live preview is rate-capped. The original Claude Code throttles streaming too.

## Verification
Bursty 40-delta stream still displays; turn-end commit contains the full response (first + last token); `npm test` **17/17**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)