### PR TITLE
feat(memdir): port the Searching-past-context prompt section; keybindings placeholder truth

### DIFF
--- a/src/keybindings/__init__.py
+++ b/src/keybindings/__init__.py
@@ -1,12 +1,16 @@
 """Placeholder for parity with ``typescript/src/keybindings/``.
 
-The real Python implementation of TUI keybindings lives at
-``src/tui/keybindings.py`` (chord-tracker dispatcher). The configurable
-loader / schema / resolver layer (mirroring chapter 13's ``loadUserBindings``,
-``parser``, ``resolver``, ``schema``, ``validate``) is planned in phase 2 of
-``my-docs/ch13-terminal-ui-refactoring-plan.md``. This module exists so the
-``reference_data`` subsystem snapshots resolve and so the namespace is
-reserved; do not add behavior here.
+Current truth (get-parity-by-folder keybindings close, 2026-07): the
+DEFAULT chord surface lives in the kept TS client
+(``ui-tui/src/app/useInputHandlers.ts`` — the sole interactive UI since the
+UI-consolidation, PR #566, deleted the Python TUIs this docstring used to
+point at). The configurable loader/schema/resolver layer is OFF in open
+builds (``loadUserBindings.ts:259-267`` gates on a key absent from the
+GrowthBook stub's ``_openBuildDefaults``), so there is nothing to port
+unless upstream un-gates it — and the port target would then be the
+CLIENT, not this package. This module exists so the ``reference_data``
+subsystem snapshots resolve and so the namespace is reserved; do not add
+behavior here.
 """
 
 from __future__ import annotations

--- a/src/memdir/memdir.py
+++ b/src/memdir/memdir.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+import os
 from pathlib import Path
 from typing import Iterable
 
@@ -200,6 +201,43 @@ def _how_to_save_section(skip_index: bool) -> list[str]:
     ]
 
 
