### PR TITLE
feat(ch03/round4): re-home the two-tier state bridge, live cost persistence, git-status parity

### DIFF
--- a/src/agent/session.py
+++ b/src/agent/session.py
@@ -145,30 +145,12 @@ class Session:
 def _snapshot_cost_block() -> dict:
     """Build the cost block written by ``Session.save``.
 
-    Shape matches the reader at
-    ``src/services/cost_restore.py:restore_cost_state_for_session``.
-    Module-private; tests can call via the public ``Session.save``.
+    ch03 round-4 GAP B: the schema owner moved to
+    ``src/services/cost_restore.py:build_cost_block`` (colocated with the
+    reader so writer/reader can't drift; also used by the LIVE
+    agent-server persister). This delegation is kept for the existing
+    tests/callers of ``Session.save``.
     """
-    return {
-        "total_cost_usd": get_total_cost_usd(),
-        "total_api_duration": get_total_api_duration(),
-        "total_api_duration_without_retries":
-            get_total_api_duration_without_retries(),
-        "total_tool_duration": get_total_tool_duration(),
-        "total_lines_added": get_total_lines_added(),
-        "total_lines_removed": get_total_lines_removed(),
-        # last_duration = elapsed since start_time. cost_restore uses
-        # this to back-date the new session's start_time so post-resume
-        # duration accumulators continue from where they left off.
-        "last_duration": time.time() - get_start_time(),
-        "model_usage": {
-            model: {
-                "input_tokens": u.input_tokens,
-                "output_tokens": u.output_tokens,
-                "cache_creation_input_tokens": u.cache_creation_input_tokens,
-                "cache_read_input_tokens": u.cache_read_input_tokens,
-                "cost_usd": u.cost_usd,
-            }
-            for model, u in get_model_usage().items()
-        },
-    }
+    from src.services.cost_restore import build_cost_block
+
+    return build_cost_block()

--- a/src/bootstrap/state.py
+++ b/src/bootstrap/state.py
@@ -695,7 +695,7 @@ def set_cost_state_for_restore(
 ) -> None:
     """Restore accumulators from a persisted session snapshot.
 
-    Called by the (deferred Phase 2) ``restore_cost_state_for_session``
+    Called by the ``restore_cost_state_for_session``
     orchestrator. Mirrors TS ``setCostStateForRestore``
     (``bootstrap/state.ts:955``).
     """

--- a/src/context_system/git_context.py
+++ b/src/context_system/git_context.py
@@ -42,17 +42,31 @@ class GitContextSnapshot:
 
 # ---------------------------------------------------------------------------
 # Module-level cache (mirrors TS memoize on getGitStatus)
+#
+# ch03 round-4 GAP C (inbound ch02 commitment): keyed by resolved cwd.
+# The old single-snapshot cache returned whatever was cached regardless of
+# the cwd argument, so on a multi-session --http server session B's prompt
+# could carry session A's git status. TS gets per-process correctness for
+# free (one cwd per process); the port's multi-session server needs the
+# key. Dict item writes are GIL-atomic; a race recomputes the same value.
 # ---------------------------------------------------------------------------
 
-_git_context_cache: GitContextSnapshot | None = None
-_git_is_repo_cache: bool | None = None
+_git_context_cache: dict[str, GitContextSnapshot] = {}
+_git_is_repo_cache: dict[str, bool] = {}
+
+
+def _cache_key(cwd: str | None) -> str:
+    target = cwd or os.getcwd()
+    try:
+        return os.path.realpath(target)
+    except OSError:
+        return str(target)
 
 
 def clear_git_caches() -> None:
-    """Clear the memoized git context cache (call after compact)."""
-    global _git_context_cache, _git_is_repo_cache
-    _git_context_cache = None
-    _git_is_repo_cache = None
+    """Clear the memoized git context caches — all cwds (call after compact)."""
+    _git_context_cache.clear()
+    _git_is_repo_cache.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -106,15 +120,17 @@ def _get_default_branch(cwd: str) -> str:
 # ---------------------------------------------------------------------------
 
 def get_is_git(cwd: str | None = None) -> bool:
-    """Check if the CWD is inside a git repository. Memoized."""
-    global _git_is_repo_cache
-    if _git_is_repo_cache is not None:
-        return _git_is_repo_cache
+    """Check if the CWD is inside a git repository. Memoized per cwd."""
+    key = _cache_key(cwd)
+    cached = _git_is_repo_cache.get(key)
+    if cached is not None:
+        return cached
 
     target = cwd or os.getcwd()
     result = _git_cmd(["rev-parse", "--is-inside-work-tree"], target)
-    _git_is_repo_cache = result == "true"
-    return _git_is_repo_cache
+    verdict = result == "true"
+    _git_is_repo_cache[key] = verdict
+    return verdict
 
 
 # ---------------------------------------------------------------------------
