### PR TITLE
feat(ch16/round4): apply ANTHROPIC_CUSTOM_HEADERS on the live API path

### DIFF
--- a/src/command_system/rename_command.py
+++ b/src/command_system/rename_command.py
@@ -88,7 +88,10 @@ async def _generate_session_name(messages: Any) -> str | None:
     try:
         import anthropic
 
-        client = anthropic.Anthropic()
+        from src.services.api.custom_headers import get_anthropic_custom_headers
+        client = anthropic.Anthropic(
+            default_headers=get_anthropic_custom_headers() or None
+        )
         result = client.messages.create(
             model="claude-3-5-haiku-20241022",
             max_tokens=100,

--- a/src/providers/anthropic_provider.py
+++ b/src/providers/anthropic_provider.py
@@ -159,6 +159,12 @@ class AnthropicProvider(BaseProvider):
         self._client_kwargs = {"api_key": api_key}
         if base_url:
             self._client_kwargs["base_url"] = base_url
+        # ch16 round-4 — ANTHROPIC_CUSTOM_HEADERS (enterprise gateway/proxy
+        # auth) → default_headers on the Anthropic client.
+        from src.services.api.custom_headers import get_anthropic_custom_headers
+        _headers = get_anthropic_custom_headers()
+        if _headers:
+            self._client_kwargs["default_headers"] = _headers
         self.client = None
 
     def _ensure_client(self):

--- a/src/services/api/claude.py
+++ b/src/services/api/claude.py
@@ -279,7 +279,16 @@ async def call_model(
         if client is None:
             try:
                 import anthropic
-                client = anthropic.AsyncAnthropic()
+
+                # ch16 round-4 — inject ANTHROPIC_CUSTOM_HEADERS (enterprise
+                # gateway/proxy auth) on the live streaming path.
+                from src.services.api.custom_headers import (
+                    get_anthropic_custom_headers,
+                )
+                _headers = get_anthropic_custom_headers()
+                client = anthropic.AsyncAnthropic(
+                    default_headers=_headers or None
+                )
             except ImportError:
                 yield ErrorEvent(error="anthropic package not installed")
                 return

--- a/src/services/api/custom_headers.py
+++ b/src/services/api/custom_headers.py
@@ -1,0 +1,44 @@
+"""ch16 round-4 — ANTHROPIC_CUSTOM_HEADERS injection.
+
+Enterprise deployments route Anthropic API traffic through a gateway / MITM
+proxy that injects org auth headers (the book's ch16 system #3: "tunnel API
+traffic through infrastructure that might inject credentials or terminate
+TLS"). The Anthropic SDK accepts a ``default_headers`` kwarg; this module
+parses the curl-style ``ANTHROPIC_CUSTOM_HEADERS`` env var into that dict.
+
+Mirrors TS ``services/api/client.ts:530-549`` (``getCustomHeaders``): split on
+newlines, parse ``Name: Value`` on the first colon, trim, skip blank /
+colon-less lines. The injection mechanism itself is already proven in-repo at
+``providers/openrouter_provider.py`` (``default_headers`` threading).
+"""
+from __future__ import annotations
+
+import os
+
+
+def parse_custom_headers(raw: str | None) -> dict[str, str]:
+    """Parse curl-style ``Name: Value`` header lines (newline-separated).
+
+    A later duplicate name wins (last-write, like a dict build). Blank lines
+    and lines with no colon are skipped; the name is trimmed and must be
+    non-empty; the value is everything after the first colon, trimmed.
+    """
+    headers: dict[str, str] = {}
+    if not raw:
+        return headers
+    for line in raw.replace("\r\n", "\n").split("\n"):
+        if not line.strip():
+            continue
+        colon = line.find(":")
+        if colon == -1:
+            continue
+        name = line[:colon].strip()
+        value = line[colon + 1:].strip()
+        if name:
+            headers[name] = value
+    return headers
+
+
+def get_anthropic_custom_headers() -> dict[str, str]:
+    """The parsed ``ANTHROPIC_CUSTOM_HEADERS`` env var (empty if unset)."""
+    return parse_custom_headers(os.environ.get("ANTHROPIC_CUSTOM_HEADERS"))

--- a/src/services/session_title.py
+++ b/src/services/session_title.py
@@ -67,7 +67,10 @@ async def generate_llm_title(
 
         summary = "\n".join(msg_summaries)
 
-        client = anthropic.AsyncAnthropic()
+        from src.services.api.custom_headers import get_anthropic_custom_headers
+        client = anthropic.AsyncAnthropic(
+            default_headers=get_anthropic_custom_headers() or None
+        )
         response = await client.messages.create(
             model=model,
             max_tokens=50,

--- a/src/token_estimation.py
+++ b/src/token_estimation.py
@@ -347,7 +347,10 @@ async def count_messages_tokens_with_api(
     try:
         import anthropic
 
-        client = anthropic.AsyncAnthropic()
+        from src.services.api.custom_headers import get_anthropic_custom_headers
+        client = anthropic.AsyncAnthropic(
+            default_headers=get_anthropic_custom_headers() or None
+        )
         response = await client.beta.messages.count_tokens(
             model="claude-sonnet-4-20250514",
             messages=messages,

--- a/tests/test_ch16_custom_headers_round4.py
+++ b/tests/test_ch16_custom_headers_round4.py
@@ -1,0 +1,169 @@
+"""ch16 round-4 — ANTHROPIC_CUSTOM_HEADERS injection (enterprise gateway/proxy).
+
+Covers my-docs/port-improvement-round-4/ch16-remote-round4-plan.md. Mirrors TS
+services/api/client.ts:530-549 (getCustomHeaders) and asserts the headers are
+threaded into the live Anthropic client on the streaming path.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from src.services.api.custom_headers import (
+    get_anthropic_custom_headers,
+    parse_custom_headers,
+)
+
+
+class TestParseCustomHeaders(unittest.TestCase):
+    def test_basic_curl_style(self):
+        self.assertEqual(
+            parse_custom_headers("X-Gateway-Auth: tok123\nX-Org: acme"),
+            {"X-Gateway-Auth": "tok123", "X-Org": "acme"},
+        )
+
+    def test_split_on_first_colon_only(self):
+        # A value may itself contain a colon (e.g. a URL / time).
+        self.assertEqual(
+            parse_custom_headers("X-Trace: id:12:34"),
+            {"X-Trace": "id:12:34"},
+        )
+
+    def test_trims_name_and_value(self):
+        self.assertEqual(
+            parse_custom_headers("  Name  :   spaced value  "),
+            {"Name": "spaced value"},
+        )
+
+    def test_skips_blank_and_colonless_lines(self):
+        self.assertEqual(
+            parse_custom_headers("\n  \nNoColonHere\nA: 1\n"),
+            {"A": "1"},
+        )
+
+    def test_crlf_supported(self):
+        self.assertEqual(
+            parse_custom_headers("A: 1\r\nB: 2"),
+            {"A": "1", "B": "2"},
+        )
+
+    def test_empty_name_skipped(self):
+        self.assertEqual(parse_custom_headers(": value"), {})
+
+    def test_none_and_empty(self):
+        self.assertEqual(parse_custom_headers(None), {})
+        self.assertEqual(parse_custom_headers(""), {})
+
+    def test_last_duplicate_wins(self):
+        self.assertEqual(parse_custom_headers("A: 1\nA: 2"), {"A": "2"})
+
+
+class TestEnvReader(unittest.TestCase):
+    def test_reads_env(self):
+        with patch.dict("os.environ", {"ANTHROPIC_CUSTOM_HEADERS": "X: y"}):
+            self.assertEqual(get_anthropic_custom_headers(), {"X": "y"})
+
+    def test_unset_is_empty(self):
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+            os.environ.pop("ANTHROPIC_CUSTOM_HEADERS", None)
+            self.assertEqual(get_anthropic_custom_headers(), {})
+
+
+class TestProviderInjection(unittest.TestCase):
+    def test_anthropic_provider_threads_headers(self):
+        from src.providers.anthropic_provider import AnthropicProvider
+
+        with patch.dict("os.environ", {"ANTHROPIC_CUSTOM_HEADERS": "X-GW: t"}):
+            p = AnthropicProvider(api_key="k")
+        self.assertEqual(p._client_kwargs.get("default_headers"), {"X-GW": "t"})
+
+    def test_anthropic_provider_no_headers_when_unset(self):
+        from src.providers.anthropic_provider import AnthropicProvider
+        import os
+
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("ANTHROPIC_CUSTOM_HEADERS", None)
+            p = AnthropicProvider(api_key="k")
+        self.assertNotIn("default_headers", p._client_kwargs)
+
+    def test_non_anthropic_provider_excluded(self):
+        # critic: ANTHROPIC_CUSTOM_HEADERS must NOT leak onto a non-Anthropic
+        # endpoint (Minimax uses the Anthropic SDK against its OWN base_url).
+        from src.providers.minimax_provider import MinimaxProvider
+
+        with patch.dict("os.environ", {"ANTHROPIC_CUSTOM_HEADERS": "X-GW: t"}):
+            p = MinimaxProvider(api_key="k", base_url="https://minimax.example")
+        self.assertNotIn("default_headers", p._client_kwargs)
+
+
+class TestStreamingPathInjection(unittest.TestCase):
+    def test_call_model_constructs_client_with_headers(self):
+        # The live streaming path (call_model) constructs AsyncAnthropic with
+        # the parsed default_headers. Stub the anthropic module (captures
+        # kwargs, fails fast after construction) so there's no network.
+        import asyncio
+        import types
+
+        captured = {}
+
+        class _FakeAsyncAnthropic:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def __getattr__(self, _name):
+                raise RuntimeError("stop-after-construct")
+
+        fake = types.ModuleType("anthropic")
+        fake.AsyncAnthropic = _FakeAsyncAnthropic
+
+        from src.services.api.claude import CallModelOptions, call_model
+
+        async def _drive():
+            gen = call_model([{"role": "user", "content": "hi"}],
+                             CallModelOptions())
+            async for _ev in gen:
+                pass  # runs to completion (construction then a fast error)
+
+        with patch.dict("sys.modules", {"anthropic": fake}), \
+                patch.dict("os.environ", {"ANTHROPIC_CUSTOM_HEADERS": "X-GW: z"}):
+            asyncio.run(_drive())
+
+        self.assertEqual(captured.get("default_headers"), {"X-GW": "z"})
+
+    def test_call_model_no_headers_passes_none(self):
+        import asyncio
+        import os
+        import types
+
+        captured = {}
+
+        class _FakeAsyncAnthropic:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def __getattr__(self, _name):
+                raise RuntimeError("stop")
+
+        fake = types.ModuleType("anthropic")
+        fake.AsyncAnthropic = _FakeAsyncAnthropic
+
+        from src.services.api.claude import CallModelOptions, call_model
+
+        async def _drive():
+            gen = call_model([{"role": "user", "content": "hi"}],
+                             CallModelOptions())
+            async for _ev in gen:
+                pass
+
+        with patch.dict("sys.modules", {"anthropic": fake}), \
+                patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("ANTHROPIC_CUSTOM_HEADERS", None)
+            asyncio.run(_drive())
+
+        # No custom headers → default_headers passed as None (SDK default).
+        self.assertIsNone(captured.get("default_headers"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Round-4 ch16 (remote/cloud): apply `ANTHROPIC_CUSTOM_HEADERS` on the live API path

**Docs:** `my-docs/ch16-remote-round4-gap-analysis.md` + facet report + critic verdict under `my-docs/port-improvement-round-4/`.

All four of the book's remote systems (Bridge v1/v2, Direct Connect, Upstream Proxy) are already ported; only Direct Connect is wired/live, and wiring the rest needs claude.ai OAuth + CCR infrastructure the port can't exercise. The one **live, user-facing, cleanly-portable** gap is the book's system #3 — "tunnel API traffic through infrastructure that might inject credentials or terminate TLS" — in its every-user form.

### The gap

Enterprise deployments route Anthropic traffic through a gateway / corporate MITM proxy that requires injected auth headers. TS parses curl-style `Name: Value` from `ANTHROPIC_CUSTOM_HEADERS` into `defaultHeaders` (`services/api/client.ts:530-549`). **Python applied it nowhere** — the var appeared only in a `SAFE_ENV_KEYS` allowlist (`trust_boundary.py:75`), never parsed. Every Anthropic client was built with no `default_headers`, so a user behind such a gateway had no way to supply the header and every call failed auth.

### The fix

- **`src/services/api/custom_headers.py`** (new): `parse_custom_headers` (curl-style, split on the first colon, trim name+value, skip blank/colon-less/empty-name lines, CRLF-safe, last-duplicate-wins — mirrors TS `getCustomHeaders`) + `get_anthropic_custom_headers`.
- **Injects `default_headers`** at every first-party Anthropic construction — the live streaming path (`claude.py` `call_model`), the provider (`anthropic_provider`), session-title, token-estimation, rename-command (behind a gateway they all need the header, else those calls fail auth). Non-Anthropic providers (minimax/openai/etc., which target their own endpoints) are excluded. The SDK merges `default_headers` with its own auth headers; a gateway overriding `x-api-key`/`Authorization` is the intended enterprise use (matching TS). Header values can't contain newlines (the parser splits on them; httpx rejects invalid values) — no header-injection vector.

### Verification

`tests/test_ch16_custom_headers_round4.py` (14): parse semantics (first-colon-split, trim, skip blank/colon-less/empty-name, CRLF, none/empty, last-duplicate-wins), the env reader, the provider `_client_kwargs` injection (+ none when unset), and the **live `call_model` construction** (stubbed `anthropic` — asserts `AsyncAnthropic` is built with the parsed `default_headers`, and `None` when unset). Full suite at the pre-existing 9-failure baseline.

### Deferred (owners)

`--permission-prompt-tool` (headless MCP approval; only the type exists); explicit `HTTPS_PROXY`/`NO_PROXY` (httpx `trust_env` already honors it implicitly); Bedrock/Vertex routing (unwired scaffolding); Gemini `base_url` nit; wiring the dormant CCR Bridge v1/v2 (needs claude.ai OAuth infra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
