### PR TITLE
fix(workflows): restore workflow surfaces on the agent-server + Ink TUI path

### DIFF
--- a/src/command_system/workflows_command.py
+++ b/src/command_system/workflows_command.py
@@ -5,29 +5,60 @@ shared ``runtime_tasks`` registry and reports each ``local_workflow`` task with
 its status, name, and live progress summary. Works on every surface without
 touching ``ctx.ui``.
 
-The rich TUI drill-down (phases → agents with the ``p``/``x``/``r``/``s`` key
-bindings from the spec) is a follow-up; the per-run/per-agent control API it
-needs already exists (``kill_workflow_task`` / ``skip_workflow_agent`` /
-``retry_workflow_agent`` in ``src/tasks/local_workflow.py``).
+:func:`render_workflows_report` is the shared renderer — the command object
+below wraps it for registry dispatch (headless / tests), and the agent-server's
+``workflows`` control request (``src/server/agent_server.py``) returns the same
+text to the Ink TUI. Per-run/per-agent controls (``kill_workflow_task`` /
+``skip_workflow_agent`` / ``retry_workflow_agent`` in
+``src/tasks/local_workflow.py``) remain available for a richer client view.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Optional
 
 from src.workflow.gating import is_workflows_enabled
 
 from .types import CommandContext, InteractiveCommand, InteractiveOutcome
 
+#: Shown when the registry has no workflow runs to report.
+NO_WORKFLOW_RUNS_MESSAGE = (
+    "No workflow runs. Start one with /deep-research or by asking for a workflow."
+)
 
-def _format_workflow(t: Any) -> str:
-    status = getattr(t, "status", "?") or "?"
-    name = getattr(t, "workflow_name", "") or "workflow"
-    summary = getattr(t, "summary", None) or ""
-    run_id = getattr(t, "run_id", "") or ""
-    tail = f" — {summary}" if summary else ""
-    return f"[{status}] {name}{tail} (run: {run_id})"
+
+def render_workflows_report(registry: Any) -> Optional[str]:
+    """Render every ``local_workflow`` run in ``registry`` as one text report
+    (blank-line-separated run blocks), or ``None`` when there are no runs.
+
+    Defensive per run: ``progress`` objects are mutated in place by engine
+    threads (see ``LocalWorkflowTaskState.progress``), so one mid-mutation
+    render must not take down the whole report.
+    """
+    if registry is None:
+        return None
+    try:
+        runs = [t for t in registry.all() if getattr(t, "type", None) == "local_workflow"]
+    except Exception:
+        runs = []
+    if not runs:
+        return None
+    from src.workflow.progress import render_run_lines
+
+    blocks: list[str] = []
+    for t in runs:
+        try:
+            lines = render_run_lines(t)
+            run_id = getattr(t, "run_id", "") or ""
+            if run_id and lines:
+                lines[0] = f"{lines[0]}  (run: {run_id})"
+            blocks.append("\n".join(lines))
+        except Exception:
+            name = getattr(t, "workflow_name", None) or "workflow"
+            status = getattr(t, "status", "?") or "?"
+            blocks.append(f"{name}  [{status}]  (progress unavailable)")
+    return "\n\n".join(blocks)
 
 
 @dataclass(frozen=True)
@@ -39,25 +70,10 @@ class WorkflowsCommand(InteractiveCommand):
             return InteractiveOutcome(
                 message="Workflows are unavailable on this surface.", display="system"
             )
-        try:
-            runs = [t for t in registry.all() if getattr(t, "type", None) == "local_workflow"]
-        except Exception:
-            runs = []
-        if not runs:
-            return InteractiveOutcome(
-                message="No workflow runs. Start one with /deep-research or by asking for a workflow.",
-                display="system",
-            )
-        from src.workflow.progress import render_run_lines
-
-        blocks: list[str] = []
-        for t in runs:
-            lines = render_run_lines(t)
-            run_id = getattr(t, "run_id", "") or ""
-            if run_id and lines:
-                lines[0] = f"{lines[0]}  (run: {run_id})"
-            blocks.append("\n".join(lines))
-        return InteractiveOutcome(message="\n\n".join(blocks), display="system")
+        report = render_workflows_report(registry)
+        if report is None:
+            return InteractiveOutcome(message=NO_WORKFLOW_RUNS_MESSAGE, display="system")
+        return InteractiveOutcome(message=report, display="system")
 
 
 WORKFLOWS_COMMAND = WorkflowsCommand(
@@ -68,4 +84,9 @@ WORKFLOWS_COMMAND = WorkflowsCommand(
 )
 
 
-__all__ = ["WORKFLOWS_COMMAND", "WorkflowsCommand"]
+__all__ = [
+    "NO_WORKFLOW_RUNS_MESSAGE",
+    "WORKFLOWS_COMMAND",
+    "WorkflowsCommand",
+    "render_workflows_report",
+]

--- a/src/command_system/workflows_integration.py
+++ b/src/command_system/workflows_integration.py
@@ -86,13 +86,14 @@ def bundled_workflow_commands() -> list[Command]:
     ``/deep-research``).
 
     Surfaced via ``get_builtin_commands()`` so they register into the global
-    command registry that both command suggestions and dispatch read — the
-    aggregator's :func:`get_commands` that also lists them has no real consumers.
+    command registry that headless/test dispatch reads — the aggregator's
+    :func:`get_commands` that also lists them has no real consumers.
     Project/personal workflows are cwd-dependent and remain the aggregator's job.
 
