### PR TITLE
feat(outputStyles): wire the feature end-to-end — startup, persistence, client command, canon dir

### DIFF
--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -213,6 +213,12 @@ def run_headless(options: HeadlessOptions) -> int:
         abort_controller=abort_controller,
     )
     tool_context.options.is_non_interactive_session = True
+    # OS-1 G1 — settings-configured output style applies headless too.
+    from src.outputStyles import output_style_from_settings
+
+    _settings_style = output_style_from_settings(cwd=str(workspace_root))
+    if _settings_style:
+        tool_context.output_style_name = _settings_style
     # ch01 round-4 WI-1 — load settings hooks into the executor-visible
     # snapshot + global registry. Safe here: run_headless is sync and its
     # asyncio.run happens later. Never raises.

--- a/src/outputStyles/__init__.py
+++ b/src/outputStyles/__init__.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from .loader import load_output_styles_dir, resolve_output_style
+from .loader import (
+    available_output_styles,
+    load_output_styles_dir,
+    output_style_from_settings,
+    resolve_output_style,
+)
 from .styles import BUILTIN_OUTPUT_STYLES, OutputStyle
 
 SNAPSHOT_PATH = Path(__file__).resolve().parent.parent / 'reference_data' / 'subsystems' / 'outputStyles.json'

--- a/src/outputStyles/loader.py
+++ b/src/outputStyles/loader.py
@@ -29,14 +29,32 @@ from .styles import BUILTIN_OUTPUT_STYLES, OutputStyle
 _logger = logging.getLogger(__name__)
 
 
-def _default_user_dir() -> Path:
-    """Resolve the default user output-styles directory lazily.
+def _user_style_dirs() -> list[Path]:
+    """User output-style directories, canon first (OS-1 G4).
 
