### PR TITLE
feat(ch10/round4): deliver queued SendMessages + reclaim terminal background tasks

### DIFF
--- a/src/agent/subagent_context.py
+++ b/src/agent/subagent_context.py
@@ -209,6 +209,19 @@ def create_subagent_context(
         # treat sub-agent loops as untrusted in a trusted workspace.
         hook_config_manager=parent_context.hook_config_manager,
         workspace_trusted=parent_context.workspace_trusted,
+        # ch10 round-4 WI-1 — SHARE the parent's task + name registries
+        # (do NOT fall to fresh empty instances). TS keeps all task state
+        # in a single AppState.tasks threaded everywhere; the port made
+        # these per-ToolContext, so a background child ran with its OWN
+        # empty runtime_tasks. A parent SendMessage(to=name) queued the
+        # message into the PARENT's registry, but the child drained its
+        # own empty one → the message was SILENTLY DROPPED while the tool
+        # reported "queued for delivery." Sharing the same instances (both
+        # are RLock-guarded — safe under the ch07 parallel-agent fan-out)
+        # restores TS's single-shared-store semantics so the child drains
+        # the same store the parent queued into.
+        runtime_tasks=parent_context.runtime_tasks,
+        agent_name_registry=parent_context.agent_name_registry,
     )
 
 

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -1635,6 +1635,16 @@ class _AgentSession:
 
     async def shutdown(self) -> None:
         self._stop.set()
+        # ch10 round-4 WI-2 — stop the eviction sweeper daemon (started in
+        # _build_runtime under single_session). Idempotent; safe if never
+        # started.
+        try:
+            from src.tasks.eviction import stop_eviction_sweeper
+
+            stop_eviction_sweeper()
+        except Exception:  # noqa: BLE001
+            logger.debug("[agent-server] eviction sweeper stop failed",
+                         exc_info=True)
         # Unblock any in-flight permission asks with a deny.
         with self._lock:
             pendings = list(self._pending.values())
@@ -1993,6 +2003,24 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
         sess.session = Session.create(provider_name, getattr(provider, "model", model or ""))
         sess._base_system_prompt = system_prompt
         sess.system_prompt = sess._compose_with_plan(system_prompt)  # honor an existing /plan
+
+        # ch10 round-4 WI-2 (critic B1) — start the terminal-task eviction
+        # sweeper HERE, after tool_context is constructed and stored (the
+        # earlier placement read sess.tool_context while it was still None,
+        # so the sweeper never started — reintroducing the very
+        # built-but-dead defect WI-2 exists to fix). The sweeper
+        # (src/tasks/eviction.py) reclaims terminal background tasks that
+        # otherwise pile up in runtime_tasks / /tasks unbounded. Gated
+        # single_session: bound to THIS session's runtime_tasks (a
+        # multi-session --http server would need one per session, deferred).
+        if sess.config.single_session:
+            try:
+                from src.tasks.eviction import start_eviction_sweeper
+
+                start_eviction_sweeper(tool_context.runtime_tasks)
+            except Exception:  # noqa: BLE001 — sweeper is advisory
+                logger.debug("[agent-server] eviction sweeper start failed",
+                             exc_info=True)
         profile_checkpoint("agent_server_build_runtime_end")
     except Exception as exc:  # noqa: BLE001
         logger.exception("[agent-server] runtime build failed")

--- a/src/tasks/local_shell.py
+++ b/src/tasks/local_shell.py
@@ -54,6 +54,13 @@ class LocalShellTaskState(TaskStateBase):
     output_path: str = ""
     exit_code: int | None = None
     finished_at: float | None = None
+    # ch10 round-4 WI-2 — eviction grace fields (mirror LocalAgentTaskState).
+    # Without these on the shell state, schedule_eviction's hasattr guard
+    # made it a no-op, so terminal background bash tasks could NEVER be
+    # reclaimed by the sweeper (they piled up in /tasks forever). ``retain``
+    # lets a UI pin the entry; ``evict_after`` is the grace deadline.
+    retain: bool = False
+    evict_after: float | None = None
     proc: subprocess.Popen | None = field(default=None, repr=False, compare=False)
     handle: IO[bytes] | None = field(default=None, repr=False, compare=False)
 