+def build_searching_past_context_section(auto_mem_dir: str) -> list[str]:
+    """The "Searching past context" guidance (memdir.ts:375-407).
+
+    MEMDIR-1: upstream gates this on ``tengu_coral_fern``, which the vendored
+    GrowthBook stub's ``_openBuildDefaults`` sets to TRUE — so the reference
+    build emits it for every user, and this port emits it unconditionally
+    (no flag system here). TS picks shell-grep forms when the dedicated Grep
+    tool is hidden (ant-native embedded search / REPL script mode); this
+    port always ships the Grep tool, so the tool-invocation forms are used
+    unconditionally. The transcript target is this port's saved-session
+    store (``~/.clawcodex/sessions/``, ``*.json``) rather than the reference
+    project-transcript dir.
+    """
+    sessions_dir = os.path.join(os.path.expanduser("~"), ".clawcodex", "sessions")
+    mem_search = (
+        f'Grep with pattern="<search term>" path="{auto_mem_dir}" glob="*.md"'
+    )
+    transcript_search = (
+        f'Grep with pattern="<search term>" path="{sessions_dir}/" glob="*.json"'
+    )
+    return [
+        "## Searching past context",
+        "",
+        "When looking for past context:",
+        "1. Search topic files in your memory directory:",
+        "```",
+        mem_search,
+        "```",
+        "2. Session transcript logs (last resort — large files, slow):",
+        "```",
+        transcript_search,
+        "```",
+        "Use narrow search terms (error messages, file paths, function names) rather than broad keywords.",
+        "",
+    ]
+
+
 def build_memory_lines(
     *,
     display_name: str,
@@ -243,6 +281,9 @@ def build_memory_lines(
             if guideline:
                 lines.append(guideline)
         lines.append("")
+
+    # memdir.ts:263 — the searching-past-context guidance closes the section.
+    lines.extend(build_searching_past_context_section(memory_dir))
 
     return lines
 

--- a/src/memdir/team_mem_prompts.py
+++ b/src/memdir/team_mem_prompts.py
@@ -202,4 +202,12 @@ def build_combined_memory_prompt(
         for guideline in extra_guidelines:
             if guideline:
                 lines.append(guideline)
+    # teamMemPrompts.ts:95-96 — a blank separator, then the combined prompt
+    # closes with the searching-past-context guidance (private dir is the
+    # search root).
+    from .memdir import build_searching_past_context_section
+
+    lines.append("")
+    lines.extend(build_searching_past_context_section(auto_dir))
+
     return "\n".join(lines)

--- a/tests/test_memdir_memdir.py
+++ b/tests/test_memdir_memdir.py
@@ -166,3 +166,57 @@ class BuildMemoryPromptTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestSearchingPastContextSection:
+    """MEMDIR-1 — the "Searching past context" guidance (memdir.ts:375-407).
+
+    Upstream gates it on tengu_coral_fern, which the vendored GrowthBook
+    stub's _openBuildDefaults sets TRUE — the reference build emits it for
+    every user, so this port emits it unconditionally (critic-caught: the
+    original close misread the flag by stopping at the call-site default).
+    """
+
+    def test_section_content(self):
+        from src.memdir.memdir import build_searching_past_context_section
+
+        lines = build_searching_past_context_section("/tmp/memdir-x")
+        joined = "\n".join(lines)
+        assert lines[0] == "## Searching past context"
+        assert 'Grep with pattern="<search term>" path="/tmp/memdir-x" glob="*.md"' in joined
+        assert '/sessions/" glob="*.json"' in joined  # the port's transcript store
+        assert "narrow search terms" in joined
+        assert "last resort" in joined
+
+    def test_build_memory_lines_ends_with_section(self):
+        from src.memdir.memdir import build_memory_lines
+
+        lines = build_memory_lines(display_name="Memory", memory_dir="/tmp/m")
+        joined = "\n".join(lines)
+        assert joined.count("## Searching past context") == 1
+        # TS memdir.ts:263 — the section closes buildMemoryLines.
+        assert "## Searching past context" in "\n".join(lines[-15:])
+
+    def test_build_memory_prompt_section_precedes_entrypoint_block(self, tmp_path):
+        from src.memdir.memdir import ENTRYPOINT_NAME, build_memory_prompt
+
+        (tmp_path / ENTRYPOINT_NAME).write_text("- indexed fact", encoding="utf-8")
+        prompt = build_memory_prompt(
+            display_name="Memory", memory_dir=str(tmp_path)
+        )
+        # TS buildMemoryPrompt (:293) reuses buildMemoryLines (section at its
+        # tail) then appends the MEMORY.md block — section BEFORE the block.
+        assert prompt.count("## Searching past context") == 1
+        assert prompt.index("## Searching past context") < prompt.index(f"## {ENTRYPOINT_NAME}")
+
+    def test_combined_prompt_ends_with_section_once(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CLAUDE_CODE_TEAM_MEMORY", "1")
+        monkeypatch.setenv("CLAUDE_CODE_AUTO_MEMORY_PATH", str(tmp_path))
+        from src.memdir.team_mem_prompts import build_combined_memory_prompt
+
+        prompt = build_combined_memory_prompt()
+        # TS teamMemPrompts.ts:95-96 — blank separator, then the section,
+        # closing the prompt.
+        assert prompt.count("## Searching past context") == 1
+        assert "\n\n## Searching past context" in prompt
+        assert prompt.rstrip().endswith("rather than broad keywords.")


### PR DESCRIPTION
## Summary

Small-folder closes from the get-parity-by-folder sweep — `memdir/` (one live gap ported) + `keybindings/` (placeholder housekeeping). Five folders were dispositioned in this batch (`keybindings/`, `memdir/`, `migrations/`, `moreright/`, `native-ts/` — docs in `my-docs/get-parity-by-folder/`); this PR carries the two code changes that fell out.

**MEMDIR-1 — the "Searching past context" prompt section.** The critic caught a flag misread in my close: I verified GrowthBook call-site *default args*, but the vendored stub's `_openBuildDefaults` table sets `tengu_coral_fern` **true** — so the reference build emits `buildSearchingPastContextSection` (memdir.ts:375-407) into every user's memory prompt, and Python's builders omitted it (with `load_memory_prompt` live in prompt assembly, the omission reached every system prompt). Ported as always-emit: `build_searching_past_context_section` in `src/memdir/memdir.py` — Grep-tool invocation forms (this port always ships the Grep tool; TS's shell-grep branch covers ant-native/REPL modes it doesn't have), memory-dir `*.md` search + the port's saved-session store (`~/.clawcodex/sessions/` `*.json`) as the transcript-search target. Wired at both live TS call sites: `build_memory_lines` tail (memdir.ts:263) and the combined team prompt after extra guidelines (teamMemPrompts.ts:96). The third TS site (:366) is the KAIROS daily-log builder — deferred with its mode, deliberately not wired. `isExtractModeActive` (also `_openBuildDefaults`-ON) is reclassified in the gap doc as a deferred feature with an owner (query/stop-hooks docket), not a memdir residual.

**keybindings/ housekeeping.** `src/keybindings/__init__.py`'s docstring pointed at `src/tui/keybindings.py` — deleted with the Textual TUI in the UI-consolidation (#566) — and a superseded plan. Restated to the current truth (defaults live in the kept ui-tui client; the customization gate resolves false in open builds — key absent from `_openBuildDefaults`). Comment-only; the placeholder stays load-bearing for reference_data snapshots.

Methodological note recorded in the docs: per-flag `_openBuildDefaults` consultation is now on the sweep's verification checklist (resolver, not call-site default) — the same table proved one flag ON (coral_fern → this port) and one absent (herring_clock → the existing env-var substitution stands).

## Verification

- 4 new pins in `tests/test_memdir_memdir.py`: section content (both Grep forms + the narrow-terms line), `build_memory_lines` ends with the section, `build_memory_prompt` keeps it before the MEMORY.md block (matching TS :293 composition), combined prompt ends with it exactly once.
- memdir suites 43 green; `test_porting_workspace` (placeholder pin) green.
- Full suite at the 6-failure baseline (**7766 passed**).
- Critic loop: five dispositions reviewed (2 APPROVE first-pass, 3 REVISE→fixed); implementation reviewed on the revision round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
