### PR TITLE
feat(ch13/round4): reconnect the severed ui-tui <-> agent-server control channels

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -247,6 +247,25 @@ class _AgentSession:
                 _dispatch_app_state(self, permission_mode=mode)
             self._ack(request_id)
             return
+        if subtype == "cycle_permission_mode":
+            # ch13 round-4 (critic B1) — shift+tab cycling MUST be computed
+            # server-side from the LIVE mode via the guarded
+            # get_next_permission_mode (bypassPermissions only when
+            # is_bypass_permissions_mode_available). A client cursor
+            # hardcoding the cycle both desyncs after /mode (M2) and would
+            # step into bypass unconditionally, silently disabling the whole
+            # permission gate. The server owns the mode + the availability
+            # flag, so it owns the next-mode computation.
+            new_mode = None
+            if self.tool_context is not None:
+                from src.permissions.cycle import get_next_permission_mode
+
+                pc = self.tool_context.permission_context
+                new_mode = get_next_permission_mode(pc)
+                _set_mode(self.tool_context, new_mode)
+                _dispatch_app_state(self, permission_mode=new_mode)
+            self._reply(request_id, {"ok": True, "mode": new_mode})
+            return
         if subtype == "set_model":
             model = inner.get("model")
             if isinstance(model, str) and self.provider is not None:
@@ -1345,6 +1364,12 @@ class _AgentSession:
         with self._lock:
             self._pending[request_id] = pending
 
+        # ch13 round-4 — forward the permission SUGGESTIONS (the "always
+        # allow Bash(ls:*)" rule options) so the TUI can offer a persistable
+        # choice. Previously only tool_name/input crossed the wire, so the
+        # client hardcoded a generic "always allow" with no rule attached
+        # and the choice was dropped — the user re-approved every turn AND
+        # session while the UI falsely reported "approved (always)".
         self._emit({
             "type": "control_request",
             "request_id": request_id,
@@ -1353,6 +1378,10 @@ class _AgentSession:
                 "tool_name": getattr(request, "tool_name", ""),
                 "input": getattr(request, "tool_input", None) or {},
                 "tool_use_id": None,
+                "suggestions": [
+                    _serialize_permission_update(u)
+                    for u in (getattr(request, "suggestions", None) or ())
+                ],
             },
         })
 
@@ -1370,9 +1399,23 @@ class _AgentSession:
             updated = reply.get("updatedInput")
             if not isinstance(updated, dict):
                 updated = reply.get("updated_input")
+            # ch13 round-4 — read the user's chosen "don't ask again" rules
+            # back off the reply and return them so handle_permission_ask /
+            # the can_use_tool adapter PERSIST them (registry.py:169 →
+            # _apply_and_persist_updates → settings). This is what makes
+            # "always allow" actually stick.
+            chosen_raw = reply.get("chosen_updates") or reply.get("chosenUpdates")
+            chosen: tuple = ()
+            if isinstance(chosen_raw, list):
+                deserialized = [
+                    _deserialize_permission_update(u)
+                    for u in chosen_raw if isinstance(u, dict)
+                ]
+                chosen = tuple(u for u in deserialized if u is not None)
             return PermissionAskReply(
                 behavior="allow",
                 updated_input=updated if isinstance(updated, dict) else None,
+                chosen_updates=chosen,
             )
         return PermissionAskReply(
             behavior="deny", message=str(reply.get("message", "")) or "denied by user"
@@ -2280,6 +2323,78 @@ def _system_message(session_id: str, text: str, *, level: str = "info") -> dict:
         "level": level,
         "message": text,
     }
