### PR TITLE
feat(tui): persistent session-stats line under the composer (provider · model · cwd · turns · tokens · cost)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -149,6 +149,11 @@ class _AgentSession:
     # real turn (inside the async context; _build_runtime runs sync in an
     # executor with no live loop). Guarded so it fires exactly once.
     _session_start_fired: bool = False
+    # Completed user turns — the "turns: N" odometer on the client's session
+    # stats line (the deleted REPL's ``_stats_turns``, repl/core.py). Counts
+    # successful non-internal, non-btw turns; /resume seeds it from the
+    # restored conversation, /clear zeroes it, /rewind recomputes it.
+    _stats_turns: int = 0
     session: Any = None
     system_prompt: Any = "You are a helpful assistant."
     _base_system_prompt: Any = None  # system prompt before the /plan section is composed in
@@ -583,6 +588,9 @@ class _AgentSession:
             try:
                 if self.session is not None:
                     self.session.conversation.clear()
+                # Fresh conversation, fresh odometer (token/cost totals are
+                # process-wide spend and deliberately survive /clear).
+                self._stats_turns = 0
                 self._reply(request_id, {"ok": True, "count": 0})
             except Exception as exc:  # noqa: BLE001
                 self._reply(request_id, {"ok": False, "error": str(exc)})
@@ -1327,6 +1335,10 @@ class _AgentSession:
             data = json.loads(f.read_text(encoding="utf-8"))
             conv = Conversation.from_dict(data.get("conversation", {"messages": []}))
             self.session.conversation = conv
+            # Seed the turns odometer from the restored conversation so the
+            # stats line continues where the resumed session left off (its
+            # token/cost siblings restore below via restore_cost_state).
+            self._stats_turns = _count_prompt_turns(conv.messages)
             # ch03 round-4 GAP B — restore the accumulated cost counters
             # (guarded: the reader refuses a file whose session_id header
             # doesn't match). Gated single_session like every other
@@ -1469,6 +1481,8 @@ class _AgentSession:
             target = prompt_idxs[max(0, len(prompt_idxs) - n)]
             removed = len(msgs) - target
             del msgs[target:]
+            # Rewound turns leave the odometer — recount from what's left.
+            self._stats_turns = _count_prompt_turns(msgs)
             self._reply(request_id, {"ok": True, "removed": removed, "count": len(msgs)})
         except Exception as exc:  # noqa: BLE001
             logger.exception("[agent-server] rewind failed")
@@ -1845,6 +1859,7 @@ class _AgentSession:
                 self.session_id,
                 permission_mode=_current_mode(self.tool_context, self.config.permission_mode), subtype="error", num_turns=0,
                 result=self.init_error, is_error=True, error=self.init_error,
+                session_turns=self._stats_turns,
             ))
             return
 
@@ -1884,6 +1899,7 @@ class _AgentSession:
                     self.session_id,
                     permission_mode=_current_mode(self.tool_context, self.config.permission_mode), subtype="success", num_turns=0,
                     result="", is_error=False, duration_ms=0,
+                    session_turns=self._stats_turns,
                 ))
                 return
             if ups is not None and ups.prevented:
@@ -1897,6 +1913,7 @@ class _AgentSession:
                     self.session_id,
                     permission_mode=_current_mode(self.tool_context, self.config.permission_mode), subtype="success", num_turns=0,
                     result="", is_error=False, duration_ms=0,
+                    session_turns=self._stats_turns,
                 ))
                 return
             if ups is not None:
@@ -2015,6 +2032,7 @@ class _AgentSession:
                 permission_mode=_current_mode(self.tool_context, self.config.permission_mode), subtype="cancelled", num_turns=0,
                 result="", is_error=False,
                 duration_ms=int((time.monotonic() - start) * 1000),
+                session_turns=self._stats_turns,
             ))
             return
         except Exception as exc:  # noqa: BLE001 - one bad turn must not kill the session
@@ -2024,6 +2042,7 @@ class _AgentSession:
                 permission_mode=_current_mode(self.tool_context, self.config.permission_mode), subtype="error", num_turns=0,
                 result=str(exc), is_error=True, error=str(exc),
                 duration_ms=int((time.monotonic() - start) * 1000),
+                session_turns=self._stats_turns,
             ))
             return
         finally:
@@ -2043,6 +2062,11 @@ class _AgentSession:
                 _cost = compute_cost(getattr(self.provider, "model", None) or self.config.model or "", _usage)
             except Exception:  # noqa: BLE001 — cost is best-effort, never break the turn
                 _cost = 0.0
+        # One more completed user turn. Internal (notification) and btw
+        # (ephemeral, rolled-back) turns don't move the odometer — same rule
+        # as the deleted REPL, which only counted real prompt→response rounds.
+        if not internal and not btw:
+            self._stats_turns += 1
         self._emit(_result_message(
             self.session_id,
             permission_mode=_current_mode(self.tool_context, self.config.permission_mode),
@@ -2053,6 +2077,7 @@ class _AgentSession:
             usage=_usage,
             duration_ms=int((time.monotonic() - start) * 1000),
             total_cost_usd=_cost,
+            session_turns=self._stats_turns,
         ))
         self._save_session()  # persist for /resume
 
@@ -2743,6 +2768,7 @@ def _result_message(
     duration_ms: int = 0,
     total_cost_usd: float = 0.0,
     permission_mode: str | None = None,
+    session_turns: int | None = None,
 ) -> dict:
     payload: dict[str, Any] = {
         "type": "result",
@@ -2761,6 +2787,10 @@ def _result_message(
     }
     if error is not None:
         payload["error"] = error
+    # Completed-user-turn odometer for the client's session stats line
+    # (distinct from num_turns, the agent-loop iteration count of THIS query).
+    if session_turns is not None:
+        payload["session_turns"] = session_turns
     # Server-side mode flips (plan approval, "accept edits for this session")
     # emit no dedicated event — the end-of-turn result refreshes the client's
     # permission-mode badge instead (at most one turn stale, and mode changes
@@ -2829,6 +2859,26 @@ def _first_prompt_preview(msgs: list) -> str:
                     if txt:
                         return str(txt)[:80]
     return ""
+
+
+def _count_prompt_turns(msgs: list) -> int:
+    """Real user prompts in a conversation — re-seeds ``_stats_turns`` after
+    /resume and /rewind. A prompt is a user message that isn't an injected
+    reminder (``isMeta``) and carries string or text-block content (a
+    tool_result carrier is also role 'user' but has no text block)."""
+    n = 0
+    for m in msgs:
+        if getattr(m, "role", None) != "user" or getattr(m, "isMeta", False):
+            continue
+        c = getattr(m, "content", None)
+        if isinstance(c, str):
+            n += 1
+        elif isinstance(c, list) and any(
+            (b.get("type") if isinstance(b, dict) else getattr(b, "type", None)) == "text"
+            for b in c
+        ):
+            n += 1
+    return n
 
 
 def _list_saved_sessions(limit: int = 20) -> list[dict]:

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -591,7 +591,14 @@ class _AgentSession:
                 # Fresh conversation, fresh odometer (token/cost totals are
                 # process-wide spend and deliberately survive /clear).
                 self._stats_turns = 0
-                self._reply(request_id, {"ok": True, "count": 0})
+                self._reply(request_id, {
+                    "ok": True,
+                    "count": 0,
+                    # Stats-line refresh rider (same shape as the resume
+                    # reply): turns reset with the conversation, spend stays.
+                    "session_turns": 0,
+                    "cost": _cost_snapshot(),
+                })
             except Exception as exc:  # noqa: BLE001
                 self._reply(request_id, {"ok": False, "error": str(exc)})
             return
@@ -693,6 +700,10 @@ class _AgentSession:
                 # re-stamp sites.
                 "mode": mode_value,
                 "conversation": self.session.conversation.to_dict(),
+                # Turns odometer — _do_resume prefers this exact counter over
+                # recounting the conversation (which can't tell a real prompt
+                # from a persisted notification/hook-context message).
+                "turns": self._stats_turns,
             }
             # ch03 round-4 GAP B — the live persister carries the cost
             # block (schema owner: cost_restore.build_cost_block, matching