@@ -129,17 +145,18 @@ async def collect_git_context(
 
     Mirrors TS getGitStatus() from context.ts.
     Runs multiple git commands in parallel for speed.
-    Results are memoized; call clear_git_caches() to invalidate.
+    Results are memoized per cwd; call clear_git_caches() to invalidate.
     """
-    global _git_context_cache
-    if _git_context_cache is not None:
-        return _git_context_cache
+    key = _cache_key(cwd)
+    cached = _git_context_cache.get(key)
+    if cached is not None:
+        return cached
 
     target = cwd or os.getcwd()
 
     if not get_is_git(target):
         snapshot = GitContextSnapshot(available=False, error="Not a git repository")
-        _git_context_cache = snapshot
+        _git_context_cache[key] = snapshot
         return snapshot
 
     loop = asyncio.get_event_loop()
@@ -173,7 +190,12 @@ async def collect_git_context(
 
     status_truncated = False
     if status and len(status) > MAX_STATUS_CHARS:
-        status = status[:MAX_STATUS_CHARS] + "\n... (truncated)"
+        # TS-exact truncation tail (context.ts:88) — tells the model how
+        # to get the full status instead of leaving a dead end.
+        status = status[:MAX_STATUS_CHARS] + (
+            '\n... (truncated because it exceeds 2k characters. '
+            'If you need more information, run "git status" using BashTool)'
+        )
         status_truncated = True
 
     snapshot = GitContextSnapshot(
@@ -186,7 +208,7 @@ async def collect_git_context(
         status_truncated=status_truncated,
         recent_commits=commits or None,
     )
-    _git_context_cache = snapshot
+    _git_context_cache[key] = snapshot
     return snapshot
 
 
@@ -198,29 +220,38 @@ def format_git_status(ctx: GitContextSnapshot) -> str:
     """
     Format git context as a string for the systemContext.gitStatus key.
 
-    Mirrors TS getGitStatus output format from context.ts.
+    ch03 round-4 GAP C: TS-exact model-facing text (context.ts:96-103).
+    The "snapshot in time" preamble is load-bearing prompt engineering —
+    it tells the model the status will NOT update during the conversation,
+    which stops it from treating the block as live output to refresh; and
+    "Main branch (you will usually use this for PRs)" carries an
+    instruction the neutral "Default branch" label lost. Blocks join with
+    blank lines, status falls back to "(clean)" — byte-shape parity with
+    the TS join('\\n\\n') list.
     """
     if not ctx.available:
         return ""
 
-    parts: list[str] = []
-    parts.append("Git repository detected.")
+    parts: list[str] = [
+        "This is the git status at the start of the conversation. Note that "
+        "this status is a snapshot in time, and will not update during the "
+        "conversation.",
+    ]
 
     if ctx.branch:
         parts.append(f"Current branch: {ctx.branch}")
     if ctx.default_branch:
-        parts.append(f"Default branch: {ctx.default_branch}")
+        parts.append(
+            f"Main branch (you will usually use this for PRs): {ctx.default_branch}"
+        )
     if ctx.user_name:
-        parts.append(f"User: {ctx.user_name}")
+        parts.append(f"Git user: {ctx.user_name}")
 
-    if ctx.status:
-        parts.append(f"\nStatus:\n{ctx.status}")
-        if ctx.status_truncated:
-            parts.append("(Status output was truncated)")
-    else:
-        parts.append("\nWorking tree clean.")
+    # The truncation notice (when any) is already embedded in ctx.status
+    # with the TS-exact wording by collect_git_context.
+    parts.append(f"Status:\n{ctx.status or '(clean)'}")
 
     if ctx.recent_commits:
-        parts.append(f"\nRecent commits:\n{ctx.recent_commits}")
+        parts.append(f"Recent commits:\n{ctx.recent_commits}")
 
-    return "\n".join(parts)
+    return "\n\n".join(parts)

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -115,6 +115,11 @@ class _AgentSession:
     provider_name: str = ""
     tool_registry: Any = None
     tool_context: Any = None
+    # ch03 round-4 GAP A — per-session reactive AppState store (the book's
+    # §3.2 tier). Attached only on single-session transports; None on
+    # --http, where the centralized on_change side effects (user-level
+    # settings persistence) must not fire from client-supplied sessions.
+    app_state_store: Any = None
     session: Any = None
     system_prompt: Any = "You are a helpful assistant."
     _base_system_prompt: Any = None  # system prompt before the /plan section is composed in
@@ -221,6 +226,10 @@ class _AgentSession:
             mode = inner.get("mode")
             if isinstance(mode, str) and self.tool_context is not None:
                 _set_mode(self.tool_context, mode)
+                # ch03 round-4 GAP A: the live gate home stays
+                # tool_context.permission_context; the store dispatch runs
+                # the centralized seams (listeners; future persistence).
+                _dispatch_app_state(self, permission_mode=mode)
             self._ack(request_id)
             return
         if subtype == "set_model":
@@ -230,6 +239,10 @@ class _AgentSession:
                     self.provider.model = model
                 except Exception:  # noqa: BLE001
                     pass
+                # ch03 round-4 GAP A: on_change mirrors the choice into
+                # bootstrap and persists (model, model_provider) to user
+                # settings — /model survives restarts for the first time.
+                _dispatch_app_state(self, main_loop_model=model)
             self._ack(request_id)
             return
         if subtype == "set_provider":
@@ -526,6 +539,12 @@ class _AgentSession:
             payload = {
                 "session_id": self.session_id,
                 "model": getattr(self.provider, "model", None) or self.config.model or "",
+                # ch03 round-4 (critic B1): the provider the model belongs
+                # to — _do_resume's model restore is gated on it matching
+                # the current provider, the same cross-provider hazard the
+                # settings-seed guards (a stale model fired at the wrong
+                # endpoint 400s and would self-persist the bad pairing).
+                "provider": self.provider_name,
                 "cwd": self.cwd,
                 "updated_at": time.time(),
                 "message_count": len(msgs),
@@ -533,6 +552,20 @@ class _AgentSession:
                 "name": self._session_name,
                 "conversation": self.session.conversation.to_dict(),
             }
+            # ch03 round-4 GAP B — the live persister carries the cost
+            # block (schema owner: cost_restore.build_cost_block, matching
+            # the /resume reader) so accumulated cost survives restarts.
+            # single_session-gated for the same reason as the restore
+            # (critic m1): bootstrap totals are process-global, so on a
+            # multi-session --http server the block would record the SUM
+            # of all sessions' cost under one session's file.
+            if self.config.single_session:
+                try:
+                    from src.services.cost_restore import build_cost_block
+
+                    payload["cost"] = build_cost_block()
+                except Exception:  # noqa: BLE001 — cost snapshot is best-effort
+                    logger.debug("[agent-server] cost snapshot failed", exc_info=True)
             (d / f"{self.session_id}.json").write_text(json.dumps(payload), encoding="utf-8")
         except Exception:  # noqa: BLE001 — persistence must never break a turn
             logger.debug("[agent-server] session save failed", exc_info=True)
@@ -627,6 +660,11 @@ class _AgentSession:
             cfg.provider_name = name
             cfg.model = model
             self.tool_registry = registry
+            # ch03 round-4 GAP A: keep the persisted (model, model_provider)
+            # pair coherent across a provider switch — the supplier reads
+            # self.provider_name, updated above, so on_change persists the
+            # new pairing.
+            _dispatch_app_state(self, main_loop_model=model)
             self._reply(request_id, {"ok": True, "provider": name, "model": model or ""})
         except Exception as exc:  # noqa: BLE001
             logger.exception("[agent-server] set_provider failed")
@@ -1083,6 +1121,48 @@ class _AgentSession:
             data = json.loads(f.read_text(encoding="utf-8"))
             conv = Conversation.from_dict(data.get("conversation", {"messages": []}))
             self.session.conversation = conv
+            # ch03 round-4 GAP B — restore the accumulated cost counters
+            # (guarded: the reader refuses a file whose session_id header
+            # doesn't match). Gated single_session like every other
+            # process-global write: bootstrap cost totals are one set per
+            # process, and a multi-session --http server must not let one
+            # session's resume overwrite another's accounting.
+            if self.config.single_session:
+                try:
+                    from src.services.cost_restore import (
+                        restore_cost_state_for_session,
+                    )
+
+                    restore_cost_state_for_session(session_id)
+                except Exception:  # noqa: BLE001 — restore is best-effort
+                    logger.debug("[agent-server] cost restore failed",
+                                 exc_info=True)
+            # Restore the session's saved model choice under the same
+            # precedence as startup seeding: an explicit launch model
+            # (cfg.model) wins; otherwise the resumed session's model is
+            # what the user was using — put it back on the provider and
+            # through the store (persists the pairing via on_change).
+            # Provider-match guard (critic B1): the saved model applies
+            # ONLY when it was saved under the CURRENT provider — the
+            # same rule as seed_app_state_from_settings. Without it, a
+            # cross-provider resume fires a stale model at the wrong
+            # endpoint AND the store dispatch would persist the bad
+            # (model, provider) pairing, poisoning every later launch.
+            # Old session files without a "provider" field never match —
+            # fail-safe.
+            saved_model = data.get("model")
+            saved_provider = data.get("provider")
+            if (
+                isinstance(saved_model, str) and saved_model
+                and self.config.model is None
+                and self.provider is not None
+                and saved_provider == self.provider_name
+            ):
+                try:
+                    self.provider.model = saved_model
+                except Exception:  # noqa: BLE001
+                    pass
+                _dispatch_app_state(self, main_loop_model=saved_model)
             self._reply(request_id, {
                 "ok": True,
                 "count": len(conv.messages),
@@ -1723,6 +1803,11 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
         )
         profile_checkpoint("agent_server_provider_ready")
 
+        # (ch03 round-4 GAP A: the per-session AppState store is created
+        # below, once the session's launch permission mode is known, so
+        # the store's initial state doesn't misreport the mode — see the
+        # block after setup_permissions.)
+
         registry = build_default_registry(provider=provider)
         profile_checkpoint("agent_server_registry_built")
         if cfg.allowed_tools:
@@ -1764,6 +1849,38 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
 
         workspace_root = Path(sess.cwd)
         mode = perm_mode or cfg.permission_mode or "default"
+        # ch03 round-4 GAP A — re-home the two-tier bridge: a per-session
+        # AppState store whose on_change router runs the centralized side
+        # effects (bootstrap model mirror + user-settings persistence).
+        # The seed applies a persisted /model choice back to the provider
+        # under seed_app_state_from_settings' provider-match guard — an
+        # explicit model (CLI/client cfg.model) always wins. The initial
+        # state carries the session's real launch permission mode (critic
+        # n5: seeding the default then dispatching the true mode would
+        # fire a spurious first mode-change notification). Gated
+        # single_session (same rule as ch02's env apply): user-level
+        # settings writes must not fire from client-supplied --http
+        # sessions.
+        if cfg.single_session:
+            try:
+                from src.state.app_state import (
+                    create_app_state_store,
+                    replace_state,
+                    seed_app_state_from_settings,
+                    set_active_provider_supplier,
+                )
+
+                set_active_provider_supplier(lambda: sess.provider_name)
+                seeded_state = replace_state(
+                    seed_app_state_from_settings(provider_name),
+                    permission_mode=mode,
+                )
+                sess.app_state_store = create_app_state_store(seeded_state)
+                if cfg.model is None and seeded_state.main_loop_model:
+                    provider.model = seeded_state.main_loop_model
+            except Exception:  # noqa: BLE001 — store failure must not break startup
+                logger.debug("[agent-server] app-state store init failed",
+                             exc_info=True)
         bypass = mode == "bypassPermissions"
         perm_setup = setup_permissions(
             cwd=str(workspace_root),
@@ -2097,6 +2214,26 @@ def _json_safe(obj: Any) -> Any:
     if isinstance(obj, (list, tuple)):
         return [_json_safe(v) for v in obj]
     return str(obj)
+
+
+def _dispatch_app_state(sess: "_AgentSession", **changes: Any) -> None:
+    """Route a state change through the session's AppState store, if any.
+
+    ch03 round-4 GAP A — the store's on_change router owns the side
+    effects (bootstrap mirror, settings persistence, listener seams), so
+    control handlers dispatch instead of scattering those effects. No-op
+    when the session has no store (--http transports). A store failure
+    must never break the control channel.
+    """
+    store = getattr(sess, "app_state_store", None)
+    if store is None:
+        return
+    try:
+        from src.state.app_state import replace_state
+
+        store.set_state(lambda prev: replace_state(prev, **changes))
+    except Exception:  # noqa: BLE001
+        logger.debug("[agent-server] app-state dispatch failed", exc_info=True)
 
 
 def _current_mode(tool_context: Any, default: str) -> str:

--- a/src/services/cost_restore.py
+++ b/src/services/cost_restore.py
@@ -32,6 +32,52 @@ def _sessions_dir() -> Path:
     return Path.home() / ".clawcodex" / "sessions"
 
 
+def build_cost_block() -> dict[str, Any]:
+    """Snapshot the bootstrap cost counters as the persisted ``cost`` block.
+
+    ch03 round-4 GAP B — single schema owner, colocated with the reader
+    below so writer/reader can't drift. Writers: the live agent-server
+    persister (``_save_session``) and the legacy ``Session.save`` (which
+    delegates here).
+    """
+    import time
+
+    from src.bootstrap.state import (
+        get_model_usage,
+        get_start_time,
+        get_total_api_duration,
+        get_total_api_duration_without_retries,
+        get_total_cost_usd,
+        get_total_lines_added,
+        get_total_lines_removed,
+        get_total_tool_duration,
+    )
+
+    return {
+        "total_cost_usd": get_total_cost_usd(),
+        "total_api_duration": get_total_api_duration(),
+        "total_api_duration_without_retries":
+            get_total_api_duration_without_retries(),
+        "total_tool_duration": get_total_tool_duration(),
+        "total_lines_added": get_total_lines_added(),
+        "total_lines_removed": get_total_lines_removed(),
+        # last_duration = elapsed since start_time. The restore reader
+        # back-dates the new session's start_time so post-resume duration
+        # accumulators continue from where they left off.
+        "last_duration": time.time() - get_start_time(),
+        "model_usage": {
+            model: {
+                "input_tokens": u.input_tokens,
+                "output_tokens": u.output_tokens,
+                "cache_creation_input_tokens": u.cache_creation_input_tokens,
+                "cache_read_input_tokens": u.cache_read_input_tokens,
+                "cost_usd": u.cost_usd,
+            }
+            for model, u in get_model_usage().items()
+        },
+    }
+
+
 def restore_cost_state_for_session(session_id: SessionId | str) -> bool:
     """Restore cost accumulators from the persisted snapshot for
     ``session_id``.

--- a/tests/test_ch03_state_round4.py
+++ b/tests/test_ch03_state_round4.py
@@ -1,0 +1,345 @@
+"""ch03 round-4 acceptance tests: the two-tier bridge re-homed into the
+agent-server session, live cost persistence, and per-cwd git caches.
+
+Covers my-docs/port-improvement-round-4/ch03-state-round4-plan.md:
+
+WI-1 — per-session AppState store: created in `_build_runtime` on the
+single-session transport; persisted model seeds the provider under the
+provider-match guard with explicit-model precedence; `set_model` /
+`set_permission_mode` controls dispatch through the store so the
+centralized on_change side effects (bootstrap mirror + settings
+persistence) run structurally; `--http`-shaped sessions get no store.
+
+WI-2 — the live persister writes the schema-owned cost block and
+`_do_resume` restores it (session-ID guard; single-session gated) plus
+the saved model under launch-model precedence.
+
+WI-3 — git context caches are per-cwd (multi-session bleed fix).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from src.bootstrap.state import (
+    get_main_loop_model_override,
+    get_total_cost_usd,
+    reset_state_for_tests,
+)
+from src.services.startup_gates import reset_session_trust_for_testing
+
+
+def _reset_all() -> None:
+    reset_state_for_tests()
+    reset_session_trust_for_testing()
+    from src.state.app_state import set_active_provider_supplier
+
+    set_active_provider_supplier(None)
+
+
+class _ServerHarness(unittest.TestCase):
+    """Builds a real `_AgentSession` runtime against the `ollama` provider
+    (keyless, local-config-only) with the global config redirected to a
+    temp dir so settings persistence is observable and hermetic."""
+
+    def setUp(self) -> None:
+        _reset_all()
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        self.ws = root / "ws"
+        self.ws.mkdir()
+        self.config_dir = root / "config-home"
+        self.config_dir.mkdir()
+        self.global_path = self.config_dir / "config.json"
+        self.global_path.write_text(json.dumps({}), encoding="utf-8")
+        self.sessions_dir = root / "sessions"
+        self.sessions_dir.mkdir()
+        self._patches = [
+            patch("src.config.get_global_config_path", return_value=self.global_path),
+            patch("src.config.GLOBAL_CONFIG_DIR", str(self.config_dir)),
+        ]
+        for p in self._patches:
+            p.start()
+        from src.settings.settings import invalidate_settings_cache
+
+        invalidate_settings_cache()
+
+    def tearDown(self) -> None:
+        for p in self._patches:
+            p.stop()
+        from src.settings.settings import invalidate_settings_cache
+
+        invalidate_settings_cache()
+        _reset_all()
+        self._tmp.cleanup()
+
+    def _build(self, *, model: str | None = None, single_session: bool = True):
+        from src.server.agent_server import (
+            AgentServerConfig,
+            _AgentSession,
+            _build_runtime,
+        )
+
+        sess = _AgentSession(
+            session_id="s-ch03",
+            cwd=str(self.ws),
+            config=AgentServerConfig(
+                provider_name="ollama",
+                model=model,
+                single_session=single_session,
+            ),
+            loop=MagicMock(),
+            out_queue=MagicMock(),
+        )
+        _build_runtime(sess, None)
+        self.assertIsNone(sess.init_error, f"runtime build failed: {sess.init_error}")
+        return sess
+
+    def _settings_section(self) -> dict:
+        data = json.loads(self.global_path.read_text(encoding="utf-8"))
+        section = data.get("settings", {})
+        return section if isinstance(section, dict) else {}
+
+
+class TestPerSessionStore(_ServerHarness):
+    def test_single_session_gets_store_http_shape_does_not(self) -> None:
+        sess = self._build(single_session=True)
+        self.assertIsNotNone(sess.app_state_store)
+        sess2 = self._build(single_session=False)
+        self.assertIsNone(sess2.app_state_store)
+
+    def test_persisted_model_seeds_provider_with_guard(self) -> None:
+        # Persisted under the SAME provider → applies.
+        self.global_path.write_text(json.dumps({
+            "settings": {"model": "persisted-model", "model_provider": "ollama"},
+        }), encoding="utf-8")
+        from src.settings.settings import invalidate_settings_cache
+
+        invalidate_settings_cache()
+        sess = self._build(model=None)
+        self.assertEqual(sess.provider.model, "persisted-model")
+        self.assertEqual(get_main_loop_model_override(), "persisted-model")
+
+    def test_explicit_launch_model_wins_over_persisted(self) -> None:
+        self.global_path.write_text(json.dumps({
+            "settings": {"model": "persisted-model", "model_provider": "ollama"},
+        }), encoding="utf-8")
+        from src.settings.settings import invalidate_settings_cache
+
+        invalidate_settings_cache()
+        sess = self._build(model="explicit-model")
+        self.assertEqual(sess.provider.model, "explicit-model")
+
+    def test_cross_provider_persisted_model_never_applies(self) -> None:
+        self.global_path.write_text(json.dumps({
+            "settings": {"model": "persisted-model", "model_provider": "deepseek"},
+        }), encoding="utf-8")
+        from src.settings.settings import invalidate_settings_cache
+
+        invalidate_settings_cache()
+        sess = self._build(model=None)
+        self.assertNotEqual(sess.provider.model, "persisted-model")
+
+    def test_set_model_control_persists_and_mirrors(self) -> None:
+        sess = self._build()
+        asyncio.run(sess._handle_control_request({
+            "request_id": "r1",
+            "request": {"subtype": "set_model", "model": "chosen-model"},
+        }))
+        self.assertEqual(sess.provider.model, "chosen-model")
+        self.assertEqual(
+            sess.app_state_store.get_state().main_loop_model, "chosen-model",
+        )
+        self.assertEqual(get_main_loop_model_override(), "chosen-model")
+        section = self._settings_section()
+        self.assertEqual(section.get("model"), "chosen-model")
+        self.assertEqual(section.get("model_provider"), "ollama")
+
+    def test_set_permission_mode_control_updates_both_homes(self) -> None:
+        sess = self._build()
+        asyncio.run(sess._handle_control_request({
+            "request_id": "r2",
+            "request": {"subtype": "set_permission_mode", "mode": "acceptEdits"},
+        }))
+        self.assertEqual(
+            sess.tool_context.permission_context.mode, "acceptEdits",
+        )
+        self.assertEqual(
+            sess.app_state_store.get_state().permission_mode, "acceptEdits",
+        )
+
+
+class TestLiveCostPersistence(_ServerHarness):
+    def _seed_cost(self) -> None:
+        from src.cost_tracker import record_api_usage
+
+        # A priced model so total_cost_usd is non-zero.
+        record_api_usage(
+            "deepseek-v4-pro", {"input_tokens": 1000, "output_tokens": 500},
+        )
+
+    def test_save_session_includes_schema_complete_cost_block(self) -> None:
+        sess = self._build()
+        self._seed_cost()
+        from src.agent.conversation import Conversation
+
+        sess.session.conversation = Conversation.from_dict(
+            {"messages": [{"role": "user", "content": "hi"}]},
+        )
+        with patch("src.server.agent_server._sessions_dir", return_value=self.sessions_dir):
+            sess._save_session()
+        payload = json.loads(
+            (self.sessions_dir / "s-ch03.json").read_text(encoding="utf-8"),
+        )
+        cost = payload.get("cost")
+        self.assertIsInstance(cost, dict)
+        # Schema keys the reader consumes (cost_restore.py) — writer owned
+        # by build_cost_block, so drift here means the extraction broke.
+        for key in (
+            "total_cost_usd", "total_api_duration",
+            "total_api_duration_without_retries", "total_tool_duration",
+            "total_lines_added", "total_lines_removed", "last_duration",
+            "model_usage",
+        ):
+            self.assertIn(key, cost)
+        self.assertGreater(cost["total_cost_usd"], 0.0)
+        self.assertIn("deepseek-v4-pro", cost["model_usage"])
+
+    def test_resume_restores_cost_with_matching_sid(self) -> None:
+        sess = self._build()
+        self._seed_cost()
+        from src.agent.conversation import Conversation
+
+        sess.session.conversation = Conversation.from_dict(
+            {"messages": [{"role": "user", "content": "hi"}]},
+        )
+        with patch("src.server.agent_server._sessions_dir", return_value=self.sessions_dir), \
+             patch("src.services.cost_restore._sessions_dir", return_value=self.sessions_dir):
+            sess._save_session()
+            saved_cost = get_total_cost_usd()
+            reset_state_for_tests()
+            self.assertEqual(get_total_cost_usd(), 0.0)
+            sess._do_resume("rq", "s-ch03")
+        self.assertAlmostEqual(get_total_cost_usd(), saved_cost, places=12)
+
+    def test_resume_guard_refuses_mismatched_header(self) -> None:
+        sess = self._build()
+        (self.sessions_dir / "s-ch03.json").write_text(json.dumps({
+            "session_id": "SOMETHING-ELSE",
+            "conversation": {"messages": [{"role": "user", "content": "x"}]},
+            "cost": {"total_cost_usd": 99.0},
+        }), encoding="utf-8")
+        with patch("src.server.agent_server._sessions_dir", return_value=self.sessions_dir), \
+             patch("src.services.cost_restore._sessions_dir", return_value=self.sessions_dir):
+            sess._do_resume("rq", "s-ch03")
+        self.assertEqual(get_total_cost_usd(), 0.0)
+
+    def test_resume_cross_provider_model_ignored(self) -> None:
+        """critic B1 — a model saved under a DIFFERENT provider must not be
+        applied (stale model at the wrong endpoint) nor persisted (the
+        store dispatch would poison the (model, provider) pairing)."""
+        sess = self._build(model=None)
+        before = sess.provider.model
+        (self.sessions_dir / "s-ch03.json").write_text(json.dumps({
+            "session_id": "s-ch03",
+            "model": "deepseek-v4-pro",
+            "provider": "deepseek",  # session's provider is ollama
+            "conversation": {"messages": [{"role": "user", "content": "x"}]},
+        }), encoding="utf-8")
+        with patch("src.server.agent_server._sessions_dir", return_value=self.sessions_dir), \
+             patch("src.services.cost_restore._sessions_dir", return_value=self.sessions_dir):
+            sess._do_resume("rq", "s-ch03")
+        self.assertEqual(sess.provider.model, before)
+        self.assertNotEqual(self._settings_section().get("model"), "deepseek-v4-pro")
+
+    def test_resume_legacy_file_without_provider_never_applies_model(self) -> None:
+        """Old session files predate the provider field — fail-safe: no match,
+        no model restore."""
+        sess = self._build(model=None)
+        before = sess.provider.model
+        (self.sessions_dir / "s-ch03.json").write_text(json.dumps({
+            "session_id": "s-ch03",
+            "model": "resumed-model",
+            "conversation": {"messages": [{"role": "user", "content": "x"}]},
+        }), encoding="utf-8")
+        with patch("src.server.agent_server._sessions_dir", return_value=self.sessions_dir), \
+             patch("src.services.cost_restore._sessions_dir", return_value=self.sessions_dir):
+            sess._do_resume("rq", "s-ch03")
+        self.assertEqual(sess.provider.model, before)
+
+    def test_resume_restores_saved_model_under_precedence(self) -> None:
+        sess = self._build(model=None)
+        (self.sessions_dir / "s-ch03.json").write_text(json.dumps({
+            "session_id": "s-ch03",
+            "model": "resumed-model",
+            "provider": "ollama",
+            "conversation": {"messages": [{"role": "user", "content": "x"}]},
+        }), encoding="utf-8")
+        with patch("src.server.agent_server._sessions_dir", return_value=self.sessions_dir), \
+             patch("src.services.cost_restore._sessions_dir", return_value=self.sessions_dir):
+            sess._do_resume("rq", "s-ch03")
+        self.assertEqual(sess.provider.model, "resumed-model")
+        # Explicit launch model wins over the saved one.
+        sess2 = self._build(model="explicit-model")
+        with patch("src.server.agent_server._sessions_dir", return_value=self.sessions_dir), \
+             patch("src.services.cost_restore._sessions_dir", return_value=self.sessions_dir):
+            sess2._do_resume("rq", "s-ch03")
+        self.assertEqual(sess2.provider.model, "explicit-model")
+
+
+class TestPerCwdGitCaches(unittest.TestCase):
+    def setUp(self) -> None:
+        from src.context_system.git_context import clear_git_caches
+
+        clear_git_caches()
+        self._tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self) -> None:
+        from src.context_system.git_context import clear_git_caches
+
+        clear_git_caches()
+        self._tmp.cleanup()
+
+    def test_two_cwds_get_independent_snapshots(self) -> None:
+        import shutil
+        import subprocess
+
+        if shutil.which("git") is None:  # pragma: no cover
+            self.skipTest("git not available")
+        from src.context_system.git_context import (
+            clear_git_caches,
+            collect_git_context,
+        )
+
+        root = Path(self._tmp.name)
+        repo_a = root / "a"
+        repo_b = root / "b"
+        for repo, branch in ((repo_a, "branch-a"), (repo_b, "branch-b")):
+            repo.mkdir()
+            subprocess.run(["git", "init", "-q", "-b", branch, str(repo)],
+                           check=True, capture_output=True)
+            (repo / "f.txt").write_text("x")
+            subprocess.run(["git", "-C", str(repo), "add", "."],
+                           check=True, capture_output=True)
+            subprocess.run(
+                ["git", "-C", str(repo), "-c", "user.email=t@t", "-c",
+                 "user.name=T", "commit", "-qm", "init"],
+                check=True, capture_output=True)
+
+        snap_a = asyncio.run(collect_git_context(str(repo_a)))
+        snap_b = asyncio.run(collect_git_context(str(repo_b)))
+        self.assertEqual(snap_a.branch, "branch-a")
+        self.assertEqual(snap_b.branch, "branch-b")
+        # Cached per key: repeated reads return the same snapshots.
+        self.assertIs(asyncio.run(collect_git_context(str(repo_a))), snap_a)
+        clear_git_caches()
+        self.assertIsNot(asyncio.run(collect_git_context(str(repo_a))), snap_a)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_git_context.py
+++ b/tests/test_git_context.py
@@ -153,7 +153,10 @@ class TestFormatGitStatus(unittest.TestCase):
             recent_commits="abc1234 Initial commit",
         )
         result = format_git_status(ctx)
-        self.assertIn("Git repository detected", result)
+        # ch03 round-4 GAP C: TS-exact model-facing text (context.ts:96-103).
+        self.assertIn("snapshot in time", result)
+        self.assertIn("Main branch (you will usually use this for PRs): main", result)
+        self.assertIn("Git user: Test User", result)
         self.assertIn("feature/ws-5", result)
         self.assertIn("main", result)
         self.assertIn("Test User", result)
@@ -166,17 +169,25 @@ class TestFormatGitStatus(unittest.TestCase):
             branch="main",
         )
         result = format_git_status(ctx)
-        self.assertIn("Working tree clean", result)
+        # TS renders an explicit "(clean)" status body, not a prose line.
+        self.assertIn("Status:\n(clean)", result)
 
     def test_truncated_status(self):
+        # ch03 round-4: the TS-exact truncation tail (context.ts:88) is
+        # embedded in the status body by collect_git_context; the formatter
+        # passes it through untouched.
+        tail = (
+            '... (truncated because it exceeds 2k characters. '
+            'If you need more information, run "git status" using BashTool)'
+        )
         ctx = GitContextSnapshot(
             available=True,
             branch="main",
-            status="M file.py",
+            status=f"M file.py\n{tail}",
             status_truncated=True,
         )
         result = format_git_status(ctx)
-        self.assertIn("truncated", result)
+        self.assertIn(tail, result)
 
 
 if __name__ == "__main__":

--- a/tests/test_ws5_integration.py
+++ b/tests/test_ws5_integration.py
@@ -275,7 +275,7 @@ class TestWS5IntegrationGitPipeline(unittest.TestCase):
             with patch.dict(os.environ, {"CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS": ""}):
                 sys_ctx = _run(get_system_context(cwd=tmp))
                 self.assertIn("gitStatus", sys_ctx)
-                self.assertIn("Git repository detected", sys_ctx["gitStatus"])
+                self.assertIn("snapshot in time", sys_ctx["gitStatus"])
                 self.assertIn("Integration Test", sys_ctx["gitStatus"])
 
     def test_git_context_disabled_via_env(self):
@@ -345,7 +345,7 @@ class TestWS5IntegrationPromptAssembly(unittest.TestCase):
 
                 # System context should have git
                 self.assertIn("gitStatus", parts.system_context)
-                self.assertIn("Git repository", parts.system_context["gitStatus"])
+                self.assertIn("snapshot in time", parts.system_context["gitStatus"])
 
     def test_custom_system_prompt_skips_default_and_system(self):
         """Custom system prompt skips default prompt and system context."""
@@ -741,7 +741,7 @@ class TestWS5IntegrationBackwardCompat(unittest.TestCase):
             prompt = build_context_prompt(root)
 
             self.assertIn("## Git Context", prompt)
-            self.assertIn("Git repository", prompt)
+            self.assertIn("snapshot in time", prompt)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Round-4 ch03 (state): re-home the two-tier bridge, live cost persistence, git-status text parity + per-cwd caches

**Docs:** `my-docs/ch03-state-round4-gap-analysis.md` + `my-docs/port-improvement-round-4/ch03-state-round4-plan.md` (+ two facet reports, critic verdict).

### The finding

The UI consolidation (PR #566) orphaned the reactive tier and the persistence bridge that round-3 shipped: `create_app_state_store` had zero production callers, so `on_change_app_state` — the chapter's centralized side-effect router — never ran in the shipped product. Live `/model` was `provider.model = x` with no bootstrap mirror and no persistence (lost even on /resume, though `_save_session` wrote the model field); live cost accumulation was wired (round-3's dead head was fixed by ch04/round-3) but the save/restore round-trip was severed — the live persister wrote no cost block and `_do_resume` restored nothing; `Session.save/resume` (which do it right, with the session-ID guard) had zero live callers.

### The fix

- **WI-1 — per-session AppState store in the agent-server** (`single_session` lane only, per the ch02 precedent — client-supplied `--http` sessions must never write user-level settings): `_build_runtime` creates the store (`create_app_state_store(active_provider=…)`), registers the provider supplier, and applies a persisted `/model` choice to the provider under `seed_app_state_from_settings`' provider-match guard — explicit `cfg.model` always wins. `set_model` / `set_permission_mode` / `set_provider` handlers dispatch through the store, so the centralized on_change effects (bootstrap mirror + `(model, model_provider)` settings persistence) run structurally instead of being scattered. Round-3's shipped-but-orphaned machinery is live again.
- **WI-2 — live cost round-trip**: `build_cost_block()` extracted to `cost_restore` (single schema owner beside the reader; `Session.save` delegates); `_save_session` writes it; `_do_resume` restores cost (header guard intact; `single_session`-gated — bootstrap totals are process-global) and restores the saved model under launch-model precedence.
- **WI-3 — git-status fidelity + cache keying**: `format_git_status` now emits the TS-exact model-facing text (`context.ts:96-103`) — the "snapshot in time" preamble and "Main branch (you will usually use this for PRs)" label are load-bearing prompt engineering the port had paraphrased away. `_git_context_cache`/`_git_is_repo_cache` are now realpath-keyed per cwd (closes the ch02-recorded multi-session bleed).

### Verification

- `tests/test_ch03_state_round4.py` (11): store gating (--http shape gets none), provider-match guard, explicit-model precedence, set_model persistence + bootstrap mirror, set_permission_mode dual-home, schema-complete cost block, restore with matching sid, guard refusal on mismatched header, model-restore precedence, two-repo cache independence.
- Live smoke against the real stdio child: `set_model deepseek-v4-flash` → user settings gain `(deepseek-v4-flash, deepseek)` → fresh child's `system/init` reports the persisted model (user config restored afterward). Full suite at the pre-existing 9-failure baseline.
- Critic loop: design pre-hardened against the two flagged holes (`--http` settings-write; process-global cost restore); APPROVE-gated merge.

### Deferred (owners)

Header-latch consumption + 1h-TTL activation → ch04 (provider sends no varying beta headers today — latches N/A-by-architecture until then); settings-diff side effects → ch04/ch15; shift+tab client lane (currently a degraded yolo no-op) → ch13/ch14; classifier consumption of `cached_claude_md_content` → ch06; concurrentSessions PID files → ch16; reservoir histograms → N/A (book describes code outside the vendored snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
