### PR TITLE
fix(perm-ux): accurate per-tool wording for the persist option

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -1389,6 +1389,12 @@ class _AgentSession:
                     _serialize_permission_update(u)
                     for u in (getattr(request, "suggestions", None) or ())
                 ],
+                # Authoritative per-tool wording for the persist option, e.g.
+                # "allow all edits during this session" for a file edit vs.
+                # "and don't ask again for <rule>" for Bash — so the box states
+                # the real grant scope instead of a generic "don't ask again for
+                # <tool>". Mirrors the original's tool-specific option text.
+                "session_label": _session_option_label_safe(request),
             },
         })
 
@@ -2461,6 +2467,22 @@ def _system_message(session_id: str, text: str, *, level: str = "info") -> dict:
         "level": level,
         "message": text,
     }
+
+
+def _session_option_label_safe(request: Any) -> str | None:
+    """Authoritative per-tool label for the persist option (see
+    ``session_option_label``). Best-effort — never break a permission prompt
+    over label wording."""
+    try:
+        from src.permissions.updates import session_option_label
+
+        return session_option_label(
+            getattr(request, "suggestions", None) or (),
+            getattr(request, "tool_name", "") or None,
+            getattr(request, "tool_input", None),
+        )
+    except Exception:  # noqa: BLE001 — label is cosmetic
+        return None
 
 
 def _serialize_permission_update(update: Any) -> dict:

--- a/tests/test_ch13_tui_round4.py
+++ b/tests/test_ch13_tui_round4.py
@@ -14,7 +14,40 @@ from unittest.mock import MagicMock
 from src.server.agent_server import (
     _deserialize_permission_update,
     _serialize_permission_update,
+    _session_option_label_safe,
 )
