### PR TITLE
feat(r5-2/ch17): port getDateChangeAttachments (midnight-rollover companion)

### DIFF
--- a/src/context_system/date_change.py
+++ b/src/context_system/date_change.py
@@ -1,0 +1,78 @@
+"""R5 round-5 (ch17) — the date-change (midnight-rollover) companion.
+
+Port of TS ``getDateChangeAttachments`` (``utils/attachments.ts:1416-1444``).
+
+The ``# Environment`` block's date is memoized at session start (round-4 ch17,
+for prompt-cache stability): the cached prefix keeps the START date so midnight
+doesn't bust ~190K cached tokens. The trade-off is a stale date after midnight.
+This companion recovers it: on the first turn after the date rolls over, append
+a ``<system-reminder>`` at the conversation TAIL (never the cached prefix)
+telling the model today's date. Cheap — a date comparison per turn, emitting
+only on rollover.
+
+The last-emitted date lives in the process-global bootstrap state
+(``last_emitted_date``), matching TS's module-level ``getLastEmittedDate``. For
+the shipped single-session ``--stdio`` interactive lane this is exactly right;
+under multi-session ``--http`` the date is a shared wall-clock value, so only
+the first session to observe the rollover emits the reminder (a benign
+divergence noted for a future per-session refinement).
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+def _current_date_iso() -> str:
+    """Today's local date, ``YYYY-MM-DD`` — LIVE (not the memoized session
+    date). This is the value that changes at midnight and drives the check.
+
+    Note: like the memoized env date (``prompt_assembly._get_session_start_
+    date_iso``), this does NOT honor TS's ``CLAUDE_CODE_OVERRIDE_DATE`` test
+    override — since BOTH ignore it they use the same real wall clock and
+    can't disagree (no spurious rollover). A pre-existing ch17 parity gap for
+    a future sweep."""
+    return datetime.now().strftime("%Y-%m-%d")
+
+
+def get_date_change_reminder() -> str | None:
+    """Return a ``<system-reminder>`` notifying the model that the date rolled
+    over, or None. Records the current date on the first call (no reminder)
+    and whenever it changes. Mirrors TS ``getDateChangeAttachments``:
+
+    - last == None  → first turn: record, emit nothing.
+    - current == last → no change: emit nothing.
+    - current != last → rollover: record + emit the new-date reminder.
+
+    Never raises (a bad clock/state read must not block a turn)."""
+    try:
+        from src.bootstrap.state import (
+            get_last_emitted_date,
+            set_last_emitted_date,
+        )
+
+        current = _current_date_iso()
+        last = get_last_emitted_date()
+        if last is None:
+            set_last_emitted_date(current)
+            return None
+        if current == last:
+            return None
+        set_last_emitted_date(current)
+        # Exact TS text (messages.ts:4177) — the "DO NOT mention this to the
+        # user" clause is a load-bearing behavioral guard (stops the model
+        # from announcing the rollover). The reconciliation hint is appended
+        # after it (the env block's date is memoized at session start).
+        return (
+            "<system-reminder>\n"
+            f"The date has changed. Today's date is now {current}. DO NOT "
+            "mention this to the user explicitly because they are already "
+            "aware. (The date in the environment context above was captured "
+            "at session start and is now stale; use this one.)\n"
+            "</system-reminder>"
+        )
+    except Exception:  # noqa: BLE001 — a date-change check must not block a turn
+        logger.debug("date-change reminder failed", exc_info=True)
+        return None

--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -456,6 +456,25 @@ async def run_query_as_agent_loop(
         logging.getLogger(__name__).debug("memory recall wiring failed",
                                           exc_info=True)
 
+    # R5 round-5 (ch17) — date-change (midnight-rollover) companion to the
+    # memoized env date. On a real turn where the date has rolled over since
+    # the last, append a <system-reminder> with today's date at the tail (the
+    # cached prefix keeps the memoized start date, so this doesn't bust it).
+    # Reuses the "real user turn" gate (memory_recall_enabled == not internal).
+    if memory_recall_enabled:
+        try:
+            from src.context_system.date_change import get_date_change_reminder
+            from src.types.messages import create_user_message
+
+            dc = get_date_change_reminder()
+            if dc:
+                messages_for_query.append(
+                    create_user_message(content=dc, isMeta=True)
+                )
+        except Exception:  # noqa: BLE001 — must never block a turn
+            logging.getLogger(__name__).debug("date-change wiring failed",
+                                              exc_info=True)
+
     params = QueryParams(
         messages=messages_for_query,
         system_prompt=system_prompt,

--- a/tests/test_r5_ch17_date_change_round5.py
+++ b/tests/test_r5_ch17_date_change_round5.py
@@ -1,0 +1,145 @@
+"""R5 round-5 (ch17) — date-change (midnight-rollover) companion.
+
+Port of TS getDateChangeAttachments: the memoized env date stays cache-stable,
+and this appends a tail <system-reminder> with today's date on rollover so a
+multi-day session isn't stuck showing the session-start date.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+import src.context_system.date_change as dc
+from src.bootstrap.state import get_last_emitted_date, set_last_emitted_date
+
+
+class TestDateChangeReminder(unittest.TestCase):
+    def setUp(self):
+        set_last_emitted_date(None)
+
+    def tearDown(self):
+        set_last_emitted_date(None)
+
+    def test_first_turn_records_no_reminder(self):
+        with patch.object(dc, "_current_date_iso", return_value="2026-07-02"):
+            r = dc.get_date_change_reminder()
+        self.assertIsNone(r)
+        self.assertEqual(get_last_emitted_date(), "2026-07-02")
+
+    def test_same_day_no_reminder(self):
+        set_last_emitted_date("2026-07-02")
+        with patch.object(dc, "_current_date_iso", return_value="2026-07-02"):
+            r = dc.get_date_change_reminder()
+        self.assertIsNone(r)
+
+    def test_rollover_emits_and_records(self):
+        set_last_emitted_date("2026-07-02")
+        with patch.object(dc, "_current_date_iso", return_value="2026-07-03"):
+            r = dc.get_date_change_reminder()
+        self.assertIsNotNone(r)
+        self.assertIn("2026-07-03", r)
+        self.assertIn("<system-reminder>", r)
+        # critic MAJOR: the TS "DO NOT mention" behavioral guard must be present.
+        self.assertIn("DO NOT mention this to the user", r)
+        self.assertEqual(get_last_emitted_date(), "2026-07-03")
+
+    def test_only_emits_once_per_rollover(self):
+        set_last_emitted_date("2026-07-02")
+        with patch.object(dc, "_current_date_iso", return_value="2026-07-03"):
+            first = dc.get_date_change_reminder()
+            second = dc.get_date_change_reminder()
+        self.assertIsNotNone(first)
+        self.assertIsNone(second)  # recorded → no re-emit same day
+
+    def test_never_raises_on_state_error(self):
+        with patch("src.bootstrap.state.get_last_emitted_date",
+                   side_effect=RuntimeError("boom")):
+            self.assertIsNone(dc.get_date_change_reminder())
+
+    def test_current_date_is_live_date_only(self):
+        # It must be a live date-only string (not the memoized session date,
+        # not a per-second timestamp).
+        val = dc._current_date_iso()
+        self.assertRegex(val, r"^\d{4}-\d{2}-\d{2}$")
+
+
+class TestLoopWiring(unittest.TestCase):
+    def test_rollover_reminder_appended_on_real_turn(self):
+        # Drives the agent-loop seam: a rollover appends a meta user message
+        # to the query WORKING set (params.messages), not the persisted
+        # conversation. We mock query() as an async generator that captures
+        # what it received and stops the loop.
+        import asyncio
+        from unittest.mock import MagicMock
+        from src.query import agent_loop_compat as alc
+
+        appended: list = []
+
+        async def _capture_query(params, **kwargs):
+            appended.extend(params.messages)
+            raise _StopLoop()
+            yield  # noqa — unreachable; makes this an async generator
+
+        async def _fake_recall(*a, **k):
+            return None
+
+        set_last_emitted_date("2026-07-02")
+        with patch.object(alc, "_maybe_recall_memories", _fake_recall), \
+                patch("src.context_system.date_change._current_date_iso",
+                      return_value="2026-07-03"), \
+                patch.object(alc, "query", _capture_query):
+            try:
+                asyncio.run(alc.run_query_as_agent_loop(
+                    initial_messages=[{"role": "user", "content": "hi"}],
+                    provider=MagicMock(),
+                    tool_registry=MagicMock(list_tools=lambda: []),
+                    tool_context=MagicMock(),
+                    memory_recall_enabled=True,
+                ))
+            except _StopLoop:
+                pass
+
+        self.assertTrue(
+            any("2026-07-03" in str(getattr(m, "content", m)) for m in appended),
+            "date-change reminder should be in the query working set",
+        )
+
+    def test_no_reminder_on_internal_turn(self):
+        # internal/notification turns (memory_recall_enabled=False) must NOT
+        # get the date-change reminder.
+        import asyncio
+        from unittest.mock import MagicMock
+        from src.query import agent_loop_compat as alc
+
+        appended: list = []
+
+        async def _capture_query(params, **kwargs):
+            appended.extend(params.messages)
+            raise _StopLoop()
+            yield
+
+        set_last_emitted_date("2026-07-02")
+        with patch("src.context_system.date_change._current_date_iso",
+                   return_value="2026-07-03"), \
+                patch.object(alc, "query", _capture_query):
+            try:
+                asyncio.run(alc.run_query_as_agent_loop(
+                    initial_messages=[{"role": "user", "content": "hi"}],
+                    provider=MagicMock(),
+                    tool_registry=MagicMock(list_tools=lambda: []),
+                    tool_context=MagicMock(),
+                    memory_recall_enabled=False,
+                ))
+            except _StopLoop:
+                pass
+
+        self.assertFalse(
+            any("2026-07-03" in str(getattr(m, "content", m)) for m in appended))
+
+
+class _StopLoop(Exception):
+    pass
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Round-5 R5-2 (ch17): midnight-rollover date-change companion

