### PR TITLE
fix(tui): make backslash+Enter multi-line input fully editable

### DIFF
--- a/ui-tui/scripts/profile-tui.mjs
+++ b/ui-tui/scripts/profile-tui.mjs
@@ -72,7 +72,7 @@ const scrollRef = { current: {
 
 const baseProps = streamingText => ({
   actions: { answerApproval: noop, answerClarify: noop, answerSecret: noop, answerSudo: noop, onModelSelect: noop, resumeById: noop, setStickyPrompt: noop },
-  composer: { cols: 120, compIdx: 0, completions: [], empty: false, handleTextPaste: () => null, input: '', inputBuf: [], pagerPageSize: 10, queueEditIdx: null, queuedDisplay: [], submit: noop, updateInput: noop },
+  composer: { cols: 120, compIdx: 0, completions: [], empty: false, handleTextPaste: () => null, input: '', pagerPageSize: 10, queueEditIdx: null, queuedDisplay: [], submit: noop, updateInput: noop },
   mouseTracking: false,
   progress: {
     activity: [], outcome: '', reasoning: streamingText, reasoningActive: true, reasoningStreaming: true,

--- a/ui-tui/src/__tests__/textInputBackslashReturn.test.ts
+++ b/ui-tui/src/__tests__/textInputBackslashReturn.test.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import { describe, expect, it } from 'vitest'
 
 import { applyBackslashReturn, lineNav } from '../components/textInput.js'
@@ -46,5 +50,32 @@ describe('multi-line value produced by backslash+Enter stays editable', () => {
 
     expect(value[startOfLine2 - 1]).toBe('\n')
     expect(merged).toBe('line1line2')
+  })
+})
+
+// The Enter handler's dispatch order lives inside useInput and cannot be
+// exercised without mounting the renderer + stdin, so — same convention as
+// textInputCursorSourceOfTruth.test.ts — pin the contract at the source
+// level instead.
+const TEXT_INPUT_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'components', 'textInput.tsx')
+const source = readFileSync(TEXT_INPUT_PATH, 'utf8')
+
+describe('k.return handler contract (source pin)', () => {
+  it('gates the continuation on the multiline prop, so plain TextInputs still submit trailing backslashes', () => {
+    expect(source).toMatch(/multiline\s*\?\s*applyBackslashReturn\(/)
+  })
+
+  it('checks continuation BEFORE the modifier-chord newline branch, mirroring original useTextInput.handleEnter', () => {
+    const returnHandler = source.slice(source.indexOf('if (k.return)'))
+    const continuationAt = returnHandler.indexOf('applyBackslashReturn(')
+    const chordBranchAt = returnHandler.indexOf('k.shift || k.ctrl')
+
+    expect(continuationAt).toBeGreaterThan(-1)
+    expect(chordBranchAt).toBeGreaterThan(-1)
+    expect(continuationAt).toBeLessThan(chordBranchAt)
+  })
+
+  it('consumes the continuation (early return) instead of falling through to submit', () => {
+    expect(source).toMatch(/if\s*\(continuation\)\s*\{\s*commit\(continuation\.value,\s*continuation\.cursor\)\s*return\s*\}/)
   })
 })

--- a/ui-tui/src/__tests__/textInputBackslashReturn.test.ts
+++ b/ui-tui/src/__tests__/textInputBackslashReturn.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { applyBackslashReturn, lineNav } from '../components/textInput.js'
+
+describe('applyBackslashReturn', () => {
+  it('replaces the backslash before the caret with a newline, caret staying after it', () => {
+    expect(applyBackslashReturn('hello\\', 6)).toEqual({ cursor: 6, value: 'hello\n' })
+  })
+
+  it('applies mid-string when the caret sits right after a backslash', () => {
+    expect(applyBackslashReturn('ab\\cd', 3)).toEqual({ cursor: 3, value: 'ab\ncd' })
+  })
+
+  it('does not apply without a backslash directly before the caret', () => {
+    expect(applyBackslashReturn('hello', 5)).toBeNull()
+    expect(applyBackslashReturn('a\\b', 3)).toBeNull()
+    expect(applyBackslashReturn('', 0)).toBeNull()
+  })
+
+  it('does not apply when the caret is at the start', () => {
+    expect(applyBackslashReturn('\\rest', 0)).toBeNull()
+  })
+})
+
+describe('multi-line value produced by backslash+Enter stays editable', () => {
+  it('up-arrow reaches the first line (regression: read-only continuation rows)', () => {
+    // 'line1\' + Enter, then 'line2' typed on the new line.
+    const cont = applyBackslashReturn('line1\\', 6)!
+    const value = cont.value + 'line2'
+    const cursorAtEnd = value.length
+
+    // lineNav must cross the boundary that backslash+Enter created.
+    expect(lineNav(value, cursorAtEnd, -1)).toBe(5)
+    // ...and refuse only on the real first line, where history takes over.
+    expect(lineNav(value, 0, -1)).toBeNull()
+  })
+
+  it('backspace at the start of line 2 can merge lines (newline is in-buffer)', () => {
+    const cont = applyBackslashReturn('line1\\', 6)!
+    const value = cont.value + 'line2'
+    const startOfLine2 = value.indexOf('\n') + 1
+
+    // The newline is an ordinary in-buffer character; deleting it merges the
+    // lines. Under the old inputBuf model there was nothing to delete here.
+    const merged = value.slice(0, startOfLine2 - 1) + value.slice(startOfLine2)
+
+    expect(value[startOfLine2 - 1]).toBe('\n')
+    expect(merged).toBe('line1line2')
+  })
+})

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -216,7 +216,6 @@ export interface ComposerActions {
   setCompIdx: StateSetter<number>
   setHistoryIdx: StateSetter<null | number>
   setInput: StateSetter<string>
-  setInputBuf: StateSetter<string[]>
   setPasteSnips: StateSetter<PasteSnippet[]>
   setQueueEdit: (index: null | number) => void
   syncQueue: () => void
@@ -236,7 +235,6 @@ export interface ComposerState {
   completions: CompletionItem[]
   historyIdx: null | number
   input: string
-  inputBuf: string[]
   pasteSnips: PasteSnippet[]
   queueEditIdx: null | number
   queuedDisplay: string[]
@@ -401,7 +399,6 @@ export interface AppLayoutComposerProps {
   empty: boolean
   handleTextPaste: (event: PasteEvent) => MaybePromise<ComposerPasteResult | null>
   input: string
-  inputBuf: string[]
   pagerPageSize: number
   queueEditIdx: null | number
   queuedDisplay: string[]

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -104,7 +104,6 @@ export function useComposerState({
   submitRef
 }: UseComposerStateOptions): UseComposerStateResult {
   const [input, setInput] = useState('')
-  const [inputBuf, setInputBuf] = useState<string[]>([])
   const [pasteSnips, setPasteSnips] = useState<PasteSnippet[]>([])
   const isBlocked = useStore($isBlocked)
   const { querier } = useStdin() as { querier: Parameters<typeof readOsc52Clipboard>[0] }
@@ -127,7 +126,6 @@ export function useComposerState({
 
   const clearIn = useCallback(() => {
     setInput('')
-    setInputBuf([])
     setPasteSnips([])
     setQueueEdit(null)
     setHistoryIdx(null)
@@ -272,7 +270,7 @@ export function useComposerState({
     const file = join(dir, 'prompt.md')
     const [cmd, ...args] = resolveEditor()
 
-    writeFileSync(file, [...inputBuf, input].join('\n'))
+    writeFileSync(file, input)
 
     let exitCode: null | number = null
 
@@ -292,12 +290,11 @@ export function useComposerState({
       }
 
       setInput('')
-      setInputBuf([])
       submitRef.current(text)
     } finally {
       rmSync(dir, { force: true, recursive: true })
     }
-  }, [input, inputBuf, submitRef])
+  }, [input, submitRef])
 
   const actions = useMemo(
     () => ({
@@ -312,7 +309,6 @@ export function useComposerState({
       setCompIdx,
       setHistoryIdx,
       setInput,
-      setInputBuf,
       setPasteSnips,
       setQueueEdit,
       syncQueue
@@ -351,12 +347,11 @@ export function useComposerState({
       completions,
       historyIdx,
       input,
-      inputBuf,
       pasteSnips,
       queueEditIdx,
       queuedDisplay
     }),
-    [compIdx, compReplace, completions, historyIdx, input, inputBuf, pasteSnips, queueEditIdx, queuedDisplay]
+    [compIdx, compReplace, completions, historyIdx, input, pasteSnips, queueEditIdx, queuedDisplay]
   )
 
   return {

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -456,7 +456,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return clearSelection()
     }
 
-    if (key.upArrow && !cState.inputBuf.length) {
+    if (key.upArrow) {
       const inputSel = getInputSelection()
       const cursor = inputSel && inputSel.start === inputSel.end ? inputSel.start : null
 
@@ -470,7 +470,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       }
     }
 
-    if (key.downArrow && !cState.inputBuf.length) {
+    if (key.downArrow) {
       const inputSel = getInputSelection()
       const cursor = inputSel && inputSel.start === inputSel.end ? inputSel.start : null
       const noLineBelow = !cState.input || (cursor !== null && cState.input.indexOf('\n', cursor) < 0)
@@ -522,7 +522,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
         })
       }
 
-      if (cState.input || cState.inputBuf.length) {
+      if (cState.input) {
         return cActions.clearIn()
       }
 

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -1071,7 +1071,6 @@ export function useMainApp(gw: GatewayClient) {
       empty,
       handleTextPaste: composerActions.handleTextPaste,
       input: composerState.input,
-      inputBuf: composerState.inputBuf,
       pagerPageSize,
       queueEditIdx: composerState.queueEditIdx,
       queuedDisplay: composerState.queuedDisplay,

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -61,7 +61,7 @@ export function useSubmission(opts: UseSubmissionOptions) {
       typingIdleTimer.current = null
     }
 
-    if (!composerState.input && !composerState.inputBuf.length) {
+    if (!composerState.input) {
       turnController.relaxStreaming()
 
       return
@@ -82,7 +82,7 @@ export function useSubmission(opts: UseSubmissionOptions) {
         typingIdleTimer.current = null
       }
     }
-  }, [composerState.input, composerState.inputBuf])
+  }, [composerState.input])
 
   const send = useCallback(
     (text: string, showUserMessage = true) => {
@@ -361,7 +361,7 @@ export function useSubmission(opts: UseSubmissionOptions) {
         }
       }
 
-      if (!value.trim() && !composerState.inputBuf.length) {
+      if (!value.trim()) {
         const live = getUiState()
         const now = Date.now()
         const doubleTap = now - lastEmptyAt.current < DOUBLE_ENTER_MS
@@ -391,13 +391,10 @@ export function useSubmission(opts: UseSubmissionOptions) {
 
       lastEmptyAt.current = 0
 
-      if (value.endsWith('\\')) {
-        composerActions.setInputBuf(prev => [...prev, value.slice(0, -1)])
-
-        return composerActions.setInput('')
-      }
-
-      dispatchSubmission([...composerState.inputBuf, value].join('\n'))
+      // Backslash line continuation is handled inside TextInput (multiline
+      // prop): `\` + Enter becomes a real newline in the editable buffer, so
+      // the value that reaches submit is already the full multi-line text.
+      dispatchSubmission(value)
     },
     [appendMessage, composerActions, composerRefs, composerState, dispatchSubmission, gw, sys]
   )

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -188,7 +188,7 @@ const ComposerPane = memo(function ComposerPane({
 }: Pick<AppLayoutProps, 'actions' | 'composer' | 'status'>) {
   const ui = useStore($uiState)
   const isBlocked = useStore($isBlocked)
-  const sh = (composer.inputBuf[0] ?? composer.input).startsWith('!')
+  const sh = composer.input.startsWith('!')
 
   const promptText = composerPromptText(
     ui.theme.brand.prompt,
@@ -199,7 +199,6 @@ const ComposerPane = memo(function ComposerPane({
   )
 
   const promptWidth = composerPromptWidth(promptText)
-  const promptBlank = ' '.repeat(promptWidth)
   const inputColumns = stableComposerColumns(composer.cols, promptWidth, TERMUX_TUI_MODE)
   const inputHeight = inputVisualHeight(composer.input, inputColumns)
   const inputMouseRef = useRef<null | TextInputMouseApi>(null)
@@ -308,24 +307,10 @@ const ComposerPane = memo(function ComposerPane({
           pagerPageSize={composer.pagerPageSize}
         />
 
-        {composer.input === '?' && !composer.inputBuf.length && <HelpHint t={ui.theme} />}
+        {composer.input === '?' && <HelpHint t={ui.theme} />}
 
         {!isBlocked && (
           <>
-            {composer.inputBuf.map((line, i) => (
-              <Box key={i}>
-                <Box width={promptWidth}>
-                  {i === 0 ? (
-                    <PromptPrefix color={ui.theme.color.muted} promptText={promptText} width={promptWidth} />
-                  ) : (
-                    <Text color={ui.theme.color.muted}>{promptBlank}</Text>
-                  )}
-                </Box>
-
-                <Text color={ui.theme.color.text}>{line || ' '}</Text>
-              </Box>
-            ))}
-
             <Box
               onMouseDown={captureInputDrag}
               onMouseDrag={dragFromPromptRow}
@@ -336,8 +321,6 @@ const ComposerPane = memo(function ComposerPane({
               <Box width={promptWidth}>
                 {sh ? (
                   <PromptPrefix color={ui.theme.color.shellDollar} promptText={promptText} width={promptWidth} />
-                ) : composer.inputBuf.length ? (
-                  <Text color={ui.theme.color.prompt}>{promptBlank}</Text>
                 ) : (
                   <PromptPrefix
                     bold
@@ -353,6 +336,7 @@ const ComposerPane = memo(function ComposerPane({
                 <TextInput
                   columns={inputColumns}
                   mouseApiRef={inputMouseRef}
+                  multiline
                   onChange={composer.updateInput}
                   onPaste={composer.handleTextPaste}
                   onSubmit={composer.submit}
@@ -374,7 +358,7 @@ const ComposerPane = memo(function ComposerPane({
 
       <ComposerFooter
         busy={ui.busy}
-        inputEmpty={!composer.input && !composer.inputBuf.length}
+        inputEmpty={!composer.input}
         mode={ui.permissionMode}
         sh={sh}
         t={ui.theme}

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -125,6 +125,22 @@ export function applyPrintableInsert(
 
 export const shouldRouteMultiCharInputAsPaste = (text: string): boolean => text.includes('\n')
 
+/**
+ * Backslash line continuation: when Enter is pressed with `\` immediately
+ * before the caret, the backslash is replaced by a real newline in the same
+ * buffer — the value stays one editable multi-line string, so cursor keys
+ * and backspace cross the line boundary. Mirrors the original
+ * useTextInput.handleEnter (cursor.backspace().insert('\n')).
+ * Returns null when the rule does not apply (caller submits instead).
+ */
+export function applyBackslashReturn(value: string, cursor: number): null | TextInsertResult {
+  if (cursor <= 0 || value[cursor - 1] !== '\\') {
+    return null
+  }
+
+  return { cursor, value: value.slice(0, cursor - 1) + '\n' + value.slice(cursor) }
+}
+
 export function shouldPreserveCtrlJNewline(env: MinimalEnv = process.env): boolean {
   if (env.WT_SESSION) {
     return true
@@ -463,6 +479,7 @@ export function TextInput({
   onSubmit,
   mask,
   mouseApiRef,
+  multiline = false,
   voiceRecordKey = DEFAULT_VOICE_RECORD_KEY,
   placeholder = '',
   focus = true
@@ -990,13 +1007,25 @@ export function TextInput({
       if (k.return) {
         flushKeyBurst()
 
+        // Checked before the modifier chords, mirroring the original
+        // useTextInput.handleEnter order.
+        const vNow = vRef.current
+        const cNow = curRef.current
+        const continuation = multiline ? applyBackslashReturn(vNow, cNow) : null
+
+        if (continuation) {
+          commit(continuation.value, continuation.cursor)
+
+          return
+        }
+
         const sequence = (event.keypress as { sequence?: string }).sequence
         const preserveBareLineFeed = shouldPreserveCtrlJNewline() && sequence === '\n'
 
         if (k.shift || k.ctrl || preserveBareLineFeed || (isMac ? isActionMod(k) : k.meta)) {
-          commit(ins(vRef.current, curRef.current, '\n'), curRef.current + 1)
+          commit(ins(vNow, cNow, '\n'), cNow + 1)
         } else {
-          cbSubmit.current?.(vRef.current)
+          cbSubmit.current?.(vNow)
         }
 
         return
@@ -1303,6 +1332,8 @@ interface TextInputProps {
   focus?: boolean
   mask?: string
   mouseApiRef?: MutableRefObject<null | TextInputMouseApi>
+  /** Allow multi-line editing: `\` + Enter inserts a newline instead of submitting. */
+  multiline?: boolean
   onChange: (v: string) => void
   onPaste?: (
     e: PasteEvent


### PR DESCRIPTION
## Problem

Backslash+Enter previously pushed the committed line into a read-only `inputBuf: string[]` outside the TextInput. The cursor could never re-enter those lines: up-arrow was dead, backspace at the start of the next line could not merge lines, and the composer believed the input was empty (resurrecting the placeholder). This was the deferred "F1-newline" item from the TUI UX parity push.

## Fix

Port the original `useTextInput.handleEnter` behavior: TextInput gains a `multiline` prop (only the main composer sets it), and `\` immediately before the caret becomes a real `\n` in the same buffer (`applyBackslashReturn`, mirroring the original's `cursor.backspace().insert('\n')`). The value stays one editable multi-line string, so `lineNav` and backspace cross line boundaries with no extra code. All `inputBuf` plumbing is removed (state, interfaces, read-only row rendering, submit-side join, external-editor path, profiling mock).

## Intentional behavior notes (parity, not regressions)

- **Completion menu vs continuation:** Enter with `\` before the caret now inserts the newline even while the completions dropdown is open. The old port let completion-accept win; the original checks continuation first (suggestion acceptance lives in PromptInput's onSubmit, which handleEnter never reaches on the backslash branch), so this is a deliberate move toward parity.
- **Whitespace-only buffer:** Enter on a value like `"\n"` still does nothing (falls into the empty-submit branch without clearing). Matches original PromptInput (`inputParam.trim() === '' → return`).
- Shift+Enter / Ctrl+J with `\` before the caret consumes the backslash rather than inserting a second newline — same order as the original's handleEnter.

## Tests

- `textInputBackslashReturn.test.ts`: pure-function coverage of `applyBackslashReturn` + regression tests that the produced value is line-navigable and backspace-mergeable, plus source-pin tests (same convention as `textInputCursorSourceOfTruth.test.ts`) locking the multiline gating, the continuation-before-chords ordering, and the early return.
- `tsc --noEmit` clean; full vitest at the known 9-failure environment baseline; all 12 composer/input test files pass (125 tests).
- Verified in a live PTY (pyte): backslash+Enter, up/down across lines, and backspace merge behave like original Claude Code.

Critic-reviewed: APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)