### PR TITLE
feat(tui): original-CC composer + permission-mode badge (look&feel C)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -1610,7 +1610,8 @@ class _AgentSession:
 
         if self.init_error is not None:
             self._emit(_result_message(
-                self.session_id, subtype="error", num_turns=0,
+                self.session_id,
+                permission_mode=_current_mode(self.tool_context, self.config.permission_mode), subtype="error", num_turns=0,
                 result=self.init_error, is_error=True, error=self.init_error,
             ))
             return
@@ -1648,7 +1649,8 @@ class _AgentSession:
                     level="warning",
                 ))
                 self._emit(_result_message(
-                    self.session_id, subtype="success", num_turns=0,
+                    self.session_id,
+                    permission_mode=_current_mode(self.tool_context, self.config.permission_mode), subtype="success", num_turns=0,
                     result="", is_error=False, duration_ms=0,
                 ))
                 return
@@ -1660,7 +1662,8 @@ class _AgentSession:
                     f"Operation stopped by hook: {ups.prevent_reason}"
                 )
                 self._emit(_result_message(
-                    self.session_id, subtype="success", num_turns=0,
+                    self.session_id,
+                    permission_mode=_current_mode(self.tool_context, self.config.permission_mode), subtype="success", num_turns=0,
                     result="", is_error=False, duration_ms=0,
                 ))
                 return
@@ -1771,7 +1774,8 @@ class _AgentSession:
             ))
         except AbortError:
             self._emit(_result_message(
-                self.session_id, subtype="cancelled", num_turns=0,
+                self.session_id,
+                permission_mode=_current_mode(self.tool_context, self.config.permission_mode), subtype="cancelled", num_turns=0,
                 result="", is_error=False,
                 duration_ms=int((time.monotonic() - start) * 1000),
             ))
@@ -1779,7 +1783,8 @@ class _AgentSession:
         except Exception as exc:  # noqa: BLE001 - one bad turn must not kill the session
             logger.exception("[agent-server] turn failed")
             self._emit(_result_message(
-                self.session_id, subtype="error", num_turns=0,
+                self.session_id,
+                permission_mode=_current_mode(self.tool_context, self.config.permission_mode), subtype="error", num_turns=0,
                 result=str(exc), is_error=True, error=str(exc),
                 duration_ms=int((time.monotonic() - start) * 1000),
             ))
