### PR TITLE
fix(r5-6): round-5 final-verdict polish (effort-mode recall pin, killed status)

### DIFF
--- a/src/memdir/find_relevant_memories.py
+++ b/src/memdir/find_relevant_memories.py
@@ -38,14 +38,17 @@ def _resolve_recall_model(provider: Any) -> str | None:
     settings/constants.py), which is only valid on the first-party Anthropic
     endpoint. Passing it to a DeepSeek/OpenAI/Minimax session would 400 and
     (since recall swallows errors) silently kill recall every turn (critic
-    M1). So the pin applies ONLY when the SESSION provider is a first-party
+    M1). So the pin applies ONLY when the SESSION provider is an
     ``AnthropicProvider``; every other provider (incl. Minimax, which runs
     the Anthropic SDK against a different endpoint) falls back to the session
     model. Returns None to signal that fallback. Never raises.
 
-    (A future ``small_fast_model_provider`` pairing — mirroring
-    ``advisor_model``/``advisor_provider`` — would let non-Anthropic sessions
-    pin their own cheap recall model; deferred.)"""
+    Note: ``AnthropicProvider`` also covers a custom ``ANTHROPIC_BASE_URL`` /
+    Bedrock-shim / proxy endpoint that might itself reject the Haiku id — in
+    that case the selector 400s and recall safe-degrades to no-recall (same
+    swallow-to-None path), narrower than the cross-provider M1. The real fix
+    for both is a future ``small_fast_model_provider`` pairing (mirroring
+    ``advisor_model``/``advisor_provider``); deferred."""
     try:
         from src.providers.anthropic_provider import AnthropicProvider
 

