### PR TITLE
fix(perm-ux): restore non-Bash persist option + preserve grant scope

### DIFF
--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -352,6 +352,34 @@ describe('GatewayClient NDJSON adapter', () => {
     expect(resp.chosen_updates[0].rules[0].rule_content).toBe('git:*')
     expect(resp.chosen_updates[0].destination).toBe('localSettings')
   })
+
+  it('offers "always" for a NON-Bash tool and passes its setMode suggestion through UNCHANGED', async () => {
+    // Regression: Write/Edit send a session-scoped acceptEdits setMode (no
+    // rules, no rule_content). The persist option must still be offered
+    // (allow_permanent=true) and the suggestion must not be mangled into a
+    // localSettings rule.
+    const sent: any[] = []
+    ;(gw as any).send = (m: any) => sent.push(m)
+    const setModeSuggestion = { type: 'setMode', destination: 'session', mode: 'acceptEdits' }
+    proc.line({
+      request: {
+        input: { file_path: '/a/b.ts' }, subtype: 'can_use_tool', tool_name: 'Write',
+        suggestions: [setModeSuggestion]
+      },
+      request_id: 'r4', type: 'control_request'
+    })
+    await vi.waitFor(() => expect(last('approval.request')).toBeTruthy())
+    // The box still offers a persistable option for non-Bash tools.
+    expect(last('approval.request').payload.allow_permanent).toBe(true)
+    expect(last('approval.request').payload.rule).toBeNull()
+
+    await gw.request('approval.respond', { choice: 'always' })
+    const resp = sent.find(m => m.type === 'control_response')?.response?.response
+    // Suggestion passes through AS-IS: session scope kept, no rules injected.
+    expect(resp.chosen_updates[0]).toEqual(setModeSuggestion)
+    expect(resp.chosen_updates[0].destination).toBe('session')
+    expect(resp.chosen_updates[0].rules).toBeUndefined()
+  })
 })
 
 describe('approvalCommandText — the human-reviewable action, not a JSON dump', () => {

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -10,10 +10,11 @@ import { TextInput } from './textInput.js'
 type ApprovalChoice = 'always' | 'deny' | 'once'
 
 // Original Claude Code's 3-option model: Yes / Yes-and-don't-ask-again / No.
-// "always" persists the (editable) rule to disk so it survives across sessions.
+// "always" sends the backend's suggestion, which persists at its own intended
+// scope (Bash → localSettings/disk; file edits → session acceptEdits; etc.).
 const APPROVAL_OPTS: readonly ApprovalChoice[] = ['once', 'always', 'deny']
-// No persistable rule (tirith warning, or backend sent no suggestion) → drop
-// the "don't ask again" option.
+// No suggestion at all (tirith warning, allowPermanent=false) → drop the
+// "don't ask again" option.
 const APPROVAL_OPTS_NO_ALWAYS: readonly ApprovalChoice[] = ['once', 'deny']
 const LABELS: Record<ApprovalChoice, string> = {
   always: "Yes, and don't ask again for",
@@ -74,7 +75,12 @@ export function approvalAction(
 }
 
 export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptProps) {
-  const opts = req.allowPermanent === false || !req.rule ? APPROVAL_OPTS_NO_ALWAYS : APPROVAL_OPTS
+  // Offer the persist ("don't ask again") option whenever the backend sent a
+  // suggestion (allowPermanent) — that includes non-Bash tools (Write→accept
+  // edits this session, Read/WebFetch→content-less allow), not just Bash. Only
+  // Bash carries an editable rule (req.rule); the others show a static label.
+  const opts = req.allowPermanent === false ? APPROVAL_OPTS_NO_ALWAYS : APPROVAL_OPTS
+  const editable = !!req.rule
   const [sel, setSel] = useState(0)
   // The editable grant rule (e.g. "git status:*"), which the user can widen to
   // "git:*" so one grant covers the family. Seeded from the backend suggestion.
@@ -88,8 +94,9 @@ export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptPr
   // Navigation — disabled while the rule field is focused (TextInput owns input).
   useInput(
     (ch, key) => {
-      // On the "don't ask again" row, open the editable rule field.
-      if (opts[sel] === 'always' && (key.tab || key.rightArrow || ch === 'e')) {
+      // On the "don't ask again" row, open the editable rule field (Bash only —
+      // other tools have no editable rule).
+      if (editable && opts[sel] === 'always' && (key.tab || key.rightArrow || ch === 'e')) {
         setEditing(true)
         return
       }
@@ -102,8 +109,8 @@ export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptPr
   // While editing, Esc cancels the edit (back to the option list), not deny.
   useInput((_ch, key) => { if (key.escape) setEditing(false) }, { isActive: editing })
 
-  // Border + paddingX ≈ 4 cols. Show the real command, wrapped, not clipped.
-  const innerWidth = Math.max(20, cols - 4)
+  // Border (2) + paddingX (2) + the command box's paddingLeft (1) = 5 cols.
+  const innerWidth = Math.max(20, cols - 5)
   const rawLines = req.command
     .split('\n')
     .flatMap(line => wrapAnsi(line, innerWidth, { hard: true, trim: false }).split('\n'))
@@ -129,13 +136,17 @@ export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptPr
         const isSel = sel === i
         const head = `${isSel ? '❯ ' : '  '}${i + 1}. `
         if (o === 'always') {
+          const label = `${head}${LABELS.always} `
+          // Bash edits the rule inline; other tools show a static scope label
+          // (rule label, else the tool name — "…don't ask again for Write").
+          const staticRule = ruleText || req.ruleLabel || req.toolName
           return (
             <Box key={o}>
-              <Text bold={isSel} color={isSel ? t.color.warn : t.color.muted}>{head}{LABELS.always} </Text>
-              {editing ? (
-                <TextInput columns={innerWidth} focus onChange={setRuleText} onSubmit={() => confirm('always')} value={ruleText} />
+              <Text bold={isSel} color={isSel ? t.color.warn : t.color.muted}>{label}</Text>
+              {editing && editable ? (
+                <TextInput columns={Math.max(12, innerWidth - label.length)} focus onChange={setRuleText} onSubmit={() => confirm('always')} value={ruleText} />
               ) : (
-                <Text bold={isSel} color={isSel ? t.color.text : t.color.muted}>{ruleText || req.ruleLabel || ''}</Text>
+                <Text bold={isSel} color={isSel ? t.color.text : t.color.muted}>{staticRule}</Text>
               )}
             </Box>
           )
@@ -148,7 +159,7 @@ export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptPr
       <Text color={t.color.muted}>
         {editing
           ? 'Enter to allow · Esc to cancel edit'
-          : `↑/↓ select · Enter confirm${alwaysIdx >= 0 ? ' · e edit rule' : ''} · Esc deny`}
+          : `↑/↓ select · Enter confirm${alwaysIdx >= 0 && editable ? ' · e edit rule' : ''} · Esc deny`}
       </Text>
     </Box>
   )

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -60,7 +60,9 @@ export function describeSuggestionRule(suggestion: any): string | null {
 export function approvalCommandText(input: unknown): string {
   if (input && typeof input === 'object') {
     const o = input as Record<string, unknown>
-    for (const key of ['command', 'file_path', 'path', 'url', 'pattern', 'prompt']) {
+    // pattern before path so a Grep/Glob box shows the search pattern (matching
+    // the tool trail label), not the directory it searched.
+    for (const key of ['command', 'file_path', 'url', 'pattern', 'path']) {
       if (typeof o[key] === 'string' && o[key]) return o[key] as string
     }
   }
@@ -383,18 +385,21 @@ export class GatewayClient extends EventEmitter {
         this.pendingApproval = null
         if (ap) {
           const deny = p.choice === 'deny'
-          // 'always' = "don't ask again": persist the (possibly user-edited)
-          // rule to localSettings so it survives across sessions, like the
-          // original. The box lets the user widen the rule (git status:* →
-          // git:*); p.rule carries that edit. 'once' sends no rule.
+          // 'always' = "don't ask again": send the backend's suggestion AS-IS so
+          // its intended SCOPE is preserved — Bash's is a localSettings rule
+          // (survives sessions); a file-edit's is a session-scoped acceptEdits
+          // setMode; a read's is a content-less allow. The ONLY mutation is the
+          // user's optional edit of a Bash rule (git status:* → git:*), which
+          // rewrites just that rule's content and nothing else. 'once' → no rule.
           let chosenUpdates: any[] = []
           const first = ap.suggestions?.[0]
           if (!deny && first && p.choice === 'always') {
-            const baseRule = first.rules?.[0] ?? {}
-            const editedContent =
-              typeof p.rule === 'string' && p.rule.trim() ? p.rule.trim() : baseRule.rule_content
+            const edited = typeof p.rule === 'string' ? p.rule.trim() : ''
+            const baseRule = Array.isArray(first.rules) ? first.rules[0] : undefined
             chosenUpdates = [
-              { ...first, destination: 'localSettings', rules: [{ ...baseRule, rule_content: editedContent }] }
+              edited && baseRule?.rule_content
+                ? { ...first, rules: [{ ...baseRule, rule_content: edited }, ...first.rules.slice(1)] }
+                : first
             ]
           }
           this.send({


### PR DESCRIPTION
Follow-up to #608 (critic REVISE). Restores the 'don't ask again' option for non-Bash tools (was gated on Bash-only rule_content → Write/Edit re-prompted every action) and sends each suggestion **as-is** so its scope is preserved (Bash→disk rule; file-edit→session acceptEdits; read→content-less allow), instead of force-upgrading to localSettings + mangling setMode. New test proves the non-Bash passthrough. Suite at the pre-existing baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)