### PR TITLE
feat(hooks): enforce the `if` hook pre-filter — was registered-but-inert (SCHEMAS-1)

### DIFF
--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -122,6 +122,63 @@ def has_hook_for_event(event: str, tool_use_context: Any) -> bool:
     return bool(hooks.get(event))
 
 
+_IF_CONDITION_EVENTS = frozenset(
+    {"PreToolUse", "PostToolUse", "PostToolUseFailure", "PermissionRequest"}
+)
+
+
+def _matchable_value_for_tool(tool_name: str, tool_input: dict[str, Any]) -> str | None:
+    """The string the `if` rule content matches against, per tool. Bash =
+    the command (the documented `if: "Bash(git *)"` case). Extend here as
+    other tools grow permission-rule matchers (kept minimal on purpose —
+    SCHEMAS-1)."""
+    if tool_name == "Bash":
+        cmd = tool_input.get("command")
+        return cmd if isinstance(cmd, str) else None
+    return None
+
+
+def _matches_if_condition(
+    if_condition: str | None, event: str, tool_name: str | None,
+    tool_input: dict[str, Any] | None,
+) -> bool:
+    """SCHEMAS-1 — the port of `prepareIfConditionMatcher`
+    (utils/hooks.ts:1571-1610): a hook's `if` permission-rule pre-filter.
+
+    Returns True (run the hook) when there is no condition, the event is
+    not a tool event (TS builds no matcher then), or the condition matches;
+    False (skip) when the condition names a different tool or its rule
+    content does not match the actual tool input.
+    """
+    if not if_condition:
+        return True
+    if event not in _IF_CONDITION_EVENTS or not tool_name:
+        return True  # non-tool events ignore `if` (TS returns undefined)
+
+    from src.permissions.rule_parser import permission_rule_value_from_string
+
+    parsed = permission_rule_value_from_string(if_condition)
+    if (parsed.tool_name or "") != tool_name:
+        return False
+    if not parsed.rule_content:
+        return True  # tool-name-only condition → run
+
+    value = _matchable_value_for_tool(tool_name, tool_input or {})
+    if value is None:
+        # Rule content present but this tool has no matchable extractor —
+        # TS skips (patternMatcher undefined → false). Log so it is not a
+        # silent drop (the general per-tool matcher is a bounded follow-up).
+        logger.debug(
+            "hook `if` condition %r on tool %s has no matchable value; skipping hook",
+            if_condition, tool_name,
+        )
+        return False
+
+    from src.permissions.check import prepare_permission_matcher
+
+    return prepare_permission_matcher(parsed.rule_content)(value)
+
+
 def _matches_tool(matcher: str | None, tool_name: str) -> bool:
     if matcher is None:
         return True
