### PR TITLE
feat(ch05/round4): wire the production compaction pipeline, +500k budget, abort-path max-turns parity

### DIFF
--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -237,6 +237,29 @@ def run_headless(options: HeadlessOptions) -> int:
         logging.getLogger(__name__).debug(
             "headless trust check failed", exc_info=True,
         )
+    try:
+        from src.services.compact.autocompact import AutoCompactTracking
+
+        _run_compact_tracking = AutoCompactTracking()
+    except Exception:  # noqa: BLE001 — pipeline wiring must not block startup
+        _run_compact_tracking = None
+
+    def _build_turn_pipeline_config():
+        """ch05 round-4 GAP A — per-turn config (fresh fingerprints),
+        run-scoped tracking (the 3-consecutive-failures breaker)."""
+        if _run_compact_tracking is None:
+            return None
+        try:
+            from src.services.compact.pipeline import (
+                build_production_pipeline_config,
+            )
+
+            return build_production_pipeline_config(
+                provider, tool_context, _run_compact_tracking,
+            )
+        except Exception:  # noqa: BLE001 — pipeline is best-effort
+            return None
+
     if options.skip_permissions or effective_mode == "bypassPermissions":
         tool_context.allow_docs = True
         tool_context.permission_handler = None
@@ -374,6 +397,13 @@ def run_headless(options: HeadlessOptions) -> int:
                             system_prompt=effective_system_prompt,
                             max_turns=options.max_turns,
                             fallback_model=options.fallback_model,
+                            # ch05 round-4 GAP A — the production pipeline:
+                            # config rebuilt per turn (fresh read-file
+                            # fingerprints), tracking RUN-scoped (breaker
+                            # persists across stream-json turns); TS 'sdk'
+                            # label for the print path.
+                            pipeline_config=_build_turn_pipeline_config(),
+                            query_source="sdk",
                             on_event=on_event,
                             on_text_chunk=on_text_chunk,
                             on_message=_persist,