-    Includes the ``/workflows`` viewer so the Rich REPL can dispatch it (the TUI
-    has its own ``open_dialog`` fast-path, which runs before registry dispatch,
-    so registering here doesn't disturb it).
+    The interactive surface (Ink TUI → agent-server) does NOT go through this
+    registry: it drives the ``workflows`` / ``list_workflow_commands`` /
+    ``workflow_command`` control requests in ``src/server/agent_server.py``,
+    which call :func:`load_workflow_commands` directly.
     """
     from .workflows_command import WORKFLOWS_COMMAND
 
@@ -150,8 +151,10 @@ def load_and_register_workflows(
     This is the workflow analogue of :func:`load_and_register_skills`, and exists
     for the same reason: the aggregator's ``get_commands()`` lists these but has
     no real consumers, so dispatch + suggestions (which read the GLOBAL registry)
-    never saw saved workflows. The REPL/TUI call this at startup, right after
-    ``load_and_register_skills``.
+    never saw saved workflows. The deleted Rich REPL / Textual TUI called this at
+    startup; the surviving interactive surface (agent-server) instead reads
+    :func:`load_workflow_commands` from disk per control request, so today this
+    helper serves registry-based (headless/test) dispatch only.
 
     Precedence, all via the shadowing guard (a name already in the target wins):
     builtins/bundled (registered first) beat saved workflows; **project beats

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -276,12 +276,16 @@ class _AgentSession:
             self._reply(request_id, {"ok": ok})
             return
         if subtype == "set_effort":
-            effort = inner.get("effort")
-            if isinstance(effort, str) and effort in ("minimal", "low", "medium", "high"):
-                self._effort = effort
-            else:
-                self._effort = None  # clear / invalid
-            self._reply(request_id, {"ok": True, "effort": self._effort or "default"})
+            self._do_set_effort(request_id, inner.get("effort"))
+            return
+        if subtype == "workflows":
+            self._do_workflows(request_id)
+            return
+        if subtype == "list_workflow_commands":
+            self._do_list_workflow_commands(request_id)
+            return
+        if subtype == "workflow_command":
+            self._do_workflow_command(request_id, inner.get("name"), inner.get("args"))
             return
         if subtype == "get_settings":
             self._reply(request_id, {
@@ -770,6 +774,156 @@ class _AgentSession:
             logger.exception("[agent-server] bgtask failed")
             self._reply(request_id, {"ok": False, "error": str(exc)})
 
+    # ─── workflow surfaces (control plane) ─────────────────────────────────
+    # The dynamic-workflow UX used to be wired through the deleted Rich REPL /
+    # Textual TUI (removed in #566); these controls are the agent-server
+    # replacements the Ink TUI drives. All are gated on is_workflows_enabled()
+    # (workflow-engine §4.8: the surfaces disappear when workflows are off).
+
+    def _do_set_effort(self, request_id: object, effort: object) -> None:
+        """``/effort`` backend: reasoning levels plus the ``ultracode``
+        workflow auto-orchestration mode (mirrors ``effort_command.py``).
+
+        No/empty arg ⇒ read-only report (the old picker's Esc-is-a-no-op).
+        ``ultracode`` enables session mode and leaves the reasoning level
+        untouched; real levels and ``auto``/``unset`` exit ultracode mode
+        (spec: "reset with /effort high")."""
+        try:
+            from src.workflow.gating import is_workflows_enabled
+            from src.workflow.ultracode import is_ultracode_session, set_ultracode_session
+
+            if effort is None or (isinstance(effort, str) and not effort.strip()):
+                # No arg ⇒ read-only report (the old picker's Esc-is-a-no-op).
+                on = is_ultracode_session()
+                self._reply(request_id, {
+                    "ok": True,
+                    "effort": "ultracode" if on else (self._effort or "default"),
+                    "ultracode": on,
+                })
+                return
+            if not isinstance(effort, str):
+                self._reply(request_id, {
+                    "ok": False,
+                    "error": f"invalid effort '{effort}' (minimal|low|medium|high|auto|ultracode)",
+                })
+                return
+            a = effort.strip().lower()
+            if a == "ultracode":
+                if not is_workflows_enabled():
+                    self._reply(
+                        request_id, {"ok": False, "error": "dynamic workflows are disabled"}
+                    )
+                    return
+                set_ultracode_session(True)
+                self._reply(request_id, {"ok": True, "effort": "ultracode", "ultracode": True})
+                return
+            if a in ("auto", "unset"):
+                self._effort = None
+                set_ultracode_session(False)
+                self._reply(request_id, {"ok": True, "effort": "default", "ultracode": False})
+                return
+            if a in ("minimal", "low", "medium", "high"):
+                self._effort = a
+                set_ultracode_session(False)  # a real level exits ultracode mode
+                self._reply(request_id, {"ok": True, "effort": a, "ultracode": False})
+                return
+            self._reply(request_id, {
+                "ok": False,
+                "error": f"invalid effort '{effort.strip()}' (minimal|low|medium|high|auto|ultracode)",
+            })
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[agent-server] set_effort failed")
+            self._reply(request_id, {"ok": False, "error": str(exc)})
+
+    def _do_workflows(self, request_id: object) -> None:
+        """``/workflows``: text report of running/recent dynamic-workflow runs
+        (shared renderer with the registry command — see
+        ``render_workflows_report``)."""
+        try:
+            from src.command_system.workflows_command import (
+                NO_WORKFLOW_RUNS_MESSAGE,
+                render_workflows_report,
+            )
+            from src.workflow.gating import is_workflows_enabled
+
+            if not is_workflows_enabled():
+                self._reply(request_id, {"ok": False, "error": "dynamic workflows are disabled"})
+                return
+            registry = getattr(self.tool_context, "runtime_tasks", None)
+            if registry is None:
+                self._reply(
+                    request_id,
+                    {"ok": False, "error": "workflows are unavailable on this surface"},
+                )
+                return
+            report = render_workflows_report(registry)
+            self._reply(request_id, {"ok": True, "text": report or NO_WORKFLOW_RUNS_MESSAGE})
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[agent-server] workflows failed")
+            self._reply(request_id, {"ok": False, "error": str(exc)})
+
+    def _do_list_workflow_commands(self, request_id: object) -> None:
+        """Slash-menu catalog: bundled (/deep-research) + saved
+        ``.claude/workflows/*.py`` workflow commands, read fresh from disk each
+        call so a workflow authored mid-session (the ultracode keyword flow)
+        appears without a restart — replaces the old REPL's mtime-gated
+        ``_refresh_workflow_commands`` loop."""
+        try:
+            from src.workflow.gating import is_workflows_enabled
+
+            if not is_workflows_enabled():
+                self._reply(request_id, {"ok": True, "commands": []})
+                return
+            from src.command_system.types import PromptCommand
+            from src.command_system.workflows_integration import load_workflow_commands
+
+            commands = [
+                {
+                    "name": c.name,
+                    "description": c.description or "",
+                    "argument_hint": getattr(c, "argument_hint", "") or "",
+                }
+                for c in load_workflow_commands(self.cwd)
+                if isinstance(c, PromptCommand)
+            ]
+            self._reply(request_id, {"ok": True, "commands": commands})
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[agent-server] list_workflow_commands failed")
+            self._reply(request_id, {"ok": False, "error": str(exc), "commands": []})
+
+    def _do_workflow_command(self, request_id: object, name: object, args: object) -> None:
+        """Dispatch a workflow slash command (``/deep-research``, saved
+        ``/<name>``): expand its directive prompt for the client to submit as a
+        user turn — the model then launches the run via the Workflow tool."""
+        try:
+            from src.workflow.gating import is_workflows_enabled
+
+            if not is_workflows_enabled():
+                self._reply(request_id, {"ok": False, "error": "dynamic workflows are disabled"})
+                return
+            if not isinstance(name, str) or not name.strip():
+                self._reply(request_id, {"ok": False, "error": "missing workflow command name"})
+                return
+            from src.command_system.argument_substitution import substitute_arguments
+            from src.command_system.types import PromptCommand
+            from src.command_system.workflows_integration import load_workflow_commands
+
+            wanted = name.strip().lstrip("/").lower()
+            for c in load_workflow_commands(self.cwd):
+                if isinstance(c, PromptCommand) and c.name.lower() == wanted:
+                    arg_str = args if isinstance(args, str) else ""
+                    prompt = substitute_arguments(c.markdown_content, arg_str, c.arg_names)
+                    self._reply(request_id, {
+                        "ok": True,
+                        "prompt": prompt,
+                        "notice": f"⚡ launching workflow /{c.name}",
+                    })
+                    return
+            self._reply(request_id, {"ok": False, "error": f"unknown workflow command '{wanted}'"})
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[agent-server] workflow_command failed")
+            self._reply(request_id, {"ok": False, "error": str(exc)})
+
     def _do_wiki(self, request_id: object, action: object, path: object) -> None:
         """/wiki: init | status | ingest <path>. File-based project wiki under
         .clawcodex/wiki (the original's /wiki)."""
@@ -1121,7 +1275,15 @@ class _AgentSession:
 
     def _run_worker(self) -> None:
         while not self._stop.is_set():
-            item = self._inbox.get()
+            try:
+                item = self._inbox.get(timeout=0.5)
+            except _queue.Empty:
+                # Idle between turns: surface any background task (workflow /
+                # background agent) that finished since the last check — the
+                # old REPL's turn-boundary drain, on a poll instead of a
+                # blocking prompt.
+                self._deliver_task_notifications()
+                continue
             if item is _SHUTDOWN or self._stop.is_set():
                 break
             if isinstance(item, dict) and item.get("__btw__"):  # side question (/btw)
@@ -1130,11 +1292,76 @@ class _AgentSession:
             if not isinstance(item, (str, list)):  # str prompt, or multimodal blocks
                 continue
             self._run_turn(item)
+            # A task that finished while the turn ran is delivered right after.
+            self._deliver_task_notifications()
         self._close_stream()
 
-    def _run_turn(self, prompt, btw: bool = False) -> None:  # prompt: str | list[ContentBlock]
+    def _deliver_task_notifications(self) -> bool:
+        """Drain finished-task ``<task-notification>`` envelopes: emit one
+        completion-banner frame per task, then hand the envelopes to the agent
+        as ONE internal turn so it summarizes the results conversationally (the
+        "the research is done…" behavior the workflow directives promise).
+
+        The ``task-notification`` queue is shared by dynamic workflows AND
+        background agents (``enqueue_workflow_notification`` /
+        ``enqueue_agent_notification``) — this consumer intentionally delivers
+        both. Runs on the worker thread strictly between turns, so it can never
+        interleave with a user turn. Returns whether anything was delivered.
+
+        CAVEAT (single-session-per-process assumption): the queue is
+        process-global while sessions are per-connection, so in a
+        multi-session process (DirectConnectServer spawns one agent per WS
+        connection) whichever worker polls first would drain EVERY session's
+        envelopes into its own conversation. Fine for the shipped stdio
+        deployment (one session per process); per-session scoping is required
+        before multi-session ``cc://`` ships.
+        """
+        if self.init_error is not None or self._stop.is_set():
+            return False
+        try:
+            from src.utils.message_queue_manager import drain_pending_notifications
+
+            drained = drain_pending_notifications(mode="task-notification")
+        except Exception:  # noqa: BLE001 — delivery must never kill the worker
+            logger.debug("[agent-server] notification drain failed", exc_info=True)
+            return False
+        if not drained:
+            return False
+
+        from src.server.task_notifications import (
+            build_notification_turn,
+            parse_task_id,
+            render_banner,
+        )
+
+        registry = getattr(self.tool_context, "runtime_tasks", None)
+        envelopes = [n.value for n in drained]
+        for xml in envelopes:
+            task_id = parse_task_id(xml)
+            state = None
+            if registry is not None and task_id:
+                try:
+                    state = registry.get(task_id)
+                except Exception:  # noqa: BLE001
+                    state = None
+            self._emit({
+                "type": "system",
+                "subtype": "task_notification",
+                "session_id": self.session_id,
+                "task_id": task_id or "task",
+                "message": "\n".join(render_banner(xml, state)),
+            })
+
+        # Let the agent read the results and report conversationally.
+        self._run_turn(build_notification_turn(envelopes), internal=True)
+        return True
+
+    def _run_turn(self, prompt, btw: bool = False, internal: bool = False) -> None:
+        # prompt: str | list[ContentBlock]
         # btw=True → a "side question" (the original's /btw): run with full context
         # but DON'T persist the Q&A, so the main conversation isn't interrupted.
+        # internal=True → a system-generated turn (task-notification delivery):
+        # skip user-turn decorations like the ultracode reminder.
         from src.query.agent_loop_compat import run_query_as_agent_loop
 
         if self.init_error is not None:
@@ -1143,6 +1370,14 @@ class _AgentSession:
                 result=self.init_error, is_error=True, error=self.init_error,
             ))
             return
+
+        # ultracode (workflow-engine §4.1): the `ultracode` keyword in this
+        # message, or the session-long `/effort ultracode` mode, appends a
+        # <system-reminder> nudging the model to author a workflow rather than
+        # working turn by turn. No-op when workflows are disabled; skipped for
+        # internal turns so a notification envelope can never trigger it.
+        if not internal:
+            prompt = _with_ultracode_reminder(prompt)
 
         abort = AbortController()
         with self._lock:
@@ -1505,6 +1740,36 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
     except Exception as exc:  # noqa: BLE001
         logger.exception("[agent-server] runtime build failed")
         sess.init_error = f"agent-server failed to start: {exc}"
+
+
+def _with_ultracode_reminder(prompt):
+    """Append the ultracode ``<system-reminder>`` to a user turn when the
+    keyword / session mode calls for it (:mod:`src.workflow.ultracode` — the
+    seam the deleted REPL provided at ``core.py:3163``). Handles both prompt
+    shapes the inbox carries: a plain string, or a content-block list
+    (multimodal) — detection joins the text blocks and the reminder lands as an
+    extra text block. Returns the prompt unchanged when no reminder applies."""
+    try:
+        from src.workflow.ultracode import ultracode_reminder_for
+
+        if isinstance(prompt, str):
+            reminder = ultracode_reminder_for(prompt)
+            if reminder:
+                return f"{prompt}\n\n{reminder}" if prompt else reminder
+            return prompt
+        if isinstance(prompt, list):
+            text = "\n".join(
+                str(b.get("text", ""))
+                for b in prompt
+                if isinstance(b, dict) and b.get("type") == "text"
+            )
+            reminder = ultracode_reminder_for(text)
+            if reminder:
+                return [*prompt, {"type": "text", "text": reminder}]
+            return prompt
+    except Exception:  # noqa: BLE001 — the reminder must never break a turn
+        logger.debug("[agent-server] ultracode reminder failed", exc_info=True)
+    return prompt
 
 
 def _filter_registry(registry, *, keep) -> None:

--- a/src/server/task_notifications.py
+++ b/src/server/task_notifications.py
@@ -1,0 +1,173 @@
+"""Server-side delivery helpers for background-task completion notifications.
+
+Background workflows (and background agents) run on daemon threads. When one
+finishes it pushes a ``<task-notification>`` envelope onto the process-global
+queue in :mod:`src.utils.message_queue_manager` (see
+``src.tasks.local_workflow.enqueue_workflow_notification`` and
+``src.tasks.local_agent``'s agent equivalent). The interactive consumer of that
+queue used to be the Rich REPL (``src/repl/task_notifications.py``, removed in
+#566); this module is its agent-server successor — the worker loop drains the
+queue between turns and, for every drained envelope:
+
+* emits a deterministic completion **banner** to the client (a
+  ``system/task_notification`` frame the TUI renders as a persistent transcript
+  line), and
+* hands the envelopes back to the agent as one **turn** so it can read the
+  result and summarize it conversationally — the Claude Code "the research is
+  done…" behavior.
+
+Everything here is pure and side-effect free (no emit, no registry mutation,
+no queue access) so it unit-tests without a live server; the glue in
+``src/server/agent_server.py`` is the thin part that wires it to the wire
+protocol and the worker inbox. Banners are plain text (the client styles its
+own transcript lines), unlike the Rich-markup originals.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+from src.constants.xml import (
+    OUTPUT_FILE_TAG,
+    STATUS_TAG,
+    SUMMARY_TAG,
+    TASK_ID_TAG,
+)
+from src.workflow.progress import format_duration, format_tokens
+
+# Status → (icon, past-tense verb) for the banner head.
+_BANNER_STYLE: dict[str, tuple[str, str]] = {
+    "completed": ("✔", "completed"),
+    "failed": ("✗", "failed"),
+    "killed": ("⊘", "stopped"),
+}
+
+
+def _field(xml: str, tag: str) -> Optional[str]:
+    m = re.search(rf"<{re.escape(tag)}>(.*?)</{re.escape(tag)}>", xml, re.DOTALL)
+    return m.group(1).strip() if m else None
+
+
+def parse_task_id(xml: str) -> Optional[str]:
+    """Pull the ``<task-id>`` out of a notification envelope (for registry
+    correlation), or ``None`` if absent."""
+    return _field(xml, TASK_ID_TAG)
+
+
+def _elapsed_seconds(state: Any) -> Optional[float]:
+    start = getattr(state, "start_time", None)
+    end = getattr(state, "end_time", None)
+    if isinstance(start, (int, float)) and isinstance(end, (int, float)) and end >= start:
+        return end - start
+    return None
+
+
+def _stat_bits(state: Any) -> list[str]:
+    progress = getattr(state, "progress", None)
+    bits: list[str] = []
+    try:
+        phases = list(getattr(progress, "phases", None) or [])
+        total = sum(len(p.agents) for p in phases)
+        if total:
+            bits.append(f"{total} agents")
+    except Exception:
+        pass
+    try:
+        tok = int(getattr(progress, "token_total", 0) or 0)
+        if tok:
+            bits.append(f"{format_tokens(tok)} tok")
+    except Exception:
+        pass
+    dur = format_duration(_elapsed_seconds(state))
+    if dur:
+        bits.append(dur)
+    return bits
+
+
+def _task_label(state: Any) -> str:
+    """Display name for a finished task: the workflow name for workflow runs,
+    the task description for background agents (which share the queue), then a
+    generic fallback."""
+    for attr in ("workflow_name", "description"):
+        val = getattr(state, attr, None)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    return "task"
+
+
+def format_completion_banner(state: Any) -> list[str]:
+    """Deterministic completion banner (plain-text lines) from a terminal
+    ``local_workflow`` / ``local_agent`` task state.
+
+    Never raises — every field degrades to a sensible default, because this
+    runs on the agent-server worker loop where an exception would be
+    disruptive.
+    """
+    status = (getattr(state, "status", "") or "").lower()
+    icon, verb = _BANNER_STYLE.get(status, ("•", status or "finished"))
+    name = _task_label(state)
+
+    tail = (" · " + " · ".join(bits)) if (bits := _stat_bits(state)) else ""
+    lines = [f"{icon} {name} {verb}{tail}"]
+
+    if status == "failed":
+        err = getattr(state, "error", None)
+        if err:
+            lines.append(f"  {err}")
+    out = getattr(state, "output_file", None)
+    if out:
+        lines.append(f"  run journal → {out}")
+    return lines
+
+
+def format_completion_banner_xml(xml: str) -> list[str]:
+    """Fallback banner built straight from an envelope, for the rare case where
+    the task state has already been evicted by delivery time."""
+    status = (_field(xml, STATUS_TAG) or "").lower()
+    icon, _verb = _BANNER_STYLE.get(status, ("•", status or "finished"))
+    summary = _field(xml, SUMMARY_TAG) or "Background task finished"
+    lines = [f"{icon} {summary}"]
+    out = _field(xml, OUTPUT_FILE_TAG)
+    if out:
+        lines.append(f"  run journal → {out}")
+    return lines
+
+
+def render_banner(xml: str, state: Any | None) -> list[str]:
+    """Prefer the rich registry-state banner; fall back to the envelope."""
+    if state is not None:
+        try:
+            return format_completion_banner(state)
+        except Exception:
+            pass
+    return format_completion_banner_xml(xml)
+
+
+_TURN_PREAMBLE = (
+    "<system-reminder>\n"
+    "One or more background tasks you launched have finished. Their results are "
+    "delivered below as <task-notification> envelopes — these are system events, "
+    "not a new request the user typed. For each finished task: briefly confirm "
+    "it's done, summarize the key findings or output for the user, and tell them "
+    "where the full result is saved (the <output-file>, or any file path named "
+    "inside the <result>). If the <result> points at a file you must read to "
+    "report it accurately (for example a CSV), read it first. Keep it concise.\n"
+    "</system-reminder>"
+)
+
+
+def build_notification_turn(notifications: list[str]) -> str:
+    """Assemble drained ``<task-notification>`` envelopes into a single agent
+    turn: a guiding preamble followed by the raw envelopes."""
+    body = "\n\n".join(n.strip() for n in notifications if n and n.strip())
+    return f"{_TURN_PREAMBLE}\n\n{body}"
+
+
+__all__ = [
+    "parse_task_id",
+    "format_completion_banner",
+    "format_completion_banner_xml",
+    "render_banner",
+    "build_notification_turn",
+]

--- a/tests/server/test_agent_server_workflows.py
+++ b/tests/server/test_agent_server_workflows.py
@@ -1,0 +1,344 @@
+"""Integration tests for the agent-server's workflow surfaces.
+
+The dynamic-workflow UX used to live in the deleted Rich REPL / Textual TUI
+(#566); these tests pin its agent-server replacements:
+
+  * the ``ultracode`` keyword appends the authoring ``<system-reminder>`` to
+    the model-visible user turn (and only to that turn),
+  * ``set_effort`` handles ``ultracode`` (session mode on/off, read-only
+    report, workflows-disabled gating),
+  * the ``workflows`` / ``list_workflow_commands`` / ``workflow_command``
+    controls (report text, catalog, directive expansion, gating), and
+  * the worker loop drains finished-task ``<task-notification>`` envelopes:
+    one banner frame per task + ONE internal summarization turn that skips
+    the ultracode reminder.
+
+They reuse the spawn-handle harness from ``test_agent_server_e2e`` (real
+``_build_runtime`` with the provider stubbed — no network).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+
+from src.server.agent_server import AgentServerConfig, make_spawn_agent
+from src.utils.message_queue_manager import (
+    clear_pending_notifications,
+    enqueue_pending_notification,
+)
+from src.workflow.ultracode import is_ultracode_session, reset_ultracode
+from tests.server.test_agent_server_e2e import (
+    _RECORDED_TURNS,
+    _patches,
+    _RecordingProvider,
+    _TextProvider,
+    _wait_for,
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def _workflow_state_hygiene(monkeypatch):
+    """The ultracode session flag and the notification queue are process-global;
+    isolate every test from its neighbors (and from the developer's env)."""
+    monkeypatch.delenv("CLAUDE_CODE_DISABLE_WORKFLOWS", raising=False)
+    reset_ultracode()
+    clear_pending_notifications()
+    yield
+    reset_ultracode()
+    clear_pending_notifications()
+
+
+@contextlib.asynccontextmanager
+async def _spawned(tmp_path, provider_cls, config: AgentServerConfig | None = None):
+    """A live agent handle (worker running) + its message generator."""
+    from src.tool_system.registry import ToolRegistry
+
+    with contextlib.ExitStack() as stack:
+        for p in _patches(provider_cls, ToolRegistry([])):
+            stack.enter_context(p)
+        spawn = make_spawn_agent(config or AgentServerConfig())
+        handle = await spawn("wf_test", str(tmp_path), None)
+        gen = handle.messages_from_agent()
+        init = await asyncio.wait_for(gen.__anext__(), timeout=10)
+        assert init["subtype"] == "init"
+        try:
+            yield handle, gen
+        finally:
+            await handle.shutdown()
+            with contextlib.suppress(Exception):
+                await gen.aclose()
+
+
+async def _control(handle, gen, rid: str, request: dict) -> dict:
+    """Send one control_request and return its reply payload."""
+    await handle.send_to_agent({"type": "control_request", "request_id": rid, "request": request})
+    for _ in range(20):
+        msg = await asyncio.wait_for(gen.__anext__(), timeout=5)
+        if msg.get("type") == "control_response" and msg["response"].get("request_id") == rid:
+            return msg["response"]["response"]
+    raise AssertionError(f"no reply for {rid}")
+
+
+def _session_of(handle):
+    """The underlying ``_AgentSession`` (send_to_agent is a bound method)."""
+    return handle.send_to_agent.__self__
+
+
+def _last_user_message(turn: str) -> str:
+    """Last message of a ``_RecordingProvider`` turn record (`` || ``-joined)."""
+    return turn.split(" || ")[-1]
+
+
+# ─── ultracode keyword injection ──────────────────────────────────────────────
+
+
+async def test_ultracode_keyword_appends_reminder(tmp_path):
+    _RECORDED_TURNS.clear()
+    async with _spawned(tmp_path, _RecordingProvider) as (handle, gen):
+        await handle.send_to_agent(
+            {"type": "user", "message": {"role": "user", "content": "ultracode: build a report tool"}}
+        )
+        assert await _wait_for(lambda: len(_RECORDED_TURNS) == 1)
+        turn = _last_user_message(_RECORDED_TURNS[0])
+        assert "ultracode: build a report tool" in turn
+        assert "WRITE a reusable" in turn, "keyword did not append the authoring reminder"
+
+        await handle.send_to_agent(
+            {"type": "user", "message": {"role": "user", "content": "just a plain question"}}
+        )
+        assert await _wait_for(lambda: len(_RECORDED_TURNS) == 2)
+        assert "WRITE a reusable" not in _last_user_message(_RECORDED_TURNS[1])
+
+
+async def test_ultracode_session_mode_reminds_every_turn(tmp_path):
+    _RECORDED_TURNS.clear()
+    async with _spawned(tmp_path, _RecordingProvider) as (handle, gen):
+        r = await _control(handle, gen, "e1", {"subtype": "set_effort", "effort": "ultracode"})
+        assert r == {"ok": True, "effort": "ultracode", "ultracode": True}
+        assert is_ultracode_session()
+
+        await handle.send_to_agent(
+            {"type": "user", "message": {"role": "user", "content": "refactor the parser"}}
+        )
+        assert await _wait_for(lambda: len(_RECORDED_TURNS) == 1)
+        assert "Ultracode is on for this session" in _last_user_message(_RECORDED_TURNS[0])
+
+
+# ─── set_effort: ultracode + levels + gating ──────────────────────────────────
+
+
+async def test_set_effort_levels_and_ultracode_roundtrip(tmp_path):
+    async with _spawned(tmp_path, _TextProvider) as (handle, gen):
+        sess = _session_of(handle)
+
+        r = await _control(handle, gen, "e1", {"subtype": "set_effort", "effort": "ultracode"})
+        assert r["ok"] is True and r["effort"] == "ultracode"
+        assert is_ultracode_session()
+        assert sess._effort is None, "ultracode must not touch the reasoning level"
+
+        # A real level exits ultracode mode.
+        r = await _control(handle, gen, "e2", {"subtype": "set_effort", "effort": "high"})
+        assert r == {"ok": True, "effort": "high", "ultracode": False}
+        assert not is_ultracode_session()
+        assert sess._effort == "high"
+
+        # Bare /effort is a read-only report (no clearing).
+        r = await _control(handle, gen, "e3", {"subtype": "set_effort"})
+        assert r == {"ok": True, "effort": "high", "ultracode": False}
+        assert sess._effort == "high"
+
+        # Explicit auto clears the level (and would exit ultracode mode).
+        r = await _control(handle, gen, "e4", {"subtype": "set_effort", "effort": "auto"})
+        assert r == {"ok": True, "effort": "default", "ultracode": False}
+        assert sess._effort is None
+
+        # Unknown value → error, nothing mutated.
+        r = await _control(handle, gen, "e5", {"subtype": "set_effort", "effort": "bogus"})
+        assert r["ok"] is False and "invalid effort" in r["error"]
+
+
+async def test_set_effort_ultracode_gated_when_workflows_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")
+    async with _spawned(tmp_path, _TextProvider) as (handle, gen):
+        r = await _control(handle, gen, "e1", {"subtype": "set_effort", "effort": "ultracode"})
+        assert r["ok"] is False and "disabled" in r["error"]
+        assert not is_ultracode_session()
+
+
+# ─── workflows control (the /workflows report) ────────────────────────────────
+
+
+async def test_workflows_control_reports_runs(tmp_path):
+    from types import SimpleNamespace
+
+    async with _spawned(tmp_path, _TextProvider) as (handle, gen):
+        r = await _control(handle, gen, "w1", {"subtype": "workflows"})
+        assert r["ok"] is True and "No workflow runs" in r["text"]
+
+        # Seed a run into the session's live registry — same object the
+        # Workflow tool records into.
+        sess = _session_of(handle)
+        sess.tool_context.runtime_tasks.upsert(
+            SimpleNamespace(
+                id="local_workflow_9",
+                type="local_workflow",
+                status="running",
+                workflow_name="deep-research",
+                run_id="wf_seed01",
+                progress=None,
+            )
+        )
+        r = await _control(handle, gen, "w2", {"subtype": "workflows"})
+        assert r["ok"] is True
+        assert "deep-research  [running]" in r["text"]
+        assert "(run: wf_seed01)" in r["text"]
+
+
+async def test_workflows_control_gated_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")
+    async with _spawned(tmp_path, _TextProvider) as (handle, gen):
+        r = await _control(handle, gen, "w1", {"subtype": "workflows"})
+        assert r["ok"] is False and "disabled" in r["error"]
+
+
+# ─── workflow command catalog + dispatch ──────────────────────────────────────
+
+_SAVED_WF = 'meta = {"name": "triage", "description": "Sort issues", "phases": []}\nreturn 1\n'
+
+
+async def test_list_workflow_commands_includes_bundled_and_saved(tmp_path):
+    wf_dir = tmp_path / ".claude" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "triage.py").write_text(_SAVED_WF, encoding="utf-8")
+
+    async with _spawned(tmp_path, _TextProvider) as (handle, gen):
+        r = await _control(handle, gen, "l1", {"subtype": "list_workflow_commands"})
+        assert r["ok"] is True
+        by_name = {c["name"]: c for c in r["commands"]}
+        assert "deep-research" in by_name  # bundled
+        assert by_name["triage"]["description"] == "Sort issues"
+        # The interactive /workflows viewer is NOT a prompt command.
+        assert "workflows" not in by_name
+
+
+async def test_list_workflow_commands_empty_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")
+    async with _spawned(tmp_path, _TextProvider) as (handle, gen):
+        r = await _control(handle, gen, "l1", {"subtype": "list_workflow_commands"})
+        assert r["ok"] is True and r["commands"] == []
+
+
+async def test_workflow_command_expands_directive(tmp_path):
+    wf_dir = tmp_path / ".claude" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "triage.py").write_text(_SAVED_WF, encoding="utf-8")
+
+    async with _spawned(tmp_path, _TextProvider) as (handle, gen):
+        r = await _control(
+            handle, gen, "d1",
+            {"subtype": "workflow_command", "name": "triage", "args": "the open bug list"},
+        )
+        assert r["ok"] is True
+        assert str(wf_dir / "triage.py") in r["prompt"]
+        assert "the open bug list" in r["prompt"], "$ARGUMENTS was not substituted"
+        assert "$ARGUMENTS" not in r["prompt"]
+        assert r["notice"] == "⚡ launching workflow /triage"
+
+        r = await _control(
+            handle, gen, "d2", {"subtype": "workflow_command", "name": "nope", "args": ""}
+        )
+        assert r["ok"] is False and "unknown workflow command" in r["error"]
+
+        r = await _control(handle, gen, "d3", {"subtype": "workflow_command"})
+        assert r["ok"] is False
+
+
+async def test_workflow_command_gated_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "1")
+    async with _spawned(tmp_path, _TextProvider) as (handle, gen):
+        r = await _control(
+            handle, gen, "d1", {"subtype": "workflow_command", "name": "deep-research", "args": "x"}
+        )
+        assert r["ok"] is False and "disabled" in r["error"]
+
+
+# ─── task-notification delivery (worker loop drain) ───────────────────────────
+
+_WF_ENVELOPE = (
+    "<task-notification><task-id>local_workflow_7</task-id>"
+    "<status>completed</status><summary>Workflow deep-research completed</summary>"
+    "<output-file>/tmp/wf_7.jsonl</output-file>"
+    "<result>saved to /tmp/report.md</result></task-notification>"
+)
+_AGENT_ENVELOPE = (
+    "<task-notification><task-id>local_agent_3</task-id>"
+    "<status>completed</status><summary>Background agent finished: map the auth module</summary>"
+    "<result>see notes</result></task-notification>"
+)
+
+
+async def test_notification_drain_emits_banner_and_summary_turn(tmp_path):
+    _RECORDED_TURNS.clear()
+    frames: list[dict] = []
+    async with _spawned(tmp_path, _RecordingProvider) as (handle, gen):
+        async def _collect():
+            with contextlib.suppress(Exception):
+                async for msg in gen:
+                    frames.append(msg)
+
+        collector = asyncio.get_running_loop().create_task(_collect())
+        try:
+            enqueue_pending_notification(value=_WF_ENVELOPE)
+            enqueue_pending_notification(value=_AGENT_ENVELOPE)
+
+            # Worker's idle poll (0.5s) drains both → 2 banners + ONE turn.
+            assert await _wait_for(
+                lambda: len([f for f in frames if f.get("subtype") == "task_notification"]) == 2,
+                timeout=10,
+            ), "banner frames not emitted"
+            banners = [f for f in frames if f.get("subtype") == "task_notification"]
+            assert banners[0]["type"] == "system"
+            assert banners[0]["task_id"] == "local_workflow_7"
+            assert "✔ Workflow deep-research completed" in banners[0]["message"]
+            assert "run journal → /tmp/wf_7.jsonl" in banners[0]["message"]
+            # The agent envelope banners as its own summary — not as "workflow".
+            assert banners[1]["task_id"] == "local_agent_3"
+            assert "map the auth module" in banners[1]["message"]
+
+            # Both envelopes are delivered (normally as ONE batched turn; a
+            # worker poll landing between the two enqueues may split them —
+            # assert delivery across all turns rather than the batch shape).
+            assert await _wait_for(
+                lambda: "local_workflow_7" in "".join(_RECORDED_TURNS)
+                and "local_agent_3" in "".join(_RECORDED_TURNS),
+                timeout=10,
+            ), "both envelopes must be delivered to the model"
+            assert "background tasks you launched have finished" in _RECORDED_TURNS[0]
+            # The summarization turn also streams a normal result frame.
+            assert await _wait_for(
+                lambda: any(f.get("type") == "result" for f in frames), timeout=10
+            )
+        finally:
+            collector.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await collector
+
+
+async def test_notification_turn_is_internal_no_ultracode_reminder(tmp_path):
+    """Session-mode ultracode must not decorate system-generated turns — an
+    envelope can never trigger workflow authoring."""
+    _RECORDED_TURNS.clear()
+    async with _spawned(tmp_path, _RecordingProvider) as (handle, gen):
+        r = await _control(handle, gen, "e1", {"subtype": "set_effort", "effort": "ultracode"})
+        assert r["ok"] is True
+
+        enqueue_pending_notification(value=_WF_ENVELOPE)
+        assert await _wait_for(lambda: len(_RECORDED_TURNS) >= 1, timeout=10)
+        turn = _last_user_message(_RECORDED_TURNS[0])
+        assert "background tasks you launched have finished" in turn
+        assert "Ultracode is on for this session" not in turn

--- a/tests/server/test_task_notifications.py
+++ b/tests/server/test_task_notifications.py
@@ -1,0 +1,156 @@
+"""Unit tests for the server-side task-notification helpers
+(:mod:`src.server.task_notifications`) and the shared ``/workflows`` report
+renderer (:func:`src.command_system.workflows_command.render_workflows_report`).
+
+These are the pure pieces the agent-server worker loop composes to deliver
+background-task completions (the old REPL consumer's successor)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.command_system.workflows_command import (
+    NO_WORKFLOW_RUNS_MESSAGE,
+    render_workflows_report,
+)
+from src.server.task_notifications import (
+    build_notification_turn,
+    format_completion_banner,
+    format_completion_banner_xml,
+    parse_task_id,
+    render_banner,
+)
+
+
+def _phase(agents_done: int, agents_total: int, tokens: int = 0):
+    agents = [
+        SimpleNamespace(
+            icon="✔", label=f"a{i}", agent_type="", tokens=10, tool_count=0,
+            elapsed=None, error=None,
+        )
+        for i in range(agents_total)
+    ]
+    return SimpleNamespace(title="Search", agents=agents, done_count=agents_done, token_total=tokens)
+
+
+def _workflow_state(**over):
+    base = dict(
+        type="local_workflow",
+        status="completed",
+        workflow_name="deep-research",
+        description="",
+        run_id="wf_abc123",
+        progress=SimpleNamespace(phases=[_phase(2, 2, tokens=1500)], token_total=45_200),
+        start_time=100.0,
+        end_time=292.0,
+        output_file="/tmp/wf_abc123.jsonl",
+        error=None,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+ENVELOPE = (
+    "<task-notification><task-id>local_workflow_1</task-id>"
+    "<status>completed</status><summary>deep-research finished</summary>"
+    "<output-file>/tmp/wf_abc123.jsonl</output-file>"
+    "<result>report at /tmp/report.md</result></task-notification>"
+)
+
+
+# ─── envelope parsing / banners ───────────────────────────────────────────────
+
+
+def test_parse_task_id():
+    assert parse_task_id(ENVELOPE) == "local_workflow_1"
+    assert parse_task_id("<task-notification></task-notification>") is None
+
+
+def test_banner_from_workflow_state_is_plain_text():
+    lines = format_completion_banner(_workflow_state())
+    assert lines[0].startswith("✔ deep-research completed")
+    assert "2 agents" in lines[0]
+    assert "45.2k tok" in lines[0]
+    assert "3m 12s" in lines[0]
+    assert lines[-1] == "  run journal → /tmp/wf_abc123.jsonl"
+    # De-Rich'd: no rich markup tags survive.
+    assert not any("[green]" in ln or "[bold]" in ln for ln in lines)
+
+
+def test_banner_labels_background_agent_by_description():
+    """The task-notification queue is shared with background agents — a state
+    without ``workflow_name`` banners as its description, not as 'workflow'."""
+    state = _workflow_state(workflow_name="", description="Explore: map the auth module")
+    lines = format_completion_banner(state)
+    assert lines[0].startswith("✔ Explore: map the auth module completed")
+
+
+def test_banner_failed_includes_error():
+    lines = format_completion_banner(
+        _workflow_state(status="failed", error="budget exhausted", progress=None)
+    )
+    assert lines[0].startswith("✗ deep-research failed")
+    assert "  budget exhausted" in lines
+    assert any("run journal" in ln for ln in lines)
+
+
+def test_banner_xml_fallback_and_render_banner():
+    lines = format_completion_banner_xml(ENVELOPE)
+    assert lines[0] == "✔ deep-research finished"
+    assert lines[1] == "  run journal → /tmp/wf_abc123.jsonl"
+    # render_banner prefers state, falls back to the envelope.
+    assert render_banner(ENVELOPE, None) == lines
+    assert render_banner(ENVELOPE, _workflow_state())[0].startswith("✔ deep-research completed")
+
+
+def test_build_notification_turn_assembles_preamble_and_envelopes():
+    turn = build_notification_turn([ENVELOPE, "", "  <task-notification>x</task-notification>  "])
+    assert turn.startswith("<system-reminder>")
+    assert "background tasks you launched have finished" in turn
+    assert ENVELOPE in turn
+    assert turn.rstrip().endswith("<task-notification>x</task-notification>")
+
+
+# ─── /workflows report renderer ───────────────────────────────────────────────
+
+
+class _FakeRegistry:
+    def __init__(self, tasks):
+        self._tasks = tasks
+
+    def all(self):
+        return list(self._tasks)
+
+
+def test_render_workflows_report_none_when_empty():
+    assert render_workflows_report(None) is None
+    assert render_workflows_report(_FakeRegistry([])) is None
+    assert render_workflows_report(
+        _FakeRegistry([SimpleNamespace(type="local_agent")])
+    ) is None
+    assert "No workflow runs" in NO_WORKFLOW_RUNS_MESSAGE
+
+
+def test_render_workflows_report_lists_runs_with_run_id():
+    report = render_workflows_report(_FakeRegistry([_workflow_state()]))
+    assert report is not None
+    assert report.splitlines()[0].startswith("deep-research  [completed]")
+    assert "(run: wf_abc123)" in report.splitlines()[0]
+    assert any("▸ Search" in ln for ln in report.splitlines())
+
+
+def test_render_workflows_report_degrades_per_run():
+    """A run whose live progress object explodes mid-render must not take the
+    report down — it degrades to a header-only line."""
+
+    class _Boom:
+        @property
+        def phases(self):
+            raise RuntimeError("mutated mid-render")
+
+    bad = _workflow_state(progress=_Boom(), workflow_name="angry")
+    good = _workflow_state()
+    report = render_workflows_report(_FakeRegistry([bad, good]))
+    assert report is not None
+    assert "angry  [completed]  (progress unavailable)" in report
+    assert "deep-research  [completed]" in report

--- a/tests/server/test_tui_launcher.py
+++ b/tests/server/test_tui_launcher.py
@@ -25,7 +25,9 @@ def test_resolve_tui_dir_finds_repo_client():
     found = _resolve_tui_dir(None)
     assert found is not None, "expected to find ui-tui by walking up from the package"
     assert found.name == "ui-tui"
-    assert (found / "src" / "cli.tsx").exists()
+    # entry.tsx is the client entrypoint (the hermes-port rename of cli.tsx) —
+    # the same marker _resolve_tui_dir itself probes for.
+    assert (found / "src" / "entry.tsx").exists()
 
 
 def test_agent_server_cmd_invokes_module():

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -307,6 +307,27 @@ describe('createSlashHandler', () => {
     expect(ctx.gateway.gw.request).toHaveBeenCalledWith('slash.exec', expect.objectContaining({ command: 'pet boba' }))
   })
 
+  it('submits a send-dispatch payload without echoing it as a user bubble', async () => {
+    // Workflow commands (/deep-research, saved .claude/workflows) resolve to
+    // {type:'send'}: the notice is printed, the expanded directive is submitted
+    // silently — the typed slash line is already in the transcript.
+    const request = vi.fn((method: string) =>
+      method === 'slash.exec'
+        ? Promise.resolve({
+            message: 'Launch the dynamic workflow "deep-research"…',
+            notice: '⚡ launching workflow /deep-research',
+            type: 'send'
+          })
+        : Promise.resolve({})
+    )
+    const ctx = buildCtx({ gateway: { ...buildGateway(), gw: { getLogTail: vi.fn(() => ''), kill: vi.fn(), request } } })
+
+    expect(createSlashHandler(ctx)('/deep-research what is love')).toBe(true)
+    await vi.waitFor(() => expect(ctx.transcript.send).toHaveBeenCalled())
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('⚡ launching workflow /deep-research')
+    expect(ctx.transcript.send).toHaveBeenCalledWith('Launch the dynamic workflow "deep-research"…', false)
+  })
+
   it('routes /skills inspect <name> to skills.manage', () => {
     const ctx = buildCtx()
 
@@ -591,7 +612,7 @@ describe('createSlashHandler', () => {
 
     expect(createSlashHandler(ctx)('/indicator sparkle')).toBe(true)
     expect(rpc).not.toHaveBeenCalled()
-    expect(ctx.transcript.sys).toHaveBeenCalledWith('usage: /indicator [ascii|emoji|kaomoji|unicode]')
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('usage: /indicator [ascii|emoji|kaomoji|star|unicode]')
   })
 
   it('drops stale slash.exec output after a newer slash', async () => {
@@ -778,7 +799,9 @@ describe('createSlashHandler', () => {
         '⊙ Goal set (20-turn budget): complete all the steps and provide a final report'
       )
     })
-    expect(ctx.transcript.send).toHaveBeenCalledWith('complete all the steps and provide a final report')
+    // The payload is submitted without a user-bubble echo (showUserMessage:
+    // false) — the typed slash line is already in the transcript.
+    expect(ctx.transcript.send).toHaveBeenCalledWith('complete all the steps and provide a final report', false)
     expect(ctx.transcript.sys).not.toHaveBeenCalledWith('/goal: no output')
     expect(ctx.gateway.gw.request).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
   })

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -164,4 +164,109 @@ describe('GatewayClient NDJSON adapter', () => {
     expect(p.inline_diff).toContain('-a')
     expect(p.inline_diff).toContain('+b')
   })
+
+  // ── workflow surfaces ──────────────────────────────────────────────────────
+
+  /** Requests the client wrote to the agent-server's stdin, parsed. */
+  const stdinFrames = (): any[] => {
+    const raw = (proc.stdin as any).read()?.toString() ?? ''
+    return raw
+      .split('\n')
+      .filter(Boolean)
+      .map((l: string) => JSON.parse(l))
+  }
+
+  /** Wait for the client to send a control_request of `subtype`, then feed the
+   *  matching control_response back on stdout. `seen` accumulates the stdin
+   *  frames of the CURRENT test only (fresh proc per test) — reset per test so
+   *  a stale frame from a prior client can never misroute a reply. */
+  let seen: any[] = []
+  beforeEach(() => {
+    seen = []
+  })
+  const replyToControl = async (subtype: string, response: unknown) => {
+    let req: any
+    await vi.waitFor(() => {
+      seen.push(...stdinFrames())
+      req = seen.find(f => f.type === 'control_request' && f.request?.subtype === subtype)
+      expect(req).toBeTruthy()
+    })
+    proc.line({ response: { request_id: req.request_id, response }, type: 'control_response' })
+  }
+
+  it('maps /workflows to the workflows control and prints its report', async () => {
+    const p = gw.request('slash.exec', { command: 'workflows' })
+    await replyToControl('workflows', { ok: true, text: 'deep-research  [running]  (run: wf_1)' })
+    await expect(p).resolves.toEqual({ output: 'deep-research  [running]  (run: wf_1)', type: 'exec' })
+  })
+
+  it('dispatches an unknown slash as a backend workflow command (send)', async () => {
+    const p = gw.request('slash.exec', { command: 'deep-research what is love' })
+    await replyToControl('workflow_command', {
+      notice: '⚡ launching workflow /deep-research',
+      ok: true,
+      prompt: 'Launch the dynamic workflow "deep-research" — args: what is love'
+    })
+    await expect(p).resolves.toEqual({
+      message: 'Launch the dynamic workflow "deep-research" — args: what is love',
+      notice: '⚡ launching workflow /deep-research',
+      type: 'send'
+    })
+    const req = seen.find(f => f.request?.subtype === 'workflow_command')
+    expect(req.request).toMatchObject({ args: 'what is love', name: 'deep-research' })
+  })
+
+  it('reports unknown commands as unwired when the backend does not own them', async () => {
+    const p = gw.request('slash.exec', { command: 'frobnicate now' })
+    await replyToControl('workflow_command', { error: "unknown workflow command 'frobnicate'", ok: false })
+    await expect(p).resolves.toEqual({ output: "/frobnicate isn't wired into the clawcodex backend yet.", type: 'exec' })
+  })
+
+  it('merges backend workflow commands into slash completion', async () => {
+    const p = gw.request<{ items: Array<{ text: string }> }>('complete.slash', { text: '/de' })
+    await replyToControl('list_workflow_commands', {
+      commands: [{ argument_hint: '<question>', description: 'Deep research', name: 'deep-research' }],
+      ok: true
+    })
+    const r = await p
+    expect(r.items.map(i => i.text)).toContain('/deep-research')
+  })
+
+  it('merges backend workflow commands into the command catalog after init', async () => {
+    proc.line(INIT) // resolves readyPromise, which the catalog awaits
+    const p = gw.request<{ canon: Record<string, string>; pairs: [string, string][] }>('commands.catalog', {})
+    await replyToControl('list_workflow_commands', {
+      commands: [{ description: 'Deep research', name: 'deep-research' }],
+      ok: true
+    })
+    const r = await p
+    expect(r.canon['/deep-research']).toBe('/deep-research')
+    expect(r.pairs).toContainEqual(['/deep-research', 'Deep research'])
+    // The static set is still present (workflow merge is additive).
+    expect(r.canon['/workflows']).toBe('/workflows')
+  })
+
+  it('degrades the catalog to the static set when the workflow list is unavailable', async () => {
+    proc.line(INIT)
+    const p = gw.request<{ canon: Record<string, string>; pairs: [string, string][] }>('commands.catalog', {})
+    await replyToControl('list_workflow_commands', { commands: [], ok: true })
+    const r = await p
+    expect(r.canon['/workflows']).toBe('/workflows')
+    expect(r.pairs.some(([name]) => name === '/deep-research')).toBe(false)
+  })
+
+  it('renders a task_notification frame as a background.complete banner', async () => {
+    proc.line({
+      message: '✔ deep-research completed · 12 agents · 45.2k tok',
+      session_id: 's1',
+      subtype: 'task_notification',
+      task_id: 'local_workflow_7',
+      type: 'system'
+    })
+    await vi.waitFor(() => expect(last('background.complete')).toBeTruthy())
+    expect(last('background.complete').payload).toEqual({
+      task_id: 'local_workflow_7',
+      text: '✔ deep-research completed · 12 agents · 45.2k tok'
+    })
+  })
 })

