### PR TITLE
feat(query): teammate TaskCompleted + TeammateIdle stop hooks (QUERY-1)

### DIFF
--- a/src/agent/run_agent.py
+++ b/src/agent/run_agent.py
@@ -54,6 +54,10 @@ class RunAgentParams:
     # Optional overrides
     model: str | None = None
     agent_id: str | None = None
+    # QUERY-1 — the spawn's addressable name (Agent tool `name` param).
+    # A NAMED agent inside a team is this port's teammate: the identity is
+    # threaded to the subagent context so teammate stop hooks can gate.
+    agent_name: str | None = None
     is_async: bool = False
     max_turns: int | None = None
     system_prompt_override: str | None = None
@@ -323,6 +327,7 @@ async def run_agent(params: RunAgentParams) -> AsyncGenerator[Message, None]:
     overrides = SubagentContextOverrides(
         agent_id=agent_id,
         agent_type=agent_def.agent_type,
+        teammate_name=params.agent_name,
         messages=sanitized_context_messages,
         abort_controller=abort_controller,
         permission_context=perm_context,

--- a/src/agent/subagent_context.py
+++ b/src/agent/subagent_context.py
@@ -185,7 +185,11 @@ def create_subagent_context(
         # agent + parent team): TS keeps one board (AppState.tasks; the
         # team file), so a teammate's TaskCompleted stop hooks can see the
         # tasks the leader assigned it. Anonymous subagents keep the ch10
-        # fresh-isolation semantics.
+        # fresh-isolation semantics. INVARIANT (critic M1): this is a plain
+        # dict shared by reference — NOT RLock-guarded like runtime_tasks.
+        # Readers snapshot (list()) before filtering; if teammate fan-out
+        # ever mutates the board from worker threads, guard it like the
+        # sibling stores.
         tasks=(
             parent_context.tasks
             if (

--- a/src/agent/subagent_context.py
+++ b/src/agent/subagent_context.py
@@ -181,7 +181,20 @@ def create_subagent_context(
         lsp_client=parent_context.lsp_client,
         # Fresh isolated collections
         todos=[],
-        tasks={},
+        # QUERY-1 — the task BOARD is shared for TEAMMATE spawns (named
+        # agent + parent team): TS keeps one board (AppState.tasks; the
+        # team file), so a teammate's TaskCompleted stop hooks can see the
+        # tasks the leader assigned it. Anonymous subagents keep the ch10
+        # fresh-isolation semantics.
+        tasks=(
+            parent_context.tasks
+            if (
+                overrides.teammate_name
+                and isinstance(parent_context.team, dict)
+                and parent_context.team.get("team_name")
+            )
+            else {}
+        ),
         outbox=[],
         crons={},
         # No-op / None for UI callbacks

--- a/src/agent/subagent_context.py
+++ b/src/agent/subagent_context.py
@@ -34,6 +34,9 @@ class SubagentContextOverrides:
     options: ToolUseOptions | None = None
     agent_id: str | None = None
     agent_type: str | None = None
+    # QUERY-1 — teammate identity (the Agent tool's `name`); None for
+    # anonymous subagents.
+    teammate_name: str | None = None
     messages: list[Any] | None = None
     read_file_state: dict[Any, Any] | None = None
     abort_controller: AbortController | None = None
@@ -200,6 +203,16 @@ def create_subagent_context(
         content_replacement_state=content_replacement_state,
         agent_id=agent_id,
         agent_type=agent_type,
+        # QUERY-1 — teammate identity: name from the spawn; team from the
+        # parent's team file (both required by the stop-hook gate, matching
+        # TS teammate.ts:125-131 — a named agent OUTSIDE a team is not a
+        # teammate).
+        teammate_name=overrides.teammate_name,
+        team_name=(
+            (parent_context.team or {}).get("team_name")
+            if isinstance(parent_context.team, dict)
+            else None
+        ),
         user_modified=parent_context.user_modified,
         # ch01 round-4 WI-1 — hooks apply to sub-agents exactly as to the
         # parent: same config snapshot, same workspace-trust verdict.

--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -692,6 +692,7 @@ async def execute_teammate_idle_hooks(
     teammate_name: str,
     team_name: str,
     tool_use_context: Any,
+    permission_mode: str | None = None,
 ) -> AsyncGenerator[dict[str, Any], None]:
     """QUERY-1 — port of ``executeTeammateIdleHooks`` (utils/hooks.ts:3920):
     fired from the teammate's stop path after the core Stop/SubagentStop
@@ -701,6 +702,8 @@ async def execute_teammate_idle_hooks(
         "teammate_name": teammate_name,
         "team_name": team_name,
     }
+    if permission_mode:
+        stdin_data["permission_mode"] = permission_mode
     abort_signal = None
     abort_ctrl = getattr(tool_use_context, "abort_controller", None)
     if abort_ctrl:
@@ -723,6 +726,7 @@ async def execute_task_completed_hooks(
     teammate_name: str,
     team_name: str,
     tool_use_context: Any,
+    permission_mode: str | None = None,
 ) -> AsyncGenerator[dict[str, Any], None]:
     """QUERY-1 — port of ``executeTaskCompletedHooks`` (utils/hooks.ts:4000):
     fired once per in-progress task OWNED by the stopping teammate. Hook
@@ -735,6 +739,8 @@ async def execute_task_completed_hooks(
         "teammate_name": teammate_name,
         "team_name": team_name,
     }
+    if permission_mode:
+        stdin_data["permission_mode"] = permission_mode
     abort_signal = None
     abort_ctrl = getattr(tool_use_context, "abort_controller", None)
     if abort_ctrl:

--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -687,3 +687,65 @@ def _flatten_text(content: Any) -> str:
                 parts.append(text)
         return " ".join(parts)
     return str(content or "")
+
+async def execute_teammate_idle_hooks(
+    teammate_name: str,
+    team_name: str,
+    tool_use_context: Any,
+) -> AsyncGenerator[dict[str, Any], None]:
+    """QUERY-1 — port of ``executeTeammateIdleHooks`` (utils/hooks.ts:3920):
+    fired from the teammate's stop path after the core Stop/SubagentStop
+    loop. Matcher-less (no tool scoping); hook stdin carries the teammate
+    identity."""
+    stdin_data: dict[str, Any] = {
+        "teammate_name": teammate_name,
+        "team_name": team_name,
+    }
+    abort_signal = None
+    abort_ctrl = getattr(tool_use_context, "abort_controller", None)
+    if abort_ctrl:
+        abort_signal = abort_ctrl.signal
+
+    async for result in _run_hooks_for_event(
+        "TeammateIdle",
+        None,
+        stdin_data,
+        tool_use_context,
+        abort_signal,
+    ):
+        yield result
+
+
+async def execute_task_completed_hooks(
+    task_id: str,
+    task_subject: str,
+    task_description: str | None,
+    teammate_name: str,
+    team_name: str,
+    tool_use_context: Any,
+) -> AsyncGenerator[dict[str, Any], None]:
+    """QUERY-1 — port of ``executeTaskCompletedHooks`` (utils/hooks.ts:4000):
+    fired once per in-progress task OWNED by the stopping teammate. Hook
+    stdin carries the task fields + teammate identity
+    (TaskCompletedHookInput)."""
+    stdin_data: dict[str, Any] = {
+        "task_id": task_id,
+        "task_subject": task_subject,
+        "task_description": task_description,
+        "teammate_name": teammate_name,
+        "team_name": team_name,
+    }
+    abort_signal = None
+    abort_ctrl = getattr(tool_use_context, "abort_controller", None)
+    if abort_ctrl:
+        abort_signal = abort_ctrl.signal
+
+    async for result in _run_hooks_for_event(
+        "TaskCompleted",
+        None,
+        stdin_data,
+        tool_use_context,
+        abort_signal,
+    ):
+        yield result
+

--- a/src/query/stop_hooks.py
+++ b/src/query/stop_hooks.py
@@ -109,9 +109,21 @@ async def _handle_stop_hooks_generator(
         # Gate on the SAME event the executor will dispatch (SubagentStop
         # when agent_id is set, hook_executor.py:561) — gating on "Stop"
         # alone silently disables SubagentStop-only configurations.
-        if not has_hook_for_event(
+        core_gate = has_hook_for_event(
             "SubagentStop" if agent_id else "Stop", tool_use_context
-        ):
+        )
+        # QUERY-1 — teammate identity gate (stopHooks.ts:335): both fields
+        # required (teammate.ts:125-131). The teammate block must run even
+        # when NO Stop/SubagentStop hooks are configured, so the early
+        # return considers all three events.
+        teammate_name = getattr(tool_use_context, "teammate_name", None)
+        team_name = getattr(tool_use_context, "team_name", None)
+        is_teammate = bool(teammate_name and team_name)
+        teammate_gate = is_teammate and (
+            has_hook_for_event("TaskCompleted", tool_use_context)
+            or has_hook_for_event("TeammateIdle", tool_use_context)
+        )
+        if not core_gate and not teammate_gate:
             return
 
         blocking_errors: list[Message] = []
@@ -125,108 +137,216 @@ async def _handle_stop_hooks_generator(
 
         all_messages = [*messages_for_query, *assistant_messages]
 
-        async for hook_result in execute_stop_hooks(
-            permission_mode=permission_mode,
-            abort_signal=abort_ctrl.signal if abort_ctrl else None,
-            stop_hook_active=stop_hook_active or False,
-            subagent_id=agent_id,
-            tool_use_context=tool_use_context,
-            messages=all_messages,
-            agent_type=agent_type,
-        ):
-            if hook_result.get("message"):
-                msg = hook_result["message"]
-                yield msg
+        if core_gate:
+            async for hook_result in execute_stop_hooks(
+                permission_mode=permission_mode,
+                abort_signal=abort_ctrl.signal if abort_ctrl else None,
+                stop_hook_active=stop_hook_active or False,
+                subagent_id=agent_id,
+                tool_use_context=tool_use_context,
+                messages=all_messages,
+                agent_type=agent_type,
+            ):
+                if hook_result.get("message"):
+                    msg = hook_result["message"]
+                    yield msg
 
-                if hasattr(msg, "type") and msg.type == "progress":
-                    if hasattr(msg, "toolUseID") and msg.toolUseID:
-                        stop_hook_tool_use_id = msg.toolUseID
-                        hook_count += 1
-                    progress_data = getattr(msg, "data", None)
-                    if isinstance(progress_data, dict) and progress_data.get("command"):
-                        hook_infos.append(StopHookInfo(
-                            command=progress_data["command"],
-                            prompt_text=progress_data.get("prompt_text"),
-                        ))
+                    if hasattr(msg, "type") and msg.type == "progress":
+                        if hasattr(msg, "toolUseID") and msg.toolUseID:
+                            stop_hook_tool_use_id = msg.toolUseID
+                            hook_count += 1
+                        progress_data = getattr(msg, "data", None)
+                        if isinstance(progress_data, dict) and progress_data.get("command"):
+                            hook_infos.append(StopHookInfo(
+                                command=progress_data["command"],
+                                prompt_text=progress_data.get("prompt_text"),
+                            ))
 
-                if hasattr(msg, "type") and msg.type == "attachment":
-                    attachments = getattr(msg, "attachments", [])
-                    for attachment in attachments:
-                        hook_event = attachment.get("hook_event", "")
-                        if hook_event in ("Stop", "SubagentStop"):
-                            att_type = attachment.get("type", "")
-                            if att_type == "hook_non_blocking_error":
-                                hook_errors.append(
-                                    attachment.get("stderr") or f"Exit code {attachment.get('exit_code')}"
-                                )
-                                has_output = True
-                            elif att_type == "hook_error_during_execution":
-                                hook_errors.append(attachment.get("content", ""))
-                                has_output = True
-                            elif att_type == "hook_success":
-                                if (
-                                    (attachment.get("stdout") or "").strip()
-                                    or (attachment.get("stderr") or "").strip()
-                                ):
+                    if hasattr(msg, "type") and msg.type == "attachment":
+                        attachments = getattr(msg, "attachments", [])
+                        for attachment in attachments:
+                            hook_event = attachment.get("hook_event", "")
+                            if hook_event in ("Stop", "SubagentStop"):
+                                att_type = attachment.get("type", "")
+                                if att_type == "hook_non_blocking_error":
+                                    hook_errors.append(
+                                        attachment.get("stderr") or f"Exit code {attachment.get('exit_code')}"
+                                    )
                                     has_output = True
+                                elif att_type == "hook_error_during_execution":
+                                    hook_errors.append(attachment.get("content", ""))
+                                    has_output = True
+                                elif att_type == "hook_success":
+                                    if (
+                                        (attachment.get("stdout") or "").strip()
+                                        or (attachment.get("stderr") or "").strip()
+                                    ):
+                                        has_output = True
 
-            if hook_result.get("blocking_error"):
-                error_info = hook_result["blocking_error"]
-                error_message = _get_stop_hook_message(error_info)
-                user_msg = create_user_message(
-                    content=error_message,
-                    isMeta=True,
+                if hook_result.get("blocking_error"):
+                    error_info = hook_result["blocking_error"]
+                    error_message = _get_stop_hook_message(error_info)
+                    user_msg = create_user_message(
+                        content=error_message,
+                        isMeta=True,
+                    )
+                    blocking_errors.append(user_msg)
+                    yield user_msg
+                    has_output = True
+                    hook_errors.append(
+                        error_info.get("blocking_error", "")
+                        if isinstance(error_info, dict)
+                        else str(error_info)
+                    )
+
+                if hook_result.get("prevent_continuation"):
+                    prevented_continuation = True
+                    stop_reason = hook_result.get("stop_reason") or "Stop hook prevented continuation"
+                    yield create_attachment_message({
+                        "type": "hook_stopped_continuation",
+                        "message": stop_reason,
+                        "hook_name": "Stop",
+                        "tool_use_id": stop_hook_tool_use_id,
+                        "hook_event": "Stop",
+                    })
+
+                if abort_ctrl and abort_ctrl.signal.aborted:
+                    yield create_user_interruption_message(tool_use=False)
+                    result_out.blocking_errors = []
+                    result_out.prevent_continuation = True
+                    return
+
+            if hook_count > 0:
+                yield create_stop_hook_summary_message(
+                    hook_count=hook_count,
+                    hook_infos=[
+                        {"command": h.command, "prompt_text": h.prompt_text, "duration_ms": h.duration_ms}
+                        for h in hook_infos
+                    ],
+                    hook_errors=hook_errors,
+                    prevented_continuation=prevented_continuation,
+                    stop_reason=stop_reason,
+                    has_output=has_output,
+                    suggestion_type="suggestion",
+                    tool_use_id=stop_hook_tool_use_id,
                 )
-                blocking_errors.append(user_msg)
-                yield user_msg
-                has_output = True
-                hook_errors.append(
-                    error_info.get("blocking_error", "")
-                    if isinstance(error_info, dict)
-                    else str(error_info)
-                )
 
-            if hook_result.get("prevent_continuation"):
-                prevented_continuation = True
-                stop_reason = hook_result.get("stop_reason") or "Stop hook prevented continuation"
-                yield create_attachment_message({
-                    "type": "hook_stopped_continuation",
-                    "message": stop_reason,
-                    "hook_name": "Stop",
-                    "tool_use_id": stop_hook_tool_use_id,
-                    "hook_event": "Stop",
-                })
-
-            if abort_ctrl and abort_ctrl.signal.aborted:
-                yield create_user_interruption_message(tool_use=False)
+            if prevented_continuation:
                 result_out.blocking_errors = []
                 result_out.prevent_continuation = True
                 return
 
-        if hook_count > 0:
-            yield create_stop_hook_summary_message(
-                hook_count=hook_count,
-                hook_infos=[
-                    {"command": h.command, "prompt_text": h.prompt_text, "duration_ms": h.duration_ms}
-                    for h in hook_infos
-                ],
-                hook_errors=hook_errors,
-                prevented_continuation=prevented_continuation,
-                stop_reason=stop_reason,
-                has_output=has_output,
-                suggestion_type="suggestion",
-                tool_use_id=stop_hook_tool_use_id,
+            if blocking_errors:
+                result_out.blocking_errors = blocking_errors
+                result_out.prevent_continuation = False
+                return
+
+        # ── QUERY-1: teammate TaskCompleted + TeammateIdle hooks ──────────
+        # Port of stopHooks.ts:335-453 — runs AFTER the core loop (TS
+        # ordering: core prevent-continuation returns before this block).
+        if is_teammate:
+            from src.hooks.hook_executor import (
+                execute_task_completed_hooks,
+                execute_teammate_idle_hooks,
             )
 
-        if prevented_continuation:
-            result_out.blocking_errors = []
-            result_out.prevent_continuation = True
-            return
+            teammate_blocking_errors: list[Message] = []
+            teammate_prevented = False
+            teammate_stop_reason = ""
+            teammate_tool_use_id = ""
 
-        if blocking_errors:
-            result_out.blocking_errors = blocking_errors
-            result_out.prevent_continuation = False
-            return
+            async def _drive(generator, event_name: str, message_prefix: str):
+                nonlocal teammate_prevented, teammate_stop_reason, teammate_tool_use_id
+                async for result in generator:
+                    msg = result.get("message")
+                    if msg is not None:
+                        if getattr(msg, "type", "") == "progress" and getattr(msg, "toolUseID", ""):
+                            teammate_tool_use_id = msg.toolUseID
+                        yield msg
+                    if result.get("blocking_error"):
+                        error_info = result["blocking_error"]
+                        text = (
+                            error_info.get("blocking_error", "")
+                            if isinstance(error_info, dict)
+                            else str(error_info)
+                        )
+                        user_msg = create_user_message(
+                            content=f"{message_prefix}\n{text}",
+                            isMeta=True,
+                        )
+                        teammate_blocking_errors.append(user_msg)
+                        yield user_msg
+                    if result.get("prevent_continuation"):
+                        teammate_prevented = True
+                        teammate_stop_reason = (
+                            result.get("stop_reason")
+                            or f"{event_name} hook prevented continuation"
+                        )
+                        yield create_attachment_message({
+                            "type": "hook_stopped_continuation",
+                            "message": teammate_stop_reason,
+                            "hook_name": event_name,
+                            "tool_use_id": teammate_tool_use_id,
+                            "hook_event": event_name,
+                        })
+                    if abort_ctrl and abort_ctrl.signal.aborted:
+                        result_out.blocking_errors = []
+                        result_out.prevent_continuation = True
+                        return
+
+            # (a) TaskCompleted per in-progress task OWNED by this teammate.
+            if has_hook_for_event("TaskCompleted", tool_use_context):
+                try:
+                    # The shared task store lives on the context
+                    # (tasks_v2's source of truth: context.tasks — dicts
+                    # keyed by id with status/owner/subject fields).
+                    task_map = getattr(tool_use_context, "tasks", {}) or {}
+                    owned = [
+                        t for t in task_map.values()
+                        if isinstance(t, dict)
+                        and t.get("status") == "in_progress"
+                        and t.get("owner") == teammate_name
+                    ]
+                except Exception:  # noqa: BLE001 — tasks are non-critical
+                    owned = []
+                for task in owned:
+                    async for msg in _drive(
+                        execute_task_completed_hooks(
+                            str(task.get("id", "")),
+                            str(task.get("subject", "")),
+                            task.get("description"),
+                            teammate_name,
+                            team_name,
+                            tool_use_context,
+                        ),
+                        "TaskCompleted",
+                        "TaskCompleted hook feedback:",
+                    ):
+                        yield msg
+                    if result_out.prevent_continuation:
+                        return
+
+            # (b) TeammateIdle, always (when configured).
+            if has_hook_for_event("TeammateIdle", tool_use_context):
+                async for msg in _drive(
+                    execute_teammate_idle_hooks(
+                        teammate_name, team_name, tool_use_context,
+                    ),
+                    "TeammateIdle",
+                    "TeammateIdle hook feedback:",
+                ):
+                    yield msg
+                if result_out.prevent_continuation:
+                    return
+
+            if teammate_prevented:
+                result_out.blocking_errors = []
+                result_out.prevent_continuation = True
+                return
+            if teammate_blocking_errors:
+                result_out.blocking_errors = teammate_blocking_errors
+                result_out.prevent_continuation = False
+                return
 
     except Exception as error:
         duration_ms = int((time.time() - hook_start_time) * 1000)

--- a/src/query/stop_hooks.py
+++ b/src/query/stop_hooks.py
@@ -301,8 +301,15 @@ async def _handle_stop_hooks_generator(
                     # (tasks_v2's source of truth: context.tasks — dicts
                     # keyed by id with status/owner/subject fields).
                     task_map = getattr(tool_use_context, "tasks", {}) or {}
+                    # M1 (critic): the board is a plain dict shared BY
+                    # REFERENCE for teammate spawns (unlike the RLock-guarded
+                    # runtime_tasks). Snapshot before filtering so a leader
+                    # mutating concurrently can at worst race the snapshot
+                    # (contained by this try) rather than the whole sweep;
+                    # the sync-only invariant for teammate boards is
+                    # documented at the sharing site (subagent_context).
                     owned = [
-                        t for t in task_map.values()
+                        t for t in list(task_map.values())
                         if isinstance(t, dict)
                         and t.get("status") == "in_progress"
                         and t.get("owner") == teammate_name
@@ -318,6 +325,7 @@ async def _handle_stop_hooks_generator(
                             teammate_name,
                             team_name,
                             tool_use_context,
+                            permission_mode=permission_mode,
                         ),
                         "TaskCompleted",
                         "TaskCompleted hook feedback:",
@@ -331,6 +339,7 @@ async def _handle_stop_hooks_generator(
                 async for msg in _drive(
                     execute_teammate_idle_hooks(
                         teammate_name, team_name, tool_use_context,
+                        permission_mode=permission_mode,
                     ),
                     "TeammateIdle",
                     "TeammateIdle hook feedback:",

--- a/src/tool_system/context.py
+++ b/src/tool_system/context.py
@@ -191,6 +191,11 @@ class ToolContext:
     glob_limits: GlobLimits | None = None
     content_replacement_state: Any | None = None
     agent_id: str | None = None
+    # QUERY-1 — teammate identity (TS teammate.ts:125: a teammate requires
+    # BOTH). Threaded by the in-process-teammate spawn; None for plain
+    # subagents, so the teammate stop-hook block never fires for them.
+    teammate_name: str | None = None
+    team_name: str | None = None
     agent_type: str | None = None
     tool_use_id: str | None = None
     user_modified: bool = False

--- a/src/tool_system/context.py
+++ b/src/tool_system/context.py
@@ -192,8 +192,10 @@ class ToolContext:
     content_replacement_state: Any | None = None
     agent_id: str | None = None
     # QUERY-1 — teammate identity (TS teammate.ts:125: a teammate requires
-    # BOTH). Threaded by the in-process-teammate spawn; None for plain
-    # subagents, so the teammate stop-hook block never fires for them.
+    # BOTH). Threaded by the Agent tool's NAMED spawn (run_agent →
+    # create_subagent_context) when the parent carries a TeamCreate'd team;
+    # None for plain subagents, so the teammate stop-hook block never fires
+    # for them.
     teammate_name: str | None = None
     team_name: str | None = None
     agent_type: str | None = None

--- a/src/tool_system/tools/agent.py
+++ b/src/tool_system/tools/agent.py
@@ -357,6 +357,7 @@ def make_agent_tool(
             provider=provider,
             model=model,
             agent_id=agent_id,
+            agent_name=agent_name,
             is_async=is_async,
             max_turns=agent_def.max_turns,
             context_messages=fork_context_messages,

--- a/tests/test_teammate_stop_hooks.py
+++ b/tests/test_teammate_stop_hooks.py
@@ -1,0 +1,192 @@
+"""QUERY-1 — teammate TaskCompleted + TeammateIdle stop hooks.
+
+Port of stopHooks.ts:335-453 + the executors (utils/hooks.ts:3920/:4000).
+Execution-style per the plugins-round lesson: the real stop-hooks generator
+is driven with real command hooks (echo/exit), asserting on YIELDED
+messages and the result_out contract — not on shapes the runtime never
+reads.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.hooks.hook_types import HookConfig, HookSource
+from src.query.stop_hooks import StopHookResult, _handle_stop_hooks_generator
+
+
+class _Snapshot:
+    def __init__(self, hooks: dict):
+        self.hooks = hooks
+
+
+def _ctx(*, hooks: dict, teammate: bool = True, tasks: dict | None = None):
+    from src.tool_system.context import ToolContext
+
+    ctx = ToolContext(workspace_root=Path("/tmp"))
+    ctx.workspace_trusted = True
+    ctx.agent_id = "a1b2"  # teammates run as subagents
+    if teammate:
+        ctx.teammate_name = "researcher"
+        ctx.team_name = "my-team"
+    if tasks:
+        ctx.tasks.update(tasks)
+    mgr = MagicMock()
+    mgr.snapshot = _Snapshot(hooks)
+    ctx.hook_config_manager = mgr
+    return ctx
+
+
+def _hook(command: str) -> list:
+    return [HookConfig(type="command", command=command, source=HookSource.PROJECT_SETTINGS)]
+
+
+def _drive(ctx) -> tuple[list, StopHookResult]:
+    result = StopHookResult()
+
+    async def go():
+        out = []
+        async for msg in _handle_stop_hooks_generator(
+            [], [], "", ctx, "repl", None, result,
+        ):
+            out.append(msg)
+        return out
+
+    return asyncio.run(go()), result
+
+
+OWNED_TASK = {"1": {"id": "1", "subject": "port hooks", "description": "d",
+                    "status": "in_progress", "owner": "researcher"}}
+OTHER_TASKS = {
+    "2": {"id": "2", "subject": "x", "status": "in_progress", "owner": "someone-else"},
+    "3": {"id": "3", "subject": "y", "status": "completed", "owner": "researcher"},
+}
+
+
+class TestTeammateBlock:
+    def test_both_events_fire_for_teammate(self, tmp_path):
+        marker_tc = tmp_path / "tc"
+        marker_ti = tmp_path / "ti"
+        ctx = _ctx(
+            hooks={
+                "TaskCompleted": _hook(f"touch {marker_tc}"),
+                "TeammateIdle": _hook(f"touch {marker_ti}"),
+            },
+            tasks=dict(OWNED_TASK),
+        )
+        _drive(ctx)
+        assert marker_tc.exists(), "TaskCompleted must fire for the owned in-progress task"
+        assert marker_ti.exists(), "TeammateIdle must always fire for a teammate"
+
+    def test_non_owned_and_completed_tasks_skipped(self, tmp_path):
+        marker = tmp_path / "tc"
+        ctx = _ctx(
+            hooks={"TaskCompleted": _hook(f"touch {marker}")},
+            tasks=dict(OTHER_TASKS),
+        )
+        _drive(ctx)
+        assert not marker.exists(), "no owned in-progress task → no TaskCompleted"
+
+    def test_non_teammate_never_fires(self, tmp_path):
+        marker = tmp_path / "m"
+        ctx = _ctx(
+            hooks={
+                "TaskCompleted": _hook(f"touch {marker}"),
+                "TeammateIdle": _hook(f"touch {marker}"),
+            },
+            teammate=False,
+            tasks=dict(OWNED_TASK),
+        )
+        _drive(ctx)
+        assert not marker.exists(), "the gate: no teammate identity → no teammate hooks"
+
+    def test_runs_even_without_stop_hooks_configured(self, tmp_path):
+        """The split-gate fix: only TeammateIdle configured (no Stop /
+        SubagentStop) must still reach the teammate block."""
+        marker = tmp_path / "ti"
+        ctx = _ctx(hooks={"TeammateIdle": _hook(f"touch {marker}")})
+        _drive(ctx)
+        assert marker.exists()
+
+    def test_blocking_error_surfaces_with_verbatim_prefix(self):
+        ctx = _ctx(hooks={"TeammateIdle": _hook("echo 'not done yet' >&2; exit 2")})
+        messages, result = _drive(ctx)
+        metas = [m for m in messages
+                 if getattr(m, "type", "") == "user" and getattr(m, "isMeta", False)]
+        assert metas, "blocking exit-2 must yield a meta user message"
+        text = str(getattr(metas[-1], "content", ""))
+        # utils/hooks.ts:2091-2094 verbatim prefix
+        assert text.startswith("TeammateIdle hook feedback:\n")
+        assert "not done yet" in text
+        assert result.blocking_errors and result.prevent_continuation is False
+
+    def test_prevent_continuation_stops_with_attachment(self):
+        payload = '{"preventContinuation": true, "stopReason": "keep working"}'
+        ctx = _ctx(hooks={"TeammateIdle": _hook(f"echo '{payload}'")})
+        messages, result = _drive(ctx)
+        assert result.prevent_continuation is True
+        att = [m for m in messages if getattr(m, "type", "") == "attachment"]
+        joined = str([getattr(a, "attachments", None) for a in att])
+        assert "hook_stopped_continuation" in joined
+        assert "keep working" in joined
+
+    def test_identity_threading_from_named_spawn(self):
+        """W2 pin: a NAMED spawn inside a team threads both fields; an
+        anonymous spawn threads neither."""
+        from src.agent.subagent_context import (
+            SubagentContextOverrides,
+            create_subagent_context,
+        )
+        from src.tool_system.context import ToolContext
+
+        parent = ToolContext(workspace_root=Path("/tmp"))
+        parent.team = {"team_name": "my-team", "members": []}
+        named = create_subagent_context(
+            parent, SubagentContextOverrides(teammate_name="researcher"),
+        )
+        assert named.teammate_name == "researcher"
+        assert named.team_name == "my-team"
+        anon = create_subagent_context(parent, SubagentContextOverrides())
+        assert anon.teammate_name is None
+
+        parent_no_team = ToolContext(workspace_root=Path("/tmp"))
+        named_no_team = create_subagent_context(
+            parent_no_team, SubagentContextOverrides(teammate_name="solo"),
+        )
+        assert named_no_team.team_name is None  # named OUTSIDE a team ≠ teammate
+
+
+class TestExecutors:
+    def test_task_completed_stdin_contract(self, tmp_path):
+        """The hook's stdin carries the TaskCompletedHookInput fields."""
+        out = tmp_path / "stdin.json"
+        ctx = _ctx(
+            hooks={"TaskCompleted": _hook(f"cat > {out}")},
+            tasks=dict(OWNED_TASK),
+        )
+        _drive(ctx)
+        import json
+
+        data = json.loads(out.read_text())
+        # The port's uniform stdin convention is "hook_event" (all existing
+        # events; TS uses hook_event_name — a pre-existing, uniform naming
+        # divergence owned by the hooks docket, not QUERY-1).
+        assert data["hook_event"] == "TaskCompleted"
+        assert data["task_id"] == "1"
+        assert data["task_subject"] == "port hooks"
+        assert data["teammate_name"] == "researcher"
+        assert data["team_name"] == "my-team"
+
+    def test_teammate_idle_stdin_contract(self, tmp_path):
+        out = tmp_path / "stdin.json"
+        ctx = _ctx(hooks={"TeammateIdle": _hook(f"cat > {out}")})
+        _drive(ctx)
+        import json
+
+        data = json.loads(out.read_text())
+        assert data["hook_event"] == "TeammateIdle"
+        assert data["teammate_name"] == "researcher"
+        assert data["team_name"] == "my-team"

--- a/tests/test_teammate_stop_hooks.py
+++ b/tests/test_teammate_stop_hooks.py
@@ -190,3 +190,63 @@ class TestExecutors:
         assert data["hook_event"] == "TeammateIdle"
         assert data["teammate_name"] == "researcher"
         assert data["team_name"] == "my-team"
+
+
+class TestRealPathLiveness:
+    """The critic's liveness demand: fire the block through REAL context
+    construction (TeamCreate-populated team + named spawn via
+    create_subagent_context), not a hand-built context."""
+
+    def test_teammate_context_from_real_spawn_fires_hooks(self, tmp_path):
+        import json as _json
+
+        from src.agent.subagent_context import (
+            SubagentContextOverrides,
+            create_subagent_context,
+        )
+        from src.tool_system.context import ToolContext
+        from src.tool_system.tools.team import TeamCreateTool
+
+        # Leader context; TeamCreate tool populates context.team (team.py:40)
+        leader = ToolContext(workspace_root=tmp_path)
+        leader.workspace_trusted = True
+        TeamCreateTool.call({"team_name": "sweep-team"}, leader)
+        assert leader.team and leader.team["team_name"] == "sweep-team"
+
+        # Leader assigns a task on the shared board
+        leader.tasks["7"] = {"id": "7", "subject": "port query folder",
+                             "status": "in_progress", "owner": "researcher"}
+
+        # Named spawn — the REAL seam (run_agent → create_subagent_context)
+        tm_ctx = create_subagent_context(
+            leader, SubagentContextOverrides(teammate_name="researcher"),
+        )
+        assert tm_ctx.teammate_name == "researcher"
+        assert tm_ctx.team_name == "sweep-team"
+        # The board is SHARED for teammates (TS single-board semantics)
+        assert tm_ctx.tasks is leader.tasks
+
+        marker_tc = tmp_path / "tc"
+        marker_ti = tmp_path / "ti"
+        mgr = MagicMock()
+        mgr.snapshot = _Snapshot({
+            "TaskCompleted": _hook(f"touch {marker_tc}"),
+            "TeammateIdle": _hook(f"touch {marker_ti}"),
+        })
+        tm_ctx.hook_config_manager = mgr
+
+        _, result = _drive(tm_ctx)
+        assert marker_tc.exists(), "TaskCompleted fires on the SHARED board's owned task"
+        assert marker_ti.exists()
+
+    def test_anonymous_subagent_keeps_isolated_board(self, tmp_path):
+        from src.agent.subagent_context import (
+            SubagentContextOverrides,
+            create_subagent_context,
+        )
+        from src.tool_system.context import ToolContext
+
+        leader = ToolContext(workspace_root=tmp_path)
+        leader.tasks["1"] = {"id": "1", "status": "in_progress", "owner": "x"}
+        anon = create_subagent_context(leader, SubagentContextOverrides())
+        assert anon.tasks == {} and anon.tasks is not leader.tasks

--- a/tests/test_teammate_stop_hooks.py
+++ b/tests/test_teammate_stop_hooks.py
@@ -250,3 +250,61 @@ class TestRealPathLiveness:
         leader.tasks["1"] = {"id": "1", "status": "in_progress", "owner": "x"}
         anon = create_subagent_context(leader, SubagentContextOverrides())
         assert anon.tasks == {} and anon.tasks is not leader.tasks
+
+
+def test_task_completed_runs_before_teammate_idle(tmp_path):
+    """Ordering pin (critic 6b): TaskCompleted precedes TeammateIdle
+    (stopHooks.ts:352 loop before :402)."""
+    log = tmp_path / "order"
+    ctx = _ctx(
+        hooks={
+            "TaskCompleted": _hook(f"echo tc >> {log}"),
+            "TeammateIdle": _hook(f"echo ti >> {log}"),
+        },
+        tasks=dict(OWNED_TASK),
+    )
+    _drive(ctx)
+    assert log.read_text().split() == ["tc", "ti"]
+
+
+def test_core_stop_prevent_returns_before_teammate_block(tmp_path):
+    """Core-precedence pin (critic 6c — the indent refactor's key
+    invariant): a core Stop/SubagentStop preventContinuation returns
+    BEFORE the teammate block (stopHooks.ts:325-332 precede :335)."""
+    marker = tmp_path / "ti"
+    payload = '{"preventContinuation": true, "stopReason": "core stops"}'
+    ctx = _ctx(
+        hooks={
+            "SubagentStop": _hook(f"echo '{payload}'"),
+            "TeammateIdle": _hook(f"touch {marker}"),
+        },
+    )
+    _, result = _drive(ctx)
+    assert result.prevent_continuation is True
+    assert not marker.exists(), "core prevent must return before the teammate block"
+
+
+def test_task_completed_verbatim_prefix(tmp_path):
+    """Symmetry pin (critic 6a): the TaskCompleted feedback prefix,
+    verbatim (utils/hooks.ts:2113)."""
+    ctx = _ctx(
+        hooks={"TaskCompleted": _hook("echo 'redo it' >&2; exit 2")},
+        tasks=dict(OWNED_TASK),
+    )
+    messages, _ = _drive(ctx)
+    metas = [m for m in messages
+             if getattr(m, "type", "") == "user" and getattr(m, "isMeta", False)]
+    assert metas
+    assert str(metas[-1].content).startswith("TaskCompleted hook feedback:\n")
+
+
+def test_permission_mode_threaded_to_stdin(tmp_path):
+    """M2 pin: the executors carry permission_mode (TS createBaseHookInput)."""
+    import json as _json
+
+    out = tmp_path / "stdin.json"
+    ctx = _ctx(hooks={"TeammateIdle": _hook(f"cat > {out}")})
+    ctx.permission_context.mode = "acceptEdits"
+    _drive(ctx)
+    data = _json.loads(out.read_text())
+    assert data.get("permission_mode") == "acceptEdits"


### PR DESCRIPTION
## Summary

`query/` parity phase QUERY-1: the TS folder holds the agent loop's support modules (the loop itself is top-level `query.ts`, a separate docket entry). Survey verdict: `tokenBudget`/`toolFailureLoopGuard`/`transitions` already ported and wired; `config`/`deps` arch-substituted; **`stopHooks.ts` partial — and the one ungated, live gap is the teammate hook block**, shipped here.

**G1 — teammate `TaskCompleted` + `TeammateIdle` stop hooks** (stopHooks.ts:335-453; executors utils/hooks.ts:3920/:4000). Both events existed in `hook_types.py` with zero executors or call sites — the registered-but-inert class, fourth instance this sweep. Now: after the core Stop/SubagentStop loop (TS ordering — core prevent-continuation returns first), a teammate context runs TaskCompleted per in-progress task it owns, then TeammateIdle — with the verbatim feedback prefixes (utils/hooks.ts:2091/:2113), `hook_stopped_continuation` attachments, blocking-error meta messages, and abort early-outs.

**The split gate.** The generator previously fast-exited when no Stop/SubagentStop hooks were configured — which would have silently skipped teammate-only configurations. The gate is now `core_gate | teammate_gate` (pinned by test).

**Identity threading.** The Agent tool's `name` → `RunAgentParams.agent_name` → `SubagentContextOverrides.teammate_name` → `ToolContext.teammate_name`, with `team_name` from the parent's team file. BOTH are required by the gate (teammate.ts:125-131 — a named agent outside a team is not a teammate).

**The board is shared for teammates (critic round).** The docs critic proved the first draft's liveness premise false (its planned `in_process_teammate` seam is Phase-7 scaffolding) — the implementation had independently landed on the critic's own named alternative: the LIVE model is **TeamCreate + a named Agent spawn** (`TeamCreate` populates `context.team`, team.py:40; subagent contexts inherit it; the Agent tool's `name` is the teammate name). The round closed the remaining dead-in-practice facet: subagent contexts get fresh `tasks={}` (ch10 isolation), so the task board is now **shared for teammate spawns** (named + team — TS's single-shared-board semantics, utils/tasks.ts:443); anonymous subagents keep fresh isolation. `TestRealPathLiveness` proves the whole chain by execution: TeamCreate tool → named `create_subagent_context` spawn → `tasks is leader.tasks` → both hooks fire via marker files.

**Flag-resolution headline (gap doc).** Every stopHooks fire-block gate re-resolved at the vendored resolver (`_openBuildDefaults` + the compile-time `feature()` map): only memory-extraction is live in open builds — deferred as its own chapter (medium-to-large: forked-agent infra); auto-dream, prompt-suggestion, job-classifier, and computer-use cleanup are flag-off N-A.

Docs: `my-docs/get-parity-by-folder/query-{gap-analysis,refactoring-plan}.md`.

## Verification

- `tests/test_teammate_stop_hooks.py` **11/11**, execution-style (real command hooks, marker files): both events fire for a teammate with an owned in-progress task; non-owned/completed tasks skipped; the non-teammate gate; the teammate-only-config split-gate pin; the verbatim blocking prefix; preventContinuation → attachment + stop; identity threading (named+team / anonymous / named-without-team); both stdin contracts.
- Query-adjacent suites: 169 passed.
- Full suite at the 6-failure baseline (**7797 passed**; one unrelated signal-timing flake passes in isolation).
- Critic loop: docs REVISE→fixed (liveness reframe, the real seam, the tasks_v2 board, executor faithfulness notes, flag-attribution precision); implementation reviewed on the revision round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
