### PR TITLE
feat(tui): original-CC task list (look&feel B)

### DIFF
--- a/ui-tui/src/__tests__/todoSurface.test.ts
+++ b/ui-tui/src/__tests__/todoSurface.test.ts
@@ -1,0 +1,183 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+import { renderSync } from '@clawcodex/ink'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+const harness = vi.hoisted(() => {
+  process.env.FORCE_COLOR = '3'
+  process.env.COLORTERM = 'truecolor'
+  delete process.env.NO_COLOR
+
+  return { proc: null as null | EventEmitter, spawnCalls: [] as unknown[][] }
+})
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => {
+    harness.spawnCalls.push(args)
+
+    return harness.proc
+  }
+}))
+
+import { turnController } from '../app/turnController.js'
+import { getTurnState, resetTurnState } from '../app/turnStore.js'
+import { TodoPanel } from '../components/todoPanel.js'
+import { GatewayClient } from '../gatewayClient.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+import type { TodoItem } from '../types.js'
+
+class FakeProc extends EventEmitter {
+  kill = vi.fn()
+  stderr = new PassThrough()
+  stdin = new PassThrough()
+  stdout = new PassThrough()
+
+  line(obj: unknown): void {
+    this.stdout.write(JSON.stringify(obj) + '\n')
+  }
+}
+
+const TODOS = [
+  { activeForm: 'Mapping call sites', content: 'Map call sites', id: '1', status: 'completed' },
+  { activeForm: 'Extracting the loader', content: 'Extract loader', id: '2', status: 'in_progress' },
+  { content: 'Add tests', id: '3', status: 'pending' }
+]
+
+// ── GatewayClient: TodoWrite input → payload.todos ───────────────────────────
+
+describe('GatewayClient todo mapping', () => {
+  it('carries TodoWrite input.todos on tool.start and tool.complete', async () => {
+    const proc = new FakeProc()
+    harness.proc = proc
+    const events: any[] = []
+    const gw = new GatewayClient()
+
+    gw.on('event', (e: any) => events.push(e))
+    gw.start()
+    gw.drain()
+
+    const last = (t: string) => [...events].reverse().find(e => e.type === t)
+
+    proc.line({
+      message: { content: [{ id: 't1', input: { todos: TODOS }, name: 'TodoWrite', type: 'tool_use' }] },
+      type: 'assistant'
+    })
+    await vi.waitFor(() => expect(last('tool.start')).toBeTruthy())
+    expect(last('tool.start').payload.todos).toHaveLength(3)
+
+    proc.line({
+      message: {
+        content: [{ content: 'Todos have been modified successfully.', is_error: false, tool_use_id: 't1', type: 'tool_result' }]
+      },
+      type: 'user'
+    })
+    await vi.waitFor(() => expect(last('tool.complete')).toBeTruthy())
+    expect(last('tool.complete').payload.todos?.[1]).toMatchObject({ activeForm: 'Extracting the loader' })
+
+    gw.kill()
+  })
+})
+
+// ── turnController: silent completion, no stranded spinner ──────────────────
+
+describe('turnController TodoWrite lifecycle', () => {
+  it('records todos (with activeForm) and completes without a trail line or stranded tool', () => {
+    turnController.recordError()
+    resetTurnState()
+    turnController.startMessage()
+
+    turnController.recordToolStart('t1', 'TodoWrite', '')
+    expect(getTurnState().tools).toHaveLength(1)
+
+    turnController.recordToolComplete('t1', 'TodoWrite', undefined, undefined, 0.1, TODOS)
+
+    const state = getTurnState()
+
+    expect(state.todos).toHaveLength(3)
+    expect(state.todos[1]).toMatchObject({ activeForm: 'Extracting the loader', status: 'in_progress' })
+    expect(state.tools).toHaveLength(0) // activeTools cleared — no stranded spinner
+    expect(state.streamPendingTools).toHaveLength(0) // no trail line
+    expect(state.streamSegments).toHaveLength(0)
+
+    turnController.recordError()
+    resetTurnState()
+  })
+
+  it('keeps the trail line for a FAILED TodoWrite (errors must stay visible)', () => {
+    turnController.recordError()
+    resetTurnState()
+    turnController.startMessage()
+
+    turnController.recordToolStart('t1', 'TodoWrite', '')
+    turnController.recordToolComplete('t1', 'TodoWrite', 'Error: invalid todos', undefined, 0.1)
+
+    expect(getTurnState().streamPendingTools[0]).toContain('TodoWrite')
+
+    turnController.recordError()
+    resetTurnState()
+  })
+})
+
+// ── TodoPanel: TaskListV2 anatomy ────────────────────────────────────────────
+
+const renderToString = (element: React.ReactElement): string => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: 90, isTTY: false, rows: 40 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(element, {
+    patchConsole: false,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream
+  })
+
+  instance.unmount()
+  instance.cleanup()
+
+  return output
+}
+
+describe('TodoPanel rendering', () => {
+  const items = TODOS as TodoItem[]
+
+  it('renders the TaskListV2 icons with the original states', () => {
+    const output = renderToString(React.createElement(TodoPanel, { t: DEFAULT_THEME, todos: items }))
+    const plain = stripAnsi(output)
+
+    expect(plain).toContain('3 tasks (1 done, 1 in progress, 1 open)')
+    expect(plain).toMatch(/✔ Map call sites/)
+    expect(plain).toMatch(/◼ Extract loader/)
+    expect(plain).toMatch(/◻ Add tests/)
+    // done rows: strikethrough SGR (9); in-progress: bold around subject
+    expect(output).toContain('\x1b[9m')
+    // icon colors: ✔ success green (78;186;101), ◼ claude orange (215,119,87 → hex D77757)
+    expect(output).toContain('78;186;101')
+    expect(output).toContain('215;119;87')
+  })
+
+  it('caps the visible list and summarizes the overflow', () => {
+    const many = Array.from({ length: 14 }, (_, i) => ({
+      content: `todo ${i}`,
+      id: String(i),
+      status: i < 2 ? 'completed' : i === 2 ? 'in_progress' : 'pending'
+    })) as TodoItem[]
+
+    const plain = stripAnsi(renderToString(React.createElement(TodoPanel, { t: DEFAULT_THEME, todos: many })))
+
+    expect(plain).toContain('todo 9')
+    expect(plain).not.toContain('todo 10')
+    expect(plain).toContain('+0 in progress, 4 pending, 0 completed')
+  })
+})

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -141,7 +141,10 @@ const parseTodos = (value: unknown): null | TodoItem[] => {
         return null
       }
 
