### PR TITLE
feat(ch02/round4): cwd-scoped trust reads, interactive prefetch, fast-path hygiene, child startup checkpoints

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -7,29 +7,22 @@ import os
 import sys
 from pathlib import Path
 
-from rich.console import Console
-from rich.prompt import Prompt
-from rich.table import Table
-
-# WI-4.1 (ch17 Phase 4): fire keychain + MDM child processes at
-# MODULE-IMPORT time so the OS schedules them in parallel with the rest
-# of the Python interpreter's module-loading work. The handles are
-# awaited later by the consumer (typically post-trust-gate when keychain
-# values are actually needed). subprocess.Popen returns in microseconds;
-# the actual subprocess work overlaps with the heavyweight imports the
-# CLI is about to do. On non-macOS platforms these are no-ops
-# (``process=None`` sentinels) so call sites don't need to special-case
-# the platform.
+# ch02 round-4 WI-3 — nothing heavy at module scope. This module IS the
+# process entry (`clawcodex = src.cli:main`), so anything fired here is
+# paid by EVERY invocation including the fast paths (--version, mcp,
+# doctor, agent-server-as-subcommand; the Ink client's spawned backend
+# does NOT route here — it runs `python -m src.entrypoints.agent_server_cli`
+# directly). TS's fast paths pay neither rich-equivalent imports nor
+# the keychain/MDM spawns because they run before main.tsx is imported
+# (cli.tsx:84-427 vs main.tsx:13-20). The keychain/MDM prefetch now fires
+# in main() once the invocation is known to need the full pipeline; rich
+# imports live in the functions that render with them. Consumers self-heal
+# regardless — init.py awaits the same get-or-start singletons, which
+# start the subprocess on first use if the early fire was skipped.
 from src.prefetch import (
     get_or_start_keychain_prefetch,
     get_or_start_mdm_raw_read,
 )
-
-# Fire ONCE per process via the singleton getter. ``setup.run_setup``
-# reads the same handles instead of re-spawning, so the cost is paid
-# exactly once even when both entrypoints run in the same interpreter.
-_keychain_handle = get_or_start_keychain_prefetch()
-_mdm_handle = get_or_start_mdm_raw_read()
 
 
 def main():
@@ -117,6 +110,15 @@ def main():
     # The API-preconnect call previously lived here at module level;
     # it now runs inside ``init()`` so it overlaps with any callers
     # of ``init()`` (REPL, headless, etc.), not just the cli.py path.
+    # WI-4.1 (ch17 Phase 4) as relocated by ch02 round-4 WI-3: fire the
+    # keychain + MDM child processes the moment the invocation is known to
+    # need the full pipeline (all fast paths have returned above). Popen
+    # returns in microseconds; the subprocess work overlaps run_pre_action
+    # → init(), whose consumer awaits these same singleton handles
+    # (init.py:84-88). Non-macOS: no-op sentinels.
+    get_or_start_keychain_prefetch()
+    get_or_start_mdm_raw_read()
+
     profile_checkpoint("phase0_end_phase2_start")
     from src.init import run_pre_action
     run_pre_action(args)
@@ -202,6 +204,12 @@ def _run_tui_subcommand(rest: list[str]) -> int:
     from types import SimpleNamespace
 
     from src.init import run_pre_action
+
+    # Full-pipeline path — fire the keychain/MDM prefetch here just like
+    # main()'s parsed path does (ch02 round-4 WI-3): the sieve dispatched
+    # before the post-sieve fire, and init() below awaits these handles.
+    get_or_start_keychain_prefetch()
+    get_or_start_mdm_raw_read()
 
     # ``print=False`` => treated as an interactive session by run_pre_action.
     run_pre_action(SimpleNamespace(print=False))
@@ -493,6 +501,9 @@ def _split_csv(value: str | None) -> list[str]:
 
 def _show_provider_defaults_table() -> None:
     """Print a table showing available providers and their defaults."""
+    from rich.console import Console
+    from rich.table import Table
+
     from src.providers import PROVIDER_INFO
 
     console = Console()
@@ -514,6 +525,9 @@ def _show_provider_defaults_table() -> None:
 
 def handle_login():
     """Interactive API configuration."""
+    from rich.console import Console
+    from rich.prompt import Prompt
+
     console = Console()
     console.print("\n[bold blue]ClawCodex - API Configuration[/bold blue]\n")
 
@@ -564,6 +578,8 @@ def handle_login():
 
 def show_config():
     """Show current configuration."""
+    from rich.console import Console
+
     console = Console()
 
     try:

--- a/src/config.py
+++ b/src/config.py
@@ -161,15 +161,34 @@ _UNTRUSTED_TIER_BLOCKED_KEYS: frozenset[str] = frozenset(
 )
 
 