@@ -1803,6 +1808,7 @@ class _AgentSession:
                 _cost = 0.0
         self._emit(_result_message(
             self.session_id,
+            permission_mode=_current_mode(self.tool_context, self.config.permission_mode),
             subtype="success",
             num_turns=result.num_turns,
             result=result.response_text,
@@ -2395,6 +2401,7 @@ def _result_message(
     error: str | None = None,
     duration_ms: int = 0,
     total_cost_usd: float = 0.0,
+    permission_mode: str | None = None,
 ) -> dict:
     payload: dict[str, Any] = {
         "type": "result",
@@ -2409,6 +2416,12 @@ def _result_message(
     }
     if error is not None:
         payload["error"] = error
+    # Server-side mode flips (plan approval, "accept edits for this session")
+    # emit no dedicated event — the end-of-turn result refreshes the client's
+    # permission-mode badge instead (at most one turn stale, and mode changes
+    # only bind next turn anyway).
+    if permission_mode is not None:
+        payload["permission_mode"] = permission_mode
     return payload
 
 

--- a/ui-tui/src/__tests__/composerFooter.test.ts
+++ b/ui-tui/src/__tests__/composerFooter.test.ts
@@ -1,0 +1,153 @@
+import { PassThrough } from 'node:stream'
+
+import { renderSync } from '@clawcodex/ink'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.hoisted(() => {
+  process.env.FORCE_COLOR = '3'
+  process.env.COLORTERM = 'truecolor'
+  delete process.env.NO_COLOR
+})
+
+import { ComposerFooter } from '../components/composerFooter.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+const renderToString = (element: React.ReactElement): string => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: 100, isTTY: false, rows: 20 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(element, {
+    patchConsole: false,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream
+  })
+
+  instance.unmount()
+  instance.cleanup()
+
+  return output
+}
+
+const footer = (props: Partial<Parameters<typeof ComposerFooter>[0]> = {}) =>
+  renderToString(
+    React.createElement(ComposerFooter, {
+      busy: false,
+      inputEmpty: true,
+      mode: 'default',
+      sh: false,
+      t: DEFAULT_THEME,
+      ...props
+    })
+  )
+
+describe('ComposerFooter', () => {
+  it('shows the idle shortcuts hint in default mode', () => {
+    expect(stripAnsi(footer())).toContain('? for shortcuts')
+  })
+
+  it('suppresses everything while the input has text (suppressHint parity)', () => {
+    expect(stripAnsi(footer({ inputEmpty: false })).trim()).toBe('')
+  })
+
+  it('swaps the hint for the interrupt hint while busy', () => {
+    const plain = stripAnsi(footer({ busy: true }))
+
+    expect(plain).toContain('ctrl+c to interrupt')
+    expect(plain).not.toContain('? for shortcuts')
+  })
+
+  it('renders each permission-mode badge with its color and the cycle hint', () => {
+    const plan = footer({ mode: 'plan' })
+
+    expect(stripAnsi(plan)).toContain('⏸ plan mode on (shift+tab to cycle)')
+    expect(plan).toContain('72;150;140') // planMode sage
+    // hint coexists with the badge
+    expect(stripAnsi(plan)).toContain('? for shortcuts')
+
+    const accept = footer({ mode: 'acceptEdits' })
+
+    expect(stripAnsi(accept)).toContain('▶▶ accept edits on')
+    expect(accept).toContain('175;135;255') // autoAccept violet
+
+    const bypass = footer({ mode: 'bypassPermissions' })
+
+    expect(stripAnsi(bypass)).toContain('▶▶ bypass permissions on')
+    expect(bypass).toContain('255;107;128') // error red
+  })
+
+  it('shows bash-mode hint in pink when the input is in ! mode', () => {
+    const out = footer({ sh: true })
+
+    expect(stripAnsi(out)).toContain('! for bash mode')
+    expect(out).toContain('253;93;177')
+  })
+
+  it('shows the voice label only while voice is actually active', () => {
+    expect(stripAnsi(footer({ voiceLabel: 'voice off' }))).not.toContain('voice off')
+    expect(stripAnsi(footer({ voiceLabel: '● rec 0:04' }))).toContain('● rec 0:04')
+  })
+})
+
+// ── permission-mode store refresh (message.complete piggyback) ──────────────
+
+import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
+import { $uiState, patchUiState } from '../app/uiStore.js'
+
+const ref = <T,>(current: T) => ({ current })
+
+const buildHandlerCtx = () =>
+  ({
+    composer: {
+      dequeue: () => undefined,
+      queueEditRef: ref<null | number>(null),
+      sendQueued: vi.fn(),
+      setInput: vi.fn()
+    },
+    gateway: { gw: { request: vi.fn() }, rpc: vi.fn(async () => null) },
+    session: {
+      STARTUP_RESUME_ID: '',
+      colsRef: ref(80),
+      newSession: vi.fn(),
+      resetSession: vi.fn(),
+      resumeById: vi.fn(),
+      setCatalog: vi.fn()
+    },
+    submission: { submitRef: { current: vi.fn() } },
+    system: { bellOnComplete: false, sys: vi.fn() },
+    transcript: { appendMessage: vi.fn(), panel: vi.fn(), setHistoryItems: vi.fn() },
+    voice: { setProcessing: vi.fn(), setRecording: vi.fn(), setVoiceEnabled: vi.fn() }
+  }) as never
+
+describe('permissionMode store refresh', () => {
+  it('patches uiState from the end-of-turn result payload', () => {
+    patchUiState({ permissionMode: 'plan' })
+
+    const handler = createGatewayEventHandler(buildHandlerCtx())
+
+    handler({ payload: { permission_mode: 'acceptEdits', text: 'done' }, type: 'message.complete' } as never)
+
+    expect($uiState.get().permissionMode).toBe('acceptEdits')
+  })
+
+  it('patches uiState from the permission.mode event (/mode while idle)', () => {
+    patchUiState({ permissionMode: 'default' })
+
+    const handler = createGatewayEventHandler(buildHandlerCtx())
+
+    handler({ payload: { mode: 'plan' }, type: 'permission.mode' } as never)
+
+    expect($uiState.get().permissionMode).toBe('plan')
+  })
+})

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -426,6 +426,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         patchUiState(state => ({
           ...state,
           info,
+          ...(info.permission_mode && { permissionMode: info.permission_mode }),
           status: state.status === 'starting agent…' ? 'ready' : state.status,
           usage: info.usage ? { ...state.usage, ...info.usage } : state.usage
         }))
