### PR TITLE
fix(tui): render WebSearch results as CC's one-line summary, not the blob

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -2390,21 +2390,45 @@ def _filter_registry(registry, *, keep) -> None:
 
 
 def _display_tool_result(value: Any) -> dict | None:
-    """Trim a rich Edit/Write tool output for the wire (display data only).
+    """Trim a rich Edit/Write or WebSearch tool output for the wire (display
+    data only).
 
-    Recognizes the self-describing shape (``type``/``filePath``/
-    ``structuredPatch``) rather than a tool name so mid-turn clients can
-    render it without tool_use bookkeeping. Deliberate delta from real CC's
-    full-parity ``tool_use_result``: ``originalFile`` is dropped (the display
-    renderer never reads it) and update-type ``content`` (the full post-edit
-    file) is reduced to ``firstLine`` (language/shebang detection only; the
-    original uses the pre-edit first line — differs only when line 1 itself
-    changed); create-type keeps ``content`` for the file preview. Always
-    builds a new dict — ``value`` is shared with the in-memory message and
-    the persisted transcript.
+    Recognizes self-describing shapes rather than a tool name so mid-turn
+    clients can render without tool_use bookkeeping:
+
+    * Edit/Write (``type``/``filePath``/``structuredPatch``) — deliberate
+      delta from real CC's full-parity ``tool_use_result``: ``originalFile``
+      is dropped (the display renderer never reads it) and update-type
+      ``content`` (the full post-edit file) is reduced to ``firstLine``
+      (language/shebang detection only; the original uses the pre-edit first
+      line — differs only when line 1 itself changed); create-type keeps
+      ``content`` for the file preview.
+    * WebSearch (``query``/``results``/``duration_seconds``) — reduced to the
+      two numbers the original's one-line render needs (UI.tsx
+      renderToolResultMessage: "Did N searches in Xs"): ``searchCount`` per
+      getSearchSummary (non-string entries in ``results``) and
+      ``durationSeconds``. The result blob itself already travels as the
+      tool_result content.
+
+    Always builds a new dict — ``value`` is shared with the in-memory message
+    and the persisted transcript.
     """
     if not isinstance(value, dict):
         return None
+    if (
+        "type" not in value
+        and isinstance(value.get("query"), str)
+        and isinstance(value.get("results"), list)
+        and isinstance(value.get("duration_seconds"), (int, float))
+        and not isinstance(value.get("duration_seconds"), bool)
+    ):
+        return {
+            "type": "web_search",
+            "durationSeconds": float(value["duration_seconds"]),
+            "searchCount": sum(
+                1 for r in value["results"] if r is not None and not isinstance(r, str)
+            ),
+        }
     if value.get("type") not in ("create", "update"):
         return None
     if not isinstance(value.get("filePath"), str) or not isinstance(value.get("structuredPatch"), list):

--- a/tests/server/test_sdk_envelope_tool_result.py
+++ b/tests/server/test_sdk_envelope_tool_result.py
@@ -66,6 +66,52 @@ class TestDisplayToolResult:
         assert source == snapshot
 
 
+def _web_search_output(**overrides):
+    out = {
+        "query": "obama news",
+        "results": [
+            "**Title A** -- snippet (https://a.example)",
+            {"tool_use_id": "tavily-search", "content": [{"title": "A", "url": "https://a.example"}]},
+        ],
+        "duration_seconds": 2.4,
+    }
+    out.update(overrides)
+    return out
+
+
+class TestDisplayWebSearchResult:
+    """WebSearch output is trimmed to the numbers the TUI one-liner needs
+    (original renders "Did N searches in Xs" — UI.tsx getSearchSummary counts
+    non-string results)."""
+
+    def test_trims_to_search_count_and_duration(self):
+        assert _display_tool_result(_web_search_output()) == {
+            "type": "web_search",
+            "durationSeconds": 2.4,
+            "searchCount": 1,
+        }
+
+    def test_counts_only_non_string_results(self):
+        trimmed = _display_tool_result(_web_search_output(results=["No results found."]))
+        assert trimmed is not None
+        assert trimmed["searchCount"] == 0
+
+    def test_rejects_lookalike_shapes(self):
+        # bool is an int subclass — a True duration is not a duration
+        assert _display_tool_result(_web_search_output(duration_seconds=True)) is None
+        assert _display_tool_result(_web_search_output(duration_seconds="2.4")) is None
+        assert _display_tool_result(_web_search_output(results="not-a-list")) is None
+        assert _display_tool_result(_web_search_output(query=7)) is None
+        # an explicit type field routes to the Edit/Write branch, not this one
+        assert _display_tool_result(_web_search_output(type="rename")) is None
+
+    def test_source_dict_is_not_mutated(self):
+        source = _web_search_output()
+        snapshot = copy.deepcopy(source)
+        _display_tool_result(source)
+        assert source == snapshot
+
+
 class TestSdkEnvelope:
     def test_user_envelope_carries_trimmed_tool_use_result(self):
         msg = create_user_message(

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -158,6 +158,31 @@ describe('GatewayClient NDJSON adapter', () => {
     expect(long.result_text).toBe('1\n2\n3\n… +3 lines (ctrl+o to expand)')
   })
 
+  // WebSearch renders as the original's one-liner (WebSearchTool/UI.tsx);
+  // the agent-server forwards searchCount/durationSeconds on tool_use_result
+  // and the raw blob stays reachable behind ctrl+o via result_raw.
+  it('collapses a WebSearch result to "Did N searches in Xs" from the envelope', async () => {
+    const blob = 'Web search results for query: "q"\n\n**A** -- snippet (https://a.example)\n\nLinks: [{"title": "A", "url": "https://a.example"}]'
+
+    proc.line(toolUse('t1', 'WebSearch', { query: 'q' }))
+    await vi.waitFor(() => expect(last('tool.start')).toBeTruthy())
+    proc.line({
+      ...toolResult('t1', blob),
+      tool_use_result: { durationSeconds: 2.4, searchCount: 1, type: 'web_search' }
+    })
+    await vi.waitFor(() => expect(last('tool.complete')).toBeTruthy())
+
+    const p = last('tool.complete').payload
+    expect(p.result_text).toBe('Did 1 search in 2s')
+    expect(p.result_raw).toContain('Links:')
+  })
+
+  it('falls back to a durationless WebSearch summary without the envelope', async () => {
+    const blob = 'Web search results for query: "q"\n\nLinks: [{"title": "A", "url": "https://a.example"}]'
+    const p = await runTool('t1', 'WebSearch', { query: 'q' }, blob)
+    expect(p.result_text).toBe('Did 1 search')
+  })
+
   it('carries error on tool.complete for failed tools (drives the red ✗ path)', async () => {
     proc.line(toolUse('t1', 'Bash', { command: 'false' }))
     await vi.waitFor(() => expect(last('tool.start')).toBeTruthy())

--- a/ui-tui/src/__tests__/toolTranscript.test.ts
+++ b/ui-tui/src/__tests__/toolTranscript.test.ts
@@ -55,6 +55,39 @@ describe('formatToolResult', () => {
     expect(formatToolResult('Bash', '   \n')).toBe('(No output)')
   })
 
+  // Original CC (WebSearchTool/UI.tsx renderToolResultMessage) renders the
+  // whole result as ONE line — never the snippet blob.
+  it('summarizes WebSearch results as the original one-liner', () => {
+    const blob =
+      'Web search results for query: "obama news"\n\n' +
+      '**Title A** -- long snippet A (https://a.example)\n' +
+      '**Title B** -- long snippet B (https://b.example)\n\n' +
+      'Links: [{"title": "Title A", "url": "https://a.example"}]\n\n' +
+      'REMINDER: You MUST include the sources above in your response to the user using markdown hyperlinks.'
+
+    // Envelope present (agent-server tool_use_result): exact CC string.
+    expect(formatToolResult('WebSearch', blob, false, { durationSeconds: 24.4, searchCount: 1 })).toBe(
+      'Did 1 search in 24s'
+    )
+    expect(formatToolResult('WebSearch', blob, false, { durationSeconds: 0.532, searchCount: 2 })).toBe(
+      'Did 2 searches in 532ms'
+    )
+
+    // No envelope (older backend): count recovered from the blob, no time.
+    expect(formatToolResult('WebSearch', blob)).toBe('Did 1 search')
+    expect(formatToolResult('WebSearch', 'Web search results for query: "x"\n\nNo results found.')).toBe(
+      'Did 0 searches'
+    )
+
+    // Envelope without a matching stored tool name (mid-turn attach).
+    expect(formatToolResult(undefined, blob, false, { durationSeconds: 2, searchCount: 1 })).toBe(
+      'Did 1 search in 2s'
+    )
+
+    // Errors keep the error path — never a fake "Did N searches".
+    expect(formatToolResult('WebSearch', 'rate limited', true)).toBe('Error: rate limited')
+  })
+
   it('prefixes errors and caps them at 10 lines', () => {
     expect(formatToolResult('Bash', 'boom', true)).toBe('Error: boom')
     expect(formatToolResult('Bash', 'Error: already prefixed', true)).toBe('Error: already prefixed')

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -147,7 +147,32 @@ function todosFromInput(name: string | undefined, input: unknown): undefined | u
 const ERROR_RESULT_MAX_LINES = 10
 const BASH_RESULT_MAX_LINES = 3
 
-export function formatToolResult(name: string | undefined, result: string, isError = false): string {
+/** WebSearch display data forwarded by the agent-server (`tool_use_result`
+ *  trimmed to the two numbers the original's one-liner needs). */
+export type WebSearchDisplay = { durationSeconds?: number; searchCount?: number }
+
+// One marker line per performed search in the model-facing blob
+// (web_search.py _map_result_to_api emits `Links: […]` / `No links found.`
+// per structured result block). Fallback only — the envelope is authoritative.
+const WEB_SEARCH_BLOCK_RE = /^(?:Links: \[|No links found\.$)/gm
+
+// Exact port of WebSearchTool/UI.tsx renderToolResultMessage: "Did N
+// search(es) in Xs" (whole seconds at >=1s, else ms). Without the envelope
+// (older backend) the duration is unknown and omitted.
+function webSearchSummary(result: string, webSearch?: WebSearchDisplay): string {
+  const searchCount = webSearch?.searchCount ?? (result.match(WEB_SEARCH_BLOCK_RE)?.length ?? 0)
+  const line = `Did ${searchCount} search${searchCount !== 1 ? 'es' : ''}`
+  const s = webSearch?.durationSeconds
+
+  return s === undefined ? line : `${line} in ${s >= 1 ? `${Math.round(s)}s` : `${Math.round(s * 1000)}ms`}`
+}
+
+export function formatToolResult(
+  name: string | undefined,
+  result: string,
+  isError = false,
+  webSearch?: WebSearchDisplay
+): string {
   if (isError) {
     let msg = (result ?? '').trim() || 'Tool execution failed'
 
@@ -168,6 +193,14 @@ export function formatToolResult(name: string | undefined, result: string, isErr
   }
 
   if (!result) {return result}
+
+  // The original renders the whole result as ONE line (never the blob —
+  // that's tens of wrapped rows of snippets); the full text stays reachable
+  // behind ctrl+o via result_raw. Shape-keyed on the envelope too so a
+  // mid-turn attach without tool_use bookkeeping still summarizes.
+  if (name === 'WebSearch' || webSearch) {
+    return webSearchSummary(result, webSearch)
+  }
 
   if (name === 'Read' && /^\s*\d+[\t→ ]/.test(result)) {
     const n = result.split('\n').filter(l => l.length > 0).length
@@ -844,6 +877,16 @@ export class GatewayClient extends EventEmitter {
     }
   }
 
+  // WebSearch display data on the same envelope (agent_server trims the
+  // structured output to searchCount/durationSeconds). Shape-detected like
+  // structuredDiff so it renders without tool_use bookkeeping.
+  private webSearchDisplay(value: any): undefined | WebSearchDisplay {
+    if (!value || typeof value !== 'object' || value.type !== 'web_search') {return undefined}
+    const num = (v: unknown) => (typeof v === 'number' && Number.isFinite(v) ? v : undefined)
+
+    return { durationSeconds: num(value.durationSeconds), searchCount: num(value.searchCount) }
+  }
+
   // Legacy fallback (agent-server predating tool_use_result): a fake unified
   // diff from the Edit/Write tool *input* so the app can render at least a
   // colored ```diff block. No line numbers/context — superseded by
@@ -981,6 +1024,7 @@ export class GatewayClient extends EventEmitter {
           // it on first attach so a hypothetical multi-block message can't
           // pin the same patch onto every result.
           let structured = this.structuredDiff(msg.tool_use_result)
+          let webSearch = this.webSearchDisplay(msg.tool_use_result)
 
           for (const b of content) {
             if (b?.type === 'tool_result') {
@@ -989,7 +1033,7 @@ export class GatewayClient extends EventEmitter {
               // real patch nor a fabricated one for an edit that never ran.
               const isError = Boolean(b.is_error)
               const fullText = typeof b.content === 'string' ? b.content : safeJson(b.content)
-              const resultText = formatToolResult(stored?.name, fullText, isError)
+              const resultText = formatToolResult(stored?.name, fullText, isError, webSearch)
               // Read shows no expand hint (the summary loses nothing the user
               // needs — the file is in context), so retain nothing for it.
               const expandable = stored?.name !== 'Read'
@@ -1010,6 +1054,7 @@ export class GatewayClient extends EventEmitter {
                 type: 'tool.complete'
               })
               structured = undefined
+              webSearch = undefined
               this.toolInputs.delete(String(b.tool_use_id))
             }
           }


### PR DESCRIPTION
## Problem

WebSearch tool results rendered the entire model-facing snippet blob inline in the transcript — dozens of wrapped rows per search (screenshot in session). `formatToolResult` had per-tool summaries for Read/Grep/Glob/Bash but WebSearch fell through to raw passthrough.

## What the original does

`typescript/src/tools/WebSearchTool/UI.tsx renderToolResultMessage` renders **one line**: `Did {searchCount} search(es) in {time}` — `searchCount` from `getSearchSummary` (non-string entries of `output.results`), time as whole seconds when >=1s else ms. The blob is never printed inline.

## Fix

- **agent-server** (`_display_tool_result`): also recognizes the WebSearch output shape (`query`/`results`/`duration_seconds`, no `type` key) and forwards `{type:"web_search", durationSeconds, searchCount}` on the `tool_use_result` envelope — the same display-data channel the Edit/Write diff renderer uses. Bool `duration_seconds` lookalikes rejected (bool is an int subclass).
- **ui-tui** (`formatToolResult` + `webSearchDisplay`): renders the exact original string from the envelope; without one (older backend) the count is recovered from the blob's `Links: [` / `No links found.` marker lines and the duration is omitted. Errors keep the error path (`Error: …`, red ✗). Full blob stays reachable behind ctrl+o via unchanged `result_raw` retention.

Wire-compat verified in all four backend×TUI combos (old TUI ignores the new envelope shape; new TUI degrades to a durationless summary on old backends).

## Tests

- `tests/server/test_sdk_envelope_tool_result.py`: new `TestDisplayWebSearchResult` (trim, non-string counting, lookalike rejection incl. bool, no-mutation) — tests/server 151 passed
- `ui-tui`: `formatToolResult` unit cases + wire-level tests (envelope → `Did 1 search in 2s` + `result_raw` retention; no-envelope fallback) — affected files 66/66; full-suite failures unchanged from main (8 pre-existing + 1 flaky, verified via stash/rerun)

Critic-reviewed: APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)