### PR TITLE
feat(coordinator): wire coordinator mode end-to-end on the live paths

### DIFF
--- a/src/agent/agent_definitions.py
+++ b/src/agent/agent_definitions.py
@@ -254,7 +254,22 @@ def get_built_in_agents() -> list[AgentDefinition]:
     """Return the list of active built-in agent definitions.
 
     Mirrors getBuiltInAgents() from typescript/src/tools/AgentTool/builtInAgents.ts.
+
+    Coordinator mode swaps in the coordinator agent list (worker /
+    general-purpose / explore / plan) so the coordinator system prompt's
+    ``subagent_type: "worker"`` calls resolve — mirrors
+    ``builtInAgents.ts:35-43``. Imports are function-local for the same
+    reason TS lazy-requires there: ``coordinator.worker_agent`` imports
+    this module (hard cycle at import time), and the env gate is read
+    live per call.
     """
+    from src.coordinator.mode import is_coordinator_mode
+
+    if is_coordinator_mode():
+        from src.coordinator.worker_agent import get_coordinator_agents
+
+        return get_coordinator_agents()
+
     return [
         GENERAL_PURPOSE_AGENT,
         EXPLORE_AGENT,

--- a/src/agent/constants.py
+++ b/src/agent/constants.py
@@ -43,7 +43,11 @@ CUSTOM_AGENT_DISALLOWED_TOOLS: frozenset[str] = frozenset([
 ])
 
 # Whitelist of tools allowed for async (background) agents.
-# Mirrors ASYNC_AGENT_ALLOWED_TOOLS from typescript/src/constants/tools.ts.
+# Mirrors ASYNC_AGENT_ALLOWED_TOOLS from typescript/src/constants/tools.ts
+# (:53-69). "PowerShell" (via TS SHELL_TOOL_NAMES) is deliberately absent —
+# this port has no PowerShell tool. This set is BOTH the async-agent runtime
+# whitelist (agent_tool_utils.filter_tools_for_agent) and the source of the
+# coordinator's rendered worker-tools list (coordinator/mode.py).
 ASYNC_AGENT_ALLOWED_TOOLS: frozenset[str] = frozenset([
     "Read",
     "WebSearch",
@@ -54,8 +58,10 @@ ASYNC_AGENT_ALLOWED_TOOLS: frozenset[str] = frozenset([
     "Bash",
     "Edit",
     "Write",
+    "NotebookEdit",
     "Skill",
     "StructuredOutput",
+    "ToolSearch",
     "EnterWorktree",
     "ExitWorktree",
 ])

--- a/src/agent/prompt.py
+++ b/src/agent/prompt.py
@@ -53,12 +53,17 @@ def get_agent_prompt(
     *,
     allow_async: bool = True,
     allow_fork: bool = False,
+    is_coordinator: bool = False,
 ) -> str:
     """Build the full prompt for the Agent tool.
 
     Mirrors getPrompt() from typescript/src/tools/AgentTool/prompt.ts.
     This text is fed to the model as the Agent tool's description, instructing
     the parent agent on how and when to spawn sub-agents.
+
+    ``is_coordinator``: return only the shared header — the coordinator
+    system prompt already carries usage notes, examples, and
+    when-not-to-use guidance (mirrors ``prompt.ts:206-211``).
     """
     # --- Shared core prompt (used by both coordinator and non-coordinator) ---
     agent_list = "\n".join(format_agent_line(a) for a in agent_definitions)
@@ -73,6 +78,11 @@ def get_agent_prompt(
         f"When using the {_AGENT_TOOL_NAME} tool, specify a subagent_type parameter "
         f"to select which agent type to use. If omitted, the general-purpose agent is used."
     )
+
+    # Coordinator mode gets the slim prompt — the coordinator system prompt
+    # already covers usage notes, examples, and when-not-to-use guidance.
+    if is_coordinator:
+        return shared
 
     # --- "When NOT to use" section ---
     when_not_to_use = (

--- a/src/coordinator/__init__.py
+++ b/src/coordinator/__init__.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 from src.coordinator.mode import (
     INTERNAL_WORKER_TOOLS,
+    coordinator_main_loop_registry,
     filter_coordinator_tools,
     filter_worker_tools,
     get_coordinator_user_context,
@@ -50,6 +51,7 @@ __all__ = [
     "SAMPLE_FILES",
     "INTERNAL_WORKER_TOOLS",
     "WORKER_AGENT",
+    "coordinator_main_loop_registry",
     "filter_coordinator_tools",
     "filter_worker_tools",
     "get_coordinator_agents",

--- a/src/coordinator/mode.py
+++ b/src/coordinator/mode.py
@@ -9,7 +9,9 @@ the ~370-line system prompt body which lives in
 * ``INTERNAL_WORKER_TOOLS`` — frozenset of tool names workers cannot
   use (TeamCreate / TeamDelete / SendMessage / StructuredOutput).
 * ``filter_coordinator_tools`` — produce the coordinator's restricted
-  tool list (``Agent`` / ``SendMessage`` / ``TaskStop`` only).
+  tool list (``Agent`` / ``SendMessage`` / ``TaskStop`` /
+  ``StructuredOutput`` + PR-activity subscription MCP tools; mirrors
+  ``COORDINATOR_MODE_ALLOWED_TOOLS`` + ``applyCoordinatorToolFilter``).
 * ``filter_worker_tools`` — produce a worker's tool list (everything
   the parent has, minus ``INTERNAL_WORKER_TOOLS``).
 * ``get_coordinator_user_context`` — produce the
@@ -27,6 +29,7 @@ from src.utils.env import is_env_truthy
 
 if TYPE_CHECKING:
     from src.tool_system.build_tool import Tool
+    from src.tool_system.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +90,8 @@ def match_session_mode(session_mode: SessionMode | None) -> str | None:
 
 
 # ---------------------------------------------------------------------------
-# Tool-set filters — coordinator gets 3 tools; workers lose 4
+# Tool-set filters — coordinator keeps 4 tools (+ PR-activity MCP); workers
+# lose the swarm-internal 4
 # ---------------------------------------------------------------------------
 
 # Tools workers cannot use. ``"StructuredOutput"`` is the literal
@@ -101,19 +105,81 @@ INTERNAL_WORKER_TOOLS: Final[frozenset[str]] = frozenset({
     "StructuredOutput",
 })
 
-# The coordinator gets EXACTLY these three tools. The chapter calls
-# this out as core: "the coordinator's power comes not from having
-# more tools, but from having fewer." No Read, no Edit, no Bash.
+# The coordinator's allowed tool set. Mirrors TS
+# ``COORDINATOR_MODE_ALLOWED_TOOLS`` (``constants/tools.ts:105-110``):
+# Agent + TaskStop + SendMessage + SyntheticOutput — whose model-facing
+# name is the literal ``"StructuredOutput"`` (``SyntheticOutputTool.ts:20``),
+# needed so structured-output-constrained headless runs still work in
+# coordinator mode. The chapter's "exactly three tools" phrasing predates
+# the TS snapshot's fourth entry. No Read, no Edit, no Bash — "the
+# coordinator's power comes not from having more tools, but from having
+# fewer."
 _COORDINATOR_ALLOWED_TOOLS: Final[frozenset[str]] = frozenset({
     "Agent",
     "SendMessage",
     "TaskStop",
+    "StructuredOutput",
 })
+
+# MCP tool-name suffixes for GitHub PR-activity subscription. These are
+# lightweight orchestration actions the coordinator calls directly rather
+# than delegating to workers; matched by suffix since the MCP server-name
+# prefix may vary. Mirrors ``utils/toolPool.ts:11-18``.
+PR_ACTIVITY_TOOL_SUFFIXES: Final[tuple[str, ...]] = (
+    "subscribe_pr_activity",
+    "unsubscribe_pr_activity",
+)
+
+
+def is_pr_activity_subscription_tool(name: str) -> bool:
+    """True for MCP PR-activity subscription tools (suffix match).
+
+    Mirrors ``isPrActivitySubscriptionTool`` (``utils/toolPool.ts:16-18``).
+    """
+    return any(name.endswith(suffix) for suffix in PR_ACTIVITY_TOOL_SUFFIXES)
 
 
 def filter_coordinator_tools(all_tools: Iterable["Tool"]) -> list["Tool"]:
-    """Return only the three tools the coordinator may use."""
-    return [t for t in all_tools if t.name in _COORDINATOR_ALLOWED_TOOLS]
+    """Filter a tool pool to the set allowed in coordinator mode.
+
+    Mirrors ``applyCoordinatorToolFilter`` (``utils/toolPool.ts:35-41``):
+    the four allowed tools plus PR-activity subscription MCP tools, which
+    are always allowed since subscription management is orchestration.
+    """
+    return [
+        t for t in all_tools
+        if t.name in _COORDINATOR_ALLOWED_TOOLS
+        or is_pr_activity_subscription_tool(t.name)
+    ]
+
+
+def coordinator_main_loop_registry(registry: "ToolRegistry") -> "ToolRegistry":
+    """Main-loop view of ``registry`` under the coordinator gate.
+
+    Identity when not in coordinator mode. In coordinator mode, returns a
+    NEW registry holding only the coordinator-allowed tools (+ PR-activity
+    MCP tools) — the port of applying ``applyCoordinatorToolFilter`` on the
+    main-loop tool assembly (``toolPool.ts:35-41`` interactive,
+    ``main.tsx:1871-1879`` headless).
+
+    Non-mutating by design: ``make_agent_tool`` captures the FULL registry
+    (``tool_system/defaults.py:18-24``) and subagent spawns list tools from
+    that captured object (``tool_system/tools/agent.py``), so workers keep
+    their full pool — the same separation TS documents at
+    ``AgentTool.tsx:568-575`` ("Workers always get their tools from
+    assembleToolPool … so they aren't affected by the parent's tool
+    restrictions"). Tool objects are shared between the two registries.
+
+    Call this FRESH at each main-loop consumption point (it is cheap):
+    building from ``list_tools()`` bakes in the disabled-MCP-server
+    exclusion at compute time, and a fresh view also picks up late MCP
+    registration and live MCP tool refresh.
+    """
+    if not is_coordinator_mode():
+        return registry
+    from src.tool_system.registry import ToolRegistry
+
+    return ToolRegistry(filter_coordinator_tools(registry.list_tools()))
 
 
 def filter_worker_tools(all_tools: Iterable["Tool"]) -> list["Tool"]:
@@ -122,6 +188,14 @@ def filter_worker_tools(all_tools: Iterable["Tool"]) -> list["Tool"]:
     Workers receive standard tools (Read / Edit / Bash / etc.) plus
     any MCP tools the parent has registered; only the swarm-internal
     coordination tools are excluded.
+
+    NB (chapter-derived, deliberately UNWIRED): TS has no runtime filter
+    at this seam — ``INTERNAL_WORKER_TOOLS`` shapes only the *rendered
+    string* in the coordinator's user context, while actual worker tool
+    filtering is the async-agent whitelist
+    (``src/agent/agent_tool_utils.py:filter_tools_for_agent``, mirror of
+    ``agentToolUtils.ts``). Do not wire this as a runtime filter; that
+    would diverge from TS.
     """
     return [t for t in all_tools if t.name not in INTERNAL_WORKER_TOOLS]
 
@@ -190,7 +264,11 @@ def get_coordinator_user_context(
 
     worker_tools = _build_worker_tools_string()
 
-    parts = [f"Workers spawned via Agent have access to these tools: {worker_tools}"]
+    # Byte-parity with ``coordinatorMode.ts:97`` (``via the ${AGENT_TOOL_NAME}
+    # tool``) — the model-facing tool reference must name the tool exactly.
+    parts = [
+        f"Workers spawned via the Agent tool have access to these tools: {worker_tools}"
+    ]
 
     mcp_server_names = sorted(
         {getattr(c, "name", "") for c in (mcp_clients or [])} - {""}
@@ -216,6 +294,9 @@ __all__ = [
     "is_coordinator_mode",
     "match_session_mode",
     "INTERNAL_WORKER_TOOLS",
+    "PR_ACTIVITY_TOOL_SUFFIXES",
+    "is_pr_activity_subscription_tool",
+    "coordinator_main_loop_registry",
     "filter_coordinator_tools",
     "filter_worker_tools",
     "get_coordinator_user_context",

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -284,7 +284,15 @@ def run_headless(options: HeadlessOptions) -> int:
     writer: StreamJsonWriter | None = None
     if options.output_format == "stream-json":
         writer = StreamJsonWriter(stdout)
-        tools = [tool.name for tool in tool_registry.list_tools()]
+        # Coordinator-filtered view (identity when the mode is off) — the
+        # init event must list what the main loop actually gets. Mirrors the
+        # headless filter application at main.tsx:1871-1879.
+        from src.coordinator.mode import coordinator_main_loop_registry
+
+        tools = [
+            tool.name
+            for tool in coordinator_main_loop_registry(tool_registry).list_tools()
+        ]
         writer.write(
             SystemEvent(
                 subtype="init",
@@ -389,10 +397,17 @@ def run_headless(options: HeadlessOptions) -> int:
                                 )
                                 raise
 
+                        # Coordinator mode: main loop on the filtered view;
+                        # subagents keep the Agent tool's captured full
+                        # registry (see coordinator_main_loop_registry).
+                        from src.coordinator.mode import (
+                            coordinator_main_loop_registry,
+                        )
+
                         compat_result = _asyncio.run(run_query_as_agent_loop(
                             initial_messages=list(session.conversation.messages),
                             provider=provider,
-                            tool_registry=tool_registry,
+                            tool_registry=coordinator_main_loop_registry(tool_registry),
                             tool_context=tool_context,
                             system_prompt=effective_system_prompt,
                             max_turns=options.max_turns,

--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -217,31 +217,74 @@ def build_effective_system_prompt(
     tool-docs section here would double-send them. ``provider``/``mcp_servers``
     feed only the global cache-scope gate; ``None`` is safe (disables the
     cross-user global scope, which TUI/headless should not use).
+
+    Coordinator mode (``CLAUDE_CODE_COORDINATOR_MODE`` truthy): the
+    coordinator orchestration prompt REPLACES the base blocks entirely,
+    ``style_prompt`` still appends, and the trailing context block is kept
+    and extended with the ``workerToolsContext`` entry — mirrors
+    ``utils/systemPrompt.ts:63-75`` + ``QueryEngine.ts:300-306``. This
+    builder only ever serves the MAIN loop (subagents build their prompts
+    via ``get_agent_system_prompt``), so the branch cannot leak into worker
+    prompts — the structural equivalent of TS's
+    ``!mainThreadAgentDefinition`` guard.
     """
     # Local imports — context_system is a heavier dep; only the cutover
     # callers need it, no need to drag it into agent_loop_compat's import time.
     from ..context_system import build_context_prompt
     from ..context_system.prompt_assembly import build_full_system_prompt_blocks
     from ..context_system.system_prompt_cache import CacheScope
+    from ..coordinator.mode import is_coordinator_mode
 
     cwd = str(tool_context.cwd or tool_context.workspace_root)
 
-    # Skills listing (best-effort; mirrors engine.py:183).
-    try:
-        from ..command_system import get_skill_tool_commands
-        skills = get_skill_tool_commands(cwd)
-    except Exception:
-        skills = None
+    coordinator = is_coordinator_mode()
+    if coordinator:
+        # Coordinator mode: the orchestration prompt REPLACES the entire base
+        # block set — no # Doing tasks, no tool guidance, no tone (mirrors
+        # ``utils/systemPrompt.ts:63-75``, where the coordinator prompt swaps
+        # in for defaultSystemPrompt while appendSystemPrompt is preserved).
+        # ``style_prompt`` is this builder's append-channel, so it survives;
+        # the trailing workspace/git/CLAUDE.md context block below is also
+        # kept — TS coordinator sessions keep userContext/systemContext
+        # (``QueryEngine.ts:300-306`` replaces only the default prompt).
+        from ..coordinator import get_coordinator_system_prompt
+        from ..state.cache_state import should_1h_cache_ttl
 
-    blocks = build_full_system_prompt_blocks(
-        cwd=cwd,
-        output_style="default",          # style is appended below (mirror engine.py:169)
-        append_system_prompt=style_prompt,
-        query_source=query_source,
-        provider=provider,
-        mcp_servers=mcp_servers,
-        skills=skills,
-    )
+        blocks: list[dict[str, Any]] = [{
+            "type": "text",
+            "text": get_coordinator_system_prompt(),
+            "_cache_scope": CacheScope.SESSION.value,
+        }]
+        if style_prompt:
+            blocks.append({
+                "type": "text",
+                "text": style_prompt,
+                "_cache_scope": CacheScope.SESSION.value,
+            })
+        # One cache marker on the LAST stable block — the same convention
+        # build_full_system_prompt_blocks applies to each scope-group's
+        # final block (prompt_assembly.py:699-761), reusing its TTL selector.
+        blocks[-1]["cache_control"] = {
+            "type": "ephemeral",
+            "ttl": "1h" if should_1h_cache_ttl(query_source) else "5m",
+        }
+    else:
+        # Skills listing (best-effort; mirrors engine.py:183).
+        try:
+            from ..command_system import get_skill_tool_commands
+            skills = get_skill_tool_commands(cwd)
+        except Exception:
+            skills = None
+
+        blocks = build_full_system_prompt_blocks(
+            cwd=cwd,
+            output_style="default",          # style is appended below (mirror engine.py:169)
+            append_system_prompt=style_prompt,
+            query_source=query_source,
+            provider=provider,
+            mcp_servers=mcp_servers,
+            skills=skills,
+        )
 
     # Preserve the existing workspace + git + CLAUDE.md context verbatim as a
     # trailing uncached block (CLAUDE.md is NOT in the base blocks above).
@@ -264,6 +307,35 @@ def build_effective_system_prompt(
         )
     except Exception:
         context_prompt = ""
+
+    if coordinator:
+        # workerToolsContext — TS merges this into the per-session userContext
+        # (``QueryEngine.ts:300-306``); this port's userContext channel on the
+        # live path is the trailing context block (same route CLAUDE.md / git
+        # status already take), rendered with the ``# {key}\n{value}`` entry
+        # idiom of prepend_user_context (prompt_assembly.py:255-256). MCP
+        # server names come from the ToolContext's connected-client catalog
+        # (agent_server.py publishes ``tool_context.mcp_clients``); the
+        # scratchpad line is surfaced whenever the dir resolves — TS gates it
+        # on Statsig ``tengu_scratch``, which this port does not have (the
+        # module-documented divergence).
+        from ..coordinator.mode import get_coordinator_user_context
+
+        try:
+            from ..permissions.filesystem import get_scratchpad_dir
+            scratchpad_dir: str | None = get_scratchpad_dir()
+        except Exception:
+            scratchpad_dir = None
+        worker_ctx = get_coordinator_user_context(
+            getattr(tool_context, "mcp_clients", None),
+            scratchpad_dir=scratchpad_dir,
+        ).get("workerToolsContext", "")
+        if worker_ctx:
+            entry = f"# workerToolsContext\n{worker_ctx}"
+            context_prompt = (
+                f"{context_prompt}\n\n{entry}" if context_prompt.strip() else entry
+            )
+
     if context_prompt.strip():
         blocks = blocks + [{
             "type": "text",

--- a/src/reference_data/ts_agent_constants.json
+++ b/src/reference_data/ts_agent_constants.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Agent system constants from TS tools/AgentTool/constants.ts",
+  "_comment": "Agent system constants from TS tools/AgentTool/constants.ts; async_agent_allowed_tools mirrors constants/tools.ts:53-69 (NotebookEdit + ToolSearch added in the coordinator/ parity phase; PowerShell deliberately absent \u2014 no Python tool).",
   "agent_tool_name": "Agent",
   "legacy_agent_tool_name": "Task",
   "all_agent_disallowed_tools": [
@@ -25,17 +25,31 @@
     "Skill",
     "StructuredOutput",
     "EnterWorktree",
-    "ExitWorktree"
+    "ExitWorktree",
+    "NotebookEdit",
+    "ToolSearch"
   ],
   "one_shot_builtin_agent_types": [
     "Explore",
     "Plan"
   ],
   "built_in_agents": [
-    {"type": "GeneralPurpose", "name": "General Purpose Agent"},
-    {"type": "Explore", "name": "Explore Agent"},
-    {"type": "Plan", "name": "Plan Agent"},
-    {"type": "fork", "name": "Fork Agent"}
+    {
+      "type": "GeneralPurpose",
+      "name": "General Purpose Agent"
+    },
+    {
+      "type": "Explore",
+      "name": "Explore Agent"
+    },
+    {
+      "type": "Plan",
+      "name": "Plan Agent"
+    },
+    {
+      "type": "fork",
+      "name": "Fork Agent"
+    }
   ],
   "permission_mode_inheritance": {
     "bypassPermissions": "parent_takes_precedence",

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -190,8 +190,16 @@ class _AgentSession:
     # ─── init ──────────────────────────────────────────────────────────────
 
     def emit_init(self) -> None:
-        """Emit ``system/init`` — the first message the client sees on connect."""
-        tools = _tool_schemas(self.tool_registry)
+        """Emit ``system/init`` — the first message the client sees on connect.
+
+        Re-emitted after a resume-driven coordinator-mode flip (_do_resume) so
+        the client's cached tool list tracks the mode."""
+        # Coordinator mode narrows the MAIN loop's advertised tools to the
+        # orchestration set; workers keep the full captured registry. Fresh
+        # per call — see coordinator_main_loop_registry.
+        from src.coordinator.mode import coordinator_main_loop_registry
+
+        tools = _tool_schemas(coordinator_main_loop_registry(self.tool_registry))
         self._emit({
             "type": "system",
             "subtype": "init",
@@ -625,6 +633,17 @@ class _AgentSession:
                 return
             d = _sessions_dir()
             d.mkdir(parents=True, exist_ok=True)
+            # Scoped so a (theoretical) import failure costs only the mode
+            # stamp, never the whole best-effort save.
+            mode_value = "normal"
+            try:
+                from src.coordinator.mode import is_coordinator_mode
+
+                if is_coordinator_mode():
+                    mode_value = "coordinator"
+            except Exception:  # noqa: BLE001
+                pass
+
             payload = {
                 "session_id": self.session_id,
                 "model": getattr(self.provider, "model", None) or self.config.model or "",
@@ -639,6 +658,11 @@ class _AgentSession:
                 "message_count": len(msgs),
                 "preview": _first_prompt_preview(msgs),
                 "name": self._session_name,
+                # Coordinator-mode stamp so _do_resume can re-enter/exit the
+                # mode (TS saveMode, sessionStorage.ts:3126). Stamped at every
+                # turn-end save — subsumes TS's materialize/exit//clear
+                # re-stamp sites.
+                "mode": mode_value,
                 "conversation": self.session.conversation.to_dict(),
             }
             # ch03 round-4 GAP B — the live persister carries the cost
@@ -1292,10 +1316,66 @@ class _AgentSession:
                 except Exception:  # noqa: BLE001
                     pass
                 _dispatch_app_state(self, main_loop_model=saved_model)
+            # Coordinator-mode sync (TS matchSessionMode at every resume
+            # surface — sessionRestore.ts:429, print.ts:4909/5114). Absent
+            # field (old session files) or junk value → None → no-op.
+            #
+            # single_session-gated like cost-restore above and for the same
+            # reason: match_session_mode flips the process-global env var
+            # (coordinator mode is inherently process-scoped — TS runs one
+            # process per session via bridge/sessionRunner, so the env-var
+            # design never meets a multi-session process there). On a
+            # multi-session --http server, one session's resume must not
+            # flip the mode — and thereby the prompt + tool set — of every
+            # sibling session. Fail-safe: --http never enters/exits
+            # coordinator mode via resume; the launch env decides for the
+            # whole process.
+            saved_mode = data.get("mode")
+            mode_banner = None
+            if self.config.single_session:
+                try:
+                    from src.coordinator.mode import match_session_mode
+
+                    mode_banner = match_session_mode(
+                        saved_mode if saved_mode in ("coordinator", "normal") else None
+                    )
+                except Exception:  # noqa: BLE001 — mode sync must not break resume
+                    logger.debug("[agent-server] session-mode sync failed", exc_info=True)
+            if mode_banner:
+                # The flip changes the system prompt and the advertised tool
+                # set. The prompt is CACHED (_base_system_prompt, built at
+                # startup and by set_output_style) — rebuild it with the same
+                # idiom; the tool list was sent once in system/init — re-emit
+                # so the client's cached list tracks the mode (the client's
+                # init handler re-sets session info idempotently).
+                try:
+                    from src.outputStyles import resolve_output_style
+                    from src.query.agent_loop_compat import build_effective_system_prompt
+
+                    tc = self.tool_context
+                    if tc is not None:
+                        style_prompt = resolve_output_style(
+                            getattr(tc, "output_style_name", None),
+                            getattr(tc, "output_style_dir", None),
+                        ).prompt
+                        self._base_system_prompt = build_effective_system_prompt(
+                            style_prompt, tc, provider=self.provider
+                        )
+                        self.system_prompt = self._compose_with_plan(self._base_system_prompt)
+                except Exception:  # noqa: BLE001 - keep the resume even if rebuild fails
+                    logger.debug(
+                        "[agent-server] system prompt rebuild after mode flip failed",
+                        exc_info=True,
+                    )
+                try:
+                    self.emit_init()
+                except Exception:  # noqa: BLE001
+                    logger.debug("[agent-server] init re-emit after mode flip failed", exc_info=True)
             self._reply(request_id, {
                 "ok": True,
                 "count": len(conv.messages),
                 "preview": data.get("preview", ""),
+                **({"mode_banner": mode_banner} if mode_banner else {}),
             })
         except Exception as exc:  # noqa: BLE001
             logger.exception("[agent-server] resume failed")
@@ -1369,11 +1449,15 @@ class _AgentSession:
             messages = (
                 self.session.conversation.get_messages() if self.session is not None else []
             )
+            from src.coordinator.mode import coordinator_main_loop_registry
+
             data = analyze_context(
                 conversation_api_messages=messages,
                 model=model,
                 system_prompt=self._system_prompt_text(),
-                tool_schemas=_tool_schemas(self.tool_registry),
+                # Coordinator-filtered view: token accounting must reflect
+                # the tool schemas actually sent on the wire.
+                tool_schemas=_tool_schemas(coordinator_main_loop_registry(self.tool_registry)),
                 claude_md_content="",
             )
             out.update({
@@ -1843,10 +1927,15 @@ class _AgentSession:
         # provider/model and read-file fingerprints.
         pipeline_config = self._build_turn_pipeline_config(turn_provider)
         try:
+            # Coordinator mode: the MAIN loop runs on the filtered view
+            # (Agent/SendMessage/TaskStop/StructuredOutput + PR-activity MCP);
+            # subagents spawn from the Agent tool's captured FULL registry.
+            from src.coordinator.mode import coordinator_main_loop_registry
+
             result = asyncio.run(run_query_as_agent_loop(
                 initial_messages=list(self.session.conversation.messages),
                 provider=turn_provider,
-                tool_registry=self.tool_registry,
+                tool_registry=coordinator_main_loop_registry(self.tool_registry),
                 tool_context=self.tool_context,
                 system_prompt=self.system_prompt,
                 max_turns=self.config.max_turns,

--- a/src/tool_system/tools/agent.py
+++ b/src/tool_system/tools/agent.py
@@ -191,7 +191,14 @@ def make_agent_tool(
 
         description = tool_input.get("description", prompt[:50])
         subagent_type = tool_input.get("subagent_type")
-        model = tool_input.get("model")
+        # Coordinator mode ignores the model param — the coordinator prompt
+        # says "Do not set the model parameter. Workers need the default
+        # model"; this enforces it. Mirrors AgentTool.tsx:252. Function-local
+        # import: src.coordinator's package init imports worker_agent →
+        # agent_definitions (cycle at import time, safe at call time).
+        from src.coordinator.mode import is_coordinator_mode
+
+        model = None if is_coordinator_mode() else tool_input.get("model")
         run_in_background = bool(tool_input.get("run_in_background", False))
         # Chapter-10 / WI-6.1 — optional human-readable name. We
         # validate / register it AFTER agent_id is generated so the
@@ -255,7 +262,12 @@ def make_agent_tool(
         from src.tasks_core import generate_task_id  # local import — see _launch_async_agent
         agent_id = generate_task_id("local_agent")
         start_time = time.time()
-        is_async = run_in_background
+        # Coordinator spawns are ALWAYS async so results arrive as
+        # <task-notification> user messages — the interaction model the
+        # coordinator system prompt teaches. Mirrors AgentTool.tsx:562's
+        # ``|| isCoordinator`` term (the selectedAgent.background / fork /
+        # kairos terms there belong to their own unported features).
+        is_async = run_in_background or is_coordinator_mode()
 
         if provider is None:
             return ToolResult(
@@ -779,7 +791,11 @@ def make_agent_tool(
                 )
                 available = []
             agents = filter_agents_by_mcp_requirements(agents, available)
-        return get_agent_prompt(agents)
+        # Env read live at prompt-build time, mirroring AgentTool.tsx:223-224's
+        # inline check (function-local import — see _agent_call).
+        from src.coordinator.mode import is_coordinator_mode
+
+        return get_agent_prompt(agents, is_coordinator=is_coordinator_mode())
 
     def _map_result_to_api(result: Any, tool_use_id: str) -> dict[str, Any]:
         if not isinstance(result, dict):

--- a/tests/coordinator/__snapshots__/user_context_default.snap.txt
+++ b/tests/coordinator/__snapshots__/user_context_default.snap.txt
@@ -1,1 +1,1 @@
-Workers spawned via Agent have access to these tools: Bash, Edit, EnterWorktree, ExitWorktree, Glob, Grep, Read, Skill, TodoWrite, WebFetch, WebSearch, Write
+Workers spawned via the Agent tool have access to these tools: Bash, Edit, EnterWorktree, ExitWorktree, Glob, Grep, NotebookEdit, Read, Skill, TodoWrite, ToolSearch, WebFetch, WebSearch, Write

--- a/tests/coordinator/__snapshots__/user_context_simple.snap.txt
+++ b/tests/coordinator/__snapshots__/user_context_simple.snap.txt
@@ -1,1 +1,1 @@
-Workers spawned via Agent have access to these tools: Bash, Edit, Read
+Workers spawned via the Agent tool have access to these tools: Bash, Edit, Read

--- a/tests/coordinator/test_mode.py
+++ b/tests/coordinator/test_mode.py
@@ -131,18 +131,41 @@ class _StubTool:
         self.name = name
 
 
-def test_filter_coordinator_tools_returns_exactly_three() -> None:
-    """The chapter calls this out as core: the coordinator gets
-    EXACTLY {Agent, SendMessage, TaskStop} — no Read, no Edit, no
-    Bash."""
+def test_filter_coordinator_tools_returns_exactly_the_allowed_set() -> None:
+    """The coordinator gets EXACTLY the TS ``COORDINATOR_MODE_ALLOWED_TOOLS``
+    set (``constants/tools.ts:105-110``): {Agent, SendMessage, TaskStop,
+    StructuredOutput} — StructuredOutput is ``SYNTHETIC_OUTPUT_TOOL_NAME``'s
+    model-facing literal. No Read, no Edit, no Bash."""
     tools = [
         _StubTool("Agent"), _StubTool("SendMessage"), _StubTool("TaskStop"),
+        _StubTool("StructuredOutput"),
         _StubTool("Read"), _StubTool("Edit"), _StubTool("Bash"),
         _StubTool("WebSearch"), _StubTool("Grep"),
     ]
     coord = filter_coordinator_tools(tools)
-    assert {t.name for t in coord} == {"Agent", "SendMessage", "TaskStop"}
-    assert len(coord) == 3
+    assert {t.name for t in coord} == {
+        "Agent", "SendMessage", "TaskStop", "StructuredOutput",
+    }
+    assert len(coord) == 4
+
+
+def test_filter_coordinator_tools_exempts_pr_activity_mcp_tools() -> None:
+    """PR-activity subscription MCP tools are always allowed — subscription
+    management is orchestration (``utils/toolPool.ts:11-18, 35-41``); every
+    other MCP tool is dropped from the coordinator's own set."""
+    tools = [
+        _StubTool("Agent"),
+        _StubTool("mcp__github__subscribe_pr_activity"),
+        _StubTool("mcp__github__unsubscribe_pr_activity"),
+        _StubTool("mcp__github__create_pr"),
+        _StubTool("mcp__sentry__search_issues"),
+    ]
+    coord = filter_coordinator_tools(tools)
+    assert {t.name for t in coord} == {
+        "Agent",
+        "mcp__github__subscribe_pr_activity",
+        "mcp__github__unsubscribe_pr_activity",
+    }
 
 
 def test_filter_worker_tools_excludes_internal_set() -> None:
@@ -193,7 +216,7 @@ def test_user_context_returns_worker_tools_block(
     monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
     ctx = get_coordinator_user_context()
     assert "workerToolsContext" in ctx
-    assert "Workers spawned via Agent" in ctx["workerToolsContext"]
+    assert "Workers spawned via the Agent tool" in ctx["workerToolsContext"]
 
 
 def test_user_context_includes_mcp_servers(

--- a/tests/coordinator/test_wiring.py
+++ b/tests/coordinator/test_wiring.py
@@ -1,0 +1,744 @@
+"""COORD-1 — coordinator-mode live-path wiring tests.
+
+The `coordinator/` parity phase (my-docs/get-parity-by-folder/
+coordinator-refactoring-plan.md) wired the already-ported
+``src/coordinator/`` module into the live paths. This file covers the
+wiring seams; the module-level behavior (gates, filters, user-context
+shape) stays in ``test_mode.py`` / ``test_prompt.py``.
+
+* W3/W4 — ``build_effective_system_prompt`` coordinator branch: the
+  orchestration prompt REPLACES the base blocks (``utils/systemPrompt.ts:
+  63-75``), style still appends, the trailing context block survives and
+  carries ``# workerToolsContext`` (``QueryEngine.ts:300-306``).
+* W2 — ``get_built_in_agents()`` swaps to the coordinator agent list
+  (``builtInAgents.ts:35-43``) so ``subagent_type: "worker"`` resolves.
+* W5 — ``coordinator_main_loop_registry``: non-mutating main-loop view
+  (``toolPool.ts:35-41`` / ``main.tsx:1871-1879``); the full registry the
+  Agent tool captured is untouched (worker-pool invariant,
+  ``AgentTool.tsx:568-575``).
+* W6 — Agent tool: model param ignored (``AgentTool.tsx:252``), spawns
+  forced async (``AgentTool.tsx:562``), slim tool prompt
+  (``prompt.ts:206-211``).
+* W7 — agent-server ``_save_session`` stamps ``mode``; ``_do_resume``
+  syncs via ``match_session_mode``, rebuilds the cached system prompt,
+  re-emits ``system/init``, and returns the banner.
+
+Env hygiene: ``is_coordinator_mode`` reads the env var live, and
+``match_session_mode`` writes ``os.environ`` directly (outside
+monkeypatch's tracking), so an autouse save/restore fixture guards both
+vars — same pattern as ``test_mode.py``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.coordinator.mode import coordinator_main_loop_registry
+
+
+@pytest.fixture(autouse=True)
+def _coordinator_env_hygiene():
+    saved = {}
+    for var in ("CLAUDE_CODE_COORDINATOR_MODE", "CLAUDE_CODE_SIMPLE"):
+        saved[var] = os.environ.pop(var, None)
+    try:
+        yield
+    finally:
+        for var, prev in saved.items():
+            os.environ.pop(var, None)
+            if prev is not None:
+                os.environ[var] = prev
+
+
+class _Client:
+    """MCP-client stub — the builder only reads ``.name``."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+def _tool_context(tmp_path: Path, mcp_clients: list | None = None):
+    """Duck-typed ToolContext: the builder reads cwd / workspace_root /
+    (getattr) mcp_clients only."""
+    return types.SimpleNamespace(
+        cwd=str(tmp_path),
+        workspace_root=str(tmp_path),
+        mcp_clients=mcp_clients,
+    )
+
+
+# ---------------------------------------------------------------------------
+# W3/W4 — build_effective_system_prompt coordinator branch
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_branch_replaces_base_blocks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    from src.query.agent_loop_compat import build_effective_system_prompt
+
+    blocks = build_effective_system_prompt("", _tool_context(tmp_path))
+    all_text = "\n".join(b["text"] for b in blocks)
+
+    assert "You are a **coordinator**" in blocks[0]["text"]
+    # The entire base prompt is REPLACED — none of its section headers leak.
+    for marker in ("# Doing tasks", "# Executing actions", "# Tone"):
+        assert marker not in all_text
+    # Exactly ONE cache marker, on the last stable block (the coordinator
+    # block here — style is empty), mirroring the scope-group convention.
+    marked = [i for i, b in enumerate(blocks) if "cache_control" in b]
+    assert marked == [0]
+    assert blocks[0]["cache_control"]["type"] == "ephemeral"
+    # Trailing context block survives, REQUEST-scoped (DeepSeek splitter).
+    assert blocks[-1]["_cache_scope"] == "request"
+
+
+def test_prompt_branch_style_appends_and_carries_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """TS preserves appendSystemPrompt next to the coordinator prompt
+    (``systemPrompt.ts:72-74``); style_prompt is this builder's
+    append-channel. The single cache marker rides the LAST stable block."""
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    from src.query.agent_loop_compat import build_effective_system_prompt
+
+    blocks = build_effective_system_prompt(
+        "STYLE-SENTINEL", _tool_context(tmp_path)
+    )
+    assert blocks[1]["text"] == "STYLE-SENTINEL"
+    marked = [i for i, b in enumerate(blocks) if "cache_control" in b]
+    assert marked == [1]
+
+
+def test_prompt_branch_worker_tools_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    from src.query.agent_loop_compat import build_effective_system_prompt
+
+    blocks = build_effective_system_prompt(
+        "", _tool_context(tmp_path, [_Client("github"), _Client("sentry")])
+    )
+    tail = blocks[-1]["text"]
+    # Rendered with the prepend_user_context entry idiom (# key\nvalue).
+    assert "# workerToolsContext" in tail
+    assert "Workers spawned via the Agent tool have access to these tools:" in tail
+    # MCP server-name line present iff clients were supplied.
+    assert "MCP servers: github, sentry" in tail
+    # Scratchpad line surfaces whenever the dir resolves (no Statsig port).
+    assert "Scratchpad directory:" in tail
+
+
+def test_prompt_branch_no_mcp_line_without_clients(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    from src.query.agent_loop_compat import build_effective_system_prompt
+
+    blocks = build_effective_system_prompt("", _tool_context(tmp_path, None))
+    assert "MCP servers:" not in blocks[-1]["text"]
+
+
+def test_prompt_branch_off_is_the_normal_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Env off → the branch is inert: normal base sections, no coordinator
+    artifacts."""
+    monkeypatch.delenv("CLAUDE_CODE_COORDINATOR_MODE", raising=False)
+    from src.query.agent_loop_compat import build_effective_system_prompt
+
+    tc = _tool_context(tmp_path)
+    blocks = build_effective_system_prompt("", tc)
+    all_text = "\n".join(b["text"] for b in blocks)
+    assert "You are a **coordinator**" not in all_text
+    assert "workerToolsContext" not in all_text
+    assert "# Doing tasks" in all_text
+
+
+def test_prompt_branch_off_matches_reference_composition(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Env off → the builder is deep-equal to the pre-change composition
+    (base blocks + trailing REQUEST-scope context block), pinning the
+    now-shared trailing-block code against regressions. The env section
+    embeds hh:mm:ss (the known second-boundary flake), so timestamps are
+    normalized before comparing."""
+    import re
+
+    monkeypatch.delenv("CLAUDE_CODE_COORDINATOR_MODE", raising=False)
+    from src.command_system import get_skill_tool_commands
+    from src.context_system import build_context_prompt
+    from src.context_system.prompt_assembly import build_full_system_prompt_blocks
+    from src.context_system.system_prompt_cache import CacheScope
+    from src.query.agent_loop_compat import build_effective_system_prompt
+
+    tc = _tool_context(tmp_path)
+    cwd = str(tmp_path)
+    try:
+        skills = get_skill_tool_commands(cwd)
+    except Exception:
+        skills = None
+    expected = build_full_system_prompt_blocks(
+        cwd=cwd,
+        output_style="default",
+        append_system_prompt="STYLE-REF",
+        query_source="main",
+        provider=None,
+        mcp_servers=None,
+        skills=skills,
+    )
+    ctx = build_context_prompt(tc.workspace_root, cwd=tc.cwd)
+    if ctx.strip():
+        expected = expected + [{
+            "type": "text",
+            "text": ctx,
+            "_cache_scope": CacheScope.REQUEST.value,
+        }]
+
+    actual = build_effective_system_prompt("STYLE-REF", tc)
+
+    def _norm(blocks: list) -> list:
+        return [
+            {**b, "text": re.sub(r"\d{2}:\d{2}:\d{2}", "HH:MM:SS", b["text"])}
+            for b in blocks
+        ]
+
+    assert _norm(actual) == _norm(expected)
+
+
+# ---------------------------------------------------------------------------
+# W2 — builtin-agents swap
+# ---------------------------------------------------------------------------
+
+
+def test_builtin_agents_swap_in_coordinator_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.agent.agent_definitions import get_built_in_agents
+
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    types_on = [a.agent_type for a in get_built_in_agents()]
+    assert types_on == ["worker", "general-purpose", "Explore", "Plan"]
+
+    monkeypatch.delenv("CLAUDE_CODE_COORDINATOR_MODE")
+    types_off = [a.agent_type for a in get_built_in_agents()]
+    assert "worker" not in types_off
+    assert types_off[0] == "general-purpose"
+
+
+def test_worker_resolves_through_overrides_chain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The spawn path resolves defs via get_agent_definitions_with_overrides
+    (agent.py) — the swap must be visible through that layering."""
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    from src.agent.agent_definitions import find_agent_by_type
+    from src.agent.load_agents_dir import get_agent_definitions_with_overrides
+
+    agents = get_agent_definitions_with_overrides(str(tmp_path))
+    worker = find_agent_by_type(agents, "worker")
+    assert worker is not None
+    assert worker.agent_type == "worker"
+
+
+# ---------------------------------------------------------------------------
+# W5 — non-mutating main-loop registry view
+# ---------------------------------------------------------------------------
+
+
+class _StubTool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.aliases: list[str] = []
+
+
+def _registry_with(*names: str):
+    from src.tool_system.registry import ToolRegistry
+
+    reg = ToolRegistry()
+    for n in names:
+        reg.register(_StubTool(n))
+    return reg
+
+
+def test_view_is_identity_when_mode_off() -> None:
+    reg = _registry_with("Agent", "Read")
+    assert coordinator_main_loop_registry(reg) is reg
+
+
+def test_view_filters_without_mutating_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    reg = _registry_with(
+        "Agent", "SendMessage", "TaskStop", "StructuredOutput",
+        "Read", "Edit", "Bash",
+        "mcp__gh__subscribe_pr_activity", "mcp__gh__create_pr",
+    )
+    view = coordinator_main_loop_registry(reg)
+    assert sorted(t.name for t in view.list_tools()) == [
+        "Agent", "SendMessage", "StructuredOutput", "TaskStop",
+        "mcp__gh__subscribe_pr_activity",
+    ]
+    # Worker-pool invariant: the source registry (what the Agent tool
+    # captured) still has everything.
+    assert len(reg.list_tools()) == 9
+    assert reg.get("Read") is not None
+    # Shared tool objects, not copies.
+    assert view.get("Agent") is reg.get("Agent")
+
+
+def test_view_bakes_in_disabled_mcp_servers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The view builds from list_tools(), so disabled-MCP-server hiding is
+    inherited by construction."""
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    reg = _registry_with("Agent", "mcp__gh__subscribe_pr_activity")
+    reg.disabled_servers.add("gh")
+    view = coordinator_main_loop_registry(reg)
+    assert [t.name for t in view.list_tools()] == ["Agent"]
+
+
+# ---------------------------------------------------------------------------
+# W6 — Agent tool coordinator behaviors
+# ---------------------------------------------------------------------------
+
+
+def test_agent_tool_prompt_slim_variant(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Coordinator gets the shared header only (``prompt.ts:206-211``) —
+    the coordinator system prompt already carries usage guidance. Exercised
+    through the live tool's prompt() so the _agent_prompt wiring is covered."""
+    from src.tool_system.defaults import build_default_registry
+
+    registry = build_default_registry(provider=object())
+    agent_tool = registry.get("Agent")
+    assert agent_tool is not None
+
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    slim = agent_tool.prompt()
+    assert "Available agent types" in slim
+    for dropped in ("When NOT to use", "Usage notes:", "Example usage:",
+                    "## Writing the prompt"):
+        assert dropped not in slim
+
+    monkeypatch.delenv("CLAUDE_CODE_COORDINATOR_MODE")
+    full = agent_tool.prompt()
+    assert "When NOT to use" in full
+    assert "Usage notes:" in full
+
+
+def test_coordinator_forces_async_spawn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All coordinator spawns run async (``AgentTool.tsx:562``) so results
+    arrive as <task-notification> messages — run_in_background omitted."""
+    from src.tool_system.defaults import build_default_registry
+    from src.tool_system.protocol import ToolCall
+    from src.tool_system.context import ToolContext
+    from src.types.content_blocks import TextBlock
+    from src.types.messages import AssistantMessage
+
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    registry = build_default_registry(provider=object())
+    context = ToolContext(workspace_root=tmp_path)
+
+    async def _fake_run_agent(_params):
+        yield AssistantMessage(content=[TextBlock(text="done")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _fake_run_agent):
+        result = registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={"description": "t", "prompt": "do work"},
+            ),
+            context,
+        )
+    assert result.is_error is False
+    assert result.output.get("status") == "async_launched"
+
+
+def test_coordinator_suppresses_model_param(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The coordinator's model param is discarded (``AgentTool.tsx:252``) —
+    workers need the default model for substantive tasks."""
+    from src.tool_system.defaults import build_default_registry
+    from src.tool_system.protocol import ToolCall
+    from src.tool_system.context import ToolContext
+    from src.types.content_blocks import TextBlock
+    from src.types.messages import AssistantMessage
+
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    registry = build_default_registry(provider=object())
+    context = ToolContext(workspace_root=tmp_path)
+    seen_models: list = []
+
+    async def _capturing_run_agent(params):
+        seen_models.append(getattr(params, "model", "<missing>"))
+        yield AssistantMessage(content=[TextBlock(text="done")])
+
+    import time as _time
+
+    with patch("src.tool_system.tools.agent.run_agent", _capturing_run_agent):
+        result = registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={
+                    "description": "t",
+                    "prompt": "do work",
+                    "model": "haiku",
+                },
+            ),
+            context,
+        )
+        assert result.output.get("status") == "async_launched"
+        # The async worker thread invokes run_agent shortly after launch.
+        deadline = _time.time() + 5.0
+        while not seen_models and _time.time() < deadline:
+            _time.sleep(0.02)
+    assert seen_models, "async worker never invoked run_agent"
+    assert seen_models[0] is None
+
+
+def test_model_param_honored_when_mode_off(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from src.tool_system.defaults import build_default_registry
+    from src.tool_system.protocol import ToolCall
+    from src.tool_system.context import ToolContext
+    from src.types.content_blocks import TextBlock
+    from src.types.messages import AssistantMessage
+
+    monkeypatch.delenv("CLAUDE_CODE_COORDINATOR_MODE", raising=False)
+    registry = build_default_registry(provider=object())
+    context = ToolContext(workspace_root=tmp_path)
+    seen_models: list = []
+
+    async def _capturing_run_agent(params):
+        seen_models.append(getattr(params, "model", "<missing>"))
+        yield AssistantMessage(content=[TextBlock(text="done")])
+
+    with patch("src.tool_system.tools.agent.run_agent", _capturing_run_agent):
+        result = registry.dispatch(
+            ToolCall(
+                name="Agent",
+                input={
+                    "description": "t",
+                    "prompt": "do work",
+                    "model": "haiku",
+                },
+            ),
+            context,
+        )
+    # Sync path (no run_in_background, mode off) → run_agent already ran.
+    assert result.output.get("status") != "async_launched"
+    assert seen_models and seen_models[0] == "haiku"
+
+
+# ---------------------------------------------------------------------------
+# W7 + W5 consumption sites — agent-server harness
+# ---------------------------------------------------------------------------
+
+
+class _ServerHarness(unittest.TestCase):
+    """Real ``_AgentSession`` against the keyless ``ollama`` provider with
+    the global config redirected to a temp dir — the
+    ``tests/test_ch03_state_round4.py`` pattern."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        self.ws = root / "ws"
+        self.ws.mkdir()
+        self.config_dir = root / "config-home"
+        self.config_dir.mkdir()
+        self.global_path = self.config_dir / "config.json"
+        self.global_path.write_text(json.dumps({}), encoding="utf-8")
+        self.sessions_dir = root / "sessions"
+        self.sessions_dir.mkdir()
+        self._patches = [
+            patch("src.config.get_global_config_path", return_value=self.global_path),
+            patch("src.config.GLOBAL_CONFIG_DIR", str(self.config_dir)),
+        ]
+        for p in self._patches:
+            p.start()
+        from src.settings.settings import invalidate_settings_cache
+
+        invalidate_settings_cache()
+
+    def tearDown(self) -> None:
+        for p in self._patches:
+            p.stop()
+        from src.settings.settings import invalidate_settings_cache
+
+        invalidate_settings_cache()
+        self._tmp.cleanup()
+
+    def _build(self, *, single_session: bool = True):
+        from src.server.agent_server import (
+            AgentServerConfig,
+            _AgentSession,
+            _build_runtime,
+        )
+
+        sess = _AgentSession(
+            session_id="s-coord",
+            cwd=str(self.ws),
+            config=AgentServerConfig(
+                provider_name="ollama",
+                model=None,
+                single_session=single_session,
+            ),
+            loop=MagicMock(),
+            out_queue=MagicMock(),
+        )
+        _build_runtime(sess, None)
+        self.assertIsNone(sess.init_error, f"runtime build failed: {sess.init_error}")
+        return sess
+
+    def _emitted(self, sess) -> list[dict]:
+        """Messages pushed by _emit. With a MagicMock loop, _emit's
+        ``loop.call_soon_threadsafe(out_queue.put_nowait, msg)`` never runs
+        the callback — the message is the second positional arg captured on
+        the mock."""
+        calls = []
+        for c in sess.loop.call_soon_threadsafe.call_args_list:
+            if len(c.args) >= 2:
+                calls.append(c.args[1])
+        return [m for m in calls if isinstance(m, dict)]
+
+    def _seed_conversation(self, sess) -> None:
+        from src.agent.conversation import Conversation
+
+        sess.session.conversation = Conversation.from_dict(
+            {"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+
+class TestServerModePersistResume(_ServerHarness):
+    def test_save_session_stamps_normal_mode(self) -> None:
+        sess = self._build()
+        self._seed_conversation(sess)
+        with patch("src.server.agent_server._sessions_dir", return_value=self.sessions_dir):
+            sess._save_session()
+        payload = json.loads((self.sessions_dir / "s-coord.json").read_text(encoding="utf-8"))
+        self.assertEqual(payload.get("mode"), "normal")
+
+    def test_save_session_stamps_coordinator_mode(self) -> None:
+        sess = self._build()
+        self._seed_conversation(sess)
+        os.environ["CLAUDE_CODE_COORDINATOR_MODE"] = "1"
+        with patch("src.server.agent_server._sessions_dir", return_value=self.sessions_dir):
+            sess._save_session()
+        payload = json.loads((self.sessions_dir / "s-coord.json").read_text(encoding="utf-8"))
+        self.assertEqual(payload.get("mode"), "coordinator")
+
+    def _write_session_file(self, mode: object) -> None:
+        payload: dict = {
+            "session_id": "saved-1",
+            "model": "",
+            "provider": "ollama",
+            "cwd": str(self.ws),
+            "message_count": 1,
+            "preview": "hi",
+            "conversation": {"messages": [{"role": "user", "content": "hi"}]},
+        }
+        if mode is not None:
+            payload["mode"] = mode
+        (self.sessions_dir / "saved-1.json").write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+
+    def _resume_reply(self, sess) -> dict:
+        for m in self._emitted(sess):
+            if m.get("type") == "control_response":
+                resp = m.get("response", {})
+                if resp.get("request_id") == "rq-1":
+                    return resp.get("response", {})
+        self.fail("no control_response for rq-1 captured")
+
+    def test_resume_enters_coordinator_and_refreshes(self) -> None:
+        sess = self._build()
+        self._write_session_file("coordinator")
+        self.assertNotIn("CLAUDE_CODE_COORDINATOR_MODE", os.environ)
+        with patch("src.server.agent_server._sessions_dir", return_value=self.sessions_dir):
+            sess._do_resume("rq-1", "saved-1")
+
+        # Env flipped (matchSessionMode) + banner surfaced in the reply.
+        from src.coordinator.mode import is_coordinator_mode
+
+        self.assertTrue(is_coordinator_mode())
+        reply = self._resume_reply(sess)
+        self.assertTrue(reply.get("ok"))
+        self.assertEqual(
+            reply.get("mode_banner"),
+            "Entered coordinator mode to match resumed session.",
+        )
+        # Cached system prompt rebuilt to the coordinator prompt.
+        base = sess._base_system_prompt
+        first_text = base[0]["text"] if isinstance(base, list) else str(base)
+        self.assertIn("You are a **coordinator**", first_text)
+        # system/init re-emitted with the narrowed tool list.
+        inits = [
+            m for m in self._emitted(sess)
+            if m.get("type") == "system" and m.get("subtype") == "init"
+        ]
+        self.assertTrue(inits, "init was not re-emitted after the mode flip")
+        names = {t["name"] for t in inits[-1]["tools"]}
+        self.assertEqual(
+            names, {"Agent", "SendMessage", "TaskStop", "StructuredOutput"}
+        )
+
+    def test_resume_without_mode_field_is_noop(self) -> None:
+        sess = self._build()
+        self._write_session_file(None)
+        with patch("src.server.agent_server._sessions_dir", return_value=self.sessions_dir):
+            sess._do_resume("rq-1", "saved-1")
+        from src.coordinator.mode import is_coordinator_mode
+
+        self.assertFalse(is_coordinator_mode())
+        reply = self._resume_reply(sess)
+        self.assertTrue(reply.get("ok"))
+        self.assertNotIn("mode_banner", reply)
+
+    def test_resume_with_junk_mode_is_noop(self) -> None:
+        sess = self._build()
+        self._write_session_file("bogus-value")
+        with patch("src.server.agent_server._sessions_dir", return_value=self.sessions_dir):
+            sess._do_resume("rq-1", "saved-1")
+        from src.coordinator.mode import is_coordinator_mode
+
+        self.assertFalse(is_coordinator_mode())
+        reply = self._resume_reply(sess)
+        self.assertNotIn("mode_banner", reply)
+
+    def test_resume_never_flips_mode_on_multi_session_server(self) -> None:
+        """The env flip is process-global; on a multi-session (--http)
+        server one session's resume must not flip the mode — and thereby
+        the prompt + tool set — of every sibling session. Same
+        single_session discipline as cost-restore."""
+        sess = self._build(single_session=False)
+        self._write_session_file("coordinator")
+        with patch("src.server.agent_server._sessions_dir", return_value=self.sessions_dir):
+            sess._do_resume("rq-1", "saved-1")
+        from src.coordinator.mode import is_coordinator_mode
+
+        self.assertFalse(is_coordinator_mode())
+        reply = self._resume_reply(sess)
+        self.assertTrue(reply.get("ok"))  # the resume itself still works
+        self.assertNotIn("mode_banner", reply)
+
+    def test_resume_exits_coordinator_for_normal_session(self) -> None:
+        sess = self._build()
+        self._write_session_file("normal")
+        os.environ["CLAUDE_CODE_COORDINATOR_MODE"] = "1"
+        with patch("src.server.agent_server._sessions_dir", return_value=self.sessions_dir):
+            sess._do_resume("rq-1", "saved-1")
+        from src.coordinator.mode import is_coordinator_mode
+
+        self.assertFalse(is_coordinator_mode())
+        reply = self._resume_reply(sess)
+        self.assertEqual(
+            reply.get("mode_banner"),
+            "Exited coordinator mode to match resumed session.",
+        )
+
+
+class TestServerMainLoopToolFilter(_ServerHarness):
+    """W5 consumption-site coverage: the MCP-ordering risk lives at the
+    sites, not the helper — fake MCP tools are registered on the FULL
+    registry (as the runtime does) and must be filtered in the views."""
+
+    def _register_fake_mcp_tools(self, sess) -> None:
+        sess.tool_registry.register(_StubTool("mcp__x__subscribe_pr_activity"))
+        sess.tool_registry.register(_StubTool("mcp__x__other"))
+
+    def test_emit_init_lists_filtered_tools_in_coordinator_mode(self) -> None:
+        sess = self._build()
+        self._register_fake_mcp_tools(sess)
+        os.environ["CLAUDE_CODE_COORDINATOR_MODE"] = "1"
+        sess.emit_init()
+        inits = [
+            m for m in self._emitted(sess)
+            if m.get("type") == "system" and m.get("subtype") == "init"
+        ]
+        names = {t["name"] for t in inits[-1]["tools"]}
+        self.assertEqual(
+            names,
+            {
+                "Agent", "SendMessage", "TaskStop", "StructuredOutput",
+                "mcp__x__subscribe_pr_activity",
+            },
+        )
+        # The full registry (what the Agent tool captured) is untouched.
+        full = {t.name for t in sess.tool_registry.list_tools()}
+        self.assertIn("Read", full)
+        self.assertIn("mcp__x__other", full)
+
+    def test_emit_init_lists_full_tools_when_mode_off(self) -> None:
+        sess = self._build()
+        self._register_fake_mcp_tools(sess)
+        sess.emit_init()
+        inits = [
+            m for m in self._emitted(sess)
+            if m.get("type") == "system" and m.get("subtype") == "init"
+        ]
+        names = {t["name"] for t in inits[-1]["tools"]}
+        self.assertIn("Read", names)
+        self.assertIn("mcp__x__other", names)
+
+
+# ---------------------------------------------------------------------------
+# Headless init-event filtering (the :287 analog of server emit_init)
+# ---------------------------------------------------------------------------
+
+
+def test_coordinator_turn_rejects_filtered_out_tool_use(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The advertised-list narrowing is enforced at execution: the main
+    loop dispatches through the filtered view, so a tool_use of a
+    filtered-out tool errors — while the full registry (the worker-side
+    pool) still dispatches it."""
+    from src.tool_system.context import ToolContext
+    from src.tool_system.defaults import build_default_registry
+    from src.tool_system.protocol import ToolCall
+
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    reg = build_default_registry(provider=object())
+    view = coordinator_main_loop_registry(reg)
+
+    target = tmp_path / "f.txt"
+    target.write_text("hello", encoding="utf-8")
+    call = ToolCall(name="Read", input={"file_path": str(target)})
+
+    rejected = view.dispatch(call, ToolContext(workspace_root=tmp_path))
+    assert rejected.is_error is True
+    assert "unknown tool" in str(rejected.output)
+
+    allowed = reg.dispatch(call, ToolContext(workspace_root=tmp_path))
+    assert allowed.is_error is not True
+
+
+def test_headless_init_event_names_are_filtered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The stream-json init event lists what the main loop actually gets —
+    exercised at the same seam headless uses (view over the built registry)."""
+    from src.tool_system.defaults import build_default_registry
+
+    monkeypatch.setenv("CLAUDE_CODE_COORDINATOR_MODE", "1")
+    registry = build_default_registry(provider=object())
+    names = {
+        t.name for t in coordinator_main_loop_registry(registry).list_tools()
+    }
+    assert names == {"Agent", "SendMessage", "TaskStop", "StructuredOutput"}

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -958,7 +958,11 @@ export class GatewayClient extends EventEmitter {
         if (arg) {
           const r = (await this.controlQuery('resume', { session_id: arg })) as any
 
-          return out(`Resumed ${arg} (${r?.count ?? 0} messages).`)
+          // mode_banner: coordinator-mode flip notice (matchSessionMode) —
+          // e.g. "Entered coordinator mode to match resumed session."
+          const banner = typeof r?.mode_banner === 'string' && r.mode_banner ? `\n${r.mode_banner}` : ''
+
+          return out(`Resumed ${arg} (${r?.count ?? 0} messages).${banner}`)
         }
 
         const r = (await this.controlQuery('list_sessions', {})) as any


### PR DESCRIPTION
## Summary

`coordinator/` parity phase (get-parity-by-folder, after `context/` #379): the coordinator-mode module (`src/coordinator/`, ported in the chapter-10 round) was **inert** — only 2 of its 15 TS wiring seams were connected. Setting `CLAUDE_CODE_COORDINATOR_MODE=1` changed nothing the model saw: normal base prompt, full tool set, no `worker` agent type (its spawn instruction would have errored). This PR wires the mode end-to-end on the live paths (agent-server + headless), gated entirely behind the env var — behavior with the var unset is unchanged.

Gap analysis + plan (critic-reviewed, 2 rounds each): `my-docs/get-parity-by-folder/coordinator-{gap-analysis,refactoring-plan}.md` (main checkout, untracked by design).

## Work items

- **W1** `mode.py`: `_COORDINATOR_ALLOWED_TOOLS` += `StructuredOutput` (TS `COORDINATOR_MODE_ALLOWED_TOOLS`, constants/tools.ts:105-110) + PR-activity-suffix MCP exemption (`toolPool.ts:11-41`); byte-parity fix "via **the** Agent **tool**" (coordinatorMode.ts:97).
- **W2** `get_built_in_agents()` swaps to `[worker, general-purpose, Explore, Plan]` in coordinator mode (builtInAgents.ts:35-43; function-local imports break the package-init cycle) — `subagent_type: "worker"` now resolves; disk agents still override.
- **W3** `build_effective_system_prompt` coordinator branch: the orchestration prompt **replaces** the base blocks (systemPrompt.ts:63-75); style prompt still appends; single `cache_control` marker on the last stable block (same `should_1h_cache_ttl` selector as the normal builder); trailing workspace/git/CLAUDE.md block kept (TS keeps userContext).
- **W4** `workerToolsContext` (worker tool list + MCP server names + scratchpad note) appended to the trailing context block with the `# key\nvalue` user-context idiom; MCP names read from `tool_context.mcp_clients` (already published by the agent-server).
- **W5** `coordinator_main_loop_registry`: **non-mutating** filtered view applied at all 5 main-loop consumption points (server `emit_init`, `_context_usage`, turn invocation; headless init event + turn invocation). The Agent tool's captured FULL registry is untouched, so **workers keep their full pool** (TS: `applyCoordinatorToolFilter` runs only on main-loop assembly, AgentTool.tsx:568-575). Computed fresh per call → post-MCP registration + live MCP refresh + disabled-server hiding all covered.
- **W6** Agent tool: `model` param ignored (AgentTool.tsx:252); all coordinator spawns forced async so results arrive as `<task-notification>` (AgentTool.tsx:562); slim tool prompt — shared header only (prompt.ts:206-211).
- **W7** `_save_session` stamps `"mode"`; `_do_resume` runs `match_session_mode` (absent/junk → no-op, old files need no migration), rebuilds the cached `_base_system_prompt` (the `set_output_style` idiom), **re-emits `system/init`** so the client's tool list tracks the flip, and returns `mode_banner` in the reply; `gatewayClient.ts` appends the banner to the `/resume` output line. **The flip is `single_session`-gated** (impl-critic MAJOR): `match_session_mode` mutates the process-global env var, so on a multi-session `--http` server one session's resume would silently contaminate every sibling's prompt + tool set — same gate discipline the method already applies to cost restore; `--http` fail-safes to launch-env-decides. Coordinator mode is inherently process-scoped (TS is one-process-per-session via `bridge/sessionRunner`).
- **W8** `ASYNC_AGENT_ALLOWED_TOOLS` += `NotebookEdit`, `ToolSearch` (TS constants/tools.ts:53-69; both tools exist under those names) — this set is both the async-agent whitelist and the coordinator's rendered worker-tools list. `PowerShell` stays out (no Python tool).

## Stop-line (documented in the gap doc, not shipped)

Proactive-prompt suppression (no Python proactive mode), analytics (N-A), spawn/resume `enableSummarization` (no summarization service; `resume_agent.py` is the future wiring point), bare-mode `getTools` coordinator additions (bare mode unported, owned by `tools.ts`), user-typed skill-command coordinator summary (no Python user-typed skill-expansion surface; trigger documented), SDK-only `QueryEngine` prompt branch.

## Verification

- `tests/coordinator/` **76/76** (50 module tests incl. 2 refreshed byte-snapshots — the deliberate review gates for the ASYNC-set + wording changes — and the renamed 4-tool filter pin; 26 new wiring tests in `test_wiring.py` covering every work item, incl. a real `_AgentSession` harness for persist/resume/emit_init, fake-MCP consumption-site checks, the multi-session no-flip guard, an off-path reference-composition deep-equality pin, and execution-side rejection of filtered-out tool_use).
- `src/reference_data/ts_agent_constants.json` refreshed: its `async_agent_allowed_tools` mirror predated TS's NotebookEdit/ToolSearch additions (caught by `tests/parity/test_agent_isolation.py` on the first full-suite run; provenance comment updated).
- Full suite: failures == the 6 pre-existing on the parent commit (advisor_smoke ×2, parity e2e ×2, tool_parity ×2), verified before and after.
- Import safety: 5 entry orders (`src.coordinator` / `agent_definitions` / `tools.agent` / `agent_loop_compat` / `agent_server` first) all clean.
- ui-tui: `npm run build` + `tsc --noEmit` clean.
- **Live NDJSON smoke** against the real `clawcodex agent-server --stdio` (hermetic `$HOME`): (A) coordinator launch → `system/init` lists exactly `Agent, SendMessage, StructuredOutput, TaskStop`; (B) normal launch + `/resume` of a coordinator-stamped session → env flipped, reply carries `mode_banner: "Entered coordinator mode to match resumed session."`, `init` re-emitted with the narrowed list.
- Filtered-turn semantics: dispatching a filtered-out tool errors `unknown tool: Read` (advertised-tools contract); Agent's `Task` alias survives the view.

Critic loop: gap analysis and plan each passed two critic rounds; the implementation critic's REVISE round (1 MAJOR cross-session env-flip on `--http`, 2 MINOR test gaps, 1 NIT) was fully applied and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
