### PR TITLE
feat(ch01/round4): bootstrap the Hooks abstraction — configured hooks fire in production

### DIFF
--- a/src/agent/subagent_context.py
+++ b/src/agent/subagent_context.py
@@ -184,6 +184,14 @@ def create_subagent_context(
         agent_id=agent_id,
         agent_type=agent_type,
         user_modified=parent_context.user_modified,
+        # ch01 round-4 WI-1 — hooks apply to sub-agents exactly as to the
+        # parent: same config snapshot, same workspace-trust verdict.
+        # Without this, PreToolUse/PostToolUse (incl. enterprise policy
+        # hooks) silently skip every sub-agent tool call — a policy bypass
+        # via the Agent tool — and the PostSampling trust filter would
+        # treat sub-agent loops as untrusted in a trusted workspace.
+        hook_config_manager=parent_context.hook_config_manager,
+        workspace_trusted=parent_context.workspace_trusted,
     )
 
 

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -213,6 +213,27 @@ def run_headless(options: HeadlessOptions) -> int:
         abort_controller=abort_controller,
     )
     tool_context.options.is_non_interactive_session = True
+    # ch01 round-4 WI-1 — load settings hooks into the executor-visible
+    # snapshot + global registry. Safe here: run_headless is sync and its
+    # asyncio.run happens later. Never raises.
+    from src.hooks.config_manager import bootstrap_hook_config_manager
+
+    tool_context.hook_config_manager = bootstrap_hook_config_manager(
+        cwd=str(workspace_root),
+    )
+    # workspace_trusted feeds the hook trust gate (trust_gate WI-0.2); it
+    # defaulted False with no production setter, so even configured hooks
+    # were silently skipped. Same source of truth as the CLI startup gate.
+    try:
+        from src.services.startup_gates import check_trust_accepted
+
+        tool_context.workspace_trusted = check_trust_accepted(workspace_root)
+    except Exception:  # noqa: BLE001 — unknown trust stays untrusted
+        import logging
+
+        logging.getLogger(__name__).debug(
+            "headless trust check failed", exc_info=True,
+        )
     if options.skip_permissions or effective_mode == "bypassPermissions":
         tool_context.allow_docs = True
         tool_context.permission_handler = None

--- a/src/hooks/config_manager.py
+++ b/src/hooks/config_manager.py
@@ -290,7 +290,30 @@ def load_hooks_from_settings(
                 translated = _translate_legacy_notification_entry(hook_raw)
                 if translated is not None:
                     target_event = translated
-            hooks.setdefault(target_event, []).append(_parse_hook_config(hook_raw))
+            # ch01 round-4 WI-1 — canonical Claude Code settings nest hook
+            # definitions in matcher groups: {"matcher": ..., "hooks": [...]}
+            # (TS schemas/hooks.ts HookMatcherSchema). Expand each group,
+            # propagating the group matcher onto inner entries that don't
+            # set their own. The flat form (a bare hook dict) stays
+            # supported. Without the expansion a real-world settings.json
+            # parsed into empty-command junk hooks.
+            inner = hook_raw.get("hooks")
+            if isinstance(inner, list):
+                group_matcher = hook_raw.get("matcher")
+                for inner_raw in inner:
+                    if not isinstance(inner_raw, dict):
+                        continue
+                    if group_matcher is not None and "matcher" not in inner_raw:
+                        inner_raw = {**inner_raw, "matcher": group_matcher}
+                    config = _parse_hook_config(inner_raw)
+                    if config.type == "command" and not config.command:
+                        continue  # malformed entry — never execute ""
+                    hooks.setdefault(target_event, []).append(config)
+                continue
+            config = _parse_hook_config(hook_raw)
+            if config.type == "command" and not config.command:
+                continue  # malformed entry — never execute ""
+            hooks.setdefault(target_event, []).append(config)
 
     return HookConfigSnapshot(
         hooks=hooks,
@@ -372,3 +395,89 @@ class HookConfigManager:
             )]
 
         return validate_hook_configs(hooks_raw)
