### PR TITLE
feat(plugins): karpathy-guidelines builtin plugin — registry live end-to-end (PLUGINS-1)

### DIFF
--- a/src/command_system/aggregator.py
+++ b/src/command_system/aggregator.py
@@ -49,6 +49,22 @@ logger = logging.getLogger(__name__)
 SKILLS_DIR_BUCKET: frozenset[str] = frozenset({"skills", "user", "project"})
 
 
+def _builtin_plugin_skill_commands() -> tuple[Command, ...]:
+    """PLUGINS-1 — the commands.ts:401 analog: enabled builtin-plugin skills
+    become slash commands. NOT cached: the enabled gate (settings overlay +
+    default_enabled) must stay fresh, and the registry lookup is cheap.
+    Failures degrade to () — plugins are non-critical."""
+    try:
+        from src.plugins.builtin_plugins import get_builtin_plugin_skill_commands
+
+        return tuple(
+            skill_to_prompt_command(s) for s in get_builtin_plugin_skill_commands()
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("builtin plugin skill loading failed: %s", exc)
+        return ()
+
+
 @lru_cache(maxsize=32)
 def _load_skill_commands_cached(cwd: str) -> tuple[Command, ...]:
     """
@@ -105,6 +121,7 @@ def get_commands(
         *get_builtin_commands(),
         *_load_workflow_commands_cached(cwd_key),
         *_load_skill_commands_cached(cwd_key),
+        *_builtin_plugin_skill_commands(),
     ]
 
     seen: set[str] = set()

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -213,6 +213,14 @@ def run_headless(options: HeadlessOptions) -> int:
         abort_controller=abort_controller,
     )
     tool_context.options.is_non_interactive_session = True
+    # PLUGINS-1 — initBuiltinPlugins (main.tsx:1926 analog), idempotent.
+    try:
+        from src.plugins.init_builtin import init_builtin_plugins
+
+        init_builtin_plugins()
+    except Exception:  # noqa: BLE001
+        pass
+
     # OS-1 G1 — settings-configured output style applies headless too.
     from src.outputStyles import output_style_from_settings
 

--- a/src/plugins/builtin_plugins.py
+++ b/src/plugins/builtin_plugins.py
@@ -34,7 +34,7 @@ def get_builtin_plugins() -> dict[str, list[LoadedPlugin]]:
             continue
 
         plugin_id = f"{name}@{BUILTIN_MARKETPLACE_NAME}"
-        is_enabled = definition.default_enabled
+        is_enabled = _enabled_override(plugin_id, definition.default_enabled)
 
         plugin = LoadedPlugin(
             name=name,
@@ -73,6 +73,21 @@ def get_builtin_plugin_skill_commands() -> list[Skill]:
                 skills.append(skill_def)
 
     return skills
+
+
+def _enabled_override(plugin_id: str, default_enabled: bool) -> bool:
+    """PLUGINS-1 — the user enable/disable overlay (TS persists /plugin
+    toggles to settings). Reads ``settings.extra["enabledPlugins"]``
+    ({plugin_id: bool}); absent → the definition's default. Never raises."""
+    try:
+        from src.settings.settings import load_settings
+
+        overrides = load_settings().extra.get("enabledPlugins")
+        if isinstance(overrides, dict) and plugin_id in overrides:
+            return bool(overrides[plugin_id])
+    except Exception:  # noqa: BLE001
+        pass
+    return default_enabled
 
 
 def clear_builtin_plugins() -> None:

--- a/src/plugins/builtin_plugins.py
+++ b/src/plugins/builtin_plugins.py
@@ -84,7 +84,11 @@ def _enabled_override(plugin_id: str, default_enabled: bool) -> bool:
 
         overrides = load_settings().extra.get("enabledPlugins")
         if isinstance(overrides, dict) and plugin_id in overrides:
-            return bool(overrides[plugin_id])
+            # TS parity: `userSetting === true` (builtinPlugins.ts:71) —
+            # enabledPlugins values may be boolean | string[]; only literal
+            # True enables. (Writer contract: the future /plugin UI must
+            # write extra["enabledPlugins"] camelCase to match this reader.)
+            return overrides[plugin_id] is True
     except Exception:  # noqa: BLE001
         pass
     return default_enabled

--- a/src/plugins/init_builtin.py
+++ b/src/plugins/init_builtin.py
@@ -1,0 +1,12 @@
+"""initBuiltinPlugins analog (PLUGINS-1) — bundled/index.ts + main.tsx:1926.
+
+Idempotent: registration replaces by name, so calling twice is harmless.
+"""
+
+from __future__ import annotations
+
+from .karpathy_guidelines import register_karpathy_guidelines_plugin
+
+
+def init_builtin_plugins() -> None:
+    register_karpathy_guidelines_plugin()

--- a/src/plugins/karpathy_guidelines.py
+++ b/src/plugins/karpathy_guidelines.py
@@ -9,6 +9,8 @@ the user enables it.
 
 from __future__ import annotations
 
+from src.skills.model import Skill
+
 from .builtin_plugins import register_builtin_plugin
 from .types import BuiltinPluginDefinition
 
@@ -26,30 +28,24 @@ def register_karpathy_guidelines_plugin() -> None:
         version="1.0.0",
         default_enabled=False,
         skills=[
-            {
-                "name": "karpathy-guidelines",
-                "description": (
+            # A real Skill instance — get_builtin_plugin_skill_commands
+            # filters with isinstance(skill, Skill); dict defs are skipped.
+            Skill(
+                name="karpathy-guidelines",
+                description=(
                     "Apply coding guidelines that reduce common LLM "
                     "implementation mistakes."
                 ),
-                "when_to_use": (
+                content=KARPATHY_GUIDELINES_PROMPT,
+                source="karpathy-guidelines@builtin",
+                loaded_from="plugin",
+                user_invocable=True,
+                when_to_use=(
                     "Use when writing, reviewing, or refactoring code, "
                     "especially when a task could become overcomplicated or "
                     "needs careful verification."
                 ),
-                "user_invocable": True,
-                "get_prompt_for_command": _prompt_for_command,
-            }
+                version="1.0.0",
+            )
         ],
     ))
-
-
-def _prompt_for_command(args: str) -> list[dict]:
-    """getPromptForCommand analog: optional user focus appended."""
-    focus = (args or "").strip()
-    text = (
-        f"{KARPATHY_GUIDELINES_PROMPT}\n\n## User Focus\n\n{focus}\n"
-        if focus
-        else KARPATHY_GUIDELINES_PROMPT
-    )
-    return [{"type": "text", "text": text}]

--- a/src/plugins/karpathy_guidelines.py
+++ b/src/plugins/karpathy_guidelines.py
@@ -37,6 +37,11 @@ def register_karpathy_guidelines_plugin() -> None:
                     "implementation mistakes."
                 ),
                 content=KARPATHY_GUIDELINES_PROMPT,
