### PR TITLE
feat(cost): restore session cost/duration/token display (/cost + exit summary), original-CC parity

### DIFF
--- a/src/query/query.py
+++ b/src/query/query.py
@@ -1107,12 +1107,22 @@ async def _call_model_sync(
     # converge here, so every main-loop response is counted exactly once.
     # Empty usage (a stream whose final-message read failed) records zeros.
     try:
+        from ..bootstrap.state import add_to_total_duration_state
         from ..cost_tracker import record_api_usage
 
         record_api_usage(
             getattr(response, "model", None) or getattr(provider, "model", "unknown"),
             response.usage,
         )
+        # The original records per-request API duration alongside cost
+        # (addToTotalDuration beside addToTotalSessionCost); this feeds
+        # /cost's "Total duration (API)". This layer can't split retries:
+        # provider-internal ones are inside the span (so both counters get
+        # the same value), while a raise-then-retry by our caller records
+        # nothing for the failed attempt (the original's including-retries
+        # counter would) — a slight undercount, accepted.
+        _api_ms = int((time.monotonic() - _t0) * 1000)
+        add_to_total_duration_state(_api_ms, _api_ms)
     except Exception:
         logger.debug("cost recording failed", exc_info=True)
 

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -399,6 +399,9 @@ class _AgentSession:
         if subtype == "get_context_usage":
             self._reply(request_id, self._context_usage())
             return
+        if subtype == "cost":
+            self._reply(request_id, _cost_snapshot())
+            return
         if subtype == "compact":
             await self._do_compact(request_id, inner.get("instructions"))
             return
@@ -2448,6 +2451,54 @@ def _sdk_envelope(message: Any, session_id: str) -> dict | None:
     return env
 
 
+def _cost_snapshot() -> dict:
+    """Session cost/duration totals for the client's /cost command and
+    exit summary (the original's formatTotalCost inputs, cost-tracker.ts:249).
+
+    Reads the bootstrap accumulators — the same counters the /resume cost
+    restore repopulates — so the numbers survive restarts. Best-effort:
+    a failure returns an empty snapshot rather than breaking the caller.
+    """
+    try:
+        from src.bootstrap.state import (
+            cost_state_lock,
+            get_model_usage,
+            get_total_api_duration,
+            get_total_cost_usd,
+            get_total_duration,
+            get_total_lines_added,
+            get_total_lines_removed,
+            has_unknown_model_cost,
+        )
+
+        # Hold the accumulator lock across the multi-accessor read —
+        # concurrent subagent threads insert into model_usage mid-turn, and
+        # an unguarded dict iteration can raise (state.py:240 contract).
+        with cost_state_lock():
+            return {
+                "total_cost_usd": get_total_cost_usd(),
+                "total_api_duration_ms": int(get_total_api_duration()),
+                "total_duration_ms": get_total_duration(),
+                "total_lines_added": get_total_lines_added(),
+                "total_lines_removed": get_total_lines_removed(),
+                "has_unknown_model_cost": has_unknown_model_cost(),
+                "model_usage": {
+                    model: {
+                        "input_tokens": u.input_tokens,
+                        "output_tokens": u.output_tokens,
+                        "cache_read_input_tokens": u.cache_read_input_tokens,
+                        "cache_creation_input_tokens": u.cache_creation_input_tokens,
+                        "web_search_requests": u.web_search_requests,
+                        "cost_usd": u.cost_usd,
+                    }
+                    for model, u in get_model_usage().items()
+                },
+            }
+    except Exception:  # noqa: BLE001 — cost display is best-effort
+        logger.debug("[agent-server] cost snapshot failed", exc_info=True)
+        return {}
+
+
 def _result_message(
     session_id: str,
     *,
@@ -2471,6 +2522,10 @@ def _result_message(
         "is_error": is_error,
         "usage": usage or None,
         "total_cost_usd": total_cost_usd,
+        # Running session totals, refreshed every turn so the client can
+        # print the exit cost summary synchronously (the original registers
+        # process.on('exit') over live cost-tracker state, costHook.ts:12).
+        "cost": _cost_snapshot(),
     }
     if error is not None:
         payload["error"] = error

--- a/src/services/compact/compact.py
+++ b/src/services/compact/compact.py
@@ -195,7 +195,12 @@ def _record_compaction_usage(context: "CompactContext", usage: Any) -> None:
     (ch04 round-3 G1 — TS counts every API call via addToTotalSessionCost
     in the API layer; the port's direct provider calls must self-record).
     Records under the summarize model (``context.model``), falling back
-    to the provider's. Never raises."""
+    to the provider's. Never raises.
+
+    Known gap: unlike the main loop and the advisor, summarize calls feed
+    no ``add_to_total_duration_state`` (this helper runs after the call,
+    with no start time in scope), so /cost's "Total duration (API)"
+    excludes compaction while its cost total includes it."""
     try:
         from src.cost_tracker import record_api_usage
 

--- a/src/tool_system/diff_utils.py
+++ b/src/tool_system/diff_utils.py
@@ -65,3 +65,32 @@ def unified_diff_hunks(diff_lines: Iterable[str]) -> list[dict]:
         hunks.append(current)
     return hunks
 
+
+def record_patch_line_totals(hunks: list[dict], new_file_content: str | None = None) -> None:
+    """Accumulate this patch's +/- line counts into the session totals.
+
+    Mirrors TS ``utils/diff.ts:50-69``: counts hunk lines by their marker,
+    with the new-file special case (empty patch + content → every line is
+    an addition). Feeds /cost's "Total code changes". Best-effort — an
+    accounting failure must never fail the edit itself.
+    """
+    try:
+        if not hunks and new_file_content:
+            # TS: newFileContent.split(/\r?\n/).length — trailing newline
+            # yields a final empty segment that IS counted; keep that.
+            added = len(re.split(r"\r?\n", new_file_content))
+            removed = 0
+        else:
+            added = sum(
+                1 for h in hunks for ln in h.get("lines", []) if ln.startswith("+")
+            )
+            removed = sum(
+                1 for h in hunks for ln in h.get("lines", []) if ln.startswith("-")
+            )
+        if added or removed:
+            from src.bootstrap.state import add_to_total_lines_changed
+
+            add_to_total_lines_changed(added, removed)
+    except Exception:  # noqa: BLE001 — cost accounting is best-effort
+        pass
+

--- a/src/tool_system/tools/edit.py
+++ b/src/tool_system/tools/edit.py
@@ -10,7 +10,11 @@ from typing import Any
 
 from ..build_tool import Tool, build_tool
 from ..context import ToolContext
-from ..diff_utils import convert_leading_tabs_to_spaces, unified_diff_hunks
+from ..diff_utils import (
+    convert_leading_tabs_to_spaces,
+    record_patch_line_totals,
+    unified_diff_hunks,
+)
 from .read import _backfill_read_edit_path  # shared file_path expander
 from ..errors import ToolInputError, ToolPermissionError
 from ..protocol import ToolResult
@@ -243,6 +247,14 @@ def _edit_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(new_string, encoding="utf-8")
         context.mark_file_read(path)
+        # The original's edit-create counts the real '' -> content patch
+        # (FileEditTool.ts:534 -> getPatchForEdit -> countLinesChanged),
+        # whose hunk is one "+" line per content line — NOT Write's
+        # empty-patch split special case (which also counts a trailing-
+        # newline empty segment). Synthesize that hunk.
+        record_patch_line_totals(
+            [{"lines": ["+" + ln for ln in new_string.splitlines()]}]
+        )
         return ToolResult(
             name="Edit",
             output={
@@ -324,6 +336,7 @@ def _edit_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
         )
     )
     hunks = unified_diff_hunks(diff_lines)
+    record_patch_line_totals(hunks)
 
     return ToolResult(
         name="Edit",

--- a/src/tool_system/tools/write.py
+++ b/src/tool_system/tools/write.py
@@ -8,7 +8,11 @@ from ..build_tool import Tool, ValidationResult, build_tool
 from ..context import ToolContext
 from ..errors import ToolInputError, ToolPermissionError
 from ..protocol import ToolResult
-from ..diff_utils import convert_leading_tabs_to_spaces, unified_diff_hunks
+from ..diff_utils import (
+    convert_leading_tabs_to_spaces,
+    record_patch_line_totals,
+    unified_diff_hunks,
+)
 from src.permissions.types import (
     PermissionAllowDecision,
     PermissionAskDecision,
@@ -259,6 +263,15 @@ def _write_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
         )
     )
     hunks = unified_diff_hunks(diff_lines)
+    # New file: the original's write-create path passes an EXPLICITLY empty
+    # patch (FileWriteTool.ts:408, countLinesChanged([], content)), so the
+    # split(/\r?\n/) special case runs and a trailing newline counts one
+    # extra (empty) segment. Passing the difflib hunks here instead would
+    # undercount by that segment.
+    record_patch_line_totals(
+        [] if original_file is None else hunks,
+        content if original_file is None else None,
+    )
     return ToolResult(
         name="Write",
         output={

--- a/src/utils/advisor.py
+++ b/src/utils/advisor.py
@@ -31,6 +31,7 @@ Anthropic advisors on Anthropic main loops, or for transparency).
 from __future__ import annotations
 
 import os
+import time
 from typing import Any, Mapping, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -783,6 +784,7 @@ def execute_client_advisor(
     # Anthropic (line 239 of anthropic_provider.py forwards unknown
     # kwargs straight to ``messages.create``). Streaming under the hood
     # but no ``on_text_chunk`` callback — we only need the final text.
+    _t0 = time.monotonic()
     try:
         try:
             response = provider.chat_stream_response(
@@ -810,8 +812,10 @@ def execute_client_advisor(
 
     # ch04 round-3 G1: the client-side advisor is its own API call -- it
     # must self-record into the bootstrap cost totals (the query loop's
-    # head only sees main-loop responses).
+    # head only sees main-loop responses). Duration rides along so /cost's
+    # "Total duration (API)" covers the same calls its cost total does.
     try:
+        from src.bootstrap.state import add_to_total_duration_state
         from src.cost_tracker import record_api_usage
 
         record_api_usage(
@@ -820,6 +824,8 @@ def execute_client_advisor(
             or getattr(provider, "model", "unknown"),
             raw_usage,
         )
+        _api_ms = int((time.monotonic() - _t0) * 1000)
+        add_to_total_duration_state(_api_ms, _api_ms)
     except Exception:
         import logging
 

--- a/tests/server/test_cost_snapshot.py
+++ b/tests/server/test_cost_snapshot.py
@@ -1,0 +1,160 @@
+"""Cost display plumbing: the agent-server ``cost`` snapshot and the
+patch line-count accounting behind /cost's "Total code changes".
+
+Covers:
+* ``_cost_snapshot()`` mirrors the bootstrap accumulators (the inputs of
+  the original's formatTotalCost, cost-tracker.ts:249).
+* ``_result_message`` carries the snapshot rider the TUI's exit summary
+  prints (the original's useCostSummary, costHook.ts:12).
+* ``record_patch_line_totals`` counts +/- hunk lines with the new-file
+  special case (TS utils/diff.ts:50-69) and never raises.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.bootstrap.state import (
+    ModelUsage,
+    add_to_total_duration_state,
+    add_to_total_lines_changed,
+    get_total_lines_added,
+    get_total_lines_removed,
+    reset_state_for_tests,
+)
+from src.cost_tracker import record_api_usage
+from src.server.agent_server import _cost_snapshot, _result_message
+from src.tool_system.diff_utils import record_patch_line_totals
+
+
+@pytest.fixture(autouse=True)
+def _reset_bootstrap():
+    reset_state_for_tests()
+    yield
+    reset_state_for_tests()
+
+
+class TestCostSnapshot:
+    def test_empty_session_snapshot_zeros(self) -> None:
+        snap = _cost_snapshot()
+        assert snap["total_cost_usd"] == 0.0
+        assert snap["total_api_duration_ms"] == 0
+        assert snap["total_duration_ms"] >= 0
+        assert snap["total_lines_added"] == 0
+        assert snap["total_lines_removed"] == 0
+        assert snap["has_unknown_model_cost"] is False
+        assert snap["model_usage"] == {}
+
+    def test_snapshot_reflects_accumulators(self) -> None:
+        record_api_usage(
+            "deepseek-chat",
+            {
+                "input_tokens": 1000,
+                "output_tokens": 2000,
+                "cache_read_input_tokens": 500,
+                "cache_creation_input_tokens": 100,
+            },
+        )
+        add_to_total_duration_state(1234, 1200)
+        add_to_total_lines_changed(10, 2)
+
+        snap = _cost_snapshot()
+        assert snap["total_api_duration_ms"] == 1234
+        assert snap["total_lines_added"] == 10
+        assert snap["total_lines_removed"] == 2
+        mu = snap["model_usage"]["deepseek-chat"]
+        assert mu["input_tokens"] == 1000
+        assert mu["output_tokens"] == 2000
+        assert mu["cache_read_input_tokens"] == 500
+        assert mu["cache_creation_input_tokens"] == 100
+        assert snap["total_cost_usd"] == pytest.approx(mu["cost_usd"])
+
+    def test_result_message_carries_cost_rider(self) -> None:
+        add_to_total_lines_changed(3, 1)
+        msg = _result_message(
+            "sid", subtype="success", num_turns=1, result="ok", is_error=False,
+        )
+        assert msg["cost"]["total_lines_added"] == 3
+        assert msg["cost"]["total_lines_removed"] == 1
+
+
+class TestRecordPatchLineTotals:
+    def test_counts_hunk_markers(self) -> None:
+        hunks = [
+            {"lines": [" ctx", "+new one", "+new two", "-old"]},
+            {"lines": ["+more", " ctx"]},
+        ]
+        record_patch_line_totals(hunks)
+        assert get_total_lines_added() == 3
+        assert get_total_lines_removed() == 1
+
+    def test_new_file_counts_every_line_as_addition(self) -> None:
+        # TS: newFileContent.split(/\r?\n/).length — the trailing-newline
+        # empty segment IS counted (3 segments here).
+        record_patch_line_totals([], "line1\nline2\n")
+        assert get_total_lines_added() == 3
+        assert get_total_lines_removed() == 0
+
+    def test_noop_patch_records_nothing(self) -> None:
+        record_patch_line_totals([])
+        record_patch_line_totals([{"lines": [" ctx only"]}])
+        assert get_total_lines_added() == 0
+        assert get_total_lines_removed() == 0
+
+    def test_best_effort_never_raises(self) -> None:
+        record_patch_line_totals([{"lines": None}])  # type: ignore[list-item]
+        record_patch_line_totals(None)  # type: ignore[arg-type]
+
+
+class TestToolCallSiteLineCounts:
+    """Pin the ORIGINAL's per-tool create semantics at the call sites —
+    Write-create uses the split special case (trailing newline counts an
+    extra empty segment, FileWriteTool.ts:408), while Edit-create counts
+    the real ''→content patch (FileEditTool.ts:534): one line fewer for
+    the same trailing-newline content."""
+
+    @pytest.fixture(autouse=True)
+    def _workspace(self, tmp_path):
+        from src.tool_system.context import ToolContext
+        from src.tool_system.defaults import build_default_registry
+
+        self.root = tmp_path
+        self.registry = build_default_registry(include_user_tools=False)
+        self.ctx = ToolContext(workspace_root=tmp_path)
+        yield
+
+    def _dispatch(self, name: str, **input_data) -> None:
+        from src.tool_system.protocol import ToolCall
+
+        result = self.registry.dispatch(ToolCall(name=name, input=input_data), self.ctx)
+        assert not result.is_error, getattr(result, "output", result)
+
+    def test_write_create_counts_trailing_newline_segment(self) -> None:
+        self._dispatch("Write", file_path=str(self.root / "new.txt"), content="a\nb\n")
+        assert get_total_lines_added() == 3
+        assert get_total_lines_removed() == 0
+
+    def test_edit_create_counts_real_patch_lines(self) -> None:
+        self._dispatch(
+            "Edit", file_path=str(self.root / "new.txt"), old_string="", new_string="a\nb\n"
+        )
+        assert get_total_lines_added() == 2
+        assert get_total_lines_removed() == 0
+
+    def test_write_update_counts_hunk_lines(self) -> None:
+        target = self.root / "f.txt"
+        self._dispatch("Write", file_path=str(target), content="a\nb\n")
+        reset_state_for_tests()
+        self._dispatch("Write", file_path=str(target), content="a\nc\n")
+        assert get_total_lines_added() == 1
+        assert get_total_lines_removed() == 1
+
+    def test_edit_update_counts_hunk_lines(self) -> None:
+        target = self.root / "f.txt"
+        self._dispatch("Write", file_path=str(target), content="a\nb\n")
+        reset_state_for_tests()
+        self._dispatch(
+            "Edit", file_path=str(target), old_string="b", new_string="c\nd"
+        )
+        assert get_total_lines_added() == 2
+        assert get_total_lines_removed() == 1

--- a/ui-tui/src/__tests__/costSummary.test.ts
+++ b/ui-tui/src/__tests__/costSummary.test.ts
@@ -1,0 +1,128 @@
+/**
+ * costSummary — parity checks against the original's formatTotalCost
+ * (cost-tracker.ts:194-265) and format helpers (utils/format.ts:34-131).
+ * Expected strings are the original functions' outputs for the same inputs.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { CostSnapshot } from '../gatewayTypes.js'
+import {
+  formatCost,
+  formatDuration,
+  formatNumber,
+  formatTotalCost,
+  getLastCostSnapshot,
+  setLastCostSnapshot
+} from '../lib/costSummary.js'
+
+describe('formatCost', () => {
+  it('uses 4 decimals at or below fifty cents (original boundary is > 0.5)', () => {
+    expect(formatCost(0)).toBe('$0.0000')
+    expect(formatCost(0.0567)).toBe('$0.0567')
+    expect(formatCost(0.5)).toBe('$0.5000')
+  })
+
+  it('rounds to 2 decimals above fifty cents', () => {
+    expect(formatCost(0.51)).toBe('$0.51')
+    expect(formatCost(1.23456)).toBe('$1.23')
+    expect(formatCost(12.999)).toBe('$13.00')
+  })
+})
+
+describe('formatDuration', () => {
+  it('formats sub-minute durations as floored whole seconds', () => {
+    expect(formatDuration(0)).toBe('0s')
+    expect(formatDuration(0.5)).toBe('0.0s')
+    expect(formatDuration(999)).toBe('0s')
+    expect(formatDuration(59_999)).toBe('59s')
+  })
+
+  it('formats minutes and carries 59.5s rounding into the next minute', () => {
+    expect(formatDuration(60_000)).toBe('1m 0s')
+    expect(formatDuration(119_500)).toBe('2m 0s')
+    expect(formatDuration(83_000)).toBe('1m 23s')
+  })
+
+  it('formats hours and days', () => {
+    expect(formatDuration(3_600_000)).toBe('1h 0m 0s')
+    expect(formatDuration(3_723_000)).toBe('1h 2m 3s')
+    expect(formatDuration(90_061_000)).toBe('1d 1h 1m')
+  })
+})
+
+describe('formatNumber', () => {
+  it('keeps small numbers uncompacted without forced decimals', () => {
+    expect(formatNumber(0)).toBe('0')
+    expect(formatNumber(900)).toBe('900')
+  })
+
+  it('compacts thousands with one consistent decimal, lowercased', () => {
+    expect(formatNumber(1000)).toBe('1.0k')
+    expect(formatNumber(1321)).toBe('1.3k')
+    expect(formatNumber(100_500)).toBe('100.5k')
+    expect(formatNumber(2_000_000)).toBe('2.0m')
+  })
+})
+
+describe('formatTotalCost', () => {
+  it('renders the original block for an empty session', () => {
+    expect(formatTotalCost({})).toBe(
+      'Total cost:            $0.0000\n' +
+        'Total duration (API):  0s\n' +
+        'Total duration (wall): 0s\n' +
+        'Total code changes:    0 lines added, 0 lines removed\n' +
+        'Usage:                 0 input, 0 output'
+    )
+  })
+
+  it('renders per-model usage with cache read/write and singular line counts', () => {
+    const snapshot: CostSnapshot = {
+      model_usage: {
+        'deepseek-chat': {
+          cache_creation_input_tokens: 2000,
+          cache_read_input_tokens: 100_500,
+          cost_usd: 0.06,
+          input_tokens: 1234,
+          output_tokens: 3456
+        }
+      },
+      total_api_duration_ms: 64_000,
+      total_cost_usd: 0.06,
+      total_duration_ms: 728_000,
+      total_lines_added: 1,
+      total_lines_removed: 2
+    }
+
+    expect(formatTotalCost(snapshot)).toBe(
+      'Total cost:            $0.0600\n' +
+        'Total duration (API):  1m 4s\n' +
+        'Total duration (wall): 12m 8s\n' +
+        'Total code changes:    1 line added, 2 lines removed\n' +
+        'Usage by model:\n' +
+        '       deepseek-chat:  1.2k input, 3.5k output, 100.5k cache read, 2.0k cache write ($0.0600)'
+    )
+  })
+
+  it('renders web search requests when the backend reports them', () => {
+    expect(
+      formatTotalCost({
+        model_usage: { m: { cost_usd: 0.01, input_tokens: 1, output_tokens: 1, web_search_requests: 2 } }
+      })
+    ).toContain('1 input, 1 output, 2 web search ($0.0100)')
+  })
+
+  it('appends the unknown-model caveat to the cost line', () => {
+    expect(formatTotalCost({ has_unknown_model_cost: true, total_cost_usd: 1 })).toContain(
+      '$1.00 (costs may be inaccurate due to usage of unknown models)'
+    )
+  })
+})
+
+describe('setLastCostSnapshot', () => {
+  it('keeps the last non-empty snapshot and ignores empty riders', () => {
+    setLastCostSnapshot({ total_cost_usd: 0.5 })
+    setLastCostSnapshot({})
+    setLastCostSnapshot(undefined)
+    expect(getLastCostSnapshot()).toEqual({ total_cost_usd: 0.5 })
+  })
+})

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -9,6 +9,7 @@ import type {
   GatewaySkin,
   SessionMostRecentResponse
 } from '../gatewayTypes.js'
+import { setLastCostSnapshot } from '../lib/costSummary.js'
 import { isTodoDone } from '../lib/liveProgress.js'
 import { openExternalUrl } from '../lib/openExternalUrl.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
@@ -962,6 +963,10 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         if (ev.payload?.usage) {
           patchUiState(state => ({ ...state, usage: { ...state.usage, ...ev.payload!.usage } }))
         }
+
+        // Session totals rider — /cost's baseline and the exit summary's
+        // data source (printed by registerCostSummaryOnExit, entry.tsx).
+        setLastCostSnapshot(ev.payload?.cost)
 
         return
       }

--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -7,6 +7,7 @@ import type { FrameEvent } from '@clawcodex/ink'
 
 import { DASHBOARD_TUI_MODE, INLINE_MODE, TERMUX_TUI_MODE } from './config/env.js'
 import { GatewayClient } from './gatewayClient.js'
+import { registerCostSummaryOnExit } from './lib/costSummary.js'
 import { setupGracefulExit } from './lib/gracefulExit.js'
 import { formatBytes, type HeapDumpResult, performHeapDump } from './lib/memory.js'
 import { type MemorySnapshot, startMemoryMonitor } from './lib/memoryMonitor.js'
@@ -50,6 +51,11 @@ resetTerminalModes()
 process.on('exit', () => {
   resetTerminalModes(process.stdout, FULLSCREEN)
 })
+
+// Session cost summary under the final frame — the original's useCostSummary
+// process-exit hook (costHook.ts:12). Registered AFTER the reset backstop
+// ('exit' listeners run in order) so the block prints onto a sane terminal.
+registerCostSummaryOnExit()
 
 // Only wipe the screen for a clean slate in fullscreen (alternate-screen) mode.
 // Inline mode (the default) and Termux keep prior terminal output intact so the

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -21,7 +21,8 @@ import { readdirSync } from 'node:fs'
 import { resolve as pathResolve } from 'node:path'
 import { createInterface } from 'node:readline'
 
-import type { GatewayEvent, PatchHunk, StructuredDiffPayload } from './gatewayTypes.js'
+import type { CostSnapshot, GatewayEvent, PatchHunk, StructuredDiffPayload } from './gatewayTypes.js'
+import { formatTotalCost, setLastCostSnapshot } from './lib/costSummary.js'
 import type { SessionInfo } from './types.js'
 
 const STARTUP_TIMEOUT_MS = 30_000
@@ -218,6 +219,7 @@ const SLASHES: ReadonlyArray<{ desc: string; name: string }> = [
   { desc: 'Set the permission mode', name: '/mode' },
   { desc: 'Compact the conversation to save context', name: '/compact' },
   { desc: 'Show context-window usage', name: '/context' },
+  { desc: 'Show the total cost and duration of the current session', name: '/cost' },
   { desc: 'Undo recent turns', name: '/rewind' },
   { desc: 'Toggle extended thinking', name: '/thinking' },
   { desc: 'Set reasoning effort (or "ultracode" workflow mode)', name: '/effort' },
@@ -644,6 +646,21 @@ export class GatewayClient extends EventEmitter {
         return out(`Context: ${r?.total_tokens ?? '?'}/${r?.max_tokens ?? '?'} tokens (${pct}%).`)
       }
 
+      case 'cost': {
+        // The original /cost prints formatTotalCost over live cost-tracker
+        // state (commands/cost/cost.ts:23); clawcodex's accounting lives in
+        // the backend bootstrap singleton, so pull a fresh snapshot.
+        const r = (await this.controlQuery('cost', {})) as CostSnapshot | null
+
+        if (!r || Object.keys(r).length === 0) {
+          return out('Cost totals unavailable (backend not ready).')
+        }
+
+        setLastCostSnapshot(r)
+
+        return out(formatTotalCost(r))
+      }
+
       case 'effort': {
         const r = (await this.controlQuery('set_effort', { effort: arg ?? null })) as any
 
@@ -923,6 +940,8 @@ export class GatewayClient extends EventEmitter {
       case 'result':
         this.publish({
           payload: {
+            // Running session totals for /cost + the exit summary.
+            cost: msg.cost && typeof msg.cost === 'object' ? msg.cost : undefined,
             permission_mode: typeof msg.permission_mode === 'string' ? msg.permission_mode : undefined,
             text: typeof msg.result === 'string' ? msg.result : undefined,
             usage: msg.usage

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -339,6 +339,29 @@ export interface SessionUndoResponse {
   removed?: number
 }
 
+/** Per-model accumulator inside a CostSnapshot (the original's ModelUsage). */
+export interface CostModelUsage {
+  cache_creation_input_tokens?: number
+  cache_read_input_tokens?: number
+  cost_usd?: number
+  input_tokens?: number
+  output_tokens?: number
+  web_search_requests?: number
+}
+
+/** Session totals from the backend's `cost` control — the inputs of the
+ *  original's formatTotalCost (cost-tracker.ts:249). Also piggybacked on
+ *  every end-of-turn result message for the exit summary. */
+export interface CostSnapshot {
+  has_unknown_model_cost?: boolean
+  model_usage?: Record<string, CostModelUsage>
+  total_api_duration_ms?: number
+  total_cost_usd?: number
+  total_duration_ms?: number
+  total_lines_added?: number
+  total_lines_removed?: number
+}
+
 export interface SessionUsageResponse {
   active_subagents?: number
   cache_read?: number
@@ -736,7 +759,14 @@ export type GatewayEvent =
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.complete' }
   | { payload: { rendered?: string; text?: string }; session_id?: string; type: 'message.delta' }
   | {
-      payload?: { permission_mode?: string; reasoning?: string; rendered?: string; text?: string; usage?: Usage }
+      payload?: {
+        cost?: CostSnapshot
+        permission_mode?: string
+        reasoning?: string
+        rendered?: string
+        text?: string
+        usage?: Usage
+      }
       session_id?: string
       type: 'message.complete'
     }

--- a/ui-tui/src/lib/costSummary.ts
+++ b/ui-tui/src/lib/costSummary.ts
@@ -1,0 +1,198 @@
+/**
+ * Session cost summary — the original's formatTotalCost block
+ * (cost-tracker.ts:249-265) with its format helpers (utils/format.ts),
+ * ported verbatim but fed from the backend's cost snapshot (accounting
+ * lives in the Python bootstrap singleton, not in-process):
+ *
+ *   Total cost:            $0.0567
+ *   Total duration (API):  1m 4s
+ *   Total duration (wall): 12m 8s
+ *   Total code changes:    10 lines added, 2 lines removed
+ *   Usage by model:
+ *           deepseek-chat:  1.2k input, 3.4k output, 100.5k cache read ($0.06)
+ *
+ * Two consumers: /cost (fresh `cost` control query) and the exit summary
+ * (the original's useCostSummary process-exit hook, costHook.ts:12), which
+ * prints the last end-of-turn snapshot after the TUI unmounts.
+ */
+import type { CostSnapshot } from '../gatewayTypes.js'
+
+const round = (n: number, precision: number): number => Math.round(n * precision) / precision
+
+/** Original formatCost: 2 decimals above $0.50, 4 below (cost-tracker.ts:194). */
+export function formatCost(cost: number, maxDecimalPlaces = 4): string {
+  return `$${cost > 0.5 ? round(cost, 100).toFixed(2) : cost.toFixed(maxDecimalPlaces)}`
+}
+
+/** Original formatDuration (utils/format.ts:34), default-options path only. */
+export function formatDuration(ms: number): string {
+  if (ms < 60_000) {
+    if (ms === 0) {
+      return '0s'
+    }
+
+    if (ms < 1) {
+      return `${(ms / 1000).toFixed(1)}s`
+    }
+
+    return `${Math.floor(ms / 1000)}s`
+  }
+
+  let days = Math.floor(ms / 86_400_000)
+  let hours = Math.floor((ms % 86_400_000) / 3_600_000)
+  let minutes = Math.floor((ms % 3_600_000) / 60_000)
+  let seconds = Math.round((ms % 60_000) / 1000)
+
+  // Rounding carry-over (59.5s → 60s).
+  if (seconds === 60) {
+    seconds = 0
+    minutes++
+  }
+
+  if (minutes === 60) {
+    minutes = 0
+    hours++
+  }
+
+  if (hours === 24) {
+    hours = 0
+    days++
+  }
+
+  if (days > 0) {
+    return `${days}d ${hours}h ${minutes}m`
+  }
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m ${seconds}s`
+  }
+
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`
+  }
+
+  return `${seconds}s`
+}
+
+// Original formatNumber (utils/format.ts:124): Intl compact notation,
+// lowercased, with consistent decimals only from 1000 up ("900", "1.3k").
+let fmtConsistent: Intl.NumberFormat | null = null
+let fmtLoose: Intl.NumberFormat | null = null
+
+export function formatNumber(n: number): string {
+  if (n >= 1000) {
+    fmtConsistent ??= new Intl.NumberFormat('en-US', {
+      maximumFractionDigits: 1,
+      minimumFractionDigits: 1,
+      notation: 'compact'
+    })
+
+    return fmtConsistent.format(n).toLowerCase()
+  }
+
+  fmtLoose ??= new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: 1,
+    minimumFractionDigits: 0,
+    notation: 'compact'
+  })
+
+  return fmtLoose.format(n).toLowerCase()
+}
+
+/** Original formatModelUsage (cost-tracker.ts:198). Model names are used
+ *  as-is — the backend reports provider model ids, already canonical. */
+function formatModelUsage(modelUsage: CostSnapshot['model_usage']): string {
+  const entries = Object.entries(modelUsage ?? {})
+
+  if (entries.length === 0) {
+    return 'Usage:                 0 input, 0 output'
+  }
+
+  let result = 'Usage by model:'
+
+  for (const [model, u] of entries) {
+    let usage = `  ${formatNumber(u.input_tokens ?? 0)} input, ${formatNumber(u.output_tokens ?? 0)} output`
+
+    if ((u.cache_read_input_tokens ?? 0) > 0) {
+      usage += `, ${formatNumber(u.cache_read_input_tokens!)} cache read`
+    }
+
+    if ((u.cache_creation_input_tokens ?? 0) > 0) {
+      usage += `, ${formatNumber(u.cache_creation_input_tokens!)} cache write`
+    }
+
+    if ((u.web_search_requests ?? 0) > 0) {
+      usage += `, ${formatNumber(u.web_search_requests!)} web search`
+    }
+
+    usage += ` (${formatCost(u.cost_usd ?? 0)})`
+    result += `\n${`${model}:`.padStart(21)}${usage}`
+  }
+
+  return result
+}
+
+/** Original formatTotalCost (cost-tracker.ts:249), unstyled — the caller
+ *  dims it (transcript sys line / ANSI dim on the exit print). */
+export function formatTotalCost(s: CostSnapshot): string {
+  const added = s.total_lines_added ?? 0
+  const removed = s.total_lines_removed ?? 0
+
+  const costDisplay =
+    formatCost(s.total_cost_usd ?? 0) +
+    (s.has_unknown_model_cost ? ' (costs may be inaccurate due to usage of unknown models)' : '')
+
+  return (
+    `Total cost:            ${costDisplay}\n` +
+    `Total duration (API):  ${formatDuration(s.total_api_duration_ms ?? 0)}\n` +
+    `Total duration (wall): ${formatDuration(s.total_duration_ms ?? 0)}\n` +
+    `Total code changes:    ${added} ${added === 1 ? 'line' : 'lines'} added, ` +
+    `${removed} ${removed === 1 ? 'line' : 'lines'} removed\n` +
+    formatModelUsage(s.model_usage)
+  )
+}
+
+// ── exit summary ────────────────────────────────────────────────────────────
+// The backend refreshes the snapshot on every end-of-turn result message;
+// the exit hook prints the last one synchronously (process.on('exit') runs
+// sync code only, and TTY stdout writes are synchronous in Node).
+
+let lastSnapshot: CostSnapshot | null = null
+let lastSnapshotAt = 0
+
+export function setLastCostSnapshot(s: CostSnapshot | null | undefined): void {
+  if (s && Object.keys(s).length > 0) {
+    lastSnapshot = s
+    lastSnapshotAt = Date.now()
+  }
+}
+
+export function getLastCostSnapshot(): CostSnapshot | null {
+  return lastSnapshot
+}
+
+/**
+ * The original prints formatTotalCost on process exit (costHook.ts:12,
+ * gated on console-billing access — clawcodex talks to API-key providers,
+ * so it always applies). Deliberate divergence: with zero completed turns
+ * there is no snapshot and nothing prints (the original would print a
+ * zeroed block). Register AFTER entry.tsx's terminal-mode reset backstop
+ * so the block lands on a sane terminal, under the final frame.
+ */
+export function registerCostSummaryOnExit(): void {
+  process.on('exit', () => {
+    if (!lastSnapshot) {
+      return
+    }
+
+    // The original reads wall duration AT exit (getTotalDuration()); the
+    // snapshot's is frozen at the last turn's end, so extend it by the idle
+    // time since. API duration/cost/lines are legitimately turn-frozen.
+    const s: CostSnapshot = {
+      ...lastSnapshot,
+      total_duration_ms: (lastSnapshot.total_duration_ms ?? 0) + Math.max(0, Date.now() - lastSnapshotAt)
+    }
+
+    process.stdout.write(`\n\x1b[2m${formatTotalCost(s)}\x1b[22m\n`)
+  })
+}


### PR DESCRIPTION
## What

Restores the overall **elapsed time / tokens used / estimated cost** display lost in the hermes TUI reramp, mimicking exactly how the original Claude Code (in-repo `typescript/`) surfaces them:

1. **`/cost`** — prints the verbatim `formatTotalCost()` block (cost-tracker.ts:249):
   ```
   Total cost:            $0.0567
   Total duration (API):  1m 4s
   Total duration (wall): 12m 8s
   Total code changes:    10 lines added, 2 lines removed
   Usage by model:
          deepseek-chat:  1.2k input, 3.5k output, 100.5k cache read ($0.0567)
   ```
2. **Exit summary** — the same block, dimmed, printed under the final frame on quit (`costHook.ts:12` `process.on('exit')` parity), with wall duration extended by idle time since the last turn.
3. In-turn elapsed/`↓ tokens` already live in the busy line from the earlier look&feel port — untouched.

## How

- **agent-server**: new `cost` control (lock-guarded bootstrap-accumulator snapshot) + the snapshot rides every end-of-turn `result` message so the client can print the exit block synchronously.
- **query loop / advisor**: feed `add_to_total_duration_state` beside the cost head — these counters existed but were never fed, so "Total duration (API)" was permanently 0. Compaction gap documented.
- **Edit/Write**: feed `add_to_total_lines_changed` from structuredPatch hunks (`utils/diff.ts:50-69`), preserving the original's asymmetric create semantics (Write-create counts `split(/\r?\n/)` segments incl. the trailing empty one; Edit-create counts the real `''→content` patch). Pinned by call-site tests through the real registry/ToolContext dispatch path.
- **ui-tui**: `lib/costSummary.ts` verbatim ports of `formatCost`/`formatDuration`/`formatNumber`/`formatModelUsage`/`formatTotalCost`; `/cost` in `dispatchSlash` + slash menu; snapshot stash on `message.complete`; exit hook registered after the terminal-mode-reset backstop in `entry.tsx`.

## Verification

- Live stdio e2e: `cost` control returns correct zeros on a fresh agent-server session.
- `tsx` simulation of the exit hook prints the exact original block (ANSI-dim).
- vitest: 12 new format-parity cases; full suite at main's 9 pre-existing failures (verified against stashed baseline on the same HEAD). typecheck clean.
- pytest: 11 new tests (snapshot / result rider / line-count call-site pins); cost + edit/write/diff/advisor/compact batches green except the 3 failures that also fail on unmodified main.
- Critic loop: round 1 REVISE (caught the Edit/Write create-count swap + snapshot lock + wall-drift-at-exit) → all applied → round 2 **APPROVE**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)