### PR TITLE
feat(providers): live model discovery for dynamic-catalog providers (INTEG-1)

### DIFF
--- a/src/providers/model_discovery.py
+++ b/src/providers/model_discovery.py
@@ -1,0 +1,227 @@
+"""Live model discovery for dynamic-catalog providers.
+
+INTEG-1 (integrations-folder parity) — the port of
+``typescript/src/integrations/discoveryService.ts`` + ``discoveryCache.ts``:
+providers whose model lists cannot be known statically (ollama's installed
+models are machine-local; vLLM/SGLang serve whatever was launched;
+OpenRouter's hosted list churns) get their lists from the endpoint itself,
+merged over the static registry list, with a persistent TTL cache.
+
+Non-blocking contract (deliberate divergence from TS's blocking
+fetch-with-TTL, documented in the plan): ``discovered_models`` returns
+IMMEDIATELY — fresh-cache ∪ static, or static alone — and refreshes a
+stale/missing entry on a single-flight background thread so the NEXT call
+is fresh. ``get_available_models()`` sits on the agent-server's control
+paths (init/list replies); a blocking network call there would stall the
+client whenever a local endpoint is down. Cost: the first-ever call on a
+cold cache shows the static list once.
+
+Failures never propagate: fetch/parse/cache errors degrade to
+stale-or-static (the TS error path's behavior).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+import threading
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+CACHE_VERSION = 1
+DISCOVERY_TTL_S = 86_400  # 1 day — TS gateways/ollama.ts discoveryCacheTtl '1d'
+FETCH_TIMEOUT_S = 2.0
+
+_refresh_locks_guard = threading.Lock()
+_refresh_in_flight: set[str] = set()
+
+
+def _cache_path() -> Path:
+    # This port's config home (settings-paths canon uses ~/.clawcodex).
+    return Path(os.path.expanduser("~/.clawcodex")) / "model-discovery-cache.json"
+
+
+def _cache_key(provider_id: str, base_url: str) -> str:
+    digest = hashlib.sha1((base_url or "").encode("utf-8")).hexdigest()[:12]
+    return f"{provider_id}:{digest}"
+
+
+def _read_cache() -> dict[str, Any]:
+    """The entries map; corrupt/missing/wrong-version files are empty, never
+    an error (discoveryCache's tolerance)."""
+    try:
+        raw = json.loads(_cache_path().read_text(encoding="utf-8"))
+        if isinstance(raw, dict) and raw.get("version") == CACHE_VERSION:
+            entries = raw.get("entries")
+            if isinstance(entries, dict):
+                return entries
+    except Exception:  # noqa: BLE001
+        pass
+    return {}
+
+
+def _write_cache(entries: dict[str, Any]) -> None:
+    """Atomic write (tempfile + os.replace in the same dir) so concurrent
+    readers always see valid JSON — the discoveryCache pattern."""
+    try:
+        path = _cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps({"version": CACHE_VERSION, "entries": entries})
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".model-discovery-")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(payload)
+            os.replace(tmp, path)
+        finally:
+            if os.path.exists(tmp):
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+    except Exception:  # noqa: BLE001 — cache persistence is best-effort
+        logger.debug("model discovery: cache write failed", exc_info=True)
+
+
+def _http_get_json(url: str, *, api_key: str | None, timeout: float) -> Any:
+    request = urllib.request.Request(url)
+    if api_key:
+        request.add_header("Authorization", f"Bearer {api_key}")
+    with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310 — provider endpoint the user configured
+        return json.loads(response.read().decode("utf-8", errors="replace"))
+
+
+def fetch_openai_compatible_models(
+    base_url: str, api_key: str | None = None, *, timeout: float = FETCH_TIMEOUT_S,
+) -> list[str] | None:
+    """GET {base}/models → data[].id (the fetchOpenAICompatibleModelsRaw
+    analog). None on any failure."""
+    try:
+        payload = _http_get_json(
+            base_url.rstrip("/") + "/models", api_key=api_key, timeout=timeout,
+        )
+        data = payload.get("data") if isinstance(payload, dict) else None
+        if not isinstance(data, list):
+            return None
+        models = [
+            str(item["id"]) for item in data
+            if isinstance(item, dict) and item.get("id")
+        ]
+        return models or None
+    except Exception:  # noqa: BLE001
+        logger.debug("model discovery: openai-compatible fetch failed for %s", base_url, exc_info=True)
+        return None
+
+
+def fetch_ollama_models(
+    base_url: str, *, timeout: float = FETCH_TIMEOUT_S,
+) -> list[str] | None:
+    """GET {root}/api/tags → models[].name. The registry's ollama base URL
+    ends in ``/v1`` (the OpenAI-compat surface); tags lives at the server
+    ROOT, so a trailing /v1 is stripped."""
+    root = base_url.rstrip("/")
+    if root.endswith("/v1"):
+        root = root[: -len("/v1")]
+    try:
+        payload = _http_get_json(root + "/api/tags", api_key=None, timeout=timeout)
+        models_raw = payload.get("models") if isinstance(payload, dict) else None
+        if not isinstance(models_raw, list):
+            return None
+        models = [
+            str(item["name"]) for item in models_raw
+            if isinstance(item, dict) and item.get("name")
+        ]
+        return models or None
+    except Exception:  # noqa: BLE001
+        logger.debug("model discovery: ollama tags fetch failed for %s", base_url, exc_info=True)
+        return None
+
+
+def _fetch_for_kind(
+    kind: str, base_url: str, api_key: str | None, timeout: float,
+) -> list[str] | None:
+    if kind == "ollama":
+        return fetch_ollama_models(base_url, timeout=timeout)
+    if kind == "openai-compatible":
+        return fetch_openai_compatible_models(base_url, api_key, timeout=timeout)
+    return None
+
+
+def _merge(discovered: list[str] | None, static_models: list[str]) -> list[str]:
+    """discovered ∪ static, discovered first, deduped — and NEVER empty when
+    the static list has entries (the no-empty-picker guarantee)."""
+    seen: set[str] = set()
+    merged: list[str] = []
+    for name in (discovered or []) + list(static_models):
+        if name not in seen:
+            seen.add(name)
+            merged.append(name)
+    return merged
+
+
+def _refresh(
+    key: str, kind: str, base_url: str, api_key: str | None, timeout: float,
+) -> None:
+    try:
+        discovered = _fetch_for_kind(kind, base_url, api_key, timeout)
+        if discovered:
+            entries = _read_cache()
+            entries[key] = {"models": discovered, "fetched_at": time.time()}
+            _write_cache(entries)
+    finally:
+        with _refresh_locks_guard:
+            _refresh_in_flight.discard(key)
+
+
+def discovered_models(
+    provider_id: str,
+    base_url: str,
+    api_key: str | None,
+    kind: str,
+    static_models: tuple[str, ...] | list[str],
+    *,
+    ttl_s: float = DISCOVERY_TTL_S,
+    timeout: float = FETCH_TIMEOUT_S,
+    background: bool = True,
+) -> list[str]:
+    """The non-blocking entry point (module docstring). ``background=False``
+    forces a synchronous refresh — for tests and explicit-refresh callers."""
+    static_list = list(static_models)
+    if not base_url:
+        return static_list
+
+    key = _cache_key(provider_id, base_url)
+    entries = _read_cache()
+    entry = entries.get(key)
+    fresh = (
+        isinstance(entry, dict)
+        and isinstance(entry.get("models"), list)
+        and (time.time() - float(entry.get("fetched_at", 0))) < ttl_s
+    )
+
+    if not fresh:
+        with _refresh_locks_guard:
+            already = key in _refresh_in_flight
+            if not already:
+                _refresh_in_flight.add(key)
+        if not already:
+            if background:
+                threading.Thread(
+                    target=_refresh,
+                    args=(key, kind, base_url, api_key, timeout),
+                    daemon=True,
+                    name=f"model-discovery:{provider_id}",
+                ).start()
+            else:
+                _refresh(key, kind, base_url, api_key, timeout)
+                entries = _read_cache()
+                entry = entries.get(key)
+
+    cached = entry.get("models") if isinstance(entry, dict) else None
+    return _merge(cached if isinstance(cached, list) else None, static_list)

