### PR TITLE
feat(wiki): align init_wiki with TS initializeWiki (C7 — wiki-init-fidelity)

### DIFF
--- a/src/wiki/wiki.py
+++ b/src/wiki/wiki.py
@@ -33,21 +33,42 @@ def get_wiki_paths(cwd: str | Path) -> WikiPaths:
 
 
 def _schema_template(project: str) -> str:
+    """Verbatim port of init.ts buildSchemaTemplate (C7 — wiki-init-fidelity;
+    OpenClaude→clawcodex per the wiki round's approved rename)."""
     return (
-        f"# {project} Wiki — Schema\n\n"
-        "How this wiki is organized:\n\n"
+        "# clawcodex Wiki Schema\n\n"
+        "This wiki stores durable, human-readable project knowledge for "
+        f"{project}.\n\n"
+        "## Goals\n\n"
+        "- Keep useful project knowledge in markdown, not only in chat history\n"
+        "- Prefer synthesized facts over raw copy-paste\n"
+        "- Keep source attribution explicit\n"
+        "- Make pages easy for both humans and agents to update\n\n"
+        "## Structure\n\n"
         "- `index.md`: top-level navigation and major topics\n"
         "- `log.md`: append-only update log\n"
         "- `pages/`: durable topic and architecture pages\n"
-        "- `sources/`: ingested source notes and summaries\n\n"
-        "Keep pages focused on one topic.\n"
+        "- `sources/`: source ingestion notes and summaries\n\n"
+        "## Page Rules\n\n"
+        "- Keep pages focused on one topic\n"
+        "- Use stable headings such as:\n"
+        "  - `## Summary`\n"
+        "  - `## Key Facts`\n"
+        "  - `## Relationships`\n"
+        "  - `## Open Questions`\n"
+        "  - `## Sources`\n"
+        "- Add or update facts only when they are grounded in project files "
+        "or explicit source notes\n"
+        "- Prefer editing an existing page over creating duplicates\n"
     )
 
 
 def _index_template(project: str) -> str:
-    # Matches rebuild_wiki_index's structure for a just-initialized wiki
-    # (only architecture.md present) so the first ingest's rebuild does not
-    # flip the headers user-visibly (critic MINOR-1).
+    # DELIBERATE divergence from TS buildIndexTemplate: matches
+    # rebuild_wiki_index's structure for a just-initialized wiki (only
+    # architecture.md present) so the first ingest's rebuild does not flip
+    # the headers user-visibly (SERVICES-4 critic MINOR-1 — TS itself has
+    # the init≠rebuild inconsistency; the port fixed it).
     return (
         f"# {project} Wiki\n\n"
         "This wiki is maintained by clawcodex as a durable project "
@@ -58,32 +79,79 @@ def _index_template(project: str) -> str:
     )
 
 
-def _log_template() -> str:
-    return "# Update Log\n\n- wiki initialized\n"
+def _log_template(timestamp: str) -> str:
+    """Port of init.ts buildLogTemplate — the ISO timestamp + attribution."""
+    return f"# Wiki Update Log\n\n- {timestamp}: Wiki initialized by clawcodex\n"
 
 
 def _architecture_template(project: str) -> str:
-    return f"# Architecture\n\n_Describe {project}'s architecture here._\n"
+    """Verbatim port of init.ts buildArchitectureTemplate."""
+    return (
+        "# Architecture\n\n"
+        "## Summary\n\n"
+        f"High-level architecture notes for {project}.\n\n"
+        "## Key Facts\n\n"
+        "- This page is the starting point for durable architecture knowledge.\n\n"
+        "## Relationships\n\n"
+        "- Link this page to major subsystems as the wiki grows.\n\n"
+        "## Open Questions\n\n"
+        "- What are the most important runtime subsystems?\n"
+        "- Which files best represent the system architecture?\n\n"
+        "## Sources\n\n"
+        "- Wiki bootstrap\n"
+    )
 
 
 def _ensure_file(path: Path, content: str, created: list[str]) -> None:
-    if not path.exists():
-        path.write_text(content, encoding="utf-8")
+    """Create-if-absent, atomically (the TS ``wx`` flag — open(..., "x")
+    raises FileExistsError instead of the racy exists()-then-write)."""
+    try:
+        with path.open("x", encoding="utf-8") as f:
+            f.write(content)
         created.append(str(path))
+    except FileExistsError:
+        return
+
+
+def _init_timestamp() -> str:
+    """ISO-8601 with milliseconds + Z (Date.toISOString parity — the same
+    format ingest uses)."""
+    import datetime as _dt
+
+    now = _dt.datetime.now(_dt.timezone.utc)
+    return now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now.microsecond // 1000:03d}Z"
 
 
 def init_wiki(cwd: str | Path) -> dict:
+    """Port of ``initializeWiki`` (init.ts): create-if-absent the wiki seed
+    files; ``already_existed`` = nothing was created (TS
+    ``createdFiles.length === 0``, replacing the prior index-precheck);
+    created paths are cwd-relative (TS ``relative(cwd, …)``)."""
     paths = get_wiki_paths(cwd)
-    already = paths.index_file.exists()
     created: list[str] = []
+    created_dirs: list[str] = []
     for d in (paths.root, paths.pages_dir, paths.sources_dir):
         d.mkdir(parents=True, exist_ok=True)
+        created_dirs.append(str(d))
     project = Path(cwd).name or "project"
+    timestamp = _init_timestamp()
     _ensure_file(paths.schema_file, _schema_template(project), created)
     _ensure_file(paths.index_file, _index_template(project), created)
-    _ensure_file(paths.log_file, _log_template(), created)
+    _ensure_file(paths.log_file, _log_template(timestamp), created)
     _ensure_file(paths.pages_dir / "architecture.md", _architecture_template(project), created)
-    return {"root": str(paths.root), "created_files": created, "already_existed": already}
+
+    def _rel(p: str) -> str:
+        try:
+            return str(Path(p).relative_to(Path(cwd)))
+        except ValueError:
+            return p
+
+    return {
+        "root": str(paths.root),
+        "created_files": [_rel(p) for p in created],
+        "created_directories": [_rel(d) for d in created_dirs],
+        "already_existed": len(created) == 0,
+    }
 
 
 def wiki_status(cwd: str | Path) -> dict:

--- a/tests/wiki/test_init_fidelity.py
+++ b/tests/wiki/test_init_fidelity.py
@@ -1,0 +1,75 @@
+"""Chapter C7 — wiki-init fidelity (port of initializeWiki, init.ts).
+
+SERVICES-4 follow-up: the init seed templates were a low-fidelity port.
+Pins the verbatim schema/log/architecture templates (clawcodex-branded), the
+TS already_existed semantics (createdFiles.length === 0, replacing the
+index-precheck), cwd-relative created paths + created_directories, and the
+atomic create-if-absent (the wx flag).
+"""
+from __future__ import annotations
+
+import re
+
+from src.wiki import get_wiki_paths, init_wiki
+
+
+def test_schema_template_verbatim(tmp_path):
+    init_wiki(tmp_path)
+    s = get_wiki_paths(tmp_path).schema_file.read_text()
+    assert s.startswith("# clawcodex Wiki Schema\n")
+    for h in ("## Goals", "## Structure", "## Page Rules",
+              "`## Summary`", "`## Key Facts`", "`## Relationships`",
+              "`## Open Questions`", "`## Sources`"):
+        assert h in s, h
+    assert "Prefer editing an existing page over creating duplicates" in s
+
+
+def test_log_template_timestamped(tmp_path):
+    init_wiki(tmp_path)
+    log = get_wiki_paths(tmp_path).log_file.read_text()
+    assert log.startswith("# Wiki Update Log\n")
+    assert re.search(
+        r"- \d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}Z: Wiki initialized by clawcodex\n",
+        log,
+    )
+
+
+def test_architecture_template_sections(tmp_path):
+    init_wiki(tmp_path)
+    a = (get_wiki_paths(tmp_path).pages_dir / "architecture.md").read_text()
+    for h in ("## Summary", "## Key Facts", "## Relationships",
+              "## Open Questions", "## Sources"):
+        assert h in a, h
+    assert "Wiki bootstrap" in a
+
+
+def test_already_existed_is_created_count_semantics(tmp_path):
+    r1 = init_wiki(tmp_path)
+    assert r1["already_existed"] is False and len(r1["created_files"]) == 4
+    # delete ONE seed file: the old index-precheck would say already_existed
+    # =True AND not recreate; TS semantics recreate the missing file and
+    # report already_existed=False (something was created).
+    get_wiki_paths(tmp_path).schema_file.unlink()
+    r2 = init_wiki(tmp_path)
+    assert r2["created_files"] == [".clawcodex/wiki/schema.md".replace(".", ".")] or (
+        len(r2["created_files"]) == 1 and r2["created_files"][0].endswith("schema.md")
+    )
+    assert r2["already_existed"] is False
+    r3 = init_wiki(tmp_path)
+    assert r3["already_existed"] is True and r3["created_files"] == []
+
+
+def test_created_paths_relative_and_directories_reported(tmp_path):
+    r = init_wiki(tmp_path)
+    assert all(not p.startswith("/") for p in r["created_files"])
+    assert any(p.endswith("index.md") for p in r["created_files"])
+    assert len(r["created_directories"]) == 3
+    assert all(not p.startswith("/") for p in r["created_directories"])
+
+
+def test_existing_content_never_clobbered(tmp_path):
+    init_wiki(tmp_path)
+    idx = get_wiki_paths(tmp_path).index_file
+    idx.write_text("USER EDITED")
+    init_wiki(tmp_path)
+    assert idx.read_text() == "USER EDITED"  # create-if-absent only

--- a/tests/wiki/test_init_fidelity.py
+++ b/tests/wiki/test_init_fidelity.py
@@ -51,9 +51,7 @@ def test_already_existed_is_created_count_semantics(tmp_path):
     # report already_existed=False (something was created).
     get_wiki_paths(tmp_path).schema_file.unlink()
     r2 = init_wiki(tmp_path)
-    assert r2["created_files"] == [".clawcodex/wiki/schema.md".replace(".", ".")] or (
-        len(r2["created_files"]) == 1 and r2["created_files"][0].endswith("schema.md")
-    )
+    assert len(r2["created_files"]) == 1 and r2["created_files"][0].endswith("schema.md")
     assert r2["already_existed"] is False
     r3 = init_wiki(tmp_path)
     assert r3["already_existed"] is True and r3["created_files"] == []
@@ -73,3 +71,92 @@ def test_existing_content_never_clobbered(tmp_path):
     idx.write_text("USER EDITED")
     init_wiki(tmp_path)
     assert idx.read_text() == "USER EDITED"  # create-if-absent only
