### PR TITLE
fix(tui): /model picker switch — parse hermes grammar + round-trip set_model

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -28,8 +28,9 @@ client → server (``send_to_agent``)::
     {type:'user', message:{role:'user', content:<str|blocks>}}            # a prompt
     {type:'control_response', response:{request_id, response:{behavior,…}}} # perm reply
     {type:'control_request', request:{subtype:'interrupt'}}               # cancel turn
-    {type:'control_request', request:{subtype:'set_permission_mode', mode}}
-    {type:'control_request', request:{subtype:'set_model', model}}
+    {type:'control_request', request_id, request:{subtype:'set_permission_mode', mode}}
+    {type:'control_request', request_id, request:{subtype:'set_model', model, provider?}}
+                                             # replies {ok, model, warning?} | {ok:false, error}
     {type:'control_request', request_id, request:{subtype:'get_settings'|'get_context_usage'}}
 
 Concurrency model
@@ -314,17 +315,7 @@ class _AgentSession:
             self._reply(request_id, {"ok": True, "mode": new_mode})
             return
         if subtype == "set_model":
-            model = inner.get("model")
-            if isinstance(model, str) and self.provider is not None:
-                try:
-                    self.provider.model = model
-                except Exception:  # noqa: BLE001
-                    pass
-                # ch03 round-4 GAP A: on_change mirrors the choice into
-                # bootstrap and persists (model, model_provider) to user
-                # settings — /model survives restarts for the first time.
-                _dispatch_app_state(self, main_loop_model=model)
-            self._ack(request_id)
+            self._do_set_model(request_id, inner.get("model"), inner.get("provider"))
             return
         if subtype == "set_provider":
             self._do_set_provider(request_id, inner.get("provider"))
@@ -700,6 +691,46 @@ class _AgentSession:
                 self._knowledge.save()
         except Exception:  # noqa: BLE001 — knowledge must never break a turn
             logger.debug("[agent-server] knowledge record failed", exc_info=True)