+      const activeForm = String(row.activeForm ?? '').trim()
+
       return {
+        ...(activeForm && { activeForm }),
         content: String(row.content ?? '').trim(),
         id: String(row.id ?? '').trim(),
         status
@@ -834,10 +837,17 @@ class TurnController {
     }
 
     this.recordTodos(todos)
+    const name = this.activeTools.find(tool => tool.id === toolId)?.name ?? fallbackName
     const line = this.completeTool(toolId, fallbackName, error, summary, duration, resultText)
 
-    this.pendingSegmentTools = [...this.pendingSegmentTools, line]
-    this.flushPendingToolsIntoLastSegment()
+    // The original renders NOTHING inline for todo tools — the checklist HUD
+    // is the whole UI. completeTool still ran above (clears activeTools +
+    // bookkeeping), only the trail-line append is suppressed.
+    if (name !== 'TodoWrite' || error) {
+      this.pendingSegmentTools = [...this.pendingSegmentTools, line]
+      this.flushPendingToolsIntoLastSegment()
+    }
+
     this.publishToolState()
   }
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -82,21 +82,6 @@ const TranscriptPane = memo(function TranscriptPane({
 }: Pick<AppLayoutProps, 'actions' | 'composer' | 'progress' | 'transcript'>) {
   const ui = useStore($uiState)
 
-  // LiveTodoPanel rides as a child of the latest user-message row so it
-  // visually belongs to the prompt and follows it during scroll. -1 when
-  // empty → row.index === -1 is always false → no render.
-  const lastUserIdx = useMemo(() => {
-    const items = transcript.historyItems
-
-    for (let i = items.length - 1; i >= 0; i--) {
-      if (items[i].role === 'user') {
-        return i
-      }
-    }
-
-    return -1
-  }, [transcript.historyItems])
-
   // Index of the first user-role message; every later user message gets a
   // small dash above it so multi-turn transcripts visually segment by
   // turn. -1 when no user message has been sent yet → no separator ever
@@ -162,8 +147,6 @@ const TranscriptPane = memo(function TranscriptPane({
                   t={ui.theme}
                 />
               )}
-
-              {row.index === lastUserIdx && <LiveTodoPanel />}
             </Box>
           ))}
 