+
+
+def bootstrap_hook_config_manager(
+    *,
+    cwd: str | Path | None = None,
+    settings_path: str | Path | None = None,
+) -> HookConfigManager | None:
+    """Build + load the manager that makes settings hooks live.
+
+    ch01 round-4 WI-1. This is the missing root of the Hooks abstraction:
+    the executors all read hook configs through
+    ``tool_use_context.hook_config_manager.snapshot``
+    (``hook_executor._get_hooks_from_snapshot``), and the router lane
+    (post-sampling / session hooks) reads the global ``AsyncHookRegistry``
+    — but nothing constructed or loaded a manager in production, so
+    configured hooks never fired. Both production ``ToolContext``
+    construction sites (agent-server ``_build_runtime``, headless
+    ``run_headless``) call this and attach the result.
+
+    ``load()`` populates BOTH read paths at once: the frozen snapshot
+    (context lane) and the global registry (router lane), because every
+    parsed config is registered into the registry the manager was
+    constructed with.
+
+    Sync-only by contract: both call sites are plain sync functions running
+    on threads with no live event loop (the agent-server builds runtimes in
+    ``run_in_executor``; headless bootstraps before its own
+    ``asyncio.run``). If a running loop is detected, log and return None
+    rather than deadlock — an async call site needs an async variant, not
+    this one.
+
+    Never raises: hooks must not be able to break startup. Returns None
+    when ``settings.hooks.enabled`` is False (the framework off-switch;
+    unreadable settings fail open to the default of enabled).
+
+    ``cwd`` asymmetry, deliberate: ``cwd`` scopes only the
+    ``hooks.enabled`` knob lookup (settings hierarchy); the hook *entries*
+    always load from the single user-scope file
+    (``$CLAUDE_CONFIG_DIR``/``~/.claude/settings.json``) regardless of
+    cwd. Multi-scope (project/local/policy) entry merging is the ch12
+    round-4 subject.
+    """
+    try:
+        from ..settings.settings import load_settings
+
+        if not load_settings(cwd=cwd).hooks.enabled:
+            logger.info("hooks disabled via settings.hooks.enabled")
+            return None
+    except Exception:  # noqa: BLE001 — the knob is an off-switch, not a gate
+        logger.debug("could not read settings.hooks.enabled; assuming enabled",
+                     exc_info=True)
+
+    import asyncio
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass  # no running loop — the expected state at both call sites
+    else:
+        # Documented sync-only contract: asyncio.run() below would raise, and
+        # probing first avoids creating a never-awaited load() coroutine.
+        logger.warning(
+            "bootstrap_hook_config_manager called from a running event loop; "
+            "hooks not loaded (use an async variant at this call site)",
+        )
+        return None
+
+    try:
+        from .registry import get_global_hook_registry
+
+        manager = HookConfigManager(
+            get_global_hook_registry(), settings_path=settings_path,
+        )
+        asyncio.run(manager.load())
+        snapshot = manager.snapshot
+        if snapshot is not None and not snapshot.is_empty:
+            count = sum(len(v) for v in snapshot.hooks.values())
+            logger.info(
+                "loaded %d hook config(s) from %s",
+                count, snapshot.source_path,
+            )
+        return manager
+    except Exception:  # noqa: BLE001 — hooks must never break startup
+        logger.warning("hook config bootstrap failed; continuing without hooks",
+                       exc_info=True)
+        return None

--- a/src/hooks/hook_types.py
+++ b/src/hooks/hook_types.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 # Hook events — Chapter-12 / Phase-1 / WI-1.1
 # ---------------------------------------------------------------------------
 #
-# 25-event taxonomy promoted from the legacy 10-event Literal. Mirrors
+# 28-event taxonomy promoted from the legacy 10-event Literal. Mirrors
 # typescript/src/utils/hooks/hooksConfigManager.ts:26-267 plus the chapter's
 # reference table (``ch12-extensibility.md`` §"Five Most Important Lifecycle
 # Events" + §"Reference table — remaining events").

--- a/src/hooks/post_sampling_hooks.py
+++ b/src/hooks/post_sampling_hooks.py
@@ -15,10 +15,18 @@ async def run_post_sampling_hooks(
     model: str = "",
     usage: dict[str, int] | None = None,
     stop_reason: str | None = None,
-    response_content: Any = None,
+    untrusted_workspace: bool = False,
 ) -> list[dict[str, Any]]:
     reg = registry or get_global_hook_registry()
     hooks = await reg.get_hooks_for_event("PostSampling")
+
+    if untrusted_workspace:
+        # Same trust rule the snapshot-lane executor applies
+        # (hook_executor._run_hooks_for_event / trust_gate WI-0.2): in an
+        # untrusted workspace only enterprise policy hooks may run. Without
+        # this, the registry lane would execute user-settings shell hooks
+        # that the tool-hook lane correctly blocks.
+        hooks = [h for h in hooks if h.source.is_policy]
 
     if not hooks:
         return []

--- a/src/hooks/registry.py
+++ b/src/hooks/registry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import asyncio
 import logging
+import threading
 from dataclasses import dataclass, field
 from typing import Any, AsyncGenerator
 
@@ -41,7 +41,16 @@ class AsyncHookRegistry:
         self._hooks: dict[HookEvent, list[RegisteredHook]] = {
             event: [] for event in ALL_HOOK_EVENTS
         }
-        self._lock = asyncio.Lock()
+        # threading.Lock, not asyncio.Lock — deliberately (ch01 round-4).
+        # The registry is a process-global singleton touched from MULTIPLE
+        # event loops (the sync bootstrap's asyncio.run, each turn's
+        # asyncio.run on the agent-server worker thread) and from multiple
+        # session worker threads. An asyncio.Lock binds to whichever loop
+        # first awaits it and raises "bound to a different event loop" ever
+        # after; it also provides zero cross-thread safety. Every critical
+        # section below is pure in-memory dict/list work with no await, so a
+        # plain mutex is both correct and loop-agnostic.
+        self._lock = threading.Lock()
         self._counter = 0
 
     async def register(
@@ -50,7 +59,7 @@ class AsyncHookRegistry:
         config: HookConfig,
         source: HookSource | None = None,
     ) -> RegisteredHook:
