### PR TITLE
feat(tui+server): restore /skills — slash-menu entry + backend wiring

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -454,10 +454,24 @@ class _AgentSession:
 
                 all_s = list(get_all_skills(project_root=self.cwd))
                 total = len(all_s)
-                for s in all_s[:120]:
+                # Settings scope beats the loader bucket so disk skills split
+                # into user/project/managed; everything else keeps its
+                # loaded_from bucket (bundled/plugin/mcp/…).
+                scope_names = {
+                    "userSettings": "user",
+                    "projectSettings": "project",
+                    "policySettings": "managed",
+                }
+                # Cap raised 120 → 1000: the TUI skills hub groups the full
+                # set by category, so a tight cap would skew its counts.
+                for s in all_s[:1000]:
+                    source = str(getattr(s, "source", "") or "")
+                    loaded_from = str(getattr(s, "loaded_from", "") or "")
                     skills.append({
                         "name": getattr(s, "name", "") or "",
-                        "description": str(getattr(s, "description", "") or "")[:80],
+                        "description": str(getattr(s, "description", "") or "")[:400],
+                        "category": scope_names.get(source) or loaded_from or source or "other",
+                        "path": str(getattr(s, "skill_root", None) or getattr(s, "base_dir", None) or ""),
                     })
             except Exception:  # noqa: BLE001
                 logger.debug("[agent-server] list_skills failed", exc_info=True)