--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -329,6 +329,14 @@ async def _maybe_recall_memories(
     query_text = _last_user_text(messages)
     if not query_text.strip():
         return None
+    # R5 (ch11 N1) — unwrap /effort's _EffortProvider so the recall SELECTOR
+    # runs on the raw provider: (a) _resolve_recall_model's
+    # isinstance(AnthropicProvider) check sees through the wrapper → the
+    # small_fast_model cost pin applies in effort mode too (it was bypassed —
+    # a bare wrapper class isn't an AnthropicProvider); (b) the wrapper's
+    # reasoning_effort injection doesn't leak into the cheap selector call.
+    # Safe: _inner is _EffortProvider-exclusive, so this is a no-op otherwise.
+    provider = getattr(provider, "_inner", provider)
     try:
         from src.memdir import get_auto_mem_path
         from src.memdir.surface_memories import get_relevant_memory_reminder

--- a/src/tool_system/tools/agent.py
+++ b/src/tool_system/tools/agent.py
@@ -644,10 +644,24 @@ def make_agent_tool(
                     # Round-4 wired terminal progress for SYNC only; async
                     # finished via enqueue_agent_notification alone, so the
                     # HUD lingered "running" until the end-of-turn flush.
+                    # Report the AUTHORITATIVE runtime status, not a hardcoded
+                    # "completed". A concurrent kill marks the task terminal
+                    # "killed" in the registry; when this success branch runs
+                    # (on natural completion — local async agents don't yet
+                    # wire abort_event, so the run finishes normally — or a
+                    # cooperative stop where wired), complete_agent_task
+                    # no-ops on that terminal state (local_agent.py:287), so
+                    # the registry status stays "killed" and the HUD should
+                    # say so (the ui-tui mapping handles killed).
+                    _st = context.runtime_tasks.get(agent_id)
+                    _final_status = (
+                        str(getattr(_st, "status", "completed"))
+                        if _st is not None else "completed"
+                    )
                     _emit_terminal_agent_progress(
                         context, agent_id=agent_id, name=agent_name,
                         description=description, subagent_type=agent_type,
-                        status="completed",
+                        status=_final_status,
                     )
                     # Chunk D / WI-3.1 + WI-3.2 — enqueue a single
                     # ``<task-notification>`` envelope. Atomic check-and-

--- a/tests/test_r5_final_verdict_polish.py
+++ b/tests/test_r5_final_verdict_polish.py
@@ -1,0 +1,130 @@
+"""R5 final-verdict polish — the non-blocking nits the round-5 critics flagged
+in their APPROVE verdicts:
+
+  N1 (r5-1): /effort's _EffortProvider wrapper made the recall cost-pin's
+     isinstance(AnthropicProvider) check False → pin bypassed in effort mode.
+     Now the recall selector unwraps _inner first.
+  KILLED (r5-3): the async terminal agent_progress hardcoded "completed"; a
+     KILLED subagent should report "killed".
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
+
+
+class TestEffortProviderUnwrapForRecall(unittest.TestCase):
+    """N1 — the /effort wrapper no longer hides the AnthropicProvider from the
+    recall cost-pin."""
+
+    def test_wrapped_bypasses_pin_unwrapped_restores_it(self):
+        from src.memdir.find_relevant_memories import _resolve_recall_model
+        from src.providers.anthropic_provider import AnthropicProvider
+        from src.server.agent_server import _EffortProvider
+
+        wrapped = _EffortProvider(AnthropicProvider(api_key="k"), "high")
+        settings = MagicMock()
+        settings.small_fast_model = "claude-3-5-haiku-20241022"
+
+        with patch("src.settings.settings.get_settings", return_value=settings):
+            # The wrapper is NOT an AnthropicProvider → the bug: no pin.
+            self.assertIsNone(_resolve_recall_model(wrapped))
+            # Unwrapped (what _maybe_recall_memories now does first) → pin.
+            unwrapped = getattr(wrapped, "_inner", wrapped)
+            self.assertEqual(_resolve_recall_model(unwrapped),
+                             "claude-3-5-haiku-20241022")
+
+    def test_maybe_recall_unwraps_effort_provider(self):
+        # Drive _maybe_recall_memories with a wrapped provider and capture the
+        # provider that reaches the recall — it must be the UNWRAPPED inner.
+        from src.providers.anthropic_provider import AnthropicProvider
+        from src.query import agent_loop_compat as alc
+        from src.server.agent_server import _EffortProvider
+
+        inner = AnthropicProvider(api_key="k")
+        wrapped = _EffortProvider(inner, "high")
+        captured = {}
+
+        async def _fake_reminder(query, memdir, *, provider, already_surfaced,
+                                 **kw):
+            captured["provider"] = provider
+            return None
+
+        settings = MagicMock()
+        settings.memory_relevance_prefetch_enabled = True
+
+        # Isolate the unwrap→reminder path: stub the enable-gate and the
+        # query-text extractor so we reach the reminder call deterministically.
+        with patch("src.settings.settings.get_settings", return_value=settings), \
+                patch.object(alc, "_last_user_text", return_value="what did we do"), \
+                patch("src.memdir.get_auto_mem_path", return_value="/tmp"), \
+                patch("src.memdir.surface_memories.get_relevant_memory_reminder",
+                      _fake_reminder):
+            asyncio.run(alc._maybe_recall_memories(
+                [{"role": "user", "content": "what did we do"}],
+                wrapped, MagicMock(), set()))
+
+        self.assertIs(captured.get("provider"), inner)  # unwrapped, not wrapper
+
+    def test_unwrap_is_noop_for_raw_provider(self):
+        from src.providers.anthropic_provider import AnthropicProvider
+        p = AnthropicProvider(api_key="k")
+        self.assertIs(getattr(p, "_inner", p), p)
+
+
+class TestAsyncKilledStatus(unittest.TestCase):
+    """KILLED — a killed async subagent emits terminal 'killed', not
+    'completed'."""
+
+    def test_killed_async_emits_killed(self):
+        import src.tool_system.tools.agent as agent_mod
+        from src.tool_system.context import ToolContext
+        from src.tool_system.defaults import build_default_registry
+        from src.tool_system.protocol import ToolCall
+        from src.types.content_blocks import TextBlock
+        from src.types.messages import AssistantMessage
+
+        with TemporaryDirectory() as tmp:
+            emitted: list = []
+            ctx = ToolContext(workspace_root=Path(tmp))
+            ctx.agent_progress_emit = lambda ev: emitted.append(ev)
+
+            async def _fake(_p):
+                yield AssistantMessage(content=[TextBlock(text="partial")])
+
+            # complete_agent_task is a local import from src.tasks.local_agent;
+            # patch it there. Simulate a concurrent kill having marked the task
+            # terminal "killed" (complete_agent_task no-ops on terminal state).
+            def _mark_killed(agent_id, **kw):
+                st = ctx.runtime_tasks.get(agent_id)
+                if st is not None:
+                    st.status = "killed"
+
+            with patch.object(agent_mod, "run_agent", _fake), \
+                    patch("src.tasks.local_agent.complete_agent_task",
+                          _mark_killed):
+                registry = build_default_registry(provider=object())
+                res = registry.dispatch(ToolCall(name="Agent", input={
+                    "description": "bg", "prompt": "work",
+                    "run_in_background": True,
+                }), ctx)
+                task_id = str(res.output["agent_id"])
+                deadline = time.time() + 2
+                while time.time() < deadline and not any(
+                    e.get("status") in ("killed", "completed", "failed")
+                    for e in emitted
+                ):
+                    time.sleep(0.05)
+
+            terminal = [e for e in emitted
+                        if e.get("status") in ("killed", "completed", "failed")]
+            self.assertTrue(terminal, "async lifecycle should emit terminal")
+            self.assertEqual(terminal[-1]["status"], "killed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Round-5 R5-6: final-verdict polish

Three non-blocking nits the round-5 critics flagged in their APPROVE verdicts — all gaps/mislabels in just-shipped round-5 code:

- **N1 (r5-1) — /effort bypassed the recall cost-pin.** `_run_turn` wraps the session provider in `_EffortProvider`, which isn't an `AnthropicProvider`, so R5-1's `isinstance` cost-pin was bypassed under `/effort` (and `reasoning_effort` leaked into the cheap selector). Fix: `_maybe_recall_memories` unwraps `getattr(provider, "_inner", provider)` first — `_inner` is `_EffortProvider`-exclusive, so it's a no-op otherwise.
- **KILLED (r5-3) — async terminal emit hardcoded "completed".** A killed async subagent's task is marked terminal `killed`; `complete_agent_task` no-ops on it, so the hardcoded "completed" mislabeled the HUD. Fix: read the authoritative runtime status after `complete_agent_task` and emit it.
- **N2 (r5-1) — docstring precision** on the custom-base_url Anthropic case.

**Tests:** `tests/test_r5_final_verdict_polish.py` (4), end-to-end. Full suite at the pre-existing baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
