### PR TITLE
feat(ch15/round4): make MCP tools/list_changed refresh tools live

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -1921,6 +1921,45 @@ def _save_disabled_mcp(disabled: set[str]) -> None:
         pass
 
 
+def _make_mcp_notification_handler(mcp_rt: Any, sess: "_AgentSession", server: str) -> Any:
+    """ch15 round-4 — sync MCP notification handler (method, params).
+
+    On ``notifications/tools/list_changed`` schedule a tools re-fetch on the
+    connection loop; when it lands, SWAP the server's tools in the live agent
+    registry (remove the old ``mcp__{server}__*`` names, register the new) so
+    a mid-session tool change is visible without a restart. Runs on the
+    McpRuntime loop thread; the schedule is non-blocking (no self-deadlock).
+
+    Resolves ``sess.tool_registry`` at REFRESH time, not boot time (critic
+    M1): a provider/model switch builds a brand-new registry and rebinds
+    ``sess.tool_registry``, so a handler closing over the boot registry would
+    mutate an orphaned one and the agent would never see the refresh. The
+    elicitation handler closes over ``sess`` for the same reason.
+    """
+
+    def _on_change(removed_full: list, new_tools: list) -> None:
+        registry = getattr(sess, "tool_registry", None)
+        if registry is None:
+            return
+        for full in removed_full:
+            try:
+                registry.remove_tool(full)
+            except Exception:  # noqa: BLE001
+                logger.debug("[mcp] remove_tool failed: %s", full, exc_info=True)
+        for tool in new_tools:
+            try:
+                registry.register(tool)
+            except Exception:  # noqa: BLE001
+                logger.debug("[mcp] re-register failed: %s",
+                             getattr(tool, "name", "?"), exc_info=True)
+
+    def _handle(method: str, _params: Any) -> None:
+        if method == "notifications/tools/list_changed":
+            mcp_rt.schedule_tool_refresh(server, _on_change)
+
+    return _handle
+
+
 def _make_elicitation_handler(sess: "_AgentSession") -> Any:
     """Async MCP elicitation handler that bridges a server's input request to the
     TUI via the session's control-request round-trip (reusing the permission
@@ -2079,9 +2118,22 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
                 sess._mcp_runtime = mcp_rt
                 # Wire MCP elicitation → TUI form (servers can request user input).
                 _eh = _make_elicitation_handler(sess)
-                for _cl in mcp_rt.clients.values():
+                # ch15 round-4 — wire tools/list_changed → live tool refresh.
+                # A server that changes its tools mid-session pushes
+                # notifications/tools/list_changed; we re-fetch and SWAP the
+                # tools in the live registry so the agent sees them without a
+                # session restart. Previously the notification was dropped.
+                for _srv_name, _cl in mcp_rt.clients.items():
                     try:
                         _cl.set_elicitation_handler(_eh)
+                    except Exception:  # noqa: BLE001
+                        pass
+                    try:
+                        _cl.set_notification_handler(
+                            _make_mcp_notification_handler(
+                                mcp_rt, sess, _srv_name
+                            )
+                        )
                     except Exception:  # noqa: BLE001
                         pass
                 logger.info(

--- a/src/server/mcp_runtime.py
+++ b/src/server/mcp_runtime.py
@@ -143,6 +143,63 @@ class McpRuntime:
             is_mcp=True,
         )
 
+    def _apply_refreshed_tools(
+        self, name: str, new_raw: list, client: Any
+    ) -> tuple[list[str], list]:
+        """ch15 round-4 — swap in a server's freshly-fetched tools.
+
+        Pure w.r.t. the event loop (no I/O) so it's unit-testable: given the
+        new raw MCP tool list, rebuild the wrapped tools, replace this
+        server's slice of self.tools/self.servers, and return
+        ``(removed_full_names, new_wrapped_tools)`` so the caller can swap
+        them in the live agent registry. Returns the FULL
+        ``mcp__server__tool`` names removed (what registry.unregister keys on).
+        """
+        from src.services.mcp.mcp_string_utils import build_mcp_tool_name
+
+        prefix = build_mcp_tool_name(name, "")  # "mcp__{name}__"
+        removed_full = [t.name for t in self.tools
+                        if getattr(t, "name", "").startswith(prefix)]
+        self.tools = [t for t in self.tools
+                      if not getattr(t, "name", "").startswith(prefix)]
+        new_tools = [self._wrap(name, mt, client) for mt in new_raw]
+        self.tools.extend(new_tools)
+        self.servers[name] = [t.name for t in new_raw]
+        return removed_full, new_tools
+
+    async def _refresh_server_tools_async(self, name: str, on_change: Any) -> None:
+        """Re-fetch a server's tools (on the connection loop) and hand the
+        diff to ``on_change(removed_full_names, new_tools)``. Guarded."""
+        client = self.clients.get(name)
+        if client is None:
+            return
+        try:
+            new_raw = await client.list_tools()
+        except Exception:  # noqa: BLE001
+            logger.debug("[mcp] refresh list_tools failed: %s", name, exc_info=True)
+            return
+        removed_full, new_tools = self._apply_refreshed_tools(name, new_raw, client)
+        try:
+            on_change(removed_full, new_tools)
+        except Exception:  # noqa: BLE001
+            logger.debug("[mcp] refresh on_change failed: %s", name, exc_info=True)
+        logger.info("[mcp] %s tools refreshed (list_changed): %d tool(s)",
+                    name, len(new_tools))
+
+    def schedule_tool_refresh(self, name: str, on_change: Any) -> None:
+        """ch15 round-4 — schedule a tools/list_changed refresh on the
+        connection loop. Safe to call from the loop thread (the notification
+        dispatch path) — it schedules without blocking, so no self-deadlock."""
+        loop = self._loop
+        if loop is None:
+            return
+        try:
+            asyncio.run_coroutine_threadsafe(
+                self._refresh_server_tools_async(name, on_change), loop
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("[mcp] schedule refresh failed: %s", name, exc_info=True)
+
     def shutdown(self) -> None:
         """Disconnect clients and stop the background loop. Idempotent."""
         loop = self._loop

--- a/src/services/mcp/client.py
+++ b/src/services/mcp/client.py
@@ -134,6 +134,11 @@ class McpClient:
         # (None) declines — a valid response, so elicitation-capable servers no
         # longer hang on an ignored request.
         self._elicitation_handler: Any = None
+        # ch15 round-4 — server→client NOTIFICATION handler (method, no id):
+        # notifications/tools/list_changed etc. Sync callback taking
+        # (method: str, params: dict). Default (None) drops the notification
+        # (back-compat). Wired by the runtime to trigger a tool re-fetch.
+        self._notification_handler: Any = None
 
     def set_elicitation_handler(self, handler: Any) -> None:
         """Inject the async elicitation handler (params dict -> result dict).
