### PR TITLE
fix(tui): revert stray file-mention hunk that broke main (missing module)

### DIFF
--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -17,11 +17,12 @@
  */
 import { type ChildProcess, spawn } from 'node:child_process'
 import { EventEmitter } from 'node:events'
+import { readdirSync } from 'node:fs'
+import { resolve as pathResolve } from 'node:path'
 import { createInterface } from 'node:readline'
 
 import type { CostSnapshot, GatewayEvent, PatchHunk, StructuredDiffPayload } from './gatewayTypes.js'
 import { formatTotalCost, setLastCostSnapshot } from './lib/costSummary.js'
-import { completeFileMention } from './lib/fileSuggestions.js'
 import type { SessionInfo } from './types.js'
 
 const STARTUP_TIMEOUT_MS = 30_000
@@ -487,17 +488,10 @@ export class GatewayClient extends EventEmitter {
           })
       }
 
-      case 'complete.path': {
-        // @-file mentions (the hook computes the replace offset; we return
-        // matching entries): path-like words traverse the real filesystem so
-        // any path completes (~/, /abs, ../), others fuzzy-search the project
-        // file index — same split as original CC's useTypeahead.
-        const cwd = process.env.CLAWCODEX_WORKSPACE || process.env.CLAWCODEX_CWD || process.cwd()
-
-        return completeFileMention(String(p.word ?? ''), cwd)
-          .catch(() => [])
-          .then(items => ({ items }) as T)
-      }
+      case 'complete.path':
+        // @-file mentions: serve workspace file completions from disk (the hook
+        // computes the replace offset; we just return matching entries).
+        return Promise.resolve({ items: this.completePath(String(p.word ?? '')) } as T)
       case 'config.get': {
         // Settings slashes read config; only 'full' maps to clawcodex settings.
         if (String(p.key ?? '') === 'full') {
@@ -1008,6 +1002,30 @@ export class GatewayClient extends EventEmitter {
     }
   }
 
+  // @-file mention completion, served from the workspace filesystem (shell-style:
+  // resolve the dir part of the typed word, list it, filter by the basename).
+  private completePath(word: string): Array<{ display: string; meta: string; text: string }> {
+    try {
+      const cwd = process.env.CLAWCODEX_WORKSPACE || process.env.CLAWCODEX_CWD || process.cwd()
+      const stripped = word.startsWith('@') ? word.slice(1) : word
+      const slash = stripped.lastIndexOf('/')
+      const dirPart = slash === -1 ? '' : stripped.slice(0, slash + 1)
+      const base = (slash === -1 ? stripped : stripped.slice(slash + 1)).toLowerCase()
+      const absDir = pathResolve(cwd, dirPart || '.')
+
+      return readdirSync(absDir, { withFileTypes: true })
+        .filter(e => !e.name.startsWith('.') && e.name.toLowerCase().startsWith(base))
+        .slice(0, 50)
+        .map(e => {
+          const isDir = e.isDirectory()
+          const rel = dirPart + e.name + (isDir ? '/' : '')
+
+          return { display: rel, meta: isDir ? 'dir' : 'file', text: rel }
+        })
+    } catch {
+      return []
+    }
+  }
   // Rich Edit/Write result forwarded by the agent-server (`tool_use_result`
   // on the user envelope, trimmed to the display shape). Shape-detected from
   // the value itself — self-describing type/filePath/structuredPatch — so it


### PR DESCRIPTION
## Summary

PR #631 accidentally swept in an unrelated in-progress hunk from the shared working tree: `complete.path` was rewritten to import `./lib/fileSuggestions.js` — a file that exists only as **untracked WIP** and was never committed. Merged main fails typecheck/build:

```
src/gatewayClient.ts(24,37): error TS2307: Cannot find module './lib/fileSuggestions.js'
```

(The pre-merge verification passed because the untracked file satisfied the import in the working tree — the commit itself wasn't self-contained.)

## Fix

Surgical revert to the pre-#631 `complete.path`: the `readdirSync`-based `completePath` method, its `node:fs`/`node:path` imports, and the simple case body. The file-mention feature can land later **with** its module.

## Verification (clean worktree, no WIP files)

- Before fix: `tsc` fails with TS2307 (captured above)
- After fix: `tsc` clean · esbuild build succeeds · gatewayClient + argumentHints suites **59/59** · eslint clean
- `git diff` vs pre-#631 main now contains only the argument-hints feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)