-    Lazy so test environments that monkeypatch ``HOME`` after import see
-    the override. Mirrors the keybindings-loader pattern.
+    Primary: ``GLOBAL_CONFIG_DIR/outputStyles`` (this port's config home —
+    the INTEG-1 canon rule; lazy import so test re-points are honored).
+    Legacy fallback: ``~/.claude/outputStyles`` — the TS config home this
+    loader originally copied; kept readable for continuity, canon wins on
+    name collisions. Lazy so tests that monkeypatch ``HOME`` /
+    ``GLOBAL_CONFIG_DIR`` after import see the override.
     """
+    from src.config import GLOBAL_CONFIG_DIR
 
-    return Path("~/.claude/outputStyles").expanduser()
+    return [
+        Path(GLOBAL_CONFIG_DIR) / "outputStyles",
+        Path("~/.claude/outputStyles").expanduser(),
+    ]
+
+
+def _load_default_user_styles() -> dict[str, OutputStyle]:
+    """Merged builtins + legacy-dir + canon-dir styles (canon wins)."""
+    canon, legacy = _user_style_dirs()
+    styles: dict[str, OutputStyle] = dict(BUILTIN_OUTPUT_STYLES)
+    for directory in (legacy, canon):  # canon merged LAST → wins collisions
+        if directory.is_dir():
+            styles.update(load_output_styles_dir(directory))
+    return styles
 
 
 def load_output_styles_dir(path: str | Path) -> dict[str, OutputStyle]:
@@ -105,11 +123,7 @@ def resolve_output_style(
     if search_dir is not None:
         styles = load_output_styles_dir(search_dir)
     else:
-        default_dir = _default_user_dir()
-        if default_dir.is_dir():
-            styles = load_output_styles_dir(default_dir)
-        else:
-            styles = dict(BUILTIN_OUTPUT_STYLES)
+        styles = _load_default_user_styles()
 
     key = (name or "default").strip() or "default"
     return styles.get(key, styles["default"])
@@ -128,3 +142,39 @@ __all__ = [
     "load_output_styles_dir",
     "resolve_output_style",
 ]
+
+def output_style_from_settings(cwd: str | None = None) -> str | None:
+    """The startup producer (OS-1 G1): ``settings.output_style.style`` →
+    the style name the live context should carry, or ``None`` for default.
+
+    TS reads ``settings?.outputStyle`` at prompt-build time
+    (constants/outputStyles.ts:207); this port carries the style on the
+    tool context, so entrypoints call this once at context construction.
+    Never raises (a broken settings file must not block startup).
+    """
+    try:
+        from src.settings.settings import load_settings
+
+        style = load_settings(cwd=cwd).output_style.style
+        if style and style != "default":
+            return str(style)
+    except Exception:  # noqa: BLE001
+        _logger.debug("output_style_from_settings failed", exc_info=True)
+    return None
+
+def available_output_styles(search_dir: str | Path | None = None) -> list[str]:
+    """Names of all resolvable styles — builtins ∪ user files. OS-1 W3:
+    feeds the set_output_style validation/reply and the client
+    /output-style listing. Mirrors resolve_output_style's directory
+    resolution exactly (same styles resolvable = same names listed)."""
+    try:
+        styles = (
+            load_output_styles_dir(search_dir)
+            if search_dir is not None
+            else _load_default_user_styles()
+        )
+        return list(styles)
+    except Exception:  # noqa: BLE001 — listing is best-effort
+        _logger.debug("available_output_styles: scan failed", exc_info=True)
+        return list(BUILTIN_OUTPUT_STYLES)
+

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -393,6 +393,9 @@ class _AgentSession:
                 "model": getattr(self.provider, "model", None),
                 "provider": self.provider_name,
                 "available_models": self._available_models(),
+                # OS-1 W3 — the /output-style no-arg display.
+                "output_style": getattr(self.tool_context, "output_style_name", None) or "default",
+                "available_output_styles": self._available_output_styles(),
             })
             return
         if subtype == "get_context_usage":
@@ -605,6 +608,19 @@ class _AgentSession:
                 "response": response,
             },
         })
+
+    def _available_output_styles(self) -> list[str]:
+        """OS-1 W3 — builtins ∪ user styles for the /output-style listing."""
+        try:
+            from src.outputStyles import available_output_styles
+
+            return available_output_styles(
+                getattr(self.tool_context, "output_style_dir", None)
+                if self.tool_context is not None
+                else None
+            )
+        except Exception:  # noqa: BLE001
+            return ["default", "explanatory"]
 
     def _available_models(self) -> list[str]:
         """Provider's selectable models (for the /model picker). Best-effort."""
@@ -1209,15 +1225,23 @@ class _AgentSession:
             self._reply(request_id, {"ok": False, "error": "cannot change output style during an active turn"})
             return
         try:
-            from src.settings.constants import VALID_OUTPUT_STYLES
+            from src.outputStyles import available_output_styles
 
-            if not isinstance(style, str) or style not in VALID_OUTPUT_STYLES:
+            tc = self.tool_context
+            valid = available_output_styles(
+                getattr(tc, "output_style_dir", None) if tc is not None else None
+            )
+            # OS-1: validate against the loader's truth (builtins ∪ user
+            # styles). The old fixed VALID_OUTPUT_STYLES list rejected the
+            # real builtin "explanatory" and accepted three styles that
+            # never existed.
+            if not isinstance(style, str) or style not in valid:
                 self._reply(
                     request_id,
-                    {"ok": False, "error": f"invalid style (valid: {', '.join(VALID_OUTPUT_STYLES)})"},
+                    {"ok": False, "error": f"invalid style (valid: {', '.join(valid)})",
+                     "available_styles": valid},
                 )
                 return
-            tc = self.tool_context
             if tc is None:
                 self._reply(request_id, {"ok": False, "error": "session not ready"})
                 return
@@ -1232,7 +1256,18 @@ class _AgentSession:
                 self.system_prompt = self._compose_with_plan(self._base_system_prompt)
             except Exception:  # noqa: BLE001 - keep the style set even if rebuild is unavailable
                 logger.debug("[agent-server] system prompt rebuild after set_output_style failed", exc_info=True)