@@ -142,6 +147,27 @@ class McpClient:
         TUI. When unset, elicitation requests are declined.
         """
         self._elicitation_handler = handler
+
+    def set_notification_handler(self, handler: Any) -> None:
+        """ch15 round-4 — inject the server-notification handler.
+
+        ``handler(method: str, params: dict) -> None``. Wired by the runtime
+        so ``notifications/tools/list_changed`` re-fetches the server's tools.
+        When unset, notifications are dropped (prior behavior).
+        """
+        self._notification_handler = handler
+
+    def _dispatch_notification(self, msg: Any) -> None:
+        """Route a server notification to the registered handler, guarded so a
+        bad handler never kills the receive loop."""
+        handler = self._notification_handler
+        if handler is None:
+            return
+        try:
+            handler(msg.method, getattr(msg, "params", None) or {})
+        except Exception:  # noqa: BLE001
+            logger.debug("MCP notification handler failed: %s",
+                         msg.method, exc_info=True)
 
     def set_auth_provider(self, provider: Any) -> None:
         """Inject the McpAuthProvider used for HTTP/SSE/WS auth flows.
@@ -220,10 +246,15 @@ class McpClient:
 
             if init_result and isinstance(init_result, dict):
                 caps = init_result.get("capabilities", {})
+                _tools_cap = caps.get("tools")
                 self._capabilities = ServerCapabilities(
-                    tools=bool(caps.get("tools")),
+                    tools=bool(_tools_cap),
                     prompts=bool(caps.get("prompts")),
                     resources=bool(caps.get("resources")),
+                    tools_list_changed=bool(
+                        isinstance(_tools_cap, dict)
+                        and _tools_cap.get("listChanged")
+                    ),
                 )
                 server_info_raw = init_result.get("serverInfo")
                 if server_info_raw and isinstance(server_info_raw, dict):