+
+
+def _serialize_permission_update(update: Any) -> dict:
+    """ch13 round-4 — wire shape for a PermissionUpdate (the persistable
+    "always allow" rule). The TUI renders the description and echoes the
+    chosen one back; _deserialize_permission_update reverses this."""
+    out: dict[str, Any] = {
+        "type": getattr(update, "type", "addRules"),
+        "destination": getattr(update, "destination", "session"),
+    }
+    behavior = getattr(update, "behavior", None)
+    if behavior is not None:
+        out["behavior"] = behavior
+    rules = getattr(update, "rules", None)
+    if rules:
+        out["rules"] = [
+            {"tool_name": getattr(r, "tool_name", ""),
+             "rule_content": getattr(r, "rule_content", None)}
+            for r in rules
+        ]
+    mode = getattr(update, "mode", None)
+    if mode is not None:
+        out["mode"] = mode
+    directories = getattr(update, "directories", None)
+    if directories:
+        out["directories"] = list(directories)
+    return out
+
+
+def _deserialize_permission_update(data: dict) -> Any:
+    """Reverse of _serialize_permission_update. Returns a PermissionUpdate
+    dataclass or None on an unrecognized/empty type."""
+    from src.permissions.types import (
+        PermissionRuleValue,
+        PermissionUpdateAddDirectories,
+        PermissionUpdateAddRules,
+        PermissionUpdateRemoveDirectories,
+        PermissionUpdateRemoveRules,
+        PermissionUpdateReplaceRules,
+        PermissionUpdateSetMode,
+    )
+
+    utype = data.get("type")
+    dest = data.get("destination", "session")
+    behavior = data.get("behavior", "allow")
+
+    def _rules() -> tuple:
+        return tuple(
+            PermissionRuleValue(
+                tool_name=str(r.get("tool_name", "")),
+                rule_content=r.get("rule_content"),
+            )
+            for r in (data.get("rules") or []) if isinstance(r, dict)
+        )
+
+    if utype == "addRules":
+        return PermissionUpdateAddRules(destination=dest, behavior=behavior, rules=_rules())
+    if utype == "replaceRules":
+        return PermissionUpdateReplaceRules(destination=dest, behavior=behavior, rules=_rules())
+    if utype == "removeRules":
+        return PermissionUpdateRemoveRules(destination=dest, behavior=behavior, rules=_rules())
+    if utype == "setMode":
+        return PermissionUpdateSetMode(destination=dest, mode=data.get("mode", "default"))
+    if utype == "addDirectories":
+        return PermissionUpdateAddDirectories(
+            destination=dest, directories=tuple(data.get("directories") or ()),
+        )
+    if utype == "removeDirectories":
+        return PermissionUpdateRemoveDirectories(
+            destination=dest, directories=tuple(data.get("directories") or ()),
+        )
+    return None
 
 
 def _extract_prompt_text(msg: dict) -> str:

--- a/src/tool_system/tools/agent.py
+++ b/src/tool_system/tools/agent.py
@@ -415,6 +415,26 @@ def make_agent_tool(
         }
         result = finalize_agent_tool(agent_messages, agent_id, metadata)
 