--- a/tests/test_skills_slash_command.py
+++ b/tests/test_skills_slash_command.py
@@ -1,0 +1,80 @@
+"""/skills backend — the enriched ``list_skills`` control.
+
+The TUI's /skills command + skills hub group skills by ``category`` and
+show ``path``, so the control must carry both (the original #463 payload
+had only name + 80-char description, capped at 120 entries).
+"""
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+def _session():
+    from src.server.agent_server import AgentServerConfig, _AgentSession
+
+    sess = _AgentSession(
+        session_id="s1", cwd="/tmp",
+        config=AgentServerConfig(single_session=True),
+        loop=MagicMock(), out_queue=MagicMock(),
+    )
+    replies = []
+    sess._reply = lambda rid, payload: replies.append(payload)
+    return sess, replies
+
+
+def _list_skills(skills):
+    sess, replies = _session()
+    with patch("src.skills.loader.get_all_skills", return_value=skills):
+        asyncio.run(sess._handle_control_request({
+            "request_id": "r1",
+            "request": {"subtype": "list_skills"},
+        }))
+    return replies[-1]
+
+
+class TestListSkillsControl(unittest.TestCase):
+    def test_payload_carries_category_and_path(self):
+        from src.skills.model import Skill
+
+        payload = _list_skills([
+            Skill(name="qa", description="QA a web app", source="userSettings",
+                  loaded_from="skills", skill_root="/u/qa"),
+            Skill(name="deep-research", description="d" * 500, source="",
+                  loaded_from="bundled"),
+        ])
+
+        self.assertEqual(payload["total"], 2)
+        by_name = {s["name"]: s for s in payload["skills"]}
+        # Settings scope wins over the generic 'skills' disk bucket.
+        self.assertEqual(by_name["qa"]["category"], "user")
+        self.assertEqual(by_name["qa"]["path"], "/u/qa")
+        # No scope → the loaded_from bucket; description capped at 400.
+        self.assertEqual(by_name["deep-research"]["category"], "bundled")
+        self.assertEqual(len(by_name["deep-research"]["description"]), 400)
+
+    def test_scope_map_covers_project_and_managed(self):
+        from src.skills.model import Skill
+
+        payload = _list_skills([
+            Skill(name="p", description="", source="projectSettings", loaded_from="skills"),
+            Skill(name="m", description="", source="policySettings", loaded_from="skills"),
+        ])
+
+        cats = {s["name"]: s["category"] for s in payload["skills"]}
+        self.assertEqual(cats, {"p": "project", "m": "managed"})
+
+    def test_total_reports_full_count_beyond_the_entry_cap(self):
+        from src.skills.model import Skill
+
+        payload = _list_skills([
+            Skill(name=f"s{i}", description="", loaded_from="bundled")
+            for i in range(1005)
+        ])
+
+        self.assertEqual(payload["total"], 1005)
+        self.assertEqual(len(payload["skills"]), 1000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -378,6 +378,66 @@ describe('GatewayClient NDJSON adapter', () => {
     expect(r.items.map(i => i.text)).toContain('/exit')
   })
 
+  it('lists /skills in the slash-completion menu (user-reported: /skills missing)', async () => {
+    const p = gw.request<{ items: Array<{ text: string }> }>('complete.slash', { text: '/sk' })
+    await replyToControl('list_workflow_commands', { commands: [], ok: true })
+    const r = await p
+    expect(r.items.map(i => i.text)).toContain('/skills')
+  })
+
+  it('skills.manage list groups backend skills by category', async () => {
+    const p = gw.request('skills.manage', { action: 'list' })
+    await replyToControl('list_skills', {
+      skills: [
+        { category: 'bundled', description: 'Deep research', name: 'deep-research', path: '/b/dr' },
+        { category: 'user', description: 'Ship it', name: 'ship', path: '/u/ship' },
+        { category: 'user', description: 'QA a web app', name: 'qa', path: '/u/qa' }
+      ],
+      total: 3
+    })
+    await expect(p).resolves.toEqual({
+      skills: { bundled: ['deep-research'], user: ['qa', 'ship'] },
+      total: 3
+    })
+  })
+
+  it('skills.manage inspect matches case-insensitively and rides the TTL cache (one list_skills per burst)', async () => {
+    const p = gw.request('skills.manage', { action: 'list' })
+    await replyToControl('list_skills', {
+      skills: [{ category: 'user', description: 'QA a web app', name: 'qa', path: '/u/qa' }],
+      total: 1
+    })
+    await p
+
+    // Within the TTL the inspect is served from the cached list — no second
+    // control round-trip (the hub inspects per selection).
+    const r = await gw.request<{ info?: { name?: string; path?: string } }>('skills.manage', {
+      action: 'inspect',
+      query: 'QA'
+    })
+    expect(r.info).toMatchObject({ name: 'qa', path: '/u/qa' })
+    expect(stdinFrames().filter(f => f.request?.subtype === 'list_skills')).toHaveLength(0)
+  })
+
+  it('skills.manage install/browse reject as unsupported instead of faking success', async () => {
+    await expect(gw.request('skills.manage', { action: 'install', query: 'foo' })).rejects.toThrow(/not supported/)
+    await expect(gw.request('skills.manage', { action: 'browse', page: 1 })).rejects.toThrow(/not supported/)
+  })
+
+  it('skills.reload busts the cache, re-scans, and reports the count', async () => {
+    const p = gw.request<{ output?: string }>('skills.reload', {})
+    await replyToControl('list_skills', { skills: [{ category: 'user', name: 'qa' }], total: 41 })
+    const r = await p
+    expect(r.output).toContain('41')
+  })
+
+  it('routes /skills <unknown-sub> to a usage hint, not the workflow fallback', async () => {
+    await expect(gw.request('slash.exec', { command: 'skills frobnicate' })).resolves.toMatchObject({
+      output: expect.stringContaining('usage: /skills'),
+      type: 'exec'
+    })
+  })
+
   it('merges backend workflow commands into the command catalog after init', async () => {
     proc.line(INIT) // resolves readyPromise, which the catalog awaits
     const p = gw.request<{ canon: Record<string, string>; pairs: [string, string][] }>('commands.catalog', {})

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -259,6 +259,7 @@ const SLASHES: ReadonlyArray<{ desc: string; name: string }> = [
   { desc: 'Switch the provider', name: '/provider' },
   { desc: 'List running and recent dynamic workflows', name: '/workflows' },
   { desc: 'Search / manage the knowledge base', name: '/knowledge' },
+  { desc: 'Browse and inspect available skills', name: '/skills' },
   { desc: 'View or set the plan', name: '/plan' },
   { desc: 'Generate session insights', name: '/insights' },
   { desc: 'List or start background agents', name: '/bg' },
@@ -273,10 +274,17 @@ type Pending = { reject: (e: Error) => void; resolve: (v: unknown) => void }
  *  bundled /deep-research plus saved `.claude/workflows/*.py`. */
 type WorkflowCommand = { argument_hint?: string; description?: string; name: string }
 
+/** A skill reported by the backend (`list_skills` control). */
+type BackendSkill = { category?: string; description?: string; name: string; path?: string }
+
 /** How long a fetched workflow-command list stays fresh. The slash menu
  *  re-queries per keystroke; the TTL keeps that to ~1 RPC per burst while a
  *  workflow authored mid-session (ultracode flow) still shows up promptly. */
 const WORKFLOW_CMDS_TTL_MS = 3_000
+
+/** How long a fetched skill list stays fresh. The skills hub inspects per
+ *  selection, so a burst of skills.manage RPCs rides one backend disk scan. */
+const SKILLS_TTL_MS = 3_000
 
 export class GatewayClient extends EventEmitter {
   private buffered: GatewayEvent[] = []
@@ -299,6 +307,10 @@ export class GatewayClient extends EventEmitter {
   private sessionId = ''
   private sessionInfo: null | SessionInfo = null
   private subscribed = false
+  // Backend skills (skills hub + /skills subcommands), TTL-cached.
+  private skills: BackendSkill[] = []
+  private skillsFetchedAt = 0
+  private skillsTotal = 0
   // Backend workflow commands (slash menu + dispatch), TTL-cached.
   private wfCommands: WorkflowCommand[] = []
   private wfFetchedAt = 0
@@ -425,7 +437,9 @@ export class GatewayClient extends EventEmitter {
               pairs.push([name, w.description ?? 'Run a dynamic workflow'])
             }
 
-            return { canon, categories: [], pairs, skill_count: 0, sub: {} } as T
+            // skill_count is served lazily from the skills cache (warmed by any
+            // /skills use) so the startup catalog doesn't pay a full disk scan.
+            return { canon, categories: [], pairs, skill_count: this.skillsTotal, sub: {} } as T
           })
       }
 
@@ -548,6 +562,64 @@ export class GatewayClient extends EventEmitter {
 
         return Promise.resolve({ ok: true } as T)
 
+      // ── skills hub + /skills subcommands ─────────────────────────────────
+      case 'skills.manage': {
+        const action = String(p.action ?? 'list')
+        const query = String(p.query ?? '').trim().toLowerCase()
+
+        // Community install/browse are Nous-portal features with no clawcodex
+        // backend; reject so the hub/command surfaces a real error, not a fake
+        // success.
+        if (action === 'install' || action === 'browse') {
+          return Promise.reject(
+            new Error(`/skills ${action}: not supported in clawcodex — add skills under ~/.claude/skills or .claude/skills`)
+          )
+        }
+
+        return this.fetchSkills().then(skills => {
+          if (action === 'inspect') {
+            const found = skills.find(s => s.name.toLowerCase() === query)
+
+            return (
+              found
+                ? { info: { category: found.category, description: found.description, name: found.name, path: found.path } }
+                : {}
+            ) as T
+          }
+
+          if (action === 'search') {
+            const results = skills
+              .filter(s => s.name.toLowerCase().includes(query) || (s.description ?? '').toLowerCase().includes(query))
+              .slice(0, 30)
+              .map(s => ({ description: s.description, name: s.name }))
+
+            return { results } as T
+          }
+
+          // 'list' (default): group by category for the hub / /skills panel.
+          const byCat: Record<string, string[]> = {}
+
+          for (const s of skills) {
+            ;(byCat[s.category || 'other'] ??= []).push(s.name)
+          }
+
+          for (const names of Object.values(byCat)) {
+            names.sort()
+          }
+
+          return { skills: byCat, total: this.skillsTotal } as T
+        })
+      }
+
+      case 'skills.reload':
+        // get_all_skills re-scans disk on every call; "reload" just busts the
+        // client TTL cache and fetches fresh.
+        this.skillsFetchedAt = 0
+
+        return this.fetchSkills().then(
+          skills => ({ output: `Re-scanned skills: ${this.skillsTotal || skills.length} available.` }) as T
+        )
+
       // ── slash commands → clawcodex control_requests ──────────────────────
       case 'command.dispatch':
         return this.dispatchSlash(String(p.name ?? ''), p.arg == null ? undefined : String(p.arg)) as Promise<T>
@@ -631,6 +703,24 @@ export class GatewayClient extends EventEmitter {
       }
 
       return this.wfCommands
+    })
+  }
+
+  // Fetch the backend's unified skill set (`list_skills` control), TTL-cached
+  // (see SKILLS_TTL_MS). Degrades to the last-known list on RPC failure.
+  private fetchSkills(): Promise<BackendSkill[]> {
+    const now = Date.now()
+
+    if (now - this.skillsFetchedAt < SKILLS_TTL_MS) {return Promise.resolve(this.skills)}
+    this.skillsFetchedAt = now
+
+    return this.controlQuery('list_skills', {}).then((r: any) => {
+      if (Array.isArray(r?.skills)) {
+        this.skills = r.skills.filter((s: any) => typeof s?.name === 'string' && s.name)
+        this.skillsTotal = Number(r.total) || this.skills.length
+      }
+
+      return this.skills
     })
   }
 
@@ -857,6 +947,11 @@ export class GatewayClient extends EventEmitter {
             : 'No saved sessions.'
         )
       }
