### PR TITLE
fix(tui): head-truncate expandable tool blocks (look&feel E, Finding B)

### DIFF
--- a/ui-tui/src/__tests__/text.test.ts
+++ b/ui-tui/src/__tests__/text.test.ts
@@ -94,11 +94,10 @@ describe('buildVerboseToolTrailLine', () => {
   })
 
   it('bounds a huge result while still expanding meaningfully (#34095 guard)', () => {
-    // A 40KB browser-snapshot-sized result must NOT be embedded whole — the
-    // render block stays bounded (VERBOSE_TRAIL_MAX_*) so a burst of huge
-    // results can't rebuild the #34095 OOM. But verbose now renders only
-    // behind the explicit ctrl+o toggle, so the budget is a real expansion
-    // (~16KB), not the old 800-char glance.
+    // A huge result must NOT embed whole — the render block stays bounded
+    // (VERBOSE_TRAIL_MAX_*) so a burst can't rebuild the #34095 OOM. Verbose
+    // renders only behind ctrl+o, so the budget is a real expansion (~16KB),
+    // not the old 800-char glance.
     const huge = 'A'.repeat(40_000)
     const line = buildVerboseToolTrailLine('browser_snapshot', 'https://x.example', false, 2, undefined, huge)
 
@@ -106,6 +105,33 @@ describe('buildVerboseToolTrailLine', () => {
     expect(line.length).toBeLessThan(17_000)
     expect(line).toContain('omitted')
     expect(line.endsWith(' ✓')).toBe(true)
+  })
+
+  it('keeps the HEAD of a multi-line result, not the tail (#34095 Finding B)', () => {
+    // A 500-line result: the reader hitting ctrl+o wants the START of the
+    // output (first matches / first error lines), with the rest marked
+    // omitted — not the live-stream tail.
+    const body = Array.from({ length: 500 }, (_, i) => `line ${i}`).join('\n')
+    const line = buildVerboseToolTrailLine('Grep', 'pattern', false, 0.1, undefined, body)
+
+    expect(line).toContain('Result:\nline 0\nline 1')
+    expect(line).toContain('line 199') // within the 200-line cap
+    expect(line).not.toContain('line 200') // beyond it, dropped
+    expect(line).not.toContain('line 499') // tail is NOT what we keep
+    // The omitted count reflects the DROPPED suffix (500 − 200 = 300), not the
+    // kept head — a constant here would be a lying status line.
+    expect(line).toContain('+300 lines omitted')
+    expect(line).not.toContain('showing live tail') // the misleading label is gone
+  })
+
+  it('reports the true omitted-line count near the cap boundary', () => {
+    // 201 lines: exactly one dropped past the 200-line cap.
+    const body = Array.from({ length: 201 }, (_, i) => `r${i}`).join('\n')
+    const line = buildVerboseToolTrailLine('Bash', 'seq', false, 0.1, undefined, body)
+
+    expect(line).toContain('r199')
+    expect(line).not.toContain('r200')
+    expect(line).toContain('+1 lines omitted')
   })
 
   it('does not truncate a result that already fits the preview budget', () => {

--- a/ui-tui/src/lib/text.ts
+++ b/ui-tui/src/lib/text.ts
@@ -230,19 +230,47 @@ export const buildToolTrailLine = (
   return `${formatToolCall(name, context)}${detail ? ` :: ${detail}` : ''} ${error ? '✗' : '✓'}`
 }
 
+// Head-truncate an expandable tool block: keep the FIRST maxLines/maxChars —
+// the start of Grep matches, Bash output, or an error is what the reader wants
+// when they hit ctrl+o — with a trailing "… +N lines/chars omitted" marker.
+// (boundedLiveRenderText keeps the *tail* with a "showing live tail" label,
+// which is right for the live stream but wrong and misleading here.)
+const headTruncate = (body: string): string => {
+  const lines = body.split('\n')
+  const overLines = lines.length > VERBOSE_TRAIL_MAX_LINES
+  let head = overLines ? lines.slice(0, VERBOSE_TRAIL_MAX_LINES).join('\n') : body
+  let omittedChars = body.length - head.length
+
+  if (head.length > VERBOSE_TRAIL_MAX_CHARS) {
+    omittedChars = body.length - VERBOSE_TRAIL_MAX_CHARS
+    head = head.slice(0, VERBOSE_TRAIL_MAX_CHARS)
+  }
+
+  if (!overLines && omittedChars <= 0) {
+    return body
+  }
+
+  // Count newlines in the OMITTED suffix (total − kept), not the kept head —
+  // body.length - omittedChars === head.length, so counting to there would
+  // report the head's line count (a constant ~cap) instead of what was dropped.
+  const omittedLines = countNewlines(body, body.length) - countNewlines(body, body.length - omittedChars)
+
+  const marker =
+    omittedLines > 0
+      ? `\n… +${fmtK(omittedLines)} lines omitted`
+      : `\n… +${fmtK(omittedChars)} chars omitted`
+
+  return head.replace(/\n+$/, '') + marker
+}
+
 const verboseToolBlock = (label: string, text?: string) => {
   const body = (text ?? '').trim()
 
-  // Persisted trail blocks are kept all session and rendered expanded by
-  // default — cap to a small readable preview (NOT the 16KB live-render
-  // budget) so a large tool output can't balloon the Ink render tree and
-  // silently OOM-kill the TUI. See VERBOSE_TRAIL_MAX_CHARS (#34095).
-  return body
-    ? `${label}:\n${boundedLiveRenderText(body, {
-        maxChars: VERBOSE_TRAIL_MAX_CHARS,
-        maxLines: VERBOSE_TRAIL_MAX_LINES
-      })}`
-    : ''
+  // Expandable blocks render only behind ctrl+o (not expanded-by-default), so
+  // the cap is a real expansion (VERBOSE_TRAIL_MAX_CHARS = 16k) that still
+  // bounds the worst case — a burst of huge results can't rebuild the #34095
+  // OOM. Head-truncated: the start of the output is what the reader wants.
+  return body ? `${label}:\n${headTruncate(body)}` : ''
 }
 
 export const buildVerboseToolTrailLine = (


### PR DESCRIPTION
The expand-result feature (#623) delegated verbose-block truncation to
boundedLiveRenderText, which keeps the TAIL with a 'showing live tail'
label — correct for the live stream, wrong for a persisted ctrl+o
expansion where the reader wants the START of Grep matches / Bash output
/ an error. The comment had also gone stale (claimed 'NOT the 16KB
budget' when the cap is now exactly 16k, and 'expanded by default' when
it's behind ctrl+o).

- New headTruncate: keeps the first VERBOSE_TRAIL_MAX_LINES/_CHARS with a
  trailing '… +N lines/chars omitted' marker (no live-tail label).
- verboseToolBlock uses it; comment corrected to match the behavior.
- boundedLiveRenderText stays for the genuine live-stream tails
  (streaming assistant text, thinking) — unchanged.

Test: a 500-line Grep result keeps line 0-199, drops line 200 and the
499 tail, shows '… +N lines omitted', and no longer says 'showing live
tail' — distinguishing head from tail (the old 'A'.repeat test couldn't).

Reconciles the plan, the comment, the label, and the code (critic
Finding B, required change #2 from the expand-E implementation review —
missed in the first fix round, which only closed Finding A).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Follow-up to #623 (the expand-result feature), closing the two findings from that PR's implementation review that were missed in the first fix round:
- Render now head-truncates expandable tool blocks (start of Grep/Bash/error output) instead of keeping the live-stream tail with a misleading 'showing live tail' label; the stale self-contradictory comment is corrected so plan/comment/label/code agree.
- Fixes the regression the head-truncation introduced: the '… +N lines omitted' count was computed over the kept head (constant 199) instead of the dropped suffix — now total − kept, with value-asserting tests (+300 for a 500-line result, +1 at the 201-line boundary) so a regressed count fails.

Critic-approved (terminal verdict, verified against the suites). tsc + eslint clean; text.test + expandResults 45/45; full suite at the pre-existing 9-failure baseline. boundedLiveRenderText is untouched — still used for the genuine live-stream tails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)