### PR TITLE
fix(perm): compound-command permission parity (split + per-sub match/suggest)

### DIFF
--- a/src/permissions/bash_suggestions.py
+++ b/src/permissions/bash_suggestions.py
@@ -145,6 +145,136 @@ def contains_unquoted_chaining(command: str) -> bool:
     return False
 
 
+# TS parity (bashPermissions.ts:98-103 MAX_SUBCOMMANDS_FOR_SECURITY_CHECK):
+# above this we refuse to split — per-sub work must stay bounded, and "refuse"
+# degrades to today's ask-every-time, never to a wider allow.
+MAX_SUBCOMMANDS: int = 50
+
+# GH#11380 parity (bashPermissions.ts:105-110): cap the per-subcommand rules
+# suggested for one compound prompt; beyond this the label degrades and saving
+# 10+ rules from a single prompt is more likely noise than intent.
+MAX_SUGGESTED_RULES_FOR_COMPOUND: int = 5
+
+
+def split_chained_command(command: str) -> list[str] | None:
+    """Split ``command`` on unquoted chaining operators (``&&``, ``||``,
+    ``;``, ``|``, ``|&``, ``&``, newline) into its sub-commands.
+
+    Port of the ESSENTIAL semantics of TS ``splitCommand``
+    (utils/bash/commands.ts:85-265) for the permission layer: the original is
+    a shell-quote-based module hardened against heredoc/continuation/comment
+    parser differentials; this port instead REFUSES (returns ``None``) on any
+    construct it cannot split with certainty:
+
+    - command substitution (``$(`` or backticks) and ANSI-C quoting (``$'`` —
+      an escaped quote inside it inverts a naive quote scanner, the same blind
+      spot :func:`contains_unquoted_chaining` documents),
+    - process substitution / subshells / grouping (any unquoted paren),
+    - heredocs (``<<``) and backslash-newline continuations (TS commands.ts:96
+      documents the odd/even-backslash join attack),
+    - unterminated quotes, or more than :data:`MAX_SUBCOMMANDS` pieces.
+
+    Refusal is always SAFE: callers fall back to today's behavior (the
+    whole-command matcher refuses chained commands → prompt). The scanner is
+    the same traversal as :func:`contains_unquoted_chaining` so the two agree
+    on what counts as chaining; redirections (``2>&1``, ``&>``, ``>``) are NOT
+    operators and stay inside their sub-command's text (the port's matcher
+    treats redirects as plain arguments — the documented pre-existing
+    limitation shared with simple commands; splitting does not widen it).
+    """
+
+    in_single = False
+    in_double = False
+    parts: list[str] = []
+    buf: list[str] = []
+    i = 0
+    n = len(command)
+
+    def _flush() -> None:
+        piece = "".join(buf).strip()
+        if piece:
+            parts.append(piece)
+        buf.clear()
+
+    while i < n:
+        ch = command[i]
+        if ch == "\\" and not in_single:
+            if i + 1 < n and command[i + 1] == "\n":
+                return None  # continuation-join attack surface (TS commands.ts:96)
+            # Escaped char (outside single quotes): literal, never an operator —
+            # and, in double quotes, `\$`/`\`` are literal (no substitution),
+            # so consuming the pair here also stops the substitution check below
+            # from firing on an escaped dollar/backtick.
+            buf.append(command[i : i + 2])
+            i += 2
+            continue
+        # Command substitution EXECUTES inside double quotes too (only single
+        # quotes make it literal), so refuse `$(`/backtick whenever NOT inside
+        # single quotes — else `echo "$(rm -rf /)" | cat` would split into
+        # [echo "$(rm -rf /)", cat] and get auto-allowed by echo:*/cat:* while
+        # bash runs the rm. This is the per-sub-command injection guard TS gets
+        # from bashCommandIsSafeAsync (bashPermissions.ts:2360-2380).
+        if not in_single:
+            if ch == "`":
+                return None
+            if ch == "$" and i + 1 < n and command[i + 1] == "(":
+                return None
+            # bash 5.3 value substitution `${ cmd; }` / `${| cmd; }` EXECUTES
+            # cmd; plain `${VAR}` / `${VAR:-x}` does not. Distinguish by the
+            # sigil right after `{` (whitespace or `|`).
+            if ch == "$" and i + 1 < n and command[i + 1] == "{":
+                after = command[i + 2] if i + 2 < n else ""
+                if after == "" or after.isspace() or after == "|":
+                    return None
+        if ch == "'" and not in_double:
+            # ANSI-C quoting $'…' has escape semantics this scanner does not
+            # model — refuse rather than mis-split.
+            if not in_single and i > 0 and command[i - 1] == "$":
+                return None
+            in_single = not in_single
+            buf.append(ch)
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+            buf.append(ch)
+        elif not in_single and not in_double:
+            # ($(…) / backtick already refused above, in or out of double quotes)
+            if ch in "()":
+                return None  # subshell / grouping / process substitution
+            if ch == "<" and i + 1 < n and command[i + 1] == "<":
+                return None  # heredoc
+            if ch in (";", "\n"):
+                _flush()
+            elif ch == "|":
+                if i > 0 and command[i - 1] == ">":
+                    buf.append(ch)  # `>|` force-clobber redirect, not a pipe
+                else:
+                    _flush()
+                    if i + 1 < n and command[i + 1] in "|&":
+                        i += 1  # `||` / `|&` are single operators
+            elif ch == "&":
+                if i + 1 < n and command[i + 1] == "&":
+                    _flush()
+                    i += 1
+                elif i > 0 and command[i - 1] in "<>":
+                    buf.append(ch)  # 2>&1-style redirection
+                elif i + 1 < n and command[i + 1] == ">":
+                    buf.append(ch)  # &> redirection
+                else:
+                    _flush()  # lone & — separator/background
+            else:
+                buf.append(ch)
+        else:
+            buf.append(ch)
+        i += 1
+
+    if in_single or in_double:
+        return None  # unterminated quote — do not guess
+    _flush()
+    if not parts or len(parts) > MAX_SUBCOMMANDS:
+        return None
+    return parts
+
+
 def _skip_safe_env_assignments(tokens: list[str]) -> list[str] | None:
     """Drop leading VAR=value tokens; ``None`` if a non-safe var appears.
 
@@ -310,6 +440,63 @@ def suggestion_for_exact_command(command: str) -> list[PermissionUpdate]:
     ]
 
 
+def _rule_value_for_subcommand(sub: str) -> PermissionRuleValue | None:
+    """Best rule VALUE for one sub-command of a compound: 2-word prefix →
+    safe first-word prefix → exact string (same ladder as the simple-command
+    path below, but yielding a value so the caller can aggregate several into
+    ONE ``addRules`` update — TS bashPermissions.ts:2487-2547 collectedRules).
+
+    Bare shells yield nothing (D1 guard): an "exact" rule is exact-OR-word-
+    prefix at match time (check.py — TS parity), so ``Bash(bash)`` would match
+    ``bash anything`` ≈ ``Bash(*)``. The sub then simply never matches and the
+    compound keeps prompting — conservative, mirroring the existing heredoc/
+    multiline bare-shell suppression."""
+
+    sub = sub.strip()
+    if not sub:
+        return None
+    prefix = get_simple_command_prefix(sub) or get_safe_first_word_prefix(sub)
+    if prefix:
+        return PermissionRuleValue(
+            tool_name=BASH_TOOL_NAME, rule_content=f"{prefix}:*"
+        )
+    tokens = [t for t in sub.split() if t]
+    remaining = _skip_safe_env_assignments(tokens)
+    first = (remaining or tokens)[0] if (remaining or tokens) else ""
+    if first in BARE_SHELL_PREFIXES:
+        return None
+    return PermissionRuleValue(tool_name=BASH_TOOL_NAME, rule_content=sub)
+
+
+def suggestions_for_compound_command(command: str) -> list[PermissionUpdate] | None:
+    """Per-sub-command "don't ask again" rules for a compound command,
+    aggregated into a SINGLE ``addRules`` update (TS builds exactly one:
+    bashPermissions.ts:2540-2547), deduped in sub-command order and capped at
+    :data:`MAX_SUGGESTED_RULES_FOR_COMPOUND` (GH#11380).
+
+    ``None`` when the command cannot be split with certainty — callers fall
+    back to the legacy single-suggestion ladder.
+    """
+
+    subs = split_chained_command(command)
+    if subs is None:
+        return None
+    seen: dict[str, PermissionRuleValue] = {}
+    for sub in subs:
+        value = _rule_value_for_subcommand(sub)
+        if value is None or value.rule_content in seen:
+            continue
+        seen[str(value.rule_content)] = value
+    if not seen:
+        return None
+    rules = tuple(list(seen.values())[:MAX_SUGGESTED_RULES_FOR_COMPOUND])
+    return [
+        PermissionUpdateAddRules(
+            destination="localSettings", behavior="allow", rules=rules
+        )
+    ]
+
+
 def suggestions_for_bash_command(command: str) -> list[PermissionUpdate]:
     """Best "don't ask again" rule for ``command``
     (TS suggestionForExactCommand :245-273).
@@ -339,30 +526,31 @@ def suggestions_for_bash_command(command: str) -> list[PermissionUpdate]:
             return suggestion_for_prefix(heredoc_prefix)
         return []
 
-    if "\n" in command:
-        # TS takes the first line verbatim as a prefix rule. Two Python
-        # adjustments (both consequences of the D3 whole-string matcher):
-        # a compound first line would mint a rule the chaining guard can
-        # never match (the user would be re-prompted forever), so derive
-        # the first sub-command's 2-word prefix instead; and a bare-shell
-        # first line is suppressed for the same reason as the heredoc D1
-        # guard.
-        first_line = command.split("\n", 1)[0].strip()
-        if contains_unquoted_chaining(first_line):
-            prefix = get_simple_command_prefix(first_line)
-            return suggestion_for_prefix(prefix) if prefix else []
-        tokens = first_line.split()
-        if len(tokens) == 1 and tokens[0] in BARE_SHELL_PREFIXES:
-            return []
-        return suggestion_for_prefix(first_line)
-
     if contains_unquoted_chaining(command):
-        # Single-line compound: the first sub-command's 2-word prefix (a
-        # SUBSET of TS's per-sub-command suggestions) — safe because the
-        # match-time guard refuses to auto-allow chained commands, so the
-        # rule only ever skips prompts for SIMPLE commands. No derivable
-        # prefix → no suggestion (an exact rule containing chaining would
-        # be unmatchable: dead).
+        # Compound (incl. multiline): per-sub-command rules aggregated into
+        # one addRules update (TS parity — bashPermissions.ts merge flow).
+        # Accepting it lets the match-time per-sub check auto-allow the whole
+        # pipeline next time (every sub must match). Splitter refusal falls
+        # back to the legacy conservative ladders below.
+        compound = suggestions_for_compound_command(command)
+        if compound is not None:
+            return compound
+        if "\n" in command:
+            # Legacy multiline fallback: first line as a prefix rule (TS took
+            # the first line verbatim); compound/bare-shell first lines are
+            # suppressed for the same reasons as the heredoc D1 guard.
+            first_line = command.split("\n", 1)[0].strip()
+            if contains_unquoted_chaining(first_line):
+                prefix = get_simple_command_prefix(first_line)
+                return suggestion_for_prefix(prefix) if prefix else []
+            tokens = first_line.split()
+            if len(tokens) == 1 and tokens[0] in BARE_SHELL_PREFIXES:
+                return []
+            return suggestion_for_prefix(first_line)
+        # Legacy single-line-compound fallback: the first sub-command's
+        # 2-word prefix; no derivable prefix → no suggestion (an exact rule
+        # containing chaining would be unmatchable by the whole-command
+        # matcher: dead).
         prefix = get_simple_command_prefix(command)
         return suggestion_for_prefix(prefix) if prefix else []
 
@@ -384,12 +572,16 @@ def suggestions_for_bash_command(command: str) -> list[PermissionUpdate]:
 __all__ = [
     "BARE_SHELL_PREFIXES",
     "BASH_TOOL_NAME",
+    "MAX_SUBCOMMANDS",
+    "MAX_SUGGESTED_RULES_FOR_COMPOUND",
     "SAFE_ENV_VARS",
     "SAFE_PREFIX_COMMANDS",
     "contains_unquoted_chaining",
     "get_safe_first_word_prefix",
     "get_simple_command_prefix",
+    "split_chained_command",
     "suggestion_for_prefix",
     "suggestion_for_exact_command",
     "suggestions_for_bash_command",
+    "suggestions_for_compound_command",
 ]

--- a/src/permissions/check.py
+++ b/src/permissions/check.py
@@ -8,7 +8,11 @@ from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Callable, Protocol, runtime_checkable
 
 from .bash_security import analyze_bash_command
-from .bash_suggestions import contains_unquoted_chaining
+from .bash_suggestions import (
+    SAFE_ENV_VARS,
+    contains_unquoted_chaining,
+    split_chained_command,
+)
 from .rules import (
     get_ask_rule_for_tool,
     get_deny_rule_for_tool,
@@ -355,6 +359,11 @@ def has_permissions_to_use_tool_inner(
             message=f"Permission to use {tool.name} has been denied.",
         )
 
+    # Bash content deny rules (compound-aware) — see _bash_content_rule_decision.
+    deny_content = _bash_content_rule_decision(tool, tool_input, context, "deny")
+    if deny_content is not None:
+        return deny_content
+
     ask_rule = get_ask_rule_for_tool(context, tool)
     if ask_rule:
         return PermissionAskDecision(
@@ -362,6 +371,11 @@ def has_permissions_to_use_tool_inner(
             decision_reason=RuleDecisionReason(rule=ask_rule),
             message=create_permission_request_message(tool.name),
         )
+
+    # Bash content ask rules (after all deny sources; before anything allows).
+    ask_content = _bash_content_rule_decision(tool, tool_input, context, "ask")
+    if ask_content is not None:
+        return ask_content
 
     tool_permission_result: PermissionResult = PermissionPassthroughResult(
         behavior="passthrough",
@@ -493,14 +507,39 @@ def has_permissions_to_use_tool_inner(
     if content_rules and tool.name == "Bash":
         command = tool_input.get("command", "")
         if command:
-            for rule_content, rule in content_rules.items():
-                matcher = prepare_permission_matcher(rule_content)
-                if matcher(command):
-                    return PermissionAllowDecision(
-                        behavior="allow",
-                        updated_input=tool_input,
-                        decision_reason=RuleDecisionReason(rule=rule),
-                    )
+            # Try the command AND — like the suggestion ladder, which skips
+            # SAFE_ENV_VARS — a copy with those safe assignments stripped, so
+            # `NODE_ENV=test npm run lint` matches the `npm run:*` rule it was
+            # suggested for (TS stripSafeWrappers strips safe env for allow).
+            # Only the curated safe-list is stripped; an unsafe env prefix still
+            # prompts.
+            allow_candidates = [command]
+            safe_stripped = _strip_env_assignments(command, safe_only=True)
+            if safe_stripped and safe_stripped != command:
+                allow_candidates.append(safe_stripped)
+            for cand in allow_candidates:
+                for rule_content, rule in content_rules.items():
+                    matcher = prepare_permission_matcher(rule_content)
+                    if matcher(cand):
+                        return PermissionAllowDecision(
+                            behavior="allow",
+                            updated_input=tool_input,
+                            decision_reason=RuleDecisionReason(rule=rule),
+                        )
+            # Compound command: allow iff EVERY sub-command matches some
+            # allow content rule (TS bashPermissions.ts:2383/2470). Runs
+            # after the whole-command loop (which refuses chained commands
+            # by design) and after the tool safety screen above — a
+            # safety-flagged compound never reaches here. Each sub faces
+            # the SAME matcher a simple command would, so this never widens
+            # what one rule can match; it only lets several rules agree.
+            witness = _all_subcommands_allowed_by_content_rules(context, command)
+            if witness is not None:
+                return PermissionAllowDecision(
+                    behavior="allow",
+                    updated_input=tool_input,
+                    decision_reason=RuleDecisionReason(rule=witness),
+                )
 
     if tool_permission_result.behavior == "passthrough":
         return _with_default_suggestions(
@@ -625,6 +664,40 @@ def _with_default_suggestions(
     return ask
 
 
+def _bash_content_rule_decision(
+    tool: CheckPermissionsTool,
+    tool_input: dict[str, Any],
+    context: ToolPermissionContext,
+    behavior: str,
+) -> PermissionAskDecision | PermissionDenyDecision | None:
+    """Bash CONTENT deny/ask rules — e.g. ``Bash(rm:*)`` — matched against
+    the whole command AND every sub-command of a compound (TS
+    bashPermissions.ts:842: deny/ask rules must match compound commands so
+    they can't be bypassed by wrapping). Previously content deny/ask rules
+    were consulted NOWHERE — only content-less rules (rules.py
+    ``_tool_matches_rule`` rejects ``rule_content``) — so a configured
+    ``Bash(rm:*)`` deny was silently unenforced."""
+
+    if tool.name != "Bash":
+        return None
+    rule = _match_bash_content_rules(
+        context, str(tool_input.get("command", "") or ""), behavior
+    )
+    if rule is None:
+        return None
+    if behavior == "deny":
+        return PermissionDenyDecision(
+            behavior="deny",
+            decision_reason=RuleDecisionReason(rule=rule),
+            message=f"Permission to use {tool.name} has been denied.",
+        )
+    return PermissionAskDecision(
+        behavior="ask",
+        decision_reason=RuleDecisionReason(rule=rule),
+        message=create_permission_request_message(tool.name),
+    )
+
+
 def check_rule_based_permissions(
     tool: CheckPermissionsTool,
     tool_input: dict[str, Any],
@@ -640,6 +713,10 @@ def check_rule_based_permissions(
             message=f"Permission to use {tool.name} has been denied.",
         )
 
+    deny_content = _bash_content_rule_decision(tool, tool_input, context, "deny")
+    if deny_content is not None:
+        return deny_content
+
     ask_rule = get_ask_rule_for_tool(context, tool)
     if ask_rule:
         return PermissionAskDecision(
@@ -647,6 +724,10 @@ def check_rule_based_permissions(
             decision_reason=RuleDecisionReason(rule=ask_rule),
             message=create_permission_request_message(tool.name),
         )
+
+    ask_content = _bash_content_rule_decision(tool, tool_input, context, "ask")
+    if ask_content is not None:
+        return ask_content
 
     tool_permission_result: PermissionResult = PermissionPassthroughResult(
         behavior="passthrough",
@@ -695,6 +776,160 @@ def check_rule_based_permissions(
         )
 
     return None
+
+
+# A leading ``NAME=value`` assignment where value may be single-quoted,
+# double-quoted (both may contain spaces), or a bare word. Matching the quote
+# form is what stops ``FOO="a b" rm x`` from splitting mid-value and leaving the
+# ``rm`` unstripped — which would let a quoted-space env prefix bypass a
+# ``Bash(rm:*)`` deny/ask rule.
+_ENV_ASSIGNMENT_RE = re.compile(
+    r"[A-Za-z_][A-Za-z0-9_]*=(?:'[^']*'|\"[^\"]*\"|[^\s'\"]*)"
+)
+
+
+def _strip_env_assignments(command: str, *, safe_only: bool) -> str:
+    """Drop leading ``NAME=value`` assignments (values may be single/double
+    quoted or bare). ``safe_only`` limits stripping to the curated
+    :data:`SAFE_ENV_VARS` allow-list; otherwise ALL assignments are dropped.
+    The remainder is returned as its original substring (no re-tokenization)."""
+
+    rest = command.lstrip()
+    while rest:
+        m = _ENV_ASSIGNMENT_RE.match(rest)
+        # Must consume a whole shell word: the char after the assignment has to
+        # be whitespace or end-of-string, else this is part of a larger token.
+        if not m or (m.end() < len(rest) and not rest[m.end()].isspace()):
+            break
+        if safe_only and m.group(0).split("=", 1)[0] not in SAFE_ENV_VARS:
+            break
+        rest = rest[m.end():].lstrip()
+    return rest
+
+
+def _strip_all_env_assignments(command: str) -> str:
+    """ALL leading ``NAME=value`` (TS ``stripAllEnvVars`` for deny/ask —
+    bashPermissions.ts:942-947) so ``FOO=1 rm x`` / ``FOO="a b" rm x`` cannot
+    slip past a ``Bash(rm:*)`` deny/ask rule."""
+
+    return _strip_env_assignments(command, safe_only=False)
+
+
+def _match_bash_content_rules(
+    context: ToolPermissionContext,
+    command: str,
+    behavior: str,
+) -> "PermissionRule | None":
+    """First Bash content rule of ``behavior`` matching ``command``, checking
+    the whole command AND — for a chained command — every sub-command.
+
+    TS parity (bashPermissions.ts:842-843): deny/ask rules MUST be able to
+    match compound commands so ``echo hi && rm -rf /`` can't bypass a
+    ``Bash(rm:*)`` deny by wrapping. Three layers, most-certain first:
+
+    1. exact string equality against the raw command (TS matchMode 'exact'
+       bypasses the compound guard — the only way an exact rule naming a
+       compound can ever match, since the generic matcher refuses chaining);
+    2. the standard whole-command matcher (refuses chained commands);
+    3. per-sub-command matching via :func:`split_chained_command` — a rule
+       matching ANY sub-command matches the compound. Deny/ask matching also
+       tries each sub with ALL env assignments stripped (TS stripAllEnvVars).
+
+    Splitter refusal (exotic syntax) degrades to layers 1-2 — i.e. today's
+    behavior — never to a wider match.
+    """
+
+    content_rules = get_rule_by_contents_for_tool(context, "Bash", behavior)
+    if not content_rules or not command:
+        return None
+
+    stripped = command.strip()
+    matchers: list[tuple[Callable[[str], bool], Any]] = []
+    for rule_content, rule in content_rules.items():
+        if stripped and stripped == str(rule_content).strip():
+            return rule  # exact match bypasses the compound guard (TS 'exact')
+        matchers.append((prepare_permission_matcher(rule_content), rule))
+
+    # For deny/ask, ALSO try the command with all leading NAME=value prefixes
+    # stripped, so `FOO=1 rm x` / `FOO="a b" rm x` can't slip past Bash(rm:*)
+    # (TS stripAllEnvVars). Allow matching deliberately does NOT strip — an
+    # env-prefixed command is a different command and should re-prompt.
+    strip_env = behavior in ("deny", "ask")
+
+    def _match_one(cmd: str) -> "PermissionRule | None":
+        variants = [cmd]
+        if strip_env:
+            no_env = _strip_all_env_assignments(cmd)
+            if no_env and no_env != cmd:
+                variants.append(no_env)
+        for cand in variants:
+            for matcher, rule in matchers:
+                if matcher(cand):
+                    return rule
+        return None
+
+    whole = _match_one(command)
+    if whole is not None:
+        return whole
+
+    if contains_unquoted_chaining(command):
+        subs = split_chained_command(command)
+        if subs:
+            for sub in subs:
+                sub_match = _match_one(sub)
+                if sub_match is not None:
+                    return sub_match
+    return None
+
+
+def _all_subcommands_allowed_by_content_rules(
+    context: ToolPermissionContext,
+    command: str,
+) -> "PermissionRule | None":
+    """When EVERY sub-command of a chained ``command`` matches some allow
+    content rule, return a witness rule (the last sub's match); else None.
+
+    TS parity (bashPermissions.ts:2383/2470): a compound command is allowed
+    iff all of its sub-commands are individually allowed. The whole-command
+    matcher (chaining guard) stays authoritative for simple commands; this
+    runs only for chained ones, each sub matched by the SAME matcher a simple
+    command would face — so splitting never widens what a single rule can
+    match, it only requires more rules to agree. Splitter refusal → None
+    (today's behavior: prompt).
+    """
+
+    if not contains_unquoted_chaining(command):
+        return None
+    content_rules = get_rule_by_contents_for_tool(context, "Bash", "allow")
+    if not content_rules:
+        return None
+    subs = split_chained_command(command)
+    if not subs:
+        return None
+
+    matchers = [
+        (prepare_permission_matcher(rule_content), rule)
+        for rule_content, rule in content_rules.items()
+    ]
+    witness = None
+    for sub in subs:
+        # Strip SAFE_ENV_VARS only (as the suggestion ladder does) so an
+        # accepted rule actually matches the sub it came from.
+        candidates = [sub]
+        safe_stripped = _strip_env_assignments(sub, safe_only=True)
+        if safe_stripped and safe_stripped != sub:
+            candidates.append(safe_stripped)
+        for cand in candidates:
+            for matcher, rule in matchers:
+                if matcher(cand):
+                    witness = rule
+                    break
+            else:
+                continue
+            break
+        else:
+            return None
+    return witness
 
 
 def prepare_permission_matcher(rule_content: str) -> Callable[[str], bool]:

--- a/tests/test_bash_suggestions.py
+++ b/tests/test_bash_suggestions.py
@@ -77,32 +77,43 @@ class TestSuggestionsForBashCommand(unittest.TestCase):
         # Deliberate divergence from TS: Bash(bash:*) ≈ Bash(*).
         self.assertEqual(suggestions_for_bash_command("bash <<EOF\nevil\nEOF"), [])
 
-    def test_multiline_uses_first_line_prefix(self) -> None:
+    def test_multiline_gets_per_sub_rules(self) -> None:
+        # R6 compound parity: each line contributes a rule (was: first line only).
         cmd = "git status\ngit diff"
-        rule = _only_rule(suggestions_for_bash_command(cmd))
-        self.assertEqual(rule.rule_content, "git status:*")
+        updates = suggestions_for_bash_command(cmd)
+        self.assertEqual(len(updates), 1)
+        self.assertEqual([r.rule_content for r in updates[0].rules],
+                         ["git status:*", "git diff:*"])
 
     def test_empty_command_yields_nothing(self) -> None:
         self.assertEqual(suggestions_for_bash_command("   "), [])
 
-    def test_compound_command_still_gets_first_prefix(self) -> None:
-        # Safe because the matcher refuses chained commands at match time.
-        rule = _only_rule(suggestions_for_bash_command("git diff && echo hi"))
-        self.assertEqual(rule.rule_content, "git diff:*")
+    def test_compound_command_gets_per_sub_rules(self) -> None:
+        # R6 compound parity: one bundled addRules update covering every sub
+        # (was: first sub's prefix only). Match-time requires ALL subs to
+        # match, so the bundle is what stops the re-prompt.
+        updates = suggestions_for_bash_command("git diff && echo hi")
+        self.assertEqual(len(updates), 1)
+        self.assertEqual([r.rule_content for r in updates[0].rules],
+                         ["git diff:*", "echo hi:*"])
 
-    def test_compound_without_derivable_prefix_yields_nothing(self) -> None:
-        # An exact rule containing chaining would be unmatchable (dead).
-        self.assertEqual(suggestions_for_bash_command("ls && pwd"), [])
+    def test_compound_of_safe_words_gets_per_sub_rules(self) -> None:
+        # R6 compound parity: was [] (nothing suggestible for "ls && pwd").
+        updates = suggestions_for_bash_command("ls && pwd")
+        self.assertEqual([r.rule_content for r in updates[0].rules],
+                         ["ls:*", "pwd:*"])
 
-    def test_multiline_compound_first_line_derives_prefix(self) -> None:
-        # A verbatim compound first line would mint a dead rule.
-        rule = _only_rule(
-            suggestions_for_bash_command("git fetch && git rebase\ngit push")
-        )
-        self.assertEqual(rule.rule_content, "git fetch:*")
+    def test_multiline_compound_gets_per_sub_rules(self) -> None:
+        # R6 compound parity: all three subs contribute (was: first only).
+        updates = suggestions_for_bash_command("git fetch && git rebase\ngit push")
+        self.assertEqual([r.rule_content for r in updates[0].rules],
+                         ["git fetch:*", "git rebase:*", "git push:*"])
 
-    def test_multiline_bare_shell_first_line_yields_nothing(self) -> None:
-        self.assertEqual(suggestions_for_bash_command("bash\necho hi"), [])
+    def test_multiline_bare_shell_sub_contributes_nothing(self) -> None:
+        # D1 guard survives the R6 rework: the bare-shell sub yields no rule
+        # (an exact "bash" rule would word-prefix-match "bash anything").
+        updates = suggestions_for_bash_command("bash\necho hi")
+        self.assertEqual([r.rule_content for r in updates[0].rules], ["echo hi:*"])
 
     def test_heredoc_at_index_zero_yields_nothing(self) -> None:
         self.assertEqual(suggestions_for_bash_command("<<EOF\nhi\nEOF"), [])
@@ -113,10 +124,11 @@ class TestSuggestionsForBashCommand(unittest.TestCase):
         )
 
     def test_env_assignment_then_compound(self) -> None:
-        rule = _only_rule(
-            suggestions_for_bash_command("NODE_ENV=test npm run lint && npm test")
-        )
-        self.assertEqual(rule.rule_content, "npm run:*")
+        # R6 compound parity: both subs contribute; the safe env assignment
+        # is still skipped for prefix derivation.
+        updates = suggestions_for_bash_command("NODE_ENV=test npm run lint && npm test")
+        self.assertEqual([r.rule_content for r in updates[0].rules],
+                         ["npm run:*", "npm test:*"])
 
 
 class TestContainsUnquotedChaining(unittest.TestCase):

--- a/tests/test_r6_compound_permissions.py
+++ b/tests/test_r6_compound_permissions.py
@@ -1,0 +1,246 @@
+"""R6 — compound-command permission parity (TS bashPermissions merge flow).
+
+User report: pipelines like ``grep … | tr … | sort -u`` re-prompted every time
+with only Yes/No (no persistable option). Root causes: (1) the suggestion
+ladder derived at most the FIRST sub-command's prefix (usually nothing) for a
+compound; (2) the matcher refuses chained commands, with no per-sub-command
+path, so no rule set could ever auto-allow a compound; (3) Bash CONTENT
+deny/ask rules (``Bash(rm:*)``) were consulted NOWHERE — silently unenforced.
+
+TS parity implemented (typescript/src/tools/BashTool/bashPermissions.ts):
+- split compound commands (splitCommand port: split_chained_command, refusing
+  exotic syntax — refusal degrades to today's prompt, never a wider allow);
+- allow iff EVERY sub-command matches an allow content rule (:2383/:2470);
+- deny/ask content rules match the whole command AND every sub-command
+  (:842 — wrapping a denied command in a compound cannot bypass it), with
+  all-env-assignment stripping for deny/ask (stripAllEnvVars);
+- per-sub-command "don't ask again" suggestions aggregated into ONE addRules
+  update, deduped, capped at 5 (:2487-2547, GH#11380).
+"""
+from __future__ import annotations
+
+import unittest
+
+from src.permissions.bash_suggestions import (
+    split_chained_command,
+    suggestions_for_bash_command,
+)
+from src.permissions.check import has_permissions_to_use_tool_inner
+from src.permissions.types import (
+    PermissionPassthroughResult,
+    ToolPermissionContext,
+)
+
+USER_PIPELINE = (
+    "grep -ohE '\"tags\": \\[[^]]*\\]' /Users/x/src/data/posts.ts"
+    " | tr ',' '\\n' | grep -o '\"[^\"]*\"' | sort -u | tr -d '\"'"
+)
+
+
+class _BashTool:
+    name = "Bash"
+
+    def check_permissions(self, tool_input, context):
+        return PermissionPassthroughResult()
+
+
+def _ctx(allow=(), deny=(), ask=()):
+    return ToolPermissionContext(
+        always_allow_rules={"session": [f"Bash({r})" for r in allow]},
+        always_deny_rules={"session": [f"Bash({r})" for r in deny]},
+        always_ask_rules={"session": [f"Bash({r})" for r in ask]},
+    )
+
+
+def _decide(command, ctx):
+    return has_permissions_to_use_tool_inner(_BashTool(), {"command": command}, ctx)
+
+
+class TestSplitChainedCommand(unittest.TestCase):
+    def test_splits_operators(self):
+        self.assertEqual(
+            split_chained_command("a | b && c ; d || e & f |& g"),
+            ["a", "b", "c", "d", "e", "f", "g"],
+        )
+        self.assertEqual(split_chained_command("a\nb"), ["a", "b"])
+
+    def test_quotes_protect_operators(self):
+        self.assertEqual(split_chained_command("echo 'a|b' | tr x y"),
+                         ["echo 'a|b'", "tr x y"])
+        self.assertEqual(split_chained_command('echo "a && b"'), ['echo "a && b"'])
+        # Escaped operator outside quotes is literal, not a separator.
+        self.assertEqual(split_chained_command("echo a\\|b"), ["echo a\\|b"])
+
+    def test_redirections_stay_inside_pieces(self):
+        self.assertEqual(split_chained_command("make 2>&1 | tail -5"),
+                         ["make 2>&1", "tail -5"])
+        self.assertEqual(split_chained_command("cmd &> log | wc -l"),
+                         ["cmd &> log", "wc -l"])
+        # `>|` is a force-clobber redirect, not a pipe boundary.
+        self.assertEqual(split_chained_command("a >| f | b"), ["a >| f", "b"])
+
+    def test_refusals(self):
+        for cmd in (
+            "echo $(rm -rf /) | cat",       # command substitution (unquoted)
+            'echo "$(rm -rf /)" | cat',     # SECURITY: $() executes in double quotes
+            'echo "`rm -rf /`" | cat',      # SECURITY: backtick executes in double quotes
+            'cat "$(id)" | grep x',         # ditto, mid-pipeline
+            "echo `id` | cat",              # backticks (unquoted)
+            "diff <(ls a) <(ls b)",         # process substitution / parens
+            "(cd /tmp && ls) | cat",        # subshell
+            "cat <<EOF | tee\nhi\nEOF",     # heredoc
+            "echo a \\\n | rm -rf /",       # backslash-newline continuation
+            "echo $'a\\'' | rm -rf /",      # ANSI-C quoting blind spot
+            "echo 'unterminated | cat",     # unbalanced quote
+        ):
+            self.assertIsNone(split_chained_command(cmd), cmd)
+        # Cap: >50 pieces refuses.
+        self.assertIsNone(split_chained_command(" ; ".join(["echo x"] * 51)))
+
+    def test_bash53_value_substitution_refused(self):
+        # bash 5.3 `${ cmd; }` / `${| cmd; }` EXECUTE cmd → refuse (like $()).
+        self.assertIsNone(split_chained_command('echo "${ rm -rf /; }" | cat'))
+        self.assertIsNone(split_chained_command('echo "${| id; }" | cat'))
+        # Plain parameter expansion does NOT execute → still splits.
+        self.assertEqual(split_chained_command('echo "${VAR}" | cat'),
+                         ['echo "${VAR}"', 'cat'])
+        self.assertEqual(split_chained_command('echo "${VAR:-x}" | cat'),
+                         ['echo "${VAR:-x}"', 'cat'])
+
+    def test_substitution_literal_in_single_quotes_still_splits(self):
+        # Single quotes make $()/backtick LITERAL (bash), so it's safe to split.
+        self.assertEqual(
+            split_chained_command("echo '$(rm -rf /)' | cat"),
+            ["echo '$(rm -rf /)'", "cat"],
+        )
+        # Backslash-escaped $ in double quotes is literal too.
+        self.assertEqual(
+            split_chained_command('echo "\\$(rm)" | cat'),
+            ['echo "\\$(rm)"', "cat"],
+        )
+
+    def test_user_pipeline_splits_correctly(self):
+        subs = split_chained_command(USER_PIPELINE)
+        self.assertIsNotNone(subs)
+        self.assertEqual(len(subs), 5)
+        self.assertTrue(subs[0].startswith("grep -ohE"))
+        self.assertEqual(subs[3], "sort -u")
+
+
+class TestCompoundSuggestions(unittest.TestCase):
+    def test_user_pipeline_gets_bundled_rules(self):
+        updates = suggestions_for_bash_command(USER_PIPELINE)
+        self.assertEqual(len(updates), 1)  # ONE addRules update (TS parity)
+        contents = [r.rule_content for r in updates[0].rules]
+        # grep/tr are read-only-safe first words → prefix rules; sort is
+        # excluded from the safe set (sort -o writes) → exact; dedup applies.
+        self.assertEqual(contents, ["grep:*", "tr:*", "sort -u"])
+        self.assertEqual(updates[0].destination, "localSettings")
+
+    def test_cap_at_five_rules(self):
+        cmd = " | ".join(f"cmd{i} arg" for i in range(9))
+        updates = suggestions_for_bash_command(cmd)
+        self.assertEqual(len(updates), 1)
+        self.assertEqual(len(updates[0].rules), 5)
+
+    def test_splitter_refusal_falls_back_to_legacy(self):
+        # Command substitution → no split; legacy first-sub 2-word prefix.
+        updates = suggestions_for_bash_command("git status && echo $(id)")
+        contents = [r.rule_content for u in updates for r in u.rules]
+        self.assertEqual(contents, ["git status:*"])
+
+
+class TestCompoundMatching(unittest.TestCase):
+    def test_all_subs_matching_allows_the_pipeline(self):
+        ctx = _ctx(allow=("grep:*", "tr:*", "sort -u"))
+        self.assertEqual(_decide(USER_PIPELINE, ctx).behavior, "allow")
+
+    def test_one_unmatched_sub_still_asks(self):
+        ctx = _ctx(allow=("grep:*", "tr:*"))  # no rule for sort -u
+        self.assertEqual(_decide(USER_PIPELINE, ctx).behavior, "ask")
+
+    def test_accepting_the_suggestion_stops_reprompting(self):
+        # The full loop: ask → accept the suggested bundle → same command allows.
+        from src.permissions.updates import apply_permission_updates
+
+        ctx = ToolPermissionContext()
+        first = _decide(USER_PIPELINE, ctx)
+        self.assertEqual(first.behavior, "ask")
+        self.assertTrue(first.suggestions)
+        ctx2 = apply_permission_updates(ctx, list(first.suggestions))
+        self.assertEqual(_decide(USER_PIPELINE, ctx2).behavior, "allow")
+        # And a VARIANT built from the same commands is covered too.
+        variant = "grep -c foo /tmp/f.txt | sort -u | tr -d 'x'"
+        self.assertEqual(_decide(variant, ctx2).behavior, "allow")
+
+    def test_simple_commands_unchanged(self):
+        ctx = _ctx(allow=("git status:*",))
+        self.assertEqual(_decide("git status --short", ctx).behavior, "allow")
+        self.assertEqual(_decide("git log", ctx).behavior, "ask")
+
+    def test_splitter_refusal_never_allows(self):
+        # Every sub would match, but the $() refusal keeps it at ask.
+        ctx = _ctx(allow=("grep:*", "cat:*"))
+        self.assertEqual(_decide("grep $(id) x | cat", ctx).behavior, "ask")
+
+    def test_double_quoted_substitution_never_auto_allows(self):
+        # SECURITY: $()/backtick execute inside double quotes; even with allow
+        # rules for every visible command, the smuggled rm must NOT be allowed.
+        ctx = _ctx(allow=("echo:*", "cat:*"))
+        self.assertEqual(_decide('echo "$(rm -rf /)" | cat', ctx).behavior, "ask")
+        self.assertEqual(_decide('echo "`rm -rf /`" | cat', ctx).behavior, "ask")
+
+
+class TestContentDenyAskEnforced(unittest.TestCase):
+    def test_deny_rule_now_enforced_on_simple_command(self):
+        ctx = _ctx(deny=("rm:*",))
+        self.assertEqual(_decide("rm -rf /tmp/x", ctx).behavior, "deny")
+
+    def test_deny_cannot_be_bypassed_by_wrapping(self):
+        ctx = _ctx(allow=("echo:*", "rm:*"), deny=("rm:*",))
+        # Deny wins over allow, whole or wrapped (TS :842).
+        self.assertEqual(_decide("echo hi && rm -rf /tmp/x", ctx).behavior, "deny")
+
+    def test_deny_ignores_env_var_prefix(self):
+        ctx = _ctx(deny=("rm:*",))
+        # Compound AND simple, bare AND quoted-value (spaces) env prefixes.
+        for cmd in (
+            "echo a && FOO=1 rm -rf /tmp/x",
+            "FOO=1 rm -rf /tmp/x",
+            'FOO="a b" rm -rf /tmp/x',
+            "A=1 B='c d' rm -rf /tmp/x",
+        ):
+            self.assertEqual(_decide(cmd, ctx).behavior, "deny", cmd)
+
+    def test_allow_strips_only_SAFE_env_prefix(self):
+        # SAFE_ENV_VARS (e.g. NODE_ENV) ARE stripped for allow matching so an
+        # accepted rule matches the command it was suggested for (TS parity +
+        # the user's "re-prompts every time" case). An UNSAFE env prefix is a
+        # different command and still prompts.
+        ctx = _ctx(allow=("npm run:*", "npm test:*"))
+        self.assertEqual(
+            _decide("NODE_ENV=test npm run lint", ctx).behavior, "allow")
+        self.assertEqual(
+            _decide("NODE_ENV=test npm run lint && npm test", ctx).behavior, "allow")
+        # Non-safe env var → not stripped → prompt.
+        self.assertEqual(
+            _decide("EVIL=1 npm run lint", ctx).behavior, "ask")
+
+    def test_value_substitution_never_auto_allows(self):
+        # SECURITY: bash 5.3 ${ cmd; } executes; must not auto-allow via echo:*.
+        ctx = _ctx(allow=("echo:*", "cat:*"))
+        self.assertEqual(_decide('echo "${ rm -rf /; }" | cat', ctx).behavior, "ask")
+
+    def test_exact_deny_matches_the_exact_compound(self):
+        ctx = ToolPermissionContext(
+            always_deny_rules={"session": ["Bash(git status && git log)"]}
+        )
+        self.assertEqual(_decide("git status && git log", ctx).behavior, "deny")
+
+    def test_ask_rule_beats_allow_for_a_sub(self):
+        ctx = _ctx(allow=("git status:*", "git log:*"), ask=("git log:*",))
+        self.assertEqual(_decide("git status && git log", ctx).behavior, "ask")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -383,6 +383,38 @@ describe('GatewayClient NDJSON adapter', () => {
     expect(resp.chosen_updates[0].destination).toBe('session')
     expect(resp.chosen_updates[0].rules).toBeUndefined()
   })
+
+  it('compound-command suggestion (multiple rules): no editable rule, ALL rules sent on always', async () => {
+    // R6 compound parity: a pipeline's suggestion bundles several rules in ONE
+    // addRules update. The box must not offer per-rule editing (rule=null) and
+    // accepting must persist the WHOLE bundle unchanged.
+    const sent: any[] = []
+    ;(gw as any).send = (m: any) => sent.push(m)
+    const bundle = {
+      type: 'addRules', destination: 'localSettings', behavior: 'allow',
+      rules: [
+        { tool_name: 'Bash', rule_content: 'grep:*' },
+        { tool_name: 'Bash', rule_content: 'tr:*' },
+        { tool_name: 'Bash', rule_content: 'sort -u' }
+      ]
+    }
+    proc.line({
+      request: {
+        input: { command: "grep x f | tr a b | sort -u" }, subtype: 'can_use_tool', tool_name: 'Bash',
+        suggestions: [bundle]
+      },
+      request_id: 'r5', type: 'control_request'
+    })
+    await vi.waitFor(() => expect(last('approval.request')).toBeTruthy())
+    const p = last('approval.request').payload
+    expect(p.allow_permanent).toBe(true)
+    expect(p.rule).toBeNull() // multi-rule → not editable
+    expect(p.rule_label).toBe('Bash(grep:*), Bash(tr:*), Bash(sort -u)')
+
+    await gw.request('approval.respond', { choice: 'always' })
+    const resp = sent.find(m => m.type === 'control_response')?.response?.response
+    expect(resp.chosen_updates[0]).toEqual(bundle) // whole bundle, untouched
+  })
 })
 
 describe('approvalCommandText — the human-reviewable action, not a JSON dump', () => {

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -46,13 +46,17 @@ function safeJson(v: unknown): string {
   }
 }
 
-/** A human label for a permission suggestion rule, e.g. `Bash(ls:*)` (or just
- *  the tool name for a content-less rule), shown on the "don't ask again"
+/** A human label for a permission suggestion's rule(s), e.g. `Bash(ls:*)` or
+ *  `Bash(grep:*), Bash(tr:*), …` for a compound command's bundled rules (just
+ *  the tool name for a content-less rule). Shown on the "don't ask again"
  *  option so the user sees what it will persist. */
 export function describeSuggestionRule(suggestion: any): string | null {
-  const rule = suggestion?.rules?.[0]
-  if (!rule || !rule.tool_name) return null
-  return rule.rule_content ? `${rule.tool_name}(${rule.rule_content})` : String(rule.tool_name)
+  const rules = Array.isArray(suggestion?.rules) ? suggestion.rules : []
+  const labels = rules
+    .filter((r: any) => r && r.tool_name)
+    .map((r: any) => (r.rule_content ? `${r.tool_name}(${r.rule_content})` : String(r.tool_name)))
+  if (labels.length === 0) return null
+  return labels.length > 3 ? `${labels.slice(0, 3).join(', ')}, …` : labels.join(', ')
 }
 
 // The human-reviewable action for a permission prompt: the actual Bash command,
@@ -780,7 +784,11 @@ export class GatewayClient extends EventEmitter {
       // JSON dump — and carry the editable grant rule separately so the box can
       // offer a broadenable "don't ask again for <rule>" option. Only offer the
       // persistable option when the backend sent a rule.
-      const ruleContent = suggestions[0]?.rules?.[0]?.rule_content ?? null
+      // Editable rule only when the suggestion carries exactly ONE rule — a
+      // compound command's suggestion bundles several (grep:*, tr:*, …) and
+      // is accepted/declined as a set (static label via session_label).
+      const suggestionRules = Array.isArray(suggestions[0]?.rules) ? suggestions[0].rules : []
+      const ruleContent = suggestionRules.length === 1 ? (suggestionRules[0]?.rule_content ?? null) : null
       this.publish({
         payload: {
           allow_permanent: suggestions.length > 0,


### PR DESCRIPTION
## Compound commands stop re-prompting

**User report:** pipelines like `grep … | tr … | sort -u | tr -d '"'` re-prompt every time with only a Yes/No box.

**Three root causes** (all fixed): the suggestion ladder derived at most the *first* sub-command's prefix; the matcher had no per-sub-command path so no grant could ever auto-allow a pipeline; and Bash **content deny/ask rules** (`Bash(rm:*)` deny) were enforced *nowhere*.

**Mimics `typescript/`:** split the compound; **allow iff every sub matches an allow rule, deny if any sub matches deny** (wrapping can't bypass a deny); bundle a per-sub "don't ask again" suggestion (cap 5). Deny/ask strip all env prefixes; allow strips only curated SAFE_ENV_VARS (so an accepted `npm run:*` matches `NODE_ENV=test npm run lint`).

**Security:** the splitter refuses every ambiguous/dangerous construct (command substitution in *and out* of double quotes, backticks, bash-5.3 `${ cmd; }`, subshell, heredoc, ANSI-C, continuation, unterminated quotes, >50 pieces) — refusal degrades to a prompt, never a wider allow. Found+fixed 4 silent-over-allow holes in self-review before the critic.

**Critic: APPROVE** — ordering sound, no silent over-allow. Addressed its 2 high-value follow-ups; deferred 2 (documented, both degrade to ask).

**Tests:** 40 new compound tests + 6 updated + 1 ui-tui. Full suite at the 9-failure baseline (7603 passed); ui-tui baseline; typecheck+build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)