### PR TITLE
feat(entrypoints): mcp serve — re-expose clawcodex tools as an MCP stdio server

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -35,6 +35,16 @@ def main():
     profile_checkpoint("cli_main_entry")
 
     import os
+
+    # OpenClaude default: experimental API betas off unless the user opts in
+    # (mirrors typescript/src/entrypoints/cli.tsx:44 — tool search
+    # defer_loading / global cache scope / context management need internal
+    # API support external accounts lack → 500). Per-process entry:
+    # everything cli.main() spawns inherits this via the environment
+    # (tui_launcher passes env=dict(os.environ)); the standalone
+    # agent-server entry sets its own (agent_server_cli).
+    os.environ.setdefault("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", "true")
+
     if os.environ.get("CLAWCODEX_DEBUG", "").lower() in ("1", "true", "yes"):
         import logging
         logging.basicConfig(

--- a/src/entrypoints/agent_server_cli.py
+++ b/src/entrypoints/agent_server_cli.py
@@ -24,8 +24,17 @@ import argparse
 import asyncio
 import json
 import logging
+import os
 import sys
 import threading
+
+# OpenClaude default: experimental API betas off unless the user opts in
+# (mirrors typescript/src/entrypoints/cli.tsx:44's MODULE-scope placement —
+# beats any import-time env capture in the heavy imports below). Per-process
+# entry: this is the standalone backend where API calls happen; a direct
+# ``clawcodex agent-server`` / ``python -m`` run inherits nothing from
+# cli.main(), and Ink-spawned children get it by env inheritance too.
+os.environ.setdefault("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", "true")
 from pathlib import Path
 
 # ch02 round-4 WI-4 — bracket the child's import cost. This module is the
@@ -71,16 +80,6 @@ def _exit_when_stdin_closes() -> None:
 
 def run_agent_server_subcommand(argv: list[str]) -> int:
     """Entry point for ``clawcodex agent-server`` (fast-path subcommand)."""
-    # OpenClaude default: experimental API betas off unless the user opts in
-    # (mirrors typescript/src/entrypoints/cli.tsx:44). Per-process entry:
-    # this is the standalone backend process where API calls happen — a
-    # direct ``clawcodex agent-server`` / ``python -m`` run inherits nothing
-    # from cli.main(); Ink-spawned children get it by env inheritance too,
-    # making this idempotent there.
-    import os
-
-    os.environ.setdefault("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", "true")
-
     parser = argparse.ArgumentParser(
         prog="clawcodex agent-server",
         description="Run the Direct Connect agent server (TUI-client backend).",

--- a/src/entrypoints/agent_server_cli.py
+++ b/src/entrypoints/agent_server_cli.py
@@ -71,6 +71,16 @@ def _exit_when_stdin_closes() -> None:
 
 def run_agent_server_subcommand(argv: list[str]) -> int:
     """Entry point for ``clawcodex agent-server`` (fast-path subcommand)."""
+    # OpenClaude default: experimental API betas off unless the user opts in
+    # (mirrors typescript/src/entrypoints/cli.tsx:44). Per-process entry:
+    # this is the standalone backend process where API calls happen — a
+    # direct ``clawcodex agent-server`` / ``python -m`` run inherits nothing
+    # from cli.main(); Ink-spawned children get it by env inheritance too,
+    # making this idempotent there.
+    import os
+
+    os.environ.setdefault("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", "true")
+
     parser = argparse.ArgumentParser(
         prog="clawcodex agent-server",
         description="Run the Direct Connect agent server (TUI-client backend).",

--- a/src/entrypoints/mcp.py
+++ b/src/entrypoints/mcp.py
@@ -30,6 +30,22 @@ def run_mcp_subcommand(rest: list[str]) -> int:
     verb = rest[0]
     if verb == "list":
         return _list_servers()
+    if verb == "serve":
+        # Engine imported only inside this branch — the ``list`` fast path
+        # keeps its lean-import contract; ``serve`` inherently loads the
+        # tool registry. Mirrors typescript/src/entrypoints/mcp.ts
+        # (startMCPServer); the TS verb router lives in cli/handlers/mcp.tsx.
+        import os
+
+        # OpenClaude default: experimental API betas off unless the user
+        # opts in (mcp.ts:6 sets this in TS's separate mcp bundle; here the
+        # value normally arrives inherited from cli.main(), and this covers
+        # any direct invocation of the handler).
+        os.environ.setdefault("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", "true")
+        from src.entrypoints.mcp_serve import run_serve
+
+        args = rest[1:]
+        return run_serve(debug="--debug" in args, verbose="--verbose" in args)
     print(f"clawcodex mcp: unknown verb {verb!r}", file=sys.stderr)
     _print_usage()
     return 2
@@ -40,6 +56,7 @@ def _print_usage() -> None:
     print("")
     print("Verbs:")
     print("  list    List configured MCP servers")
+    print("  serve   Re-expose clawcodex's tools as an MCP stdio server")
 
 
 def _list_servers() -> int:

--- a/src/entrypoints/mcp_serve.py
+++ b/src/entrypoints/mcp_serve.py
@@ -1,0 +1,280 @@
+"""``clawcodex mcp serve`` — re-expose clawcodex's tools as an MCP stdio server.
+
+Port of ``typescript/src/entrypoints/mcp.ts`` (``startMCPServer``): any MCP
+host (Claude Desktop, another agent, an IDE) can connect over stdio and use
+this port's built-in tools — plus the tools of MCP servers configured for
+this workspace, re-exposed through the same connection
+(``loadReexposedMcpTools``, mcp.ts:56-70).
+
+Design decisions (mirroring the TS engine unless noted):
+
+* **Permission posture (security-relevant, plan §W1/P1):** TS builds the
+  tool context with ``getEmptyToolPermissionContext()`` — an ENFORCING
+  posture (``mode:'default'``, bypass unavailable; Tool.ts:142) — and routes
+  execution through ``hasPermissionsToUseTool``. Python's ``ToolContext``
+  default is the OPPOSITE (``mode="bypassPermissions"``, context.py) — so
+  this module explicitly constructs ``ToolPermissionContext()`` (mode
+  "default", empty rules, bypass unavailable) and executes via
+  ``registry.dispatch``, which runs the full pipeline
+  (schema validation → ``validate_input`` → ``has_permissions_to_use_tool``
+  → ask, registry.py:144-224). With no ``permission_handler`` on the
+  context, ask-requiring tools **fail closed** (``handle_permission_ask``
+  with a ``None`` handler denies) — exactly the TS non-interactive
+  behavior.
+* **Identity:** ``clawcodex`` + this port's version (TS: ``claude/tengu`` +
+  MACRO.VERSION — the established branding divergence).
+* **No output schemas:** this port's tools declare none, so none are
+  emitted (pre-empts TS's object-rooted-only branch, mcp.ts:106-120).
+* **SDK input validation disabled** (``validate_input=False``): the
+  registry's ``validate_json_schema`` runs inside ``dispatch`` and produces
+  this port's error text — the analog of TS shaping its own ZodError
+  message (mcp.ts:231-241) rather than letting the transport layer do it.
+* **No provider:** the registry is built with ``provider=None`` — the
+  serve surface exposes the tool set, not the model stack; agent-spawning
+  tools report "no provider configured" honestly at call time (divergence
+  from TS, which threads ``getMainLoopModel()``; revisit if a use case
+  needs Agent-via-serve).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+import mcp.types as mcp_types
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+
+from src import __version__
+
+logger = logging.getLogger(__name__)
+
+
+def _build_serve_context(cwd: Path) -> Any:
+    """The synthetic non-interactive ToolContext for serve calls.
+
+    ``ToolPermissionContext()`` — NOT the ToolContext default factory —
+    pins ``mode="default"`` + empty rules +
+    ``is_bypass_permissions_mode_available=False`` (the
+    ``getEmptyToolPermissionContext`` analog; see module docstring).
+    """
+    from src.permissions.types import ToolPermissionContext
+    from src.tool_system.context import ToolContext
+
+    return ToolContext(
+        workspace_root=cwd,
+        cwd=cwd,
+        permission_context=ToolPermissionContext(),
+    )
+
+
+def get_combined_tools(builtins: list[Any], mcp_tools: list[Any]) -> list[Any]:
+    """MCP tools first; builtins shadowed by an MCP tool name are dropped.
+
+    Mirrors ``getCombinedTools`` (mcp.ts:46-54).
+    """
+    mcp_names = {t.name for t in mcp_tools}
+    return [*mcp_tools, *[t for t in builtins if t.name not in mcp_names]]
+
+
+async def load_reexposed_mcp_tools() -> tuple[list[Any], list[Any]]:
+    """Connect configured MCP servers and collect their tools.
+
+    Mirrors ``loadReexposedMcpTools`` (mcp.ts:56-70) via the same client
+    machinery the TS engine uses (``get_mcp_tools_commands_and_resources``
+    is the port of ``getMcpToolsCommandsAndResources``). Best-effort: a
+    failing server is logged and skipped — it must not kill serve.
+    """
+    from src.services.mcp.manager import (
+        ConnectionAttemptResult,
+        get_mcp_tools_commands_and_resources,
+    )
+
+    clients: list[Any] = []
+    tools: list[Any] = []
+
+    def _on_attempt(result: ConnectionAttemptResult) -> None:
+        clients.append(result.client)
+        tools.extend(result.tools or [])
+
+    try:
+        await get_mcp_tools_commands_and_resources(_on_attempt)
+    except Exception:  # noqa: BLE001 — serve must come up even if MCP config is broken
+        logger.exception("mcp serve: loading configured MCP servers failed; continuing without")
+    return clients, tools
+
+
+def _tool_description(tool: Any) -> str:
+    """Model-facing description — ``tool.prompt()`` (a string), NOT the raw
+    ``description`` field, which may be a callable for dynamic tools. Same
+    rule as the agent-server's ``_tool_schemas``."""
+    try:
+        prompt = tool.prompt
+        return prompt() if callable(prompt) else str(prompt or "")
+    except Exception:  # noqa: BLE001 — a broken prompt() must not hide the tool
+        logger.exception("mcp serve: tool.prompt() failed for %s", getattr(tool, "name", "?"))
+        return str(getattr(tool, "description", "") or "")
+
+
+def _result_to_content(result: Any) -> list[mcp_types.ContentBlock]:
+    """Map a ToolResult's output to MCP content blocks.
+
+    Mirrors mcp.ts:199-227: str → text; list of blocks → text/image
+    (``source.data``/``media_type`` → data/mimeType), unknown block types
+    json-stringified with a warning; anything else → json-stringified text.
+    """
+    data = result.output if not isinstance(result, (str, list)) else result
+    if isinstance(data, str):
+        return [mcp_types.TextContent(type="text", text=data)]
+    if isinstance(data, list):
+        blocks: list[mcp_types.ContentBlock] = []
+        for block in data:
+            btype = block.get("type") if isinstance(block, dict) else None
+            if btype == "text":
+                blocks.append(mcp_types.TextContent(type="text", text=str(block.get("text") or "")))
+            elif btype == "image" and isinstance(block.get("source"), dict):
+                source = block["source"]
+                blocks.append(mcp_types.ImageContent(
+                    type="image",
+                    data=str(source.get("data") or ""),
+                    mimeType=str(source.get("media_type") or "application/octet-stream"),
+                ))
+            else:
+                logger.warning("mcp serve: unmapped content block type: %s", btype or "unknown")
+                blocks.append(mcp_types.TextContent(
+                    type="text", text=json.dumps(block, ensure_ascii=False, default=str),
+                ))
+        return blocks
+    return [mcp_types.TextContent(
+        type="text", text=json.dumps(data, ensure_ascii=False, default=str),
+    )]
+
+
+def _error_result(text: str) -> mcp_types.CallToolResult:
+    return mcp_types.CallToolResult(
+        content=[mcp_types.TextContent(type="text", text=text or "Error")],
+        isError=True,
+    )
+
+
+async def build_server(
+    cwd: Path,
+    *,
+    load_configured_mcp: bool = True,
+) -> Server:
+    """Construct the MCP server with handlers registered (testable seam).
+
+    ``start_mcp_server`` wraps this with the stdio transport; tests drive it
+    through the SDK's in-memory transport instead.
+    """
+    from src.tool_system.defaults import build_default_registry
+    from src.tool_system.protocol import ToolCall
+    from src.tool_system.registry import get_tools
+
+    registry = build_default_registry(provider=None)
+    context = _build_serve_context(cwd)
+    if load_configured_mcp:
+        mcp_clients, reexposed_tools = await load_reexposed_mcp_tools()
+    else:
+        mcp_clients, reexposed_tools = [], []
+    context.mcp_clients = {getattr(c, "name", str(i)): c for i, c in enumerate(mcp_clients)}
+    for t in reexposed_tools:
+        try:
+            registry.register(t)
+        except ValueError:
+            # Name collision: TS's getCombinedTools gives the MCP tool the
+            # win (mcp.ts:46-54 drops the shadowed builtin) — mirror that by
+            # evicting the builtin and registering the MCP tool.
+            registry.remove_tool(t.name)
+            try:
+                registry.register(t)
+            except Exception:  # noqa: BLE001
+                logger.exception("mcp serve: could not register MCP tool %s", getattr(t, "name", "?"))
+        except Exception:  # noqa: BLE001 — a single broken tool must not kill serve
+            logger.exception("mcp serve: could not register MCP tool %s", getattr(t, "name", "?"))
+
+    server: Server = Server("clawcodex", version=__version__)
+
+    def _is_mcp_tool(tool: Any) -> bool:
+        # Same predicate as agent_tool_utils.filter_tools_for_agent.
+        return tool.name.startswith("mcp__") or bool(getattr(tool, "is_mcp", False))
+
+    def _current_tools() -> list[Any]:
+        # get_tools = deny-rule + is_enabled filtered view; partition it and
+        # recombine MCP-first (TS's [...mcpTools, ...dedupedBuiltins] order).
+        visible = get_tools(registry, context.permission_context)
+        builtins = [t for t in visible if not _is_mcp_tool(t)]
+        reexposed = [t for t in visible if _is_mcp_tool(t)]
+        return get_combined_tools(builtins, reexposed)
+
+    @server.list_tools()
+    async def _list_tools() -> list[mcp_types.Tool]:
+        out: list[mcp_types.Tool] = []
+        for tool in _current_tools():
+            out.append(mcp_types.Tool(
+                name=tool.name,
+                description=_tool_description(tool),
+                inputSchema=tool.input_schema,
+            ))
+        return out
+
+    @server.call_tool(validate_input=False)
+    async def _call_tool(name: str, arguments: dict[str, Any] | None) -> mcp_types.CallToolResult:
+        from src.tool_system.errors import ToolInputError, ToolPermissionError
+
+        try:
+            tool = registry.get(name)
+            if tool is None:
+                return _error_result(f"Tool {name} not found")
+            if not tool.is_enabled():
+                return _error_result(f"Tool {name} is not enabled")
+            # The full pipeline: schema validation → validate_input →
+            # has_permissions_to_use_tool (ask fails closed — no handler on
+            # the serve context) → call. See module docstring.
+            result = registry.dispatch(ToolCall(name=name, input=arguments or {}), context)
+            if result.is_error:
+                error_text = (
+                    result.output.get("error") if isinstance(result.output, dict) else None
+                )
+                return _error_result(str(error_text or result.output))
+            return mcp_types.CallToolResult(content=_result_to_content(result), isError=False)
+        except ToolInputError as exc:
+            # The registry's schema validator renders field-path messages —
+            # the analog of TS's ZodError formatting branch (mcp.ts:231-241).
+            return _error_result(f"Tool {name} input is invalid:\n{exc}")
+        except ToolPermissionError as exc:
+            return _error_result(str(exc))
+        except Exception as exc:  # noqa: BLE001 — mirror mcp.ts:243-256 (never crash the server)
+            logger.exception("mcp serve: tool %s raised", name)
+            return _error_result(str(exc) or "Error")
+
+    return server
+
+
+async def start_mcp_server(cwd: Path, *, debug: bool = False, verbose: bool = False) -> None:
+    """Run the stdio MCP server until the client disconnects.
+
+    Mirrors ``startMCPServer`` (mcp.ts:72-266).
+    """
+    server = await build_server(cwd)
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())
+
+
+def run_serve(cwd: str | None = None, *, debug: bool = False, verbose: bool = False) -> int:
+    """Sync wrapper for the ``serve`` verb."""
+    import asyncio
+    import os
+
+    target = Path(cwd or os.getcwd()).resolve()
+    try:
+        asyncio.run(start_mcp_server(target, debug=debug, verbose=verbose))
+        return 0
+    except KeyboardInterrupt:
+        return 0
+    except Exception as exc:  # noqa: BLE001 — surface startup failures on stderr
+        print(f"clawcodex mcp serve: {exc}", file=sys.stderr)
+        return 1

--- a/src/entrypoints/mcp_serve.py
+++ b/src/entrypoints/mcp_serve.py
@@ -61,14 +61,34 @@ def _build_serve_context(cwd: Path) -> Any:
     pins ``mode="default"`` + empty rules +
     ``is_bypass_permissions_mode_available=False`` (the
     ``getEmptyToolPermissionContext`` analog; see module docstring).
+
+    Settings-level DENY rules are grafted on (critic follow-up): a user who
+    approved a server (C7) but added ``deny: mcp__x__dangerous`` in settings
+    must have that deny honored — deny rules precede allow rules in the
+    pipeline, so this also beats the re-exposure grant. ONLY deny rules are
+    taken: importing the settings ALLOW rules (or mode) would widen the
+    serve surface beyond the pinned posture. Best-effort — a broken settings
+    file leaves the pinned fail-closed posture intact.
     """
     from src.permissions.types import ToolPermissionContext
     from src.tool_system.context import ToolContext
 
+    permission_context = ToolPermissionContext()
+    try:
+        from src.permissions.settings_paths import default_setup_paths
+        from src.permissions.setup import setup_permissions
+
+        setup = setup_permissions(cwd=str(cwd), **default_setup_paths(str(cwd)))
+        for source, rules in setup.context.always_deny_rules.items():
+            if rules:
+                permission_context.always_deny_rules.setdefault(source, []).extend(rules)
+    except Exception:  # noqa: BLE001 — serve must come up; posture stays fail-closed
+        logger.exception("mcp serve: loading settings deny rules failed; continuing without")
+
     return ToolContext(
         workspace_root=cwd,
         cwd=cwd,
-        permission_context=ToolPermissionContext(),
+        permission_context=permission_context,
     )
 
 
@@ -217,6 +237,14 @@ async def build_server(
 
     server: Server = Server("clawcodex", version=__version__)
 
+    # Tool calls execute sequentially (critic follow-up): the shared
+    # ToolContext is mutable (read_file_fingerprints, task registries) and
+    # not thread-safe, so a pipelining client must not run two dispatches
+    # concurrently. The asyncio.Lock preserves the sequential profile while
+    # to_thread keeps the event loop free for pings/cancellation — the two
+    # concerns M1 separated.
+    dispatch_lock = asyncio.Lock()
+
     def _is_mcp_tool(tool: Any) -> bool:
         # Same predicate as agent_tool_utils.filter_tools_for_agent.
         return tool.name.startswith("mcp__") or bool(getattr(tool, "is_mcp", False))
@@ -265,9 +293,10 @@ async def build_server(
             # running loop, so async tools take _invoke_tool_call's clean
             # asyncio.run path. TS's `await tool.call(...)` is cooperative —
             # this is the Python equivalent.
-            result = await asyncio.to_thread(
-                registry.dispatch, ToolCall(name=name, input=arguments or {}), context
-            )
+            async with dispatch_lock:
+                result = await asyncio.to_thread(
+                    registry.dispatch, ToolCall(name=name, input=arguments or {}), context
+                )
             if result.is_error:
                 error_text = (
                     result.output.get("error") if isinstance(result.output, dict) else None

--- a/src/entrypoints/mcp_serve.py
+++ b/src/entrypoints/mcp_serve.py
@@ -38,6 +38,7 @@ Design decisions (mirroring the TS engine unless noted):
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import sys
@@ -125,6 +126,8 @@ def _result_to_content(result: Any) -> list[mcp_types.ContentBlock]:
     Mirrors mcp.ts:199-227: str → text; list of blocks → text/image
     (``source.data``/``media_type`` → data/mimeType), unknown block types
     json-stringified with a warning; anything else → json-stringified text.
+    (A plain non-block list would json-stringify per element via the unknown
+    branch — same as TS, whose list branch assumes content blocks too.)
     """
     data = result.output if not isinstance(result, (str, list)) else result
     if isinstance(data, str):
@@ -180,6 +183,20 @@ async def build_server(
         mcp_clients, reexposed_tools = await load_reexposed_mcp_tools()
     else:
         mcp_clients, reexposed_tools = [], []
+
+    if reexposed_tools:
+        # Re-exposed MCP tools are ask-gated in this port (PR #347 kept all
+        # mcp__* gated), so under the fail-closed serve posture they would
+        # deny — dead on arrival. TS's serve executes them ungated
+        # (mcp.ts calls tool.call directly). The coherent middle: the user's
+        # CONFIGURED servers are already their grant (and the C7 .mcp.json
+        # approval gate filtered unapproved project servers inside
+        # get_all_mcp_configs), so grant content-less session allow rules
+        # (bare tool-name rule strings — the PR #342 mechanism) for exactly
+        # the re-exposed tool names — builtins stay fail-closed.
+        context.permission_context.always_allow_rules.setdefault(
+            "session", []
+        ).extend(t.name for t in reexposed_tools)
     context.mcp_clients = {getattr(c, "name", str(i)): c for i, c in enumerate(mcp_clients)}
     for t in reexposed_tools:
         try:
@@ -187,7 +204,9 @@ async def build_server(
         except ValueError:
             # Name collision: TS's getCombinedTools gives the MCP tool the
             # win (mcp.ts:46-54 drops the shadowed builtin) — mirror that by
-            # evicting the builtin and registering the MCP tool.
+            # evicting the builtin and registering the MCP tool. (An ALIAS
+            # collision would re-raise into the drop-and-log branch below —
+            # acceptable: mcp__-namespaced tools can't realistically alias.)
             registry.remove_tool(t.name)
             try:
                 registry.register(t)
@@ -205,6 +224,10 @@ async def build_server(
     def _current_tools() -> list[Any]:
         # get_tools = deny-rule + is_enabled filtered view; partition it and
         # recombine MCP-first (TS's [...mcpTools, ...dedupedBuiltins] order).
+        # Intentional divergence: disabled tools are HIDDEN from ListTools
+        # here (TS lists them and only CallTool rejects, mcp.ts:174) — the
+        # filtered view is the honest advertisement; CallTool still rejects
+        # disabled tools by name for parity.
         visible = get_tools(registry, context.permission_context)
         builtins = [t for t in visible if not _is_mcp_tool(t)]
         reexposed = [t for t in visible if _is_mcp_tool(t)]
@@ -234,7 +257,17 @@ async def build_server(
             # The full pipeline: schema validation → validate_input →
             # has_permissions_to_use_tool (ask fails closed — no handler on
             # the serve context) → call. See module docstring.
-            result = registry.dispatch(ToolCall(name=name, input=arguments or {}), context)
+            #
+            # to_thread: dispatch is sync (and its async-tool bridge blocks
+            # the calling thread), so running it inline would freeze the MCP
+            # server's event loop for the tool's whole duration (a 30s Bash
+            # would stall pings/cancellation). The worker thread has no
+            # running loop, so async tools take _invoke_tool_call's clean
+            # asyncio.run path. TS's `await tool.call(...)` is cooperative —
+            # this is the Python equivalent.
+            result = await asyncio.to_thread(
+                registry.dispatch, ToolCall(name=name, input=arguments or {}), context
+            )
             if result.is_error:
                 error_text = (
                     result.output.get("error") if isinstance(result.output, dict) else None

--- a/tests/entrypoints/test_mcp_serve.py
+++ b/tests/entrypoints/test_mcp_serve.py
@@ -223,21 +223,31 @@ def test_betas_default_at_cli_entry(monkeypatch: pytest.MonkeyPatch) -> None:
     assert os.environ["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] == "false"
 
 
-def test_betas_default_at_agent_server_entry(monkeypatch: pytest.MonkeyPatch) -> None:
-    """agent_server_cli is its own process entry (standalone backend) — it
-    must set the default itself, not rely on cli.main() inheritance."""
-    from src.entrypoints.agent_server_cli import run_agent_server_subcommand
+def test_betas_default_at_agent_server_entry() -> None:
+    """agent_server_cli is its own process entry (standalone backend) — the
+    default is set at MODULE scope (mirroring cli.tsx:44's placement, before
+    the heavy imports can capture env), so it must hold on a bare import
+    with the var absent, and an explicit user value must survive."""
+    repo_root = str(Path(__file__).resolve().parents[2])
+    code = (
+        "import os; import src.entrypoints.agent_server_cli; "
+        "print(os.environ.get('CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS'))"
+    )
+    base_env = {k: v for k, v in os.environ.items()
+                if k != "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"}
 
-    monkeypatch.delenv("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", raising=False)
-    # ``--help`` exits via argparse SystemExit AFTER the setdefault runs.
-    with pytest.raises(SystemExit):
-        run_agent_server_subcommand(["--help"])
-    assert os.environ["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] == "true"
+    p1 = subprocess.run([sys.executable, "-c", code], capture_output=True,
+                        text=True, timeout=120, cwd=repo_root, env=base_env)
+    assert p1.returncode == 0, p1.stderr
+    assert p1.stdout.strip() == "true"
 
-    monkeypatch.setenv("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", "false")
-    with pytest.raises(SystemExit):
-        run_agent_server_subcommand(["--help"])
-    assert os.environ["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] == "false"
+    p2 = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True,
+        timeout=120, cwd=repo_root,
+        env={**base_env, "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "false"},
+    )
+    assert p2.returncode == 0, p2.stderr
+    assert p2.stdout.strip() == "false"
 
 
 def test_call_tool_out_of_workspace_read_denied(tmp_path: Path) -> None:
@@ -255,5 +265,73 @@ def test_call_tool_out_of_workspace_read_denied(tmp_path: Path) -> None:
         async with cm as s:
             r = await s.call_tool("Glob", {"pattern": "*.txt", "path": str(outside)})
             assert r.isError is True
+
+    asyncio.run(run())
+
+
+def test_reexposed_mcp_tools_integration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The full re-exposure chain (critic MAJOR-2): loader → registry
+    registration incl. the evict-and-replace MCP-wins collision recovery →
+    list_tools surfacing → dispatch. Re-exposed tools carry a content-less
+    session allow rule (the user's configured servers are already their
+    grant; the C7 approval gate filtered unapproved ones) — builtins stay
+    fail-closed."""
+    import src.entrypoints.mcp_serve as sm
+    from src.tool_system.build_tool import build_tool
+    from src.tool_system.protocol import ToolResult
+
+    echo = build_tool(
+        name="mcp__fake__echo",
+        input_schema={
+            "type": "object",
+            "properties": {"msg": {"type": "string"}},
+            "required": ["msg"],
+            "additionalProperties": False,
+        },
+        call=lambda i, c: ToolResult(name="mcp__fake__echo", output=f"echo:{i['msg']}"),
+        prompt="Echo from the fake MCP server.",
+        description="Echo tool.",
+    )
+    colliding = build_tool(
+        name="Read",
+        input_schema={"type": "object", "properties": {}, "additionalProperties": True},
+        call=lambda i, c: ToolResult(name="Read", output="MCP-READ"),
+        prompt="MCP Read replacement.",
+        description="Shadowing Read.",
+    )
+
+    async def fake_loader():
+        return [], [echo, colliding]
+
+    monkeypatch.setattr(sm, "load_reexposed_mcp_tools", fake_loader)
+
+    async def run() -> None:
+        from mcp.shared.memory import create_connected_server_and_client_session
+
+        server = await sm.build_server(tmp_path)  # default: uses the (fake) loader
+        async with create_connected_server_and_client_session(server) as s:
+            listing = await s.list_tools()
+            names = [t.name for t in listing.tools]
+            by_name = {t.name: t for t in listing.tools}
+            # Surfaced, MCP-first ordering.
+            assert "mcp__fake__echo" in names
+            assert names.index("mcp__fake__echo") < names.index("Glob")
+            # Evict-and-replace happened in the REAL registry: the builtin
+            # Read's slot now serves the MCP tool's description and body.
+            assert by_name["Read"].description.startswith("MCP Read replacement")
+
+            r = await s.call_tool("mcp__fake__echo", {"msg": "hi"})
+            assert r.isError is False and r.content[0].text == "echo:hi"
+
+            r2 = await s.call_tool("Read", {"anything": 1})
+            assert r2.isError is False and r2.content[0].text == "MCP-READ"
+
+            # The grant covers ONLY re-exposed names — builtin asks still
+            # fail closed.
+            r3 = await s.call_tool("Write", {"file_path": str(tmp_path / "n"), "content": "x"})
+            assert r3.isError is True
+            assert not (tmp_path / "n").exists()
 
     asyncio.run(run())

--- a/tests/entrypoints/test_mcp_serve.py
+++ b/tests/entrypoints/test_mcp_serve.py
@@ -335,3 +335,62 @@ def test_reexposed_mcp_tools_integration(
             assert not (tmp_path / "n").exists()
 
     asyncio.run(run())
+
+
+def test_settings_deny_rule_beats_reexposure_grant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A user who approved a server (C7) but denied one of its tools in
+    settings must have the deny honored — deny rules precede allow rules,
+    so the settings deny beats the re-exposure grant (critic follow-up)."""
+    import src.entrypoints.mcp_serve as sm
+    from src.tool_system.build_tool import build_tool
+    from src.tool_system.protocol import ToolResult
+
+    dangerous = build_tool(
+        name="mcp__fake__dangerous",
+        input_schema={"type": "object", "properties": {}, "additionalProperties": True},
+        call=lambda i, c: ToolResult(name="mcp__fake__dangerous", output="RAN"),
+        prompt="Should never run.",
+        description="d",
+    )
+    benign = build_tool(
+        name="mcp__fake__benign",
+        input_schema={"type": "object", "properties": {}, "additionalProperties": True},
+        call=lambda i, c: ToolResult(name="mcp__fake__benign", output="OK"),
+        prompt="Fine to run.",
+        description="b",
+    )
+
+    async def fake_loader():
+        return [], [dangerous, benign]
+
+    monkeypatch.setattr(sm, "load_reexposed_mcp_tools", fake_loader)
+
+    local_settings = tmp_path / "settings.local.json"
+    local_settings.write_text(
+        json.dumps({"permissions": {"deny": ["mcp__fake__dangerous"]}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "src.permissions.settings_paths.default_setup_paths",
+        lambda cwd=None: {
+            "user_settings_path": None,
+            "project_settings_path": None,
+            "local_settings_path": str(local_settings),
+            "managed_settings_path": None,
+        },
+    )
+
+    async def run() -> None:
+        from mcp.shared.memory import create_connected_server_and_client_session
+
+        server = await sm.build_server(tmp_path)
+        async with create_connected_server_and_client_session(server) as s:
+            r_deny = await s.call_tool("mcp__fake__dangerous", {})
+            assert r_deny.isError is True
+            assert "RAN" not in (r_deny.content[0].text if r_deny.content else "")
+            r_ok = await s.call_tool("mcp__fake__benign", {})
+            assert r_ok.isError is False and r_ok.content[0].text == "OK"
+
+    asyncio.run(run())

--- a/tests/entrypoints/test_mcp_serve.py
+++ b/tests/entrypoints/test_mcp_serve.py
@@ -1,0 +1,259 @@
+"""ENTRY-1 — ``clawcodex mcp serve`` engine tests.
+
+Port of ``typescript/src/entrypoints/mcp.ts`` (``startMCPServer``); plan:
+my-docs/get-parity-by-folder/entrypoints-refactoring-plan.md §ENTRY-1.
+
+The security-relevant pin (plan §W1/P1): the serve ToolContext is built with
+``ToolPermissionContext()`` — mode "default", empty rules, bypass
+UNAVAILABLE — NOT the ``ToolContext`` default factory (which is
+``bypassPermissions`` and would run the server with all gating off). With no
+``permission_handler``, ask-requiring tools fail CLOSED.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.entrypoints.mcp_serve import (
+    _build_serve_context,
+    _error_result,
+    _result_to_content,
+    _tool_description,
+    build_server,
+    get_combined_tools,
+)
+
+
+class _StubTool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+# ---------------------------------------------------------------------------
+# Unit — helpers
+# ---------------------------------------------------------------------------
+
+
+def test_serve_context_is_enforcing_not_bypass(tmp_path: Path) -> None:
+    """Regression pin for critic P1: Python's ToolContext DEFAULT is
+    bypassPermissions (context.py) — the serve context must not inherit it."""
+    ctx = _build_serve_context(tmp_path)
+    assert ctx.permission_context.mode == "default"
+    assert ctx.permission_context.is_bypass_permissions_mode_available is False
+    assert ctx.permission_handler is None
+
+
+def test_get_combined_tools_mcp_wins_on_collision() -> None:
+    """mcp.ts:46-54 — builtins shadowed by an MCP tool name are dropped;
+    MCP tools come first."""
+    builtins = [_StubTool("Read"), _StubTool("Grep")]
+    mcp_tools = [_StubTool("Read"), _StubTool("mcp__x__y")]
+    combined = get_combined_tools(builtins, mcp_tools)
+    assert [t.name for t in combined] == ["Read", "mcp__x__y", "Grep"]
+    assert combined[0] is mcp_tools[0]
+
+
+def test_result_to_content_mappings() -> None:
+    """mcp.ts:199-227 — str / text-block / image-block / unknown / other."""
+    from src.tool_system.protocol import ToolResult
+
+    r = ToolResult(name="T", output="plain")
+    [c] = _result_to_content(r)
+    assert c.type == "text" and c.text == "plain"
+
+    blocks = ToolResult(name="T", output=[
+        {"type": "text", "text": "hello"},
+        {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "QUJD"}},
+        {"type": "mystery", "value": 1},
+    ])
+    out = _result_to_content(blocks)
+    assert out[0].type == "text" and out[0].text == "hello"
+    assert out[1].type == "image" and out[1].data == "QUJD" and out[1].mimeType == "image/png"
+    assert out[2].type == "text" and json.loads(out[2].text)["type"] == "mystery"
+
+    other = ToolResult(name="T", output={"k": "v"})
+    [c2] = _result_to_content(other)
+    assert json.loads(c2.text) == {"k": "v"}
+
+
+def test_error_result_shape() -> None:
+    r = _error_result("boom")
+    assert r.isError is True and r.content[0].text == "boom"
+    assert _error_result("").content[0].text == "Error"
+
+
+# ---------------------------------------------------------------------------
+# In-process round-trips over the SDK memory transport (real build_server)
+# ---------------------------------------------------------------------------
+
+
+def _session(tmp_path: Path):
+    from mcp.shared.memory import create_connected_server_and_client_session
+
+    async def _factory():
+        server = await build_server(tmp_path, load_configured_mcp=False)
+        return create_connected_server_and_client_session(server)
+
+    return _factory
+
+
+def test_list_tools_shape(tmp_path: Path) -> None:
+    async def run() -> None:
+        cm = await _session(tmp_path)()
+        async with cm as s:
+            listing = await s.list_tools()
+            by_name = {t.name: t for t in listing.tools}
+            assert {"Read", "Glob", "Grep", "Bash", "Write"} <= set(by_name)
+            # Descriptions come from tool.prompt() (a non-empty string).
+            assert by_name["Glob"].description
+            # Input schemas are the registry's JSON-schema dicts.
+            assert by_name["Glob"].inputSchema.get("type") == "object"
+            # No output schemas — this port's tools declare none.
+            assert all(t.outputSchema is None for t in listing.tools)
+
+    asyncio.run(run())
+
+
+def test_call_tool_read_only_executes(tmp_path: Path) -> None:
+    (tmp_path / "hello.txt").write_text("hi", encoding="utf-8")
+
+    async def run() -> None:
+        cm = await _session(tmp_path)()
+        async with cm as s:
+            r = await s.call_tool("Glob", {"pattern": "*.txt", "path": str(tmp_path)})
+            assert r.isError is False
+            assert "hello.txt" in r.content[0].text
+
+    asyncio.run(run())
+
+
+def test_call_tool_ask_requiring_denied_fail_closed(tmp_path: Path) -> None:
+    """The serve posture has no permission handler → ask escalations DENY
+    and the tool must not execute (mirrors TS's non-interactive empty
+    permission context)."""
+    async def run() -> None:
+        cm = await _session(tmp_path)()
+        async with cm as s:
+            target = tmp_path / "never.txt"
+            r = await s.call_tool("Write", {"file_path": str(target), "content": "x"})
+            assert r.isError is True
+            assert not target.exists(), "denied tool must not have executed"
+
+    asyncio.run(run())
+
+
+def test_call_tool_validation_error_formatted(tmp_path: Path) -> None:
+    async def run() -> None:
+        cm = await _session(tmp_path)()
+        async with cm as s:
+            r = await s.call_tool("Glob", {"pattern": 123})
+            assert r.isError is True
+            text = r.content[0].text
+            assert "Glob" in text and "pattern" in text
+
+    asyncio.run(run())
+
+
+def test_call_tool_unknown_tool(tmp_path: Path) -> None:
+    async def run() -> None:
+        cm = await _session(tmp_path)()
+        async with cm as s:
+            r = await s.call_tool("NoSuchTool", {})
+            assert r.isError is True
+            assert "not found" in r.content[0].text
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Verb + lean contract + betas defaults
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_usage_lists_serve(capsys: pytest.CaptureFixture[str]) -> None:
+    from src.entrypoints.mcp import run_mcp_subcommand
+
+    assert run_mcp_subcommand(["--help"]) == 0
+    out = capsys.readouterr().out
+    assert "serve" in out and "list" in out
+
+
+def test_mcp_list_stays_lean() -> None:
+    """The list fast path must not load the serve engine, the agent-server,
+    or the TUI launcher (WI-4.3 contract) — serve's engine import lives
+    inside its own verb branch. (Pre-existing transitive imports of the mcp
+    PACKAGE's own server modules and the partial tool_system pull via the
+    MCP config layer are NOT this contract — both measured before this PR.)"""
+    code = (
+        "import sys; from src.entrypoints.mcp import run_mcp_subcommand; "
+        "run_mcp_subcommand(['list']); "
+        "heavy = [m for m in sys.modules if m.startswith(("
+        "'src.entrypoints.mcp_serve', 'src.server.agent_server', "
+        "'src.entrypoints.tui_launcher'))]; "
+        "print('HEAVY:' + ','.join(heavy))"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True, text=True, timeout=120,
+        cwd=str(Path(__file__).resolve().parents[2]),
+    )
+    assert proc.returncode == 0, proc.stderr
+    heavy_line = [l for l in proc.stdout.splitlines() if l.startswith("HEAVY:")][-1]
+    assert heavy_line == "HEAVY:", f"lean contract broken: {heavy_line}"
+
+
+def test_betas_default_at_cli_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """cli.main() sets the OpenClaude experimental-betas-off default
+    (cli.tsx:44) without clobbering an explicit user value."""
+    import src.cli as cli
+
+    monkeypatch.delenv("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", raising=False)
+    monkeypatch.setattr(sys, "argv", ["clawcodex", "--version"])
+    cli.main()
+    assert os.environ["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] == "true"
+
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", "false")
+    cli.main()
+    assert os.environ["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] == "false"
+
+
+def test_betas_default_at_agent_server_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """agent_server_cli is its own process entry (standalone backend) — it
+    must set the default itself, not rely on cli.main() inheritance."""
+    from src.entrypoints.agent_server_cli import run_agent_server_subcommand
+
+    monkeypatch.delenv("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", raising=False)
+    # ``--help`` exits via argparse SystemExit AFTER the setdefault runs.
+    with pytest.raises(SystemExit):
+        run_agent_server_subcommand(["--help"])
+    assert os.environ["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] == "true"
+
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", "false")
+    with pytest.raises(SystemExit):
+        run_agent_server_subcommand(["--help"])
+    assert os.environ["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] == "false"
+
+
+def test_call_tool_out_of_workspace_read_denied(tmp_path: Path) -> None:
+    """The serve posture composes with the ported read-permission semantics
+    (check_read_permission_for_tool): in-workspace reads are silent, an
+    out-of-workspace read raises the external-read ask — which fails closed
+    with no permission handler. Found live by the stdio smoke."""
+    import tempfile
+
+    outside = Path(tempfile.mkdtemp())
+    (outside / "secret.txt").write_text("x", encoding="utf-8")
+
+    async def run() -> None:
+        cm = await _session(tmp_path)()
+        async with cm as s:
+            r = await s.call_tool("Glob", {"pattern": "*.txt", "path": str(outside)})
+            assert r.isError is True
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

`entrypoints/` parity phase ENTRY-1 (after `coordinator/` #634): ports **`mcp serve`** — `typescript/src/entrypoints/mcp.ts` (`startMCPServer`) — the headline gap of the folder. Python's `mcp` handler only had `list`; there was no way to expose this port's tools to another MCP host. Plus the G12 betas-default micro-item.

Gap analysis + plan (critic-reviewed): `my-docs/get-parity-by-folder/entrypoints-{gap-analysis,refactoring-plan}.md` (main checkout, untracked by design). ENTRY-2 (startup provider validation) follows as its own PR per the critic-recommended split.

## What ships

- **`src/entrypoints/mcp_serve.py`** — stdio MCP server re-exposing the built-in tools + configured MCP servers' tools:
  - ListTools from the registry (`tool.prompt()` descriptions, JSON-schema inputs, no output schemas — none declared); disabled tools hidden (documented divergence: TS lists + rejects at call).
  - CallTool via `registry.dispatch` → schema validation (field-path error text, the ZodError-branch analog), `validate_input`, the full permission pipeline, result mapping (text/image/json per mcp.ts:199-227), errors → `isError` never crash.
  - Configured-server re-exposure via `get_mcp_tools_commands_and_resources` (the port of `getMcpToolsCommandsAndResources`) with **MCP-wins name dedup** (registry evict-and-replace, mcp.ts:46-54).
  - `await asyncio.to_thread(dispatch)` + a dispatch lock: sequential tool execution with a **free event loop** (pings/cancellation stay serviceable during a 30s Bash).
- **Security posture** (plan-critic BLOCKING item, judged sound structurally in review):
  - The synthetic serve context pins `ToolPermissionContext()` — mode `default`, empty rules, **bypass unavailable** — because Python's `ToolContext` default factory is `bypassPermissions`, which would have run the server with all gating off. No permission handler → ask-requiring tools **fail closed** (TS `getEmptyToolPermissionContext` analog; net STRICTER than TS, whose serve executes builtins — including Write — ungated).
  - **Re-exposure grant**: `mcp__*` tools are ask-gated in this port (PR #347), so the fail-closed posture would have denied them (dead on arrival). Content-less session allow rules are granted for exactly the re-exposed tool names — the user's configured servers are already their grant, and the C7 `.mcp.json` approval gate filtered unapproved project servers. Structurally cannot leak to builtins (rule matching is exact-name or mcp-prefix-gated; critic-verified).
  - **Settings deny rules honored**: the settings tiers' `deny` rules graft onto the pinned context (deny precedes allow → beats the grant); allow rules and mode deliberately NOT imported.
- **`serve` verb** in `entrypoints/mcp.py` (engine imported only in its branch; `list` lean-contract preserved and pinned by test).
- **G12**: `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` defaults to `"true"` at both per-process entries — `cli.main()` (cli.tsx:44) and `agent_server_cli` module scope (beats import-time env capture). Gates only the unwired tool-search mode selector today; the contract is for the ch04 betas docket.

## Verification

- `tests/entrypoints/test_mcp_serve.py` **16/16**: posture pins (context-not-bypass regression), MCP-wins dedup (pure + REAL registry chain), content mapping, memory-transport round-trips (list / call / fail-closed Write / validation / unknown / out-of-workspace read deny — the last found live by the smoke, then pinned), re-exposure integration (loader → evict-and-replace → surface → dispatch), **deny-beats-grant**, verb usage, lean contract, betas defaults (subprocess bare-import checks).
- **Live stdio smoke**: real `clawcodex mcp serve` subprocess driven by a real MCP client — initialize handshake (`clawcodex 0.6.0`), 39 tools, in-workspace Glob executes, Write denied fail-closed.
- Full suite: failures == the 6 pre-existing baseline (advisor ×2, parity e2e ×2, tool_parity ×2), verified on the worktree parent and the final tree.
- Critic loop: gap doc REVISE→APPROVE; plan REVISE (2 BLOCKING: permission posture, teams-cleanup cross-process no-op → deferred) →APPROVE; implementation REVISE (event-loop block, re-exposure untested) →APPROVE with the grant judged structurally sound; both post-APPROVE minors (settings denies, dispatch serialization) implemented rather than deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
