### PR TITLE
feat(r5-1/ch11): fix the memory-recall enable-blockers

### DIFF
--- a/src/memdir/find_relevant_memories.py
+++ b/src/memdir/find_relevant_memories.py
@@ -27,6 +27,40 @@ from .memory_scan import MemoryHeader, format_memory_manifest, scan_memory_files
 
 logger = logging.getLogger(__name__)
 
+
+def _resolve_recall_model(provider: Any) -> str | None:
+    """R5 round-5 (ch11 #2) — the model for the memory-selector side-query.
+
+    TS pins the selector to a small default (``getDefaultSonnetModel``) so a
+    turn on an expensive session model doesn't pay full price for the recall
+    call. The multi-provider port wires the ``small_fast_model`` setting —
+    BUT its shipped default is an Anthropic id (``claude-3-5-haiku-…``,
+    settings/constants.py), which is only valid on the first-party Anthropic
+    endpoint. Passing it to a DeepSeek/OpenAI/Minimax session would 400 and
+    (since recall swallows errors) silently kill recall every turn (critic
+    M1). So the pin applies ONLY when the SESSION provider is a first-party
+    ``AnthropicProvider``; every other provider (incl. Minimax, which runs
+    the Anthropic SDK against a different endpoint) falls back to the session
+    model. Returns None to signal that fallback. Never raises.
+
+    (A future ``small_fast_model_provider`` pairing — mirroring
+    ``advisor_model``/``advisor_provider`` — would let non-Anthropic sessions
+    pin their own cheap recall model; deferred.)"""
+    try:
+        from src.providers.anthropic_provider import AnthropicProvider
+
+        # Minimax subclasses BaseProvider (not AnthropicProvider) and targets
+        # its own endpoint, so isinstance correctly excludes it.
+        if not isinstance(provider, AnthropicProvider):
+            return None
+        from src.settings.settings import get_settings
+
+        model = (getattr(get_settings(), "small_fast_model", "") or "").strip()
+        return model or None
+    except Exception:  # noqa: BLE001 — a settings/import failure must not block recall
+        return None
+
+
 __all__ = [
     "RelevantMemory",
     "MAX_RELEVANT_MEMORIES",
@@ -114,16 +148,22 @@ async def _select_with_provider(
             "memdir selector: provider lacks chat_async; skipping selection"
         )
         return []
+    # R5 (ch11 #2) — run the selector on the cheap small_fast_model when
+    # configured, so recall doesn't pay the (Opus/DeepSeek) session-model
+    # price every turn. Omit `model` entirely when unset → session model.
+    recall_kwargs: dict[str, Any] = {
+        "system": _SELECT_SYSTEM_PROMPT,
+        "max_tokens": 256,
+        "output_format": {
+            "type": "json_schema",
+            "schema": _SELECTOR_JSON_SCHEMA,
+        },
+    }
+    recall_model = _resolve_recall_model(provider)
+    if recall_model:
+        recall_kwargs["model"] = recall_model
     try:
-        response = await provider.chat_async(
-            messages,
-            system=_SELECT_SYSTEM_PROMPT,
-            max_tokens=256,
-            output_format={
-                "type": "json_schema",
-                "schema": _SELECTOR_JSON_SCHEMA,
-            },
-        )
+        response = await provider.chat_async(messages, **recall_kwargs)
     except Exception as exc:
         logger.debug("memdir selector failed: %s", exc)
         return []

--- a/src/memdir/surface_memories.py
+++ b/src/memdir/surface_memories.py
@@ -19,6 +19,11 @@ logger = logging.getLogger(__name__)
 # Per-file surfacing caps (TS readMemoriesForSurfacing: 200 lines / 4 KB).
 MAX_SURFACE_LINES = 200
 MAX_SURFACE_CHARS = 4096
+# R5 round-5 (ch11 #4) — total cap across ALL files surfaced in one turn.
+# find_relevant_memories selects up to 5, each capped at 4 KB, so a single
+# turn could inject ~20 KB of memory bodies; TS bounds the aggregate. Cap
+# the combined reminder so one turn can't bloat the request.
+MAX_TOTAL_SURFACE_CHARS = 12288  # 12 KB (≈3× the per-file cap)
 
 
 def _read_capped(path: str) -> str | None:
@@ -40,12 +45,20 @@ def _read_capped(path: str) -> str | None:
     return body
 
 
-def build_relevant_memory_reminder(memories: list[Any]) -> str | None:
+def build_relevant_memory_reminder_with_paths(
+    memories: list[Any],
+) -> tuple[str | None, list[str]]:
     """Wrap the surfaced memory bodies in a single ``<system-reminder>``.
 
-    ``memories`` is a list of ``RelevantMemory`` (``.path``). Returns None
-    when nothing readable was surfaced."""
+    ``memories`` is a list of ``RelevantMemory`` (``.path``). Returns
+    ``(reminder, surfaced_paths)`` — ``reminder`` is None when nothing
+    readable was surfaced, and ``surfaced_paths`` is EXACTLY the files that
+    made it into the reminder (fewer than ``memories`` when the R5 #4
+    aggregate cap trims the tail). The caller de-dups on ``surfaced_paths``,
+    NOT the full selection, so a capped-out memory can still surface later."""
     blocks: list[str] = []
+    surfaced: list[str] = []
+    total = 0
     for mem in memories:
         path = getattr(mem, "path", None) or (
             mem.get("path") if isinstance(mem, dict) else None
@@ -55,11 +68,22 @@ def build_relevant_memory_reminder(memories: list[Any]) -> str | None:
         body = _read_capped(str(path))
         if not body:
             continue
-        blocks.append(f"### {path}\n{body}")
+        block = f"### {path}\n{body}"
+        # R5 (ch11 #4) — stop once the aggregate turn cap is reached rather
+        # than injecting every selected file unbounded.
+        if total + len(block) > MAX_TOTAL_SURFACE_CHARS and blocks:
+            blocks.append(
+                "… (additional relevant memories omitted; Read the memory "
+                "directory for more)"
+            )
+            break
+        blocks.append(block)
+        surfaced.append(str(path))
+        total += len(block)
     if not blocks:
-        return None
+        return None, []
     joined = "\n\n".join(blocks)
-    return (
+    reminder = (
         "<system-reminder>\n"
         "The following saved memories were selected as relevant to the "
         "current request (recalled automatically from your memory "
@@ -69,6 +93,15 @@ def build_relevant_memory_reminder(memories: list[Any]) -> str | None:
         f"{joined}\n"
         "</system-reminder>"
     )
+    return reminder, surfaced
+
+
+def build_relevant_memory_reminder(memories: list[Any]) -> str | None:
+    """Back-compat wrapper: the reminder string only (drops the
+    surfaced-paths list). Prefer ``build_relevant_memory_reminder_with_paths``
+    so de-dup tracks exactly what was surfaced."""
+    reminder, _ = build_relevant_memory_reminder_with_paths(memories)
+    return reminder
 
 
 async def get_relevant_memory_reminder(
@@ -103,11 +136,11 @@ async def get_relevant_memory_reminder(
         return None
     if not memories:
         return None
-    reminder = build_relevant_memory_reminder(memories)
+    reminder, surfaced_paths = build_relevant_memory_reminder_with_paths(memories)
     if reminder is None:
         return None
-    for mem in memories:
-        path = getattr(mem, "path", None)
-        if path:
-            already_surfaced.add(str(path))
+    # R5 (ch11 #4) — de-dup ONLY the paths that actually made it into the
+    # reminder; a memory trimmed by the aggregate cap stays eligible.
+    for path in surfaced_paths:
+        already_surfaced.add(path)
     return reminder

--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -314,7 +314,10 @@ async def _maybe_recall_memories(
     memory_surfaced: set[str] | None,
 ) -> Message | None:
     """ch11 round-4 WI-1 — the gated memory-relevance recall. Returns a
-    <system-reminder> UserMessage to prepend, or None. Never raises."""
+    <system-reminder> UserMessage to APPEND after the user turn (not prepend
+    — TS surfaces memory after the user message, and normalize_messages
+    merges consecutive user messages so there is no 400), or None. Never
+    raises."""
     try:
         from src.settings.settings import get_settings
 

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -1329,6 +1329,13 @@ class _AgentSession:
                 custom_instructions=instr,
                 trigger="manual",
             )
