### PR TITLE
feat(hooks): honor PreToolUse hookSpecificOutput.permissionDecision (C1)

### DIFF
--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -542,11 +542,35 @@ async def _execute_command_hook(
                     result.updated_permissions = parsed.updatedPermissions
                 if parsed.interrupt:
                     result.interrupt = True
+                hso = parsed.hookSpecificOutput or {}
+                # EVENT-NAME GATE (critic C1-M1/M3): TS validates the emitted
+                # hookEventName against the RUNNING event at the TOP of the
+                # `if (json.hookSpecificOutput)` block (hooks.ts:757-765,
+                # "Hook returned incorrect event name") — BEFORE the switch
+                # that maps the envelope/permissionDecision forms — and rejects
+                # the WHOLE output on mismatch. Placed here (above the envelope
+                # block below) so it covers ALL hso extraction, not just the
+                # permissionDecision path: otherwise a hook registered under
+                # the wrong event emitting EITHER form leaks a decision into
+                # the permission grant (fail-OPEN). Port posture is warn+drop
+                # (the WI-1.4 analog of TS's throw); mirroring TS's
+                # `if (expectedHookEvent && …)`, the check is SKIPPED when the
+                # running event is absent (direct/test calls pass no
+                # ``hook_event``). Also closes m1 (additionalContext
+                # over-extraction on wrong-event forms).
+                _running_event = stdin_data.get("hook_event")
+                _hso_event = hso.get("hookEventName") if isinstance(hso, dict) else None
+                if _running_event and _hso_event and _hso_event != _running_event:
+                    logger.warning(
+                        "Hook %r hookSpecificOutput.hookEventName=%r != running "
+                        "event %r; dropping the hookSpecificOutput payload.",
+                        command, _hso_event, _running_event,
+                    )
+                    hso = {}
                 # TS wire-envelope compat (utils/hooks.ts:833-840): a hook
                 # written for the reference CLI emits
                 # ``hookSpecificOutput.decision`` — normalize onto the same
                 # fields; the flat form (above) wins on conflict.
-                hso = parsed.hookSpecificOutput or {}
                 hso_decision = hso.get("decision") if isinstance(hso, dict) else None
                 if isinstance(hso_decision, dict):
                     behavior = hso_decision.get("behavior")
@@ -569,28 +593,8 @@ async def _execute_command_hook(
                 # above, which only fills when unset). A deny's message rides
                 # hook_permission_decision_reason (the port's single-path deny
                 # convention — TS also sets a separate blockingError, which
-                # here would double-yield a denial).
-                #
-                # EVENT-NAME GATE (critic C1-M1): TS rejects the WHOLE output
-                # when the emitted hookEventName ≠ the running event
-                # (hooks.ts:757-765, "Hook returned incorrect event name") —
-                # otherwise a hook registered under PermissionRequest emitting
-                # the PreToolUse form would leak an `allow` into the permission
-                # grant (fail-OPEN). Port posture is warn+drop (the WI-1.4
-                # analog of TS's throw), and — mirroring TS's
-                # `if (expectedHookEvent && …)` — the check is SKIPPED when the
-                # running event is absent (direct/test calls pass no
-                # ``hook_event``). Gates ALL hso extraction below (also closes
-                # m1: additionalContext over-extraction on wrong-event forms).
-                _running_event = stdin_data.get("hook_event")
-                _hso_event = hso.get("hookEventName") if isinstance(hso, dict) else None
-                if _running_event and _hso_event and _hso_event != _running_event:
-                    logger.warning(
-                        "Hook %r hookSpecificOutput.hookEventName=%r != running "
-                        "event %r; dropping the hookSpecificOutput payload.",
-                        command, _hso_event, _running_event,
-                    )
-                    hso = {}
+                # here would double-yield a denial). The event-name gate above
+                # has already dropped this whole payload on a wrong-event emit.
                 if isinstance(hso, dict) and hso.get("hookEventName") == "PreToolUse":
                     pd = hso.get("permissionDecision")
                     if pd is not None:

--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -570,6 +570,27 @@ async def _execute_command_hook(
                 # hook_permission_decision_reason (the port's single-path deny
                 # convention — TS also sets a separate blockingError, which
                 # here would double-yield a denial).
+                #
+                # EVENT-NAME GATE (critic C1-M1): TS rejects the WHOLE output
+                # when the emitted hookEventName ≠ the running event
+                # (hooks.ts:757-765, "Hook returned incorrect event name") —
+                # otherwise a hook registered under PermissionRequest emitting
+                # the PreToolUse form would leak an `allow` into the permission
+                # grant (fail-OPEN). Port posture is warn+drop (the WI-1.4
+                # analog of TS's throw), and — mirroring TS's
+                # `if (expectedHookEvent && …)` — the check is SKIPPED when the
+                # running event is absent (direct/test calls pass no
+                # ``hook_event``). Gates ALL hso extraction below (also closes
+                # m1: additionalContext over-extraction on wrong-event forms).
+                _running_event = stdin_data.get("hook_event")
+                _hso_event = hso.get("hookEventName") if isinstance(hso, dict) else None
+                if _running_event and _hso_event and _hso_event != _running_event:
+                    logger.warning(
+                        "Hook %r hookSpecificOutput.hookEventName=%r != running "
+                        "event %r; dropping the hookSpecificOutput payload.",
+                        command, _hso_event, _running_event,
+                    )
+                    hso = {}
                 if isinstance(hso, dict) and hso.get("hookEventName") == "PreToolUse":
                     pd = hso.get("permissionDecision")
                     if pd is not None:

--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -561,11 +561,55 @@ async def _execute_command_hook(
                         result.updated_permissions = hso_decision["updatedPermissions"]
                     if hso_decision.get("interrupt"):
                         result.interrupt = True
+                # PreToolUse structured form (types/hooks.ts:73-78, mapped at
+                # utils/hooks.ts:726-800): ``hookSpecificOutput.permissionDecision``
+                # is the DOCUMENTED way a PreToolUse hook allows/denies/asks.
+                # TS treats it as the MORE SPECIFIC decision — it OVERRIDES the
+                # flat ``decision`` (unlike the PermissionRequest envelope
+                # above, which only fills when unset). A deny's message rides
+                # hook_permission_decision_reason (the port's single-path deny
+                # convention — TS also sets a separate blockingError, which
+                # here would double-yield a denial).
+                if isinstance(hso, dict) and hso.get("hookEventName") == "PreToolUse":
+                    pd = hso.get("permissionDecision")
+                    if pd is not None:
+                        if pd in ("allow", "deny", "ask"):
+                            result.permission_behavior = pd
+                            if pd == "deny":
+                                result.hook_permission_decision_reason = (
+                                    hso.get("permissionDecisionReason")
+                                    or parsed.reason
+                                    or "Blocked by hook"
+                                )
+                        else:
+                            # TS throws "Unknown hook permissionDecision
+                            # type"; the port's WI-1.4 posture is warn + drop.
+                            logger.warning(
+                                "Hook %r emitted unknown permissionDecision %r;"
+                                " valid types are: allow, deny, ask. Dropping.",
+                                command, pd,
+                            )
+                    pdr = hso.get("permissionDecisionReason")
+                    if isinstance(pdr, str) and pdr:
+                        result.hook_permission_decision_reason = pdr
+                    if isinstance(hso.get("updatedInput"), dict):
+                        result.updated_input = hso["updatedInput"]
                 if parsed.preventContinuation:
                     result.prevent_continuation = True
                     result.stop_reason = parsed.stopReason
                 if parsed.additionalContexts:
                     result.additional_contexts = parsed.additionalContexts
+                # ``hookSpecificOutput.additionalContext`` (singular string —
+                # the PreToolUse/PostToolUse/UserPromptSubmit/SessionStart
+                # forms all carry it, utils/hooks.ts:793-800): APPEND onto the
+                # additional_contexts list (after the flat assignment above,
+                # so both survive) → the hook_additional_context attachment.
+                if isinstance(hso, dict):
+                    _hso_ac = hso.get("additionalContext")
+                    if isinstance(_hso_ac, str) and _hso_ac:
+                        result.additional_contexts = (
+                            list(result.additional_contexts or []) + [_hso_ac]
+                        )
                 if parsed.updatedMCPToolOutput is not None:
                     result.updated_mcp_tool_output = parsed.updatedMCPToolOutput
 

--- a/src/services/tool_execution/tool_execution.py
+++ b/src/services/tool_execution/tool_execution.py
@@ -267,6 +267,18 @@ async def _check_permissions_and_call_tool(
                 hook_permission_result = result.get("hookPermissionResult") if isinstance(result, dict) else getattr(result, "hook_permission_result", None)
             elif result_type == "hookUpdatedInput":
                 processed_input = result.get("updatedInput") if isinstance(result, dict) else getattr(result, "updated_input", processed_input)
+            elif result_type == "additionalContext":
+                # A PreToolUse hook's additionalContext / additionalContexts
+                # (the hook_additional_context attachment). run_pre_tool_use_hooks
+                # wraps it as {"type":"additionalContext","message":{"message":
+                # <attachment>}} (tool_hooks.py:116-128); surface it like the
+                # "message" case. Previously DROPPED (critic C1-M2).
+                _wrap = result.get("message") if isinstance(result, dict) else None
+                _msg = _wrap.get("message") if isinstance(_wrap, dict) else _wrap
+                if _msg:
+                    resulting_messages.append(
+                        _msg if isinstance(_msg, MessageUpdateLazy) else MessageUpdateLazy(message=_msg)
+                    )
             elif result_type == "preventContinuation":
                 should_prevent_continuation = True
             elif result_type == "stopReason":

--- a/tests/test_pretooluse_permission_decision.py
+++ b/tests/test_pretooluse_permission_decision.py
@@ -1,0 +1,125 @@
+"""Chapter C1 — PreToolUse ``hookSpecificOutput.permissionDecision``.
+
+A PreToolUse hook emitting the DOCUMENTED structured form
+(types/hooks.ts:73-78) parsed fine in the port but was silently ignored —
+hook_executor read only the PermissionRequest ``decision`` envelope. These
+execute REAL hook commands (echo the JSON) through ``_execute_command_hook``
+and pin the TS mapping (utils/hooks.ts:726-800): permissionDecision
+OVERRIDES the flat decision; deny's message = permissionDecisionReason ||
+reason || "Blocked by hook"; unknown value → warn + drop; hso updatedInput /
+additionalContext extracted.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import shlex
+
+import pytest
+
+from src.hooks.hook_executor import _execute_command_hook
+from src.hooks.hook_types import HookConfig, HookSource
+
+
+def _hook(payload: dict) -> HookConfig:
+    return HookConfig(
+        type="command",
+        command=f"echo {shlex.quote(json.dumps(payload))}",
+        source=HookSource.USER_SETTINGS,
+    )
+
+
+def _run(payload: dict):
+    return asyncio.run(_execute_command_hook(_hook(payload), {"tool_name": "Bash"}))
+
+
+def _pre(hso_extra: dict, **flat) -> dict:
+    return {**flat, "hookSpecificOutput": {"hookEventName": "PreToolUse", **hso_extra}}
+
+
+class TestPermissionDecision:
+    def test_deny_with_reason(self):
+        r = _run(_pre({"permissionDecision": "deny",
+                       "permissionDecisionReason": "policy says no"}))
+        assert r.permission_behavior == "deny"
+        assert r.hook_permission_decision_reason == "policy says no"
+
+    def test_allow(self):
+        r = _run(_pre({"permissionDecision": "allow"}))
+        assert r.permission_behavior == "allow"
+
+    def test_ask(self):
+        r = _run(_pre({"permissionDecision": "ask"}))
+        assert r.permission_behavior == "ask"
+
+    def test_overrides_flat_decision(self):
+        # TS: "Override with more specific permission decision if provided" —
+        # the opposite precedence of the PermissionRequest envelope.
+        r = _run(_pre({"permissionDecision": "deny",
+                       "permissionDecisionReason": "specific wins"},
+                      decision="allow"))
+        assert r.permission_behavior == "deny"
+        assert r.hook_permission_decision_reason == "specific wins"
+
+    def test_deny_reason_fallback_to_flat_reason(self):
+        # permissionDecisionReason || reason || "Blocked by hook"
+        r = _run(_pre({"permissionDecision": "deny"}, reason="flat reason"))
+        assert r.hook_permission_decision_reason == "flat reason"
+        r2 = _run(_pre({"permissionDecision": "deny"}))
+        assert r2.hook_permission_decision_reason == "Blocked by hook"
+
+    def test_unknown_value_warn_and_drop(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="src.hooks.hook_executor"):
+            r = _run(_pre({"permissionDecision": "maybe"}))
+        assert r.permission_behavior is None  # dropped, not honored
+        assert any("permissionDecision" in m for m in caplog.messages)
+
+    def test_updated_input_extracted(self):
+        r = _run(_pre({"permissionDecision": "allow",
+                       "updatedInput": {"command": "ls -la"}}))
+        assert r.updated_input == {"command": "ls -la"}
+
+    def test_reason_without_decision_still_recorded(self):
+        # TS sets hookPermissionDecisionReason from the hso field in the
+        # PreToolUse case (port: only when present/non-empty).
+        r = _run(_pre({"permissionDecisionReason": "context only"}))
+        assert r.hook_permission_decision_reason == "context only"
+        assert r.permission_behavior is None
+
+
+class TestAdditionalContext:
+    def test_pretooluse_additional_context_appended(self):
+        r = _run(_pre({"permissionDecision": "allow",
+                       "additionalContext": "heads up"}))
+        assert r.additional_contexts == ["heads up"]
+
+    def test_userpromptsubmit_form_additional_context(self):
+        r = _run({"hookSpecificOutput": {"hookEventName": "UserPromptSubmit",
+                                         "additionalContext": "from UPS"}})
+        assert r.additional_contexts == ["from UPS"]
+
+    def test_appends_after_flat_additional_contexts(self):
+        r = _run(_pre({"additionalContext": "hso one"},
+                      additionalContexts=["flat one"]))
+        assert r.additional_contexts == ["flat one", "hso one"]
+
+
+class TestUnregressed:
+    def test_flat_decision_still_works(self):
+        r = _run({"decision": "deny", "reason": "flat"})
+        assert r.permission_behavior == "deny"
+        assert r.hook_permission_decision_reason == "flat"
+
+    def test_permissionrequest_envelope_still_fill_only(self):
+        # the PermissionRequest dict envelope only fills when the flat form
+        # is unset (unchanged behavior)
+        r = _run({
+            "decision": "allow",
+            "hookSpecificOutput": {
+                "hookEventName": "PermissionRequest",
+                "decision": {"behavior": "deny", "message": "no"},
+            },
+        })
+        assert r.permission_behavior == "allow"  # flat wins for the envelope

--- a/tests/test_pretooluse_permission_decision.py
+++ b/tests/test_pretooluse_permission_decision.py
@@ -159,6 +159,26 @@ class TestEventNameGate:
         r = self._run_on_event(_pre({"permissionDecision": "deny"}), "PreToolUse")
         assert r.permission_behavior == "deny"
 
+    def test_wrong_event_envelope_decision_dropped(self):
+        # M3: the SYMMETRIC leak — the PermissionRequest ENVELOPE form
+        # ({"decision":{"behavior":...}}) on the wrong running event must ALSO
+        # be dropped by the gate (it sits above the envelope block now).
+        r = self._run_on_event(
+            {"hookSpecificOutput": {"hookEventName": "PermissionRequest",
+                                    "decision": {"behavior": "allow"}}},
+            "PreToolUse",
+        )
+        assert r.permission_behavior is None  # NOT granted via the envelope form
+
+    def test_matching_event_envelope_still_works(self):
+        # the envelope on its MATCHING event is unaffected by the gate
+        r = self._run_on_event(
+            {"hookSpecificOutput": {"hookEventName": "PermissionRequest",
+                                    "decision": {"behavior": "deny", "message": "no"}}},
+            "PermissionRequest",
+        )
+        assert r.permission_behavior == "deny"
+
     def test_no_running_event_skips_gate(self):
         # direct/test calls pass no hook_event → gate skipped (TS's
         # `if (expectedHookEvent && …)`); the unit tests above rely on this

--- a/tests/test_pretooluse_permission_decision.py
+++ b/tests/test_pretooluse_permission_decision.py
@@ -123,3 +123,95 @@ class TestUnregressed:
             },
         })
         assert r.permission_behavior == "allow"  # flat wins for the envelope
+
+
+class TestEventNameGate:
+    """critic C1-M1: the emitted hookSpecificOutput.hookEventName must match
+    the RUNNING event, else the payload is dropped (TS throws + rejects,
+    hooks.ts:757-765). Otherwise a PermissionRequest hook emitting the
+    PreToolUse form would leak an `allow` into the grant — fail-open."""
+
+    def _run_on_event(self, payload: dict, event: str):
+        import asyncio
+        from src.hooks.hook_executor import _execute_command_hook
+
+        return asyncio.run(_execute_command_hook(
+            _hook(payload), {"tool_name": "Bash", "hook_event": event}
+        ))
+
+    def test_wrong_event_permission_decision_dropped(self):
+        # running PermissionRequest, emitting the PreToolUse allow form
+        r = self._run_on_event(
+            _pre({"permissionDecision": "allow"}), "PermissionRequest"
+        )
+        assert r.permission_behavior is None  # NOT granted (was fail-open)
+
+    def test_wrong_event_additional_context_dropped(self):
+        # m1: additionalContext over-extraction on a wrong-event form
+        r = self._run_on_event(
+            {"hookSpecificOutput": {"hookEventName": "PreToolUse",
+                                    "additionalContext": "leak"}},
+            "PostToolUse",
+        )
+        assert not r.additional_contexts
+
+    def test_matching_event_still_works(self):
+        r = self._run_on_event(_pre({"permissionDecision": "deny"}), "PreToolUse")
+        assert r.permission_behavior == "deny"
+
+    def test_no_running_event_skips_gate(self):
+        # direct/test calls pass no hook_event → gate skipped (TS's
+        # `if (expectedHookEvent && …)`); the unit tests above rely on this
+        r = _run(_pre({"permissionDecision": "allow"}))
+        assert r.permission_behavior == "allow"
+
+
+class TestPreToolAdditionalContextReachesModel:
+    """critic C1-M2: the pre-tool additionalContext must actually be YIELDED
+    as a consumable attachment (not dropped by run_pre_tool_use_hooks/the
+    tool_execution consumer)."""
+
+    def test_additional_context_yielded_by_pre_tool_hooks(self, monkeypatch):
+        # drive run_pre_tool_use_hooks with a real PreToolUse hook (via the
+        # snapshot source has_hook_for_event/execute_pre_tool_hooks read) and
+        # assert an additionalContext result carrying the attachment is
+        # produced (the yield the tool_execution consumer branch handles).
+        import asyncio
+        from pathlib import Path
+        from types import SimpleNamespace
+
+        from src.hooks.hook_types import HookConfig, HookSource
+        from src.tool_system.context import ToolContext, ToolUseOptions
+
+        cfg = HookConfig(
+            type="command",
+            command=(
+                "echo '{\"hookSpecificOutput\":{\"hookEventName\":"
+                "\"PreToolUse\",\"additionalContext\":\"ctx-for-model\"}}'"
+            ),
+            source=HookSource.USER_SETTINGS,
+            matcher="Bash",
+        )
+        monkeypatch.setattr(
+            "src.hooks.hook_executor._get_hooks_from_snapshot",
+            lambda ctx: {"PreToolUse": [cfg]},
+        )
+        # WI-0.2 trust gate skips non-policy hooks for an untrusted workspace
+        monkeypatch.setattr(
+            "src.hooks.hook_executor.should_skip_hook_due_to_trust",
+            lambda ctx: False,
+        )
+
+        ctx = ToolContext(workspace_root=Path("/tmp"))
+        ctx.options = ToolUseOptions(tools=[])
+        tool = SimpleNamespace(name="Bash", is_mcp=False)
+
+        from src.services.tool_execution.tool_hooks import run_pre_tool_use_hooks
+
+        async def go():
+            return [r async for r in run_pre_tool_use_hooks(ctx, tool, {"command": "ls"}, "tu-1")]
+
+        results = asyncio.run(go())
+        ac = [r for r in results if isinstance(r, dict) and r.get("type") == "additionalContext"]
+        assert ac, f"no additionalContext yielded: {results}"
+        assert "ctx-for-model" in str(ac[0])


### PR DESCRIPTION
## Summary

Chapter **C1 — PreToolUse `hookSpecificOutput.permissionDecision`** (deferred hooks follow-up from the types/ round). A PreToolUse hook emitting the DOCUMENTED structured form (`types/hooks.ts:73-78`):

```json
{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "…"}}
```

parsed fine (the schema's `hookSpecificOutput` is a free dict) but was **silently ignored** — the executor read only the PermissionRequest `decision` envelope. This ports the TS mapping (`utils/hooks.ts:726-800`):

- `permissionDecision` allow/deny/ask → `permission_behavior`, **OVERRIDING** the flat `decision` (the opposite precedence of the PermissionRequest envelope, which only fills when unset).
- deny message = `permissionDecisionReason || reason || "Blocked by hook"`.
- Unknown value → warn + drop (TS throws; the port's WI-1.4 posture).
- `hookSpecificOutput.updatedInput` → `updated_input`; `additionalContext` → appended to `additional_contexts`.

## Critic rounds (3)

- R1 REVISE: **M1** — the block keyed on the EMITTED `hookEventName` with no running-event guard → a hook registered under PermissionRequest emitting the PreToolUse form leaked an `allow` into the permission grant (**fail-open**). Added the event-name gate (warn+drop on mismatch, mirroring TS's throw at hooks.ts:757-765). **M2** — the pre-tool `additionalContext` was dropped by the `tool_execution.py` consumer (no branch); added it.
- R2 REVISE: **M3** — the gate sat AFTER the PermissionRequest-envelope block, leaving a symmetric fail-open (the envelope form on a wrong event still leaked). Moved the gate above the envelope block so it covers ALL hso extraction.
- R3 **APPROVE** — all findings empirically re-verified closed; 20 C1 tests + 1066 hook/tool_execution/permission tests green.

## Verification

`tests/test_pretooluse_permission_decision.py` (20): the mapping, override precedence, reason fallback, unknown warn+drop, updatedInput, additionalContext (+ reaching the model via the new consumer branch), and the event-name gate (both the permissionDecision and envelope fail-open forms, matching-event + no-running-event paths). Full suite at the 6-failure baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
