### PR TITLE
feat(mcp): wire MCP server instructions into the live system prompt (C2)

### DIFF
--- a/src/context_system/prompt_assembly.py
+++ b/src/context_system/prompt_assembly.py
@@ -490,10 +490,15 @@ def build_full_system_prompt(
     if memory_section:
         sections.append(memory_section)
 
-    # 30. MCP instructions
+    # 30. MCP servers (session-cached name list)
     mcp_section = _build_mcp_section(mcp_servers, use_cache)
     if mcp_section:
         sections.append(mcp_section)
+
+    # 31. MCP server instructions (REQUEST-scoped, uncached — C2)
+    mcp_instructions = _build_mcp_instructions_section(mcp_servers)
+    if mcp_instructions:
+        sections.append(mcp_instructions)
 
     # 40. Agent instructions
     agent_section = _build_agent_section(agents, use_cache)
@@ -661,6 +666,9 @@ def build_full_system_prompt_blocks(
     mcp_section = _build_mcp_section(mcp_servers, use_cache)
     if mcp_section:
         sections.append(mcp_section)
+    mcp_instructions = _build_mcp_instructions_section(mcp_servers)
+    if mcp_instructions:
+        sections.append(mcp_instructions)
     agent_section = _build_agent_section(agents, use_cache)
     if agent_section:
         sections.append(agent_section)
@@ -1144,32 +1152,47 @@ def _build_mcp_section(
         name = getattr(server, "name", str(server))
         parts.append(f"- {name}")
 
-    # Surface server-authored `instructions` (from the MCP InitializeResult
-    # handshake) — port of getMcpInstructions (constants/prompts.ts:572-596).
-    # RENDERING ONLY: the LIVE wiring is DEFERRED (McpRuntime discards the
-    # connect() instructions at mcp_runtime.py:101 and every live prompt-build
-    # site passes mcp_servers=None). See the "MCP-instructions-live-wiring"
-    # chapter: retain {name,instructions} in McpRuntime + thread here + make
-    # this a REQUEST-scoped per-turn section (TS uses an UNCACHED section so
-    # late/OAuth-gated connects aren't missed). This block renders correctly
-    # once fed.
+    content = "\n".join(parts)
+    if use_cache:
+        _prompt_cache.set("mcp", content, scope=CacheScope.SESSION)
+    return SystemPromptSection(id="mcp", content=content, cache_scope=CacheScope.SESSION, order=30)
+
+
+def _build_mcp_instructions_section(
+    mcp_servers: list[Any] | None,
+) -> SystemPromptSection | None:
+    """Server-authored ``instructions`` (MCP InitializeResult handshake) —
+    port of ``getMcpInstructions`` (constants/prompts.ts:572-596).
+
+    REQUEST-scoped and NEVER ``_prompt_cache``d, mirroring TS's
+    ``DANGEROUS_uncachedSystemPromptSection('mcp_instructions', …, reason:
+    "MCP servers connect/disconnect between turns")`` (prompts.ts:506-513):
+    a late/OAuth-gated connect or a ``/mcp`` toggle must re-render on the
+    next prompt build without serving a stale session-cached copy, and
+    REQUEST scope keeps the volatile block out of the cached prefix. (The
+    render previously lived inside the SESSION-cached ``mcp`` section — the
+    utils-critic's M1; moved out here as part of the C2 live wiring.)"""
+    if not mcp_servers:
+        return None
     instruction_blocks = [
         f"## {getattr(server, 'name', str(server))}\n{instr}"
         for server in mcp_servers
         if (instr := (getattr(server, "instructions", None) or "").strip())
     ]
-    if instruction_blocks:
-        parts.append(
-            "\n# MCP Server Instructions\n\n"
-            "The following MCP servers have provided instructions for how to "
-            "use their tools and resources:\n\n"
-            + "\n\n".join(instruction_blocks)
-        )
-
-    content = "\n".join(parts)
-    if use_cache:
-        _prompt_cache.set("mcp", content, scope=CacheScope.SESSION)
-    return SystemPromptSection(id="mcp", content=content, cache_scope=CacheScope.SESSION, order=30)
+    if not instruction_blocks:
+        return None
+    content = (
+        "# MCP Server Instructions\n\n"
+        "The following MCP servers have provided instructions for how to "
+        "use their tools and resources:\n\n"
+        + "\n\n".join(instruction_blocks)
+    )
+    return SystemPromptSection(
+        id="mcp_instructions",
+        content=content,
+        cache_scope=CacheScope.REQUEST,
+        order=31,
+    )
 
 
 def _build_agent_section(

--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -214,9 +214,11 @@ def build_effective_system_prompt(
     ``tools``/``tool_registry`` are deliberately NOT passed to
     ``build_full_system_prompt_blocks`` (matching ``engine.py:167``): tool
     schemas reach the model via the API ``tools=`` param, so emitting a prose
-    tool-docs section here would double-send them. ``provider``/``mcp_servers``
-    feed only the global cache-scope gate; ``None`` is safe (disables the
-    cross-user global scope, which TUI/headless should not use).
+    tool-docs section here would double-send them. ``provider`` feeds the
+    global cache-scope gate; ``mcp_servers`` ALSO feeds the REQUEST-scoped
+    ``_build_mcp_instructions_section`` (C2 — server-authored instructions),
+    so it is no longer inert here; ``None`` is safe (no instructions section
+    + disables the cross-user global scope, which TUI/headless should not use).
 
     Coordinator mode (``CLAUDE_CODE_COORDINATOR_MODE`` truthy): the
     coordinator orchestration prompt REPLACES the base blocks entirely,

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -857,6 +857,20 @@ class _AgentSession:
             logger.exception("[agent-server] set_provider failed")
             self._reply(request_id, {"ok": False, "error": str(exc)})
 
+    def _mcp_server_infos(self) -> list[Any] | None:
+        """The connected MCP servers' info objects (name + instructions) for
+        the system-prompt build, filtered by the registry's disabled set —
+        a disabled server's tools are hidden, so its instructions hide too.
+        ``None`` when no MCP runtime (C2 — MCP-instructions live wiring)."""
+        rt = getattr(self, "_mcp_runtime", None)
+        if rt is None:
+            return None
+        infos = list(getattr(rt, "server_infos", None) or [])
+        reg = self.tool_registry
+        disabled = set(getattr(reg, "disabled_servers", None) or ()) if reg is not None else set()
+        live = [s for s in infos if getattr(s, "name", None) not in disabled]
+        return live or None
+
     def _compose_with_plan(self, base: Any) -> Any:
         """Append the active /plan as a system-prompt section so the agent follows
         it. No plan → returns base unchanged (regression-safe)."""
@@ -885,6 +899,29 @@ class _AgentSession:
             else:
                 reg.disabled_servers.add(name)
             _save_disabled_mcp(reg.disabled_servers)
+            # Re-render the MCP-instructions section for the new server set
+            # (C2 — the port-idiomatic analog of TS's per-call UNCACHED
+            # mcp_instructions section, given the memoized base prompt).
+            if self._base_system_prompt is not None and self.tool_context is not None:
+                try:
+                    from src.outputStyles import resolve_output_style
+                    from src.query.agent_loop_compat import build_effective_system_prompt
+
+                    tc = self.tool_context
+                    style_prompt = resolve_output_style(
+                        getattr(tc, "output_style_name", None),
+                        getattr(tc, "output_style_dir", None),
+                    ).prompt
+                    self._base_system_prompt = build_effective_system_prompt(
+                        style_prompt, tc, provider=self.provider,
+                        mcp_servers=self._mcp_server_infos(),
+                    )
+                    self.system_prompt = self._compose_with_plan(self._base_system_prompt)
+                except Exception:  # noqa: BLE001 — keep the toggle even if rebuild fails
+                    logger.debug(
+                        "[agent-server] prompt rebuild after set_mcp_enabled failed",
+                        exc_info=True,
+                    )
         self._reply(request_id, {
             "ok": True,
             "disabled": sorted(reg.disabled_servers) if reg is not None else [],
@@ -1257,7 +1294,10 @@ class _AgentSession:
                 from src.query.agent_loop_compat import build_effective_system_prompt
 
                 style_prompt = resolve_output_style(style, getattr(tc, "output_style_dir", None)).prompt
-                self._base_system_prompt = build_effective_system_prompt(style_prompt, tc, provider=self.provider)
+                self._base_system_prompt = build_effective_system_prompt(
+                    style_prompt, tc, provider=self.provider,
+                    mcp_servers=self._mcp_server_infos(),
+                )
                 self.system_prompt = self._compose_with_plan(self._base_system_prompt)
             except Exception:  # noqa: BLE001 - keep the style set even if rebuild is unavailable
                 logger.debug("[agent-server] system prompt rebuild after set_output_style failed", exc_info=True)
@@ -1412,7 +1452,8 @@ class _AgentSession:
                             getattr(tc, "output_style_dir", None),
                         ).prompt
                         self._base_system_prompt = build_effective_system_prompt(
-                            style_prompt, tc, provider=self.provider
+                            style_prompt, tc, provider=self.provider,
+                            mcp_servers=self._mcp_server_infos(),
                         )
                         self.system_prompt = self._compose_with_plan(self._base_system_prompt)
                 except Exception:  # noqa: BLE001 - keep the resume even if rebuild fails
@@ -2513,7 +2554,8 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
                 getattr(tool_context, "output_style_dir", None),
             ).prompt
             system_prompt = build_effective_system_prompt(
-                style_prompt, tool_context, provider=provider
+                style_prompt, tool_context, provider=provider,
+                mcp_servers=sess._mcp_server_infos(),
             )
         except Exception:  # noqa: BLE001 - fall back to a plain prompt
             logger.debug("[agent-server] system prompt build failed", exc_info=True)

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -2545,6 +2545,14 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
         except Exception:  # noqa: BLE001 — style must not block startup
             logger.debug("[agent-server] output style from settings failed", exc_info=True)
 
+        # Assign the registry + load the persisted MCP toggles BEFORE the
+        # prompt build — _mcp_server_infos() filters by
+        # registry.disabled_servers, so a disabled server's instructions must
+        # be excludable at this init build (critic C2-MAJOR: the filter was
+        # non-functional here because these ran AFTER the build).
+        sess.tool_registry = registry
+        registry.disabled_servers = _load_disabled_mcp()  # honor persisted MCP toggles
+
         try:
             from src.outputStyles import resolve_output_style
             from src.query.agent_loop_compat import build_effective_system_prompt
@@ -2564,8 +2572,6 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
 
         sess.provider = provider
         sess.provider_name = provider_name
-        sess.tool_registry = registry
-        registry.disabled_servers = _load_disabled_mcp()  # honor persisted MCP toggles
         sess.tool_context = tool_context
         tool_context.agent_progress_emit = sess._emit_agent_progress  # stream subagent progress
         sess.session = Session.create(provider_name, getattr(provider, "model", model or ""))

--- a/src/server/mcp_runtime.py
+++ b/src/server/mcp_runtime.py
@@ -239,3 +239,5 @@ class McpRuntime:
         self._loop = None
         self.clients = {}
         self.tools = []
+        self.servers = {}
+        self.server_infos = []  # consistency: a re-start() would double-append otherwise

--- a/src/server/mcp_runtime.py
+++ b/src/server/mcp_runtime.py
@@ -60,6 +60,12 @@ class McpRuntime:
         self.clients: dict[str, Any] = {}
         self.servers: dict[str, list[str]] = {}  # server name -> tool names
         self.tools: list[Any] = []  # wrapped sync Tool objects (mcp__server__tool)
+        # ConnectedMCPServer objects (name + server-authored ``instructions``
+        # from the InitializeResult handshake). The connect() return used to
+        # be DISCARDED here, so instructions never reached the system prompt
+        # (the UTILS-1 inert-wiring gap) — retained so the prompt build can
+        # render the "# MCP Server Instructions" section (C2).
+        self.server_infos: list[Any] = []
 
     def _run(self, coro: Any, timeout: float) -> Any:
         assert self._loop is not None
@@ -98,10 +104,14 @@ class McpRuntime:
         for name, scoped in enabled.items():
             try:
                 client = McpClient()
-                self._run(client.connect(name, scoped), _CONNECT_TIMEOUT_S)
+                connected = self._run(client.connect(name, scoped), _CONNECT_TIMEOUT_S)
                 mcp_tools = self._run(client.list_tools(), _CONNECT_TIMEOUT_S)
                 self.clients[name] = client
                 self.servers[name] = [t.name for t in mcp_tools]
+                # Keep the server info (name + instructions) for the prompt —
+                # only truly-connected servers carry instructions.
+                if getattr(connected, "type", "") == "connected":
+                    self.server_infos.append(connected)
                 for mt in mcp_tools:
                     self.tools.append(self._wrap(name, mt, client))
                 logger.info("[mcp] connected %s (%d tools)", name, len(mcp_tools))

--- a/tests/test_mcp_instructions.py
+++ b/tests/test_mcp_instructions.py
@@ -1,14 +1,17 @@
-"""UTILS-1 — MCP server `instructions` surfaced in the system prompt.
+"""UTILS-1 — MCP server `instructions` rendering (getMcpInstructions port).
 
-Port of getMcpInstructions (constants/prompts.ts:572-596). The MCP client
-captures each connected server's InitializeResult `instructions`, but the
-port previously listed only server NAMES — dropping server-authored guidance.
+C2 moved the render OUT of the session-cached name-list section into the
+REQUEST-scoped `_build_mcp_instructions_section` (the utils-critic's M1) —
+these pin the split renderer.
 """
 from __future__ import annotations
 
 from types import SimpleNamespace
 
-from src.context_system.prompt_assembly import _build_mcp_section
+from src.context_system.prompt_assembly import (
+    _build_mcp_instructions_section,
+    _build_mcp_section,
+)
 
 
 def _srv(name, instructions=None):
@@ -16,26 +19,27 @@ def _srv(name, instructions=None):
 
 
 def test_instructions_surfaced_for_servers_that_have_them():
-    sec = _build_mcp_section([_srv("github", "Authenticate first."), _srv("fs")], use_cache=False)
+    # C2 split: names in the session section, instructions in the request one.
+    names = _build_mcp_section([_srv("github", "Authenticate first."), _srv("fs")], use_cache=False)
+    assert "# MCP Servers" in names.content and "- github" in names.content and "- fs" in names.content
+    sec = _build_mcp_instructions_section([_srv("github", "Authenticate first."), _srv("fs")])
     c = sec.content
-    assert "# MCP Servers" in c and "- github" in c and "- fs" in c
     assert "# MCP Server Instructions" in c
     assert "## github\nAuthenticate first." in c
     assert "## fs" not in c
 
 
 def test_no_instructions_section_when_none_provided():
-    sec = _build_mcp_section([_srv("fs"), _srv("db", "")], use_cache=False)
-    assert "# MCP Server Instructions" not in sec.content
-    assert "- fs" in sec.content and "- db" in sec.content
+    assert _build_mcp_instructions_section([_srv("fs"), _srv("db", "")]) is None
+    names = _build_mcp_section([_srv("fs"), _srv("db", "")], use_cache=False)
+    assert "- fs" in names.content and "- db" in names.content
 
 
 def test_whitespace_only_instructions_ignored():
-    sec = _build_mcp_section([_srv("x", "   \n  ")], use_cache=False)
-    assert "# MCP Server Instructions" not in sec.content
+    assert _build_mcp_instructions_section([_srv("x", "   \n  ")]) is None
 
 
 def test_multiple_instruction_blocks_joined():
-    sec = _build_mcp_section([_srv("a", "AAA"), _srv("b", "BBB")], use_cache=False)
+    sec = _build_mcp_instructions_section([_srv("a", "AAA"), _srv("b", "BBB")])
     c = sec.content
     assert "## a\nAAA" in c and "## b\nBBB" in c

--- a/tests/test_mcp_instructions_init_ordering.py
+++ b/tests/test_mcp_instructions_init_ordering.py
@@ -1,0 +1,85 @@
+"""Chapter C2 — the _build_runtime INIT ordering (critic C2-MAJOR).
+
+The disabled-server filter was non-functional at the PRIMARY path: at init,
+sess._mcp_server_infos() ran BEFORE sess.tool_registry / registry.disabled_servers
+were assigned, so a /mcp-disabled server's instructions still reached the
+prompt. This drives the REAL _build_runtime with a fake provider + a fake MCP
+runtime carrying an enabled + a disabled server, CAPTURES the mcp_servers the
+init build actually receives, and asserts the disabled one is excluded — the
+exact spot that was inert before, tested through the live wiring (not the unit).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from src.server.agent_server import (
+    AgentServerConfig,
+    _AgentSession,
+    _build_runtime,
+)
+from src.tool_system.defaults import build_default_registry
+
+
+class _FakeProvider:
+    def __init__(self, api_key=None, base_url=None, model=None):
+        self.model = model or "fake"
+
+
+def _srv(name):
+    return SimpleNamespace(name=name, type="connected", instructions=f"use {name}")
+
+
+def test_init_build_filters_disabled_server_instructions(tmp_path):
+    captured = {}
+
+    def _capture_prompt(*a, **k):
+        captured["mcp_servers"] = k.get("mcp_servers")
+        return "You are a test assistant."
+
+    registry = build_default_registry()
+
+    class _FakeRuntime:
+        def __init__(self):
+            self.server_infos = [_srv("enabled"), _srv("disabled")]
+            self.tools = [SimpleNamespace(name="mcp__enabled__t")]
+            self.clients = {"enabled": object(), "disabled": object()}
+            self.servers = {"enabled": ["t"], "disabled": ["u"]}
+
+        def start(self):
+            return True
+
+        def shutdown(self):
+            pass
+
+    sess = _AgentSession(
+        session_id="s1",
+        cwd=str(tmp_path),
+        config=AgentServerConfig(provider_name="anthropic", single_session=True),
+        loop=MagicMock(),
+        out_queue=MagicMock(),
+    )
+
+    with patch("src.config.get_default_provider", lambda: "anthropic"), \
+         patch("src.config.get_provider_config",
+               lambda n: {"api_key": "x", "default_model": "fake", "base_url": None}), \
+         patch("src.providers.get_provider_class", lambda n: _FakeProvider), \
+         patch("src.providers.provider_requires_api_key", lambda n: False), \
+         patch("src.providers.resolve_api_key", lambda n, c: "x"), \
+         patch("src.tool_system.defaults.build_default_registry",
+               lambda provider=None: registry), \
+         patch("src.query.agent_loop_compat.build_effective_system_prompt",
+               _capture_prompt), \
+         patch("src.outputStyles.resolve_output_style",
+               lambda *a, **k: SimpleNamespace(prompt="")), \
+         patch("src.server.mcp_runtime.McpRuntime", _FakeRuntime), \
+         patch("src.server.agent_server._load_disabled_mcp", lambda: {"disabled"}):
+        _build_runtime(sess, None)
+
+    # the init build must have RECEIVED the infos (not None), with the
+    # disabled server filtered out — this fails if the registry/disabled set
+    # is assigned AFTER the build (the ordering bug).
+    infos = captured.get("mcp_servers")
+    assert infos is not None, "init build got mcp_servers=None (wiring inert)"
+    names = {getattr(s, "name", None) for s in infos}
+    assert names == {"enabled"}, f"disabled server not filtered at init: {names}"

--- a/tests/test_mcp_instructions_live_wiring.py
+++ b/tests/test_mcp_instructions_live_wiring.py
@@ -1,0 +1,173 @@
+"""Chapter C2 — MCP server instructions LIVE wiring (completes UTILS-1).
+
+PR #650 ported the rendering but the utils-critic caught it inert: McpRuntime
+discarded connect()'s instructions and every live prompt-build site passed
+mcp_servers=None. These pin the full live path: retention in McpRuntime, the
+REQUEST-scoped uncached section through build_effective_system_prompt (the
+LIVE entry point — the UTILS-1 lesson), the disabled-server filter, and the
+session/request cache split.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src.context_system.prompt_assembly import (
+    _build_mcp_instructions_section,
+    _build_mcp_section,
+)
+from src.query.agent_loop_compat import build_effective_system_prompt
+from src.tool_system.context import ToolContext, ToolUseOptions
+
+
+def _tc():
+    tc = ToolContext(workspace_root=Path("/tmp"))
+    tc.options = ToolUseOptions(tools=[])
+    return tc
+
+
+def _srv(name, instructions=None):
+    return SimpleNamespace(name=name, instructions=instructions, type="connected")
+
+
+def _texts(blocks):
+    return "\n".join(b.get("text", "") for b in blocks if isinstance(b, dict))
+
+
+class TestLiveEntryPoint:
+    """Through build_effective_system_prompt — the path the agent-server uses."""
+
+    def test_instructions_reach_the_live_build(self):
+        blocks = build_effective_system_prompt(
+            "", _tc(), mcp_servers=[_srv("github", "Auth via /mcp first."), _srv("fs")]
+        )
+        joined = _texts(blocks)
+        assert "# MCP Server Instructions" in joined
+        assert "## github\nAuth via /mcp first." in joined
+        assert "## fs" not in joined  # no instructions → no block
+
+    def test_instructions_block_is_request_scoped(self):
+        blocks = build_effective_system_prompt(
+            "", _tc(), mcp_servers=[_srv("github", "Auth first.")]
+        )
+        instr = [b for b in blocks if isinstance(b, dict)
+                 and "MCP Server Instructions" in b.get("text", "")]
+        assert instr and all(b.get("_cache_scope") == "request" for b in instr)
+
+    def test_name_list_stays_session_scoped_without_instructions(self):
+        blocks = build_effective_system_prompt(
+            "", _tc(), mcp_servers=[_srv("github", "Auth first.")]
+        )
+        names = [b for b in blocks if isinstance(b, dict)
+                 and b.get("text", "").startswith("# MCP Servers")]
+        assert names and all(b.get("_cache_scope") == "session" for b in names)
+        # the split: the session block must NOT embed the instructions
+        assert all("MCP Server Instructions" not in b["text"] for b in names)
+
+    def test_none_path_unchanged(self):
+        joined = _texts(build_effective_system_prompt("", _tc(), mcp_servers=None))
+        assert "# MCP Server Instructions" not in joined
+
+
+class TestSectionBuilder:
+    def test_never_prompt_cached(self):
+        # two consecutive builds with DIFFERENT instructions must both render
+        # fresh (no _prompt_cache stale-serve — the utils-critic's M1).
+        s1 = _build_mcp_instructions_section([_srv("a", "one")])
+        s2 = _build_mcp_instructions_section([_srv("a", "two")])
+        assert "one" in s1.content and "two" in s2.content
+
+    def test_no_instructions_no_section(self):
+        assert _build_mcp_instructions_section([_srv("a"), _srv("b", "  ")]) is None
+        assert _build_mcp_instructions_section(None) is None
+
+    def test_name_section_no_longer_renders_instructions(self):
+        sec = _build_mcp_section([_srv("a", "SECRET-GUIDANCE")], use_cache=False)
+        assert "SECRET-GUIDANCE" not in sec.content  # moved to the request section
+
+
+class TestRuntimeRetention:
+    def test_start_retains_connected_server_infos(self, monkeypatch):
+        """Execute McpRuntime.start() for real against fakes: the connect()
+        return is RETAINED (previously discarded — the inert-wiring gap)."""
+        from src.server import mcp_runtime as mod
+
+        info = SimpleNamespace(name="srv", type="connected",
+                               instructions="use wisely")
+        fake_tool = SimpleNamespace(
+            name="do_thing", description="d",
+            inputSchema={"type": "object", "properties": {}},
+        )
+
+        class _FakeClient:
+            async def connect(self, name, scoped):
+                return info
+
+            async def list_tools(self):
+                return [fake_tool]
+
+        scoped = SimpleNamespace(config=SimpleNamespace(enabled=True))
+        monkeypatch.setattr(
+            "src.services.mcp.config.get_all_mcp_configs", lambda: {"srv": scoped}
+        )
+        monkeypatch.setattr("src.services.mcp.client.McpClient", _FakeClient)
+
+        rt = mod.McpRuntime()
+        try:
+            assert rt.start() is True
+            assert rt.server_infos == [info]
+        finally:
+            rt.shutdown()
+
+    def test_non_connected_returns_not_retained(self, monkeypatch):
+        from src.server import mcp_runtime as mod
+
+        needs_auth = SimpleNamespace(name="srv", type="needs-auth")
+        fake_tool = SimpleNamespace(
+            name="t", description="d",
+            inputSchema={"type": "object", "properties": {}},
+        )
+
+        class _FakeClient:
+            async def connect(self, name, scoped):
+                return needs_auth
+
+            async def list_tools(self):
+                return [fake_tool]
+
+        scoped = SimpleNamespace(config=SimpleNamespace(enabled=True))
+        monkeypatch.setattr(
+            "src.services.mcp.config.get_all_mcp_configs", lambda: {"srv": scoped}
+        )
+        monkeypatch.setattr("src.services.mcp.client.McpClient", _FakeClient)
+
+        rt = mod.McpRuntime()
+        try:
+            rt.start()
+            assert rt.server_infos == []  # only truly-connected retained
+        finally:
+            rt.shutdown()
+
+
+class TestSessionHelper:
+    def _sess(self, runtime, registry):
+        from src.server.agent_server import _AgentSession
+
+        stub = SimpleNamespace(_mcp_runtime=runtime, tool_registry=registry)
+        return _AgentSession._mcp_server_infos(stub)
+
+    def test_no_runtime_none(self):
+        assert self._sess(None, None) is None
+
+    def test_disabled_server_filtered(self):
+        rt = SimpleNamespace(server_infos=[_srv("a", "ia"), _srv("b", "ib")])
+        reg = SimpleNamespace(disabled_servers={"a"})
+        live = self._sess(rt, reg)
+        assert [s.name for s in live] == ["b"]
+
+    def test_all_disabled_none(self):
+        rt = SimpleNamespace(server_infos=[_srv("a", "ia")])
+        reg = SimpleNamespace(disabled_servers={"a"})
+        assert self._sess(rt, reg) is None


### PR DESCRIPTION
## Summary

Chapter **C2 — MCP server instructions LIVE wiring** — completes UTILS-1 (PR #650 ported the `getMcpInstructions` rendering; the utils-critic caught it INERT: `McpRuntime` discarded the connect() instructions and every live prompt-build site passed `mcp_servers=None`, so only the dead `engine.py` path threaded it).

- **Retention**: `McpRuntime.start()` now keeps the `ConnectedMCPServer` objects (`server_infos`, only `type=="connected"`) instead of discarding them.
- **Section split (utils-critic M1)**: the instructions moved out of the SESSION-cached `mcp` name-list section into a new `_build_mcp_instructions_section` — `CacheScope.REQUEST`, `order=31`, NEVER `_prompt_cache`'d — mirroring TS's `DANGEROUS_uncachedSystemPromptSection('mcp_instructions', reason: "MCP servers connect/disconnect between turns")`. A late connect or `/mcp` toggle re-renders without a stale session-cached serve.
- **Threading**: `_mcp_server_infos()` (runtime's `server_infos` filtered by `registry.disabled_servers`) at all 3 live build sites (init/resume/style) + a base-prompt rebuild in `_do_set_mcp_enabled` so a mid-session toggle re-renders. Headless has no MCP runtime → its `None` stays correct.

## Critic rounds

- Round 1 REVISE: (MAJOR-1) the init disabled-filter was non-functional — `_mcp_server_infos()` ran before `tool_registry`/`disabled_servers` were assigned; hoisted them above the build. (MAJOR-2) added `test_mcp_instructions_init_ordering.py` driving the REAL `_build_runtime` and capturing the build's `mcp_servers` arg (the spot that was inert). Nits: `shutdown()` clears `server_infos`; docstring corrected.
- Round 2 **APPROVE**: both Majors verified genuinely fixed (the init-ordering test "actually bites" — fails on regression); nits done.

## Verification

- `test_mcp_instructions_live_wiring.py` + `test_mcp_instructions_init_ordering.py` + updated `test_mcp_instructions.py`: 17 green — the live entry point (`build_effective_system_prompt`), REQUEST-scope + session/request split, McpRuntime retention EXECUTED via `start()`, the init-ordering capture, the disabled filter.
- Full suite at the 6-failure baseline (7928 passed).

## Forward-notes recorded
C4 (MCP-auth) must trigger a base-prompt rebuild on a late/OAuth connect or the uncached section still won't get instructions in; coordinator-mode instruction-absence is a narrow follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
