### PR TITLE
feat(ch11/round4): wire the LLM memory-relevance recall (gated default-off)

### DIFF
--- a/src/memdir/surface_memories.py
+++ b/src/memdir/surface_memories.py
@@ -1,0 +1,113 @@
+"""ch11 round-4 WI-1 — surface query-relevant memory bodies.
+
+The read-side companion to ``find_relevant_memories`` (the LLM selector).
+Port of TS ``readMemoriesForSurfacing`` + ``getRelevantMemoryAttachments``
+(``utils/attachments.ts:2197-2242``): read each selected memory file,
+cap it (200 lines / 4 KB with a truncation note), and wrap the set in a
+single ``<system-reminder>`` so the model sees the actual memory content
+relevant to the current turn — not just the MEMORY.md index pointer.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Per-file surfacing caps (TS readMemoriesForSurfacing: 200 lines / 4 KB).
+MAX_SURFACE_LINES = 200
+MAX_SURFACE_CHARS = 4096
+
+
+def _read_capped(path: str) -> str | None:
+    try:
+        raw = Path(path).read_text(encoding="utf-8", errors="replace")
+    except Exception:  # noqa: BLE001 — a missing/unreadable memory is skipped
+        return None
+    lines = raw.splitlines()
+    truncated = False
+    if len(lines) > MAX_SURFACE_LINES:
+        lines = lines[:MAX_SURFACE_LINES]
+        truncated = True
+    body = "\n".join(lines)
+    if len(body) > MAX_SURFACE_CHARS:
+        body = body[:MAX_SURFACE_CHARS]
+        truncated = True
+    if truncated:
+        body += "\n… (truncated; Read the file for the full memory)"
+    return body
+
+
+def build_relevant_memory_reminder(memories: list[Any]) -> str | None:
+    """Wrap the surfaced memory bodies in a single ``<system-reminder>``.
+
+    ``memories`` is a list of ``RelevantMemory`` (``.path``). Returns None
+    when nothing readable was surfaced."""
+    blocks: list[str] = []
+    for mem in memories:
+        path = getattr(mem, "path", None) or (
+            mem.get("path") if isinstance(mem, dict) else None
+        )
+        if not path:
+            continue
+        body = _read_capped(str(path))
+        if not body:
+            continue
+        blocks.append(f"### {path}\n{body}")
+    if not blocks:
+        return None
+    joined = "\n\n".join(blocks)
+    return (
+        "<system-reminder>\n"
+        "The following saved memories were selected as relevant to the "
+        "current request (recalled automatically from your memory "
+        "directory). Treat them as background context — they reflect what "
+        "was true when written and may be stale; verify before relying on "
+        "specifics.\n\n"
+        f"{joined}\n"
+        "</system-reminder>"
+    )
+
+
+async def get_relevant_memory_reminder(
+    query_text: str,
+    memory_dir: str,
+    *,
+    provider: Any,
+    already_surfaced: set[str],
+    recent_tools: tuple[str, ...] = (),
+    cancel_event: asyncio.Event | None = None,
+) -> str | None:
+    """Run the LLM recall for ``query_text`` and return a
+    ``<system-reminder>`` string with the relevant memory bodies, or None.
+
+    Never raises. Updates ``already_surfaced`` in place with the paths it
+    surfaces so a session doesn't re-inject the same memory every turn.
+    """
+    if not query_text or not query_text.strip() or provider is None:
+        return None
+    try:
+        from src.memdir.find_relevant_memories import find_relevant_memories
+
+        ev = cancel_event or asyncio.Event()
+        memories = await find_relevant_memories(
+            query_text, memory_dir,
+            cancel_event=ev, provider=provider,
+            recent_tools=recent_tools,
+            already_surfaced=frozenset(already_surfaced),
+        )
+    except Exception:  # noqa: BLE001 — recall failure must never block a turn
+        logger.debug("memory recall failed", exc_info=True)
+        return None
+    if not memories:
+        return None
+    reminder = build_relevant_memory_reminder(memories)
+    if reminder is None:
+        return None
+    for mem in memories:
+        path = getattr(mem, "path", None)
+        if path:
+            already_surfaced.add(str(path))
+    return reminder

--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -287,6 +287,62 @@ class AgentLoopRunResult:
     terminal: Terminal | None = None
 
 
+def _last_user_text(messages: list[Message]) -> str:
+    """The current user turn's text — the query for memory recall."""
+    for msg in reversed(messages):
+        if getattr(msg, "role", None) != "user":
+            continue
+        if getattr(msg, "isMeta", False):
+            continue  # skip injected system-reminders
+        content = getattr(msg, "content", None)
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = [
+                str(b.get("text", "")) for b in content
+                if isinstance(b, dict) and b.get("type") == "text"
+            ]
+            if parts:
+                return "\n".join(parts)
+    return ""
+
+
+async def _maybe_recall_memories(
+    messages: list[Message],
+    provider: Any,
+    tool_context: ToolContext,
+    memory_surfaced: set[str] | None,
+) -> Message | None:
+    """ch11 round-4 WI-1 — the gated memory-relevance recall. Returns a
+    <system-reminder> UserMessage to prepend, or None. Never raises."""
+    try:
+        from src.settings.settings import get_settings
+
+        if not getattr(get_settings(), "memory_relevance_prefetch_enabled", False):
+            return None
+    except Exception:  # noqa: BLE001
+        return None
+
+    query_text = _last_user_text(messages)
+    if not query_text.strip():
+        return None
+    try:
+        from src.memdir import get_auto_mem_path
+        from src.memdir.surface_memories import get_relevant_memory_reminder
+        from src.types.messages import create_user_message
+
+        memdir = str(get_auto_mem_path())
+        surfaced = memory_surfaced if memory_surfaced is not None else set()
+        reminder = await get_relevant_memory_reminder(
+            query_text, memdir, provider=provider, already_surfaced=surfaced,
+        )
+        if not reminder:
+            return None
+        return create_user_message(content=reminder, isMeta=True)
+    except Exception:  # noqa: BLE001 — recall must never block a turn
+        return None
+
+
 async def run_query_as_agent_loop(
     *,
     initial_messages: list[Message],
@@ -303,6 +359,14 @@ async def run_query_as_agent_loop(
     abort_controller: AbortController | None = None,
     extended_thinking: bool | None = None,
     fallback_model: str | None = None,
+    # ch11 round-4 WI-1 — session-scoped set of already-surfaced memory
+    # file paths (de-dups the LLM recall across turns). The agent-server
+    # passes its per-session set; headless a per-run set. None disables
+    # de-dup (a fresh set is used per call).
+    memory_surfaced: set[str] | None = None,
+    # ch11 round-4 WI-1 (critic #8) — set False to skip the recall entirely
+    # (internal/notification turns). The settings gate still applies on top.
+    memory_recall_enabled: bool = True,
     # ch05 round-4 GAP A — the production compaction pipeline. When None
     # (the pre-round-4 default) Phase-0 (tool-result budget/snip/
     # microcompact/collapse/auto-compact) is inert and only the blocking
@@ -366,8 +430,31 @@ async def run_query_as_agent_loop(
         else:
             abort_controller = AbortController()
 
+    # ch11 round-4 WI-1 — LLM memory-relevance recall (gated, default off).
+    # Fire once at turn start on the current user message: select up to 5
+    # relevant memory files, read their bodies, and APPEND them as a
+    # <system-reminder> AFTER the user turn (TS also surfaces memory after
+    # the user message, never before — query.ts:1810-1831; do NOT move this
+    # before the user turn). The model then recalls the RIGHT memory content
+    # (not just the MEMORY.md index pointer). Never blocks the turn on
+    # failure. Ephemeral: appended to the query's working set only, never
+    # persisted to the conversation (matches TS attachments).
+    messages_for_query = list(initial_messages)
+    try:
+        recall_msg = (
+            await _maybe_recall_memories(
+                messages_for_query, provider, tool_context, memory_surfaced,
+            )
+            if memory_recall_enabled else None
+        )
+        if recall_msg is not None:
+            messages_for_query.append(recall_msg)
+    except Exception:  # noqa: BLE001 — recall must never block a turn
+        logging.getLogger(__name__).debug("memory recall wiring failed",
+                                          exc_info=True)
+
     params = QueryParams(
-        messages=list(initial_messages),
+        messages=messages_for_query,
         system_prompt=system_prompt,
         tools=tool_registry.list_tools(),
         tool_registry=tool_registry,

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -128,6 +128,9 @@ class _AgentSession:
     # engine's engine.py:74-79 rationale); a per-turn instance would reset
     # it every prompt. Created lazily on first turn.
     _auto_compact_tracking: Any = None
+    # ch11 round-4 WI-1 — SESSION-scoped set of already-surfaced memory
+    # paths, so the LLM recall doesn't re-inject the same memory every turn.
+    _memory_surfaced: set = field(default_factory=set)
     session: Any = None
     system_prompt: Any = "You are a helpful assistant."
     _base_system_prompt: Any = None  # system prompt before the /plan section is composed in
@@ -1588,6 +1591,13 @@ class _AgentSession:
                 pipeline_config=pipeline_config,
                 query_source="repl_main_thread",
                 token_budget=token_budget,
+                # ch11 round-4 WI-1 — session-scoped memory-recall de-dup.
+                # Only enable the recall for REAL user turns: passing None on
+                # internal/notification turns (critic #8) means the adapter
+                # uses a throwaway set, but we ALSO want to skip the recall
+                # entirely there, so gate on `internal`.
+                memory_surfaced=None if internal else self._memory_surfaced,
+                memory_recall_enabled=not internal,
             ))
         except AbortError:
             self._emit(_result_message(

--- a/src/settings/types.py
+++ b/src/settings/types.py
@@ -137,6 +137,15 @@ class SettingsSchema:
     # fail-open (return the original ask).
     auto_mode_iron_gate_open: bool = False
 
+    # ch11 round-4 — the LLM memory-relevance recall. Default OFF, faithful
+    # to TS (its recall is behind isAutoMemoryEnabled() &&
+    # feature('tengu_moth_copse'), off in OSS) and because firing an LLM
+    # side-query per user turn on the session provider is a real
+    # multi-provider cost. When True, the shared adapter recalls up to 5
+    # query-relevant memory files and injects their bodies as a
+    # <system-reminder>; the static MEMORY.md index injection is unaffected.
+    memory_relevance_prefetch_enabled: bool = False
+
     # Provider
     provider: str = "anthropic"
 

--- a/tests/test_ch11_memory_round4.py
+++ b/tests/test_ch11_memory_round4.py
@@ -1,0 +1,142 @@
+"""ch11 round-4 acceptance tests: the LLM memory-relevance recall is wired
+into the live adapter (gated), surfacing relevant memory BODIES as a
+<system-reminder>, with per-session de-dup.
+
+Covers my-docs/ch11-memory-round4-gap-analysis.md §2.
+"""
+from __future__ import annotations
+
+import asyncio
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.memdir.surface_memories import (
+    build_relevant_memory_reminder,
+    get_relevant_memory_reminder,
+)
+
+
+class _RelMem:
+    def __init__(self, path):
+        self.path = path
+        self.mtime_ms = 0.0
+
+
+class TestBuildReminder(unittest.TestCase):
+    def test_reads_bodies_into_reminder(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "user_pref.md"
+            p.write_text("Prefers real DB instances in tests, not mocks.")
+            reminder = build_relevant_memory_reminder([_RelMem(str(p))])
+            self.assertIsNotNone(reminder)
+            self.assertIn("<system-reminder>", reminder)
+            self.assertIn("real DB instances", reminder)
+            self.assertIn(str(p), reminder)
+
+    def test_empty_when_nothing_readable(self):
+        self.assertIsNone(build_relevant_memory_reminder([_RelMem("/nope/x.md")]))
+
+    def test_caps_long_body(self):
+        import tempfile
+
+        from src.memdir.surface_memories import MAX_SURFACE_LINES
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "big.md"
+            p.write_text("\n".join(f"line {i}" for i in range(1000)))
+            reminder = build_relevant_memory_reminder([_RelMem(str(p))])
+            self.assertIn("truncated", reminder)
+            # Well under 1000 lines surfaced.
+            self.assertLess(reminder.count("\n"), MAX_SURFACE_LINES + 30)
+
+
+class TestRecallGateAndDedup(unittest.TestCase):
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_no_provider_returns_none(self):
+        out = self._run(get_relevant_memory_reminder(
+            "some query", "/tmp/memdir", provider=None, already_surfaced=set(),
+        ))
+        self.assertIsNone(out)
+
+    def test_surfaced_paths_recorded_for_dedup(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "m.md"
+            p.write_text("a memory body")
+
+            async def _fake_find(query, memdir, **kw):
+                return [_RelMem(str(p))]
+
+            surfaced = set()
+            with patch(
+                "src.memdir.find_relevant_memories.find_relevant_memories",
+                _fake_find,
+            ):
+                out = self._run(get_relevant_memory_reminder(
+                    "q", tmp, provider=object(), already_surfaced=surfaced,
+                ))
+            self.assertIsNotNone(out)
+            self.assertIn(str(p), surfaced)  # recorded for de-dup
+
+
+class TestAdapterGate(unittest.TestCase):
+    """The adapter's _maybe_recall_memories respects the settings gate."""
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_gate_off_returns_none(self):
+        from src.query.agent_loop_compat import _maybe_recall_memories
+        from src.tool_system.context import ToolContext
+        from src.types.messages import create_user_message
+
+        class _S:
+            memory_relevance_prefetch_enabled = False
+
+        with patch("src.settings.settings.get_settings", return_value=_S()):
+            out = self._run(_maybe_recall_memories(
+                [create_user_message(content="hi")], object(),
+                ToolContext(workspace_root=Path("/tmp")), set(),
+            ))
+        self.assertIsNone(out)
+
+    def test_gate_on_fires_recall(self):
+        import tempfile
+
+        from src.query.agent_loop_compat import _maybe_recall_memories
+        from src.tool_system.context import ToolContext
+        from src.types.messages import create_user_message
+
+        class _S:
+            memory_relevance_prefetch_enabled = True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "pref.md"
+            p.write_text("use real DB in tests")
+
+            async def _fake_find(query, memdir, **kw):
+                return [_RelMem(str(p))]
+
+            with patch("src.settings.settings.get_settings", return_value=_S()), \
+                 patch("src.memdir.get_auto_mem_path", return_value=Path(tmp)), \
+                 patch(
+                     "src.memdir.find_relevant_memories.find_relevant_memories",
+                     _fake_find,
+                 ):
+                out = self._run(_maybe_recall_memories(
+                    [create_user_message(content="write the tests")],
+                    object(), ToolContext(workspace_root=Path(tmp)), set(),
+                ))
+        self.assertIsNotNone(out)
+        self.assertTrue(getattr(out, "isMeta", False))
+        self.assertIn("real DB", str(out.content))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Round-4 ch11 (memory): wire the LLM memory-relevance recall so the agent surfaces the RIGHT memory bodies

**Docs:** `my-docs/ch11-memory-round4-gap-analysis.md` + facet report + critic verdict under `my-docs/port-improvement-round-4/`.

The memory storage, two-step write protocol, static MEMORY.md **index** injection, path resolution, and write-side are all faithful live parity. The relevance-selector library (`find_relevant_memories` — a real LLM side-query, not RAG) is a faithful port. But:

### GAP A (headline) — the LLM recall was a library, not a behavior

`find_relevant_memories` had **zero live callers**, and the config flag `memory_prefetch_enabled` was defined-but-never-read. So every turn the port injected the full MEMORY.md *index* (all one-line hooks, truncated at 200 lines/25 KB) but **never the bodies** of the memories relevant to the current query — the model had to notice a pointer and manually `Read` the file. TS auto-surfaces up to 5 LLM-selected full memory files as `<system-reminder>` attachments scoped to the query. The gap degrades exactly as memory grows (the index itself truncates, dropping pointers, with no relevance selection to compensate).

Fix: wire the recall into the shared adapter (`run_query_as_agent_loop` — covers agent-server + headless top-level turns; subagents call `query()` directly and are unaffected, matching TS's top-level `query.ts:321` prefetch). Once at turn start on the current user message: `find_relevant_memories(query, memdir, provider, already_surfaced)` → read the selected bodies (`surface_memories.py`: 200 lines/4 KB each with a truncation note) → prepend a single `<system-reminder>` (isMeta) with the memory content. Ephemeral per-turn (not persisted to the conversation, matching TS attachments). A session-scoped `_memory_surfaced` set de-dups across turns.

**Gated default-OFF** (`memory_relevance_prefetch_enabled`) — faithful to TS (its recall is behind `isAutoMemoryEnabled() && feature('tengu_moth_copse')`, off in OSS) and because firing an LLM side-query per user turn on the session provider is a real multi-provider cost. Gate-off = zero behavior change (the static index still carries); no provider / no memories / recall error → no injection.

### Verification

`tests/test_ch11_memory_round4.py` (7): reminder reads bodies / caps long / empty-when-unreadable; recall no-provider → None; surfaced paths recorded for de-dup; adapter gate off → None, gate on → fires + returns an isMeta `<system-reminder>` carrying the memory body. Adapter/memdir/server adjacents + full suite at the pre-existing 9-failure baseline.

### Deferred (owners)

General `getAttachmentMessages` per-tool-round loop + queued-command attachments (ch10) → ch14; dynamic nested-CLAUDE.md attachment → ch14; `autoMemoryDirectory` override (merged-read security concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
