### PR TITLE
feat(r5-4/ch15): MCP tools/list_changed refresh correctness (m1/m2/m3)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -2135,12 +2135,20 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
                         _cl.set_elicitation_handler(_eh)
                     except Exception:  # noqa: BLE001
                         pass
+                    # R5 (ch15 m3) — only wire the tools/list_changed refresh
+                    # for servers that ADVERTISE tools.listChanged, mirroring
+                    # TS (useManageMCPConnections registers the handler only
+                    # when client.capabilities.tools.listChanged). This makes
+                    # the parsed capability load-bearing; a server that never
+                    # advertised it can't trigger a refresh.
                     try:
-                        _cl.set_notification_handler(
-                            _make_mcp_notification_handler(
-                                mcp_rt, sess, _srv_name
+                        _caps = getattr(_cl, "capabilities", None)
+                        if getattr(_caps, "tools_list_changed", False):
+                            _cl.set_notification_handler(
+                                _make_mcp_notification_handler(
+                                    mcp_rt, sess, _srv_name
+                                )
                             )
-                        )
                     except Exception:  # noqa: BLE001
                         pass
                 logger.info(

--- a/src/server/mcp_runtime.py
+++ b/src/server/mcp_runtime.py
@@ -157,12 +157,24 @@ class McpRuntime:
         """
         from src.services.mcp.mcp_string_utils import build_mcp_tool_name
 
-        prefix = build_mcp_tool_name(name, "")  # "mcp__{name}__"
-        removed_full = [t.name for t in self.tools
-                        if getattr(t, "name", "").startswith(prefix)]
-        self.tools = [t for t in self.tools
-                      if not getattr(t, "name", "").startswith(prefix)]
+        # R5 (ch15 m2) — derive the removed set from THIS server's KNOWN tool
+        # names, not a ``startswith("mcp__{name}__")`` prefix. A sibling
+        # server whose name normalizes to share the prefix (e.g. "foo, bar"
+        # → mcp__foo__bar__…, which startswith mcp__foo__) would be wrongly
+        # captured and nuked when refreshing "foo".
+        removed_full = [
+            build_mcp_tool_name(name, t) for t in self.servers.get(name, [])
+        ]
+        # R5 (ch15 m1) — build the new wrapped tools BEFORE mutating
+        # self.tools, so a _wrap failure leaves the current tool list intact.
+        # (Was remove-then-build: a mid-build failure truncated self.tools AND
+        # was swallowed on the discarded future, leaving the server's tools
+        # gone with no refresh.)
         new_tools = [self._wrap(name, mt, client) for mt in new_raw]
+        removed_set = set(removed_full)
+        self.tools = [
+            t for t in self.tools if getattr(t, "name", "") not in removed_set
+        ]
         self.tools.extend(new_tools)
         self.servers[name] = [t.name for t in new_raw]
         return removed_full, new_tools

--- a/src/services/mcp/client.py
+++ b/src/services/mcp/client.py
@@ -41,6 +41,28 @@ from .types import (
 
 logger = logging.getLogger(__name__)
 
+
+def _parse_server_capabilities(caps: Any) -> ServerCapabilities:
+    """Parse the ``capabilities`` object from an MCP ``initialize`` result.
+
+    Factored out of ``connect()`` so the nested ``tools.listChanged`` parse —
+    which the ch15 list_changed refresh wiring gates on — is directly
+    testable. ``tools``/``prompts``/``resources`` collapse to a bool
+    (present-or-not); ``tools_list_changed`` is the nested
+    ``{tools: {listChanged: true}}`` sub-flag."""
+    if not isinstance(caps, dict):
+        caps = {}
+    tools_cap = caps.get("tools")
+    return ServerCapabilities(
+        tools=bool(tools_cap),
+        prompts=bool(caps.get("prompts")),
+        resources=bool(caps.get("resources")),
+        tools_list_changed=bool(
+            isinstance(tools_cap, dict) and tools_cap.get("listChanged")
+        ),
+    )
+
+
 # Tool-call timeout: 5 minutes default, mirrors TS canonical
 # (typescript/src/services/mcp/client.ts:DEFAULT_MCP_TOOL_TIMEOUT_MS = 300_000).
 # Operators raise via the MCP_TOOL_TIMEOUT env override when a long-running
@@ -245,16 +267,8 @@ class McpClient:
             )
 
             if init_result and isinstance(init_result, dict):
-                caps = init_result.get("capabilities", {})
-                _tools_cap = caps.get("tools")
-                self._capabilities = ServerCapabilities(
-                    tools=bool(_tools_cap),
-                    prompts=bool(caps.get("prompts")),
-                    resources=bool(caps.get("resources")),
-                    tools_list_changed=bool(
-                        isinstance(_tools_cap, dict)
-                        and _tools_cap.get("listChanged")
-                    ),
+                self._capabilities = _parse_server_capabilities(
+                    init_result.get("capabilities", {})
                 )
                 server_info_raw = init_result.get("serverInfo")
                 if server_info_raw and isinstance(server_info_raw, dict):

--- a/tests/test_r5_ch15_mcp_refresh_correctness.py
+++ b/tests/test_r5_ch15_mcp_refresh_correctness.py
@@ -1,0 +1,155 @@
+"""R5 round-5 (ch15) — MCP refresh correctness (m1/m2/m3).
+
+m1: _apply_refreshed_tools builds new tools BEFORE mutating self.tools, so a
+    _wrap failure leaves the current tools intact (was: truncate-then-fail).
+m2: the removed set is derived from self.servers[name], not a prefix match,
+    so a sibling server sharing the prefix isn't wrongly captured.
+m3: the tools/list_changed handler is wired only for clients that ADVERTISE
+    tools.listChanged.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from src.services.mcp.mcp_string_utils import build_mcp_tool_name
+
+
+def _wrapped(server, tool_name):
+    t = MagicMock()
+    t.name = build_mcp_tool_name(server, tool_name)
+    return t
+
+
+def _raw(name):
+    r = MagicMock(); r.name = name
+    return r
+
+
+def _rt():
+    from src.server.mcp_runtime import McpRuntime
+    rt = McpRuntime()
+    rt._wrap = lambda server, mt, client: _wrapped(server, mt.name)
+    return rt
+
+
+class TestBuildBeforeSwap(unittest.TestCase):
+    """m1 — a _wrap failure must not truncate self.tools."""
+
+    def test_wrap_failure_leaves_tools_intact(self):
+        rt = _rt()
+        rt.tools = [_wrapped("srv", "a"), _wrapped("other", "keep")]
+        rt.servers = {"srv": ["a"], "other": ["keep"]}
+
+        def _boom(server, mt, client):
+            raise RuntimeError("wrap failed")
+        rt._wrap = _boom
+
+        with self.assertRaises(RuntimeError):
+            rt._apply_refreshed_tools("srv", [_raw("new_a")], MagicMock())
+
+        # self.tools untouched — the old srv tool + other server survive.
+        names = sorted(t.name for t in rt.tools)
+        self.assertEqual(names, ["mcp__other__keep", "mcp__srv__a"])
+        self.assertEqual(rt.servers["srv"], ["a"])  # not clobbered
+
+
+class TestNoSiblingCapture(unittest.TestCase):
+    """m2 — refreshing "foo" must not nuke a sibling whose prefix overlaps."""
+
+    def test_prefix_sibling_not_removed(self):
+        rt = _rt()
+        # "foo" server + a sibling registered as "foo__bar" (normalized from
+        # e.g. "foo, bar") whose full tool names startswith "mcp__foo__".
+        rt.tools = [
+            _wrapped("foo", "x"),          # mcp__foo__x
+            _wrapped("foo__bar", "y"),     # mcp__foo__bar__y  (startswith mcp__foo__)
+        ]
+        rt.servers = {"foo": ["x"], "foo__bar": ["y"]}
+
+        removed, new_tools = rt._apply_refreshed_tools(
+            "foo", [_raw("x2")], MagicMock())
+
+        # Only foo's own tool is removed; the sibling survives.
+        self.assertEqual(removed, ["mcp__foo__x"])
+        names = sorted(t.name for t in rt.tools)
+        self.assertEqual(names, ["mcp__foo__bar__y", "mcp__foo__x2"])
+
+
+class TestCapabilityGatedWiring(unittest.TestCase):
+    """m3 — the list_changed handler is wired only when advertised."""
+
+    def _run_wiring(self, advertises):
+        # Reproduce the agent_server wiring predicate (the load-bearing
+        # condition), since driving full _build_runtime is heavy.
+        cl = MagicMock()
+        caps = MagicMock()
+        caps.tools_list_changed = advertises
+        cl.capabilities = caps
+        wired = {"called": False}
+        cl.set_notification_handler = lambda h: wired.__setitem__("called", True)
+
+        _caps = getattr(cl, "capabilities", None)
+        if getattr(_caps, "tools_list_changed", False):
+            cl.set_notification_handler(lambda m, p: None)
+        return wired["called"]
+
+    def test_wired_when_advertised(self):
+        self.assertTrue(self._run_wiring(True))
+
+    def test_not_wired_when_not_advertised(self):
+        self.assertFalse(self._run_wiring(False))
+
+    def test_nested_listchanged_parsed_from_init_result(self):
+        # critic minor: the m3 gate hinges on parsing {tools:{listChanged:true}}
+        # from the real init capabilities — pin the TRUE and FALSE cases on the
+        # actual parse function (not just the dataclass constructor).
+        from src.services.mcp.client import _parse_server_capabilities
+
+        adv = _parse_server_capabilities({"tools": {"listChanged": True}})
+        self.assertTrue(adv.tools_list_changed)
+        self.assertTrue(adv.tools)  # tools present
+
+        # listChanged absent → False (must NOT wire refresh). The m3 gate
+        # cares only about tools_list_changed. (Note: an empty {} tools cap
+        # collapses tools→False under the existing bool() parse — a
+        # pre-existing quirk, unchanged here and orthogonal to m3.)
+        no_lc = _parse_server_capabilities({"tools": {"other": 1}})
+        self.assertFalse(no_lc.tools_list_changed)
+        self.assertTrue(no_lc.tools)  # non-empty dict → tools present
+
+        # bare truthy tools (not a dict) → False.
+        bare = _parse_server_capabilities({"tools": True})
+        self.assertFalse(bare.tools_list_changed)
+
+        # missing / malformed caps → all False, no raise.
+        self.assertFalse(_parse_server_capabilities({}).tools_list_changed)
+        self.assertFalse(_parse_server_capabilities(None).tools_list_changed)
+
+    def test_capability_property_exposed(self):
+        # The gate reads client.capabilities.tools_list_changed — confirm the
+        # client exposes it (parsed at connect from the nested listChanged).
+        from src.services.mcp.client import McpClient
+        c = McpClient()
+        self.assertTrue(hasattr(c.capabilities, "tools_list_changed"))
+
+    def test_agent_server_wiring_gates_on_capability(self):
+        # Source-level guard: the REAL wiring in agent_server must gate
+        # set_notification_handler on tools_list_changed (so this can't
+        # silently regress to unconditional wiring). Mirrors the ch10
+        # sweeper-ordering guard approach.
+        import inspect
+        import re
+        from src.server import agent_server
+
+        src = inspect.getsource(agent_server)
+        # The set_notification_handler call must be preceded by a
+        # tools_list_changed capability check within the same wiring block.
+        idx = src.index("set_notification_handler")
+        window = src[max(0, idx - 400):idx]
+        self.assertIn("tools_list_changed", window,
+                      "notification handler wiring must be capability-gated")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Round-5 R5-4 (ch15): MCP tools/list_changed refresh correctness

Fix the three non-gating leftovers the round-4 ch15 critic flagged:

- **m1 build-new-before-swap** (`_apply_refreshed_tools`): round-4 removed old tools then built new; a `_wrap` failure truncated `self.tools` and was swallowed. Now new tools are built first; a failure leaves the list intact.
- **m2 no sibling capture**: the removed set is derived from `self.servers[name]` (exact-name membership), not a `startswith("mcp__{name}__")` prefix — so refreshing `foo` no longer nukes a sibling `foo__bar` whose full names share the prefix.
- **m3 capability-gated wiring**: `set_notification_handler` is wired only for clients that advertise `tools.listChanged` (TS-faithful), making the parsed `ServerCapabilities.tools_list_changed` load-bearing.

Also factored the init-capabilities parse into a testable `_parse_server_capabilities()` (behavior-identical) with positive coverage (critic minor).

**Tests:** `tests/test_r5_ch15_mcp_refresh_correctness.py` (7) + R4 ch15 (11) + mcp_client_full (24) green. Full suite at the pre-existing baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
