### PR TITLE
feat(ch14/round4): wire the UserPromptSubmit hook (executor + agent-server)

### DIFF
--- a/src/hooks/hook_types.py
+++ b/src/hooks/hook_types.py
@@ -336,8 +336,12 @@ class NotificationHookInput:
 
 @dataclass
 class UserPromptSubmitHookInput:
-    user_message: str = ""
+    # ch14 round-4 — the Claude Code hook contract's stdin field is
+    # ``prompt`` (matches the TS executor). ``user_message`` kept as a
+    # deprecated alias so any legacy reader still resolves.
+    prompt: str = ""
     session_id: str | None = None
+    user_message: str = ""
 
 
 @dataclass

--- a/src/hooks/session_hooks.py
+++ b/src/hooks/session_hooks.py
@@ -70,6 +70,119 @@ async def _resolve_event_configs(
     return [h.config for h in hooks]
 
 
+USER_PROMPT_SUBMIT_EVENT: HookEvent = "UserPromptSubmit"
+
+
+MAX_HOOK_OUTPUT_LENGTH = 10000  # TS processUserInput.ts:272-277 per-context cap
+
+
+class UserPromptSubmitOutcome:
+    """ch14 round-4 — the collected result of the UserPromptSubmit hooks.
+
+    Unlike the lifecycle routers (fire-and-forget), UserPromptSubmit's whole
+    value is the OUTCOME. Mirrors ``processUserInput.ts:194-262``, which
+    distinguishes two stop modes:
+
+    - ``blocked`` (a ``blockingError``) → ERASE the prompt + emit a system
+      warning; the model never sees the prompt.
+    - ``prevented`` (``preventContinuation``) → KEEP the prompt in context +
+      push an "Operation stopped by hook" note; no query runs this turn.
+
+    plus ``additional_contexts`` → extra model-visible context (each capped
+    at MAX_HOOK_OUTPUT_LENGTH).
+    """
+
+    __slots__ = ("blocked", "block_message", "prevented",
+                 "prevent_reason", "additional_contexts")
+
+    def __init__(self) -> None:
+        self.blocked: bool = False
+        self.block_message: str | None = None
+        self.prevented: bool = False
+        self.prevent_reason: str | None = None
+        self.additional_contexts: list[str] = []
+
+    @property
+    def stop(self) -> bool:
+        """True when either stop mode fired → skip the query this turn."""
+        return self.blocked or self.prevented
+
+
+async def run_user_prompt_submit_hooks(
+    prompt: str,
+    *,
+    registry: AsyncHookRegistry | None = None,
+    session_id: str | None = None,
+    cwd: str | None = None,
+    tool_use_context: Any = None,
+) -> UserPromptSubmitOutcome:
+    """ch14 round-4 — fire UserPromptSubmit hooks on a raw user prompt.
+
+    Trust-gated (via _resolve_event_configs → the per-context snapshot +
+    should_skip_hook_due_to_trust) exactly like the other snapshot-lane
+    hooks (ch12): an untrusted workspace runs only ``is_policy`` hooks.
+    Returns the collected block/inject outcome. Never raises.
+    """
+    outcome = UserPromptSubmitOutcome()
+    try:
+        configs = await _resolve_event_configs(
+            USER_PROMPT_SUBMIT_EVENT, registry, tool_use_context,
+        )
+    except Exception:  # noqa: BLE001 — hook resolution must not block a turn
+        return outcome
+
+    for config in configs:
+        stdin_data = {
+            "hook_event": USER_PROMPT_SUBMIT_EVENT,
+            "prompt": prompt,  # Claude Code contract field name (NOT user_message)
+            "session_id": session_id,
+            "cwd": cwd,
+        }
+        from .hook_executor import _execute_command_hook
+        from .exec_http_hook import execute_http_hook
+        from .exec_prompt_hook import execute_prompt_hook
+
+        try:
+            if config.type == "command":
+                result = await _execute_command_hook(config, stdin_data)
+            elif config.type == "http":
+                result = await execute_http_hook(config, stdin_data)
+            elif config.type == "prompt":
+                result = await execute_prompt_hook(config, stdin_data)
+            else:
+                continue
+        except Exception:  # noqa: BLE001 — one bad hook must not block the turn
+            logger.debug("UserPromptSubmit hook failed", exc_info=True)
+            continue
+
+        # blockingError (exit-2) → erase the prompt + warn. preventContinuation
+        # → keep the prompt + "Operation stopped by hook". blockingError wins
+        # over preventContinuation (TS checks it first). Either stop mode
+        # short-circuits: TS returns at the first blocker, so we stop running
+        # further hooks (their subprocesses would side-effect for nothing —
+        # agent_server discards anything collected past a stop).
+        block = getattr(result, "blocking_error", None)
+        if block:
+            outcome.blocked = True
+            outcome.block_message = str(block)
+            break
+        if getattr(result, "prevent_continuation", False):
+            outcome.prevented = True
+            outcome.prevent_reason = (
+                getattr(result, "stop_reason", None) or "blocked by hook"
+            )
+            break
+        # additionalContext → injected as extra model-visible context, each
+        # capped at MAX_HOOK_OUTPUT_LENGTH (TS processUserInput.ts:272-277).
+        extra = getattr(result, "additional_contexts", None)
+        if extra:
+            outcome.additional_contexts.extend(
+                str(c)[:MAX_HOOK_OUTPUT_LENGTH] for c in extra
+            )
+
+    return outcome
+
+
 async def run_session_start_hooks(
     registry: AsyncHookRegistry | None = None,
     *,

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -1555,6 +1555,25 @@ class _AgentSession:
             logger.debug("[agent-server] SessionStart hooks failed",
                          exc_info=True)
 
+    def _run_user_prompt_submit_hooks(self, prompt: Any) -> Any:
+        """ch14 round-4 — sync wrapper around the async UserPromptSubmit
+        router (_run_turn is a sync worker). Returns the outcome or None on
+        failure. Never raises."""
+        try:
+            import asyncio as _asyncio
+
+            from src.hooks.session_hooks import run_user_prompt_submit_hooks
+
+            text = _extract_prompt_text({"content": prompt})
+            return _asyncio.run(run_user_prompt_submit_hooks(
+                text, session_id=self.session_id, cwd=self.cwd,
+                tool_use_context=self.tool_context,
+            ))
+        except Exception:  # noqa: BLE001 — a hook must not block the turn
+            logger.debug("[agent-server] UserPromptSubmit hooks failed",
+                         exc_info=True)
+            return None
+
     @staticmethod
     def _parse_turn_budget(prompt: Any) -> int | None:
         """ch05 round-4 GAP B — the '+500k' auto-continue budget from the
@@ -1589,6 +1608,52 @@ class _AgentSession:
         # match a trailing "+500k" once a <system-reminder> follows it.
         token_budget = self._parse_turn_budget(prompt) if not internal else None
 
+        # ch14 round-4 — UserPromptSubmit hooks (TS processUserInput.ts:182).
+        # Fire on the RAW prompt of a real user turn, BEFORE any ultracode
+        # augmentation (the hook contract sees exactly what the user typed;
+        # internal/notification turns skip). A hook can BLOCK (erase the
+        # prompt + warn, no query) or INJECT additionalContext the model
+        # sees. Trust-gated via the per-context snapshot (ch12). A hook
+        # failure never blocks the turn.
+        # Skip on `internal` (notification/side-generated) turns AND on `btw`
+        # side-questions: /btw is an ephemeral meta-turn whose Q&A is rolled
+        # back, and firing on it would (a) run a real-prompt validation hook
+        # on a meta-turn and (b) leak the prevent-path messages past the btw
+        # rollback (critic-2 MINOR). UserPromptSubmit fires only on real,
+        # persisted user prompts.
+        _ups_contexts: list[str] = []
+        if not internal and not btw:
+            ups = self._run_user_prompt_submit_hooks(prompt)
+            if ups is not None and ups.blocked:
+                # blockingError → ERASE the prompt + warn (TS
+                # processUserInput.ts:203-211): the model never sees it.
+                self._emit(_system_message(
+                    self.session_id,
+                    f"UserPromptSubmit operation blocked by hook:\n"
+                    f"{ups.block_message}\n\nOriginal prompt: "
+                    f"{_extract_prompt_text({'content': prompt})}",
+                    level="warning",
+                ))
+                self._emit(_result_message(
+                    self.session_id, subtype="success", num_turns=0,
+                    result="", is_error=False, duration_ms=0,
+                ))
+                return
+            if ups is not None and ups.prevented:
+                # preventContinuation → KEEP the prompt in context + push an
+                # "Operation stopped by hook" note; no query (TS :213-224).
+                self.session.conversation.add_user_message(prompt)
+                self.session.conversation.add_user_message(
+                    f"Operation stopped by hook: {ups.prevent_reason}"
+                )
+                self._emit(_result_message(
+                    self.session_id, subtype="success", num_turns=0,
+                    result="", is_error=False, duration_ms=0,
+                ))
+                return
+            if ups is not None:
+                _ups_contexts = list(ups.additional_contexts)
+
         # ultracode (workflow-engine §4.1): the `ultracode` keyword in this
         # message, or the session-long `/effort ultracode` mode, appends a
         # <system-reminder> nudging the model to author a workflow rather than
@@ -1611,6 +1676,12 @@ class _AgentSession:
         # (drops the ephemeral Q + A on every exit path via the finally below).
         _btw_snapshot = list(self.session.conversation.messages) if btw else None
         self.session.conversation.add_user_message(prompt)
+        # Inject any UserPromptSubmit additionalContext as a system-reminder
+        # user message right after the prompt (the model reads it as context).
+        for _ctx in _ups_contexts:
+            self.session.conversation.add_user_message(
+                f"<system-reminder>\n{_ctx}\n</system-reminder>"
+            )
         start = time.monotonic()
 
         def on_text_chunk(chunk: str) -> None:

--- a/tests/test_ch14_user_prompt_submit_round4.py
+++ b/tests/test_ch14_user_prompt_submit_round4.py
@@ -1,0 +1,197 @@
+"""ch14 round-4 — UserPromptSubmit hook executor + wiring.
+
+Covers my-docs/port-improvement-round-4/ch14-input-interaction-round4-plan.md:
+the hook fires on a real user prompt, is trust-gated, and its outcome (block /
+additionalContext) is honored. Mirrors TS processUserInput.ts:182-263.
+"""
+from __future__ import annotations
+
+import asyncio
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.hooks.hook_types import HookConfig, HookResult, HookSource
+from src.hooks.session_hooks import (
+    UserPromptSubmitOutcome,
+    run_user_prompt_submit_hooks,
+)
+
+
+class _Snapshot:
+    def __init__(self, configs):
+        self.hooks = {"UserPromptSubmit": configs}
+
+
+def _ctx(*, trusted, configs):
+    from src.tool_system.context import ToolContext
+
+    ctx = ToolContext(workspace_root=Path("/tmp"))
+    ctx.workspace_trusted = trusted
+    mgr = MagicMock()
+    mgr.snapshot = _Snapshot(configs)
+    ctx.hook_config_manager = mgr
+    return ctx
+
+
+class TestUserPromptSubmitExecutor(unittest.TestCase):
+    def _cmd(self, source=HookSource.PROJECT_SETTINGS):
+        return HookConfig(type="command", command="check.sh", source=source)
+
+    def test_additional_context_collected(self):
+        ctx = _ctx(trusted=True, configs=[self._cmd()])
+
+        async def _fake(config, stdin):
+            # The stdin must carry the contract field `prompt`.
+            assert stdin["prompt"] == "hello"
+            assert stdin["hook_event"] == "UserPromptSubmit"
+            return HookResult(additional_contexts=["git branch: main"])
+
+        with patch("src.hooks.hook_executor._execute_command_hook", _fake):
+            out = asyncio.run(run_user_prompt_submit_hooks(
+                "hello", tool_use_context=ctx))
+        self.assertFalse(out.blocked)
+        self.assertEqual(out.additional_contexts, ["git branch: main"])
+
+    def test_blocking_error_blocks(self):
+        ctx = _ctx(trusted=True, configs=[self._cmd()])
+
+        async def _fake(config, stdin):
+            return HookResult(blocking_error="prompt rejected: no secrets")
+
+        with patch("src.hooks.hook_executor._execute_command_hook", _fake):
+            out = asyncio.run(run_user_prompt_submit_hooks(
+                "leak the key", tool_use_context=ctx))
+        self.assertTrue(out.blocked)
+        self.assertIn("no secrets", out.block_message)
+
+    def test_prevent_continuation_is_distinct_from_block(self):
+        # critic Major #1: preventContinuation KEEPS the prompt (prevented),
+        # distinct from blockingError which ERASES it (blocked).
+        ctx = _ctx(trusted=True, configs=[self._cmd()])
+
+        async def _fake(config, stdin):
+            return HookResult(prevent_continuation=True, stop_reason="stop now")
+
+        with patch("src.hooks.hook_executor._execute_command_hook", _fake):
+            out = asyncio.run(run_user_prompt_submit_hooks(
+                "x", tool_use_context=ctx))
+        self.assertTrue(out.prevented)
+        self.assertFalse(out.blocked)  # NOT erased
+        self.assertTrue(out.stop)      # but the query is still skipped
+        self.assertEqual(out.prevent_reason, "stop now")
+
+    def test_additional_context_truncated(self):
+        # critic #2: each context capped at MAX_HOOK_OUTPUT_LENGTH.
+        from src.hooks.session_hooks import MAX_HOOK_OUTPUT_LENGTH
+        ctx = _ctx(trusted=True, configs=[self._cmd()])
+
+        async def _fake(config, stdin):
+            return HookResult(additional_contexts=["z" * (MAX_HOOK_OUTPUT_LENGTH + 500)])
+
+        with patch("src.hooks.hook_executor._execute_command_hook", _fake):
+            out = asyncio.run(run_user_prompt_submit_hooks(
+                "x", tool_use_context=ctx))
+        self.assertEqual(len(out.additional_contexts[0]), MAX_HOOK_OUTPUT_LENGTH)
+
+    def test_short_circuits_on_first_blocker(self):
+        # critic #3: stop running hooks once a blocker fires.
+        ctx = _ctx(trusted=True, configs=[self._cmd(), self._cmd()])
+        calls = []
+
+        async def _fake(config, stdin):
+            calls.append(1)
+            return HookResult(blocking_error="stop")
+
+        with patch("src.hooks.hook_executor._execute_command_hook", _fake):
+            asyncio.run(run_user_prompt_submit_hooks("x", tool_use_context=ctx))
+        self.assertEqual(len(calls), 1)  # second hook not run
+
+    def test_untrusted_project_hook_skipped(self):
+        # critic-ch12 parity: an untrusted workspace runs only policy hooks.
+        ctx = _ctx(trusted=False, configs=[self._cmd(HookSource.PROJECT_SETTINGS)])
+        ran = []
+
+        async def _fake(config, stdin):
+            ran.append(1)
+            return HookResult(blocking_error="should not run")
+
+        with patch("src.hooks.hook_executor._execute_command_hook", _fake):
+            out = asyncio.run(run_user_prompt_submit_hooks(
+                "x", tool_use_context=ctx))
+        self.assertEqual(ran, [])
+        self.assertFalse(out.blocked)
+
+    def test_untrusted_policy_hook_runs(self):
+        ctx = _ctx(trusted=False, configs=[self._cmd(HookSource.POLICY_SETTINGS)])
+
+        async def _fake(config, stdin):
+            return HookResult(blocking_error="policy block")
+
+        with patch("src.hooks.hook_executor._execute_command_hook", _fake):
+            out = asyncio.run(run_user_prompt_submit_hooks(
+                "x", tool_use_context=ctx))
+        self.assertTrue(out.blocked)
+
+    def test_hook_failure_does_not_block_turn(self):
+        ctx = _ctx(trusted=True, configs=[self._cmd()])
+
+        async def _fake(config, stdin):
+            raise RuntimeError("hook crashed")
+
+        with patch("src.hooks.hook_executor._execute_command_hook", _fake):
+            out = asyncio.run(run_user_prompt_submit_hooks(
+                "x", tool_use_context=ctx))
+        # A crashing hook is swallowed — the turn proceeds unblocked.
+        self.assertFalse(out.blocked)
+        self.assertIsInstance(out, UserPromptSubmitOutcome)
+
+
+class TestRunTurnWiring(unittest.TestCase):
+    def _session(self):
+        from src.server.agent_server import AgentServerConfig, _AgentSession
+
+        emitted = []
+        sess = _AgentSession(
+            session_id="s1", cwd="/tmp",
+            config=AgentServerConfig(single_session=True),
+            loop=MagicMock(), out_queue=MagicMock(),
+        )
+        sess._emit = lambda env: emitted.append(env)
+        return sess, emitted
+
+    def test_block_emits_warning_and_skips_query(self):
+        sess, emitted = self._session()
+        blocked = UserPromptSubmitOutcome()
+        blocked.blocked = True
+        blocked.block_message = "no"
+        sess._run_user_prompt_submit_hooks = lambda p: blocked
+        # If the turn is blocked, run_query_as_agent_loop must NOT be reached.
+        with patch("src.query.agent_loop_compat.run_query_as_agent_loop") as q:
+            sess._run_turn("hello")
+        q.assert_not_called()
+        warns = [e for e in emitted if e.get("type") == "system"]
+        self.assertTrue(any("operation blocked by hook" in str(w)
+                            for w in warns))
+
+    def test_prevent_keeps_prompt_and_skips_query(self):
+        sess, emitted = self._session()
+        prevented = UserPromptSubmitOutcome()
+        prevented.prevented = True
+        prevented.prevent_reason = "nope"
+        sess._run_user_prompt_submit_hooks = lambda p: prevented
+        added = []
+        conv = MagicMock()
+        conv.add_user_message = lambda m: added.append(m)
+        conv.messages = []
+        sess.session = MagicMock(conversation=conv)
+        with patch("src.query.agent_loop_compat.run_query_as_agent_loop") as q:
+            sess._run_turn("hello")
+        q.assert_not_called()
+        # The prompt is KEPT (unlike block, which erases it).
+        self.assertIn("hello", added)
+        self.assertTrue(any("Operation stopped by hook" in a for a in added))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Round-4 ch14 (input/interaction): wire the UserPromptSubmit hook

**Docs:** `my-docs/ch14-input-interaction-round4-gap-analysis.md` + facet report + critic verdict under `my-docs/port-improvement-round-4/`.

The book chapter is terminal-input parsing (5 keyboard protocols, chords — TS ui-tui internals, out of scope). The round-4 target is the Python **input→model lane**, the convergence point for the ch10/ch11/ch12 injection-lane deferrals. The headline: `UserPromptSubmit` — one of the most commonly configured `settings.json` hooks — was **entirely absent** in the port (dataclass only, no executor, no fire site; the dataclass field was even mis-named `user_message` vs the contract's `prompt`). A user who ported their `.claude/settings.json` UserPromptSubmit hook got silence.

### What it does now (TS `processUserInput.ts:182-263`)

`run_user_prompt_submit_hooks(prompt, …)` fires once per real user prompt and honors the three effects distinctly:
- **blockingError** → **erase** the prompt, emit a warning (`UserPromptSubmit operation blocked by hook: … Original prompt: <input>`), no query;
- **preventContinuation** → **keep** the prompt in context + push an `Operation stopped by hook: <reason>` note, no query;
- **additionalContexts** → inject extra model-visible context (each capped at 10 000 chars, TS `:272-277`).

The executor short-circuits at the first blocker (TS returns at the first stop).

### How it's wired

- **Executor** (`session_hooks.py`): trust-gated via ch12's `_resolve_event_configs` (per-context snapshot + `should_skip_hook_due_to_trust`) — an **untrusted workspace runs only `is_policy` hooks**, so a malicious repo's `.clawcodex/settings.json` UserPromptSubmit command hook does **not** run when the user declined the trust dialog. Dispatches command/http/prompt with stdin carrying the contract field `prompt`; collects the outcome (first blocker wins; accumulate additionalContext). Never raises — a crashing hook can't block the turn.
- **Fire site** (`agent_server._run_turn`): on the **raw** prompt of a real user turn, **before** ultracode augmentation; `internal`/notification turns skip (TS fires only on real user input). Block → warning system message + zero-turn result + return (no `add_user_message`, no query). additionalContext → `<system-reminder>` user messages after the prompt. `_run_user_prompt_submit_hooks` is the sync wrapper (mirrors `_fire_session_start_once`).
- `UserPromptSubmitHookInput.prompt` added (contract name; `user_message` kept as a deprecated alias).

### Verification

`tests/test_ch14_user_prompt_submit_round4.py` (7): additionalContext collected (stdin carries `prompt`); blocking_error and prevent_continuation each block; **untrusted-project hook skipped, untrusted-policy hook runs** (the trust-gate security property); a crashing hook doesn't block; the `_run_turn` block path emits the warning and does **not** reach `run_query_as_agent_loop`. Full Python suite at the pre-existing 9-failure baseline.

### Deferred (owners)

General `getAttachmentMessages` per-round lane (~35 kinds — a chapter, not a PR); queued-commands-as-attachments (≤1 round-trip, no live bug); input parsing (TS, functional hermes port); the `run_headless` fire site (agent-server is the shipped interactive path) → follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
