### PR TITLE
perf(ch17/round4): memoize the # Environment date so it stops busting the prompt cache

### DIFF
--- a/src/context_system/prompt_assembly.py
+++ b/src/context_system/prompt_assembly.py
@@ -349,7 +349,8 @@ def _compute_env_info(cwd: str) -> str:
     parts: list[str] = []
     parts.append(f"CWD: {cwd}")
     parts.append(f"OS: {platform.system()} {platform.release()}")
-    parts.append(f"Date: {_get_local_iso_date()}")
+    # ch17 round-4 — date-only for cache stability (see _build_env_section).
+    parts.append(f"Date: {_get_session_start_date_iso()}")
 
     return "\n".join(parts)
 
@@ -1080,7 +1081,15 @@ def _build_env_section(cwd: str | None, use_cache: bool) -> SystemPromptSection 
     parts.append("# Environment")
     parts.append(f"- CWD: {target}")
     parts.append(f"- OS: {platform.system()} {platform.release()}")
-    parts.append(f"- Date: {_get_local_iso_date()}")
+    # ch17 round-4 — memoized DATE-ONLY (not per-second wall clock). This
+    # block is REQUEST-scope, and the REQUEST group's last block carries a
+    # cache_control marker, so a per-second timestamp busts the REQUEST cache
+    # breakpoint (1 of only 4 the request is allowed) on EVERY turn — writing
+    # a +25% cache entry that's never read back. _get_session_start_date_iso
+    # is the in-file cache-safe helper built for exactly this (the older
+    # "safe after the DYNAMIC_BOUNDARY" rationale was invalidated when the
+    # REQUEST group gained its own marker).
+    parts.append(f"- Date: {_get_session_start_date_iso()}")
     shell = os.environ.get("SHELL", "unknown")
     parts.append(f"- Shell: {shell}")
     try:

--- a/tests/test_ch17_env_cache_stability_round4.py
+++ b/tests/test_ch17_env_cache_stability_round4.py
@@ -1,0 +1,98 @@
+"""ch17 round-4 — the # Environment block's date must be cache-stable.
+
+The env block is REQUEST-scope and the REQUEST group's last block carries a
+cache_control marker, so a per-second timestamp busted the REQUEST cache
+breakpoint (1 of only 4) on every turn. It now uses the memoized date-only
+helper. These tests pin that regression.
+"""
+from __future__ import annotations
+
+import unittest
+from datetime import datetime
+from unittest.mock import patch
+
+from src.context_system import prompt_assembly as pa
+
+
+class TestEnvDateCacheStability(unittest.TestCase):
+    def setUp(self):
+        # The date helper is process-memoized; clear it so each test controls
+        # the frozen value.
+        pa._get_session_start_date_iso.cache_clear()
+
+    def tearDown(self):
+        pa._get_session_start_date_iso.cache_clear()
+
+    def test_env_block_is_date_only_no_seconds(self):
+        with patch.object(pa, "datetime") as m:
+            m.now.return_value = datetime(2026, 7, 2, 15, 10, 8)
+            section = pa._build_env_section("/x", False)
+        self.assertIn("- Date: 2026-07-02", section.content)
+        # No per-second wall clock (the thing that busted the cache).
+        self.assertNotIn("T15:10", section.content)
+        self.assertNotIn(":08", section.content)
+
+    def test_env_block_byte_identical_across_clock_advance(self):
+        # First build freezes the date; a later build (clock advanced by
+        # hours) must produce a BYTE-IDENTICAL block → the REQUEST cache
+        # breakpoint's prefix stays cacheable turn-over-turn.
+        with patch.object(pa, "datetime") as m:
+            m.now.return_value = datetime(2026, 7, 2, 15, 10, 8)
+            s1 = pa._build_env_section("/x", False)
+        with patch.object(pa, "datetime") as m:
+            m.now.return_value = datetime(2026, 7, 2, 23, 59, 59)  # hours later
+            s2 = pa._build_env_section("/x", False)
+        self.assertEqual(s1.content, s2.content)
+
+    def test_env_section_is_request_scope(self):
+        # Guards the assumption that makes the timestamp cache-relevant.
+        from src.context_system.system_prompt_cache import CacheScope
+        section = pa._build_env_section("/x", False)
+        self.assertEqual(section.cache_scope, CacheScope.REQUEST)
+
+    def test_legacy_str_env_info_also_date_only(self):
+        with patch.object(pa, "datetime") as m:
+            m.now.return_value = datetime(2026, 7, 2, 15, 10, 8)
+            info = pa._compute_env_info("/x")
+        self.assertIn("Date: 2026-07-02", info)
+        self.assertNotIn("T15:10", info)
+
+
+class TestFullBlocksRequestBreakpointStable(unittest.TestCase):
+    def setUp(self):
+        pa._get_session_start_date_iso.cache_clear()
+
+    def tearDown(self):
+        pa._get_session_start_date_iso.cache_clear()
+
+    def test_request_scope_env_stable_across_two_builds(self):
+        # End-to-end: two full block-list builds with the clock advanced
+        # between them must have byte-identical REQUEST-scope env text
+        # (mirrors the facet's empirical probe — the only prior diff was the
+        # env date's seconds).
+        # Default assembly (no custom prompt, which would replace the blocks).
+        with patch.object(pa, "datetime") as m:
+            m.now.return_value = datetime(2026, 7, 2, 15, 10, 8)
+            blocks1 = pa.build_full_system_prompt_blocks(cwd="/x")
+        with patch.object(pa, "datetime") as m:
+            m.now.return_value = datetime(2026, 7, 2, 15, 10, 30)
+            blocks2 = pa.build_full_system_prompt_blocks(cwd="/x")
+
+        env1 = [b for b in _texts(blocks1) if "# Environment" in b]
+        env2 = [b for b in _texts(blocks2) if "# Environment" in b]
+        self.assertTrue(env1, "env block present")
+        self.assertEqual(env1, env2)  # byte-identical → cache prefix matches
+
+
+def _texts(blocks) -> list[str]:
+    out = []
+    for b in blocks:
+        if isinstance(b, dict):
+            t = b.get("text")
+            if isinstance(t, str):
+                out.append(t)
+    return out
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Round-4 ch17 (performance): stop the `# Environment` date busting the prompt cache every turn