--- a/src/providers/model_discovery.py
+++ b/src/providers/model_discovery.py
@@ -41,11 +41,21 @@ FETCH_TIMEOUT_S = 2.0
 
 _refresh_locks_guard = threading.Lock()
 _refresh_in_flight: set[str] = set()
+# Serializes the cache read-modify-write in _refresh (critic round: the
+# in-flight guard alone left a cross-KEY lost-update window — two providers
+# refreshing concurrently could clobber each other's entry; TS serializes
+# via withDiscoveryCacheLock). In-process only; a cross-process race
+# self-heals (one refetch).
+_cache_write_lock = threading.Lock()
 
 
 def _cache_path() -> Path:
-    # This port's config home (settings-paths canon uses ~/.clawcodex).
-    return Path(os.path.expanduser("~/.clawcodex")) / "model-discovery-cache.json"
+    """Under the canonical config home (critic round: reuse
+    config.GLOBAL_CONFIG_DIR — test fixtures re-point it — instead of a
+    hardcoded ~/.clawcodex)."""
+    from src.config import GLOBAL_CONFIG_DIR
+
+    return Path(GLOBAL_CONFIG_DIR) / "model-discovery-cache.json"
 
 
 def _cache_key(provider_id: str, base_url: str) -> str:
@@ -153,14 +163,29 @@ def _fetch_for_kind(
     return None
 
 
-def _merge(discovered: list[str] | None, static_models: list[str]) -> list[str]:
-    """discovered ∪ static, discovered first, deduped — and NEVER empty when
-    the static list has entries (the no-empty-picker guarantee)."""
-    seen: set[str] = set()
-    merged: list[str] = []
-    for name in (discovered or []) + list(static_models):
-        if name not in seen:
-            seen.add(name)
+def _merge(
+    discovered: list[str] | None, static_models: list[str], mode: str,
+) -> list[str]:
+    """The two TS catalog-source semantics (critic MAJOR — a single
+    discovered-first union defeated both target providers):
+
+    * ``dynamic`` (ollama/vllm/sglang; gateways/ollama.ts source:'dynamic'):
+      the endpoint is the truth — discovered REPLACES static when non-empty;
+      static is only the no-discovery fallback. This is what actually kills
+      the bogus ``deepseek-coder:1.3b`` stub once a real list arrives.
+    * ``hybrid`` (openrouter; gateways/openrouter.ts source:'hybrid'):
+      STATIC-first merge, discovered appended case-insensitively deduped
+      (discoveryService.ts:194-212 mergeCatalogEntries) — curation keeps its
+      order; the live tail extends it.
+    """
+    discovered_list = discovered or []
+    if mode == "dynamic":
+        return list(discovered_list) if discovered_list else list(static_models)
+    merged = list(static_models)
+    seen = {name.lower() for name in merged}
+    for name in discovered_list:
+        if name.lower() not in seen:
+            seen.add(name.lower())
             merged.append(name)
     return merged
 
@@ -171,9 +196,10 @@ def _refresh(
     try:
         discovered = _fetch_for_kind(kind, base_url, api_key, timeout)
         if discovered:
-            entries = _read_cache()
-            entries[key] = {"models": discovered, "fetched_at": time.time()}
-            _write_cache(entries)
+            with _cache_write_lock:
+                entries = _read_cache()
+                entries[key] = {"models": discovered, "fetched_at": time.time()}
+                _write_cache(entries)
     finally:
         with _refresh_locks_guard:
             _refresh_in_flight.discard(key)
@@ -186,12 +212,16 @@ def discovered_models(
     kind: str,
     static_models: tuple[str, ...] | list[str],
     *,
+    mode: str = "dynamic",
     ttl_s: float = DISCOVERY_TTL_S,
     timeout: float = FETCH_TIMEOUT_S,
     background: bool = True,
 ) -> list[str]:
-    """The non-blocking entry point (module docstring). ``background=False``
-    forces a synchronous refresh — for tests and explicit-refresh callers."""
+    """The non-blocking entry point (module docstring). ``mode`` selects the
+    catalog-source semantics (see ``_merge``): "dynamic" (default —
+    endpoint-authoritative) or "hybrid" (curated-static-first).
+    ``background=False`` forces a synchronous refresh — for tests and
+    explicit-refresh callers."""
     static_list = list(static_models)
     if not base_url:
         return static_list
@@ -224,4 +254,4 @@ def discovered_models(
                 entry = entries.get(key)
 
     cached = entry.get("models") if isinstance(entry, dict) else None
-    return _merge(cached if isinstance(cached, list) else None, static_list)
+    return _merge(cached if isinstance(cached, list) else None, static_list, mode)

--- a/src/providers/openai_compatible_specs.py
+++ b/src/providers/openai_compatible_specs.py
@@ -65,6 +65,11 @@ class ProviderSpec:
     #: Whether a key is mandatory. ``False`` for local servers (Ollama, vLLM,
     #: SGLang) that accept any/no token — these stay usable without ``login``.
     requires_api_key: bool = True
+    #: INTEG-1 — dynamic-catalog kind ("ollama" | "openai-compatible") for
+    #: providers whose real model list lives on the endpoint (local servers,
+    #: churning hosted catalogs). None = static list only. See
+    #: src/providers/model_discovery.py (the discoveryService port).
+    dynamic_catalog: str | None = None
     #: Generated subclass name (for repr / debugging). Derived from ``id`` when
     #: omitted.
     class_name: str = ""
@@ -224,6 +229,7 @@ _SPECS: tuple[ProviderSpec, ...] = (
     ),
     ProviderSpec(
         id="sglang",
+        dynamic_catalog="openai-compatible",
         label="SGLang (local)",
         default_base_url="http://localhost:30000/v1",
         default_model="deepseek-ai/DeepSeek-V4-Pro",
@@ -237,6 +243,7 @@ _SPECS: tuple[ProviderSpec, ...] = (
     ),
     ProviderSpec(
         id="vllm",
+        dynamic_catalog="openai-compatible",
         label="vLLM (local)",
         default_base_url="http://localhost:8000/v1",
         default_model="deepseek-ai/DeepSeek-V4-Pro",
@@ -250,6 +257,7 @@ _SPECS: tuple[ProviderSpec, ...] = (
     ),
     ProviderSpec(
         id="ollama",
+        dynamic_catalog="ollama",
         label="Ollama (local)",
         default_base_url="http://localhost:11434/v1",
         default_model="deepseek-coder:1.3b",
@@ -363,7 +371,21 @@ class _SpecOpenAICompatibleProvider(OpenAICompatibleProvider):
         return OpenAI(**kwargs)
 
     def get_available_models(self) -> list[str]:
-        return list(self.SPEC.available_models)
+        spec = self.SPEC
+        if spec.dynamic_catalog is None:
+            return list(spec.available_models)
+        # Dynamic catalog (INTEG-1): endpoint-discovered ∪ static, via the
+        # non-blocking TTL cache — never blocks the caller, never returns
+        # empty when the static list has entries.
+        from src.providers.model_discovery import discovered_models
+
+        return discovered_models(
+            spec.id,
+            getattr(self, "base_url", None) or spec.default_base_url,
+            getattr(self, "api_key", None) or None,
+            spec.dynamic_catalog,
+            spec.available_models,
+        )
 
 
 # Generated subclasses are cached so repeated lookups return the same class

--- a/src/providers/openrouter_provider.py
+++ b/src/providers/openrouter_provider.py
@@ -81,6 +81,7 @@ class OpenRouterProvider(OpenAICompatibleProvider):
             getattr(self, "api_key", None) or None,
             "openai-compatible",
             self._curated_models(),
+            mode="hybrid",  # gateways/openrouter.ts source:'hybrid' — curation first
         )
 
     @staticmethod

--- a/src/providers/openrouter_provider.py
+++ b/src/providers/openrouter_provider.py
@@ -66,11 +66,25 @@ class OpenRouterProvider(OpenAICompatibleProvider):
         return OpenAI(**kwargs)
 
     def get_available_models(self) -> list[str]:
-        """Return a curated list of popular OpenRouter model IDs.
+        """Curated popular OpenRouter model IDs ∪ the endpoint's live list.
 
-        OpenRouter supports hundreds of models; this list is a starting point —
-        any valid ``vendor/model`` ID accepted by OpenRouter can be used.
+        OpenRouter's hosted catalog churns weekly (INTEG-1): the live list is
+        discovered via the non-blocking TTL cache and merged over this
+        curated starting point; any valid ``vendor/model`` ID is accepted
+        regardless.
         """
+        from src.providers.model_discovery import discovered_models
+
+        return discovered_models(
+            "openrouter",
+            getattr(self, "base_url", None) or "https://openrouter.ai/api/v1",
+            getattr(self, "api_key", None) or None,
+            "openai-compatible",
+            self._curated_models(),
+        )
+
+    @staticmethod
+    def _curated_models() -> list[str]:
         return [
             # DeepSeek V4 (latest, strongest — top of the list)
             "deepseek/deepseek-v4-pro",

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -818,6 +818,19 @@ class _AgentSession:
             # self.provider_name, updated above, so on_change persists the
             # new pairing.
             _dispatch_app_state(self, main_loop_model=model)
+            # INTEG-1 warm-on-activation (the refreshStartupDiscoveryForActiveRoute
+            # analog, discoveryService.ts:415): one non-blocking
+            # get_available_models call kicks the single-flight background
+            # refresh at SWITCH time, so the picker's later read sees the
+            # discovered list instead of the static stub. (Server init warms
+            # the initial provider the same way via get_settings →
+            # _available_models.)
+            try:
+                warm = getattr(provider, "get_available_models", None)
+                if callable(warm):
+                    warm()
+            except Exception:  # noqa: BLE001 — warm is best-effort
+                logger.debug("[agent-server] discovery warm failed", exc_info=True)
             self._reply(request_id, {"ok": True, "provider": name, "model": model or ""})
         except Exception as exc:  # noqa: BLE001
             logger.exception("[agent-server] set_provider failed")

--- a/tests/providers/test_model_discovery.py
+++ b/tests/providers/test_model_discovery.py
@@ -1,0 +1,213 @@
+"""INTEG-1 — live model discovery (port of discoveryService/discoveryCache).
+
+Plan: my-docs/get-parity-by-folder/integrations-refactoring-plan.md.
+The contract under test: non-blocking (cache-or-static immediately +
+single-flight background refresh), never-empty merge, corruption-tolerant
+atomic cache, and the spec/openrouter wiring.
+"""
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+import src.providers.model_discovery as md
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(md, "_cache_path", lambda: tmp_path / "cache.json")
+    # Reset single-flight state between tests.
+    with md._refresh_locks_guard:
+        md._refresh_in_flight.clear()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Parsers
+# ---------------------------------------------------------------------------
+
+
+def test_openai_compatible_parser(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        md, "_http_get_json",
+        lambda url, *, api_key, timeout: {"data": [{"id": "m1"}, {"id": "m2"}, {"bad": 1}]},
+    )
+    assert md.fetch_openai_compatible_models("http://x/v1") == ["m1", "m2"]
+
+
+def test_openai_compatible_parser_malformed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(md, "_http_get_json", lambda url, *, api_key, timeout: {"nope": 1})
+    assert md.fetch_openai_compatible_models("http://x/v1") is None
+
+
+def test_ollama_parser_strips_v1(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str] = []
+
+    def _fake(url, *, api_key, timeout):
+        seen.append(url)
+        return {"models": [{"name": "llama3:8b"}, {"name": "qwen3:4b"}]}
+
+    monkeypatch.setattr(md, "_http_get_json", _fake)
+    models = md.fetch_ollama_models("http://localhost:11434/v1")
+    assert models == ["llama3:8b", "qwen3:4b"]
+    # /api/tags lives at the server ROOT — the /v1 surface must be stripped.
+    assert seen == ["http://localhost:11434/api/tags"]
+
+
+def test_fetch_errors_return_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(url, *, api_key, timeout):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(md, "_http_get_json", _boom)
+    assert md.fetch_openai_compatible_models("http://x/v1") is None
+    assert md.fetch_ollama_models("http://x/v1") is None
+
+
+# ---------------------------------------------------------------------------
+# Cache
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_cache_is_served_without_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    key = md._cache_key("ollama", "http://x/v1")
+    md._write_cache({key: {"models": ["cached:1"], "fetched_at": time.time()}})
+    fetches: list = []
+    monkeypatch.setattr(md, "_fetch_for_kind", lambda *a: fetches.append(a) or ["live"])
+    out = md.discovered_models("ollama", "http://x/v1", None, "ollama", ("static:1",))
+    assert out == ["cached:1", "static:1"]
+    assert fetches == [], "fresh cache must not trigger a fetch"
+
+
+def test_stale_cache_refreshes_and_next_call_is_fresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = md._cache_key("ollama", "http://x/v1")
+    md._write_cache({key: {"models": ["old:1"], "fetched_at": time.time() - 999_999}})
+    monkeypatch.setattr(md, "_fetch_for_kind", lambda *a: ["new:1"])
+    first = md.discovered_models(
+        "ollama", "http://x/v1", None, "ollama", ("static:1",), background=False,
+    )
+    # background=False → synchronous refresh → already fresh.
+    assert first == ["new:1", "static:1"]
+    second = md.discovered_models("ollama", "http://x/v1", None, "ollama", ("static:1",))
+    assert second == ["new:1", "static:1"]
+
+
+def test_corrupt_cache_treated_empty(tmp_path: Path) -> None:
+    md._cache_path().write_text("{ not json", encoding="utf-8")
+    assert md._read_cache() == {}
+    md._cache_path().write_text(json.dumps({"version": 999, "entries": {"k": {}}}), encoding="utf-8")
+    assert md._read_cache() == {}
+
+
+def test_atomic_write_leaves_valid_json() -> None:
+    md._write_cache({"k": {"models": ["a"], "fetched_at": 1.0}})
+    raw = json.loads(md._cache_path().read_text(encoding="utf-8"))
+    assert raw["version"] == md.CACHE_VERSION
+    assert raw["entries"]["k"]["models"] == ["a"]
+    # No stray temp files.
+    stray = [p for p in md._cache_path().parent.iterdir() if p.name.startswith(".model-discovery-")]
+    assert stray == []
+
+
+# ---------------------------------------------------------------------------
+# Merge semantics
+# ---------------------------------------------------------------------------
+
+
+def test_merge_discovered_first_dedup_and_never_empty() -> None:
+    assert md._merge(["b", "a"], ["a", "c"]) == ["b", "a", "c"]
+    assert md._merge(None, ["s1"]) == ["s1"]
+    assert md._merge([], ["s1"]) == ["s1"]
+
+
+def test_fetch_failure_falls_back_to_static(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(md, "_fetch_for_kind", lambda *a: None)
+    out = md.discovered_models(
+        "ollama", "http://x/v1", None, "ollama", ("static:1",), background=False,
+    )
+    assert out == ["static:1"]
+
+
+def test_no_base_url_returns_static() -> None:
+    assert md.discovered_models("p", "", None, "ollama", ("s",)) == ["s"]
+
+
+# ---------------------------------------------------------------------------
+# Single-flight
+# ---------------------------------------------------------------------------
+
+
+def test_single_flight_one_refresh_for_concurrent_stale_reads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = threading.Event()
+    release = threading.Event()
+    calls: list = []
+
+    def _slow_fetch(*a):
+        calls.append(a)
+        started.set()
+        release.wait(timeout=5)
+        return ["live:1"]
+
+    monkeypatch.setattr(md, "_fetch_for_kind", _slow_fetch)
+    md.discovered_models("ollama", "http://x/v1", None, "ollama", ("s",))
+    started.wait(timeout=5)
+    # Second stale read while the first refresh is in flight → no new thread.
+    md.discovered_models("ollama", "http://x/v1", None, "ollama", ("s",))
+    release.set()
+    deadline = time.time() + 5
+    while md._refresh_in_flight and time.time() < deadline:
+        time.sleep(0.01)
+    assert len(calls) == 1, "single-flight must coalesce concurrent refreshes"
+
+
+# ---------------------------------------------------------------------------
+# Provider wiring
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_spec_provider_uses_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.providers.openai_compatible_specs import build_provider_class
+
+    monkeypatch.setattr(md, "_fetch_for_kind", lambda *a: ["local-model:7b"])
+    cls = build_provider_class("ollama")
+    provider = cls(api_key="", base_url=None, model=None)
+    key = md._cache_key("ollama", provider.base_url or cls.SPEC.default_base_url)
+    md._write_cache({key: {"models": ["local-model:7b"], "fetched_at": time.time()}})
+    models = provider.get_available_models()
+    assert "local-model:7b" in models
+    assert "deepseek-coder:1.3b" in models  # static stub still merged
+
+
+def test_static_spec_provider_never_touches_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.providers.openai_compatible_specs import SPECS_BY_ID, build_provider_class
+
+    marker: list = []
+    monkeypatch.setattr(md, "discovered_models", lambda *a, **k: marker.append(a) or ["x"])
+    static_id = next(i for i, s in SPECS_BY_ID.items() if s.dynamic_catalog is None)
+    cls = build_provider_class(static_id)
+    provider = cls(api_key="k", base_url=None, model=None)
+    models = provider.get_available_models()
+    assert models == list(SPECS_BY_ID[static_id].available_models)
+    assert marker == [], "static-catalog specs must not consult discovery"
+
+
+def test_openrouter_override_merges_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.providers.openrouter_provider import OpenRouterProvider
+
+    key = md._cache_key("openrouter", "https://openrouter.ai/api/v1")
+    md._write_cache({key: {"models": ["brand-new/model"], "fetched_at": time.time()}})
+    provider = OpenRouterProvider.__new__(OpenRouterProvider)  # skip network-y __init__
+    provider.base_url = None
+    provider.api_key = None
+    models = provider.get_available_models()
+    assert models[0] == "brand-new/model"
+    assert any("deepseek" in m for m in models)  # curated list still present

--- a/tests/providers/test_model_discovery.py
+++ b/tests/providers/test_model_discovery.py
@@ -78,7 +78,8 @@ def test_fresh_cache_is_served_without_fetch(monkeypatch: pytest.MonkeyPatch) ->
     fetches: list = []
     monkeypatch.setattr(md, "_fetch_for_kind", lambda *a: fetches.append(a) or ["live"])
     out = md.discovered_models("ollama", "http://x/v1", None, "ollama", ("static:1",))
-    assert out == ["cached:1", "static:1"]
+    # dynamic mode: the endpoint is authoritative — discovered REPLACES static.
+    assert out == ["cached:1"]
     assert fetches == [], "fresh cache must not trigger a fetch"
 
 
@@ -91,10 +92,11 @@ def test_stale_cache_refreshes_and_next_call_is_fresh(
     first = md.discovered_models(
         "ollama", "http://x/v1", None, "ollama", ("static:1",), background=False,
     )
-    # background=False → synchronous refresh → already fresh.
-    assert first == ["new:1", "static:1"]
+    # background=False → synchronous refresh → already fresh; dynamic mode
+    # replaces the static stub outright.
+    assert first == ["new:1"]
     second = md.discovered_models("ollama", "http://x/v1", None, "ollama", ("static:1",))
-    assert second == ["new:1", "static:1"]
+    assert second == ["new:1"]
 
 
 def test_corrupt_cache_treated_empty(tmp_path: Path) -> None:
@@ -119,10 +121,15 @@ def test_atomic_write_leaves_valid_json() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_merge_discovered_first_dedup_and_never_empty() -> None:
-    assert md._merge(["b", "a"], ["a", "c"]) == ["b", "a", "c"]
-    assert md._merge(None, ["s1"]) == ["s1"]
-    assert md._merge([], ["s1"]) == ["s1"]
+def test_merge_dynamic_replaces_hybrid_curates() -> None:
+    # dynamic: endpoint-authoritative; static only as the no-discovery fallback.
+    assert md._merge(["b", "a"], ["a", "c"], "dynamic") == ["b", "a"]
+    assert md._merge(None, ["s1"], "dynamic") == ["s1"]
+    assert md._merge([], ["s1"], "dynamic") == ["s1"]
+    # hybrid: STATIC-first (curation order kept), discovered appended with
+    # case-insensitive dedup (mergeCatalogEntries, discoveryService.ts:194-212).
+    assert md._merge(["b", "A", "d"], ["a", "c"], "hybrid") == ["a", "c", "b", "d"]
+    assert md._merge(None, ["s1"], "hybrid") == ["s1"]
 
 
 def test_fetch_failure_falls_back_to_static(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -181,8 +188,10 @@ def test_ollama_spec_provider_uses_discovery(monkeypatch: pytest.MonkeyPatch) ->
     key = md._cache_key("ollama", provider.base_url or cls.SPEC.default_base_url)
     md._write_cache({key: {"models": ["local-model:7b"], "fetched_at": time.time()}})
     models = provider.get_available_models()
-    assert "local-model:7b" in models
-    assert "deepseek-coder:1.3b" in models  # static stub still merged
+    # THE headline behavior: once real local models are discovered, the
+    # bogus static stub is GONE (dynamic mode replaces).
+    assert models == ["local-model:7b"]
+    assert "deepseek-coder:1.3b" not in models
 
 
 def test_static_spec_provider_never_touches_discovery(
@@ -200,14 +209,51 @@ def test_static_spec_provider_never_touches_discovery(
     assert marker == [], "static-catalog specs must not consult discovery"
 
 
-def test_openrouter_override_merges_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_openrouter_override_hybrid_keeps_curation_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from src.providers.openrouter_provider import OpenRouterProvider
 
     key = md._cache_key("openrouter", "https://openrouter.ai/api/v1")
-    md._write_cache({key: {"models": ["brand-new/model"], "fetched_at": time.time()}})
-    provider = OpenRouterProvider.__new__(OpenRouterProvider)  # skip network-y __init__
-    provider.base_url = None
-    provider.api_key = None
+    md._write_cache({key: {"models": ["brand-new/model", "deepseek/deepseek-v4-pro"], "fetched_at": time.time()}})
+    provider = OpenRouterProvider(api_key="")  # __init__ is lazy (no network)
     models = provider.get_available_models()
-    assert models[0] == "brand-new/model"
-    assert any("deepseek" in m for m in models)  # curated list still present
+    curated = OpenRouterProvider._curated_models()
+    # hybrid: curated order intact at the head; discovered tail deduped in.
+    assert models[: len(curated)] == curated
+    assert "brand-new/model" in models
+    assert models.count("deepseek/deepseek-v4-pro") == 1
+
+
+def test_cache_path_honors_config_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import src.config as config
+
+    monkeypatch.setattr(config, "GLOBAL_CONFIG_DIR", tmp_path / "home")
+    # bypass the autouse fixture's patch for this assertion
+    monkeypatch.undo()  # undo BOTH patches; re-apply config one only
+    monkeypatch.setattr(config, "GLOBAL_CONFIG_DIR", tmp_path / "home")
+    assert md._cache_path() == tmp_path / "home" / "model-discovery-cache.json"
+
+
+def test_concurrent_refreshes_for_different_keys_both_persist() -> None:
+    barrier = threading.Barrier(2, timeout=5)
+    real_fetch = md._fetch_for_kind
+
+    def _sync_refresh(key: str, models: list[str]) -> None:
+        md._refresh_in_flight.add(key)
+        barrier.wait()
+        md._refresh(key, "test", "http://x", None, 1.0)
+
+    import unittest.mock as mock
+
+    with mock.patch.object(
+        md, "_fetch_for_kind",
+        side_effect=lambda kind, *a: {"k": None}.get(kind) or ["m-" + kind],
+    ):
+        t1 = threading.Thread(target=_sync_refresh, args=(md._cache_key("p1", "u"), ["a"]))
+        t2 = threading.Thread(target=_sync_refresh, args=(md._cache_key("p2", "u"), ["b"]))
+        t1.start(); t2.start(); t1.join(5); t2.join(5)
+    entries = md._read_cache()
+    # The RMW lock prevents the cross-key lost update: both entries persist.
+    assert md._cache_key("p1", "u") in entries
+    assert md._cache_key("p2", "u") in entries


### PR DESCRIPTION
## Summary

`integrations/` parity phase INTEG-1 (after `ink/` docs-only close): the TS folder is the provider-descriptor subsystem (77 files: descriptors/registry/discovery/profiles/route-metadata + `vendors/`/`gateways/`/`brands/`/`models/`/`generated/`). Python substitutes the descriptor SYSTEM with its two-tier flat registry (deliberate; different provider universe) — the genuinely missing RUNTIME function was **live model discovery**, which ships here as the port of `discoveryService.ts` + `discoveryCache.ts`.

**The problem:** every Python `get_available_models()` returned a static tuple — the ollama spec shipped `available_models=("deepseek-coder:1.3b",)`, guaranteed wrong on any real machine (installed ollama models are machine-local; vLLM/SGLang serve whatever was launched; OpenRouter's hosted list churns weekly) — and that stub flowed straight to the `/model` picker.

**The port:** `src/providers/model_discovery.py` — openai-compatible `{base}/models` + ollama `{root}/api/tags` fetchers (the `/v1` OpenAI-compat surface is stripped for tags), persistent TTL cache at `GLOBAL_CONFIG_DIR/model-discovery-cache.json` (versioned, corruption-tolerant, atomic tempfile+replace writes, RMW under a write-lock, 1-day TTL matching TS `discoveryCacheTtl: '1d'`), and the TS **two-mode merge semantics** (`mergeCatalogEntries` + the gateway `source` fields): `dynamic` (ollama/vllm/sglang) — discovered **replaces** static when non-empty, so the bogus stub actually disappears; `hybrid` (openrouter) — **static-first** with case-insensitive dedup, so curation keeps its order with the live tail appended. **Non-blocking contract** (documented divergence from TS's blocking fetch-with-TTL): returns cache-or-static immediately and refreshes stale entries on a single-flight daemon thread — `get_available_models` sits on agent-server control paths where a blocking fetch would stall the client whenever a local endpoint is down; the cost is one static-only response on a cold cache. Errors never propagate (stale-or-static fallback). `_do_set_provider` warms discovery on switch (the `refreshStartupDiscoveryForActiveRoute` analog); init warms the initial provider emergently.

**Wiring:** `ProviderSpec.dynamic_catalog` (`"ollama" | "openai-compatible"`, default `None`) on the `ollama`/`vllm`/`sglang` rows; the spec-provider `get_available_models` branches to discovery only when set; the hand-written OpenRouter provider merges live discovery over its curated list (hybrid mode). The only agent-server change is the best-effort discovery warm in `_do_set_provider`.

**G4 spot-check (per plan)** ran clean: no Python request path sends `store` and none uses `max_completion_tokens` — the TS per-vendor shim knobs aren't needed for this port's provider set (recorded in the gap doc).

Docs (critic loop per the sweep cadence): `my-docs/get-parity-by-folder/integrations-{gap-analysis,refactoring-plan}.md` — full subsystem inventory (all five subfolders iterated), Python analog map, and the stop-line: startup validation already shipped by ENTRY-2 (#636); saved provider profiles = real gap deferred as its own chapter; route metadata / presets / brands / build tooling N-A by architecture.

## Verification

- `tests/providers/test_model_discovery.py` **17/17**: parsers (incl. the `/v1`-strip pin and malformed-JSON tolerance), cache (fresh-no-fetch, stale→refresh→next-call-fresh, corrupt/version tolerance, atomic writes with no stray temps, config-home re-point, concurrent cross-key RMW), the two merge modes (the ollama wiring test asserts the stub is ABSENT once discovery lands — the headline; the OpenRouter test pins the curated list as the exact head), single-flight coalescing, and static specs never touching discovery.
- Critic loop: gap doc APPROVE; plan + implementation REVISE→fixed (2 MAJORs: single-union merge contradicted the TS two-mode design; no warm-on-switch — plus cache-home, RMW-lock, and test-construction minors).
- No local ollama on this machine — the live smoke was fixture-only (stated honestly); the fetchers are exercised against recorded shapes.
- Full suite at the 6-failure baseline (**7762 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