-def _session_trusted() -> bool:
-    try:
-        from src.bootstrap.state import get_session_trust_accepted
+def _session_trusted(cwd: str | Path | None = None) -> bool:
+    """Is the workspace the given manager reads trusted?
 
-        return get_session_trust_accepted()
+    ch02 round-4 WI-1 — cwd-scoped. The old body read only the
+    process-global session flag, which the agent-server CHILD never sets
+    (the parent's ``establish_session_trust`` runs in the parent process),
+    so the interactive path stripped trusted-project provider config that
+    headless honored. Flipping the global flag in the child instead would
+    leak trust across sessions (one server process can host sessions with
+    different cwds — ``session_manager.py:59-80``).
+
+    ``check_trust_accepted`` gives both semantics in one read: the
+    session-flag short-circuit first (parent piped-stdin implicit trust),
+    else the PERSISTED per-project verdict for exactly the cwd whose
+    project/local tiers are being merged. Memoized per-cwd in
+    ``startup_gates``.
+
+    Fail-closed on exception (unknown trust strips the committable
+    tiers) — deliberately stricter than the round-3 body's fail-open,
+    whose rationale (bootstrap-state import unavailable) doesn't apply to
+    the persisted walk.
+    """
+    try:
+        from src.services.startup_gates import check_trust_accepted
+
+        return check_trust_accepted(cwd)
     except Exception:
-        # Bootstrap state unavailable (early import, standalone script):
-        # fail toward the pre-round-3 behavior rather than breaking reads.
-        return True
+        return False
 
 
 def _strip_untrusted_keys(tier: dict[str, Any]) -> dict[str, Any]:
@@ -235,7 +254,9 @@ class ConfigManager:
         merged = self.load_global()
         project = self.load_project()
         local = self.load_local()
-        if not _session_trusted():
+        # Gate on the SAME cwd the project/local tiers were resolved from
+        # (self.cwd None ⇒ process cwd on both sides).
+        if not _session_trusted(self.cwd):
             project = _strip_untrusted_keys(project)
             local = _strip_untrusted_keys(local)
         merged = _deep_merge(merged, project)