@@ -415,8 +472,16 @@ async def _run_hooks_for_event(
     tool_use_id = stdin_data.get("tool_use_id", str(uuid4()))
     parent_tool_use_id = ""
 
+    tool_input = stdin_data.get("tool_input") if isinstance(stdin_data.get("tool_input"), dict) else None
+
     for hook in event_hooks:
         if tool_name and not _matches_tool(hook.matcher, tool_name):
+            continue
+        # SCHEMAS-1 — the `if` permission-rule pre-filter (was inert: the
+        # field parsed but never evaluated, so `if` hooks ran unconditionally).
+        if not _matches_if_condition(
+            getattr(hook, "if_condition", None), event, tool_name, tool_input
+        ):
             continue
 
         yield {

--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -125,16 +125,91 @@ def has_hook_for_event(event: str, tool_use_context: Any) -> bool:
 _IF_CONDITION_EVENTS = frozenset(
     {"PreToolUse", "PostToolUse", "PostToolUseFailure", "PermissionRequest"}
 )
+# The seven tools whose TS analogs implement preparePermissionMatcher
+# (each matches its rule pattern with matchWildcardPattern):
+#   file-path tools → file_path / notebook_path;
+#   pattern tools (Glob/Grep/Monitor) → pattern;
+#   Bash → command (with any-subcommand semantics).
+_IF_FILE_PATH_TOOLS = frozenset(
+    {"Read", "Edit", "MultiEdit", "Write", "NotebookEdit"}
+)
+_IF_PATTERN_TOOLS = frozenset({"Glob", "Grep", "Monitor"})
+
+_ESCAPED_STAR = "\x00ESC_STAR\x00"
+_ESCAPED_BACKSLASH = "\x00ESC_BSL\x00"
 
 
-def _matchable_value_for_tool(tool_name: str, tool_input: dict[str, Any]) -> str | None:
-    """The string the `if` rule content matches against, per tool. Bash =
-    the command (the documented `if: "Bash(git *)"` case). Extend here as
-    other tools grow permission-rule matchers (kept minimal on purpose —
-    SCHEMAS-1)."""
+def _match_wildcard_pattern(pattern: str, value: str) -> bool:
+    """Port of `matchWildcardPattern`
+    (utils/permissions/shellRuleMatching.ts:90) — the SAME matcher every
+    TS tool's preparePermissionMatcher uses for `if`, so it is faithful for
+    both Bash commands and file/pattern values (and, unlike the Bash-only
+    permission matcher, carries no command-chaining strictness)."""
+    import re
+
+    trimmed = pattern.strip()
+    # Escape-sequence handling: \* → literal star, \\ → literal backslash.
+    processed_chars: list[str] = []
+    i = 0
+    while i < len(trimmed):
+        ch = trimmed[i]
+        if ch == "\\" and i + 1 < len(trimmed):
+            nxt = trimmed[i + 1]
+            if nxt == "*":
+                processed_chars.append(_ESCAPED_STAR)
+                i += 2
+                continue
+            if nxt == "\\":
+                processed_chars.append(_ESCAPED_BACKSLASH)
+                i += 2
+                continue
+        processed_chars.append(ch)
+        i += 1
+    processed = "".join(processed_chars)
+
+    escaped = re.sub(r"""[.+?^${}()|\[\]\\'"]""", lambda m: "\\" + m.group(0), processed)
+    with_wildcards = escaped.replace("*", ".*")
+    regex_pattern = (
+        with_wildcards.replace(_ESCAPED_STAR, "\\*").replace(_ESCAPED_BACKSLASH, "\\\\")
+    )
+    # Trailing ' *' (the only unescaped wildcard) → optional, so 'git *'
+    # matches bare 'git' too (prefix-rule alignment).
+    unescaped_star_count = processed.count("*")
+    if regex_pattern.endswith(" .*") and unescaped_star_count == 1:
+        regex_pattern = regex_pattern[:-3] + "( .*)?"
+    return re.match(f"^{regex_pattern}$", value, re.DOTALL) is not None
+
+
+def _matchable_values_for_tool(
+    tool_name: str, tool_input: dict[str, Any]
+) -> list[str] | None:
+    """The value(s) a tool's `if` rule content matches against, or None
+    when the tool has no matcher analog (→ fail-OPEN, run + warn). Bash
+    returns the command plus each chained sub-command (any-subcommand
+    match, BashTool preparePermissionMatcher), so `if:"Bash(git *)"` fires
+    on `git push && npm test`."""
     if tool_name == "Bash":
         cmd = tool_input.get("command")
-        return cmd if isinstance(cmd, str) else None
+        if not isinstance(cmd, str):
+            return None
+        cands = [cmd]
+        try:
+            from src.permissions.bash_suggestions import (
+                contains_unquoted_chaining,
+                split_chained_command,
+            )
+
+            if contains_unquoted_chaining(cmd):
+                cands.extend(split_chained_command(cmd) or [])
+        except Exception:  # noqa: BLE001
+            pass
+        return cands
+    if tool_name in _IF_FILE_PATH_TOOLS:
+        val = tool_input.get("file_path") or tool_input.get("notebook_path")
+        return [val] if isinstance(val, str) else None
+    if tool_name in _IF_PATTERN_TOOLS:
+        val = tool_input.get("pattern")
+        return [val] if isinstance(val, str) else None
     return None
 
 
@@ -145,38 +220,52 @@ def _matches_if_condition(
     """SCHEMAS-1 — the port of `prepareIfConditionMatcher`
     (utils/hooks.ts:1571-1610): a hook's `if` permission-rule pre-filter.
 
-    Returns True (run the hook) when there is no condition, the event is
-    not a tool event (TS builds no matcher then), or the condition matches;
-    False (skip) when the condition names a different tool or its rule
-    content does not match the actual tool input.
+    Returns True (run the hook) or False (skip). Semantics match TS:
+    * no condition → run;
+    * present condition on a NON-tool event → SKIP (TS's caller sees an
+      undefined matcher and returns false — hooks.ts:2023-2027);
+    * rule tool-name ≠ current tool → skip;
+    * no rule-content → run;
+    * rule-content → matched with matchWildcardPattern against the tool's
+      value(s); a tool WITHOUT a matcher analog fails OPEN (run + warn) so
+      a configured hook is never silently disabled.
     """
     if not if_condition:
         return True
+
+    from src.permissions.rule_parser import (
+        normalize_legacy_tool_name,
+        permission_rule_value_from_string,
+    )
+
     if event not in _IF_CONDITION_EVENTS or not tool_name:
-        return True  # non-tool events ignore `if` (TS returns undefined)
+        # A tool-syntax `if` cannot be evaluated for a non-tool event → skip
+        # (TS parity, hooks.ts:2023-2027). Not "ignore and run".
+        logger.debug(
+            "hook `if` condition %r cannot be evaluated for non-tool event %s; skipping",
+            if_condition, event,
+        )
+        return False
 
-    from src.permissions.rule_parser import permission_rule_value_from_string
-
+    current = normalize_legacy_tool_name(tool_name)
     parsed = permission_rule_value_from_string(if_condition)
-    if (parsed.tool_name or "") != tool_name:
+    if normalize_legacy_tool_name(parsed.tool_name or "") != current:
         return False
     if not parsed.rule_content:
         return True  # tool-name-only condition → run
 
-    value = _matchable_value_for_tool(tool_name, tool_input or {})
-    if value is None:
-        # Rule content present but this tool has no matchable extractor —
-        # TS skips (patternMatcher undefined → false). Log so it is not a
-        # silent drop (the general per-tool matcher is a bounded follow-up).
-        logger.debug(
-            "hook `if` condition %r on tool %s has no matchable value; skipping hook",
-            if_condition, tool_name,
+    values = _matchable_values_for_tool(current, tool_input or {})
+    if values is None:
+        # No matcher analog for this tool — fail OPEN (run) with a visible
+        # warning rather than silently disabling a configured hook.
+        logger.warning(
+            "hook `if` condition %r on tool %s has no matcher; running the "
+            "hook unconditionally (no per-tool matcher for %s)",
+            if_condition, current, current,
         )
-        return False
+        return True
 
-    from src.permissions.check import prepare_permission_matcher
-
-    return prepare_permission_matcher(parsed.rule_content)(value)
+    return any(_match_wildcard_pattern(parsed.rule_content, v) for v in values)
 
 
 def _matches_tool(matcher: str | None, tool_name: str) -> bool:

--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -133,7 +133,12 @@ _IF_CONDITION_EVENTS = frozenset(
 _IF_FILE_PATH_TOOLS = frozenset(
     {"Read", "Edit", "MultiEdit", "Write", "NotebookEdit"}
 )
-_IF_PATTERN_TOOLS = frozenset({"Glob", "Grep", "Monitor"})
+_IF_PATTERN_TOOLS = frozenset({"Glob", "Grep"})
+# Bash + Monitor match on the COMMAND with prefix-or-wildcard semantics
+# (TS MonitorTool.preparePermissionMatcher also uses `command`, Bash-style).
+# Monitor is unreachable today (the port has no Monitor tool) but the
+# categorization is kept faithful for when it lands.
+_IF_COMMAND_TOOLS = frozenset({"Bash", "Monitor"})
 
 _ESCAPED_STAR = "\x00ESC_STAR\x00"
 _ESCAPED_BACKSLASH = "\x00ESC_BSL\x00"
@@ -180,6 +185,39 @@ def _match_wildcard_pattern(pattern: str, value: str) -> bool:
     return re.match(f"^{regex_pattern}$", value, re.DOTALL) is not None
 
 
+def _extract_rule_prefix(rule_content: str) -> str | None:
+    """Port of `permissionRuleExtractPrefix` (shellRuleMatching.ts:43-48):
+    the legacy colon form ``git:*`` → prefix ``git``; anything else → None."""
+    import re
+
+    m = re.match(r"^(.+):\*$", rule_content)
+    return m.group(1) if m else None
+
+
+def _strip_env_prefix(command: str) -> str:
+    """Strip leading ``VAR=val`` assignments so ``FOO=bar git push`` matches
+    ``Bash(git *)`` (TS matches on argv, BashTool preparePermissionMatcher)."""
+    import re
+
+    prev = None
+    cur = command.strip()
+    while cur != prev:
+        prev = cur
+        cur = re.sub(r"^[A-Za-z_][A-Za-z0-9_]*=\S*\s+", "", cur)
+    return cur
+
+
+def _command_rule_matches(rule_content: str, command: str) -> bool:
+    """The Bash/Monitor command matcher (BashTool.preparePermissionMatcher):
+    the colon-prefix branch (``git:*`` → exact or prefix+space), else the
+    wildcard matcher — applied to the env-stripped command."""
+    cmd = _strip_env_prefix(command)
+    prefix = _extract_rule_prefix(rule_content)
+    if prefix is not None:
+        return cmd == prefix or cmd.startswith(prefix + " ")
+    return _match_wildcard_pattern(rule_content, cmd)
+
+
 def _matchable_values_for_tool(
     tool_name: str, tool_input: dict[str, Any]
 ) -> list[str] | None:
@@ -188,7 +226,7 @@ def _matchable_values_for_tool(
     returns the command plus each chained sub-command (any-subcommand
     match, BashTool preparePermissionMatcher), so `if:"Bash(git *)"` fires
     on `git push && npm test`."""
-    if tool_name == "Bash":
+    if tool_name in _IF_COMMAND_TOOLS:
         cmd = tool_input.get("command")
         if not isinstance(cmd, str):
             return None
@@ -265,7 +303,15 @@ def _matches_if_condition(
         )
         return True
 
-    return any(_match_wildcard_pattern(parsed.rule_content, v) for v in values)
+    # Command-class tools (Bash/Monitor) use the prefix-or-wildcard matcher
+    # (so colon rules like `Bash(rm:*)` work — the canonical rule form);
+    # file/pattern tools use the plain wildcard matcher.
+    matcher = (
+        _command_rule_matches
+        if current in _IF_COMMAND_TOOLS
+        else _match_wildcard_pattern
+    )
+    return any(matcher(parsed.rule_content, v) for v in values)
 
 
 def _matches_tool(matcher: str | None, tool_name: str) -> bool:

--- a/src/hooks/hook_types.py
+++ b/src/hooks/hook_types.py
@@ -238,10 +238,13 @@ class HookConfig:
     # Phase-1 / WI-1.3 — schema additions:
     #
     # ``if_condition`` — permission-rule grammar string (e.g.,
-    # ``"Bash(git commit*)"``). Evaluated by ``matches_hook_condition``
-    # (Phase 4 / WI-4.2) against the active tool call. ``None`` means "no
-    # extra filter beyond ``matcher``." Mirrors TS ``schemas/hooks.ts:19-27``
-    # ``if`` field.
+    # ``"Bash(git commit*)"``). Evaluated by
+    # ``hook_executor._matches_if_condition`` (SCHEMAS-1 — the port of TS
+    # ``prepareIfConditionMatcher``) against the active tool call before the
+    # hook spawns. ``None`` means "no extra filter beyond ``matcher``."
+    # Mirrors TS ``schemas/hooks.ts:19-27`` ``if`` field. (Prior to
+    # SCHEMAS-1 this comment named ``matches_hook_condition``, an evaluator
+    # that was never built — the field parsed but was inert.)
     if_condition: str | None = None
 
     # ``once`` — if True, the hook is removed from the session registry after

--- a/tests/test_hook_if_condition.py
+++ b/tests/test_hook_if_condition.py
@@ -92,6 +92,18 @@ class TestMatcherUnit:
         # never silently disabled.
         assert _matches_if_condition("CustomTool(x)", "PreToolUse", "CustomTool", {"y": 1}) is True
 
+    def test_colon_prefix_bash_rule(self):
+        # The gating safety MAJOR: colon is the canonical rule form. A
+        # `Bash(rm:*)` guard must FIRE on `rm -rf /` (was fail-closed).
+        assert _matches_if_condition("Bash(rm:*)", "PreToolUse", "Bash", {"command": "rm -rf /"}) is True
+        assert _matches_if_condition("Bash(git:*)", "PreToolUse", "Bash", {"command": "git push"}) is True
+        assert _matches_if_condition("Bash(git:*)", "PreToolUse", "Bash", {"command": "git"}) is True  # bare
+        assert _matches_if_condition("Bash(git:*)", "PreToolUse", "Bash", {"command": "ls"}) is False
+
+    def test_env_prefix_stripped(self):
+        # TS matches on argv (strips leading VAR=val).
+        assert _matches_if_condition("Bash(git *)", "PreToolUse", "Bash", {"command": "FOO=bar git push"}) is True
+
 
 class TestExecutionEnforcement:
     """The gap this closes: the hook must actually NOT spawn when `if`

--- a/tests/test_hook_if_condition.py
+++ b/tests/test_hook_if_condition.py
@@ -1,0 +1,102 @@
+"""SCHEMAS-1 — the hook `if` permission-rule pre-filter.
+
+The field (HookConfig.if_condition) round-tripped through config but was
+NEVER evaluated (_run_hooks_for_event filtered only by matcher) — a hook
+with `if: "Bash(git *)"` ran for every Bash command. Port of
+prepareIfConditionMatcher (utils/hooks.ts:1571-1610). Execution-style per
+the plugins/query lessons: real command hooks + marker files prove the
+hook actually does/doesn't spawn.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.hooks.hook_executor import _matches_if_condition, _run_hooks_for_event
+from src.hooks.hook_types import HookConfig, HookSource
+
+
+class _Snapshot:
+    def __init__(self, hooks):
+        self.hooks = hooks
+
+
+def _ctx(configs):
+    from src.tool_system.context import ToolContext
+
+    ctx = ToolContext(workspace_root=Path("/tmp"))
+    ctx.workspace_trusted = True
+    mgr = MagicMock()
+    mgr.snapshot = _Snapshot({"PreToolUse": configs})
+    ctx.hook_config_manager = mgr
+    return ctx
+
+
+def _run(ctx, tool_name, tool_input):
+    async def go():
+        out = []
+        async for r in _run_hooks_for_event(
+            "PreToolUse", tool_name,
+            {"tool_name": tool_name, "tool_input": tool_input, "tool_use_id": "t"},
+            ctx,
+        ):
+            out.append(r)
+        return out
+
+    return asyncio.run(go())
+
+
+class TestMatcherUnit:
+    def test_matching_command_runs(self):
+        assert _matches_if_condition("Bash(git *)", "PreToolUse", "Bash", {"command": "git status"}) is True
+
+    def test_non_matching_command_skips(self):
+        assert _matches_if_condition("Bash(git *)", "PreToolUse", "Bash", {"command": "ls"}) is False
+
+    def test_tool_mismatch_skips(self):
+        assert _matches_if_condition("Bash(git *)", "PreToolUse", "Read", {"file_path": "x"}) is False
+
+    def test_no_rule_content_runs(self):
+        assert _matches_if_condition("Bash", "PreToolUse", "Bash", {"command": "anything"}) is True
+
+    def test_non_tool_event_ignores_if(self):
+        assert _matches_if_condition("Bash(git *)", "Stop", None, None) is True
+
+    def test_no_condition_runs(self):
+        assert _matches_if_condition(None, "PreToolUse", "Bash", {"command": "x"}) is True
+
+    def test_unmatchable_tool_with_rule_content_skips(self):
+        # Read has no matchable extractor yet → conservative skip (logged).
+        assert _matches_if_condition("Read(*.py)", "PreToolUse", "Read", {"file_path": "a.py"}) is False
+
+
+class TestExecutionEnforcement:
+    """The gap this closes: the hook must actually NOT spawn when `if`
+    excludes the command, and spawn when it matches."""
+
+    def _hook(self, command, if_condition):
+        return [HookConfig(
+            type="command", command=command, if_condition=if_condition,
+            source=HookSource.PROJECT_SETTINGS,
+        )]
+
+    def test_if_excludes_nonmatching_command(self, tmp_path):
+        marker = tmp_path / "ran"
+        ctx = _ctx(self._hook(f"touch {marker}", "Bash(git *)"))
+        _run(ctx, "Bash", {"command": "ls -la"})
+        assert not marker.exists(), "the `if` filter must skip a non-git command"
+
+    def test_if_allows_matching_command(self, tmp_path):
+        marker = tmp_path / "ran"
+        ctx = _ctx(self._hook(f"touch {marker}", "Bash(git *)"))
+        _run(ctx, "Bash", {"command": "git commit -m x"})
+        assert marker.exists(), "the `if` filter must run for a matching command"
+
+    def test_no_if_still_runs(self, tmp_path):
+        marker = tmp_path / "ran"
+        ctx = _ctx(self._hook(f"touch {marker}", None))
+        _run(ctx, "Bash", {"command": "anything"})
+        assert marker.exists(), "no `if` → unconditional (unchanged behavior)"

--- a/tests/test_hook_if_condition.py
+++ b/tests/test_hook_if_condition.py
@@ -62,15 +62,35 @@ class TestMatcherUnit:
     def test_no_rule_content_runs(self):
         assert _matches_if_condition("Bash", "PreToolUse", "Bash", {"command": "anything"}) is True
 
-    def test_non_tool_event_ignores_if(self):
-        assert _matches_if_condition("Bash(git *)", "Stop", None, None) is True
+    def test_non_tool_event_with_if_skips(self):
+        # TS parity (hooks.ts:2023-2027): a tool-syntax `if` cannot be
+        # evaluated for a non-tool event → SKIP (not ignore-and-run).
+        assert _matches_if_condition("Bash(git *)", "Stop", None, None) is False
 
     def test_no_condition_runs(self):
         assert _matches_if_condition(None, "PreToolUse", "Bash", {"command": "x"}) is True
 
-    def test_unmatchable_tool_with_rule_content_skips(self):
-        # Read has no matchable extractor yet → conservative skip (logged).
-        assert _matches_if_condition("Read(*.py)", "PreToolUse", "Read", {"file_path": "a.py"}) is False
+    def test_file_tool_if_evaluated(self):
+        # MAJOR-1 fix: Read/Edit/Write/Glob/Grep are evaluated (were
+        # fail-closed). The `if` schema's own example is Read(*.ts).
+        assert _matches_if_condition("Read(*.ts)", "PreToolUse", "Read", {"file_path": "a.ts"}) is True
+        assert _matches_if_condition("Read(*.ts)", "PreToolUse", "Read", {"file_path": "a.py"}) is False
+
+    def test_edit_env_guard_fires(self):
+        # The safety case: an `if:"Edit(*.env)"` PreToolUse guard must FIRE
+        # on a .env write (pre-fix it silently never did).
+        assert _matches_if_condition("Edit(*.env)", "PreToolUse", "Edit", {"file_path": ".env"}) is True
+
+    def test_bash_chaining_any_subcommand(self):
+        # MINOR-2 fix: `Bash(git *)` fires on a chained command if ANY
+        # sub-command matches (matchWildcardPattern per sub-command, not the
+        # chaining-strict permission matcher).
+        assert _matches_if_condition("Bash(git *)", "PreToolUse", "Bash", {"command": "git push && npm test"}) is True
+
+    def test_unsupported_tool_fails_open(self):
+        # A tool with no matcher analog runs the hook (fail-OPEN + warn) —
+        # never silently disabled.
+        assert _matches_if_condition("CustomTool(x)", "PreToolUse", "CustomTool", {"y": 1}) is True
 
 
 class TestExecutionEnforcement:
@@ -100,3 +120,21 @@ class TestExecutionEnforcement:
         ctx = _ctx(self._hook(f"touch {marker}", None))
         _run(ctx, "Bash", {"command": "anything"})
         assert marker.exists(), "no `if` → unconditional (unchanged behavior)"
+
+    def test_file_if_excludes_nonmatching_path(self, tmp_path):
+        marker = tmp_path / "ran"
+        ctx = _ctx([HookConfig(
+            type="command", command=f"touch {marker}", if_condition="Read(*.ts)",
+            source=HookSource.PROJECT_SETTINGS,
+        )])
+        _run(ctx, "Read", {"file_path": "notes.md"})
+        assert not marker.exists(), "Read(*.ts) must skip a .md read"
+
+    def test_file_if_allows_matching_path(self, tmp_path):
+        marker = tmp_path / "ran"
+        ctx = _ctx([HookConfig(
+            type="command", command=f"touch {marker}", if_condition="Read(*.ts)",
+            source=HookSource.PROJECT_SETTINGS,
+        )])
+        _run(ctx, "Read", {"file_path": "app.ts"})
+        assert marker.exists(), "Read(*.ts) must run on a .ts read"


### PR DESCRIPTION
## Summary

`schemas/` parity: `typescript/src/schemas/hooks.ts` is a TS import-cycle-breaker (hook Zod schemas extracted so settings and `plugins/schemas.ts` stop importing each other) — no Python analog needed (the hook schema lives with the hooks subsystem, no Zod, no cycle). But dispositioning the folder's one file surfaced a live gap: the hook **`if` permission-rule pre-filter was registered-but-inert**.

**The gap.** `HookConfig.if_condition` (`if: "Bash(git *)"` / `"Read(*.ts)"` — filters a hook to matching tool calls before spawning) round-tripped through config but was **never evaluated**: `_run_hooks_for_event` filtered only by `matcher`, so an `if`-scoped hook ran for *every* call of its tool. The field's own docstring even claimed it was "Evaluated by `matches_hook_condition`" — an evaluator that existed nowhere in the repo. Self-caught while dispositioning the folder (the sweep's recurring registered-but-inert pattern).

**The fix (SCHEMAS-1)** — port of `prepareIfConditionMatcher` (utils/hooks.ts:1571-1610) wired into `_run_hooks_for_event` *before* the spawn:
- **`_match_wildcard_pattern`** ports `matchWildcardPattern` (shellRuleMatching.ts:90) — the same matcher every TS tool's `preparePermissionMatcher` uses (so no Bash-command-specific chaining strictness).
- **Per-tool value extraction** for the tools with a matcher analog: Bash/Monitor → command *and each env-stripped chained sub-command* (any-subcommand match, so `Bash(git *)` fires on `git push && npm test` and `FOO=bar git push`); Read/Edit/MultiEdit/Write/NotebookEdit → `file_path`/`notebook_path`; Glob/Grep → `pattern`.
- **Both rule forms** for command tools: the wildcard glob (`Bash(git *)`) AND the canonical colon form (`Bash(rm:*)` → prefix `rm` → `cmd == "rm"` or `cmd.startswith("rm ")`), porting `permissionRuleExtractPrefix` (shellRuleMatching.ts:43-48).
- **Semantics match TS:** no condition → run; parsed tool-name (legacy-normalized on both sides) must equal the current tool; no rule-content → run; rule-content → matched against the tool's value(s); a **non-tool event** with a present `if` → **skip** (TS's caller sees an undefined matcher → `return false`); a tool with **no matcher analog** → **fail-OPEN** (run + `logger.warning`), never silently disabling a configured guard.

The docstring is corrected to point at the real evaluator and record the pre-SCHEMAS-1 inertness.

**Recorded, not in this PR** (gap doc): the full zod-key diff surfaced four other absent fields — `headers`/`allowedEnvVars` (real http-hook auth gaps — a webhook can't currently send `Authorization`), `model` (per-hook override ignored), `statusMessage` — scoped as a bounded hooks-subsystem follow-up (SCHEMAS-2). The `remote/` folder closed docs-only in the same review batch (dormant CCR client; 2/4 faithful + 1/4 divergent adapter + 1/4 absent bridge already solved by the backend forwarding raw `can_use_tool`).

## Verification

- `tests/test_hook_if_condition.py` **17/17**, execution-style (real command hooks + marker files prove spawn/no-spawn): Bash glob + colon (`Bash(rm:*)` on `rm -rf /` fires) + `VAR=val` strip, **file-tool `Read(*.ts)` run/skip**, the **`Edit(*.env)` guard-fires safety pin**, Bash chaining any-subcommand, tool-name mismatch skip, no-rule-content run, non-tool-event skip, unsupported-tool fail-open.
- Existing hook + permission suites green; full suite at the 6-failure baseline (**7817 passed**).
- Critic loop (4 rounds, execution-probed each time): the `if`-inert finding + scope affirmed; two successive fail-closed **safety regressions** caught and fixed — the non-Bash tools (an `if:"Edit(*.env)"` guard silently never firing), then the canonical colon form (`if:"Bash(rm:*)"`) — plus the non-tool-event inversion, legacy-normalization, and Monitor categorization. Both docs APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