@@ -364,6 +395,14 @@ class McpClient:
                     asyncio.get_event_loop().create_task(
                         self._handle_incoming_request(msg)
                     )
+                elif msg.method is not None and msg.id is None:
+                    # ch15 round-4 — server→client NOTIFICATION (method set, no
+                    # id, per JSON-RPC 2.0): e.g. notifications/tools/list_changed.
+                    # Previously this matched NEITHER branch above and was
+                    # SILENTLY DROPPED, so a server that changed its tools
+                    # mid-session was invisible until a restart. Dispatch to the
+                    # registered handler (out-of-band so the loop keeps draining).
+                    self._dispatch_notification(msg)
         except Exception as e:
             logger.debug("MCP receive loop error: %s", e)
             for future in self._pending_requests.values():

--- a/src/services/mcp/types.py
+++ b/src/services/mcp/types.py
@@ -83,6 +83,11 @@ class ServerCapabilities:
     tools: bool = False
     prompts: bool = False
     resources: bool = False
+    # ch15 round-4 — the nested `tools.listChanged` sub-flag (a server that
+    # advertises it will push notifications/tools/list_changed on change).
+    # Previously the whole tools capability object was collapsed to a bool,
+    # losing this — so the client couldn't tell whether to expect refreshes.
+    tools_list_changed: bool = False
 
 
 @dataclass

--- a/src/tool_system/registry.py
+++ b/src/tool_system/registry.py
@@ -98,6 +98,32 @@ class ToolRegistry:
                 raise ValueError(f"duplicate tool alias: {alias}")
             self._by_name[alias_key] = tool
 
+    def remove_tool(self, name: str) -> bool:
+        """ch15 round-4 — remove a tool (and its aliases) by name. Returns
+        True if a tool was removed. Needed so MCP tools can be SWAPPED live
+        when a server sends notifications/tools/list_changed — the registry
+        was otherwise append-only, so a re-fetch couldn't reach the agent.
+
+        NB: deliberately NOT named ``unregister`` — ``_filter_registry``
+        (--allowedTools/--disallowedTools, agent_server.py + headless.py)
+        already calls a non-existent ``registry.unregister`` inside a
+        try/except as a silent no-op, so its registry-level filtering has
+        never actually run (the live enforcement is the deny-rule path at
+        assembly). Adding an ``unregister`` here would silently ACTIVATE that
+        untested, security-relevant path; a distinct name keeps this MCP
+        change scoped. Activating that filtering is a separate follow-up."""
+        key = name.lower()
+        tool = self._by_name.pop(key, None)
+        if tool is None:
+            return False
+        self._tools = [t for t in self._tools if t is not tool]
+        for alias in getattr(tool, "aliases", ()) or ():
+            # Only drop the alias if it still points at THIS tool (another
+            # tool may have claimed it — don't clobber that).
+            if self._by_name.get(alias.lower()) is tool:
+                self._by_name.pop(alias.lower(), None)
+        return True
+
     def get(self, name: str) -> Tool | None:
         return self._by_name.get(name.lower())
 