-            self._reply(request_id, {"ok": True, "style": style})
+            # OS-1 G3 — persist the choice (localSettings analog,
+            # Settings/Config.tsx:1600). Best-effort: the in-memory switch
+            # above already applies.
+            try:
+                from src.settings.settings import update_local_settings
+
+                update_local_settings(
+                    {"output_style": {"style": style}}, cwd=self.cwd,
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug("[agent-server] output style persist failed", exc_info=True)
+            self._reply(request_id, {"ok": True, "style": style, "available_styles": valid})
         except Exception as exc:  # noqa: BLE001
             logger.exception("[agent-server] set_output_style failed")
             self._reply(request_id, {"ok": False, "error": str(exc)})
@@ -2442,6 +2477,18 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
         profile_checkpoint("agent_server_permissions_hooks_done")
         if sess._mcp_runtime is not None:
             tool_context.mcp_clients = sess._mcp_runtime.clients  # server-name catalog for the agent tool
+
+        # OS-1 G1 — the startup producer: a settings-configured output style
+        # applies from the FIRST prompt (before this, output_style_name was
+        # only ever set by the set_output_style control).
+        try:
+            from src.outputStyles import output_style_from_settings
+
+            settings_style = output_style_from_settings(cwd=sess.cwd)
+            if settings_style and getattr(tool_context, "output_style_name", None) is None:
+                tool_context.output_style_name = settings_style
+        except Exception:  # noqa: BLE001 — style must not block startup
+            logger.debug("[agent-server] output style from settings failed", exc_info=True)
 
         try:
             from src.outputStyles import resolve_output_style

--- a/src/settings/constants.py
+++ b/src/settings/constants.py
@@ -49,7 +49,10 @@ DEFAULT_SETTINGS = SettingsSchema(
 VALID_EFFORT_VALUES = ("", "low", "medium", "high", "max")
 
 # Known valid output styles
-VALID_OUTPUT_STYLES = ("default", "concise", "verbose", "markdown")
+# OS-1: the VALID_OUTPUT_STYLES enum was removed — it was invented (rejected
+# the real builtin "explanatory", accepted three nonexistent styles). Style
+# names are free-form (TS z.string()); the loader's available_output_styles()
+# is the runtime truth where a listing is needed.
 
 # Known valid spinner-verb merge modes (TS settings/types.ts:696)
 VALID_SPINNER_VERB_MODES = ("append", "replace")

--- a/src/settings/settings.py
+++ b/src/settings/settings.py
@@ -91,3 +91,62 @@ def apply_persisted_model(provider: Any, provider_name: str) -> bool:
         provider.model = s.model
         return True
     return False
+
+def update_local_settings(
+    updates: dict[str, Any], *, cwd: str | Path | None = None,
+) -> bool:
+    """Merge ``updates`` into the LOCAL settings tier and persist.
+
+    OS-1 G3 — the ``updateSettingsForSource('localSettings', ...)`` analog
+    (Settings/Config.tsx:1600): writes the ``settings`` sub-key of the
+    project-local config file (``.claude/config.local.json``), creating the
+    file/dir as needed, atomically (tempfile + replace), then invalidates
+    the settings cache. Returns False (logged) on any failure — persistence
+    is best-effort; callers' in-memory state still applies.
+    """
+    import json as _json
+    import logging as _logging
+    import os as _os
+    import tempfile as _tempfile
+
+    from src.config import get_local_config_path
+
+    logger = _logging.getLogger(__name__)
+    try:
+        path = get_local_config_path(cwd)
+        if path is None:
+            # Outside a git root there is no local tier — persist to the
+            # GLOBAL config's settings block instead (also merged by
+            # load_settings), so the choice survives everywhere.
+            from src.config import GLOBAL_CONFIG_FILE
+
+            path = Path(GLOBAL_CONFIG_FILE)
+        cfg_dir = path.parent
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            data = _json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                data = {}
+        except Exception:  # noqa: BLE001 — missing/corrupt starts fresh
+            data = {}
+        settings_block = data.get("settings")
+        if not isinstance(settings_block, dict):
+            settings_block = {}
+        data["settings"] = _deep_merge(settings_block, updates)
+        fd, tmp = _tempfile.mkstemp(dir=str(cfg_dir), prefix=".settings-")
+        try:
+            with _os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(_json.dumps(data, indent=2) + "\n")
+            _os.replace(tmp, path)
+        finally:
+            if _os.path.exists(tmp):
+                try:
+                    _os.unlink(tmp)
+                except OSError:
+                    pass
+        invalidate_settings_cache()
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("update_local_settings failed", exc_info=True)
+        return False
+

--- a/src/settings/validation.py
+++ b/src/settings/validation.py
@@ -7,7 +7,6 @@ from typing import Any
 
 from .constants import (
     VALID_EFFORT_VALUES,
-    VALID_OUTPUT_STYLES,
     VALID_PERMISSION_MODES,
     VALID_SPINNER_VERB_MODES,
 )
@@ -42,13 +41,11 @@ def validate_settings(settings: SettingsSchema) -> list[ValidationError]:
             value=settings.permission_mode,
         ))
 
