### PR TITLE
fix(perm-ux): readable approval box + broadenable session grants

### DIFF
--- a/ui-tui/src/__tests__/approvalAction.test.ts
+++ b/ui-tui/src/__tests__/approvalAction.test.ts
@@ -8,11 +8,11 @@ describe('approvalAction — pure key dispatch for ApprovalPrompt', () => {
     expect(approvalAction('', { escape: true }, 2)).toEqual({ kind: 'choose', choice: 'deny' })
   })
 
-  it('maps number keys 1..4 to once/session/always/deny in registration order', () => {
+  it('maps number keys 1..3 to once/always/deny in registration order', () => {
     expect(approvalAction('1', {}, 0)).toEqual({ kind: 'choose', choice: 'once' })
-    expect(approvalAction('2', {}, 0)).toEqual({ kind: 'choose', choice: 'session' })
-    expect(approvalAction('3', {}, 0)).toEqual({ kind: 'choose', choice: 'always' })
-    expect(approvalAction('4', {}, 0)).toEqual({ kind: 'choose', choice: 'deny' })
+    expect(approvalAction('2', {}, 0)).toEqual({ kind: 'choose', choice: 'always' })
+    expect(approvalAction('3', {}, 0)).toEqual({ kind: 'choose', choice: 'deny' })
+    expect(approvalAction('4', {}, 0)).toEqual({ kind: 'noop' })
   })
 
   it('ignores out-of-range numbers', () => {
@@ -23,7 +23,7 @@ describe('approvalAction — pure key dispatch for ApprovalPrompt', () => {
 
   it('confirms the current selection on Enter', () => {
     expect(approvalAction('', { return: true }, 0)).toEqual({ kind: 'choose', choice: 'once' })
-    expect(approvalAction('', { return: true }, 3)).toEqual({ kind: 'choose', choice: 'deny' })
+    expect(approvalAction('', { return: true }, 2)).toEqual({ kind: 'choose', choice: 'deny' })
   })
 
   it('moves selection up/down within bounds', () => {
@@ -33,7 +33,7 @@ describe('approvalAction — pure key dispatch for ApprovalPrompt', () => {
 
   it('clamps selection movement at the edges', () => {
     expect(approvalAction('', { upArrow: true }, 0)).toEqual({ kind: 'noop' })
-    expect(approvalAction('', { downArrow: true }, 3)).toEqual({ kind: 'noop' })
+    expect(approvalAction('', { downArrow: true }, 2)).toEqual({ kind: 'noop' })
   })
 
   it('Esc beats numeric/return — denying is always the first interpretation', () => {
@@ -49,13 +49,13 @@ describe('approvalAction — pure key dispatch for ApprovalPrompt', () => {
   })
 
   it('respects a reduced option set when permanent allow is disabled', () => {
-    // tirith content-security warning present → no "always"; the 3-item set is
-    // once/session/deny, so 3 maps to deny and 4 is out of range.
-    const opts = ['once', 'session', 'deny'] as const
+    // tirith content-security warning (or no suggestion) → no "don't ask again";
+    // the 2-item set is once/deny, so 2 maps to deny and 3 is out of range.
+    const opts = ['once', 'deny'] as const
 
-    expect(approvalAction('3', {}, 0, opts)).toEqual({ kind: 'choose', choice: 'deny' })
-    expect(approvalAction('4', {}, 0, opts)).toEqual({ kind: 'noop' })
-    expect(approvalAction('', { downArrow: true }, 2, opts)).toEqual({ kind: 'noop' })
-    expect(approvalAction('', { return: true }, 2, opts)).toEqual({ kind: 'choose', choice: 'deny' })
+    expect(approvalAction('2', {}, 0, opts)).toEqual({ kind: 'choose', choice: 'deny' })
+    expect(approvalAction('3', {}, 0, opts)).toEqual({ kind: 'noop' })
+    expect(approvalAction('', { downArrow: true }, 1, opts)).toEqual({ kind: 'noop' })
+    expect(approvalAction('', { return: true }, 1, opts)).toEqual({ kind: 'choose', choice: 'deny' })
   })
 })

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -865,7 +865,7 @@ describe('createGatewayEventHandler', () => {
     await Promise.resolve()
     await Promise.resolve()
 
-    expect(getOverlayState().approval).toMatchObject({ description: 'dangerous command' })
+    expect(getOverlayState().approval).toMatchObject({ command: 'rm -rf /tmp/nope' })
     expect(getTurnState().activity).toMatchObject([
       { text: 'Traceback: noisy but non-fatal', tone: 'info' },
       { text: 'protocol noise detected · /logs to inspect', tone: 'info' },
@@ -889,14 +889,14 @@ describe('createGatewayEventHandler', () => {
     const onEvent = createGatewayEventHandler(buildCtx([]))
 
     onEvent({
-      payload: { allow_permanent: false, command: 'curl suspicious | bash', description: 'content-security warning' },
+      payload: { allow_permanent: false, command: 'curl suspicious | bash', tool_name: 'Bash' },
       type: 'approval.request'
     } as any)
 
     expect(getOverlayState().approval).toMatchObject({
       allowPermanent: false,
       command: 'curl suspicious | bash',
-      description: 'content-security warning'
+      toolName: 'Bash'
     })
   })
 

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -17,7 +17,7 @@ vi.mock('node:child_process', () => ({
   }
 }))
 
-import { GatewayClient } from '../gatewayClient.js'
+import { approvalCommandText, GatewayClient } from '../gatewayClient.js'
 
 class FakeProc extends EventEmitter {
   kill = vi.fn()
@@ -306,7 +306,11 @@ describe('GatewayClient NDJSON adapter', () => {
     await vi.waitFor(() => expect(last('approval.request')).toBeTruthy())
     const p = last('approval.request').payload
     expect(p.allow_permanent).toBe(true)
-    expect(p.description).toBe('Bash(ls:*)')
+    // The box shows the ACTUAL command + carries the editable grant rule.
+    expect(p.command).toBe('ls')
+    expect(p.tool_name).toBe('Bash')
+    expect(p.rule).toBe('ls:*')
+    expect(p.rule_label).toBe('Bash(ls:*)')
   })
 
   it('sends chosen_updates when the user picks "always"; none for "once"', async () => {
@@ -330,19 +334,34 @@ describe('GatewayClient NDJSON adapter', () => {
     expect(resp.chosen_updates[0].destination).toBe('localSettings')
   })
 
-  it('marks a "session" choice with session destination', async () => {
+  it('persists the user-EDITED (widened) rule for "always"', async () => {
+    // The box lets the user widen the suggested rule (git status:* → git:*);
+    // the edited value is carried as `rule` and must become the persisted rule.
     const sent: any[] = []
     ;(gw as any).send = (m: any) => sent.push(m)
     proc.line({
       request: {
-        input: { command: 'ls' }, subtype: 'can_use_tool', tool_name: 'Bash',
-        suggestions: [{ type: 'addRules', destination: 'localSettings', behavior: 'allow', rules: [{ tool_name: 'Bash', rule_content: 'ls:*' }] }]
+        input: { command: 'git status' }, subtype: 'can_use_tool', tool_name: 'Bash',
+        suggestions: [{ type: 'addRules', destination: 'localSettings', behavior: 'allow', rules: [{ tool_name: 'Bash', rule_content: 'git status:*' }] }]
       },
       request_id: 'r3', type: 'control_request'
     })
     await vi.waitFor(() => expect(last('approval.request')).toBeTruthy())
-    await gw.request('approval.respond', { choice: 'session' })
+    await gw.request('approval.respond', { choice: 'always', rule: 'git:*' })
     const resp = sent.find(m => m.type === 'control_response')?.response?.response
-    expect(resp.chosen_updates[0].destination).toBe('session')
+    expect(resp.chosen_updates[0].rules[0].rule_content).toBe('git:*')
+    expect(resp.chosen_updates[0].destination).toBe('localSettings')
+  })
+})
+
+describe('approvalCommandText — the human-reviewable action, not a JSON dump', () => {
+  it('shows the Bash command / file path / url, not the whole input blob', () => {
+    expect(approvalCommandText({ command: 'git status --short' })).toBe('git status --short')
+    expect(approvalCommandText({ description: 'x', file_path: '/a/b.ts' })).toBe('/a/b.ts')
+    expect(approvalCommandText({ url: 'https://example.com' })).toBe('https://example.com')
+  })
+
+  it('falls back to compact JSON for inputs with no obvious action field', () => {
+    expect(approvalCommandText({ foo: 1 })).toBe('{"foo":1}')
   })
 })

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -758,12 +758,19 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         return
       case 'approval.request': {
-        const description = String(ev.payload.description ?? 'dangerous command')
         // Only an explicit false (tirith warning) drops the permanent-allow option.
         const allowPermanent = ev.payload.allow_permanent !== false
+        const rule = ev.payload.rule
+        const ruleLabel = ev.payload.rule_label
 
         patchOverlayState({
-          approval: { allowPermanent, command: String(ev.payload.command ?? ''), description }
+          approval: {
+            allowPermanent,
+            command: String(ev.payload.command ?? ''),
+            rule: rule ? String(rule) : undefined,
+            ruleLabel: ruleLabel ? String(ruleLabel) : undefined,
+            toolName: String(ev.payload.tool_name ?? 'tool')
+          }
         })
         setStatus('approval needed')
 

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -376,7 +376,7 @@ export interface SlashHandlerContext {
 }
 
 export interface AppLayoutActions {
-  answerApproval: (choice: string) => void
+  answerApproval: (choice: string, rule?: string) => void
   answerClarify: (answer: string) => void
   answerSecret: (value: string) => void
   answerSudo: (pw: string) => void
@@ -442,7 +442,7 @@ export interface AppOverlaysProps {
   cols: number
   compIdx: number
   completions: CompletionItem[]
-  onApprovalChoice: (choice: string) => void
+  onApprovalChoice: (choice: string, rule?: string) => void
   onClarifyAnswer: (value: string) => void
   onActiveSessionSelect: (sessionId: string) => void
   onActiveSessionClose: (sessionId: string) => Promise<null | SessionCloseResponse>

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -890,8 +890,10 @@ export function useMainApp(gw: GatewayClient) {
   )
 
   const answerApproval = useCallback(
-    (choice: string) =>
-      respondWith('approval.respond', { choice, session_id: ui.sid }, () => {
+    // `rule` carries the (possibly user-edited) grant prefix for the "don't ask
+    // again" choice so the box can widen git status:* → git:*.
+    (choice: string, rule?: string) =>
+      respondWith('approval.respond', { choice, rule, session_id: ui.sid }, () => {
         patchOverlayState({ approval: null })
         patchTurnState({ outcome: choice === 'deny' ? 'denied' : `approved (${choice})` })
         patchUiState({ status: 'running…' })

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -7,13 +7,20 @@ import type { ApprovalReq, ClarifyReq, ConfirmReq } from '../types.js'
 
 import { TextInput } from './textInput.js'
 
-const APPROVAL_OPTS = ['once', 'session', 'always', 'deny'] as const
-// tirith warning present → backend downgrades "always" to session scope, so drop it.
-const APPROVAL_OPTS_NO_ALWAYS = APPROVAL_OPTS.filter(o => o !== 'always')
-const LABELS = { always: 'Always allow', deny: 'Deny', once: 'Allow once', session: 'Allow this session' } as const
-const CMD_PREVIEW_LINES = 10
+type ApprovalChoice = 'always' | 'deny' | 'once'
 
-type ApprovalChoice = 'always' | 'deny' | 'once' | 'session'
+// Original Claude Code's 3-option model: Yes / Yes-and-don't-ask-again / No.
+// "always" persists the (editable) rule to disk so it survives across sessions.
+const APPROVAL_OPTS: readonly ApprovalChoice[] = ['once', 'always', 'deny']
+// No persistable rule (tirith warning, or backend sent no suggestion) → drop
+// the "don't ask again" option.
+const APPROVAL_OPTS_NO_ALWAYS: readonly ApprovalChoice[] = ['once', 'deny']
+const LABELS: Record<ApprovalChoice, string> = {
+  always: "Yes, and don't ask again for",
+  deny: 'No',
+  once: 'Yes'
+}
+const CMD_PREVIEW_LINES = 10
 
 type ApprovalKey = {
   downArrow?: boolean
@@ -67,63 +74,82 @@ export function approvalAction(
 }
 
 export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptProps) {
+  const opts = req.allowPermanent === false || !req.rule ? APPROVAL_OPTS_NO_ALWAYS : APPROVAL_OPTS
   const [sel, setSel] = useState(0)
-  const opts = req.allowPermanent === false ? APPROVAL_OPTS_NO_ALWAYS : APPROVAL_OPTS
+  // The editable grant rule (e.g. "git status:*"), which the user can widen to
+  // "git:*" so one grant covers the family. Seeded from the backend suggestion.
+  const [ruleText, setRuleText] = useState(req.rule ?? '')
+  const [editing, setEditing] = useState(false)
+  const alwaysIdx = opts.indexOf('always')
 
-  useInput((ch, key) => {
-    const action = approvalAction(ch, key, sel, opts)
+  const confirm = (choice: ApprovalChoice) =>
+    onChoice(choice, choice === 'always' ? ruleText.trim() || req.rule : undefined)
 
-    if (action.kind === 'choose') {
-      onChoice(action.choice)
-    } else if (action.kind === 'move') {
-      setSel(s => s + action.delta)
-    }
-  })
+  // Navigation — disabled while the rule field is focused (TextInput owns input).
+  useInput(
+    (ch, key) => {
+      // On the "don't ask again" row, open the editable rule field.
+      if (opts[sel] === 'always' && (key.tab || key.rightArrow || ch === 'e')) {
+        setEditing(true)
+        return
+      }
+      const action = approvalAction(ch, key, sel, opts)
+      if (action.kind === 'choose') confirm(action.choice)
+      else if (action.kind === 'move') setSel(s => s + action.delta)
+    },
+    { isActive: !editing }
+  )
+  // While editing, Esc cancels the edit (back to the option list), not deny.
+  useInput((_ch, key) => { if (key.escape) setEditing(false) }, { isActive: editing })
 
-  // Wrap long single-line commands to the panel width instead of clipping the
-  // tail (mirrors the CLI approval panel fix — the full command must be
-  // reviewable before approving). Border + paddingX + inner padding ≈ 8 cols.
-  const innerWidth = Math.max(20, cols - 8)
-
+  // Border + paddingX ≈ 4 cols. Show the real command, wrapped, not clipped.
+  const innerWidth = Math.max(20, cols - 4)
   const rawLines = req.command
     .split('\n')
     .flatMap(line => wrapAnsi(line, innerWidth, { hard: true, trim: false }).split('\n'))
-
   const shown = rawLines.slice(0, CMD_PREVIEW_LINES)
   const overflow = rawLines.length - shown.length
 
   return (
-    <Box borderColor={t.color.warn} borderStyle="double" flexDirection="column" paddingX={1}>
-      <Text bold color={t.color.warn}>
-        ⚠ approval required · {req.description}
-      </Text>
+    <Box borderColor={t.color.warn} borderStyle="round" flexDirection="column" paddingX={1}>
+      <Text bold color={t.color.warn}>{req.toolName} command</Text>
 
       <Box flexDirection="column" paddingLeft={1}>
         {shown.map((line, i) => (
-          <Text color={t.color.text} key={i} wrap="truncate-end">
-            {line || ' '}
-          </Text>
+          <Text color={t.color.text} key={i} wrap="truncate-end">{line || ' '}</Text>
         ))}
-
         {overflow > 0 ? (
-          <Text color={t.color.muted}>
-            … +{overflow} more line{overflow === 1 ? '' : 's'} (full text above)
-          </Text>
+          <Text color={t.color.muted}>… +{overflow} more line{overflow === 1 ? '' : 's'}</Text>
         ) : null}
       </Box>
 
-      <Text />
+      <Text color={t.color.muted}>Do you want to proceed?</Text>
 
-      {opts.map((o, i) => (
-        <Text key={o}>
-          <Text bold={sel === i} color={sel === i ? t.color.warn : t.color.muted} inverse={sel === i}>
-            {sel === i ? '▸ ' : '  '}
-            {i + 1}. {LABELS[o]}
-          </Text>
-        </Text>
-      ))}
+      {opts.map((o, i) => {
+        const isSel = sel === i
+        const head = `${isSel ? '❯ ' : '  '}${i + 1}. `
+        if (o === 'always') {
+          return (
+            <Box key={o}>
+              <Text bold={isSel} color={isSel ? t.color.warn : t.color.muted}>{head}{LABELS.always} </Text>
+              {editing ? (
+                <TextInput columns={innerWidth} focus onChange={setRuleText} onSubmit={() => confirm('always')} value={ruleText} />
+              ) : (
+                <Text bold={isSel} color={isSel ? t.color.text : t.color.muted}>{ruleText || req.ruleLabel || ''}</Text>
+              )}
+            </Box>
+          )
+        }
+        return (
+          <Text bold={isSel} color={isSel ? t.color.warn : t.color.muted} key={o}>{head}{LABELS[o]}</Text>
+        )
+      })}
 
-      <Text color={t.color.muted}>↑/↓ select · Enter confirm · 1-{opts.length} quick pick · Esc/Ctrl+C deny</Text>
+      <Text color={t.color.muted}>
+        {editing
+          ? 'Enter to allow · Esc to cancel edit'
+          : `↑/↓ select · Enter confirm${alwaysIdx >= 0 ? ' · e edit rule' : ''} · Esc deny`}
+      </Text>
     </Box>
   )
 }
@@ -271,7 +297,7 @@ export function ConfirmPrompt({ onCancel, onConfirm, req, t }: ConfirmPromptProp
 
 interface ApprovalPromptProps {
   cols?: number
-  onChoice: (s: string) => void
+  onChoice: (s: string, rule?: string) => void
   req: ApprovalReq
   t: Theme
 }

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -54,6 +54,19 @@ export function describeSuggestionRule(suggestion: any): string | null {
   return rule.rule_content ? `${rule.tool_name}(${rule.rule_content})` : String(rule.tool_name)
 }
 
+// The human-reviewable action for a permission prompt: the actual Bash command,
+// file path, or URL under review — NOT the full tool-input JSON blob (which the
+// box previously dumped verbatim and made the prompt unreadable).
+export function approvalCommandText(input: unknown): string {
+  if (input && typeof input === 'object') {
+    const o = input as Record<string, unknown>
+    for (const key of ['command', 'file_path', 'path', 'url', 'pattern', 'prompt']) {
+      if (typeof o[key] === 'string' && o[key]) return o[key] as string
+    }
+  }
+  return safeJson(input)
+}
+
 /** Pick the salient arg for a tool so the trail label reads `Bash(ls)` /
  *  `Read(package.json)` / `Grep(TODO)` (Claude-style) instead of a bare tool
  *  name. File paths are shown relative to the workspace so the label stays
@@ -370,18 +383,18 @@ export class GatewayClient extends EventEmitter {
         this.pendingApproval = null
         if (ap) {
           const deny = p.choice === 'deny'
-          // ch13 round-4 — 'always' persists the rule (its backend
-          // destination, e.g. localSettings); 'session' persists it for
-          // the session only (destination overridden to 'session'); 'once'
-          // sends no rule. Previously always/session/once were byte-
-          // identical on the wire and nothing was ever persisted.
+          // 'always' = "don't ask again": persist the (possibly user-edited)
+          // rule to localSettings so it survives across sessions, like the
+          // original. The box lets the user widen the rule (git status:* →
+          // git:*); p.rule carries that edit. 'once' sends no rule.
           let chosenUpdates: any[] = []
           const first = ap.suggestions?.[0]
-          if (!deny && first && (p.choice === 'always' || p.choice === 'session')) {
+          if (!deny && first && p.choice === 'always') {
+            const baseRule = first.rules?.[0] ?? {}
+            const editedContent =
+              typeof p.rule === 'string' && p.rule.trim() ? p.rule.trim() : baseRule.rule_content
             chosenUpdates = [
-              p.choice === 'session'
-                ? { ...first, destination: 'session' }
-                : first
+              { ...first, destination: 'localSettings', rules: [{ ...baseRule, rule_content: editedContent }] }
             ]
           }
           this.send({
@@ -754,17 +767,21 @@ export class GatewayClient extends EventEmitter {
     const req = msg.request
     if (req?.subtype === 'can_use_tool') {
       // ch13 round-4 — carry the backend's permission SUGGESTIONS so the
-      // "Always allow" / "Allow this session" choices persist a real rule.
+      // "don't ask again" choice persists a real rule.
       const suggestions: any[] = Array.isArray(req.suggestions) ? req.suggestions : []
       this.pendingApproval = { input: req.input, request_id: String(msg.request_id ?? ''), suggestions }
-      // Only offer the persistable "always" option when the backend sent a
-      // rule for it (the server strips allow_permanent otherwise).
-      const rule = describeSuggestionRule(suggestions[0])
+      // Show the ACTUAL command/action under review, not the tool name or a raw
+      // JSON dump — and carry the editable grant rule separately so the box can
+      // offer a broadenable "don't ask again for <rule>" option. Only offer the
+      // persistable option when the backend sent a rule.
+      const ruleContent = suggestions[0]?.rules?.[0]?.rule_content ?? null
       this.publish({
         payload: {
           allow_permanent: suggestions.length > 0,
-          command: String(req.tool_name ?? 'tool'),
-          description: rule ?? safeJson(req.input)
+          command: approvalCommandText(req.input),
+          rule: ruleContent,
+          rule_label: describeSuggestionRule(suggestions[0]),
+          tool_name: String(req.tool_name ?? 'tool')
         },
         type: 'approval.request'
       })

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -685,7 +685,13 @@ export type GatewayEvent =
       type: 'clarify.request'
     }
   | {
-      payload: { allow_permanent?: boolean; command: string; description: string }
+      payload: {
+        allow_permanent?: boolean
+        command: string
+        rule?: null | string
+        rule_label?: null | string
+        tool_name: string
+      }
       session_id?: string
       type: 'approval.request'
     }

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -90,10 +90,19 @@ export interface DelegationStatus {
 }
 
 export interface ApprovalReq {
-  // false when the backend won't honor a permanent allow (tirith warning) → hide "Always allow".
+  // false when the backend won't honor a permanent allow (tirith warning) → hide "don't ask again".
   allowPermanent?: boolean
+  // The actual command / action under review (e.g. the Bash command line), NOT
+  // the tool name or a JSON dump — this is what the box shows.
   command: string
-  description: string
+  // Tool name for the box title ("Bash", "Write", …).
+  toolName: string
+  // The grant rule content the "don't ask again" option would persist, e.g.
+  // "git status:*". Editable in the box so the user can widen it (git:*).
+  // undefined when the backend sent no suggestion (→ no persist option).
+  rule?: string
+  // Display form of the rule for the option label, e.g. "Bash(git status:*)".
+  ruleLabel?: string
 }
 
 export interface ConfirmReq {


### PR DESCRIPTION
## Permission UX: match the original Claude Code

User report: the Bash permission prompt asks on **every command**, it's unclear whether "allow this session" is kept, and the box has **too much text**.

**Diagnosis:** within a session, grants *do* persist (identical safe command → no re-prompt; `test_permission_session_options` passes). The annoyance is that the port grants a **narrow** rule (`Bash(git status:*)`, or an exact string for `python foo.py`) and — unlike the original — offered **no way to broaden it**. The box also showed the tool name + a raw rule string / full JSON dump in a double border with a dead 10-line preview and 4 options.

**Fix (ui-tui only — the sole approval UI):**
- **Show the real command** (`approvalCommandText`) instead of the tool name / JSON dump.
- **Concise box:** single border, `<tool> command` title, the command, "Do you want to proceed?", options, one footer.
- **Original's 3-option model:** Yes / "Yes, and don't ask again for `<rule>`" / No. The grant persists to `localSettings` (disk) so it **survives across sessions**, like the original.
- **Editable, broadenable prefix:** press `e`/Tab on the "don't ask again" row to widen `git status:*` → `git:*` so one grant covers the family. The edit rides `chosen_updates` → the backend persists it.

**Tests:** `approvalAction` (3-option dispatch), `gatewayClient` (real command in payload; `always`→localSettings; **edited** `git:*` persisted; `approvalCommandText`), `createGatewayEventHandler` (overlay shape). ui-tui suite **14 failed / 1080 passed — identical to the clean-tree baseline** (stash-verified), zero new failures. typecheck + build clean.

Follow-ups (separate): non-TUI clients still drop grants (direct-connect + bridge field-name split); installed clawcodex is v0.6.0 and needs a ui-tui redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