+
+      case 'skills':
+        // Reached only via the slash-worker fallback for unknown subcommands —
+        // the TUI-local /skills (ops.ts) owns the hub + list/inspect/search.
+        return out('usage: /skills [list | inspect <name> | search <query>] — bare /skills opens the hub')
 
       case 'workflows': {
         const r = (await this.controlQuery('workflows', {})) as any


### PR DESCRIPTION
## Summary

User report: *there is no slash command `/skills`. Please add it back.*

The hermes TUI port (#572) shipped a full `/skills` implementation (`ops.ts` + SkillsHub overlay), but it was invisible and inert against the clawcodex backend:

- the completion menu + `/help` catalog are fed by the hardcoded `SLASHES` list in `gatewayClient.ts`, which lacked `/skills` (same bug class as `/exit`, #625)
- its `skills.manage` / `skills.reload` RPCs hit the adapter's default case and resolved `{}`, so even typed blind the hub said "no skills available"
- `/skills <unknown-sub>` fell through to the workflow fallback ("isn't wired into the clawcodex backend yet")

## Changes

**`ui-tui/src/gatewayClient.ts`**
- `/skills` added to `SLASHES` (completion menu + catalog recognition)
- `skills.manage`: `list`/`inspect`/`search` served from a TTL-cached `list_skills` control; `install`/`browse` reject honestly (no community-skill backend in clawcodex)
- `skills.reload`: busts the cache, re-fetches, reports the count
- catalog `skill_count` fills lazily from the warm cache (startup doesn't pay a disk scan); `/help` then shows "N skill commands available — /skills to browse"
- `dispatchSlash` `'skills'`: usage hint instead of the workflow fallback

**`src/server/agent_server.py`**
- `list_skills` payload gains `category` (settings scope beats loader bucket: user/project/managed, else bundled/plugin/mcp/…) + `path`; entry cap 120→1000 (hub groups the full set), description cap 80→400

## Verification (live, real surfaces)

- agent-server stdio NDJSON: `list_skills` → `total=540`, categorized entries with paths
- Real TUI under a PTY (built dist, char-by-char keys): `/sk` completion entry, hub (`bundled · 5` / `user · 535`), category → skill → info drill-down, Esc/q close, `/skills list|inspect simplify|search research` panels, `/reload-skills` → "Re-scanned skills: 540 available."
- Error paths probed: unknown name → "unknown skill: qa"; `install foo` → clean unsupported error; `frobnicate` → usage hint; paste-chunked `/sk` correctly keeps the menu closed
- `tsc` clean; gatewayClient suite 47/47 (7 new tests); 3 new server tests pass; full-suite failures confirmed pre-existing via stashed-tree run

## Follow-ups noticed (not in this PR)

- Boot banner hardcodes `0 skills` (`toSessionInfo` → `skills: {}`) — reads wrong next to a working hub
- `/plugins` hub has the same unmapped-RPC disease (`plugins.manage`; backend `list_plugins` exists)
- Backend loader indexes junk skills from dot-dirs under `~/.claude/skills` (e.g. `gstack:.opencode:skills:…`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)