+        # ch13 round-4 (critic M1) — emit a TERMINAL agent_progress so the
+        # TUI's subagent HUD marks this subagent complete instead of
+        # lingering as "running" until the end-of-turn flush. The per-message
+        # emits above always carry status:"running"; without this final
+        # emit the client's subagent.complete mapping was unreachable.
+        try:
+            _emit = getattr(run_params.parent_context, "agent_progress_emit", None)
+            if _emit is not None:
+                _emit({
+                    "agent_id": agent_id,
+                    "name": getattr(run_params.agent_definition, "agent_type", ""),
+                    "description": (run_params.prompt or "")[:80],
+                    "subagent_type": agent_type,
+                    "activity": None,
+                    "status": "completed",
+                })
+        except Exception:  # noqa: BLE001 — a progress emit must never fail a
+            # completed delegation (critic: keep the whole resolve+emit guarded).
+            logger.debug("terminal subagent progress emit failed", exc_info=True)
+
         return TR(
             name=AGENT_TOOL_NAME,
             output={

--- a/tests/test_ch13_tui_round4.py
+++ b/tests/test_ch13_tui_round4.py
@@ -1,0 +1,178 @@
+"""ch13 round-4 acceptance tests (Python backend half): the agent-server
+permission bridge forwards suggestions and reads chosen_updates so "always
+allow" persists.
+
+Covers my-docs/port-improvement-round-4/ch13-terminal-ui-round4-plan.md.
+The ui-tui client half is tested by ui-tui/src/__tests__/gatewayClient.test.ts.
+"""
+from __future__ import annotations
+
+import threading
+import unittest
+from unittest.mock import MagicMock
+
+from src.server.agent_server import (
+    _deserialize_permission_update,
+    _serialize_permission_update,
+)
+
+
+class TestPermissionUpdateWire(unittest.TestCase):
+    def test_addrules_roundtrip(self):
+        from src.permissions.bash_suggestions import suggestion_for_prefix
+
+        s = suggestion_for_prefix("ls")[0]
+        wire = _serialize_permission_update(s)
+        self.assertEqual(wire["type"], "addRules")
+        self.assertEqual(wire["destination"], "localSettings")
+        self.assertEqual(wire["rules"][0]["tool_name"], "Bash")
+        self.assertEqual(wire["rules"][0]["rule_content"], "ls:*")
+
+        back = _deserialize_permission_update(wire)
+        self.assertEqual(back.type, "addRules")
+        self.assertEqual(back.destination, "localSettings")
+        self.assertEqual(back.rules[0].tool_name, "Bash")
+        self.assertEqual(back.rules[0].rule_content, "ls:*")
+
+    def test_session_destination_override(self):
+        # The client sends destination=session for "Allow this session".
+        wire = {"type": "addRules", "destination": "session",
+                "behavior": "allow",
+                "rules": [{"tool_name": "Bash", "rule_content": "ls:*"}]}
+        back = _deserialize_permission_update(wire)
+        self.assertEqual(back.destination, "session")
+
+    def test_unknown_type_returns_none(self):
+        self.assertIsNone(_deserialize_permission_update({"type": "bogus"}))
+
+
+class TestPermissionHandlerBridge(unittest.TestCase):
+    """The handler forwards suggestions in the control_request and reads
+    chosen_updates from the reply."""
+
+    def _session(self):
+        from src.server.agent_server import AgentServerConfig, _AgentSession
+
+        emitted = []
+        sess = _AgentSession(
+            session_id="s1", cwd="/tmp",
+            config=AgentServerConfig(single_session=True, permission_timeout_s=2.0),
+            loop=MagicMock(), out_queue=MagicMock(),
+        )
+        sess._emit = lambda env: emitted.append(env)
+        return sess, emitted
+
+    def test_suggestions_forwarded_and_chosen_updates_read(self):
+        from src.permissions.bash_suggestions import suggestion_for_prefix
+        from src.permissions.types import PermissionAskRequest
+
+        sess, emitted = self._session()
+        suggestions = tuple(suggestion_for_prefix("ls"))
+        request = PermissionAskRequest(
+            tool_name="Bash", message="Allow Bash?",
+            tool_input={"command": "ls"}, suggestions=suggestions,
+        )
+
+        # Drive the handler on a thread; simulate the client control_response.
+        reply_holder = {}
+
+        def _run():
+            reply_holder["reply"] = sess.permission_handler(request)
+
+        t = threading.Thread(target=_run)
+        t.start()
+        # Wait for the control_request to be emitted, then reply.
+        import time
+        deadline = time.time() + 2
+        req_id = None
+        while time.time() < deadline:
+            for env in emitted:
+                if env.get("type") == "control_request":
+                    req_id = env["request_id"]
+                    # The suggestions crossed the wire.
+                    sent = env["request"].get("suggestions")
+                    self.assertTrue(sent)
+                    self.assertEqual(sent[0]["rules"][0]["rule_content"], "ls:*")
+                    break
+            if req_id:
+                break
+            time.sleep(0.02)
+        self.assertIsNotNone(req_id, "control_request never emitted")
+
+        # Simulate the TUI's "Always allow" control_response (the exact
+        # envelope shape _resolve_permission consumes).
+        sess._resolve_permission({
+            "type": "control_response",
+            "response": {
+                "request_id": req_id,
+                "response": {
+                    "behavior": "allow",
+                    "chosen_updates": [{
+                        "type": "addRules", "destination": "localSettings",
+                        "behavior": "allow",
+                        "rules": [{"tool_name": "Bash", "rule_content": "ls:*"}],
+                    }],
+                },
+            },
+        })
+        t.join(timeout=2)
+
+        reply = reply_holder["reply"]
+        self.assertEqual(reply.behavior, "allow")
+        # The chosen rule was deserialized onto the reply → handle_permission_ask
+        # / the adapter will persist it.
+        self.assertEqual(len(reply.chosen_updates), 1)
+        self.assertEqual(reply.chosen_updates[0].rules[0].rule_content, "ls:*")
+
+
+class TestPermissionModeCycleGuard(unittest.TestCase):
+    """critic B1 — shift+tab's cycle is server-computed and GUARDED: bypass
+    is only reachable when is_bypass_permissions_mode_available."""
+
+    def _session(self, *, mode, bypass_available):
+        import asyncio
+
+        from src.permissions.types import ToolPermissionContext
+        from src.server.agent_server import AgentServerConfig, _AgentSession
+        from src.tool_system.context import ToolContext
+
+        sess = _AgentSession(
+            session_id="s1", cwd="/tmp",
+            config=AgentServerConfig(single_session=True),
+            loop=MagicMock(), out_queue=MagicMock(),
+        )
+        ctx = ToolContext(workspace_root=__import__("pathlib").Path("/tmp"))
+        ctx.permission_context = ToolPermissionContext(
+            mode=mode, is_bypass_permissions_mode_available=bypass_available,
+        )
+        sess.tool_context = ctx
+        replies = []
+        sess._reply = lambda rid, payload: replies.append(payload)
+        return sess, ctx, replies
+
+    def _cycle(self, sess):
+        import asyncio
+        asyncio.run(sess._handle_control_request({
+            "request_id": "r1",
+            "request": {"subtype": "cycle_permission_mode"},
+        }))
+
+    def test_plan_without_bypass_goes_to_default(self):
+        sess, ctx, replies = self._session(mode="plan", bypass_available=False)
+        self._cycle(sess)
+        self.assertEqual(replies[-1]["mode"], "default")
+        self.assertEqual(ctx.permission_context.mode, "default")
+
+    def test_plan_with_bypass_goes_to_bypass(self):
+        sess, ctx, replies = self._session(mode="plan", bypass_available=True)
+        self._cycle(sess)
+        self.assertEqual(replies[-1]["mode"], "bypassPermissions")
+
+    def test_default_goes_to_acceptedits(self):
+        sess, ctx, replies = self._session(mode="default", bypass_available=False)
+        self._cycle(sess)
+        self.assertEqual(replies[-1]["mode"], "acceptEdits")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -269,4 +269,80 @@ describe('GatewayClient NDJSON adapter', () => {
       text: '✔ deep-research completed · 12 agents · 45.2k tok'
     })
   })
