### PR TITLE
feat(services): autoFix — lint/test-on-edit → model self-fix (SERVICES-2)

### DIFF
--- a/src/services/autofix/__init__.py
+++ b/src/services/autofix/__init__.py
@@ -1,0 +1,24 @@
+"""autoFix — run the user's lint/test command after a file edit and, on
+failure, inject ``<auto_fix_feedback>`` telling the model to self-fix.
+
+SERVICES-2 (services-folder parity). Port of typescript/src/services/autoFix/
+(config + hook + runner). Settings opt-in (``settings.autoFix``), NOT
+flag-gated. Python previously had only the ``/autofix`` slash shell that
+DOCUMENTS the config; the runtime hook + runner were absent.
+"""
+
+from __future__ import annotations
+
+from .config import AutoFixConfig, get_auto_fix_config
+from .hook import AUTO_FIX_TOOLS, build_auto_fix_context, should_run_auto_fix
+from .runner import AutoFixResult, run_auto_fix_check
+
+__all__ = [
+    "AutoFixConfig",
+    "get_auto_fix_config",
+    "AUTO_FIX_TOOLS",
+    "build_auto_fix_context",
+    "should_run_auto_fix",
+    "AutoFixResult",
+    "run_auto_fix_check",
+]

--- a/src/services/autofix/config.py
+++ b/src/services/autofix/config.py
@@ -1,0 +1,83 @@
+"""autoFix config — port of autoFixConfig.ts.
+
+``get_auto_fix_config(raw)`` mirrors ``getAutoFixConfig`` + the zod schema:
+returns a config only when ``raw`` is a dict, ``enabled`` is truthy, at
+least one of ``lint``/``test`` is set (the schema's ``.refine``), and the
+numeric bounds hold; otherwise ``None`` (the ``safeParse``-returns-null
+posture — never raises).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+_MAX_RETRIES_DEFAULT = 3
+_MAX_RETRIES_LO, _MAX_RETRIES_HI = 0, 10
+_TIMEOUT_DEFAULT = 30000
+_TIMEOUT_LO, _TIMEOUT_HI = 1000, 300000
+
+
+@dataclass(frozen=True)
+class AutoFixConfig:
+    enabled: bool
+    lint: str | None = None
+    test: str | None = None
+    max_retries: int = _MAX_RETRIES_DEFAULT
+    timeout_ms: int = _TIMEOUT_DEFAULT
+
+
+def _opt_str(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _bounded_int(value: Any, default: int, lo: int, hi: int) -> int | None:
+    """Zod ``.int().min(lo).max(hi).default(d)``: absent → default; present
+    but out of range / non-int → None (parse failure, matching safeParse)."""
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    if value < lo or value > hi:
+        return None
+    return value
+
+
+def get_auto_fix_config(raw: Any) -> AutoFixConfig | None:
+    """``settings.autoFix`` → :class:`AutoFixConfig` or ``None``."""
+    if not isinstance(raw, dict):
+        return None
+    if not raw.get("enabled"):
+        return None
+    lint = _opt_str(raw.get("lint"))
+    test = _opt_str(raw.get("test"))
+    # The schema's .refine: enabled requires at least one of lint/test.
+    if lint is None and test is None:
+        return None
+    max_retries = _bounded_int(
+        raw.get("maxRetries"), _MAX_RETRIES_DEFAULT, _MAX_RETRIES_LO, _MAX_RETRIES_HI
+    )
+    timeout_ms = _bounded_int(
+        raw.get("timeout"), _TIMEOUT_DEFAULT, _TIMEOUT_LO, _TIMEOUT_HI
+    )
+    if max_retries is None or timeout_ms is None:
+        return None
+    return AutoFixConfig(
+        enabled=True,
+        lint=lint,
+        test=test,
+        max_retries=max_retries,
+        timeout_ms=timeout_ms,
+    )
+
+
+def load_auto_fix_config() -> AutoFixConfig | None:
+    """Read ``settings.autoFix`` (it lands in ``settings.extra`` — there is
+    no typed field). Never raises."""
+    try:
+        from src.settings.settings import load_settings
+
+        raw = load_settings().extra.get("autoFix")
+        return get_auto_fix_config(raw)
+    except Exception:  # noqa: BLE001
+        return None

--- a/src/services/autofix/config.py
+++ b/src/services/autofix/config.py
@@ -27,8 +27,19 @@ class AutoFixConfig:
     timeout_ms: int = _TIMEOUT_DEFAULT
 
 
+class _Reject(Exception):
+    """A field failed zod validation → the whole config is None (safeParse)."""
+
+
 def _opt_str(value: Any) -> str | None:
-    return value if isinstance(value, str) else None
+    """Zod ``z.string().optional()``: absent → None; a string → itself; a
+    present non-string → REJECT the whole config (matching safeParse, not a
+    silent drop — critic minor)."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise _Reject
+    return value
 
 
 def _bounded_int(value: Any, default: int, lo: int, hi: int) -> int | None:
@@ -47,10 +58,19 @@ def get_auto_fix_config(raw: Any) -> AutoFixConfig | None:
     """``settings.autoFix`` → :class:`AutoFixConfig` or ``None``."""
     if not isinstance(raw, dict):
         return None
-    if not raw.get("enabled"):
+    # ``enabled: z.boolean()`` is REQUIRED and strict — a string "false" (or
+    # any non-bool) rejects the whole config, so it can't turn autoFix ON
+    # against apparent intent (critic minor #1).
+    enabled = raw.get("enabled")
+    if not isinstance(enabled, bool):
         return None
-    lint = _opt_str(raw.get("lint"))
-    test = _opt_str(raw.get("test"))
+    if not enabled:
+        return None
+    try:
+        lint = _opt_str(raw.get("lint"))
+        test = _opt_str(raw.get("test"))
+    except _Reject:
+        return None
     # The schema's .refine: enabled requires at least one of lint/test.
     if lint is None and test is None:
         return None

--- a/src/services/autofix/hook.py
+++ b/src/services/autofix/hook.py
@@ -1,0 +1,48 @@
+"""autoFix hook helpers — port of autoFixHook.ts.
+
+``AUTO_FIX_TOOLS`` maps TS's internal ``file_edit``/``file_write`` to the
+port's file-mutation registry tool names
+(``permissions/check.py:_FILE_EDIT_TOOLS``).
+"""
+
+from __future__ import annotations
+
+from .config import AutoFixConfig
+from .runner import AutoFixResult
+
+# The port's file-mutation tools (registry names), the analog of TS's
+# {file_edit, file_write}. Kept in sync with permissions._FILE_EDIT_TOOLS.
+AUTO_FIX_TOOLS = frozenset({"Write", "Edit", "MultiEdit", "NotebookEdit"})
+
+
+def should_run_auto_fix(tool_name: str, config: AutoFixConfig | None) -> bool:
+    if config is None:
+        return False
+    return tool_name in AUTO_FIX_TOOLS
+
+
+def build_auto_fix_context(result: AutoFixResult) -> str | None:
+    """The ``<auto_fix_feedback>`` block, VERBATIM (autoFixHook.ts:16-24).
+    None when there are no errors / no summary."""
+    if not result.has_errors or not result.error_summary:
+        return None
+    return (
+        "<auto_fix_feedback>\n"
+        "AUTO-FIX: The file you just edited has errors. Please fix them:\n\n"
+        f"{result.error_summary}\n\n"
+        "Please fix these errors in the files you just edited. "
+        "Do not ask the user — just apply the fix.\n"
+        "</auto_fix_feedback>"
+    )
+
+
+def build_max_retries_context(max_retries: int) -> str:
+    """The max-retries-reached ``<auto_fix_feedback>`` (toolHooks.ts:216-220),
+    verbatim."""
+    return (
+        "<auto_fix_feedback>\n"
+        f"AUTO-FIX: Maximum retry limit ({max_retries}) reached. "
+        "Skipping further auto-fix attempts. Please review the errors "
+        "manually.\n"
+        "</auto_fix_feedback>"
+    )

--- a/src/services/autofix/hook.py
+++ b/src/services/autofix/hook.py
@@ -10,9 +10,13 @@ from __future__ import annotations
 from .config import AutoFixConfig
 from .runner import AutoFixResult
 
-# The port's file-mutation tools (registry names), the analog of TS's
-# {file_edit, file_write}. Kept in sync with permissions._FILE_EDIT_TOOLS.
-AUTO_FIX_TOOLS = frozenset({"Write", "Edit", "MultiEdit", "NotebookEdit"})
+# The author's INTENT (critic M4): TS's dead `{file_edit, file_write}` was
+# meant to match FileEditTool (`Edit`) + FileWriteTool (`Write`). NOT the
+# 4-element _FILE_EDIT_TOOLS — TS deliberately excluded NotebookEdit and has
+# no MultiEdit tool; over-broadening would diverge past the intent. See the
+# plan's D1: this port ACTIVATES a feature TS never fires (a documented,
+# opt-in-gated divergence that fixes the reference's dead tool-name set).
+AUTO_FIX_TOOLS = frozenset({"Edit", "Write"})
 
 
 def should_run_auto_fix(tool_name: str, config: AutoFixConfig | None) -> bool:

--- a/src/services/autofix/runner.py
+++ b/src/services/autofix/runner.py
@@ -15,6 +15,7 @@ import logging
 import os
 import signal
 from dataclasses import dataclass
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -38,17 +39,23 @@ class _CmdResult:
     timed_out: bool
 
 
-async def _run_command(command: str, cwd: str, timeout_ms: float) -> _CmdResult:
-    """Spawn ``command`` via the shell, bounded by ``timeout_ms``. On timeout
-    kill the process group. Never raises — a spawn failure is a non-zero
-    exit."""
+_OUTPUT_CAP = 10000  # TS slices stdout/stderr to 10k before combining.
+
+
+async def _run_command(
+    command: str, cwd: str, timeout_ms: float, abort_signal: Any = None
+) -> _CmdResult:
+    """Spawn ``command`` via the shell, bounded by ``timeout_ms`` AND a
+    mid-flight abort signal. On either, kill the process group (the TS
+    ``detached`` + ``killTree`` analog) and reap. Never raises — a spawn
+    failure is a non-zero exit."""
     try:
         proc = await asyncio.create_subprocess_shell(
             command,
             cwd=cwd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            # Own process group so a timeout can kill the whole tree (the
+            # Own process group so a timeout/abort kills the whole tree (the
             # shell + its children), not just the shell.
             start_new_session=True,
         )