+
+
+class TestSessionOptionLabel(unittest.TestCase):
+    """R6 — the can_use_tool request carries the authoritative per-tool label
+    so the box states the real grant scope (not a generic "for <tool>")."""
+
+    def test_file_edit_label(self):
+        from src.permissions.updates import default_session_suggestions
+
+        req = MagicMock()
+        req.suggestions = default_session_suggestions("Write", {"file_path": "/a/b"})
+        req.tool_name = "Write"
+        req.tool_input = {"file_path": "/a/b"}
+        # A file edit grants session accept-edits mode, not a per-Write rule.
+        self.assertEqual(
+            _session_option_label_safe(req), "allow all edits during this session"
+        )
+
+    def test_bash_label_and_safe_on_garbage(self):
+        from src.permissions.bash_suggestions import suggestions_for_bash_command
+
+        req = MagicMock()
+        req.suggestions = suggestions_for_bash_command("git status")
+        req.tool_name = "Bash"
+        req.tool_input = {"command": "git status"}
+        label = _session_option_label_safe(req)
+        self.assertIsNotNone(label)
+        self.assertIn("git status", label)
+        # Never raises — a malformed request yields None, not an exception.
+        broken = MagicMock()
+        broken.suggestions = object()  # not iterable
+        self.assertIsNone(_session_option_label_safe(broken))
 
 
 class TestPermissionUpdateWire(unittest.TestCase):

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -364,14 +364,17 @@ describe('GatewayClient NDJSON adapter', () => {
     proc.line({
       request: {
         input: { file_path: '/a/b.ts' }, subtype: 'can_use_tool', tool_name: 'Write',
+        session_label: 'allow all edits during this session',
         suggestions: [setModeSuggestion]
       },
       request_id: 'r4', type: 'control_request'
     })
     await vi.waitFor(() => expect(last('approval.request')).toBeTruthy())
-    // The box still offers a persistable option for non-Bash tools.
+    // The box still offers a persistable option for non-Bash tools, with the
+    // backend's authoritative per-tool wording (not "don't ask again for Write").
     expect(last('approval.request').payload.allow_permanent).toBe(true)
     expect(last('approval.request').payload.rule).toBeNull()
+    expect(last('approval.request').payload.session_label).toBe('allow all edits during this session')
 
     await gw.request('approval.respond', { choice: 'always' })
     const resp = sent.find(m => m.type === 'control_response')?.response?.response

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -762,6 +762,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         const allowPermanent = ev.payload.allow_permanent !== false
         const rule = ev.payload.rule
         const ruleLabel = ev.payload.rule_label
+        const sessionLabel = ev.payload.session_label
 
         patchOverlayState({
           approval: {
@@ -769,6 +770,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
             command: String(ev.payload.command ?? ''),
             rule: rule ? String(rule) : undefined,
             ruleLabel: ruleLabel ? String(ruleLabel) : undefined,
+            sessionLabel: sessionLabel ? String(sessionLabel) : undefined,
             toolName: String(ev.payload.tool_name ?? 'tool')
           }
         })

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -136,19 +136,29 @@ export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptPr
         const isSel = sel === i
         const head = `${isSel ? '❯ ' : '  '}${i + 1}. `
         if (o === 'always') {
-          const label = `${head}${LABELS.always} `
-          // Bash edits the rule inline; other tools show a static scope label
-          // (rule label, else the tool name — "…don't ask again for Write").
-          const staticRule = ruleText || req.ruleLabel || req.toolName
+          // Bash edits the rule inline: "Yes, and don't ask again for [git:*]".
+          if (editable) {
+            const label = `${head}${LABELS.always} `
+            const staticRule = ruleText || req.ruleLabel || req.toolName
+            return (
+              <Box key={o}>
+                <Text bold={isSel} color={isSel ? t.color.warn : t.color.muted}>{label}</Text>
+                {editing ? (
+                  <TextInput columns={Math.max(12, innerWidth - label.length)} focus onChange={setRuleText} onSubmit={() => confirm('always')} value={ruleText} />
+                ) : (
+                  <Text bold={isSel} color={isSel ? t.color.text : t.color.muted}>{staticRule}</Text>
+                )}
+              </Box>
+            )
+          }
+          // Other tools: the backend's authoritative per-tool wording, which
+          // states the real scope ("Yes, allow all edits during this session"),
+          // not a generic "don't ask again for <tool>".
+          const text = req.sessionLabel
+            ? `Yes, ${req.sessionLabel}`
+            : `${LABELS.always} ${req.ruleLabel || req.toolName}`
           return (
-            <Box key={o}>
-              <Text bold={isSel} color={isSel ? t.color.warn : t.color.muted}>{label}</Text>
-              {editing && editable ? (
-                <TextInput columns={Math.max(12, innerWidth - label.length)} focus onChange={setRuleText} onSubmit={() => confirm('always')} value={ruleText} />
-              ) : (
-                <Text bold={isSel} color={isSel ? t.color.text : t.color.muted}>{staticRule}</Text>
-              )}
-            </Box>
+            <Text bold={isSel} color={isSel ? t.color.warn : t.color.muted} key={o}>{head}{text}</Text>
           )
         }
         return (

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -46,8 +46,9 @@ function safeJson(v: unknown): string {
   }
 }
 
-/** ch13 round-4 — a human label for a permission suggestion rule, e.g.
- *  `Bash(ls:*)`, so the "Always allow" option shows what it will persist. */
+/** A human label for a permission suggestion rule, e.g. `Bash(ls:*)` (or just
+ *  the tool name for a content-less rule), shown on the "don't ask again"
+ *  option so the user sees what it will persist. */
 export function describeSuggestionRule(suggestion: any): string | null {
   const rule = suggestion?.rules?.[0]
   if (!rule || !rule.tool_name) return null
@@ -786,6 +787,10 @@ export class GatewayClient extends EventEmitter {
           command: approvalCommandText(req.input),
           rule: ruleContent,
           rule_label: describeSuggestionRule(suggestions[0]),
+          // Authoritative per-tool wording for the persist option (e.g. "allow
+          // all edits during this session"); the box uses it verbatim for
+          // non-Bash tools instead of a generic "don't ask again for <tool>".
+          session_label: typeof req.session_label === 'string' ? req.session_label : null,
           tool_name: String(req.tool_name ?? 'tool')
         },
         type: 'approval.request'

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -690,6 +690,7 @@ export type GatewayEvent =
         command: string
         rule?: null | string
         rule_label?: null | string
+        session_label?: null | string
         tool_name: string
       }
       session_id?: string

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -103,6 +103,10 @@ export interface ApprovalReq {
   rule?: string
   // Display form of the rule for the option label, e.g. "Bash(git status:*)".
   ruleLabel?: string
+  // Authoritative per-tool wording for the persist option, rendered as
+  // "Yes, <sessionLabel>" (e.g. "Yes, allow all edits during this session").
+  // Used for non-Bash tools; Bash uses the editable rule instead.
+  sessionLabel?: string
 }
 
 export interface ConfirmReq {


### PR DESCRIPTION
Follow-up to #608/#609. Both critics noted the non-Bash label "…don't ask again for Write" overstates the scope — a file edit is a **session-scoped accept-edits** grant, not a per-Write rule. Wires the backend's authoritative `session_option_label` through so the box shows "Yes, allow all edits during this session" (reads: "allow reading during this session"; Bash keeps its inline-editable rule). Best-effort on the backend (label is cosmetic). Tests for the label helper + the payload flow. Suite at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)