### PR TITLE
feat(sandbox): honest unsandboxed guard — refuse-to-start hard gate (C8)

### DIFF
--- a/src/permissions/sandbox_guard.py
+++ b/src/permissions/sandbox_guard.py
@@ -22,13 +22,20 @@ silently given an unsandboxed shell. Actual enforcement (a native
 ``sandbox-exec``/``bwrap`` engine) is the deferred
 **sandbox-native-enforcement** sub-chapter.
 
-SCOPE: like TS (``shouldUseSandbox`` is BashTool-scoped — called only from
-``bashPermissions.ts``), this guards the **Bash tool** — both foreground and
-background commands, which share the ``_bash_call`` entry (the guard runs
-before the ``run_in_background`` branch). Hook subprocesses and MCP stdio
-servers are user-authored config that TS's sandbox does not wrap either, so
-they are intentionally out of scope — the hard gate is an honest "no
-unsandboxed BASH", not a false "nothing runs unsandboxed".
+SCOPE — two distinct mechanisms (critic C8):
+
+* The WARNING path (``enabled`` and not ``failIfUnavailable``) is
+  BashTool-scoped, like TS ``shouldUseSandbox`` (called only from
+  ``bashPermissions.ts``): it warns once and runs the command unsandboxed.
+  Hooks/MCP/`/bg` running unsandboxed here is faithful — TS doesn't sandbox
+  those either.
+* The HARD GATE (``enabled`` + ``failIfUnavailable``) is a REFUSE-TO-START, not
+  a per-command refusal — TS exits at the entrypoints (print.ts:600 /
+  REPL.tsx:2362, "refusing to start without a working sandbox"). The port
+  enforces it in ``agent_server._build_runtime`` (``sess.init_error`` →
+  the session refuses to start, so /bg + MCP + hooks never run) AND at
+  ``_bash_call`` as a CLI-path backstop. So the "hard gate" is truthful:
+  nothing runs, not just Bash.
 """
 from __future__ import annotations
 
@@ -53,8 +60,26 @@ _HARD_GATE_ERROR = (
 )
 
 
+def _current_platform() -> str:
+    """Map sys.platform to TS's platform tokens (macos/linux/windows)."""
+    import sys
+
+    return {"darwin": "macos", "win32": "windows"}.get(
+        sys.platform, "linux" if sys.platform.startswith("linux") else sys.platform
+    )
+
+
 def _sandbox(settings: Any) -> Any | None:
-    return getattr(settings, "sandbox", None)
+    """The sandbox settings, or None when sandbox does not apply on this
+    platform (TS enabledPlatforms: on a platform not listed, sandbox is
+    treated as disabled — no gate, no warning)."""
+    sb = getattr(settings, "sandbox", None)
+    if sb is None:
+        return None
+    platforms = getattr(sb, "enabled_platforms", None) or []
+    if platforms and _current_platform() not in platforms:
+        return None
+    return sb
 
 
 def is_sandbox_requested(settings: Any) -> bool:

--- a/src/permissions/sandbox_guard.py
+++ b/src/permissions/sandbox_guard.py
@@ -21,6 +21,14 @@ This module surfaces that guard so a user who asked for a sandbox is never
 silently given an unsandboxed shell. Actual enforcement (a native
 ``sandbox-exec``/``bwrap`` engine) is the deferred
 **sandbox-native-enforcement** sub-chapter.
+
+SCOPE: like TS (``shouldUseSandbox`` is BashTool-scoped — called only from
+``bashPermissions.ts``), this guards the **Bash tool** — both foreground and
+background commands, which share the ``_bash_call`` entry (the guard runs
+before the ``run_in_background`` branch). Hook subprocesses and MCP stdio
+servers are user-authored config that TS's sandbox does not wrap either, so
+they are intentionally out of scope — the hard gate is an honest "no
+unsandboxed BASH", not a false "nothing runs unsandboxed".
 """
 from __future__ import annotations
 

--- a/src/permissions/sandbox_guard.py
+++ b/src/permissions/sandbox_guard.py
@@ -32,10 +32,13 @@ SCOPE — two distinct mechanisms (critic C8):
 * The HARD GATE (``enabled`` + ``failIfUnavailable``) is a REFUSE-TO-START, not
   a per-command refusal — TS exits at the entrypoints (print.ts:600 /
   REPL.tsx:2362, "refusing to start without a working sandbox"). The port
-  enforces it in ``agent_server._build_runtime`` (``sess.init_error`` →
-  the session refuses to start, so /bg + MCP + hooks never run) AND at
-  ``_bash_call`` as a CLI-path backstop. So the "hard gate" is truthful:
-  nothing runs, not just Bash.
+  enforces it in ``agent_server._build_runtime`` (``sess.init_error`` → the
+  session refuses to start, so MCP + hooks never run) AND in
+  ``_handle_control_request`` (a refused session rejects ``bg_run``/``bg_agent``
+  and every other control request except ``interrupt`` — /bg is a CONTROL
+  request that bypasses _build_runtime and the turn path) AND at ``_bash_call``
+  as a CLI-path backstop. So the "hard gate" is truthful: nothing runs, not
+  just Bash.
 """
 from __future__ import annotations
 