-    # Output style
-    if settings.output_style.style not in VALID_OUTPUT_STYLES:
-        errors.append(ValidationError(
-            field="output_style.style",
-            message=f"Invalid output style: {settings.output_style.style!r}",
-            value=settings.output_style.style,
-        ))
+    # Output style: a free-form name (TS settings schema is z.string() —
+    # custom user styles make a fixed enum impossible to validate here;
+    # unknown names fall back to "default" at resolve time). OS-1 removed
+    # the invented VALID_OUTPUT_STYLES enum check, which rejected the real
+    # builtin "explanatory" and accepted three styles that never existed.
 
     # Max width
     if settings.output_style.max_width < 40:

--- a/tests/server/test_agent_server_e2e.py
+++ b/tests/server/test_agent_server_e2e.py
@@ -611,8 +611,12 @@ async def test_control_set_output_style(tmp_path):
                         return msg["response"]["response"]
                 raise AssertionError(f"no reply for {rid}")
 
-            ok = await _reply_for("s1", {"subtype": "set_output_style", "style": "concise"})
-            assert ok["ok"] is True and ok["style"] == "concise"
+            # OS-1: validation now follows the loader's truth — "explanatory"
+            # is the real builtin (the old fixed list wrongly accepted
+            # "concise", which never existed as a style).
+            ok = await _reply_for("s1", {"subtype": "set_output_style", "style": "explanatory"})
+            assert ok["ok"] is True and ok["style"] == "explanatory"
+            assert "explanatory" in ok.get("available_styles", [])
 
             bad = await _reply_for("s2", {"subtype": "set_output_style", "style": "bogus"})
             assert bad["ok"] is False and "valid" in bad["error"]

--- a/tests/server/test_agent_server_e2e.py
+++ b/tests/server/test_agent_server_e2e.py
@@ -977,3 +977,50 @@ class _SpinProvider:
 async def spawn_for(stack, agent_config, tmp_path):
     spawn = make_spawn_agent(agent_config)
     return await spawn("ds_test", str(tmp_path), None)
+
+@pytest.mark.asyncio
+async def test_settings_output_style_applies_at_startup(tmp_path):
+    """OS-1 G1 seam (critic MAJOR): a settings-configured output style must
+    reach tool_context.output_style_name during _build_runtime — asserted
+    through the get_settings reply, which reads that exact field. Regression
+    guard for reordering the producer after the prompt build or breaking
+    the assignment (the leaf/unit tests alone would stay green)."""
+    import json as _json
+    import subprocess
+    from src.tool_system.registry import ToolRegistry
+
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    cfg_dir = tmp_path / ".claude"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.local.json").write_text(
+        _json.dumps({"settings": {"output_style": {"style": "explanatory"}}}),
+        encoding="utf-8",
+    )
+
+    with contextlib.ExitStack() as stack:
+        for p in _patches(_TextProvider, ToolRegistry([])):
+            stack.enter_context(p)
+        spawn = make_spawn_agent(AgentServerConfig(permission_mode="default"))
+        handle = await spawn("os1_seam", str(tmp_path), None)
+        gen = handle.messages_from_agent()
+        try:
+            init = await asyncio.wait_for(gen.__anext__(), timeout=5)
+            assert init["subtype"] == "init"
+
+            await handle.send_to_agent({
+                "type": "control_request", "request_id": "gs1",
+                "request": {"subtype": "get_settings"},
+            })
+            for _ in range(12):
+                msg = await asyncio.wait_for(gen.__anext__(), timeout=5)
+                if msg.get("type") == "control_response" and msg["response"].get("request_id") == "gs1":
+                    payload = msg["response"]["response"]
+                    break
+            else:
+                raise AssertionError("no get_settings reply")
+            assert payload["output_style"] == "explanatory", payload
+        finally:
+            with contextlib.suppress(Exception):
+                await handle.shutdown()
+            with contextlib.suppress(Exception):
+                await gen.aclose()

