### PR TITLE
feat(tui): faithful Claude Code diff rendering for Edit/Write results

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -2325,6 +2325,40 @@ def _filter_registry(registry, *, keep) -> None:
 # ─── message shaping ─────────────────────────────────────────────────────────
 
 
+def _display_tool_result(value: Any) -> dict | None:
+    """Trim a rich Edit/Write tool output for the wire (display data only).
+
+    Recognizes the self-describing shape (``type``/``filePath``/
+    ``structuredPatch``) rather than a tool name so mid-turn clients can
+    render it without tool_use bookkeeping. Deliberate delta from real CC's
+    full-parity ``tool_use_result``: ``originalFile`` is dropped (the display
+    renderer never reads it) and update-type ``content`` (the full post-edit
+    file) is reduced to ``firstLine`` (language/shebang detection only; the
+    original uses the pre-edit first line — differs only when line 1 itself
+    changed); create-type keeps ``content`` for the file preview. Always
+    builds a new dict — ``value`` is shared with the in-memory message and
+    the persisted transcript.
+    """
+    if not isinstance(value, dict):
+        return None
+    if value.get("type") not in ("create", "update"):
+        return None
+    if not isinstance(value.get("filePath"), str) or not isinstance(value.get("structuredPatch"), list):
+        return None
+    trimmed: dict[str, Any] = {
+        "type": value["type"],
+        "filePath": value["filePath"],
+        "structuredPatch": value["structuredPatch"],
+    }
+    content = value.get("content")
+    if isinstance(content, str):
+        if value["type"] == "create":
+            trimmed["content"] = content
+        else:
+            trimmed["firstLine"] = content.split("\n", 1)[0]
+    return trimmed
+
+
 def _sdk_envelope(message: Any, session_id: str) -> dict | None:
     """Wrap a :class:`Message` into the SDK envelope the client renders."""
     from src.types.messages import message_to_dict
@@ -2335,12 +2369,19 @@ def _sdk_envelope(message: Any, session_id: str) -> dict | None:
         return None
     role = d.get("role", getattr(message, "role", "assistant"))
     msg_type = "assistant" if role == "assistant" else "user"
