### PR TITLE
feat(tools): gate StructuredOutput out of the interactive registry (C6)

### DIFF
--- a/src/reference_data/ts_tool_names.json
+++ b/src/reference_data/ts_tool_names.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Canonical TS tool names from tools.ts getAllBaseTools, mapped to Python equivalents",
+  "_comment": "Canonical TS tool names from tools.ts getAllBaseTools, mapped to Python equivalents. NOTE: StructuredOutput/SyntheticOutputTool is a 'specialTool' EXCLUDED from getAllBaseTools (tools.ts:293-299) and is injected per-call only for schema/jsonSchema runs \u2014 so it is intentionally NOT a core base tool (C6).",
   "core_tools": {
     "Agent": {
       "python_name": "Agent",
@@ -85,9 +85,6 @@
     },
     "Status": {
       "python_name": "Status"
-    },
-    "StructuredOutput": {
-      "python_name": "StructuredOutput"
     },
     "TaskCreate": {
       "python_name": "TaskCreate"

--- a/src/tool_system/tools/__init__.py
+++ b/src/tool_system/tools/__init__.py
@@ -69,7 +69,13 @@ ALL_STATIC_TOOLS: list[Tool] = [
     SkillTool,
     SleepTool,
     StatusTool,
-    StructuredOutputTool,
+    # StructuredOutputTool is deliberately NOT registered: it is a
+    # "special" tool (TS tools.ts:293-299 specialTools excludes
+    # SyntheticOutputTool from getAllBaseTools). The genuine schema
+    # path injects a per-call VALIDATING instance
+    # (workflow/structured.py make_structured_output_tool); the static
+    # unvalidated one exposed interactively was a footgun — its output
+    # dead-ends in outbox with no consumer (tools-round critic, C6).
     TaskCreateTool,
     TaskGetTool,
     TaskListTool,

--- a/tests/coordinator/test_wiring.py
+++ b/tests/coordinator/test_wiring.py
@@ -595,7 +595,7 @@ class TestServerModePersistResume(_ServerHarness):
         self.assertTrue(inits, "init was not re-emitted after the mode flip")
         names = {t["name"] for t in inits[-1]["tools"]}
         self.assertEqual(
-            names, {"Agent", "SendMessage", "TaskStop", "StructuredOutput"}
+            names, {"Agent", "SendMessage", "TaskStop"}
         )
 
     def test_resume_without_mode_field_is_noop(self) -> None:
@@ -675,7 +675,7 @@ class TestServerMainLoopToolFilter(_ServerHarness):
         self.assertEqual(
             names,
             {
-                "Agent", "SendMessage", "TaskStop", "StructuredOutput",
+                "Agent", "SendMessage", "TaskStop",
                 "mcp__x__subscribe_pr_activity",
             },
         )
@@ -741,4 +741,6 @@ def test_headless_init_event_names_are_filtered(
     names = {
         t.name for t in coordinator_main_loop_registry(registry).list_tools()
     }
-    assert names == {"Agent", "SendMessage", "TaskStop", "StructuredOutput"}
+    # C6: StructuredOutput is no longer a static tool (TS specialTools), so the
+    # coordinator keep-if-in-allowset filter now yields the 3 real tools.
+    assert names == {"Agent", "SendMessage", "TaskStop"}

--- a/tests/test_claude_code_tool_parity.py
+++ b/tests/test_claude_code_tool_parity.py
@@ -66,7 +66,11 @@ class TestClaudeCodeToolParity(unittest.TestCase):
             "Write",
         ]
         not_yet_implemented = {"NotebookEdit", "PowerShell", "REPL", "RemoteTrigger", "SendMessage"}
-        missing = [name for name in expected if self.registry.get(name) is None and name not in not_yet_implemented]
+        # C6: StructuredOutput is a SPECIAL tool — injected per-call by the
+        # schema path (workflow/structured.py), NOT in the default registry
+        # (TS specialTools excludes SyntheticOutputTool from getAllBaseTools).
+        special_injected = {"StructuredOutput"}
+        missing = [name for name in expected if self.registry.get(name) is None and name not in not_yet_implemented and name not in special_injected]
         self.assertEqual(missing, [])
 
     def test_send_user_message_is_user_visible_fallback(self) -> None:

--- a/tests/test_structured_output_gate.py
+++ b/tests/test_structured_output_gate.py
@@ -23,14 +23,37 @@ def test_module_still_exported_for_injection():
     assert StructuredOutputTool.name == "StructuredOutput"
 
 
-def test_schema_path_injection_unaffected():
-    # the workflow schema path builds its own validating instance and
-    # registers it per-call — independent of the static registration
+def test_schema_path_injection_still_validates():
+    # the workflow schema path builds its OWN validating instance per-call,
+    # independent of the (now-removed) static registration — pin that it still
+    # validates: a good offer is accepted, a bad one is rejected with a message
+    # (not just that the tool exists).
+    from types import SimpleNamespace
+
     from src.workflow.structured import (
         StructuredOutputCollector,
         make_structured_output_tool,
     )
 
-    collector = StructuredOutputCollector(schema={"type": "object", "properties": {"x": {"type": "integer"}}, "required": ["x"]})
+    schema = {"type": "object", "properties": {"x": {"type": "integer"}}, "required": ["x"]}
+    collector = StructuredOutputCollector(schema=schema)
     tool = make_structured_output_tool(collector)
     assert tool.name == "StructuredOutput"
+
+    ctx = SimpleNamespace(outbox=[])
+    bad = tool.call({"x": "not-an-int"}, ctx)
+    assert bad.is_error or "validation" in str(bad.output).lower()  # rejected
+    good = tool.call({"x": 7}, ctx)
+    assert not getattr(good, "is_error", False)  # accepted
+    assert ctx.outbox and ctx.outbox[-1]["structured_output"] == {"x": 7}
+
+
+def test_text_workflow_agent_gets_no_structured_output():
+    # the no-collector (text) path must NOT receive StructuredOutput — matches
+    # TS (no jsonSchema ⇒ no SyntheticOutputTool). A pin so a future re-add of
+    # the static tool to the default registry is caught.
+    from src.tool_system.defaults import build_default_registry
+
+    reg = build_default_registry()
+    names = {t.name for t in reg.list_tools()}
+    assert "StructuredOutput" not in names

--- a/tests/test_structured_output_gate.py
+++ b/tests/test_structured_output_gate.py
@@ -1,0 +1,36 @@
+"""Chapter C6 — StructuredOutput interactive gate.
+
+The static, unvalidated StructuredOutput was registered always-on in
+ALL_STATIC_TOOLS — an interactive footgun (its output dead-ends in outbox
+with no consumer; TS keeps SyntheticOutputTool in specialTools, EXCLUDED
+from getAllBaseTools, injecting a schema-bound validated instance only for
+jsonSchema sessions). Pins the gate + the intact schema path.
+"""
+from __future__ import annotations
+
+from src.tool_system.defaults import build_default_registry
+from src.tool_system.tools import ALL_STATIC_TOOLS, StructuredOutputTool
+
+
+def test_not_in_default_registry():
+    # the TS specialTools analog: the model must not see an unvalidated
+    # dead-end StructuredOutput in an ordinary interactive session
+    assert "StructuredOutput" not in {t.name for t in ALL_STATIC_TOOLS}
+    assert build_default_registry().get("StructuredOutput") is None
+
+
+def test_module_still_exported_for_injection():
+    assert StructuredOutputTool.name == "StructuredOutput"
+
+
+def test_schema_path_injection_unaffected():
+    # the workflow schema path builds its own validating instance and
+    # registers it per-call — independent of the static registration
+    from src.workflow.structured import (
+        StructuredOutputCollector,
+        make_structured_output_tool,
+    )
+
+    collector = StructuredOutputCollector(schema={"type": "object", "properties": {"x": {"type": "integer"}}, "required": ["x"]})
+    tool = make_structured_output_tool(collector)
+    assert tool.name == "StructuredOutput"

--- a/tests/test_structured_output_gate.py
+++ b/tests/test_structured_output_gate.py
@@ -48,12 +48,18 @@ def test_schema_path_injection_still_validates():
     assert ctx.outbox and ctx.outbox[-1]["structured_output"] == {"x": 7}
 
 
-def test_text_workflow_agent_gets_no_structured_output():
-    # the no-collector (text) path must NOT receive StructuredOutput — matches
-    # TS (no jsonSchema ⇒ no SyntheticOutputTool). A pin so a future re-add of
-    # the static tool to the default registry is caught.
+def test_resolved_worker_tools_exclude_structured_output():
+    # A workflow TEXT agent (no collector) resolves its worker tools from the
+    # default registry and gets no StructuredOutput — matches TS (no jsonSchema
+    # ⇒ no SyntheticOutputTool). Drive the actual resolution path (not just
+    # registry contents) so a re-add that slips through resolve_agent_tools is
+    # caught.
+    from src.agent.agent_tool_utils import filter_tools_for_agent
     from src.tool_system.defaults import build_default_registry
 
-    reg = build_default_registry()
-    names = {t.name for t in reg.list_tools()}
-    assert "StructuredOutput" not in names
+    base = build_default_registry().list_tools()
+    # the worker allow-set filter over the default pool (keep-if-in-set): with
+    # StructuredOutput no longer static, it cannot appear in the resolved
+    # worker toolset for a text agent.
+    resolved = filter_tools_for_agent(tools=base, is_built_in=True)
+    assert "StructuredOutput" not in {t.name for t in resolved}


### PR DESCRIPTION
## Summary

Chapter **C6 — gate StructuredOutput out of the interactive registry**. The static, UNVALIDATED `StructuredOutput` was registered always-on in `ALL_STATIC_TOOLS` — an interactive footgun: TS keeps `SyntheticOutputTool` in `specialTools`, EXCLUDED from `getAllBaseTools` (`tools.ts:293-299`), injecting a schema-bound validated instance only for `nonInteractive+jsonSchema` sessions; the port's static one was offered to the model unconditionally while its output dead-ends in outbox with no consumer.

The gate removes it from `ALL_STATIC_TOOLS` (the `specialTools` analog). **Safe** because the genuine schema path is independent — `workflow/runner.py` filter-then-injects its own per-call VALIDATING instance regardless of the static registration; every other reference is a name-based string set (disallowed lists, permissions allow-set, coordinator/async allow-sets) that stays correct; no outbox consumer or headless `jsonSchema` path exists.

## Critic rounds

- R1 REVISE: (blocking) the commit shipped 3 red `tests/coordinator/` tests + a false green claim (I'd skipped `tests/coordinator/`). Fixed the 3 expected sets to the corrected 3-tool coordinator surface; left `_COORDINATOR_ALLOWED_TOOLS` untouched (keeping StructuredOutput is TS-faithful — a conditional-keep). Strengthened the injection test to a good+bad `offer` round-trip.
- R2 **APPROVE** (1 non-gating nit, done): renamed the text-agent pin to drive the real `filter_tools_for_agent` resolution.
- Full-suite gate then caught a 7th failure: the `ts_tool_names.json` snapshot wrongly listed StructuredOutput as a `getAllBaseTools` core tool. Removed it (TS excludes it) — back to the exact 6-failure baseline.

## Fidelity improvements (critic-verified)
The change also aligns two spots with TS: the `tool_execution.py` fallback resolver (`findToolByName(getAllBaseTools())`) now fails to resolve "StructuredOutput" identically to TS; and the coordinator normal-case tool count.

## Verification
`test_structured_output_gate.py` (5) + updated coordinator/parity tests; 84 affected tests green; full suite at the 6-failure baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