+            # R5 round-5 (ch11 #3) — compaction drops the earlier conversation
+            # (and with it any memory the model had seen), so reset the
+            # recall de-dup set: memories surfaced pre-compaction become
+            # eligible again. Without this the monotonic set silently
+            # degrades recall on long sessions (a memory recalled once is
+            # never re-surfaced even after its context is compacted away).
+            self._memory_surfaced.clear()
             self._reply(request_id, {
                 "ok": True,
                 "tokens_saved": res.tokens_saved,

--- a/tests/test_r5_ch11_memory_enable_blockers.py
+++ b/tests/test_r5_ch11_memory_enable_blockers.py
@@ -1,0 +1,184 @@
+"""R5 round-5 (ch11) — memory-recall enable-blockers.
+
+Covers the 4 fixes that make the memory-relevance recall safe to enable:
+  #2 selector runs on the cheap small_fast_model when configured (not the
+     session Opus/DeepSeek model);
+  #3 the de-dup set resets on manual /compact (recall doesn't silently
+     degrade on long sessions);
+  #4 an aggregate per-turn byte cap on surfaced memory, and de-dup marks
+     ONLY the memories that actually made it into the reminder.
+"""
+from __future__ import annotations
+
+import asyncio
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+class _RelMem:
+    def __init__(self, path):
+        self.path = path
+
+
+class TestRecallModelPin(unittest.TestCase):
+    """#2 — the selector pins small_fast_model ONLY on a first-party
+    AnthropicProvider (critic M1: the default id is Anthropic-only)."""
+
+    def _run_select(self, small_fast_model, *, anthropic):
+        import importlib
+        frm = importlib.import_module("src.memdir.find_relevant_memories")
+        captured = {}
+
+        if anthropic:
+            from src.providers.anthropic_provider import AnthropicProvider
+
+            class _Provider(AnthropicProvider):
+                def __init__(self):
+                    super().__init__(api_key="k")
+
+                async def chat_async(self, messages, **kwargs):
+                    captured.update(kwargs)
+                    r = MagicMock(); r.content = '{"selected_memories": []}'
+                    return r
+        else:
+            class _Provider:  # non-Anthropic (e.g. DeepSeek/OpenAI)
+                async def chat_async(self, messages, **kwargs):
+                    captured.update(kwargs)
+                    r = MagicMock(); r.content = '{"selected_memories": []}'
+                    return r
+
+        settings = MagicMock()
+        settings.small_fast_model = small_fast_model
+        with patch("src.settings.settings.get_settings", return_value=settings):
+            asyncio.run(frm._select_with_provider(
+                "q", [], provider=_Provider(),
+                recent_tools=(), cancel_event=asyncio.Event(),
+            ))
+        return captured
+
+    def test_anthropic_session_pins_model(self):
+        captured = self._run_select("claude-3-5-haiku-20241022", anthropic=True)
+        self.assertEqual(captured.get("model"), "claude-3-5-haiku-20241022")
+
+    def test_anthropic_unset_omits_model(self):
+        captured = self._run_select("", anthropic=True)
+        self.assertNotIn("model", captured)  # → session model
+
+    def test_non_anthropic_never_pins_even_when_set(self):
+        # critic M1: the Anthropic-default id must NOT reach a non-Anthropic
+        # endpoint (would 400 → silent no-recall). → session model.
+        captured = self._run_select("claude-3-5-haiku-20241022", anthropic=False)
+        self.assertNotIn("model", captured)
+
+    def test_resolve_recall_model_none_on_settings_error(self):
+        from src.memdir.find_relevant_memories import _resolve_recall_model
+        from src.providers.anthropic_provider import AnthropicProvider
+        p = AnthropicProvider(api_key="k")
+        with patch("src.settings.settings.get_settings",
+                   side_effect=RuntimeError("boom")):
+            self.assertIsNone(_resolve_recall_model(p))
+
+
+class TestAggregateByteCap(unittest.TestCase):
+    """#4 — the turn's total surfaced bytes are capped, and de-dup tracks
+    only what was actually surfaced."""
+
+    def _write(self, tmp, name, kb):
+        p = Path(tmp) / name
+        p.write_text("x" * (kb * 1024), encoding="utf-8")
+        return str(p)
+
+    def test_total_cap_trims_tail_and_reports_surfaced(self):
+        from src.memdir import surface_memories as sm
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            # Each file is per-file-capped at 4 KB; 5 of them would be ~20 KB,
+            # over the 12 KB aggregate cap → only the first few survive.
+            mems = [_RelMem(self._write(tmp, f"m{i}.md", 5)) for i in range(5)]
+            reminder, surfaced = sm.build_relevant_memory_reminder_with_paths(mems)
+
+        self.assertIsNotNone(reminder)
+        self.assertLess(len(surfaced), 5)  # tail trimmed
+        self.assertIn("omitted", reminder)
+        # Every surfaced path is present in the reminder; trimmed ones are not.
+        for p in surfaced:
+            self.assertIn(p, reminder)
+
+    def test_dedup_marks_only_surfaced_not_full_selection(self):
+        from src.memdir import surface_memories as sm
+        import tempfile
+
+        async def _go():
+            with tempfile.TemporaryDirectory() as tmp:
+                mems = [_RelMem(self._write(tmp, f"m{i}.md", 5)) for i in range(5)]
+
+                async def _fake_find(*a, **k):
+                    return mems
+
+                surfaced_set: set[str] = set()
+                with patch(
+                    "src.memdir.find_relevant_memories.find_relevant_memories",
+                    _fake_find,
+                ):
+                    await sm.get_relevant_memory_reminder(
+                        "q", tmp, provider=MagicMock(),
+                        already_surfaced=surfaced_set,
+                    )
+                return surfaced_set, [m.path for m in mems]
+
+        surfaced_set, all_paths = asyncio.run(_go())
+        # Fewer than all selected are de-dup-marked (the capped-out tail
+        # stays eligible for a later turn).
+        self.assertLess(len(surfaced_set), len(all_paths))
+        self.assertTrue(surfaced_set)
+
+    def test_backcompat_string_wrapper(self):
+        from src.memdir.surface_memories import build_relevant_memory_reminder
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "a.md"
+            p.write_text("hello memory", encoding="utf-8")
+            r = build_relevant_memory_reminder([_RelMem(str(p))])
+        self.assertIsInstance(r, str)
+        self.assertIn("hello memory", r)
+
+
+class TestDedupResetOnCompact(unittest.TestCase):
+    """#3 — manual /compact clears the recall de-dup set."""
+
+    def test_compact_clears_memory_surfaced(self):
+        from src.server.agent_server import AgentServerConfig, _AgentSession
+
+        sess = _AgentSession(
+            session_id="s1", cwd="/tmp",
+            config=AgentServerConfig(single_session=True),
+            loop=MagicMock(), out_queue=MagicMock(),
+        )
+        sess._memory_surfaced.update({"/mem/a.md", "/mem/b.md"})
+        sess._emit = lambda e: None
+        sess._reply = lambda rid, payload: None
+        sess._current_abort = None  # idle → compaction allowed
+
+        # Stub the conversation + compaction so _do_compact reaches success.
+        sess.session = MagicMock()
+        res = MagicMock(tokens_saved=10, pre_compact_count=5, post_compact_count=1)
+
+        async def _fake_compact(*a, **k):
+            return res
+
+        with patch("src.compact_service.service.compact_conversation", _fake_compact), \
+                patch("src.hooks.session_hooks.run_compact_hooks",
+                      new=_async_noop):
+            asyncio.run(sess._do_compact("r1", None))
+
+        self.assertEqual(sess._memory_surfaced, set())  # reset
+
+
+async def _async_noop(*a, **k):
+    return []
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Round-5 R5-1 (ch11): memory-recall enable-blockers

**Docs:** `my-docs/port-improvement-round-5/r5-1-ch11-memory-enable-blockers.md` + critic verdicts (REVISE→APPROVE).

The round-4 LLM memory-relevance recall (#594) ships **default-off** because flipping it on is a latency + cost + correctness regression. This fixes the four blockers the round-4 critic flagged, so the flag is safe to enable. Still default-off — zero behavior change on merge.

### #2 — selector cost (provider-gated pin)

The recall side-query ran on the **session** model, so an Opus turn paid full price every turn. TS pins the selector to a small default (`getDefaultSonnetModel`). The port wires the `small_fast_model` setting — but its shipped default is an **Anthropic** id (`claude-3-5-haiku-20241022`), valid only on the first-party Anthropic endpoint. So `_resolve_recall_model(provider)` applies the pin **only when the session provider is a first-party `AnthropicProvider`**; every other provider — Minimax (Anthropic SDK, different endpoint), DeepSeek, OpenAI, OpenRouter — falls back to the session model. Without the gate the Anthropic default id would 400 on a non-Anthropic endpoint and — since recall swallows errors — silently kill recall every turn (critic M1). A future `small_fast_model_provider` pairing (mirroring `advisor_model`/`advisor_provider`) would let non-Anthropic sessions pin a cheap recall model — deferred.

### #3 — de-dup reset on compaction

The recall reminder is ephemeral, but the session-scoped `_memory_surfaced` set was monotonic: once surfaced, a memory was never re-surfaced. On a long session that runs `/compact`, the earlier context (where the model saw that memory) is dropped, yet the memory stayed suppressed. `_do_compact` now clears `_memory_surfaced` on success → pre-compaction memories become eligible again. Idle-gated, so no race with the turn worker.

### #4 — aggregate turn byte-cap

Per-file was capped at 4 KB but 5 selections could inject ~20 KB/turn. `build_relevant_memory_reminder_with_paths` stops at `MAX_TOTAL_SURFACE_CHARS=12 KB` and appends an "omitted" note. Critically it returns the paths **actually surfaced**, and `get_relevant_memory_reminder` de-dups **only those** — so a memory trimmed by the cap stays eligible next turn instead of being suppressed forever (the old "mark all selected" was a latent suppress-forever bug that the cap would have activated). Old `build_relevant_memory_reminder` kept as a back-compat string wrapper.

### #5 — docstring

`_maybe_recall_memories` said "prepend"; the code appends after the user turn (correct — TS surfaces memory after the user message; `normalize_messages` merges consecutive user messages). Wording fixed.

### Deferred

**#1 (latency)** — the recall is `await`ed once per turn before the loop; TS hides the latency by overlapping it with other prefetches. The port has only this one prefetch (no overlap without a larger prompt-submit refactor), so it stays synchronous — one small-model call per turn (a fast Haiku one on the default Anthropic path). Documented.

### Verification

`tests/test_r5_ch11_memory_enable_blockers.py` (8): Anthropic session pins the model / unset omits it / **non-Anthropic never pins even when the Anthropic-default id is set** (the M1 regression guard) / settings-error → None; aggregate cap trims the tail + reports surfaced; de-dup marks only surfaced (not the full selection); back-compat string wrapper; `/compact` clears `_memory_surfaced`. Existing memory suite (466) green via the back-compat wrapper. Full suite at the pre-existing 9-failure baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