+                # B1 (critic): the render paths read markdown_content
+                # (skill_to_prompt_command copies it; _run_markdown_skill
+                # falls back content-wise) — the canonical loader contract
+                # sets BOTH (loader.py:433,:455).
+                markdown_content=KARPATHY_GUIDELINES_PROMPT,
                 source="karpathy-guidelines@builtin",
                 loaded_from="plugin",
                 user_invocable=True,

--- a/src/plugins/karpathy_guidelines.py
+++ b/src/plugins/karpathy_guidelines.py
@@ -1,0 +1,55 @@
+"""Bundled built-in plugin: karpathy-guidelines (PLUGINS-1).
+
+Port of ``typescript/src/plugins/bundled/karpathyGuidelines.ts``. The prompt
+is VERBATIM (model-facing, eval-tuned prose — extracted mechanically from
+the TS source; do not paraphrase). ``defaultEnabled`` is False: the plugin
+appears in the built-in registry but its skill command is exposed only when
+the user enables it.
+"""
+
+from __future__ import annotations
+
+from .builtin_plugins import register_builtin_plugin
+from .types import BuiltinPluginDefinition
+
+KARPATHY_GUIDELINES_PROMPT = '# CLAUDE.md\n\nBehavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.\n\n**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.\n\n## 1. Think Before Coding\n\n**Don\'t assume. Don\'t hide confusion. Surface tradeoffs.**\n\nBefore implementing:\n- State your assumptions explicitly. If uncertain, ask.\n- If multiple interpretations exist, present them - don\'t pick silently.\n- If a simpler approach exists, say so. Push back when warranted.\n- If something is unclear, stop. Name what\'s confusing. Ask.\n\n## 2. Simplicity First\n\n**Minimum code that solves the problem. Nothing speculative.**\n\n- No features beyond what was asked.\n- No abstractions for single-use code.\n- No "flexibility" or "configurability" that wasn\'t requested.\n- No error handling for impossible scenarios.\n- If you write 200 lines and it could be 50, rewrite it.\n\nAsk yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.\n\n## 3. Surgical Changes\n\n**Touch only what you must. Clean up only your own mess.**\n\nWhen editing existing code:\n- Don\'t "improve" adjacent code, comments, or formatting.\n- Don\'t refactor things that aren\'t broken.\n- Match existing style, even if you\'d do it differently.\n- If you notice unrelated dead code, mention it - don\'t delete it.\n\nWhen your changes create orphans:\n- Remove imports/variables/functions that YOUR changes made unused.\n- Don\'t remove pre-existing dead code unless asked.\n\nThe test: Every changed line should trace directly to the user\'s request.\n\n## 4. Goal-Driven Execution\n\n**Define success criteria. Loop until verified.**\n\nTransform tasks into verifiable goals:\n- "Add validation" -> "Write tests for invalid inputs, then make them pass"\n- "Fix the bug" -> "Write a test that reproduces it, then make it pass"\n- "Refactor X" -> "Ensure tests pass before and after"\n\nFor multi-step tasks, state a brief plan:\n```\n1. [Step] -> verify: [check]\n2. [Step] -> verify: [check]\n3. [Step] -> verify: [check]\n```\n\nStrong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.\n\n---\n\n**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.\n'
+
+
+def register_karpathy_guidelines_plugin() -> None:
+    """The registerKarpathyGuidelinesPlugin analog."""
+    register_builtin_plugin(BuiltinPluginDefinition(
+        name="karpathy-guidelines",
+        description=(
+            "Optional coding guidelines that favor simple, surgical, "
+            "verifiable changes."
+        ),
+        version="1.0.0",
+        default_enabled=False,
+        skills=[
+            {
+                "name": "karpathy-guidelines",
+                "description": (
+                    "Apply coding guidelines that reduce common LLM "
+                    "implementation mistakes."
+                ),
+                "when_to_use": (
+                    "Use when writing, reviewing, or refactoring code, "
+                    "especially when a task could become overcomplicated or "
+                    "needs careful verification."
+                ),
+                "user_invocable": True,
+                "get_prompt_for_command": _prompt_for_command,
+            }
+        ],
+    ))
+
+
+def _prompt_for_command(args: str) -> list[dict]:
+    """getPromptForCommand analog: optional user focus appended."""
+    focus = (args or "").strip()
+    text = (
+        f"{KARPATHY_GUIDELINES_PROMPT}\n\n## User Focus\n\n{focus}\n"
+        if focus
+        else KARPATHY_GUIDELINES_PROMPT
+    )
+    return [{"type": "text", "text": text}]

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -2478,6 +2478,15 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
         if sess._mcp_runtime is not None:
             tool_context.mcp_clients = sess._mcp_runtime.clients  # server-name catalog for the agent tool
 