@@ -345,6 +366,15 @@ def update_project_entry(
     except OSError:
         return False
     _get_default_manager().invalidate()
+    # Project entries carry the folder-trust verdict; drop the per-cwd
+    # trust memo so a just-recorded acceptance is visible to the next
+    # get_merged strip decision (ch02 round-4 WI-1).
+    try:
+        from src.services.startup_gates import _invalidate_trust_memo
+
+        _invalidate_trust_memo()
+    except Exception:
+        pass
     return True
 
 

--- a/src/deferred_init.py
+++ b/src/deferred_init.py
@@ -10,12 +10,11 @@ caches instead of paying the cold filesystem/subprocess cost inside the
 user's first request.
 
 Trust gating mirrors TS ``prefetchSystemContextIfSafe``: system context
-(git subprocess execution in the workspace) only runs when
-``bootstrap.state.get_session_trust_accepted()`` is True. Post ch02
-round-3 PR-1 that flag covers both TS conditions (explicit trust OR
-non-interactive implicit trust). Deliberately NOT gated on
-``ToolContext.workspace_trusted`` — that field has no production
-setters yet (ch12 follow-up).
+(git subprocess execution in the workspace) only runs when the workspace
+is trusted. ch02 round-4: the gate is ``check_trust_accepted(cwd)`` —
+the session-flag short-circuit covers the parent's explicit/implicit
+grants, and the persisted per-project verdict covers the agent-server
+child, which never sets the in-process flag.
 
 Two execution modes, because the port's entrypoints split by loop
 ownership:
@@ -55,11 +54,17 @@ class DeferredPrefetchHandle:
             self.thread.join(timeout=timeout)
 
 
-def _system_context_allowed() -> bool:
+def _system_context_allowed(cwd: str | None = None) -> bool:
+    # ch02 round-4 WI-1: cwd-composed. The agent-server CHILD never sets
+    # the in-process session flag (the parent's establish_session_trust
+    # ran in the parent), so the old bootstrap-flag read kept the git half
+    # dead on the interactive path. check_trust_accepted embeds the
+    # session-flag short-circuit (parent semantics unchanged) and
+    # otherwise reads the persisted per-project verdict for THIS cwd.
     try:
-        from src.bootstrap.state import get_session_trust_accepted
+        from src.services.startup_gates import check_trust_accepted
 
-        return get_session_trust_accepted()
+        return check_trust_accepted(cwd)
     except Exception:
         return False
 
@@ -102,7 +107,7 @@ def start_deferred_prefetches(
     fills lanes that are still cold.
     """
     if include_system_context is None:
-        include_system_context = _system_context_allowed()
+        include_system_context = _system_context_allowed(cwd)
 
     try:
         loop = asyncio.get_running_loop()

--- a/src/entrypoints/agent_server_cli.py
+++ b/src/entrypoints/agent_server_cli.py
@@ -26,10 +26,21 @@ import sys
 import threading
 from pathlib import Path
 
+# ch02 round-4 WI-4 — bracket the child's import cost. This module is the
+# spawned backend's entry (`python -m src.entrypoints.agent_server_cli`),
+# and the transitive agent_server/query/tool imports below dominate its
+# cold start. Zero cost unless CLAUDE_CODE_PROFILE_STARTUP is set (the
+# gate latches at startup_profiler import).
+from src.utils.startup_profiler import profile_checkpoint
+
+profile_checkpoint("agent_server_import_start")
+
 from src.server.agent_server import AgentServerConfig, PROTOCOL_VERSION, make_spawn_agent
 from src.server.server import DirectConnectServer
 from src.server.session_manager import SessionManager
 from src.server.types import ServerConfig
+
+profile_checkpoint("agent_server_import_end")
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +137,14 @@ async def _serve_stdio(workspace: str, agent_config: AgentServerConfig) -> int:
     RESERVED for JSON frames (diagnostics go to ``stderr``); ``stdin`` EOF — the
     parent TUI going away — ends the session.
     """
+    profile_checkpoint("agent_server_serve_start")
+    # This transport serves exactly ONE session (the Ink client's child, or
+    # a hand-run standalone). single_session unlocks the process-global
+    # side effects in _build_runtime (post-trust env apply, context-cache
+    # prefetch) that the multi-session --http transport must not perform.
+    import dataclasses as _dc
+
+    agent_config = _dc.replace(agent_config, single_session=True)
     index_path = Path.home() / ".clawcodex" / "server-sessions.json"
     index_path.parent.mkdir(parents=True, exist_ok=True)
     manager = SessionManager(workspace=workspace, index_path=index_path)

--- a/src/prefetch.py
+++ b/src/prefetch.py
@@ -145,10 +145,12 @@ def start_keychain_prefetch() -> PrefetchHandle:
 def get_or_start_keychain_prefetch() -> PrefetchHandle:
     """Process-wide singleton: fire once per interpreter, return same handle.
 
-    Resolves the cli.py/setup.py double-fire: ``cli.py`` calls this at
-    module import time so the cost overlaps argparse; ``setup.run_setup``
-    later calls the same getter and gets the in-flight handle instead of
-    spawning a second subprocess.
+    Resolves the double-fire between call sites: ``cli.py`` fires this in
+    ``main()`` once the invocation is known to need the full pipeline
+    (ch02 round-4 WI-3 — fast paths like ``--version``/``mcp`` no longer
+    spawn it); ``init()`` later awaits the same getter and gets the
+    in-flight handle (or starts it, self-healing) instead of spawning a
+    second subprocess.
     """
     with _singleton_lock:
         cached = _singletons.get("keychain")

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -85,6 +85,13 @@ class AgentServerConfig:
     allowed_tools: tuple[str, ...] = ()
     disallowed_tools: tuple[str, ...] = ()
     permission_timeout_s: float = DEFAULT_PERMISSION_TIMEOUT_S
+    # ch02 round-4 (critic B1): True only on the --stdio transport, which
+    # serves exactly one session (the Ink client's spawned child). Gates
+    # the process-global side effects in _build_runtime (post-trust env
+    # apply, context-cache prefetch) that would bleed across sessions on
+    # the multi-session --http transport, where sessions carry
+    # client-supplied cwds and over-strict is the safe direction.
+    single_session: bool = False
 
 
 @dataclass
@@ -1639,6 +1646,63 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
         from src.agent import Session
         from src.tool_system.context import ToolContext
         from src.tool_system.defaults import build_default_registry
+        from src.utils.startup_profiler import profile_checkpoint
+
+        profile_checkpoint("agent_server_build_runtime_start")
+
+        # ch02 round-4 WI-1 — one persisted-trust verdict for this
+        # session's cwd, evaluated BEFORE any config read: get_merged's
+        # untrusted-tier strip now gates per-cwd on this same source, and
+        # the provider below is resolved through that merge. Never
+        # prompts; NEVER flips the process-global session flag — one
+        # server process can host sessions with different (even
+        # client-supplied, on --http) cwds, and the flag short-circuits
+        # check_trust_accepted for every later session (critic B1).
+        trusted = False
+        try:
+            from src.services.startup_gates import check_trust_accepted
+
+            trusted = check_trust_accepted(sess.cwd)
+        except Exception:  # noqa: BLE001 — unknown trust stays untrusted
+            logger.debug("[agent-server] trust check failed", exc_info=True)
+        if trusted and sess.config.single_session:
+            # Post-trust env repair for a standalone single-session server
+            # (`clawcodex agent-server --stdio` run by hand — no parent
+            # bootstrap applied any config env). For the Ink-spawned child
+            # this re-applies what the parent already applied — an
+            # idempotent no-op. Gated single_session (critic B1): on the
+            # multi-session --http transport a session must not mutate the
+            # process-global os.environ from its project config (bleed
+            # into other sessions + unlocked concurrent mutation).
+            # Standalone limitation, documented (critic M2): the MDM
+            # policy tier and keychain stash live in init()'s SAFE pass,
+            # which no agent-server lane runs — config-file env only here.
+            try:
+                from src.permissions.trust_boundary import (
+                    apply_full_config_environment_variables,
+                )
+
+                apply_full_config_environment_variables()
+            except Exception:  # noqa: BLE001 — env repair is best-effort
+                logger.debug("[agent-server] post-trust env apply failed",
+                             exc_info=True)
+        # ch02 round-4 WI-2 — warm the context caches (CLAUDE.md walk,
+        # git status when trusted) during the user's typing window; the
+        # first turn's build_context_prompt reads the same underlying
+        # caches. Fire-and-forget daemon thread; failures swallowed.
+        # Gated single_session: _git_context_cache is process-global and
+        # not cwd-keyed (pre-existing; ch03 follow-up), so warming it on a
+        # multi-session --http server would seed other sessions' prompts
+        # with this session's git status (critic M3).
+        if sess.config.single_session:
+            try:
+                from src.deferred_init import start_deferred_prefetches
+
+                start_deferred_prefetches(cwd=sess.cwd)
+            except Exception:  # noqa: BLE001 — prefetch is advisory
+                logger.debug("[agent-server] deferred prefetch kick failed",
+                             exc_info=True)
+        profile_checkpoint("agent_server_trust_prefetch_done")
 
         cfg = sess.config
         provider_name = cfg.provider_name or get_default_provider()
@@ -1657,8 +1721,10 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
         provider = provider_cls(
             api_key=api_key, base_url=provider_cfg.get("base_url"), model=model
         )
+        profile_checkpoint("agent_server_provider_ready")
 
         registry = build_default_registry(provider=provider)
+        profile_checkpoint("agent_server_registry_built")
         if cfg.allowed_tools:
             allow = {n.lower() for n in cfg.allowed_tools}
             _filter_registry(registry, keep=lambda n: n.lower() in allow)
@@ -1694,6 +1760,7 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
                 )
         except Exception:  # noqa: BLE001 — MCP must never break startup
             logger.debug("[agent-server] MCP bootstrap skipped", exc_info=True)
+        profile_checkpoint("agent_server_mcp_done")
 
         workspace_root = Path(sess.cwd)
         mode = perm_mode or cfg.permission_mode or "default"
@@ -1718,16 +1785,12 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
         tool_context.hook_config_manager = bootstrap_hook_config_manager(
             cwd=sess.cwd,
         )
-        # workspace_trusted feeds the hook trust gate (trust_gate WI-0.2);
-        # it defaulted False with no production setter, so even configured
-        # hooks were silently skipped. Same source of truth as the CLI's
-        # startup trust gate (TS computeTrustDialogAccepted parity).
-        try:
-            from src.services.startup_gates import check_trust_accepted
-
-            tool_context.workspace_trusted = check_trust_accepted(sess.cwd)
-        except Exception:  # noqa: BLE001 — unknown trust stays untrusted
-            logger.debug("[agent-server] trust check failed", exc_info=True)
+        # workspace_trusted feeds the hook trust gate (trust_gate WI-0.2) —
+        # the verdict hoisted at function entry (ch02 WI-1), same source of
+        # truth as the CLI's startup trust gate (computeTrustDialogAccepted
+        # parity).
+        tool_context.workspace_trusted = trusted
+        profile_checkpoint("agent_server_permissions_hooks_done")
         if sess._mcp_runtime is not None:
             tool_context.mcp_clients = sess._mcp_runtime.clients  # server-name catalog for the agent tool
 
@@ -1745,6 +1808,7 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
         except Exception:  # noqa: BLE001 - fall back to a plain prompt
             logger.debug("[agent-server] system prompt build failed", exc_info=True)
             system_prompt = "You are a helpful assistant."
+        profile_checkpoint("agent_server_prompt_built")
 
         sess.provider = provider
         sess.provider_name = provider_name
@@ -1755,6 +1819,7 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
         sess.session = Session.create(provider_name, getattr(provider, "model", model or ""))
         sess._base_system_prompt = system_prompt
         sess.system_prompt = sess._compose_with_plan(system_prompt)  # honor an existing /plan
+        profile_checkpoint("agent_server_build_runtime_end")
     except Exception as exc:  # noqa: BLE001
         logger.exception("[agent-server] runtime build failed")
         sess.init_error = f"agent-server failed to start: {exc}"

--- a/src/services/startup_gates.py
+++ b/src/services/startup_gates.py
@@ -57,11 +57,41 @@ _session_trust_accepted = False
 def reset_session_trust_for_testing() -> None:
     global _session_trust_accepted
     _session_trust_accepted = False
+    _invalidate_trust_memo()
 
 
 # ---------------------------------------------------------------------------
 # Gate 1: folder trust
 # ---------------------------------------------------------------------------
+
+# ch02 round-4 WI-1 — per-cwd verdict memo. config.get_merged now gates its
+# untrusted-tier strip on check_trust_accepted(<manager cwd>) on EVERY merge,
+# so the parent-walk must not re-read config files each time. Invalidated by
+# grant_session_trust / record_trust_accepted (the only in-process writers of
+# the verdict). A grant made by ANOTHER process is observed at next process
+# start — fails safe (stale False, never stale True... a stale entry can only
+# be False→True, and False keeps the strict behavior).
+_trust_verdict_memo: dict[str, bool] = {}
+
+
+def _invalidate_trust_memo() -> None:
+    _trust_verdict_memo.clear()
+
+
+def _bootstrap_session_trust() -> bool:
+    """The bootstrap-state twin of ``_session_trust_accepted``.
+
+    ``grant_session_trust`` sets both flags and documents that they must
+    never desync; consulting both here makes the canonical gate robust to
+    callers (tests, embedders) that set only the bootstrap one.
+    """
+    try:
+        from src.bootstrap.state import get_session_trust_accepted
+
+        return get_session_trust_accepted()
+    except Exception:
+        return False
+
 
 def check_trust_accepted(cwd: str | Path | None = None) -> bool:
     """TS ``computeTrustDialogAccepted``: session trust, then cwd and
@@ -72,19 +102,30 @@ def check_trust_accepted(cwd: str | Path | None = None) -> bool:
     can yield a non-ancestor root; trust recorded there is then missed
     and the dialog re-asks — fails safe, never silently trusts.)"""
 
-    if _session_trust_accepted:
+    if _session_trust_accepted or _bootstrap_session_trust():
         return True
 
     from src import config as config_mod
 
-    current = Path(config_mod.normalize_path_for_config_key(cwd or Path.cwd()))
+    start = Path(config_mod.normalize_path_for_config_key(cwd or Path.cwd()))
+    memo_key = str(start)
+    cached = _trust_verdict_memo.get(memo_key)
+    if cached is not None:
+        return cached
+
+    current = start
+    result = False
     while True:
         if config_mod.get_project_entry(current).get(TRUST_KEY):
-            return True
+            result = True
+            break
         parent = current.parent
         if parent == current:
-            return False
+            break
         current = parent
+
+    _trust_verdict_memo[memo_key] = result
+    return result
 
 
 def grant_session_trust() -> None:
@@ -100,6 +141,7 @@ def grant_session_trust() -> None:
     """
     global _session_trust_accepted
     _session_trust_accepted = True
+    _invalidate_trust_memo()
     try:
         from src.bootstrap.state import set_session_trust_accepted
 

--- a/tests/test_ch02_bootstrap_round4.py
+++ b/tests/test_ch02_bootstrap_round4.py
@@ -1,0 +1,321 @@
+"""ch02 round-4 acceptance tests: cwd-scoped trust reads, interactive
+prefetch wire, fast-path hygiene, child startup checkpoints.
+
+Covers the four work items of my-docs/port-improvement-round-4/
+ch02-bootstrap-round4-plan.md:
+
+WI-1 — `config.get_merged`'s untrusted-tier strip gates per-cwd on the
+persisted verdict (`check_trust_accepted`), so the agent-server child —
+which never sets the process-global session flag — honors a trusted
+project's `providers`/`default_provider`/`env` config, while sessions in
+untrusted cwds within the SAME process stay stripped.
+
+WI-2 — `_build_runtime` kicks `start_deferred_prefetches(cwd)`.
+
+WI-3 — fast paths (`--version`, sieve subcommands) do not spawn the
+keychain/MDM prefetch; the full-pipeline path fires it before
+`run_pre_action`.
+
+WI-4 — `_build_runtime` records startup checkpoints.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.services.startup_gates import (
+    TRUST_KEY,
+    check_trust_accepted,
+    reset_session_trust_for_testing,
+)
+
+
+def _reset_all_trust_flags() -> None:
+    """Both session-trust flags (startup_gates' + bootstrap state's) — the
+    canonical gate honors either, so tests must clear both."""
+    reset_session_trust_for_testing()
+    from src.bootstrap.state import set_session_trust_accepted
+
+    set_session_trust_accepted(False)
+
+
+def _write_global_config(config_dir: Path, *, trusted_paths: list[str]) -> Path:
+    """Write a global config whose ``projects`` map trusts *trusted_paths*."""
+    from src.config import normalize_path_for_config_key
+
+    cfg = {
+        "projects": {
+            normalize_path_for_config_key(p): {TRUST_KEY: True}
+            for p in trusted_paths
+        }
+    }
+    path = config_dir / "config.json"
+    path.write_text(json.dumps(cfg), encoding="utf-8")
+    return path
+
+
+class _TrustHarness(unittest.TestCase):
+    """Temp global config + two workspaces (one trusted, one not), with the
+    session flag OFF — the agent-server child's exact situation."""
+
+    def setUp(self) -> None:
+        import shutil
+        import subprocess
+
+        if shutil.which("git") is None:  # pragma: no cover
+            self.skipTest("git not available (project config needs a git root)")
+        _reset_all_trust_flags()
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        self.trusted_ws = root / "trusted-ws"
+        self.untrusted_ws = root / "untrusted-ws"
+        for ws in (self.trusted_ws, self.untrusted_ws):
+            (ws / ".claude").mkdir(parents=True)
+            # Project-tier config resolves from the git root.
+            subprocess.run(
+                ["git", "init", "-q", str(ws)], check=True, capture_output=True,
+            )
+            (ws / ".claude" / "config.json").write_text(json.dumps({
+                "providers": {"deepseek": {"base_url": "https://project.example"}},
+                "default_provider": "deepseek",
+                "env": {"PROJECT_MARKER": "1"},
+                "harmless_key": {"kept": True},
+            }), encoding="utf-8")
+        self.config_dir = root / "config-home"
+        self.config_dir.mkdir()
+        self.global_path = _write_global_config(
+            self.config_dir, trusted_paths=[str(self.trusted_ws)],
+        )
+        self._patches = [
+            # ConfigManager.load_global resolves via get_global_config_path;
+            # the trust walk (get_project_entry) + update_project_entry
+            # resolve via GLOBAL_CONFIG_DIR at call time. Point both at the
+            # same temp file so the two lanes agree.
+            patch("src.config.get_global_config_path", return_value=self.global_path),
+            patch("src.config.GLOBAL_CONFIG_DIR", str(self.config_dir)),
+        ]
+        for p in self._patches:
+            p.start()
+
+    def tearDown(self) -> None:
+        for p in self._patches:
+            p.stop()
+        _reset_all_trust_flags()
+        self._tmp.cleanup()
+
+
+class TestCwdScopedTrustGate(_TrustHarness):
+    def _merged(self, cwd: Path) -> dict:
+        from src.config import ConfigManager
+
+        return ConfigManager(cwd=cwd).get_merged()
+
+    def test_trusted_cwd_honors_project_provider_config(self) -> None:
+        merged = self._merged(self.trusted_ws)
+        self.assertEqual(merged.get("default_provider"), "deepseek")
+        self.assertEqual(
+            merged.get("providers", {}).get("deepseek", {}).get("base_url"),
+            "https://project.example",
+        )
+        self.assertEqual(merged.get("env", {}).get("PROJECT_MARKER"), "1")
+
+    def test_untrusted_cwd_strips_blocked_keys_but_keeps_others(self) -> None:
+        merged = self._merged(self.untrusted_ws)
+        self.assertNotEqual(merged.get("default_provider"), "deepseek")
+        # The global tier's built-in deepseek defaults legitimately remain;
+        # what must NOT land is the project tier's base_url override.
+        self.assertNotEqual(
+            merged.get("providers", {}).get("deepseek", {}).get("base_url"),
+            "https://project.example",
+        )
+        self.assertNotIn("PROJECT_MARKER", merged.get("env", {}) or {})
+        self.assertEqual(merged.get("harmless_key"), {"kept": True})
+
+    def test_multi_session_property_independent_verdicts(self) -> None:
+        """One process, two managers, different cwds — the trusted one must
+        not leak trust into the untrusted one (the reason WI-1 rejects a
+        process-global flag flip)."""
+        trusted = self._merged(self.trusted_ws)
+        untrusted = self._merged(self.untrusted_ws)
+        self.assertEqual(trusted.get("default_provider"), "deepseek")
+        self.assertNotEqual(untrusted.get("default_provider"), "deepseek")
+
+    def test_memo_invalidated_by_record_trust_accepted(self) -> None:
+        from src.services.startup_gates import record_trust_accepted
+
+        self.assertFalse(check_trust_accepted(self.untrusted_ws))
+        # record_trust_accepted persists via update_project_entry (which
+        # drops the memo) and grants the session flag; the next read must
+        # see the flip.
+        record_trust_accepted(self.untrusted_ws)
+        self.assertTrue(check_trust_accepted(self.untrusted_ws))
+        # And the config gate follows.
+        _reset_all_trust_flags()  # drop the session flag; persisted verdict remains
+        merged = self._merged(self.untrusted_ws)
+        self.assertEqual(merged.get("default_provider"), "deepseek")
+
+    def test_session_flag_shortcircuit_preserved(self) -> None:
+        """Parent semantics: implicit (piped-stdin) trust grants apply to
+        every cwd in that process — unchanged by the cwd scoping."""
+        from src.services.startup_gates import grant_session_trust
+
+        grant_session_trust()
+        merged = self._merged(self.untrusted_ws)
+        self.assertEqual(merged.get("default_provider"), "deepseek")
+
+    def test_deferred_prefetch_gate_is_cwd_scoped(self) -> None:
+        from src.deferred_init import _system_context_allowed
+
+        self.assertTrue(_system_context_allowed(str(self.trusted_ws)))
+        self.assertFalse(_system_context_allowed(str(self.untrusted_ws)))
+
+
+class TestBuildRuntimeWiring(_TrustHarness):
+    """WI-1 step 3 + WI-2 + WI-4 at the `_build_runtime` seam. The config
+    names an unknown provider so the build early-returns right after the
+    trust/prefetch/checkpoint block — cheap and hermetic."""
+
+    def _build(self, cwd: Path, checkpoints: list[str], *, single_session: bool = True):
+        from src.server.agent_server import AgentServerConfig, _AgentSession
+
+        sess = _AgentSession(
+            session_id="s1",
+            cwd=str(cwd),
+            config=AgentServerConfig(
+                provider_name="definitely-not-a-provider",
+                single_session=single_session,
+            ),
+            loop=MagicMock(),
+            out_queue=MagicMock(),
+        )
+        with patch(
+            "src.utils.startup_profiler.profile_checkpoint",
+            side_effect=checkpoints.append,
+        ), patch(
+            "src.deferred_init.start_deferred_prefetches",
+        ) as prefetch_spy, patch(
+            "src.permissions.trust_boundary.apply_full_config_environment_variables",
+        ) as env_spy:
+            from src.server.agent_server import _build_runtime
+
+            _build_runtime(sess, None)
+        return sess, prefetch_spy, env_spy
+
+    def test_trusted_cwd_applies_env_and_kicks_prefetch(self) -> None:
+        checkpoints: list[str] = []
+        sess, prefetch_spy, env_spy = self._build(self.trusted_ws, checkpoints)
+        env_spy.assert_called_once()
+        prefetch_spy.assert_called_once_with(cwd=str(self.trusted_ws))
+        self.assertIn("agent_server_build_runtime_start", checkpoints)
+        self.assertIn("agent_server_trust_prefetch_done", checkpoints)
+
+    def test_untrusted_cwd_skips_env_apply_but_still_prefetches(self) -> None:
+        checkpoints: list[str] = []
+        sess, prefetch_spy, env_spy = self._build(self.untrusted_ws, checkpoints)
+        env_spy.assert_not_called()
+        prefetch_spy.assert_called_once_with(cwd=str(self.untrusted_ws))
+
+    def test_multi_session_transport_never_touches_process_globals(self) -> None:
+        """critic B1/M3 — the --http shape (single_session=False): even a
+        TRUSTED cwd must not apply project env process-wide nor warm the
+        non-cwd-keyed context caches. Over-strict is the safe direction;
+        the per-cwd config gate (TestCwdScopedTrustGate) still applies."""
+        checkpoints: list[str] = []
+        sess, prefetch_spy, env_spy = self._build(
+            self.trusted_ws, checkpoints, single_session=False,
+        )
+        env_spy.assert_not_called()
+        prefetch_spy.assert_not_called()
+
+    def test_no_global_trust_flag_flip_ever(self) -> None:
+        """critic B1 — a trusted single-session build must not set the
+        process-global session-trust flags (a later session with another
+        cwd would short-circuit check_trust_accepted on them)."""
+        from src.bootstrap.state import get_session_trust_accepted
+        import src.services.startup_gates as gates
+
+        checkpoints: list[str] = []
+        self._build(self.trusted_ws, checkpoints)
+        self.assertFalse(gates._session_trust_accepted)
+        self.assertFalse(get_session_trust_accepted())
+        # And an untrusted cwd evaluated afterwards stays untrusted.
+        self.assertFalse(check_trust_accepted(self.untrusted_ws))
+
+
+class TestFastPathHygiene(unittest.TestCase):
+    """WI-3 — fast paths must not spawn the keychain/MDM prefetch."""
+
+    def _spies(self):
+        return (
+            patch("src.cli.get_or_start_keychain_prefetch"),
+            patch("src.cli.get_or_start_mdm_raw_read"),
+        )
+
+    def test_version_flag_does_not_fire_prefetch(self) -> None:
+        import src.cli as cli
+
+        kp, mp = self._spies()
+        with kp as k, mp as m, patch.object(cli.sys, "argv", ["clawcodex", "--version"]):
+            rc = cli.main()
+        self.assertEqual(rc, 0)
+        k.assert_not_called()
+        m.assert_not_called()
+
+    def test_sieve_subcommand_does_not_fire_prefetch(self) -> None:
+        import src.cli as cli
+
+        kp, mp = self._spies()
+        with kp as k, mp as m, patch.object(
+            cli.sys, "argv", ["clawcodex", "doctor"],
+        ), patch("src.entrypoints.doctor.run_doctor", return_value=0):
+            rc = cli.main()
+        self.assertEqual(rc, 0)
+        k.assert_not_called()
+        m.assert_not_called()
+
+    def test_full_pipeline_fires_prefetch_before_pre_action(self) -> None:
+        import src.cli as cli
+
+        order: list[str] = []
+        kp, mp = self._spies()
+        with kp as k, mp as m, patch.object(
+            cli.sys, "argv", ["clawcodex", "-p", "hi"],
+        ), patch("src.init.run_pre_action", side_effect=lambda a: order.append("pre_action")):
+            k.side_effect = lambda: order.append("keychain")
+            m.side_effect = lambda: order.append("mdm")
+            # Stop the run right after pre_action — print mode would need a
+            # provider; the ordering property is established by then.
+            with patch.object(cli, "_resolve_permission_state", side_effect=SystemExit(0)):
+                with self.assertRaises(SystemExit):
+                    cli.main()
+        self.assertEqual(order[:3], ["keychain", "mdm", "pre_action"])
+
+    def test_module_import_fires_nothing(self) -> None:
+        """The import-time fire is gone: importing src.cli must not create
+        prefetch singletons. Run in a pristine subprocess so this pins the
+        real import-time behavior regardless of test ordering."""
+        import subprocess
+        import sys
+
+        code = (
+            "import src.cli, src.prefetch as p; "
+            "import sys; sys.exit(0 if not p._singletons else 1)"
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=str(Path(__file__).resolve().parents[1]),
+            capture_output=True,
+            timeout=60,
+        )
+        self.assertEqual(
+            proc.returncode, 0,
+            f"prefetch singletons created at import: {proc.stderr.decode()[:400]}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prefetch.py
+++ b/tests/test_prefetch.py
@@ -114,29 +114,21 @@ class TestWaitAndRead(unittest.TestCase):
 
 
 class TestModuleLevelFireAndForget(unittest.TestCase):
-    """``src/cli.py`` fires the prefetch at module-import time.
-
-    Structural test (per critic M10): importing ``src.cli`` should result
-    in module-level handles being populated. We don't time the subprocess
-    work itself (that's OS-scheduling-dependent and would flake on CI);
-    we just verify the wiring is in place.
+    """ch02 round-4 WI-3 INVERTED the original contract: ``src/cli.py`` no
+    longer fires the prefetch at module-import time — fast paths like
+    ``--version``/``mcp`` must not spawn subprocesses. ``main()`` fires it
+    once the invocation is known to need the full pipeline; the
+    fire-before-init ordering and fast-path skips are pinned by
+    tests/test_ch02_bootstrap_round4.py::TestFastPathHygiene.
     """
 
-    def test_cli_module_import_populates_prefetch_handles(self):
+    def test_cli_module_import_fires_nothing(self):
         # Re-import to ensure module-level code re-runs in a clean way.
         import importlib
         import src.cli
         importlib.reload(src.cli)
-        self.assertIsInstance(src.cli._keychain_handle, PrefetchHandle)
-        self.assertIsInstance(src.cli._mdm_handle, PrefetchHandle)
-        # Drain children if spawned, so the test process exits cleanly.
-        for handle in (src.cli._keychain_handle, src.cli._mdm_handle):
-            if handle.process is not None:
-                try:
-                    handle.process.kill()
-                    handle.process.wait(timeout=2.0)
-                except Exception:
-                    pass
+        self.assertFalse(hasattr(src.cli, "_keychain_handle"))
+        self.assertFalse(hasattr(src.cli, "_mdm_handle"))
 
 
 class TestProjectScanStub(unittest.TestCase):


### PR DESCRIPTION
## Round-4 ch02 (bootstrap): cwd-scoped trust reads, interactive prefetch, fast-path hygiene, child startup checkpoints

**Docs:** `my-docs/ch02-bootstrap-round4-gap-analysis.md` + `my-docs/port-improvement-round-4/ch02-bootstrap-round4-plan.md` (+ two facet reports, critic verdict). Round-3's trust-boundary work (GAP A/A5, CA-certs) re-verified FIXED at current main.

### WI-1 — the two-process split orphaned session trust in the agent-server child (behavioral fix, critic-hardened)

The parent CLI's `establish_session_trust()` sets in-process flags the spawned child never sees, so on the PRIMARY interactive path `config._session_trusted()` was False forever → `get_merged` stripped `providers`/`default_provider`/`env` from a **trusted** project's `.claude/config.json` — while headless (`-p`) honored them. Same input, different behavior per surface.

The naive fix (seed the global flag in the child) is a hole the critic's review confirmed independently: one server process can host sessions with different, client-supplied cwds (`--http`), and the flag is monotonic + short-circuits `check_trust_accepted` for every later session. Instead:

- `config._session_trusted(cwd)` now delegates to `check_trust_accepted(<manager cwd>)` — read-only, per-cwd, multi-session-safe on every transport; session-flag short-circuit preserves parent (piped-stdin implicit trust) semantics; fails closed.
- `check_trust_accepted` gains a per-cwd memo (get_merged is hot), invalidated by `grant_session_trust` / `record_trust_accepted` / `update_project_entry`, and honors the bootstrap-state twin flag (the documented never-desync contract, made robust).
- New `AgentServerConfig.single_session` (True only on `--stdio`, the Ink child's transport): post-trust env apply (standalone repair; idempotent no-op for spawned children) and the WI-2 prefetch kick are gated on it — the multi-session `--http` transport never mutates process-global state from a session's project config (cross-session bleed + unlocked concurrent mutation). Documented limitations: standalone servers get config-file env only (MDM/keychain live in `init()`'s SAFE pass → ch16); parent home-dir trust is session-only → child strips (safe direction).
- Tests pin the multi-session properties: independent per-cwd verdicts in one process, `--http` shape never touches process globals, no global flag flip ever.

### WI-2 — deferred prefetch on the interactive path

`start_deferred_prefetches(cwd)` now fires in `_build_runtime` (single-session lane): warms `_memory_files_cache` + `_git_context_cache` — verified to be the same underlying caches the first turn's `build_context_prompt` reads — during the user's typing window. Git half is trust-gated per-cwd. (Git caches are process-global and not cwd-keyed — pre-existing `--http` bleed recorded as a ch03 follow-up; the kick is single-session-gated for exactly that reason.)

### WI-3 — fast paths stop paying module-level costs

`src.cli` no longer fires the keychain/MDM subprocess spawns at import and no longer imports `rich` at module level; `main()` fires the prefetch once the invocation is known to need the full pipeline (`tui` subcommand path included). `--version`/`mcp`/`doctor`/`daemon`/`login`/`config`/`agent-server`-as-subcommand no longer spawn two subprocesses per invocation. Consumers self-heal via the get-or-start singletons. (Scope note per critic: the Ink-spawned child enters via `python -m src.entrypoints.agent_server_cli` and never imported `src.cli` — this is fast-path hygiene, not a child cold-start change.) The old test pinning fire-at-import was updated to pin the inverted contract.

### WI-4 — the ~22s child cold start is finally measurable

`profile_checkpoint` brackets in `agent_server_cli` (import start/end, serve) and `_build_runtime` (entry, trust+prefetch, provider, registry, MCP, permissions+hooks, prompt, end). Warm-start sample from the live smoke: import 19ms → build_runtime 1.5s with prompt-build 767ms as the top slice. Zero cost when `CLAUDE_CODE_PROFILE_STARTUP` unset. This is the measurement seam ch17 needs before parallelizing `_build_runtime`.

### Verification

- New `tests/test_ch02_bootstrap_round4.py` (15) incl. the multi-session security properties; `tests/test_prefetch.py` contract update; full suite at the pre-existing 9-failure baseline.
- Live smokes: stdio child emits `system/init` with all checkpoints in the startup-perf report (pre- and post-single_session change); `--version` probe spawns nothing (`prefetch._singletons` empty); headless `-p` turn returns OK.
- Critic: REVISE round addressed in full (B1 single-session scoping, M1 GAP-C correction, M2/m3/m4 documented) → re-verdict requested; APPROVE-gated merge.

### Deferred (owners)

Migrations runner (N/A-by-content; seam `run_pre_action`); config-validation UX → ch03; git-cache cwd-keying → ch03; `--http` per-session config/provider resolution + standalone MDM/keychain bootstrap → ch16; `_build_runtime` parallelization → ch17 (on WI-4 data); early stdin capture → ch14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