--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -303,6 +303,19 @@ async def run_query_as_agent_loop(
     abort_controller: AbortController | None = None,
     extended_thinking: bool | None = None,
     fallback_model: str | None = None,
+    # ch05 round-4 GAP A — the production compaction pipeline. When None
+    # (the pre-round-4 default) Phase-0 (tool-result budget/snip/
+    # microcompact/collapse/auto-compact) is inert and only the blocking
+    # guards + reactive recovery run. Callers build it via
+    # services.compact.pipeline.build_production_pipeline_config with a
+    # SESSION-scoped AutoCompactTracking.
+    pipeline_config: Any | None = None,
+    # TS querySource per surface: 'repl_main_thread' (interactive turns),
+    # 'sdk' (headless/print), 'agent:*' (subagents — ch08).
+    query_source: str = "repl_main_thread",
+    # ch05 round-4 GAP B — the '+500k' auto-continue budget parsed from
+    # the user's prompt (query/token_budget.parse_token_budget).
+    token_budget: int | None = None,
 ) -> AgentLoopRunResult:
     """Drive the canonical query() loop and adapt to AgentLoopResult.
 
@@ -365,6 +378,11 @@ async def run_query_as_agent_loop(
         # ch04 round-4 GAP B — capacity-relief model switch after repeated
         # 529s (see QueryParams.fallback_model).
         fallback_model=fallback_model,
+        # ch05 round-4 GAP A/B — production pipeline + surface label +
+        # +500k budget.
+        pipeline_config=pipeline_config,
+        query_source=query_source,
+        token_budget=token_budget,
         # C3b /thinking: None = auto (model-gated default), True/False =
         # explicit session override (TS ThinkingToggle semantics).
         extended_thinking=extended_thinking,

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -75,10 +75,13 @@ MAX_529_RETRIES = 3
 # timeout), TS DEFAULT_MAX_RETRIES (withRetry.ts:52).
 DEFAULT_MAX_RETRIES = 10
 RETRY_BASE_DELAY_SECONDS = 0.5
-# Narrower than TS's FOREGROUND_529_RETRY_SOURCES (agents/sdk/compact/
-# side_question, withRetry.ts:62-90) -- minimal posture; widen to agent
-# sources when subagent traffic matters.
-FOREGROUND_529_RETRY_SOURCES = frozenset({"repl_main_thread"})
+# Narrower than TS's FOREGROUND_529_RETRY_SOURCES (agents/compact/
+# side_question etc., withRetry.ts:62-90) -- minimal posture; widen to
+# agent sources when subagent traffic matters. 'sdk' added in ch05
+# round-4 alongside the headless query_source relabel ('repl_main_thread'
+# -> 'sdk'): TS's set includes 'sdk' (withRetry.ts:67), so headless keeps
+# the yield-based retry lane after the relabel.
+FOREGROUND_529_RETRY_SOURCES = frozenset({"repl_main_thread", "sdk"})
 MAX_OUTPUT_TOKENS_RECOVERY_LIMIT = 3
 PROMPT_TOO_LONG_ERROR_MESSAGE = (
     "Your conversation is too long. Please use /compact to reduce context size, "
@@ -113,6 +116,12 @@ class QueryParams:
     # query.ts:276; --fallback-model in headless). Session-sticky switch
     # via provider.model; never persisted to settings.
     fallback_model: str | None = None
+    # ch05 round-4 note — N/A-by-architecture on the LIVE paths: the
+    # adapter's build_effective_system_prompt already injects CLAUDE.md
+    # ("## Project Instructions") and the date via the SYSTEM prompt, so
+    # wiring TS's prependUserContext there would double-inject. Only the
+    # test-only engine path uses the message-based mechanism
+    # (prepend_user_context at engine.py:221). One mechanism per surface.
     user_context: dict[str, str] | None = None
     system_context: dict[str, str] | None = None
     pipeline_config: PipelineConfig | None = None
@@ -2028,6 +2037,15 @@ async def query(
             # confirming it doesn't double-pair against that backstop.
             if params.abort_controller.signal.reason != "interrupt":
                 yield _create_user_interruption_message(tool_use=True)
+            # ch05 round-4 GAP C — TS query.ts:1621-1629: an abort that
+            # lands ON the max-turns boundary also announces the limit
+            # before the aborted_tools return (the terminal reason stays
+            # aborted_tools either way).
+            next_turn_count_on_abort = turn_count + 1
+            if params.max_turns and next_turn_count_on_abort > params.max_turns:
+                yield _create_max_turns_attachment(
+                    params.max_turns, next_turn_count_on_abort,
+                )
             set_terminal(holder, natural_termination, Terminal(reason="aborted_tools"))
             return
 

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -123,6 +123,11 @@ class _AgentSession:
     # --http, where the centralized on_change side effects (user-level
     # settings persistence) must not fire from client-supplied sessions.
     app_state_store: Any = None
+    # ch05 round-4 GAP A — SESSION-scoped auto-compact tracking: the
+    # 3-consecutive-failures circuit breaker counts across turns (the
+    # engine's engine.py:74-79 rationale); a per-turn instance would reset
+    # it every prompt. Created lazily on first turn.
+    _auto_compact_tracking: Any = None
     session: Any = None
     system_prompt: Any = "You are a helpful assistant."
     _base_system_prompt: Any = None  # system prompt before the /plan section is composed in
@@ -1446,6 +1451,40 @@ class _AgentSession:
         self._run_turn(build_notification_turn(envelopes), internal=True)
         return True
 
+    def _build_turn_pipeline_config(self, turn_provider: Any) -> Any:
+        """ch05 round-4 GAP A — per-turn PipelineConfig with the
+        SESSION-scoped AutoCompactTracking (lazy-created once; the
+        3-consecutive-failures circuit breaker must count across turns —
+        a per-turn instance would reset it every prompt). Never raises."""
+        try:
+            from src.services.compact.autocompact import AutoCompactTracking
+            from src.services.compact.pipeline import (
+                build_production_pipeline_config,
+            )
+
+            if self._auto_compact_tracking is None:
+                self._auto_compact_tracking = AutoCompactTracking()
+            return build_production_pipeline_config(
+                turn_provider, self.tool_context, self._auto_compact_tracking,
+            )
+        except Exception:  # noqa: BLE001 — pipeline wiring must not kill the turn
+            logger.debug("[agent-server] pipeline config build failed",
+                         exc_info=True)
+            return None
+
+    @staticmethod
+    def _parse_turn_budget(prompt: Any) -> int | None:
+        """ch05 round-4 GAP B — the '+500k' auto-continue budget from the
+        ORIGINAL user prompt (str or content-block list). Best-effort."""
+        try:
+            from src.query.token_budget import parse_token_budget
+
+            return parse_token_budget(_extract_prompt_text({"content": prompt}))
+        except Exception:  # noqa: BLE001 — budget parse is best-effort
+            logger.debug("[agent-server] token budget parse failed",
+                         exc_info=True)
+            return None
+
     def _run_turn(self, prompt, btw: bool = False, internal: bool = False) -> None:
         # prompt: str | list[ContentBlock]
         # btw=True → a "side question" (the original's /btw): run with full context
@@ -1460,6 +1499,12 @@ class _AgentSession:
                 result=self.init_error, is_error=True, error=self.init_error,
             ))
             return
+
+        # ch05 round-4 GAP B (critic m1) — parse the '+500k' budget from the
+        # ORIGINAL prompt BEFORE ultracode augmentation: the reminder is
+        # APPENDED, and the shorthand's end-anchored regex would no longer
+        # match a trailing "+500k" once a <system-reminder> follows it.
+        token_budget = self._parse_turn_budget(prompt) if not internal else None
 
         # ultracode (workflow-engine §4.1): the `ultracode` keyword in this
         # message, or the session-long `/effort ultracode` mode, appends a
@@ -1521,6 +1566,11 @@ class _AgentSession:
         # /effort: wrap the provider to inject reasoning_effort (default off ⇒
         # the real provider is used unchanged).
         turn_provider = _EffortProvider(self.provider, self._effort) if self._effort else self.provider
+        # ch05 round-4 GAP A — the production compaction pipeline. The
+        # tracking is session-scoped (circuit breaker survives turns); the
+        # config is rebuilt per turn so it always carries the CURRENT
+        # provider/model and read-file fingerprints.
+        pipeline_config = self._build_turn_pipeline_config(turn_provider)
         try:
             result = asyncio.run(run_query_as_agent_loop(
                 initial_messages=list(self.session.conversation.messages),
@@ -1535,6 +1585,9 @@ class _AgentSession:
                 abort_controller=abort,
                 extended_thinking=self._thinking,  # None = model default; True/False = ThinkingToggle
                 fallback_model=self.config.fallback_model,
+                pipeline_config=pipeline_config,
+                query_source="repl_main_thread",
+                token_budget=token_budget,
             ))
         except AbortError:
             self._emit(_result_message(

--- a/src/services/compact/pipeline.py
+++ b/src/services/compact/pipeline.py
@@ -89,6 +89,35 @@ class PipelineConfig:
     early_exit_tokens: int = 20_000
 
 
+def build_production_pipeline_config(
+    provider: Any,
+    tool_context: Any,
+    autocompact_tracking: "AutoCompactTracking | None",
+) -> PipelineConfig:
+    """The minimal correct PipelineConfig for the live surfaces.
+
+    ch05 round-4 GAP A — mirrors the test-only ``QueryEngine``'s
+    construction (``query/engine.py:233-250``) exactly: provider + model +
+    the read-file fingerprints (so post-compact file restoration fires) +
+    the SESSION-scoped ``autocompact_tracking``. The tracking instance MUST
+    outlive single turns — the 3-consecutive-failures circuit breaker
+    counts across prompts; a per-turn instance would reset it every turn
+    (the exact reason the engine holds one at ``engine.py:74-79``).
+    """
+    fingerprints = getattr(tool_context, "read_file_fingerprints", None) or {}
+    read_file_state = {
+        str(path): {"timestamp": fp[0]}
+        for path, fp in fingerprints.items()
+        if isinstance(fp, (tuple, list)) and fp
+    }
+    return PipelineConfig(
+        provider=provider,
+        model=getattr(provider, "model", "") or "",
+        read_file_state=read_file_state or None,
+        autocompact_tracking=autocompact_tracking,
+    )
+
+
 class CompressionPipeline:
     """
     Orchestrates the 5-layer compression pipeline.

