### PR TITLE
test(perm-ux): guard the persist-option gating (approvalOptions)

### DIFF
--- a/ui-tui/src/__tests__/approvalAction.test.ts
+++ b/ui-tui/src/__tests__/approvalAction.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { approvalAction } from '../components/prompts.js'
+import { approvalAction, approvalOptions } from '../components/prompts.js'
 
 describe('approvalAction — pure key dispatch for ApprovalPrompt', () => {
   it('maps Esc to deny — parity with global Ctrl+C cancellation', () => {
@@ -46,6 +46,25 @@ describe('approvalAction — pure key dispatch for ApprovalPrompt', () => {
   it('returns noop for unrelated keystrokes (printable letters etc.)', () => {
     expect(approvalAction('a', {}, 0)).toEqual({ kind: 'noop' })
     expect(approvalAction(' ', {}, 0)).toEqual({ kind: 'noop' })
+  })
+
+  it('offers the persist option for EVERY tool with a suggestion, editable only for Bash', () => {
+    // Bash: suggestion with an editable rule → 3 options, editable.
+    expect(approvalOptions({ allowPermanent: true, rule: 'git status:*' })).toEqual({
+      editable: true,
+      opts: ['once', 'always', 'deny']
+    })
+    // Non-Bash (Write/Read/WebFetch): suggestion but no rule → 3 options, NOT
+    // editable (this is the regression that was fixed — the option must appear).
+    expect(approvalOptions({ allowPermanent: true, rule: undefined })).toEqual({
+      editable: false,
+      opts: ['once', 'always', 'deny']
+    })
+    // No suggestion / tirith warning → 2 options, not editable.
+    expect(approvalOptions({ allowPermanent: false, rule: undefined })).toEqual({
+      editable: false,
+      opts: ['once', 'deny']
+    })
   })
 
   it('respects a reduced option set when permanent allow is disabled', () => {

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -74,13 +74,28 @@ export function approvalAction(
   return { kind: 'noop' }
 }
 
+/**
+ * Which options to show, and whether the grant rule is editable. Exported +
+ * pure so the gating is testable without mounting Ink (this is the exact site
+ * of a fixed regression: the persist option must appear for EVERY tool the
+ * backend sent a suggestion for, not only Bash).
+ *
+ * - `allowPermanent` is the backend's "a suggestion exists" signal
+ *   (`suggestions.length > 0`), false only for a tirith warning / no suggestion
+ *   → no persist option.
+ * - `editable` is Bash-only: only a Bash suggestion carries a `rule` to widen.
+ */
+export function approvalOptions(
+  req: Pick<ApprovalReq, 'allowPermanent' | 'rule'>
+): { editable: boolean; opts: readonly ApprovalChoice[] } {
+  return {
+    editable: !!req.rule,
+    opts: req.allowPermanent === false ? APPROVAL_OPTS_NO_ALWAYS : APPROVAL_OPTS
+  }
+}
+
 export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptProps) {
-  // Offer the persist ("don't ask again") option whenever the backend sent a
-  // suggestion (allowPermanent) — that includes non-Bash tools (Write→accept
-  // edits this session, Read/WebFetch→content-less allow), not just Bash. Only
-  // Bash carries an editable rule (req.rule); the others show a static label.
-  const opts = req.allowPermanent === false ? APPROVAL_OPTS_NO_ALWAYS : APPROVAL_OPTS
-  const editable = !!req.rule
+  const { editable, opts } = approvalOptions(req)
   const [sel, setSel] = useState(0)
   // The editable grant rule (e.g. "git status:*"), which the user can widen to
   // "git:*" so one grant covers the family. Seeded from the backend suggestion.


### PR DESCRIPTION
Closes the coverage gap perm-ux-2 flagged: the ApprovalPrompt opts/editable gating (the site of the #609 regression) had no test. Extracts a pure `approvalOptions(req)` helper and unit-tests it — persist option for every tool with a suggestion, editable only for Bash. Test-only + a 2-line behavior-preserving refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)