@@ -1335,10 +1346,20 @@ class _AgentSession:
             data = json.loads(f.read_text(encoding="utf-8"))
             conv = Conversation.from_dict(data.get("conversation", {"messages": []}))
             self.session.conversation = conv
-            # Seed the turns odometer from the restored conversation so the
-            # stats line continues where the resumed session left off (its
-            # token/cost siblings restore below via restore_cost_state).
-            self._stats_turns = _count_prompt_turns(conv.messages)
+            # Seed the turns odometer so the stats line continues where the
+            # resumed session left off (its token/cost siblings restore below
+            # via restore_cost_state). Prefer the exact persisted counter
+            # (_save_session stamps it every turn end); fall back to counting
+            # the restored conversation for pre-"turns" session files — an
+            # approximation: notification prompts, hook-injected context and
+            # aborted-turn prompts persist as plain user messages, so the
+            # recount can run high vs the live success-only rule.
+            saved_turns = data.get("turns")
+            self._stats_turns = (
+                saved_turns
+                if isinstance(saved_turns, int) and not isinstance(saved_turns, bool) and saved_turns >= 0
+                else _count_prompt_turns(conv.messages)
+            )
             # ch03 round-4 GAP B — restore the accumulated cost counters
             # (guarded: the reader refuses a file whose session_id header
             # doesn't match). Gated single_session like every other
@@ -1440,6 +1461,11 @@ class _AgentSession:
                 "ok": True,
                 "count": len(conv.messages),
                 "preview": data.get("preview", ""),
+                # Session-stats seed for the client's stats line — the next
+                # result message is potentially a whole turn away, so the
+                # reply carries the authoritative odometer + totals now.
+                "session_turns": self._stats_turns,
+                "cost": _cost_snapshot(),
                 **({"mode_banner": mode_banner} if mode_banner else {}),
             })
         except Exception as exc:  # noqa: BLE001
@@ -1482,6 +1508,10 @@ class _AgentSession:
             removed = len(msgs) - target
             del msgs[target:]
             # Rewound turns leave the odometer — recount from what's left.
+            # NOTE: `is_prompt` above counts isMeta text messages (rewind
+            # boundaries pre-date the odometer); _count_prompt_turns excludes
+            # them, so the recount can sit below the number of boundaries
+            # rewind saw. Fine for an odometer; don't reuse is_prompt here.
             self._stats_turns = _count_prompt_turns(msgs)
             self._reply(request_id, {"ok": True, "removed": removed, "count": len(msgs)})
         except Exception as exc:  # noqa: BLE001

--- a/tests/server/test_session_stats_turns.py
+++ b/tests/server/test_session_stats_turns.py
@@ -1,0 +1,158 @@
+"""The ``session_turns`` odometer behind the TUI's session-stats line (the
+deleted REPL's bottom toolbar, repl/core.py ``_bottom_toolbar``).
+
+Covers:
+* ``_count_prompt_turns`` — the /resume & /rewind re-seed predicate (real
+  prompts only: no meta reminders, no tool_result carrier messages).
+* ``_result_message`` — stamps ``session_turns`` only when provided.
+* ``_run_turn`` — a successful turn increments the odometer and stamps the
+  result payload; an aborted turn stamps the current value unchanged; an
+  internal (notification) turn never moves it.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from src.server.agent_server import (
+    AgentServerConfig,
+    _AgentSession,
+    _count_prompt_turns,
+    _result_message,
+)
+
+
+def _msg(role: str, content, is_meta: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(role=role, content=content, isMeta=is_meta)
+
+
+class TestCountPromptTurns(unittest.TestCase):
+    def test_counts_string_and_text_block_prompts(self) -> None:
+        msgs = [
+            _msg("user", "hello"),
+            _msg("assistant", "hi"),
+            _msg("user", [{"type": "text", "text": "second"}]),
+        ]
+        self.assertEqual(_count_prompt_turns(msgs), 2)
+
+    def test_skips_meta_tool_results_and_non_user(self) -> None:
+        msgs = [
+            _msg("user", "real prompt"),
+            _msg("user", "<system-reminder>…</system-reminder>", is_meta=True),
+            _msg("user", [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]),
+            _msg("assistant", [{"type": "text", "text": "answer"}]),
+            _msg("user", None),
+        ]
+        self.assertEqual(_count_prompt_turns(msgs), 1)
+
+    def test_multimodal_prompt_with_text_block_counts_once(self) -> None:
+        msgs = [
+            _msg("user", [
+                {"type": "image", "source": {}},
+                {"type": "text", "text": "what is this?"},
+            ]),
+        ]
+        self.assertEqual(_count_prompt_turns(msgs), 1)
+
+    def test_empty_conversation(self) -> None:
+        self.assertEqual(_count_prompt_turns([]), 0)
+
+
+class TestResultMessageRider(unittest.TestCase):
+    def test_omitted_when_none(self) -> None:
+        msg = _result_message(
+            "sid", subtype="success", num_turns=1, result="ok", is_error=False,
+        )
+        self.assertNotIn("session_turns", msg)
+
+    def test_stamped_when_given(self) -> None:
+        msg = _result_message(
+            "sid", subtype="success", num_turns=1, result="ok", is_error=False,
+            session_turns=7,
+        )
+        self.assertEqual(msg["session_turns"], 7)
+
+
+class TestRunTurnOdometer(unittest.TestCase):
+    def _session(self) -> tuple[_AgentSession, list[dict]]:
+        emitted: list[dict] = []
+        sess = _AgentSession(
+            session_id="s1", cwd="/tmp",
+            config=AgentServerConfig(single_session=True),
+            loop=MagicMock(), out_queue=MagicMock(),
+        )
+        sess._emit = lambda env: emitted.append(env)
+        sess.session = MagicMock()
+        sess.session.conversation.messages = []
+        sess._run_user_prompt_submit_hooks = lambda p: None
+        sess._fire_session_start_once = lambda: None
+        sess._build_turn_pipeline_config = lambda provider: None
+        sess._save_session = lambda: None
+        return sess, emitted
+
+    def _loop_result(self, num_turns: int = 1):
+        return SimpleNamespace(
+            response_text="done",
+            usage={"input_tokens": 5, "output_tokens": 3},
+            num_turns=num_turns,
+        )
+
+    def _run(self, sess: _AgentSession, *, result=None, error: Exception | None = None, **kwargs) -> None:
+        async def _fake_query(**_kw):
+            if error is not None:
+                raise error
+            return result if result is not None else self._loop_result()
+
+        # patch() swaps the async loop entry point for an AsyncMock; an async
+        # side_effect is awaited, so raising AbortError here surfaces exactly
+        # like a real aborted query.
+        with patch(
+            "src.query.agent_loop_compat.run_query_as_agent_loop",
+            side_effect=_fake_query,
+        ), patch(
+            "src.coordinator.mode.coordinator_main_loop_registry",
+            side_effect=lambda reg: reg,
+        ):
+            sess._run_turn("hello", **kwargs)
+
+    @staticmethod
+    def _last_result(emitted: list[dict]) -> dict:
+        results = [e for e in emitted if e.get("type") == "result"]
+        assert results, f"no result message emitted: {emitted}"
+        return results[-1]
+
+    def test_success_increments_and_stamps(self) -> None:
+        sess, emitted = self._session()
+        self._run(sess)
+        payload = self._last_result(emitted)
+        self.assertEqual(payload["subtype"], "success")
+        self.assertEqual(payload["session_turns"], 1)
+        self.assertEqual(sess._stats_turns, 1)
+
+        self._run(sess)
+        self.assertEqual(self._last_result(emitted)["session_turns"], 2)
+
+    def test_abort_stamps_without_increment(self) -> None:
+        from src.utils.abort_controller import AbortError
+
+        sess, emitted = self._session()
+        self._run(sess)  # one real turn first
+        self._run(sess, error=AbortError("interrupted"))
+        payload = self._last_result(emitted)
+        self.assertEqual(payload["subtype"], "cancelled")
+        self.assertEqual(payload["session_turns"], 1)
+        self.assertEqual(sess._stats_turns, 1)
+
+    def test_internal_turn_does_not_increment(self) -> None:
+        sess, emitted = self._session()
+        self._run(sess, internal=True)
+        payload = self._last_result(emitted)
+        self.assertEqual(payload["subtype"], "success")
+        self.assertEqual(payload["session_turns"], 0)
+        self.assertEqual(sess._stats_turns, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/server/test_session_stats_turns.py
+++ b/tests/server/test_session_stats_turns.py
@@ -2,16 +2,21 @@
 deleted REPL's bottom toolbar, repl/core.py ``_bottom_toolbar``).
 
 Covers:
-* ``_count_prompt_turns`` — the /resume & /rewind re-seed predicate (real
-  prompts only: no meta reminders, no tool_result carrier messages).
+* ``_count_prompt_turns`` — the /resume-fallback & /rewind recount predicate
+  (real prompts only: no meta reminders, no tool_result carrier messages).
 * ``_result_message`` — stamps ``session_turns`` only when provided.
 * ``_run_turn`` — a successful turn increments the odometer and stamps the
-  result payload; an aborted turn stamps the current value unchanged; an
-  internal (notification) turn never moves it.
+  result payload; an aborted turn stamps the current value unchanged;
+  internal (notification) and btw (ephemeral) turns never move it.
+* Lifecycle: ``clear`` zeroes it (reply rider included), ``_do_rewind``
+  recounts it, ``_do_resume`` seeds it (persisted counter first, recount
+  fallback for old files), ``_save_session`` persists it.
 """
 
 from __future__ import annotations
 