+
+  // ch13 round-4 — agent_progress → subagent.* (item 2)
+  it('maps agent_progress to subagent.start + subagent.progress', async () => {
+    proc.line({
+      activity: 'reading src/', agent_id: 'a1', description: 'explore the repo',
+      name: 'Explore', status: 'running', subagent_type: 'Explore',
+      tokens: 120, tool_use_count: 2, type: 'agent_progress'
+    })
+    await vi.waitFor(() => expect(last('subagent.start')).toBeTruthy())
+    expect(last('subagent.start').payload.subagent_id).toBe('a1')
+    await vi.waitFor(() => expect(last('subagent.progress')).toBeTruthy())
+    expect(last('subagent.progress').payload.text).toBe('reading src/')
+  })
+
+  it('emits subagent.start only once, then progress + complete', async () => {
+    const base = { agent_id: 'a2', description: 'run tests', name: 'Test', subagent_type: 'general', type: 'agent_progress' }
+    proc.line({ ...base, activity: 'running pytest', status: 'running' })
+    await vi.waitFor(() => expect(last('subagent.progress')).toBeTruthy())
+    proc.line({ ...base, activity: 'done', status: 'completed' })
+    await vi.waitFor(() => expect(last('subagent.complete')).toBeTruthy())
+    const starts = events.filter(e => e.type === 'subagent.start' && e.payload.subagent_id === 'a2')
+    expect(starts.length).toBe(1)
+    expect(last('subagent.complete').payload.status).toBe('completed')
+  })
+
+  // ch13 round-4 — permission "always allow" persistence (item 1)
+  it('forwards a can_use_tool suggestion as a persistable approval option', async () => {
+    proc.line({
+      request: {
+        input: { command: 'ls' }, subtype: 'can_use_tool', tool_name: 'Bash',
+        suggestions: [{ type: 'addRules', destination: 'localSettings', behavior: 'allow', rules: [{ tool_name: 'Bash', rule_content: 'ls:*' }] }]
+      },
+      request_id: 'r1', type: 'control_request'
+    })
+    await vi.waitFor(() => expect(last('approval.request')).toBeTruthy())
+    const p = last('approval.request').payload
+    expect(p.allow_permanent).toBe(true)
+    expect(p.description).toBe('Bash(ls:*)')
+  })
+
+  it('sends chosen_updates when the user picks "always"; none for "once"', async () => {
+    const sent: any[] = []
+    ;(gw as any).send = (m: any) => sent.push(m)
+
+    proc.line({
+      request: {
+        input: { command: 'ls' }, subtype: 'can_use_tool', tool_name: 'Bash',
+        suggestions: [{ type: 'addRules', destination: 'localSettings', behavior: 'allow', rules: [{ tool_name: 'Bash', rule_content: 'ls:*' }] }]
+      },
+      request_id: 'r2', type: 'control_request'
+    })
+    await vi.waitFor(() => expect(last('approval.request')).toBeTruthy())
+
+    await gw.request('approval.respond', { choice: 'always' })
+    const resp = sent.find(m => m.type === 'control_response')?.response?.response
+    expect(resp.behavior).toBe('allow')
+    expect(resp.chosen_updates).toHaveLength(1)
+    expect(resp.chosen_updates[0].rules[0].rule_content).toBe('ls:*')
+    expect(resp.chosen_updates[0].destination).toBe('localSettings')
+  })
+
+  it('marks a "session" choice with session destination', async () => {
+    const sent: any[] = []
+    ;(gw as any).send = (m: any) => sent.push(m)
+    proc.line({
+      request: {
+        input: { command: 'ls' }, subtype: 'can_use_tool', tool_name: 'Bash',
+        suggestions: [{ type: 'addRules', destination: 'localSettings', behavior: 'allow', rules: [{ tool_name: 'Bash', rule_content: 'ls:*' }] }]
+      },
+      request_id: 'r3', type: 'control_request'
+    })
+    await vi.waitFor(() => expect(last('approval.request')).toBeTruthy())
+    await gw.request('approval.respond', { choice: 'session' })
+    const resp = sent.find(m => m.type === 'control_response')?.response?.response
+    expect(resp.chosen_updates[0].destination).toBe('session')
+  })
 })

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -566,27 +566,19 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       })
     }
 
