### PR TITLE
fix(server): raise default max_turns from 20 to 50

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,50 @@
+# TODOS
+
+## Server / Agent Loop
+
+### Advisor tool violates default is_read_only / is_concurrency_safe
+
+**What:** The `advisor` tool reports `is_read_only({}) == True` and `is_concurrency_safe({}) == True`, but the tool-property-parity suite expects tools not in the override list to fall back to the registry default (`False` for both). Also breaks two advisor smoke-test flows.
+
+**Why:** Silently-wrong tool properties can change scheduling/concurrency behavior for a tool in ways nothing else guards against (e.g. a tool assumed read-only being allowed to run concurrently with a write).
+
+**Context:** Discovered pre-existing on 2026-07-04 while shipping an unrelated `max_turns` default change (branch `chore/max-turns-default-50`) — verified these fail identically on `main` with that branch's changes stashed, so this predates and is unrelated to that PR. Failing tests:
+- `tests/parity/test_tool_parity.py::TestToolPropertyParity::test_default_is_concurrency_safe_false`
+- `tests/parity/test_tool_parity.py::TestToolPropertyParity::test_default_is_read_only_false`
+- `tests/integration/test_advisor_smoke.py::TestAdvisorHappyPath::test_advisor_pair_preserved_in_history`
+- `tests/integration/test_advisor_smoke.py::TestAdvisorInterruptPath::test_orphan_stripped_even_with_beta_active`
+
+Start by checking whether `advisor` is missing from `tool_overrides` (if `True`/`True` is actually correct for this tool) or whether its `is_read_only`/`is_concurrency_safe` implementation is wrong (if `False`/`False` is correct and it should behave like other tools).
+
+**Effort:** S
+**Priority:** P0
+**Depends on:** None
+
+### Workspace-boundary blocking not enforced in write/read e2e flows
+
+**What:** Writes and reads outside the workspace root are not being blocked in the e2e flow tests.
+
+**Why:** Workspace-boundary enforcement is a safety boundary — if it's silently not firing, a tool call could read or write outside the intended sandboxed directory.
+
+**Context:** Discovered pre-existing on 2026-07-04, same session as above — verified identical failures on `main` with the unrelated branch's changes stashed. Failing tests:
+- `tests/parity/test_e2e_edit_flow.py::TestE2EWriteFlow::test_write_outside_workspace_blocked`
+- `tests/parity/test_e2e_file_read.py::TestE2EFileRead::test_read_outside_workspace_blocked`
+
+**Effort:** M
+**Priority:** P0
+**Depends on:** None
+
+### Wire up max_cost_usd / settings.max_turns, and let the TUI override --max-turns per launch
+
+**What:** `SettingsSchema.max_cost_usd` and `SettingsSchema.max_turns` are both defined and validated but never actually read/enforced anywhere in the query loop or agent-server (confirmed: `agent_server.py`'s only `load_settings()` call reads `.hooks` only). Separately, `clawcodex tui` spawns the backend without ever forwarding a `--max-turns` flag, so a running interactive session has no way to raise or lower its own turn ceiling.
+
+**Why:** `AgentServerConfig.max_turns` / `--max-turns` is currently the *only* enforced ceiling on a single prompt's wall-clock time, token spend, $ cost, and tool side effects. Independently flagged by both a Claude adversarial-review subagent and a Codex adversarial pass while shipping the `max_turns` default bump (20→50, branch `chore/max-turns-default-50`) — raising that default widens the blast radius of this pre-existing gap by 2.5x with nothing else to catch a model that keeps calling tools "successfully" forever.
+
+**Context:** Two independent fixes bundled here since they're the same root gap: (1) actually enforce `max_cost_usd`/`settings.max_turns` as a real backstop, not just a validated-but-unused setting; (2) add a per-launch (or in-session) `--max-turns` override path for `clawcodex tui`, mirroring the flag `clawcodex agent-server`/`clawcodex -p` already accept directly.
+
+**Effort:** M
+**Priority:** P2
+**Depends on:** None
+
+## Completed
+</content>

--- a/src/cli.py
+++ b/src/cli.py
@@ -359,8 +359,8 @@ Examples:
     noninteractive.add_argument(
         '--max-turns',
         type=int,
-        default=20,
-        help='Maximum number of agent tool turns (default: 20)',
+        default=50,
+        help='Maximum number of agent tool turns (default: 50)',
     )
     noninteractive.add_argument(
         '--model',

--- a/src/entrypoints/agent_server_cli.py
+++ b/src/entrypoints/agent_server_cli.py
@@ -46,7 +46,12 @@ from src.utils.startup_profiler import profile_checkpoint
 
 profile_checkpoint("agent_server_import_start")
 
-from src.server.agent_server import AgentServerConfig, PROTOCOL_VERSION, make_spawn_agent
+from src.server.agent_server import (
+    DEFAULT_MAX_TURNS,
+    AgentServerConfig,
+    PROTOCOL_VERSION,
+    make_spawn_agent,
+)
 from src.server.server import DirectConnectServer
 from src.server.session_manager import SessionManager
 from src.server.types import ServerConfig
@@ -114,7 +119,7 @@ def run_agent_server_subcommand(argv: list[str]) -> int:
     )
     parser.add_argument("--workspace", default=None,
                         help="Workspace root the agent operates in (default: cwd).")
-    parser.add_argument("--max-turns", type=int, default=20, dest="max_turns")
+    parser.add_argument("--max-turns", type=int, default=DEFAULT_MAX_TURNS, dest="max_turns")
     parser.add_argument(
         "--exit-on-parent", action="store_true", dest="exit_on_parent",
         help="Exit when stdin reaches EOF — used when a parent TUI spawns this "

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -83,7 +83,7 @@ class HeadlessOptions:
     # ch04 round-4 GAP B — `--fallback-model` (TS cli/print.ts:473):
     # capacity-relief switch after repeated 529s; session-sticky.
     fallback_model: str | None = None
-    max_turns: int = 20
+    max_turns: int = 50
     # ``skip_permissions`` is a backward-compat alias for the boolean form
     # of ``--dangerously-skip-permissions``. ``permission_mode`` and
     # ``is_bypass_permissions_mode_available`` were added in round 5 to

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -72,6 +72,11 @@ PROTOCOL_VERSION = "0.1.0"
 #: not wedge a tool forever, so we default-deny after this (proposal §7).
 DEFAULT_PERMISSION_TIMEOUT_S = 300.0
 
+#: Default agent-loop turn ceiling for an interactive session. Shared by the
+#: dataclass default below and the ``--max-turns`` CLI flag (agent_server_cli.py)
+#: so the two can't drift apart from independently hand-edited literals.
+DEFAULT_MAX_TURNS = 50
+
 _SHUTDOWN = object()  # sentinel pushed onto the worker inbox to stop it
 
 
@@ -93,7 +98,7 @@ class AgentServerConfig:
     # isBypassPermissionsModeAvailable in
     # typescript/src/utils/permissions/permissionSetup.ts:941.
     is_bypass_available: bool = False
-    max_turns: int = 20
+    max_turns: int = DEFAULT_MAX_TURNS
     allowed_tools: tuple[str, ...] = ()
     disallowed_tools: tuple[str, ...] = ()
     permission_timeout_s: float = DEFAULT_PERMISSION_TIMEOUT_S

--- a/tests/server/test_bypass_permissions_wiring.py
+++ b/tests/server/test_bypass_permissions_wiring.py
@@ -243,6 +243,16 @@ class TestAgentServerCliFlags(unittest.TestCase):
         self.assertEqual(cfg.permission_mode, "default")
         self.assertFalse(cfg.is_bypass_available)
 
+    def test_no_flags_defaults_max_turns_to_shared_constant(self) -> None:
+        # Pins the --max-turns CLI default to the same DEFAULT_MAX_TURNS the
+        # AgentServerConfig dataclass field uses, so the two can't silently
+        # drift apart again (they used to be two independently hand-edited
+        # literals with nothing to catch a partial edit).
+        from src.server.agent_server import DEFAULT_MAX_TURNS
+
+        cfg = self._run([])
+        self.assertEqual(cfg.max_turns, DEFAULT_MAX_TURNS)
+
     def test_stdio_folds_in_settings_availability(self) -> None:
         # A hand-launched single-session stdio server honors the operator's
         # own user/local settings.allowBypassPermissionsMode.


### PR DESCRIPTION
## Summary

- **Raise the default `max_turns` from 20 to 50** across every entry point (`clawcodex tui` / agent-server, `clawcodex -p` / headless), so a legitimate multi-step task no longer gets cut off with "Reached maximum number of turns (20)" mid-work.
- **Hoist `DEFAULT_MAX_TURNS`** as a shared constant between `AgentServerConfig`'s dataclass default and the `--max-turns` argparse default, so the two literals can't silently drift apart again (they were previously two independently hand-edited numbers with nothing to catch a partial edit).
- **Add a regression test** pinning the CLI default to the shared constant.
- **Add `TODOS.md`** (new to this repo) logging 2 pre-existing test-failure clusters found while verifying this change, plus a P2 follow-up for a gap two independent adversarial reviews flagged (see below).

## Test Coverage

Both changed defaults are a single literal-value path each (no new branches/conditionals), already exercised end-to-end by the existing suite:

| Changed default | Location | Exercised by |
|---|---|---|
| `AgentServerConfig.max_turns` | `src/server/agent_server.py` | 316 passing tests construct `AgentServerConfig(...)` across `tests/server/`, `tests/entrypoints/`, and 10 other files |
| `--max-turns` argparse default | `src/entrypoints/agent_server_cli.py` | New regression test `TestAgentServerCliFlags::test_no_flags_defaults_max_turns_to_shared_constant` pins it to `DEFAULT_MAX_TURNS` |
| `HeadlessOptions.max_turns` + `src/cli.py` `--max-turns` | `src/entrypoints/headless.py`, `src/cli.py` | Existing `tests/test_headless_cli.py` suite |

Coverage gate: **PASS** — no new branches introduced; independently verified by a dispatched coverage-audit subagent (100% coverage, 0 gaps, recommended no additional test beyond the one added since there's no branching logic or TS-parity contract at stake).

Full suite: **7915 passed, 6 failed, 3 skipped**. All 6 failures verified pre-existing — identical failures reproduced with this branch's changes stashed against `main` — and logged in the new `TODOS.md` (P0) rather than fixed here, since they're in unrelated subsystems (an `advisor` tool default-property mismatch, and workspace-boundary enforcement in read/write e2e flows).

Targeted re-verification after every edit in this branch: 292 passed (`tests/server/`, `tests/entrypoints/`, `tests/test_headless_cli.py`, `tests/test_dangerous_skip_permissions.py`, `tests/test_headless_sigint.py`, `tests/test_permission_ask_flow.py`, `tests/test_deferred_prefetch.py`, `tests/test_query_error_recovery.py`, `tests/test_query_engine.py`, `tests/test_query_loop.py`, `tests/test_query_terminal.py`).

## Pre-Landing Review

No issues found. Diff is 2 literal-value changes plus their CLI/headless counterparts and one new test — no SQL, concurrency, LLM-trust-boundary, shell-injection, or enum-completeness surface touched.

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN
Intent: Raise the agent-server's default `max_turns` from 20 to 50 (direct request, prompted by hitting the old ceiling mid-task) and ship it.
Delivered: Exactly that, extended to the headless entrypoint per an explicit follow-up decision to keep both surfaces consistent, plus the mechanical constant-hoist + regression test that both review passes below flagged as directly relevant.

## Plan Completion

No plan file detected — skipping (this shipped directly from a chat request, not a `/spec` or plan-mode session).

## Adversarial Review (Claude subagent + Codex, always-on)

Both independently converged on the same two findings:

1. **No cost/turn ceiling backstop.** `max_turns` is currently the *only* enforced ceiling on a session's cost/time/tool side effects — `SettingsSchema.max_cost_usd` and `SettingsSchema.max_turns` are both defined and validated but never actually read/enforced anywhere in the query loop or agent-server. Raising the turn default 2.5x widens the worst case of this pre-existing, unrelated gap. Logged as a P2 follow-up in `TODOS.md` (wire up the cost ceiling + give the TUI a way to override `--max-turns` per launch, since it currently can't).
2. **Cross-entrypoint consistency** (Codex: P2; Claude: INVESTIGATE) — headless/`-p` mode's default hadn't moved. Resolved in this PR: bumped it to 50 too, for consistent behavior across both surfaces.

A third finding (Claude subagent, FIXABLE) — the CLI-parser default and dataclass default were two independently hand-maintained literals with no shared source of truth and no test pinning either — is fixed directly in this PR (`DEFAULT_MAX_TURNS` constant + regression test).

Codex's overall recommendation was to block pending the cost-ceiling gap; that gap pre-dates this change (confirmed: neither setting was ever wired up before this PR) and is out of scope for a default-value fix, so it's tracked instead of blocking this specific change.

## TODOS

`TODOS.md` created (new to this repo). 3 items logged, 0 completed (nothing pre-existing to complete against a file that didn't exist before this PR):
- P0: Advisor tool violates default `is_read_only` / `is_concurrency_safe`
- P0: Workspace-boundary blocking not enforced in write/read e2e flows
- P2: Wire up `max_cost_usd` / `settings.max_turns` enforcement + TUI `--max-turns` override

## Documentation

No updates needed. Checked `README.md` and `CONTRIBUTING.md` for stale references to the old default: README has one historical changelog line mentioning an unrelated workflow-engine max-turns fix (#272, different subsystem) and one example command (`--max-turns 10`) that passes its own explicit value regardless of the default — neither is affected by this change.

## Test plan
- [x] Full suite: 7915 passed, 6 failed (all verified pre-existing, logged in TODOS.md), 3 skipped
- [x] Targeted re-verification after every edit: 292 passed
- [x] New regression test (`test_no_flags_defaults_max_turns_to_shared_constant`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