-    return {
+    env: dict[str, Any] = {
         "type": msg_type,
         "uuid": d.get("uuid"),
         "session_id": session_id,
         "message": {"role": role, "content": d.get("content")},
     }
+    # Rich Edit/Write result → snake_case per the SDK stream convention
+    # (SDKUserMessage.tool_use_result); the TUI renders the structured patch
+    # from it instead of fabricating a diff from tool input.
+    tool_use_result = _display_tool_result(d.get("toolUseResult"))
+    if tool_use_result is not None:
+        env["tool_use_result"] = tool_use_result
+    return env
 
 
 def _result_message(

--- a/src/tool_system/diff_utils.py
+++ b/src/tool_system/diff_utils.py
@@ -7,8 +7,34 @@ from typing import Iterable
 
 _HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 
+# One line terminator at end-of-line (difflib is fed splitlines(keepends=True),
+# so hunk lines arrive as a mix of "\n" / "\r\n" / bare-final-line).
+_LINE_TERM_RE = re.compile(r"(?:\r\n|\r|\n)$")
+
+_LEADING_TABS_RE = re.compile(r"^\t+", re.MULTILINE)
+
+
+def convert_leading_tabs_to_spaces(content: str) -> str:
+    """Leading tabs → 2 spaces each, for display patches only.
+
+    Mirrors the TS ``convertLeadingTabsToSpaces`` (utils/diff.ts) that the
+    original applies to both sides before computing ``structuredPatch`` — a
+    raw ``\\t`` reaching the TUI renderer has terminal-dependent width and
+    breaks the diff gutter/padding math.
+    """
+    if "\t" not in content:
+        return content
+    return _LEADING_TABS_RE.sub(lambda m: "  " * len(m.group(0)), content)
+
 
 def unified_diff_hunks(diff_lines: Iterable[str]) -> list[dict]:
+    """Parse ``difflib.unified_diff`` output into jsdiff StructuredPatchHunk dicts.
+
+    Hunk lines keep their ``+``/``-``/`` `` marker but are stripped of the
+    single trailing line terminator so the shape matches jsdiff's
+    ``structuredPatch`` (whose lines carry no terminators) — consumers concat
+    them with ``\\n`` and index into them for word-diff ranges.
+    """
     hunks: list[dict] = []
     current: dict | None = None
     for line in diff_lines:
@@ -29,10 +55,12 @@ def unified_diff_hunks(diff_lines: Iterable[str]) -> list[dict]:
             }
             continue
         if current is None:
+            # difflib's ---/+++ file headers precede the first @@, so this
+            # guard is what skips them. Inside a hunk every line starts with
+            # +/-/space; a removed "-- sql comment" emits "--- sql comment"
+            # and MUST be kept (an explicit header skip here used to eat it).
             continue
-        if line.startswith("---") or line.startswith("+++") or line.startswith("\\ No newline"):
-            continue
-        current["lines"].append(line)
+        current["lines"].append(_LINE_TERM_RE.sub("", line))
     if current is not None:
         hunks.append(current)
     return hunks

--- a/src/tool_system/tools/edit.py
+++ b/src/tool_system/tools/edit.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from ..build_tool import Tool, build_tool
 from ..context import ToolContext
-from ..diff_utils import unified_diff_hunks
+from ..diff_utils import convert_leading_tabs_to_spaces, unified_diff_hunks
 from .read import _backfill_read_edit_path  # shared file_path expander
 from ..errors import ToolInputError, ToolPermissionError
 from ..protocol import ToolResult
@@ -311,8 +311,8 @@ def _edit_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
     path.write_text(updated, encoding="utf-8")
     context.mark_file_read(path)
 
-    before_lines = original.splitlines(keepends=True)
-    after_lines = updated.splitlines(keepends=True)
+    before_lines = convert_leading_tabs_to_spaces(original).splitlines(keepends=True)
+    after_lines = convert_leading_tabs_to_spaces(updated).splitlines(keepends=True)
     diff_lines = list(
         difflib.unified_diff(
             before_lines,

--- a/src/tool_system/tools/write.py
+++ b/src/tool_system/tools/write.py
@@ -8,7 +8,7 @@ from ..build_tool import Tool, ValidationResult, build_tool
 from ..context import ToolContext
 from ..errors import ToolInputError, ToolPermissionError
 from ..protocol import ToolResult
-from ..diff_utils import unified_diff_hunks
+from ..diff_utils import convert_leading_tabs_to_spaces, unified_diff_hunks
 from src.permissions.types import (
     PermissionAllowDecision,
     PermissionAskDecision,
@@ -246,8 +246,8 @@ def _write_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
     context.mark_file_read(path)
-    before_lines = (original_file or "").splitlines(keepends=True)
-    after_lines = content.splitlines(keepends=True)
+    before_lines = convert_leading_tabs_to_spaces(original_file or "").splitlines(keepends=True)
+    after_lines = convert_leading_tabs_to_spaces(content).splitlines(keepends=True)
     diff_lines = list(
         difflib.unified_diff(
             before_lines,

--- a/tests/server/test_sdk_envelope_tool_result.py
+++ b/tests/server/test_sdk_envelope_tool_result.py
@@ -1,0 +1,149 @@
+"""_sdk_envelope forwarding of rich Edit/Write tool results (tool_use_result).
+
+The TUI renders the structured patch (line numbers, word diff, hunks) from
+``tool_use_result`` on the user envelope; these tests pin the trimming rules
+and the no-mutation contract, plus the diff_utils normalization the wire
+shape depends on.
+"""
+
+from __future__ import annotations
+
+import copy
+
+from src.server.agent_server import _display_tool_result, _sdk_envelope
+from src.tool_system.diff_utils import convert_leading_tabs_to_spaces, unified_diff_hunks
+from src.types.messages import create_user_message
+
+
+def _edit_output(**overrides):
+    out = {
+        "type": "update",
+        "filePath": "/tmp/x.py",
+        "content": "line one\nline two\n",
+        "structuredPatch": [
+            {"oldStart": 1, "oldLines": 2, "newStart": 1, "newLines": 2, "lines": [" a", "-b", "+B"]}
+        ],
+    }
+    out.update(overrides)
+    return out
+
+
+class TestDisplayToolResult:
+    def test_update_replaces_content_with_first_line(self):
+        trimmed = _display_tool_result(_edit_output())
+        assert trimmed == {
+            "type": "update",
+            "filePath": "/tmp/x.py",
+            "structuredPatch": _edit_output()["structuredPatch"],
+            "firstLine": "line one",
+        }
+
+    def test_create_keeps_content(self):
+        trimmed = _display_tool_result(
+            _edit_output(type="create", structuredPatch=[], content="new file\nbody\n")
+        )
+        assert trimmed is not None
+        assert trimmed["content"] == "new file\nbody\n"
+        assert "firstLine" not in trimmed
+
+    def test_original_file_never_forwarded(self):
+        trimmed = _display_tool_result(_edit_output(originalFile="old contents"))
+        assert trimmed is not None
+        assert "originalFile" not in trimmed
+
+    def test_rejects_non_edit_shapes(self):
+        assert _display_tool_result("Error: old_string not found in file") is None
+        assert _display_tool_result(None) is None
+        assert _display_tool_result({"stdout": "", "stderr": ""}) is None
+        assert _display_tool_result(_edit_output(type="rename")) is None
+        assert _display_tool_result(_edit_output(structuredPatch="nope")) is None
+        assert _display_tool_result(_edit_output(filePath=123)) is None
+
+    def test_source_dict_is_not_mutated(self):
+        source = _edit_output(originalFile="old contents")
+        snapshot = copy.deepcopy(source)
+        _display_tool_result(source)
+        assert source == snapshot
+
+
+class TestSdkEnvelope:
+    def test_user_envelope_carries_trimmed_tool_use_result(self):
+        msg = create_user_message(
+            content=[{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}],
+            toolUseResult=_edit_output(),
+        )
+        env = _sdk_envelope(msg, "sess")
+        assert env is not None
+        assert env["type"] == "user"
+        assert env["tool_use_result"]["firstLine"] == "line one"
+        assert "content" not in env["tool_use_result"]
+
+    def test_envelope_omits_field_for_plain_results(self):
+        msg = create_user_message(
+            content=[{"type": "tool_result", "tool_use_id": "t1", "content": "boom"}],
+            toolUseResult="Error: boom",
+        )
+        env = _sdk_envelope(msg, "sess")
+        assert env is not None
+        assert "tool_use_result" not in env
+
+    def test_envelope_leaves_message_tool_use_result_intact(self):
+        source = _edit_output(originalFile="old contents")
+        snapshot = copy.deepcopy(source)
+        msg = create_user_message(
+            content=[{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}],
+            toolUseResult=source,
+        )
+        _sdk_envelope(msg, "sess")
+        assert source == snapshot
+
+
+class TestDiffUtilsNormalization:
+    def test_hunk_lines_have_no_terminators_lf(self):
+        import difflib
+
+        before = "a\nb\nc\n".splitlines(keepends=True)
+        after = "a\nB\nc\n".splitlines(keepends=True)
+        hunks = unified_diff_hunks(difflib.unified_diff(before, after, n=3, lineterm=""))
+        assert hunks[0]["lines"] == [" a", "-b", "+B", " c"]
+
+    def test_hunk_lines_have_no_terminators_crlf(self):
+        import difflib
+
+        before = "a\r\nb\r\n".splitlines(keepends=True)
+        after = "a\r\nB\r\n".splitlines(keepends=True)
+        hunks = unified_diff_hunks(difflib.unified_diff(before, after, n=3, lineterm=""))
+        assert hunks[0]["lines"] == [" a", "-b", "+B"]
+
+    def test_no_trailing_newline_final_line(self):
+        import difflib
+
+        before = "a\nb".splitlines(keepends=True)
+        after = "a\nB".splitlines(keepends=True)
+        hunks = unified_diff_hunks(difflib.unified_diff(before, after, n=3, lineterm=""))
+        assert hunks[0]["lines"] == [" a", "-b", "+B"]
+
+    def test_leading_tabs_become_two_spaces(self):
+        assert convert_leading_tabs_to_spaces("\tx\n\t\ty\nz\ta\n") == "  x\n    y\nz\ta\n"
+        # fast path: untouched when no tabs
+        s = "plain\n"
+        assert convert_leading_tabs_to_spaces(s) is s
+
+    def test_lone_cr_terminators_stripped(self):
+        import difflib
+
+        before = "a\rb\r".splitlines(keepends=True)
+        after = "a\rB\r".splitlines(keepends=True)
+        hunks = unified_diff_hunks(difflib.unified_diff(before, after, n=3, lineterm=""))
+        assert hunks[0]["lines"] == [" a", "-b", "+B"]
+
+    def test_content_lines_starting_with_marker_runs_survive(self):
+        # A removed "-- sql comment" emits "--- sql comment" and an added
+        # "++i;" emits "+++i;" — both are hunk CONTENT, not file headers, and
+        # must not be eaten (the header skip regression).
+        import difflib
+
+        before = "x\n-- sql comment\ny\n".splitlines(keepends=True)
+        after = "x\ny\n++i;\n".splitlines(keepends=True)
+        hunks = unified_diff_hunks(difflib.unified_diff(before, after, fromfile="a", tofile="b", n=3, lineterm=""))
+        assert hunks[0]["lines"] == [" x", "--- sql comment", " y", "+++i;"]

--- a/ui-tui/package-lock.json
+++ b/ui-tui/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@clawcodex/ink": "file:./packages/clawcodex-ink",
         "@nanostores/react": "^1.1.0",
+        "diff": "^9.0.0",
+        "highlight.js": "^11.11.1",
         "ink": "^6.8.0",
         "ink-text-input": "^6.0.0",
         "nanostores": "^1.2.0",
@@ -19,6 +21,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9",
+        "@types/diff": "^7.0.2",
         "@types/node": "^24.13.2",
         "@types/react": "^19.2.14",
         "@typescript-eslint/eslint-plugin": "^8",
@@ -1361,6 +1364,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/diff": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
+      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "dev": true,
@@ -2315,6 +2325,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {
@@ -3286,6 +3305,15 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/ignore": {

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -18,6 +18,8 @@
   "dependencies": {
     "@clawcodex/ink": "file:./packages/clawcodex-ink",
     "@nanostores/react": "^1.1.0",
+    "diff": "^9.0.0",
+    "highlight.js": "^11.11.1",
     "ink": "^6.8.0",
     "ink-text-input": "^6.0.0",
     "nanostores": "^1.2.0",
@@ -27,6 +29,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9",
+    "@types/diff": "^7.0.2",
     "@types/node": "^24.13.2",
     "@types/react": "^19.2.14",
     "@typescript-eslint/eslint-plugin": "^8",

--- a/ui-tui/src/__tests__/structuredDiff.test.ts
+++ b/ui-tui/src/__tests__/structuredDiff.test.ts
@@ -1,0 +1,495 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Fake the agent-server child so tests can feed NDJSON protocol lines and
+// observe the GatewayEvents (same harness as gatewayClient.test.ts).
+const harness = vi.hoisted(() => ({ proc: null as null | EventEmitter, spawnCalls: [] as unknown[][] }))
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => {
+    harness.spawnCalls.push(args)
+
+    return harness.proc
+  }
+}))
+
+import { renderSync } from '@clawcodex/ink'
+import React from 'react'
+
+import { turnController } from '../app/turnController.js'
+import { getTurnState, resetTurnState } from '../app/turnStore.js'
+import { DiffView } from '../components/diffView.js'
+import { MessageLine } from '../components/messageLine.js'
+import { GatewayClient } from '../gatewayClient.js'
+import { ColorDiff, ensureHighlighter } from '../lib/colorDiff.js'
+import { buildToolTrailLine, stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+import type { MsgDiffData } from '../types.js'
+
+class FakeProc extends EventEmitter {
+  kill = vi.fn()
+  stderr = new PassThrough()
+  stdin = new PassThrough()
+  stdout = new PassThrough()
+
+  line(obj: unknown): void {
+    this.stdout.write(JSON.stringify(obj) + '\n')
+  }
+}
+
+const HUNK = {
+  lines: [' context line', '-  id: "obama-as-author",', '+  id: "drone-warfare",', ' tail line'],
+  newLines: 3,
+  newStart: 220,
+  oldLines: 3,
+  oldStart: 220
+}
+
+const TOOL_USE_RESULT = {
+  filePath: '/ws/src/posts.ts',
+  firstLine: 'export const posts = [',
+  structuredPatch: [
+    {
+      lines: HUNK.lines,
+      newLines: HUNK.newLines,
+      newStart: HUNK.newStart,
+      oldLines: HUNK.oldLines,
+      oldStart: HUNK.oldStart
+    }
+  ],
+  type: 'update'
+}
+
+// ── ColorDiff layout (the faithful renderer itself) ─────────────────────────
+
+describe('ColorDiff layout', () => {
+  const prevColorTerm = process.env.COLORTERM
+
+  beforeEach(() => {
+    process.env.COLORTERM = 'truecolor'
+  })
+
+  afterEach(() => {
+    if (prevColorTerm === undefined) {
+      delete process.env.COLORTERM
+    } else {
+      process.env.COLORTERM = prevColorTerm
+    }
+  })
+
+  it('renders the original gutter: right-aligned line number, marker, padded background rows', async () => {
+    await ensureHighlighter()
+    const rows = new ColorDiff(HUNK, null, '/ws/src/posts.ts', null).render('dark', 60, false)!
+    const plain = rows.map(row => stripAnsi(row))
+
+    // ` NNN ` gutter + marker + content; context rows unpadded, changed rows
+    // padded to the wrap width (60 − 3 digits − 3 = 54 content columns).
+    expect(plain[0]).toBe(' 220  context line')
+    expect(plain[1]).toBe(' 221 -  id: "obama-as-author",' + ' '.repeat(54 - '  id: "obama-as-author",'.length))
+    expect(plain[2]).toBe(' 221 +  id: "drone-warfare",' + ' '.repeat(54 - '  id: "drone-warfare",'.length))
+    expect(plain[3]).toBe(' 222  tail line')
+    // no ---/+++ headers, ever
+    expect(plain.join('\n')).not.toMatch(/^[-+]{3} /m)
+  })
+
+  it('paints the original dark-theme backgrounds and word-diff highlights', () => {
+    // Small change (one token) so the 0.4 change-ratio threshold admits
+    // word-level highlighting.
+    const small = {
+      lines: [' before', '-  date: "2026-06-21",', '+  date: "2026-06-22",', ' after'],
+      newLines: 3,
+      newStart: 10,
+      oldLines: 3,
+      oldStart: 10
+    }
+
+    const rows = new ColorDiff(small, null, '/ws/src/posts.ts', null).render('dark', 60, false)!
+
+    // deleteLine rgb(61,1,0) on the removed row, deleteWord rgb(92,2,0) on
+    // the changed token; addLine rgb(2,40,0) / addWord rgb(4,71,0).
+    expect(rows[1]).toContain('48;2;61;1;0')
+    expect(rows[1]).toContain('48;2;92;2;0')
+    expect(rows[2]).toContain('48;2;2;40;0')
+    expect(rows[2]).toContain('48;2;4;71;0')
+    // context rows keep the terminal default background
+    expect(rows[0]).not.toContain('48;2;')
+  })
+
+  it('rejects word-diff when most of the line changed (threshold parity)', () => {
+    const rows = new ColorDiff(HUNK, null, '/ws/src/posts.ts', null).render('dark', 60, false)!
+
+    expect(rows[1]).toContain('48;2;61;1;0')
+    expect(rows[1]).not.toContain('48;2;92;2;0')
+  })
+
+  it('wraps long lines with a blank continuation gutter', () => {
+    const wide = {
+      lines: ['+' + 'x'.repeat(60)],
+      newLines: 1,
+      newStart: 7,
+      oldLines: 0,
+      oldStart: 7
+    }
+
+    const rows = new ColorDiff(wide, null, '/ws/a.txt', null).render('dark', 40, false)!
+    const plain = rows.map(row => stripAnsi(row))
+
+    expect(plain.length).toBeGreaterThan(1)
+    expect(plain[0]!.startsWith(' 7 +')).toBe(true)
+    expect(plain[1]!.startsWith('   +')).toBe(true)
+  })
+})
+
+// ── GatewayClient: tool_use_result → structured_diff ────────────────────────
+
+describe('GatewayClient structured diff mapping', () => {
+  const prevWs = process.env.CLAWCODEX_WORKSPACE
+  let events: any[]
+  let gw: GatewayClient
+  let proc: FakeProc
+
+  beforeEach(() => {
+    process.env.CLAWCODEX_WORKSPACE = '/ws'
+    proc = new FakeProc()
+    harness.proc = proc
+    harness.spawnCalls = []
+    events = []
+    gw = new GatewayClient()
+    gw.on('event', (e: any) => events.push(e))
+    gw.start()
+    gw.drain()
+  })
+
+  afterEach(() => {
+    gw.kill()
+
+    if (prevWs === undefined) {
+      delete process.env.CLAWCODEX_WORKSPACE
+    } else {
+      process.env.CLAWCODEX_WORKSPACE = prevWs
+    }
+  })
+
+  const last = (t: string) => [...events].reverse().find(e => e.type === t)
+
+  const completeTool = async (id: string, name: string, input: unknown, resultMsg: Record<string, unknown>) => {
+    proc.line({ message: { content: [{ id, input, name, type: 'tool_use' }] }, type: 'assistant' })
+    await vi.waitFor(() => expect(last('tool.start')).toBeTruthy())
+    proc.line(resultMsg)
+    await vi.waitFor(() => expect(last('tool.complete')).toBeTruthy())
+
+    return last('tool.complete').payload
+  }
+
+  const userResult = (id: string, content: unknown, extra: Record<string, unknown> = {}, isError = false) => ({
+    message: { content: [{ content, is_error: isError, tool_use_id: id, type: 'tool_result' }] },
+    type: 'user',
+    ...extra
+  })
+
+  it('maps an update tool_use_result to structured_diff and skips the legacy fake diff', async () => {
+    const payload = await completeTool(
+      't1',
+      'Edit',
+      { file_path: '/ws/src/posts.ts', new_string: 'b', old_string: 'a' },
+      userResult('t1', 'ok', { tool_use_result: TOOL_USE_RESULT })
+    )
+
+    expect(payload.structured_diff).toMatchObject({
+      filePath: '/ws/src/posts.ts',
+      firstLine: 'export const posts = [',
+      kind: 'update'
+    })
+    expect(payload.structured_diff.hunks).toHaveLength(1)
+    expect(payload.structured_diff.hunks[0].lines).toEqual(HUNK.lines)
+    expect(payload.inline_diff).toBeUndefined()
+  })
+
+  it('maps a create tool_use_result with its content preview', async () => {
+    const payload = await completeTool(
+      't1',
+      'Write',
+      { content: 'hello\nworld\n', file_path: '/ws/new.txt' },
+      userResult('t1', 'ok', {
+        tool_use_result: { content: 'hello\nworld\n', filePath: '/ws/new.txt', structuredPatch: [], type: 'create' }
+      })
+    )
+
+    expect(payload.structured_diff).toMatchObject({ content: 'hello\nworld\n', kind: 'create' })
+  })
+
+  it('falls back to the legacy input diff when tool_use_result is absent', async () => {
+    const payload = await completeTool(
+      't1',
+      'Edit',
+      { file_path: '/ws/src/posts.ts', new_string: 'b', old_string: 'a' },
+      userResult('t1', 'ok')
+    )
+
+    expect(payload.structured_diff).toBeUndefined()
+    expect(payload.inline_diff).toContain('-a')
+    expect(payload.inline_diff).toContain('+b')
+  })
+
+  it('rejects malformed tool_use_result shapes', async () => {
+    const payload = await completeTool(
+      't1',
+      'Edit',
+      { file_path: '/ws/x.ts', new_string: 'b', old_string: 'a' },
+      userResult('t1', 'ok', { tool_use_result: { structuredPatch: [{ nope: true }], type: 'update' } })
+    )
+
+    expect(payload.structured_diff).toBeUndefined()
+  })
+
+  it('renders no diff of any kind for a failed edit', async () => {
+    const payload = await completeTool(
+      't1',
+      'Edit',
+      { file_path: '/ws/x.ts', new_string: 'b', old_string: 'a' },
+      userResult('t1', 'Error: old_string not found in file', { tool_use_result: TOOL_USE_RESULT }, true)
+    )
+
+    expect(payload.structured_diff).toBeUndefined()
+    expect(payload.inline_diff).toBeUndefined()
+  })
+})
+
+// ── turnController: structured diff segments ────────────────────────────────
+
+describe('turnController structured diff segments', () => {
+  beforeEach(() => {
+    turnController.recordError() // clears any segment state left by other suites
+    resetTurnState()
+    turnController.startMessage()
+  })
+
+  afterEach(() => {
+    turnController.recordError()
+    resetTurnState()
+  })
+
+  const diff = (): Parameters<typeof turnController.pushStructuredDiffSegment>[0] => ({
+    filePath: '/ws/src/posts.ts',
+    firstLine: 'export const posts = [',
+    hunks: [{ ...HUNK, lines: [...HUNK.lines] }],
+    kind: 'update'
+  })
+
+  it('pushes a diff segment carrying diffData and a derived ```diff fence', () => {
+    turnController.pushStructuredDiffSegment(diff(), ['Edit(src/posts.ts)'])
+
+    const segments = getTurnState().streamSegments
+    expect(segments).toHaveLength(1)
+    expect(segments[0]).toMatchObject({ kind: 'diff', role: 'assistant' })
+    expect(segments[0]!.diffData?.hunks).toHaveLength(1)
+    expect(segments[0]!.text).toBe('```diff\n' + HUNK.lines.join('\n') + '\n```')
+    expect(segments[0]!.tools).toEqual(['Edit(src/posts.ts)'])
+  })
+
+  it('drops consecutive duplicate segments', () => {
+    turnController.pushStructuredDiffSegment(diff())
+    turnController.pushStructuredDiffSegment(diff())
+
+    expect(getTurnState().streamSegments).toHaveLength(1)
+  })
+
+  it('caps giant patches at ingestion and records the dropped count', () => {
+    const big = {
+      filePath: '/ws/big.ts',
+      hunks: [
+        {
+          lines: Array.from({ length: 300 }, (_, i) => `+line ${i}`),
+          newLines: 300,
+          newStart: 1,
+          oldLines: 0,
+          oldStart: 1
+        }
+      ],
+      kind: 'update' as const
+    }
+
+    turnController.pushStructuredDiffSegment(big)
+
+    const seg = getTurnState().streamSegments[0]!
+    expect(seg.diffData?.hunks[0]!.lines).toHaveLength(240)
+    expect(seg.diffData?.truncatedLines).toBe(60)
+    expect(seg.text.split('\n')).toHaveLength(242) // fence open + 240 + fence close
+  })
+
+  it('previews create-type segments from content', () => {
+    turnController.pushStructuredDiffSegment({
+      content: Array.from({ length: 14 }, (_, i) => `line ${i}`).join('\n') + '\n',
+      filePath: '/ws/new.txt',
+      hunks: [],
+      kind: 'create'
+    })
+
+    const seg = getTurnState().streamSegments[0]!
+    expect(seg.diffData?.kind).toBe('create')
+    // fence carries only the 10-line preview
+    expect(seg.text.split('\n')).toHaveLength(12)
+    expect(seg.text).toContain('+line 0')
+  })
+
+  it('renders create-type WITH hunks as the content preview, not diff rows', () => {
+    // Write of a new file: difflib emits an all-additions hunk, but the
+    // original renders the created-file preview (kind switch, not hunk
+    // presence).
+    turnController.pushStructuredDiffSegment({
+      content: 'alpha\nbeta\n',
+      filePath: '/ws/new.ts',
+      hunks: [{ lines: ['+alpha', '+beta'], newLines: 2, newStart: 1, oldLines: 0, oldStart: 0 }],
+      kind: 'create'
+    })
+
+    const seg = getTurnState().streamSegments[0]!
+    expect(seg.diffData?.kind).toBe('create')
+    expect(seg.text).toBe('```diff\n+alpha\n+beta\n```')
+  })
+
+  it('keeps the tool trail line when nothing is renderable (no-op update)', () => {
+    turnController.recordStructuredDiffToolComplete({ filePath: '/ws/x.ts', hunks: [], kind: 'update' }, 't9', 'Write', undefined, 0.1)
+
+    // No diff segment to render — the completion survives on the pending
+    // trail (merged into the transcript at message.complete, same as the
+    // plain recordToolComplete path).
+    expect(getTurnState().streamSegments).toHaveLength(0)
+    expect(getTurnState().streamPendingTools[0]).toContain('Write')
+  })
+})
+
+// ── DiffView (MessageLine integration) ──────────────────────────────────────
+
+describe('DiffView rendering', () => {
+  const prevColorTerm = process.env.COLORTERM
+
+  beforeEach(() => {
+    process.env.COLORTERM = 'truecolor'
+    delete process.env.NO_COLOR
+  })
+
+  afterEach(() => {
+    if (prevColorTerm === undefined) {
+      delete process.env.COLORTERM
+    } else {
+      process.env.COLORTERM = prevColorTerm
+    }
+  })
+
+  const renderToString = (element: React.ReactElement): string => {
+    const stdout = new PassThrough()
+    const stdin = new PassThrough()
+    const stderr = new PassThrough()
+    let output = ''
+
+    Object.assign(stdout, { columns: 80, isTTY: false, rows: 24 })
+    Object.assign(stdin, { isTTY: false })
+    Object.assign(stderr, { isTTY: false })
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+
+    const instance = renderSync(element, {
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream
+    })
+
+    instance.unmount()
+    instance.cleanup()
+
+    return output
+  }
+
+  const DIFF: MsgDiffData = {
+    filePath: '/ws/src/posts.ts',
+    firstLine: 'export const posts = [',
+    hunks: [HUNK],
+    kind: 'update'
+  }
+
+  it('renders the summary, gutter line numbers and colored rows', async () => {
+    await ensureHighlighter()
+
+    const output = renderToString(React.createElement(DiffView, { cols: 80, diff: DIFF, t: DEFAULT_THEME }))
+    const plain = stripAnsi(output)
+
+    expect(plain).toContain('⎿')
+    expect(plain).toContain('Added 1 line, removed 1 line')
+    expect(plain).toMatch(/221 -\s+id: "obama-as-author",/)
+    expect(plain).toMatch(/221 \+\s+id: "drone-warfare",/)
+    expect(plain).not.toContain('---')
+    // real ColorDiff output, not the fallback: add/remove backgrounds present
+    expect(output).toContain('48;2;61;1;0')
+    expect(output).toContain('48;2;2;40;0')
+  })
+
+  it('renders a created file as "Wrote N lines" with a highlighted preview', () => {
+    const output = renderToString(
+      React.createElement(DiffView, {
+        cols: 80,
+        diff: {
+          content: Array.from({ length: 14 }, (_, i) => `line ${i}`).join('\n') + '\n',
+          filePath: '/ws/new.txt',
+          hunks: [],
+          kind: 'create'
+        },
+        t: DEFAULT_THEME
+      })
+    )
+
+    const plain = stripAnsi(output)
+
+    expect(plain).toContain('Wrote 14 lines to')
+    expect(plain).toContain('… +4 lines')
+    expect(plain).toContain(' 1 line 0')
+  })
+
+  it('renders create-with-hunks as the Wrote-N-lines preview, never diff rows', () => {
+    const output = renderToString(
+      React.createElement(DiffView, {
+        cols: 80,
+        diff: {
+          content: 'alpha\nbeta\n',
+          filePath: '/ws/new.ts',
+          hunks: [{ lines: ['+alpha', '+beta'], newLines: 2, newStart: 1, oldLines: 0, oldStart: 0 }],
+          kind: 'create'
+        },
+        t: DEFAULT_THEME
+      })
+    )
+    const plain = stripAnsi(output)
+
+    expect(plain).toContain('Wrote 2 lines to')
+    expect(plain).not.toContain('Added')
+    // preview rows are line-numbered content, not +-prefixed diff rows
+    expect(plain).toMatch(/1 alpha/)
+    expect(plain).not.toMatch(/\+alpha/)
+  })
+
+  it('renders diff segments through MessageLine without a Response separator', () => {
+    const output = renderToString(
+      React.createElement(MessageLine, {
+        cols: 80,
+        msg: {
+          diffData: DIFF,
+          kind: 'diff',
+          role: 'assistant',
+          text: '```diff\n' + HUNK.lines.join('\n') + '\n```',
+          tools: [buildToolTrailLine('Edit', 'src/posts.ts', false, 'ok', 0.2)]
+        },
+        t: DEFAULT_THEME
+      })
+    )
+
+    const plain = stripAnsi(output)
+
+    expect(plain).toContain('Edit(src/posts.ts)')
+    expect(plain).not.toContain('Response')
+    expect(plain).toMatch(/221 \+\s+id: "drone-warfare",/)
+  })
+})

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -721,12 +721,26 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           flushAbandonedClarify()
         }
 
+        // Both diff flavors honor the same user setting; disabled → the tool
+        // completes as a plain trail line.
+        const inlineDiffsEnabled = getUiState().inlineDiffs
+
+        const structuredDiff = inlineDiffsEnabled ? ev.payload.structured_diff : undefined
+
         const inlineDiffText =
-          ev.payload.inline_diff && getUiState().inlineDiffs ? stripAnsi(String(ev.payload.inline_diff)).trim() : ''
+          ev.payload.inline_diff && inlineDiffsEnabled ? stripAnsi(String(ev.payload.inline_diff)).trim() : ''
 
         const resultText = ev.payload.result_text ? stripAnsi(String(ev.payload.result_text)) : undefined
 
-        if (inlineDiffText) {
+        if (structuredDiff) {
+          turnController.recordStructuredDiffToolComplete(
+            structuredDiff,
+            ev.payload.tool_id,
+            ev.payload.name,
+            ev.payload.error,
+            ev.payload.duration_s
+          )
+        } else if (inlineDiffText) {
           turnController.recordInlineDiffToolComplete(
             inlineDiffText,
             ev.payload.tool_id,

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -5,19 +5,19 @@ import {
   STREAM_SCROLL_BATCH_MS,
   STREAM_TYPING_BATCH_MS
 } from '../config/timing.js'
-import type { SessionInterruptResponse, SubagentEventPayload } from '../gatewayTypes.js'
+import type { SessionInterruptResponse, StructuredDiffPayload, SubagentEventPayload } from '../gatewayTypes.js'
+import { ensureHighlighter } from '../lib/colorDiff.js'
 import { appendToolShelfMessage, isToolShelfMessage } from '../lib/liveProgress.js'
 import { hasReasoningTag, splitReasoning } from '../lib/reasoning.js'
 import {
   boundedLiveRenderText,
   buildToolTrailLine,
-  buildVerboseToolTrailLine,
   estimateTokensRough,
   isTransientTrailLine,
   sameToolTrailGroup,
   toolTrailLabel
 } from '../lib/text.js'
-import type { ActiveTool, ActivityItem, Msg, SubagentProgress, TodoItem } from '../types.js'
+import type { ActiveTool, ActivityItem, Msg, MsgDiffData, SubagentProgress, TodoItem } from '../types.js'
 
 import type { Notice } from './interfaces.js'
 import { resetFlowOverlays } from './overlayStore.js'
@@ -28,6 +28,81 @@ import { getUiState, patchUiState } from './uiStore.js'
 const INTERRUPT_COOLDOWN_MS = 1500
 const ACTIVITY_LIMIT = 8
 const TRAIL_LIMIT = 8
+
+// Safety caps for structured diff segments, applied once at ingestion so the
+// DiffView render cache keys on stable hunk objects. EDIT cap keeps a giant
+// edit from flooding the live viewport; WRITE cap mirrors the original's
+// created-file preview (first 10 lines).
+const DIFF_SEGMENT_MAX_LINES = 240
+const CREATE_PREVIEW_LINES = 10
+
+/**
+ * Build the Msg fields for a structured diff segment: hunks capped to
+ * DIFF_SEGMENT_MAX_LINES (dropped count recorded for the "… +N lines" hint)
+ * and a ```diff fence derived from the same lines. The fence keeps the
+ * existing text-based machinery working unchanged — message.complete dedupe
+ * (diffSegmentBody), the consecutive-duplicate check, selection copy, and
+ * virtual height estimates.
+ */
+const buildDiffSegment = (diff: StructuredDiffPayload): null | { diffData: MsgDiffData; text: string } => {
+  // Branch on kind ALONE, matching the original's renderToolResultMessage
+  // switch (FileWriteTool/UI.tsx): a Write-created file arrives with an
+  // all-additions hunk from difflib, but renders as the 10-line content
+  // preview — never as a wall of green diff rows.
+  if (diff.kind === 'update') {
+    let budget = DIFF_SEGMENT_MAX_LINES
+    let dropped = 0
+    const hunks: MsgDiffData['hunks'] = []
+
+    for (const hunk of diff.hunks) {
+      if (budget <= 0) {
+        dropped += hunk.lines.length
+
+        continue
+      }
+
+      if (hunk.lines.length <= budget) {
+        hunks.push(hunk)
+        budget -= hunk.lines.length
+      } else {
+        dropped += hunk.lines.length - budget
+        hunks.push({ ...hunk, lines: hunk.lines.slice(0, budget) })
+        budget = 0
+      }
+    }
+
+    if (!hunks.length) {
+      return null
+    }
+
+    const body = hunks.flatMap(hunk => hunk.lines).join('\n')
+
+    return {
+      diffData: { ...diff, hunks, ...(dropped > 0 && { truncatedLines: dropped }) },
+      text: `\`\`\`diff\n${body}\n\`\`\``
+    }
+  }
+
+  // create: preview the new content (hunks, if any, are ignored — see above).
+  // The fence only needs the preview lines — heights/dedupe track what
+  // actually renders.
+  const lines = (diff.content ?? '').split('\n')
+
+  if (lines.length > 0 && lines.at(-1) === '') {
+    lines.pop()
+  }
+
+  if (!lines.length) {
+    return null
+  }
+
+  const preview = lines.slice(0, CREATE_PREVIEW_LINES)
+
+  return {
+    diffData: { ...diff },
+    text: `\`\`\`diff\n${preview.map(line => '+' + line).join('\n')}\n\`\`\``
+  }
+}
 
 // Extracts the raw patch from a diff-only segment produced by
 // pushInlineDiffSegment. Used at message.complete to dedupe against final
@@ -507,6 +582,36 @@ class TurnController {
     patchTurnState({ streamSegments: this.segmentMessages })
   }
 
+  pushStructuredDiffSegment(diff: StructuredDiffPayload, tools: string[] = []): 'duplicate' | 'empty' | 'pushed' {
+    const built = buildDiffSegment(diff)
+
+    if (!built) {
+      // Nothing renderable (no-op update, empty created file) — the caller
+      // must surface the tool completion some other way.
+      return 'empty'
+    }
+
+    // Warm the syntax highlighter while the segment is still upstream of the
+    // viewport — by first paint the grammars are usually registered.
+    void ensureHighlighter()
+
+    // Same flow as pushInlineDiffSegment: land the diff BETWEEN the narration
+    // that preceded the edit and whatever streams afterwards.
+    this.flushStreamingSegment()
+
+    if (this.segmentMessages.at(-1)?.text === built.text) {
+      return 'duplicate'
+    }
+
+    this.segmentMessages = [
+      ...this.segmentMessages,
+      { diffData: built.diffData, kind: 'diff', role: 'assistant', text: built.text, ...(tools.length && { tools }) }
+    ]
+    patchTurnState({ streamSegments: this.segmentMessages })
+
+    return 'pushed'
+  }
+
   pushActivity(text: string, tone: ActivityItem['tone'] = 'info', replaceLabel?: string) {
     patchTurnState(state => {
       const base = replaceLabel
@@ -746,6 +851,33 @@ class TurnController {
 
     this.flushStreamingSegment()
     this.pushInlineDiffSegment(diffText, [this.completeTool(toolId, fallbackName, error, '', duration, resultText)])
+    this.publishToolState()
+  }
+
+  recordStructuredDiffToolComplete(
+    diff: StructuredDiffPayload,
+    toolId: string,
+    fallbackName?: string,
+    error?: string,
+    duration?: number
+  ) {
+    if (this.interrupted) {
+      return
+    }
+
+    this.flushStreamingSegment()
+    // No result text on the trail line: the structured diff below IS the
+    // result (the original shows only "⎿ Added N…" — not the model-facing
+    // "file has been updated successfully" boilerplate).
+    const line = this.completeTool(toolId, fallbackName, error, '', duration)
+
+    if (this.pushStructuredDiffSegment(diff, [line]) === 'empty') {
+      // Nothing renderable (no-op update, empty created file): keep the tool
+      // completion visible on the plain trail instead of dropping it.
+      this.pendingSegmentTools = [...this.pendingSegmentTools, line]
+      this.flushPendingToolsIntoLastSegment()
+    }
+
     this.publishToolState()
   }
 

--- a/ui-tui/src/components/diffView.tsx
+++ b/ui-tui/src/components/diffView.tsx
@@ -1,0 +1,223 @@
+import { relative } from 'node:path'
+
+/**
+ * Structured Edit/Write diff block — renders a tool patch the way the
+ * original Claude Code transcript does (FileEditToolUpdatedMessage +
+ * StructuredDiffList + MessageResponse, tools/FileWriteTool/UI.tsx):
+ *
+ *   ⎿  Added N lines, removed M lines          (update; bold counts)
+ *      ... ColorDiff rows: dim right-aligned line numbers, +/- markers,
+ *      add/remove backgrounds padded to width, word-level diff,
+ *      syntax-highlighted context/added rows ...
+ *      ...                                      (dim, between hunks)
+ *
+ *   ⎿  Wrote N lines to path                   (create; bold count/path)
+ *      ... ColorFile rows: first 10 lines, syntax highlighted ...
+ *      … +N lines                               (dim truncation hint)
+ *
+ * The ColorDiff/ColorFile output is pre-wrapped ANSI, handed to <RawAnsi>
+ * exactly like the original's StructuredDiff (constant-time Yoga leaf; the
+ * screen parser ingests the escapes). Rows are cached at module level keyed
+ * on hunk identity — the virtualized transcript remounts rows on
+ * resize/scroll and must not re-run highlighting + word diff each time
+ * (mirrors the original's RENDER_CACHE, StructuredDiff.tsx).
+ */
+import { Box, NoSelect, RawAnsi, Text } from '@clawcodex/ink'
+import { memo, type ReactNode, useSyncExternalStore } from 'react'
+
+import { ColorDiff, ColorFile, highlighterReady, subscribeHighlighter } from '../lib/colorDiff.js'
+import type { Theme } from '../theme.js'
+import type { MsgDiffData } from '../types.js'
+
+// Same layout numbers as the original: diff body width = terminal columns
+// − 12 (floored so narrow terminals stay renderable), created-file previews
+// show the first 10 lines.
+const WIDTH_MARGIN = 12
+const MIN_BODY_WIDTH = 20
+const CREATE_PREVIEW_LINES = 10
+
+// Dim separator between hunks (the original renders <Text dimColor>...</Text>;
+// RawAnsi rows carry the styling inline).
+const HUNK_SEPARATOR = '\x1b[0m\x1b[2m...\x1b[0m'
+
+/**
+ * True when ANSI diff rendering makes sense for this terminal. Under
+ * NO_COLOR the raw escape rows would stay fully colored while the rest of
+ * the UI goes monochrome — callers should fall back to the plain ```diff
+ * markdown path instead. NO_COLOR is the only gate needed: ColorDiff's
+ * detectColorMode degrades to 256-color escapes whenever COLORTERM isn't
+ * truecolor (e.g. Apple Terminal, where forceTruecolor deliberately deletes
+ * COLORTERM), so any color-capable terminal receives valid sequences — and a
+ * terminal with no color support at all breaks the chalk-driven UI equally.
+ */
+export function structuredDiffSupported(): boolean {
+  return !process.env.NO_COLOR
+}
+
+// ── Module-level render cache ────────────────────────────────────────────
+// WeakMap on the hunk object (stable per segment — hunks are capped once at
+// ingestion) → per-variant rows. Four variants cover the steady state
+// (resize thrash beyond that just recomputes), mirroring the original.
+type HunkLike = MsgDiffData['hunks'][number]
+const RENDER_CACHE = new WeakMap<HunkLike, Map<string, string[]>>()
+
+function renderHunk(hunk: HunkLike, diff: MsgDiffData, themeName: string, width: number, hlReady: boolean): string[] {
+  const key = `${themeName}|${width}|${hlReady ? 1 : 0}|${diff.firstLine ?? ''}|${diff.filePath}`
+  let perHunk = RENDER_CACHE.get(hunk)
+  const hit = perHunk?.get(key)
+
+  if (hit) {
+    return hit
+  }
+
+  const rows = new ColorDiff(hunk, diff.firstLine ?? null, diff.filePath, null).render(themeName, width, false) ?? []
+
+  if (!perHunk) {
+    perHunk = new Map()
+    RENDER_CACHE.set(hunk, perHunk)
+  }
+
+  if (perHunk.size >= 4) {
+    perHunk.clear()
+  }
+
+  perHunk.set(key, rows)
+
+  return rows
+}
+
+const countPatchLines = (hunks: HunkLike[]) => {
+  let added = 0
+  let removed = 0
+
+  for (const hunk of hunks) {
+    for (const line of hunk.lines) {
+      if (line.startsWith('+')) {
+        added++
+      } else if (line.startsWith('-')) {
+        removed++
+      }
+    }
+  }
+
+  return { added, removed }
+}
+
+/** "Added N lines, removed M lines" with the original's bold counts + casing. */
+const UpdateSummary = ({ added, removed }: { added: number; removed: number }) => {
+  if (added === 0 && removed === 0) {
+    return null
+  }
+
+  return (
+    <Text>
+      {added > 0 && (
+        <>
+          Added <Text bold>{added}</Text> {added > 1 ? 'lines' : 'line'}
+        </>
+      )}
+      {added > 0 && removed > 0 ? ', ' : null}
+      {removed > 0 && (
+        <>
+          {added === 0 ? 'R' : 'r'}emoved <Text bold>{removed}</Text> {removed > 1 ? 'lines' : 'line'}
+        </>
+      )}
+    </Text>
+  )
+}
+
+const workspaceCwd = () => process.env.CLAWCODEX_WORKSPACE || process.env.CLAWCODEX_CWD || process.cwd()
+
+export const DiffView = memo(function DiffView({ cols, diff, fallback = null, t }: DiffViewProps) {
+  // Re-render once when highlight.js finishes registering grammars — rows
+  // rendered before that are structurally identical, just untinted.
+  const hlReady = useSyncExternalStore(subscribeHighlighter, highlighterReady, highlighterReady)
+  const themeName = t.mode
+  const width = Math.max(MIN_BODY_WIDTH, cols - WIDTH_MARGIN)
+
+  let summary: null | ReactNode = null
+  const rows: string[] = []
+  let hint = ''
+
+  try {
+    // Branch on kind ALONE (original renderToolResultMessage switch): a
+    // Write-created file ships an all-additions hunk but renders as the
+    // 10-line content preview, never as diff rows.
+    if (diff.kind === 'update') {
+      const { added, removed } = countPatchLines(diff.hunks)
+      summary = <UpdateSummary added={added} removed={removed} />
+
+      diff.hunks.forEach((hunk, i) => {
+        if (i > 0) {
+          rows.push(HUNK_SEPARATOR)
+        }
+
+        rows.push(...renderHunk(hunk, diff, themeName, width, hlReady))
+      })
+
+      if (diff.truncatedLines) {
+        hint = `… +${diff.truncatedLines} ${diff.truncatedLines === 1 ? 'line' : 'lines'}`
+      }
+    } else {
+      // create: "Wrote N lines to path" + highlighted preview of the head of
+      // the file (tools/FileWriteTool/UI.tsx).
+      const all = (diff.content ?? '').split('\n')
+
+      if (all.length > 0 && all.at(-1) === '') {
+        all.pop()
+      }
+
+      summary = (
+        <Text>
+          Wrote <Text bold>{all.length}</Text> {all.length === 1 ? 'line' : 'lines'} to{' '}
+          <Text bold>{relative(workspaceCwd(), diff.filePath) || diff.filePath}</Text>
+        </Text>
+      )
+
+      const shown = all.slice(0, CREATE_PREVIEW_LINES)
+      rows.push(...(new ColorFile(shown.join('\n'), diff.filePath).render(themeName, width, false) ?? []))
+      // ColorFile drops a trailing empty line (Rust .lines() parity), so
+      // count the hint from what actually rendered.
+      const rendered = shown.length > 0 && shown.at(-1) === '' ? shown.length - 1 : shown.length
+      const extra = all.length - rendered
+
+      if (extra > 0) {
+        hint = `… +${extra} ${extra === 1 ? 'line' : 'lines'}`
+      }
+    }
+  } catch {
+    // A renderer bug must never take down the transcript — degrade to the
+    // fenced-text markdown path the caller supplies.
+    return <>{fallback}</>
+  }
+
+  if (!rows.length && !summary) {
+    return null
+  }
+
+  return (
+    <Box flexDirection="row">
+      <NoSelect flexShrink={0} fromLeftEdge>
+        <Text color={t.color.muted}>{'  ⎿  '}</Text>
+      </NoSelect>
+      <Box flexDirection="column" flexGrow={1}>
+        {summary}
+        {rows.length > 0 && <RawAnsi lines={rows} width={width} />}
+        {hint ? (
+          <Text color={t.color.muted} dim>
+            {hint}
+          </Text>
+        ) : null}
+      </Box>
+    </Box>
+  )
+})
+
+interface DiffViewProps {
+  /** Full terminal columns (the component applies the original's −12 margin). */
+  cols: number
+  diff: MsgDiffData
+  /** Rendered when the ANSI pipeline throws (plain ```diff markdown path). */
+  fallback?: ReactNode
+  t: Theme
+}

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -817,15 +817,18 @@ function MdImpl({ cols, compact, t, text }: MdProps) {
                 )
               }
 
-              const add = isDiff && l.startsWith('+')
-              const del = isDiff && l.startsWith('-')
-              const hunk = isDiff && l.startsWith('@@')
+              // ---/+++/@@ are patch metadata, not removed/added code — dim
+              // them instead of painting a background (the original's diff
+              // rendering never shows them as content rows).
+              const meta = isDiff && (l.startsWith('@@') || l.startsWith('---') || l.startsWith('+++'))
+              const add = isDiff && !meta && l.startsWith('+')
+              const del = isDiff && !meta && l.startsWith('-')
 
               return (
                 <Text
                   backgroundColor={add ? t.color.diffAdded : del ? t.color.diffRemoved : undefined}
-                  color={add ? t.color.diffAddedWord : del ? t.color.diffRemovedWord : hunk ? t.color.muted : undefined}
-                  dimColor={isDiff && !add && !del && !hunk && l.startsWith(' ')}
+                  color={meta ? t.color.muted : undefined}
+                  dimColor={isDiff && !add && !del && (meta || l.startsWith(' '))}
                   key={j}
                 >
                   {l}

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -19,6 +19,7 @@ import {
 import type { Theme } from '../theme.js'
 import type { ActiveTool, DetailsMode, Msg, SectionVisibility } from '../types.js'
 
+import { DiffView, structuredDiffSupported } from './diffView.js'
 import { Md } from './markdown.js'
 import { StreamingMd } from './streamingMarkdown.js'
 import { ToolTrail } from './thinking.js'
@@ -117,6 +118,41 @@ export const MessageLine = memo(function MessageLine({
             {preview}
           </Text>
         )}
+      </Box>
+    )
+  }
+
+  // Structured tool diff — render like the original's transcript: the tool
+  // line (⏺ Edit(...)) with the patch indented under a ⎿ gutter. No role
+  // glyph, no "Response" separator; those belong to prose segments. Legacy
+  // text-only diff segments (or NO_COLOR terminals) fall through to the
+  // markdown ```diff path below.
+  if (msg.kind === 'diff' && msg.diffData && structuredDiffSupported()) {
+    // Recreated per render, which defeats DiffView's memo — fine: the
+    // expensive work (highlight + word diff) sits behind its module-level
+    // render cache, so a re-render is a WeakMap hit.
+    const mdFallback = (
+      <Md
+        cols={transcriptBodyWidth(cols, msg.role, t.brand.prompt, TERMUX_TUI_MODE)}
+        compact={compact}
+        t={t}
+        text={msg.text}
+      />
+    )
+
+    return (
+      <Box flexDirection="column" marginBottom={1} marginTop={1}>
+        {toolsMode !== 'hidden' && Boolean(msg.tools?.length) && (
+          <ToolTrail
+            commandOverride={detailsModeCommandOverride}
+            detailsMode={detailsMode}
+            reasoning=""
+            sections={sections}
+            t={t}
+            trail={msg.tools}
+          />
+        )}
+        <DiffView cols={cols} diff={msg.diffData} fallback={mdFallback} t={t} />
       </Box>
     )
   }
@@ -239,8 +275,10 @@ export const MessageLine = memo(function MessageLine({
   )
 })
 
+// Diff segments are a tool patch, not prose — a "Response" label above them
+// is chrome noise (and the structured branch above never reaches here).
 export const shouldShowResponseSeparator = (msg: Msg, showDetails: boolean): boolean =>
-  msg.role === 'assistant' && showDetails && /\S/.test(msg.text)
+  msg.role === 'assistant' && msg.kind !== 'diff' && showDetails && /\S/.test(msg.text)
 
 interface MessageLineProps {
   cols: number

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -21,7 +21,7 @@ import { readdirSync } from 'node:fs'
 import { resolve as pathResolve } from 'node:path'
 import { createInterface } from 'node:readline'
 
-import type { GatewayEvent } from './gatewayTypes.js'
+import type { GatewayEvent, PatchHunk, StructuredDiffPayload } from './gatewayTypes.js'
 import type { SessionInfo } from './types.js'
 
 const STARTUP_TIMEOUT_MS = 30_000
@@ -697,9 +697,43 @@ export class GatewayClient extends EventEmitter {
     }
   }
 
-  // Build a unified diff for Edit/Write tool results so the app renders a colored
-  // ```diff block (turnController.pushInlineDiffSegment). Other tools → undefined
-  // (just the result text shows).
+  // Rich Edit/Write result forwarded by the agent-server (`tool_use_result`
+  // on the user envelope, trimmed to the display shape). Shape-detected from
+  // the value itself — self-describing type/filePath/structuredPatch — so it
+  // works even when the tool_use bookkeeping is empty (mid-turn attach).
+  private structuredDiff(value: any): StructuredDiffPayload | undefined {
+    if (!value || typeof value !== 'object') {return undefined}
+    const kind = value.type
+
+    if (kind !== 'create' && kind !== 'update') {return undefined}
+
+    if (typeof value.filePath !== 'string' || !Array.isArray(value.structuredPatch)) {return undefined}
+    const hunks: PatchHunk[] = []
+
+    for (const h of value.structuredPatch) {
+      if (!h || typeof h !== 'object' || !Array.isArray(h.lines)) {return undefined}
+      hunks.push({
+        lines: h.lines.map(String),
+        newLines: Number(h.newLines ?? 0),
+        newStart: Number(h.newStart ?? 1),
+        oldLines: Number(h.oldLines ?? 0),
+        oldStart: Number(h.oldStart ?? 1)
+      })
+    }
+
+    return {
+      ...(typeof value.content === 'string' && { content: value.content }),
+      filePath: value.filePath,
+      ...(typeof value.firstLine === 'string' && { firstLine: value.firstLine }),
+      hunks,
+      kind
+    }
+  }
+
+  // Legacy fallback (agent-server predating tool_use_result): a fake unified
+  // diff from the Edit/Write tool *input* so the app can render at least a
+  // colored ```diff block. No line numbers/context — superseded by
+  // structuredDiff whenever the backend forwards the real patch.
   private editDiff(name: string, input: any): string | undefined {
     try {
       const file = String(input?.file_path ?? input?.path ?? '')
@@ -821,22 +855,34 @@ export class GatewayClient extends EventEmitter {
         const content = msg.message?.content
 
         if (Array.isArray(content)) {
+          // The backend builds one user message per tool result, so a
+          // message-level tool_use_result belongs to the lone block. Consume
+          // it on first attach so a hypothetical multi-block message can't
+          // pin the same patch onto every result.
+          let structured = this.structuredDiff(msg.tool_use_result)
+
           for (const b of content) {
             if (b?.type === 'tool_result') {
               const stored = this.toolInputs.get(String(b.tool_use_id))
+              // A failed edit must not render a diff at all — neither the
+              // real patch nor a fabricated one for an edit that never ran.
+              const isError = Boolean(b.is_error)
               this.publish({
                 payload: {
-                  inline_diff: stored ? this.editDiff(stored.name, stored.input) : undefined,
+                  inline_diff:
+                    isError || structured || !stored ? undefined : this.editDiff(stored.name, stored.input),
                   name: stored?.name,
                   result_text: formatToolResult(
                     stored?.name,
                     typeof b.content === 'string' ? b.content : safeJson(b.content),
-                    Boolean(b.is_error)
+                    isError
                   ),
+                  structured_diff: isError ? undefined : structured,
                   tool_id: b.tool_use_id
                 },
                 type: 'tool.complete'
               })
+              structured = undefined
               this.toolInputs.delete(String(b.tool_use_id))
             }
           }

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -34,11 +34,13 @@ const CLAWCODEX_VERSION = '0.7.0'
 /** Command that launches the clawcodex agent-server (set by the Python launcher). */
 function resolveAgentCmd(): string[] {
   const raw = process.env.CLAWCODEX_AGENT_SERVER_CMD?.trim()
+
   return raw ? raw.split(/\s+/) : ['clawcodex', 'agent-server']
 }
 
 function safeJson(v: unknown): string {
-  if (typeof v === 'string') return v
+  if (typeof v === 'string') {return v}
+
   try {
     return JSON.stringify(v)
   } catch {
@@ -51,7 +53,9 @@ function safeJson(v: unknown): string {
  *  option so the user sees what it will persist. */
 export function describeSuggestionRule(suggestion: any): string | null {
   const rule = suggestion?.rules?.[0]
-  if (!rule || !rule.tool_name) return null
+
+  if (!rule || !rule.tool_name) {return null}
+
   return rule.rule_content ? `${rule.tool_name}(${rule.rule_content})` : String(rule.tool_name)
 }
 
@@ -61,12 +65,14 @@ export function describeSuggestionRule(suggestion: any): string | null {
 export function approvalCommandText(input: unknown): string {
   if (input && typeof input === 'object') {
     const o = input as Record<string, unknown>
+
     // pattern before path so a Grep/Glob box shows the search pattern (matching
     // the tool trail label), not the directory it searched.
     for (const key of ['command', 'file_path', 'url', 'pattern', 'path']) {
-      if (typeof o[key] === 'string' && o[key]) return o[key] as string
+      if (typeof o[key] === 'string' && o[key]) {return o[key] as string}
     }
   }
+
   return safeJson(input)
 }
 
@@ -75,19 +81,24 @@ export function approvalCommandText(input: unknown): string {
  *  name. File paths are shown relative to the workspace so the label stays
  *  short; search tools show their pattern rather than the search directory. */
 function toolContext(input: any): string {
-  if (!input || typeof input !== 'object') return ''
-  if (input.pattern != null) return String(input.pattern)
+  if (!input || typeof input !== 'object') {return ''}
+
+  if (input.pattern != null) {return String(input.pattern)}
   const p = input.file_path ?? input.path ?? input.notebook_path
-  if (p != null) return relativizePath(String(p))
+
+  if (p != null) {return relativizePath(String(p))}
   const v = input.command ?? input.url ?? input.query ?? input.description ?? input.prompt
+
   return v == null ? '' : String(v)
 }
 
 /** Shorten an absolute path to a workspace-relative path (or basename). */
 function relativizePath(p: string): string {
   const ws = (process.env.CLAWCODEX_WORKSPACE || process.env.CLAWCODEX_CWD || process.cwd()).replace(/\/+$/, '')
-  if (ws && p.startsWith(ws + '/')) return p.slice(ws.length + 1)
+
+  if (ws && p.startsWith(ws + '/')) {return p.slice(ws.length + 1)}
   const parts = p.split('/')
+
   return parts[parts.length - 1] || p
 }
 
@@ -98,11 +109,14 @@ function relativizePath(p: string): string {
  *  acknowledgements (empty-file / file_unchanged warnings, PDF/image stubs)
  *  aren't `N\t…` text and pass through, so nothing is mislabeled or hidden. */
 function formatToolResult(name: string | undefined, result: string, isError = false): string {
-  if (!result || isError) return result
+  if (!result || isError) {return result}
+
   if (name === 'Read' && /^\s*\d+\t/.test(result)) {
     const n = result.split('\n').filter(l => l.length > 0).length
+
     return `Read ${n} line${n === 1 ? '' : 's'}`
   }
+
   return result
 }
 
@@ -198,13 +212,16 @@ export class GatewayClient extends EventEmitter {
     } catch (err) {
       this.pushLog(`[spawn error] ${String(err)}`)
       this.handleExit(null, String(err))
+
       return
     }
 
     const rl = createInterface({ input: this.proc.stdout! })
     rl.on('line', raw => {
       const line = raw.trim()
-      if (!line) return
+
+      if (!line) {return}
+
       try {
         this.dispatch(JSON.parse(line))
       } catch {
@@ -227,9 +244,11 @@ export class GatewayClient extends EventEmitter {
 
   drain(): void {
     this.subscribed = true
-    for (const ev of this.buffered) this.emit('event', ev)
+
+    for (const ev of this.buffered) {this.emit('event', ev)}
     this.buffered = []
-    if (this.pendingExit !== undefined) this.emit('exit', this.pendingExit)
+
+    if (this.pendingExit !== undefined) {this.emit('exit', this.pendingExit)}
   }
 
   getLogTail(limit = 20): string {
@@ -241,11 +260,13 @@ export class GatewayClient extends EventEmitter {
       clearTimeout(this.readyTimer)
       this.readyTimer = null
     }
+
     try {
       this.proc?.kill('SIGTERM')
     } catch {
       // best effort
     }
+
     this.proc = null
   }
 
@@ -256,6 +277,7 @@ export class GatewayClient extends EventEmitter {
   // ── client → server RPCs ─────────────────────────────────────────────────
   request<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T> {
     const p = (params ?? {}) as Record<string, unknown>
+
     switch (method) {
       // ── startup handshake ────────────────────────────────────────────────
       case 'commands.catalog': {
@@ -267,18 +289,24 @@ export class GatewayClient extends EventEmitter {
           .then(wf => {
             const pairs = SLASHES.map(s => [s.name, s.desc] as [string, string])
             const canon: Record<string, string> = {}
-            for (const s of SLASHES) canon[s.name] = s.name
+
+            for (const s of SLASHES) {canon[s.name] = s.name}
+
             for (const w of wf) {
               const name = `/${w.name}`
-              if (canon[name]) continue
+
+              if (canon[name]) {continue}
               canon[name] = name
               pairs.push([name, w.description ?? 'Run a dynamic workflow'])
             }
+
             return { canon, categories: [], pairs, skill_count: 0, sub: {} } as T
           })
       }
+
       case 'complete.slash': {
         const text = String(p.text ?? '').toLowerCase() || '/'
+
         return this.fetchWorkflowCommands()
           .catch(() => [] as WorkflowCommand[])
           .then(wf => {
@@ -288,12 +316,15 @@ export class GatewayClient extends EventEmitter {
                 .filter(w => !SLASHES.some(s => s.name === `/${w.name}`))
                 .map(w => ({ desc: w.description ?? 'Run a dynamic workflow', name: `/${w.name}` }))
             ]
+
             const items = entries
               .filter(s => s.name.toLowerCase().startsWith(text))
               .map(s => ({ display: s.name, meta: s.desc, text: s.name }))
+
             return { items, replace_from: 1 } as T
           })
       }
+
       case 'complete.path':
         // @-file mentions: serve workspace file completions from disk (the hook
         // computes the replace offset; we just return matching entries).
@@ -303,33 +334,42 @@ export class GatewayClient extends EventEmitter {
         if (String(p.key ?? '') === 'full') {
           return this.controlQuery('get_settings', {}).then(s => (s ?? {}) as T)
         }
+
         return Promise.resolve({} as T)
       }
+
       case 'config.set': {
         // Route clawcodex-backed settings to control_requests; display-only prefs
         // (mouse/details/statusbar/skin/…) have no backend and apply locally, so
         // accept them silently.
         const key = String(p.key ?? '')
         const value = p.value
-        if (key === 'model') this.sendControl('set_model', { model: value })
-        else if (key === 'permission_mode') this.sendControl('set_permission_mode', { mode: value })
-        else if (key === 'effort' || key === 'reasoning') this.sendControl('set_effort', { effort: value })
-        else if (key === 'provider') this.sendControl('set_provider', { provider: value })
-        else if (key === 'thinking') this.sendControl('set_thinking', { action: value })
+
+        if (key === 'model') {this.sendControl('set_model', { model: value })}
+        else if (key === 'permission_mode') {this.sendControl('set_permission_mode', { mode: value })}
+        else if (key === 'effort' || key === 'reasoning') {this.sendControl('set_effort', { effort: value })}
+        else if (key === 'provider') {this.sendControl('set_provider', { provider: value })}
+        else if (key === 'thinking') {this.sendControl('set_thinking', { action: value })}
+
         return Promise.resolve({ ok: true } as T)
       }
+
       case 'permission.cycle':
         // ch13 round-4 — shift+tab: the SERVER computes the guarded next
         // mode (get_next_permission_mode; bypass only when available) from
         // the live mode, so the client can't step into bypassPermissions
         // unconditionally or desync a cursor after /mode.
         return this.controlQuery('cycle_permission_mode', {}).then(r => (r ?? {}) as T)
+
       case 'session.activate':
+
       case 'session.create':
+
       case 'session.resume':
         // clawcodex runs a single agent-server session; hand back its id once
         // system/init has set it. The app then enables the composer.
         return this.readyPromise.then(() => ({ info: this.sessionInfo ?? undefined, session_id: this.sessionId }) as T)
+
       case 'setup.status':
         return Promise.resolve({ provider_configured: true } as T)
 
@@ -338,6 +378,7 @@ export class GatewayClient extends EventEmitter {
         return this.controlQuery('get_settings', {}).then((r: any) => {
           const models: string[] = Array.isArray(r?.available_models) ? r.available_models : []
           const provider = String(r?.provider ?? 'clawcodex')
+
           return {
             model: r?.model,
             provider,
@@ -357,16 +398,21 @@ export class GatewayClient extends EventEmitter {
         const text = String(p.text ?? '')
         this.msgStarted = false
         this.send({ message: { content: text, role: 'user' }, type: 'user' })
+
         return Promise.resolve({ ok: true } as T)
       }
+
       case 'session.active_list':
+
       case 'session.list':
         // Single agent-server session in the basic port; the switcher/resume
         // list is Phase 2. Resolve locally so the 1.5s poll doesn't spam the
         // backend with list_sessions.
         return Promise.resolve({ sessions: [] } as T)
+
       case 'session.interrupt':
         this.sendControl('interrupt', {})
+
         return Promise.resolve({ ok: true } as T)
 
       // ── slash commands → clawcodex control_requests ──────────────────────
@@ -377,6 +423,7 @@ export class GatewayClient extends EventEmitter {
         const sp = raw.indexOf(' ')
         const name = sp === -1 ? raw : raw.slice(0, sp)
         const arg = sp === -1 ? undefined : raw.slice(sp + 1)
+
         return this.dispatchSlash(name, arg) as Promise<T>
       }
 
@@ -384,6 +431,7 @@ export class GatewayClient extends EventEmitter {
       case 'approval.respond': {
         const ap = this.pendingApproval
         this.pendingApproval = null
+
         if (ap) {
           const deny = p.choice === 'deny'
           // 'always' = "don't ask again": send the backend's suggestion AS-IS so
@@ -394,6 +442,7 @@ export class GatewayClient extends EventEmitter {
           // rewrites just that rule's content and nothing else. 'once' → no rule.
           let chosenUpdates: any[] = []
           const first = ap.suggestions?.[0]
+
           if (!deny && first && p.choice === 'always') {
             const edited = typeof p.rule === 'string' ? p.rule.trim() : ''
             const baseRule = Array.isArray(first.rules) ? first.rules[0] : undefined
@@ -403,6 +452,7 @@ export class GatewayClient extends EventEmitter {
                 : first
             ]
           }
+
           this.send({
             response: {
               request_id: ap.request_id,
@@ -413,8 +463,10 @@ export class GatewayClient extends EventEmitter {
             type: 'control_response'
           })
         }
+
         return Promise.resolve({ ok: true } as T)
       }
+
       case 'clarify.respond':
         this.send({
           response: {
@@ -423,6 +475,7 @@ export class GatewayClient extends EventEmitter {
           },
           type: 'control_response'
         })
+
         return Promise.resolve({ ok: true } as T)
 
       default:
@@ -435,12 +488,15 @@ export class GatewayClient extends EventEmitter {
   // WORKFLOW_CMDS_TTL_MS). Degrades to the last-known list on RPC failure.
   private fetchWorkflowCommands(): Promise<WorkflowCommand[]> {
     const now = Date.now()
-    if (now - this.wfFetchedAt < WORKFLOW_CMDS_TTL_MS) return Promise.resolve(this.wfCommands)
+
+    if (now - this.wfFetchedAt < WORKFLOW_CMDS_TTL_MS) {return Promise.resolve(this.wfCommands)}
     this.wfFetchedAt = now
+
     return this.controlQuery('list_workflow_commands', {}).then((r: any) => {
       if (Array.isArray(r?.commands)) {
         this.wfCommands = r.commands.filter((c: any) => typeof c?.name === 'string' && c.name)
       }
+
       return this.wfCommands
     })
   }
@@ -448,6 +504,7 @@ export class GatewayClient extends EventEmitter {
   // ── event plumbing ───────────────────────────────────────────────────────
   private controlQuery(subtype: string, params: Record<string, unknown>): Promise<unknown> {
     const requestId = `q${++this.reqId}`
+
     return new Promise(resolve => {
       this.pending.set(requestId, { reject: () => resolve(null), resolve })
       this.send({ request: { subtype, ...params }, request_id: requestId, type: 'control_request' })
@@ -471,97 +528,137 @@ export class GatewayClient extends EventEmitter {
     arg?: string
   ): Promise<{ output: string; type: string } | { message: string; notice?: string; type: 'send' }> {
     const out = (output: string) => ({ output, type: 'exec' })
+
     switch (name) {
       case 'clear':
         await this.controlQuery('clear', {})
+
         return out('Conversation cleared.')
       case 'compact': {
         const r = (await this.controlQuery('compact', { instructions: arg ?? null })) as any
+
         return out(`Compacted${r?.tokens_saved ? ` (saved ~${r.tokens_saved} tokens)` : ''}.`)
       }
+
       case 'context': {
         const r = (await this.controlQuery('get_context_usage', {})) as any
         const pct = r?.percentage == null ? '?' : Math.round(r.percentage)
+
         return out(`Context: ${r?.total_tokens ?? '?'}/${r?.max_tokens ?? '?'} tokens (${pct}%).`)
       }
+
       case 'effort': {
         const r = (await this.controlQuery('set_effort', { effort: arg ?? null })) as any
-        if (r && r.ok === false) return out(`effort: ${r.error ?? 'invalid value'}`)
+
+        if (r && r.ok === false) {return out(`effort: ${r.error ?? 'invalid value'}`)}
+
         if (r?.effort === 'ultracode') {
           return out('Ultracode on: workflow auto-orchestration for this session (reset with /effort high).')
         }
+
         return out(`Effort: ${r?.effort ?? arg ?? '(unchanged)'}.`)
       }
+
       case 'mode':
         await this.controlQuery('set_permission_mode', { mode: arg })
+
         return out(`Permission mode: ${arg ?? '(unchanged)'}.`)
+
       case 'model':
         await this.controlQuery('set_model', { model: arg })
+
         return out(`Model set to ${arg ?? '(unchanged)'}.`)
       case 'provider': {
         const r = (await this.controlQuery('set_provider', { provider: arg })) as any
+
         return out(`Provider: ${r?.provider ?? arg ?? '(unchanged)'}${r?.model ? ` (model ${r.model})` : ''}.`)
       }
+
       case 'rewind': {
         const r = (await this.controlQuery('rewind', { turns: arg ? Number(arg) || 1 : 1 })) as any
+
         return out(`Rewound ${r?.removed ?? 0} turn(s).`)
       }
+
       case 'thinking': {
         const r = (await this.controlQuery('set_thinking', { action: arg ?? 'toggle' })) as any
+
         return out(`Thinking ${r?.thinking ? 'on' : 'off'}.`)
       }
+
       case 'bg': {
         if (arg) {
           const r = (await this.controlQuery('bg_agent', { command: arg })) as any
+
           return out(`Started background agent ${r?.id ?? ''}.`)
         }
+
         const r = (await this.controlQuery('bg_list', {})) as any
         const tasks = Array.isArray(r?.tasks) ? r.tasks : []
+
         return out(tasks.length ? tasks.map((t: any) => `${t.id} [${t.status}] ${t.command}`).join('\n') : 'No background tasks.')
       }
+
       case 'insights': {
         const r = (await this.controlQuery('insights', {})) as any
+
         return out(r?.insights ? String(r.insights) : 'No insights available.')
       }
+
       case 'knowledge': {
         const r = (await this.controlQuery('knowledge', { action: arg || 'status' })) as any
+
         const bits = [
           r?.enabled != null ? `enabled=${r.enabled}` : '',
           r?.semantic != null ? `semantic=${r.semantic}` : ''
         ].filter(Boolean)
+
         return out(`Knowledge ${bits.join(' ') || safeJson(r ?? {})}`)
       }
+
       case 'plan': {
         const r = (await this.controlQuery('plan', { action: arg ? 'set' : 'view', text: arg })) as any
+
         return out(r?.plan ? `Plan:\n${r.plan}` : 'No plan set.')
       }
+
       case 'rename': {
         const r = (await this.controlQuery('rename', { name: arg })) as any
+
         return out(`Renamed to ${r?.name ?? arg ?? '(unchanged)'}.`)
       }
+
       case 'resume': {
         if (arg) {
           const r = (await this.controlQuery('resume', { session_id: arg })) as any
+
           return out(`Resumed ${arg} (${r?.count ?? 0} messages).`)
         }
+
         const r = (await this.controlQuery('list_sessions', {})) as any
         const ss = Array.isArray(r?.sessions) ? r.sessions : []
+
         return out(
           ss.length
             ? `Sessions:\n${ss.slice(0, 10).map((s: any) => `${s.session_id} — ${s.preview ?? ''}`).join('\n')}\nUse /resume <id>`
             : 'No saved sessions.'
         )
       }
+
       case 'workflows': {
         const r = (await this.controlQuery('workflows', {})) as any
-        if (r && r.ok === false) return out(`workflows: ${r.error ?? 'unavailable'}`)
+
+        if (r && r.ok === false) {return out(`workflows: ${r.error ?? 'unavailable'}`)}
+
         return out(String(r?.text ?? 'No workflow runs.'))
       }
+
       default: {
         // Workflow commands (/deep-research + saved .claude/workflows/*.py):
         // the backend expands the directive; the app submits it as a prompt so
         // the model launches the run via the Workflow tool.
         const r = (await this.controlQuery('workflow_command', { args: arg ?? '', name })) as any
+
         if (r?.ok && typeof r.prompt === 'string' && r.prompt) {
           return {
             message: r.prompt,
@@ -569,6 +666,7 @@ export class GatewayClient extends EventEmitter {
             type: 'send'
           }
         }
+
         return out(`/${name} isn't wired into the clawcodex backend yet.`)
       }
     }
@@ -584,12 +682,14 @@ export class GatewayClient extends EventEmitter {
       const dirPart = slash === -1 ? '' : stripped.slice(0, slash + 1)
       const base = (slash === -1 ? stripped : stripped.slice(slash + 1)).toLowerCase()
       const absDir = pathResolve(cwd, dirPart || '.')
+
       return readdirSync(absDir, { withFileTypes: true })
         .filter(e => !e.name.startsWith('.') && e.name.toLowerCase().startsWith(base))
         .slice(0, 50)
         .map(e => {
           const isDir = e.isDirectory()
           const rel = dirPart + e.name + (isDir ? '/' : '')
+
           return { display: rel, meta: isDir ? 'dir' : 'file', text: rel }
         })
     } catch {
@@ -603,27 +703,33 @@ export class GatewayClient extends EventEmitter {
   private editDiff(name: string, input: any): string | undefined {
     try {
       const file = String(input?.file_path ?? input?.path ?? '')
+
       if (name === 'Write') {
         const body = String(input?.content ?? '')
           .split('\n')
           .map(l => '+' + l)
           .join('\n')
+
         return body ? `+++ ${file}\n${body}` : undefined
       }
+
       if (name === 'Edit') {
         const oldB = String(input?.old_string ?? '')
           .split('\n')
           .map(l => '-' + l)
           .join('\n')
+
         const newB = String(input?.new_string ?? '')
           .split('\n')
           .map(l => '+' + l)
           .join('\n')
+
         return `--- ${file}\n+++ ${file}\n${oldB}\n${newB}`
       }
     } catch {
       /* ignore */
     }
+
     return undefined
   }
 
@@ -632,6 +738,7 @@ export class GatewayClient extends EventEmitter {
     switch (msg?.type) {
       case 'assistant': {
         const content = msg.message?.content
+
         if (Array.isArray(content)) {
           for (const b of content) {
             if (b?.type === 'tool_use') {
@@ -644,14 +751,20 @@ export class GatewayClient extends EventEmitter {
             }
           }
         }
+
         break
       }
+
       case 'control_request':
         this.handleServerControl(msg)
+
         break
+
       case 'control_response':
         this.resolvePending(msg)
+
         break
+
       case 'result':
         this.publish({
           payload: {
@@ -661,12 +774,15 @@ export class GatewayClient extends EventEmitter {
           type: 'message.complete'
         })
         this.msgStarted = false
+
         if (msg.is_error || msg.subtype === 'error') {
           this.publish({ payload: { message: String(msg.error ?? msg.result ?? 'error') }, type: 'error' })
         }
+
         break
       case 'stream_event': {
         const d = msg.event?.delta
+
         if (d?.type === 'text_delta' && d.text) {
           this.ensureMsgStart()
           this.publish({ payload: { text: d.text }, type: 'message.delta' })
@@ -674,8 +790,10 @@ export class GatewayClient extends EventEmitter {
           this.ensureMsgStart()
           this.publish({ payload: { text: d.thinking }, type: 'thinking.delta' })
         }
+
         break
       }
+
       case 'system':
         if (msg.subtype === 'init') {
           this.sessionId = String(msg.session_id ?? '')
@@ -697,9 +815,11 @@ export class GatewayClient extends EventEmitter {
             type: 'background.complete'
           })
         }
+
         break
       case 'user': {
         const content = msg.message?.content
+
         if (Array.isArray(content)) {
           for (const b of content) {
             if (b?.type === 'tool_result') {
@@ -721,14 +841,17 @@ export class GatewayClient extends EventEmitter {
             }
           }
         }
+
         break
       }
+
       case 'agent_progress': {
         // ch13 round-4 — the backend emits rich subagent progress
         // (agent.py ProgressTracker) but the bridge dropped it, so the
         // subagent HUD stayed dark during Task/Agent delegation. Map it to
         // the subagent.* events the app renderer already handles.
         const aid = String(msg.agent_id ?? '')
+
         if (aid) {
           const payload: any = {
             depth: msg.depth ?? 0,
@@ -736,11 +859,14 @@ export class GatewayClient extends EventEmitter {
             subagent_id: aid,
             subagent_type: msg.subagent_type
           }
+
           if (!this.seenSubagents.has(aid)) {
             this.seenSubagents.add(aid)
             this.publish({ payload: { ...payload, status: 'running' }, type: 'subagent.start' })
           }
+
           const activity = String(msg.activity ?? '').trim()
+
           if (activity) {
             // ch13 round-4 — map to the field names the HUD renderer reads
             // (turnController: output_tokens / tool_count), not the backend's
@@ -750,11 +876,14 @@ export class GatewayClient extends EventEmitter {
               type: 'subagent.progress'
             })
           }
+
           const status = String(msg.status ?? '')
+
           if (status === 'completed' || status === 'failed' || status === 'killed') {
             this.publish({ payload: { ...payload, status }, type: 'subagent.complete' })
           }
         }
+
         break
       }
       // keep_alive / streamlined_* → ignored for the basic port
@@ -771,6 +900,7 @@ export class GatewayClient extends EventEmitter {
   // Server-initiated control requests (tool permission / elicitation).
   private handleServerControl(msg: any): void {
     const req = msg.request
+
     if (req?.subtype === 'can_use_tool') {
       // ch13 round-4 — carry the backend's permission SUGGESTIONS so the
       // "don't ask again" choice persists a real rule.
@@ -808,11 +938,14 @@ export class GatewayClient extends EventEmitter {
       clearTimeout(this.readyTimer)
       this.readyTimer = null
     }
+
     const err = new Error(reason || `agent-server exited${code === null ? '' : ` (${code})`}`)
-    for (const p of this.pending.values()) p.reject(err)
+
+    for (const p of this.pending.values()) {p.reject(err)}
     this.pending.clear()
-    if (this.subscribed) this.emit('exit', code)
-    else this.pendingExit = code
+
+    if (this.subscribed) {this.emit('exit', code)}
+    else {this.pendingExit = code}
   }
 
   private publish(ev: GatewayEvent): void {
@@ -820,23 +953,27 @@ export class GatewayClient extends EventEmitter {
       clearTimeout(this.readyTimer)
       this.readyTimer = null
     }
-    if (this.subscribed) this.emit('event', ev)
-    else this.buffered.push(ev)
+
+    if (this.subscribed) {this.emit('event', ev)}
+    else {this.buffered.push(ev)}
   }
 
   private pushLog(line: string): void {
     this.logs.push(line)
-    if (this.logs.length > MAX_LOG_LINES) this.logs.shift()
+
+    if (this.logs.length > MAX_LOG_LINES) {this.logs.shift()}
   }
 
   private resolvePending(msg: any): void {
     const r = msg.response
     const id = r?.request_id
     const p = id ? this.pending.get(id) : undefined
-    if (!p) return
+
+    if (!p) {return}
     this.pending.delete(id)
-    if (r.subtype === 'error') p.reject(new Error(String(r.error ?? 'error')))
-    else p.resolve(r.response)
+
+    if (r.subtype === 'error') {p.reject(new Error(String(r.error ?? 'error')))}
+    else {p.resolve(r.response)}
   }
 
   private send(obj: unknown): void {
@@ -855,6 +992,7 @@ export class GatewayClient extends EventEmitter {
     const toolNames: string[] = Array.isArray(init.tools)
       ? init.tools.map((t: any) => t?.name).filter(Boolean)
       : []
+
     return {
       cwd: init.cwd,
       model: String(init.model ?? ''),

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -22,6 +22,31 @@ export interface GatewayTranscriptMessage {
   text?: string
 }
 
+// ── Structured tool diffs ────────────────────────────────────────────
+
+/** jsdiff StructuredPatchHunk: lines keep their +/-/space marker, no terminators. */
+export interface PatchHunk {
+  lines: string[]
+  newLines: number
+  newStart: number
+  oldLines: number
+  oldStart: number
+}
+
+/**
+ * Rich Edit/Write result forwarded by the agent-server as `tool_use_result`
+ * on the user envelope (trimmed display shape — see _display_tool_result).
+ * `content` is present for create-type results (file preview); `firstLine`
+ * for update-type (language/shebang detection).
+ */
+export interface StructuredDiffPayload {
+  content?: string
+  filePath: string
+  firstLine?: null | string
+  hunks: PatchHunk[]
+  kind: 'create' | 'update'
+}
+
 // ── Commands / completion ────────────────────────────────────────────
 
 export interface CommandsCatalogResponse {
@@ -672,6 +697,7 @@ export type GatewayEvent =
         inline_diff?: string
         name?: string
         result_text?: string
+        structured_diff?: StructuredDiffPayload
         summary?: string
         tool_id: string
         todos?: unknown[]

--- a/ui-tui/src/lib/colorDiff.ts
+++ b/ui-tui/src/lib/colorDiff.ts
@@ -1,0 +1,1120 @@
+/**
+ * Pure TypeScript color-diff renderer — ported VERBATIM from openclaude's
+ * typescript/src/native-ts/color-diff/index.ts (itself a pure-TS port of the
+ * Rust `color-diff` NAPI module). This is the exact non-native path the
+ * original TUI uses, so our diffs render identically by construction.
+ *
+ * `ColorDiff(hunk, firstLine, filePath, fileContent).render(themeName, width, dim)`
+ * returns an array of fully ANSI-escaped lines (right-aligned line-number
+ * gutter, +/-/space markers, add/remove backgrounds that extend to the wrap
+ * width, highlight.js syntax colors, and word-level diff highlighting). The
+ * output is self-contained ANSI — it does NOT use Ink's theme system — so the
+ * React wrapper only has to print each line in a <Text>.
+ *
+ * Local deltas vs the upstream file (kept minimal for re-sync):
+ *   - stringWidth: the `@clawcodex/ink` fork helper (the same measurement the
+ *     surrounding layout uses).
+ *   - logError: silent no-op (writing to stderr would corrupt the TUI).
+ *   - highlight.js loaded via lazy dynamic import(): the deployed TUI is a
+ *     single self-contained esbuild bundle with no runtime node_modules, so
+ *     a createRequire lookup would throw there. esbuild inlines dynamic
+ *     imports of bundled deps as lazily-evaluated closures, preserving the
+ *     upstream defer-190-grammars behavior. Rendering before the import
+ *     resolves just skips token colors (structure, backgrounds, and word
+ *     diff are unaffected); callers kick ensureHighlighter() and re-render
+ *     on readiness via subscribeHighlighter().
+ *   - emitter access tolerates both `emitter` (hljs 10.x) and `_emitter`
+ *     (hljs 11.x); ui-tui ships 11.x.
+ *
+ * Style: kept close to the upstream file for future re-sync; the remaining
+ * padding-line lint warnings are accepted for the same reason.
+ */
+
+import { basename, extname } from 'node:path'
+
+import { stringWidth } from '@clawcodex/ink'
+import { diffArrays } from 'diff'
+import type { HLJSApi } from 'highlight.js'
+
+/** Silent in a TUI — stderr writes would punch through the Ink frame. */
+function logError(_e: unknown): void {
+  /* intentionally empty */
+}
+
+// Lazy: defers loading highlight.js until the first diff arrives (registers
+// 190+ grammars, ~100-200ms). ESM bundles can't require() synchronously, so
+// the load is a promise; hljs() returns null until it resolves and the
+// pipeline falls back to unstyled tokens for that render.
+let cachedHljs: HLJSApi | null = null
+let hljsPromise: null | Promise<void> = null
+const hljsListeners = new Set<() => void>()
+
+/** Kick off (or join) the highlight.js load. Resolves once hljs is usable. */
+export function ensureHighlighter(): Promise<void> {
+  if (cachedHljs) {
+    return Promise.resolve()
+  }
+  hljsPromise ??= import('highlight.js')
+    .then(mod => {
+      const m = mod as { default?: HLJSApi }
+      cachedHljs = (m.default ?? mod) as HLJSApi
+
+      for (const fn of hljsListeners) {
+        fn()
+      }
+      hljsListeners.clear()
+    })
+    .catch(e => logError(e))
+
+  return hljsPromise
+}
+
+/** useSyncExternalStore-shaped readiness: subscribe + snapshot. */
+export function subscribeHighlighter(fn: () => void): () => void {
+  hljsListeners.add(fn)
+
+  return () => {
+    hljsListeners.delete(fn)
+  }
+}
+
+export function highlighterReady(): boolean {
+  return cachedHljs !== null
+}
+
+function hljs(): HLJSApi | null {
+  if (!cachedHljs) {
+    void ensureHighlighter()
+  }
+
+  return cachedHljs
+}
+
+// ---------------------------------------------------------------------------
+// Public API types (match vendor/color-diff-src/index.d.ts)
+// ---------------------------------------------------------------------------
+
+export type Hunk = {
+  oldStart: number
+  oldLines: number
+  newStart: number
+  newLines: number
+  lines: string[]
+}
+
+export type SyntaxTheme = {
+  theme: string
+  source: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Color / ANSI escape helpers
+// ---------------------------------------------------------------------------
+
+type Color = { r: number; g: number; b: number; a: number }
+type Style = { foreground: Color; background: Color }
+type Block = [Style, string]
+type ColorMode = 'truecolor' | 'color256' | 'ansi'
+
+const RESET = '\x1b[0m'
+const DIM = '\x1b[2m'
+const UNDIM = '\x1b[22m'
+
+function rgb(r: number, g: number, b: number): Color {
+  return { r, g, b, a: 255 }
+}
+
+function ansiIdx(index: number): Color {
+  return { r: index, g: 0, b: 0, a: 0 }
+}
+
+// Sentinel: a=1 means "terminal default" (matches bat convention)
+const DEFAULT_BG: Color = { r: 0, g: 0, b: 0, a: 1 }
+
+function detectColorMode(theme: string): ColorMode {
+  if (theme.includes('ansi')) {
+    return 'ansi'
+  }
+  const ct = process.env.COLORTERM ?? ''
+
+  return ct === 'truecolor' || ct === '24bit' ? 'truecolor' : 'color256'
+}
+
+// Port of ansi_colours::ansi256_from_rgb — approximates RGB to the xterm-256
+// palette (6x6x6 cube + 24 greys).
+const CUBE_LEVELS = [0, 95, 135, 175, 215, 255]
+
+function ansi256FromRgb(r: number, g: number, b: number): number {
+  const q = (c: number) => (c < 48 ? 0 : c < 115 ? 1 : c < 155 ? 2 : c < 195 ? 3 : c < 235 ? 4 : 5)
+
+  const qr = q(r)
+  const qg = q(g)
+  const qb = q(b)
+  const cubeIdx = 16 + 36 * qr + 6 * qg + qb
+  const grey = Math.round((r + g + b) / 3)
+
+  if (grey < 5) {
+    return 16
+  }
+
+  if (grey > 244 && qr === qg && qg === qb) {
+    return cubeIdx
+  }
+  const greyLevel = Math.max(0, Math.min(23, Math.round((grey - 8) / 10)))
+  const greyIdx = 232 + greyLevel
+  const greyRgb = 8 + greyLevel * 10
+  const cr = CUBE_LEVELS[qr]!
+  const cg = CUBE_LEVELS[qg]!
+  const cb = CUBE_LEVELS[qb]!
+  const dCube = (r - cr) ** 2 + (g - cg) ** 2 + (b - cb) ** 2
+  const dGrey = (r - greyRgb) ** 2 + (g - greyRgb) ** 2 + (b - greyRgb) ** 2
+
+  return dGrey < dCube ? greyIdx : cubeIdx
+}
+
+function colorToEscape(c: Color, fg: boolean, mode: ColorMode): string {
+  // alpha=0: palette index encoded in .r (bat's ansi-theme convention)
+  if (c.a === 0) {
+    const idx = c.r
+
+    if (idx < 8) {
+      return `\x1b[${(fg ? 30 : 40) + idx}m`
+    }
+
+    if (idx < 16) {
+      return `\x1b[${(fg ? 90 : 100) + (idx - 8)}m`
+    }
+
+    return `\x1b[${fg ? 38 : 48};5;${idx}m`
+  }
+
+  // alpha=1: terminal default
+  if (c.a === 1) {
+    return fg ? '\x1b[39m' : '\x1b[49m'
+  }
+
+  const codeType = fg ? 38 : 48
+
+  if (mode === 'truecolor') {
+    return `\x1b[${codeType};2;${c.r};${c.g};${c.b}m`
+  }
+
+  return `\x1b[${codeType};5;${ansi256FromRgb(c.r, c.g, c.b)}m`
+}
+
+function asTerminalEscaped(blocks: readonly Block[], mode: ColorMode, skipBackground: boolean, dim: boolean): string {
+  let out = dim ? RESET + DIM : RESET
+
+  for (const [style, text] of blocks) {
+    out += colorToEscape(style.foreground, true, mode)
+
+    if (!skipBackground) {
+      out += colorToEscape(style.background, false, mode)
+    }
+
+    out += text
+  }
+
+  return out + RESET
+}
+
+// ---------------------------------------------------------------------------
+// Theme
+// ---------------------------------------------------------------------------
+
+type Marker = '+' | '-' | ' '
+
+type Theme = {
+  addLine: Color
+  addWord: Color
+  addDecoration: Color
+  deleteLine: Color
+  deleteWord: Color
+  deleteDecoration: Color
+  foreground: Color
+  background: Color
+  scopes: Record<string, Color>
+}
+
+function defaultSyntaxThemeName(themeName: string): string {
+  if (themeName.includes('ansi')) {
+    return 'ansi'
+  }
+
+  if (themeName.includes('dark')) {
+    return 'Monokai Extended'
+  }
+
+  return 'GitHub'
+}
+
+// highlight.js scope → syntect Monokai Extended foreground (measured from the
+// Rust module's output so colors match the original exactly)
+const MONOKAI_SCOPES: Record<string, Color> = {
+  keyword: rgb(249, 38, 114),
+  _storage: rgb(102, 217, 239),
+  built_in: rgb(166, 226, 46),
+  type: rgb(166, 226, 46),
+  literal: rgb(190, 132, 255),
+  number: rgb(190, 132, 255),
+  string: rgb(230, 219, 116),
+  title: rgb(166, 226, 46),
+  'title.function': rgb(166, 226, 46),
+  'title.class': rgb(166, 226, 46),
+  'title.class.inherited': rgb(166, 226, 46),
+  params: rgb(253, 151, 31),
+  comment: rgb(117, 113, 94),
+  meta: rgb(117, 113, 94),
+  attr: rgb(166, 226, 46),
+  attribute: rgb(166, 226, 46),
+  variable: rgb(255, 255, 255),
+  'variable.language': rgb(255, 255, 255),
+  property: rgb(255, 255, 255),
+  operator: rgb(249, 38, 114),
+  punctuation: rgb(248, 248, 242),
+  symbol: rgb(190, 132, 255),
+  regexp: rgb(230, 219, 116),
+  subst: rgb(248, 248, 242)
+}
+
+// highlight.js scope → syntect GitHub-light foreground (measured from Rust)
+const GITHUB_SCOPES: Record<string, Color> = {
+  keyword: rgb(167, 29, 93),
+  _storage: rgb(167, 29, 93),
+  built_in: rgb(0, 134, 179),
+  type: rgb(0, 134, 179),
+  literal: rgb(0, 134, 179),
+  number: rgb(0, 134, 179),
+  string: rgb(24, 54, 145),
+  title: rgb(121, 93, 163),
+  'title.function': rgb(121, 93, 163),
+  'title.class': rgb(0, 0, 0),
+  'title.class.inherited': rgb(0, 0, 0),
+  params: rgb(0, 134, 179),
+  comment: rgb(150, 152, 150),
+  meta: rgb(150, 152, 150),
+  attr: rgb(0, 134, 179),
+  attribute: rgb(0, 134, 179),
+  variable: rgb(0, 134, 179),
+  'variable.language': rgb(0, 134, 179),
+  property: rgb(0, 134, 179),
+  operator: rgb(167, 29, 93),
+  punctuation: rgb(51, 51, 51),
+  symbol: rgb(0, 134, 179),
+  regexp: rgb(24, 54, 145),
+  subst: rgb(51, 51, 51)
+}
+
+// Keywords that syntect scopes as storage.type rather than keyword.control.
+const STORAGE_KEYWORDS = new Set([
+  'const',
+  'let',
+  'var',
+  'function',
+  'class',
+  'type',
+  'interface',
+  'enum',
+  'namespace',
+  'module',
+  'def',
+  'fn',
+  'func',
+  'struct',
+  'trait',
+  'impl'
+])
+
+const ANSI_SCOPES: Record<string, Color> = {
+  keyword: ansiIdx(13),
+  _storage: ansiIdx(14),
+  built_in: ansiIdx(14),
+  type: ansiIdx(14),
+  literal: ansiIdx(12),
+  number: ansiIdx(12),
+  string: ansiIdx(10),
+  title: ansiIdx(11),
+  'title.function': ansiIdx(11),
+  'title.class': ansiIdx(11),
+  comment: ansiIdx(8),
+  meta: ansiIdx(8)
+}
+
+function buildTheme(themeName: string, mode: ColorMode): Theme {
+  const isDark = themeName.includes('dark')
+  const isAnsi = themeName.includes('ansi')
+  const isDaltonized = themeName.includes('daltonized')
+  const tc = mode === 'truecolor'
+
+  if (isAnsi) {
+    return {
+      addLine: DEFAULT_BG,
+      addWord: DEFAULT_BG,
+      addDecoration: ansiIdx(10),
+      deleteLine: DEFAULT_BG,
+      deleteWord: DEFAULT_BG,
+      deleteDecoration: ansiIdx(9),
+      foreground: ansiIdx(7),
+      background: DEFAULT_BG,
+      scopes: ANSI_SCOPES
+    }
+  }
+
+  if (isDark) {
+    const fg = rgb(248, 248, 242)
+    const deleteLine = rgb(61, 1, 0)
+    const deleteWord = rgb(92, 2, 0)
+    const deleteDecoration = rgb(220, 90, 90)
+
+    if (isDaltonized) {
+      return {
+        addLine: tc ? rgb(0, 27, 41) : ansiIdx(17),
+        addWord: tc ? rgb(0, 48, 71) : ansiIdx(24),
+        addDecoration: rgb(81, 160, 200),
+        deleteLine,
+        deleteWord,
+        deleteDecoration,
+        foreground: fg,
+        background: DEFAULT_BG,
+        scopes: MONOKAI_SCOPES
+      }
+    }
+
+    return {
+      addLine: tc ? rgb(2, 40, 0) : ansiIdx(22),
+      addWord: tc ? rgb(4, 71, 0) : ansiIdx(28),
+      addDecoration: rgb(80, 200, 80),
+      deleteLine,
+      deleteWord,
+      deleteDecoration,
+      foreground: fg,
+      background: DEFAULT_BG,
+      scopes: MONOKAI_SCOPES
+    }
+  }
+
+  // light
+  const fg = rgb(51, 51, 51)
+  const deleteLine = rgb(255, 220, 220)
+  const deleteWord = rgb(255, 199, 199)
+  const deleteDecoration = rgb(207, 34, 46)
+
+  if (isDaltonized) {
+    return {
+      addLine: rgb(219, 237, 255),
+      addWord: rgb(179, 217, 255),
+      addDecoration: rgb(36, 87, 138),
+      deleteLine,
+      deleteWord,
+      deleteDecoration,
+      foreground: fg,
+      background: DEFAULT_BG,
+      scopes: GITHUB_SCOPES
+    }
+  }
+
+  return {
+    addLine: rgb(220, 255, 220),
+    addWord: rgb(178, 255, 178),
+    addDecoration: rgb(36, 138, 61),
+    deleteLine,
+    deleteWord,
+    deleteDecoration,
+    foreground: fg,
+    background: DEFAULT_BG,
+    scopes: GITHUB_SCOPES
+  }
+}
+
+function defaultStyle(theme: Theme): Style {
+  return { foreground: theme.foreground, background: theme.background }
+}
+
+function lineBackground(marker: Marker, theme: Theme): Color {
+  switch (marker) {
+    case '+':
+      return theme.addLine
+
+    case '-':
+      return theme.deleteLine
+
+    case ' ':
+      return theme.background
+  }
+}
+
+function wordBackground(marker: Marker, theme: Theme): Color {
+  switch (marker) {
+    case '+':
+      return theme.addWord
+
+    case '-':
+      return theme.deleteWord
+
+    case ' ':
+      return theme.background
+  }
+}
+
+function decorationColor(marker: Marker, theme: Theme): Color {
+  switch (marker) {
+    case '+':
+      return theme.addDecoration
+
+    case '-':
+      return theme.deleteDecoration
+
+    case ' ':
+      return theme.foreground
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Syntax highlighting via highlight.js
+// ---------------------------------------------------------------------------
+
+// hljs 10.x uses `kind`; 11.x uses `scope`. Handle both.
+type HljsNode = {
+  scope?: string
+  kind?: string
+  children: (HljsNode | string)[]
+}
+
+const FILENAME_LANGS: Record<string, string> = {
+  Dockerfile: 'dockerfile',
+  Makefile: 'makefile',
+  Rakefile: 'ruby',
+  Gemfile: 'ruby',
+  CMakeLists: 'cmake'
+}
+
+function detectLanguage(filePath: string, firstLine: string | null): string | null {
+  const base = basename(filePath)
+  const ext = extname(filePath).slice(1)
+
+  const hl = hljs()
+
+  if (!hl) {
+    return null
+  }
+  const stem = base.split('.')[0] ?? ''
+  const byName = FILENAME_LANGS[base] ?? FILENAME_LANGS[stem]
+
+  if (byName && hl.getLanguage(byName)) {
+    return byName
+  }
+
+  if (ext) {
+    const lang = hl.getLanguage(ext)
+
+    if (lang) {
+      return ext
+    }
+  }
+
+  if (firstLine) {
+    const line = firstLine.startsWith('﻿') ? firstLine.slice(1) : firstLine
+
+    if (line.startsWith('#!')) {
+      if (line.includes('bash') || line.includes('/sh')) {
+        return 'bash'
+      }
+
+      if (line.includes('python')) {
+        return 'python'
+      }
+
+      if (line.includes('node')) {
+        return 'javascript'
+      }
+
+      if (line.includes('ruby')) {
+        return 'ruby'
+      }
+
+      if (line.includes('perl')) {
+        return 'perl'
+      }
+    }
+
+    if (line.startsWith('<?php')) {
+      return 'php'
+    }
+
+    if (line.startsWith('<?xml')) {
+      return 'xml'
+    }
+  }
+
+  return null
+}
+
+function scopeColor(scope: string | undefined, text: string, theme: Theme): Color {
+  if (!scope) {
+    return theme.foreground
+  }
+
+  if (scope === 'keyword' && STORAGE_KEYWORDS.has(text.trim())) {
+    return theme.scopes['_storage'] ?? theme.foreground
+  }
+
+  return theme.scopes[scope] ?? theme.scopes[scope.split('.')[0]!] ?? theme.foreground
+}
+
+function flattenHljs(node: HljsNode | string, theme: Theme, parentScope: string | undefined, out: Block[]): void {
+  if (typeof node === 'string') {
+    const fg = scopeColor(parentScope, node, theme)
+    out.push([{ foreground: fg, background: theme.background }, node])
+
+    return
+  }
+
+  const scope = node.scope ?? node.kind ?? parentScope
+
+  for (const child of node.children) {
+    flattenHljs(child, theme, scope, out)
+  }
+}
+
+function hasRootNode(emitter: unknown): emitter is { rootNode: HljsNode } {
+  return (
+    typeof emitter === 'object' &&
+    emitter !== null &&
+    'rootNode' in emitter &&
+    typeof (emitter as { rootNode: unknown }).rootNode === 'object' &&
+    (emitter as { rootNode: unknown }).rootNode !== null &&
+    'children' in (emitter as { rootNode: object }).rootNode
+  )
+}
+
+let loggedEmitterShapeError = false
+
+function highlightLine(state: { lang: string | null; stack: unknown }, line: string, theme: Theme): Block[] {
+  // syntect-parity: feed a trailing \n so line comments terminate, then strip
+  const code = line + '\n'
+  const hl = hljs()
+
+  if (!state.lang || !hl) {
+    return [[defaultStyle(theme), code]]
+  }
+
+  let result
+
+  try {
+    result = hl.highlight(code, {
+      language: state.lang,
+      ignoreIllegals: true
+    })
+  } catch {
+    return [[defaultStyle(theme), code]]
+  }
+
+  // hljs 10.x exposes `.emitter`; 11.x renamed it to `._emitter`.
+  const emitter =
+    (result as { emitter?: unknown; _emitter?: unknown }).emitter ?? (result as { _emitter?: unknown })._emitter
+
+  if (!hasRootNode(emitter)) {
+    if (!loggedEmitterShapeError) {
+      loggedEmitterShapeError = true
+      logError(new Error(`color-diff: hljs emitter shape mismatch. Syntax highlighting disabled.`))
+    }
+
+    return [[defaultStyle(theme), code]]
+  }
+
+  const blocks: Block[] = []
+  flattenHljs(emitter.rootNode, theme, undefined, blocks)
+
+  return blocks
+}
+
+// ---------------------------------------------------------------------------
+// Word diff
+// ---------------------------------------------------------------------------
+
+type Range = { start: number; end: number }
+
+const CHANGE_THRESHOLD = 0.4
+
+function tokenize(text: string): string[] {
+  const tokens: string[] = []
+  let i = 0
+
+  while (i < text.length) {
+    const ch = text[i]!
+
+    if (/[\p{L}\p{N}_]/u.test(ch)) {
+      let j = i + 1
+
+      while (j < text.length && /[\p{L}\p{N}_]/u.test(text[j]!)) {
+        j++
+      }
+      tokens.push(text.slice(i, j))
+      i = j
+    } else if (/\s/.test(ch)) {
+      let j = i + 1
+
+      while (j < text.length && /\s/.test(text[j]!)) {
+        j++
+      }
+      tokens.push(text.slice(i, j))
+      i = j
+    } else {
+      const cp = text.codePointAt(i)!
+      const len = cp > 0xffff ? 2 : 1
+      tokens.push(text.slice(i, i + len))
+      i += len
+    }
+  }
+
+  return tokens
+}
+
+function findAdjacentPairs(markers: Marker[]): [number, number][] {
+  const pairs: [number, number][] = []
+  let i = 0
+
+  while (i < markers.length) {
+    if (markers[i] === '-') {
+      const delStart = i
+      let delEnd = i
+
+      while (delEnd < markers.length && markers[delEnd] === '-') {
+        delEnd++
+      }
+      let addEnd = delEnd
+
+      while (addEnd < markers.length && markers[addEnd] === '+') {
+        addEnd++
+      }
+      const delCount = delEnd - delStart
+      const addCount = addEnd - delEnd
+
+      if (delCount > 0 && addCount > 0) {
+        const n = Math.min(delCount, addCount)
+
+        for (let k = 0; k < n; k++) {
+          pairs.push([delStart + k, delEnd + k])
+        }
+
+        i = addEnd
+      } else {
+        i = delEnd
+      }
+    } else {
+      i++
+    }
+  }
+
+  return pairs
+}
+
+function wordDiffStrings(oldStr: string, newStr: string): [Range[], Range[]] {
+  const oldTokens = tokenize(oldStr)
+  const newTokens = tokenize(newStr)
+  const ops = diffArrays(oldTokens, newTokens)
+
+  const totalLen = oldStr.length + newStr.length
+  let changedLen = 0
+  const oldRanges: Range[] = []
+  const newRanges: Range[] = []
+  let oldOff = 0
+  let newOff = 0
+
+  for (const op of ops) {
+    const len = op.value.reduce((s, t) => s + t.length, 0)
+
+    if (op.removed) {
+      changedLen += len
+      oldRanges.push({ start: oldOff, end: oldOff + len })
+      oldOff += len
+    } else if (op.added) {
+      changedLen += len
+      newRanges.push({ start: newOff, end: newOff + len })
+      newOff += len
+    } else {
+      oldOff += len
+      newOff += len
+    }
+  }
+
+  if (totalLen > 0 && changedLen / totalLen > CHANGE_THRESHOLD) {
+    return [[], []]
+  }
+
+  return [oldRanges, newRanges]
+}
+
+// ---------------------------------------------------------------------------
+// Highlight (per-line transform pipeline)
+// ---------------------------------------------------------------------------
+
+type Highlight = {
+  marker: Marker | null
+  lineNumber: number
+  lines: Block[][]
+}
+
+function removeNewlines(h: Highlight): void {
+  h.lines = h.lines.map(line =>
+    line.flatMap(([style, text]) =>
+      text
+        .split('\n')
+        .filter(p => p.length > 0)
+        .map((p): Block => [style, p])
+    )
+  )
+}
+
+function charWidth(ch: string): number {
+  return stringWidth(ch)
+}
+
+function wrapText(h: Highlight, width: number, theme: Theme): void {
+  const newLines: Block[][] = []
+
+  for (const line of h.lines) {
+    const queue: Block[] = line.slice()
+    let cur: Block[] = []
+    let curW = 0
+
+    while (queue.length > 0) {
+      const [style, text] = queue.shift()!
+      const tw = stringWidth(text)
+
+      if (curW + tw <= width) {
+        cur.push([style, text])
+        curW += tw
+      } else {
+        const remaining = width - curW
+        let bytePos = 0
+        let accW = 0
+
+        for (const ch of text) {
+          const cw = charWidth(ch)
+
+          if (accW + cw > remaining) {
+            break
+          }
+          accW += cw
+          bytePos += ch.length
+        }
+
+        if (bytePos === 0) {
+          if (curW === 0) {
+            const firstCp = text.codePointAt(0)!
+            bytePos = firstCp > 0xffff ? 2 : 1
+          } else {
+            newLines.push(cur)
+            queue.unshift([style, text])
+            cur = []
+            curW = 0
+
+            continue
+          }
+        }
+
+        cur.push([style, text.slice(0, bytePos)])
+        newLines.push(cur)
+        queue.unshift([style, text.slice(bytePos)])
+        cur = []
+        curW = 0
+      }
+    }
+
+    newLines.push(cur)
+  }
+
+  h.lines = newLines
+
+  // Pad changed lines so background extends to edge
+  if (h.marker && h.marker !== ' ') {
+    const bg = lineBackground(h.marker, theme)
+    const padStyle: Style = { foreground: theme.foreground, background: bg }
+
+    for (const line of h.lines) {
+      const curW = line.reduce((s, [, t]) => s + stringWidth(t), 0)
+
+      if (curW < width) {
+        line.push([padStyle, ' '.repeat(width - curW)])
+      }
+    }
+  }
+}
+
+function addLineNumber(h: Highlight, theme: Theme, maxDigits: number, fullDim: boolean): void {
+  const style: Style = {
+    foreground: h.marker ? decorationColor(h.marker, theme) : theme.foreground,
+    background: h.marker ? lineBackground(h.marker, theme) : theme.background
+  }
+
+  const shouldDim = h.marker === null || h.marker === ' '
+
+  for (let i = 0; i < h.lines.length; i++) {
+    const prefix = i === 0 ? ` ${String(h.lineNumber).padStart(maxDigits)} ` : ' '.repeat(maxDigits + 2)
+
+    const wrapped = shouldDim && !fullDim ? `${DIM}${prefix}${UNDIM}` : prefix
+    h.lines[i]!.unshift([style, wrapped])
+  }
+}
+
+function addMarker(h: Highlight, theme: Theme): void {
+  if (!h.marker) {
+    return
+  }
+
+  const style: Style = {
+    foreground: decorationColor(h.marker, theme),
+    background: lineBackground(h.marker, theme)
+  }
+
+  for (const line of h.lines) {
+    line.unshift([style, h.marker])
+  }
+}
+
+function dimContent(h: Highlight): void {
+  for (const line of h.lines) {
+    if (line.length > 0) {
+      line[0]![1] = DIM + line[0]![1]
+      const last = line.length - 1
+      line[last]![1] = line[last]![1] + UNDIM
+    }
+  }
+}
+
+function applyBackground(h: Highlight, theme: Theme, ranges: Range[]): void {
+  if (!h.marker) {
+    return
+  }
+  const lineBg = lineBackground(h.marker, theme)
+  const wordBg = wordBackground(h.marker, theme)
+
+  let rangeIdx = 0
+  let byteOff = 0
+
+  for (let li = 0; li < h.lines.length; li++) {
+    const newLine: Block[] = []
+
+    for (const [style, text] of h.lines[li]!) {
+      const textStart = byteOff
+      const textEnd = byteOff + text.length
+
+      while (rangeIdx < ranges.length && ranges[rangeIdx]!.end <= textStart) {
+        rangeIdx++
+      }
+
+      if (rangeIdx >= ranges.length) {
+        newLine.push([{ ...style, background: lineBg }, text])
+        byteOff = textEnd
+
+        continue
+      }
+
+      let remaining = text
+      let pos = textStart
+
+      while (remaining.length > 0 && rangeIdx < ranges.length) {
+        const r = ranges[rangeIdx]!
+        const inRange = pos >= r.start && pos < r.end
+        let next: number
+
+        if (inRange) {
+          next = Math.min(r.end, textEnd)
+        } else if (r.start > pos && r.start < textEnd) {
+          next = r.start
+        } else {
+          next = textEnd
+        }
+
+        const segLen = next - pos
+        const seg = remaining.slice(0, segLen)
+        newLine.push([{ ...style, background: inRange ? wordBg : lineBg }, seg])
+        remaining = remaining.slice(segLen)
+        pos = next
+
+        if (pos >= r.end) {
+          rangeIdx++
+        }
+      }
+
+      if (remaining.length > 0) {
+        newLine.push([{ ...style, background: lineBg }, remaining])
+      }
+
+      byteOff = textEnd
+    }
+
+    h.lines[li] = newLine
+  }
+}
+
+function intoLines(h: Highlight, dim: boolean, skipBg: boolean, mode: ColorMode): string[] {
+  return h.lines.map(line => asTerminalEscaped(line, mode, skipBg, dim))
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+function maxLineNumber(hunk: Hunk): number {
+  const oldEnd = Math.max(0, hunk.oldStart + hunk.oldLines - 1)
+  const newEnd = Math.max(0, hunk.newStart + hunk.newLines - 1)
+
+  return Math.max(oldEnd, newEnd)
+}
+
+function parseMarker(s: string): Marker {
+  return s === '+' || s === '-' ? s : ' '
+}
+
+export class ColorDiff {
+  private hunk: Hunk
+  private filePath: string
+  private firstLine: string | null
+  private prefixContent: string | null
+
+  constructor(hunk: Hunk, firstLine: string | null, filePath: string, prefixContent?: string | null) {
+    this.hunk = hunk
+    this.filePath = filePath
+    this.firstLine = firstLine
+    this.prefixContent = prefixContent ?? null
+  }
+
+  render(themeName: string, width: number, dim: boolean): string[] | null {
+    const mode = detectColorMode(themeName)
+    const theme = buildTheme(themeName, mode)
+    const lang = detectLanguage(this.filePath, this.firstLine)
+    const hlState = { lang, stack: null }
+
+    void this.prefixContent
+
+    const maxDigits = String(maxLineNumber(this.hunk)).length
+    let oldLine = this.hunk.oldStart
+    let newLine = this.hunk.newStart
+
+    // First pass: assign markers + line numbers
+    type Entry = { lineNumber: number; marker: Marker; code: string }
+
+    const entries: Entry[] = this.hunk.lines.map(rawLine => {
+      const marker = parseMarker(rawLine.slice(0, 1))
+      const code = rawLine.slice(1)
+      let lineNumber: number
+
+      switch (marker) {
+        case '+':
+          lineNumber = newLine++
+
+          break
+
+        case '-':
+          lineNumber = oldLine++
+
+          break
+
+        case ' ':
+          lineNumber = newLine
+          oldLine++
+          newLine++
+
+          break
+      }
+
+      return { lineNumber, marker, code }
+    })
+
+    // Word-diff ranges (skip when dim — too loud)
+    const ranges: Range[][] = entries.map(() => [])
+
+    if (!dim) {
+      const markers = entries.map(e => e.marker)
+
+      for (const [delIdx, addIdx] of findAdjacentPairs(markers)) {
+        const [delR, addR] = wordDiffStrings(entries[delIdx]!.code, entries[addIdx]!.code)
+
+        ranges[delIdx] = delR
+        ranges[addIdx] = addR
+      }
+    }
+
+    const effectiveWidth = Math.max(1, width - maxDigits - 2 - 1)
+
+    // Second pass: highlight + transform pipeline
+    const out: string[] = []
+
+    for (let i = 0; i < entries.length; i++) {
+      const { lineNumber, marker, code } = entries[i]!
+
+      const tokens: Block[] = marker === '-' ? [[defaultStyle(theme), code]] : highlightLine(hlState, code, theme)
+
+      const h: Highlight = { marker, lineNumber, lines: [tokens] }
+      removeNewlines(h)
+      applyBackground(h, theme, ranges[i]!)
+      wrapText(h, effectiveWidth, theme)
+
+      if (mode === 'ansi' && marker === '-') {
+        dimContent(h)
+      }
+
+      addMarker(h, theme)
+      addLineNumber(h, theme, maxDigits, dim)
+      out.push(...intoLines(h, dim, false, mode))
+    }
+
+    return out
+  }
+}
+
+export class ColorFile {
+  private code: string
+  private filePath: string
+
+  constructor(code: string, filePath: string) {
+    this.code = code
+    this.filePath = filePath
+  }
+
+  render(themeName: string, width: number, dim: boolean): string[] | null {
+    const mode = detectColorMode(themeName)
+    const theme = buildTheme(themeName, mode)
+    const lines = this.code.split('\n')
+
+    if (lines.length > 0 && lines[lines.length - 1] === '') {
+      lines.pop()
+    }
+    const firstLine = lines[0] ?? null
+    const lang = detectLanguage(this.filePath, firstLine)
+    const hlState = { lang, stack: null }
+
+    const maxDigits = String(lines.length).length
+    const effectiveWidth = Math.max(1, width - maxDigits - 2)
+
+    const out: string[] = []
+
+    for (let i = 0; i < lines.length; i++) {
+      const tokens = highlightLine(hlState, lines[i]!, theme)
+      const h: Highlight = { marker: null, lineNumber: i + 1, lines: [tokens] }
+      removeNewlines(h)
+      wrapText(h, effectiveWidth, theme)
+      addLineNumber(h, theme, maxDigits, dim)
+      out.push(...intoLines(h, dim, true, mode))
+    }
+
+    return out
+  }
+}
+
+export function getSyntaxTheme(themeName: string): SyntaxTheme {
+  return { theme: defaultSyntaxThemeName(themeName), source: null }
+}
+
+// Exported for testing (mirrors upstream __test)
+export const __test = {
+  ansi256FromRgb,
+  colorToEscape,
+  detectColorMode,
+  detectLanguage,
+  findAdjacentPairs,
+  tokenize,
+  wordDiffStrings
+}

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -49,6 +49,9 @@ export interface Theme {
   brand: ThemeBrand
   bannerLogo: string
   bannerHero: string
+  // Palette identity for renderers that pick their own colors by theme
+  // (ColorDiff's diff backgrounds + Monokai/GitHub syntax scopes).
+  mode: 'dark' | 'light'
 }
 
 // ── Color math ───────────────────────────────────────────────────────
@@ -282,17 +285,20 @@ export const DARK_THEME: Theme = {
     statusCritical: '#FF6B80',
     selectionBg: '#373737',
 
-    diffAdded: 'rgb(220,255,220)',
-    diffRemoved: 'rgb(255,220,220)',
-    diffAddedWord: 'rgb(36,138,61)',
-    diffRemovedWord: 'rgb(207,34,46)',
+    // Original Claude Code dark-theme diff tokens (utils/theme.ts darkTheme):
+    // dark green/red backgrounds, brighter word-level highlights.
+    diffAdded: 'rgb(34,92,43)',
+    diffRemoved: 'rgb(122,41,54)',
+    diffAddedWord: 'rgb(56,166,96)',
+    diffRemovedWord: 'rgb(179,89,107)',
     shellDollar: '#B1B9F9'
   },
 
   brand: BRAND,
 
   bannerLogo: '',
-  bannerHero: ''
+  bannerHero: '',
+  mode: 'dark'
 }
 
 // Light-terminal palette: darker golds/ambers that stay legible on white
@@ -327,17 +333,19 @@ export const LIGHT_THEME: Theme = {
     statusCritical: '#AB2B3F',
     selectionBg: '#E0E0E0',
 
-    diffAdded: 'rgb(200,240,200)',
-    diffRemoved: 'rgb(240,200,200)',
-    diffAddedWord: 'rgb(27,94,32)',
-    diffRemovedWord: 'rgb(183,28,28)',
+    // Original Claude Code light-theme diff tokens (utils/theme.ts lightTheme).
+    diffAdded: 'rgb(105,219,124)',
+    diffRemoved: 'rgb(255,168,180)',
+    diffAddedWord: 'rgb(47,157,68)',
+    diffRemovedWord: 'rgb(209,69,75)',
     shellDollar: '#5769F7'
   },
 
   brand: BRAND,
 
   bannerLogo: '',
-  bannerHero: ''
+  bannerHero: '',
+  mode: 'light'
 }
 
 const TRUE_RE = /^(?:1|true|yes|on)$/
@@ -637,7 +645,8 @@ export function fromSkin(
       },
 
       bannerLogo,
-      bannerHero
+      bannerHero,
+      mode: d.mode
     },
     process.env,
     DEFAULT_LIGHT_MODE

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -125,6 +125,10 @@ export interface ClarifyReq {
 }
 
 export interface Msg {
+  // Structured Edit/Write patch for kind:'diff' segments — rendered by
+  // DiffView (line numbers, word diff, ColorDiff). Text-only diff segments
+  // (legacy backends) fall back to the markdown ```diff path.
+  diffData?: MsgDiffData
   info?: SessionInfo
   kind?: 'diff' | 'intro' | 'panel' | 'slash' | 'trail'
   panelData?: PanelData
@@ -137,6 +141,22 @@ export interface Msg {
   todos?: TodoItem[]
   todoIncomplete?: boolean
   todoCollapsedByDefault?: boolean
+}
+
+/**
+ * Display data for a structured diff segment. Same shape as the gateway's
+ * StructuredDiffPayload plus the ingestion-time truncation bookkeeping
+ * (hunks are capped once when the segment is built so the render cache can
+ * key on stable hunk objects).
+ */
+export interface MsgDiffData {
+  content?: string
+  filePath: string
+  firstLine?: null | string
+  hunks: Array<{ lines: string[]; newLines: number; newStart: number; oldLines: number; oldStart: number }>
+  kind: 'create' | 'update'
+  /** Hunk lines dropped by the ingestion cap (renders as "… +N lines"). */
+  truncatedLines?: number
 }
 
 export type Role = 'assistant' | 'system' | 'tool' | 'user'


### PR DESCRIPTION
## Problem

Inline Edit/Write diffs in the TUI were unreadable (user screenshot): a fake unified diff fabricated from tool *input* — `---/+++` headers rendered as content, every old/new line painted whole-row, **light-theme pastel backgrounds on dark terminals**, no line numbers, no context lines, no word-level diff, backgrounds bleeding across wrapped rows.

## Fix — render exactly what the original Claude Code renders

The original implementation (in-repo at `typescript/`) drives `FileEditToolUpdatedMessage` → `StructuredDiff` → the `native-ts/color-diff` renderer with the tool's real `structuredPatch`. This PR wires that pipeline end to end:

**Backend**
- `_sdk_envelope` forwards the rich Edit/Write output as `tool_use_result` (SDK stream convention), trimmed for display (`_display_tool_result`): self-describing shape gate, `originalFile` dropped, update-`content` (full post-edit file, 1 GiB ceiling) reduced to `firstLine`; create keeps `content` for the preview. Builds a new dict — the source object is shared with the persisted transcript.
- `diff_utils`: hunk lines normalized to the jsdiff `StructuredPatchHunk` shape (strip the one trailing terminator difflib's keepends leaves), leading tabs → 2 spaces on diff inputs (display-only, matching the original), and a pre-existing parser bug fixed: in-hunk content lines starting with `--`/`++` (SQL comments, `++i;`) were eaten by an over-broad header skip.

**ui-tui**
- `lib/colorDiff.ts` — verbatim port of the original's `native-ts/color-diff`: dim right-aligned line-number gutter, `+`/`-` markers, add/remove backgrounds padded to the wrap width, word-level diff (0.4 change threshold), Monokai/GitHub syntax scopes. highlight.js loads via lazy dynamic `import()` — `createRequire` would throw in the self-contained esbuild bundle.
- `components/diffView.tsx` — the original result message: `Added N lines, removed M lines` / `Wrote N lines to path`, ColorDiff/ColorFile rows in `RawAnsi` at `columns − 12`, dim `...` between hunks, module-level render cache on stable hunk objects (the virtualized transcript remounts rows on resize/scroll). Create-type always renders the 10-line content preview (kind switch, like the original).
- `turnController` — structured segments capped once at ingestion (240 rows + `… +N lines` hint) with a derived ```` ```diff ```` fence so the existing dedupe/copy/height machinery keeps working; unrenderable results (no-op write) fall back to the plain trail line.
- `gatewayClient` — shape-detects `tool_use_result`; **both** diff flavors gated on `!is_error` (a failed edit no longer fabricates a diff for an edit that never ran); legacy input-diff only for older backends.
- `theme` — original CC diff tokens (the dark theme was carrying light-theme pastels: `rgb(220,255,220)` → `rgb(34,92,43)` etc.) + a `mode` field; markdown ```` ```diff ```` fallback dims `---/+++/@@` meta rows.
- `messageLine` — diff segments render tool trail + DiffView at the left edge; no role glyph, no stray `Response` separator.

Before / after (pyte screenshot, real render):

```
BEFORE                                        AFTER
--- /Users/…/posts.ts                         ⏺ Edit(src/data/posts.ts) (0.0s)
+++ /Users/…/posts.ts                           ⎿  Added 2 lines, removed 2 lines
-  {                                                1  export const posts = [
-    id: "obama-as-author",                         2    {
-    title: "Obama Before the Presidency…           3 -    id: "obama-as-author",
(pink-on-dark, whole blob)                          4 -    title: "Obama Before the Presidency",
+  {                                                3 +    id: "drone-warfare",
+    id: "drone-warfare",                           4 +    title: "The Drone Presidency",
                                                    5      date: "2026-06-21",
```

## Verification

- 19 new vitest cases (ColorDiff layout/word-diff/wrap, gatewayClient mapping incl. malformed shapes + `is_error`, turnController cap/dedupe/fallback, DiffView render incl. create-with-hunks) — full ui-tui suite stays at its pre-existing 14-failure env baseline (1103 passed).
- 14 new pytest cases (`_display_tool_result` trimming + no-mutation, envelope forwarding, terminator normalization LF/CRLF/lone-CR/no-EOL, tab conversion, `--`/`++` content-line regression) — full Python suite at its pre-existing 9-failure baseline (7592 passed).
- Deterministic pyte e2e (scripted backend): asserts gutter line numbers, no `---/+++` rows, and the **exact original background colors** on add/remove cells (`rgb(2,40,0)` / `rgb(61,1,0)`).
- Live pyte e2e (real agent-server + model): structured diff rendered correctly, file actually edited, and an intermediate failed Edit rendered no diff (error gate verified live).
- Critic (plan + implementation) review loop: APPROVE.

Two commits: a mechanical `eslint --fix` of `gatewayClient.ts` (pre-existing violations force a reformat on any edit), then the feature — so the feature diff stays reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
