### PR TITLE
fix(ch06/round4-A): close the fail-open hook-ask permission branch + Read/Edit input backfill + InputValidationError parity

### DIFF
--- a/src/services/tool_execution/can_use_tool_adapter.py
+++ b/src/services/tool_execution/can_use_tool_adapter.py
@@ -42,10 +42,81 @@ def build_can_use_tool(context: Any) -> Callable[..., dict[str, Any]]:
         _tool_use_context: Any,
         _assistant_message: Any,
         _tool_use_id: str,
+        force_decision: Any = None,
     ) -> dict[str, Any]:
+        # ch06 round-4 PR-A GAP A — the 6th ``force_decision`` param
+        # (TS CanUseToolFn / toolHooks.ts:482-499). The hook-"ask" branch
+        # of resolve_hook_permission_decision passes the hook result here
+        # positionally; before this param existed the call raised TypeError
+        # and fell through to a FAIL-OPEN allow. A PreToolUse hook that
+        # already decided allow/deny short-circuits to that behavior; an
+        # "ask" (or None) falls through to the normal prompt resolution.
         from src.permissions.check import has_permissions_to_use_tool
         from src.permissions.handler import handle_permission_ask
         from src.tool_system.registry import _apply_and_persist_updates
+
+        if isinstance(force_decision, dict):
+            forced = force_decision.get("behavior")
+            forced_updated = (
+                force_decision.get("updatedInput")
+                or force_decision.get("input")
+            )
+            if forced == "allow":
+                return {
+                    "behavior": "allow",
+                    "updatedInput": forced_updated,
+                    "userModified": bool(forced_updated),
+                }
+            if forced == "deny":
+                return {
+                    "behavior": "deny",
+                    "message": force_decision.get("message")
+                    or "permission denied by hook",
+                }
+            if forced == "ask":
+                # critic M2 — a hook that returns `ask` must reach the
+                # PROMPT, NOT rule resolution. TS routes forceDecision
+                # straight to `case "ask"` (useCanUseTool.tsx:37,93) and
+                # never consults rules — else a static allow-rule would
+                # silently bypass a hook explicitly demanding confirmation
+                # (defense-in-depth defeated). We synthesize the ask
+                # decision directly from the hook and prompt on it; NO
+                # has_permissions_to_use_tool call. Fail-closed to deny
+                # when there's no handler (mirrors the no-hook branch). m1
+                # — honor the hook's updatedInput for the prompt.
+                from src.permissions.types import (
+                    HookDecisionReason,
+                    PermissionAskDecision,
+                )
+
+                ask_input = forced_updated or tool_input
+                ask_decision = PermissionAskDecision(
+                    behavior="ask",
+                    message=force_decision.get("message")
+                    or f"Hook requires approval for {tool.name}",
+                    decision_reason=HookDecisionReason(
+                        reason="PreToolUse hook returned 'ask'",
+                    ),
+                )
+                final, chosen_updates = handle_permission_ask(
+                    tool.name, ask_decision, context.permission_handler,
+                    tool_input=ask_input,
+                )
+                if getattr(final, "behavior", "deny") != "allow":
+                    return {
+                        "behavior": "deny",
+                        "message": getattr(final, "message", None)
+                        or "permission denied by user",
+                    }
+                if chosen_updates:
+                    _apply_and_persist_updates(context, chosen_updates)
+                return {
+                    "behavior": "allow",
+                    "updatedInput": getattr(final, "updated_input", None)
+                    or forced_updated,
+                    "userModified": bool(chosen_updates)
+                    or forced_updated is not None,
+                }
 
         decision = has_permissions_to_use_tool(
             tool,

--- a/src/services/tool_execution/tool_execution.py
+++ b/src/services/tool_execution/tool_execution.py
@@ -184,15 +184,24 @@ async def _check_permissions_and_call_tool(
             msg = str(schema_err)
             if getattr(tool, "should_defer", False):
                 msg = msg + build_schema_not_sent_hint(tool)
+            # ch06 round-4 PR-A GAP C — the ``InputValidationError:`` prefix
+            # (TS toolExecution.ts:726). Load-bearing: the tool-failure-loop
+            # guard categorizes on ``\bInputValidationError\b`` (ch01
+            # round-3 port), so without the prefix repeated schema failures
+            # are miscategorized as generic errors and the path-based /
+            # signature-based trip logic doesn't recognize them.
             resulting_messages.append(MessageUpdateLazy(
                 message=create_user_message(
                     content=[{
                         "type": "tool_result",
-                        "content": f"<tool_use_error>{msg}</tool_use_error>",
+                        "content": (
+                            f"<tool_use_error>InputValidationError: "
+                            f"{msg}</tool_use_error>"
+                        ),
                         "is_error": True,
                         "tool_use_id": tool_use_id,
                     }],
-                    toolUseResult=f"Error: {msg}",
+                    toolUseResult=f"InputValidationError: {msg}",
                 ),
             ))
             return resulting_messages

--- a/src/services/tool_execution/tool_hooks.py
+++ b/src/services/tool_execution/tool_hooks.py
@@ -407,7 +407,19 @@ async def resolve_hook_permission_decision(
                 return decision
             if hasattr(decision, "behavior"):
                 return {"behavior": decision.behavior, "message": getattr(decision, "message", None)}
+            # critic M1 — unrecognized decision shape → fail CLOSED (deny),
+            # matching the no-hook branch's philosophy (:314-319). This
+            # branch used to fall through to allow.
+            logger.debug("can_use_tool returned unrecognized shape in ask path")
         except Exception as e:
             logger.debug("can_use_tool error in ask path: %s", e)
 
-    return {"behavior": "allow"}
+    # critic M1 — the hook-'ask' branch fails CLOSED on any adapter
+    # exception, a missing adapter, or an unrecognized shape. Previously
+    # this returned {"behavior": "allow"} — a fail-OPEN asymmetric with the
+    # no-hook branch (which denies on all three). TS also fails closed here
+    # (a throwing canUseTool propagates and aborts the tool call).
+    return {
+        "behavior": "deny",
+        "message": f"Permission resolution failed for {tool.name}",
+    }

--- a/src/tool_system/tools/edit.py
+++ b/src/tool_system/tools/edit.py
@@ -11,6 +11,7 @@ from typing import Any
 from ..build_tool import Tool, build_tool
 from ..context import ToolContext
 from ..diff_utils import unified_diff_hunks
+from .read import _backfill_read_edit_path  # shared file_path expander
 from ..errors import ToolInputError, ToolPermissionError
 from ..protocol import ToolResult
 from src.permissions.types import (
@@ -391,6 +392,9 @@ EditTool: Tool = build_tool(
     is_destructive=lambda _input: True,
     is_concurrency_safe=lambda _input: False,
     check_permissions=_check_permissions,
+    # ch06 round-4 PR-A GAP B — expand file_path before permissions +
+    # PreToolUse hooks (TS FileEditTool.ts:115); shared with Read.
+    backfill_observable_input=_backfill_read_edit_path,
     get_path=lambda input_data: input_data.get("file_path", ""),
     user_facing_name=lambda input_data: f"Edit: {(input_data or {}).get('file_path', '')}" if input_data else "Edit",
     search_hint="edit modify replace change file",

--- a/src/tool_system/tools/read.py
+++ b/src/tool_system/tools/read.py
@@ -16,6 +16,16 @@ from ..utils.path_utils import suggest_path_under_cwd
 # Constants
 # ---------------------------------------------------------------------------
 
+
+def _backfill_read_edit_path(tool_input: dict[str, Any]) -> None:
+    """ch06 round-4 PR-A GAP B — expand ``file_path`` in-place so hook
+    allowlists / permission rules can't be bypassed via ``~`` or a
+    relative path (TS FileReadTool.ts:388 / FileEditTool.ts:115, both
+    overwrite-only). Shared by Read and Edit."""
+    fp = tool_input.get("file_path")
+    if isinstance(fp, str):
+        tool_input["file_path"] = str(Path(fp).expanduser().resolve())
+
 FILE_UNCHANGED_STUB = (
     "File unchanged since last read. The content from the earlier Read "
     "tool_result in this conversation is still current \u2014 refer to that "
@@ -754,6 +764,11 @@ ReadTool: Tool = build_tool(
     },
     call=_read_call,
     check_permissions=_read_check_permissions,
+    # ch06 round-4 PR-A GAP B — expand file_path before permission checks +
+    # PreToolUse hooks see it, so ~/relative paths can't dodge allowlists
+    # (TS FileReadTool.ts:388). Overwrite-only: the model-original path
+    # still reaches call() (call-input discipline) and the yielded message.
+    backfill_observable_input=_backfill_read_edit_path,
     prompt=_render_prompt(),
     description="Read a file from the local filesystem.",
     map_result_to_api=_read_map_result_to_api,

--- a/src/tool_system/tools/write.py
+++ b/src/tool_system/tools/write.py
@@ -46,11 +46,11 @@ def _expand_path(file_path: str) -> str:
 
 def _backfill_observable_input(tool_input: dict[str, Any]) -> None:
     """Expand *file_path* in-place so hook allowlists cannot be bypassed
-    via ``~`` or relative paths.
-    """
-    fp = tool_input.get("file_path")
-    if isinstance(fp, str):
-        tool_input["file_path"] = _expand_path(fp)
+    via ``~`` or relative paths. ch06 round-4 (critic m3): delegates to the
+    shared Read/Edit helper so the three file tools can't drift."""
+    from .read import _backfill_read_edit_path
+
+    _backfill_read_edit_path(tool_input)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ch06_tools_round4_A.py
+++ b/tests/test_ch06_tools_round4_A.py
@@ -1,0 +1,222 @@
+"""ch06 round-4 PR-A acceptance tests: the fail-open hook-ask fix, Read/Edit
+permission-input backfill, and the InputValidationError prefix + guard
+category.
+
+Covers my-docs/port-improvement-round-4/ch06-tools-round4-plan-A.md.
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.services.tool_execution.can_use_tool_adapter import build_can_use_tool
+from src.tool_system.context import ToolContext
+
+
+class TestForceDecisionAdapter(unittest.TestCase):
+    """GAP A — the 6-arg can_use_tool honors a hook force-decision instead
+    of raising TypeError and failing OPEN."""
+
+    def _adapter(self):
+        with tempfile.TemporaryDirectory() as _:
+            ctx = ToolContext(workspace_root=Path("/tmp"))
+        return build_can_use_tool(ctx)
+
+    def test_accepts_six_args_without_typeerror(self):
+        fn = self._adapter()
+        # The 6th positional (force_decision) must not raise.
+        import inspect
+
+        sig = inspect.signature(fn)
+        self.assertEqual(len(sig.parameters), 6)
+
+    def test_force_allow_short_circuits(self):
+        fn = self._adapter()
+        tool = MagicMock()
+        tool.name = "Bash"
+        out = fn(tool, {"command": "ls"}, None, None, "t1",
+                 {"behavior": "allow", "input": {"command": "ls -la"}})
+        self.assertEqual(out["behavior"], "allow")
+        self.assertEqual(out.get("updatedInput"), {"command": "ls -la"})
+
+    def test_force_deny_short_circuits(self):
+        fn = self._adapter()
+        tool = MagicMock()
+        tool.name = "Bash"
+        out = fn(tool, {"command": "rm -rf /"}, None, None, "t1",
+                 {"behavior": "deny", "message": "blocked by hook"})
+        self.assertEqual(out["behavior"], "deny")
+        self.assertIn("blocked by hook", out["message"])
+
+    def test_force_ask_prompts_never_consults_rules(self):
+        # critic M2 — an "ask" force-decision must reach the PROMPT and must
+        # NOT consult rules. Even with an allow-rule that would match, the
+        # hook's ask wins → the prompt fires. Here the prompt (handler)
+        # denies; assert has_permissions_to_use_tool was NOT called.
+        fn = self._adapter()
+        tool = MagicMock()
+        tool.name = "Bash"
+        # has_permissions_to_use_tool / handle_permission_ask are imported
+        # inside the adapter fn, so patch them at their source modules.
+        with patch(
+            "src.permissions.check.has_permissions_to_use_tool",
+        ) as perm, patch(
+            "src.permissions.handler.handle_permission_ask",
+            return_value=(MagicMock(behavior="deny", message="user declined"),
+                          ()),
+        ):
+            out = fn(tool, {"command": "ls"}, None, None, "t1",
+                     {"behavior": "ask"})
+        self.assertEqual(out["behavior"], "deny")
+        perm.assert_not_called()  # rules never consulted for an ask-hook
+
+    def test_force_ask_no_handler_fails_closed(self):
+        # critic M1/M2 — ask + no handler → the real handle_permission_ask
+        # returns a deny (handler-less contract). Never auto-allows.
+        fn = self._adapter()
+        tool = MagicMock()
+        tool.name = "Bash"
+        out = fn(tool, {"command": "ls"}, None, None, "t1",
+                 {"behavior": "ask"})
+        self.assertEqual(out["behavior"], "deny")
+
+    def test_hook_ask_branch_prompts_not_autoallows(self):
+        """End-to-end through resolve_hook_permission_decision: a PreToolUse
+        hook returning 'ask' reaches the adapter's normal resolution, not
+        the fail-open allow."""
+        import asyncio
+
+        from src.services.tool_execution.tool_hooks import (
+            resolve_hook_permission_decision,
+        )
+
+        fn = self._adapter()
+        tool = MagicMock()
+        tool.name = "Bash"
+        calls = {}
+
+        def _spy(tool_, tinput, ctx, amsg, tid, force=None):
+            calls["force"] = force
+            # Simulate the normal-resolution outcome for an ask.
+            return {"behavior": "deny", "message": "prompted → denied"}
+
+        hook_result = {"behavior": "ask"}
+        out = asyncio.run(resolve_hook_permission_decision(
+            hook_result, tool, {"command": "curl x"}, MagicMock(),
+            _spy, MagicMock(), "t1",
+        ))
+        # The adapter was called WITH the force-decision (not swallowed).
+        self.assertEqual(calls.get("force"), {"behavior": "ask"})
+        self.assertEqual(out["behavior"], "deny")
+
+    def test_hook_ask_branch_fails_closed_on_adapter_exception(self):
+        """critic M1 — if the adapter raises during ask resolution, the
+        hook-ask branch DENIES (fail-closed), not allows."""
+        import asyncio
+
+        from src.services.tool_execution.tool_hooks import (
+            resolve_hook_permission_decision,
+        )
+
+        tool = MagicMock()
+        tool.name = "Bash"
+
+        def _boom(*a, **k):
+            raise RuntimeError("resolution blew up")
+
+        out = asyncio.run(resolve_hook_permission_decision(
+            {"behavior": "ask"}, tool, {"command": "x"}, MagicMock(),
+            _boom, MagicMock(), "t1",
+        ))
+        self.assertEqual(out["behavior"], "deny")
+
+    def test_hook_ask_branch_fails_closed_without_adapter(self):
+        """critic M1 — no adapter → DENY, not allow."""
+        import asyncio
+
+        from src.services.tool_execution.tool_hooks import (
+            resolve_hook_permission_decision,
+        )
+
+        tool = MagicMock()
+        tool.name = "Bash"
+        out = asyncio.run(resolve_hook_permission_decision(
+            {"behavior": "ask"}, tool, {"command": "x"}, MagicMock(),
+            None, MagicMock(), "t1",
+        ))
+        self.assertEqual(out["behavior"], "deny")
+
+
+class TestReadEditBackfill(unittest.TestCase):
+    """GAP B — Read/Edit expand file_path before permissions/hooks."""
+
+    def test_backfill_helper_expands(self):
+        from src.tool_system.tools.read import _backfill_read_edit_path
+
+        home = str(Path.home())
+        inp = {"file_path": "~/somefile.txt"}
+        _backfill_read_edit_path(inp)
+        self.assertTrue(inp["file_path"].startswith(home))
+        self.assertNotIn("~", inp["file_path"])
+
+    def test_read_and_edit_declare_backfill(self):
+        from src.tool_system.tools.edit import EditTool
+        from src.tool_system.tools.read import ReadTool
+
+        self.assertIsNotNone(ReadTool.backfill_observable_input)
+        self.assertIsNotNone(EditTool.backfill_observable_input)
+        # Same shared function.
+        self.assertIs(
+            ReadTool.backfill_observable_input,
+            EditTool.backfill_observable_input,
+        )
+
+    def test_backfill_leaves_non_string_untouched(self):
+        from src.tool_system.tools.read import _backfill_read_edit_path
+
+        inp = {"offset": 5}
+        _backfill_read_edit_path(inp)
+        self.assertEqual(inp, {"offset": 5})
+
+
+class TestInputValidationErrorPrefix(unittest.TestCase):
+    """GAP C — the prefix reconnects the tool-failure-loop guard's
+    InputValidationError category."""
+
+    def test_guard_categorizes_prefixed_error(self):
+        from src.query.tool_failure_loop_guard import _normalize_error_category
+
+        wrapped = "<tool_use_error>InputValidationError: missing 'command'</tool_use_error>"
+        self.assertEqual(_normalize_error_category(wrapped), "InputValidationError")
+
+    def test_guard_trips_on_repeated_validation_errors(self):
+        from src.query.tool_failure_loop_guard import (
+            create_tool_failure_loop_guard_state,
+            update_tool_failure_loop_guard,
+        )
+        from src.types.content_blocks import ToolResultBlock
+        from src.types.messages import UserMessage
+
+        state = create_tool_failure_loop_guard_state()
+        decision = None
+        for i in range(3):
+            blocks = [{
+                "id": f"tu_{i}", "name": "Bash", "type": "tool_use",
+                "input": {"command": "x"},
+            }]
+            results = [UserMessage(content=[ToolResultBlock(
+                tool_use_id=f"tu_{i}",
+                content="<tool_use_error>InputValidationError: bad</tool_use_error>",
+                is_error=True,
+            )])]
+            decision = update_tool_failure_loop_guard(
+                state=state, tool_use_blocks=blocks, tool_results=results,
+            )
+        self.assertTrue(decision.tripped)
+        self.assertEqual(decision.error_category, "InputValidationError")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Round-4 ch06 (tools) PR-A: fail-open hook-ask fix + Read/Edit permission-input backfill + InputValidationError parity

**Docs:** `my-docs/ch06-tools-round4-gap-analysis.md` (§2 GAP A/B/C, §4 two-PR split) + `my-docs/port-improvement-round-4/ch06-tools-round4-plan-A.md` + facet reports + critic verdicts (REVISE→APPROVE). The larger LLM auto-mode classifier is PR-B (plan already written).

The round-3 tool-lane unification means hooks now fire in production — which exposed a live fail-open in the permission path.

### GAP A (security) — the hook-"ask" branch failed open

A PreToolUse hook returning `permissionDecision:"ask"` auto-allowed the tool without prompting: `tool_hooks.py` passed 6 positional args to a 5-arg adapter → `TypeError` → `except` → `return allow`. Fixes:
- `can_use_tool_adapter` gains the 6th `force_decision` param (TS `CanUseToolFn`). `allow`/`deny` force-decisions short-circuit; an **`ask` force-decision routes straight to the prompt and NEVER consults rules** (critic M2 — TS `useCanUseTool.tsx:37,93`; otherwise a static allow-rule would silently bypass a hook explicitly demanding confirmation), synthesizing a `PermissionAskDecision` and honoring the hook's `updatedInput`.
- The hook-"ask" branch now **fails closed** (deny) on adapter exception / missing adapter / unrecognized shape (critic M1), matching the no-hook branch's philosophy and TS (a throwing `canUseTool` aborts the call, never allows).

### GAP B — Read/Edit permission input is now path-expanded

Read and Edit matched permission rules (and PreToolUse hook stdin) against the raw `file_path` (`~`/relative dodged allowlists); Write already expanded. Added the shared `_backfill_read_edit_path` (overwrite-only, TS `FileReadTool.ts:388`/`FileEditTool.ts:115`) to Read + Edit; Write now delegates to it too (one helper for all three — critic m3). Call-input discipline preserved: the model-original path still reaches `call()` and the yielded message (overwrite-only → no clone, correct parity).

### GAP C — InputValidationError prefix

Schema-validation errors now carry the `InputValidationError:` prefix inside `<tool_use_error>` (TS `toolExecution.ts:726`) — load-bearing: the tool-failure-loop guard categorizes on `\bInputValidationError\b`, so without it repeated schema failures were miscategorized.

### Verification

`tests/test_ch06_tools_round4_A.py` (13): force-decision allow/deny short-circuits, ask-prompts-never-consults-rules (`perm.assert_not_called()`), ask-no-handler / adapter-exception / no-adapter all fail closed, Read/Edit backfill expansion + shared helper, InputValidationError prefix + guard-category trip. Full suite at the pre-existing 9-failure baseline. No live path regressed (no-hook/allow/deny paths unchanged).

### Deferred → PR-B / owners

GAP D (LLM auto-mode classifier) = PR-B (plan written). MCP post-hook output override → ch12; tool-lookup fallback breadth → ch12; in-stream tool progress → ch13/17; Agent-concurrency (book-faithful serial) → kept; sed strip / speculative classifier → ch12/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
