### PR TITLE
feat(services): tool-use summary generator (SERVICES-1; wiring deferred)

### DIFF
--- a/src/services/tool_use_summary.py
+++ b/src/services/tool_use_summary.py
@@ -50,11 +50,16 @@ TOOL_USE_SUMMARY_SYSTEM_PROMPT = (
 
 def _truncate_json(value: Any, max_len: int) -> str:
     """Port of ``truncateJson``: JSON-stringify then slice. BYTE-EXACT to TS
-    (critic B3): ``str.slice(0, maxLength - 3) + '...'`` — three ASCII dots,
-    and the slice stops 3 short so the result length == ``max_len``. None-safe;
-    non-serializable values fall back to ``str()``."""
+    (critic B3 + the follow-up): ``str.slice(0, maxLength - 3) + '...'`` —
+    three ASCII dots, slice stops 3 short so the result length == ``max_len``;
+    AND ``separators=(",", ":")`` so the serialization matches
+    ``JSON.stringify``'s no-space form (Python ``json.dumps`` defaults to
+    spaced separators). None-safe; non-serializable values fall back to
+    ``str()``."""
     try:
-        text = json.dumps(value, ensure_ascii=False, default=str)
+        text = json.dumps(
+            value, ensure_ascii=False, separators=(",", ":"), default=str
+        )
     except (TypeError, ValueError):
         text = str(value)
     if len(text) > max_len:

--- a/src/services/tool_use_summary.py
+++ b/src/services/tool_use_summary.py
@@ -1,0 +1,132 @@
+"""Tool-use summary generator — SERVICES-1 (services-folder parity).
+
+Port of ``typescript/src/services/toolUseSummary/toolUseSummaryGenerator.ts``:
+a small-fast-model side query that writes a ~30-char git-commit-subject
+label for a completed tool round. It appears as a single mobile-app row
+(the SDK ``streamlined_tool_use_summary`` message). Non-critical — every
+failure path returns ``None`` and never raises (TS: "summaries are
+non-critical").
+
+The plumbing was present but DEAD: ``QueryState.pending_tool_use_summary``
+(query/transitions.py), ``config.tool_use_summary_enabled`` /
+``emit_tool_use_summaries`` — all carried, never produced or consumed. This
+module is the faithful port of the missing GENERATOR.
+
+Query-loop wiring is DEFERRED (critic round, distinct from the sweep's other
+inert-plumbing fixes): unlike PermissionRequest hooks or the `if`-filter —
+whose consumers existed once wired — the Haiku-label consumer is a mobile /
+external SDK app that does NOT exist in this port. TS emits the label
+SDK-only (``createToolUseSummaryMessage`` → ``{type:'tool_use_summary',
+summary, precedingToolUseIds, …}``, "SDK-only, ignore in stream handling")
+and Python's ``sdk_types`` carries only the UNRELATED drop-filtered
+``streamlined_tool_use_summary`` (a tool-COUNT feature, not this label).
+Wiring a per-tool-round small-model call here would be cost-without-benefit
+until such a consumer lands. This generator is complete and tested, ready to
+wire (fire-and-forget after the tool round → carry on
+``pending_tool_use_summary`` → await bounded → yield a ``tool_use_summary``
+SDK message with ``preceding_tool_use_ids``) the moment one does.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# VERBATIM from toolUseSummaryGenerator.ts (model-facing, eval-tuned —
+# mechanically extracted, do not paraphrase).
+TOOL_USE_SUMMARY_SYSTEM_PROMPT = (
+    "Write a short summary label describing what these tool calls "
+    "accomplished. It appears as a single-line row in a mobile app and "
+    "truncates around 30 characters, so think git-commit-subject, not "
+    "sentence.\n\nKeep the verb in past tense and the most distinctive "
+    "noun. Drop articles, connectors, and long location context first."
+    "\n\nExamples:\n- Searched in auth/\n- Fixed NPE in UserService\n"
+    "- Created signup endpoint\n- Read config.json\n- Ran failing tests"
+)
+
+
+def _truncate_json(value: Any, max_len: int) -> str:
+    """Port of ``truncateJson``: JSON-stringify then slice. BYTE-EXACT to TS
+    (critic B3): ``str.slice(0, maxLength - 3) + '...'`` — three ASCII dots,
+    and the slice stops 3 short so the result length == ``max_len``. None-safe;
+    non-serializable values fall back to ``str()``."""
+    try:
+        text = json.dumps(value, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        text = str(value)
+    if len(text) > max_len:
+        return text[: max_len - 3] + "..."
+    return text
+
+
+def _resolve_summary_model(provider: Any) -> str | None:
+    """The small-fast-model pin for this side query. Reuses the memdir
+    selector's resolver — the SAME concern (don't pay the session model's
+    price for a cheap side call; the shipped small_fast_model default is an
+    Anthropic id, so pin only when the session provider is Anthropic, else
+    fall back to the session model). Returns None to signal fallback.
+    Never raises."""
+    try:
+        from src.memdir.find_relevant_memories import _resolve_recall_model
+
+        return _resolve_recall_model(provider)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+async def generate_tool_use_summary(
+    tools: list[dict[str, Any]],
+    provider: Any,
+    *,
+    last_assistant_text: str | None = None,
+) -> str | None:
+    """Generate a short label for a completed tool round, or None.
+
+    ``tools`` — list of ``{"name", "input", "output"}``. Empty → None.
+    Mirrors ``generateToolUseSummary``: build the truncated per-tool
+    representation, prepend the optional last-assistant-intent context,
+    query the small fast model, return the stripped label (or None).
+    """
+    if not tools:
+        return None
+    try:
+        tool_summaries = "\n\n".join(
+            "Tool: {name}\nInput: {inp}\nOutput: {out}".format(
+                name=t.get("name", ""),
+                inp=_truncate_json(t.get("input"), 300),
+                out=_truncate_json(t.get("output"), 300),
+            )
+            for t in tools
+        )
+        context_prefix = (
+            "User's intent (from assistant's last message): "
+            f"{last_assistant_text[:200]}\n\n"
+            if last_assistant_text
+            else ""
+        )
+        user_prompt = (
+            f"{context_prefix}Tools completed:\n\n{tool_summaries}\n\nLabel:"
+        )
+
+        if provider is None or not hasattr(provider, "chat_async"):
+            return None
+        kwargs: dict[str, Any] = {
+            "system": TOOL_USE_SUMMARY_SYSTEM_PROMPT,
+            "max_tokens": 64,
+        }
+        model = _resolve_summary_model(provider)
+        if model:
+            kwargs["model"] = model
+        response = await provider.chat_async(
+            [{"role": "user", "content": user_prompt}], **kwargs
+        )
+        if response is None:
+            return None
+        summary = (getattr(response, "content", "") or "").strip()
+        return summary or None
+    except Exception:  # noqa: BLE001 — summaries are non-critical
+        logger.debug("tool-use summary generation failed", exc_info=True)
+        return None

--- a/tests/services/test_tool_use_summary.py
+++ b/tests/services/test_tool_use_summary.py
@@ -62,7 +62,8 @@ class TestTruncateJson:
         assert "…" not in r  # NOT the unicode ellipsis
 
     def test_small_and_none(self):
-        assert _truncate_json({"a": 1}, 300) == '{"a": 1}'
+        assert _truncate_json({"a": 1}, 300) == '{"a":1}'  # JSON.stringify no-space form
+        assert _truncate_json({"a": 1, "b": 2}, 300) == '{"a":1,"b":2}'
         assert _truncate_json(None, 300) == "null"
 
     def test_non_serializable_falls_back(self):

--- a/tests/services/test_tool_use_summary.py
+++ b/tests/services/test_tool_use_summary.py
@@ -1,0 +1,138 @@
+"""SERVICES-1 — the tool-use summary GENERATOR (faithful port).
+
+Port of toolUseSummaryGenerator.ts. Query-loop wiring is deferred (no
+in-repo consumer of the label; see the module docstring), so these tests
+pin the generator's faithfulness in isolation — verbatim system prompt,
+byte-exact truncation, exact user-prompt shape, small-model side query,
+and the never-raises contract.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.services.tool_use_summary import (
+    TOOL_USE_SUMMARY_SYSTEM_PROMPT,
+    _truncate_json,
+    generate_tool_use_summary,
+)
+
+
+class _Provider:
+    """Captures the side-query args; returns a canned label."""
+
+    def __init__(self, label: str = "Fixed NPE in UserService"):
+        self.label = label
+        self.calls: list = []
+
+    async def chat_async(self, messages, **kwargs):
+        self.calls.append((messages, kwargs))
+
+        class _R:
+            content = self.label
+
+        return _R()
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestSystemPrompt:
+    def test_verbatim(self):
+        # Mechanically extracted from the TS template literal (444 chars).
+        assert len(TOOL_USE_SUMMARY_SYSTEM_PROMPT) == 444
+        assert "git-commit-subject, not\nsentence" not in TOOL_USE_SUMMARY_SYSTEM_PROMPT
+        for needle in (
+            "truncates around 30 characters",
+            "Keep the verb in past tense",
+            "- Searched in auth/",
+            "- Fixed NPE in UserService",
+            "- Ran failing tests",
+        ):
+            assert needle in TOOL_USE_SUMMARY_SYSTEM_PROMPT
+
+
+class TestTruncateJson:
+    def test_byte_exact_to_ts(self):
+        # TS: slice(0, maxLen-3) + '...' (three ASCII dots); result len==maxLen.
+        r = _truncate_json("x" * 400, 10)
+        assert r.endswith("...") and len(r) == 10
+        assert "…" not in r  # NOT the unicode ellipsis
+
+    def test_small_and_none(self):
+        assert _truncate_json({"a": 1}, 300) == '{"a": 1}'
+        assert _truncate_json(None, 300) == "null"
+
+    def test_non_serializable_falls_back(self):
+        class X:
+            pass
+
+        assert isinstance(_truncate_json(X(), 300), str)  # default=str, no raise
+
+
+class TestGenerator:
+    def test_empty_tools_returns_none(self):
+        assert _run(generate_tool_use_summary([], _Provider())) is None
+
+    def test_returns_stripped_label(self):
+        p = _Provider("  Created signup endpoint  ")
+        out = _run(generate_tool_use_summary(
+            [{"name": "Write", "input": {"file_path": "x"}, "output": "ok"}], p,
+        ))
+        assert out == "Created signup endpoint"
+
+    def test_user_prompt_shape(self):
+        p = _Provider()
+        _run(generate_tool_use_summary(
+            [{"name": "Edit", "input": {"file_path": "a.py"}, "output": "done"}],
+            p, last_assistant_text="fix the null deref",
+        ))
+        messages, kwargs = p.calls[-1]
+        prompt = messages[0]["content"]
+        # exact TS segments
+        assert prompt.startswith(
+            "User's intent (from assistant's last message): fix the null deref\n\n"
+        )
+        assert "Tools completed:\n\n" in prompt
+        assert "Tool: Edit\nInput: " in prompt and "Output: " in prompt
+        assert prompt.endswith("\n\nLabel:")
+        assert kwargs["system"] == TOOL_USE_SUMMARY_SYSTEM_PROMPT
+
+    def test_no_context_prefix_when_no_last_text(self):
+        p = _Provider()
+        _run(generate_tool_use_summary([{"name": "X", "input": 1, "output": 2}], p))
+        prompt = p.calls[-1][0][0]["content"]
+        assert prompt.startswith("Tools completed:\n\n")
+
+    def test_never_raises_on_provider_error(self):
+        class _Bad:
+            async def chat_async(self, m, **k):
+                raise RuntimeError("boom")
+
+        assert _run(generate_tool_use_summary(
+            [{"name": "X", "input": 1, "output": 2}], _Bad(),
+        )) is None
+
+    def test_none_provider_and_no_chat_async(self):
+        assert _run(generate_tool_use_summary(
+            [{"name": "X", "input": 1, "output": 2}], None,
+        )) is None
+        assert _run(generate_tool_use_summary(
+            [{"name": "X", "input": 1, "output": 2}], object(),
+        )) is None
+
+    def test_empty_label_becomes_none(self):
+        assert _run(generate_tool_use_summary(
+            [{"name": "X", "input": 1, "output": 2}], _Provider("   "),
+        )) is None
+
+    def test_small_model_pin_reused(self, monkeypatch):
+        # The generator reuses memdir's small-fast-model resolver.
+        import src.services.tool_use_summary as mod
+
+        monkeypatch.setattr(mod, "_resolve_summary_model", lambda p: "small-fast-x")
+        p = _Provider()
+        _run(generate_tool_use_summary([{"name": "X", "input": 1, "output": 2}], p))
+        assert p.calls[-1][1]["model"] == "small-fast-x"


### PR DESCRIPTION
## Summary

`services/` parity, iteration 1. The reference `toolUseSummaryGenerator.ts` — a small-fast-model side query that writes a ~30-char git-commit-style label for a completed tool round — was **ABSENT** in Python; the state (`QueryState.pending_tool_use_summary`) and config were carried but dead.

**Ships:** `src/services/tool_use_summary.py` — a faithful, byte-exact port:
- `TOOL_USE_SUMMARY_SYSTEM_PROMPT` **verbatim** (mechanically extracted; the critic independently confirmed `ts == py`, 444 chars).
- `_truncate_json` **byte-exact** to `truncateJson`: `json.dumps(…, separators=(",", ":"))` (JSON.stringify's no-space form) → `text[:max_len-3] + "..."` (three ASCII dots, result length == `max_len` — not U+2026).
- The exact user-prompt shape: the verbatim `User's intent…` contextPrefix + `Tools completed:\n\n` + `Tool:/Input:/Output:` + `\n\nLabel:`.
- The small-fast-model side query via `chat_async` **directly** (free text, reusing only memdir's `_resolve_recall_model` pin — not `_select_with_provider`, which forces JSON mode). Never raises (every failure → `None`).

**Query-loop wiring (W2/W3) is DEFERRED** — the principled call, not a punt. Unlike the sweep's other inert-plumbing fixes (PermissionRequest hooks, the `if`-filter, teammate hooks — whose consumers existed once wired), the Haiku-label consumer is a mobile/external SDK app that **does not exist in this port**. TS emits the label SDK-only (`createToolUseSummaryMessage` → `{type:'tool_use_summary', summary, precedingToolUseIds}`); Python's `sdk_types` carries only the **unrelated drop-filtered** `streamlined_tool_use_summary` (a tool-count feature — `direct_connect_manager.py:67-73 _FILTERED_TYPES` drops it). Wiring a per-tool-round small-model call to feed a message nothing renders is cost-without-benefit. The tested generator is the actual missing artifact; the corrected wiring design (emit the real `tool_use_summary` message with `preceding_tool_use_ids`; fire after the abort/terminal early-returns; cancel the Task on terminal-return; `asyncio.wait_for` bound) is recorded in the plan doc, ready to wire when a consumer lands.

**Docs:** the folder gap analysis (`services-gap-analysis.md`) now dispositions **every** subsystem — the critic caught that the first draft omitted several. `autoFix` is surfaced as a **real live settings-opt-in unowned gap → SERVICES-2** (the next phase to implement); `AgentSummary` → coordinator docket; `tips`/`github-deviceFlow`/`rateLimitMocking`/`voice*` each dispositioned; flag resolution independently re-verified at both the runtime `_openBuildDefaults` and compile-time `scripts/build.ts` maps.

## Verification

- `tests/services/test_tool_use_summary.py` **12/12** (critic ran them independently): verbatim prompt, byte-exact truncate (`...` ASCII + no-space JSON), exact user-prompt shape, label strip, never-raises (raise/None/no-chat_async/empty-label), small-model pin reuse.
- Full suite at the 6-failure baseline (**7831 passed**).
- Critic loop: 2 rounds — both docs + implementation APPROVE; the defer-the-wiring decision confirmed as the correct integrity choice; the one gating refinement (true byte-exact JSON separators) applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
