### PR TITLE
feat(ch08/round4): per-subagent model resolution + query_source parity + bubble self-consistency

### DIFF
--- a/src/agent/agent_definitions.py
+++ b/src/agent/agent_definitions.py
@@ -158,6 +158,11 @@ EXPLORE_AGENT = AgentDefinition(
     source="built-in",
     base_dir="built-in",
     omit_claude_md=True,
+    # ch08 round-4 (critic M1) — Explore is the fast/cheap read-only agent;
+    # TS exploreAgent.ts:77 runs it on Haiku. get_agent_model resolves this
+    # against the session provider and inherits on providers that don't
+    # serve haiku (e.g. DeepSeek), so it is cross-provider safe.
+    model="haiku",
     get_system_prompt=_explore_system_prompt,
 )
 

--- a/src/agent/agent_model.py
+++ b/src/agent/agent_model.py
@@ -1,0 +1,112 @@
+"""ch08 round-4 WI-1 — per-subagent model resolution.
+
+Port of TS ``getAgentModel`` (``utils/model/agent.ts``, called at
+``runAgent.ts:340``): resolve the model a subagent should run on from the
+tool ``model`` param, the agent definition's ``model:`` frontmatter, and
+the session model, with a ``CLAUDE_CODE_SUBAGENT_MODEL`` env override.
+
+Multi-provider guard: the port runs on 7+ providers, and the abstract
+aliases (``sonnet``/``opus``/``haiku``) only map on Anthropic-family
+providers. So an alias/id the SESSION provider doesn't recognize falls
+back to the session model rather than 400-ing the request.
+
+Concurrency (ch07): Agent is now concurrency-safe, so N parallel
+subagents share the session ``provider`` instance. This module only
+COMPUTES the model string; the caller (``run_agent``) applies it to a
+per-subagent provider CLONE and never mutates the shared provider.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_INHERIT = "inherit"
+# Bare family aliases (TS agent.ts). A request for one of these that
+# matches the parent's TIER keeps the parent's EXACT model rather than
+# downgrading to the alias's canonical (older) target.
+_FAMILY_ALIASES = ("opus", "sonnet", "haiku")
+
+
+def _resolve_against_provider(
+    value: str, session_provider: Any, *, trust_literal: bool = False,
+) -> str:
+    """Resolve an alias/id to the model the subagent should run on; inherit
+    the session model on a miss. Never raises.
+
+    - ``'inherit'``/empty → the session model.
+    - A bare family alias whose tier == the parent's tier → the parent's
+      EXACT model (critic M2 — TS ``aliasMatchesParentTier``; avoids the
+      surprising same-tier downgrade, e.g. sonnet-4-6 → sonnet-4-2025...).
+    - A full (non-alias) model id → trusted literally when ``trust_literal``
+      (the env override / an explicit id — critic M3, TS
+      ``parseUserSpecifiedModel``); otherwise gated by availability.
+    - An alias mapped to a model the provider serves → that canonical id.
+    - Anything the provider doesn't serve → the session model.
+    """
+    session_model = getattr(session_provider, "model", "") or ""
+    normalized = (value or "").strip().lower()
+    if not normalized or normalized == _INHERIT:
+        return session_model
+
+    # M2 — same-tier alias keeps the parent's exact model.
+    if normalized in _FAMILY_ALIASES and normalized in session_model.lower():
+        return session_model
+
+    try:
+        from src.models.model import canonical_model_name
+
+        canonical = canonical_model_name(value)
+    except Exception:  # noqa: BLE001 — resolution failure → inherit
+        return session_model
+
+    # M3 — a full id (canonical didn't change it, i.e. not a known alias)
+    # from the env override or an explicit pin is trusted literally, so it
+    # survives static-list staleness / proxy deployments with custom names.
+    is_bare_alias = normalized in _FAMILY_ALIASES
+    if trust_literal and not is_bare_alias:
+        return value
+
+    try:
+        available = session_provider.get_available_models() or []
+        available = [str(m) for m in available]
+    except Exception:  # noqa: BLE001 — provider can't enumerate → inherit
+        available = []
+    if canonical in available:
+        return canonical
+    # Not served by this provider (e.g. 'haiku' on a DeepSeek session).
+    # Inherit rather than 400. Elevated to WARNING (M3) so an ignored
+    # explicit pin is observable, not silently dropped at debug.
+    logger.warning(
+        "agent model %r (→ %r) is not available on the session provider; "
+        "inheriting the session model %r",
+        value, canonical, session_model,
+    )
+    return session_model
+
+
+def get_agent_model(
+    tool_model: str | None,
+    agent_def_model: str | None,
+    session_provider: Any,
+) -> str:
+    """Resolve the subagent's model. Precedence (TS getAgentModel):
+    ``CLAUDE_CODE_SUBAGENT_MODEL`` env > tool ``model`` param > agent-def
+    ``model:`` > ``'inherit'`` (= the session model). Always returns a
+    non-empty model when the session provider has one; never raises."""
+    env_override = os.environ.get("CLAUDE_CODE_SUBAGENT_MODEL")
+    if env_override:
+        # M3 — the env override is honored more literally (a full id it
+        # names is trusted; TS agent.ts:43-45 bypasses provider gating).
+        return _resolve_against_provider(
+            env_override, session_provider, trust_literal=True,
+        )
+
+    chosen = tool_model or agent_def_model or _INHERIT
+    # A tool param / frontmatter that names a full model id is trusted
+    # literally; bare aliases still go through availability/tier logic.
+    return _resolve_against_provider(
+        chosen, session_provider, trust_literal=True,
+    )

--- a/src/agent/agent_tool_utils.py
+++ b/src/agent/agent_tool_utils.py
@@ -24,6 +24,20 @@ from .constants import (
 logger = logging.getLogger(__name__)
 
 
+def get_query_source_for_agent(agent_type: str, is_built_in: bool) -> str:
+    """ch08 round-4 WI-2 — the subagent query_source label.
+
+    Port of TS ``getQuerySourceForAgent`` (``utils/promptCategory.ts``):
+    ``agent:builtin:<type>`` for built-in agents, ``agent:custom`` for
+    user/project agents. (The fork path threads its own
+    ``agent:builtin:fork`` explicitly.) The ``agent:`` prefix keeps these
+    outside the ``("compact","session_memory")`` skip-set and inside the
+    foreground-retry family, matching TS."""
+    if is_built_in:
+        return f"agent:builtin:{agent_type}"
+    return "agent:custom"
+
+
 @dataclass
 class ResolvedAgentTools:
     """Result of resolving agent tools against available tools."""

--- a/src/agent/run_agent.py
+++ b/src/agent/run_agent.py
@@ -5,6 +5,7 @@ Provides the core run_agent() async generator and filter_incomplete_tool_calls()
 """
 from __future__ import annotations
 