**Docs:** `my-docs/ch17-performance-round4-gap-analysis.md` + facet report (with empirical probes) + critic verdict under `my-docs/port-improvement-round-4/`.

Of the chapter's five perf sub-problems, all the prior-round work has landed and the prompt cache is stable turn-over-turn for the GLOBAL and SESSION breakpoints (the ~190K-token bulk). Exactly **one live cache-stability defect remained**, and it's empirically proven.

### The defect

`_build_env_section` (`prompt_assembly.py:1083`) emitted the date via `_get_local_iso_date()` — **per-second** precision (`…T15:10:08`). The `# Environment` section is REQUEST-scope, and `build_full_system_prompt_blocks` places a `cache_control` marker on the **last block of the REQUEST group**, so the env block sits *inside* that breakpoint's cached prefix. The facet's probe: two live builds 1.2 s apart diffed to **exactly the env date's seconds and nothing else** — GLOBAL/SESSION byte-identical, the REQUEST prefix changing every turn.

The REQUEST breakpoint is **1 of only 4** `cache_control` markers the request is allowed. It was fully budgeted and **wasted** — every turn writing a +25% cache entry (5m-write premium on the REQUEST-scope tokens: env ~60-100 tokens + `# auto memory` up to ~6K when `MEMORY.md` is present) that is **never read back**, because next turn's seconds differ.

### The fix

`_build_env_section` (and the legacy str-path `_compute_env_info`) now use `_get_session_start_date_iso()` — the `@lru_cache`-memoized, date-only (`YYYY-MM-DD`) helper already in-file and documented as *"Used in any prompt section that flows through the prompt cache."* (`_get_local_iso_date` is itself documented as *"DEPRECATED for use in any section that flows through the prompt cache"* — its "safe after the DYNAMIC_BOUNDARY" rationale was invalidated when the REQUEST group gained its own marker.) This matches TS, which memoizes the session date (`getSessionStartDate = memoize(getLocalISODate)`); user-context already used this helper. Per-second time in the env block served no purpose and only busted the cache; a session that crosses midnight shows the start date (same as TS — "a stale date is cosmetic; a cache bust reprocesses the conversation").

### Verification

`tests/test_ch17_env_cache_stability_round4.py` (5): the env block is date-only (no seconds); the env block is **byte-identical across a clock advanced by hours** (the cache-stability guarantee); the env section is REQUEST-scope; the legacy `_compute_env_info` is date-only; and a full `build_full_system_prompt_blocks` build has a byte-identical env block across an advanced clock (mirrors the facet's empirical probe). Full suite at the pre-existing 9-failure baseline; `test_prompt_assembly.py` (46) green.

### Deferred (owners)

No `cache_control` marker on the tools array (correct under the 4-marker cap — tools cache in the GLOBAL prefix); `MEMORY.md`-write-turn REQUEST volatility (correct behavior); `_build_runtime` cold-start parallelization (bounded — no blocking boot I/O); the Haiku small-model lane (no consumer → dead code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