+
+    def _do_set_model(self, request_id: object, model: object, provider: object = None) -> None:
+        """Switch the active model (the /model picker + typed /model). Replies
+        {ok, model, warning?} — the TUI's ConfigSetResponse contract needs the
+        resulting model echoed back as proof the switch happened; a bare ack
+        reads as failure client-side. ``provider`` (when sent) must match the
+        session's provider: cross-provider switches need the full registry
+        rebuild that set_provider does, so refusing here beats silently
+        pointing the current provider at a foreign model id."""
+        if not isinstance(model, str) or not model.strip():
+            self._reply(request_id, {"ok": False, "error": "missing model"})
+            return
+        model = model.strip()
+        if self.provider is None:
+            self._reply(request_id, {"ok": False, "error": "session not ready"})
+            return
+        if isinstance(provider, str) and provider and provider != self.provider_name:
+            self._reply(request_id, {
+                "ok": False,
+                "error": f"model '{model}' expects provider '{provider}' but this "
+                         f"session is on '{self.provider_name}'",
+            })
+            return
+        try:
+            self.provider.model = model
+        except Exception as exc:  # noqa: BLE001
+            self._reply(request_id, {"ok": False, "error": f"model switch failed: {exc}"})
+            return
+        # ch03 round-4 GAP A: on_change mirrors the choice into bootstrap and
+        # persists (model, model_provider) to user settings — /model survives
+        # restarts.
+        _dispatch_app_state(self, main_loop_model=model)
+        response: dict = {"ok": True, "model": getattr(self.provider, "model", model)}
+        known = self._available_models()
+        if known and model not in known:
+            response["warning"] = (
+                f"'{model}' is not in {self.provider_name}'s model list — "
+                "the API may reject it"
+            )
+        self._reply(request_id, response)
 
     def _do_set_provider(self, request_id: object, name: object) -> None:
         """Switch the LLM provider mid-session (the original's /provider). Rebuilds

--- a/tests/server/test_agent_server_e2e.py
+++ b/tests/server/test_agent_server_e2e.py
@@ -623,6 +623,64 @@ async def test_control_set_output_style(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_control_set_model(tmp_path):
+    """set_model round-trips {ok, model}: the TUI's /model needs the resulting
+    model echoed back (a bare ack reads as failure), refusal on cross-provider
+    switches, and a warning for models outside the provider's list."""
+    from src.tool_system.registry import ToolRegistry
+
+    class _ListingProvider(_TextProvider):
+        def get_available_models(self):
+            return ["fake", "fake-pro"]
+
+    with contextlib.ExitStack() as stack:
+        for p in _patches(_ListingProvider, ToolRegistry([])):
+            stack.enter_context(p)
+        spawn = make_spawn_agent(AgentServerConfig(permission_mode="default"))
+        handle = await spawn("ds_test", str(tmp_path), None)
+        gen = handle.messages_from_agent()
+        try:
+            init = await asyncio.wait_for(gen.__anext__(), timeout=5)
+            assert init["subtype"] == "init"
+
+            async def _reply_for(rid, req):
+                await handle.send_to_agent({"type": "control_request", "request_id": rid, "request": req})
+                for _ in range(12):
+                    msg = await asyncio.wait_for(gen.__anext__(), timeout=5)
+                    if msg.get("type") == "control_response" and msg["response"].get("request_id") == rid:
+                        return msg["response"]["response"]
+                raise AssertionError(f"no reply for {rid}")
+
+            # Same-provider switch echoes the new model, no warning.
+            ok = await _reply_for("m1", {"subtype": "set_model", "model": "fake-pro", "provider": "anthropic"})
+            assert ok["ok"] is True and ok["model"] == "fake-pro"
+            assert "warning" not in ok
+
+            # get_settings reflects the switch (the picker's Current: line).
+            settings = await _reply_for("m2", {"subtype": "get_settings"})
+            assert settings["model"] == "fake-pro"
+
+            # A model outside the provider's list still switches but warns.
+            warned = await _reply_for("m3", {"subtype": "set_model", "model": "mystery"})
+            assert warned["ok"] is True and warned["model"] == "mystery"
+            assert "not in anthropic's model list" in warned["warning"]
+
+            # Cross-provider switch is refused and leaves the model untouched.
+            bad = await _reply_for("m4", {"subtype": "set_model", "model": "gpt-x", "provider": "openai"})
+            assert bad["ok"] is False and "openai" in bad["error"]
+            settings = await _reply_for("m5", {"subtype": "get_settings"})
+            assert settings["model"] == "mystery"
+
+            # Missing/blank model is refused.
+            missing = await _reply_for("m6", {"subtype": "set_model", "model": "  "})
+            assert missing["ok"] is False and "missing model" in missing["error"]
+        finally:
+            await handle.shutdown()
+            with contextlib.suppress(Exception):
+                await gen.aclose()
+
+
+@pytest.mark.asyncio
 async def test_control_knowledge(tmp_path):
     """knowledge control returns stats and toggles enable/disable."""
     from src.tool_system.registry import ToolRegistry

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -271,6 +271,59 @@ describe('GatewayClient NDJSON adapter', () => {
     await expect(p).resolves.toEqual({ ok: false })
   })
 