-        async with self._lock:
+        with self._lock:
             effective_source = source or config.source
             self._counter += 1
             hook = RegisteredHook(
@@ -76,7 +85,7 @@ class AsyncHookRegistry:
         event: HookEvent,
         config: HookConfig,
     ) -> bool:
-        async with self._lock:
+        with self._lock:
             existing = self._hooks.get(event, [])
             temp_hook = RegisteredHook(event=event, config=config, source=config.source)
             dedup_key = temp_hook.dedup_key
@@ -90,7 +99,7 @@ class AsyncHookRegistry:
         event: HookEvent,
         tool_name: str | None = None,
     ) -> list[RegisteredHook]:
-        async with self._lock:
+        with self._lock:
             hooks = list(self._hooks.get(event, []))
 
         if tool_name is not None:
@@ -110,13 +119,13 @@ class AsyncHookRegistry:
         return len(hooks) > 0
 
     async def clear(self) -> None:
-        async with self._lock:
+        with self._lock:
             for event in ALL_HOOK_EVENTS:
                 self._hooks[event] = []
             self._counter = 0
 
     async def clear_source(self, source: HookSource) -> int:
-        async with self._lock:
+        with self._lock:
             removed = 0
             for event in ALL_HOOK_EVENTS:
                 before = len(self._hooks[event])

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -178,6 +178,68 @@ def _create_max_turns_attachment(max_turns: int, turn_count: int) -> SystemMessa
     )
 
 
+async def _fire_post_sampling_hooks(
+    assistant_messages: list[AssistantMessage],
+    provider: Any,
+    tool_use_context: Any,
+) -> None:
+    """Run configured ``PostSampling`` hooks for a completed model stream.
+
+    ch01 round-4 WI-2 — restores the dependency-graph edge "Query Loop
+    fires Hooks" for the one event TS fires from query.ts itself
+    (``executePostSamplingHooks``, query.ts:1079-1089). Reads the global
+    ``AsyncHookRegistry`` (populated at startup by
+    ``bootstrap_hook_config_manager``); with no ``PostSampling`` hooks
+    configured this returns after one in-memory lookup.
+
+    Deviation from TS, deliberate: awaited inline instead of
+    fire-and-forget. The agent-server drives each turn with
+    ``asyncio.run(...)``, so a task created on the loop's final iteration
+    would be cancelled at teardown — losing the hook on exactly the
+    turn-final response. Inline await trades stream/hook overlap for a
+    completion guarantee.
+
+    Hook failures are logged and swallowed — a hook must never kill the
+    turn (TS parity: logError + continue). ``additional_contexts`` from
+    hook results are debug-logged and dropped: TS post-sampling hooks
+    return void, so there are no injection semantics to mirror; a uniform
+    injection lane across events is the ch12 round-4 subject.
+    """
+    if not assistant_messages:
+        return
+    try:
+        from ..hooks.post_sampling_hooks import run_post_sampling_hooks
+        from ..hooks.trust_gate import should_skip_hook_due_to_trust
+
+        last = assistant_messages[-1]
+        results = await run_post_sampling_hooks(
+            model=(
+                getattr(last, "model", None)
+                or getattr(provider, "model", None)
+                or ""
+            ),
+            usage=getattr(last, "usage", None) or {},
+            stop_reason=getattr(last, "stop_reason", None),
+            # Same trust rule as the tool-hook lane: untrusted workspace →
+            # policy hooks only (trust_gate WI-0.2).
+            untrusted_workspace=should_skip_hook_due_to_trust(tool_use_context),
+        )
+        for entry in results:
+            injected = entry.get("injected_messages")
+            if injected:
+                logger.debug(
+                    "PostSampling hook additional_contexts dropped "
+                    "(no injection lane yet — ch12): %d block(s)",
+                    len(injected),
+                )
+    except (asyncio.CancelledError, AbortError):
+        # User intent wins — AbortError subclasses Exception, so without the
+        # explicit re-raise the blanket handler below would swallow it.
+        raise
+    except Exception:  # noqa: BLE001 — hook failure must never kill the turn
+        logger.error("PostSampling hook execution failed", exc_info=True)
+
+
 def _drain_pending_user_messages(tool_use_context: Any) -> list[UserMessage]:
     """Drain the running agent's ``pending_messages`` inbox, if any.
 
@@ -1007,6 +1069,10 @@ async def _call_model_sync(
     assistant_msg = AssistantMessage(
         content=assistant_blocks if assistant_blocks else "",
         stop_reason=stop_reason,
+        # TS assistant messages carry the responding model (query.ts message
+        # assembly); consumers like the PostSampling hook payload and cost
+        # attribution read it. Same fallback chain as record_api_usage above.
+        model=getattr(response, "model", None) or getattr(provider, "model", None),
         usage=response.usage,
     )
     if response.reasoning_content:
@@ -1037,9 +1103,11 @@ async def query(
     See :func:`run_query` for a convenience helper that consumes the
     generator and returns ``(messages, terminal)``.
 
-    This PR (Phase A) introduces the typed Terminal infrastructure;
-    recovery integration, stop hooks, token budget, model fallback,
-    and continuation nudge land in subsequent PRs.
+    Recovery integration, stop hooks, token budget, and the continuation
+    nudge are wired (ch05 rounds 2-3). Model fallback (TS
+    FallbackTriggeredError → sticky model switch + tombstones) is NOT yet
+    ported — tracked as ch04/ch05 round-4 scope; see
+    my-docs/ch01-architecture-round4-gap-analysis.md §3 GAP B.
     """
     _diag = os.environ.get("CLAWCODEX_DEBUG", "").lower() in ("1", "true", "yes")
     holder = terminal_holder or TerminalHolder()
