### PR TITLE
fix(ui-tui): stop inline TUI overlapping terminal scrollback on startup/exit

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -2398,6 +2398,20 @@ export default class Ink {
         // <AlternateScreen>'s unmount effect won't run during signal-exit.
         // Exit alt screen FIRST so other cleanup sequences go to the main screen.
         writeSync(1, EXIT_ALT_SCREEN)
+      } else {
+        // Inline (primary-screen) exit: the renderer parks the cursor on the
+        // frame's caret row (displayCursor), which can sit ABOVE rows like a
+        // bottom status rule. Drop onto a fresh line below the WHOLE frame so the
+        // returning shell prompt lands cleanly under the TUI regardless of
+        // layout, instead of overwriting its last row(s). When the caret is
+        // blurred (displayCursor null) the cursor already sits one past the last
+        // row, so nothing is emitted. (Alt-screen's rmcup restores the pre-TUI
+        // cursor, so this is inline-only.)
+        const parkedY = this.displayCursor?.y ?? this.frontFrame.screen.height
+        const below = Math.max(0, this.frontFrame.screen.height - parkedY)
+        if (below > 0) {
+          writeSync(1, '\r' + '\n'.repeat(below))
+        }
       }
 
       // Disable mouse tracking — unconditional because altScreenActive can be

--- a/ui-tui/src/__tests__/terminalModes.test.ts
+++ b/ui-tui/src/__tests__/terminalModes.test.ts
@@ -23,11 +23,28 @@ describe('terminal mode reset', () => {
     expect(TERMINAL_MODE_RESET).toContain('\x1b[>4m')
   })
 