+import copy
 import logging
 import time
 from dataclasses import dataclass, field
@@ -21,7 +22,11 @@ from ..types.messages import AssistantMessage, Message, UserMessage
 from ..utils.abort_controller import AbortController
 
 from .agent_definitions import AgentDefinition, is_built_in_agent
-from .agent_tool_utils import resolve_agent_tools, count_tool_uses
+from .agent_tool_utils import (
+    count_tool_uses,
+    get_query_source_for_agent,
+    resolve_agent_tools,
+)
 from .constants import AGENT_TOOL_NAME
 from .prompt import get_agent_system_prompt
 from .subagent_context import SubagentContextOverrides, create_subagent_context
@@ -349,18 +354,47 @@ async def run_agent(params: RunAgentParams) -> AsyncGenerator[Message, None]:
     # TS has no built-in fallback, but we keep a safety net to prevent runaway agents.
     max_turns = params.max_turns or agent_def.max_turns or SUBAGENT_DEFAULT_MAX_TURNS
 
+    # ch08 round-4 WI-1 — per-subagent model resolution (TS getAgentModel,
+    # runAgent.ts:340). Resolve the model from the tool param / agent-def /
+    # env, then apply it to a per-subagent provider CLONE. NEVER mutate the
+    # shared session provider: ch07 made Agent concurrency-safe, so N
+    # parallel subagents share params.provider — mutating provider.model
+    # would race across them. copy.copy shares the HTTP client (thread-safe,
+    # per-request model) and gives this subagent its own .model.
+    turn_provider = params.provider
+    try:
+        from .agent_model import get_agent_model
+
+        resolved_model = get_agent_model(
+            params.model, agent_def.model, params.provider,
+        )
+        if resolved_model and resolved_model != getattr(
+            params.provider, "model", None
+        ):
+            turn_provider = copy.copy(params.provider)
+            turn_provider.model = resolved_model
+    except Exception:  # noqa: BLE001 — model resolution never blocks a spawn
+        logger.debug("subagent model resolution failed; using session model",
+                     exc_info=True)
+        turn_provider = params.provider
+
     # --- Query loop ---
     # TS microcompact is a no-op for subagents (only fires for
     # repl_main_thread). Don't pass pipeline_config so we don't
     # aggressively clear tool results the model just read.
