### PR TITLE
feat(services): wiki completion — structured ingest + index rebuild (SERVICES-4)

### DIFF
--- a/src/wiki/index_builder.py
+++ b/src/wiki/index_builder.py
@@ -1,0 +1,67 @@
+"""Wiki index rebuild — port of typescript/src/services/wiki/indexBuilder.ts.
+
+Lists the wiki's markdown pages + sources, extracts each page's title (its
+first ``# `` heading, else the filename), and writes a browsable index.
+Called after each ingest; exposed for a future ``/wiki reindex``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .wiki import get_wiki_paths
+
+
+def _list_markdown_files(directory: Path) -> list[Path]:
+    if not directory.is_dir():
+        return []
+    files: list[Path] = []
+    for entry in sorted(directory.rglob("*.md")):
+        if entry.is_file():
+            files.append(entry)
+    return sorted(files)
+
+
+def _get_page_title(path: Path) -> str:
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return path.stem
+    for line in content.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            return stripped[2:].strip()
+    return path.stem
+
+
+def rebuild_wiki_index(cwd: str | Path) -> None:
+    """Port of ``rebuildWikiIndex``: write ``index.md`` from the pages +
+    sources markdown."""
+    paths = get_wiki_paths(cwd)
+    page_files = _list_markdown_files(paths.pages_dir)
+    source_files = _list_markdown_files(paths.sources_dir)
+
+    page_links = []
+    for f in page_files:
+        rel = f.relative_to(paths.root).as_posix()
+        title = _get_page_title(f)
+        page_links.append(f"- [{title}](./{rel})")
+
+    source_links = []
+    for f in source_files:
+        rel = f.relative_to(paths.root).as_posix()
+        source_links.append(f"- [{f.stem}](./{rel})")
+
+    project_name = Path(cwd).name
+    content = (
+        f"# {project_name} Wiki\n\n"
+        "This wiki is maintained by clawcodex as a durable project "
+        "knowledge layer.\n\n"
+        "## Core Pages\n\n"
+        f"{chr(10).join(page_links) if page_links else '- No pages yet'}\n\n"
+        "## Sources\n\n"
+        f"{chr(10).join(source_links) if source_links else '- No sources yet'}\n\n"
+        "## Recent Updates\n\n"
+        "- See [log.md](./log.md)\n"
+    )
+    paths.index_file.write_text(content, encoding="utf-8")

--- a/src/wiki/utils.py
+++ b/src/wiki/utils.py
@@ -1,0 +1,45 @@
+"""Wiki text utils — port of typescript/src/services/wiki/utils.ts.
+
+Pure/mechanical: slug sanitization, a NON-LLM 280-char summary (a truncate,
+not a model call), and first-line title extraction.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def sanitize_wiki_slug(value: str) -> str:
+    """Port of ``sanitizeWikiSlug``: lowercase, non-alnum → ``-``, collapse
+    and trim dashes."""
+    out = value.lower()
+    out = re.sub(r"[^a-z0-9]+", "-", out)
+    out = re.sub(r"^-+|-+$", "", out)
+    out = re.sub(r"-{2,}", "-", out)
+    return out
+
+
+def summarize_text(text: str, max_len: int = 280) -> str:
+    """Port of ``summarizeText``: whitespace-normalize; empty → the default;
+    ≤max → itself; else truncate to ``max_len-1`` + ``…`` (U+2026, verbatim
+    to TS)."""
+    normalized = re.sub(r"\s+", " ", text).strip()
+    if not normalized:
+        return "No summary available."
+    if len(normalized) <= max_len:
+        return normalized
+    return normalized[: max_len - 1].rstrip() + "…"
+
+
+def extract_title_from_text(fallback_name: str, content: str) -> str:
+    """Port of ``extractTitleFromText``: the first non-empty trimmed line,
+    with a leading ``#…`` stripped; empty → the fallback."""
+    first_non_empty = None
+    for line in content.split("\n"):
+        stripped = line.strip()
+        if stripped:
+            first_non_empty = stripped
+            break
+    if not first_non_empty:
+        return fallback_name
+    return re.sub(r"^#+\s*", "", first_non_empty) or fallback_name

--- a/src/wiki/wiki.py
+++ b/src/wiki/wiki.py
@@ -45,11 +45,16 @@ def _schema_template(project: str) -> str:
 
 
 def _index_template(project: str) -> str:
+    # Matches rebuild_wiki_index's structure for a just-initialized wiki
+    # (only architecture.md present) so the first ingest's rebuild does not
+    # flip the headers user-visibly (critic MINOR-1).
     return (
         f"# {project} Wiki\n\n"
-        "## Pages\n\n- [Architecture](./pages/architecture.md)\n\n"
-        "## Sources\n\nSource notes live in [sources/](./sources/)\n\n"
-        "## Log\n\nSee [log.md](./log.md)\n"
+        "This wiki is maintained by clawcodex as a durable project "
+        "knowledge layer.\n\n"
+        "## Core Pages\n\n- [Architecture](./pages/architecture.md)\n\n"
+        "## Sources\n\n- No sources yet\n\n"
+        "## Recent Updates\n\n- See [log.md](./log.md)\n"
     )
 
 
@@ -114,6 +119,8 @@ def ingest_source(cwd: str | Path, src: str) -> dict:
     """Port of ``ingestLocalWikiSource`` (SERVICES-4): write a STRUCTURED
     source note (title/summary/excerpt) + a log entry + rebuild the index —
     replacing the prior copy-only behavior."""
+    import datetime as _dt
+    import os as _os
     import time as _time
 
     from .index_builder import rebuild_wiki_index
@@ -129,11 +136,15 @@ def ingest_source(cwd: str | Path, src: str) -> dict:
         return {"ok": False, "error": f"not a file: {src}"}
     try:
         content = src_path.read_text(encoding="utf-8", errors="replace")