+        # PLUGINS-1 — initBuiltinPlugins (main.tsx:1926 analog): register
+        # bundled built-in plugins before commands/prompt assemble. Idempotent.
+        try:
+            from src.plugins.init_builtin import init_builtin_plugins
+
+            init_builtin_plugins()
+        except Exception:  # noqa: BLE001 — plugins must not block startup
+            logger.debug("[agent-server] init_builtin_plugins failed", exc_info=True)
+
         # OS-1 G1 — the startup producer: a settings-configured output style
         # applies from the FIRST prompt (before this, output_style_name was
         # only ever set by the set_output_style control).

--- a/src/skills/loader.py
+++ b/src/skills/loader.py
@@ -1221,7 +1221,24 @@ def get_registered_skill(name: str) -> Skill | None:
     found = _skill_registry.get(name)
     if found is not None:
         return found
-    return get_bundled_skill_by_name(name)
+    bundled = get_bundled_skill_by_name(name)
+    if bundled is not None:
+        return bundled
+    # PLUGINS-1 — plugin-aware resolution (the TS SkillTool.ts:91 analog:
+    # TS resolves model invocations through the plugin-aware getCommands();
+    # this registry was plugin-blind, so an ENABLED builtin-plugin skill was
+    # advertised to the model but failed "Unknown skill"). Enable-gated by
+    # construction: get_builtin_plugin_skill_commands only yields skills of
+    # ENABLED plugins, so a disabled plugin's skill never leaks here.
+    try:
+        from src.plugins.builtin_plugins import get_builtin_plugin_skill_commands
+
+        for skill in get_builtin_plugin_skill_commands():
+            if skill.name == name or name in getattr(skill, "aliases", ()):
+                return skill
+    except Exception:  # noqa: BLE001 — plugins are non-critical
+        pass
+    return None
 
 
 # Back-compat shim for the old PromptSkill-producing loader. Some callers