@@ -807,6 +808,10 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         return
 
+      case 'permission.mode':
+        patchUiState({ permissionMode: ev.payload.mode })
+
+        return
       case 'background.complete':
         dropBgTask(ev.payload.task_id)
         sys(`[bg ${ev.payload.task_id}] ${ev.payload.text}`)
@@ -931,6 +936,9 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         return
       case 'message.complete': {
+        if (ev.payload?.permission_mode) {
+          patchUiState({ permissionMode: ev.payload.permission_mode })
+        }
         const { finalMessages, finalText, wasInterrupted } = turnController.recordMessageComplete(ev.payload ?? {})
 
         if (!wasInterrupted) {

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -160,6 +160,10 @@ export interface TranscriptRow {
 export interface UiState {
   bgTasks: Set<string>
   busy: boolean
+  // Live permission mode (default | plan | acceptEdits | bypassPermissions |
+  // auto) — seeded from system/init, refreshed by shift+tab cycling, /mode,
+  // and the end-of-turn result (covers server-side flips like plan approval).
+  permissionMode: string
   busyInputMode: BusyInputMode
   compact: boolean
   detailsMode: DetailsMode

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -9,6 +9,7 @@ import { DEFAULT_INDICATOR_STYLE, type UiState } from './interfaces.js'
 const buildUiState = (): UiState => ({
   bgTasks: new Set(),
   busy: false,
+  permissionMode: 'default',
   busyInputMode: 'queue',
   compact: false,
   detailsMode: 'collapsed',

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -6,7 +6,6 @@ import { DASHBOARD_TUI_MODE } from '../config/env.js'
 import { TYPING_IDLE_MS } from '../config/timing.js'
 import type {
   ApprovalRespondResponse,
-  ConfigSetResponse,
   SecretRespondResponse,
   SudoRespondResponse,
   VoiceRecordResponse
@@ -20,7 +19,7 @@ import type { InputHandlerActions, InputHandlerContext, InputHandlerResult } fro
 import { $isBlocked, $overlayState, patchOverlayState } from './overlayStore.js'
 import { turnController } from './turnController.js'
 import { patchTurnState } from './turnStore.js'
-import { getUiState } from './uiStore.js'
+import { getUiState, patchUiState } from './uiStore.js'
 
 const isCtrl = (key: { ctrl: boolean }, ch: string, target: string) => key.ctrl && ch.toLowerCase() === target
 const DASHBOARD_NEW_SESSION_MESSAGE = 'starting a fresh dashboard chat...'
@@ -576,9 +575,15 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       if (!live.sid) {
         return void actions.sys('mode needs an active session')
       }
+
       return void gateway
         .rpc<{ mode?: string }>('permission.cycle', {})
-        .then(r => { if (r?.mode) actions.sys(`permission mode: ${r.mode}`) })
+        .then(r => {
+          if (r?.mode) {
+            patchUiState({ permissionMode: r.mode })
+            actions.sys(`permission mode: ${r.mode}`)
+          }
+        })
     }
 
     if (key.tab && cState.completions.length) {

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -23,6 +23,7 @@ import { AgentsOverlay } from './agentsOverlay.js'
 import { GoodVibesHeart, StatusRule, StickyPromptTracker, TranscriptScrollbar } from './appChrome.js'
 import { FloatingOverlays, PromptZone } from './appOverlays.js'
 import { Banner, Panel, SessionPanel } from './branding.js'
+import { ComposerFooter } from './composerFooter.js'
 import { FpsOverlay } from './fpsOverlay.js'
 import { HelpHint } from './helpHint.js'
 import { MessageLine } from './messageLine.js'
@@ -274,7 +275,17 @@ const ComposerPane = memo(function ComposerPane({
 
       <LiveTodoPanel />
 
-      <Box flexDirection="column" marginTop={ui.statusBar === 'top' ? 0 : 1} position="relative">
+      <Box
+        borderBottom
+        borderColor={sh ? ui.theme.color.bashBorder : ui.theme.color.promptBorder}
+        borderLeft={false}
+        borderRight={false}
+        borderStyle="round"
+        borderTop
+        flexDirection="column"
+        marginTop={ui.statusBar === 'top' ? 0 : 1}
+        position="relative"
+      >
         <FloatingOverlays
           cols={composer.cols}
           compIdx={composer.compIdx}
@@ -319,7 +330,12 @@ const ComposerPane = memo(function ComposerPane({
                 ) : composer.inputBuf.length ? (
                   <Text color={ui.theme.color.prompt}>{promptBlank}</Text>
                 ) : (
-                  <PromptPrefix bold color={ui.theme.color.prompt} promptText={promptText} width={promptWidth} />
+                  <PromptPrefix
+                    bold
+                    color={ui.busy ? ui.theme.color.muted : ui.theme.color.prompt}
+                    promptText={promptText}
+                    width={promptWidth}
+                  />
                 )}
               </Box>
 
@@ -331,7 +347,7 @@ const ComposerPane = memo(function ComposerPane({
                   onChange={composer.updateInput}
                   onPaste={composer.handleTextPaste}
                   onSubmit={composer.submit}
-                  placeholder={composer.empty ? PLACEHOLDER : ui.busy ? 'Ctrl+C to interrupt…' : ''}
+                  placeholder={composer.empty && !ui.busy ? PLACEHOLDER : ''}
                   value={composer.input}
                   voiceRecordKey={composer.voiceRecordKey}
                 />
@@ -346,6 +362,15 @@ const ComposerPane = memo(function ComposerPane({
       </Box>
 
       {!composer.empty && !ui.sid && <Text color={ui.theme.color.muted}>⚕ {ui.status}</Text>}
+
+      <ComposerFooter
+        busy={ui.busy}
+        inputEmpty={!composer.input && !composer.inputBuf.length}
+        mode={ui.permissionMode}
+        sh={sh}
+        t={ui.theme}
+        voiceLabel={status.voiceLabel}
+      />
 
       <StatusRulePane at="bottom" composer={composer} status={status} />
     </NoSelect>

--- a/ui-tui/src/components/composerFooter.tsx
+++ b/ui-tui/src/components/composerFooter.tsx
@@ -1,0 +1,100 @@
+/**
+ * Footer row below the composer's bottom rule — the original PromptInput
+ * footer (PromptInputFooterLeftSide + ModeIndicator):
+ *
+ *   ? for shortcuts                                  ⏸ plan mode on (shift+tab to cycle)
+ *
+ * Left byline precedence: bash-mode hint → busy interrupt hint → idle
+ * `? for shortcuts`. Right side: the permission-mode badge (plan sage /
+ * accept-edits violet / bypass red / auto amber) and the voice indicator when
+ * active. Everything hides while the input has text (suppressHint).
+ */
+import { Box, Text } from '@clawcodex/ink'
+import { memo } from 'react'
+
+import type { Theme } from '../theme.js'
+
+interface ModeBadge {
+  color: (t: Theme) => string
+  label: string
+  symbol: string
+}
+
+// Original PermissionMode.ts symbols/titles: ⏸ (U+23F8) for plan, ▶▶
+// (U+25B6 ×2) for the rest.
+const MODE_BADGES: Record<string, ModeBadge> = {
+  acceptEdits: { color: t => t.color.autoAccept, label: 'accept edits on', symbol: '▶▶' },
+  auto: { color: t => t.color.warn, label: 'auto mode on', symbol: '▶▶' },
+  bypassPermissions: { color: t => t.color.error, label: 'bypass permissions on', symbol: '▶▶' },
+  dontAsk: { color: t => t.color.error, label: "don't ask on", symbol: '▶▶' },
+  plan: { color: t => t.color.planMode, label: 'plan mode on', symbol: '⏸' }
+}
+
+export const ComposerFooter = memo(function ComposerFooter({
+  busy,
+  inputEmpty,
+  mode,
+  sh,
+  t,
+  voiceLabel = ''
+}: ComposerFooterProps) {
+  // CC suppressHint: nothing while the user is typing.
+  if (!inputEmpty) {
+    return null
+  }
+
+  const badge = MODE_BADGES[mode]
+  // Voice shows only when actually active — the StatusRule's label starts
+  // with ●/◉ while recording/transcribing and reads "voice off" otherwise.
+  const voiceActive = /^[●◉]/.test(voiceLabel)
+
+  // Left hint is independent of the badge (both render, like the original's
+  // byline; the badge just lives on the right here).
+  const left = sh ? (
+    <Text color={t.color.bashBorder}>! for bash mode</Text>
+  ) : busy ? (
+    <Text color={t.color.muted} dim>
+      ctrl+c to interrupt
+    </Text>
+  ) : (
+    <Text color={t.color.muted} dim>
+      ? for shortcuts
+    </Text>
+  )
+
+  const right = (
+    <>
+      {voiceActive && (
+        <Text color={t.color.muted} dim>
+          {voiceLabel}
+          {badge ? ' · ' : ''}
+        </Text>
+      )}
+      {badge && (
+        <Text color={badge.color(t)}>
+          {badge.symbol} {badge.label}
+          <Text color={t.color.muted} dim>
+            {' (shift+tab to cycle)'}
+          </Text>
+        </Text>
+      )}
+    </>
+  )
+
+  return (
+    <Box justifyContent="space-between" paddingX={2}>
+      <Box>{left ?? <Text> </Text>}</Box>
+      <Box>{right}</Box>
+    </Box>
+  )
+})
+
+interface ComposerFooterProps {
+  busy: boolean
+  inputEmpty: boolean
+  mode: string
+  sh: boolean
+  t: Theme
+  /** StatusRule-style voice label ("voice off" / "● rec 0:04" / "◉ …"). */
+  voiceLabel?: string
+}

--- a/ui-tui/src/components/queuedMessages.tsx
+++ b/ui-tui/src/components/queuedMessages.tsx
@@ -24,7 +24,7 @@ export function QueuedMessages({ cols, queueEditIdx, queued, t }: QueuedMessages
   return (
     <Box flexDirection="column" marginTop={1}>
       <Text color={t.color.muted} dimColor>
-        {`queued (${queued.length})${
+        {`${queued.length} ${queued.length === 1 ? 'message' : 'messages'} queued for next turn${
           queueEditIdx !== null ? ` · editing ${queueEditIdx + 1} · Ctrl+X delete · Esc cancel` : ''
         }`}
       </Text>

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -631,10 +631,16 @@ export class GatewayClient extends EventEmitter {
         return out(`Effort: ${r?.effort ?? arg ?? '(unchanged)'}.`)
       }
 
-      case 'mode':
-        await this.controlQuery('set_permission_mode', { mode: arg })
+      case 'mode': {
+        const r = (await this.controlQuery('set_permission_mode', { mode: arg })) as any
+        const mode = typeof r?.mode === 'string' ? r.mode : arg
 
-        return out(`Permission mode: ${arg ?? '(unchanged)'}.`)
+        if (mode) {
+          this.publish({ payload: { mode: String(mode) }, type: 'permission.mode' })
+        }
+
+        return out(`Permission mode: ${mode ?? '(unchanged)'}.`)
+      }
 
       case 'model':
         await this.controlQuery('set_model', { model: arg })
@@ -880,6 +886,7 @@ export class GatewayClient extends EventEmitter {
       case 'result':
         this.publish({
           payload: {
+            permission_mode: typeof msg.permission_mode === 'string' ? msg.permission_mode : undefined,
             text: typeof msg.result === 'string' ? msg.result : undefined,
             usage: msg.usage
           },
@@ -1125,6 +1132,7 @@ export class GatewayClient extends EventEmitter {
     return {
       cwd: init.cwd,
       model: String(init.model ?? ''),
+      permission_mode: typeof init.permission_mode === 'string' ? init.permission_mode : undefined,
       profile_name: init.provider ? String(init.provider) : undefined,
       skills: {},
       tools: { '': toolNames },

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -724,6 +724,7 @@ export type GatewayEvent =
     }
   | { payload: { request_id: string }; session_id?: string; type: 'sudo.request' }
   | { payload: { env_var: string; prompt: string; request_id: string }; session_id?: string; type: 'secret.request' }
+  | { payload: { mode: string }; session_id?: string; type: 'permission.mode' }
   | { payload: { task_id: string; text: string }; session_id?: string; type: 'background.complete' }
   | { payload?: { text?: string }; session_id?: string; type: 'review.summary' }
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.spawn_requested' }
@@ -734,7 +735,7 @@ export type GatewayEvent =
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.complete' }
   | { payload: { rendered?: string; text?: string }; session_id?: string; type: 'message.delta' }
   | {
-      payload?: { reasoning?: string; rendered?: string; text?: string; usage?: Usage }
+      payload?: { permission_mode?: string; reasoning?: string; rendered?: string; text?: string; usage?: Usage }
       session_id?: string
       type: 'message.complete'
     }

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -189,6 +189,7 @@ export interface SessionInfo {
   lazy?: boolean
   mcp_servers?: McpServerStatus[]
   model: string
+  permission_mode?: string
   profile_name?: string
   reasoning_effort?: string
   release_date?: string


### PR DESCRIPTION
Composer anatomy from the original PromptInput (typescript/):

- Input framed by full-width top+bottom ─ rules (borderStyle round with
  left/right off → no corner glyphs), promptBorder gray; bash-! mode
  turns the rules bashBorder pink. Prompt ❯ dims while busy; the busy
  placeholder is gone (the footer owns the interrupt hint).
- Footer row under the bottom rule (PromptInputFooterLeftSide): idle
  dim '? for shortcuts', busy 'ctrl+c to interrupt' (our real binding),
  bash-mode '! for bash mode' pink; right side shows the permission-mode
  badge — ⏸ plan mode on (sage) / ▶▶ accept edits on (violet) / ▶▶
  bypass permissions on (red) / ▶▶ auto mode on (amber), each with a dim
  '(shift+tab to cycle)'. Everything hides while the input has text
  (suppressHint parity).
- Queued header reworded to the original: 'N messages queued for next
  turn'.

Permission-mode state (badge can never lie — critic B3):
- agent-server: every end-of-turn result now carries permission_mode
  (6 call sites via _current_mode), covering server-side flips (plan
  approval, accept-edits-for-session grants) with at-most-one-turn
  staleness; system/init already carried it.
- client: uiStore.permissionMode seeded from session.info, refreshed by
  message.complete, shift+tab cycle response (now also patches the
  store), and /mode (publishes a permission.mode event so idle flips
  update immediately).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Critic-approved (plan + implementation incl. footer test suite, live voice wiring, hint/badge coexistence). Part C; see #613/#617. Recreated from auto-closed #615 — content identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)