-    effective_query_source = params.query_source or f"agent_{agent_def.agent_type}"
+    # ch08 round-4 WI-2 — query_source labeling parity (agent:builtin:<type>
+    # / agent:custom), TS promptCategory.getQuerySourceForAgent. The fork
+    # path threads its own 'agent:builtin:fork' via params.query_source.
+    effective_query_source = params.query_source or get_query_source_for_agent(
+        agent_def.agent_type, is_built_in_agent(agent_def),
+    )
     query_params = QueryParams(
         messages=initial_messages,
         system_prompt=system_prompt,
         tools=agent_tools,
         tool_registry=params.tool_registry,
         tool_use_context=subagent_context,
-        provider=params.provider,
+        provider=turn_provider,
         abort_controller=abort_controller,
         query_source=effective_query_source,
         max_turns=max_turns,

--- a/src/entrypoints/agent_server_cli.py
+++ b/src/entrypoints/agent_server_cli.py
@@ -111,6 +111,17 @@ def run_agent_server_subcommand(argv: list[str]) -> int:
     if args.exit_on_parent and not args.stdio:
         _exit_when_stdin_closes()
 
+    # ch08 round-4 WI-3 — 'bubble' is a runtime-only sub-agent-escalation
+    # mode; it has no meaning as a top-level session mode (there is no
+    # parent to escalate to). Reject it explicitly rather than start a
+    # session that behaves surprisingly. ('auto' IS a valid top-level mode
+    # — the ch06 classifier lane — so it stays allowed.)
+    if args.permission_mode == "bubble":
+        print("agent-server: --permission-mode 'bubble' is a runtime-only "
+              "sub-agent mode; use default | plan | acceptEdits | "
+              "bypassPermissions | auto", file=sys.stderr)
+        return 2
+
     workspace = str(Path(args.workspace).resolve()) if args.workspace else str(Path.cwd())
 
     if args.fallback_model and args.fallback_model == args.model:

--- a/src/entrypoints/tui_launcher.py
+++ b/src/entrypoints/tui_launcher.py
@@ -57,6 +57,14 @@ def run_tui_launcher(argv: list[str]) -> int:
                         help="Run the agent-server directly, print cc:// URL + token, and wait (no TUI).")
     args = parser.parse_args(argv)
 