--- a/tests/test_plugins_builtin_karpathy.py
+++ b/tests/test_plugins_builtin_karpathy.py
@@ -78,3 +78,56 @@ def test_skill_command_exposed_only_when_enabled(monkeypatch, tmp_path):
     monkeypatch.setattr(settings_mod, "load_settings", lambda **kw: _S())
     names_enabled = {c.name for c in get_commands(cwd=str(d2))}
     assert "karpathy-guidelines" in names_enabled
+
+
+def test_enabled_command_renders_guidelines(monkeypatch, tmp_path):
+    """B1 execution pin (critic): the enabled command must RENDER the
+    guidelines — both the headless fallback and the skill-runner path."""
+    import src.settings.settings as settings_mod
+
+    class _S:
+        extra = {"enabledPlugins": {"karpathy-guidelines@builtin": True}}
+    monkeypatch.setattr(settings_mod, "load_settings", lambda **kw: _S())
+    init_builtin_plugins()
+    from src.command_system.aggregator import get_commands
+
+    import asyncio
+
+    cmd = next(c for c in get_commands(cwd=str(tmp_path)) if c.name == "karpathy-guidelines")
+    rendered = asyncio.run(cmd.get_prompt_for_command("", None))
+    # Content-block list (the canonical prompt-command shape).
+    text = "".join(
+        b.get("text", "") for b in rendered if isinstance(b, dict)
+    ) if isinstance(rendered, list) else str(rendered)
+    assert "## 1. Think Before Coding" in text
+    assert len(text) >= 2351
+
+
+def test_skill_tool_resolves_enabled_plugin_skill(monkeypatch):
+    """B2 pin: get_registered_skill (the Skill tool's resolution path) finds
+    the ENABLED plugin skill; a disabled plugin's skill never leaks."""
+    import src.settings.settings as settings_mod
+    from src.skills.loader import get_registered_skill
+
+    init_builtin_plugins()
+    assert get_registered_skill("karpathy-guidelines") is None  # default off
+
+    class _S:
+        extra = {"enabledPlugins": {"karpathy-guidelines@builtin": True}}
+    monkeypatch.setattr(settings_mod, "load_settings", lambda **kw: _S())
+    skill = get_registered_skill("karpathy-guidelines")
+    assert skill is not None
+    assert "## 1. Think Before Coding" in (skill.markdown_content or skill.content)
+
+
+def test_string_list_override_is_disabled(monkeypatch):
+    """TS parity: enabledPlugins values are boolean|string[]; only literal
+    True enables (userSetting === true)."""
+    import src.settings.settings as settings_mod
+
+    class _S:
+        extra = {"enabledPlugins": {"karpathy-guidelines@builtin": ["1.0.0"]}}
+    monkeypatch.setattr(settings_mod, "load_settings", lambda **kw: _S())
+    init_builtin_plugins()
+    ps = get_builtin_plugins()
+    assert [p.name for p in ps["disabled"]] == ["karpathy-guidelines"]