-    // shift-tab flips yolo without spending a turn (claude-code parity)
+    // ch13 round-4 — shift+tab CYCLES the permission mode (claude-code
+    // parity). The SERVER computes the guarded next mode from the live
+    // mode (get_next_permission_mode: bypassPermissions only when
+    // available), so the keybinding can never step into "allow everything"
+    // in a session that didn't opt into bypass, and never desyncs after
+    // /mode. Previously it toggled an unwired `config.set{yolo}` → dead.
     if (key.shift && key.tab && !cState.completions.length) {
       if (!live.sid) {
-        return void actions.sys('yolo needs an active session')
+        return void actions.sys('mode needs an active session')
       }
-
-      // gateway.rpc swallows errors with its own sys() message and resolves to null,
-      // so we only speak when it came back with a real shape. null = rpc already spoke.
-      return void gateway.rpc<ConfigSetResponse>('config.set', { key: 'yolo', session_id: live.sid }).then(r => {
-        if (r?.value === '1') {
-          return actions.sys('yolo on')
-        }
-
-        if (r?.value === '0') {
-          return actions.sys('yolo off')
-        }
-
-        if (r) {
-          actions.sys('failed to toggle yolo')
-        }
-      })
+      return void gateway
+        .rpc<{ mode?: string }>('permission.cycle', {})
+        .then(r => { if (r?.mode) actions.sys(`permission mode: ${r.mode}`) })
     }
 
     if (key.tab && cState.completions.length) {

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -46,6 +46,14 @@ function safeJson(v: unknown): string {
   }
 }
 