+    # ch08 round-4 WI-3 — 'bubble' is a runtime-only sub-agent-escalation
+    # mode with no top-level meaning; reject it (auto stays valid).
+    if args.permission_mode == "bubble":
+        print("clawcodex tui: --permission-mode 'bubble' is a runtime-only "
+              "sub-agent mode; use default | plan | acceptEdits | "
+              "bypassPermissions | auto", file=sys.stderr)
+        return 2
+
     if args.print_connect:
         return _print_connect(args)
     return launch_ink_tui(

--- a/src/permissions/check.py
+++ b/src/permissions/check.py
@@ -316,21 +316,19 @@ def has_permissions_to_use_tool(
             ),
         )
 
-    if context.mode == "bubble":
-        # Stub for the parent-escalation path described in
-        # book/ch01-architecture.md line 126 + ch06 lines 211-213. A future
-        # change replaces this with a real cross-process request to the
-        # parent agent; the structured reason makes that swap observable.
-        return PermissionDenyDecision(
-            behavior="deny",
-            message=(
-                f"Permission required for {tool.name} in bubble mode; "
-                "request must be escalated to the parent agent."
-            ),
-            decision_reason=AsyncAgentDecisionReason(
-                reason="bubble: sub-agent escalates permission to parent",
-            ),
-        )
+    # ch08 round-4 WI-3 — bubble mode is NOT a resolver case (TS has no
+    # 'bubble' branch in permissions.ts; facet Q4). Bubble is purely an
+    # upstream setting: run_agent._build_permission_context sets
+    # should_avoid_permission_prompts=False + await_automated=True for
+    # bubble, so the ask "bubbles" to the parent's handler by falling
+    # through here (return result). The previous deny-stub CONTRADICTED
+    # that cascade — it denied every ask in bubble mode, which would have
+    # made every subagent (and any --permission-mode bubble session)
+    # uniformly denied the moment bubble became reachable. A headless
+    # bubble agent (should_avoid=True, no handler) still fails closed at
+    # the guard just below. Removing the stub makes bubble ready for the
+    # deferred async-fork escalation without shipping the deny-everything
+    # trap.
 
     if context.should_avoid_permission_prompts:
         return PermissionDenyDecision(

--- a/tests/test_ch08_subagents_round4.py
+++ b/tests/test_ch08_subagents_round4.py
@@ -1,0 +1,268 @@
+"""ch08 round-4 acceptance tests: per-subagent model resolution, query_source
+labeling, and the bubble self-consistency + CLI guard.
+
+Covers my-docs/port-improvement-round-4/ch08-subagents-round4-plan.md.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+from src.agent.agent_model import get_agent_model
+from src.agent.agent_tool_utils import get_query_source_for_agent
+
+
+class _FakeProvider:
+    def __init__(self, model, available):
+        self.model = model
+        self._available = available
+
+    def get_available_models(self):
+        return list(self._available)
+
+
+_SONNET = "claude-sonnet-4-20250514"
+_HAIKU = "claude-3-5-haiku-20241022"
+
+
+class TestAgentModelResolution(unittest.TestCase):
+    def setUp(self):
+        # Ensure no env override leaks between tests.
+        self._env = dict(os.environ)
+        os.environ.pop("CLAUDE_CODE_SUBAGENT_MODEL", None)
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self._env)
+
+    def test_inherit_returns_session_model(self):
+        p = _FakeProvider(_SONNET, [_SONNET, _HAIKU])
+        self.assertEqual(get_agent_model(None, "inherit", p), _SONNET)
+        self.assertEqual(get_agent_model(None, None, p), _SONNET)
+
+    def test_alias_resolves_when_available(self):
+        p = _FakeProvider(_SONNET, [_SONNET, _HAIKU])
+        self.assertEqual(get_agent_model(None, "haiku", p), _HAIKU)
+
+    def test_same_tier_alias_keeps_parent_exact_model(self):
+        # critic M2 — session is a NEWER same-tier model; 'sonnet' must keep
+        # it, NOT downgrade to the alias's canonical (older) target.
+        p = _FakeProvider("claude-sonnet-4-6", [_SONNET, _HAIKU])
+        self.assertEqual(get_agent_model(None, "sonnet", p), "claude-sonnet-4-6")
+        self.assertEqual(get_agent_model("sonnet", None, p), "claude-sonnet-4-6")
+
+    def test_cross_tier_alias_downgrades_as_requested(self):
+        # A DIFFERENT tier is honored (opus session, 'haiku' → haiku).
+        p = _FakeProvider("claude-opus-4-6", [_SONNET, _HAIKU, "claude-opus-4-6"])
+        self.assertEqual(get_agent_model(None, "haiku", p), _HAIKU)
+
+    def test_full_id_trusted_literally(self):
+        # critic M3 — an explicit full id is trusted even if absent from the
+        # (aging) static list, so proxy/custom-name deployments work.
+        p = _FakeProvider(_SONNET, [_SONNET])
+        self.assertEqual(
+            get_agent_model("claude-opus-4-7", None, p), "claude-opus-4-7",
+        )
+
+    def test_tool_model_overrides_agent_def(self):
+        p = _FakeProvider(_SONNET, [_SONNET, _HAIKU])
+        # tool 'haiku' wins over agent-def 'sonnet'
+        self.assertEqual(get_agent_model("haiku", "sonnet", p), _HAIKU)
+
+    def test_unavailable_alias_falls_back_to_session(self):
+        # A DeepSeek-style provider that doesn't serve 'haiku' → inherit,
+        # never a foreign model that would 400.
+        p = _FakeProvider("deepseek-v4-pro", ["deepseek-v4-pro"])
+        self.assertEqual(get_agent_model(None, "haiku", p), "deepseek-v4-pro")
+
+    def test_env_override_wins(self):
+        p = _FakeProvider(_SONNET, [_SONNET, _HAIKU])
+        os.environ["CLAUDE_CODE_SUBAGENT_MODEL"] = "haiku"
+        self.assertEqual(get_agent_model("sonnet", "sonnet", p), _HAIKU)
+
+    def test_env_override_full_id_trusted(self):
+        p = _FakeProvider(_SONNET, [_SONNET])
+        os.environ["CLAUDE_CODE_SUBAGENT_MODEL"] = "my-proxy-model-x"
+        self.assertEqual(get_agent_model(None, None, p), "my-proxy-model-x")
+
+    def test_provider_enumeration_failure_inherits(self):
+        class _Broken:
+            model = _SONNET
+
+            def get_available_models(self):
+                raise RuntimeError("boom")
+
+        self.assertEqual(get_agent_model(None, "haiku", _Broken()), _SONNET)
+
+    def test_never_raises(self):
+        # Even a totally bogus provider returns something falsy-safe.
+        class _Nothing:
+            pass
+
+        self.assertEqual(get_agent_model(None, "haiku", _Nothing()), "")
+
+
+class TestModelResolutionIsConcurrencySafe(unittest.TestCase):
+    """The resolver must NOT mutate the shared session provider (ch07 made
+    Agent concurrency-safe → parallel subagents share the provider)."""
+
+    def test_resolution_does_not_mutate_provider(self):
+        p = _FakeProvider(_SONNET, [_SONNET, _HAIKU])
+        resolved = get_agent_model(None, "haiku", p)
+        self.assertEqual(resolved, _HAIKU)
+        # The shared provider's model is UNCHANGED — the caller clones.
+        self.assertEqual(p.model, _SONNET)
+
+
+class TestExploreRunsOnHaiku(unittest.TestCase):
+    def test_explore_agent_def_declares_haiku(self):
+        # critic M1 — the headline win: Explore's built-in def must request
+        # haiku so get_agent_model resolves it (on Anthropic sessions).
+        from src.agent.agent_definitions import EXPLORE_AGENT
+
+        self.assertEqual(EXPLORE_AGENT.model, "haiku")
+
+    def test_explore_resolves_to_haiku_on_anthropic_session(self):
+        p = _FakeProvider(_SONNET, [_SONNET, _HAIKU])
+        from src.agent.agent_definitions import EXPLORE_AGENT
+
+        self.assertEqual(get_agent_model(None, EXPLORE_AGENT.model, p), _HAIKU)
+
+
+class TestRunAgentClonesProvider(unittest.TestCase):
+    """critic minor — the ACTUAL mutation site: run_agent must clone the
+    provider and set the resolved model on the clone, never on the shared
+    session provider."""
+
+    def test_run_agent_uses_cloned_provider(self):
+        import asyncio
+        from unittest.mock import patch
+
+        from src.agent.run_agent import RunAgentParams, run_agent
+        from src.agent.agent_definitions import EXPLORE_AGENT
+
+        session_provider = _FakeProvider(_SONNET, [_SONNET, _HAIKU])
+        captured = {}
+
+        async def _fake_query(qp):
+            captured["provider"] = qp.provider
+            captured["model"] = getattr(qp.provider, "model", None)
+            return
+            yield  # make it an async generator
+
+        params = RunAgentParams(
+            parent_context=_min_context(),
+            agent_definition=EXPLORE_AGENT,
+            prompt="explore",
+            available_tools=[],
+            tool_registry=_min_registry(),
+            provider=session_provider,
+        )
+        # run_agent imports `query` inside the function from src.query.query.
+        with patch("src.query.query.query", _fake_query):
+            asyncio.run(_drain(run_agent(params)))
+
+        # The query got a clone carrying haiku…
+        self.assertEqual(captured.get("model"), _HAIKU)
+        self.assertIsNot(captured.get("provider"), session_provider)
+        # …and the SHARED session provider is unmutated (concurrency-safe).
+        self.assertEqual(session_provider.model, _SONNET)
+
+
+async def _drain(agen):
+    async for _ in agen:
+        pass
+
+
+def _min_context():
+    from pathlib import Path
+
+    from src.tool_system.context import ToolContext, ToolUseOptions
+
+    ctx = ToolContext(workspace_root=Path("/tmp"))
+    ctx.options = ToolUseOptions(tools=[])
+    return ctx
+
+
+def _min_registry():
+    from src.tool_system.defaults import build_default_registry
+
+    return build_default_registry()
+
+
+class TestQuerySourceLabeling(unittest.TestCase):
+    def test_builtin_label(self):
+        self.assertEqual(
+            get_query_source_for_agent("Explore", True),
+            "agent:builtin:Explore",
+        )
+
+    def test_custom_label(self):
+        self.assertEqual(
+            get_query_source_for_agent("my-agent", False), "agent:custom",
+        )
+
+
+class TestBubbleAndCliGuards(unittest.TestCase):
+    def test_bubble_surfaces_ask(self):
+        from src.permissions.check import has_permissions_to_use_tool
+        from src.permissions.types import ToolPermissionContext
+        from src.tool_system.build_tool import build_tool
+
+        tool = build_tool(
+            name="TestTool", input_schema={"type": "object"},
+            call=lambda i, c: None, prompt="", description="",
+        )
+        ctx = ToolPermissionContext(mode="bubble")
+        decision = has_permissions_to_use_tool(tool, {}, ctx)
+        self.assertEqual(decision.behavior, "ask")
+
+    def test_agent_server_cli_rejects_bubble(self):
+        from src.entrypoints.agent_server_cli import run_agent_server_subcommand
+
+        # The guard returns 2 BEFORE any server spawn.
+        rc = run_agent_server_subcommand(["--permission-mode", "bubble", "--stdio"])
+        self.assertEqual(rc, 2)
+
+    def test_tui_launcher_rejects_bubble(self):
+        from src.entrypoints.tui_launcher import run_tui_launcher
+
+        rc = run_tui_launcher(["--permission-mode", "bubble"])
+        self.assertEqual(rc, 2)
+
+    def test_bubble_headless_fails_closed(self):
+        # critic minor — the untested safety branch: bubble + no prompts →
+        # deny (fail-closed).
+        from src.permissions.check import has_permissions_to_use_tool
+        from src.permissions.types import ToolPermissionContext
+        from src.tool_system.build_tool import build_tool
+
+        tool = build_tool(
+            name="TestTool", input_schema={"type": "object"},
+            call=lambda i, c: None, prompt="", description="",
+        )
+        ctx = ToolPermissionContext(
+            mode="bubble", should_avoid_permission_prompts=True,
+        )
+        decision = has_permissions_to_use_tool(tool, {}, ctx)
+        self.assertEqual(decision.behavior, "deny")
+
+    def test_cli_still_accepts_auto(self):
+        # critic minor — lock intent: 'auto' (ch06 classifier lane) must NOT
+        # be rejected. run_tui_launcher with auto should pass the guard (it
+        # won't return 2 for the permission-mode reason). We stop it before
+        # the real launch by giving --print-connect a path it handles.
+        from unittest.mock import patch
+
+        from src.entrypoints import tui_launcher
+
+        with patch.object(tui_launcher, "_print_connect", return_value=0):
+            rc = tui_launcher.run_tui_launcher(
+                ["--permission-mode", "auto", "--print-connect"],
+            )
+        self.assertEqual(rc, 0)  # not the bubble-reject 2
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_permission_auto_bubble.py
+++ b/tests/test_permission_auto_bubble.py
@@ -133,14 +133,26 @@ class TestAutoMode(unittest.TestCase):
 
 
 class TestBubbleMode(unittest.TestCase):
-    def test_bubble_denies_with_async_agent_reason(self) -> None:
+    def test_bubble_surfaces_ask_not_deny(self) -> None:
+        # ch08 round-4 WI-3 — bubble is NOT a resolver deny case (TS has no
+        # bubble branch in permissions.ts). An interactive bubble agent
+        # (should_avoid_permission_prompts=False) surfaces the ASK so it can
+        # bubble to the parent's handler — agreeing with run_agent's
+        # should_avoid=False cascade. The old deny-stub contradicted that.
         ctx = ToolPermissionContext(mode="bubble")
         tool = _MockTool(name="TestTool")
         decision = has_permissions_to_use_tool(tool, {}, ctx)
+        self.assertEqual(decision.behavior, "ask")
+
+    def test_bubble_headless_still_fails_closed(self) -> None:
+        # A headless bubble agent (no handler) still denies at the
+        # should_avoid guard below the removed stub.
+        ctx = ToolPermissionContext(
+            mode="bubble", should_avoid_permission_prompts=True,
+        )
+        tool = _MockTool(name="TestTool")
+        decision = has_permissions_to_use_tool(tool, {}, ctx)
         self.assertEqual(decision.behavior, "deny")
-        self.assertIsInstance(decision.decision_reason, AsyncAgentDecisionReason)
-        assert isinstance(decision.decision_reason, AsyncAgentDecisionReason)
-        self.assertIn("bubble", decision.decision_reason.reason.lower())
 
     def test_bubble_does_not_block_allow_decisions(self) -> None:
         # If the tool itself returns allow (via rule or its own check), bubble
@@ -168,7 +180,7 @@ class TestModeOrderingInOuterFlow(unittest.TestCase):
     """The outer ask-transformation order in has_permissions_to_use_tool:
     1. dontAsk → deny (highest priority)
     2. auto → classifier
-    3. bubble → escalation deny
+    3. bubble → falls through (no resolver case; ch08 round-4 WI-3)
     4. should_avoid_permission_prompts → headless deny
     """
 


### PR DESCRIPTION
## Round-4 ch08 (sub-agents): per-subagent model resolution + query_source parity + bubble self-consistency

**Docs:** `my-docs/ch08-subagents-round4-gap-analysis.md` + two facet reports + critic verdict under `my-docs/port-improvement-round-4/`.

The dominant subagent path is already at parity (foreground subagents inherit the parent's permission context + handler and prompt over the WS channel — the client/server split doesn't break it; `bypassPermissions`/`acceptEdits` inheritance holds). Three gaps closed:

### GAP A (headline) — per-subagent model resolution was entirely unimplemented

The `model` tool param (`sonnet`/`opus`/`haiku`, advertised "takes precedence") and every agent-def `model:` were **parsed, stored, and dropped**: `run_agent()` never read `params.model`, so every subagent ran on the session model. **Explore never ran on Haiku.** New `agent_model.get_agent_model(tool_model, agent_def_model, session_provider)` (TS `getAgentModel`): precedence env `CLAUDE_CODE_SUBAGENT_MODEL` > tool param > agent-def > `inherit`, resolved provider-aware. `EXPLORE_AGENT.model` is now `"haiku"` (TS `exploreAgent.ts:77`) so the fast read-only agent actually runs on Haiku. Three resolution rules match TS: a **bare family alias whose tier matches the session model keeps the parent's exact model** (`aliasMatchesParentTier` — no surprising same-tier downgrade); a **full model id is trusted literally** (`parseUserSpecifiedModel` — proxy/custom-name deployments survive static-list staleness); an **alias the session provider doesn't serve** (e.g. `haiku` on a DeepSeek session) falls back to the session model rather than 400-ing (with a WARNING so an ignored pin is observable).

**Concurrency-safe (ties to ch07):** since ch07 made Agent concurrency-safe, N parallel subagents share the session `provider`. Model resolution therefore applies the resolved model to a **per-subagent provider clone** (`copy.copy`, own `.model`, shared thread-safe client) and NEVER mutates the shared provider — a test asserts the shared provider's `.model` is unchanged after resolution.

### GAP B — query_source labeling parity

Non-fork subagents got `agent_<type>`; TS gives `agent:builtin:<type>` / `agent:custom` (`getQuerySourceForAgent`). The `agent:` prefix keeps them in the foreground-retry family and outside the `("compact","session_memory")` skip-set. Fixed on the non-fork path; the fork path's explicit `agent:builtin:fork` is unchanged.

### GAP C — the bubble resolver contradicted run_agent (+ a CLI footgun)

`check.py` DENIED every `ask` in bubble mode, but `run_agent._build_permission_context` treats bubble as prompts-on (`should_avoid=False`) — the two halves disagreed, and the deny-stub was a latent trap (aligning `FORK_AGENT` to TS's `bubble` would have denied every subagent ask). TS has no bubble resolver case at all (facet Q4) — bubble is purely an upstream setting. Removed the stub so bubble falls through to the `ask` (surfacing to the parent's handler), agreeing with the cascade; a headless bubble agent still fails closed at the `should_avoid` guard. Also guarded the agent-server + tui CLIs to reject `--permission-mode bubble` (a runtime-only sub-agent mode with no top-level meaning; `auto` stays valid).

### Verification

`tests/test_ch08_subagents_round4.py` (22): model resolution matrix (inherit, alias-available, same-tier-keeps-parent, cross-tier-honored, full-id-trusted, tool-overrides-agent-def, unavailable-alias→inherit, env-override + env-full-id, enumeration-failure→inherit, never-raises), Explore→haiku, a `run_agent` wiring test (query gets a provider CLONE carrying haiku; the shared session provider unmutated — the actual mutation site), query_source labels, bubble-surfaces-ask + bubble-headless-fails-closed, CLI bubble rejection + auto-still-accepted. Updated `test_permission_auto_bubble.py` to the fall-through contract. Full suite at the pre-existing 9-failure baseline. Critic REVISE→APPROVE.

### Deferred (owners)

Full async-fork-bubble escalation (feature-flagged; WI-3 makes bubble ready) → fork PR; isolation:'worktree' (git-worktree machinery); frontmatter hooks/skills/MCP preload + omit_claude_md + initialPrompt → ch12; `background:true` trigger; flagSettings agent tier; built-in registry 3→6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
