### PR TITLE
fix(deepseek): keep the live workspace/git context out of the prefix cache

### DIFF
--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -222,6 +222,7 @@ def build_effective_system_prompt(
     # callers need it, no need to drag it into agent_loop_compat's import time.
     from ..context_system import build_context_prompt
     from ..context_system.prompt_assembly import build_full_system_prompt_blocks
+    from ..context_system.system_prompt_cache import CacheScope
 
     cwd = str(tool_context.cwd or tool_context.workspace_root)
 
@@ -244,6 +245,18 @@ def build_effective_system_prompt(
 
     # Preserve the existing workspace + git + CLAUDE.md context verbatim as a
     # trailing uncached block (CLAUDE.md is NOT in the base blocks above).
+    #
+    # Tag it REQUEST-scope. This block is a *live workspace snapshot*: it embeds
+    # ``git status`` (and file counts / top-level entries) that mutate the moment
+    # the agent edits a file — which, for a coding agent, is essentially every
+    # turn. For DeepSeek, ``query._split_system_prompt_blocks`` relocates
+    # REQUEST-scope sections out of the byte-stable ``system + tools + history``
+    # prefix into the trailing tail; without the tag this snapshot would sit in
+    # the prefix and a single mid-session file edit would bust DeepSeek's
+    # automatic prefix cache for the entire prefix. The tag honours the block's
+    # already-intended "uncached" status while keeping the prefix stable. It is a
+    # strict no-op for every other provider: relocation only fires for DeepSeek,
+    # and the Anthropic path strips ``_cache_scope`` before the wire.
     try:
         context_prompt = build_context_prompt(
             tool_context.workspace_root,
@@ -252,7 +265,11 @@ def build_effective_system_prompt(
     except Exception:
         context_prompt = ""
     if context_prompt.strip():
-        blocks = blocks + [{"type": "text", "text": context_prompt}]
+        blocks = blocks + [{
+            "type": "text",
+            "text": context_prompt,
+            "_cache_scope": CacheScope.REQUEST.value,
+        }]
 
     return blocks
 

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -738,7 +738,12 @@ async def _call_model_sync(
         # False for every other provider, so ``flattened`` keeps every
         # non-boundary block (byte-for-byte the prior behaviour) and
         # ``volatile_tail`` is "".
-        is_deepseek = bool(getattr(provider, "is_deepseek", False))
+        # ``is True`` (not ``bool(...)``): every real provider sets the flag to a
+        # literal ``True``/``False`` (see ``BaseProvider.is_deepseek``), so this
+        # is identical in production — but it also makes a bare test double (e.g.
+        # ``MagicMock()``, whose auto-attributes are truthy) fall through to the
+        # non-relocating path instead of silently exercising DeepSeek relocation.
+        is_deepseek = getattr(provider, "is_deepseek", False) is True
         volatile_tail = ""
         if isinstance(system_prompt, list):
             flattened, volatile_tail = _split_system_prompt_blocks(

--- a/tests/test_context_system.py
+++ b/tests/test_context_system.py
@@ -68,6 +68,13 @@ class TestContextSystem(unittest.TestCase):
             conversation.add_user_message("hello")
 
             provider = MagicMock()
+            # Model a real *generic* (non-DeepSeek) provider: is_deepseek is a
+            # real False, not a truthy auto-MagicMock. Otherwise the query layer
+            # treats this mock as DeepSeek and relocates the REQUEST-scope
+            # workspace/git/CLAUDE.md context out of the system message into the
+            # trailing prefix-cache tail — which is exactly what this test is
+            # asserting does NOT happen for a non-DeepSeek provider.
+            provider.is_deepseek = False
             # Force chat() fallback (new adapter tries chat_stream_response
             # first). Without this a plain MagicMock returns MagicMock
             # content that corrupts response_text.

--- a/tests/test_deepseek_prefix_cache.py
+++ b/tests/test_deepseek_prefix_cache.py
@@ -352,6 +352,149 @@ def test_memory_section_is_request_scoped():
 
 
 # --------------------------------------------------------------------------- #
+# build_effective_system_prompt trailing context block (new-TUI cutover path)
+#
+# The live TUI + headless route through build_effective_system_prompt, which
+# appends a build_context_prompt block — a *live workspace snapshot* embedding
+# ``git status`` (+ file counts / top-level entries). Those mutate the moment the
+# agent edits a file, i.e. essentially every turn. The block MUST be REQUEST-
+# scoped so DeepSeek relocates it out of the byte-stable system prefix; otherwise
+# a single mid-session file edit busts the whole prefix cache. (Regression for
+# the gap where the block was appended untagged.)
+# --------------------------------------------------------------------------- #
+
+_CTX_HEAD = "## Runtime Context\n- Today's date: 2026-07-01\n- Workspace root: /repo\n\n"
+_CTX_CLAUDE = "\n\n## Project Instructions\nCLAUDE_MD_SENTINEL\n"
+# Turn 1 vs Turn 2: same session, but the agent created a file so git status changed.
+_CTX_GIT_T1 = _CTX_HEAD + "## Git Context\nCurrent branch: main\n\nStatus:\n M src/foo.py" + _CTX_CLAUDE
+_CTX_GIT_T2 = _CTX_HEAD + "## Git Context\nCurrent branch: main\n\nStatus:\n M src/foo.py\n?? src/new.py" + _CTX_CLAUDE
+
+
+def _effective_blocks(context_text, tmp_path):
+    """build_effective_system_prompt with build_context_prompt stubbed to a fixed
+    workspace snapshot, so the test pins the trailing-block scope deterministically."""
+    from unittest import mock
+
+    from src.query.agent_loop_compat import build_effective_system_prompt
+    from src.tool_system.context import ToolContext
+
+    ctx = ToolContext(workspace_root=tmp_path)
+    with mock.patch(
+        "src.context_system.build_context_prompt", return_value=context_text
+    ):
+        return build_effective_system_prompt(
+            "", ctx, provider=DeepSeekProvider(api_key=_KEY)
+        )
+
+
+def test_effective_prompt_tags_context_block_request_scope(tmp_path):
+    blocks = _effective_blocks(_CTX_GIT_T1, tmp_path)
+    ctx_block = next(b for b in blocks if "## Git Context" in b.get("text", ""))
+    assert ctx_block.get("_cache_scope") == "request"
+
+
+def test_deepseek_relocates_git_context_out_of_prefix(tmp_path):
+    """The volatile workspace snapshot rides the tail; CLAUDE.md is preserved
+    there (not dropped) and is NOT left in the prefix."""
+    blocks = _effective_blocks(_CTX_GIT_T1, tmp_path)
+    system, tail = _split_system_prompt_blocks(blocks, relocate_request_scope=True)
+    assert "## Git Context" not in system and "Status:" not in system
+    assert "## Git Context" in tail
+    assert "CLAUDE_MD_SENTINEL" in tail
+    assert "CLAUDE_MD_SENTINEL" not in system
+
+
+def test_deepseek_prefix_stable_across_mid_session_git_change(tmp_path):
+    """Core guarantee for the new-TUI path: a file edit that changes ``git
+    status`` must NOT perturb the DeepSeek system prefix — only the tail."""
+    sys1, tail1 = _split_system_prompt_blocks(
+        _effective_blocks(_CTX_GIT_T1, tmp_path), relocate_request_scope=True
+    )
+    sys2, tail2 = _split_system_prompt_blocks(
+        _effective_blocks(_CTX_GIT_T2, tmp_path), relocate_request_scope=True
+    )
+    assert sys1 == sys2, "a git-status change must not bust the DeepSeek prefix"
+    assert tail1 != tail2, "the changed snapshot rides the (uncached) tail"
+
+
+def test_non_deepseek_keeps_context_block_in_system(tmp_path):
+    """No regression: for non-DeepSeek providers the context block stays in the
+    flattened system string (byte-for-byte the prior behaviour), tail empty."""
+    system, tail = _split_system_prompt_blocks(
+        _effective_blocks(_CTX_GIT_T1, tmp_path), relocate_request_scope=False
+    )
+    assert "## Git Context" in system and "CLAUDE_MD_SENTINEL" in system
+    assert tail == ""
+
+
+def test_deepseek_end_to_end_relocates_context_after_history(tmp_path):
+    """End-to-end through the exact new-TUI adapter the agent-server uses:
+    build_effective_system_prompt -> run_query_as_agent_loop -> _call_model_sync
+    (DeepSeek). Pins the full wire composition: the live workspace/git/CLAUDE.md
+    context must be ABSENT from the system message and instead ride a trailing
+    user <system-reminder> that lands AFTER the conversation history."""
+    import asyncio
+    from unittest import mock
+
+    from src.providers.base import ChatResponse
+    from src.query.agent_loop_compat import (
+        build_effective_system_prompt,
+        run_query_as_agent_loop,
+    )
+    from src.tool_system.context import ToolContext
+    from src.tool_system.defaults import build_default_registry
+    from src.types.messages import UserMessage
+
+    captured: list = []
+
+    class _CapturingDeepSeek(DeepSeekProvider):
+        def chat_stream_response(self, messages, tools=None, on_text_chunk=None,
+                                 abort_signal=None, on_thinking_chunk=None, **kwargs):
+            captured.append(messages)
+            return ChatResponse(
+                content="ok", model=self.model,
+                usage={"input_tokens": 1, "output_tokens": 1},
+                finish_reason="end_turn", tool_uses=None,
+            )
+
+    provider = _CapturingDeepSeek(api_key=_KEY)
+    ctx = ToolContext(workspace_root=tmp_path)
+    registry = build_default_registry(provider=provider)
+
+    with mock.patch(
+        "src.context_system.build_context_prompt", return_value=_CTX_GIT_T1
+    ):
+        system_prompt = build_effective_system_prompt("", ctx, provider=provider)
+
+    asyncio.run(run_query_as_agent_loop(
+        initial_messages=[UserMessage(content="hello there")],
+        provider=provider,
+        tool_registry=registry,
+        tool_context=ctx,
+        system_prompt=system_prompt,
+        max_turns=1,
+        on_text_chunk=lambda _s: None,
+    ))
+
+    assert captured, "the DeepSeek provider was never called"
+    wire = captured[0]
+    # System message (index 0) is free of the volatile snapshot + CLAUDE.md.
+    assert wire[0]["role"] == "system"
+    assert "## Git Context" not in wire[0]["content"]
+    assert "CLAUDE_MD_SENTINEL" not in wire[0]["content"]
+    # The relocated snapshot rides the LAST message (after the history) as a
+    # user <system-reminder>.
+    last = wire[-1]
+    last_text = (
+        last["content"] if isinstance(last["content"], str) else str(last["content"])
+    )
+    assert last["role"] == "user"
+    assert "<system-reminder>" in last_text
+    assert "## Git Context" in last_text
+    assert "CLAUDE_MD_SENTINEL" in last_text
+
+
+# --------------------------------------------------------------------------- #
 # _append_session_context_tail (placement / alternation hardening)
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
## What & why

Revisiting the **DeepSeek prefix-caching** feature on the new (hermes) TUI. DeepSeek does automatic on-disk prefix caching keyed on a **byte-stable request prefix**. clawcodex exploits this by relocating `request`-scoped system sections (env, auto-memory, plan-mode) into a trailing `<system-reminder>` *after* the conversation, so `system + tools + history` stays byte-stable across turns; the DeepSeek provider also maps cache-hit tokens into `cache_read_input_tokens` for `/cost`.

### The bug (new-TUI / agent-server path)
The live TUI + headless route through `build_effective_system_prompt`, which appends a trailing `build_context_prompt` block — `## Runtime Context` / `## Git Context` / `## Project Instructions` (CLAUDE.md). That block was **untagged**, so `query._split_system_prompt_blocks` left it in DeepSeek's stable prefix. Its `## Git Context` section embeds **live `git status`**, which changes the instant the agent edits a file — i.e. essentially every turn of a coding session. Result: the "byte-stable" prefix mutates and DeepSeek's prefix cache busts for the **entire** `system + tools + history` prefix. env/auto-memory were already relocated correctly; this trailing block (added by the cutover path) was simply never tagged.

Reproduced concretely: two builds differing only by one new untracked file produce **different** system prefixes.

### The fix
- Tag the appended block `_cache_scope = CacheScope.REQUEST.value` so DeepSeek relocates it to the trailing tail alongside env/memory. Prefix is byte-stable again; the volatile snapshot rides the uncached tail.
- **Strict no-op for other providers**, verified at the code level and empirically:
  - non-DeepSeek OpenAI-compat: `relocate_request_scope=False` keeps every block in the flattened system string → byte-identical.
  - Anthropic: `_strip_block_metadata` removes `_cache_scope` before the wire; no `cache_control` added → byte-identical.
- Harden the gate in `query.py` to `getattr(...) is True` (was `bool(...)`): identical in production (every real provider sets a literal bool), but stops a bare `MagicMock` test double — whose auto-attributes are truthy — from silently exercising DeepSeek relocation. Fixed one existing test (`test_agent_loop_injects_context_prompt_for_non_anthropic`) that relied on that accident.

## Tests
- 5 new tests in `tests/test_deepseek_prefix_cache.py`: context block is REQUEST-tagged; git context relocates out of the prefix; **prefix byte-stable across a mid-session git change** (fails on revert); non-DeepSeek keeps it in system; CLAUDE.md preserved (not dropped); plus an **end-to-end wire test** driving `build_effective_system_prompt → run_query_as_agent_loop → _call_model_sync (DeepSeek)` that pins the context to a post-history user `<system-reminder>`, absent from the system message.
- Targeted sweep across query/provider/agent-loop/cost/context/streaming: **1044 passed, 0 failed**.

## Review
Reviewed by the `critic` subagent — **APPROVE**, no blocking/major issues. The two cheap follow-ups it recommended (`is True` gate hardening + the end-to-end wire test) are included here.

### Noted follow-up (out of scope)
The DeepSeek tail is uncached, so CLAUDE.md is re-sent uncached each turn (a few cents over a long session; still a strict improvement over the pre-fix state, which cached nothing and busted the whole prefix). A future optimization could split `build_context_prompt` into individually-scoped sub-blocks to keep the stable CLAUDE.md portion in the cached prefix — deliberately not attempted here to keep the fix minimal and avoid fragile string-splitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)