--- a/tests/test_plugins_builtin_karpathy.py
+++ b/tests/test_plugins_builtin_karpathy.py
@@ -1,0 +1,56 @@
+"""PLUGINS-1 — the karpathy-guidelines bundled builtin plugin.
+
+Registry was ported 6/6 but INERT (zero registrations/consumers); this
+phase ports the one bundled plugin verbatim and inits it at startup.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.plugins.builtin_plugins import (
+    clear_builtin_plugins,
+    get_builtin_plugin_definition,
+    get_builtin_plugins,
+)
+from src.plugins.init_builtin import init_builtin_plugins
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    clear_builtin_plugins()
+    yield
+    clear_builtin_plugins()
+
+
+def test_init_registers_karpathy_default_disabled():
+    init_builtin_plugins()
+    init_builtin_plugins()  # idempotent
+    ps = get_builtin_plugins()
+    assert [p.name for p in ps["disabled"]] == ["karpathy-guidelines"]
+    assert ps["enabled"] == []
+
+
+def test_prompt_verbatim_pin():
+    """The prompt is model-facing eval-tuned prose, mechanically extracted
+    from the TS template literal — pin its size and section headers."""
+    from src.plugins.karpathy_guidelines import KARPATHY_GUIDELINES_PROMPT as P
+
+    assert len(P) == 2351
+    for header in (
+        "## 1. Think Before Coding",
+        "## 2. Simplicity First",
+        "## 3. Surgical Changes",
+        "## 4. Goal-Driven Execution",
+    ):
+        assert header in P
+
+
+def test_focus_suffix():
+    init_builtin_plugins()
+    d = get_builtin_plugin_definition("karpathy-guidelines")
+    skill = d.skills[0]
+    bare = skill["get_prompt_for_command"]("")
+    focused = skill["get_prompt_for_command"](" tighten error handling ")
+    assert "## User Focus" not in bare[0]["text"]
+    assert focused[0]["text"].rstrip().endswith("tighten error handling")
+    assert "## User Focus" in focused[0]["text"]

--- a/tests/test_plugins_builtin_karpathy.py
+++ b/tests/test_plugins_builtin_karpathy.py
@@ -45,12 +45,36 @@ def test_prompt_verbatim_pin():
         assert header in P
 
 
-def test_focus_suffix():
+def test_skill_shape_and_content():
+    """The registry filter requires a real Skill instance; its content is
+    the verbatim prompt (args handling is the skill runner's job)."""
+    from src.skills.model import Skill
+    from src.plugins.karpathy_guidelines import KARPATHY_GUIDELINES_PROMPT
+
     init_builtin_plugins()
     d = get_builtin_plugin_definition("karpathy-guidelines")
     skill = d.skills[0]
-    bare = skill["get_prompt_for_command"]("")
-    focused = skill["get_prompt_for_command"](" tighten error handling ")
-    assert "## User Focus" not in bare[0]["text"]
-    assert focused[0]["text"].rstrip().endswith("tighten error handling")
-    assert "## User Focus" in focused[0]["text"]
+    assert isinstance(skill, Skill)
+    assert skill.content == KARPATHY_GUIDELINES_PROMPT
+    assert skill.user_invocable is True
+    assert skill.loaded_from == "plugin"
+
+
+def test_skill_command_exposed_only_when_enabled(monkeypatch, tmp_path):
+    """commands.ts:401 analog: the skill surfaces as a command ONLY when the
+    plugin is enabled (settings overlay over default_enabled=False)."""
+    from src.command_system.aggregator import get_commands
+
+    init_builtin_plugins()
+    d1 = tmp_path / "a"; d1.mkdir()
+    d2 = tmp_path / "b"; d2.mkdir()  # distinct cwd — get_commands caches per cwd
+    names_disabled = {c.name for c in get_commands(cwd=str(d1))}
+    assert "karpathy-guidelines" not in names_disabled  # default off
+
+    import src.settings.settings as settings_mod
+
+    class _S:
+        extra = {"enabledPlugins": {"karpathy-guidelines@builtin": True}}
+    monkeypatch.setattr(settings_mod, "load_settings", lambda **kw: _S())
+    names_enabled = {c.name for c in get_commands(cwd=str(d2))}
+    assert "karpathy-guidelines" in names_enabled


### PR DESCRIPTION
## Summary

`plugins/` parity phase PLUGINS-1: the TS folder is the built-in plugin registry (`builtinPlugins.ts`) plus ONE bundled plugin (`bundled/karpathyGuidelines.ts`). Python's registry mirrored it 6/6 but was **inert** — zero registrations, zero consumers (the registered-but-inert class the sweep exists to catch).

**The plugin.** `src/plugins/karpathy_guidelines.py` carries the guidelines prompt **verbatim** — mechanically extracted from the TS template literal (2,351 chars, byte-identical per the critic's independent SHA256 check) — registered as `default_enabled=False` with a real `Skill` instance (the registry's skill-command path `isinstance`-filters; dict defs are silently skipped).

**Startup + gate.** `init_builtin_plugins()` (idempotent) runs at both `main.tsx:1926` analogs (agent-server `_build_runtime` + headless, guarded). `get_builtin_plugins` gains the user enable/disable overlay: `settings.extra["enabledPlugins"]` (`{plugin_id: bool}`) over `default_enabled`, with TS `userSetting === true` parity (string[] values disable).

**The wiring (commands.ts:401 analog).** `get_commands` merges `_builtin_plugin_skill_commands()` — deliberately uncached so the enabled gate stays fresh (a placement bug during wiring briefly stole `_load_skill_commands_cached`'s `@lru_cache`; caught by the enabled-gate test).

**Critic round (execution-verified).** The first cut shipped a feature that **rendered empty**: only `Skill.content` was set while both render paths read `markdown_content` (B1 — fixed per the canonical loader contract, both fields set), and the model was advertised the enabled skill but invocation failed "Unknown skill" because `get_registered_skill` was plugin-blind where TS resolves through the plugin-aware `getCommands()` (SkillTool.ts:91) — fixed with an enable-gated plugin fallback (only ENABLED plugins' skills are yielded; disabled never leak). The original tests were green throughout because they asserted fields the runtime never reads — the round added three **execution pins** (render through the aggregator-built command asserting the guidelines in the output; Skill-tool resolution enabled-only/default-off; string-list override disabled). The plan doc records the lesson.

Docs: `my-docs/get-parity-by-folder/plugins-{gap-analysis,refactoring-plan}.md` (as-built + critic-round addendum). Stop-line: `utils/plugins/*` (marketplace loader/manifests) → utils docket; the `/plugin` management UI → ui-tui docket.

## Verification

- `tests/test_plugins_builtin_karpathy.py` **7/7**: idempotent default-disabled registration, verbatim pin (2,351 chars + all four section headers), Skill-shape pin, enabled-gate command exposure (distinct cwds — `get_commands` caches per cwd), the B1 render execution pin, the B2 resolution pin, and the string-list-disables parity pin.
- Touched slice (plugin/aggregator/command_system/skills): 484 passed.
- Full suite at the 6-failure baseline (**7787 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