--- a/tests/test_output_style_wiring.py
+++ b/tests/test_output_style_wiring.py
@@ -1,0 +1,231 @@
+"""OS-1 — output-style feature wiring end-to-end.
+
+Plan: my-docs/get-parity-by-folder/outputStyles-refactoring-plan.md.
+G1 startup producer (settings → tool_context.output_style_name),
+G3 persistence (set_output_style → local settings tier),
+W3 availability (get_settings + validation against the loader's truth —
+the old fixed VALID_OUTPUT_STYLES list rejected the real builtin
+"explanatory" and accepted three nonexistent styles),
+G4 loader canon dir (GLOBAL_CONFIG_DIR primary, ~/.claude legacy fallback).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# G1 — startup producer
+# ---------------------------------------------------------------------------
+
+
+class TestOutputStyleFromSettings:
+    def test_reads_configured_style(self, tmp_path, monkeypatch):
+        import src.settings.settings as settings_mod
+        from src.outputStyles import output_style_from_settings
+
+        monkeypatch.setattr(
+            settings_mod, "load_settings",
+            lambda **kw: type("S", (), {"output_style": type("O", (), {"style": "explanatory"})()})(),
+        )
+        assert output_style_from_settings() == "explanatory"
+
+    def test_default_returns_none(self, monkeypatch):
+        import src.settings.settings as settings_mod
+        from src.outputStyles import output_style_from_settings
+
+        monkeypatch.setattr(
+            settings_mod, "load_settings",
+            lambda **kw: type("S", (), {"output_style": type("O", (), {"style": "default"})()})(),
+        )
+        assert output_style_from_settings() is None
+
+    def test_broken_settings_never_raise(self, monkeypatch):
+        import src.settings.settings as settings_mod
+        from src.outputStyles import output_style_from_settings
+
+        def _boom(**kw):
+            raise RuntimeError("corrupt settings")
+
+        monkeypatch.setattr(settings_mod, "load_settings", _boom)
+        assert output_style_from_settings() is None
+
+
+# ---------------------------------------------------------------------------
+# G3 — persistence (the localSettings analog)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateLocalSettings:
+    def test_roundtrip_in_git_root(self, tmp_path, monkeypatch):
+        import subprocess
+
+        subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+        from src.settings.settings import load_settings, update_local_settings
+        from src.config import get_local_config_path
+
+        assert update_local_settings(
+            {"output_style": {"style": "explanatory"}}, cwd=tmp_path,
+        )
+        path = get_local_config_path(tmp_path)
+        assert path is not None and path.exists()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["settings"]["output_style"]["style"] == "explanatory"
+        assert load_settings(cwd=tmp_path).output_style.style == "explanatory"
+
+    def test_merge_preserves_other_settings(self, tmp_path):
+        import subprocess
+
+        subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+        from src.settings.settings import update_local_settings
+        from src.config import get_local_config_path
+
+        update_local_settings({"output_style": {"style": "explanatory"}}, cwd=tmp_path)
+        update_local_settings({"output_style": {"max_width": 100}}, cwd=tmp_path)
+        data = json.loads(get_local_config_path(tmp_path).read_text(encoding="utf-8"))
+        # deep-merged, not clobbered
+        assert data["settings"]["output_style"]["style"] == "explanatory"
+        assert data["settings"]["output_style"]["max_width"] == 100
+
+    def test_global_fallback_outside_git(self, tmp_path, monkeypatch):
+        import src.config as config
+        from src.settings.settings import update_local_settings
+
+        monkeypatch.setattr(config, "GLOBAL_CONFIG_FILE", tmp_path / "home" / "config.json")
+        assert update_local_settings(
+            {"output_style": {"style": "explanatory"}}, cwd=tmp_path / "no-git",
+        )
+        data = json.loads((tmp_path / "home" / "config.json").read_text(encoding="utf-8"))
+        assert data["settings"]["output_style"]["style"] == "explanatory"
+
+
+# ---------------------------------------------------------------------------
+# W3 — availability + validation truth
+# ---------------------------------------------------------------------------
+
+
+class TestAvailability:
+    def test_builtins_present(self):
+        from src.outputStyles import available_output_styles
+
+        names = available_output_styles()
+        assert "default" in names
+        assert "explanatory" in names  # rejected by the OLD fixed list
+
+    def test_user_style_listed_and_resolvable(self, tmp_path):
+        from src.outputStyles import available_output_styles, resolve_output_style
+
+        (tmp_path / "pirate.md").write_text(
+            "---\nname: pirate\ndescription: yar\n---\nSpeak like a pirate.",
+            encoding="utf-8",
+        )
+        names = available_output_styles(tmp_path)
+        assert "pirate" in names
+        assert resolve_output_style("pirate", tmp_path).prompt.startswith("Speak like")
+
+    def test_listing_matches_resolution(self, tmp_path):
+        """The set_output_style validation invariant: every listed name
+        resolves to itself (no invented names, no rejected builtins)."""
+        from src.outputStyles import available_output_styles, resolve_output_style
+
+        for name in available_output_styles(tmp_path):
+            assert resolve_output_style(name, tmp_path).name == name
+
+
+# ---------------------------------------------------------------------------
+# G4 — canon dir + legacy fallback
+# ---------------------------------------------------------------------------
+
+
+class TestUserDirCanon:
+    def test_canon_dir_primary(self, tmp_path, monkeypatch):
+        import src.config as config
+        from src.outputStyles import available_output_styles
+
+        canon = tmp_path / "clawhome"
+        (canon / "outputStyles").mkdir(parents=True)
+        (canon / "outputStyles" / "canonstyle.md").write_text(
+            "---\nname: canonstyle\n---\nCanon.", encoding="utf-8",
+        )
+        monkeypatch.setattr(config, "GLOBAL_CONFIG_DIR", canon)
+        monkeypatch.setenv("HOME", str(tmp_path / "emptyhome"))
+        assert "canonstyle" in available_output_styles()
+
+    def test_legacy_dir_fallback_and_canon_wins(self, tmp_path, monkeypatch):
+        import src.config as config
+        from src.outputStyles import available_output_styles, resolve_output_style
+
+        canon = tmp_path / "clawhome"
+        legacy_home = tmp_path / "home"
+        (canon / "outputStyles").mkdir(parents=True)
+        (legacy_home / ".claude" / "outputStyles").mkdir(parents=True)
+        (legacy_home / ".claude" / "outputStyles" / "legacystyle.md").write_text(
+            "---\nname: legacystyle\n---\nLegacy.", encoding="utf-8",
+        )
+        (legacy_home / ".claude" / "outputStyles" / "shared.md").write_text(
+            "---\nname: shared\n---\nFrom legacy.", encoding="utf-8",
+        )
+        (canon / "outputStyles" / "shared.md").write_text(
+            "---\nname: shared\n---\nFrom canon.", encoding="utf-8",
+        )
+        monkeypatch.setattr(config, "GLOBAL_CONFIG_DIR", canon)
+        monkeypatch.setenv("HOME", str(legacy_home))
+        names = available_output_styles()
+        assert "legacystyle" in names  # legacy dir still readable
+        assert resolve_output_style("shared").prompt == "From canon."  # canon wins
+
+
+# ---------------------------------------------------------------------------
+# Server handler (G1 startup + G3 persist + W3 reply) — direct handler tests
+# ---------------------------------------------------------------------------
+
+
+class TestSetOutputStyleHandler:
+    def _server(self, tmp_path):
+        from src.server.agent_server import _AgentSession
+        from src.tool_system.context import ToolContext
+
+        srv = _AgentSession.__new__(_AgentSession)
+        import threading
+
+        srv._lock = threading.Lock()
+        srv._current_abort = None
+        srv.cwd = str(tmp_path)
+        srv.tool_context = ToolContext(workspace_root=tmp_path)
+        srv.provider = None
+        srv.replies = []
+        srv._reply = lambda rid, payload: srv.replies.append((rid, payload))
+        return srv
+
+    def test_explanatory_accepted_and_persisted(self, tmp_path, monkeypatch):
+        import subprocess
+
+        subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+        srv = self._server(tmp_path)
+        # prompt rebuild path needs provider bits; stub it to no-op
+        monkeypatch.setattr(
+            "src.query.agent_loop_compat.build_effective_system_prompt",
+            lambda *a, **k: "PROMPT",
+        )
+        srv._compose_with_plan = lambda p: p
+        srv._do_set_output_style("r1", "explanatory")
+        rid, payload = srv.replies[-1]
+        assert payload["ok"] is True, payload
+        assert payload["style"] == "explanatory"
+        assert "explanatory" in payload["available_styles"]
+        assert srv.tool_context.output_style_name == "explanatory"
+        from src.config import get_local_config_path
+
+        data = json.loads(get_local_config_path(tmp_path).read_text(encoding="utf-8"))
+        assert data["settings"]["output_style"]["style"] == "explanatory"
+
+    def test_unknown_style_rejected_with_availability(self, tmp_path):
+        srv = self._server(tmp_path)
+        srv._do_set_output_style("r1", "concise")  # in the OLD invented list
+        rid, payload = srv.replies[-1]
+        assert payload["ok"] is False
+        assert "available_styles" in payload
+        assert "explanatory" in payload["available_styles"]
+        assert "concise" not in payload["available_styles"]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -82,10 +82,15 @@ class TestValidation:
         errors = validate_settings(s)
         assert any(e.field == "permission_mode" for e in errors)
 
-    def test_invalid_output_style(self):
-        s = SettingsSchema(output_style=OutputStyleSettings(style="nonexistent"))
-        errors = validate_settings(s)
-        assert any(e.field == "output_style.style" for e in errors)
+    def test_output_style_is_free_form(self):
+        """OS-1: style names are free-form (TS z.string() — custom user
+        styles exist); unknown names fall back to default at resolve time
+        instead of failing validation. The old enum check rejected the
+        real builtin "explanatory"."""
+        s = SettingsSchema(output_style=OutputStyleSettings(style="explanatory"))
+        assert not any(e.field == "output_style.style" for e in validate_settings(s))
+        s2 = SettingsSchema(output_style=OutputStyleSettings(style="my-custom-style"))
+        assert not any(e.field == "output_style.style" for e in validate_settings(s2))
 
     def test_max_width_too_small(self):
         s = SettingsSchema(output_style=OutputStyleSettings(max_width=10))

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -258,6 +258,7 @@ const SLASHES: ReadonlyArray<{ desc: string; hint?: string; name: string }> = [
   { desc: 'Show available commands', name: '/help' },
   { desc: 'Clear the conversation', name: '/clear' },
   { desc: 'Switch the model', name: '/model' },
+  { desc: 'Set the output style', hint: '[<name>]', name: '/output-style' },
   { desc: 'Set the permission mode', hint: '[default|plan|acceptEdits|dontAsk|bypassPermissions]', name: '/mode' },
   { desc: 'Compact the conversation to save context', name: '/compact' },
   { desc: 'Show context-window usage', name: '/context' },
@@ -894,6 +895,29 @@ export class GatewayClient extends EventEmitter {
         await this.controlQuery('set_model', { model: arg })
 
         return out(`Model set to ${arg ?? '(unchanged)'}.`)
+      case 'output-style': {
+        if (arg) {
+          const r = (await this.controlQuery('set_output_style', { style: arg })) as any
+
+          if (r?.ok === false) {
+            const avail = Array.isArray(r?.available_styles) ? ` Available: ${r.available_styles.join(', ')}.` : ''
+
+            return out(`${r?.error ?? 'Failed to set output style.'}${avail}`)
+          }
+
+          return out(`Output style: ${r?.style ?? arg}.`)
+        }
+
+        const st = (await this.controlQuery('get_settings', {})) as any
+        const avail = Array.isArray(st?.available_output_styles) ? st.available_output_styles : []
+        const current = st?.output_style ?? 'default'
+
+        return out(
+          avail.length
+            ? `Output style: ${current}. Available: ${avail.map((n: string) => (n === current ? `${n} (current)` : n)).join(', ')}.`
+            : `Output style: ${current}.`
+        )
+      }
       case 'provider': {
         const r = (await this.controlQuery('set_provider', { provider: arg })) as any
 


### PR DESCRIPTION
## Summary

`outputStyles/` parity phase OS-1: the folder's single file was already ported (`loader.py` = `loadOutputStylesDir.ts`, ch13 phase-9), but the FEATURE around it was unwired — memory's standing "output styles producer unwired" item, closed end-to-end here.

**G1 — startup producer.** `settings.output_style.style` now initializes `tool_context.output_style_name` at agent-server context construction and the headless entry (`output_style_from_settings`, never raises) — a configured style applies from the first prompt. TS reads `settings?.outputStyle` at prompt-build time (constants/outputStyles.ts:207); this port carries the style on the context (the established `set_output_style` pattern).

**G3 — persistence.** `_do_set_output_style` persists the choice via the new `settings.update_local_settings` — the `updateSettingsForSource('localSettings')` analog (Settings/Config.tsx:1600): atomic merge into the local tier (`.claude/config.local.json` settings block), global-config fallback outside git roots, cache invalidation, best-effort (the in-memory switch still applies on write failure).

**W3 — client command + availability.** The kept ui-tui client gains `/output-style` (SLASHES + arg grammar: named → `set_output_style`; bare → current + available list). `get_settings` now carries `output_style` + `available_output_styles`; the control replies `available_styles` on both paths.

**Validation now follows the loader's truth** — a real bug found while wiring, plus a consistency hole self-caught during critic review: the invented `VALID_OUTPUT_STYLES` tuple **rejected the real builtin `explanatory` and accepted three styles that never existed** (`concise`/`verbose`/`markdown` silently resolved to default), and `settings/validation.py` enforced the same wrong enum (a settings file configuring `explanatory` — which G1 now applies — would flag invalid). The control validates against `available_output_styles()` (builtins ∪ user styles); the enum check and constant are removed (TS's schema is a plain `z.string()`; unknown names fall back to default at resolve time).

**G4 — loader canon dir.** User styles live at `GLOBAL_CONFIG_DIR/outputStyles` (the INTEG-1 canon rule) with `~/.claude/outputStyles` as a documented legacy read-fallback; canon wins collisions; `resolve_output_style` and `available_output_styles` share one resolution (listed == resolvable).

Docs: `my-docs/get-parity-by-folder/outputStyles-{gap-analysis,refactoring-plan}.md` (G5 records the enum removal + the remaining invented `max_width`/`show_thinking` fields for the settings docket; stop-line: plugin styles → plugins docket, picker polish → ui-tui docket).

## Verification

- `tests/test_output_style_wiring.py` **13/13**: startup-producer trio (configured / default / broken-settings-never-raise), persistence roundtrip + deep-merge + global fallback, availability incl. the listing==resolution invariant, canon/legacy dir semantics (canon wins), and direct handler tests (`explanatory` accepted + persisted + replied with availability; `concise` rejected WITH availability).
- Existing output-style suites 70 green; one e2e pin + one validation pin updated from the old invented list (both verified green).
- ui-tui builds (`npm run build`).
- Full suite at the 6-failure baseline (**7774 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