--- a/tests/test_ch15_mcp_list_changed_round4.py
+++ b/tests/test_ch15_mcp_list_changed_round4.py
@@ -1,0 +1,220 @@
+"""ch15 round-4 — MCP tools/list_changed dynamic refresh.
+
+Covers my-docs/port-improvement-round-4/ch15-mcp-round4-plan.md: the structural
+notification-dispatch hole (client._receive_loop dropped ALL notifications),
+the listChanged capability, the registry swap seam, and the McpRuntime refresh.
+"""
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock
+
+from src.services.mcp.client import McpClient
+from src.services.mcp.types import ServerCapabilities
+
+
+class _Msg:
+    def __init__(self, method=None, id=None, params=None, result=None, error=None):
+        self.method = method
+        self.id = id
+        self.params = params
+        self.result = result
+        self.error = error
+
+
+class TestClientNotificationDispatch(unittest.TestCase):
+    def test_notification_routes_to_handler(self):
+        client = McpClient()
+        seen = []
+        client.set_notification_handler(lambda m, p: seen.append((m, p)))
+        client._dispatch_notification(
+            _Msg(method="notifications/tools/list_changed", params={"x": 1})
+        )
+        self.assertEqual(seen, [("notifications/tools/list_changed", {"x": 1})])
+
+    def test_no_handler_is_safe(self):
+        client = McpClient()
+        # No handler registered → dropped, no crash (back-compat).
+        client._dispatch_notification(_Msg(method="notifications/tools/list_changed"))
+
+    def test_bad_handler_does_not_raise(self):
+        client = McpClient()
+
+        def _boom(m, p):
+            raise RuntimeError("bad")
+
+        client.set_notification_handler(_boom)
+        # Must not propagate — a bad handler can't kill the receive loop.
+        client._dispatch_notification(_Msg(method="notifications/tools/list_changed"))
+
+    def test_receive_loop_dispatches_notification(self):
+        # The structural fix: a notification (method set, id None) reaches the
+        # handler instead of being silently dropped.
+        client = McpClient()
+        seen = []
+        client.set_notification_handler(lambda m, p: seen.append(m))
+
+        msgs = [
+            _Msg(method="notifications/tools/list_changed", params={}),
+            None,  # then transport closes → loop exits
+        ]
+
+        transport = MagicMock()
+        transport.is_connected = True
+
+        async def _recv():
+            return msgs.pop(0)
+
+        transport.receive = _recv
+        client._transport = transport
+        asyncio.run(client._receive_loop())
+        self.assertIn("notifications/tools/list_changed", seen)
+
+
+class TestListChangedCapability(unittest.TestCase):
+    def test_nested_listchanged_preserved(self):
+        caps = ServerCapabilities(tools=True, tools_list_changed=True)
+        self.assertTrue(caps.tools_list_changed)
+
+    def test_default_false(self):
+        self.assertFalse(ServerCapabilities().tools_list_changed)
+
+
+class TestRegistryUnregister(unittest.TestCase):
+    def _reg(self):
+        from src.tool_system.registry import ToolRegistry
+        return ToolRegistry()
+
+    def _tool(self, name, aliases=()):
+        t = MagicMock()
+        t.name = name
+        t.aliases = list(aliases)
+        return t
+
+    def test_unregister_removes_tool_and_aliases(self):
+        reg = self._reg()
+        t = self._tool("mcp__srv__do", aliases=["do_alias"])
+        reg.register(t)
+        self.assertIsNotNone(reg.get("mcp__srv__do"))
+        self.assertIsNotNone(reg.get("do_alias"))
+        self.assertTrue(reg.remove_tool("mcp__srv__do"))
+        self.assertIsNone(reg.get("mcp__srv__do"))
+        self.assertIsNone(reg.get("do_alias"))
+        # Idempotent / absent-safe.
+        self.assertFalse(reg.remove_tool("mcp__srv__do"))
+
+    def test_reregister_after_remove(self):
+        reg = self._reg()
+        reg.register(self._tool("mcp__srv__do"))
+        reg.remove_tool("mcp__srv__do")
+        # No duplicate error now that it was removed.
+        reg.register(self._tool("mcp__srv__do"))
+        self.assertIsNotNone(reg.get("mcp__srv__do"))
+
+
+class TestRuntimeApplyRefreshedTools(unittest.TestCase):
+    def _rt(self):
+        from src.server.mcp_runtime import McpRuntime
+        rt = McpRuntime()
+        # _wrap builds a real sync Tool; give it a trivial loop-less stub via
+        # a fake that just returns an object with a .name.
+        rt._wrap = lambda server, mt, client: _wrapped(server, mt.name)
+        return rt
+
+    def test_swap_returns_removed_full_and_new(self):
+        rt = self._rt()
+        rt.tools = [_wrapped("srv", "old_a"), _wrapped("srv", "old_b"),
+                    _wrapped("other", "keep")]
+        rt.servers = {"srv": ["old_a", "old_b"], "other": ["keep"]}
+
+        new_raw = [_raw("new_x"), _raw("new_y")]
+        removed, new_tools = rt._apply_refreshed_tools("srv", new_raw, MagicMock())
+
+        self.assertEqual(sorted(removed),
+                         ["mcp__srv__old_a", "mcp__srv__old_b"])
+        self.assertEqual([t.name for t in new_tools],
+                         ["mcp__srv__new_x", "mcp__srv__new_y"])
+        # self.tools: other server's tool kept, srv's swapped.
+        names = sorted(t.name for t in rt.tools)
+        self.assertEqual(names, ["mcp__other__keep",
+                                 "mcp__srv__new_x", "mcp__srv__new_y"])
+        self.assertEqual(rt.servers["srv"], ["new_x", "new_y"])
+
+
+class TestNotificationHandlerFactory(unittest.TestCase):
+    def test_list_changed_schedules_refresh_and_swaps_registry(self):
+        from src.server.agent_server import _make_mcp_notification_handler
+        from src.tool_system.registry import ToolRegistry
+
+        reg = ToolRegistry()
+        old = MagicMock(); old.name = "mcp__srv__old"; old.aliases = []
+        reg.register(old)
+
+        # critic M1: the handler resolves sess.tool_registry at refresh time
+        # (switch-safe), not a boot-time registry.
+        sess = MagicMock()
+        sess.tool_registry = reg
+
+        rt = MagicMock()
+        # Capture what schedule_tool_refresh is asked to do, then drive on_change.
+        captured = {}
+        rt.schedule_tool_refresh = lambda name, on_change: captured.update(
+            name=name, on_change=on_change)
+
+        handler = _make_mcp_notification_handler(rt, sess, "srv")
+        # A non-list_changed notification is ignored.
+        handler("notifications/resources/updated", {})
+        self.assertEqual(captured, {})
+        # list_changed schedules the refresh for this server.
+        handler("notifications/tools/list_changed", {})
+        self.assertEqual(captured["name"], "srv")
+
+        # Drive the on_change callback → registry swap.
+        new = MagicMock(); new.name = "mcp__srv__new"; new.aliases = []
+        captured["on_change"](["mcp__srv__old"], [new])
+        self.assertIsNone(reg.get("mcp__srv__old"))
+        self.assertIsNotNone(reg.get("mcp__srv__new"))
+
+    def test_refresh_follows_a_switched_registry(self):
+        # critic M1: after a provider switch rebinds sess.tool_registry to a
+        # NEW registry, the refresh must target the new one, not the boot one.
+        from src.server.agent_server import _make_mcp_notification_handler
+        from src.tool_system.registry import ToolRegistry
+
+        boot_reg = ToolRegistry()
+        new_reg = ToolRegistry()
+        sess = MagicMock()
+        sess.tool_registry = boot_reg
+
+        captured = {}
+        rt = MagicMock()
+        rt.schedule_tool_refresh = lambda name, on_change: captured.update(
+            on_change=on_change)
+        handler = _make_mcp_notification_handler(rt, sess, "srv")
+        handler("notifications/tools/list_changed", {})
+
+        # Simulate a provider switch: sess now points at a NEW registry.
+        sess.tool_registry = new_reg
+        t = MagicMock(); t.name = "mcp__srv__x"; t.aliases = []
+        captured["on_change"]([], [t])
+        # The tool landed in the CURRENT (switched) registry, not the boot one.
+        self.assertIsNotNone(new_reg.get("mcp__srv__x"))
+        self.assertIsNone(boot_reg.get("mcp__srv__x"))
+
+
+def _wrapped(server, tool_name):
+    from src.services.mcp.mcp_string_utils import build_mcp_tool_name
+    t = MagicMock()
+    t.name = build_mcp_tool_name(server, tool_name)
+    return t
+
+
+def _raw(name):
+    r = MagicMock()
+    r.name = name
+    return r
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Round-4 ch15 (MCP): make `tools/list_changed` actually refresh tools live