@@ -1362,6 +1430,16 @@ async def query(
                 yield _create_user_interruption_message(tool_use=False)
             set_terminal(holder, natural_termination, Terminal(reason="aborted_streaming"))
             return
+
+        # ch01 round-4 WI-2 — PostSampling hook wire (TS query.ts:1079-1089).
+        # Placed after the abort check: TS fires before it, but its call is
+        # non-blocking (`void …`) so pre-abort is free there; an inline await
+        # before the abort return would delay ESC responsiveness by the hook
+        # runtime. Consequence: hooks do not fire for user-aborted streams.
+        if assistant_messages:
+            await _fire_post_sampling_hooks(
+                assistant_messages, params.provider, tool_use_context,
+            )
 
         if not needs_follow_up:
             last_message = assistant_messages[-1] if assistant_messages else None

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -1710,6 +1710,24 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
             abort_controller=AbortController(),
         )
         tool_context.options.is_non_interactive_session = True
+        # ch01 round-4 WI-1 — load settings hooks into the executor-visible
+        # snapshot + global registry. Safe here: _build_runtime runs in an
+        # executor thread with no live event loop. Never raises.
+        from src.hooks.config_manager import bootstrap_hook_config_manager
+
+        tool_context.hook_config_manager = bootstrap_hook_config_manager(
+            cwd=sess.cwd,
+        )
+        # workspace_trusted feeds the hook trust gate (trust_gate WI-0.2);
+        # it defaulted False with no production setter, so even configured
+        # hooks were silently skipped. Same source of truth as the CLI's
+        # startup trust gate (TS computeTrustDialogAccepted parity).
+        try:
+            from src.services.startup_gates import check_trust_accepted
+
+            tool_context.workspace_trusted = check_trust_accepted(sess.cwd)
+        except Exception:  # noqa: BLE001 — unknown trust stays untrusted
+            logger.debug("[agent-server] trust check failed", exc_info=True)
         if sess._mcp_runtime is not None:
             tool_context.mcp_clients = sess._mcp_runtime.clients  # server-name catalog for the agent tool
 

