### PR TITLE
feat(tui): original-CC busy line + CC-clean idle chrome (look&feel D)

### DIFF
--- a/ui-tui/src/__tests__/busyLine.test.ts
+++ b/ui-tui/src/__tests__/busyLine.test.ts
@@ -1,0 +1,121 @@
+import { PassThrough } from 'node:stream'
+
+import { renderSync } from '@clawcodex/ink'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.hoisted(() => {
+  process.env.FORCE_COLOR = '3'
+  process.env.COLORTERM = 'truecolor'
+  delete process.env.NO_COLOR
+})
+
+import { patchTurnState, resetTurnState } from '../app/turnStore.js'
+import { patchUiState } from '../app/uiStore.js'
+import { BusyLine } from '../components/busyLine.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+const renderToString = (element: React.ReactElement): string => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: 100, isTTY: false, rows: 30 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(element, {
+    patchConsole: false,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream
+  })
+
+  instance.unmount()
+  instance.cleanup()
+
+  return output
+}
+
+const busyRender = (turnStartedAt: number) => {
+  patchUiState({ busy: true })
+
+  return renderToString(React.createElement(BusyLine, { t: DEFAULT_THEME, turnStartedAt }))
+}
+
+describe('BusyLine', () => {
+  it('renders nothing when idle (no persistent chrome)', () => {
+    resetTurnState()
+    patchUiState({ busy: false })
+
+    const plain = stripAnsi(renderToString(React.createElement(BusyLine, { t: DEFAULT_THEME, turnStartedAt: null })))
+
+    expect(plain.trim()).toBe('')
+  })
+
+  it('shows the in-progress todo activeForm as the verb and the pending todo as Next', () => {
+    resetTurnState()
+    patchTurnState({
+      lastDeltaAt: Date.now(),
+      todos: [
+        { activeForm: 'Extracting the loader', content: 'Extract loader', id: '1', status: 'in_progress' },
+        { content: 'Add unit tests', id: '2', status: 'pending' }
+      ]
+    })
+
+    const plain = stripAnsi(busyRender(Date.now()))
+
+    expect(plain).toContain('Extracting the loader…')
+    expect(plain).toContain('Next: Add unit tests')
+    // under 30s: no elapsed/token suffix
+    expect(plain).not.toContain('tokens')
+  })
+
+  it('adds the dim elapsed + ~token suffix only after 30s', () => {
+    resetTurnState()
+    patchTurnState({ lastDeltaAt: Date.now(), streamedChars: 4800 })
+
+    const plain = stripAnsi(busyRender(Date.now() - 45_000))
+
+    expect(plain).toMatch(/\(45s · ↓ ~1\.2k tokens\)/)
+  })
+
+  it('cuts glyph+verb to the stall red after 3s without deltas', () => {
+    resetTurnState()
+    patchTurnState({ lastDeltaAt: Date.now() - 10_000, tools: [] })
+
+    const output = busyRender(Date.now())
+
+    expect(output).toContain('171;43;63')
+  })
+
+  it('does not false-stall between tools (tool lifecycle counts as liveness)', () => {
+    resetTurnState()
+    // Simulate the inter-tool gap: last stamp recent because a tool just
+    // completed, no text deltas at all this turn.
+    patchTurnState({ lastDeltaAt: Date.now() - 1_000, streamedChars: 0, tools: [] })
+
+    const output = busyRender(Date.now() - 10_000)
+
+    expect(output).not.toContain('171;43;63')
+  })
+
+  it('shows the delegation segment only while fanning out', () => {
+    resetTurnState()
+    patchTurnState({
+      lastDeltaAt: Date.now(),
+      subagents: [
+        { depth: 1, goal: 'explore', id: 'sa1', status: 'running' } as never
+      ]
+    })
+
+    const plain = stripAnsi(busyRender(Date.now()))
+
+    expect(plain).toContain('⛓')
+  })
+})

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -64,7 +64,7 @@ describe('applyDisplay', () => {
     expect(setBell).toHaveBeenCalledWith(false)
     expect(s.inlineDiffs).toBe(true)
     expect(s.showReasoning).toBe(false)
-    expect(s.statusBar).toBe('top')
+    expect(s.statusBar).toBe('off')
     expect(s.streaming).toBe(true)
     expect(s.sections).toEqual({})
   })