--- a/tests/test_ch05_loop_round4.py
+++ b/tests/test_ch05_loop_round4.py
@@ -1,0 +1,306 @@
+"""ch05 round-4 acceptance tests: the production compaction pipeline wire,
+the +500k budget thread, and the abort-path max-turns attachment.
+
+Covers my-docs/port-improvement-round-4/ch05-agent-loop-round4-plan.md.
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.providers.base import ChatResponse
+from src.query.query import (
+    FOREGROUND_529_RETRY_SOURCES,
+    QueryParams,
+    run_query,
+)
+from src.services.compact.autocompact import AutoCompactTracking
+from src.services.compact.pipeline import (
+    PipelineConfig,
+    build_production_pipeline_config,
+)
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.types.messages import SystemMessage, UserMessage
+from src.utils.abort_controller import AbortController
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _completion(content="Done."):
+    return ChatResponse(
+        content=content,
+        model="test-model",
+        usage={"input_tokens": 10, "output_tokens": 5},
+        finish_reason="end_turn",
+        tool_uses=None,
+    )
+
+
+class TestPipelineConfigBuilder(unittest.TestCase):
+    def test_mirrors_engine_shape(self):
+        provider = MagicMock()
+        provider.model = "m1"
+        context = MagicMock()
+        context.read_file_fingerprints = {Path("/tmp/a.py"): (123.0, 42)}
+        tracking = AutoCompactTracking()
+
+        cfg = build_production_pipeline_config(provider, context, tracking)
+
+        self.assertIsInstance(cfg, PipelineConfig)
+        self.assertIs(cfg.provider, provider)
+        self.assertEqual(cfg.model, "m1")
+        self.assertEqual(cfg.read_file_state, {"/tmp/a.py": {"timestamp": 123.0}})
+        self.assertIs(cfg.autocompact_tracking, tracking)
+
+    def test_empty_fingerprints_yield_none_state(self):
+        provider = MagicMock()
+        provider.model = "m1"
+        context = MagicMock()
+        context.read_file_fingerprints = {}
+        cfg = build_production_pipeline_config(
+            provider, context, AutoCompactTracking(),
+        )
+        self.assertIsNone(cfg.read_file_state)
+
+
+class TestAdapterThreading(unittest.TestCase):
+    """The adapter forwards pipeline_config / query_source / token_budget."""
+
+    def test_params_reach_query(self):
+        from src.query import agent_loop_compat as compat
+
+        captured: dict = {}
+        real_qp = compat.QueryParams
+
+        def _spy_params(**kwargs):
+            captured.update(kwargs)
+            return real_qp(**kwargs)
+
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = _completion()
+        registry = build_default_registry()
+        with tempfile.TemporaryDirectory() as tmp:
+            context = ToolContext(workspace_root=Path(tmp))
+            cfg = PipelineConfig(provider=provider, model="m")
+            with patch.object(compat, "QueryParams", side_effect=_spy_params):
+                _run(compat.run_query_as_agent_loop(
+                    initial_messages=[UserMessage(content="hi")],
+                    provider=provider,
+                    tool_registry=registry,
+                    tool_context=context,
+                    system_prompt="You are helpful.",
+                    max_turns=2,
+                    pipeline_config=cfg,
+                    query_source="sdk",
+                    token_budget=500_000,
+                ))
+        self.assertIs(captured.get("pipeline_config"), cfg)
+        self.assertEqual(captured.get("query_source"), "sdk")
+        self.assertEqual(captured.get("token_budget"), 500_000)
+
+    def test_sdk_is_a_foreground_retry_source(self):
+        # The headless relabel must not lose the retry lane (TS
+        # withRetry.ts:67 includes 'sdk').
+        self.assertIn("sdk", FOREGROUND_529_RETRY_SOURCES)
+        self.assertIn("repl_main_thread", FOREGROUND_529_RETRY_SOURCES)
+
+
+class TestPipelineRunsInLoop(unittest.TestCase):
+    """With a pipeline_config present, the loop invokes the pipeline."""
+
+    def test_pipeline_invoked_when_config_present(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = _completion()
+        registry = build_default_registry()
+        with tempfile.TemporaryDirectory() as tmp:
+            context = ToolContext(workspace_root=Path(tmp))
+            cfg = PipelineConfig(provider=provider, model="test-model")
+            params = QueryParams(
+                messages=[UserMessage(content="hi")],
+                system_prompt="You are helpful.",
+                tools=registry.list_tools(),
+                tool_registry=registry,
+                tool_use_context=context,
+                provider=provider,
+                abort_controller=AbortController(),
+                max_turns=2,
+                pipeline_config=cfg,
+            )
+            from src.services.compact.pipeline import CompressionResult
+
+            with patch(
+                "src.query.query.run_compression_pipeline",
+            ) as pipeline_spy:
+                # critic m3: a REAL typed result (tokens_saved=0) so the
+                # loop's `.tokens_saved` read means what it says instead of
+                # hitting a truthy MagicMock auto-attribute.
+                pipeline_spy.return_value = CompressionResult(
+                    messages=list(params.messages), tokens_saved=0,
+                )
+                _, terminal = _run(run_query(params))
+        self.assertEqual(terminal.reason, "completed")
+        pipeline_spy.assert_called()
+
+    def test_pipeline_skipped_without_config(self):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = _completion()
+        registry = build_default_registry()
+        with tempfile.TemporaryDirectory() as tmp:
+            context = ToolContext(workspace_root=Path(tmp))
+            params = QueryParams(
+                messages=[UserMessage(content="hi")],
+                system_prompt="You are helpful.",
+                tools=registry.list_tools(),
+                tool_registry=registry,
+                tool_use_context=context,
+                provider=provider,
+                abort_controller=AbortController(),
+                max_turns=2,
+            )
+            with patch(
+                "src.query.query.run_compression_pipeline",
+            ) as pipeline_spy:
+                _, terminal = _run(run_query(params))
+        self.assertEqual(terminal.reason, "completed")
+        pipeline_spy.assert_not_called()
+
+
+class TestServerSessionTracking(unittest.TestCase):
+    """The agent-server session owns ONE tracking instance across turns —
+    exercised through the PRODUCTION config-build block (critic M2: the
+    prior version re-implemented the pattern in the test body)."""
+
+    def _make_session(self):
+        from src.server.agent_server import AgentServerConfig, _AgentSession
+
+        sess = _AgentSession(
+            session_id="s1",
+            cwd="/tmp",
+            config=AgentServerConfig(single_session=True),
+            loop=MagicMock(),
+            out_queue=MagicMock(),
+        )
+        sess.tool_context = MagicMock()
+        sess.tool_context.read_file_fingerprints = {}
+        return sess
+
+    def test_two_turn_builds_share_one_tracking_instance(self):
+        sess = self._make_session()
+        provider = MagicMock()
+        provider.model = "m"
+        self.assertIsNone(sess._auto_compact_tracking)
+
+        cfg1 = sess._build_turn_pipeline_config(provider)
+        cfg2 = sess._build_turn_pipeline_config(provider)
+
+        self.assertIsNotNone(cfg1)
+        self.assertIsNotNone(cfg2)
+        self.assertIsNot(cfg1, cfg2)  # fresh config each turn
+        self.assertIs(
+            cfg1.autocompact_tracking, cfg2.autocompact_tracking,
+        )  # SAME breaker across turns
+        self.assertIs(cfg1.autocompact_tracking, sess._auto_compact_tracking)
+
+    def test_build_failure_returns_none(self):
+        sess = self._make_session()
+        with patch(
+            "src.services.compact.pipeline.build_production_pipeline_config",
+            side_effect=RuntimeError("boom"),
+        ):
+            self.assertIsNone(sess._build_turn_pipeline_config(MagicMock()))
+
+
+class TestTokenBudgetParseInServer(unittest.TestCase):
+    def test_parse_token_budget_shorthand(self):
+        from src.query.token_budget import parse_token_budget
+
+        self.assertEqual(parse_token_budget("+500k fix the bug"), 500_000)
+        self.assertEqual(parse_token_budget("fix the bug +500k"), 500_000)
+        self.assertIsNone(parse_token_budget("fix the bug"))
+
+    def test_server_parses_original_prompt_shapes(self):
+        """critic m1 — the server parses the ORIGINAL prompt (str or block
+        list) BEFORE ultracode appends a reminder; an end-anchored '+500k'
+        must survive. The ordering itself is pinned by parsing the raw
+        prompt through the production helper, then showing the augmented
+        form would NOT match."""
+        from src.server.agent_server import _AgentSession, _with_ultracode_reminder
+
+        raw = "fix the bug +500k"
+        self.assertEqual(_AgentSession._parse_turn_budget(raw), 500_000)
+        blocks = [{"type": "text", "text": raw}]
+        self.assertEqual(_AgentSession._parse_turn_budget(blocks), 500_000)
+        # The augmented prompt (reminder APPENDED) breaks the end anchor —
+        # exactly why _run_turn parses before augmentation.
+        augmented = f"{raw}\n\n<system-reminder>ultracode</system-reminder>"
+        self.assertIsNone(_AgentSession._parse_turn_budget(augmented))
+
+
+class TestAbortPathMaxTurnsAttachment(unittest.TestCase):
+    def test_abort_at_limit_yields_attachment(self):
+        from src.services.tool_execution.orchestrator import MessageUpdate
+        from src.types.content_blocks import ToolResultBlock
+
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = ChatResponse(
+            content="Working...",
+            model="test-model",
+            usage={"input_tokens": 10, "output_tokens": 20},
+            finish_reason="tool_use",
+            tool_uses=[{
+                "id": "toolu_a1",
+                "name": "Write",
+                "input": {"file_path": "/tmp/x.txt", "content": "hi"},
+            }],
+        )
+        registry = build_default_registry()
+        with tempfile.TemporaryDirectory() as tmp:
+            context = ToolContext(workspace_root=Path(tmp))
+            abort = AbortController()
+            params = QueryParams(
+                messages=[UserMessage(content="hi")],
+                system_prompt="You are helpful.",
+                tools=registry.list_tools(),
+                tool_registry=registry,
+                tool_use_context=context,
+                provider=provider,
+                abort_controller=abort,
+                max_turns=1,
+            )
+
+            async def _abort_during_tools(_b, _a, _c, ctx, *args, **kwargs):
+                abort.abort("test_abort")
+                yield MessageUpdate(
+                    message=UserMessage(content=[ToolResultBlock(
+                        tool_use_id="toolu_a1", content="ok", is_error=False,
+                    )]),
+                    new_context=ctx,
+                )
+
+            with patch(
+                "src.services.tool_execution.orchestrator.run_tools",
+                new=_abort_during_tools,
+            ):
+                messages, terminal = _run(run_query(params))
+
+        self.assertEqual(terminal.reason, "aborted_tools")
+        max_turn_msgs = [
+            m for m in messages
+            if isinstance(m, SystemMessage)
+            and getattr(m, "subtype", "") == "max_turns_reached"
+        ]
+        self.assertEqual(len(max_turn_msgs), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Round-4 ch05 (agent loop): wire the production compaction pipeline, +500k budget, abort-path max-turns parity

**Docs:** `my-docs/ch05-agent-loop-round4-gap-analysis.md` + plan + two facet reports + critic verdicts (REQUEST-CHANGES→APPROVE) under `my-docs/port-improvement-round-4/`.

### WI-1 — auto-compact never fired in the shipped product

The loop's Phase-0 compression pipeline (tool-result budget → snip → microcompact → collapse → auto-compact) was gated on a `pipeline_config` that only the **test-only** `QueryEngine` ever built — the production adapter passed nothing, so long conversations hit a hard `blocking_limit` wall instead of compacting (the summarizer itself was proven: manual `/compact` uses it). Now:

- `run_query_as_agent_loop` gains `pipeline_config` / `query_source` / `token_budget` pass-throughs.
- `build_production_pipeline_config` (shared builder mirroring the engine's exact shape: provider, model, read-file fingerprints for post-compact restoration, tracking).
- Agent-server: session-scoped `AutoCompactTracking` (the 3-consecutive-failures circuit breaker must count **across turns** — a per-turn instance would reset it) with a fresh config per turn (current provider/model/fingerprints), via the extracted, directly-tested `_build_turn_pipeline_config`.
- Headless: run-scoped tracking + per-turn config; `query_source='sdk'` (the TS print/SDK label — the old default mislabeled headless as `repl_main_thread`), with `'sdk'` added to `FOREGROUND_529_RETRY_SOURCES` (TS includes it — `withRetry.ts:67`) so the relabel loses no retry coverage.

**Honest cost note (critic M1, documented + deferred with owner):** Phase-0's compacted messages are adopted loop-locally and not yielded, so the server's durable conversation stays full — a session that stays over threshold re-summarizes from scratch each turn (no corruption, no summary-of-summary, strictly better than the previous hard wall). Boundary persistence → ch07 (two candidate mechanisms named in the doc).

### WI-2 — the +500k auto-continue budget goes live

Round-3's fully-wired loop machinery had no producer: `parse_token_budget` had zero callers. The agent-server now parses the directive from the **original** user prompt — before ultracode augmentation appends a reminder that would break the end-anchored `"… +500k"` form (critic m1) — and threads it through the adapter. Directive is not stripped from the model-facing prompt (documented divergence; the position-finder is caller-less in both trees).

### WI-3 — abort-path max-turns attachment

An abort landing on the max-turns boundary now also announces the limit (TS `query.ts:1621-1629`), terminal reason unchanged.

### N/A determinations (proofs in the facets)

`userContext` prepend (live paths inject CLAUDE.md+date via the system prompt — wiring it would double-inject), `taskBudget.remaining` (feeds a 1P server-side renderer + beta the port doesn't ship), per-iteration boundary re-slice (the loop carries the projected working set), exit-path order swaps (single-valued `_api_error` makes the branches mutually exclusive).

### Verification

- `tests/test_ch05_loop_round4.py` (12): builder shape, adapter threading, pipeline invoked-with-config / skipped-without (typed `CompressionResult`), session-tracking identity across two production builds, budget parse shapes + the ultracode-ordering pin, abort-at-limit attachment, 'sdk' in the retry sources.
- Full suite at the exact 9-failure environmental baseline (7406 passed); headless deepseek smoke OK with the pipeline live.
- Critic: REQUEST CHANGES (M1 doc-honesty, M2 tautological test, 3 minors) → all addressed → APPROVE-gated merge.

### Deferred (owners)

Compaction boundary-persistence → ch07; tool-use summaries (absent both ends) + `tokenCountWithEstimation` + `collapse_drain` → ch17; `query/streaming.py` retirement → ch07; subagent `query_source` labels → ch08; `pending_post_compaction` consumer (needs telemetry substrate) → recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