@@ -56,22 +63,55 @@ async def _run_command(command: str, cwd: str, timeout_ms: float) -> _CmdResult:
         logger.debug("autofix: failed to spawn %r", command, exc_info=True)
         return _CmdResult(stdout="", stderr="spawn failed", exit_code=1, timed_out=False)
 
+    comm = asyncio.ensure_future(proc.communicate())
+    timeout_s = timeout_ms / 1000.0
+
+    async def _abort_watch() -> None:
+        # Poll the abort signal (TS wires an abort listener → killTree); exit
+        # early if the command finishes on its own.
+        while not getattr(abort_signal, "aborted", False):
+            if comm.done():
+                return
+            await asyncio.sleep(0.05)
+
+    waiters = {comm}
+    watcher = None
+    if abort_signal is not None:
+        watcher = asyncio.ensure_future(_abort_watch())
+        waiters.add(watcher)
     try:
-        stdout_b, stderr_b = await asyncio.wait_for(
-            proc.communicate(), timeout=timeout_ms / 1000.0
+        done, _pending = await asyncio.wait(
+            waiters, timeout=timeout_s, return_when=asyncio.FIRST_COMPLETED
         )
-    except asyncio.TimeoutError:
+    finally:
+        if watcher is not None:
+            watcher.cancel()
+
+    # A timeout is the wait elapsing with NOTHING done. If the watcher
+    # completed (abort fired) while comm did not, that is an abort — not a
+    # timeout.
+    timed_out = len(done) == 0
+    aborted_mid = (
+        not timed_out
+        and comm not in done
+        and abort_signal is not None
+        and getattr(abort_signal, "aborted", False)
+    )
+    if timed_out or aborted_mid:
         _kill_group(proc)
-        # Reap the killed process so it does not become a zombie.
         try:
             await asyncio.wait_for(proc.wait(), timeout=2.0)
-        except (asyncio.TimeoutError, Exception):  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             pass
-        return _CmdResult(stdout="", stderr="", exit_code=1, timed_out=True)
+        comm.cancel()
+        return _CmdResult(stdout="", stderr="", exit_code=1, timed_out=timed_out)
 
+    stdout_b, stderr_b = await comm
+    stdout = stdout_b.decode("utf-8", "replace")[:_OUTPUT_CAP]
+    stderr = stderr_b.decode("utf-8", "replace")[:_OUTPUT_CAP]
     return _CmdResult(
-        stdout=stdout_b.decode("utf-8", "replace"),
-        stderr=stderr_b.decode("utf-8", "replace"),
+        stdout=stdout,
+        stderr=stderr,
         exit_code=proc.returncode if proc.returncode is not None else 1,
         timed_out=False,
     )
@@ -81,9 +121,10 @@ def _kill_group(proc: asyncio.subprocess.Process) -> None:
     if proc.pid is None:
         return
     try:
-        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        # SIGTERM to match TS (graceful group terminate).
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
     except (ProcessLookupError, PermissionError, OSError):
-        # Fall back to killing just the process if the group is gone.
+        # Already-exited race (TS catches the same) or no group — fall back.
         try:
             proc.kill()
         except (ProcessLookupError, OSError):
@@ -116,18 +157,25 @@ async def run_auto_fix_check(
     test: str | None,
     timeout_ms: int,
     cwd: str,
-    aborted: bool = False,
+    abort_signal: Any = None,
 ) -> AutoFixResult:
     """Run lint (then test if lint passed) — port of ``runAutoFixCheck``."""
     if not lint and not test:
         return AutoFixResult(has_errors=False)
-    if aborted:
+    if abort_signal is not None and getattr(abort_signal, "aborted", False):
         return AutoFixResult(has_errors=False)
 
     result = AutoFixResult(has_errors=False)
 
+    def _is_aborted() -> bool:
+        return abort_signal is not None and getattr(abort_signal, "aborted", False)
+
     if lint:
-        lint_r = await _run_command(lint, cwd, timeout_ms)
+        lint_r = await _run_command(lint, cwd, timeout_ms, abort_signal)
+        # An abort that killed the command mid-flight is NOT a lint failure —
+        # degrade to no-errors (no feedback injected), matching TS.
+        if _is_aborted():
+            return AutoFixResult(has_errors=False)
         result.lint_output = (lint_r.stdout + "\n" + lint_r.stderr).strip()
         result.lint_exit_code = lint_r.exit_code
         if lint_r.timed_out:
@@ -142,7 +190,9 @@ async def run_auto_fix_check(
 
     # Tests only if lint passed (or no lint configured).
     if test:
-        test_r = await _run_command(test, cwd, timeout_ms)
+        test_r = await _run_command(test, cwd, timeout_ms, abort_signal)
+        if _is_aborted():
+            return AutoFixResult(has_errors=False)
         result.test_output = (test_r.stdout + "\n" + test_r.stderr).strip()
         result.test_exit_code = test_r.exit_code
         if test_r.timed_out:

--- a/src/services/autofix/runner.py
+++ b/src/services/autofix/runner.py
@@ -1,0 +1,155 @@
+"""autoFix runner — port of autoFixRunner.ts.
+
+Runs the configured lint command first, then the test command only if lint
+passed (or none configured), each as a shell subprocess bounded by a
+timeout. On timeout the whole process GROUP is killed (the TS ``detached`` +
+``killTree`` analog) so shell-spawned children don't leak. Never raises — a
+spawn failure degrades to ``has_errors=False`` (auto-fix is non-critical,
+matching the TS runner's resolve-on-error).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AutoFixResult:
+    has_errors: bool = False
+    lint_output: str | None = None
+    lint_exit_code: int | None = None
+    test_output: str | None = None
+    test_exit_code: int | None = None
+    timed_out: bool = False
+    error_summary: str | None = None
+
+
+@dataclass
+class _CmdResult:
+    stdout: str
+    stderr: str
+    exit_code: int
+    timed_out: bool
+
+
+async def _run_command(command: str, cwd: str, timeout_ms: float) -> _CmdResult:
+    """Spawn ``command`` via the shell, bounded by ``timeout_ms``. On timeout
+    kill the process group. Never raises — a spawn failure is a non-zero
+    exit."""
+    try:
+        proc = await asyncio.create_subprocess_shell(
+            command,
+            cwd=cwd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            # Own process group so a timeout can kill the whole tree (the
+            # shell + its children), not just the shell.
+            start_new_session=True,
+        )
+    except Exception:  # noqa: BLE001 — spawn failure is non-critical
+        logger.debug("autofix: failed to spawn %r", command, exc_info=True)
+        return _CmdResult(stdout="", stderr="spawn failed", exit_code=1, timed_out=False)
+
+    try:
+        stdout_b, stderr_b = await asyncio.wait_for(
+            proc.communicate(), timeout=timeout_ms / 1000.0
+        )
+    except asyncio.TimeoutError:
+        _kill_group(proc)
+        # Reap the killed process so it does not become a zombie.
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=2.0)
+        except (asyncio.TimeoutError, Exception):  # noqa: BLE001
+            pass
+        return _CmdResult(stdout="", stderr="", exit_code=1, timed_out=True)
+
+    return _CmdResult(
+        stdout=stdout_b.decode("utf-8", "replace"),
+        stderr=stderr_b.decode("utf-8", "replace"),
+        exit_code=proc.returncode if proc.returncode is not None else 1,
+        timed_out=False,
+    )
+
+
+def _kill_group(proc: asyncio.subprocess.Process) -> None:
+    if proc.pid is None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        # Fall back to killing just the process if the group is gone.
+        try:
+            proc.kill()
+        except (ProcessLookupError, OSError):
+            pass
+
+
+def _build_error_summary(result: AutoFixResult) -> str | None:
+    """Verbatim autoFixRunner.ts:118-133."""
+    if not result.has_errors:
+        return None
+    parts: list[str] = []
+    if result.timed_out:
+        parts.append("Command timed out.")
+    if result.lint_exit_code is not None and result.lint_exit_code != 0:
+        parts.append(
+            f"Lint errors (exit code {result.lint_exit_code}):\n"
+            f"{result.lint_output or ''}"
+        )
+    if result.test_exit_code is not None and result.test_exit_code != 0:
+        parts.append(
+            f"Test failures (exit code {result.test_exit_code}):\n"
+            f"{result.test_output or ''}"
+        )
+    return "\n\n".join(parts)
+
+
+async def run_auto_fix_check(
+    *,
+    lint: str | None,
+    test: str | None,
+    timeout_ms: int,
+    cwd: str,
+    aborted: bool = False,
+) -> AutoFixResult:
+    """Run lint (then test if lint passed) — port of ``runAutoFixCheck``."""
+    if not lint and not test:
+        return AutoFixResult(has_errors=False)
+    if aborted:
+        return AutoFixResult(has_errors=False)
+
+    result = AutoFixResult(has_errors=False)
+
+    if lint:
+        lint_r = await _run_command(lint, cwd, timeout_ms)
+        result.lint_output = (lint_r.stdout + "\n" + lint_r.stderr).strip()
+        result.lint_exit_code = lint_r.exit_code
+        if lint_r.timed_out:
+            result.has_errors = True
+            result.timed_out = True
+            result.error_summary = _build_error_summary(result)
+            return result
+        if lint_r.exit_code != 0:
+            result.has_errors = True
+            result.error_summary = _build_error_summary(result)
+            return result
+
+    # Tests only if lint passed (or no lint configured).
+    if test:
+        test_r = await _run_command(test, cwd, timeout_ms)
+        result.test_output = (test_r.stdout + "\n" + test_r.stderr).strip()
+        result.test_exit_code = test_r.exit_code
+        if test_r.timed_out:
+            result.has_errors = True
+            result.timed_out = True
+        elif test_r.exit_code != 0:
+            result.has_errors = True
+
+    result.error_summary = _build_error_summary(result)
+    return result

--- a/src/services/autofix/step.py
+++ b/src/services/autofix/step.py
@@ -1,0 +1,94 @@
+"""autoFix post-tool step — port of the toolHooks.ts:196-253 autoFix block.
+
+Runs as a SIBLING of ``run_post_tool_use_hooks`` at the orchestrator (NOT
+inside it — that function early-returns when no user PostToolUse hook is
+configured, tool_hooks.py:166, which is the common case for an autoFix
+user; putting the step there would strand it — the teammate-hooks
+split-gate class). This step runs regardless of user hooks, gated only on
+the ``settings.autoFix`` opt-in.
+
+D1 (see the plan): TS's tool-name set never matches real tool names, so the
+reference feature never fires; this port activates the author's intent
+(``{Edit, Write}``) — a documented, opt-in-gated divergence.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, AsyncGenerator
+
+from src.types.messages import create_attachment_message
+
+from .config import load_auto_fix_config
+from .hook import (
+    build_auto_fix_context,
+    build_max_retries_context,
+    should_run_auto_fix,
+)
+from .runner import run_auto_fix_check
+
+logger = logging.getLogger(__name__)
+
+# chain_id → consecutive auto-fix attempt count (the TS autoFixRetryCount
+# analog). Cleared on a clean run so a later unrelated failure starts fresh.
+_auto_fix_retry_count: dict[str, int] = {}
+
+
+def _chain_key(tool_use_context: Any) -> str:
+    qt = getattr(tool_use_context, "query_tracking", None)
+    return (getattr(qt, "chain_id", "") if qt else "") or "default"
+
+
+def _attachment(content: str, tool_name: str, tool_use_id: str) -> dict[str, Any]:
+    return {
+        "message": create_attachment_message({
+            "type": "hook_additional_context",
+            "content": [content],
+            "hook_name": f"AutoFix:{tool_name}",
+            "tool_use_id": tool_use_id,
+            "hook_event": "PostToolUse",
+        })
+    }
+
+
+async def run_auto_fix_step(
+    tool_use_context: Any,
+    tool_name: str,
+    tool_use_id: str,
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Yield the ``<auto_fix_feedback>`` attachment(s) after a file edit, or
+    nothing. Guarded — an autoFix failure never breaks the tool loop."""
+    try:
+        config = load_auto_fix_config()
+        if not should_run_auto_fix(tool_name, config) or config is None:
+            return
+
+        chain_key = _chain_key(tool_use_context)
+        current = _auto_fix_retry_count.get(chain_key, 0)
+        if current >= config.max_retries:
+            yield _attachment(
+                build_max_retries_context(config.max_retries), tool_name, tool_use_id
+            )
+            return
+
+        abort_ctrl = getattr(tool_use_context, "abort_controller", None)
+        abort_signal = getattr(abort_ctrl, "signal", None) if abort_ctrl else None
+        cwd = getattr(tool_use_context, "cwd", None) or "."
+
+        result = await run_auto_fix_check(
+            lint=config.lint,
+            test=config.test,
+            timeout_ms=config.timeout_ms,
+            cwd=str(cwd),
+            abort_signal=abort_signal,
+        )
+        context = build_auto_fix_context(result)
+        if context:
+            _auto_fix_retry_count[chain_key] = current + 1
+            yield _attachment(context, tool_name, tool_use_id)
+        else:
+            # Clean run — reset the counter (toolHooks.ts:247) so a later
+            # unrelated failing edit is not prematurely capped.
+            _auto_fix_retry_count.pop(chain_key, None)
+    except Exception:  # noqa: BLE001 — autoFix must never break the tool loop
+        logger.debug("autofix step failed", exc_info=True)

--- a/src/services/tool_execution/tool_execution.py
+++ b/src/services/tool_execution/tool_execution.py
@@ -446,6 +446,20 @@ async def _check_permissions_and_call_tool(
         except Exception as e:
             logger.debug("Post-tool hook error: %s", e)
 
+        # SERVICES-2 autoFix — a SIBLING of the PostToolUse hooks (run_post_tool_use_hooks
+        # early-returns when no user hook is configured; autoFix must run
+        # regardless, gated only on the settings.autoFix opt-in).
+        try:
+            from src.services.autofix.step import run_auto_fix_step
+
+            async for af_result in run_auto_fix_step(
+                tool_use_context, tool.name, tool_use_id,
+            ):
+                if isinstance(af_result, dict) and "message" in af_result:
+                    resulting_messages.append(MessageUpdateLazy(message=af_result["message"]))
+        except Exception as e:  # noqa: BLE001
+            logger.debug("autoFix step error: %s", e)
+
         if result.new_messages:
             for msg in result.new_messages:
                 resulting_messages.append(MessageUpdateLazy(message=msg))

--- a/tests/services/test_autofix.py
+++ b/tests/services/test_autofix.py
@@ -223,3 +223,22 @@ class TestStep:
         ctx = SimpleNamespace(query_tracking=None, abort_controller=None, cwd="/tmp")
         out = self._collect(ctx)
         assert len(out) == 1 and "default" in stepmod._auto_fix_retry_count
+
+
+class TestConfigStrictness:
+    """critic minor #1 — zod z.boolean()/z.string() reject the whole config
+    on a bad type (safeParse null), not a silent coerce/drop."""
+
+    def test_string_enabled_rejected(self):
+        # "false" is truthy in Python — must NOT turn autoFix on.
+        assert get_auto_fix_config({"enabled": "false", "lint": "x"}) is None
+        assert get_auto_fix_config({"enabled": "true", "lint": "x"}) is None
+        assert get_auto_fix_config({"enabled": 1, "lint": "x"}) is None
+
+    def test_bad_type_lint_rejects_whole_config(self):
+        assert get_auto_fix_config({"enabled": True, "lint": 123, "test": "y"}) is None
+        assert get_auto_fix_config({"enabled": True, "test": ["not", "a", "string"]}) is None
+
+    def test_real_bool_enabled_still_works(self):
+        assert get_auto_fix_config({"enabled": True, "lint": "x"}) is not None
+        assert get_auto_fix_config({"enabled": False, "lint": "x"}) is None

--- a/tests/services/test_autofix.py
+++ b/tests/services/test_autofix.py
@@ -1,0 +1,225 @@
+"""SERVICES-2 — autoFix (lint/test-on-edit → model self-fix).
+
+Port of typescript/src/services/autoFix/ with a DOCUMENTED DIVERGENCE (D1):
+TS's AUTO_FIX_TOOLS = {file_edit,file_write} never matches real tool names
+(Edit/Write), so the reference feature is dead code; this port activates the
+author's intent ({Edit,Write}), gated behind the settings.autoFix opt-in.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from src.services.autofix.config import AutoFixConfig, get_auto_fix_config
+from src.services.autofix.hook import (
+    AUTO_FIX_TOOLS,
+    build_auto_fix_context,
+    build_max_retries_context,
+    should_run_auto_fix,
+)
+from src.services.autofix.runner import AutoFixResult, run_auto_fix_check
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestConfig:
+    def test_enabled_with_lint(self):
+        c = get_auto_fix_config({"enabled": True, "lint": "eslint ."})
+        assert c is not None and c.lint == "eslint ." and c.max_retries == 3
+
+    def test_disabled_returns_none(self):
+        assert get_auto_fix_config({"enabled": False, "lint": "x"}) is None
+
+    def test_enabled_without_lint_or_test_none(self):
+        # the zod .refine
+        assert get_auto_fix_config({"enabled": True}) is None
+
+    def test_non_dict_none(self):
+        assert get_auto_fix_config("nope") is None
+        assert get_auto_fix_config(None) is None
+
+    def test_camelcase_keys_honored(self):
+        # critic M2: reads maxRetries / timeout (NOT timeout_ms).
+        c = get_auto_fix_config(
+            {"enabled": True, "test": "t", "maxRetries": 5, "timeout": 12000}
+        )
+        assert c.max_retries == 5 and c.timeout_ms == 12000
+
+    def test_out_of_range_rejects_not_clamps(self):
+        # critic M1: zod .min/.max REJECTS → whole config None (not clamp).
+        assert get_auto_fix_config({"enabled": True, "test": "t", "maxRetries": 20}) is None
+        assert get_auto_fix_config({"enabled": True, "test": "t", "maxRetries": -1}) is None
+        assert get_auto_fix_config({"enabled": True, "test": "t", "timeout": 999}) is None
+        assert get_auto_fix_config({"enabled": True, "test": "t", "timeout": 999999}) is None
+
+    def test_non_int_rejects(self):
+        assert get_auto_fix_config({"enabled": True, "test": "t", "maxRetries": "3"}) is None
+
+
+class TestHook:
+    def test_tool_set_is_edit_write_intent(self):
+        # critic M4 + D1: the author's intent, not the dead literal or the
+        # 4-element _FILE_EDIT_TOOLS.
+        assert AUTO_FIX_TOOLS == frozenset({"Edit", "Write"})
+
+    def test_should_run(self):
+        c = AutoFixConfig(enabled=True, lint="x")
+        assert should_run_auto_fix("Edit", c) and should_run_auto_fix("Write", c)
+        assert not should_run_auto_fix("Read", c)
+        assert not should_run_auto_fix("NotebookEdit", c)  # excluded, per intent
+        assert not should_run_auto_fix("Edit", None)
+
+    def test_build_context_verbatim(self):
+        ctx = build_auto_fix_context(
+            AutoFixResult(has_errors=True, error_summary="Lint errors (exit code 1):\nbad")
+        )
+        assert ctx.startswith("<auto_fix_feedback>\nAUTO-FIX: The file you just edited has errors")
+        assert "Do not ask the user — just apply the fix." in ctx
+        assert ctx.endswith("</auto_fix_feedback>")
+
+    def test_build_context_none_when_clean(self):
+        assert build_auto_fix_context(AutoFixResult(has_errors=False)) is None
+
+    def test_max_retries_message_verbatim(self):
+        m = build_max_retries_context(3)
+        assert "Maximum retry limit (3) reached" in m
+        assert m.startswith("<auto_fix_feedback>") and m.endswith("</auto_fix_feedback>")
+
+
+class TestRunner:
+    def test_lint_fail_skips_test(self):
+        r = _run(run_auto_fix_check(lint="exit 1", test="echo NO", timeout_ms=5000, cwd="/tmp"))
+        assert r.has_errors and r.lint_exit_code == 1 and r.test_exit_code is None
+        assert "Lint errors (exit code 1)" in r.error_summary
+
+    def test_lint_pass_test_fail(self):
+        r = _run(run_auto_fix_check(lint="true", test="exit 2", timeout_ms=5000, cwd="/tmp"))
+        assert r.has_errors and r.test_exit_code == 2 and "Test failures (exit code 2)" in r.error_summary
+
+    def test_both_clean(self):
+        r = _run(run_auto_fix_check(lint="true", test="true", timeout_ms=5000, cwd="/tmp"))
+        assert not r.has_errors
+
+    def test_timeout_kills_group(self):
+        import time
+
+        t0 = time.time()
+        r = _run(run_auto_fix_check(lint="sleep 30", test=None, timeout_ms=800, cwd="/tmp"))
+        assert r.timed_out and r.has_errors and (time.time() - t0) < 5
+        assert "Command timed out." in r.error_summary
+
+    def test_output_capped_at_10k(self):
+        r = _run(run_auto_fix_check(
+            lint='python3 -c "print(chr(120)*50000)"; exit 1', test=None,
+            timeout_ms=5000, cwd="/tmp",
+        ))
+        assert r.has_errors and len(r.lint_output) <= 10002  # 10k + the "\n" join strip slack
+
+    def test_abort_pre_set(self):
+        class _Sig:
+            aborted = True
+
+        r = _run(run_auto_fix_check(lint="exit 1", test=None, timeout_ms=5000, cwd="/tmp", abort_signal=_Sig()))
+        assert not r.has_errors
+
+    def test_mid_flight_abort_no_errors(self):
+        import time
+
+        class _Sig:
+            aborted = False
+
+        sig = _Sig()
+
+        async def go():
+            task = asyncio.ensure_future(run_auto_fix_check(
+                lint="sleep 30", test=None, timeout_ms=60000, cwd="/tmp", abort_signal=sig,
+            ))
+            await asyncio.sleep(0.2)
+            sig.aborted = True
+            return await asyncio.wait_for(task, timeout=5)
+
+        t0 = time.time()
+        r = asyncio.run(go())
+        assert not r.has_errors and not r.timed_out and (time.time() - t0) < 5
+
+    def test_no_commands_no_errors(self):
+        assert not _run(run_auto_fix_check(lint=None, test=None, timeout_ms=5000, cwd="/tmp")).has_errors
+
+
+class TestStep:
+    """The wiring step — incl. the B1 regression (runs with ZERO PostToolUse
+    hooks) and the M3 reset-on-success."""
+
+    def _ctx(self, chain="c1"):
+        return SimpleNamespace(
+            query_tracking=SimpleNamespace(chain_id=chain),
+            abort_controller=None,
+            cwd="/tmp",
+        )
+
+    def _collect(self, ctx, tool="Edit", tool_use_id="tu"):
+        from src.services.autofix.step import run_auto_fix_step
+
+        async def go():
+            return [m async for m in run_auto_fix_step(ctx, tool, tool_use_id)]
+
+        return asyncio.run(go())
+
+    def _patch_config(self, monkeypatch, cfg):
+        import src.services.autofix.step as stepmod
+
+        monkeypatch.setattr(stepmod, "load_auto_fix_config", lambda: cfg)
+
+    def test_fires_with_zero_posttool_hooks(self, monkeypatch):
+        """B1 regression — the single most important case: autoFix runs even
+        when NO user PostToolUse hook is configured (the common case). It's a
+        sibling of run_post_tool_use_hooks, not gated by has_hook_for_event.
+        The ctx here has no hook_config_manager at all."""
+        import src.services.autofix.step as stepmod
+
+        stepmod._auto_fix_retry_count.clear()
+        self._patch_config(monkeypatch, AutoFixConfig(enabled=True, lint="exit 1", max_retries=3))
+        out = self._collect(self._ctx())
+        assert len(out) == 1 and "auto_fix_feedback" in str(out[0])
+
+    def test_non_file_tool_skips(self, monkeypatch):
+        self._patch_config(monkeypatch, AutoFixConfig(enabled=True, lint="exit 1"))
+        assert self._collect(self._ctx(), tool="Bash") == []
+
+    def test_no_config_skips(self, monkeypatch):
+        self._patch_config(monkeypatch, None)
+        assert self._collect(self._ctx(), tool="Edit") == []
+
+    def test_retry_cap_fires_max_message(self, monkeypatch):
+        import src.services.autofix.step as stepmod
+
+        stepmod._auto_fix_retry_count.clear()
+        self._patch_config(monkeypatch, AutoFixConfig(enabled=True, lint="exit 1", max_retries=2))
+        ctx = self._ctx("cap")
+        self._collect(ctx)  # 1
+        self._collect(ctx)  # 2
+        capped = self._collect(ctx)  # 2 >= 2 → capped message
+        assert len(capped) == 1 and "Maximum retry limit (2)" in str(capped[0])
+
+    def test_reset_on_clean_run(self, monkeypatch):
+        import src.services.autofix.step as stepmod
+
+        stepmod._auto_fix_retry_count.clear()
+        stepmod._auto_fix_retry_count["r"] = 1
+        self._patch_config(monkeypatch, AutoFixConfig(enabled=True, lint="true", max_retries=3))
+        self._collect(self._ctx("r"))
+        assert "r" not in stepmod._auto_fix_retry_count  # cleared on clean run
+
+    def test_none_query_tracking_uses_default_key(self, monkeypatch):
+        # critic M5: query_tracking=None must not crash.
+        import src.services.autofix.step as stepmod
+
+        stepmod._auto_fix_retry_count.clear()
+        self._patch_config(monkeypatch, AutoFixConfig(enabled=True, lint="exit 1", max_retries=3))
+        ctx = SimpleNamespace(query_tracking=None, abort_controller=None, cwd="/tmp")
+        out = self._collect(ctx)
+        assert len(out) == 1 and "default" in stepmod._auto_fix_retry_count


### PR DESCRIPTION
## Summary

`services/` parity, iteration 2. TS's `autoFix/` runs the user's configured lint/test command after a file edit and, on failure, injects `<auto_fix_feedback>` telling the model to self-fix. Settings opt-in. Python had only the `/autofix` slash shell; the runtime was absent.

**The decisive finding (a documented divergence, not a silent one).** The critic caught — and I verified first-hand — that **TS autoFix is dead code**: its `AUTO_FIX_TOOLS = {'file_edit','file_write'}` never matches the real tool names (`FILE_EDIT_TOOL_NAME = 'Edit'`, no alias; the `file_edit`/`file_write` strings elsewhere are analytics event names), and the call site passes `tool.name` — so the reference feature has never fired. Porting the dead literal would be a no-op. This port instead ships the **author's intent** (`AUTO_FIX_TOOLS = {"Edit","Write"}`, working) as a **deliberate, documented divergence**: it activates a feature the reference intended but never ran (a latent reference bug — the whole subsystem, config, and tests exist). It is safe to diverge because the feature is **settings-opt-in**: zero effect unless a user writes `{"autoFix":{"enabled":true,…}}`, and then it does exactly what they plainly asked for. Framed as parity-of-intent + reference-bug-fix, not byte-faithful runtime parity.

**Implementation** (`src/services/autofix/`):
- `config.py` — `get_auto_fix_config` mirrors the zod schema, **rejecting** (not clamping) out-of-range/non-int values (whole config → `None`, like `safeParse`), reading the camelCase JSON keys (`maxRetries`/`timeout`), from `get_settings().extra["autoFix"]`.
- `hook.py` — `AUTO_FIX_TOOLS = {"Edit","Write"}` (the intent), `should_run_auto_fix`, and the verbatim `<auto_fix_feedback>` + max-retries texts.
- `runner.py` — `run_auto_fix_check`: lint first, test only if lint passed; each an `asyncio.create_subprocess_shell` bounded by a timeout **and** a mid-flight abort watcher, killing the process **group** (`SIGTERM` + reap + already-exited race catch) on either; each stream capped at 10 000 chars; never raises.
- `step.py` — `run_auto_fix_step`, wired as a **sibling** of `run_post_tool_use_hooks` at the orchestrator (**not** inside it — that function early-returns when no user PostToolUse hook is configured, the common autoFix case; the teammate-hooks split-gate class). Retry-capped by `query_tracking.chain_id` with **reset-on-clean-run**.

## Verification

- `tests/services/test_autofix.py` **26/26**, execution-style (real subprocesses): config matrix (parse/refine/reject-not-clamp/camelCase), hook + verbatim contexts + the `{Edit,Write}` intent, runner (lint-skips-test / test-fail / clean / **timeout-SIGTERM-kill** / **10K cap** / pre-set abort / **mid-flight abort** / no-commands), and the step (**the zero-PostToolUse-hooks regression** — the single most important case, B1; non-file skip; retry cap; reset-on-clean; None-`query_tracking`).
- Full suite at the 6-failure baseline (**7857 passed**).
- Critic loop: plan REVISE → all findings fixed (D1 divergence framing; B1 split-gate; B2 accessor; M1 reject-not-clamp; M2 camelCase; M3 reset-on-success; M4 tool set; M5 None-guard; M6 10K cap; SIGTERM/reap/mid-flight-abort minors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