-  it('writes reset sequence to TTY streams without fds', () => {
+  it('writes the inline reset (no alt-screen leave) to TTY streams without fds', () => {
     const write = vi.fn()
 
     expect(resetTerminalModes({ isTTY: true, write } as unknown as NodeJS.WriteStream)).toBe(true)
+    const written = write.mock.calls[0]?.[0] as string
+    // Input/display modes are still reset...
+    expect(written).toContain("\x1b[0'z")
+    expect(written).toContain('\x1b[?1000l')
+    expect(written).toContain('\x1b[?2004l')
+    expect(written).toContain('\x1b[?25h')
+    // ...but NOT the alt-screen leave: inline mode never entered the alt screen,
+    // and rmcup homes the cursor on Apple Terminal (overlapping startup/exit).
+    expect(written).not.toContain('\x1b[?1049l')
+  })
+
+  it('includes the alt-screen leave only when leaveAltScreen is set (fullscreen)', () => {
+    const write = vi.fn()
+
+    expect(resetTerminalModes({ isTTY: true, write } as unknown as NodeJS.WriteStream, true)).toBe(true)
+    // Fullscreen reset is the full canonical sequence, including rmcup.
     expect(write).toHaveBeenCalledWith(TERMINAL_MODE_RESET)
+    expect((write.mock.calls[0]?.[0] as string)).toContain('\x1b[?1049l')
   })
 
   it('skips non-TTY streams', () => {
@@ -48,7 +65,9 @@ describe('terminal mode reset', () => {
     const write = vi.fn()
     const stream = { isTTY: true, write } as unknown as NodeJS.WriteStream
 
-    // Mirror entry.tsx's process.on('exit') callback.
+    // entry.tsx's exit backstop calls resetTerminalModes(stdout, FULLSCREEN);
+    // the mouse-disarm bytes live in MODE_RESET_HEAD/TAIL and are emitted
+    // regardless of the alt-screen flag, so the default call exercises them.
     const onExit = () => resetTerminalModes(stream)
     onExit()
 

--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -19,8 +19,20 @@ if (!process.stdin.isTTY) {
   process.exit(0)
 }
 
-// Start from a clean slate. If a previous TUI crashed or was kill -9'd, the
-// terminal tab can still have mouse/focus/paste modes enabled.
+// Whether we run in the alternate screen — must match appLayout's
+// `INLINE_MODE ? Fragment : AlternateScreen`, which keys off INLINE_MODE alone
+// (so Termux + HERMES_TUI_INLINE=0 is fullscreen too). Only fullscreen should
+// leave the alt screen on cleanup: in inline mode emitting rmcup (?1049l) homes
+// the cursor on Apple Terminal, overlapping the banner onto scrollback at startup
+// and dropping the prompt onto the frame at exit — see terminalModes.ts.
+const FULLSCREEN = !INLINE_MODE
+
+// Reset leftover input modes (mouse/focus/paste) a crashed-or-killed prior
+// program may have armed. Never leave the alt screen here: at startup we haven't
+// entered it, and rmcup would home the cursor inline. (Tradeoff: an inline TUI
+// launched into a stale alt screen left by a hard-crashed fullscreen program
+// won't be pulled back to the primary buffer — rare, vs. the common-case overlap
+// this avoids.)
 resetTerminalModes()
 
 // Final backstop for terminal cleanup. setupGracefulExit() resets modes on
@@ -36,7 +48,7 @@ resetTerminalModes()
 // before the process is gone. Idempotent and cheap, so layering it under the
 // graceful-exit cleanups is safe.
 process.on('exit', () => {
-  resetTerminalModes()
+  resetTerminalModes(process.stdout, FULLSCREEN)
 })
 
 // Only wipe the screen for a clean slate in fullscreen (alternate-screen) mode.
@@ -60,7 +72,7 @@ const dumpNotice = (snap: MemorySnapshot, dump: HeapDumpResult | null) =>
 setupGracefulExit({
   cleanups: [
     () => {
-      resetTerminalModes()
+      resetTerminalModes(process.stdout, FULLSCREEN)
 
       return gw.kill('graceful-exit-cleanup')
     }
@@ -76,7 +88,7 @@ setupGracefulExit({
     // (gw.kill forwards SIGTERM regardless of which signal hit us) — this is
     // what tells SIGHUP (terminal/SSH dropped) apart from a real SIGTERM.
     recordParentLifecycle(`graceful-exit received signal=${signal} → killing gateway`)
-    resetTerminalModes()
+    resetTerminalModes(process.stdout, FULLSCREEN)
     process.stderr.write(`hermes-tui lifecycle: received ${signal}\n`)
   },
   // The dashboard chat tab has no in-page restart path after the PTY child
@@ -94,7 +106,7 @@ const stopMemoryMonitor = startMemoryMonitor({
     recordParentLifecycle(
       `memory-critical process.exit(137) heap=${formatBytes(snap.heapUsed)} rss=${formatBytes(snap.rss)} dump=${dump?.heapPath ?? 'failed'}`
     )
-    resetTerminalModes()
+    resetTerminalModes(process.stdout, FULLSCREEN)
     process.stderr.write(
       `hermes-tui lifecycle: memory critical exit heap=${formatBytes(snap.heapUsed)} rss=${formatBytes(snap.rss)}\n`
     )

--- a/ui-tui/src/lib/terminalModes.ts
+++ b/ui-tui/src/lib/terminalModes.ts
@@ -1,6 +1,8 @@
 import { writeSync } from 'node:fs'
 
-export const TERMINAL_MODE_RESET =
+// Input/display modes a crashed-or-killed prior program may have left armed.
+// These are safe to reset unconditionally — they don't touch the screen buffer.
+const MODE_RESET_HEAD =
   "\x1b[0'z" + // DEC locator reporting
   "\x1b[0'{" + // selectable locator events
   '\x1b[?2029l' + // passive mouse
@@ -14,27 +16,43 @@ export const TERMINAL_MODE_RESET =
   '\x1b[?1000l' + // click mouse
   '\x1b[?9l' + // X10 mouse
   '\x1b[?1004l' + // focus events
-  '\x1b[?2004l' + // bracketed paste
-  '\x1b[?1049l' + // alternate screen
+  '\x1b[?2004l' // bracketed paste
+
+// Leaving the alternate screen (rmcup). On Apple Terminal, rmcup WITHOUT a
+// matching prior smcup homes the cursor to the top-left — which makes an inline
+// (primary-screen) TUI paint its banner over existing scrollback on startup and
+// drop the shell prompt onto the frame on exit. So this is gated: only emit it
+// in fullscreen mode, where the renderer actually entered the alt screen.
+const ALT_SCREEN_LEAVE = '\x1b[?1049l'
+
+const MODE_RESET_TAIL =
   '\x1b[<u' + // kitty keyboard
   '\x1b[>4m' + // modifyOtherKeys
   '\x1b[0m' + // attributes
   '\x1b[?25h' // cursor visible
 
+// The full reset (including the alt-screen leave), kept as the canonical
+// fullscreen sequence and for back-compat with anything importing it.
+export const TERMINAL_MODE_RESET = MODE_RESET_HEAD + ALT_SCREEN_LEAVE + MODE_RESET_TAIL
+
 type ResettableStream = Pick<NodeJS.WriteStream, 'isTTY' | 'write'> & {
   fd?: number
 }
 
-export function resetTerminalModes(stream: ResettableStream = process.stdout): boolean {
+/** Reset terminal input/display modes. Pass `leaveAltScreen` only in fullscreen
+ *  mode — inline mode never entered the alt screen, and emitting rmcup there
+ *  homes the cursor on Apple Terminal (causing startup/exit overlap). */
+export function resetTerminalModes(stream: ResettableStream = process.stdout, leaveAltScreen = false): boolean {
   if (!stream.isTTY) {
     return false
   }
 
+  const seq = MODE_RESET_HEAD + (leaveAltScreen ? ALT_SCREEN_LEAVE : '') + MODE_RESET_TAIL
   const fd = typeof stream.fd === 'number' ? stream.fd : stream === process.stdout ? 1 : undefined
 
   if (fd !== undefined) {
     try {
-      writeSync(fd, TERMINAL_MODE_RESET)
+      writeSync(fd, seq)
 
       return true
     } catch {
@@ -43,7 +61,7 @@ export function resetTerminalModes(stream: ResettableStream = process.stdout): b
   }
 
   try {
-    stream.write(TERMINAL_MODE_RESET)
+    stream.write(seq)
 
     return true
   } catch {


### PR DESCRIPTION
## Symptom

In **inline mode** (the default), the TUI overlapped existing terminal output — on **Apple Terminal**:
- **Startup:** the banner painted on top of the shell's prior `ls`/command output.
- **Exit:** the returning shell prompt landed on top of the TUI frame.

## Root cause

`terminalModes.ts`'s `TERMINAL_MODE_RESET` emitted **`\x1b[?1049l`** (rmcup / leave alt-screen) **unconditionally**, and `entry.tsx` calls `resetTerminalModes()` at startup and on every exit path. On Apple Terminal, **`rmcup` without a matching prior `smcup` homes the cursor to the top-left** — so the banner painted from the top (startup) and the prompt returned at the top (exit). Inline mode never enters the alt screen, so leaving it is semantically wrong.

PR #573 fixed a *different* mechanism (it removed an explicit `2J` clear), which is why the overlap persisted. pyte-based verification can't catch this because pyte treats a stray `rmcup` as a no-op — only a real Apple Terminal homes the cursor.

## Fix

- **`terminalModes.ts`** — split the reset into `MODE_RESET_HEAD` (mouse/focus/paste disarm — the `#28419` bytes, still unconditional) + `ALT_SCREEN_LEAVE` + `MODE_RESET_TAIL`. `resetTerminalModes(stream, leaveAltScreen = false)` emits the alt-leave only when asked. `TERMINAL_MODE_RESET` const kept identical for back-compat.
- **`entry.tsx`** — `FULLSCREEN = !INLINE_MODE` (matching `appLayout`'s `INLINE_MODE ? Fragment : AlternateScreen`); exit-path resets pass `FULLSCREEN`, startup never leaves the alt screen.
- **`hermes-ink/ink.tsx` (`unmount`)** — on inline exit, drop the cursor onto a fresh line **below the whole frame** (`displayCursor.y` → `frontFrame.screen.height`), since the renderer parks the caret on the input row (which can sit above a bottom status rule). The shell prompt now returns cleanly under the TUI.

Fullscreen is unchanged: the renderer still emits `EXIT_ALT_SCREEN` on unmount, and `FULLSCREEN` resets still send `rmcup`.

## Verification

pty + pyte reproduction (Apple_Terminal env):
- **0** occurrences of `\x1b[?1049l` in the inline stream.
- Startup: banner renders **below** the prior shell output.
- Exit: the last TUI row stays intact and the cursor is parked **below** the frame.

`npm run build` succeeds. Full `ui-tui` vitest suite: **10 failed / 737 passed** — identical pre-existing failures to baseline (theme/textInput/markdown/etc., unrelated), **zero regressions**; new `leaveAltScreen` test passes.

Reviewed via the `critic` loop (**APPROVE**); its recommended fast-follows (frame-height-aware drop, `FULLSCREEN` predicate alignment) are folded in.

## Test plan
- `cd ui-tui && npx vitest run src/__tests__/terminalModes.test.ts`
- Live on **Apple Terminal**: run some shell commands, launch `clawcodex`, confirm the banner appears **below** the prior output (not overlapping); exit (Ctrl-C ×2 or `/quit`) and confirm the prompt returns cleanly **below** the TUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
