### PR TITLE
feat(tui): Esc interrupts the turn, Ctrl+C defanged, /exit in the slash menu

### DIFF
--- a/ui-tui/src/__tests__/composerFooter.test.ts
+++ b/ui-tui/src/__tests__/composerFooter.test.ts
@@ -64,7 +64,7 @@ describe('ComposerFooter', () => {
   it('swaps the hint for the interrupt hint while busy', () => {
     const plain = stripAnsi(footer({ busy: true }))
 
-    expect(plain).toContain('ctrl+c to interrupt')
+    expect(plain).toContain('esc to interrupt')
     expect(plain).not.toContain('? for shortcuts')
   })
 

--- a/ui-tui/src/__tests__/escInterruptKeybinding.test.ts
+++ b/ui-tui/src/__tests__/escInterruptKeybinding.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import { HOTKEYS } from '../content/hotkeys.js'
+
+// Esc — not Ctrl+C — interrupts the running turn. Esc-interrupt matches the
+// original's `escape → chat:cancel` binding (defaultBindings.ts /
+// useCancelRequest.ts). NOTE: the original ALSO binds `ctrl+c →
+// app:interrupt` (plus double-press exit); removing Ctrl+C's interrupt/exit
+// roles here is a deliberate deviation per explicit user request ("use ESC
+// for interrupt, not Control+C … use /exit to exit the app") — do not
+// "restore" Ctrl+C-interrupt in a parity sweep.
+//
+// The dispatch lives inside a useInput closure and cannot be exercised
+// without mounting the renderer + stdin, so — same convention as
+// textInputCursorSourceOfTruth.test.ts — pin the contract at source level.
+const HANDLERS_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'app', 'useInputHandlers.ts')
+const source = readFileSync(HANDLERS_PATH, 'utf8')
+
+// The unblocked main dispatch — everything after the isBlocked early-return
+// block. The blocked branch legitimately keeps Ctrl+C as overlay dismissal.
+const MAIN_ANCHOR = '// Escape-based voice bindings'
+const mainDispatch = source.slice(source.indexOf(MAIN_ANCHOR))
+
+it('main-dispatch anchor exists (guards every slice below from matching nothing)', () => {
+  expect(source.indexOf(MAIN_ANCHOR)).toBeGreaterThan(-1)
+})
+
+describe('Esc interrupts the running turn', () => {
+  it('dismisses an open completion menu first (original: autocomplete registers as an overlay so chat:cancel defers)', () => {
+    expect(mainDispatch).toMatch(
+      /if\s*\(key\.escape\s*&&\s*cState\.completions\.length\)\s*\{\s*return cActions\.dismissCompletions\(\)/
+    )
+  })
+
+  it('has an escape branch calling turnController.interruptTurn gated on busy + sid', () => {
+    expect(mainDispatch).toMatch(
+      /if\s*\(key\.escape\s*&&\s*live\.busy\s*&&\s*live\.sid\)\s*\{\s*return turnController\.interruptTurn\(/
+    )
+  })
+
+  it('orders the Esc handlers: precedence guards → menu dismissal → interrupt', () => {
+    const voiceAt = mainDispatch.search(/key\.escape\s*&&\s*isVoiceToggleKey/)
+    const queueEditAt = mainDispatch.search(/key\.escape\s*&&\s*cState\.queueEditIdx/)
+    const selectionAt = mainDispatch.search(/key\.escape\s*&&\s*terminal\.hasSelection/)
+    const dismissAt = mainDispatch.search(/key\.escape\s*&&\s*cState\.completions\.length/)
+    const interruptAt = mainDispatch.search(/key\.escape\s*&&\s*live\.busy/)
+
+    for (const at of [voiceAt, queueEditAt, selectionAt, dismissAt, interruptAt]) {
+      expect(at).toBeGreaterThan(-1)
+    }
+
+    expect(voiceAt).toBeLessThan(dismissAt)
+    expect(queueEditAt).toBeLessThan(dismissAt)
+    expect(selectionAt).toBeLessThan(dismissAt)
+    expect(dismissAt).toBeLessThan(interruptAt)
+  })
+})
+
+describe('Ctrl+C neither interrupts nor exits', () => {
+  const CTRL_C_ANCHOR = "if (key.ctrl && ch.toLowerCase() === 'c')"
+  const END_ANCHOR = 'isAction'
+
+  it('anchors exist (a reformat must fail here, not silently pass the slices below)', () => {
+    expect(mainDispatch.indexOf(CTRL_C_ANCHOR)).toBeGreaterThan(-1)
+    expect(mainDispatch.slice(mainDispatch.indexOf(CTRL_C_ANCHOR)).indexOf(END_ANCHOR)).toBeGreaterThan(-1)
+  })
+
+  const afterCtrlC = mainDispatch.slice(Math.max(0, mainDispatch.indexOf(CTRL_C_ANCHOR)))
+  const ctrlCBlock = afterCtrlC.slice(0, Math.max(0, afterCtrlC.indexOf(END_ANCHOR)))
+
+  it('no longer calls interruptTurn from Ctrl+C', () => {
+    expect(ctrlCBlock).not.toContain('interruptTurn')
+  })
+
+  it('no longer exits from Ctrl+C — /exit owns exiting the app', () => {
+    expect(ctrlCBlock).not.toContain('handleIdleHotkeyExit')
+  })
+})
+
+describe('help content matches the bindings', () => {
+  it('advertises Esc as the interrupt key', () => {
+    expect(HOTKEYS.some(([k, v]) => k === 'Esc' && v.includes('interrupt'))).toBe(true)
+  })
+
+  it('does not advertise interrupt or exit on Ctrl+C', () => {
+    for (const [k, v] of HOTKEYS) {
+      if (k.includes('Ctrl+C')) {
+        expect(v).not.toContain('interrupt')
+        expect(v).not.toContain('exit')
+      }
+    }
+  })
+})

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -293,6 +293,13 @@ describe('GatewayClient NDJSON adapter', () => {
     expect(r.items.map(i => i.text)).toContain('/deep-research')
   })
 
+  it('lists /exit in the slash-completion menu (user-reported: /exit executed but never showed as a command)', async () => {
+    const p = gw.request<{ items: Array<{ text: string }> }>('complete.slash', { text: '/ex' })
+    await replyToControl('list_workflow_commands', { commands: [], ok: true })
+    const r = await p
+    expect(r.items.map(i => i.text)).toContain('/exit')
+  })
+
   it('merges backend workflow commands into the command catalog after init', async () => {
     proc.line(INIT) // resolves readyPromise, which the catalog awaits
     const p = gw.request<{ canon: Record<string, string>; pairs: [string, string][] }>('commands.catalog', {})

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -207,6 +207,7 @@ export type MaybePromise<T> = Promise<T> | T
 export interface ComposerActions {
   clearIn: () => void
   dequeue: () => string | undefined
+  dismissCompletions: () => void
   enqueue: (text: string) => void
   handleTextPaste: (event: PasteEvent) => MaybePromise<ComposerPasteResult | null>
   openEditor: () => Promise<void>

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -122,7 +122,7 @@ export function useComposerState({
   } = useQueue()
 
   const { historyRef, historyIdx, setHistoryIdx, historyDraftRef, pushHistory } = useInputHistory()
-  const { completions, compIdx, setCompIdx, compReplace } = useCompletion(input, isBlocked, gw)
+  const { completions, compIdx, setCompIdx, compReplace, dismissCompletions } = useCompletion(input, isBlocked, gw)
 
   const clearIn = useCallback(() => {
     setInput('')
@@ -300,6 +300,7 @@ export function useComposerState({
     () => ({
       clearIn,
       dequeue,
+      dismissCompletions,
       enqueue,
       handleTextPaste,
       openEditor,
@@ -316,6 +317,7 @@ export function useComposerState({
     [
       clearIn,
       dequeue,
+      dismissCompletions,
       enqueue,
       handleTextPaste,
       openEditor,

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -456,6 +456,29 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return clearSelection()
     }
 
+    // Esc dismisses an open completion menu before anything else — the
+    // original registers autocomplete as an overlay so its chat:cancel
+    // handler defers to the menu (useTypeahead.tsx); a second Esc then
+    // interrupts. Without this, Esc would kill the turn out from under a
+    // user who is mid-command (or mid-path) in the composer.
+    if (key.escape && cState.completions.length) {
+      return cActions.dismissCompletions()
+    }
+
+    // Esc interrupts the running turn, matching the original's
+    // `escape → chat:cancel` binding (defaultBindings.ts / useCancelRequest).
+    // NOTE deliberate deviation: the original ALSO binds `ctrl+c →
+    // app:interrupt`; Ctrl+C's interrupt/exit roles were removed here per
+    // explicit user request (Esc interrupts, /exit exits).
+    if (key.escape && live.busy && live.sid) {
+      return turnController.interruptTurn({
+        appendMessage: actions.appendMessage,
+        gw: gateway.gw,
+        sid: live.sid,
+        sys: actions.sys
+      })
+    }
+
     if (key.upArrow) {
       const inputSel = getInputSelection()
       const cursor = inputSel && inputSel.start === inputSel.end ? inputSel.start : null
@@ -495,8 +518,9 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
         return
       }
 
-      // On macOS, Cmd+C with no selection is a no-op (Ctrl+C below handles interrupt).
-      // On non-macOS, isAction uses Ctrl, so fall through to interrupt/clear/exit.
+      // On macOS, Cmd+C with no selection is a no-op (Ctrl+C below clears the
+      // draft). On non-macOS, isAction uses Ctrl, so fall through to the
+      // clear-draft / hint handler.
       if (isMac) {
         return
       }
@@ -513,26 +537,18 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     }
 
     if (key.ctrl && ch.toLowerCase() === 'c') {
-      if (live.busy && live.sid) {
-        return turnController.interruptTurn({
-          appendMessage: actions.appendMessage,
-          gw: gateway.gw,
-          sid: live.sid,
-          sys: actions.sys
-        })
-      }
-
       if (cState.input) {
         return cActions.clearIn()
       }
 
-      return handleIdleHotkeyExit(actions, DASHBOARD_TUI_MODE, () => {
-        gateway.gw.publishLocalEvent({
-          payload: { reason: 'idle_exit_hotkey' },
-          session_id: live.sid ?? undefined,
-          type: 'dashboard.new_session_requested'
-        })
-      })
+      // Ctrl+C neither interrupts (Esc does) nor exits (/exit does) — a bare
+      // press stays harmless so terminal muscle-memory can't kill a live turn
+      // or the whole app. Point at the real bindings instead. Dashboard chat
+      // gates /exit (core.ts DASHBOARD_EXIT_DISABLED_MESSAGE), so hint /new
+      // there.
+      const exitHint = DASHBOARD_TUI_MODE ? '/new to start a fresh chat' : '/exit to quit clawcodex'
+
+      return actions.sys(live.busy ? `esc to interrupt · ${exitHint}` : exitHint)
     }
 
     if (isAction(key, ch, 'd')) {

--- a/ui-tui/src/components/composerFooter.tsx
+++ b/ui-tui/src/components/composerFooter.tsx
@@ -54,7 +54,7 @@ export const ComposerFooter = memo(function ComposerFooter({
     <Text color={t.color.bashBorder}>! for bash mode</Text>
   ) : busy ? (
     <Text color={t.color.muted} dim>
-      ctrl+c to interrupt
+      esc to interrupt
     </Text>
   ) : (
     <Text color={t.color.muted} dim>

--- a/ui-tui/src/components/helpHint.tsx
+++ b/ui-tui/src/components/helpHint.tsx
@@ -9,7 +9,7 @@ const COMMON_COMMANDS: [string, string][] = [
   ['/resume', 'switch live or resume past sessions'],
   ['/details', 'control transcript detail level'],
   ['/copy', 'copy selection or last assistant message'],
-  ['/quit', 'exit clawcodex']
+  ['/exit', 'exit clawcodex']
 ]
 
 const HOTKEY_PREVIEW = HOTKEYS.slice(0, 8)

--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -6,16 +6,17 @@ const paste = isMac ? 'Cmd' : 'Alt'
 const copyHotkeys: [string, string][] = isMac
   ? [
       ['Cmd+C', 'copy selection'],
-      ['Ctrl+C', 'interrupt / clear draft / exit']
+      ['Ctrl+C', 'clear draft']
     ]
   : isRemoteShell()
     ? [
         ['Cmd+C', 'copy selection when forwarded by the terminal'],
-        ['Ctrl+C', 'copy selection / interrupt / clear draft / exit']
+        ['Ctrl+C', 'copy selection / clear draft']
       ]
-    : [['Ctrl+C', 'copy selection / interrupt / clear draft / exit']]
+    : [['Ctrl+C', 'copy selection / clear draft']]
 
 export const HOTKEYS: [string, string][] = [
+  ['Esc', 'interrupt the running turn'],
   ...copyHotkeys,
   [action + '+D', 'exit'],
   [action + '+G / Alt+G', 'open $EDITOR (Alt+G fallback for VSCode/Cursor)'],

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -228,7 +228,8 @@ const SLASHES: ReadonlyArray<{ desc: string; name: string }> = [
   { desc: 'Generate session insights', name: '/insights' },
   { desc: 'List or start background agents', name: '/bg' },
   { desc: 'Resume a past session', name: '/resume' },
-  { desc: 'Rename this session', name: '/rename' }
+  { desc: 'Rename this session', name: '/rename' },
+  { desc: 'Exit clawcodex', name: '/exit' }
 ]
 
 type Pending = { reject: (e: Error) => void; resolve: (v: unknown) => void }

--- a/ui-tui/src/hooks/useCompletion.ts
+++ b/ui-tui/src/hooks/useCompletion.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { CompletionItem } from '../app/interfaces.js'
 import { looksLikeSlashCommand } from '../domain/slash.js'
@@ -43,6 +43,15 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
   const [compIdx, setCompIdx] = useState(0)
   const [compReplace, setCompReplace] = useState(0)
   const ref = useRef('')
+
+  // Esc closes the menu without touching the input. The clear sticks because
+  // the fetch effect below only re-runs when the input text changes
+  // (ref.current guard) — the menu reappears on the next keystroke.
+  const dismissCompletions = useCallback(() => {
+    setCompletions([])
+    setCompIdx(0)
+    setCompReplace(0)
+  }, [])
 
   useEffect(() => {
     const clear = () => {
@@ -109,5 +118,5 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
     return () => clearTimeout(t)
   }, [blocked, gw, input])
 
-  return { completions, compIdx, setCompIdx, compReplace }
+  return { completions, compIdx, setCompIdx, compReplace, dismissCompletions }
 }


### PR DESCRIPTION
## User request

> use ESC for interrupt, not Control+C. and use "/exit" command to exit the app
> /exit should be a slash command. But it doesn't show as a slash command currently. When user hits the /exit slash command, app should exit.

## Changes

**Esc interrupts the running turn.** Matches the original's `escape → chat:cancel` binding (`useCancelRequest.ts`, `SpinnerAnimationRow`'s "(esc to interrupt"). Handler precedence: voice chord → queue-edit cancel → selection clear → **completion-menu dismissal** → interrupt. The menu-dismissal step mirrors the original's overlay deferral (useTypeahead registers autocomplete as an overlay so a first Esc closes the menu, a second cancels the task) — without it, Esc would kill the turn out from under a user mid-command or mid-path. Blocked overlays (approval prompts etc.) keep their own Esc semantics via the existing early-return; live-verified that an approval prompt's "Esc deny" still wins.

**Ctrl+C no longer interrupts or exits.** It keeps clear-draft; a bare press prints a hint pointing at `esc` / `/exit` (or `/new` in dashboard chat, where `/exit` is gated). Note: the original also binds `ctrl+c → app:interrupt` + double-press exit — removing those roles is a **deliberate deviation per the explicit user request**, and the code comment + pin test say so to protect future parity sweeps. Ctrl+D retains standard EOF exit.

**/exit now shows in the slash menu and /help catalog.** It always executed (alias of `/quit` in the TUI-local registry) but was missing from the hardcoded `SLASHES` list in `gatewayClient.ts` that feeds `complete.slash` and `commands.catalog`. Dispatch is unchanged — `createSlashHandler` consults the local registry first, so the menu entry routes to `session.die()`.

**Hint surfaces updated**: busy footer `ctrl+c to interrupt` → `esc to interrupt` (original parity), hotkeys help rows, `?`-help common commands show `/exit`.

**New plumbing**: `useCompletion` exposes `dismissCompletions()`; the clear sticks because the fetch effect only re-runs on input change.

## Tests

- New `escInterruptKeybinding.test.ts` — source-pin convention (dispatch lives in a `useInput` closure): Esc handler ordering incl. dismiss-before-interrupt, Ctrl+C block free of `interruptTurn`/`handleIdleHotkeyExit` (with anchor-exists guards against vacuous passes), HOTKEYS content.
- `gatewayClient.test.ts`: `complete.slash('/ex')` lists `/exit` (regression for the user report).
- `composerFooter.test.ts`: busy-hint expectation updated.
- `tsc --noEmit` clean; full vitest at the known 9-failure env baseline (1177 passed).

## Live PTY e2e (pyte, real backend + real model turn) — ALL PASS

draft → Ctrl+C clears (app alive) → second Ctrl+C shows `/exit` hint (app alive) → idle Esc harmless → busy footer shows `esc to interrupt` → `/he` opens menu **while streaming** → first Esc dismisses menu, turn keeps running → second Esc interrupts (`Interrupted · What should clawcodex do instead?`) → `/ex` shows the `/exit · Exit clawcodex` menu entry → menu-selected `/exit` exits the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)