### PR TITLE
feat(tui): original-CC tool-call transcript + theme tokens (look&feel A)

### DIFF
--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -13,6 +13,7 @@ const harness = vi.hoisted(() => ({ proc: null as null | EventEmitter, spawnCall
 vi.mock('node:child_process', () => ({
   spawn: (...args: unknown[]) => {
     harness.spawnCalls.push(args)
+
     return harness.proc
   }
 }))
@@ -35,6 +36,7 @@ const toolUse = (id: string, name: string, input: unknown) => ({
   message: { content: [{ id, input, name, type: 'tool_use' }] },
   type: 'assistant'
 })
+
 const toolResult = (id: string, content: unknown, isError = false) => ({
   message: { content: [{ content, is_error: isError, tool_use_id: id, type: 'tool_result' }] },
   type: 'user'
@@ -70,12 +72,14 @@ describe('GatewayClient NDJSON adapter', () => {
 
   afterEach(() => {
     gw.kill()
-    if (prevWs === undefined) delete process.env.CLAWCODEX_WORKSPACE
-    else process.env.CLAWCODEX_WORKSPACE = prevWs
+
+    if (prevWs === undefined) {delete process.env.CLAWCODEX_WORKSPACE}
+    else {process.env.CLAWCODEX_WORKSPACE = prevWs}
   })
 
   const types = () => events.map(e => e.type)
   const last = (t: string) => [...events].reverse().find(e => e.type === t)
+
   // Emit a tool_use then await its tool.start (so toolInputs is populated),
   // then emit the matching tool_result and await its tool.complete.
   const runTool = async (id: string, name: string, input: unknown, result: unknown) => {
@@ -83,6 +87,7 @@ describe('GatewayClient NDJSON adapter', () => {
     await vi.waitFor(() => expect(last('tool.start')).toBeTruthy())
     proc.line(toolResult(id, result))
     await vi.waitFor(() => expect(last('tool.complete')).toBeTruthy())
+
     return last('tool.complete').payload
   }
 
@@ -145,17 +150,32 @@ describe('GatewayClient NDJSON adapter', () => {
     expect(p.result_text).toBe(stub)
   })
 
-  it('passes non-Read results through unchanged', async () => {
+  it('passes short Bash results through and caps long ones (CC parity)', async () => {
     const p = await runTool('t1', 'Bash', { command: 'echo hi' }, 'hi\n')
-    expect(p.result_text).toBe('hi\n')
+    expect(p.result_text).toBe('hi')
+
+    const long = await runTool('t2', 'Bash', { command: 'seq 9' }, '1\n2\n3\n4\n5\n6')
+    expect(long.result_text).toBe('1\n2\n3\n… +3 lines')
   })
 
-  it('keeps a failed Read result visible instead of collapsing it to a line count', async () => {
+  it('carries error on tool.complete for failed tools (drives the red ✗ path)', async () => {
+    proc.line(toolUse('t1', 'Bash', { command: 'false' }))
+    await vi.waitFor(() => expect(last('tool.start')).toBeTruthy())
+    proc.line(toolResult('t1', 'exit 1', true))
+    await vi.waitFor(() => expect(last('tool.complete')).toBeTruthy())
+
+    const p = last('tool.complete').payload
+    expect(p.error).toBe('Error: exit 1')
+    expect(p.result_text).toBe('Error: exit 1')
+  })
+
+  it('keeps a failed Read result visible (Error-prefixed), not collapsed to a line count', async () => {
     proc.line(toolUse('t1', 'Read', { file_path: '/ws/missing.ts' }))
     await vi.waitFor(() => expect(last('tool.start')).toBeTruthy())
     proc.line(toolResult('t1', 'File does not exist.', true))
     await vi.waitFor(() => expect(last('tool.complete')).toBeTruthy())
-    expect(last('tool.complete').payload.result_text).toBe('File does not exist.')
+    expect(last('tool.complete').payload.result_text).toBe('Error: File does not exist.')
+    expect(last('tool.complete').payload.error).toBe('Error: File does not exist.')
   })
 
   it('attaches an inline diff for Edit results', async () => {
@@ -170,6 +190,7 @@ describe('GatewayClient NDJSON adapter', () => {
   /** Requests the client wrote to the agent-server's stdin, parsed. */
   const stdinFrames = (): any[] => {
     const raw = (proc.stdin as any).read()?.toString() ?? ''
+
     return raw
       .split('\n')
       .filter(Boolean)
@@ -184,6 +205,7 @@ describe('GatewayClient NDJSON adapter', () => {
   beforeEach(() => {
     seen = []
   })
+
   const replyToControl = async (subtype: string, response: unknown) => {
     let req: any
     await vi.waitFor(() => {
@@ -315,6 +337,7 @@ describe('GatewayClient NDJSON adapter', () => {
 
   it('sends chosen_updates when the user picks "always"; none for "once"', async () => {
     const sent: any[] = []
+
     ;(gw as any).send = (m: any) => sent.push(m)
 
     proc.line({
@@ -338,6 +361,7 @@ describe('GatewayClient NDJSON adapter', () => {
     // The box lets the user widen the suggested rule (git status:* → git:*);
     // the edited value is carried as `rule` and must become the persisted rule.
     const sent: any[] = []
+
     ;(gw as any).send = (m: any) => sent.push(m)
     proc.line({
       request: {
@@ -359,6 +383,7 @@ describe('GatewayClient NDJSON adapter', () => {
     // (allow_permanent=true) and the suggestion must not be mangled into a
     // localSettings rule.
     const sent: any[] = []
+
     ;(gw as any).send = (m: any) => sent.push(m)
     const setModeSuggestion = { type: 'setMode', destination: 'session', mode: 'acceptEdits' }
     proc.line({

--- a/ui-tui/src/__tests__/text.test.ts
+++ b/ui-tui/src/__tests__/text.test.ts
@@ -29,12 +29,35 @@ describe('isToolTrailResultLine', () => {
 })
 
 describe('buildToolTrailLine', () => {
-  it('puts completion duration inline before the result marker', () => {
+  it('omits durations on the tool line (CC parity)', () => {
     const line = buildToolTrailLine('read_file', 'x', false, '', 0.94)
 
-    expect(line).toBe('Read File("x") (0.9s) ✓')
-    expect(parseToolTrailResultLine(line)).toEqual({ call: 'Read File("x") (0.9s)', detail: '', mark: '✓' })
-    expect(splitToolDuration('Read File("x") (0.9s)')).toEqual({ label: 'Read File("x")', duration: ' (0.9s)' })
+    expect(line).toBe('Read File(x) ✓')
+    expect(parseToolTrailResultLine(line)).toEqual({ call: 'Read File(x)', detail: '', mark: '✓' })
+    // legacy resumed-session lines still split cleanly
+    expect(splitToolDuration('Read File(x) (0.9s)')).toEqual({ label: 'Read File(x)', duration: ' (0.9s)' })
+  })
+
+  it('keeps multi-line details intact for the shelf', () => {
+    const line = buildToolTrailLine('Bash', 'ls', false, 'a\nb\nc')
+
+    expect(line).toBe('Bash(ls) :: a\nb\nc ✓')
+    expect(parseToolTrailResultLine(line)).toEqual({ call: 'Bash(ls)', detail: 'a\nb\nc', mark: '✓' })
+  })
+
+  it('caps runaway details at the safety limit', () => {
+    const big = Array.from({ length: 40 }, (_, i) => `l${i}`).join('\n')
+    const line = buildToolTrailLine('Bash', 'x', false, big)
+    const detail = parseToolTrailResultLine(line)!.detail
+
+    expect(detail.split('\n')).toHaveLength(13) // 12 + trailing …
+    expect(detail.endsWith('…')).toBe(true)
+  })
+
+  it('anchors the call/detail split so args containing :: cannot mis-split', () => {
+    const line = buildToolTrailLine('Bash', 'echo a :: b', false, 'out')
+
+    expect(parseToolTrailResultLine(line)).toEqual({ call: 'Bash(echo a :: b)', detail: 'out', mark: '✓' })
   })
 })
 
@@ -52,7 +75,7 @@ describe('buildVerboseToolTrailLine', () => {
     expect(line).toContain('Args:\n{')
     expect(line).toContain('Result:\nfirst line\nsecond :: line')
     expect(parseToolTrailResultLine(line)).toEqual({
-      call: 'Terminal("npm test") (1.3s)',
+      call: 'Terminal(npm test) (1.3s)',
       detail: 'Args:\n{\n  "cmd": "npm test"\n}\nResult:\nfirst line\nsecond :: line',
       mark: '✓'
     })
@@ -64,7 +87,7 @@ describe('buildVerboseToolTrailLine', () => {
     expect(line).toContain('Error:\ncommand failed')
     expect(line).not.toContain('Result:\ncommand failed')
     expect(parseToolTrailResultLine(line)).toEqual({
-      call: 'Terminal("npm test") (0.5s)',
+      call: 'Terminal(npm test) (0.5s)',
       detail: 'Error:\ncommand failed',
       mark: '✗'
     })

--- a/ui-tui/src/__tests__/theme.test.ts
+++ b/ui-tui/src/__tests__/theme.test.ts
@@ -48,11 +48,21 @@ describe('DEFAULT_THEME', () => {
     expect(DEFAULT_THEME.brand.tool).toBe('┊')
   })
 
-  it('has color palette', async () => {
+  it('has the original Claude Code dark palette', async () => {
     const { DEFAULT_THEME } = await importThemeWithCleanEnv()
 
-    expect(DEFAULT_THEME.color.primary).toBe('#FFD700')
-    expect(DEFAULT_THEME.color.error).toBe('#ef5350')
+    expect(DEFAULT_THEME.color.primary).toBe('#D77757') // claude orange
+    expect(DEFAULT_THEME.color.error).toBe('#FF6B80')
+    expect(DEFAULT_THEME.color.text).toBe('#FFFFFF')
+    expect(DEFAULT_THEME.color.muted).toBe('rgb(153,153,153)')
+    // original-CC tokens consumed by the ported surfaces
+    expect(DEFAULT_THEME.color.subtle).toBe('rgb(80,80,80)')
+    expect(DEFAULT_THEME.color.claudeShimmer).toBe('rgb(235,159,127)')
+    expect(DEFAULT_THEME.color.planMode).toBe('rgb(72,150,140)')
+    expect(DEFAULT_THEME.color.autoAccept).toBe('rgb(175,135,255)')
+    expect(DEFAULT_THEME.color.permission).toBe('rgb(177,185,249)')
+    expect(DEFAULT_THEME.color.bashBorder).toBe('rgb(253,93,177)')
+    expect(DEFAULT_THEME.color.promptBorder).toBe('rgb(136,136,136)')
   })
 })
 

--- a/ui-tui/src/__tests__/toolTranscript.test.ts
+++ b/ui-tui/src/__tests__/toolTranscript.test.ts
@@ -1,0 +1,173 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+import { renderSync } from '@clawcodex/ink'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+// gatewayClient spawns the agent-server on import-time side effects only when
+// instantiated; formatToolResult is a pure export, but mock spawn defensively.
+vi.mock('node:child_process', () => ({ spawn: () => new EventEmitter() }))
+
+// Styled-output assertions need a color-capable terminal profile — the
+// renderer snapshots support at module load, so hoist the env ahead of the
+// @clawcodex/ink import (PassThrough stdout has isTTY=false otherwise).
+vi.hoisted(() => {
+  process.env.FORCE_COLOR = '3'
+  process.env.COLORTERM = 'truecolor'
+  delete process.env.NO_COLOR
+})
+
+import { ToolTrail } from '../components/thinking.js'
+import { formatToolResult } from '../gatewayClient.js'
+import { buildToolTrailLine, stripAnsi } from '../lib/text.js'
+import { estimatedMsgHeight } from '../lib/virtualHeights.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+// ── formatToolResult: per-tool summaries (original CC transcript) ────────────
+
+describe('formatToolResult', () => {
+  it('summarizes Read results as a line count', () => {
+    expect(formatToolResult('Read', '1\tfoo\n2\tbar\n')).toBe('Read 2 lines')
+    expect(formatToolResult('Read', '1\tfoo\n')).toBe('Read 1 line')
+  })
+
+  it('summarizes Grep results as found-lines', () => {
+    expect(formatToolResult('Grep', 'a.ts:1: x\na.ts:9: y')).toBe('Found 2 lines')
+    expect(formatToolResult('Grep', 'No matches found')).toBe('Found 0 lines')
+  })
+
+  it('summarizes Glob results as found-files', () => {
+    expect(formatToolResult('Glob', '/ws/a.ts')).toBe('Found 1 file')
+  })
+
+  it('caps Bash output at 3 lines with an overflow hint', () => {
+    const out = formatToolResult('Bash', 'l1\nl2\nl3\nl4\nl5')
+
+    expect(out).toBe('l1\nl2\nl3\n… +2 lines')
+  })
+
+  it('shows the 4th Bash line instead of a one-line hint (CC parity)', () => {
+    expect(formatToolResult('Bash', 'l1\nl2\nl3\nl4')).toBe('l1\nl2\nl3\nl4')
+  })
+
+  it('renders empty Bash output as (No output)', () => {
+    expect(formatToolResult('Bash', '   \n')).toBe('(No output)')
+  })
+
+  it('prefixes errors and caps them at 10 lines', () => {
+    expect(formatToolResult('Bash', 'boom', true)).toBe('Error: boom')
+    expect(formatToolResult('Bash', 'Error: already prefixed', true)).toBe('Error: already prefixed')
+
+    const big = Array.from({ length: 14 }, (_, i) => `e${i}`).join('\n')
+    const out = formatToolResult('Bash', big, true)
+    const lines = out.split('\n')
+
+    expect(lines).toHaveLength(11)
+    expect(lines[0]).toBe('Error: e0')
+    expect(lines[10]).toBe('… +4 lines')
+  })
+})
+
+// ── virtualHeights: multi-line tool entries count rendered rows ──────────────
+
+describe('estimatedMsgHeight with multi-line tool details', () => {
+  it('counts one row per rendered detail line, not per entry', () => {
+    const base = {
+      kind: 'trail' as const,
+      role: 'system' as const,
+      text: '',
+      tools: [buildToolTrailLine('Bash', 'ls', false, 'a\nb\nc')]
+    }
+
+    const single = {
+      ...base,
+      tools: [buildToolTrailLine('Bash', 'ls', false, 'a')]
+    }
+
+    const opts = { compact: false, details: true, leadGap: false, withSeparator: false }
+    const tall = estimatedMsgHeight(base, 80, opts)
+    const short = estimatedMsgHeight(single, 80, opts)
+
+    expect(tall - short).toBe(2) // two extra detail rows
+  })
+})
+
+// ── ToolTrail render: CC anatomy ─────────────────────────────────────────────
+
+const renderToString = (element: React.ReactElement): string => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: 100, isTTY: false, rows: 40 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(element, {
+    patchConsole: false,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream
+  })
+
+  instance.unmount()
+  instance.cleanup()
+
+  return output
+}
+
+describe('ToolTrail rendering', () => {
+  it('renders a 3-line Bash result as three aligned rows under one connector', () => {
+    const line = buildToolTrailLine('Bash', 'ls src/', false, 'components\nlib\napp')
+
+    const output = renderToString(
+      React.createElement(ToolTrail, { detailsMode: 'expanded', t: DEFAULT_THEME, trail: [line] })
+    )
+
+    const rows = stripAnsi(output)
+      .split('\n')
+      .filter(r => r.trim().length > 0)
+
+    const bullet = rows.findIndex(r => r.includes('Bash(ls src/)'))
+
+    expect(bullet).toBeGreaterThanOrEqual(0)
+    expect(rows[bullet]).not.toMatch(/\(\d+(\.\d+)?s\)/) // no duration
+    expect(rows[bullet + 1]).toMatch(/⎿\s+components/)
+    // continuations align under the content column, no second connector
+    expect(rows[bullet + 2]).toMatch(/^\s{5,}lib/)
+    expect(rows[bullet + 2]).not.toContain('⎿')
+    expect(rows[bullet + 3]).toMatch(/^\s{5,}app/)
+  })
+
+  it('bolds the tool name and keeps args plain', () => {
+    const line = buildToolTrailLine('Bash', 'npm test', false, 'ok')
+
+    const output = renderToString(
+      React.createElement(ToolTrail, { detailsMode: 'expanded', t: DEFAULT_THEME, trail: [line] })
+    )
+
+    // bold SGR immediately around the name, not the args
+    // eslint-disable-next-line no-control-regex
+    expect(output).toMatch(/\x1b\[1m[^\x1b]*Bash/)
+    expect(stripAnsi(output)).toContain('Bash(npm test)')
+  })
+
+  it('marks failed tools with an error bullet while the name row stays plain', () => {
+    const line = buildToolTrailLine('Bash', 'false', true, 'Error: exit 1')
+
+    const output = renderToString(
+      React.createElement(ToolTrail, { detailsMode: 'expanded', t: DEFAULT_THEME, trail: [line] })
+    )
+
+    const plain = stripAnsi(output)
+
+    expect(plain).toContain('Error: exit 1')
+    // error red on the bullet: theme error #FF6B80 → 255;107;128
+    expect(output).toContain('255;107;128')
+  })
+})

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -367,7 +367,7 @@ class TurnController {
   // drains on the gateway's real settle edge (message.complete, suppressed
   // while `interrupted`) instead of racing the still-unwinding turn — the race
   // duplicated the user bubble, leaked a "queued: …" note, and surfaced the
-  // cancelled turn's "[interrupted]" reply.
+  // cancelled turn's "Interrupted · …" reply.
   interruptTurn({ appendMessage, gw, sid, sys }: InterruptDeps, opts: { keepBusy?: boolean } = {}) {
     this.interrupted = true
     gw.request<SessionInterruptResponse>('session.interrupt', { session_id: sid }).catch(() => {})
@@ -394,14 +394,18 @@ class TurnController {
     // `partial` or pending tools, fold them into a single assistant message;
     // otherwise emit a sys note so the transcript always records that the
     // turn was cancelled, even when only prior `segments` were preserved.
+    // CC parity string (InterruptedByUser.tsx): a dim one-liner that invites
+    // the redirect instead of a bare "[interrupted]" tag.
+    const interruptNote = 'Interrupted · What should clawcodex do instead?'
+
     if (partial || tools.length) {
       appendMessage({
         role: 'assistant',
-        text: partial ? `${partial}\n\n*[interrupted]*` : '*[interrupted]*',
+        text: partial ? `${partial}\n\n*${interruptNote}*` : `*${interruptNote}*`,
         ...(tools.length && { tools })
       })
     } else {
-      sys('interrupted')
+      sys(interruptNote)
     }
 
     this.clearStatusTimer()

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -669,6 +669,8 @@ interface Group {
   color: string
   content: ReactNode
   details: DetailRow[]
+  // Failed tool — paints the bullet error-red (name row stays text-colored).
+  error?: boolean
   key: string
   label: string
   // Live (still-running) tool — its content carries the spinner, so the flat
@@ -734,14 +736,16 @@ export const ToolTrail = memo(function ToolTrail({
   const [openMeta, setOpenMeta] = useState(visible.activity === 'expanded')
 
   useEffect(() => {
-    if (!tools.length || (visible.tools !== 'expanded' && !openTools)) {
+    // The running-tool bullet blinks on this clock, so it must tick whenever
+    // a live tool exists — not only while the tools panel is expanded.
+    if (!tools.length) {
       return
     }
 
     const id = setInterval(() => setNow(Date.now()), 500)
 
     return () => clearInterval(id)
-  }, [openTools, tools.length, visible.tools])
+  }, [tools.length])
 
   useEffect(() => {
     setOpenThinking(visible.thinking === 'expanded')
@@ -786,9 +790,12 @@ export const ToolTrail = memo(function ToolTrail({
 
     if (parsed) {
       groups.push({
-        color: parsed.mark === '✗' ? t.color.error : t.color.text,
+        // CC parity: the tool NAME row stays text-colored even on failure —
+        // the error shows on the bullet and the result rows.
+        color: t.color.text,
         content: parsed.call,
         details: [],
+        error: parsed.mark === '✗',
         key: `tr-${i}`,
         label: parsed.call
       })
@@ -847,14 +854,10 @@ export const ToolTrail = memo(function ToolTrail({
       key: tool.id,
       label,
       live: true,
-      // Flat Claude render: args live in the label (Bash(ls)), so no Args row.
-      details: [],
-      content: (
-        <>
-          <Spinner color={t.color.accent} variant="tool" /> {label}
-          {tool.startedAt ? ` (${fmtElapsed(now - tool.startedAt)})` : ''}
-        </>
-      )
+      // CC parity: a running tool shows a dim "Running…" result row; the
+      // bullet itself blinks (rendered in the flat pass below).
+      details: [{ color: t.color.muted, content: 'Running…', dimColor: true, key: `${tool.id}-run` }],
+      content: label
     })
   }
 
@@ -886,17 +889,25 @@ export const ToolTrail = memo(function ToolTrail({
   const inlineDelegateKey = hasSubagents && delegateGroups.length === 1 ? delegateGroups[0]!.key : null
 
   const toolLabel = (group: Group) => {
-    const { duration, label } = splitToolDuration(String(group.content))
+    // CC parity: bold tool name, plain (args). Durations are no longer
+    // emitted on trail lines; strip any legacy `(N.Ns)` from resumed
+    // sessions via splitToolDuration.
+    if (typeof group.content !== 'string') {
+      return group.content
+    }
 
-    return duration ? (
+    const { label } = splitToolDuration(group.content)
+    const paren = label.indexOf('(')
+
+    if (paren <= 0) {
+      return <Text bold>{label}</Text>
+    }
+
+    return (
       <>
-        {label}
-        <Text color={t.color.statusFg} dim>
-          {duration}
-        </Text>
+        <Text bold>{label.slice(0, paren)}</Text>
+        {label.slice(paren)}
       </>
-    ) : (
-      group.content
     )
   }
 
@@ -995,16 +1006,9 @@ export const ToolTrail = memo(function ToolTrail({
           }}
         >
           <Text color={t.color.muted} dim={!thinkingLive}>
-            <Text color={t.color.accent}>{openThinking ? '▾ ' : '▸ '}</Text>
-            {thinkingLive ? (
-              <Text bold color={t.color.text}>
-                Thinking
-              </Text>
-            ) : (
-              <Text color={t.color.muted} dim>
-                Thinking
-              </Text>
-            )}
+            <Text color={t.color.muted} dim italic>
+              {'∴ Thinking…'}
+            </Text>
             {thinkingTokensLabel ? (
               <Text color={t.color.statusFg} dim>
                 {'  '}
@@ -1033,17 +1037,28 @@ export const ToolTrail = memo(function ToolTrail({
   // Claude Code flat tool render: each call as `⏺ Tool(args)` with its result
   // indented under `⎿` — no collapsible "Tool calls" wrapper, tree rails, or
   // token tally. Live (running) tools keep their spinner bullet (group.live).
+  // CC blink cadence for a running tool's bullet: the shared 500ms ticker
+  // alternates glyph/space (original useBlink is 600ms — same read).
+  const blinkOn = Math.floor(now / 500) % 2 === 0
+
   const toolsFlat =
     hasTools && visible.tools !== 'hidden' ? (
       <Box flexDirection="column">
         {groups.map(group => {
           const isDelegateGroup = group.label.startsWith('Delegate Task')
-          const bulletColor = group.color === t.color.error ? t.color.error : t.color.ok
+          const bulletColor = group.error ? t.color.error : t.color.ok
 
           return (
             <Box flexDirection="column" key={group.key}>
               <Text color={group.color}>
-                {group.live ? null : <Text color={bulletColor}>⏺ </Text>}
+                {group.live ? (
+                  // Running: dim blinking ⏺ — the off-frame renders two
+                  // spaces matching the glyph+space width so the row never
+                  // reflows mid-blink.
+                  <Text dimColor>{blinkOn ? '⏺ ' : '  '}</Text>
+                ) : (
+                  <Text color={bulletColor}>⏺ </Text>
+                )}
                 {toolLabel(group)}
                 {isDelegateGroup ? (
                   <Text color={t.color.statusFg} dim>
@@ -1051,13 +1066,34 @@ export const ToolTrail = memo(function ToolTrail({
                   </Text>
                 ) : null}
               </Text>
-              {group.details.map(detail => (
-                <Text color={detail.color} dimColor={detail.dimColor} key={detail.key}>
-                  {'  '}
-                  <Text color={t.color.muted}>⎿  </Text>
-                  {detail.content}
-                </Text>
-              ))}
+              {group.details.map(detail => {
+                // Multi-line details (Bash 3-line summaries, error caps):
+                // first row carries the ⎿ connector, continuations align
+                // under the content column.
+                if (typeof detail.content === 'string' && detail.content.includes('\n')) {
+                  return detail.content.split('\n').map((row, rowIdx) => (
+                    <Text color={detail.color} dimColor={detail.dimColor} key={`${detail.key}-${rowIdx}`}>
+                      {rowIdx === 0 ? (
+                        <>
+                          {'  '}
+                          <Text color={t.color.muted}>⎿  </Text>
+                        </>
+                      ) : (
+                        '     '
+                      )}
+                      {row || ' '}
+                    </Text>
+                  ))
+                }
+
+                return (
+                  <Text color={detail.color} dimColor={detail.dimColor} key={detail.key}>
+                    {'  '}
+                    <Text color={t.color.muted}>⎿  </Text>
+                    {detail.content}
+                  </Text>
+                )
+              })}
               {inlineDelegateKey === group.key ? renderSubagentList([]) : null}
             </Box>
           )

--- a/ui-tui/src/domain/roles.ts
+++ b/ui-tui/src/domain/roles.ts
@@ -1,11 +1,13 @@
 import type { Theme } from '../theme.js'
 import type { Role } from '../types.js'
 
-// Claude Code glyphs: › user, ⏺ assistant/tool bullet, · system. The orange ⏺
-// marks the assistant; a green ⏺ marks a tool call (Claude's status coloring).
+// Original Claude Code glyphs/colors (messages/*.tsx): assistant prose gets a
+// plain text-white ⏺ (AssistantTextMessage), the user echo is a near-invisible
+// `❯` in `subtle` with white text (HighlightedThinkingText figures.pointer +
+// pointerColor "subtle"), tools keep the green ⏺ result coloring.
 export const ROLE: Record<Role, (t: Theme) => { body: string; glyph: string; prefix: string }> = {
-  assistant: t => ({ body: t.color.text, glyph: '⏺', prefix: t.color.accent }),
+  assistant: t => ({ body: t.color.text, glyph: '⏺', prefix: t.color.text }),
   system: t => ({ body: '', glyph: '·', prefix: t.color.muted }),
   tool: t => ({ body: t.color.muted, glyph: '⏺', prefix: t.color.ok }),
-  user: t => ({ body: t.color.label, glyph: '›', prefix: t.color.muted })
+  user: t => ({ body: t.color.text, glyph: '❯', prefix: t.color.subtle })
 }

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -108,13 +108,72 @@ function relativizePath(p: string): string {
  *  genuine numbered output is collapsed — errors (is_error) and Read's other
  *  acknowledgements (empty-file / file_unchanged warnings, PDF/image stubs)
  *  aren't `N\t…` text and pass through, so nothing is mislabeled or hidden. */
-function formatToolResult(name: string | undefined, result: string, isError = false): string {
-  if (!result || isError) {return result}
+// Per-tool result summaries, matching the original Claude Code transcript
+// (tools/*/UI.tsx): Read → "Read N lines", Grep/Glob → "Found N …", Bash →
+// first 3 stdout lines + overflow hint, errors → red "Error: …" capped at 10
+// lines. No "(… to expand)" hints: this TUI has no expand binding and the
+// raw result is not retained client-side — promising one would lie. A real
+// expand affordance (raw retention + binding) is a documented follow-up.
+const ERROR_RESULT_MAX_LINES = 10
+const BASH_RESULT_MAX_LINES = 3
 
-  if (name === 'Read' && /^\s*\d+\t/.test(result)) {
+export function formatToolResult(name: string | undefined, result: string, isError = false): string {
+  if (isError) {
+    let msg = (result ?? '').trim() || 'Tool execution failed'
+
+    if (!/^(Error|Cancelled): /.test(msg)) {
+      msg = `Error: ${msg}`
+    }
+
+    const lines = msg.split('\n')
+
+    if (lines.length > ERROR_RESULT_MAX_LINES) {
+      return [
+        ...lines.slice(0, ERROR_RESULT_MAX_LINES),
+        `… +${lines.length - ERROR_RESULT_MAX_LINES} lines`
+      ].join('\n')
+    }
+
+    return msg
+  }
+
+  if (!result) {return result}
+
+  if (name === 'Read' && /^\s*\d+[\t→ ]/.test(result)) {
     const n = result.split('\n').filter(l => l.length > 0).length
 
     return `Read ${n} line${n === 1 ? '' : 's'}`
+  }
+
+  if (name === 'Grep' || name === 'Glob') {
+    if (/^No (files|matches|content)/i.test(result.trim())) {
+      return `Found 0 ${name === 'Glob' ? 'files' : 'lines'}`
+    }
+
+    const n = result.split('\n').filter(l => l.length > 0).length
+    const noun = name === 'Glob' ? (n === 1 ? 'file' : 'files') : n === 1 ? 'line' : 'lines'
+
+    return `Found ${n} ${noun}`
+  }
+
+  if (name === 'Bash') {
+    const trimmed = result.replace(/\s+$/, '')
+
+    if (!trimmed) {
+      return '(No output)'
+    }
+
+    const lines = trimmed.split('\n')
+
+    // CC parity: when exactly one line overflows, show it instead of a hint.
+    if (lines.length <= BASH_RESULT_MAX_LINES + 1) {
+      return trimmed
+    }
+
+    return [
+      ...lines.slice(0, BASH_RESULT_MAX_LINES),
+      `… +${lines.length - BASH_RESULT_MAX_LINES} lines`
+    ].join('\n')
   }
 
   return result
@@ -867,16 +926,20 @@ export class GatewayClient extends EventEmitter {
               // A failed edit must not render a diff at all — neither the
               // real patch nor a fabricated one for an edit that never ran.
               const isError = Boolean(b.is_error)
+              const resultText = formatToolResult(
+                stored?.name,
+                typeof b.content === 'string' ? b.content : safeJson(b.content),
+                isError
+              )
               this.publish({
                 payload: {
+                  // error drives the ✗ mark (red bullet + red result rows);
+                  // without it a real failure renders as a green success.
+                  error: isError ? resultText : undefined,
                   inline_diff:
                     isError || structured || !stored ? undefined : this.editDiff(stored.name, stored.input),
                   name: stored?.name,
-                  result_text: formatToolResult(
-                    stored?.name,
-                    typeof b.content === 'string' ? b.content : safeJson(b.content),
-                    isError
-                  ),
+                  result_text: resultText,
                   structured_diff: isError ? undefined : structured,
                   tool_id: b.tool_use_id
                 },

--- a/ui-tui/src/lib/text.ts
+++ b/ui-tui/src/lib/text.ts
@@ -202,17 +202,32 @@ export const formatToolCall = (name: string, context = '') => {
   return preview ? `${label}(${preview})` : label
 }
 
+// Hard safety cap on shelf details — per-tool formatting upstream already
+// trims to CC's limits (Bash 3 + hint, errors 10 + hint); this only guards a
+// runaway caller from ballooning the render tree.
+const TRAIL_DETAIL_MAX_LINES = 12
+
 export const buildToolTrailLine = (
   name: string,
   context: string,
   error?: boolean,
   note?: string,
-  duration?: number
+  // Kept for call-site compatibility; the original Claude Code transcript
+  // never shows durations on the tool line, so neither do we (verbose rows
+  // still carry them via buildVerboseToolTrailLine).
+  _duration?: number
 ) => {
-  const detail = compactPreview(note ?? '', 72)
-  const took = duration !== undefined ? ` (${duration.toFixed(1)}s)` : ''
+  const raw = (note ?? '').trim()
+  const lines = raw.split('\n')
 
-  return `${formatToolCall(name, context)}${took}${detail ? ` :: ${detail}` : ''} ${error ? '✗' : '✓'}`
+  const detail = (lines.length > TRAIL_DETAIL_MAX_LINES
+    ? [...lines.slice(0, TRAIL_DETAIL_MAX_LINES), '…']
+    : lines
+  )
+    .join('\n')
+    .trim()
+
+  return `${formatToolCall(name, context)}${detail ? ` :: ${detail}` : ''} ${error ? '✗' : '✓'}`
 }
 
 const verboseToolBlock = (label: string, text?: string) => {
@@ -256,7 +271,12 @@ export const parseToolTrailResultLine = (line: string) => {
 
   const mark = line.endsWith(' ✗') ? '✗' : '✓'
   const body = line.slice(0, -2)
-  const sep = body.indexOf(' :: ')
+  // The call part is always single-line (`Label(args…)` with compacted args);
+  // details may span lines. Prefer the `) :: ` boundary so a command that
+  // itself contains ` :: ` can't mis-split; otherwise search the first line.
+  const parenSep = body.indexOf(') :: ')
+  const firstLine = body.indexOf('\n') === -1 ? body : body.slice(0, body.indexOf('\n'))
+  const sep = parenSep >= 0 ? parenSep + 1 : firstLine.indexOf(' :: ')
 
   if (sep >= 0) {
     return { call: body.slice(0, sep), detail: body.slice(sep + 4), mark }

--- a/ui-tui/src/lib/virtualHeights.ts
+++ b/ui-tui/src/lib/virtualHeights.ts
@@ -122,9 +122,14 @@ export const estimatedMsgHeight = (
     const hasVisibleDetails = hasVisibleTools || hasVisibleThinking
 
     if (hasVisibleDetails) {
-      h +=
-        (hasVisibleTools ? (msg.tools?.length ?? 0) : 0) +
-        (hasVisibleThinking ? wrappedLines(msg.thinking ?? '', bodyWidth) : 0)
+      // Tool entries can carry multi-line details (Bash 3-line summaries,
+      // 10-line error caps) — count rendered rows, not entries, or off-screen
+      // estimates under-count and the scrollbar/topSpacer math jumps.
+      const toolRows = hasVisibleTools
+        ? (msg.tools ?? []).reduce((sum, line) => sum + line.split('\n').length, 0)
+        : 0
+
+      h += toolRows + (hasVisibleThinking ? wrappedLines(msg.thinking ?? '', bodyWidth) : 0)
 
       if (msg.role === 'assistant' && /\S/.test(msg.text)) {
         h += 2

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -26,6 +26,16 @@ export interface ThemeColors {
   statusCritical: string
   selectionBg: string
 
+  // Original Claude Code tokens (utils/theme.ts) consumed by the ported
+  // surfaces: busy-line shimmer, composer rules, permission-mode badges.
+  claudeShimmer: string
+  subtle: string
+  planMode: string
+  autoAccept: string
+  permission: string
+  bashBorder: string
+  promptBorder: string
+
   diffAdded: string
   diffRemoved: string
   diffAddedWord: string
@@ -261,8 +271,8 @@ export const DARK_THEME: Theme = {
     primary: '#D77757',
     accent: '#D77757',
     border: '#505050',
-    text: '#E6E6E6',
-    muted: '#BBBBBB',
+    text: '#FFFFFF',
+    muted: 'rgb(153,153,153)',
     completionBg: '#1f1f1f',
     completionCurrentBg: '#383838',
     completionMetaBg: '#1f1f1f',
@@ -274,7 +284,7 @@ export const DARK_THEME: Theme = {
     warn: '#FFC107',
 
     prompt: '#E6E6E6',
-    sessionLabel: '#BBBBBB',
+    sessionLabel: 'rgb(153,153,153)',
     sessionBorder: '#505050',
 
     statusBg: '#1a1a1a',
@@ -284,6 +294,14 @@ export const DARK_THEME: Theme = {
     statusBad: '#FF8C5A',
     statusCritical: '#FF6B80',
     selectionBg: '#373737',
+
+    claudeShimmer: 'rgb(235,159,127)',
+    subtle: 'rgb(80,80,80)',
+    planMode: 'rgb(72,150,140)',
+    autoAccept: 'rgb(175,135,255)',
+    permission: 'rgb(177,185,249)',
+    bashBorder: 'rgb(253,93,177)',
+    promptBorder: 'rgb(136,136,136)',
 
     // Original Claude Code dark-theme diff tokens (utils/theme.ts darkTheme):
     // dark green/red backgrounds, brighter word-level highlights.
@@ -309,7 +327,7 @@ export const LIGHT_THEME: Theme = {
     primary: '#D77757',
     accent: '#D77757',
     border: '#AFAFAF',
-    text: '#2B2B2B',
+    text: '#000000',
     muted: '#666666',
     completionBg: '#F5F5F5',
     completionCurrentBg: mix('#F5F5F5', '#D77757', 0.25),
@@ -332,6 +350,14 @@ export const LIGHT_THEME: Theme = {
     statusBad: '#C25A3A',
     statusCritical: '#AB2B3F',
     selectionBg: '#E0E0E0',
+
+    claudeShimmer: 'rgb(245,149,117)',
+    subtle: 'rgb(175,175,175)',
+    planMode: 'rgb(0,102,102)',
+    autoAccept: 'rgb(135,0,255)',
+    permission: 'rgb(87,105,247)',
+    bashBorder: 'rgb(255,0,135)',
+    promptBorder: 'rgb(153,153,153)',
 
     // Original Claude Code light-theme diff tokens (utils/theme.ts lightTheme).
     diffAdded: 'rgb(105,219,124)',
@@ -613,8 +639,8 @@ export function fromSkin(
         warn: c('ui_warn') ?? d.color.warn,
 
         prompt: c('prompt') ?? c('banner_text') ?? d.color.prompt,
-        sessionLabel: c('session_label') ?? muted,
-        sessionBorder: c('session_border') ?? muted,
+        sessionLabel: c('session_label') ?? (hasSkinColors ? muted : d.color.sessionLabel),
+        sessionBorder: c('session_border') ?? (hasSkinColors ? muted : d.color.sessionBorder),
 
         statusBg: d.color.statusBg,
         statusFg: d.color.statusFg,
@@ -626,6 +652,14 @@ export function fromSkin(
           c('selection_bg') ??
           c('completion_menu_current_bg') ??
           (hasSkinColors ? completionCurrentBg : d.color.selectionBg),
+
+        claudeShimmer: d.color.claudeShimmer,
+        subtle: d.color.subtle,
+        planMode: d.color.planMode,
+        autoAccept: d.color.autoAccept,
+        permission: d.color.permission,
+        bashBorder: d.color.bashBorder,
+        promptBorder: d.color.promptBorder,
 
         diffAdded: d.color.diffAdded,
         diffRemoved: d.color.diffRemoved,


### PR DESCRIPTION
Port the original Claude Code transcript anatomy for tool calls
(typescript/ source, specs extracted per component):

- Tool line: BOLD name + plain (args); durations dropped (the original
  never shows them; verbose rows keep theirs). Running tools show a dim
  BLINKING ⏺ (500ms ticker, now gated only on live-tool presence) with a
  dim 'Running…' result row — replacing the braille spinner + live
  elapsed. Failed tools: error-red bullet, name row stays text-colored.
- Results: per-tool summaries matching tools/*/UI.tsx — Read → 'Read N
  lines', Grep/Glob → 'Found N lines/files (ctrl+r to expand)', Bash →
  first 3 stdout lines + '… +N lines (ctrl+r to expand)' (4th line shown
  instead of a one-line hint), empty → '(No output)'; errors 'Error: '-
  prefixed, red, capped at 10 lines + '… (ctrl+r to see all)'. Hints name
  OUR real binding.
- Multi-line details complete across all four protocol consumers:
  build (\n kept, 12-line safety cap), parse (call/detail split anchored
  at ') :: ' with first-line fallback so args containing :: can't
  mis-split), render (first row ⎿, continuations aligned, no second
  connector), heights (virtualHeights counts rendered rows per entry —
  entries used to count 1 row and under-estimated scroll math).
- Prose/echo/thinking: assistant ⏺ in text-white (was accent), user echo
  '❯ ' in subtle + white text (figures.pointer + pointerColor), thinking
  header '∴ Thinking…' dim italic, interrupt line 'Interrupted · What
  should clawcodex do instead?'.
- Theme: dark text #FFFFFF, muted rgb(153,153,153) (original values);
  new tokens subtle/claudeShimmer/planMode/autoAccept/permission/
  bashBorder/promptBorder (dark+light, permission uses the DARK value
  rgb(177,185,249)); fromSkin carries them and no longer leaks the
  muted cascade into session tokens for skinless sessions.

Tests: 11-case toolTranscript suite (per-tool formatting, multiline
parse/render/heights, bold-name + error-bullet SGR assertions with
hoisted color env); stale baseline pins rewritten and now green
(text.test quoting+duration, theme.test palette) — full suite baseline
14 → 9 pre-existing failures, 0 new. Pyte gallery re-shot: tools
scenario shows the exact CC anatomy.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Part A of the 4-PR look-and-feel port (plan critic-approved; per-surface pyte before/after in the final report). Post-review fixes: dropped the '(ctrl+r to …)' hints (no expand binding exists and raw results aren't retained — real affordance is a follow-up) and wired is_error → payload.error so failed tools get the red ✗ path end-to-end (production-path test added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)