### PR TITLE
fix(r6-4): auto-compact pipeline now applies the compaction (was discarded)

### DIFF
--- a/src/services/compact/pipeline.py
+++ b/src/services/compact/pipeline.py
@@ -250,7 +250,31 @@ class CompressionPipeline:
                     total_saved += result.tokens_saved
                     layers_applied.append("autocompact")
                     autocompact_result = result
-                    logger.debug("Layer 5 (autocompact): saved %d tokens", result.tokens_saved)
+                    # R6 — APPLY the compaction to the working messages. This
+                    # was the bug: the pipeline computed the summary (an LLM
+                    # call, cost incurred) but returned the UNCOMPACTED
+                    # current_messages, so query() kept the full conversation
+                    # and auto-compact re-fired every turn without ever
+                    # shrinking the context — the exact opposite of what a
+                    # long task needs. Assemble the compacted conversation the
+                    # way the manual /compact path does (compact_service/
+                    # service.py:101-104): the summary (a USER message — safe
+                    # as the first message) + kept recent messages + the
+                    # post-compact attachments (file-state a coding agent needs
+                    # after compaction). The system boundary_marker is
+                    # bookkeeping for the persisted conversation and is omitted
+                    # from the working set (as the reactive path does), so the
+                    # working messages stay API-clean.
+                    n_before = len(current_messages)
+                    current_messages = (
+                        list(result.summary_messages)
+                        + list(result.messages_to_keep)
+                        + list(result.attachments)
+                    )
+                    logger.debug(
+                        "Layer 5 (autocompact): saved %d tokens, %d -> %d msgs",
+                        result.tokens_saved, n_before, len(current_messages),
+                    )
             except Exception:
                 logger.warning("Layer 5 (autocompact) failed", exc_info=True)
 

--- a/tests/test_r6_autocompact_applied.py
+++ b/tests/test_r6_autocompact_applied.py
@@ -1,0 +1,76 @@
+"""R6-4 — the compression pipeline must APPLY the auto-compaction.
+
+Found during the R6-3 long-task eval: run_compression_pipeline layer-5
+(autocompact) computed the CompactionResult (an LLM summarization call — cost
+incurred) but returned messages=current_messages (the UNCOMPACTED original) and
+query() used that, so auto-compact never actually shrank the context — it
+re-summarized every turn without effect. The fix assembles the compacted
+conversation (summary_messages + messages_to_keep + attachments) into the
+pipeline's returned messages.
+"""
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import patch
+
+from src.services.compact import pipeline as pipeline_mod
+from src.services.compact.compact import CompactionResult
+from src.services.compact.pipeline import PipelineConfig, run_compression_pipeline
+
+
+def _msgs(n):
+    return [{"type": "user" if i % 2 == 0 else "assistant",
+             "content": f"message {i} " + "word " * 50} for i in range(n)]
+
+
+class TestAutocompactApplied(unittest.TestCase):
+    def _run(self, *, fires):
+        # A big conversation; mock auto_compact_if_needed so no real LLM call.
+        original = _msgs(120)
+        summary = [{"type": "user", "content": "SUMMARY of the older messages."}]
+        keep = [{"type": "user", "content": "recent kept message"}]
+        attach = [{"type": "user", "content": "<file-state> foo.py …"}]
+
+        async def _fake_autocompact(messages, input_tokens, *a, **k):
+            if not fires:
+                return None
+            return CompactionResult(
+                boundary_marker={"type": "system", "content": "[boundary]"},
+                summary_messages=summary,
+                messages_to_keep=keep,
+                attachments=attach,
+                tokens_saved=9000,
+            )
+
+        cfg = PipelineConfig(provider=object(), model="m")  # provider+model set
+        # Only mock layer 5's decision. Layers 1-4 fail-soft / no-op on these
+        # plain-dict messages (the pipeline catches each layer's exception),
+        # and layer 5 replaces the working set wholesale, so the assertion on
+        # res.messages is deterministic regardless.
+        with patch.object(pipeline_mod, "auto_compact_if_needed", _fake_autocompact):
+            res = asyncio.run(run_compression_pipeline(
+                original, input_token_count=40000, config=cfg))
+        return original, summary, keep, attach, res
+
+    def test_pipeline_returns_the_compacted_conversation(self):
+        original, summary, keep, attach, res = self._run(fires=True)
+        self.assertIn("autocompact", res.layers_applied)
+        # The returned messages are the ASSEMBLED compacted set, NOT the 120
+        # originals — this is the whole bug fix.
+        self.assertEqual(res.messages, summary + keep + attach)
+        self.assertLess(len(res.messages), len(original))
+        # File-state attachments are preserved (a coding agent needs them).
+        self.assertIn(attach[0], res.messages)
+        # The system boundary marker is NOT in the working set (API-clean).
+        self.assertFalse(any(
+            isinstance(m, dict) and m.get("type") == "system" for m in res.messages))
+
+    def test_no_compaction_leaves_messages_unchanged(self):
+        original, *_ , res = self._run(fires=False)
+        self.assertNotIn("autocompact", res.layers_applied)
+        self.assertEqual(len(res.messages), len(original))  # untouched
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## R6-4: auto-compact was computing the summary but throwing it away

Found during the R6-3 compact/auto-compact evaluation. The compression pipeline's **layer 5 (autocompact)** called `auto_compact_if_needed` — which makes a full **LLM summarization call (cost incurred)** — but then returned `messages=current_messages` (the **uncompacted** original) and captured the real result into `autocompact_result`, which **query.py never reads** (it uses `pipeline_result.messages`). So when auto-compact fired, it paid for a summary and **shrank nothing** — the exact opposite of what a long task needs.

**Fix:** assemble the compacted conversation into the pipeline's output the way the working manual `/compact` path does — `summary_messages + messages_to_keep + attachments` (summary is a user message → API-safe; attachments preserve post-compact file-state; the system boundary is omitted, matching the reactive path). Diagnostic: **120 msgs → 1** after the fix (was 120 → 120).

**No history lost** (critic-confirmed): the boundary-present case drops only `isMeta`/system markers that `normalize_message_for_api` filters anyway.

**Reachability:** layer 5 is the last resort — cheaper layers keep most conversations small — so this bites genuinely long tasks whose essential content exceeds ~10k after the cheap layers.

**Tests:** `tests/test_r6_autocompact_applied.py` (2). 381 compact/pipeline/ch05 green; full suite at the pre-existing baseline. Critic: APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
