### PR TITLE
fix(perm): wire --dangerously-skip-permissions through the TUI/agent-server chain

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -164,6 +164,7 @@ def main():
         provider=args.provider,
         model=args.model,
         permission_mode=args._resolved_permission_mode,
+        is_bypass_available=args._resolved_is_bypass_available,
     )
 
 

--- a/src/entrypoints/agent_server_cli.py
+++ b/src/entrypoints/agent_server_cli.py
@@ -12,6 +12,8 @@ Usage::
     clawcodex agent-server [--host H] [--port P] [--token T]
                            [--provider NAME] [--model M]
                            [--permission-mode MODE] [--workspace DIR]
+                           [--dangerously-skip-permissions]
+                           [--allow-dangerously-skip-permissions]
 
 On start it prints the ``cc://`` and ``http://`` URLs to connect to.
 """
@@ -89,6 +91,18 @@ def run_agent_server_subcommand(argv: list[str]) -> int:
     parser.add_argument("--permission-mode", default="default",
                         dest="permission_mode",
                         help="default | acceptEdits | bypassPermissions | plan | auto")
+    parser.add_argument(
+        "--dangerously-skip-permissions", action="store_true",
+        dest="dangerously_skip_permissions",
+        help="Bypass all permission checks (start in bypassPermissions mode). "
+             "Recommended only for sandboxes with no internet access.",
+    )
+    parser.add_argument(
+        "--allow-dangerously-skip-permissions", action="store_true",
+        dest="allow_dangerously_skip_permissions",
+        help="Make bypassPermissions AVAILABLE (Shift+Tab / /mode) without "
+             "starting in it.",
+    )
     parser.add_argument("--workspace", default=None,
                         help="Workspace root the agent operates in (default: cwd).")
     parser.add_argument("--max-turns", type=int, default=20, dest="max_turns")
@@ -122,6 +136,36 @@ def run_agent_server_subcommand(argv: list[str]) -> int:
               "bypassPermissions | auto", file=sys.stderr)
         return 2
 
+    # Same root-outside-sandbox refusal the top-level CLI runs for these
+    # flags (src/cli.py _resolve_permission_state); a hand-launched
+    # agent-server must not be a way around it.
+    dangerously = bool(args.dangerously_skip_permissions)
+    allow_dangerously = bool(args.allow_dangerously_skip_permissions)
+    from src.permissions.dangerous_safety import (
+        enforce_dangerous_skip_permissions_safety,
+    )
+
+    enforce_dangerous_skip_permissions_safety(
+        bypass_requested=dangerously or allow_dangerously,
+    )
+    if dangerously:
+        # Flag wins over --permission-mode, same priority as
+        # initial_permission_mode_from_cli (src/permissions/modes.py).
+        args.permission_mode = "bypassPermissions"
+
+    # bypass AVAILABILITY. Flags always count. Trusted settings
+    # (permissions.allowBypassPermissionsMode) count only on the
+    # single-session --stdio transport: this server serves exactly the
+    # operator who launched it, so their own user/local settings apply. On
+    # the multi-session --http transport, folding host settings in would
+    # unlock bypass for every remote client — resolve that per-launch
+    # upstream and pass a flag instead.
+    is_bypass_available = dangerously or allow_dangerously
+    if not is_bypass_available and args.stdio:
+        from src.permissions.modes import has_allow_bypass_permissions_mode
+
+        is_bypass_available = has_allow_bypass_permissions_mode()
+
     workspace = str(Path(args.workspace).resolve()) if args.workspace else str(Path.cwd())
 
     if args.fallback_model and args.fallback_model == args.model:
@@ -133,6 +177,7 @@ def run_agent_server_subcommand(argv: list[str]) -> int:
         model=args.model,
         fallback_model=args.fallback_model,
         permission_mode=args.permission_mode,
+        is_bypass_available=is_bypass_available,
         max_turns=args.max_turns,
     )
 

--- a/src/entrypoints/tui_launcher.py
+++ b/src/entrypoints/tui_launcher.py
@@ -13,6 +13,8 @@ exit:
 Usage::
 
     clawcodex tui [--provider P] [--model M] [--permission-mode MODE]
+                  [--dangerously-skip-permissions]
+                  [--allow-dangerously-skip-permissions]
                   [--workspace DIR] [--tui-dir DIR] [--print-connect]
 
 ``--print-connect`` instead runs the agent-server directly and prints its
@@ -49,6 +51,18 @@ def run_tui_launcher(argv: list[str]) -> int:
     parser.add_argument("--provider", default=None)
     parser.add_argument("--model", default=None)
     parser.add_argument("--permission-mode", default="default", dest="permission_mode")
+    parser.add_argument(
+        "--dangerously-skip-permissions", action="store_true",
+        dest="dangerously_skip_permissions",
+        help="Bypass all permission checks. Recommended only for sandboxes "
+             "with no internet access.",
+    )
+    parser.add_argument(
+        "--allow-dangerously-skip-permissions", action="store_true",
+        dest="allow_dangerously_skip_permissions",
+        help="Make bypassPermissions available (Shift+Tab / /mode) without "
+             "starting in it.",
+    )
     parser.add_argument("--workspace", default=None,
                         help="Workspace root the agent operates in (default: cwd).")
     parser.add_argument("--tui-dir", default=None,
@@ -65,12 +79,39 @@ def run_tui_launcher(argv: list[str]) -> int:
               "bypassPermissions | auto", file=sys.stderr)
         return 2
 
+    # Same resolution the default `clawcodex` entry runs in
+    # src/cli.py::_resolve_permission_state — safety gate first, then
+    # flag > --permission-mode priority, then availability.
+    from src.permissions.dangerous_safety import (
+        enforce_dangerous_skip_permissions_safety,
+    )
+    from src.permissions.modes import (
+        has_allow_bypass_permissions_mode,
+        initial_permission_mode_from_cli,
+    )
+
+    dangerously = bool(args.dangerously_skip_permissions)
+    allow_dangerously = bool(args.allow_dangerously_skip_permissions)
+    enforce_dangerous_skip_permissions_safety(
+        bypass_requested=dangerously or allow_dangerously,
+    )
+    mode = initial_permission_mode_from_cli(
+        permission_mode_cli=args.permission_mode,
+        dangerously_skip_permissions=dangerously,
+    )
+    is_bypass_available = (
+        dangerously or allow_dangerously or has_allow_bypass_permissions_mode()
+    )
+
     if args.print_connect:
+        args.permission_mode = mode
+        args.is_bypass_available = is_bypass_available
         return _print_connect(args)
     return launch_ink_tui(
         provider=args.provider,
         model=args.model,
-        permission_mode=args.permission_mode,
+        permission_mode=mode,
+        is_bypass_available=is_bypass_available,
         workspace=args.workspace,
         tui_dir=args.tui_dir,
     )
@@ -81,6 +122,7 @@ def launch_ink_tui(
     provider: str | None = None,
     model: str | None = None,
     permission_mode: str = "default",
+    is_bypass_available: bool = False,
     workspace: str | None = None,
     tui_dir: str | None = None,
 ) -> int:
@@ -90,11 +132,19 @@ def launch_ink_tui(
     entry in :func:`src.cli.main`. Returns the Ink client's exit code, or a
     non-zero code with a helpful message (printed to stderr by :func:`_launch`)
     when the client or a JS runtime can't be found.
+
+    ``is_bypass_available`` carries the caller-resolved bypassPermissions
+    availability (``--dangerously-skip-permissions`` /
+    ``--allow-dangerously-skip-permissions`` / settings) to the spawned
+    agent-server, which owns the Shift+Tab cycle and set_permission_mode
+    guards. Without it, availability resolved by the CLI was silently dropped
+    and bypass could never be reached at runtime.
     """
     args = SimpleNamespace(
         provider=provider,
         model=model,
         permission_mode=permission_mode,
+        is_bypass_available=is_bypass_available,
         workspace=workspace,
         tui_dir=tui_dir,
         print_connect=False,
@@ -153,6 +203,11 @@ def _agent_server_cmd(args) -> list[str]:
     """
     cmd = [sys.executable, "-m", "src.entrypoints.agent_server_cli",
            "--permission-mode", args.permission_mode]
+    if getattr(args, "is_bypass_available", False):
+        # Availability only — the launch mode above decides whether the
+        # session STARTS in bypass; this keeps bypass reachable via
+        # Shift+Tab / /mode either way.
+        cmd += ["--allow-dangerously-skip-permissions"]
     if args.provider:
         cmd += ["--provider", args.provider]
     if args.model:
@@ -197,6 +252,8 @@ def _print_connect(args) -> int:
     return run_agent_server_subcommand([
         "--host", "127.0.0.1", "--port", "0", "--token", token,
         "--permission-mode", args.permission_mode,
+        *(["--allow-dangerously-skip-permissions"]
+          if getattr(args, "is_bypass_available", False) else []),
         *(["--provider", args.provider] if args.provider else []),
         *(["--model", args.model] if args.model else []),
         "--workspace", workspace,

--- a/src/permissions/modes.py
+++ b/src/permissions/modes.py
@@ -111,30 +111,32 @@ def initial_permission_mode_from_cli(
 
 
 def has_allow_bypass_permissions_mode() -> bool:
-    """Return True if any trusted settings source enables bypass mode availability.
+    """Return True if a trusted settings source enables bypass availability.
 
     Mirrors ``hasAllowBypassPermissionsMode`` in
-    ``typescript/src/utils/settings/settings.ts:897``.
+    ``typescript/src/utils/settings/settings.ts:897``: reads
+    ``permissions.allowBypassPermissionsMode`` from the user (global) and local
+    tiers, and INTENTIONALLY EXCLUDES the project tier
+    (``<git-root>/.claude/config.json``) — that file is committable, so a
+    cloned repo must not be able to auto-enable bypass (the TS comment: "a
+    malicious project could otherwise enable bypass mode (security risk)").
 
-    The TS reference reads ``permissions.allowBypassPermissionsMode`` from
-    user, local, flag, and policy settings — projectSettings is intentionally
-    excluded because a malicious project could otherwise auto-enable bypass.
-
-    Python today merges all settings sources into a single ``SettingsSchema``
-    (see ``src/settings/settings.py``). We read the merged ``extra`` dict for
-    the same key. When source-segmented settings land we can tighten this.
+    We read the RAW per-tier config dicts rather than the merged
+    ``SettingsSchema`` for two reasons: the schema has no structured slot for
+    this scalar (``permissions`` is modeled as a flat rule *list*), and the
+    merged view can't tell the project tier apart from the trusted tiers, which
+    is exactly the distinction the security exclusion turns on.
     """
     try:
-        from src.settings.settings import get_settings
+        from src.config import ConfigManager
+
+        cm = ConfigManager()
+        # Global (user) + local (gitignored, operator-owned) only — never the
+        # committable project tier.
+        for loader in (cm.load_global, cm.load_local):
+            perms = loader().get("settings", {}).get("permissions")
+            if isinstance(perms, dict) and perms.get("allowBypassPermissionsMode"):
+                return True
     except Exception:
         return False
-
-    try:
-        settings = get_settings()
-    except Exception:
-        return False
-
-    perms = settings.extra.get("permissions") if hasattr(settings, "extra") else None
-    if isinstance(perms, dict):
-        return bool(perms.get("allowBypassPermissionsMode"))
     return False

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -84,6 +84,14 @@ class AgentServerConfig:
     # (`--fallback-model`; session-sticky, never persisted).
     fallback_model: str | None = None
     permission_mode: str = "default"
+    # bypassPermissions AVAILABILITY, decoupled from the launch mode: True when
+    # the user passed --dangerously-skip-permissions / --allow-dangerously-
+    # skip-permissions to the launcher. Availability is what lets Shift+Tab
+    # cycling and set_permission_mode reach bypassPermissions at runtime;
+    # launching IN bypass mode implies it (see _build_runtime). Mirrors
+    # isBypassPermissionsModeAvailable in
+    # typescript/src/utils/permissions/permissionSetup.ts:941.
+    is_bypass_available: bool = False
     max_turns: int = 20
     allowed_tools: tuple[str, ...] = ()
     disallowed_tools: tuple[str, ...] = ()
@@ -239,13 +247,51 @@ class _AgentSession:
             return
         if subtype == "set_permission_mode":
             mode = inner.get("mode")
-            if isinstance(mode, str) and self.tool_context is not None:
-                _set_mode(self.tool_context, mode)
-                # ch03 round-4 GAP A: the live gate home stays
-                # tool_context.permission_context; the store dispatch runs
-                # the centralized seams (listeners; future persistence).
-                _dispatch_app_state(self, permission_mode=mode)
-            self._ack(request_id)
+            # Validate BEFORE setting: an unknown string would land verbatim in
+            # permission_context.mode and silently behave like a mode it isn't.
+            # 'bubble' is runtime-only sub-agent escalation (rejected as a
+            # top-level mode everywhere else, e.g. agent_server_cli).
+            from src.permissions.types import PERMISSION_MODES
+
+            if (
+                not isinstance(mode, str)
+                or mode not in PERMISSION_MODES
+                or mode == "bubble"
+            ):
+                self._reply(request_id, {
+                    "ok": False,
+                    "error": f"invalid permission mode: {mode!r} "
+                             "(default | plan | acceptEdits | bypassPermissions "
+                             "| dontAsk | auto)",
+                })
+                return
+            if self.tool_context is None:
+                self._reply(request_id, {"ok": False, "error": "session not ready"})
+                return
+            # bypassPermissions is only settable when the session made it
+            # available (--dangerously-skip-permissions / --allow-…). Same
+            # guard the Shift+Tab cycle enforces (get_next_permission_mode) —
+            # without it, /mode bypassPermissions silently disabled the whole
+            # permission gate in any session. Mirrors the onSetPermissionMode
+            # contract in typescript/src/bridge/replBridge.ts:182-193.
+            pc = self.tool_context.permission_context
+            if mode == "bypassPermissions" and not getattr(
+                pc, "is_bypass_permissions_mode_available", False
+            ):
+                self._reply(request_id, {
+                    "ok": False,
+                    "error": "bypassPermissions is not available in this "
+                             "session — launch with "
+                             "--dangerously-skip-permissions or "
+                             "--allow-dangerously-skip-permissions",
+                })
+                return
+            _set_mode(self.tool_context, mode)
+            # ch03 round-4 GAP A: the live gate home stays
+            # tool_context.permission_context; the store dispatch runs
+            # the centralized seams (listeners; future persistence).
+            _dispatch_app_state(self, permission_mode=mode)
+            self._reply(request_id, {"ok": True, "mode": mode})
             return
         if subtype == "cycle_permission_mode":
             # ch13 round-4 (critic B1) — shift+tab cycling MUST be computed
@@ -256,14 +302,15 @@ class _AgentSession:
             # step into bypass unconditionally, silently disabling the whole
             # permission gate. The server owns the mode + the availability
             # flag, so it owns the next-mode computation.
-            new_mode = None
-            if self.tool_context is not None:
-                from src.permissions.cycle import get_next_permission_mode
+            if self.tool_context is None:
+                self._reply(request_id, {"ok": False, "error": "session not ready"})
+                return
+            from src.permissions.cycle import get_next_permission_mode
 
-                pc = self.tool_context.permission_context
-                new_mode = get_next_permission_mode(pc)
-                _set_mode(self.tool_context, new_mode)
-                _dispatch_app_state(self, permission_mode=new_mode)
+            pc = self.tool_context.permission_context
+            new_mode = get_next_permission_mode(pc)
+            _set_mode(self.tool_context, new_mode)
+            _dispatch_app_state(self, permission_mode=new_mode)
             self._reply(request_id, {"ok": True, "mode": new_mode})
             return
         if subtype == "set_model":
@@ -2205,7 +2252,18 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
             except Exception:  # noqa: BLE001 — store failure must not break startup
                 logger.debug("[agent-server] app-state store init failed",
                              exc_info=True)
-        bypass = mode == "bypassPermissions"
+        # Availability = launched IN bypass mode, OR the launch boundary
+        # resolved it available (flags and/or trusted settings) and forwarded
+        # it via cfg.is_bypass_available. We do NOT read settings ambiently
+        # here: on the multi-session --http transport that would let the server
+        # host's own settings unlock bypass for every client session,
+        # regardless of the client's cwd. Availability is decided once per
+        # launch (src/cli.py _resolve_permission_state,
+        # tui_launcher.run_tui_launcher, and agent_server_cli for the
+        # single-session stdio case) and carried in. Availability alone does
+        # NOT enter bypass; it only unlocks it for Shift+Tab /
+        # set_permission_mode. Mirrors permissionSetup.ts:941-945.
+        bypass = mode == "bypassPermissions" or cfg.is_bypass_available
         perm_setup = setup_permissions(
             cwd=str(workspace_root),
             mode=mode,  # type: ignore[arg-type]

--- a/tests/server/test_bypass_permissions_wiring.py
+++ b/tests/server/test_bypass_permissions_wiring.py
@@ -1,0 +1,261 @@
+"""--dangerously-skip-permissions wiring through the TUI/agent-server path.
+
+The headless path was already covered (tests/test_dangerous_skip_permissions.py);
+these tests pin the interactive chain that used to drop the flags:
+
+- `clawcodex agent-server --dangerously-skip-permissions` forces
+  bypassPermissions mode; `--allow-dangerously-skip-permissions` makes bypass
+  AVAILABLE without entering it (AgentServerConfig.is_bypass_available).
+- `_build_runtime` derives permission-context availability from
+  mode-implies-available OR the forwarded `cfg.is_bypass_available` — it does
+  NOT read settings ambiently (availability is resolved once per launch and
+  carried in). Mirrors typescript/src/utils/permissions/permissionSetup.ts:941.
+- The `set_permission_mode` control validates the mode and gates
+  bypassPermissions on availability — the same guard the Shift+Tab cycle
+  enforces (mirrors the onSetPermissionMode contract in
+  typescript/src/bridge/replBridge.ts:182-193).
+- `has_allow_bypass_permissions_mode()` reads the user + local settings
+  tiers only, EXCLUDING the committable project tier (security parity with
+  hasAllowBypassPermissionsMode in typescript/.../settings.ts:897).
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import asyncio
+
+import pytest
+
+from src.bootstrap.state import reset_state_for_tests
+from src.services.startup_gates import reset_session_trust_for_testing
+
+pytestmark = pytest.mark.integration
+
+
+def _reset_all() -> None:
+    reset_state_for_tests()
+    reset_session_trust_for_testing()
+    from src.state.app_state import set_active_provider_supplier
+
+    set_active_provider_supplier(None)
+
+
+class _SessionHarness(unittest.TestCase):
+    """Real `_AgentSession` runtime against the keyless `ollama` provider with
+    global config redirected to a temp dir (same shape as the ch03 harness)."""
+
+    def setUp(self) -> None:
+        _reset_all()
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        self.ws = root / "ws"
+        self.ws.mkdir()
+        self.config_dir = root / "config-home"
+        self.config_dir.mkdir()
+        global_path = self.config_dir / "config.json"
+        global_path.write_text(json.dumps({}), encoding="utf-8")
+        self._patches = [
+            patch("src.config.get_global_config_path", return_value=global_path),
+            patch("src.config.GLOBAL_CONFIG_DIR", str(self.config_dir)),
+        ]
+        for p in self._patches:
+            p.start()
+        from src.settings.settings import invalidate_settings_cache
+
+        invalidate_settings_cache()
+
+    def tearDown(self) -> None:
+        for p in self._patches:
+            p.stop()
+        from src.settings.settings import invalidate_settings_cache
+
+        invalidate_settings_cache()
+        _reset_all()
+        self._tmp.cleanup()
+
+    def _build(self, **cfg_kwargs):
+        from src.server.agent_server import (
+            AgentServerConfig,
+            _AgentSession,
+            _build_runtime,
+        )
+
+        sess = _AgentSession(
+            session_id="s-bypass",
+            cwd=str(self.ws),
+            config=AgentServerConfig(
+                provider_name="ollama",
+                single_session=True,
+                **cfg_kwargs,
+            ),
+            loop=MagicMock(),
+            out_queue=MagicMock(),
+        )
+        _build_runtime(sess, None)
+        self.assertIsNone(sess.init_error, f"runtime build failed: {sess.init_error}")
+        return sess
+
+    @staticmethod
+    def _control_replies(sess) -> list[dict]:
+        """Control responses captured through the mocked loop/_emit path."""
+        out = []
+        for call in sess.loop.call_soon_threadsafe.call_args_list:
+            args = call.args
+            if (
+                len(args) == 2
+                and isinstance(args[1], dict)
+                and args[1].get("type") == "control_response"
+            ):
+                out.append(args[1]["response"]["response"])
+        return out
+
+    def _set_mode(self, sess, mode) -> dict:
+        asyncio.run(sess._handle_control_request({
+            "request_id": "r-mode",
+            "request": {"subtype": "set_permission_mode", "mode": mode},
+        }))
+        replies = self._control_replies(sess)
+        self.assertTrue(replies, "set_permission_mode sent no control_response")
+        return replies[-1]
+
+
+class TestBuildRuntimeAvailability(_SessionHarness):
+    def test_default_session_has_no_bypass_availability(self) -> None:
+        sess = self._build()
+        pc = sess.tool_context.permission_context
+        self.assertEqual(pc.mode, "default")
+        self.assertFalse(pc.is_bypass_permissions_mode_available)
+
+    def test_launching_in_bypass_mode_implies_availability(self) -> None:
+        sess = self._build(permission_mode="bypassPermissions")
+        pc = sess.tool_context.permission_context
+        self.assertEqual(pc.mode, "bypassPermissions")
+        self.assertTrue(pc.is_bypass_permissions_mode_available)
+
+    def test_allow_flag_grants_availability_without_entering_bypass(self) -> None:
+        sess = self._build(is_bypass_available=True)
+        pc = sess.tool_context.permission_context
+        self.assertEqual(pc.mode, "default")
+        self.assertTrue(pc.is_bypass_permissions_mode_available)
+
+    def test_shift_tab_cycle_reaches_bypass_only_when_available(self) -> None:
+        from src.permissions.cycle import get_next_permission_mode
+
+        available = self._build(is_bypass_available=True)
+        available.tool_context.permission_context.mode = "plan"
+        self.assertEqual(
+            get_next_permission_mode(available.tool_context.permission_context),
+            "bypassPermissions",
+        )
+
+        unavailable = self._build()
+        unavailable.tool_context.permission_context.mode = "plan"
+        self.assertEqual(
+            get_next_permission_mode(unavailable.tool_context.permission_context),
+            "default",
+        )
+
+
+class TestSetPermissionModeGate(_SessionHarness):
+    def test_rejects_bypass_when_unavailable(self) -> None:
+        sess = self._build()
+        reply = self._set_mode(sess, "bypassPermissions")
+        self.assertIs(reply.get("ok"), False)
+        self.assertIn("not available", reply.get("error", ""))
+        self.assertEqual(sess.tool_context.permission_context.mode, "default")
+
+    def test_allows_bypass_when_available(self) -> None:
+        sess = self._build(is_bypass_available=True)
+        reply = self._set_mode(sess, "bypassPermissions")
+        self.assertIs(reply.get("ok"), True)
+        self.assertEqual(reply.get("mode"), "bypassPermissions")
+        self.assertEqual(
+            sess.tool_context.permission_context.mode, "bypassPermissions",
+        )
+
+    def test_rejects_unknown_mode_string(self) -> None:
+        sess = self._build()
+        reply = self._set_mode(sess, "banana")
+        self.assertIs(reply.get("ok"), False)
+        self.assertEqual(sess.tool_context.permission_context.mode, "default")
+
+    def test_rejects_bubble_as_top_level_mode(self) -> None:
+        sess = self._build()
+        reply = self._set_mode(sess, "bubble")
+        self.assertIs(reply.get("ok"), False)
+        self.assertEqual(sess.tool_context.permission_context.mode, "default")
+
+    def test_plain_modes_still_settable(self) -> None:
+        sess = self._build()
+        reply = self._set_mode(sess, "acceptEdits")
+        self.assertIs(reply.get("ok"), True)
+        self.assertEqual(sess.tool_context.permission_context.mode, "acceptEdits")
+
+
+class TestAgentServerCliFlags(unittest.TestCase):
+    """The subcommand flags land in AgentServerConfig before serving."""
+
+    def _run(self, argv: list[str], *, settings_bypass: bool = False):
+        import src.entrypoints.agent_server_cli as cli
+
+        captured: dict = {}
+
+        async def fake_serve(args, workspace, agent_config):
+            captured["cfg"] = agent_config
+            return 0
+
+        async def fake_serve_stdio(workspace, agent_config):
+            captured["cfg"] = agent_config
+            return 0
+
+        with patch.object(cli, "_serve", fake_serve), \
+                patch.object(cli, "_serve_stdio", fake_serve_stdio), \
+                patch(
+                    "src.permissions.modes.has_allow_bypass_permissions_mode",
+                    return_value=settings_bypass,
+                ):
+            rc = cli.run_agent_server_subcommand(argv)
+        self.assertEqual(rc, 0)
+        return captured["cfg"]
+
+    def test_dsp_flag_forces_bypass_mode_and_availability(self) -> None:
+        cfg = self._run(["--dangerously-skip-permissions"])
+        self.assertEqual(cfg.permission_mode, "bypassPermissions")
+        self.assertTrue(cfg.is_bypass_available)
+
+    def test_dsp_flag_wins_over_permission_mode(self) -> None:
+        cfg = self._run([
+            "--permission-mode", "plan", "--dangerously-skip-permissions",
+        ])
+        self.assertEqual(cfg.permission_mode, "bypassPermissions")
+
+    def test_allow_flag_grants_availability_only(self) -> None:
+        cfg = self._run(["--allow-dangerously-skip-permissions"])
+        self.assertEqual(cfg.permission_mode, "default")
+        self.assertTrue(cfg.is_bypass_available)
+
+    def test_no_flags_no_availability(self) -> None:
+        cfg = self._run([])
+        self.assertEqual(cfg.permission_mode, "default")
+        self.assertFalse(cfg.is_bypass_available)
+
+    def test_stdio_folds_in_settings_availability(self) -> None:
+        # A hand-launched single-session stdio server honors the operator's
+        # own user/local settings.allowBypassPermissionsMode.
+        cfg = self._run(["--stdio"], settings_bypass=True)
+        self.assertEqual(cfg.permission_mode, "default")
+        self.assertTrue(cfg.is_bypass_available)
+
+    def test_http_does_not_fold_in_settings_availability(self) -> None:
+        # The multi-session --http transport must NOT let the host's settings
+        # unlock bypass for every remote client session.
+        cfg = self._run([], settings_bypass=True)
+        self.assertFalse(cfg.is_bypass_available)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/server/test_tui_launcher.py
+++ b/tests/server/test_tui_launcher.py
@@ -41,6 +41,65 @@ def test_agent_server_cmd_invokes_module():
     assert cmd[0] == sys.executable
     assert cmd[1:3] == ["-m", "src.entrypoints.agent_server_cli"]
     assert "--permission-mode" in cmd
+    # No bypass flags → availability must not leak into the backend cmd.
+    assert "--allow-dangerously-skip-permissions" not in cmd
+
+
+def test_agent_server_cmd_forwards_bypass_availability():
+    """Resolved availability rides to the backend as --allow-dangerously-…,
+    so Shift+Tab / /mode can reach bypassPermissions at runtime."""
+    class _Args:
+        permission_mode = "bypassPermissions"
+        is_bypass_available = True
+        provider = None
+        model = None
+
+    cmd = _agent_server_cmd(_Args())
+    assert "--allow-dangerously-skip-permissions" in cmd
+    i = cmd.index("--permission-mode")
+    assert cmd[i + 1] == "bypassPermissions"
+
+
+def _flag_probe_stub(tmp_path, monkeypatch, expect: str) -> None:
+    """Point CLAWCODEX_TUI_CMD at a stub that exits 0 iff the launcher's
+    CLAWCODEX_AGENT_SERVER_CMD contains `expect`.
+
+    `expect` pins the exact `--permission-mode <mode> [--allow-…]` ordering
+    that `_agent_server_cmd` emits — intentional, so a reorder of that builder
+    surfaces here rather than silently changing the spawned backend cmd."""
+    child = tmp_path / "fake_tui.py"
+    child.write_text(textwrap.dedent(
+        f"""
+        import os, sys
+        cmd = os.environ.get("CLAWCODEX_AGENT_SERVER_CMD", "")
+        sys.exit(0 if {expect!r} in cmd else 4)
+        """
+    ))
+    monkeypatch.setenv("CLAWCODEX_TUI_CMD", f"{sys.executable} {child}")
+
+
+def test_launcher_dsp_flag_starts_backend_in_bypass(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _flag_probe_stub(
+        tmp_path, monkeypatch,
+        "--permission-mode bypassPermissions",
+    )
+    rc = run_tui_launcher(
+        ["--workspace", str(tmp_path), "--dangerously-skip-permissions"],
+    )
+    assert rc == 0, "expected --permission-mode bypassPermissions in backend cmd"
+
+
+def test_launcher_allow_flag_forwards_availability_without_bypass(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _flag_probe_stub(
+        tmp_path, monkeypatch,
+        "--permission-mode default --allow-dangerously-skip-permissions",
+    )
+    rc = run_tui_launcher(
+        ["--workspace", str(tmp_path), "--allow-dangerously-skip-permissions"],
+    )
+    assert rc == 0, "expected availability flag (and default mode) in backend cmd"
 
 
 def test_launcher_hands_client_a_runnable_backend_cmd(tmp_path, monkeypatch):

--- a/tests/test_dangerous_skip_permissions.py
+++ b/tests/test_dangerous_skip_permissions.py
@@ -138,6 +138,61 @@ def test_has_allow_bypass_permissions_mode_default_false():
     assert isinstance(result, bool)
 
 
+def _write_perms_config(path: Path, enabled: bool) -> None:
+    import json
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"settings": {"permissions": {"allowBypassPermissionsMode": enabled}}}),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def _tiered_configs(tmp_path, monkeypatch):
+    """Patch the three config-tier paths to hermetic temp files and return them.
+
+    Sidesteps git-root resolution + the real user config so the reader's tier
+    selection is observable in isolation.
+    """
+    global_path = tmp_path / "global.json"
+    project_path = tmp_path / "project.json"
+    local_path = tmp_path / "local.json"
+    monkeypatch.setattr("src.config.get_global_config_path", lambda: global_path)
+    monkeypatch.setattr(
+        "src.config.get_project_config_path", lambda cwd=None: project_path,
+    )
+    monkeypatch.setattr(
+        "src.config.get_local_config_path", lambda cwd=None: local_path,
+    )
+    return global_path, project_path, local_path
+
+
+def test_has_allow_bypass_reads_global_tier(_tiered_configs):
+    global_path, _, _ = _tiered_configs
+    _write_perms_config(global_path, True)
+    assert has_allow_bypass_permissions_mode() is True
+
+
+def test_has_allow_bypass_reads_local_tier(_tiered_configs):
+    _, _, local_path = _tiered_configs
+    _write_perms_config(local_path, True)
+    assert has_allow_bypass_permissions_mode() is True
+
+
+def test_has_allow_bypass_ignores_project_tier(_tiered_configs):
+    # SECURITY: the committable <git-root>/.claude/config.json must NOT be able
+    # to auto-enable bypass availability (parity with the TS projectSettings
+    # exclusion). Only the project tier is set here.
+    _, project_path, _ = _tiered_configs
+    _write_perms_config(project_path, True)
+    assert has_allow_bypass_permissions_mode() is False
+
+
+def test_has_allow_bypass_false_when_all_tiers_absent(_tiered_configs):
+    assert has_allow_bypass_permissions_mode() is False
+
+
 # ---------------------------------------------------------------------------
 # Headless wiring
 

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -222,6 +222,45 @@ describe('GatewayClient NDJSON adapter', () => {
     await expect(p).resolves.toEqual({ output: 'deep-research  [running]  (run: wf_1)', type: 'exec' })
   })
 
+  it('confirms the applied mode from the server reply on /mode', async () => {
+    const p = gw.request('slash.exec', { command: 'mode acceptEdits' })
+    await replyToControl('set_permission_mode', { mode: 'acceptEdits', ok: true })
+    await expect(p).resolves.toEqual({ output: 'Permission mode: acceptEdits.', type: 'exec' })
+  })
+
+  it('treats bare /mode as a no-op query, not an empty set', async () => {
+    // No arg → must NOT send an empty mode the server would reject; report
+    // unchanged instead (the pre-hardening behavior).
+    const p = gw.request('slash.exec', { command: 'mode' })
+    const r: any = await p
+    expect(r).toEqual({ output: 'Permission mode: (unchanged).', type: 'exec' })
+    // And it must not have hit the backend at all.
+    expect(stdinFrames().some(f => f.request?.subtype === 'set_permission_mode')).toBe(false)
+  })
+
+  it('reflects the server rejection through config.set permission_mode', async () => {
+    // The settings-panel write path must not report success when the server
+    // refuses (bypassPermissions gated on availability).
+    const p = gw.request('config.set', { key: 'permission_mode', value: 'bypassPermissions' })
+    await replyToControl('set_permission_mode', { error: 'not available', ok: false })
+    await expect(p).resolves.toEqual({ ok: false })
+  })
+
+  it('surfaces the server rejection when /mode bypassPermissions is unavailable', async () => {
+    // The server gates bypassPermissions on availability (same guard as the
+    // Shift+Tab cycle) — the client must show the refusal, not pretend the
+    // mode changed.
+    const p = gw.request('slash.exec', { command: 'mode bypassPermissions' })
+    await replyToControl('set_permission_mode', {
+      error: 'bypassPermissions is not available in this session',
+      ok: false
+    })
+    const r: any = await p
+    expect(r.type).toBe('exec')
+    expect(r.output).toContain('not available')
+    expect(r.output).not.toContain('Permission mode:')
+  })
+
   it('dispatches an unknown slash as a backend workflow command (send)', async () => {
     const p = gw.request('slash.exec', { command: 'deep-research what is love' })
     await replyToControl('workflow_command', {

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -417,8 +417,15 @@ export class GatewayClient extends EventEmitter {
         const key = String(p.key ?? '')
         const value = p.value
 
+        if (key === 'permission_mode') {
+          // The server can reject this (bypassPermissions is gated on
+          // availability); reflect its verdict so a settings-panel write
+          // doesn't falsely report success while the server refused.
+          return this.controlQuery('set_permission_mode', { mode: value })
+            .then(r => ({ ok: (r as any)?.ok !== false } as T))
+        }
+
         if (key === 'model') {this.sendControl('set_model', { model: value })}
-        else if (key === 'permission_mode') {this.sendControl('set_permission_mode', { mode: value })}
         else if (key === 'effort' || key === 'reasoning') {this.sendControl('set_effort', { effort: value })}
         else if (key === 'provider') {this.sendControl('set_provider', { provider: value })}
         else if (key === 'thinking') {this.sendControl('set_thinking', { action: value })}
@@ -632,14 +639,26 @@ export class GatewayClient extends EventEmitter {
       }
 
       case 'mode': {
-        const r = (await this.controlQuery('set_permission_mode', { mode: arg })) as any
-        const mode = typeof r?.mode === 'string' ? r.mode : arg
+        // Bare `/mode` is a no-op query, not a set — don't send an empty mode
+        // (the server would reject it as invalid). Matches the prior behavior.
+        if (arg == null || arg.trim() === '') {return out('Permission mode: (unchanged).')}
+
+        // The server validates the mode and gates bypassPermissions on
+        // availability (same guard as the Shift+Tab cycle) — surface its
+        // verdict instead of echoing the arg as if it took effect.
+        const r = (await this.controlQuery('set_permission_mode', { mode: arg.trim() })) as any
+
+        if (r && r.ok === false) {return out(`mode: ${r.error ?? 'invalid mode'}`)}
+
+        // Only badge the mode the server actually confirmed — a rejected set
+        // must not flip the composer's permission-mode indicator.
+        const mode = typeof r?.mode === 'string' ? r.mode : arg.trim()
 
         if (mode) {
           this.publish({ payload: { mode: String(mode) }, type: 'permission.mode' })
         }
 
-        return out(`Permission mode: ${mode ?? '(unchanged)'}.`)
+        return out(`Permission mode: ${mode}.`)
       }
 
       case 'model':


### PR DESCRIPTION
## Summary

The main `clawcodex --dangerously-skip-permissions` entry and the headless (`-p`) path already worked, but the interactive Ink-TUI chain dropped the flag family, and the settings-driven form of the feature was dead code. This closes three interactive-path gaps plus a latent settings-reader bug the critic surfaced.

- **`clawcodex tui` subcommand** now accepts `--dangerously-skip-permissions` / `--allow-dangerously-skip-permissions`, running the same root-safety gate and `initial_permission_mode_from_cli` resolution as the default entry.
- **Bypass availability is forwarded** from the launch boundary to the spawned agent-server (`launch_ink_tui` → `_agent_server_cmd` → `AgentServerConfig.is_bypass_available`), so Shift+Tab / `/mode` can reach `bypassPermissions` even when the session didn't start in it. Mirrors `permissionSetup.ts:941`.
- **`set_permission_mode` control hardened**: validates the mode (∈ `PERMISSION_MODES`, not `bubble`) and gates `bypassPermissions` on availability — the same guard Shift+Tab uses. Previously *any* string was accepted, so `/mode bypassPermissions` silently disabled the whole permission gate in any session. Client surfaces the accept/reject verdict; bare `/mode` is a no-op; `config.set` reflects a rejection. Mirrors the `onSetPermissionMode` contract in `replBridge.ts:182-193`.
- **Dead settings reader fixed**: `has_allow_bypass_permissions_mode()` read `settings.extra["permissions"]`, but `permissions` is a first-class `SettingsSchema` field so that key is never present → always `False`. Rewrote it to read the raw global+local config tiers at `settings.permissions.allowBypassPermissionsMode`, **excluding the committable project tier** (security parity with `settings.ts:897`). The ambient per-session read was removed from `_build_runtime` so a multi-session `--http` host's settings can't unlock bypass for remote clients; availability is resolved once per launch and carried in, with `agent_server_cli` folding settings only on the single-session `--stdio` transport.

## Testing

- **Python**: tier-segmentation (global/local grant, project excluded), stdio-vs-http availability, and `set_permission_mode` gating. 273 passed across permission/server/dispatch suites.
- **Client (vitest)**: bare `/mode` no-op (asserts no backend frame sent) + `config.set` verdict reflection. 31 passed.
- **Live pyte e2e** (real backend, real TTY): main flag bypasses the approval box; default mode prompts; `/mode bypassPermissions` refused in a plain session; `--allow-…` + `/mode` switch runs tools unprompted; `clawcodex tui --dangerously-skip-permissions` bypasses.
- Critic-reviewed to APPROVE (findings independently re-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)