+  // ── config.set model (the /model picker + typed /model) ───────────────────
+
+  it('parses the picker model grammar and answers with the switched value', async () => {
+    // The picker emits "<model> --provider <slug> [--global|--tui-session]";
+    // the gateway owns parsing it (hermes contract). The flags must never
+    // reach the backend as part of the model id.
+    const p = gw.request('config.set', { key: 'model', value: 'deepseek-v4-pro --provider deepseek --global' })
+    await replyToControl('set_model', { model: 'deepseek-v4-pro', ok: true })
+    await expect(p).resolves.toEqual({ value: 'deepseek-v4-pro' })
+
+    const req = seen.find(f => f.request?.subtype === 'set_model')!.request
+    expect(req.model).toBe('deepseek-v4-pro')
+    expect(req.provider).toBe('deepseek')
+  })
+
+  it('sends a bare typed /model value without a provider param', async () => {
+    const p = gw.request('config.set', { key: 'model', value: 'x-model --tui-session' })
+    await replyToControl('set_model', { model: 'x-model', ok: true })
+    await expect(p).resolves.toEqual({ value: 'x-model' })
+
+    const req = seen.find(f => f.request?.subtype === 'set_model')!.request
+    expect(req.model).toBe('x-model')
+    expect('provider' in req).toBe(false)
+  })
+
+  it('passes the backend model-switch warning through to the caller', async () => {
+    const p = gw.request('config.set', { key: 'model', value: 'mystery-model' })
+    await replyToControl('set_model', {
+      model: 'mystery-model',
+      ok: true,
+      warning: "'mystery-model' is not in deepseek's model list — the API may reject it"
+    })
+    await expect(p).resolves.toEqual({
+      value: 'mystery-model',
+      warning: "'mystery-model' is not in deepseek's model list — the API may reject it"
+    })
+  })
+
+  it('falls back to the requested model when an older backend acks without echoing it', async () => {
+    const p = gw.request('config.set', { key: 'model', value: 'x-model' })
+    await replyToControl('set_model', { ok: true })
+    await expect(p).resolves.toEqual({ value: 'x-model' })
+  })
+
+  it('rejects with the backend error when the model switch is refused', async () => {
+    const p = gw.request('config.set', { key: 'model', value: 'm --provider other' })
+    await replyToControl('set_model', {
+      error: "model 'm' expects provider 'other' but this session is on 'deepseek'",
+      ok: false
+    })
+    await expect(p).rejects.toThrow("model 'm' expects provider 'other' but this session is on 'deepseek'")
+  })
+
   it('surfaces the server rejection when /mode bypassPermissions is unavailable', async () => {
     // The server gates bypassPermissions on availability (same guard as the
     // Shift+Tab cycle) — the client must show the refusal, not pretend the

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -119,7 +119,13 @@ export async function startPromptLiveSession({
   if (requestedModel) {
     const result = await rpc<ConfigSetResponse>('config.set', { key: 'model', session_id: sid, value: requestedModel })
 
-    if (!result?.value) {
+    // Null means rpc() already printed the backend's error — only a truthy
+    // reply that still lacks `value` is a malformed response worth reporting.
+    if (!result) {
+      return sid
+    }
+
+    if (!result.value) {
       sys('error: invalid response: model switch')
 
       return sid

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -478,8 +478,9 @@ export class GatewayClient extends EventEmitter {
             .then(r => ({ ok: (r as any)?.ok !== false } as T))
         }
 
-        if (key === 'model') {this.sendControl('set_model', { model: value })}
-        else if (key === 'effort' || key === 'reasoning') {this.sendControl('set_effort', { effort: value })}
+        if (key === 'model') {return this.setModel(String(value ?? '')) as Promise<T>}
+
+        if (key === 'effort' || key === 'reasoning') {this.sendControl('set_effort', { effort: value })}
         else if (key === 'provider') {this.sendControl('set_provider', { provider: value })}
         else if (key === 'thinking') {this.sendControl('set_thinking', { action: value })}
 
@@ -630,6 +631,53 @@ export class GatewayClient extends EventEmitter {
       }
 
       return this.wfCommands
+    })
+  }
+
+  // config.set{model} carries the hermes /model grammar —
+  // "<model> [--provider <slug>] [--global|--tui-session]" — verbatim from the
+  // picker/slash layer; parsing it is the gateway's job. The callers require a
+  // ConfigSetResponse `value` on success (its absence is what "error: invalid
+  // response: model switch" reports), so this must round-trip the control
+  // rather than fire-and-forget. Scope flags are dropped: the backend persists
+  // every switch (agent_server set_model → app-state on_change).
+  private setModel(raw: string): Promise<{ value: string; warning?: string }> {
+    const tokens = raw.trim().split(/\s+/).filter(Boolean)
+    const modelParts: string[] = []
+    let provider: string | undefined
+
+    for (let i = 0; i < tokens.length; i++) {
+      const tok = tokens[i]!
+
+      if (tok === '--provider') {
+        provider = tokens[++i]
+
+        continue
+      }
+
+      if (tok === '--global' || tok === '--tui-session') {
+        continue
+      }
+
+      modelParts.push(tok)
+    }
+
+    const model = modelParts.join(' ')
+
+    return this.controlQuery('set_model', { model, ...(provider ? { provider } : {}) }).then((r: any) => {
+      if (r == null) {
+        throw new Error('model switch: no response from backend')
+      }
+
+      if (r.ok === false) {
+        throw new Error(typeof r.error === 'string' && r.error ? r.error : 'model switch failed')
+      }
+
+      // Older backends ack {ok:true} without echoing the model.
+      return {
+        value: typeof r.model === 'string' && r.model ? r.model : model,
+        ...(typeof r.warning === 'string' && r.warning ? { warning: r.warning } : {})
+      }
     })
   }
 


### PR DESCRIPTION
## Bug

Selecting a model in the `/model` picker (or typing `/model <id>`) always printed `error: invalid response: model switch` — and, worse, silently corrupted the active model.

## Root cause

The hermes TUI contract: the picker/slash layer passes the raw `/model` grammar — `"<model> [--provider <slug>] [--global|--tui-session]"` — through `config.set{key:'model'}`, and **the gateway** parses it and answers with `ConfigSetResponse.value` (createSlashHandler.test.ts pins the pass-through). Our adapter did neither:

1. `gatewayClient.ts` mapped it to a **fire-and-forget** `set_model` control and resolved `{ok:true}` with no `value` → both callers (`/model` in session.ts, `startPromptLiveSession` in useMainApp.ts) report "invalid response: model switch" on **every** switch, success included.
2. The **raw string with flags** was sent as the model id → the backend set `provider.model = "deepseek-v4-pro --provider deepseek"` and **persisted the garbage** to `~/.clawcodex/config.json` (via the app-state on_change), re-seeding it at every launch (verified live: the boot header showed the corrupted string).
3. The backend `set_model` handler acked `{ok:true}` unconditionally, swallowed setter exceptions, and echoed nothing.

## Fix

**Adapter (`gatewayClient.ts`)** — new `setModel(raw)`:
- Tokenizes the grammar: `--provider` consumes the next token; `--global`/`--tui-session` are dropped (the backend persists every switch unconditionally, so scope flags are cosmetic today).
- Round-trips `controlQuery('set_model', {model, provider?})` and maps `{ok, model, warning?}` → `{value, warning?}`.
- `{ok:false}` → throws with the backend's error text (every `config.set` caller goes through the catching `rpc()` wrapper, which prints `error: <msg>`); timeout → throws "no response from backend". Falls back to the requested model when an older backend acks without echoing.

**Backend (`agent_server.py`)** — `_do_set_model` replaces the inline block:
- Refuses missing model, not-ready session, and cross-provider switches (`provider` param ≠ session provider) with honest errors — cross-provider needs the registry rebuild only `set_provider` does; the picker can only send the current provider.
- Replies `{ok:false, error}` on setter exceptions instead of swallow-and-ack.
- Replies `{ok:true, model: provider.model}` + a `warning` when the model isn't in the provider's `get_available_models()` list (shown via the TUI's `maybeWarn`).
- Persistence semantics unchanged (`_dispatch_app_state(main_loop_model=…)`); deliberately does **not** touch `config.model` (that's the launch-flag pin that drives resume precedence).

## Verification

- vitest: 5 new adapter tests (grammar parse, provider param, warning pass-through, older-backend fallback, rejection surfacing); full ui-tui suite green at the pre-existing-failure baseline (verified via stash run on main).
- pytest: new `test_control_set_model` (echo, get_settings reflects, unknown-model warning, mismatch refusal leaves model untouched, blank refusal); tests/server + ch03/ch13/app-state suites 201 passed.
- `tsc --noEmit` clean.
- **Live pyte e2e** (real TUI + real backend + deepseek provider): typed switch → `model → deepseek-v4-flash`; picker step 1/2 → 2/2 → Enter → `model → deepseek-v4-pro`; `/model x --provider nope` → `error: model 'x' expects provider 'nope' but this session is on 'deepseek'`; zero occurrences of the old error.

No migration shim for already-corrupted persisted configs: one clean `/model` heals them, and the affected install's config was verified healed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