--- a/ui-tui/src/app/createSlashHandler.ts
+++ b/ui-tui/src/app/createSlashHandler.ts
@@ -100,7 +100,10 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
           sys(d.notice)
         }
 
-        return d.message?.trim() ? send(d.message) : sys(`/${parsed.name}: empty message`)
+        // Submit without echoing the expanded payload as a user bubble — the
+        // typed slash line is already in the transcript (dispatchSubmission
+        // appends it as kind:'slash' before invoking this handler).
+        return d.message?.trim() ? send(d.message, false) : sys(`/${parsed.name}: empty message`)
       }
 
       if (d.type === 'prefill') {

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -363,7 +363,7 @@ export interface SlashHandlerContext {
   transcript: {
     page: (text: string, title?: string) => void
     panel: (title: string, sections: PanelSection[]) => void
-    send: (text: string) => void
+    send: (text: string, showUserMessage?: boolean) => void
     setHistoryItems: StateSetter<Msg[]>
     sys: (text: string) => void
     trimLastExchange: (items: Msg[]) => Msg[]

--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -137,7 +137,7 @@ process.on('beforeExit', () => stopMemoryMonitor())
 
 const [ink, { App }, { logFrameEvent }, { trackFrame }] = await Promise.all([
   import('@clawcodex/ink'),
-  import('./app.js'),
+  import('./App.js'),
   import('./lib/perfPane.js'),
   import('./lib/fpsStore.js')
 ])

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -93,8 +93,9 @@ const SLASHES: ReadonlyArray<{ desc: string; name: string }> = [
   { desc: 'Show context-window usage', name: '/context' },
   { desc: 'Undo recent turns', name: '/rewind' },
   { desc: 'Toggle extended thinking', name: '/thinking' },
-  { desc: 'Set reasoning effort', name: '/effort' },
+  { desc: 'Set reasoning effort (or "ultracode" workflow mode)', name: '/effort' },
   { desc: 'Switch the provider', name: '/provider' },
+  { desc: 'List running and recent dynamic workflows', name: '/workflows' },
   { desc: 'Search / manage the knowledge base', name: '/knowledge' },
   { desc: 'View or set the plan', name: '/plan' },
   { desc: 'Generate session insights', name: '/insights' },
@@ -104,6 +105,15 @@ const SLASHES: ReadonlyArray<{ desc: string; name: string }> = [
 ]
 
 type Pending = { reject: (e: Error) => void; resolve: (v: unknown) => void }
+
+/** A workflow slash command reported by the backend (`list_workflow_commands`):
+ *  bundled /deep-research plus saved `.claude/workflows/*.py`. */
+type WorkflowCommand = { argument_hint?: string; description?: string; name: string }
+
+/** How long a fetched workflow-command list stays fresh. The slash menu
+ *  re-queries per keystroke; the TTL keeps that to ~1 RPC per burst while a
+ *  workflow authored mid-session (ultracode flow) still shows up promptly. */
+const WORKFLOW_CMDS_TTL_MS = 3_000
 
 export class GatewayClient extends EventEmitter {
   private buffered: GatewayEvent[] = []
@@ -123,6 +133,9 @@ export class GatewayClient extends EventEmitter {
   private sessionId = ''
   private sessionInfo: null | SessionInfo = null
   private subscribed = false
+  // Backend workflow commands (slash menu + dispatch), TTL-cached.
+  private wfCommands: WorkflowCommand[] = []
+  private wfFetchedAt = 0
 
   constructor() {
     super()
@@ -219,19 +232,40 @@ export class GatewayClient extends EventEmitter {
     switch (method) {
       // ── startup handshake ────────────────────────────────────────────────
       case 'commands.catalog': {
-        const pairs = SLASHES.map(s => [s.name, s.desc] as [string, string])
-        const canon: Record<string, string> = {}
-        for (const s of SLASHES) canon[s.name] = s.name
-        return Promise.resolve({ canon, categories: [], pairs, skill_count: 0, sub: {} } as T)
+        // Await the backend so the catalog can include its workflow commands
+        // (/deep-research + saved .claude/workflows) alongside the static set.
+        return this.readyPromise
+          .then(() => this.fetchWorkflowCommands())
+          .catch(() => [] as WorkflowCommand[])
+          .then(wf => {
+            const pairs = SLASHES.map(s => [s.name, s.desc] as [string, string])
+            const canon: Record<string, string> = {}
+            for (const s of SLASHES) canon[s.name] = s.name
+            for (const w of wf) {
+              const name = `/${w.name}`
+              if (canon[name]) continue
+              canon[name] = name
+              pairs.push([name, w.description ?? 'Run a dynamic workflow'])
+            }
+            return { canon, categories: [], pairs, skill_count: 0, sub: {} } as T
+          })
       }
       case 'complete.slash': {
         const text = String(p.text ?? '').toLowerCase() || '/'
-        const items = SLASHES.filter(s => s.name.toLowerCase().startsWith(text)).map(s => ({
-          display: s.name,
-          meta: s.desc,
-          text: s.name
-        }))
-        return Promise.resolve({ items, replace_from: 1 } as T)
+        return this.fetchWorkflowCommands()
+          .catch(() => [] as WorkflowCommand[])
+          .then(wf => {
+            const entries = [
+              ...SLASHES,
+              ...wf
+                .filter(w => !SLASHES.some(s => s.name === `/${w.name}`))
+                .map(w => ({ desc: w.description ?? 'Run a dynamic workflow', name: `/${w.name}` }))
+            ]
+            const items = entries
+              .filter(s => s.name.toLowerCase().startsWith(text))
+              .map(s => ({ display: s.name, meta: s.desc, text: s.name }))
+            return { items, replace_from: 1 } as T
+          })
       }
       case 'complete.path':
         // @-file mentions: serve workspace file completions from disk (the hook
@@ -347,6 +381,20 @@ export class GatewayClient extends EventEmitter {
     }
   }
 
+  // Fetch the backend's workflow slash commands, TTL-cached (see
+  // WORKFLOW_CMDS_TTL_MS). Degrades to the last-known list on RPC failure.
+  private fetchWorkflowCommands(): Promise<WorkflowCommand[]> {
+    const now = Date.now()
+    if (now - this.wfFetchedAt < WORKFLOW_CMDS_TTL_MS) return Promise.resolve(this.wfCommands)
+    this.wfFetchedAt = now
+    return this.controlQuery('list_workflow_commands', {}).then((r: any) => {
+      if (Array.isArray(r?.commands)) {
+        this.wfCommands = r.commands.filter((c: any) => typeof c?.name === 'string' && c.name)
+      }
+      return this.wfCommands
+    })
+  }
+
   // ── event plumbing ───────────────────────────────────────────────────────
   private controlQuery(subtype: string, params: Record<string, unknown>): Promise<unknown> {
     const requestId = `q${++this.reqId}`
@@ -363,9 +411,15 @@ export class GatewayClient extends EventEmitter {
   }
 
   // Map a slash command (name + optional arg) to a clawcodex control_request
-  // and return a CommandDispatchResponse (`type:'exec'` + human-readable output
-  // the app prints). Unknown commands report that they aren't wired yet.
-  private async dispatchSlash(name: string, arg?: string): Promise<{ output: string; type: string }> {
+  // and return a CommandDispatchResponse — `type:'exec'` + human-readable output
+  // the app prints, or `type:'send'` for workflow commands whose expanded
+  // directive the app submits as a prompt. Unknown commands are offered to the
+  // backend as workflow commands (/deep-research, saved .claude/workflows)
+  // before reporting they aren't wired.
+  private async dispatchSlash(
+    name: string,
+    arg?: string
+  ): Promise<{ output: string; type: string } | { message: string; notice?: string; type: 'send' }> {
     const out = (output: string) => ({ output, type: 'exec' })
     switch (name) {
       case 'clear':
@@ -382,6 +436,10 @@ export class GatewayClient extends EventEmitter {
       }
       case 'effort': {
         const r = (await this.controlQuery('set_effort', { effort: arg ?? null })) as any
+        if (r && r.ok === false) return out(`effort: ${r.error ?? 'invalid value'}`)
+        if (r?.effort === 'ultracode') {
+          return out('Ultracode on: workflow auto-orchestration for this session (reset with /effort high).')
+        }
         return out(`Effort: ${r?.effort ?? arg ?? '(unchanged)'}.`)
       }
       case 'mode':
@@ -444,8 +502,25 @@ export class GatewayClient extends EventEmitter {
             : 'No saved sessions.'
         )
       }
-      default:
+      case 'workflows': {
+        const r = (await this.controlQuery('workflows', {})) as any
+        if (r && r.ok === false) return out(`workflows: ${r.error ?? 'unavailable'}`)
+        return out(String(r?.text ?? 'No workflow runs.'))
+      }
+      default: {
+        // Workflow commands (/deep-research + saved .claude/workflows/*.py):
+        // the backend expands the directive; the app submits it as a prompt so
+        // the model launches the run via the Workflow tool.
+        const r = (await this.controlQuery('workflow_command', { args: arg ?? '', name })) as any
+        if (r?.ok && typeof r.prompt === 'string' && r.prompt) {
+          return {
+            message: r.prompt,
+            notice: typeof r.notice === 'string' ? r.notice : undefined,
+            type: 'send'
+          }
+        }
         return out(`/${name} isn't wired into the clawcodex backend yet.`)
+      }
     }
   }
 
@@ -564,6 +639,13 @@ export class GatewayClient extends EventEmitter {
           } else {
             this.publish({ payload: { kind: 'status', text: String(msg.message ?? '') }, type: 'status.update' })
           }
+        } else if (msg.subtype === 'task_notification') {
+          // A background workflow/agent finished: render the completion banner
+          // as a persistent system transcript line ("[bg <id>] ✔ … completed").
+          this.publish({
+            payload: { task_id: String(msg.task_id ?? 'task'), text: String(msg.message ?? '') },
+            type: 'background.complete'
+          })
         }
         break
       case 'user': {


### PR DESCRIPTION
## Summary

The UI consolidation (#566: deleted Rich REPL + Textual TUI) and the hermes TUI port (#572) left every **surface-level dynamic-workflow feature** dead — the engine (`src/workflow/`, the Workflow tool) survived intact, but nothing drove it:

| Feature | What was broken |
|---|---|
| `ultracode` keyword | `ultracode_reminder_for` had **zero callers** (the seam was the deleted REPL chat loop) — the keyword silently did nothing |
| `/effort ultracode` | The TUI maps `/effort` → `set_effort`, whose whitelist rejected `ultracode` and **silently cleared** the effort level instead of enabling session mode |
| `/workflows` | "…isn't wired into the clawcodex backend yet." |
| `/deep-research` + saved `.claude/workflows/*.py` | Invisible to the TUI's hardcoded 16-entry slash catalog, undispatchable |
| Completion delivery | The `<task-notification>` queue had **no consumer** — runs finished silently; the directive's promise "the finished report is delivered automatically" was false |

## What this PR does

**Python agent-server (server-authoritative, works for any client):**
- `_run_turn` appends the ultracode `<system-reminder>` (keyword or session mode; str + multimodal block prompts; skipped for internal turns) — the seam the old REPL provided at `core.py:3163`.
- Worker loop drains finished-task notifications between turns (`get(timeout=0.5)`): one plain-text **banner frame** per task (`system/task_notification`) + **one summarization turn** so the model reports results conversationally. Shared queue means background-agent completions are delivered too.
- `src/server/task_notifications.py`: resurrection of the deleted `src/repl/task_notifications.py` pure helpers, de-Rich'd, with an agent-aware label fallback (`workflow_name → description → "task"`).
- New controls (all gated on `is_workflows_enabled()`, all exception-wrapped with error replies): `workflows` (text report via shared `render_workflows_report`), `list_workflow_commands` (bundled + saved, read fresh from disk so an ultracode-authored workflow appears without restart), `workflow_command` (expands the directive prompt, `$ARGUMENTS` substituted).
- `set_effort`: accepts `ultracode` (session mode on; workflows-disabled ⇒ error), real levels / `auto` exit the mode, bare `/effort` is now a **read-only report** (the old picker's Esc-is-a-no-op).

**Ink TUI:**
- `/workflows` in the catalog; backend workflow commands (TTL-cached `list_workflow_commands`) merged into `commands.catalog` + `complete.slash`.
- `dispatchSlash`: `/workflows` → report; unknown names are offered to the backend as workflow commands and dispatch as `{type:'send'}` — the app prints the notice and submits the directive (without echoing it as a user bubble; the typed slash line is already in the transcript).
- `system/task_notification` → `background.complete` → persistent transcript banner (`[bg wf_…] ✔ deep-research completed · 12 agents · 45.2k tok · 3m 12s`).

**Drive-by fixes (pre-existing breakage on main, caught while validating):**
- `ui-tui/src/entry.tsx`: `./app.js` → `./App.js` (typecheck was failing on the case-sensitivity rule).
- `tests/server/test_tui_launcher.py`: stale `cli.tsx` assertion → `entry.tsx` (the hermes-port rename).
- `createSlashHandler.test.ts`: stale `/indicator` usage expectation (missing `star`).

## Tests

- **New:** `tests/server/test_agent_server_workflows.py` (12 integration tests over the real spawn-handle: keyword/session injection, set_effort semantics + gating, workflows report, catalog, dispatch expansion, notification drain incl. agent envelopes + internal-turn reminder suppression) and `tests/server/test_task_notifications.py` (9 unit tests: banners, labels, turn assembly, defensive report rendering). TS: 6 new tests across `gatewayClient.test.ts` / `createSlashHandler.test.ts`.
- **Suites:** Python `7355+ passed`, only the 9 known pre-existing env failures remain (this PR fixes the 10th). `ui-tui` typecheck clean (was broken on main); the two touched TS files 84/84 (remaining vitest failures pre-exist on main, verified against a pristine baseline worktree).
- **Live e2e (real TUI + agent-server + deepseek, pyte-verified):** `/workflows` report ✓, `/effort ultracode` on/off ✓, slash menu lists `/deep-research` ✓, `/hello-check` full cycle — dispatch notice → Workflow tool launch → background run → `✔ hello-check completed · 1 agents · 7.3k tok · 1s` banner + auto-summary turn ✓, and the `ultracode` keyword had the model author `.claude/workflows/trivia.py`, which immediately parses and lists as `/trivia` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
