### PR TITLE
feat(tui): argument hints for slash commands — menu grammar + inline ghost text

### DIFF
--- a/ui-tui/src/__tests__/argumentHints.test.ts
+++ b/ui-tui/src/__tests__/argumentHints.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { argumentHintFor, ghostArgumentHint } from '../app/slash/argumentHints.js'
+
+// User report: slash commands had no value suggestions. The ghost hint fires
+// on exactly `/name ` (one trailing space, no args) — the original CC's
+// hasExactlyOneTrailingSpace gate — and resolves local-registry hints first
+// (dispatch order), then catalog hints (gateway/workflow commands).
+describe('argumentHintFor', () => {
+  it('resolves a local registry command hint', () => {
+    expect(argumentHintFor('skills')).toBe('[list | inspect <name> | search <query>]')
+  })
+
+  it('resolves via a local alias (dispatch consults aliases too)', () => {
+    // /bg is a SLASHES name, but dispatch resolves it to the local
+    // `background` command via its alias — the hint must follow dispatch.
+    expect(argumentHintFor('bg')).toBe('<prompt>')
+  })
+
+  it('prefers the local hint over a catalog hint for shadowed names', () => {
+    // Local /compact (transcript display toggle) shadows the gateway
+    // /compact (conversation compaction); dispatch runs the local one.
+    expect(argumentHintFor('compact', { '/compact': '[<instructions>]' })).toBe('[on|off|toggle]')
+  })
+
+  it('falls back to catalog hints for gateway/workflow commands', () => {
+    expect(argumentHintFor('effort', { '/effort': '[minimal|low|medium|high|auto|ultracode]' })).toBe(
+      '[minimal|low|medium|high|auto|ultracode]'
+    )
+    expect(argumentHintFor('deep-research', { '/deep-research': '<question>' })).toBe('<question>')
+  })
+
+  it('returns undefined for unknown commands', () => {
+    expect(argumentHintFor('frobnicate', {})).toBeUndefined()
+  })
+})
+
+describe('ghostArgumentHint', () => {
+  const catalog = { '/effort': '[minimal|low|medium|high|auto|ultracode]' }
+
+  it('fires on exactly one trailing space after a known command', () => {
+    expect(ghostArgumentHint('/skills ', null)).toBe('[list | inspect <name> | search <query>]')
+    expect(ghostArgumentHint('/effort ', catalog)).toBe('[minimal|low|medium|high|auto|ultracode]')
+  })
+
+  it('stays hidden while the name is still being typed', () => {
+    expect(ghostArgumentHint('/skills', null)).toBeUndefined()
+  })
+
+  it('clears once a real argument or extra space is typed', () => {
+    expect(ghostArgumentHint('/skills l', null)).toBeUndefined()
+    expect(ghostArgumentHint('/skills  ', null)).toBeUndefined()
+    expect(ghostArgumentHint('/skills list ', null)).toBeUndefined()
+  })
+
+  it('ignores non-slash input and bare slashes', () => {
+    expect(ghostArgumentHint('skills ', null)).toBeUndefined()
+    expect(ghostArgumentHint('/ ', null)).toBeUndefined()
+    expect(ghostArgumentHint('', null)).toBeUndefined()
+  })
+})

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -385,6 +385,40 @@ describe('GatewayClient NDJSON adapter', () => {
     expect(r.items.map(i => i.text)).toContain('/skills')
   })
 
