### PR TITLE
feat(hooks): MCP elicitation hooks — the 3-event unit (C3)

### DIFF
--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -1029,3 +1029,182 @@ async def execute_task_completed_hooks(
     ):
         yield result
 
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MCP elicitation hooks (C3) — the 3-event UNIT.
+#
+# Port of executeElicitationHooks / executeElicitationResultHooks /
+# executeNotificationHooks (utils/hooks.ts:4623-4810) + the
+# elicitationHandler.ts:220-313 wrapping. These fire around an MCP server's
+# elicitation request: an Elicitation hook BEFORE (may provide a response or
+# block), an ElicitationResult hook AFTER (may OVERRIDE the user's response or
+# block — shipping only the notification would be a correctness trap), and a
+# Notification hook for observability. Matched on the server name.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _parse_elicitation_hook_output(
+    result: "HookResult", expected_event: str
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Mirror ``parseElicitationHookOutput`` (utils/hooks.ts:4623): return
+    ``(response, blocking_error)`` from one hook's result.
+
+    exit 2 → blocking; JSON ``decision:'block'`` → blocking; otherwise
+    ``hookSpecificOutput.{hookEventName==expected, action, content}`` → response
+    (and ``action=='decline'`` ALSO yields a blocking_error, matching TS)."""
+    # exit code 2 = blocking (same convention as the tool-hook path)
+    if result.exit_code == 2:
+        return None, {
+            "blockingError": (result.stdout or "").strip() or "Elicitation blocked by hook",
+            "command": result.command,
+        }
+    out = (result.stdout or "").strip()
+    if not out or not out.startswith("{"):
+        return None, None
+    try:
+        parsed = json.loads(out)
+    except (json.JSONDecodeError, ValueError):
+        return None, None
+    if not isinstance(parsed, dict):
+        return None, None
+    if parsed.get("decision") == "block":
+        return None, {
+            "blockingError": parsed.get("reason") or "Elicitation blocked by hook",
+            "command": result.command,
+        }
+    hso = parsed.get("hookSpecificOutput")
+    if not isinstance(hso, dict) or hso.get("hookEventName") != expected_event:
+        return None, None
+    action = hso.get("action")
+    if not action:
+        return None, None
+    response = {"action": action, "content": hso.get("content")}
+    blocking = None
+    if action == "decline":
+        default = (
+            "Elicitation denied by hook"
+            if expected_event == "Elicitation"
+            else "Elicitation result blocked by hook"
+        )
+        blocking = {"blockingError": parsed.get("reason") or default, "command": result.command}
+    return response, blocking
+
+
+async def _run_elicitation_event_hooks(
+    event: str,
+    server_name: str,
+    stdin_data: dict[str, Any],
+    tool_use_context: Any,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Run all hooks matching ``event`` + ``server_name`` (trust-gated,
+    snapshot-sourced — same machinery as the tool-hook path) and fold their
+    parsed outputs: the LAST non-empty response wins and any blocking error is
+    retained (TS loops with ``response`` overwrite + ``blockingError`` keep)."""
+    trust_skip = should_skip_hook_due_to_trust(tool_use_context)
+    hooks = _get_hooks_from_snapshot(tool_use_context)
+    event_hooks = hooks.get(event, [])
+    if trust_skip:
+        event_hooks = [h for h in event_hooks if h.source.is_policy]
+    abort_signal = None
+    abort_ctrl = getattr(tool_use_context, "abort_controller", None)
+    if abort_ctrl:
+        abort_signal = abort_ctrl.signal
+
+    response: dict[str, Any] | None = None
+    blocking: dict[str, Any] | None = None
+    for hook in event_hooks:
+        # matcher matches the SERVER NAME (TS matchQuery: serverName)
+        if server_name and not _matches_tool(hook.matcher, server_name):
+            continue
+        result = await _execute_command_hook(
+            hook, {**stdin_data, "hook_event": event},
+            abort_signal=abort_signal, tool_use_context=tool_use_context,
+        )
+        r, b = _parse_elicitation_hook_output(result, event)
+        if b is not None:
+            blocking = b
+        if r is not None:
+            response = r
+    return response, blocking
+
+
+async def execute_elicitation_hooks(
+    server_name: str,
+    message: str,
+    tool_use_context: Any,
+    *,
+    requested_schema: dict[str, Any] | None = None,
+    mode: str | None = None,
+    url: str | None = None,
+    elicitation_id: str | None = None,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """BEFORE the user prompt (executeElicitationHooks). Returns
+    ``(response, blocking_error)``: blocking → decline; response →
+    short-circuit the prompt with ``{action, content}``."""
+    stdin_data = {
+        "mcp_server_name": server_name,
+        "message": message,
+        "mode": mode,
+        "url": url,
+        "elicitation_id": elicitation_id,
+        "requested_schema": requested_schema,
+    }
+    return await _run_elicitation_event_hooks(
+        "Elicitation", server_name, stdin_data, tool_use_context
+    )
+
+
+async def execute_elicitation_result_hooks(
+    server_name: str,
+    action: str,
+    content: dict[str, Any] | None,
+    tool_use_context: Any,
+    *,
+    mode: str | None = None,
+    elicitation_id: str | None = None,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """AFTER the user responds (executeElicitationResultHooks). The response
+    may OVERRIDE the user's ``action``/``content``; blocking → decline."""
+    stdin_data = {
+        "mcp_server_name": server_name,
+        "action": action,
+        "content": content,
+        "mode": mode,
+        "elicitation_id": elicitation_id,
+    }
+    return await _run_elicitation_event_hooks(
+        "ElicitationResult", server_name, stdin_data, tool_use_context
+    )
+
+
+async def execute_notification_hooks(
+    message: str,
+    notification_type: str,
+    tool_use_context: Any,
+    *,
+    title: str | None = None,
+) -> None:
+    """Fire-and-forget Notification hooks (observability) matched on
+    ``notification_type`` (TS matchQuery: notificationType). Output is
+    ignored — a notification hook cannot change control flow."""
+    trust_skip = should_skip_hook_due_to_trust(tool_use_context)
+    hooks = _get_hooks_from_snapshot(tool_use_context)
+    event_hooks = hooks.get("Notification", [])
+    if trust_skip:
+        event_hooks = [h for h in event_hooks if h.source.is_policy]
+    abort_signal = None
+    abort_ctrl = getattr(tool_use_context, "abort_controller", None)
+    if abort_ctrl:
+        abort_signal = abort_ctrl.signal
+    stdin_data = {"message": message, "notification_type": notification_type, "title": title}
+    for hook in event_hooks:
+        if notification_type and not _matches_tool(hook.matcher, notification_type):
+            continue
+        try:
+            await _execute_command_hook(
+                hook, {**stdin_data, "hook_event": "Notification"},
+                abort_signal=abort_signal, tool_use_context=tool_use_context,
+            )
+        except Exception:  # noqa: BLE001 — observability must not break the flow
+            logger.debug("[hooks] notification hook failed", exc_info=True)

--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -317,6 +317,15 @@ def _matches_if_condition(
 def _matches_tool(matcher: str | None, tool_name: str) -> bool:
     if matcher is None:
         return True
+    # A non-string matcher (e.g. a hand-edited settings.json with
+    # ``"matcher": 0`` — the parser stores it verbatim, config_manager.py:63)
+    # must not crash the match loop: the .endswith/.startswith calls below
+    # would raise AttributeError, aborting ALL hooks for the event and
+    # (on the elicitation decision path) silently dropping a block/override —
+    # a guardrail fail-open (critic C3). Treat a malformed matcher as
+    # NON-matching (not match-all), isolating the bad hook to itself.
+    if not isinstance(matcher, str):
+        return False
     if matcher == tool_name:
         return True
     if matcher.endswith("*"):

--- a/src/hooks/hook_executor.py
+++ b/src/hooks/hook_executor.py
@@ -1068,6 +1068,11 @@ def _parse_elicitation_hook_output(
         return None, None
     if not isinstance(parsed, dict):
         return None, None
+    # Async hook output (TS isAsyncHookJSONOutput, utils/hooks.ts:4652-4654) is
+    # ignored for elicitation — an {"async": true, ...} payload carries no
+    # synchronous decision.
+    if parsed.get("async") is True:
+        return None, None
     if parsed.get("decision") == "block":
         return None, {
             "blockingError": parsed.get("reason") or "Elicitation blocked by hook",
@@ -1187,24 +1192,35 @@ async def execute_notification_hooks(
 ) -> None:
     """Fire-and-forget Notification hooks (observability) matched on
     ``notification_type`` (TS matchQuery: notificationType). Output is
-    ignored — a notification hook cannot change control flow."""
-    trust_skip = should_skip_hook_due_to_trust(tool_use_context)
-    hooks = _get_hooks_from_snapshot(tool_use_context)
-    event_hooks = hooks.get("Notification", [])
-    if trust_skip:
-        event_hooks = [h for h in event_hooks if h.source.is_policy]
-    abort_signal = None
-    abort_ctrl = getattr(tool_use_context, "abort_controller", None)
-    if abort_ctrl:
-        abort_signal = abort_ctrl.signal
-    stdin_data = {"message": message, "notification_type": notification_type, "title": title}
-    for hook in event_hooks:
-        if notification_type and not _matches_tool(hook.matcher, notification_type):
-            continue
-        try:
-            await _execute_command_hook(
-                hook, {**stdin_data, "hook_event": "Notification"},
-                abort_signal=abort_signal, tool_use_context=tool_use_context,
-            )
-        except Exception:  # noqa: BLE001 — observability must not break the flow
-            logger.debug("[hooks] notification hook failed", exc_info=True)
+    ignored — a notification hook cannot change control flow.
+
+    This is ``-> None`` fire-and-forget (TS ``void executeNotificationHooks``,
+    elicitationHandler.ts:283/298/307): the ENTIRE body is guarded so it can
+    NEVER raise. Callers ``await`` it while computing a return value (e.g.
+    ``_finish_elicitation``); if a raise here propagated, it would discard a
+    block/override decision — the exact guardrail bypass SERVICES-3 flagged
+    (critic C3-MAJOR: a malformed non-string Notification matcher would raise
+    AttributeError in ``_matches_tool``)."""
+    try:
+        trust_skip = should_skip_hook_due_to_trust(tool_use_context)
+        hooks = _get_hooks_from_snapshot(tool_use_context)
+        event_hooks = hooks.get("Notification", [])
+        if trust_skip:
+            event_hooks = [h for h in event_hooks if h.source.is_policy]
+        abort_signal = None
+        abort_ctrl = getattr(tool_use_context, "abort_controller", None)
+        if abort_ctrl:
+            abort_signal = abort_ctrl.signal
+        stdin_data = {"message": message, "notification_type": notification_type, "title": title}
+        for hook in event_hooks:
+            try:
+                if notification_type and not _matches_tool(hook.matcher, notification_type):
+                    continue
+                await _execute_command_hook(
+                    hook, {**stdin_data, "hook_event": "Notification"},
+                    abort_signal=abort_signal, tool_use_context=tool_use_context,
+                )
+            except Exception:  # noqa: BLE001 — one bad hook must not stop the rest
+                logger.debug("[hooks] notification hook failed", exc_info=True)
+    except Exception:  # noqa: BLE001 — observability must NEVER break the flow
+        logger.debug("[hooks] notification dispatch failed", exc_info=True)

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -2332,6 +2332,38 @@ def _make_elicitation_handler(sess: "_AgentSession") -> Any:
     """
 
     async def _elicit(params: dict[str, Any]) -> dict[str, Any]:
+        # MCP elicitation hooks (C3): fire the 3-event unit around the prompt.
+        # An Elicitation hook may provide a response (short-circuit) or block
+        # (→ decline); an ElicitationResult hook may OVERRIDE the response or
+        # block; a Notification hook records the final action. server_name is
+        # threaded in by McpClient._run_elicitation.
+        ctx = getattr(sess, "tool_context", None)
+        server_name = params.get("serverName") or ""
+        mode = params.get("mode")
+        elicitation_id = params.get("elicitationId")
+
+        if ctx is not None and server_name:
+            try:
+                from src.hooks.hook_executor import execute_elicitation_hooks
+
+                resp, block = await execute_elicitation_hooks(
+                    server_name, params.get("message", ""), ctx,
+                    requested_schema=params.get("requestedSchema"),
+                    mode=mode, url=params.get("url"),
+                    elicitation_id=elicitation_id,
+                )
+                if block is not None:
+                    return {"action": "decline"}
+                if resp is not None:
+                    # short-circuit: the Elicitation hook itself answered.
+                    # TS returns this DIRECTLY (elicitationHandler.ts:96-107 —
+                    # `if (hookResponse) return hookResponse`), WITHOUT running
+                    # the result hooks or the notification (those run only on
+                    # the real user-prompt path below). Return as-is.
+                    return {"action": resp["action"], "content": resp.get("content")}
+            except Exception:  # noqa: BLE001 — a hook failure must not brick elicitation
+                logger.debug("[hooks] elicitation pre-hook failed", exc_info=True)
+
         request_id = str(_uuid.uuid4())
         pending = _Pending(event=threading.Event())
         with sess._lock:
@@ -2349,9 +2381,45 @@ def _make_elicitation_handler(sess: "_AgentSession") -> Any:
         finally:
             with sess._lock:
                 sess._pending.pop(request_id, None)
-        if not got:
-            return {"action": "cancel"}
-        return pending.reply or {"action": "decline"}
+        raw = {"action": "cancel"} if not got else (pending.reply or {"action": "decline"})
+        if ctx is not None and server_name:
+            return await _finish_elicitation(raw, ctx, server_name, mode, elicitation_id)
+        return raw
+
+    async def _finish_elicitation(
+        raw: dict[str, Any], ctx: Any, server_name: str,
+        mode: str | None, elicitation_id: str | None,
+    ) -> dict[str, Any]:
+        """Run ElicitationResult hooks (may override/block) + fire the
+        elicitation_response Notification (port of runElicitationResultHooks)."""
+        try:
+            from src.hooks.hook_executor import (
+                execute_elicitation_result_hooks,
+                execute_notification_hooks,
+            )
+
+            resp, block = await execute_elicitation_result_hooks(
+                server_name, raw.get("action", "decline"), raw.get("content"),
+                ctx, mode=mode, elicitation_id=elicitation_id,
+            )
+            if block is not None:
+                await execute_notification_hooks(
+                    f'Elicitation response for server "{server_name}": decline',
+                    "elicitation_response", ctx,
+                )
+                return {"action": "decline"}
+            final = (
+                {"action": resp["action"], "content": resp.get("content") if resp.get("content") is not None else raw.get("content")}
+                if resp is not None else raw
+            )
+            await execute_notification_hooks(
+                f'Elicitation response for server "{server_name}": {final.get("action")}',
+                "elicitation_response", ctx,
+            )
+            return final
+        except Exception:  # noqa: BLE001
+            logger.debug("[hooks] elicitation result-hook failed", exc_info=True)
+            return raw
 
     return _elicit
 

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -2360,7 +2360,7 @@ def _make_elicitation_handler(sess: "_AgentSession") -> Any:
                     # `if (hookResponse) return hookResponse`), WITHOUT running
                     # the result hooks or the notification (those run only on
                     # the real user-prompt path below). Return as-is.
-                    return {"action": resp["action"], "content": resp.get("content")}
+                    return _elicit_result(resp["action"], resp.get("content"))
             except Exception:  # noqa: BLE001 — a hook failure must not brick elicitation
                 logger.debug("[hooks] elicitation pre-hook failed", exc_info=True)
 
@@ -2386,40 +2386,53 @@ def _make_elicitation_handler(sess: "_AgentSession") -> Any:
             return await _finish_elicitation(raw, ctx, server_name, mode, elicitation_id)
         return raw
 
+    def _elicit_result(action: str, content: Any) -> dict[str, Any]:
+        # Omit ``content`` when None (TS emits ``undefined``, which
+        # JSON.stringify drops — a strict MCP server validating ElicitResult
+        # against "object or absent" could reject an explicit ``null``).
+        return {"action": action} if content is None else {"action": action, "content": content}
+
     async def _finish_elicitation(
         raw: dict[str, Any], ctx: Any, server_name: str,
         mode: str | None, elicitation_id: str | None,
     ) -> dict[str, Any]:
-        """Run ElicitationResult hooks (may override/block) + fire the
-        elicitation_response Notification (port of runElicitationResultHooks)."""
-        try:
-            from src.hooks.hook_executor import (
-                execute_elicitation_result_hooks,
-                execute_notification_hooks,
-            )
+        """Run ElicitationResult hooks (may override/block), then fire the
+        elicitation_response Notification (port of runElicitationResultHooks).
 
+        The return value is computed inside the try (a result-hook raise leaves
+        ``final = raw``) but the notification fires OUTSIDE it: TS fires it
+        fire-and-forget (``void``) so it can NEVER alter the ElicitResult
+        (critic C3-MAJOR). It fires on every path — block, override,
+        passthrough, and the result-hook error path (TS "even on error",
+        elicitationHandler.ts:304-310 → MINOR-1). ``execute_notification_hooks``
+        itself never raises."""
+        from src.hooks.hook_executor import (
+            execute_elicitation_result_hooks,
+            execute_notification_hooks,
+        )
+
+        final = raw
+        try:
             resp, block = await execute_elicitation_result_hooks(
                 server_name, raw.get("action", "decline"), raw.get("content"),
                 ctx, mode=mode, elicitation_id=elicitation_id,
             )
             if block is not None:
-                await execute_notification_hooks(
-                    f'Elicitation response for server "{server_name}": decline',
-                    "elicitation_response", ctx,
+                final = {"action": "decline"}
+            elif resp is not None:
+                _c = resp.get("content")
+                final = _elicit_result(
+                    resp["action"], _c if _c is not None else raw.get("content")
                 )
-                return {"action": "decline"}
-            final = (
-                {"action": resp["action"], "content": resp.get("content") if resp.get("content") is not None else raw.get("content")}
-                if resp is not None else raw
-            )
-            await execute_notification_hooks(
-                f'Elicitation response for server "{server_name}": {final.get("action")}',
-                "elicitation_response", ctx,
-            )
-            return final
-        except Exception:  # noqa: BLE001
+        except Exception:  # noqa: BLE001 — a result-hook failure falls back to raw
             logger.debug("[hooks] elicitation result-hook failed", exc_info=True)
-            return raw
+            final = raw
+        # Fire-and-forget observability — never alters ``final``.
+        await execute_notification_hooks(
+            f'Elicitation response for server "{server_name}": {final.get("action")}',
+            "elicitation_response", ctx,
+        )
+        return final
 
     return _elicit
 

--- a/src/services/mcp/client.py
+++ b/src/services/mcp/client.py
@@ -449,7 +449,11 @@ class McpClient:
         if handler is None:
             return {"action": "decline"}
         try:
-            res = await handler(params)
+            # Thread the server name to the handler (C3): the MCP elicitation
+            # params don't carry it, but the elicitation hooks match on and
+            # report the server name (TS matchQuery: serverName).
+            handler_params = {**params, "serverName": self._name} if self._name else params
+            res = await handler(handler_params)
             return res if isinstance(res, dict) and res.get("action") else {"action": "decline"}
         except Exception:
             return {"action": "decline"}

--- a/tests/test_mcp_elicitation_hooks.py
+++ b/tests/test_mcp_elicitation_hooks.py
@@ -1,0 +1,214 @@
+"""Chapter C3 — MCP elicitation hooks (the 3-event UNIT).
+
+Port of executeElicitationHooks / executeElicitationResultHooks /
+executeNotificationHooks + the elicitationHandler.ts wrapping. The critical
+correctness property (why the 3 must ship together): the ElicitationResult
+hook can OVERRIDE the user's response — shipping only the notification would
+silently drop that. These drive the executors with real hook commands (echo
+JSON), matched on server name, and pin the override/short-circuit/block flow.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import shlex
+
+import pytest
+
+from src.hooks.hook_executor import (
+    _parse_elicitation_hook_output,
+    execute_elicitation_hooks,
+    execute_elicitation_result_hooks,
+    execute_notification_hooks,
+)
+from src.hooks.hook_types import HookConfig, HookSource
+
+
+def _hook(payload_json: str, matcher: str | None = None) -> HookConfig:
+    return HookConfig(type="command", command=f"echo {shlex.quote(payload_json)}",
+                      source=HookSource.USER_SETTINGS, matcher=matcher)
+
+
+def _exit2_hook(matcher: str | None = None) -> HookConfig:
+    # exit code 2 = blocking
+    return HookConfig(type="command", command="exit 2",
+                      source=HookSource.USER_SETTINGS, matcher=matcher)
+
+
+class _Ctx:
+    """A minimal tool_use_context whose hook snapshot is these configs."""
+    def __init__(self, hooks_by_event):
+        self._hooks = hooks_by_event
+        self.abort_controller = None
+
+
+@pytest.fixture(autouse=True)
+def _snapshot(monkeypatch):
+    # route _get_hooks_from_snapshot to the ctx's dict, and disable the trust gate
+    monkeypatch.setattr(
+        "src.hooks.hook_executor._get_hooks_from_snapshot",
+        lambda ctx: getattr(ctx, "_hooks", {}),
+    )
+    monkeypatch.setattr(
+        "src.hooks.hook_executor.should_skip_hook_due_to_trust", lambda ctx: False
+    )
+
+
+def _elic(action, content=None):
+    return json.dumps({"hookSpecificOutput": {"hookEventName": "Elicitation",
+                       "action": action, **({"content": content} if content is not None else {})}})
+
+
+def _result(action, content=None):
+    return json.dumps({"hookSpecificOutput": {"hookEventName": "ElicitationResult",
+                       "action": action, **({"content": content} if content is not None else {})}})
+
+
+class TestParse:
+    def test_exit2_blocks(self):
+        from src.hooks.hook_executor import HookResult
+        r = HookResult(exit_code=2, stdout="nope", command="c")
+        resp, block = _parse_elicitation_hook_output(r, "Elicitation")
+        assert resp is None and block and "nope" in block["blockingError"]
+
+    def test_response_parsed(self):
+        from src.hooks.hook_executor import HookResult
+        r = HookResult(exit_code=0, stdout=_elic("accept", {"x": 1}), command="c")
+        resp, block = _parse_elicitation_hook_output(r, "Elicitation")
+        assert resp == {"action": "accept", "content": {"x": 1}} and block is None
+
+    def test_decline_action_also_blocks(self):
+        from src.hooks.hook_executor import HookResult
+        r = HookResult(exit_code=0, stdout=_elic("decline"), command="c")
+        resp, block = _parse_elicitation_hook_output(r, "Elicitation")
+        assert resp["action"] == "decline" and block is not None
+
+    def test_wrong_event_ignored(self):
+        from src.hooks.hook_executor import HookResult
+        r = HookResult(exit_code=0, stdout=_result("accept"), command="c")
+        resp, block = _parse_elicitation_hook_output(r, "Elicitation")  # expected Elicitation
+        assert resp is None and block is None
+
+
+class TestElicitationHook:
+    def test_response_short_circuits(self):
+        ctx = _Ctx({"Elicitation": [_hook(_elic("accept", {"y": 2}))]})
+        resp, block = asyncio.run(
+            execute_elicitation_hooks("srv", "msg", ctx))
+        assert resp == {"action": "accept", "content": {"y": 2}} and block is None
+
+    def test_block(self):
+        ctx = _Ctx({"Elicitation": [_exit2_hook()]})
+        resp, block = asyncio.run(execute_elicitation_hooks("srv", "msg", ctx))
+        assert block is not None
+
+    def test_matcher_scopes_by_server_name(self):
+        ctx = _Ctx({"Elicitation": [_hook(_elic("accept"), matcher="other-server")]})
+        resp, block = asyncio.run(execute_elicitation_hooks("srv", "msg", ctx))
+        assert resp is None and block is None  # matcher didn't match srv
+
+    def test_no_hooks_returns_none(self):
+        resp, block = asyncio.run(execute_elicitation_hooks("srv", "msg", _Ctx({})))
+        assert resp is None and block is None
+
+
+class TestElicitationResultHook:
+    def test_override(self):
+        ctx = _Ctx({"ElicitationResult": [_hook(_result("accept", {"overridden": True}))]})
+        resp, block = asyncio.run(
+            execute_elicitation_result_hooks("srv", "cancel", None, ctx))
+        assert resp == {"action": "accept", "content": {"overridden": True}}
+
+    def test_block(self):
+        ctx = _Ctx({"ElicitationResult": [_exit2_hook()]})
+        resp, block = asyncio.run(
+            execute_elicitation_result_hooks("srv", "accept", {"x": 1}, ctx))
+        assert block is not None
+
+
+class TestNotificationHook:
+    def test_fires_matching_notification_type(self, tmp_path):
+        marker = tmp_path / "fired"
+        cfg = HookConfig(type="command", command=f"touch {shlex.quote(str(marker))}",
+                         source=HookSource.USER_SETTINGS, matcher="elicitation_response")
+        ctx = _Ctx({"Notification": [cfg]})
+        asyncio.run(execute_notification_hooks("m", "elicitation_response", ctx))
+        assert marker.exists()
+
+    def test_type_matcher_scopes(self, tmp_path):
+        marker = tmp_path / "fired"
+        cfg = HookConfig(type="command", command=f"touch {shlex.quote(str(marker))}",
+                         source=HookSource.USER_SETTINGS, matcher="some_other_type")
+        ctx = _Ctx({"Notification": [cfg]})
+        asyncio.run(execute_notification_hooks("m", "elicitation_response", ctx))
+        assert not marker.exists()  # notification_type didn't match
+
+
+class TestElicitHandlerIntegration:
+    """Through the REAL _elicit handler (the live entry point) — a fake sess
+    that simulates the user round-trip so we prove the hooks flow end-to-end,
+    not just the executors in isolation."""
+
+    def _sess(self, hooks, *, user_reply=None):
+        import threading
+        import types
+
+        from src.server.agent_server import _Pending
+
+        emitted = []
+
+        sess = types.SimpleNamespace()
+        sess.tool_context = _Ctx(hooks)
+        sess._lock = threading.Lock()
+        sess._pending = {}
+        sess.config = types.SimpleNamespace(permission_timeout_s=5.0)
+
+        def _emit(msg):
+            emitted.append(msg)
+            # simulate the TUI answering: set the matching pending's reply+event
+            rid = msg.get("request_id")
+            p = sess._pending.get(rid)
+            if p is not None and user_reply is not None:
+                p.reply = user_reply
+                p.event.set()
+
+        sess._emit = _emit
+        sess._emitted = emitted
+        return sess
+
+    def test_before_hook_short_circuits_without_prompting(self, monkeypatch):
+        from src.server.agent_server import _make_elicitation_handler
+
+        # a before-hook that answers AND a result-hook that WOULD override:
+        # TS returns the before-hook response DIRECTLY (elicitationHandler.ts:
+        # 96-107), so the result-hook must NOT run on the short-circuit.
+        sess = self._sess({
+            "Elicitation": [_hook(_elic("accept", {"pre": True}))],
+            "ElicitationResult": [_hook(_result("accept", {"should_not_apply": True}))],
+        })
+        handler = _make_elicitation_handler(sess)
+        res = asyncio.run(handler({"serverName": "srv", "message": "m"}))
+        assert res == {"action": "accept", "content": {"pre": True}}  # NOT overridden
+        assert sess._emitted == []  # the user was NEVER prompted
+
+    def test_result_hook_overrides_user_reply(self, monkeypatch):
+        from src.server.agent_server import _make_elicitation_handler
+
+        # user says accept {u:1}; the ElicitationResult hook overrides to
+        # accept {overridden:1} — the override must win.
+        sess = self._sess(
+            {"ElicitationResult": [_hook(_result("accept", {"overridden": 1}))]},
+            user_reply={"action": "accept", "content": {"u": 1}},
+        )
+        handler = _make_elicitation_handler(sess)
+        res = asyncio.run(handler({"serverName": "srv", "message": "m"}))
+        assert sess._emitted, "the user SHOULD have been prompted"
+        assert res == {"action": "accept", "content": {"overridden": 1}}
+
+    def test_no_hooks_passes_user_reply_through(self):
+        from src.server.agent_server import _make_elicitation_handler
+
+        sess = self._sess({}, user_reply={"action": "accept", "content": {"u": 9}})
+        handler = _make_elicitation_handler(sess)
+        res = asyncio.run(handler({"serverName": "srv", "message": "m"}))
+        assert res == {"action": "accept", "content": {"u": 9}}

--- a/tests/test_mcp_elicitation_hooks.py
+++ b/tests/test_mcp_elicitation_hooks.py
@@ -212,3 +212,89 @@ class TestElicitHandlerIntegration:
         handler = _make_elicitation_handler(sess)
         res = asyncio.run(handler({"serverName": "srv", "message": "m"}))
         assert res == {"action": "accept", "content": {"u": 9}}
+
+
+class TestParseEdgeCases:
+    def test_decision_block_json_path(self):
+        from src.hooks.hook_executor import HookResult
+        r = HookResult(exit_code=0, stdout='{"decision": "block", "reason": "nope"}', command="c")
+        resp, block = _parse_elicitation_hook_output(r, "Elicitation")
+        assert resp is None and block and block["blockingError"] == "nope"
+
+    def test_async_output_ignored(self):
+        # MINOR-2: isAsyncHookJSONOutput — an async payload with an inline
+        # action is honored by neither TS nor the port.
+        from src.hooks.hook_executor import HookResult
+        r = HookResult(exit_code=0,
+                       stdout='{"async": true, "hookSpecificOutput": {"hookEventName": "Elicitation", "action": "accept"}}',
+                       command="c")
+        resp, block = _parse_elicitation_hook_output(r, "Elicitation")
+        assert resp is None and block is None
+
+
+class TestFinishElicitationThroughHandler:
+    """MINOR-3: the safety-critical paths through the REAL _elicit +
+    _finish_elicitation — block wins, content-fallback, and (the MAJOR) a
+    notification failure must NOT discard the block/override."""
+
+    def _sess(self, hooks, *, user_reply):
+        import threading
+        import types
+
+        sess = types.SimpleNamespace()
+        sess.tool_context = _Ctx(hooks)
+        sess._lock = threading.Lock()
+        sess._pending = {}
+        sess.config = types.SimpleNamespace(permission_timeout_s=5.0)
+
+        def _emit(msg):
+            p = sess._pending.get(msg.get("request_id"))
+            if p is not None:
+                p.reply = user_reply
+                p.event.set()
+
+        sess._emit = _emit
+        return sess
+
+    def test_result_hook_block_declines_through_handler(self):
+        from src.server.agent_server import _make_elicitation_handler
+
+        # user accepts; an ElicitationResult hook BLOCKS → decline must win
+        sess = self._sess(
+            {"ElicitationResult": [_exit2_hook()]},
+            user_reply={"action": "accept", "content": {"u": 1}},
+        )
+        res = asyncio.run(_make_elicitation_handler(sess)({"serverName": "srv", "message": "m"}))
+        assert res == {"action": "decline"}  # block wins, no content
+
+    def test_override_action_only_falls_back_to_user_content(self):
+        from src.server.agent_server import _make_elicitation_handler
+
+        # result-hook overrides ACTION only (no content) → content falls back
+        # to the user's raw content (None-coalesce)
+        sess = self._sess(
+            {"ElicitationResult": [_hook(_result("accept"))]},  # no content
+            user_reply={"action": "cancel", "content": {"raw": 7}},
+        )
+        res = asyncio.run(_make_elicitation_handler(sess)({"serverName": "srv", "message": "m"}))
+        assert res == {"action": "accept", "content": {"raw": 7}}
+
+    def test_notification_failure_does_not_discard_override(self):
+        from src.server.agent_server import _make_elicitation_handler
+
+        # THE MAJOR (critic C3): a result-hook OVERRIDES the user reply, then a
+        # malformed non-string Notification matcher raises AttributeError in
+        # _matches_tool. The OVERRIDE is the discriminating case — without
+        # execute_notification_hooks' outer guard the raise would propagate and
+        # the handler would fall back to {action: decline}, LOSING the override.
+        bad_notif = HookConfig(type="command", command="true",
+                               source=HookSource.USER_SETTINGS, matcher=123)  # non-string
+        sess = self._sess(
+            {"ElicitationResult": [_hook(_result("accept", {"overridden": 1}))],
+             "Notification": [bad_notif]},
+            user_reply={"action": "cancel"},
+        )
+        res = asyncio.run(_make_elicitation_handler(sess)({"serverName": "srv", "message": "m"}))
+        # the override must SURVIVE the malformed notification matcher
+        assert res == {"action": "accept", "content": {"overridden": 1}}, \
+            "notification failure discarded the override!"

--- a/tests/test_mcp_elicitation_hooks.py
+++ b/tests/test_mcp_elicitation_hooks.py
@@ -298,3 +298,45 @@ class TestFinishElicitationThroughHandler:
         # the override must SURVIVE the malformed notification matcher
         assert res == {"action": "accept", "content": {"overridden": 1}}, \
             "notification failure discarded the override!"
+
+
+class TestMalformedMatcherOnDecisionPath:
+    """critic C3 re-review: a non-string matcher on the DECISION path
+    (Elicitation/ElicitationResult) must not abort the hook loop — else a valid
+    blocking/overriding sibling never runs and the raw user response leaks
+    (the guardrail bypass, worse blast radius than the notification path)."""
+
+    def test_matches_tool_non_string_is_non_matching(self):
+        from src.hooks.hook_executor import _matches_tool
+        assert _matches_tool(123, "srv") is False  # not a crash, not match-all
+        assert _matches_tool([], "srv") is False
+        assert _matches_tool(None, "srv") is True   # unchanged
+
+    def test_malformed_matcher_before_blocking_sibling_still_blocks(self):
+        import threading
+        import types
+
+        from src.server.agent_server import _make_elicitation_handler
+
+        # a malformed-matcher ElicitationResult hook FIRST, then a valid
+        # blocking sibling (matcher=None → matches). Old code: the malformed
+        # one crashes _matches_tool → loop aborts → sibling never runs → raw
+        # accept leaks. Fixed: malformed one is skipped, sibling blocks.
+        bad = HookConfig(type="command", command="true",
+                         source=HookSource.USER_SETTINGS, matcher=0)  # non-string
+        blocker = _exit2_hook()  # matcher=None → matches srv
+        sess = types.SimpleNamespace()
+        sess.tool_context = _Ctx({"ElicitationResult": [bad, blocker]})
+        sess._lock = threading.Lock()
+        sess._pending = {}
+        sess.config = types.SimpleNamespace(permission_timeout_s=5.0)
+
+        def _emit(msg):
+            p = sess._pending.get(msg.get("request_id"))
+            if p is not None:
+                p.reply = {"action": "accept", "content": {"leak": True}}
+                p.event.set()
+        sess._emit = _emit
+
+        res = asyncio.run(_make_elicitation_handler(sess)({"serverName": "srv", "message": "m"}))
+        assert res == {"action": "decline"}, "malformed matcher aborted the loop — block lost!"


### PR DESCRIPTION
## Summary

Chapter **C3 — MCP elicitation hooks (the 3-event unit)** (SERVICES-3 deferral). An MCP server's elicitation request fired NO hooks; TS wraps it with three (`utils/hooks.ts:4623-4810` + `elicitationHandler.ts:220-313`). Shipped as ONE unit because the ElicitationResult hook can **OVERRIDE** the user's response — shipping only the notification would silently drop that (the correctness trap SERVICES-3 flagged).

- `hook_executor.py`: `execute_elicitation_hooks` (BEFORE — provide a response to short-circuit, or block→decline), `execute_elicitation_result_hooks` (AFTER — OVERRIDE action/content, or block→decline), `execute_notification_hooks` (fire-and-forget observability), + `_parse_elicitation_hook_output` (exit-2 / `decision:block` / `action==decline` → blocking; `hookSpecificOutput.{hookEventName,action,content}` → response; `async:true` ignored). Matched on the server name.
- `client.py`: `_run_elicitation` threads `self._name` into the handler params.
- `agent_server.py`: `_elicit` wraps the control-request round-trip — before-hook short-circuit (returns DIRECTLY, no result-hooks, matching TS) → prompt → `_finish_elicitation` (result-hook override/block + the notification, fired OUTSIDE the return-computing try so it can never alter the ElicitResult).

## Critic rounds (3)
- R1 REVISE: M1 short-circuit must not run result-hooks (pre-fixed); M2 notification-await coupling could discard a block/override.
- R2 REVISE: same `_matches_tool`-raises root cause on the DECISION path (larger blast radius).
- **APPROVE** — "All findings across the three review rounds are closed... the SERVICES-3 correctness trap (block/override must win) now holds on every path — including the malformed-matcher fail-open the permissive parser exposes."

## Key fixes (each with a discriminating test verified to fail without it)
- `execute_notification_hooks` can never raise (whole-body guard + `_matches_tool` inside the per-hook try); `_finish_elicitation` fires the notification outside the return-computing try (fires on every path incl. error).
- `_matches_tool` returns False for a non-string matcher (not match-all) — isolates a misconfigured hook to itself instead of aborting its siblings; covers all four call sites.

## Verification
`tests/test_mcp_elicitation_hooks.py` (22) + the 5 pre-existing bridge tests: parse edge cases, each executor, the live `_elicit` (short-circuit/override/block/passthrough), the notification-failure-doesn't-discard-override MAJOR guard, and the malformed-matcher-before-blocking-sibling decision-path guard. Full suite confirmed on merged main (below). Rebased cleanly over C8.

Documented omission: `elicitation_complete` (URL-mode) — a separate `setNotificationHandler` path, deferred with the rest of URL-mode elicitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
