### PR TITLE
feat(ch09/round4): wire Layer 1 system-prompt threading so fork hits the parent's cache

### DIFF
--- a/src/agent/prompt.py
+++ b/src/agent/prompt.py
@@ -189,8 +189,8 @@ def get_agent_prompt(
 
 def get_agent_system_prompt(
     agent_definition: AgentDefinition,
-    parent_system_prompt: str | None = None,
-) -> str:
+    parent_system_prompt: "str | list | None" = None,
+) -> "str | list":
     """Get the system prompt for an agent.
 
     Mirrors getAgentSystemPrompt() from typescript/src/tools/AgentTool/runAgent.ts.

--- a/src/agent/run_agent.py
+++ b/src/agent/run_agent.py
@@ -57,7 +57,7 @@ class RunAgentParams:
     is_async: bool = False
     max_turns: int | None = None
     system_prompt_override: str | None = None
-    parent_system_prompt: str | None = None
+    parent_system_prompt: "str | list | None" = None
     permission_mode_override: PermissionMode | None = None
     context_messages: list[Message] | None = None
     abort_controller: AbortController | None = None

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -1206,6 +1206,24 @@ async def query(
     # defaults. Sync once per query.
     params.tool_use_context.options.tools = list(params.tools)
 
+    # ch09 round-4 WI-1 — capture the parent's rendered system prompt onto
+    # its context so a fork spawned DURING this turn threads the parent's
+    # EXACT prompt (byte-identical), letting the fork child chain onto the
+    # parent's warm [system+tools+history] cache. Without this the field
+    # was dead scaffolding (permanently None) and fork children fell back
+    # to DEFAULT_AGENT_PROMPT — diverging at byte 0 and reprocessing the
+    # whole history at full price (fork's entire economic point, inert).
+    # TS: toolUseContext.renderedSystemPrompt (AgentTool.tsx:496). The
+    # captured value is the INPUT to _call_model_sync's assembly; the fork
+    # child threads the same input and goes through the same assembly, so
+    # the wire bytes match. Set unconditionally (cheap; only fork reads it;
+    # a fork-of-subagent is guarded regardless).
+    if params.system_prompt:
+        try:
+            params.tool_use_context.rendered_system_prompt = params.system_prompt
+        except Exception:  # noqa: BLE001 — read-only stub context
+            pass
+
     while True:
         messages = state.messages
         if _diag:

--- a/src/tool_system/context.py
+++ b/src/tool_system/context.py
@@ -233,7 +233,15 @@ class ToolContext:
     # transitions (GrowthBook cold→warm) and bust the prompt cache; the
     # main loop should populate this field whenever it has the rendered
     # bytes on hand for the parent's last turn.
-    rendered_system_prompt: str | None = None
+    #
+    # ch09 round-4 WI-1 — now POPULATED by query() at turn entry
+    # (query.py, after the options.tools sync). Accepts the parent's actual
+    # ``system_prompt`` shape: a ``list[dict]`` on the live agent-server /
+    # headless path (build_effective_system_prompt) or a ``str`` on
+    # string-prompt callers. The fork threads it verbatim into the child's
+    # QueryParams.system_prompt so both sides run the identical
+    # _call_model_sync assembly → byte-identical wire prefix.
+    rendered_system_prompt: "str | list[dict[str, Any]] | None" = None
 
     def __post_init__(self) -> None:
         self.workspace_root = Path(self.workspace_root).resolve()

--- a/src/tool_system/tools/agent.py
+++ b/src/tool_system/tools/agent.py
@@ -258,7 +258,7 @@ def make_agent_tool(
         fork_context_messages: list[Any] | None = None
         fork_query_source: str | None = None
         fork_use_exact_tools = False
-        fork_parent_system_prompt: str | None = None
+        fork_parent_system_prompt: "str | list | None" = None
         fork_prompt = prompt
 
         if is_fork_path:
@@ -750,7 +750,7 @@ def make_agent_tool(
 def _resolve_parent_system_prompt(
     context: ToolContext,
     agent_definitions: list[AgentDefinition],
-) -> str | None:
+) -> "str | list | None":
     """Resolve the parent system prompt for fork children.
 
     Mirrors the layered fallback in
