### PR TITLE
fix(ui-tui): don't clear the screen on inline startup

### DIFF
--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -5,7 +5,7 @@ import './lib/forceTruecolor.js'
 
 import type { FrameEvent } from '@hermes/ink'
 
-import { DASHBOARD_TUI_MODE, TERMUX_TUI_MODE } from './config/env.js'
+import { DASHBOARD_TUI_MODE, INLINE_MODE, TERMUX_TUI_MODE } from './config/env.js'
 import { GatewayClient } from './gatewayClient.js'
 import { setupGracefulExit } from './lib/gracefulExit.js'
 import { formatBytes, type HeapDumpResult, performHeapDump } from './lib/memory.js'
@@ -39,10 +39,12 @@ process.on('exit', () => {
   resetTerminalModes()
 })
 
-// Desktop terminals benefit from a clean startup slate because the TUI usually
-// runs in AlternateScreen. On Termux we keep prior output intact so users can
-// review/copy earlier assistant replies after reopening the app.
-if (TERMUX_TUI_MODE) {
+// Only wipe the screen for a clean slate in fullscreen (alternate-screen) mode.
+// Inline mode (the default) and Termux keep prior terminal output intact so the
+// transcript flows into native scrollback — Claude Code-style. The erase
+// (2J + home + 3J scrollback) is exactly what made launch read as a vim-style
+// takeover, so it's gated to the fullscreen path only.
+if (TERMUX_TUI_MODE || INLINE_MODE) {
   process.stdout.write('\n')
 } else {
   process.stdout.write('\x1b[2J\x1b[H\x1b[3J')


### PR DESCRIPTION
## Summary

Inline mode (the default since #572) was still **clearing the terminal on launch** — a `\x1b[2J\x1b[H\x1b[3J` write in `entry.tsx` bootstrap that assumed the alternate screen. With no alt-screen actually in use, that erase wiped the user's terminal on startup, reading as a **vim-style fullscreen takeover**.

This gates the erase to fullscreen (non-inline) mode only. Inline + Termux now just emit a newline and let the transcript flow into the terminal's **native scrollback** — true Claude Code-style inline rendering.

## Change

`entry.tsx`: `if (TERMUX_TUI_MODE)` → `if (TERMUX_TUI_MODE || INLINE_MODE)` (one line + the import).

## Verification (pyte)

- Startup `\x1b[2J` count: **1 → 0**.
- Banner paints inline at the cursor; prompt/response render without garble.
- No `?1049h` (no alternate screen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