-        try:
-            rel_source = src_path.resolve().relative_to(Path(cwd).resolve()).as_posix()
-        except ValueError:
-            rel_source = src_path.name
-        ingested_at = _time.strftime("%Y-%m-%dT%H:%M:%S", _time.gmtime()) + "Z"
+        # Lexical relative path (TS path.relative), so out-of-cwd sources get a
+        # ``../``-style path rather than a bare basename (critic MINOR-4).
+        rel_source = _os.path.relpath(
+            _os.path.abspath(str(src_path)), _os.path.abspath(str(cwd))
+        ).replace(_os.sep, "/")
+        # ISO-8601 with milliseconds + Z, matching TS Date.toISOString()
+        # (critic MINOR-2).
+        _now = _dt.datetime.now(_dt.timezone.utc)
+        ingested_at = _now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{_now.microsecond // 1000:03d}Z"
         base_name = src_path.stem
         title = extract_title_from_text(base_name, content)
         summary = summarize_text(content)

--- a/src/wiki/wiki.py
+++ b/src/wiki/wiki.py
@@ -90,7 +90,35 @@ def wiki_status(cwd: str | Path) -> dict:
     return {"initialized": True, "root": str(paths.root), "page_count": pages, "source_count": sources}
 
 
+def _build_source_note(
+    *, title: str, source_path: str, ingested_at: str, summary: str, excerpt: str
+) -> str:
+    """Verbatim template from ingest.ts:13-46 (buildSourceNote)."""
+    return (
+        f"# {title}\n\n"
+        "## Source\n\n"
+        f"- Path: `{source_path}`\n"
+        f"- Ingested at: {ingested_at}\n\n"
+        "## Summary\n\n"
+        f"{summary}\n\n"
+        "## Excerpt\n\n"
+        "```\n"
+        f"{excerpt}\n"
+        "```\n\n"
+        "## Linked Pages\n\n"
+        "- [Architecture](../pages/architecture.md)\n"
+    )
+
+
 def ingest_source(cwd: str | Path, src: str) -> dict:
+    """Port of ``ingestLocalWikiSource`` (SERVICES-4): write a STRUCTURED
+    source note (title/summary/excerpt) + a log entry + rebuild the index —
+    replacing the prior copy-only behavior."""
+    import time as _time
+
+    from .index_builder import rebuild_wiki_index
+    from .utils import extract_title_from_text, sanitize_wiki_slug, summarize_text
+
     paths = get_wiki_paths(cwd)
     if not paths.index_file.exists():
         return {"ok": False, "error": "wiki not initialized — run /wiki init first"}
@@ -99,14 +127,42 @@ def ingest_source(cwd: str | Path, src: str) -> dict:
         src_path = Path(cwd) / src
     if not src_path.is_file():
         return {"ok": False, "error": f"not a file: {src}"}
-    dest = paths.sources_dir / src_path.name
     try:
-        shutil.copyfile(src_path, dest)
+        content = src_path.read_text(encoding="utf-8", errors="replace")
+        try:
+            rel_source = src_path.resolve().relative_to(Path(cwd).resolve()).as_posix()
+        except ValueError:
+            rel_source = src_path.name
+        ingested_at = _time.strftime("%Y-%m-%dT%H:%M:%S", _time.gmtime()) + "Z"
+        base_name = src_path.stem
+        title = extract_title_from_text(base_name, content)
+        summary = summarize_text(content)
+        excerpt = "\n".join(content.split("\n")[:20]).strip()
+        ms = _time.time_ns() // 1_000_000
+        slug = sanitize_wiki_slug(f"{base_name}-{ms}") or f"source-{ms}"
+
+        note_path = paths.sources_dir / f"{slug}.md"
+        note_path.write_text(
+            _build_source_note(
+                title=title, source_path=rel_source, ingested_at=ingested_at,
+                summary=summary, excerpt=excerpt,
+            ),
+            encoding="utf-8",
+        )
+        with paths.log_file.open("a", encoding="utf-8") as f:
+            f.write(
+                f'- {ingested_at}: Ingested `{rel_source}` into source '
+                f'note "{title}"\n'
+            )
+        rebuild_wiki_index(cwd)
     except Exception as exc:  # noqa: BLE001
         return {"ok": False, "error": str(exc)}
-    try:  # append to the log (best-effort)
-        with paths.log_file.open("a", encoding="utf-8") as f:
-            f.write(f"- ingested source: {src_path.name}\n")
-    except Exception:  # noqa: BLE001
-        pass
-    return {"ok": True, "dest": str(dest)}
+    return {
+        "ok": True,
+        "dest": str(note_path),
+        "source_note": note_path.relative_to(Path(cwd)).as_posix()
+        if note_path.is_relative_to(Path(cwd))
+        else str(note_path),
+        "summary": summary,
+        "title": title,
+    }

--- a/tests/test_wiki_completion.py
+++ b/tests/test_wiki_completion.py
@@ -1,0 +1,124 @@
+"""SERVICES-4 — wiki completion (structured ingest + index rebuild).
+
+Port of typescript/src/services/wiki/{utils,ingest,indexBuilder}.ts. The
+/wiki command is wired live (agent_server.py _do_wiki), so the on-disk wiki
+is a real consumer; these pin the structured note + index vs the prior
+copy-only ingest.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.wiki.index_builder import rebuild_wiki_index
+from src.wiki.utils import (
+    extract_title_from_text,
+    sanitize_wiki_slug,
+    summarize_text,
+)
+from src.wiki.wiki import get_wiki_paths, ingest_source, init_wiki
+
+
+class TestUtils:
+    def test_slug(self):
+        assert sanitize_wiki_slug("Hello World!! Foo") == "hello-world-foo"
+        assert sanitize_wiki_slug("--a--b--") == "a-b"
+        assert sanitize_wiki_slug("Already-Clean") == "already-clean"
+        assert sanitize_wiki_slug("!!!") == ""
+
+    def test_summarize(self):
+        assert summarize_text("") == "No summary available."
+        assert summarize_text("   \n\t ") == "No summary available."
+        assert summarize_text("short text") == "short text"
+        assert summarize_text("a\n\nb   c") == "a b c"  # whitespace-normalized
+        long = "x " * 300
+        s = summarize_text(long)
+        assert len(s) == 280 and s.endswith("…")
+
+    def test_summarize_custom_max(self):
+        assert summarize_text("abcdefghij", max_len=5) == "abcd…"
+
+    def test_extract_title(self):
+        assert extract_title_from_text("fb", "# My Title\nbody") == "My Title"
+        assert extract_title_from_text("fb", "### Deep\n") == "Deep"
+        assert extract_title_from_text("fb", "plain first line\nmore") == "plain first line"
+        assert extract_title_from_text("fb", "\n\n   \n") == "fb"
+        assert extract_title_from_text("fb", "") == "fb"
+
+
+class TestIngest:
+    def test_structured_note_not_raw_copy(self, tmp_path):
+        init_wiki(str(tmp_path))
+        src = tmp_path / "notes.md"
+        src.write_text("# Design Notes\n\nBody of the design.\n" + ("detail " * 100))
+        r = ingest_source(str(tmp_path), str(src))
+        assert r["ok"] and r["title"] == "Design Notes"
+        note = Path(r["dest"])
+        assert note.exists() and note.parent.name == "sources"
+        txt = note.read_text()
+        # structured, not a raw copy
+        assert "# Design Notes" in txt
+        assert "## Source" in txt and "## Summary" in txt and "## Excerpt" in txt
+        assert "```" in txt
+        assert r["summary"].startswith("# Design Notes Body of the design")
+
+    def test_log_appended_and_index_rebuilt(self, tmp_path):
+        init_wiki(str(tmp_path))
+        src = tmp_path / "a.md"
+        src.write_text("# Alpha\ntext")
+        ingest_source(str(tmp_path), str(src))
+        paths = get_wiki_paths(str(tmp_path))
+        log = paths.log_file.read_text()
+        assert "Ingested" in log and "Alpha" in log
+        idx = paths.index_file.read_text()
+        assert "## Core Pages" in idx and "## Sources" in idx
+        # the ingested source note is linked under Sources
+        assert "/sources/" in idx
+
+    def test_not_initialized(self, tmp_path):
+        src = tmp_path / "x.md"
+        src.write_text("hi")
+        r = ingest_source(str(tmp_path), str(src))
+        assert not r["ok"] and "not initialized" in r["error"]
+
+    def test_missing_file(self, tmp_path):
+        init_wiki(str(tmp_path))
+        r = ingest_source(str(tmp_path), str(tmp_path / "nope.md"))
+        assert not r["ok"] and "not a file" in r["error"]
+
+    def test_slug_unique_per_ingest(self, tmp_path):
+        init_wiki(str(tmp_path))
+        src = tmp_path / "dup.md"
+        src.write_text("# Dup\nx")
+        r1 = ingest_source(str(tmp_path), str(src))
+        r2 = ingest_source(str(tmp_path), str(src))
+        # both ingests produce a note (slug carries a ms suffix); at least one
+        # distinct path, never an error.
+        assert r1["ok"] and r2["ok"]
+
+
+class TestIndexRebuild:
+    def test_lists_pages_and_sources_with_titles(self, tmp_path):
+        init_wiki(str(tmp_path))
+        paths = get_wiki_paths(str(tmp_path))
+        # a titled page + an untitled page
+        (paths.pages_dir / "titled.md").write_text("# The Title\nbody")
+        (paths.pages_dir / "untitled.md").write_text("no heading here")
+        (paths.sources_dir / "src1.md").write_text("# S1\nx")
+        rebuild_wiki_index(str(tmp_path))
+        idx = paths.index_file.read_text()
+        assert "[The Title]" in idx  # titled → heading
+        assert "[untitled]" in idx  # untitled → filename stem
+        assert "[src1]" in idx  # source → filename stem
+        # the index file itself is not listed as a page
+        assert "[index]" not in idx
+
+    def test_empty_wiki_placeholders(self, tmp_path):
+        init_wiki(str(tmp_path))
+        paths = get_wiki_paths(str(tmp_path))
+        # remove the seed architecture page so pages is empty
+        (paths.pages_dir / "architecture.md").unlink()
+        rebuild_wiki_index(str(tmp_path))
+        idx = paths.index_file.read_text()
+        assert "- No pages yet" in idx and "- No sources yet" in idx

--- a/tests/test_wiki_completion.py
+++ b/tests/test_wiki_completion.py
@@ -98,6 +98,48 @@ class TestIngest:
         assert r1["ok"] and r2["ok"]
 
 
+class TestByteFidelity:
+    """critic MINOR-3 — pin the exact artifacts (highest-risk #2), not just
+    substrings."""
+
+    def test_build_source_note_byte_exact(self):
+        from src.wiki.wiki import _build_source_note
+
+        note = _build_source_note(
+            title="My Title",
+            source_path="docs/readme.md",
+            ingested_at="2026-07-04T12:00:00.000Z",
+            summary="A short summary.",
+            excerpt="line one\nline two",
+        )
+        expected = (
+            "# My Title\n\n"
+            "## Source\n\n"
+            "- Path: `docs/readme.md`\n"
+            "- Ingested at: 2026-07-04T12:00:00.000Z\n\n"
+            "## Summary\n\n"
+            "A short summary.\n\n"
+            "## Excerpt\n\n"
+            "```\n"
+            "line one\nline two\n"
+            "```\n\n"
+            "## Linked Pages\n\n"
+            "- [Architecture](../pages/architecture.md)\n"
+        )
+        assert note == expected
+
+    def test_log_line_format(self, tmp_path):
+        init_wiki(str(tmp_path))
+        src = tmp_path / "doc.md"
+        src.write_text("# Doc Title\nbody")
+        ingest_source(str(tmp_path), str(src))
+        log_lines = get_wiki_paths(str(tmp_path)).log_file.read_text().splitlines()
+        entry = [ln for ln in log_lines if "Ingested" in ln][-1]
+        # verbatim: - {ts}: Ingested `{path}` into source note "{title}"
+        assert entry.endswith('Ingested `doc.md` into source note "Doc Title"')
+        assert entry.startswith("- 20")  # ISO timestamp prefix
+
+
 class TestIndexRebuild:
     def test_lists_pages_and_sources_with_titles(self, tmp_path):
         init_wiki(str(tmp_path))

--- a/tests/wiki/test_wiki.py
+++ b/tests/wiki/test_wiki.py
@@ -1,5 +1,7 @@
 """Project wiki init/status/ingest tests."""
 
+from pathlib import Path
+
 from src.wiki import get_wiki_paths, ingest_source, init_wiki, wiki_status
 
 
@@ -28,13 +30,19 @@ def test_status_before_and_after(tmp_path):
     assert st["page_count"] == 1  # architecture.md
 
 
-def test_ingest_copies_into_sources(tmp_path):
+def test_ingest_writes_structured_source_note(tmp_path):
+    # SERVICES-4: ingest now writes a STRUCTURED note (title/summary/excerpt)
+    # at sources/{slug}.md, not a raw copy of README.md.
     (tmp_path / "README.md").write_text("# Readme", encoding="utf-8")
     assert ingest_source(tmp_path, "README.md")["ok"] is False  # not initialized yet
     init_wiki(tmp_path)
     res = ingest_source(tmp_path, "README.md")
-    assert res["ok"] is True
-    assert (get_wiki_paths(tmp_path).sources_dir / "README.md").exists()
+    assert res["ok"] is True and res["title"] == "Readme"
+    note = get_wiki_paths(tmp_path).sources_dir / "README.md"
+    assert not note.exists()  # NOT a raw copy of the original name
+    dest = Path(res["dest"])
+    assert dest.exists() and dest.parent.name == "sources"
+    assert "## Summary" in dest.read_text(encoding="utf-8")
     assert wiki_status(tmp_path)["source_count"] == 1
 
 


### PR DESCRIPTION
## Summary

`services/` parity, iteration 4. The `/wiki` command is wired live (`agent_server.py:_do_wiki` → init/status/ingest), so the on-disk project wiki is a real consumer — but the port's `ingest_source` was **copy-only** (`shutil.copyfile` + a log line) vs TS's `ingestLocalWikiSource`, which writes a **structured source note** and rebuilds a **browsable index**. This ports the missing pieces (all pure/mechanical, **non-LLM** — `summarizeText` is a 280-char truncate, not a model call):

- **`src/wiki/utils.py`** (port of `utils.ts`): `sanitize_wiki_slug`, `summarize_text` (whitespace-normalize → 280-char truncate + `…`, verbatim), `extract_title_from_text`.
- **`src/wiki/wiki.py` `ingest_source`** (port of `ingestLocalWikiSource`): reads the source → writes a structured `sources/{slug}.md` (title/summary/excerpt) via the **byte-identical** `buildSourceNote` template + a verbatim log entry → `rebuild_wiki_index`. Returns `{ok, dest, source_note, summary, title}` (passthrough-safe — `_do_wiki` forwards the dict; `ok`+`dest` preserved).
- **`src/wiki/index_builder.py`** (port of `indexBuilder.ts`): `rebuild_wiki_index` lists pages+sources markdown, extracts page titles (first `# ` heading or filename), writes the index; called by ingest + exposed for a future `/wiki reindex`.

## Verification

- `tests/test_wiki_completion.py` (13) + the legacy copy-only test updated to the structured-note behavior — **18 wiki tests green**.
- Full suite at the 6-failure baseline (**7873 passed**).
- Critic (2 rounds): APPROVE after byte-fidelity verified programmatically (`_build_source_note` + log entry byte-identical to TS) and no live-command regression; all four minors fixed — **MINOR-1** the init `_index_template` now matches `rebuild_wiki_index` (no first-ingest header flip), **MINOR-2** ms-precision ISO timestamp, **MINOR-3** byte-exact template + log-line test pins, **MINOR-4** lexical `os.path.relpath` (`../`-style for out-of-cwd sources).
- Pre-existing out-of-scope items (the not-initialized guard vs TS auto-init; the broader `init_wiki` low-fidelity seed) logged as a wiki-init-fidelity follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