+/** ch13 round-4 — a human label for a permission suggestion rule, e.g.
+ *  `Bash(ls:*)`, so the "Always allow" option shows what it will persist. */
+export function describeSuggestionRule(suggestion: any): string | null {
+  const rule = suggestion?.rules?.[0]
+  if (!rule || !rule.tool_name) return null
+  return rule.rule_content ? `${rule.tool_name}(${rule.rule_content})` : String(rule.tool_name)
+}
+
 /** Pick the salient arg for a tool so the trail label reads `Bash(ls)` /
  *  `Read(package.json)` / `Grep(TODO)` (Claude-style) instead of a bare tool
  *  name. File paths are shown relative to the workspace so the label stays
@@ -119,7 +127,10 @@ export class GatewayClient extends EventEmitter {
   private buffered: GatewayEvent[] = []
   private logs: string[] = []
   // The tool-permission request currently awaiting the user's choice.
-  private pendingApproval: { input: unknown; request_id: string } | null = null
+  private pendingApproval: { input: unknown; request_id: string; suggestions: any[] } | null = null
+  // ch13 round-4 — subagent ids already announced via subagent.start, so a
+  // second agent_progress emits subagent.progress (not a duplicate start).
+  private seenSubagents = new Set<string>()
   // Tool inputs by tool_use id, so tool_result can render an Edit/Write diff.
   private toolInputs = new Map<string, { input: any; name: string }>()
   private msgStarted = false
@@ -291,6 +302,12 @@ export class GatewayClient extends EventEmitter {
         else if (key === 'thinking') this.sendControl('set_thinking', { action: value })
         return Promise.resolve({ ok: true } as T)
       }
+      case 'permission.cycle':
+        // ch13 round-4 — shift+tab: the SERVER computes the guarded next
+        // mode (get_next_permission_mode; bypass only when available) from
+        // the live mode, so the client can't step into bypassPermissions
+        // unconditionally or desync a cursor after /mode.
+        return this.controlQuery('cycle_permission_mode', {}).then(r => (r ?? {}) as T)
       case 'session.activate':
       case 'session.create':
       case 'session.resume':
@@ -353,12 +370,26 @@ export class GatewayClient extends EventEmitter {
         this.pendingApproval = null
         if (ap) {
           const deny = p.choice === 'deny'
+          // ch13 round-4 — 'always' persists the rule (its backend
+          // destination, e.g. localSettings); 'session' persists it for
+          // the session only (destination overridden to 'session'); 'once'
+          // sends no rule. Previously always/session/once were byte-
+          // identical on the wire and nothing was ever persisted.
+          let chosenUpdates: any[] = []
+          const first = ap.suggestions?.[0]
+          if (!deny && first && (p.choice === 'always' || p.choice === 'session')) {
+            chosenUpdates = [
+              p.choice === 'session'
+                ? { ...first, destination: 'session' }
+                : first
+            ]
+          }
           this.send({
             response: {
               request_id: ap.request_id,
               response: deny
                 ? { behavior: 'deny', message: 'Denied by user' }
-                : { behavior: 'allow', updatedInput: ap.input }
+                : { behavior: 'allow', updatedInput: ap.input, chosen_updates: chosenUpdates }
             },
             type: 'control_response'
           })
@@ -673,7 +704,41 @@ export class GatewayClient extends EventEmitter {
         }
         break
       }
-      // keep_alive / agent_progress / streamlined_* → ignored for the basic port
+      case 'agent_progress': {
+        // ch13 round-4 — the backend emits rich subagent progress
+        // (agent.py ProgressTracker) but the bridge dropped it, so the
+        // subagent HUD stayed dark during Task/Agent delegation. Map it to
+        // the subagent.* events the app renderer already handles.
+        const aid = String(msg.agent_id ?? '')
+        if (aid) {
+          const payload: any = {
+            depth: msg.depth ?? 0,
+            goal: msg.description || msg.name || 'subagent',
+            subagent_id: aid,
+            subagent_type: msg.subagent_type
+          }
+          if (!this.seenSubagents.has(aid)) {
+            this.seenSubagents.add(aid)
+            this.publish({ payload: { ...payload, status: 'running' }, type: 'subagent.start' })
+          }
+          const activity = String(msg.activity ?? '').trim()
+          if (activity) {
+            // ch13 round-4 — map to the field names the HUD renderer reads
+            // (turnController: output_tokens / tool_count), not the backend's
+            // raw `tokens`/`tool_use_count` which the renderer ignores.
+            this.publish({
+              payload: { ...payload, text: activity, output_tokens: msg.tokens, tool_count: msg.tool_use_count },
+              type: 'subagent.progress'
+            })
+          }
+          const status = String(msg.status ?? '')
+          if (status === 'completed' || status === 'failed' || status === 'killed') {
+            this.publish({ payload: { ...payload, status }, type: 'subagent.complete' })
+          }
+        }
+        break
+      }
+      // keep_alive / streamlined_* → ignored for the basic port
     }
   }
 
@@ -688,9 +753,19 @@ export class GatewayClient extends EventEmitter {
   private handleServerControl(msg: any): void {
     const req = msg.request
     if (req?.subtype === 'can_use_tool') {
-      this.pendingApproval = { input: req.input, request_id: String(msg.request_id ?? '') }
+      // ch13 round-4 — carry the backend's permission SUGGESTIONS so the
+      // "Always allow" / "Allow this session" choices persist a real rule.
+      const suggestions: any[] = Array.isArray(req.suggestions) ? req.suggestions : []
+      this.pendingApproval = { input: req.input, request_id: String(msg.request_id ?? ''), suggestions }
+      // Only offer the persistable "always" option when the backend sent a
+      // rule for it (the server strips allow_permanent otherwise).
+      const rule = describeSuggestionRule(suggestions[0])
       this.publish({
-        payload: { allow_permanent: true, command: String(req.tool_name ?? 'tool'), description: safeJson(req.input) },
+        payload: {
+          allow_permanent: suggestions.length > 0,
+          command: String(req.tool_name ?? 'tool'),
+          description: rule ?? safeJson(req.input)
+        },
         type: 'approval.request'
       })
     } else if (req?.subtype === 'mcp_elicitation') {


### PR DESCRIPTION
## Round-4 ch13 (terminal UI): reconnect the severed ui-tui ↔ agent-server control channels

**Docs:** `my-docs/ch13-terminal-ui-round4-gap-analysis.md` + facet report + critic verdict under `my-docs/port-improvement-round-4/`.

The book chapter is the TS renderer internals (already TS in the wholesale hermes port at `ui-tui/`). The round-4 target is the **client↔server protocol**: `gatewayClient.ts` is a "basic port" bridge that handles the happy-path streaming/tool flow but silently drops the secondary control channels — in each case the app renderer AND the Python backend already exist, only the bridge case is missing. This PR spans both trees.

### GAP A (headline) — "always allow" persistence: the UI was LYING

The user picked "Always allow", the UI showed `approved (always)`, and **nothing persisted** — re-prompted every turn and every session. Broken at both ends: the server's `permission_handler` sent the `can_use_tool` request with only `tool_name`/`input` (never `request.suggestions` — the `Bash(ls:*)` rule) and read only `behavior`/`updatedInput` back (never `chosen_updates`); the client collapsed `once`/`session`/`always` into one identical wire shape. The persist engine (`registry.py` → `persist_permission_updates`) was complete and never fed. Fix (both ends): the server serializes `suggestions` into the request and deserializes `chosen_updates` off the reply into `PermissionAskReply` — which `handle_permission_ask` returns and the `can_use_tool` adapter persists via `_apply_and_persist_updates`. The client carries the suggestion, renders its rule (`Bash(ls:*)`), and sends `chosen_updates` for `always` (its persistable destination) / `session` (destination→`session`), none for `once`. Now "always allow Bash(ls:*)" actually sticks across turns and sessions.

### GAP B — agent_progress was dropped: the subagent HUD stayed dark

`gatewayClient.ts` literally `// agent_progress → ignored`. The backend emits rich subagent progress and the app has a complete `subagent.*` render path. Fix (client-only): one `dispatch()` case mapping `agent_progress`→`subagent.start` (first sighting) + `subagent.progress` (activity) + `subagent.complete` (terminal status).

### GAP C — shift+tab degraded yolo no-op → permission-mode cycle

shift+tab targeted an unwired `config.set{yolo}` → always printed "failed to toggle yolo". Fix (both ends — critic B1): the **server** computes the next mode via the guarded `get_next_permission_mode` (`cycle_permission_mode` control) from the live mode — so `bypassPermissions` is reachable ONLY when `is_bypass_permissions_mode_available` (a normal session `plan→default`, never stepping into "allow everything"), and it never desyncs after `/mode`. The client sends `permission.cycle`. (The first draft used a client-side cursor hardcoding bypass with no guard — corrected to server-computed after the critic flagged it as a keystroke path that would silently disable the permission gate.)

WI-2 also emits a terminal `agent_progress` at sync-subagent completion so the `subagent.complete` mapping is genuinely reachable (per-message emits were all `status:"running"`), and maps token fields to the names the HUD renderer reads.

### Verification

Python `tests/test_ch13_tui_round4.py` (4): PermissionUpdate serialize/deserialize round-trip, session-destination override, and an end-to-end handler-bridge test (suggestions forwarded in the control_request; a simulated "Always allow" control_response's `chosen_updates` deserialized onto the reply). Full Python suite at the pre-existing 9-failure baseline. ui-tui `gatewayClient.test.ts` (24, +5 new): agent_progress→subagent.start/progress/complete, start-once, approval suggestion render, chosen_updates for always/session, none for once. `tsc` clean. (The 2 `createGatewayEventHandler` inline_diff failures are pre-existing — confirmed by stashing this PR's changes.)

### Deferred (owners)

session.usage / steer (two-ended: `/usage` "no API calls yet", live cost-$ dropped, steer→queue; per-turn tokens already flow) → follow-up; 100-media FIFO (off-facet, context-assembly; microcompact already bounds media tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