@@ -288,6 +271,8 @@ const ComposerPane = memo(function ComposerPane({
       )}
 
       <StatusRulePane at="top" composer={composer} status={status} />
+
+      <LiveTodoPanel />
 
       <Box flexDirection="column" marginTop={ui.statusBar === 'top' ? 0 : 1} position="relative">
         <FloatingOverlays

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -847,6 +847,12 @@ export const ToolTrail = memo(function ToolTrail({
   }
 
   for (const tool of tools) {
+    // Todo tools never render inline (original CC) — the checklist HUD is
+    // their entire UI; a blinking "TodoWrite" row would just be noise.
+    if (tool.name === 'TodoWrite') {
+      continue
+    }
+
     const label = formatToolCall(tool.name, tool.context || '')
 
     groups.push({

--- a/ui-tui/src/components/todoPanel.tsx
+++ b/ui-tui/src/components/todoPanel.tsx
@@ -2,15 +2,17 @@ import { Box, Text } from '@clawcodex/ink'
 import { memo, useState } from 'react'
 
 import { countPendingTodos } from '../lib/liveProgress.js'
-import { todoGlyph, todoTone } from '../lib/todo.js'
+import { todoGlyph } from '../lib/todo.js'
 import type { Theme } from '../theme.js'
 import type { TodoItem } from '../types.js'
 
-const rowColor = (t: Theme, status: TodoItem['status']) => {
-  const tone = todoTone(status)
+// Original TaskListV2 icon colors: ✔ success-green, ◼ claude-orange,
+// ◻ default text (cancelled dims via the row style).
+const iconColor = (t: Theme, status: TodoItem['status']) =>
+  status === 'completed' ? t.color.ok : status === 'in_progress' ? t.color.accent : t.color.text
 
-  return tone === 'active' ? t.color.text : tone === 'body' ? t.color.statusFg : t.color.muted
-}
+// Cap the visible list like the original HUD; the summary row carries the rest.
+const MAX_VISIBLE_TODOS = 10
 
 export const TodoPanel = memo(function TodoPanel({
   collapsed,
@@ -51,18 +53,33 @@ export const TodoPanel = memo(function TodoPanel({
   }
 
   const done = todos.filter(todo => todo.status === 'completed').length
+  const inProgress = todos.filter(todo => todo.status === 'in_progress').length
+  const open = todos.length - done - inProgress
   const pending = countPendingTodos(todos)
+
+  // Original standalone header: "N tasks (X done, Y in progress, Z open)".
+  const headerCounts = [
+    `${done} done`,
+    ...(inProgress > 0 ? [`${inProgress} in progress`] : []),
+    `${open} open`
+  ].join(', ')
+
+  const visible = todos.slice(0, MAX_VISIBLE_TODOS)
+  const hidden = todos.slice(MAX_VISIBLE_TODOS)
+
+  const hiddenSummary =
+    hidden.length > 0
+      ? ` … +${hidden.filter(todo => todo.status === 'in_progress').length} in progress, ${hidden.filter(todo => todo.status === 'pending').length} pending, ${hidden.filter(todo => todo.status === 'completed').length} completed`
+      : ''
 
   return (
     <Box flexDirection="column" marginBottom={1}>
       <Box onClick={handleToggle}>
         <Text color={t.color.muted}>
           <Text color={t.color.accent}>{effectiveCollapsed ? '▸ ' : '▾ '}</Text>
-          <Text bold color={t.color.text}>
-            Todo
-          </Text>{' '}
+          <Text bold>{todos.length}</Text> {todos.length === 1 ? 'task' : 'tasks'}{' '}
           <Text color={t.color.statusFg} dim>
-            ({done}/{todos.length})
+            ({headerCounts})
           </Text>
           {incomplete && pending > 0 && (
             <Text color={t.color.muted} dim>
@@ -75,17 +92,25 @@ export const TodoPanel = memo(function TodoPanel({
 
       {!effectiveCollapsed && (
         <Box flexDirection="column" marginLeft={2}>
-          {todos.map(todo => {
-            const tone = todoTone(todo.status)
-            const color = rowColor(t, todo.status)
+          {visible.map(todo => {
+            const isDone = todo.status === 'completed'
+            const isActive = todo.status === 'in_progress'
+            const isCancelled = todo.status === 'cancelled'
 
             return (
-              <Text color={color} dim={tone === 'dim'} key={todo.id}>
-                <Text color={color}>{todoGlyph(todo.status)} </Text>
-                {todo.content}
+              <Text color={t.color.text} key={todo.id}>
+                <Text color={iconColor(t, todo.status)}>{todoGlyph(todo.status)} </Text>
+                <Text bold={isActive} dimColor={isDone || isCancelled} strikethrough={isDone || isCancelled}>
+                  {todo.content}
+                </Text>
               </Text>
             )
           })}
+          {hiddenSummary ? (
+            <Text color={t.color.muted} dim>
+              {hiddenSummary}
+            </Text>
+          ) : null}
         </Box>
       )}
     </Box>

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -108,6 +108,19 @@ function relativizePath(p: string): string {
  *  genuine numbered output is collapsed — errors (is_error) and Read's other
  *  acknowledgements (empty-file / file_unchanged warnings, PDF/image stubs)
  *  aren't `N\t…` text and pass through, so nothing is mislabeled or hidden. */
+// TodoWrite's input IS the todo list — surface it on tool events so the task
+// HUD renders (the original never shows todo tool calls inline; the checklist
+// under the busy line is the whole UI).
+function todosFromInput(name: string | undefined, input: unknown): undefined | unknown[] {
+  if (name !== 'TodoWrite' || !input || typeof input !== 'object') {
+    return undefined
+  }
+
+  const todos = (input as { todos?: unknown }).todos
+
+  return Array.isArray(todos) ? todos : undefined
+}
+
 // Per-tool result summaries, matching the original Claude Code transcript
 // (tools/*/UI.tsx): Read → "Read N lines", Grep/Glob → "Found N …", Bash →
 // first 3 stdout lines + overflow hint, errors → red "Error: …" capped at 10
@@ -838,7 +851,13 @@ export class GatewayClient extends EventEmitter {
               this.ensureMsgStart()
               this.toolInputs.set(String(b.id), { input: b.input, name: String(b.name ?? '') })
               this.publish({
-                payload: { args_text: safeJson(b.input), context: toolContext(b.input), name: b.name, tool_id: b.id },
+                payload: {
+                  args_text: safeJson(b.input),
+                  context: toolContext(b.input),
+                  name: b.name,
+                  todos: todosFromInput(b.name, b.input),
+                  tool_id: b.id
+                },
                 type: 'tool.start'
               })
             }
@@ -941,6 +960,7 @@ export class GatewayClient extends EventEmitter {
                   name: stored?.name,
                   result_text: resultText,
                   structured_diff: isError ? undefined : structured,
+                  todos: isError ? undefined : todosFromInput(stored?.name, stored?.input),
                   tool_id: b.tool_use_id
                 },
                 type: 'tool.complete'

--- a/ui-tui/src/lib/todo.test.ts
+++ b/ui-tui/src/lib/todo.test.ts
@@ -3,11 +3,11 @@ import { describe, expect, it } from 'vitest'
 import { todoGlyph, todoTone } from './todo.js'
 
 describe('todoGlyph', () => {
-  it('uses fixed-width ASCII markers so the active row does not render wide or emoji-like', () => {
-    expect(todoGlyph('completed')).toBe('[x]')
-    expect(todoGlyph('in_progress')).toBe('[>]')
-    expect(todoGlyph('pending')).toBe('[ ]')
-    expect(todoGlyph('cancelled')).toBe('[-]')
+  it('uses the original TaskListV2 icons (✔ done, ◼ in-progress, ◻ pending)', () => {
+    expect(todoGlyph('completed')).toBe('✔')
+    expect(todoGlyph('in_progress')).toBe('◼')
+    expect(todoGlyph('pending')).toBe('◻')
+    expect(todoGlyph('cancelled')).toBe('◻')
   })
 })
 

--- a/ui-tui/src/lib/todo.ts
+++ b/ui-tui/src/lib/todo.ts
@@ -2,8 +2,10 @@ import type { TodoItem } from '../types.js'
 
 export type TodoTone = 'active' | 'body' | 'dim'
 
+// Original TaskListV2 icons: ✔ done (green), ◼ in-progress (claude orange),
+// ◻ pending (default); cancelled reuses the pending square, dimmed by tone.
 export const todoGlyph = (status: TodoItem['status']) =>
-  status === 'completed' ? '[x]' : status === 'cancelled' ? '[-]' : status === 'in_progress' ? '[>]' : '[ ]'
+  status === 'completed' ? '✔' : status === 'in_progress' ? '◼' : '◻'
 
 export const todoTone = (status: TodoItem['status']): TodoTone =>
   status === 'in_progress' ? 'active' : status === 'pending' ? 'body' : 'dim'

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -7,6 +7,9 @@ export interface ActiveTool {
 }
 
 export interface TodoItem {
+  // Present-continuous label ("Fixing the parser…") — the busy line shows the
+  // in-progress todo's activeForm as its verb (original Spinner.tsx).
+  activeForm?: string
   content: string
   id: string
   status: 'cancelled' | 'completed' | 'in_progress' | 'pending'


### PR DESCRIPTION
The task/todo UI is invisible on the clawcodex backend path: the NDJSON
gateway never populated payload.todos, and TodoWrite rendered as a
generic tool line. The original renders NOTHING inline for todo tools —
the checklist HUD + spinner verb ARE the task UI.

- gatewayClient: TodoWrite's input.todos ride tool.start/tool.complete
  (self-describing passthrough incl. activeForm; suppressed on error).
- turnController: TodoWrite completes silently — completeTool still runs
  (activeTools cleared, bookkeeping intact; no stranded spinner), only
  the trail-line append is suppressed. FAILED TodoWrite keeps its line
  (errors stay visible). parseTodos carries activeForm for the busy-line
  verb (wired in PR-D).
- ToolTrail: live TodoWrite rows suppressed (no blinking noise while the
  list writes).
- TodoPanel → original TaskListV2 anatomy: ✔ success-green +
  strikethrough+dim done rows, ◼ claude-orange + bold in-progress, ◻
  default pending; header 'N tasks (X done, Y in progress, Z open)'
  (bold count); 10-item cap + dim '… +N in progress, M pending, K
  completed' overflow summary.
- LiveTodoPanel deliberately relocated: transcript last-user row → the
  composer pane above the (busy) status area, where the original pins
  its task HUD under the spinner.

Tests: 5-case todoSurface suite (gateway mapping incl. activeForm,
silent-completion without stranded spinner, failed-write keeps line,
TaskListV2 render with SGR assertions, overflow cap) + todo.test glyph
update. Full suite at the same 9-failure pre-existing baseline. Pyte
gallery: todos scenario now renders the CC checklist.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Critic-approved (plan + implementation). Part B of the look-and-feel port; see #613. Recreated from auto-closed #614 (stacked base deleted on merge) — content identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)