Round-4 ch17 (#600) memoized the `# Environment` date for prompt-cache stability (the cached prefix keeps the session-START date so midnight doesn't bust ~190K tokens). The round-4 critic flagged the missing companion — TS pairs the memoized date with `getDateChangeAttachments` (`utils/attachments.ts:1416-1444`), appending the corrected date at the conversation **tail** on rollover so a multi-day session isn't stuck showing the start date. The port had the dead scaffolding (`bootstrap/state.last_emitted_date`, zero callers).

- **NEW `src/context_system/date_change.py`** — faithful three-branch port (`last==None`→record; `current==last`→nothing; `current!=last`→record+emit). `_current_date_iso()` is the LIVE date-only value (distinct from the memoized `_get_session_start_date_iso`). The reminder uses the **exact TS text** including the load-bearing guard *"DO NOT mention this to the user explicitly because they are already aware"* (critic MAJOR), plus a reconciliation hint. Never raises.
- **Wired** at the agent-loop recall seam on real turns only (`memory_recall_enabled == not internal`) — appended as a meta user message to the query **working set** (ephemeral, tail, never the cached prefix, never persisted). The env block (memoized start date) is **unchanged** — the cache-stability win stands.

**Tests:** `tests/test_r5_ch17_date_change_round5.py` (8): three branches, once-per-rollover, never-raises, live-date format, the TS guard-clause assertion, loop-wiring (rollover appends on a real turn; internal turn does NOT). Full suite at the pre-existing baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
