### PR TITLE
feat(utils): subprocess secret-scrub (UTILS-2) + MCP-instructions rendering (UTILS-1, wiring deferred)

### DIFF
--- a/src/context_system/prompt_assembly.py
+++ b/src/context_system/prompt_assembly.py
@@ -1146,9 +1146,13 @@ def _build_mcp_section(
 
     # Surface server-authored `instructions` (from the MCP InitializeResult
     # handshake) — port of getMcpInstructions (constants/prompts.ts:572-596).
-    # The client captures + truncates them onto the server object; without
-    # this the guidance ("authenticate before calling tools", usage
-    # conventions, …) is silently dropped and the model sees only schemas.
+    # RENDERING ONLY: the LIVE wiring is DEFERRED (McpRuntime discards the
+    # connect() instructions at mcp_runtime.py:101 and every live prompt-build
+    # site passes mcp_servers=None). See the "MCP-instructions-live-wiring"
+    # chapter: retain {name,instructions} in McpRuntime + thread here + make
+    # this a REQUEST-scoped per-turn section (TS uses an UNCACHED section so
+    # late/OAuth-gated connects aren't missed). This block renders correctly
+    # once fed.
     instruction_blocks = [
         f"## {getattr(server, 'name', str(server))}\n{instr}"
         for server in mcp_servers

--- a/src/context_system/prompt_assembly.py
+++ b/src/context_system/prompt_assembly.py
@@ -1144,6 +1144,24 @@ def _build_mcp_section(
         name = getattr(server, "name", str(server))
         parts.append(f"- {name}")
 
+    # Surface server-authored `instructions` (from the MCP InitializeResult
+    # handshake) — port of getMcpInstructions (constants/prompts.ts:572-596).
+    # The client captures + truncates them onto the server object; without
+    # this the guidance ("authenticate before calling tools", usage
+    # conventions, …) is silently dropped and the model sees only schemas.
+    instruction_blocks = [
+        f"## {getattr(server, 'name', str(server))}\n{instr}"
+        for server in mcp_servers
+        if (instr := (getattr(server, "instructions", None) or "").strip())
+    ]
+    if instruction_blocks:
+        parts.append(
+            "\n# MCP Server Instructions\n\n"
+            "The following MCP servers have provided instructions for how to "
+            "use their tools and resources:\n\n"
+            + "\n\n".join(instruction_blocks)
+        )
+
     content = "\n".join(parts)
     if use_cache:
         _prompt_cache.set("mcp", content, scope=CacheScope.SESSION)

--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -360,8 +360,13 @@ def _build_hook_env(
 
     env_file = _env_file_for_event(event_name)
 
+    from src.utils.subprocess_env import subprocess_env
+
     return {
-        **os.environ,
+        # subprocess_env() scrubs secret vars when CLAUDE_CODE_SUBPROCESS_ENV_SCRUB
+        # is set (anti-exfiltration; parity with TS subprocessEnv at the hook
+        # spawn site) — otherwise a pass-through copy of os.environ.
+        **subprocess_env(),
         "CLAUDE_HOOK_EVENT": event_name,
         "CLAUDE_PROJECT_DIR": workspace_root,
         "CLAUDE_PLUGIN_ROOT": hook.skill_root or "",

--- a/src/tool_system/tools/bash/background.py
+++ b/src/tool_system/tools/bash/background.py
@@ -76,9 +76,15 @@ def spawn_background_bash(
     # ``stdin=DEVNULL`` mirrors the foreground bash path: prevents background
     # commands that read fd 0 from blocking on a TTY inherited from clawcodex's
     # REPL (see bash_tool.py:_run_bash_with_abort for the same reasoning).
+    from src.utils.subprocess_env import subprocess_env
+
     proc = subprocess.Popen(
         ["bash", "-lc", wrapped],
         cwd=str(cwd),
+        # Scrub secret env vars when CLAUDE_CODE_SUBPROCESS_ENV_SCRUB is set,
+        # so a prompt-injected background command can't exfiltrate a credential
+        # via ${ANTHROPIC_API_KEY} (parity with TS subprocessEnv).
+        env=subprocess_env(),
         stdin=subprocess.DEVNULL,
         stdout=output_handle,
         stderr=subprocess.STDOUT,

--- a/src/tool_system/tools/bash/bash_tool.py
+++ b/src/tool_system/tools/bash/bash_tool.py
@@ -95,6 +95,13 @@ def _run_bash_with_abort(
     else:
         popen_kwargs["start_new_session"] = True
 
+    if "env" not in popen_kwargs:
+        # Scrub secret env vars when CLAUDE_CODE_SUBPROCESS_ENV_SCRUB is set
+        # (anti-exfiltration; parity with TS subprocessEnv at the Bash site).
+        from src.utils.subprocess_env import subprocess_env
+
+        popen_kwargs["env"] = subprocess_env()
+
     proc = subprocess.Popen(argv, **popen_kwargs)
 
     deadline = _time_mod.monotonic() + timeout_s

--- a/src/utils/subprocess_env.py
+++ b/src/utils/subprocess_env.py
@@ -1,0 +1,71 @@
+"""Subprocess environment scrubbing — port of utils/subprocessEnv.ts.
+
+The canonical "env for a spawned child process" chokepoint. When
+``CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`` is truthy, it strips a fixed set of
+secret env vars (+ their ``INPUT_`` GitHub-Action twins) from the child's
+environment — an anti-exfiltration control so a prompt-injected Bash command
+cannot read a credential via shell expansion (``${ANTHROPIC_API_KEY}``) in a
+subprocess. Gated because ``claude-code-action`` sets the flag; a plain local
+CLI leaves the env untouched (parity with TS).
+
+NOTE: TS's ``subprocessEnv`` also merges the upstream-proxy env
+(``registerUpstreamProxyEnvFn``). That half is intentionally NOT wired here —
+the port's upstreamproxy is unwired (the deferred CCR-remote-proxy chapter);
+when it lands, merge ``get_upstream_proxy_env()`` into the base below.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Verbatim from subprocessEnv.ts GHA_SUBPROCESS_SCRUB (23 vars).
+_GHA_SUBPROCESS_SCRUB: tuple[str, ...] = (
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_FOUNDRY_API_KEY",
+    "ANTHROPIC_CUSTOM_HEADERS",
+    "OTEL_EXPORTER_OTLP_HEADERS",
+    "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+    "OTEL_EXPORTER_OTLP_METRICS_HEADERS",
+    "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "AZURE_CLIENT_SECRET",
+    "AZURE_CLIENT_CERTIFICATE_PATH",
+    "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+    "ACTIONS_ID_TOKEN_REQUEST_URL",
+    "ACTIONS_RUNTIME_TOKEN",
+    "ACTIONS_RUNTIME_URL",
+    "ALL_INPUTS",
+    "OVERRIDE_GITHUB_TOKEN",
+    "DEFAULT_WORKFLOW_TOKEN",
+    "SSH_SIGNING_KEY",
+)
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _is_env_truthy(value: str | None) -> bool:
+    return bool(value) and value.strip().lower() in _TRUTHY
+
+
+def subprocess_env(base: dict[str, str] | None = None) -> dict[str, str]:
+    """Return the environment a child process should inherit.
+
+    ``base`` defaults to a copy of ``os.environ``. When
+    ``CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`` is truthy, the scrub set (+ ``INPUT_``
+    twins) is removed; otherwise ``base`` is returned unchanged (parity with
+    TS's non-gated pass-through). Always returns a fresh dict."""
+    env = dict(os.environ if base is None else base)
+    if not _is_env_truthy(env.get("CLAUDE_CODE_SUBPROCESS_ENV_SCRUB")):
+        return env
+    for key in _GHA_SUBPROCESS_SCRUB:
+        env.pop(key, None)
+        env.pop(f"INPUT_{key}", None)  # the GitHub-Action input twin
+    return env
+
+
+__all__ = ["subprocess_env"]

--- a/tests/test_mcp_instructions.py
+++ b/tests/test_mcp_instructions.py
@@ -1,0 +1,41 @@
+"""UTILS-1 — MCP server `instructions` surfaced in the system prompt.
+
+Port of getMcpInstructions (constants/prompts.ts:572-596). The MCP client
+captures each connected server's InitializeResult `instructions`, but the
+port previously listed only server NAMES — dropping server-authored guidance.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.context_system.prompt_assembly import _build_mcp_section
+
+
+def _srv(name, instructions=None):
+    return SimpleNamespace(name=name, instructions=instructions)
+
+
+def test_instructions_surfaced_for_servers_that_have_them():
+    sec = _build_mcp_section([_srv("github", "Authenticate first."), _srv("fs")], use_cache=False)
+    c = sec.content
+    assert "# MCP Servers" in c and "- github" in c and "- fs" in c
+    assert "# MCP Server Instructions" in c
+    assert "## github\nAuthenticate first." in c
+    assert "## fs" not in c
+
+
+def test_no_instructions_section_when_none_provided():
+    sec = _build_mcp_section([_srv("fs"), _srv("db", "")], use_cache=False)
+    assert "# MCP Server Instructions" not in sec.content
+    assert "- fs" in sec.content and "- db" in sec.content
+
+
+def test_whitespace_only_instructions_ignored():
+    sec = _build_mcp_section([_srv("x", "   \n  ")], use_cache=False)
+    assert "# MCP Server Instructions" not in sec.content
+
+
+def test_multiple_instruction_blocks_joined():
+    sec = _build_mcp_section([_srv("a", "AAA"), _srv("b", "BBB")], use_cache=False)
+    c = sec.content
+    assert "## a\nAAA" in c and "## b\nBBB" in c

--- a/tests/test_subprocess_env_scrub.py
+++ b/tests/test_subprocess_env_scrub.py
@@ -1,0 +1,61 @@
+"""UTILS-2 — subprocess env secret-scrub (port of utils/subprocessEnv.ts).
+
+Anti-exfiltration: when CLAUDE_CODE_SUBPROCESS_ENV_SCRUB is truthy, secret env
+vars (+ their INPUT_ GitHub-Action twins) are stripped from a child process's
+environment so a prompt-injected Bash command can't read them via ${VAR}.
+Wired at the bash (fg+bg) + hook subprocess sites.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from src.utils.subprocess_env import subprocess_env
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for k in ("CLAUDE_CODE_SUBPROCESS_ENV_SCRUB", "ANTHROPIC_API_KEY",
+              "INPUT_ANTHROPIC_API_KEY", "AWS_SECRET_ACCESS_KEY", "SSH_SIGNING_KEY"):
+        monkeypatch.delenv(k, raising=False)
+    yield
+
+
+def test_flag_off_passes_through(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sekret")
+    e = subprocess_env()
+    assert e["ANTHROPIC_API_KEY"] == "sekret"  # untouched when flag off
+
+
+def test_flag_on_scrubs_secrets_and_input_twins(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_SUBPROCESS_ENV_SCRUB", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "s")
+    monkeypatch.setenv("INPUT_ANTHROPIC_API_KEY", "twin")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "a")
+    monkeypatch.setenv("SSH_SIGNING_KEY", "k")
+    e = subprocess_env()
+    for gone in ("ANTHROPIC_API_KEY", "INPUT_ANTHROPIC_API_KEY",
+                 "AWS_SECRET_ACCESS_KEY", "SSH_SIGNING_KEY"):
+        assert gone not in e
+    assert "PATH" in e  # non-secret retained
+
+
+def test_truthy_variants(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "s")
+    for v, scrubbed in [("true", True), ("yes", True), ("on", True),
+                        ("0", False), ("false", False), ("", False)]:
+        monkeypatch.setenv("CLAUDE_CODE_SUBPROCESS_ENV_SCRUB", v)
+        assert ("ANTHROPIC_API_KEY" not in subprocess_env()) is scrubbed
+
+
+def test_returns_fresh_dict_not_os_environ(monkeypatch):
+    e = subprocess_env()
+    e["_MUT"] = "x"
+    assert "_MUT" not in os.environ
+
+
+def test_explicit_base(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_SUBPROCESS_ENV_SCRUB", "1")
+    e = subprocess_env({"CLAUDE_CODE_SUBPROCESS_ENV_SCRUB": "1", "ANTHROPIC_API_KEY": "x", "KEEP": "y"})
+    assert "ANTHROPIC_API_KEY" not in e and e["KEEP"] == "y"

--- a/tests/test_subprocess_env_scrub.py
+++ b/tests/test_subprocess_env_scrub.py
@@ -59,3 +59,17 @@ def test_explicit_base(monkeypatch):
     monkeypatch.setenv("CLAUDE_CODE_SUBPROCESS_ENV_SCRUB", "1")
     e = subprocess_env({"CLAUDE_CODE_SUBPROCESS_ENV_SCRUB": "1", "ANTHROPIC_API_KEY": "x", "KEEP": "y"})
     assert "ANTHROPIC_API_KEY" not in e and e["KEEP"] == "y"
+
+
+def test_all_23_scrub_vars_stripped(monkeypatch):
+    from src.utils.subprocess_env import _GHA_SUBPROCESS_SCRUB
+    assert len(_GHA_SUBPROCESS_SCRUB) == 23
+    monkeypatch.setenv("CLAUDE_CODE_SUBPROCESS_ENV_SCRUB", "1")
+    for v in _GHA_SUBPROCESS_SCRUB:
+        monkeypatch.setenv(v, "secret")
+        monkeypatch.setenv(f"INPUT_{v}", "twin")
+    e = subprocess_env()
+    for v in _GHA_SUBPROCESS_SCRUB:
+        assert v not in e and f"INPUT_{v}" not in e, v
+    # the flag itself is preserved for the child (TS keeps it)
+    assert e.get("CLAUDE_CODE_SUBPROCESS_ENV_SCRUB") == "1"


### PR DESCRIPTION
## Summary

`utils/` parity — the **largest folder** (~603 files / 190,251 L), swept via a two-explorer fan-out (a–m + n–z). The port distributes utilities faithfully, so the 190K lines resolve to ~200 ported (co-located), ~158 N-A (each gate-checked against `scripts/build.ts`), and a small live-gap set.

**UTILS-2 — subprocess env secret-scrub (IMPLEMENTED, critic-APPROVED).** Port of `subprocessEnv.ts`: when `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` is truthy, strip 23 secret vars (`ANTHROPIC_API_KEY`/`CLAUDE_CODE_OAUTH_TOKEN`/`AWS_SECRET_ACCESS_KEY`/`ACTIONS_*_TOKEN`/`OTEL_*_HEADERS`/…) + their `INPUT_` GitHub-Action twins from a child process's env — anti-exfiltration so a prompt-injected Bash command can't read a credential via `${VAR}`. The port previously spawned every child with the full `os.environ`.
- `src/utils/subprocess_env.py` (23-var list exact + same order as `GHA_SUBPROCESS_SCRUB`; flag-off pass-through, flag-on scrub + twins, fresh dict).
- Wired at the 3 inherited-env subprocess sites: bash foreground + background Popen, and hook `_build_hook_env`. (The MCP stdio spawn is a verified non-issue — the Python MCP SDK uses a `get_default_environment()` allowlist, so secrets are never inherited. The proxy-merge half of `subprocessEnv` is left for the deferred CCR-remote-proxy chapter.)

**UTILS-1 — MCP server `instructions`: RENDERING PORTED, LIVE WIRING DEFERRED.** `_build_mcp_section` now faithfully renders `getMcpInstructions` (`## <name>\n<instructions>` per server), **but the critic caught it inert on the live path** — `McpRuntime` discards the connect() instructions and every live prompt-build site passes `mcp_servers=None`; only the dead `engine.py`/`QueryEngine` path threads it. So this ships the rendering half (ready to feed) with the live wiring recorded as a deferred chapter (retain in `McpRuntime` + thread + a REQUEST-scoped per-turn section, since MCP servers connect between turns). **Not claimed closed.**

## Verification

- `tests/test_subprocess_env_scrub.py` (6): flag-off/on, all-23-vars + `INPUT_` twins stripped (PATH kept, flag preserved for child), truthy variants, fresh-dict, explicit base. `tests/test_mcp_instructions.py` (4): the rendering. 253 bash tests green (`env=` no regression).
- Full suite at the 6-failure baseline (7914 passed).
- Critic: UTILS-2 APPROVE (scrub list exact, wiring live, MCP non-issue verified); UTILS-1 re-dispositioned per the critic's B1 (rendering ported, wiring deferred).

## Deferred-owned chapters recorded

Sandbox (external `@anthropic-ai/sandbox-runtime`; + a `settings.sandbox` silent-unsandboxed guard follow-up), MCP-instructions-live-wiring, relevancePruning + streamJsonStdoutGuard (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