+import asyncio
+import json
 import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -152,6 +157,123 @@ class TestRunTurnOdometer(unittest.TestCase):
         self.assertEqual(payload["subtype"], "success")
         self.assertEqual(payload["session_turns"], 0)
         self.assertEqual(sess._stats_turns, 0)
+
+    def test_btw_turn_does_not_increment(self) -> None:
+        sess, emitted = self._session()
+        self._run(sess, btw=True)
+        payload = self._last_result(emitted)
+        self.assertEqual(payload["subtype"], "success")
+        self.assertEqual(payload["session_turns"], 0)
+        self.assertEqual(sess._stats_turns, 0)
+
+
+class TestLifecycleSync(unittest.TestCase):
+    """clear zeroes, rewind recounts, resume seeds, save persists."""
+
+    def _session(self) -> tuple[_AgentSession, list[dict]]:
+        from src.agent.conversation import Conversation
+
+        emitted: list[dict] = []
+        sess = _AgentSession(
+            session_id="s1", cwd="/tmp",
+            config=AgentServerConfig(single_session=True),
+            loop=MagicMock(), out_queue=MagicMock(),
+        )
+        sess._emit = lambda env: emitted.append(env)
+        sess.session = SimpleNamespace(conversation=Conversation())
+        return sess, emitted
+
+    @staticmethod
+    def _reply_of(emitted: list[dict]) -> dict:
+        responses = [e for e in emitted if e.get("type") == "control_response"]
+        assert responses, f"no control_response emitted: {emitted}"
+        return responses[-1]["response"]["response"]
+
+    def test_clear_zeroes_odometer_and_stamps_reply(self) -> None:
+        sess, emitted = self._session()
+        sess._stats_turns = 4
+        sess.session.conversation.add_user_message("hello")
+        asyncio.run(sess._handle_control_request({
+            "type": "control_request",
+            "request_id": "r1",
+            "request": {"subtype": "clear"},
+        }))
+        self.assertEqual(sess._stats_turns, 0)
+        self.assertEqual(sess.session.conversation.messages, [])
+        reply = self._reply_of(emitted)
+        self.assertEqual(reply["session_turns"], 0)
+        self.assertIn("cost", reply)
+
+    def test_rewind_recounts_from_remaining_messages(self) -> None:
+        sess, _ = self._session()
+        conv = sess.session.conversation
+        for i in range(3):
+            conv.add_user_message(f"prompt {i}")
+            conv.add_assistant_message(f"answer {i}")
+        sess._stats_turns = 3
+        sess._do_rewind("r1", 2)
+        self.assertEqual(sess._stats_turns, 1)
+        self.assertEqual(_count_prompt_turns(conv.messages), 1)
+
+    def _write_session_file(self, tmpdir, *, turns: int | None) -> str:
+        from src.agent.conversation import Conversation
+
+        conv = Conversation()
+        conv.add_user_message("first prompt")
+        conv.add_assistant_message("first answer")
+        conv.add_user_message("second prompt")
+        payload = {
+            "session_id": "saved1",
+            "conversation": conv.to_dict(),
+        }
+        if turns is not None:
+            payload["turns"] = turns
+        (tmpdir / "saved1.json").write_text(json.dumps(payload), encoding="utf-8")
+        return "saved1"
+
+    def test_resume_prefers_persisted_counter(self) -> None:
+        import pathlib
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            tmpdir = pathlib.Path(td)
+            sid = self._write_session_file(tmpdir, turns=7)
+            sess, emitted = self._session()
+            with patch("src.server.agent_server._sessions_dir", return_value=tmpdir):
+                sess._do_resume("r1", sid)
+            self.assertEqual(sess._stats_turns, 7)
+            reply = self._reply_of(emitted)
+            self.assertTrue(reply["ok"])
+            self.assertEqual(reply["session_turns"], 7)
+            self.assertIn("cost", reply)
+
+    def test_resume_falls_back_to_recount_for_old_files(self) -> None:
+        import pathlib
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            tmpdir = pathlib.Path(td)
+            sid = self._write_session_file(tmpdir, turns=None)
+            sess, _ = self._session()
+            with patch("src.server.agent_server._sessions_dir", return_value=tmpdir):
+                sess._do_resume("r1", sid)
+            # Two real prompts restored through the REAL Conversation/message
+            # round-trip — pins the predicate to the production message type.
+            self.assertEqual(sess._stats_turns, 2)
+
+    def test_save_session_persists_odometer(self) -> None:
+        import pathlib
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            tmpdir = pathlib.Path(td)
+            sess, _ = self._session()
+            sess.session.conversation.add_user_message("hello")
+            sess._stats_turns = 5
+            with patch("src.server.agent_server._sessions_dir", return_value=tmpdir):
+                sess._save_session()
+            data = json.loads((tmpdir / "s1.json").read_text(encoding="utf-8"))
+            self.assertEqual(data["turns"], 5)
 
 
 if __name__ == "__main__":

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -376,7 +376,9 @@ describe('createSlashHandler', () => {
     getOverlayState().confirm?.onConfirm()
 
     expect(ctx.session.newSession).toHaveBeenCalledWith('new session started', 'sprint planning')
-    expect(ctx.gateway.rpc).not.toHaveBeenCalled()
+    // The commit's server half: reset the backend conversation + turn
+    // odometer (session.create alone reattaches to the same session).
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('session.clear', {})
   })
 
   it('keeps visible scrollback when branching a TUI session', async () => {

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -99,6 +99,22 @@ describe('GatewayClient NDJSON adapter', () => {
     await expect(gw.request('session.create', {})).resolves.toMatchObject({ session_id: 's1' })
   })
 
+  it('passes the session totals rider through on result (cost + session_turns)', async () => {
+    proc.line({
+      cost: { total_cost_usd: 0.0048 },
+      result: 'done',
+      session_turns: 3,
+      subtype: 'success',
+      type: 'result'
+    })
+    await vi.waitFor(() => expect(last('message.complete')).toBeTruthy())
+    expect(last('message.complete').payload).toMatchObject({
+      cost: { total_cost_usd: 0.0048 },
+      session_turns: 3,
+      text: 'done'
+    })
+  })
+
   it('labels file tools with a workspace-relative path', async () => {
     proc.line(toolUse('t1', 'Read', { file_path: '/ws/src/foo.ts' }))
     await vi.waitFor(() => expect(last('tool.start')).toBeTruthy())

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -263,6 +263,20 @@ describe('GatewayClient NDJSON adapter', () => {
     await expect(p).resolves.toEqual({ output: 'deep-research  [running]  (run: wf_1)', type: 'exec' })
   })
 
+  it('publishes a session.stats event from the session.clear reply rider', async () => {
+    const p = gw.request('session.clear', {})
+    await replyToControl('clear', { cost: { total_cost_usd: 0.5 }, count: 0, ok: true, session_turns: 0 })
+    await expect(p).resolves.toEqual({ ok: true })
+    expect(last('session.stats').payload).toMatchObject({ cost: { total_cost_usd: 0.5 }, session_turns: 0 })
+  })
+
+  it('stays silent on a session.clear reply without the rider (old backend)', async () => {
+    const p = gw.request('session.clear', {})
+    await replyToControl('clear', { count: 0, ok: true })
+    await expect(p).resolves.toEqual({ ok: true })
+    expect(last('session.stats')).toBeUndefined()
+  })
+
   it('confirms the applied mode from the server reply on /mode', async () => {
     const p = gw.request('slash.exec', { command: 'mode acceptEdits' })
     await replyToControl('set_permission_mode', { mode: 'acceptEdits', ok: true })

--- a/ui-tui/src/__tests__/sessionStats.test.ts
+++ b/ui-tui/src/__tests__/sessionStats.test.ts
@@ -94,6 +94,19 @@ describe('buildSessionStatsLine', () => {
     expect(build(90)).toBe('deepseek · deepseek-v4-flash · turns: 1 · tokens: 33189 in / 622 out · cost $0.0048')
   })
 
+  it('tilde-abbreviates only at a path boundary (/Users/testuser is not under /Users/test)', () => {
+    const under = `/Users/test/${'a'.repeat(30)}`
+    const sibling = `/Users/testuser/${'a'.repeat(26)}`
+
+    // Same length (42): the under-home cwd shrinks to ~/… and fits; the
+    // sibling must NOT become ~user/… — it falls through to the … tail.
+    expect(build(120, { cwd: under })).toContain(` · ~/${'a'.repeat(30)} · `)
+
+    const shed = build(120, { cwd: sibling })
+    expect(shed).not.toContain('~user')
+    expect(shed).toContain(' · …')
+  })
+
   it('omits empty segments instead of doubling separators', () => {
     expect(build(200, { cwd: '', provider: '' })).toBe(
       'deepseek-v4-flash · turns: 1 · tokens: 33189 in / 622 out · cost $0.0048'
@@ -170,6 +183,21 @@ describe('message.complete → ui.sessionStats', () => {
     onEvent({ payload: { text: 'plain' }, type: 'message.complete' } as any)
 
     expect(getUiState().sessionStats).toBe(before)
+  })
+
+  it('folds an out-of-band session.stats event (/clear and /resume reply riders)', () => {
+    const onEvent = createGatewayEventHandler(buildCtx())
+
+    onEvent({ payload: { cost: SNAPSHOT, session_turns: 5, text: 'a' }, type: 'message.complete' } as any)
+    // /clear rider: odometer resets, spend totals persist.
+    onEvent({ payload: { cost: SNAPSHOT, session_turns: 0 }, type: 'session.stats' } as any)
+
+    expect(getUiState().sessionStats).toEqual({
+      costUsd: 0.0048,
+      inputTokens: 33189,
+      outputTokens: 622,
+      turns: 0
+    })
   })
 })
 

--- a/ui-tui/src/__tests__/sessionStats.test.ts
+++ b/ui-tui/src/__tests__/sessionStats.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Session-stats line under the composer — the deleted REPL's bottom toolbar:
+ * `provider · model · cwd · turns: N · tokens: X in / Y out · cost $C`.
+ *
+ * Covers the CostSnapshot fold, the width-aware line builder, the
+ * message.complete → ui.sessionStats patch, and the component render gate.
+ */
+import { PassThrough } from 'node:stream'
+
+import { renderSync } from '@clawcodex/ink'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
+import { resetOverlayState } from '../app/overlayStore.js'
+import { turnController } from '../app/turnController.js'
+import { resetTurnState } from '../app/turnStore.js'
+import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
+import { SessionStatsLine } from '../components/sessionStatsLine.js'
+import type { CostSnapshot } from '../gatewayTypes.js'
+import { buildSessionStatsLine, statsFromCostSnapshot, ZERO_SESSION_STATS } from '../lib/sessionStats.js'
+import { stripAnsi } from '../lib/text.js'
+import type { Msg } from '../types.js'
+
+const SNAPSHOT: CostSnapshot = {
+  model_usage: {
+    'deepseek-chat': {
+      cache_creation_input_tokens: 100,
+      cache_read_input_tokens: 2000,
+      cost_usd: 0.004,
+      input_tokens: 31089,
+      output_tokens: 600
+    },
+    'deepseek-reasoner': { cost_usd: 0.0008, input_tokens: 0, output_tokens: 22 }
+  },
+  total_cost_usd: 0.0048
+}
+
+describe('statsFromCostSnapshot', () => {
+  it('folds per-model accumulators, counting cache reads/writes as input', () => {
+    expect(statsFromCostSnapshot(SNAPSHOT, 3)).toEqual({
+      costUsd: 0.0048,
+      inputTokens: 33189,
+      outputTokens: 622,
+      turns: 3
+    })
+  })
+
+  it('degrades an empty snapshot to zeros', () => {
+    expect(statsFromCostSnapshot({}, 1)).toEqual({ ...ZERO_SESSION_STATS, turns: 1 })
+  })
+})
+
+describe('buildSessionStatsLine', () => {
+  const HOME = process.env.HOME
+
+  beforeEach(() => {
+    process.env.HOME = '/Users/test'
+  })
+
+  afterEach(() => {
+    if (HOME === undefined) {delete process.env.HOME}
+    else {process.env.HOME = HOME}
+  })
+
+  const stats = { costUsd: 0.0048, inputTokens: 33189, outputTokens: 622, turns: 1 }
+
+  const build = (cols: number, overrides: Partial<Parameters<typeof buildSessionStatsLine>[0]> = {}) =>
+    buildSessionStatsLine({
+      cols,
+      cwd: '/Users/test/workspace/clawcodex',
+      model: 'deepseek-v4-flash',
+      provider: 'deepseek',
+      stats,
+      ...overrides
+    })
+
+  it('renders the full toolbar line when it fits (REPL toolbar parity)', () => {
+    expect(build(200)).toBe(
+      'deepseek · deepseek-v4-flash · /Users/test/workspace/clawcodex · ' +
+        'turns: 1 · tokens: 33189 in / 622 out · cost $0.0048'
+    )
+  })
+
+  it('hides the cost segment while nothing has been spent', () => {
+    expect(build(200, { stats: { ...stats, costUsd: 0 } })).toBe(
+      'deepseek · deepseek-v4-flash · /Users/test/workspace/clawcodex · turns: 1 · tokens: 33189 in / 622 out'
+    )
+  })
+
+  it('sheds cwd detail as the terminal narrows: ~ first, then a tail, then nothing', () => {
+    expect(build(110)).toContain(' · ~/workspace/clawcodex · ')
+    expect(build(100)).toContain(' · …e/clawcodex · ')
+    expect(build(90)).toBe('deepseek · deepseek-v4-flash · turns: 1 · tokens: 33189 in / 622 out · cost $0.0048')
+  })
+
+  it('omits empty segments instead of doubling separators', () => {
+    expect(build(200, { cwd: '', provider: '' })).toBe(
+      'deepseek-v4-flash · turns: 1 · tokens: 33189 in / 622 out · cost $0.0048'
+    )
+  })
+})
+
+describe('message.complete → ui.sessionStats', () => {
+  const buildCtx = () =>
+    ({
+      composer: {
+        dequeue: () => undefined,
+        queueEditRef: { current: null },
+        sendQueued: vi.fn(),
+        setInput: vi.fn()
+      },
+      gateway: { gw: { request: vi.fn() }, rpc: vi.fn(async () => null) },
+      session: {
+        STARTUP_RESUME_ID: '',
+        colsRef: { current: 80 },
+        newSession: vi.fn(),
+        resetSession: vi.fn(),
+        resumeById: vi.fn(),
+        setCatalog: vi.fn()
+      },
+      submission: { submitRef: { current: vi.fn() } },
+      system: { bellOnComplete: false, sys: vi.fn() },
+      transcript: {
+        appendMessage: (_msg: Msg) => undefined,
+        panel: vi.fn(),
+        setHistoryItems: vi.fn()
+      },
+      voice: { setProcessing: vi.fn(), setRecording: vi.fn(), setVoiceEnabled: vi.fn() }
+    }) as any
+
+  beforeEach(() => {
+    resetOverlayState()
+    resetUiState()
+    resetTurnState()
+    turnController.fullReset()
+  })
+
+  it('folds the end-of-turn snapshot + odometer into sessionStats', () => {
+    const onEvent = createGatewayEventHandler(buildCtx())
+
+    onEvent({ payload: { cost: SNAPSHOT, session_turns: 1, text: 'done' }, type: 'message.complete' } as any)
+
+    expect(getUiState().sessionStats).toEqual({
+      costUsd: 0.0048,
+      inputTokens: 33189,
+      outputTokens: 622,
+      turns: 1
+    })
+  })
+
+  it('keeps totals when the best-effort snapshot comes back empty', () => {
+    const onEvent = createGatewayEventHandler(buildCtx())
+
+    onEvent({ payload: { cost: SNAPSHOT, session_turns: 1, text: 'a' }, type: 'message.complete' } as any)
+    onEvent({ payload: { cost: {}, session_turns: 2, text: 'b' }, type: 'message.complete' } as any)
+
+    expect(getUiState().sessionStats).toEqual({
+      costUsd: 0.0048,
+      inputTokens: 33189,
+      outputTokens: 622,
+      turns: 2
+    })
+  })
+
+  it('leaves sessionStats untouched when the payload carries neither field', () => {
+    const onEvent = createGatewayEventHandler(buildCtx())
+    const before = getUiState().sessionStats
+
+    onEvent({ payload: { text: 'plain' }, type: 'message.complete' } as any)
+
+    expect(getUiState().sessionStats).toBe(before)
+  })
+})
+
+describe('SessionStatsLine', () => {
+  const renderToString = (element: React.ReactElement): string => {
+    const stdout = new PassThrough()
+    const stdin = new PassThrough()
+    const stderr = new PassThrough()
+    let output = ''
+
+    Object.assign(stdout, { columns: 120, isTTY: false, rows: 20 })
+    Object.assign(stdin, { isTTY: false })
+    Object.assign(stderr, { isTTY: false })
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+
+    const instance = renderSync(element, {
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream
+    })
+
+    instance.unmount()
+    instance.cleanup()
+
+    return output
+  }
+
+  beforeEach(() => {
+    resetUiState()
+  })
+
+  it('stays hidden until session.info arrives', () => {
+    const out = renderToString(React.createElement(SessionStatsLine, { cols: 120 }))
+
+    expect(stripAnsi(out).trim()).toBe('')
+  })
+
+  it('renders provider · model · cwd and the accumulators once ready', () => {
+    patchUiState({
+      info: { cwd: '/w/app', model: 'deepseek-v4-flash', profile_name: 'deepseek', skills: {}, tools: {} } as any,
+      sessionStats: { costUsd: 0.0048, inputTokens: 33189, outputTokens: 622, turns: 1 }
+    })
+
+    const out = stripAnsi(renderToString(React.createElement(SessionStatsLine, { cols: 120 })))
+
+    expect(out).toContain('deepseek · deepseek-v4-flash · /w/app · turns: 1 · tokens: 33189 in / 622 out · cost $0.0048')
+  })
+})

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -13,6 +13,7 @@ import { setLastCostSnapshot } from '../lib/costSummary.js'
 import { isTodoDone } from '../lib/liveProgress.js'
 import { openExternalUrl } from '../lib/openExternalUrl.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
+import { statsFromCostSnapshot } from '../lib/sessionStats.js'
 import { topLevelSubagents } from '../lib/subagentTree.js'
 import { formatAbandonedClarify, formatToolCall, stripAnsi } from '../lib/text.js'
 import { fromSkin } from '../theme.js'
@@ -968,6 +969,25 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         // Session totals rider — /cost's baseline and the exit summary's
         // data source (printed by registerCostSummaryOnExit, entry.tsx).
         setLastCostSnapshot(ev.payload?.cost)
+
+        // Stats line under the composer: token/cost totals fold out of the
+        // snapshot; the turn odometer is server-authoritative. Each piece
+        // updates independently so an empty best-effort snapshot can't zero
+        // the totals and a snapshot-only payload can't stall the odometer.
+        {
+          const snap = ev.payload?.cost
+          const turns = ev.payload?.session_turns
+
+          if ((snap && Object.keys(snap).length > 0) || typeof turns === 'number') {
+            patchUiState(state => ({
+              ...state,
+              sessionStats:
+                snap && Object.keys(snap).length > 0
+                  ? statsFromCostSnapshot(snap, turns ?? state.sessionStats.turns)
+                  : { ...state.sessionStats, turns: turns! }
+            }))
+          }
+        }
 
         return
       }

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -4,6 +4,7 @@ import { buildSetupRequiredSections, SETUP_REQUIRED_TITLE } from '../content/set
 import type {
   CommandsCatalogResponse,
   ConfigFullResponse,
+  CostSnapshot,
   DelegationStatusResponse,
   GatewayEvent,
   GatewaySkin,
@@ -78,6 +79,25 @@ const normalizeSubagentStatus = (status: unknown, fallback: SubagentStatus): Sub
   const normalized = status.toLowerCase() as SubagentStatus
 
   return KNOWN_SUBAGENT_STATUSES.has(normalized) ? normalized : fallback
+}
+
+// Stats line under the composer: token/cost totals fold out of the backend's
+// cumulative CostSnapshot; the turn odometer is server-authoritative. Each
+// piece updates independently so an empty best-effort snapshot ({}) can't
+// zero the totals and a snapshot-only payload can't stall the odometer.
+const foldSessionStats = (snap: CostSnapshot | undefined, turns: number | undefined): void => {
+  const hasSnap = !!snap && Object.keys(snap).length > 0
+
+  if (!hasSnap && typeof turns !== 'number') {
+    return
+  }
+
+  patchUiState(state => ({
+    ...state,
+    sessionStats: hasSnap
+      ? statsFromCostSnapshot(snap!, turns ?? state.sessionStats.turns)
+      : { ...state.sessionStats, turns: turns! }
+  }))
 }
 
 export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev: GatewayEvent) => void {
@@ -970,27 +990,17 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         // data source (printed by registerCostSummaryOnExit, entry.tsx).
         setLastCostSnapshot(ev.payload?.cost)
 
-        // Stats line under the composer: token/cost totals fold out of the
-        // snapshot; the turn odometer is server-authoritative. Each piece
-        // updates independently so an empty best-effort snapshot can't zero
-        // the totals and a snapshot-only payload can't stall the odometer.
-        {
-          const snap = ev.payload?.cost
-          const turns = ev.payload?.session_turns
-
-          if ((snap && Object.keys(snap).length > 0) || typeof turns === 'number') {
-            patchUiState(state => ({
-              ...state,
-              sessionStats:
-                snap && Object.keys(snap).length > 0
-                  ? statsFromCostSnapshot(snap, turns ?? state.sessionStats.turns)
-                  : { ...state.sessionStats, turns: turns! }
-            }))
-          }
-        }
+        foldSessionStats(ev.payload?.cost, ev.payload?.session_turns)
 
         return
       }
+
+      case 'session.stats':
+        // Out-of-band refresh from a /clear or /resume reply — the next
+        // end-of-turn result may be a whole turn away.
+        foldSessionStats(ev.payload?.cost, ev.payload?.session_turns)
+
+        return
 
       case 'error':
         turnController.recordError()

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -6,6 +6,7 @@ import type { GatewayClient } from '../gatewayClient.js'
 import type { BillingStateResponse, ImageAttachResponse, SessionCloseResponse } from '../gatewayTypes.js'
 import type { ParsedVoiceRecordKey } from '../lib/platform.js'
 import type { RpcResult } from '../lib/rpc.js'
+import type { SessionStats } from '../lib/sessionStats.js'
 import type { Theme } from '../theme.js'
 import type {
   ApprovalReq,
@@ -180,6 +181,9 @@ export interface UiState {
 
   sections: SectionVisibility
   sessionTitle: string
+  // Accumulated turn/token/cost totals for the stats line under the composer
+  // (refreshed from each end-of-turn result's CostSnapshot + session_turns).
+  sessionStats: SessionStats
   showReasoning: boolean
   indicatorStyle: IndicatorStyle
   sid: null | string

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -190,6 +190,11 @@ export const coreCommands: SlashCommand[] = [
 
       const commit = () => {
         patchUiState({ status: 'forging session…' })
+        // Server half first: reset the backend conversation + turn odometer
+        // (single-session adapter — session.create alone reattaches to the
+        // same session, silently keeping the old context). Best-effort: the
+        // client-side reset proceeds either way.
+        void ctx.gateway.rpc('session.clear', {}).catch(() => undefined)
         ctx.session.newSession(isNew ? 'new session started' : undefined, requestedTitle || undefined)
       }
 

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -2,6 +2,7 @@ import { atom, computed } from 'nanostores'
 
 import { MOUSE_TRACKING } from '../config/env.js'
 import { ZERO } from '../domain/usage.js'
+import { ZERO_SESSION_STATS } from '../lib/sessionStats.js'
 import { DEFAULT_THEME } from '../theme.js'
 
 import { DEFAULT_INDICATOR_STYLE, type UiState } from './interfaces.js'
@@ -24,6 +25,7 @@ const buildUiState = (): UiState => ({
   pasteCollapseChars: 2000,
   sections: {},
   sessionTitle: '',
+  sessionStats: ZERO_SESSION_STATS,
   showReasoning: false,
   sid: null,
   status: 'starting clawcodex…',

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -18,6 +18,7 @@ import type {
   SetupStatusResponse
 } from '../gatewayTypes.js'
 import { asRpcResult } from '../lib/rpc.js'
+import { ZERO_SESSION_STATS } from '../lib/sessionStats.js'
 import type { Msg, PanelSection, SessionInfo, Usage } from '../types.js'
 
 import type { ComposerActions, GatewayRpc, StateSetter } from './interfaces.js'
@@ -156,7 +157,10 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
     turnController.fullReset()
     setVoiceRecording(false)
     setVoiceProcessing(false)
-    patchUiState({ bgTasks: new Set(), info: null, sid: null, usage: ZERO })
+    // sessionStats: zeros beat another session's numbers; the server
+    // re-stamps truth on the clear/resume reply (session.stats event) or at
+    // the latest on the next end-of-turn result.
+    patchUiState({ bgTasks: new Set(), info: null, sessionStats: ZERO_SESSION_STATS, sid: null, usage: ZERO })
     setHistoryItems([])
     setLastUserMsg('')
     setStickyPrompt('')

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -31,6 +31,7 @@ import { HelpHint } from './helpHint.js'
 import { MessageLine } from './messageLine.js'
 import { PetKitty, PetSprite } from './petSprite.js'
 import { QueuedMessages } from './queuedMessages.js'
+import { SessionStatsLine } from './sessionStatsLine.js'
 import { LiveTodoPanel, StreamingAssistant } from './streamingAssistant.js'
 import { TextInput, type TextInputMouseApi } from './textInput.js'
 
@@ -367,6 +368,8 @@ const ComposerPane = memo(function ComposerPane({
       />
 
       <StatusRulePane at="bottom" composer={composer} status={status} />
+
+      <SessionStatsLine cols={composer.cols} />
     </NoSelect>
   )
 })

--- a/ui-tui/src/components/sessionStatsLine.tsx
+++ b/ui-tui/src/components/sessionStatsLine.tsx
@@ -1,0 +1,42 @@
+/**
+ * Persistent session-stats line — the last row under the composer, the
+ * deleted REPL's bottom toolbar reborn:
+ *
+ *   deepseek · deepseek-v4-flash · ~/work/app · turns: 3 · tokens: 33189 in / 622 out · cost $0.0048
+ *
+ * Provider/model/cwd come from session.info; the accumulators refresh on
+ * every end-of-turn result (createGatewayEventHandler → ui.sessionStats).
+ * Hidden until the backend's init arrives — there is nothing to report
+ * while "starting clawcodex…" still owns the status row.
+ */
+import { Box, Text } from '@clawcodex/ink'
+import { useStore } from '@nanostores/react'
+import { memo } from 'react'
+
+import { $uiState } from '../app/uiStore.js'
+import { buildSessionStatsLine } from '../lib/sessionStats.js'
+
+export const SessionStatsLine = memo(function SessionStatsLine({ cols }: { cols: number }) {
+  const ui = useStore($uiState)
+
+  if (!ui.info) {
+    return null
+  }
+
+  // ComposerPane pads 1 column and this Box pads 2 more per side.
+  const line = buildSessionStatsLine({
+    cols: Math.max(1, cols - 6),
+    cwd: ui.info.cwd ?? '',
+    model: ui.info.model ?? '',
+    provider: ui.info.profile_name ?? '',
+    stats: ui.sessionStats
+  })
+
+  return (
+    <Box paddingX={2}>
+      <Text color={ui.theme.color.muted} wrap="truncate-end">
+        {line}
+      </Text>
+    </Box>
+  )
+})

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -1178,6 +1178,7 @@ export class GatewayClient extends EventEmitter {
             // Running session totals for /cost + the exit summary.
             cost: msg.cost && typeof msg.cost === 'object' ? msg.cost : undefined,
             permission_mode: typeof msg.permission_mode === 'string' ? msg.permission_mode : undefined,
+            session_turns: typeof msg.session_turns === 'number' ? msg.session_turns : undefined,
             text: typeof msg.result === 'string' ? msg.result : undefined,
             usage: msg.usage
           },

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -542,6 +542,16 @@ export class GatewayClient extends EventEmitter {
         // system/init has set it. The app then enables the composer.
         return this.readyPromise.then(() => ({ info: this.sessionInfo ?? undefined, session_id: this.sessionId }) as T)
 
+      case 'session.clear':
+        // /clear's server half: reset the backend conversation (and its turn
+        // odometer) so a "cleared" transcript isn't silently re-fed the old
+        // context next prompt. The reply's stats rider refreshes the line.
+        return this.controlQuery('clear', {}).then(r => {
+          this.publishSessionStats(r)
+
+          return { ok: (r as any)?.ok !== false } as T
+        })
+
       case 'setup.status':
         return Promise.resolve({ provider_configured: true } as T)
 
@@ -824,10 +834,12 @@ export class GatewayClient extends EventEmitter {
     const out = (output: string) => ({ output, type: 'exec' })
 
     switch (name) {
-      case 'clear':
-        await this.controlQuery('clear', {})
+      case 'clear': {
+        const r = await this.controlQuery('clear', {})
+        this.publishSessionStats(r)
 
         return out('Conversation cleared.')
+      }
       case 'compact': {
         const r = (await this.controlQuery('compact', { instructions: arg ?? null })) as any
 
@@ -981,6 +993,7 @@ export class GatewayClient extends EventEmitter {
       case 'resume': {
         if (arg) {
           const r = (await this.controlQuery('resume', { session_id: arg })) as any
+          this.publishSessionStats(r)
 
           // mode_banner: coordinator-mode flip notice (matchSessionMode) —
           // e.g. "Entered coordinator mode to match resumed session."
@@ -1391,6 +1404,24 @@ export class GatewayClient extends EventEmitter {
 
     if (this.subscribed) {this.emit('event', ev)}
     else {this.buffered.push(ev)}
+  }
+
+  /** Stats-line refresh from a clear/resume reply's rider (session_turns +
+   *  cost snapshot). Silently a no-op for replies without the fields. */
+  private publishSessionStats(r: unknown): void {
+    const reply = r as { cost?: unknown; session_turns?: unknown } | null
+
+    if (typeof reply?.session_turns !== 'number' && !reply?.cost) {
+      return
+    }
+
+    this.publish({
+      payload: {
+        cost: reply.cost && typeof reply.cost === 'object' ? (reply.cost as any) : undefined,
+        session_turns: typeof reply.session_turns === 'number' ? reply.session_turns : undefined
+      },
+      type: 'session.stats'
+    })
   }
 
   private pushLog(line: string): void {

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -776,4 +776,7 @@ export type GatewayEvent =
       session_id?: string
       type: 'message.complete'
     }
+  /** Out-of-band stats-line refresh: /clear and /resume replies carry the
+   *  odometer + totals so the line is right before any turn completes. */
+  | { payload: { cost?: CostSnapshot; session_turns?: number }; session_id?: string; type: 'session.stats' }
   | { payload?: { message?: string }; session_id?: string; type: 'error' }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -768,6 +768,8 @@ export type GatewayEvent =
         permission_mode?: string
         reasoning?: string
         rendered?: string
+        /** Completed-user-turn odometer (server-authoritative; survives /resume). */
+        session_turns?: number
         text?: string
         usage?: Usage
       }

--- a/ui-tui/src/lib/sessionStats.ts
+++ b/ui-tui/src/lib/sessionStats.ts
@@ -60,7 +60,10 @@ export function buildSessionStatsLine({ cols, cwd, model, provider, stats }: Ses
   ]
 
   const home = process.env.HOME
-  const tilde = home && cwd.startsWith(home) ? `~${cwd.slice(home.length)}` : cwd
+  // Boundary-safe prefix check: /Users/testuser must not abbreviate under
+  // HOME=/Users/test (shortCwd's looser match is a pre-existing quirk).
+  const underHome = !!home && (cwd === home || cwd.startsWith(`${home}/`))
+  const tilde = underHome ? `~${cwd.slice(home!.length)}` : cwd
   const cwdVariants = cwd ? [cwd, tilde, shortCwd(cwd, 28), shortCwd(cwd, 12), ''] : ['']
 
   let line = ''

--- a/ui-tui/src/lib/sessionStats.ts
+++ b/ui-tui/src/lib/sessionStats.ts
@@ -1,0 +1,77 @@
+/**
+ * Accumulated session stats for the persistent line under the composer —
+ * the deleted REPL's bottom toolbar (repl/core.py `_bottom_toolbar`):
+ *
+ *   deepseek · deepseek-v4-flash · ~/work/app · turns: 3 · tokens: 33189 in / 622 out · cost $0.0048
+ *
+ * Token/cost totals derive from the backend's end-of-turn CostSnapshot (the
+ * same accumulators /cost prints, subagents included, restored on /resume);
+ * the turn count is the server's `session_turns` odometer.
+ */
+import { stringWidth } from '@clawcodex/ink'
+
+import { shortCwd } from '../domain/paths.js'
+import type { CostSnapshot } from '../gatewayTypes.js'
+
+import { formatCost } from './costSummary.js'
+
+export interface SessionStats {
+  costUsd: number
+  /** Total prompt tokens sent: uncached input + cache reads + cache writes. */
+  inputTokens: number
+  outputTokens: number
+  turns: number
+}
+
+export const ZERO_SESSION_STATS: SessionStats = { costUsd: 0, inputTokens: 0, outputTokens: 0, turns: 0 }
+
+/** Fold a CostSnapshot's per-model accumulators into display totals. */
+export function statsFromCostSnapshot(snap: CostSnapshot, turns: number): SessionStats {
+  let input = 0
+  let output = 0
+
+  for (const u of Object.values(snap.model_usage ?? {})) {
+    input += (u.input_tokens ?? 0) + (u.cache_read_input_tokens ?? 0) + (u.cache_creation_input_tokens ?? 0)
+    output += u.output_tokens ?? 0
+  }
+
+  return { costUsd: snap.total_cost_usd ?? 0, inputTokens: input, outputTokens: output, turns }
+}
+
+export interface SessionStatsLineInput {
+  cols: number
+  cwd: string
+  model: string
+  provider: string
+  stats: SessionStats
+}
+
+/**
+ * Compose the stats line, shedding cwd detail as the terminal narrows:
+ * full path → `~`-abbreviated → 28-col tail → 12-col tail → no cwd. The
+ * accumulators on the right are the payload, so the path yields first; if
+ * even the cwd-less form overflows, the caller's truncate-end clips it.
+ */
+export function buildSessionStatsLine({ cols, cwd, model, provider, stats }: SessionStatsLineInput): string {
+  const tail = [
+    `turns: ${stats.turns}`,
+    `tokens: ${stats.inputTokens} in / ${stats.outputTokens} out`,
+    ...(stats.costUsd > 0 ? [`cost ${formatCost(stats.costUsd)}`] : [])
+  ]
+
+  const home = process.env.HOME
+  const tilde = home && cwd.startsWith(home) ? `~${cwd.slice(home.length)}` : cwd
+  const cwdVariants = cwd ? [cwd, tilde, shortCwd(cwd, 28), shortCwd(cwd, 12), ''] : ['']
+
+  let line = ''
+
+  for (const variant of cwdVariants) {
+    line = [provider, model, variant, ...tail].filter(Boolean).join(' · ')
+
+    if (stringWidth(line) <= cols) {
+      return line
+    }
+  }
+
+  return line
+}


### PR DESCRIPTION
## What

A persistent, muted stats line pinned as the last row under the composer — the deleted prompt_toolkit REPL's bottom toolbar (repl/core.py `_bottom_toolbar`), reborn for the Ink TUI:

```
deepseek · deepseek-v4-flash · ~/workspace/app · turns: 3 · tokens: 33189 in / 622 out · cost $0.0048
```

- **provider · model · cwd** from session.info; cwd sheds detail as the terminal narrows (full → `~`-abbreviated → 28-col tail → 12-col tail → dropped) so the accumulators never yield first. Home abbreviation is path-boundary-safe (`/Users/testuser` doesn't abbreviate under `HOME=/Users/test`).
- **turns** — a server-side odometer (`_AgentSession._stats_turns`): successful user turns only (internal notification turns and ephemeral `/btw` turns excluded), stamped on every result message as `session_turns`, persisted in the session file, seeded back on `_do_resume` (exact saved counter preferred; conversation recount as fallback for old files), zeroed by `clear`, recounted after `/rewind`.
- **tokens in / out · cost** — folded client-side from the existing end-of-turn CostSnapshot rider (the same accumulators `/cost` and the exit summary print — subagents included, restored on `/resume`). "in" counts uncached input + cache reads + cache writes = total prompt volume sent (DeepSeek remaps prefix-cache hits to `cache_read_input_tokens`, so uncached-only would understate by roughly the whole prompt). Cost formatting is shared with `/cost` (`formatCost`); the segment hides until something is spent.

## Bug found & fixed along the way

**`/clear` was cosmetic.** The single-session adapter resolves `session.create` by reattaching to the same backend session, so `/clear`/`/new` wiped the transcript while the backend conversation silently kept feeding the old context. The commit now fires a `session.clear` RPC → backend `clear` control, so conversation + odometer reset together (verified live).

## Session-boundary truth

`resetSession` zeroes the stats so a fresh/switched session never shows another session's numbers. The backend's `clear`/`resume` replies carry a `session_turns` + cost rider published as a new `session.stats` gateway event, so after `/clear` the line is right immediately (turns reset, spend kept) rather than one turn later. Note: the resume rider currently benefits control-plane clients only — the TUI's user-reachable resume flows go through the adapter's single-session reattach and don't hit the backend `resume` control (pre-existing; filed as a follow-up). Those flows degrade to honest zeros until the next turn completes.

## Version skew

Old backend + new TUI: `turns` stays 0 (no `session_turns` on the wire) while tokens/cost still work off the cost rider. New backend + old TUI: the extra result field and reply riders are ignored. Both directions are safe.

## Verification

- Python: 15 new tests (`tests/server/test_session_stats_turns.py`) — odometer increments/exclusions (internal, btw, abort), reply stamping, clear/rewind/resume/save lifecycle incl. a real `Conversation.to_dict → from_dict` round-trip; full `tests/server/` green (180); cost-persistence suites green.
- TS: 13 tests in `sessionStats.test.ts` (snapshot fold, width shedding, tilde boundary, handler folds incl. the out-of-band `session.stats` path, component render gate) + 3 in `gatewayClient.test.ts` (result pass-through, clear-reply rider publication, old-backend silence). Full vitest suite matches the base commit's 9 pre-existing failures exactly; `tsc --noEmit` clean.
- Live pyte e2e against the real DeepSeek backend: pre-turn line shows `turns: 0 · tokens: 0 in / 0 out`; after one real turn `turns: 1 · tokens: 81420 in / 19 out · cost $0.0012`; after `/clear`+confirm `turns: 0` with tokens kept; clean `/exit`.
- Critic-reviewed: REVISE → all findings addressed → **APPROVE**.

## Follow-up filed (not in this PR)

The adapter's `session.resume` reattach means TUI-reachable resume flows never restore the backend conversation for cold sessions (same defect class as the `/clear` find). Needs its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)