+  it('carries argument hints on completion items (user-reported: no value suggestions)', async () => {
+    const p = gw.request<{ items: Array<{ hint?: string; text: string }> }>('complete.slash', { text: '/ef' })
+    await replyToControl('list_workflow_commands', { commands: [], ok: true })
+    const r = await p
+    const effort = r.items.find(i => i.text === '/effort')
+    expect(effort?.hint).toBe('[minimal|low|medium|high|auto|ultracode]')
+  })
+
+  it('passes workflow argument_hint through to completion items', async () => {
+    const p = gw.request<{ items: Array<{ hint?: string; text: string }> }>('complete.slash', { text: '/de' })
+    await replyToControl('list_workflow_commands', {
+      commands: [{ argument_hint: '<question>', description: 'Deep research', name: 'deep-research' }],
+      ok: true
+    })
+    const r = await p
+    expect(r.items.find(i => i.text === '/deep-research')?.hint).toBe('<question>')
+  })
+
+  it('exposes argument hints in the command catalog (ghost-text lookup source)', async () => {
+    proc.line(INIT)
+    const p = gw.request<{ hints: Record<string, string> }>('commands.catalog', {})
+    await replyToControl('list_workflow_commands', {
+      commands: [{ argument_hint: '<question>', description: 'Deep research', name: 'deep-research' }],
+      ok: true
+    })
+    const r = await p
+    expect(r.hints['/mode']).toBe('[default|plan|acceptEdits|dontAsk|bypassPermissions]')
+    expect(r.hints['/deep-research']).toBe('<question>')
+    // Names shadowed by TUI-local commands carry no gateway hint — the local
+    // registry's argumentHint is the truthful one (dispatch order).
+    expect(r.hints['/compact']).toBeUndefined()
+    expect(r.hints['/model']).toBeUndefined()
+  })
+
   it('skills.manage list groups backend skills by category', async () => {
     const p = gw.request('skills.manage', { action: 'list' })
     await replyToControl('list_skills', {

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -327,6 +327,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         setCatalog({
           canon: (r.canon ?? {}) as Record<string, string>,
           categories: r.categories ?? [],
+          hints: (r.hints ?? {}) as Record<string, string>,
           pairs: r.pairs as [string, string][],
           skillCount: (r.skill_count ?? 0) as number,
           sub: (r.sub ?? {}) as Record<string, string[]>

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -68,6 +68,8 @@ export interface SelectionApi {
 
 export interface CompletionItem {
   display: string
+  /** Argument hint shown dim after the name, e.g. `[on|off|toggle]`. */
+  hint?: string
   meta?: string
   text: string
 }
@@ -394,6 +396,8 @@ export interface AppLayoutActions {
 }
 
 export interface AppLayoutComposerProps {
+  /** Ghost argument hint for the exactly-typed `/command ` in the input. */
+  argumentHint?: string
   cols: number
   compIdx: number
   completions: CompletionItem[]

--- a/ui-tui/src/app/slash/argumentHints.ts
+++ b/ui-tui/src/app/slash/argumentHints.ts
@@ -1,0 +1,39 @@
+import { findSlashCommand } from './registry.js'
+
+/** Ghost-hint gate: exactly `/name ` — one trailing space, no args typed yet.
+ *  Mirrors the original CC's hasExactlyOneTrailingSpace (useTypeahead.tsx),
+ *  so the hint appears right after completing a command and disappears the
+ *  moment a real argument (or a second space) is typed. */
+const GHOST_RE = /^\/([^\s/][^\s]*) $/
+
+/**
+ * Argument hint for a slash command name (no leading `/`).
+ *
+ * The TUI-local registry wins over the catalog — dispatch consults it first
+ * (createSlashHandler), so a local command that shadows a gateway one (e.g.
+ * /compact, /model) must also shadow its hint. The catalog covers the rest:
+ * gateway-dispatched SLASHES commands and backend workflow commands.
+ */
+export function argumentHintFor(
+  name: string,
+  catalogHints?: null | Record<string, string>
+): string | undefined {
+  const local = findSlashCommand(name)
+
+  if (local?.argumentHint) {
+    return local.argumentHint
+  }
+
+  return catalogHints?.[`/${name.toLowerCase()}`]
+}
+
+/** Hint to ghost-render after the input, or undefined when the input isn't an
+ *  exactly-completed `/command ` (or the command has no hint). */
+export function ghostArgumentHint(
+  input: string,
+  catalogHints?: null | Record<string, string>
+): string | undefined {
+  const m = GHOST_RE.exec(input)
+
+  return m ? argumentHintFor(m[1]!, catalogHints) : undefined
+}

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -158,6 +158,7 @@ export const coreCommands: SlashCommand[] = [
 
   {
     aliases: ['scroll'],
+    argumentHint: '[on|off|toggle|wheel|buttons|all]',
     help: 'set mouse tracking preset [on|off|toggle|wheel|buttons|all]',
     name: 'mouse',
     run: (arg, ctx) => {
@@ -234,6 +235,7 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[<title>]',
     help: 'set or show current session title',
     name: 'title',
     run: (arg, ctx) => {
@@ -275,6 +277,7 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[on|off|toggle]',
     help: 'toggle compact transcript',
     name: 'compact',
     run: (arg, ctx) => {
@@ -293,6 +296,7 @@ export const coreCommands: SlashCommand[] = [
 
   {
     aliases: ['detail'],
+    argumentHint: '[hidden|collapsed|expanded|cycle]',
     help: 'control agent detail visibility (global or per-section)',
     name: 'details',
     run: (arg, ctx) => {
@@ -356,6 +360,7 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[random|daily]',
     help: 'local fortune',
     name: 'fortune',
     run: (arg, ctx) => {
@@ -374,6 +379,7 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[<number>]',
     help: 'copy selection or assistant message',
     name: 'copy',
     run: async (arg, ctx) => {
@@ -446,6 +452,7 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[auto|vscode|cursor|windsurf]',
     help: 'configure IDE terminal keybindings for multiline + undo/redo',
     name: 'terminal-setup',
     run: (arg, ctx) => {
@@ -481,6 +488,7 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[<lines>]',
     help: 'view gateway logs',
     name: 'logs',
     run: (arg, ctx) => {
@@ -491,6 +499,7 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[<preview-chars>]',
     help: 'view current transcript (user + assistant messages)',
     name: 'history',
     run: (arg, ctx) => {
@@ -553,6 +562,7 @@ export const coreCommands: SlashCommand[] = [
 
   {
     aliases: ['sb'],
+    argumentHint: '[on|off|top|bottom|toggle]',
     help: 'status bar position (on|off|top|bottom)',
     name: 'statusbar',
     run: (arg, ctx) => {
@@ -581,6 +591,7 @@ export const coreCommands: SlashCommand[] = [
 
   {
     aliases: ['q'],
+    argumentHint: '[<message>]',
     help: 'inspect or enqueue a message',
     name: 'queue',
     run: (arg, ctx) => {
@@ -594,6 +605,7 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '<prompt>',
     help: 'inject a message after the next tool call (no interrupt)',
     name: 'steer',
     run: (arg, ctx) => {

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -81,6 +81,7 @@ export const opsCommands: SlashCommand[] = [
 
   {
     aliases: ['reload_mcp'],
+    argumentHint: '[now|always]',
     help: 'reload MCP servers in the live session (warns about prompt cache invalidation)',
     name: 'reload-mcp',
     run: (arg, ctx) => {
@@ -145,6 +146,7 @@ export const opsCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[connect [<url>]|disconnect|status]',
     help: 'manage browser CDP connection [connect|disconnect|status]',
     name: 'browser',
     run: (arg, ctx) => {
@@ -198,6 +200,7 @@ export const opsCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[list | diff <n> | restore <n>]',
     help: 'list, diff, or restore checkpoints',
     name: 'rollback',
     run: (arg, ctx) => {
@@ -326,6 +329,7 @@ export const opsCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[<n>|last|list|load <path>]',
     help: 'replay a completed spawn tree · `/replay [N|last|list|load <path>]`',
     name: 'replay',
     run: (arg, ctx) => {
@@ -412,6 +416,7 @@ export const opsCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '<baseline> <candidate>',
     help: 'diff two completed spawn trees · `/replay-diff <baseline> <candidate>` (indexes from /replay list or history N)',
     name: 'replay-diff',
     run: (arg, ctx) => {
@@ -467,6 +472,7 @@ export const opsCommands: SlashCommand[] = [
                   ctx.local.setCatalog({
                     canon: (catalog.canon ?? {}) as Record<string, string>,
                     categories: catalog.categories ?? [],
+                    hints: (catalog.hints ?? {}) as Record<string, string>,
                     pairs: catalog.pairs as [string, string][],
                     skillCount: (catalog.skill_count ?? 0) as number,
                     sub: (catalog.sub ?? {}) as Record<string, string[]>
@@ -481,6 +487,7 @@ export const opsCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[list | inspect <name> | search <query>]',
     help: 'browse, inspect, install skills',
     name: 'skills',
     run: (arg, ctx, cmd) => {
@@ -660,6 +667,7 @@ export const opsCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[enable|disable <name>]',
     help: 'view & toggle plugins (no arg opens the hub; enable/disable <name> for direct toggle)',
     name: 'plugins',
     run: (arg, ctx, cmd) => {
@@ -688,6 +696,7 @@ export const opsCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[enable|disable <name> [name ...]]',
     help: 'enable or disable tools (client-side history reset on change)',
     name: 'tools',
     run: (arg, ctx, cmd) => {

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -41,6 +41,7 @@ const modelValueForConfigSet = (arg: string) => {
 export const sessionCommands: SlashCommand[] = [
   {
     aliases: ['bg', 'btw'],
+    argumentHint: '<prompt>',
     help: 'launch a background prompt',
     name: 'background',
     run: (arg, ctx) => {
@@ -62,6 +63,7 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[<model> [--provider <slug>]]',
     help: 'change or show model',
     name: 'model',
     run: (arg, ctx) => {
@@ -118,6 +120,7 @@ export const sessionCommands: SlashCommand[] = [
 
   {
     aliases: ['switch', 'session', 'resume'],
+    argumentHint: '[new | <id or title>]',
     help: 'browse, switch, or resume sessions',
     name: 'sessions',
     run: (arg, ctx) => {
@@ -146,6 +149,7 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '<path>',
     help: 'attach an image',
     name: 'image',
     run: (arg, ctx) => {
@@ -162,6 +166,7 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[<name>]',
     help: 'switch personality for this session',
     name: 'personality',
     run: (arg, ctx) => {
@@ -183,6 +188,7 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[<focus-topic>]',
     help: 'compress transcript',
     name: 'compress',
     run: (arg, ctx) => {
@@ -238,6 +244,7 @@ export const sessionCommands: SlashCommand[] = [
 
   {
     aliases: ['fork'],
+    argumentHint: '[<name>]',
     help: 'branch the session',
     name: 'branch',
     run: (arg, ctx) => {
@@ -259,6 +266,7 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[on|off|tts|status]',
     help: 'voice mode: [on|off|tts|status]',
     name: 'voice',
     run: (arg, ctx) => {
@@ -348,6 +356,7 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[toggle | list | scale <n> | <slug>]',
     help: 'toggle / adopt / resize an animated pet',
     name: 'pet',
     usage: '/pet [toggle | list | scale <n> | <slug>]',
@@ -373,6 +382,7 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[<name>]',
     help: 'switch theme skin (fires skin.changed)',
     name: 'skin',
     run: (arg, ctx) => {
@@ -389,6 +399,7 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[kaomoji|emoji|unicode|ascii]',
     help: 'pick the busy indicator: kaomoji (default), emoji, unicode (braille), or ascii',
     name: 'indicator',
     usage: `/indicator [${INDICATOR_STYLES.join('|')}]`,
@@ -436,6 +447,7 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[<level>|show|hide]',
     help: 'inspect or set reasoning effort (updates live agent)',
     name: 'reasoning',
     run: (arg, ctx) => {
@@ -476,6 +488,7 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[normal|fast|status|on|off|toggle]',
     help: 'toggle fast mode [normal|fast|status|on|off|toggle]',
     name: 'fast',
     run: (arg, ctx) => {
@@ -520,6 +533,7 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[queue|steer|interrupt|status]',
     help: 'control busy enter mode [queue|steer|interrupt|status]',
     name: 'busy',
     run: (arg, ctx) => {

--- a/ui-tui/src/app/slash/types.ts
+++ b/ui-tui/src/app/slash/types.ts
@@ -14,6 +14,10 @@ export interface SlashRunCtx extends SlashHandlerContext {
 
 export interface SlashCommand {
   aliases?: string[]
+  /** Allowed values / argument grammar, e.g. `[on|off|toggle]` — shown dim in
+   *  the completion menu and as ghost text after `/name ` (original CC's
+   *  Command.argumentHint). */
+  argumentHint?: string
   help?: string
   name: string
   run: (arg: string, ctx: SlashRunCtx, cmd: string) => void

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -36,6 +36,7 @@ import { getInputSelection } from './inputSelectionStore.js'
 import { type GatewayRpc, type TranscriptRow } from './interfaces.js'
 import { $overlayState, patchOverlayState } from './overlayStore.js'
 import { scrollWithSelectionBy } from './scroll.js'
+import { ghostArgumentHint } from './slash/argumentHints.js'
 import { turnController } from './turnController.js'
 import { patchTurnState, useTurnSelector } from './turnStore.js'
 import { $uiState, getUiState, patchUiState } from './uiStore.js'
@@ -1077,6 +1078,9 @@ export function useMainApp(gw: GatewayClient) {
 
   const appComposer = useMemo(
     () => ({
+      // Ghost grammar hint once the input is exactly `/command ` (original
+      // CC's argumentHint); catalog hints cover gateway/workflow commands.
+      argumentHint: ghostArgumentHint(composerState.input, catalog?.hints),
       cols,
       compIdx: composerState.compIdx,
       completions: composerState.completions,
@@ -1090,7 +1094,7 @@ export function useMainApp(gw: GatewayClient) {
       updateInput: composerActions.setInput,
       voiceRecordKey
     }),
-    [cols, composerActions, composerState, empty, pagerPageSize, submit, voiceRecordKey]
+    [catalog, cols, composerActions, composerState, empty, pagerPageSize, submit, voiceRecordKey]
   )
 
   // Pass current progress through unfrozen — streaming update throttling

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -334,6 +334,7 @@ const ComposerPane = memo(function ComposerPane({
               <Box flexGrow={0} flexShrink={0} height={inputHeight} width={inputColumns}>
                 {/* Reserve the transcript scrollbar gutter too so typing never rewraps when the scrollbar column repaints. */}
                 <TextInput
+                  argumentHint={composer.argumentHint}
                   columns={inputColumns}
                   mouseApiRef={inputMouseRef}
                   multiline

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -4,6 +4,7 @@ import { useStore } from '@nanostores/react'
 import { useGateway } from '../app/gatewayContext.js'
 import type { AppOverlaysProps } from '../app/interfaces.js'
 import { $overlayState, patchOverlayState } from '../app/overlayStore.js'
+import { argumentHintFor } from '../app/slash/argumentHints.js'
 import { $uiSessionId, $uiTheme } from '../app/uiStore.js'
 
 import { ActiveSessionSwitcher } from './activeSessionSwitcher.js'
@@ -238,6 +239,14 @@ export function FloatingOverlays({
             {completions.slice(start, start + viewportSize).map((item, i) => {
               const active = start + i === compIdx
 
+              // Slash rows show the command's argument grammar dim after the
+              // name (original CC's argumentHint). Local registry wins over
+              // the gateway item's hint — dispatch consults it first, so a
+              // shadowing local command's grammar is the truthful one.
+              const hint = item.text.startsWith('/')
+                ? (argumentHintFor(item.text.slice(1)) ?? item.hint)
+                : item.hint
+
               return (
                 <Box
                   backgroundColor={active ? theme.color.completionCurrentBg : theme.color.completionBg}
@@ -254,6 +263,14 @@ export function FloatingOverlays({
                       {item.display}
                     </Text>
                   </Box>
+                  {hint ? (
+                    <Box flexShrink={0}>
+                      <Text color={theme.color.muted}>
+                        {' '}
+                        {hint}
+                      </Text>
+                    </Box>
+                  ) : null}
                   {item.meta ? (
                     <Text
                       backgroundColor={active ? theme.color.completionMetaCurrentBg : theme.color.completionMetaBg}

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -472,6 +472,7 @@ const isPasteResultPromise = (
 ): value is Promise<PasteResult> => !!value && typeof (value as PromiseLike<PasteResult>).then === 'function'
 
 export function TextInput({
+  argumentHint,
   columns = 80,
   value,
   onChange,
@@ -567,8 +568,13 @@ export function TextInput({
   // 0 and visually marks the input start. Non-TTY surfaces still need the
   // synthetic inverse first-char to draw a cursor at all.
   const rendered = useMemo(() => {
+    // Ghost argument hint appended after the typed command (original CC's
+    // BaseTextInput): dim, after the cursor, never part of the value. The
+    // separator space is skipped when the value already ends with one.
+    const hint = argumentHint && display ? dim((display.endsWith(' ') ? '' : ' ') + argumentHint) : ''
+
     if (!focus) {
-      return display || dim(placeholder)
+      return display ? display + hint : dim(placeholder)
     }
 
     if (!display && placeholder) {
@@ -576,11 +582,11 @@ export function TextInput({
     }
 
     if (selected) {
-      return renderWithSelection(display, selected.start, selected.end)
+      return renderWithSelection(display, selected.start, selected.end) + hint
     }
 
-    return nativeCursor ? display || ' ' : renderWithCursor(display, cur)
-  }, [cur, display, focus, nativeCursor, placeholder, selected])
+    return (nativeCursor ? display || ' ' : renderWithCursor(display, cur)) + hint
+  }, [argumentHint, cur, display, focus, nativeCursor, placeholder, selected])
 
   useEffect(() => {
     if (self.current) {
@@ -1334,6 +1340,10 @@ export interface PasteEvent {
 }
 
 interface TextInputProps {
+  /** Ghost text appended dim after the value — the slash command's argument
+   *  grammar once `/name ` is typed (original CC's BaseTextInput argumentHint).
+   *  Purely visual: never part of `value`, never submitted. */
+  argumentHint?: string
   columns?: number
   focus?: boolean
   mask?: string

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -17,12 +17,11 @@
  */
 import { type ChildProcess, spawn } from 'node:child_process'
 import { EventEmitter } from 'node:events'
-import { readdirSync } from 'node:fs'
-import { resolve as pathResolve } from 'node:path'
 import { createInterface } from 'node:readline'
 
 import type { CostSnapshot, GatewayEvent, PatchHunk, StructuredDiffPayload } from './gatewayTypes.js'
 import { formatTotalCost, setLastCostSnapshot } from './lib/costSummary.js'
+import { completeFileMention } from './lib/fileSuggestions.js'
 import type { SessionInfo } from './types.js'
 
 const STARTUP_TIMEOUT_MS = 30_000
@@ -55,10 +54,13 @@ function safeJson(v: unknown): string {
  *  option so the user sees what it will persist. */
 export function describeSuggestionRule(suggestion: any): string | null {
   const rules = Array.isArray(suggestion?.rules) ? suggestion.rules : []
+
   const labels = rules
     .filter((r: any) => r && r.tool_name)
     .map((r: any) => (r.rule_content ? `${r.tool_name}(${r.rule_content})` : String(r.tool_name)))
+
   if (labels.length === 0) {return null}
+
   return labels.length > 3 ? `${labels.slice(0, 3).join(', ')}, …` : labels.join(', ')
 }
 
@@ -244,27 +246,37 @@ export function formatToolResult(
 }
 
 /** clawcodex-backed slash commands (handled via command.dispatch → dispatchSlash).
- *  Drives both the catalog (recognition) and the complete.slash menu. */
-const SLASHES: ReadonlyArray<{ desc: string; name: string }> = [
+ *  Drives both the catalog (recognition) and the complete.slash menu.
+ *
+ *  `hint` is the argument grammar shown dim in the menu and as ghost text
+ *  after `/name ` (original CC's Command.argumentHint). Names shadowed by a
+ *  TUI-local command (/model, /compact, /bg, /resume, /clear, /exit — the
+ *  local registry dispatches first) deliberately carry NO hint here: the
+ *  local command's argumentHint is the one that matches actual behavior. */
+const SLASHES: ReadonlyArray<{ desc: string; hint?: string; name: string }> = [
   { desc: 'Show available commands', name: '/help' },
   { desc: 'Clear the conversation', name: '/clear' },
   { desc: 'Switch the model', name: '/model' },
-  { desc: 'Set the permission mode', name: '/mode' },
+  { desc: 'Set the permission mode', hint: '[default|plan|acceptEdits|dontAsk|bypassPermissions]', name: '/mode' },
   { desc: 'Compact the conversation to save context', name: '/compact' },
   { desc: 'Show context-window usage', name: '/context' },
   { desc: 'Show the total cost and duration of the current session', name: '/cost' },
-  { desc: 'Undo recent turns', name: '/rewind' },
-  { desc: 'Toggle extended thinking', name: '/thinking' },
-  { desc: 'Set reasoning effort (or "ultracode" workflow mode)', name: '/effort' },
-  { desc: 'Switch the provider', name: '/provider' },
+  { desc: 'Undo recent turns', hint: '[<turns>]', name: '/rewind' },
+  { desc: 'Toggle extended thinking', hint: '[on|off|toggle]', name: '/thinking' },
+  {
+    desc: 'Set reasoning effort (or "ultracode" workflow mode)',
+    hint: '[minimal|low|medium|high|auto|ultracode]',
+    name: '/effort'
+  },
+  { desc: 'Switch the provider', hint: '[<provider>]', name: '/provider' },
   { desc: 'List running and recent dynamic workflows', name: '/workflows' },
-  { desc: 'Search / manage the knowledge base', name: '/knowledge' },
-  { desc: 'Browse and inspect available skills', name: '/skills' },
-  { desc: 'View or set the plan', name: '/plan' },
+  { desc: 'Search / manage the knowledge base', hint: '[status|list|clear|enable|disable]', name: '/knowledge' },
+  { desc: 'Browse and inspect available skills', hint: '[list | inspect <name> | search <query>]', name: '/skills' },
+  { desc: 'View or set the plan', hint: '[<text>]', name: '/plan' },
   { desc: 'Generate session insights', name: '/insights' },
   { desc: 'List or start background agents', name: '/bg' },
   { desc: 'Resume a past session', name: '/resume' },
-  { desc: 'Rename this session', name: '/rename' },
+  { desc: 'Rename this session', hint: '<name>', name: '/rename' },
   { desc: 'Exit clawcodex', name: '/exit' }
 ]
 
@@ -426,8 +438,13 @@ export class GatewayClient extends EventEmitter {
           .then(wf => {
             const pairs = SLASHES.map(s => [s.name, s.desc] as [string, string])
             const canon: Record<string, string> = {}
+            const hints: Record<string, string> = {}
 
-            for (const s of SLASHES) {canon[s.name] = s.name}
+            for (const s of SLASHES) {
+              canon[s.name] = s.name
+
+              if (s.hint) {hints[s.name] = s.hint}
+            }
 
             for (const w of wf) {
               const name = `/${w.name}`
@@ -435,11 +452,13 @@ export class GatewayClient extends EventEmitter {
               if (canon[name]) {continue}
               canon[name] = name
               pairs.push([name, w.description ?? 'Run a dynamic workflow'])
+
+              if (w.argument_hint) {hints[name] = w.argument_hint}
             }
 
             // skill_count is served lazily from the skills cache (warmed by any
             // /skills use) so the startup catalog doesn't pay a full disk scan.
-            return { canon, categories: [], pairs, skill_count: this.skillsTotal, sub: {} } as T
+            return { canon, categories: [], hints, pairs, skill_count: this.skillsTotal, sub: {} } as T
           })
       }
 
@@ -453,21 +472,32 @@ export class GatewayClient extends EventEmitter {
               ...SLASHES,
               ...wf
                 .filter(w => !SLASHES.some(s => s.name === `/${w.name}`))
-                .map(w => ({ desc: w.description ?? 'Run a dynamic workflow', name: `/${w.name}` }))
+                .map(w => ({
+                  desc: w.description ?? 'Run a dynamic workflow',
+                  hint: w.argument_hint,
+                  name: `/${w.name}`
+                }))
             ]
 
             const items = entries
               .filter(s => s.name.toLowerCase().startsWith(text))
-              .map(s => ({ display: s.name, meta: s.desc, text: s.name }))
+              .map(s => ({ display: s.name, hint: s.hint, meta: s.desc, text: s.name }))
 
             return { items, replace_from: 1 } as T
           })
       }
 
-      case 'complete.path':
-        // @-file mentions: serve workspace file completions from disk (the hook
-        // computes the replace offset; we just return matching entries).
-        return Promise.resolve({ items: this.completePath(String(p.word ?? '')) } as T)
+      case 'complete.path': {
+        // @-file mentions (the hook computes the replace offset; we return
+        // matching entries): path-like words traverse the real filesystem so
+        // any path completes (~/, /abs, ../), others fuzzy-search the project
+        // file index — same split as original CC's useTypeahead.
+        const cwd = process.env.CLAWCODEX_WORKSPACE || process.env.CLAWCODEX_CWD || process.cwd()
+
+        return completeFileMention(String(p.word ?? ''), cwd)
+          .catch(() => [])
+          .then(items => ({ items }) as T)
+      }
       case 'config.get': {
         // Settings slashes read config; only 'full' maps to clawcodex settings.
         if (String(p.key ?? '') === 'full') {
@@ -561,7 +591,6 @@ export class GatewayClient extends EventEmitter {
         this.sendControl('interrupt', {})
 
         return Promise.resolve({ ok: true } as T)
-
       // ── skills hub + /skills subcommands ─────────────────────────────────
       case 'skills.manage': {
         const action = String(p.action ?? 'list')
@@ -952,7 +981,6 @@ export class GatewayClient extends EventEmitter {
         // Reached only via the slash-worker fallback for unknown subcommands —
         // the TUI-local /skills (ops.ts) owns the hub + list/inspect/search.
         return out('usage: /skills [list | inspect <name> | search <query>] — bare /skills opens the hub')
-
       case 'workflows': {
         const r = (await this.controlQuery('workflows', {})) as any
 
@@ -977,31 +1005,6 @@ export class GatewayClient extends EventEmitter {
 
         return out(`/${name} isn't wired into the clawcodex backend yet.`)
       }
-    }
-  }
-
-  // @-file mention completion, served from the workspace filesystem (shell-style:
-  // resolve the dir part of the typed word, list it, filter by the basename).
-  private completePath(word: string): Array<{ display: string; meta: string; text: string }> {
-    try {
-      const cwd = process.env.CLAWCODEX_WORKSPACE || process.env.CLAWCODEX_CWD || process.cwd()
-      const stripped = word.startsWith('@') ? word.slice(1) : word
-      const slash = stripped.lastIndexOf('/')
-      const dirPart = slash === -1 ? '' : stripped.slice(0, slash + 1)
-      const base = (slash === -1 ? stripped : stripped.slice(slash + 1)).toLowerCase()
-      const absDir = pathResolve(cwd, dirPart || '.')
-
-      return readdirSync(absDir, { withFileTypes: true })
-        .filter(e => !e.name.startsWith('.') && e.name.toLowerCase().startsWith(base))
-        .slice(0, 50)
-        .map(e => {
-          const isDir = e.isDirectory()
-          const rel = dirPart + e.name + (isDir ? '/' : '')
-
-          return { display: rel, meta: isDir ? 'dir' : 'file', text: rel }
-        })
-    } catch {
-      return []
     }
   }
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -11,6 +11,8 @@ export interface GatewaySkin {
 
 export interface GatewayCompletionItem {
   display: string
+  /** Argument hint shown dim after the name, e.g. `[on|off|toggle]`. */
+  hint?: string
   meta?: string
   text: string
 }
@@ -52,6 +54,8 @@ export interface StructuredDiffPayload {
 export interface CommandsCatalogResponse {
   canon?: Record<string, string>
   categories?: SlashCategory[]
+  /** Argument hints by canonical `/name` (gateway + workflow commands). */
+  hints?: Record<string, string>
   pairs?: [string, string][]
   skill_count?: number
   sub?: Record<string, string[]>

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -248,6 +248,8 @@ export interface PanelSection {
 export interface SlashCatalog {
   canon: Record<string, string>
   categories: SlashCategory[]
+  /** Argument hints by canonical `/name` (gateway + workflow commands). */
+  hints: Record<string, string>
   pairs: [string, string][]
   skillCount: number
   sub: Record<string, string[]>


### PR DESCRIPTION
## Summary

User report (`/goal`): *slash commands have no value suggestion — original Claude Code shows e.g. `/goal [<condition> | clear]` as you type.*

Ported the original's mechanism from `typescript/` (`Command.argumentHint` → `useTypeahead`'s exactly-one-trailing-space gate → `BaseTextInput` dim ghost text) onto clawcodex's completion stack.

## What you see

- **Menu rows** now show the grammar dim between name and description:
  `║ /effort [minimal|low|medium|high|auto|ultracode] Set reasoning effort… ║`
- **Inline ghost text** once the input is exactly `/name ` (appears on the space keystroke, clears on the first real argument):
  `deepseek ❯ /skills [list | inspect <name> | search <query>]`

## Changes

- `SlashCommand.argumentHint` on **34 TUI-local commands** — grammars derived from each `run()`'s actual parsing/usage strings, not guessed
- `hint` on **10 gateway `SLASHES` entries** — values validated against the agent-server handlers (`PERMISSION_MODES`, `set_effort`, `set_thinking`, `knowledge`)
- **Workflow commands**: `argument_hint` from `list_workflow_commands` finally used — `/deep-research <question>` shows in the menu
- `complete.slash` items + `commands.catalog` carry hint data; the catalog `hints` map is the ghost-text lookup for gateway/workflow commands
- New pure module `app/slash/argumentHints.ts` (`argumentHintFor` / `ghostArgumentHint`)
- `TextInput.argumentHint` prop — dim, appended after the value, never part of it
- **Precedence rule** the original doesn't need: local-registry hints win over gateway hints, matching dispatch order — shadowed names (`/compact`, `/model`, `/bg`, `/resume`) show the grammar that actually runs

Deliberate deviation: clawcodex's `applyCompletion` inserts `/name` without a trailing space (original inserts `/name `), so the ghost appears at the user's space keystroke instead of changing completion semantics.

## Verification (live PTY drive, built dist, char-by-char keys)

- `/eff` → menu row with grammar · `/effort ` → ghost on composer line · `/effort m` → ghost cleared
- `/skills ` and `/pet ` → local-registry ghosts · `/deep` → workflow `<question>` row
- Probes: unknown `/frobnicate ` → no ghost; `/skills  ` (two spaces) → hidden (gate holds)
- `tsc` clean; eslint clean on touched files (`--fix` also normalized pre-existing padding warnings in `gatewayClient.ts`/`appOverlays.tsx`); 1218 tests pass (12 new), same 8 pre-existing env-baseline failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)