### PR TITLE
feat(hooks): execute PermissionRequest hooks at the ask seam; TS rejection texts

### DIFF
--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -341,6 +341,29 @@ async def _execute_command_hook(
                     result.hook_permission_decision_reason = parsed.reason
                 if parsed.updatedInput:
                     result.updated_input = parsed.updatedInput
+                if parsed.updatedPermissions:
+                    result.updated_permissions = parsed.updatedPermissions
+                if parsed.interrupt:
+                    result.interrupt = True
+                # TS wire-envelope compat (utils/hooks.ts:833-840): a hook
+                # written for the reference CLI emits
+                # ``hookSpecificOutput.decision`` — normalize onto the same
+                # fields; the flat form (above) wins on conflict.
+                hso = parsed.hookSpecificOutput or {}
+                hso_decision = hso.get("decision") if isinstance(hso, dict) else None
+                if isinstance(hso_decision, dict):
+                    behavior = hso_decision.get("behavior")
+                    if result.permission_behavior is None and behavior in ("allow", "deny", "ask"):
+                        result.permission_behavior = behavior
+                        result.hook_permission_decision_reason = (
+                            hso_decision.get("message") or result.hook_permission_decision_reason
+                        )
+                    if result.updated_input is None and isinstance(hso_decision.get("updatedInput"), dict):
+                        result.updated_input = hso_decision["updatedInput"]
+                    if result.updated_permissions is None and isinstance(hso_decision.get("updatedPermissions"), list):
+                        result.updated_permissions = hso_decision["updatedPermissions"]
+                    if hso_decision.get("interrupt"):
+                        result.interrupt = True
                 if parsed.preventContinuation:
                     result.prevent_continuation = True
                     result.stop_reason = parsed.stopReason
@@ -420,6 +443,8 @@ async def _run_hooks_for_event(
                 "permission_behavior": result.permission_behavior,
                 "hook_permission_decision_reason": result.hook_permission_decision_reason,
                 "updated_input": result.updated_input,
+                "updated_permissions": result.updated_permissions,
+                "interrupt": result.interrupt,
             }
 
         if result.prevent_continuation:
@@ -481,6 +506,45 @@ async def execute_pre_tool_hooks(
 
     async for result in _run_hooks_for_event(
         "PreToolUse",
+        tool_name,
+        stdin_data,
+        tool_use_context,
+        abort_signal=abort_signal,
+    ):
+        yield result
+
+
+async def execute_permission_request_hooks(
+    tool_name: str,
+    tool_use_id: str,
+    tool_input: dict[str, Any],
+    tool_use_context: Any,
+    permission_suggestions: list[Any] | None = None,
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Run PermissionRequest hooks for a pending permission ask.
+
+    HOOKS-1 (my-docs/get-parity-by-folder/hooks-refactoring-plan.md W1) —
+    the port of ``executePermissionRequestHooks`` (utils/hooks.ts:4392-4427):
+    fired at the ask seam BEFORE any interactive prompt, matcher-scoped by
+    tool name like PreToolUse. A hook may resolve the ask (allow with
+    optional updatedInput/updatedPermissions; deny with message + optional
+    interrupt) or stay silent (normal prompt flow continues).
+    """
+    stdin_data: dict[str, Any] = {
+        "tool_name": tool_name,
+        "tool_use_id": tool_use_id,
+        "tool_input": tool_input,
+    }
+    if permission_suggestions:
+        stdin_data["permission_suggestions"] = permission_suggestions
+
+    abort_signal = None
+    abort_ctrl = getattr(tool_use_context, "abort_controller", None)
+    if abort_ctrl:
+        abort_signal = abort_ctrl.signal
+
+    async for result in _run_hooks_for_event(
+        "PermissionRequest",
         tool_name,
         stdin_data,
         tool_use_context,

--- a/src/hooks/hook_types.py
+++ b/src/hooks/hook_types.py
@@ -281,6 +281,11 @@ class HookResult:
     hook_permission_decision_reason: str | None = None
     hook_source: str | None = None
     updated_input: dict[str, Any] | None = None
+    # PermissionRequest-event extras (HOOKS-1): permission updates a hook may
+    # attach to an allow, and the deny-time turn-abort flag. Mirrors the TS
+    # PermissionRequest decision shape (utils/hooks.ts:833-840).
+    updated_permissions: list[dict[str, Any]] | None = None
+    interrupt: bool = False
     prevent_continuation: bool = False
     stop_reason: str | None = None
     additional_contexts: list[str] | None = None

--- a/src/hooks/output_schema.py
+++ b/src/hooks/output_schema.py
@@ -47,6 +47,15 @@ class HookOutput(BaseModel):
     preventContinuation: bool | None = None
     stopReason: str | None = None
     updatedMCPToolOutput: Any | None = None
+    # PermissionRequest-event extras (HOOKS-1). Flat form follows this
+    # schema's existing convention; ``hookSpecificOutput`` accepts the TS
+    # wire envelope (``{hookEventName, decision: {behavior, message,
+    # updatedInput, updatedPermissions, interrupt}}`` — utils/hooks.ts:833-840)
+    # so hooks written for the reference CLI work unchanged. The executor
+    # normalizes both forms onto the same HookResult fields.
+    updatedPermissions: list[dict[str, Any]] | None = None
+    interrupt: bool | None = None
+    hookSpecificOutput: dict[str, Any] | None = None
 
 
 def parse_hook_output(stdout: str) -> tuple[HookOutput | None, str | None]:

--- a/src/permissions/handler.py
+++ b/src/permissions/handler.py
@@ -35,6 +35,7 @@ import logging
 from typing import Any
 
 from .types import (
+    HookDecisionReason,
     PermissionAllowDecision,
     PermissionAskDecision,
     PermissionAskHandler,
@@ -110,6 +111,16 @@ def _run_permission_request_hooks(
 
         from src.utils.async_bridge import run_coroutine_blocking
 
+        from .updates import serialize_permission_update
+
+        # Canonical wire JSON for hook stdin (critic MAJOR: __dict__ left
+        # nested PermissionRuleValue objects to be repr-stringified —
+        # unusable for hook authors and divergent from TS's
+        # PermissionUpdate JSON).
+        suggestions_json = [
+            serialize_permission_update(s) for s in (decision.suggestions or ())
+        ] or None
+
         async def _collect() -> list[dict[str, Any]]:
             results: list[dict[str, Any]] = []
             async for item in execute_permission_request_hooks(
@@ -117,12 +128,15 @@ def _run_permission_request_hooks(
                 tool_use_id or "",
                 tool_input or {},
                 context,
-                permission_suggestions=[
-                    getattr(s, "__dict__", s) for s in (decision.suggestions or ())
-                ]
-                or None,
+                permission_suggestions=suggestions_json,
             ):
                 results.append(item)
+                # First decisive hook wins AND later hooks never execute —
+                # exact TS runHooks parity (returns mid-generator,
+                # abandoning the rest). Progress/attachment items carry no
+                # permission_behavior and keep streaming until then.
+                if item.get("permission_behavior") in ("allow", "deny"):
+                    break
             return results
 
         results = run_coroutine_blocking(
@@ -158,10 +172,9 @@ def _run_permission_request_hooks(
                     behavior="allow",
                     updated_input=item.get("updated_input")
                     or decision.updated_input,
-                    decision_reason={
-                        "type": "hook",
-                        "hookName": "PermissionRequest",
-                    },
+                    decision_reason=HookDecisionReason(
+                        hook_name="PermissionRequest",
+                    ),
                 ),
                 chosen,
             )
@@ -183,11 +196,10 @@ def _run_permission_request_hooks(
                 PermissionDenyDecision(
                     behavior="deny",
                     message=message,
-                    decision_reason={
-                        "type": "hook",
-                        "hookName": "PermissionRequest",
-                        "reason": message,
-                    },
+                    decision_reason=HookDecisionReason(
+                        hook_name="PermissionRequest",
+                        reason=message,
+                    ),
                 ),
                 (),
             )

--- a/src/permissions/handler.py
+++ b/src/permissions/handler.py
@@ -7,10 +7,31 @@ receives the full :class:`PermissionAskRequest` (tool input drives
 per-tool previews; suggestions drive the "always allow" option) and
 answers with a :class:`PermissionAskReply` (which may carry the chosen
 "don't ask again" updates and deny feedback).
+
+HOOKS-1 (hooks-folder parity) adds two behaviors at this — the single —
+ask choke point (both live seams funnel here: the query-loop adapter,
+``can_use_tool_adapter.py``, and ``registry.dispatch``):
+
+* **PermissionRequest hooks** run BEFORE any interactive prompt — and
+  before the no-handler fail-closed branch, so hook decisions work
+  headless (half their point). Port of ``PermissionContext.runHooks``
+  (typescript/src/hooks/toolPermission/PermissionContext.ts:216-263):
+  first decisive hook wins — ``allow`` (optional updatedInput +
+  updatedPermissions → chosen_updates) or ``deny`` (message; optional
+  ``interrupt`` aborts the turn via the context's abort controller);
+  no decision → the normal flow, unchanged. Hook failures are contained
+  (logged; flow continues) — a broken hook must not brick every prompt.
+* **Rejection texts the model can act on** — the TS constants verbatim
+  (utils/messages.ts:214-221) with the main-agent vs subagent split from
+  ``cancelAndAbort`` (PermissionContext.ts:154-173), keyed on
+  ``ToolContext.agent_id`` (the ``toolUseContext.agentId`` analog, set by
+  ``subagent_context``). ``withMemoryCorrectionHint`` is NOT ported
+  (GrowthBook ``tengu_amber_prism``, default false — a no-op upstream too).
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from .types import (
@@ -23,21 +44,182 @@ from .types import (
     PermissionUpdate,
 )
 
+logger = logging.getLogger(__name__)
+
+
+# Verbatim TS rejection texts (typescript/src/utils/messages.ts:214-221).
+# These are MODEL-FACING: the instructive wording ("the new_string was NOT
+# written", "STOP…" / "Try a different approach…") is what lets the model
+# change course correctly after a denial.
+REJECT_MESSAGE = (
+    "The user doesn't want to proceed with this tool use. The tool use was "
+    "rejected (eg. if it was a file edit, the new_string was NOT written to "
+    "the file). STOP what you are doing and wait for the user to tell you "
+    "how to proceed."
+)
+REJECT_MESSAGE_WITH_REASON_PREFIX = (
+    "The user doesn't want to proceed with this tool use. The tool use was "
+    "rejected (eg. if it was a file edit, the new_string was NOT written to "
+    "the file). To tell you how to proceed, the user said:\n"
+)
+SUBAGENT_REJECT_MESSAGE = (
+    "Permission for this tool use was denied. The tool use was rejected "
+    "(eg. if it was a file edit, the new_string was NOT written to the "
+    "file). Try a different approach or report the limitation to complete "
+    "your task."
+)
+SUBAGENT_REJECT_MESSAGE_WITH_REASON_PREFIX = (
+    "Permission for this tool use was denied. The tool use was rejected "
+    "(eg. if it was a file edit, the new_string was NOT written to the "
+    "file). The user said:\n"
+)
+
+
+def _rejection_message(feedback: str, *, is_subagent: bool) -> str:
+    """The cancelAndAbort message matrix (PermissionContext.ts:154-167)."""
+    if feedback:
+        prefix = (
+            SUBAGENT_REJECT_MESSAGE_WITH_REASON_PREFIX
+            if is_subagent
+            else REJECT_MESSAGE_WITH_REASON_PREFIX
+        )
+        return f"{prefix}{feedback}"
+    return SUBAGENT_REJECT_MESSAGE if is_subagent else REJECT_MESSAGE
+
+
+def _run_permission_request_hooks(
+    tool_name: str,
+    decision: PermissionAskDecision,
+    tool_input: dict[str, Any] | None,
+    context: Any,
+    tool_use_id: str | None,
+) -> tuple[PermissionDecision, tuple[PermissionUpdate, ...]] | None:
+    """Consult PermissionRequest hooks; a decisive result resolves the ask.
+
+    Returns ``None`` when no hook made a decision (or hooks are not
+    configured / failed) — the caller continues the normal flow.
+    """
+    try:
+        from src.hooks.hook_executor import (
+            execute_permission_request_hooks,
+            has_hook_for_event,
+        )
+
+        if not has_hook_for_event("PermissionRequest", context):
+            return None
+
+        from src.utils.async_bridge import run_coroutine_blocking
+
+        async def _collect() -> list[dict[str, Any]]:
+            results: list[dict[str, Any]] = []
+            async for item in execute_permission_request_hooks(
+                tool_name,
+                tool_use_id or "",
+                tool_input or {},
+                context,
+                permission_suggestions=[
+                    getattr(s, "__dict__", s) for s in (decision.suggestions or ())
+                ]
+                or None,
+            ):
+                results.append(item)
+            return results
+
+        results = run_coroutine_blocking(
+            _collect(), thread_name=f"permission-request-hooks:{tool_name}"
+        )
+    except Exception:  # noqa: BLE001 — a broken hook must not brick prompts
+        logger.exception(
+            "PermissionRequest hooks failed for %s; continuing to the normal flow",
+            tool_name,
+        )
+        return None
+
+    # First decisive result wins (runHooks loop semantics).
+    for item in results:
+        behavior = item.get("permission_behavior")
+        if behavior == "allow":
+            chosen: tuple[PermissionUpdate, ...] = ()
+            raw_updates = item.get("updated_permissions")
+            if isinstance(raw_updates, list):
+                from .updates import deserialize_permission_update
+
+                chosen = tuple(
+                    u
+                    for u in (
+                        deserialize_permission_update(d)
+                        for d in raw_updates
+                        if isinstance(d, dict)
+                    )
+                    if u is not None
+                )
+            return (
+                PermissionAllowDecision(
+                    behavior="allow",
+                    updated_input=item.get("updated_input")
+                    or decision.updated_input,
+                    decision_reason={
+                        "type": "hook",
+                        "hookName": "PermissionRequest",
+                    },
+                ),
+                chosen,
+            )
+        if behavior == "deny":
+            message = (
+                item.get("hook_permission_decision_reason")
+                or "Permission denied by hook"
+            )
+            if item.get("interrupt"):
+                abort_ctrl = getattr(context, "abort_controller", None)
+                if abort_ctrl is not None:
+                    try:
+                        abort_ctrl.abort("permission_request_hook_interrupt")
+                    except Exception:  # noqa: BLE001 — deny still stands
+                        logger.exception(
+                            "PermissionRequest hook interrupt abort failed"
+                        )
+            return (
+                PermissionDenyDecision(
+                    behavior="deny",
+                    message=message,
+                    decision_reason={
+                        "type": "hook",
+                        "hookName": "PermissionRequest",
+                        "reason": message,
+                    },
+                ),
+                (),
+            )
+    return None
+
 
 def handle_permission_ask(
     tool_name: str,
     decision: PermissionAskDecision,
     handler: PermissionAskHandler | None = None,
     tool_input: dict[str, Any] | None = None,
+    context: Any = None,
+    tool_use_id: str | None = None,
 ) -> tuple[PermissionDecision, tuple[PermissionUpdate, ...]]:
-    """Resolve an ``ask`` decision through ``handler``.
+    """Resolve an ``ask`` decision through hooks, then ``handler``.
 
     Returns ``(final_decision, chosen_updates)``. ``chosen_updates`` are
     the "don't ask again" rules the user accepted (empty on deny / plain
     allow); the caller applies them to the live context and persists the
     persistable destinations — mirroring how TS applies
     ``updatedPermissions`` from the dialog's ``PermissionResult``.
+    ``context``/``tool_use_id`` are optional for backward compatibility;
+    call sites that pass them enable PermissionRequest hooks and the
+    subagent-aware rejection texts.
     """
+
+    if context is not None:
+        hook_resolution = _run_permission_request_hooks(
+            tool_name, decision, tool_input, context, tool_use_id
+        )
+        if hook_resolution is not None:
+            return hook_resolution
 
     if handler is None:
         return (
@@ -70,11 +252,8 @@ def handle_permission_ask(
         )
 
     feedback = (reply.message or "").strip()
-    message = "Permission denied by user."
-    if feedback:
-        # TS deny-with-feedback: the user's note reaches the model via the
-        # tool error so it can change course.
-        message = f"Permission denied by user: {feedback}"
+    is_subagent = bool(getattr(context, "agent_id", None))
+    message = _rejection_message(feedback, is_subagent=is_subagent)
     return (
         PermissionDenyDecision(
             behavior="deny",
@@ -85,4 +264,10 @@ def handle_permission_ask(
     )
 
 
-__all__ = ["handle_permission_ask"]
+__all__ = [
+    "handle_permission_ask",
+    "REJECT_MESSAGE",
+    "REJECT_MESSAGE_WITH_REASON_PREFIX",
+    "SUBAGENT_REJECT_MESSAGE",
+    "SUBAGENT_REJECT_MESSAGE_WITH_REASON_PREFIX",
+]

--- a/src/permissions/updates.py
+++ b/src/permissions/updates.py
@@ -650,3 +650,52 @@ def session_option_label(
     if base:
         return f"and {base}"
     return None
+
+
+def deserialize_permission_update(data: dict) -> "Any":
+    """Wire dict → PermissionUpdate dataclass (None on unrecognized type).
+
+    Promoted from the agent-server (HOOKS-1): the can_use_tool reply AND
+    PermissionRequest-hook ``updatedPermissions`` both arrive in the same
+    wire shape, so the one parser lives here with the update types.
+    """
+    from .types import (
+        PermissionRuleValue,
+        PermissionUpdateAddDirectories,
+        PermissionUpdateAddRules,
+        PermissionUpdateRemoveDirectories,
+        PermissionUpdateRemoveRules,
+        PermissionUpdateReplaceRules,
+        PermissionUpdateSetMode,
+    )
+
+    utype = data.get("type")
+    dest = data.get("destination", "session")
+    behavior = data.get("behavior", "allow")
+
+    def _rules() -> tuple:
+        return tuple(
+            PermissionRuleValue(
+                tool_name=str(r.get("tool_name", "")),
+                rule_content=r.get("rule_content"),
+            )
+            for r in (data.get("rules") or []) if isinstance(r, dict)
+        )
+
+    if utype == "addRules":
+        return PermissionUpdateAddRules(destination=dest, behavior=behavior, rules=_rules())
+    if utype == "replaceRules":
+        return PermissionUpdateReplaceRules(destination=dest, behavior=behavior, rules=_rules())
+    if utype == "removeRules":
+        return PermissionUpdateRemoveRules(destination=dest, behavior=behavior, rules=_rules())
+    if utype == "setMode":
+        return PermissionUpdateSetMode(destination=dest, mode=data.get("mode", "default"))
+    if utype == "addDirectories":
+        return PermissionUpdateAddDirectories(
+            destination=dest, directories=tuple(data.get("directories") or ()),
+        )
+    if utype == "removeDirectories":
+        return PermissionUpdateRemoveDirectories(
+            destination=dest, directories=tuple(data.get("directories") or ()),
+        )
+    return None

--- a/src/permissions/updates.py
+++ b/src/permissions/updates.py
@@ -699,3 +699,35 @@ def deserialize_permission_update(data: dict) -> "Any":
             destination=dest, directories=tuple(data.get("directories") or ()),
         )
     return None
+
+
+def serialize_permission_update(update: "Any") -> dict:
+    """PermissionUpdate dataclass → wire dict (the shape hooks and the TUI
+    see; ``deserialize_permission_update`` reverses it).
+
+    Promoted from the agent-server (HOOKS-1 critic round): the can_use_tool
+    round-trip and PermissionRequest-hook stdin both need the SAME canonical
+    JSON — nested rules as ``{"tool_name", "rule_content"}`` dicts, never
+    Python reprs.
+    """
+    out: dict = {
+        "type": getattr(update, "type", "addRules"),
+        "destination": getattr(update, "destination", "session"),
+    }
+    behavior = getattr(update, "behavior", None)
+    if behavior is not None:
+        out["behavior"] = behavior
+    rules = getattr(update, "rules", None)
+    if rules:
+        out["rules"] = [
+            {"tool_name": getattr(r, "tool_name", ""),
+             "rule_content": getattr(r, "rule_content", None)}
+            for r in rules
+        ]
+    mode = getattr(update, "mode", None)
+    if mode is not None:
+        out["mode"] = mode
+    directories = getattr(update, "directories", None)
+    if directories:
+        out["directories"] = list(directories)
+    return out

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -2811,30 +2811,12 @@ def _session_option_label_safe(request: Any) -> str | None:
 
 
 def _serialize_permission_update(update: Any) -> dict:
-    """ch13 round-4 — wire shape for a PermissionUpdate (the persistable
-    "always allow" rule). The TUI renders the description and echoes the
-    chosen one back; _deserialize_permission_update reverses this."""
-    out: dict[str, Any] = {
-        "type": getattr(update, "type", "addRules"),
-        "destination": getattr(update, "destination", "session"),
-    }
-    behavior = getattr(update, "behavior", None)
-    if behavior is not None:
-        out["behavior"] = behavior
-    rules = getattr(update, "rules", None)
-    if rules:
-        out["rules"] = [
-            {"tool_name": getattr(r, "tool_name", ""),
-             "rule_content": getattr(r, "rule_content", None)}
-            for r in rules
-        ]
-    mode = getattr(update, "mode", None)
-    if mode is not None:
-        out["mode"] = mode
-    directories = getattr(update, "directories", None)
-    if directories:
-        out["directories"] = list(directories)
-    return out
+    """ch13 round-4 — wire shape for a PermissionUpdate. Delegates to the
+    canonical serializer (promoted to src/permissions/updates.py in HOOKS-1,
+    paired with deserialize_permission_update)."""
+    from src.permissions.updates import serialize_permission_update
+
+    return serialize_permission_update(update)
 
 
 def _deserialize_permission_update(data: dict) -> Any:

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -2838,48 +2838,12 @@ def _serialize_permission_update(update: Any) -> dict:
 
 
 def _deserialize_permission_update(data: dict) -> Any:
-    """Reverse of _serialize_permission_update. Returns a PermissionUpdate
-    dataclass or None on an unrecognized/empty type."""
-    from src.permissions.types import (
-        PermissionRuleValue,
-        PermissionUpdateAddDirectories,
-        PermissionUpdateAddRules,
-        PermissionUpdateRemoveDirectories,
-        PermissionUpdateRemoveRules,
-        PermissionUpdateReplaceRules,
-        PermissionUpdateSetMode,
-    )
+    """Reverse of _serialize_permission_update. Delegates to the canonical
+    parser (promoted to src/permissions/updates.py in HOOKS-1 so the
+    PermissionRequest-hook path shares it)."""
+    from src.permissions.updates import deserialize_permission_update
 
-    utype = data.get("type")
-    dest = data.get("destination", "session")
-    behavior = data.get("behavior", "allow")
-
-    def _rules() -> tuple:
-        return tuple(
-            PermissionRuleValue(
-                tool_name=str(r.get("tool_name", "")),
-                rule_content=r.get("rule_content"),
-            )
-            for r in (data.get("rules") or []) if isinstance(r, dict)
-        )
-
-    if utype == "addRules":
-        return PermissionUpdateAddRules(destination=dest, behavior=behavior, rules=_rules())
-    if utype == "replaceRules":
-        return PermissionUpdateReplaceRules(destination=dest, behavior=behavior, rules=_rules())
-    if utype == "removeRules":
-        return PermissionUpdateRemoveRules(destination=dest, behavior=behavior, rules=_rules())
-    if utype == "setMode":
-        return PermissionUpdateSetMode(destination=dest, mode=data.get("mode", "default"))
-    if utype == "addDirectories":
-        return PermissionUpdateAddDirectories(
-            destination=dest, directories=tuple(data.get("directories") or ()),
-        )
-    if utype == "removeDirectories":
-        return PermissionUpdateRemoveDirectories(
-            destination=dest, directories=tuple(data.get("directories") or ()),
-        )
-    return None
+    return deserialize_permission_update(data)
 
 
 def _extract_prompt_text(msg: dict) -> str:

--- a/src/services/tool_execution/can_use_tool_adapter.py
+++ b/src/services/tool_execution/can_use_tool_adapter.py
@@ -41,7 +41,7 @@ def build_can_use_tool(context: Any) -> Callable[..., dict[str, Any]]:
         tool_input: dict[str, Any],
         _tool_use_context: Any,
         _assistant_message: Any,
-        _tool_use_id: str,
+        tool_use_id: str,
         force_decision: Any = None,
     ) -> dict[str, Any]:
         # ch06 round-4 PR-A GAP A — the 6th ``force_decision`` param
@@ -101,6 +101,7 @@ def build_can_use_tool(context: Any) -> Callable[..., dict[str, Any]]:
                 final, chosen_updates = handle_permission_ask(
                     tool.name, ask_decision, context.permission_handler,
                     tool_input=ask_input,
+                    context=context, tool_use_id=tool_use_id,
                 )
                 if getattr(final, "behavior", "deny") != "allow":
                     return {
@@ -138,6 +139,8 @@ def build_can_use_tool(context: Any) -> Callable[..., dict[str, Any]]:
                 decision,
                 context.permission_handler,
                 tool_input=tool_input,
+                context=context,
+                tool_use_id=tool_use_id,
             )
             if final.behavior == "deny":
                 return {

--- a/src/tool_system/registry.py
+++ b/src/tool_system/registry.py
@@ -182,6 +182,8 @@ class ToolRegistry:
                 decision,
                 context.permission_handler,
                 tool_input=call.input,
+                context=context,
+                tool_use_id=call.tool_use_id,
             )
 
             if final.behavior == "deny":
@@ -241,44 +243,19 @@ def _invoke_tool_call(tool: Any, input: dict, context: ToolContext) -> ToolResul
     if not inspect.iscoroutinefunction(fn):
         return fn(input, context)
 
-    # Async tool — drive the coroutine to completion.
-    try:
-        running = asyncio.get_running_loop()
-    except RuntimeError:
-        running = None
+    # Async tool — drive the coroutine to completion via the shared bridge
+    # (extracted to utils/async_bridge in HOOKS-1 so the permission-ask
+    # seam reuses the exact same run-or-thread semantics). No timeout on
+    # the wait — async tools are expected to self-bound (TaskOutput uses
+    # its own ``timeout`` knob; TaskStop uses ``asyncio.wait_for`` inside
+    # its body). A hang here is a tool bug, not something the dispatcher
+    # papers over with a global cap.
+    from src.utils.async_bridge import run_coroutine_blocking
 
-    if running is None:
-        return asyncio.run(fn(input, context))
-
-    # Already inside a loop — schedule on a worker thread to avoid
-    # nesting (Python disallows ``run_until_complete`` on a running
-    # loop). Same pattern as ``task_stop.py``'s async-kill bridge.
-    holder: dict[str, Any] = {}
-    done = threading.Event()
-
-    def _runner() -> None:
-        try:
-            holder["result"] = asyncio.run(fn(input, context))
-        except BaseException as exc:  # noqa: BLE001 — re-raise
-            holder["error"] = exc
-        finally:
-            done.set()
-
-    threading.Thread(
-        target=_runner,
-        daemon=True,
-        name=f"tool-async-bridge:{getattr(tool, 'name', '?')}",
-    ).start()
-    # No timeout on this wait — async tools are expected to self-bound
-    # (TaskOutput uses its own ``timeout`` knob; TaskStop uses
-    # ``asyncio.wait_for(timeout=5.0)`` inside its body). A hung
-    # ``done.wait()`` here is a tool bug, not something the dispatcher
-    # tries to paper over with a global cap. If a future tool grows a
-    # naturally-unbounded await, give it an internal deadline first.
-    done.wait()
-    if "error" in holder:
-        raise holder["error"]  # type: ignore[misc]
-    return holder["result"]  # type: ignore[no-any-return]
+    return run_coroutine_blocking(
+        fn(input, context),
+        thread_name=f"tool-async-bridge:{getattr(tool, 'name', '?')}",
+    )
 
 
 def get_all_base_tools(registry: ToolRegistry) -> Tools:

--- a/src/tool_system/registry.py
+++ b/src/tool_system/registry.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import asyncio
 import inspect
 import logging
-import threading
 from typing import Any, Iterable
 
 from .build_tool import Tool, Tools, tool_matches_name

--- a/src/utils/async_bridge.py
+++ b/src/utils/async_bridge.py
@@ -1,0 +1,57 @@
+"""Run a coroutine to completion from synchronous code, loop or no loop.
+
+Extracted from ``tool_system/registry._invoke_tool_call``'s async-tool bridge
+(HOOKS-1 plan W2) so the permission-ask seam can drive the async hook
+executor with the SAME semantics the dispatcher already uses for async
+tools:
+
+* No running loop in this thread → plain ``asyncio.run``.
+* A loop IS running in this thread → drive the coroutine on a worker
+  thread's own fresh loop (Python disallows nested ``run_until_complete``);
+  block this thread until it finishes. Callers on such threads are already
+  synchronous-by-contract (the registry dispatch path, the permission ask) —
+  the bridge preserves that contract without deadlocking the loop thread's
+  callbacks, which run on the loop, not here.
+
+No timeout by design — mirror the dispatcher's posture: bounded work is the
+coroutine's own job (hook execution carries TOOL_HOOK_EXECUTION_TIMEOUT_MS).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, Coroutine, TypeVar
+
+T = TypeVar("T")
+
+
+def run_coroutine_blocking(
+    coro: Coroutine[Any, Any, T],
+    *,
+    thread_name: str = "async-bridge",
+) -> T:
+    try:
+        running = asyncio.get_running_loop()
+    except RuntimeError:
+        running = None
+
+    if running is None:
+        return asyncio.run(coro)
+
+    holder: dict[str, Any] = {}
+    done = threading.Event()
+
+    def _runner() -> None:
+        try:
+            holder["result"] = asyncio.run(coro)
+        except BaseException as exc:  # noqa: BLE001 — re-raise in the caller
+            holder["error"] = exc
+        finally:
+            done.set()
+
+    threading.Thread(target=_runner, daemon=True, name=thread_name).start()
+    done.wait()
+    if "error" in holder:
+        raise holder["error"]  # type: ignore[misc]
+    return holder["result"]  # type: ignore[no-any-return]

--- a/tests/test_permission_request_hooks.py
+++ b/tests/test_permission_request_hooks.py
@@ -1,0 +1,393 @@
+"""HOOKS-1 — PermissionRequest hook execution + rejection-text fidelity.
+
+Plan: my-docs/get-parity-by-folder/hooks-refactoring-plan.md.
+G1: the "PermissionRequest" event was registered (hook_types.py) but had no
+execution site; it now fires at the single ask choke point
+(`handle_permission_ask`), which BOTH live seams funnel through
+(can_use_tool_adapter + registry.dispatch). Port of
+PermissionContext.runHooks (PermissionContext.ts:216-263) +
+executePermissionRequestHooks (utils/hooks.ts:4392-4427).
+G2: deny texts are the TS constants verbatim with the main-vs-subagent split
+(utils/messages.ts:214-221, cancelAndAbort :154-173) keyed on
+ToolContext.agent_id.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from src.hooks.hook_types import HookConfig, HookSource
+from src.permissions.handler import (
+    REJECT_MESSAGE,
+    REJECT_MESSAGE_WITH_REASON_PREFIX,
+    SUBAGENT_REJECT_MESSAGE,
+    SUBAGENT_REJECT_MESSAGE_WITH_REASON_PREFIX,
+    handle_permission_ask,
+)
+from src.permissions.types import (
+    PermissionAskDecision,
+    PermissionAskReply,
+)
+
+
+class _Snapshot:
+    def __init__(self, configs):
+        self.hooks = {"PermissionRequest": configs}
+
+
+def _ctx(*, configs=None, agent_id=None, tmp: Path = Path("/tmp")):
+    from src.tool_system.context import ToolContext
+
+    ctx = ToolContext(workspace_root=tmp)
+    ctx.workspace_trusted = True
+    if agent_id is not None:
+        ctx.agent_id = agent_id
+    mgr = MagicMock()
+    mgr.snapshot = _Snapshot(list(configs or []))
+    ctx.hook_config_manager = mgr
+    return ctx
+
+
+def _hook(command: str, matcher: str | None = None) -> HookConfig:
+    return HookConfig(
+        type="command",
+        command=command,
+        matcher=matcher,
+        source=HookSource.PROJECT_SETTINGS,
+    )
+
+
+def _echo_json(payload: dict) -> str:
+    return f"echo '{json.dumps(payload)}'"
+
+
+def _ask(message: str = "needs approval") -> PermissionAskDecision:
+    return PermissionAskDecision(behavior="ask", message=message)
+
+
+class _RecordingHandler:
+    def __init__(self, reply: PermissionAskReply):
+        self.reply = reply
+        self.calls: list = []
+
+    def __call__(self, request):
+        self.calls.append(request)
+        return self.reply
+
+
+class TestPermissionRequestHookDecisions(unittest.TestCase):
+    def test_hook_allow_short_circuits_the_handler(self):
+        handler = _RecordingHandler(PermissionAskReply(behavior="deny"))
+        ctx = _ctx(configs=[_hook(_echo_json({"decision": "allow"}))])
+        final, updates = handle_permission_ask(
+            "Write", _ask(), handler, tool_input={"file_path": "x"},
+            context=ctx, tool_use_id="tu-1",
+        )
+        self.assertEqual(final.behavior, "allow")
+        self.assertEqual(updates, ())
+        self.assertEqual(handler.calls, [], "handler must not be consulted")
+        self.assertEqual(final.decision_reason.get("hookName"), "PermissionRequest")
+
+    def test_hook_allow_updated_input_and_permissions(self):
+        payload = {
+            "decision": "allow",
+            "updatedInput": {"file_path": "redirected"},
+            "updatedPermissions": [
+                {"type": "addRules", "behavior": "allow",
+                 "rules": [{"tool_name": "Write"}], "destination": "session"},
+            ],
+        }
+        ctx = _ctx(configs=[_hook(_echo_json(payload))])
+        final, updates = handle_permission_ask(
+            "Write", _ask(), None, tool_input={"file_path": "x"},
+            context=ctx, tool_use_id="tu-1",
+        )
+        self.assertEqual(final.behavior, "allow")
+        self.assertEqual(final.updated_input, {"file_path": "redirected"})
+        self.assertEqual(len(updates), 1)
+        self.assertEqual(type(updates[0]).__name__, "PermissionUpdateAddRules")
+        self.assertEqual(updates[0].rules[0].tool_name, "Write")
+
+    def test_hook_deny_with_message(self):
+        handler = _RecordingHandler(PermissionAskReply(behavior="allow"))
+        ctx = _ctx(configs=[_hook(_echo_json({"decision": "deny", "reason": "policy says no"}))])
+        final, updates = handle_permission_ask(
+            "Bash", _ask(), handler, tool_input={"command": "ls"},
+            context=ctx, tool_use_id="tu-1",
+        )
+        self.assertEqual(final.behavior, "deny")
+        self.assertEqual(final.message, "policy says no")
+        self.assertEqual(handler.calls, [])
+        self.assertEqual(final.decision_reason.get("type"), "hook")
+
+    def test_hook_deny_interrupt_aborts(self):
+        from types import SimpleNamespace
+
+        ctx = _ctx(configs=[_hook(_echo_json({"decision": "deny", "interrupt": True}))])
+        aborts: list = []
+        # A bare MagicMock's ``signal.aborted`` is truthy and the executor
+        # would treat the run as already-aborted — stub a real-shaped one.
+        ctx.abort_controller = SimpleNamespace(
+            signal=SimpleNamespace(aborted=False),
+            abort=lambda *a: aborts.append(a),
+        )
+        final, _ = handle_permission_ask(
+            "Bash", _ask(), None, tool_input={},
+            context=ctx, tool_use_id="tu-1",
+        )
+        self.assertEqual(final.behavior, "deny")
+        self.assertTrue(aborts, "interrupt must abort the turn")
+
+    def test_ts_wire_envelope_form_accepted(self):
+        """A hook written for the reference CLI emits hookSpecificOutput.decision
+        (utils/hooks.ts:833-840) — must work unchanged."""
+        payload = {
+            "hookSpecificOutput": {
+                "hookEventName": "PermissionRequest",
+                "decision": {"behavior": "deny", "message": "envelope says no"},
+            }
+        }
+        ctx = _ctx(configs=[_hook(_echo_json(payload))])
+        final, _ = handle_permission_ask(
+            "Write", _ask(), None, tool_input={}, context=ctx, tool_use_id="t",
+        )
+        self.assertEqual(final.behavior, "deny")
+        self.assertEqual(final.message, "envelope says no")
+
+    def test_no_decision_falls_through_to_handler(self):
+        handler = _RecordingHandler(PermissionAskReply(behavior="allow"))
+        ctx = _ctx(configs=[_hook("echo ''")])  # silent hook = no decision
+        final, _ = handle_permission_ask(
+            "Write", _ask(), handler, tool_input={},
+            context=ctx, tool_use_id="tu-1",
+        )
+        self.assertEqual(final.behavior, "allow")
+        self.assertEqual(len(handler.calls), 1, "normal flow must continue")
+
+    def test_matcher_scopes_by_tool(self):
+        """A Bash-matched hook must not fire for Write (PreToolUse matcher
+        machinery, reused)."""
+        handler = _RecordingHandler(PermissionAskReply(behavior="allow"))
+        ctx = _ctx(configs=[_hook(_echo_json({"decision": "deny"}), matcher="Bash")])
+        final, _ = handle_permission_ask(
+            "Write", _ask(), handler, tool_input={},
+            context=ctx, tool_use_id="tu-1",
+        )
+        self.assertEqual(final.behavior, "allow")
+        self.assertEqual(len(handler.calls), 1)
+
+    def test_hook_failure_falls_through(self):
+        """A crashing hook is contained: exit(1) is a non-blocking error →
+        no decision → normal flow."""
+        handler = _RecordingHandler(PermissionAskReply(behavior="allow"))
+        ctx = _ctx(configs=[_hook("exit 1")])
+        final, _ = handle_permission_ask(
+            "Write", _ask(), handler, tool_input={},
+            context=ctx, tool_use_id="tu-1",
+        )
+        self.assertEqual(final.behavior, "allow")
+        self.assertEqual(len(handler.calls), 1)
+
+    def test_headless_hook_allow_without_handler(self):
+        """Hooks run BEFORE the no-handler fail-closed branch — half their
+        point is resolving asks headless."""
+        ctx = _ctx(configs=[_hook(_echo_json({"decision": "allow"}))])
+        final, _ = handle_permission_ask(
+            "Write", _ask(), None, tool_input={},
+            context=ctx, tool_use_id="tu-1",
+        )
+        self.assertEqual(final.behavior, "allow")
+
+    def test_no_hooks_no_executor_invocation(self):
+        """has_hook_for_event fast path: nothing configured → the executor
+        is never constructed (pinned via import-time marker)."""
+        import src.permissions.handler as handler_mod
+
+        calls: list = []
+        original = handler_mod._run_permission_request_hooks
+
+        def _marker(*args, **kwargs):
+            calls.append(args)
+            return original(*args, **kwargs)
+
+        handler_mod._run_permission_request_hooks = _marker
+        try:
+            ctx = _ctx(configs=[])
+            handler = _RecordingHandler(PermissionAskReply(behavior="allow"))
+            final, _ = handle_permission_ask(
+                "Write", _ask(), handler, tool_input={},
+                context=ctx, tool_use_id="tu-1",
+            )
+            self.assertEqual(final.behavior, "allow")
+            # _run... is called but exits on has_hook_for_event without
+            # constructing the executor; behavior identical.
+            self.assertEqual(len(calls), 1)
+        finally:
+            handler_mod._run_permission_request_hooks = original
+
+    def test_backward_compatible_without_context(self):
+        """Old call shape (no context) still works — no hooks, generic flow."""
+        handler = _RecordingHandler(PermissionAskReply(behavior="allow"))
+        final, _ = handle_permission_ask("Write", _ask(), handler, tool_input={})
+        self.assertEqual(final.behavior, "allow")
+
+
+class TestChokePointCoverage(unittest.TestCase):
+    """Both live seams route the hook (the single-choke-point claim)."""
+
+    def test_registry_dispatch_ask_short_circuited_by_hook(self):
+        from src.tool_system.build_tool import build_tool
+        from src.tool_system.protocol import ToolCall, ToolResult
+        from src.tool_system.registry import ToolRegistry
+        from src.permissions.types import (
+            PermissionAskDecision as Ask,
+            PermissionPassthroughResult,
+        )
+
+        def _check(tool_input, context):
+            return Ask(behavior="ask", message="approve?")
+
+        asked_tool = build_tool(
+            name="AskyTool",
+            input_schema={"type": "object", "properties": {}, "additionalProperties": True},
+            call=lambda i, c: ToolResult(name="AskyTool", output="RAN"),
+            prompt="p", description="d",
+            check_permissions=_check,
+        )
+        reg = ToolRegistry()
+        reg.register(asked_tool)
+
+        ctx = _ctx(configs=[_hook(_echo_json({"decision": "allow"}))])
+        ctx.permission_handler = None  # would fail closed without the hook
+        result = reg.dispatch(ToolCall(name="AskyTool", input={}), ctx)
+        self.assertFalse(result.is_error, result.output)
+        self.assertEqual(result.output, "RAN")
+
+    def test_adapter_ask_short_circuited_by_hook(self):
+        from src.services.tool_execution.can_use_tool_adapter import build_can_use_tool
+        from src.tool_system.build_tool import build_tool
+        from src.tool_system.protocol import ToolResult
+        from src.permissions.types import PermissionAskDecision as Ask
+
+        def _check(tool_input, context):
+            return Ask(behavior="ask", message="approve?")
+
+        asked_tool = build_tool(
+            name="AskyTool",
+            input_schema={"type": "object", "properties": {}, "additionalProperties": True},
+            call=lambda i, c: ToolResult(name="AskyTool", output="RAN"),
+            prompt="p", description="d",
+            check_permissions=_check,
+        )
+        ctx = _ctx(configs=[_hook(_echo_json({"decision": "allow"}))])
+        ctx.permission_handler = None
+        can_use = build_can_use_tool(ctx)
+        outcome = can_use(asked_tool, {}, None, None, "tu-9")
+        self.assertEqual(outcome.get("behavior"), "allow", outcome)
+
+
+class TestRejectionTexts(unittest.TestCase):
+    """G2 — the TS constants verbatim + the main/subagent split."""
+
+    def _deny(self, feedback: str | None, agent_id: str | None):
+        handler = _RecordingHandler(
+            PermissionAskReply(behavior="deny", message=feedback)
+        )
+        ctx = _ctx(configs=[], agent_id=agent_id)
+        final, _ = handle_permission_ask(
+            "Write", _ask(), handler, tool_input={},
+            context=ctx, tool_use_id="tu-1",
+        )
+        return final
+
+    def test_main_agent_bare_reject(self):
+        final = self._deny(None, None)
+        self.assertEqual(final.message, REJECT_MESSAGE)
+        self.assertIn("STOP what you are doing", final.message)
+
+    def test_main_agent_with_feedback(self):
+        final = self._deny("use the API instead", None)
+        self.assertEqual(
+            final.message,
+            REJECT_MESSAGE_WITH_REASON_PREFIX + "use the API instead",
+        )
+
+    def test_subagent_bare_reject(self):
+        final = self._deny(None, "a1b2c3")
+        self.assertEqual(final.message, SUBAGENT_REJECT_MESSAGE)
+        self.assertIn("Try a different approach", final.message)
+
+    def test_subagent_with_feedback(self):
+        final = self._deny("out of scope", "a1b2c3")
+        self.assertEqual(
+            final.message,
+            SUBAGENT_REJECT_MESSAGE_WITH_REASON_PREFIX + "out of scope",
+        )
+
+    def test_no_handler_message_not_conflated(self):
+        """The no-handler fail-closed branch keeps its distinct message —
+        it is not a user rejection."""
+        final, _ = handle_permission_ask(
+            "Write", _ask("ask msg"), None, tool_input={},
+            context=_ctx(configs=[]), tool_use_id="tu-1",
+        )
+        self.assertEqual(final.behavior, "deny")
+        self.assertNotIn("STOP what you are doing", final.message)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestConfigLoaderEndToEnd(unittest.TestCase):
+    """A real settings-file-configured PermissionRequest hook fires through
+    the ch01 config loader (HookConfigManager.load), not an injected
+    snapshot — the full user-facing path."""
+
+    def test_settings_configured_hook_denies(self):
+        import asyncio
+        import tempfile
+
+        from src.hooks.config_manager import HookConfigManager
+        from src.hooks.registry import AsyncHookRegistry
+        from src.tool_system.context import ToolContext
+
+        tmp = Path(tempfile.mkdtemp())
+        settings = tmp / "settings.json"
+        settings.write_text(json.dumps({
+            "hooks": {
+                "PermissionRequest": [
+                    {
+                        "matcher": "Write",
+                        "hooks": [
+                            {"type": "command",
+                             "command": "echo '{\"decision\": \"deny\", \"reason\": \"settings hook says no\"}'"}
+                        ],
+                    }
+                ]
+            }
+        }), encoding="utf-8")
+
+        mgr = HookConfigManager(AsyncHookRegistry(), settings_path=settings)
+        asyncio.run(mgr.load())
+
+        ctx = ToolContext(workspace_root=tmp)
+        ctx.workspace_trusted = True
+        ctx.hook_config_manager = mgr
+
+        final, _ = handle_permission_ask(
+            "Write", _ask(), None, tool_input={"file_path": "x"},
+            context=ctx, tool_use_id="tu-e2e",
+        )
+        self.assertEqual(final.behavior, "deny")
+        self.assertEqual(final.message, "settings hook says no")
+
+        # And the matcher scopes: a Read ask sails past this Write hook
+        # (falls to the no-handler branch, whose message is distinct).
+        final2, _ = handle_permission_ask(
+            "Read", _ask(), None, tool_input={"file_path": "x"},
+            context=ctx, tool_use_id="tu-e2e2",
+        )
+        self.assertNotEqual(final2.message, "settings hook says no")

--- a/tests/test_permission_request_hooks.py
+++ b/tests/test_permission_request_hooks.py
@@ -88,7 +88,7 @@ class TestPermissionRequestHookDecisions(unittest.TestCase):
         self.assertEqual(final.behavior, "allow")
         self.assertEqual(updates, ())
         self.assertEqual(handler.calls, [], "handler must not be consulted")
-        self.assertEqual(final.decision_reason.get("hookName"), "PermissionRequest")
+        self.assertEqual(final.decision_reason.hook_name, "PermissionRequest")
 
     def test_hook_allow_updated_input_and_permissions(self):
         payload = {
@@ -120,7 +120,7 @@ class TestPermissionRequestHookDecisions(unittest.TestCase):
         self.assertEqual(final.behavior, "deny")
         self.assertEqual(final.message, "policy says no")
         self.assertEqual(handler.calls, [])
-        self.assertEqual(final.decision_reason.get("type"), "hook")
+        self.assertEqual(final.decision_reason.type, "hook")
 
     def test_hook_deny_interrupt_aborts(self):
         from types import SimpleNamespace
@@ -337,8 +337,6 @@ class TestRejectionTexts(unittest.TestCase):
         self.assertNotIn("STOP what you are doing", final.message)
 
 
-if __name__ == "__main__":
-    unittest.main()
 
 
 class TestConfigLoaderEndToEnd(unittest.TestCase):
@@ -391,3 +389,66 @@ class TestConfigLoaderEndToEnd(unittest.TestCase):
             context=ctx, tool_use_id="tu-e2e2",
         )
         self.assertNotEqual(final2.message, "settings hook says no")
+
+class TestSuggestionSerializationReadBack(unittest.TestCase):
+    """The MAJOR's proof: hooks receive suggestions as canonical wire JSON
+    (nested rules as {"tool_name","rule_content"} dicts), never Python
+    reprs. The hook echoes its stdin back through the deny reason."""
+
+    def test_hook_sees_canonical_suggestion_json(self):
+        from src.permissions.types import (
+            PermissionRuleValue,
+            PermissionUpdateAddRules,
+        )
+
+        suggestion = PermissionUpdateAddRules(
+            destination="session",
+            behavior="allow",
+            rules=(PermissionRuleValue(tool_name="Bash", rule_content="ls:*"),),
+        )
+        echo_stdin = (
+            "python3 -c 'import sys, json; d = json.load(sys.stdin); "
+            "print(json.dumps({\"decision\": \"deny\", "
+            "\"reason\": json.dumps(d.get(\"permission_suggestions\"))}))'"
+        )
+        ctx = _ctx(configs=[_hook(echo_stdin)])
+        ask = PermissionAskDecision(
+            behavior="ask", message="approve?", suggestions=(suggestion,),
+        )
+        final, _ = handle_permission_ask(
+            "Bash", ask, None, tool_input={"command": "ls"},
+            context=ctx, tool_use_id="tu-sj",
+        )
+        self.assertEqual(final.behavior, "deny")
+        received = json.loads(final.message)
+        self.assertEqual(received, [{
+            "type": "addRules",
+            "destination": "session",
+            "behavior": "allow",
+            "rules": [{"tool_name": "Bash", "rule_content": "ls:*"}],
+        }])
+        self.assertNotIn("PermissionRuleValue", final.message)
+
+
+class TestMultiHookFirstDecisiveWins(unittest.TestCase):
+    """TS runHooks returns on the first decisive result, abandoning later
+    hooks — they must NOT execute (side-effect proof)."""
+
+    def test_second_hook_never_executes(self):
+        import tempfile
+
+        marker = Path(tempfile.mkdtemp()) / "second-ran"
+        first = _hook(_echo_json({"decision": "deny", "reason": "first wins"}))
+        second = _hook(f"touch {marker} && " + _echo_json({"decision": "allow"}))
+        ctx = _ctx(configs=[first, second])
+        final, _ = handle_permission_ask(
+            "Write", _ask(), None, tool_input={},
+            context=ctx, tool_use_id="tu-mh",
+        )
+        self.assertEqual(final.behavior, "deny")
+        self.assertEqual(final.message, "first wins")
+        self.assertFalse(marker.exists(), "later hooks must be abandoned")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -201,7 +201,11 @@ class TestToolRegistryDispatchPermissions(unittest.TestCase):
         )
 
         self.assertTrue(result.is_error)
-        self.assertIn("denied", result.output.get("error", "").lower())
+        # HOOKS-1 G2: bare user denial now carries the TS-verbatim
+        # instructive REJECT_MESSAGE (utils/messages.ts:214).
+        from src.permissions.handler import REJECT_MESSAGE
+
+        self.assertEqual(result.output.get("error"), REJECT_MESSAGE)
 
     def test_dispatch_deny_feedback_reaches_error(self) -> None:
         from src.permissions.types import PermissionAskReply

--- a/tests/test_tool_registry_pipeline.py
+++ b/tests/test_tool_registry_pipeline.py
@@ -174,7 +174,11 @@ class TestRegistryDispatch(unittest.TestCase):
         ctx.permission_handler = lambda request: PermissionAskReply(behavior="deny")
         result = reg.dispatch(ToolCall(name="NeedApproval", input={}), ctx)
         self.assertTrue(result.is_error)
-        self.assertIn("denied", result.output["error"])
+        # HOOKS-1 G2: the TS-verbatim REJECT_MESSAGE replaced the generic
+        # "denied" text (utils/messages.ts:214).
+        from src.permissions.handler import REJECT_MESSAGE
+
+        self.assertEqual(result.output["error"], REJECT_MESSAGE)
 
 
 class TestPipelineFunctions(unittest.TestCase):


### PR DESCRIPTION
## Summary

`hooks/` parity phase HOOKS-1 (after `grpc/`+`proto/`): the folder is the ink-REPL's React-hook layer (88 files), dispositioned per-file in the gap analysis — most N-A for this port's architecture (the kept hermes ui-tui client) or already ported in earlier rounds. The two real, verified gaps both live at the permission-ask seam and ship here:

**G1 — PermissionRequest hooks were registered but never executed.** The hook event sat in `hook_types.py` with zero fire sites — the same registered-but-inert class round-4 ch01 fixed for PreToolUse/PostToolUse. They now run at the single ask choke point (`handle_permission_ask`, which both live seams funnel through: the query-loop `can_use_tool_adapter` and `registry.dispatch`), BEFORE any prompt and BEFORE the no-handler fail-closed branch — so a configured hook can resolve permission asks headless. Port of `PermissionContext.runHooks` (PermissionContext.ts:216-263) + `executePermissionRequestHooks` (utils/hooks.ts:4392-4427): first decisive hook wins — allow (optional `updatedInput` + `updatedPermissions` → applied/persisted via the same updates path as dialog choices) or deny (message; optional `interrupt` aborts the turn via the context's abort controller). Hook failures are contained. Both output forms accepted: the flat schema (this port's documented convention) and the TS wire envelope `hookSpecificOutput.decision`, so hooks written for the reference CLI work unchanged.

**G2 — rejection texts the model can act on.** User denials now carry the TS-verbatim instructive texts (utils/messages.ts:214-221) with the main-agent vs subagent split (`cancelAndAbort`, keyed on `ToolContext.agent_id`): "…the new_string was NOT written… STOP and wait…" vs "…Try a different approach or report the limitation…", plus the with-reason prefix variants carrying the user's typed feedback. (`withMemoryCorrectionHint` not ported — GrowthBook-default-off upstream.)

Supporting refactors: `run_coroutine_blocking` extracted to `utils/async_bridge` (the registry's run-or-thread bridge, now shared by the ask seam); the `serialize_permission_update`/`deserialize_permission_update` PAIR promoted from the agent-server to `permissions/updates.py` (one canonical wire shape for can_use_tool replies AND hook stdin/updatedPermissions — the critic's MAJOR caught the first cut handing hooks repr-stringified rule objects); the adapter's unused `_tool_use_id` param threaded.

Critic-round hardening: first-decisive short-circuit (later hooks are ABANDONED mid-generator, TS runHooks parity — side-effect-proven by test); `HookDecisionReason` typed dataclass for the decision reason; documented sequential-vs-race divergence (TS races the hook against the open dialog; this port runs hooks before prompting, bounded by the executor's per-hook timeout — the deliberate choice for the wire round-trip architecture).

Docs (critic loop per the sweep cadence): `my-docs/get-parity-by-folder/hooks-{gap-analysis,refactoring-plan}.md` — full per-file disposition incl. the `notifs/` + `toolPermission/` subfolders and the ~80 top-level hooks (ported / ink-UI N-A / defer-with-owner), with the stop-line (classifier-race UX, unified suggestions, bridge/channel relays, etc.).

## Verification

- `tests/test_permission_request_hooks.py` **21/21**: decision matrix (allow / deny / updatedInput / updatedPermissions / interrupt / TS-envelope form), matcher scoping, failure containment, headless hook-allow, no-hooks fast path, backward-compatible signature, BOTH choke-point seams end-to-end (registry dispatch + adapter), the four rejection-text pins + subagent split + no-handler distinctness, a real settings-file → `HookConfigManager.load` → decision end-to-end, the suggestion-JSON read-back (a hook echoes its stdin — asserts the canonical dict shape, no Python reprs), and multi-hook first-decisive abandonment.
- Adjacent suites green; full suite at the 6-failure baseline (**7745 passed**); two pre-existing deny-text pins updated to the new constants.
- Critic loop: gap doc APPROVE (survey-cross-checked, incl. two self-corrections + the cron/voice functional-break dispositions); plan + implementation REVISE→fixed (1 MAJOR: suggestion serialization; minors: first-decisive parity, typed reason, test placement, dead imports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