@@ -176,11 +176,11 @@ describe('normalizeStatusBar', () => {
     expect(normalizeStatusBar('bottom')).toBe('bottom')
   })
 
-  it('defaults missing/unknown values to top', () => {
-    expect(normalizeStatusBar(undefined)).toBe('top')
-    expect(normalizeStatusBar(null)).toBe('top')
-    expect(normalizeStatusBar('sideways')).toBe('top')
-    expect(normalizeStatusBar(42)).toBe('top')
+  it('defaults missing/unknown values to off (CC-clean chrome)', () => {
+    expect(normalizeStatusBar(undefined)).toBe('off')
+    expect(normalizeStatusBar(null)).toBe('off')
+    expect(normalizeStatusBar('sideways')).toBe('off')
+    expect(normalizeStatusBar(42)).toBe('off')
   })
 
   it('trims whitespace and folds case', () => {

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -778,6 +778,11 @@ class TurnController {
     // — visible as overlapping coloured text and lost prose under
     // `display.final_response_markdown: render`.
     this.bufRef += text
+    patchTurnState(state => ({
+      ...state,
+      lastDeltaAt: Date.now(),
+      streamedChars: state.streamedChars + text.length
+    }))
 
     if (getUiState().streaming) {
       this.scheduleStreaming()
@@ -813,6 +818,11 @@ class TurnController {
 
     this.reasoningText += text
     this.activeReasoningText += text
+    patchTurnState(state => ({
+      ...state,
+      lastDeltaAt: Date.now(),
+      streamedChars: state.streamedChars + text.length
+    }))
 
     if (this.reasoningText.length > 80_000) {
       this.reasoningText = this.reasoningText.slice(-60_000)
@@ -837,6 +847,7 @@ class TurnController {
     }
 
     this.recordTodos(todos)
+    patchTurnState({ lastDeltaAt: Date.now() })
     const name = this.activeTools.find(tool => tool.id === toolId)?.name ?? fallbackName
     const line = this.completeTool(toolId, fallbackName, error, summary, duration, resultText)
 
@@ -964,6 +975,10 @@ class TurnController {
   }
 
   recordToolStart(toolId: string, name: string, context: string, verboseArgs?: string) {
+    // Tool activity is liveness for the busy line's stall detector — a
+    // tool-only turn produces no text deltas for long stretches.
+    patchTurnState({ lastDeltaAt: Date.now() })
+
     if (this.interrupted) {
       return
     }
@@ -1066,7 +1081,16 @@ class TurnController {
     }
 
     patchUiState({ busy: true })
-    patchTurnState({ activity: [], outcome: '', subagents: [], toolTokens: 0, tools: [], turnTrail: [] })
+    patchTurnState({
+      activity: [],
+      lastDeltaAt: Date.now(),
+      outcome: '',
+      streamedChars: 0,
+      subagents: [],
+      toolTokens: 0,
+      tools: [],
+      turnTrail: []
+    })
   }
 
   upsertSubagent(

--- a/ui-tui/src/app/turnStore.ts
+++ b/ui-tui/src/app/turnStore.ts
@@ -6,6 +6,8 @@ import type { ActiveTool, ActivityItem, Msg, SubagentProgress, TodoItem } from '
 
 const buildTurnState = (): TurnState => ({
   activity: [],
+  lastDeltaAt: null,
+  streamedChars: 0,
   outcome: '',
   reasoning: '',
   reasoningActive: false,
@@ -68,6 +70,10 @@ export const resetTurnState = () => $turnState.set(buildTurnState())
 
 export interface TurnState {
   activity: ActivityItem[]
+  // Busy-line telemetry: total streamed response chars this turn (token
+  // estimate = chars/4) and the last delta timestamp (stall detection).
+  lastDeltaAt: null | number
+  streamedChars: number
   outcome: string
   reasoning: string
   reasoningActive: boolean

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -27,7 +27,7 @@ const buildUiState = (): UiState => ({
   showReasoning: false,
   sid: null,
   status: 'starting clawcodex…',
-  statusBar: 'top',
+  statusBar: 'off',
   streaming: true,
   theme: DEFAULT_THEME,
   usage: ZERO

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -24,8 +24,16 @@ const STATUSBAR_ALIAS: Record<string, StatusBarMode> = {
   top: 'top'
 }
 
+// Unset defaults to 'off' — CC-clean chrome (the original has no persistent
+// status bar; set tui_statusbar: top|bottom to restore the legacy rule).
 export const normalizeStatusBar = (raw: unknown): StatusBarMode =>
-  raw === false ? 'off' : typeof raw === 'string' ? (STATUSBAR_ALIAS[raw.trim().toLowerCase()] ?? 'top') : 'top'
+  raw === false
+    ? 'off'
+    : raw === true
+      ? 'top'
+      : typeof raw === 'string'
+        ? (STATUSBAR_ALIAS[raw.trim().toLowerCase()] ?? 'off')
+        : 'off'
 
 const BUSY_MODES = new Set<BusyInputMode>(['interrupt', 'queue', 'steer'])
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -18,11 +18,13 @@ import {
 } from '../lib/inputMetrics.js'
 import { PerfPane } from '../lib/perfPane.js'
 import { composerPromptText } from '../lib/prompt.js'
+import type { Theme } from '../theme.js'
 
 import { AgentsOverlay } from './agentsOverlay.js'
 import { GoodVibesHeart, StatusRule, StickyPromptTracker, TranscriptScrollbar } from './appChrome.js'
 import { FloatingOverlays, PromptZone } from './appOverlays.js'
 import { Banner, Panel, SessionPanel } from './branding.js'
+import { BusyLine } from './busyLine.js'
 import { ComposerFooter } from './composerFooter.js'
 import { FpsOverlay } from './fpsOverlay.js'
 import { HelpHint } from './helpHint.js'
@@ -273,6 +275,13 @@ const ComposerPane = memo(function ComposerPane({
 
       <StatusRulePane at="top" composer={composer} status={status} />
 
+      {ui.statusBar === 'off' && (
+        <>
+          <IdleChromeNotes t={ui.theme} />
+          <BusyLine t={ui.theme} turnStartedAt={status.turnStartedAt} />
+        </>
+      )}
+
       <LiveTodoPanel />
 
       <Box
@@ -374,6 +383,42 @@ const ComposerPane = memo(function ComposerPane({
 
       <StatusRulePane at="bottom" composer={composer} status={status} />
     </NoSelect>
+  )
+})
+
+// Idle-only signals that previously lived on the StatusRule: a live credits/
+// status notice, and the parked-background reassurance while a top-level
+// delegate keeps running after the turn ended. Rendered only when the bar is
+// off (its 'top'/'bottom' modes still own them).
+const IdleChromeNotes = memo(function IdleChromeNotes({ t }: { t: Theme }) {
+  const ui = useStore($uiState)
+
+  if (ui.busy) {
+    return null
+  }
+
+  // usage.active_subagents persists past turn end (turnState.subagents is
+  // cleared by idle()) — it's the same source the StatusRule used.
+  const running = typeof ui.usage?.active_subagents === 'number' ? ui.usage.active_subagents : 0
+  const notice = ui.notice?.text
+
+  if (!notice && running === 0) {
+    return null
+  }
+
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      {notice ? (
+        <Text color={t.color.muted} wrap="truncate-end">
+          {notice}
+        </Text>
+      ) : null}
+      {running > 0 ? (
+        <Text color={t.color.muted} dim>
+          {running === 1 ? '↩ resumes when subagent finishes' : `↩ resumes when ${running} subagents finish`}
+        </Text>
+      ) : null}
+    </Box>
   )
 })
 

--- a/ui-tui/src/components/busyLine.tsx
+++ b/ui-tui/src/components/busyLine.tsx
@@ -1,0 +1,173 @@
+/**
+ * The original Claude Code busy line (Spinner.tsx / SpinnerAnimationRow.tsx),
+ * rendered directly above the composer when the opt-in status bar is off:
+ *
+ *   ✻ Extracting the loader… (1m 3s · ↓ ~1.2k tokens · thinking…)
+ *   Next: Add unit tests for env overrides
+ *
+ * - Star ping-pong glyph `· ✢ ✳ ✶ ✻ ✽ ✽ ✻ ✶ ✳ ✢ ·` @120ms in claude orange.
+ * - Verb = in-progress todo's activeForm ?? subject ?? a per-turn pick from
+ *   the brand VERBS list, with a 3-column claudeShimmer band sweeping
+ *   right→left @200ms (GlimmerMessage).
+ * - Dim parenthetical appears only after 30s (SHOW_TOKENS_AFTER_MS): elapsed
+ *   and `↓ ~N tokens` (chars/4 — an estimate, hence the ~). `thinking…`
+ *   rides along while reasoning streams.
+ * - Stall: >3s without any delta (and no running tools) cuts glyph+verb to
+ *   the original's hardcoded rgb(171,43,63).
+ * - Right-aligned dim delegation segment (depth/⚡/⛓) only during fan-out —
+ *   deliberate delta from the original's bare row (that signal is
+ *   load-bearing here).
+ */
+import { Box, stringWidth, Text } from '@clawcodex/ink'
+import { useStore } from '@nanostores/react'
+import { memo, useEffect, useMemo, useState } from 'react'
+
+import { $delegationState } from '../app/delegationStore.js'
+import { useTurnSelector } from '../app/turnStore.js'
+import { $uiState } from '../app/uiStore.js'
+import { VERBS } from '../content/verbs.js'
+import { fmtDuration } from '../domain/messages.js'
+import { buildSubagentTree, treeTotals } from '../lib/subagentTree.js'
+import { fmtK } from '../lib/text.js'
+import type { Theme } from '../theme.js'
+
+const STAR_FRAMES = ['·', '✢', '✳', '✶', '✻', '✽', '✽', '✻', '✶', '✳', '✢', '·']
+const GLYPH_TICK_MS = 120
+const SHIMMER_TICK_MS = 200
+const SHIMMER_BAND = 3
+const SHOW_SUFFIX_AFTER_MS = 30_000
+const STALL_AFTER_MS = 3_000
+// Original useStalledAnimation ERROR_RED — deliberately NOT theme.error.
+const STALL_RED = 'rgb(171,43,63)'
+
+/** Verb with a claudeShimmer band sweeping right→left (GlimmerMessage-lite). */
+function ShimmerVerb({ stalled, t, tick, verb }: { stalled: boolean; t: Theme; tick: number; verb: string }) {
+  if (stalled) {
+    return <Text color={STALL_RED}>{verb}</Text>
+  }
+
+  const chars = [...verb]
+  const period = chars.length + SHIMMER_BAND
+  const head = period - 1 - (tick % period) // right→left sweep
+
+  return (
+    <Text>
+      {chars.map((ch, i) => (
+        <Text color={i >= head && i < head + SHIMMER_BAND ? t.color.claudeShimmer : t.color.accent} key={i}>
+          {ch}
+        </Text>
+      ))}
+    </Text>
+  )
+}
+
+export const BusyLine = memo(function BusyLine({ t, turnStartedAt }: BusyLineProps) {
+  const ui = useStore($uiState)
+  const todos = useTurnSelector(state => state.todos)
+  const tools = useTurnSelector(state => state.tools)
+  const streamedChars = useTurnSelector(state => state.streamedChars)
+  const lastDeltaAt = useTurnSelector(state => state.lastDeltaAt)
+  const reasoningStreaming = useTurnSelector(state => state.reasoningStreaming)
+  const subagents = useTurnSelector(state => state.subagents)
+  const delegation = useStore($delegationState)
+
+  const [tick, setTick] = useState(0)
+  const [now, setNow] = useState(() => Date.now())
+
+  // One random verb per turn (original sample()-on-mount).
+  const fallbackVerb = useMemo(
+    () => VERBS[Math.floor(Math.random() * VERBS.length)] ?? 'working',
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [turnStartedAt]
+  )
+
+  useEffect(() => {
+    if (!ui.busy) {
+      return
+    }
+
+    const glyph = setInterval(() => setTick(n => n + 1), GLYPH_TICK_MS)
+    const clock = setInterval(() => setNow(Date.now()), 1000)
+
+    return () => {
+      clearInterval(glyph)
+      clearInterval(clock)
+    }
+  }, [ui.busy])
+
+  if (!ui.busy) {
+    return null
+  }
+
+  const activeTodo = todos.find(todo => todo.status === 'in_progress')
+  const verb = `${activeTodo?.activeForm ?? activeTodo?.content ?? fallbackVerb}…`
+
+  const glyph = STAR_FRAMES[tick % STAR_FRAMES.length] ?? '✻'
+  const shimmerTick = Math.floor((tick * GLYPH_TICK_MS) / SHIMMER_TICK_MS)
+
+  const elapsedMs = turnStartedAt ? now - turnStartedAt : 0
+  const stalled = tools.length === 0 && lastDeltaAt !== null && now - lastDeltaAt > STALL_AFTER_MS
+
+  // Suffix parts appear progressively after 30s (SHOW_TOKENS_AFTER_MS parity).
+  const parts: string[] = []
+
+  if (elapsedMs > SHOW_SUFFIX_AFTER_MS) {
+    parts.push(fmtDuration(elapsedMs))
+
+    const tokens = Math.round(streamedChars / 4)
+
+    if (tokens > 0) {
+      parts.push(`↓ ~${fmtK(tokens)} tokens`)
+    }
+  }
+
+  if (reasoningStreaming) {
+    parts.push('thinking…')
+  }
+
+  // Delegation segment (right-aligned, dim) only while fanning out.
+  const tree = buildSubagentTree(subagents)
+  const totals = treeTotals(tree)
+  const delegating = totals.descendantCount > 0 || delegation.paused
+
+  const delegationLabel = !delegating
+    ? ''
+    : totals.descendantCount === 0
+      ? '⏸ paused'
+      : `${delegation.paused ? '⏸ ' : ''}⛓ ${totals.activeCount > 0 ? `${totals.activeCount} running` : `${totals.descendantCount} spawned`}`
+
+  const nextTodo = todos.find(todo => todo.status === 'pending')
+
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Box justifyContent="space-between">
+        <Text>
+          <Text color={stalled ? STALL_RED : t.color.accent}>{glyph} </Text>
+          <ShimmerVerb stalled={stalled} t={t} tick={shimmerTick} verb={verb} />
+          {parts.length > 0 && (
+            <Text color={t.color.muted} dim>
+              {' ('}
+              {parts.join(' · ')}
+              {')'}
+            </Text>
+          )}
+        </Text>
+        {delegationLabel ? (
+          <Text color={t.color.muted} dim>
+            {delegationLabel}
+          </Text>
+        ) : null}
+      </Box>
+      {nextTodo && stringWidth(nextTodo.content) > 0 ? (
+        <Text color={t.color.muted} dim>
+          Next: {nextTodo.content}
+        </Text>
+      ) : null}
+    </Box>
+  )
+})
+
+interface BusyLineProps {
+  t: Theme
+  turnStartedAt: null | number
+}


### PR DESCRIPTION
The persistent '─ ready │ model │ … ─ /cwd' status rule is replaced by
the original's UX: NOTHING when idle, and while working a star spinner
line directly above the composer (Spinner.tsx anatomy):

  ✻ Extracting the loader… (1m 3s · ↓ ~1.2k tokens · thinking…)
  Next: Add unit tests for env overrides

- Star ping-pong glyph @120ms in claude orange; verb = in-progress
  todo's activeForm ?? subject ?? a per-turn pick from the brand VERBS
  list, with a 3-col claudeShimmer band sweeping right→left @200ms.
- Dim suffix appears only after 30s (SHOW_TOKENS_AFTER_MS parity):
  elapsed + '↓ ~N tokens' (streamedChars/4 — estimate, hence ~);
  'thinking…' rides along while reasoning streams. Stall (>3s without
  deltas, no running tools) cuts glyph+verb to the original's hardcoded
  rgb(171,43,63). Telemetry: turnStore gains streamedChars/lastDeltaAt,
  stamped by text+thinking deltas, reset at turn start.
- Delegation segment (⛓ running/spawned, ⏸ when paused) right-aligned
  on the busy row only during fan-out — documented delta from the
  original's bare row (the signal is load-bearing here).
- Idle-only StatusRule signals relocated per the audit: live notices +
  '↩ resumes when subagent finishes' render as dim rows above the
  composer when the bar is off; bg-task count already lived outside the
  rule; model/cwd/duration/context are accepted losses (banner /status).
- tui_statusbar default flips 'top' → 'off' (visible change: the legacy
  rule is now opt-in via tui_statusbar: top|bottom; legacy  still
  means top). When the bar is ON it keeps owning busy display — BusyLine
  self-suppresses, so no double indicator; FaceTicker tests unchanged.

Tests: 5-case busyLine suite (idle-null, activeForm verb + Next row,
30s suffix gating with ~tokens, stall red, delegation segment) +
useConfigSync default-flip pins. Full suite at the same 9-failure
pre-existing baseline. Gallery: idle shows pure CC chrome (rules +
? for shortcuts, no status rule); busy shows the ✻ verb line.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Part D; stacked on C. NOTE: flips the tui_statusbar default to 'off' (legacy rule becomes opt-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)