**Docs:** `my-docs/ch15-mcp-round4-gap-analysis.md` + facet report + critic verdict under `my-docs/port-improvement-round-4/`.

Two committed items; one was a misread, one is a real structural gap:

- **`DANGEROUSLY_uncached` MCP tool-caching — rejected.** The facet confirmed no such escape hatch exists for MCP tools in the TS original (that symbol is a *system-prompt* helper, unrelated). Both trees fetch `tools/list` once per connect and cache the wrapped tools; neither re-fetches per turn. No gap.

- **`tools/list_changed` dynamic refresh — the real gap (structural).** `McpClient._receive_loop` dispatched only responses (`id` present) and incoming requests (`method`+`id`). A **notification** (`method` set, `id` absent, per JSON-RPC 2.0) — like `notifications/tools/list_changed` — matched **neither** branch and was **silently dropped**. So a server that added/removed/renamed its tools mid-session was invisible until the agent-server restarted (silent, no error). Compounded by `ServerCapabilities` collapsing the tools capability to a bool (losing the nested `listChanged`), no handler surface, no runtime refresh path, and an append-only registry.

### The end-to-end fix

1. **`client._receive_loop`** — the missing notification branch → `_dispatch_notification` → registered handler (guarded so a bad handler can't kill the loop). This unblocks **all** server→client notifications, not just tools.
2. **`client.set_notification_handler`** — the handler surface (mirrors `set_elicitation_handler`; `None` → drop, back-compat).
3. **`ServerCapabilities.tools_list_changed`** — preserve the nested `tools.listChanged` sub-flag from the initialize handshake.
4. **`registry.remove_tool(name)`** — remove a tool + its aliases (was append-only) so MCP tools can be swapped live; drops an alias only if it still points at that tool. **Deliberately not named `unregister`** (critic M2): `_filter_registry` (`--allowedTools`/`--disallowedTools`) already calls a non-existent `registry.unregister` as a silent no-op, so naming it `unregister` would silently activate that untested, security-relevant filtering path. A distinct name keeps this PR scoped to MCP; the dormant filtering is flagged as a follow-up.
5. **`McpRuntime`** — `_apply_refreshed_tools` (pure: swap only this server's slice of `self.tools`/`self.servers`, return `(removed_full_names, new_tools)`), `_refresh_server_tools_async` (re-fetch on the loop), `schedule_tool_refresh` (non-blocking schedule — safe from the loop thread, no self-deadlock).
6. **`agent_server`** — `_make_mcp_notification_handler(mcp_rt, sess, server)` per client (alongside elicitation): on `tools/list_changed`, schedule the refresh; when it lands, `remove_tool` the old `mcp__{server}__*` names and `register` the new — the agent sees the change without a restart. Resolves `sess.tool_registry` at **refresh time** (critic M1), so a provider/model switch that rebinds the registry doesn't orphan the handler.

**Severity: medium-live** — correctness (silent stale tools) for *dynamic* MCP servers in long sessions. (TS live-refreshes only in the interactive REPL; headless does one-shot, like the port's other path.)

### Verification

`tests/test_ch15_mcp_list_changed_round4.py` (10): client notification dispatch (routes / no-handler-safe / bad-handler-safe / the `_receive_loop` branch actually delivers), the `tools_list_changed` capability, `registry.unregister` (+aliases, idempotent, re-register-after), `McpRuntime._apply_refreshed_tools` swap (keeps other servers), and the notification factory (ignores non-list_changed, schedules on list_changed, `on_change` swaps the registry). MCP suite 503 pass; full suite at the pre-existing 9-failure baseline (2 of which are keyring-missing MCP env failures, unrelated).

### Deferred (owners)

Hard-reconnect for a dead stdio subprocess (reconnect lives in the unwired `MCPConnectionManager`); `list_tools` 3-retry (TS `client.ts:1778`); wiring prompts/resources `list_changed` to a refresh (the branch now delivers them); cross-thread registry mutation (GIL-atomic — `get_all` iterates a copy — worst case a tool momentarily missing/dup during a refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