--- a/src/permissions/sandbox_guard.py
+++ b/src/permissions/sandbox_guard.py
@@ -1,0 +1,90 @@
+"""Sandbox availability guard (C8 — the silent-unsandboxed footgun).
+
+The port does NOT implement sandbox ENFORCEMENT: TS wraps the external
+``@anthropic-ai/sandbox-runtime`` (macOS Seatbelt / Linux bubblewrap) via
+``SandboxManager``; the port has only the decision helper
+(``bash_security.should_sandbox_command``, currently unwired) and runs a bare
+``subprocess.Popen`` (bash_tool.py). So in the port the sandbox is permanently
+UNAVAILABLE.
+
+That is not a divergence to hide — it maps exactly onto TS's OWN documented
+sandbox-unavailable path (``entrypoints/sandboxTypes.ts:96-103``): when
+``sandbox.enabled`` is true but the sandbox cannot start,
+
+  * ``failIfUnavailable: true``  → "Exit with an error at startup" (a
+    managed-settings HARD GATE — sandboxing is required, so running
+    unsandboxed is a refusal, not a warning), and
+  * ``failIfUnavailable: false`` (default) → "a warning is shown and commands
+    run unsandboxed".
+
+This module surfaces that guard so a user who asked for a sandbox is never
+silently given an unsandboxed shell. Actual enforcement (a native
+``sandbox-exec``/``bwrap`` engine) is the deferred
+**sandbox-native-enforcement** sub-chapter.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_UNSANDBOXED_WARNING = (
+    "settings.sandbox.enabled is true, but this build does not implement "
+    "sandbox enforcement — commands run UNSANDBOXED. Set "
+    "sandbox.failIfUnavailable=true to make this a hard startup error instead, "
+    "or unset sandbox.enabled to silence this warning."
+)
+
+_HARD_GATE_ERROR = (
+    "settings.sandbox.enabled and sandbox.failIfUnavailable are both true, but "
+    "this build does not implement sandbox enforcement, so the sandbox cannot "
+    "start. Refusing to run unsandboxed (the managed-settings hard gate). "
+    "Unset sandbox.failIfUnavailable to fall back to a warning + unsandboxed "
+    "execution."
+)
+
+
+def _sandbox(settings: Any) -> Any | None:
+    return getattr(settings, "sandbox", None)
+
+
+def is_sandbox_requested(settings: Any) -> bool:
+    sb = _sandbox(settings)
+    return bool(sb is not None and getattr(sb, "enabled", False))
+
+
+def sandbox_hard_gate_error(settings: Any) -> str | None:
+    """The hard-gate message when the user REQUIRES a sandbox
+    (``enabled`` + ``failIfUnavailable``) that the port cannot provide, else
+    ``None``. Callers must refuse to proceed when this is non-None."""
+    sb = _sandbox(settings)
+    if sb is not None and getattr(sb, "enabled", False) and getattr(sb, "fail_if_unavailable", False):
+        return _HARD_GATE_ERROR
+    return None
+
+
+def sandbox_unsandboxed_warning(settings: Any) -> str | None:
+    """The warning message when the user ASKED for a sandbox but it is
+    unavailable and NOT required (``enabled`` + not ``failIfUnavailable``),
+    else ``None``."""
+    sb = _sandbox(settings)
+    if sb is not None and getattr(sb, "enabled", False) and not getattr(sb, "fail_if_unavailable", False):
+        return _UNSANDBOXED_WARNING
+    return None
+
+
+_warned_once = False
+
+
+def warn_if_unsandboxed_once(settings: Any) -> None:
+    """Emit the unsandboxed warning at most once per process (so bash-per-call
+    wiring doesn't spam). The hard-gate case is handled separately by callers
+    that must refuse."""
+    global _warned_once
+    if _warned_once:
+        return
+    msg = sandbox_unsandboxed_warning(settings)
+    if msg:
+        logger.warning("[sandbox] %s", msg)
+        _warned_once = True

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -2325,6 +2325,25 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
         profile_checkpoint("agent_server_trust_prefetch_done")
 
         cfg = sess.config
+
+        # Sandbox HARD GATE (C8): TS's failIfUnavailable is a REFUSE-TO-START
+        # at the entrypoints (print.ts:600 / REPL.tsx:2362 "refusing to start
+        # without a working sandbox"), NOT a per-command refusal. The port has
+        # no sandbox enforcement, so under sandbox.enabled+failIfUnavailable the
+        # SESSION must refuse to start — otherwise /bg, MCP servers, and hooks
+        # (which run OUTSIDE _bash_call) would execute unsandboxed while the
+        # per-_bash_call guard only stops foreground/bg BashTool commands.
+        try:
+            from src.permissions.sandbox_guard import sandbox_hard_gate_error
+            from src.settings.settings import get_settings
+
+            _gate = sandbox_hard_gate_error(get_settings(cwd=sess.cwd))
+            if _gate:
+                sess.init_error = _gate
+                return
+        except Exception:  # noqa: BLE001 — the guard must never crash startup
+            logger.debug("[agent-server] sandbox hard-gate check failed", exc_info=True)
+
         provider_name = cfg.provider_name or get_default_provider()
         provider_cfg = get_provider_config(provider_name)
         api_key = resolve_api_key(provider_name, provider_cfg)

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -245,6 +245,18 @@ class _AgentSession:
             return
         subtype = inner.get("subtype")
         request_id = msg.get("request_id")
+        # A session that refused to start (``init_error`` — e.g. the sandbox
+        # HARD GATE) must not service control requests that actually DO work.
+        # ``bg_run``/``bg_agent`` (/bg, /bg-agent) spawn subprocesses via
+        # ``_do_bgtask`` → ``subprocess.Popen(shell=True)`` OUTSIDE
+        # ``_build_runtime`` and the turn path — so without this guard they'd
+        # run UNSANDBOXED under a hard-gate config the session was supposed to
+        # refuse (critic C8). ``interrupt`` is exempt (a benign abort of a
+        # non-existent turn). Mirrors the ``session not ready`` pattern the
+        # permission-mode handlers already use.
+        if self.init_error is not None and subtype != "interrupt":
+            self._reply(request_id, {"ok": False, "error": self.init_error})
+            return
         if subtype == "interrupt":
             with self._lock:
                 abort = self._current_abort

--- a/src/settings/types.py
+++ b/src/settings/types.py
@@ -68,6 +68,10 @@ class SandboxSettings:
     auto_allow_bash_if_sandboxed: bool = True
     allow_unsandboxed_commands: bool = True
     excluded_commands: list[str] = field(default_factory=list)
+    # TS enabledPlatforms (sandboxTypes.ts:104): restrict sandboxing to
+    # specific platforms; on a platform NOT listed, TS treats sandbox as
+    # disabled (no gate, no warning). Empty = all platforms.
+    enabled_platforms: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -277,6 +281,7 @@ class SettingsSchema:
                 auto_allow_bash_if_sandboxed=bool(_sb.get("autoAllowBashIfSandboxed", _sb.get("auto_allow_bash_if_sandboxed", True))),
                 allow_unsandboxed_commands=bool(_sb.get("allowUnsandboxedCommands", _sb.get("allow_unsandboxed_commands", True))),
                 excluded_commands=list(_sb.get("excludedCommands", _sb.get("excluded_commands", [])) or []),
+                enabled_platforms=list(_sb.get("enabledPlatforms", _sb.get("enabled_platforms", [])) or []),
             )
         if "spinner_verbs" in known and isinstance(known["spinner_verbs"], dict):
             known["spinner_verbs"] = SpinnerVerbsSettings(**known["spinner_verbs"])

--- a/src/settings/types.py
+++ b/src/settings/types.py
@@ -50,6 +50,27 @@ class SpinnerVerbsSettings:
 
 
 @dataclass
+class SandboxSettings:
+    """Sandbox configuration — mirrors TS ``SandboxSettingsSchema``
+    (entrypoints/sandboxTypes.ts:91).
+
+    The port does NOT implement sandbox ENFORCEMENT (TS wraps the external
+    ``@anthropic-ai/sandbox-runtime`` — a deferred sub-chapter). So the port's
+    sandbox is permanently "unavailable", which maps onto TS's OWN documented
+    fallback (sandboxTypes.ts:96-103): when ``enabled`` is true but the sandbox
+    cannot start, ``failIfUnavailable`` decides between a hard startup error
+    (managed-settings hard gate) and "a warning is shown and commands run
+    unsandboxed". Parsing these fields (rather than dropping the whole
+    ``sandbox`` key) is what makes that guard possible — an unparsed key would
+    silently vanish, giving a false sense of security."""
+    enabled: bool = False
+    fail_if_unavailable: bool = False  # TS failIfUnavailable (default false)
+    auto_allow_bash_if_sandboxed: bool = True
+    allow_unsandboxed_commands: bool = True
+    excluded_commands: list[str] = field(default_factory=list)
+
+
+@dataclass
 class CompactSettings:
     """Compaction settings."""
     auto_compact: bool = True
@@ -161,6 +182,9 @@ class SettingsSchema:
     # Output
     output_style: OutputStyleSettings = field(default_factory=OutputStyleSettings)
 
+    # Sandbox (parsed but enforcement deferred — see SandboxSettings + C8)
+    sandbox: SandboxSettings | None = None
+
     # Spinner verbs (None = built-in defaults)
     spinner_verbs: SpinnerVerbsSettings | None = None
 
@@ -242,6 +266,18 @@ class SettingsSchema:
             ]
         if "output_style" in known and isinstance(known["output_style"], dict):
             known["output_style"] = OutputStyleSettings(**known["output_style"])
+        # ``sandbox`` — TS's SandboxSettingsSchema uses camelCase + .passthrough();
+        # accept both cases and IGNORE unknown keys (the enforcement-only fields
+        # the port doesn't act on) so a valid settings.json never fails to load.
+        if "sandbox" in known and isinstance(known["sandbox"], dict):
+            _sb = known["sandbox"]
+            known["sandbox"] = SandboxSettings(
+                enabled=bool(_sb.get("enabled", False)),
+                fail_if_unavailable=bool(_sb.get("failIfUnavailable", _sb.get("fail_if_unavailable", False))),
+                auto_allow_bash_if_sandboxed=bool(_sb.get("autoAllowBashIfSandboxed", _sb.get("auto_allow_bash_if_sandboxed", True))),
+                allow_unsandboxed_commands=bool(_sb.get("allowUnsandboxedCommands", _sb.get("allow_unsandboxed_commands", True))),
+                excluded_commands=list(_sb.get("excludedCommands", _sb.get("excluded_commands", [])) or []),
+            )
         if "spinner_verbs" in known and isinstance(known["spinner_verbs"], dict):
             known["spinner_verbs"] = SpinnerVerbsSettings(**known["spinner_verbs"])
         if "compact" in known and isinstance(known["compact"], dict):

--- a/src/settings/validation.py
+++ b/src/settings/validation.py
@@ -82,6 +82,20 @@ def validate_settings(settings: SettingsSchema) -> list[ValidationError]:
             value=settings.max_cost_usd,
         ))
 
+    # Sandbox (C8): a hard gate — enabled + failIfUnavailable but no
+    # enforcement engine in this build → invalid (TS "exit with error at
+    # startup", sandboxTypes.ts:96-103). The warning-only case (enabled,
+    # not failIfUnavailable) is NOT an error here — it's surfaced as a
+    # runtime warning at the bash path so settings still load.
+    from src.permissions.sandbox_guard import sandbox_hard_gate_error
+    _gate = sandbox_hard_gate_error(settings)
+    if _gate:
+        errors.append(ValidationError(
+            field="sandbox",
+            message=_gate,
+            value=True,
+        ))
+
     # Session retention
     if settings.session_retention_days < 1:
         errors.append(ValidationError(

--- a/src/tool_system/tools/bash/bash_tool.py
+++ b/src/tool_system/tools/bash/bash_tool.py
@@ -251,6 +251,32 @@ def _bash_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
         if pat.search(command):
             raise ToolPermissionError("refusing to run potentially dangerous command")
 
+    # Sandbox guard (C8): the port has no sandbox ENFORCEMENT, so a
+    # ``sandbox.enabled`` setting maps onto TS's documented sandbox-unavailable
+    # path (sandboxTypes.ts:96-103). failIfUnavailable → REFUSE (the
+    # managed-settings hard gate: never silently run unsandboxed); otherwise
+    # warn once and proceed unsandboxed. Best-effort: a settings problem must
+    # not crash a plain bash call.
+    try:
+        from src.permissions.sandbox_guard import (
+            sandbox_hard_gate_error,
+            warn_if_unsandboxed_once,
+        )
+        from src.settings.settings import get_settings
+
+        _settings = get_settings()
+        _gate = sandbox_hard_gate_error(_settings)
+        if _gate:
+            raise ToolPermissionError(_gate)
+        warn_if_unsandboxed_once(_settings)
+    except ToolPermissionError:
+        raise
+    except Exception:  # noqa: BLE001 — the guard must never break bash
+        import logging as _logging
+        _logging.getLogger(__name__).debug(
+            "[sandbox] guard check failed", exc_info=True
+        )
+
     explicit_cwd = tool_input.get("cwd")
     if explicit_cwd is not None:
         if not isinstance(explicit_cwd, str) or not explicit_cwd.startswith("/"):

--- a/tests/test_sandbox_guard.py
+++ b/tests/test_sandbox_guard.py
@@ -151,3 +151,111 @@ class TestBackgroundBashAlsoGuarded:
         ctx.options = ToolUseOptions(tools=[])
         with pytest.raises(ToolPermissionError):
             _bash_call({"command": "sleep 100", "run_in_background": True}, ctx)
+
+
+class TestHardGateRefusesToStart:
+    """critic C8-MAJOR: failIfUnavailable is a REFUSE-TO-START, not a per-bash
+    refusal — so /bg + MCP + hooks (which run OUTSIDE _bash_call) don't leak.
+    Drive the REAL _build_runtime under a hard-gate config → sess.init_error
+    is set (the session refuses to start)."""
+
+    def test_build_runtime_refuses_under_hard_gate(self, monkeypatch, tmp_path):
+        from unittest.mock import MagicMock
+
+        from src.server.agent_server import (
+            AgentServerConfig,
+            _AgentSession,
+            _build_runtime,
+        )
+        from src.settings.types import SettingsSchema
+
+        hard = SettingsSchema.from_dict({"sandbox": {"enabled": True, "failIfUnavailable": True}})
+        monkeypatch.setattr("src.settings.settings.get_settings", lambda *a, **k: hard)
+
+        sess = _AgentSession(
+            session_id="s1", cwd=str(tmp_path),
+            config=AgentServerConfig(provider_name="anthropic", single_session=True),
+            loop=MagicMock(), out_queue=MagicMock(),
+        )
+        _build_runtime(sess, None)
+        assert sess.init_error is not None
+        assert "sandbox" in sess.init_error.lower()
+        # refused BEFORE building tools/provider — no runtime to leak /bg through
+        assert sess.tool_registry is None
+
+    def test_build_runtime_starts_normally_without_hard_gate(self, monkeypatch, tmp_path):
+        from unittest.mock import MagicMock
+
+        from src.server.agent_server import (
+            AgentServerConfig,
+            _AgentSession,
+            _build_runtime,
+        )
+        from src.settings.types import SettingsSchema
+
+        # warning-only (enabled, not failIfUnavailable) must NOT refuse to start
+        warn = SettingsSchema.from_dict({"sandbox": {"enabled": True}})
+        monkeypatch.setattr("src.settings.settings.get_settings", lambda *a, **k: warn)
+
+        sess = _AgentSession(
+            session_id="s2", cwd=str(tmp_path),
+            config=AgentServerConfig(provider_name="definitely-not-a-provider", single_session=True),
+            loop=MagicMock(), out_queue=MagicMock(),
+        )
+        _build_runtime(sess, None)
+        # it may fail for the unknown provider, but NOT with a sandbox gate
+        assert sess.init_error is None or "sandbox" not in sess.init_error.lower()
+
+
+class TestSkillShellFailsClosed:
+    """minor #4: a skill/slash `!`-embedded shell runs through _bash_call, so
+    the hard gate refuses it too (fail-closed)."""
+
+    def test_skill_shell_refused_under_hard_gate(self, monkeypatch, tmp_path):
+        from src.settings.types import SettingsSchema
+        from src.tool_system.context import ToolContext, ToolUseOptions
+        from src.tool_system.errors import ToolPermissionError
+        from src.tool_system.tools.bash.bash_tool import _bash_call
+
+        hard = SettingsSchema.from_dict({"sandbox": {"enabled": True, "failIfUnavailable": True}})
+        monkeypatch.setattr("src.settings.settings.get_settings", lambda *a, **k: hard)
+        ctx = ToolContext(workspace_root=tmp_path)
+        ctx.options = ToolUseOptions(tools=[])
+        # the skill !-shell path is just _bash_call with a command — must refuse
+        with pytest.raises(ToolPermissionError):
+            _bash_call({"command": "echo from-skill-shell"}, ctx)
+
+
+class TestEnabledPlatforms:
+    """minor #3: TS enabledPlatforms — sandbox is disabled (no gate/warning)
+    on a platform not in the list. The port was more aggressive; now faithful."""
+
+    def test_other_platform_disables_hard_gate(self, monkeypatch):
+        from src.permissions import sandbox_guard
+        from src.settings.types import SettingsSchema
+
+        # a hard-gate config restricted to a platform we're NOT on → no gate
+        monkeypatch.setattr(sandbox_guard, "_current_platform", lambda: "linux")
+        s = SettingsSchema.from_dict({"sandbox": {
+            "enabled": True, "failIfUnavailable": True, "enabledPlatforms": ["macos"],
+        }})
+        assert sandbox_guard.sandbox_hard_gate_error(s) is None
+        assert sandbox_guard.sandbox_unsandboxed_warning(s) is None
+
+    def test_current_platform_listed_still_gates(self, monkeypatch):
+        from src.permissions import sandbox_guard
+        from src.settings.types import SettingsSchema
+
+        monkeypatch.setattr(sandbox_guard, "_current_platform", lambda: "macos")
+        s = SettingsSchema.from_dict({"sandbox": {
+            "enabled": True, "failIfUnavailable": True, "enabledPlatforms": ["macos"],
+        }})
+        assert sandbox_guard.sandbox_hard_gate_error(s) is not None
+
+    def test_empty_platforms_means_all(self, monkeypatch):
+        from src.permissions import sandbox_guard
+        from src.settings.types import SettingsSchema
+
+        monkeypatch.setattr(sandbox_guard, "_current_platform", lambda: "windows")
+        s = SettingsSchema.from_dict({"sandbox": {"enabled": True, "failIfUnavailable": True}})
+        assert sandbox_guard.sandbox_hard_gate_error(s) is not None

--- a/tests/test_sandbox_guard.py
+++ b/tests/test_sandbox_guard.py
@@ -206,6 +206,63 @@ class TestHardGateRefusesToStart:
         # it may fail for the unknown provider, but NOT with a sandbox gate
         assert sess.init_error is None or "sandbox" not in sess.init_error.lower()
 
+    def test_bg_run_control_request_refused_under_init_error(self, monkeypatch, tmp_path):
+        """critic C8 re-review: /bg is a CONTROL request that bypasses
+        _build_runtime + the turn path, so a refused-to-start session (init_error
+        set) must REFUSE bg_run — else it spawns an unsandboxed subprocess. Drive
+        the real _handle_control_request and assert no subprocess + the gate
+        error reply."""
+        import asyncio
+        import subprocess
+        from unittest.mock import MagicMock
+
+        from src.server.agent_server import AgentServerConfig, _AgentSession
+
+        sess = _AgentSession(
+            session_id="s1", cwd=str(tmp_path),
+            config=AgentServerConfig(provider_name="anthropic", single_session=True),
+            loop=MagicMock(), out_queue=MagicMock(),
+        )
+        sess.init_error = "sandbox hard gate: refusing to start"
+
+        replies = []
+        monkeypatch.setattr(sess, "_reply", lambda rid, payload: replies.append((rid, payload)))
+        # if the guard fails, _do_bgtask would run — trip both it and Popen
+        monkeypatch.setattr(subprocess, "Popen",
+                            lambda *a, **k: (_ for _ in ()).throw(
+                                AssertionError("subprocess spawned under init_error — /bg leaked!")))
+        monkeypatch.setattr(sess, "_do_bgtask",
+                            lambda *a, **k: (_ for _ in ()).throw(
+                                AssertionError("_do_bgtask reached under init_error")))
+
+        asyncio.run(sess._handle_control_request({
+            "request_id": "r1",
+            "request": {"subtype": "bg_run", "command": "echo leaked"},
+        }))
+        assert replies and replies[0][0] == "r1"
+        assert replies[0][1]["ok"] is False
+        assert "sandbox" in replies[0][1]["error"].lower()
+
+    def test_interrupt_still_works_under_init_error(self, monkeypatch, tmp_path):
+        # interrupt is exempt (benign abort) — must NOT be refused with the gate error
+        import asyncio
+        from unittest.mock import MagicMock
+
+        from src.server.agent_server import AgentServerConfig, _AgentSession
+
+        sess = _AgentSession(
+            session_id="s2", cwd=str(tmp_path),
+            config=AgentServerConfig(provider_name="anthropic", single_session=True),
+            loop=MagicMock(), out_queue=MagicMock(),
+        )
+        sess.init_error = "sandbox hard gate"
+        replies = []
+        monkeypatch.setattr(sess, "_reply", lambda rid, payload: replies.append((rid, payload)))
+        asyncio.run(sess._handle_control_request({
+            "request_id": "r2", "request": {"subtype": "interrupt"},
+        }))
+        assert not any("sandbox" in str(r[1].get("error", "")).lower() for r in replies)
+
 
 class TestSkillShellFailsClosed:
     """minor #4: a skill/slash `!`-embedded shell runs through _bash_call, so