--- a/tests/test_hooks_bootstrap.py
+++ b/tests/test_hooks_bootstrap.py
@@ -1,0 +1,194 @@
+"""ch01 round-4 WI-1 acceptance tests: hooks-subsystem bootstrap.
+
+Before this round, nothing in production constructed a
+``HookConfigManager`` or populated ``tool_use_context.hook_config_manager``
+/ the global ``AsyncHookRegistry`` — configured hooks never fired.
+``bootstrap_hook_config_manager`` is the single wire both production
+``ToolContext`` construction sites (agent-server ``_build_runtime``,
+headless ``run_headless``) now call.
+
+Covers:
+  * happy path — temp settings.json entries land in BOTH read paths
+    (frozen snapshot + global registry);
+  * the executors' actual read predicate (``has_hook_for_event``) sees the
+    configs once the manager is attached to a real ToolContext;
+  * settings.hooks.enabled=False → None, registry untouched;
+  * malformed settings.json → manager with empty snapshot, no raise;
+  * idempotence — bootstrapping twice does not duplicate registry entries;
+  * running-event-loop misuse → None (documented sync-only contract).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.hooks.config_manager import (
+    HookConfigManager,
+    bootstrap_hook_config_manager,
+)
+from src.hooks.registry import (
+    get_global_hook_registry,
+    reset_global_hook_registry,
+)
+
+
+def _write_settings(dir_path: Path, hooks: dict | str) -> Path:
+    settings = dir_path / "settings.json"
+    if isinstance(hooks, str):
+        settings.write_text(hooks, encoding="utf-8")
+    else:
+        settings.write_text(json.dumps({"hooks": hooks}), encoding="utf-8")
+    return settings
+
+
+_TWO_EVENTS = {
+    "PreToolUse": [
+        {"type": "command", "command": "echo pre", "matcher": "Write"},
+    ],
+    "PostSampling": [
+        {"type": "command", "command": "echo post"},
+    ],
+}
+
+
+class TestBootstrapHookConfigManager(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_global_hook_registry()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+
+    def tearDown(self) -> None:
+        reset_global_hook_registry()
+        self._tmp.cleanup()
+
+    def test_happy_path_populates_snapshot_and_registry(self) -> None:
+        settings = _write_settings(self.tmp, _TWO_EVENTS)
+
+        manager = bootstrap_hook_config_manager(settings_path=settings)
+
+        self.assertIsInstance(manager, HookConfigManager)
+        assert manager is not None
+        snapshot = manager.snapshot
+        assert snapshot is not None
+        self.assertIn("PreToolUse", snapshot.hooks)
+        self.assertIn("PostSampling", snapshot.hooks)
+
+        registry = get_global_hook_registry()
+        self.assertTrue(
+            asyncio.run(registry.has_hooks_for_event("PreToolUse", "Write")),
+        )
+        self.assertTrue(
+            asyncio.run(registry.has_hooks_for_event("PostSampling")),
+        )
+
+    def test_executor_read_path_sees_configs_via_tool_context(self) -> None:
+        """The production predicate the tool pipeline uses must go live."""
+        from src.hooks.hook_executor import has_hook_for_event
+        from src.tool_system.context import ToolContext
+
+        settings = _write_settings(self.tmp, _TWO_EVENTS)
+        context = ToolContext(workspace_root=self.tmp)
+        self.assertFalse(has_hook_for_event("PreToolUse", context))
+
+        context.hook_config_manager = bootstrap_hook_config_manager(
+            settings_path=settings,
+        )
+
+        self.assertTrue(has_hook_for_event("PreToolUse", context))
+        self.assertTrue(has_hook_for_event("PostSampling", context))
+        self.assertFalse(has_hook_for_event("SessionStart", context))
+
+    def test_hooks_disabled_returns_none_and_leaves_registry_empty(self) -> None:
+        settings = _write_settings(self.tmp, _TWO_EVENTS)
+
+        class _Knob:
+            enabled = False
+
+        class _Settings:
+            hooks = _Knob()
+
+        with patch(
+            "src.settings.settings.load_settings", return_value=_Settings(),
+        ):
+            manager = bootstrap_hook_config_manager(settings_path=settings)
+
+        self.assertIsNone(manager)
+        registry = get_global_hook_registry()
+        self.assertFalse(
+            asyncio.run(registry.has_hooks_for_event("PreToolUse", "Write")),
+        )
+
+    def test_malformed_settings_yields_empty_snapshot_without_raise(self) -> None:
+        settings = _write_settings(self.tmp, "{not json")
+
+        manager = bootstrap_hook_config_manager(settings_path=settings)
+
+        self.assertIsNotNone(manager)
+        assert manager is not None
+        snapshot = manager.snapshot
+        assert snapshot is not None
+        self.assertTrue(snapshot.is_empty)
+
+    def test_bootstrap_twice_does_not_duplicate_registry_entries(self) -> None:
+        settings = _write_settings(self.tmp, _TWO_EVENTS)
+
+        bootstrap_hook_config_manager(settings_path=settings)
+        bootstrap_hook_config_manager(settings_path=settings)
+
+        registry = get_global_hook_registry()
+        hooks = asyncio.run(registry.get_hooks_for_event("PostSampling"))
+        self.assertEqual(len(hooks), 1)
+
+    def test_canonical_matcher_group_format_expands(self) -> None:
+        """Real Claude Code settings nest hooks in matcher groups
+        ({"matcher": ..., "hooks": [...]}); the loader must expand them
+        with the group matcher propagated — not parse the group itself
+        into an empty-command junk hook."""
+        settings = _write_settings(self.tmp, {
+            "PreToolUse": [{
+                "matcher": "Write",
+                "hooks": [
+                    {"type": "command", "command": "echo grouped-1"},
+                    {"type": "command", "command": "echo grouped-2",
+                     "matcher": "Edit"},
+                ],
+            }],
+            # Malformed flat entry: command-type with no command — dropped.
+            "Stop": [{"type": "command"}],
+        })
+
+        manager = bootstrap_hook_config_manager(settings_path=settings)
+
+        assert manager is not None
+        snapshot = manager.snapshot
+        assert snapshot is not None
+        pre = snapshot.hooks.get("PreToolUse", [])
+        self.assertEqual(
+            [(h.command, h.matcher) for h in pre],
+            [("echo grouped-1", "Write"), ("echo grouped-2", "Edit")],
+        )
+        self.assertEqual(snapshot.hooks.get("Stop", []), [])
+
+        registry = get_global_hook_registry()
+        self.assertTrue(
+            asyncio.run(registry.has_hooks_for_event("PreToolUse", "Write")),
+        )
+        self.assertFalse(
+            asyncio.run(registry.has_hooks_for_event("Stop")),
+        )
+
+    def test_called_from_running_loop_returns_none(self) -> None:
+        settings = _write_settings(self.tmp, _TWO_EVENTS)
+
+        async def _inside_loop():
+            return bootstrap_hook_config_manager(settings_path=settings)
+
+        self.assertIsNone(asyncio.run(_inside_loop()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_query_post_sampling.py
+++ b/tests/test_query_post_sampling.py
@@ -1,0 +1,277 @@
+"""ch01 round-4 WI-2 acceptance tests: PostSampling hooks fired by the loop.
+
+TS fires ``executePostSamplingHooks`` after every completed model stream
+(query.ts:1079-1089). The Python port routes the event through the
+config-hook registry (``run_post_sampling_hooks``); the loop awaits it
+inline right after the streaming-abort check (deviation from TS's
+fire-and-forget — see the plan's WI-2 design notes).
+
+Covers:
+  * end-to-end registry lane: a real command hook configured via
+    ``HookConfigManager`` writes a file once per completed stream;
+  * multi-iteration: tool turn + final turn → fired twice;
+  * payload: hook stdin carries hook_event/model/usage/stop_reason;
+  * error-swallow: a raising runner does not kill the turn;
+  * abort path: user-aborted stream → not fired;
+  * fast path: no hooks configured → stream and terminal unchanged.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.hooks.config_manager import bootstrap_hook_config_manager
+from src.hooks.registry import reset_global_hook_registry
+from src.providers.base import ChatResponse
+from src.query.query import QueryParams, run_query
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.types.content_blocks import ToolResultBlock
+from src.types.messages import UserMessage
+from src.utils.abort_controller import AbortController
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_params(
+    *,
+    workspace: Path,
+    provider: MagicMock,
+    abort: AbortController | None = None,
+    max_turns: int = 10,
+    trusted: bool = True,
+) -> QueryParams:
+    registry = build_default_registry()
+    context = ToolContext(workspace_root=workspace)
+    # Both production construction sites now set this from
+    # check_trust_accepted; tests default to trusted so the hook path is
+    # exercised (the trust-gate class pins the untrusted behavior).
+    context.workspace_trusted = trusted
+    return QueryParams(
+        messages=[UserMessage(content="Hi")],
+        system_prompt="You are helpful.",
+        tools=registry.list_tools(),
+        tool_registry=registry,
+        tool_use_context=context,
+        provider=provider,
+        abort_controller=abort or AbortController(),
+        max_turns=max_turns,
+    )
+
+
+def _completion(content: str = "Done.") -> ChatResponse:
+    return ChatResponse(
+        content=content,
+        model="test-model",
+        usage={"input_tokens": 10, "output_tokens": 5},
+        finish_reason="end_turn",
+        tool_uses=None,
+    )
+
+
+def _tool_use(*, tool_use_id: str, workspace: Path) -> ChatResponse:
+    return ChatResponse(
+        content="Working...",
+        model="test-model",
+        usage={"input_tokens": 10, "output_tokens": 20},
+        finish_reason="tool_use",
+        tool_uses=[{
+            "id": tool_use_id,
+            "name": "Write",
+            "input": {
+                "file_path": str(workspace / "x.txt"),
+                "content": "hi",
+            },
+        }],
+    )
+
+
+def _as_run_tools_stub(messages_factory):
+    from src.services.tool_execution.orchestrator import MessageUpdate
+
+    async def _stub(_blocks, _assistants, _can_use_tool, _ctx, *a, **k):
+        for m in messages_factory():
+            yield MessageUpdate(message=m, new_context=_ctx)
+
+    return _stub
+
+
+def _tool_result(tool_use_id: str) -> UserMessage:
+    return UserMessage(
+        content=[
+            ToolResultBlock(tool_use_id=tool_use_id, content="ok", is_error=False),
+        ],
+    )
+
+
+class _PostSamplingHarness(unittest.TestCase):
+    """Shared setup: temp workspace + a PostSampling command hook that
+    appends its stdin JSON to ``hook_log`` — loaded through the real
+    bootstrap so the test exercises the same lane production does."""
+
+    def setUp(self) -> None:
+        reset_global_hook_registry()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self._tmp.name)
+        self.hook_log = self.workspace / "post_sampling_log.jsonl"
+
+    def tearDown(self) -> None:
+        reset_global_hook_registry()
+        self._tmp.cleanup()
+
+    def _bootstrap_post_sampling_hook(self) -> None:
+        settings = self.workspace / "settings.json"
+        settings.write_text(json.dumps({
+            "hooks": {
+                "PostSampling": [{
+                    "type": "command",
+                    # Append the stdin payload as one line per invocation
+                    # (command hooks run via create_subprocess_shell).
+                    "command": f"cat >> {self.hook_log}; echo >> {self.hook_log}",
+                }],
+            },
+        }), encoding="utf-8")
+        manager = bootstrap_hook_config_manager(settings_path=settings)
+        assert manager is not None and not manager.snapshot.is_empty
+
+    def _log_lines(self) -> list[dict]:
+        if not self.hook_log.exists():
+            return []
+        return [
+            json.loads(line)
+            for line in self.hook_log.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+
+class TestPostSamplingFires(_PostSamplingHarness):
+    def test_single_turn_fires_once_with_payload(self) -> None:
+        self._bootstrap_post_sampling_hook()
+
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = _completion()
+
+        params = _make_params(workspace=self.workspace, provider=provider)
+        _, terminal = _run(run_query(params))
+
+        self.assertEqual(terminal.reason, "completed")
+        lines = self._log_lines()
+        self.assertEqual(len(lines), 1)
+        payload = lines[0]
+        self.assertEqual(payload["hook_event"], "PostSampling")
+        self.assertEqual(payload["model"], "test-model")
+        self.assertEqual(payload["usage"].get("output_tokens"), 5)
+
+    def test_two_iterations_fire_twice(self) -> None:
+        self._bootstrap_post_sampling_hook()
+
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.side_effect = [
+            _tool_use(tool_use_id="toolu_ps1", workspace=self.workspace),
+            _completion(),
+        ]
+
+        params = _make_params(workspace=self.workspace, provider=provider)
+        with patch(
+            "src.services.tool_execution.orchestrator.run_tools",
+            new=_as_run_tools_stub(lambda: [_tool_result("toolu_ps1")]),
+        ):
+            _, terminal = _run(run_query(params))
+
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(len(self._log_lines()), 2)
+
+    def test_aborted_stream_does_not_fire(self) -> None:
+        """Deviation pinned: unlike TS (non-blocking, fires pre-abort-check),
+        the Python wire sits after the abort check so ESC stays instant."""
+        self._bootstrap_post_sampling_hook()
+
+        abort = AbortController()
+        abort.abort("test_abort")
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = _completion("Should not see this")
+
+        params = _make_params(
+            workspace=self.workspace, provider=provider, abort=abort,
+        )
+        _, terminal = _run(run_query(params))
+
+        self.assertEqual(terminal.reason, "aborted_streaming")
+        self.assertEqual(self._log_lines(), [])
+
+
+class TestPostSamplingTrustGate(_PostSamplingHarness):
+    """The router lane must apply the same workspace-trust rule as the
+    snapshot-lane executor (trust_gate WI-0.2): untrusted workspace →
+    only enterprise policy hooks run."""
+
+    def _one_turn(self, *, trusted: bool):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = _completion()
+        params = _make_params(
+            workspace=self.workspace, provider=provider, trusted=trusted,
+        )
+        return _run(run_query(params))
+
+    def test_untrusted_workspace_skips_user_settings_hooks(self) -> None:
+        self._bootstrap_post_sampling_hook()  # USER_SETTINGS source
+        _, terminal = self._one_turn(trusted=False)
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(self._log_lines(), [])
+
+    def test_trusted_workspace_runs_user_settings_hooks(self) -> None:
+        self._bootstrap_post_sampling_hook()
+        _, terminal = self._one_turn(trusted=True)
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(len(self._log_lines()), 1)
+
+
+class TestPostSamplingIsolation(_PostSamplingHarness):
+    def test_runner_exception_does_not_kill_turn(self) -> None:
+        self._bootstrap_post_sampling_hook()
+
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = _completion()
+
+        params = _make_params(workspace=self.workspace, provider=provider)
+        with patch(
+            "src.hooks.post_sampling_hooks.run_post_sampling_hooks",
+            side_effect=RuntimeError("hook exploded"),
+        ):
+            with self.assertLogs("src.query.query", level="ERROR") as captured:
+                _, terminal = _run(run_query(params))
+
+        self.assertEqual(terminal.reason, "completed")
+        self.assertTrue(
+            any("PostSampling" in line for line in captured.output),
+        )
+
+    def test_no_hooks_configured_is_a_noop(self) -> None:
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = _completion()
+
+        params = _make_params(workspace=self.workspace, provider=provider)
+        messages, terminal = _run(run_query(params))
+
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(self._log_lines(), [])
+        # The completed stream still reached the consumer untouched.
+        self.assertTrue(
+            any(getattr(m, "type", "") == "assistant" for m in messages),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_subagent_context.py
+++ b/tests/test_subagent_context.py
@@ -329,3 +329,17 @@ class TestWorkspaceInheritance:
         child = create_subagent_context(parent)
 
         assert child.file_reading_limits is parent.file_reading_limits
+
+    def test_hook_config_manager_and_trust_inherited(self):
+        """ch01 round-4 WI-1 — hooks apply to sub-agents as to the parent:
+        same config snapshot, same workspace-trust verdict. Without the
+        inheritance, PreToolUse/PostToolUse (incl. enterprise policy hooks)
+        silently skip every sub-agent tool call."""
+        parent = _make_parent_context()
+        parent.hook_config_manager = object()
+        parent.workspace_trusted = True
+
+        child = create_subagent_context(parent)
+
+        assert child.hook_config_manager is parent.hook_config_manager
+        assert child.workspace_trusted is True


### PR DESCRIPTION
## Round-4 ch01 (architecture): make the Hooks abstraction actually fire in production

**Docs:** `my-docs/ch01-architecture-round4-gap-analysis.md` (fresh re-verification of every ch01 claim at current main) + `my-docs/port-improvement-round-4/ch01-architecture-round4-plan.md`.

### The gap (GAP A)

The book's six-abstraction dependency graph has "Query Loop → fires → Hooks" and "Hooks → can block → Tool System". The executors for those edges exist and are tested — but **no production path ever loaded hook configs**:

- `HookConfigManager` was never constructed in production; `tool_use_context.hook_config_manager` was never assigned; the global `AsyncHookRegistry` was never populated. Both production `ToolContext` sites (agent-server `_build_runtime`, headless `run_headless`) built contexts with no hooks.
- Even with configs present, the trust gate fail-safed everything off: `workspace_trusted` defaults `False` and had **no production setter**.
- The registry-lane routers (`run_post_sampling_hooks`, session-hook routers) additionally had **zero callers**.
- Net effect: hooks configured in `~/.claude/settings.json` NEVER fired — while the TUI's `list_hooks` RPC displayed hook settings, making the feature look present. Every hook test passed because tests inject configs directly.

### The fix

1. **`bootstrap_hook_config_manager()`** (`src/hooks/config_manager.py`) — builds + loads a global-registry-backed manager; called at both production construction sites. One call populates both read lanes (frozen snapshot for PreToolUse/PostToolUse/Stop; registry for routers). Honors `settings.hooks.enabled`; never raises; sync-only contract enforced (running-loop probe).
2. **`workspace_trusted` wired** from the CLI's own trust source (`check_trust_accepted`, TS `computeTrustDialogAccepted` parity) at both sites.
3. **Canonical settings format**: `load_hooks_from_settings` now expands Claude Code matcher groups (`{"matcher": ..., "hooks": [...]}`) with matcher propagation, and drops command-type entries with empty commands (a real-world `~/.claude/settings.json` previously parsed into empty-command junk). Flat form still supported.
4. **PostSampling loop wire** (`src/query/query.py`) — the one hook event TS fires from `query.ts` itself (`query.ts:1079-1089`) now fires after each completed stream. Documented deviations: awaited inline (fire-and-forget tasks would be cancelled at the agent-server's per-turn `asyncio.run` teardown, losing exactly the turn-final sample) and placed after the abort check (inline await before it would delay ESC).
5. **Trust symmetry**: `run_post_sampling_hooks` gained `untrusted_workspace` and filters to policy-source hooks under distrust — previously the router lane would have executed user-settings shell hooks in untrusted workspaces that the tool lane correctly blocks.
6. **Sub-agent inheritance**: `create_subagent_context` now carries `hook_config_manager` + `workspace_trusted` to children — otherwise PreToolUse/PostToolUse (incl. enterprise policy hooks) silently skip every sub-agent tool call (a policy bypass via the Agent tool).
7. Drive-by parity fix: loop-built `AssistantMessage` now carries `model` (field existed, never set; TS messages carry it; the hook payload and cost attribution read it).
8. Docstring fix: `query()` no longer promises a model-fallback PR that never came; fallback is committed ch04/ch05 round-4 scope (gap analysis GAP B).

### Behavior change note

Users with hooks in `~/.claude/settings.json` (shared with Claude Code by the port's config convention) will see them fire in clawcodex for the first time, in trusted workspaces only. This is the feature's designed behavior finally taking effect.

### Verification

- New tests: `tests/test_hooks_bootstrap.py` (7 — incl. canonical-format expansion, enabled=False, idempotence, executor read-path integration) + `tests/test_query_post_sampling.py` (8 — payload e2e via a real command hook, per-iteration firing, abort path, error-swallow, trust gate both ways, no-hooks fast path) + sub-agent inheritance test. All green.
- Full suite: pre-existing 9-failure baseline only (7369+ passed), no new failures.
- Live smoke (deepseek-v4-pro, headless): flat AND canonical nested formats — PostSampling fired once per iteration with real model/usage payload; matcher-scoped PreToolUse fired on the Read call. First time hooks have ever fired in the product.

### Deliberately deferred (committed owners in the gap analysis)

Model-fallback chain (ch04/ch05), dead `services/api/retry.py` reconciliation (ch04), LLM auto-mode classifier (ch06), real bubble escalation (ch08), multi-scope hook-settings merge + SessionStart/End/PreCompact router call sites + injection lane (ch02/ch11/ch12), loop-tail feature table per owner (ch05-ch16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