--- a/src/tool_system/tools/bash/background.py
+++ b/src/tool_system/tools/bash/background.py
@@ -129,14 +129,33 @@ def spawn_background_bash(
                 # ``replace`` keeps every other field (incl. proc/handle)
                 # so a still-pending TaskStop call has the Popen reference.
                 from dataclasses import replace
+
+                from src.tasks.eviction import schedule_eviction
                 new_status = "completed" if rc == 0 else "failed"
-                return replace(
+                terminal = replace(
                     prev,
                     exit_code=rc,
                     finished_at=finished_at,
                     end_time=finished_at,
                     status=new_status,
+                    # ch10 round-4 WI-2 — a background bash task has no async
+                    # completion notification (it is polled via TaskOutput),
+                    # so mark it ``notified`` on the terminal transition;
+                    # otherwise the eviction sweeper's notify-before-evict
+                    # guard would keep it forever. The grace period
+                    # (PANEL_GRACE_SECONDS) still gives the model time to read
+                    # the output before the entry is reclaimed. Without this
+                    # (and the schedule_eviction below) terminal bash tasks
+                    # accumulated unbounded and lingered in /tasks.
+                    # FORWARD-TRAP (critic m1): this unconditionally marks
+                    # notified. If a bash completion notification is later
+                    # ported (TS enqueueShellNotification), REMOVE this line —
+                    # otherwise the check-and-set here pre-suppresses that
+                    # notification. Semantically analogous to TS
+                    # markTaskNotified today (marks notified WITHOUT sending).
+                    notified=True,
                 )
+                return schedule_eviction(terminal)
 
             context.runtime_tasks.update(task_id, _patch)
             # Mirror to the legacy dict in lockstep so old readers see the

--- a/src/tool_system/tools/send_message.py
+++ b/src/tool_system/tools/send_message.py
@@ -199,12 +199,22 @@ async def _route_in_process(
         agent_id=agent_id, prompt=message_text, context=context,
     )
     if result.resumed:
-        return _ok(
-            f"Agent {to!r} was {state.status!r}; resumed it in the "
-            f"background with your message.",
+        # ch10 round-4 (critic M1) — HONEST message. resume_agent_background
+        # re-registers the terminal agent as running and queues the message,
+        # but does NOT yet spawn a run_agent loop (resume_agent.py:163-165 —
+        # "wiring the resumed lifecycle into run_agent is a subsequent
+        # integration step"), so the follow-up is NOT processed. The old
+        # text claimed "resumed it in the background with your message,"
+        # which made the model wait for a reply that never comes — the exact
+        # silent-success failure this chapter's PR exists to eliminate.
+        # Report the limitation and tell the model to spawn a fresh agent.
+        # When the resume lifecycle lands, restore the success message.
+        return _err(
+            f"Agent {to!r} had already {state.status!r}. Live resume of a "
+            f"finished background agent is not yet supported, so your "
+            f"message will NOT be processed — spawn a fresh agent with the "
+            f"follow-up instead.",
             agent_id=agent_id,
-            output_file=result.output_file,
-            replayed_messages=result.replayed_message_count,
         )
     # Lost the race or unable to resume — queue onto whatever the
     # winner registered (or report an error if the agent state moved

--- a/tests/test_ch10_coordination_round4.py
+++ b/tests/test_ch10_coordination_round4.py
@@ -1,0 +1,186 @@
+"""ch10 round-4 acceptance tests: (WI-1) the subagent context shares the
+parent's task/name registries so SendMessage-to-a-running-child is actually
+delivered, and (WI-2) terminal background bash tasks become eviction-eligible.
+
+Covers my-docs/port-improvement-round-4/ch10-coordination-round4-plan.md.
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from src.agent.subagent_context import (
+    SubagentContextOverrides,
+    create_subagent_context,
+)
+from src.tool_system.context import ToolContext
+
+
+class TestSubagentSharesRegistries(unittest.TestCase):
+    """WI-1 — the fix for the silent SendMessage-to-running-child drop."""
+
+    def test_child_shares_parent_runtime_tasks(self):
+        parent = ToolContext(workspace_root=Path("/tmp"))
+        child = create_subagent_context(
+            parent, SubagentContextOverrides(agent_id="worker-1"),
+        )
+        # SAME instance — not a fresh empty registry.
+        self.assertIs(child.runtime_tasks, parent.runtime_tasks)
+        self.assertIs(child.agent_name_registry, parent.agent_name_registry)
+
+    def test_message_queued_on_parent_drains_via_query_hook(self):
+        # End-to-end through the REAL query drain hook (critic M2): a message
+        # SendMessage queues into the parent's registry is drained by the
+        # child via _drain_pending_user_messages(child_context) — the exact
+        # call query.py makes each tool round. Before WI-1 the child's
+        # registry was a fresh empty instance → the hook returned [].
+        from src.query.query import _drain_pending_user_messages
+        from src.tasks.local_agent import (
+            queue_pending_message,
+            register_async_agent,
+        )
+
+        parent = ToolContext(workspace_root=Path("/tmp"))
+        register_async_agent(
+            agent_id="worker-1", description="d", prompt="p",
+            agent_type="general-purpose", registry=parent.runtime_tasks,
+        )
+        child = create_subagent_context(
+            parent, SubagentContextOverrides(agent_id="worker-1"),
+        )
+        ok = queue_pending_message("worker-1", "follow-up task",
+                                   parent.runtime_tasks)
+        self.assertTrue(ok)
+
+        # The real query hook, driven with the CHILD context.
+        drained = _drain_pending_user_messages(child)
+        # It yields user messages carrying the queued text.
+        joined = " ".join(
+            str(getattr(m, "content", m)) for m in (drained or [])
+        )
+        self.assertIn("follow-up task", joined)
+
+
+class TestBashTerminalEvictionEligible(unittest.TestCase):
+    """WI-2 — a terminal background bash task is eviction-eligible (was
+    doubly ineligible: no evict_after, notified=False)."""
+
+    def test_terminal_bash_is_eligible_after_grace(self):
+        import time
+
+        from dataclasses import replace
+
+        from src.tasks.eviction import is_eligible_for_eviction, schedule_eviction
+        from src.tasks.local_shell import LocalShellTaskState
+
+        # Simulate the reaper's terminal patch (WI-2).
+        state = LocalShellTaskState(
+            id="bg-1", type="local_bash", status="running", description="d",
+            start_time=0.0, output_file="/tmp/bg-1.log",
+        )
+        terminal = replace(state, status="completed", notified=True)
+        terminal = schedule_eviction(terminal)
+
+        self.assertIsNotNone(terminal.evict_after)
+        self.assertTrue(terminal.notified)
+        # Eligible once the grace deadline has passed.
+        future = terminal.evict_after + 1
+        self.assertTrue(is_eligible_for_eviction(terminal, now=future))
+        # NOT eligible before the deadline.
+        self.assertFalse(
+            is_eligible_for_eviction(terminal, now=terminal.evict_after - 1),
+        )
+
+
+class TestBashReaperMakesEligible(unittest.TestCase):
+    """critic M2 — drive the REAL bash reaper to terminal and assert the
+    resulting registry state is eviction-eligible (not the hand-built one)."""
+
+    def test_reaper_terminal_state_is_eligible(self):
+        import subprocess
+        import time
+
+        from src.tasks.eviction import is_eligible_for_eviction
+        from src.tool_system.context import ToolContext
+        from src.tool_system.tools.bash.background import spawn_background_bash
+
+        ctx = ToolContext(workspace_root=Path("/tmp"))
+        # A command that exits immediately.
+        result = spawn_background_bash(
+            command="true", cwd=Path("/tmp"), description="t", context=ctx,
+        )
+        task_id = result["backgroundTaskId"]
+        # Wait for the reaper daemon to flip the state terminal.
+        deadline = time.time() + 5.0
+        state = None
+        while time.time() < deadline:
+            state = ctx.runtime_tasks.get(task_id)
+            if state is not None and state.status in ("completed", "failed"):
+                break
+            time.sleep(0.05)
+        self.assertIsNotNone(state)
+        self.assertIn(state.status, ("completed", "failed"))
+        # The reaper set notified + evict_after (WI-2), so it is eligible
+        # once the grace deadline passes.
+        self.assertTrue(state.notified)
+        self.assertIsNotNone(state.evict_after)
+        self.assertTrue(
+            is_eligible_for_eviction(state, now=state.evict_after + 1),
+        )
+
+
+class TestAgentServerStartsSweeperOrdering(unittest.TestCase):
+    """critic B1/M2 — the sweeper start must come AFTER tool_context is
+    stored on the session; the first attempt placed it earlier and read a
+    still-None sess.tool_context, so the sweeper never started (the exact
+    built-but-dead defect WI-2 exists to fix). Guard the ordering."""
+
+    def test_sweeper_starts_after_tool_context_assignment(self):
+        import inspect
+
+        from src.server import agent_server as asrv
+
+        src = inspect.getsource(asrv._build_runtime)
+        assign_idx = src.find("sess.tool_context = tool_context")
+        start_idx = src.find("start_eviction_sweeper(")
+        self.assertNotEqual(assign_idx, -1, "tool_context assignment present")
+        self.assertNotEqual(start_idx, -1, "sweeper start present")
+        # The sweeper start must appear AFTER the assignment (B1 regression).
+        self.assertGreater(start_idx, assign_idx)
+        # And it must NOT read the stale sess.tool_context — it uses the
+        # in-scope local tool_context.
+        snippet = src[start_idx - 60:start_idx + 60]
+        self.assertIn("tool_context.runtime_tasks", snippet)
+        self.assertNotIn("sess.tool_context.runtime_tasks", snippet)
+
+
+class TestSweeperReclaimsTerminalTasks(unittest.TestCase):
+    """WI-2 — sweep_once actually removes an eligible terminal task."""
+
+    def test_sweep_removes_eligible(self):
+        from dataclasses import replace
+
+        from src.task_registry import RuntimeTaskRegistry
+        from src.tasks.eviction import schedule_eviction, sweep_once
+        from src.tasks.local_shell import LocalShellTaskState
+
+        reg = RuntimeTaskRegistry()
+        state = LocalShellTaskState(
+            id="bg-1", type="local_bash", status="completed", description="d",
+            start_time=0.0, output_file="/tmp/bg-1.log", notified=True,
+        )
+        reg.upsert(schedule_eviction(state))
+        # A still-running task must survive.
+        reg.upsert(LocalShellTaskState(
+            id="bg-2", type="local_bash", status="running", description="d2",
+            start_time=0.0, output_file="/tmp/bg-2.log",
+        ))
+
+        dropped = sweep_once(reg, now=reg.get("bg-1").evict_after + 1)
+        self.assertIn("bg-1", dropped)
+        self.assertIsNone(reg.get("bg-1"))
+        self.assertIsNotNone(reg.get("bg-2"))  # running task retained
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_eviction.py
+++ b/tests/test_eviction.py
@@ -13,6 +13,22 @@ import threading
 import time
 from dataclasses import replace
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_sweeper():
+    """ch10 round-4 — the eviction sweeper is a process-global singleton,
+    and the agent-server now starts it in _build_runtime. Server tests
+    elsewhere in the suite can therefore leave a sweeper running, which
+    would race these tests' global-thread-count assertions. Reset before
+    and after so the global-singleton tests are isolated."""
+    from src.tasks.eviction import stop_eviction_sweeper as _stop
+
+    _stop(timeout=1.0)
+    yield
+    _stop(timeout=1.0)
+
 from src.task_registry import RuntimeTaskRegistry
 from src.tasks.eviction import (
     PANEL_GRACE_SECONDS,

--- a/tests/tool_system/test_send_message.py
+++ b/tests/tool_system/test_send_message.py
@@ -221,10 +221,13 @@ def test_message_to_running_agent_by_raw_id(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_message_to_terminal_agent_triggers_resume(tmp_path: Path) -> None:
-    """Terminal agent + SendMessage → resume_agent_background fires.
-    The resumed entry shows status='running' and the resume prompt
-    is the new state's prompt."""
+def test_message_to_terminal_agent_reports_honestly(tmp_path: Path) -> None:
+    """ch10 round-4 (critic M1) — SendMessage to a TERMINAL agent no longer
+    returns a false 'resumed it in the background' success (the live-resume
+    lifecycle is a documented stub that never spawns the loop). It returns
+    an error telling the model the message will NOT be processed and to
+    spawn a fresh agent. The resume_agent_background call still re-registers
+    the state (running + prompt), but the tool is honest about the outcome."""
     from src.tasks.local_agent import (
         complete_agent_task,
         register_async_agent,
@@ -241,12 +244,10 @@ def test_message_to_terminal_agent_triggers_resume(tmp_path: Path) -> None:
         {"to": "a-dead", "message": "wake up", "summary": "wakeup"},
         ctx,
     )
-    assert result.is_error is False
-    assert "resumed" in result.output["message"].lower()
-    refreshed = ctx.runtime_tasks.get(state.id)
-    assert refreshed.status == "running"
-    assert refreshed.prompt == "wake up"
-    assert refreshed.is_resuming is False  # reset on the fresh state
+    assert result.is_error is True
+    msg = result.output["message"].lower()
+    assert "not yet supported" in msg or "fresh agent" in msg
+    assert "resumed it in the background" not in msg
 
 
 @pytest.mark.asyncio
@@ -276,14 +277,21 @@ async def test_concurrent_resume_race_only_one_winner(tmp_path: Path) -> None:
         ),
     )
 
-    msgs = [r.output["message"].lower() for r in results]
-    resumed_count = sum(1 for m in msgs if "resumed" in m)
-    queued_count = sum(1 for m in msgs if "queued" in m)
-    assert resumed_count == 1, f"expected exactly 1 resume, got {resumed_count}: {msgs}"
-    assert queued_count == 1, f"expected exactly 1 queue, got {queued_count}: {msgs}"
+    # ch10 round-4 (critic M1) — the atomic claim still yields exactly one
+    # winner + one loser, but the winner now reports the honest "not yet
+    # supported" error (was a false "resumed" success) while the loser
+    # queues onto the re-registered running state.
+    error_count = sum(1 for r in results if r.is_error)
+    queued_count = sum(
+        1 for r in results if not r.is_error
+        and "queued" in r.output["message"].lower()
+    )
+    assert error_count == 1, f"expected exactly 1 honest-error winner: {results}"
+    assert queued_count == 1, f"expected exactly 1 queued loser: {results}"
 
-    # The fresh state has the resume prompt + the queued message in
-    # pending_messages.
+    # The fresh state still has the resume prompt + the queued message in
+    # pending_messages (resume_agent_background's re-registration is
+    # unchanged; only the tool's message is honest).
     final = ctx.runtime_tasks.get("a-race")
     assert final.status == "running"
     assert final.prompt in {"msg-A", "msg-B"}


### PR DESCRIPTION
## Round-4 ch10 (coordination): deliver queued SendMessages + reclaim terminal background tasks

**Docs:** `my-docs/ch10-coordination-round4-gap-analysis.md` + two facet reports + critic verdict under `my-docs/port-improvement-round-4/`.

The Task state machine + background paths are a strong, live, well-tested port (local_bash/local_agent/local_workflow/in_process_teammate all wired; TaskCreate/Output/Stop/List live; completion notifications reach the TUI). Two gaps were live, user-reachable, and wired-but-broken:

### GAP A (silent failure, highest value) — SendMessage to a running background child was dropped

Spawning a named background agent WORKS and `SendMessage(to=name)` is a live tool that resolves the name and returns success ("Message queued for delivery at its next tool round") — but the message was **never delivered**. A background child ran on a `create_subagent_context` that built its `ToolContext` **without** the parent's `runtime_tasks`/`agent_name_registry`, so those fell to fresh empty instances: the parent queued into `R_parent`, the child drained an empty `R_child`. Worst failure mode — the model reasons as if the worker got the follow-up and waits, no error. Fix: `create_subagent_context` now threads the parent's `runtime_tasks` + `agent_name_registry` **instances** (shared, not copied — both RLock-guarded, safe under the ch07 parallel-agent fan-out; distinct from the ch07 `options` copy, which stays per-subagent). This restores TS's single-shared-store (`AppState.tasks`) semantics, so the child drains the same store the parent queues into.

### GAP B (unbounded leak) — terminal background tasks were never reclaimed

The eviction sweeper (`tasks/eviction.py`) was fully built + tested but had **zero live call sites** (the port dropped TS's lazy GC in `generateTaskAttachments` and built this standalone sweeper to replace it, then never wired it). Terminal background tasks piled up in `runtime_tasks` and lingered in `/tasks` as stale `[completed]` entries. Compounding it, `LocalShellTaskState` **lacked `evict_after`/`retain` entirely** (so `schedule_eviction` was a `hasattr`-guarded no-op for bash) and the reaper set neither `evict_after` nor `notified` → terminal bash tasks were doubly ineligible. Fix: (1) start the sweeper at agent-server boot (single_session-gated) + stop on shutdown; (2) add `evict_after`/`retain` to `LocalShellTaskState`; (3) the bash reaper's terminal transition calls `schedule_eviction` + sets `notified=True` (bash has no async notification — it's polled via TaskOutput — so the grace period covers the read before reclaim, matching TS's terminal-bash eviction).

Also made honest (critic M1): SendMessage to a **terminal** named agent used to return a false "resumed it in the background with your message" success while `resume_agent_background` never spawns the loop — the same silent-success trap. It now returns an error telling the model the message won't be processed and to spawn a fresh agent (full resume lifecycle stays deferred).

### Verification

`tests/test_ch10_coordination_round4.py` (6): child shares the parent's registries; a message queued on the parent drains via the **real `_drain_pending_user_messages` query hook**; the **real bash reaper** driven to terminal is eviction-eligible (notified + evict_after); a source-ordering guard that the sweeper starts **after** `tool_context` is stored (catches the B1 ordering bug where the start read a still-None `sess.tool_context`); `sweep_once` removes an eligible terminal task and retains a running one. Eviction/drain/agent + ch07 concurrency + server adjacents (182) green. Full suite at the pre-existing 9-failure baseline. Critic REVISE→APPROVE.

### Deferred (owners)

Coordinator mode (dead gate — env only disables fork; TS wires ~15 sites), swarm teammate spawn + mailbox poller (Phase-7, feature-gated on both sides), resume lifecycle (documented stub), `generateTaskAttachments`/queued-command attachments → ch14, Monitor tool / `remote_agent` / `dream` (absent), mid-turn notifications → ch14/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