--- a/tests/test_sandbox_guard.py
+++ b/tests/test_sandbox_guard.py
@@ -132,3 +132,22 @@ class TestBashHardGateRefusal:
         res = _bash_call({"command": "echo sandbox-ok"}, ctx)
         assert res.is_error is False
         assert "sandbox-ok" in res.output["stdout"]  # ran unsandboxed, with the warning
+
+
+class TestBackgroundBashAlsoGuarded:
+    """The hard gate must cover BACKGROUND bash too — else it's a false gate.
+    Both fg + bg flow through _bash_call; the guard precedes the
+    run_in_background branch."""
+
+    def test_background_bash_refused_under_hard_gate(self, monkeypatch, tmp_path):
+        from src.settings.types import SettingsSchema
+        from src.tool_system.context import ToolContext, ToolUseOptions
+        from src.tool_system.errors import ToolPermissionError
+        from src.tool_system.tools.bash.bash_tool import _bash_call
+
+        hard = SettingsSchema.from_dict({"sandbox": {"enabled": True, "failIfUnavailable": True}})
+        monkeypatch.setattr("src.settings.settings.get_settings", lambda *a, **k: hard)
+        ctx = ToolContext(workspace_root=tmp_path)
+        ctx.options = ToolUseOptions(tools=[])
+        with pytest.raises(ToolPermissionError):
+            _bash_call({"command": "sleep 100", "run_in_background": True}, ctx)