@@ -772,6 +772,12 @@ def _resolve_parent_system_prompt(
     Returns ``None`` when no candidate is available.
     """
     rendered = getattr(context, "rendered_system_prompt", None)
+    # ch09 round-4 WI-1 — accept the parent's actual prompt shape. On the
+    # live path this is a non-empty list[dict] of system blocks; on
+    # string-prompt callers it is a str. Both are threaded verbatim into
+    # the fork child's system_prompt for byte-identity.
+    if isinstance(rendered, list) and rendered:
+        return rendered
     if isinstance(rendered, str) and rendered.strip():
         return rendered
 

--- a/tests/test_ch09_fork_round4.py
+++ b/tests/test_ch09_fork_round4.py
@@ -1,0 +1,161 @@
+"""ch09 round-4 acceptance tests: Layer 1 system-prompt threading — the
+fork child inherits the parent's EXACT rendered prompt (byte-identical), not
+DEFAULT_AGENT_PROMPT.
+
+Covers my-docs/port-improvement-round-4/ch09-fork-agents-round4-plan.md.
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.providers.base import ChatResponse
+from src.tool_system.context import ToolContext
+
+
+_PARENT_LIST_PROMPT = [
+    {"type": "text", "text": "You are a helpful CLI agent.",
+     "cache_control": {"type": "ephemeral"}},
+    {"type": "text", "text": "## Project Instructions\nBe concise."},
+]
+
+
+def _completion(text="ok"):
+    return ChatResponse(content=text, model="test-model",
+                        usage={"input_tokens": 1, "output_tokens": 1},
+                        finish_reason="end_turn", tool_uses=None)
+
+
+class TestResolveParentPrompt(unittest.TestCase):
+    def _ctx(self, rendered):
+        ctx = ToolContext(workspace_root=Path("/tmp"))
+        ctx.rendered_system_prompt = rendered
+        return ctx
+
+    def test_prefers_rendered_list(self):
+        from src.tool_system.tools.agent import _resolve_parent_system_prompt
+        from src.agent.agent_definitions import get_built_in_agents
+
+        out = _resolve_parent_system_prompt(
+            self._ctx(_PARENT_LIST_PROMPT), get_built_in_agents(),
+        )
+        self.assertEqual(out, _PARENT_LIST_PROMPT)
+
+    def test_prefers_rendered_str(self):
+        from src.tool_system.tools.agent import _resolve_parent_system_prompt
+        from src.agent.agent_definitions import get_built_in_agents
+
+        out = _resolve_parent_system_prompt(
+            self._ctx("PARENT STRING PROMPT"), get_built_in_agents(),
+        )
+        self.assertEqual(out, "PARENT STRING PROMPT")
+
+    def test_none_when_unset(self):
+        from src.tool_system.tools.agent import _resolve_parent_system_prompt
+        from src.agent.agent_definitions import get_built_in_agents
+
+        ctx = self._ctx(None)
+        ctx.agent_type = None
+        out = _resolve_parent_system_prompt(ctx, get_built_in_agents())
+        self.assertIsNone(out)
+
+
+class TestQueryCapturesRenderedPrompt(unittest.TestCase):
+    """query() must populate tool_use_context.rendered_system_prompt so a
+    fork spawned during the turn threads it."""
+
+    def _drive(self, system_prompt):
+        from src.query.query import QueryParams, run_query
+        from src.tool_system.defaults import build_default_registry
+        from src.types.messages import UserMessage
+        from src.utils.abort_controller import AbortController
+
+        provider = MagicMock()
+        provider.chat_stream_response.side_effect = NotImplementedError()
+        provider.chat.return_value = _completion()
+        registry = build_default_registry()
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = ToolContext(workspace_root=Path(tmp))
+            params = QueryParams(
+                messages=[UserMessage(content="hi")],
+                system_prompt=system_prompt,
+                tools=registry.list_tools(),
+                tool_registry=registry,
+                tool_use_context=ctx,
+                provider=provider,
+                abort_controller=AbortController(),
+                max_turns=1,
+            )
+            asyncio.run(run_query(params))
+            return ctx.rendered_system_prompt
+
+    def test_captures_list_prompt(self):
+        self.assertEqual(self._drive(_PARENT_LIST_PROMPT), _PARENT_LIST_PROMPT)
+
+    def test_captures_str_prompt(self):
+        self.assertEqual(self._drive("You are helpful."), "You are helpful.")
+
+
+class TestForkThreadsParentPrompt(unittest.TestCase):
+    """End-to-end: with the parent context carrying a rendered list prompt,
+    a fork threads THAT prompt into the child's query — not DEFAULT_AGENT_PROMPT."""
+
+    def test_fork_child_system_prompt_is_parent_prompt(self):
+        import os
+
+        from src.agent.run_agent import RunAgentParams, run_agent
+        from src.agent.agent_definitions import FORK_AGENT
+        from src.tool_system.context import ToolUseOptions
+        from src.tool_system.defaults import build_default_registry
+
+        parent = ToolContext(workspace_root=Path("/tmp"))
+        parent.rendered_system_prompt = _PARENT_LIST_PROMPT
+        parent.options = ToolUseOptions(tools=[])
+
+        # Resolve the parent prompt exactly as the fork path does.
+        from src.tool_system.tools.agent import _resolve_parent_system_prompt
+        from src.agent.agent_definitions import get_built_in_agents
+
+        resolved = _resolve_parent_system_prompt(parent, get_built_in_agents())
+        self.assertEqual(resolved, _PARENT_LIST_PROMPT)
+
+        captured = {}
+
+        async def _fake_query(qp):
+            captured["system_prompt"] = qp.system_prompt
+            return
+            yield
+
+        provider = MagicMock()
+        provider.model = "test-model"
+        params = RunAgentParams(
+            parent_context=parent,
+            agent_definition=FORK_AGENT,
+            prompt="",
+            available_tools=[],
+            tool_registry=build_default_registry(),
+            provider=provider,
+            parent_system_prompt=resolved,
+            use_exact_tools=True,
+            context_messages=[],
+        )
+
+        async def _drain(agen):
+            async for _ in agen:
+                pass
+
+        with patch("src.query.query.query", _fake_query):
+            asyncio.run(_drain(run_agent(params)))
+
+        # The child threaded the PARENT's exact prompt, not DEFAULT_AGENT_PROMPT.
+        self.assertEqual(captured.get("system_prompt"), _PARENT_LIST_PROMPT)
+        from src.agent.constants import DEFAULT_AGENT_PROMPT
+
+        self.assertNotEqual(captured.get("system_prompt"), DEFAULT_AGENT_PROMPT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Round-4 ch09 (fork agents): wire Layer 1 system-prompt threading so fork actually hits the parent's cache

**Docs:** `my-docs/ch09-fork-agents-round4-gap-analysis.md` + facet report + critic verdict under `my-docs/port-improvement-round-4/`.

Fork agents exist to exploit the prompt cache: parallel children share the parent's ~30-80K-token `[system + tools + history]` prefix, so children 2..N get a 90% input-cost discount. That requires the child's system prompt to be byte-identical to the parent's.

### GAP A (headline) — Layer 1 was dead scaffolding; the cache win was inert

`ToolContext.rendered_system_prompt` was **read by the fork path but never written anywhere** (permanently `None`), so fork children fell through to `DEFAULT_AGENT_PROMPT` — a generic ~70-word string that diverges from the parent at **byte 0** of the cache key. Every child reprocessed the whole history at full price; fork's entire economic point never materialized (directly undercutting the ch07 parallel-multi-agent work — the "cheap" parallel children weren't cheap).

Fix: `query()` now captures the parent's actual `system_prompt` onto `tool_use_context.rendered_system_prompt` at turn entry (once per query, next to the `options.tools` sync). The field widens to `str | list[dict] | None` — the live agent-server/headless path produces a `list[dict]` from `build_effective_system_prompt`; string callers a `str`. `_resolve_parent_system_prompt` accepts both and threads the captured value verbatim into the fork child's `system_prompt`. Since the captured value is the INPUT to `_call_model_sync`'s assembly and the child runs the identical assembly, the wire prefix is byte-identical → the child chains onto the parent's warm cache. TS: `toolUseContext.renderedSystemPrompt` (`AgentTool.tsx:496`).

### Verification

`tests/test_ch09_fork_round4.py` (6): `_resolve_parent_system_prompt` prefers the rendered list / str / falls through when unset; `query()` captures both a list and a str prompt onto the context; end-to-end — a fork threads the parent's exact list prompt into the child's query (NOT `DEFAULT_AGENT_PROMPT`). Fork/agent/query adjacents green. Full suite at the pre-existing 9-failure baseline. The capture is a no-op for the non-fork path (only the fork reads the field) — regression-only for everything else.

### Deferred (owners)

Fork is env-gated OFF by default (`CLAUDE_FORK_SUBAGENT`), a faithful port of TS's `feature('FORK_SUBAGENT')`. Sibling-to-sibling marker placement (WI-1 already delivers the primary parent-cache reuse) → ch17; `forceAsync` on fork + `FORK_AGENT.permission_mode=bubble` → the async-fork-bubble follow-up (ch08 made bubble ready); `tool_result` list-shape (TS's own low-pri TODO); `isolation:'worktree'` child creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
