### PR TITLE
fix(perm): harden Bash permission normalization (substitution guard + deny wrappers)

### DIFF
--- a/src/permissions/bash_suggestions.py
+++ b/src/permissions/bash_suggestions.py
@@ -156,6 +156,61 @@ MAX_SUBCOMMANDS: int = 50
 MAX_SUGGESTED_RULES_FOR_COMPOUND: int = 5
 
 
+def contains_executable_substitution(command: str) -> bool:
+    """True if ``command`` contains command substitution that EXECUTES —
+    ``$(…)``, backticks, or bash-5.3 value substitution ``${ …}`` / ``${| …}`` —
+    anywhere NOT inside single quotes (single quotes make them literal; a
+    backslash-escaped ``\\$``/``\\```` in double quotes is literal too).
+
+    The safety analyzer (``analyze_bash_command``) tokenizes ``$(…)`` into an
+    opaque placeholder and never rates the inner command, and the content
+    matcher compares raw substrings — so ``echo "$(rm -rf /)"`` with an
+    ``echo:*`` allow rule would run the ``rm`` unseen. Callers use this to
+    REFUSE to auto-allow such a command (it prompts instead), converting a
+    silent over-allow into a review. It does NOT make a ``rm:*`` deny fire on
+    the hidden command — that needs the analyzer to recurse (a larger change).
+    """
+
+    in_single = False
+    in_double = False
+    i = 0
+    n = len(command)
+    while i < n:
+        ch = command[i]
+        if ch == "\\" and not in_single:
+            i += 2  # escaped char (incl. \$ / \` in double quotes) — literal
+            continue
+        if ch == "'" and not in_double:
+            # `$'…'` ANSI-C quoting desyncs this scanner (escaped quotes inside)
+            # — refuse defensively rather than risk missing a trailing $().
+            if not in_single and i > 0 and command[i - 1] == "$":
+                return True
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif not in_single:
+            if ch == "`":
+                return True
+            if ch == "$" and i + 1 < n and command[i + 1] == "{":
+                after = command[i + 2] if i + 2 < n else ""
+                if after == "" or after.isspace() or after == "|":
+                    return True
+            if ch == "$" and i + 1 < n and command[i + 1] == "(":
+                if i + 2 < n and command[i + 2] == "(":
+                    i += 3  # `$((` arithmetic — evaluates, runs no command
+                    continue
+                return True  # `$(` command substitution
+            # A bare `(` outside quotes is a subshell / group / the paren of
+            # process substitution `<(`/`>(` — all execute. (Inside double
+            # quotes `(` is literal; `$(`'s own paren is handled above.) This
+            # is what catches `\$(rm)` — the `\$` is literal but `(rm)` is a
+            # subshell — plus `cat <(rm)` / `tee >(rm) f`.
+            if not in_double and ch == "(":
+                return True
+        i += 1
+    return False
+
+
 def split_chained_command(command: str) -> list[str] | None:
     """Split ``command`` on unquoted chaining operators (``&&``, ``||``,
     ``;``, ``|``, ``|&``, ``&``, newline) into its sub-commands.
@@ -576,6 +631,7 @@ __all__ = [
     "MAX_SUGGESTED_RULES_FOR_COMPOUND",
     "SAFE_ENV_VARS",
     "SAFE_PREFIX_COMMANDS",
+    "contains_executable_substitution",
     "contains_unquoted_chaining",
     "get_safe_first_word_prefix",
     "get_simple_command_prefix",

--- a/src/permissions/check.py
+++ b/src/permissions/check.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, Protocol, runtime_checkable
 from .bash_security import analyze_bash_command
 from .bash_suggestions import (
     SAFE_ENV_VARS,
+    contains_executable_substitution,
     contains_unquoted_chaining,
     split_chained_command,
 )
@@ -506,6 +507,16 @@ def has_permissions_to_use_tool_inner(
     content_rules = get_rule_by_contents_for_tool(context, tool.name, "allow")
     if content_rules and tool.name == "Bash":
         command = tool_input.get("command", "")
+        # A content ALLOW rule (e.g. Bash(echo:*)) must never auto-allow a
+        # command that hides an executable substitution — `echo "$(rm -rf /)"`
+        # runs the rm, which the safety analyzer tokenizes away and the string
+        # matcher can't see. Refuse to auto-allow → the command prompts instead
+        # (the compound path is already covered: split_chained_command refuses
+        # substitution, so per-sub allow never fires on it). Content-less
+        # "allow all Bash" is intentionally NOT gated here — that user allowed
+        # everything.
+        if command and contains_executable_substitution(command):
+            command = ""
         if command:
             # Try the command AND — like the suggestion ladder, which skips
             # SAFE_ENV_VARS — a copy with those safe assignments stripped, so
@@ -782,10 +793,59 @@ def check_rule_based_permissions(
 # double-quoted (both may contain spaces), or a bare word. Matching the quote
 # form is what stops ``FOO="a b" rm x`` from splitting mid-value and leaving the
 # ``rm`` unstripped — which would let a quoted-space env prefix bypass a
-# ``Bash(rm:*)`` deny/ask rule.
+# ``Bash(rm:*)`` deny/ask rule. The bare value class excludes shell metachars
+# (``;|&()<>$`` + backtick) so it can't over-consume an operator into the value
+# (TS's class does the same); the splitter separates real operators first, but
+# this keeps the helper correct if reused outside that sandwich.
 _ENV_ASSIGNMENT_RE = re.compile(
-    r"[A-Za-z_][A-Za-z0-9_]*=(?:'[^']*'|\"[^\"]*\"|[^\s'\"]*)"
+    r"[A-Za-z_][A-Za-z0-9_]*=(?:'[^']*'|\"[^\"]*\"|[^\s'\";|&()<>$`]*)"
 )
+
+# Safe command wrappers TS strips before deny/ask matching (stripSafeWrappers,
+# bashPermissions.ts:501-540) so `timeout 5 rm -rf x` / `nohup rm x` can't slip
+# past a Bash(rm:*) deny. Only wrappers that don't change WHICH program runs
+# (sudo/env/xargs are deliberately excluded — they can redirect execution).
+_SAFE_WRAPPER_RES = [
+    re.compile(
+        r"^timeout[ \t]+(?:(?:--\S+|-[A-Za-z][ \t]+\S+|-[A-Za-z]\S*)[ \t]+)*"
+        r"(?:--[ \t]+)?\d+(?:\.\d+)?[smhd]?[ \t]+"
+    ),
+    re.compile(r"^time[ \t]+(?:--[ \t]+)?"),
+    re.compile(r"^nice(?:[ \t]+-n[ \t]+-?\d+|[ \t]+-\d+)?[ \t]+(?:--[ \t]+)?"),
+    re.compile(r"^stdbuf(?:[ \t]+-[ioe]\S+)+[ \t]+(?:--[ \t]+)?"),
+    re.compile(r"^nohup[ \t]+(?:--[ \t]+)?"),
+]
+
+
+def _strip_safe_wrappers(command: str) -> str:
+    rest = command.lstrip()
+    changed = True
+    while changed:
+        changed = False
+        for pat in _SAFE_WRAPPER_RES:
+            m = pat.match(rest)
+            if m:
+                rest = rest[m.end():].lstrip()
+                changed = True
+                break
+    return rest
+
+
+def _normalize_for_deny_ask(command: str) -> str:
+    """Reduce a command to the program it will actually run, for deny/ask
+    matching: strip ALL env assignments and safe wrappers, interleaved to a
+    fixed point (``nohup FOO=1 timeout 5 rm`` → ``rm``), then unescape a leading
+    ``\\`` on the command word (bash runs ``\\rm`` as ``rm``)."""
+
+    prev = None
+    cur = command.lstrip()
+    while cur != prev:
+        prev = cur
+        cur = _strip_all_env_assignments(cur)
+        cur = _strip_safe_wrappers(cur)
+    if cur.startswith("\\") and len(cur) > 1 and cur[1] not in " \t\\":
+        cur = cur[1:]
+    return cur
 
 
 def _strip_env_assignments(command: str, *, safe_only: bool) -> str:
@@ -850,18 +910,20 @@ def _match_bash_content_rules(
             return rule  # exact match bypasses the compound guard (TS 'exact')
         matchers.append((prepare_permission_matcher(rule_content), rule))
 
-    # For deny/ask, ALSO try the command with all leading NAME=value prefixes
-    # stripped, so `FOO=1 rm x` / `FOO="a b" rm x` can't slip past Bash(rm:*)
-    # (TS stripAllEnvVars). Allow matching deliberately does NOT strip — an
-    # env-prefixed command is a different command and should re-prompt.
-    strip_env = behavior in ("deny", "ask")
+    # For deny/ask, ALSO try the command normalized to the program it actually
+    # runs — env assignments + safe wrappers stripped, leading `\` unescaped —
+    # so `FOO=1 rm x`, `timeout 5 rm x`, `nohup rm x`, `\rm x` can't slip past
+    # Bash(rm:*) (TS stripAllEnvVars + stripSafeWrappers). Allow matching
+    # deliberately does NOT normalize — a wrapped/prefixed command is a
+    # different command and should re-prompt.
+    normalize = behavior in ("deny", "ask")
 
     def _match_one(cmd: str) -> "PermissionRule | None":
         variants = [cmd]
-        if strip_env:
-            no_env = _strip_all_env_assignments(cmd)
-            if no_env and no_env != cmd:
-                variants.append(no_env)
+        if normalize:
+            norm = _normalize_for_deny_ask(cmd)
+            if norm and norm != cmd:
+                variants.append(norm)
         for cand in variants:
             for matcher, rule in matchers:
                 if matcher(cand):

--- a/tests/test_r6_compound_permissions.py
+++ b/tests/test_r6_compound_permissions.py
@@ -242,5 +242,114 @@ class TestContentDenyAskEnforced(unittest.TestCase):
         self.assertEqual(_decide("git status && git log", ctx).behavior, "ask")
 
 
+class TestSubstitutionAllowGuard(unittest.TestCase):
+    """A content ALLOW rule must never auto-allow a command hiding an
+    executable construct. The guard is SELF-SUFFICIENT — it catches every
+    execution form directly, not relying on the safety analyzer's tokenizer
+    (see TestSafetyScreenBackstop for the independent belt-and-suspenders)."""
+
+    def test_echo_grant_does_not_run_hidden_execution(self):
+        ctx = _ctx(allow=("echo:*", "cat:*", "tee:*"))
+        for cmd in (
+            'echo "$(rm -rf /)"',        # cmd-sub in double quotes
+            'echo "`rm -rf /`"',         # backtick in double quotes
+            'echo "${ rm -rf /; }"',     # bash-5.3 value substitution
+            'echo $(rm -rf /)',          # cmd-sub unquoted
+            'echo \\$(rm -rf /)',        # \$ literal but (rm) is a SUBSHELL
+            'cat <(rm -rf /)',           # process substitution
+            'tee >(rm -rf /) f',         # process substitution
+            "echo $'x'$(rm -rf /)",      # ANSI-C quoting (scanner desync)
+            'echo hi; (rm -rf /)',       # bare subshell in a compound
+        ):
+            self.assertEqual(_decide(cmd, ctx).behavior, "ask", cmd)
+
+    def test_legit_commands_under_the_grant_still_allow(self):
+        ctx = _ctx(allow=("echo:*",))
+        self.assertEqual(_decide("echo hello world", ctx).behavior, "allow")
+        # Single quotes make $() literal — no execution, so allow is fine.
+        self.assertEqual(_decide("echo '$(x)'", ctx).behavior, "allow")
+        # Arithmetic runs no command; parameter expansion / quoted parens too.
+        self.assertEqual(_decide("echo $((1 + 1))", ctx).behavior, "allow")
+        self.assertEqual(_decide('echo "${HOME}"', ctx).behavior, "allow")
+        self.assertEqual(_decide('echo "(literal paren)"', ctx).behavior, "allow")
+
+    def test_deny_still_wins_over_substitution_command(self):
+        # Even though the guard makes it ask, an explicit echo deny still denies.
+        ctx = _ctx(allow=("echo:*",), deny=("echo:*",))
+        self.assertEqual(_decide('echo "$(rm -rf /)"', ctx).behavior, "deny")
+
+
+class TestSafetyScreenBackstop(unittest.TestCase):
+    """Belt-and-suspenders: with the REAL bash safety screen wired in (not the
+    passthrough stub the other tests use), genuinely-dangerous commands are
+    caught even without any rule — and the substitution forms stay ask whether
+    the guard or the analyzer fires. Pins that the two layers agree."""
+
+    def _decide_faithful(self, command, allow=()):
+        from src.tool_system.tools.bash.bash_tool import check_bash_command_safety
+
+        class _FaithfulBash:
+            name = "Bash"
+
+            def check_permissions(self, tool_input, context):
+                r = check_bash_command_safety(tool_input.get("command", ""), cwd=None)
+                return r if r is not None else PermissionPassthroughResult()
+
+        ctx = ToolPermissionContext(
+            always_allow_rules={"session": [f"Bash({r})" for r in allow]}
+        )
+        return has_permissions_to_use_tool_inner(
+            _FaithfulBash(), {"command": command}, ctx
+        ).behavior
+
+    def test_dangerous_command_asks_without_a_rule(self):
+        self.assertEqual(self._decide_faithful("rm -rf /tmp/x"), "ask")
+
+    def test_substitution_forms_ask_even_with_a_grant(self):
+        # The guard fires first; the safety screen would also catch these — both
+        # layers point the same way, so this can never silently over-allow.
+        for cmd in (
+            'echo "$(rm -rf /)"',
+            'cat <(rm -rf /)',
+            'echo \\$(rm -rf /)',
+            "echo $'x'$(rm -rf /)",
+        ):
+            self.assertEqual(self._decide_faithful(cmd, allow=("echo:*", "cat:*")),
+                             "ask", cmd)
+
+    def test_plain_safe_command_still_allows_under_grant(self):
+        self.assertEqual(self._decide_faithful("echo hello", allow=("echo:*",)),
+                         "allow")
+
+
+class TestDenyNormalization(unittest.TestCase):
+    """deny/ask reduce to the program that actually runs (env + safe wrappers +
+    leading-backslash) so wrapping can't bypass a Bash(rm:*) deny."""
+
+    def test_safe_wrappers_cannot_bypass_deny(self):
+        ctx = _ctx(deny=("rm:*",))
+        for cmd in (
+            "timeout 5 rm -rf x",
+            "timeout --preserve-status 5s rm -rf x",
+            "nohup rm -rf x",
+            "nice -n 5 rm -rf x",
+            "time rm -rf x",
+            "nohup FOO=1 timeout 5 rm -rf x",  # interleaved wrapper + env
+            "echo hi && timeout 5 rm -rf x",   # inside a compound sub
+        ):
+            self.assertEqual(_decide(cmd, ctx).behavior, "deny", cmd)
+
+    def test_leading_backslash_cannot_bypass_deny(self):
+        ctx = _ctx(deny=("rm:*",))
+        self.assertEqual(_decide("\\rm -rf x", ctx).behavior, "deny")
+        self.assertEqual(_decide("echo a && \\rm -rf x", ctx).behavior, "deny")
+
+    def test_wrapper_stripping_does_not_false_allow(self):
+        # timeout-wrapped command is NOT auto-allowed just because a sub-word
+        # matches (allow does not normalize wrappers).
+        ctx = _ctx(allow=("rm:*",))
+        self.assertEqual(_decide("timeout 5 rm -rf x", ctx).behavior, "ask")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-up to #622 from the critic-compound security review. Closes a **pre-existing silent-over-allow** + brings deny/ask normalization to TS parity.

- **(A) Executable-substitution allow guard.** A simple `echo "$(rm -rf /)"` with a common `Bash(echo:*)` grant **ran the rm** (the safety analyzer tokenizes `$()` opaque; a `rm:*` deny didn't stop it either). New self-sufficient, quote-aware `contains_executable_substitution` catches `$()`/backtick/`${ }`, ANSI-C `$'`, and any bare unquoted `(` (subshell / process-sub `<(`/`>(` / the `(rm)` of `\$(rm)`), while allowing arithmetic `$((…))` and quoted parens. Content-ALLOW refuses to auto-allow such a command → it prompts.
- **(B)** deny/ask strip safe wrappers (`timeout`/`nohup`/`nice`/`stdbuf`/`time`, interleaved with env to a fixed point) so `timeout 5 rm` can't bypass a deny. **(C)** unescape leading `\` (`\rm`). **(D)** tighten the env-value regex.

**Critic: APPROVE**; addressed its MAJOR (made the guard self-sufficient rather than relying on the analyzer backstop, + a faithful-stub test calling the real `check_bash_command_safety`).

Tests: TestSubstitutionAllowGuard + TestSafetyScreenBackstop + TestDenyNormalization. Full suite at the 9-failure baseline (7648 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)