--- a/tests/test_sandbox_guard.py
+++ b/tests/test_sandbox_guard.py
@@ -1,0 +1,134 @@
+"""Chapter C8 — sandbox guard (the silent-unsandboxed footgun).
+
+The port has no sandbox ENFORCEMENT and previously didn't even PARSE
+settings.sandbox — a user's sandbox config was silently dropped AND unenforced
+(false sense of security). These pin: the settings parse (camelCase + unknown-
+key passthrough), and the guard mapping onto TS's documented sandbox-unavailable
+path (sandboxTypes.ts:96-103) — hard-gate refusal when failIfUnavailable, warn
+otherwise, silent when off.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from src.permissions.sandbox_guard import (
+    is_sandbox_requested,
+    sandbox_hard_gate_error,
+    sandbox_unsandboxed_warning,
+    warn_if_unsandboxed_once,
+)
+from src.settings.types import SandboxSettings, SettingsSchema
+from src.settings.validation import validate_settings
+
+
+class TestParse:
+    def test_camelcase_object_parsed_not_dropped(self):
+        s = SettingsSchema.from_dict({"sandbox": {
+            "enabled": True,
+            "failIfUnavailable": True,
+            "autoAllowBashIfSandboxed": False,
+            "allowUnsandboxedCommands": False,
+            "excludedCommands": ["git status", "ls"],
+        }})
+        assert isinstance(s.sandbox, SandboxSettings)
+        assert s.sandbox.enabled and s.sandbox.fail_if_unavailable
+        assert s.sandbox.auto_allow_bash_if_sandboxed is False
+        assert s.sandbox.allow_unsandboxed_commands is False
+        assert s.sandbox.excluded_commands == ["git status", "ls"]
+
+    def test_unknown_enforcement_keys_ignored(self):
+        # TS schema is .passthrough() with network/filesystem/ignoreViolations
+        # etc. the port doesn't act on — must not crash the load.
+        s = SettingsSchema.from_dict({"sandbox": {
+            "enabled": True, "network": {"allowAll": True}, "ripgrep": {"command": "rg"},
+        }})
+        assert s.sandbox.enabled
+
+    def test_absent_sandbox_is_none(self):
+        assert SettingsSchema.from_dict({}).sandbox is None
+
+
+class TestGuardMapping:
+    def _s(self, **sb):
+        return SettingsSchema.from_dict({"sandbox": sb}) if sb else SettingsSchema.from_dict({})
+
+    def test_hard_gate_when_enabled_and_fail_if_unavailable(self):
+        s = self._s(enabled=True, failIfUnavailable=True)
+        assert sandbox_hard_gate_error(s) is not None
+        assert sandbox_unsandboxed_warning(s) is None  # gate, not warning
+        assert "hard gate" in sandbox_hard_gate_error(s).lower()
+
+    def test_warning_when_enabled_only(self):
+        s = self._s(enabled=True)
+        assert sandbox_hard_gate_error(s) is None
+        assert "unsandboxed" in sandbox_unsandboxed_warning(s).lower()
+
+    def test_silent_when_disabled(self):
+        s = self._s(enabled=False, failIfUnavailable=True)  # enabled gates both
+        assert sandbox_hard_gate_error(s) is None
+        assert sandbox_unsandboxed_warning(s) is None
+
+    def test_silent_when_absent(self):
+        s = self._s()
+        assert not is_sandbox_requested(s)
+        assert sandbox_hard_gate_error(s) is None
+        assert sandbox_unsandboxed_warning(s) is None
+
+
+class TestValidateSettings:
+    def test_hard_gate_is_a_validation_error(self):
+        s = SettingsSchema.from_dict({"sandbox": {"enabled": True, "failIfUnavailable": True}})
+        assert any(e.field == "sandbox" for e in validate_settings(s))
+
+    def test_warning_only_does_not_invalidate(self):
+        # enabled without failIfUnavailable must still LOAD (TS runs with a warning)
+        s = SettingsSchema.from_dict({"sandbox": {"enabled": True}})
+        assert not any(e.field == "sandbox" for e in validate_settings(s))
+
+
+class TestWarnOnce:
+    def test_warns_once(self, caplog):
+        import src.permissions.sandbox_guard as mod
+
+        mod._warned_once = False
+        s = SettingsSchema.from_dict({"sandbox": {"enabled": True}})
+        with caplog.at_level(logging.WARNING, logger="src.permissions.sandbox_guard"):
+            warn_if_unsandboxed_once(s)
+            warn_if_unsandboxed_once(s)
+        assert sum("UNSANDBOXED" in m for m in caplog.messages) == 1
+
+
+class TestBashHardGateRefusal:
+    def test_bash_refuses_under_hard_gate(self, monkeypatch, tmp_path):
+        # the guaranteed-reached path: a hard-gate config makes _bash_call REFUSE
+        from src.settings.types import SettingsSchema
+        from src.tool_system.errors import ToolPermissionError
+
+        hard = SettingsSchema.from_dict({"sandbox": {"enabled": True, "failIfUnavailable": True}})
+        monkeypatch.setattr("src.settings.settings.get_settings", lambda *a, **k: hard)
+
+        from src.tool_system.tools.bash.bash_tool import _bash_call
+        from src.tool_system.context import ToolContext, ToolUseOptions
+
+        ctx = ToolContext(workspace_root=tmp_path)
+        ctx.options = ToolUseOptions(tools=[])
+        with pytest.raises(ToolPermissionError, match="hard gate|unsandboxed"):
+            _bash_call({"command": "echo hi"}, ctx)
+
+    def test_bash_runs_with_warning_when_not_hard_gate(self, monkeypatch, tmp_path):
+        import src.permissions.sandbox_guard as mod
+
+        mod._warned_once = False
+        warn_only = SettingsSchema.from_dict({"sandbox": {"enabled": True}})
+        monkeypatch.setattr("src.settings.settings.get_settings", lambda *a, **k: warn_only)
+
+        from src.tool_system.tools.bash.bash_tool import _bash_call
+        from src.tool_system.context import ToolContext, ToolUseOptions
+
+        ctx = ToolContext(workspace_root=tmp_path)
+        ctx.options = ToolUseOptions(tools=[])
+        res = _bash_call({"command": "echo sandbox-ok"}, ctx)
+        assert res.is_error is False
+        assert "sandbox-ok" in res.output["stdout"]  # ran unsandboxed, with the warning


### PR DESCRIPTION
## Summary

Chapter **C8 — sandbox unsandboxed-guard** (the utils/-round deferred security chapter). The port has NO sandbox enforcement (TS wraps external `@anthropic-ai/sandbox-runtime`) and `SettingsSchema` had no `sandbox` field — so a user's `settings.sandbox` was silently DROPPED at parse AND unenforced: a false sense of security. This ships the honest guard (enforcement itself remains a separate scoped chapter, critic-endorsed).

The guard maps the port's permanently-unavailable sandbox onto TS's OWN documented sandbox-unavailable path (`entrypoints/sandboxTypes.ts:96-103`):
- `sandbox.enabled` + `failIfUnavailable` → **HARD GATE: refuse-to-start** (TS `print.ts:600`/`REPL.tsx:2362` "refusing to start without a working sandbox"). Enforced in `agent_server._build_runtime` (`sess.init_error` → session refuses to start, so MCP + hooks never run), in `_handle_control_request` (a refused session rejects `bg_run`/`bg_agent` + every control request except `interrupt` — `/bg` is a control request that bypasses `_build_runtime`), and at `_bash_call` as a CLI backstop.
- `enabled` only → warn once + run unsandboxed (TS's documented fallback; BashTool-scoped, faithful).
- `enabledPlatforms` honored — on a platform not listed, sandbox is disabled (no gate/warning).

## Critic rounds (3)
- R1: pre-addressed the false-hard-gate probe (guard covers fg+bg bash, BashTool-scoped).
- R2 REVISE→fix: MAJOR — `failIfUnavailable` is a refuse-to-START, not per-bash; moved to `_build_runtime`. + `enabledPlatforms`.
- R3 REVISE→fix: the `/bg` control-path (bypasses `_build_runtime`) — guarded `_handle_control_request`.
- **APPROVE** — "/bg leak closed... verified end-to-end... ran it myself: 21/21 sandbox + 111 control/bgtask tests, no regressions."

## Verification
`tests/test_sandbox_guard.py` (21): parse (camelCase + passthrough), the 3-way guard mapping, refuse-to-start via real `_build_runtime`, the real `bg_run` control request refused (Popen + `_do_bgtask` tripwired) + interrupt exempt, skill-shell fails closed, enabledPlatforms. Full suite confirmed on merged main (below).

Deferred (critic-endorsed): native `sandbox-exec`/`bwrap` enforcement — its own scoped chapter (a half-working sandbox is worse than an honest refusal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