+
+
+# ── Golden-string equality (nit 1): a verbatim-fidelity chapter must lock the
+# EXACT bytes — substring checks miss blank-line/indent/trailing-newline drift
+# and the one intentional index divergence. These reconstruct the TS template
+# literals (init.ts) + the OpenClaude→clawcodex rename and assert equality.
+
+_PROJECT = "proj"
+
+_SCHEMA_GOLDEN = """# clawcodex Wiki Schema
+
+This wiki stores durable, human-readable project knowledge for proj.
+
+## Goals
+
+- Keep useful project knowledge in markdown, not only in chat history
+- Prefer synthesized facts over raw copy-paste
+- Keep source attribution explicit
+- Make pages easy for both humans and agents to update
+
+## Structure
+
+- `index.md`: top-level navigation and major topics
+- `log.md`: append-only update log
+- `pages/`: durable topic and architecture pages
+- `sources/`: source ingestion notes and summaries
+
+## Page Rules
+
+- Keep pages focused on one topic
+- Use stable headings such as:
+  - `## Summary`
+  - `## Key Facts`
+  - `## Relationships`
+  - `## Open Questions`
+  - `## Sources`
+- Add or update facts only when they are grounded in project files or explicit source notes
+- Prefer editing an existing page over creating duplicates
+"""
+
+_ARCH_GOLDEN = """# Architecture
+
+## Summary
+
+High-level architecture notes for proj.
+
+## Key Facts
+
+- This page is the starting point for durable architecture knowledge.
+
+## Relationships
+
+- Link this page to major subsystems as the wiki grows.
+
+## Open Questions
+
+- What are the most important runtime subsystems?
+- Which files best represent the system architecture?
+
+## Sources
+
+- Wiki bootstrap
+"""
+
+
+def _init_in(tmp_path):
+    d = tmp_path / _PROJECT
+    d.mkdir()
+    init_wiki(d)
+    return get_wiki_paths(d)
+
+
+def test_schema_golden(tmp_path):
+    assert _init_in(tmp_path).schema_file.read_text() == _SCHEMA_GOLDEN
+
+
+def test_architecture_golden(tmp_path):
+    p = _init_in(tmp_path)
+    assert (p.pages_dir / "architecture.md").read_text() == _ARCH_GOLDEN
+
+
+def test_index_sources_divergence_pinned(tmp_path):
+    # the ONE intentional deviation from TS init (which writes
+    # "- Source notes live in [sources/](./sources/)"): the port aligns init
+    # to its own rebuildWikiIndex ("- No sources yet"). Pin it so a future
+    # "fix" toward TS fails loudly.
+    idx = _init_in(tmp_path).index_file.read_text()
+    assert "## Sources\n\n- No sources yet\n" in idx
+    assert "Source notes live in" not in idx


### PR DESCRIPTION
## Summary

Chapter **C7 — wiki-init fidelity** (deferred-owned follow-up from SERVICES-4 / PR #646). Aligns `init_wiki` with the TS reference `initializeWiki` (`typescript/src/services/wiki/init.ts`), which was ported at low fidelity.

- **Verbatim templates**: `_schema_template` (Goals / Structure / Page Rules with the stable-headings sublist) and `_architecture_template` (Summary / Key Facts / Relationships / Open Questions / Sources) are now byte-identical to the TS literals modulo the approved upstream TypeScript implementation→clawcodex rename; `_log_template` gains the ISO-ms-Z timestamp + attribution it was missing.
- **`already_existed` semantics**: now `len(created) == 0` (TS `createdFiles.length === 0`) — replacing the index-precheck, which returned an internally-inconsistent `already_existed=True` *with* `created_files=[…]` when a single seed file was missing. Recreating one deleted seed now correctly reports created + not-already.
- **Return shape**: `created_files` cwd-relative + `created_directories` added (TS `WikiInitResult`), `root` kept absolute.
- **Atomic create-if-absent**: `open("x")` (the TS `wx` flag) instead of the racy `exists()`-then-write.
- **Kept divergence**: the index template stays the port's rebuild-aligned version (`- No sources yet`) — TS init genuinely disagrees with its own `rebuildWikiIndex`; the port fixed that in #646 and this documents + pins it.

## Verification

- `tests/wiki/test_init_fidelity.py` (9): verbatim substring pins + **byte-exact golden-string equality** for schema/architecture, the index-divergence pin, timestamped log, `already_existed` count-semantics (incl. recreate-one-file), relative paths + directories, never-clobber.
- Full suite at the 6-failure baseline (7922 passed). 24 wiki tests green.
- **Critic: APPROVE** (byte-level programmatic diff confirmed schema/log/architecture identical; the index divergence verified accurate against both `init.ts` and `indexBuilder.ts`). Both non-gating nits addressed in the follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
